### PR TITLE
Don't initialize editor when exiting

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3409,6 +3409,7 @@ int EditorNode::_next_unsaved_scene(bool p_valid_filename, int p_start) {
 
 void EditorNode::_exit_editor(int p_exit_code) {
 	exiting = true;
+	waiting_for_first_scan = false;
 	resource_preview->stop(); // Stop early to avoid crashes.
 	_save_editor_layout();
 


### PR DESCRIPTION
When exporting the project from command line, the editor is supposed to quit once finished. It doesn't, it first runs its initialization (restoring layout, loading scenes) and only then it quits.

This PR makes the exit actually exit immediately.