### PR TITLE
Fix over saturated static colored lights

### DIFF
--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -648,7 +648,7 @@ void trace_direct_light(vec3 p_position, vec3 p_normal, uint p_light_index, bool
 	}
 
 	r_shadow = penumbra;
-	r_light = light_data.color * light_data.energy * attenuation * penumbra * penumbra_color;
+	r_light = light_data.energy * attenuation * penumbra * penumbra_color;
 }
 
 #endif


### PR DESCRIPTION
Fixes #102203 

The output of `trace_direct_light()` was multiplied by a color vector twice resulting in over saturation. 

Since `penumbra_color` is already derived from `light_color` it shouldn't be necessary to use `light_color` anymore in the final calculation.

I tested using:
 - [playble_terrain.zip](https://github.com/user-attachments/files/18661255/playble_terrain.zip)
 - [test_lightmap_directional_compress.zip](https://github.com/user-attachments/files/18661256/test_lightmap_directional_compress.zip)

Both seeme to be fixed:
![image](https://github.com/user-attachments/assets/a268624d-a5ed-40dc-94b8-c62327e4b5ae)

And
![image](https://github.com/user-attachments/assets/3baa62f1-6f84-4a79-97b8-73e590b88439)

This is the first time I'm diving into lighting, so please double check me. 