### PR TITLE
GDScript: Do phrase level recovery when parsing faulty dictionaries

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3123,13 +3123,9 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 				case DictionaryNode::LUA_TABLE:
 					if (key != nullptr && key->type != Node::IDENTIFIER && key->type != Node::LITERAL) {
 						push_error(R"(Expected identifier or string as Lua-style dictionary key (e.g "{ key = value }").)");
-						advance();
-						break;
 					}
 					if (key != nullptr && key->type == Node::LITERAL && static_cast<LiteralNode *>(key)->value.get_type() != Variant::STRING) {
 						push_error(R"(Expected identifier or string as Lua-style dictionary key (e.g "{ key = value }").)");
-						advance();
-						break;
 					}
 					if (!match(GDScriptTokenizer::Token::EQUAL)) {
 						if (match(GDScriptTokenizer::Token::COLON)) {
@@ -3169,6 +3165,21 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 			if (key != nullptr && value != nullptr) {
 				dictionary->elements.push_back({ key, value });
 			}
+
+			// Do phrase level recovery by inserting an imaginary expression for missing keys or values.
+			// This ensures the successfully parsed expression is part of the AST and can be analyzed.
+			if (key != nullptr && value == nullptr) {
+				LiteralNode *dummy = alloc_recovery_node<LiteralNode>();
+				dummy->value = Variant();
+
+				dictionary->elements.push_back({ key, dummy });
+			} else if (key == nullptr && value != nullptr) {
+				LiteralNode *dummy = alloc_recovery_node<LiteralNode>();
+				dummy->value = Variant();
+
+				dictionary->elements.push_back({ dummy, value });
+			}
+
 		} while (match(GDScriptTokenizer::Token::COMMA) && !is_at_end());
 	}
 	pop_multiline();

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1453,6 +1453,18 @@ private:
 
 		return node;
 	}
+
+	// Allocates a node for patching up the parse tree when an error occurred.
+	// Such nodes don't track their extents as they don't relate to actual tokens.
+	template <typename T>
+	T *alloc_recovery_node() {
+		T *node = memnew(T);
+		node->next = list;
+		list = node;
+
+		return node;
+	}
+
 	void clear();
 	void push_error(const String &p_message, const Node *p_origin = nullptr);
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_1.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_1.cfg
@@ -1,0 +1,4 @@
+[output]
+exclude=[
+    {"display": "AUTO_TRANSLATE_MODE_INHERIT"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_1.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_1.gd
@@ -1,0 +1,6 @@
+extends Node
+
+var test = {
+    t = 1,
+    AutoTranslateMode.➡
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_2.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_2.cfg
@@ -1,0 +1,4 @@
+[output]
+exclude=[
+    {"display": "VALUE"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_2.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_2.gd
@@ -1,0 +1,10 @@
+extends Node
+
+enum TestEnum {
+    VALUE,
+}
+
+var test = {
+    t = 1,
+    TestEnum.➡ = 1,
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_1.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_1.cfg
@@ -1,0 +1,4 @@
+[output]
+include=[
+    {"display": "AUTO_TRANSLATE_MODE_INHERIT"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_1.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_1.gd
@@ -1,0 +1,5 @@
+extends Node
+
+var test = {
+    t = AutoTranslateMode.➡
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_2.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_2.cfg
@@ -1,0 +1,4 @@
+[output]
+include=[
+    {"display": "VALUE"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_2.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_2.gd
@@ -1,0 +1,9 @@
+extends Node
+
+enum TestEnum {
+    VALUE,
+}
+
+var test = {
+    = TestEnum.➡
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_3.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_3.cfg
@@ -1,0 +1,4 @@
+[output]
+include=[
+    {"display": "AUTO_TRANSLATE_MODE_INHERIT"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_3.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_3.gd
@@ -1,0 +1,6 @@
+extends Node
+
+var test = {
+    t = 1,
+    e AutoTranslateMode.➡,
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_4.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_4.cfg
@@ -1,0 +1,4 @@
+[output]
+include=[
+    {"display": "VALUE"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_4.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_4.gd
@@ -1,0 +1,9 @@
+extends Node
+
+enum TestEnum {
+    VALUE,
+}
+
+var test = {
+    1 = TestEnum.➡
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_5.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_5.cfg
@@ -1,0 +1,4 @@
+[output]
+include=[
+    {"display": "AUTO_TRANSLATE_MODE_INHERIT"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_5.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_value_5.gd
@@ -1,0 +1,6 @@
+extends Node
+
+var test = {
+    t = 1,
+    1 AutoTranslateMode.➡,
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_1.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_1.cfg
@@ -1,0 +1,4 @@
+[output]
+include=[
+    {"display": "AUTO_TRANSLATE_MODE_INHERIT"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_1.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_1.gd
@@ -1,0 +1,5 @@
+extends Node
+
+var test = {
+    AutoTranslateMode.➡
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_2.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_2.cfg
@@ -1,0 +1,4 @@
+[output]
+include=[
+    {"display": "AUTO_TRANSLATE_MODE_INHERIT"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_2.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_2.gd
@@ -1,0 +1,5 @@
+extends Node
+
+var test = {
+    AutoTranslateMode.➡:
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_3.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_3.cfg
@@ -1,0 +1,4 @@
+[output]
+include=[
+    {"display": "VALUE"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_3.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_3.gd
@@ -1,0 +1,9 @@
+extends Node
+
+enum TestEnum {
+    VALUE,
+}
+
+var test = {
+    TestEnum.➡ "test"
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_4.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_4.cfg
@@ -1,0 +1,4 @@
+[output]
+include=[
+    {"display": "AUTO_TRANSLATE_MODE_INHERIT"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_4.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_key_4.gd
@@ -1,0 +1,5 @@
+extends Node
+
+var test = {
+    AutoTranslateMode.➡: 1
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_value_1.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_value_1.cfg
@@ -1,0 +1,4 @@
+[output]
+include=[
+    {"display": "AUTO_TRANSLATE_MODE_INHERIT"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_value_1.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_value_1.gd
@@ -1,0 +1,5 @@
+extends Node
+
+var test = {
+    1: AutoTranslateMode.➡
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_value_2.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_value_2.cfg
@@ -1,0 +1,4 @@
+[output]
+include=[
+    {"display": "VALUE"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_value_2.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_value_2.gd
@@ -1,0 +1,9 @@
+extends Node
+
+enum TestEnum {
+    VALUE,
+}
+
+var test = {
+    : TestEnum.➡
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_value_3.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_value_3.cfg
@@ -1,0 +1,4 @@
+[output]
+include=[
+    {"display": "AUTO_TRANSLATE_MODE_INHERIT"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_value_3.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/py_value_3.gd
@@ -1,0 +1,5 @@
+extends Node
+
+var test = {
+    1 AutoTranslateMode.➡
+}


### PR DESCRIPTION
Fixes #78602
Fixes #37061 (this is on the 3.x milestone, but I don't think we'll able to back port any fix, so we might as well close it)
Fixes partially #96157

Partial alternative to #79424

Descritpion from there:
> There are cases in the parser were successfully parsed nodes don't end up in the final parse tree because they are part of a faulty structure. Because those nodes do not end up in the parse tree they are never examined by the analyzer. This is usually fine because it is assumed that scripts don't contain errors. However when providing code completion a structure might be invalid because the user is currently typing it in. In this case we still want to provide the best autocompletion for the valid subparts. And indeed these subparts end up in the CompletionContext. But since the analyzer never resolved their types the autocompletion can be worse at some points.
>
>This PR tries to resolve this by letting the parser save such completed fragments with the nearest valid Node if parsing fails somewhere. The analyzer does now also analyze all fragments for a node and can therefore add type information e.g. for identifiers.

In #79424 the parser would add such fully parsed parts to a new list "unfinished fragments" and the analyzer was adjusted to analyze this list as well. This PR takes a different approach and patches the tree in the parser in a way that is transparent to the analyzer. This is a better approach since it ensures that the analyzer encounters those fragments in the correct context.

The patched tree might be faulty on the analyzer level, but to the analyzer it looks like an syntactically correct file. Those analyzer errors resulting from faulty patching (e.g. patching a incompatible value into a typed dictionary) can be ignored, since analyzer errors are not shown as long as there are parser errors (which is always the case when we are patching the tree).

If we can reach any consensus on this approach I'll add recovery for the other cases from #79424 as well (ternaries and match statements). But I'd like to hear some thoughts on this first, since I don't think there is any precedence for this kind of recovery in the parser.
