### PR TITLE
Editor: Fix node selection within SubViewports using size 2d override

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -623,7 +623,7 @@ void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_no
 			return;
 		}
 		xform = vp->get_popup_base_transform();
-		if (!vp->get_visible_rect().has_point(xform.xform_inv(p_pos))) {
+		if (!vp->get_visible_rect().has_point(xform.affine_inverse().xform(p_pos))) {
 			return;
 		}
 	}
@@ -726,7 +726,7 @@ void CanvasItemEditor::_find_canvas_items_in_rect(const Rect2 &p_rect, Node *p_n
 			return;
 		}
 		xform = vp->get_popup_base_transform();
-		if (!vp->get_visible_rect().intersects(xform.xform_inv(p_rect))) {
+		if (!vp->get_visible_rect().intersects(xform.affine_inverse().xform(p_rect))) {
 			return;
 		}
 	}


### PR DESCRIPTION
Fix single and rectangular selection inside `SubViewport` when the viewport uses a size 2d override.

Closes #102388

<details>
<summary>Demonstration</summary>

| before | after |
| :---- | :---- |
| ![CleanShot 2025-02-04 at 12 41 19](https://github.com/user-attachments/assets/503a0f5f-6139-4ba8-b49e-e33cbed8748c) | ![CleanShot 2025-02-04 at 12 43 48](https://github.com/user-attachments/assets/4b68106e-193f-4b5d-b133-5f83d9a7d3e2) |
</details>