### PR TITLE
Fix incorrect `render_priority` property documentation in `Material` class

### DIFF
--- a/doc/classes/Material.xml
+++ b/doc/classes/Material.xml
@@ -56,7 +56,7 @@
 			[b]Note:[/b] This only applies to [StandardMaterial3D]s and [ShaderMaterial]s with type "Spatial".
 		</member>
 		<member name="render_priority" type="int" setter="set_render_priority" getter="get_render_priority">
-			Sets the render priority for objects in 3D scenes. Higher priority objects will be sorted in front of lower priority objects. In other words, all objects with [member render_priority] [code]1[/code] will render before all objects with [member render_priority] [code]0[/code].
+			Sets the render priority for objects in 3D scenes. Higher priority objects will be sorted in front of lower priority objects. In other words, all objects with [member render_priority] [code]-1[/code] will render before all objects with [member render_priority] [code]0[/code].
 			[b]Note:[/b] This only applies to [StandardMaterial3D]s and [ShaderMaterial]s with type "Spatial".
 			[b]Note:[/b] This will not impact how transparent objects are sorted relative to opaque objects or how dynamic meshes will be sorted relative to other opaque meshes. This is because all transparent objects are drawn after all opaque objects and all dynamic opaque meshes are drawn before other opaque meshes.
 		</member>


### PR DESCRIPTION
Closes [#10530](https://github.com/godotengine/godot-docs/issues/10530)

#### Changes made

- This PR updates the documentation for the `render_priority` property in the `Material` class to fix an inaccurate explanation. The example value has been corrected from `1` to `-1` to accurately describe the rendering order.