### PR TITLE
Add UID upgrade tool

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -163,6 +163,7 @@
 #include "editor/surface_upgrade_tool.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
+#include "editor/uid_upgrade_tool.h"
 #include "editor/window_wrapper.h"
 
 #include "modules/modules_enabled.gen.h" // For gdscript, mono.
@@ -651,6 +652,10 @@ void EditorNode::_notification(int p_what) {
 					run_surface_upgrade_tool = false;
 					SurfaceUpgradeTool::get_singleton()->connect("upgrade_finished", callable_mp(EditorFileSystem::get_singleton(), &EditorFileSystem::scan), CONNECT_ONE_SHOT);
 					SurfaceUpgradeTool::get_singleton()->finish_upgrade();
+				} else if (run_uid_upgrade_tool) {
+					run_uid_upgrade_tool = false;
+					UIDUpgradeTool::get_singleton()->connect("upgrade_finished", callable_mp(EditorFileSystem::get_singleton(), &EditorFileSystem::scan), CONNECT_ONE_SHOT);
+					UIDUpgradeTool::get_singleton()->finish_upgrade();
 				} else {
 					EditorFileSystem::get_singleton()->scan();
 				}
@@ -735,6 +740,23 @@ void EditorNode::_notification(int p_what) {
 
 			// Save the project after opening to mark it as last modified, except in headless mode.
 			if (DisplayServer::get_singleton()->window_can_draw()) {
+				// Try to determine if this project's Godot version was less than 4.4 - if
+				// so, we'll ask the user if they want to upgrade the project.
+				PackedStringArray features = ProjectSettings::get_singleton()->get_setting("application/config/features");
+				if (!features.is_empty()) {
+					String version_str = features[0];
+					PackedStringArray version_parts = version_str.split(".", true, 1);
+					if (version_parts.size() >= 2) {
+						if (version_parts[0].is_valid_int() && version_parts[1].is_valid_int()) {
+							int major_ver = version_parts[0].to_int();
+							int minor_ver = version_parts[1].to_int();
+							if (major_ver < 4 || (major_ver == 4 && minor_ver < 4)) {
+								should_prompt_uid_upgrade_tool = true;
+							}
+						}
+					}
+				}
+
 				ProjectSettings::get_singleton()->save();
 			}
 
@@ -1178,6 +1200,11 @@ void EditorNode::_sources_changed(bool p_exist) {
 		// Start preview thread now that it's safe.
 		if (!singleton->cmdline_export_mode) {
 			EditorResourcePreview::get_singleton()->start();
+		}
+
+		if (should_prompt_uid_upgrade_tool) {
+			should_prompt_uid_upgrade_tool = false;
+			uid_upgrade_dialog->popup_on_demand();
 		}
 
 		get_tree()->create_timer(1.0f)->connect("timeout", callable_mp(this, &EditorNode::_remove_lock_file));
@@ -3316,6 +3343,9 @@ void EditorNode::_tool_menu_option(int p_idx) {
 		} break;
 		case TOOLS_SURFACE_UPGRADE: {
 			surface_upgrade_dialog->popup_on_demand();
+		} break;
+		case TOOLS_UID_UPGRADE: {
+			uid_upgrade_dialog->popup_on_demand();
 		} break;
 		case TOOLS_CUSTOM: {
 			if (tool_menu->get_item_submenu(p_idx) == "") {
@@ -6864,6 +6894,13 @@ EditorNode::EditorNode() {
 		SurfaceUpgradeTool::get_singleton()->begin_upgrade();
 	}
 
+	// Same for UID upgrade tool.
+	uid_upgrade_tool = memnew(UIDUpgradeTool);
+	run_uid_upgrade_tool = EditorSettings::get_singleton()->get_project_metadata(UIDUpgradeTool::META_UID_UPGRADE_TOOL, UIDUpgradeTool::META_RUN_ON_RESTART, false);
+	if (run_uid_upgrade_tool) {
+		UIDUpgradeTool::get_singleton()->begin_upgrade();
+	}
+
 	{
 		bool agile_input_event_flushing = EDITOR_GET("input/buffering/agile_event_flushing");
 		bool use_accumulated_input = EDITOR_GET("input/buffering/use_accumulated_input");
@@ -7406,6 +7443,7 @@ EditorNode::EditorNode() {
 	tool_menu->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/orphan_resource_explorer", TTRC("Orphan Resource Explorer...")), TOOLS_ORPHAN_RESOURCES);
 	tool_menu->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/engine_compilation_configuration_editor", TTRC("Engine Compilation Configuration Editor...")), TOOLS_BUILD_PROFILE_MANAGER);
 	tool_menu->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/upgrade_mesh_surfaces", TTRC("Upgrade Mesh Surfaces...")), TOOLS_SURFACE_UPGRADE);
+	tool_menu->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/upgrade_uids", TTRC("Upgrade UIDs...")), TOOLS_UID_UPGRADE);
 
 	project_menu->add_separator();
 	project_menu->add_shortcut(ED_SHORTCUT("editor/reload_current_project", TTRC("Reload Current Project")), PROJECT_RELOAD_CURRENT_PROJECT);
@@ -7685,6 +7723,9 @@ EditorNode::EditorNode() {
 
 	surface_upgrade_dialog = memnew(SurfaceUpgradeDialog);
 	gui_base->add_child(surface_upgrade_dialog);
+
+	uid_upgrade_dialog = memnew(UIDUpgradeDialog);
+	gui_base->add_child(uid_upgrade_dialog);
 
 	confirmation = memnew(ConfirmationDialog);
 	gui_base->add_child(confirmation);
@@ -8079,6 +8120,7 @@ EditorNode::~EditorNode() {
 	memdelete(editor_plugins_force_input_forwarding);
 	memdelete(progress_hb);
 	memdelete(surface_upgrade_tool);
+	memdelete(uid_upgrade_tool);
 	memdelete(editor_dock_manager);
 
 	EditorSettings::destroy();

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -100,6 +100,8 @@ class ProjectSettingsEditor;
 class SceneImportSettingsDialog;
 class SurfaceUpgradeTool;
 class SurfaceUpgradeDialog;
+class UIDUpgradeTool;
+class UIDUpgradeDialog;
 
 struct EditorProgress {
 	String task;
@@ -166,6 +168,7 @@ public:
 		TOOLS_ORPHAN_RESOURCES,
 		TOOLS_BUILD_PROFILE_MANAGER,
 		TOOLS_SURFACE_UPGRADE,
+		TOOLS_UID_UPGRADE,
 		TOOLS_CUSTOM,
 
 		VCS_METADATA,
@@ -460,7 +463,14 @@ private:
 
 	SurfaceUpgradeTool *surface_upgrade_tool = nullptr;
 	SurfaceUpgradeDialog *surface_upgrade_dialog = nullptr;
+
 	bool run_surface_upgrade_tool = false;
+
+	UIDUpgradeTool *uid_upgrade_tool = nullptr;
+	UIDUpgradeDialog *uid_upgrade_dialog = nullptr;
+
+	bool run_uid_upgrade_tool = false;
+	bool should_prompt_uid_upgrade_tool = false;
 
 	bool was_window_windowed_last = false;
 

--- a/editor/uid_upgrade_tool.cpp
+++ b/editor/uid_upgrade_tool.cpp
@@ -1,0 +1,126 @@
+/**************************************************************************/
+/*  uid_upgrade_tool.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "uid_upgrade_tool.h"
+
+#include "editor/editor_file_system.h"
+#include "editor/editor_log.h"
+#include "editor/editor_node.h"
+#include "editor/editor_settings.h"
+#include "editor/gui/editor_scene_tabs.h"
+#include "editor/gui/editor_toaster.h"
+#include "editor/themes/editor_scale.h"
+#include "servers/rendering_server.h"
+
+void UIDUpgradeTool::_add_files(EditorFileSystemDirectory *p_dir, Vector<String> &r_resave_paths) {
+	for (int i = 0; i < p_dir->get_subdir_count(); i++) {
+		_add_files(p_dir->get_subdir(i), r_resave_paths);
+	}
+
+	for (int i = 0; i < p_dir->get_file_count(); i++) {
+		if (p_dir->get_file_type(i) == "PackedScene" || p_dir->get_file_type(i) == "Resource") {
+			r_resave_paths.append(p_dir->get_file_path(i));
+		}
+	}
+}
+
+void UIDUpgradeTool::prepare_upgrade() {
+	EditorSettings::get_singleton()->set_project_metadata(META_UID_UPGRADE_TOOL, META_RUN_ON_RESTART, true);
+	Vector<String> resave_paths;
+	_add_files(EditorFileSystem::get_singleton()->get_filesystem(), resave_paths);
+
+	EditorSettings::get_singleton()->set_project_metadata(META_UID_UPGRADE_TOOL, META_RESAVE_PATHS, resave_paths);
+
+	// Delay to avoid deadlocks, since this dialog can be triggered by loading a scene.
+	callable_mp(EditorNode::get_singleton(), &EditorNode::restart_editor).call_deferred(false);
+}
+
+void UIDUpgradeTool::begin_upgrade() {
+	EditorSettings::get_singleton()->set_project_metadata(META_UID_UPGRADE_TOOL, META_RUN_ON_RESTART, false);
+}
+
+void UIDUpgradeTool::finish_upgrade() {
+	EditorNode::get_singleton()->trigger_menu_option(EditorSceneTabs::SCENE_CLOSE_ALL, true);
+
+	Vector<String> resave_paths = EditorSettings::get_singleton()->get_project_metadata(META_UID_UPGRADE_TOOL, META_RESAVE_PATHS, Variant());
+	EditorProgress ep("uid_upgrade_resave", TTR("Updating Script UIDs"), resave_paths.size());
+
+	int step = 0;
+	for (const String &file_path : resave_paths) {
+		Ref<Resource> res = ResourceLoader::load(file_path);
+		ep.step(TTR("Attempting to re-save ") + file_path, step++);
+		if (res.is_valid()) {
+			ResourceSaver::save(res);
+		}
+	}
+	EditorSettings::get_singleton()->set_project_metadata(META_UID_UPGRADE_TOOL, META_RESAVE_PATHS, Vector<String>());
+
+	emit_signal(SNAME(UPGRADE_FINISHED));
+}
+
+void UIDUpgradeTool::_bind_methods() {
+	ADD_SIGNAL(MethodInfo(UPGRADE_FINISHED));
+}
+
+UIDUpgradeTool::UIDUpgradeTool() {
+	singleton = this;
+}
+
+UIDUpgradeTool::~UIDUpgradeTool() {
+	singleton = nullptr;
+}
+
+void UIDUpgradeDialog::popup_on_demand() {
+	const String confirmation_message = TTR("As of Godot 4.4, scenes and resources use UIDs to reference scripts and shaders.\n\nNormally, this update is applied to a single scene or resource once you save it in Godot 4.4 for the first time. If you have a lot of scenes and/or resources, doing this manually may be time-consuming. This tool will update all of the project's scenes and resources at once.\n\nClick \"Restart & Upgrade\" to restart the editor and update all of the scenes and resources in this project. Depending on the project size, it may take several minutes.\n\nNote: Please make sure you have your project backed up before running the tool, to avoid the possibility of data loss. Additionally, make sure to commit all .uid files into version control (and do not add them to ignore-lists like .gitignore).");
+	set_text(confirmation_message);
+	get_ok_button()->set_text("Restart & Upgrade");
+	popup_centered(Size2(750 * EDSCALE, 0));
+}
+
+void UIDUpgradeDialog::_on_custom_action(const String &p_action) {
+	if (p_action == UID_UPGRADE_LEARN_MORE) {
+		OS::get_singleton()->shell_open("https://godotengine.org/article/uid-changes-coming-to-godot-4-4/");
+	}
+}
+
+void UIDUpgradeDialog::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_READY:
+			connect(SceneStringName(confirmed), callable_mp(UIDUpgradeTool::get_singleton(), &UIDUpgradeTool::prepare_upgrade));
+			connect(SNAME("custom_action"), callable_mp(this, &UIDUpgradeDialog::_on_custom_action));
+			break;
+	}
+}
+
+UIDUpgradeDialog::UIDUpgradeDialog() {
+	set_autowrap(true);
+	get_label()->set_custom_minimum_size(Size2(750 * EDSCALE, 0));
+	learn_more_button = add_button(TTR("Learn More"), true, UID_UPGRADE_LEARN_MORE);
+}

--- a/editor/uid_upgrade_tool.h
+++ b/editor/uid_upgrade_tool.h
@@ -1,0 +1,82 @@
+/**************************************************************************/
+/*  uid_upgrade_tool.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef UID_UPGRADE_TOOL_H
+#define UID_UPGRADE_TOOL_H
+
+#include "scene/gui/dialogs.h"
+
+class EditorFileSystemDirectory;
+
+class UIDUpgradeTool : public Object {
+	GDCLASS(UIDUpgradeTool, Object);
+
+	inline static UIDUpgradeTool *singleton = nullptr;
+
+	static constexpr const char *UPGRADE_FINISHED = "upgrade_finished";
+	static constexpr const char *META_RESAVE_PATHS = "resave_paths";
+
+	void _add_files(EditorFileSystemDirectory *p_dir, Vector<String> &r_resave_paths);
+
+protected:
+	static void _bind_methods();
+
+public:
+	static constexpr const char *META_UID_UPGRADE_TOOL = "uid_upgrade_tool";
+	static constexpr const char *META_RUN_ON_RESTART = "run_on_restart";
+
+	static UIDUpgradeTool *get_singleton() { return singleton; }
+
+	void prepare_upgrade();
+	void begin_upgrade();
+	void finish_upgrade();
+
+	UIDUpgradeTool();
+	~UIDUpgradeTool();
+};
+
+class UIDUpgradeDialog : public ConfirmationDialog {
+	GDCLASS(UIDUpgradeDialog, ConfirmationDialog);
+
+	static constexpr const char *UID_UPGRADE_LEARN_MORE = "uid_upgrade_learn_more";
+
+	Button *learn_more_button = nullptr;
+
+protected:
+	void _on_custom_action(const String &p_action);
+	void _notification(int p_what);
+
+public:
+	void popup_on_demand();
+
+	UIDUpgradeDialog();
+};
+
+#endif // UID_UPGRADE_TOOL_H


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11639 .

This PR adds a new tool to the Project > Tools menu, currently titled "Update UIDs...". When run, it finds all of the `Resource` and `PackedScene` files in the project and re-saves them, causing the UID references to scripts and shaders to be added to them.

![CleanShot 2025-01-26 at 19 40 24@2x](https://github.com/user-attachments/assets/427ce900-ea9c-4a87-a4e4-c9050a3fb9e9)

Here is a small project I put together with a few PackedScenes and a custom Resource subclass: 
[uid-upgrader-test_2025-01-26_19-36-02.zip](https://github.com/user-attachments/files/18553209/uid-upgrader-test_2025-01-26_19-36-02.zip)

After running the tool, you can see that the UIDs have been added to all of the scene and resource files:
![CleanShot 2025-01-26 at 19 39 21@2x](https://github.com/user-attachments/assets/309ae937-b657-437c-8334-e7ffdf396d91)

The code in this PR is adapted from the "Upgrade Mesh Surfaces..." tool (`SurfaceUpgradeTool` and `SurfaceUpgradeDialog` in the source code).

>[!NOTE]
> I think it would be nice to have this pop-up display automatically when a project is first opened in 4.4 from a previous version, although I'm not sure yet how easy that would be to do. I hope to look more into that in the coming days, but in the meantime the tool is accessible through the menu bar as described previously.

## To Do
- [x] Add "Learn More" button to window - should open blog post page
- [x] Look into `_open_selected_projects_check_warnings` for possibility of auto-opening tool when upgrading to 4.4
