### PR TITLE
Optimize `Font` calculations by avoiding unnecessary copy-on-write.

### DIFF
--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -210,9 +210,10 @@ real_t Font::get_height(int p_font_size) const {
 	if (dirty_rids) {
 		_update_rids();
 	}
+
 	real_t ret = 0.f;
 	for (int i = 0; i < rids.size(); i++) {
-		ret = MAX(ret, TS->font_get_ascent(rids[i], p_font_size) + TS->font_get_descent(rids[i], p_font_size));
+		ret = MAX(ret, TS->font_get_ascent(rids.get(i), p_font_size) + TS->font_get_descent(rids.get(i), p_font_size));
 	}
 	return ret + get_spacing(TextServer::SPACING_BOTTOM) + get_spacing(TextServer::SPACING_TOP);
 }
@@ -223,7 +224,7 @@ real_t Font::get_ascent(int p_font_size) const {
 	}
 	real_t ret = 0.f;
 	for (int i = 0; i < rids.size(); i++) {
-		ret = MAX(ret, TS->font_get_ascent(rids[i], p_font_size));
+		ret = MAX(ret, TS->font_get_ascent(rids.get(i), p_font_size));
 	}
 	return ret + get_spacing(TextServer::SPACING_TOP);
 }
@@ -234,7 +235,7 @@ real_t Font::get_descent(int p_font_size) const {
 	}
 	real_t ret = 0.f;
 	for (int i = 0; i < rids.size(); i++) {
-		ret = MAX(ret, TS->font_get_descent(rids[i], p_font_size));
+		ret = MAX(ret, TS->font_get_descent(rids.get(i), p_font_size));
 	}
 	return ret + get_spacing(TextServer::SPACING_BOTTOM);
 }
@@ -245,7 +246,7 @@ real_t Font::get_underline_position(int p_font_size) const {
 	}
 	real_t ret = 0.f;
 	for (int i = 0; i < rids.size(); i++) {
-		ret = MAX(ret, TS->font_get_underline_position(rids[i], p_font_size));
+		ret = MAX(ret, TS->font_get_underline_position(rids.get(i), p_font_size));
 	}
 	return ret + get_spacing(TextServer::SPACING_TOP);
 }
@@ -256,7 +257,7 @@ real_t Font::get_underline_thickness(int p_font_size) const {
 	}
 	real_t ret = 0.f;
 	for (int i = 0; i < rids.size(); i++) {
-		ret = MAX(ret, TS->font_get_underline_thickness(rids[i], p_font_size));
+		ret = MAX(ret, TS->font_get_underline_thickness(rids.get(i), p_font_size));
 	}
 	return ret;
 }
@@ -476,9 +477,9 @@ Size2 Font::get_char_size(char32_t p_char, int p_font_size) const {
 		_update_rids();
 	}
 	for (int i = 0; i < rids.size(); i++) {
-		if (TS->font_has_char(rids[i], p_char)) {
-			int32_t glyph = TS->font_get_glyph_index(rids[i], p_font_size, p_char, 0);
-			return Size2(TS->font_get_glyph_advance(rids[i], p_font_size, glyph).x, get_height(p_font_size));
+		if (TS->font_has_char(rids.get(i), p_char)) {
+			int32_t glyph = TS->font_get_glyph_index(rids.get(i), p_font_size, p_char, 0);
+			return Size2(TS->font_get_glyph_advance(rids.get(i), p_font_size, glyph).x, get_height(p_font_size));
 		}
 	}
 	return Size2();
@@ -489,10 +490,10 @@ real_t Font::draw_char(RID p_canvas_item, const Point2 &p_pos, char32_t p_char, 
 		_update_rids();
 	}
 	for (int i = 0; i < rids.size(); i++) {
-		if (TS->font_has_char(rids[i], p_char)) {
-			int32_t glyph = TS->font_get_glyph_index(rids[i], p_font_size, p_char, 0);
-			TS->font_draw_glyph(rids[i], p_canvas_item, p_font_size, p_pos, glyph, p_modulate);
-			return TS->font_get_glyph_advance(rids[i], p_font_size, glyph).x;
+		if (TS->font_has_char(rids.get(i), p_char)) {
+			int32_t glyph = TS->font_get_glyph_index(rids.get(i), p_font_size, p_char, 0);
+			TS->font_draw_glyph(rids.get(i), p_canvas_item, p_font_size, p_pos, glyph, p_modulate);
+			return TS->font_get_glyph_advance(rids.get(i), p_font_size, glyph).x;
 		}
 	}
 	return 0.f;
@@ -503,10 +504,10 @@ real_t Font::draw_char_outline(RID p_canvas_item, const Point2 &p_pos, char32_t 
 		_update_rids();
 	}
 	for (int i = 0; i < rids.size(); i++) {
-		if (TS->font_has_char(rids[i], p_char)) {
-			int32_t glyph = TS->font_get_glyph_index(rids[i], p_font_size, p_char, 0);
-			TS->font_draw_glyph_outline(rids[i], p_canvas_item, p_font_size, p_size, p_pos, glyph, p_modulate);
-			return TS->font_get_glyph_advance(rids[i], p_font_size, glyph).x;
+		if (TS->font_has_char(rids.get(i), p_char)) {
+			int32_t glyph = TS->font_get_glyph_index(rids.get(i), p_font_size, p_char, 0);
+			TS->font_draw_glyph_outline(rids.get(i), p_canvas_item, p_font_size, p_size, p_pos, glyph, p_modulate);
+			return TS->font_get_glyph_advance(rids.get(i), p_font_size, glyph).x;
 		}
 	}
 	return 0.f;
@@ -518,7 +519,7 @@ bool Font::has_char(char32_t p_char) const {
 		_update_rids();
 	}
 	for (int i = 0; i < rids.size(); i++) {
-		if (TS->font_has_char(rids[i], p_char)) {
+		if (TS->font_has_char(rids.get(i), p_char)) {
 			return true;
 		}
 	}
@@ -531,7 +532,7 @@ String Font::get_supported_chars() const {
 	}
 	String chars;
 	for (int i = 0; i < rids.size(); i++) {
-		String data_chars = TS->font_get_supported_chars(rids[i]);
+		String data_chars = TS->font_get_supported_chars(rids.get(i));
 		for (int j = 0; j < data_chars.length(); j++) {
 			if (chars.find_char(data_chars[j]) == -1) {
 				chars += data_chars[j];


### PR DESCRIPTION
- *Production edit: Related to https://github.com/godotengine/godot/pull/102129.*

I profiled scrolling across 4000 `Node` entries in the scene tree.
I was able to improve its performance by 20% by avoiding unnecessary copy-on-write calls.

## Explanation
`Array[i]` has a const and a non-const implementation.
When a mutable instance is available, the non-const implementation is always chosen. This version implies a fork of the `CowData` (copy-on-write). 
`Font` has a `mutable TypedArray<RID> rids` - because it is `mutable`, it is always non-const. For this reason, it will always cause forks on `operator[]` access.
The `.get` function does not have a non-const implementation. As such, it does not cause forks.

## Profiler
I profiled the scrolling across 4000 items in the scene tree.
I used Apple Instruments' CPU profiler and inverted the call tree.

Before (after this PR, this entry is completely gone).
```
1.50 Gc  22,8 %	  CowData<Variant>::_copy_on_write()
1.48 Gc  22,4 %	   CowData<Variant>::ptrw()
1.48 Gc  22,4 %	    VectorWriteProxy<Variant>::operator[](long long)
1.48 Gc  22,4 %	     Array::operator[](int)
1.48 Gc  22,4 %	      Font::get_height(int) const
1.48 Gc  22,4 %	       Tree::compute_item_height(TreeItem*) const
917.26 Mc  13,9 %	        Tree::get_item_height(TreeItem*) const
917.26 Mc  13,9 %	         Tree::get_item_height(TreeItem*) const
917.26 Mc  13,9 %	          Tree::get_internal_min_size() const
917.26 Mc  13,9 %	           Tree::update_scrollbars()
```

## Caveats
It would be better to eliminate the non-const `operator[]` entirely, and replace it with a `Vector.write`-like construct, such that `CoW` must be intentional. This change would avoid this kind of problem in the future.
However, that will require quite a lot more work.