### PR TITLE
[4.4] [Core] Fix performance issues in some `CowData` methods

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -436,20 +436,19 @@ Error CowData<T>::_realloc(Size p_alloc_size) {
 
 template <typename T>
 typename CowData<T>::Size CowData<T>::find(const T &p_val, Size p_from) const {
-	Size ret = -1;
-
-	if (p_from < 0 || size() == 0) {
-		return ret;
+	if (p_from < 0) {
+		return -1;
 	}
 
-	for (Size i = p_from; i < size(); i++) {
-		if (get(i) == p_val) {
-			ret = i;
-			break;
+	const Size s = size();
+
+	for (Size i = p_from; i < s; i++) {
+		if (_ptr[i] == p_val) {
+			return i;
 		}
 	}
 
-	return ret;
+	return -1;
 }
 
 template <typename T>
@@ -464,7 +463,7 @@ typename CowData<T>::Size CowData<T>::rfind(const T &p_val, Size p_from) const {
 	}
 
 	for (Size i = p_from; i >= 0; i--) {
-		if (get(i) == p_val) {
+		if (_ptr[i] == p_val) {
 			return i;
 		}
 	}
@@ -474,8 +473,9 @@ typename CowData<T>::Size CowData<T>::rfind(const T &p_val, Size p_from) const {
 template <typename T>
 typename CowData<T>::Size CowData<T>::count(const T &p_val) const {
 	Size amount = 0;
-	for (Size i = 0; i < size(); i++) {
-		if (get(i) == p_val) {
+	const Size s = size();
+	for (Size i = 0; i < s; i++) {
+		if (_ptr[i] == p_val) {
 			amount++;
 		}
 	}


### PR DESCRIPTION
These relied on `get` which does a bounds check each time on debug builds

In my testing, using the below MRP, this gives (before vs after):
```
PackedInt32Array.find():  607259 usec for 5000000 iterations
PackedInt32Array.rfind(): 483297 usec for 5000000 iterations
PackedInt32Array.count(): 747576 usec for 5000000 iterations
```
```
PackedInt32Array.find():  480270 usec for 5000000 iterations
PackedInt32Array.rfind(): 465183 usec for 5000000 iterations
PackedInt32Array.count(): 470655 usec for 5000000 iterations
```

[test-cowdata.zip](https://github.com/user-attachments/files/18550508/test-cowdata.zip)

There might be more points of issue here (`CowData(std::initializer_list<T> p_init)` calling `set` repeatedly and causing COW for example) but these are the most trivial cases

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
