### PR TITLE
Add basic descriptions to the BreadcrumbMarker enum

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -2580,30 +2580,43 @@
 			Returned by functions that return a format ID if a value is invalid.
 		</constant>
 		<constant name="NONE" value="0" enum="BreadcrumbMarker">
+			No breadcrumb marker will be added.
 		</constant>
 		<constant name="REFLECTION_PROBES" value="65536" enum="BreadcrumbMarker">
+			During a GPU crash in dev or debug mode, Godot's error message will include [code]"REFLECTION_PROBES"[/code] for added context as to when the crash occurred.
 		</constant>
 		<constant name="SKY_PASS" value="131072" enum="BreadcrumbMarker">
+			During a GPU crash in dev or debug mode, Godot's error message will include [code]"SKY_PASS"[/code] for added context as to when the crash occurred.
 		</constant>
 		<constant name="LIGHTMAPPER_PASS" value="196608" enum="BreadcrumbMarker">
+			During a GPU crash in dev or debug mode, Godot's error message will include [code]"LIGHTMAPPER_PASS"[/code] for added context as to when the crash occurred.
 		</constant>
 		<constant name="SHADOW_PASS_DIRECTIONAL" value="262144" enum="BreadcrumbMarker">
+			During a GPU crash in dev or debug mode, Godot's error message will include [code]"SHADOW_PASS_DIRECTIONAL"[/code] for added context as to when the crash occurred.
 		</constant>
 		<constant name="SHADOW_PASS_CUBE" value="327680" enum="BreadcrumbMarker">
+			During a GPU crash in dev or debug mode, Godot's error message will include [code]"SHADOW_PASS_CUBE"[/code] for added context as to when the crash occurred.
 		</constant>
 		<constant name="OPAQUE_PASS" value="393216" enum="BreadcrumbMarker">
+			During a GPU crash in dev or debug mode, Godot's error message will include [code]"OPAQUE_PASS"[/code] for added context as to when the crash occurred.
 		</constant>
 		<constant name="ALPHA_PASS" value="458752" enum="BreadcrumbMarker">
+			During a GPU crash in dev or debug mode, Godot's error message will include [code]"ALPHA_PASS"[/code] for added context as to when the crash occurred.
 		</constant>
 		<constant name="TRANSPARENT_PASS" value="524288" enum="BreadcrumbMarker">
+			During a GPU crash in dev or debug mode, Godot's error message will include [code]"TRANSPARENT_PASS"[/code] for added context as to when the crash occurred.
 		</constant>
 		<constant name="POST_PROCESSING_PASS" value="589824" enum="BreadcrumbMarker">
+			During a GPU crash in dev or debug mode, Godot's error message will include [code]"POST_PROCESSING_PASS"[/code] for added context as to when the crash occurred.
 		</constant>
 		<constant name="BLIT_PASS" value="655360" enum="BreadcrumbMarker">
+			During a GPU crash in dev or debug mode, Godot's error message will include [code]"BLIT_PASS"[/code] for added context as to when the crash occurred.
 		</constant>
 		<constant name="UI_PASS" value="720896" enum="BreadcrumbMarker">
+			During a GPU crash in dev or debug mode, Godot's error message will include [code]"UI_PASS"[/code] for added context as to when the crash occurred.
 		</constant>
 		<constant name="DEBUG_PASS" value="786432" enum="BreadcrumbMarker">
+			During a GPU crash in dev or debug mode, Godot's error message will include [code]"DEBUG_PASS"[/code] for added context as to when the crash occurred.
 		</constant>
 		<constant name="DRAW_DEFAULT_ALL" value="0" enum="DrawFlags" is_bitfield="true">
 			Do not clear or ignore any attachments.


### PR DESCRIPTION
This adds basic descriptions to all of the default BreadcrumbMarkers. These descriptions overlap a lot with the new description of draw_list_begin, but I figure they make it a little more clear what the point of the enum is.