### PR TITLE
Fix error when embedded popup is closed while resizing

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -317,7 +317,13 @@ void Viewport::_sub_window_register(Window *p_window) {
 
 void Viewport::_sub_window_update(Window *p_window) {
 	int index = _sub_window_find(p_window);
-	ERR_FAIL_COND(index == -1);
+
+	// _sub_window_update is sometimes called deferred, and the window may have been closed since then.
+	// For example, when the user resizes the game window.
+	// In that case, _sub_window_find will not find it, which is expected.
+	if (index == -1) {
+		return;
+	}
 
 	SubWindow &sw = gui.sub_windows.write[index];
 	sw.pending_window_update = false;


### PR DESCRIPTION
- Fixes #100613
- Fixes #102357

When resizing the game window, Godot closes the embedded popup window. The `print error` was triggered because on resize, the `_sub_window_update` is called deferred, but when it is executed, the window was already closed.

Replacing the `ERR_FAIL_COND` by a simple check fixed the issue.

Tested with or without the Floating Window, on Linux and Windows.

Note 1: I was able to reproduce the issue with the MRP from #100613 on Windows only and without the Floating Window.
Note 2: I was able to reproduce the issue with the MRP from #102357 on Linux only and with the Floating Window.


