### PR TITLE
Add `--force-console` option to force the creation of a console on Windows

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -356,6 +356,8 @@ public:
 	// This is invoked by the GDExtensionManager after loading GDExtensions specified by the project.
 	virtual void load_platform_gdextensions() const {}
 
+	virtual void alloc_console() {}
+
 	OS();
 	virtual ~OS();
 };

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -356,7 +356,7 @@ public:
 	// This is invoked by the GDExtensionManager after loading GDExtensions specified by the project.
 	virtual void load_platform_gdextensions() const {}
 
-	virtual void alloc_console() {}
+	virtual void _alloc_console() {}
 
 	OS();
 	virtual ~OS();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -575,7 +575,10 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("", "--fixed-fps is forced when enabled, but it can be used to change movie FPS.\n");
 	print_help_option("", "--disable-vsync can speed up movie writing but makes interaction more difficult.\n");
 	print_help_option("", "--quit-after can be used to specify the number of frames to write.\n");
-
+#ifdef WINDOWS_ENABLED
+	print_help_option("--force-console", "Force creation of console window on Windows.\n");
+	print_help_option("", "Does not spawn a child process, unlike the console executable. Allows for viewing Godot logs when debugging a C# project with Visual Studio.\n");
+#endif
 	print_help_title("Display options");
 	print_help_option("-f, --fullscreen", "Request fullscreen mode.\n");
 	print_help_option("-m, --maximized", "Request a maximized window.\n");
@@ -1705,6 +1708,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing write-movie argument, aborting.\n");
 				goto error;
 			}
+		} else if (arg == "--force-console") {
+			OS::get_singleton()->alloc_console();
 		} else if (arg == "--disable-vsync") {
 			disable_vsync = true;
 		} else if (arg == "--print-fps") {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1708,8 +1708,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing write-movie argument, aborting.\n");
 				goto error;
 			}
+#if defined(WINDOWS_ENABLED) && !defined(WINDOWS_SUBSYSTEM_CONSOLE)
 		} else if (arg == "--force-console") {
-			OS::get_singleton()->alloc_console();
+			OS::get_singleton()->_alloc_console();
+#endif
 		} else if (arg == "--disable-vsync") {
 			disable_vsync = true;
 		} else if (arg == "--print-fps") {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -575,7 +575,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("", "--fixed-fps is forced when enabled, but it can be used to change movie FPS.\n");
 	print_help_option("", "--disable-vsync can speed up movie writing but makes interaction more difficult.\n");
 	print_help_option("", "--quit-after can be used to specify the number of frames to write.\n");
-#ifdef WINDOWS_ENABLED
+#if defined(WINDOWS_ENABLED) && !defined(WINDOWS_SUBSYSTEM_CONSOLE)
 	print_help_option("--force-console", "Force creation of console window on Windows.\n");
 	print_help_option("", "Does not spawn a child process, unlike the console executable. Allows for viewing Godot logs when debugging a C# project with Visual Studio.\n");
 #endif

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -579,6 +579,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--force-console", "Force creation of console window on Windows.\n");
 	print_help_option("", "Does not spawn a child process, unlike the console executable. Allows for viewing Godot logs when debugging a C# project with Visual Studio.\n");
 #endif
+
 	print_help_title("Display options");
 	print_help_option("-f, --fullscreen", "Request fullscreen mode.\n");
 	print_help_option("-m, --maximized", "Request a maximized window.\n");

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2346,6 +2346,10 @@ void OS_Windows::add_frame_delay(bool p_can_draw) {
 	}
 }
 
+void OS_Windows::alloc_console() {
+	AllocConsole();
+}
+
 OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	hInstance = _hInstance;
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2346,7 +2346,7 @@ void OS_Windows::add_frame_delay(bool p_can_draw) {
 	}
 }
 
-void OS_Windows::alloc_console() {
+void OS_Windows::_alloc_console() {
 	AllocConsole();
 }
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -252,7 +252,7 @@ public:
 
 	void set_main_window(HWND p_main_window) { main_window = p_main_window; }
 
-	virtual void alloc_console() override;
+	virtual void _alloc_console() override;
 
 	HINSTANCE get_hinstance() { return hInstance; }
 	OS_Windows(HINSTANCE _hInstance);

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -252,6 +252,8 @@ public:
 
 	void set_main_window(HWND p_main_window) { main_window = p_main_window; }
 
+	virtual void alloc_console() override;
+
 	HINSTANCE get_hinstance() { return hInstance; }
 	OS_Windows(HINSTANCE _hInstance);
 	~OS_Windows();


### PR DESCRIPTION
Added --force-console option to force the creation of a console on Windows.

This is to make Godot logging visible when debugging C# script projects using Visual Studio.

This is an update of this PR [here](https://github.com/godotengine/godot/pull/95340) which somehow automatically closed itself while I was syncing my fork and resolving conflicts.
