### PR TITLE
Fix `NOTIFICATION_WM_CLOSE_REQUEST` in Embedded Floating Window

### DIFF
--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -162,7 +162,7 @@ class GameView : public VBoxContainer {
 	void _camera_override_button_toggled(bool p_pressed);
 	void _camera_override_menu_id_pressed(int p_id);
 
-	void _window_before_closing();
+	void _window_close_request();
 	void _update_floating_window_settings();
 	void _attach_script_debugger();
 	void _detach_script_debugger();

--- a/editor/window_wrapper.h
+++ b/editor/window_wrapper.h
@@ -50,12 +50,15 @@ class WindowWrapper : public MarginContainer {
 
 	Ref<Shortcut> enable_shortcut;
 
+	bool override_close_request = false;
+
 	Rect2 _get_default_window_rect() const;
 	Node *_get_wrapped_control_parent() const;
 
 	void _set_window_enabled_with_rect(bool p_visible, const Rect2 p_rect);
 	void _set_window_rect(const Rect2 p_rect);
 	void _window_size_changed();
+	void _window_close_request();
 
 protected:
 	static void _bind_methods();
@@ -83,6 +86,8 @@ public:
 	void set_window_title(const String &p_title);
 	void set_margins_enabled(bool p_enabled);
 	void grab_window_focus();
+
+	void set_override_close_request(bool p_enabled);
 
 	WindowWrapper();
 	~WindowWrapper();

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5849,6 +5849,24 @@ Error DisplayServerX11::remove_embedded_process(OS::ProcessID p_pid) {
 	}
 
 	EmbeddedProcessData *ep = embedded_processes.get(p_pid);
+
+	// Handle bad window errors silently because just in case the embedded window was closed.
+	int (*oldHandler)(Display *, XErrorEvent *) = XSetErrorHandler(&bad_window_error_handler);
+
+	// Send the message to gracefully close the window.
+	XEvent ev;
+	memset(&ev, 0, sizeof(ev));
+	ev.xclient.type = ClientMessage;
+	ev.xclient.window = ep->process_window;
+	ev.xclient.message_type = XInternAtom(x11_display, "WM_PROTOCOLS", True);
+	ev.xclient.format = 32;
+	ev.xclient.data.l[0] = XInternAtom(x11_display, "WM_DELETE_WINDOW", False);
+	ev.xclient.data.l[1] = CurrentTime;
+	XSendEvent(x11_display, ep->process_window, False, NoEventMask, &ev);
+
+	// Restore default error handler.
+	XSetErrorHandler(oldHandler);
+
 	embedded_processes.erase(p_pid);
 	memdelete(ep);
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2975,6 +2975,9 @@ Error DisplayServerWindows::remove_embedded_process(OS::ProcessID p_pid) {
 
 	EmbeddedProcessData *ep = embedded_processes.get(p_pid);
 
+	// Send a close message to gracefully close the process.
+	PostMessage(ep->window_handle, WM_CLOSE, 0, 0);
+
 	// This is a workaround to ensure the parent window correctly regains focus after the
 	// embedded window is closed. When the embedded window is closed while it has focus,
 	// the parent window (the editor) does not become active. It appears focused but is not truly activated.


### PR DESCRIPTION
- Fixes #101863

This PR should fixes the notification NOTIFICATION_WM_CLOSE_REQUEST when closing the floating window.

I changed the way the embedded process is closed. In the previous implementation, I based the code on the stop button in the editor which kills the process. Now, I use a native send message in Windows and Linux the close the game window.

I added to rework the `WindowWrapper` to prevent to closing of the floating window while the game is closing. That's why I added the `WindowWrapper::set_override_close_request` method.

I did not changed the editor stop button, it's working as before. It kills the process, preventing the notification.

Tested on Windows 11 and Ubuntu 23.10.