### PR TITLE
Fix double `set_name` in renaming node

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1571,7 +1571,6 @@ void SceneTreeEditor::rename_node(Node *p_node, const String &p_name, TreeItem *
 		undo_redo->add_undo_method(item, "set_metadata", 0, p_node->get_path());
 		undo_redo->add_undo_method(item, "set_text", 0, p_node->get_name());
 
-		p_node->set_name(new_name);
 		undo_redo->add_do_method(p_node, "set_name", new_name);
 		undo_redo->add_do_method(item, "set_metadata", 0, p_node->get_path());
 		undo_redo->add_do_method(item, "set_text", 0, new_name);


### PR DESCRIPTION
Fixes #102411

Currently the name is set and then the undo system sets it again.
I've tested multiple ways of renaming and it seems that just removing this line works.
Checked previous commit and seems unintentional the double set_name.