### PR TITLE
[WS] Fix peer stuck in CLOSING state

### DIFF
--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -860,10 +860,12 @@ void WSLPeer::close(int p_code, String p_reason) {
 		}
 	}
 
-	heartbeat_waiting = false;
-	in_buffer.clear();
-	packet_buffer.resize(0);
-	pending_message.clear();
+	if (ready_state == STATE_CLOSED) {
+		heartbeat_waiting = false;
+		in_buffer.clear();
+		packet_buffer.resize(0);
+		pending_message.clear();
+	}
 }
 
 IPAddress WSLPeer::get_connected_host() const {


### PR DESCRIPTION
This was due by the buffer being cleared on close (including in closing state) preventing further reads.

This commit changes the close logic to only clear the buffer when the peer connection has been fully closed (acknowledged by the other end, or closed due to a "broken" connection).

Fixes #100948