### PR TITLE
CI: Add a Linux job for `template_debug`

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -74,11 +74,21 @@ jobs:
             artifact: false
             cache-limit: 5
 
-          - name: Template w/ Mono (target=template_release, tests=yes)
+          - name: Template w/ Mono, release (target=template_release, tests=yes)
             cache-name: linux-template-mono
             target: template_release
             sconsflags: module_mono_enabled=yes
             bin: ./bin/godot.linuxbsd.template_release.x86_64.mono
+            build-mono: false
+            tests: true
+            artifact: true
+            cache-limit: 1
+
+          - name: Template w/ Mono, debug (target=template_debug, tests=yes)
+            cache-name: linux-template-mono-debug
+            target: template_debug
+            sconsflags: module_mono_enabled=yes
+            bin: ./bin/godot.linuxbsd.template_debug.x86_64.mono
             build-mono: false
             tests: true
             artifact: true


### PR DESCRIPTION
Seems like we've been lacking this for a while, probably assuming that `target=editor` + `target=template_debug` was enough, but it's not:
- `editor`: `TOOLS_ENABLED` + `DEBUG_ENABLED`
- `template_debug`: `DEBUG_ENABLED`
- `template_release`: neither

So to test what happens when `DEBUG_ENABLED` is defined but not `TOOLS_ENABLED`, we do need a `template_debug` build, the combination of the other two isn't enough.

For now I'm just quickly adding a duplicate Linux template build with Mono. We might want to review the build matrix and ensure we have good coverage on multiple platforms (but still taking care of not doubling the size of the build matrix - we try to strike a balance between coverage and efficiency, but time and energy wise).