### PR TITLE
Fix Jolt note in WorldBoundaryShape3D documentation

### DIFF
--- a/doc/classes/WorldBoundaryShape3D.xml
+++ b/doc/classes/WorldBoundaryShape3D.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		A 3D world boundary shape, intended for use in physics. [WorldBoundaryShape3D] works like an infinite plane that forces all physics bodies to stay above it. The [member plane]'s normal determines which direction is considered as "above" and in the editor, the line over the plane represents this direction. It can for example be used for endless flat floors.
-		[b]Note:[/b] When the physics engine is set to [b]Jolt Physics[/b] in the project settings ([member ProjectSettings.physics/3d/physics_engine]), [WorldBoundaryShape3D] has a finite size (centered at the world origin). It can be adjusted by changing [member ProjectSettings.physics/jolt_physics_3d/limits/world_boundary_shape_size].
+		[b]Note:[/b] When the physics engine is set to [b]Jolt Physics[/b] in the project settings ([member ProjectSettings.physics/3d/physics_engine]), [WorldBoundaryShape3D] has a finite size (centered at the shape's origin). It can be adjusted by changing [member ProjectSettings.physics/jolt_physics_3d/limits/world_boundary_shape_size].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
The dimensions are around the shape's origin, not the world origin (i.e. `(0, 0, 0)` in global coordinates).

Not cherry-pickable to `4.3` as Jolt is only in 4.4.
