### PR TITLE
Fix Escape does not work the first time when pressed at the Find(Replace)Bar

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -145,7 +145,7 @@ void FindReplaceBar::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			set_process_unhandled_input(is_visible_in_tree());
+			set_process_input(is_visible_in_tree());
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -161,11 +161,11 @@ void FindReplaceBar::_notification(int p_what) {
 	}
 }
 
-void FindReplaceBar::unhandled_input(const Ref<InputEvent> &p_event) {
+// Implemented in input(..) as the LineEdit consumes the Escape pressed key.
+void FindReplaceBar::input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
 	Ref<InputEventKey> k = p_event;
-
 	if (k.is_valid() && k->is_action_pressed(SNAME("ui_cancel"), false, true)) {
 		Control *focus_owner = get_viewport()->gui_get_focus_owner();
 
@@ -173,13 +173,6 @@ void FindReplaceBar::unhandled_input(const Ref<InputEvent> &p_event) {
 			_hide_bar();
 			accept_event();
 		}
-	}
-}
-
-void FindReplaceBar::_focus_lost() {
-	if (Input::get_singleton()->is_action_pressed(SNAME("ui_cancel"))) {
-		// Unfocused after pressing Escape, so hide the bar.
-		_hide_bar(true);
 	}
 }
 
@@ -564,8 +557,8 @@ bool FindReplaceBar::search_next() {
 	return _search(flags, line, col);
 }
 
-void FindReplaceBar::_hide_bar(bool p_force_focus) {
-	if (replace_text->has_focus() || search_text->has_focus() || p_force_focus) {
+void FindReplaceBar::_hide_bar() {
+	if (replace_text->has_focus() || search_text->has_focus()) {
 		text_editor->grab_focus();
 	}
 
@@ -789,7 +782,6 @@ FindReplaceBar::FindReplaceBar() {
 	search_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	search_text->connect(SceneStringName(text_changed), callable_mp(this, &FindReplaceBar::_search_text_changed));
 	search_text->connect(SceneStringName(text_submitted), callable_mp(this, &FindReplaceBar::_search_text_submitted));
-	search_text->connect(SceneStringName(focus_exited), callable_mp(this, &FindReplaceBar::_focus_lost));
 
 	matches_label = memnew(Label);
 	hbc_button_search->add_child(matches_label);
@@ -828,7 +820,6 @@ FindReplaceBar::FindReplaceBar() {
 	replace_text->set_tooltip_text(TTR("Replace"));
 	replace_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	replace_text->connect(SceneStringName(text_submitted), callable_mp(this, &FindReplaceBar::_replace_text_submitted));
-	replace_text->connect(SceneStringName(focus_exited), callable_mp(this, &FindReplaceBar::_focus_lost));
 
 	replace = memnew(Button);
 	hbc_button_replace->add_child(replace);
@@ -850,7 +841,7 @@ FindReplaceBar::FindReplaceBar() {
 	add_child(hide_button);
 	hide_button->set_tooltip_text(TTR("Hide"));
 	hide_button->set_focus_mode(FOCUS_NONE);
-	hide_button->connect(SceneStringName(pressed), callable_mp(this, &FindReplaceBar::_hide_bar).bind(false));
+	hide_button->connect(SceneStringName(pressed), callable_mp(this, &FindReplaceBar::_hide_bar));
 	hide_button->set_v_size_flags(SIZE_SHRINK_CENTER);
 }
 

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -104,12 +104,14 @@ class FindReplaceBar : public HBoxContainer {
 	bool replace_all_mode = false;
 	bool preserve_cursor = false;
 
+	virtual void input(const Ref<InputEvent> &p_event) override;
+
 	void _get_search_from(int &r_line, int &r_col, SearchMode p_search_mode);
 	void _update_results_count();
 	void _update_matches_display();
 
 	void _show_search(bool p_with_replace, bool p_show_only);
-	void _hide_bar(bool p_force_focus = false);
+	void _hide_bar();
 	void _update_toggle_replace_button(bool p_replace_visible);
 
 	void _editor_text_changed();
@@ -121,8 +123,6 @@ class FindReplaceBar : public HBoxContainer {
 
 protected:
 	void _notification(int p_what);
-	virtual void unhandled_input(const Ref<InputEvent> &p_event) override;
-	void _focus_lost();
 
 	void _update_flags(bool p_direction_backwards);
 

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -4581,6 +4581,7 @@ EditorHelpHighlighter::~EditorHelpHighlighter() {
 FindBar::FindBar() {
 	search_text = memnew(LineEdit);
 	add_child(search_text);
+	search_text->set_keep_editing_on_text_submit(true);
 	search_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	search_text->set_h_size_flags(SIZE_EXPAND_FILL);
 	search_text->connect(SceneStringName(text_changed), callable_mp(this, &FindBar::_search_text_changed));
@@ -4644,7 +4645,7 @@ void FindBar::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			set_process_unhandled_input(is_visible_in_tree());
+			set_process_input(is_visible_in_tree());
 		} break;
 	}
 }
@@ -4721,12 +4722,15 @@ void FindBar::_hide_bar() {
 	hide();
 }
 
-void FindBar::unhandled_input(const Ref<InputEvent> &p_event) {
+// Implemented in input(..) as the LineEdit consumes the Escape pressed key.
+void FindBar::input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && k->is_action_pressed(SNAME("ui_cancel"), false, true)) {
-		if (rich_text_label->has_focus() || is_ancestor_of(get_viewport()->gui_get_focus_owner())) {
+		Control *focus_owner = get_viewport()->gui_get_focus_owner();
+
+		if (rich_text_label->has_focus() || (focus_owner && is_ancestor_of(focus_owner))) {
 			_hide_bar();
 			accept_event();
 		}

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -57,6 +57,8 @@ class FindBar : public HBoxContainer {
 
 	int results_count = 0;
 
+	virtual void input(const Ref<InputEvent> &p_event) override;
+
 	void _hide_bar();
 
 	void _search_text_changed(const String &p_text);
@@ -67,7 +69,6 @@ class FindBar : public HBoxContainer {
 
 protected:
 	void _notification(int p_what);
-	virtual void unhandled_input(const Ref<InputEvent> &p_event) override;
 
 	bool _search(bool p_search_previous = false);
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/102331
Closes: https://github.com/godotengine/godot/issues/85847 (although the issue is different, it is the same bug with pressing Escape to close the Bar)

The Find(Replace)Bar code is now pretty much the same. 
When we receive the `ui_cancel` (Escape) event, we will close the bar from within the `input` function. The bar will only process input events when visible (like before).