### PR TITLE
Hide slider for array size selector in editor

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -447,6 +447,7 @@ void EditorPropertyArray::update_property() {
 			size_slider = memnew(EditorSpinSlider);
 			size_slider->set_step(1);
 			size_slider->set_max(INT32_MAX);
+			size_slider->set_editing_integer(true);
 			size_slider->set_h_size_flags(SIZE_EXPAND_FILL);
 			size_slider->set_read_only(is_read_only());
 			size_slider->connect(SceneStringName(value_changed), callable_mp(this, &EditorPropertyArray::_length_changed));


### PR DESCRIPTION
Closes #102391.

This PR removes the slider from the array size field in the inspector:

![CleanShot 2025-02-03 at 19 09 18@2x](https://github.com/user-attachments/assets/a7e0f838-22e5-4416-ac24-33141ba3f665)

The behavior before this PR can be seen in the issue linked above. While not explicitly a *bug*, per se, the field's range is so wide that the moving the slider the tiniest bit would cause the array size to balloon past anything reasonable for people to make entries in or find a specific value for.
