### PR TITLE
Fix Floating Game Window Title

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -826,6 +826,9 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread
 		}
 	} else if (p_msg == "evaluation_return") {
 		expression_evaluator->add_value(p_data);
+	} else if (p_msg == "window:title") {
+		ERR_FAIL_COND(p_data.size() != 1);
+		emit_signal(SNAME("remote_window_title_changed"), p_data[0]);
 	} else {
 		int colon_index = p_msg.find_char(':');
 		ERR_FAIL_COND_MSG(colon_index < 1, "Invalid message received");
@@ -1784,6 +1787,7 @@ void ScriptEditorDebugger::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("remote_object_property_updated", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::STRING, "property")));
 	ADD_SIGNAL(MethodInfo("remote_tree_updated"));
 	ADD_SIGNAL(MethodInfo("remote_tree_select_requested", PropertyInfo(Variant::NODE_PATH, "path")));
+	ADD_SIGNAL(MethodInfo("remote_window_title_changed", PropertyInfo(Variant::STRING, "title")));
 	ADD_SIGNAL(MethodInfo("output", PropertyInfo(Variant::STRING, "msg"), PropertyInfo(Variant::INT, "level")));
 	ADD_SIGNAL(MethodInfo("stack_dump", PropertyInfo(Variant::ARRAY, "stack_dump")));
 	ADD_SIGNAL(MethodInfo("stack_frame_vars", PropertyInfo(Variant::INT, "num_vars")));

--- a/editor/plugins/embedded_process.cpp
+++ b/editor/plugins/embedded_process.cpp
@@ -145,6 +145,10 @@ bool EmbeddedProcess::is_embedding_completed() {
 	return embedding_completed;
 }
 
+int EmbeddedProcess::get_embedded_pid() const {
+	return current_process_id;
+}
+
 void EmbeddedProcess::embed_process(OS::ProcessID p_pid) {
 	if (!window) {
 		return;

--- a/editor/plugins/embedded_process.h
+++ b/editor/plugins/embedded_process.h
@@ -82,6 +82,7 @@ public:
 	Rect2i get_screen_embedded_window_rect();
 	bool is_embedding_in_progress();
 	bool is_embedding_completed();
+	int get_embedded_pid() const;
 
 	EmbeddedProcess();
 	~EmbeddedProcess();

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -40,6 +40,7 @@
 class EmbeddedProcess;
 class VSeparator;
 class WindowWrapper;
+class ScriptEditorDebugger;
 
 class GameViewDebugger : public EditorDebuggerPlugin {
 	GDCLASS(GameViewDebugger, EditorDebuggerPlugin);
@@ -101,6 +102,7 @@ class GameView : public VBoxContainer {
 	bool is_feature_enabled = true;
 	int active_sessions = 0;
 	int screen_index_before_start = -1;
+	ScriptEditorDebugger *embedded_script_debugger = nullptr;
 
 	bool embed_on_play = true;
 	bool make_floating_on_play = true;
@@ -162,6 +164,9 @@ class GameView : public VBoxContainer {
 
 	void _window_before_closing();
 	void _update_floating_window_settings();
+	void _attach_script_debugger();
+	void _detach_script_debugger();
+	void _remote_window_title_changed(String title);
 
 protected:
 	void _notification(int p_what);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -31,6 +31,7 @@
 #include "window.h"
 
 #include "core/config/project_settings.h"
+#include "core/debugger/engine_debugger.h"
 #include "core/input/shortcut.h"
 #include "core/string/translation_server.h"
 #include "scene/gui/control.h"
@@ -306,6 +307,14 @@ void Window::set_title(const String &p_title) {
 		}
 	}
 	emit_signal("title_changed");
+
+#ifdef DEBUG_ENABLED
+	if (EngineDebugger::get_singleton() && window_id == DisplayServer::MAIN_WINDOW_ID && !Engine::get_singleton()->is_project_manager_hint()) {
+		Array arr;
+		arr.push_back(tr_title);
+		EngineDebugger::get_singleton()->send_message("window:title", arr);
+	}
+#endif
 }
 
 String Window::get_title() const {


### PR DESCRIPTION
- Fixes #101539

This PR updates the Floating Game Workspace title to match the Game Window title. With this modification, the title will correspond to the game window title when embedding is not enabled.

The main challenge with this issue was ensuring that the Floating Window title is updated when a script changes the title within the game process. Since the Floating Window runs in the editor process, it had no way of knowing when the game title changed. The solution I implemented is to use the remote debugger to send the updated title to the editor.

I believe that using the remote debugger could eventually help resolve other issues where the embedded game window falls out of sync with the editor.

https://github.com/user-attachments/assets/fa4f41cc-378e-4f42-b6e0-ccdb7aff9cb4

