### PR TITLE
Remove early return for cached resources in `GDScript::set_path_cache()`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1076,11 +1076,6 @@ void GDScript::_bind_methods() {
 }
 
 void GDScript::set_path_cache(const String &p_path) {
-	if (ResourceCache::has(p_path)) {
-		set_path(p_path, true);
-		return;
-	}
-
 	if (is_root_script()) {
 		Script::set_path_cache(p_path);
 	}


### PR DESCRIPTION
Fix #99006

From what I understand the logic that was removed meant that if a script were cached, it would never set the path cache, just the path.

I believe removing that check and early exit to guarantee setting the path cache is the appropriate fix.