### PR TITLE
Fix `SceneTreeDock::_new_scene_from()`'s reset_scale in 3D

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3386,7 +3386,7 @@ void SceneTreeDock::_new_scene_from(const String &p_file) {
 				copy_3d->set_rotation(Vector3(0, 0, 0));
 			}
 			if (reset_scale) {
-				copy_3d->set_scale(Vector3(0, 0, 0));
+				copy_3d->set_scale(Vector3(1, 1, 1));
 			}
 		}
 


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/101907 as described by https://github.com/godotengine/godot/issues/101907#issuecomment-2606942345

A typo snuck into `SceneTreeDock::_new_scene_from()` that meant `reset_scale` set the scale to `0` instead of `1` for all axes.
