### PR TITLE
[Windows] Fix left/right Shift key regression

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4684,7 +4684,9 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					// If multiple Shifts are held down at the same time,
 					// Windows natively only sends a KEYUP for the last one to be released.
 					if (raw->data.keyboard.Flags & RI_KEY_BREAK) {
-						if (!mods.has_flag(WinKeyModifierMask::SHIFT)) {
+						// Make sure to check the latest key state since
+						// we're in the middle of the message queue.
+						if (GetAsyncKeyState(VK_SHIFT) < 0) {
 							// A Shift is released, but another Shift is still held
 							ERR_BREAK(key_event_pos >= KEY_EVENT_BUFFER_SIZE);
 


### PR DESCRIPTION
This fixes a regression introduced in #92415 and reported in #101384.

When multiple Shift keys are pressed, Windows only sends a KEYUP for the last key released, leaving the other stuck pressed. A workaround was introduced in #80231 to fake this missing KEYUP event.
However this workaround was broken in #92415. _get_mods() returns the modifier keys *before* the KEYUP, so there will always be a Shift key pressed before it's released.

This PR restores the original check and respective functionality. The MRP in #101384 can be used to reproduce and confirm the fix.

Thanks to @ghostsoft @andyprice @romlok for helping debug the issue.

* *Bugsquad edit, fixes: #101384*