### PR TITLE
[AudioFilterSW] Fix audio cutting out due to numerical errors

### DIFF
--- a/servers/audio/audio_filter_sw.h
+++ b/servers/audio/audio_filter_sw.h
@@ -36,11 +36,11 @@
 class AudioFilterSW {
 public:
 	struct Coeffs {
-		float a1 = 0.0f;
-		float a2 = 0.0f;
-		float b0 = 0.0f;
-		float b1 = 0.0f;
-		float b2 = 0.0f;
+		double a1 = 0.0;
+		double a2 = 0.0;
+		double b0 = 0.0;
+		double b1 = 0.0;
+		double b2 = 0.0;
 	};
 
 	enum Mode {


### PR DESCRIPTION
This aims to fix a long-standing audio issue which someone at my local user group brought up.
When interpolating the cutoff frequency of the AudioEffectFilterHighPass towards 1.0, at a certain point the audio becomes unstable until it suddenly stops working and clips (+- 1.0 on both channels).
After investigation I found out that this problem (probably) occurs due to numerical cancelation/inprecision when calculation the coefficients of the biquad filter.
For some reason, the coefficients were of type float while the rest of the code used double. 
After increasing the precision, the issue was gone for me. There might be a better solution, but for now this is probably the quickest and safest way to fix it.
Other filter effects which use AudioFilterSW under the hood might benefit from this too.