### PR TITLE
Prevent LineEdit focus loss when editing `resources_to_open_in_new_inspector`

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4735,7 +4735,10 @@ void EditorInspector::_notification(int p_what) {
 			}
 
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/inspector")) {
-				needs_update = true;
+				// Extra condition to avoid LineEdit focus loss when editing resources_to_open_in_new_inspector setting.
+				if (!get_meta(SNAME("editor_settings_inspector"), false) || !EditorSettings::get_singleton()->check_changed_settings_in_group("interface/inspector/resources_to_open_in_new_inspector")) {
+					needs_update = true;
+				}
 			}
 
 			if (needs_update) {

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -913,6 +913,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	inspector->register_advanced_toggle(advanced_switch);
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tab_general->add_child(inspector);
+	inspector->get_inspector()->set_meta("editor_settings_inspector", true);
 	inspector->get_inspector()->connect("property_edited", callable_mp(this, &EditorSettingsDialog::_settings_property_edited));
 	inspector->get_inspector()->connect("restart_requested", callable_mp(this, &EditorSettingsDialog::_editor_restart_request));
 


### PR DESCRIPTION
Fixes #20708
I went with a fix that has least performance impact, but it's not very clean.