### PR TITLE
Improve `ViewportTexture::get_size`

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -134,10 +134,7 @@ int ViewportTexture::get_width() const {
 		_err_print_viewport_not_set();
 		return 0;
 	}
-	if (vp->is_sub_viewport()) {
-		return vp->size.width;
-	}
-	return vp->size.width * vp->get_stretch_transform().get_scale().width;
+	return vp->texture_size.width;
 }
 
 int ViewportTexture::get_height() const {
@@ -145,10 +142,7 @@ int ViewportTexture::get_height() const {
 		_err_print_viewport_not_set();
 		return 0;
 	}
-	if (vp->is_sub_viewport()) {
-		return vp->size.height;
-	}
-	return vp->size.height * vp->get_stretch_transform().get_scale().height;
+	return vp->texture_size.height;
 }
 
 Size2 ViewportTexture::get_size() const {
@@ -156,11 +150,7 @@ Size2 ViewportTexture::get_size() const {
 		_err_print_viewport_not_set();
 		return Size2();
 	}
-	if (vp->is_sub_viewport()) {
-		return vp->size;
-	}
-	Size2 scale = vp->get_stretch_transform().get_scale();
-	return Size2(vp->size.width * scale.width, vp->size.height * scale.height).ceil();
+	return vp->texture_size;
 }
 
 RID ViewportTexture::get_rid() const {
@@ -1111,6 +1101,7 @@ bool Viewport::_set_size(const Size2i &p_size, const Size2 &p_size_2d_override, 
 	}
 
 	size = new_size;
+	texture_size = new_size;
 	size_allocated = p_allocated;
 	size_2d_override = p_size_2d_override;
 	stretch_transform = stretch_transform_new;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -256,6 +256,7 @@ private:
 	Transform2D stretch_transform;
 
 	Size2i size = Size2i(512, 512);
+	Size2i texture_size = Size2i(512, 512);
 	Size2 size_2d_override;
 	bool size_allocated = false;
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1320,9 +1320,9 @@ void Window::_update_viewport_size() {
 	if (embedder) {
 		float scale = MIN(embedder->stretch_transform.get_scale().width, embedder->stretch_transform.get_scale().height);
 		Viewport::set_oversampling_override(scale);
-		Size2 s = Size2(final_size.width * scale, final_size.height * scale).ceil();
+		texture_size = Size2(final_size.width * scale, final_size.height * scale).ceil();
 		RS::get_singleton()->viewport_set_global_canvas_transform(get_viewport_rid(), global_canvas_transform * scale * content_scale_factor);
-		RS::get_singleton()->viewport_set_size(get_viewport_rid(), s.width, s.height);
+		RS::get_singleton()->viewport_set_size(get_viewport_rid(), texture_size.width, texture_size.height);
 		embedder->_sub_window_update(this);
 	}
 }


### PR DESCRIPTION
After #101700 I felt that `ViewportTexture::get_size` has become a bit complicated. If the real size of the viewport can be obtained directly, then there is no need to perform additional operations in `ViewportTexture::get_size`, so I tried to add `Viewport->texture_size`.

Fix https://github.com/godotengine/godot/issues/110922
Supersedes https://github.com/godotengine/godot/pull/110960