### PR TITLE
Linux/BSD: Modify only keypad keys

### DIFF
--- a/platform/linuxbsd/wayland/key_mapping_xkb.cpp
+++ b/platform/linuxbsd/wayland/key_mapping_xkb.cpp
@@ -369,6 +369,30 @@ void KeyMappingXKB::initialize() {
 	location_map[0x86] = KeyLocation::RIGHT;
 }
 
+bool KeyMappingXKB::is_sym_numpad(xkb_keysym_t p_keysym) {
+	switch (p_keysym) {
+		case XKB_KEY_KP_Multiply:
+		case XKB_KEY_KP_Divide:
+		case XKB_KEY_KP_Subtract:
+		case XKB_KEY_KP_Separator:
+		case XKB_KEY_KP_Add:
+		case XKB_KEY_KP_0:
+		case XKB_KEY_KP_1:
+		case XKB_KEY_KP_2:
+		case XKB_KEY_KP_3:
+		case XKB_KEY_KP_4:
+		case XKB_KEY_KP_5:
+		case XKB_KEY_KP_6:
+		case XKB_KEY_KP_7:
+		case XKB_KEY_KP_8:
+		case XKB_KEY_KP_9: {
+			return true;
+		} break;
+	}
+
+	return false;
+}
+
 Key KeyMappingXKB::get_keycode(xkb_keycode_t p_keysym) {
 	if (p_keysym >= 0x20 && p_keysym < 0x7E) { // ASCII, maps 1-1
 		if (p_keysym > 0x60 && p_keysym < 0x7B) { // Lowercase ASCII.

--- a/platform/linuxbsd/wayland/key_mapping_xkb.h
+++ b/platform/linuxbsd/wayland/key_mapping_xkb.h
@@ -56,6 +56,7 @@ class KeyMappingXKB {
 public:
 	static void initialize();
 
+	static bool is_sym_numpad(xkb_keysym_t p_keysym);
 	static Key get_keycode(xkb_keysym_t p_keysym);
 	static xkb_keycode_t get_xkb_keycode(Key p_keycode);
 	static Key get_scancode(unsigned int p_code);

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -193,18 +193,26 @@ Vector<uint8_t> WaylandThread::_wp_primary_selection_offer_read(struct wl_displa
 
 // Sets up an `InputEventKey` and returns whether it has any meaningful value.
 bool WaylandThread::_seat_state_configure_key_event(SeatState &p_ss, Ref<InputEventKey> p_event, xkb_keycode_t p_keycode, bool p_pressed) {
-	// NOTE: xkbcommon's API really encourages to apply the modifier state but we
-	// only want a "plain" symbol so that we can convert it into a godot keycode.
-	const xkb_keysym_t *syms = nullptr;
-	int num_sys = xkb_keymap_key_get_syms_by_level(p_ss.xkb_keymap, p_keycode, p_ss.current_layout_index, 0, &syms);
+	xkb_keysym_t shifted_sym = xkb_state_key_get_one_sym(p_ss.xkb_state, p_keycode);
 
 	Key physical_keycode = KeyMappingXKB::get_scancode(p_keycode);
 	KeyLocation key_location = KeyMappingXKB::get_location(p_keycode);
 	uint32_t unicode = xkb_state_key_get_utf32(p_ss.xkb_state, p_keycode);
 
 	Key keycode = Key::NONE;
-	if (num_sys > 0 && syms) {
-		keycode = KeyMappingXKB::get_keycode(syms[0]);
+
+	if (KeyMappingXKB::is_sym_numpad(shifted_sym)) {
+		keycode = KeyMappingXKB::get_keycode(shifted_sym);
+	}
+
+	if (keycode == Key::NONE) {
+		// NOTE: xkbcommon's API really encourages to apply the modifier state but we
+		// only want a "plain" symbol so that we can convert it into a godot keycode.
+		const xkb_keysym_t *syms = nullptr;
+		int num_sys = xkb_keymap_key_get_syms_by_level(p_ss.xkb_keymap, p_keycode, p_ss.current_layout_index, 0, &syms);
+		if (num_sys > 0 && syms) {
+			keycode = KeyMappingXKB::get_keycode(syms[0]);
+		}
 	}
 
 	if (keycode == Key::NONE) {

--- a/platform/linuxbsd/x11/key_mapping_x11.cpp
+++ b/platform/linuxbsd/x11/key_mapping_x11.cpp
@@ -1129,6 +1129,30 @@ void KeyMappingX11::initialize() {
 	location_map[0x86] = KeyLocation::RIGHT;
 }
 
+bool KeyMappingX11::is_sym_numpad(KeySym p_keysym) {
+	switch (p_keysym) {
+		case XK_KP_Multiply:
+		case XK_KP_Divide:
+		case XK_KP_Subtract:
+		case XK_KP_Separator:
+		case XK_KP_Add:
+		case XK_KP_0:
+		case XK_KP_1:
+		case XK_KP_2:
+		case XK_KP_3:
+		case XK_KP_4:
+		case XK_KP_5:
+		case XK_KP_6:
+		case XK_KP_7:
+		case XK_KP_8:
+		case XK_KP_9: {
+			return true;
+		} break;
+	}
+
+	return false;
+}
+
 Key KeyMappingX11::get_keycode(KeySym p_keysym) {
 	if (p_keysym >= 0x20 && p_keysym < 0x7E) { // ASCII, maps 1-1
 		if (p_keysym > 0x60 && p_keysym < 0x7B) { // Lowercase ASCII.

--- a/platform/linuxbsd/x11/key_mapping_x11.h
+++ b/platform/linuxbsd/x11/key_mapping_x11.h
@@ -61,6 +61,7 @@ class KeyMappingX11 {
 public:
 	static void initialize();
 
+	static bool is_sym_numpad(KeySym p_keysym);
 	static Key get_keycode(KeySym p_keysym);
 	static unsigned int get_xlibcode(Key p_keysym);
 	static Key get_scancode(unsigned int p_code);


### PR DESCRIPTION
Should greatly alleviate #102137.
Fixes #102259.

The `keycode` field of `InputEventKey` is supposed to be "unshifted"; That is, what the key would output if no modifier keys were pressed. This should match what's written on the key label, but `Key` enumerates also all keypad keys, which require a modifier. We thus require some extra checks for them.

Note that this can still allow "stuck keys", but that's an even deeper problem.

---

This should bring both the X11 and Wayland backend to "parity" with Windows. Now only keypad keys should be able to get stuck; Better than having every other "non-US" modifier at least.

Feedback appreciated on the X11 impl.

Also note that I purposely made the "is keypad" method specific to only the related (modified) `Key` enumerations. If that's excessive, we could replace it with a simple check between `XKB_KEY_KP_Space` and `XKB_KEY_KP_9` (same for the XK equivalent on X11), as all keypad scancodes are consecutive. That would require no other changes as I built the code to allow for "no matches" to the mapping table, just in case.

CC @bruvzg