### PR TITLE
Avoid leaking ninepatch state to other draw commands in GLES backend

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -915,8 +915,6 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 		state.instance_data_array[r_index].flags = base_flags;
 		state.instance_data_array[r_index].instance_uniforms_ofs = p_item->instance_allocated_shader_uniforms_offset;
 
-		state.instance_data_array[r_index].flags = base_flags | (state.instance_data_array[r_index == 0 ? 0 : r_index - 1].flags & (BATCH_FLAGS_DEFAULT_NORMAL_MAP_USED | BATCH_FLAGS_DEFAULT_SPECULAR_MAP_USED)); // Reset on each command for safety, keep canvastexture binding config.
-
 		Color blend_color = base_color;
 		GLES3::CanvasShaderData::BlendMode blend_mode = p_blend_mode;
 		if (c->type == Item::Command::TYPE_RECT) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/101699
Fixes: https://github.com/godotengine/godot/issues/101672

https://github.com/godotengine/godot/pull/99230 accidentally brought this line of code back after it was removed in https://github.com/godotengine/godot/pull/98835

The line of code was removed in https://github.com/godotengine/godot/pull/98835 because those flags are part of the batch data now, not part of the instance draw data, so they don't need to be carried over between instances. 