### PR TITLE
Bake UV2 emission using half float in the compatibility backend

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3991,7 +3991,7 @@ TypedArray<Image> RasterizerSceneGLES3::bake_render_uv2(RID p_base, const TypedA
 	// Consider rendering to RGBA8 encoded as RGBE, then manually convert to RGBAH on CPU.
 	glBindTexture(GL_TEXTURE_2D, emission_tex);
 	if (config->float_texture_supported) {
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, p_image_size.width, p_image_size.height, 0, GL_RGBA, GL_FLOAT, nullptr);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, p_image_size.width, p_image_size.height, 0, GL_RGBA, GL_FLOAT, nullptr);
 		GLES3::Utilities::get_singleton()->texture_allocated_data(emission_tex, p_image_size.width * p_image_size.height * 16, "Lightmap emission texture");
 	} else {
 		// Fallback to RGBA8 on devices that don't support rendering to floating point textures. This will look bad, but we have no choice.
@@ -4094,9 +4094,9 @@ TypedArray<Image> RasterizerSceneGLES3::bake_render_uv2(RID p_base, const TypedA
 	{
 		tex->tex_id = emission_tex;
 		if (config->float_texture_supported) {
-			tex->format = Image::FORMAT_RGBAF;
+			tex->format = Image::FORMAT_RGBAH;
 			tex->real_format = Image::FORMAT_RGBAH;
-			tex->gl_type_cache = GL_FLOAT;
+			tex->gl_type_cache = GL_HALF_FLOAT;
 		}
 		Ref<Image> img = GLES3::TextureStorage::get_singleton()->texture_2d_get(tex_rid);
 		GLES3::Utilities::get_singleton()->texture_free_data(emission_tex);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/101589

As I suspected, this is an existing issue that was made worse in 4.4

The problem came from the fact that we used a full float texture, but when retrieving the texture we used a "real format" of half float. We could have just changed the "real format" to full float, but the lightmapper expects a half float texture anyway, so it is better to just bake in half float. 

IIRC I used full float originally as I thought there wasn't as much support for half float. But anywhere full float is supported half float is as well. I.e. `RGBA16F` is a required renderable format in the OpenGL 3.3 spec and is required for the [`GL_EXT_color_buffer_float`](https://registry.khronos.org/OpenGL/extensions/EXT/EXT_color_buffer_float.txt) extension. 

We can cherrypick this to 4.3 since the core bug is present there too. The regression component of this is just how obvious the problem became in 4.4