### PR TITLE
Fix slow resize Embedded Game Window

### DIFF
--- a/editor/plugins/embedded_process.h
+++ b/editor/plugins/embedded_process.h
@@ -48,6 +48,7 @@ class EmbeddedProcess : public Control {
 
 	Window *window = nullptr;
 	Timer *timer_embedding = nullptr;
+	Timer *timer_update_embedded_process = nullptr;
 
 	const int embedding_timeout = 45000;
 
@@ -61,6 +62,7 @@ class EmbeddedProcess : public Control {
 	void _try_embed_process();
 	void _update_embedded_process();
 	void _timer_embedding_timeout();
+	void _timer_update_embedded_process_timeout();
 	void _draw();
 	void _check_mouse_over();
 	void _check_focused_process_id();

--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -977,6 +977,11 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, WindowWrapper *p_wrapper) {
 	game_size_label = memnew(Label());
 	main_menu_hbox->add_child(game_size_label);
 	game_size_label->hide();
+	// Setting the minimum size prevents the game workspace from resizing indefinitely
+	// due to the label size oscillating by a few pixels when the game is in stretch mode
+	// and the game workspace is at its minimum size.
+	game_size_label->set_custom_minimum_size(Size2(80 * EDSCALE, 0));
+	game_size_label->set_horizontal_alignment(HorizontalAlignment::HORIZONTAL_ALIGNMENT_RIGHT);
 
 	panel = memnew(Panel);
 	add_child(panel);


### PR DESCRIPTION
- Fixes #102197

After some testing the performance issue was caused by the `NOTIFICATION_PROCESS` and `NOTIFICATION_RESIZED` which triggered a deferred call to `EmbeddedProcess::_update_embedded_process` each frame which was really unnecessarily. This helps the Floating Window but also the Editor Window when resizing the window or docks.

Using a timer to update the embedded window less frequently seems to work fine. At the same time, I was able to remove the `NOTIFICATION_PROCESS` from the `EmbeddedProcess` control which always bothered me.

Note: It does not affect the re-rendering of the game but rather the unresponsiveness of the window.

Note 2: There's an issue actually when resizing the game window, sometime, it stop resizing and focuses the game window. This was fixed in #102247.