### PR TITLE
SCons: Fix handling of platform-specific tools, notably `mingw`

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -19,6 +19,10 @@ def can_build():
     return os.path.exists(get_env_android_sdk_root())
 
 
+def get_tools(env: "SConsEnvironment"):
+    return ["clang", "clang++", "as", "ar", "link"]
+
+
 def get_opts():
     from SCons.Variables import BoolVariable
 

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -28,6 +28,11 @@ def can_build():
     return WhereIs("emcc") is not None
 
 
+def get_tools(env: "SConsEnvironment"):
+    # Use generic POSIX build toolchain for Emscripten.
+    return ["cc", "c++", "ar", "link", "textfile", "zip"]
+
+
 def get_opts():
     from SCons.Variables import BoolVariable
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -155,6 +155,13 @@ def detect_build_env_arch():
     return ""
 
 
+def get_tools(env: "SConsEnvironment"):
+    if os.name != "nt" or env["use_mingw"]:
+        return ["mingw"]
+    else:
+        return ["default"]
+
+
 def get_opts():
     from SCons.Variables import BoolVariable, EnumVariable
 
@@ -325,10 +332,6 @@ def setup_mingw(env: "SConsEnvironment"):
     ):
         print_error("No valid compilers found, use MINGW_PREFIX environment variable to set MinGW path.")
         sys.exit(255)
-
-    env.Tool("mingw")
-    env.AppendUnique(CCFLAGS=env.get("ccflags", "").split())
-    env.AppendUnique(RCFLAGS=env.get("rcflags", "").split())
 
     print("Using MinGW, arch %s" % (env["arch"]))
 


### PR DESCRIPTION
- Fixes #101186

Redo of #99762 on top of #101715, aiming to fix various issues we have with the fact that we need to know the selected platform to define the right SCons "tools" to enable when creating the environment, but we need the environment to register command line options that help set said platform.

Using two environments with `env.Clone()` seems to help solve the problems in #101715, and fixing the detection of when `mingw` should be set as tool via #99762 seems to make it work out of the box for Linux+mingw at least.