### PR TITLE
Editor: Improve capsule gizmos

### DIFF
--- a/editor/plugins/gizmos/gizmo_3d_helper.h
+++ b/editor/plugins/gizmos/gizmo_3d_helper.h
@@ -41,17 +41,44 @@ class Gizmo3DHelper : public RefCounted {
 	Variant initial_value;
 	Transform3D initial_transform;
 
+private:
+	void _cylinder_or_capsule_set_handle(const Vector3 p_segment[2], int p_id, real_t &r_height, real_t &r_radius, Vector3 &r_cylinder_position, bool p_is_capsule);
+
 public:
+	/**
+	 * Initializes a new action involving a handle.
+	 *
+	 * Depending on the type of gizmo that will be used, different formats for the `p_initial_value` are required:
+	 * Box: The size of the box as `Vector3`
+	 * Cylinder or Capsule: A `Vector2` of the form `Vector2(radius, height)`
+	 */
 	void initialize_handle_action(const Variant &p_initial_value, const Transform3D &p_initial_transform);
 	void get_segment(Camera3D *p_camera, const Point2 &p_point, Vector3 *r_segment);
+
+	// Box
 
 	Vector<Vector3> box_get_handles(const Vector3 &p_box_size);
 	String box_get_handle_name(int p_id) const;
 	void box_set_handle(const Vector3 p_segment[2], int p_id, Vector3 &r_box_size, Vector3 &r_box_position);
 	void box_commit_handle(const String &p_action_name, bool p_cancel, Object *p_position_object, Object *p_size_object = nullptr, const StringName &p_position_property = "global_position", const StringName &p_size_property = "size");
 
+	// Cylinder
+
 	Vector<Vector3> cylinder_get_handles(real_t p_height, real_t p_radius);
 	String cylinder_get_handle_name(int p_id) const;
-	void cylinder_set_handle(const Vector3 p_segment[2], int p_id, real_t &r_height, real_t &r_radius, Vector3 &r_cylinder_position);
+	_FORCE_INLINE_ void cylinder_set_handle(const Vector3 p_segment[2], int p_id, real_t &r_height, real_t &r_radius, Vector3 &r_cylinder_position) {
+		_cylinder_or_capsule_set_handle(p_segment, p_id, r_height, r_radius, r_cylinder_position, false);
+	}
 	void cylinder_commit_handle(int p_id, const String &p_radius_action_name, const String &p_height_action_name, bool p_cancel, Object *p_position_object, Object *p_height_object = nullptr, Object *p_radius_object = nullptr, const StringName &p_position_property = "global_position", const StringName &p_height_property = "height", const StringName &p_radius_property = "radius");
+
+	// Capsule
+
+	_FORCE_INLINE_ Vector<Vector3> capsule_get_handles(real_t p_height, real_t p_radius) { return cylinder_get_handles(p_height, p_radius); }
+	_FORCE_INLINE_ String capsule_get_handle_name(int p_id) { return cylinder_get_handle_name(p_id); }
+	_FORCE_INLINE_ void capsule_set_handle(const Vector3 p_segment[2], int p_id, real_t &r_height, real_t &r_radius, Vector3 &r_capsule_position) {
+		_cylinder_or_capsule_set_handle(p_segment, p_id, r_height, r_radius, r_capsule_position, true);
+	}
+	_FORCE_INLINE_ void capsule_commit_handle(int p_id, const String &p_radius_action_name, const String &p_height_action_name, bool p_cancel, Object *p_position_object, Object *p_height_object = nullptr, Object *p_radius_object = nullptr, const StringName &p_position_property = "global_position", const StringName &p_height_property = "height", const StringName &p_radius_property = "radius") {
+		cylinder_commit_handle(p_id, p_radius_action_name, p_height_action_name, p_cancel, p_position_object, p_height_object, p_radius_object, p_position_property, p_height_property, p_radius_property);
+	}
 };

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -222,7 +222,7 @@ Variant CSGShape3DGizmoPlugin::get_handle_value(const EditorNode3DGizmo *p_gizmo
 
 	if (Object::cast_to<CSGCylinder3D>(cs)) {
 		CSGCylinder3D *s = Object::cast_to<CSGCylinder3D>(cs);
-		return p_id == 0 ? s->get_radius() : s->get_height();
+		return Vector2(s->get_radius(), s->get_height());
 	}
 
 	if (Object::cast_to<CSGTorus3D>(cs)) {


### PR DESCRIPTION
Similar to #97535 but for capsules


https://github.com/user-attachments/assets/03200a4f-e02e-478c-a346-398e0667a942

In addition to splitting the hight handle into two handles, this also changes the bahaviour, when dragging of one handle influences the other. Before this if e.g. height was dragged to be very small the radius would become very small. If the height would be dragged bigger again the radius would stay small. This would require a complete restart of the action if the height was accidentally dragged to low. Now when dragging the height bigger again the radius will increase again to its original value.
