### PR TITLE
Fix ColorPicker sliders in overbright RGB

### DIFF
--- a/scene/gui/color_mode.cpp
+++ b/scene/gui/color_mode.cpp
@@ -43,12 +43,6 @@ String ColorModeRGB::get_slider_label(int idx) const {
 	return labels[idx];
 }
 
-float ColorModeRGB::get_slider_max(int idx) const {
-	ERR_FAIL_INDEX_V_MSG(idx, 4, 0, "Couldn't get slider max value.");
-	Color color = color_picker->get_pick_color();
-	return next_power_of_2(MAX(255, color.components[idx] * 255.0)) - 1;
-}
-
 float ColorModeRGB::get_slider_value(int idx) const {
 	ERR_FAIL_INDEX_V_MSG(idx, 4, 0, "Couldn't get slider value.");
 	return color_picker->get_pick_color().components[idx] * 255;

--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -46,6 +46,7 @@ public:
 	virtual float get_spinbox_arrow_step() const { return get_slider_step(); }
 	virtual String get_slider_label(int idx) const = 0;
 	virtual float get_slider_max(int idx) const = 0;
+	virtual bool get_allow_greater() const { return false; }
 	virtual float get_slider_value(int idx) const = 0;
 
 	virtual Color get_color() const = 0;
@@ -92,7 +93,8 @@ public:
 
 	virtual float get_slider_step() const override { return 1; }
 	virtual String get_slider_label(int idx) const override;
-	virtual float get_slider_max(int idx) const override;
+	virtual float get_slider_max(int idx) const override { return 255; }
+	virtual bool get_allow_greater() const override { return true; }
 	virtual float get_slider_value(int idx) const override;
 
 	virtual Color get_color() const override;
@@ -114,6 +116,7 @@ public:
 	virtual float get_spinbox_arrow_step() const override { return 0.01; }
 	virtual String get_slider_label(int idx) const override;
 	virtual float get_slider_max(int idx) const override;
+	virtual bool get_allow_greater() const override { return true; }
 	virtual float get_slider_value(int idx) const override;
 
 	virtual Color get_color() const override;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -675,8 +675,9 @@ void ColorPicker::_update_color(bool p_update_sliders) {
 		for (int i = 0; i < current_slider_count; i++) {
 			sliders[i]->set_max(modes[current_mode]->get_slider_max(i));
 			sliders[i]->set_step(step);
-			values[i]->set_custom_arrow_step(spinbox_arrow_step);
 			sliders[i]->set_value(modes[current_mode]->get_slider_value(i));
+			values[i]->set_custom_arrow_step(spinbox_arrow_step);
+			values[i]->set_allow_greater(modes[current_mode]->get_allow_greater());
 		}
 		alpha_slider->set_max(modes[current_mode]->get_slider_max(current_slider_count));
 		alpha_slider->set_step(step);


### PR DESCRIPTION
Fixes #62894
Supersedes #62913

https://github.com/user-attachments/assets/838a4825-4d94-45b0-be88-11aaf24acd5f

I removed the `next_power_of_2` thing, which dates back to #17383 with no explanation. Instead I made RGB mode SpinBoxes allow greater values (inspired by #88072). `allow_greater` is also enabled in RAW mode; this technically allows to limit the sliders to 10.0, while still allowing bigger values.