### PR TITLE
Optimize text rendering by caching `UBreakIterator` instances.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -5632,8 +5632,12 @@ bool TextServerAdvanced::_shaped_text_update_breaks(const RID &p_shaped) {
 				i++;
 			}
 			int r_end = sd->spans[i].end;
-			UBreakIterator *bi = ubrk_open(UBRK_LINE, (language.is_empty()) ? TranslationServer::get_singleton()->get_tool_locale().ascii().get_data() : language.ascii().get_data(), data + _convert_pos_inv(sd, r_start), _convert_pos_inv(sd, r_end - r_start), &err);
-			if (U_FAILURE(err)) {
+			UBreakIterator *bi = sd->_get_break_iterator_for_locale(language, &err);
+			if (!U_FAILURE(err) && bi) {
+				ubrk_setText(bi, data + _convert_pos_inv(sd, r_start), _convert_pos_inv(sd, r_end - r_start), &err);
+			}
+
+			if (U_FAILURE(err) || !bi) {
 				// No data loaded - use fallback.
 				for (int j = r_start; j < r_end; j++) {
 					char32_t c = sd->text[j - sd->start];
@@ -5662,7 +5666,6 @@ bool TextServerAdvanced::_shaped_text_update_breaks(const RID &p_shaped) {
 					}
 				}
 			}
-			ubrk_close(bi);
 			i++;
 		}
 		sd->break_ops_valid = true;
@@ -6108,6 +6111,15 @@ _FORCE_INLINE_ void TextServerAdvanced::_add_featuers(const Dictionary &p_source
 			r_ftrs.push_back(feature);
 		}
 	}
+}
+
+UBreakIterator *TextServerAdvanced::ShapedTextDataAdvanced::_get_break_iterator_for_locale(const String &p_language, UErrorCode *r_err) {
+	HashMap<String, UBreakIterator *>::Iterator key_value = line_break_iterators_per_language.find(p_language);
+	if (key_value) {
+		return key_value->value;
+	}
+	UBreakIterator *brk = ubrk_open(UBRK_LINE, p_language.is_empty() ? TranslationServer::get_singleton()->get_tool_locale().ascii().get_data() : p_language.ascii().get_data(), nullptr, 0, r_err);
+	return line_break_iterators_per_language.insert(p_language, brk)->value;
 }
 
 void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_end, hb_script_t p_script, hb_direction_t p_direction, TypedArray<RID> p_fonts, int64_t p_span, int64_t p_fb_index, int64_t p_prev_start, int64_t p_prev_end, RID p_prev_font) {

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -544,6 +544,11 @@ class TextServerAdvanced : public TextServerExtension {
 		bool js_ops_valid = false;
 		bool chars_valid = false;
 
+		HashMap<String, UBreakIterator *> line_break_iterators_per_language;
+
+		// Creating UBreakIterator is surprisingly costly. To improve efficiency, we cache them.
+		UBreakIterator *_get_break_iterator_for_locale(const String &p_language, UErrorCode *r_err);
+
 		~ShapedTextDataAdvanced() {
 			for (int i = 0; i < bidi_iter.size(); i++) {
 				if (bidi_iter[i]) {
@@ -555,6 +560,9 @@ class TextServerAdvanced : public TextServerExtension {
 			}
 			if (hb_buffer) {
 				hb_buffer_destroy(hb_buffer);
+			}
+			for (const KeyValue<String, UBreakIterator *> &bi : line_break_iterators_per_language) {
+				ubrk_close(bi.value);
 			}
 		}
 	};


### PR DESCRIPTION
- *Production edit: Related to https://github.com/godotengine/godot/pull/102132.*

Today I profiled Godot launch times again.
Through caching, I was able to shave 4% total launch time off the Godot Editor (and additionally, improve render time of texts).

I am not familiar with the advanced text server, so I this change should be well tested and reviewed.

## Explanation
It appears that `ubrk_open` converts its input locale from UTF8 to UTF16, allocating memory. This is surprisingly slow, and called quite often too. 

The implementation of `BreakIterator::createLineInstance(Locale(locale), *status);` appears to not be able to avoid this behavior, e.g. by using `UTF32` strings directly.
Instead, it is easy to cache `UBreakIterator` instances. There is already a thread lock on `sd->mutex`, so we should be safe that this does not cause cache variable contention. 
Using a `UBreakIterator` pool independent of `sd` might be even better; I experimented with this and got the launch time down by almost 12% (almost the entire contribution of `createLineInstance`). However, I am not aware of a precedent for variable pools like this, so that may require a more complex solution.

## Profiling details
I used Apple Instruments' CPU Profiler and inverted the call tree.

### Launch

Before update
```
1.35 Gc  12,2 %	  u_strFromUTF8WithSub_76_godot
1.35 Gc  12,2 %	   icu_76_godot::UnicodeString::setToUTF8(icu_76_godot::StringPiece)
1.35 Gc  12,2 %	    icu_76_godot::RBBIDataWrapper::init(icu_76_godot::RBBIDataHeader const*, UErrorCode&)
1.35 Gc  12,2 %	     icu_76_godot::RBBIDataWrapper::RBBIDataWrapper(UDataMemory*, UErrorCode&)
1.35 Gc  12,2 %	      icu_76_godot::RBBIDataWrapper::RBBIDataWrapper(UDataMemory*, UErrorCode&)
1.35 Gc  12,2 %	       icu_76_godot::RuleBasedBreakIterator::RuleBasedBreakIterator(UDataMemory*, UErrorCode&)
1.35 Gc  12,2 %	        icu_76_godot::RuleBasedBreakIterator::RuleBasedBreakIterator(UDataMemory*, signed char, UErrorCode&)
1.35 Gc  12,2 %	         icu_76_godot::BreakIterator::buildInstance(icu_76_godot::Locale const&, char const*, UErrorCode&)
1.35 Gc  12,2 %	          icu_76_godot::BreakIterator::makeInstance(icu_76_godot::Locale const&, int, UErrorCode&)
1.35 Gc  12,2 %	           ubrk_open_76_godot
1.35 Gc  12,2 %	            TextServerAdvanced::_shaped_text_update_breaks(RID const&)
1.35 Gc  12,1 %	             TextServer::shaped_text_get_line_breaks(RID const&, double, long long, BitField<TextServer::LineBreakFlag>) const
```

After update
```
882.78 Mc   8,2 %	  u_strFromUTF8WithSub_76_godot
882.78 Mc   8,2 %	   icu_76_godot::UnicodeString::setToUTF8(icu_76_godot::StringPiece)
882.78 Mc   8,2 %	    icu_76_godot::RBBIDataWrapper::init(icu_76_godot::RBBIDataHeader const*, UErrorCode&)
882.78 Mc   8,2 %	     icu_76_godot::RBBIDataWrapper::RBBIDataWrapper(UDataMemory*, UErrorCode&)
882.78 Mc   8,2 %	      icu_76_godot::RBBIDataWrapper::RBBIDataWrapper(UDataMemory*, UErrorCode&)
882.78 Mc   8,2 %	       icu_76_godot::RuleBasedBreakIterator::RuleBasedBreakIterator(UDataMemory*, UErrorCode&)
882.78 Mc   8,2 %	        icu_76_godot::RuleBasedBreakIterator::RuleBasedBreakIterator(UDataMemory*, signed char, UErrorCode&)
882.78 Mc   8,2 %	         icu_76_godot::BreakIterator::buildInstance(icu_76_godot::Locale const&, char const*, UErrorCode&)
882.78 Mc   8,2 %	          icu_76_godot::BreakIterator::makeInstance(icu_76_godot::Locale const&, int, UErrorCode&)
882.78 Mc   8,2 %	           ubrk_open_76_godot
882.78 Mc   8,2 %	            TextServerAdvanced::ShapedTextDataAdvanced::_get_break_iterator_for_locale(String const&, UErrorCode*)
882.78 Mc   8,2 %	             TextServerAdvanced::_shaped_text_update_breaks(RID const&)
878.78 Mc   8,2 %	              TextServer::shaped_text_get_line_breaks(RID const&, double, long long, BitField<TextServer::LineBreakFlag>) const
```

## Caveats
This change is likely to use some additional RAM. I don't have a sophisticated way to measure this, but my system reports a potential increase of 70mb:

- 1,22 GB on master
- 1,29 GB on this PR

It would be good if this could be measured more precisely to weigh it against the performance improvement.
Using a `UBreakIterator` pool (explained above) would likely further improve RAM efficiency.
