### PR TITLE
Add `use_self_delta_to_fade` to NodeOneShot to fade finished animation

### DIFF
--- a/doc/classes/AnimationNodeOneShot.xml
+++ b/doc/classes/AnimationNodeOneShot.xml
@@ -74,17 +74,21 @@
 		</member>
 		<member name="fadein_time" type="float" setter="set_fadein_time" getter="get_fadein_time" default="0.0">
 			The fade-in duration. For example, setting this to [code]1.0[/code] for a 5 second length animation will produce a cross-fade that starts at 0 second and ends at 1 second during the animation.
-			[b]Note:[/b] [AnimationNodeOneShot] transitions the current state after the end of the fading. When [AnimationNodeOutput] is considered as the most upstream, so the [member fadein_time] is scaled depending on the downstream delta. For example, if this value is set to [code]1.0[/code] and a [AnimationNodeTimeScale] with a value of [code]2.0[/code] is chained downstream, the actual processing time will be 0.5 second.
+			[b]Note:[/b] [AnimationNodeOneShot] transitions the current state after the end of the fading. The timing and running duration of the fading depends on [member use_self_delta_to_fade].
 		</member>
 		<member name="fadeout_curve" type="Curve" setter="set_fadeout_curve" getter="get_fadeout_curve">
 			Determines how cross-fading between animations is eased. If empty, the transition will be linear. Should be a unit [Curve].
 		</member>
 		<member name="fadeout_time" type="float" setter="set_fadeout_time" getter="get_fadeout_time" default="0.0">
 			The fade-out duration. For example, setting this to [code]1.0[/code] for a 5 second length animation will produce a cross-fade that starts at 4 second and ends at 5 second during the animation.
-			[b]Note:[/b] [AnimationNodeOneShot] transitions the current state after the end of the fading. When [AnimationNodeOutput] is considered as the most upstream, so the [member fadeout_time] is scaled depending on the downstream delta. For example, if this value is set to [code]1.0[/code] and an [AnimationNodeTimeScale] with a value of [code]2.0[/code] is chained downstream, the actual processing time will be 0.5 second.
+			[b]Note:[/b] [AnimationNodeOneShot] transitions the current state after the end of the fading. The timing and running duration of the fading depends on [member use_self_delta_to_fade].
 		</member>
 		<member name="mix_mode" type="int" setter="set_mix_mode" getter="get_mix_mode" enum="AnimationNodeOneShot.MixMode" default="0">
 			The blend type.
+		</member>
+		<member name="use_self_delta_to_fade" type="bool" setter="set_use_self_delta_to_fade" getter="is_using_self_delta_to_fade" default="false">
+			If [code]false[/code], when [AnimationNodeOutput] is considered as the most upstream, so the [member fadein_time] and the [member fadeout_time] are scaled depending on the downstream delta. For example, if this value is set to [code]1.0[/code] and an [AnimationNodeTimeScale] with a value of [code]2.0[/code] is chained downstream, the actual processing time will be 0.5 second.
+			If [code]true[/code], No longer depends on downstream time scale.
 		</member>
 	</members>
 	<constants>

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -527,6 +527,14 @@ bool AnimationNodeOneShot::is_loop_broken_at_end() const {
 	return break_loop_at_end;
 }
 
+void AnimationNodeOneShot::set_use_self_delta_to_fade(bool p_enable) {
+	use_self_delta_to_fade = p_enable;
+}
+
+bool AnimationNodeOneShot::is_using_self_delta_to_fade() const {
+	return use_self_delta_to_fade;
+}
+
 String AnimationNodeOneShot::get_caption() const {
 	return "OneShot";
 }
@@ -686,7 +694,7 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 				set_parameter(time_to_restart, restart_sec);
 			}
 		}
-		double d = Math::abs(os_nti.delta);
+		double d = use_self_delta_to_fade ? abs_delta : Math::abs(os_nti.delta);
 		if (!do_start) {
 			cur_fade_in_remaining = MAX(0, cur_fade_in_remaining - d); // Don't consider seeked delta by restart.
 		}
@@ -715,6 +723,9 @@ void AnimationNodeOneShot::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_break_loop_at_end", "enable"), &AnimationNodeOneShot::set_break_loop_at_end);
 	ClassDB::bind_method(D_METHOD("is_loop_broken_at_end"), &AnimationNodeOneShot::is_loop_broken_at_end);
 
+	ClassDB::bind_method(D_METHOD("set_use_self_delta_to_fade", "enable"), &AnimationNodeOneShot::set_use_self_delta_to_fade);
+	ClassDB::bind_method(D_METHOD("is_using_self_delta_to_fade"), &AnimationNodeOneShot::is_using_self_delta_to_fade);
+
 	ClassDB::bind_method(D_METHOD("set_autorestart", "active"), &AnimationNodeOneShot::set_auto_restart_enabled);
 	ClassDB::bind_method(D_METHOD("has_autorestart"), &AnimationNodeOneShot::is_auto_restart_enabled);
 
@@ -734,6 +745,7 @@ void AnimationNodeOneShot::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fadeout_time", PROPERTY_HINT_RANGE, "0,60,0.01,or_greater,suffix:s"), "set_fadeout_time", "get_fadeout_time");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "fadeout_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_fadeout_curve", "get_fadeout_curve");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "break_loop_at_end"), "set_break_loop_at_end", "is_loop_broken_at_end");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_self_delta_to_fade"), "set_use_self_delta_to_fade", "is_using_self_delta_to_fade");
 
 	ADD_GROUP("Auto Restart", "autorestart_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autorestart"), "set_autorestart", "has_autorestart");

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -149,6 +149,7 @@ private:
 	double auto_restart_random_delay = 0.0;
 	MixMode mix = MIX_MODE_BLEND;
 	bool break_loop_at_end = false;
+	bool use_self_delta_to_fade = false;
 
 	StringName request = PNAME("request");
 	StringName active = PNAME("active");
@@ -192,6 +193,9 @@ public:
 
 	void set_break_loop_at_end(bool p_enable);
 	bool is_loop_broken_at_end() const;
+
+	void set_use_self_delta_to_fade(bool p_enable);
+	bool is_using_self_delta_to_fade() const;
 
 	virtual bool has_filter() const override;
 	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/101169

First, note that this is a band-aid solution.

For example, when there is a 1 second fade in OneShot, when the input TimeScale is 2.0, the fade is actually 0.5 seconds.

This is a fix to address the problem noted in #87009 and to keep the past behavior that has existed since 3.x, but I assume it is not correct in terms of consistency.

For complete consistency, I think the NodeTimeInfo should include the TimeScale and get the remaining time depending on that. However, this is a major rework and should not be done at this stage as it would be a significant behavior change. So, I believe we should rethink this when the update timing to 5.0. (So this and https://github.com/godotengine/godot/pull/101792 using prediction.)

For now, enabling this option will allow the fade to work even when the input animation delta is `0`.