### PR TITLE
Minimize some editor panels to prevent GUI overflow

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -7533,9 +7533,11 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	timeline_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	timeline_vbox = memnew(VBoxContainer);
-	timeline_scroll->add_child(timeline_vbox);
+	timeline_vbox->set_size(Size2(0, 150) * EDSCALE);
+	timeline_vbox->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
 	timeline_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
 	timeline_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+	timeline_scroll->add_child(timeline_vbox);
 
 	info_message = memnew(Label);
 	info_message->set_text(TTR("Select an AnimationPlayer node to create and edit animations."));
@@ -7592,8 +7594,6 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	bezier_edit->set_timeline(timeline);
 	bezier_edit->hide();
 	bezier_edit->set_v_size_flags(SIZE_EXPAND_FILL);
-
-	timeline_vbox->set_custom_minimum_size(Size2(0, 150) * EDSCALE);
 
 	hscroll = memnew(HScrollBar);
 	hscroll->share(timeline);

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -36,6 +36,7 @@
 #include "editor/gui/editor_run_bar.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/flow_container.h"
 #include "scene/resources/image_texture.h"
 
 void EditorProfiler::_make_metric_ptrs(Metric &m) {
@@ -658,27 +659,39 @@ Vector<Vector<String>> EditorProfiler::get_data_as_csv() const {
 
 EditorProfiler::EditorProfiler() {
 	HBoxContainer *hb = memnew(HBoxContainer);
+	hb->add_theme_constant_override(SNAME("separation"), 8 * EDSCALE);
 	add_child(hb);
+
+	FlowContainer *container = memnew(FlowContainer);
+	container->set_h_size_flags(SIZE_EXPAND_FILL);
+	container->add_theme_constant_override(SNAME("h_separation"), 8 * EDSCALE);
+	container->add_theme_constant_override(SNAME("v_separation"), 2 * EDSCALE);
+	hb->add_child(container);
+
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_disabled(true);
 	activate->set_text(TTR("Start"));
 	activate->connect(SceneStringName(pressed), callable_mp(this, &EditorProfiler::_activate_pressed));
-	hb->add_child(activate);
+	container->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
 	clear_button->connect(SceneStringName(pressed), callable_mp(this, &EditorProfiler::_clear_pressed));
 	clear_button->set_disabled(true);
-	hb->add_child(clear_button);
+	container->add_child(clear_button);
 
 	CheckBox *autostart_checkbox = memnew(CheckBox);
 	autostart_checkbox->set_text(TTR("Autostart"));
 	autostart_checkbox->set_pressed(EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_profiler", false));
 	autostart_checkbox->connect(SceneStringName(toggled), callable_mp(this, &EditorProfiler::_autostart_toggled));
-	hb->add_child(autostart_checkbox);
+	container->add_child(autostart_checkbox);
 
-	hb->add_child(memnew(Label(TTR("Measure:"))));
+	HBoxContainer *hb_measure = memnew(HBoxContainer);
+	hb_measure->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
+	container->add_child(hb_measure);
+
+	hb_measure->add_child(memnew(Label(TTR("Measure:"))));
 
 	display_mode = memnew(OptionButton);
 	display_mode->add_item(TTR("Frame Time (ms)"));
@@ -687,9 +700,13 @@ EditorProfiler::EditorProfiler() {
 	display_mode->add_item(TTR("Physics Frame %"));
 	display_mode->connect(SceneStringName(item_selected), callable_mp(this, &EditorProfiler::_combo_changed));
 
-	hb->add_child(display_mode);
+	hb_measure->add_child(display_mode);
 
-	hb->add_child(memnew(Label(TTR("Time:"))));
+	HBoxContainer *hb_time = memnew(HBoxContainer);
+	hb_time->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
+	container->add_child(hb_time);
+
+	hb_time->add_child(memnew(Label(TTR("Time:"))));
 
 	display_time = memnew(OptionButton);
 	// TRANSLATORS: This is an option in the profiler to display the time spent in a function, including the time spent in other functions called by that function.
@@ -698,27 +715,27 @@ EditorProfiler::EditorProfiler() {
 	display_time->add_item(TTR("Self"));
 	display_time->set_tooltip_text(TTR("Inclusive: Includes time from other functions called by this function.\nUse this to spot bottlenecks.\n\nSelf: Only count the time spent in the function itself, not in other functions called by that function.\nUse this to find individual functions to optimize."));
 	display_time->connect(SceneStringName(item_selected), callable_mp(this, &EditorProfiler::_combo_changed));
-
-	hb->add_child(display_time);
+	hb_time->add_child(display_time);
 
 	display_internal_profiles = memnew(CheckButton(TTR("Display internal functions")));
 	display_internal_profiles->set_visible(EDITOR_GET("debugger/profile_native_calls"));
 	display_internal_profiles->set_pressed(false);
 	display_internal_profiles->connect(SceneStringName(pressed), callable_mp(this, &EditorProfiler::_internal_profiles_pressed));
-	hb->add_child(display_internal_profiles);
+	container->add_child(display_internal_profiles);
 
-	hb->add_spacer();
+	HBoxContainer *hb_frame = memnew(HBoxContainer);
+	hb_frame->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
+	hb_frame->set_v_size_flags(SIZE_SHRINK_BEGIN);
+	hb->add_child(hb_frame);
 
-	hb->add_child(memnew(Label(TTR("Frame #:"))));
+	hb_frame->add_child(memnew(Label(TTR("Frame #:"))));
 
 	cursor_metric_edit = memnew(SpinBox);
 	cursor_metric_edit->set_h_size_flags(SIZE_FILL);
 	cursor_metric_edit->set_value(0);
 	cursor_metric_edit->set_editable(false);
-	hb->add_child(cursor_metric_edit);
+	hb_frame->add_child(cursor_metric_edit);
 	cursor_metric_edit->connect(SceneStringName(value_changed), callable_mp(this, &EditorProfiler::_cursor_metric_changed));
-
-	hb->add_theme_constant_override("separation", 8 * EDSCALE);
 
 	h_split = memnew(HSplitContainer);
 	add_child(h_split);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_run_bar.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/gui/flow_container.h"
 #include "scene/resources/image_texture.h"
 
 void EditorVisualProfiler::set_hardware_info(const String &p_cpu_name, const String &p_gpu_name) {
@@ -742,54 +743,67 @@ Vector<Vector<String>> EditorVisualProfiler::get_data_as_csv() const {
 
 EditorVisualProfiler::EditorVisualProfiler() {
 	HBoxContainer *hb = memnew(HBoxContainer);
+	hb->add_theme_constant_override(SNAME("separation"), 8 * EDSCALE);
 	add_child(hb);
+
+	FlowContainer *container = memnew(FlowContainer);
+	container->set_h_size_flags(SIZE_EXPAND_FILL);
+	container->add_theme_constant_override(SNAME("h_separation"), 8 * EDSCALE);
+	container->add_theme_constant_override(SNAME("v_separation"), 2 * EDSCALE);
+	hb->add_child(container);
+
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_disabled(true);
 	activate->set_text(TTR("Start"));
 	activate->connect(SceneStringName(pressed), callable_mp(this, &EditorVisualProfiler::_activate_pressed));
-	hb->add_child(activate);
+	container->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
 	clear_button->set_disabled(true);
 	clear_button->connect(SceneStringName(pressed), callable_mp(this, &EditorVisualProfiler::_clear_pressed));
-	hb->add_child(clear_button);
+	container->add_child(clear_button);
 
 	CheckBox *autostart_checkbox = memnew(CheckBox);
 	autostart_checkbox->set_text(TTR("Autostart"));
 	autostart_checkbox->set_pressed(EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_visual_profiler", false));
 	autostart_checkbox->connect(SceneStringName(toggled), callable_mp(this, &EditorVisualProfiler::_autostart_toggled));
-	hb->add_child(autostart_checkbox);
+	container->add_child(autostart_checkbox);
 
-	hb->add_child(memnew(Label(TTR("Measure:"))));
+	HBoxContainer *hb_measure = memnew(HBoxContainer);
+	hb_measure->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
+	container->add_child(hb_measure);
+
+	hb_measure->add_child(memnew(Label(TTR("Measure:"))));
 
 	display_mode = memnew(OptionButton);
 	display_mode->add_item(TTR("Frame Time (ms)"));
 	display_mode->add_item(TTR("Frame %"));
 	display_mode->connect(SceneStringName(item_selected), callable_mp(this, &EditorVisualProfiler::_combo_changed));
 
-	hb->add_child(display_mode);
+	hb_measure->add_child(display_mode);
 
 	frame_relative = memnew(CheckBox(TTR("Fit to Frame")));
 	frame_relative->set_pressed(true);
-	hb->add_child(frame_relative);
+	container->add_child(frame_relative);
 	frame_relative->connect(SceneStringName(pressed), callable_mp(this, &EditorVisualProfiler::_update_plot));
 	linked = memnew(CheckBox(TTR("Linked")));
 	linked->set_pressed(true);
-	hb->add_child(linked);
+	container->add_child(linked);
 	linked->connect(SceneStringName(pressed), callable_mp(this, &EditorVisualProfiler::_update_plot));
 
-	hb->add_spacer();
+	HBoxContainer *hb_frame = memnew(HBoxContainer);
+	hb_frame->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
+	hb_frame->set_v_size_flags(SIZE_SHRINK_BEGIN);
+	hb->add_child(hb_frame);
 
-	hb->add_child(memnew(Label(TTR("Frame #:"))));
+	hb_frame->add_child(memnew(Label(TTR("Frame #:"))));
 
 	cursor_metric_edit = memnew(SpinBox);
 	cursor_metric_edit->set_h_size_flags(SIZE_FILL);
-	hb->add_child(cursor_metric_edit);
+	hb_frame->add_child(cursor_metric_edit);
 	cursor_metric_edit->connect(SceneStringName(value_changed), callable_mp(this, &EditorVisualProfiler::_cursor_metric_changed));
-
-	hb->add_theme_constant_override("separation", 8 * EDSCALE);
 
 	h_split = memnew(HSplitContainer);
 	add_child(h_split);

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1337,7 +1337,8 @@ EditorAudioBuses::EditorAudioBuses() {
 
 	bus_scroll = memnew(ScrollContainer);
 	bus_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
-	bus_scroll->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+	bus_scroll->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
+	bus_scroll->set_size(Size2(0, 350) * EDSCALE);
 	add_child(bus_scroll);
 	bus_hb = memnew(HBoxContainer);
 	bus_hb->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -1072,7 +1072,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	error_label = memnew(Label);
 	error_panel->add_child(error_label);
 
-	set_custom_minimum_size(Size2(0, 300 * EDSCALE));
+	set_custom_minimum_size(Size2(0, 150 * EDSCALE));
+	set_size(Size2(0, 300 * EDSCALE));
 
 	menu = memnew(PopupMenu);
 	add_child(menu);

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1911,8 +1911,6 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	error_panel->add_child(error_label);
 	error_panel->hide();
 
-	set_custom_minimum_size(Size2(0, 300 * EDSCALE));
-
 	menu = memnew(PopupMenu);
 	add_child(menu);
 	menu->connect(SceneStringName(id_pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_add_menu_type));

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -302,7 +302,7 @@ void AnimationTreeEditorPlugin::make_visible(bool p_visible) {
 
 AnimationTreeEditorPlugin::AnimationTreeEditorPlugin() {
 	anim_tree_editor = memnew(AnimationTreeEditor);
-	anim_tree_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
+	anim_tree_editor->set_size(Size2(0, 300) * EDSCALE);
 
 	button = EditorNode::get_bottom_panel()->add_item(TTR("AnimationTree"), anim_tree_editor, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_animation_tree_bottom_panel", TTRC("Toggle AnimationTree Bottom Panel")));
 	button->hide();

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -43,6 +43,7 @@
 #include "scene/2d/skeleton_2d.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/flow_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel.h"
@@ -866,7 +867,7 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 					bone_paint_pos = mm->get_position();
 				} break;
 				default: {
-				}
+				} break;
 			}
 
 			if (bone_painting) {
@@ -1279,11 +1280,18 @@ Polygon2DEditor::Polygon2DEditor() {
 	polygon_edit = memnew(VBoxContainer);
 	HBoxContainer *toolbar = memnew(HBoxContainer);
 
+	FlowContainer *container = memnew(FlowContainer);
+	container->set_h_size_flags(SIZE_EXPAND_FILL);
+	toolbar->add_child(container);
+
+	HBoxContainer *hb_mode = memnew(HBoxContainer);
+	container->add_child(hb_mode);
+
 	Ref<ButtonGroup> mode_button_group;
 	mode_button_group.instantiate();
 	for (int i = 0; i < MODE_MAX; i++) {
 		mode_buttons[i] = memnew(Button);
-		toolbar->add_child(mode_buttons[i]);
+		hb_mode->add_child(mode_buttons[i]);
 		mode_buttons[i]->set_toggle_mode(true);
 		mode_buttons[i]->set_button_group(mode_button_group);
 		mode_buttons[i]->connect(SceneStringName(pressed), callable_mp(this, &Polygon2DEditor::_select_mode).bind(i));
@@ -1293,14 +1301,14 @@ Polygon2DEditor::Polygon2DEditor() {
 	mode_buttons[MODE_UV]->set_text(TTR("UV"));
 	mode_buttons[MODE_BONES]->set_text(TTR("Bones"));
 
-	toolbar->add_child(memnew(VSeparator));
+	hb_mode->add_child(memnew(VSeparator));
 
 	polygon_edit->add_child(toolbar);
 	for (int i = 0; i < ACTION_MAX; i++) {
 		action_buttons[i] = memnew(Button);
 		action_buttons[i]->set_theme_type_variation(SceneStringName(FlatButton));
 		action_buttons[i]->set_toggle_mode(true);
-		toolbar->add_child(action_buttons[i]);
+		container->add_child(action_buttons[i]);
 		action_buttons[i]->connect(SceneStringName(pressed), callable_mp(this, &Polygon2DEditor::_set_action).bind(i));
 		action_buttons[i]->set_focus_mode(FOCUS_NONE);
 	}
@@ -1320,7 +1328,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	action_buttons[ACTION_CLEAR_WEIGHT]->set_tooltip_text(TTR("Unpaint weights with specified intensity."));
 
 	bone_paint_strength = memnew(HSlider);
-	toolbar->add_child(bone_paint_strength);
+	container->add_child(bone_paint_strength);
 	bone_paint_strength->set_custom_minimum_size(Size2(75 * EDSCALE, 0));
 	bone_paint_strength->set_v_size_flags(SIZE_SHRINK_CENTER);
 	bone_paint_strength->set_min(0);
@@ -1329,9 +1337,9 @@ Polygon2DEditor::Polygon2DEditor() {
 	bone_paint_strength->set_value(0.5);
 
 	bone_paint_radius_label = memnew(Label(TTR("Radius:")));
-	toolbar->add_child(bone_paint_radius_label);
+	container->add_child(bone_paint_radius_label);
 	bone_paint_radius = memnew(SpinBox);
-	toolbar->add_child(bone_paint_radius);
+	container->add_child(bone_paint_radius);
 
 	bone_paint_radius->set_min(1);
 	bone_paint_radius->set_max(100);
@@ -1345,7 +1353,8 @@ Polygon2DEditor::Polygon2DEditor() {
 	canvas_background = memnew(Panel);
 	uv_main_hsc->add_child(canvas_background);
 	canvas_background->set_h_size_flags(SIZE_EXPAND_FILL);
-	canvas_background->set_custom_minimum_size(Size2(200, 200) * EDSCALE);
+	canvas_background->set_size(Size2(200, 200) * EDSCALE);
+	canvas_background->set_custom_minimum_size(Size2(200, 100) * EDSCALE);
 	canvas_background->set_clip_contents(true);
 
 	preview_polygon = memnew(Polygon2D);
@@ -1355,12 +1364,14 @@ Polygon2DEditor::Polygon2DEditor() {
 	canvas_background->add_child(canvas);
 	canvas->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 
-	Control *space = memnew(Control);
-	toolbar->add_child(space);
-	space->set_h_size_flags(SIZE_EXPAND_FILL);
+	HBoxContainer *hb = memnew(HBoxContainer);
+	hb->set_v_size_flags(SIZE_SHRINK_BEGIN);
+	toolbar->add_child(hb);
+
+	hb->add_spacer();
 
 	edit_menu = memnew(MenuButton);
-	toolbar->add_child(edit_menu);
+	hb->add_child(edit_menu);
 	edit_menu->set_flat(false);
 	edit_menu->set_theme_type_variation("FlatMenuButton");
 	edit_menu->set_text(TTR("Edit"));
@@ -1372,11 +1383,11 @@ Polygon2DEditor::Polygon2DEditor() {
 	edit_menu->get_popup()->add_item(TTR("Grid Settings"), MENU_GRID_SETTINGS);
 	edit_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &Polygon2DEditor::_edit_menu_option));
 
-	toolbar->add_child(memnew(VSeparator));
+	hb->add_child(memnew(VSeparator));
 
 	b_snap_enable = memnew(Button);
 	b_snap_enable->set_theme_type_variation(SceneStringName(FlatButton));
-	toolbar->add_child(b_snap_enable);
+	hb->add_child(b_snap_enable);
 	b_snap_enable->set_text(TTR("Snap"));
 	b_snap_enable->set_focus_mode(FOCUS_NONE);
 	b_snap_enable->set_toggle_mode(true);
@@ -1386,7 +1397,7 @@ Polygon2DEditor::Polygon2DEditor() {
 
 	b_snap_grid = memnew(Button);
 	b_snap_grid->set_theme_type_variation(SceneStringName(FlatButton));
-	toolbar->add_child(b_snap_grid);
+	hb->add_child(b_snap_grid);
 	b_snap_grid->set_text(TTR("Grid"));
 	b_snap_grid->set_focus_mode(FOCUS_NONE);
 	b_snap_grid->set_toggle_mode(true);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4159,7 +4159,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	script_list = memnew(ItemList);
 	script_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	scripts_vbox->add_child(script_list);
-	script_list->set_custom_minimum_size(Size2(100, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
+	script_list->set_custom_minimum_size(Size2(100, 40) * EDSCALE); // Nneed to give a bit of limit to avoid it from disappearing.
 	script_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	script_list->set_theme_type_variation("ItemListSecondary");
 	script_split->set_split_offset(200 * EDSCALE);
@@ -4173,7 +4173,6 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	context_menu->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptEditor::_menu_option));
 
 	overview_vbox = memnew(VBoxContainer);
-	overview_vbox->set_custom_minimum_size(Size2(0, 90));
 	overview_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	list_split->add_child(overview_vbox);
@@ -4209,7 +4208,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	overview_vbox->add_child(members_overview);
 
 	members_overview->set_allow_reselect(true);
-	members_overview->set_custom_minimum_size(Size2(0, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
+	members_overview->set_custom_minimum_size(Size2(0, 40) * EDSCALE); // Need to give a bit of limit to avoid it from disappearing.
 	members_overview->set_v_size_flags(SIZE_EXPAND_FILL);
 	members_overview->set_allow_rmb_select(true);
 
@@ -4218,7 +4217,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	help_overview->set_theme_type_variation("ItemListSecondary");
 	overview_vbox->add_child(help_overview);
 	help_overview->set_allow_reselect(true);
-	help_overview->set_custom_minimum_size(Size2(0, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
+	help_overview->set_custom_minimum_size(Size2(0, 40) * EDSCALE); // Need to give a bit of limit to avoid it from disappearing.
 	help_overview->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	VBoxContainer *code_editor_container = memnew(VBoxContainer);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -829,10 +829,12 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	shader_list->set_allow_rmb_select(true);
 	SET_DRAG_FORWARDING_GCD(shader_list, ShaderEditorPlugin);
 
+	left_panel->set_size(Size2(100, 300) * EDSCALE);
+	left_panel->set_custom_minimum_size(Size2(100, 220) * EDSCALE);
 	main_split->add_child(left_panel);
-	left_panel->set_custom_minimum_size(Size2(100, 300) * EDSCALE);
 
 	shader_tabs = memnew(TabContainer);
+	shader_tabs->set_custom_minimum_size(Size2(410, 220) * EDSCALE);
 	shader_tabs->set_tabs_visible(false);
 	shader_tabs->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	main_split->add_child(shader_tabs);

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -315,7 +315,8 @@ void ShaderFileEditorPlugin::make_visible(bool p_visible) {
 ShaderFileEditorPlugin::ShaderFileEditorPlugin() {
 	shader_editor = memnew(ShaderFileEditor);
 
-	shader_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
+	shader_editor->set_size(Size2(0, 300) * EDSCALE);
+	shader_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 	button = EditorNode::get_bottom_panel()->add_item(TTR("ShaderFile"), shader_editor, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_shader_file_bottom_panel", TTRC("Toggle ShaderFile Bottom Panel")));
 	button->hide();
 }

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1923,7 +1923,6 @@ void SpriteFramesEditor::_node_removed(Node *p_node) {
 SpriteFramesEditor::SpriteFramesEditor() {
 	VBoxContainer *vbc_animlist = memnew(VBoxContainer);
 	add_child(vbc_animlist);
-	vbc_animlist->set_custom_minimum_size(Size2(150, 0) * EDSCALE);
 
 	VBoxContainer *sub_vb = memnew(VBoxContainer);
 	vbc_animlist->add_margin_child(TTR("Animations:"), sub_vb, true);
@@ -2526,7 +2525,8 @@ void SpriteFramesEditorPlugin::make_visible(bool p_visible) {
 
 SpriteFramesEditorPlugin::SpriteFramesEditorPlugin() {
 	frames_editor = memnew(SpriteFramesEditor);
-	frames_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
+	frames_editor->set_size(Size2(0, 300) * EDSCALE);
+	frames_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 	button = EditorNode::get_bottom_panel()->add_item(TTR("SpriteFrames"), frames_editor, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_sprite_frames_bottom_panel", TTRC("Toggle SpriteFrames Bottom Panel")));
 	button->hide();
 }

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -2290,7 +2290,7 @@ Control *ThemeItemLabel::make_custom_tooltip(const String &p_text) const {
 
 VBoxContainer *ThemeTypeEditor::_create_item_list(Theme::DataType p_data_type) {
 	VBoxContainer *items_tab = memnew(VBoxContainer);
-	items_tab->set_custom_minimum_size(Size2(0, 160) * EDSCALE);
+	items_tab->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
 	data_type_tabs->add_child(items_tab);
 	data_type_tabs->set_tab_title(data_type_tabs->get_tab_count() - 1, "");
 
@@ -3497,7 +3497,7 @@ ThemeTypeEditor::ThemeTypeEditor() {
 	stylebox_items_list = _create_item_list(Theme::DATA_TYPE_STYLEBOX);
 
 	VBoxContainer *type_settings_tab = memnew(VBoxContainer);
-	type_settings_tab->set_custom_minimum_size(Size2(0, 160) * EDSCALE);
+	type_settings_tab->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
 	data_type_tabs->add_child(type_settings_tab);
 	data_type_tabs->set_tab_title(data_type_tabs->get_tab_count() - 1, "");
 
@@ -3798,7 +3798,7 @@ ThemeEditor::ThemeEditor() {
 
 	VBoxContainer *preview_tabs_vb = memnew(VBoxContainer);
 	preview_tabs_vb->set_h_size_flags(SIZE_EXPAND_FILL);
-	preview_tabs_vb->set_custom_minimum_size(Size2(520, 0) * EDSCALE);
+	preview_tabs_vb->set_size(Size2(520, 0) * EDSCALE);
 	preview_tabs_vb->add_theme_constant_override("separation", 2 * EDSCALE);
 	main_hs->add_child(preview_tabs_vb);
 	HBoxContainer *preview_tabbar_hb = memnew(HBoxContainer);
@@ -3837,8 +3837,8 @@ ThemeEditor::ThemeEditor() {
 	main_hs->add_child(preview_scene_dialog);
 	preview_scene_dialog->connect("file_selected", callable_mp(this, &ThemeEditor::_preview_scene_dialog_cbk));
 
-	main_hs->add_child(theme_type_editor);
 	theme_type_editor->set_custom_minimum_size(Size2(280, 0) * EDSCALE);
+	main_hs->add_child(theme_type_editor);
 
 	SET_DRAG_FORWARDING_CD(top_menu, ThemeEditor);
 	SET_DRAG_FORWARDING_CD(preview_tabs, ThemeEditor);
@@ -3874,7 +3874,6 @@ bool ThemeEditorPlugin::can_auto_hide() const {
 ThemeEditorPlugin::ThemeEditorPlugin() {
 	theme_editor = memnew(ThemeEditor);
 	theme_editor->plugin = this;
-	theme_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 
 	button = EditorNode::get_bottom_panel()->add_item(TTR("Theme"), theme_editor, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_theme_bottom_panel", TTRC("Toggle Theme Bottom Panel")));
 	button->hide();

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -250,7 +250,7 @@ ThemeEditorPreview::ThemeEditorPreview() {
 	picker_button->connect(SceneStringName(pressed), callable_mp(this, &ThemeEditorPreview::_picker_button_cbk));
 
 	MarginContainer *preview_body = memnew(MarginContainer);
-	preview_body->set_custom_minimum_size(Size2(480, 0) * EDSCALE);
+	preview_body->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 	preview_body->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(preview_body);
 

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -2371,6 +2371,7 @@ TileMapLayerEditorTilesPlugin::TileMapLayerEditorTilesPlugin() {
 
 	missing_source_label = memnew(Label);
 	missing_source_label->set_text(TTR("This TileMap's TileSet has no Tile Source configured. Go to the TileSet bottom panel to add one."));
+	missing_source_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	missing_source_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	missing_source_label->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	missing_source_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
@@ -2489,8 +2490,10 @@ TileMapLayerEditorTilesPlugin::TileMapLayerEditorTilesPlugin() {
 
 	patterns_help_label = memnew(Label);
 	patterns_help_label->set_text(TTR("Drag and drop or paste a TileMap selection here to store a pattern."));
+	patterns_help_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	patterns_help_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	patterns_help_label->set_anchors_and_offsets_preset(Control::PRESET_CENTER);
+	patterns_help_label->set_anchors_and_offsets_preset(Control::PRESET_HCENTER_WIDE);
+
 	patterns_item_list->add_child(patterns_help_label);
 
 	// Update.

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -916,6 +916,7 @@ TileSetEditor::TileSetEditor() {
 	no_source_selected_label->set_text(TTR("No TileSet source selected. Select or create a TileSet source.\nYou can create a new source by using the Add button on the left or by dropping a tileset texture onto the source list."));
 	no_source_selected_label->set_h_size_flags(SIZE_EXPAND_FILL);
 	no_source_selected_label->set_v_size_flags(SIZE_EXPAND_FILL);
+	no_source_selected_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	no_source_selected_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	no_source_selected_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	split_container_right_side->add_child(no_source_selected_label);

--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -35,6 +35,7 @@
 #include "editor/gui/editor_run_bar.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/flow_container.h"
 
 void EditorNetworkProfiler::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("enable_profiling", PropertyInfo(Variant::BOOL, "enable")));
@@ -297,30 +298,33 @@ bool EditorNetworkProfiler::is_profiling() {
 }
 
 EditorNetworkProfiler::EditorNetworkProfiler() {
-	HBoxContainer *hb = memnew(HBoxContainer);
-	hb->add_theme_constant_override("separation", 8 * EDSCALE);
-	add_child(hb);
+	FlowContainer *container = memnew(FlowContainer);
+	container->add_theme_constant_override(SNAME("h_separation"), 8 * EDSCALE);
+	container->add_theme_constant_override(SNAME("v_separation"), 2 * EDSCALE);
+	add_child(container);
 
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_text(TTR("Start"));
 	activate->set_disabled(true);
 	activate->connect(SceneStringName(pressed), callable_mp(this, &EditorNetworkProfiler::_activate_pressed));
-	hb->add_child(activate);
+	container->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
 	clear_button->set_disabled(true);
 	clear_button->connect(SceneStringName(pressed), callable_mp(this, &EditorNetworkProfiler::_clear_pressed));
-	hb->add_child(clear_button);
+	container->add_child(clear_button);
 
 	CheckBox *autostart_checkbox = memnew(CheckBox);
 	autostart_checkbox->set_text(TTR("Autostart"));
 	autostart_checkbox->set_pressed(EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_network_profiler", false));
 	autostart_checkbox->connect(SceneStringName(toggled), callable_mp(this, &EditorNetworkProfiler::_autostart_toggled));
-	hb->add_child(autostart_checkbox);
+	container->add_child(autostart_checkbox);
 
-	hb->add_spacer();
+	HBoxContainer *hb = memnew(HBoxContainer);
+	hb->add_theme_constant_override(SNAME("separation"), 8 * EDSCALE);
+	container->add_child(hb);
 
 	Label *lb = memnew(Label);
 	// TRANSLATORS: This is the label for the network profiler's incoming bandwidth.
@@ -346,7 +350,7 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	outgoing_bandwidth_text->set_editable(false);
 	outgoing_bandwidth_text->set_custom_minimum_size(Size2(120, 0) * EDSCALE);
 	outgoing_bandwidth_text->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
-	hb->add_child(outgoing_bandwidth_text);
+	container->add_child(outgoing_bandwidth_text);
 
 	// Set initial texts in the incoming/outgoing bandwidth labels
 	set_bandwidth(0, 0);
@@ -359,7 +363,7 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 
 	// RPC
 	counters_display = memnew(Tree);
-	counters_display->set_custom_minimum_size(Size2(320, 0) * EDSCALE);
+	counters_display->set_custom_minimum_size(Size2(280, 0) * EDSCALE);
 	counters_display->set_v_size_flags(SIZE_EXPAND_FILL);
 	counters_display->set_h_size_flags(SIZE_EXPAND_FILL);
 	counters_display->set_hide_folding(true);
@@ -382,7 +386,7 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 
 	// Replication
 	replication_display = memnew(Tree);
-	replication_display->set_custom_minimum_size(Size2(320, 0) * EDSCALE);
+	replication_display->set_custom_minimum_size(Size2(280, 0) * EDSCALE);
 	replication_display->set_v_size_flags(SIZE_EXPAND_FILL);
 	replication_display->set_h_size_flags(SIZE_EXPAND_FILL);
 	replication_display->set_hide_folding(true);


### PR DESCRIPTION
Alternative to https://github.com/godotengine/godot/pull/101828. 
Same as linked PR, may fix https://github.com/godotengine/godot/issues/26835 and fix https://github.com/godotengine/godot/issues/96479.

Aslo includes https://github.com/godotengine/godot/pull/102024 for now

I looked at (almost) every panel which could affect horizontal or vertical overflow when window size is minimal and did some tweaks of minimal size or another changes to minimize panel size (for example, use `FlowContainer` instead of `BoxContainer`, enable `ScrollContainer` scrolling).

For now only missing editor panel is `AnimationTree` (WIP). But I may overlooked another panels.

Also includes some concomitant changes like enabling `Label` word wrapping and fixing C++ C26819 warning (this could be reverted if not wanted).

May include some improper changes, so any suggestions are very appreciated. Also, it may look different than it does on my end, and therefore not fix the overflow, so it needs testing.

It could be split into several PRs if needed and changes are accepted.

|      | Before | After |
| --- | ---| --- |
| `AnimationPlayer` tab (vertical overflow) | ![image](https://github.com/user-attachments/assets/c2e468b4-d8f9-4916-932e-7110a305ca59) | ![image](https://github.com/user-attachments/assets/2002137f-77ae-4e49-a201-3a532e4dea28) |
| `Audio` tab (vertical overflow) | ![image](https://github.com/user-attachments/assets/c5a5c1c3-58e5-460d-8225-42797e57d863) | ![image](https://github.com/user-attachments/assets/61ee1d51-78b6-4809-802b-d72c3dc122fc) | 
| `AnimationTree` tab (vertical overflow, WIP) | ![image](https://github.com/user-attachments/assets/f02d08a7-a249-4e01-ae11-e3ad6449d002) | ![image](https://github.com/user-attachments/assets/8b91ced1-fef3-4960-86ec-a7bd0d8ea478) |
| Animation, `BlendSpace1D` (vertical overflow) | ![image](https://github.com/user-attachments/assets/78f4893c-8246-4d44-8489-c8e70992ef28) |  ![image](https://github.com/user-attachments/assets/b3aa1ba8-a0f5-4bbb-b8c8-08699d423742) |
| Animation, `BlendSpace2D` (horizontal and vertical overflow, WIP) | ![image](https://github.com/user-attachments/assets/9ac9fdea-66e3-4056-bb21-84dd2f62648e) | ![image](https://github.com/user-attachments/assets/be256ba8-e3ff-4111-a78f-e4a11bfc469c) |
| `Polygon2DEditor` (horizontal and vertical overflow) | ![image](https://github.com/user-attachments/assets/524c114b-acde-477a-a68d-6451e0d97e8b) | ![image](https://github.com/user-attachments/assets/fe813a3e-9a18-4f19-a441-45c8551b8661) |
| `Shader Editor` (vertical overflow) | ![image](https://github.com/user-attachments/assets/0771278f-ac54-42c9-8d89-1d530844dd6f) | ![image](https://github.com/user-attachments/assets/3adb3fa8-a377-4369-a82c-41c60ae8bd75) |
| `ShaderFile` (vertical overflow) | ![image](https://github.com/user-attachments/assets/9a10cbb7-24a9-4bb6-b739-ed6810253c5d) | ![image](https://github.com/user-attachments/assets/b0e86566-e154-4c69-97af-7b7ea613ccc7) |
| `SpriteFrames` (vertical overflow) | ![image](https://github.com/user-attachments/assets/c66898ad-9fae-494b-baae-cffc5e6c2d8e) | ![image](https://github.com/user-attachments/assets/0920b4bb-70c9-4633-8da0-e636c332224b) |
| `ThemeEditor` (horizontal and vertical overflow) | ![image](https://github.com/user-attachments/assets/1c324375-dcc5-4799-b528-ad9fb767e074) | ![image](https://github.com/user-attachments/assets/281629f9-97fe-4d67-b10c-3717c5de6b81) |
| `EditorNetworkProfiler` (vertical overflow) | ![image](https://github.com/user-attachments/assets/3767443e-25a0-44ee-9ae3-30385c552711) | ![image](https://github.com/user-attachments/assets/09729706-d0f2-46f8-80b0-9349e0eaf3ee) |