### PR TITLE
Add restart emission for multi edit in particles editor

### DIFF
--- a/editor/scene/2d/particles_2d_editor_plugin.cpp
+++ b/editor/scene/2d/particles_2d_editor_plugin.cpp
@@ -59,6 +59,7 @@ void GPUParticles2DEditorPlugin::_menu_callback(int p_idx) {
 void GPUParticles2DEditorPlugin::_add_menu_options(PopupMenu *p_menu) {
 	Particles2DEditorPlugin::_add_menu_options(p_menu);
 	p_menu->add_item(TTR("Generate Visibility Rect"), MENU_GENERATE_VISIBILITY_RECT);
+	p_menu->set_item_metadata(-1, "disable_on_multiselect");
 }
 
 void Particles2DEditorPlugin::_file_selected(const String &p_file) {

--- a/editor/scene/3d/particles_3d_editor_plugin.cpp
+++ b/editor/scene/3d/particles_3d_editor_plugin.cpp
@@ -144,7 +144,9 @@ void Particles3DEditorPlugin::_menu_callback(int p_idx) {
 
 void Particles3DEditorPlugin::_add_menu_options(PopupMenu *p_menu) {
 	p_menu->add_item(TTR("Generate AABB"), MENU_OPTION_GENERATE_AABB);
+	p_menu->set_item_metadata(-1, "disable_on_multiselect");
 	p_menu->add_item(TTR("Create Emission Points From Node"), MENU_OPTION_CREATE_EMISSION_VOLUME_FROM_NODE);
+	p_menu->set_item_metadata(-1, "disable_on_multiselect");
 }
 
 bool Particles3DEditorPlugin::_generate(Vector<Vector3> &r_points, Vector<Vector3> &r_normals) {

--- a/editor/scene/particles_editor_plugin.h
+++ b/editor/scene/particles_editor_plugin.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "editor/inspector/multi_node_edit.h"
 #include "editor/plugins/editor_plugin.h"
 
 class CheckBox;
@@ -57,10 +58,12 @@ protected:
 	String conversion_option_name;
 
 	Node *edited_node = nullptr;
+	Ref<MultiNodeEdit> mne;
 
 	void _notification(int p_what);
 
 	bool need_show_lifetime_dialog(SpinBox *p_seconds);
+	void disable_single_select_operations(bool p_disabled) const;
 	virtual void _menu_callback(int p_idx);
 
 	virtual void _add_menu_options(PopupMenu *p_menu) {}

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -597,7 +597,6 @@ void PropertyTweener::start() {
 
 	Object *target_instance = ObjectDB::get_instance(target);
 	if (!target_instance) {
-		WARN_PRINT("Target object freed before starting, aborting Tweener.");
 		return;
 	}
 


### PR DESCRIPTION
This adds Multi Node Edit support for the Particles Editor Plugin to allow restarting multiple particle systems at once. (Also works with the Ctrl + R shortcut)
Note the other options are not yet implemented and will just act on the first object in the Multi Node Edit, similar to the Mesh Instance 3D Editor Plugin.


https://github.com/user-attachments/assets/fec7e897-72a9-4e83-b978-aab12da5e187



Closes https://github.com/godotengine/godot/issues/99684