### PR TITLE
Reimplement _wsl_frame_recv_end_callback()

### DIFF
--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -611,6 +611,16 @@ void WSLPeer::_wsl_frame_recv_chunk_callback(wslay_event_context_ptr ctx, const 
 	}
 }
 
+void WSLPeer::_wsl_frame_recv_end_callback(wslay_event_context_ptr ctx, void *user_data) {
+	WSLPeer *peer = (WSLPeer *)user_data;
+	PendingMessage &pm = peer->pending_message;
+	if (pm.opcode == WSLAY_TEXT_FRAME || pm.opcode == WSLAY_BINARY_FRAME) {
+		// Only write the packet (since it's now completed).
+		uint8_t is_string = pm.opcode == WSLAY_TEXT_FRAME ? 1 : 0;
+		peer->in_buffer.write_packet(nullptr, pm.payload_size, &is_string);
+	}
+}
+
 ssize_t WSLPeer::_wsl_send_callback(wslay_event_context_ptr ctx, const uint8_t *data, size_t len, int flags, void *user_data) {
 	WSLPeer *peer = (WSLPeer *)user_data;
 	Ref<StreamPeer> conn = peer->connection;
@@ -658,13 +668,6 @@ void WSLPeer::_wsl_msg_recv_callback(wslay_event_context_ptr ctx, const struct w
 
 	if (op == WSLAY_PONG) {
 		peer->heartbeat_waiting = false;
-	} else if (op == WSLAY_TEXT_FRAME || op == WSLAY_BINARY_FRAME) {
-		PendingMessage &pm = peer->pending_message;
-		ERR_FAIL_COND(pm.opcode != op);
-		// Only write the packet (since it's now completed).
-		uint8_t is_string = pm.opcode == WSLAY_TEXT_FRAME ? 1 : 0;
-		peer->in_buffer.write_packet(nullptr, pm.payload_size, &is_string);
-		pm.clear();
 	}
 	// Ping.
 }
@@ -675,7 +678,7 @@ wslay_event_callbacks WSLPeer::_wsl_callbacks = {
 	_wsl_genmask_callback,
 	_wsl_recv_start_callback,
 	_wsl_frame_recv_chunk_callback,
-	nullptr,
+	_wsl_frame_recv_end_callback,
 	_wsl_msg_recv_callback
 };
 

--- a/modules/websocket/wsl_peer.h
+++ b/modules/websocket/wsl_peer.h
@@ -53,6 +53,7 @@ private:
 	static ssize_t _wsl_recv_callback(wslay_event_context_ptr ctx, uint8_t *data, size_t len, int flags, void *user_data);
 	static void _wsl_recv_start_callback(wslay_event_context_ptr ctx, const struct wslay_event_on_frame_recv_start_arg *arg, void *user_data);
 	static void _wsl_frame_recv_chunk_callback(wslay_event_context_ptr ctx, const struct wslay_event_on_frame_recv_chunk_arg *arg, void *user_data);
+	static void _wsl_frame_recv_end_callback(wslay_event_context_ptr ctx, void *user_data);
 
 	static ssize_t _wsl_send_callback(wslay_event_context_ptr ctx, const uint8_t *data, size_t len, int flags, void *user_data);
 	static int _wsl_genmask_callback(wslay_event_context_ptr ctx, uint8_t *buf, size_t len, void *user_data);


### PR DESCRIPTION
Fix #101811

An [extraneous call to clear the PendingMessage](https://github.com/godotengine/godot/pull/98343/files#diff-9348306b0794d0739d7d81022e096cede90d18fe9b9113f60c36e802ce572634R621) was in the original PR #98343, which was moved to `_wsl_send_callback()` in #100631 in an attempt to fix incoming control frames during a multi-frame message.

This PR seeks to restore the fixed multi-frame logic to `_wsl_frame_recv_end_callback()` while limiting that callback to text and binary frames only, as originally intended.