### PR TITLE
Pass angular diameter into light size constants for sky shaders.

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -708,12 +708,7 @@ void RasterizerSceneGLES3::_setup_sky(const RenderDataGLES3 *p_render_data, cons
 				sky_light_data.enabled = true;
 
 				float angular_diameter = light_storage->light_get_param(base, RS::LIGHT_PARAM_SIZE);
-				if (angular_diameter > 0.0) {
-					angular_diameter = Math::tan(Math::deg_to_rad(angular_diameter));
-				} else {
-					angular_diameter = 0.0;
-				}
-				sky_light_data.size = angular_diameter;
+				sky_light_data.size = Math::deg_to_rad(angular_diameter);
 				sky_globals.directional_light_count++;
 				if (sky_globals.directional_light_count >= sky_globals.max_directional_lights) {
 					break;

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1093,15 +1093,7 @@ void SkyRD::setup_sky(const RenderDataRD *p_render_data, const Size2i p_screen_s
 				sky_light_data.enabled = true;
 
 				float angular_diameter = light_storage->light_get_param(base, RS::LIGHT_PARAM_SIZE);
-				if (angular_diameter > 0.0) {
-					// I know tan(0) is 0, but let's not risk it with numerical precision.
-					// Technically this will keep expanding until reaching the sun, but all we care about
-					// is expanding until we reach the radius of the near plane. There can't be more occluders than that.
-					angular_diameter = Math::tan(Math::deg_to_rad(angular_diameter));
-				} else {
-					angular_diameter = 0.0;
-				}
-				sky_light_data.size = angular_diameter;
+				sky_light_data.size = Math::deg_to_rad(angular_diameter);
 				sky_scene_state.ubo.directional_light_count++;
 				if (sky_scene_state.ubo.directional_light_count >= sky_scene_state.max_directional_lights) {
 					break;


### PR DESCRIPTION
This fixes an unreported bug in sky shaders that I noticed while doing some optimization work. 

We are using the tangent of the angular diameter instead of the angular diameter in sky shaders. This code was copied and pasted from the scene shader which uses it for calculating size for shadows:

https://github.com/godotengine/godot/blob/b0655dc86f096b3496a9ab5b18965676d4fb35ba/servers/rendering/renderer_rd/storage_rd/light_storage.cpp#L675

It's worth noting that for the actual light size we use the cosine offset:

https://github.com/godotengine/godot/blob/b0655dc86f096b3496a9ab5b18965676d4fb35ba/servers/rendering/renderer_rd/storage_rd/light_storage.cpp#L664

This flew under the radar for so long since tan is nearly linear at small values. See the below clip from Desmos (tangent is green, linear x is blue):

<img width="485" alt="Screenshot 2025-01-23 at 5 35 21 PM" src="https://github.com/user-attachments/assets/53325bfa-8e61-431a-8ad0-125717a6c403" />

The values don't really diverge much until you reach around 0.3 (about 17 degrees), and don't become problematic under you reach around 30 degrees which is a very extreme size for the sun, so it makes sense that no one has noticed this issue.
