### PR TITLE
Display correct symbol in warning when unique name is used without @onready annotation

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1093,7 +1093,12 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 							}
 						}
 						if (is_get_node) {
-							parser->push_warning(member.variable, GDScriptWarning::GET_NODE_DEFAULT_WITHOUT_ONREADY, is_using_shorthand ? "$" : "get_node()");
+							String offending_syntax = "get_node()";
+							if (is_using_shorthand) {
+								GDScriptParser::GetNodeNode *get_node_node = static_cast<GDScriptParser::GetNodeNode *>(expr);
+								offending_syntax = get_node_node->use_dollar ? "$" : "%";
+							}
+							parser->push_warning(member.variable, GDScriptWarning::GET_NODE_DEFAULT_WITHOUT_ONREADY, offending_syntax);
 						}
 					}
 				}

--- a/modules/gdscript/tests/scripts/analyzer/warnings/get_node_without_onready.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/get_node_without_onready.gd
@@ -1,6 +1,6 @@
 extends Node
 
-var add_node = do_add_node() # Hack to have one node on init and not fail at runtime.
+var add_node = do_add_nodes() # Hack to have nodes on init and not fail at runtime.
 
 var shorthand = $Node
 var with_self = self.get_node(^"Node")
@@ -8,11 +8,23 @@ var without_self = get_node(^"Node")
 var with_cast = get_node(^"Node") as Node
 var shorthand_with_cast = $Node as Node
 
+var shorthand_unique = %UniqueNode
+var shorthand_in_dollar_unique = $"%UniqueNode"
+var without_self_unique = get_node(^"%UniqueNode")
+var shorthand_with_cast_unique = %UniqueNode as Node
+
 func test():
 	print("warn")
 
-func do_add_node():
+func do_add_nodes():
 	var node = Node.new()
 	node.name = "Node"
 	@warning_ignore("unsafe_call_argument")
 	add_child(node)
+
+	var unique_node = Node.new()
+	unique_node.name = "UniqueNode"
+	@warning_ignore("unsafe_call_argument")
+	add_child(unique_node)
+	unique_node.owner = self
+	unique_node.unique_name_in_owner = true

--- a/modules/gdscript/tests/scripts/analyzer/warnings/get_node_without_onready.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/get_node_without_onready.out
@@ -4,4 +4,8 @@ GDTEST_OK
 ~~ WARNING at line 7: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "get_node()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
 ~~ WARNING at line 8: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "get_node()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
 ~~ WARNING at line 9: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "$" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+~~ WARNING at line 11: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "%" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+~~ WARNING at line 12: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "$" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+~~ WARNING at line 13: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "get_node()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+~~ WARNING at line 14: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "%" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
 warn


### PR DESCRIPTION
Closes #102386.

This adds a few lines of code to the procedure generating the warning. It simply checks if the path being used in shorthand begins with "%", and if so uses that symbol instead of "$" for the warning.


https://github.com/user-attachments/assets/9cbd3e4a-0fa5-4d4b-8106-198c2e157cd9


