### PR TITLE
Add a method to calculate a flow map to `AStarGrid2D`

### DIFF
--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -91,6 +91,9 @@ private:
 		real_t abs_g_score = 0;
 		real_t abs_f_score = 0;
 
+		Vector2 flow_direction;
+		uint32_t cost = 1;
+
 		Point() {}
 
 		Point(const Vector2i &p_id, const Vector2 &p_pos) :
@@ -113,10 +116,15 @@ private:
 	LocalVector<LocalVector<Point>> points;
 	Point *end = nullptr;
 	Point *last_closest_point = nullptr;
+	Rect2i previous_ff_region;
 
 	uint64_t pass = 1;
 
 private: // Internal routines.
+	_FORCE_INLINE_ size_t _to_index(const Vector2i &p_id, const Rect2i &p_region) const {
+		return ((p_id.y - p_region.position.y) * p_region.size.x) + p_id.x - p_region.position.x;
+	}
+
 	_FORCE_INLINE_ size_t _to_mask_index(int32_t p_x, int32_t p_y) const {
 		return ((p_y - region.position.y + 1) * (region.size.x + 2)) + p_x - region.position.x + 1;
 	}
@@ -156,7 +164,7 @@ private: // Internal routines.
 		return &points[p_id.y - region.position.y][p_id.x - region.position.x];
 	}
 
-	void _get_nbors(Point *p_point, LocalVector<Point *> &r_nbors);
+	void _get_nbors(Point *p_point, const Rect2i &p_region, LocalVector<Point *> &r_nbors);
 	Point *_jump(Point *p_from, Point *p_to);
 	bool _solve(Point *p_begin_point, Point *p_end_point, bool p_allow_partial_path);
 	Point *_forced_successor(int32_t p_x, int32_t p_y, int32_t p_dx, int32_t p_dy, bool p_inclusive = false);
@@ -219,12 +227,19 @@ public:
 	void fill_solid_region(const Rect2i &p_region, bool p_solid = true);
 	void fill_weight_scale_region(const Rect2i &p_region, real_t p_weight_scale);
 
+	Vector2 get_flow_direction(const Vector2i &p_id) const;
+
+	void set_point_cost(const Vector2i &p_id, int p_cost);
+	int get_point_cost(const Vector2i &p_id) const;
+
 	void clear();
 
 	Vector2 get_point_position(const Vector2i &p_id) const;
 	TypedArray<Dictionary> get_point_data_in_region(const Rect2i &p_region) const;
 	Vector<Vector2> get_point_path(const Vector2i &p_from, const Vector2i &p_to, bool p_allow_partial_path = false);
 	TypedArray<Vector2i> get_id_path(const Vector2i &p_from, const Vector2i &p_to, bool p_allow_partial_path = false);
+	void calculate_flow_field(const Vector2i &p_id, const Rect2i &p_region = Rect2i(), bool p_clear_previous_region = true);
+	void fill_flow_field_region(const Rect2i &p_region, const Vector2 &p_value = Vector2());
 };
 
 VARIANT_ENUM_CAST(AStarGrid2D::DiagonalMode);

--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -47,10 +47,31 @@
 				Note that this function is hidden in the default [AStarGrid2D] class.
 			</description>
 		</method>
+		<method name="calculate_flow_field">
+			<return type="void" />
+			<param index="0" name="id" type="Vector2i" />
+			<param index="1" name="region" type="Rect2i" default="Rect2i(0, 0, 0, 0)" />
+			<param index="2" name="clear_previous_region" type="bool" default="true" />
+			<description>
+				Calculates a direction of flow field within a specified [param region] using simple Dijkstra algorithm.
+				[b]Note:[/b] If [param clear_previous_region] is [code]false[/code] the cleanup of the previous results on the region will not happen, see [method fill_flow_field_region] to clear it up manually.
+				[b]Note:[/b] If [param region] is empty, the whole grid will be used.
+				[b]Note:[/b] weight_scale parameter has no meaning for this method, use [method set_point_cost] to set a cost instead.
+			</description>
+		</method>
 		<method name="clear">
 			<return type="void" />
 			<description>
 				Clears the grid and sets the [member region] to [code]Rect2i(0, 0, 0, 0)[/code].
+			</description>
+		</method>
+		<method name="fill_flow_field_region">
+			<return type="void" />
+			<param index="0" name="region" type="Rect2i" />
+			<param index="1" name="value" type="Vector2" default="Vector2(0, 0)" />
+			<description>
+				Fills the given [param region] on the grid with the specified value for the flow directions.
+				[b]Note:[/b] Calling [method update] is not needed after the call of this function.
 			</description>
 		</method>
 		<method name="fill_solid_region">
@@ -71,6 +92,13 @@
 				[b]Note:[/b] Calling [method update] is not needed after the call of this function.
 			</description>
 		</method>
+		<method name="get_flow_direction" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="id" type="Vector2i" />
+			<description>
+				Returns a specified flow direction. Have meaningful value only after calling [method calculate_flow_field].
+			</description>
+		</method>
 		<method name="get_id_path">
 			<return type="Vector2i[]" />
 			<param index="0" name="from_id" type="Vector2i" />
@@ -80,6 +108,13 @@
 				Returns an array with the IDs of the points that form the path found by AStar2D between the given points. The array is ordered from the starting point to the ending point of the path.
 				If there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
 				[b]Note:[/b] When [param allow_partial_path] is [code]true[/code] and [param to_id] is solid the search may take an unusually long time to finish.
+			</description>
+		</method>
+		<method name="get_point_cost" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="id" type="Vector2i" />
+			<description>
+				Returns the cost of the point associated with the given [param id].
 			</description>
 		</method>
 		<method name="get_point_data_in_region" qualifiers="const">
@@ -141,6 +176,16 @@
 			<param index="0" name="id" type="Vector2i" />
 			<description>
 				Returns [code]true[/code] if a point is disabled for pathfinding. By default, all points are enabled.
+			</description>
+		</method>
+		<method name="set_point_cost">
+			<return type="void" />
+			<param index="0" name="id" type="Vector2i" />
+			<param index="1" name="cost" type="int" />
+			<description>
+				Sets the [param cost] for the point with the given [param id]. The [param cost] is used to calculate a flow field by [method calculate_flow_field] and must be within 1-254 range.
+				[b]Note:[/b] By default, the cost of each point is equal to 1.
+				[b]Note:[/b] Calling [method update] is not needed after the call of this function.
 			</description>
 		</method>
 		<method name="set_point_solid">


### PR DESCRIPTION
Some users want to have a method to calculate a path for the whole grid for many units, rather than one path for a single unit. This PR adds a `calculate_flow_field` method as well as `get_flow_direction` and `get_flow_directions` methods to retrieve those directions. Weight scale cannot be used to calculate a flow field, instead a cost value between 1-254 (255 has no meaning since solid flag used instead for complete block) range is introduced (`set_point_cost`/`get_point_cost`) methods.

![flow_field](https://github.com/user-attachments/assets/fe8f69b1-9bb0-48d4-b991-94355b13c81d)

Demo project:
[FlowFieldDemo.zip](https://github.com/user-attachments/files/18568150/FlowFieldDemo.zip)
