### PR TITLE
Change `VariantUtility` to prevent undef `print_verbose`

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -999,9 +999,7 @@ void VariantUtilityFunctions::print_rich(const Variant **p_args, int p_arg_count
 	r_error.error = Callable::CallError::CALL_OK;
 }
 
-#undef print_verbose
-
-void VariantUtilityFunctions::print_verbose(const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+void VariantUtilityFunctions::_print_verbose(const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
 	if (OS::get_singleton()->is_stdout_verbose()) {
 		String s;
 		for (int i = 0; i < p_arg_count; i++) {
@@ -1581,16 +1579,16 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 	};                                                                                                           \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
-#define FUNCBINDVARARGV(m_func, m_args, m_category)                                                              \
+#define FUNCBINDVARARGV_CNAME(m_func, m_func_cname, m_args, m_category)                                          \
 	class Func_##m_func {                                                                                        \
 	public:                                                                                                      \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
 			r_error.error = Callable::CallError::CALL_OK;                                                        \
-			VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                                        \
+			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, r_error);                                  \
 		}                                                                                                        \
 		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
 			Callable::CallError c;                                                                               \
-			VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                              \
+			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, c);                                        \
 		}                                                                                                        \
 		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
 			Vector<Variant> args;                                                                                \
@@ -1624,6 +1622,8 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		}                                                                                                        \
 	};                                                                                                           \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
+
+#define FUNCBINDVARARGV(m_func, m_args, m_category) FUNCBINDVARARGV_CNAME(m_func, m_func, m_args, m_category)
 
 #define FUNCBIND(m_func, m_args, m_category)                                                                     \
 	class Func_##m_func {                                                                                        \
@@ -1832,7 +1832,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDVARARGV(printt, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(prints, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(printraw, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDVARARGV(print_verbose, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDVARARGV_CNAME(print_verbose, _print_verbose, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(push_error, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(push_warning, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -133,8 +133,7 @@ struct VariantUtilityFunctions {
 	static String type_string(Variant::Type p_type);
 	static void print(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static void print_rich(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
-#undef print_verbose
-	static void print_verbose(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
+	static void _print_verbose(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static void printerr(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static void printt(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static void prints(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);


### PR DESCRIPTION
Changes the `VariantUtility` function from `print_verbose` to `_print_verbose`, eliminating the need for undefining the `print_verbose` macro, which caused compilation problems.

Fixes #101966

## Notes
* Although the problem was seen occurring in a SCU build, the problem was not directly related to SCU, but rather the fact that `variant_utility.h` undefined `print_verbose`.
* This meant that any code compiled _after_ this include would fail to compile `print_verbose`.
* Feel free to suggest any variations on the macro name / func name, these were just a quick guess.

## Discussion
`VariantUtility` contained a `print_verbose` function for binding (with gdscript etc) which conflicted with the global definition of `print_verbose`. This had been worked around by undefining `print_verbose` in these files, which was a little hacky, and had the side effect of breaking compilation in any later file that tried to use `print_verbose`.

The more sensible solution was to give the `VariantUtility` function a different name. @Calinou informed me that it was possible to bind a function with a different name exposed to gdscript than the c++ function, and this (hopefully) provides the simplest solution.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
