### PR TITLE
Fix GUI overflow when script editor and bottom panel are opened concurrently

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1634,6 +1634,7 @@ void CodeTextEditor::_set_show_warnings_panel(bool p_show) {
 void CodeTextEditor::_toggle_scripts_pressed() {
 	ERR_FAIL_NULL(toggle_scripts_list);
 	toggle_scripts_list->set_visible(!toggle_scripts_list->is_visible());
+	EditorSettings::get_singleton()->set_project_metadata("scripts_panel", "show_scripts_panel", toggle_scripts_list->is_visible());
 	update_toggle_scripts_button();
 }
 

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -150,6 +150,7 @@ void EditorBottomPanel::_switch_to_item(bool p_visible, int p_idx, bool p_ignore
 	}
 
 	last_opened_control = items[p_idx].control;
+	emit_signal("toggle_bottom_panel", p_visible);
 }
 
 void EditorBottomPanel::_pin_button_toggled(bool p_pressed) {
@@ -291,6 +292,10 @@ void EditorBottomPanel::toggle_last_opened_bottom_panel() {
 		// Open the first panel in the list if no panel was opened this session.
 		_switch_to_item(true, 0, true);
 	}
+}
+
+void EditorBottomPanel::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("toggle_bottom_panel", PropertyInfo(Variant::BOOL, "visible")));
 }
 
 EditorBottomPanel::EditorBottomPanel() {

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -75,6 +75,7 @@ class EditorBottomPanel : public PanelContainer {
 
 protected:
 	void _notification(int p_what);
+	static void _bind_methods();
 
 public:
 	void save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1830,6 +1830,8 @@ void ScriptEditor::_notification(int p_what) {
 
 			EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &ScriptEditor::_editor_settings_changed));
 			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &ScriptEditor::_filesystem_changed));
+
+			EditorNode::get_bottom_panel()->connect("toggle_bottom_panel", callable_mp(this, &ScriptEditor::_bottom_pannel_toggled));
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -4085,6 +4087,15 @@ void ScriptEditor::_on_find_in_files_close_button_clicked() {
 void ScriptEditor::_window_changed(bool p_visible) {
 	make_floating->set_visible(!p_visible);
 	is_floating = p_visible;
+}
+
+void ScriptEditor::_bottom_pannel_toggled(bool p_visible) {
+	if (p_visible) {
+		list_split->set_visible(false);
+	} else if (EditorSettings::get_singleton()->get_project_metadata("scripts_panel", "show_scripts_panel", true)) {
+		// If the bottom panel is hidden and the script panel was previously visible, show the script panel again.
+		list_split->set_visible(true);
+	}
 }
 
 void ScriptEditor::_filter_scripts_text_changed(const String &p_newtext) {

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -535,6 +535,8 @@ class ScriptEditor : public PanelContainer {
 
 	void _window_changed(bool p_visible);
 
+	void _bottom_pannel_toggled(bool p_visible);
+
 	static void _open_script_request(const String &p_path);
 	void _close_builtin_scripts_from_scene(const String &p_scene);
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96479
Fixes https://github.com/godotengine/godot/issues/26835

Also fixed an issue where closing the `scripts_panel` using the `toggle_scripts_button` did not save its the state.

**Before**

https://github.com/user-attachments/assets/920e0893-3e44-4816-b4bd-f39e4dc96cbf

**After**


https://github.com/user-attachments/assets/80b12875-25da-4674-b9ae-ec425b69d5f4

