### PR TITLE
Documentation change from Blender directory to executable

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -711,8 +711,28 @@
 			Port used for file server when exporting project with remote file system.
 		</member>
 		<member name="filesystem/import/blender/blender_path" type="String" setter="" getter="">
-			The path to the directory containing the Blender executable used for converting the Blender 3D scene files [code].blend[/code] to glTF 2.0 format during import. Blender 3.0 or later is required.
+			The path to the Blender executable used for converting the Blender 3D scene files [code].blend[/code] to glTF 2.0 format during import. Blender 3.0 or later is required.
 			To enable this feature for your specific project, use [member ProjectSettings.filesystem/import/blender/enabled].
+			If this setting is empty, Blender's default paths will be detected and used automatically if present in this order:
+			[b]Windows:[/b]
+			[codeblock]
+			- C:\Program Files\Blender Foundation\blender.exe
+			- C:\Program Files (x86)\Blender Foundation\blender.exe
+			[/codeblock]
+			[b]macOS:[/b]
+			[codeblock]
+			- /opt/homebrew/bin/blender
+			- /opt/local/bin/blender
+			- /usr/local/bin/blender
+			- /usr/local/opt/blender
+			- /Applications/Blender.app/Contents/MacOS/Blender
+			[/codeblock]
+			[b]Linux/*BSD:[/b]
+			[codeblock]
+			- /usr/bin/blender
+			- /usr/local/bin/blender
+			- /opt/blender/bin/blender
+			[/codeblock]
 		</member>
 		<member name="filesystem/import/blender/rpc_port" type="int" setter="" getter="">
 			The port number used for Remote Procedure Call (RPC) communication with Godot's created process of the blender executable.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Currently the editor documentation says that the user should pass the directory where the executable is located, but in fact the editor is expecting the path to the executable.

![image](https://github.com/user-attachments/assets/27b6b8ee-2284-433b-a6a7-49963d1ad0b5)

![image](https://github.com/user-attachments/assets/327f136a-c92d-4e61-bb82-78ca826994d8)

![image](https://github.com/user-attachments/assets/73bd656d-b84e-43c2-a28b-e655e3397868)
