### PR TITLE
Add the ability to set the global position of Line2D points

### DIFF
--- a/doc/classes/Line2D.xml
+++ b/doc/classes/Line2D.xml
@@ -22,6 +22,14 @@
 				If [param index] is given, the new point is inserted before the existing point identified by index [param index]. The indices of the points after the new point get increased by 1. The provided [param index] must not exceed the number of existing points in the polyline. See [method get_point_count].
 			</description>
 		</method>
+		<method name="add_point_global">
+			<return type="void" />
+			<param index="0" name="position" type="Vector2" />
+			<param index="1" name="index" type="int" default="-1" />
+			<description>
+				Adds a point in global coordinates to the line.
+			</description>
+		</method>
 		<method name="clear_points">
 			<return type="void" />
 			<description>
@@ -32,6 +40,13 @@
 			<return type="int" />
 			<description>
 				Returns the number of points in the polyline.
+			</description>
+		</method>
+		<method name="get_point_global_position" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns the global position of the point at index [param index].
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">
@@ -46,6 +61,15 @@
 			<param index="0" name="index" type="int" />
 			<description>
 				Removes the point at index [param index] from the polyline.
+			</description>
+		</method>
+		<method name="set_point_global_position">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="position" type="Vector2" />
+			<description>
+				Overwrites the position of the point at the given [param index] with the supplied [param position] in global coordinates.
+				[b]Note:[/b] The supplied [param position] will be converted to the polyline's local coordinate space.
 			</description>
 		</method>
 		<method name="set_point_position">

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -134,6 +134,17 @@ Vector2 Line2D::get_point_position(int i) const {
 	return _points.get(i);
 }
 
+void Line2D::set_point_global_position(int i, Vector2 p_pos) {
+	ERR_FAIL_INDEX(i, _points.size());
+	_points.set(i, p_pos - get_global_position());
+	queue_redraw();
+}
+
+Vector2 Line2D::get_point_global_position(int i) const {
+	ERR_FAIL_INDEX_V(i, _points.size(), Vector2());
+	return _points.get(i) + get_global_position();
+}
+
 int Line2D::get_point_count() const {
 	return _points.size();
 }
@@ -153,6 +164,10 @@ void Line2D::add_point(Vector2 p_pos, int p_atpos) {
 		_points.insert(p_atpos, p_pos);
 	}
 	queue_redraw();
+}
+
+void Line2D::add_point_global(Vector2 p_pos, int p_atpos) {
+	add_point(p_pos - get_global_position(), p_atpos);
 }
 
 void Line2D::remove_point(int i) {
@@ -342,10 +357,15 @@ void Line2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_point_position", "index", "position"), &Line2D::set_point_position);
 	ClassDB::bind_method(D_METHOD("get_point_position", "index"), &Line2D::get_point_position);
 
+	ClassDB::bind_method(D_METHOD("set_point_global_position", "index", "position"), &Line2D::set_point_global_position);
+	ClassDB::bind_method(D_METHOD("get_point_global_position", "index"), &Line2D::get_point_global_position);
+
 	ClassDB::bind_method(D_METHOD("get_point_count"), &Line2D::get_point_count);
 
 	ClassDB::bind_method(D_METHOD("add_point", "position", "index"), &Line2D::add_point, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("remove_point", "index"), &Line2D::remove_point);
+
+	ClassDB::bind_method(D_METHOD("add_point_global", "position", "index"), &Line2D::add_point_global, DEFVAL(-1));
 
 	ClassDB::bind_method(D_METHOD("clear_points"), &Line2D::clear_points);
 

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -136,13 +136,13 @@ Vector2 Line2D::get_point_position(int i) const {
 
 void Line2D::set_point_global_position(int i, Vector2 p_pos) {
 	ERR_FAIL_INDEX(i, _points.size());
-	_points.set(i, p_pos - get_global_position());
+	_points.set(i, to_local(p_pos));
 	queue_redraw();
 }
 
 Vector2 Line2D::get_point_global_position(int i) const {
 	ERR_FAIL_INDEX_V(i, _points.size(), Vector2());
-	return _points.get(i) + get_global_position();
+	return to_global(_points.get(i));
 }
 
 int Line2D::get_point_count() const {
@@ -167,7 +167,7 @@ void Line2D::add_point(Vector2 p_pos, int p_atpos) {
 }
 
 void Line2D::add_point_global(Vector2 p_pos, int p_atpos) {
-	add_point(p_pos - get_global_position(), p_atpos);
+	add_point(to_local(p_pos), p_atpos);
 }
 
 void Line2D::remove_point(int i) {

--- a/scene/2d/line_2d.h
+++ b/scene/2d/line_2d.h
@@ -69,12 +69,17 @@ public:
 	void set_point_position(int i, Vector2 pos);
 	Vector2 get_point_position(int i) const;
 
+	void set_point_global_position(int i, Vector2 p_pos);
+	Vector2 get_point_global_position(int i) const;
+
 	int get_point_count() const;
 
 	void clear_points();
 
 	void add_point(Vector2 pos, int atpos = -1);
 	void remove_point(int i);
+
+	void add_point_global(Vector2 p_pos, int p_atpos);
 
 	void set_closed(bool p_closed);
 	bool is_closed() const;


### PR DESCRIPTION
Adds a few functions that make it a bit cleaner to set the position of line points.

People will probably say this is unnecessary, so here is my reasoning:
- Most people probably don't know the to_local function off the top of their head, so they'll have to go through the documentation to find it, or
- They'll decide to spend a few seconds working out the math, which they might get wrong.
- It'll make people's code cleaner.

Happy to discuss this further ... 

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/11664*