### PR TITLE
Documentation: small tweak to phrasing for Control.localize_numeral_system

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -987,7 +987,7 @@
 		</member>
 		<member name="localize_numeral_system" type="bool" setter="set_localize_numeral_system" getter="is_localizing_numeral_system" default="true">
 			If [code]true[/code], automatically converts code line numbers, list indices, [SpinBox] and [ProgressBar] values from the Western Arabic (0..9) to the numeral systems used in current locale.
-			[b]Note:[/b] Numbers within the text are not automatically converted, it can be done manually, using [method TextServer.format_number].
+			[b]Note:[/b] Numbers within the text are not automatically converted. This can be done manually with [method TextServer.format_number].
 		</member>
 		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" enum="Control.CursorShape" default="0">
 			The default cursor shape for this control. Useful for Godot plugins and applications or games that use the system's mouse cursors.


### PR DESCRIPTION
I found the original phrasing a bit awkward. Splitting the big sentence into two sentences, and removing the commas, improves clarity and readability IMO.

I also changed the word "using" to "with", which I subjectively think is a better word to use here.

This is my first PR to the Godot docs so please let me know if I've missed anything or done anything wrong!