### PR TITLE
Update SubViewport documentation to include a note about input behavior

### DIFF
--- a/doc/classes/SubViewport.xml
+++ b/doc/classes/SubViewport.xml
@@ -6,6 +6,7 @@
 	<description>
 		[SubViewport] Isolates a rectangular region of a scene to be displayed independently. This can be used, for example, to display UI in 3D space.
 		[b]Note:[/b] [SubViewport] is a [Viewport] that isn't a [Window], i.e. it doesn't draw anything by itself. To display anything, [SubViewport] must have a non-zero size and be either put inside a [SubViewportContainer] or assigned to a [ViewportTexture].
+		[b]Note:[/b] [InputEvent]s are not passed to a standalone [SubViewport] by default. To ensure [InputEvent] propagation, a [SubViewport] can be placed inside of a [SubViewportContainer].
 	</description>
 	<tutorials>
 		<link title="Using Viewports">$DOCS_URL/tutorials/rendering/viewports.html</link>


### PR DESCRIPTION
There were no notes in the documentation regarding Input Events not being passed to a `SubViewport` by itself.

Added a note in the documentation about `SubViewport` not handling input events by itself, and needing a `SubViewportContainer` for input event propagation.

Fixes #99912