### PR TITLE
Add InputEventRotateGesture for mac trackpads

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1719,7 +1719,7 @@ Ref<InputEvent> InputEventMagnifyGesture::xformed_by(const Transform2D &p_xform,
 }
 
 String InputEventMagnifyGesture::as_text() const {
-	return vformat(RTR("Magnify Gesture at (%s) with factor %s"), String(get_position()), rtos(get_factor()));
+	return vformat(RTR("Magnify Gesture at (%s) with factor %s"), get_position(), rtos(get_factor()));
 }
 
 String InputEventMagnifyGesture::to_string() {
@@ -1761,7 +1761,7 @@ Ref<InputEvent> InputEventPanGesture::xformed_by(const Transform2D &p_xform, con
 }
 
 String InputEventPanGesture::as_text() const {
-	return vformat(RTR("Pan Gesture at (%s) with delta (%s)"), String(get_position()), String(get_delta()));
+	return vformat(RTR("Pan Gesture at (%s) with delta (%s)"), get_position(), get_delta());
 }
 
 String InputEventPanGesture::to_string() {
@@ -1773,6 +1773,46 @@ void InputEventPanGesture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_delta"), &InputEventPanGesture::get_delta);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "delta"), "set_delta", "get_delta");
+}
+
+///////////////////////////////////
+
+void InputEventRotateGesture::set_rotation(real_t p_rotation) {
+	rotation = p_rotation;
+}
+
+real_t InputEventRotateGesture::get_rotation() const {
+	return rotation;
+}
+
+void InputEventRotateGesture::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_rotation", "rotation"), &InputEventRotateGesture::set_rotation);
+	ClassDB::bind_method(D_METHOD("get_rotation"), &InputEventRotateGesture::get_rotation);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rotation"), "set_rotation", "get_rotation");
+}
+
+Ref<InputEvent> InputEventRotateGesture::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
+	Ref<InputEventRotateGesture> ev;
+	ev.instantiate();
+
+	ev->set_device(get_device());
+	ev->set_window_id(get_window_id());
+
+	ev->set_modifiers_from_event(this);
+
+	ev->set_position(p_xform.xform(get_position() + p_local_ofs));
+	ev->set_rotation(rotation);
+
+	return ev;
+}
+
+String InputEventRotateGesture::as_text() const {
+	return vformat(RTR("Rotate Gesture at (%s) rotation=%.2f"), get_position(), rotation);
+}
+
+String InputEventRotateGesture::to_string() {
+	return vformat("InputEventRotateGesture: rotation=%.2f, position=(%s)", rotation, String(get_position()));
 }
 
 ///////////////////////////////////

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -532,6 +532,24 @@ public:
 	InputEventPanGesture() {}
 };
 
+class InputEventRotateGesture : public InputEventGesture {
+	GDCLASS(InputEventRotateGesture, InputEventGesture);
+	real_t rotation = 0.0;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_rotation(real_t p_rotation);
+	real_t get_rotation() const;
+
+	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
+	virtual String as_text() const override;
+	virtual String to_string() override;
+
+	InputEventRotateGesture() {}
+};
+
 class InputEventMIDI : public InputEvent {
 	GDCLASS(InputEventMIDI, InputEvent);
 

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -184,6 +184,7 @@ void register_core_types() {
 	GDREGISTER_ABSTRACT_CLASS(InputEventGesture);
 	GDREGISTER_CLASS(InputEventMagnifyGesture);
 	GDREGISTER_CLASS(InputEventPanGesture);
+	GDREGISTER_CLASS(InputEventRotateGesture);
 	GDREGISTER_CLASS(InputEventMIDI);
 
 	// Network

--- a/doc/classes/InputEventRotateGesture.xml
+++ b/doc/classes/InputEventRotateGesture.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InputEventRotateGesture" inherits="InputEventGesture" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Represents a rotation touch gesture.
+	</brief_description>
+	<description>
+		Stores information about rotation gestures. A rotation gesture is performed when the user moves two fingers in a circular motion over the touch screen. It's typically used for rotating the camera.
+		[b]Note:[/b] Only working on MacOS.
+	</description>
+	<tutorials>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
+	</tutorials>
+	<members>
+		<member name="rotation" type="float" setter="set_rotation" getter="get_rotation" default="0.0">
+			Rotation amount since last rotation event (in radians).
+		</member>
+	</members>
+</class>

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -882,4 +882,23 @@
 	}
 }
 
+- (void)rotateWithEvent:(NSEvent *)event {
+	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	if (!ds || !ds->has_window(window_id)) {
+		return;
+	}
+
+	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
+	ds->update_mouse_pos(wd, [event locationInWindow]);
+
+	Ref<InputEventRotateGesture> ev;
+	ev.instantiate();
+	ds->get_key_modifier_state([event modifierFlags], ev);
+	ev->set_position(wd.mouse_pos);
+	// Convert from degrees to radians and invert direction to match standard rotation direction
+	ev->set_rotation(-[event rotation] * (Math_PI / 180.0));
+
+	Input::get_singleton()->parse_input_event(ev);
+}
+
 @end


### PR DESCRIPTION
Disclaimer: I'm a newbie with godot

This feature allows rotational gestures for camera input event. We pass the rotation angle as well as the position of the cursor. 

Rotational gestures with 2 fingers allows for very cool user experiences within games, and they are impossible to implement at the game level (for trackpads).

I'm aware this might not get accepted at its current stage since it's only implemented on Mac. I may look into the other platforms, but not very knowledgeable on those. Let me know what you think.

Video Demo:

https://github.com/user-attachments/assets/89e0d6f8-a8b8-4366-b3db-4693950d3c86

Demo Code:
https://github.com/bkniffler/godot-rotation-demo

```gdscript
func rotate_around_point(angle: float, point: Vector2):
	# Get viewport center and convert cursor to relative position
	var viewport_size = get_viewport_rect().size
	var viewport_center = viewport_size / 2
	var cursor_offset = point - viewport_center
	
	# Convert cursor offset to world space (accounting for zoom and rotation)
	var world_cursor_offset = cursor_offset / zoom.x
	world_cursor_offset = world_cursor_offset.rotated(rotation)
	
	# Calculate world space pivot point
	var pivot_point = position + world_cursor_offset
	
	# Rotate camera
	rotate(angle)
	
	# Calculate new position to maintain pivot
	var new_cursor_offset = world_cursor_offset.rotated(angle)
	position = pivot_point - new_cursor_offset

func _unhandled_input(event):
	if event is InputEventRotateGesture:
		# Rotate around gesture position
		rotate_around_point(event.rotation, event.position)
		get_viewport().set_input_as_handled()
	....
```