### PR TITLE
Fix editor `Parallax2D` grid snap movement

### DIFF
--- a/scene/2d/parallax_2d.cpp
+++ b/scene/2d/parallax_2d.cpp
@@ -69,7 +69,9 @@ void Parallax2D::_notification(int p_what) {
 
 #ifdef TOOLS_ENABLED
 void Parallax2D::_edit_set_position(const Point2 &p_position) {
-	set_scroll_offset(p_position);
+	// Avoids early return for grid snap compatibility
+	scroll_offset = p_position;
+	_update_scroll();
 }
 #endif // TOOLS_ENABLED
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/97601

As far as I can see the editor avoids updating the position when grid snap is on because it sends multiple of the same value causing an early return. I think that guard should be there in most cases, but in the editor it makes sense to remove.

https://github.com/user-attachments/assets/8acfccfe-ccc2-409f-a155-8cf95197da01


