### PR TITLE
Update capsule documentations for size constraint clarifications

### DIFF
--- a/doc/classes/CapsuleMesh.xml
+++ b/doc/classes/CapsuleMesh.xml
@@ -11,12 +11,14 @@
 	<members>
 		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
 			Total height of the capsule mesh (including the hemispherical ends).
+			[b]Note:[/b] The [member height] of a capsule must be at least twice its [member radius]. Otherwise, the capsule becomes a circle. If the [member height] is less than twice the [member radius], the properties adjust to a valid value.
 		</member>
 		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments" default="64">
 			Number of radial segments on the capsule mesh.
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
 			Radius of the capsule mesh.
+			[b]Note:[/b] The [member radius] of a capsule cannot be greater than half of its [member height]. Otherwise, the capsule becomes a circle. If the [member radius] is greater than half of the [member height], the properties adjust to a valid value.
 		</member>
 		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="8">
 			Number of rings along the height of the capsule.

--- a/doc/classes/CapsuleShape2D.xml
+++ b/doc/classes/CapsuleShape2D.xml
@@ -12,12 +12,14 @@
 	<members>
 		<member name="height" type="float" setter="set_height" getter="get_height" default="30.0">
 			The capsule's full height, including the semicircles.
+			[b]Note:[/b] The [member height] of a capsule must be at least twice its [member radius]. Otherwise, the capsule becomes a circle. If the [member height] is less than twice the [member radius], the properties adjust to a valid value.
 		</member>
 		<member name="mid_height" type="float" setter="set_mid_height" getter="get_mid_height">
 			The capsule's height, excluding the semicircles. This is the height of the central rectangular part in the middle of the capsule, and is the distance between the centers of the two semicircles. This is a wrapper for [member height].
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="10.0">
 			The capsule's radius.
+			[b]Note:[/b] The [member radius] of a capsule cannot be greater than half of its [member height]. Otherwise, the capsule becomes a circle. If the [member radius] is greater than half of the [member height], the properties adjust to a valid value.
 		</member>
 	</members>
 </class>

--- a/doc/classes/CapsuleShape3D.xml
+++ b/doc/classes/CapsuleShape3D.xml
@@ -13,12 +13,14 @@
 	<members>
 		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
 			The capsule's full height, including the hemispheres.
+			[b]Note:[/b] The [member height] of a capsule must be at least twice its [member radius]. Otherwise, the capsule becomes a sphere. If the [member height] is less than twice the [member radius], the properties adjust to a valid value.
 		</member>
 		<member name="mid_height" type="float" setter="set_mid_height" getter="get_mid_height">
 			The capsule's height, excluding the hemispheres. This is the height of the central cylindrical part in the middle of the capsule, and is the distance between the centers of the two hemispheres. This is a wrapper for [member height].
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
 			The capsule's radius.
+			[b]Note:[/b] The [member radius] of a capsule cannot be greater than half of its [member height]. Otherwise, the capsule becomes a sphere. If the [member radius] is greater than half of the [member height], the properties adjust to a valid value.
 		</member>
 	</members>
 </class>

--- a/doc/classes/SpringBoneCollisionCapsule3D.xml
+++ b/doc/classes/SpringBoneCollisionCapsule3D.xml
@@ -11,6 +11,7 @@
 	<members>
 		<member name="height" type="float" setter="set_height" getter="get_height" default="0.5">
 			The capsule's full height, including the hemispheres.
+			[b]Note:[/b] The [member height] of a capsule must be at least twice its [member radius]. Otherwise, the capsule becomes a sphere. If the [member height] is less than twice the [member radius], the properties adjust to a valid value.
 		</member>
 		<member name="inside" type="bool" setter="set_inside" getter="is_inside" default="false">
 			If [code]true[/code], the collision acts to trap the joint within the collision.
@@ -20,6 +21,7 @@
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.1">
 			The capsule's radius.
+			[b]Note:[/b] The [member radius] of a capsule cannot be greater than half of its [member height]. Otherwise, the capsule becomes a sphere. If the [member radius] is greater than half of the [member height], the properties adjust to a valid value.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Added a note for all capsule classes to avoid confusion with their sizing behaviours.

A capsule's radius can't be more than half of its height, since it ends up becoming a circle. Changing the radius to exceed that limit causes the properties to be adjusted to a correct value, which has caused some confusion.

Fixes #101084 