### PR TITLE
Enhance the export preset interface method

### DIFF
--- a/doc/classes/EditorExportPreset.xml
+++ b/doc/classes/EditorExportPreset.xml
@@ -9,6 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="add_export_file">
+			<return type="void" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Adds a file to the export list with default export mode.
+			</description>
+		</method>
 		<method name="are_advanced_options_enabled" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -160,6 +167,125 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if "Runnable" toggle is enabled in the export dialog.
+			</description>
+		</method>
+		<method name="remove_export_file">
+			<return type="void" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Removes a file from the export list.
+			</description>
+		</method>
+		<method name="set_advanced_options_enabled">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Enables or disables advanced export options.
+			</description>
+		</method>
+		<method name="set_custom_features">
+			<return type="void" />
+			<param index="0" name="features" type="String" />
+			<description>
+				Sets a comma-separated list of custom features to enable during export. These features can be used for conditional compilation or platform-specific functionality.
+			</description>
+		</method>
+		<method name="set_customized_files">
+			<return type="void" />
+			<param index="0" name="files" type="Dictionary" />
+			<description>
+				Sets the customized files dictionary. The dictionary keys are file paths and values are export modes (0 = not customized, 1 = strip, 2 = keep, 3 = remove).
+			</description>
+		</method>
+		<method name="set_encrypt_directory">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Enables or disables directory encryption.
+			</description>
+		</method>
+		<method name="set_encrypt_pck">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Enables or disables PCK file encryption.
+			</description>
+		</method>
+		<method name="set_encryption_ex_filter">
+			<return type="void" />
+			<param index="0" name="filter" type="String" />
+			<description>
+				Sets the exclude filter pattern for files to not encrypt.
+			</description>
+		</method>
+		<method name="set_encryption_in_filter">
+			<return type="void" />
+			<param index="0" name="filter" type="String" />
+			<description>
+				Sets the include filter pattern for files to encrypt.
+			</description>
+		</method>
+		<method name="set_encryption_key">
+			<return type="void" />
+			<param index="0" name="key" type="String" />
+			<description>
+				Sets the encryption key for the exported files.
+			</description>
+		</method>
+		<method name="set_exclude_filter">
+			<return type="void" />
+			<param index="0" name="exclude" type="String" />
+			<description>
+				Sets the exclude filter pattern for resources to exclude from export.
+			</description>
+		</method>
+		<method name="set_export_filter">
+			<return type="void" />
+			<param index="0" name="filter" type="int" enum="EditorExportPreset.ExportFilter" />
+			<description>
+				Sets the export filter mode. Modes are: 0 = all resources, 1 = selected scenes, 2 = selected resources, 3 = exclude selected resources, 4 = customized.
+			</description>
+		</method>
+		<method name="set_export_path">
+			<return type="void" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Sets the output path for the exported file.
+			</description>
+		</method>
+		<method name="set_file_export_mode">
+			<return type="void" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="mode" type="int" enum="EditorExportPreset.FileExportMode" />
+			<description>
+				Sets the export mode for a specific file. Modes are: 0 = not customized, 1 = strip, 2 = keep, 3 = remove.
+			</description>
+		</method>
+		<method name="set_include_filter">
+			<return type="void" />
+			<param index="0" name="include" type="String" />
+			<description>
+				Sets the include filter pattern for resources to export.
+			</description>
+		</method>
+		<method name="set_patches">
+			<return type="void" />
+			<param index="0" name="patches" type="PackedStringArray" />
+			<description>
+				Sets the list of patch files to include in the export.
+			</description>
+		</method>
+		<method name="set_script_export_mode">
+			<return type="void" />
+			<param index="0" name="mode" type="int" />
+			<description>
+				Sets the script export mode. Modes are: 0 = text, 1 = binary tokens, 2 = compressed binary tokens.
+			</description>
+		</method>
+		<method name="update_files">
+			<return type="void" />
+			<description>
+				Updates the list of files to export based on current settings.
 			</description>
 		</method>
 	</methods>

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -65,27 +65,46 @@ void EditorExportPreset::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("has", "property"), &EditorExportPreset::has);
 
+	ClassDB::bind_method(D_METHOD("set_customized_files", "files"), &EditorExportPreset::set_customized_files);
+	ClassDB::bind_method(D_METHOD("update_files"), &EditorExportPreset::update_files);
+	ClassDB::bind_method(D_METHOD("add_export_file", "path"), &EditorExportPreset::add_export_file);
+	ClassDB::bind_method(D_METHOD("remove_export_file", "path"), &EditorExportPreset::remove_export_file);
+	ClassDB::bind_method(D_METHOD("has_export_file", "path"), &EditorExportPreset::has_export_file);
+
 	ClassDB::bind_method(D_METHOD("get_files_to_export"), &EditorExportPreset::get_files_to_export);
 	ClassDB::bind_method(D_METHOD("get_customized_files"), &EditorExportPreset::get_customized_files);
 	ClassDB::bind_method(D_METHOD("get_customized_files_count"), &EditorExportPreset::get_customized_files_count);
-	ClassDB::bind_method(D_METHOD("has_export_file", "path"), &EditorExportPreset::has_export_file);
+	ClassDB::bind_method(D_METHOD("set_file_export_mode", "path", "mode"), &EditorExportPreset::set_file_export_mode);
 	ClassDB::bind_method(D_METHOD("get_file_export_mode", "path", "default"), &EditorExportPreset::get_file_export_mode, DEFVAL(MODE_FILE_NOT_CUSTOMIZED));
 
 	ClassDB::bind_method(D_METHOD("get_preset_name"), &EditorExportPreset::get_name);
 	ClassDB::bind_method(D_METHOD("is_runnable"), &EditorExportPreset::is_runnable);
+	ClassDB::bind_method(D_METHOD("set_advanced_options_enabled", "enabled"), &EditorExportPreset::set_advanced_options_enabled);
 	ClassDB::bind_method(D_METHOD("are_advanced_options_enabled"), &EditorExportPreset::are_advanced_options_enabled);
 	ClassDB::bind_method(D_METHOD("is_dedicated_server"), &EditorExportPreset::is_dedicated_server);
+	ClassDB::bind_method(D_METHOD("set_export_filter", "filter"), &EditorExportPreset::set_export_filter);
 	ClassDB::bind_method(D_METHOD("get_export_filter"), &EditorExportPreset::get_export_filter);
+	ClassDB::bind_method(D_METHOD("set_include_filter", "include"), &EditorExportPreset::set_include_filter);
 	ClassDB::bind_method(D_METHOD("get_include_filter"), &EditorExportPreset::get_include_filter);
+	ClassDB::bind_method(D_METHOD("set_exclude_filter", "exclude"), &EditorExportPreset::set_exclude_filter);
 	ClassDB::bind_method(D_METHOD("get_exclude_filter"), &EditorExportPreset::get_exclude_filter);
+	ClassDB::bind_method(D_METHOD("set_custom_features", "features"), &EditorExportPreset::set_custom_features);
 	ClassDB::bind_method(D_METHOD("get_custom_features"), &EditorExportPreset::get_custom_features);
+	ClassDB::bind_method(D_METHOD("set_patches", "patches"), &EditorExportPreset::set_patches);
 	ClassDB::bind_method(D_METHOD("get_patches"), &EditorExportPreset::get_patches);
+	ClassDB::bind_method(D_METHOD("set_export_path", "path"), &EditorExportPreset::set_export_path);
 	ClassDB::bind_method(D_METHOD("get_export_path"), &EditorExportPreset::get_export_path);
+	ClassDB::bind_method(D_METHOD("set_encryption_in_filter", "filter"), &EditorExportPreset::set_enc_in_filter);
 	ClassDB::bind_method(D_METHOD("get_encryption_in_filter"), &EditorExportPreset::get_enc_in_filter);
+	ClassDB::bind_method(D_METHOD("set_encryption_ex_filter", "filter"), &EditorExportPreset::set_enc_ex_filter);
 	ClassDB::bind_method(D_METHOD("get_encryption_ex_filter"), &EditorExportPreset::get_enc_ex_filter);
+	ClassDB::bind_method(D_METHOD("set_encrypt_pck", "enabled"), &EditorExportPreset::set_enc_pck);
 	ClassDB::bind_method(D_METHOD("get_encrypt_pck"), &EditorExportPreset::get_enc_pck);
+	ClassDB::bind_method(D_METHOD("set_encrypt_directory", "enabled"), &EditorExportPreset::set_enc_directory);
 	ClassDB::bind_method(D_METHOD("get_encrypt_directory"), &EditorExportPreset::get_enc_directory);
+	ClassDB::bind_method(D_METHOD("set_encryption_key", "key"), &EditorExportPreset::set_script_encryption_key);
 	ClassDB::bind_method(D_METHOD("get_encryption_key"), &EditorExportPreset::get_script_encryption_key);
+	ClassDB::bind_method(D_METHOD("set_script_export_mode", "mode"), &EditorExportPreset::set_script_export_mode);
 	ClassDB::bind_method(D_METHOD("get_script_export_mode"), &EditorExportPreset::get_script_export_mode);
 
 	ClassDB::bind_method(D_METHOD("get_or_env", "name", "env_var"), &EditorExportPreset::_get_or_env);


### PR DESCRIPTION
The current ExportPrset interface has limitations for custom export plugins, making it difficult to handle pck processing flexibly. This PR will expose more internal interfaces to the user layer, enhancing the plugin's processing capabilities. 
*My use case involves exporting different pck files based on the file list I configure during the export process.*

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/11798*