### PR TITLE
Use "literal" term where appropriate in shader language internals and in error messages.

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -573,7 +573,7 @@ Variant ShaderData::get_default_parameter(const StringName &p_parameter) const {
 	if (uniforms.has(p_parameter)) {
 		ShaderLanguage::ShaderNode::Uniform uniform = uniforms[p_parameter];
 		Vector<ShaderLanguage::Scalar> default_value = uniform.default_value;
-		return ShaderLanguage::constant_value_to_variant(default_value, uniform.type, uniform.array_size, uniform.hint);
+		return ShaderLanguage::literal_value_to_variant(default_value, uniform.type, uniform.array_size, uniform.hint);
 	}
 	return Variant();
 }
@@ -626,7 +626,7 @@ void ShaderData::get_instance_param_list(List<RendererMaterialStorage::InstanceS
 		p.info = ShaderLanguage::uniform_to_property_info(E.value);
 		p.info.name = E.key; //supply name
 		p.index = E.value.instance_index;
-		p.default_value = ShaderLanguage::constant_value_to_variant(E.value.default_value, E.value.type, E.value.array_size, E.value.hint);
+		p.default_value = ShaderLanguage::literal_value_to_variant(E.value.default_value, E.value.type, E.value.array_size, E.value.hint);
 		p_param_list->push_back(p);
 	}
 }

--- a/servers/rendering/dummy/storage/material_storage.cpp
+++ b/servers/rendering/dummy/storage/material_storage.cpp
@@ -275,7 +275,7 @@ void MaterialStorage::material_get_instance_shader_parameters(RID p_material, Li
 			p.info = ShaderLanguage::uniform_to_property_info(E.value);
 			p.info.name = E.key; //supply name
 			p.index = E.value.instance_index;
-			p.default_value = ShaderLanguage::constant_value_to_variant(E.value.default_value, E.value.type, E.value.array_size, E.value.hint);
+			p.default_value = ShaderLanguage::literal_value_to_variant(E.value.default_value, E.value.type, E.value.array_size, E.value.hint);
 			r_parameters->push_back(p);
 		}
 	}

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -569,7 +569,7 @@ Variant MaterialStorage::ShaderData::get_default_parameter(const StringName &p_p
 	if (uniforms.has(p_parameter)) {
 		ShaderLanguage::ShaderNode::Uniform uniform = uniforms[p_parameter];
 		Vector<ShaderLanguage::Scalar> default_value = uniform.default_value;
-		return ShaderLanguage::constant_value_to_variant(default_value, uniform.type, uniform.array_size, uniform.hint);
+		return ShaderLanguage::literal_value_to_variant(default_value, uniform.type, uniform.array_size, uniform.hint);
 	}
 	return Variant();
 }
@@ -622,7 +622,7 @@ void MaterialStorage::ShaderData::get_instance_param_list(List<RendererMaterialS
 		p.info = ShaderLanguage::uniform_to_property_info(E.value);
 		p.info.name = E.key; //supply name
 		p.index = E.value.instance_index;
-		p.default_value = ShaderLanguage::constant_value_to_variant(E.value.default_value, E.value.type, E.value.array_size, E.value.hint);
+		p.default_value = ShaderLanguage::literal_value_to_variant(E.value.default_value, E.value.type, E.value.array_size, E.value.hint);
 		p_param_list->push_back(p);
 	}
 }

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -1086,28 +1086,28 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 			}
 
 		} break;
-		case SL::Node::NODE_TYPE_CONSTANT: {
-			SL::ConstantNode *cnode = (SL::ConstantNode *)p_node;
+		case SL::Node::NODE_TYPE_LITERAL: {
+			SL::LiteralNode *lnode = (SL::LiteralNode *)p_node;
 
-			if (cnode->array_size == 0) {
-				return get_constant_text(cnode->datatype, cnode->values);
+			if (lnode->array_size == 0) {
+				return get_constant_text(lnode->datatype, lnode->values);
 			} else {
-				if (cnode->get_datatype() == SL::TYPE_STRUCT) {
-					code += _mkid(cnode->struct_name);
+				if (lnode->get_datatype() == SL::TYPE_STRUCT) {
+					code += _mkid(lnode->struct_name);
 				} else {
-					code += _typestr(cnode->datatype);
+					code += _typestr(lnode->datatype);
 				}
 				code += "[";
-				code += itos(cnode->array_size);
+				code += itos(lnode->array_size);
 				code += "]";
 				code += "(";
-				for (int i = 0; i < cnode->array_size; i++) {
+				for (int i = 0; i < lnode->array_size; i++) {
 					if (i > 0) {
 						code += ",";
 					} else {
 						code += "";
 					}
-					code += _dump_node_code(cnode->array_declarations[0].initializer[i], p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
+					code += _dump_node_code(lnode->array_declarations[0].initializer[i], p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
 				}
 				code += ")";
 			}

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -57,10 +57,10 @@ public:
 		TK_IDENTIFIER,
 		TK_TRUE,
 		TK_FALSE,
-		TK_FLOAT_CONSTANT,
-		TK_INT_CONSTANT,
-		TK_UINT_CONSTANT,
-		TK_STRING_CONSTANT,
+		TK_FLOAT_LITERAL,
+		TK_INT_LITERAL,
+		TK_UINT_LITERAL,
+		TK_STRING_LITERAL,
 		TK_TYPE_VOID,
 		TK_TYPE_BOOL,
 		TK_TYPE_BVEC2,
@@ -374,7 +374,7 @@ public:
 			NODE_TYPE_BLOCK,
 			NODE_TYPE_VARIABLE,
 			NODE_TYPE_VARIABLE_DECLARATION,
-			NODE_TYPE_CONSTANT,
+			NODE_TYPE_LITERAL,
 			NODE_TYPE_OPERATOR,
 			NODE_TYPE_CONTROL_FLOW,
 			NODE_TYPE_MEMBER,
@@ -494,7 +494,7 @@ public:
 				Node(NODE_TYPE_ARRAY_CONSTRUCT) {}
 	};
 
-	struct ConstantNode : public Node {
+	struct LiteralNode : public Node {
 		DataType datatype = TYPE_VOID;
 		String struct_name = "";
 		int array_size = 0;
@@ -509,8 +509,8 @@ public:
 			return values;
 		}
 
-		ConstantNode() :
-				Node(NODE_TYPE_CONSTANT) {}
+		LiteralNode() :
+				Node(NODE_TYPE_LITERAL) {}
 	};
 
 	struct FunctionNode;
@@ -549,7 +549,7 @@ public:
 		bool use_op_eval = true;
 
 		DataType expected_type = TYPE_VOID;
-		HashSet<int> constants;
+		HashSet<int> literals;
 
 		BlockNode() :
 				Node(NODE_TYPE_BLOCK) {}
@@ -788,10 +788,10 @@ public:
 	struct Token {
 		TokenType type;
 		StringName text;
-		double constant;
+		double literal;
 		uint16_t line;
-		bool is_integer_constant() const {
-			return type == TK_INT_CONSTANT || type == TK_UINT_CONSTANT;
+		bool is_integer_literal() const {
+			return type == TK_INT_LITERAL || type == TK_UINT_LITERAL;
 		}
 	};
 
@@ -817,13 +817,13 @@ public:
 	static bool is_token_operator_assign(TokenType p_type);
 	static bool is_token_hint(TokenType p_type);
 
-	static bool convert_constant(ConstantNode *p_constant, DataType p_to_type, Scalar *p_value = nullptr);
+	static bool convert_literal(LiteralNode *p_literal, DataType p_to_type, Scalar *p_value = nullptr);
 	static DataType get_scalar_type(DataType p_type);
 	static int get_cardinality(DataType p_type);
 	static bool is_scalar_type(DataType p_type);
 	static bool is_float_type(DataType p_type);
 	static bool is_sampler_type(DataType p_type);
-	static Variant constant_value_to_variant(const Vector<Scalar> &p_value, DataType p_type, int p_array_size, ShaderLanguage::ShaderNode::Uniform::Hint p_hint = ShaderLanguage::ShaderNode::Uniform::HINT_NONE);
+	static Variant literal_value_to_variant(const Vector<Scalar> &p_value, DataType p_type, int p_array_size, ShaderLanguage::ShaderNode::Uniform::Hint p_hint = ShaderLanguage::ShaderNode::Uniform::HINT_NONE);
 	static PropertyInfo uniform_to_property_info(const ShaderNode::Uniform &p_uniform);
 	static uint32_t get_datatype_size(DataType p_type);
 	static uint32_t get_datatype_component_count(DataType p_type);
@@ -1087,7 +1087,7 @@ private:
 
 	IdentifierType last_type = IDENTIFIER_MAX;
 
-	bool _find_identifier(const BlockNode *p_block, bool p_allow_reassign, const FunctionInfo &p_function_info, const StringName &p_identifier, DataType *r_data_type = nullptr, IdentifierType *r_type = nullptr, bool *r_is_const = nullptr, int *r_array_size = nullptr, StringName *r_struct_name = nullptr, Vector<Scalar> *r_constant_values = nullptr);
+	bool _find_identifier(const BlockNode *p_block, bool p_allow_reassign, const FunctionInfo &p_function_info, const StringName &p_identifier, DataType *r_data_type = nullptr, IdentifierType *r_type = nullptr, bool *r_is_const = nullptr, int *r_array_size = nullptr, StringName *r_struct_name = nullptr, Vector<Scalar> *r_literal_values = nullptr);
 #ifdef DEBUG_ENABLED
 	void _parse_used_identifier(const StringName &p_identifier, IdentifierType p_type, const StringName &p_function);
 #endif // DEBUG_ENABLED


### PR DESCRIPTION


Previously we were using "constant" to describe all instances of immutable declarations, whether that was an inline literal or an actual declared constant variable. This lack of disambiguation also resulted in some misleading error messages, ie: "expected integer constant" where only a literal is actually valid (and passing an actual constant like PI would fail with that exact error message).

This also improves a few error messages that only stated the expectation of an integer constant when it was more appropriate to say an integer OR float literal. This was originally brought up here: https://github.com/godotengine/godot/issues/101926

If this gets a green light I'll also take a stab at shoring up the docs to see if there's improvements to be made around "constant" vs "literal".

Before:
![Godot_v4 4-beta1_win64_Cq0W3xbX6Z](https://github.com/user-attachments/assets/43dba1ff-3f53-43de-b18a-a402592ddf54)

After:
![godot windows editor dev x86_64_MLxbNq5qr4](https://github.com/user-attachments/assets/1731c45c-ab99-46fb-abc1-94b3860cbe54)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
