### PR TITLE
Add missing `cstdint` includes for GCC 15

### DIFF
--- a/thirdparty/glslang/SPIRV/SpvBuilder.h
+++ b/thirdparty/glslang/SPIRV/SpvBuilder.h
@@ -56,6 +56,7 @@ namespace spv {
 }
 
 #include <algorithm>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>

--- a/thirdparty/glslang/patches/fix-build-gcc15.patch
+++ b/thirdparty/glslang/patches/fix-build-gcc15.patch
@@ -1,0 +1,12 @@
+diff --git a/thirdparty/glslang/SPIRV/SpvBuilder.h b/thirdparty/glslang/SPIRV/SpvBuilder.h
+index a65a98e337..1499592c4f 100644
+--- a/thirdparty/glslang/SPIRV/SpvBuilder.h
++++ b/thirdparty/glslang/SPIRV/SpvBuilder.h
+@@ -56,6 +56,7 @@ namespace spv {
+ }
+ 
+ #include <algorithm>
++#include <cstdint>
+ #include <map>
+ #include <memory>
+ #include <set>

--- a/thirdparty/thorvg/inc/thorvg.h
+++ b/thirdparty/thorvg/inc/thorvg.h
@@ -1,6 +1,7 @@
 #ifndef _THORVG_H_
 #define _THORVG_H_
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>

--- a/thirdparty/thorvg/patches/fix-build-gcc15.patch
+++ b/thirdparty/thorvg/patches/fix-build-gcc15.patch
@@ -1,0 +1,12 @@
+diff --git a/thirdparty/thorvg/inc/thorvg.h b/thirdparty/thorvg/inc/thorvg.h
+index 8e3ab4e6ce..f515a03136 100644
+--- a/thirdparty/thorvg/inc/thorvg.h
++++ b/thirdparty/thorvg/inc/thorvg.h
+@@ -1,6 +1,7 @@
+ #ifndef _THORVG_H_
+ #define _THORVG_H_
+ 
++#include <cstdint>
+ #include <functional>
+ #include <memory>
+ #include <string>


### PR DESCRIPTION
For glslang, that fix was already made upstream with https://github.com/KhronosGroup/glslang/commit/e40c14a3e007fac0e4f2e4164fdf14d1712355bd, but we're still on an older version.

For thorvg, the fix was made in their `main` branch but not in the `v0.15.x` branch.

I've confirmed that this fixes building Godot on Fedora 42 with GCC 15: https://bugzilla.redhat.com/show_bug.cgi?id=2340256