### PR TITLE
[Windows] Override key codes with Unicode values for OEM keys only.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -5838,7 +5838,9 @@ void DisplayServerWindows::_process_key_events() {
 					Ref<InputEventKey> k;
 					k.instantiate();
 
-					Key keycode = KeyMappingWindows::get_keysym(MapVirtualKey((ke.lParam >> 16) & 0xFF, MAPVK_VSC_TO_VK));
+					UINT vk = MapVirtualKey((ke.lParam >> 16) & 0xFF, MAPVK_VSC_TO_VK);
+					bool is_oem = (vk >= 0xB8) && (vk <= 0xE6);
+					Key keycode = KeyMappingWindows::get_keysym(vk);
 					Key key_label = keycode;
 					Key physical_keycode = KeyMappingWindows::get_scansym((ke.lParam >> 16) & 0xFF, ke.lParam & (1 << 24));
 
@@ -5851,7 +5853,7 @@ void DisplayServerWindows::_process_key_events() {
 						if (!keysym.is_empty()) {
 							char32_t unicode_value = keysym[0];
 							// For printable ASCII characters (0x20-0x7E), override the original keycode with the character value.
-							if (Key::SPACE <= (Key)unicode_value && (Key)unicode_value <= Key::ASCIITILDE) {
+							if (is_oem && Key::SPACE <= (Key)unicode_value && (Key)unicode_value <= Key::ASCIITILDE) {
 								keycode = fix_keycode(unicode_value, (Key)unicode_value);
 							}
 							key_label = fix_key_label(unicode_value, keycode);
@@ -5894,6 +5896,7 @@ void DisplayServerWindows::_process_key_events() {
 				k->set_window_id(ke.window_id);
 				k->set_pressed(ke.uMsg == WM_KEYDOWN);
 
+				bool is_oem = (ke.wParam >= 0xB8) && (ke.wParam <= 0xE6);
 				Key keycode = KeyMappingWindows::get_keysym(ke.wParam);
 				if ((ke.lParam & (1 << 24)) && (ke.wParam == VK_RETURN)) {
 					// Special case for Numpad Enter key.
@@ -5912,7 +5915,7 @@ void DisplayServerWindows::_process_key_events() {
 					if (!keysym.is_empty()) {
 						char32_t unicode_value = keysym[0];
 						// For printable ASCII characters (0x20-0x7E), override the original keycode with the character value.
-						if (Key::SPACE <= (Key)unicode_value && (Key)unicode_value <= Key::ASCIITILDE) {
+						if (is_oem && Key::SPACE <= (Key)unicode_value && (Key)unicode_value <= Key::ASCIITILDE) {
 							keycode = fix_keycode(unicode_value, (Key)unicode_value);
 						}
 						key_label = fix_key_label(unicode_value, keycode);


### PR DESCRIPTION
Should fix https://github.com/godotengine/godot/issues/101701 and still correctly process OEM keys (https://github.com/godotengine/godot/pull/100960).

I was not able to fully test it since layouts from https://bepo.fr seems to be non-functional (crash explorer when you try to switch layout) and do not have physical JP106 keyboard.