### PR TITLE
Don't inline certain functions for smaller binary size

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -167,7 +167,7 @@ opts.Add(
         "optimize",
         "Optimization level (by default inferred from 'target' and 'dev_build')",
         "auto",
-        ("auto", "none", "custom", "debug", "speed", "speed_trace", "size"),
+        ("auto", "none", "custom", "debug", "speed", "speed_trace", "size", "size_extra"),
     )
 )
 opts.Add(BoolVariable("debug_symbols", "Build with debugging symbols", False))
@@ -725,9 +725,11 @@ if env.msvc:
         env.Append(LINKFLAGS=["/OPT:REF"])
         if env["optimize"] == "speed_trace":
             env.Append(LINKFLAGS=["/OPT:NOICF"])
-    elif env["optimize"] == "size":
+    elif env["optimize"].startswith("size"):
         env.Append(CCFLAGS=["/O1"])
         env.Append(LINKFLAGS=["/OPT:REF"])
+        if env["optimize"] == "size_extra":
+            env.Append(CPPDEFINES=["SIZE_EXTRA"])
     elif env["optimize"] == "debug" or env["optimize"] == "none":
         env.Append(CCFLAGS=["/Od"])
 else:
@@ -772,9 +774,11 @@ else:
     elif env["optimize"] == "speed_trace":
         env.Append(CCFLAGS=["-O2"])
         env.Append(LINKFLAGS=["-O2"])
-    elif env["optimize"] == "size":
+    elif env["optimize"].startswith("size"):
         env.Append(CCFLAGS=["-Os"])
         env.Append(LINKFLAGS=["-Os"])
+        if env["optimize"] == "size_extra":
+            env.Append(CPPDEFINES=["SIZE_EXTRA"])
     elif env["optimize"] == "debug":
         env.Append(CCFLAGS=["-Og"])
         env.Append(LINKFLAGS=["-Og"])

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -208,7 +208,13 @@ public:
 	StringName() {}
 
 	static void assign_static_unique_class_name(StringName *ptr, const char *p_name);
-	_FORCE_INLINE_ ~StringName() {
+
+#ifdef SIZE_EXTRA
+	_NO_INLINE_
+#else
+	_FORCE_INLINE_
+#endif
+	~StringName() {
 		if (likely(configured) && _data) { //only free if configured
 			unref();
 		}

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -617,6 +617,9 @@ public:
 	_FORCE_INLINE_ String(const String &p_str) { _cowdata._ref(p_str._cowdata); }
 	_FORCE_INLINE_ String(String &&p_str) :
 			_cowdata(std::move(p_str._cowdata)) {}
+#ifdef SIZE_EXTRA
+	_NO_INLINE_ ~String() {}
+#endif
 	_FORCE_INLINE_ void operator=(const String &p_str) { _cowdata._ref(p_str._cowdata); }
 	_FORCE_INLINE_ void operator=(String &&p_str) { _cowdata = std::move(p_str._cowdata); }
 

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -65,9 +65,10 @@ static_assert(__cplusplus >= 201703L);
 #endif
 #endif
 
-// Should always inline, except in dev builds because it makes debugging harder.
+// Should always inline, except in dev builds because it makes debugging harder,
+// or `size_enabled` builds where inlining is actively avoided.
 #ifndef _FORCE_INLINE_
-#ifdef DEV_ENABLED
+#if defined(DEV_ENABLED) || defined(SIZE_EXTRA)
 #define _FORCE_INLINE_ inline
 #else
 #define _FORCE_INLINE_ _ALWAYS_INLINE_


### PR DESCRIPTION
AFAIK godot has a long standing issue that its binary size is too big for web platform which leads to slow starup time. See https://github.com/godotengine/godot/issues/68647 for more details. I profile the binary size a bit with [SizeBench](https://github.com/microsoft/SizeBench) and apply several suggestions.

What I have done:
- no inline `String::~String()`(\~-5MB), `StringName:~StringName`(\~-1MB), `_err_print_error`(\~-200KB)
- Make `_FORCE_INLINE_` a no-op.
- ~remove unused `virtual` qualifier for `Object::call_const` (\~-10KB) (I wonder if this can be automated, some of these functions are configuration-dependent, e.g. `Object::setvar()` overriden on web but not on Windows. Manually doing this is time-consuming and prone to errors.)(These unused virtuals waste approximately 2.8MB of space in total.)~

These changes are guarded by a `SIZE_EXTRA` macro and can be enabled by passing `optimize=size_extra` from cmd.

Result(Web Release):
compile with `scons p=web target=template_release optimize=size_extra production=yes`
- godot.wasm
    - master 41,664,454 bytes
    - this PR 30,784,747 bytes
- the whole zip package
    - master 9,421,090 bytes
    - this PR 8,706,984 bytes

Performance impact: 5%~10%, measured by godot-benchmark exported to web. https://github.com/godotengine/godot/pull/101964#issuecomment-2613820912