### PR TITLE
Add ZWSP to the list of space characters.

### DIFF
--- a/core/string/char_utils.h
+++ b/core/string/char_utils.h
@@ -117,7 +117,7 @@ constexpr bool is_control(char32_t p_char) {
 }
 
 constexpr bool is_whitespace(char32_t p_char) {
-	return (p_char == ' ') || (p_char == 0x00a0) || (p_char == 0x1680) || (p_char >= 0x2000 && p_char <= 0x200a) || (p_char == 0x202f) || (p_char == 0x205f) || (p_char == 0x3000) || (p_char == 0x2028) || (p_char == 0x2029) || (p_char >= 0x0009 && p_char <= 0x000d) || (p_char == 0x0085);
+	return (p_char == ' ') || (p_char == 0x00a0) || (p_char == 0x1680) || (p_char >= 0x2000 && p_char <= 0x200b) || (p_char == 0x202f) || (p_char == 0x205f) || (p_char == 0x3000) || (p_char == 0x2028) || (p_char == 0x2029) || (p_char >= 0x0009 && p_char <= 0x000d) || (p_char == 0x0085);
 }
 
 constexpr bool is_linebreak(char32_t p_char) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/102414

Fixes line breaking with fallback break iterator (no ICU data loaded).
