### PR TITLE
[3.x] Physics Interpolation - fix client interpolation pump

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -559,11 +559,6 @@ void SceneTree::iteration_prepare() {
 		// are flushed before pumping the interpolation prev and currents.
 		flush_transform_notifications();
 		VisualServer::get_singleton()->tick();
-
-		// Any objects performing client physics interpolation
-		// should be given an opportunity to keep their previous transforms
-		// up to date before each new physics tick.
-		_client_physics_interpolation.physics_process();
 	}
 }
 
@@ -572,6 +567,11 @@ void SceneTree::iteration_end() {
 	// to be flushed to the VisualServer before finishing a physics tick.
 	if (_physics_interpolation_enabled) {
 		flush_transform_notifications();
+
+		// Any objects performing client physics interpolation
+		// should be given an opportunity to keep their previous transforms
+		// up to date.
+		_client_physics_interpolation.physics_process();
 	}
 }
 


### PR DESCRIPTION
Client interpolation pump is moved AFTER the physics tick, after physics objects have been moved. This is necessary because the `current` transform is also updated during the pump.

Fixes #102142

## Notes
* This was an oversight for client interpolation that seemed to only cause problems for physics objects, and only in the case where more than one physics tick took place before the frame.
* The server side pumps can take place before the tick because setting transforms will update the `current` as they come in, however for the client side interpolation, we have to wait until all changes have been made before setting the `current` transform.
* This is one of those bugs that is super obvious in retrospect :grin: . It may also fix some other behaviour on the first frame of `get_global_transform_interpolated()`.
* I've tested using non-physics and physics objects, and the first frames of following and all looks good, even in the issue conditions (faster tick rate than frame rate).
* Should be forward ported to 4.x @rburing .

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
