### PR TITLE
Fix regression in moving resources in filesystem dock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1488,11 +1488,6 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 						break;
 					}
 				}
-			} else {
-				Ref<Resource> res = ResourceCache::get_ref(old_path);
-				if (res.is_valid()) {
-					res->set_path_cache(new_path);
-				}
 			}
 		}
 


### PR DESCRIPTION
This code was introduced in  #101616, but it breaks moving of resources, since it disallows the logic in `__update_resource_paths_after_move()`.

[test_proj.zip](https://github.com/user-attachments/files/18693756/test_proj.zip)

To reproduce the issue, open the scene and the script, then move the script twice, in and out of the additional dir. Errors will appear and the script will be detached on the second move.