### PR TITLE
Ensure instance uniforms are freed by updating dirty items before freeing

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -2605,8 +2605,8 @@ bool RendererCanvasCull::free(RID p_rid) {
 		}
 
 		canvas_item_set_material(canvas_item->self, RID());
-		canvas_item->instance_uniforms.free(canvas_item->self);
 		update_dirty_items();
+		canvas_item->instance_uniforms.free(canvas_item->self);
 
 		if (canvas_item->canvas_group != nullptr) {
 			memdelete(canvas_item->canvas_group);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/101663

`update_dirty_items()` goes through the list of canvas items that have instance uniforms that have changed and updates/allocates them as needed. By default it always allocates space if the canvas item hasn't had instance uniforms allocated. Therefore, immediately after freeing the instance uniform we were re-allocating it and then freeing the canvas item and leaking that memory. 

This PR fixes the issue by ensuring all the dirty items are updated before freeing. 

Targeting 4.4 since this is a serious problem with the new 2D instance uniform system. 