### PR TITLE
Override mass properties for `Area3D` when using Jolt Physics

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -92,6 +92,9 @@ void JoltArea3D::_add_to_space() {
 	jolt_settings->mMotionType = _get_motion_type();
 	jolt_settings->mIsSensor = true;
 	jolt_settings->mUseManifoldReduction = false;
+	jolt_settings->mOverrideMassProperties = JPH::EOverrideMassProperties::MassAndInertiaProvided;
+	jolt_settings->mMassPropertiesOverride.mMass = 1.0f;
+	jolt_settings->mMassPropertiesOverride.mInertia = JPH::Mat44::sIdentity();
 
 	if (JoltProjectSettings::areas_detect_static_bodies()) {
 		jolt_settings->mCollideKinematicVsNonDynamic = true;


### PR DESCRIPTION
Fixes #101917.

Doing this resolves the assertion about "Invalid mass" when trying to use `ConcavePolygonShape3D` for an `Area3D`.

The reason for this assertion is that `Area3D` are implemented with what Jolt calls sensors, which are a type of body, and thus happen to have mass properties as well, which can't reasonably be calculated automatically for shapes like `ConcavePolygonShape3D`.

Note that concave shapes for an `Area3D` is problematic for a number of reasons, as mentioned in [the documentation](https://docs.godotengine.org/en/latest/classes/class_area3d.html) for `Area3D`, but it seems to work on some basic level at least, and seems to be about as janky in Godot Physics already, so I guess it's fine to just allow it for now.