### PR TITLE
Fix Floating Window not visible after restore on KDE

### DIFF
--- a/editor/window_wrapper.cpp
+++ b/editor/window_wrapper.cpp
@@ -261,6 +261,11 @@ void WindowWrapper::restore_window_from_saved_position(const Rect2 p_window_rect
 	window_rect = Rect2i(window_rect.position * screen_ratio, window_rect.size * screen_ratio);
 	window_rect.position += real_screen_rect.position;
 
+	// Make sure to restore the window if the user minimized it the last time it was displayed.
+	if (window->get_mode() == Window::MODE_MINIMIZED) {
+		window->set_mode(Window::MODE_WINDOWED);
+	}
+
 	// All good, restore the window.
 	window->set_current_screen(p_screen);
 	if (window->is_visible()) {

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4727,6 +4727,13 @@ void DisplayServerX11::process_events() {
 
 				// Have we failed to set fullscreen while the window was unmapped?
 				_validate_mode_on_map(window_id);
+
+				// On KDE Plasma, when the parent window of an embedded process is restored after being minimized,
+				// only the embedded window receives the Map notification, causing it to
+				// appear without its parent.
+				if (wd.embed_parent) {
+					XMapWindow(x11_display, wd.embed_parent);
+				}
 			} break;
 
 			case Expose: {


### PR DESCRIPTION
- Fixes #102285

This should fix the issue in KDE Plasma when restoring the Floating Window. Only the embedded window receives the Map notification when clicking on the floating window or on Godot in the TaskBar.

Also, I added a check in the `WrapperWindow` to restore the window on the next run if the game is stopped while the Floating Window is minimized.