### PR TITLE
GDExtension: Add interface functions for `Object::set_script_instance()`

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1572,6 +1572,15 @@ static GDExtensionScriptInstancePtr gdextension_object_get_script_instance(GDExt
 	return script_instance_extension->instance;
 }
 
+static void gdextension_object_set_script_instance(GDExtensionObjectPtr p_object, GDExtensionScriptInstancePtr p_script_instance) {
+	ERR_FAIL_NULL(p_object);
+
+	Object *o = (Object *)p_object;
+	ScriptInstance *script_instance = (ScriptInstanceExtension *)p_script_instance;
+
+	o->set_script_instance(script_instance);
+}
+
 #ifndef DISABLE_DEPRECATED
 static void gdextension_callable_custom_create(GDExtensionUninitializedTypePtr r_callable, GDExtensionCallableCustomInfo *p_custom_callable_info) {
 	memnew_placement(r_callable, Callable(memnew(CallableCustomExtension(p_custom_callable_info))));
@@ -1809,6 +1818,7 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(placeholder_script_instance_create);
 	REGISTER_INTERFACE_FUNC(placeholder_script_instance_update);
 	REGISTER_INTERFACE_FUNC(object_get_script_instance);
+	REGISTER_INTERFACE_FUNC(object_set_script_instance);
 #ifndef DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(callable_custom_create);
 #endif // DISABLE_DEPRECATED

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -2721,6 +2721,17 @@ typedef void (*GDExtensionInterfacePlaceHolderScriptInstanceUpdate)(GDExtensionS
  */
 typedef GDExtensionScriptInstanceDataPtr (*GDExtensionInterfaceObjectGetScriptInstance)(GDExtensionConstObjectPtr p_object, GDExtensionObjectPtr p_language);
 
+/**
+ * @name object_set_script_instance
+ * @since 4.5
+ *
+ * Set the script instance data attached to this object.
+ *
+ * @param p_object A pointer to the Object.
+ * @param p_script_instance A pointer to the script instance data to attach to this object.
+ */
+typedef void (*GDExtensionInterfaceObjectSetScriptInstance)(GDExtensionObjectPtr p_object, GDExtensionScriptInstanceDataPtr p_script_instance);
+
 /* INTERFACE: Callable */
 
 /**


### PR DESCRIPTION
Currently for GDExtensions that provide scripting language, fully setup instances can only be created by Godot calling the `_instance_create()` or `_placeholder_instance_create()` virtual methods, because after it calls them, it will do the `Object::set_script_instance()` call.

However, if the GDExtension wants to create instances itself outside of those virtual methods, or to manually set the script instance for any other reason, it can't do that.

Looking at GDScript and C#, they both use `set_script_instance()` to implement their own internal hot reloading. And C# uses `set_script_and_instance()` in its `tie_user_managed_to_unmanaged()`. This could be useful to other scripting languages from GDExtension for the same reasons.

**UPDATE:** `Object::set_script_and_instance()` doesn't really seem to be necessary since `Object::set_script_instance()` also sets the script to whatever the script instance has - I'm not really sure why we even have that function! But that's why it's fine to only expose `set_script_instance` and not also `set_script_and_instance`.

Also, adding these functions would also bring more parity between Godot modules and GDExtensions, since these are functions that Godot modules can use.