### PR TITLE
Refactor post-step operations in Jolt module to be done as needed

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.h
+++ b/modules/jolt_physics/objects/jolt_area_3d.h
@@ -117,8 +117,6 @@ private:
 
 	virtual JPH::EMotionType _get_motion_type() const override { return JPH::EMotionType::Kinematic; }
 
-	bool _has_pending_events() const;
-
 	virtual void _add_to_space() override;
 
 	void _enqueue_call_queries();
@@ -145,6 +143,7 @@ private:
 
 	virtual void _space_changing() override;
 	virtual void _space_changed() override;
+	void _events_changed();
 	void _body_monitoring_changed();
 	void _area_monitoring_changed();
 	void _monitorable_changed();
@@ -228,8 +227,6 @@ public:
 
 	virtual bool has_custom_center_of_mass() const override { return false; }
 	virtual Vector3 get_center_of_mass_custom() const override { return Vector3(); }
-
-	virtual void post_step(float p_step, JPH::Body &p_jolt_body) override;
 };
 
 #endif // JOLT_AREA_3D_H

--- a/modules/jolt_physics/objects/jolt_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_object_3d.cpp
@@ -136,12 +136,6 @@ bool JoltObject3D::can_interact_with(const JoltObject3D &p_other) const {
 	}
 }
 
-void JoltObject3D::pre_step(float p_step, JPH::Body &p_jolt_body) {
-}
-
-void JoltObject3D::post_step(float p_step, JPH::Body &p_jolt_body) {
-}
-
 String JoltObject3D::to_string() const {
 	Object *instance = get_instance();
 	return instance != nullptr ? instance->to_string() : "<unknown>";

--- a/modules/jolt_physics/objects/jolt_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_object_3d.h
@@ -148,8 +148,7 @@ public:
 
 	virtual bool reports_contacts() const = 0;
 
-	virtual void pre_step(float p_step, JPH::Body &p_jolt_body);
-	virtual void post_step(float p_step, JPH::Body &p_jolt_body);
+	virtual void pre_step(float p_step, JPH::Body &p_jolt_body) {}
 
 	String to_string() const;
 };

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.h
@@ -44,6 +44,7 @@ class JoltShapedObject3D : public JoltObject3D {
 	friend class JoltShape3D;
 
 protected:
+	SelfList<JoltShapedObject3D> shapes_changed_element;
 	SelfList<JoltShapedObject3D> needs_optimization_element;
 
 	Vector3 scale = Vector3(1, 1, 1);
@@ -60,6 +61,9 @@ protected:
 	JPH::ShapeRefC _try_build_shape(bool p_optimize_compound);
 	JPH::ShapeRefC _try_build_single_shape();
 	JPH::ShapeRefC _try_build_compound_shape(bool p_optimize);
+
+	void _enqueue_shapes_changed();
+	void _dequeue_shapes_changed();
 
 	void _enqueue_needs_optimization();
 	void _dequeue_needs_optimization();
@@ -106,6 +110,7 @@ public:
 	void set_shape(int p_index, JoltShape3D *p_shape);
 
 	void clear_shapes();
+	void clear_previous_shape();
 
 	int get_shape_count() const { return shapes.size(); }
 
@@ -123,8 +128,6 @@ public:
 
 	bool is_shape_disabled(int p_index) const;
 	void set_shape_disabled(int p_index, bool p_disabled);
-
-	virtual void post_step(float p_step, JPH::Body &p_jolt_body) override;
 };
 
 #endif // JOLT_SHAPED_OBJECT_3D_H

--- a/modules/jolt_physics/spaces/jolt_space_3d.h
+++ b/modules/jolt_physics/spaces/jolt_space_3d.h
@@ -59,6 +59,7 @@ class JoltShapedObject3D;
 class JoltSpace3D {
 	SelfList<JoltBody3D>::List body_call_queries_list;
 	SelfList<JoltArea3D>::List area_call_queries_list;
+	SelfList<JoltShapedObject3D>::List shapes_changed_list;
 	SelfList<JoltShapedObject3D>::List needs_optimization_list;
 
 	RID rid;
@@ -141,6 +142,9 @@ public:
 	void enqueue_call_queries(SelfList<JoltArea3D> *p_area);
 	void dequeue_call_queries(SelfList<JoltBody3D> *p_body);
 	void dequeue_call_queries(SelfList<JoltArea3D> *p_area);
+
+	void enqueue_shapes_changed(SelfList<JoltShapedObject3D> *p_object);
+	void dequeue_shapes_changed(SelfList<JoltShapedObject3D> *p_object);
 
 	void enqueue_needs_optimization(SelfList<JoltShapedObject3D> *p_object);
 	void dequeue_needs_optimization(SelfList<JoltShapedObject3D> *p_object);


### PR DESCRIPTION
Fixes #101695.
Fixes #101721.

The general theme of this PR is to remove `JoltObject3D::post_step`, and instead replace whatever previously happened in `JoltBody3D::post_step` and `JoltArea3D::post_step` with more specific operations that are invoked as needed rather than for every active/awake body in the simulation on every physics step.

What mainly prompted this change was that `JoltShapedObject3D::previous_jolt_shape` was until now being cleared as part of `JoltShapedObject3D::post_step`, which worked fine prior to #100983 due to `post_step` always being invoked for every single body, sleeping or otherwise, but as of #100983 `post_step` will only be called for active/awake bodies. This meant that `previous_jolt_shape` would never be cleared for something like `StaticBody3D`, which is always sleeping, leading to the forced `Area3D` enter/exit events emitted by `JoltContactListener3D::_flush_area_shifts` to be queued up every single physics step as opposed to just once.

The solution to this is to add a new list in `JoltSpace3D`, called `shapes_changed_list`, that keeps track of any `JoltShapedObject3D` that have changed their shape since the last physics step, and use that list to clear all of their respective `previous_jolt_shape` after we've checked against it in `JoltContactListener3D::post_step`.

However, seeing as how this clearing of `previous_jolt_shape` was the only thing happening in `JoltBody3D::post_step`, we have no need to call it at all for bodies anymore. This meant that the only object being post-stepped was `JoltArea3D`, which currently uses it to check if there are any pending events and queue up the invocation of its `JoltArea3D::call_queries` for the next physics frame if there are, which upon closer inspection wasn't strictly necessary. We may just as well queue up `JoltArea3D::call_queries` as the individual events are being added instead, obviating the need for `JoltArea3D::post_step` (and thus also `JoltObject3D::post_step`) altogether.

Removing `JoltArea3D::post_step` also happens to resolve #101695, as `JoltArea3D::post_step` wasn't invoking the base implementation of `JoltShapedObject3D::post_step`, leading to its `previous_jolt_shape` never being cleared either.