### PR TITLE
Allow calling an Object's method on a specific CallQueue

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -951,6 +951,11 @@ public:
 		MessageQueue::get_singleton()->push_call(this, p_name, p_args...);
 	}
 
+	template <typename... VarArgs>
+	void call_deferred_on_queue(CallQueue *p_callqueue, const StringName &p_name, VarArgs... p_args) {
+		p_callqueue->push_call(this, p_name, p_args...);
+	}
+
 	void set_deferred(const StringName &p_property, const Variant &p_value);
 
 	void set_block_signals(bool p_block);

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -36,8 +36,11 @@
 #include "core/variant/callable_bind.h"
 #include "core/variant/variant_callable.h"
 
-void Callable::call_deferredp(const Variant **p_arguments, int p_argcount) const {
-	MessageQueue::get_singleton()->push_callablep(*this, p_arguments, p_argcount, true);
+void Callable::call_deferredp(const Variant **p_arguments, int p_argcount, CallQueue *p_callqueue) const {
+	if (!p_callqueue) {
+		p_callqueue = MessageQueue::get_singleton();
+	}
+	p_callqueue->push_callablep(*this, p_arguments, p_argcount, true);
 }
 
 void Callable::callp(const Variant **p_arguments, int p_argcount, Variant &r_return_value, CallError &r_call_error) const {

--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -412,7 +412,7 @@ void EditorToaster::popup_str(const String &p_message, Severity p_severity, cons
 	// Since "_popup_str" adds nodes to the tree, and since the "add_child" method is not
 	// thread-safe, it's better to defer the call to the next cycle to be thread-safe.
 	is_processing_error = true;
-	callable_mp(this, &EditorToaster::_popup_str).call_deferred(p_message, p_severity, p_tooltip);
+	callable_mp(this, &EditorToaster::_popup_str).call_deferred_on_queue(MessageQueue::get_main_singleton(), p_message, p_severity, p_tooltip);
 	is_processing_error = false;
 }
 


### PR DESCRIPTION
This PR adds a new ``call_deferred_on_queue()`` method to the Object type.

This is required because call_deferred() semantics has changed: it is now possible to instantiate a CallQueue on a thread, and in this case, call_deferred() will schedule the call on the CallQueue associated with the current thread, instead of the CallQueue on the main thread.

In particular the ResourceLoader's thread instantiates a CallQueue, so call_deferred() calls on that thread are scheduled on that thread local CallQueue instance.

This new behavior interferes with the usage of ``EditorToaster::popup_str()`` which needs to be deferred on the main thread, because it modifies the scene tree. This PR also modifies popup_str to always defer to the main queue so it can modify the scene tree.

Without this change the popup_str() calls on the ResourceLoader thread result in error, like it is currently used in the ResourceImporterTexture class.

Developed by [Migeran](https://migeran.com/).



<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
