### PR TITLE
Add unit tests for control focus navigation

### DIFF
--- a/tests/scene/test_control.h
+++ b/tests/scene/test_control.h
@@ -31,6 +31,7 @@
 #ifndef TEST_CONTROL_H
 #define TEST_CONTROL_H
 
+#include "scene/2d/node_2d.h"
 #include "scene/gui/control.h"
 
 #include "tests/test_macros.h"
@@ -66,7 +67,7 @@ TEST_CASE("[SceneTree][Control] Focus") {
 	SceneTree::get_singleton()->get_root()->add_child(ctrl);
 
 	SUBCASE("[SceneTree][Control] Default focus") {
-		CHECK_FALSE(ctrl->has_focus());
+		CHECK_UNARY_FALSE(ctrl->has_focus());
 	}
 
 	SUBCASE("[SceneTree][Control] Can't grab focus with default focus mode") {
@@ -74,39 +75,826 @@ TEST_CASE("[SceneTree][Control] Focus") {
 		ctrl->grab_focus();
 		ERR_PRINT_ON
 
-		CHECK_FALSE(ctrl->has_focus());
+		CHECK_UNARY_FALSE(ctrl->has_focus());
 	}
 
 	SUBCASE("[SceneTree][Control] Can grab focus") {
 		ctrl->set_focus_mode(Control::FocusMode::FOCUS_ALL);
 		ctrl->grab_focus();
 
-		CHECK(ctrl->has_focus());
+		CHECK_UNARY(ctrl->has_focus());
 	}
 
 	SUBCASE("[SceneTree][Control] Can release focus") {
 		ctrl->set_focus_mode(Control::FocusMode::FOCUS_ALL);
 		ctrl->grab_focus();
-		CHECK(ctrl->has_focus());
+		CHECK_UNARY(ctrl->has_focus());
 
 		ctrl->release_focus();
-		CHECK_FALSE(ctrl->has_focus());
+		CHECK_UNARY_FALSE(ctrl->has_focus());
 	}
 
 	SUBCASE("[SceneTree][Control] Only one can grab focus at the same time") {
 		ctrl->set_focus_mode(Control::FocusMode::FOCUS_ALL);
 		ctrl->grab_focus();
-		CHECK(ctrl->has_focus());
+		CHECK_UNARY(ctrl->has_focus());
 
 		Control *other_ctrl = memnew(Control);
 		SceneTree::get_singleton()->get_root()->add_child(other_ctrl);
 		other_ctrl->set_focus_mode(Control::FocusMode::FOCUS_ALL);
 		other_ctrl->grab_focus();
 
-		CHECK(other_ctrl->has_focus());
-		CHECK_FALSE(ctrl->has_focus());
+		CHECK_UNARY(other_ctrl->has_focus());
+		CHECK_UNARY_FALSE(ctrl->has_focus());
 
 		memdelete(other_ctrl);
+	}
+
+	SUBCASE("[SceneTree][Control] Hide control will cause the focus to be released") {
+		ctrl->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+		ctrl->grab_focus();
+		CHECK_UNARY(ctrl->has_focus());
+
+		ctrl->hide();
+		CHECK_UNARY_FALSE(ctrl->has_focus());
+
+		ctrl->show();
+		CHECK_UNARY_FALSE(ctrl->has_focus());
+	}
+
+	SUBCASE("[SceneTree][Control] The parent node is hidden causing the focus to be released") {
+		Control *child_ctrl = memnew(Control);
+		ctrl->add_child(child_ctrl);
+
+		child_ctrl->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+		child_ctrl->grab_focus();
+		CHECK_UNARY(child_ctrl->has_focus());
+
+		ctrl->hide();
+		CHECK_UNARY_FALSE(child_ctrl->has_focus());
+
+		ctrl->show();
+		CHECK_UNARY_FALSE(child_ctrl->has_focus());
+
+		memdelete(child_ctrl);
+	}
+
+	memdelete(ctrl);
+}
+
+TEST_CASE("[SceneTree][Control] Find next/prev valid focus") {
+	Control *ctrl = memnew(Control);
+	SceneTree::get_singleton()->get_root()->add_child(ctrl);
+
+	SUBCASE("[SceneTree][Control] In FOCUS_CLICK mode") {
+		ctrl->set_focus_mode(Control::FocusMode::FOCUS_CLICK);
+		ctrl->grab_focus();
+		REQUIRE_UNARY(ctrl->has_focus());
+
+		SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+			SEND_GUI_ACTION("ui_focus_next");
+			CHECK_UNARY(ctrl->has_focus());
+		}
+
+		SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+			SEND_GUI_ACTION("ui_focus_prev");
+			CHECK_UNARY(ctrl->has_focus());
+		}
+
+		SUBCASE("[SceneTree][Control] Has a sibling control but the parent node is not a control") {
+			Control *other_ctrl = memnew(Control);
+			SceneTree::get_singleton()->get_root()->add_child(other_ctrl);
+
+			SUBCASE("[SceneTree][Control] Has a sibling control with FOCUS_ALL") {
+				other_ctrl->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+				REQUIRE_EQ(other_ctrl->get_focus_mode(), Control::FocusMode::FOCUS_ALL);
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+					SEND_GUI_ACTION("ui_focus_next");
+					CHECK_UNARY(ctrl->has_focus());
+					CHECK_UNARY_FALSE(other_ctrl->has_focus());
+				}
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+					SEND_GUI_ACTION("ui_focus_prev");
+					CHECK_UNARY(ctrl->has_focus());
+					CHECK_UNARY_FALSE(other_ctrl->has_focus());
+				}
+
+				SUBCASE("[SceneTree][Control] Manually specify focus next") {
+					ctrl->set_focus_next(ctrl->get_path_to(other_ctrl));
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY_FALSE(ctrl->has_focus());
+						CHECK_UNARY(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Manually specified focus next is hidden") {
+						other_ctrl->hide();
+						REQUIRE_UNARY_FALSE(other_ctrl->is_visible());
+
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+							SEND_GUI_ACTION("ui_focus_next");
+							CHECK_UNARY(ctrl->has_focus());
+							CHECK_UNARY_FALSE(other_ctrl->has_focus());
+						}
+
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+							SEND_GUI_ACTION("ui_focus_prev");
+							CHECK_UNARY(ctrl->has_focus());
+							CHECK_UNARY_FALSE(other_ctrl->has_focus());
+						}
+					}
+				}
+
+				SUBCASE("[SceneTree][Control] Manually specify focus prev") {
+					ctrl->set_focus_previous(ctrl->get_path_to(other_ctrl));
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY_FALSE(ctrl->has_focus());
+						CHECK_UNARY(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Manually specified focus next is hidden") {
+						other_ctrl->hide();
+						REQUIRE_UNARY_FALSE(other_ctrl->is_visible());
+
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+							SEND_GUI_ACTION("ui_focus_next");
+							CHECK_UNARY(ctrl->has_focus());
+							CHECK_UNARY_FALSE(other_ctrl->has_focus());
+						}
+
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+							SEND_GUI_ACTION("ui_focus_prev");
+							CHECK_UNARY(ctrl->has_focus());
+							CHECK_UNARY_FALSE(other_ctrl->has_focus());
+						}
+					}
+				}
+			}
+
+			SUBCASE("[SceneTree][Control] Has a sibling control with FOCUS_CLICK") {
+				other_ctrl->set_focus_mode(Control::FocusMode::FOCUS_CLICK);
+				REQUIRE_EQ(other_ctrl->get_focus_mode(), Control::FocusMode::FOCUS_CLICK);
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+					SEND_GUI_ACTION("ui_focus_next");
+					CHECK_UNARY(ctrl->has_focus());
+					CHECK_UNARY_FALSE(other_ctrl->has_focus());
+				}
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+					SEND_GUI_ACTION("ui_focus_prev");
+					CHECK_UNARY(ctrl->has_focus());
+					CHECK_UNARY_FALSE(other_ctrl->has_focus());
+				}
+
+				SUBCASE("[SceneTree][Control] Manually specify focus next") {
+					ctrl->set_focus_next(ctrl->get_path_to(other_ctrl));
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY_FALSE(ctrl->has_focus());
+						CHECK_UNARY(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+				}
+
+				SUBCASE("[SceneTree][Control] Manually specify focus prev") {
+					ctrl->set_focus_previous(ctrl->get_path_to(other_ctrl));
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY_FALSE(ctrl->has_focus());
+						CHECK_UNARY(other_ctrl->has_focus());
+					}
+				}
+			}
+
+			SUBCASE("[SceneTree][Control] Has a sibling control with FOCUS_NONE") {
+				other_ctrl->set_focus_mode(Control::FocusMode::FOCUS_NONE);
+				REQUIRE_EQ(other_ctrl->get_focus_mode(), Control::FocusMode::FOCUS_NONE);
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+					SEND_GUI_ACTION("ui_focus_next");
+					CHECK_UNARY(ctrl->has_focus());
+					CHECK_UNARY_FALSE(other_ctrl->has_focus());
+				}
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+					SEND_GUI_ACTION("ui_focus_prev");
+					CHECK_UNARY(ctrl->has_focus());
+					CHECK_UNARY_FALSE(other_ctrl->has_focus());
+				}
+
+				SUBCASE("[SceneTree][Control] Manually specify focus next") {
+					ctrl->set_focus_next(ctrl->get_path_to(other_ctrl));
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+				}
+
+				SUBCASE("[SceneTree][Control] Manually specify focus prev") {
+					ctrl->set_focus_previous(ctrl->get_path_to(other_ctrl));
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+				}
+			}
+
+			memdelete(other_ctrl);
+		}
+	}
+
+	SUBCASE("[SceneTree][Control] In FOCUS_ALL mode") {
+		ctrl->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+		REQUIRE_EQ(ctrl->get_focus_mode(), Control::FocusMode::FOCUS_ALL);
+
+		ctrl->grab_focus();
+		REQUIRE_UNARY(ctrl->has_focus());
+
+		SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+			SEND_GUI_ACTION("ui_focus_next");
+			CHECK_UNARY(ctrl->has_focus());
+		}
+
+		SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+			SEND_GUI_ACTION("ui_focus_prev");
+			CHECK_UNARY(ctrl->has_focus());
+		}
+
+		SUBCASE("[SceneTree][Control] Has a sibling control but the parent node is not a control") {
+			Control *other_ctrl = memnew(Control);
+			SceneTree::get_singleton()->get_root()->add_child(other_ctrl);
+
+			SUBCASE("[SceneTree][Control] Has a sibling control with FOCUS_ALL") {
+				other_ctrl->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+				REQUIRE_EQ(other_ctrl->get_focus_mode(), Control::FocusMode::FOCUS_ALL);
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+					SEND_GUI_ACTION("ui_focus_next");
+					CHECK_UNARY(ctrl->has_focus());
+					CHECK_UNARY_FALSE(other_ctrl->has_focus());
+				}
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+					SEND_GUI_ACTION("ui_focus_prev");
+					CHECK_UNARY(ctrl->has_focus());
+					CHECK_UNARY_FALSE(other_ctrl->has_focus());
+				}
+
+				SUBCASE("[SceneTree][Control] Manually specify focus next") {
+					ctrl->set_focus_next(ctrl->get_path_to(other_ctrl));
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY_FALSE(ctrl->has_focus());
+						CHECK_UNARY(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Manually specified focus next is hidden") {
+						other_ctrl->hide();
+						REQUIRE_UNARY_FALSE(other_ctrl->is_visible());
+
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+							SEND_GUI_ACTION("ui_focus_next");
+							CHECK_UNARY(ctrl->has_focus());
+							CHECK_UNARY_FALSE(other_ctrl->has_focus());
+						}
+
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+							SEND_GUI_ACTION("ui_focus_prev");
+							CHECK_UNARY(ctrl->has_focus());
+							CHECK_UNARY_FALSE(other_ctrl->has_focus());
+						}
+					}
+				}
+
+				SUBCASE("[SceneTree][Control] Manually specify focus prev") {
+					ctrl->set_focus_previous(ctrl->get_path_to(other_ctrl));
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY_FALSE(ctrl->has_focus());
+						CHECK_UNARY(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Manually specified focus next is hidden") {
+						other_ctrl->hide();
+						REQUIRE_UNARY_FALSE(other_ctrl->is_visible());
+
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+							SEND_GUI_ACTION("ui_focus_next");
+							CHECK_UNARY(ctrl->has_focus());
+							CHECK_UNARY_FALSE(other_ctrl->has_focus());
+						}
+
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+							SEND_GUI_ACTION("ui_focus_prev");
+							CHECK_UNARY(ctrl->has_focus());
+							CHECK_UNARY_FALSE(other_ctrl->has_focus());
+						}
+					}
+				}
+			}
+
+			SUBCASE("[SceneTree][Control] Has a sibling control with FOCUS_CLICK") {
+				other_ctrl->set_focus_mode(Control::FocusMode::FOCUS_CLICK);
+				REQUIRE_EQ(other_ctrl->get_focus_mode(), Control::FocusMode::FOCUS_CLICK);
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+					SEND_GUI_ACTION("ui_focus_next");
+					CHECK_UNARY(ctrl->has_focus());
+					CHECK_UNARY_FALSE(other_ctrl->has_focus());
+				}
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+					SEND_GUI_ACTION("ui_focus_prev");
+					CHECK_UNARY(ctrl->has_focus());
+					CHECK_UNARY_FALSE(other_ctrl->has_focus());
+				}
+
+				SUBCASE("[SceneTree][Control] Manually specify focus next") {
+					ctrl->set_focus_next(ctrl->get_path_to(other_ctrl));
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY_FALSE(ctrl->has_focus());
+						CHECK_UNARY(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+				}
+
+				SUBCASE("[SceneTree][Control] Manually specify focus prev") {
+					ctrl->set_focus_previous(ctrl->get_path_to(other_ctrl));
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY_FALSE(ctrl->has_focus());
+						CHECK_UNARY(other_ctrl->has_focus());
+					}
+				}
+			}
+
+			SUBCASE("[SceneTree][Control] Has a sibling control with FOCUS_NONE") {
+				other_ctrl->set_focus_mode(Control::FocusMode::FOCUS_NONE);
+				REQUIRE_EQ(other_ctrl->get_focus_mode(), Control::FocusMode::FOCUS_NONE);
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+					SEND_GUI_ACTION("ui_focus_next");
+					CHECK_UNARY(ctrl->has_focus());
+					CHECK_UNARY_FALSE(other_ctrl->has_focus());
+				}
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+					SEND_GUI_ACTION("ui_focus_prev");
+					CHECK_UNARY(ctrl->has_focus());
+					CHECK_UNARY_FALSE(other_ctrl->has_focus());
+				}
+
+				SUBCASE("[SceneTree][Control] Manually specify focus next") {
+					ctrl->set_focus_next(ctrl->get_path_to(other_ctrl));
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+				}
+
+				SUBCASE("[SceneTree][Control] Manually specify focus prev") {
+					ctrl->set_focus_previous(ctrl->get_path_to(other_ctrl));
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY(ctrl->has_focus());
+						CHECK_UNARY_FALSE(other_ctrl->has_focus());
+					}
+				}
+			}
+
+			memdelete(other_ctrl);
+		}
+
+		SUBCASE("[SceneTree][Control] Simple control tree") {
+			Control *ctrl_0 = memnew(Control);
+			Control *ctrl_1 = memnew(Control);
+			Node2D *node_2d_2 = memnew(Node2D);
+
+			ctrl->add_child(ctrl_0);
+			ctrl->add_child(ctrl_1);
+			ctrl->add_child(node_2d_2);
+
+			ctrl_0->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+			ctrl_1->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+			REQUIRE_EQ(ctrl_0->get_focus_mode(), Control::FocusMode::FOCUS_ALL);
+			REQUIRE_EQ(ctrl_1->get_focus_mode(), Control::FocusMode::FOCUS_ALL);
+
+			SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+				SEND_GUI_ACTION("ui_focus_next");
+				CHECK_UNARY(ctrl_0->has_focus());
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+					SEND_GUI_ACTION("ui_focus_next");
+					CHECK_UNARY(ctrl_1->has_focus());
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY(ctrl->has_focus());
+					}
+				}
+			}
+
+			SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+				SEND_GUI_ACTION("ui_focus_prev");
+				CHECK_UNARY(ctrl_1->has_focus());
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+					SEND_GUI_ACTION("ui_focus_prev");
+					CHECK_UNARY(ctrl_0->has_focus());
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY(ctrl->has_focus());
+					}
+				}
+			}
+
+			SUBCASE("[SceneTree][Control] Skip next hidden control") {
+				ctrl_0->hide();
+				REQUIRE_UNARY_FALSE(ctrl_0->is_visible());
+				SEND_GUI_ACTION("ui_focus_next");
+				CHECK_UNARY_FALSE(ctrl_0->has_focus());
+				CHECK_UNARY(ctrl_1->has_focus());
+			}
+
+			SUBCASE("[SceneTree][Control] Skip next control with FOCUS_NONE") {
+				ctrl_0->set_focus_mode(Control::FocusMode::FOCUS_NONE);
+				REQUIRE_EQ(ctrl_0->get_focus_mode(), Control::FocusMode::FOCUS_NONE);
+				SEND_GUI_ACTION("ui_focus_next");
+				CHECK_UNARY_FALSE(ctrl_0->has_focus());
+				CHECK_UNARY(ctrl_1->has_focus());
+			}
+
+			SUBCASE("[SceneTree][Control] Skip next control with FOCUS_CLICK") {
+				ctrl_0->set_focus_mode(Control::FocusMode::FOCUS_CLICK);
+				REQUIRE_EQ(ctrl_0->get_focus_mode(), Control::FocusMode::FOCUS_CLICK);
+				SEND_GUI_ACTION("ui_focus_next");
+				CHECK_UNARY_FALSE(ctrl_0->has_focus());
+				CHECK_UNARY(ctrl_1->has_focus());
+			}
+
+			SUBCASE("[SceneTree][Control] Skip next top level control") {
+				ctrl_0->set_as_top_level(true);
+				REQUIRE_UNARY(ctrl_0->is_set_as_top_level());
+				SEND_GUI_ACTION("ui_focus_next");
+				CHECK_UNARY_FALSE(ctrl_0->has_focus());
+				CHECK_UNARY(ctrl_1->has_focus());
+			}
+
+			SUBCASE("[SceneTree][Control] Skip prev hidden control") {
+				ctrl_1->hide();
+				REQUIRE_UNARY_FALSE(ctrl_1->is_visible());
+				SEND_GUI_ACTION("ui_focus_prev");
+				CHECK_UNARY_FALSE(ctrl_1->has_focus());
+				CHECK_UNARY(ctrl_0->has_focus());
+			}
+
+			SUBCASE("[SceneTree][Control] Skip prev control with FOCUS_NONE") {
+				ctrl_1->set_focus_mode(Control::FocusMode::FOCUS_NONE);
+				REQUIRE_EQ(ctrl_1->get_focus_mode(), Control::FocusMode::FOCUS_NONE);
+				SEND_GUI_ACTION("ui_focus_prev");
+				CHECK_UNARY_FALSE(ctrl_1->has_focus());
+				CHECK_UNARY(ctrl_0->has_focus());
+			}
+
+			SUBCASE("[SceneTree][Control] Skip prev control with FOCUS_CLICK") {
+				ctrl_1->set_focus_mode(Control::FocusMode::FOCUS_CLICK);
+				REQUIRE_EQ(ctrl_1->get_focus_mode(), Control::FocusMode::FOCUS_CLICK);
+				SEND_GUI_ACTION("ui_focus_prev");
+				CHECK_UNARY_FALSE(ctrl_1->has_focus());
+				CHECK_UNARY(ctrl_0->has_focus());
+			}
+
+			SUBCASE("[SceneTree][Control] Skip prev top level control") {
+				ctrl_1->set_as_top_level(true);
+				REQUIRE_UNARY(ctrl_1->is_set_as_top_level());
+				SEND_GUI_ACTION("ui_focus_prev");
+				CHECK_UNARY_FALSE(ctrl_1->has_focus());
+				CHECK_UNARY(ctrl_0->has_focus());
+			}
+
+			SUBCASE("[SceneTree][Control] Add more node controls") {
+				Control *ctrl_0_0 = memnew(Control);
+				Control *ctrl_0_1 = memnew(Control);
+				Control *ctrl_0_2 = memnew(Control);
+				ctrl_0->add_child(ctrl_0_0);
+				ctrl_0->add_child(ctrl_0_1);
+				ctrl_0->add_child(ctrl_0_2);
+				ctrl_0_0->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+				ctrl_0_1->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+				ctrl_0_2->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+
+				Control *ctrl_1_0 = memnew(Control);
+				Control *ctrl_1_1 = memnew(Control);
+				Control *ctrl_1_2 = memnew(Control);
+				ctrl_1->add_child(ctrl_1_0);
+				ctrl_1->add_child(ctrl_1_1);
+				ctrl_1->add_child(ctrl_1_2);
+				ctrl_1_0->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+				ctrl_1_1->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+				ctrl_1_2->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+
+				Control *ctrl_2_0 = memnew(Control);
+				Control *ctrl_2_1 = memnew(Control);
+				Control *ctrl_2_2 = memnew(Control);
+				node_2d_2->add_child(ctrl_2_0);
+				node_2d_2->add_child(ctrl_2_1);
+				node_2d_2->add_child(ctrl_2_2);
+				ctrl_2_0->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+				ctrl_2_1->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+				ctrl_2_2->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+					SEND_GUI_ACTION("ui_focus_next");
+					CHECK_UNARY(ctrl_0->has_focus());
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY(ctrl_0_0->has_focus());
+					}
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+						SEND_GUI_ACTION("ui_focus_prev");
+						CHECK_UNARY(ctrl->has_focus());
+					}
+				}
+
+				SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+					SEND_GUI_ACTION("ui_focus_prev");
+					CHECK_UNARY(ctrl_1_2->has_focus());
+				}
+
+				SUBCASE("[SceneTree][Control] Exist top level tree") {
+					ctrl_0->set_as_top_level(true);
+					REQUIRE_UNARY(ctrl_0->is_set_as_top_level());
+
+					SUBCASE("[SceneTree][Control] Outside top level tree") {
+						ctrl->grab_focus();
+						REQUIRE_UNARY(ctrl->has_focus());
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+							SEND_GUI_ACTION("ui_focus_next");
+							CHECK_UNARY(ctrl_1->has_focus());
+
+							SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+								SEND_GUI_ACTION("ui_focus_prev");
+								CHECK_UNARY(ctrl->has_focus());
+							}
+						}
+					}
+
+					SUBCASE("[SceneTree][Control] Inside top level tree") {
+						ctrl_0->grab_focus();
+						REQUIRE_UNARY(ctrl_0->has_focus());
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+							SEND_GUI_ACTION("ui_focus_next");
+							CHECK_UNARY(ctrl_0_0->has_focus());
+
+							SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+								SEND_GUI_ACTION("ui_focus_prev");
+								CHECK_UNARY(ctrl_0->has_focus());
+							}
+						}
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+							SEND_GUI_ACTION("ui_focus_prev");
+							CHECK_UNARY(ctrl_0_2->has_focus());
+
+							SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+								SEND_GUI_ACTION("ui_focus_next");
+								CHECK_UNARY(ctrl_0->has_focus());
+							}
+						}
+					}
+
+					SUBCASE("[SceneTree][Control] Manually specified focus next") {
+						ctrl->set_focus_next(ctrl->get_path_to(ctrl_2_1));
+						ctrl_2_1->set_focus_next(ctrl_2_1->get_path_to(ctrl_1_0));
+						ctrl_1_0->set_focus_next(ctrl_1_0->get_path_to(ctrl_0));
+						ctrl_0->set_focus_next(ctrl_0->get_path_to(ctrl));
+
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+							SEND_GUI_ACTION("ui_focus_next");
+							CHECK_UNARY(ctrl_2_1->has_focus());
+
+							SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+								SEND_GUI_ACTION("ui_focus_next");
+								CHECK_UNARY(ctrl_1_0->has_focus());
+
+								SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+									SEND_GUI_ACTION("ui_focus_next");
+									CHECK_UNARY(ctrl_0->has_focus());
+
+									SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+										SEND_GUI_ACTION("ui_focus_next");
+										CHECK_UNARY(ctrl->has_focus());
+									}
+
+									SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+										SEND_GUI_ACTION("ui_focus_prev");
+										CHECK_UNARY(ctrl_0_2->has_focus());
+									}
+								}
+
+								SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+									SEND_GUI_ACTION("ui_focus_prev");
+									CHECK_UNARY(ctrl_1->has_focus());
+								}
+							}
+
+							SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+								SEND_GUI_ACTION("ui_focus_prev");
+								CHECK_UNARY(ctrl_2_1->has_focus());
+							}
+						}
+
+						SUBCASE("[SceneTree][Control] The parent node is not visible") {
+							node_2d_2->hide();
+							REQUIRE_UNARY(ctrl_2_1->is_visible());
+							REQUIRE_UNARY_FALSE(ctrl_2_1->is_visible_in_tree());
+							SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+								SEND_GUI_ACTION("ui_focus_next");
+								CHECK_UNARY_FALSE(ctrl->has_focus());
+								CHECK_UNARY_FALSE(ctrl_2_1->has_focus());
+								CHECK_UNARY_FALSE(ctrl_0->has_focus());
+								CHECK_UNARY(ctrl_1->has_focus());
+							}
+						}
+					}
+
+					SUBCASE("[SceneTree][Control] Manually specified focus prev") {
+						ctrl->set_focus_previous(ctrl->get_path_to(ctrl_0_2));
+						ctrl_0_2->set_focus_previous(ctrl_0_2->get_path_to(ctrl_1_1));
+						ctrl_1_1->set_focus_previous(ctrl_1_1->get_path_to(ctrl_2_0));
+						ctrl_2_0->set_focus_previous(ctrl_2_0->get_path_to(ctrl));
+
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+							SEND_GUI_ACTION("ui_focus_prev");
+							CHECK_UNARY(ctrl_0_2->has_focus());
+
+							SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+								SEND_GUI_ACTION("ui_focus_prev");
+								CHECK_UNARY(ctrl_1_1->has_focus());
+
+								SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+									SEND_GUI_ACTION("ui_focus_prev");
+									CHECK_UNARY(ctrl_2_0->has_focus());
+
+									SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+										SEND_GUI_ACTION("ui_focus_prev");
+										CHECK_UNARY(ctrl->has_focus());
+									}
+
+									SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+										SEND_GUI_ACTION("ui_focus_next");
+										CHECK_UNARY(ctrl_2_0->has_focus());
+									}
+								}
+
+								SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+									SEND_GUI_ACTION("ui_focus_next");
+									CHECK_UNARY(ctrl_1_2->has_focus());
+								}
+							}
+
+							SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+								SEND_GUI_ACTION("ui_focus_next");
+								CHECK_UNARY(ctrl_0->has_focus());
+							}
+						}
+
+						SUBCASE("[SceneTree][Control] The parent node is not visible") {
+							ctrl_0->hide();
+							REQUIRE_UNARY(ctrl_0_2->is_visible());
+							REQUIRE_UNARY_FALSE(ctrl_0_2->is_visible_in_tree());
+							SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+								SEND_GUI_ACTION("ui_focus_prev");
+								CHECK_UNARY_FALSE(ctrl->has_focus());
+								CHECK_UNARY_FALSE(ctrl_0_2->has_focus());
+								CHECK_UNARY(ctrl_1_2->has_focus());
+							}
+						}
+					}
+				}
+
+				SUBCASE("[SceneTree][Control] Exist hidden control tree") {
+					ctrl_0->hide();
+					REQUIRE_UNARY_FALSE(ctrl_0->is_visible());
+
+					SUBCASE("[SceneTree][Control] Simulate ui_focus_next action") {
+						SEND_GUI_ACTION("ui_focus_next");
+						CHECK_UNARY(ctrl_1->has_focus());
+
+						SUBCASE("[SceneTree][Control] Simulate ui_focus_prev action") {
+							SEND_GUI_ACTION("ui_focus_prev");
+							CHECK_UNARY(ctrl->has_focus());
+						}
+					}
+				}
+
+				memdelete(ctrl_2_2);
+				memdelete(ctrl_2_1);
+				memdelete(ctrl_2_0);
+				memdelete(ctrl_1_2);
+				memdelete(ctrl_1_1);
+				memdelete(ctrl_1_0);
+				memdelete(ctrl_0_2);
+				memdelete(ctrl_0_1);
+				memdelete(ctrl_0_0);
+			}
+
+			memdelete(node_2d_2);
+			memdelete(ctrl_1);
+			memdelete(ctrl_0);
+		}
 	}
 
 	memdelete(ctrl);


### PR DESCRIPTION
Users can navigate focus between controls using `ui_focus_next` or `ui_focus_prev actions`. Add unit tests for these behaviors.

The situation mentioned in #95747 has been added, so some test failures are expected.

Use [binary and unary asserts](https://github.com/doctest/doctest/blob/master/doc/markdown/assertions.md#binary-and-unary-asserts) to speed up compilation.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
