### PR TITLE
2D: Fix clip children and rendering artefacts

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -568,8 +568,6 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 
 	// Clear out state used in 2D pass
 	reset_canvas();
-	state.current_batch_index = 0;
-	state.canvas_instance_batches.clear();
 	state.current_data_buffer_index = (state.current_data_buffer_index + 1) % state.canvas_instance_data_buffers.size();
 	state.current_instance_buffer_index = 0;
 }
@@ -807,6 +805,8 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 	}
 
 	glDisable(GL_SCISSOR_TEST);
+	state.current_batch_index = 0;
+	state.canvas_instance_batches.clear();
 	state.last_item_index += index;
 }
 
@@ -1567,7 +1567,9 @@ void RasterizerCanvasGLES3::_add_to_batch(uint32_t &r_index, bool &r_batch_broke
 
 void RasterizerCanvasGLES3::_new_batch(bool &r_batch_broken) {
 	if (state.canvas_instance_batches.size() == 0) {
-		state.canvas_instance_batches.push_back(Batch());
+		Batch new_batch;
+		new_batch.instance_buffer_index = state.current_instance_buffer_index;
+		state.canvas_instance_batches.push_back(new_batch);
 		return;
 	}
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -914,8 +914,6 @@ void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p
 	}
 
 	texture_info_map.clear();
-	state.current_batch_index = 0;
-	state.canvas_instance_batches.clear();
 	state.current_data_buffer_index = (state.current_data_buffer_index + 1) % BATCH_DATA_BUFFER_COUNT;
 	state.current_instance_buffer_index = 0;
 }
@@ -2289,6 +2287,8 @@ void RendererCanvasRenderRD::_render_batch_items(RenderTarget p_to_render_target
 
 	RD::get_singleton()->draw_list_end();
 
+	state.current_batch_index = 0;
+	state.canvas_instance_batches.clear();
 	state.last_instance_index += instance_index;
 }
 
@@ -3200,7 +3200,9 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 
 RendererCanvasRenderRD::Batch *RendererCanvasRenderRD::_new_batch(bool &r_batch_broken) {
 	if (state.canvas_instance_batches.size() == 0) {
-		state.canvas_instance_batches.push_back(Batch());
+		Batch new_batch;
+		new_batch.instance_buffer_index = state.current_instance_buffer_index;
+		state.canvas_instance_batches.push_back(new_batch);
 		return state.canvas_instance_batches.ptr();
 	}
 


### PR DESCRIPTION
Closes #102147

Fixes both GLES3 and RendererRD implementations

> [!NOTE]
>
> This fix also addresses the root cause of #101998, which was that instance buffers were reused in the same draw call, causing rendering artefacts.

<details>
<summary>Both issues resolved</summary>

| clip children | rendering artefact |
| :---- | :---- |
| <img src="https://github.com/user-attachments/assets/f4876ad9-73ec-4345-8f90-50b514fce1cc" /> | <img src="https://github.com/user-attachments/assets/6c6f6082-4e3e-4982-9db0-fe95c7134b96" /> |

</details>

