### PR TITLE
Deprecate `PackedStringArray.to_byte_array()`

### DIFF
--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -190,7 +190,7 @@
 				Sorts the elements of the array in ascending order.
 			</description>
 		</method>
-		<method name="to_byte_array" qualifiers="const">
+		<method name="to_byte_array" qualifiers="const" deprecated="This method returns a byte representation of the internal pointers used to manage the strings in PackedStringArray, rather than the string data itself. It likely has no practical use in projects.">
 			<return type="PackedByteArray" />
 			<description>
 				Returns a [PackedByteArray] with each string encoded as bytes.


### PR DESCRIPTION
This method returns a byte representation of the internal pointers used to manage the strings in PackedStringArray, rather than the string data itself. It likely has no practical use in projects and was accidentally exposed at some point during 4.0's development.

Since we can't remove it to avoid breaking compatibility, we deprecate it instead.

- This closes https://github.com/godotengine/godot/issues/66526.