### PR TITLE
Fix framebuffer clear for particle collider heightfield.

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2862,7 +2862,7 @@ void RenderForwardClustered::_render_particle_collider_heightfield(RID p_fb, con
 	{
 		//regular forward for now
 		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), false, pass_mode, 0, true, false, rp_uniform_set);
-		_render_list_with_draw_list(&render_list_params, p_fb);
+		_render_list_with_draw_list(&render_list_params, p_fb, RD::DRAW_CLEAR_ALL);
 	}
 	RD::get_singleton()->draw_command_end_label();
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/100793.

A mistake was made while porting over the draw list behavior to the new function and the clear that was necessary on this particular case was not implemented. Unlike what the issue led me to believe, the issue does not affect only MacOS, but it was where it was shown most prominently and consistently.

I've verified this fixes the problem in MacOS and no regressiones are perceived on Windows either.