### PR TITLE
Ensure albedo texture size is available for Label3D and Sprite3D

### DIFF
--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -392,6 +392,7 @@ void Label3D::_generate_glyph_surfaces(const Glyph &p_glyph, Vector2 &r_offset, 
 
 			RS::get_singleton()->material_set_shader(surf.material, shader_rid);
 			RS::get_singleton()->material_set_param(surf.material, "texture_albedo", tex);
+			RS::get_singleton()->material_set_param(surf.material, "albedo_texture_size", texs);
 			if (get_alpha_cut_mode() == ALPHA_CUT_DISABLED) {
 				RS::get_singleton()->material_set_render_priority(surf.material, p_priority);
 			} else {

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -276,6 +276,7 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 	}
 	if (last_texture != p_texture->get_rid()) {
 		RS::get_singleton()->material_set_param(get_material(), "texture_albedo", p_texture->get_rid());
+		RS::get_singleton()->material_set_param(get_material(), "albedo_texture_size", Vector2i(p_texture->get_width(), p_texture->get_height()));
 		last_texture = p_texture->get_rid();
 	}
 	if (get_alpha_cut_mode() == ALPHA_CUT_DISABLED) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/102180

Regression from: https://github.com/godotengine/godot/pull/100280

Neither Label3D nor Sprite3D were setting the "albedo_texture_size" uniform. So when we started using the uniform instead of calculating the size in the shader it broke MSDF. 

As a nice side effect, this PR also fixes alpha hash edge antialiasing for Sprite3D and Label3D!
