### PR TITLE
Fix kinematic bodies not synchronizing state when using Jolt Physics

### DIFF
--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -110,15 +110,13 @@ private:
 
 	virtual void _add_to_space() override;
 
+	bool _should_call_queries() const { return state_sync_callback.is_valid() || custom_integration_callback.is_valid(); }
 	void _enqueue_call_queries();
 	void _dequeue_call_queries();
 
 	void _integrate_forces(float p_step, JPH::Body &p_jolt_body);
 
 	void _move_kinematic(float p_step, JPH::Body &p_jolt_body);
-
-	void _pre_step_rigid(float p_step, JPH::Body &p_jolt_body);
-	void _pre_step_kinematic(float p_step, JPH::Body &p_jolt_body);
 
 	JPH::EAllowedDOFs _calculate_allowed_dofs() const;
 


### PR DESCRIPTION
Fixes #101753.

Prior to #100983 we relied on a `JoltBody3D::sync_state` flag to indicate whether a rigid/kinematic body should have its state synchronized on the next `PhysicsServer3D::flush_queries`, but as of #100983 the Jolt Physics module now does the same kind of "self-listing" as Godot Physics, where each body registers with its respective physics space to have its `call_queries` invoked.

However, it seems I had forgot to replace one important `sync_state = true` with the new `_enqueue_call_queries`, which was the one happening in `JoltBody3D::_move_kinematic`, meaning we now never invoke state synchronization for things like `AnimatableBody3D`, which relies on this for its `sync_to_physics` property.

With this PR we now instead always `_enqueue_call_queries` if any active `JoltBody3D` has a valid state synchronization callback or a valid custom integration callback before stepping the simulation, which should bring it in line with Godot Physics.

(I also removed/inlined `_pre_step_rigid` and `_pre_step_kinematic` as they felt a bit excessive now.)