### PR TITLE
Fix Tree `item_margin` for low spacing values in Editor Theme

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -966,7 +966,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 			p_theme->set_constant("v_separation", "Tree", p_config.separation_margin);
 			p_theme->set_constant("h_separation", "Tree", (p_config.increased_margin + 2) * EDSCALE);
 			p_theme->set_constant("guide_width", "Tree", p_config.border_width);
-			p_theme->set_constant("item_margin", "Tree", 3 * p_config.increased_margin * EDSCALE);
+			p_theme->set_constant("item_margin", "Tree", MAX(3 * p_config.increased_margin * EDSCALE, 12 * EDSCALE));
 			p_theme->set_constant("inner_item_margin_top", "Tree", p_config.separation_margin);
 			p_theme->set_constant("inner_item_margin_bottom", "Tree", p_config.separation_margin);
 			p_theme->set_constant("inner_item_margin_left", "Tree", p_config.increased_margin * EDSCALE);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/98418


base_spacing and additional_spacing set to 0

Before:
![Screenshot_20250204_035351](https://github.com/user-attachments/assets/9c1aca84-d3d9-419a-be1e-380dbc798ef9)


After:
![Screenshot_20250204_035423](https://github.com/user-attachments/assets/219725e1-d5a4-400a-b565-53bef25c834c)

