### PR TITLE
Fix `Camera3D` gizmo representation to accurately reflect FOV

### DIFF
--- a/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
@@ -180,7 +180,13 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 			const float hsize = Math::sin(Math::deg_to_rad(fov));
 			const float depth = -Math::cos(Math::deg_to_rad(fov));
-			Vector3 side = Vector3(hsize * size_factor.x, 0, depth);
+
+			Vector3 side;
+			if (camera->get_keep_aspect_mode() == Camera3D::KEEP_WIDTH) {
+				side = Vector3(hsize * size_factor.x, 0, depth * size_factor.x);
+			} else {
+				side = Vector3(hsize * size_factor.x, 0, depth * size_factor.y);
+			}
 			Vector3 nside = Vector3(-side.x, side.y, side.z);
 			Vector3 up = Vector3(0, hsize * size_factor.y, 0);
 


### PR DESCRIPTION
Updated gizmo drawing to keep depth proportional to width or height based on whether FOV is horizontal or vertical.

Fixes #101516

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
