### PR TITLE
Git-ignore built `Godot.app` package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,6 +363,7 @@ cpp.hint
 # macOS
 .DS_Store
 __MACOSX
+Godot.app
 
 # Windows
 # https://github.com/github/gitignore/blob/main/Global/Windows.gitignore


### PR DESCRIPTION
Following the "compiling for Mac" tutorial, one will eventually end with a Godot.app package inside the repo folder. To prevent it from being tracked by git,  I added it to .gitignore. 

Building Godot from the source will result in dozens of untracked/unstaged new files/changes as an app package is a folder. This entry also prevents git from seeing all files inside the "Godot.app" folder.