### PR TITLE
Add DDS image load and save functionality

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -89,11 +89,13 @@ SavePNGFunc Image::save_png_func = nullptr;
 SaveJPGFunc Image::save_jpg_func = nullptr;
 SaveEXRFunc Image::save_exr_func = nullptr;
 SaveWebPFunc Image::save_webp_func = nullptr;
+SaveDDSFunc Image::save_dds_func = nullptr;
 
 SavePNGBufferFunc Image::save_png_buffer_func = nullptr;
 SaveJPGBufferFunc Image::save_jpg_buffer_func = nullptr;
 SaveEXRBufferFunc Image::save_exr_buffer_func = nullptr;
 SaveWebPBufferFunc Image::save_webp_buffer_func = nullptr;
+SaveDDSBufferFunc Image::save_dds_buffer_func = nullptr;
 
 // External loader function pointers.
 
@@ -105,6 +107,7 @@ ImageMemLoadFunc Image::_tga_mem_loader_func = nullptr;
 ImageMemLoadFunc Image::_bmp_mem_loader_func = nullptr;
 ScalableImageMemLoadFunc Image::_svg_scalable_mem_loader_func = nullptr;
 ImageMemLoadFunc Image::_ktx_mem_loader_func = nullptr;
+ImageMemLoadFunc Image::_dds_mem_loader_func = nullptr;
 
 // External VRAM compression function pointers.
 
@@ -2603,6 +2606,21 @@ Vector<uint8_t> Image::save_exr_to_buffer(bool p_grayscale) const {
 	return save_exr_buffer_func(Ref<Image>((Image *)this), p_grayscale);
 }
 
+Error Image::save_dds(const String &p_path) const {
+	if (save_dds_func == nullptr) {
+		return ERR_UNAVAILABLE;
+	}
+
+	return save_dds_func(p_path, Ref<Image>((Image *)this));
+}
+
+Vector<uint8_t> Image::save_dds_to_buffer() const {
+	if (save_dds_buffer_func == nullptr) {
+		return Vector<uint8_t>();
+	}
+	return save_dds_buffer_func(Ref<Image>((Image *)this));
+}
+
 Error Image::save_webp(const String &p_path, const bool p_lossy, const float p_quality) const {
 	if (save_webp_func == nullptr) {
 		return ERR_UNAVAILABLE;
@@ -3524,6 +3542,9 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save_jpg_to_buffer", "quality"), &Image::save_jpg_to_buffer, DEFVAL(0.75));
 	ClassDB::bind_method(D_METHOD("save_exr", "path", "grayscale"), &Image::save_exr, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("save_exr_to_buffer", "grayscale"), &Image::save_exr_to_buffer, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("save_dds", "path"), &Image::save_dds);
+	ClassDB::bind_method(D_METHOD("save_dds_to_buffer"), &Image::save_dds_to_buffer);
+
 	ClassDB::bind_method(D_METHOD("save_webp", "path", "lossy", "quality"), &Image::save_webp, DEFVAL(false), DEFVAL(0.75f));
 	ClassDB::bind_method(D_METHOD("save_webp_to_buffer", "lossy", "quality"), &Image::save_webp_to_buffer, DEFVAL(false), DEFVAL(0.75f));
 
@@ -3577,6 +3598,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("load_tga_from_buffer", "buffer"), &Image::load_tga_from_buffer);
 	ClassDB::bind_method(D_METHOD("load_bmp_from_buffer", "buffer"), &Image::load_bmp_from_buffer);
 	ClassDB::bind_method(D_METHOD("load_ktx_from_buffer", "buffer"), &Image::load_ktx_from_buffer);
+	ClassDB::bind_method(D_METHOD("load_dds_from_buffer", "buffer"), &Image::load_dds_from_buffer);
 
 	ClassDB::bind_method(D_METHOD("load_svg_from_buffer", "buffer", "scale"), &Image::load_svg_from_buffer, DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("load_svg_from_string", "svg_str", "scale"), &Image::load_svg_from_string, DEFVAL(1.0));
@@ -4070,6 +4092,14 @@ Error Image::load_bmp_from_buffer(const Vector<uint8_t> &p_array) {
 			ERR_UNAVAILABLE,
 			"The BMP module isn't enabled. Recompile the Godot editor or export template binary with the `module_bmp_enabled=yes` SCons option.");
 	return _load_from_buffer(p_array, _bmp_mem_loader_func);
+}
+
+Error Image::load_dds_from_buffer(const Vector<uint8_t> &p_array) {
+	ERR_FAIL_NULL_V_MSG(
+			_dds_mem_loader_func,
+			ERR_UNAVAILABLE,
+			"The DDS module isn't enabled. Recompile the Godot editor or export template binary with the `module_dds_enabled=yes` SCons option.");
+	return _load_from_buffer(p_array, _dds_mem_loader_func);
 }
 
 Error Image::load_svg_from_buffer(const Vector<uint8_t> &p_array, float scale) {

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -58,6 +58,9 @@ typedef Vector<uint8_t> (*SaveWebPBufferFunc)(const Ref<Image> &p_img, const boo
 typedef Error (*SaveEXRFunc)(const String &p_path, const Ref<Image> &p_img, bool p_grayscale);
 typedef Vector<uint8_t> (*SaveEXRBufferFunc)(const Ref<Image> &p_img, bool p_grayscale);
 
+typedef Error (*SaveDDSFunc)(const String &p_path, const Ref<Image> &p_img);
+typedef Vector<uint8_t> (*SaveDDSBufferFunc)(const Ref<Image> &p_img);
+
 class Image : public Resource {
 	GDCLASS(Image, Resource);
 
@@ -185,10 +188,12 @@ public:
 	static SaveJPGFunc save_jpg_func;
 	static SaveEXRFunc save_exr_func;
 	static SaveWebPFunc save_webp_func;
+	static SaveDDSFunc save_dds_func;
 	static SavePNGBufferFunc save_png_buffer_func;
 	static SaveEXRBufferFunc save_exr_buffer_func;
 	static SaveJPGBufferFunc save_jpg_buffer_func;
 	static SaveWebPBufferFunc save_webp_buffer_func;
+	static SaveDDSBufferFunc save_dds_buffer_func;
 
 	// External loader function pointers.
 
@@ -200,6 +205,7 @@ public:
 	static ImageMemLoadFunc _bmp_mem_loader_func;
 	static ScalableImageMemLoadFunc _svg_scalable_mem_loader_func;
 	static ImageMemLoadFunc _ktx_mem_loader_func;
+	static ImageMemLoadFunc _dds_mem_loader_func;
 
 	// External VRAM compression function pointers.
 
@@ -333,9 +339,11 @@ public:
 	static Ref<Image> load_from_file(const String &p_path);
 	Error save_png(const String &p_path) const;
 	Error save_jpg(const String &p_path, float p_quality = 0.75) const;
+	Error save_dds(const String &p_path) const;
 	Vector<uint8_t> save_png_to_buffer() const;
 	Vector<uint8_t> save_jpg_to_buffer(float p_quality = 0.75) const;
 	Vector<uint8_t> save_exr_to_buffer(bool p_grayscale = false) const;
+	Vector<uint8_t> save_dds_to_buffer() const;
 	Error save_exr(const String &p_path, bool p_grayscale = false) const;
 	Error save_webp(const String &p_path, const bool p_lossy = false, const float p_quality = 0.75f) const;
 	Vector<uint8_t> save_webp_to_buffer(const bool p_lossy = false, const float p_quality = 0.75f) const;
@@ -402,6 +410,7 @@ public:
 	Error load_tga_from_buffer(const Vector<uint8_t> &p_array);
 	Error load_bmp_from_buffer(const Vector<uint8_t> &p_array);
 	Error load_ktx_from_buffer(const Vector<uint8_t> &p_array);
+	Error load_dds_from_buffer(const Vector<uint8_t> &p_array);
 
 	Error load_svg_from_buffer(const Vector<uint8_t> &p_array, float scale = 1.0);
 	Error load_svg_from_string(const String &p_svg_str, float scale = 1.0);

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -346,6 +346,14 @@
 				[b]Note:[/b] This method is only available in engine builds with the BMP module enabled. By default, the BMP module is enabled, but it can be disabled at build-time using the [code]module_bmp_enabled=no[/code] SCons option.
 			</description>
 		</method>
+		<method name="load_dds_from_buffer">
+			<return type="int" enum="Error" />
+			<param index="0" name="buffer" type="PackedByteArray" />
+			<description>
+				Loads an image from the binary contents of a DDS file.
+				[b]Note:[/b] This method is only available in engine builds with the DDS module enabled. By default, the DDS module is enabled, but it can be disabled at build-time using the [code]module_dds_enabled=no[/code] SCons option.
+			</description>
+		</method>
 		<method name="load_from_file" qualifiers="static">
 			<return type="Image" />
 			<param index="0" name="path" type="String" />
@@ -456,6 +464,21 @@
 			<return type="void" />
 			<description>
 				Rotates the image by [code]180[/code] degrees. The width and height of the image must be greater than [code]1[/code].
+			</description>
+		</method>
+		<method name="save_dds" qualifiers="const">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Saves the image as a DDS (DirectDraw Surface) file to [param path]. DDS is a container format that can store textures in various compression formats, such as DXT1, DXT5, or BC7. This function will return [constant ERR_UNAVAILABLE] if Godot was compiled without the DDS module.
+				[b]Note:[/b] The DDS module may be disabled in certain builds, which means [method save_dds] will return [constant ERR_UNAVAILABLE] when it is called from an exported project.
+			</description>
+		</method>
+		<method name="save_dds_to_buffer" qualifiers="const">
+			<return type="PackedByteArray" />
+			<description>
+				Saves the image as a DDS (DirectDraw Surface) file to a byte array. DDS is a container format that can store textures in various compression formats, such as DXT1, DXT5, or BC7. This function will return an empty byte array if Godot was compiled without the DDS module.
+				[b]Note:[/b] The DDS module may be disabled in certain builds, which means [method save_dds_to_buffer] will return an empty byte array when it is called from an exported project.
 			</description>
 		</method>
 		<method name="save_exr" qualifiers="const">

--- a/modules/dds/dds_enums.h
+++ b/modules/dds/dds_enums.h
@@ -1,0 +1,203 @@
+/**************************************************************************/
+/*  dds_enums.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/image.h"
+
+#define PF_FOURCC(m_s) ((uint32_t)(((m_s)[3] << 24U) | ((m_s)[2] << 16U) | ((m_s)[1] << 8U) | ((m_s)[0])))
+
+// Reference: https://docs.microsoft.com/en-us/windows/win32/direct3ddds/dds-header
+
+enum {
+	DDS_MAGIC = 0x20534444,
+	DDS_HEADER_SIZE = 124,
+	DDS_PIXELFORMAT_SIZE = 32,
+
+	DDSD_PITCH = 0x00000008,
+	DDSD_LINEARSIZE = 0x00080000,
+	DDSD_MIPMAPCOUNT = 0x00020000,
+	DDSD_CAPS = 0x1,
+	DDSD_HEIGHT = 0x2,
+	DDSD_WIDTH = 0x4,
+	DDSD_PIXELFORMAT = 0x1000,
+	DDPF_ALPHAPIXELS = 0x00000001,
+	DDPF_ALPHAONLY = 0x00000002,
+	DDPF_FOURCC = 0x00000004,
+	DDPF_RGB = 0x00000040,
+	DDPF_RG_SNORM = 0x00080000,
+
+	DDSC2_CUBEMAP = 0x200,
+	DDSC2_VOLUME = 0x200000,
+
+	DX10D_1D = 2,
+	DX10D_2D = 3,
+	DX10D_3D = 4,
+};
+
+enum DDSFourCC {
+	DDFCC_DXT1 = PF_FOURCC("DXT1"),
+	DDFCC_DXT2 = PF_FOURCC("DXT2"),
+	DDFCC_DXT3 = PF_FOURCC("DXT3"),
+	DDFCC_DXT4 = PF_FOURCC("DXT4"),
+	DDFCC_DXT5 = PF_FOURCC("DXT5"),
+	DDFCC_ATI1 = PF_FOURCC("ATI1"),
+	DDFCC_BC4U = PF_FOURCC("BC4U"),
+	DDFCC_ATI2 = PF_FOURCC("ATI2"),
+	DDFCC_BC5U = PF_FOURCC("BC5U"),
+	DDFCC_A2XY = PF_FOURCC("A2XY"),
+	DDFCC_DX10 = PF_FOURCC("DX10"),
+	DDFCC_R16F = 111,
+	DDFCC_RG16F = 112,
+	DDFCC_RGBA16F = 113,
+	DDFCC_R32F = 114,
+	DDFCC_RG32F = 115,
+	DDFCC_RGBA32F = 116,
+};
+
+// Reference: https://learn.microsoft.com/en-us/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format
+enum DXGIFormat {
+	DXGI_R32G32B32A32_FLOAT = 2,
+	DXGI_R32G32B32_FLOAT = 6,
+	DXGI_R16G16B16A16_FLOAT = 10,
+	DXGI_R32G32_FLOAT = 16,
+	DXGI_R10G10B10A2_UNORM = 24,
+	DXGI_R8G8B8A8_UNORM = 28,
+	DXGI_R8G8B8A8_UNORM_SRGB = 29,
+	DXGI_R16G16_FLOAT = 34,
+	DXGI_R32_FLOAT = 41,
+	DXGI_R8G8_UNORM = 49,
+	DXGI_R16_FLOAT = 54,
+	DXGI_R8_UNORM = 61,
+	DXGI_A8_UNORM = 65,
+	DXGI_R9G9B9E5 = 67,
+	DXGI_BC1_UNORM = 71,
+	DXGI_BC1_UNORM_SRGB = 72,
+	DXGI_BC2_UNORM = 74,
+	DXGI_BC2_UNORM_SRGB = 75,
+	DXGI_BC3_UNORM = 77,
+	DXGI_BC3_UNORM_SRGB = 78,
+	DXGI_BC4_UNORM = 80,
+	DXGI_BC5_UNORM = 83,
+	DXGI_B5G6R5_UNORM = 85,
+	DXGI_B5G5R5A1_UNORM = 86,
+	DXGI_B8G8R8A8_UNORM = 87,
+	DXGI_BC6H_UF16 = 95,
+	DXGI_BC6H_SF16 = 96,
+	DXGI_BC7_UNORM = 98,
+	DXGI_BC7_UNORM_SRGB = 99,
+	DXGI_B4G4R4A4_UNORM = 115,
+};
+
+// The legacy bitmasked format names here represent the actual data layout in the files,
+// while their official names are flipped (e.g. RGBA8 layout is officially called ABGR8).
+enum DDSFormat {
+	DDS_DXT1,
+	DDS_DXT3,
+	DDS_DXT5,
+	DDS_ATI1,
+	DDS_ATI2,
+	DDS_BC6U,
+	DDS_BC6S,
+	DDS_BC7,
+	DDS_R16F,
+	DDS_RG16F,
+	DDS_RGBA16F,
+	DDS_R32F,
+	DDS_RG32F,
+	DDS_RGB32F,
+	DDS_RGBA32F,
+	DDS_RGB9E5,
+	DDS_RGB8,
+	DDS_RGBA8,
+	DDS_BGR8,
+	DDS_BGRA8,
+	DDS_BGR5A1,
+	DDS_BGR565,
+	DDS_B2GR3,
+	DDS_B2GR3A8,
+	DDS_BGR10A2,
+	DDS_RGB10A2,
+	DDS_BGRA4,
+	DDS_LUMINANCE,
+	DDS_LUMINANCE_ALPHA,
+	DDS_LUMINANCE_ALPHA_4,
+	DDS_MAX
+};
+
+enum DDSType {
+	DDST_2D = 1,
+	DDST_CUBEMAP,
+	DDST_3D,
+
+	DDST_TYPE_MASK = 0x7F,
+	DDST_ARRAY = 0x80,
+};
+
+struct DDSFormatInfo {
+	const char *name = nullptr;
+	bool compressed = false;
+	uint32_t divisor = 0;
+	uint32_t block_size = 0;
+	Image::Format format = Image::Format::FORMAT_BPTC_RGBA;
+};
+
+static const DDSFormatInfo dds_format_info[DDS_MAX] = {
+	{ "DXT1/BC1", true, 4, 8, Image::FORMAT_DXT1 },
+	{ "DXT2/DXT3/BC2", true, 4, 16, Image::FORMAT_DXT3 },
+	{ "DXT4/DXT5/BC3", true, 4, 16, Image::FORMAT_DXT5 },
+	{ "ATI1/BC4", true, 4, 8, Image::FORMAT_RGTC_R },
+	{ "ATI2/A2XY/BC5", true, 4, 16, Image::FORMAT_RGTC_RG },
+	{ "BC6UF", true, 4, 16, Image::FORMAT_BPTC_RGBFU },
+	{ "BC6SF", true, 4, 16, Image::FORMAT_BPTC_RGBF },
+	{ "BC7", true, 4, 16, Image::FORMAT_BPTC_RGBA },
+	{ "R16F", false, 1, 2, Image::FORMAT_RH },
+	{ "RG16F", false, 1, 4, Image::FORMAT_RGH },
+	{ "RGBA16F", false, 1, 8, Image::FORMAT_RGBAH },
+	{ "R32F", false, 1, 4, Image::FORMAT_RF },
+	{ "RG32F", false, 1, 8, Image::FORMAT_RGF },
+	{ "RGB32F", false, 1, 12, Image::FORMAT_RGBF },
+	{ "RGBA32F", false, 1, 16, Image::FORMAT_RGBAF },
+	{ "RGB9E5", false, 1, 4, Image::FORMAT_RGBE9995 },
+	{ "RGB8", false, 1, 3, Image::FORMAT_RGB8 },
+	{ "RGBA8", false, 1, 4, Image::FORMAT_RGBA8 },
+	{ "BGR8", false, 1, 3, Image::FORMAT_RGB8 },
+	{ "BGRA8", false, 1, 4, Image::FORMAT_RGBA8 },
+	{ "BGR5A1", false, 1, 2, Image::FORMAT_RGBA8 },
+	{ "BGR565", false, 1, 2, Image::FORMAT_RGB8 },
+	{ "B2GR3", false, 1, 1, Image::FORMAT_RGB8 },
+	{ "B2GR3A8", false, 1, 2, Image::FORMAT_RGBA8 },
+	{ "BGR10A2", false, 1, 4, Image::FORMAT_RGBA8 },
+	{ "RGB10A2", false, 1, 4, Image::FORMAT_RGBA8 },
+	{ "BGRA4", false, 1, 2, Image::FORMAT_RGBA8 },
+	{ "GRAYSCALE", false, 1, 1, Image::FORMAT_L8 },
+	{ "GRAYSCALE_ALPHA", false, 1, 2, Image::FORMAT_LA8 },
+	{ "GRAYSCALE_ALPHA_4", false, 1, 1, Image::FORMAT_LA8 },
+};

--- a/modules/dds/image_saver_dds.cpp
+++ b/modules/dds/image_saver_dds.cpp
@@ -1,0 +1,487 @@
+/**************************************************************************/
+/*  image_saver_dds.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "image_saver_dds.h"
+
+#include "dds_enums.h"
+
+#include "core/io/file_access.h"
+#include "core/io/stream_peer.h"
+
+Error save_dds(const String &p_path, const Ref<Image> &p_img) {
+	Vector<uint8_t> buffer = save_dds_buffer(p_img);
+
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE);
+	if (file.is_null()) {
+		return ERR_CANT_CREATE;
+	}
+
+	file->store_buffer(buffer.ptr(), buffer.size());
+
+	return OK;
+}
+
+enum DDSFormatType {
+	DDFT_BITMASK,
+	DDFT_FOURCC,
+	DDFT_DXGI,
+};
+
+DDSFormatType _dds_format_get_type(DDSFormat p_format) {
+	switch (p_format) {
+		case DDS_DXT1:
+		case DDS_DXT3:
+		case DDS_DXT5:
+		case DDS_ATI1:
+		case DDS_ATI2:
+		case DDS_R16F:
+		case DDS_RG16F:
+		case DDS_RGBA16F:
+		case DDS_R32F:
+		case DDS_RG32F:
+		case DDS_RGBA32F:
+			return DDFT_FOURCC;
+
+		case DDS_BC6S:
+		case DDS_BC6U:
+		case DDS_BC7:
+		case DDS_RGB9E5:
+		case DDS_RGB32F:
+			return DDFT_DXGI;
+
+		default:
+			return DDFT_BITMASK;
+	}
+}
+
+DDSFormat _image_format_to_dds_format(Image::Format p_image_format) {
+	switch (p_image_format) {
+		case Image::FORMAT_RGBAF: {
+			return DDS_RGBA32F;
+		}
+		case Image::FORMAT_RGBF: {
+			return DDS_RGB32F;
+		}
+		case Image::FORMAT_RGBAH: {
+			return DDS_RGBA16F;
+		}
+		case Image::FORMAT_RGF: {
+			return DDS_RG32F;
+		}
+		case Image::FORMAT_RGBA8: {
+			return DDS_RGBA8;
+		}
+		case Image::FORMAT_RGH: {
+			return DDS_RG16F;
+		}
+		case Image::FORMAT_RF: {
+			return DDS_R32F;
+		}
+		case Image::FORMAT_L8:
+		case Image::FORMAT_R8: {
+			return DDS_LUMINANCE;
+		}
+		case Image::FORMAT_RH: {
+			return DDS_R16F;
+		}
+		case Image::FORMAT_LA8:
+		case Image::FORMAT_RG8: {
+			return DDS_LUMINANCE_ALPHA;
+		}
+		case Image::FORMAT_RGBA4444: {
+			return DDS_BGRA4;
+		}
+		case Image::FORMAT_RGB565: {
+			return DDS_BGR565;
+		}
+		case Image::FORMAT_RGBE9995: {
+			return DDS_RGB9E5;
+		}
+		case Image::FORMAT_DXT1: {
+			return DDS_DXT1;
+		}
+		case Image::FORMAT_DXT3: {
+			return DDS_DXT3;
+		}
+		case Image::FORMAT_DXT5: {
+			return DDS_DXT5;
+		}
+		case Image::FORMAT_RGTC_R: {
+			return DDS_ATI1;
+		}
+		case Image::FORMAT_RGTC_RG: {
+			return DDS_ATI2;
+		}
+		case Image::FORMAT_RGB8: {
+			return DDS_RGB8;
+		}
+		case Image::FORMAT_BPTC_RGBFU: {
+			return DDS_BC6U;
+		}
+		case Image::FORMAT_BPTC_RGBF: {
+			return DDS_BC6S;
+		}
+		case Image::FORMAT_BPTC_RGBA: {
+			return DDS_BC7;
+		}
+		default: {
+			return DDS_MAX;
+		}
+	}
+}
+
+uint32_t _image_format_to_fourcc_format(Image::Format p_format) {
+	switch (p_format) {
+		case Image::FORMAT_DXT1:
+			return DDFCC_DXT1;
+		case Image::FORMAT_DXT3:
+			return DDFCC_DXT3;
+		case Image::FORMAT_DXT5:
+			return DDFCC_DXT5;
+		case Image::FORMAT_RGTC_R:
+			return DDFCC_ATI1;
+		case Image::FORMAT_RGTC_RG:
+			return DDFCC_ATI2;
+		case Image::FORMAT_RF:
+			return DDFCC_R32F;
+		case Image::FORMAT_RGF:
+			return DDFCC_RG32F;
+		case Image::FORMAT_RGBAF:
+			return DDFCC_RGBA32F;
+		case Image::FORMAT_RH:
+			return DDFCC_R16F;
+		case Image::FORMAT_RGH:
+			return DDFCC_RG16F;
+		case Image::FORMAT_RGBAH:
+			return DDFCC_RGBA16F;
+
+		default:
+			return 0;
+	}
+}
+
+uint32_t _image_format_to_dxgi_format(Image::Format p_format) {
+	switch (p_format) {
+		case Image::FORMAT_DXT1:
+			return DXGI_BC1_UNORM;
+		case Image::FORMAT_DXT3:
+			return DXGI_BC2_UNORM;
+		case Image::FORMAT_DXT5:
+			return DXGI_BC3_UNORM;
+		case Image::FORMAT_RGTC_R:
+			return DXGI_BC4_UNORM;
+		case Image::FORMAT_RGTC_RG:
+			return DXGI_BC5_UNORM;
+		case Image::FORMAT_BPTC_RGBFU:
+			return DXGI_BC6H_UF16;
+		case Image::FORMAT_BPTC_RGBF:
+			return DXGI_BC6H_SF16;
+		case Image::FORMAT_BPTC_RGBA:
+			return DXGI_BC7_UNORM;
+		case Image::FORMAT_RF:
+			return DXGI_R32_FLOAT;
+		case Image::FORMAT_RGF:
+			return DXGI_R32G32_FLOAT;
+		case Image::FORMAT_RGBF:
+			return DXGI_R32G32B32_FLOAT;
+		case Image::FORMAT_RGBAF:
+			return DXGI_R32G32B32A32_FLOAT;
+		case Image::FORMAT_RH:
+			return DXGI_R16_FLOAT;
+		case Image::FORMAT_RGH:
+			return DXGI_R16G16_FLOAT;
+		case Image::FORMAT_RGBAH:
+			return DXGI_R16G16B16A16_FLOAT;
+		case Image::FORMAT_RGBE9995:
+			return DXGI_R9G9B9E5;
+
+		default:
+			return 0;
+	}
+}
+
+void _get_dds_pixel_bitmask(Image::Format p_format, uint32_t &r_bit_count, uint32_t &r_red_mask, uint32_t &r_green_mask, uint32_t &r_blue_mask, uint32_t &r_alpha_mask) {
+	switch (p_format) {
+		case Image::FORMAT_R8:
+		case Image::FORMAT_L8: {
+			r_bit_count = 8;
+			r_red_mask = 0xff;
+			r_green_mask = 0;
+			r_blue_mask = 0;
+			r_alpha_mask = 0;
+		} break;
+		case Image::FORMAT_RG8:
+		case Image::FORMAT_LA8: {
+			r_bit_count = 16;
+			r_red_mask = 0xff;
+			r_green_mask = 0;
+			r_blue_mask = 0;
+			r_alpha_mask = 0xff00;
+		} break;
+		case Image::FORMAT_RGB8: {
+			// BGR8
+			r_bit_count = 24;
+			r_red_mask = 0xff0000;
+			r_green_mask = 0xff00;
+			r_blue_mask = 0xff;
+			r_alpha_mask = 0;
+		} break;
+		case Image::FORMAT_RGBA8: {
+			r_bit_count = 32;
+			r_red_mask = 0xff;
+			r_green_mask = 0xff00;
+			r_blue_mask = 0xff0000;
+			r_alpha_mask = 0xff000000;
+		} break;
+		case Image::FORMAT_RGBA4444: {
+			// BGRA4444
+			r_bit_count = 16;
+			r_red_mask = 0xf00;
+			r_green_mask = 0xf0;
+			r_blue_mask = 0xf;
+			r_alpha_mask = 0xf000;
+		} break;
+		case Image::FORMAT_RGB565: {
+			// BGR565
+			r_bit_count = 16;
+			r_red_mask = 0xf800;
+			r_green_mask = 0x7e0;
+			r_blue_mask = 0x1f;
+			r_alpha_mask = 0;
+		} break;
+
+		default: {
+			r_bit_count = 0;
+			r_red_mask = 0;
+			r_green_mask = 0;
+			r_blue_mask = 0;
+			r_alpha_mask = 0;
+		} break;
+	}
+}
+
+Vector<uint8_t> save_dds_buffer(const Ref<Image> &p_img) {
+	Ref<StreamPeerBuffer> stream_buffer;
+	stream_buffer.instantiate();
+
+	Ref<Image> image = p_img;
+
+	stream_buffer->put_32(DDS_MAGIC);
+	stream_buffer->put_32(DDS_HEADER_SIZE);
+
+	uint32_t flags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT | DDSD_PITCH | DDSD_LINEARSIZE;
+
+	if (image->has_mipmaps()) {
+		flags |= DDSD_MIPMAPCOUNT;
+	}
+
+	stream_buffer->put_32(flags);
+
+	uint32_t height = image->get_height();
+	stream_buffer->put_32(height);
+
+	uint32_t width = image->get_width();
+	stream_buffer->put_32(width);
+
+	DDSFormat dds_format = _image_format_to_dds_format(image->get_format());
+	const DDSFormatInfo &info = dds_format_info[dds_format];
+
+	uint32_t depth = 1; // Default depth for 2D textures
+
+	uint32_t pitch;
+	if (info.compressed) {
+		pitch = ((MAX(info.divisor, width) + info.divisor - 1) / info.divisor) * ((MAX(info.divisor, height) + info.divisor - 1) / info.divisor) * info.block_size;
+	} else {
+		pitch = width * info.block_size;
+	}
+
+	stream_buffer->put_32(pitch);
+	stream_buffer->put_32(depth);
+
+	uint32_t mipmaps = image->get_mipmap_count() + 1;
+	stream_buffer->put_32(mipmaps);
+
+	uint32_t reserved = 0;
+	for (int i = 0; i < 11; i++) {
+		stream_buffer->put_32(reserved);
+	}
+
+	stream_buffer->put_32(DDS_PIXELFORMAT_SIZE);
+
+	uint32_t pf_flags = 0;
+
+	DDSFormatType format_type = _dds_format_get_type(dds_format);
+
+	if (format_type == DDFT_BITMASK) {
+		pf_flags = DDPF_RGB;
+
+		if (image->get_format() == Image::FORMAT_LA8 || image->get_format() == Image::FORMAT_RG8 || image->get_format() == Image::FORMAT_RGBA8 || image->get_format() == Image::FORMAT_RGBA4444) {
+			pf_flags |= DDPF_ALPHAPIXELS;
+		}
+	} else {
+		pf_flags = DDPF_FOURCC;
+	}
+
+	stream_buffer->put_32(pf_flags);
+
+	bool needs_pixeldata_swap = false;
+
+	if (format_type == DDFT_BITMASK) {
+		// Uncompressed bitmasked.
+		stream_buffer->put_32(0); // FourCC
+
+		uint32_t bit_count, r_mask, g_mask, b_mask, a_mask;
+		_get_dds_pixel_bitmask(image->get_format(), bit_count, r_mask, g_mask, b_mask, a_mask);
+
+		stream_buffer->put_32(bit_count);
+		stream_buffer->put_32(r_mask);
+		stream_buffer->put_32(g_mask);
+		stream_buffer->put_32(b_mask);
+		stream_buffer->put_32(a_mask);
+
+		if (image->get_format() == Image::FORMAT_RGBA4444 || image->get_format() == Image::FORMAT_RGB565 || image->get_format() == Image::FORMAT_RGB8) {
+			needs_pixeldata_swap = true;
+		}
+	} else if (format_type == DDFT_FOURCC) {
+		// FourCC.
+		uint32_t fourcc = _image_format_to_fourcc_format(image->get_format());
+		stream_buffer->put_32(fourcc);
+
+		stream_buffer->put_32(0); // Bit count
+		stream_buffer->put_32(0); // R Bitmask
+		stream_buffer->put_32(0); // G Bitmask
+		stream_buffer->put_32(0); // B Bitmask
+		stream_buffer->put_32(0); // A Bitmask
+	} else {
+		// DXGI format and DX10 header.
+		stream_buffer->put_32(DDFCC_DX10);
+
+		stream_buffer->put_32(0); // Bit count
+		stream_buffer->put_32(0); // R Bitmask
+		stream_buffer->put_32(0); // G Bitmask
+		stream_buffer->put_32(0); // B Bitmask
+		stream_buffer->put_32(0); // A Bitmask
+	}
+
+	uint32_t caps1 = info.compressed ? DDSD_LINEARSIZE : DDSD_PITCH;
+	stream_buffer->put_32(caps1);
+
+	stream_buffer->put_32(0); // Caps2
+	stream_buffer->put_32(0); // Caps3
+	stream_buffer->put_32(0); // Caps4
+	stream_buffer->put_32(0); // Reserved 2
+
+	if (format_type == DDFT_DXGI) {
+		// DX10 header.
+		uint32_t dxgi_format = _image_format_to_dxgi_format(image->get_format());
+		stream_buffer->put_32(dxgi_format);
+		stream_buffer->put_32(DX10D_2D);
+		stream_buffer->put_32(0); // Misc flags 1
+		stream_buffer->put_32(1); // Array size
+		stream_buffer->put_32(0); // Misc flags 2
+	}
+
+	for (uint32_t mip_i = 0; mip_i < mipmaps; mip_i++) {
+		uint32_t mip_width = MAX(1u, width >> mip_i);
+		uint32_t mip_height = MAX(1u, height >> mip_i);
+
+		uint32_t expected_size = 0;
+		if (info.compressed) {
+			uint32_t blocks_x = (mip_width + info.divisor - 1) / info.divisor;
+			uint32_t blocks_y = (mip_height + info.divisor - 1) / info.divisor;
+			expected_size = blocks_x * blocks_y * info.block_size;
+		} else {
+			expected_size = mip_width * mip_height * info.block_size;
+		}
+
+		if (needs_pixeldata_swap) {
+			// The image's channels need to be swapped.
+			Ref<Image> mip_image = image->get_image_from_mipmap(mip_i);
+			Vector<uint8_t> data = mip_image->get_data();
+
+			ERR_FAIL_COND_V_MSG(data.size() != expected_size, Vector<uint8_t>(),
+					"Image data size mismatch for mipmap level " + itos(mip_i) +
+							". Expected size: " + itos(expected_size) + ", actual size: " + itos(data.size()) + ".");
+
+			if (mip_image->get_format() == Image::FORMAT_RGBA4444) {
+				// RGBA4 to BGRA4
+				const int64_t data_size = data.size();
+				uint8_t *wb = data.ptrw();
+
+				for (int64_t data_i = 0; data_i < data_size; data_i += 2) {
+					uint8_t ar = wb[data_i + 0];
+					uint8_t gb = wb[data_i + 1];
+
+					wb[data_i + 1] = ((ar & 0x0F) << 4) | ((gb & 0xF0) >> 4);
+					wb[data_i + 0] = ((ar & 0xF0) >> 4) | ((gb & 0x0F) << 4);
+				}
+			} else if (mip_image->get_format() == Image::FORMAT_RGB565) {
+				// RGB565 to BGR565
+				const int64_t data_size = data.size();
+				uint8_t *wb = data.ptrw();
+
+				for (int64_t data_i = 0; data_i < data_size; data_i += 2) {
+					uint16_t px = wb[data_i] | (wb[data_i + 1] << 8);
+
+					uint8_t r = (px >> 11) & 0x1F;
+					uint8_t g = (px >> 5) & 0x3F;
+					uint8_t b = px & 0x1F;
+
+					uint16_t out_px = (b << 11) | (g << 5) | r;
+
+					wb[data_i + 0] = out_px & 0xFF;
+					wb[data_i + 1] = (out_px >> 8) & 0xFF;
+				}
+			} else if (mip_image->get_format() == Image::FORMAT_RGB8) {
+				// RGB8 to BGR8
+				const int64_t data_size = data.size();
+				uint8_t *wb = data.ptrw();
+
+				for (int64_t data_i = 0; data_i < data_size; data_i += 3) {
+					SWAP(wb[data_i], wb[data_i + 2]);
+				}
+			}
+
+			stream_buffer->put_data(data.ptr(), data.size());
+		} else {
+			int64_t ofs, size;
+
+			image->get_mipmap_offset_and_size(mip_i, ofs, size);
+
+			ERR_FAIL_COND_V_MSG(size != expected_size, Vector<uint8_t>(),
+					"Image data size mismatch for mipmap level " + itos(mip_i) +
+							". Expected size: " + itos(expected_size) + ", actual size: " + itos(size) + ".");
+
+			stream_buffer->put_data(image->ptr() + ofs, size);
+		}
+	}
+
+	return stream_buffer->get_data_array();
+}

--- a/modules/dds/image_saver_dds.h
+++ b/modules/dds/image_saver_dds.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  image_saver_dds.h                                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,32 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#pragma once
 
-#include "image_saver_dds.h"
-#include "texture_loader_dds.h"
+#include "core/io/image.h"
 
-static Ref<ResourceFormatDDS> resource_loader_dds;
-
-void initialize_dds_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-
-	Image::save_dds_func = save_dds;
-	Image::save_dds_buffer_func = save_dds_buffer;
-
-	resource_loader_dds.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_loader_dds);
-}
-
-void uninitialize_dds_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-
-	ResourceLoader::remove_resource_format_loader(resource_loader_dds);
-	resource_loader_dds.unref();
-	Image::save_dds_func = nullptr;
-	Image::save_dds_buffer_func = nullptr;
-}
+Error save_dds(const String &p_path, const Ref<Image> &p_img);
+Vector<uint8_t> save_dds_buffer(const Ref<Image> &p_img);

--- a/modules/dds/tests/test_dds.h
+++ b/modules/dds/tests/test_dds.h
@@ -1,0 +1,161 @@
+/**************************************************************************/
+/*  test_dds.h                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "../image_saver_dds.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
+#include "core/io/image.h"
+#include "tests/core/config/test_project_settings.h"
+#include "tests/test_macros.h"
+#include "tests/test_utils.h"
+
+namespace TestDDS {
+String init(const String &p_test, const String &p_copy_target = String()) {
+	String old_resource_path = TestProjectSettingsInternalsAccessor::resource_path();
+	Error err;
+	// Setup project settings since it's needed for the import process.
+	String project_folder = TestUtils::get_temp_path(p_test.get_file().get_basename());
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(project_folder.path_join(".godot").path_join("imported"));
+	// Initialize res:// to `project_folder`.
+	TestProjectSettingsInternalsAccessor::resource_path() = project_folder;
+	err = ProjectSettings::get_singleton()->setup(project_folder, String(), true);
+
+	if (p_copy_target.is_empty()) {
+		return old_resource_path;
+	}
+
+	// Copy all the necessary test data files to the res:// directory.
+	da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	String test_data = String("tests/data").path_join(p_test);
+	da = DirAccess::open(test_data);
+	CHECK_MESSAGE(da.is_valid(), "Unable to open folder.");
+	da->list_dir_begin();
+	for (String item = da->get_next(); !item.is_empty(); item = da->get_next()) {
+		if (!FileAccess::exists(test_data.path_join(item))) {
+			continue;
+		}
+		Ref<FileAccess> output = FileAccess::open(p_copy_target.path_join(item), FileAccess::WRITE, &err);
+		CHECK_MESSAGE(err == OK, "Unable to open output file.");
+		output->store_buffer(FileAccess::get_file_as_bytes(test_data.path_join(item)));
+		output->close();
+	}
+	da->list_dir_end();
+	return old_resource_path;
+}
+
+TEST_CASE("[SceneTree][DDSSaver] Save DDS - Save valid image with mipmap" * doctest::skip(true)) {
+	String old_resource_path = init("save_dds_valid_image_with_mipmap");
+	Ref<Image> image = Image::create_empty(4, 4, false, Image::FORMAT_RGBA8);
+	image->fill(Color(1, 0, 0)); // Fill with red color
+	image->generate_mipmaps();
+	image->compress_from_channels(Image::COMPRESS_S3TC, Image::USED_CHANNELS_RGBA);
+	Error err = save_dds("res://valid_image_with_mipmap.dds", image);
+	CHECK(err == OK);
+
+	Ref<Image> loaded_image;
+	loaded_image.instantiate();
+	Vector<uint8_t> buffer = FileAccess::get_file_as_bytes("res://valid_image_with_mipmap.dds", &err);
+	CHECK(err == OK);
+	err = loaded_image->load_dds_from_buffer(buffer);
+	CHECK(err == OK);
+	Dictionary metrics = image->compute_image_metrics(loaded_image, false);
+	CHECK(metrics.size() > 0);
+	CHECK_MESSAGE(metrics.has("root_mean_squared"), "Metrics dictionary contains 'root_mean_squared'.");
+	float rms = metrics["root_mean_squared"];
+	CHECK(rms == 0.0f);
+	TestProjectSettingsInternalsAccessor::resource_path() = old_resource_path;
+}
+
+TEST_CASE("[SceneTree][DDSSaver] Save DDS - Save valid image with BPTC and S3TC compression" * doctest::skip(true)) {
+	String old_resource_path = init("save_dds_valid_image_bptc_s3tc");
+	Ref<Image> image_bptc = Image::create_empty(4, 4, false, Image::FORMAT_RGBA8);
+	image_bptc->fill(Color(0, 0, 1)); // Fill with blue color
+	image_bptc->compress_from_channels(Image::COMPRESS_BPTC, Image::USED_CHANNELS_RGBA);
+	Error err_bptc = image_bptc->save_dds("res://valid_image_bptc.dds");
+	CHECK(err_bptc == OK);
+
+	Ref<Image> image_s3tc = Image::create_empty(4, 4, false, Image::FORMAT_RGBA8);
+	image_s3tc->fill(Color(1, 1, 1)); // Fill with white color
+	image_s3tc->compress_from_channels(Image::COMPRESS_S3TC, Image::USED_CHANNELS_RGBA);
+	Error err_s3tc = image_s3tc->save_dds("res://valid_image_s3tc_combined.dds");
+	CHECK(err_s3tc == OK);
+
+	// Validate BPTC image
+	Ref<Image> loaded_image_bptc;
+	loaded_image_bptc.instantiate();
+	Vector<uint8_t> buffer_bptc = FileAccess::get_file_as_bytes("res://valid_image_bptc.dds", &err_bptc);
+	CHECK(err_bptc == OK);
+	err_bptc = loaded_image_bptc->load_dds_from_buffer(buffer_bptc);
+	CHECK(err_bptc == OK);
+	Dictionary metrics_bptc = image_bptc->compute_image_metrics(loaded_image_bptc, false);
+	CHECK(metrics_bptc.size() > 0);
+	CHECK_MESSAGE(metrics_bptc.has("root_mean_squared"), "Metrics dictionary contains 'root_mean_squared' for BPTC.");
+	float rms_bptc = metrics_bptc["root_mean_squared"];
+	CHECK(rms_bptc == 0.0f);
+
+	// Validate S3TC image
+	Ref<Image> loaded_image_s3tc;
+	loaded_image_s3tc.instantiate();
+	Vector<uint8_t> buffer_s3tc = FileAccess::get_file_as_bytes("res://valid_image_s3tc_combined.dds", &err_s3tc);
+	CHECK(err_s3tc == OK);
+	err_s3tc = loaded_image_s3tc->load_dds_from_buffer(buffer_s3tc);
+	CHECK(err_s3tc == OK);
+	Dictionary metrics_s3tc = image_s3tc->compute_image_metrics(loaded_image_s3tc, false);
+	CHECK(metrics_s3tc.size() > 0);
+	CHECK_MESSAGE(metrics_s3tc.has("root_mean_squared"), "Metrics dictionary contains 'root_mean_squared' for S3TC.");
+	float rms_s3tc = metrics_s3tc["root_mean_squared"];
+	CHECK(rms_s3tc == 0.0f);
+	TestProjectSettingsInternalsAccessor::resource_path() = old_resource_path;
+}
+
+TEST_CASE("[SceneTree][DDSSaver] Save DDS - Save valid uncompressed image") {
+	String old_resource_path = init("save_dds_valid_uncompressed");
+	Ref<Image> image = Image::create_empty(4, 4, false, Image::FORMAT_RGBA8);
+	image->fill(Color(0, 0, 1)); // Fill with blue color
+	Error err = image->save_dds("res://valid_image_uncompressed.dds");
+	CHECK(err == OK);
+	Vector<uint8_t> buffer = FileAccess::get_file_as_bytes("res://valid_image_uncompressed.dds", &err);
+	CHECK(err == OK);
+	Ref<Image> loaded_image;
+	loaded_image.instantiate();
+	err = loaded_image->load_dds_from_buffer(buffer);
+	CHECK(err == OK);
+	Dictionary metrics = image->compute_image_metrics(loaded_image, false);
+	CHECK(metrics.size() > 0);
+	CHECK_MESSAGE(metrics.has("root_mean_squared"), "Metrics dictionary contains 'root_mean_squared' for uncompressed.");
+	float rms = metrics["root_mean_squared"];
+	CHECK(rms == 0.0f);
+	TestProjectSettingsInternalsAccessor::resource_path() = old_resource_path;
+}
+} //namespace TestDDS

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -30,171 +30,13 @@
 
 #include "texture_loader_dds.h"
 
+#include "dds_enums.h"
+
 #include "core/io/file_access.h"
+#include "core/io/file_access_memory.h"
 #include "scene/resources/image_texture.h"
 
-#define PF_FOURCC(s) ((uint32_t)(((s)[3] << 24U) | ((s)[2] << 16U) | ((s)[1] << 8U) | ((s)[0])))
-
-// Reference: https://docs.microsoft.com/en-us/windows/win32/direct3ddds/dds-header
-
-enum {
-	DDS_MAGIC = 0x20534444,
-	DDSD_PITCH = 0x00000008,
-	DDSD_LINEARSIZE = 0x00080000,
-	DDSD_MIPMAPCOUNT = 0x00020000,
-	DDPF_ALPHAPIXELS = 0x00000001,
-	DDPF_ALPHAONLY = 0x00000002,
-	DDPF_FOURCC = 0x00000004,
-	DDPF_RGB = 0x00000040,
-	DDPF_RG_SNORM = 0x00080000,
-	DDSC2_CUBEMAP = 0x200,
-	DDSC2_VOLUME = 0x200000,
-	DX10D_1D = 2,
-	DX10D_2D = 3,
-	DX10D_3D = 4,
-};
-
-enum DDSFourCC {
-	DDFCC_DXT1 = PF_FOURCC("DXT1"),
-	DDFCC_DXT2 = PF_FOURCC("DXT2"),
-	DDFCC_DXT3 = PF_FOURCC("DXT3"),
-	DDFCC_DXT4 = PF_FOURCC("DXT4"),
-	DDFCC_DXT5 = PF_FOURCC("DXT5"),
-	DDFCC_ATI1 = PF_FOURCC("ATI1"),
-	DDFCC_BC4U = PF_FOURCC("BC4U"),
-	DDFCC_ATI2 = PF_FOURCC("ATI2"),
-	DDFCC_BC5U = PF_FOURCC("BC5U"),
-	DDFCC_A2XY = PF_FOURCC("A2XY"),
-	DDFCC_DX10 = PF_FOURCC("DX10"),
-	DDFCC_R16F = 111,
-	DDFCC_RG16F = 112,
-	DDFCC_RGBA16F = 113,
-	DDFCC_R32F = 114,
-	DDFCC_RG32F = 115,
-	DDFCC_RGBA32F = 116
-};
-
-// Reference: https://learn.microsoft.com/en-us/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format
-enum DXGIFormat {
-	DXGI_R32G32B32A32_FLOAT = 2,
-	DXGI_R32G32B32_FLOAT = 6,
-	DXGI_R16G16B16A16_FLOAT = 10,
-	DXGI_R32G32_FLOAT = 16,
-	DXGI_R10G10B10A2_UNORM = 24,
-	DXGI_R8G8B8A8_UNORM = 28,
-	DXGI_R8G8B8A8_UNORM_SRGB = 29,
-	DXGI_R16G16_FLOAT = 34,
-	DXGI_R32_FLOAT = 41,
-	DXGI_R8G8_UNORM = 49,
-	DXGI_R16_FLOAT = 54,
-	DXGI_R8_UNORM = 61,
-	DXGI_A8_UNORM = 65,
-	DXGI_R9G9B9E5 = 67,
-	DXGI_BC1_UNORM = 71,
-	DXGI_BC1_UNORM_SRGB = 72,
-	DXGI_BC2_UNORM = 74,
-	DXGI_BC2_UNORM_SRGB = 75,
-	DXGI_BC3_UNORM = 77,
-	DXGI_BC3_UNORM_SRGB = 78,
-	DXGI_BC4_UNORM = 80,
-	DXGI_BC5_UNORM = 83,
-	DXGI_B5G6R5_UNORM = 85,
-	DXGI_B5G5R5A1_UNORM = 86,
-	DXGI_B8G8R8A8_UNORM = 87,
-	DXGI_BC6H_UF16 = 95,
-	DXGI_BC6H_SF16 = 96,
-	DXGI_BC7_UNORM = 98,
-	DXGI_BC7_UNORM_SRGB = 99,
-	DXGI_B4G4R4A4_UNORM = 115
-};
-
-// The legacy bitmasked format names here represent the actual data layout in the files,
-// while their official names are flipped (e.g. RGBA8 layout is officially called ABGR8).
-enum DDSFormat {
-	DDS_DXT1,
-	DDS_DXT3,
-	DDS_DXT5,
-	DDS_ATI1,
-	DDS_ATI2,
-	DDS_BC6U,
-	DDS_BC6S,
-	DDS_BC7,
-	DDS_R16F,
-	DDS_RG16F,
-	DDS_RGBA16F,
-	DDS_R32F,
-	DDS_RG32F,
-	DDS_RGB32F,
-	DDS_RGBA32F,
-	DDS_RGB9E5,
-	DDS_RGB8,
-	DDS_RGBA8,
-	DDS_BGR8,
-	DDS_BGRA8,
-	DDS_BGR5A1,
-	DDS_BGR565,
-	DDS_B2GR3,
-	DDS_B2GR3A8,
-	DDS_BGR10A2,
-	DDS_RGB10A2,
-	DDS_BGRA4,
-	DDS_LUMINANCE,
-	DDS_LUMINANCE_ALPHA,
-	DDS_LUMINANCE_ALPHA_4,
-	DDS_MAX
-};
-
-enum DDSType {
-	DDST_2D = 1,
-	DDST_CUBEMAP,
-	DDST_3D,
-
-	DDST_TYPE_MASK = 0x7F,
-	DDST_ARRAY = 0x80,
-};
-
-struct DDSFormatInfo {
-	const char *name = nullptr;
-	bool compressed = false;
-	uint32_t divisor = 0;
-	uint32_t block_size = 0;
-	Image::Format format = Image::Format::FORMAT_BPTC_RGBA;
-};
-
-static const DDSFormatInfo dds_format_info[DDS_MAX] = {
-	{ "DXT1/BC1", true, 4, 8, Image::FORMAT_DXT1 },
-	{ "DXT2/DXT3/BC2", true, 4, 16, Image::FORMAT_DXT3 },
-	{ "DXT4/DXT5/BC3", true, 4, 16, Image::FORMAT_DXT5 },
-	{ "ATI1/BC4", true, 4, 8, Image::FORMAT_RGTC_R },
-	{ "ATI2/A2XY/BC5", true, 4, 16, Image::FORMAT_RGTC_RG },
-	{ "BC6UF", true, 4, 16, Image::FORMAT_BPTC_RGBFU },
-	{ "BC6SF", true, 4, 16, Image::FORMAT_BPTC_RGBF },
-	{ "BC7", true, 4, 16, Image::FORMAT_BPTC_RGBA },
-	{ "R16F", false, 1, 2, Image::FORMAT_RH },
-	{ "RG16F", false, 1, 4, Image::FORMAT_RGH },
-	{ "RGBA16F", false, 1, 8, Image::FORMAT_RGBAH },
-	{ "R32F", false, 1, 4, Image::FORMAT_RF },
-	{ "RG32F", false, 1, 8, Image::FORMAT_RGF },
-	{ "RGB32F", false, 1, 12, Image::FORMAT_RGBF },
-	{ "RGBA32F", false, 1, 16, Image::FORMAT_RGBAF },
-	{ "RGB9E5", false, 1, 4, Image::FORMAT_RGBE9995 },
-	{ "RGB8", false, 1, 3, Image::FORMAT_RGB8 },
-	{ "RGBA8", false, 1, 4, Image::FORMAT_RGBA8 },
-	{ "BGR8", false, 1, 3, Image::FORMAT_RGB8 },
-	{ "BGRA8", false, 1, 4, Image::FORMAT_RGBA8 },
-	{ "BGR5A1", false, 1, 2, Image::FORMAT_RGBA8 },
-	{ "BGR565", false, 1, 2, Image::FORMAT_RGB8 },
-	{ "B2GR3", false, 1, 1, Image::FORMAT_RGB8 },
-	{ "B2GR3A8", false, 1, 2, Image::FORMAT_RGBA8 },
-	{ "BGR10A2", false, 1, 4, Image::FORMAT_RGBA8 },
-	{ "RGB10A2", false, 1, 4, Image::FORMAT_RGBA8 },
-	{ "BGRA4", false, 1, 2, Image::FORMAT_RGBA8 },
-	{ "GRAYSCALE", false, 1, 1, Image::FORMAT_L8 },
-	{ "GRAYSCALE_ALPHA", false, 1, 2, Image::FORMAT_LA8 },
-	{ "GRAYSCALE_ALPHA_4", false, 1, 1, Image::FORMAT_LA8 }
-};
-
-inline DDSFormat _dxgi_to_dds_format(uint32_t p_dxgi_format) {
+DDSFormat _dxgi_to_dds_format(uint32_t p_dxgi_format) {
 	switch (p_dxgi_format) {
 		case DXGI_R32G32B32A32_FLOAT: {
 			return DDS_RGBA32F;
@@ -543,7 +385,295 @@ static Ref<Image> _dds_load_layer(Ref<FileAccess> p_file, DDSFormat p_dds_format
 	return memnew(Image(p_width, p_height, p_mipmaps > 1, info.format, r_src_data));
 }
 
-Ref<Resource> ResourceFormatDDS::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+static Vector<Ref<Image>> _dds_load_images(Ref<FileAccess> p_f, DDSFormat p_dds_format, uint32_t p_width, uint32_t p_height, uint32_t p_mipmaps, uint32_t p_pitch, uint32_t p_flags, uint32_t p_layer_count) {
+	Vector<uint8_t> src_data;
+	Vector<Ref<Image>> images;
+	images.resize(p_layer_count);
+
+	for (uint32_t i = 0; i < p_layer_count; i++) {
+		images.write[i] = _dds_load_layer(p_f, p_dds_format, p_width, p_height, p_mipmaps, p_pitch, p_flags, src_data);
+	}
+
+	return images;
+}
+
+static Ref<Resource> _dds_create_texture(const Vector<Ref<Image>> &p_images, uint32_t p_dds_type, uint32_t p_width, uint32_t p_height, uint32_t p_layer_count, uint32_t p_mipmaps, Error *r_error) {
+	if ((p_dds_type & DDST_TYPE_MASK) == DDST_2D) {
+		if (p_dds_type & DDST_ARRAY) {
+			Ref<Texture2DArray> texture;
+			texture.instantiate();
+			texture->create_from_images(p_images);
+
+			if (r_error) {
+				*r_error = OK;
+			}
+
+			return texture;
+
+		} else {
+			if (r_error) {
+				*r_error = OK;
+			}
+
+			return ImageTexture::create_from_image(p_images[0]);
+		}
+
+	} else if ((p_layer_count & DDST_TYPE_MASK) == DDST_CUBEMAP) {
+		ERR_FAIL_COND_V(p_layer_count % 6 != 0, Ref<Resource>());
+
+		if (p_dds_type & DDST_ARRAY) {
+			Ref<CubemapArray> texture;
+			texture.instantiate();
+			texture->create_from_images(p_images);
+
+			if (r_error) {
+				*r_error = OK;
+			}
+
+			return texture;
+
+		} else {
+			Ref<Cubemap> texture;
+			texture.instantiate();
+			texture->create_from_images(p_images);
+
+			if (r_error) {
+				*r_error = OK;
+			}
+
+			return texture;
+		}
+
+	} else if ((p_dds_type & DDST_TYPE_MASK) == DDST_3D) {
+		Ref<ImageTexture3D> texture;
+		texture.instantiate();
+		texture->create(p_images[0]->get_format(), p_width, p_height, p_layer_count, p_mipmaps > 1, p_images);
+
+		if (r_error) {
+			*r_error = OK;
+		}
+
+		return texture;
+	}
+
+	return Ref<Resource>();
+}
+
+static Ref<Resource> _dds_create_texture_from_images(const Vector<Ref<Image>> &p_images, DDSFormat p_dds_format, uint32_t p_width, uint32_t p_height, uint32_t p_mipmaps, uint32_t p_pitch, uint32_t p_flags, uint32_t p_layer_count, uint32_t p_dds_type, Error *r_error) {
+	return _dds_create_texture(p_images, p_dds_type, p_width, p_height, p_layer_count, p_mipmaps, r_error);
+}
+
+static Vector<Ref<Image>> _dds_load_images_from_buffer(Ref<FileAccess> p_f, DDSFormat &r_dds_format, uint32_t &r_width, uint32_t &r_height, uint32_t &r_mipmaps, uint32_t &r_pitch, uint32_t &r_flags, uint32_t &r_layer_count, uint32_t &r_dds_type, const String &p_path = "") {
+	ERR_FAIL_COND_V_MSG(p_f.is_null(), Vector<Ref<Image>>(), vformat("Empty DDS texture file."));
+	ERR_FAIL_COND_V_MSG(!p_f->get_length(), Vector<Ref<Image>>(), vformat("Empty DDS texture file."));
+
+	uint32_t magic = p_f->get_32();
+	uint32_t hsize = p_f->get_32();
+	r_flags = p_f->get_32();
+	r_height = p_f->get_32();
+	r_width = p_f->get_32();
+	r_pitch = p_f->get_32();
+	uint32_t depth = p_f->get_32();
+	r_mipmaps = p_f->get_32();
+
+	// Skip reserved.
+	for (int i = 0; i < 11; i++) {
+		p_f->get_32();
+	}
+
+	// Validate.
+	// We don't check DDSD_CAPS or DDSD_PIXELFORMAT, as they're mandatory when writing,
+	// but non-mandatory when reading (as some writers don't set them).
+	if (magic != DDS_MAGIC || hsize != 124) {
+		ERR_FAIL_V_MSG(Vector<Ref<Image>>(), vformat("Invalid or unsupported DDS texture file '%s'.", p_path));
+	}
+
+	/* uint32_t format_size = */ p_f->get_32();
+	uint32_t format_flags = p_f->get_32();
+	uint32_t format_fourcc = p_f->get_32();
+	uint32_t format_rgb_bits = p_f->get_32();
+	uint32_t format_red_mask = p_f->get_32();
+	uint32_t format_green_mask = p_f->get_32();
+	uint32_t format_blue_mask = p_f->get_32();
+	uint32_t format_alpha_mask = p_f->get_32();
+
+	/* uint32_t caps_1 = */ p_f->get_32();
+	uint32_t caps_2 = p_f->get_32();
+	/* uint32_t caps_3 = */ p_f->get_32();
+	/* uint32_t caps_4 = */ p_f->get_32();
+
+	// Skip reserved.
+	p_f->get_32();
+
+	if (p_f->get_position() < 128) {
+		p_f->seek(128);
+	}
+
+	r_layer_count = 1;
+	r_dds_type = DDST_2D;
+
+	if (caps_2 & DDSC2_CUBEMAP) {
+		r_dds_type = DDST_CUBEMAP;
+		r_layer_count *= 6;
+
+	} else if (caps_2 & DDSC2_VOLUME) {
+		r_dds_type = DDST_3D;
+		r_layer_count = depth;
+	}
+
+	r_dds_format = DDS_MAX;
+
+	if (format_flags & DDPF_FOURCC) {
+		// FourCC formats.
+		switch (format_fourcc) {
+			case DDFCC_DXT1: {
+				r_dds_format = DDS_DXT1;
+			} break;
+			case DDFCC_DXT2:
+			case DDFCC_DXT3: {
+				r_dds_format = DDS_DXT3;
+			} break;
+			case DDFCC_DXT4:
+			case DDFCC_DXT5: {
+				r_dds_format = DDS_DXT5;
+			} break;
+			case DDFCC_ATI1:
+			case DDFCC_BC4U: {
+				r_dds_format = DDS_ATI1;
+			} break;
+			case DDFCC_ATI2:
+			case DDFCC_BC5U:
+			case DDFCC_A2XY: {
+				r_dds_format = DDS_ATI2;
+			} break;
+			case DDFCC_R16F: {
+				r_dds_format = DDS_R16F;
+			} break;
+			case DDFCC_RG16F: {
+				r_dds_format = DDS_RG16F;
+			} break;
+			case DDFCC_RGBA16F: {
+				r_dds_format = DDS_RGBA16F;
+			} break;
+			case DDFCC_R32F: {
+				r_dds_format = DDS_R32F;
+			} break;
+			case DDFCC_RG32F: {
+				r_dds_format = DDS_RG32F;
+			} break;
+			case DDFCC_RGBA32F: {
+				r_dds_format = DDS_RGBA32F;
+			} break;
+			case DDFCC_DX10: {
+				uint32_t dxgi_format = p_f->get_32();
+				uint32_t dimension = p_f->get_32();
+				/* uint32_t misc_flags_1 = */ p_f->get_32();
+				uint32_t array_size = p_f->get_32();
+				/* uint32_t misc_flags_2 = */ p_f->get_32();
+
+				if (dimension == DX10D_3D) {
+					r_dds_type = DDST_3D;
+					r_layer_count = depth;
+				}
+
+				if (array_size > 1) {
+					r_layer_count *= array_size;
+					r_dds_type |= DDST_ARRAY;
+				}
+
+				r_dds_format = _dxgi_to_dds_format(dxgi_format);
+			} break;
+
+			default: {
+				ERR_FAIL_V_MSG(Vector<Ref<Image>>(), vformat("Unrecognized or unsupported FourCC in DDS '%s'.", p_path));
+			}
+		}
+
+	} else if (format_flags & DDPF_RGB) {
+		// Channel-bitmasked formats.
+		if (format_flags & DDPF_ALPHAPIXELS) {
+			// With alpha.
+			if (format_rgb_bits == 32 && format_red_mask == 0xff0000 && format_green_mask == 0xff00 && format_blue_mask == 0xff && format_alpha_mask == 0xff000000) {
+				r_dds_format = DDS_BGRA8;
+			} else if (format_rgb_bits == 32 && format_red_mask == 0xff && format_green_mask == 0xff00 && format_blue_mask == 0xff0000 && format_alpha_mask == 0xff000000) {
+				r_dds_format = DDS_RGBA8;
+			} else if (format_rgb_bits == 16 && format_red_mask == 0x00007c00 && format_green_mask == 0x000003e0 && format_blue_mask == 0x0000001f && format_alpha_mask == 0x00008000) {
+				r_dds_format = DDS_BGR5A1;
+			} else if (format_rgb_bits == 32 && format_red_mask == 0x3ff00000 && format_green_mask == 0xffc00 && format_blue_mask == 0x3ff && format_alpha_mask == 0xc0000000) {
+				r_dds_format = DDS_BGR10A2;
+			} else if (format_rgb_bits == 32 && format_red_mask == 0x3ff && format_green_mask == 0xffc00 && format_blue_mask == 0x3ff00000 && format_alpha_mask == 0xc0000000) {
+				r_dds_format = DDS_RGB10A2;
+			} else if (format_rgb_bits == 16 && format_red_mask == 0xf00 && format_green_mask == 0xf0 && format_blue_mask == 0xf && format_alpha_mask == 0xf000) {
+				r_dds_format = DDS_BGRA4;
+			} else if (format_rgb_bits == 16 && format_red_mask == 0xe0 && format_green_mask == 0x1c && format_blue_mask == 0x3 && format_alpha_mask == 0xff00) {
+				r_dds_format = DDS_B2GR3A8;
+			}
+
+		} else {
+			// Without alpha.
+			if (format_rgb_bits == 24 && format_red_mask == 0xff0000 && format_green_mask == 0xff00 && format_blue_mask == 0xff) {
+				r_dds_format = DDS_BGR8;
+			} else if (format_rgb_bits == 24 && format_red_mask == 0xff && format_green_mask == 0xff00 && format_blue_mask == 0xff0000) {
+				r_dds_format = DDS_RGB8;
+			} else if (format_rgb_bits == 16 && format_red_mask == 0x0000f800 && format_green_mask == 0x000007e0 && format_blue_mask == 0x0000001f) {
+				r_dds_format = DDS_BGR565;
+			} else if (format_rgb_bits == 8 && format_red_mask == 0xe0 && format_green_mask == 0x1c && format_blue_mask == 0x3) {
+				r_dds_format = DDS_B2GR3;
+			}
+		}
+
+	} else {
+		// Other formats.
+		if (format_flags & DDPF_ALPHAONLY && format_rgb_bits == 8 && format_alpha_mask == 0xff) {
+			// Alpha only.
+			r_dds_format = DDS_LUMINANCE;
+		}
+	}
+
+	// Depending on the writer, luminance formats may or may not have the DDPF_RGB or DDPF_LUMINANCE flags defined,
+	// so we check for these formats after everything else failed.
+	if (r_dds_format == DDS_MAX) {
+		if (format_flags & DDPF_ALPHAPIXELS) {
+			// With alpha.
+			if (format_rgb_bits == 16 && format_red_mask == 0xff && format_alpha_mask == 0xff00) {
+				r_dds_format = DDS_LUMINANCE_ALPHA;
+			} else if (format_rgb_bits == 8 && format_red_mask == 0xf && format_alpha_mask == 0xf0) {
+				r_dds_format = DDS_LUMINANCE_ALPHA_4;
+			}
+
+		} else {
+			// Without alpha.
+			if (format_rgb_bits == 8 && format_red_mask == 0xff) {
+				r_dds_format = DDS_LUMINANCE;
+			}
+		}
+	}
+
+	// No format detected, error.
+	if (r_dds_format == DDS_MAX) {
+		ERR_FAIL_V_MSG(Vector<Ref<Image>>(), vformat("Unrecognized or unsupported color layout in DDS '%s'.", p_path));
+	}
+
+	if (!(r_flags & DDSD_MIPMAPCOUNT)) {
+		r_mipmaps = 1;
+	}
+
+	return _dds_load_images(p_f, r_dds_format, r_width, r_height, r_mipmaps, r_pitch, r_flags, r_layer_count);
+}
+
+static Ref<Resource> _dds_load_from_buffer(Ref<FileAccess> p_f, Error *r_error, const String &p_path = "") {
+	if (r_error) {
+		*r_error = ERR_FILE_CORRUPT;
+	}
+
+	DDSFormat dds_format;
+	uint32_t width = 0, height = 0, mipmaps = 0, pitch = 0, flags = 0, layer_count = 0, dds_type = 0;
+
+	Vector<Ref<Image>> images = _dds_load_images_from_buffer(p_f, dds_format, width, height, mipmaps, pitch, flags, layer_count, dds_type, p_path);
+	return _dds_create_texture_from_images(images, dds_format, width, height, mipmaps, pitch, flags, layer_count, dds_type, r_error);
+}
+
+static Ref<Resource> _dds_load_from_file(const String &p_path, Error *r_error) {
 	if (r_error) {
 		*r_error = ERR_CANT_OPEN;
 	}
@@ -554,268 +684,11 @@ Ref<Resource> ResourceFormatDDS::load(const String &p_path, const String &p_orig
 		return Ref<Resource>();
 	}
 
-	Ref<FileAccess> fref(f);
-	if (r_error) {
-		*r_error = ERR_FILE_CORRUPT;
-	}
+	return _dds_load_from_buffer(f, r_error, p_path);
+}
 
-	ERR_FAIL_COND_V_MSG(err != OK, Ref<Resource>(), vformat("Unable to open DDS texture file '%s'.", p_path));
-
-	uint32_t magic = f->get_32();
-	uint32_t hsize = f->get_32();
-	uint32_t flags = f->get_32();
-	uint32_t height = f->get_32();
-	uint32_t width = f->get_32();
-	uint32_t pitch = f->get_32();
-	uint32_t depth = f->get_32();
-	uint32_t mipmaps = f->get_32();
-
-	// Skip reserved.
-	for (int i = 0; i < 11; i++) {
-		f->get_32();
-	}
-
-	// Validate.
-	// We don't check DDSD_CAPS or DDSD_PIXELFORMAT, as they're mandatory when writing,
-	// but non-mandatory when reading (as some writers don't set them).
-	if (magic != DDS_MAGIC || hsize != 124) {
-		ERR_FAIL_V_MSG(Ref<Resource>(), vformat("Invalid or unsupported DDS texture file '%s'.", p_path));
-	}
-
-	/* uint32_t format_size = */ f->get_32();
-	uint32_t format_flags = f->get_32();
-	uint32_t format_fourcc = f->get_32();
-	uint32_t format_rgb_bits = f->get_32();
-	uint32_t format_red_mask = f->get_32();
-	uint32_t format_green_mask = f->get_32();
-	uint32_t format_blue_mask = f->get_32();
-	uint32_t format_alpha_mask = f->get_32();
-
-	/* uint32_t caps_1 = */ f->get_32();
-	uint32_t caps_2 = f->get_32();
-	/* uint32_t caps_3 = */ f->get_32();
-	/* uint32_t caps_4 = */ f->get_32();
-
-	// Skip reserved.
-	f->get_32();
-
-	if (f->get_position() < 128) {
-		f->seek(128);
-	}
-
-	uint32_t layer_count = 1;
-	uint32_t dds_type = DDST_2D;
-
-	if (caps_2 & DDSC2_CUBEMAP) {
-		dds_type = DDST_CUBEMAP;
-		layer_count *= 6;
-
-	} else if (caps_2 & DDSC2_VOLUME) {
-		dds_type = DDST_3D;
-		layer_count = depth;
-	}
-
-	DDSFormat dds_format = DDS_MAX;
-
-	if (format_flags & DDPF_FOURCC) {
-		// FourCC formats.
-		switch (format_fourcc) {
-			case DDFCC_DXT1: {
-				dds_format = DDS_DXT1;
-			} break;
-			case DDFCC_DXT2:
-			case DDFCC_DXT3: {
-				dds_format = DDS_DXT3;
-			} break;
-			case DDFCC_DXT4:
-			case DDFCC_DXT5: {
-				dds_format = DDS_DXT5;
-			} break;
-			case DDFCC_ATI1:
-			case DDFCC_BC4U: {
-				dds_format = DDS_ATI1;
-			} break;
-			case DDFCC_ATI2:
-			case DDFCC_BC5U:
-			case DDFCC_A2XY: {
-				dds_format = DDS_ATI2;
-			} break;
-			case DDFCC_R16F: {
-				dds_format = DDS_R16F;
-			} break;
-			case DDFCC_RG16F: {
-				dds_format = DDS_RG16F;
-			} break;
-			case DDFCC_RGBA16F: {
-				dds_format = DDS_RGBA16F;
-			} break;
-			case DDFCC_R32F: {
-				dds_format = DDS_R32F;
-			} break;
-			case DDFCC_RG32F: {
-				dds_format = DDS_RG32F;
-			} break;
-			case DDFCC_RGBA32F: {
-				dds_format = DDS_RGBA32F;
-			} break;
-			case DDFCC_DX10: {
-				uint32_t dxgi_format = f->get_32();
-				uint32_t dimension = f->get_32();
-				/* uint32_t misc_flags_1 = */ f->get_32();
-				uint32_t array_size = f->get_32();
-				/* uint32_t misc_flags_2 = */ f->get_32();
-
-				if (dimension == DX10D_3D) {
-					dds_type = DDST_3D;
-					layer_count = depth;
-				}
-
-				if (array_size > 1) {
-					layer_count *= array_size;
-					dds_type |= DDST_ARRAY;
-				}
-
-				dds_format = _dxgi_to_dds_format(dxgi_format);
-			} break;
-
-			default: {
-				ERR_FAIL_V_MSG(Ref<Resource>(), vformat("Unrecognized or unsupported FourCC in DDS '%s'.", p_path));
-			}
-		}
-
-	} else if (format_flags & DDPF_RGB) {
-		// Channel-bitmasked formats.
-		if (format_flags & DDPF_ALPHAPIXELS) {
-			// With alpha.
-			if (format_rgb_bits == 32 && format_red_mask == 0xff0000 && format_green_mask == 0xff00 && format_blue_mask == 0xff && format_alpha_mask == 0xff000000) {
-				dds_format = DDS_BGRA8;
-			} else if (format_rgb_bits == 32 && format_red_mask == 0xff && format_green_mask == 0xff00 && format_blue_mask == 0xff0000 && format_alpha_mask == 0xff000000) {
-				dds_format = DDS_RGBA8;
-			} else if (format_rgb_bits == 16 && format_red_mask == 0x00007c00 && format_green_mask == 0x000003e0 && format_blue_mask == 0x0000001f && format_alpha_mask == 0x00008000) {
-				dds_format = DDS_BGR5A1;
-			} else if (format_rgb_bits == 32 && format_red_mask == 0x3ff00000 && format_green_mask == 0xffc00 && format_blue_mask == 0x3ff && format_alpha_mask == 0xc0000000) {
-				dds_format = DDS_BGR10A2;
-			} else if (format_rgb_bits == 32 && format_red_mask == 0x3ff && format_green_mask == 0xffc00 && format_blue_mask == 0x3ff00000 && format_alpha_mask == 0xc0000000) {
-				dds_format = DDS_RGB10A2;
-			} else if (format_rgb_bits == 16 && format_red_mask == 0xf00 && format_green_mask == 0xf0 && format_blue_mask == 0xf && format_alpha_mask == 0xf000) {
-				dds_format = DDS_BGRA4;
-			} else if (format_rgb_bits == 16 && format_red_mask == 0xe0 && format_green_mask == 0x1c && format_blue_mask == 0x3 && format_alpha_mask == 0xff00) {
-				dds_format = DDS_B2GR3A8;
-			}
-
-		} else {
-			// Without alpha.
-			if (format_rgb_bits == 24 && format_red_mask == 0xff0000 && format_green_mask == 0xff00 && format_blue_mask == 0xff) {
-				dds_format = DDS_BGR8;
-			} else if (format_rgb_bits == 24 && format_red_mask == 0xff && format_green_mask == 0xff00 && format_blue_mask == 0xff0000) {
-				dds_format = DDS_RGB8;
-			} else if (format_rgb_bits == 16 && format_red_mask == 0x0000f800 && format_green_mask == 0x000007e0 && format_blue_mask == 0x0000001f) {
-				dds_format = DDS_BGR565;
-			} else if (format_rgb_bits == 8 && format_red_mask == 0xe0 && format_green_mask == 0x1c && format_blue_mask == 0x3) {
-				dds_format = DDS_B2GR3;
-			}
-		}
-
-	} else {
-		// Other formats.
-		if (format_flags & DDPF_ALPHAONLY && format_rgb_bits == 8 && format_alpha_mask == 0xff) {
-			// Alpha only.
-			dds_format = DDS_LUMINANCE;
-		}
-	}
-
-	// Depending on the writer, luminance formats may or may not have the DDPF_RGB or DDPF_LUMINANCE flags defined,
-	// so we check for these formats after everything else failed.
-	if (dds_format == DDS_MAX) {
-		if (format_flags & DDPF_ALPHAPIXELS) {
-			// With alpha.
-			if (format_rgb_bits == 16 && format_red_mask == 0xff && format_alpha_mask == 0xff00) {
-				dds_format = DDS_LUMINANCE_ALPHA;
-			} else if (format_rgb_bits == 8 && format_red_mask == 0xf && format_alpha_mask == 0xf0) {
-				dds_format = DDS_LUMINANCE_ALPHA_4;
-			}
-
-		} else {
-			// Without alpha.
-			if (format_rgb_bits == 8 && format_red_mask == 0xff) {
-				dds_format = DDS_LUMINANCE;
-			}
-		}
-	}
-
-	// No format detected, error.
-	if (dds_format == DDS_MAX) {
-		ERR_FAIL_V_MSG(Ref<Resource>(), vformat("Unrecognized or unsupported color layout in DDS '%s'.", p_path));
-	}
-
-	if (!(flags & DDSD_MIPMAPCOUNT)) {
-		mipmaps = 1;
-	}
-
-	Vector<uint8_t> src_data;
-
-	Vector<Ref<Image>> images;
-	images.resize(layer_count);
-
-	for (uint32_t i = 0; i < layer_count; i++) {
-		images.write[i] = _dds_load_layer(f, dds_format, width, height, mipmaps, pitch, flags, src_data);
-	}
-
-	if ((dds_type & DDST_TYPE_MASK) == DDST_2D) {
-		if (dds_type & DDST_ARRAY) {
-			Ref<Texture2DArray> texture = memnew(Texture2DArray());
-			texture->create_from_images(images);
-
-			if (r_error) {
-				*r_error = OK;
-			}
-
-			return texture;
-
-		} else {
-			if (r_error) {
-				*r_error = OK;
-			}
-
-			return ImageTexture::create_from_image(images[0]);
-		}
-
-	} else if ((dds_type & DDST_TYPE_MASK) == DDST_CUBEMAP) {
-		ERR_FAIL_COND_V(layer_count % 6 != 0, Ref<Resource>());
-
-		if (dds_type & DDST_ARRAY) {
-			Ref<CubemapArray> texture = memnew(CubemapArray());
-			texture->create_from_images(images);
-
-			if (r_error) {
-				*r_error = OK;
-			}
-
-			return texture;
-
-		} else {
-			Ref<Cubemap> texture = memnew(Cubemap());
-			texture->create_from_images(images);
-
-			if (r_error) {
-				*r_error = OK;
-			}
-
-			return texture;
-		}
-
-	} else if ((dds_type & DDST_TYPE_MASK) == DDST_3D) {
-		Ref<ImageTexture3D> texture = memnew(ImageTexture3D());
-		texture->create(images[0]->get_format(), width, height, layer_count, mipmaps > 1, images);
-
-		if (r_error) {
-			*r_error = OK;
-		}
-
-		return texture;
-	}
-
-	return Ref<Resource>();
+Ref<Resource> ResourceFormatDDS::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+	return _dds_load_from_file(p_path, r_error);
 }
 
 void ResourceFormatDDS::get_recognized_extensions(List<String> *p_extensions) const {
@@ -831,4 +704,25 @@ String ResourceFormatDDS::get_resource_type(const String &p_path) const {
 		return "Texture";
 	}
 	return "";
+}
+
+Ref<Image> load_mem_dds(const uint8_t *p_dds, int p_size) {
+	ERR_FAIL_NULL_V(p_dds, Ref<Image>());
+	ERR_FAIL_COND_V(!p_size, Ref<Image>());
+	Ref<FileAccessMemory> memfile;
+	memfile.instantiate();
+	Error open_memfile_error = memfile->open_custom(p_dds, p_size);
+	ERR_FAIL_COND_V_MSG(open_memfile_error, Ref<Image>(), "Could not create memfile for DDS image buffer.");
+
+	DDSFormat dds_format;
+	uint32_t width, height, mipmaps, pitch, flags, layer_count, dds_type;
+
+	Vector<Ref<Image>> images = _dds_load_images_from_buffer(memfile, dds_format, width, height, mipmaps, pitch, flags, layer_count, dds_type);
+	ERR_FAIL_COND_V_MSG(images.is_empty(), Ref<Image>(), "Failed to load DDS image.");
+
+	return images[0];
+}
+
+ResourceFormatDDS::ResourceFormatDDS() {
+	Image::_dds_mem_loader_func = load_mem_dds;
 }

--- a/modules/dds/texture_loader_dds.h
+++ b/modules/dds/texture_loader_dds.h
@@ -39,5 +39,6 @@ public:
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 
+	ResourceFormatDDS();
 	virtual ~ResourceFormatDDS() {}
 };


### PR DESCRIPTION
See: https://github.com/godotengine/godot-proposals/issues/5748

The proposal involves adding the ImageLoaderDDS class, moving the DDS handling code inside it, and reusing the image loader (or part of it) in the texture loader in the future.

We are not supporting saving non-2d textures at this moment. Feature enhancement wanted.

- [x] ~~BetsyCompressor has a runtime execution error~~ Rendering team is handling it.
- [x] Only handle saving 2d-textures (like not 3d or 2d arrays)
- [x] Pass GitHub actions tests
- [x] Expand the list of supported Image::Formats and DDSFormats
- [x] Extract common header from DDS reader and DDS writer
- [x] Debug why BPTC dds loading isn't working
   - [x] Fix BPTC unit test
- [x] Stress test the system with an example project https://v-sekai.github.io/manuals/decisions/20250122-VRChat-Loader-with-Godot-Engine.html
  - [x] In a GDScript project, create a web server (Godot Engine) to export from its current scene with all images repacked as a GLTF2 binary DDS and png/jpeg on HTTP GET.
  - [x] https://github.com/V-Sekai-fire/godot-http-glb-host
- [x] Add `Image.load_dds_from_buffer()`
- [x] Add `Image.save_dds_from_buffer()`
- [x] `Error save_dds(const String &p_path) const`
- [x] `Vector<uint8_t> save_dds_to_buffer() const`
- [x] Refactor DDS image preparation, update function signatures, and improve mipmap handling
- [x] Enhance DDS functionality by adding image saving, buffer handling, and loading capabilities
- [x] Expand DDS tests with image format conversions, metric checks, and compression methods
- [x] Update the DDS loader to use buffers in tests and handle unsupported formats
- [x]  Improve DDS image saver to handle all mipmap levels and validate data sizes
- [x]  Fix include guards and formatting in DDS image saver header files
