### PR TITLE
Make dialogs non-cancelable on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/utils/DialogUtils.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/utils/DialogUtils.kt
@@ -151,6 +151,7 @@ internal class DialogUtils {
 				builder.setView(parentLayout)
 				val dialog = builder.create()
 				dismissDialog = {dialog.dismiss()}
+				dialog.setCancelable(false)
 				dialog.show()
 			}
 		}
@@ -178,6 +179,7 @@ internal class DialogUtils {
 					dialog.dismiss()
 				}
 				val dialog = builder.create()
+				dialog.setCancelable(false)
 				dialog.show()
 			}
 		}


### PR DESCRIPTION
This PR addresses dialog canceling behavior in the app. Currently, native-dialogs are canceled when the user presses the back button or taps outside the dialog.
This PR is disabling this behavior to prevent unintentional dismissals. However, it's open for discussion whether we should disable canceling by both `touch outside` and `back press`, only touch outside, or leave the current behavior as is.