### PR TITLE
WASAPI multi-channel microphone input

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -906,7 +906,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 
 					// fixme: Only works for floating point atm
 					for (UINT32 j = 0; j < num_frames_available; j++) {
-						int32_t l, r;
+						int32_t l = 0, r = 0;
 
 						if (flags & AUDCLNT_BUFFERFLAGS_SILENT) {
 							l = r = 0;
@@ -916,6 +916,29 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 								r = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j * 2 + 1);
 							} else if (ad->audio_input.channels == 1) {
 								l = r = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j);
+							} else if (ad->audio_input.channels > 2) {
+								int64_t ltemp = 0, rtemp = 0;
+								int channels = ad->audio_input.channels;
+								for (int ch = 0; ch < channels - 1; ch++) {
+									int32_t sample = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j * channels + ch);
+									if (ch % 2 == 0) {
+										rtemp += sample;
+									} else {
+										ltemp += sample;
+									}
+								}
+								int32_t last_sample = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j * channels + (channels - 1));
+								r += last_sample;
+								if (channels % 2 != 0) {
+									ltemp += last_sample;
+									ltemp /= ((channels + 1) / 2);
+									rtemp /= ((channels + 1) / 2);
+								} else {
+									ltemp /= (channels / 2);
+									rtemp /= (channels / 2);
+								}
+								l = static_cast<int32_t>(ltemp);
+								r = static_cast<int32_t>(rtemp);
 							} else {
 								l = r = 0;
 								ERR_PRINT("WASAPI: unsupported channel count in microphone!");

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -916,7 +916,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 								r = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j * 2 + 1);
 							} else if (ad->audio_input.channels == 1) {
 								l = r = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j);
-							} else if (ad->audio_input.channels > 2) {
+							} else if (ad->audio_input.channels >= 2) {
 								int64_t ltemp = 0, rtemp = 0;
 								int channels = ad->audio_input.channels;
 								for (int ch = 0; ch < channels - 1; ch++) {

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -927,6 +927,8 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 								int channels = ad->audio_input.channels;
 								for (int ch = 0; ch < channels - 1; ch++) {
 									int32_t sample = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j * channels + ch);
+									// Consider all odd channel indices to be right channels,
+									// and all even channel indices to be left channels.
 									if (ch % 2 == 0) {
 										rtemp += sample;
 									} else {

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -917,6 +917,12 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 							} else if (ad->audio_input.channels == 1) {
 								l = r = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j);
 							} else if (ad->audio_input.channels >= 2) {
+								// Average all channels to left and right channels.
+								// This is done to cater to microphones with 3 channels or more,
+								// some of which may be used for specialized purposes
+								// like noise reduction or better spatialization.
+								// However, since we cannot presume the exact purpose of each channel,
+								// the best course of action is to downmix to stereo.
 								int64_t ltemp = 0, rtemp = 0;
 								int channels = ad->audio_input.channels;
 								for (int ch = 0; ch < channels - 1; ch++) {

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -906,14 +906,14 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 
 					// fixme: Only works for floating point atm
 					for (UINT32 j = 0; j < num_frames_available; j++) {
-						int32_t l, r;
+						int32_t l = 0, r = 0;
 
 						if (flags & AUDCLNT_BUFFERFLAGS_SILENT) {
 							l = r = 0;
 						} else {
-							if (ad->audio_input.channels == 2) {
-								l = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j * 2);
-								r = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j * 2 + 1);
+							if (ad->audio_input.channels >= 2) {
+								l = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j * ad->audio_input.channels);
+								r = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j * ad->audio_input.channels + 1);
 							} else if (ad->audio_input.channels == 1) {
 								l = r = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j);
 							} else {


### PR DESCRIPTION
Support multi-channel microphone input by downmixing to stereo
- Enhanced the WASAPI audio driver to support microphones with any number of channels.
- This modification ensures compatibility with a broader range of multi-channel microphones, allowing for more versatile input handling in Godot. 
- Regarding “WASAPI: unsupported channel count in microphone!” error.

I mistakenly modified the branch of the original PR #96947 ,  so I have recreated this PR.

Fix #82823 
Fix #30313 
Issues #82823

I tried compiling and testing the four channel microphone on my laptop, and it turned out to be error free. This enables the successful use of multi-channel microphones in Godot.

I made the assumption that the microphone might have a potential configuration with odd channels (e.g., Left, Right, Center), although such configurations are uncommon (in some professional audio equipment). The goal was to ensure that the microphone is at least usable within Godot, regardless of the channel count. The WASAPI documentation itself doesn't explicitly specify how multi-channel microphones should be handled, so I aimed for a more general solution to accommodate various configurations.

I apologize for the inconvenience caused by the multiple review requests. Due to my unfamiliarity with the process, I made several revisions which have led to some wasted time. I have now reviewed and confirmed that everything is correct.
Thank you for your understanding and patience. 

Thank you for reviewing !

