### PR TITLE
Make color picker preview mouse passthrough.

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4410,7 +4410,7 @@ bool DisplayServerX11::mouse_process_popups() {
 						Rect2i win_rect = Rect2i(window_get_position_with_decorations(E->get()), window_get_size_with_decorations(E->get()));
 						// Area of the parent window, which responsible for opening sub-menu.
 						Rect2i safe_rect = window_get_popup_safe_rect(E->get());
-						if (win_rect.has_point(pos)) {
+						if (win_rect.has_point(pos) && !window_get_flag(DisplayServer::WINDOW_FLAG_MOUSE_PASSTHROUGH, E->get())) {
 							break;
 						} else if (safe_rect != Rect2i() && safe_rect.has_point(pos)) {
 							break;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3632,7 +3632,7 @@ bool DisplayServerMacOS::mouse_process_popups(bool p_close) {
 			Rect2i win_rect = Rect2i(window_get_position_with_decorations(E->get()), window_get_size_with_decorations(E->get()));
 			// Area of the parent window, which responsible for opening sub-menu.
 			Rect2i safe_rect = window_get_popup_safe_rect(E->get());
-			if (win_rect.has_point(pos)) {
+			if (win_rect.has_point(pos) && !window_get_flag(DisplayServer::WINDOW_FLAG_MOUSE_PASSTHROUGH, E->get())) {
 				break;
 			} else if (safe_rect != Rect2i() && safe_rect.has_point(pos)) {
 				break;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4389,7 +4389,7 @@ LRESULT DisplayServerWindows::MouseProc(int code, WPARAM wParam, LPARAM lParam) 
 					Rect2i win_rect = Rect2i(window_get_position_with_decorations(E->get()), window_get_size_with_decorations(E->get()));
 					// Area of the parent window, which responsible for opening sub-menu.
 					Rect2i safe_rect = window_get_popup_safe_rect(E->get());
-					if (win_rect.has_point(pos)) {
+					if (win_rect.has_point(pos) && !window_get_flag(DisplayServer::WINDOW_FLAG_MOUSE_PASSTHROUGH, E->get())) {
 						break;
 					} else if (safe_rect != Rect2i() && safe_rect.has_point(pos)) {
 						break;
@@ -5010,7 +5010,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					Rect2i win_rect = Rect2i(window_get_position_with_decorations(E->get()), window_get_size_with_decorations(E->get()));
 					// Area of the parent window, which responsible for opening sub-menu.
 					Rect2i safe_rect = window_get_popup_safe_rect(E->get());
-					if (win_rect.has_point(pos)) {
+					if (win_rect.has_point(pos) && !window_get_flag(DisplayServer::WINDOW_FLAG_MOUSE_PASSTHROUGH, E->get())) {
 						break;
 					} else if (safe_rect != Rect2i() && safe_rect.has_point(pos)) {
 						break;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1704,6 +1704,7 @@ void ColorPicker::_pick_button_pressed() {
 		} else {
 			picker_window->set_size(Vector2i(55, 72));
 			picker_window->set_flag(Window::FLAG_EXCLUDE_FROM_CAPTURE, true); // Only supported on MacOS and Windows.
+			picker_window->set_flag(Window::FLAG_MOUSE_PASSTHROUGH, true);
 		}
 		picker_window->connect(SceneStringName(visibility_changed), callable_mp(this, &ColorPicker::_pick_finished));
 		picker_window->connect(SceneStringName(window_input), callable_mp(this, &ColorPicker::_target_gui_input));


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/102293 on macOS, on Windows `FLAG_MOUSE_PASSTHROUGH` seems to only work with the same app windows and this only work with the editor but not other windows, so might need another approach.