### PR TITLE
Initialize `pa_buffer_attr.maxlength` to -1

### DIFF
--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -725,7 +725,8 @@ Error AudioDriverPulseAudio::init_input_device() {
 	int input_buffer_frames = closest_power_of_2(input_latency * mix_rate / 1000);
 	int input_buffer_size = input_buffer_frames * spec.channels;
 
-	pa_buffer_attr attr;
+	pa_buffer_attr attr = {};
+	attr.maxlength = (uint32_t)-1;
 	attr.fragsize = input_buffer_size * sizeof(int16_t);
 
 	pa_rec_str = pa_stream_new(pa_ctx, "Record", &spec, &pa_rec_map);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/102013 (and other long term unreliabilities of the pulseaudio microphone on Linux) by initializing and uninitialized buffer definition attribute to -1 as recommended here: https://maemo.org/api_refs/5.0/5.0-final/pulseaudio/structpa__buffer__attr.html

The other three attributes (tlength, prebuf, minreq) are not used by the recording feature `pa_stream_connect_record()` and probably don't have to be initialized.