### PR TITLE
Optimize `String` and `Vector` equality test if the arguments are copies of each other.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -335,7 +335,7 @@ bool String::operator==(const char32_t *p_str) const {
 }
 
 bool String::operator==(const String &p_str) const {
-	return span() == p_str.span();
+	return _cowdata.ptr() == p_str._cowdata.ptr() || span() == p_str.span();
 }
 
 bool String::operator==(const Span<char32_t> &p_str_range) const {
@@ -441,7 +441,8 @@ bool String::operator<(const String &p_str) const {
 }
 
 signed char String::nocasecmp_to(const String &p_str) const {
-	if (is_empty() && p_str.is_empty()) {
+	if (unlikely(p_str.ptr() == ptr())) {
+		// We have the same buffer (or are both null).
 		return 0;
 	}
 	if (is_empty()) {
@@ -473,7 +474,8 @@ signed char String::nocasecmp_to(const String &p_str) const {
 }
 
 signed char String::casecmp_to(const String &p_str) const {
-	if (is_empty() && p_str.is_empty()) {
+	if (unlikely(p_str.ptr() == ptr())) {
+		// We have the same buffer (or are both null).
 		return 0;
 	}
 	if (is_empty()) {

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -252,8 +252,8 @@ public:
 		return result;
 	}
 
-	bool operator==(const Vector<T> &p_arr) const { return span() == p_arr.span(); }
-	bool operator!=(const Vector<T> &p_arr) const { return span() != p_arr.span(); }
+	bool operator==(const Vector<T> &p_arr) const { return _cowdata.ptr() == p_arr._cowdata.ptr() || span() == p_arr.span(); }
+	bool operator!=(const Vector<T> &p_arr) const { return _cowdata.ptr() == p_arr._cowdata.ptr() || span() != p_arr.span(); }
 
 	struct Iterator {
 		_FORCE_INLINE_ T &operator*() const {


### PR DESCRIPTION
This optimizes the trivial case (both sides share the same buffer) from `O(n)` to `O(1)`.

This case is likely rare, but it may happen sometimes.

## Benchmark
A benchmark to prove this isn't really needed, but I made one anyway, just for fun. In the optimized case, there can be a 31x speed up (or infinite if the string is infinitely long :P):

```c++
	String s = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
	String s1 = s;

	auto t0 = std::chrono::high_resolution_clock::now();
	for (int i = 0; i < 10000000; i ++) {
		// Test
		bool equal = s == s1;
	}
	auto t1 = std::chrono::high_resolution_clock::now();
	std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
```

- `508ms` on `master` (d19147e09a13a7d6df44076f15893a5d1108fbb0)
- `16ms` on this PR (7670d25c9023e39cdc14fcc6e3c654b15da3e222)

## Notes
Follow-up PRs could address comparison operators (like `<`) or similar comparisons. But these are _probably_ the most common ones where we can benefit.