### PR TITLE
Update export preset options overrides before doing "Remote Debug"

### DIFF
--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -145,6 +145,8 @@ Error EditorRunNative::start_run_native(int p_id) {
 	}
 	run_confirmed = false;
 
+	preset->update_value_overrides();
+
 	emit_signal(SNAME("native_run"), preset);
 
 	BitField<EditorExportPlatform::DebugFlags> flags = 0;


### PR DESCRIPTION
When doing an export any other way, it's already updating the export preset options before doing it.

For example, via the "Export PCK/ZIP..." or "Export Project..." buttons:

https://github.com/godotengine/godot/blob/d33da79d3f8fe84be2521d25b9ba8e440cf25a88/editor/export/project_export.cpp#L1312

Or, via the "Export All..." button:

https://github.com/godotengine/godot/blob/d33da79d3f8fe84be2521d25b9ba8e440cf25a88/editor/export/project_export.cpp#L1365

But before this PR, it's not doing it before export when using the "Remote Debug" button (aka "One click deploy"). If you've got an export plugin that sets overrides that depend on project or editor settings, this will mean that your settings won't be in effect when using the "Remote Debug" button.

This PR fixes that!
