### PR TITLE
Update Jolt Physics `BoxShape` to allow for zero-sized boxes

### DIFF
--- a/thirdparty/jolt_physics/Jolt/Physics/Collision/Shape/BoxShape.cpp
+++ b/thirdparty/jolt_physics/Jolt/Physics/Collision/Shape/BoxShape.cpp
@@ -59,7 +59,7 @@ BoxShape::BoxShape(const BoxShapeSettings &inSettings, ShapeResult &outResult) :
 {
 	// Check convex radius
 	if (inSettings.mConvexRadius < 0.0f
-		|| inSettings.mHalfExtent.ReduceMin() <= inSettings.mConvexRadius)
+		|| inSettings.mHalfExtent.ReduceMin() < inSettings.mConvexRadius)
 	{
 		outResult.SetError("Invalid convex radius");
 		return;
@@ -278,7 +278,7 @@ void BoxShape::CollideSoftBodyVertices(Mat44Arg inCenterOfMassTransform, Vec3Arg
 
 void BoxShape::GetTrianglesStart(GetTrianglesContext &ioContext, const AABox &inBox, Vec3Arg inPositionCOM, QuatArg inRotation, Vec3Arg inScale) const
 {
-	new (&ioContext) GetTrianglesContextVertexList(inPositionCOM, inRotation, inScale, Mat44::sScale(mHalfExtent), sUnitBoxTriangles, sizeof(sUnitBoxTriangles) / sizeof(Vec3), GetMaterial());
+	new (&ioContext) GetTrianglesContextVertexList(inPositionCOM, inRotation, inScale, Mat44::sScale(mHalfExtent), sUnitBoxTriangles, std::size(sUnitBoxTriangles), GetMaterial());
 }
 
 int BoxShape::GetTrianglesNext(GetTrianglesContext &ioContext, int inMaxTrianglesRequested, Float3 *outTriangleVertices, const PhysicsMaterial **outMaterials) const


### PR DESCRIPTION
Fixes #101893.

This PR is a partial update of `thirdparty/jolt_physics`, cherry picking only the changes from jrouwe/JoltPhysics@fcea5132be9a8651de7c44282b466fe0a5dd8278, which relaxes the error checking when creating a `JPH::BoxShape` to allow for the case where we have at least one zero-sized axis as well as a convex radius (collision margin) of zero.

This should bring the Jolt Physics module in line with Godot Physics in this regard.