### PR TITLE
Fix Embedded Game disappear when not focused on KDE 5

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -6276,7 +6276,7 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 			}
 		}
 
-		if (wd.is_popup || wd.no_focus || wd.embed_parent) {
+		if (wd.is_popup || wd.no_focus || (wd.embed_parent && !kde5_embed_workaround)) {
 			// Set Utility type to disable fade animations.
 			Atom type_atom = XInternAtom(x11_display, "_NET_WM_WINDOW_TYPE_UTILITY", False);
 			Atom wt_atom = XInternAtom(x11_display, "_NET_WM_WINDOW_TYPE", False);
@@ -6422,6 +6422,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	KeyMappingX11::initialize();
 
 	xwayland = OS::get_singleton()->get_environment("XDG_SESSION_TYPE").to_lower() == "wayland";
+	kde5_embed_workaround = OS::get_singleton()->get_environment("XDG_CURRENT_DESKTOP").to_lower() == "kde" && OS::get_singleton()->get_environment("KDE_SESSION_VERSION") == "5";
 
 	native_menu = memnew(NativeMenu);
 	context = p_context;

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -338,6 +338,7 @@ class DisplayServerX11 : public DisplayServer {
 	bool xinerama_ext_ok = true;
 	bool xshaped_ext_ok = true;
 	bool xwayland = false;
+	bool kde5_embed_workaround = false; // Workaround embedded game visibility on KDE 5 (GH-102043).
 
 	struct Property {
 		unsigned char *data;


### PR DESCRIPTION
- Fixes #102043

This PR resolves the issue where the Embedded Game Window disappears when the Floating Game Window is not focused on Xorg/Kubuntu.

On Ubuntu 24.04 Gnome and Fedora 40 KDE Plasma 6.1.5, a window of type `_NET_WM_WINDOW_TYPE_UTILITY` remains visible even when the parent window is not focused. However, on Kubuntu/KDE (tested on Kubuntu 22.04 and KDE Plasma 5.24.7), this type of window is hidden when the parent window loses focus, causing the Embedded Game Window to disappear.

To address this, this PR changes the window type to `_NET_WM_WINDOW_TYPE_NORMAL`. A side effect of this change is that the Embedded Game Window now appears in the alt-tab window list. I tested several window types, but none could simultaneously prevent the window from disappearing when the parent is not focused and exclude it from the alt-tab list. Although the `_set_window_taskbar_pager_enabled` method was designed for this purpose, it does not seem to work on Kubuntu/KDE. Given the circumstances, I believe this trade-off is acceptable.