### PR TITLE
Fix Plugin Scripts load twice on startup

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3710,7 +3710,9 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled,
 	// Only try to load the script if it has a name. Else, the plugin has no init script.
 	if (script_path.length() > 0) {
 		script_path = addon_path.get_base_dir().path_join(script_path);
-		scr = ResourceLoader::load(script_path, "Script", ResourceFormatLoader::CACHE_MODE_IGNORE);
+		// We should not use the cached version on startup to prevent a script reload
+		// if it is already loaded and potentially running from autoloads. See GH-100750.
+		scr = ResourceLoader::load(script_path, "Script", EditorFileSystem::get_singleton()->doing_first_scan() ? ResourceFormatLoader::CACHE_MODE_REUSE : ResourceFormatLoader::CACHE_MODE_IGNORE);
 
 		if (scr.is_null()) {
 			show_warning(vformat(TTR("Unable to load addon script from path: '%s'."), script_path));


### PR DESCRIPTION
- Fixes #100750

Thanks to @HolonProduction for helping fix this issue.!!

The issue was caused by the plugin script being loaded twice on startup when the same script is used in the plugin's `ready` method and as an autoload. Autoloads are created before plugins, triggering the first load. When the plugin is enabled, the script is loaded again with `CACHE_MODE_IGNORE`, causing it to reload while `await` calls are still running.  

I changed the cache mode to `CACHE_MODE_REUSE` when enabling plugins on editor startup (while the first scan is running).

I tested this with the MRP from #100750, and as suggested by @HolonProduction, I also retested the MRP from **#70667**. Godot's startup process has changed quite a bit since this issue was first reported. Since #92667, scripts that reference resources can now load even before the first scan, allowing the project to load without any errors or warnings on the first startup without the `.godot` folder.  

I have kept `CACHE_MODE_IGNORE` when the editor is not in startup mode to prevent potential side effects.