### PR TITLE
Editor: Fix AtlasTexture editor previews for compressed textures

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -100,6 +100,13 @@ Ref<Texture2D> EditorTexturePreviewPlugin::generate(const Ref<Resource> &p_from,
 			return Ref<Texture2D>();
 		}
 
+		if (atlas->is_compressed()) {
+			atlas = atlas->duplicate();
+			if (atlas->decompress() != OK) {
+				return Ref<Texture2D>();
+			}
+		}
+
 		if (!tex_atlas->get_region().has_area()) {
 			return Ref<Texture2D>();
 		}

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -132,8 +132,21 @@ static Image::Format get_texture_2d_format(const Ref<Texture2D> &p_texture) {
 
 static int get_texture_mipmaps_count(const Ref<Texture2D> &p_texture) {
 	ERR_FAIL_COND_V(p_texture.is_null(), -1);
+
 	// We are having to download the image only to get its mipmaps count. It would be nice if we didn't have to.
-	Ref<Image> image = p_texture->get_image();
+	Ref<Image> image;
+	Ref<AtlasTexture> at = p_texture;
+	if (at.is_valid()) {
+		// The AtlasTexture tries to obtain the region from the atlas as an image,
+		// which will fail if it is a compressed format.
+		Ref<Texture2D> atlas = at->get_atlas();
+		if (atlas.is_valid()) {
+			image = atlas->get_image();
+		}
+	} else {
+		image = p_texture->get_image();
+	}
+
 	if (image.is_valid()) {
 		return image->get_mipmap_count();
 	}


### PR DESCRIPTION
This PR resolves errors in the Godot Editor when working with an AtlasTexture resource that uses a compressed image format. The specific error is:

```
Cannot blit_rect in compressed or custom image formats.
```

When the texture is compressed, the preview in the File Manager and the Inspector are black:

| before | after |
| :---- | :---- |
| ![CleanShot 2025-02-08 at 08 15 46@2x](https://github.com/user-attachments/assets/82849a44-6af7-4cc4-9bed-fa5ea7f62961) | ![CleanShot 2025-02-08 at 08 13 22@2x](https://github.com/user-attachments/assets/d51096f4-b44f-4c69-91a9-c5e5a4a26bce) | 

## MRP

[mpr.zip](https://github.com/user-attachments/files/18789403/mpr.zip)

