### PR TITLE
[Windows] Fix build with MinGW 8.0.0-1.

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -55,6 +55,7 @@ typedef interface IAudioClient3 IAudioClient3;
 #ifndef __IAudioClient3_INTERFACE_DEFINED__
 #define __IAudioClient3_INTERFACE_DEFINED__
 
+// clang-format off
 MIDL_INTERFACE("7ED4EE07-8E67-4CD4-8C1A-2B7A5987AD42")
 IAudioClient3 : public IAudioClient2 {
 public:
@@ -85,7 +86,8 @@ public:
 			_In_ const WAVEFORMATEX *pFormat,
 			/* [annotation][in] */
 			_In_opt_ LPCGUID AudioSessionGuid) = 0;
-}
+};
+// clang-format on
 __CRT_UUID_DECL(IAudioClient3, 0x7ED4EE07, 0x8E67, 0x4CD4, 0x8C, 0x1A, 0x2B, 0x7A, 0x59, 0x87, 0xAD, 0x42)
 
 #endif // __IAudioClient3_INTERFACE_DEFINED__


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/102228
Fixes https://github.com/godotengine/godot/issues/98822 (for the reference, it's already closed, but only part was fixed before)

Not sure why this caused issues with old MinGW, but changes in clang format rules, and removal of this `;` broke the build.

Reproducible on Ubuntu 22.04, with MinGW 8.0.0-1 / GCC 10. Not reproducible with recent MinGW versions.