### PR TITLE
ufbx: Update to 0.17.1

### DIFF
--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -251,18 +251,16 @@ static bool _thread_pool_init_fn(void *user, ufbx_thread_pool_context ctx, const
 	return true;
 }
 
-static bool _thread_pool_run_fn(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t start_index, uint32_t count) {
+static void _thread_pool_run_fn(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t start_index, uint32_t count) {
 	ThreadPoolFBX *pool = (ThreadPoolFBX *)user;
 	ThreadPoolFBX::Group &pool_group = pool->groups[group];
 	pool_group.start_index = start_index;
 	pool_group.task_id = pool->pool->add_native_group_task(_thread_pool_task, &pool_group, (int)count, -1, true, "ufbx");
-	return true;
 }
 
-static bool _thread_pool_wait_fn(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t max_index) {
+static void _thread_pool_wait_fn(void *user, ufbx_thread_pool_context ctx, uint32_t group, uint32_t max_index) {
 	ThreadPoolFBX *pool = (ThreadPoolFBX *)user;
 	pool->pool->wait_for_group_task_completion(pool->groups[group].task_id);
-	return true;
 }
 
 String FBXDocument::_gen_unique_name(HashSet<String> &unique_names, const String &p_name) {

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -976,7 +976,7 @@ Patches:
 ## ufbx
 
 - Upstream: https://github.com/ufbx/ufbx
-- Version: 0.15.0 (24eea6f40929fe0f679b7950def378edb003afdb, 2024)
+- Version: 0.17.1 (6ca5309972f03625e6990f3084ff4c1cc55a09b6, 2025)
 - License: MIT
 
 Files extracted from upstream source:


### PR DESCRIPTION
https://github.com/ufbx/ufbx/releases/tag/v0.17.1

**Changes from version 0.15.0 to version 0.15.1:**

- Fix detection of SSE/NEON extensions

**Changes from version 0.15.1 to version 0.16.0:**

- Breaking: Change ufbx_thread_pool_[run/wait]_fn() return type to void
- Add thread pool documentation

**Changes from version 0.16.0 to version 0.16.1:**

- Fixed parsing multi-part base64 ASCII embedded data

**Changes from version 0.16.1 to version 0.17.0:**

- Decode ASCII base64 embedded data during parsing
- Any embedded content with invalid base64 is now ignored
- Added a warning for broken base64 data during import
- Base64-encoded embedded data now is decoded if you request the DOM

**Changes from version 0.17.0 to version 0.17.1:**

- Fixed warnings in newer compilers

*Bugsquad edit:*
- Fixes #103178.