### PR TITLE
Fix ColorPicker RAW alpha slider theme

### DIFF
--- a/scene/gui/color_mode.cpp
+++ b/scene/gui/color_mode.cpp
@@ -267,7 +267,7 @@ void ColorModeRAW::slider_draw(int p_which) {
 }
 
 bool ColorModeRAW::apply_theme() const {
-	for (int i = 0; i < 4; i++) {
+	for (int i = 0; i < ColorPicker::SLIDER_COUNT; i++) {
 		HSlider *slider = color_picker->get_slider(i);
 		slider->remove_theme_icon_override("grabber");
 		slider->remove_theme_icon_override("grabber_highlight");


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/102348

SLIDER_COUNT was changed in https://github.com/godotengine/godot/pull/101100
This made the apply_theme for color mode RAW in color_mode reset the theme for the alpha slider too. 
