### PR TITLE
Change `NodeOneShot` fading to uses self delta instead of input delta

### DIFF
--- a/doc/classes/AnimationNodeOneShot.xml
+++ b/doc/classes/AnimationNodeOneShot.xml
@@ -74,14 +74,14 @@
 		</member>
 		<member name="fadein_time" type="float" setter="set_fadein_time" getter="get_fadein_time" default="0.0">
 			The fade-in duration. For example, setting this to [code]1.0[/code] for a 5 second length animation will produce a cross-fade that starts at 0 second and ends at 1 second during the animation.
-			[b]Note:[/b] [AnimationNodeOneShot] transitions the current state after the end of the fading. When [AnimationNodeOutput] is considered as the most upstream, so the [member fadein_time] is scaled depending on the downstream delta. For example, if this value is set to [code]1.0[/code] and a [AnimationNodeTimeScale] with a value of [code]2.0[/code] is chained downstream, the actual processing time will be 0.5 second.
+			[b]Note:[/b] [AnimationNodeOneShot] transitions the current state after the fading has finished.
 		</member>
 		<member name="fadeout_curve" type="Curve" setter="set_fadeout_curve" getter="get_fadeout_curve">
 			Determines how cross-fading between animations is eased. If empty, the transition will be linear. Should be a unit [Curve].
 		</member>
 		<member name="fadeout_time" type="float" setter="set_fadeout_time" getter="get_fadeout_time" default="0.0">
 			The fade-out duration. For example, setting this to [code]1.0[/code] for a 5 second length animation will produce a cross-fade that starts at 4 second and ends at 5 second during the animation.
-			[b]Note:[/b] [AnimationNodeOneShot] transitions the current state after the end of the fading. When [AnimationNodeOutput] is considered as the most upstream, so the [member fadeout_time] is scaled depending on the downstream delta. For example, if this value is set to [code]1.0[/code] and an [AnimationNodeTimeScale] with a value of [code]2.0[/code] is chained downstream, the actual processing time will be 0.5 second.
+			[b]Note:[/b] [AnimationNodeOneShot] transitions the current state after the fading has finished.
 		</member>
 		<member name="mix_mode" type="int" setter="set_mix_mode" getter="get_mix_mode" enum="AnimationNodeOneShot.MixMode" default="0">
 			The blend type.


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/101169
- Alternative of https://github.com/godotengine/godot/pull/101788

Predict the time scale from the delta difference so that the fading time does not depend on the input AnimationNode's delta.

This breaks compatibility a bit because it changes the behavior of the existing fading time scaled by the downstream time scale. However, since the scaling is specific to NodeOneShot, this should bring it closer to the behavior of other AnimationNodes.

It is possible that a strange state may be produced if the timescale is changed during a fade, but since NodeTransiton and StateMachine should have the same problem, I judge that it is not a problem. The case where the timescale is changed during a transition in AtEnd with a fade is quite niche, IMO.

The problem of the fade time and end time being out of sync as in #87009, should no longer occur, but the fade duration will change, as explained below (bit change old behavior).