### PR TITLE
Save LightmapGI shadowmask to a lossless WebP image to reduce file size

### DIFF
--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -834,7 +834,7 @@ LightmapGI::BakeError LightmapGI::_save_and_reimport_atlas_textures(const Ref<Li
 			texture_image->blit_rect(images[i * slices_per_texture + j], Rect2i(0, 0, slice_width, slice_height), Point2i(0, slice_height * j));
 		}
 
-		const String atlas_path = (texture_count > 1 ? p_base_name + "_" + itos(i) : p_base_name) + (p_is_shadowmask ? ".png" : ".exr");
+		const String atlas_path = (texture_count > 1 ? p_base_name + "_" + itos(i) : p_base_name) + (p_is_shadowmask ? ".webp" : ".exr");
 		const String config_path = atlas_path + ".import";
 
 		Ref<ConfigFile> config;
@@ -865,7 +865,19 @@ LightmapGI::BakeError LightmapGI::_save_and_reimport_atlas_textures(const Ref<Li
 		// Save the file.
 		Error save_err;
 		if (p_is_shadowmask) {
-			save_err = texture_image->save_png(atlas_path);
+			// Downsize the image if needed to fit within the WebP format limitations.
+			// In practice, the maximum usable texture size is typically 16384×16384,
+			// so this only changes the size by 1 pixel which is unnoticeable.
+			constexpr int WEBP_SIZE_LIMIT = 16383;
+			if (texture_image->get_width() > WEBP_SIZE_LIMIT) {
+				texture_image->resize(WEBP_SIZE_LIMIT, texture_image->get_height() * WEBP_SIZE_LIMIT / texture_image->get_width());
+			} else if (texture_image->get_height() > WEBP_SIZE_LIMIT) {
+				texture_image->resize(texture_image->get_width() * WEBP_SIZE_LIMIT / texture_image->get_height(), WEBP_SIZE_LIMIT);
+			}
+			// Save as lossless WebP instead of PNG to reduce file size in the project files.
+			// The exported project size will remain identical, but this reduces the size of the file
+			// that is committed to version control.
+			save_err = texture_image->save_webp(atlas_path);
 		} else {
 			save_err = texture_image->save_exr(atlas_path, false);
 		}


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/85653.

This doesn't affect the size of the exported project (which uses a VRAM-compressed copy by default), but it reduces the size of the files that are committed to version control or included within MRP ZIPs.

When you iterate on lightmaps frequently and commit new versions of them, this can add up to saving dozens if not hundreds of megabytes over time.

This change is fully backwards-compatible and forwards-compatible with existing projects that use PNG shadowmask textures, as the shadowmask path is saved in LightmapGIData.

Example with a baked shadowmask (5461×5461) on the Truck Town demo:

- Before: **315 KB**
- After: **143 KB** (-172 KB)

The output quality is the exact same. Saving a lossless WebP is a tad slower than a PNG, but it doesn't increase bake times by more than a second or two in this large scene. If the shadowmask is more than 16383 pixels wide or tall, it will be downsized automatically to fit within WebP format limitations. (Note that this size is the source image size, not the texture array size which is always rounded up to a power of 2.)

In the future, we can combine this with a **Shadowmask Texel Scale** property so you can control the shadowmask resolution separately from the lightmap.