### PR TITLE
Fix `PackedStringArray.to_byte_array()` to return UTF-8 encoded data instead of pointers.

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1034,6 +1034,18 @@ struct _VariantCall {
 		return len;
 	}
 
+	static PackedByteArray func_PackedStringArray_to_byte_array(PackedStringArray *p_instance) {
+		PackedByteArray ret;
+		uint64_t size = p_instance->size();
+		const String *r = p_instance->ptr();
+
+		for (uint64_t i = 0; i < size; i++) {
+			ret.append_array(r[i].to_utf8_buffer());
+			ret.append(0);
+		}
+		return ret;
+	}
+
 	static void func_Callable_call(Variant *v, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
 		Callable *callable = VariantGetInternalPtr<Callable>::get_ptr(v);
 		callable->callp(p_args, p_argcount, r_ret, r_error);
@@ -2577,7 +2589,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedStringArray, has, sarray("value"), varray());
 	bind_method(PackedStringArray, reverse, sarray(), varray());
 	bind_method(PackedStringArray, slice, sarray("begin", "end"), varray(INT_MAX));
-	bind_method(PackedStringArray, to_byte_array, sarray(), varray());
+	bind_function(PackedStringArray, to_byte_array, _VariantCall::func_PackedStringArray_to_byte_array, sarray(), varray());
 	bind_method(PackedStringArray, sort, sarray(), varray());
 	bind_method(PackedStringArray, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedStringArray, duplicate, sarray(), varray());

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -193,7 +193,7 @@
 		<method name="to_byte_array" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>
-				Returns a [PackedByteArray] with each string encoded as bytes.
+				Returns a [PackedByteArray] with each string encoded as UTF-8. Strings are [code]null[/code] terminated.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/66526
Alternative to https://github.com/godotengine/godot/pull/102486

Adds `to_byte_array` override to return UTF-8 null terminated strings:
```gdscript
var arr : PackedStringArray = [ "Test", "String "]
print(arr.to_byte_array()) # prints [84, 101, 115, 116, 0, 83, 116, 114, 105, 110, 103, 32, 0]
```