### PR TITLE
[Web] Add accelerometer and gyroscope support

### DIFF
--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -126,6 +126,10 @@ private:
 	static int _mouse_wheel_callback(double p_delta_x, double p_delta_y);
 	WASM_EXPORT static void touch_callback(int p_type, int p_count);
 	static void _touch_callback(int p_type, int p_count);
+	WASM_EXPORT static void accelerometer_callback(double p_x, double p_y, double p_z);
+	static void _accelerometer_callback(double p_x, double p_y, double p_z);
+	WASM_EXPORT static void gyroscope_callback(double p_x, double p_y, double p_z);
+	static void _gyroscope_callback(double p_x, double p_y, double p_z);
 	WASM_EXPORT static void key_callback(int p_pressed, int p_repeat, int p_modifiers);
 	static void _key_callback(const String &p_key_event_code, const String &p_key_event_key, int p_pressed, int p_repeat, int p_modifiers);
 	WASM_EXPORT static void vk_input_text_callback(const char *p_text, int p_cursor);

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -57,10 +57,13 @@ extern int godot_js_pwa_cb(void (*p_callback)());
 extern int godot_js_pwa_update();
 
 // Input
+extern void godot_js_input_init(int p_accelerometer_enabled, int p_gyroscope_enabled);
 extern void godot_js_input_mouse_button_cb(int (*p_callback)(int p_pressed, int p_button, double p_x, double p_y, int p_modifiers));
 extern void godot_js_input_mouse_move_cb(void (*p_callback)(double p_x, double p_y, double p_rel_x, double p_rel_y, int p_modifiers));
 extern void godot_js_input_mouse_wheel_cb(int (*p_callback)(double p_delta_x, double p_delta_y));
 extern void godot_js_input_touch_cb(void (*p_callback)(int p_type, int p_count), uint32_t *r_identifiers, double *r_coords);
+extern void godot_js_input_accelerometer_cb(void (*p_callback)(double p_x, double p_y, double p_z));
+extern void godot_js_input_gyroscope_cb(void (*p_callback)(double p_x, double p_y, double p_z));
 extern void godot_js_input_key_cb(void (*p_callback)(int p_type, int p_repeat, int p_modifiers), char r_code[32], char r_key[32]);
 extern void godot_js_input_vibrate_handheld(int p_duration_ms);
 


### PR DESCRIPTION
This PR adds accelerometer and gyroscope support on the Web platform.

For more detail about support, see: https://caniuse.com/accelerometer and https://caniuse.com/gyroscope
Currently, only Chromium browsers support the feature (i.e. Chrome + Edge).