### PR TITLE
Add low VRAM mode in the lightmapper.

### DIFF
--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -62,6 +62,10 @@
 		<member name="light_data" type="LightmapGIData" setter="set_light_data" getter="get_light_data">
 			The [LightmapGIData] associated to this [LightmapGI] node. This resource is automatically created after baking, and is not meant to be created manually.
 		</member>
+		<member name="low_vram_mode" type="bool" setter="set_low_vram_mode" getter="is_low_vram_mode" default="false">
+			If [code]true[/code], the lightmapper will attempt to use less VRAM by calculating each lightmap array slice separately in multiple compute shader invocations.
+			[b]Note:[/b] [member use_texture_for_bounces] will be ignored if this is [code]true[/code].
+		</member>
 		<member name="max_texture_size" type="int" setter="set_max_texture_size" getter="get_max_texture_size" default="16384">
 			The maximum texture size for the generated texture atlas. Higher values will result in fewer slices being generated, but may not work on all hardware as a result of hardware limitations on texture sizes. Leave [member max_texture_size] at its default value of [code]16384[/code] if unsure.
 		</member>
@@ -93,7 +97,7 @@
 		</member>
 		<member name="use_texture_for_bounces" type="bool" setter="set_use_texture_for_bounces" getter="is_using_texture_for_bounces" default="true">
 			If [code]true[/code], a texture with the lighting information will be generated to speed up the generation of indirect lighting at the cost of some accuracy. The geometry might exhibit extra light leak artifacts when using low resolution lightmaps or UVs that stretch the lightmap significantly across surfaces. Leave [member use_texture_for_bounces] at its default value of [code]true[/code] if unsure.
-			[b]Note:[/b] [member use_texture_for_bounces] only has an effect if [member bounces] is set to a value greater than or equal to [code]1[/code].
+			[b]Note:[/b] [member use_texture_for_bounces] only has an effect if [member bounces] is set to a value greater than or equal to [code]1[/code] and [member low_vram_mode] is [code]false[/code].
 		</member>
 	</members>
 	<constants>

--- a/modules/lightmapper_rd/lightmapper_rd.h
+++ b/modules/lightmapper_rd/lightmapper_rd.h
@@ -259,6 +259,8 @@ class LightmapperRD : public Lightmapper {
 	Vector<Ref<Image>> lightmap_textures;
 	Vector<Ref<Image>> shadowmask_textures;
 	Vector<Color> probe_values;
+	bool low_vram_mode = false;
+	int baking_slice = -1; // the slice currently being baked when in low VRAM mode or -1
 
 	struct DilateParams {
 		uint32_t radius;
@@ -294,6 +296,7 @@ public:
 	virtual void add_omni_light(const String &p_name, bool p_static, const Vector3 &p_position, const Color &p_color, float p_energy, float p_indirect_energy, float p_range, float p_attenuation, float p_size, float p_shadow_blur) override;
 	virtual void add_spot_light(const String &p_name, bool p_static, const Vector3 &p_position, const Vector3 p_direction, const Color &p_color, float p_energy, float p_indirect_energy, float p_range, float p_attenuation, float p_spot_angle, float p_spot_attenuation, float p_size, float p_shadow_blur) override;
 	virtual void add_probe(const Vector3 &p_position) override;
+	virtual void set_low_vram_mode(bool p_enable) override;
 	virtual BakeError bake(BakeQuality p_quality, bool p_use_denoiser, float p_denoiser_strength, int p_denoiser_range, int p_bounces, float p_bounce_indirect_energy, float p_bias, int p_max_texture_size, bool p_bake_sh, bool p_bake_shadowmask, bool p_texture_for_bounces, GenerateProbes p_generate_probes, const Ref<Image> &p_environment_panorama, const Basis &p_environment_transform, BakeStepFunc p_step_function = nullptr, void *p_bake_userdata = nullptr, float p_exposure_normalization = 1.0, float p_supersampling_factor = 1.0f) override;
 
 	int get_bake_texture_count() const override;

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1266,6 +1266,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 		}
 	}
 
+	lightmapper->set_low_vram_mode(low_vram_mode);
 	Lightmapper::BakeError bake_err = lightmapper->bake(Lightmapper::BakeQuality(bake_quality), use_denoiser, denoiser_strength, denoiser_range, bounces,
 			bounce_indirect_energy, bias, max_texture_size, directional, shadowmask_mode != LightmapGIData::SHADOWMASK_MODE_NONE, use_texture_for_bounces,
 			Lightmapper::GenerateProbes(gen_probes), environment_image, environment_transform, _lightmap_bake_step_function, &bsud, exposure_normalization, (supersampling_enabled ? supersampling_factor : 1));
@@ -1630,6 +1631,14 @@ bool LightmapGI::is_using_texture_for_bounces() const {
 	return use_texture_for_bounces;
 }
 
+void LightmapGI::set_low_vram_mode(bool p_enable) {
+	low_vram_mode = p_enable;
+}
+
+bool LightmapGI::is_low_vram_mode() const {
+	return low_vram_mode;
+}
+
 void LightmapGI::set_interior(bool p_enable) {
 	interior = p_enable;
 }
@@ -1860,6 +1869,9 @@ void LightmapGI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_texture_for_bounces", "use_texture_for_bounces"), &LightmapGI::set_use_texture_for_bounces);
 	ClassDB::bind_method(D_METHOD("is_using_texture_for_bounces"), &LightmapGI::is_using_texture_for_bounces);
 
+	ClassDB::bind_method(D_METHOD("set_low_vram_mode", "low_vram_mode"), &LightmapGI::set_low_vram_mode);
+	ClassDB::bind_method(D_METHOD("is_low_vram_mode"), &LightmapGI::is_low_vram_mode);
+
 	ClassDB::bind_method(D_METHOD("set_camera_attributes", "camera_attributes"), &LightmapGI::set_camera_attributes);
 	ClassDB::bind_method(D_METHOD("get_camera_attributes"), &LightmapGI::get_camera_attributes);
 
@@ -1874,6 +1886,7 @@ void LightmapGI::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "directional"), "set_directional", "is_directional");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "shadowmask_mode", PROPERTY_HINT_ENUM, "None,Replace,Overlay"), "set_shadowmask_mode", "get_shadowmask_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_texture_for_bounces"), "set_use_texture_for_bounces", "is_using_texture_for_bounces");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "low_vram_mode"), "set_low_vram_mode", "is_low_vram_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "interior"), "set_interior", "is_interior");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_denoiser"), "set_use_denoiser", "is_using_denoiser");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "denoiser_strength", PROPERTY_HINT_RANGE, "0.001,0.2,0.001,or_greater"), "set_denoiser_strength", "get_denoiser_strength");

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -201,6 +201,7 @@ private:
 	float environment_custom_energy = 1.0;
 	bool directional = false;
 	bool use_texture_for_bounces = true;
+	bool low_vram_mode = false;
 	LightmapGIData::ShadowmaskMode shadowmask_mode = LightmapGIData::SHADOWMASK_MODE_NONE;
 	GenerateProbes gen_probes = GENERATE_PROBES_SUBDIV_8;
 	Ref<CameraAttributes> camera_attributes;
@@ -303,6 +304,9 @@ public:
 
 	void set_use_texture_for_bounces(bool p_enable);
 	bool is_using_texture_for_bounces() const;
+
+	void set_low_vram_mode(bool p_enable);
+	bool is_low_vram_mode() const;
 
 	void set_interior(bool p_interior);
 	bool is_interior() const;

--- a/scene/3d/lightmapper.h
+++ b/scene/3d/lightmapper.h
@@ -182,6 +182,7 @@ public:
 	virtual void add_omni_light(const String &p_name, bool p_static, const Vector3 &p_position, const Color &p_color, float p_energy, float p_indirect_energy, float p_range, float p_attenuation, float p_size, float p_shadow_blur) = 0;
 	virtual void add_spot_light(const String &p_name, bool p_static, const Vector3 &p_position, const Vector3 p_direction, const Color &p_color, float p_energy, float p_indirect_energy, float p_range, float p_attenuation, float p_spot_angle, float p_spot_attenuation, float p_size, float p_shadow_blur) = 0;
 	virtual void add_probe(const Vector3 &p_position) = 0;
+	virtual void set_low_vram_mode(bool p_enable) = 0;
 	virtual BakeError bake(BakeQuality p_quality, bool p_use_denoiser, float p_denoiser_strength, int p_denoiser_range, int p_bounces, float p_bounce_indirect_energy, float p_bias, int p_max_texture_size, bool p_bake_sh, bool p_bake_shadowmask, bool p_texture_for_bounces, GenerateProbes p_generate_probes, const Ref<Image> &p_environment_panorama, const Basis &p_environment_transform, BakeStepFunc p_step_function = nullptr, void *p_step_userdata = nullptr, float p_exposure_normalization = 1.0, float p_supersampling_factor = 1.0) = 0;
 
 	virtual int get_bake_texture_count() const = 0;


### PR DESCRIPTION
This closes https://github.com/godotengine/godot/issues/95204.

Adds a "low VRAM mode" in the lightmapper (`LightmapGI` node). Normally the lightmapper allocates VRAM to hold all lightmap array slices and runs a compute shader that works on all of them at once. In "low VRAM mode" the lightmapper allocates VRAM for a single array slice and runs the compute shader repeatedly for each slice. This is slightly slower (e.g. can be ~1.3 times slower in some tests i made) but can help users with GPUs that have low VRAM to lightmap their scenes.

The VRAM savings depend on the lightmapping setup, in the worst case if the lightmapper creates a lightmap array with a single slice, it will not make a difference. However in the test mentioned in #95204 above (with 1.5 lightmap scaling) the VRAM use dropped from 24GB down to 8GB. In other, less "stress test-y" tests i made, the VRAM use was around half. In general, the more lightmap array slices, the larger the savings.

This is still a draft meant for testing. There are a few issues:

- Some of the code inside the loop (e.g. probe calculation) can most likely be moved outside
- The `baking_slice` field can be removed
- I haven't tested directional lightmaps (i couldn't get them to work with the TPS demo modified as mentioned in the issue above - this was the case even in `master` but perhaps i didn't set it up correctly, i only checked the directional lightmaps property in `LightmapGI` and expected it to work, but that wasn't the case and i didn't look into it further than that)
- In the denoising pass the accessed albedo and normal values in the compute shader may get invalid values during weight calculation so the weight can be off in low VRAM mode. In practice i haven't seen this make a visual difference between the two modes. It is an easy fix but it'd require passing an additional parameter to the compute shader for both modes.
- The progress bar in low VRAM mode jumps back and forth for each slice (EDIT: forgot to mention this)
- Currently enabling the low VRAM mode is done via a new property in the `LightmapGI` node. There was some discussion in a recent rendering meeting about not adding a new property for this but instead piggybacking on `use_texture_for_bounces` and assume low VRAM is desired if it is `false` since the low VRAM mode ignores the lightmap texture (as it isn't fully available in VRAM anyway). Personally i'm not a fan of this as it is about something separate and i'd prefer more explicit control, but at the end i do not hold strong opinions either way - the important is getting it in the engine so that people with low VRAM can use it.

Some minor VRAM savings could also be done regardless of the low VRAM mode, but considering the changes in this PR i'd rather look into those at a later time.