### PR TITLE
CI: Tighten timeout period for all jobs

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -12,6 +12,7 @@ jobs:
   build-android:
     runs-on: ubuntu-24.04
     name: ${{ matrix.name }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/godot_cpp_test.yml
+++ b/.github/workflows/godot_cpp_test.yml
@@ -13,6 +13,7 @@ jobs:
   godot-cpp-tests:
     runs-on: ubuntu-24.04
     name: Build and test Godot CPP
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -12,6 +12,7 @@ jobs:
   ios-template:
     runs-on: macos-latest
     name: Template (target=template_release)
+    timeout-minutes: 60
 
     steps:
       - name: Checkout

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -17,6 +17,7 @@ jobs:
     # Stay one LTS before latest to increase portability of Linux artifacts.
     runs-on: ubuntu-22.04
     name: ${{ matrix.name }}
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -12,6 +12,7 @@ jobs:
   build-macos:
     runs-on: macos-latest
     name: ${{ matrix.name }}
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -6,6 +6,7 @@ jobs:
   static-checks:
     name: Code style, file formatting, and docs
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -13,6 +13,7 @@ jobs:
   web-template:
     runs-on: ubuntu-24.04
     name: ${{ matrix.name }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -15,6 +15,7 @@ jobs:
     # Windows 10 with latest image
     runs-on: windows-latest
     name: ${{ matrix.name }}
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes an issue brought up in RC chat[^1] where portions of a job stuck in an indefinite loop will only be timed out at the default interval of 6-hours. Now the maximum timeout period for jobs is 2 hours, with the majority being smaller than that:
- static-checks/godot-cpp: 30 minutes
- android/ios/web: 60 minutes
- windows/macos/linux: 120 minutes

[^1]:https://chat.godotengine.org/channel/buildsystem?msg=RJiJn3G8KxA4tqbp6