### PR TITLE
Fix ColorPicker hide save/load swatches for presets_visible

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2038,8 +2038,7 @@ void ColorPicker::set_presets_visible(bool p_visible) {
 		return;
 	}
 	presets_visible = p_visible;
-	btn_preset->set_visible(p_visible);
-	btn_recent_preset->set_visible(p_visible);
+	swatches_vbc->set_visible(p_visible);
 }
 
 bool ColorPicker::are_presets_visible() const {
@@ -2348,6 +2347,9 @@ ColorPicker::ColorPicker() {
 	_update_controls();
 	updating = false;
 
+	swatches_vbc = memnew(VBoxContainer);
+	real_vbox->add_child(swatches_vbc);
+
 	preset_container = memnew(GridContainer);
 	preset_container->set_h_size_flags(SIZE_EXPAND_FILL);
 	preset_container->set_columns(PRESET_COLUMN_COUNT);
@@ -2357,7 +2359,7 @@ ColorPicker::ColorPicker() {
 
 	HBoxContainer *palette_box = memnew(HBoxContainer);
 	palette_box->set_h_size_flags(SIZE_EXPAND_FILL);
-	real_vbox->add_child(palette_box);
+	swatches_vbc->add_child(palette_box);
 
 	btn_preset = memnew(Button);
 	btn_preset->set_text("Swatches");
@@ -2382,9 +2384,9 @@ ColorPicker::ColorPicker() {
 	palette_name = memnew(Label);
 	palette_name->hide();
 	palette_name->set_mouse_filter(MOUSE_FILTER_PASS);
-	real_vbox->add_child(palette_name);
+	swatches_vbc->add_child(palette_name);
 
-	real_vbox->add_child(preset_container);
+	swatches_vbc->add_child(preset_container);
 
 	recent_preset_hbc = memnew(HBoxContainer);
 	recent_preset_hbc->set_v_size_flags(SIZE_SHRINK_BEGIN);
@@ -2398,9 +2400,9 @@ ColorPicker::ColorPicker() {
 	btn_recent_preset->set_focus_mode(FOCUS_NONE);
 	btn_recent_preset->set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 	btn_recent_preset->connect(SceneStringName(toggled), callable_mp(this, &ColorPicker::_show_hide_preset).bind(btn_recent_preset, recent_preset_hbc));
-	real_vbox->add_child(btn_recent_preset);
+	swatches_vbc->add_child(btn_recent_preset);
 
-	real_vbox->add_child(recent_preset_hbc);
+	swatches_vbc->add_child(recent_preset_hbc);
 
 	set_pick_color(Color(1, 1, 1));
 

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -157,6 +157,7 @@ private:
 	Control *wheel = nullptr;
 	Control *wheel_uv = nullptr;
 	TextureRect *sample = nullptr;
+	VBoxContainer *swatches_vbc = nullptr;
 	GridContainer *preset_container = nullptr;
 	HBoxContainer *recent_preset_hbc = nullptr;
 	Button *btn_add_preset = nullptr;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/101908

Hides the menu button for loading and saving swatches when presets_visible is false.

This PR does not fix "You can load a new palette even if can_add_swatches = false" mentioned in the issue
