### PR TITLE
C#: Expose `rid_allocate_id` and `rid_from_int64`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -61,6 +61,25 @@ namespace Godot
         }
 
         /// <summary>
+        /// Allocates a unique ID which can be used by the implementation to construct an RID. This is used mainly from native extensions to implement servers.
+        /// </summary>
+        /// <returns>The allocated ID </returns>
+        public static ulong RidAllocateId()
+        {
+            return NativeFuncs.godotsharp_rid_allocate_id();
+        }
+
+        /// <summary>
+        /// Creates an RID from a <paramref name="base"/>. This is used mainly from native extensions to build servers.
+        /// </summary>
+        /// <param name="base">The ID to create <see cref="Rid"/></param>
+        /// <returns>The <see cref="Rid"/></returns>
+        public static Rid RidFromInt64(ulong @base)
+        {
+            return new Rid(@base);
+        }
+
+        /// <summary>
         /// Returns the integer hash of the passed <paramref name="var"/>.
         /// </summary>
         /// <example>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -548,6 +548,8 @@ namespace Godot.NativeInterop
         internal static partial void godotsharp_convert(scoped in godot_variant p_what, int p_type,
             out godot_variant r_ret);
 
+        internal static partial ulong godotsharp_rid_allocate_id();
+
         internal static partial int godotsharp_hash(in godot_variant p_var);
 
         internal static partial IntPtr godotsharp_instance_from_id(ulong p_instance_id);

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -46,6 +46,7 @@
 #include "core/object/method_bind.h"
 #include "core/os/os.h"
 #include "core/string/string_name.h"
+#include "core/variant/variant_utility.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_file_system.h"
@@ -1478,6 +1479,10 @@ void godotsharp_bytes_to_var(const godot_packed_array *p_bytes, bool p_allow_obj
 	memnew_placement(r_ret, Variant(ret));
 }
 
+uint64_t godotsharp_rid_alloc_id() {
+	return VariantUtilityFunctions::rid_allocate_id();
+}
+
 int godotsharp_hash(const godot_variant *p_var) {
 	return reinterpret_cast<const Variant *>(p_var)->hash();
 }
@@ -1715,6 +1720,7 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_node_path_hash,
 	(void *)godotsharp_bytes_to_var,
 	(void *)godotsharp_convert,
+	(void *)godotsharp_rid_alloc_id,
 	(void *)godotsharp_hash,
 	(void *)godotsharp_instance_from_id,
 	(void *)godotsharp_print,


### PR DESCRIPTION
Adds `GD.RidAllocateId` and `GD.RidFromInt64` in C#.

`rid_allocate_id` and `rid_from_int64` provide a way to create rid, but they are missing in C#.(https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/c_sharp_differences.html)