### PR TITLE
Blend Factor Specification in Shaders

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -264,7 +264,9 @@ public:
 		RS::CanvasItemTextureRepeat repeat = RS::CANVAS_ITEM_TEXTURE_REPEAT_MAX;
 
 		GLES3::CanvasShaderData::BlendMode blend_mode = GLES3::CanvasShaderData::BLEND_MODE_MIX;
+		GLenum blend_factors[4] = { GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA };
 		Color blend_color = Color(1.0, 1.0, 1.0, 1.0);
+		bool uses_blend_factors = false;
 
 		Item *clip = nullptr;
 
@@ -362,7 +364,7 @@ public:
 
 	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used, RenderingMethod::RenderInfo *r_render_info = nullptr) override;
 	void _render_items(RID p_to_render_target, int p_item_count, const Transform2D &p_canvas_transform_inverse, Light *p_lights, bool &r_sdf_used, bool p_to_backbuffer = false, RenderingMethod::RenderInfo *r_render_info = nullptr, bool p_backbuffer_has_mipmaps = false);
-	void _record_item_commands(const Item *p_item, RID p_render_target, const Transform2D &p_canvas_transform_inverse, Item *&current_clip, GLES3::CanvasShaderData::BlendMode p_blend_mode, Light *p_lights, uint32_t &r_index, bool &r_break_batch, bool &r_sdf_used, const Point2 &p_repeat_offset);
+	void _record_item_commands(const Item *p_item, RID p_render_target, const Transform2D &p_canvas_transform_inverse, Item *&current_clip, GLES3::CanvasShaderData::BlendMode p_blend_mode, const GLenum *p_blend_factors, Light *p_lights, uint32_t &r_index, bool &r_break_batch, bool &r_sdf_used, const Point2 &p_repeat_offset);
 	void _render_batch(Light *p_lights, uint32_t p_index, RenderingMethod::RenderInfo *r_render_info = nullptr);
 	bool _bind_material(GLES3::CanvasMaterialData *p_material_data, CanvasShaderGLES3::ShaderVariant p_variant, uint64_t p_specialization);
 	void _new_batch(bool &r_batch_broken);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3149,52 +3149,96 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 			}
 
 			if constexpr (p_pass_mode == PASS_MODE_COLOR || p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) {
-				GLES3::SceneShaderData::BlendMode desired_blend_mode;
+				GLES3::SceneShaderData::BlendMode desired_blend_mode = scene_state.current_blend_mode;
+				GLenum desired_blend_factors[4] = { scene_state.current_blend_factors[0], scene_state.current_blend_factors[1], scene_state.current_blend_factors[2], scene_state.current_blend_factors[3] };
 				if (pass > 0) {
 					desired_blend_mode = GLES3::SceneShaderData::BLEND_MODE_ADD;
+					desired_blend_factors[0] = (p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) ? GL_SRC_ALPHA : GL_ONE;
+					desired_blend_factors[1] = GL_ONE;
+					desired_blend_factors[2] = (p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) ? GL_SRC_ALPHA : GL_ONE;
+					desired_blend_factors[3] = GL_ONE;
 				} else {
 					desired_blend_mode = shader->blend_mode;
+					if (shader->uses_blend_factors) {
+						desired_blend_factors[0] = shader->blend_factors[0];
+						desired_blend_factors[1] = shader->blend_factors[1];
+						desired_blend_factors[2] = shader->blend_factors[2];
+						desired_blend_factors[3] = shader->blend_factors[3];
+					} else {
+						switch (desired_blend_mode) {
+							case GLES3::SceneShaderData::BLEND_MODE_MIX: {
+								desired_blend_factors[0] = GL_SRC_ALPHA;
+								desired_blend_factors[1] = GL_ONE_MINUS_SRC_ALPHA;
+								desired_blend_factors[2] = p_render_data->transparent_bg ? GL_ONE : GL_ZERO;
+								desired_blend_factors[3] = p_render_data->transparent_bg ? GL_ONE_MINUS_SRC_ALPHA : GL_ONE;
+							} break;
+							case GLES3::SceneShaderData::BLEND_MODE_ADD: {
+								desired_blend_factors[0] = (p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) ? GL_SRC_ALPHA : GL_ONE;
+								desired_blend_factors[1] = GL_ONE;
+								desired_blend_factors[2] = (p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) ? GL_SRC_ALPHA : GL_ONE;
+								desired_blend_factors[3] = GL_ONE;
+							} break;
+							case GLES3::SceneShaderData::BLEND_MODE_SUB: {
+								desired_blend_factors[0] = GL_SRC_ALPHA;
+								desired_blend_factors[1] = GL_ONE;
+								desired_blend_factors[2] = GL_SRC_ALPHA;
+								desired_blend_factors[3] = GL_ONE;
+							} break;
+							case GLES3::SceneShaderData::BLEND_MODE_MUL: {
+								desired_blend_factors[0] = GL_DST_COLOR;
+								desired_blend_factors[1] = GL_ZERO;
+								desired_blend_factors[2] = p_render_data->transparent_bg ? GL_DST_ALPHA : GL_ZERO;
+								desired_blend_factors[3] = p_render_data->transparent_bg ? GL_ZERO : GL_ONE;
+							} break;
+							case GLES3::SceneShaderData::BLEND_MODE_PREMULT_ALPHA: {
+								desired_blend_factors[0] = GL_ONE;
+								desired_blend_factors[1] = GL_ONE_MINUS_SRC_ALPHA;
+								desired_blend_factors[2] = GL_ONE;
+								desired_blend_factors[3] = GL_ONE_MINUS_SRC_ALPHA;
+							} break;
+							case GLES3::SceneShaderData::BLEND_MODE_ALPHA_TO_COVERAGE: {
+								// Do nothing for now.
+							} break;
+						}
+					}
 				}
 
-				if (desired_blend_mode != scene_state.current_blend_mode) {
+				bool need_state_switch = (desired_blend_mode != scene_state.current_blend_mode);
+				if (!need_state_switch) {
+					for (int j = 0; j < 4; j++) {
+						if (desired_blend_factors[j] != scene_state.current_blend_factors[j]) {
+							need_state_switch = true;
+							break;
+						}
+					}
+				}
+
+				if (need_state_switch) {
 					switch (desired_blend_mode) {
 						case GLES3::SceneShaderData::BLEND_MODE_MIX: {
 							glBlendEquation(GL_FUNC_ADD);
-							if (p_render_data->transparent_bg) {
-								glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-							} else {
-								glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
-							}
-
 						} break;
 						case GLES3::SceneShaderData::BLEND_MODE_ADD: {
 							glBlendEquation(GL_FUNC_ADD);
-							glBlendFunc(p_pass_mode == PASS_MODE_COLOR_TRANSPARENT ? GL_SRC_ALPHA : GL_ONE, GL_ONE);
-
 						} break;
 						case GLES3::SceneShaderData::BLEND_MODE_SUB: {
 							glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
-							glBlendFunc(GL_SRC_ALPHA, GL_ONE);
-
 						} break;
 						case GLES3::SceneShaderData::BLEND_MODE_MUL: {
 							glBlendEquation(GL_FUNC_ADD);
-							if (p_render_data->transparent_bg) {
-								glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_DST_ALPHA, GL_ZERO);
-							} else {
-								glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_ZERO, GL_ONE);
-							}
-
 						} break;
 						case GLES3::SceneShaderData::BLEND_MODE_PREMULT_ALPHA: {
 							glBlendEquation(GL_FUNC_ADD);
-							glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-
 						} break;
 						case GLES3::SceneShaderData::BLEND_MODE_ALPHA_TO_COVERAGE: {
 							// Do nothing for now.
 						} break;
 					}
+					glBlendFuncSeparate(desired_blend_factors[0], desired_blend_factors[1], desired_blend_factors[2], desired_blend_factors[3]);
+					scene_state.current_blend_factors[0] = desired_blend_factors[0];
+					scene_state.current_blend_factors[1] = desired_blend_factors[1];
+					scene_state.current_blend_factors[2] = desired_blend_factors[2];
+					scene_state.current_blend_factors[3] = desired_blend_factors[3];
 					scene_state.current_blend_mode = desired_blend_mode;
 				}
 			}

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -463,6 +463,7 @@ private:
 		bool used_depth_prepass = false;
 
 		GLES3::SceneShaderData::BlendMode current_blend_mode = GLES3::SceneShaderData::BLEND_MODE_MIX;
+		GLenum current_blend_factors[4] = { GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA };
 		RS::CullMode cull_mode = RS::CULL_MODE_BACK;
 		GLenum current_depth_function = GL_GEQUAL;
 

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -545,6 +545,33 @@ _FORCE_INLINE_ static void _fill_std140_ubo_empty(ShaderLanguage::DataType type,
 	}
 }
 
+static GLenum get_blend_factor_by_name(const StringName &name) {
+	static const int BLEND_FACTOR_MAX = 15;
+	static const Pair<const char *, GLenum> BLEND_FACTOR_NAMES[BLEND_FACTOR_MAX] = {
+		{ "zero", GL_ZERO },
+		{ "one", GL_ONE },
+		{ "src_color", GL_SRC_COLOR },
+		{ "one_minus_src_color", GL_ONE_MINUS_SRC_COLOR },
+		{ "dst_color", GL_DST_COLOR },
+		{ "one_minus_dst_color", GL_ONE_MINUS_DST_COLOR },
+		{ "src_alpha", GL_SRC_ALPHA },
+		{ "one_minus_src_alpha", GL_ONE_MINUS_SRC_ALPHA },
+		{ "dst_alpha", GL_DST_ALPHA },
+		{ "one_minus_dst_alpha", GL_ONE_MINUS_DST_ALPHA },
+		{ "constant_color", GL_CONSTANT_COLOR },
+		{ "one_minus_constant_color", GL_ONE_MINUS_CONSTANT_COLOR },
+		{ "constant_alpha", GL_CONSTANT_ALPHA },
+		{ "one_minus_constant_alpha", GL_ONE_MINUS_CONSTANT_ALPHA },
+		{ "src_alpha_saturate", GL_SRC_ALPHA_SATURATE },
+	};
+	for (int i = 0; i < BLEND_FACTOR_MAX; i++) {
+		if (name == StringName(BLEND_FACTOR_NAMES[i].first)) {
+			return BLEND_FACTOR_NAMES[i].second;
+		}
+	}
+	ERR_FAIL_V_MSG(GL_ZERO, vformat("Illegal blend factor name '%s'", name));
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // ShaderData
 
@@ -2591,6 +2618,7 @@ void CanvasShaderData::set_code(const String &p_code) {
 	ubo_size = 0;
 	uniforms.clear();
 
+	uses_blend_factors = false;
 	uses_screen_texture = false;
 	uses_screen_texture_mipmaps = false;
 	uses_sdf = false;
@@ -2606,6 +2634,7 @@ void CanvasShaderData::set_code(const String &p_code) {
 
 	// Actual enum set further down after compilation.
 	int blend_modei = BLEND_MODE_MIX;
+	Vector<StringName> blend_factor_names;
 
 	ShaderCompiler::IdentifierActions actions;
 	actions.entry_point_stages["vertex"] = ShaderCompiler::STAGE_VERTEX;
@@ -2624,6 +2653,7 @@ void CanvasShaderData::set_code(const String &p_code) {
 	actions.usage_flag_pointers["CUSTOM0"] = &uses_custom0;
 	actions.usage_flag_pointers["CUSTOM1"] = &uses_custom1;
 
+	actions.blend_factors = &blend_factor_names;
 	actions.uniforms = &uniforms;
 	Error err = MaterialStorage::get_singleton()->shaders.compiler_canvas.compile(RS::SHADER_CANVAS_ITEM, code, &actions, path, gen_code);
 	ERR_FAIL_COND_MSG(err != OK, "Shader compilation failed.");
@@ -2633,6 +2663,13 @@ void CanvasShaderData::set_code(const String &p_code) {
 	}
 
 	blend_mode = BlendMode(blend_modei);
+	if (blend_factor_names.size() == 4) {
+		uses_blend_factors = true;
+		for (int i = 0; i < 4; i++) {
+			blend_factors[i] = get_blend_factor_by_name(blend_factor_names[i]);
+		}
+	}
+
 	uses_screen_texture = gen_code.uses_screen_texture;
 	uses_screen_texture_mipmaps = gen_code.uses_screen_texture_mipmaps;
 
@@ -2908,6 +2945,7 @@ void SceneShaderData::set_code(const String &p_code) {
 	uses_alpha = false;
 	uses_alpha_clip = false;
 	uses_blend_alpha = false;
+	uses_blend_factors = false;
 	uses_depth_prepass_alpha = false;
 	uses_discard = false;
 	uses_roughness = false;
@@ -2951,6 +2989,7 @@ void SceneShaderData::set_code(const String &p_code) {
 	int blend_modei = BLEND_MODE_MIX;
 	int depth_test_disabledi = 0;
 	int depth_test_invertedi = 0;
+	Vector<StringName> blend_factor_names;
 	int alpha_antialiasing_modei = ALPHA_ANTIALIASING_OFF;
 	int cull_modei = RS::CULL_MODE_BACK;
 	int depth_drawi = DEPTH_DRAW_OPAQUE;
@@ -3044,6 +3083,7 @@ void SceneShaderData::set_code(const String &p_code) {
 
 	actions.stencil_reference = &stencil_referencei;
 
+	actions.blend_factors = &blend_factor_names;
 	actions.uniforms = &uniforms;
 
 	Error err = MaterialStorage::get_singleton()->shaders.compiler_scene.compile(RS::SHADER_SPATIAL, code, &actions, path, gen_code);
@@ -3054,6 +3094,12 @@ void SceneShaderData::set_code(const String &p_code) {
 	}
 
 	blend_mode = BlendMode(blend_modei);
+	if (blend_factor_names.size() == 4) {
+		uses_blend_factors = true;
+		for (int i = 0; i < 4; i++) {
+			blend_factors[i] = get_blend_factor_by_name(blend_factor_names[i]);
+		}
+	}
 	alpha_antialiasing_mode = AlphaAntiAliasing(alpha_antialiasing_modei);
 	depth_draw = DepthDraw(depth_drawi);
 	if (depth_test_disabledi) {

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -159,7 +159,9 @@ struct CanvasShaderData : public ShaderData {
 	String code;
 
 	BlendMode blend_mode;
+	GLenum blend_factors[4] = { GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA };
 
+	bool uses_blend_factors = false;
 	bool uses_screen_texture;
 	bool uses_screen_texture_mipmaps;
 	bool uses_sdf;
@@ -298,6 +300,7 @@ struct SceneShaderData : public ShaderData {
 	String code;
 
 	BlendMode blend_mode;
+	GLenum blend_factors[4] = { GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA };
 	AlphaAntiAliasing alpha_antialiasing_mode;
 	DepthDraw depth_draw;
 	DepthTest depth_test;
@@ -312,6 +315,7 @@ struct SceneShaderData : public ShaderData {
 	bool uses_alpha;
 	bool uses_alpha_clip;
 	bool uses_blend_alpha;
+	bool uses_blend_factors;
 	bool uses_depth_prepass_alpha;
 	bool uses_discard;
 	bool uses_roughness;

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -231,6 +231,7 @@ public:
 		DepthTest depth_test = DEPTH_TEST_ENABLED;
 
 		int blend_mode = BLEND_MODE_MIX;
+		RD::BlendFactor blend_factors[4] = { RD::BLEND_FACTOR_SRC_ALPHA, RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, RD::BLEND_FACTOR_ONE, RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA };
 		int depth_test_disabledi = 0;
 		int depth_test_invertedi = 0;
 		int alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF;
@@ -238,6 +239,7 @@ public:
 		bool uses_point_size = false;
 		bool uses_alpha = false;
 		bool uses_blend_alpha = false;
+		bool uses_blend_factors = false;
 		bool uses_alpha_clip = false;
 		bool uses_alpha_antialiasing = false;
 		bool uses_depth_prepass_alpha = false;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -231,6 +231,7 @@ public:
 		DepthTest depth_test;
 
 		int blend_mode = BLEND_MODE_MIX;
+		RD::BlendFactor blend_factors[4] = { RD::BLEND_FACTOR_SRC_ALPHA, RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, RD::BLEND_FACTOR_ONE, RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA };
 		int depth_test_disabledi = 0;
 		int depth_test_invertedi = 0;
 		int alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF;
@@ -239,6 +240,7 @@ public:
 		bool uses_point_size = false;
 		bool uses_alpha = false;
 		bool uses_blend_alpha = false;
+		bool uses_blend_factors = false;
 		bool uses_alpha_clip = false;
 		bool uses_alpha_antialiasing = false;
 		bool uses_depth_prepass_alpha = false;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -147,6 +147,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 	struct CanvasShaderData : public RendererRD::MaterialStorage::ShaderData {
 		Vector<ShaderCompiler::GeneratedCode::Texture> texture_uniforms;
 		int blend_mode = 0;
+		RD::BlendFactor blend_factors[4] = { RD::BLEND_FACTOR_SRC_ALPHA, RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, RD::BLEND_FACTOR_ONE, RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA };
 
 		Vector<uint32_t> ubo_offsets;
 		uint32_t ubo_size = 0;
@@ -158,6 +159,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		static const uint32_t VERTEX_INPUT_MASKS_SIZE = SHADER_VARIANT_MAX * 2;
 		std::atomic<uint64_t> vertex_input_masks[VERTEX_INPUT_MASKS_SIZE] = {};
 
+		bool uses_blend_factors = false;
 		bool uses_screen_texture = false;
 		bool uses_screen_texture_mipmaps = false;
 		bool uses_sdf = false;

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -648,7 +648,7 @@ bool MaterialStorage::ShaderData::is_parameter_texture(const StringName &p_param
 	return uniforms[p_param].is_texture();
 }
 
-RD::PipelineColorBlendState::Attachment MaterialStorage::ShaderData::blend_mode_to_blend_attachment(BlendMode p_mode) {
+RD::PipelineColorBlendState::Attachment MaterialStorage::ShaderData::blend_mode_to_blend_attachment(BlendMode p_mode, const RD::BlendFactor *p_blend_factors) {
 	RD::PipelineColorBlendState::Attachment attachment;
 
 	switch (p_mode) {
@@ -710,6 +710,13 @@ RD::PipelineColorBlendState::Attachment MaterialStorage::ShaderData::blend_mode_
 		default: {
 			// Use default attachment values.
 		} break;
+	}
+
+	if (p_blend_factors) {
+		attachment.src_color_blend_factor = p_blend_factors[0];
+		attachment.dst_color_blend_factor = p_blend_factors[1];
+		attachment.src_alpha_blend_factor = p_blend_factors[2];
+		attachment.dst_alpha_blend_factor = p_blend_factors[3];
 	}
 
 	return attachment;

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -84,7 +84,7 @@ public:
 
 		virtual ~ShaderData() {}
 
-		static RD::PipelineColorBlendState::Attachment blend_mode_to_blend_attachment(BlendMode p_mode);
+		static RD::PipelineColorBlendState::Attachment blend_mode_to_blend_attachment(BlendMode p_mode, const RD::BlendFactor *p_factors);
 		static bool blend_mode_uses_blend_alpha(BlendMode p_mode);
 	};
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -3956,6 +3956,15 @@ bool RenderingDevice::uniform_sets_have_linear_pools() const {
 /**** PIPELINES ****/
 /*******************/
 
+RenderingDeviceCommons::BlendFactor RenderingDevice::render_get_blend_factor_by_name(const StringName &name) {
+	for (int i = 0; i < BLEND_FACTOR_MAX; i++) {
+		if (name == StringName(BLEND_FACTOR_NAMES[i])) {
+			return BlendFactor(i);
+		}
+	}
+	return BLEND_FACTOR_MAX;
+}
+
 RID RenderingDevice::render_pipeline_create(RID p_shader, FramebufferFormatID p_framebuffer_format, VertexFormatID p_vertex_format, RenderPrimitive p_render_primitive, const PipelineRasterizationState &p_rasterization_state, const PipelineMultisampleState &p_multisample_state, const PipelineDepthStencilState &p_depth_stencil_state, const PipelineColorBlendState &p_blend_state, BitField<PipelineDynamicStateFlags> p_dynamic_state_flags, uint32_t p_for_render_pass, const Vector<PipelineSpecializationConstant> &p_specialization_constants) {
 	// Needs a shader.
 	Shader *shader = shader_owner.get_or_null(p_shader);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1160,6 +1160,7 @@ private:
 	RID_Owner<ComputePipeline, true> compute_pipeline_owner;
 
 public:
+	static BlendFactor render_get_blend_factor_by_name(const StringName &name);
 	RID render_pipeline_create(RID p_shader, FramebufferFormatID p_framebuffer_format, VertexFormatID p_vertex_format, RenderPrimitive p_render_primitive, const PipelineRasterizationState &p_rasterization_state, const PipelineMultisampleState &p_multisample_state, const PipelineDepthStencilState &p_depth_stencil_state, const PipelineColorBlendState &p_blend_state, BitField<PipelineDynamicStateFlags> p_dynamic_state_flags = 0, uint32_t p_for_render_pass = 0, const Vector<PipelineSpecializationConstant> &p_specialization_constants = Vector<PipelineSpecializationConstant>());
 	bool render_pipeline_is_valid(RID p_pipeline);
 

--- a/servers/rendering/rendering_device_commons.cpp
+++ b/servers/rendering/rendering_device_commons.cpp
@@ -1309,3 +1309,29 @@ Error RenderingDeviceCommons::reflect_spirv(VectorView<ShaderStageSPIRVData> p_s
 
 	return OK;
 }
+
+/*******************/
+/**** RENDERING ****/
+/*******************/
+
+const char *const RenderingDeviceCommons::BLEND_FACTOR_NAMES[BLEND_FACTOR_MAX] = {
+	"zero",
+	"one",
+	"src_color",
+	"one_minus_src_color",
+	"dst_color",
+	"one_minus_dst_color",
+	"src_alpha",
+	"one_minus_src_alpha",
+	"dst_alpha",
+	"one_minus_dst_alpha",
+	"constant_color",
+	"one_minus_constant_color",
+	"constant_alpha",
+	"one_minus_constant_alpha",
+	"src_alpha_saturate",
+	"src1_color",
+	"one_minus_src1_color",
+	"src1_alpha",
+	"one_minus_src1_alpha",
+};

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -737,6 +737,8 @@ public:
 		BLEND_FACTOR_MAX
 	};
 
+	static const char *const BLEND_FACTOR_NAMES[BLEND_FACTOR_MAX];
+
 	enum BlendOperation {
 		BLEND_OP_ADD,
 		BLEND_OP_SUBTRACT,

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -486,6 +486,12 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 				*p_actions.stencil_reference = pnode->stencil_reference;
 			}
 
+			// Blend factors.
+
+			if (p_actions.blend_factors) {
+				*p_actions.blend_factors = pnode->blend_factors;
+			}
+
 			// structs
 
 			for (int i = 0; i < pnode->vstructs.size(); i++) {

--- a/servers/rendering/shader_compiler.h
+++ b/servers/rendering/shader_compiler.h
@@ -53,6 +53,7 @@ public:
 		HashMap<StringName, Pair<int *, int>> stencil_mode_values;
 		int *stencil_reference = nullptr;
 
+		Vector<StringName> *blend_factors = nullptr;
 		HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> *uniforms = nullptr;
 	};
 

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -201,6 +201,7 @@ const char *ShaderLanguage::token_names[TK_MAX] = {
 	"ARG_OUT",
 	"ARG_INOUT",
 	"RENDER_MODE",
+	"BLEND_FACTORS",
 	"HINT_DEFAULT_WHITE_TEXTURE",
 	"HINT_DEFAULT_BLACK_TEXTURE",
 	"HINT_DEFAULT_TRANSPARENT_TEXTURE",
@@ -340,6 +341,7 @@ const ShaderLanguage::KeyWord ShaderLanguage::keyword_list[] = {
 	{ TK_SHADER_TYPE, "shader_type", CF_SHADER_TYPE, {}, {} },
 	{ TK_RENDER_MODE, "render_mode", CF_GLOBAL_SPACE, {}, {} },
 	{ TK_STENCIL_MODE, "stencil_mode", CF_GLOBAL_SPACE, {}, {} },
+	{ TK_BLEND_FACTORS, "blend_factors", CF_GLOBAL_SPACE, {}, {} },
 
 	// uniform qualifiers
 
@@ -9255,6 +9257,51 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 				keyword_completion_context = CF_GLOBAL_SPACE;
 #endif // DEBUG_ENABLED
 			} break;
+			case TK_BLEND_FACTORS: {
+#ifdef DEBUG_ENABLED
+				keyword_completion_context = CF_UNSPECIFIED;
+#endif // DEBUG_ENABLED
+				shader->blend_factors.clear();
+				for (int k = 0; k < 4; k++) {
+					StringName mode;
+					_get_completable_identifier(nullptr, COMPLETION_BLEND_FACTORS, mode);
+
+					if (mode == StringName()) {
+						_set_error(RTR("Expected an identifier for blend mode."));
+						return ERR_PARSE_ERROR;
+					}
+
+					const String smode = String(mode);
+					bool found = false;
+					for (int i = 0; i < RD::BLEND_FACTOR_MAX; i++) {
+						const String name = String(RD::BLEND_FACTOR_NAMES[i]);
+						if (smode == name) {
+							found = true;
+							break;
+						}
+					}
+
+					if (!found) {
+						_set_error(vformat(RTR("Invalid blend mode: '%s'."), smode));
+						return ERR_PARSE_ERROR;
+					}
+
+					shader->blend_factors.push_back(mode);
+
+					tk = _get_token();
+					if ((k < 3) && (tk.type == TK_COMMA)) {
+						//all good, do nothing
+					} else if ((k == 3) && (tk.type == TK_SEMICOLON)) {
+						break; //done
+					} else {
+						_set_error(vformat(RTR("Unexpected token: '%s'; blend mode list must consist of exactly 4 mode names, separated by commas)."), get_token_text(tk)));
+						return ERR_PARSE_ERROR;
+					}
+				}
+#ifdef DEBUG_ENABLED
+				keyword_completion_context = CF_GLOBAL_SPACE;
+#endif // DEBUG_ENABLED
+			} break;
 			case TK_STRUCT: {
 				ShaderNode::Struct st;
 				DataType type;
@@ -11493,6 +11540,14 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 						}
 					}
 				}
+			}
+
+			return OK;
+		} break;
+		case COMPLETION_BLEND_FACTORS: {
+			for (int i = 0; i < RD::BLEND_FACTOR_MAX; i++) {
+				ScriptLanguage::CodeCompletionOption option(String(RD::BLEND_FACTOR_NAMES[i]), ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
+				r_options->push_back(option);
 			}
 
 			return OK;

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -165,6 +165,7 @@ public:
 		TK_ARG_INOUT,
 		TK_RENDER_MODE,
 		TK_STENCIL_MODE,
+		TK_BLEND_FACTORS,
 		TK_HINT_DEFAULT_WHITE_TEXTURE,
 		TK_HINT_DEFAULT_BLACK_TEXTURE,
 		TK_HINT_DEFAULT_TRANSPARENT_TEXTURE,
@@ -726,6 +727,7 @@ public:
 		Vector<StringName> render_modes;
 		Vector<StringName> stencil_modes;
 		int stencil_reference = -1;
+		Vector<StringName> blend_factors;
 
 		Vector<Function> vfunctions;
 		Vector<Constant> vconstants;
@@ -803,6 +805,7 @@ public:
 		COMPLETION_SHADER_TYPE,
 		COMPLETION_RENDER_MODE,
 		COMPLETION_STENCIL_MODE,
+		COMPLETION_BLEND_FACTORS,
 		COMPLETION_MAIN_FUNCTION,
 		COMPLETION_IDENTIFIER,
 		COMPLETION_FUNCTION_CALL,


### PR DESCRIPTION
This PR augments shaders to allow explicit specification of which blend factors should be used for the material, and adds a directive to the shading language accordingly (`blend_factors`). These blend factors are expressed in terms that are already familiar to `RenderingDevice`, but lowercased to fit in with other identifiers in the shading language (e.g., `src_alpha`, `one_minus_src_alpha`, `dst_color`, etc.)

The current paradigm for specifying blend modes (`render_mode`) provides only the handful of most commonly-used blend modes, but the underlying graphics APIs support thousands of possible blend modes (4 fields, 19 possible values in each position = many thousands of options). Some applications would wish to use some of those blend modes which are not currently accessible to shaders (e.g., [emulation/recreation of old games)](https://github.com/godotengine/godot-proposals/issues/7058).

Additionally, direct support for specifying blend modes will provide more flexibility when using [premultiplied alpha](https://github.com/godotengine/godot-proposals/issues/4433). It would also allow users to [force material opacity](https://github.com/godotengine/godot-proposals/issues/3598), for shaders which don't currently support `blend_disabled`.

Finally, this would bring our blending flexibility much closer to what is supported by [other engines](https://docs.unity3d.com/ScriptReference/Rendering.BlendMode.html), which would make it easier for developers using those engines to transition their materials to Godot. This [Unigine documentation](https://developer.unigine.com/en/docs/latest/principles/render/blending/?rlang=cpp) of the feature gives some nice examples of effects that can be achieved by combining various blend factors.

The underlying blend factors are already supported in `RenderingDevice`; this PR just allows shaders to explicitly specify the quartet that they want.

This does not seek to replace or remove the existing blend mode specifications in `render_mode` for two reasons:
 - For basic usage, the existing `blend_*` specifications are perfectly sufficient and much more user-friendly
 - Users still need a way to express which blend equation / blend operation they want (`ADD`, `REVERSE_SUBTRACT`, `MIN`, `MAX`, etc.), and the `blend_*` specifications seem perfect for that

This feature is very straightforward to add to the `RenderingDevice`-based renderers, with minimal intrusion. Adding it to the Compatibility renderer is a bit more intrusive, but these blend modes have been supported since ancient, fixed-function OpenGL days, so there was no reason not to add them to the GLES3 renderer.

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/2621.*