### PR TITLE
Don't update inspector when invisible

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -3845,6 +3845,11 @@ void EditorInspector::update_tree() {
 		return;
 	}
 
+	if (!is_visible_in_tree()) {
+		update_tree_pending = true;
+		return;
+	}
+
 	bool root_inspector_was_following_focus = get_root_inspector()->is_following_focus();
 	if (root_inspector_was_following_focus) {
 		// Temporarily disable focus following on the root inspector to avoid jumping while the inspector is updating.
@@ -5911,8 +5916,6 @@ void EditorInspector::_bind_methods() {
 }
 
 EditorInspector::EditorInspector() {
-	object = nullptr;
-
 	base_vbox = memnew(VBoxContainer);
 	base_vbox->set_theme_type_variation(SNAME("EditorInspectorContainer"));
 	base_vbox->set_h_size_flags(SIZE_EXPAND_FILL);


### PR DESCRIPTION
There is no reason to update invisible inspector. This PR makes the update queued to run once the inspector appears.

I tested out of curiosity and the added `return` takes effect 84 times when starting the editor. The inspectors are mostly empty at the time, so probably doesn't have big impact. The most noticeable improvement is when switching nodes while another dock is visible instead of the inspector.