### PR TITLE
Replace references from TileMap to TileMapLayer in documentation

### DIFF
--- a/doc/classes/TileData.xml
+++ b/doc/classes/TileData.xml
@@ -4,7 +4,7 @@
 		Settings for a single tile in a [TileSet].
 	</brief_description>
 	<description>
-		[TileData] object represents a single tile in a [TileSet]. It is usually edited using the tileset editor, but it can be modified at runtime using [method TileMap._tile_data_runtime_update].
+		[TileData] object represents a single tile in a [TileSet]. It is usually edited using the tileset editor, but it can be modified at runtime using [method TileMapLayer._tile_data_runtime_update].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -301,7 +301,7 @@
 			Vertical point of the tile used for determining y-sorted order.
 		</member>
 		<member name="z_index" type="int" setter="set_z_index" getter="get_z_index" default="0">
-			Ordering index of this tile, relative to [TileMap].
+			Ordering index of this tile, relative to [TileMapLayer].
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -491,8 +491,7 @@
 			<param index="5" name="alternative_to" type="int" />
 			<description>
 				Create an alternative-level proxy for the given identifiers. A proxy will map set of tile identifiers to another set of identifiers.
-				This can be used to replace a tile in all TileMaps using this TileSet, as TileMap nodes will find and use the proxy's target tile when one is available.
-				Proxied tiles can be automatically replaced in TileMap nodes using the editor.
+				Proxied tiles can be automatically replaced in TileMapLayer nodes using the editor.
 			</description>
 		</method>
 		<method name="set_coords_level_tile_proxy">
@@ -503,8 +502,7 @@
 			<param index="3" name="coords_to" type="Vector2i" />
 			<description>
 				Creates a coordinates-level proxy for the given identifiers. A proxy will map set of tile identifiers to another set of identifiers. The alternative tile ID is kept the same when using coordinates-level proxies.
-				This can be used to replace a tile in all TileMaps using this TileSet, as TileMap nodes will find and use the proxy's target tile when one is available.
-				Proxied tiles can be automatically replaced in TileMap nodes using the editor.
+				Proxied tiles can be automatically replaced in TileMapLayer nodes using the editor.
 			</description>
 		</method>
 		<method name="set_custom_data_layer_name">
@@ -602,8 +600,7 @@
 			<param index="1" name="source_to" type="int" />
 			<description>
 				Creates a source-level proxy for the given source ID. A proxy will map set of tile identifiers to another set of identifiers. Both the atlas coordinates ID and the alternative tile ID are kept the same when using source-level proxies.
-				This can be used to replace a source in all TileMaps using this TileSet, as TileMap nodes will find and use the proxy's target source when one is available.
-				Proxied tiles can be automatically replaced in TileMap nodes using the editor.
+				Proxied tiles can be automatically replaced in TileMapLayer nodes using the editor.
 			</description>
 		</method>
 		<method name="set_terrain_color">
@@ -635,7 +632,7 @@
 	</methods>
 	<members>
 		<member name="tile_layout" type="int" setter="set_tile_layout" getter="get_tile_layout" enum="TileSet.TileLayout" default="0">
-			For all half-offset shapes (Isometric, Hexagonal and Half-Offset square), changes the way tiles are indexed in the TileMap grid.
+			For all half-offset shapes (Isometric, Hexagonal and Half-Offset square), changes the way tiles are indexed in the [TileMapLayer] grid.
 		</member>
 		<member name="tile_offset_axis" type="int" setter="set_tile_offset_axis" getter="get_tile_offset_axis" enum="TileSet.TileOffsetAxis" default="0">
 			For all half-offset shapes (Isometric, Hexagonal and Half-Offset square), determines the offset axis.
@@ -656,7 +653,7 @@
 		</constant>
 		<constant name="TILE_SHAPE_ISOMETRIC" value="1" enum="TileShape">
 			Diamond tile shape (for isometric look).
-			[b]Note:[/b] Isometric [TileSet] works best if [TileMap] and all its layers have Y-sort enabled.
+			[b]Note:[/b] Isometric [TileSet] works best if all sibling [TileMapLayer]s and their parent inheriting from [Node2D] have Y-sort enabled.
 		</constant>
 		<constant name="TILE_SHAPE_HALF_OFFSET_SQUARE" value="2" enum="TileShape">
 			Rectangular tile shape with one row/column out of two offset by half a tile.

--- a/doc/classes/TileSetAtlasSource.xml
+++ b/doc/classes/TileSetAtlasSource.xml
@@ -288,12 +288,12 @@
 			Represents the size of the [enum TileAnimationMode] enum.
 		</constant>
 		<constant name="TRANSFORM_FLIP_H" value="4096">
-			Represents cell's horizontal flip flag. Should be used directly with [TileMap] to flip placed tiles by altering their alternative IDs.
+			Represents cell's horizontal flip flag. Should be used directly with [TileMapLayer] to flip placed tiles by altering their alternative IDs.
 			[codeblock]
-			var alternate_id = $TileMap.get_cell_alternative_tile(0, Vector2i(2, 2))
+			var alternate_id = $TileMapLayer.get_cell_alternative_tile(Vector2i(2, 2))
 			if not alternate_id &amp; TileSetAtlasSource.TRANSFORM_FLIP_H:
 			    # If tile is not already flipped, flip it.
-			    $TileMap.set_cell(0, Vector2i(2, 2), source_id, atlas_coords, alternate_id | TileSetAtlasSource.TRANSFORM_FLIP_H)
+			    $TileMapLayer.set_cell(Vector2i(2, 2), source_id, atlas_coords, alternate_id | TileSetAtlasSource.TRANSFORM_FLIP_H)
 			[/codeblock]
 			[b]Note:[/b] These transformations can be combined to do the equivalent of 0, 90, 180, and 270 degree rotations, as shown below:
 			[codeblock]

--- a/doc/classes/TileSetScenesCollectionSource.xml
+++ b/doc/classes/TileSetScenesCollectionSource.xml
@@ -4,8 +4,8 @@
 		Exposes a set of scenes as tiles for a [TileSet] resource.
 	</brief_description>
 	<description>
-		When placed on a [TileMap], tiles from [TileSetScenesCollectionSource] will automatically instantiate an associated scene at the cell's position in the TileMap.
-		Scenes are instantiated as children of the [TileMap] when it enters the tree. If you add/remove a scene tile in the [TileMap] that is already inside the tree, the [TileMap] will automatically instantiate/free the scene accordingly.
+		When placed on a [TileMapLayer], tiles from [TileSetScenesCollectionSource] will automatically instantiate an associated scene at the cell's position in the TileMapLayer.
+		Scenes are instantiated as children of the [TileMapLayer] when it enters the tree. If you add/remove a scene tile in the [TileMapLayer] that is already inside the tree, the [TileMapLayer] will automatically instantiate/free the scene accordingly.
 		[b]Note:[/b] Scene tiles all occupy one tile slot and instead use alternate tile ID to identify scene index. [method TileSetSource.get_tiles_count] will always return [code]1[/code]. Use [method get_scene_tiles_count] to get a number of scenes in a [TileSetScenesCollectionSource].
 		Use this code if you want to find the scene path at a given tile in [TileMapLayer]:
 		[codeblocks]
@@ -113,7 +113,7 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="packed_scene" type="PackedScene" />
 			<description>
-				Assigns a [PackedScene] resource to the scene tile with [param id]. This will fail if the scene does not extend CanvasItem, as positioning properties are needed to place the scene on the TileMap.
+				Assigns a [PackedScene] resource to the scene tile with [param id]. This will fail if the scene does not extend [CanvasItem], as positioning properties are needed to place the scene on the [TileMapLayer].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
We have several important doc pages that still reference TileMap, when it is already deprecated, as well as code examples that do not work on the new TileMapLayers.

- TileData
- TileSet
- TileSetAtlasSource
- TileSetScenesCollectionSource

Pretty sure there are other places, but these are the most important since they're closely related to TileMapLayers.
