### PR TITLE
Remove `PackedStringArray.to_byte_array`

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2577,7 +2577,6 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedStringArray, has, sarray("value"), varray());
 	bind_method(PackedStringArray, reverse, sarray(), varray());
 	bind_method(PackedStringArray, slice, sarray("begin", "end"), varray(INT_MAX));
-	bind_method(PackedStringArray, to_byte_array, sarray(), varray());
 	bind_method(PackedStringArray, sort, sarray(), varray());
 	bind_method(PackedStringArray, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedStringArray, duplicate, sarray(), varray());

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -190,12 +190,6 @@
 				Sorts the elements of the array in ascending order.
 			</description>
 		</method>
-		<method name="to_byte_array" qualifiers="const">
-			<return type="PackedByteArray" />
-			<description>
-				Returns a [PackedByteArray] with each string encoded as bytes.
-			</description>
-		</method>
 	</methods>
 	<operators>
 		<operator name="operator !=">


### PR DESCRIPTION
Looks like the method was added accidentally to PackedStringArray. The bytes returned are the raw pointer bytes of the String pointers, not the value of the string. This seems somewhat unsafe/inappropriate to expose to GDScript. I don't think anybody should be using it!

In the reported issue, @gormster suggested to remove it, so opening this PR to bring some attention to the issue and to make this an easy decision to make. Note: removing this is a breaking change and may have minor backwards-incompatible ramifications for GDExtension bindings until they are updated who may be trying to fetch bindings for something that no longer exists (which prints an error on startup).

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/66526*