### PR TITLE
Improve line wrapping performance

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -165,15 +165,7 @@ int TextEdit::Text::get_line_wrap_amount(int p_line) const {
 }
 
 Vector<Vector2i> TextEdit::Text::get_line_wrap_ranges(int p_line) const {
-	Vector<Vector2i> ret;
-	ERR_FAIL_INDEX_V(p_line, text.size(), ret);
-
-	Ref<TextParagraph> data_buf = text[p_line].data_buf;
-	int line_count = data_buf->get_line_count();
-	for (int i = 0; i < line_count; i++) {
-		ret.push_back(data_buf->get_line_range(i));
-	}
-	return ret;
+	return text[p_line].data_buf->get_line_ranges();
 }
 
 const Ref<TextParagraph> TextEdit::Text::get_line_data(int p_line) const {

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -752,6 +752,20 @@ Vector2i TextParagraph::get_line_range(int p_line) const {
 	return TS->shaped_text_get_range(lines_rid[p_line]);
 }
 
+Vector<Vector2i> TextParagraph::get_line_ranges() const {
+	_THREAD_SAFE_METHOD_
+
+	_shape_lines();
+
+	Vector<Vector2i> ret;
+	int line_count = lines_rid.size();
+	for (int i = 0; i < line_count; i++) {
+		ret.push_back(TS->shaped_text_get_range(lines_rid[i]));
+	}
+
+	return ret;
+}
+
 float TextParagraph::get_line_ascent(int p_line) const {
 	_THREAD_SAFE_METHOD_
 

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -139,6 +139,7 @@ public:
 	float get_line_descent(int p_line) const;
 	float get_line_width(int p_line) const;
 	Vector2i get_line_range(int p_line) const;
+	Vector<Vector2i> get_line_ranges() const;
 	float get_line_underline_position(int p_line) const;
 	float get_line_underline_thickness(int p_line) const;
 


### PR DESCRIPTION
While this PR's implementation works, it's more so meant to start a discussion than to actually be finished. I think there are probably better ways to go about this.

In a nutshell, very long lines are really harsh on TextEdit when wrapping is enabled. I made this benchmark in 4.4.beta1 for `get_rect_at_line_column()`, an example of a method that's bottlenecked by this:

- 64 B -> 0.01ms
- 350 B -> 0.03ms
- 1.5 kB -> 0.15ms
- 9 kB -> 3ms
- 62 kB -> 65ms

Not a very tight benchmark, as the amount of linewraps matters more (it's roughly every 50 characters for the benchmark) but it shows how the method gets slower way too fast. 62 kB is 180 times more than 350 B, but it's 2200 times slower.

In development builds, with the 9 kB line, I got 7.8ms; with this PR, I get 0.8ms and I don't notice any regressions.

If I gauge correctly, the issue is that `_shape_lines()` in TextParagraph is called numerous times without anything that would actually change the output. Wouldn't caching make more sense then, and be implemented throughout the class?