### PR TITLE
Fix ColorPicker load/save swatches button interactions

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1770,13 +1770,6 @@ void ColorPicker::_pick_finished() {
 }
 
 void ColorPicker::_update_menu_items() {
-	if (!options_menu) {
-		options_menu = memnew(PopupMenu);
-		add_child(options_menu, false, INTERNAL_MODE_FRONT);
-		options_menu->force_parent_owned();
-		options_menu->connect("id_pressed", callable_mp(this, &ColorPicker::_options_menu_cbk));
-	}
-
 	options_menu->clear();
 	options_menu->reset_size();
 
@@ -1800,16 +1793,6 @@ void ColorPicker::_update_menu_items() {
 		options_menu->add_icon_item(get_theme_icon(SNAME("clear"), SNAME("FileDialog")), RTR("Clear"), static_cast<int>(MenuOption::MENU_CLEAR));
 		options_menu->set_item_tooltip(-1, ETR("Clear the currently loaded color palettes in the picker."));
 	}
-}
-
-void ColorPicker::_update_menu() {
-	_update_menu_items();
-	Rect2 gt = menu_btn->get_screen_rect();
-	menu_btn->reset_size();
-	int min_size = menu_btn->get_minimum_size().width;
-	Vector2 popup_pos = gt.get_end() - Vector2(min_size, 0);
-	options_menu->set_position(popup_pos);
-	options_menu->popup();
 }
 
 void ColorPicker::_options_menu_cbk(int p_which) {
@@ -2369,12 +2352,14 @@ ColorPicker::ColorPicker() {
 	btn_preset->connect(SceneStringName(toggled), callable_mp(this, &ColorPicker::_show_hide_preset).bind(btn_preset, preset_container));
 	palette_box->add_child(btn_preset);
 
-	menu_btn = memnew(Button);
+	menu_btn = memnew(MenuButton);
 	menu_btn->set_flat(true);
 	menu_btn->set_tooltip_text(ETR("Show all options available."));
-	menu_btn->set_focus_mode(FOCUS_NONE);
-	menu_btn->connect(SceneStringName(pressed), callable_mp(this, &ColorPicker::_update_menu));
+	menu_btn->connect("about_to_popup", callable_mp(this, &ColorPicker::_update_menu_items));
 	palette_box->add_child(menu_btn);
+
+	options_menu = menu_btn->get_popup();
+	options_menu->connect(SceneStringName(id_pressed), callable_mp(this, &ColorPicker::_options_menu_cbk));
 
 	palette_name = memnew(Label);
 	palette_name->hide();

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -144,7 +144,7 @@ private:
 	TextureRect *picker_texture_rect = nullptr;
 	Color picker_color;
 	FileDialog *file_dialog = nullptr;
-	Button *menu_btn = nullptr;
+	MenuButton *menu_btn = nullptr;
 	PopupMenu *options_menu = nullptr;
 
 	MarginContainer *internal_margin = nullptr;
@@ -305,7 +305,6 @@ private:
 	void _target_gui_input(const Ref<InputEvent> &p_event);
 	void _pick_finished();
 	void _update_menu_items();
-	void _update_menu();
 	void _options_menu_cbk(int p_which);
 
 	// Legacy color picking.


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/101959

Changed menu_btn to be a MenuButton instead of a regular Button
