### PR TITLE
Add missing `Auto (Except Pixel Fonts)` option to advanced import dialog.

### DIFF
--- a/editor/import/dynamic_font_import_settings.h
+++ b/editor/import/dynamic_font_import_settings.h
@@ -84,6 +84,8 @@ class DynamicFontImportSettingsDialog : public ConfirmationDialog {
 	List<ResourceImporter::ImportOption> options_variations;
 	List<ResourceImporter::ImportOption> options_general;
 
+	bool is_pixel = false;
+
 	// Root layout
 	Label *label_warn = nullptr;
 	TabContainer *main_pages = nullptr;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/102509

This option was added to the main import properties, but missing from advance import dialog.