### PR TITLE
Do not commit gizmo handles if no changes were made

### DIFF
--- a/editor/scene/3d/gizmos/soft_body_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/soft_body_3d_gizmo_plugin.cpp
@@ -54,6 +54,10 @@ bool SoftBody3DGizmoPlugin::is_selectable_when_hidden() const {
 	return true;
 }
 
+bool SoftBody3DGizmoPlugin::can_commit_handle_on_click() const {
+	return true;
+}
+
 void SoftBody3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	SoftBody3D *soft_body = Object::cast_to<SoftBody3D>(p_gizmo->get_node_3d());
 

--- a/editor/scene/3d/gizmos/soft_body_3d_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/soft_body_3d_gizmo_plugin.h
@@ -40,6 +40,7 @@ public:
 	String get_gizmo_name() const override;
 	int get_priority() const override;
 	bool is_selectable_when_hidden() const override;
+	bool can_commit_handle_on_click() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
 	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const override;

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -1138,6 +1138,10 @@ bool EditorNode3DGizmoPlugin::is_selectable_when_hidden() const {
 	return ret;
 }
 
+bool EditorNode3DGizmoPlugin::can_commit_handle_on_click() const {
+	return false;
+}
+
 void EditorNode3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	GDVIRTUAL_CALL(_redraw, p_gizmo);
 }

--- a/editor/scene/3d/node_3d_editor_gizmos.h
+++ b/editor/scene/3d/node_3d_editor_gizmos.h
@@ -197,6 +197,7 @@ public:
 	virtual int get_priority() const;
 	virtual bool can_be_hidden() const;
 	virtual bool is_selectable_when_hidden() const;
+	virtual bool can_commit_handle_on_click() const;
 
 	virtual void redraw(EditorNode3DGizmo *p_gizmo);
 	virtual bool is_handle_highlighted(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const;

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2029,7 +2029,11 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					}
 
 					if (_edit.gizmo.is_valid()) {
-						_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, false);
+						// Certain gizmo plugins should be able to commit handles without dragging them.
+						if (_edit.original_mouse_pos != _edit.mouse_pos || _edit.gizmo->get_plugin()->can_commit_handle_on_click()) {
+							_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, false);
+						}
+
 						spatial_editor->get_single_selected_node()->update_gizmos();
 						_edit.gizmo = Ref<EditorNode3DGizmo>();
 						break;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Unreverts the 3d gizmo handle part of: https://github.com/godotengine/godot/pull/87161/

https://github.com/godotengine/godot/pull/94684 partially reverted the above-mentioned PR, because it ended up breaking `SoftBody3D` pinned points interaction, but reintroduced the problem in all other 3D gizmos. This PR fixes the problem by making `SoftBody3DGizmoPlugin` an exception to the mouse movement requirement to interact with gizmo handles. 