### PR TITLE
Dynamically load MetalFX. Disable Metal and Vulkan renderers in simulator builds.

### DIFF
--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -44,6 +44,17 @@
 #endif
 #endif
 
+#ifdef __OBJC__
+
+#pragma mark - MetalFX dynamic loading
+
+void *get_MetalFX();
+Class get_MTLFXSpatialScalerDescriptor();
+Class get_MTLFXTemporalScalerDescriptor();
+void unload_MetalFX();
+
+#endif
+
 class RenderingContextDriverMetal;
 
 class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) RenderingDeviceDriverMetal : public RenderingDeviceDriver {

--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-        054F8BE62D38852F00B81423 /* MetalFX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 054F8BE52D38852F00B81423 /* MetalFX.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		1F1575721F582BE20003B888 /* dylibs in Resources */ = {isa = PBXBuildFile; fileRef = 1F1575711F582BE20003B888 /* dylibs */; };
 		DEADBEEF2F582BE20003B888 /* $binary.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEADBEEF1F582BE20003B888 /* $binary.xcframework */; };
 		$modules_buildfile
@@ -43,7 +42,6 @@
 		1FF4C1881F584E6300A41E41 /* $binary.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "$binary.entitlements"; sourceTree = "<group>"; };
 		1FF8DBB01FBA9DE1009DE660 /* dummy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = dummy.cpp; sourceTree = "<group>"; };
 		9039D3BD24C093AC0020482C /* MoltenVK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MoltenVK; path = MoltenVK.xcframework; sourceTree = "<group>"; };
-		054F8BE52D38852F00B81423 /* MetalFX.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalFX.framework; path = System/Library/Frameworks/MetalFX.framework; sourceTree = SDKROOT; };
 		D07CD44D1C5D589C00B7FB28 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		D0BCFE3418AEBDA2004A7AAE /* $binary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "$binary.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0BCFE4318AEBDA2004A7AAE /* $binary-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "$binary-Info.plist"; sourceTree = "<group>"; };
@@ -62,7 +60,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9039D3BE24C093AC0020482C /* MoltenVK.xcframework in Frameworks */,
-				054F8BE62D38852F00B81423 /* MetalFX.framework in Frameworks */,
 				DEADBEEF2F582BE20003B888 /* $binary.xcframework */,
 				$modules_buildphase
 				$additional_pbx_frameworks_build
@@ -97,7 +94,6 @@
 			isa = PBXGroup;
 			children = (
 				9039D3BD24C093AC0020482C /* MoltenVK.xcframework */,
-				054F8BE52D38852F00B81423 /* MetalFX.framework */,
 				DEADBEEF1F582BE20003B888 /* $binary.xcframework */,
 				$modules_buildgrp
 				$additional_pbx_frameworks_refs

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -151,8 +151,8 @@ def configure(env: "SConsEnvironment"):
     env.Prepend(CPPPATH=["#platform/ios"])
     env.Append(CPPDEFINES=["IOS_ENABLED", "UNIX_ENABLED", "COREAUDIO_ENABLED"])
 
-    if env["metal"] and env["arch"] != "arm64":
-        print_warning("Target architecture '{}' does not support the Metal rendering driver".format(env["arch"]))
+    if env["metal"] and env["ios_simulator"]:
+        print_warning("iOS simulator does not support the Metal rendering driver")
         env["metal"] = False
 
     if env["metal"]:
@@ -166,11 +166,16 @@ def configure(env: "SConsEnvironment"):
         )
         env.Prepend(CPPPATH=["#thirdparty/spirv-cross"])
 
+    if env["vulkan"] and env["ios_simulator"]:
+        print_warning("iOS simulator does not support the Vulkan rendering driver")
+        env["vulkan"] = False
+
     if env["vulkan"]:
         env.AppendUnique(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])
 
     if env["opengl3"]:
         env.Append(CPPDEFINES=["GLES3_ENABLED", "GLES_SILENCE_DEPRECATION"])
+        env.Append(CCFLAGS=["-Wno-module-import-in-extern-c"])
         env.Prepend(
             CPPPATH=[
                 "$IOS_SDK_PATH/System/Library/Frameworks/OpenGLES.framework/Headers",

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -2445,6 +2445,8 @@ Error EditorExportPlatformIOS::_export_project_helper(const Ref<EditorExportPres
 		if (!_archive_has_arm64(sim_lib_path, &cputype, &cpusubtype) && _archive_has_arm64(dev_lib_path) && FileAccess::exists(dev_lib_path)) {
 			add_message(EXPORT_MESSAGE_INFO, TTR("Export"), TTR("ARM64 simulator library, generating from device library."));
 
+			tmp_app_path->make_dir_recursive(dest_dir + String(binary_name + ".xcframework").path_join("ios-arm64_x86_64-simulator"));
+
 			Vector<String> tmp_lib_files;
 			Vector<Vector2i> tmp_lib_cputypes;
 			// Extract/copy simulator lib.

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -245,7 +245,6 @@ def configure(env: "SConsEnvironment"):
         env.AppendUnique(CPPDEFINES=["METAL_ENABLED", "RD_ENABLED"])
         extra_frameworks.add("Metal")
         extra_frameworks.add("MetalKit")
-        extra_frameworks.add("MetalFX")
         env.Prepend(CPPPATH=["#thirdparty/spirv-cross"])
 
     if env["vulkan"]:

--- a/servers/rendering/renderer_rd/effects/metal_fx.mm
+++ b/servers/rendering/renderer_rd/effects/metal_fx.mm
@@ -106,7 +106,7 @@ MFXSpatialContext *MFXSpatialEffect::create_context(CreateParams p_params) const
 	PixelFormats &pf = rdd->get_pixel_formats();
 	id<MTLDevice> dev = rdd->get_device();
 
-	MTLFXSpatialScalerDescriptor *desc = [MTLFXSpatialScalerDescriptor new];
+	MTLFXSpatialScalerDescriptor *desc = [get_MTLFXSpatialScalerDescriptor() new];
 	desc.inputWidth = (NSUInteger)p_params.input_size.width;
 	desc.inputHeight = (NSUInteger)p_params.input_size.height;
 
@@ -142,7 +142,7 @@ MFXTemporalContext *MFXTemporalEffect::create_context(CreateParams p_params) con
 	PixelFormats &pf = rdd->get_pixel_formats();
 	id<MTLDevice> dev = rdd->get_device();
 
-	MTLFXTemporalScalerDescriptor *desc = [MTLFXTemporalScalerDescriptor new];
+	MTLFXTemporalScalerDescriptor *desc = [get_MTLFXTemporalScalerDescriptor() new];
 	desc.inputWidth = (NSUInteger)p_params.input_size.width;
 	desc.inputHeight = (NSUInteger)p_params.input_size.height;
 


### PR DESCRIPTION
Supersede https://github.com/godotengine/godot/pull/102151

- Reverts https://github.com/godotengine/godot/pull/101614 and partially reintroduce https://github.com/godotengine/godot/pull/101590
Weak linking works only if library is present when building, it's not the case for simulator, so Xcode project build always fail.
- Disables Metal and Vulkan renderers in dedicated simulator builds.
Neither was functional due to lack of image cube map arrays support in simulated GPU.
- Fixes generated simulator library creation on export in some case.

Simulator never worked with Vulkan and Metal renderers, but is working with OpenGL.

The problem is, we are always using the same library which includes all renderers, regardless of renderer. Also, our OSXCross can't build dedicated simulator library, so for official templates, a device library is converted to simulator library on export (by patching `LC_BUILD_VERSION` load commands).

I'm not sure if we should introduce all this hacky stuff, but also not sure if there are any other options:

We can:
- Make a separate iOS builds for Metal, Vulkan and OpenGL (and only OpenGL build will have simulator support), and only export one specific library. This is likely a more clean option, but will triple iOS export template size, and will make fallback from Metal/Vulkan to OpenGL completely impossible (it's not working right now in any case, but there seems to be some interest in it).
- Remove device to simulator library conversion, disable Vulkan and Metal renderers in simulator builds. Update docs to make it clear that simulator is not supported by official export template, support OpenGL only, and you have to build it yourself if you need it.
- Drop simulator support entirely. What it is useful for? It's not representative of any real device capabilities, and you can run and test iOS apps on Apple Silicon macs directly, without any simulated GPU limitations.