### PR TITLE
Core: Decouple `Variant` enums to standalone file

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -62,6 +62,7 @@
 #include "core/variant/callable.h"
 #include "core/variant/dictionary.h"
 #include "core/variant/variant_deep_duplicate.h"
+#include "core/variant/variant_enums.h"
 
 class Object;
 class RefCounted;
@@ -92,58 +93,77 @@ typedef Vector<Vector4> PackedVector4Array;
 
 class Variant {
 public:
-	// If this changes the table in variant_op must be updated
-	enum Type {
-		NIL,
+	// Compatibility binding for `VariantType`; should eventually be phased out.
+	using Type = VariantType;
+	static constexpr Type NIL = VariantType::NIL;
+	static constexpr Type BOOL = VariantType::BOOL;
+	static constexpr Type INT = VariantType::INT;
+	static constexpr Type FLOAT = VariantType::FLOAT;
+	static constexpr Type STRING = VariantType::STRING;
+	static constexpr Type VECTOR2 = VariantType::VECTOR2;
+	static constexpr Type VECTOR2I = VariantType::VECTOR2I;
+	static constexpr Type RECT2 = VariantType::RECT2;
+	static constexpr Type RECT2I = VariantType::RECT2I;
+	static constexpr Type VECTOR3 = VariantType::VECTOR3;
+	static constexpr Type VECTOR3I = VariantType::VECTOR3I;
+	static constexpr Type TRANSFORM2D = VariantType::TRANSFORM2D;
+	static constexpr Type VECTOR4 = VariantType::VECTOR4;
+	static constexpr Type VECTOR4I = VariantType::VECTOR4I;
+	static constexpr Type PLANE = VariantType::PLANE;
+	static constexpr Type QUATERNION = VariantType::QUATERNION;
+	static constexpr Type AABB = VariantType::AABB;
+	static constexpr Type BASIS = VariantType::BASIS;
+	static constexpr Type TRANSFORM3D = VariantType::TRANSFORM3D;
+	static constexpr Type PROJECTION = VariantType::PROJECTION;
+	static constexpr Type COLOR = VariantType::COLOR;
+	static constexpr Type STRING_NAME = VariantType::STRING_NAME;
+	static constexpr Type NODE_PATH = VariantType::NODE_PATH;
+	static constexpr Type RID = VariantType::RID;
+	static constexpr Type OBJECT = VariantType::OBJECT;
+	static constexpr Type CALLABLE = VariantType::CALLABLE;
+	static constexpr Type SIGNAL = VariantType::SIGNAL;
+	static constexpr Type DICTIONARY = VariantType::DICTIONARY;
+	static constexpr Type ARRAY = VariantType::ARRAY;
+	static constexpr Type PACKED_BYTE_ARRAY = VariantType::PACKED_BYTE_ARRAY;
+	static constexpr Type PACKED_INT32_ARRAY = VariantType::PACKED_INT32_ARRAY;
+	static constexpr Type PACKED_INT64_ARRAY = VariantType::PACKED_INT64_ARRAY;
+	static constexpr Type PACKED_FLOAT32_ARRAY = VariantType::PACKED_FLOAT32_ARRAY;
+	static constexpr Type PACKED_FLOAT64_ARRAY = VariantType::PACKED_FLOAT64_ARRAY;
+	static constexpr Type PACKED_STRING_ARRAY = VariantType::PACKED_STRING_ARRAY;
+	static constexpr Type PACKED_VECTOR2_ARRAY = VariantType::PACKED_VECTOR2_ARRAY;
+	static constexpr Type PACKED_VECTOR3_ARRAY = VariantType::PACKED_VECTOR3_ARRAY;
+	static constexpr Type PACKED_COLOR_ARRAY = VariantType::PACKED_COLOR_ARRAY;
+	static constexpr Type PACKED_VECTOR4_ARRAY = VariantType::PACKED_VECTOR4_ARRAY;
+	static constexpr Type VARIANT_MAX = VariantType::MAX;
 
-		// atomic types
-		BOOL,
-		INT,
-		FLOAT,
-		STRING,
-
-		// math types
-		VECTOR2,
-		VECTOR2I,
-		RECT2,
-		RECT2I,
-		VECTOR3,
-		VECTOR3I,
-		TRANSFORM2D,
-		VECTOR4,
-		VECTOR4I,
-		PLANE,
-		QUATERNION,
-		AABB,
-		BASIS,
-		TRANSFORM3D,
-		PROJECTION,
-
-		// misc types
-		COLOR,
-		STRING_NAME,
-		NODE_PATH,
-		RID,
-		OBJECT,
-		CALLABLE,
-		SIGNAL,
-		DICTIONARY,
-		ARRAY,
-
-		// typed arrays
-		PACKED_BYTE_ARRAY,
-		PACKED_INT32_ARRAY,
-		PACKED_INT64_ARRAY,
-		PACKED_FLOAT32_ARRAY,
-		PACKED_FLOAT64_ARRAY,
-		PACKED_STRING_ARRAY,
-		PACKED_VECTOR2_ARRAY,
-		PACKED_VECTOR3_ARRAY,
-		PACKED_COLOR_ARRAY,
-		PACKED_VECTOR4_ARRAY,
-
-		VARIANT_MAX
-	};
+	// Compatibility binding for `VariantOperator`; should eventually be phased out.
+	using Operator = VariantOperator;
+	static constexpr Operator OP_EQUAL = VariantOperator::EQUAL;
+	static constexpr Operator OP_NOT_EQUAL = VariantOperator::NOT_EQUAL;
+	static constexpr Operator OP_LESS = VariantOperator::LESS;
+	static constexpr Operator OP_LESS_EQUAL = VariantOperator::LESS_EQUAL;
+	static constexpr Operator OP_GREATER = VariantOperator::GREATER;
+	static constexpr Operator OP_GREATER_EQUAL = VariantOperator::GREATER_EQUAL;
+	static constexpr Operator OP_ADD = VariantOperator::ADD;
+	static constexpr Operator OP_SUBTRACT = VariantOperator::SUBTRACT;
+	static constexpr Operator OP_MULTIPLY = VariantOperator::MULTIPLY;
+	static constexpr Operator OP_DIVIDE = VariantOperator::DIVIDE;
+	static constexpr Operator OP_NEGATE = VariantOperator::NEGATE;
+	static constexpr Operator OP_POSITIVE = VariantOperator::POSITIVE;
+	static constexpr Operator OP_MODULE = VariantOperator::MODULE;
+	static constexpr Operator OP_POWER = VariantOperator::POWER;
+	static constexpr Operator OP_SHIFT_LEFT = VariantOperator::SHIFT_LEFT;
+	static constexpr Operator OP_SHIFT_RIGHT = VariantOperator::SHIFT_RIGHT;
+	static constexpr Operator OP_BIT_AND = VariantOperator::BIT_AND;
+	static constexpr Operator OP_BIT_OR = VariantOperator::BIT_OR;
+	static constexpr Operator OP_BIT_XOR = VariantOperator::BIT_XOR;
+	static constexpr Operator OP_BIT_NEGATE = VariantOperator::BIT_NEGATE;
+	static constexpr Operator OP_AND = VariantOperator::AND;
+	static constexpr Operator OP_OR = VariantOperator::OR;
+	static constexpr Operator OP_XOR = VariantOperator::XOR;
+	static constexpr Operator OP_NOT = VariantOperator::NOT;
+	static constexpr Operator OP_IN = VariantOperator::IN;
+	static constexpr Operator OP_MAX = VariantOperator::MAX;
 
 	enum {
 		// Maximum recursion depth allowed when serializing variants.
@@ -559,42 +579,6 @@ public:
 	template <typename K, typename V>
 	_FORCE_INLINE_ Variant(const TypedDictionary<K, V> &p_typed_dictionary) :
 			Variant(static_cast<const Dictionary &>(p_typed_dictionary)) {}
-
-	// If this changes the table in variant_op must be updated
-	enum Operator {
-		//comparison
-		OP_EQUAL,
-		OP_NOT_EQUAL,
-		OP_LESS,
-		OP_LESS_EQUAL,
-		OP_GREATER,
-		OP_GREATER_EQUAL,
-		//mathematic
-		OP_ADD,
-		OP_SUBTRACT,
-		OP_MULTIPLY,
-		OP_DIVIDE,
-		OP_NEGATE,
-		OP_POSITIVE,
-		OP_MODULE,
-		OP_POWER,
-		//bitwise
-		OP_SHIFT_LEFT,
-		OP_SHIFT_RIGHT,
-		OP_BIT_AND,
-		OP_BIT_OR,
-		OP_BIT_XOR,
-		OP_BIT_NEGATE,
-		//logic
-		OP_AND,
-		OP_OR,
-		OP_XOR,
-		OP_NOT,
-		//containment
-		OP_IN,
-		OP_MAX
-
-	};
 
 	static String get_operator_name(Operator p_op);
 	static void evaluate(const Operator &p_op, const Variant &p_a, const Variant &p_b, Variant &r_ret, bool &r_valid);

--- a/core/variant/variant_enums.h
+++ b/core/variant/variant_enums.h
@@ -1,0 +1,145 @@
+/**************************************************************************/
+/*  variant_enums.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+// HACK: By wrapping these enums in a namespace, we're able to hoist the enumeration itself into
+//  the global namespace while keeping the enumeration constants constrained. This has a similar
+//  effect to the behavior of scoped enums, where the constants will require the type preceding it,
+//  but does so without changing the existing type/conversion properties. This workaround can be
+//  removed if these enums ever become scoped (ie: enum class).
+// NOTE: The secondary layer of wrappers, the "Scoped<EnumName>" namespaces, are required in order
+//  to support enums with shared names. As of now, this is relevant for exactly one case: `MAX`.
+
+namespace Internal {
+
+namespace ScopedVariantType {
+// WARNING: If this changes, the table in variant_op must be updated.
+enum VariantType {
+	NIL,
+
+	// Atomic types.
+	BOOL,
+	INT,
+	FLOAT,
+	STRING,
+
+	// Math types.
+	VECTOR2,
+	VECTOR2I,
+	RECT2,
+	RECT2I,
+	VECTOR3,
+	VECTOR3I,
+	TRANSFORM2D,
+	VECTOR4,
+	VECTOR4I,
+	PLANE,
+	QUATERNION,
+	AABB,
+	BASIS,
+	TRANSFORM3D,
+	PROJECTION,
+
+	// Misc types.
+	COLOR,
+	STRING_NAME,
+	NODE_PATH,
+	RID,
+	OBJECT,
+	CALLABLE,
+	SIGNAL,
+	DICTIONARY,
+	ARRAY,
+
+	// Packed arrays.
+	PACKED_BYTE_ARRAY,
+	PACKED_INT32_ARRAY,
+	PACKED_INT64_ARRAY,
+	PACKED_FLOAT32_ARRAY,
+	PACKED_FLOAT64_ARRAY,
+	PACKED_STRING_ARRAY,
+	PACKED_VECTOR2_ARRAY,
+	PACKED_VECTOR3_ARRAY,
+	PACKED_COLOR_ARRAY,
+	PACKED_VECTOR4_ARRAY,
+
+	// Enum size.
+	MAX,
+};
+} // namespace ScopedVariantType
+
+namespace ScopedVariantOperator {
+// WARNING: If this changes, the table in variant_op must be updated.
+enum VariantOperator {
+	// Comparison operators.
+	EQUAL,
+	NOT_EQUAL,
+	LESS,
+	LESS_EQUAL,
+	GREATER,
+	GREATER_EQUAL,
+
+	// Mathematic operators.
+	ADD,
+	SUBTRACT,
+	MULTIPLY,
+	DIVIDE,
+	NEGATE,
+	POSITIVE,
+	MODULE,
+	POWER,
+
+	// Bitwise operators.
+	SHIFT_LEFT,
+	SHIFT_RIGHT,
+	BIT_AND,
+	BIT_OR,
+	BIT_XOR,
+	BIT_NEGATE,
+
+	// Logical operators.
+	AND,
+	OR,
+	XOR,
+	NOT,
+
+	// Containment operators.
+	IN,
+
+	// Enum size.
+	MAX,
+};
+
+} // namespace ScopedVariantOperator
+} // namespace Internal
+
+using VariantType = Internal::ScopedVariantType::VariantType;
+using VariantOperator = Internal::ScopedVariantOperator::VariantOperator;


### PR DESCRIPTION
This PR creates a separate file for Variant's enums, similar to what Input has done. However, unlike the Input enums, this keeps them as regular enums but within a namespaced scope:
```cpp
namespace godot {
namespace details {

enum VariantType { ... }
enum VariantOperator { ... }

} // namespace details
} // namespace godot

using VariantType = godot::details::VariantType;
using VariantOperator = godot::details::VariantOperator;
```
These "namespaced" enums are a sort of middle-ground between legacy & scoped enums, where the type can be hoisted to the global namespace *without* also adding the enum constants with it. That is, the enum values will require a preceeding type, but are otherwise identical to legacy enums. Fully backwards-compatible bindings have been setup in `Variant`, ensuring this PR does not break compatibility out of the gate.

The purpose of this is to allow for typing logic & conditionals to be applied **without** requiring a `variant.h` include. Currently, that include severly impairs type binding tools, as they cannot properly create advanced type logic until it's too late. Similarly, this would allow for explicitly binding these enums are argument/return types for scopes prior to Variant being defined, as you cannot forward declare a nested enum. Arrays and dictionaries are by far the biggest winners from this change, as they'd be able to use `VariantType` immediately & `TypedArray`/`TypedDictionary` could have their name/bind logic consolidated to the regular headers of each respective type (what #96741 tried to accomplish).

I believe that the decoupling warrants the PR in and of itself, with explicit integration happening in subsequent PRs, but I'm open to expanding this scope instead if desired.