### PR TITLE
Fix crash in `Particles3DEmissionShapeGizmoPlugin`.

### DIFF
--- a/editor/plugins/gizmos/particles_3d_emission_shape_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/particles_3d_emission_shape_gizmo_plugin.cpp
@@ -85,8 +85,8 @@ void Particles3DEmissionShapeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	if (Object::cast_to<GPUParticles3D>(p_gizmo->get_node_3d())) {
 		const GPUParticles3D *particles = Object::cast_to<GPUParticles3D>(p_gizmo->get_node_3d());
 
-		if (particles->get_process_material().is_valid()) {
-			const Ref<ParticleProcessMaterial> mat = particles->get_process_material();
+		const Ref<ParticleProcessMaterial> mat = particles->get_process_material();
+		if (mat.is_valid()) {
 			const ParticleProcessMaterial::EmissionShape shape = mat->get_emission_shape();
 
 			const Ref<Material> material = get_material("particles_emission_shape_material", p_gizmo);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/101611

It was checking validity before casting. So in case `get_process_material()` returns valid object (`ShaderMaterial` in case of issue MRP) other than `ParticleProcessMaterial` check was passed, but `mat` was null (and dereferenced later).