### PR TITLE
Fix memory leak when `ClassDB::bind_method_custom()` fails

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1866,9 +1866,12 @@ void ClassDB::_bind_compatibility(ClassInfo *type, MethodBind *p_method) {
 void ClassDB::_bind_method_custom(const StringName &p_class, MethodBind *p_method, bool p_compatibility) {
 	OBJTYPE_WLOCK;
 
+	StringName method_name = p_method->get_name();
+
 	ClassInfo *type = classes.getptr(p_class);
 	if (!type) {
-		ERR_FAIL_MSG(vformat("Couldn't bind custom method '%s' for instance '%s'.", p_method->get_name(), p_class));
+		memdelete(p_method);
+		ERR_FAIL_MSG(vformat("Couldn't bind custom method '%s' for instance '%s'.", method_name, p_class));
 	}
 
 	if (p_compatibility) {
@@ -1876,16 +1879,17 @@ void ClassDB::_bind_method_custom(const StringName &p_class, MethodBind *p_metho
 		return;
 	}
 
-	if (type->method_map.has(p_method->get_name())) {
+	if (type->method_map.has(method_name)) {
 		// overloading not supported
-		ERR_FAIL_MSG(vformat("Method already bound '%s::%s'.", p_class, p_method->get_name()));
+		memdelete(p_method);
+		ERR_FAIL_MSG(vformat("Method already bound '%s::%s'.", p_class, method_name));
 	}
 
 #ifdef DEBUG_METHODS_ENABLED
-	type->method_order.push_back(p_method->get_name());
+	type->method_order.push_back(method_name);
 #endif
 
-	type->method_map[p_method->get_name()] = p_method;
+	type->method_map[method_name] = p_method;
 }
 
 MethodBind *ClassDB::_bind_vararg_method(MethodBind *p_bind, const StringName &p_name, const Vector<Variant> &p_default_args, bool p_compatibility) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/101870

In other cases (for example, `ClassDB::_bind_vararg_method()` and `ClassDB::bind_methodfi()`), the method bind is deleted just before returning if it can't be added for some reason.

A couple examples:

https://github.com/godotengine/godot/blob/71d80b26a4c47e1b5e1bab9ed8ef1512e359b5e9/core/object/class_db.cpp#L1899-L1902

https://github.com/godotengine/godot/blob/71d80b26a4c47e1b5e1bab9ed8ef1512e359b5e9/core/object/class_db.cpp#L1949-L1953

So, this PR is aiming to do the same thing but in `ClassDB::_bind_method_custom()`.

(Because I needed to stash `p_method->get_name()` in a variable so I could use it after the method bind is deleted, I also did a tiny refactor to stash that in a local variable for all cases, since it was referred to quite a lot.)