### PR TITLE
Add an option to capture scene thumbnails with fixed view

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -222,6 +222,11 @@
 		</member>
 		<member name="docks/filesystem/thumbnail_size" type="int" setter="" getter="">
 			The thumbnail size to use in the FileSystem dock (in pixels). See also [member filesystem/file_dialog/thumbnail_size].
+		<member name="docks/filesystem/scene_thumbnail_capture_method" type="int" setter="" getter="">
+			Controls how scene file (.tscn, .scn) thumbnail images will be captured.
+			- [b]Free[/b]: Use the current viewport view
+			- [b]Fixed[/b]: Fit all visual instances into view, also use a fixed angle to capture
+		</member>
 		</member>
 		<member name="docks/property_editor/auto_refresh_interval" type="float" setter="" getter="">
 			The refresh interval to use for the Inspector dock's properties. The effect of this setting is mainly noticeable when adjusting gizmos in the 2D/3D editor and looking at the inspector at the same time. Lower values make the inspector refresh more often, but take up more CPU time.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -217,16 +217,16 @@
 		<member name="docks/filesystem/other_file_extensions" type="String" setter="" getter="">
 			A comma separated list of unsupported file extensions to show in the FileSystem dock, e.g. [code]"ico,icns"[/code].
 		</member>
-		<member name="docks/filesystem/textfile_extensions" type="String" setter="" getter="">
-			A comma separated list of file extensions to consider as editable text files in the FileSystem dock (by double-clicking on the files), e.g. [code]"txt,md,cfg,ini,log,json,yml,yaml,toml,xml"[/code].
-		</member>
-		<member name="docks/filesystem/thumbnail_size" type="int" setter="" getter="">
-			The thumbnail size to use in the FileSystem dock (in pixels). See also [member filesystem/file_dialog/thumbnail_size].
 		<member name="docks/filesystem/scene_thumbnail_capture_method" type="int" setter="" getter="">
 			Controls how scene file (.tscn, .scn) thumbnail images will be captured.
 			- [b]Free[/b]: Use the current viewport view
 			- [b]Fixed[/b]: Fit all visual instances into view, also use a fixed angle to capture
 		</member>
+		<member name="docks/filesystem/textfile_extensions" type="String" setter="" getter="">
+			A comma separated list of file extensions to consider as editable text files in the FileSystem dock (by double-clicking on the files), e.g. [code]"txt,md,cfg,ini,log,json,yml,yaml,toml,xml"[/code].
+		</member>
+		<member name="docks/filesystem/thumbnail_size" type="int" setter="" getter="">
+			The thumbnail size to use in the FileSystem dock (in pixels). See also [member filesystem/file_dialog/thumbnail_size].
 		</member>
 		<member name="docks/property_editor/auto_refresh_interval" type="float" setter="" getter="">
 			The refresh interval to use for the Inspector dock's properties. The effect of this setting is mainly noticeable when adjusting gizmos in the 2D/3D editor and looking at the inspector at the same time. Lower values make the inspector refresh more often, but take up more CPU time.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1769,24 +1769,30 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			// The preview will be generated if no feature profile is set (as the 3D editor is enabled by default).
 			Ref<EditorFeatureProfile> profile = feature_profile_manager->get_current_profile();
 			if (profile.is_null() || !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D)) {
-				Camera3D *vpcam = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_camera_3d();
-				Transform3D prev_trans_3d = vpcam->get_transform();
-				
-				// Move camera to fit 3d scene
-				AABB scene_aabb = AABB();
-				_calculate_aabb_merged(editor_data.get_edited_scene_root(), scene_aabb);
-				Vector3 scene_center = scene_aabb.get_center();
-				Transform3D thumbnail_cam_trans_3d = Transform3D();
-				float bound_sphere_radius = scene_aabb.get_longest_axis_size() / 2.0f;
-				float cam_distance = (bound_sphere_radius * 2.0f ) / Math::tan(vpcam->get_fov() / 2.0f);
-				thumbnail_cam_trans_3d.set_origin(scene_center + Vector3(1.0f, 0.25f, 1.0f).normalized() * cam_distance);
-				thumbnail_cam_trans_3d.set_look_at(thumbnail_cam_trans_3d.origin, scene_center);
-				RenderingServer::get_singleton()->camera_set_transform(vpcam->get_camera(), thumbnail_cam_trans_3d);
-				RenderingServer::get_singleton()->draw(false); // Redraw without glitching the viewport
+				if (int(EDITOR_GET("docks/filesystem/scene_thumbnail_capture_method")) == ThumbnailCaptureMethod::FREE){
+					img = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_image();
+				}
 
-				// Move back camera after captured image
-				img = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_image();
-				RenderingServer::get_singleton()->camera_set_transform(vpcam->get_camera(), prev_trans_3d);
+				if (int(EDITOR_GET("docks/filesystem/scene_thumbnail_capture_method")) == ThumbnailCaptureMethod::FIXED){
+					Camera3D *vpcam = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_camera_3d();
+					Transform3D prev_trans_3d = vpcam->get_transform();
+					
+					// Move camera to fit 3d scene
+					AABB scene_aabb = AABB();
+					_calculate_aabb_merged(editor_data.get_edited_scene_root(), scene_aabb);
+					Vector3 scene_center = scene_aabb.get_center();
+					Transform3D thumbnail_cam_trans_3d = Transform3D();
+					float bound_sphere_radius = scene_aabb.get_longest_axis_size() / 2.0f;
+					float cam_distance = (bound_sphere_radius * 2.0f ) / Math::tan(vpcam->get_fov() / 2.0f);
+					thumbnail_cam_trans_3d.set_origin(scene_center + Vector3(1.0f, 0.25f, 1.0f).normalized() * cam_distance);
+					thumbnail_cam_trans_3d.set_look_at(thumbnail_cam_trans_3d.origin, scene_center);
+					RenderingServer::get_singleton()->camera_set_transform(vpcam->get_camera(), thumbnail_cam_trans_3d);
+					RenderingServer::get_singleton()->draw(false); // Redraw without glitching the viewport
+
+					// Move back camera after captured image
+					img = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_image();
+					RenderingServer::get_singleton()->camera_set_transform(vpcam->get_camera(), prev_trans_3d);
+				}
 			}
 		}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1769,21 +1769,21 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			// The preview will be generated if no feature profile is set (as the 3D editor is enabled by default).
 			Ref<EditorFeatureProfile> profile = feature_profile_manager->get_current_profile();
 			if (profile.is_null() || !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D)) {
-				if (int(EDITOR_GET("docks/filesystem/scene_thumbnail_capture_method")) == ThumbnailCaptureMethod::FREE){
+				if (int(EDITOR_GET("docks/filesystem/scene_thumbnail_capture_method")) == ThumbnailCaptureMethod::FREE) {
 					img = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_image();
 				}
 
-				if (int(EDITOR_GET("docks/filesystem/scene_thumbnail_capture_method")) == ThumbnailCaptureMethod::FIXED){
+				if (int(EDITOR_GET("docks/filesystem/scene_thumbnail_capture_method")) == ThumbnailCaptureMethod::FIXED) {
 					Camera3D *vpcam = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_camera_3d();
 					Transform3D prev_trans_3d = vpcam->get_transform();
-					
+
 					// Move camera to fit 3d scene
 					AABB scene_aabb = AABB();
 					_calculate_aabb_merged(editor_data.get_edited_scene_root(), scene_aabb);
 					Vector3 scene_center = scene_aabb.get_center();
 					Transform3D thumbnail_cam_trans_3d = Transform3D();
 					float bound_sphere_radius = scene_aabb.get_longest_axis_size() / 2.0f;
-					float cam_distance = (bound_sphere_radius * 2.0f ) / Math::tan(vpcam->get_fov() / 2.0f);
+					float cam_distance = (bound_sphere_radius * 2.0f) / Math::tan(vpcam->get_fov() / 2.0f);
 					thumbnail_cam_trans_3d.set_origin(scene_center + Vector3(1.0f, 0.25f, 1.0f).normalized() * cam_distance);
 					thumbnail_cam_trans_3d.set_look_at(thumbnail_cam_trans_3d.origin, scene_center);
 					RenderingServer::get_singleton()->camera_set_transform(vpcam->get_camera(), thumbnail_cam_trans_3d);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -234,6 +234,11 @@ private:
 		MAX_BUILD_CALLBACKS = 128,
 	};
 
+	enum ThumbnailCaptureMethod {
+		FREE = 0,
+		FIXED = 1
+	};
+
 	struct ExportDefer {
 		String preset;
 		String path;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -617,6 +617,7 @@ private:
 	void _mark_unsaved_scenes();
 
 	void _find_node_types(Node *p_node, int &count_2d, int &count_3d);
+	void _calculate_aabb_merged(Node *p_node, AABB &aabb);
 	void _save_scene_with_preview(String p_file, int p_idx = -1);
 	void _close_save_scene_progress();
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -637,6 +637,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// FileSystem
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "docks/filesystem/thumbnail_size", 64, "32,128,16")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "docks/filesystem/scene_thumbnail_capture_method", 0, "Free, Fixed");
 	_initial_set("docks/filesystem/always_show_folders", true);
 	_initial_set("docks/filesystem/textfile_extensions", "txt,md,cfg,ini,log,json,yml,yaml,toml,xml");
 	_initial_set("docks/filesystem/other_file_extensions", "ico,icns");


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Add a setting ```docks/filesystem/scene_thumbnail_capture_method``` to toggle between **FREE** / **FIXED** thumbnail captures, **FREE** is the default behavior, which captures scene thumbnail by the current camera view. This PR adds a **FIXED** option to always capture scene thumbnails with a 3/4 fixed view (in 3d), also ensures all visual elements are within the capture.

![scene_thumbnail_fixed](https://github.com/user-attachments/assets/4d1b396f-c0cc-4ba2-b9e0-6a7e87bc5f5e)

https://github.com/user-attachments/assets/4524f572-d47a-4db9-8fe3-69e24154dcad

TODO:
 - [ ] Set fixed camera zoom / fov when capturing
 - [ ] Hide gizmo when capturing thumbnails
 - [ ] Exclude node types that are generally not concerned in thumbnails from AABB calculation (light, particles, probes, skeletons, colliders)
 - [ ] Implement FIXED thumbnail capturing for 2d scenes
 - [ ] Check if performance is okay for large scenes with large number of nodes

___

- *Production edit: This partially addresses https://github.com/godotengine/godot-proposals/issues/7232 (3D only).*