### PR TITLE
Add toggle state feature to Input class

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -125,6 +125,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action", "exact_match"), &Input::is_action_pressed, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("is_action_just_pressed", "action", "exact_match"), &Input::is_action_just_pressed, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("is_action_just_released", "action", "exact_match"), &Input::is_action_just_released, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("is_action_toggled", "action"), &Input::is_action_toggled);
 	ClassDB::bind_method(D_METHOD("get_action_strength", "action", "exact_match"), &Input::get_action_strength, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_action_raw_strength", "action", "exact_match"), &Input::get_action_raw_strength, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_axis", "negative_action", "positive_action"), &Input::get_axis);
@@ -382,6 +383,13 @@ bool Input::is_action_pressed(const StringName &p_action, bool p_exact) const {
 	}
 
 	return E->value.cache.pressed && (p_exact ? E->value.exact : true);
+}
+
+bool Input::is_action_toggled(const StringName &p_action) const {
+	if (Input::is_action_just_pressed(p_action)) {
+		action_states[p_action].toggle_state = !action_states[p_action].toggle_state;
+	}
+	return action_states[p_action].toggle_state;
 }
 
 bool Input::is_action_just_pressed(const StringName &p_action, bool p_exact) const {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -113,6 +113,7 @@ private:
 		uint64_t released_physics_frame = UINT64_MAX;
 		uint64_t released_process_frame = UINT64_MAX;
 		bool exact = true;
+		bool toggle_state = false;
 
 		struct DeviceState {
 			bool pressed[MAX_EVENT] = { false };
@@ -131,7 +132,7 @@ private:
 		} cache;
 	};
 
-	HashMap<StringName, ActionState> action_states;
+	mutable HashMap<StringName, ActionState> action_states;
 
 	bool emulate_touch_from_mouse = false;
 	bool emulate_mouse_from_touch = false;
@@ -308,6 +309,7 @@ public:
 	bool is_joy_button_pressed(int p_device, JoyButton p_button) const;
 	bool is_action_pressed(const StringName &p_action, bool p_exact = false) const;
 	bool is_action_just_pressed(const StringName &p_action, bool p_exact = false) const;
+	bool is_action_toggled(const StringName &p_action) const;
 	bool is_action_just_released(const StringName &p_action, bool p_exact = false) const;
 	float get_action_strength(const StringName &p_action, bool p_exact = false) const;
 	float get_action_raw_strength(const StringName &p_action, bool p_exact = false) const;


### PR DESCRIPTION
This is my first time contributing to the Godot Engine, and I noticed the lack of a built-in toggle feature for input actions. While this can be implemented in game scripts, I have added only about 10 lines of code to provide this functionality directly within the engine.

**What this PR does:**
- Introduces the method Input.is_action_toggled("action_name"), which maintains a toggle state for an action.
- The first time it is called, it returns false.
- When the action is pressed (or held), it switches to true and remains true until the action is toggled again.
- Works seamlessly within process or physics_process.
- 
**Why this is useful:**
This simplifies toggle-based mechanics (such as switching a flashlight on/off) without requiring additional script logic in user projects.

**Testing:**
- I've verified that the toggle state updates correctly when an action is pressed.
- I've confirmed that holding the button doesn't repeatedly change the state.
- I've made sure that the feature doesn't interfere with existing input functions (is_action_pressed, is_action_just_pressed, etc.).

I appreciate any feedback you may have on this implementation. If there's a better approach to achieving this within the existing input system, I'm open to suggestions.

Thank you for reviewing this PR!

