### PR TITLE
Avoid flipping normal based on facing direction when calculating SDF

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -2603,7 +2603,7 @@ void fragment_shader(in SceneData scene_data) {
 				vec3(0, -1, 0),
 				vec3(0, 0, -1));
 
-		vec3 cam_normal = mat3(scene_data.inv_view_matrix) * geo_normal;
+		vec3 cam_normal = mat3(scene_data.inv_view_matrix) * normalize(normal_interp);
 
 		float closest_dist = -1e20;
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/101746
Regression from: https://github.com/godotengine/godot/pull/100441

This reverts us back to the state prior to #100441. By switching to `geo_normal` we were implicitly adding the following lines of code which flip the normal based on the direction that the surface is viewed from:

https://github.com/godotengine/godot/blob/6dc78c8aa17ad46e701e0c4e7b7632c2f0e098f1/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl#L1171-L1177

Normally this code is desirable as it allows users to get acceptable normals when viewing backfaces. However, for rendering the SDF, we are viewing the surface from multiple sides and we do not want the normal to flip based on view direction.