### PR TITLE
Specify `max_slides` must be greater than 0

### DIFF
--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -166,7 +166,7 @@
 			If [code]false[/code], the body will slide on floor's slopes when [member velocity] applies a downward force.
 		</member>
 		<member name="max_slides" type="int" setter="set_max_slides" getter="get_max_slides" default="4">
-			Maximum number of times the body can change direction before it stops when calling [method move_and_slide].
+			Maximum number of times the body can change direction before it stops when calling [method move_and_slide]. Must be greater than zero.
 		</member>
 		<member name="motion_mode" type="int" setter="set_motion_mode" getter="get_motion_mode" enum="CharacterBody2D.MotionMode" default="0">
 			Sets the motion mode which defines the behavior of [method move_and_slide]. See [enum MotionMode] constants for available modes.

--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -157,7 +157,7 @@
 			If [code]false[/code], the body will slide on floor's slopes when [member velocity] applies a downward force.
 		</member>
 		<member name="max_slides" type="int" setter="set_max_slides" getter="get_max_slides" default="6">
-			Maximum number of times the body can change direction before it stops when calling [method move_and_slide].
+			Maximum number of times the body can change direction before it stops when calling [method move_and_slide]. Must be greater than zero.
 		</member>
 		<member name="motion_mode" type="int" setter="set_motion_mode" getter="get_motion_mode" enum="CharacterBody3D.MotionMode" default="0">
 			Sets the motion mode which defines the behavior of [method move_and_slide]. See [enum MotionMode] constants for available modes.


### PR DESCRIPTION
This is a change to the docs, highlighting a potential gotcha that wasted a few hours of my time. Hopefully, this helps someone else.