### PR TITLE
Improve efficiency and precision of Geometry2D.is_point_in_polygon.

### DIFF
--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -368,40 +368,39 @@ public:
 		return sum > 0.0f;
 	}
 
-	// Alternate implementation that should be faster.
 	static bool is_point_in_polygon(const Vector2 &p_point, const Vector<Vector2> &p_polygon) {
 		int c = p_polygon.size();
 		if (c < 3) {
 			return false;
 		}
 		const Vector2 *p = p_polygon.ptr();
-		Vector2 further_away(-1e20, -1e20);
-		Vector2 further_away_opposite(1e20, 1e20);
-
+		// The point is inside if there's and odd number of intersections between
+		// every line in the polygon and a ray going from p_point towards (-inf, p_point.y)
+		bool odd_intersections = false;
 		for (int i = 0; i < c; i++) {
-			further_away = further_away.max(p[i]);
-			further_away_opposite = further_away_opposite.min(p[i]);
-		}
-
-		// Make point outside that won't intersect with points in segment from p_point.
-		further_away += (further_away - further_away_opposite) * Vector2(1.221313, 1.512312);
-
-		int intersections = 0;
-		for (int i = 0; i < c; i++) {
+			if (p_point == p[i]) {
+				return true;
+			}
 			const Vector2 &v1 = p[i];
-			const Vector2 &v2 = p[(i + 1) % c];
-
-			Vector2 res;
-			if (segment_intersects_segment(v1, v2, p_point, further_away, &res)) {
-				intersections++;
-				if (res.is_equal_approx(p_point)) {
-					// Point is in one of the polygon edges.
+			const Vector2 &v2 = p[i == 0 ? c - 1 : i - 1];
+			// If the line is parallel, the point is touching the
+			// polygon if v1.x and v2.x are on different sides of p_point.x
+			if ((v1.y == p_point.y) && (v2.y == p_point.y) && ((v1.x < p_point.x) != (v2.x < p_point.x))) {
+				return true;
+			}
+			// There can only ever be an intersection if v1.y and v2.y are on different sides of p_point.y
+			if ((v1.y < p_point.y) != (v2.y < p_point.y)) {
+				float cross = (p_point.y - v1.y) * (v2.x - v1.x) - (p_point.x - v1.x) * (v2.y - v1.y);
+				if ((cross < 0) == (v1.y < v2.y)) {
+					odd_intersections = !odd_intersections;
+				}
+				if (cross == 0) {
 					return true;
 				}
 			}
 		}
 
-		return (intersections & 1);
+		return odd_intersections;
 	}
 
 	static bool is_segment_intersecting_polygon(const Vector2 &p_from, const Vector2 &p_to, const Vector<Vector2> &p_polygon) {


### PR DESCRIPTION
The previos version called `segment_intersects_segment`, which is less precise as it checks against an epsilon. As far as I can tell, the only inputs for which the result differs is when that imprecision comes into play. 
So, this version also fixes https://github.com/godotengine/godot/issues/81042 and fixes https://github.com/godotengine/godot/issues/82305 (at least, the provided reproductions now work)
It's also about 6x faster, from my (very limited) tests.


This version turned out to be the same concept as was suggested [here](https://github.com/godotengine/godot/issues/82305#issuecomment-1735498943). It still checks for an odd number of intersections, but instead of using a preliminary loop to finding a point outside the polygon in order to construct a line, it uses an infinite ray from p_point towards (-inf, p_point.y).
In the intersection calculation, between the ray and every line in the polygon, there are some edge cases that return true for points exactly on the polygon boundary. Otherwise, an intersection can only exist if `p_point.y` is between `v1.y` and `v2.y`. With that knowledge, we can calculate `p = inverse_lerp(v1.y, v2.y, p_point.y)`, a value between 0 and 1. The x of the intersection point between the polygon's line, and the infinite line described by `y = p_point.y`, is `x = lerp(v1.x, v2.x, p)`. If `x <= p_point.x` then there is an intersection. Since we only care about that inequality and don't actually want the exact x of the intersection point, the math can be simplified, and it turns out to basically be a cross product between `p_point - v1` and `v2 - v1`. Which is easier to compute as it avoids a division caused by `inverse_lerp`.
I also replaced a remainder `(%)` with a ternary operation, which also seemed to boost performance slightly.