### PR TITLE
SCons: Enable `wasm64` support on web builds

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -20,16 +20,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Template w/ threads (target=template_release, threads=yes)
+          - name: Template w/ threads, 64-bit (target=template_release, threads=yes, arch=wasm64)
             cache-name: web-template
             target: template_release
-            scons-flags: threads=yes
+            scons-flags: threads=yes arch=wasm64
             artifact: true
 
-          - name: Template w/o threads (target=template_release, threads=no)
+          - name: Template w/o threads, 32-bit (target=template_release, threads=no, arch=wasm32)
             cache-name: web-nothreads-template
             target: template_release
-            scons-flags: threads=no
+            scons-flags: threads=no arch=wasm32
             artifact: true
 
     steps:

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -122,7 +122,7 @@ def configure(env: "SConsEnvironment"):
     env["EXPORTED_RUNTIME_METHODS"] = []
 
     # Validate arch.
-    supported_arches = ["wasm32"]
+    supported_arches = ["wasm32", "wasm64"]
     validate_arch(env["arch"], get_name(), supported_arches)
 
     try:
@@ -299,6 +299,8 @@ def configure(env: "SConsEnvironment"):
         env.extra_suffix = ".dlink" + env.extra_suffix
 
     env.Append(LINKFLAGS=["-sWASM_BIGINT"])
+    env.Append(CCFLAGS=[f"-sMEMORY64={0 if env['arch'] == 'wasm32' else 1}"])
+    env.Append(LINKFLAGS=[f"-sMEMORY64={0 if env['arch'] == 'wasm32' else 1}"])
 
     # Run the main application in a web worker
     if env["proxy_to_pthread"]:

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -17,7 +17,7 @@ compatibility_platform_aliases = {
 }
 
 # CPU architecture options.
-architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc64", "wasm32", "loongarch64"]
+architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc64", "wasm32", "wasm64", "loongarch64"]
 architecture_aliases = {
     "x86": "x86_32",
     "x64": "x86_64",


### PR DESCRIPTION
- Requires #100525
- Requires jrouwe/JoltPhysics#1491

This PR makes the necessary accomodations to allow 64-bit emscription builds to happen:
- Add `wasm64` architecture to support `MEMORY64=1`[^1]. The "hybrid" implementation is outside the scope of this PR.
- Explicitly pass architectures to web GHA, chosen arbitrarily (threads = 64-bit, no threads = 32-bit).
- Add "alt" 64-bit integer constructors/operators to `Variant`, enabling conversion of whichever integral type was *not* assigned to `int64_t`/`uint64_t`.

[^1]: https://emscripten.org/docs/tools_reference/settings_reference.html#memory64
[^2]: https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#3172---111924