### PR TITLE
Physics interpolation (3D): Fix warning spam

### DIFF
--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -113,19 +113,6 @@ void VisualInstance3D::_notification(int p_what) {
 
 				RenderingServer::get_singleton()->instance_reset_physics_interpolation(instance);
 			}
-#if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
-			else if (GLOBAL_GET("debug/settings/physics_interpolation/enable_warnings")) {
-
-				String node_name = is_inside_tree() ? String(get_path()) : String(get_name());
-				if (!_is_vi_visible()) {
-					WARN_PRINT("[Physics interpolation] NOTIFICATION_RESET_PHYSICS_INTERPOLATION only works with unhidden nodes: \"" + node_name + "\".");
-				}
-				if (!is_physics_interpolated()) {
-					WARN_PRINT("[Physics interpolation] NOTIFICATION_RESET_PHYSICS_INTERPOLATION only works with interpolated nodes: \"" + node_name + "\".");
-				}
-			}
-#endif
-
 		} break;
 
 		case NOTIFICATION_EXIT_WORLD: {


### PR DESCRIPTION
These warnings were spamming, and they were removed in `3.x` in https://github.com/godotengine/godot/commit/5162efbfe9daddb9b30c15c906890e0ea4e4213a, so we do the same in `master`.

- Fixes https://github.com/godotengine/godot/issues/101665