### PR TITLE
Core: Migrate `ALLOCA` macros from `rendering_device_driver.h` to `typedefs.h`

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -124,7 +124,7 @@ public:
 			validated_call_func(method_userdata, extension_instance, reinterpret_cast<GDExtensionConstVariantPtr *>(p_args), (GDExtensionVariantPtr)r_ret);
 		} else {
 			// If not provided, go via ptrcall, which is faster than resorting to regular call.
-			const void **argptrs = (const void **)alloca(argument_count * sizeof(void *));
+			const void **argptrs = ALLOCA_ARRAY(const void *, argument_count);
 			for (uint32_t i = 0; i < argument_count; i++) {
 				argptrs[i] = VariantInternal::get_opaque_pointer(p_args[i]);
 			}

--- a/core/math/bvh_cull.inc
+++ b/core/math/bvh_cull.inc
@@ -212,7 +212,7 @@ bool _cull_segment_iterative(uint32_t p_node_id, CullParams &r_params) {
 
 	// alloca must allocate the stack from this function, it cannot be allocated in the
 	// helper class
-	ii.stack = (CullSegParams *)alloca(ii.get_alloca_stacksize());
+	ii.stack = ALLOCA_ARRAY(CullSegParams, BVHCommon::ALLOCA_STACK_SIZE);
 
 	// seed the stack
 	ii.get_first()->node_id = p_node_id;
@@ -273,7 +273,7 @@ bool _cull_point_iterative(uint32_t p_node_id, CullParams &r_params) {
 
 	// alloca must allocate the stack from this function, it cannot be allocated in the
 	// helper class
-	ii.stack = (CullPointParams *)alloca(ii.get_alloca_stacksize());
+	ii.stack = ALLOCA_ARRAY(CullPointParams, BVHCommon::ALLOCA_STACK_SIZE);
 
 	// seed the stack
 	ii.get_first()->node_id = p_node_id;
@@ -335,7 +335,7 @@ bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully
 
 	// alloca must allocate the stack from this function, it cannot be allocated in the
 	// helper class
-	ii.stack = (CullAABBParams *)alloca(ii.get_alloca_stacksize());
+	ii.stack = ALLOCA_ARRAY(CullAABBParams, BVHCommon::ALLOCA_STACK_SIZE);
 
 	// seed the stack
 	ii.get_first()->node_id = p_node_id;
@@ -438,7 +438,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 
 	// alloca must allocate the stack from this function, it cannot be allocated in the
 	// helper class
-	ii.stack = (CullConvexParams *)alloca(ii.get_alloca_stacksize());
+	ii.stack = ALLOCA_ARRAY(CullConvexParams, BVHCommon::ALLOCA_STACK_SIZE);
 
 	// seed the stack
 	ii.get_first()->node_id = p_node_id;
@@ -446,7 +446,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 
 	// preallocate these as a once off to be reused
 	uint32_t max_planes = r_params.hull.num_planes;
-	uint32_t *plane_ids = (uint32_t *)alloca(sizeof(uint32_t) * max_planes);
+	uint32_t *plane_ids = ALLOCA_ARRAY(uint32_t, max_planes);
 
 	CullConvexParams ccp;
 

--- a/core/math/bvh_refit.inc
+++ b/core/math/bvh_refit.inc
@@ -109,7 +109,7 @@ void refit_branch(uint32_t p_node_id) {
 
 	// alloca must allocate the stack from this function, it cannot be allocated in the
 	// helper class
-	ii.stack = (RefitParams *)alloca(ii.get_alloca_stacksize());
+	ii.stack = ALLOCA_ARRAY(RefitParams, BVHCommon::ALLOCA_STACK_SIZE);
 
 	// seed the stack
 	ii.get_first()->node_id = p_node_id;

--- a/core/math/bvh_split.inc
+++ b/core/math/bvh_split.inc
@@ -200,7 +200,7 @@ uint32_t split_leaf_complex(uint32_t p_node_id, const BVHABB_CLASS &p_added_item
 	BVH_ASSERT(_nodes[p_node_id].is_leaf());
 
 	// first create child leaf nodes
-	uint32_t *child_ids = (uint32_t *)alloca(sizeof(uint32_t) * MAX_CHILDREN);
+	uint32_t *child_ids = ALLOCA_ARRAY(uint32_t, MAX_CHILDREN);
 
 	for (int n = 0; n < MAX_CHILDREN; n++) {
 		// create node children
@@ -232,11 +232,11 @@ uint32_t split_leaf_complex(uint32_t p_node_id, const BVHABB_CLASS &p_added_item
 	int max_children = orig_leaf.num_items + 1; // plus 1 for the wildcard .. the item being added
 	//CRASH_COND(max_children > MAX_CHILDREN);
 
-	uint16_t *group_a = (uint16_t *)alloca(sizeof(uint16_t) * max_children);
-	uint16_t *group_b = (uint16_t *)alloca(sizeof(uint16_t) * max_children);
+	uint16_t *group_a = ALLOCA_ARRAY(uint16_t, max_children);
+	uint16_t *group_b = ALLOCA_ARRAY(uint16_t, max_children);
 
 	// we are copying the ABBs. This is ugly, but we need one extra for the inserted item...
-	BVHABB_CLASS *temp_bounds = (BVHABB_CLASS *)alloca(sizeof(BVHABB_CLASS) * max_children);
+	BVHABB_CLASS *temp_bounds = ALLOCA_ARRAY(BVHABB_CLASS, max_children);
 
 	int num_a = max_children;
 	int num_b = 0;

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -79,6 +79,7 @@
 
 // really just a namespace
 struct BVHCommon {
+	static constexpr size_t ALLOCA_STACK_SIZE = 128;
 	// these could possibly also be the same constant,
 	// although this may be useful for debugging.
 	// or use zero for invalid and +1 based indices.
@@ -109,15 +110,13 @@ struct BVHHandle {
 template <typename T>
 class BVH_IterativeInfo {
 public:
-	constexpr static const size_t ALLOCA_STACK_SIZE = 128;
-
 	int32_t depth = 1;
-	int32_t threshold = ALLOCA_STACK_SIZE - 2;
+	int32_t threshold = BVHCommon::ALLOCA_STACK_SIZE - 2;
 	T *stack;
 	//only used in rare occasions when you run out of alloca memory
 	// because tree is too unbalanced.
 	LocalVector<T> aux_stack;
-	int32_t get_alloca_stacksize() const { return ALLOCA_STACK_SIZE * sizeof(T); }
+	int32_t get_alloca_stacksize() const { return BVHCommon::ALLOCA_STACK_SIZE * sizeof(T); }
 
 	T *get_first() const {
 		return &stack[0];
@@ -138,7 +137,7 @@ public:
 	T *request() {
 		if (depth > threshold) {
 			if (aux_stack.is_empty()) {
-				aux_stack.resize(ALLOCA_STACK_SIZE * 2);
+				aux_stack.resize(BVHCommon::ALLOCA_STACK_SIZE * 2);
 				memcpy(aux_stack.ptr(), stack, get_alloca_stacksize());
 			} else {
 				aux_stack.resize(aux_stack.size() * 2);

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -328,7 +328,7 @@ void DynamicBVH::aabb_query(const AABB &p_box, QueryResult &r_result) {
 	volume.min = p_box.position;
 	volume.max = p_box.position + p_box.size;
 
-	const Node **alloca_stack = (const Node **)alloca(ALLOCA_STACK_SIZE * sizeof(const Node *));
+	const Node **alloca_stack = ALLOCA_ARRAY(const Node *, ALLOCA_STACK_SIZE);
 	const Node **stack = alloca_stack;
 	stack[0] = bvh_root;
 	int32_t depth = 1;
@@ -381,7 +381,7 @@ void DynamicBVH::convex_query(const Plane *p_planes, int p_plane_count, const Ve
 		}
 	}
 
-	const Node **alloca_stack = (const Node **)alloca(ALLOCA_STACK_SIZE * sizeof(const Node *));
+	const Node **alloca_stack = ALLOCA_ARRAY(const Node *, ALLOCA_STACK_SIZE);
 	const Node **stack = alloca_stack;
 	stack[0] = bvh_root;
 	int32_t depth = 1;
@@ -435,7 +435,7 @@ void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResu
 
 	Vector3 bounds[2];
 
-	const Node **alloca_stack = (const Node **)alloca(ALLOCA_STACK_SIZE * sizeof(const Node *));
+	const Node **alloca_stack = ALLOCA_ARRAY(const Node *, ALLOCA_STACK_SIZE);
 	const Node **stack = alloca_stack;
 	stack[0] = bvh_root;
 	int32_t depth = 1;

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -864,9 +864,9 @@ Vector<Vector3> Geometry3D::compute_convex_mesh_points(const Plane *p_planes, in
 
 /* dt of 1d function using squared distance */
 static void edt(float *f, int stride, int n) {
-	float *d = (float *)alloca(sizeof(float) * n + sizeof(int) * n + sizeof(float) * (n + 1));
-	int *v = reinterpret_cast<int *>(&(d[n]));
-	float *z = reinterpret_cast<float *>(&v[n]);
+	float *d = ALLOCA_ARRAY(float, n);
+	int *v = ALLOCA_ARRAY(int, n);
+	float *z = ALLOCA_ARRAY(float, n + 1);
 
 	int k = 0;
 	v[0] = 0;

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -472,7 +472,7 @@ public:
 			return polygon;
 		}
 
-		int *location_cache = (int *)alloca(sizeof(int) * polygon.size());
+		int *location_cache = ALLOCA_ARRAY(int, polygon.size());
 		int inside_count = 0;
 		int outside_count = 0;
 

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -183,7 +183,7 @@ void TriangleMesh::create(const Vector<Vector3> &p_faces, const Vector<int32_t> 
 }
 
 bool TriangleMesh::intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index) const {
-	uint32_t *stack = (uint32_t *)alloca(sizeof(int) * max_depth);
+	uint32_t *stack = ALLOCA_ARRAY(uint32_t, max_depth);
 
 	enum {
 		TEST_AABB_BIT = 0,
@@ -284,7 +284,7 @@ bool TriangleMesh::intersect_segment(const Vector3 &p_begin, const Vector3 &p_en
 }
 
 bool TriangleMesh::intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index) const {
-	uint32_t *stack = (uint32_t *)alloca(sizeof(int) * max_depth);
+	uint32_t *stack = ALLOCA_ARRAY(uint32_t, max_depth);
 
 	enum {
 		TEST_AABB_BIT = 0,
@@ -385,7 +385,7 @@ bool TriangleMesh::intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, V
 }
 
 bool TriangleMesh::inside_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count, Vector3 p_scale) const {
-	uint32_t *stack = (uint32_t *)alloca(sizeof(int) * max_depth);
+	uint32_t *stack = ALLOCA_ARRAY(uint32_t, max_depth);
 
 	enum {
 		TEST_AABB_BIT = 0,

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -209,7 +209,7 @@ Error CallQueue::push_notification(ObjectID p_id, int p_notification) {
 void CallQueue::_call_function(const Callable &p_callable, const Variant *p_args, int p_argcount, bool p_show_error) {
 	const Variant **argptrs = nullptr;
 	if (p_argcount) {
-		argptrs = (const Variant **)alloca(sizeof(Variant *) * p_argcount);
+		argptrs = ALLOCA_ARRAY(const Variant *, p_argcount);
 		for (int i = 0; i < p_argcount; i++) {
 			argptrs[i] = &p_args[i];
 		}

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -777,7 +777,7 @@ Variant Object::callv(const StringName &p_method, const Array &p_args) {
 	const Variant **argptrs = nullptr;
 
 	if (p_args.size() > 0) {
-		argptrs = (const Variant **)alloca(sizeof(Variant *) * p_args.size());
+		argptrs = ALLOCA_ARRAY(const Variant *, p_args.size());
 		for (int i = 0; i < p_args.size(); i++) {
 			argptrs[i] = &p_args[i];
 		}
@@ -1185,8 +1185,8 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 
 	// Ensure that disconnecting the signal or even deleting the object
 	// will not affect the signal calling.
-	Callable *slot_callables = (Callable *)alloca(sizeof(Callable) * s->slot_map.size());
-	uint32_t *slot_flags = (uint32_t *)alloca(sizeof(uint32_t) * s->slot_map.size());
+	Callable *slot_callables = ALLOCA_ARRAY(Callable, s->slot_map.size());
+	uint32_t *slot_flags = ALLOCA_ARRAY(uint32_t, s->slot_map.size());
 	uint32_t slot_count = 0;
 
 	for (const KeyValue<Callable, SignalData::Slot> &slot_kv : s->slot_map) {

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -632,7 +632,7 @@ WorkerThreadPool::GroupID WorkerThreadPool::_add_group_task(const Callable &p_ca
 
 	} else {
 		group->tasks_used = p_tasks;
-		tasks_posted = (Task **)alloca(sizeof(Task *) * p_tasks);
+		tasks_posted = ALLOCA_ARRAY(Task *, p_tasks);
 		for (int i = 0; i < p_tasks; i++) {
 			Task *task = task_allocator.alloc();
 			task->native_group_func = p_func;

--- a/core/string/fuzzy_search.cpp
+++ b/core/string/fuzzy_search.cpp
@@ -175,7 +175,7 @@ void FuzzySearchResult::score_token_match(FuzzyTokenMatch &p_match, bool p_case_
 
 void FuzzySearchResult::maybe_apply_score_bonus() {
 	// This adds a small bonus to results which match tokens in the same order they appear in the query.
-	int *token_range_starts = (int *)alloca(sizeof(int) * token_matches.size());
+	int *token_range_starts = ALLOCA_ARRAY(int, token_matches.size());
 
 	for (const FuzzyTokenMatch &match : token_matches) {
 		token_range_starts[match.token_idx] = match.interval.x;

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -316,4 +316,9 @@ struct BuildIndexSequence<0, Is...> : IndexSequence<Is...> {};
 #define ___gd_is_defined(val) ____gd_is_defined(__GDARG_PLACEHOLDER_##val)
 #define GD_IS_DEFINED(x) ___gd_is_defined(x)
 
+// Convenience macros for common `alloca` calls.
+#define ALLOCA(m_size) ((m_size != 0) ? alloca(m_size) : nullptr)
+#define ALLOCA_ARRAY(m_type, m_count) reinterpret_cast<m_type *>((m_count != 0) ? alloca(sizeof(m_type) * (m_count)) : nullptr)
+#define ALLOCA_SINGLE(m_type) reinterpret_cast<m_type *>(alloca(sizeof(m_type)))
+
 #endif // TYPEDEFS_H

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -74,7 +74,7 @@ Variant Callable::callv(const Array &p_arguments) const {
 	int argcount = p_arguments.size();
 	const Variant **argptrs = nullptr;
 	if (argcount) {
-		argptrs = (const Variant **)alloca(sizeof(Variant *) * argcount);
+		argptrs = ALLOCA_ARRAY(const Variant *, argcount);
 		for (int i = 0; i < argcount; i++) {
 			argptrs[i] = &p_arguments[i];
 		}
@@ -103,7 +103,7 @@ Error Callable::rpcp(int p_id, const Variant **p_arguments, int p_argcount, Call
 #endif
 
 		int argcount = p_argcount + 2;
-		const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * argcount);
+		const Variant **argptrs = ALLOCA_ARRAY(const Variant *, argcount);
 		const Variant args[2] = { p_id, method };
 
 		argptrs[0] = &args[0];

--- a/core/variant/callable_bind.cpp
+++ b/core/variant/callable_bind.cpp
@@ -139,7 +139,7 @@ int CallableCustomBind::get_unbound_arguments_count() const {
 }
 
 void CallableCustomBind::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
-	const Variant **args = (const Variant **)alloca(sizeof(Variant *) * (binds.size() + p_argcount));
+	const Variant **args = ALLOCA_ARRAY(const Variant *, binds.size() + p_argcount);
 	for (int i = 0; i < p_argcount; i++) {
 		args[i] = (const Variant *)p_arguments[i];
 	}
@@ -151,7 +151,7 @@ void CallableCustomBind::call(const Variant **p_arguments, int p_argcount, Varia
 }
 
 Error CallableCustomBind::rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const {
-	const Variant **args = (const Variant **)alloca(sizeof(Variant *) * (binds.size() + p_argcount));
+	const Variant **args = ALLOCA_ARRAY(const Variant *, binds.size() + p_argcount);
 	for (int i = 0; i < p_argcount; i++) {
 		args[i] = (const Variant *)p_arguments[i];
 	}

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -73,7 +73,7 @@ uint32_t VariantParser::StreamFile::_read_buffer(char32_t *p_buffer, uint32_t p_
 	// The buffer is assumed to include at least one character (for null terminator)
 	ERR_FAIL_COND_V(!p_num_chars, 0);
 
-	uint8_t *temp = (uint8_t *)alloca(p_num_chars);
+	uint8_t *temp = ALLOCA_ARRAY(uint8_t, p_num_chars);
 	uint64_t num_read = f->get_buffer(temp, p_num_chars);
 	ERR_FAIL_COND_V(num_read == UINT64_MAX, 0);
 

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -6086,7 +6086,7 @@ void RenderingDeviceDriverD3D12::end_segment() {
 void RenderingDeviceDriverD3D12::_set_object_name(ID3D12Object *p_object, String p_object_name) {
 	ERR_FAIL_NULL(p_object);
 	int name_len = p_object_name.size();
-	WCHAR *name_w = (WCHAR *)alloca(sizeof(WCHAR) * (name_len + 1));
+	WCHAR *name_w = ALLOCA_ARRAY(WCHAR, name_len + 1);
 	MultiByteToWideChar(CP_UTF8, 0, p_object_name.utf8().get_data(), -1, name_w, name_len);
 	p_object->SetName(name_w);
 }

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -3301,7 +3301,7 @@ RenderingDeviceDriverMetal::Result<id<MTLFunction>> RenderingDeviceDriverMetal::
 	}
 
 	// Initialize an array of integers representing the indexes of p_specialization_constants
-	uint32_t *indexes = (uint32_t *)alloca(p_specialization_constants.size() * sizeof(uint32_t));
+	uint32_t *indexes = ALLOCA_ARRAY(uint32_t, p_specialization_constants.size());
 	for (uint32_t i = 0; i < p_specialization_constants.size(); i++) {
 		indexes[i] = i;
 	}

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -90,7 +90,7 @@ public:
 			if (unbinds > 0) {
 				return Callable(target, method).unbind(unbinds);
 			} else if (!binds.is_empty()) {
-				const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * binds.size());
+				const Variant **argptrs = ALLOCA_ARRAY(const Variant *, binds.size());
 				for (int i = 0; i < binds.size(); i++) {
 					argptrs[i] = &binds[i];
 				}

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -231,7 +231,7 @@ void EditorCommandPalette::remove_command(String p_key_name) {
 void EditorCommandPalette::add_command(String p_command_name, String p_key_name, Callable p_action, Vector<Variant> arguments, const Ref<Shortcut> &p_shortcut) {
 	ERR_FAIL_COND_MSG(commands.has(p_key_name), "The Command '" + String(p_command_name) + "' already exists. Unable to add it.");
 
-	const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * arguments.size());
+	const Variant **argptrs = ALLOCA_ARRAY(const Variant *, arguments.size());
 	for (int i = 0; i < arguments.size(); i++) {
 		argptrs[i] = &arguments[i];
 	}

--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -98,7 +98,7 @@ void GDScriptLambdaCallable::call(const Variant **p_arguments, int p_argcount, V
 
 	if (captures_amount > 0) {
 		const int total_argcount = p_argcount + captures_amount;
-		const Variant **args = (const Variant **)alloca(sizeof(Variant *) * total_argcount);
+		const Variant **args = ALLOCA_ARRAY(const Variant *, total_argcount);
 		for (int i = 0; i < captures_amount; i++) {
 			args[i] = &captures[i];
 			if (captures[i].get_type() == Variant::OBJECT) {
@@ -230,7 +230,7 @@ void GDScriptLambdaSelfCallable::call(const Variant **p_arguments, int p_argcoun
 
 	if (captures_amount > 0) {
 		const int total_argcount = p_argcount + captures_amount;
-		const Variant **args = (const Variant **)alloca(sizeof(Variant *) * total_argcount);
+		const Variant **args = ALLOCA_ARRAY(const Variant *, total_argcount);
 		for (int i = 0; i < captures_amount; i++) {
 			args[i] = &captures[i];
 			if (captures[i].get_type() == Variant::OBJECT) {

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -547,7 +547,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		// Add 3 here for self, class, and nil.
 		alloca_size = sizeof(Variant *) * 3 + sizeof(Variant *) * _instruction_args_size + sizeof(Variant) * _stack_size;
 
-		uint8_t *aptr = (uint8_t *)alloca(alloca_size);
+		uint8_t *aptr = ALLOCA_ARRAY(uint8_t, alloca_size);
 		stack = (Variant *)aptr;
 
 		for (int i = 0; i < p_argcount; i++) {

--- a/modules/godot_physics_2d/godot_shape_2d.cpp
+++ b/modules/godot_physics_2d/godot_shape_2d.cpp
@@ -669,7 +669,7 @@ bool GodotConcavePolygonShape2D::intersect_segment(const Vector2 &p_begin, const
 		return false;
 	}
 
-	uint32_t *stack = (uint32_t *)alloca(sizeof(int) * bvh_depth);
+	uint32_t *stack = ALLOCA_ARRAY(uint32_t, bvh_depth);
 
 	enum {
 		TEST_AABB_BIT = 0,
@@ -901,7 +901,7 @@ Variant GodotConcavePolygonShape2D::get_data() const {
 }
 
 void GodotConcavePolygonShape2D::cull(const Rect2 &p_local_aabb, QueryCallback p_callback, void *p_userdata) const {
-	uint32_t *stack = (uint32_t *)alloca(sizeof(int) * bvh_depth);
+	uint32_t *stack = ALLOCA_ARRAY(uint32_t, bvh_depth);
 
 	enum {
 		TEST_AABB_BIT = 0,

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -164,7 +164,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 	jvalue *argv = nullptr;
 
 	if (method->param_types.size()) {
-		argv = (jvalue *)alloca(sizeof(jvalue) * method->param_types.size());
+		argv = ALLOCA_ARRAY(jvalue, method->param_types.size());
 	}
 
 	List<jobject> to_free;

--- a/platform/android/plugin/godot_plugin_jni.cpp
+++ b/platform/android/plugin/godot_plugin_jni.cpp
@@ -123,8 +123,8 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeEmitS
 
 	int count = env->GetArrayLength(j_signal_params);
 
-	Variant *variant_params = (Variant *)alloca(sizeof(Variant) * count);
-	const Variant **args = (const Variant **)alloca(sizeof(Variant *) * count);
+	Variant *variant_params = ALLOCA_ARRAY(Variant, count);
+	const Variant **args = ALLOCA_ARRAY(const Variant *, count);
 
 	for (int i = 0; i < count; i++) {
 		jobject j_param = env->GetObjectArrayElement(j_signal_params, i);

--- a/platform/android/variant/callable_jni.cpp
+++ b/platform/android/variant/callable_jni.cpp
@@ -43,8 +43,8 @@ static Callable _generate_callable(JNIEnv *p_env, jlong p_object_id, jstring p_m
 
 	int count = p_env->GetArrayLength(p_parameters);
 
-	Variant *args = (Variant *)alloca(sizeof(Variant) * count);
-	const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * count);
+	Variant *args = ALLOCA_ARRAY(Variant, count);
+	const Variant **argptrs = ALLOCA_ARRAY(const Variant *, count);
 
 	for (int i = 0; i < count; i++) {
 		jobject jobj = p_env->GetObjectArrayElement(p_parameters, i);
@@ -74,8 +74,8 @@ JNIEXPORT jobject JNICALL Java_org_godotengine_godot_variant_Callable_nativeCall
 
 	int count = p_env->GetArrayLength(p_parameters);
 
-	Variant *args = (Variant *)alloca(sizeof(Variant) * count);
-	const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * count);
+	Variant *args = ALLOCA_ARRAY(Variant, count);
+	const Variant **argptrs = ALLOCA_ARRAY(const Variant *, count);
 
 	for (int i = 0; i < count; i++) {
 		jobject jobj = p_env->GetObjectArrayElement(p_parameters, i);

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3064,7 +3064,7 @@ Error DisplayServerWindows::dialog_show(String p_title, String p_description, Ve
 	config.cButtons = button_count;
 
 	// No dynamic stack array size :(
-	TASKDIALOG_BUTTON *tbuttons = button_count != 0 ? (TASKDIALOG_BUTTON *)alloca(sizeof(TASKDIALOG_BUTTON) * button_count) : nullptr;
+	TASKDIALOG_BUTTON *tbuttons = ALLOCA_ARRAY(TASKDIALOG_BUTTON, button_count);
 	if (tbuttons) {
 		for (int i = 0; i < button_count; i++) {
 			tbuttons[i].nButtonID = i + 100;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1061,7 +1061,7 @@ Dictionary OS_Windows::execute_with_pipe(const String &p_path, const List<String
 
 	SIZE_T attr_list_size = 0;
 	InitializeProcThreadAttributeList(nullptr, 1, 0, &attr_list_size);
-	pi.si.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)alloca(attr_list_size);
+	pi.si.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)ALLOCA(attr_list_size);
 	if (!InitializeProcThreadAttributeList(pi.si.lpAttributeList, 1, 0, &attr_list_size)) {
 		CLEAN_PIPES
 		ERR_FAIL_V(ret);
@@ -1157,7 +1157,7 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 
 		SIZE_T attr_list_size = 0;
 		InitializeProcThreadAttributeList(nullptr, 1, 0, &attr_list_size);
-		pi.si.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)alloca(attr_list_size);
+		pi.si.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)ALLOCA(attr_list_size);
 		if (!InitializeProcThreadAttributeList(pi.si.lpAttributeList, 1, 0, &attr_list_size)) {
 			CloseHandle(pipe[0]); // Cleanup pipe handles.
 			CloseHandle(pipe[1]);

--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -190,9 +190,9 @@ void RigidBody2D::_body_state_changed(PhysicsDirectBodyState2D *p_state) {
 			}
 		}
 
-		_RigidBody2DInOut *toadd = (_RigidBody2DInOut *)alloca(p_state->get_contact_count() * sizeof(_RigidBody2DInOut));
+		_RigidBody2DInOut *toadd = ALLOCA_ARRAY(_RigidBody2DInOut, p_state->get_contact_count());
 		int toadd_count = 0; //state->get_contact_count();
-		RigidBody2D_RemoveAction *toremove = (RigidBody2D_RemoveAction *)alloca(rc * sizeof(RigidBody2D_RemoveAction));
+		RigidBody2D_RemoveAction *toremove = ALLOCA_ARRAY(RigidBody2D_RemoveAction, rc);
 		int toremove_count = 0;
 
 		//put the ones to add

--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -190,9 +190,9 @@ void RigidBody3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 			}
 		}
 
-		_RigidBodyInOut *toadd = (_RigidBodyInOut *)alloca(p_state->get_contact_count() * sizeof(_RigidBodyInOut));
+		_RigidBodyInOut *toadd = ALLOCA_ARRAY(_RigidBodyInOut, p_state->get_contact_count());
 		int toadd_count = 0;
-		RigidBody3D_RemoveAction *toremove = (RigidBody3D_RemoveAction *)alloca(rc * sizeof(RigidBody3D_RemoveAction));
+		RigidBody3D_RemoveAction *toremove = ALLOCA_ARRAY(RigidBody3D_RemoveAction, rc);
 		int toremove_count = 0;
 
 		//put the ones to add

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -817,9 +817,9 @@ Vector<int> Voxelizer::get_voxel_gi_level_cell_count() const {
 
 /* dt of 1d function using squared distance */
 static void edt(float *f, int stride, int n) {
-	float *d = (float *)alloca(sizeof(float) * n + sizeof(int) * n + sizeof(float) * (n + 1));
-	int *v = reinterpret_cast<int *>(&(d[n]));
-	float *z = reinterpret_cast<float *>(&v[n]);
+	float *d = ALLOCA_ARRAY(float, n);
+	int *v = ALLOCA_ARRAY(int, n);
+	float *z = ALLOCA_ARRAY(float, n + 1);
 
 	int k = 0;
 	v[0] = 0;

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -2016,7 +2016,7 @@ void AnimationMixer::_blend_apply() {
 
 void AnimationMixer::_call_object(ObjectID p_object_id, const StringName &p_method, const Vector<Variant> &p_params, bool p_deferred) {
 	// Separate function to use alloca() more efficiently
-	const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * p_params.size());
+	const Variant **argptrs = ALLOCA_ARRAY(const Variant *, p_params.size());
 	const Variant *args = p_params.ptr();
 	uint32_t argcount = p_params.size();
 	for (uint32_t i = 0; i < argcount; i++) {

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -816,7 +816,7 @@ bool MethodTweener::step(double &r_delta) {
 	} else {
 		current_val = final_val;
 	}
-	const Variant **argptr = (const Variant **)alloca(sizeof(Variant *));
+	const Variant **argptr = ALLOCA_SINGLE(const Variant *);
 	argptr[0] = &current_val;
 
 	Variant result;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1499,7 +1499,7 @@ void Node::_validate_child_name(Node *p_child, bool p_force_human_readable) {
 			uint32_t cn_length = cn.length();
 			uint32_t c_chars = String::num_characters(c);
 			uint32_t len = 2 + cn_length + c_chars;
-			char32_t *str = (char32_t *)alloca(sizeof(char32_t) * (len + 1));
+			char32_t *str = ALLOCA_ARRAY(char32_t, len + 1);
 			uint32_t idx = 0;
 			str[idx++] = '@';
 			for (uint32_t i = 0; i < cn_length; i++) {
@@ -2056,8 +2056,8 @@ bool Node::is_greater_than(const Node *p_node) const {
 
 	_update_children_cache();
 
-	int *this_stack = (int *)alloca(sizeof(int) * data.depth);
-	int *that_stack = (int *)alloca(sizeof(int) * p_node->data.depth);
+	int *this_stack = ALLOCA_ARRAY(int, data.depth);
+	int *that_stack = ALLOCA_ARRAY(int, p_node->data.depth);
 
 	const Node *n = this;
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -208,7 +208,7 @@ void SceneTree::_flush_ugc() {
 	while (unique_group_calls.size()) {
 		HashMap<UGCall, Vector<Variant>, UGCall>::Iterator E = unique_group_calls.begin();
 
-		const Variant **argptrs = (const Variant **)alloca(E->value.size() * sizeof(Variant *));
+		const Variant **argptrs = ALLOCA_ARRAY(const Variant *, E->value.size());
 
 		for (int i = 0; i < E->value.size(); i++) {
 			argptrs[i] = &E->value[i];

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -156,7 +156,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 	const NodeData *nd = &nodes[0];
 
-	Node **ret_nodes = (Node **)alloca(sizeof(Node *) * nc);
+	Node **ret_nodes = ALLOCA_ARRAY(Node *, nc);
 
 	bool gen_node_path_cache = p_edit_state != GEN_EDIT_STATE_DISABLED && node_path_cache.is_empty();
 
@@ -598,7 +598,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 				}
 			}
 
-			const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * binds.size());
+			const Variant **argptrs = ALLOCA_ARRAY(const Variant *, binds.size());
 			for (int j = 0; j < binds.size(); j++) {
 				argptrs[j] = &binds[j];
 			}

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1033,7 +1033,7 @@ Error ResourceLoaderText::rename_dependencies(Ref<FileAccess> p_f, const String 
 	f->seek(tag_end);
 
 	const uint32_t buffer_size = 2048;
-	uint8_t *buffer = (uint8_t *)alloca(buffer_size);
+	uint8_t *buffer = ALLOCA_ARRAY(uint8_t, buffer_size);
 	uint32_t num_read;
 
 	num_read = f->get_buffer(buffer, buffer_size);

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -417,7 +417,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 			}
 
 			child_item_count = ci->ysort_children_count + 1;
-			child_items = (Item **)alloca(child_item_count * sizeof(Item *));
+			child_items = ALLOCA_ARRAY(Item *, child_item_count);
 
 			ci->ysort_xform = Transform2D();
 			ci->ysort_modulate = Color(1, 1, 1, 1);

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -4215,7 +4215,7 @@ void RendererSceneCull::update() {
 	//optimize bvhs
 
 	uint32_t rid_count = scenario_owner.get_rid_count();
-	RID *rids = (RID *)alloca(sizeof(RID) * rid_count);
+	RID *rids = ALLOCA_ARRAY(RID, rid_count);
 	scenario_owner.fill_owned_buffer(rids);
 	for (uint32_t i = 0; i < rid_count; i++) {
 		Scenario *s = scenario_owner.get_or_null(rids[i]);

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -1534,7 +1534,7 @@ void RendererViewport::viewport_set_sdf_oversize_and_scale(RID p_viewport, RS::V
 RID RendererViewport::viewport_find_from_screen_attachment(DisplayServer::WindowID p_id) const {
 	RID *rids = nullptr;
 	uint32_t rid_count = viewport_owner.get_rid_count();
-	rids = (RID *)alloca(sizeof(RID) * rid_count);
+	rids = ALLOCA_ARRAY(RID, rid_count);
 	viewport_owner.fill_owned_buffer(rids);
 	for (uint32_t i = 0; i < rid_count; i++) {
 		Viewport *viewport = viewport_owner.get_or_null(rids[i]);

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -82,11 +82,6 @@ public:
 			_ptr(p_lv.ptr()), _size(p_lv.size()) {}
 };
 
-// These utilities help drivers avoid allocations.
-#define ALLOCA(m_size) ((m_size != 0) ? alloca(m_size) : nullptr)
-#define ALLOCA_ARRAY(m_type, m_count) ((m_type *)ALLOCA(sizeof(m_type) * (m_count)))
-#define ALLOCA_SINGLE(m_type) ALLOCA_ARRAY(m_type, 1)
-
 // This helps forwarding certain arrays to the API with confidence.
 #define ARRAYS_COMPATIBLE(m_type_a, m_type_b) (sizeof(m_type_a) == sizeof(m_type_b) && alignof(m_type_a) == alignof(m_type_b))
 // This is used when you also need to ensure structured types are compatible field-by-field.


### PR DESCRIPTION
`rendering_device_driver.h` defines 3 convenience/safety macros for `alloca`: `ALLOCA`, `ALLOCA_ARRAY`, and `ALLOCA_SINGLE`. These macros have the potential to streamline `alloca` throughout the repo, so it felt appropriate to relocate them to a place where everything can use them: `typedefs.h`. This PR does exactly that, and replaces all instances of `alloca` with an equivalent macro.