### PR TITLE
Make `Control.global_position` represent the same point as `position`, not `global_transform.origin`

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -185,9 +185,9 @@ bool Control::_edit_use_rect() const {
 void Control::reparent(Node *p_parent, bool p_keep_global_transform) {
 	ERR_MAIN_THREAD_GUARD;
 	if (p_keep_global_transform) {
-		Transform2D temp = get_global_transform();
+		Vector2 global_pos = get_global_position();
 		Node::reparent(p_parent);
-		set_global_position(temp.get_origin());
+		set_global_position(global_pos);
 	} else {
 		Node::reparent(p_parent);
 	}
@@ -1417,18 +1417,30 @@ void Control::_set_global_position(const Point2 &p_point) {
 	set_global_position(p_point);
 }
 
+// `global_position` represents the same point as `position`, but in the global space.
+// Because `get_transform()` incorporates `rotation`/`scale` around a custom `pivot_offset`,
+// `position` is NOT equivalent to `get_transform().origin` (in general; in case of
+// zero pivot offset or no rotation/scale they are equivalent).
+// Similarly, `global_position` is NOT equivalent to `get_global_transform().origin`.
 void Control::set_global_position(const Point2 &p_point, bool p_keep_offsets) {
 	ERR_MAIN_THREAD_GUARD;
-	// (parent_global_transform * T(new_position) * internal_transform).origin == new_global_position
-	// (T(new_position) * internal_transform).origin == new_position_in_parent_space
-	// new_position == new_position_in_parent_space - internal_transform.origin
-	Point2 position_in_parent_space = data.parent_canvas_item ? data.parent_canvas_item->get_global_transform().affine_inverse().xform(p_point) : p_point;
-	set_position(position_in_parent_space - _get_internal_transform().get_origin(), p_keep_offsets);
+	// TODO: `data.parent_canvas_item` is set on enter/exit canvas,
+	// could it be done on parented/unparented instead (to work when not in tree)?
+	CanvasItem *parent_canvas_item = is_inside_tree() ? data.parent_canvas_item : get_parent_item();
+	Point2 position_in_parent_space = parent_canvas_item ? parent_canvas_item->get_global_transform().affine_inverse().xform(p_point) : p_point;
+	set_position(position_in_parent_space, p_keep_offsets);
 }
 
 Point2 Control::get_global_position() const {
 	ERR_READ_THREAD_GUARD_V(Point2());
-	return get_global_transform().get_origin();
+	// TODO: `data.parent_canvas_item` is set on enter/exit canvas,
+	// could it be done on parented/unparented instead (to work when not in tree)?
+	CanvasItem *parent_canvas_item = is_inside_tree() ? data.parent_canvas_item : get_parent_item();
+	if (parent_canvas_item) {
+		return parent_canvas_item->get_global_transform().xform(data.pos_cache);
+	} else {
+		return data.pos_cache;
+	}
 }
 
 Point2 Control::get_screen_position() const {

--- a/tests/scene/test_control.h
+++ b/tests/scene/test_control.h
@@ -46,8 +46,14 @@ TEST_CASE("[SceneTree][Control]") {
 		test_node->set_global_position(Point2(1, 1));
 		CHECK_EQ(test_node->get_global_position(), Point2(1, 1));
 		CHECK_EQ(test_child->get_global_position(), Point2(1, 1));
+		test_child->set_global_position(Point2(2, 2));
+		CHECK_EQ(test_child->get_global_position(), Point2(2, 2));
 		test_node->set_global_position(Point2(2, 2));
 		CHECK_EQ(test_node->get_global_position(), Point2(2, 2));
+		CHECK_EQ(test_child->get_global_position(), Point2(3, 3));
+		test_child->set_global_position(Point2(4, 4));
+		CHECK_EQ(test_child->get_global_position(), Point2(4, 4));
+
 		test_node->set_scale(Vector2(4, 4));
 		CHECK_EQ(test_node->get_global_transform(), Transform2D(0, Size2(4, 4), 0, Vector2(2, 2)));
 		test_node->set_scale(Vector2(1, 1));


### PR DESCRIPTION
**Note that the issues/discrepancies occur only for Controls with non-default `rotation`/`scale` and `pivot_offset`.**

After rethinking https://github.com/godotengine/godot/issues/95798#issuecomment-2297502534 (please read for a detailed explanation of the issue), I think the current behavior is wrong.


Currently (after #89502) `Control.global_position` is being equivalent to `Control.global_transform.origin`.

However, AFAICT it makes more sense for `Control.global_position` to be instead representing the same exact point as `Control.position`, just in a different coordinate system. And `Control.position` is not equivalent to `Control.transform.origin`, because the transform incorporates rotation/scale around custom pivot, hence the final translation/origin part of such transform is not only the `position`. These imply that `Control.global_position` would be not equivalent to `Control.global_transform.origin`:

If:
- `Control.global_position` and `Control.position` represent the same point.
- `Control.global_transform.origin` and `Control.transform.origin` represent the same point.
- `Control.position` is not equivalent to `Control.transform.origin`.

then:
-  `Control.global_position` is not equivalent to `Control.global_transform.origin`.

---

So this PR implements the alternative mentioned in https://github.com/godotengine/godot/issues/95798#issuecomment-2297502534, now both `Control.global_position` and `Control.position` represent the same point (but in different spaces (global/parent)). Also, as a consequence, `Control.global_position` is no longer equivalent to `Control.global_transform.origin`.

Regarding compatibility breaking:
- As mentioned in https://github.com/godotengine/godot/issues/95798#issuecomment-2297502534, pre-4.3 the behavior between `Control.set_global_position` and `Control.get_global_position` was mixed/broken.
- In 4.3.stable it was "fixed" in #89502, making `Control.{set|get}_global_position` consistently referring to `Control.global_transform.origin` (aka the same point as `Control.transform.origin` (but in different coordinate system), which is not necessarily the same point as `Control.position`).
- This PR completely changes the behavior compared to 4.3.stable, so it definitely is / can be considered compat breaking (hence I'm marking it as such). But I consider this to be a bug fix, this PR seems to be the correct approach to me, the current behavior should be changed. I'd say the faster the better, less versions with `Control.global_position` and `Control.position` representing different points. So I suggest merging for 4.4, whether it should / should not be cherry-picked for 4.3.1 I'm not sure.

Fixes #95798.
Fixes #101692.

---

To-do (hence a draft):
- [ ] Improve docs.