### PR TITLE
Add dashed/dotted line support to Line2D node

### DIFF
--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -27,10 +27,14 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
+
 #include "line_2d.h"
 
 #include "core/math/geometry_2d.h"
 #include "line_builder.h"
+
+Line2D::Line2D() {
+}
 
 #ifdef DEBUG_ENABLED
 Rect2 Line2D::_edit_get_rect() const {
@@ -60,21 +64,15 @@ bool Line2D::_edit_is_selected_on_click(const Point2 &p_point, double p_toleranc
 		}
 	}
 	if (_closed && _points.size() > 2) {
-		const Vector2 closing_segment[2] = { points[0], points[_points.size() - 1] };
+		const Vector2 closing_segment[2] = { points[0], _points[_points.size() - 1] };
 		Vector2 p = Geometry2D::get_closest_point_to_segment(p_point, closing_segment);
 		if (p_point.distance_to(p) <= d) {
 			return true;
 		}
 	}
-
 	return false;
 }
 #endif
-
-// Constructor
-Line2D::Line2D() {
-	// (Default values are already set in the member declarations.)
-}
 
 void Line2D::set_points(const Vector<Vector2> &p_points) {
 	_points = p_points;
@@ -101,7 +99,8 @@ int Line2D::get_point_count() const {
 }
 
 void Line2D::clear_points() {
-	if (!_points.empty()) {
+	int count = _points.size();
+	if (count > 0) {
 		_points.clear();
 		queue_redraw();
 	}
@@ -146,13 +145,10 @@ void Line2D::set_curve(const Ref<Curve> &p_curve) {
 	if (_curve.is_valid()) {
 		_curve->disconnect_changed(callable_mp(this, &Line2D::_curve_changed));
 	}
-
 	_curve = p_curve;
-
 	if (_curve.is_valid()) {
 		_curve->connect_changed(callable_mp(this, &Line2D::_curve_changed));
 	}
-
 	queue_redraw();
 }
 
@@ -173,13 +169,10 @@ void Line2D::set_gradient(const Ref<Gradient> &p_gradient) {
 	if (_gradient.is_valid()) {
 		_gradient->disconnect_changed(callable_mp(this, &Line2D::_gradient_changed));
 	}
-
 	_gradient = p_gradient;
-
 	if (_gradient.is_valid()) {
 		_gradient->connect_changed(callable_mp(this, &Line2D::_gradient_changed));
 	}
-
 	queue_redraw();
 }
 
@@ -262,7 +255,7 @@ bool Line2D::get_antialiased() const {
 	return _antialiased;
 }
 
-// --- New dashed/dotted setters and getters ---
+/* --- New dashed/dotted property setters/getters --- */
 
 void Line2D::set_dashed(bool p_dashed) {
 	_dashed = p_dashed;
@@ -291,7 +284,6 @@ float Line2D::get_gap_length() const {
 	return _gap_length;
 }
 
-// Notification (only handling the draw notification)
 void Line2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
@@ -300,30 +292,20 @@ void Line2D::_notification(int p_what) {
 	}
 }
 
-// --- Dashed/dotted helper ---
-// Given the full polyline, compute an array of “dash” segments.
-// Each dash segment is represented as a vector of Vector2 points.
-// (The dash pattern is continuous along the line.)
-Vector<Vector<Vector2>> Line2D::_compute_dashed_segments(const Vector<Vector2>& points, bool closed, float dash_length, float gap_length) const {
+Vector<Vector<Vector2>> Line2D::_compute_dashed_segments(const Vector<Vector2> &points, bool closed, float dash_length, float gap_length) const {
 	Vector<Vector<Vector2>> segments;
 	if (points.size() < 2)
 		return segments;
 	if (dash_length <= 0)
-		return segments; // nothing to draw if dash length is zero.
-	// If gap_length is zero, the line is continuous.
+		return segments;
 	
-	// State for the dash pattern:
-	bool drawing = true; // true means we are currently drawing a dash.
-	float phase_remaining = dash_length; // remaining length in the current dash or gap.
+	bool drawing = true;
+	float phase_remaining = dash_length;
 	Vector<Vector2> current_dash;
 
-	// Number of segments to process:
 	int num_segments = closed ? points.size() : points.size() - 1;
-
-	// Process each segment in the polyline.
 	for (int i = 0; i < num_segments; i++) {
 		Vector2 p0 = points[i];
-		// For closed polyline, wrap around; otherwise next point:
 		Vector2 p1 = (i == points.size() - 1 && closed) ? points[0] : points[i + 1];
 		Vector2 segment = p1 - p0;
 		float seg_len = segment.length();
@@ -332,18 +314,14 @@ Vector<Vector<Vector2>> Line2D::_compute_dashed_segments(const Vector<Vector2>& 
 		Vector2 dir = segment / seg_len;
 		float seg_remaining = seg_len;
 		Vector2 pos = p0;
-
 		while (seg_remaining > 0) {
 			if (phase_remaining <= seg_remaining) {
-				// We can complete the current phase within this segment.
 				Vector2 new_pos = pos + dir * phase_remaining;
 				if (drawing) {
-					// Start a new dash segment if needed.
 					if (current_dash.empty())
 						current_dash.push_back(pos);
 					current_dash.push_back(new_pos);
 				} else {
-					// End the current dash (if any) when a gap finishes.
 					if (!current_dash.empty()) {
 						segments.push_back(current_dash);
 						current_dash.clear();
@@ -351,11 +329,9 @@ Vector<Vector<Vector2>> Line2D::_compute_dashed_segments(const Vector<Vector2>& 
 				}
 				pos = new_pos;
 				seg_remaining -= phase_remaining;
-				// Toggle mode and reset phase_remaining.
 				drawing = !drawing;
 				phase_remaining = drawing ? dash_length : gap_length;
 			} else {
-				// The segment ends before finishing the current phase.
 				if (drawing) {
 					if (current_dash.empty())
 						current_dash.push_back(pos);
@@ -367,42 +343,35 @@ Vector<Vector<Vector2>> Line2D::_compute_dashed_segments(const Vector<Vector2>& 
 			}
 		}
 	}
-	// If we ended in a drawing phase, output the current dash segment.
 	if (!current_dash.empty()) {
 		segments.push_back(current_dash);
 	}
 	return segments;
 }
 
-// --- Drawing function ---
 void Line2D::_draw() {
 	int len = _points.size();
-	if (len <= 1 || _width == 0.f)
+	if (len <= 1 || _width == 0.f) {
 		return;
+	}
 
-	// If dashed mode is enabled, compute dash segments and build geometry for each.
 	if (_dashed) {
 		Vector<Vector<Vector2>> dash_segments = _compute_dashed_segments(_points, _closed, _dash_length, _gap_length);
-
-		// We will combine the geometry from each dash segment into a single triangle array.
 		Vector<int> combined_indices;
 		Vector<Vector2> combined_vertices;
 		Vector<Color> combined_colors;
 		Vector<Vector2> combined_uvs;
 		int vertex_offset = 0;
 
-		// For each dash segment, build geometry if there are at least two points.
 		for (int i = 0; i < dash_segments.size(); i++) {
 			Vector<Vector2> seg_points = dash_segments[i];
 			if (seg_points.size() < 2)
 				continue;
-
+			
 			LineBuilder lb;
 			lb.points = seg_points;
-			// Even if the full line was marked as closed, individual dashes are drawn as open segments.
-			lb.closed = false;
+			lb.closed = false; // Each dash segment is open
 			lb.default_color = _default_color;
-			// If a gradient is assigned, use it; otherwise, the builder will use default_color.
 			if (_gradient.is_valid())
 				lb.gradient = *_gradient;
 			lb.texture_mode = _texture_mode;
@@ -417,10 +386,8 @@ void Line2D::_draw() {
 			if (_texture.is_valid()) {
 				lb.tile_aspect = _texture->get_size().aspect();
 			}
-			// Build the geometry for this dash.
 			lb.build();
 
-			// Append this dash’s geometry to the combined arrays.
 			for (int idx : lb.indices) {
 				combined_indices.push_back(idx + vertex_offset);
 			}
@@ -432,21 +399,19 @@ void Line2D::_draw() {
 			vertex_offset += lb.vertices.size();
 		}
 
-		// Get the texture RID if a texture is used.
 		RID texture_rid;
 		if (_texture.is_valid())
 			texture_rid = _texture->get_rid();
 
 		RS::get_singleton()->canvas_item_add_triangle_array(
-				get_canvas_item(),
-				combined_indices,
-				combined_vertices,
-				combined_colors,
-				combined_uvs, Vector<int>(), Vector<float>(),
-				texture_rid);
-
+			get_canvas_item(),
+			combined_indices,
+			combined_vertices,
+			combined_colors,
+			combined_uvs, Vector<int>(), Vector<float>(),
+			texture_rid
+		);
 	} else {
-		// Non-dashed mode: use the normal procedure.
 		LineBuilder lb;
 		lb.points = _points;
 		lb.closed = _closed;
@@ -467,39 +432,17 @@ void Line2D::_draw() {
 			texture_rid = _texture->get_rid();
 			lb.tile_aspect = _texture->get_size().aspect();
 		}
-
 		lb.build();
 
 		RS::get_singleton()->canvas_item_add_triangle_array(
-				get_canvas_item(),
-				lb.indices,
-				lb.vertices,
-				lb.colors,
-				lb.uvs, Vector<int>(), Vector<float>(),
-				texture_rid);
+			get_canvas_item(),
+			lb.indices,
+			lb.vertices,
+			lb.colors,
+			lb.uvs, Vector<int>(), Vector<float>(),
+			texture_rid
+		);
 	}
-
-	// DEBUG: (Optional) Draw wireframe for debugging.
-	// Uncomment the following block to see the underlying triangles.
-	/*
-		if (_dashed) {
-			// Draw the combined wireframe if needed.
-		} else if (lb.indices.size() % 3 == 0) {
-			Color col(0, 0, 0);
-			for (int i = 0; i < lb.indices.size(); i += 3) {
-				Vector2 a = lb.vertices[lb.indices[i]];
-				Vector2 b = lb.vertices[lb.indices[i+1]];
-				Vector2 c = lb.vertices[lb.indices[i+2]];
-				draw_line(a, b, col);
-				draw_line(b, c, col);
-				draw_line(c, a, col);
-			}
-			for (int i = 0; i < lb.vertices.size(); ++i) {
-				Vector2 p = lb.vertices[i];
-				draw_rect(Rect2(p.x - 1, p.y - 1, 2, 2), Color(0, 0, 0, 0.5));
-			}
-		}
-	*/
 }
 
 void Line2D::_gradient_changed() {
@@ -510,7 +453,6 @@ void Line2D::_curve_changed() {
 	queue_redraw();
 }
 
-// --- Binding methods ---
 void Line2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_points", "points"), &Line2D::set_points);
 	ClassDB::bind_method(D_METHOD("get_points"), &Line2D::get_points);
@@ -564,7 +506,7 @@ void Line2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_antialiased", "antialiased"), &Line2D::set_antialiased);
 	ClassDB::bind_method(D_METHOD("get_antialiased"), &Line2D::get_antialiased);
 
-	// Bind the new dashed/dotted properties.
+	// Bind new dashed/dotted properties.
 	ClassDB::bind_method(D_METHOD("set_dashed", "dashed"), &Line2D::set_dashed);
 	ClassDB::bind_method(D_METHOD("is_dashed"), &Line2D::is_dashed);
 	ClassDB::bind_method(D_METHOD("set_dash_length", "length"), &Line2D::set_dash_length);
@@ -572,7 +514,6 @@ void Line2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_gap_length", "gap"), &Line2D::set_gap_length);
 	ClassDB::bind_method(D_METHOD("get_gap_length"), &Line2D::get_gap_length);
 
-	// Register properties.
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "points"), "set_points", "get_points");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "closed"), "set_closed", "is_closed");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "width", PROPERTY_HINT_NONE, "suffix:px"), "set_width", "get_width");
@@ -591,6 +532,7 @@ void Line2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "round_precision", PROPERTY_HINT_RANGE, "1,32,1"), "set_round_precision", "get_round_precision");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "antialiased"), "set_antialiased", "get_antialiased");
 
+	// Register dashed/dotted properties.
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "dashed"), "set_dashed", "is_dashed");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dash_length", PROPERTY_HINT_RANGE, "0,1024,0.1"), "set_dash_length", "get_dash_length");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "gap_length", PROPERTY_HINT_RANGE, "0,1024,0.1"), "set_gap_length", "get_gap_length");

--- a/scene/2d/line_2d.h
+++ b/scene/2d/line_2d.h
@@ -27,6 +27,7 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
+
 #ifndef LINE_2D_H
 #define LINE_2D_H
 
@@ -36,7 +37,6 @@ class Line2D : public Node2D {
 	GDCLASS(Line2D, Node2D);
 
 public:
-	// Enums for joint, cap and texture modes.
 	enum LineJointMode {
 		LINE_JOINT_SHARP = 0,
 		LINE_JOINT_BEVEL,
@@ -63,7 +63,6 @@ public:
 
 	Line2D();
 
-	// Point manipulation
 	void set_points(const Vector<Vector2> &p_points);
 	Vector<Vector2> get_points() const;
 
@@ -77,18 +76,15 @@ public:
 	void add_point(Vector2 pos, int atpos = -1);
 	void remove_point(int i);
 
-	// Closed polyline?
 	void set_closed(bool p_closed);
 	bool is_closed() const;
 
-	// Width and curves
 	void set_width(float width);
 	float get_width() const;
 
 	void set_curve(const Ref<Curve> &curve);
 	Ref<Curve> get_curve() const;
 
-	// Colors, gradients and textures
 	void set_default_color(Color color);
 	Color get_default_color() const;
 
@@ -101,7 +97,6 @@ public:
 	void set_texture_mode(const LineTextureMode mode);
 	LineTextureMode get_texture_mode() const;
 
-	// Joint and cap modes
 	void set_joint_mode(LineJointMode mode);
 	LineJointMode get_joint_mode() const;
 
@@ -111,7 +106,6 @@ public:
 	void set_end_cap_mode(LineCapMode mode);
 	LineCapMode get_end_cap_mode() const;
 
-	// Border options
 	void set_sharp_limit(float limit);
 	float get_sharp_limit() const;
 
@@ -121,17 +115,13 @@ public:
 	void set_antialiased(bool p_antialiased);
 	bool get_antialiased() const;
 
-	// --- New dashed/dotted line properties ---
-
-	/// If true the line will be drawn in a dashed/dotted pattern.
+	/* --- New dashed/dotted line properties --- */
 	void set_dashed(bool p_dashed);
 	bool is_dashed() const;
 
-	/// The length (in pixels) of each dash segment.
 	void set_dash_length(float p_length);
 	float get_dash_length() const;
 
-	/// The gap (in pixels) between dashes.
 	void set_gap_length(float p_gap);
 	float get_gap_length() const;
 
@@ -145,8 +135,8 @@ private:
 	void _gradient_changed();
 	void _curve_changed();
 
-	// Helper for dashed-line processing: given the full polyline, split it into dash segments.
-	Vector<Vector<Vector2>> _compute_dashed_segments(const Vector<Vector2>& points, bool closed, float dash_length, float gap_length) const;
+	/* Helper to compute dashed segments from the polyline */
+	Vector<Vector<Vector2>> _compute_dashed_segments(const Vector<Vector2> &points, bool closed, float dash_length, float gap_length) const;
 
 private:
 	Vector<Vector2> _points;
@@ -164,10 +154,10 @@ private:
 	int _round_precision = 8;
 	bool _antialiased = false;
 
-	// New dashed/dotted line properties:
+	/* New dashed/dotted properties */
 	bool _dashed = false;
-	float _dash_length = 10.0f;
-	float _gap_length = 5.0f;
+	float _dash_length = 10.0;
+	float _gap_length = 5.0;
 };
 
 VARIANT_ENUM_CAST(Line2D::LineJointMode)

--- a/scene/2d/line_2d.h
+++ b/scene/2d/line_2d.h
@@ -27,7 +27,6 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
-
 #ifndef LINE_2D_H
 #define LINE_2D_H
 
@@ -37,6 +36,7 @@ class Line2D : public Node2D {
 	GDCLASS(Line2D, Node2D);
 
 public:
+	// Enums for joint, cap and texture modes.
 	enum LineJointMode {
 		LINE_JOINT_SHARP = 0,
 		LINE_JOINT_BEVEL,
@@ -63,6 +63,7 @@ public:
 
 	Line2D();
 
+	// Point manipulation
 	void set_points(const Vector<Vector2> &p_points);
 	Vector<Vector2> get_points() const;
 
@@ -76,15 +77,18 @@ public:
 	void add_point(Vector2 pos, int atpos = -1);
 	void remove_point(int i);
 
+	// Closed polyline?
 	void set_closed(bool p_closed);
 	bool is_closed() const;
 
+	// Width and curves
 	void set_width(float width);
 	float get_width() const;
 
 	void set_curve(const Ref<Curve> &curve);
 	Ref<Curve> get_curve() const;
 
+	// Colors, gradients and textures
 	void set_default_color(Color color);
 	Color get_default_color() const;
 
@@ -97,6 +101,7 @@ public:
 	void set_texture_mode(const LineTextureMode mode);
 	LineTextureMode get_texture_mode() const;
 
+	// Joint and cap modes
 	void set_joint_mode(LineJointMode mode);
 	LineJointMode get_joint_mode() const;
 
@@ -106,6 +111,7 @@ public:
 	void set_end_cap_mode(LineCapMode mode);
 	LineCapMode get_end_cap_mode() const;
 
+	// Border options
 	void set_sharp_limit(float limit);
 	float get_sharp_limit() const;
 
@@ -114,6 +120,20 @@ public:
 
 	void set_antialiased(bool p_antialiased);
 	bool get_antialiased() const;
+
+	// --- New dashed/dotted line properties ---
+
+	/// If true the line will be drawn in a dashed/dotted pattern.
+	void set_dashed(bool p_dashed);
+	bool is_dashed() const;
+
+	/// The length (in pixels) of each dash segment.
+	void set_dash_length(float p_length);
+	float get_dash_length() const;
+
+	/// The gap (in pixels) between dashes.
+	void set_gap_length(float p_gap);
+	float get_gap_length() const;
 
 protected:
 	void _notification(int p_what);
@@ -124,6 +144,9 @@ protected:
 private:
 	void _gradient_changed();
 	void _curve_changed();
+
+	// Helper for dashed-line processing: given the full polyline, split it into dash segments.
+	Vector<Vector<Vector2>> _compute_dashed_segments(const Vector<Vector2>& points, bool closed, float dash_length, float gap_length) const;
 
 private:
 	Vector<Vector2> _points;
@@ -140,9 +163,13 @@ private:
 	float _sharp_limit = 2.f;
 	int _round_precision = 8;
 	bool _antialiased = false;
+
+	// New dashed/dotted line properties:
+	bool _dashed = false;
+	float _dash_length = 10.0f;
+	float _gap_length = 5.0f;
 };
 
-// Needed so we can bind functions
 VARIANT_ENUM_CAST(Line2D::LineJointMode)
 VARIANT_ENUM_CAST(Line2D::LineCapMode)
 VARIANT_ENUM_CAST(Line2D::LineTextureMode)


### PR DESCRIPTION
- Introduce new properties for dashed/dotted patterns:
  - `dashed` (bool): Enables or disables dashed rendering.
  - `dash_length` (float): Specifies the length of each dash.
  - `gap_length` (float): Specifies the gap between dashes.
  
- Implement a helper method `_compute_dashed_segments()` that processes the original polyline into segments based on the dash and gap lengths.
  
- Update the `_draw()` method to:
  - Check for the `dashed` flag.
  - Use the new helper function to generate dash segments.
  - Build and combine geometry for each dash segment.
  
- Bind the new properties in `_bind_methods()` so that they are exposed to the scripting API and editor.
  
- Ensure that the non-dashed mode continues to function as before.

This commit adds flexible support for dashed/dotted line rendering, improving the visual customization of the Line2D node.
