### PR TITLE
Fix Error when connecting signal with unbinds not yet existing function

### DIFF
--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1001,13 +1001,6 @@ void ConnectionsDock::_make_or_edit_connection() {
 		}
 	}
 
-	if (connect_dialog->is_editing()) {
-		_disconnect(connect_dialog->get_source_connection_data());
-		_connect(cd);
-	} else {
-		_connect(cd);
-	}
-
 	if (add_script_function_request) {
 		PackedStringArray script_function_args = connect_dialog->get_signal_args();
 		script_function_args.resize(script_function_args.size() - cd.unbinds);
@@ -1055,6 +1048,13 @@ void ConnectionsDock::_make_or_edit_connection() {
 		}
 
 		EditorNode::get_singleton()->emit_signal(SNAME("script_add_function_request"), target, cd.method, script_function_args);
+	}
+
+	if (connect_dialog->is_editing()) {
+		_disconnect(connect_dialog->get_source_connection_data());
+		_connect(cd);
+	} else {
+		_connect(cd);
 	}
 
 	update_tree();


### PR DESCRIPTION
Fixes #102007 Fixes #107606

When a Signal with unbinds was connected to a non-existing function, the connection attempt was made before the function was created.

I moved the creation of the function in front of the connection attempt.


I did not write Unit Tests, because as far as I can see, they would involve the Script Editor.
