### PR TITLE
Refactor Debugger, enforce correspondence between name and value

### DIFF
--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -190,22 +190,19 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 			}
 
 		} else if (line == "lv" || line == "locals") {
-			List<String> locals;
-			List<Variant> values;
-			script_lang->debug_get_stack_level_locals(current_frame, &locals, &values);
-			print_variables(locals, values, variable_prefix);
+			LocalVector<Pair<String, Variant>> locals;
+			script_lang->debug_get_stack_level_locals(current_frame, locals);
+			print_variables(locals, variable_prefix);
 
 		} else if (line == "gv" || line == "globals") {
-			List<String> globals;
-			List<Variant> values;
-			script_lang->debug_get_globals(&globals, &values);
-			print_variables(globals, values, variable_prefix);
+			LocalVector<Pair<String, Variant>> globals;
+			script_lang->debug_get_globals(globals);
+			print_variables(globals, variable_prefix);
 
 		} else if (line == "mv" || line == "members") {
-			List<String> members;
-			List<Variant> values;
-			script_lang->debug_get_stack_level_members(current_frame, &members, &values);
-			print_variables(members, values, variable_prefix);
+			LocalVector<Pair<String, Variant>> members;
+			script_lang->debug_get_stack_level_members(current_frame, members);
+			print_variables(members, variable_prefix);
 
 		} else if (line.begins_with("p") || line.begins_with("print")) {
 			if (line.find_char(' ') < 0) {
@@ -319,24 +316,21 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 	}
 }
 
-void LocalDebugger::print_variables(const List<String> &names, const List<Variant> &values, const String &variable_prefix) {
+void LocalDebugger::print_variables(const LocalVector<Pair<String, Variant>> &variables, const String &variable_prefix) {
 	String value;
 	Vector<String> value_lines;
-	const List<Variant>::Element *V = values.front();
-	for (const String &E : names) {
-		value = String(V->get());
+	for (const Pair<String, Variant> &E : variables) {
+		value = String(E.second);
 
 		if (variable_prefix.is_empty()) {
-			print_line(E + ": " + String(V->get()));
+			print_line(E.first + ": " + value);
 		} else {
-			print_line(E + ":");
+			print_line(E.first + ":");
 			value_lines = value.split("\n");
 			for (int i = 0; i < value_lines.size(); ++i) {
 				print_line(variable_prefix + value_lines[i]);
 			}
 		}
-
-		V = V->next();
 	}
 }
 

--- a/core/debugger/local_debugger.h
+++ b/core/debugger/local_debugger.h
@@ -44,7 +44,7 @@ private:
 	HashMap<String, String> options;
 
 	Pair<String, int> to_breakpoint(const String &p_line);
-	void print_variables(const List<String> &names, const List<Variant> &values, const String &variable_prefix);
+	void print_variables(const LocalVector<Pair<String, Variant>> &variables, const String &variable_prefix);
 
 public:
 	void debug(bool p_can_continue, bool p_is_error_breakpoint);

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -314,17 +314,13 @@ void RemoteDebugger::send_error(const String &p_func, const String &p_file, int 
 	}
 }
 
-void RemoteDebugger::_send_stack_vars(List<String> &p_names, List<Variant> &p_vals, int p_type) {
+void RemoteDebugger::_send_stack_vars(const LocalVector<Pair<String, Variant>> &p_variables, int p_type) {
 	DebuggerMarshalls::ScriptStackVariable stvar;
-	List<String>::Element *E = p_names.front();
-	List<Variant>::Element *F = p_vals.front();
-	while (E) {
-		stvar.name = E->get();
-		stvar.value = F->get();
+	for (const Pair<String, Variant> &E : p_variables) {
+		stvar.name = E.first;
+		stvar.value = E.second;
 		stvar.type = p_type;
 		send_message("stack_frame_var", stvar.serialize());
-		E = E->next();
-		F = F->next();
 	}
 }
 
@@ -484,30 +480,23 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 				ERR_FAIL_NULL(script_lang);
 				int lv = data[0];
 
-				List<String> members;
-				List<Variant> member_vals;
+				LocalVector<Pair<String, Variant>> members;
 				if (ScriptInstance *inst = script_lang->debug_get_stack_level_instance(lv)) {
-					members.push_back("self");
-					member_vals.push_back(inst->get_owner());
+					members.push_back(Pair<String, Variant>("self", inst->get_owner()));
 				}
-				script_lang->debug_get_stack_level_members(lv, &members, &member_vals);
-				ERR_FAIL_COND(members.size() != member_vals.size());
+				script_lang->debug_get_stack_level_members(lv, members);
 
-				List<String> locals;
-				List<Variant> local_vals;
-				script_lang->debug_get_stack_level_locals(lv, &locals, &local_vals);
-				ERR_FAIL_COND(locals.size() != local_vals.size());
+				LocalVector<Pair<String, Variant>> locals;
+				script_lang->debug_get_stack_level_locals(lv, locals);
 
-				List<String> globals;
-				List<Variant> globals_vals;
-				script_lang->debug_get_globals(&globals, &globals_vals);
-				ERR_FAIL_COND(globals.size() != globals_vals.size());
+				LocalVector<Pair<String, Variant>> globals;
+				script_lang->debug_get_globals(globals);
 
-				Array var_size = { local_vals.size() + member_vals.size() + globals_vals.size() };
+				Array var_size = { locals.size() + members.size() + globals.size() };
 				send_message("stack_frame_vars", var_size);
-				_send_stack_vars(locals, local_vals, 0);
-				_send_stack_vars(members, member_vals, 1);
-				_send_stack_vars(globals, globals_vals, 2);
+				_send_stack_vars(locals, 0);
+				_send_stack_vars(members, 1);
+				_send_stack_vars(globals, 2);
 
 			} else if (command == "reload_scripts") {
 				script_paths_to_reload = data;
@@ -540,30 +529,20 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 				PackedStringArray input_names;
 				Array input_vals;
 
-				List<String> locals;
-				List<Variant> local_vals;
-				script_debugger->get_break_language()->debug_get_stack_level_locals(frame, &locals, &local_vals);
-				ERR_FAIL_COND(locals.size() != local_vals.size());
+				LocalVector<Pair<String, Variant>> locals;
+				script_debugger->get_break_language()->debug_get_stack_level_locals(frame, locals);
 
-				for (const String &S : locals) {
-					input_names.append(S);
+				for (const Pair<String, Variant> &local : locals) {
+					input_names.append(local.first);
+					input_vals.append(local.second);
 				}
 
-				for (const Variant &V : local_vals) {
-					input_vals.append(V);
-				}
+				LocalVector<Pair<String, Variant>> globals;
+				script_debugger->get_break_language()->debug_get_globals(globals);
 
-				List<String> globals;
-				List<Variant> globals_vals;
-				script_debugger->get_break_language()->debug_get_globals(&globals, &globals_vals);
-				ERR_FAIL_COND(globals.size() != globals_vals.size());
-
-				for (const String &S : globals) {
-					input_names.append(S);
-				}
-
-				for (const Variant &V : globals_vals) {
-					input_vals.append(V);
+				for (const Pair<String, Variant> &global : globals) {
+					input_names.append(global.first);
+					input_vals.append(global.second);
 				}
 
 				List<StringName> native_types;

--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -102,7 +102,7 @@ private:
 	bool is_peer_connected() { return peer->is_peer_connected(); }
 	void flush_output();
 
-	void _send_stack_vars(List<String> &p_names, List<Variant> &p_vals, int p_type);
+	void _send_stack_vars(const LocalVector<Pair<String, Variant>> &p_variables, int p_type);
 
 	Error _profiler_capture(const String &p_cmd, const Array &p_data, bool &r_captured);
 	Error _core_capture(const String &p_cmd, const Array &p_data, bool &r_captured);

--- a/core/object/script_backtrace.h
+++ b/core/object/script_backtrace.h
@@ -54,7 +54,7 @@ class ScriptBacktrace : public RefCounted {
 	LocalVector<StackVariable> global_variables;
 	String language_name;
 
-	static void _store_variables(const List<String> &p_names, const List<Variant> &p_values, LocalVector<StackVariable> &r_variables);
+	static void _store_variables(const LocalVector<Pair<String, Variant>> &p_variables, LocalVector<StackVariable> &r_variables);
 
 protected:
 	static void _bind_methods();

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -408,10 +408,10 @@ public:
 	virtual int debug_get_stack_level_line(int p_level) const = 0;
 	virtual String debug_get_stack_level_function(int p_level) const = 0;
 	virtual String debug_get_stack_level_source(int p_level) const = 0;
-	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) = 0;
-	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) = 0;
+	virtual void debug_get_stack_level_locals(int p_level, LocalVector<Pair<String, Variant>> &p_locals, int p_max_subitems = -1, int p_max_depth = -1) = 0;
+	virtual void debug_get_stack_level_members(int p_level, LocalVector<Pair<String, Variant>> &p_members, int p_max_subitems = -1, int p_max_depth = -1) = 0;
 	virtual ScriptInstance *debug_get_stack_level_instance(int p_level) { return nullptr; }
-	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) = 0;
+	virtual void debug_get_globals(LocalVector<Pair<String, Variant>> &p_globals, int p_max_subitems = -1, int p_max_depth = -1) = 0;
 	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems = -1, int p_max_depth = -1) = 0;
 
 	virtual Vector<StackInfo> debug_get_current_stack_info() { return Vector<StackInfo>(); }

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -498,42 +498,36 @@ public:
 	EXBIND1RC(String, debug_get_stack_level_source, int)
 
 	GDVIRTUAL3R_REQUIRED(Dictionary, _debug_get_stack_level_locals, int, int, int)
-	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override {
+	virtual void debug_get_stack_level_locals(int p_level, LocalVector<Pair<String, Variant>> &p_locals, int p_max_subitems = -1, int p_max_depth = -1) override {
 		Dictionary ret;
 		GDVIRTUAL_CALL(_debug_get_stack_level_locals, p_level, p_max_subitems, p_max_depth, ret);
 		if (ret.is_empty()) {
 			return;
 		}
-		if (p_locals != nullptr && ret.has("locals")) {
+		if (ret.has("locals") && ret.has("values")) {
 			PackedStringArray strings = ret["locals"];
-			for (int i = 0; i < strings.size(); i++) {
-				p_locals->push_back(strings[i]);
-			}
-		}
-		if (p_values != nullptr && ret.has("values")) {
 			Array values = ret["values"];
-			for (const Variant &value : values) {
-				p_values->push_back(value);
+			ERR_FAIL_COND(strings.size() != values.size());
+			p_locals.reserve(strings.size());
+			for (int i = 0; i < strings.size(); i++) {
+				p_locals.push_back(Pair(strings[i], values[i]));
 			}
 		}
 	}
 	GDVIRTUAL3R_REQUIRED(Dictionary, _debug_get_stack_level_members, int, int, int)
-	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override {
+	virtual void debug_get_stack_level_members(int p_level, LocalVector<Pair<String, Variant>> &p_members, int p_max_subitems = -1, int p_max_depth = -1) override {
 		Dictionary ret;
 		GDVIRTUAL_CALL(_debug_get_stack_level_members, p_level, p_max_subitems, p_max_depth, ret);
 		if (ret.is_empty()) {
 			return;
 		}
-		if (p_members != nullptr && ret.has("members")) {
+		if (ret.has("members") && ret.has("values")) {
 			PackedStringArray strings = ret["members"];
-			for (int i = 0; i < strings.size(); i++) {
-				p_members->push_back(strings[i]);
-			}
-		}
-		if (p_values != nullptr && ret.has("values")) {
 			Array values = ret["values"];
-			for (const Variant &value : values) {
-				p_values->push_back(value);
+			ERR_FAIL_COND(strings.size() != values.size());
+			p_members.reserve(strings.size());
+			for (int i = 0; i < strings.size(); i++) {
+				p_members.push_back(Pair<String, Variant>(strings[i], values[i]));
 			}
 		}
 	}
@@ -545,22 +539,19 @@ public:
 		return reinterpret_cast<ScriptInstance *>(ret.operator void *());
 	}
 	GDVIRTUAL2R_REQUIRED(Dictionary, _debug_get_globals, int, int)
-	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override {
+	virtual void debug_get_globals(LocalVector<Pair<String, Variant>> &p_globals, int p_max_subitems = -1, int p_max_depth = -1) override {
 		Dictionary ret;
 		GDVIRTUAL_CALL(_debug_get_globals, p_max_subitems, p_max_depth, ret);
 		if (ret.is_empty()) {
 			return;
 		}
-		if (p_globals != nullptr && ret.has("globals")) {
+		if (ret.has("globals") && ret.has("values")) {
 			PackedStringArray strings = ret["globals"];
-			for (int i = 0; i < strings.size(); i++) {
-				p_globals->push_back(strings[i]);
-			}
-		}
-		if (p_values != nullptr && ret.has("values")) {
 			Array values = ret["values"];
-			for (const Variant &value : values) {
-				p_values->push_back(value);
+			ERR_FAIL_COND(strings.size() != values.size());
+			p_globals.reserve(strings.size());
+			for (int i = 0; i < strings.size(); i++) {
+				p_globals.push_back(Pair(strings[i], values[i]));
 			}
 		}
 	}

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -634,10 +634,10 @@ public:
 	virtual int debug_get_stack_level_line(int p_level) const override;
 	virtual String debug_get_stack_level_function(int p_level) const override;
 	virtual String debug_get_stack_level_source(int p_level) const override;
-	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override;
-	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override;
+	virtual void debug_get_stack_level_locals(int p_level, LocalVector<Pair<String, Variant>> &p_locals, int p_max_subitems = -1, int p_max_depth = -1) override;
+	virtual void debug_get_stack_level_members(int p_level, LocalVector<Pair<String, Variant>> &p_members, int p_max_subitems = -1, int p_max_depth = -1) override;
 	virtual ScriptInstance *debug_get_stack_level_instance(int p_level) override;
-	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override;
+	virtual void debug_get_globals(LocalVector<Pair<String, Variant>> &p_globals, int p_max_subitems = -1, int p_max_depth = -1) override;
 	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems = -1, int p_max_depth = -1) override;
 
 	virtual void reload_all_scripts() override;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -537,9 +537,9 @@ public:
 	int debug_get_stack_level_line(int p_level) const override;
 	String debug_get_stack_level_function(int p_level) const override;
 	String debug_get_stack_level_source(int p_level) const override;
-	/* TODO */ void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems, int p_max_depth) override {}
-	/* TODO */ void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems, int p_max_depth) override {}
-	/* TODO */ void debug_get_globals(List<String> *p_locals, List<Variant> *p_values, int p_max_subitems, int p_max_depth) override {}
+	/* TODO */ void debug_get_stack_level_locals(int p_level, LocalVector<Pair<String, Variant>> &p_locals, int p_max_subitems, int p_max_depth) override {}
+	/* TODO */ void debug_get_stack_level_members(int p_level, LocalVector<Pair<String, Variant>> &p_members, int p_max_subitems, int p_max_depth) override {}
+	/* TODO */ void debug_get_globals(LocalVector<Pair<String, Variant>> &p_globals, int p_max_subitems, int p_max_depth) override {}
 	/* TODO */ String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems, int p_max_depth) override {
 		return "";
 	}


### PR DESCRIPTION
While reading this part of code, I notice that debugger variable getters do not check if name is correctly mapped to values, but comsumers assume this condition is true(or check explicitly). So I merge `names` and `values` to amend this hole and place a check in the producers incase there is a mismatch, we can catch it earlier.

Since I was already working on this part, I went ahead and did some additional refactoring, mainly `List` and raw pointer stuff. I think they are harmless. If they do cause some problem please tell me.