### PR TITLE
Fix 'Show in FileSystem' jumps to incorrect entry under certain conditions

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -746,7 +746,8 @@ void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_fa
 	// Select the file or directory in the tree.
 	tree->deselect_all();
 	if (display_mode == DISPLAY_MODE_TREE_ONLY) {
-		const String file_name = is_directory ? target_path.trim_suffix("/").get_file() + "/" : target_path.get_file();
+		// Either search for 'folder/' or '/file.ext'.
+		const String file_name = is_directory ? target_path.trim_suffix("/").get_file() + "/" : "/" + target_path.get_file();
 		TreeItem *item = is_directory ? *directory_ptr : (*directory_ptr)->get_first_child();
 		while (item) {
 			if (item->get_metadata(0).operator String().ends_with(file_name)) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/102335

The broken selection was caused because we are searching the `FileSystem` Tree with an `ends_with` to find the correct file.
In the case which is described in the issue, if we search for `dice.gd`, we will accidentally select `attack_dice.gd`, because it also ends with `dice.gd`.

The fix is to add a slash to the file search logic, e.g. we are now searching for `/dice.gd` instead. With that, we make sure to not accidentally select something just because it ends with the same string.