### PR TITLE
Fix TextEdit cusor shape when mouse is held

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -660,6 +660,10 @@ Control::CursorShape CodeEdit::get_cursor_shape(const Point2 &p_pos) const {
 		return CURSOR_POINTING_HAND;
 	}
 
+	if (is_dragging_cursor()) {
+		return TextEdit::get_cursor_shape(p_pos);
+	}
+
 	if ((code_completion_active && code_completion_rect.has_point(p_pos)) || (!is_editable() && (!is_selecting_enabled() || get_line_count() == 0))) {
 		return CURSOR_ARROW;
 	}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1674,6 +1674,7 @@ void TextEdit::_notification(int p_what) {
 			selection_drag_attempt = false;
 			drag_action = false;
 			drag_caret_force_displayed = false;
+			dragging_selection = false;
 		} break;
 
 		case NOTIFICATION_MOUSE_EXIT_SELF: {
@@ -3112,6 +3113,14 @@ void TextEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 }
 
 Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
+	if (dragging_selection) {
+		return get_default_cursor_shape();
+	}
+
+	if (dragging_minimap) {
+		return CURSOR_ARROW;
+	}
+
 	Vector2i current_hovered_gutter = _get_hovered_gutter(p_pos);
 	if (current_hovered_gutter != Vector2i(-1, -1)) {
 		if (gutters[current_hovered_gutter.x].clickable || is_line_gutter_clickable(current_hovered_gutter.y, current_hovered_gutter.x)) {


### PR DESCRIPTION
When selecting text with the mouse and the cursor goes outside the textbox to the left or over something clickable like the gutters, the mouse cursor should not change.
Same with dragging the minimap, the cursor should always be the same while the mouse is held down.

I think `dragging_selection` shouldn't be set when dragging text, but changing it could affect other logic, so for now I just make sure to set it to false when dragging ends. Otherwise it could be in the wrong state. This could be seen by moving some text and immediately ctrl+click on something, it doesn't work.