### PR TITLE
Fix ColorPicker Swatches button width

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2365,12 +2365,9 @@ ColorPicker::ColorPicker() {
 	btn_preset->set_toggle_mode(true);
 	btn_preset->set_focus_mode(FOCUS_NONE);
 	btn_preset->set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
+	btn_preset->set_h_size_flags(SIZE_EXPAND_FILL);
 	btn_preset->connect(SceneStringName(toggled), callable_mp(this, &ColorPicker::_show_hide_preset).bind(btn_preset, preset_container));
 	palette_box->add_child(btn_preset);
-
-	HBoxContainer *padding_box = memnew(HBoxContainer);
-	padding_box->set_h_size_flags(SIZE_EXPAND_FILL);
-	palette_box->add_child(padding_box);
 
 	menu_btn = memnew(Button);
 	menu_btn->set_flat(true);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/101922

After:

[Screencast_20250122_162705.webm](https://github.com/user-attachments/assets/899b2a37-f661-4023-bb51-e8cc858c8897)



Not sure if the HBoxContainer separation should be changed (0?) or not?
