### PR TITLE
Add parentheses to method links in online class reference

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -2238,6 +2238,8 @@ def format_text_block(
                         repl_text = target_name
                         if target_class_name != state.current_class:
                             repl_text = f"{target_class_name}.{target_name}"
+                        if tag_state.name == "method":
+                            repl_text = f"{repl_text}()"
                         tag_text = f":ref:`{repl_text}<class_{sanitize_class_name(target_class_name)}{ref_type}_{target_name}>`"
                         escape_pre = True
                         escape_post = True


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/10641.

Currently we use parentheses when linking to methods within the editor class reference, but not the online class reference. This PR unifies the look of both by using parentheses for method links in the online class reference.
**Editor:**
![Screenshot 2025-02-07 150315](https://github.com/user-attachments/assets/37528ec4-30b3-499d-a7b2-0b4ad9722373)

**Online, master:**
![Screenshot 2025-02-07 150326](https://github.com/user-attachments/assets/a4bccf29-0de4-4a4a-aa07-0122843099e4)

**Online, after this PR:**
![image](https://github.com/user-attachments/assets/0705ec6c-5fd3-43ac-8637-2ef28de6b998)


**Testing:**
- Generate the RST files with some variant of the command from the Sync Class Reference GHA (https://github.com/godotengine/godot-docs/blob/cb0009a3c89c5841e8644e9c6f6a95d96821d941/.github/workflows/sync_class_ref.yml#L59). I used this on Windows:
```
.\doc\tools\make_rst.py --color -o ../classes -l en ./doc/classes ./modules ./platform
```
- Clone the docs repo if you don't have it. Copy the generated classes to the [classes](https://github.com/godotengine/godot-docs/tree/master/classes) folder of the docs repo, overwriting existing files. I did this by hand 🙂
- [Build the manual](https://docs.godotengine.org/en/stable/contributing/documentation/building_the_manual.html).