### PR TITLE
Fix deadlock caused by nested thread groups in `RaycastOcclusionCull`

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -338,7 +338,7 @@ void RaycastOcclusionCull::Scenario::_update_dirty_instance(int p_idx, RID *p_in
 	const Vector3 *read_ptr = occ->vertices.ptr();
 	float *write_ptr = occ_inst->xformed_vertices.ptr();
 
-	if (vertices_size > 1024) {
+	if (vertices_size > 1024 && WorkerThreadPool::get_singleton()->get_thread_index() == -1) {
 		TransformThreadData td;
 		td.xform = occ_inst->xform;
 		td.read = read_ptr;


### PR DESCRIPTION
Should fix deadlock which is described in [86306#issuecomment-2604466301](https://github.com/godotengine/godot/issues/86306#issuecomment-2604466301)

https://github.com/godotengine/godot/blob/b15b24b087e792335d919fd83055f50f276fbe22/modules/raycast/raycast_occlusion_cull.cpp#L427 and https://github.com/godotengine/godot/blob/b15b24b087e792335d919fd83055f50f276fbe22/modules/raycast/raycast_occlusion_cull.cpp#L432 state that there is should be only one threaded group call in both branches, possibly to avoid deadlocks like described above. So the fix is to add a variable to check if we are already in a threaded call.