### PR TITLE
Fix reflection probes working in stereo on compatibility renderer

### DIFF
--- a/drivers/gles3/effects/cubemap_filter.cpp
+++ b/drivers/gles3/effects/cubemap_filter.cpp
@@ -127,6 +127,8 @@ Vector2 hammersley(uint32_t i, uint32_t N) {
 }
 
 void CubemapFilter::filter_radiance(GLuint p_source_cubemap, GLuint p_dest_cubemap, GLuint p_dest_framebuffer, int p_source_size, int p_mipmap_count, int p_layer) {
+	glDisable(GL_CULL_FACE);
+
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_CUBE_MAP, p_source_cubemap);
 	glBindFramebuffer(GL_FRAMEBUFFER, p_dest_framebuffer);


### PR DESCRIPTION
When rendering in stereo we do not do our right-side-up rendering of the main buffer. There seems to be a condition where our culling direction remains reversed which stopped the cubemap filter from working and copying the final mipmap results of the reflection probe leaving the contents of the reflection probe empty.

Disabling culling before performing the cubemap filter ensures we always perform the process.

Note that when the reflection probe is set to once, it can take over 6 frames before the reflection probe is populated with data as we render one side of the reflection probe per frame to save performance. So for the first 6 to 15 frames the reflection probe still remains black in the MRP supplied on the bug report causing the pillars to not be lit up correctly.

Fixes #102443
