### PR TITLE
Fix BadWindow error when stopping embedded game on Linux

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5853,16 +5853,20 @@ Error DisplayServerX11::remove_embedded_process(OS::ProcessID p_pid) {
 	// Handle bad window errors silently because just in case the embedded window was closed.
 	int (*oldHandler)(Display *, XErrorEvent *) = XSetErrorHandler(&bad_window_error_handler);
 
-	// Send the message to gracefully close the window.
-	XEvent ev;
-	memset(&ev, 0, sizeof(ev));
-	ev.xclient.type = ClientMessage;
-	ev.xclient.window = ep->process_window;
-	ev.xclient.message_type = XInternAtom(x11_display, "WM_PROTOCOLS", True);
-	ev.xclient.format = 32;
-	ev.xclient.data.l[0] = XInternAtom(x11_display, "WM_DELETE_WINDOW", False);
-	ev.xclient.data.l[1] = CurrentTime;
-	XSendEvent(x11_display, ep->process_window, False, NoEventMask, &ev);
+	// Check if the window is still valid.
+	XWindowAttributes attr;
+	if (XGetWindowAttributes(x11_display, ep->process_window, &attr)) {
+		// Send the message to gracefully close the window.
+		XEvent ev;
+		memset(&ev, 0, sizeof(ev));
+		ev.xclient.type = ClientMessage;
+		ev.xclient.window = ep->process_window;
+		ev.xclient.message_type = XInternAtom(x11_display, "WM_PROTOCOLS", True);
+		ev.xclient.format = 32;
+		ev.xclient.data.l[0] = XInternAtom(x11_display, "WM_DELETE_WINDOW", False);
+		ev.xclient.data.l[1] = CurrentTime;
+		XSendEvent(x11_display, ep->process_window, False, NoEventMask, &ev);
+	}
 
 	// Restore default error handler.
 	XSetErrorHandler(oldHandler);


### PR DESCRIPTION
- Fixes #102039

The error was introduced in the PR https://github.com/godotengine/godot/pull/101895 on Linux when using the `Stop` button when the game is embedded. When using the `Stop` button the game process is killed and the window id becomes invalid. Even with the `XSetErrorHandler(&bad_window_error_handler)`, the error is thrown on the next x11 call. Adding a little check to see if the window is still valid before executing the `XSendEvent` fixed the issue.

The error was:
```
INTERNAL ERROR: Unhandled XServer error: BadWindow (invalid Window parameter)
   Major opcode of failed request: 25
   Serial number of failed request: 0
   Current serial number in output stream: 8195764
```

CC @YeldhamDev