### PR TITLE
Add property guards to shape 2D's

### DIFF
--- a/scene/resources/2d/capsule_shape_2d.cpp
+++ b/scene/resources/2d/capsule_shape_2d.cpp
@@ -60,6 +60,9 @@ void CapsuleShape2D::_update_shape() {
 
 void CapsuleShape2D::set_radius(real_t p_radius) {
 	ERR_FAIL_COND_MSG(p_radius < 0, "CapsuleShape2D radius cannot be negative.");
+	if (radius == p_radius) {
+		return;
+	}
 	radius = p_radius;
 	if (radius > height * 0.5) {
 		height = radius * 2.0;
@@ -73,6 +76,9 @@ real_t CapsuleShape2D::get_radius() const {
 
 void CapsuleShape2D::set_height(real_t p_height) {
 	ERR_FAIL_COND_MSG(p_height < 0, "CapsuleShape2D height cannot be negative.");
+	if (height == p_height) {
+		return;
+	}
 	height = p_height;
 	if (radius > height * 0.5) {
 		radius = height * 0.5;

--- a/scene/resources/2d/circle_shape_2d.cpp
+++ b/scene/resources/2d/circle_shape_2d.cpp
@@ -44,6 +44,9 @@ void CircleShape2D::_update_shape() {
 
 void CircleShape2D::set_radius(real_t p_radius) {
 	ERR_FAIL_COND_MSG(p_radius < 0, "CircleShape2D radius cannot be negative.");
+	if (radius == p_radius) {
+		return;
+	}
 	radius = p_radius;
 	_update_shape();
 }

--- a/scene/resources/2d/rectangle_shape_2d.cpp
+++ b/scene/resources/2d/rectangle_shape_2d.cpp
@@ -59,6 +59,9 @@ bool RectangleShape2D::_get(const StringName &p_name, Variant &r_property) const
 
 void RectangleShape2D::set_size(const Size2 &p_size) {
 	ERR_FAIL_COND_MSG(p_size.x < 0 || p_size.y < 0, "RectangleShape2D size cannot be negative.");
+	if (size == p_size) {
+		return;
+	}
 	size = p_size;
 	_update_shape();
 }

--- a/scene/resources/2d/segment_shape_2d.cpp
+++ b/scene/resources/2d/segment_shape_2d.cpp
@@ -49,6 +49,9 @@ void SegmentShape2D::_update_shape() {
 }
 
 void SegmentShape2D::set_a(const Vector2 &p_a) {
+	if (a == p_a) {
+		return;
+	}
 	a = p_a;
 	_update_shape();
 }
@@ -58,6 +61,9 @@ Vector2 SegmentShape2D::get_a() const {
 }
 
 void SegmentShape2D::set_b(const Vector2 &p_b) {
+	if (b == p_b) {
+		return;
+	}
 	b = p_b;
 	_update_shape();
 }

--- a/scene/resources/2d/separation_ray_shape_2d.cpp
+++ b/scene/resources/2d/separation_ray_shape_2d.cpp
@@ -94,6 +94,9 @@ void SeparationRayShape2D::_bind_methods() {
 }
 
 void SeparationRayShape2D::set_length(real_t p_length) {
+	if (length == p_length) {
+		return;
+	}
 	length = p_length;
 	_update_shape();
 }
@@ -103,6 +106,9 @@ real_t SeparationRayShape2D::get_length() const {
 }
 
 void SeparationRayShape2D::set_slide_on_slope(bool p_active) {
+	if (slide_on_slope == p_active) {
+		return;
+	}
 	slide_on_slope = p_active;
 	_update_shape();
 }


### PR DESCRIPTION
Using master, setting `CircleShape2D`'s radius to the same value every frame causes a quite big performance hit. 

There are, of course, many ways to prevent doing this, but quite often, especially prototyping and testing new stuff, the simplest way is just to set the property and to do not care about the previous value. Checking the current property value before changing it or using some sort of flag in GDScript is most likely slower than letting the C++ property guard handle the situation.

`WorldBoundaryShape2D` already had property guards.