### PR TITLE
Fix `ResourceLoader.has_cached()` and `ResourceLoader.get_cached_ref()` not handling UIDs.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -113,12 +113,12 @@ PackedStringArray ResourceLoader::get_dependencies(const String &p_path) {
 }
 
 bool ResourceLoader::has_cached(const String &p_path) {
-	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
+	String local_path = ::ResourceLoader::_validate_local_path(p_path);
 	return ResourceCache::has(local_path);
 }
 
 Ref<Resource> ResourceLoader::get_cached_ref(const String &p_path) {
-	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
+	String local_path = ::ResourceLoader::_validate_local_path(p_path);
 	return ResourceCache::get_ref(local_path);
 }
 

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -495,7 +495,7 @@ void ResourceLoader::_run_load_task(void *p_userdata) {
 	curr_load_task = curr_load_task_backup;
 }
 
-static String _validate_local_path(const String &p_path) {
+String ResourceLoader::_validate_local_path(const String &p_path) {
 	ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(p_path);
 	if (uid != ResourceUID::INVALID_ID) {
 		return ResourceUID::get_singleton()->get_id_path(uid);

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -36,6 +36,10 @@
 #include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
 
+namespace core_bind {
+class ResourceLoader;
+}
+
 class ConditionVariable;
 
 template <int Tag>
@@ -101,6 +105,7 @@ typedef void (*ResourceLoadedCallback)(Ref<Resource> p_resource, const String &p
 
 class ResourceLoader {
 	friend class LoadToken;
+	friend class core_bind::ResourceLoader;
 
 	enum {
 		MAX_LOADERS = 64
@@ -216,6 +221,8 @@ private:
 	static float _dependency_get_progress(const String &p_path);
 
 	static bool _ensure_load_progress();
+
+	static String _validate_local_path(const String &p_path);
 
 public:
 	static Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE);


### PR DESCRIPTION
Moves cache-related logic of `ResourceLoader` to the `ResourceLoader` class so we can reuse the `_validate_local_path()` function to handle UID paths properly. `ResourceCache` is already used in other functions of the `ResourceLoader` class, so I feel like this is not too big of a move. However, do correct me if I'm wrong.

Fixes #101743.

I've built and tested the fix on my PC. While this fixes the issue, I would appreciate some input on the code styling. Mainly the placement of function definitions and declarations in `resource_loader.cpp` and `resource_loader.h`.  I just placed them where I thought they would kinda make sense. I am also not too familiar with C++ development, so please be sure to check if I missed anything.