### PR TITLE
Fix crash when assigning wrong shader to particle process material

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1325,10 +1325,11 @@ void ParticlesStorage::particles_set_view_axis(RID p_particles, const Vector3 &p
 void ParticlesStorage::_particles_update_buffers(Particles *particles) {
 	uint32_t userdata_count = 0;
 
-	MaterialStorage::ShaderData *shader_data = MaterialStorage::get_singleton()->material_get_shader_data(particles->process_material);
-	if (shader_data) {
-		const ParticlesShaderData *particle_shader_data = static_cast<const ParticlesShaderData *>(shader_data);
-		userdata_count = particle_shader_data->userdata_count;
+	if (particles->process_material.is_valid()) {
+		ParticleProcessMaterialData *material_data = static_cast<ParticleProcessMaterialData *>(MaterialStorage::get_singleton()->material_get_data(particles->process_material, MaterialStorage::SHADER_TYPE_PARTICLES));
+		if (material_data && material_data->shader_data->version.is_valid() && material_data->shader_data->valid) {
+			userdata_count = material_data->shader_data->userdata_count;
+		}
 	}
 
 	bool uses_motion_vectors = RSG::viewport->get_num_viewports_with_motion_vectors() > 0 || (RendererCompositorStorage::get_singleton()->get_num_compositor_effects_with_motion_vectors() > 0);


### PR DESCRIPTION
- Fix https://github.com/godotengine/godot/issues/102277

(this bug does not happen on GLES3 (because it has a correct material checking), so I did not change it).