### PR TITLE
SCons: Add emitter to declutter build objects

### DIFF
--- a/modules/SCsub
+++ b/modules/SCsub
@@ -101,7 +101,7 @@ for name, path in env.module_list.items():
 if env["tests"]:
 
     def modules_tests_builder(target, source, env):
-        headers = sorted([os.path.relpath(src.path, methods.base_folder_path).replace("\\", "/") for src in source])
+        headers = sorted([os.path.relpath(src.path, methods.base_folder).replace("\\", "/") for src in source])
         with methods.generated_wrapper(str(target[0])) as file:
             for header in headers:
                 file.write(f'#include "{header}"\n')

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -44,7 +44,7 @@ env_thirdparty.disable_warnings()
 thirdparty_obj = env_thirdparty.SharedObject("#thirdparty/misc/ifaddrs-android.cc")
 android_objects.append(thirdparty_obj)
 
-lib = env_android.add_shared_library("#bin/libgodot", [android_objects], SHLIBSUFFIX=env["SHLIBSUFFIX"])
+lib = env_android.add_shared_library("libgodot", android_objects)
 
 # Needed to force rebuilding the platform files when the thirdparty code is updated.
 env.Depends(lib, thirdparty_obj)
@@ -78,9 +78,7 @@ if lib_arch_dir != "":
         lib_tools_dir = ""
 
     out_dir = "#platform/android/java/lib/libs/" + lib_tools_dir + lib_type_dir + "/" + lib_arch_dir
-    env_android.Command(
-        out_dir + "/libgodot_android.so", "#bin/libgodot" + env["SHLIBSUFFIX"], Move("$TARGET", "$SOURCE")
-    )
+    env_android.Command(out_dir + "/libgodot_android.so", lib, Move("$TARGET", "$SOURCE"))
 
     stl_lib_path = (
         str(env["ANDROID_NDK_ROOT"]) + "/sources/cxx-stl/llvm-libc++/libs/" + lib_arch_dir + "/libc++_shared.so"

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -98,7 +98,7 @@ def library_emitter(target, source, env):
 
 
 def configure(env: "SConsEnvironment"):
-    env.Append(LIBEMITTER=library_emitter)
+    env.Append(LIBEMITTER=[library_emitter])
 
     # Validate arch.
     supported_arches = ["wasm32"]

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import platform_windows_builders
 
+from methods import redirect_emitter
+
 sources = []
 
 common_win = [
@@ -49,6 +51,7 @@ def arrange_program_clean(prog):
         Clean(prog, extra_files_to_clean)
 
 
+env["BUILDERS"]["RES"].emitter = redirect_emitter
 res_file = "godot_res.rc"
 res_target = "godot_res" + env["OBJSUFFIX"]
 res_obj = env.RES(res_target, res_file)

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -278,7 +278,7 @@ def configure_msvc(env: "SConsEnvironment"):
         from tempfile import mkstemp
 
         # Ensure we have a location to write captured output to, in case of false positives.
-        capture_path = methods.base_folder_path + "platform/windows/msvc_capture.log"
+        capture_path = methods.base_folder / "platform" / "windows" / "msvc_capture.log"
         with open(capture_path, "wt", encoding="utf-8"):
             pass
 


### PR DESCRIPTION
This PR aims to fix a long-standing problem annoyance with the SCons buildsystem: storing build objects in the same directory as the source code. While there *is* a built-in functionality that somewhat addresses this issue via `VariantDir`[^1], it's not a suitable out-of-the-box solution with the way our repo is setup, and it doesn't easily account for the files we **want** in the source code (eg: generated scripts). Instead, there's another built-in way of achieving this goal that *does* work for us: **custom emitters**[^2]! With these, we can directly modify the target/source lists of a given builder, allowing us to seamlessly reroute our intermediate build files.

This implementation adds the option `redirect_build_objects` to the buildsystem, enabled by default. When on, all built objects/libraries are redirected to the root `bin/obj/` folder automatically, preserving the passed subfolder structure. This will not apply to any builder calls passing `redirect_build_objects=False` (see `platform/android/SCsub`). The emitter has been applied to `StaticObject`, `SharedObject`, `StaticLibrary`, `SharedLibrary`, and `RES` — it **doesn't** apply to any of the other builders (e.g. generated scripts, `Program`), as we want to keep their output as-is.

[^1]: https://scons.org/doc/production/HTML/scons-user/ch15s04.html
[^2]: https://scons.org/doc/production/HTML/scons-user/ch17s06.html