### PR TITLE
Fix script class icons not inheriting parent

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1023,7 +1023,7 @@ String EditorData::script_class_get_icon_path(const String &p_class, bool *r_val
 			return String();
 		}
 		HashMap<StringName, String>::ConstIterator E = _script_class_icon_paths.find(current);
-		if ((bool)E) {
+		if ((bool)E && !E->value.is_empty()) {
 			if (r_valid) {
 				*r_valid = true;
 			}


### PR DESCRIPTION
Closes #102565 by re-adding an omitted check for an empty icon path. While doing `git bisect`, identified this commit as the cause of the problem: https://github.com/godotengine/godot/commit/a20934c8e40e258e8372cbb2b7c689cc315b7e11 ([see removed check](https://github.com/godotengine/godot/commit/a20934c8e40e258e8372cbb2b7c689cc315b7e11#diff-f0240d0efbe692c6d11a2642d167512a99edb5605af5e6b749bd18173c54e6bdL1036-L1037)). There was a check for the return value being empty that was accidentally omitted, so this PR adds it back.

Sample I used for testing:
```
@icon("res://icon.svg")
extends Node2D
class_name BaseClass
```
```
extends BaseClass
class_name ChildClass
```

![image](https://github.com/user-attachments/assets/28bf8d4d-fb4a-4dac-a374-797b439bc479)
Previously, ChildScene icon would be a circle as per the issue.