### PR TITLE
Remove confusing `Control::is_top_level_control()`

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -607,11 +607,6 @@ bool Control::_property_get_revert(const StringName &p_name, Variant &r_property
 
 // Global relations.
 
-bool Control::is_top_level_control() const {
-	ERR_READ_THREAD_GUARD_V(false);
-	return is_inside_tree() && (!data.parent_canvas_item && !data.RI && is_set_as_top_level());
-}
-
 Control *Control::get_parent_control() const {
 	ERR_READ_THREAD_GUARD_V(nullptr);
 	return data.parent_control;
@@ -631,10 +626,6 @@ Control *Control::get_root_parent_control() const {
 		const Control *c = Object::cast_to<Control>(ci);
 		if (c) {
 			root = c;
-
-			if (c->data.RI || c->is_top_level_control()) {
-				break;
-			}
 		}
 
 		ci = ci->get_parent_item();

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -428,8 +428,6 @@ public:
 
 	// Global relations.
 
-	bool is_top_level_control() const;
-
 	Control *get_parent_control() const;
 	Window *get_parent_window() const;
 	Control *get_root_parent_control() const;


### PR DESCRIPTION
It's hard to tell at first glance under what circumstances `is_top_level_control()` returns `true`. So it's hard to decide when to use this method. And it seems to be just a helper function for `Control::get_root_parent_control()`.

`is_top_level_control()` seems to only return `true` during entry and exit of canvas for top level case.

~~`data.RI` is equivalent to `is_inside_tree() && (!data.parent_control || is_set_as_top_level())` in most cases.~~

Finding the root parent control does not require relying on `data.RI`.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
