### PR TITLE
Use `FlowContainer` for `Profiler` and `Visual Profiler` bars

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -36,6 +36,7 @@
 #include "editor/gui/editor_run_bar.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/flow_container.h"
 #include "scene/resources/image_texture.h"
 
 void EditorProfiler::_make_metric_ptrs(Metric &m) {
@@ -658,27 +659,39 @@ Vector<Vector<String>> EditorProfiler::get_data_as_csv() const {
 
 EditorProfiler::EditorProfiler() {
 	HBoxContainer *hb = memnew(HBoxContainer);
+	hb->add_theme_constant_override(SNAME("separation"), 8 * EDSCALE);
 	add_child(hb);
+
+	FlowContainer *container = memnew(FlowContainer);
+	container->set_h_size_flags(SIZE_EXPAND_FILL);
+	container->add_theme_constant_override(SNAME("h_separation"), 8 * EDSCALE);
+	container->add_theme_constant_override(SNAME("v_separation"), 2 * EDSCALE);
+	hb->add_child(container);
+
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_disabled(true);
 	activate->set_text(TTR("Start"));
 	activate->connect(SceneStringName(pressed), callable_mp(this, &EditorProfiler::_activate_pressed));
-	hb->add_child(activate);
+	container->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
 	clear_button->connect(SceneStringName(pressed), callable_mp(this, &EditorProfiler::_clear_pressed));
 	clear_button->set_disabled(true);
-	hb->add_child(clear_button);
+	container->add_child(clear_button);
 
 	CheckBox *autostart_checkbox = memnew(CheckBox);
 	autostart_checkbox->set_text(TTR("Autostart"));
 	autostart_checkbox->set_pressed(EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_profiler", false));
 	autostart_checkbox->connect(SceneStringName(toggled), callable_mp(this, &EditorProfiler::_autostart_toggled));
-	hb->add_child(autostart_checkbox);
+	container->add_child(autostart_checkbox);
 
-	hb->add_child(memnew(Label(TTR("Measure:"))));
+	HBoxContainer *hb_measure = memnew(HBoxContainer);
+	hb_measure->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
+	container->add_child(hb_measure);
+
+	hb_measure->add_child(memnew(Label(TTR("Measure:"))));
 
 	display_mode = memnew(OptionButton);
 	display_mode->add_item(TTR("Frame Time (ms)"));
@@ -687,9 +700,13 @@ EditorProfiler::EditorProfiler() {
 	display_mode->add_item(TTR("Physics Frame %"));
 	display_mode->connect(SceneStringName(item_selected), callable_mp(this, &EditorProfiler::_combo_changed));
 
-	hb->add_child(display_mode);
+	hb_measure->add_child(display_mode);
 
-	hb->add_child(memnew(Label(TTR("Time:"))));
+	HBoxContainer *hb_time = memnew(HBoxContainer);
+	hb_time->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
+	container->add_child(hb_time);
+
+	hb_time->add_child(memnew(Label(TTR("Time:"))));
 
 	display_time = memnew(OptionButton);
 	// TRANSLATORS: This is an option in the profiler to display the time spent in a function, including the time spent in other functions called by that function.
@@ -698,27 +715,27 @@ EditorProfiler::EditorProfiler() {
 	display_time->add_item(TTR("Self"));
 	display_time->set_tooltip_text(TTR("Inclusive: Includes time from other functions called by this function.\nUse this to spot bottlenecks.\n\nSelf: Only count the time spent in the function itself, not in other functions called by that function.\nUse this to find individual functions to optimize."));
 	display_time->connect(SceneStringName(item_selected), callable_mp(this, &EditorProfiler::_combo_changed));
-
-	hb->add_child(display_time);
+	hb_time->add_child(display_time);
 
 	display_internal_profiles = memnew(CheckButton(TTR("Display internal functions")));
 	display_internal_profiles->set_visible(EDITOR_GET("debugger/profile_native_calls"));
 	display_internal_profiles->set_pressed(false);
 	display_internal_profiles->connect(SceneStringName(pressed), callable_mp(this, &EditorProfiler::_internal_profiles_pressed));
-	hb->add_child(display_internal_profiles);
+	container->add_child(display_internal_profiles);
 
-	hb->add_spacer();
+	HBoxContainer *hb_frame = memnew(HBoxContainer);
+	hb_frame->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
+	hb_frame->set_v_size_flags(SIZE_SHRINK_BEGIN);
+	hb->add_child(hb_frame);
 
-	hb->add_child(memnew(Label(TTR("Frame #:"))));
+	hb_frame->add_child(memnew(Label(TTR("Frame #:"))));
 
 	cursor_metric_edit = memnew(SpinBox);
 	cursor_metric_edit->set_h_size_flags(SIZE_FILL);
 	cursor_metric_edit->set_value(0);
 	cursor_metric_edit->set_editable(false);
-	hb->add_child(cursor_metric_edit);
+	hb_frame->add_child(cursor_metric_edit);
 	cursor_metric_edit->connect(SceneStringName(value_changed), callable_mp(this, &EditorProfiler::_cursor_metric_changed));
-
-	hb->add_theme_constant_override("separation", 8 * EDSCALE);
 
 	h_split = memnew(HSplitContainer);
 	add_child(h_split);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_run_bar.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/gui/flow_container.h"
 #include "scene/resources/image_texture.h"
 
 void EditorVisualProfiler::set_hardware_info(const String &p_cpu_name, const String &p_gpu_name) {
@@ -742,54 +743,67 @@ Vector<Vector<String>> EditorVisualProfiler::get_data_as_csv() const {
 
 EditorVisualProfiler::EditorVisualProfiler() {
 	HBoxContainer *hb = memnew(HBoxContainer);
+	hb->add_theme_constant_override(SNAME("separation"), 8 * EDSCALE);
 	add_child(hb);
+
+	FlowContainer *container = memnew(FlowContainer);
+	container->set_h_size_flags(SIZE_EXPAND_FILL);
+	container->add_theme_constant_override(SNAME("h_separation"), 8 * EDSCALE);
+	container->add_theme_constant_override(SNAME("v_separation"), 2 * EDSCALE);
+	hb->add_child(container);
+
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_disabled(true);
 	activate->set_text(TTR("Start"));
 	activate->connect(SceneStringName(pressed), callable_mp(this, &EditorVisualProfiler::_activate_pressed));
-	hb->add_child(activate);
+	container->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
 	clear_button->set_disabled(true);
 	clear_button->connect(SceneStringName(pressed), callable_mp(this, &EditorVisualProfiler::_clear_pressed));
-	hb->add_child(clear_button);
+	container->add_child(clear_button);
 
 	CheckBox *autostart_checkbox = memnew(CheckBox);
 	autostart_checkbox->set_text(TTR("Autostart"));
 	autostart_checkbox->set_pressed(EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_visual_profiler", false));
 	autostart_checkbox->connect(SceneStringName(toggled), callable_mp(this, &EditorVisualProfiler::_autostart_toggled));
-	hb->add_child(autostart_checkbox);
+	container->add_child(autostart_checkbox);
 
-	hb->add_child(memnew(Label(TTR("Measure:"))));
+	HBoxContainer *hb_measure = memnew(HBoxContainer);
+	hb_measure->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
+	container->add_child(hb_measure);
+
+	hb_measure->add_child(memnew(Label(TTR("Measure:"))));
 
 	display_mode = memnew(OptionButton);
 	display_mode->add_item(TTR("Frame Time (ms)"));
 	display_mode->add_item(TTR("Frame %"));
 	display_mode->connect(SceneStringName(item_selected), callable_mp(this, &EditorVisualProfiler::_combo_changed));
 
-	hb->add_child(display_mode);
+	hb_measure->add_child(display_mode);
 
 	frame_relative = memnew(CheckBox(TTR("Fit to Frame")));
 	frame_relative->set_pressed(true);
-	hb->add_child(frame_relative);
+	container->add_child(frame_relative);
 	frame_relative->connect(SceneStringName(pressed), callable_mp(this, &EditorVisualProfiler::_update_plot));
 	linked = memnew(CheckBox(TTR("Linked")));
 	linked->set_pressed(true);
-	hb->add_child(linked);
+	container->add_child(linked);
 	linked->connect(SceneStringName(pressed), callable_mp(this, &EditorVisualProfiler::_update_plot));
 
-	hb->add_spacer();
+	HBoxContainer *hb_frame = memnew(HBoxContainer);
+	hb_frame->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
+	hb_frame->set_v_size_flags(SIZE_SHRINK_BEGIN);
+	hb->add_child(hb_frame);
 
-	hb->add_child(memnew(Label(TTR("Frame #:"))));
+	hb_frame->add_child(memnew(Label(TTR("Frame #:"))));
 
 	cursor_metric_edit = memnew(SpinBox);
 	cursor_metric_edit->set_h_size_flags(SIZE_FILL);
-	hb->add_child(cursor_metric_edit);
+	hb_frame->add_child(cursor_metric_edit);
 	cursor_metric_edit->connect(SceneStringName(value_changed), callable_mp(this, &EditorVisualProfiler::_cursor_metric_changed));
-
-	hb->add_theme_constant_override("separation", 8 * EDSCALE);
 
 	h_split = memnew(HSplitContainer);
 	add_child(h_split);


### PR DESCRIPTION
This should prevent the editor GUI from breaking when the `Profiler` or `Visual Profiler` tabs are opened when the window is small.

Video with initial version of PR which shows the problem.

https://github.com/user-attachments/assets/0b009bac-2b28-45b0-bad9-b5ee5b2025cf


Video with current state of PR. Frame selection now always in the top right corner.

https://github.com/user-attachments/assets/0c40b4ba-0ac9-4587-9440-059fdc334c97