### PR TITLE
Change editor viewport condition for `accept_event()` from freelook active to more generic `Input::MODE_MOUSE_CAPTURED`

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2508,9 +2508,9 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		}
 	}
 
-	// freelook uses most of the useful shortcuts, like save, so its ok
-	// to consider freelook active as end of the line for future events.
-	if (freelook_active) {
+	// If the mouse is captured, it can be safe to assume inputs should not propagate as it can
+	// cause conflicts like when freelook is active.
+	if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
 		accept_event();
 	}
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Related: https://github.com/godotengine/godot/pull/101251
Related: https://github.com/godotengine/godot-proposals/issues/11424#issuecomment-2571719418

This PR doesn't change any behavior by default but will allow plugins or other future core features to take advantage of editor viewport(s) while the mouse is captured, so that there aren't conflicting inputs that result in unwanted behavior. In general, I think it's safe to assume that if the mouse is captured, you don't want things to happen outside the context of the object that triggered the capture, which means that using freelook active alone is not enough of a constraint. 