### PR TITLE
Fix Make Sub-Resources Unique shortcut focus

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -750,7 +750,6 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	object_menu = memnew(MenuButton);
 	object_menu->set_flat(false);
 	object_menu->set_theme_type_variation("FlatMenuButton");
-	object_menu->set_shortcut_context(this);
 	property_tools_hb->add_child(object_menu);
 	object_menu->set_tooltip_text(TTR("Manage object properties."));
 	object_menu->get_popup()->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_menu));


### PR DESCRIPTION
After a shortcut is assigned by the user, the assigned shortcut for "Make Sub-Resources Unique" wasn't working unless the user focused on the inspector tab. This made the shortcut ineffective, as the user would already need to interact with the tab where the operation could be performed manually.

- Removed the line responsible for setting the shortcut context.

Tested by trying the assigned shortcut without focusing on the inspector tab.

Fixes #93038