### PR TITLE
[DisplayServer] Decouple `show_window(MAIN_WINDOW_ID)` from `DisplayServer` constructor, update project manager size/position after DS init.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7004,7 +7004,7 @@ EditorNode::EditorNode() {
 		switch (display_scale) {
 			case 0:
 				// Try applying a suitable display scale automatically.
-				EditorScale::set_scale(EditorSettings::get_singleton()->get_auto_display_scale());
+				EditorScale::set_scale(EditorSettings::get_auto_display_scale());
 				break;
 			case 1:
 				EditorScale::set_scale(0.75);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1816,7 +1816,7 @@ String EditorSettings::get_editor_layouts_config() const {
 	return EditorPaths::get_singleton()->get_config_dir().path_join("editor_layouts.cfg");
 }
 
-float EditorSettings::get_auto_display_scale() const {
+float EditorSettings::get_auto_display_scale() {
 #ifdef LINUXBSD_ENABLED
 	if (DisplayServer::get_singleton()->get_name() == "Wayland") {
 		float main_window_scale = DisplayServer::get_singleton()->screen_get_scale(DisplayServer::SCREEN_OF_MAIN_WINDOW);

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -191,7 +191,7 @@ public:
 
 	Vector<String> get_script_templates(const String &p_extension, const String &p_custom_path = String());
 	String get_editor_layouts_config() const;
-	float get_auto_display_scale() const;
+	static float get_auto_display_scale();
 
 	void _add_shortcut_default(const String &p_name, const Ref<Shortcut> &p_shortcut);
 	void add_shortcut(const String &p_name, const Ref<Shortcut> &p_shortcut);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -149,9 +149,8 @@ void ProjectManager::_build_icon_type_cache(Ref<Theme> p_theme) {
 
 // Main layout.
 
-void ProjectManager::_update_size_limits(bool p_custom_res) {
+void ProjectManager::_update_size_limits() {
 	const Size2 minimum_size = Size2(720, 450) * EDSCALE;
-	const Size2 default_size = Size2(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT) * EDSCALE;
 
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
 	Window *w = Object::cast_to<Window>(SceneTree::get_singleton()->get_root());
@@ -159,12 +158,6 @@ void ProjectManager::_update_size_limits(bool p_custom_res) {
 		// Calling Window methods this early doesn't sync properties with DS.
 		w->set_min_size(minimum_size);
 		DisplayServer::get_singleton()->window_set_min_size(minimum_size);
-		if (!p_custom_res) {
-			// Only set window size if it currently matches the default, which is defined in `main/main.cpp`.
-			// This allows CLI arguments to override the window size.
-			w->set_size(default_size);
-			DisplayServer::get_singleton()->window_set_size(default_size);
-		}
 	}
 	Size2 real_size = DisplayServer::get_singleton()->window_get_size();
 
@@ -174,7 +167,6 @@ void ProjectManager::_update_size_limits(bool p_custom_res) {
 		Vector2i window_position;
 		window_position.x = screen_rect.position.x + (screen_rect.size.x - real_size.x) / 2;
 		window_position.y = screen_rect.position.y + (screen_rect.size.y - real_size.y) / 2;
-		DisplayServer::get_singleton()->window_set_position(window_position);
 
 		// Limit popup menus to prevent unusably long lists.
 		// We try to set it to half the screen resolution, but no smaller than the minimum window size.
@@ -1159,7 +1151,7 @@ void ProjectManager::_titlebar_resized() {
 
 // Object methods.
 
-ProjectManager::ProjectManager(bool p_custom_res) {
+ProjectManager::ProjectManager() {
 	singleton = this;
 
 	// Turn off some servers we aren't going to be using in the Project Manager.
@@ -1187,7 +1179,7 @@ ProjectManager::ProjectManager(bool p_custom_res) {
 		switch (display_scale) {
 			case 0:
 				// Try applying a suitable display scale automatically.
-				EditorScale::set_scale(EditorSettings::get_singleton()->get_auto_display_scale());
+				EditorScale::set_scale(EditorSettings::get_auto_display_scale());
 				break;
 			case 1:
 				EditorScale::set_scale(0.75);
@@ -1745,7 +1737,7 @@ ProjectManager::ProjectManager(bool p_custom_res) {
 		title_bar->connect(SceneStringName(item_rect_changed), callable_mp(this, &ProjectManager::_titlebar_resized));
 	}
 
-	_update_size_limits(p_custom_res);
+	_update_size_limits();
 }
 
 ProjectManager::~ProjectManager() {

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -69,7 +69,7 @@ class ProjectManager : public Control {
 
 	Ref<Theme> theme;
 
-	void _update_size_limits(bool p_custom_res);
+	void _update_size_limits();
 	void _update_theme(bool p_skip_creation = false);
 	void _titlebar_resized();
 
@@ -261,6 +261,6 @@ public:
 
 	void add_new_tag(const String &p_tag);
 
-	ProjectManager(bool p_custom_res);
+	ProjectManager();
 	~ProjectManager();
 };

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -228,6 +228,12 @@ static bool init_use_custom_pos = false;
 static bool init_use_custom_screen = false;
 static Vector2 init_custom_pos;
 static int64_t init_embed_parent_window_id = 0;
+#ifdef TOOLS_ENABLED
+static bool init_display_scale_found = false;
+static int init_display_scale = 0;
+static float init_custom_scale = 1.0;
+static bool init_expand_to_title = false;
+#endif
 static bool use_custom_res = true;
 static bool force_res = false;
 
@@ -2874,8 +2880,14 @@ Error Main::setup2(bool p_show_boot_logo) {
 									restore_editor_window_layout = value.operator int() == EditorSettings::InitialScreen::INITIAL_SCREEN_AUTO;
 								}
 							}
-
-							if (!prefer_wayland_found && assign == "run/platforms/linuxbsd/prefer_wayland") {
+							if (assign == "interface/editor/expand_to_title") {
+								init_expand_to_title = value;
+							} else if (assign == "interface/editor/display_scale") {
+								init_display_scale = value;
+								init_display_scale_found = true;
+							} else if (assign == "interface/editor/custom_display_scale") {
+								init_custom_scale = value;
+							} else if (!prefer_wayland_found && assign == "run/platforms/linuxbsd/prefer_wayland") {
 								prefer_wayland = value;
 								prefer_wayland_found = true;
 							}
@@ -3031,6 +3043,12 @@ Error Main::setup2(bool p_show_boot_logo) {
 			window_flags = DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
 		}
 
+#ifdef TOOLS_ENABLED
+		if ((project_manager || editor) && init_expand_to_title) {
+			window_flags |= DisplayServer::WINDOW_FLAG_EXTEND_TO_TITLE_BIT;
+		}
+#endif
+
 		// rendering_driver now held in static global String in main and initialized in setup()
 		Error err;
 		display_server = DisplayServer::create(display_driver_idx, rendering_driver, window_mode, window_vsync_mode, window_flags, window_position, window_size, init_screen, context, init_embed_parent_window_id, err);
@@ -3081,6 +3099,48 @@ Error Main::setup2(bool p_show_boot_logo) {
 			}
 
 			return err;
+		}
+
+#ifdef TOOLS_ENABLED
+		if (project_manager && init_display_scale_found) {
+			float ui_scale = init_custom_scale;
+			switch (init_display_scale) {
+				case 0:
+					ui_scale = EditorSettings::get_auto_display_scale();
+					break;
+				case 1:
+					ui_scale = 0.75;
+					break;
+				case 2:
+					ui_scale = 1.0;
+					break;
+				case 3:
+					ui_scale = 1.25;
+					break;
+				case 4:
+					ui_scale = 1.5;
+					break;
+				case 5:
+					ui_scale = 1.75;
+					break;
+				case 6:
+					ui_scale = 2.0;
+					break;
+				default:
+					break;
+			}
+			if (!(force_res || use_custom_res)) {
+				display_server->window_set_size(window_size * ui_scale, DisplayServer::MAIN_WINDOW_ID);
+			}
+			if (display_server->has_feature(DisplayServer::FEATURE_SUBWINDOWS)) { // Note: add "&& !display_server->has_feature(DisplayServer::FEATURE_SELF_FITTING_WINDOWS)" when Wayland multi-window support is merged.
+				Size2 real_size = DisplayServer::get_singleton()->window_get_size();
+				Rect2i scr_rect = display_server->screen_get_usable_rect(init_screen);
+				display_server->window_set_position(scr_rect.position + (scr_rect.size - real_size) / 2, DisplayServer::MAIN_WINDOW_ID);
+			}
+		}
+#endif
+		if (display_server->has_feature(DisplayServer::FEATURE_SUBWINDOWS)) {
+			display_server->show_window(DisplayServer::MAIN_WINDOW_ID);
 		}
 
 		if (display_server->has_feature(DisplayServer::FEATURE_ORIENTATION)) {
@@ -4350,7 +4410,7 @@ int Main::start() {
 				translation_server->get_editor_domain()->set_pseudolocalization_enabled(true);
 			}
 
-			ProjectManager *pmanager = memnew(ProjectManager(force_res || use_custom_res));
+			ProjectManager *pmanager = memnew(ProjectManager);
 			ProgressDialog *progress_dialog = memnew(ProgressDialog);
 			pmanager->add_child(progress_dialog);
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2345,6 +2345,7 @@ void DisplayServerX11::window_set_position(const Point2i &p_position, WindowID p
 		return;
 	}
 
+	wd.position = p_position;
 	int x = 0;
 	int y = 0;
 	if (!window_get_flag(WINDOW_FLAG_BORDERLESS, p_window)) {
@@ -6957,7 +6958,6 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 			window_set_flag(WindowFlags(i), true, main_window);
 		}
 	}
-	show_window(main_window);
 
 #if defined(RD_ENABLED)
 	if (rendering_context) {

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3902,7 +3902,6 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 			window_set_flag(WindowFlags(i), true, main_window);
 		}
 	}
-	show_window(MAIN_WINDOW_ID);
 	force_process_and_drop_events();
 
 #if defined(GLES3_ENABLED)

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -7055,7 +7055,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 		}
 	}
 
-	show_window(MAIN_WINDOW_ID);
+	windows[MAIN_WINDOW_ID].initialized = true;
 
 #if defined(RD_ENABLED)
 	if (rendering_context) {


### PR DESCRIPTION
Should fix project manager window jumping and changing size during start.

- Decouples `show_window(MAIN_WINDOW_ID)` from `DisplayServer` constructor.
- Applies `EDSCALE` to project manager window between `DisplayServer` init/main window creation (since functional `DisplayServer` to determine scale) and `show_window(MAIN_WINDOW_ID)`.
- Reverts https://github.com/godotengine/godot/pull/101576 changes (no longer needed).

Tested on:
- [x] macOS
- [x] Windows 
- [x] Linux/X11 (still have some jumping, not sure if fixable, seems like X11 can't get decoration size before window is fully shown).
- [x] Linux/Wayland (only size adjustment).