### PR TITLE
Improve UID file creation condition

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1196,6 +1196,20 @@ bool ResourceLoader::has_custom_uid_support(const String &p_path) {
 	return false;
 }
 
+bool ResourceLoader::should_create_uid_file(const String &p_path) {
+	const String local_path = _validate_local_path(p_path);
+	if (FileAccess::exists(local_path + ".uid")) {
+		return false;
+	}
+
+	for (int i = 0; i < loader_count; i++) {
+		if (loader[i]->recognize_path(local_path)) {
+			return !loader[i]->has_custom_uid_support();
+		}
+	}
+	return false;
+}
+
 String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_remapped) {
 	String new_path = p_path;
 

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -246,6 +246,7 @@ public:
 	static String get_resource_script_class(const String &p_path);
 	static ResourceUID::ID get_resource_uid(const String &p_path);
 	static bool has_custom_uid_support(const String &p_path);
+	static bool should_create_uid_file(const String &p_path);
 	static void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false);
 	static Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map);
 	static bool is_import_valid(const String &p_path);

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1263,7 +1263,7 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 				}
 			}
 
-			if (ResourceLoader::exists(path) && !ResourceLoader::has_custom_uid_support(path) && !FileAccess::exists(path + ".uid")) {
+			if (ResourceLoader::should_create_uid_file(path)) {
 				// Create a UID file and new UID, if it's invalid.
 				Ref<FileAccess> f = FileAccess::open(path + ".uid", FileAccess::WRITE);
 				if (f.is_valid()) {
@@ -2345,7 +2345,7 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 
 				ResourceUID::get_singleton()->update_cache();
 			} else {
-				if (ResourceLoader::exists(file) && !ResourceLoader::has_custom_uid_support(file) && !FileAccess::exists(file + ".uid")) {
+				if (ResourceLoader::should_create_uid_file(file)) {
 					Ref<FileAccess> f = FileAccess::open(file + ".uid", FileAccess::WRITE);
 					if (f.is_valid()) {
 						const ResourceUID::ID id = ResourceUID::get_singleton()->create_id();


### PR DESCRIPTION
Fixes #102465

The original code used `ResourceLoader::exists` and then `ResourceLoader::has_custom_uid_support`, which means it traversed all loaders twice to check whether the file is recognized and can generate .uid file. I added a new method that does it within a single loop and prevents creating .uid file if no loader recognized the resource.