### PR TITLE
Optimize `String::get_data` by avoiding a dereference of ptr, and inlining the function.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -745,11 +745,6 @@ signed char String::filenocasecmp_to(const String &p_str) const {
 	return naturalnocasecmp_to_base(this_str, that_str);
 }
 
-const char32_t *String::get_data() const {
-	static const char32_t zero = 0;
-	return size() ? &operator[](0) : &zero;
-}
-
 String String::_separate_compound_words() const {
 	if (length() == 0) {
 		return *this;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -177,7 +177,11 @@ class [[nodiscard]] CharStringT {
 public:
 	_FORCE_INLINE_ T *ptrw() { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ const T *get_data() const { return ptr() ? ptr() : &_null; }
+
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+	_FORCE_INLINE_ int length() const { return ptr() ? size() - 1 : 0; }
+	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
 
 	_FORCE_INLINE_ operator Span<T>() const { return Span(ptr(), length()); }
 	_FORCE_INLINE_ Span<T> span() const { return Span(ptr(), length()); }
@@ -224,14 +228,6 @@ public:
 		dst[lhs_len + 1] = _null;
 
 		return *this;
-	}
-
-	_FORCE_INLINE_ int length() const { return size() ? size() - 1 : 0; }
-	_FORCE_INLINE_ const T *get_data() const {
-		if (size()) {
-			return &operator[](0);
-		}
-		return &_null;
 	}
 
 protected:
@@ -313,7 +309,11 @@ public:
 
 	_FORCE_INLINE_ char32_t *ptrw() { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const char32_t *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ const char32_t *get_data() const { return ptr() ? ptr() : &_null; }
+
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+	_FORCE_INLINE_ int length() const { return ptr() ? size() - 1 : 0; }
+	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
 
 	_FORCE_INLINE_ operator Span<char32_t>() const { return Span(ptr(), length()); }
 	_FORCE_INLINE_ Span<char32_t> span() const { return Span(ptr(), length()); }
@@ -376,14 +376,6 @@ public:
 	// Special sorting for file names. Names starting with `_` are put before all others except those starting with `.`, otherwise natural comparison is used.
 	signed char filecasecmp_to(const String &p_str) const;
 	signed char filenocasecmp_to(const String &p_str) const;
-
-	const char32_t *get_data() const;
-	/* standard size stuff */
-
-	_FORCE_INLINE_ int length() const {
-		int s = size();
-		return s ? (s - 1) : 0; // length does not include zero
-	}
 
 	bool is_valid_string() const;
 
@@ -587,7 +579,6 @@ public:
 	Vector<uint8_t> sha1_buffer() const;
 	Vector<uint8_t> sha256_buffer() const;
 
-	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
 	_FORCE_INLINE_ bool contains(const char *p_str) const { return find(p_str) != -1; }
 	_FORCE_INLINE_ bool contains(const String &p_str) const { return find(p_str) != -1; }
 	_FORCE_INLINE_ bool contains_char(char32_t p_chr) const { return find_char(p_chr) != -1; }


### PR DESCRIPTION
I have just profiled 'extremely long' text editing: https://github.com/godotengine/godot/issues/101882#issuecomment-2631165014

One thing that surprised me was that `String::get_data` took an observable role at 1.3% (0.2s in the profiled case). This warrants optimizing it.

## Explanation
**size()**
The current implementation (effectively `size() ? ptr() : &_null`) forces the compiler to fetch the size from RAM. While it is unlikely that `get_data` is called without accessing the data afterwards, it _is_ likely that the data is accessed somewhere deeper in the array (not at the start where `size` is located), and thus the fetch to `size` may require a separate RAM fetch anyway. `String` guarantees that 0-size strings use `nullptr` semantics, thus fetching size is not actually necessary. I have used the same trick to optimize the `is_empty()` implementation (`CowData` / `Vector` already use this trick).

**inline**
Not inlining `get_data()` forces the compiler to generate a blackbox call (possibly unless `LTO` is used), which actually generates _more_ code (due to call semantics) than the inlined code may generate ([proof on GodBolt](https://godbolt.org/z/sYEb8xT83)). It is therefore warranted to expose the implementation to the header file, and allow it to be inlined.
In particular, the inline may allow the compiler to omit the `if` clause if `ptr` has already been established to be non-null at some earlier time.