### PR TITLE
CI: Separate Android editor artifacts

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -103,7 +103,27 @@ jobs:
           cd ../../..
           ls -l bin/android_editor_builds/
 
+          # Separate different editors for multiple artifacts
+          mkdir horizonos
+          mv bin/android_editor_builds/*-horizonos-* horizonos
+          mkdir picoos
+          mv bin/android_editor_builds/*-picoos-* picoos
+
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact
         with:
           name: ${{ matrix.cache-name }}
+
+      - name: Upload artifact (Horizon OS)
+        if: matrix.target == 'editor'
+        uses: ./.github/actions/upload-artifact
+        with:
+          name: ${{ matrix.cache-name }}-horizonos
+          path: horizonos
+
+      - name: Upload artifact (PICO OS)
+        if: matrix.target == 'editor'
+        uses: ./.github/actions/upload-artifact
+        with:
+          name: ${{ matrix.cache-name }}-picoos
+          path: picoos


### PR DESCRIPTION
- Implements [this RC suggestion](https://chat.godotengine.org/channel/buildsystem?msg=vb2vqiyPG8iOMReZU)

Splits the GHA upload for the android editor action into 3 separate artifacts: `android-editor`, `android-editor-horizonos`, and `android-editor-picoos`