### PR TITLE
Fix Floating Window focus on run

### DIFF
--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -230,6 +230,8 @@ void GameView::_instance_starting(int p_idx, List<String> &r_arguments) {
 		window_wrapper->set_window_title(appname);
 
 		_show_update_window_wrapper();
+
+		embedded_process->grab_focus();
 	}
 
 	_update_arguments_for_instance(p_idx, r_arguments);


### PR DESCRIPTION
- Fixes #102306

The issue was present on Windows and Linux.

I simply added a `grab_focus` after the opening of the Floating Window.