### PR TITLE
Disable Game Embedding in Single Window Mode

### DIFF
--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -223,7 +223,7 @@ void GameView::_instance_starting(int p_idx, List<String> &r_arguments) {
 	if (!is_feature_enabled) {
 		return;
 	}
-	if (p_idx == 0 && embed_on_play && make_floating_on_play && !window_wrapper->get_window_enabled() && EditorNode::get_singleton()->is_multi_window_enabled() && _get_embed_available() == EMBED_AVAILABLE) {
+	if (p_idx == 0 && embed_on_play && make_floating_on_play && !window_wrapper->get_window_enabled() && _get_embed_available() == EMBED_AVAILABLE) {
 		// Set the Floating Window default title. Always considered in DEBUG mode, same as in Window::set_title.
 		String appname = GLOBAL_GET("application/config/name");
 		appname = vformat("%s (DEBUG)", TranslationServer::get_singleton()->translate(appname));
@@ -423,6 +423,9 @@ GameView::EmbedAvailability GameView::_get_embed_available() {
 	if (!DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_WINDOW_EMBEDDING)) {
 		return EMBED_NOT_AVAILABLE_FEATURE_NOT_SUPPORTED;
 	}
+	if (!EditorNode::get_singleton()->is_multi_window_enabled()) {
+		return EMBED_NOT_AVAILABLE_SINGLE_WINDOW_MODE;
+	}
 
 	EditorRun::WindowPlacement placement = EditorRun::get_window_placement();
 	if (placement.force_fullscreen) {
@@ -477,6 +480,9 @@ void GameView::_update_ui() {
 		case EMBED_NOT_AVAILABLE_FULLSCREEN:
 			state_label->set_text(TTR("Game embedding not available when the game starts in fullscreen.\nConsider overriding the window mode project setting with the editor feature tag to Windowed to use game embedding while leaving the exported project intact."));
 			break;
+		case EMBED_NOT_AVAILABLE_SINGLE_WINDOW_MODE:
+			state_label->set_text(TTR("Game embedding not available in single window mode."));
+			break;
 	}
 
 	if (available == EMBED_AVAILABLE) {
@@ -495,8 +501,7 @@ void GameView::_update_embed_menu_options() {
 	menu->set_item_checked(menu->get_item_index(EMBED_RUN_GAME_EMBEDDED), embed_on_play);
 	menu->set_item_checked(menu->get_item_index(EMBED_MAKE_FLOATING_ON_PLAY), make_floating_on_play);
 
-	// When embed is Off or in single window mode, Make floating is not available.
-	menu->set_item_disabled(menu->get_item_index(EMBED_MAKE_FLOATING_ON_PLAY), !embed_on_play || !EditorNode::get_singleton()->is_multi_window_enabled());
+	menu->set_item_disabled(menu->get_item_index(EMBED_MAKE_FLOATING_ON_PLAY), !embed_on_play);
 
 	fixed_size_button->set_pressed(embed_size_mode == SIZE_MODE_FIXED);
 	keep_aspect_button->set_pressed(embed_size_mode == SIZE_MODE_KEEP_ASPECT);

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -106,6 +106,7 @@ class GameView : public VBoxContainer {
 		EMBED_NOT_AVAILABLE_MINIMIZED,
 		EMBED_NOT_AVAILABLE_MAXIMIZED,
 		EMBED_NOT_AVAILABLE_FULLSCREEN,
+		EMBED_NOT_AVAILABLE_SINGLE_WINDOW_MODE,
 	};
 
 	inline static GameView *singleton = nullptr;


### PR DESCRIPTION
- Fixes #101654
- Fixes #101718
- Fixes #101666

This PR disables Game Embedding in Single Window Mode. It is currently not functioning well due to the inability to display popups or tooltips in front of the game window. On top of that, embedding mode is now the default.

While this is not a true fix for these issues, I do not have a better solution at the moment. At the very least, users will no longer need to disable embedding to run their games properly. A more suitable solution is required to correctly embed the game window in Single Window Mode.

