### PR TITLE
LightmapGI: Allow using lightmaps and shadowmasks with different resolutions

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3393,6 +3393,9 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 							if (lightmap_bicubic_upscale) {
 								Vector2 light_texture_size(lm->light_texture_size.x, lm->light_texture_size.y);
 								material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::LIGHTMAP_TEXTURE_SIZE, light_texture_size, shader->version, instance_variant, spec_constants);
+
+								Vector2 shadow_texture_size(lm->shadow_texture_size.x, lm->shadow_texture_size.y);
+								material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::SHADOWMASK_TEXTURE_SIZE, shadow_texture_size, shader->version, instance_variant, spec_constants);
 							}
 
 							material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::LIGHTMAP_SHADOWMASK_MODE, (uint32_t)lm->shadowmask_mode, shader->version, instance_variant, spec_constants);

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1200,6 +1200,7 @@ uniform uint lightmap_shadowmask_mode;
 
 #ifdef LIGHTMAP_BICUBIC_FILTER
 uniform highp vec2 lightmap_texture_size;
+uniform highp vec2 shadowmask_texture_size;
 #endif
 
 #ifdef USE_SH_LIGHTMAP
@@ -2335,7 +2336,7 @@ void main() {
 		uvw.z = float(lightmap_slice);
 
 #ifdef LIGHTMAP_BICUBIC_FILTER
-		shadowmask = textureArray_bicubic(shadowmask_textures, uvw, lightmap_texture_size).x;
+		shadowmask = textureArray_bicubic(shadowmask_textures, uvw, shadowmask_texture_size).x;
 #else
 		shadowmask = textureLod(shadowmask_textures, uvw, 0.0).x;
 #endif

--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -1215,6 +1215,9 @@ void LightStorage::lightmap_set_shadowmask_textures(RID p_lightmap, RID p_shadow
 	ERR_FAIL_NULL(lightmap);
 	lightmap->shadow_texture = p_shadow;
 
+	Vector3i shadow_texture_size = GLES3::TextureStorage::get_singleton()->texture_get_size(lightmap->shadow_texture);
+	lightmap->shadow_texture_size = Vector2i(shadow_texture_size.x, shadow_texture_size.y);
+
 	GLuint tex = GLES3::TextureStorage::get_singleton()->texture_get_texid(lightmap->shadow_texture);
 	glBindTexture(GL_TEXTURE_2D_ARRAY, tex);
 	glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -181,6 +181,7 @@ struct Lightmap {
 	AABB bounds = AABB(Vector3(), Vector3(1, 1, 1));
 	float baked_exposure = 1.0;
 	Vector2i light_texture_size;
+	Vector2i shadow_texture_size;
 	int32_t array_index = -1; //unassigned
 	RS::ShadowmaskMode shadowmask_mode = RS::SHADOWMASK_MODE_NONE;
 	PackedVector3Array points;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1176,12 +1176,22 @@ void RenderForwardClustered::_setup_lightmaps(const RenderDataRD *p_render_data,
 
 		// Light texture size.
 		Vector2i lightmap_size = light_storage->lightmap_get_light_texture_size(lightmap);
-		scene_state.lightmaps[i].texture_size[0] = lightmap_size[0];
-		scene_state.lightmaps[i].texture_size[1] = lightmap_size[1];
+		scene_state.lightmaps[i].light_texture_size[0] = lightmap_size[0];
+		scene_state.lightmaps[i].light_texture_size[1] = lightmap_size[1];
+
+		// Shadowmasks.
+		const RS::ShadowmaskMode shadowmask_mode = light_storage->lightmap_get_shadowmask_mode(lightmap);
+		if (shadowmask_mode != RS::SHADOWMASK_MODE_NONE) {
+			// Shadow texture size.
+			Vector2i shadowmask_size = light_storage->lightmap_get_shadow_texture_size(lightmap);
+			scene_state.lightmaps[i].shadow_texture_size[0] = shadowmask_size[0];
+			scene_state.lightmaps[i].shadow_texture_size[1] = shadowmask_size[1];
+		}
+
+		scene_state.lightmaps[i].flags = shadowmask_mode;
 
 		// Exposure.
 		scene_state.lightmaps[i].exposure_normalization = 1.0;
-		scene_state.lightmaps[i].flags = light_storage->lightmap_get_shadowmask_mode(lightmap);
 		if (p_render_data->camera_attributes.is_valid()) {
 			float baked_exposure = light_storage->lightmap_get_baked_exposure_normalization(lightmap);
 			float enf = RSG::camera_attributes->camera_attributes_get_exposure_normalization_factor(p_render_data->camera_attributes);

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -243,9 +243,11 @@ private:
 
 	struct LightmapData {
 		float normal_xform[12];
-		float texture_size[2];
+		uint32_t light_texture_size[2];
+		uint32_t shadow_texture_size[2];
 		float exposure_normalization;
 		uint32_t flags;
+		uint32_t padding[2];
 	};
 
 	struct LightmapCaptureData {

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -655,12 +655,22 @@ void RenderForwardMobile::_setup_lightmaps(const RenderDataRD *p_render_data, co
 
 		// Light texture size.
 		Vector2i lightmap_size = light_storage->lightmap_get_light_texture_size(lightmap);
-		scene_state.lightmaps[i].texture_size[0] = lightmap_size[0];
-		scene_state.lightmaps[i].texture_size[1] = lightmap_size[1];
+		scene_state.lightmaps[i].light_texture_size[0] = lightmap_size[0];
+		scene_state.lightmaps[i].light_texture_size[1] = lightmap_size[1];
+
+		// Shadowmasks.
+		const RS::ShadowmaskMode shadowmask_mode = light_storage->lightmap_get_shadowmask_mode(lightmap);
+		if (shadowmask_mode != RS::SHADOWMASK_MODE_NONE) {
+			// Shadow texture size.
+			Vector2i shadowmask_size = light_storage->lightmap_get_shadow_texture_size(lightmap);
+			scene_state.lightmaps[i].shadow_texture_size[0] = shadowmask_size[0];
+			scene_state.lightmaps[i].shadow_texture_size[1] = shadowmask_size[1];
+		}
+
+		scene_state.lightmaps[i].flags = shadowmask_mode;
 
 		// Exposure.
 		scene_state.lightmaps[i].exposure_normalization = 1.0;
-		scene_state.lightmaps[i].flags = light_storage->lightmap_get_shadowmask_mode(lightmap);
 		if (p_render_data->camera_attributes.is_valid()) {
 			float baked_exposure = light_storage->lightmap_get_baked_exposure_normalization(lightmap);
 			float enf = RSG::camera_attributes->camera_attributes_get_exposure_normalization_factor(p_render_data->camera_attributes);

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -178,9 +178,11 @@ private:
 
 	struct LightmapData {
 		float normal_xform[12];
-		float texture_size[2];
+		uint32_t light_texture_size[2];
+		uint32_t shadow_texture_size[2];
 		float exposure_normalization;
 		uint32_t flags;
+		uint32_t padding[2];
 	};
 
 	struct LightmapCaptureData {

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -2048,7 +2048,7 @@ void fragment_shader(in SceneData scene_data) {
 				const vec3 uvw = vec3(scaled_uv, float(slice));
 
 				if (sc_use_lightmap_bicubic_filter()) {
-					shadowmask = textureArray_bicubic(lightmap_textures[MAX_LIGHTMAP_TEXTURES + ofs], uvw, lightmaps.data[ofs].light_texture_size).x;
+					shadowmask = textureArray_bicubic(lightmap_textures[MAX_LIGHTMAP_TEXTURES + ofs], uvw, lightmaps.data[ofs].shadow_texture_size).x;
 				} else {
 					shadowmask = textureLod(sampler2DArray(lightmap_textures[MAX_LIGHTMAP_TEXTURES + ofs], SAMPLER_LINEAR_CLAMP), uvw, 0.0).x;
 				}

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -207,7 +207,8 @@ directional_lights;
 
 struct Lightmap {
 	mat3 normal_xform;
-	vec2 light_texture_size;
+	uvec2 light_texture_size;
+	uvec2 shadow_texture_size;
 	float exposure_normalization;
 	uint flags;
 };

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1507,7 +1507,7 @@ void main() {
 				const vec3 uvw = vec3(scaled_uv, float(slice));
 
 				if (sc_use_lightmap_bicubic_filter()) {
-					shadowmask = textureArray_bicubic(lightmap_textures[MAX_LIGHTMAP_TEXTURES + ofs], uvw, lightmaps.data[ofs].light_texture_size).x;
+					shadowmask = textureArray_bicubic(lightmap_textures[MAX_LIGHTMAP_TEXTURES + ofs], uvw, lightmaps.data[ofs].shadow_texture_size).x;
 				} else {
 					shadowmask = textureLod(sampler2DArray(lightmap_textures[MAX_LIGHTMAP_TEXTURES + ofs], SAMPLER_LINEAR_CLAMP), uvw, 0.0).x;
 				}

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
@@ -253,7 +253,8 @@ directional_lights;
 
 struct Lightmap {
 	mediump mat3 normal_xform;
-	vec2 light_texture_size;
+	uvec2 light_texture_size;
+	uvec2 shadow_texture_size;
 	float exposure_normalization;
 	uint flags;
 };

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -2055,6 +2055,7 @@ void LightStorage::lightmap_set_shadowmask_textures(RID p_lightmap, RID p_shadow
 	}
 
 	t->lightmap_users.insert(p_lightmap);
+	lm->shadow_texture_size = Vector2i(t->width, t->height);
 
 	if (lm->array_index < 0) {
 		// Not in array, try to put in array.

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -340,6 +340,7 @@ private:
 		AABB bounds = AABB(Vector3(), Vector3(1, 1, 1));
 		float baked_exposure = 1.0;
 		Vector2i light_texture_size;
+		Vector2i shadow_texture_size;
 		int32_t array_index = -1; //unassigned
 		PackedVector3Array points;
 		PackedColorArray point_sh;
@@ -1025,6 +1026,10 @@ public:
 	_FORCE_INLINE_ Vector2i lightmap_get_light_texture_size(RID p_lightmap) const {
 		const Lightmap *lm = lightmap_owner.get_or_null(p_lightmap);
 		return lm->light_texture_size;
+	}
+	_FORCE_INLINE_ Vector2i lightmap_get_shadow_texture_size(RID p_lightmap) const {
+		const Lightmap *lm = lightmap_owner.get_or_null(p_lightmap);
+		return lm->shadow_texture_size;
 	}
 	_FORCE_INLINE_ uint64_t lightmap_array_get_version() const {
 		ERR_FAIL_COND_V(!using_lightmap_array, 0); //only for arrays


### PR DESCRIPTION
This makes it possible to have a LightmapGI node with lightmap and shadowmask textures baked at different resolutions. Since shadowmasks usually require a higher texel density than lightmaps, scaling them independently can reduce the VRAM usage at a minimal quality cost.

Note: This PR doesn't allow baking the textures at different resolutions yet, it just makes them work with bicubic filtering