### PR TITLE
Make `CharFXTransform.font` property read only, add some extra documentation notes.

### DIFF
--- a/doc/classes/CharFXTransform.xml
+++ b/doc/classes/CharFXTransform.xml
@@ -25,28 +25,34 @@
 			[/codeblock]
 		</member>
 		<member name="font" type="RID" setter="set_font" getter="get_font" default="RID()">
-			Font resource used to render glyph.
+			[TextServer] RID of the font used to render glyph, this value can be used with [code]TextServer.font_*[/code] methods to retrieve font information.
+			[b]Note:[/b] Read-only. Setting this property won't affect drawing.
 		</member>
 		<member name="glyph_count" type="int" setter="set_glyph_count" getter="get_glyph_count" default="0">
-			Number of glyphs in the grapheme cluster. This value is set in the first glyph of a cluster. Setting this property won't affect drawing.
+			Number of glyphs in the grapheme cluster. This value is set in the first glyph of a cluster.
+			[b]Note:[/b] Read-only. Setting this property won't affect drawing.
 		</member>
 		<member name="glyph_flags" type="int" setter="set_glyph_flags" getter="get_glyph_flags" default="0">
-			Glyph flags. See [enum TextServer.GraphemeFlag] for more info. Setting this property won't affect drawing.
+			Glyph flags. See [enum TextServer.GraphemeFlag] for more info.
+			[b]Note:[/b] Read-only. Setting this property won't affect drawing.
 		</member>
 		<member name="glyph_index" type="int" setter="set_glyph_index" getter="get_glyph_index" default="0">
-			Font specific glyph index.
+			Glyph index specific to the [member font]. If you want to replace this glyph, use [method TextServer.font_get_glyph_index] with [member font] to get a new glyph index for a single character.
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The position offset the character will be drawn with (in pixels).
 		</member>
 		<member name="outline" type="bool" setter="set_outline" getter="is_outline" default="false">
-			If [code]true[/code], FX transform is called for outline drawing. Setting this property won't affect drawing.
+			If [code]true[/code], FX transform is called for outline drawing.
+			[b]Note:[/b] Read-only. Setting this property won't affect drawing.
 		</member>
 		<member name="range" type="Vector2i" setter="set_range" getter="get_range" default="Vector2i(0, 0)">
-			Absolute character range in the string, corresponding to the glyph. Setting this property won't affect drawing.
+			Absolute character range in the string, corresponding to the glyph.
+			[b]Note:[/b] Read-only. Setting this property won't affect drawing.
 		</member>
 		<member name="relative_index" type="int" setter="set_relative_index" getter="get_relative_index" default="0">
-			The character offset of the glyph, relative to the current [RichTextEffect] custom block. Setting this property won't affect drawing.
+			The character offset of the glyph, relative to the current [RichTextEffect] custom block.
+			[b]Note:[/b] Read-only. Setting this property won't affect drawing.
 		</member>
 		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D(1, 0, 0, 1, 0, 0)">
 			The current transform of the current glyph. It can be overridden (for example, by driving the position and rotation from a curve). You can also alter the existing value to apply transforms on top of other effects.

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1224,7 +1224,6 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 								char_xform = charfx->transform;
 								fx_offset = charfx->offset;
 								font_color = charfx->color;
-								frid = charfx->font;
 								gl = charfx->glyph_index;
 								txt_visible &= charfx->visibility;
 							}


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/102333

In most cases, setting `font` value will result in incorrect rendering, since it's `CharFX` is applied after text shaping (and therefor changing font require replicating shaping process and in many cases completely impossible). `font` value was intended to get replacement glyph indices, not to change it.