### PR TITLE
Update the app bundle's access and modified times to match the build time on macOS

### DIFF
--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -33,7 +33,16 @@ def generate_bundle(target, source, env):
         templ = Dir("#misc/dist/macos_tools.app").abspath
         if os.path.exists(app_dir):
             shutil.rmtree(app_dir)
-        shutil.copytree(templ, app_dir, ignore=shutil.ignore_patterns("Contents/Info.plist"))
+
+        # Create the .app bundle directory itself from scratch so that the creation
+        # date is accurate, but copy the rest of the template over.
+        os.mkdir(app_dir)
+        shutil.copytree(
+            os.path.join(templ, "Contents"),
+            os.path.join(app_dir, "Contents"),
+            ignore=shutil.ignore_patterns("Info.plist"),
+        )
+
         if not os.path.isdir(app_dir + "/Contents/MacOS"):
             os.mkdir(app_dir + "/Contents/MacOS")
         if target_bin != "":
@@ -66,6 +75,7 @@ def generate_bundle(target, source, env):
                 sign_command += [Dir("#misc/dist/macos").abspath + "/editor.entitlements"]
             sign_command += [app_dir]
             subprocess.run(sign_command)
+
     else:
         # Template bundle.
         app_prefix = "godot." + env["platform"]


### PR DESCRIPTION
(Mostly) closes #102001 .

This adds a step to the bundle-generation script that updates the access and modification times for the macOS Godot editor .app bundle, so that it appears in the filesystem as having been last accessed and modified when the bundle was built, rather than when the original app *template* was created back in March 2024.

![CleanShot 2025-01-24 at 16 02 26@2x](https://github.com/user-attachments/assets/282a00e7-426d-4b86-b4cc-424f23b4bef8)

In the orange box here, the executable and app bundle were both just built, while the top two app bundles were built a while time ago. You can see that with this PR, the new app bundle has an accurate "Date Modified" time.

Changing the "Date Created" date appears to be less trivial - I think the easiest way to go about that would be to create the .app directory itself from scratch, then copy all subdirectories from the template bundle into this newly-created directory. If you think that'd be a good idea to pursue, I can update my branch to try to implement that.
