### PR TITLE
Add a `run` SCons option to run the engine binary after a build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -250,6 +250,11 @@ opts.Add(
         True,
     )
 )
+opts.Add(
+    "run",
+    'If non-empty, run the compiled binary with the specified arguments on successful build. Try "--path /path/to/project" to run a project, append "-e" to edit it or use "-p" on its own for project manager',
+    "",
+)
 
 # Thirdparty libraries
 opts.Add(BoolVariable("builtin_brotli", "Use the built-in Brotli library", True))
@@ -358,6 +363,21 @@ if env["platform"] not in platform_list:
 # Add platform-specific options.
 if env["platform"] in platform_opts:
     opts.AddVariables(*platform_opts[env["platform"]])
+
+if env["run"] != "":
+    import platform
+
+    if env["platform"] != "windows" and env["platform"] != "macos" and env["platform"] != "linuxbsd":
+        print_error("The `run` option is only supported for Windows, macOS, and Linux/BSD targets.")
+    elif env["platform"] == "windows" and platform.system() != "Windows":
+        print_error("Can't run Windows binary after compiling on a non-Windows platform.")
+        Exit(255)
+    elif env["platform"] == "macos" and platform.system() != "Darwin":
+        print_error("Can't run macOS binary after compiling on a non-macOS platform.")
+        Exit(255)
+    elif env["platform"] == "linuxbsd" and platform.system() != "Linux":
+        print_error("Can't run Linux binary after compiling on a non-Linux platform.")
+        Exit(255)
 
 # Platform-specific flags.
 # These can sometimes override default options, so they need to be processed
@@ -1161,3 +1181,11 @@ if not env.GetOption("clean") and not env.GetOption("help"):
     methods.show_progress(env)
     methods.prepare_purge(env)
     methods.prepare_timer()
+
+    if env["run"] != "":
+        if os.name == "nt":
+            env["bin_path"] = f"bin\\godot{suffix}.exe"
+        else:
+            env["bin_path"] = f"bin/godot{suffix}"
+
+        methods.prepare_run(env)

--- a/methods.py
+++ b/methods.py
@@ -941,6 +941,23 @@ def prepare_timer():
     atexit.register(print_elapsed_time, time.time())
 
 
+def prepare_run(env) -> None:
+    import subprocess
+
+    from SCons.Script.Main import GetBuildFailures
+
+    def run() -> None:
+        if len(GetBuildFailures()) == 0:
+            print("-" * 80 + f"\nBuild successful, running: {env['bin_path']} {env['run']}\n" + "-" * 80)
+            try:
+                # Allow using `~` as a shorthand for `$HOME` on all platforms.
+                subprocess.run([env["bin_path"], *env["run"].replace("~", os.environ["HOME"]).split()], shell=True)
+            except:  # noqa: E722
+                print("-" * 80 + "\nAn error has occurred while Godot was running.\n" + "-" * 80)
+
+    atexit.register(run)
+
+
 def dump(env):
     """
     Dumps latest build information for debugging purposes and external tools.


### PR DESCRIPTION
This makes the compile-test cycle faster for engine contributors, as you no longer need to manually run the engine binary after it's done compiling. This can also avoid distractions that occur when you leave the engine building in the background and forget to run the project/editor afterwards.

- This closes https://github.com/godotengine/godot-proposals/issues/11719.

## Examples

```bash
# Run project manager.
scons run=-p

# This passes "yes" as a positional argument to Godot, which Godot won't do anything about, so it'll act the same as above unless CWD is a project folder.
scons run=yes

# Open a project in the editor.
# You can use `~` as a standin for the `$HOME` environment variable.
# This works on all platforms regardless of shell as this PR handles `~` specifically.
scons run=/path/to/project.godot

# Run a project directly.
scons run="--path /path/to/project"
```

## Preview

```
$ scons run="--path ~/Documents/Godot/test-tablet --quit"
scons: Reading SConscript files ...
Using SCons-detected MSVC version 14.3, arch x86_64
Building for platform "windows", architecture "x86_64", target "editor".
Checking for C header file mntent.h... (cached) no
scons: done reading SConscript files.
scons: Building targets ...
scons: `.' is up to date.
scons: done building targets.
--------------------------------------------------------------------------------
Build successful, running: bin\godot.windows.editor.x86_64.exe --path ~/Documents/Godot/test-tablet --quit
--------------------------------------------------------------------------------
Godot Engine v4.4.beta.custom_build.eee01066b (2025-02-07 17:57:42 UTC) - https://godotengine.org
Requested V-Sync mode: Disabled
OpenGL API 3.3.0 NVIDIA 566.36 - Compatibility - Using Device: NVIDIA - NVIDIA GeForce RTX 4090

INFO: Time elapsed: 00:00:09.72
```

## TODO

- [ ] Figure out if it's possible to move the `Time elapsed` calculation and text to be printed before the engine starts. This way, we don't take the engine runtime into account.