### PR TITLE
Fix flickering in embedded game when paused

### DIFF
--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -301,6 +301,7 @@ void GameView::_stop_pressed() {
 	}
 
 	_detach_script_debugger();
+	paused = false;
 
 	EditorNode::get_singleton()->set_unfocused_low_processor_usage_mode_enabled(true);
 	embedded_process->reset();
@@ -515,15 +516,26 @@ void GameView::_update_embed_menu_options() {
 }
 
 void GameView::_update_embed_window_size() {
-	if (embed_size_mode == SIZE_MODE_FIXED || embed_size_mode == SIZE_MODE_KEEP_ASPECT) {
-		//The embedded process control will need the desired window size.
-		EditorRun::WindowPlacement placement = EditorRun::get_window_placement();
-		embedded_process->set_window_size(placement.size);
+	if (paused) {
+		// When paused, Godot does not re-render. As a result, resizing the game window to a larger size
+		// causes artifacts and flickering. However, resizing to a smaller size seems fine.
+		// To prevent artifacts and flickering, we will force the game window to maintain its size.
+		// Using the same technique as SIZE_MODE_FIXED, the embedded process control will
+		// prevent resizing the game to a larger size while maintaining the aspect ratio.
+		embedded_process->set_window_size(size_paused);
+		embedded_process->set_keep_aspect(false);
+
 	} else {
-		//Stretch... No need for the window size.
-		embedded_process->set_window_size(Size2i());
+		if (embed_size_mode == SIZE_MODE_FIXED || embed_size_mode == SIZE_MODE_KEEP_ASPECT) {
+			// The embedded process control will need the desired window size.
+			EditorRun::WindowPlacement placement = EditorRun::get_window_placement();
+			embedded_process->set_window_size(placement.size);
+		} else {
+			// Stretch... No need for the window size.
+			embedded_process->set_window_size(Size2i());
+		}
+		embedded_process->set_keep_aspect(embed_size_mode == SIZE_MODE_KEEP_ASPECT);
 	}
-	embedded_process->set_keep_aspect(embed_size_mode == SIZE_MODE_KEEP_ASPECT);
 }
 
 void GameView::_hide_selection_toggled(bool p_pressed) {
@@ -787,12 +799,27 @@ void GameView::_window_close_request() {
 		embedded_process->reset();
 
 		// When the embedding is not complete, we need to kill the process.
-		if (embedded_process->is_embedding_in_progress()) {
+		// If the game is paused, the close request will not be processed by the game, so it's better to kill the process.
+		if (paused || embedded_process->is_embedding_in_progress()) {
 			// Call deferred to prevent the _stop_pressed callback to be executed before the wrapper window
 			// actually closes.
 			callable_mp(EditorRunBar::get_singleton(), &EditorRunBar::stop_playing).call_deferred();
 		}
 	}
+}
+
+void GameView::_debugger_breaked(bool p_breaked, bool p_can_debug) {
+	if (p_breaked == paused) {
+		return;
+	}
+
+	paused = p_breaked;
+
+	if (paused) {
+		size_paused = embedded_process->get_screen_embedded_window_rect().size;
+	}
+
+	_update_embed_window_size();
 }
 
 GameView::GameView(Ref<GameViewDebugger> p_debugger, WindowWrapper *p_wrapper) {
@@ -984,6 +1011,8 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, WindowWrapper *p_wrapper) {
 	p_wrapper->set_override_close_request(true);
 	p_wrapper->connect("window_close_requested", callable_mp(this, &GameView::_window_close_request));
 	p_wrapper->connect("window_size_changed", callable_mp(this, &GameView::_update_floating_window_settings));
+
+	EditorDebuggerNode::get_singleton()->connect("breaked", callable_mp(this, &GameView::_debugger_breaked));
 }
 
 ///////
@@ -1053,15 +1082,18 @@ void GameViewPlugin::_window_visibility_changed(bool p_visible) {
 }
 
 void GameViewPlugin::_save_last_editor(const String &p_editor) {
-	if (p_editor != get_name()) {
+	if (p_editor != get_plugin_name()) {
 		last_editor = p_editor;
 	}
 }
 
 void GameViewPlugin::_focus_another_editor() {
 	if (window_wrapper->get_window_enabled()) {
-		ERR_FAIL_COND(last_editor.is_empty());
-		EditorInterface::get_singleton()->set_main_screen_editor(last_editor);
+		if (last_editor.is_empty()) {
+			EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_2D);
+		} else {
+			EditorInterface::get_singleton()->set_main_screen_editor(last_editor);
+		}
 	}
 }
 

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -122,6 +122,8 @@ class GameView : public VBoxContainer {
 	bool embed_on_play = true;
 	bool make_floating_on_play = true;
 	EmbedSizeMode embed_size_mode = SIZE_MODE_FIXED;
+	bool paused = false;
+	Size2 size_paused;
 
 	Rect2i floating_window_rect;
 	int floating_window_screen = -1;
@@ -185,6 +187,8 @@ class GameView : public VBoxContainer {
 	void _attach_script_debugger();
 	void _detach_script_debugger();
 	void _remote_window_title_changed(String title);
+
+	void _debugger_breaked(bool p_breaked, bool p_can_debug);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
- Fixes #101993

This PR should fix the flickering and artefacts when the embedded game is resized for a larger size when the game is paused. This is caused by the fact that Godot does not rerender when the game is paused, which is expected.

Although I was unable to reproduce the flickering on my computer, I did observe artifacts when the game was paused and the window was resized to a larger size.

To prevent these artifacts and hopefully the flickering, I have implemented a solution that saves the size of the embedded game when the pause is activated. This saved size is then set as a fixed size in the embedded process control to ensure the game window never becomes larger.

I also fixed another issue related to pause mode. When the game was paused, closing the floating window did not complete until the game was unpaused. This issue occurred because the close message sent to the window was not processed.

Additionally, I discovered another minor, unrelated issue. If the last selected tab was `Game` when the editor was launched, and the game was started with the floating window enabled, a blank main screen would appear in the editor. The content of the `Game` tab was transferred to the floating window, but the tab (main screen) was not changed for another editor.
