### PR TITLE
Fix rendering material when UV2 is compressed

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -713,7 +713,14 @@ void main() {
 #endif
 
 #ifdef RENDER_MATERIAL
-	gl_Position.xy = (uv2_attrib.xy + uv_offset) * 2.0 - 1.0;
+	vec2 uv_dest_attrib;
+	if (uv_scale != vec4(0.0)) {
+		uv_dest_attrib = (uv2_attrib.xy - 0.5) * uv_scale.zw;
+	} else {
+		uv_dest_attrib = uv2_attrib.xy;
+	}
+
+	gl_Position.xy = (uv_dest_attrib + uv_offset) * 2.0 - 1.0;
 	gl_Position.z = 0.00001;
 	gl_Position.w = 1.0;
 #endif

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -652,8 +652,15 @@ void vertex_shader(vec3 vertex_input,
 #endif
 #ifdef MODE_RENDER_MATERIAL
 	if (scene_data.material_uv2_mode) {
+		vec2 uv_dest_attrib;
+		if (uv_scale != vec4(0.0)) {
+			uv_dest_attrib = (uv2_attrib.xy - 0.5) * uv_scale.zw;
+		} else {
+			uv_dest_attrib = uv2_attrib.xy;
+		}
+
 		vec2 uv_offset = unpackHalf2x16(draw_call.uv_offset);
-		gl_Position.xy = (uv2_attrib.xy + uv_offset) * 2.0 - 1.0;
+		gl_Position.xy = (uv_dest_attrib + uv_offset) * 2.0 - 1.0;
 		gl_Position.z = 0.00001;
 		gl_Position.w = 1.0;
 	}

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -557,7 +557,14 @@ void main() {
 #endif // MODE_RENDER_DEPTH
 #ifdef MODE_RENDER_MATERIAL
 	if (scene_data.material_uv2_mode) {
-		gl_Position.xy = (uv2_attrib.xy + draw_call.uv_offset) * 2.0 - 1.0;
+		vec2 uv_dest_attrib;
+		if (uv_scale != vec4(0.0)) {
+			uv_dest_attrib = (uv2_attrib.xy - 0.5) * uv_scale.zw;
+		} else {
+			uv_dest_attrib = uv2_attrib.xy;
+		}
+
+		gl_Position.xy = (uv_dest_attrib + draw_call.uv_offset) * 2.0 - 1.0;
 		gl_Position.z = 0.00001;
 		gl_Position.w = 1.0;
 	}


### PR DESCRIPTION
Fixes #102164

The `RENDER_MATERIAL` shader mode didn't account for compressed UV2 data that had been packed into the UNORM16 0.0-1.0 range.