### PR TITLE
Fix imported scene warning showing for resource anims

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3800,10 +3800,12 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim, bool p_re
 		auto_fit_bezier->set_disabled(false);
 
 		imported_anim_warning->hide();
-		for (int i = 0; i < animation->get_track_count(); i++) {
-			if (animation->track_is_imported(i)) {
-				imported_anim_warning->show();
-				break;
+		if (!animation->get_path().is_resource_file()) {
+			for (int i = 0; i < animation->get_track_count(); i++) {
+				if (animation->track_is_imported(i)) {
+					imported_anim_warning->show();
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
Intended to fix #69595 

Would be nice to eventually also check the status of keep_custom_tracks but that isn't saved to the animation itself atm. This at least removes the confusing warning.

Test evidence:
![image](https://github.com/user-attachments/assets/63149020-ad82-47d6-9dc3-3b6413fb4e65)
![image](https://github.com/user-attachments/assets/236d29e2-03f3-42ae-aab3-94f433a9bec2)
![image](https://github.com/user-attachments/assets/a583a26f-68f1-4422-b3a7-a55082d7bb80)
[importedwarningtestproj.zip](https://github.com/user-attachments/files/18478633/importedwarningtestproj.zip)
