### PR TITLE
Compatibility: Fix certain gl format mappings

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -492,7 +492,7 @@ Ref<Image> TextureStorage::_get_gl_image_and_format(const Ref<Image> &p_image, I
 		case Image::FORMAT_RGTC_R: {
 			if (config->rgtc_supported) {
 				r_gl_internal_format = _EXT_COMPRESSED_RED_RGTC1_EXT;
-				r_gl_format = GL_RGBA;
+				r_gl_format = GL_RED;
 				r_gl_type = GL_UNSIGNED_BYTE;
 				r_compressed = true;
 			} else {
@@ -502,7 +502,7 @@ Ref<Image> TextureStorage::_get_gl_image_and_format(const Ref<Image> &p_image, I
 		case Image::FORMAT_RGTC_RG: {
 			if (config->rgtc_supported) {
 				r_gl_internal_format = _EXT_COMPRESSED_RED_GREEN_RGTC2_EXT;
-				r_gl_format = GL_RGBA;
+				r_gl_format = GL_RG;
 				r_gl_type = GL_UNSIGNED_BYTE;
 				r_compressed = true;
 			} else {


### PR DESCRIPTION
Fixes certain mappings to gl_format, namely:
- RGTC_R: RGBA to RED,
- RGTC_RG: RGBA to RG

TODO:
Figure out whether ASTC_HDR needs to decode to FLOAT, and if ETC2_Signed to BYTE