### PR TITLE
Add saving flag hack to Skeleton and revert reset timing of animation

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1913,14 +1913,12 @@ void EditorNode::_save_scene(String p_file, int idx) {
 		return;
 	}
 
-	List<Pair<AnimationMixer *, Ref<AnimatedValuesBackup>>> anim_backups;
-	_reset_animation_mixers(scene, &anim_backups);
-
 	scene->propagate_notification(NOTIFICATION_EDITOR_PRE_SAVE);
 
 	editor_data.apply_changes_in_editors();
 	save_default_environment();
-
+	List<Pair<AnimationMixer *, Ref<AnimatedValuesBackup>>> anim_backups;
+	_reset_animation_mixers(scene, &anim_backups);
 	_save_editor_states(p_file, idx);
 
 	Ref<PackedScene> sdata;

--- a/scene/3d/retarget_modifier_3d.cpp
+++ b/scene/3d/retarget_modifier_3d.cpp
@@ -465,12 +465,6 @@ void RetargetModifier3D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			_update_child_skeletons();
 		} break;
-#ifdef TOOLS_ENABLED
-		case NOTIFICATION_EDITOR_PRE_SAVE: {
-			_reset_child_skeleton_poses();
-			_force_update_child_skeletons();
-		} break;
-#endif // TOOLS_ENABLED
 		case NOTIFICATION_EXIT_TREE: {
 			_reset_child_skeletons();
 		} break;

--- a/scene/3d/retarget_modifier_3d.h
+++ b/scene/3d/retarget_modifier_3d.h
@@ -117,6 +117,10 @@ public:
 	void set_profile(Ref<SkeletonProfile> p_profile);
 	Ref<SkeletonProfile> get_profile() const;
 
+#ifdef TOOLS_ENABLED
+	virtual bool is_processed_on_saving() const override { return true; }
+#endif
+
 	RetargetModifier3D();
 	virtual ~RetargetModifier3D();
 };

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -66,6 +66,10 @@ public:
 class Skeleton3D : public Node3D {
 	GDCLASS(Skeleton3D, Node3D);
 
+#ifdef TOOLS_ENABLED
+	bool saving = false;
+#endif //TOOLS_ENABLED
+
 #ifndef DISABLE_DEPRECATED
 	bool animate_physical_bones = true;
 	Node *simulator = nullptr;

--- a/scene/3d/skeleton_modifier_3d.h
+++ b/scene/3d/skeleton_modifier_3d.h
@@ -91,6 +91,10 @@ public:
 	static Vector3 get_vector_from_axis(Vector3::Axis p_axis);
 	static Vector3::Axis get_axis_from_bone_axis(BoneAxis p_axis);
 
+#ifdef TOOLS_ENABLED
+	virtual bool is_processed_on_saving() const { return false; }
+#endif
+
 	SkeletonModifier3D();
 };
 

--- a/scene/3d/spring_bone_collision_3d.cpp
+++ b/scene/3d/spring_bone_collision_3d.cpp
@@ -180,13 +180,3 @@ Vector3 SpringBoneCollision3D::collide(const Transform3D &p_center, float p_bone
 Vector3 SpringBoneCollision3D::_collide(const Transform3D &p_center, float p_bone_radius, float p_bone_length, const Vector3 &p_current) const {
 	return Vector3(0, 0, 0);
 }
-
-#ifdef TOOLS_ENABLED
-void SpringBoneCollision3D::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_EDITOR_PRE_SAVE: {
-			sync_pose();
-		} break;
-	}
-}
-#endif // TOOLS_ENABLED

--- a/scene/3d/spring_bone_collision_3d.h
+++ b/scene/3d/spring_bone_collision_3d.h
@@ -47,9 +47,6 @@ protected:
 
 	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
-#ifdef TOOLS_ENABLED
-	virtual void _notification(int p_what);
-#endif // TOOLS_ENABLED
 
 	virtual Vector3 _collide(const Transform3D &p_center, float p_bone_radius, float p_bone_length, const Vector3 &p_current) const;
 

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -397,6 +397,12 @@ void SpringBoneSimulator3D::_notification(int p_what) {
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 			update_gizmos();
 		} break;
+		case NOTIFICATION_EDITOR_PRE_SAVE: {
+			saving = true;
+		} break;
+		case NOTIFICATION_EDITOR_POST_SAVE: {
+			saving = false;
+		} break;
 #endif // TOOLS_ENABLED
 	}
 }
@@ -1467,6 +1473,13 @@ void SpringBoneSimulator3D::_process_modification() {
 	}
 	_find_collisions();
 	_process_collisions();
+
+#ifdef TOOLS_ENABLED
+	if (saving) {
+		return; // Collision position has been reset but we don't want to process simulating on saving. Abort.
+	}
+#endif //TOOLS_ENABLED
+
 	double delta = skeleton->get_modifier_callback_mode_process() == Skeleton3D::MODIFIER_CALLBACK_MODE_PROCESS_IDLE ? skeleton->get_process_delta_time() : skeleton->get_physics_process_delta_time();
 	for (int i = 0; i < settings.size(); i++) {
 		_init_joints(skeleton, settings[i]);

--- a/scene/3d/spring_bone_simulator_3d.h
+++ b/scene/3d/spring_bone_simulator_3d.h
@@ -36,6 +36,10 @@
 class SpringBoneSimulator3D : public SkeletonModifier3D {
 	GDCLASS(SpringBoneSimulator3D, SkeletonModifier3D);
 
+#ifdef TOOLS_ENABLED
+	bool saving = false;
+#endif //TOOLS_ENABLED
+
 	bool joints_dirty = false;
 
 	LocalVector<ObjectID> collisions; // To process collisions for sync position with skeleton.
@@ -274,6 +278,10 @@ public:
 
 	// To process manually.
 	void reset();
+
+#ifdef TOOLS_ENABLED
+	virtual bool is_processed_on_saving() const override { return true; }
+#endif
 };
 
 VARIANT_ENUM_CAST(SpringBoneSimulator3D::BoneDirection);


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/101963
- Revert https://github.com/godotengine/godot/pull/101450

Revert the reset timing of Animation and instead add a saving flag to Skeleton3D as in https://github.com/godotengine/godot/pull/91495.

For review, check if the following issue occurs again as regression. Maybe we should add static tests later.
- https://github.com/godotengine/godot/issues/95202
- https://github.com/godotengine/godot/pull/101451