### PR TITLE
Fix symbol lookup misidentifying class constants

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -4043,7 +4043,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 	GDScriptAnalyzer analyzer(&parser);
 	analyzer.analyze();
 
-	if (context.current_class && context.current_class->extends.size() > 0) {
+	if (context.current_class && context.current_class->extends.size() > 0 && context.type == GDScriptParser::COMPLETION_IDENTIFIER) {
 		StringName class_name = context.current_class->extends[0]->name;
 
 		bool success = false;


### PR DESCRIPTION
My attempt to fix #97988.

The issue was caused by `GDScriptLanguage::lookup_code` checking base class constants and enums without considering the context. I added a condition to ensure this check only runs when the lookup context is `COMPLETION_IDENTIFIER`, preventing incorrect symbol resolution in other cases.