### PR TITLE
Windows: Normalize slashes in return of `OS.get_temp_dir()`

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2168,7 +2168,7 @@ String OS_Windows::get_temp_path() const {
 			temp_path_cache = get_config_path();
 		}
 	}
-	return temp_path_cache;
+	return temp_path_cache.replace("\\", "/").trim_suffix("/");
 }
 
 // Get properly capitalized engine name for system paths


### PR DESCRIPTION
Added Backslash replacement in OS.get_temp_dir() function for consistency with other OS file path functions.

Fixes https://github.com/godotengine/godot/issues/102008

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
