### PR TITLE
Create .uid files in EditorFileSystem

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1482,16 +1482,6 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 	file->popup_file_dialog();
 }
 
-void EditorNode::ensure_uid_file(const String &p_new_resource_path) {
-	if (ResourceLoader::exists(p_new_resource_path) && !ResourceLoader::has_custom_uid_support(p_new_resource_path) && !FileAccess::exists(p_new_resource_path + ".uid")) {
-		Ref<FileAccess> f = FileAccess::open(p_new_resource_path + ".uid", FileAccess::WRITE);
-		if (f.is_valid()) {
-			const ResourceUID::ID id = ResourceUID::get_singleton()->create_id();
-			f->store_line(ResourceUID::get_singleton()->id_to_text(id));
-		}
-	}
-}
-
 void EditorNode::_menu_option(int p_option) {
 	_menu_option_confirm(p_option, false);
 }
@@ -2232,11 +2222,6 @@ void EditorNode::_dialog_action(String p_file) {
 		case RESOURCE_SAVE_AS: {
 			ERR_FAIL_COND(saving_resource.is_null());
 			save_resource_in_path(saving_resource, p_file);
-
-			if (current_menu_option == RESOURCE_SAVE_AS) {
-				// Create .uid file when making new Resource.
-				ensure_uid_file(p_file);
-			}
 
 			saving_resource = Ref<Resource>();
 			ObjectID current_id = editor_history.get_current();

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -746,7 +746,6 @@ public:
 	void save_resource_in_path(const Ref<Resource> &p_resource, const String &p_path);
 	void save_resource(const Ref<Resource> &p_resource);
 	void save_resource_as(const Ref<Resource> &p_resource, const String &p_at_path = String());
-	void ensure_uid_file(const String &p_new_resource_path);
 
 	void show_about() { _menu_option_confirm(HELP_ABOUT, false); }
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -374,7 +374,6 @@ void ScriptCreateDialog::_create_new() {
 			alert->popup_centered();
 			return;
 		}
-		EditorNode::get_singleton()->ensure_uid_file(lpath);
 	}
 
 	emit_signal(SNAME("script_created"), scr);

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -241,7 +241,6 @@ void fog() {
 			alert->popup_centered();
 			return;
 		}
-		EditorNode::get_singleton()->ensure_uid_file(lpath);
 
 		emit_signal(SNAME("shader_include_created"), shader_inc);
 	} else {
@@ -260,7 +259,6 @@ void fog() {
 				alert->popup_centered();
 				return;
 			}
-			EditorNode::get_singleton()->ensure_uid_file(lpath);
 		}
 
 		emit_signal(SNAME("shader_created"), shader);


### PR DESCRIPTION
Fixes #101591

Turns out the `ensure_uid_file()` method I once added was wrong, because *EditorFileSystem has its own uid cache*. The bug occured, because the new UID was not registered in the EditorFileSystem, which is used by ResourceSaver to determine UIDs when saving.
I fixed the bug for scripts and shaders, but I see more places where FileInfo is created. There might be some edge case where either UID is not registered or .uid file is not created, idk.