### PR TITLE
Forward color picker preview mouse button events to the window underneath.

### DIFF
--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -211,6 +211,7 @@ private:
 
 	Color color;
 	Color old_color;
+	Color pre_picking_color;
 	bool is_picking_color = false;
 
 	bool display_old_color = false;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/102293
Supersede https://github.com/godotengine/godot/pull/102320