### PR TITLE
Ensure Voxelizer SDF generation uses the correct cell level

### DIFF
--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -871,7 +871,7 @@ Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, Bake
 		uint32_t cell_count = bake_cells.size();
 
 		for (uint32_t i = 0; i < cell_count; i++) {
-			if (cells[i].level < (cell_subdiv - 1)) {
+			if (cells[i].level < cell_subdiv) {
 				continue; //do not care about this level
 			}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

For a while, there have been strange shadows in VoxelGI lighting. Recently, through testing, I identified that it was essentially placing two copies of the scene in the SDF, one at full scale and one at half scale. Some digging revealed that the SDF texture generator in `Voxelizer` was placing both the lowest (highest cell count) and second-lowest octree levels in the SDF. By changing it to only consider the lowest level, the issue is resolved!

Before:
![Screenshot_20250116_001702](https://github.com/user-attachments/assets/41e6e18a-6bed-4501-86cd-7552f66a3d4f)

After:
![Screenshot_20250116_001635](https://github.com/user-attachments/assets/53ba0b29-353d-4312-bc96-5e5df0585611)

Screenshots taken with the VoxelGI Lighting visualization.

Fixes #84992
Fixes #90976
Fixes #38020

First main engine pull request, so please treat me kindly!