### PR TITLE
Wayland: Check custom cursor resource reference for cache invalidation

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1033,7 +1033,7 @@ void DisplayServerWayland::cursor_set_custom_image(const Ref<Resource> &p_cursor
 		HashMap<CursorShape, CustomCursor>::Iterator cursor_c = custom_cursors.find(p_shape);
 
 		if (cursor_c) {
-			if (cursor_c->value.rid == p_cursor->get_rid() && cursor_c->value.hotspot == p_hotspot) {
+			if (cursor_c->value.resource == p_cursor && cursor_c->value.hotspot == p_hotspot) {
 				// We have a cached cursor. Nice.
 				wayland_thread.cursor_set_shape(p_shape);
 				return;
@@ -1049,7 +1049,7 @@ void DisplayServerWayland::cursor_set_custom_image(const Ref<Resource> &p_cursor
 
 		CustomCursor &cursor = custom_cursors[p_shape];
 
-		cursor.rid = p_cursor->get_rid();
+		cursor.resource = p_cursor;
 		cursor.hotspot = p_hotspot;
 
 		wayland_thread.cursor_shape_set_custom_image(p_shape, image, p_hotspot);

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -101,7 +101,7 @@ class DisplayServerWayland : public DisplayServer {
 	};
 
 	struct CustomCursor {
-		RID rid;
+		Ref<Resource> resource;
 		Point2i hotspot;
 	};
 


### PR DESCRIPTION
Fixes #101929.

Images don't have RIDs and this way of checking stuff broke the cursor cache. Let's do like all other platforms and check the resource reference instead.