### PR TITLE
SCons: Fix platform tool integration

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -326,10 +326,6 @@ def setup_mingw(env: "SConsEnvironment"):
         print_error("No valid compilers found, use MINGW_PREFIX environment variable to set MinGW path.")
         sys.exit(255)
 
-    env.Tool("mingw")
-    env.AppendUnique(CCFLAGS=env.get("ccflags", "").split())
-    env.AppendUnique(RCFLAGS=env.get("rcflags", "").split())
-
     print("Using MinGW, arch %s" % (env["arch"]))
 
 


### PR DESCRIPTION
- Fixes #101186
- Related #98105

This PR removes a later `mingw` tool call by having the call handled in SConstruct instead. It turns out that `mingw` as a tool was already declared in that file, but wasn't always being processed thanks to these platform arguments being parsed *before* validation. While this PR fixes that by moving the tools a bit further down, it's still hacky by necessity; we will eventually need a **much** broader refactor of our SCons structure.