### PR TITLE
Fix french translation for "cryptage" and one typo

### DIFF
--- a/doc/translations/fr.po
+++ b/doc/translations/fr.po
@@ -107,6 +107,7 @@
 # zefdzeqf <azrzrezfafe@users.noreply.hosted.weblate.org>, 2024.
 # Edvard Fauchelevent <edvardfauchelevent@gmail.com>, 2024.
 # Fontaine Nathan <nathan.fontaine53@gmail.com>, 2024.
+# Patrice Ferlet <metal3d@gmail.com>, 2025
 msgid ""
 msgstr ""
 "Project-Id-Version: Godot Engine class reference\n"
@@ -2331,13 +2332,13 @@ msgid "AES electronic codebook encryption mode."
 msgstr "Mode de chiffrement du livre de codes électroniques AES."
 
 msgid "AES electronic codebook decryption mode."
-msgstr "Mode de décryptage du codebook électronique AES."
+msgstr "Mode de déchiffrement du codebook électronique AES."
 
 msgid "AES cipher blocker chaining encryption mode."
-msgstr "Mode de cryptage de chiffre de chaînage de blocs AES."
+msgstr "Mode de chiffrement par chaînage AES."
 
 msgid "AES cipher blocker chaining decryption mode."
-msgstr "Mode de décryptage de chiffre de chaînage de blocs AES."
+msgstr "Mode de déchiffrement par chaînage du bloqueur de chiffrement AES."
 
 msgid "Maximum value for the mode enum."
 msgstr "Valeur maximale pour le mode énumeration."
@@ -7020,7 +7021,7 @@ msgstr ""
 "avancées dans Godot.\n"
 "Pour l'instant, cela inclus la génération de données aléatoires pour des "
 "utilisations cryptographiques, la génération de clés RSA et de certificats "
-"auto-signés X509, de clé asymétriques de cryptage/décryptage, la signature et "
+"auto-signés X509, de clé asymétriques de chiffrement/déchiffrement, la signature et "
 "la vérification.\n"
 "[codeblock]\n"
 "extends Node\n"
@@ -7038,10 +7039,10 @@ msgstr ""
 "    # Enregistrer la clé et le certificat dans le dossier utilisateur.\n"
 "    key.save(\"user://generated.key\")\n"
 "    cert.save(\"user://generated.crt\")\n"
-"    # Cryptage\n"
+"    # Chiffrement\n"
 "    var data = \"Des données\"\n"
 "    var encrypted = crypto.encrypt(key, data.to_utf8())\n"
-"    # Décryptage\n"
+"    # Déchiffrement\n"
 "    var decrypted = crypto.decrypt(key, encrypted)\n"
 "    # Signature\n"
 "    var signature = crypto.sign(HashingContext.HASH_SHA256, data."

--- a/editor/translations/editor/fr.po
+++ b/editor/translations/editor/fr.po
@@ -174,6 +174,7 @@
 # Unreal Vision <unrealvisionyt@gmail.com>, 2024.
 # Jokod <jb.jokod@gmail.com>, 2024.
 # didierGuieu <didier.guieu@hotmail.fr>, 2024.
+# Patrice Ferlet <metal3d@gmail.com>, 2025
 msgid ""
 msgstr ""
 "Project-Id-Version: Godot Engine editor interface\n"
@@ -5211,7 +5212,7 @@ msgid "Feature List:"
 msgstr "Liste des fonctionnalités :"
 
 msgid "Encryption"
-msgstr "Cryptage"
+msgstr "Chiffrement"
 
 msgid "Encrypt Exported PCK"
 msgstr "Encrypter le PCK exporté"
@@ -5243,7 +5244,7 @@ msgid ""
 "Note: Encryption key needs to be stored in the binary,\n"
 "you need to build the export templates from source."
 msgstr ""
-"Note : La clé de cryptage doit être stocké dans le binaire,\n"
+"Note : La clé de chiffrement doit être stockée dans le binaire,\n"
 "vous devez compiler les modèles d'exportation depuis les sources."
 
 msgid "More Info..."


### PR DESCRIPTION
In french, the word "Cryptage" and "Décryptage" are not correct. We must use "Chiffrement" and "Déchiffrement".

Also, "la clé" is female gender, so we must add "e" to "stockée"

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
