### PR TITLE
Export the `rendering/renderer/rendering_method.mobile` project setting to the AndroidManifest

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -3406,6 +3406,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		}
 
 		String addons_directory = ProjectSettings::get_singleton()->globalize_path("res://addons");
+		String current_renderer = GLOBAL_GET("rendering/renderer/rendering_method.mobile");
 
 		cmdline.push_back("-p"); // argument to specify the start directory.
 		cmdline.push_back(build_path); // start directory.
@@ -3423,6 +3424,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		cmdline.push_back("-Pperform_signing=" + sign_flag); // argument to specify whether the build should be signed.
 		cmdline.push_back("-Pcompress_native_libraries=" + compress_native_libraries_flag); // argument to specify whether the build should compress native libraries.
 		cmdline.push_back("-Pgodot_editor_version=" + String(VERSION_FULL_CONFIG));
+		cmdline.push_back("-Pgodot_rendering_method=" + current_renderer);
 
 		// NOTE: The release keystore is not included in the verbose logging
 		// to avoid accidentally leaking sensitive information when sharing verbose logs for troubleshooting.

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -33,6 +33,10 @@
         <meta-data
             android:name="org.godotengine.editor.version"
             android:value="${godotEditorVersion}" />
+        <!-- Records the rendering method used by the Godot engine -->
+        <meta-data
+            android:name="org.godotengine.rendering.method"
+            android:value="${godotRenderingMethod}"/>
 
         <activity
             android:name=".GodotApp"

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -102,7 +102,10 @@ android {
             abiFilters export_abi_list
         }
 
-        manifestPlaceholders = [godotEditorVersion: getGodotEditorVersion()]
+        manifestPlaceholders = [
+            godotEditorVersion: getGodotEditorVersion(),
+            godotRenderingMethod: getGodotRenderingMethod()
+        ]
 
         // Feel free to modify the application id to your own.
         applicationId getExportPackageName()

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -70,6 +70,11 @@ ext.getExportTargetSdkVersion = { ->
     }
 }
 
+ext.getGodotRenderingMethod = { ->
+    String renderingMethod = project.hasProperty("godot_rendering_method") ? project.property("godot_rendering_method") : ""
+    return renderingMethod
+}
+
 ext.getGodotEditorVersion = { ->
     String editorVersion = project.hasProperty("godot_editor_version") ? project.property("godot_editor_version") : ""
     if (editorVersion == null || editorVersion.isEmpty()) {


### PR DESCRIPTION
The AndroidManifest already stores the Godot editor and library versions. The addition of this meta-data allows to identify Godot Android apps that may be subject to renderer specific issues addressed in future versions of the engine.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
