### PR TITLE
Track mesh dependencies in Dummy RenderingServer

### DIFF
--- a/servers/rendering/dummy/storage/mesh_storage.cpp
+++ b/servers/rendering/dummy/storage/mesh_storage.cpp
@@ -53,13 +53,14 @@ void MeshStorage::mesh_initialize(RID p_rid) {
 void MeshStorage::mesh_free(RID p_rid) {
 	DummyMesh *mesh = mesh_owner.get_or_null(p_rid);
 	ERR_FAIL_NULL(mesh);
-
+	mesh->dependency.deleted_notify(p_rid);
 	mesh_owner.free(p_rid);
 }
 
 void MeshStorage::mesh_surface_remove(RID p_mesh, int p_surface) {
 	DummyMesh *m = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(m);
+	m->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MESH);
 	m->surfaces.remove_at(p_surface);
 }
 

--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -36,16 +36,17 @@
 
 namespace RendererDummy {
 
+struct DummyMesh {
+	Vector<RS::SurfaceData> surfaces;
+	int blend_shape_count;
+	RS::BlendShapeMode blend_shape_mode;
+	PackedFloat32Array blend_shape_values;
+	Dependency dependency;
+};
+
 class MeshStorage : public RendererMeshStorage {
 private:
 	static MeshStorage *singleton;
-
-	struct DummyMesh {
-		Vector<RS::SurfaceData> surfaces;
-		int blend_shape_count;
-		RS::BlendShapeMode blend_shape_mode;
-		PackedFloat32Array blend_shape_values;
-	};
 
 	mutable RID_Owner<DummyMesh> mesh_owner;
 
@@ -62,7 +63,7 @@ public:
 	~MeshStorage();
 
 	/* MESH API */
-
+	DummyMesh *get_mesh(RID p_rid) { return mesh_owner.get_or_null(p_rid); }
 	bool owns_mesh(RID p_rid) { return mesh_owner.owns(p_rid); }
 
 	virtual RID mesh_allocate() override;
@@ -92,6 +93,7 @@ public:
 		s->blend_shape_data = p_surface.blend_shape_data;
 		s->uv_scale = p_surface.uv_scale;
 		s->material = p_surface.material;
+		m->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MESH);
 	}
 
 	virtual int mesh_get_blend_shape_count(RID p_mesh) const override { return 0; }

--- a/servers/rendering/dummy/storage/utilities.cpp
+++ b/servers/rendering/dummy/storage/utilities.cpp
@@ -30,9 +30,54 @@
 
 #include "utilities.h"
 
+#include "light_storage.h"
+#include "material_storage.h"
+#include "mesh_storage.h"
+#include "texture_storage.h"
+
 using namespace RendererDummy;
 
 Utilities *Utilities::singleton = nullptr;
+
+RS::InstanceType Utilities::get_base_type(RID p_rid) const {
+	if (RendererDummy::MeshStorage::get_singleton()->owns_mesh(p_rid)) {
+		return RS::INSTANCE_MESH;
+	} else if (RendererDummy::MeshStorage::get_singleton()->owns_multimesh(p_rid)) {
+		return RS::INSTANCE_MULTIMESH;
+	} else if (RendererDummy::LightStorage::get_singleton()->owns_lightmap(p_rid)) {
+		return RS::INSTANCE_LIGHTMAP;
+	}
+	return RS::INSTANCE_NONE;
+}
+
+bool Utilities::free(RID p_rid) {
+	if (RendererDummy::LightStorage::get_singleton()->free(p_rid)) {
+		return true;
+	} else if (RendererDummy::TextureStorage::get_singleton()->owns_texture(p_rid)) {
+		RendererDummy::TextureStorage::get_singleton()->texture_free(p_rid);
+		return true;
+	} else if (RendererDummy::MeshStorage::get_singleton()->owns_mesh(p_rid)) {
+		RendererDummy::MeshStorage::get_singleton()->mesh_free(p_rid);
+		return true;
+	} else if (RendererDummy::MeshStorage::get_singleton()->owns_multimesh(p_rid)) {
+		RendererDummy::MeshStorage::get_singleton()->multimesh_free(p_rid);
+		return true;
+	} else if (RendererDummy::MaterialStorage::get_singleton()->owns_shader(p_rid)) {
+		RendererDummy::MaterialStorage::get_singleton()->shader_free(p_rid);
+		return true;
+	} else if (RendererDummy::MaterialStorage::get_singleton()->owns_material(p_rid)) {
+		RendererDummy::MaterialStorage::get_singleton()->material_free(p_rid);
+		return true;
+	}
+	return false;
+}
+
+void Utilities::base_update_dependency(RID p_base, DependencyTracker *p_instance) {
+	if (RendererDummy::MeshStorage::get_singleton()->owns_mesh(p_base)) {
+		DummyMesh *mesh = RendererDummy::MeshStorage::get_singleton()->get_mesh(p_base);
+		p_instance->update_dependency(&mesh->dependency);
+	}
+}
 
 Utilities::Utilities() {
 	singleton = this;

--- a/servers/rendering/dummy/storage/utilities.h
+++ b/servers/rendering/dummy/storage/utilities.h
@@ -31,11 +31,7 @@
 #ifndef UTILITIES_DUMMY_H
 #define UTILITIES_DUMMY_H
 
-#include "light_storage.h"
-#include "material_storage.h"
-#include "mesh_storage.h"
 #include "servers/rendering/storage/utilities.h"
-#include "texture_storage.h"
 
 namespace RendererDummy {
 
@@ -51,42 +47,12 @@ public:
 
 	/* INSTANCES */
 
-	virtual RS::InstanceType get_base_type(RID p_rid) const override {
-		if (RendererDummy::MeshStorage::get_singleton()->owns_mesh(p_rid)) {
-			return RS::INSTANCE_MESH;
-		} else if (RendererDummy::MeshStorage::get_singleton()->owns_multimesh(p_rid)) {
-			return RS::INSTANCE_MULTIMESH;
-		} else if (RendererDummy::LightStorage::get_singleton()->owns_lightmap(p_rid)) {
-			return RS::INSTANCE_LIGHTMAP;
-		}
-		return RS::INSTANCE_NONE;
-	}
-
-	virtual bool free(RID p_rid) override {
-		if (RendererDummy::LightStorage::get_singleton()->free(p_rid)) {
-			return true;
-		} else if (RendererDummy::TextureStorage::get_singleton()->owns_texture(p_rid)) {
-			RendererDummy::TextureStorage::get_singleton()->texture_free(p_rid);
-			return true;
-		} else if (RendererDummy::MeshStorage::get_singleton()->owns_mesh(p_rid)) {
-			RendererDummy::MeshStorage::get_singleton()->mesh_free(p_rid);
-			return true;
-		} else if (RendererDummy::MeshStorage::get_singleton()->owns_multimesh(p_rid)) {
-			RendererDummy::MeshStorage::get_singleton()->multimesh_free(p_rid);
-			return true;
-		} else if (RendererDummy::MaterialStorage::get_singleton()->owns_shader(p_rid)) {
-			RendererDummy::MaterialStorage::get_singleton()->shader_free(p_rid);
-			return true;
-		} else if (RendererDummy::MaterialStorage::get_singleton()->owns_material(p_rid)) {
-			RendererDummy::MaterialStorage::get_singleton()->material_free(p_rid);
-			return true;
-		}
-		return false;
-	}
+	virtual RS::InstanceType get_base_type(RID p_rid) const override;
+	virtual bool free(RID p_rid) override;
 
 	/* DEPENDENCIES */
 
-	virtual void base_update_dependency(RID p_base, DependencyTracker *p_instance) override {}
+	virtual void base_update_dependency(RID p_base, DependencyTracker *p_instance) override;
 
 	/* VISIBILITY NOTIFIER */
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/86806

The root of the problem here is that there is that the mesh is getting freed before the MeshInstance. When the MeshInstance is freed, it has to flush pending updates. In that update it attempts to read info from the mesh, but the mesh is already freed. The solution is to use the dependency tracking system that already exists for this purpose. 

~This PR only solves the problem for MeshInstance/Mesh, but the problem exists for all the VisualInstance derived nodes.~ I checked out the other node types quickly and I can't recreate the problem with them. Most likely since their dependencies are of a different nature