### PR TITLE
RenderingDevice: Check for whether an ASTC texture has HDR data

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -1839,7 +1839,7 @@ RDD::TextureID RenderingDeviceDriverVulkan::texture_create(const TextureFormat &
 		if (image_view_create_info.format >= VK_FORMAT_ASTC_4x4_UNORM_BLOCK && image_view_create_info.format <= VK_FORMAT_ASTC_12x12_SRGB_BLOCK) {
 			decode_mode.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_ASTC_DECODE_MODE_EXT;
 			decode_mode.pNext = nullptr;
-			decode_mode.decodeMode = VK_FORMAT_R8G8B8A8_UNORM;
+			decode_mode.decodeMode = (p_format.format_flags & TEXTURE_FORMAT_DECODE_HDR) ? VK_FORMAT_R16G16B16A16_SFLOAT : VK_FORMAT_R8G8B8A8_UNORM;
 			image_view_create_info.pNext = &decode_mode;
 		}
 	}

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -810,6 +810,7 @@ void TextureStorage::texture_2d_initialize(RID p_texture, const Ref<Image> &p_im
 	RD::TextureView rd_view;
 	{ //attempt register
 		rd_format.format = texture.rd_format;
+		rd_format.format_flags = ret_format.force_hdr_decode ? RD::TEXTURE_FORMAT_DECODE_HDR : 0;
 		rd_format.width = texture.width;
 		rd_format.height = texture.height;
 		rd_format.depth = 1;
@@ -920,6 +921,7 @@ void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<R
 	RD::TextureView rd_view;
 	{ //attempt register
 		rd_format.format = texture.rd_format;
+		rd_format.format_flags = ret_format.force_hdr_decode ? RD::TEXTURE_FORMAT_DECODE_HDR : 0;
 		rd_format.width = texture.width;
 		rd_format.height = texture.height;
 		rd_format.depth = 1;
@@ -1039,6 +1041,7 @@ void TextureStorage::texture_3d_initialize(RID p_texture, Image::Format p_format
 	RD::TextureView rd_view;
 	{ //attempt register
 		rd_format.format = texture.rd_format;
+		rd_format.format_flags = ret_format.force_hdr_decode ? RD::TEXTURE_FORMAT_DECODE_HDR : 0;
 		rd_format.width = texture.width;
 		rd_format.height = texture.height;
 		rd_format.depth = texture.depth;
@@ -2198,6 +2201,8 @@ Ref<Image> TextureStorage::_validate_texture_format(const Ref<Image> &p_image, T
 				r_format.format = RD::DATA_FORMAT_ASTC_4x4_UNORM_BLOCK;
 				if (p_image->get_format() == Image::FORMAT_ASTC_4x4) {
 					r_format.format_srgb = RD::DATA_FORMAT_ASTC_4x4_SRGB_BLOCK;
+				} else {
+					r_format.force_hdr_decode = true;
 				}
 			} else {
 				//not supported, reconvert
@@ -2223,6 +2228,8 @@ Ref<Image> TextureStorage::_validate_texture_format(const Ref<Image> &p_image, T
 				r_format.format = RD::DATA_FORMAT_ASTC_8x8_UNORM_BLOCK;
 				if (p_image->get_format() == Image::FORMAT_ASTC_8x8) {
 					r_format.format_srgb = RD::DATA_FORMAT_ASTC_8x8_SRGB_BLOCK;
+				} else {
+					r_format.force_hdr_decode = true;
 				}
 			} else {
 				//not supported, reconvert

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -207,6 +207,8 @@ private:
 		RD::TextureSwizzle swizzle_g;
 		RD::TextureSwizzle swizzle_b;
 		RD::TextureSwizzle swizzle_a;
+		bool force_hdr_decode;
+
 		TextureToRDFormat() {
 			format = RD::DATA_FORMAT_MAX;
 			format_srgb = RD::DATA_FORMAT_MAX;
@@ -214,6 +216,7 @@ private:
 			swizzle_g = RD::TEXTURE_SWIZZLE_G;
 			swizzle_b = RD::TEXTURE_SWIZZLE_B;
 			swizzle_a = RD::TEXTURE_SWIZZLE_A;
+			force_hdr_decode = false;
 		}
 	};
 

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -379,8 +379,13 @@ public:
 		TEXTURE_USAGE_TRANSIENT_BIT = (1 << 11),
 	};
 
+	enum TextureFormatFlags {
+		TEXTURE_FORMAT_DECODE_HDR = (1 << 0),
+	};
+
 	struct TextureFormat {
 		DataFormat format = DATA_FORMAT_R8_UNORM;
+		uint32_t format_flags = 0;
 		uint32_t width = 1;
 		uint32_t height = 1;
 		uint32_t depth = 1;


### PR DESCRIPTION
This PR adds a check to RenderingDevice to ensure that when the `VkImageViewASTCDecodeModeEXT` extension is available, decoding as RGBA8 is only done when the texture's format is neither ASTC_4x4_HDR nor ASTC_8x8_HDR.

[This is mandated by the extension.](https://registry.khronos.org/vulkan/specs/latest/man/html/VkImageViewASTCDecodeModeEXT.html)

TODO:
- [ ] Find out whether this data can be passed to the Renderer in a less intrusive way,
- [ ] Test on mobile hardware.