### PR TITLE
Add user annotations

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1956,6 +1956,7 @@ CodeTextEditor::CodeTextEditor() {
 	cs.push_back("=");
 	cs.push_back("$");
 	cs.push_back("@");
+	cs.push_back("@@");
 	cs.push_back("\"");
 	cs.push_back("\'");
 	text_editor->set_code_completion_prefixes(cs);

--- a/modules/gdscript/config.py
+++ b/modules/gdscript/config.py
@@ -11,7 +11,12 @@ def get_doc_classes():
     return [
         "@GDScript",
         "GDScript",
+        "GDScriptAnnotation",
+        "GDScriptClassAnnotation",
+        "GDScriptFunctionAnnotation",
+        "GDScriptSignalAnnotation",
         "GDScriptSyntaxHighlighter",
+        "GDScriptVariableAnnotation",
     ]
 
 

--- a/modules/gdscript/doc_classes/GDScript.xml
+++ b/modules/gdscript/doc_classes/GDScript.xml
@@ -12,6 +12,25 @@
 		<link title="GDScript documentation index">$DOCS_URL/tutorials/scripting/gdscript/index.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_class_annotations" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns all [GDScriptAnnotation]s targeting the top-level class of this script.
+			</description>
+		</method>
+		<method name="get_member_annotations" qualifiers="const">
+			<return type="Array" />
+			<param index="0" name="member" type="StringName" />
+			<description>
+				Returns all [GDScriptAnnotation]s targeting [param member].
+			</description>
+		</method>
+		<method name="get_members_with_annotations" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns all members of this script that is targeted by at least one [GDScriptAnnotation].
+			</description>
+		</method>
 		<method name="new" qualifiers="vararg">
 			<return type="Variant" />
 			<description>

--- a/modules/gdscript/doc_classes/GDScriptAnnotation.xml
+++ b/modules/gdscript/doc_classes/GDScriptAnnotation.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDScriptAnnotation" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A user annotation implemented in the GDScript language.
+	</brief_description>
+	<description>
+		A user annotation implemented in the GDScript language. User annotations are metadata that can be associated with a GDScript.
+		You can create a new GDScriptAnnotation by extending GDScriptAnnotation's subclasses, such as [GDScriptVariableAnnotation] and [GDScriptFunctionAnnotation].
+		User annotations must have a class name, cannot be a nested class, and must define the constructor [code]_init[/code], which defines the annotation's parameters.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_name" qualifiers="const">
+			<return type="StringName" />
+			<description>
+				Returns the annotation's name, which is equal to the class name.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="error_message" type="String" setter="set_error_message" getter="get_error_message">
+			The annotation's current error message. Setting this to a non-empty value when the annotation is being compiled will cause the GDScript parser to emit an error.
+		</member>
+	</members>
+</class>

--- a/modules/gdscript/doc_classes/GDScriptClassAnnotation.xml
+++ b/modules/gdscript/doc_classes/GDScriptClassAnnotation.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDScriptClassAnnotation" inherits="GDScriptAnnotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A user annotation that can only target classes.
+	</brief_description>
+	<description>
+		A user annotation that can only target classes.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_analyze" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Override to access the targeted class's information.
+				- [param name] is the class's name.
+			</description>
+		</method>
+		<method name="_get_allow_multiple" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Override to specify if there can be multiple instances of this annotation on the same target. If not overridden, the default is [code]false[/code].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/gdscript/doc_classes/GDScriptFunctionAnnotation.xml
+++ b/modules/gdscript/doc_classes/GDScriptFunctionAnnotation.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDScriptFunctionAnnotation" inherits="GDScriptAnnotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A user annotation that can only target functions.
+	</brief_description>
+	<description>
+		A user annotation that can only target functions.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_analyze" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="parameter_names" type="PackedStringArray" />
+			<param index="2" name="parameter_type_names" type="PackedStringArray" />
+			<param index="3" name="parameter_builtin_types" type="PackedInt32Array" />
+			<param index="4" name="return_type_name" type="StringName" />
+			<param index="5" name="return_builtin_type" type="int" enum="Variant.Type" />
+			<param index="6" name="default_arguments" type="Array" />
+			<param index="7" name="is_static" type="bool" />
+			<param index="8" name="is_coroutine" type="bool" />
+			<description>
+				Override to access the targeted function's information. This can be used for validation, for example requiring the function to have a specific signature.
+				- [param name] is the function's name;
+				- [param parameter_names] is an array containing every parameter's name.
+				- [param parameter_type_names] is an array containing every parameter's type name.
+				- [param parameter_builtin_types] is an array containing every parameter's type, as an [int] (see [enum Variant.Type]);
+				- [param return_type_name] is the return type's type name;
+				- [param return_builtin_type] is the return type, as an [int] (see [enum Variant.Type]);
+				- [param default_arguments] is an array containing default arguments for the function;
+				- [param is_static] is whether the function is static or not;
+				- [param is_coroutine] is whether the function is a coroutine or not.
+			</description>
+		</method>
+		<method name="_get_allow_multiple" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Override to specify if there can be multiple instances of this annotation on the same target. If not overridden, the default is [code]false[/code].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/gdscript/doc_classes/GDScriptSignalAnnotation.xml
+++ b/modules/gdscript/doc_classes/GDScriptSignalAnnotation.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDScriptSignalAnnotation" inherits="GDScriptAnnotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A user annotation that can only target signals.
+	</brief_description>
+	<description>
+		A user annotation that can only target signals.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_analyze" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="parameter_names" type="PackedStringArray" />
+			<param index="2" name="parameter_type_names" type="PackedStringArray" />
+			<param index="3" name="parameter_builtin_types" type="PackedInt32Array" />
+			<description>
+				Override to access the targeted signal's information. This can be used for validation, for example requiring the signal to have a specific signature.
+				- [param name] is the signal's name;
+				- [param parameter_names] is an array containing every parameter's name.
+				- [param parameter_type_names] is an array containing every parameter's type name.
+				- [param parameter_builtin_types] is an array containing every parameter's type, as an [int] (see [enum Variant.Type]).
+			</description>
+		</method>
+		<method name="_get_allow_multiple" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Override to specify if there can be multiple instances of this annotation on the same target. If not overridden, the default is [code]false[/code].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/gdscript/doc_classes/GDScriptVariableAnnotation.xml
+++ b/modules/gdscript/doc_classes/GDScriptVariableAnnotation.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDScriptVariableAnnotation" inherits="GDScriptAnnotation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A user annotation that can only target variables.
+	</brief_description>
+	<description>
+		A user annotation that can only target variables. By overriding [method _is_export_annotation], this annotation can also act as an export annotation like [annotation @GDScript.@export_custom].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_analyze" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="type_name" type="StringName" />
+			<param index="2" name="type" type="int" enum="Variant.Type" />
+			<param index="3" name="is_static" type="bool" />
+			<description>
+				Override to access the targeted variable's information. This can be used for validation, for example requiring the variable to be a certain type.
+				- [param name] is the variable's name;
+				- [param type_name] is the variable's type name;
+				- [param type] is the variable's type, as an [int] (see [enum Variant.Type]);
+				- [param is_static] is whether the variable is static or not.
+			</description>
+		</method>
+		<method name="_get_allow_multiple" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Override to specify if there can be multiple instances of this annotation on the same target. If not overridden, the default is [code]false[/code].
+			</description>
+		</method>
+		<method name="_get_property_hint" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+				Override to specify the annotation's property hint. If not overridden, the default is [constant PROPERTY_HINT_NONE].
+			</description>
+		</method>
+		<method name="_get_property_hint_string" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+				Override to specify the annotation's property hint string. If not overridden, the default is an empty string.
+			</description>
+		</method>
+		<method name="_get_property_usage" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+				Override to specify the annotation's property usage. If not overridden, the default is [constant PROPERTY_USAGE_DEFAULT].
+			</description>
+		</method>
+		<method name="_is_export_annotation" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Override to specify if the annotation should be treated as an export annotation. If not overridden, the default is [code]false[/code].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -57,6 +57,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 	bool in_node_path = false;
 	bool in_node_ref = false;
 	bool in_annotation = false;
+	bool in_user_annotation = false;
 	bool in_string_name = false;
 	bool is_hex_notation = false;
 	bool is_bin_notation = false;
@@ -593,8 +594,11 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 
 		if (!in_annotation && in_region == -1 && str[j] == '@') {
 			in_annotation = true;
+		} else if (in_annotation && in_region == -1 && str[j] == '@') {
+			in_user_annotation = true;
 		} else if (in_region != -1 || is_a_symbol) {
 			in_annotation = false;
+			in_user_annotation = false;
 		}
 
 		const bool in_raw_string_prefix = in_region == -1 && str[j] == 'r' && j + 1 < line_length && (str[j + 1] == '"' || str[j + 1] == '\'');
@@ -604,7 +608,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 		} else if (in_node_ref) {
 			next_type = NODE_REF;
 			color = node_ref_color;
-		} else if (in_annotation) {
+		} else if (in_annotation || in_user_annotation) {
 			next_type = ANNOTATION;
 			color = annotation_color;
 		} else if (in_string_name) {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -110,6 +110,9 @@ class GDScript : public Script {
 	HashMap<StringName, MethodInfo> _signals;
 	Dictionary rpc_config;
 
+	Array class_annotations;
+	HashMap<StringName, Array> member_annotations;
+
 public:
 	struct LambdaInfo {
 		int capture_count;
@@ -194,7 +197,7 @@ private:
 
 	GDScriptFunction *_super_constructor(GDScript *p_script);
 	void _super_implicit_constructor(GDScript *p_script, GDScriptInstance *p_instance, Callable::CallError &r_error);
-	GDScriptInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_is_ref_counted, Callable::CallError &r_error);
+	GDScriptInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_is_ref_counted, Callable::CallError &r_error, bool p_show_error = true);
 
 	String _get_debug_path() const;
 
@@ -286,6 +289,7 @@ public:
 	StringName debug_get_static_var_by_index(int p_idx) const;
 
 	Variant _new(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
+	Variant _new_internal(const Variant **p_args, int p_argcount, Callable::CallError &r_error, bool p_show_error);
 	virtual bool can_instantiate() const override;
 
 	virtual Ref<Script> get_base_script() const override;
@@ -342,6 +346,18 @@ public:
 
 	virtual void get_constants(HashMap<StringName, Variant> *p_constants) override;
 	virtual void get_members(HashSet<StringName> *p_members) override;
+	PackedStringArray get_members_with_annotations() const {
+		PackedStringArray arr;
+		for (const KeyValue<StringName, Array> &E : member_annotations) {
+			arr.push_back(E.key);
+		}
+		return arr;
+	}
+	Array get_member_annotations(const StringName &p_member) const {
+		const Array *ret = member_annotations.getptr(p_member);
+		return ret ? *ret : Array();
+	}
+	Array get_class_annotations() const { return class_annotations; }
 
 	virtual Variant get_rpc_config() const override;
 

--- a/modules/gdscript/gdscript_annotation.cpp
+++ b/modules/gdscript/gdscript_annotation.cpp
@@ -1,0 +1,85 @@
+/**************************************************************************/
+/*  gdscript_annotation.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdscript_annotation.h"
+#include "core/object/script_language.h"
+#include "gdscript.h"
+
+void GDScriptAnnotation::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_name"), &GDScriptAnnotation::get_name);
+
+	ClassDB::bind_method(D_METHOD("set_error_message", "error_message"), &GDScriptAnnotation::set_error_message);
+	ClassDB::bind_method(D_METHOD("get_error_message"), &GDScriptAnnotation::get_error_message);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "error_message"), "set_error_message", "get_error_message");
+}
+
+StringName GDScriptAnnotation::get_name() const {
+	return name;
+}
+
+void GDScriptAnnotation::set_error_message(const String &p_error_message) {
+	error_message = p_error_message;
+}
+
+String GDScriptAnnotation::get_error_message() const {
+	return error_message;
+}
+
+void GDScriptAnnotation::find_user_annotations(List<MethodInfo> *r_annotations) {
+	List<StringName> global_classes;
+	ScriptServer::get_global_class_list(&global_classes);
+	for (const StringName &global_class : global_classes) {
+		if (ScriptServer::get_global_class_language(global_class) == GDScript::get_class_static()) {
+			if (ClassDB::is_parent_class(ScriptServer::get_global_class_native_base(global_class), get_class_static())) {
+				const String path = ScriptServer::get_global_class_path(global_class);
+				Ref<GDScript> script = ResourceLoader::load(path, GDScript::get_class_static());
+				if (script->has_method("_init")) {
+					MethodInfo mi = script->get_method_info("_init");
+					mi.name = "@@" + global_class;
+					r_annotations->push_back(mi);
+				}
+			}
+		}
+	}
+}
+
+void GDScriptAnnotation::find_native_user_annotations(List<MethodInfo> *r_annotations) {
+	List<StringName> annotation_classes;
+	ClassDB::get_inheriters_from_class(get_class_static(), &annotation_classes);
+	for (const StringName &annotation_class : annotation_classes) {
+		if (!ClassDB::is_abstract(annotation_class) && !ClassDB::is_virtual(annotation_class)) {
+			MethodInfo mi;
+			if (ClassDB::get_method_info(annotation_class, GDScriptLanguage::get_singleton()->strings._init, &mi)) {
+				mi.name = "@@" + annotation_class;
+				r_annotations->push_back(mi);
+			}
+		}
+	}
+}

--- a/modules/gdscript/gdscript_annotation.h
+++ b/modules/gdscript/gdscript_annotation.h
@@ -1,0 +1,87 @@
+/**************************************************************************/
+/*  gdscript_annotation.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef GDSCRIPT_ANNOTATION_H
+#define GDSCRIPT_ANNOTATION_H
+
+#include "core/object/gdvirtual.gen.inc"
+#include "core/object/ref_counted.h"
+
+class GDScriptAnnotation : public RefCounted {
+	GDCLASS(GDScriptAnnotation, RefCounted);
+
+	friend class GDScriptAnalyzer;
+
+public:
+	enum TargetFlags : int {
+		TARGET_NONE = 0,
+		TARGET_VARIABLE = 1 << 0,
+		TARGET_FUNCTION = 1 << 1,
+		TARGET_SIGNAL = 1 << 2,
+		TARGET_CLASS = 1 << 3,
+	};
+
+protected:
+	StringName name;
+	String error_message;
+
+	static void _bind_methods();
+
+public:
+	StringName get_name() const;
+
+	void set_error_message(const String &p_error_message);
+	String get_error_message() const;
+	_FORCE_INLINE_ bool has_error_message() const { return !error_message.is_empty(); }
+
+	virtual TargetFlags get_target_mask() = 0;
+
+	virtual bool get_allow_multiple() = 0;
+
+	static _FORCE_INLINE_ constexpr const char *target_to_name(TargetFlags p_target) {
+		switch (p_target) {
+			case TARGET_VARIABLE:
+				return "Variable";
+			case TARGET_FUNCTION:
+				return "Function";
+			case TARGET_SIGNAL:
+				return "Signal";
+			case TARGET_CLASS:
+				return "Class";
+			default:
+				return "Unknown";
+		}
+	}
+
+	static void find_user_annotations(List<MethodInfo> *r_annotations);
+	static void find_native_user_annotations(List<MethodInfo> *r_annotations);
+};
+
+#endif // GDSCRIPT_ANNOTATION_H

--- a/modules/gdscript/gdscript_member_annotations.cpp
+++ b/modules/gdscript/gdscript_member_annotations.cpp
@@ -1,0 +1,79 @@
+/**************************************************************************/
+/*  gdscript_member_annotations.cpp                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdscript_member_annotations.h"
+
+void GDScriptVariableAnnotation::_bind_methods() {
+	GDVIRTUAL_BIND(_analyze, "name", "type_name", "type", "is_static");
+	GDVIRTUAL_BIND(_get_allow_multiple);
+	GDVIRTUAL_BIND(_is_export_annotation);
+	GDVIRTUAL_BIND(_get_property_hint);
+	GDVIRTUAL_BIND(_get_property_hint_string);
+	GDVIRTUAL_BIND(_get_property_usage);
+}
+
+bool GDScriptVariableAnnotation::apply(GDScriptParser::VariableNode *p_target, GDScriptParser::ClassNode *p_class) {
+	if (is_export_annotation()) {
+		if (p_target->is_static) {
+			error_message = vformat(R"(Annotation "%s" cannot be applied to a static variable.)", name);
+			return false;
+		}
+		if (p_target->exported) {
+			error_message = vformat(R"(Annotation "%s" cannot be used with another export annotation.)", name);
+			return false;
+		}
+
+		p_target->exported = true;
+
+		GDScriptParser::DataType export_type = p_target->get_datatype();
+
+		p_target->export_info.type = export_type.builtin_type;
+		p_target->export_info.hint = get_property_hint();
+		p_target->export_info.hint_string = get_property_hint_string();
+		p_target->export_info.usage = get_property_usage();
+	}
+
+	return true;
+}
+
+void GDScriptFunctionAnnotation::_bind_methods() {
+	GDVIRTUAL_BIND(_analyze, "name", "parameter_names", "parameter_type_names", "parameter_builtin_types", "return_type_name", "return_builtin_type", "default_arguments", "is_static", "is_coroutine");
+	GDVIRTUAL_BIND(_get_allow_multiple);
+}
+
+void GDScriptSignalAnnotation::_bind_methods() {
+	GDVIRTUAL_BIND(_analyze, "name", "parameter_names", "parameter_type_names", "parameter_builtin_types");
+	GDVIRTUAL_BIND(_get_allow_multiple);
+}
+
+void GDScriptClassAnnotation::_bind_methods() {
+	GDVIRTUAL_BIND(_analyze, "name");
+	GDVIRTUAL_BIND(_get_allow_multiple);
+}

--- a/modules/gdscript/gdscript_member_annotations.h
+++ b/modules/gdscript/gdscript_member_annotations.h
@@ -1,0 +1,201 @@
+/**************************************************************************/
+/*  gdscript_member_annotations.h                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef GDSCRIPT_MEMBER_ANNOTATIONS_H
+#define GDSCRIPT_MEMBER_ANNOTATIONS_H
+
+#include "gdscript_annotation.h"
+#include "gdscript_parser.h"
+
+class GDScriptVariableAnnotation : public GDScriptAnnotation {
+	GDCLASS(GDScriptVariableAnnotation, GDScriptAnnotation);
+
+protected:
+	static void _bind_methods();
+
+public:
+	GDVIRTUAL0RC(bool, _get_allow_multiple)
+	virtual bool get_allow_multiple() override final {
+		if (GDVIRTUAL_IS_OVERRIDDEN(_get_allow_multiple)) {
+			bool ret = false;
+			GDVIRTUAL_CALL(_get_allow_multiple, ret);
+			return ret;
+		}
+		return false;
+	}
+
+	virtual TargetFlags get_target_mask() override final {
+		return TARGET_VARIABLE;
+	}
+
+	GDVIRTUAL4(_analyze, StringName, StringName, Variant::Type, bool)
+	virtual void analyze(const StringName &p_name, const StringName &p_type_name, Variant::Type p_builtin_type, bool p_is_static) {
+		if (GDVIRTUAL_IS_OVERRIDDEN(_analyze)) {
+			GDVIRTUAL_CALL(_analyze, p_name, p_type_name, p_builtin_type, p_is_static);
+		}
+	}
+
+	GDVIRTUAL0RC(bool, _is_export_annotation)
+	virtual bool is_export_annotation() const {
+		if (GDVIRTUAL_IS_OVERRIDDEN(_is_export_annotation)) {
+			bool ret = false;
+			GDVIRTUAL_CALL(_is_export_annotation, ret);
+			return ret;
+		} else {
+			return false;
+		}
+	}
+
+	GDVIRTUAL0RC(int, _get_property_hint)
+	virtual PropertyHint get_property_hint() const {
+		if (GDVIRTUAL_IS_OVERRIDDEN(_get_property_hint)) {
+			int ret = PROPERTY_HINT_NONE;
+			GDVIRTUAL_CALL(_get_property_hint, ret);
+			return (PropertyHint)ret;
+		} else {
+			return PROPERTY_HINT_NONE;
+		}
+	}
+
+	GDVIRTUAL0RC(String, _get_property_hint_string)
+	virtual String get_property_hint_string() const {
+		if (GDVIRTUAL_IS_OVERRIDDEN(_get_property_hint_string)) {
+			String ret;
+			GDVIRTUAL_CALL(_get_property_hint_string, ret);
+			return ret;
+		} else {
+			return String();
+		}
+	}
+
+	GDVIRTUAL0RC(int, _get_property_usage)
+	virtual PropertyUsageFlags get_property_usage() const {
+		if (GDVIRTUAL_IS_OVERRIDDEN(_get_property_usage)) {
+			int ret = PROPERTY_USAGE_DEFAULT;
+			GDVIRTUAL_CALL(_get_property_usage, ret);
+			return (PropertyUsageFlags)ret;
+		} else {
+			return PROPERTY_USAGE_DEFAULT;
+		}
+	}
+
+	// Default implementation is roughly equivalent to using @export_custom.
+	// This means no validation is performed on the hint string. The user is responsible for validation in _init.
+	virtual bool apply(GDScriptParser::VariableNode *p_target, GDScriptParser::ClassNode *p_class);
+};
+
+class GDScriptFunctionAnnotation : public GDScriptAnnotation {
+	GDCLASS(GDScriptFunctionAnnotation, GDScriptAnnotation);
+
+protected:
+	static void _bind_methods();
+
+public:
+	GDVIRTUAL0RC(bool, _get_allow_multiple)
+	virtual bool get_allow_multiple() override final {
+		if (GDVIRTUAL_IS_OVERRIDDEN(_get_allow_multiple)) {
+			bool ret = false;
+			GDVIRTUAL_CALL(_get_allow_multiple, ret);
+			return ret;
+		}
+		return false;
+	}
+
+	virtual TargetFlags get_target_mask() override final {
+		return TARGET_FUNCTION;
+	}
+
+	GDVIRTUAL9(_analyze, StringName, PackedStringArray, PackedStringArray, PackedInt32Array, StringName, Variant::Type, Array, bool, bool)
+	virtual void analyze(const StringName &p_name, const PackedStringArray &p_parameter_names, const PackedStringArray &p_parameter_type_names, const PackedInt32Array &p_parameter_builtin_types, const StringName &p_return_type_name, Variant::Type p_return_builtin_type, const Array &p_default_arguments, bool p_is_static, bool p_is_coroutine) {
+		if (GDVIRTUAL_IS_OVERRIDDEN(_analyze)) {
+			GDVIRTUAL_CALL(_analyze, p_name, p_parameter_names, p_parameter_type_names, p_parameter_builtin_types, p_return_type_name, p_return_builtin_type, p_default_arguments, p_is_static, p_is_coroutine);
+		}
+	}
+};
+
+class GDScriptSignalAnnotation : public GDScriptAnnotation {
+	GDCLASS(GDScriptSignalAnnotation, GDScriptAnnotation);
+
+protected:
+	static void _bind_methods();
+
+public:
+	GDVIRTUAL0RC(bool, _get_allow_multiple)
+	virtual bool get_allow_multiple() override final {
+		if (GDVIRTUAL_IS_OVERRIDDEN(_get_allow_multiple)) {
+			bool ret = false;
+			GDVIRTUAL_CALL(_get_allow_multiple, ret);
+			return ret;
+		}
+		return false;
+	}
+
+	virtual TargetFlags get_target_mask() override final {
+		return TARGET_SIGNAL;
+	}
+
+	GDVIRTUAL4(_analyze, StringName, PackedStringArray, PackedStringArray, PackedInt32Array)
+	virtual void analyze(const StringName &p_name, const PackedStringArray &p_parameter_names, const PackedStringArray &p_parameter_type_names, const PackedInt32Array &p_parameter_builtin_types) {
+		if (GDVIRTUAL_IS_OVERRIDDEN(_analyze)) {
+			GDVIRTUAL_CALL(_analyze, p_name, p_parameter_names, p_parameter_type_names, p_parameter_builtin_types);
+		}
+	}
+};
+
+class GDScriptClassAnnotation : public GDScriptAnnotation {
+	GDCLASS(GDScriptClassAnnotation, GDScriptAnnotation);
+
+protected:
+	static void _bind_methods();
+
+public:
+	GDVIRTUAL0RC(bool, _get_allow_multiple)
+	virtual bool get_allow_multiple() override final {
+		if (GDVIRTUAL_IS_OVERRIDDEN(_get_allow_multiple)) {
+			bool ret = false;
+			GDVIRTUAL_CALL(_get_allow_multiple, ret);
+			return ret;
+		}
+		return false;
+	}
+
+	virtual TargetFlags get_target_mask() override final {
+		return TARGET_CLASS;
+	}
+
+	GDVIRTUAL1(_analyze, StringName)
+	virtual void analyze(const StringName &p_name) {
+		if (GDVIRTUAL_IS_OVERRIDDEN(_analyze)) {
+			GDVIRTUAL_CALL(_analyze, p_name);
+		}
+	}
+};
+
+#endif // GDSCRIPT_MEMBER_ANNOTATIONS_H

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -481,9 +481,17 @@ GDScriptTokenizer::Token GDScriptTokenizerText::check_vcs_marker(char32_t p_test
 GDScriptTokenizer::Token GDScriptTokenizerText::annotation() {
 	if (is_unicode_identifier_start(_peek())) {
 		_advance(); // Consume start character.
+	} else if (_peek() == '@') {
+		_advance(); // Consume the second @ in @@ (user annotations).
+		if (is_unicode_identifier_start(_peek())) {
+			_advance(); // Consume start character.
+		} else {
+			push_error("Expected annotation identifier after \"@@\".");
+		}
 	} else {
-		push_error("Expected annotation identifier after \"@\".");
+		push_error("Expected annotation identifier or @ after \"@\".");
 	}
+
 	while (is_unicode_identifier_continue(_peek())) {
 		// Consume all identifier characters.
 		_advance();

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -32,6 +32,7 @@
 
 #include "gdscript.h"
 #include "gdscript_cache.h"
+#include "gdscript_member_annotations.h"
 #include "gdscript_parser.h"
 #include "gdscript_tokenizer_buffer.h"
 #include "gdscript_utility_functions.h"
@@ -153,6 +154,11 @@ void initialize_gdscript_module(ModuleInitializationLevel p_level) {
 		gdscript_cache = memnew(GDScriptCache);
 
 		GDScriptUtilityFunctions::register_functions();
+		GDREGISTER_ABSTRACT_CLASS(GDScriptAnnotation);
+		GDREGISTER_VIRTUAL_CLASS(GDScriptVariableAnnotation);
+		GDREGISTER_VIRTUAL_CLASS(GDScriptFunctionAnnotation);
+		GDREGISTER_VIRTUAL_CLASS(GDScriptSignalAnnotation);
+		GDREGISTER_VIRTUAL_CLASS(GDScriptClassAnnotation);
 	}
 
 #ifdef TOOLS_ENABLED

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -220,6 +220,7 @@ private:
 	float code_completion_pan_offset = 0.0f;
 
 	HashSet<char32_t> code_completion_prefixes;
+	HashSet<uint64_t> code_completion_digraph_prefixes;
 	List<ScriptLanguage::CodeCompletionOption> code_completion_option_submitted;
 	List<ScriptLanguage::CodeCompletionOption> code_completion_option_sources;
 	String code_completion_base;

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -3936,20 +3936,22 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		code_edit->set_code_completion_enabled(true);
 		CHECK(code_edit->is_code_completion_enabled());
 
-		/* Set prefixes, single char only, disallow empty. */
+		/* Set prefixes, single char or double chars (digraphs) only, disallow empty. */
 		TypedArray<String> completion_prefixes;
 		completion_prefixes.push_back("");
 		completion_prefixes.push_back(".");
 		completion_prefixes.push_back(".");
+		completion_prefixes.push_back(",");
 		completion_prefixes.push_back(",,");
 
 		ERR_PRINT_OFF;
 		code_edit->set_code_completion_prefixes(completion_prefixes);
 		ERR_PRINT_ON;
 		completion_prefixes = code_edit->get_code_completion_prefixes();
-		CHECK(completion_prefixes.size() == 2);
+		CHECK(completion_prefixes.size() == 3);
 		CHECK(completion_prefixes.has("."));
 		CHECK(completion_prefixes.has(","));
+		CHECK(completion_prefixes.has(",,"));
 
 		code_edit->set_text("test\ntest");
 		CHECK(code_edit->get_text_for_code_completion() == String::chr(0xFFFF) + "test\ntest");


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
(Update 2025/2/14) This PR has been superceded by a different solution that doesn't actually involve the concept of "custom annotations," and so it has been closed. The author of this PR has chosen not to work on that solution, but you can find the specifications here if you are interested: https://github.com/godotengine/godot/pull/102516#issuecomment-2658985337

<details><summary>Original Post</summary>
<p>

Closes https://github.com/godotengine/godot-proposals/issues/1316

This PR implements user annotations AKA custom annotations, a feature that allows users to define their own annotations with GDScript, for GDScript.

Interacting with user annotation-based custom editor properties:

https://github.com/user-attachments/assets/f75f5b69-c1a9-40cb-80b9-5b6cd511d064

Editor autocomplete for user annotations:

https://github.com/user-attachments/assets/6c503eda-a492-4a51-a676-fe697c141495

User-implemented compile-time validation for user annotations:

https://github.com/user-attachments/assets/fbd9aec8-6771-4230-a023-afd0bb9897f1

You can try out this PR with the project provided here: https://github.com/chocola-mint/GodotDevSandbox/tree/custom-annotations , which demonstrates how user annotations can be used in conjunction with EditorInspectorPlugins to achieve the results above.

Note that the examples are meant to demonstrate *usage* and *capabilities*. The user annotation `@@ToolButton` included here is -mostly- redundant with `@export_tool_button` existing, for example. (Though it does allow you to embed arguments to be bound to the function as a CSV string, and can even check if the string's valid in compile time!)

---

## Specifications
- User annotations are created by extending a non-abstract subclass of `GDScriptAnnotation`, with either GDScript or core C++.
  - The builtin virtual classes `GDScriptVariableAnnotation`, `GDScriptFunctionAnnotation`, `GDScriptSignalAnnotation`, `GDScriptClassAnnotation` can be extended to add annotations that can only target variables, functions, signals, and classes respectively.
  - This is also why the implementation here doesn't come with some kind of `annotation <class name>` syntax sugar. (as suggested in the proposal thread)
- User annotations are defined as metadata associated with some "target" of a GDScript. Currently, class members and classes can all be valid targets, but not expressions, suites (indent blocks), etc.
- User annotations must implement a constructor (`_init`), which defines the annotation's parameters, and cannot be a C++ virtual class.
- User annotations can set the property `error_message` to a non-empty string inside any callback (virtual function) called by the parser. The parser will then format the error message into a parser error message.
  - This means that, for example, `_init` can be used to validate the annotation's arguments as well.
- The builtin `GDScript<type>Annotation` classes come with `_analyze` virtual functions that allow the user to read the target's info and execute logic (including validation) based on it.
  - For example, one could require a variable targeted by an annotation to be of type `Vector2`.
  - Or one could require a function targeted by an annotation to have an exact signature.
- The virtual function `_get_allow_multiple` can be overridden to specify if there can be multiple of an annotation. The default is to disallow multiple annotations.
- User annotations extending `GDScriptVariableAnnotation` can additionally override `_is_export_annotation` to act as an export annotation similar to `@export_custom`. This is mainly for ergonomics, as otherwise for "property drawer" use cases (reasonably common IMO), users would have to write an additional `@export` after their custom annotation every time they want to use it.
  - Implementing the `_get_property_hint`, `_get_property_hint_string`, `_get_property_usage` virtual functions allows the user to specify the `PropertyInfo` parameters. If not implemented, the default behaviour is exactly the same as `@export`.
- User annotations can be used with the `@@` ~~googly eyes~~ prefix. `@@<user annotation class name>`
  - This disambiguates user annotations from the builtin annotations and allow builtin annotations to retain their original purpose of adding keywords without causing name collisions.
  - Appending parentheses after the class name allows the user to specify arguments for the annotation, which is then used to call the annotation's constructor.
  - If there are zero parameters, the parentheses can be omitted.
  - C++ virtual/abstract classes inheriting from `GDScriptAnnotation` cannot be used as a user annotation.
- `GDScript.get_members_with_annotations`, `GDScript.get_member_annotations`, and `GDScript.get_class_annotations` can be used to query user annotations from a `GDScript` resource.

## Some notes
- User annotations are a GDScript-specific concept and is *only* implemented for GDScript.
  - Other languages already have their own annotation-like systems and designing interop over this would be quite a mess. (Not to mention how `CSharpScript::get_public_annotations` isn't even actually implemented at the moment)
- Design is based off C#'s attributes, but with some notable changes:
  - C# has the user directly extend the `System.Attribute` class, and use another built-in attribute `System.AttributeUsage` to specify if the attribute should allow multiples, and what it is allowed to target.
  - Adding a builtin annotation just to serve this one special case (GDScript-extended subclasses of `GDScriptAnnotation`) is not exactly a good idea in my opinion, and would result in an uglier implementation on the parser/analyzer's end.
  - Instead, these are both implemented as virtual functions, but only C++ GDScriptAnnotations can override the `get_target_mask` virtual function.
  - The reasoning behind this is so the `_analyze` virtual function overridden by the user can have a strongly-typed interface. (instead of having to remember how to unpack a `Dictionary` based on the target type)
    - Ideally this should be a single struct, but unfortunately GDScript doesn't support structs (yet) so we'll have to live with the monstrous 9-parameter `GDScriptFunctionAnnotation._analyze`.
- In order to support the `@@` syntax, digraph (two-character) prefix support has been added to `CodeEdit` (which previously only supported single-character prefixes)
- Is this enough to replace the weird editor-focused export annotations like `@export_navigation_flags_2d` and `@export_range`? No, as those add metadata shared across languages (`PropertyInfo`) and that's why both GDScript's export annotations and C#'s attributes can cause the Godot inspector to show the same UI.
  - I personally believe that these "property drawers" (custom editor controls) should be implemented per-language, and the foundation provided in this PR could allow a GDScript-specific editor implementation to come true, but that would be way out of the scope of this PR.


(Draft PR for now, usability/design feedback highly appreciated)
</p>
</details> 