### PR TITLE
Add info about units used in AtlasTexture's region

### DIFF
--- a/doc/classes/AtlasTexture.xml
+++ b/doc/classes/AtlasTexture.xml
@@ -18,10 +18,10 @@
 			If [code]true[/code], the area outside of the [member region] is clipped to avoid bleeding of the surrounding texture pixels.
 		</member>
 		<member name="margin" type="Rect2" setter="set_margin" getter="get_margin" default="Rect2(0, 0, 0, 0)">
-			The margin around the [member region]. Useful for small adjustments. If the [member Rect2.size] of this property ("w" and "h" in the editor) is set, the drawn texture is resized to fit within the margin.
+			The margin around the [member region] in pixel coordinates relative to the texture at its original scale. Useful for small adjustments. If the [member Rect2.size] of this property ("w" and "h" in the editor) is set, the drawn texture is resized to fit within the margin.
 		</member>
 		<member name="region" type="Rect2" setter="set_region" getter="get_region" default="Rect2(0, 0, 0, 0)">
-			The region used to draw the [member atlas]. If either dimension of the region's size is [code]0[/code], the value from [member atlas] size will be used for that axis instead.
+			The region used to draw the [member atlas] in pixel coordinates relative to the texture at its original scale. A pixel coordinate at [code](0, 0)[/code] maps to the top-left corner of the texture. If either dimension of the region's size is [code]0[/code], the value from [member atlas] size will be used for that axis instead.
 		</member>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 	</members>


### PR DESCRIPTION
Specifies units used in `AtlasTexture`'s `region` and `margin`. Intended to close godotengine/godot-docs#8530.

Behavior tested experimentally. During testing, I may have found an issue where setting the margin's size (`h` and `w`) in the editor doesn't seem to have any effect, will investigate further tomorrow.