### PR TITLE
Add a rendering driver fallback order

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2968,17 +2968,10 @@
 		<member name="rendering/rendering_device/driver.windows" type="String" setter="" getter="">
 			Windows override for [member rendering/rendering_device/driver].
 		</member>
-		<member name="rendering/rendering_device/fallback_to_d3d12" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the forward renderer will fall back to Direct3D 12 if Vulkan is not supported.
-			[b]Note:[/b] This setting is implemented only on Windows.
-		</member>
-		<member name="rendering/rendering_device/fallback_to_opengl3" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the forward renderer will fall back to OpenGL 3 if Direct3D 12, Metal, and Vulkan are not supported.
-			[b]Note:[/b] This setting is implemented only on Windows, Android, macOS, iOS, and Linux/X11.
-		</member>
-		<member name="rendering/rendering_device/fallback_to_vulkan" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the forward renderer will fall back to Vulkan if Direct3D 12 is not supported.
-			[b]Note:[/b] This setting is implemented only on Windows.
+		<member name="rendering/rendering_device/drivers_fallback_order" type="PackedStringArray" setter="" getter="">
+			A [PackedStringArray] of rendering drivers fall back order. The forward renderer will fall back to other rendering drivers according to this order if current rendering driver is not supported. Make it empty to disable this feature.
+			Each item in it should be one of the following: [code]vulkan[/code], [code]d3d12[/code], [code]metal[/code], and [code]opengl3[/code].
+			[b]Note:[/b] Depending on the operating system, some rendering drivers might be unavailable and would be skipped.
 		</member>
 		<member name="rendering/rendering_device/pipeline_cache/enable" type="bool" setter="" getter="" default="true">
 			Enable the pipeline cache that is saved to disk if the graphics API supports it.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2969,9 +2969,22 @@
 			Windows override for [member rendering/rendering_device/driver].
 		</member>
 		<member name="rendering/rendering_device/drivers_fallback_order" type="PackedStringArray" setter="" getter="">
-			A [PackedStringArray] of rendering drivers fall back order. The forward renderer will fall back to other rendering drivers according to this order if current rendering driver is not supported. Make it empty to disable this feature.
-			Each item in it should be one of the following: [code]vulkan[/code], [code]d3d12[/code], [code]metal[/code], and [code]opengl3[/code].
-			[b]Note:[/b] Depending on the operating system, some rendering drivers might be unavailable and would be skipped.
+			A [PackedStringArray] of rendering drivers fall back order. The forward renderer will fall back to other rendering drivers according to this order if current rendering driver is not supported. Make it empty to disable this feature. This property can't be edited directly. Instead, set the order using the platform-specific overrides.
+		</member>
+		<member name="rendering/rendering_device/drivers_fallback_order.android" type="PackedStringArray" setter="" getter="">
+			Android override for [member rendering/rendering_device/drivers_fallback_order].
+		</member>
+		<member name="rendering/rendering_device/drivers_fallback_order.ios" type="PackedStringArray" setter="" getter="">
+			iOS override for [member rendering/rendering_device/drivers_fallback_order].
+		</member>
+		<member name="rendering/rendering_device/drivers_fallback_order.linuxbsd" type="PackedStringArray" setter="" getter="">
+			LinuxBSD override for [member rendering/rendering_device/drivers_fallback_order].
+		</member>
+		<member name="rendering/rendering_device/drivers_fallback_order.macos" type="PackedStringArray" setter="" getter="">
+			macOS override for [member rendering/rendering_device/drivers_fallback_order].
+		</member>
+		<member name="rendering/rendering_device/drivers_fallback_order.windows" type="PackedStringArray" setter="" getter="">
+			Windows override for [member rendering/rendering_device/drivers_fallback_order].
 		</member>
 		<member name="rendering/rendering_device/pipeline_cache/enable" type="bool" setter="" getter="" default="true">
 			Enable the pipeline cache that is saved to disk if the graphics API supports it.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2061,9 +2061,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/rendering_device/driver.ios", PROPERTY_HINT_ENUM, driver_hints_with_metal), default_driver_with_metal);
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/rendering_device/driver.macos", PROPERTY_HINT_ENUM, driver_hints_with_metal), default_driver_with_metal);
 
-		GLOBAL_DEF_RST("rendering/rendering_device/fallback_to_vulkan", true);
-		GLOBAL_DEF_RST("rendering/rendering_device/fallback_to_d3d12", true);
-		GLOBAL_DEF_RST("rendering/rendering_device/fallback_to_opengl3", true);
+		PackedStringArray drivers;
+		drivers.push_back("vulkan");
+		drivers.push_back("d3d12");
+		drivers.push_back("metal");
+		drivers.push_back("opengl3");
+		GLOBAL_DEF_NOVAL(PropertyInfo(Variant::PACKED_STRING_ARRAY, "rendering/rendering_device/drivers_fallback_order"), drivers);
 	}
 
 	{

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2061,12 +2061,29 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/rendering_device/driver.ios", PROPERTY_HINT_ENUM, driver_hints_with_metal), default_driver_with_metal);
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/rendering_device/driver.macos", PROPERTY_HINT_ENUM, driver_hints_with_metal), default_driver_with_metal);
 
-		PackedStringArray drivers;
-		drivers.push_back("vulkan");
-		drivers.push_back("d3d12");
-		drivers.push_back("metal");
-		drivers.push_back("opengl3");
-		GLOBAL_DEF_NOVAL(PropertyInfo(Variant::PACKED_STRING_ARRAY, "rendering/rendering_device/drivers_fallback_order"), drivers);
+		PackedStringArray default_drivers;
+		PackedStringArray default_drivers_with_d3d12;
+		PackedStringArray default_drivers_with_metal;
+
+		for (int i = 0; i < driver_hints.get_slice_count(","); i += 1) {
+			default_drivers.append(driver_hints.get_slice(",", i));
+		}
+		for (int i = 0; i < driver_hints_with_d3d12.get_slice_count(","); i += 1) {
+			default_drivers_with_d3d12.append(driver_hints_with_d3d12.get_slice(",", i));
+		}
+		for (int i = 0; i < driver_hints_with_metal.get_slice_count(","); i += 1) {
+			default_drivers_with_metal.append(driver_hints_with_metal.get_slice(",", i));
+		}
+		default_drivers.append("opengl3");
+		default_drivers_with_d3d12.append("opengl3");
+		default_drivers_with_metal.append("opengl3");
+
+		GLOBAL_DEF_NOVAL(PropertyInfo(Variant::PACKED_STRING_ARRAY, "rendering/rendering_device/drivers_fallback_order"), default_drivers);
+		GLOBAL_DEF_NOVAL(PropertyInfo(Variant::PACKED_STRING_ARRAY, "rendering/rendering_device/drivers_fallback_order.windows"), default_drivers_with_d3d12);
+		GLOBAL_DEF_NOVAL(PropertyInfo(Variant::PACKED_STRING_ARRAY, "rendering/rendering_device/drivers_fallback_order.linuxbsd"), default_drivers);
+		GLOBAL_DEF_NOVAL(PropertyInfo(Variant::PACKED_STRING_ARRAY, "rendering/rendering_device/drivers_fallback_order.android"), default_drivers);
+		GLOBAL_DEF_NOVAL(PropertyInfo(Variant::PACKED_STRING_ARRAY, "rendering/rendering_device/drivers_fallback_order.ios"), default_drivers_with_metal);
+		GLOBAL_DEF_NOVAL(PropertyInfo(Variant::PACKED_STRING_ARRAY, "rendering/rendering_device/drivers_fallback_order.macos"), default_drivers_with_metal);
 	}
 
 	{

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -670,7 +670,7 @@ DisplayServerAndroid::DisplayServerAndroid(const String &p_rendering_driver, Dis
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
 			bool failed = true;
-			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order");
+			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order.android");
 			for (int i = 0; i < drivers.size(); ++i) {
 				String driver = drivers[i];
 #if defined(GLES3_ENABLED)

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -669,18 +669,23 @@ DisplayServerAndroid::DisplayServerAndroid(const String &p_rendering_driver, Dis
 
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
-			memdelete(rendering_context);
-			rendering_context = nullptr;
+			bool failed = true;
+			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order");
+			for (int i = 0; i < drivers.size(); ++i) {
+				String driver = drivers[i];
 #if defined(GLES3_ENABLED)
-			bool fallback_to_opengl3 = GLOBAL_GET("rendering/rendering_device/fallback_to_opengl3");
-			if (fallback_to_opengl3 && rendering_driver != "opengl3") {
-				WARN_PRINT("Your device seem not to support Vulkan, switching to OpenGL 3.");
-				rendering_driver = "opengl3";
-				OS::get_singleton()->set_current_rendering_method("gl_compatibility");
-				OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
-			} else
+				if (driver == "opengl3" && rendering_driver != "opengl3") {
+					failed = false;
+					memdelete(rendering_context);
+					rendering_context = nullptr;
+					WARN_PRINT("Your device seem not to support Vulkan, switching to OpenGL 3.");
+					rendering_driver = "opengl3";
+					OS::get_singleton()->set_current_rendering_method("gl_compatibility");
+					OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+				}
 #endif
-			{
+			}
+			if (failed) {
 				ERR_PRINT(vformat("Failed to initialize %s context", rendering_driver));
 				r_error = ERR_UNAVAILABLE;
 				return;

--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -84,7 +84,7 @@ DisplayServerIOS::DisplayServerIOS(const String &p_rendering_driver, WindowMode 
 #endif
 	} wpd;
 
-#if defined(VULKAN_ENABLED)
+#ifdef VULKAN_ENABLED
 	if (rendering_driver == "vulkan") {
 		layer = [AppDelegate.viewController.godotView initializeRenderingForDriver:@"vulkan"];
 		if (!layer) {
@@ -109,18 +109,69 @@ DisplayServerIOS::DisplayServerIOS(const String &p_rendering_driver, WindowMode 
 #endif
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
-			memdelete(rendering_context);
-			rendering_context = nullptr;
-#if defined(GLES3_ENABLED)
-			bool fallback_to_opengl3 = GLOBAL_GET("rendering/rendering_device/fallback_to_opengl3");
-			if (fallback_to_opengl3 && rendering_driver != "opengl3") {
-				WARN_PRINT("Your device seem not to support MoltenVK or Metal, switching to OpenGL 3.");
-				rendering_driver = "opengl3";
-				OS::get_singleton()->set_current_rendering_method("gl_compatibility");
-				OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
-			} else
+			bool failed = true
+			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order");
+			for (int i = 0; i < drivers.size(); ++i) {
+				String driver = drivers[i];
+#if defined(VULKAN_ENABLED)
+				if (driver == "vulkan" && rendering_driver != "vulkan") {
+					layer = [AppDelegate.viewController.godotView initializeRenderingForDriver:@"vulkan"];
+					if (!layer) {
+						ERR_FAIL_MSG("Failed to create iOS Vulkan rendering layer.");
+					}
+					wpd.vulkan.layer_ptr = (CAMetalLayer *const *)&layer;
+					rendering_context = memnew(RenderingContextDriverVulkanIOS);
+					if (layer) {
+						failed = false;
+						WARN_PRINT("Your video card drivers seem not to support Metal, switching to MoltenVK.");
+						rendering_driver = "vulkan";
+						OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+						continue;
+					} else {
+						failed = true;
+						break;
+					}
+				}
 #endif
-			{
+#if defined(METAL_ENABLED)
+				if (driver == "metal" && rendering_driver != "metal") {
+					if (@available(iOS 14.0, *)) {
+						layer = [AppDelegate.viewController.godotView initializeRenderingForDriver:@"metal"];
+						wpd.metal.layer = (CAMetalLayer *)layer;
+						rendering_context = memnew(RenderingContextDriverMetal);
+						if (layer) {
+							failed = false;
+							WARN_PRINT("Your video card drivers seem not to support MoltenVK, switching to Metal.");
+							rendering_driver = "metal";
+							OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+							break;
+						} else {
+							failed = true;
+							continue;
+						}
+					} else {
+						OS::get_singleton()->alert("Metal is only supported on iOS 14.0 and later.");
+						failed = true;
+						continue;
+					}
+				}
+#endif
+#if defined(GLES3_ENABLED)
+				if (driver == "opengl3" && rendering_driver != "opengl3") {
+					failed = false;
+					WARN_PRINT("Your device seem not to support MoltenVK or Metal, switching to OpenGL 3.");
+					memdelete(rendering_context);
+					rendering_context = nullptr;
+					rendering_driver = "opengl3";
+					OS::get_singleton()->set_current_rendering_method("gl_compatibility");
+					OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+					break;
+				}
+#endif
+			}
+			if (failed) {
+				memdelete(rendering_context);
+				rendering_context = nullptr;
 				ERR_PRINT(vformat("Failed to initialize %s context", rendering_driver));
 				r_error = ERR_UNAVAILABLE;
 				return;

--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -110,7 +110,7 @@ DisplayServerIOS::DisplayServerIOS(const String &p_rendering_driver, WindowMode 
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
 			bool failed = true;
-			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order");
+			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order.ios");
 			for (int i = 0; i < drivers.size(); ++i) {
 				String driver = drivers[i];
 #if defined(VULKAN_ENABLED)

--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -109,7 +109,7 @@ DisplayServerIOS::DisplayServerIOS(const String &p_rendering_driver, WindowMode 
 #endif
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
-			bool failed = true
+			bool failed = true;
 			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order");
 			for (int i = 0; i < drivers.size(); ++i) {
 				String driver = drivers[i];

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1434,18 +1434,23 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Win
 
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
-			memdelete(rendering_context);
-			rendering_context = nullptr;
+			bool failed = true;
+			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order");
+			for (int i = 0; i < drivers.size(); ++i) {
+				String driver = drivers[i];
 #if defined(GLES3_ENABLED)
-			bool fallback_to_opengl3 = GLOBAL_GET("rendering/rendering_device/fallback_to_opengl3");
-			if (fallback_to_opengl3 && rendering_driver != "opengl3") {
-				WARN_PRINT("Your video card drivers seem not to support the required Vulkan version, switching to OpenGL 3.");
-				rendering_driver = "opengl3";
-				OS::get_singleton()->set_current_rendering_method("gl_compatibility");
-				OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
-			} else
+				if (driver == "opengl3" && rendering_driver != "opengl3") {
+					failed = false;
+					memdelete(rendering_context);
+					rendering_context = nullptr;
+					WARN_PRINT("Your video card drivers seem not to support the required Vulkan version, switching to OpenGL 3.");
+					rendering_driver = "opengl3";
+					OS::get_singleton()->set_current_rendering_method("gl_compatibility");
+					OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+				}
 #endif // GLES3_ENABLED
-			{
+			}
+			if (failed) {
 				r_error = ERR_CANT_CREATE;
 
 				if (p_rendering_driver == "vulkan") {

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1435,7 +1435,7 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Win
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
 			bool failed = true;
-			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order");
+			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order.linuxbsd");
 			for (int i = 0; i < drivers.size(); ++i) {
 				String driver = drivers[i];
 #if defined(GLES3_ENABLED)

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -6687,7 +6687,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
 			bool failed = true;
-			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order");
+			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order.linuxbsd");
 			for (int i = 0; i < drivers.size(); ++i) {
 				String driver = drivers[i];
 #if defined(GLES3_ENABLED)

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -6686,18 +6686,23 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
-			memdelete(rendering_context);
-			rendering_context = nullptr;
+			bool failed = true;
+			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order");
+			for (int i = 0; i < drivers.size(); ++i) {
+				String driver = drivers[i];
 #if defined(GLES3_ENABLED)
-			bool fallback_to_opengl3 = GLOBAL_GET("rendering/rendering_device/fallback_to_opengl3");
-			if (fallback_to_opengl3 && rendering_driver != "opengl3") {
-				WARN_PRINT("Your video card drivers seem not to support the required Vulkan version, switching to OpenGL 3.");
-				rendering_driver = "opengl3";
-				OS::get_singleton()->set_current_rendering_method("gl_compatibility");
-				OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
-			} else
+				if (driver == "opengl3" && rendering_driver != "opengl3") {
+					failed = false;
+					memdelete(rendering_context);
+					rendering_context = nullptr;
+					WARN_PRINT("Your video card drivers seem not to support the required Vulkan version, switching to OpenGL 3.");
+					rendering_driver = "opengl3";
+					OS::get_singleton()->set_current_rendering_method("gl_compatibility");
+					OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+				}
 #endif // GLES3_ENABLED
-			{
+			}
+			if (failed) {
 				r_error = ERR_CANT_CREATE;
 
 				if (p_rendering_driver == "vulkan") {

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3798,7 +3798,7 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
 			bool failed = true;
-			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order");
+			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order.macos");
 			for (int i = 0; i < drivers.size(); ++i) {
 				String driver = drivers[i];
 #if defined(VULKAN_ENABLED)

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3803,7 +3803,7 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 				String driver = drivers[i];
 #if defined(VULKAN_ENABLED)
 				if (driver == "vulkan" && rendering_driver != "vulkan") {
-					failed = false
+					failed = false;
 					memdelete(rendering_context);
 					rendering_context = memnew(RenderingContextDriverVulkanMacOS);
 					if (rendering_context->initialize() == OK) {
@@ -3823,7 +3823,7 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 					rendering_context = memnew(RenderingContextDriverMetal);
 					if (rendering_context->initialize() == OK) {
 						failed = false;
-						WARN_PRINT("Your video card drivers seem not to support MoltenVK, switching to Metal.");;
+						WARN_PRINT("Your video card drivers seem not to support MoltenVK, switching to Metal.");
 						rendering_driver = "metal";
 						OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
 						break;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3797,20 +3797,61 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
-			memdelete(rendering_context);
-			rendering_context = nullptr;
-#if defined(GLES3_ENABLED)
-			bool fallback_to_opengl3 = GLOBAL_GET("rendering/rendering_device/fallback_to_opengl3");
-			if (fallback_to_opengl3 && rendering_driver != "opengl3") {
-				WARN_PRINT("Your device seem not to support MoltenVK or Metal, switching to OpenGL 3.");
-				rendering_driver = "opengl3";
-				OS::get_singleton()->set_current_rendering_method("gl_compatibility");
-				OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
-			} else
+			bool failed = true;
+			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order");
+			for (int i = 0; i < drivers.size(); ++i) {
+				String driver = drivers[i];
+#if defined(VULKAN_ENABLED)
+				if (driver == "vulkan" && rendering_driver != "vulkan") {
+					failed = false
+					memdelete(rendering_context);
+					rendering_context = memnew(RenderingContextDriverVulkanMacOS);
+					if (rendering_context->initialize() == OK) {
+						WARN_PRINT("Your video card drivers seem not to support Metal, switching to MoltenVK.");
+						rendering_driver = "vulkan";
+						OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+						break;
+					} else {
+						failed = true;
+						continue;
+					}
+				}
 #endif
-			{
-				r_error = ERR_CANT_CREATE;
-				ERR_FAIL_MSG("Could not initialize " + rendering_driver);
+#if defined(METAL_ENABLED)
+				if (driver == "metal" && rendering_driver != "metal") {
+					memdelete(rendering_context);
+					rendering_context = memnew(RenderingContextDriverMetal);
+					if (rendering_context->initialize() == OK) {
+						failed = false;
+						WARN_PRINT("Your video card drivers seem not to support MoltenVK, switching to Metal.");;
+						rendering_driver = "metal";
+						OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+						break;
+					} else {
+						failed = true;
+						continue;
+					}
+				}
+#endif
+#if defined(GLES3_ENABLED)
+				if (driver == "opengl3" && rendering_driver != "opengl3") {
+					failed = false;
+					WARN_PRINT("Your device seem not to support MoltenVK or Metal, switching to OpenGL 3.");
+					memdelete(rendering_context);
+					rendering_context = nullptr;
+					rendering_driver = "opengl3";
+					OS::get_singleton()->set_current_rendering_method("gl_compatibility");
+					OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+					break;
+				}
+#endif
+			}
+			if (failed) {
+				memdelete(rendering_context);
+				rendering_context = nullptr;
+				ERR_PRINT(vformat("Failed to initialize %s context", rendering_driver));
+				r_error = ERR_UNAVAILABLE;
+				return;
 			}
 		}
 	}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -6712,47 +6712,57 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
 			bool failed = true;
+			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order");
+			for (int i = 0; i < drivers.size(); ++i) {
+				String driver = drivers[i];
 #if defined(VULKAN_ENABLED)
-			bool fallback_to_vulkan = GLOBAL_GET("rendering/rendering_device/fallback_to_vulkan");
-			if (failed && fallback_to_vulkan && rendering_driver != "vulkan") {
-				memdelete(rendering_context);
-				rendering_context = memnew(RenderingContextDriverVulkanWindows);
-				tested_drivers.set_flag(DRIVER_ID_RD_VULKAN);
-				if (rendering_context->initialize() == OK) {
-					WARN_PRINT("Your video card drivers seem not to support Direct3D 12, switching to Vulkan.");
-					rendering_driver = "vulkan";
-					OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
-					failed = false;
+				if (driver == "vulkan" && rendering_driver != "vulkan") {
+					memdelete(rendering_context);
+					rendering_context = memnew(RenderingContextDriverVulkanWindows);
+					tested_drivers.set_flag(DRIVER_ID_RD_VULKAN);
+					if (rendering_context->initialize() == OK) {
+						failed = false;
+						WARN_PRINT("Your video card drivers seem not to support Direct3D 12, switching to Vulkan.");
+						rendering_driver = "vulkan";
+						OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+						break;
+					} else {
+						failed = true;
+						continue;
+					}
 				}
-			}
 #endif
 #if defined(D3D12_ENABLED)
-			bool fallback_to_d3d12 = GLOBAL_GET("rendering/rendering_device/fallback_to_d3d12");
-			if (failed && fallback_to_d3d12 && rendering_driver != "d3d12") {
-				memdelete(rendering_context);
-				rendering_context = memnew(RenderingContextDriverD3D12);
-				tested_drivers.set_flag(DRIVER_ID_RD_D3D12);
-				if (rendering_context->initialize() == OK) {
-					WARN_PRINT("Your video card drivers seem not to support Vulkan, switching to Direct3D 12.");
-					rendering_driver = "d3d12";
-					OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
-					failed = false;
+				if (driver == "d3d12" && rendering_driver != "d3d12") {
+					memdelete(rendering_context);
+					rendering_context = memnew(RenderingContextDriverD3D12);
+					tested_drivers.set_flag(DRIVER_ID_RD_D3D12);
+					if (rendering_context->initialize() == OK) {
+						failed = false;
+						WARN_PRINT("Your video card drivers seem not to support Vulkan, switching to Direct3D 12.");
+						rendering_driver = "d3d12";
+						OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+						break;
+					} else {
+						failed = true;
+						continue;
+					}
 				}
-			}
 #endif
 #if defined(GLES3_ENABLED)
-			bool fallback_to_opengl3 = GLOBAL_GET("rendering/rendering_device/fallback_to_opengl3");
-			if (failed && fallback_to_opengl3 && rendering_driver != "opengl3") {
-				memdelete(rendering_context);
-				rendering_context = nullptr;
-				tested_drivers.set_flag(DRIVER_ID_COMPAT_OPENGL3);
-				WARN_PRINT("Your video card drivers seem not to support Direct3D 12 or Vulkan, switching to OpenGL 3.");
-				rendering_driver = "opengl3";
-				OS::get_singleton()->set_current_rendering_method("gl_compatibility");
-				OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
-				failed = false;
-			}
+				if (driver == "opengl3" && rendering_driver != "opengl3") {
+					failed = false;
+					memdelete(rendering_context);
+					rendering_context = nullptr;
+					tested_drivers.set_flag(DRIVER_ID_COMPAT_OPENGL3);
+					WARN_PRINT("Your video card drivers seem not to support Direct3D 12 or Vulkan, switching to OpenGL 3.");
+					rendering_driver = "opengl3";
+					OS::get_singleton()->set_current_rendering_method("gl_compatibility");
+					OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+					break;
+				}
 #endif
+			}
 			if (failed) {
 				memdelete(rendering_context);
 				rendering_context = nullptr;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -6712,7 +6712,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
 			bool failed = true;
-			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order");
+			PackedStringArray drivers = GLOBAL_GET("rendering/rendering_device/drivers_fallback_order.windows");
 			for (int i = 0; i < drivers.size(); ++i) {
 				String driver = drivers[i];
 #if defined(VULKAN_ENABLED)


### PR DESCRIPTION
Add a rendering driver fallback order to replace the original single toggles (```rendering/rendering_device/fallback_to_*```)
![image](https://github.com/user-attachments/assets/27e2968e-b3a5-4dd7-b127-c455f7de42be)
I didn't replace ```rendering/rendering_device/driver.*``` because I think changing its type would break codes somewhere.
This won't affect normal rendering driver settings.

Tested on a Windows 11 with Vulkan and D3D12 support and another Windows 11 without them.
More tests are required.