### PR TITLE
Fix wrong default texture for global uniforms of type `sampler2DArray`

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -872,7 +872,11 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 						E->value = global_textures_pass;
 					}
 
-					textures.push_back(v->override.get_type() != Variant::NIL ? v->override : v->value);
+					if (v->override.get_type() == Variant::RID && ((RID)v->override).is_valid()) {
+						textures.push_back(v->override);
+					} else if (v->value.get_type() == Variant::RID && ((RID)v->value).is_valid()) {
+						textures.push_back(v->value);
+					}
 				}
 
 			} else {

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -906,7 +906,11 @@ void MaterialStorage::MaterialData::update_textures(const HashMap<StringName, Va
 						E->value = global_textures_pass;
 					}
 
-					textures.push_back(v->override.get_type() != Variant::NIL ? v->override : v->value);
+					if (v->override.get_type() == Variant::RID && ((RID)v->override).is_valid()) {
+						textures.push_back(v->override);
+					} else if (v->value.get_type() == Variant::RID && ((RID)v->value).is_valid()) {
+						textures.push_back(v->value);
+					}
 				}
 
 			} else {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/101938

There were two problem in this code:

1. It always added a texture, even if it wasn't set on either `value` or `override`
2. It assumed an unset value would be `Variant::NIL`, however, it looks like it's `Variant::RID` but if it's not set it'll be an empty RID (ie `RID()`).

With this PR, if you open the MRP from https://github.com/godotengine/godot/issues/101938, it will no longer spam the error every frame