### PR TITLE
Optimize Lighting when energy is set to 0

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -765,6 +765,11 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 					continue;
 				}
 
+				// Has no energy, don't draw this light to improve performance.
+				if (light->param[RSE::LIGHT_PARAM_ENERGY] <= CMP_EPSILON) {
+					continue;
+				}
+
 				Transform3D light_transform = light_instance->transform;
 				const real_t distance = p_camera_transform.origin.distance_to(light_transform.origin);
 
@@ -787,6 +792,11 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 			} break;
 			case RSE::LIGHT_SPOT: {
 				if (spot_light_count >= max_lights) {
+					continue;
+				}
+
+				// Has no energy, don't draw this light to improve performance.
+				if (light->param[RSE::LIGHT_PARAM_ENERGY] <= CMP_EPSILON) {
 					continue;
 				}
 

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2860,10 +2860,17 @@ void RendererSceneCull::_scene_cull(CullData &cull_data, InstanceCullResult &cul
 			if ((LAYER_CHECK && IN_FRUSTUM(cull_data.cull->frustum) && VIS_CHECK && !OCCLUSION_CULLED) || (cull_data.scenario->instance_data[i].flags & InstanceData::FLAG_IGNORE_ALL_CULLING)) {
 				uint32_t base_type = idata.flags & InstanceData::FLAG_BASE_TYPE_MASK;
 				if (base_type == RSE::INSTANCE_LIGHT) {
-					cull_result.lights.push_back(idata.instance);
-					cull_result.light_instances.push_back(RID::from_uint64(idata.instance_data_rid));
-					if (cull_data.shadow_atlas.is_valid() && RSG::light_storage->light_has_shadow(idata.base_rid)) {
-						RSG::light_storage->light_instance_mark_visible(RID::from_uint64(idata.instance_data_rid)); //mark it visible for shadow allocation later
+					RSE::LightType light_type = RSG::light_storage->light_get_type(idata.base_rid);
+					bool is_light_energy_culled =
+							(light_type == RSE::LIGHT_OMNI || light_type == RSE::LIGHT_SPOT) &&
+							RSG::light_storage->light_get_param(idata.base_rid, RSE::LIGHT_PARAM_ENERGY) <= CMP_EPSILON;
+
+					if (!is_light_energy_culled) {
+						cull_result.lights.push_back(idata.instance);
+						cull_result.light_instances.push_back(RID::from_uint64(idata.instance_data_rid));
+						if (cull_data.shadow_atlas.is_valid() && RSG::light_storage->light_has_shadow(idata.base_rid)) {
+							RSG::light_storage->light_instance_mark_visible(RID::from_uint64(idata.instance_data_rid)); //mark it visible for shadow allocation later
+						}
 					}
 
 				} else if (base_type == RSE::INSTANCE_REFLECTION_PROBE) {
@@ -3276,7 +3283,11 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 
 			if (light) {
 				if (p_using_shadows && p_shadow_atlas.is_valid() && RSG::light_storage->light_has_shadow(E->base) && !(RSG::light_storage->light_get_type(E->base) == RSE::LIGHT_DIRECTIONAL && RSG::light_storage->light_directional_get_sky_mode(E->base) == RSE::LIGHT_DIRECTIONAL_SKY_MODE_SKY_ONLY)) {
-					lights_with_shadow.push_back(E);
+					// Only draw the shadow only if it has energy
+					// otherwise we are wasting performance and lowering shadow resolution for other lights
+					if (bool is_light_energy_culled = RSG::light_storage->light_get_param(E->base, RSE::LIGHT_PARAM_ENERGY) <= CMP_EPSILON; !is_light_energy_culled) {
+						lights_with_shadow.push_back(E);
+					}
 				}
 				//add to list
 				directional_lights.push_back(light->instance);


### PR DESCRIPTION
I noticed that my FPS was tanking due to lights with no energy still being processed, so I culled omni and spot lights with no energy. I left DirectionalLight3D as-is because some people may be using the blackhole-like effect.

I also updated some code to use a hashmap instead of searching.

Closes https://github.com/godotengine/godot/issues/56633

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
