### PR TITLE
Focus shader text editor when opened with quick open dialog

### DIFF
--- a/editor/shader/shader_editor_plugin.h
+++ b/editor/shader/shader_editor_plugin.h
@@ -98,6 +98,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 	ShaderCreateDialog *shader_create_dialog = nullptr;
 
 	float text_shader_zoom_factor = 1.0f;
+	bool restoring_layout = false;
 
 	Ref<Resource> _get_current_shader();
 	void _update_shader_list();
@@ -127,7 +128,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 	void _set_text_shader_zoom_factor(float p_zoom_factor);
 	void _update_shader_editor_zoom_factor(CodeTextEditor *p_shader_editor) const;
 
-	void _switch_to_editor(ShaderEditor *p_editor);
+	void _switch_to_editor(ShaderEditor *p_editor, bool p_focus = false);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
This is my first PR to the project so don't hesitate to ask me for improvements or any kind of modification.

I was a little bit annoyed that opening a shader with the Quick open dialog didn't focus it in the editor, so I added a line to focus the editor when opening a shader.

I'm not sure all the case are handled so feel free to comment on that.
