### PR TITLE
JavaClassWrapper: Give additional error when trying to call non-static method directly on the class

### DIFF
--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -156,6 +156,9 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 	}
 
 	if (!method) {
+		if (r_error.error == Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL) {
+			ERR_PRINT(vformat(R"(Cannot call static function "%s" on Java class "%s" directly. Make an instance instead.)", p_method, java_class_name));
+		}
 		return true; //no version convinces
 	}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/102019

I'm not sure this is the right fix.

`JavaClass` is still returning `CALL_ERROR_INSTANCE_IS_NULL` when a developer tries to call a non-static method directly on the class, which means the GDScript VM will still show its not-very-helpful message. But this adds an additional error giving more helpful information.

I went this way because the other `CALL_ERROR_*` values aren't any more appropriate to this situation. We could do `CALL_ERROR_INVALID_METHOD`, but that has the same confusion as on the issue, where the developer listed the methods, and saw that this one exists, but they can't call it on the class. And looking at other places where Godot uses `CALL_ERROR_INSTANCE_IS_NULL`, it really seems like the most appropriate error.

Another option would be to modify the GDScript VM's message to say something about non-static methods, but that would be kinda weird because GDScript itself can detect that you're calling a non-static method in the parser, before it even gets to the VM, so this can't come up with pure GDScript or native classes. So, I don't know that it makes sense to change that?

I'd love feedback on if doing it this way makes sense, or if we should do one of the alternatives.