### PR TITLE
Fix GPUParticles2D not randomizing seed when `set_one_shot` is called

### DIFF
--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -912,6 +912,8 @@ GPUParticles2D::GPUParticles2D() {
 	one_shot = false; // Needed so that set_emitting doesn't access uninitialized values
 	set_emitting(true);
 	set_one_shot(false);
+	set_use_fixed_seed(false);
+	set_seed(0);
 	set_amount(8);
 	set_amount_ratio(1.0);
 	set_lifetime(1);

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -92,10 +92,6 @@ void GPUParticles3D::set_one_shot(bool p_one_shot) {
 
 	if (is_emitting()) {
 		if (!one_shot) {
-			if (!use_fixed_seed) {
-				set_seed(Math::rand());
-			}
-
 			RenderingServer::get_singleton()->particles_restart(particles);
 		}
 	}


### PR DESCRIPTION
`gpu_particelse_2d` needed fixing in this regard as well as pointed out by @clayjohn and @QbieShay: https://github.com/godotengine/godot/pull/101596#issuecomment-2596405186

The seed should be randomized by calls to `set_one_shot`.  Although the behavior is redundant imo, @clayjohn made a solid point that we should still do it so that the behavior remains the same for gpu particles between 4.3 and 4.4.