### PR TITLE
Fix animation name replacement logic for scene resource reimporting

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1350,7 +1350,12 @@ Node *ResourceImporterScene::_post_fix_animations(Node *p_node, Node *p_root, co
 
 				if (saved_anim != anim) {
 					Ref<AnimationLibrary> al = ap->get_animation_library(ap->find_animation_library(anim));
-					al->add_animation(name, saved_anim); //replace
+					String an = String(name);
+					int ai = an.rfind("/");
+					if (ai >= 0 && ai + 1 < an.size() && an.substr(0, ai + 1) == al->get_name() + "/") {
+						an = an.substr(ai + 1);
+					}
+					al->add_animation(StringName(an), saved_anim); //replace
 				}
 			}
 		}


### PR DESCRIPTION
Sometimes upon invoking "Reimport" on certain external scene resources whose original formats support animations ( and likely specifically after the scene has already been instantiated as a child under another scene's root node ), the following error log message may appear:

```
Invalid animation name: 'my_animation_library_name/my_animation_name'.
```

Such an occurrence is due to how the `AnimationMixer::get_animation_list` method is implemented to return registered animation names with a prefix of the name of the owning animation library if it is not the default library which is nameless ( https://github.com/PierceLBrooks/godot/blob/plb/import-scene-res-anim-name-replacement-bug/scene/animation/animation_mixer.cpp#L146 ).

My changes will resolve this issue.