### PR TITLE
[Buildsystem] Break after purging cache

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -847,8 +847,9 @@ def clean_cache(cache_path: str, cache_limit: int, verbose: bool) -> None:
                 except OSError:
                     print_error(f'Failed to remove cache file "{file}"; skipping.')
                     count -= 1
-            if verbose:
+            if verbose and count:
                 print_info(f"Purged {count} file{'s' if count else ''} from cache.")
+            break
 
 
 def prepare_cache(env) -> None:


### PR DESCRIPTION
Also added a check to ensure the purge message is only printed if any files were actually purged after the error

Follow-up to:
* https://github.com/godotengine/godot/pull/101008
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
