### PR TITLE
Fix Theora video issues

### DIFF
--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -74,7 +74,8 @@ void VideoStreamPlaybackTheora::video_write(th_ycbcr_buffer yuv) {
 		yuv420_2_rgb8888((uint8_t *)dst, (uint8_t *)yuv[0].data + y_offset, (uint8_t *)yuv[1].data + uv_offset, (uint8_t *)yuv[2].data + uv_offset, region.size.x, region.size.y, yuv[0].stride, yuv[1].stride, region.size.x << 2);
 	}
 
-	Ref<Image> img = memnew(Image(region.size.x, region.size.y, false, Image::FORMAT_RGBA8, frame_data)); //zero copy image creation
+	Ref<Image> img;
+	img.instantiate(region.size.x, region.size.y, false, Image::FORMAT_RGBA8, frame_data); //zero copy image creation
 
 	texture->update(img); //zero copy send to rendering server
 }

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -41,27 +41,20 @@
 
 class ImageTexture;
 
-//#define THEORA_USE_THREAD_STREAMING
-
 class VideoStreamPlaybackTheora : public VideoStreamPlayback {
 	GDCLASS(VideoStreamPlaybackTheora, VideoStreamPlayback);
 
-	enum {
-		MAX_FRAMES = 4,
-	};
-
-	//Image frames[MAX_FRAMES];
 	Image::Format format = Image::Format::FORMAT_L8;
 	Vector<uint8_t> frame_data;
 	int frames_pending = 0;
 	Ref<FileAccess> file;
 	String file_name;
-	int audio_frames_wrote = 0;
 	Point2i size;
+	Rect2i region;
 
 	int buffer_data();
 	int queue_page(ogg_page *page);
-	void video_write();
+	void video_write(th_ycbcr_buffer yuv);
 	double get_time() const;
 
 	bool theora_eos = false;
@@ -79,42 +72,29 @@ class VideoStreamPlaybackTheora : public VideoStreamPlayback {
 	vorbis_block vb;
 	vorbis_comment vc;
 	th_pixel_fmt px_fmt;
-	double videobuf_time = 0;
-	int pp_inc = 0;
+	double frame_duration;
 
 	int theora_p = 0;
 	int vorbis_p = 0;
 	int pp_level_max = 0;
 	int pp_level = 0;
-	int videobuf_ready = 0;
+	int pp_inc = 0;
 
 	bool playing = false;
 	bool buffering = false;
+	bool paused = false;
 
-	double last_update_time = 0;
+	bool dup_frame = false;
+	bool video_ready = false;
+	bool video_done = false;
+	bool audio_done = false;
+
 	double time = 0;
+	double next_frame_time = 0;
+	double current_frame_time = 0;
 	double delay_compensation = 0;
 
 	Ref<ImageTexture> texture;
-
-	bool paused = false;
-
-#ifdef THEORA_USE_THREAD_STREAMING
-
-	enum {
-		RB_SIZE_KB = 1024
-	};
-
-	RingBuffer<uint8_t> ring_buffer;
-	Vector<uint8_t> read_buffer;
-	bool thread_eof = false;
-	Semaphore *thread_sem = nullptr;
-	Thread thread;
-	SafeFlag thread_exit;
-
-	static void _streaming_thread(void *ud);
-
-#endif
 
 	int audio_track = 0;
 

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -158,6 +158,7 @@ void VideoStreamPlayer::_notification(int p_notification) {
 			playback->update(delta); // playback->is_playing() returns false in the last video frame
 
 			if (!playback->is_playing()) {
+				resampler.flush();
 				if (loop) {
 					play();
 					return;

--- a/servers/audio/audio_rb_resampler.h
+++ b/servers/audio/audio_rb_resampler.h
@@ -86,7 +86,7 @@ public:
 		} else if (w < r) {
 			space = r - w - 1;
 		} else {
-			space = (rb_len - r) + w - 1;
+			space = rb_len - w + r - 1;
 		}
 
 		return space;

--- a/servers/audio/audio_rb_resampler.h
+++ b/servers/audio/audio_rb_resampler.h
@@ -86,7 +86,7 @@ public:
 		} else if (w < r) {
 			space = r - w - 1;
 		} else {
-			space = rb_len - w + r - 1;
+			space = (rb_len - w) + (r - 1);
 		}
 
 		return space;


### PR DESCRIPTION
This fixes many (if not all) of the long-standing issues when playing Theora video streams. Even though Theora is an old codec, it can still do a decent job, specially when it works 100% correctly. That's what this PR aims to do.

Videos are an essential piece for many games, and I think Godot can be a lot better by fulfilling that need in the core. Having at least a backup codec which can be used out of the box and offers compatibility with old and new hardware will make life easier for a lot of developers.

What's fixed:

- Duplicate frames being ignored (TH_DUPFRAME). These are used when there are continuous identical frames in the stream.
- Frames playing ahead of time, more noticeable with lower framerates. ~~The latter can happen when the encoder skips identical frames, but also when the video frame rate is lower than the screen frame rate.~~ Edit: this was made worse by a bug in FFmpeg.
- Audio buffer running out of data when the previous situations happened and also when decoding was slow.
- Buffering of the stream didn't work. Now it works for the decoded audio and the encoded video data.
- The audio buffer couldn't be filled without overwriting previous audio data.
- Frames weren't being cropped to the original picture size and offset and produced artifacts around the image for some frame sizes.

I've also removed the Theora thread streaming code since it was disabled in code and it would involve more testing. I think it's better to remove that code for now than leave it untested and focus on getting it working 100% right.

The issues fixed could be mostly worked around by setting the keyframe inverval to 1 but this would take away most compression benefits. Now videos should play correctly even at the highest keyframe interval.

- Fixes #66331 (same as #21568)
- Fixes #101837
- Fixes #62752 
- Fixes #53503
- Fixes #98302

And possibly other issues.

There's some code left to dynamically change post-processing levels depending on codec performance, but it doesn't really do anything as it's set to no post-processing. I think I could easily make it work but it would be good to have a setting so the user can disable post-processing or set a max level that suits the video content.

Audio delay compensation is supposed to need some work also according to code comments. I could look at it too.

Please test it. Now that I've gotten a grasp of the code, I'm determined to make it work 100%.

I think this could be easily ported to Godot 3.X.