### PR TITLE
Fix TextEdit visible line count when setting text

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -410,17 +410,11 @@ void TextEdit::Text::insert(int p_at, const Vector<String> &p_text, const Vector
 }
 
 void TextEdit::Text::remove_range(int p_from_line, int p_to_line) {
-	p_from_line = MAX(p_from_line, 0);
-	ERR_FAIL_INDEX(p_from_line, text.size());
-
-	p_to_line = MIN(p_to_line, text.size());
-	ERR_FAIL_COND(p_to_line < p_from_line);
-
 	if (p_from_line == p_to_line) {
 		return;
 	}
 
-	for (int i = p_from_line; i < p_to_line; i++) {
+	for (int i = p_from_line + 1; i <= p_to_line; i++) {
 		const Line &text_line = text[i];
 		if (text_line.hidden) {
 			continue;
@@ -435,9 +429,9 @@ void TextEdit::Text::remove_range(int p_from_line, int p_to_line) {
 		total_visible_line_count -= text_line.line_count;
 	}
 
-	int diff = (p_to_line - p_from_line);
-	for (int i = p_to_line; i < text.size() - 1; i++) {
-		text.write[(i - diff) + 1] = text[i + 1];
+	int diff = p_to_line - p_from_line;
+	for (int i = p_to_line + 1; i < text.size(); i++) {
+		text.write[i - diff] = text[i];
 	}
 	text.resize(text.size() - diff);
 


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/102279
- fixes https://github.com/godotengine/godot/issues/102211

`remove_range` actually removes from `p_from_line + 1` to `p_to_line`, it seems weird, but it is to preserve gutters on the first line I think. The line content will be replaced afterwards anyway.
 
The `total_visible_line_count` should now be in sync with the actual text that is removed, so the future call to `invalidate_text` will calculate the change correctly.

The for loop should function the same but be more clear.
`remove_range` is only called from `_base_remove_text` which handles validation of the arguments so it isn't needed here. The max and min functions never do anything.