### PR TITLE
`TextureProgressBar` minimum size selection as maximum among all textures

### DIFF
--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -81,15 +81,19 @@ bool TextureProgressBar::get_nine_patch_stretch() const {
 Size2 TextureProgressBar::get_minimum_size() const {
 	if (nine_patch_stretch) {
 		return Size2(stretch_margin[SIDE_LEFT] + stretch_margin[SIDE_RIGHT], stretch_margin[SIDE_TOP] + stretch_margin[SIDE_BOTTOM]);
-	} else if (under.is_valid()) {
-		return under->get_size();
-	} else if (over.is_valid()) {
-		return over->get_size();
-	} else if (progress.is_valid()) {
-		return progress->get_size();
 	}
 
-	return Size2(1, 1);
+	Size2 size = Size2(1, 1);
+	if (under.is_valid()) {
+		size = size.max(under->get_size());
+	}
+	if (progress.is_valid()) {
+		size = size.max(progress->get_size());
+	}
+	if (over.is_valid()) {
+		size = size.max(over->get_size());
+	}
+	return size;
 }
 
 void TextureProgressBar::set_progress_texture(const Ref<Texture2D> &p_texture) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/100693
Supersedes  https://github.com/godotengine/godot/pull/101281 (skill issue, sorry 😢)

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/dec43dff-25f8-4df2-aec2-a36df3dfdadf) | ![After](https://github.com/user-attachments/assets/202d46a8-3a9c-4261-b7f9-98e098eb0d03) |