### PR TITLE
Fix `OptionButton.show_popup` width

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -468,12 +468,6 @@ void OptionButton::show_popup() {
 		return;
 	}
 
-	Rect2 rect = get_screen_rect();
-	rect.position.y += rect.size.height;
-	rect.size.height = 0;
-	popup->set_position(rect.position);
-	popup->set_size(rect.size);
-
 	// If not triggered by the mouse, start the popup with the checked item (or the first enabled one) focused.
 	if (current != NONE_SELECTED && !popup->is_item_disabled(current)) {
 		if (!_was_pressed_by_mouse()) {
@@ -495,7 +489,10 @@ void OptionButton::show_popup() {
 		}
 	}
 
-	popup->popup();
+	Rect2 rect = get_screen_rect();
+	rect.position.y += rect.size.height;
+	rect.size.height = 0;
+	popup->popup(rect);
 }
 
 void OptionButton::_validate_property(PropertyInfo &p_property) const {


### PR DESCRIPTION
Replace #101858 


embedded window:
![屏幕截图_20250121_063239](https://github.com/user-attachments/assets/f3bc906c-aa49-4079-98f8-5fbc7dcc0d34)

native window master:
![屏幕截图_20250121_063515](https://github.com/user-attachments/assets/2ae33cea-00d5-4838-9a80-e01ff57c499b)

native window this pr:
![屏幕截图_20250121_062536](https://github.com/user-attachments/assets/729c7d23-76ad-4e97-8c4e-aa5791e97d10)

