### PR TITLE
Fix collision normal being referred to as surface normal in PhysicsDirectSpaceState doc

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -37,7 +37,7 @@
 				[b]Note:[/b] This method does not take into account the [code]motion[/code] property of the object. The returned object is a dictionary containing the following fields:
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]linear_velocity[/code]: The colliding object's velocity [Vector2]. If the object is an [Area2D], the result is [code](0, 0)[/code].
-				[code]normal[/code]: The object's surface normal at the intersection point.
+				[code]normal[/code]: The collision normal of the query shape at the intersection point, pointing away from the intersecting object.
 				[code]point[/code]: The intersection point.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -37,7 +37,7 @@
 				Checks the intersections of a shape, given through a [PhysicsShapeQueryParameters3D] object, against the space. If it collides with more than one shape, the nearest one is selected. The returned object is a dictionary containing the following fields:
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]linear_velocity[/code]: The colliding object's velocity [Vector3]. If the object is an [Area3D], the result is [code](0, 0, 0)[/code].
-				[code]normal[/code]: The object's surface normal at the intersection point.
+				[code]normal[/code]: The collision normal of the query shape at the intersection point, pointing away from the intersecting object.
 				[code]point[/code]: The intersection point.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.


### PR DESCRIPTION
In the `PhysicsDirectSpaceState` class references (2D and 3D) the `get_rest_info` method descriptions state that the returned dictionary's "normal" field contains the surface normal at the contact point, but it's actually the collision normal.