### PR TITLE
Add new method for getting multiple rest infos

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -30,6 +30,22 @@
 				Returned points are a list of pairs of contact points. For each pair the first one is in the shape passed in [PhysicsShapeQueryParameters2D] object, second one is in the collided shape from the physics space.
 			</description>
 		</method>
+		<method name="get_complete_rest_info">
+			<return type="Dictionary[]" />
+			<param index="0" name="parameters" type="PhysicsShapeQueryParameters2D" />
+			<param index="1" name="max_results" type="int" default="32" />
+			<description>
+				Checks the intersections of a shape, given through a [PhysicsShapeQueryParameters2D] object, against the space. The information about the intersections is returned in an array containing dictionaries with the following fields:
+				[code]collider_id[/code]: The colliding object's ID.
+				[code]linear_velocity[/code]: The colliding object's velocity [Vector2]. If the object is an [Area2D], the result is [code](0, 0)[/code].
+				[code]normal[/code]: The collision normal of the query shape at the intersection point, pointing away from the intersecting object.
+				[code]depth[/code]: The collision depth of the intersection point.
+				[code]point[/code]: The intersection point.
+				[code]rid[/code]: The intersecting object's [RID].
+				[code]shape[/code]: The shape index of the colliding shape.
+				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
+			</description>
+		</method>
 		<method name="get_rest_info">
 			<return type="Dictionary" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters2D" />

--- a/doc/classes/PhysicsDirectSpaceState2DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState2DExtension.xml
@@ -39,6 +39,20 @@
 			<description>
 			</description>
 		</method>
+		<method name="_complete_rest_info" qualifiers="virtual required">
+			<return type="int" />
+			<param index="0" name="shape_rid" type="RID" />
+			<param index="1" name="transform" type="Transform2D" />
+			<param index="2" name="motion" type="Vector2" />
+			<param index="3" name="margin" type="float" />
+			<param index="4" name="collision_mask" type="int" />
+			<param index="5" name="collide_with_bodies" type="bool" />
+			<param index="6" name="collide_with_areas" type="bool" />
+			<param index="7" name="rest_infos" type="PhysicsServer2DExtensionShapeRestInfo*" />
+			<param index="8" name="max_results" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="_intersect_point" qualifiers="virtual required">
 			<return type="int" />
 			<param index="0" name="position" type="Vector2" />

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -31,6 +31,23 @@
 				[b]Note:[/b] This method does not take into account the [code]motion[/code] property of the object.
 			</description>
 		</method>
+		<method name="get_complete_rest_info">
+			<return type="Dictionary[]" />
+			<param index="0" name="parameters" type="PhysicsShapeQueryParameters3D" />
+			<param index="1" name="max_results" type="int" default="32" />
+			<description>
+				Checks the intersections of a shape, given through a [PhysicsShapeQueryParameters3D] object, against the space. The information about the intersections is returned in an array containing dictionaries with the following fields:
+				[code]collider_id[/code]: The colliding object's ID.
+				[code]linear_velocity[/code]: The colliding object's velocity [Vector3]. If the object is an [Area3D], the result is [code](0, 0, 0)[/code].
+				[code]normal[/code]: The collision normal of the query shape at the intersection point, pointing away from the intersecting object.
+				[code]depth[/code]: The collision depth of the intersection point.
+				[code]point[/code]: The intersection point.
+				[code]rid[/code]: The intersecting object's [RID].
+				[code]shape[/code]: The shape index of the colliding shape.
+				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
+				[b]Note:[/b] This method does not take into account the [code]motion[/code] property of the object.
+			</description>
+		</method>
 		<method name="get_rest_info">
 			<return type="Dictionary" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters3D" />

--- a/doc/classes/PhysicsDirectSpaceState3DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState3DExtension.xml
@@ -40,6 +40,20 @@
 			<description>
 			</description>
 		</method>
+		<method name="_complete_rest_info" qualifiers="virtual required">
+			<return type="int" />
+			<param index="0" name="shape_rid" type="RID" />
+			<param index="1" name="transform" type="Transform3D" />
+			<param index="2" name="motion" type="Vector3" />
+			<param index="3" name="margin" type="float" />
+			<param index="4" name="collision_mask" type="int" />
+			<param index="5" name="collide_with_bodies" type="bool" />
+			<param index="6" name="collide_with_areas" type="bool" />
+			<param index="7" name="rest_infos" type="PhysicsServer3DExtensionShapeRestInfo*" />
+			<param index="8" name="max_results" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="_get_closest_point_to_object_volume" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="object" type="RID" />

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -501,6 +501,182 @@ bool GodotPhysicsDirectSpaceState2D::rest_info(const ShapeParameters &p_paramete
 	return true;
 }
 
+struct _RestResultData {
+	const GodotCollisionObject2D *object = nullptr;
+	int local_shape = 0;
+	int shape = 0;
+	Vector2 contact;
+	Vector2 normal;
+	real_t len = 0.0;
+};
+
+struct _RestCallbackData {
+	const GodotCollisionObject2D *object = nullptr;
+	int local_shape = 0;
+	int shape = 0;
+
+	real_t min_allowed_depth = 0.0;
+	Vector2 valid_dir;
+	real_t valid_depth = 0.0;
+
+	_RestResultData best_result;
+
+	int max_results = 0;
+	int result_count = 0;
+	_RestResultData *other_results = nullptr;
+};
+
+static void _complete_rest_cbk_result(const Vector2 &p_point_A, const Vector2 &p_point_B, void *p_userdata) {
+	_RestCallbackData *rd = static_cast<_RestCallbackData *>(p_userdata);
+
+	Vector2 contact_rel = p_point_B - p_point_A;
+	real_t len = contact_rel.length();
+
+	if (len < rd->min_allowed_depth) {
+		return;
+	}
+
+	Vector2 normal = contact_rel / len;
+
+	if (rd->valid_dir != Vector2()) {
+		if (len > rd->valid_depth) {
+			return;
+		}
+
+		if (rd->valid_dir.dot(normal) > -CMP_EPSILON) {
+			return;
+		}
+	}
+
+	bool is_best_result = (len > rd->best_result.len);
+
+	if (rd->other_results && rd->result_count > 0) {
+		// Consider as new result by default.
+		int prev_result_count = rd->result_count++;
+
+		int result_index = 0;
+		real_t tested_len = is_best_result ? rd->best_result.len : len;
+		for (; result_index < prev_result_count - 1; ++result_index) {
+			if (tested_len > rd->other_results[result_index].len) {
+				// Reusing a previous result.
+				rd->result_count--;
+				break;
+			}
+		}
+
+		if (result_index < rd->max_results - 1) {
+			_RestResultData &result = rd->other_results[result_index];
+
+			if (is_best_result) {
+				// Keep the previous best result as separate result.
+				result = rd->best_result;
+			} else {
+				// Keep this result as separate result.
+				result.len = len;
+				result.contact = p_point_B;
+				result.normal = normal;
+				result.object = rd->object;
+				result.shape = rd->shape;
+				result.local_shape = rd->local_shape;
+			}
+		} else {
+			// Discarding this result.
+			rd->result_count--;
+		}
+	} else if (is_best_result) {
+		rd->result_count = 1;
+	}
+
+	if (!is_best_result) {
+		return;
+	}
+
+	rd->best_result.len = len;
+	rd->best_result.contact = p_point_B;
+	rd->best_result.normal = normal;
+	rd->best_result.object = rd->object;
+	rd->best_result.shape = rd->shape;
+	rd->best_result.local_shape = rd->local_shape;
+}
+
+int GodotPhysicsDirectSpaceState2D::complete_rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_infos, int p_result_max) {
+	if (p_result_max <= 0) {
+		return 0;
+	}
+
+	GodotShape2D *shape = GodotPhysicsServer2D::godot_singleton->shape_owner.get_or_null(p_parameters.shape_rid);
+	ERR_FAIL_NULL_V(shape, false);
+
+	real_t margin = MAX(p_parameters.margin, TEST_MOTION_MARGIN_MIN_VALUE);
+
+	Rect2 aabb = p_parameters.transform.xform(shape->get_aabb());
+	aabb = aabb.merge(Rect2(aabb.position + p_parameters.motion, aabb.size)); //motion
+	aabb = aabb.grow(margin);
+
+	int amount = space->broadphase->cull_aabb(aabb, space->intersection_query_results, GodotSpace2D::INTERSECTION_QUERY_MAX, space->intersection_query_subindex_results);
+
+	Vector<_RestResultData> results;
+	results.resize(p_result_max);
+
+	_RestCallbackData rcd;
+	if (p_result_max > 1) {
+		rcd.max_results = p_result_max;
+		rcd.other_results = results.ptrw();
+	}
+
+	// Allowed depth can't be lower than motion length, in order to handle contacts at low speed.
+	real_t motion_length = p_parameters.motion.length();
+	real_t min_contact_depth = margin * TEST_MOTION_MIN_CONTACT_DEPTH_FACTOR;
+	rcd.min_allowed_depth = MIN(motion_length, min_contact_depth);
+
+	for (int i = 0; i < amount; i++) {
+		if (!_can_collide_with(space->intersection_query_results[i], p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas)) {
+			continue;
+		}
+
+		const GodotCollisionObject2D *col_obj = space->intersection_query_results[i];
+
+		if (p_parameters.exclude.has(col_obj->get_self())) {
+			continue;
+		}
+
+		int shape_idx = space->intersection_query_subindex_results[i];
+
+		rcd.valid_dir = Vector2();
+		rcd.object = col_obj;
+		rcd.shape = shape_idx;
+		rcd.local_shape = 0;
+		GodotCollisionSolver2D::solve(shape, p_parameters.transform, p_parameters.motion, col_obj->get_shape(shape_idx), col_obj->get_transform() * col_obj->get_shape_transform(shape_idx), Vector2(), _complete_rest_cbk_result, &rcd, nullptr, margin);
+	}
+
+	if (rcd.best_result.len == 0 || !rcd.best_result.object) {
+		return 0;
+	}
+
+	for (int collision_index = 0; collision_index < rcd.result_count; ++collision_index) {
+		const _RestResultData &result = (collision_index > 0) ? rcd.other_results[collision_index - 1] : rcd.best_result;
+
+		ShapeRestInfo &sri = r_infos[collision_index];
+
+		sri.collider_id = result.object->get_instance_id();
+		sri.shape = result.shape;
+		sri.normal = result.normal;
+		sri.point = result.contact;
+		sri.depth = result.len;
+		sri.rid = result.object->get_self();
+		if (result.object->get_type() == GodotCollisionObject2D::TYPE_BODY) {
+			const GodotBody2D *body = static_cast<const GodotBody2D *>(result.object);
+			Vector2 rel_vec = sri.point - (body->get_transform().get_origin() + body->get_center_of_mass());
+			sri.linear_velocity = Vector2(-body->get_angular_velocity() * rel_vec.y, body->get_angular_velocity() * rel_vec.x) + body->get_linear_velocity();
+
+		} else {
+			sri.linear_velocity = Vector2();
+		}
+	}
+
+	return rcd.result_count;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 int GodotSpace2D::_cull_aabb_for_body(GodotBody2D *p_body, const Rect2 &p_aabb) {

--- a/modules/godot_physics_2d/godot_space_2d.h
+++ b/modules/godot_physics_2d/godot_space_2d.h
@@ -49,6 +49,7 @@ public:
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe) override;
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector2 *r_results, int p_result_max, int &r_result_count) override;
 	virtual bool rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_info) override;
+	virtual int complete_rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_infos, int p_result_max) override;
 
 	GodotPhysicsDirectSpaceState2D() {}
 };

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -571,6 +571,81 @@ bool GodotPhysicsDirectSpaceState3D::rest_info(const ShapeParameters &p_paramete
 	return true;
 }
 
+int GodotPhysicsDirectSpaceState3D::complete_rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_infos, int p_result_max) {
+	if (p_result_max <= 0) {
+		return 0;
+	}
+
+	GodotShape3D *shape = GodotPhysicsServer3D::godot_singleton->shape_owner.get_or_null(p_parameters.shape_rid);
+	ERR_FAIL_NULL_V(shape, false);
+
+	real_t margin = MAX(p_parameters.margin, TEST_MOTION_MARGIN_MIN_VALUE);
+
+	AABB aabb = p_parameters.transform.xform(shape->get_aabb());
+	aabb = aabb.grow(margin);
+
+	int amount = space->broadphase->cull_aabb(aabb, space->intersection_query_results, GodotSpace3D::INTERSECTION_QUERY_MAX, space->intersection_query_subindex_results);
+
+	Vector<_RestResultData> results;
+	results.resize(p_result_max);
+
+	_RestCallbackData rcd;
+	if (p_result_max > 1) {
+		rcd.max_results = p_result_max;
+		rcd.other_results = results.ptrw();
+	}
+
+	// Allowed depth can't be lower than motion length, in order to handle contacts at low speed.
+	real_t motion_length = p_parameters.motion.length();
+	real_t min_contact_depth = margin * TEST_MOTION_MIN_CONTACT_DEPTH_FACTOR;
+	rcd.min_allowed_depth = MIN(motion_length, min_contact_depth);
+
+	for (int i = 0; i < amount; i++) {
+		if (!_can_collide_with(space->intersection_query_results[i], p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas)) {
+			continue;
+		}
+
+		const GodotCollisionObject3D *col_obj = space->intersection_query_results[i];
+
+		if (p_parameters.exclude.has(col_obj->get_self())) {
+			continue;
+		}
+
+		int shape_idx = space->intersection_query_subindex_results[i];
+
+		rcd.object = col_obj;
+		rcd.shape = shape_idx;
+		GodotCollisionSolver3D::solve_static(shape, p_parameters.transform, col_obj->get_shape(shape_idx), col_obj->get_transform() * col_obj->get_shape_transform(shape_idx), _rest_cbk_result, &rcd, nullptr, margin);
+	}
+
+	if (rcd.best_result.len == 0 || !rcd.best_result.object) {
+		return 0;
+	}
+
+	for (int collision_index = 0; collision_index < rcd.result_count; ++collision_index) {
+		const _RestResultData &result = (collision_index > 0) ? rcd.other_results[collision_index - 1] : rcd.best_result;
+
+		ShapeRestInfo &sri = r_infos[collision_index];
+
+		sri.collider_id = result.object->get_instance_id();
+		sri.shape = result.shape;
+		sri.normal = result.normal;
+		sri.point = result.contact;
+		sri.depth = result.len;
+		sri.rid = result.object->get_self();
+		if (result.object->get_type() == GodotCollisionObject3D::TYPE_BODY) {
+			const GodotBody3D *body = static_cast<const GodotBody3D *>(result.object);
+			Vector3 rel_vec = result.contact - (body->get_transform().origin + body->get_center_of_mass());
+			sri.linear_velocity = body->get_linear_velocity() + (body->get_angular_velocity()).cross(rel_vec);
+
+		} else {
+			sri.linear_velocity = Vector3();
+		}
+	}
+
+	return rcd.result_count;
+}
+
 Vector3 GodotPhysicsDirectSpaceState3D::get_closest_point_to_object_volume(RID p_object, const Vector3 p_point) const {
 	GodotCollisionObject3D *obj = GodotPhysicsServer3D::godot_singleton->area_owner.get_or_null(p_object);
 	if (!obj) {

--- a/modules/godot_physics_3d/godot_space_3d.h
+++ b/modules/godot_physics_3d/godot_space_3d.h
@@ -50,6 +50,7 @@ public:
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe, ShapeRestInfo *r_info = nullptr) override;
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector3 *r_results, int p_result_max, int &r_result_count) override;
 	virtual bool rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_info) override;
+	virtual int complete_rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_infos, int p_result_max) override;
 	virtual Vector3 get_closest_point_to_object_volume(RID p_object, const Vector3 p_point) const override;
 
 	GodotPhysicsDirectSpaceState3D();

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -782,6 +782,164 @@ bool JoltPhysicsDirectSpaceState3D::rest_info(const ShapeParameters &p_parameter
 	return true;
 }
 
+int JoltPhysicsDirectSpaceState3D::complete_rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_infos, int p_result_max) {
+	ERR_FAIL_COND_V_MSG(space->is_stepping(), false, "complete_rest_info must not be called while the physics space is being stepped.");
+
+	if (p_result_max == 0) {
+		return 0;
+	}
+
+	space->flush_pending_objects();
+
+	JoltShape3D *shape = JoltPhysicsServer3D::get_singleton()->get_shape(p_parameters.shape_rid);
+	ERR_FAIL_NULL_V(shape, false);
+
+	const JPH::ShapeRefC jolt_shape = shape->try_build();
+	ERR_FAIL_NULL_V(jolt_shape, false);
+
+	Transform3D transform = p_parameters.transform;
+	JOLT_ENSURE_SCALE_NOT_ZERO(transform, "complete_rest_info was passed an invalid transform.");
+
+	Vector3 scale;
+	JoltMath::decompose(transform, scale);
+	JOLT_ENSURE_SCALE_VALID(jolt_shape, scale, "complete_rest_info was passed an invalid transform.");
+
+	const Vector3 com_scaled = to_godot(jolt_shape->GetCenterOfMass());
+	const Transform3D transform_com = transform.translated_local(com_scaled);
+
+	JPH::CollideShapeSettings settings;
+	settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
+	settings.mMaxSeparationDistance = (float)p_parameters.margin;
+
+	const Vector3 &base_offset = transform_com.origin;
+
+	const JoltQueryFilter3D query_filter(*this, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.exclude);
+	class Collector : public JPH::CollideShapeCollector {
+	public:
+		typedef typename JPH::CollideShapeCollector::ResultType Hit;
+		struct HitWithContactPoints {
+			Hit hit;
+			JPH::ContactPoints contact_points;
+
+			HitWithContactPoints() = default;
+		};
+		typedef JPH::Array<HitWithContactPoints, JPH::STLLocalAllocator<HitWithContactPoints, 33>> HitWithContactPointsArray;
+
+	private:
+		HitWithContactPointsArray hits_with_contact_points;
+		const int max_points;
+		const JPH::PhysicsSettings &physics_settings;
+		JPH_IF_DEBUG_RENDERER(const Vector3 &base_offset;)
+
+	public:
+		Collector(int p_max_points, const JPH::PhysicsSettings &p_physics_settings JPH_IF_DEBUG_RENDERER(, const Vector3 &p_base_offset)) :
+				max_points(p_max_points), physics_settings(p_physics_settings) JPH_IF_DEBUG_RENDERER(, base_offset(p_base_offset)) {
+			hits_with_contact_points.reserve(33);
+		}
+
+		bool had_hit() const {
+			return hits_with_contact_points.size() > 0;
+		}
+
+		int get_hit_count() const {
+			return hits_with_contact_points.size();
+		}
+
+		const HitWithContactPoints &get_hit_with_contact_points(int p_index) const {
+			return hits_with_contact_points[p_index];
+		}
+
+		virtual void AddHit(const Hit &p_hit) override {
+			HitWithContactPoints hit_with_contact_points;
+			hit_with_contact_points.hit = p_hit;
+
+			if (max_points > 1) {
+				JPH::ContactPoints contact_points1;
+				const JPH::Vec3 penetration_axis = p_hit.mPenetrationAxis.Normalized();
+
+				JPH::ManifoldBetweenTwoFaces(p_hit.mContactPointOn1, p_hit.mContactPointOn2, penetration_axis, physics_settings.mManifoldTolerance, p_hit.mShape1Face, p_hit.mShape2Face, contact_points1, hit_with_contact_points.contact_points JPH_IF_DEBUG_RENDERER(, to_jolt_r(base_offset)));
+				if (contact_points1.size() > 4) {
+					JPH::PruneContactPoints(penetration_axis, contact_points1, hit_with_contact_points.contact_points JPH_IF_DEBUG_RENDERER(, to_jolt_r(base_offset)));
+				}
+			} else {
+				hit_with_contact_points.contact_points.push_back(p_hit.mContactPointOn2);
+			}
+
+			typename HitWithContactPointsArray::const_iterator E = hits_with_contact_points.cbegin();
+			for (; E != hits_with_contact_points.cend(); ++E) {
+				if (p_hit.GetEarlyOutFraction() < E->hit.GetEarlyOutFraction()) {
+					break;
+				}
+			}
+
+			hits_with_contact_points.insert(E, hit_with_contact_points);
+
+			int points_count = 0;
+			for (int i = 0; i < (int)hits_with_contact_points.size(); ++i) {
+				points_count += hits_with_contact_points[i].contact_points.size();
+				if (points_count >= max_points) {
+					hits_with_contact_points.resize(i + 1);
+					break;
+				}
+			}
+
+			if (points_count >= max_points) {
+				JPH::CollideShapeCollector::UpdateEarlyOutFraction(hits_with_contact_points.back().hit.GetEarlyOutFraction());
+			}
+		}
+	};
+	const JPH::PhysicsSystem &physics_system = space->get_physics_system();
+	const JPH::PhysicsSettings &physics_settings = physics_system.GetPhysicsSettings();
+	Collector collector(p_result_max, physics_settings JPH_IF_DEBUG_RENDERER(, base_offset));
+	_collide_shape_queries(jolt_shape, to_jolt(scale), to_jolt_r(transform_com), settings, to_jolt_r(base_offset), collector, query_filter, query_filter, query_filter);
+
+	if (!collector.had_hit()) {
+		return 0;
+	}
+
+	int count = 0;
+
+	for (int i = 0; i < collector.get_hit_count(); i++) {
+		const Collector::HitWithContactPoints &hit_with_contact_points = collector.get_hit_with_contact_points(i);
+		const JPH::CollideShapeResult &hit = hit_with_contact_points.hit;
+
+		const JoltObject3D *object = space->try_get_object(hit.mBodyID2);
+		ERR_FAIL_NULL_V(object, false);
+
+		int shape_index = 0;
+		if (const JoltShapedObject3D *shaped_object = object->as_shaped()) {
+			shape_index = shaped_object->find_shape_index(hit.mSubShapeID2);
+			ERR_FAIL_COND_V(shape_index == -1, false);
+		}
+
+		const Vector3 normal = to_godot(-hit.mPenetrationAxis.Normalized());
+		const float penetration_depth = hit.mPenetrationDepth + (float)p_parameters.margin;
+
+		for (JPH::Vec3 contact_point : hit_with_contact_points.contact_points) {
+			ShapeRestInfo &sri = r_infos[count++];
+
+			const Vector3 position = base_offset + to_godot(contact_point);
+
+			sri.shape = shape_index;
+			sri.point = position;
+			sri.depth = penetration_depth;
+			sri.normal = normal;
+			sri.rid = object->get_rid();
+			sri.collider_id = object->get_instance_id();
+			sri.linear_velocity = object->get_velocity_at_position(position);
+
+			if (count == p_result_max) {
+				break;
+			}
+		}
+		if (count == p_result_max) {
+			break;
+		}
+	}
+
+	return count;
+}
+
 Vector3 JoltPhysicsDirectSpaceState3D::get_closest_point_to_object_volume(RID p_object, Vector3 p_point) const {
 	ERR_FAIL_COND_V_MSG(space->is_stepping(), Vector3(), "get_closest_point_to_object_volume must not be called while the physics space is being stepped.");
 

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.h
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.h
@@ -76,6 +76,7 @@ public:
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &r_closest_safe, real_t &r_closest_unsafe, ShapeRestInfo *r_info = nullptr) override;
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector3 *r_results, int p_result_max, int &r_result_count) override;
 	virtual bool rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_info) override;
+	virtual int complete_rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_infos, int p_result_max) override;
 	virtual Vector3 get_closest_point_to_object_volume(RID p_object, Vector3 p_point) const override;
 
 	bool body_test_motion(const JoltBody3D &p_body, const PhysicsServer3D::MotionParameters &p_parameters, PhysicsServer3D::MotionResult *r_result) const;

--- a/servers/physics_2d/physics_server_2d.cpp
+++ b/servers/physics_2d/physics_server_2d.cpp
@@ -457,6 +457,31 @@ Dictionary PhysicsDirectSpaceState2D::_get_rest_info(RequiredParam<PhysicsShapeQ
 	return r;
 }
 
+TypedArray<Dictionary> PhysicsDirectSpaceState2D::_get_complete_rest_info(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, TypedArray<Dictionary>());
+
+	Vector<ShapeRestInfo> shape_rest_infos;
+	shape_rest_infos.resize(p_max_results);
+	int rc = complete_rest_info(p_shape_query->get_parameters(), shape_rest_infos.ptrw(), p_max_results);
+	TypedArray<Dictionary> ret;
+	ret.resize(rc);
+	for (int i = 0; i < rc; i++) {
+		Dictionary d;
+		ShapeRestInfo sri = shape_rest_infos[i];
+		d["point"] = sri.point;
+		d["normal"] = sri.normal;
+		d["depth"] = sri.depth;
+		d["rid"] = sri.rid;
+		d["collider_id"] = sri.collider_id;
+		d["shape"] = sri.shape;
+		d["linear_velocity"] = sri.linear_velocity;
+
+		ret[i] = d;
+	}
+
+	return ret;
+}
+
 PhysicsDirectSpaceState2D::PhysicsDirectSpaceState2D() {
 }
 
@@ -467,6 +492,7 @@ void PhysicsDirectSpaceState2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("cast_motion", "parameters"), &PhysicsDirectSpaceState2D::_cast_motion);
 	ClassDB::bind_method(D_METHOD("collide_shape", "parameters", "max_results"), &PhysicsDirectSpaceState2D::_collide_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("get_rest_info", "parameters"), &PhysicsDirectSpaceState2D::_get_rest_info);
+	ClassDB::bind_method(D_METHOD("get_complete_rest_info", "parameters", "max_results"), &PhysicsDirectSpaceState2D::_get_complete_rest_info, DEFVAL(32));
 }
 
 ///////////////////////////////

--- a/servers/physics_2d/physics_server_2d.h
+++ b/servers/physics_2d/physics_server_2d.h
@@ -130,6 +130,7 @@ class PhysicsDirectSpaceState2D : public Object {
 	Vector<real_t> _cast_motion(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query);
 	TypedArray<Vector2> _collide_shape(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query, int p_max_results = 32);
 	Dictionary _get_rest_info(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query);
+	TypedArray<Dictionary> _get_complete_rest_info(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query, int p_max_results = 32);
 
 protected:
 	static void _bind_methods();
@@ -198,12 +199,14 @@ public:
 		ObjectID collider_id;
 		int shape = 0;
 		Vector2 linear_velocity; // Velocity at contact point.
+		real_t depth = 0.0;
 	};
 
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) = 0;
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe) = 0;
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector2 *r_results, int p_result_max, int &r_result_count) = 0;
 	virtual bool rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_info) = 0;
+	virtual int complete_rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_infos, int p_result_max) = 0;
 
 	PhysicsDirectSpaceState2D();
 };

--- a/servers/physics_2d/physics_server_2d_dummy.h
+++ b/servers/physics_2d/physics_server_2d_dummy.h
@@ -122,6 +122,7 @@ public:
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe) override { return false; }
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector2 *r_results, int p_result_max, int &r_result_count) override { return false; }
 	virtual bool rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_info) override { return false; }
+	virtual int complete_rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_infos, int p_result_max) override { return false; }
 };
 
 class PhysicsServer2DDummy : public PhysicsServer2D {

--- a/servers/physics_2d/physics_server_2d_extension.cpp
+++ b/servers/physics_2d/physics_server_2d_extension.cpp
@@ -45,6 +45,7 @@ void PhysicsDirectSpaceState2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_cast_motion, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "closest_safe", "closest_unsafe");
 	GDVIRTUAL_BIND(_collide_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "results", "max_results", "result_count");
 	GDVIRTUAL_BIND(_rest_info, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "rest_info");
+	GDVIRTUAL_BIND(_complete_rest_info, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "rest_infos", "max_results");
 }
 
 PhysicsDirectSpaceState2DExtension::PhysicsDirectSpaceState2DExtension() {

--- a/servers/physics_2d/physics_server_2d_extension.h
+++ b/servers/physics_2d/physics_server_2d_extension.h
@@ -137,6 +137,7 @@ protected:
 	GDVIRTUAL9R_REQUIRED(bool, _cast_motion, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<real_t>, GDExtensionPtr<real_t>)
 	GDVIRTUAL10R_REQUIRED(bool, _collide_shape, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<Vector2>, int, GDExtensionPtr<int>)
 	GDVIRTUAL8R_REQUIRED(bool, _rest_info, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeRestInfo>)
+	GDVIRTUAL9R_REQUIRED(int, _complete_rest_info, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeRestInfo>, int)
 
 public:
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override {
@@ -178,6 +179,13 @@ public:
 		exclude = &p_parameters.exclude;
 		bool ret = false;
 		GDVIRTUAL_CALL(_rest_info, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_info, ret);
+		exclude = nullptr;
+		return ret;
+	}
+	virtual int complete_rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_infos, int p_result_max) override {
+		exclude = &p_parameters.exclude;
+		int ret = 0;
+		GDVIRTUAL_CALL(_complete_rest_info, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_infos, p_result_max, ret);
 		exclude = nullptr;
 		return ret;
 	}

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -481,6 +481,31 @@ Dictionary PhysicsDirectSpaceState3D::_get_rest_info(RequiredParam<PhysicsShapeQ
 	return r;
 }
 
+TypedArray<Dictionary> PhysicsDirectSpaceState3D::_get_complete_rest_info(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, TypedArray<Dictionary>());
+
+	Vector<ShapeRestInfo> shape_rest_infos;
+	shape_rest_infos.resize(p_max_results);
+	int rc = complete_rest_info(p_shape_query->get_parameters(), shape_rest_infos.ptrw(), p_max_results);
+	TypedArray<Dictionary> ret;
+	ret.resize(rc);
+	for (int i = 0; i < rc; i++) {
+		Dictionary d;
+		ShapeRestInfo sri = shape_rest_infos[i];
+		d["point"] = sri.point;
+		d["normal"] = sri.normal;
+		d["depth"] = sri.depth;
+		d["rid"] = sri.rid;
+		d["collider_id"] = sri.collider_id;
+		d["shape"] = sri.shape;
+		d["linear_velocity"] = sri.linear_velocity;
+
+		ret[i] = d;
+	}
+
+	return ret;
+}
+
 PhysicsDirectSpaceState3D::PhysicsDirectSpaceState3D() {
 }
 
@@ -491,6 +516,7 @@ void PhysicsDirectSpaceState3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("cast_motion", "parameters"), &PhysicsDirectSpaceState3D::_cast_motion);
 	ClassDB::bind_method(D_METHOD("collide_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_collide_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("get_rest_info", "parameters"), &PhysicsDirectSpaceState3D::_get_rest_info);
+	ClassDB::bind_method(D_METHOD("get_complete_rest_info", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_get_complete_rest_info, DEFVAL(32));
 }
 
 ///////////////////////////////

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -132,6 +132,7 @@ private:
 	Vector<real_t> _cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query);
 	TypedArray<Vector3> _collide_shape(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query, int p_max_results = 32);
 	Dictionary _get_rest_info(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query);
+	TypedArray<Dictionary> _get_complete_rest_info(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query, int p_max_results = 32);
 
 protected:
 	static void _bind_methods();
@@ -201,12 +202,14 @@ public:
 		ObjectID collider_id;
 		int shape = 0;
 		Vector3 linear_velocity; // Velocity at contact point.
+		real_t depth = 0.0;
 	};
 
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) = 0;
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe, ShapeRestInfo *r_info = nullptr) = 0;
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector3 *r_results, int p_result_max, int &r_result_count) = 0;
 	virtual bool rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_info) = 0;
+	virtual int complete_rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_infos, int p_result_max) = 0;
 
 	virtual Vector3 get_closest_point_to_object_volume(RID p_object, const Vector3 p_point) const = 0;
 

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -124,6 +124,7 @@ public:
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe, ShapeRestInfo *r_info = nullptr) override { return false; }
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector3 *r_results, int p_result_max, int &r_result_count) override { return false; }
 	virtual bool rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_info) override { return false; }
+	virtual int complete_rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_infos, int p_result_max) override { return false; }
 
 	virtual Vector3 get_closest_point_to_object_volume(RID p_object, const Vector3 p_point) const override { return Vector3(); }
 };

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -45,6 +45,7 @@ void PhysicsDirectSpaceState3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_cast_motion, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "closest_safe", "closest_unsafe", "info");
 	GDVIRTUAL_BIND(_collide_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "results", "max_results", "result_count");
 	GDVIRTUAL_BIND(_rest_info, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "rest_info");
+	GDVIRTUAL_BIND(_complete_rest_info, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "rest_infos", "max_results");
 	GDVIRTUAL_BIND(_get_closest_point_to_object_volume, "object", "point");
 }
 

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -139,6 +139,7 @@ protected:
 	GDVIRTUAL10R_REQUIRED(bool, _cast_motion, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<real_t>, GDExtensionPtr<real_t>, GDExtensionPtr<PhysicsServer3DExtensionShapeRestInfo>)
 	GDVIRTUAL10R_REQUIRED(bool, _collide_shape, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<Vector3>, int, GDExtensionPtr<int>)
 	GDVIRTUAL8R_REQUIRED(bool, _rest_info, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeRestInfo>)
+	GDVIRTUAL9R_REQUIRED(int, _complete_rest_info, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeRestInfo>, int)
 	GDVIRTUAL2RC_REQUIRED(Vector3, _get_closest_point_to_object_volume, RID, const Vector3 &)
 
 public:
@@ -184,7 +185,13 @@ public:
 		exclude = nullptr;
 		return ret;
 	}
-
+	virtual int complete_rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_infos, int p_result_max) override {
+		exclude = &p_parameters.exclude;
+		int ret = 0;
+		GDVIRTUAL_CALL(_complete_rest_info, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_infos, p_result_max, ret);
+		exclude = nullptr;
+		return ret;
+	}
 	virtual Vector3 get_closest_point_to_object_volume(RID p_object, const Vector3 p_point) const override {
 		Vector3 ret;
 		GDVIRTUAL_CALL(_get_closest_point_to_object_volume, p_object, p_point, ret);


### PR DESCRIPTION
Closes godotengine/godot-proposals/issues/11609
(Also implements this proposal, but with a new method instead: godotengine/godot-proposals/issues/9341)

This PR aims to add a new method for `PhysicsDirectSpaceState` (2D and 3D), that retrieves shape rest info from all contacts, with the ability to limit the number of results returned. This needs to be implemented with Godod Physics 3D, 2D, and Jolt Physics.

Currently there is no method for checking a shape's intersections in a space and getting detailed information about all contacts, which I think is an important feature to have. Ideally, this is how the `PhysicsDirectSpaceState.get_rest_info` method should work, since if you want only one result to be returned, you can limit the number of results returned to 1 with the `max_results` parameter of this proposed new method, and you get the same result as `PhysicsDirectSpaceState.get_rest_info`, which can only return one.  To avoid breaking compatibility though, this has to be a new method.
