### PR TITLE
[Web] Fix audio issues with samples and GodotPositionReportingProcessor

### DIFF
--- a/platform/web/js/libs/audio.position.worklet.js
+++ b/platform/web/js/libs/audio.position.worklet.js
@@ -28,10 +28,20 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+const POST_THRESHOLD_S = 0.1;
+
 class GodotPositionReportingProcessor extends AudioWorkletProcessor {
-	constructor() {
-		super();
+	constructor(...args) {
+		super(...args);
+		this.lastPostTime = currentTime;
 		this.position = 0;
+
+		this.port.onmessage = (event) => {
+			if (event?.data?.type === 'clear') {
+				this.lastPostTime = currentTime;
+				this.position = 0;
+			}
+		};
 	}
 
 	process(inputs, _outputs, _parameters) {
@@ -39,10 +49,15 @@ class GodotPositionReportingProcessor extends AudioWorkletProcessor {
 			const input = inputs[0];
 			if (input.length > 0) {
 				this.position += input[0].length;
-				this.port.postMessage({ 'type': 'position', 'data': this.position });
-				return true;
 			}
 		}
+
+		// Posting messages is expensive. Let's limit the number of posts.
+		if (currentTime - this.lastPostTime > POST_THRESHOLD_S) {
+			this.lastPostTime = currentTime;
+			this.port.postMessage({ 'type': 'position', 'data': this.position });
+		}
+
 		return true;
 	}
 }


### PR DESCRIPTION
This PR pools the `GodotPositionReportingProcessor` worklets created instead of creating new worklets every time. This seems to prevent an escalation in memory usage over time.

Fixes #98731.