### PR TITLE
Fix Floating Window overlapping when on screen edge on KDE

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1364,8 +1364,6 @@ Rect2i DisplayServerX11::screen_get_usable_rect(int p_screen) const {
 					}
 
 					if (desktop_valid) {
-						use_simple_method = false;
-
 						// Handle bad window errors silently because there's no other way to check
 						// that one of the windows has been destroyed in the meantime.
 						int (*oldHandler)(Display *, XErrorEvent *) = XSetErrorHandler(&bad_window_error_handler);
@@ -1393,6 +1391,8 @@ Rect2i DisplayServerX11::screen_get_usable_rect(int p_screen) const {
 								}
 							}
 							if (!g_bad_window && strut_found && (format == 32) && (strut_len >= 4) && strut_data) {
+								use_simple_method = false;
+
 								long *struts = (long *)strut_data;
 
 								long left = struts[0];


### PR DESCRIPTION
- Fixes #102309  

I was able to reproduce the issue only on KDE Plasma when multiple monitors were connected.  

The method `DisplayServerX11::screen_get_usable_rect` was incorrectly including the taskbar in the usable rectangle. For some unknown reason, all calls to `_NET_WM_STRUT_PARTIAL` and `_NET_WM_STRUT` returned `Success`, but `strut_len` remained zero, and `strut_data` was null.  

Since the `use_simple_method` variable was set to `true`, even though all calls to `_NET_WM_STRUT_PARTIAL` and `_NET_WM_STRUT` failed, the simple method was not used as a fallback. However, the simple method correctly returns the usable size, excluding the taskbar.  

A side effect is that the taskbar space is also considered on the second monitor, prematurely resizing the embedded window when the Floating Window is positioned at the bottom of the second screen. I think this solution is good enough.