### PR TITLE
jpeg-compressor: Fix include when compiling with Clang and `FORTIFY_SOURCE >= 1`

### DIFF
--- a/thirdparty/jpeg-compressor/jpge.cpp
+++ b/thirdparty/jpeg-compressor/jpge.cpp
@@ -30,6 +30,7 @@
 
 #include "jpge.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -933,7 +934,6 @@ namespace jpge {
 	}
 
 	// Higher level wrappers/examples (optional).
-#include <stdio.h>
 
 	class cfile_stream : public output_stream
 	{

--- a/thirdparty/jpeg-compressor/patches/clang-fortify-fix.patch
+++ b/thirdparty/jpeg-compressor/patches/clang-fortify-fix.patch
@@ -1,0 +1,20 @@
+diff --git a/thirdparty/jpeg-compressor/jpge.cpp b/thirdparty/jpeg-compressor/jpge.cpp
+index 5a36c19653..bb0c54bbf0 100644
+--- a/thirdparty/jpeg-compressor/jpge.cpp
++++ b/thirdparty/jpeg-compressor/jpge.cpp
+@@ -30,6 +30,7 @@
+ 
+ #include "jpge.h"
+ 
++#include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+ 
+@@ -933,7 +934,6 @@ namespace jpge {
+ 	}
+ 
+ 	// Higher level wrappers/examples (optional).
+-#include <stdio.h>
+ 
+ 	class cfile_stream : public output_stream
+ 	{


### PR DESCRIPTION
…ue to clang being built with FORTIFY_SOURCE>=1 on some systems. Stdio.h should have already been up there anyway, if used.

* This fixes compiling GODOT with Clang fortified via FORTIFY_SOURCE>=1
* Normally, the compiler should fix this
* Some of the details can be found here by OpenEmbedded implementation: https://git.openembedded.org/meta-openembedded/tree/meta-oe/recipes-graphics/renderdoc/renderdoc/0001-jpeg-compressor-Reorder-stdio.h-include-location.patch?h=master
* A unknown developer from Renderdoc rejected the fix without considering the solution, and based on the fact that the Clang upstream should fix it first


I'm compiling GoDot source via FORTIFY_SOURCE=2 clang (via Gentoo profiles), and went through the same exact issue as the one reported in the OpenEmbedded channel:

```
In file included from thirdparty/jpeg-compressor/jpge.cpp:936:
In file included from /usr/lib/clang/19/include/llvm_libc_wrappers/stdio.h:13:
In file included from /usr/include/stdio.h:970:
/usr/include/bits/stdio2.h:128:13: error: use of undeclared identifier '__builtin___vfprintf_chk'; did you mean '__builtin___sprintf_chk'?
  128 |   int __r = __builtin___vfprintf_chk (__stream, __USE_FORTIFY_LEVEL - 1,
      |             ^
/usr/include/bits/stdio2.h:128:39: error: cannot initialize a parameter of type 'char *' with an lvalue of type 'FILE *const __restrict' (aka 'jpge::_IO_FILE *const __restrict')
  128 |   int __r = __builtin___vfprintf_chk (__stream, __USE_FORTIFY_LEVEL - 1,
```
  
This is done via Clang 19.1.4, with makefile scons options:

```
scons platform=linuxbsd target=editor production=true use_llvm=yes linker=lld compiledb=yes precision=single debug_symbols=true pulseaudio=true dbus=true fontconfig=true -j 22
```

In order to reproduce this, you would have to either install gentoo, or follow the precompiled gentoo binary guide via pulling a docker image with stage3 on it: 

```docker pull gentoo/stage3```

Get a container exec into /bin/bash

```env-update && source /etc/profile```
```emerge --sync```
```emerge -v sec-keys/openpgp-keys-gentoo-release```

Edit /etc/portage/make.conf to look exactly like this:
(with MAKEOPTS -j22 changed to how many CPU threads you want, of course, but no need to change the others)

```COMMON_FLAGS="-O2 -pipe"
MAKEOPTS="-j22 -s"
CFLAGS="${COMMON_FLAGS}"
CXXFLAGS="${COMMON_FLAGS}"
FCFLAGS="${COMMON_FLAGS}"
FFLAGS="${COMMON_FLAGS}"
LC_MESSAGES=C.utf8
BINPKG_FORMAT="gpkg"
EMERGE_DEFAULT_OPTS="${EMERGE_DEFAULT_OPTS} --getbinpkg"
```

Then:



```emerge -v llvm-core/clang:19 dev-vcs/git scons```
```eselect profile set default/linux/amd64/23.0/desktop/systemd```
```env-update && source /etc/profile```
```cd /tmp && git clone https://github.com/godotengine/godot.git```
```cd /tmp/godot```

Up until this step it should be maximum of 15 minutes.

Create a Makefile to /tmp/godot with these options (changed -j <processor_count>):
**build: ./SConstruct**
scons platform=linuxbsd target=editor production=true use_llvm=yes linker=lld compiledb=yes precision=single debug_symbols=true pulseaudio=true dbus=true fontconfig=true -j 22

Attached Makefile as example: 
[godot_Makefile.txt](https://github.com/user-attachments/files/18564557/godot_Makefile.txt)



And then just:
 ```make build```

(Attached the buildfile to the ticket here: [Gentoo_x86-64_Clang19_GodotCompilation.txt](https://github.com/user-attachments/files/18564253/Gentoo_x86-64_Clang19_GodotCompilation.txt))
The full compilation toolchain with all the system tools and versions here: 
[Gentoo_System_CompilationOptions_x64.txt](https://github.com/user-attachments/files/18564510/Gentoo_System_CompilationOptions_x64.txt)


The reason this is happening is because the Gentoo profile version 23.0/desktop/systemd has its CLANG, GCC, GLIBC and toolchain in Gentoo built with FORTIFY_SOURCE >= 1, and Clang doesn't have full support for FORTIFY_SOURCE, or at least there are some minor bugs regarding it.

Explanation for FORTIFY_SOURCE here: https://www.redhat.com/en/blog/enhance-application-security-fortifysource
Same exact issue with third-party jpeg-compressor/jpge.cpp was already fixed in NixOS: https://github.com/NixOS/nixpkgs/issues/349359 with similar patch (which is also a solution, but a bit of a stretch).

But nobody understands why the upstream Clang hasn't fixed this yet, one discussion about it is here: https://github.com/baldurk/renderdoc/pull/3369