### PR TITLE
Stack buffer overrun for enum function arguments in gdextension API, affecting at least godot-cpp

### DIFF
--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -93,7 +93,7 @@ struct VariantCaster<const T &> {
 	template <>                                                              \
 	struct PtrToArg<m_enum> {                                                \
 		_FORCE_INLINE_ static m_enum convert(const void *p_ptr) {            \
-			return m_enum(*reinterpret_cast<const int64_t *>(p_ptr));        \
+			return *reinterpret_cast<const m_enum *>(p_ptr);                 \
 		}                                                                    \
 		typedef int64_t EncodeT;                                             \
 		_FORCE_INLINE_ static void encode(m_enum p_val, const void *p_ptr) { \


### PR DESCRIPTION
I ran into a stack buffer overrun, code reading extra memory that it should not, only to throw these extra bytes away.

This bug was detected with address sanitizer (GCC -fsanitize=address), and prevents anyone from using address sanitizer in combination with godot-cpp, because address sanitizer aborts on first error. Otherwise the impact of this bug is probably low. 

However, allowing use of address sanitizer by contributors does seem like it will benefit the quality of the godot codebase long term. There is no realistic workaround if one wishes to use address sanitizer with godot-cpp, because any call to the godot API that involves an enum parameter will trigger the buffer overrun + abort by asan.

Bug details: the affected code receives a pointer to an enum as a void pointer, and reinterpret casts it to an int64 pointer, probably because int64 is the size used for variants. But enums are not 64 bit by default, and the majority of enums in the godot codebase use the default size, which is usually int (32 bit on most platforms), and never larger unless absolutely needed, see [C++ standard on enum size](https://timsong-cpp.github.io/cppwp/n4140/dcl.enum#7)
Since the code immediately does a truncating C-style cast of this int64 to the enum type, the 4 extra bytes will be discarded immediately and not result in any program logic errors.