### PR TITLE
Use `LocalVector<Glyph>` in `TextServerAdvanced` to reduce reallocation

### DIFF
--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -543,8 +543,8 @@ class TextServerAdvanced : public TextServerExtension {
 		TrimData overrun_trim_data;
 		bool fit_width_minimum_reached = false;
 
-		Vector<Glyph> glyphs;
-		Vector<Glyph> glyphs_logical;
+		LocalVector<Glyph> glyphs;
+		LocalVector<Glyph> glyphs_logical;
 
 		/* Intermediate data */
 		Char16String utf16;


### PR DESCRIPTION
As I stated in https://github.com/godotengine/godot/issues/101882#issuecomment-2607076532, `TextServerAdvanced::glyphs` contributes a lot of heap reallocations via `push_back` calls. An ideal solution would be reserving enough space before the loop but unfortunately the control flow here is quite complex and I do not obtain enough domain specific knowledge to determin which branch is used most often. So instead I change the `Vector` to `LocalVector` to benifit from default x2 resizing behaviour.

I check the code and can confirm that COW is not needed here. Only one reference to `glyphs` includes COW copy but that one is  followed by an immediate sorting which triggers the duplication anyway.

Performance gain is rather small, this patch saves about 1s in #101882's MRP from 22s on my PC. Some screenshots to show we are actually doing less reallocation:
master:
![image](https://github.com/user-attachments/assets/f88c3dbe-975a-419d-9a8a-d2411d3b5670)

This PR:
![image](https://github.com/user-attachments/assets/bd457cc1-e36b-41bb-b433-151f75a080e2)
