### PR TITLE
Add method to get file icon image.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -584,6 +584,10 @@ String OS::get_temp_dir() const {
 	return ::OS::get_singleton()->get_temp_path();
 }
 
+Ref<Image> OS::get_file_icon(const String &p_path, const Size2i &p_size, Image::Interpolation p_interpolation) const {
+	return ::OS::get_singleton()->get_file_icon(p_path, p_size, p_interpolation);
+}
+
 bool OS::is_debug_build() const {
 #ifdef DEBUG_ENABLED
 	return true;
@@ -715,6 +719,8 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_cache_dir"), &OS::get_cache_dir);
 	ClassDB::bind_method(D_METHOD("get_temp_dir"), &OS::get_temp_dir);
 	ClassDB::bind_method(D_METHOD("get_unique_id"), &OS::get_unique_id);
+
+	ClassDB::bind_method(D_METHOD("get_file_icon", "path", "size", "interpolation"), &OS::get_file_icon, DEFVAL(Image::INTERPOLATE_LANCZOS));
 
 	ClassDB::bind_method(D_METHOD("get_keycode_string", "code"), &OS::get_keycode_string);
 	ClassDB::bind_method(D_METHOD("is_keycode_unicode", "code"), &OS::is_keycode_unicode);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -262,6 +262,8 @@ public:
 	String get_cache_dir() const;
 	String get_temp_dir() const;
 
+	Ref<Image> get_file_icon(const String &p_path, const Size2i &p_size, Image::Interpolation p_interpolation = Image::INTERPOLATE_LANCZOS) const;
+
 	Error set_thread_name(const String &p_name);
 	::Thread::ID get_thread_caller_id() const;
 	::Thread::ID get_main_thread_id() const;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/config/engine.h"
+#include "core/io/image.h"
 #include "core/io/logger.h"
 #include "core/io/remote_filesystem_client.h"
 #include "core/os/time_enums.h"
@@ -293,6 +294,8 @@ public:
 	virtual String get_user_data_dir(const String &p_user_dir) const;
 	virtual String get_user_data_dir() const;
 	virtual String get_resource_dir() const;
+
+	virtual Ref<Image> get_file_icon(const String &p_path, const Size2i &p_size, Image::Interpolation p_interpolation = Image::INTERPOLATE_LANCZOS) const { return Ref<Image>(); }
 
 	enum SystemDir {
 		SYSTEM_DIR_DESKTOP,

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -290,6 +290,16 @@
 				[b]Note:[/b] On macOS, if you want to launch another instance of Godot, always use [method create_instance] instead of relying on the executable path.
 			</description>
 		</method>
+		<method name="get_file_icon" qualifiers="const">
+			<return type="Image" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="size" type="Vector2i" />
+			<param index="2" name="interpolation" type="int" enum="Image.Interpolation" default="4" />
+			<description>
+				Returns an image containing the OS theme icon associated with the file/folder specified by [param path]. If multiple icon sizes are available, the closest to the [param size] is selected, and the image is resized to the requested size using [param interpolation].
+				[b]Note:[/b] This method is implemented on macOS and Windows.
+			</description>
+		</method>
 		<method name="get_granted_permissions" qualifiers="const">
 			<return type="PackedStringArray" />
 			<description>

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -99,6 +99,8 @@ public:
 
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;
 
+	virtual Ref<Image> get_file_icon(const String &p_path, const Size2i &p_size, Image::Interpolation p_interpolation = Image::INTERPOLATE_LANCZOS) const override;
+
 	virtual Error shell_open(const String &p_uri) override;
 	virtual Error shell_show_in_file_manager(String p_path, bool p_open_folder) override;
 

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -38,6 +38,7 @@
 
 #include "core/crypto/crypto_core.h"
 #include "core/version_generated.gen.h"
+#include "drivers/png/png_driver_common.h"
 #include "main/main.h"
 
 #include <dlfcn.h>
@@ -382,6 +383,31 @@ String OS_MacOS::get_system_dir(SystemDir p_dir, bool p_shared_storage) const {
 	}
 
 	return ret;
+}
+
+Ref<Image> OS_MacOS::get_file_icon(const String &p_path, const Size2i &p_size, Image::Interpolation p_interpolation) const {
+	NSImage *ns_img = [[NSWorkspace sharedWorkspace] iconForFile:[NSString stringWithUTF8String:p_path.utf8().get_data()]];
+	if (ns_img == nil) {
+		return Ref<Image>();
+	}
+	NSImageRep *best_size_rep = [ns_img bestRepresentationForRect:NSMakeRect(0, 0, p_size.x, p_size.y) context:nil hints:nil];
+	NSBitmapImageRep *bitmap_rep;
+	if ([best_size_rep isKindOfClass:[NSBitmapImageRep class]]) {
+		bitmap_rep = (NSBitmapImageRep *)best_size_rep;
+	} else {
+		NSImage *new_image = [[NSImage alloc] initWithSize:[best_size_rep size]];
+		[new_image addRepresentation:best_size_rep];
+		bitmap_rep = [NSBitmapImageRep imageRepWithData:[new_image TIFFRepresentation]];
+	}
+	if (bitmap_rep == nil) {
+		return Ref<Image>();
+	}
+	NSData *png_data = [bitmap_rep representationUsingType:NSBitmapImageFileTypePNG properties:@{}];
+	Ref<Image> image;
+	image.instantiate();
+	PNGDriverCommon::png_to_image((const uint8_t *)png_data.bytes, png_data.length, false, image);
+	image->resize(p_size.x, p_size.y, p_interpolation);
+	return image;
 }
 
 Error OS_MacOS::shell_show_in_file_manager(String p_path, bool p_open_folder) {

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -414,6 +414,7 @@ def configure_msvc(env: "SConsEnvironment"):
         "dwrite",
         "wbemuuid",
         "ntdll",
+        "Comctl32",
     ]
 
     if env.debug_features:
@@ -762,6 +763,7 @@ def configure_mingw(env: "SConsEnvironment"):
             "dwrite",
             "wbemuuid",
             "ntdll",
+            "comctl32",
         ]
     )
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -51,8 +51,12 @@
 #include "servers/rendering/rendering_server_default.h"
 #include "servers/text_server.h"
 
+#include <initguid.h> // Note: should be included before "commctrl/commoncontrols".
+
 #include <avrt.h>
 #include <bcrypt.h>
+#include <commctrl.h>
+#include <commoncontrols.h>
 #include <direct.h>
 #include <knownfolders.h>
 #include <process.h>
@@ -2229,6 +2233,76 @@ String OS_Windows::get_system_dir(SystemDir p_dir, bool p_shared_storage) const 
 
 String OS_Windows::get_user_data_dir(const String &p_user_dir) const {
 	return get_data_path().path_join(p_user_dir).replace("\\", "/");
+}
+
+Ref<Image> OS_Windows::get_file_icon(const String &p_path, const Size2i &p_size, Image::Interpolation p_interpolation) const {
+	String path = fix_path(p_path);
+	SHFILEINFOW info;
+	UINT flags = SHGFI_SYSICONINDEX | SHGFI_USEFILEATTRIBUTES;
+
+	UINT file_flags = FILE_ATTRIBUTE_NORMAL;
+	if (DirAccess::dir_exists_absolute(p_path)) {
+		file_flags = FILE_ATTRIBUTE_DIRECTORY;
+	}
+
+	UINT sz_flags = SHIL_SMALL;
+	if (p_size.x >= 256) {
+		sz_flags = SHIL_JUMBO;
+	} else if (p_size.x >= 48) {
+		sz_flags = SHIL_EXTRALARGE;
+	} else if (p_size.x >= 32) {
+		sz_flags = SHIL_LARGE;
+	}
+
+	if (SHGetFileInfoW((LPCWSTR)p_path.utf16().get_data(), file_flags, &info, sizeof(info), flags) == 0) {
+		return Ref<Image>();
+	}
+
+	HIMAGELIST hil = nullptr;
+	if (SHGetImageList(sz_flags, IID_IImageList, (void **)&hil) != S_OK) {
+		return Ref<Image>();
+	}
+
+	int x = p_size.x;
+	int y = p_size.y;
+	ImageList_GetIconSize(hil, &x, &y);
+
+	Ref<Image> image;
+	HDC dc = GetDC(nullptr);
+	if (dc) {
+		HDC hdc = CreateCompatibleDC(dc);
+		if (hdc) {
+			HBITMAP hbm = CreateCompatibleBitmap(dc, x, y);
+			if (hbm) {
+				SelectObject(hdc, hbm);
+				ImageList_DrawEx(hil, info.iIcon, hdc, 0, 0, 0, 0, CLR_NONE, CLR_NONE, ILD_NORMAL);
+
+				BITMAPINFO bmp_info = {};
+				bmp_info.bmiHeader.biSize = sizeof(bmp_info.bmiHeader);
+				bmp_info.bmiHeader.biWidth = x;
+				bmp_info.bmiHeader.biHeight = -y;
+				bmp_info.bmiHeader.biPlanes = 1;
+				bmp_info.bmiHeader.biBitCount = 32;
+				bmp_info.bmiHeader.biCompression = BI_RGB;
+
+				Vector<uint8_t> img_data;
+				img_data.resize(x * y * 4);
+				GetDIBits(hdc, hbm, 0, x, img_data.ptrw(), &bmp_info, DIB_RGB_COLORS);
+
+				uint8_t *wr = (uint8_t *)img_data.ptrw();
+				for (int i = 0; i < x * y; i++) {
+					SWAP(wr[i * 4 + 0], wr[i * 4 + 2]); // Swap B and R.
+				}
+				image = Image::create_from_data(x, y, false, Image::Format::FORMAT_RGBA8, img_data);
+				image->resize(p_size.x, p_size.y, p_interpolation);
+
+				DeleteObject(hbm);
+			}
+			DeleteDC(hdc);
+		}
+		ReleaseDC(nullptr, dc);
+	}
+	return image;
 }
 
 String OS_Windows::get_unique_id() const {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -232,6 +232,8 @@ public:
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;
 	virtual String get_user_data_dir(const String &p_user_dir) const override;
 
+	virtual Ref<Image> get_file_icon(const String &p_path, const Size2i &p_size, Image::Interpolation p_interpolation = Image::INTERPOLATE_LANCZOS) const override;
+
 	virtual String get_unique_id() const override;
 
 	virtual Error shell_open(const String &p_uri) override;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/discussions/11550

Adds `OS.get_file_icon(path, size, interpolation)` method to get system file icon.

| macOS | Windows 11 | Wine |
|---|---|---|
| <img width="600" src="https://github.com/user-attachments/assets/1e0eff78-96ee-44f1-98d6-414313e09630" /> | <img width="600" src="https://github.com/user-attachments/assets/1993e3e5-c3a3-4d71-bec3-35d99aa043ee" /> | <img width="600" src="https://github.com/user-attachments/assets/c68fc17f-fd33-4713-95de-c1556a92cbbc" /> |
