### PR TITLE
ItemList: Fix `text_overrun_behavior`

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1201,7 +1201,7 @@ void ItemList::_notification(int p_what) {
 
 					const int y = base_ofs.y + separators[i];
 					if (rtl && scroll_bar_v->is_visible()) {
-						draw_line(Vector2(theme_cache.panel_style->get_margin(SIDE_LEFT) * 2 + scroll_bar_v_min.width, y), Vector2(width + theme_cache.panel_style->get_margin(SIDE_LEFT) + scroll_bar_v_min.width, y), theme_cache.guide_color);
+						draw_line(Vector2(theme_cache.panel_style->get_margin(SIDE_LEFT) + scroll_bar_v_min.width, y), Vector2(width + theme_cache.panel_style->get_margin(SIDE_LEFT) + scroll_bar_v_min.width, y), theme_cache.guide_color);
 					} else {
 						draw_line(Vector2(theme_cache.panel_style->get_margin(SIDE_LEFT), y), Vector2(width + theme_cache.panel_style->get_margin(SIDE_LEFT), y), theme_cache.guide_color);
 					}
@@ -1358,16 +1358,7 @@ void ItemList::_notification(int p_what) {
 				}
 
 				if (!items[i].text.is_empty()) {
-					int max_len = -1;
-
 					Vector2 size2 = items[i].text_buf->get_size();
-					if (fixed_column_width) {
-						max_len = fixed_column_width;
-					} else if (same_column_width) {
-						max_len = items[i].rect_cache.size.x;
-					} else {
-						max_len = size2.x;
-					}
 
 					Color txt_modulate;
 					if (items[i].selected && hovered == i) {
@@ -1392,14 +1383,17 @@ void ItemList::_notification(int p_what) {
 
 						text_ofs.y += MAX(theme_cache.v_separation, 0) / 2;
 
-						if (rtl) {
-							text_ofs.x = size.width - text_ofs.x - max_len;
-						}
-
 						items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 
 						float text_w = items[i].rect_cache.size.width;
+						if (wraparound_items && items[i].rect_cache.size.width > width) {
+							text_w -= items[i].rect_cache.size.width - width;
+						}
 						items.write[i].text_buf->set_width(text_w);
+
+						if (rtl) {
+							text_ofs.x = size.width - text_ofs.x - text_w;
+						}
 
 						if (theme_cache.font_outline_size > 0 && theme_cache.font_outline_color.a > 0) {
 							items[i].text_buf->draw_outline(get_canvas_item(), text_ofs, theme_cache.font_outline_size, theme_cache.font_outline_color);
@@ -1423,11 +1417,17 @@ void ItemList::_notification(int p_what) {
 						text_ofs += base_ofs;
 						text_ofs += items[i].rect_cache.position;
 
-						float text_w = width - text_ofs.x + theme_cache.panel_style->get_margin(SIDE_LEFT);
+						float text_w = items[i].rect_cache.size.width - (items[i].get_icon_size().x * icon_scale) - MAX(theme_cache.h_separation, 0);
+						if (wraparound_items && items[i].rect_cache.size.width > width) {
+							text_w -= items[i].rect_cache.size.width - width;
+						}
 						items.write[i].text_buf->set_width(text_w);
 
 						if (rtl) {
-							text_ofs.x = size.width - width - theme_cache.panel_style->get_margin(SIDE_RIGHT);
+							text_ofs.x = size.width - items[i].rect_cache.size.width + (items[i].get_icon_size().x * icon_scale) - text_ofs.x + MAX(theme_cache.h_separation, 0);
+							if (wraparound_items) {
+								text_ofs.x += MAX(items[i].rect_cache.size.width - width, 0);
+							}
 							items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 						} else {
 							items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_LEFT);
@@ -1437,12 +1437,16 @@ void ItemList::_notification(int p_what) {
 							items[i].text_buf->draw_outline(get_canvas_item(), text_ofs, theme_cache.font_outline_size, theme_cache.font_outline_color);
 						}
 
-						if (rtl) {
-							if (width - items[i].rect_cache.position.x - (MAX(theme_cache.h_separation, 0) / 2) - int(scroll_bar_h->get_value()) > 0) {
+						if (fixed_column_width > 0) {
+							if (items[i].rect_cache.size.width - (items[i].get_icon_size().x * icon_scale) - MAX(theme_cache.h_separation, 0) > 0) {
 								items[i].text_buf->draw(get_canvas_item(), text_ofs, txt_modulate);
 							}
 						} else {
-							if (width - text_ofs.x + theme_cache.panel_style->get_margin(SIDE_LEFT) > 0) {
+							if (wraparound_items) {
+								if (width - (items[i].get_icon_size().x * icon_scale) - MAX(theme_cache.h_separation, 0) - int(scroll_bar_h->get_value()) > 0) {
+									items[i].text_buf->draw(get_canvas_item(), text_ofs, txt_modulate);
+								}
+							} else {
 								items[i].text_buf->draw(get_canvas_item(), text_ofs, txt_modulate);
 							}
 						}
@@ -1506,8 +1510,6 @@ void ItemList::force_update_list_size() {
 			int max_width = -1;
 			if (fixed_column_width) {
 				max_width = fixed_column_width;
-			} else if (same_column_width) {
-				max_width = items[i].rect_cache.size.x;
 			}
 			items.write[i].text_buf->set_width(max_width);
 			Size2 s = items[i].text_buf->get_size();
@@ -1595,13 +1597,12 @@ void ItemList::force_update_list_size() {
 			}
 		}
 
-		Size2 scroll_bar_v_min = scroll_bar_v->is_visible() ? scroll_bar_v->get_combined_minimum_size() : Size2();
 		float scroll_bar_v_page = MAX(0, size.height - theme_cache.panel_style->get_minimum_size().height);
 		float scroll_bar_v_max = MAX(scroll_bar_v_page, ofs.y + max_h);
 		float scroll_bar_h_page = MAX(0, size.width - theme_cache.panel_style->get_minimum_size().width);
 		float scroll_bar_h_max = 0;
 		if (!wraparound_items) {
-			scroll_bar_h_max = MAX(scroll_bar_h_page, max_w) - scroll_bar_v_min.width;
+			scroll_bar_h_max = MAX(scroll_bar_h_page, max_w);
 		}
 
 		if (scroll_bar_v_page >= scroll_bar_v_max || is_layout_rtl()) {
@@ -1626,7 +1627,6 @@ void ItemList::force_update_list_size() {
 				scroll_bar_v->hide();
 			} else {
 				auto_width_value += scroll_bar_v_minwidth;
-				scroll_bar_h_max += scroll_bar_v_minwidth;
 				scroll_bar_v->show();
 
 				if (do_autoscroll_to_bottom) {
@@ -1634,7 +1634,7 @@ void ItemList::force_update_list_size() {
 				}
 			}
 
-			if (is_layout_rtl()) {
+			if (is_layout_rtl() && !wraparound_items) {
 				scroll_bar_h->set_max(scroll_bar_h_page);
 				scroll_bar_h->set_min(-(scroll_bar_h_max - scroll_bar_h_page));
 			} else {
@@ -1692,7 +1692,7 @@ int ItemList::get_item_at_position(const Point2 &p_pos, bool p_exact) const {
 	pos.x += scroll_bar_h->get_value();
 
 	if (is_layout_rtl()) {
-		pos.x = get_size().width - pos.x - theme_cache.panel_style->get_margin(SIDE_LEFT) - theme_cache.panel_style->get_margin(SIDE_RIGHT);
+		pos.x = get_size().width - pos.x - scroll_bar_h->get_value() - theme_cache.panel_style->get_margin(SIDE_LEFT) - theme_cache.panel_style->get_margin(SIDE_RIGHT);
 	}
 
 	int closest = -1;
@@ -1701,8 +1701,16 @@ int ItemList::get_item_at_position(const Point2 &p_pos, bool p_exact) const {
 	for (int i = 0; i < items.size(); i++) {
 		Rect2 rc = items[i].rect_cache;
 
-		if (i % current_columns == current_columns - 1 && wraparound_items) {
-			rc.size.width = get_size().width - rc.position.x; // Make sure you can still select the last item when clicking past the column.
+		if (i % current_columns == current_columns - 1) { // Make sure you can still select the last item when clicking past the column.
+			if (is_layout_rtl()) {
+				rc.size.width = get_size().width - scroll_bar_h->get_value() + rc.position.x;
+			} else {
+				rc.size.width = get_size().width + scroll_bar_h->get_value() - rc.position.x;
+			}
+		}
+
+		if (rc.size.x < 0) {
+			continue; // Skip negative item sizes, because they are off screen.
 		}
 
 		if (rc.has_point(pos)) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/100810 and fixes https://github.com/godotengine/godot/issues/74486
This pr also fixes the bug that item texts aren't rendered in rtl layout direction. (wasn't reported yet)
I removed an unnecessary addition and subtraction (line 1604 and line 1629).

I have changed the text offset when using `icon_mode TOP` so that the text is off center, but remains visible when using a small width.

<details><summary>Videos</summary>
<p>
<h3> icon_mode = Top:</h3>

https://github.com/user-attachments/assets/878fa6f8-94fe-4ad1-94de-9bfb57490014

<h3> icon_mode = Left:</h3>

https://github.com/user-attachments/assets/4e361d08-bf11-44cc-bd17-faebc9a6cde0

</p>
</details> 

