### PR TITLE
Fix non-static members warning about shadowing in static context

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5900,7 +5900,31 @@ void GDScriptAnalyzer::is_shadowing(GDScriptParser::IdentifierNode *p_identifier
 
 		if (base_class != nullptr) {
 			if (base_class->has_member(name)) {
-				parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_VARIABLE, p_context, p_identifier->name, base_class->get_member(name).get_type_name(), itos(base_class->get_member(name).get_line()));
+				GDScriptParser::ClassNode::Member member = base_class->get_member(name);
+
+				bool is_member_static = true;
+
+				switch (member.type) {
+					case GDScriptParser::ClassNode::Member::FUNCTION:
+						is_member_static = member.function->is_static;
+						break;
+					case GDScriptParser::ClassNode::Member::VARIABLE:
+						is_member_static = member.variable->is_static;
+						break;
+					case GDScriptParser::ClassNode::Member::UNDEFINED:
+					case GDScriptParser::ClassNode::Member::CLASS:
+					case GDScriptParser::ClassNode::Member::CONSTANT:
+					case GDScriptParser::ClassNode::Member::SIGNAL:
+					case GDScriptParser::ClassNode::Member::ENUM:
+					case GDScriptParser::ClassNode::Member::ENUM_VALUE:
+					case GDScriptParser::ClassNode::Member::GROUP:
+						break;
+				}
+
+				if (is_member_static || !static_context) {
+					parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_VARIABLE, p_context, p_identifier->name, base_class->get_member(name).get_type_name(), itos(base_class->get_member(name).get_line()));
+				}
+
 				return;
 			}
 			base_class = base_class->base_type.class_type;
@@ -5908,12 +5932,36 @@ void GDScriptAnalyzer::is_shadowing(GDScriptParser::IdentifierNode *p_identifier
 
 		while (base_class != nullptr) {
 			if (base_class->has_member(name)) {
-				String base_class_name = base_class->get_global_name();
-				if (base_class_name.is_empty()) {
-					base_class_name = base_class->fqcn;
+				GDScriptParser::ClassNode::Member member = base_class->get_member(name);
+
+				bool is_member_static = true;
+
+				switch (member.type) {
+					case GDScriptParser::ClassNode::Member::FUNCTION:
+						is_member_static = member.function->is_static;
+						break;
+					case GDScriptParser::ClassNode::Member::VARIABLE:
+						is_member_static = member.variable->is_static;
+						break;
+					case GDScriptParser::ClassNode::Member::UNDEFINED:
+					case GDScriptParser::ClassNode::Member::CLASS:
+					case GDScriptParser::ClassNode::Member::CONSTANT:
+					case GDScriptParser::ClassNode::Member::SIGNAL:
+					case GDScriptParser::ClassNode::Member::ENUM:
+					case GDScriptParser::ClassNode::Member::ENUM_VALUE:
+					case GDScriptParser::ClassNode::Member::GROUP:
+						break;
 				}
 
-				parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_VARIABLE_BASE_CLASS, p_context, p_identifier->name, base_class->get_member(name).get_type_name(), itos(base_class->get_member(name).get_line()), base_class_name);
+				if (is_member_static || !static_context) {
+					String base_class_name = base_class->get_global_name();
+					if (base_class_name.is_empty()) {
+						base_class_name = base_class->fqcn;
+					}
+
+					parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_VARIABLE_BASE_CLASS, p_context, p_identifier->name, base_class->get_member(name).get_type_name(), itos(base_class->get_member(name).get_line()), base_class_name);
+				}
+
 				return;
 			}
 			base_class = base_class->base_type.class_type;


### PR DESCRIPTION
Fixed issue in ``gdscript_analyzer.cpp`` causing it to recognize non-static members as conflicting with the names of parameters of static functions and push a ``SHADOWED_VARIABLE`` warning to the Debugger.

For example:

``foo.gd``
```gdscript
class_name Foo
extends Node

var bar: int

static func baz(bar: int) -> void:
	print(bar)
```

Pushes the following warning:

``
W 0:00:01:0408   The local function parameter "bar" is shadowing an already-declared variable at line 4 in the current class.
  <GDScript Error>SHADOWED_VARIABLE
  <GDScript Source>foo.gd:6
``

And:

``foo2.gd``
```gdscript 
class_name Foo2
extends Foo

static func baz2(bar: int) -> void:
	print(bar)
```

Pushes the following warning:

``
W 0:00:01:0408   The local function parameter "bar" is shadowing an already-declared variable at line 4 in the base class "Foo".
  <GDScript Error>SHADOWED_VARIABLE_BASE_CLASS
  <GDScript Source>foo2.gd:4
``

This warning is unnecessary (and potentially confusing) as, even though the ``bar`` member variable of ``Foo`` is named the same as the parameter of ``func baz`` and ``func baz2``, these static functions do not have access to the class' non-static member.

The changes proposed check that non-static members are not considered for shadowing warnings in static contexts.

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/63120*