### PR TITLE
Separate directory for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ misc/hooks/pre-commit-custom-*
 #############################
 
 # Buildsystem
-build
+./build/*
 bin
 *.gen.*
 compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ misc/hooks/pre-commit-custom-*
 #############################
 
 # Buildsystem
+build
 bin
 *.gen.*
 compile_commands.json

--- a/SConstruct
+++ b/SConstruct
@@ -10,9 +10,10 @@ import os
 import pickle
 import sys
 from collections import OrderedDict
-from methods import load_helper_module
 
 from SCons import __version__ as scons_raw_version
+
+from methods import load_helper_module
 
 load_helper_module("gles3_builders", "gles3_builders.py")
 load_helper_module("glsl_builders", "glsl_builders.py")
@@ -1031,10 +1032,12 @@ if env["build_dir"]:
 # Build subdirs, the build order is dependent on link order.
 Export("env")
 
+
 # this function only has to be used for direct SConscript calls from SConstruct.
 # hence it is placed here locally and not in methods.py
 def call_sconscript(subdir: str):
     SConscript(f"{subdir}/SCsub", variant_dir=f"{env['build_dir']}/{subdir}", duplicate=False)
+
 
 call_sconscript("core")
 call_sconscript("servers")

--- a/core/SCsub
+++ b/core/SCsub
@@ -5,6 +5,12 @@ Import("env")
 
 import os
 
+# since we are using variant_dir this SCsub file is actually being executed in
+# the variant_dir. so to load the local python file, we will need to use
+# _helper_module function to tell python where this module is located.
+from methods import load_helper_module
+
+load_helper_module("core_builders", "core/core_builders.py")
 import core_builders
 
 import methods
@@ -252,28 +258,28 @@ env.add_source_files(env.core_sources, gen_encrypt)
 
 # Certificates
 env.Depends(
-    "#core/io/certs_compressed.gen.h",
+    f"#{env['build_dir']}/core/io/certs_compressed.gen.h",
     ["#thirdparty/certs/ca-certificates.crt", env.Value(env["builtin_certs"]), env.Value(env["system_certs_path"])],
 )
 env.CommandNoCache(
-    "#core/io/certs_compressed.gen.h",
+    f"#{env['build_dir']}/core/io/certs_compressed.gen.h",
     "#thirdparty/certs/ca-certificates.crt",
     env.Run(core_builders.make_certs_header),
 )
 
 # Authors
-env.Depends("#core/authors.gen.h", "../AUTHORS.md")
-env.CommandNoCache("#core/authors.gen.h", "../AUTHORS.md", env.Run(core_builders.make_authors_header))
+env.Depends(f"#{env['build_dir']}/core/authors.gen.h", "#AUTHORS.md")
+env.CommandNoCache(f"#{env['build_dir']}/core/authors.gen.h", "#AUTHORS.md", env.Run(core_builders.make_authors_header))
 
 # Donors
-env.Depends("#core/donors.gen.h", "../DONORS.md")
-env.CommandNoCache("#core/donors.gen.h", "../DONORS.md", env.Run(core_builders.make_donors_header))
+env.Depends(f"#{env['build_dir']}/core/donors.gen.h", "#DONORS.md")
+env.CommandNoCache(f"#{env['build_dir']}/core/donors.gen.h", "#DONORS.md", env.Run(core_builders.make_donors_header))
 
 # License
-env.Depends("#core/license.gen.h", ["../COPYRIGHT.txt", "../LICENSE.txt"])
+env.Depends(f"#{env['build_dir']}/core/license.gen.h", ["#COPYRIGHT.txt", "#LICENSE.txt"])
 env.CommandNoCache(
-    "#core/license.gen.h",
-    ["../COPYRIGHT.txt", "../LICENSE.txt"],
+    f"#{env['build_dir']}/core/license.gen.h",
+    ["#COPYRIGHT.txt", "#LICENSE.txt"],
     env.Run(core_builders.make_license_header),
 )
 

--- a/core/extension/SCsub
+++ b/core/extension/SCsub
@@ -3,6 +3,10 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
+from methods import load_helper_module
+
+load_helper_module("make_interface_dumper", "core/extension/make_interface_dumper.py")
+load_helper_module("make_wrappers", "core/extension/make_wrappers.py")
 import make_interface_dumper
 import make_wrappers
 

--- a/core/input/SCsub
+++ b/core/input/SCsub
@@ -3,6 +3,9 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
+from methods import load_helper_module
+
+load_helper_module("input_builders", "core/input/input_builders.py")
 import input_builders
 
 # Order matters here. Higher index controller database files write on top of lower index database files.

--- a/core/object/SCsub
+++ b/core/object/SCsub
@@ -3,6 +3,9 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
+from methods import load_helper_module
+
+load_helper_module("make_virtuals", "core/object/make_virtuals.py")
 import make_virtuals
 
 env.CommandNoCache(["gdvirtual.gen.inc"], "make_virtuals.py", env.Run(make_virtuals.run))

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -8,6 +8,9 @@ env.editor_sources = []
 import glob
 import os
 
+from methods import load_helper_module
+
+load_helper_module("editor_builders", "editor/editor_builders.py")
 import editor_builders
 
 import methods
@@ -45,7 +48,7 @@ static const _DocDataClassPath _doc_data_class_paths[{len(env.doc_class_path) + 
         with methods.generated_wrapper(target) as file:
             file.write(
                 f"""\
-#include "register_exporters.h"
+#include "editor/register_exporters.h"
 
 {exp_inc}
 
@@ -64,7 +67,9 @@ void register_exporter_types() {{
     )
     for e in env.platform_exporters:
         # Add all .cpp files in export folder
-        env.add_source_files(env.editor_sources, f"../platform/{e}/export/*.cpp")
+        env_platform = env.Clone()
+        env_platform.Append(CPPPATH=[f"#{env['build_dir']}/platform/{e}/export"])
+        env_platform.add_source_files(env.editor_sources, f"#platform/{e}/export/*.cpp")
 
     # Core API documentation.
     docs = []
@@ -83,9 +88,9 @@ void register_exporter_types() {{
             docs += Glob(d + "/*.xml")  # Custom.
 
     docs = sorted(docs)
-    env.Depends("#editor/doc_data_compressed.gen.h", docs)
+    env.Depends(f"#{env['build_dir']}/editor/doc_data_compressed.gen.h", docs)
     env.CommandNoCache(
-        "#editor/doc_data_compressed.gen.h",
+        f"#{env['build_dir']}/editor/doc_data_compressed.gen.h",
         docs,
         env.Run(editor_builders.make_doc_header),
     )
@@ -98,27 +103,27 @@ void register_exporter_types() {{
 
     # Editor translations
     tlist = glob.glob(env.Dir("#editor/translations/editor").abspath + "/*.po")
-    env.Depends("#editor/editor_translations.gen.h", tlist)
+    env.Depends(f"#{env['build_dir']}/editor/editor_translations.gen.h", tlist)
     env.CommandNoCache(
-        "#editor/editor_translations.gen.h",
+        f"#{env['build_dir']}/editor/editor_translations.gen.h",
         tlist,
         env.Run(editor_builders.make_editor_translations_header),
     )
 
     # Property translations
     tlist = glob.glob(env.Dir("#editor/translations/properties").abspath + "/*.po")
-    env.Depends("#editor/property_translations.gen.h", tlist)
+    env.Depends(f"#{env['build_dir']}/editor/property_translations.gen.h", tlist)
     env.CommandNoCache(
-        "#editor/property_translations.gen.h",
+        f"#{env['build_dir']}/editor/property_translations.gen.h",
         tlist,
         env.Run(editor_builders.make_property_translations_header),
     )
 
     # Documentation translations
     tlist = glob.glob(env.Dir("#doc/translations").abspath + "/*.po")
-    env.Depends("#editor/doc_translations.gen.h", tlist)
+    env.Depends(f"#{env['build_dir']}/editor/doc_translations.gen.h", tlist)
     env.CommandNoCache(
-        "#editor/doc_translations.gen.h",
+        f"#{env['build_dir']}/editor/doc_translations.gen.h",
         tlist,
         env.Run(editor_builders.make_doc_translations_header),
     )
@@ -126,9 +131,9 @@ void register_exporter_types() {{
     # Extractable translations
     tlist = glob.glob(env.Dir("#editor/translations/extractable").abspath + "/*.po")
     tlist.extend(glob.glob(env.Dir("#editor/translations/extractable").abspath + "/extractable.pot"))
-    env.Depends("#editor/extractable_translations.gen.h", tlist)
+    env.Depends(f"#{env['build_dir']}/editor/extractable_translations.gen.h", tlist)
     env.CommandNoCache(
-        "#editor/extractable_translations.gen.h",
+        f"#{env['build_dir']}/editor/extractable_translations.gen.h",
         tlist,
         env.Run(editor_builders.make_extractable_translations_header),
     )

--- a/editor/icons/SCsub
+++ b/editor/icons/SCsub
@@ -5,6 +5,9 @@ Import("env")
 
 import os
 
+from methods import load_helper_module
+
+load_helper_module("editor_icons_builders", "editor/icons/editor_icons_builders.py")
 import editor_icons_builders
 
 # Editor's own icons
@@ -18,7 +21,7 @@ for path in env.module_icons_paths:
         icon_sources += Glob(f"{path}/*.svg")  # Custom.
 
 env.CommandNoCache(
-    "#editor/themes/editor_icons.gen.h",
+    f"#{env['build_dir']}/editor/themes/editor_icons.gen.h",
     icon_sources,
     env.Run(editor_icons_builders.make_editor_icons_action),
 )

--- a/editor/themes/SCsub
+++ b/editor/themes/SCsub
@@ -5,6 +5,9 @@ Import("env")
 
 import glob
 
+from methods import load_helper_module
+
+load_helper_module("editor_theme_builders", "editor/themes/editor_theme_builders.py")
 import editor_theme_builders
 
 # Fonts
@@ -13,9 +16,9 @@ flist.extend(glob.glob(env.Dir("#thirdparty").abspath + "/fonts/*.otf"))
 flist.extend(glob.glob(env.Dir("#thirdparty").abspath + "/fonts/*.woff"))
 flist.extend(glob.glob(env.Dir("#thirdparty").abspath + "/fonts/*.woff2"))
 flist.sort()
-env.Depends("#editor/themes/builtin_fonts.gen.h", flist)
+env.Depends(f"#{env['build_dir']}/editor/themes/builtin_fonts.gen.h", flist)
 env.CommandNoCache(
-    "#editor/themes/builtin_fonts.gen.h",
+    f"#{env['build_dir']}/editor/themes/builtin_fonts.gen.h",
     flist,
     env.Run(editor_theme_builders.make_fonts_header),
 )

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -3,7 +3,7 @@
 import os.path
 from typing import Optional
 
-from methods import print_error, to_raw_cstring
+from methods import print_error, to_raw_cstring, base_folder_path
 
 
 class GLES3HeaderStruct:
@@ -191,6 +191,7 @@ def include_file_in_gles3_header(filename: str, header_data: GLES3HeaderStruct, 
 
 def build_gles3_header(
     filename: str,
+    env,
     include: str,
     class_suffix: str,
     optional_output_filename: Optional[str] = None,
@@ -203,6 +204,15 @@ def build_gles3_header(
         out_file = filename + ".gen.h"
     else:
         out_file = optional_output_filename
+
+    if env["build_dir"]:
+        if os.path.isabs(out_file):
+            out_file = os.path.relpath(out_file, base_folder_path)
+        out_file = os.path.join(base_folder_path, env["build_dir"], out_file)
+        out_dir = os.path.dirname(out_file)
+        if not os.path.isdir(out_dir):
+            os.makedirs(out_dir)
+
 
     with open(out_file, "w", encoding="utf-8", newline="\n") as fd:
         defspec = 0
@@ -587,4 +597,4 @@ def build_gles3_header(
 def build_gles3_headers(target, source, env):
     env.NoCache(target)
     for x in source:
-        build_gles3_header(str(x), include="drivers/gles3/shader_gles3.h", class_suffix="GLES3")
+        build_gles3_header(str(x), include="drivers/gles3/shader_gles3.h", class_suffix="GLES3", env=env)

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -191,9 +191,9 @@ def include_file_in_gles3_header(filename: str, header_data: GLES3HeaderStruct, 
 
 def build_gles3_header(
     filename: str,
-    env,
     include: str,
     class_suffix: str,
+    env=None,
     optional_output_filename: Optional[str] = None,
     header_data: Optional[GLES3HeaderStruct] = None,
 ):
@@ -205,13 +205,16 @@ def build_gles3_header(
     else:
         out_file = optional_output_filename
 
-    if env["build_dir"]:
-        if os.path.isabs(out_file):
-            out_file = os.path.relpath(out_file, base_folder_path)
-        out_file = os.path.join(base_folder_path, env["build_dir"], out_file)
-        out_dir = os.path.dirname(out_file)
-        if not os.path.isdir(out_dir):
-            os.makedirs(out_dir)
+    if env is not None and env["build_dir"]:
+        build_dir = env["build_dir"]
+    else:
+        build_dir = "build"
+    if os.path.isabs(out_file):
+        out_file = os.path.relpath(out_file, base_folder_path)
+    out_file = os.path.join(base_folder_path, build_dir, out_file)
+    out_dir = os.path.dirname(out_file)
+    if not os.path.isdir(out_dir):
+        os.makedirs(out_dir)
 
     with open(out_file, "w", encoding="utf-8", newline="\n") as fd:
         defspec = 0

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -209,6 +209,7 @@ def build_gles3_header(
         build_dir = env["build_dir"]
     else:
         build_dir = "build"
+
     if os.path.isabs(out_file):
         out_file = os.path.relpath(out_file, base_folder_path)
     out_file = os.path.join(base_folder_path, build_dir, out_file)

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -3,7 +3,7 @@
 import os.path
 from typing import Optional
 
-from methods import print_error, to_raw_cstring, base_folder_path
+from methods import base_folder_path, print_error, to_raw_cstring
 
 
 class GLES3HeaderStruct:
@@ -212,7 +212,6 @@ def build_gles3_header(
         out_dir = os.path.dirname(out_file)
         if not os.path.isdir(out_dir):
             os.makedirs(out_dir)
-
 
     with open(out_file, "w", encoding="utf-8", newline="\n") as fd:
         defspec = 0

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -3,7 +3,7 @@
 import os.path
 from typing import Optional
 
-from methods import print_error, to_raw_cstring
+from methods import print_error, to_raw_cstring, base_folder_path
 
 
 class RDHeaderStruct:
@@ -93,7 +93,7 @@ def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth:
 
 
 def build_rd_header(
-    filename: str, optional_output_filename: Optional[str] = None, header_data: Optional[RDHeaderStruct] = None
+    filename: str, env, optional_output_filename: Optional[str] = None, header_data: Optional[RDHeaderStruct] = None
 ) -> None:
     header_data = header_data or RDHeaderStruct()
     include_file_in_rd_header(filename, header_data, 0)
@@ -102,6 +102,14 @@ def build_rd_header(
         out_file = filename + ".gen.h"
     else:
         out_file = optional_output_filename
+
+    if env["build_dir"]:
+        if os.path.isabs(out_file):
+            out_file = os.path.relpath(out_file, base_folder_path)
+        out_file = os.path.join(base_folder_path, env["build_dir"], out_file)
+        out_dir = os.path.dirname(out_file)
+        if not os.path.isdir(out_dir):
+            os.makedirs(out_dir)
 
     out_file_base = out_file
     out_file_base = out_file_base[out_file_base.rfind("/") + 1 :]
@@ -150,7 +158,7 @@ public:
 def build_rd_headers(target, source, env):
     env.NoCache(target)
     for x in source:
-        build_rd_header(filename=str(x))
+        build_rd_header(filename=str(x), env=env)
 
 
 class RAWHeaderStruct:
@@ -176,7 +184,7 @@ def include_file_in_raw_header(filename: str, header_data: RAWHeaderStruct, dept
 
 
 def build_raw_header(
-    filename: str, optional_output_filename: Optional[str] = None, header_data: Optional[RAWHeaderStruct] = None
+    filename: str, env, optional_output_filename: Optional[str] = None, header_data: Optional[RAWHeaderStruct] = None
 ):
     header_data = header_data or RAWHeaderStruct()
     include_file_in_raw_header(filename, header_data, 0)
@@ -185,6 +193,14 @@ def build_raw_header(
         out_file = filename + ".gen.h"
     else:
         out_file = optional_output_filename
+
+    if env["build_dir"]:
+        if os.path.isabs(out_file):
+            out_file = os.path.relpath(out_file, base_folder_path)
+        out_file = os.path.join(base_folder_path, env["build_dir"], out_file)
+        out_dir = os.path.dirname(out_file)
+        if not os.path.isdir(out_dir):
+            os.makedirs(out_dir)
 
     out_file_base = out_file.replace(".glsl.gen.h", "_shader_glsl")
     out_file_base = out_file_base[out_file_base.rfind("/") + 1 :]
@@ -208,4 +224,4 @@ static const char {out_file_base}[] = {{
 def build_raw_headers(target, source, env):
     env.NoCache(target)
     for x in source:
-        build_raw_header(filename=str(x))
+        build_raw_header(filename=str(x), env=env)

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -3,7 +3,7 @@
 import os.path
 from typing import Optional
 
-from methods import print_error, to_raw_cstring, base_folder_path
+from methods import base_folder_path, print_error, to_raw_cstring
 
 
 class RDHeaderStruct:

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -112,6 +112,7 @@ def build_rd_header(
         build_dir = env["build_dir"]
     else:
         build_dir = "build"
+
     if os.path.isabs(out_file):
         out_file = os.path.relpath(out_file, base_folder_path)
     out_file = os.path.join(base_folder_path, build_dir, out_file)
@@ -209,6 +210,7 @@ def build_raw_header(
         build_dir = env["build_dir"]
     else:
         build_dir = "build"
+
     if os.path.isabs(out_file):
         out_file = os.path.relpath(out_file, base_folder_path)
     out_file = os.path.join(base_folder_path, build_dir, out_file)

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -62,6 +62,8 @@ def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth:
                 else:
                     included_file = os.path.relpath(os.path.dirname(filename) + "/" + includeline)
 
+                included_file = included_file.replace("\\", "/")  # win32
+
                 if included_file not in header_data.vertex_included_files and header_data.reading == "vertex":
                     header_data.vertex_included_files += [included_file]
                     if include_file_in_rd_header(included_file, header_data, depth + 1) is None:
@@ -93,7 +95,10 @@ def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth:
 
 
 def build_rd_header(
-    filename: str, env, optional_output_filename: Optional[str] = None, header_data: Optional[RDHeaderStruct] = None
+    filename: str,
+    env=None,
+    optional_output_filename: Optional[str] = None,
+    header_data: Optional[RDHeaderStruct] = None,
 ) -> None:
     header_data = header_data or RDHeaderStruct()
     include_file_in_rd_header(filename, header_data, 0)
@@ -103,13 +108,16 @@ def build_rd_header(
     else:
         out_file = optional_output_filename
 
-    if env["build_dir"]:
-        if os.path.isabs(out_file):
-            out_file = os.path.relpath(out_file, base_folder_path)
-        out_file = os.path.join(base_folder_path, env["build_dir"], out_file)
-        out_dir = os.path.dirname(out_file)
-        if not os.path.isdir(out_dir):
-            os.makedirs(out_dir)
+    if env is not None and env["build_dir"]:
+        build_dir = env["build_dir"]
+    else:
+        build_dir = "build"
+    if os.path.isabs(out_file):
+        out_file = os.path.relpath(out_file, base_folder_path)
+    out_file = os.path.join(base_folder_path, build_dir, out_file)
+    out_dir = os.path.dirname(out_file)
+    if not os.path.isdir(out_dir):
+        os.makedirs(out_dir)
 
     out_file_base = out_file
     out_file_base = out_file_base[out_file_base.rfind("/") + 1 :]
@@ -184,7 +192,10 @@ def include_file_in_raw_header(filename: str, header_data: RAWHeaderStruct, dept
 
 
 def build_raw_header(
-    filename: str, env, optional_output_filename: Optional[str] = None, header_data: Optional[RAWHeaderStruct] = None
+    filename: str,
+    env=None,
+    optional_output_filename: Optional[str] = None,
+    header_data: Optional[RAWHeaderStruct] = None,
 ):
     header_data = header_data or RAWHeaderStruct()
     include_file_in_raw_header(filename, header_data, 0)
@@ -194,13 +205,16 @@ def build_raw_header(
     else:
         out_file = optional_output_filename
 
-    if env["build_dir"]:
-        if os.path.isabs(out_file):
-            out_file = os.path.relpath(out_file, base_folder_path)
-        out_file = os.path.join(base_folder_path, env["build_dir"], out_file)
-        out_dir = os.path.dirname(out_file)
-        if not os.path.isdir(out_dir):
-            os.makedirs(out_dir)
+    if env is not None and env["build_dir"]:
+        build_dir = env["build_dir"]
+    else:
+        build_dir = "build"
+    if os.path.isabs(out_file):
+        out_file = os.path.relpath(out_file, base_folder_path)
+    out_file = os.path.join(base_folder_path, build_dir, out_file)
+    out_dir = os.path.dirname(out_file)
+    if not os.path.isdir(out_dir):
+        os.makedirs(out_dir)
 
     out_file_base = out_file.replace(".glsl.gen.h", "_shader_glsl")
     out_file_base = out_file_base[out_file_base.rfind("/") + 1 :]

--- a/main/SCsub
+++ b/main/SCsub
@@ -3,6 +3,9 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
+from methods import load_helper_module
+
+load_helper_module("main_builders", "main/main_builders.py")
 import main_builders
 
 env.main_sources = []
@@ -17,9 +20,9 @@ if env["steamapi"] and env.editor_build:
 if env["tests"]:
     env_main.Append(CPPDEFINES=["TESTS_ENABLED"])
 
-env_main.Depends("#main/splash.gen.h", "#main/splash.png")
+env_main.Depends(f"#{env['build_dir']}/main/splash.gen.h", "#main/splash.png")
 env_main.CommandNoCache(
-    "#main/splash.gen.h",
+    f"#{env['build_dir']}/main/splash.gen.h",
     "#main/splash.png",
     env.Run(main_builders.make_splash),
 )
@@ -32,9 +35,9 @@ if env_main.editor_build and not env_main["no_editor_splash"]:
         env.Run(main_builders.make_splash_editor),
     )
 
-env_main.Depends("#main/app_icon.gen.h", "#main/app_icon.png")
+env_main.Depends(f"#{env['build_dir']}/main/app_icon.gen.h", "#main/app_icon.png")
 env_main.CommandNoCache(
-    "#main/app_icon.gen.h",
+    f"#{env['build_dir']}/main/app_icon.gen.h",
     "#main/app_icon.png",
     env.Run(main_builders.make_app_icon),
 )

--- a/methods.py
+++ b/methods.py
@@ -8,11 +8,11 @@ import re
 import subprocess
 import sys
 from collections import OrderedDict
+from importlib.util import module_from_spec, spec_from_file_location
 from io import StringIO, TextIOWrapper
 from pathlib import Path
-from typing import Generator, List, Optional, Union, cast
-from importlib.util import module_from_spec, spec_from_file_location
 from types import ModuleType
+from typing import Generator, List, Optional, Union, cast
 
 from misc.utility.color import print_error, print_info, print_warning
 
@@ -26,7 +26,7 @@ base_folder_only = os.path.basename(os.path.normpath(base_folder_path))
 # folder when doing `import editor.template_builder`)
 
 
-def load_helper_module(name: str, path: str):
+def load_helper_module(name, path):
     if path.startswith("#"):
         path = path[1:]
     if not os.path.isabs(path):
@@ -50,6 +50,7 @@ def load_helper_module(name: str, path: str):
             parent_module = ModuleType(parent_name)
             sys.modules[parent_name] = parent_module
         setattr(parent_module, child_name, child_module)
+
 
 # Listing all the folders we have converted
 # for SCU in scu_builders.py
@@ -79,7 +80,7 @@ def add_source_files_orig(self, sources, files, allow_gen=False):
         if os.path.isabs(target_path):
             target_path = os.path.relpath(target_path, base_folder_path)
         target_path = os.path.join(base_folder_path, self["build_dir"], target_path)
-        target_path = '.'.join(target_path.split('.')[:-1]) + self["OBJSUFFIX"]
+        target_path = ".".join(target_path.split(".")[:-1]) + self["OBJSUFFIX"]
         obj = self.Object(target=target_path, source=path)
         if obj in sources:
             print_warning('Object "{}" already included in environment sources.'.format(obj))

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -39,7 +39,7 @@ def register_module_types_builder(target, source, env):
     with methods.generated_wrapper(target) as file:
         file.write(
             f"""\
-#include "register_module_types.h"
+#include "modules/register_module_types.h"
 
 #include "modules/modules_enabled.gen.h"
 

--- a/modules/betsy/SCsub
+++ b/modules/betsy/SCsub
@@ -1,15 +1,21 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
+from glob import glob
 
 Import("env")
 Import("env_modules")
 
 env_betsy = env_modules.Clone()
-env_betsy.GLSL_HEADER("bc6h.glsl")
-env_betsy.GLSL_HEADER("bc1.glsl")
-env_betsy.GLSL_HEADER("bc4.glsl")
-env_betsy.GLSL_HEADER("alpha_stitch.glsl")
-env_betsy.Depends(Glob("*.glsl.gen.h"), ["#glsl_builders.py"])
+
+shader_files = ["alpha_stitch.glsl", "bc1.glsl", "bc4.glsl", "bc6h.glsl"]
+for file in shader_files:
+    env_betsy.GLSL_HEADER(f"#modules/betsy/{file}")
+env_betsy.Depends(
+    Glob(f"#{env['build_dir']}/modules/betsy/*.glsl.gen.h"),
+    ["#glsl_builders.py"]
+)
+
+env_betsy.Append(CPPPATH=[f"#{env['build_dir']}/modules/betsy"])
 
 # Thirdparty source files
 thirdparty_obj = []

--- a/modules/betsy/SCsub
+++ b/modules/betsy/SCsub
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
-from glob import glob
 
 Import("env")
 Import("env_modules")
@@ -10,10 +9,7 @@ env_betsy = env_modules.Clone()
 shader_files = ["alpha_stitch.glsl", "bc1.glsl", "bc4.glsl", "bc6h.glsl"]
 for file in shader_files:
     env_betsy.GLSL_HEADER(f"#modules/betsy/{file}")
-env_betsy.Depends(
-    Glob(f"#{env['build_dir']}/modules/betsy/*.glsl.gen.h"),
-    ["#glsl_builders.py"]
-)
+env_betsy.Depends(Glob(f"#{env['build_dir']}/modules/betsy/*.glsl.gen.h"), ["#glsl_builders.py"])
 
 env_betsy.Append(CPPPATH=[f"#{env['build_dir']}/modules/betsy"])
 

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -8,7 +8,7 @@ env_freetype = env_modules.Clone()
 
 # Thirdparty source files
 
-thirdparty_obj = []
+thirdparty_lib = []
 
 if env["builtin_freetype"]:
     thirdparty_dir = "#thirdparty/freetype/"
@@ -72,6 +72,7 @@ if env["builtin_freetype"]:
     if env["builtin_libpng"]:
         env_freetype.Prepend(CPPPATH=["#thirdparty/libpng"])
 
+    thirdparty_obj = []
     sfnt = thirdparty_dir + "src/sfnt/sfnt.c"
     # Must be done after all CPPDEFINES are being set so we can copy them.
     if env["platform"] == "web":
@@ -80,13 +81,15 @@ if env["builtin_freetype"]:
         tmp_env = env_freetype.Clone()
         tmp_env.disable_warnings()
         tmp_env.Append(CPPFLAGS=["-U__OPTIMIZE__"])
-        sfnt = tmp_env.Object(sfnt)
-    thirdparty_sources += [sfnt]
+        tmp_env.add_source_files(thirdparty_obj, sfnt)
+    else:
+        thirdparty_sources += [sfnt]
 
     env_thirdparty = env_freetype.Clone()
     env_thirdparty.disable_warnings()
-    lib = env_thirdparty.add_library("freetype_builtin", thirdparty_sources)
-    thirdparty_obj += lib
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    lib = env_thirdparty.add_library("freetype_builtin", thirdparty_obj)
+    thirdparty_lib += lib
 
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack
@@ -110,4 +113,4 @@ env_freetype.add_source_files(module_obj, "*.cpp")
 env.modules_sources += module_obj
 
 # Needed to force rebuilding the module files when the thirdparty library is updated.
-env.Depends(module_obj, thirdparty_obj)
+env.Depends(module_obj, thirdparty_lib)

--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -7,6 +7,7 @@ Import("env_modules")
 env_gdscript = env_modules.Clone()
 
 env_gdscript.add_source_files(env.modules_sources, "*.cpp")
+env_gdscript.Append(CPPPATH=[f"#{env['build_dir']}/modules/gdscript/"])
 
 if env.editor_build:
     env_gdscript.add_source_files(env.modules_sources, "./editor/*.cpp")

--- a/modules/lightmapper_rd/SCsub
+++ b/modules/lightmapper_rd/SCsub
@@ -10,8 +10,7 @@ for file in shader_files:
     env_lightmapper_rd.GLSL_HEADER(f"#modules/lightmapper_rd/{file}")
 
 env_lightmapper_rd.Depends(
-    Glob(f"#{env['build_dir']}/modules/lightmapper_rd/*.glsl.gen.h"),
-    ["lm_common_inc.glsl", "#glsl_builders.py"]
+    Glob(f"#{env['build_dir']}/modules/lightmapper_rd/*.glsl.gen.h"), ["lm_common_inc.glsl", "#glsl_builders.py"]
 )
 env_lightmapper_rd.Append(CPPPATH=[f"#{env['build_dir']}/modules/lightmapper_rd"])
 

--- a/modules/lightmapper_rd/SCsub
+++ b/modules/lightmapper_rd/SCsub
@@ -5,10 +5,15 @@ Import("env")
 Import("env_modules")
 
 env_lightmapper_rd = env_modules.Clone()
-env_lightmapper_rd.GLSL_HEADER("lm_raster.glsl")
-env_lightmapper_rd.GLSL_HEADER("lm_compute.glsl")
-env_lightmapper_rd.GLSL_HEADER("lm_blendseams.glsl")
-env_lightmapper_rd.Depends(Glob("*.glsl.gen.h"), ["lm_common_inc.glsl", "#glsl_builders.py"])
+shader_files = ["lm_raster.glsl", "lm_compute.glsl", "lm_blendseams.glsl"]
+for file in shader_files:
+    env_lightmapper_rd.GLSL_HEADER(f"#modules/lightmapper_rd/{file}")
+
+env_lightmapper_rd.Depends(
+    Glob(f"#{env['build_dir']}/modules/lightmapper_rd/*.glsl.gen.h"),
+    ["lm_common_inc.glsl", "#glsl_builders.py"]
+)
+env_lightmapper_rd.Append(CPPPATH=[f"#{env['build_dir']}/modules/lightmapper_rd"])
 
 # Godot source files
 env_lightmapper_rd.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/msdfgen/SCsub
+++ b/modules/msdfgen/SCsub
@@ -8,7 +8,7 @@ env_msdfgen = env_modules.Clone()
 
 # Thirdparty source files
 
-thirdparty_obj = []
+thirdparty_lib = []
 
 if env["builtin_msdfgen"]:
     env_msdfgen.disable_warnings()
@@ -44,8 +44,10 @@ if env["builtin_msdfgen"]:
     env_msdfgen.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
     env_msdfgen.Prepend(CPPPATH=["#thirdparty/freetype/include", "#thirdparty/msdfgen", "#thirdparty/nanosvg"])
 
-    lib = env_msdfgen.add_library("msdfgen_builtin", thirdparty_sources)
-    thirdparty_obj += lib
+    thirdparty_obj = []
+    env_msdfgen.add_source_files(thirdparty_obj, thirdparty_sources)
+    lib = env_msdfgen.add_library("msdfgen_builtin", thirdparty_obj)
+    thirdparty_lib += lib
 
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack
@@ -69,4 +71,4 @@ env_msdfgen.add_source_files(module_obj, "*.cpp")
 env.modules_sources += module_obj
 
 # Needed to force rebuilding the module files when the thirdparty library is updated.
-env.Depends(module_obj, thirdparty_obj)
+env.Depends(module_obj, thirdparty_lib)

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -486,7 +486,7 @@ if env["builtin_icu4c"]:
         env_icu.CommandNoCache(
             f"#{env['build_dir']}/thirdparty/icu4c/icudata.gen.h",
             "#thirdparty/icu4c/icudt_godot.dat",
-            env.Run(make_icu_data)
+            env.Run(make_icu_data),
         )
         env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/", f"#{env['build_dir']}/thirdparty/icu4c"])
     else:

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -34,7 +34,7 @@ def make_icu_data(target, source, env):
 
 # Thirdparty source files
 
-thirdparty_obj = []
+thirdparty_lib = []
 freetype_enabled = "freetype" in env.module_list
 msdfgen_enabled = "msdfgen" in env.module_list
 
@@ -177,8 +177,10 @@ if env["builtin_harfbuzz"]:
 
     env_text_server_adv.Prepend(CPPPATH=["#thirdparty/harfbuzz/src"])
 
-    lib = env_harfbuzz.add_library("harfbuzz_builtin", thirdparty_sources)
-    thirdparty_obj += lib
+    thirdparty_obj = []
+    env_harfbuzz.add_source_files(thirdparty_obj, thirdparty_sources)
+    lib = env_harfbuzz.add_library("harfbuzz_builtin", thirdparty_obj)
+    thirdparty_lib += lib
 
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack
@@ -247,8 +249,10 @@ if env["builtin_graphite"] and freetype_enabled and env["graphite"]:
         ]
     )
 
-    lib = env_graphite.add_library("graphite_builtin", thirdparty_sources)
-    thirdparty_obj += lib
+    thirdparty_obj = []
+    env_graphite.add_source_files(thirdparty_obj, thirdparty_sources)
+    lib = env_graphite.add_library("graphite_builtin", thirdparty_obj)
+    thirdparty_lib += lib
 
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack
@@ -480,9 +484,11 @@ if env["builtin_icu4c"]:
 
     if env.editor_build:
         env_icu.CommandNoCache(
-            "#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/icudt_godot.dat", env.Run(make_icu_data)
+            f"#{env['build_dir']}/thirdparty/icu4c/icudata.gen.h",
+            "#thirdparty/icu4c/icudt_godot.dat",
+            env.Run(make_icu_data)
         )
-        env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/"])
+        env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/", f"#{env['build_dir']}/thirdparty/icu4c"])
     else:
         thirdparty_sources += ["icu_data/icudata_stub.cpp"]
 
@@ -517,8 +523,10 @@ if env["builtin_icu4c"]:
 
     env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
 
-    lib = env_icu.add_library("icu_builtin", thirdparty_sources)
-    thirdparty_obj += lib
+    thirdparty_obj = []
+    env_icu.add_source_files(thirdparty_obj, thirdparty_sources)
+    lib = env_icu.add_library("icu_builtin", thirdparty_obj)
+    thirdparty_lib += lib
 
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack
@@ -557,4 +565,4 @@ env_text_server_adv.add_source_files(module_obj, "*.cpp")
 env.modules_sources += module_obj
 
 # Needed to force rebuilding the module files when the thirdparty library is updated.
-env.Depends(module_obj, thirdparty_obj)
+env.Depends(module_obj, thirdparty_lib)

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
 
-from glob import glob
-from pathlib import Path
 import os.path
+from pathlib import Path
 
 import methods
 

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -3,6 +3,7 @@ from misc.utility.scons_hints import *
 
 from glob import glob
 from pathlib import Path
+import os.path
 
 import methods
 
@@ -27,20 +28,22 @@ static const char *_{platform}_{src_name}_svg = {methods.to_raw_cstring(svg)};
 
 
 for platform in env.platform_exporters:
-    for path in glob(f"{platform}/export/*.svg"):
-        env.CommandNoCache(path.replace(".svg", "_svg.gen.h"), path, env.Run(export_icon_builder))
+    for path in Glob(f"#/platform/{platform}/export/*.svg"):
+        rel_path = os.path.relpath(str(path), env.Dir("#").abspath)
+        target_path = os.path.join(env.Dir("#").abspath, env["build_dir"], rel_path)
+        env.CommandNoCache(target_path.replace(".svg", "_svg.gen.h"), path, env.Run(export_icon_builder))
 
 
 # Register platform-exclusive APIs
 def register_platform_apis_builder(target, source, env):
     platforms = source[0].read()
-    api_inc = "\n".join([f'#include "{p}/api/api.h"' for p in platforms])
+    api_inc = "\n".join([f'#include "platform/{p}/api/api.h"' for p in platforms])
     api_reg = "\n".join([f"\tregister_{p}_api();" for p in platforms])
     api_unreg = "\n".join([f"\tunregister_{p}_api();" for p in platforms])
     with methods.generated_wrapper(target) as file:
         file.write(
             f"""\
-#include "register_platform_apis.h"
+#include "platform/register_platform_apis.h"
 
 {api_inc}
 

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -3,6 +3,9 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
+from methods import load_helper_module
+
+load_helper_module("platform_linuxbsd_builders", "platform/linuxbsd/platform_linuxbsd_builders.py")
 import platform_linuxbsd_builders
 
 common_linuxbsd = [

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -7,6 +7,9 @@ import os
 import shutil
 import subprocess
 
+from methods import load_helper_module
+
+load_helper_module("platform_macos_builders", "platform/macos/platform_macos_builders.py")
 import platform_macos_builders
 
 from platform_methods import get_build_version, lipo

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -6,6 +6,9 @@ Import("env")
 import os
 from pathlib import Path
 
+from methods import load_helper_module
+
+load_helper_module("platform_windows_builders", "platform/windows/platform_windows_builders.py")
 import platform_windows_builders
 
 sources = []
@@ -52,8 +55,9 @@ def arrange_program_clean(prog):
 res_file = "godot_res.rc"
 res_target = "godot_res" + env["OBJSUFFIX"]
 res_obj = env.RES(res_target, res_file)
-env.Depends(res_obj, "#core/version_generated.gen.h")
+env.Depends(res_obj, f"#{env['build_dir']}/core/version_generated.gen.h")
 
+common_win = [f"#platform/windows/{f}" for f in common_win]
 env.add_source_files(sources, common_win)
 sources += res_obj
 
@@ -69,7 +73,7 @@ if env["windows_subsystem"] == "gui":
     res_wrap_file = "godot_res_wrap.rc"
     res_wrap_target = "godot_res_wrap" + env["OBJSUFFIX"]
     res_wrap_obj = env_wrap.RES(res_wrap_target, res_wrap_file)
-    env_wrap.Depends(res_wrap_obj, "#core/version_generated.gen.h")
+    env_wrap.Depends(res_wrap_obj, f"#{env['build_dir']}/core/version_generated.gen.h")
 
     if env.msvc:
         env_wrap.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])

--- a/scene/theme/SCsub
+++ b/scene/theme/SCsub
@@ -3,15 +3,20 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
+from methods import load_helper_module
+
+load_helper_module("default_theme_builders", "scene/theme/default_theme_builders.py")
 import default_theme_builders
 
-env.add_source_files(env.scene_sources, "*.cpp")
+env_scene_theme = env.Clone()
+env_scene_theme.add_source_files(env.scene_sources, "*.cpp")
 
 SConscript("icons/SCsub")
 
-env.Depends("#scene/theme/default_font.gen.h", "#thirdparty/fonts/OpenSans_SemiBold.woff2")
-env.CommandNoCache(
-    "#scene/theme/default_font.gen.h",
+env_scene_theme.Append(CPPPATH=[f"#{env['build_dir']}/scene/theme"])
+env_scene_theme.Depends(f"#{env['build_dir']}/scene/theme/default_font.gen.h", "#thirdparty/fonts/OpenSans_SemiBold.woff2")
+env_scene_theme.CommandNoCache(
+    f"#{env['build_dir']}/scene/theme/default_font.gen.h",
     "#thirdparty/fonts/OpenSans_SemiBold.woff2",
     env.Run(default_theme_builders.make_fonts_header),
 )

--- a/scene/theme/SCsub
+++ b/scene/theme/SCsub
@@ -14,7 +14,9 @@ env_scene_theme.add_source_files(env.scene_sources, "*.cpp")
 SConscript("icons/SCsub")
 
 env_scene_theme.Append(CPPPATH=[f"#{env['build_dir']}/scene/theme"])
-env_scene_theme.Depends(f"#{env['build_dir']}/scene/theme/default_font.gen.h", "#thirdparty/fonts/OpenSans_SemiBold.woff2")
+env_scene_theme.Depends(
+    f"#{env['build_dir']}/scene/theme/default_font.gen.h", "#thirdparty/fonts/OpenSans_SemiBold.woff2"
+)
 env_scene_theme.CommandNoCache(
     f"#{env['build_dir']}/scene/theme/default_font.gen.h",
     "#thirdparty/fonts/OpenSans_SemiBold.woff2",

--- a/scene/theme/icons/SCsub
+++ b/scene/theme/icons/SCsub
@@ -3,10 +3,13 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
+from methods import load_helper_module
+
+load_helper_module("default_theme_icons_builders", "scene/theme/icons/default_theme_icons_builders.py")
 import default_theme_icons_builders
 
 env.CommandNoCache(
-    "#scene/theme/default_theme_icons.gen.h",
+    f"#{env['build_dir']}/scene/theme/default_theme_icons.gen.h",
     Glob("*.svg"),
     env.Run(default_theme_icons_builders.make_default_theme_icons_action),
 )

--- a/tests/python_build/conftest.py
+++ b/tests/python_build/conftest.py
@@ -13,10 +13,10 @@ sys.path.append(str(ROOT))
 @pytest.fixture
 def shader_files(request):
     shader_path = request.param
-
+    base_folder_path = Path(os.path.join(CWD, "../.."))
     res = {
         "path_input": str(CWD / "fixtures" / f"{shader_path}.glsl"),
-        "path_output": str(CWD / "fixtures" / f"{shader_path}.glsl.gen.h"),
+        "path_output": str(base_folder_path / "build/tests/python_build/fixtures" / f"{shader_path}.glsl.gen.h"),
         "path_expected_full": str(CWD / "fixtures" / f"{shader_path}_expected_full.glsl"),
         "path_expected_parts": str(CWD / "fixtures" / f"{shader_path}_expected_parts.json"),
     }


### PR DESCRIPTION
This PR adds a "build_dir" option (default: build) in the SCons build environment. It will output all the build artifacts generated during compilation in the build directory. 

This will help to reduce clutter in the file explorer while working on the project.
