### PR TITLE
Fully enable HDR2D when the setting is changed

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -467,6 +467,7 @@ void EditorNode::_update_from_settings() {
 
 	bool use_hdr_2d = GLOBAL_GET("rendering/viewport/hdr_2d");
 	scene_root->set_use_hdr_2d(use_hdr_2d);
+	get_viewport()->set_use_hdr_2d(use_hdr_2d);
 
 	float mesh_lod_threshold = GLOBAL_GET("rendering/mesh_lod/lod_change/threshold_pixels");
 	scene_root->set_mesh_lod_threshold(mesh_lod_threshold);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1892,7 +1892,7 @@ SceneTree::SceneTree() {
 	const bool transparent_background = GLOBAL_DEF("rendering/viewport/transparent_background", false);
 	root->set_transparent_background(transparent_background);
 
-	const bool use_hdr_2d = GLOBAL_DEF_RST_BASIC("rendering/viewport/hdr_2d", false);
+	const bool use_hdr_2d = GLOBAL_DEF_BASIC("rendering/viewport/hdr_2d", false);
 	root->set_use_hdr_2d(use_hdr_2d);
 
 	const int ssaa_mode = GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "rendering/anti_aliasing/quality/screen_space_aa", PROPERTY_HINT_ENUM, "Disabled (Fastest),FXAA (Fast)"), 0);


### PR DESCRIPTION
When I added HDR2D, I ended up making it force a restart when the project setting was changed because the editor would look wrong until restart. There was no technical reason for it, I just couldn't figure out how to change the setting for the editor's root Viewport. 

This PR ensures that the setting gets changed for both the SubViewports (2D and 3D which already worked) and the editor root. So now there is no need to restart. 

This issue came up today in the rendering meeting as it makes proper HDR a little more awkward CC @DarkKilauea

This issue was also noted by @Calinou in the original PR https://github.com/godotengine/godot/pull/80215#pullrequestreview-1567254374