### PR TITLE
Prevent instantiating classes that aren't exposed

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -548,6 +548,7 @@ Object *ClassDB::_instantiate_internal(const StringName &p_class, bool p_require
 		}
 		ERR_FAIL_NULL_V_MSG(ti, nullptr, vformat("Cannot get class '%s'.", String(p_class)));
 		ERR_FAIL_COND_V_MSG(ti->disabled, nullptr, vformat("Class '%s' is disabled.", String(p_class)));
+		ERR_FAIL_COND_V_MSG(!ti->exposed, nullptr, vformat("Class '%s' isn't exposed.", String(p_class)));
 		ERR_FAIL_NULL_V_MSG(ti->creation_func, nullptr, vformat("Class '%s' or its base class cannot be instantiated.", String(p_class)));
 	}
 
@@ -604,7 +605,7 @@ bool ClassDB::_can_instantiate(ClassInfo *p_class_info) {
 		return false;
 	}
 
-	if (p_class_info->disabled || !p_class_info->creation_func) {
+	if (p_class_info->disabled || !p_class_info->exposed || !p_class_info->creation_func) {
 		return false;
 	}
 


### PR DESCRIPTION
Originally from https://github.com/godotengine/godot/issues/99534

Currently, if you call `ClassDB::can_instantiate("...")` for an internal class, it will return `true`, but most normal ways of instantiating the class in GDScript, GDExtension or C# won't work. However, they still can be created via `ClassDB::instantiate("...")`. There's also no indication to GDExtension or scripting from `ClassDB` that these classes can't be instantiated normally because we don't expose `ClassDB::class_is_exposed()`.

For example:

```
func _ready() -> void:
	# Prints: true
	print(ClassDB.class_exists("AnimationNodeStartState"))

	# Prints: true
	print(ClassDB.can_instantiate("AnimationNodeStartState"))

	# Prints: <AnimationNodeStartState#12345>
	print(ClassDB.instantiate("AnimationNodeStartState"))

	# ERROR!
	AnimationNodeStartState.new()
```

**Do we even want internal classes to be instantiatable via `ClassDB::instantiate("...")`?**

This PR answers **no**, and makes it so that internal classes return `false` for `ClassDB::can_instantiate()` and can't be created via `ClassDB::instantiate("...")`.

I don't _think_ there's anything that depends on the old behavior, but I'm not 100% sure, so treat this one with caution.
