### PR TITLE
Fix NavigationObstacle3D debug clear regression

### DIFF
--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -111,7 +111,7 @@ void NavigationObstacle3D::_notification(int p_what) {
 			set_physics_process_internal(false);
 			_update_map(RID());
 #ifdef DEBUG_ENABLED
-			_update_debug();
+			_clear_debug();
 #endif // DEBUG_ENABLED
 		} break;
 
@@ -631,5 +631,16 @@ void NavigationObstacle3D::_update_static_obstacle_debug() {
 		rs->instance_set_scenario(static_obstacle_debug_instance_rid, get_world_3d()->get_scenario());
 		rs->instance_set_visible(static_obstacle_debug_instance_rid, is_visible_in_tree());
 	}
+}
+#endif // DEBUG_ENABLED
+
+#ifdef DEBUG_ENABLED
+void NavigationObstacle3D::_clear_debug() {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	ERR_FAIL_NULL(rs);
+	rs->mesh_clear(fake_agent_radius_debug_mesh_rid);
+	rs->mesh_clear(static_obstacle_debug_mesh_rid);
+	rs->instance_set_scenario(fake_agent_radius_debug_instance_rid, RID());
+	rs->instance_set_scenario(static_obstacle_debug_instance_rid, RID());
 }
 #endif // DEBUG_ENABLED

--- a/scene/3d/navigation_obstacle_3d.h
+++ b/scene/3d/navigation_obstacle_3d.h
@@ -71,6 +71,7 @@ private:
 	void _update_debug();
 	void _update_fake_agent_radius_debug();
 	void _update_static_obstacle_debug();
+	void _clear_debug();
 #endif // DEBUG_ENABLED
 
 protected:


### PR DESCRIPTION
Clears NavigationObstacle3D on tree exit.

When users would switch scenes the obstacle debug would persist because the is_inside_tree() check in the  _update_debug() would still return true, making the debug update instead of removing it.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
