### PR TITLE
Wayland: Release pressed events on application focus out

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1174,6 +1174,7 @@ void DisplayServerWayland::process_events() {
 				if (OS::get_singleton()->get_main_loop()) {
 					OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
 				}
+				Input::get_singleton()->release_pressed_events();
 			}
 		}
 


### PR DESCRIPTION
Related to #100713

Looks like I always assumed wrongly that the compositor would send us key release events when unfocusing... It did not.

---

To test this PR do this:

 1. On an unpatched binary, just keep _anything_ pressed and focus any other window, then release the key. Now notice how tooltips don't show anymore. Press and release the "stuck" key while keeping the game focused and bam, things work again.
 2. On a patched binary, notice how this weird dance does not happen anymore ;)