### PR TITLE
Prefer reference over raw pointer

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1384,7 +1384,7 @@ void ProjectSettings::load_scene_groups_cache() {
 	cf.instantiate();
 	if (cf->load(get_scene_groups_cache_path()) == OK) {
 		List<String> scene_paths;
-		cf->get_sections(&scene_paths);
+		cf->get_sections(scene_paths);
 		for (const String &E : scene_paths) {
 			Array scene_groups = cf->get_value(E, "groups", Array());
 			HashSet<StringName> cache;
@@ -1401,7 +1401,7 @@ const HashMap<StringName, HashSet<StringName>> &ProjectSettings::get_scene_group
 }
 
 #ifdef TOOLS_ENABLED
-void ProjectSettings::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void ProjectSettings::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "has_setting" || pf == "set_setting" || pf == "get_setting" || pf == "get_setting_with_override" ||
@@ -1412,7 +1412,7 @@ void ProjectSettings::get_argument_options(const StringName &p_function, int p_i
 					continue;
 				}
 
-				r_options->push_back(String(E.key).quote());
+				r_options.push_back(String(E.key).quote());
 			}
 		}
 	}

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -219,7 +219,7 @@ public:
 	void load_scene_groups_cache();
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	ProjectSettings();

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -79,7 +79,7 @@ Ref<Resource> ResourceLoader::load(const String &p_path, const String &p_type_hi
 
 Vector<String> ResourceLoader::get_recognized_extensions_for_type(const String &p_type) {
 	List<String> exts;
-	::ResourceLoader::get_recognized_extensions_for_type(p_type, &exts);
+	::ResourceLoader::get_recognized_extensions_for_type(p_type, exts);
 	Vector<String> ret;
 	for (const String &E : exts) {
 		ret.push_back(E);
@@ -102,7 +102,7 @@ void ResourceLoader::set_abort_on_missing_resources(bool p_abort) {
 
 PackedStringArray ResourceLoader::get_dependencies(const String &p_path) {
 	List<String> deps;
-	::ResourceLoader::get_dependencies(p_path, &deps);
+	::ResourceLoader::get_dependencies(p_path, deps);
 
 	PackedStringArray ret;
 	for (const String &E : deps) {
@@ -171,7 +171,7 @@ Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path,
 
 Vector<String> ResourceSaver::get_recognized_extensions(const Ref<Resource> &p_resource) {
 	List<String> exts;
-	::ResourceSaver::get_recognized_extensions(p_resource, &exts);
+	::ResourceSaver::get_recognized_extensions(p_resource, exts);
 	Vector<String> ret;
 	for (const String &E : exts) {
 		ret.push_back(E);
@@ -1601,7 +1601,7 @@ Variant ClassDB::class_call_static(const Variant **p_arguments, int p_argcount, 
 
 PackedStringArray ClassDB::class_get_integer_constant_list(const StringName &p_class, bool p_no_inheritance) const {
 	List<String> constants;
-	::ClassDB::get_integer_constant_list(p_class, &constants, p_no_inheritance);
+	::ClassDB::get_integer_constant_list(p_class, constants, p_no_inheritance);
 
 	PackedStringArray ret;
 	ret.resize(constants.size());
@@ -1671,7 +1671,7 @@ bool ClassDB::is_class_enabled(const StringName &p_class) const {
 }
 
 #ifdef TOOLS_ENABLED
-void ClassDB::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void ClassDB::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	bool first_argument_is_class = false;
 	if (p_idx == 0) {
@@ -1686,7 +1686,7 @@ void ClassDB::get_argument_options(const StringName &p_function, int p_idx, List
 	}
 	if (first_argument_is_class || pf == "is_parent_class") {
 		for (const String &E : get_class_list()) {
-			r_options->push_back(E.quote());
+			r_options.push_back(E.quote());
 		}
 	}
 
@@ -1931,11 +1931,11 @@ bool Engine::is_printing_error_messages() const {
 }
 
 #ifdef TOOLS_ENABLED
-void Engine::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void Engine::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0 && (pf == "has_singleton" || pf == "get_singleton" || pf == "unregister_singleton")) {
 		for (const String &E : get_singleton_list()) {
-			r_options->push_back(E.quote());
+			r_options.push_back(E.quote());
 		}
 	}
 	Object::get_argument_options(p_function, p_idx, r_options);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -517,7 +517,7 @@ public:
 	bool is_class_enabled(const StringName &p_class) const;
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	ClassDB() {}
@@ -596,7 +596,7 @@ public:
 	bool is_printing_error_messages() const;
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	Engine() { singleton = this; }

--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -204,10 +204,10 @@ Ref<Resource> ResourceFormatLoaderCrypto::load(const String &p_path, const Strin
 	return nullptr;
 }
 
-void ResourceFormatLoaderCrypto::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("crt");
-	p_extensions->push_back("key");
-	p_extensions->push_back("pub");
+void ResourceFormatLoaderCrypto::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("crt");
+	p_extensions.push_back("key");
+	p_extensions.push_back("pub");
 }
 
 bool ResourceFormatLoaderCrypto::handles_type(const String &p_type) const {
@@ -240,17 +240,17 @@ Error ResourceFormatSaverCrypto::save(const Ref<Resource> &p_resource, const Str
 	return OK;
 }
 
-void ResourceFormatSaverCrypto::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaverCrypto::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const {
 	const X509Certificate *cert = Object::cast_to<X509Certificate>(*p_resource);
 	const CryptoKey *key = Object::cast_to<CryptoKey>(*p_resource);
 	if (cert) {
-		p_extensions->push_back("crt");
+		p_extensions.push_back("crt");
 	}
 	if (key) {
 		if (!key->is_public_only()) {
-			p_extensions->push_back("key");
+			p_extensions.push_back("key");
 		}
-		p_extensions->push_back("pub");
+		p_extensions.push_back("pub");
 	}
 }
 

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -152,7 +152,7 @@ public:
 class ResourceFormatLoaderCrypto : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 
@@ -164,7 +164,7 @@ public:
 class ResourceFormatSaverCrypto : public ResourceFormatSaver {
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
-	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };
 

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -930,7 +930,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 				//constants
 				Array constants;
 				List<String> constant_list;
-				ClassDB::get_integer_constant_list(class_name, &constant_list, true);
+				ClassDB::get_integer_constant_list(class_name, constant_list, true);
 				for (const String &F : constant_list) {
 					StringName enum_name = ClassDB::get_integer_constant_enum(class_name, F);
 					if (enum_name != StringName()) {

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -839,8 +839,8 @@ Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String
 	return lib;
 }
 
-void GDExtensionResourceLoader::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("gdextension");
+void GDExtensionResourceLoader::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("gdextension");
 }
 
 bool GDExtensionResourceLoader::handles_type(const String &p_type) const {

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -178,7 +178,7 @@ public:
 	static Error load_gdextension_resource(const String &p_path, Ref<GDExtension> &p_extension);
 
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };

--- a/core/extension/gdextension_library_loader.cpp
+++ b/core/extension/gdextension_library_loader.cpp
@@ -39,7 +39,7 @@ Vector<SharedObject> GDExtensionLibraryLoader::find_extension_dependencies(const
 	Vector<SharedObject> dependencies_shared_objects;
 	if (p_config->has_section("dependencies")) {
 		List<String> config_dependencies;
-		p_config->get_section_keys("dependencies", &config_dependencies);
+		p_config->get_section_keys("dependencies", config_dependencies);
 
 		for (const String &dependency : config_dependencies) {
 			Vector<String> dependency_tags = dependency.split(".");
@@ -74,7 +74,7 @@ String GDExtensionLibraryLoader::find_extension_library(const String &p_path, Re
 	// First, check the explicit libraries.
 	if (p_config->has_section("libraries")) {
 		List<String> libraries;
-		p_config->get_section_keys("libraries", &libraries);
+		p_config->get_section_keys("libraries", libraries);
 
 		// Iterate the libraries, finding the best matching tags.
 		String best_library_path;
@@ -379,7 +379,7 @@ Error GDExtensionLibraryLoader::parse_gdextension_file(const String &p_path) {
 	// Handle icons if any are specified.
 	if (config->has_section("icons")) {
 		List<String> keys;
-		config->get_section_keys("icons", &keys);
+		config->get_section_keys("icons", keys);
 		for (const String &key : keys) {
 			String icon_path = config->get_value("icons", key);
 			if (icon_path.is_relative_path()) {

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -205,7 +205,7 @@ void Input::_bind_methods() {
 }
 
 #ifdef TOOLS_ENABLED
-void Input::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void Input::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 
 	if ((p_idx == 0 && (pf == "is_action_pressed" || pf == "action_press" || pf == "action_release" || pf == "is_action_just_pressed" || pf == "is_action_just_released" || pf == "get_action_strength" || pf == "get_action_raw_strength")) ||
@@ -220,7 +220,7 @@ void Input::get_argument_options(const StringName &p_function, int p_idx, List<S
 			}
 
 			String name = pi.name.substr(pi.name.find_char('/') + 1, pi.name.length());
-			r_options->push_back(name.quote());
+			r_options.push_back(name.quote());
 		}
 	}
 	Object::get_argument_options(p_function, p_idx, r_options);

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -294,7 +294,7 @@ public:
 	bool is_mouse_mode_override_enabled();
 
 #ifdef TOOLS_ENABLED
-	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	static Input *get_singleton();

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -87,7 +87,7 @@ String InputMap::suggest_actions(const StringName &p_action) const {
 }
 
 #ifdef TOOLS_ENABLED
-void InputMap::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void InputMap::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	bool first_argument_is_action = false;
 	if (p_idx == 0) {
@@ -107,7 +107,7 @@ void InputMap::get_argument_options(const StringName &p_function, int p_idx, Lis
 			}
 
 			String name = pi.name.substr(pi.name.find_char('/') + 1, pi.name.length());
-			r_options->push_back(name.quote());
+			r_options.push_back(name.quote());
 		}
 	}
 

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -103,7 +103,7 @@ public:
 	String suggest_actions(const StringName &p_action) const;
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	String get_builtin_display_name(const String &p_name) const;

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -36,7 +36,7 @@
 
 PackedStringArray ConfigFile::_get_sections() const {
 	List<String> s;
-	get_sections(&s);
+	get_sections(s);
 	PackedStringArray arr;
 	arr.resize(s.size());
 	int idx = 0;
@@ -49,7 +49,7 @@ PackedStringArray ConfigFile::_get_sections() const {
 
 PackedStringArray ConfigFile::_get_section_keys(const String &p_section) const {
 	List<String> s;
-	get_section_keys(p_section, &s);
+	get_section_keys(p_section, s);
 	PackedStringArray arr;
 	arr.resize(s.size());
 	int idx = 0;
@@ -101,17 +101,17 @@ bool ConfigFile::has_section_key(const String &p_section, const String &p_key) c
 	return values[p_section].has(p_key);
 }
 
-void ConfigFile::get_sections(List<String> *r_sections) const {
+void ConfigFile::get_sections(List<String> &r_sections) const {
 	for (const KeyValue<String, HashMap<String, Variant>> &E : values) {
-		r_sections->push_back(E.key);
+		r_sections.push_back(E.key);
 	}
 }
 
-void ConfigFile::get_section_keys(const String &p_section, List<String> *r_keys) const {
+void ConfigFile::get_section_keys(const String &p_section, List<String> &r_keys) const {
 	ERR_FAIL_COND_MSG(!values.has(p_section), vformat("Cannot get keys from nonexistent section \"%s\".", p_section));
 
 	for (const KeyValue<String, Variant> &E : values[p_section]) {
-		r_keys->push_back(E.key);
+		r_keys.push_back(E.key);
 	}
 }
 

--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -58,8 +58,8 @@ public:
 	bool has_section(const String &p_section) const;
 	bool has_section_key(const String &p_section, const String &p_key) const;
 
-	void get_sections(List<String> *r_sections) const;
-	void get_section_keys(const String &p_section, List<String> *r_keys) const;
+	void get_sections(List<String> &r_sections) const;
+	void get_section_keys(const String &p_section, List<String> &r_keys) const;
 
 	void erase_section(const String &p_section);
 	void erase_section_key(const String &p_section, const String &p_key);

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -110,7 +110,7 @@ Error HTTPClient::verify_headers(const Vector<String> &p_headers) {
 
 Dictionary HTTPClient::_get_response_headers_as_dictionary() {
 	List<String> rh;
-	get_response_headers(&rh);
+	get_response_headers(rh);
 	Dictionary ret;
 	for (const String &s : rh) {
 		int sp = s.find_char(':');
@@ -127,7 +127,7 @@ Dictionary HTTPClient::_get_response_headers_as_dictionary() {
 
 PackedStringArray HTTPClient::_get_response_headers() {
 	List<String> rh;
-	get_response_headers(&rh);
+	get_response_headers(rh);
 	PackedStringArray ret;
 	ret.resize(rh.size());
 	int idx = 0;

--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -181,7 +181,7 @@ public:
 	virtual bool has_response() const = 0;
 	virtual bool is_response_chunked() const = 0;
 	virtual int get_response_code() const = 0;
-	virtual Error get_response_headers(List<String> *r_response) = 0;
+	virtual Error get_response_headers(List<String> &r_response) = 0;
 	virtual int64_t get_response_body_length() const = 0;
 
 	virtual PackedByteArray read_response_body_chunk() = 0; // Can't get body as partial text because of most encodings UTF8, gzip, etc.

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -229,13 +229,13 @@ int HTTPClientTCP::get_response_code() const {
 	return response_num;
 }
 
-Error HTTPClientTCP::get_response_headers(List<String> *r_response) {
+Error HTTPClientTCP::get_response_headers(List<String> &r_response) {
 	if (!response_headers.size()) {
 		return ERR_INVALID_PARAMETER;
 	}
 
 	for (int i = 0; i < response_headers.size(); i++) {
-		r_response->push_back(response_headers[i]);
+		r_response.push_back(response_headers[i]);
 	}
 
 	response_headers.clear();

--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -88,7 +88,7 @@ public:
 	bool has_response() const override;
 	bool is_response_chunked() const override;
 	int get_response_code() const override;
-	Error get_response_headers(List<String> *r_response) override;
+	Error get_response_headers(List<String> &r_response) override;
 	int64_t get_response_body_length() const override;
 	PackedByteArray read_response_body_chunk() override;
 	void set_blocking_mode(bool p_enable) override;

--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -38,7 +38,7 @@ void ImageFormatLoader::_bind_methods() {
 
 bool ImageFormatLoader::recognize(const String &p_extension) const {
 	List<String> extensions;
-	get_recognized_extensions(&extensions);
+	get_recognized_extensions(extensions);
 	for (const String &E : extensions) {
 		if (E.nocasecmp_to(p_extension) == 0) {
 			return true;
@@ -54,11 +54,11 @@ Error ImageFormatLoaderExtension::load_image(Ref<Image> p_image, Ref<FileAccess>
 	return err;
 }
 
-void ImageFormatLoaderExtension::get_recognized_extensions(List<String> *p_extension) const {
+void ImageFormatLoaderExtension::get_recognized_extensions(List<String> &p_extension) const {
 	PackedStringArray ext;
 	if (GDVIRTUAL_CALL(_get_recognized_extensions, ext)) {
 		for (int i = 0; i < ext.size(); i++) {
-			p_extension->push_back(ext[i]);
+			p_extension.push_back(ext[i]);
 		}
 	}
 }
@@ -108,7 +108,7 @@ Error ImageLoader::load_image(const String &p_file, Ref<Image> p_image, Ref<File
 	return ERR_FILE_UNRECOGNIZED;
 }
 
-void ImageLoader::get_recognized_extensions(List<String> *p_extensions) {
+void ImageLoader::get_recognized_extensions(List<String> &p_extensions) {
 	for (int i = 0; i < loader.size(); i++) {
 		loader[i]->get_recognized_extensions(p_extensions);
 	}
@@ -199,8 +199,8 @@ Ref<Resource> ResourceFormatLoaderImage::load(const String &p_path, const String
 	return image;
 }
 
-void ResourceFormatLoaderImage::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("image");
+void ResourceFormatLoaderImage::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("image");
 }
 
 bool ResourceFormatLoaderImage::handles_type(const String &p_type) const {

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -59,7 +59,7 @@ protected:
 	static void _bind_methods();
 
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags = FLAG_NONE, float p_scale = 1.0) = 0;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const = 0;
 	bool recognize(const String &p_extension) const;
 
 public:
@@ -76,7 +76,7 @@ protected:
 
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags = FLAG_NONE, float p_scale = 1.0) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 
 	void add_format_loader();
 	void remove_format_loader();
@@ -92,7 +92,7 @@ class ImageLoader {
 protected:
 public:
 	static Error load_image(const String &p_file, Ref<Image> p_image, Ref<FileAccess> p_custom = Ref<FileAccess>(), BitField<ImageFormatLoader::LoaderFlags> p_flags = ImageFormatLoader::FLAG_NONE, float p_scale = 1.0);
-	static void get_recognized_extensions(List<String> *p_extensions);
+	static void get_recognized_extensions(List<String> &p_extensions);
 	static Ref<ImageFormatLoader> recognize(const String &p_extension);
 
 	static void add_image_format_loader(Ref<ImageFormatLoader> p_loader);
@@ -104,7 +104,7 @@ public:
 class ResourceFormatLoaderImage : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -1642,8 +1642,8 @@ Ref<Resource> ResourceFormatLoaderJSON::load(const String &p_path, const String 
 	return json;
 }
 
-void ResourceFormatLoaderJSON::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("json");
+void ResourceFormatLoaderJSON::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("json");
 }
 
 bool ResourceFormatLoaderJSON::handles_type(const String &p_type) const {
@@ -1677,10 +1677,10 @@ Error ResourceFormatSaverJSON::save(const Ref<Resource> &p_resource, const Strin
 	return OK;
 }
 
-void ResourceFormatSaverJSON::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaverJSON::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const {
 	Ref<JSON> json = p_resource;
 	if (json.is_valid()) {
-		p_extensions->push_back("json");
+		p_extensions.push_back("json");
 	}
 }
 

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -110,7 +110,7 @@ public:
 class ResourceFormatLoaderJSON : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 
@@ -122,7 +122,7 @@ public:
 class ResourceFormatSaverJSON : public ResourceFormatSaver {
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
-	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -953,7 +953,7 @@ void ResourceLoaderBinary::get_classes_used(Ref<FileAccess> p_f, HashSet<StringN
 	}
 }
 
-void ResourceLoaderBinary::get_dependencies(Ref<FileAccess> p_f, List<String> *p_dependencies, bool p_add_types) {
+void ResourceLoaderBinary::get_dependencies(Ref<FileAccess> p_f, List<String> &p_dependencies, bool p_add_types) {
 	open(p_f, false, true);
 	if (error) {
 		return;
@@ -980,7 +980,7 @@ void ResourceLoaderBinary::get_dependencies(Ref<FileAccess> p_f, List<String> *p
 			dep += "::" + fallback_path;
 		}
 
-		p_dependencies->push_back(dep);
+		p_dependencies.push_back(dep);
 	}
 }
 
@@ -1260,7 +1260,7 @@ Ref<Resource> ResourceFormatLoaderBinary::load(const String &p_path, const Strin
 	return loader.resource;
 }
 
-void ResourceFormatLoaderBinary::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
+void ResourceFormatLoaderBinary::get_recognized_extensions_for_type(const String &p_type, List<String> &p_extensions) const {
 	if (p_type.is_empty()) {
 		get_recognized_extensions(p_extensions);
 		return;
@@ -1272,24 +1272,24 @@ void ResourceFormatLoaderBinary::get_recognized_extensions_for_type(const String
 	}
 
 	List<String> extensions;
-	ClassDB::get_extensions_for_type(p_type, &extensions);
+	ClassDB::get_extensions_for_type(p_type, extensions);
 
 	extensions.sort();
 
 	for (const String &E : extensions) {
 		String ext = E.to_lower();
-		p_extensions->push_back(ext);
+		p_extensions.push_back(ext);
 	}
 }
 
-void ResourceFormatLoaderBinary::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceFormatLoaderBinary::get_recognized_extensions(List<String> &p_extensions) const {
 	List<String> extensions;
-	ClassDB::get_resource_base_extensions(&extensions);
+	ClassDB::get_resource_base_extensions(extensions);
 	extensions.sort();
 
 	for (const String &E : extensions) {
 		String ext = E.to_lower();
-		p_extensions->push_back(ext);
+		p_extensions.push_back(ext);
 	}
 }
 
@@ -1297,7 +1297,7 @@ bool ResourceFormatLoaderBinary::handles_type(const String &p_type) const {
 	return true; //handles all
 }
 
-void ResourceFormatLoaderBinary::get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types) {
+void ResourceFormatLoaderBinary::get_dependencies(const String &p_path, List<String> &p_dependencies, bool p_add_types) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_MSG(f.is_null(), vformat("Cannot open file '%s'.", p_path));
 
@@ -2516,11 +2516,11 @@ bool ResourceFormatSaverBinary::recognize(const Ref<Resource> &p_resource) const
 	return true; //all recognized
 }
 
-void ResourceFormatSaverBinary::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaverBinary::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const {
 	String base = p_resource->get_base_extension().to_lower();
-	p_extensions->push_back(base);
+	p_extensions.push_back(base);
 	if (base != "res") {
-		p_extensions->push_back("res");
+		p_extensions.push_back("res");
 	}
 }
 

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -102,7 +102,7 @@ public:
 	void open(Ref<FileAccess> p_f, bool p_no_resources = false, bool p_keep_uuid_paths = false);
 	String recognize(Ref<FileAccess> p_f);
 	String recognize_script_class(Ref<FileAccess> p_f);
-	void get_dependencies(Ref<FileAccess> p_f, List<String> *p_dependencies, bool p_add_types);
+	void get_dependencies(Ref<FileAccess> p_f, List<String> &p_dependencies, bool p_add_types);
 	void get_classes_used(Ref<FileAccess> p_f, HashSet<StringName> *p_classes);
 
 	ResourceLoaderBinary() {}
@@ -111,15 +111,15 @@ public:
 class ResourceFormatLoaderBinary : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> &p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 	virtual String get_resource_script_class(const String &p_path) const override;
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes) override;
 	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
 	virtual bool has_custom_uid_support() const override;
-	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;
+	virtual void get_dependencies(const String &p_path, List<String> &p_dependencies, bool p_add_types = false) override;
 	virtual Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map) override;
 };
 
@@ -185,7 +185,7 @@ public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
-	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const override;
 
 	ResourceFormatSaverBinary();
 };

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -183,22 +183,22 @@ Ref<Resource> ResourceFormatImporter::load_internal(const String &p_path, Error 
 	return res;
 }
 
-void ResourceFormatImporter::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceFormatImporter::get_recognized_extensions(List<String> &p_extensions) const {
 	HashSet<String> found;
 
 	for (int i = 0; i < importers.size(); i++) {
 		List<String> local_exts;
-		importers[i]->get_recognized_extensions(&local_exts);
+		importers[i]->get_recognized_extensions(local_exts);
 		for (const String &F : local_exts) {
 			if (!found.has(F)) {
-				p_extensions->push_back(F);
+				p_extensions.push_back(F);
 				found.insert(F);
 			}
 		}
 	}
 }
 
-void ResourceFormatImporter::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
+void ResourceFormatImporter::get_recognized_extensions_for_type(const String &p_type, List<String> &p_extensions) const {
 	if (p_type.is_empty()) {
 		get_recognized_extensions(p_extensions);
 		return;
@@ -217,10 +217,10 @@ void ResourceFormatImporter::get_recognized_extensions_for_type(const String &p_
 		}
 
 		List<String> local_exts;
-		importers[i]->get_recognized_extensions(&local_exts);
+		importers[i]->get_recognized_extensions(local_exts);
 		for (const String &F : local_exts) {
 			if (!found.has(F)) {
-				p_extensions->push_back(F);
+				p_extensions.push_back(F);
 				found.insert(F);
 			}
 		}
@@ -309,7 +309,7 @@ String ResourceFormatImporter::get_internal_resource_path(const String &p_path) 
 	return pat.path;
 }
 
-void ResourceFormatImporter::get_internal_resource_path_list(const String &p_path, List<String> *r_paths) {
+void ResourceFormatImporter::get_internal_resource_path_list(const String &p_path, List<String> &r_paths) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path + ".import", FileAccess::READ, &err);
 
@@ -341,9 +341,9 @@ void ResourceFormatImporter::get_internal_resource_path_list(const String &p_pat
 
 		if (!assign.is_empty()) {
 			if (assign.begins_with("path.")) {
-				r_paths->push_back(value);
+				r_paths.push_back(value);
 			} else if (assign == "path") {
-				r_paths->push_back(value);
+				r_paths.push_back(value);
 			}
 		} else if (next_tag.name != "remap") {
 			break;
@@ -429,7 +429,7 @@ void ResourceFormatImporter::get_classes_used(const String &p_path, HashSet<Stri
 	ResourceLoader::get_classes_used(pat.path, r_classes);
 }
 
-void ResourceFormatImporter::get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types) {
+void ResourceFormatImporter::get_dependencies(const String &p_path, List<String> &p_dependencies, bool p_add_types) {
 	PathAndType pat;
 	Error err = _get_path_and_type(p_path, pat);
 
@@ -462,7 +462,7 @@ void ResourceFormatImporter::add_importer(const Ref<ResourceImporter> &p_importe
 void ResourceFormatImporter::get_importers_for_extension(const String &p_extension, List<Ref<ResourceImporter>> *r_importers) {
 	for (int i = 0; i < importers.size(); i++) {
 		List<String> local_exts;
-		importers[i]->get_recognized_extensions(&local_exts);
+		importers[i]->get_recognized_extensions(local_exts);
 		for (const String &F : local_exts) {
 			if (p_extension.to_lower() == F) {
 				r_importers->push_back(importers[i]);
@@ -484,7 +484,7 @@ Ref<ResourceImporter> ResourceFormatImporter::get_importer_by_extension(const St
 
 	for (int i = 0; i < importers.size(); i++) {
 		List<String> local_exts;
-		importers[i]->get_recognized_extensions(&local_exts);
+		importers[i]->get_recognized_extensions(local_exts);
 		for (const String &F : local_exts) {
 			if (p_extension.to_lower() == F && importers[i]->get_priority() > priority) {
 				importer = importers[i];

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -64,8 +64,8 @@ public:
 	static ResourceFormatImporter *get_singleton() { return singleton; }
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	Ref<Resource> load_internal(const String &p_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode, bool p_silence_errors);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
-	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
+	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> &p_extensions) const override;
 	virtual bool recognize_path(const String &p_path, const String &p_for_type = String()) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
@@ -73,7 +73,7 @@ public:
 	virtual bool has_custom_uid_support() const override;
 	virtual Variant get_resource_metadata(const String &p_path) const;
 	virtual bool is_import_valid(const String &p_path) const override;
-	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;
+	virtual void get_dependencies(const String &p_path, List<String> &p_dependencies, bool p_add_types = false) override;
 	virtual bool is_imported(const String &p_path) const override { return recognize_path(p_path); }
 	virtual String get_import_group_file(const String &p_path) const override;
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes) override;
@@ -84,7 +84,7 @@ public:
 	Error get_import_order_threads_and_importer(const String &p_path, int &r_order, bool &r_can_threads, String &r_importer) const;
 
 	String get_internal_resource_path(const String &p_path) const;
-	void get_internal_resource_path_list(const String &p_path, List<String> *r_paths);
+	void get_internal_resource_path_list(const String &p_path, List<String> &r_paths);
 
 	void add_importer(const Ref<ResourceImporter> &p_importer, bool p_first_priority = false);
 
@@ -114,7 +114,7 @@ public:
 
 	virtual String get_importer_name() const = 0;
 	virtual String get_visible_name() const = 0;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const = 0;
 	virtual String get_save_extension() const = 0;
 	virtual String get_resource_type() const = 0;
 	virtual float get_priority() const { return 1.0; }

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -65,9 +65,9 @@ bool ResourceFormatLoader::recognize_path(const String &p_path, const String &p_
 
 	List<String> extensions;
 	if (p_for_type.is_empty()) {
-		get_recognized_extensions(&extensions);
+		get_recognized_extensions(extensions);
 	} else {
-		get_recognized_extensions_for_type(p_for_type, &extensions);
+		get_recognized_extensions_for_type(p_for_type, extensions);
 	}
 
 	for (const String &E : extensions) {
@@ -129,13 +129,13 @@ bool ResourceFormatLoader::has_custom_uid_support() const {
 	return GDVIRTUAL_IS_OVERRIDDEN(_get_resource_uid);
 }
 
-void ResourceFormatLoader::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
+void ResourceFormatLoader::get_recognized_extensions_for_type(const String &p_type, List<String> &p_extensions) const {
 	if (p_type.is_empty() || handles_type(p_type)) {
 		get_recognized_extensions(p_extensions);
 	}
 }
 
-void ResourceLoader::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) {
+void ResourceLoader::get_recognized_extensions_for_type(const String &p_type, List<String> &p_extensions) {
 	for (int i = 0; i < loader_count; i++) {
 		loader[i]->get_recognized_extensions_for_type(p_type, p_extensions);
 	}
@@ -149,12 +149,12 @@ bool ResourceFormatLoader::exists(const String &p_path) const {
 	return FileAccess::exists(p_path); // By default just check file.
 }
 
-void ResourceFormatLoader::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceFormatLoader::get_recognized_extensions(List<String> &p_extensions) const {
 	PackedStringArray exts;
 	if (GDVIRTUAL_CALL(_get_recognized_extensions, exts)) {
 		const String *r = exts.ptr();
 		for (int i = 0; i < exts.size(); ++i) {
-			p_extensions->push_back(r[i]);
+			p_extensions.push_back(r[i]);
 		}
 	}
 }
@@ -178,12 +178,12 @@ Ref<Resource> ResourceFormatLoader::load(const String &p_path, const String &p_o
 	ERR_FAIL_V_MSG(Ref<Resource>(), vformat("Failed to load resource '%s'. ResourceFormatLoader::load was not implemented for this resource type.", p_path));
 }
 
-void ResourceFormatLoader::get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types) {
+void ResourceFormatLoader::get_dependencies(const String &p_path, List<String> &p_dependencies, bool p_add_types) {
 	PackedStringArray deps;
 	if (GDVIRTUAL_CALL(_get_dependencies, p_path, p_add_types, deps)) {
 		const String *r = deps.ptr();
 		for (int i = 0; i < deps.size(); ++i) {
-			p_dependencies->push_back(r[i]);
+			p_dependencies.push_back(r[i]);
 		}
 	}
 }
@@ -1104,7 +1104,7 @@ bool ResourceLoader::is_imported(const String &p_path) {
 	return false; //not found
 }
 
-void ResourceLoader::get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types) {
+void ResourceLoader::get_dependencies(const String &p_path, List<String> &p_dependencies, bool p_add_types) {
 	String local_path = _path_remap(_validate_local_path(p_path));
 
 	for (int i = 0; i < loader_count; i++) {

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -76,8 +76,8 @@ protected:
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual bool exists(const String &p_path) const;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
-	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const;
+	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> &p_extensions) const;
 	virtual bool recognize_path(const String &p_path, const String &p_for_type = String()) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes);
@@ -85,7 +85,7 @@ public:
 	virtual String get_resource_script_class(const String &p_path) const;
 	virtual ResourceUID::ID get_resource_uid(const String &p_path) const;
 	virtual bool has_custom_uid_support() const;
-	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false);
+	virtual void get_dependencies(const String &p_path, List<String> &p_dependencies, bool p_add_types = false);
 	virtual Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map);
 	virtual bool is_import_valid(const String &p_path) const { return true; }
 	virtual bool is_imported(const String &p_path) const { return false; }
@@ -238,7 +238,7 @@ public:
 	static Ref<Resource> load(const String &p_path, const String &p_type_hint = "", ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE, Error *r_error = nullptr);
 	static bool exists(const String &p_path, const String &p_type_hint = "");
 
-	static void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions);
+	static void get_recognized_extensions_for_type(const String &p_type, List<String> &p_extensions);
 	static void add_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader, bool p_at_front = false);
 	static void remove_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader);
 	static void get_classes_used(const String &p_path, HashSet<StringName> *r_classes);
@@ -246,7 +246,7 @@ public:
 	static String get_resource_script_class(const String &p_path);
 	static ResourceUID::ID get_resource_uid(const String &p_path);
 	static bool has_custom_uid_support(const String &p_path);
-	static void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false);
+	static void get_dependencies(const String &p_path, List<String> &p_dependencies, bool p_add_types = false);
 	static Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map);
 	static bool is_import_valid(const String &p_path);
 	static String get_import_group_file(const String &p_path);

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -59,12 +59,12 @@ bool ResourceFormatSaver::recognize(const Ref<Resource> &p_resource) const {
 	return success;
 }
 
-void ResourceFormatSaver::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaver::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const {
 	PackedStringArray exts;
 	if (GDVIRTUAL_CALL(_get_recognized_extensions, p_resource, exts)) {
 		const String *r = exts.ptr();
 		for (int i = 0; i < exts.size(); ++i) {
-			p_extensions->push_back(r[i]);
+			p_extensions.push_back(r[i]);
 		}
 	}
 }
@@ -78,7 +78,7 @@ bool ResourceFormatSaver::recognize_path(const Ref<Resource> &p_resource, const 
 	String extension = p_path.get_extension();
 
 	List<String> extensions;
-	get_recognized_extensions(p_resource, &extensions);
+	get_recognized_extensions(p_resource, extensions);
 
 	for (const String &E : extensions) {
 		if (E.nocasecmp_to(extension) == 0) {
@@ -174,7 +174,7 @@ void ResourceSaver::set_save_callback(ResourceSavedCallback p_callback) {
 	save_callback = p_callback;
 }
 
-void ResourceSaver::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) {
+void ResourceSaver::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) {
 	ERR_FAIL_COND_MSG(p_resource.is_null(), "It's not a reference to a valid Resource object.");
 	for (int i = 0; i < saver_count; i++) {
 		saver[i]->get_recognized_extensions(p_resource, p_extensions);

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -50,7 +50,7 @@ public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
-	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const;
 	virtual bool recognize_path(const Ref<Resource> &p_resource, const String &p_path) const;
 
 	virtual ~ResourceFormatSaver() {}
@@ -85,7 +85,7 @@ public:
 	};
 
 	static Error save(const Ref<Resource> &p_resource, const String &p_path = "", uint32_t p_flags = (uint32_t)FLAG_NONE);
-	static void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions);
+	static void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions);
 	static void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front = false);
 	static void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);
 

--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -354,9 +354,9 @@ Ref<Resource> TranslationLoaderPO::load(const String &p_path, const String &p_or
 	return load_translation(f, r_error);
 }
 
-void TranslationLoaderPO::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("po");
-	p_extensions->push_back("mo");
+void TranslationLoaderPO::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("po");
+	p_extensions.push_back("mo");
 }
 
 bool TranslationLoaderPO::handles_type(const String &p_type) const {

--- a/core/io/translation_loader_po.h
+++ b/core/io/translation_loader_po.h
@@ -39,7 +39,7 @@ class TranslationLoaderPO : public ResourceFormatLoader {
 public:
 	static Ref<Resource> load_translation(Ref<FileAccess> f, Error *r_error = nullptr);
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1141,7 +1141,7 @@ void ClassDB::bind_integer_constant(const StringName &p_class, const StringName 
 #endif
 }
 
-void ClassDB::get_integer_constant_list(const StringName &p_class, List<String> *p_constants, bool p_no_inheritance) {
+void ClassDB::get_integer_constant_list(const StringName &p_class, List<String> &p_constants, bool p_no_inheritance) {
 	OBJTYPE_RLOCK;
 
 	ClassInfo *type = classes.getptr(p_class);
@@ -1149,12 +1149,12 @@ void ClassDB::get_integer_constant_list(const StringName &p_class, List<String> 
 	while (type) {
 #ifdef DEBUG_METHODS_ENABLED
 		for (const StringName &E : type->constant_order) {
-			p_constants->push_back(E);
+			p_constants.push_back(E);
 		}
 #else
 
 		for (const KeyValue<StringName, int64_t> &E : type->constant_map) {
-			p_constants->push_back(E.key);
+			p_constants.push_back(E.key);
 		}
 
 #endif
@@ -2159,9 +2159,9 @@ void ClassDB::add_resource_base_extension(const StringName &p_extension, const S
 	resource_base_extensions[p_extension] = p_class;
 }
 
-void ClassDB::get_resource_base_extensions(List<String> *p_extensions) {
+void ClassDB::get_resource_base_extensions(List<String> &p_extensions) {
 	for (const KeyValue<StringName, StringName> &E : resource_base_extensions) {
-		p_extensions->push_back(E.key);
+		p_extensions.push_back(E.key);
 	}
 }
 
@@ -2169,10 +2169,10 @@ bool ClassDB::is_resource_extension(const StringName &p_extension) {
 	return resource_base_extensions.has(p_extension);
 }
 
-void ClassDB::get_extensions_for_type(const StringName &p_class, List<String> *p_extensions) {
+void ClassDB::get_extensions_for_type(const StringName &p_class, List<String> &p_extensions) {
 	for (const KeyValue<StringName, StringName> &E : resource_base_extensions) {
 		if (is_parent_class(p_class, E.value) || is_parent_class(E.value, p_class)) {
-			p_extensions->push_back(E.key);
+			p_extensions.push_back(E.key);
 		}
 	}
 }

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -459,7 +459,7 @@ public:
 	static Vector<uint32_t> get_virtual_method_compatibility_hashes(const StringName &p_class, const StringName &p_name);
 
 	static void bind_integer_constant(const StringName &p_class, const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield = false);
-	static void get_integer_constant_list(const StringName &p_class, List<String> *p_constants, bool p_no_inheritance = false);
+	static void get_integer_constant_list(const StringName &p_class, List<String> &p_constants, bool p_no_inheritance = false);
 	static int64_t get_integer_constant(const StringName &p_class, const StringName &p_name, bool *p_success = nullptr);
 	static bool has_integer_constant(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false);
 
@@ -482,8 +482,8 @@ public:
 	static bool is_class_runtime(const StringName &p_class);
 
 	static void add_resource_base_extension(const StringName &p_extension, const StringName &p_class);
-	static void get_resource_base_extensions(List<String> *p_extensions);
-	static void get_extensions_for_type(const StringName &p_class, List<String> *p_extensions);
+	static void get_resource_base_extensions(List<String> &p_extensions);
+	static void get_extensions_for_type(const StringName &p_class, List<String> &p_extensions);
 	static bool is_resource_extension(const StringName &p_extension);
 
 	static void add_compatibility_class(const StringName &p_class, const StringName &p_fallback);

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -249,10 +249,10 @@ void Object::_postinitialize() {
 	notification(NOTIFICATION_POSTINITIALIZE);
 }
 
-void Object::get_valid_parents_static(List<String> *p_parents) {
+void Object::get_valid_parents_static(List<String> &p_parents) {
 }
 
-void Object::_get_valid_parents_static(List<String> *p_parents) {
+void Object::_get_valid_parents_static(List<String> &p_parents) {
 }
 
 void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid) {
@@ -2235,14 +2235,14 @@ void ObjectDB::debug_objects(DebugFunc p_func) {
 }
 
 #ifdef TOOLS_ENABLED
-void Object::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void Object::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "connect" || pf == "is_connected" || pf == "disconnect" || pf == "emit_signal" || pf == "has_signal") {
 			List<MethodInfo> signals;
 			get_signal_list(&signals);
 			for (const MethodInfo &E : signals) {
-				r_options->push_back(E.name.quote());
+				r_options.push_back(E.name.quote());
 			}
 		} else if (pf == "call" || pf == "call_deferred" || pf == "callv" || pf == "has_method") {
 			List<MethodInfo> methods;
@@ -2251,19 +2251,19 @@ void Object::get_argument_options(const StringName &p_function, int p_idx, List<
 				if (E.name.begins_with("_") && !(E.flags & METHOD_FLAG_VIRTUAL)) {
 					continue;
 				}
-				r_options->push_back(E.name.quote());
+				r_options.push_back(E.name.quote());
 			}
 		} else if (pf == "set" || pf == "set_deferred" || pf == "get") {
 			List<PropertyInfo> properties;
 			get_property_list(&properties);
 			for (const PropertyInfo &E : properties) {
 				if (E.usage & PROPERTY_USAGE_DEFAULT && !(E.usage & PROPERTY_USAGE_INTERNAL)) {
-					r_options->push_back(E.name.quote());
+					r_options.push_back(E.name.quote());
 				}
 			}
 		} else if (pf == "set_meta" || pf == "get_meta" || pf == "has_meta" || pf == "remove_meta") {
 			for (const KeyValue<StringName, Variant> &K : metadata) {
-				r_options->push_back(String(K.key).quote());
+				r_options.push_back(String(K.key).quote());
 			}
 		}
 	} else if (p_idx == 2) {
@@ -2273,7 +2273,7 @@ void Object::get_argument_options(const StringName &p_function, int p_idx, List<
 			List<StringName> constants;
 			ClassDB::get_enum_constants("Object", "ConnectFlags", &constants);
 			for (const StringName &E : constants) {
-				r_options->push_back(String(E));
+				r_options.push_back(String(E));
 			}
 		}
 	}

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -427,9 +427,9 @@ public:                                                                         
 	static _FORCE_INLINE_ String get_parent_class_static() {                                                                                \
 		return m_inherits::get_class_static();                                                                                              \
 	}                                                                                                                                       \
-	static void get_inheritance_list_static(List<String> *p_inheritance_list) {                                                             \
+	static void get_inheritance_list_static(List<String> &p_inheritance_list) {                                                             \
 		m_inherits::get_inheritance_list_static(p_inheritance_list);                                                                        \
-		p_inheritance_list->push_back(String(#m_class));                                                                                    \
+		p_inheritance_list.push_back(String(#m_class));                                                                                     \
 	}                                                                                                                                       \
 	virtual bool is_class(const String &p_class) const override {                                                                           \
 		if (_get_extension() && _get_extension()->is_class(p_class)) {                                                                      \
@@ -441,7 +441,7 @@ public:                                                                         
 		return (p_ptr == get_class_ptr_static()) ? true : m_inherits::is_class_ptr(p_ptr);                                                  \
 	}                                                                                                                                       \
                                                                                                                                             \
-	static void get_valid_parents_static(List<String> *p_parents) {                                                                         \
+	static void get_valid_parents_static(List<String> &p_parents) {                                                                         \
 		if (m_class::_get_valid_parents_static != m_inherits::_get_valid_parents_static) {                                                  \
 			m_class::_get_valid_parents_static(p_parents);                                                                                  \
 		}                                                                                                                                   \
@@ -743,8 +743,8 @@ protected:
 	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) {
 		return &Object::_notification;
 	}
-	static void get_valid_parents_static(List<String> *p_parents);
-	static void _get_valid_parents_static(List<String> *p_parents);
+	static void get_valid_parents_static(List<String> &p_parents);
+	static void _get_valid_parents_static(List<String> &p_parents);
 
 	Variant _call_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 	Variant _call_deferred_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
@@ -814,7 +814,7 @@ public:
 	};
 
 	/* TYPE API */
-	static void get_inheritance_list_static(List<String> *p_inheritance_list) { p_inheritance_list->push_back("Object"); }
+	static void get_inheritance_list_static(List<String> &p_inheritance_list) { p_inheritance_list.push_back("Object"); }
 
 	static String get_class_static() { return "Object"; }
 	static String get_parent_class_static() { return String(); }
@@ -973,7 +973,7 @@ public:
 	virtual void set_translation_domain(const StringName &p_domain);
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const;
 	void editor_set_section_unfold(const String &p_section, bool p_unfolded);
 	bool editor_is_section_unfolded(const String &p_section);
 	const HashSet<String> &editor_get_section_folding() const { return editor_section_folding; }

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -542,41 +542,41 @@ ScriptCodeCompletionCache::ScriptCodeCompletionCache() {
 	singleton = this;
 }
 
-void ScriptLanguage::get_core_type_words(List<String> *p_core_type_words) const {
-	p_core_type_words->push_back("String");
-	p_core_type_words->push_back("Vector2");
-	p_core_type_words->push_back("Vector2i");
-	p_core_type_words->push_back("Rect2");
-	p_core_type_words->push_back("Rect2i");
-	p_core_type_words->push_back("Vector3");
-	p_core_type_words->push_back("Vector3i");
-	p_core_type_words->push_back("Transform2D");
-	p_core_type_words->push_back("Vector4");
-	p_core_type_words->push_back("Vector4i");
-	p_core_type_words->push_back("Plane");
-	p_core_type_words->push_back("Quaternion");
-	p_core_type_words->push_back("AABB");
-	p_core_type_words->push_back("Basis");
-	p_core_type_words->push_back("Transform3D");
-	p_core_type_words->push_back("Projection");
-	p_core_type_words->push_back("Color");
-	p_core_type_words->push_back("StringName");
-	p_core_type_words->push_back("NodePath");
-	p_core_type_words->push_back("RID");
-	p_core_type_words->push_back("Callable");
-	p_core_type_words->push_back("Signal");
-	p_core_type_words->push_back("Dictionary");
-	p_core_type_words->push_back("Array");
-	p_core_type_words->push_back("PackedByteArray");
-	p_core_type_words->push_back("PackedInt32Array");
-	p_core_type_words->push_back("PackedInt64Array");
-	p_core_type_words->push_back("PackedFloat32Array");
-	p_core_type_words->push_back("PackedFloat64Array");
-	p_core_type_words->push_back("PackedStringArray");
-	p_core_type_words->push_back("PackedVector2Array");
-	p_core_type_words->push_back("PackedVector3Array");
-	p_core_type_words->push_back("PackedColorArray");
-	p_core_type_words->push_back("PackedVector4Array");
+void ScriptLanguage::get_core_type_words(List<String> &p_core_type_words) const {
+	p_core_type_words.push_back("String");
+	p_core_type_words.push_back("Vector2");
+	p_core_type_words.push_back("Vector2i");
+	p_core_type_words.push_back("Rect2");
+	p_core_type_words.push_back("Rect2i");
+	p_core_type_words.push_back("Vector3");
+	p_core_type_words.push_back("Vector3i");
+	p_core_type_words.push_back("Transform2D");
+	p_core_type_words.push_back("Vector4");
+	p_core_type_words.push_back("Vector4i");
+	p_core_type_words.push_back("Plane");
+	p_core_type_words.push_back("Quaternion");
+	p_core_type_words.push_back("AABB");
+	p_core_type_words.push_back("Basis");
+	p_core_type_words.push_back("Transform3D");
+	p_core_type_words.push_back("Projection");
+	p_core_type_words.push_back("Color");
+	p_core_type_words.push_back("StringName");
+	p_core_type_words.push_back("NodePath");
+	p_core_type_words.push_back("RID");
+	p_core_type_words.push_back("Callable");
+	p_core_type_words.push_back("Signal");
+	p_core_type_words.push_back("Dictionary");
+	p_core_type_words.push_back("Array");
+	p_core_type_words.push_back("PackedByteArray");
+	p_core_type_words.push_back("PackedInt32Array");
+	p_core_type_words.push_back("PackedInt64Array");
+	p_core_type_words.push_back("PackedFloat32Array");
+	p_core_type_words.push_back("PackedFloat64Array");
+	p_core_type_words.push_back("PackedStringArray");
+	p_core_type_words.push_back("PackedVector2Array");
+	p_core_type_words.push_back("PackedVector3Array");
+	p_core_type_words.push_back("PackedColorArray");
+	p_core_type_words.push_back("PackedVector4Array");
 }
 
 void ScriptLanguage::frame() {

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -262,12 +262,12 @@ public:
 		}
 	};
 
-	void get_core_type_words(List<String> *p_core_type_words) const;
-	virtual void get_reserved_words(List<String> *p_words) const = 0;
+	void get_core_type_words(List<String> &p_core_type_words) const;
+	virtual void get_reserved_words(List<String> &p_words) const = 0;
 	virtual bool is_control_flow_keyword(const String &p_string) const = 0;
-	virtual void get_comment_delimiters(List<String> *p_delimiters) const = 0;
-	virtual void get_doc_comment_delimiters(List<String> *p_delimiters) const = 0;
-	virtual void get_string_delimiters(List<String> *p_delimiters) const = 0;
+	virtual void get_comment_delimiters(List<String> &p_delimiters) const = 0;
+	virtual void get_doc_comment_delimiters(List<String> &p_delimiters) const = 0;
+	virtual void get_string_delimiters(List<String> &p_delimiters) const = 0;
 	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const { return Ref<Script>(); }
 	virtual Vector<ScriptTemplate> get_built_in_templates(const StringName &p_object) { return Vector<ScriptTemplate>(); }
 	virtual bool is_using_templates() { return false; }
@@ -424,7 +424,7 @@ public:
 	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) = 0;
 	/* LOADER FUNCTIONS */
 
-	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const = 0;
 	virtual void get_public_functions(List<MethodInfo> *p_functions) const = 0;
 	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const = 0;
 	virtual void get_public_annotations(List<MethodInfo> *p_annotations) const = 0;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -242,42 +242,42 @@ public:
 
 	GDVIRTUAL0RC_REQUIRED(Vector<String>, _get_reserved_words)
 
-	virtual void get_reserved_words(List<String> *p_words) const override {
+	virtual void get_reserved_words(List<String> &p_words) const override {
 		Vector<String> ret;
 		GDVIRTUAL_CALL(_get_reserved_words, ret);
 		for (int i = 0; i < ret.size(); i++) {
-			p_words->push_back(ret[i]);
+			p_words.push_back(ret[i]);
 		}
 	}
 	EXBIND1RC(bool, is_control_flow_keyword, const String &)
 
 	GDVIRTUAL0RC_REQUIRED(Vector<String>, _get_comment_delimiters)
 
-	virtual void get_comment_delimiters(List<String> *p_words) const override {
+	virtual void get_comment_delimiters(List<String> &p_words) const override {
 		Vector<String> ret;
 		GDVIRTUAL_CALL(_get_comment_delimiters, ret);
 		for (int i = 0; i < ret.size(); i++) {
-			p_words->push_back(ret[i]);
+			p_words.push_back(ret[i]);
 		}
 	}
 
 	GDVIRTUAL0RC(Vector<String>, _get_doc_comment_delimiters)
 
-	virtual void get_doc_comment_delimiters(List<String> *p_words) const override {
+	virtual void get_doc_comment_delimiters(List<String> &p_words) const override {
 		Vector<String> ret;
 		GDVIRTUAL_CALL(_get_doc_comment_delimiters, ret);
 		for (int i = 0; i < ret.size(); i++) {
-			p_words->push_back(ret[i]);
+			p_words.push_back(ret[i]);
 		}
 	}
 
 	GDVIRTUAL0RC_REQUIRED(Vector<String>, _get_string_delimiters)
 
-	virtual void get_string_delimiters(List<String> *p_words) const override {
+	virtual void get_string_delimiters(List<String> &p_words) const override {
 		Vector<String> ret;
 		GDVIRTUAL_CALL(_get_string_delimiters, ret);
 		for (int i = 0; i < ret.size(); i++) {
-			p_words->push_back(ret[i]);
+			p_words.push_back(ret[i]);
 		}
 	}
 
@@ -608,11 +608,11 @@ public:
 
 	GDVIRTUAL0RC_REQUIRED(PackedStringArray, _get_recognized_extensions)
 
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override {
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override {
 		PackedStringArray ret;
 		GDVIRTUAL_CALL(_get_recognized_extensions, ret);
 		for (int i = 0; i < ret.size(); i++) {
-			p_extensions->push_back(ret[i]);
+			p_extensions.push_back(ret[i]);
 		}
 	}
 

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -565,7 +565,7 @@ StringName TranslationServer::pseudolocalize(const StringName &p_message) const 
 }
 
 #ifdef TOOLS_ENABLED
-void TranslationServer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void TranslationServer::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
 		HashMap<String, String> *target_hash_map = nullptr;
@@ -579,7 +579,7 @@ void TranslationServer::get_argument_options(const StringName &p_function, int p
 
 		if (target_hash_map) {
 			for (const KeyValue<String, String> &E : *target_hash_map) {
-				r_options->push_back(E.key.quote());
+				r_options.push_back(E.key.quote());
 			}
 		}
 	}

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -155,7 +155,7 @@ public:
 	void load_translations();
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif // TOOLS_ENABLED
 
 	TranslationServer();

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -49,8 +49,8 @@ Error ImageLoaderPNG::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 	return PNGDriverCommon::png_to_image(reader, buffer_size, p_flags & FLAG_FORCE_LINEAR, p_image);
 }
 
-void ImageLoaderPNG::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("png");
+void ImageLoaderPNG::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("png");
 }
 
 Ref<Image> ImageLoaderPNG::load_mem_png(const uint8_t *p_png, int p_size) {

--- a/drivers/png/image_loader_png.h
+++ b/drivers/png/image_loader_png.h
@@ -42,7 +42,7 @@ private:
 
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const;
 	ImageLoaderPNG();
 };
 

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -76,9 +76,9 @@ bool ResourceSaverPNG::recognize(const Ref<Resource> &p_resource) const {
 	return (p_resource.is_valid() && p_resource->is_class("ImageTexture"));
 }
 
-void ResourceSaverPNG::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+void ResourceSaverPNG::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const {
 	if (Object::cast_to<ImageTexture>(*p_resource)) {
-		p_extensions->push_back("png");
+		p_extensions.push_back("png");
 	}
 }
 

--- a/drivers/png/resource_saver_png.h
+++ b/drivers/png/resource_saver_png.h
@@ -41,7 +41,7 @@ public:
 
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
-	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const override;
 
 	ResourceSaverPNG();
 };

--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -143,7 +143,7 @@ Dictionary DebugAdapterParser::req_initialize(const Dictionary &p_params) const 
 	if (DebugAdapterProtocol::get_singleton()->_sync_breakpoints) {
 		// Send all current breakpoints
 		List<String> breakpoints;
-		ScriptEditor::get_singleton()->get_breakpoints(&breakpoints);
+		ScriptEditor::get_singleton()->get_breakpoints(breakpoints);
 		for (List<String>::Element *E = breakpoints.front(); E; E = E->next()) {
 			String breakpoint = E->get();
 

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -407,7 +407,7 @@ void EditorDebuggerTree::_item_menu_id_pressed(int p_option) {
 
 			List<String> extensions;
 			Ref<PackedScene> sd = memnew(PackedScene);
-			ResourceSaver::get_recognized_extensions(sd, &extensions);
+			ResourceSaver::get_recognized_extensions(sd, extensions);
 			file_dialog->clear_filters();
 			for (const String &extension : extensions) {
 				file_dialog->add_filter("*." + extension, extension.to_upper());

--- a/editor/debugger/editor_file_server.cpp
+++ b/editor/debugger/editor_file_server.cpp
@@ -70,7 +70,7 @@ void EditorFileServer::_scan_files_changed(EditorFileSystemDirectory *efd, const
 			}
 
 			List<String> remaps;
-			cf->get_section_keys("remap", &remaps);
+			cf->get_section_keys("remap", remaps);
 
 			for (const String &remap : remaps) {
 				if (remap == "path") {

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -64,7 +64,7 @@ void DependencyEditor::_load_pressed(Object *p_item, int p_cell, int p_button, M
 
 	search->clear_filters();
 	List<String> ext;
-	ResourceLoader::get_recognized_extensions_for_type(ti->get_metadata(0), &ext);
+	ResourceLoader::get_recognized_extensions_for_type(ti->get_metadata(0), ext);
 	for (const String &E : ext) {
 		search->add_filter("*." + E);
 	}
@@ -165,7 +165,7 @@ void DependencyEditor::_update_file() {
 
 void DependencyEditor::_update_list() {
 	List<String> deps;
-	ResourceLoader::get_dependencies(editing, &deps, true);
+	ResourceLoader::get_dependencies(editing, deps, true);
 
 	tree->clear();
 	missing.clear();

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -666,7 +666,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 			}
 
 			List<String> constant_list;
-			ClassDB::get_integer_constant_list(name, &constant_list, true);
+			ClassDB::get_integer_constant_list(name, constant_list, true);
 
 			for (const String &E : constant_list) {
 				DocData::ConstantDoc constant;

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1353,7 +1353,7 @@ EditorAudioBuses::EditorAudioBuses() {
 
 	file_dialog = memnew(EditorFileDialog);
 	List<String> ext;
-	ResourceLoader::get_recognized_extensions_for_type("AudioBusLayout", &ext);
+	ResourceLoader::get_recognized_extensions_for_type("AudioBusLayout", ext);
 	for (const String &E : ext) {
 		file_dialog->add_filter("*." + E, TTR("Audio Bus Layout"));
 	}

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -47,8 +47,8 @@ void EditorAutoloadSettings::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			List<String> afn;
-			ResourceLoader::get_recognized_extensions_for_type("Script", &afn);
-			ResourceLoader::get_recognized_extensions_for_type("PackedScene", &afn);
+			ResourceLoader::get_recognized_extensions_for_type("Script", afn);
+			ResourceLoader::get_recognized_extensions_for_type("PackedScene", afn);
 
 			for (const String &E : afn) {
 				file_dialog->add_filter("*." + E);
@@ -131,7 +131,7 @@ bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, Strin
 
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 		List<String> keywords;
-		ScriptServer::get_language(i)->get_reserved_words(&keywords);
+		ScriptServer::get_language(i)->get_reserved_words(keywords);
 		for (const String &E : keywords) {
 			if (E == p_name) {
 				if (r_error) {

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -216,9 +216,9 @@ void EditorCommandPalette::open_popup() {
 	search_options->scroll_to_item(search_options->get_root());
 }
 
-void EditorCommandPalette::get_actions_list(List<String> *p_list) const {
+void EditorCommandPalette::get_actions_list(List<String> &p_list) const {
 	for (const KeyValue<String, Command> &E : commands) {
-		p_list->push_back(E.key);
+		p_list.push_back(E.key);
 	}
 }
 

--- a/editor/editor_command_palette.h
+++ b/editor/editor_command_palette.h
@@ -92,7 +92,7 @@ protected:
 
 public:
 	void open_popup();
-	void get_actions_list(List<String> *p_list) const;
+	void get_actions_list(List<String> &p_list) const;
 	void add_command(String p_command_name, String p_key_name, Callable p_action, Vector<Variant> arguments, const Ref<Shortcut> &p_shortcut);
 	void execute_command(const String &p_command_name);
 	void register_shortcuts_as_command();

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -302,7 +302,7 @@ void EditorData::copy_object_params(Object *p_object) {
 	}
 }
 
-void EditorData::get_editor_breakpoints(List<String> *p_breakpoints) {
+void EditorData::get_editor_breakpoints(List<String> &p_breakpoints) {
 	for (int i = 0; i < editor_plugins.size(); i++) {
 		editor_plugins[i]->get_breakpoints(p_breakpoints);
 	}

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -162,7 +162,7 @@ public:
 	Dictionary get_editor_plugin_states() const;
 	Dictionary get_scene_editor_states(int p_idx) const;
 	void set_editor_plugin_states(const Dictionary &p_states);
-	void get_editor_breakpoints(List<String> *p_breakpoints);
+	void get_editor_breakpoints(List<String> &p_breakpoints);
 	void clear_editor_states();
 	void save_editor_external_data();
 	void apply_changes_in_editors();

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -251,7 +251,7 @@ void EditorFileSystem::_first_scan_filesystem() {
 	// Preloading GDExtensions file extensions to prevent looping on all the resource loaders
 	// for each files in _first_scan_process_scripts.
 	List<String> gdextension_extensions;
-	ResourceLoader::get_recognized_extensions_for_type("GDExtension", &gdextension_extensions);
+	ResourceLoader::get_recognized_extensions_for_type("GDExtension", gdextension_extensions);
 
 	// This loads the global class names from the scripts and ensures that even if the
 	// global_script_class_cache.cfg was missing or invalid, the global class names are valid in ScriptServer.
@@ -1516,7 +1516,7 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, ScanPr
 void EditorFileSystem::_delete_internal_files(const String &p_file) {
 	if (FileAccess::exists(p_file + ".import")) {
 		List<String> paths;
-		ResourceFormatImporter::get_singleton()->get_internal_resource_path_list(p_file, &paths);
+		ResourceFormatImporter::get_singleton()->get_internal_resource_path_list(p_file, paths);
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		for (const String &E : paths) {
 			da->remove(E);
@@ -1958,7 +1958,7 @@ Vector<String> EditorFileSystem::_get_dependencies(const String &p_path) {
 	}
 
 	List<String> deps;
-	ResourceLoader::get_dependencies(p_path, &deps);
+	ResourceLoader::get_dependencies(p_path, deps);
 
 	Vector<String> ret;
 	for (const String &E : deps) {
@@ -2492,7 +2492,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 
 		if (config->has_section("params")) {
 			List<String> sk;
-			config->get_section_keys("params", &sk);
+			config->get_section_keys("params", sk);
 			for (const String &param : sk) {
 				Variant value = config->get_value("params", param);
 				//override with whatever is in file
@@ -2676,7 +2676,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		if (err == OK) {
 			if (cf->has_section("params")) {
 				List<String> sk;
-				cf->get_section_keys("params", &sk);
+				cf->get_section_keys("params", sk);
 				for (const String &E : sk) {
 					if (!params.has(E)) {
 						params[E] = cf->get_value("params", E);
@@ -3314,7 +3314,7 @@ void EditorFileSystem::_move_group_files(EditorFileSystemDirectory *efd, const S
 			}
 
 			List<String> sk;
-			config->get_section_keys("params", &sk);
+			config->get_section_keys("params", sk);
 			for (const String &param : sk) {
 				//not very clean, but should work
 				String value = config->get_value("params", param);
@@ -3506,7 +3506,7 @@ void EditorFileSystem::_update_extensions() {
 	other_file_extensions.clear();
 
 	List<String> extensionsl;
-	ResourceLoader::get_recognized_extensions_for_type("", &extensionsl);
+	ResourceLoader::get_recognized_extensions_for_type("", extensionsl);
 	for (const String &E : extensionsl) {
 		valid_extensions.insert(E);
 	}
@@ -3529,7 +3529,7 @@ void EditorFileSystem::_update_extensions() {
 	}
 
 	extensionsl.clear();
-	ResourceFormatImporter::get_singleton()->get_recognized_extensions(&extensionsl);
+	ResourceFormatImporter::get_singleton()->get_recognized_extensions(extensionsl);
 	for (const String &E : extensionsl) {
 		import_extensions.insert(E);
 	}

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -737,16 +737,16 @@ bool EditorInterface::is_movie_maker_enabled() const {
 }
 
 #ifdef TOOLS_ENABLED
-void EditorInterface::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void EditorInterface::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "set_main_screen_editor") {
 			for (String E : { "\"2D\"", "\"3D\"", "\"Script\"", "\"AssetLib\"" }) {
-				r_options->push_back(E);
+				r_options.push_back(E);
 			}
 		} else if (pf == "get_editor_viewport_3d") {
 			for (uint32_t i = 0; i < Node3DEditor::VIEWPORTS_COUNT; i++) {
-				r_options->push_back(String::num_int64(i));
+				r_options.push_back(String::num_int64(i));
 			}
 		}
 	}

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -191,7 +191,7 @@ public:
 	bool is_movie_maker_enabled() const;
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	// Base.

--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -96,7 +96,7 @@ void EditorLayoutsDialog::_post_popup() {
 	}
 
 	List<String> layouts;
-	config.ptr()->get_sections(&layouts);
+	config.ptr()->get_sections(layouts);
 
 	for (const String &E : layouts) {
 		layout_names->add_item(E);

--- a/editor/editor_native_shader_source_visualizer.cpp
+++ b/editor/editor_native_shader_source_visualizer.cpp
@@ -46,7 +46,7 @@ void EditorNativeShaderSourceVisualizer::_load_theme_settings() {
 	syntax_highlighter->clear_keyword_colors();
 
 	List<String> keywords;
-	ShaderLanguage::get_keyword_list(&keywords);
+	ShaderLanguage::get_keyword_list(keywords);
 	const Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
 	const Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1458,7 +1458,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 	current_menu_option = RESOURCE_SAVE_AS;
 	List<String> extensions;
 	Ref<PackedScene> sd = memnew(PackedScene);
-	ResourceSaver::get_recognized_extensions(p_resource, &extensions);
+	ResourceSaver::get_recognized_extensions(p_resource, extensions);
 	file->clear_filters();
 
 	List<String> preferred;
@@ -1566,7 +1566,7 @@ void EditorNode::_load_editor_plugin_states_from_config(const Ref<ConfigFile> &p
 	}
 
 	List<String> esl;
-	p_config_file->get_section_keys("editor_states", &esl);
+	p_config_file->get_section_keys("editor_states", esl);
 
 	Dictionary md;
 	for (const String &E : esl) {
@@ -2297,7 +2297,7 @@ void EditorNode::_dialog_action(String p_file) {
 
 			// Erase key values.
 			List<String> keys;
-			config->get_section_keys(p_file, &keys);
+			config->get_section_keys(p_file, keys);
 			for (const String &key : keys) {
 				config->set_value(p_file, key, Variant());
 			}
@@ -2758,7 +2758,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case FILE_OPEN_SCENE: {
 			file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 			List<String> extensions;
-			ResourceLoader::get_recognized_extensions_for_type("PackedScene", &extensions);
+			ResourceLoader::get_recognized_extensions_for_type("PackedScene", extensions);
 			file->clear_filters();
 			for (const String &extension : extensions) {
 				file->add_filter("*." + extension, extension.to_upper());
@@ -2869,7 +2869,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 			List<String> extensions;
 			Ref<PackedScene> sd = memnew(PackedScene);
-			ResourceSaver::get_recognized_extensions(sd, &extensions);
+			ResourceSaver::get_recognized_extensions(sd, extensions);
 			file->clear_filters();
 			for (const String &extension : extensions) {
 				file->add_filter("*." + extension, extension.to_upper());
@@ -3192,7 +3192,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case SETTINGS_PICK_MAIN_SCENE: {
 			file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 			List<String> extensions;
-			ResourceLoader::get_recognized_extensions_for_type("PackedScene", &extensions);
+			ResourceLoader::get_recognized_extensions_for_type("PackedScene", extensions);
 			file->clear_filters();
 			for (const String &extension : extensions) {
 				file->add_filter("*." + extension, extension.to_upper());
@@ -3375,7 +3375,7 @@ void EditorNode::_export_as_menu_option(int p_idx) {
 
 		List<String> extensions;
 		Ref<MeshLibrary> ml(memnew(MeshLibrary));
-		ResourceSaver::get_recognized_extensions(ml, &extensions);
+		ResourceSaver::get_recognized_extensions(ml, extensions);
 		file_export_lib->clear_filters();
 		for (const String &E : extensions) {
 			file_export_lib->add_filter("*." + E);
@@ -5593,7 +5593,7 @@ void EditorNode::_update_layouts_menu() {
 	}
 
 	List<String> layouts;
-	config.ptr()->get_sections(&layouts);
+	config.ptr()->get_sections(layouts);
 
 	for (const String &layout : layouts) {
 		if (layout == TTR("Default")) {
@@ -7812,7 +7812,7 @@ EditorNode::EditorNode() {
 	file_script->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	file_script->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	List<String> sexts;
-	ResourceLoader::get_recognized_extensions_for_type("Script", &sexts);
+	ResourceLoader::get_recognized_extensions_for_type("Script", sexts);
 	for (const String &E : sexts) {
 		file_script->add_filter("*." + E);
 	}

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2991,7 +2991,7 @@ void EditorPropertyResource::_resource_selected(const Ref<Resource> &p_resource,
 	if (p_resource->is_built_in() && !p_resource->get_path().is_empty()) {
 		String parent = p_resource->get_path().get_slice("::", 0);
 		List<String> extensions;
-		ResourceLoader::get_recognized_extensions_for_type("PackedScene", &extensions);
+		ResourceLoader::get_recognized_extensions_for_type("PackedScene", extensions);
 
 		if (p_inspect) {
 			if (extensions.find(parent.get_extension()) && (!EditorNode::get_singleton()->get_edited_scene() || EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path() != parent)) {

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -314,9 +314,9 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			List<String> extensions;
 			for (int i = 0; i < base_type.get_slice_count(","); i++) {
 				String base = base_type.get_slice(",", i);
-				ResourceLoader::get_recognized_extensions_for_type(base, &extensions);
+				ResourceLoader::get_recognized_extensions_for_type(base, extensions);
 				if (ScriptServer::is_global_class(base)) {
-					ResourceLoader::get_recognized_extensions_for_type(ScriptServer::get_global_class_native_base(base), &extensions);
+					ResourceLoader::get_recognized_extensions_for_type(ScriptServer::get_global_class_native_base(base), extensions);
 				}
 			}
 

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -117,7 +117,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 	}
 
 	List<String> breakpoints;
-	EditorNode::get_editor_data().get_editor_breakpoints(&breakpoints);
+	EditorNode::get_editor_data().get_editor_breakpoints(breakpoints);
 
 	if (!breakpoints.is_empty()) {
 		args.push_back("--breakpoints");

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1032,7 +1032,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 		if (p_extra_config->has_section("presets")) {
 			List<String> keys;
-			p_extra_config->get_section_keys("presets", &keys);
+			p_extra_config->get_section_keys("presets", keys);
 
 			for (const String &key : keys) {
 				Variant val = p_extra_config->get_value("presets", key);
@@ -1583,7 +1583,7 @@ void EditorSettings::load_favorites_and_recent_dirs() {
 	cf.instantiate();
 	if (cf->load(favorite_properties_file) == OK) {
 		List<String> secs;
-		cf->get_sections(&secs);
+		cf->get_sections(secs);
 
 		for (String &E : secs) {
 			PackedStringArray properties = PackedStringArray(cf->get_value(E, "properties"));
@@ -1653,7 +1653,7 @@ void EditorSettings::load_text_editor_theme() {
 	}
 
 	List<String> keys;
-	cf->get_section_keys("color_theme", &keys);
+	cf->get_section_keys("color_theme", keys);
 
 	for (const String &key : keys) {
 		String val = cf->get_value("color_theme", key);
@@ -1851,9 +1851,9 @@ Ref<Shortcut> EditorSettings::get_shortcut(const String &p_name) const {
 	return Ref<Shortcut>();
 }
 
-void EditorSettings::get_shortcut_list(List<String> *r_shortcuts) {
+void EditorSettings::get_shortcut_list(List<String> &r_shortcuts) {
 	for (const KeyValue<String, Ref<Shortcut>> &E : shortcuts) {
-		r_shortcuts->push_back(E.key);
+		r_shortcuts.push_back(E.key);
 	}
 }
 
@@ -2060,7 +2060,7 @@ void EditorSettings::notify_changes() {
 }
 
 #ifdef TOOLS_ENABLED
-void EditorSettings::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void EditorSettings::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "has_setting" || pf == "set_setting" || pf == "get_setting" || pf == "erase" ||
@@ -2070,17 +2070,17 @@ void EditorSettings::get_argument_options(const StringName &p_function, int p_id
 					continue;
 				}
 
-				r_options->push_back(E.key.quote());
+				r_options.push_back(E.key.quote());
 			}
 		} else if (pf == "get_project_metadata" && project_metadata.is_valid()) {
 			List<String> sections;
-			project_metadata->get_sections(&sections);
+			project_metadata->get_sections(sections);
 			for (const String &section : sections) {
-				r_options->push_back(section.quote());
+				r_options.push_back(section.quote());
 			}
 		} else if (pf == "set_builtin_action_override") {
 			for (const StringName &action : InputMap::get_singleton()->get_actions()) {
-				r_options->push_back(String(action).quote());
+				r_options.push_back(String(action).quote());
 			}
 		}
 	}

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -197,7 +197,7 @@ public:
 	void add_shortcut(const String &p_name, const Ref<Shortcut> &p_shortcut);
 	bool is_shortcut(const String &p_name, const Ref<InputEvent> &p_event) const;
 	Ref<Shortcut> get_shortcut(const String &p_name) const;
-	void get_shortcut_list(List<String> *r_shortcuts);
+	void get_shortcut_list(List<String> &r_shortcuts);
 
 	void set_builtin_action_override(const String &p_name, const TypedArray<InputEvent> &p_events);
 	const Array get_builtin_action_overrides(const String &p_name) const;
@@ -205,7 +205,7 @@ public:
 	void notify_changes();
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	EditorSettings();

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -563,7 +563,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 	// Editor Shortcuts
 
 	List<String> slist;
-	EditorSettings::get_singleton()->get_shortcut_list(&slist);
+	EditorSettings::get_singleton()->get_shortcut_list(slist);
 	slist.sort(); // Sort alphabetically.
 
 	const EditorPropertyNameProcessor::Style name_style = EditorPropertyNameProcessor::get_settings_style();

--- a/editor/editor_translation_parser.cpp
+++ b/editor/editor_translation_parser.cpp
@@ -79,11 +79,11 @@ void EditorTranslationParserPlugin::get_comments(Vector<String> *r_ids_comment, 
 	}
 }
 
-void EditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_extensions) const {
+void EditorTranslationParserPlugin::get_recognized_extensions(List<String> &r_extensions) const {
 	Vector<String> extensions;
 	if (GDVIRTUAL_CALL(_get_recognized_extensions, extensions)) {
 		for (int i = 0; i < extensions.size(); i++) {
-			r_extensions->push_back(extensions[i]);
+			r_extensions.push_back(extensions[i]);
 		}
 	} else {
 		ERR_PRINT("Custom translation parser plugin's \"func get_recognized_extensions()\" is undefined.");
@@ -98,27 +98,27 @@ void EditorTranslationParserPlugin::_bind_methods() {
 
 /////////////////////////
 
-void EditorTranslationParser::get_recognized_extensions(List<String> *r_extensions) const {
+void EditorTranslationParser::get_recognized_extensions(List<String> &r_extensions) const {
 	HashSet<String> extensions;
 	List<String> temp;
 	for (int i = 0; i < standard_parsers.size(); i++) {
-		standard_parsers[i]->get_recognized_extensions(&temp);
+		standard_parsers[i]->get_recognized_extensions(temp);
 	}
 	for (int i = 0; i < custom_parsers.size(); i++) {
-		custom_parsers[i]->get_recognized_extensions(&temp);
+		custom_parsers[i]->get_recognized_extensions(temp);
 	}
 	// Remove duplicates.
 	for (const String &E : temp) {
 		extensions.insert(E);
 	}
 	for (const String &E : extensions) {
-		r_extensions->push_back(E);
+		r_extensions.push_back(E);
 	}
 }
 
 bool EditorTranslationParser::can_parse(const String &p_extension) const {
 	List<String> extensions;
-	get_recognized_extensions(&extensions);
+	get_recognized_extensions(extensions);
 	for (const String &extension : extensions) {
 		if (p_extension == extension) {
 			return true;
@@ -131,7 +131,7 @@ Ref<EditorTranslationParserPlugin> EditorTranslationParser::get_parser(const Str
 	// Consider user-defined parsers first.
 	for (int i = 0; i < custom_parsers.size(); i++) {
 		List<String> temp;
-		custom_parsers[i]->get_recognized_extensions(&temp);
+		custom_parsers[i]->get_recognized_extensions(temp);
 		for (const String &E : temp) {
 			if (E == p_extension) {
 				return custom_parsers[i];
@@ -141,7 +141,7 @@ Ref<EditorTranslationParserPlugin> EditorTranslationParser::get_parser(const Str
 
 	for (int i = 0; i < standard_parsers.size(); i++) {
 		List<String> temp;
-		standard_parsers[i]->get_recognized_extensions(&temp);
+		standard_parsers[i]->get_recognized_extensions(temp);
 		for (const String &E : temp) {
 			if (E == p_extension) {
 				return standard_parsers[i];

--- a/editor/editor_translation_parser.h
+++ b/editor/editor_translation_parser.h
@@ -49,7 +49,7 @@ protected:
 public:
 	virtual Error parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural);
 	virtual void get_comments(Vector<String> *r_ids_comment, Vector<String> *r_ids_ctx_plural_comment);
-	virtual void get_recognized_extensions(List<String> *r_extensions) const;
+	virtual void get_recognized_extensions(List<String> &r_extensions) const;
 };
 
 class EditorTranslationParser {
@@ -66,7 +66,7 @@ public:
 	Vector<Ref<EditorTranslationParserPlugin>> standard_parsers;
 	Vector<Ref<EditorTranslationParserPlugin>> custom_parsers;
 
-	void get_recognized_extensions(List<String> *r_extensions) const;
+	void get_recognized_extensions(List<String> &r_extensions) const;
 	bool can_parse(const String &p_extension) const;
 	Ref<EditorTranslationParserPlugin> get_parser(const String &p_extension) const;
 	void add_parser(const Ref<EditorTranslationParserPlugin> &p_parser, ParserType p_type);

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -331,7 +331,7 @@ void EditorExport::load_config() {
 		String option_section = "preset." + itos(index) + ".options";
 
 		List<String> options;
-		config->get_section_keys(option_section, &options);
+		config->get_section_keys(option_section, options);
 
 		for (const String &E : options) {
 			Variant value = config->get_value(option_section, E);
@@ -340,7 +340,7 @@ void EditorExport::load_config() {
 
 		if (credentials->has_section(option_section)) {
 			options.clear();
-			credentials->get_section_keys(option_section, &options);
+			credentials->get_section_keys(option_section, options);
 
 			for (const String &E : options) {
 				// Drop values for secret properties that no longer exist, or during the next save they would end up in the regular config file.

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -556,8 +556,8 @@ void EditorExportPlatform::_edit_filter_list(HashSet<String> &r_list, const Stri
 HashSet<String> EditorExportPlatform::get_features(const Ref<EditorExportPreset> &p_preset, bool p_debug) const {
 	Ref<EditorExportPlatform> platform = p_preset->get_platform();
 	List<String> feature_list;
-	platform->get_platform_features(&feature_list);
-	platform->get_preset_features(p_preset, &feature_list);
+	platform->get_platform_features(feature_list);
+	platform->get_preset_features(p_preset, feature_list);
 
 	HashSet<String> result;
 	for (const String &E : feature_list) {
@@ -1362,7 +1362,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 
 				// Erase all Paths.
 				List<String> keys;
-				config->get_section_keys("remap", &keys);
+				config->get_section_keys("remap", keys);
 				for (const String &K : keys) {
 					if (K.begins_with("path")) {
 						config->erase_section_key("remap", K);
@@ -1398,7 +1398,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			} else {
 				// File is imported and not customized, replace by what it imports.
 				List<String> remaps;
-				config->get_section_keys("remap", &remaps);
+				config->get_section_keys("remap", remaps);
 
 				HashSet<String> remap_features;
 
@@ -2236,7 +2236,7 @@ Vector<String> EditorExportPlatform::gen_export_flags(BitField<EditorExportPlatf
 		ret.push_back(get_debug_protocol() + host + ":" + String::num_int64(remote_port));
 
 		List<String> breakpoints;
-		ScriptEditor::get_singleton()->get_breakpoints(&breakpoints);
+		ScriptEditor::get_singleton()->get_breakpoints(breakpoints);
 
 		if (breakpoints.size()) {
 			ret.push_back("--breakpoints");

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -205,7 +205,7 @@ protected:
 	Ref<Image> _load_icon_or_splash_image(const String &p_path, Error *r_error) const;
 
 public:
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const = 0;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> &r_features) const = 0;
 
 	struct ExportOption {
 		PropertyInfo option;
@@ -333,7 +333,7 @@ public:
 	virtual Error export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0);
 	virtual Error export_pack_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, const Vector<String> &p_patches = Vector<String>(), BitField<EditorExportPlatform::DebugFlags> p_flags = 0);
 	virtual Error export_zip_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, const Vector<String> &p_patches = Vector<String>(), BitField<EditorExportPlatform::DebugFlags> p_flags = 0);
-	virtual void get_platform_features(List<String> *r_features) const = 0;
+	virtual void get_platform_features(List<String> &r_features) const = 0;
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) {}
 	virtual String get_debug_protocol() const { return "tcp://"; }
 

--- a/editor/export/editor_export_platform_extension.cpp
+++ b/editor/export/editor_export_platform_extension.cpp
@@ -79,11 +79,11 @@ void EditorExportPlatformExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_debug_protocol);
 }
 
-void EditorExportPlatformExtension::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
+void EditorExportPlatformExtension::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> &r_features) const {
 	Vector<String> ret;
-	if (GDVIRTUAL_CALL(_get_preset_features, p_preset, ret) && r_features) {
+	if (GDVIRTUAL_CALL(_get_preset_features, p_preset, ret)) {
 		for (const String &E : ret) {
-			r_features->push_back(E);
+			r_features.push_back(E);
 		}
 	}
 }
@@ -331,11 +331,11 @@ Error EditorExportPlatformExtension::export_zip_patch(const Ref<EditorExportPres
 	return err;
 }
 
-void EditorExportPlatformExtension::get_platform_features(List<String> *r_features) const {
+void EditorExportPlatformExtension::get_platform_features(List<String> &r_features) const {
 	Vector<String> ret;
-	if (GDVIRTUAL_CALL(_get_platform_features, ret) && r_features) {
+	if (GDVIRTUAL_CALL(_get_platform_features, ret)) {
 		for (const String &E : ret) {
-			r_features->push_back(E);
+			r_features.push_back(E);
 		}
 	}
 }

--- a/editor/export/editor_export_platform_extension.h
+++ b/editor/export/editor_export_platform_extension.h
@@ -44,7 +44,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> &r_features) const override;
 	GDVIRTUAL1RC_REQUIRED(Vector<String>, _get_preset_features, Ref<EditorExportPreset>);
 
 	virtual bool is_executable(const String &p_path) const override;
@@ -142,7 +142,7 @@ public:
 	virtual Error export_zip_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, const Vector<String> &p_patches = Vector<String>(), BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
 	GDVIRTUAL5R(Error, _export_zip_patch, Ref<EditorExportPreset>, bool, const String &, const Vector<String> &, BitField<EditorExportPlatform::DebugFlags>);
 
-	virtual void get_platform_features(List<String> *r_features) const override;
+	virtual void get_platform_features(List<String> &r_features) const override;
 	GDVIRTUAL0RC_REQUIRED(Vector<String>, _get_platform_features);
 
 	virtual String get_debug_protocol() const override;

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -33,18 +33,18 @@
 #include "core/config/project_settings.h"
 #include "scene/resources/image_texture.h"
 
-void EditorExportPlatformPC::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
+void EditorExportPlatformPC::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> &r_features) const {
 	if (p_preset->get("texture_format/s3tc_bptc")) {
-		r_features->push_back("s3tc");
-		r_features->push_back("bptc");
+		r_features.push_back("s3tc");
+		r_features.push_back("bptc");
 	}
 	if (p_preset->get("texture_format/etc2_astc")) {
-		r_features->push_back("etc2");
-		r_features->push_back("astc");
+		r_features.push_back("etc2");
+		r_features.push_back("astc");
 	}
 	// PC platforms only have one architecture per export, since
 	// we export a single executable instead of a bundle.
-	r_features->push_back(p_preset->get("binary_format/architecture"));
+	r_features.push_back(p_preset->get("binary_format/architecture"));
 }
 
 void EditorExportPlatformPC::get_export_options(List<ExportOption> *r_options) const {
@@ -257,9 +257,9 @@ void EditorExportPlatformPC::set_logo(const Ref<Texture2D> &p_logo) {
 	logo = p_logo;
 }
 
-void EditorExportPlatformPC::get_platform_features(List<String> *r_features) const {
-	r_features->push_back("pc"); // Identify PC platforms as such.
-	r_features->push_back(get_os_name().to_lower()); // OS name is a feature.
+void EditorExportPlatformPC::get_platform_features(List<String> &r_features) const {
+	r_features.push_back("pc"); // Identify PC platforms as such.
+	r_features.push_back(get_os_name().to_lower()); // OS name is a feature.
 }
 
 void EditorExportPlatformPC::resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) {

--- a/editor/export/editor_export_platform_pc.h
+++ b/editor/export/editor_export_platform_pc.h
@@ -44,7 +44,7 @@ private:
 	int chmod_flags = -1;
 
 public:
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> &r_features) const override;
 
 	virtual void get_export_options(List<ExportOption> *r_options) const override;
 
@@ -68,7 +68,7 @@ public:
 	void set_logo(const Ref<Texture2D> &p_logo);
 
 	void add_platform_feature(const String &p_feature);
-	virtual void get_platform_features(List<String> *r_features) const override;
+	virtual void get_platform_features(List<String> &r_features) const override;
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) override;
 
 	int get_chmod_flags() const;

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -425,8 +425,8 @@ void ProjectExportDialog::_update_feature_list() {
 
 	List<String> features_list;
 
-	current->get_platform()->get_platform_features(&features_list);
-	current->get_platform()->get_preset_features(current, &features_list);
+	current->get_platform()->get_platform_features(features_list);
+	current->get_platform()->get_preset_features(current, features_list);
 
 	String custom = current->get_custom_features();
 	Vector<String> custom_list = custom.split(",");

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1240,7 +1240,7 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 
 			{
 				List<String> importer_exts;
-				ResourceImporterScene::get_scene_importer_extensions(&importer_exts);
+				ResourceImporterScene::get_scene_importer_extensions(importer_exts);
 				String extension = fpath.get_extension();
 				for (const String &E : importer_exts) {
 					if (extension.nocasecmp_to(E) == 0) {
@@ -3345,7 +3345,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 
 		{
 			List<String> resource_extensions;
-			ResourceFormatImporter::get_singleton()->get_recognized_extensions_for_type("Resource", &resource_extensions);
+			ResourceFormatImporter::get_singleton()->get_recognized_extensions_for_type("Resource", resource_extensions);
 			HashSet<String> extension_list;
 			for (const String &extension : resource_extensions) {
 				extension_list.insert(extension);

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -343,7 +343,7 @@ void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 		file_type_icons.insert(SNAME("__default_icon"), get_editor_theme_icon(SNAME("Object")));
 
 		List<String> history_keys;
-		history_file->get_section_keys("selected_history", &history_keys);
+		history_file->get_section_keys("selected_history", history_keys);
 		for (const String &type : history_keys) {
 			const StringName type_name = type;
 			const PackedStringArray paths = history_file->get_value("selected_history", type);

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -1796,8 +1796,8 @@ void ColladaImport::create_animation(int p_clip, bool p_import_value_tracks) {
 /*************************************** SCENE ***********************************/
 /*********************************************************************************/
 
-void EditorSceneFormatImporterCollada::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("dae");
+void EditorSceneFormatImporterCollada::get_extensions(List<String> &r_extensions) const {
+	r_extensions.push_back("dae");
 }
 
 Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err) {

--- a/editor/import/3d/editor_import_collada.h
+++ b/editor/import/3d/editor_import_collada.h
@@ -37,7 +37,7 @@ class EditorSceneFormatImporterCollada : public EditorSceneFormatImporter {
 	GDCLASS(EditorSceneFormatImporterCollada, EditorSceneFormatImporter);
 
 public:
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(List<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps = nullptr, Error *r_err = nullptr) override;
 
 	EditorSceneFormatImporterCollada();

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -580,8 +580,8 @@ Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, co
 	return scene;
 }
 
-void EditorOBJImporter::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("obj");
+void EditorOBJImporter::get_extensions(List<String> &r_extensions) const {
+	r_extensions.push_back("obj");
 }
 
 EditorOBJImporter::EditorOBJImporter() {
@@ -597,8 +597,8 @@ String ResourceImporterOBJ::get_visible_name() const {
 	return "OBJ as Mesh";
 }
 
-void ResourceImporterOBJ::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("obj");
+void ResourceImporterOBJ::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("obj");
 }
 
 String ResourceImporterOBJ::get_save_extension() const {

--- a/editor/import/3d/resource_importer_obj.h
+++ b/editor/import/3d/resource_importer_obj.h
@@ -37,7 +37,7 @@ class EditorOBJImporter : public EditorSceneFormatImporter {
 	GDCLASS(EditorOBJImporter, EditorSceneFormatImporter);
 
 public:
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(List<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr) override;
 
 	EditorOBJImporter();
@@ -49,7 +49,7 @@ class ResourceImporterOBJ : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 	virtual int get_format_version() const override;

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -57,11 +57,11 @@
 #include "scene/resources/packed_scene.h"
 #include "scene/resources/resource_format_text.h"
 
-void EditorSceneFormatImporter::get_extensions(List<String> *r_extensions) const {
+void EditorSceneFormatImporter::get_extensions(List<String> &r_extensions) const {
 	Vector<String> arr;
 	if (GDVIRTUAL_CALL(_get_extensions, arr)) {
 		for (int i = 0; i < arr.size(); i++) {
-			r_extensions->push_back(arr[i]);
+			r_extensions.push_back(arr[i]);
 		}
 		return;
 	}
@@ -271,7 +271,7 @@ String ResourceImporterScene::get_visible_name() const {
 	return _scene_import_type.capitalize();
 }
 
-void ResourceImporterScene::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterScene::get_recognized_extensions(List<String> &p_extensions) const {
 	get_scene_importer_extensions(p_extensions);
 }
 
@@ -2369,7 +2369,7 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "nodes/root_name"), ""));
 
 	List<String> script_extensions;
-	ResourceLoader::get_recognized_extensions_for_type("Script", &script_extensions);
+	ResourceLoader::get_recognized_extensions_for_type("Script", script_extensions);
 
 	String script_ext_hint;
 
@@ -2838,7 +2838,7 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashM
 
 	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
 		List<String> extensions;
-		importer_elem->get_extensions(&extensions);
+		importer_elem->get_extensions(extensions);
 
 		for (const String &F : extensions) {
 			if (F.to_lower() == ext) {
@@ -2896,7 +2896,7 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 
 	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
 		List<String> extensions;
-		importer_elem->get_extensions(&extensions);
+		importer_elem->get_extensions(extensions);
 
 		for (const String &F : extensions) {
 			if (F.to_lower() == ext) {
@@ -3262,7 +3262,7 @@ void ResourceImporterScene::clean_up_importer_plugins() {
 	post_importer_plugins.clear();
 }
 
-void ResourceImporterScene::get_scene_importer_extensions(List<String> *p_extensions) {
+void ResourceImporterScene::get_scene_importer_extensions(List<String> &p_extensions) {
 	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
 		importer_elem->get_extensions(p_extensions);
 	}
@@ -3270,8 +3270,8 @@ void ResourceImporterScene::get_scene_importer_extensions(List<String> *p_extens
 
 ///////////////////////////////////////
 
-void EditorSceneFormatImporterESCN::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("escn");
+void EditorSceneFormatImporterESCN::get_extensions(List<String> &r_extensions) const {
+	r_extensions.push_back("escn");
 }
 
 Node *EditorSceneFormatImporterESCN::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err) {

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -76,7 +76,7 @@ public:
 
 	void add_import_option(const String &p_name, const Variant &p_default_value);
 	void add_import_option_advanced(Variant::Type p_type, const String &p_name, const Variant &p_default_value, PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = String(), int p_usage_flags = PROPERTY_USAGE_DEFAULT);
-	virtual void get_extensions(List<String> *r_extensions) const;
+	virtual void get_extensions(List<String> &r_extensions) const;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr);
 	virtual void get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options);
 	virtual Variant get_option_visibility(const String &p_path, const String &p_scene_import_type, const String &p_option, const HashMap<StringName, Variant> &p_options);
@@ -251,7 +251,7 @@ public:
 	const Vector<Ref<EditorSceneFormatImporter>> &get_scene_importers() const { return scene_importers; }
 	static void add_scene_importer(Ref<EditorSceneFormatImporter> p_importer, bool p_first_priority = false);
 	static void remove_scene_importer(Ref<EditorSceneFormatImporter> p_importer);
-	static void get_scene_importer_extensions(List<String> *p_extensions);
+	static void get_scene_importer_extensions(List<String> &p_extensions);
 
 	static void clean_up_importer_plugins();
 
@@ -260,7 +260,7 @@ public:
 
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 	virtual int get_format_version() const override;
@@ -320,7 +320,7 @@ class EditorSceneFormatImporterESCN : public EditorSceneFormatImporter {
 	GDCLASS(EditorSceneFormatImporterESCN, EditorSceneFormatImporter);
 
 public:
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(List<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr) override;
 };
 

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -756,7 +756,7 @@ void SceneImportSettingsDialog::open_settings(const String &p_path, const String
 		Error err = config->load(p_path + ".import");
 		if (err == OK) {
 			List<String> keys;
-			config->get_section_keys("params", &keys);
+			config->get_section_keys("params", keys);
 			for (const String &E : keys) {
 				Variant value = config->get_value("params", E);
 				if (E == "_subresources") {

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -441,7 +441,7 @@ void AudioStreamImportSettingsDialog::edit(const String &p_path, const String &p
 			bar_beats_edit->set_value(config_file->get_value("params", "bar_beats", 4));
 
 			List<String> keys;
-			config_file->get_section_keys("params", &keys);
+			config_file->get_section_keys("params", keys);
 			for (const String &K : keys) {
 				params[K] = config_file->get_value("params", K);
 			}

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -1156,7 +1156,7 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 	print_verbose("Loading import settings:");
 	if (err == OK) {
 		List<String> keys;
-		config->get_section_keys("params", &keys);
+		config->get_section_keys("params", keys);
 		for (List<String>::Element *E = keys.front(); E; E = E->next()) {
 			String key = E->get();
 			print_verbose(String("    ") + key + " == " + String(config->get_value("params", key)));

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -52,12 +52,12 @@ String EditorImportPlugin::get_visible_name() const {
 	ERR_FAIL_V_MSG(String(), "Unimplemented _get_visible_name in add-on.");
 }
 
-void EditorImportPlugin::get_recognized_extensions(List<String> *p_extensions) const {
+void EditorImportPlugin::get_recognized_extensions(List<String> &p_extensions) const {
 	Vector<String> extensions;
 
 	if (GDVIRTUAL_CALL(_get_recognized_extensions, extensions)) {
 		for (int i = 0; i < extensions.size(); i++) {
-			p_extensions->push_back(extensions[i]);
+			p_extensions.push_back(extensions[i]);
 		}
 		return;
 	}

--- a/editor/import/editor_import_plugin.h
+++ b/editor/import/editor_import_plugin.h
@@ -61,7 +61,7 @@ public:
 	EditorImportPlugin();
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_preset_name(int p_idx) const override;
 	virtual int get_preset_count() const override;
 	virtual String get_save_extension() const override;

--- a/editor/import/resource_importer_bitmask.cpp
+++ b/editor/import/resource_importer_bitmask.cpp
@@ -43,7 +43,7 @@ String ResourceImporterBitMap::get_visible_name() const {
 	return "BitMap";
 }
 
-void ResourceImporterBitMap::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterBitMap::get_recognized_extensions(List<String> &p_extensions) const {
 	ImageLoader::get_recognized_extensions(p_extensions);
 }
 

--- a/editor/import/resource_importer_bitmask.h
+++ b/editor/import/resource_importer_bitmask.h
@@ -39,7 +39,7 @@ class ResourceImporterBitMap : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_bmfont.cpp
+++ b/editor/import/resource_importer_bmfont.cpp
@@ -41,11 +41,9 @@ String ResourceImporterBMFont::get_visible_name() const {
 	return "Font Data (AngelCode BMFont)";
 }
 
-void ResourceImporterBMFont::get_recognized_extensions(List<String> *p_extensions) const {
-	if (p_extensions) {
-		p_extensions->push_back("font");
-		p_extensions->push_back("fnt");
-	}
+void ResourceImporterBMFont::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("font");
+	p_extensions.push_back("fnt");
 }
 
 String ResourceImporterBMFont::get_save_extension() const {

--- a/editor/import/resource_importer_bmfont.h
+++ b/editor/import/resource_importer_bmfont.h
@@ -41,7 +41,7 @@ class ResourceImporterBMFont : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -43,8 +43,8 @@ String ResourceImporterCSVTranslation::get_visible_name() const {
 	return "CSV Translation";
 }
 
-void ResourceImporterCSVTranslation::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("csv");
+void ResourceImporterCSVTranslation::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("csv");
 }
 
 String ResourceImporterCSVTranslation::get_save_extension() const {

--- a/editor/import/resource_importer_csv_translation.h
+++ b/editor/import/resource_importer_csv_translation.h
@@ -39,7 +39,7 @@ class ResourceImporterCSVTranslation : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -44,17 +44,15 @@ String ResourceImporterDynamicFont::get_visible_name() const {
 	return "Font Data (Dynamic Font)";
 }
 
-void ResourceImporterDynamicFont::get_recognized_extensions(List<String> *p_extensions) const {
-	if (p_extensions) {
-		p_extensions->push_back("ttf");
-		p_extensions->push_back("ttc");
-		p_extensions->push_back("otf");
-		p_extensions->push_back("otc");
-		p_extensions->push_back("woff");
-		p_extensions->push_back("woff2");
-		p_extensions->push_back("pfb");
-		p_extensions->push_back("pfm");
-	}
+void ResourceImporterDynamicFont::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("ttf");
+	p_extensions.push_back("ttc");
+	p_extensions.push_back("otf");
+	p_extensions.push_back("otc");
+	p_extensions.push_back("woff");
+	p_extensions.push_back("woff2");
+	p_extensions.push_back("pfb");
+	p_extensions.push_back("pfm");
 }
 
 String ResourceImporterDynamicFont::get_save_extension() const {

--- a/editor/import/resource_importer_dynamic_font.h
+++ b/editor/import/resource_importer_dynamic_font.h
@@ -45,7 +45,7 @@ class ResourceImporterDynamicFont : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_image.cpp
+++ b/editor/import/resource_importer_image.cpp
@@ -41,7 +41,7 @@ String ResourceImporterImage::get_visible_name() const {
 	return "Image";
 }
 
-void ResourceImporterImage::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterImage::get_recognized_extensions(List<String> &p_extensions) const {
 	ImageLoader::get_recognized_extensions(p_extensions);
 }
 

--- a/editor/import/resource_importer_image.h
+++ b/editor/import/resource_importer_image.h
@@ -40,7 +40,7 @@ class ResourceImporterImage : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -41,10 +41,8 @@ String ResourceImporterImageFont::get_visible_name() const {
 	return "Font Data (Image Font)";
 }
 
-void ResourceImporterImageFont::get_recognized_extensions(List<String> *p_extensions) const {
-	if (p_extensions) {
-		ImageLoader::get_recognized_extensions(p_extensions);
-	}
+void ResourceImporterImageFont::get_recognized_extensions(List<String> &p_extensions) const {
+	ImageLoader::get_recognized_extensions(p_extensions);
 }
 
 String ResourceImporterImageFont::get_save_extension() const {

--- a/editor/import/resource_importer_imagefont.h
+++ b/editor/import/resource_importer_imagefont.h
@@ -41,7 +41,7 @@ class ResourceImporterImageFont : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -77,7 +77,7 @@ String ResourceImporterLayeredTexture::get_visible_name() const {
 	ERR_FAIL_V("");
 }
 
-void ResourceImporterLayeredTexture::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterLayeredTexture::get_recognized_extensions(List<String> &p_extensions) const {
 	ImageLoader::get_recognized_extensions(p_extensions);
 }
 

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -92,7 +92,7 @@ public:
 	static ResourceImporterLayeredTexture *get_singleton() { return singleton; }
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_shader_file.cpp
+++ b/editor/import/resource_importer_shader_file.cpp
@@ -44,8 +44,8 @@ String ResourceImporterShaderFile::get_visible_name() const {
 	return "GLSL Shader File";
 }
 
-void ResourceImporterShaderFile::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("glsl");
+void ResourceImporterShaderFile::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("glsl");
 }
 
 String ResourceImporterShaderFile::get_save_extension() const {

--- a/editor/import/resource_importer_shader_file.h
+++ b/editor/import/resource_importer_shader_file.h
@@ -39,7 +39,7 @@ class ResourceImporterShaderFile : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -175,7 +175,7 @@ String ResourceImporterTexture::get_visible_name() const {
 	return "Texture2D";
 }
 
-void ResourceImporterTexture::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterTexture::get_recognized_extensions(List<String> &p_extensions) const {
 	ImageLoader::get_recognized_extensions(p_extensions);
 }
 

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -87,7 +87,7 @@ public:
 	static ResourceImporterTexture *get_singleton() { return singleton; }
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -50,7 +50,7 @@ String ResourceImporterTextureAtlas::get_visible_name() const {
 	return "TextureAtlas";
 }
 
-void ResourceImporterTextureAtlas::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterTextureAtlas::get_recognized_extensions(List<String> &p_extensions) const {
 	ImageLoader::get_recognized_extensions(p_extensions);
 }
 

--- a/editor/import/resource_importer_texture_atlas.h
+++ b/editor/import/resource_importer_texture_atlas.h
@@ -53,7 +53,7 @@ public:
 
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -40,8 +40,8 @@ String ResourceImporterWAV::get_visible_name() const {
 	return "Microsoft WAV";
 }
 
-void ResourceImporterWAV::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("wav");
+void ResourceImporterWAV::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("wav");
 }
 
 String ResourceImporterWAV::get_save_extension() const {

--- a/editor/import/resource_importer_wav.h
+++ b/editor/import/resource_importer_wav.h
@@ -40,7 +40,7 @@ class ResourceImporterWAV : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -191,7 +191,7 @@ void ImportDock::_update_options(const String &p_path, const Ref<ConfigFile> &p_
 	HashMap<StringName, Variant> import_options;
 	if (p_config.is_valid() && p_config->has_section("params")) {
 		List<String> section_keys;
-		p_config->get_section_keys("params", &section_keys);
+		p_config->get_section_keys("params", section_keys);
 		for (const String &section_key : section_keys) {
 			import_options[section_key] = p_config->get_value("params", section_key);
 		}
@@ -259,7 +259,7 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 		}
 
 		List<String> keys;
-		config->get_section_keys("params", &keys);
+		config->get_section_keys("params", keys);
 
 		for (const String &E : keys) {
 			if (!value_frequency.has(E)) {

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -234,7 +234,7 @@ void InspectorDock::_load_resource(const String &p_type) {
 	load_resource_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 
 	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type(p_type, &extensions);
+	ResourceLoader::get_recognized_extensions_for_type(p_type, extensions);
 
 	load_resource_dialog->clear_filters();
 	for (const String &extension : extensions) {

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -48,14 +48,14 @@ void LocalizationEditor::_notification(int p_what) {
 			translation_pot_add_builtin->set_pressed(GLOBAL_GET("internationalization/locale/translation_add_builtin_strings_to_pot"));
 
 			List<String> tfn;
-			ResourceLoader::get_recognized_extensions_for_type("Translation", &tfn);
+			ResourceLoader::get_recognized_extensions_for_type("Translation", tfn);
 			tfn.erase("csv"); // CSV is recognized by the resource importer to generate translation files, but it's not a translation file itself.
 			for (const String &E : tfn) {
 				translation_file_open->add_filter("*." + E);
 			}
 
 			List<String> rfn;
-			ResourceLoader::get_recognized_extensions_for_type("Resource", &rfn);
+			ResourceLoader::get_recognized_extensions_for_type("Resource", rfn);
 			for (const String &E : rfn) {
 				translation_res_file_open_dialog->add_filter("*." + E);
 				translation_res_option_file_open_dialog->add_filter("*." + E);
@@ -406,7 +406,7 @@ void LocalizationEditor::_pot_generate(const String &p_file) {
 void LocalizationEditor::_update_pot_file_extensions() {
 	pot_file_open_dialog->clear_filters();
 	List<String> translation_parse_file_extensions;
-	EditorTranslationParser::get_singleton()->get_recognized_extensions(&translation_parse_file_extensions);
+	EditorTranslationParser::get_singleton()->get_recognized_extensions(translation_parse_file_extensions);
 	for (const String &E : translation_parse_file_extensions) {
 		pot_file_open_dialog->add_filter("*." + E);
 	}

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -406,7 +406,7 @@ void AnimationNodeBlendSpace1DEditor::_add_menu_type(int p_index) {
 	if (p_index == MENU_LOAD_FILE) {
 		open_file->clear_filters();
 		List<String> filters;
-		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", &filters);
+		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", filters);
 		for (const String &E : filters) {
 			open_file->add_filter("*." + E);
 		}

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -331,7 +331,7 @@ void AnimationNodeBlendSpace2DEditor::_add_menu_type(int p_index) {
 	if (p_index == MENU_LOAD_FILE) {
 		open_file->clear_filters();
 		List<String> filters;
-		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", &filters);
+		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", filters);
 		for (const String &E : filters) {
 			open_file->add_filter("*." + E);
 		}

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -315,7 +315,7 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 	if (p_idx == MENU_LOAD_FILE) {
 		open_file->clear_filters();
 		List<String> ext_filters;
-		ResourceLoader::get_recognized_extensions_for_type("AnimationNode", &ext_filters);
+		ResourceLoader::get_recognized_extensions_for_type("AnimationNode", ext_filters);
 		for (const String &E : ext_filters) {
 			open_file->add_filter("*." + E);
 		}

--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -135,7 +135,7 @@ void AnimationLibraryEditor::_add_library_confirm() {
 
 void AnimationLibraryEditor::_load_library() {
 	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("AnimationLibrary", &extensions);
+	ResourceLoader::get_recognized_extensions_for_type("AnimationLibrary", extensions);
 
 	file_dialog->set_title(TTR("Load Animation"));
 	file_dialog->clear_filters();
@@ -197,7 +197,7 @@ void AnimationLibraryEditor::_file_popup_selected(int p_id) {
 			}
 			file_dialog->clear_filters();
 			List<String> exts;
-			ResourceLoader::get_recognized_extensions_for_type("AnimationLibrary", &exts);
+			ResourceLoader::get_recognized_extensions_for_type("AnimationLibrary", exts);
 			for (const String &K : exts) {
 				file_dialog->add_filter("*." + K);
 			}
@@ -275,7 +275,7 @@ void AnimationLibraryEditor::_file_popup_selected(int p_id) {
 			}
 			file_dialog->clear_filters();
 			List<String> exts;
-			ResourceLoader::get_recognized_extensions_for_type("Animation", &exts);
+			ResourceLoader::get_recognized_extensions_for_type("Animation", exts);
 			for (const String &K : exts) {
 				file_dialog->add_filter("*." + K);
 			}
@@ -545,7 +545,7 @@ void AnimationLibraryEditor::_button_pressed(TreeItem *p_item, int p_column, int
 			case LIB_BUTTON_LOAD: {
 				adding_animation_to_library = p_item->get_metadata(0);
 				List<String> extensions;
-				ResourceLoader::get_recognized_extensions_for_type("Animation", &extensions);
+				ResourceLoader::get_recognized_extensions_for_type("Animation", extensions);
 
 				file_dialog->clear_filters();
 				for (const String &K : extensions) {
@@ -890,7 +890,7 @@ Vector<uint64_t> AnimationLibraryEditor::_load_mixer_libs_folding() {
 		uint64_t current_mixer_id = uint64_t(mixer->get_instance_id());
 		String current_mixer_signature = _get_mixer_signature();
 		List<String> sections;
-		config->get_sections(&sections);
+		config->get_sections(sections);
 
 		for (const String &section : sections) {
 			Variant mixer_id = config->get_value(section, "mixer");

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -774,7 +774,7 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 	if (p_index == MENU_LOAD_FILE) {
 		open_file->clear_filters();
 		List<String> filters;
-		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", &filters);
+		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", filters);
 		for (const String &E : filters) {
 			open_file->add_filter("*." + E);
 		}

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -378,11 +378,11 @@ void EditorPlugin::apply_changes() {
 	GDVIRTUAL_CALL(_apply_changes);
 }
 
-void EditorPlugin::get_breakpoints(List<String> *p_breakpoints) {
+void EditorPlugin::get_breakpoints(List<String> &p_breakpoints) {
 	PackedStringArray arr;
 	if (GDVIRTUAL_CALL(_get_breakpoints, arr)) {
 		for (int i = 0; i < arr.size(); i++) {
-			p_breakpoints->push_back(arr[i]);
+			p_breakpoints.push_back(arr[i]);
 		}
 	}
 }

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -197,7 +197,7 @@ public:
 	virtual String get_unsaved_status(const String &p_for_scene = "") const;
 	virtual void save_external_data(); // if editor references external resources/scenes, save them
 	virtual void apply_changes(); // if changes are pending in editor, apply them
-	virtual void get_breakpoints(List<String> *p_breakpoints);
+	virtual void get_breakpoints(List<String> &p_breakpoints);
 	virtual bool get_remove_list(List<Node *> *p_list);
 	virtual void set_window_layout(Ref<ConfigFile> p_layout);
 	virtual void get_window_layout(Ref<ConfigFile> p_layout);

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -518,7 +518,7 @@ Ref<Texture2D> EditorScriptPreviewPlugin::_generate_from_source_code(const Scrip
 
 	List<String> kwors;
 	if (p_language) {
-		p_language->get_reserved_words(&kwors);
+		p_language->get_reserved_words(kwors);
 	}
 
 	HashSet<String> control_flow_keywords;

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -264,7 +264,7 @@ MeshLibraryEditor::MeshLibraryEditor() {
 	file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	//not for now?
 	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("PackedScene", &extensions);
+	ResourceLoader::get_recognized_extensions_for_type("PackedScene", extensions);
 	file->clear_filters();
 	file->set_title(TTR("Import Scene"));
 	for (const String &extension : extensions) {

--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -34,7 +34,7 @@
 #include "core/object/script_language.h"
 #include "scene/resources/packed_scene.h"
 
-void PackedSceneEditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_extensions) const {
+void PackedSceneEditorTranslationParserPlugin::get_recognized_extensions(List<String> &r_extensions) const {
 	ResourceLoader::get_recognized_extensions_for_type("PackedScene", r_extensions);
 }
 

--- a/editor/plugins/packed_scene_translation_parser_plugin.h
+++ b/editor/plugins/packed_scene_translation_parser_plugin.h
@@ -44,7 +44,7 @@ class PackedSceneEditorTranslationParserPlugin : public EditorTranslationParserP
 public:
 	virtual Error parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural) override;
 	bool match_property(const String &p_property_name, const String &p_node_type);
-	virtual void get_recognized_extensions(List<String> *r_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &r_extensions) const override;
 
 	PackedSceneEditorTranslationParserPlugin();
 };

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -257,7 +257,7 @@ Particles2DEditorPlugin::Particles2DEditorPlugin() {
 	file = memnew(EditorFileDialog);
 
 	List<String> ext;
-	ImageLoader::get_recognized_extensions(&ext);
+	ImageLoader::get_recognized_extensions(ext);
 	for (const String &E : ext) {
 		file->add_filter("*." + E, E.to_upper());
 	}

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -88,7 +88,7 @@ void ResourcePreloaderEditor::_load_pressed() {
 
 	file->clear_filters();
 	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("", &extensions);
+	ResourceLoader::get_recognized_extensions_for_type("", extensions);
 	for (const String &extension : extensions) {
 		file->add_filter("*." + extension);
 	}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -156,7 +156,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		/* Core types. */
 		const Color basetype_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
 		List<String> core_types;
-		scr_lang->get_core_type_words(&core_types);
+		scr_lang->get_core_type_words(core_types);
 		for (const String &E : core_types) {
 			highlighter->add_keyword_color(E, basetype_color);
 		}
@@ -165,7 +165,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		const Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
 		const Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
 		List<String> keywords;
-		scr_lang->get_reserved_words(&keywords);
+		scr_lang->get_reserved_words(keywords);
 		for (const String &E : keywords) {
 			if (scr_lang->is_control_flow_keyword(E)) {
 				highlighter->add_keyword_color(E, control_flow_keyword_color);
@@ -191,7 +191,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 			}
 
 			List<String> clist;
-			ClassDB::get_integer_constant_list(instance_base, &clist);
+			ClassDB::get_integer_constant_list(instance_base, clist);
 			for (const String &E : clist) {
 				highlighter->add_member_keyword_color(E, member_variable_color);
 			}
@@ -200,7 +200,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		/* Comments */
 		const Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
 		List<String> comments;
-		scr_lang->get_comment_delimiters(&comments);
+		scr_lang->get_comment_delimiters(comments);
 		for (const String &comment : comments) {
 			String beg = comment.get_slice(" ", 0);
 			String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
@@ -210,7 +210,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		/* Doc comments */
 		const Color doc_comment_color = EDITOR_GET("text_editor/theme/highlighting/doc_comment_color");
 		List<String> doc_comments;
-		scr_lang->get_doc_comment_delimiters(&doc_comments);
+		scr_lang->get_doc_comment_delimiters(doc_comments);
 		for (const String &doc_comment : doc_comments) {
 			String beg = doc_comment.get_slice(" ", 0);
 			String end = doc_comment.get_slice_count(" ") > 1 ? doc_comment.get_slice(" ", 1) : String();
@@ -220,7 +220,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		/* Strings */
 		const Color string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
 		List<String> strings;
-		scr_lang->get_string_delimiters(&strings);
+		scr_lang->get_string_delimiters(strings);
 		for (const String &string : strings) {
 			String beg = string.get_slice(" ", 0);
 			String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
@@ -615,7 +615,7 @@ void ScriptEditor::_clear_breakpoints() {
 
 	// Clear from closed scripts.
 	List<String> cached_editors;
-	script_editor_cache->get_sections(&cached_editors);
+	script_editor_cache->get_sections(cached_editors);
 	for (const String &E : cached_editors) {
 		Array breakpoints = _get_cached_breakpoints_for_script(E);
 		for (int breakpoint : breakpoints) {
@@ -826,8 +826,8 @@ void ScriptEditor::_open_recent_script(int p_idx) {
 	// if its not on disk its a help file or deleted
 	if (FileAccess::exists(path)) {
 		List<String> extensions;
-		ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
-		ResourceLoader::get_recognized_extensions_for_type("JSON", &extensions);
+		ResourceLoader::get_recognized_extensions_for_type("Script", extensions);
+		ResourceLoader::get_recognized_extensions_for_type("JSON", extensions);
 
 		if (extensions.find(path.get_extension())) {
 			Ref<Resource> scr = ResourceLoader::load(path);
@@ -1328,7 +1328,7 @@ void ScriptEditor::_menu_option(int p_option) {
 			file_dialog_option = FILE_OPEN;
 
 			List<String> extensions;
-			ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
+			ResourceLoader::get_recognized_extensions_for_type("Script", extensions);
 			file_dialog->clear_filters();
 			for (const String &extension : extensions) {
 				file_dialog->add_filter("*." + extension, extension.to_upper());
@@ -1351,8 +1351,8 @@ void ScriptEditor::_menu_option(int p_option) {
 			previous_scripts.pop_back();
 
 			List<String> extensions;
-			ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
-			ResourceLoader::get_recognized_extensions_for_type("JSON", &extensions);
+			ResourceLoader::get_recognized_extensions_for_type("Script", extensions);
+			ResourceLoader::get_recognized_extensions_for_type("JSON", extensions);
 			bool built_in = !path.is_resource_file();
 
 			if (extensions.find(path.get_extension()) || built_in) {
@@ -1483,7 +1483,7 @@ void ScriptEditor::_menu_option(int p_option) {
 					file_dialog_option = FILE_SAVE_AS;
 
 					List<String> extensions;
-					ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
+					ResourceLoader::get_recognized_extensions_for_type("Script", extensions);
 					file_dialog->clear_filters();
 					file_dialog->set_current_dir(text_file->get_path().get_base_dir());
 					file_dialog->set_current_file(text_file->get_path().get_file());
@@ -1910,7 +1910,7 @@ Vector<String> ScriptEditor::_get_breakpoints() {
 
 	// Load breakpoints that are in closed scripts.
 	List<String> cached_editors;
-	script_editor_cache->get_sections(&cached_editors);
+	script_editor_cache->get_sections(cached_editors);
 	for (const String &E : cached_editors) {
 		if (loaded_scripts.has(E)) {
 			continue;
@@ -1924,7 +1924,7 @@ Vector<String> ScriptEditor::_get_breakpoints() {
 	return ret;
 }
 
-void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
+void ScriptEditor::get_breakpoints(List<String> &p_breakpoints) {
 	HashSet<String> loaded_scripts;
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
@@ -1945,13 +1945,13 @@ void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
 
 		PackedInt32Array bpoints = se->get_breakpoints();
 		for (int32_t bpoint : bpoints) {
-			p_breakpoints->push_back(base + ":" + itos((int)bpoint + 1));
+			p_breakpoints.push_back(base + ":" + itos((int)bpoint + 1));
 		}
 	}
 
 	// Load breakpoints that are in closed scripts.
 	List<String> cached_editors;
-	script_editor_cache->get_sections(&cached_editors);
+	script_editor_cache->get_sections(cached_editors);
 	for (const String &E : cached_editors) {
 		if (loaded_scripts.has(E)) {
 			continue;
@@ -1959,7 +1959,7 @@ void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
 
 		Array breakpoints = _get_cached_breakpoints_for_script(E);
 		for (int breakpoint : breakpoints) {
-			p_breakpoints->push_back(E + ":" + itos((int)breakpoint + 1));
+			p_breakpoints.push_back(E + ":" + itos((int)breakpoint + 1));
 		}
 	}
 }
@@ -2878,8 +2878,8 @@ void ScriptEditor::open_text_file_create_dialog(const String &p_base_path, const
 
 Ref<Resource> ScriptEditor::open_file(const String &p_file) {
 	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
-	ResourceLoader::get_recognized_extensions_for_type("JSON", &extensions);
+	ResourceLoader::get_recognized_extensions_for_type("Script", extensions);
+	ResourceLoader::get_recognized_extensions_for_type("JSON", extensions);
 	if (extensions.find(p_file.get_extension())) {
 		Ref<Resource> scr = ResourceLoader::load(p_file);
 		if (scr.is_null()) {
@@ -3475,8 +3475,8 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 
 	HashSet<String> loaded_scripts;
 	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
-	ResourceLoader::get_recognized_extensions_for_type("JSON", &extensions);
+	ResourceLoader::get_recognized_extensions_for_type("Script", extensions);
+	ResourceLoader::get_recognized_extensions_for_type("JSON", extensions);
 
 	for (int i = 0; i < scripts.size(); i++) {
 		String path = scripts[i];
@@ -3544,7 +3544,7 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 	// Remove any deleted editors that have been removed between launches.
 	// and if a Script, register breakpoints with the debugger.
 	List<String> cached_editors;
-	script_editor_cache->get_sections(&cached_editors);
+	script_editor_cache->get_sections(cached_editors);
 	for (const String &E : cached_editors) {
 		if (loaded_scripts.has(E)) {
 			continue;
@@ -4659,7 +4659,7 @@ void ScriptEditorPlugin::get_window_layout(Ref<ConfigFile> p_layout) {
 	}
 }
 
-void ScriptEditorPlugin::get_breakpoints(List<String> *p_breakpoints) {
+void ScriptEditorPlugin::get_breakpoints(List<String> &p_breakpoints) {
 	script_editor->get_breakpoints(p_breakpoints);
 }
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -563,7 +563,7 @@ public:
 	bool edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus = true);
 
 	Vector<String> _get_breakpoints();
-	void get_breakpoints(List<String> *p_breakpoints);
+	void get_breakpoints(List<String> &p_breakpoints);
 
 	PackedStringArray get_unsaved_scripts() const;
 	void save_current_script();
@@ -636,7 +636,7 @@ public:
 	virtual void set_window_layout(Ref<ConfigFile> p_layout) override;
 	virtual void get_window_layout(Ref<ConfigFile> p_layout) override;
 
-	virtual void get_breakpoints(List<String> *p_breakpoints) override;
+	virtual void get_breakpoints(List<String> &p_breakpoints) override;
 
 	virtual void edited_scene_changed() override;
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -225,7 +225,7 @@ void ScriptTextEditor::_set_theme_for_script() {
 	text_edit->get_syntax_highlighter()->update_cache();
 
 	List<String> strings;
-	script->get_language()->get_string_delimiters(&strings);
+	script->get_language()->get_string_delimiters(strings);
 	text_edit->clear_string_delimiters();
 	for (const String &string : strings) {
 		String beg = string.get_slice(" ", 0);
@@ -242,7 +242,7 @@ void ScriptTextEditor::_set_theme_for_script() {
 	text_edit->clear_comment_delimiters();
 
 	List<String> comments;
-	script->get_language()->get_comment_delimiters(&comments);
+	script->get_language()->get_comment_delimiters(comments);
 	for (const String &comment : comments) {
 		String beg = comment.get_slice(" ", 0);
 		String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
@@ -254,7 +254,7 @@ void ScriptTextEditor::_set_theme_for_script() {
 	}
 
 	List<String> doc_comments;
-	script->get_language()->get_doc_comment_delimiters(&doc_comments);
+	script->get_language()->get_doc_comment_delimiters(doc_comments);
 	for (const String &doc_comment : doc_comments) {
 		String beg = doc_comment.get_slice(" ", 0);
 		String end = doc_comment.get_slice_count(" ") > 1 ? doc_comment.get_slice(" ", 1) : String();
@@ -963,7 +963,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 		}
 
 		List<String> scene_extensions;
-		ResourceLoader::get_recognized_extensions_for_type("PackedScene", &scene_extensions);
+		ResourceLoader::get_recognized_extensions_for_type("PackedScene", scene_extensions);
 
 		if (scene_extensions.find(symbol.get_extension())) {
 			EditorNode::get_singleton()->load_scene(symbol);
@@ -1065,7 +1065,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 		String path = _get_absolute_path(p_symbol);
 		if (FileAccess::exists(path)) {
 			List<String> scene_extensions;
-			ResourceLoader::get_recognized_extensions_for_type("PackedScene", &scene_extensions);
+			ResourceLoader::get_recognized_extensions_for_type("PackedScene", scene_extensions);
 
 			if (scene_extensions.find(path.get_extension())) {
 				EditorNode::get_singleton()->load_scene(path);
@@ -1762,7 +1762,7 @@ void ScriptTextEditor::_edit_option_toggle_inline_comment() {
 
 	String delimiter = "#";
 	List<String> comment_delimiters;
-	script->get_language()->get_comment_delimiters(&comment_delimiters);
+	script->get_language()->get_comment_delimiters(comment_delimiters);
 
 	for (const String &script_delimiter : comment_delimiters) {
 		if (!script_delimiter.contains_char(' ')) {

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -611,7 +611,7 @@ void Skeleton3DEditor::export_skeleton_profile() {
 	file_dialog->set_title(TTR("Export Skeleton Profile As..."));
 
 	List<String> exts;
-	ResourceLoader::get_recognized_extensions_for_type("SkeletonProfile", &exts);
+	ResourceLoader::get_recognized_extensions_for_type("SkeletonProfile", exts);
 	file_dialog->clear_filters();
 	for (const String &K : exts) {
 		file_dialog->add_filter("*." + K);

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -61,7 +61,7 @@ static void _draw_shadowed_line(Control *p_control, const Point2 &p_from, const 
 void SpriteFramesEditor::_open_sprite_sheet() {
 	file_split_sheet->clear_filters();
 	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("Texture2D", &extensions);
+	ResourceLoader::get_recognized_extensions_for_type("Texture2D", extensions);
 	for (const String &extension : extensions) {
 		file_split_sheet->add_filter("*." + extension);
 	}
@@ -747,7 +747,7 @@ void SpriteFramesEditor::_load_pressed() {
 
 	file->clear_filters();
 	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("Texture2D", &extensions);
+	ResourceLoader::get_recognized_extensions_for_type("Texture2D", extensions);
 	for (const String &extension : extensions) {
 		file->add_filter("*." + extension);
 	}

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -238,7 +238,7 @@ void ShaderTextEditor::_load_theme_settings() {
 	const Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
 
 	List<String> keywords;
-	ShaderLanguage::get_keyword_list(&keywords);
+	ShaderLanguage::get_keyword_list(keywords);
 
 	for (const String &E : keywords) {
 		if (ShaderLanguage::is_control_flow_keyword(E)) {
@@ -249,7 +249,7 @@ void ShaderTextEditor::_load_theme_settings() {
 	}
 
 	List<String> pp_keywords;
-	ShaderPreprocessor::get_keyword_list(&pp_keywords, false);
+	ShaderPreprocessor::get_keyword_list(pp_keywords, false);
 
 	for (const String &E : pp_keywords) {
 		syntax_highlighter->add_keyword_color(E, control_flow_keyword_color);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -2107,7 +2107,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 	import_another_theme_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	import_another_theme_dialog->set_title(TTR("Select Another Theme Resource:"));
 	List<String> ext;
-	ResourceLoader::get_recognized_extensions_for_type("Theme", &ext);
+	ResourceLoader::get_recognized_extensions_for_type("Theme", ext);
 	for (const String &E : ext) {
 		import_another_theme_dialog->add_filter("*." + E, TTR("Theme Resource"));
 	}
@@ -3830,7 +3830,7 @@ ThemeEditor::ThemeEditor() {
 	preview_scene_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	preview_scene_dialog->set_title(TTR("Select UI Scene:"));
 	List<String> ext;
-	ResourceLoader::get_recognized_extensions_for_type("PackedScene", &ext);
+	ResourceLoader::get_recognized_extensions_for_type("PackedScene", ext);
 	for (const String &E : ext) {
 		preview_scene_dialog->add_filter("*." + E, TTR("Scene"));
 	}

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -301,7 +301,7 @@ void TileSetEditor::_source_add_id_pressed(int p_id_pressed) {
 				texture_file_dialog->connect("files_selected", callable_mp(this, &TileSetEditor::_load_texture_files));
 
 				List<String> extensions;
-				ResourceLoader::get_recognized_extensions_for_type("Texture2D", &extensions);
+				ResourceLoader::get_recognized_extensions_for_type("Texture2D", extensions);
 				for (const String &E : extensions) {
 					texture_file_dialog->add_filter("*." + E, E.to_upper());
 				}

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -6375,7 +6375,7 @@ void VisualShaderEditor::_bind_methods() {
 }
 
 VisualShaderEditor::VisualShaderEditor() {
-	ShaderLanguage::get_keyword_list(&keyword_list);
+	ShaderLanguage::get_keyword_list(keyword_list);
 	EditorNode::get_singleton()->connect("resource_saved", callable_mp(this, &VisualShaderEditor::_resource_saved));
 	FileSystemDock::get_singleton()->get_script_create_dialog()->connect("script_created", callable_mp(this, &VisualShaderEditor::_script_created));
 	FileSystemDock::get_singleton()->connect("resource_removed", callable_mp(this, &VisualShaderEditor::_resource_removed));

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -388,7 +388,7 @@ void ProjectList::_scan_thread(void *p_scan_data) {
 
 	for (const String &base_path : scan_data->paths_to_scan) {
 		print_verbose(vformat("Scanning for projects in \"%s\".", base_path));
-		_scan_folder_recursive(base_path, &scan_data->found_projects, scan_data->scan_in_progress);
+		_scan_folder_recursive(base_path, scan_data->found_projects, scan_data->scan_in_progress);
 
 		if (!scan_data->scan_in_progress.is_set()) {
 			print_verbose("Scan aborted.");
@@ -748,7 +748,7 @@ void ProjectList::find_projects_multiple(const PackedStringArray &p_paths) {
 void ProjectList::load_project_list() {
 	List<String> sections;
 	_config.load(_config_path);
-	_config.get_sections(&sections);
+	_config.get_sections(sections);
 
 	for (const String &path : sections) {
 		bool favorite = _config.get_value(path, "favorite", false);
@@ -756,7 +756,7 @@ void ProjectList::load_project_list() {
 	}
 }
 
-void ProjectList::_scan_folder_recursive(const String &p_path, List<String> *r_projects, const SafeFlag &p_scan_active) {
+void ProjectList::_scan_folder_recursive(const String &p_path, List<String> &r_projects, const SafeFlag &p_scan_active) {
 	if (!p_scan_active.is_set()) {
 		return;
 	}
@@ -775,7 +775,7 @@ void ProjectList::_scan_folder_recursive(const String &p_path, List<String> *r_p
 		if (da->current_is_dir() && n[0] != '.') {
 			_scan_folder_recursive(da->get_current_dir().path_join(n), r_projects, p_scan_active);
 		} else if (n == "project.godot") {
-			r_projects->push_back(da->get_current_dir());
+			r_projects.push_back(da->get_current_dir());
 		}
 		n = da->get_next();
 	}

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -204,7 +204,7 @@ private:
 
 	// Project list updates.
 
-	static void _scan_folder_recursive(const String &p_path, List<String> *r_projects, const SafeFlag &p_scan_active);
+	static void _scan_folder_recursive(const String &p_path, List<String> &r_projects, const SafeFlag &p_scan_active);
 
 	// Project list items.
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -298,7 +298,7 @@ void ProjectSettingsEditor::_add_feature_overrides() {
 
 	for (int i = 0; i < ee->get_export_platform_count(); i++) {
 		List<String> p;
-		ee->get_export_platform(i)->get_platform_features(&p);
+		ee->get_export_platform(i)->get_platform_features(p);
 		for (const String &E : p) {
 			presets.insert(E);
 		}
@@ -306,7 +306,7 @@ void ProjectSettingsEditor::_add_feature_overrides() {
 
 	for (int i = 0; i < ee->get_export_preset_count(); i++) {
 		List<String> p;
-		ee->get_export_preset(i)->get_platform()->get_preset_features(ee->get_export_preset(i), &p);
+		ee->get_export_preset(i)->get_platform()->get_preset_features(ee->get_export_preset(i), p);
 		for (const String &E : p) {
 			presets.insert(E);
 		}

--- a/editor/scene_create_dialog.cpp
+++ b/editor/scene_create_dialog.cpp
@@ -258,7 +258,7 @@ SceneCreateDialog::SceneCreateDialog() {
 
 		List<String> extensions;
 		Ref<PackedScene> sd = memnew(PackedScene);
-		ResourceSaver::get_recognized_extensions(sd, &extensions);
+		ResourceSaver::get_recognized_extensions(sd, extensions);
 
 		scene_extension_picker = memnew(OptionButton);
 		hb->add_child(scene_extension_picker);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1173,7 +1173,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 			List<String> extensions;
 			Ref<PackedScene> sd = memnew(PackedScene);
-			ResourceSaver::get_recognized_extensions(sd, &extensions);
+			ResourceSaver::get_recognized_extensions(sd, extensions);
 			new_scene_from_dialog->clear_filters();
 			for (const String &extension : extensions) {
 				new_scene_from_dialog->add_filter("*." + extension, extension.to_upper());

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -269,7 +269,7 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 
 	// Get all possible extensions for script.
 	for (int l = 0; l < language_menu->get_item_count(); l++) {
-		ScriptServer::get_language(l)->get_recognized_extensions(&extensions);
+		ScriptServer::get_language(l)->get_recognized_extensions(extensions);
 	}
 
 	bool found = false;
@@ -447,7 +447,7 @@ void ScriptCreateDialog::_browse_path(bool browse_parent, bool p_save) {
 	List<String> extensions;
 
 	int lang = language_menu->get_selected();
-	ScriptServer::get_language(lang)->get_recognized_extensions(&extensions);
+	ScriptServer::get_language(lang)->get_recognized_extensions(extensions);
 
 	for (const String &E : extensions) {
 		file_browse->add_filter("*." + E);
@@ -740,7 +740,7 @@ ScriptLanguage::ScriptTemplate ScriptCreateDialog::_parse_template(const ScriptL
 	// Get meta delimiter
 	String meta_delimiter;
 	List<String> comment_delimiters;
-	p_language->get_comment_delimiters(&comment_delimiters);
+	p_language->get_comment_delimiters(comment_delimiters);
 	for (const String &script_delimiter : comment_delimiters) {
 		if (!script_delimiter.contains_char(' ')) {
 			meta_delimiter = script_delimiter;

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -385,7 +385,7 @@ void ShaderGlobalsEditor::_variable_added() {
 	}
 
 	List<String> keywords;
-	ShaderLanguage::get_keyword_list(&keywords);
+	ShaderLanguage::get_keyword_list(keywords);
 
 	if (keywords.find(var) != nullptr || var == "script") {
 		EditorNode::get_singleton()->show_warning(vformat(TTR("Name '%s' is a reserved shader language keyword."), var));

--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -311,8 +311,8 @@ Error ImageLoaderBMP::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 	return err;
 }
 
-void ImageLoaderBMP::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("bmp");
+void ImageLoaderBMP::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("bmp");
 }
 
 static Ref<Image> _bmp_mem_loader_func(const uint8_t *p_bmp, int p_size) {

--- a/modules/bmp/image_loader_bmp.h
+++ b/modules/bmp/image_loader_bmp.h
@@ -103,7 +103,7 @@ protected:
 
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const;
 	ImageLoaderBMP();
 };
 

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -818,8 +818,8 @@ Ref<Resource> ResourceFormatDDS::load(const String &p_path, const String &p_orig
 	return Ref<Resource>();
 }
 
-void ResourceFormatDDS::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("dds");
+void ResourceFormatDDS::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("dds");
 }
 
 bool ResourceFormatDDS::handles_type(const String &p_type) const {

--- a/modules/dds/texture_loader_dds.h
+++ b/modules/dds/texture_loader_dds.h
@@ -36,7 +36,7 @@
 class ResourceFormatDDS : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
@@ -38,8 +38,8 @@
 
 #include "modules/gltf/gltf_document.h"
 
-void EditorSceneFormatImporterFBX2GLTF::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("fbx");
+void EditorSceneFormatImporterFBX2GLTF::get_extensions(List<String> &r_extensions) const {
+	r_extensions.push_back("fbx");
 }
 
 Node *EditorSceneFormatImporterFBX2GLTF::import_scene(const String &p_path, uint32_t p_flags,

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.h
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.h
@@ -42,7 +42,7 @@ class EditorSceneFormatImporterFBX2GLTF : public EditorSceneFormatImporter {
 	GDCLASS(EditorSceneFormatImporterFBX2GLTF, EditorSceneFormatImporter);
 
 public:
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(List<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;

--- a/modules/fbx/editor/editor_scene_importer_ufbx.cpp
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.cpp
@@ -37,8 +37,8 @@
 
 #include "core/config/project_settings.h"
 
-void EditorSceneFormatImporterUFBX::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("fbx");
+void EditorSceneFormatImporterUFBX::get_extensions(List<String> &r_extensions) const {
+	r_extensions.push_back("fbx");
 }
 
 Node *EditorSceneFormatImporterUFBX::import_scene(const String &p_path, uint32_t p_flags,

--- a/modules/fbx/editor/editor_scene_importer_ufbx.h
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.h
@@ -46,7 +46,7 @@ public:
 		FBX_IMPORTER_UFBX,
 		FBX_IMPORTER_FBX2GLTF,
 	};
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(List<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -733,7 +733,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	/* Core types. */
 	const Color basetype_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
 	List<String> core_types;
-	gdscript->get_core_type_words(&core_types);
+	gdscript->get_core_type_words(core_types);
 	for (const String &E : core_types) {
 		class_names[StringName(E)] = basetype_color;
 	}
@@ -748,7 +748,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	const Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
 	const Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
 	List<String> keyword_list;
-	gdscript->get_reserved_words(&keyword_list);
+	gdscript->get_reserved_words(keyword_list);
 	for (const String &E : keyword_list) {
 		if (gdscript->is_control_flow_keyword(E)) {
 			reserved_keywords[StringName(E)] = control_flow_keyword_color;
@@ -775,7 +775,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	/* Comments */
 	const Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
 	List<String> comments;
-	gdscript->get_comment_delimiters(&comments);
+	gdscript->get_comment_delimiters(comments);
 	for (const String &comment : comments) {
 		String beg = comment.get_slice(" ", 0);
 		String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
@@ -785,7 +785,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	/* Doc comments */
 	const Color doc_comment_color = EDITOR_GET("text_editor/theme/highlighting/doc_comment_color");
 	List<String> doc_comments;
-	gdscript->get_doc_comment_delimiters(&doc_comments);
+	gdscript->get_doc_comment_delimiters(doc_comments);
 	for (const String &doc_comment : doc_comments) {
 		String beg = doc_comment.get_slice(" ", 0);
 		String end = doc_comment.get_slice_count(" ") > 1 ? doc_comment.get_slice(" ", 1) : String();
@@ -828,7 +828,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 			}
 
 			List<String> clist;
-			ClassDB::get_integer_constant_list(instance_base, &clist);
+			ClassDB::get_integer_constant_list(instance_base, clist);
 			for (const String &E : clist) {
 				member_keywords[E] = member_variable_color;
 			}

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -35,7 +35,7 @@
 
 #include "core/io/resource_loader.h"
 
-void GDScriptEditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_extensions) const {
+void GDScriptEditorTranslationParserPlugin::get_recognized_extensions(List<String> &r_extensions) const {
 	GDScriptLanguage::get_singleton()->get_recognized_extensions(r_extensions);
 }
 

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.h
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.h
@@ -83,7 +83,7 @@ class GDScriptEditorTranslationParserPlugin : public EditorTranslationParserPlug
 public:
 	virtual Error parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural) override;
 	virtual void get_comments(Vector<String> *r_ids_comment, Vector<String> *r_ids_ctx_plural_comment) override;
-	virtual void get_recognized_extensions(List<String> *r_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &r_extensions) const override;
 
 	GDScriptEditorTranslationParserPlugin();
 };

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2727,7 +2727,7 @@ void GDScriptLanguage::frame() {
 }
 
 /* EDITOR FUNCTIONS */
-void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
+void GDScriptLanguage::get_reserved_words(List<String> &p_words) const {
 	// Please keep alphabetical order within categories.
 	static const char *_reserved_words[] = {
 		// Control flow.
@@ -2787,7 +2787,7 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
 	const char **w = _reserved_words;
 
 	while (*w) {
-		p_words->push_back(*w);
+		p_words.push_back(*w);
 		w++;
 	}
 }
@@ -3030,9 +3030,9 @@ Ref<Resource> ResourceFormatLoaderGDScript::load(const String &p_path, const Str
 	return scr;
 }
 
-void ResourceFormatLoaderGDScript::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("gd");
-	p_extensions->push_back("gdc");
+void ResourceFormatLoaderGDScript::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("gd");
+	p_extensions.push_back("gdc");
 }
 
 bool ResourceFormatLoaderGDScript::handles_type(const String &p_type) const {
@@ -3047,7 +3047,7 @@ String ResourceFormatLoaderGDScript::get_resource_type(const String &p_path) con
 	return "";
 }
 
-void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types) {
+void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<String> &p_dependencies, bool p_add_types) {
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_MSG(file.is_null(), "Cannot open file '" + p_path + "'.");
 
@@ -3062,7 +3062,7 @@ void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<S
 	}
 
 	for (const String &E : parser.get_dependencies()) {
-		p_dependencies->push_back(E);
+		p_dependencies.push_back(E);
 	}
 }
 
@@ -3091,9 +3091,9 @@ Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const S
 	return OK;
 }
 
-void ResourceFormatSaverGDScript::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaverGDScript::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const {
 	if (Object::cast_to<GDScript>(*p_resource)) {
-		p_extensions->push_back("gd");
+		p_extensions.push_back("gd");
 	}
 }
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -571,11 +571,11 @@ public:
 	virtual void finish() override;
 
 	/* EDITOR FUNCTIONS */
-	virtual void get_reserved_words(List<String> *p_words) const override;
+	virtual void get_reserved_words(List<String> &p_words) const override;
 	virtual bool is_control_flow_keyword(const String &p_keywords) const override;
-	virtual void get_comment_delimiters(List<String> *p_delimiters) const override;
-	virtual void get_doc_comment_delimiters(List<String> *p_delimiters) const override;
-	virtual void get_string_delimiters(List<String> *p_delimiters) const override;
+	virtual void get_comment_delimiters(List<String> &p_delimiters) const override;
+	virtual void get_doc_comment_delimiters(List<String> &p_delimiters) const override;
+	virtual void get_string_delimiters(List<String> &p_delimiters) const override;
 	virtual bool is_using_templates() override;
 	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const override;
 	virtual Vector<ScriptTemplate> get_built_in_templates(const StringName &p_object) override;
@@ -632,7 +632,7 @@ public:
 
 	/* LOADER FUNCTIONS */
 
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 
 	/* GLOBAL CLASSES */
 
@@ -651,16 +651,16 @@ public:
 class ResourceFormatLoaderGDScript : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
-	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;
+	virtual void get_dependencies(const String &p_path, List<String> &p_dependencies, bool p_add_types = false) override;
 };
 
 class ResourceFormatSaverGDScript : public ResourceFormatSaver {
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
-	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -51,19 +51,19 @@
 #include "editor/editor_settings.h"
 #endif
 
-void GDScriptLanguage::get_comment_delimiters(List<String> *p_delimiters) const {
-	p_delimiters->push_back("#");
+void GDScriptLanguage::get_comment_delimiters(List<String> &p_delimiters) const {
+	p_delimiters.push_back("#");
 }
 
-void GDScriptLanguage::get_doc_comment_delimiters(List<String> *p_delimiters) const {
-	p_delimiters->push_back("##");
+void GDScriptLanguage::get_doc_comment_delimiters(List<String> &p_delimiters) const {
+	p_delimiters.push_back("##");
 }
 
-void GDScriptLanguage::get_string_delimiters(List<String> *p_delimiters) const {
-	p_delimiters->push_back("\" \"");
-	p_delimiters->push_back("' '");
-	p_delimiters->push_back("\"\"\" \"\"\"");
-	p_delimiters->push_back("''' '''");
+void GDScriptLanguage::get_string_delimiters(List<String> &p_delimiters) const {
+	p_delimiters.push_back("\" \"");
+	p_delimiters.push_back("' '");
+	p_delimiters.push_back("\"\"\" \"\"\"");
+	p_delimiters.push_back("''' '''");
 	// NOTE: StringName, NodePath and r-strings are not listed here.
 }
 
@@ -454,8 +454,8 @@ String GDScriptLanguage::debug_parse_stack_level_expression(int p_level, const S
 	return String();
 }
 
-void GDScriptLanguage::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("gd");
+void GDScriptLanguage::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("gd");
 }
 
 void GDScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) const {
@@ -1292,7 +1292,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 				if (!p_only_functions) {
 					List<String> constants;
-					ClassDB::get_integer_constant_list(type, &constants);
+					ClassDB::get_integer_constant_list(type, constants);
 					for (const String &E : constants) {
 						int location = p_recursion_depth + _get_constant_location(type, StringName(E));
 						ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT, location);
@@ -2831,7 +2831,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						Object *obj = base.operator Object *();
 						if (obj) {
 							List<String> options;
-							obj->get_argument_options(p_method, p_argidx, &options);
+							obj->get_argument_options(p_method, p_argidx, options);
 							for (String &opt : options) {
 								// Handle user preference.
 								if (opt.is_quoted()) {
@@ -3519,7 +3519,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 			// Handles the `$Node/Path` or `$"Some NodePath"` syntax specifically.
 			if (p_owner) {
 				List<String> opts;
-				p_owner->get_argument_options("get_node", 0, &opts);
+				p_owner->get_argument_options("get_node", 0, opts);
 
 				bool for_unique_name = false;
 				if (completion_context.node != nullptr && completion_context.node->type == GDScriptParser::Node::GET_NODE && !static_cast<GDScriptParser::GetNodeNode *>(completion_context.node)->use_dollar) {
@@ -3878,7 +3878,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				}
 
 				List<String> constants;
-				ClassDB::get_integer_constant_list(class_name, &constants, true);
+				ClassDB::get_integer_constant_list(class_name, constants, true);
 				for (const String &E : constants) {
 					if (E == p_symbol) {
 						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -102,8 +102,8 @@ static bool _get_blender_version(const String &p_path, int &r_major, int &r_mino
 	return true;
 }
 
-void EditorSceneFormatImporterBlend::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("blend");
+void EditorSceneFormatImporterBlend::get_extensions(List<String> &r_extensions) const {
+	r_extensions.push_back("blend");
 }
 
 Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_t p_flags,

--- a/modules/gltf/editor/editor_scene_importer_blend.h
+++ b/modules/gltf/editor/editor_scene_importer_blend.h
@@ -67,7 +67,7 @@ public:
 		BLEND_MODIFIERS_ALL
 	};
 
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(List<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -35,9 +35,9 @@
 #include "../gltf_defines.h"
 #include "../gltf_document.h"
 
-void EditorSceneFormatImporterGLTF::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("gltf");
-	r_extensions->push_back("glb");
+void EditorSceneFormatImporterGLTF::get_extensions(List<String> &r_extensions) const {
+	r_extensions.push_back("gltf");
+	r_extensions.push_back("glb");
 }
 
 Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t p_flags,

--- a/modules/gltf/editor/editor_scene_importer_gltf.h
+++ b/modules/gltf/editor/editor_scene_importer_gltf.h
@@ -42,7 +42,7 @@ class EditorSceneFormatImporterGLTF : public EditorSceneFormatImporter {
 	GDCLASS(EditorSceneFormatImporterGLTF, EditorSceneFormatImporter);
 
 public:
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(List<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;

--- a/modules/hdr/image_loader_hdr.cpp
+++ b/modules/hdr/image_loader_hdr.cpp
@@ -152,8 +152,8 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 	return OK;
 }
 
-void ImageLoaderHDR::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("hdr");
+void ImageLoaderHDR::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("hdr");
 }
 
 ImageLoaderHDR::ImageLoaderHDR() {

--- a/modules/hdr/image_loader_hdr.h
+++ b/modules/hdr/image_loader_hdr.h
@@ -36,7 +36,7 @@
 class ImageLoaderHDR : public ImageFormatLoader {
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const;
 
 	ImageLoaderHDR();
 };

--- a/modules/jpg/image_loader_jpegd.cpp
+++ b/modules/jpg/image_loader_jpegd.cpp
@@ -117,9 +117,9 @@ Error ImageLoaderJPG::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 	return err;
 }
 
-void ImageLoaderJPG::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("jpg");
-	p_extensions->push_back("jpeg");
+void ImageLoaderJPG::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("jpg");
+	p_extensions.push_back("jpeg");
 }
 
 static Ref<Image> _jpegd_mem_loader_func(const uint8_t *p_png, int p_size) {

--- a/modules/jpg/image_loader_jpegd.h
+++ b/modules/jpg/image_loader_jpegd.h
@@ -36,7 +36,7 @@
 class ImageLoaderJPG : public ImageFormatLoader {
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const;
 	ImageLoaderJPG();
 };
 

--- a/modules/ktx/texture_loader_ktx.cpp
+++ b/modules/ktx/texture_loader_ktx.cpp
@@ -543,9 +543,9 @@ static Ref<Image> _ktx_mem_loader_func(const uint8_t *p_ktx, int p_size) {
 	return img;
 }
 
-void ResourceFormatKTX::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("ktx");
-	p_extensions->push_back("ktx2");
+void ResourceFormatKTX::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("ktx");
+	p_extensions.push_back("ktx2");
 }
 
 bool ResourceFormatKTX::handles_type(const String &p_type) const {

--- a/modules/ktx/texture_loader_ktx.h
+++ b/modules/ktx/texture_loader_ktx.h
@@ -37,7 +37,7 @@
 class ResourceFormatKTX : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 

--- a/modules/minimp3/resource_importer_mp3.cpp
+++ b/modules/minimp3/resource_importer_mp3.cpp
@@ -45,12 +45,12 @@ String ResourceImporterMP3::get_visible_name() const {
 	return "MP3";
 }
 
-void ResourceImporterMP3::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterMP3::get_recognized_extensions(List<String> &p_extensions) const {
 #ifndef MINIMP3_ONLY_MP3
-	p_extensions->push_back("mp1");
-	p_extensions->push_back("mp2");
+	p_extensions.push_back("mp1");
+	p_extensions.push_back("mp2");
 #endif
-	p_extensions->push_back("mp3");
+	p_extensions.push_back("mp3");
 }
 
 String ResourceImporterMP3::get_save_extension() const {

--- a/modules/minimp3/resource_importer_mp3.h
+++ b/modules/minimp3/resource_importer_mp3.h
@@ -41,7 +41,7 @@ class ResourceImporterMP3 : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 
@@ -56,7 +56,7 @@ public:
 	virtual void show_advanced_options(const String &p_path) override;
 #endif
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -189,7 +189,7 @@ void CSharpLanguage::finalize() {
 	finalized = true;
 }
 
-void CSharpLanguage::get_reserved_words(List<String> *p_words) const {
+void CSharpLanguage::get_reserved_words(List<String> &p_words) const {
 	static const char *_reserved_words[] = {
 		// Reserved keywords
 		"abstract",
@@ -306,7 +306,7 @@ void CSharpLanguage::get_reserved_words(List<String> *p_words) const {
 	const char **w = _reserved_words;
 
 	while (*w) {
-		p_words->push_back(*w);
+		p_words.push_back(*w);
 		w++;
 	}
 }
@@ -331,20 +331,20 @@ bool CSharpLanguage::is_control_flow_keyword(const String &p_keyword) const {
 			p_keyword == "while";
 }
 
-void CSharpLanguage::get_comment_delimiters(List<String> *p_delimiters) const {
-	p_delimiters->push_back("//"); // single-line comment
-	p_delimiters->push_back("/* */"); // delimited comment
+void CSharpLanguage::get_comment_delimiters(List<String> &p_delimiters) const {
+	p_delimiters.push_back("//"); // single-line comment
+	p_delimiters.push_back("/* */"); // delimited comment
 }
 
-void CSharpLanguage::get_doc_comment_delimiters(List<String> *p_delimiters) const {
-	p_delimiters->push_back("///"); // single-line doc comment
-	p_delimiters->push_back("/** */"); // delimited doc comment
+void CSharpLanguage::get_doc_comment_delimiters(List<String> &p_delimiters) const {
+	p_delimiters.push_back("///"); // single-line doc comment
+	p_delimiters.push_back("/** */"); // delimited doc comment
 }
 
-void CSharpLanguage::get_string_delimiters(List<String> *p_delimiters) const {
-	p_delimiters->push_back("' '"); // character literal
-	p_delimiters->push_back("\" \""); // regular string literal
-	p_delimiters->push_back("@\" \""); // verbatim string literal
+void CSharpLanguage::get_string_delimiters(List<String> &p_delimiters) const {
+	p_delimiters.push_back("' '"); // character literal
+	p_delimiters.push_back("\" \""); // regular string literal
+	p_delimiters.push_back("@\" \""); // verbatim string literal
 	// Generic string highlighting suffices as a workaround for now.
 }
 
@@ -390,7 +390,7 @@ Vector<ScriptLanguage::ScriptTemplate> CSharpLanguage::get_built_in_templates(co
 String CSharpLanguage::validate_path(const String &p_path) const {
 	String class_name = p_path.get_file().get_basename();
 	List<String> keywords;
-	get_reserved_words(&keywords);
+	get_reserved_words(keywords);
 	if (keywords.find(class_name)) {
 		return RTR("Class name can't be a reserved keyword");
 	}
@@ -1012,8 +1012,8 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 }
 #endif
 
-void CSharpLanguage::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("cs");
+void CSharpLanguage::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("cs");
 }
 
 #ifdef TOOLS_ENABLED
@@ -2863,8 +2863,8 @@ Ref<Resource> ResourceFormatLoaderCSharpScript::load(const String &p_path, const
 	return scr;
 }
 
-void ResourceFormatLoaderCSharpScript::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("cs");
+void ResourceFormatLoaderCSharpScript::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("cs");
 }
 
 bool ResourceFormatLoaderCSharpScript::handles_type(const String &p_type) const {
@@ -2912,9 +2912,9 @@ Error ResourceFormatSaverCSharpScript::save(const Ref<Resource> &p_resource, con
 	return OK;
 }
 
-void ResourceFormatSaverCSharpScript::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaverCSharpScript::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const {
 	if (Object::cast_to<CSharpScript>(p_resource.ptr())) {
-		p_extensions->push_back("cs");
+		p_extensions.push_back("cs");
 	}
 }
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -500,11 +500,11 @@ public:
 	void finalize();
 
 	/* EDITOR FUNCTIONS */
-	void get_reserved_words(List<String> *p_words) const override;
+	void get_reserved_words(List<String> &p_words) const override;
 	bool is_control_flow_keyword(const String &p_keyword) const override;
-	void get_comment_delimiters(List<String> *p_delimiters) const override;
-	void get_doc_comment_delimiters(List<String> *p_delimiters) const override;
-	void get_string_delimiters(List<String> *p_delimiters) const override;
+	void get_comment_delimiters(List<String> &p_delimiters) const override;
+	void get_doc_comment_delimiters(List<String> &p_delimiters) const override;
+	void get_string_delimiters(List<String> &p_delimiters) const override;
 	bool is_using_templates() override;
 	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const override;
 	virtual Vector<ScriptTemplate> get_built_in_templates(const StringName &p_object) override;
@@ -568,7 +568,7 @@ public:
 	void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) override;
 
 	/* LOADER FUNCTIONS */
-	void get_recognized_extensions(List<String> *p_extensions) const override;
+	void get_recognized_extensions(List<String> &p_extensions) const override;
 
 #ifdef TOOLS_ENABLED
 	Error open_in_external_editor(const Ref<Script> &p_script, int p_line, int p_col) override;
@@ -592,7 +592,7 @@ public:
 class ResourceFormatLoaderCSharpScript : public ResourceFormatLoader {
 public:
 	Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	void get_recognized_extensions(List<String> *p_extensions) const override;
+	void get_recognized_extensions(List<String> &p_extensions) const override;
 	bool handles_type(const String &p_type) const override;
 	String get_resource_type(const String &p_path) const override;
 };
@@ -600,7 +600,7 @@ public:
 class ResourceFormatSaverCSharpScript : public ResourceFormatSaver {
 public:
 	Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
-	void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const override;
 	bool recognize(const Ref<Resource> &p_resource) const override;
 };
 

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -4324,7 +4324,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 		// Populate enums and constants
 
 		List<String> constants;
-		ClassDB::get_integer_constant_list(type_cname, &constants, true);
+		ClassDB::get_integer_constant_list(type_cname, constants, true);
 
 		const HashMap<StringName, ClassDB::ClassInfo::EnumInfo> &enum_map = class_info->enum_map;
 

--- a/modules/multiplayer/multiplayer_spawner.cpp
+++ b/modules/multiplayer/multiplayer_spawner.cpp
@@ -70,7 +70,7 @@ bool MultiplayerSpawner::_get(const StringName &p_name, Variant &r_ret) const {
 void MultiplayerSpawner::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::INT, "_spawnable_scene_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_ARRAY, "Auto Spawn List,scenes/"));
 	List<String> exts;
-	ResourceLoader::get_recognized_extensions_for_type("PackedScene", &exts);
+	ResourceLoader::get_recognized_extensions_for_type("PackedScene", exts);
 	String ext_hint;
 	for (const String &E : exts) {
 		if (!ext_hint.is_empty()) {

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -150,8 +150,8 @@ Error ImageLoaderSVG::create_image_from_string(Ref<Image> p_image, String p_stri
 	return create_image_from_utf8_buffer(p_image, bytes, p_scale, p_upsample);
 }
 
-void ImageLoaderSVG::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("svg");
+void ImageLoaderSVG::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("svg");
 }
 
 Error ImageLoaderSVG::load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {

--- a/modules/svg/image_loader_svg.h
+++ b/modules/svg/image_loader_svg.h
@@ -49,7 +49,7 @@ public:
 	static Error create_image_from_string(Ref<Image> p_image, String p_string, float p_scale, bool p_upsample, const HashMap<Color, Color> &p_color_map);
 
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 
 	ImageLoaderSVG();
 };

--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -359,8 +359,8 @@ Error ImageLoaderTGA::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 	return err;
 }
 
-void ImageLoaderTGA::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("tga");
+void ImageLoaderTGA::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("tga");
 }
 
 static Ref<Image> _tga_mem_loader_func(const uint8_t *p_tga, int p_size) {

--- a/modules/tga/image_loader_tga.h
+++ b/modules/tga/image_loader_tga.h
@@ -76,7 +76,7 @@ class ImageLoaderTGA : public ImageFormatLoader {
 
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const;
 	ImageLoaderTGA();
 };
 

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -660,8 +660,8 @@ Ref<Resource> ResourceFormatLoaderTheora::load(const String &p_path, const Strin
 	return ogv_stream;
 }
 
-void ResourceFormatLoaderTheora::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("ogv");
+void ResourceFormatLoaderTheora::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("ogv");
 }
 
 bool ResourceFormatLoaderTheora::handles_type(const String &p_type) const {

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -170,7 +170,7 @@ public:
 class ResourceFormatLoaderTheora : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };

--- a/modules/tinyexr/image_loader_tinyexr.cpp
+++ b/modules/tinyexr/image_loader_tinyexr.cpp
@@ -287,8 +287,8 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitF
 	return OK;
 }
 
-void ImageLoaderTinyEXR::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("exr");
+void ImageLoaderTinyEXR::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("exr");
 }
 
 ImageLoaderTinyEXR::ImageLoaderTinyEXR() {

--- a/modules/tinyexr/image_loader_tinyexr.h
+++ b/modules/tinyexr/image_loader_tinyexr.h
@@ -36,7 +36,7 @@
 class ImageLoaderTinyEXR : public ImageFormatLoader {
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const;
 	ImageLoaderTinyEXR();
 };
 

--- a/modules/vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/vorbis/resource_importer_ogg_vorbis.cpp
@@ -48,8 +48,8 @@ String ResourceImporterOggVorbis::get_visible_name() const {
 	return "oggvorbisstr";
 }
 
-void ResourceImporterOggVorbis::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("ogg");
+void ResourceImporterOggVorbis::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("ogg");
 }
 
 String ResourceImporterOggVorbis::get_save_extension() const {

--- a/modules/vorbis/resource_importer_ogg_vorbis.h
+++ b/modules/vorbis/resource_importer_ogg_vorbis.h
@@ -52,7 +52,7 @@ public:
 	static Ref<AudioStreamOggVorbis> load_from_buffer(const Vector<uint8_t> &p_stream_data);
 #endif
 
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 	virtual String get_importer_name() const override;

--- a/modules/webp/image_loader_webp.cpp
+++ b/modules/webp/image_loader_webp.cpp
@@ -58,8 +58,8 @@ Error ImageLoaderWebP::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitFiel
 	return err;
 }
 
-void ImageLoaderWebP::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("webp");
+void ImageLoaderWebP::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("webp");
 }
 
 ImageLoaderWebP::ImageLoaderWebP() {

--- a/modules/webp/image_loader_webp.h
+++ b/modules/webp/image_loader_webp.h
@@ -36,7 +36,7 @@
 class ImageLoaderWebP : public ImageFormatLoader {
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const;
 	ImageLoaderWebP();
 };
 

--- a/modules/webp/resource_saver_webp.cpp
+++ b/modules/webp/resource_saver_webp.cpp
@@ -79,9 +79,9 @@ bool ResourceSaverWebP::recognize(const Ref<Resource> &p_resource) const {
 	return (p_resource.is_valid() && p_resource->is_class("ImageTexture"));
 }
 
-void ResourceSaverWebP::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+void ResourceSaverWebP::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const {
 	if (Object::cast_to<ImageTexture>(*p_resource)) {
-		p_extensions->push_back("webp");
+		p_extensions.push_back("webp");
 	}
 }
 

--- a/modules/webp/resource_saver_webp.h
+++ b/modules/webp/resource_saver_webp.h
@@ -41,7 +41,7 @@ public:
 
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
-	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const override;
 
 	ResourceSaverWebP();
 };

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1828,13 +1828,13 @@ Vector<EditorExportPlatformAndroid::ABI> EditorExportPlatformAndroid::get_enable
 	return enabled_abis;
 }
 
-void EditorExportPlatformAndroid::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
-	r_features->push_back("etc2");
-	r_features->push_back("astc");
+void EditorExportPlatformAndroid::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> &r_features) const {
+	r_features.push_back("etc2");
+	r_features.push_back("astc");
 
 	Vector<ABI> abis = get_enabled_abis(p_preset);
 	for (int i = 0; i < abis.size(); ++i) {
-		r_features->push_back(abis[i].arch);
+		r_features.push_back(abis[i].arch);
 	}
 }
 
@@ -3859,9 +3859,9 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 	CLEANUP_AND_RETURN(OK);
 }
 
-void EditorExportPlatformAndroid::get_platform_features(List<String> *r_features) const {
-	r_features->push_back("mobile");
-	r_features->push_back("android");
+void EditorExportPlatformAndroid::get_platform_features(List<String> &r_features) const {
+	r_features.push_back("mobile");
+	r_features.push_back("android");
 }
 
 void EditorExportPlatformAndroid::resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) {

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -190,7 +190,7 @@ protected:
 public:
 	typedef Error (*EditorExportSaveFunction)(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
 
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> &r_features) const override;
 
 	virtual void get_export_options(List<ExportOption> *r_options) const override;
 
@@ -261,7 +261,7 @@ public:
 
 	Error export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int export_format, bool should_sign, BitField<EditorExportPlatform::DebugFlags> p_flags);
 
-	virtual void get_platform_features(List<String> *r_features) const override;
+	virtual void get_platform_features(List<String> &r_features) const override;
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) override;
 

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -49,14 +49,14 @@
 #include "modules/modules_enabled.gen.h" // For mono.
 #include "modules/svg/image_loader_svg.h"
 
-void EditorExportPlatformIOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
+void EditorExportPlatformIOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> &r_features) const {
 	// Vulkan and OpenGL ES 3.0 both mandate ETC2 support.
-	r_features->push_back("etc2");
-	r_features->push_back("astc");
+	r_features.push_back("etc2");
+	r_features.push_back("astc");
 
 	Vector<String> architectures = _get_preset_architectures(p_preset);
 	for (int i = 0; i < architectures.size(); ++i) {
-		r_features->push_back(architectures[i]);
+		r_features.push_back(architectures[i]);
 	}
 }
 
@@ -2834,7 +2834,7 @@ Error EditorExportPlatformIOS::run(const Ref<EditorExportPreset> &p_preset, int 
 		cmd_args_list.push_back(get_debug_protocol() + host + ":" + String::num_int64(remote_port));
 
 		List<String> breakpoints;
-		ScriptEditor::get_singleton()->get_breakpoints(&breakpoints);
+		ScriptEditor::get_singleton()->get_breakpoints(breakpoints);
 
 		if (breakpoints.size()) {
 			cmd_args_list.push_back("--breakpoints");

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -150,7 +150,7 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 	bool is_package_name_valid(const String &p_package, String *r_error = nullptr) const;
 
 protected:
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> &r_features) const override;
 	virtual void get_export_options(List<ExportOption> *r_options) const override;
 	virtual bool get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const override;
 	virtual String get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const override;
@@ -206,9 +206,9 @@ public:
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
 	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const override;
 
-	virtual void get_platform_features(List<String> *r_features) const override {
-		r_features->push_back("mobile");
-		r_features->push_back("ios");
+	virtual void get_platform_features(List<String> &r_features) const override {
+		r_features.push_back("mobile");
+		r_features.push_back("ios");
 	}
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) override {

--- a/platform/ios/export/godot_plugin_config.cpp
+++ b/platform/ios/export/godot_plugin_config.cpp
@@ -210,7 +210,7 @@ PluginConfigIOS PluginConfigIOS::load_plugin_config(Ref<ConfigFile> config_file,
 
 	if (config_file->has_section(PluginConfigIOS::PLIST_SECTION)) {
 		List<String> keys;
-		config_file->get_section_keys(PluginConfigIOS::PLIST_SECTION, &keys);
+		config_file->get_section_keys(PluginConfigIOS::PLIST_SECTION, keys);
 
 		for (const String &key : keys) {
 			Vector<String> key_components = key.split(":");

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -49,23 +49,23 @@
 
 #include "modules/svg/image_loader_svg.h"
 
-void EditorExportPlatformMacOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
-	r_features->push_back(p_preset->get("binary_format/architecture"));
+void EditorExportPlatformMacOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> &r_features) const {
+	r_features.push_back(p_preset->get("binary_format/architecture"));
 	String architecture = p_preset->get("binary_format/architecture");
 
 	if (architecture == "universal" || architecture == "x86_64") {
-		r_features->push_back("s3tc");
-		r_features->push_back("bptc");
+		r_features.push_back("s3tc");
+		r_features.push_back("bptc");
 	} else if (architecture == "arm64") {
-		r_features->push_back("etc2");
-		r_features->push_back("astc");
+		r_features.push_back("etc2");
+		r_features.push_back("astc");
 	} else {
 		ERR_PRINT("Invalid architecture");
 	}
 
 	if (architecture == "universal") {
-		r_features->push_back("x86_64");
-		r_features->push_back("arm64");
+		r_features.push_back("x86_64");
+		r_features.push_back("arm64");
 	}
 }
 

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -130,7 +130,7 @@ class EditorExportPlatformMacOS : public EditorExportPlatform {
 	bool is_shebang(const String &p_path) const;
 
 protected:
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> &r_features) const override;
 	virtual void get_export_options(List<ExportOption> *r_options) const override;
 	virtual bool get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const override;
 	virtual String get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const override;
@@ -153,10 +153,10 @@ public:
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
 	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const override;
 
-	virtual void get_platform_features(List<String> *r_features) const override {
-		r_features->push_back("pc");
-		r_features->push_back("s3tc");
-		r_features->push_back("macos");
+	virtual void get_platform_features(List<String> &r_features) const override {
+		r_features.push_back("pc");
+		r_features.push_back("s3tc");
+		r_features.push_back("macos");
 	}
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) override {

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -335,21 +335,21 @@ Error EditorExportPlatformWeb::_build_pwa(const Ref<EditorExportPreset> &p_prese
 	return OK;
 }
 
-void EditorExportPlatformWeb::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
+void EditorExportPlatformWeb::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> &r_features) const {
 	if (p_preset->get("vram_texture_compression/for_desktop")) {
-		r_features->push_back("s3tc");
-		r_features->push_back("bptc");
+		r_features.push_back("s3tc");
+		r_features.push_back("bptc");
 	}
 	if (p_preset->get("vram_texture_compression/for_mobile")) {
-		r_features->push_back("etc2");
-		r_features->push_back("astc");
+		r_features.push_back("etc2");
+		r_features.push_back("astc");
 	}
 	if (p_preset->get("variant/thread_support").operator bool()) {
-		r_features->push_back("threads");
+		r_features.push_back("threads");
 	} else {
-		r_features->push_back("nothreads");
+		r_features.push_back("nothreads");
 	}
-	r_features->push_back("wasm32");
+	r_features.push_back("wasm32");
 }
 
 void EditorExportPlatformWeb::get_export_options(List<ExportOption> *r_options) const {

--- a/platform/web/export/export_plugin.h
+++ b/platform/web/export/export_plugin.h
@@ -117,7 +117,7 @@ class EditorExportPlatformWeb : public EditorExportPlatform {
 	Error _stop_server();
 
 public:
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> &r_features) const override;
 
 	virtual void get_export_options(List<ExportOption> *r_options) const override;
 	virtual bool get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const override;
@@ -139,9 +139,9 @@ public:
 	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_option, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;
 	virtual Ref<Texture2D> get_run_icon() const override;
 
-	virtual void get_platform_features(List<String> *r_features) const override {
-		r_features->push_back("web");
-		r_features->push_back(get_os_name().to_lower());
+	virtual void get_platform_features(List<String> &r_features) const override {
+		r_features.push_back("web");
+		r_features.push_back(get_os_name().to_lower());
 	}
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) override {

--- a/platform/web/http_client_web.cpp
+++ b/platform/web/http_client_web.cpp
@@ -137,12 +137,12 @@ int HTTPClientWeb::get_response_code() const {
 	return polled_response_code;
 }
 
-Error HTTPClientWeb::get_response_headers(List<String> *r_response) {
+Error HTTPClientWeb::get_response_headers(List<String> &r_response) {
 	if (!response_headers.size()) {
 		return ERR_INVALID_PARAMETER;
 	}
 	for (int i = 0; i < response_headers.size(); i++) {
-		r_response->push_back(response_headers[i]);
+		r_response.push_back(response_headers[i]);
 	}
 	response_headers.clear();
 	return OK;

--- a/platform/web/http_client_web.h
+++ b/platform/web/http_client_web.h
@@ -93,7 +93,7 @@ public:
 	bool has_response() const override;
 	bool is_response_chunked() const override;
 	int get_response_code() const override;
-	Error get_response_headers(List<String> *r_response) override;
+	Error get_response_headers(List<String> &r_response) override;
 	int64_t get_response_body_length() const override;
 	PackedByteArray read_response_body_chunk() override;
 	void set_blocking_mode(bool p_enable) override;

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -582,14 +582,14 @@ PackedStringArray AnimatedSprite2D::get_configuration_warnings() const {
 }
 
 #ifdef TOOLS_ENABLED
-void AnimatedSprite2D::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void AnimatedSprite2D::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0 && frames.is_valid()) {
 		if (pf == "play" || pf == "play_backwards" || pf == "set_animation" || pf == "set_autoplay") {
 			List<StringName> al;
 			frames->get_animation_list(&al);
 			for (const StringName &name : al) {
-				r_options->push_back(String(name).quote());
+				r_options.push_back(String(name).quote());
 			}
 		}
 	}

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -131,7 +131,7 @@ public:
 	PackedStringArray get_configuration_warnings() const override;
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif // TOOLS_ENABLED
 
 	AnimatedSprite2D();

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1442,14 +1442,14 @@ PackedStringArray AnimatedSprite3D::get_configuration_warnings() const {
 }
 
 #ifdef TOOLS_ENABLED
-void AnimatedSprite3D::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void AnimatedSprite3D::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0 && frames.is_valid()) {
 		if (pf == "play" || pf == "play_backwards" || pf == "set_animation" || pf == "set_autoplay") {
 			List<StringName> al;
 			frames->get_animation_list(&al);
 			for (const StringName &name : al) {
-				r_options->push_back(String(name).quote());
+				r_options.push_back(String(name).quote());
 			}
 		}
 	}

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -288,7 +288,7 @@ public:
 	virtual PackedStringArray get_configuration_warnings() const override;
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	AnimatedSprite3D();

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1802,7 +1802,7 @@ void AnimationNodeBlendTree::_node_changed(const StringName &p_node) {
 }
 
 #ifdef TOOLS_ENABLED
-void AnimationNodeBlendTree::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void AnimationNodeBlendTree::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	bool add_node_options = false;
 	if (p_idx == 0) {
@@ -1812,7 +1812,7 @@ void AnimationNodeBlendTree::get_argument_options(const StringName &p_function, 
 	}
 	if (add_node_options) {
 		for (const KeyValue<StringName, Node> &E : nodes) {
-			r_options->push_back(String(E.key).quote());
+			r_options.push_back(String(E.key).quote());
 		}
 	}
 	AnimationRootNode::get_argument_options(p_function, p_idx, r_options);

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -477,7 +477,7 @@ public:
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	AnimationNodeBlendTree();

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -2367,20 +2367,20 @@ void AnimationMixer::_notification(int p_what) {
 }
 
 #ifdef TOOLS_ENABLED
-void AnimationMixer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void AnimationMixer::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "get_animation" || pf == "has_animation") {
 			List<StringName> al;
 			get_animation_list(&al);
 			for (const StringName &name : al) {
-				r_options->push_back(String(name).quote());
+				r_options.push_back(String(name).quote());
 			}
 		} else if (pf == "get_animation_library" || pf == "has_animation_library" || pf == "remove_animation_library" || pf == "rename_animation_library") {
 			List<StringName> al;
 			get_animation_library_list(&al);
 			for (const StringName &name : al) {
-				r_options->push_back(String(name).quote());
+				r_options.push_back(String(name).quote());
 			}
 		}
 	}

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -349,7 +349,7 @@ protected:
 	virtual void _validate_property(PropertyInfo &p_property) const;
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	static void _bind_methods();

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1770,7 +1770,7 @@ void AnimationNodeStateMachine::_animation_node_removed(const ObjectID &p_oid, c
 }
 
 #ifdef TOOLS_ENABLED
-void AnimationNodeStateMachine::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void AnimationNodeStateMachine::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	bool add_state_options = false;
 	if (p_idx == 0) {
@@ -1780,7 +1780,7 @@ void AnimationNodeStateMachine::get_argument_options(const StringName &p_functio
 	}
 	if (add_state_options) {
 		for (const KeyValue<StringName, State> &E : states) {
-			r_options->push_back(String(E.key).quote());
+			r_options.push_back(String(E.key).quote());
 		}
 	}
 	AnimationRootNode::get_argument_options(p_function, p_idx, r_options);

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -217,7 +217,7 @@ public:
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	Vector<StringName> get_nodes_with_transitions_from(const StringName &p_node) const;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -871,13 +871,13 @@ Tween::EaseType AnimationPlayer::get_auto_capture_ease_type() const {
 }
 
 #ifdef TOOLS_ENABLED
-void AnimationPlayer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void AnimationPlayer::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0 && (pf == "play" || pf == "play_backwards" || pf == "has_animation" || pf == "queue")) {
 		List<StringName> al;
 		get_animation_list(&al);
 		for (const StringName &name : al) {
-			r_options->push_back(String(name).quote());
+			r_options.push_back(String(name).quote());
 		}
 	}
 	AnimationMixer::get_argument_options(p_function, p_idx, r_options);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -190,7 +190,7 @@ public:
 	Tween::EaseType get_auto_capture_ease_type() const;
 
 #ifdef TOOLS_ENABLED
-	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	void play(const StringName &p_name = StringName(), double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -512,12 +512,12 @@ double AnimationNode::blend_input_ex(int p_input, double p_time, bool p_seek, bo
 }
 
 #ifdef TOOLS_ENABLED
-void AnimationNode::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void AnimationNode::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "find_input") {
 			for (const AnimationNode::Input &E : inputs) {
-				r_options->push_back(E.name.quote());
+				r_options.push_back(E.name.quote());
 			}
 		} else if (pf == "get_parameter" || pf == "set_parameter") {
 			bool is_setter = pf == "set_parameter";
@@ -527,11 +527,11 @@ void AnimationNode::get_argument_options(const StringName &p_function, int p_idx
 				if (is_setter && is_parameter_read_only(E.name)) {
 					continue;
 				}
-				r_options->push_back(E.name.quote());
+				r_options.push_back(E.name.quote());
 			}
 		} else if (pf == "set_filter_path" || pf == "is_path_filtered") {
 			for (const KeyValue<NodePath, bool> &E : filter) {
-				r_options->push_back(String(E.key).quote());
+				r_options.push_back(String(E.key).quote());
 			}
 		}
 	}

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -233,7 +233,7 @@ public:
 	virtual bool has_filter() const;
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -849,7 +849,7 @@ void ColorPicker::_add_recent_preset_button(int p_size, const Color &p_color) {
 
 void ColorPicker::_load_palette() {
 	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("ColorPalette", &extensions);
+	ResourceLoader::get_recognized_extensions_for_type("ColorPalette", extensions);
 
 	file_dialog->set_title(RTR("Load Color Palette"));
 	file_dialog->clear_filters();
@@ -869,7 +869,7 @@ void ColorPicker::_save_palette(bool p_is_save_as) {
 		return;
 	} else {
 		List<String> extensions;
-		ResourceLoader::get_recognized_extensions_for_type("ColorPalette", &extensions);
+		ResourceLoader::get_recognized_extensions_for_type("ColorPalette", extensions);
 
 		file_dialog->set_title(RTR("Save Color Palette"));
 		file_dialog->clear_filters();

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -202,7 +202,7 @@ void Control::set_root_layout_direction(int p_root_dir) {
 }
 
 #ifdef TOOLS_ENABLED
-void Control::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void Control::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	ERR_READ_THREAD_GUARD;
 	if (p_idx == 0) {
 		const String pf = p_function;
@@ -235,7 +235,7 @@ void Control::get_argument_options(const StringName &p_function, int p_idx, List
 
 			sn.sort_custom<StringName::AlphCompare>();
 			for (const StringName &name : sn) {
-				r_options->push_back(String(name).quote());
+				r_options.push_back(String(name).quote());
 			}
 		}
 	}

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -421,7 +421,7 @@ public:
 
 	PackedStringArray get_configuration_warnings() const override;
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif //TOOLS_ENABLED
 
 	virtual bool is_text_field() const;

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -218,7 +218,7 @@ bool HTTPRequest::_handle_response(bool *ret_value) {
 	got_response = true;
 	response_code = client->get_response_code();
 	List<String> rheaders;
-	client->get_response_headers(&rheaders);
+	client->get_response_headers(rheaders);
 	response_headers.clear();
 	downloaded.set(0);
 	final_body_size.set(0);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3377,29 +3377,29 @@ NodePath Node::get_import_path() const {
 }
 
 #ifdef TOOLS_ENABLED
-static void _add_nodes_to_options(const Node *p_base, const Node *p_node, List<String> *r_options) {
+static void _add_nodes_to_options(const Node *p_base, const Node *p_node, List<String> &r_options) {
 	if (p_node != p_base && !p_node->get_owner()) {
 		return;
 	}
 	if (p_node->is_unique_name_in_owner() && p_node->get_owner() == p_base) {
 		String n = "%" + p_node->get_name();
-		r_options->push_back(n.quote());
+		r_options.push_back(n.quote());
 	}
 	String n = p_base->get_path_to(p_node);
-	r_options->push_back(n.quote());
+	r_options.push_back(n.quote());
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		_add_nodes_to_options(p_base, p_node->get_child(i), r_options);
 	}
 }
 
-void Node::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void Node::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0 && (pf == "has_node" || pf == "get_node" || pf == "get_node_or_null")) {
 		_add_nodes_to_options(this, this, r_options);
 	} else if (p_idx == 0 && (pf == "add_to_group" || pf == "remove_from_group" || pf == "is_in_group")) {
 		HashMap<StringName, String> global_groups = ProjectSettings::get_singleton()->get_global_groups_list();
 		for (const KeyValue<StringName, String> &E : global_groups) {
-			r_options->push_back(E.key.operator String().quote());
+			r_options.push_back(E.key.operator String().quote());
 		}
 	}
 	Object::get_argument_options(p_function, p_idx, r_options);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -697,7 +697,7 @@ public:
 #ifdef TOOLS_ENABLED
 	String validate_child_name(Node *p_child);
 	String prevalidate_child_name(Node *p_child, StringName p_name);
-	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 	static String adjust_name_casing(const String &p_name);
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1811,7 +1811,7 @@ void SceneTree::add_idle_callback(IdleCallback p_callback) {
 }
 
 #ifdef TOOLS_ENABLED
-void SceneTree::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void SceneTree::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	bool add_options = false;
 	if (p_idx == 0) {
@@ -1822,7 +1822,7 @@ void SceneTree::get_argument_options(const StringName &p_function, int p_idx, Li
 	if (add_options) {
 		HashMap<StringName, String> global_groups = ProjectSettings::get_singleton()->get_global_groups_list();
 		for (const KeyValue<StringName, String> &E : global_groups) {
-			r_options->push_back(E.key.operator String().quote());
+			r_options.push_back(E.key.operator String().quote());
 		}
 	}
 	MainLoop::get_argument_options(p_function, p_idx, r_options);
@@ -1958,7 +1958,7 @@ SceneTree::SceneTree() {
 	{ // Load default fallback environment.
 		// Get possible extensions.
 		List<String> exts;
-		ResourceLoader::get_recognized_extensions_for_type("Environment", &exts);
+		ResourceLoader::get_recognized_extensions_for_type("Environment", exts);
 		String ext_hint;
 		for (const String &E : exts) {
 			if (!ext_hint.is_empty()) {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -420,7 +420,7 @@ public:
 	static SceneTree *get_singleton() { return singleton; }
 
 #ifdef TOOLS_ENABLED
-	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	//network API

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -150,13 +150,13 @@ Dictionary AnimationLibrary::_get_data() const {
 }
 
 #ifdef TOOLS_ENABLED
-void AnimationLibrary::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void AnimationLibrary::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0 && (pf == "get_animation" || pf == "has_animation" || pf == "rename_animation" || pf == "remove_animation")) {
 		List<StringName> names;
 		get_animation_list(&names);
 		for (const StringName &E : names) {
-			r_options->push_back(E.operator String().quote());
+			r_options.push_back(E.operator String().quote());
 		}
 	}
 	Resource::get_argument_options(p_function, p_idx, r_options);

--- a/scene/resources/animation_library.h
+++ b/scene/resources/animation_library.h
@@ -64,7 +64,7 @@ public:
 	int get_animation_list_size() const;
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	AnimationLibrary();

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -480,8 +480,8 @@ Ref<Resource> ResourceFormatLoaderCompressedTexture2D::load(const String &p_path
 	return st;
 }
 
-void ResourceFormatLoaderCompressedTexture2D::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("ctex");
+void ResourceFormatLoaderCompressedTexture2D::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("ctex");
 }
 
 bool ResourceFormatLoaderCompressedTexture2D::handles_type(const String &p_type) const {
@@ -669,8 +669,8 @@ Ref<Resource> ResourceFormatLoaderCompressedTexture3D::load(const String &p_path
 	return st;
 }
 
-void ResourceFormatLoaderCompressedTexture3D::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("ctex3d");
+void ResourceFormatLoaderCompressedTexture3D::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("ctex3d");
 }
 
 bool ResourceFormatLoaderCompressedTexture3D::handles_type(const String &p_type) const {
@@ -884,10 +884,10 @@ Ref<Resource> ResourceFormatLoaderCompressedTextureLayered::load(const String &p
 	return ct;
 }
 
-void ResourceFormatLoaderCompressedTextureLayered::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("ctexarray");
-	p_extensions->push_back("ccube");
-	p_extensions->push_back("ccubearray");
+void ResourceFormatLoaderCompressedTextureLayered::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("ctexarray");
+	p_extensions.push_back("ccube");
+	p_extensions.push_back("ccubearray");
 }
 
 bool ResourceFormatLoaderCompressedTextureLayered::handles_type(const String &p_type) const {

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -115,7 +115,7 @@ public:
 class ResourceFormatLoaderCompressedTexture2D : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };
@@ -180,7 +180,7 @@ public:
 class ResourceFormatLoaderCompressedTextureLayered : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };
@@ -266,7 +266,7 @@ public:
 class ResourceFormatLoaderCompressedTexture3D : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -526,14 +526,14 @@ void ShaderMaterial::_bind_methods() {
 }
 
 #ifdef TOOLS_ENABLED
-void ShaderMaterial::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void ShaderMaterial::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0 && (pf == "get_shader_parameter" || pf == "set_shader_parameter")) {
 		if (shader.is_valid()) {
 			List<PropertyInfo> pl;
 			shader->get_shader_uniform_list(&pl);
 			for (const PropertyInfo &E : pl) {
-				r_options->push_back(E.name.replace_first("shader_parameter/", "").quote());
+				r_options.push_back(E.name.replace_first("shader_parameter/", "").quote());
 			}
 		}
 	}

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -110,7 +110,7 @@ protected:
 	static void _bind_methods();
 
 #ifdef TOOLS_ENABLED
-	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	virtual bool _can_do_next_pass() const override;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -868,7 +868,7 @@ void ResourceLoaderText::set_translation_remapped(bool p_remapped) {
 ResourceLoaderText::ResourceLoaderText() :
 		stream(false), format_version(FORMAT_VERSION) {}
 
-void ResourceLoaderText::get_dependencies(Ref<FileAccess> p_f, List<String> *p_dependencies, bool p_add_types) {
+void ResourceLoaderText::get_dependencies(Ref<FileAccess> p_f, List<String> &p_dependencies, bool p_add_types) {
 	open(p_f);
 	ignore_resource_parsing = true;
 	ERR_FAIL_COND(error != OK);
@@ -919,7 +919,7 @@ void ResourceLoaderText::get_dependencies(Ref<FileAccess> p_f, List<String> *p_d
 			path += "::" + fallback_path;
 		}
 
-		p_dependencies->push_back(path);
+		p_dependencies.push_back(path);
 
 		Error err = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp);
 
@@ -1421,25 +1421,25 @@ Ref<Resource> ResourceFormatLoaderText::load(const String &p_path, const String 
 	}
 }
 
-void ResourceFormatLoaderText::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
+void ResourceFormatLoaderText::get_recognized_extensions_for_type(const String &p_type, List<String> &p_extensions) const {
 	if (p_type.is_empty()) {
 		get_recognized_extensions(p_extensions);
 		return;
 	}
 
 	if (ClassDB::is_parent_class("PackedScene", p_type)) {
-		p_extensions->push_back("tscn");
+		p_extensions.push_back("tscn");
 	}
 
 	// Don't allow .tres for PackedScenes or GDExtension.
 	if (p_type != "PackedScene" && p_type != "GDExtension") {
-		p_extensions->push_back("tres");
+		p_extensions.push_back("tres");
 	}
 }
 
-void ResourceFormatLoaderText::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("tscn");
-	p_extensions->push_back("tres");
+void ResourceFormatLoaderText::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("tscn");
+	p_extensions.push_back("tres");
 }
 
 bool ResourceFormatLoaderText::handles_type(const String &p_type) const {
@@ -1529,7 +1529,7 @@ bool ResourceFormatLoaderText::has_custom_uid_support() const {
 	return true;
 }
 
-void ResourceFormatLoaderText::get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types) {
+void ResourceFormatLoaderText::get_dependencies(const String &p_path, List<String> &p_dependencies, bool p_add_types) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	if (f.is_null()) {
 		ERR_FAIL();
@@ -2161,11 +2161,11 @@ bool ResourceFormatSaverText::recognize(const Ref<Resource> &p_resource) const {
 	return true; // All resources recognized!
 }
 
-void ResourceFormatSaverText::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaverText::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const {
 	if (Ref<PackedScene>(p_resource).is_valid()) {
-		p_extensions->push_back("tscn"); // Text scene.
+		p_extensions.push_back("tscn"); // Text scene.
 	} else {
-		p_extensions->push_back("tres"); // Text resource.
+		p_extensions.push_back("tres"); // Text resource.
 	}
 }
 

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -136,7 +136,7 @@ public:
 	String recognize(Ref<FileAccess> p_f);
 	String recognize_script_class(Ref<FileAccess> p_f);
 	ResourceUID::ID get_uid(Ref<FileAccess> p_f);
-	void get_dependencies(Ref<FileAccess> p_f, List<String> *p_dependencies, bool p_add_types);
+	void get_dependencies(Ref<FileAccess> p_f, List<String> &p_dependencies, bool p_add_types);
 	Error rename_dependencies(Ref<FileAccess> p_f, const String &p_path, const HashMap<String, String> &p_map);
 	Error get_classes_used(HashSet<StringName> *r_classes);
 
@@ -147,8 +147,8 @@ class ResourceFormatLoaderText : public ResourceFormatLoader {
 public:
 	static ResourceFormatLoaderText *singleton;
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> &p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes) override;
 
@@ -156,7 +156,7 @@ public:
 	virtual String get_resource_script_class(const String &p_path) const override;
 	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
 	virtual bool has_custom_uid_support() const override;
-	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;
+	virtual void get_dependencies(const String &p_path, List<String> &p_dependencies, bool p_add_types = false) override;
 	virtual Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map) override;
 
 	ResourceFormatLoaderText() { singleton = this; }
@@ -209,7 +209,7 @@ public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
-	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const override;
 
 	ResourceFormatSaverText();
 };

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -329,8 +329,8 @@ Ref<Resource> ResourceFormatLoaderShader::load(const String &p_path, const Strin
 	return shader;
 }
 
-void ResourceFormatLoaderShader::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("gdshader");
+void ResourceFormatLoaderShader::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("gdshader");
 }
 
 bool ResourceFormatLoaderShader::handles_type(const String &p_type) const {
@@ -364,10 +364,10 @@ Error ResourceFormatSaverShader::save(const Ref<Resource> &p_resource, const Str
 	return OK;
 }
 
-void ResourceFormatSaverShader::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaverShader::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const {
 	if (const Shader *shader = Object::cast_to<Shader>(*p_resource)) {
 		if (shader->is_text_shader()) {
-			p_extensions->push_back("gdshader");
+			p_extensions.push_back("gdshader");
 		}
 	}
 }

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -109,7 +109,7 @@ VARIANT_ENUM_CAST(Shader::Mode);
 class ResourceFormatLoaderShader : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };
@@ -117,7 +117,7 @@ public:
 class ResourceFormatSaverShader : public ResourceFormatSaver {
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
-	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };
 

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -111,8 +111,8 @@ Ref<Resource> ResourceFormatLoaderShaderInclude::load(const String &p_path, cons
 	return shader_inc;
 }
 
-void ResourceFormatLoaderShaderInclude::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("gdshaderinc");
+void ResourceFormatLoaderShaderInclude::get_recognized_extensions(List<String> &p_extensions) const {
+	p_extensions.push_back("gdshaderinc");
 }
 
 bool ResourceFormatLoaderShaderInclude::handles_type(const String &p_type) const {
@@ -148,10 +148,10 @@ Error ResourceFormatSaverShaderInclude::save(const Ref<Resource> &p_resource, co
 	return OK;
 }
 
-void ResourceFormatSaverShaderInclude::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaverShaderInclude::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const {
 	const ShaderInclude *shader_inc = Object::cast_to<ShaderInclude>(*p_resource);
 	if (shader_inc != nullptr) {
-		p_extensions->push_back("gdshaderinc");
+		p_extensions.push_back("gdshaderinc");
 	}
 }
 

--- a/scene/resources/shader_include.h
+++ b/scene/resources/shader_include.h
@@ -59,7 +59,7 @@ public:
 class ResourceFormatLoaderShaderInclude : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(List<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };
@@ -67,7 +67,7 @@ public:
 class ResourceFormatSaverShaderInclude : public ResourceFormatSaver {
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
-	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> &p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };
 

--- a/scene/resources/sprite_frames.cpp
+++ b/scene/resources/sprite_frames.cpp
@@ -231,7 +231,7 @@ void SpriteFrames::_set_animations(const Array &p_animations) {
 }
 
 #ifdef TOOLS_ENABLED
-void SpriteFrames::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void SpriteFrames::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "has_animation" || pf == "remove_animation" || pf == "rename_animation" ||
@@ -241,7 +241,7 @@ void SpriteFrames::get_argument_options(const StringName &p_function, int p_idx,
 				pf == "get_frame_count" || pf == "get_frame_texture" || pf == "get_frame_duration" ||
 				pf == "clear") {
 			for (const String &E : get_animation_names()) {
-				r_options->push_back(E.quote());
+				r_options.push_back(E.quote());
 			}
 		}
 	}

--- a/scene/resources/sprite_frames.h
+++ b/scene/resources/sprite_frames.h
@@ -105,7 +105,7 @@ public:
 	void clear_all();
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	SpriteFrames();

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -4241,7 +4241,7 @@ String VisualShaderNodeParameter::_get_qual_str() const {
 
 String VisualShaderNodeParameter::get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const {
 	List<String> keyword_list;
-	ShaderLanguage::get_keyword_list(&keyword_list);
+	ShaderLanguage::get_keyword_list(keyword_list);
 	if (keyword_list.find(parameter_name)) {
 		return RTR("Shader keywords cannot be used as parameter names.\nChoose another name.");
 	}

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1832,11 +1832,11 @@ void AudioServer::set_enable_tagging_used_audio_streams(bool p_enable) {
 }
 
 #ifdef TOOLS_ENABLED
-void AudioServer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void AudioServer::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if ((p_idx == 0 && pf == "get_bus_index") || (p_idx == 1 && pf == "set_bus_send")) {
 		for (const AudioServer::Bus *E : buses) {
-			r_options->push_back(String(E->name).quote());
+			r_options.push_back(String(E->name).quote());
 		}
 	}
 

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -488,7 +488,7 @@ public:
 	void set_enable_tagging_used_audio_streams(bool p_enable);
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	PlaybackType get_default_playback_type() const;

--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -86,11 +86,11 @@ bool MovieWriter::handles_file(const String &p_path) const {
 	return ret;
 }
 
-void MovieWriter::get_supported_extensions(List<String> *r_extensions) const {
+void MovieWriter::get_supported_extensions(List<String> &r_extensions) const {
 	Vector<String> exts;
 	GDVIRTUAL_CALL(_get_supported_extensions, exts);
 	for (int i = 0; i < exts.size(); i++) {
-		r_extensions->push_back(exts[i]);
+		r_extensions.push_back(exts[i]);
 	}
 }
 
@@ -153,7 +153,7 @@ void MovieWriter::set_extensions_hint() {
 	RBSet<String> found;
 	for (uint32_t i = 0; i < writer_count; i++) {
 		List<String> extensions;
-		writers[i]->get_supported_extensions(&extensions);
+		writers[i]->get_supported_extensions(extensions);
 		for (const String &ext : extensions) {
 			found.insert(ext);
 		}

--- a/servers/movie_writer/movie_writer.h
+++ b/servers/movie_writer/movie_writer.h
@@ -77,7 +77,7 @@ protected:
 
 public:
 	virtual bool handles_file(const String &p_path) const;
-	virtual void get_supported_extensions(List<String> *r_extensions) const;
+	virtual void get_supported_extensions(List<String> &r_extensions) const;
 
 	static void add_writer(MovieWriter *p_writer);
 	static MovieWriter *find_writer_for_file(const String &p_file);

--- a/servers/movie_writer/movie_writer_mjpeg.cpp
+++ b/servers/movie_writer/movie_writer_mjpeg.cpp
@@ -42,8 +42,8 @@ bool MovieWriterMJPEG::handles_file(const String &p_path) const {
 	return p_path.get_extension().to_lower() == "avi";
 }
 
-void MovieWriterMJPEG::get_supported_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("avi");
+void MovieWriterMJPEG::get_supported_extensions(List<String> &r_extensions) const {
+	r_extensions.push_back("avi");
 }
 
 Error MovieWriterMJPEG::write_begin(const Size2i &p_movie_size, uint32_t p_fps, const String &p_base_path) {

--- a/servers/movie_writer/movie_writer_mjpeg.h
+++ b/servers/movie_writer/movie_writer_mjpeg.h
@@ -58,7 +58,7 @@ class MovieWriterMJPEG : public MovieWriter {
 protected:
 	virtual uint32_t get_audio_mix_rate() const override;
 	virtual AudioServer::SpeakerMode get_audio_speaker_mode() const override;
-	virtual void get_supported_extensions(List<String> *r_extensions) const override;
+	virtual void get_supported_extensions(List<String> &r_extensions) const override;
 
 	virtual Error write_begin(const Size2i &p_movie_size, uint32_t p_fps, const String &p_base_path) override;
 	virtual Error write_frame(const Ref<Image> &p_image, const int32_t *p_audio_data) override;

--- a/servers/movie_writer/movie_writer_pngwav.cpp
+++ b/servers/movie_writer/movie_writer_pngwav.cpp
@@ -39,8 +39,8 @@ AudioServer::SpeakerMode MovieWriterPNGWAV::get_audio_speaker_mode() const {
 	return speaker_mode;
 }
 
-void MovieWriterPNGWAV::get_supported_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("png");
+void MovieWriterPNGWAV::get_supported_extensions(List<String> &r_extensions) const {
+	r_extensions.push_back("png");
 }
 
 bool MovieWriterPNGWAV::handles_file(const String &p_path) const {

--- a/servers/movie_writer/movie_writer_pngwav.h
+++ b/servers/movie_writer/movie_writer_pngwav.h
@@ -56,7 +56,7 @@ class MovieWriterPNGWAV : public MovieWriter {
 protected:
 	virtual uint32_t get_audio_mix_rate() const override;
 	virtual AudioServer::SpeakerMode get_audio_speaker_mode() const override;
-	virtual void get_supported_extensions(List<String> *r_extensions) const override;
+	virtual void get_supported_extensions(List<String> &r_extensions) const override;
 
 	virtual Error write_begin(const Size2i &p_movie_size, uint32_t p_fps, const String &p_base_path) override;
 	virtual Error write_frame(const Ref<Image> &p_image, const int32_t *p_audio_data) override;

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -1590,7 +1590,7 @@ void ShaderCompiler::initialize(DefaultIdentifierActions p_actions) {
 
 	List<String> func_list;
 
-	ShaderLanguage::get_builtin_funcs(&func_list);
+	ShaderLanguage::get_builtin_funcs(func_list);
 
 	for (const String &E : func_list) {
 		internal_functions.insert(E);

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -5154,7 +5154,7 @@ uint32_t ShaderLanguage::get_datatype_component_count(ShaderLanguage::DataType p
 	return 0U;
 }
 
-void ShaderLanguage::get_keyword_list(List<String> *r_keywords) {
+void ShaderLanguage::get_keyword_list(List<String> &r_keywords) {
 	HashSet<String> kws;
 
 	int idx = 0;
@@ -5173,7 +5173,7 @@ void ShaderLanguage::get_keyword_list(List<String> *r_keywords) {
 	}
 
 	for (const String &E : kws) {
-		r_keywords->push_back(E);
+		r_keywords.push_back(E);
 	}
 }
 
@@ -5191,7 +5191,7 @@ bool ShaderLanguage::is_control_flow_keyword(String p_keyword) {
 			p_keyword == "while";
 }
 
-void ShaderLanguage::get_builtin_funcs(List<String> *r_keywords) {
+void ShaderLanguage::get_builtin_funcs(List<String> &r_keywords) {
 	HashSet<String> kws;
 
 	int idx = 0;
@@ -5203,7 +5203,7 @@ void ShaderLanguage::get_builtin_funcs(List<String> *r_keywords) {
 	}
 
 	for (const String &E : kws) {
-		r_keywords->push_back(E);
+		r_keywords.push_back(E);
 	}
 }
 

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -829,9 +829,9 @@ public:
 	static uint32_t get_datatype_size(DataType p_type);
 	static uint32_t get_datatype_component_count(DataType p_type);
 
-	static void get_keyword_list(List<String> *r_keywords);
+	static void get_keyword_list(List<String> &r_keywords);
 	static bool is_control_flow_keyword(String p_keyword);
-	static void get_builtin_funcs(List<String> *r_keywords);
+	static void get_builtin_funcs(List<String> &r_keywords);
 
 	static SafeNumeric<int> instance_counter;
 
@@ -1203,7 +1203,7 @@ public:
 	uint32_t get_warning_flags() const;
 #endif // DEBUG_ENABLED
 
-	//static void get_keyword_list(ShaderType p_type,List<String> *p_keywords);
+	//static void get_keyword_list(ShaderType p_type,List<String> &p_keywords);
 
 	void clear();
 

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -1381,7 +1381,7 @@ Error ShaderPreprocessor::preprocess(const String &p_code, const String &p_filen
 		switch (pp_state.completion_type) {
 			case COMPLETION_TYPE_DIRECTIVE: {
 				List<String> options;
-				get_keyword_list(&options, true, true);
+				get_keyword_list(options, true, true);
 
 				for (const String &E : options) {
 					ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
@@ -1391,7 +1391,7 @@ Error ShaderPreprocessor::preprocess(const String &p_code, const String &p_filen
 			} break;
 			case COMPLETION_TYPE_PRAGMA: {
 				List<String> options;
-				ShaderPreprocessor::get_pragma_list(&options);
+				ShaderPreprocessor::get_pragma_list(options);
 
 				for (const String &E : options) {
 					ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
@@ -1420,29 +1420,29 @@ Error ShaderPreprocessor::preprocess(const String &p_code, const String &p_filen
 	return err;
 }
 
-void ShaderPreprocessor::get_keyword_list(List<String> *r_keywords, bool p_include_shader_keywords, bool p_ignore_context_keywords) {
-	r_keywords->push_back("define");
+void ShaderPreprocessor::get_keyword_list(List<String> &r_keywords, bool p_include_shader_keywords, bool p_ignore_context_keywords) {
+	r_keywords.push_back("define");
 	if (!p_ignore_context_keywords) {
-		r_keywords->push_back("defined");
+		r_keywords.push_back("defined");
 	}
-	r_keywords->push_back("elif");
+	r_keywords.push_back("elif");
 	if (p_include_shader_keywords) {
-		r_keywords->push_back("else");
+		r_keywords.push_back("else");
 	}
-	r_keywords->push_back("endif");
-	r_keywords->push_back("error");
+	r_keywords.push_back("endif");
+	r_keywords.push_back("error");
 	if (p_include_shader_keywords) {
-		r_keywords->push_back("if");
+		r_keywords.push_back("if");
 	}
-	r_keywords->push_back("ifdef");
-	r_keywords->push_back("ifndef");
-	r_keywords->push_back("include");
-	r_keywords->push_back("pragma");
-	r_keywords->push_back("undef");
+	r_keywords.push_back("ifdef");
+	r_keywords.push_back("ifndef");
+	r_keywords.push_back("include");
+	r_keywords.push_back("pragma");
+	r_keywords.push_back("undef");
 }
 
-void ShaderPreprocessor::get_pragma_list(List<String> *r_pragmas) {
-	r_pragmas->push_back("disable_preprocessor");
+void ShaderPreprocessor::get_pragma_list(List<String> &r_pragmas) {
+	r_pragmas.push_back("disable_preprocessor");
 }
 
 ShaderPreprocessor::ShaderPreprocessor() {

--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -222,8 +222,8 @@ public:
 
 	Error preprocess(const String &p_code, const String &p_filename, String &r_result, String *r_error_text = nullptr, List<FilePosition> *r_error_position = nullptr, List<Region> *r_regions = nullptr, HashSet<Ref<ShaderInclude>> *r_includes = nullptr, List<ScriptLanguage::CodeCompletionOption> *r_completion_options = nullptr, List<ScriptLanguage::CodeCompletionOption> *r_completion_defines = nullptr, IncludeCompletionFunction p_include_completion_func = nullptr);
 
-	static void get_keyword_list(List<String> *r_keywords, bool p_include_shader_keywords, bool p_ignore_context_keywords = false);
-	static void get_pragma_list(List<String> *r_pragmas);
+	static void get_keyword_list(List<String> &r_keywords, bool p_include_shader_keywords, bool p_ignore_context_keywords = false);
+	static void get_pragma_list(List<String> &r_pragmas);
 
 	ShaderPreprocessor();
 	~ShaderPreprocessor();

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2221,17 +2221,17 @@ void RenderingServer::fix_surface_compatibility(SurfaceData &p_surface, const St
 #endif
 
 #ifdef TOOLS_ENABLED
-void RenderingServer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void RenderingServer::get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "global_shader_parameter_set" || pf == "global_shader_parameter_set_override" ||
 				pf == "global_shader_parameter_get" || pf == "global_shader_parameter_get_type" || pf == "global_shader_parameter_remove") {
 			for (const StringName &E : global_shader_parameter_get_list()) {
-				r_options->push_back(E.operator String().quote());
+				r_options.push_back(E.operator String().quote());
 			}
 		} else if (pf == "has_os_feature") {
 			for (const String E : { "\"rgtc\"", "\"s3tc\"", "\"bptc\"", "\"etc\"", "\"etc2\"", "\"astc\"" }) {
-				r_options->push_back(E);
+				r_options.push_back(E);
 			}
 		}
 	}

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1852,7 +1852,7 @@ public:
 	String get_current_rendering_method() const;
 
 #ifdef TOOLS_ENABLED
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> &r_options) const override;
 #endif
 
 	RenderingServer();

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -773,7 +773,7 @@ void add_exposed_classes(Context &r_context) {
 		// Add enums and constants
 
 		List<String> constants;
-		ClassDB::get_integer_constant_list(class_name, &constants, true);
+		ClassDB::get_integer_constant_list(class_name, constants, true);
 
 		const HashMap<StringName, ClassDB::ClassInfo::EnumInfo> &enum_map = class_info->enum_map;
 

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -146,7 +146,7 @@ TEST_CASE("[Object] Core getters") {
 			"The returned save class should match the expected value.");
 
 	List<String> inheritance_list;
-	object.get_inheritance_list_static(&inheritance_list);
+	object.get_inheritance_list_static(inheritance_list);
 	CHECK_MESSAGE(
 			inheritance_list.size() == 1,
 			"The inheritance list should consist of Object only");


### PR DESCRIPTION
Many functions have `List<> *` out params which either lead to extra checking code or have the risk of null pointer dereference. Replace with `List<> &` to make it safer.
