### PR TITLE
Fix `LogMultiplayer` example in documentation

### DIFF
--- a/doc/classes/MultiplayerAPIExtension.xml
+++ b/doc/classes/MultiplayerAPIExtension.xml
@@ -18,10 +18,12 @@
 		    # Just passthrough base signals (copied to var to avoid cyclic reference)
 		    var cts = connected_to_server
 		    var cf = connection_failed
+		    var sd = server_disconnected
 		    var pc = peer_connected
 		    var pd = peer_disconnected
 		    base_multiplayer.connected_to_server.connect(func(): cts.emit())
 		    base_multiplayer.connection_failed.connect(func(): cf.emit())
+		    base_multiplayer.server_disconnected.connect(func(): sd.emit())
 		    base_multiplayer.peer_connected.connect(func(id): pc.emit(id))
 		    base_multiplayer.peer_disconnected.connect(func(id): pd.emit(id))
 
@@ -58,6 +60,9 @@
 
 		func _get_unique_id() -&gt; int:
 		    return base_multiplayer.get_unique_id()
+
+		func _get_remote_sender_id() -&gt; int:
+		    return base_multiplayer.get_remote_sender_id()
 
 		func _get_peer_ids() -&gt; PackedInt32Array:
 		    return base_multiplayer.get_peers()


### PR DESCRIPTION
Using `LogMultiplayer` example mentioned in the official documentation: https://docs.godotengine.org/en/latest/classes/class_multiplayerapiextension.html causes issues elsewhere in the project using it:

 - `multiplayer.server_disconnected` signal not being emitted
 - `multiplayer.get_remote_sender_id()` returning `0`

This PR adds the missing function and signal forwarding to the example to address those issues. 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
