### PR TITLE
Fold resources when object is unedited

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -4870,6 +4870,18 @@ void EditorInspector::_clear(bool p_hide_plugins) {
 		memdelete(favorites_groups_vbox->get_child(0));
 	}
 
+	if (p_hide_plugins) {
+		for (KeyValue<StringName, List<EditorProperty *>> &F : editor_property_map) {
+			for (EditorProperty *property : F.value) {
+				// Circumvent special case that makes the Resource property not folding.
+				EditorPropertyResource *ep = Object::cast_to<EditorPropertyResource>(property);
+				if (ep) {
+					ep->fold_resource();
+				}
+			}
+		}
+	}
+
 	while (main_vbox->get_child_count()) {
 		memdelete(main_vbox->get_child(0));
 	}


### PR DESCRIPTION
Closes #99772
Closes #100152

However this has a side-effect of always closing resources when node is deselected.

https://github.com/user-attachments/assets/e7a589c3-efb3-4625-a01d-676248452984

The shader editor was opening, because Shader stayed unfolded when switching nodes. This is the only way to fix it, other than reworking how resources are edited.