### PR TITLE
Fix error spam at start with `Skeleton3D` modifiers

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -355,7 +355,9 @@ void Skeleton3D::_notification(int p_what) {
 				// Store dirty flags for global bone poses.
 				bone_global_pose_dirty_backup = bone_global_pose_dirty;
 
-				_process_modifiers();
+				if (is_inside_tree()) {
+					_process_modifiers();
+				}
 			}
 
 			// Abort if pose is not changed.


### PR DESCRIPTION
Without this, the following error will printed several times at the start:
```
ERROR: scene/3d/node_3d.cpp:466 - Condition "!is_inside_tree()" is true. Returning: Transform3D()
```