### PR TITLE
Fix animation filter bug when selecting a keyframe or a resource

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -629,7 +629,7 @@ bool AnimationBezierTrackEdit::_is_track_displayed(int p_track_index) {
 		return false;
 	}
 
-	if (is_filtered) {
+	if (is_filtered && EditorNode::get_singleton()->get_editor_selection()->get_selected_nodes().size() > 0) {
 		String path = animation->track_get_path(p_track_index);
 		if (root && root->has_node(path)) {
 			Node *node = root->get_node(path);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -806,6 +806,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _view_group_toggle();
 	Button *view_group = nullptr;
 	Button *selected_filter = nullptr;
+	TypedArray<Node> nodes_filtered;
 
 	void _auto_fit();
 	void _auto_fit_bezier();


### PR DESCRIPTION
This fixes #101031 where the animation editor timeline editor gets filtered out when a resource is selected in the editor

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
