### PR TITLE
Implement incremental search for `OptionButton`, split input and selection timeout settings.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1589,7 +1589,8 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "internationalization/rendering/root_node_layout_direction", PROPERTY_HINT_ENUM, "Based on Application Locale,Left-to-Right,Right-to-Left,Based on System Locale"), 0);
 	GLOBAL_DEF_BASIC("internationalization/rendering/root_node_auto_translate", true);
 
-	GLOBAL_DEF(PropertyInfo(Variant::INT, "gui/timers/incremental_search_max_interval_msec", PROPERTY_HINT_RANGE, "0,10000,1,or_greater"), 2000);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "gui/timers/incremental_search_max_search_interval_msec", PROPERTY_HINT_RANGE, "0,10000,1,or_greater"), 4000);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "gui/timers/incremental_search_max_interval_msec", PROPERTY_HINT_RANGE, "0,10000,1,or_greater"), 500);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "gui/timers/tooltip_delay_sec", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"), 0.5);
 #ifdef TOOLS_ENABLED
 	GLOBAL_DEF("gui/timers/tooltip_delay_sec.editor_hint", 0.5);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1100,8 +1100,11 @@
 		<member name="gui/timers/button_shortcut_feedback_highlight_time" type="float" setter="" getter="" default="0.2">
 			When [member BaseButton.shortcut_feedback] is enabled, this is the time the [BaseButton] will remain highlighted after a shortcut.
 		</member>
-		<member name="gui/timers/incremental_search_max_interval_msec" type="int" setter="" getter="" default="2000">
-			Timer setting for incremental search in [Tree], [ItemList], etc. controls (in milliseconds).
+		<member name="gui/timers/incremental_search_max_interval_msec" type="int" setter="" getter="" default="500">
+			Character input timer setting for incremental search in [Tree], [ItemList], etc. controls (in milliseconds).
+		</member>
+		<member name="gui/timers/incremental_search_max_search_interval_msec" type="int" setter="" getter="" default="4000">
+			Item selection timer setting for incremental search in [ItemList] (in milliseconds).
 		</member>
 		<member name="gui/timers/text_edit_idle_detect_sec" type="float" setter="" getter="" default="3">
 			Timer for detecting idle in [TextEdit] (in seconds).

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -839,7 +839,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 				uint64_t now = OS::get_singleton()->get_ticks_msec();
 				uint64_t diff = now - search_time_msec;
 
-				if (diff < uint64_t(GLOBAL_GET("gui/timers/incremental_search_max_interval_msec")) * 2) {
+				if (diff < uint64_t(GLOBAL_GET("gui/timers/incremental_search_max_search_interval_msec"))) {
 					for (int i = current - 1; i >= 0; i--) {
 						if (CAN_SELECT(i) && items[i].text.begins_with(search_string)) {
 							set_current(i);
@@ -877,7 +877,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 				uint64_t now = OS::get_singleton()->get_ticks_msec();
 				uint64_t diff = now - search_time_msec;
 
-				if (diff < uint64_t(GLOBAL_GET("gui/timers/incremental_search_max_interval_msec")) * 2) {
+				if (diff < uint64_t(GLOBAL_GET("gui/timers/incremental_search_max_search_interval_msec"))) {
 					for (int i = current + 1; i < items.size(); i++) {
 						if (CAN_SELECT(i) && items[i].text.begins_with(search_string)) {
 							set_current(i);
@@ -1001,7 +1001,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 		} else {
 			Ref<InputEventKey> k = p_event;
 
-			if (allow_search && k.is_valid() && k->get_unicode()) {
+			if (allow_search && k.is_valid() && k->get_unicode() && k->is_pressed()) {
 				uint64_t now = OS::get_singleton()->get_ticks_msec();
 				uint64_t diff = now - search_time_msec;
 				uint64_t max_interval = uint64_t(GLOBAL_GET("gui/timers/incremental_search_max_interval_msec"));
@@ -1011,9 +1011,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					search_string = "";
 				}
 
-				if (String::chr(k->get_unicode()) != search_string) {
-					search_string += String::chr(k->get_unicode());
-				}
+				search_string += String::chr(k->get_unicode());
 
 				for (int i = current + 1; i <= items.size(); i++) {
 					if (i == items.size()) {

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -30,9 +30,41 @@
 
 #include "option_button.h"
 
+#include "core/config/project_settings.h"
 #include "scene/theme/theme_db.h"
 
 static const int NONE_SELECTED = -1;
+
+void OptionButton::gui_input(const Ref<InputEvent> &p_event) {
+	Ref<InputEventKey> k = p_event;
+
+	if (p_event->is_action("ui_cancel", true)) {
+		search_string = "";
+	}
+
+	if (k.is_valid() && k->get_unicode() && k->is_pressed()) {
+		uint64_t now = OS::get_singleton()->get_ticks_msec();
+		uint64_t diff = now - search_time_msec;
+		uint64_t max_interval = uint64_t(GLOBAL_GET("gui/timers/incremental_search_max_interval_msec"));
+		search_time_msec = now;
+
+		if (diff > max_interval) {
+			search_string = "";
+		}
+
+		search_string += String::chr(k->get_unicode());
+
+		for (int i = 0; i < get_item_count(); i++) {
+			if (popup->get_item_text(i).findn(search_string) == 0) {
+				_select(i, true);
+				accept_event();
+				break;
+			}
+		}
+	}
+
+	Button::gui_input(p_event);
+}
 
 void OptionButton::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -47,6 +47,8 @@ class OptionButton : public Button {
 	bool allow_reselect = false;
 	bool initialized = false;
 	int queued_current = -1;
+	uint64_t search_time_msec = 0;
+	String search_string = "";
 
 	struct ThemeCache {
 		Ref<StyleBox> normal;
@@ -91,6 +93,7 @@ protected:
 	static void _bind_methods();
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+	virtual void gui_input(const Ref<InputEvent> &p_gui_input) override;
 
 public:
 	// ATTENTION: This is used by the POT generator's scene parser. If the number of properties returned by `_get_items()` ever changes,

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -710,9 +710,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 			search_string = "";
 		}
 
-		if (String::chr(k->get_unicode()) != search_string) {
-			search_string += String::chr(k->get_unicode());
-		}
+		search_string += String::chr(k->get_unicode());
 
 		for (int i = mouse_over + 1; i <= items.size(); i++) {
 			if (i == items.size()) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11652

- Implements incremental search for `OptionButton` with closed popup.
- Splits `incremental_search_max_interval_msec` into two settings to make it more responsive (with 2000 msec timeout you can't quickly reset and reenter search string in case of type):
  - `incremental_search_max_search_interval_msec` - 4000 msec, used as timeout for `ItemList` item selection with arrows, after incremental search string is entered (was 2 * `incremental_search_max_interval_msec`).
  - `incremental_search_max_interval_msec` - 500 msec (was 2000), used as timeout between entering incremental search characters.