### PR TITLE
Add `ERR_FAIL_COND_MSG` for reparenting to self

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1957,6 +1957,7 @@ void Node::reparent(Node *p_parent, bool p_keep_global_transform) {
 	ERR_THREAD_GUARD
 	ERR_FAIL_NULL(p_parent);
 	ERR_FAIL_NULL_MSG(data.parent, "Node needs a parent to be reparented.");
+	ERR_FAIL_COND_MSG(p_parent == this, vformat("Can't reparent '%s' to itself.", p_parent->get_name()));
 
 	if (p_parent == data.parent) {
 		return;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

As suggested here: https://github.com/godotengine/godot/pull/102444#discussion_r1942537089 by @Ivorforce 

This error would be caught downstream by `add_child()`, but it is better to be more explicit about the origin of the error. 