### PR TITLE
Enable changing editor language without restart

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7369,7 +7369,7 @@ EditorNode::EditorNode() {
 	main_menu->set_switch_on_hover(true);
 
 	file_menu = memnew(PopupMenu);
-	file_menu->set_name(TTR("Scene"));
+	file_menu->set_name(TTRC("Scene"));
 	main_menu->add_child(file_menu);
 	main_menu->set_menu_tooltip(0, TTR("Operations with scene files."));
 
@@ -7494,7 +7494,7 @@ EditorNode::EditorNode() {
 #endif
 
 	project_menu = memnew(PopupMenu);
-	project_menu->set_name(TTR("Project"));
+	project_menu->set_name(TTRC("Project"));
 	main_menu->add_child(project_menu);
 
 	project_menu->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/project_settings", TTRC("Project Settings..."), Key::NONE, TTRC("Project Settings")), PROJECT_OPEN_SETTINGS);
@@ -7552,11 +7552,11 @@ EditorNode::EditorNode() {
 
 	// Options are added and handled by DebuggerEditorPlugin.
 	debug_menu = memnew(PopupMenu);
-	debug_menu->set_name(TTR("Debug"));
+	debug_menu->set_name(TTRC("Debug"));
 	main_menu->add_child(debug_menu);
 
 	settings_menu = memnew(PopupMenu);
-	settings_menu->set_name(TTR("Editor"));
+	settings_menu->set_name(TTRC("Editor"));
 	main_menu->add_child(settings_menu);
 
 #ifdef MACOS_ENABLED
@@ -7607,7 +7607,7 @@ EditorNode::EditorNode() {
 #endif
 
 	help_menu = memnew(PopupMenu);
-	help_menu->set_name(TTR("Help"));
+	help_menu->set_name(TTRC("Help"));
 	if (global_menu && NativeMenu::get_singleton()->has_system_menu(NativeMenu::HELP_MENU_ID)) {
 		help_menu->set_system_menu(NativeMenu::HELP_MENU_ID);
 	}

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -68,6 +68,10 @@ bool EditorSettings::_set(const StringName &p_name, const Variant &p_value) {
 	if (changed && initialized) {
 		changed_settings.insert(p_name);
 		emit_signal(SNAME("settings_changed"));
+
+		if (p_name == SNAME("interface/editor/editor_language")) {
+			setup_language();
+		}
 	}
 	return true;
 }
@@ -1256,9 +1260,9 @@ fail:
 
 void EditorSettings::setup_language() {
 	String lang = get("interface/editor/editor_language");
-	TranslationServer::get_singleton()->set_locale(lang);
 
 	if (lang == "en") {
+		TranslationServer::get_singleton()->set_locale(lang);
 		return; // Default, nothing to do.
 	}
 	// Load editor translation for configured/detected locale.
@@ -1270,6 +1274,8 @@ void EditorSettings::setup_language() {
 
 	// Load extractable translation for projects.
 	load_extractable_translations(lang);
+
+	TranslationServer::get_singleton()->set_locale(lang);
 }
 
 void EditorSettings::setup_network() {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -770,9 +770,7 @@ void SceneTree::_main_window_focus_in() {
 void SceneTree::_notification(int p_notification) {
 	switch (p_notification) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			if (!Engine::get_singleton()->is_editor_hint()) {
-				get_root()->propagate_notification(p_notification);
-			}
+			get_root()->propagate_notification(p_notification);
 		} break;
 
 		case NOTIFICATION_OS_MEMORY_WARNING:


### PR DESCRIPTION
Currently changing editor language requires editor restart. Godot has a good auto-translation system, which is under-utilized in the editor. For a long time the editor auto-translation was completely disabled. Then there is TTR method which we use everywhere, which makes it impossible to auto-translate, because it immediately translates the string.

#75012 enabled auto-translation to work in the editor, and recently there were some efforts to replace TTR with TTRC (e.g. #99158). Also in 4.4 there were various GUI enhancements that added better localization support to many Control nodes.

This PR makes another step - it actually enables language switching in the editor.

https://github.com/user-attachments/assets/4f8bf1a4-a8b4-437d-85ce-84f118ab63cf

Though as you can see, it's very basic right now. For proper language switching we need to use TTRC where possible, and NOTIFICATION_TRANSLATION_CHANGED where not (e.g. in format strings). Thus, while the PR makes changing the language setting have immediate effect, the user is still prompted to restart the editor as before.

IMO enabling this before the editor is ready is harmless, while it allows for easier testing of auto-translation. Eventually we will be able to properly switch editor language without restart at all.

Included some extra changes to the top menu bar, to make it more obvious that the language has changed.