### PR TITLE
Fix a crash on iOS from Joypad initialization

### DIFF
--- a/platform/ios/os_ios.h
+++ b/platform/ios/os_ios.h
@@ -65,8 +65,7 @@ private:
 	virtual void initialize_core() override;
 	virtual void initialize() override;
 
-	virtual void initialize_joypads() override {
-	}
+	virtual void initialize_joypads() override;
 
 	virtual void set_main_loop(MainLoop *p_main_loop) override;
 	virtual MainLoop *get_main_loop() const override;

--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -126,11 +126,13 @@ void OS_IOS::initialize() {
 	initialize_core();
 }
 
+void OS_IOS::initialize_joypads() {
+	joypad_apple = memnew(JoypadApple);
+}
+
 void OS_IOS::initialize_modules() {
 	ios = memnew(iOS);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("iOS", ios));
-
-	joypad_apple = memnew(JoypadApple);
 }
 
 void OS_IOS::deinitialize_modules() {


### PR DESCRIPTION
The way iOS initializes joypads right now will crash the app, if a gamepad is already connected before the game is started.

`JoypadApple` starts listening for joypad notifications before the `Input` singleton is available. iOS will immediately send a notification about controllers already on and connected. This will lead to attempted use of the Input singleton before it's ready ([here is where the crash will happen](https://github.com/godotengine/godot/blob/9ee1873ae1e09c217ac24a5800007f63cb895615/drivers/apple/joypad_apple.mm#L303)). 

`initialize_joypad()` on the other hand is called explicitly after the Input singleton becomes available ([here](https://github.com/godotengine/godot/blob/9ee1873ae1e09c217ac24a5800007f63cb895615/main/main.cpp#L2941)).

For context - the issue was introduced [here](https://github.com/godotengine/godot/commit/cd17cb011075d110d1ea50f8a9c0573b22c3dc58#diff-f0ce1cbd4e741f31a64b71de9cc7633aacc3e1e75b16562b41df7d6142c3af45), and from the context it seems like it was probably an oversight.

**Steps to reproduce**

- Connect a hardware controller to an iOS device
- Launch any Godot app