### PR TITLE
Fix shadow peter-panning with default spotlight

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -733,7 +733,7 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 		vec4 v = vec4(vertex + normal_bias, 1.0);
 
 		vec4 splane = (spot_lights.data[idx].shadow_matrix * v);
-		splane.z += spot_lights.data[idx].shadow_bias / (light_length * spot_lights.data[idx].inv_radius);
+		splane.z += spot_lights.data[idx].shadow_bias;
 		splane /= splane.w;
 
 		if (sc_use_light_soft_shadows() && spot_lights.data[idx].soft_shadow_size > 0.0) {

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2510,7 +2510,7 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 				}
 
 				real_t radius = RSG::light_storage->light_get_param(p_instance->base, RS::LIGHT_PARAM_RANGE);
-				real_t z_near = MIN(0.005f, radius);
+				real_t z_near = MIN(0.025f, radius);
 				Projection cm;
 				cm.set_perspective(90, 1, z_near, radius);
 
@@ -2600,7 +2600,7 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 
 			real_t radius = RSG::light_storage->light_get_param(p_instance->base, RS::LIGHT_PARAM_RANGE);
 			real_t angle = RSG::light_storage->light_get_param(p_instance->base, RS::LIGHT_PARAM_SPOT_ANGLE);
-			real_t z_near = MIN(0.005f, radius);
+			real_t z_near = MIN(0.025f, radius);
 
 			Projection cm;
 			cm.set_perspective(angle * 2.0, 1.0, z_near, radius);


### PR DESCRIPTION
Fixes #101857.

A regression with default spotlights exhibiting significant shadow peter-panning was introduced in #100319.

This PR fixes it with 2 changes :
1. sets the now-fixed light znear to *0.025* instead of *0.005*. This is to match the former behavior of default spotlights and omnis (*range = 5* driving *znear = 0.005 * 5 = 0.025*)
2. applies bias as a constant offset in clip space. Now znear is fixed, *z = w* in clip space always represents the same *z = znear* in view space, therefore there is no need to rescale bias before applying it in clip space anymore

This is how default point lights' shadows look like with this PR.
Appearance also does not depend on range.
| Default Spotlight | Default Omni |
| --- | --- |
| range = 5 and bias =  0.03| range = 5 and bias = 0.1 |
| ![Capture d’écran du 2025-01-23 09-19-01](https://github.com/user-attachments/assets/73a6d7d0-d504-4caa-9739-cb7d213c84d8) | ![Capture d’écran du 2025-01-23 09-19-34](https://github.com/user-attachments/assets/a99580f5-de46-4cf1-91e4-13ae7357f862) |

I'd need other pairs of eyes especially on change no. 2. I was originally counting on Omni shadows implementation to serve as a reference to double check Spotlight implementation, but it turned out that they are rather different both code-wise and math-wise.
