### PR TITLE
Use iterator pattern instead of manually traverse `List::Element *`

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1434,8 +1434,8 @@ void ProjectSettings::_add_builtin_input_map() {
 			Array events;
 
 			// Convert list of input events into array
-			for (List<Ref<InputEvent>>::Element *I = E.value.front(); I; I = I->next()) {
-				events.push_back(I->get());
+			for (const Ref<InputEvent> &event : E.value) {
+				events.push_back(event);
 			}
 
 			Dictionary action;

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -466,8 +466,8 @@ bool OS::is_restart_on_exit_set() const {
 Vector<String> OS::get_restart_on_exit_arguments() const {
 	List<String> args = ::OS::get_singleton()->get_restart_on_exit_arguments();
 	Vector<String> args_vector;
-	for (List<String>::Element *E = args.front(); E; E = E->next()) {
-		args_vector.push_back(E->get());
+	for (const String &arg : args) {
+		args_vector.push_back(arg);
 	}
 
 	return args_vector;
@@ -1879,8 +1879,8 @@ Vector<String> Engine::get_singleton_list() const {
 	List<::Engine::Singleton> singletons;
 	::Engine::get_singleton()->get_singletons(&singletons);
 	Vector<String> ret;
-	for (List<::Engine::Singleton>::Element *E = singletons.front(); E; E = E->next()) {
-		ret.push_back(E->get().name);
+	for (const ::Engine::Singleton &E : singletons) {
+		ret.push_back(E.name);
 	}
 	return ret;
 }

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -975,14 +975,14 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 					Array values;
 					List<StringName> enum_constant_list;
 					ClassDB::get_enum_constants(class_name, F, &enum_constant_list, true);
-					for (List<StringName>::Element *G = enum_constant_list.front(); G; G = G->next()) {
+					for (const StringName &enum_constant : enum_constant_list) {
 						Dictionary d3;
-						d3["name"] = String(G->get());
-						d3["value"] = ClassDB::get_integer_constant(class_name, G->get());
+						d3["name"] = String(enum_constant);
+						d3["value"] = ClassDB::get_integer_constant(class_name, enum_constant);
 
 						if (p_include_docs) {
 							for (const DocData::ConstantDoc &constant_doc : class_doc->constants) {
-								if (constant_doc.name == G->get()) {
+								if (constant_doc.name == enum_constant) {
 									d3["description"] = fix_doc_description(constant_doc.description);
 									break;
 								}

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -103,9 +103,7 @@ Vector<Vector<Vector2>> Geometry2D::decompose_many_polygons_in_convex(const Vect
 
 	decomp.resize(out_poly.size());
 	int idx = 0;
-	for (List<TPPLPoly>::Element *I = out_poly.front(); I; I = I->next()) {
-		TPPLPoly &tp = I->get();
-
+	for (TPPLPoly &tp : out_poly) {
 		decomp.write[idx].resize(tp.GetNumPoints());
 
 		for (int64_t i = 0; i < tp.GetNumPoints(); i++) {

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1089,8 +1089,8 @@ TypedArray<Dictionary> Object::_get_method_list_bind() const {
 	get_method_list(&ml);
 	TypedArray<Dictionary> ret;
 
-	for (List<MethodInfo>::Element *E = ml.front(); E; E = E->next()) {
-		Dictionary d = E->get();
+	for (const MethodInfo &mi : ml) {
+		Dictionary d = mi;
 		//va.push_back(d);
 		ret.push_back(d);
 	}

--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -53,8 +53,7 @@ void TranslationPO::print_translation_map() {
 
 		List<StringName> id_l;
 		inner_map.get_key_list(&id_l);
-		for (List<StringName>::Element *E2 = id_l.front(); E2; E2 = E2->next()) {
-			StringName id = E2->get();
+		for (const StringName &id : id_l) {
 			file->store_line("msgid: " + String::utf8(String(id).utf8()));
 			for (int i = 0; i < inner_map[id].size(); i++) {
 				file->store_line("msgstr[" + String::num_int64(i) + "]: " + String::utf8(String(inner_map[id][i]).utf8()));

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1468,8 +1468,8 @@ void TextureStorage::texture_debug_usage(List<RS::TextureInfo> *r_info) {
 	List<RID> textures;
 	texture_owner.get_owned_list(&textures);
 
-	for (List<RID>::Element *E = textures.front(); E; E = E->next()) {
-		Texture *t = texture_owner.get_or_null(E->get());
+	for (const RID &rid : textures) {
+		Texture *t = texture_owner.get_or_null(rid);
 		if (!t) {
 			continue;
 		}

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1251,12 +1251,12 @@ void AnimationMultiTrackKeyEdit::_get_property_list(List<PropertyInfo> *p_list) 
 					if (ap) {
 						List<StringName> anims;
 						ap->get_animation_list(&anims);
-						for (List<StringName>::Element *G = anims.front(); G; G = G->next()) {
+						for (const StringName &anim : anims) {
 							if (!animations.is_empty()) {
 								animations += ",";
 							}
 
-							animations += String(G->get());
+							animations += String(anim);
 						}
 					}
 				}

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -1463,8 +1463,8 @@ void ConnectionsDock::update_tree() {
 				List<MethodInfo> base_signals;
 				base->get_script_signal_list(&base_signals);
 				HashSet<String> base_signal_names;
-				for (List<MethodInfo>::Element *F = base_signals.front(); F; F = F->next()) {
-					base_signal_names.insert(F->get().name);
+				for (const MethodInfo &signal : base_signals) {
+					base_signal_names.insert(signal.name);
 				}
 				for (List<MethodInfo>::Element *F = class_signals.front(); F; F = F->next()) {
 					if (base_signal_names.has(F->get().name)) {

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -83,8 +83,7 @@ void CreateDialog::_fill_type_list() {
 
 	EditorData &ed = EditorNode::get_editor_data();
 
-	for (List<StringName>::Element *I = complete_type_list.front(); I; I = I->next()) {
-		StringName type = I->get();
+	for (const StringName &type : complete_type_list) {
 		if (!_should_hide_type(type)) {
 			type_list.push_back(type);
 
@@ -216,8 +215,7 @@ void CreateDialog::_update_search() {
 	float highest_score = 0.0f;
 	StringName best_match;
 
-	for (List<StringName>::Element *I = type_list.front(); I; I = I->next()) {
-		StringName candidate = I->get();
+	for (const StringName &candidate : type_list) {
 		if (empty_search || search_text.is_subsequence_ofn(candidate)) {
 			_add_type(candidate, ClassDB::class_exists(candidate) ? TypeCategory::CPP_TYPE : TypeCategory::OTHER_TYPE);
 

--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -144,9 +144,7 @@ Dictionary DebugAdapterParser::req_initialize(const Dictionary &p_params) const 
 		// Send all current breakpoints
 		List<String> breakpoints;
 		ScriptEditor::get_singleton()->get_breakpoints(&breakpoints);
-		for (List<String>::Element *E = breakpoints.front(); E; E = E->next()) {
-			String breakpoint = E->get();
-
+		for (const String &breakpoint : breakpoints) {
 			String path = breakpoint.left(breakpoint.find_char(':', 6)); // Skip initial part of path, aka "res://"
 			int line = breakpoint.substr(path.size()).to_int();
 

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -906,66 +906,66 @@ void DebugAdapterProtocol::notify_process() {
 	String launch_mode = _current_peer->attached ? "attach" : "launch";
 
 	Dictionary event = parser->ev_process(launch_mode);
-	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		E->get()->res_queue.push_back(event);
+	for (const Ref<DAPeer> &peer : clients) {
+		peer->res_queue.push_back(event);
 	}
 }
 
 void DebugAdapterProtocol::notify_terminated() {
 	Dictionary event = parser->ev_terminated();
-	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		if ((_current_request == "launch" || _current_request == "restart") && _current_peer == E->get()) {
+	for (const Ref<DAPeer> &peer : clients) {
+		if ((_current_request == "launch" || _current_request == "restart") && _current_peer == peer) {
 			continue;
 		}
-		E->get()->res_queue.push_back(event);
+		peer->res_queue.push_back(event);
 	}
 }
 
 void DebugAdapterProtocol::notify_exited(const int &p_exitcode) {
 	Dictionary event = parser->ev_exited(p_exitcode);
-	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		if ((_current_request == "launch" || _current_request == "restart") && _current_peer == E->get()) {
+	for (const Ref<DAPeer> &peer : clients) {
+		if ((_current_request == "launch" || _current_request == "restart") && _current_peer == peer) {
 			continue;
 		}
-		E->get()->res_queue.push_back(event);
+		peer->res_queue.push_back(event);
 	}
 }
 
 void DebugAdapterProtocol::notify_stopped_paused() {
 	Dictionary event = parser->ev_stopped_paused();
-	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		E->get()->res_queue.push_back(event);
+	for (const Ref<DAPeer> &peer : clients) {
+		peer->res_queue.push_back(event);
 	}
 }
 
 void DebugAdapterProtocol::notify_stopped_exception(const String &p_error) {
 	Dictionary event = parser->ev_stopped_exception(p_error);
-	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		E->get()->res_queue.push_back(event);
+	for (const Ref<DAPeer> &peer : clients) {
+		peer->res_queue.push_back(event);
 	}
 }
 
 void DebugAdapterProtocol::notify_stopped_breakpoint(const int &p_id) {
 	Dictionary event = parser->ev_stopped_breakpoint(p_id);
-	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		E->get()->res_queue.push_back(event);
+	for (const Ref<DAPeer> &peer : clients) {
+		peer->res_queue.push_back(event);
 	}
 }
 
 void DebugAdapterProtocol::notify_stopped_step() {
 	Dictionary event = parser->ev_stopped_step();
-	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		E->get()->res_queue.push_back(event);
+	for (const Ref<DAPeer> &peer : clients) {
+		peer->res_queue.push_back(event);
 	}
 }
 
 void DebugAdapterProtocol::notify_continued() {
 	Dictionary event = parser->ev_continued();
-	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		if (_current_request == "continue" && E->get() == _current_peer) {
+	for (const Ref<DAPeer> &peer : clients) {
+		if (_current_request == "continue" && peer == _current_peer) {
 			continue;
 		}
-		E->get()->res_queue.push_back(event);
+		peer->res_queue.push_back(event);
 	}
 
 	reset_stack_info();
@@ -973,15 +973,14 @@ void DebugAdapterProtocol::notify_continued() {
 
 void DebugAdapterProtocol::notify_output(const String &p_message, RemoteDebugger::MessageType p_type) {
 	Dictionary event = parser->ev_output(p_message, p_type);
-	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		E->get()->res_queue.push_back(event);
+	for (const Ref<DAPeer> &peer : clients) {
+		peer->res_queue.push_back(event);
 	}
 }
 
 void DebugAdapterProtocol::notify_custom_data(const String &p_msg, const Array &p_data) {
 	Dictionary event = parser->ev_custom_data(p_msg, p_data);
-	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		Ref<DAPeer> peer = E->get();
+	for (const Ref<DAPeer> &peer : clients) {
 		if (peer->supportsCustomData) {
 			peer->res_queue.push_back(event);
 		}
@@ -990,11 +989,11 @@ void DebugAdapterProtocol::notify_custom_data(const String &p_msg, const Array &
 
 void DebugAdapterProtocol::notify_breakpoint(const DAP::Breakpoint &p_breakpoint, const bool &p_enabled) {
 	Dictionary event = parser->ev_breakpoint(p_breakpoint, p_enabled);
-	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		if (_current_request == "setBreakpoints" && E->get() == _current_peer) {
+	for (const Ref<DAPeer> &peer : clients) {
+		if (_current_request == "setBreakpoints" && peer == _current_peer) {
 			continue;
 		}
-		E->get()->res_queue.push_back(event);
+		peer->res_queue.push_back(event);
 	}
 }
 
@@ -1013,8 +1012,7 @@ Array DebugAdapterProtocol::update_breakpoints(const String &p_path, const Array
 	}
 
 	// Remove breakpoints
-	for (List<DAP::Breakpoint>::Element *E = breakpoint_list.front(); E; E = E->next()) {
-		DAP::Breakpoint b = E->get();
+	for (const DAP::Breakpoint &b : breakpoint_list) {
 		if (b.source.path == p_path && !p_lines.has(b.line)) {
 			EditorDebuggerNode::get_singleton()->get_default_debugger()->_set_breakpoint(p_path, b.line, false);
 		}
@@ -1133,8 +1131,7 @@ void DebugAdapterProtocol::on_debug_stack_frame_vars(const int &p_size) {
 	frame.id = _current_frame;
 	ERR_FAIL_COND(!stackframe_list.has(frame));
 	List<int> scope_ids = stackframe_list.find(frame)->value;
-	for (List<int>::Element *E = scope_ids.front(); E; E = E->next()) {
-		int var_id = E->get();
+	for (const int var_id : scope_ids) {
 		if (variable_list.has(var_id)) {
 			variable_list.find(var_id)->value.clear();
 		} else {
@@ -1195,8 +1192,7 @@ void DebugAdapterProtocol::poll() {
 		on_client_connected();
 	}
 	List<Ref<DAPeer>> to_delete;
-	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		Ref<DAPeer> peer = E->get();
+	for (const Ref<DAPeer> &peer : clients) {
 		peer->connection->poll();
 		StreamPeerTCP::Status status = peer->connection->get_status();
 		if (status == StreamPeerTCP::STATUS_NONE || status == StreamPeerTCP::STATUS_ERROR) {
@@ -1214,8 +1210,8 @@ void DebugAdapterProtocol::poll() {
 		}
 	}
 
-	for (List<Ref<DAPeer>>::Element *E = to_delete.front(); E; E = E->next()) {
-		on_client_disconnected(E->get());
+	for (const Ref<DAPeer> &peer : to_delete) {
+		on_client_disconnected(peer);
 	}
 	to_delete.clear();
 }
@@ -1228,8 +1224,8 @@ Error DebugAdapterProtocol::start(int p_port, const IPAddress &p_bind_ip) {
 }
 
 void DebugAdapterProtocol::stop() {
-	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
-		E->get()->connection->disconnect_from_host();
+	for (const Ref<DAPeer> &peer : clients) {
+		peer->connection->disconnect_from_host();
 	}
 
 	clients.clear();

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -394,9 +394,9 @@ static Variant get_documentation_default_value(const StringName &p_class_name, c
 		// Cannot get default value of classes that can't be instantiated
 		List<StringName> inheriting_classes;
 		ClassDB::get_direct_inheriters_from_class(p_class_name, &inheriting_classes);
-		for (List<StringName>::Element *E2 = inheriting_classes.front(); E2; E2 = E2->next()) {
-			if (ClassDB::can_instantiate(E2->get())) {
-				default_value = ClassDB::class_get_default_property_value(E2->get(), p_property_name, &r_default_value_valid);
+		for (const StringName &class_name : inheriting_classes) {
+			if (ClassDB::can_instantiate(class_name)) {
+				default_value = ClassDB::class_get_default_property_value(class_name, p_property_name, &r_default_value_valid);
 				if (r_default_value_valid) {
 					break;
 				}
@@ -657,10 +657,10 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 			ClassDB::get_signal_list(name, &signal_list, true);
 
 			if (signal_list.size()) {
-				for (List<MethodInfo>::Element *EV = signal_list.front(); EV; EV = EV->next()) {
+				for (const MethodInfo &mi : signal_list) {
 					DocData::MethodDoc signal;
-					signal.name = EV->get().name;
-					for (const PropertyInfo &arginfo : EV->get().arguments) {
+					signal.name = mi.name;
+					for (const PropertyInfo &arginfo : mi.arguments) {
 						DocData::ArgumentDoc argument;
 						DocData::argument_doc_from_arginfo(argument, arginfo);
 

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -598,8 +598,7 @@ void EditorData::instantiate_object_properties(Object *p_object) {
 	List<PropertyInfo> pinfo;
 	p_object->get_property_list(&pinfo);
 
-	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-		PropertyInfo pi = E->get();
+	for (const PropertyInfo &pi : pinfo) {
 		if (pi.type == Variant::OBJECT && pi.usage & PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT) {
 			Object *prop = ClassDB::instantiate(pi.class_name);
 			p_object->set(pi.name, prop);

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1151,15 +1151,15 @@ int EditorFileSystem::_scan_new_dir(ScannedDirectory *p_dir, Ref<DirAccess> &da)
 
 	int nb_files_total_scan = 0;
 
-	for (List<String>::Element *E = dirs.front(); E; E = E->next()) {
-		if (da->change_dir(E->get()) == OK) {
+	for (const String &dir : dirs) {
+		if (da->change_dir(dir) == OK) {
 			String d = da->get_current_dir();
 
 			if (d == cd || !d.begins_with(cd)) {
 				da->change_dir(cd); //avoid recursion
 			} else {
 				ScannedDirectory *sd = memnew(ScannedDirectory);
-				sd->name = E->get();
+				sd->name = dir;
 				sd->full_path = p_dir->full_path.path_join(sd->name);
 
 				nb_files_total_scan += _scan_new_dir(sd, da);
@@ -1169,7 +1169,7 @@ int EditorFileSystem::_scan_new_dir(ScannedDirectory *p_dir, Ref<DirAccess> &da)
 				da->change_dir("..");
 			}
 		} else {
-			ERR_PRINT("Cannot go into subdir '" + E->get() + "'.");
+			ERR_PRINT("Cannot go into subdir '" + dir + "'.");
 		}
 	}
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -780,9 +780,7 @@ bool EditorProperty::use_keying_next() const {
 	List<PropertyInfo> plist;
 	object->get_property_list(&plist, true);
 
-	for (List<PropertyInfo>::Element *I = plist.front(); I; I = I->next()) {
-		PropertyInfo &p = I->get();
-
+	for (const PropertyInfo &p : plist) {
 		if (p.name == property) {
 			return (p.usage & PROPERTY_USAGE_KEYING_INCREMENTS);
 		}

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -1642,22 +1642,22 @@ void ColladaImport::create_animation(int p_clip, bool p_import_value_tracks) {
 		}
 
 		for (int i = 0; i < snapshots.size(); i++) {
-			for (List<int>::Element *ET = nm.anim_tracks.front(); ET; ET = ET->next()) {
+			for (const int track_id : nm.anim_tracks) {
 				//apply tracks
 
 				if (p_clip == -1) {
-					if (track_filter.has(ET->get())) {
+					if (track_filter.has(track_id)) {
 						continue;
 					}
 				} else {
-					if (!track_filter.has(ET->get())) {
+					if (!track_filter.has(track_id)) {
 						continue;
 					}
 				}
 
 				found_anim = true;
 
-				const Collada::AnimationTrack &at = collada.state.animation_tracks[ET->get()];
+				const Collada::AnimationTrack &at = collada.state.animation_tracks[track_id];
 
 				int xform_idx = -1;
 				for (int j = 0; j < cn->xform_list.size(); j++) {

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -533,8 +533,8 @@ void DynamicFontImportSettingsDialog::_variation_add() {
 	import_variation_data->owner = this;
 	ERR_FAIL_COND(import_variation_data.is_null());
 
-	for (List<ResourceImporter::ImportOption>::Element *E = options_variations.front(); E; E = E->next()) {
-		import_variation_data->defaults[E->get().option.name] = E->get().default_value;
+	for (const ResourceImporter::ImportOption &option : options_variations) {
+		import_variation_data->defaults[option.option.name] = option.default_value;
 	}
 
 	import_variation_data->options = options_variations;
@@ -1170,8 +1170,8 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 
 	text_settings_data->owner = this;
 
-	for (List<ResourceImporter::ImportOption>::Element *F = options_text.front(); F; F = F->next()) {
-		text_settings_data->defaults[F->get().option.name] = F->get().default_value;
+	for (const ResourceImporter::ImportOption &option : options_text) {
+		text_settings_data->defaults[option.option.name] = option.default_value;
 	}
 
 	text_settings_data->fd = font_main;
@@ -1190,8 +1190,8 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 
 	import_settings_data->settings.clear();
 	import_settings_data->defaults.clear();
-	for (List<ResourceImporter::ImportOption>::Element *E = options_general.front(); E; E = E->next()) {
-		import_settings_data->defaults[E->get().option.name] = E->get().default_value;
+	for (const ResourceImporter::ImportOption &option : options_general) {
+		import_settings_data->defaults[option.option.name] = option.default_value;
 	}
 
 	Ref<ConfigFile> config;
@@ -1203,8 +1203,7 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 	if (err == OK) {
 		List<String> keys;
 		config->get_section_keys("params", &keys);
-		for (List<String>::Element *E = keys.front(); E; E = E->next()) {
-			String key = E->get();
+		for (const String &key : keys) {
 			print_verbose(String("    ") + key + " == " + String(config->get_value("params", key)));
 			if (key == "preload") {
 				Array preload_configurations = config->get_value("params", key);
@@ -1231,8 +1230,8 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 					ERR_FAIL_COND(import_variation_data_custom.is_null());
 
 					import_variation_data_custom->owner = this;
-					for (List<ResourceImporter::ImportOption>::Element *F = options_variations.front(); F; F = F->next()) {
-						import_variation_data_custom->defaults[F->get().option.name] = F->get().default_value;
+					for (const ResourceImporter::ImportOption &option : options_variations) {
+						import_variation_data_custom->defaults[option.option.name] = option.default_value;
 					}
 
 					import_variation_data_custom->fd = font_main;

--- a/editor/import/resource_importer_bmfont.cpp
+++ b/editor/import/resource_importer_bmfont.cpp
@@ -81,16 +81,16 @@ Error ResourceImporterBMFont::import(ResourceUID::ID p_source_id, const String &
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot load font to file \"" + p_source_file + "\".");
 
 	// Update import settings for the image files used by font.
-	for (List<String>::Element *E = image_files.front(); E; E = E->next()) {
+	for (const String &file : image_files) {
 		Ref<ConfigFile> config;
 		config.instantiate();
 
-		err = config->load(E->get() + ".import");
+		err = config->load(file + ".import");
 		if (err == OK) {
 			config->clear();
 			config->set_value("remap", "importer", "skip");
 
-			config->save(E->get() + ".import");
+			config->save(file + ".import");
 		}
 	}
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -643,14 +643,14 @@ void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 	ClassDB::get_inheriters_from_class("AnimationRootNode", &classes);
 	classes.sort_custom<StringName::AlphCompare>();
 
-	for (List<StringName>::Element *E = classes.front(); E; E = E->next()) {
-		String name = String(E->get()).replace_first("AnimationNode", "");
+	for (const StringName &class_name : classes) {
+		String name = String(class_name).replace_first("AnimationNode", "");
 		if (name == "Animation" || name == "StartState" || name == "EndState") {
 			continue; // nope
 		}
 		int idx = menu->get_item_count();
 		menu->add_item(vformat(TTR("Add %s"), name), idx);
-		menu->set_item_metadata(idx, E->get());
+		menu->set_item_metadata(idx, class_name);
 	}
 	Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
 
@@ -2019,16 +2019,16 @@ void EditorAnimationMultiTransitionEdit::_get_property_list(List<PropertyInfo> *
 		prop_transition_path.name = itos(i) + "/" + "transition_path";
 		p_list->push_back(prop_transition_path);
 
-		for (List<PropertyInfo>::Element *F = plist.front(); F; F = F->next()) {
-			if (F->get().name == "script" || F->get().name == "resource_name" || F->get().name == "resource_path" || F->get().name == "resource_local_to_scene") {
+		for (const PropertyInfo &pi : plist) {
+			if (pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene") {
 				continue;
 			}
 
-			if (F->get().usage != PROPERTY_USAGE_DEFAULT) {
+			if (pi.usage != PROPERTY_USAGE_DEFAULT) {
 				continue;
 			}
 
-			PropertyInfo prop = F->get();
+			PropertyInfo prop = pi;
 			prop.name = itos(i) + "/" + prop.name;
 
 			p_list->push_back(prop);

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -463,13 +463,13 @@ void TileSetAtlasSourceEditor::AtlasTileProxyObject::_get_property_list(List<Pro
 		tile_data->get_property_list(&list);
 
 		HashMap<String, int> counts; // Counts the number of time a property appears (useful for groups that may appear more than once)
-		for (List<PropertyInfo>::Element *E_property = list.front(); E_property; E_property = E_property->next()) {
+		for (const PropertyInfo &property : list) {
 			// Don't show category for TileData.
-			if (E_property->get().usage & PROPERTY_USAGE_CATEGORY) {
+			if (property.usage & PROPERTY_USAGE_CATEGORY) {
 				continue;
 			}
 
-			const String &property_string = E_property->get().name;
+			const String &property_string = property.name;
 			if (!tile_data->is_allowing_transform() && (property_string == "flip_h" || property_string == "flip_v" || property_string == "transpose")) {
 				continue;
 			}
@@ -480,7 +480,7 @@ void TileSetAtlasSourceEditor::AtlasTileProxyObject::_get_property_list(List<Pro
 				counts[property_string] += 1;
 			}
 
-			PropertyInfo stored_property_info = E_property->get();
+			PropertyInfo stored_property_info = property;
 			stored_property_info.usage |= PROPERTY_USAGE_STORAGE; // Ignore the storage flag in comparing properties.
 
 			PropertyId id = { counts[property_string], property_string };

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -222,8 +222,7 @@ void VersionControlEditorPlugin::_refresh_commit_list() {
 
 	List<EditorVCSInterface::Commit> commit_info_list = EditorVCSInterface::get_singleton()->get_previous_commits(commit_list_size_button->get_selected_metadata());
 
-	for (List<EditorVCSInterface::Commit>::Element *e = commit_info_list.front(); e; e = e->next()) {
-		EditorVCSInterface::Commit commit = e->get();
+	for (const EditorVCSInterface::Commit &commit : commit_info_list) {
 		TreeItem *item = commit_list->create_item();
 
 		// Only display the first line of a commit message
@@ -370,8 +369,7 @@ void VersionControlEditorPlugin::_refresh_stage_area() {
 	unstaged_files->get_root()->clear_children();
 
 	List<EditorVCSInterface::StatusFile> status_files = EditorVCSInterface::get_singleton()->get_modified_files_data();
-	for (List<EditorVCSInterface::StatusFile>::Element *E = status_files.front(); E; E = E->next()) {
-		EditorVCSInterface::StatusFile sf = E->get();
+	for (const EditorVCSInterface::StatusFile &sf : status_files) {
 		if (sf.area == EditorVCSInterface::TREE_AREA_STAGED) {
 			_add_new_item(staged_files, sf.file_path, sf.change_type);
 		} else if (sf.area == EditorVCSInterface::TREE_AREA_UNSTAGED) {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4421,8 +4421,8 @@ void VisualShaderEditor::_delete_nodes(int p_type, const List<int> &p_nodes) {
 		for (const VisualShader::Connection &E : conns) {
 			if (E.from_node == F || E.to_node == F) {
 				bool cancel = false;
-				for (List<VisualShader::Connection>::Element *R = used_conns.front(); R; R = R->next()) {
-					if (R->get().from_node == E.from_node && R->get().from_port == E.from_port && R->get().to_node == E.to_node && R->get().to_port == E.to_port) {
+				for (const VisualShader::Connection &R : used_conns) {
+					if (R.from_node == E.from_node && R.from_port == E.from_port && R.to_node == E.to_node && R.to_port == E.to_port) {
 						cancel = true; // to avoid ERR_ALREADY_EXISTS warning
 						break;
 					}

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -142,8 +142,8 @@ void ProjectManager::_build_icon_type_cache(Ref<Theme> p_theme) {
 	}
 	List<StringName> tl;
 	p_theme->get_icon_list(EditorStringName(EditorIcons), &tl);
-	for (List<StringName>::Element *E = tl.front(); E; E = E->next()) {
-		icon_type_cache[E->get()] = p_theme->get_icon(E->get(), EditorStringName(EditorIcons));
+	for (const StringName &name : tl) {
+		icon_type_cache[name] = p_theme->get_icon(name, EditorStringName(EditorIcons));
 	}
 }
 

--- a/modules/enet/enet_connection.cpp
+++ b/modules/enet/enet_connection.cpp
@@ -72,8 +72,8 @@ Error ENetConnection::create_host(int p_max_peers, int p_max_channels, int p_in_
 
 void ENetConnection::destroy() {
 	ERR_FAIL_NULL_MSG(host, "Host already destroyed.");
-	for (List<Ref<ENetPacketPeer>>::Element *E = peers.front(); E; E = E->next()) {
-		E->get()->_on_disconnect();
+	for (const Ref<ENetPacketPeer> &peer : peers) {
+		peer->_on_disconnect();
 	}
 	peers.clear();
 	enet_host_destroy(host);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1508,8 +1508,8 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	List<StringName> utility_func_names;
 	Variant::get_utility_function_list(&utility_func_names);
 
-	for (List<StringName>::Element *E = utility_func_names.front(); E; E = E->next()) {
-		ScriptLanguage::CodeCompletionOption option(E->get(), ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
+	for (const StringName &util_func_name : utility_func_names) {
+		ScriptLanguage::CodeCompletionOption option(util_func_name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 		option.insert_text += "(";
 		option.display += U"(\u2026)"; // As all utility functions contain an argument or more, this is hardcoded here.
 		r_result.insert(option.display, option);

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -543,8 +543,8 @@ Vector<LSP::Location> GDScriptWorkspace::find_all_usages(const LSP::DocumentSymb
 	list_script_files("res://", paths);
 
 	Vector<LSP::Location> usages;
-	for (List<String>::Element *PE = paths.front(); PE; PE = PE->next()) {
-		usages.append_array(find_usages_in_file(p_symbol, PE->get()));
+	for (const String &path : paths) {
+		usages.append_array(find_usages_in_file(p_symbol, path));
 	}
 	return usages;
 }

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1873,7 +1873,7 @@ struct GodotNativeClassInfo {
 	const DocData::ClassDoc *class_doc = nullptr;
 	const ClassDB::ClassInfo *class_info = nullptr;
 
-	Dictionary to_json() {
+	Dictionary to_json() const {
 		Dictionary dict;
 		dict["name"] = name;
 		dict["inherits"] = class_doc->inherits;
@@ -1888,11 +1888,11 @@ struct GodotCapabilities {
 	 */
 	List<GodotNativeClassInfo> native_classes;
 
-	Dictionary to_json() {
+	Dictionary to_json() const {
 		Dictionary dict;
 		Array classes;
-		for (List<GodotNativeClassInfo>::Element *E = native_classes.front(); E; E = E->next()) {
-			classes.push_back(E->get().to_json());
+		for (const GodotNativeClassInfo &native_class : native_classes) {
+			classes.push_back(native_class.to_json());
 		}
 		dict["native_classes"] = classes;
 		return dict;

--- a/modules/navigation/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation/2d/nav_mesh_generator_2d.cpp
@@ -502,9 +502,7 @@ void NavMeshGenerator2D::generator_bake_from_source_geometry_data(Ref<Navigation
 	Vector<Vector<int>> new_polygons;
 
 	HashMap<Vector2, int> points;
-	for (List<TPPLPoly>::Element *I = tppl_out_polygon.front(); I; I = I->next()) {
-		TPPLPoly &tp = I->get();
-
+	for (const TPPLPoly &tp : tppl_out_polygon) {
 		Vector<int> new_polygon;
 
 		for (int64_t i = 0; i < tp.GetNumPoints(); i++) {

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -256,8 +256,7 @@ void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, f
 float AnimationPlayer::get_current_blend_amount() {
 	Playback &c = playback;
 	float blend = 1.0;
-	for (List<Blend>::Element *E = c.blend.front(); E; E = E->next()) {
-		Blend &b = E->get();
+	for (const Blend &b : c.blend) {
 		blend = blend - b.blend_left;
 	}
 	return MAX(0, blend);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2679,11 +2679,11 @@ bool Node::is_part_of_edited_scene() const {
 
 void Node::get_storable_properties(HashSet<StringName> &r_storable_properties) const {
 	ERR_THREAD_GUARD
-	List<PropertyInfo> pi;
-	get_property_list(&pi);
-	for (List<PropertyInfo>::Element *E = pi.front(); E; E = E->next()) {
-		if ((E->get().usage & PROPERTY_USAGE_STORAGE)) {
-			r_storable_properties.insert(E->get().name);
+	List<PropertyInfo> property_list;
+	get_property_list(&property_list);
+	for (const PropertyInfo &pi : property_list) {
+		if ((pi.usage & PROPERTY_USAGE_STORAGE)) {
+			r_storable_properties.insert(pi.name);
 		}
 	}
 }

--- a/scene/resources/2d/navigation_polygon.cpp
+++ b/scene/resources/2d/navigation_polygon.cpp
@@ -396,9 +396,7 @@ void NavigationPolygon::make_polygons_from_outlines() {
 	vertices.clear();
 
 	HashMap<Vector2, int> points;
-	for (List<TPPLPoly>::Element *I = out_poly.front(); I; I = I->next()) {
-		TPPLPoly &tp = I->get();
-
+	for (const TPPLPoly &tp : out_poly) {
 		Vector<int> p;
 
 		for (int64_t i = 0; i < tp.GetNumPoints(); i++) {

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -3105,14 +3105,13 @@ void TextMesh::_generate_glyph_mesh_data(const GlyphMeshKey &p_key, const Glyph 
 		ERR_FAIL_MSG("Convex decomposing failed. Make sure the font doesn't contain self-intersecting lines, as these are not supported in TextMesh.");
 	}
 	List<TPPLPoly> out_tris;
-	for (List<TPPLPoly>::Element *I = out_poly.front(); I; I = I->next()) {
-		if (tpart.Triangulate_OPT(&(I->get()), &out_tris) == 0) {
+	for (TPPLPoly &tp : out_poly) {
+		if (tpart.Triangulate_OPT(&tp, &out_tris) == 0) {
 			ERR_FAIL_MSG("Triangulation failed. Make sure the font doesn't contain self-intersecting lines, as these are not supported in TextMesh.");
 		}
 	}
 
-	for (List<TPPLPoly>::Element *I = out_tris.front(); I; I = I->next()) {
-		TPPLPoly &tp = I->get();
+	for (const TPPLPoly &tp : out_tris) {
 		ERR_FAIL_COND(tp.GetNumPoints() != 3); // Triangles only.
 
 		for (int i = 0; i < 3; i++) {

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1905,18 +1905,18 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 
 		List<PropertyInfo> property_list;
 		res->get_property_list(&property_list);
-		for (List<PropertyInfo>::Element *PE = property_list.front(); PE; PE = PE->next()) {
-			if (skip_editor && PE->get().name.begins_with("__editor")) {
+		for (const PropertyInfo &pi : property_list) {
+			if (skip_editor && pi.name.begins_with("__editor")) {
 				continue;
 			}
-			if (PE->get().name == META_PROPERTY_MISSING_RESOURCES) {
+			if (pi.name == META_PROPERTY_MISSING_RESOURCES) {
 				continue;
 			}
 
-			if (PE->get().usage & PROPERTY_USAGE_STORAGE || missing_resource_properties.has(PE->get().name)) {
-				String name = PE->get().name;
+			if (pi.usage & PROPERTY_USAGE_STORAGE || missing_resource_properties.has(pi.name)) {
+				String name = pi.name;
 				Variant value;
-				if (PE->get().usage & PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT) {
+				if (pi.usage & PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT) {
 					NonPersistentKey npk;
 					npk.base = res;
 					npk.property = name;
@@ -1927,11 +1927,11 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 					value = res->get(name);
 				}
 
-				if (PE->get().type == Variant::OBJECT && missing_resource_properties.has(PE->get().name)) {
+				if (pi.type == Variant::OBJECT && missing_resource_properties.has(pi.name)) {
 					// Was this missing resource overridden? If so do not save the old value.
 					Ref<Resource> ures = value;
 					if (ures.is_null()) {
-						value = missing_resource_properties[PE->get().name];
+						value = missing_resource_properties[pi.name];
 					}
 				}
 
@@ -1941,7 +1941,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 					continue;
 				}
 
-				if (PE->get().type == Variant::OBJECT && value.is_zero() && !(PE->get().usage & PROPERTY_USAGE_STORE_IF_NULL)) {
+				if (pi.type == Variant::OBJECT && value.is_zero() && !(pi.usage & PROPERTY_USAGE_STORE_IF_NULL)) {
 					continue;
 				}
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1645,8 +1645,8 @@ void TextureStorage::texture_debug_usage(List<RS::TextureInfo> *r_info) {
 	List<RID> textures;
 	texture_owner.get_owned_list(&textures);
 
-	for (List<RID>::Element *E = textures.front(); E; E = E->next()) {
-		Texture *t = texture_owner.get_or_null(E->get());
+	for (const RID &rid : textures) {
+		Texture *t = texture_owner.get_or_null(rid);
 		if (!t) {
 			continue;
 		}


### PR DESCRIPTION
This is mostly a style change. `for (List<>::Element *E = list.front(); E; E = E->next())` is lengthy and hard to read, `for (const Type &E : list)` make it clear that we are doing a one-way scan and not mutating the container or elements.

An additional benefit is that we have removed the type name of `List` from the loop, making it possible to replace the container type in the future. In the previous pattern, we would have to modify the `for` loop if we wanted to replace `List` with `Vector` or `LocalVector`.
