### PR TITLE
Add `XK_KP_{Decimal,Enter}` to `KeyMappingX11::is_sym_numpad()`

### DIFF
--- a/platform/linuxbsd/wayland/key_mapping_xkb.cpp
+++ b/platform/linuxbsd/wayland/key_mapping_xkb.cpp
@@ -371,11 +371,13 @@ void KeyMappingXKB::initialize() {
 
 bool KeyMappingXKB::is_sym_numpad(xkb_keysym_t p_keysym) {
 	switch (p_keysym) {
+		case XKB_KEY_KP_Equal:
+		case XKB_KEY_KP_Add:
+		case XKB_KEY_KP_Subtract:
 		case XKB_KEY_KP_Multiply:
 		case XKB_KEY_KP_Divide:
-		case XKB_KEY_KP_Subtract:
 		case XKB_KEY_KP_Separator:
-		case XKB_KEY_KP_Add:
+		case XKB_KEY_KP_Decimal:
 		case XKB_KEY_KP_0:
 		case XKB_KEY_KP_1:
 		case XKB_KEY_KP_2:

--- a/platform/linuxbsd/x11/key_mapping_x11.cpp
+++ b/platform/linuxbsd/x11/key_mapping_x11.cpp
@@ -1131,11 +1131,13 @@ void KeyMappingX11::initialize() {
 
 bool KeyMappingX11::is_sym_numpad(KeySym p_keysym) {
 	switch (p_keysym) {
+		case XK_KP_Equal:
+		case XK_KP_Add:
+		case XK_KP_Subtract:
 		case XK_KP_Multiply:
 		case XK_KP_Divide:
-		case XK_KP_Subtract:
 		case XK_KP_Separator:
-		case XK_KP_Add:
+		case XK_KP_Decimal:
 		case XK_KP_0:
 		case XK_KP_1:
 		case XK_KP_2:


### PR DESCRIPTION
Seems that "Separator" doesn't catch all the cases. Sometimes, the period on the keypad is "Decimal".

Fixes #102404