### PR TITLE
Revert "Use `AHashMap` for `RBMap` nodes and `HashMap` `input_activity`"

### DIFF
--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -410,7 +410,7 @@ class AnimationNodeBlendTree : public AnimationRootNode {
 		Vector<StringName> connections;
 	};
 
-	AHashMap<StringName, Node> nodes;
+	RBMap<StringName, Node, StringName::AlphCompare> nodes;
 
 	Vector2 graph_offset;
 

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -306,8 +306,8 @@ private:
 		uint64_t last_pass = 0;
 		real_t activity = 0.0;
 	};
-	mutable AHashMap<StringName, LocalVector<Activity>> input_activity_map;
-	mutable AHashMap<StringName, LocalVector<Activity> *> input_activity_map_get;
+	mutable HashMap<StringName, LocalVector<Activity>> input_activity_map;
+	mutable HashMap<StringName, LocalVector<Activity> *> input_activity_map_get;
 
 	NodePath animation_player;
 


### PR DESCRIPTION
This reverts commit c91c604eaa66d2307d13655ce513392e3bae77d6.

This caused a critical regression:

- Fixes #102374.
- Reverts #101548.