### PR TITLE
[TextEdit] Use actual indentation offset instead of space width for wrapped lines.

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -159,6 +159,7 @@ private:
 			int line_count = 0;
 			int height = 0;
 			int width = 0;
+			float indent_ofs = -1.0;
 
 			Line() {
 				data_buf.instantiate();
@@ -228,6 +229,7 @@ private:
 
 		Vector<Vector2i> get_line_wrap_ranges(int p_line) const;
 		const Ref<TextParagraph> get_line_data(int p_line) const;
+		float get_indent_offset(int p_line, bool p_rtl) const;
 
 		void set(int p_line, const String &p_text, const Array &p_bidi_override);
 		void set_ime(int p_line, const String &p_text, const Array &p_bidi_override);

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -7344,7 +7344,7 @@ TEST_CASE("[SceneTree][TextEdit] multicaret") {
 		CHECK(text_edit->get_caret_line(1) == 1);
 		CHECK(text_edit->get_caret_column(1) == 1);
 		CHECK(text_edit->get_caret_line(2) == 0);
-		CHECK(text_edit->get_caret_column(2) == 8);
+		CHECK(text_edit->get_caret_column(2) == 7);
 
 		// Add caret above from first line and not first line wrap.
 		text_edit->add_caret_at_carets(false);
@@ -7355,9 +7355,9 @@ TEST_CASE("[SceneTree][TextEdit] multicaret") {
 		CHECK(text_edit->get_caret_line(1) == 1);
 		CHECK(text_edit->get_caret_column(1) == 1);
 		CHECK(text_edit->get_caret_line(2) == 0);
-		CHECK(text_edit->get_caret_column(2) == 8);
+		CHECK(text_edit->get_caret_column(2) == 7);
 		CHECK(text_edit->get_caret_line(3) == 0);
-		CHECK(text_edit->get_caret_column(3) == 4);
+		CHECK(text_edit->get_caret_column(3) == 2);
 
 		// Cannot add caret above from first line first line wrap.
 		text_edit->remove_secondary_carets();


### PR DESCRIPTION
Fixes indentation offset when using non-monospaced font (hinting or subpixel positioning enabled) and spaces.

Fixes https://github.com/godotengine/godot/issues/101062