### PR TITLE
Implement `get_length()` for pipes.

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -451,7 +451,7 @@ String FileAccess::get_line() const {
 	uint8_t c = get_8();
 
 	while (!eof_reached()) {
-		if (c == '\n' || c == '\0') {
+		if (c == '\n' || c == '\0' || get_error() != OK) {
 			line.push_back(0);
 			return String::utf8(line.get_data());
 		} else if (c != '\r') {

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -204,7 +204,7 @@
 		<method name="get_length" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the size of the file in bytes.
+				Returns the size of the file in bytes. For a pipe, returns the number of bytes available for reading from the pipe.
 			</description>
 		</method>
 		<method name="get_line" qualifiers="const">

--- a/drivers/unix/file_access_unix_pipe.cpp
+++ b/drivers/unix/file_access_unix_pipe.cpp
@@ -37,6 +37,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -130,6 +131,14 @@ String FileAccessUnixPipe::get_path() const {
 
 String FileAccessUnixPipe::get_path_absolute() const {
 	return path_src;
+}
+
+uint64_t FileAccessUnixPipe::get_length() const {
+	ERR_FAIL_COND_V_MSG(fd[0] < 0, 0, "Pipe must be opened before use.");
+
+	int buf_rem = 0;
+	ERR_FAIL_COND_V(ioctl(fd[0], FIONREAD, &buf_rem) != 0, 0);
+	return buf_rem;
 }
 
 uint64_t FileAccessUnixPipe::get_buffer(uint8_t *p_dst, uint64_t p_length) const {

--- a/drivers/unix/file_access_unix_pipe.h
+++ b/drivers/unix/file_access_unix_pipe.h
@@ -61,7 +61,7 @@ public:
 	virtual void seek(uint64_t p_position) override {}
 	virtual void seek_end(int64_t p_position = 0) override {}
 	virtual uint64_t get_position() const override { return 0; }
-	virtual uint64_t get_length() const override { return 0; }
+	virtual uint64_t get_length() const override;
 
 	virtual bool eof_reached() const override { return false; }
 

--- a/drivers/windows/file_access_windows_pipe.cpp
+++ b/drivers/windows/file_access_windows_pipe.cpp
@@ -102,6 +102,14 @@ String FileAccessWindowsPipe::get_path_absolute() const {
 	return path_src;
 }
 
+uint64_t FileAccessWindowsPipe::get_length() const {
+	ERR_FAIL_COND_V_MSG(fd[0] == nullptr, -1, "Pipe must be opened before use.");
+
+	DWORD buf_rem = 0;
+	ERR_FAIL_COND_V(!PeekNamedPipe(fd[0], nullptr, 0, nullptr, &buf_rem, nullptr), 0);
+	return buf_rem;
+}
+
 uint64_t FileAccessWindowsPipe::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V_MSG(fd[0] == nullptr, -1, "Pipe must be opened before use.");
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);

--- a/drivers/windows/file_access_windows_pipe.h
+++ b/drivers/windows/file_access_windows_pipe.h
@@ -60,7 +60,7 @@ public:
 	virtual void seek(uint64_t p_position) override {}
 	virtual void seek_end(int64_t p_position = 0) override {}
 	virtual uint64_t get_position() const override { return 0; }
-	virtual uint64_t get_length() const override { return 0; }
+	virtual uint64_t get_length() const override;
 
 	virtual bool eof_reached() const override { return false; }
 


### PR DESCRIPTION
- Fixes `get_line()` getting stick if used with the pipes.
- Add implementation of `get_length` for Windows and Unix pipes, allows checking for available input buffer bytes: 
```gdscript
if pipe["stdio"].is_open():
	var sz = pipe["stdio"].get_length()
	if sz > 0:
		var buffer = pipe["stdio"].get_buffer(sz)
		$TextEdit.text += buffer.get_string_from_utf8()
```

Fixes https://github.com/godotengine/godot/issues/102340
