### PR TITLE
Use float instead of integers for durations in `Tween` documentation

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -11,8 +11,8 @@
 		[codeblocks]
 		[gdscript]
 		var tween = get_tree().create_tween()
-		tween.tween_property($Sprite, "modulate", Color.RED, 1)
-		tween.tween_property($Sprite, "scale", Vector2(), 1)
+		tween.tween_property($Sprite, "modulate", Color.RED, 1.0)
+		tween.tween_property($Sprite, "scale", Vector2(), 1.0)
 		tween.tween_callback($Sprite.queue_free)
 		[/gdscript]
 		[csharp]
@@ -27,8 +27,8 @@
 		[codeblocks]
 		[gdscript]
 		var tween = get_tree().create_tween()
-		tween.tween_property($Sprite, "modulate", Color.RED, 1).set_trans(Tween.TRANS_SINE)
-		tween.tween_property($Sprite, "scale", Vector2(), 1).set_trans(Tween.TRANS_BOUNCE)
+		tween.tween_property($Sprite, "modulate", Color.RED, 1.0).set_trans(Tween.TRANS_SINE)
+		tween.tween_property($Sprite, "scale", Vector2(), 1.0).set_trans(Tween.TRANS_BOUNCE)
 		tween.tween_callback($Sprite.queue_free)
 		[/gdscript]
 		[csharp]
@@ -42,8 +42,8 @@
 		[codeblocks]
 		[gdscript]
 		var tween = get_tree().create_tween().bind_node(self).set_trans(Tween.TRANS_ELASTIC)
-		tween.tween_property($Sprite, "modulate", Color.RED, 1)
-		tween.tween_property($Sprite, "scale", Vector2(), 1)
+		tween.tween_property($Sprite, "modulate", Color.RED, 1.0)
+		tween.tween_property($Sprite, "scale", Vector2(), 1.0)
 		tween.tween_callback($Sprite.queue_free)
 		[/gdscript]
 		[csharp]
@@ -58,7 +58,7 @@
 		[gdscript]
 		var tween = create_tween()
 		for sprite in get_children():
-		    tween.tween_property(sprite, "position", Vector2(0, 0), 1)
+		    tween.tween_property(sprite, "position", Vector2(0, 0), 1.0)
 		[/gdscript]
 		[csharp]
 		Tween tween = CreateTween();
@@ -326,7 +326,7 @@
 				[codeblocks]
 				[gdscript]
 				var tween = get_tree().create_tween().set_loops()
-				tween.tween_callback(shoot).set_delay(1)
+				tween.tween_callback(shoot).set_delay(1.0)
 				[/gdscript]
 				[csharp]
 				Tween tween = GetTree().CreateTween().SetLoops();
@@ -371,10 +371,10 @@
 				[codeblocks]
 				[gdscript]
 				var tween = create_tween().set_loops()
-				tween.tween_property($Sprite, "position:x", 200.0, 1).as_relative()
+				tween.tween_property($Sprite, "position:x", 200.0, 1.0).as_relative()
 				tween.tween_callback(jump)
 				tween.tween_interval(2)
-				tween.tween_property($Sprite, "position:x", -200.0, 1).as_relative()
+				tween.tween_property($Sprite, "position:x", -200.0, 1.0).as_relative()
 				tween.tween_callback(jump)
 				tween.tween_interval(2)
 				[/gdscript]
@@ -402,7 +402,7 @@
 				[codeblocks]
 				[gdscript]
 				var tween = create_tween()
-				tween.tween_method(look_at.bind(Vector3.UP), Vector3(-1, 0, -1), Vector3(1, 0, -1), 1) # The look_at() method takes up vector as second argument.
+				tween.tween_method(look_at.bind(Vector3.UP), Vector3(-1, 0, -1), Vector3(1, 0, -1), 1.0) # The look_at() method takes up vector as second argument.
 				[/gdscript]
 				[csharp]
 				Tween tween = CreateTween();
@@ -414,7 +414,7 @@
 				[gdscript]
 				func _ready():
 				    var tween = create_tween()
-				    tween.tween_method(set_label_text, 0, 10, 1).set_delay(1)
+				    tween.tween_method(set_label_text, 0, 10, 1.0).set_delay(1.0)
 
 				func set_label_text(value: int):
 				    $Label.text = "Counting " + str(value)
@@ -447,8 +447,8 @@
 				[codeblocks]
 				[gdscript]
 				var tween = create_tween()
-				tween.tween_property($Sprite, "position", Vector2(100, 200), 1)
-				tween.tween_property($Sprite, "position", Vector2(200, 300), 1)
+				tween.tween_property($Sprite, "position", Vector2(100, 200), 1.0)
+				tween.tween_property($Sprite, "position", Vector2(200, 300), 1.0)
 				[/gdscript]
 				[csharp]
 				Tween tween = CreateTween();
@@ -462,8 +462,8 @@
 				[codeblocks]
 				[gdscript]
 				var tween = create_tween()
-				tween.tween_property($Sprite, "position", Vector2.RIGHT * 300, 1).as_relative().set_trans(Tween.TRANS_SINE)
-				tween.tween_property($Sprite, "position", Vector2.RIGHT * 300, 1).as_relative().from_current().set_trans(Tween.TRANS_EXPO)
+				tween.tween_property($Sprite, "position", Vector2.RIGHT * 300, 1.0).as_relative().set_trans(Tween.TRANS_SINE)
+				tween.tween_property($Sprite, "position", Vector2.RIGHT * 300, 1.0).as_relative().from_current().set_trans(Tween.TRANS_EXPO)
 				[/gdscript]
 				[csharp]
 				Tween tween = CreateTween();


### PR DESCRIPTION
I think it could be cleaner to use floats instead of integers, since duration is supposed to be floating numbers. In this case it doesn't make a big difference, but if you use integers instead of floats as target value in tweens, it can create unexpected results, so I think it could be cleaner to use floats when floats are expected, at least in the documentation itself.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
