### PR TITLE
Add `is_trivially_relocatable` struct to facilitate reasoning about trivial relocatability.

### DIFF
--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -340,4 +340,12 @@ ZERO_INITIALIZER_NUMBER(char32_t)
 ZERO_INITIALIZER_NUMBER(float)
 ZERO_INITIALIZER_NUMBER(double)
 
+// Mimics std::is_trivially_relocatable https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p1144r7.html.
+// For more information, see GH-100509.
+// A class can be marked not trivially relocatable by declaring:
+// struct is_trivially_relocatable<MyStruct> : std::false_type {};
+template <class T>
+struct is_trivially_relocatable : std::true_type {
+};
+
 #endif // TYPE_INFO_H


### PR DESCRIPTION
Trivial relocatability describes whether an object can be _moved_ to a different address without invalidating its invariants.
For more information on trivial relocatability, see https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p1144r7.html and https://github.com/godotengine/godot/issues/100509. 

Trivial relocatability can be used to improve performance, especially for vector-like types. Notably, it is assumed to be 'always true' in some parts of our codebase (see https://github.com/godotengine/godot/issues/100509).

This PR is the first step for addressing https://github.com/godotengine/godot/issues/100509 by allowing us to reason about it at all.

## Caveats
In the current implementation, trivial relocatability is eagerly `true` for all types except trivially copyable types. This matches the current behavior of types where this is relevant (see https://github.com/godotengine/godot/issues/100509).
It would be possible to instead choose the safe, conservative approach of defaulting to `false` (or better, `is_trivially_copyable`). A more complex implementation might even try to figure out trivial relocatability in a more advanced way ([reference folly](https://github.com/facebook/folly/blob/859ce5ae782145a3f6803c54caa1741475db4018/folly/Traits.h#L702-L714)). 

However, given that our current codebase seems to be _fairly safe_ w.r.t. trivial relocatability, I think we should try to avoid performance regressions by defaulting to `true`.

## Usage Guide

To reference this information, reference the following code example:
```c++
if constexpr (is_trivially_relocatable<T>) {
    buf_ptr = Memory::realloc_static(ptr, alloc_size, false);
}
else {
   T *new_buf_ptr = Memory::alloc_static(alloc_size, false);
    for (int i = 0; i < size(); i++) {
        new_buf_ptr[i] = std::move(buf_ptr[i]);
    }
    Memory::free_static(buf_ptr, false);
    buf_ptr = new_buf_ptr;
}
```

Alternatively, a type can be marked unsafe for nontrivial relocatability by using SFINAE:
```c++
template <typename T, typename = std::enable_if_t<is_trivially_relocatable<T>>
struct CowData {
    // ...
}
```

To mark a struct as not trivially relocatable, reference the following code:
```c++
struct is_trivially_relocatable<MyStruct> : std::false_type {};
```
