### PR TITLE
Don't expose AnimationNodeStartState and AnimationNodeEndState as internal, this triggers a ClassDB bug

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1322,7 +1322,8 @@ bool AnimationNodeStateMachine::are_ends_reset() const {
 
 bool AnimationNodeStateMachine::can_edit_node(const StringName &p_name) const {
 	if (states.has(p_name)) {
-		return !(states[p_name].node->is_class("AnimationNodeStartState") || states[p_name].node->is_class("AnimationNodeEndState"));
+		const AnimationNode *anode = states[p_name].node.ptr();
+		return !(Object::cast_to<AnimationNodeStartState>(anode) || Object::cast_to<AnimationNodeEndState>(anode));
 	}
 
 	return true;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -523,9 +523,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(AnimationNodeStateMachinePlayback);
 	GDREGISTER_VIRTUAL_CLASS(AnimationNodeExtension);
 
-	GDREGISTER_INTERNAL_CLASS(AnimationNodeStartState);
-	GDREGISTER_INTERNAL_CLASS(AnimationNodeEndState);
-
 	GDREGISTER_CLASS(AnimationNodeSync);
 	GDREGISTER_CLASS(AnimationNodeStateMachineTransition);
 	GDREGISTER_CLASS(AnimationNodeOutput);


### PR DESCRIPTION
Fixes #99534.

Please test to confirm the functionality still works, I don't know how to use of it.