### PR TITLE
Use `FlowContainer` for `EditorNetworkProfiler` bar

### DIFF
--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -35,6 +35,7 @@
 #include "editor/gui/editor_run_bar.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/flow_container.h"
 
 void EditorNetworkProfiler::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("enable_profiling", PropertyInfo(Variant::BOOL, "enable")));
@@ -297,30 +298,37 @@ bool EditorNetworkProfiler::is_profiling() {
 }
 
 EditorNetworkProfiler::EditorNetworkProfiler() {
-	HBoxContainer *hb = memnew(HBoxContainer);
-	hb->add_theme_constant_override("separation", 8 * EDSCALE);
-	add_child(hb);
+	FlowContainer *container = memnew(FlowContainer);
+	container->add_theme_constant_override(SNAME("h_separation"), 8 * EDSCALE);
+	container->add_theme_constant_override(SNAME("v_separation"), 2 * EDSCALE);
+	add_child(container);
 
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_text(TTR("Start"));
 	activate->set_disabled(true);
 	activate->connect(SceneStringName(pressed), callable_mp(this, &EditorNetworkProfiler::_activate_pressed));
-	hb->add_child(activate);
+	container->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
 	clear_button->set_disabled(true);
 	clear_button->connect(SceneStringName(pressed), callable_mp(this, &EditorNetworkProfiler::_clear_pressed));
-	hb->add_child(clear_button);
+	container->add_child(clear_button);
 
 	CheckBox *autostart_checkbox = memnew(CheckBox);
 	autostart_checkbox->set_text(TTR("Autostart"));
 	autostart_checkbox->set_pressed(EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_network_profiler", false));
 	autostart_checkbox->connect(SceneStringName(toggled), callable_mp(this, &EditorNetworkProfiler::_autostart_toggled));
-	hb->add_child(autostart_checkbox);
+	container->add_child(autostart_checkbox);
 
-	hb->add_spacer();
+	Control *c = memnew(Control);
+	c->set_h_size_flags(SIZE_EXPAND_FILL);
+	container->add_child(c);
+
+	HBoxContainer *hb = memnew(HBoxContainer);
+	hb->add_theme_constant_override(SNAME("separation"), 8 * EDSCALE);
+	container->add_child(hb);
 
 	Label *lb = memnew(Label);
 	// TRANSLATORS: This is the label for the network profiler's incoming bandwidth.
@@ -359,7 +367,7 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 
 	// RPC
 	counters_display = memnew(Tree);
-	counters_display->set_custom_minimum_size(Size2(320, 0) * EDSCALE);
+	counters_display->set_custom_minimum_size(Size2(280, 0) * EDSCALE);
 	counters_display->set_v_size_flags(SIZE_EXPAND_FILL);
 	counters_display->set_h_size_flags(SIZE_EXPAND_FILL);
 	counters_display->set_hide_folding(true);
@@ -382,7 +390,7 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 
 	// Replication
 	replication_display = memnew(Tree);
-	replication_display->set_custom_minimum_size(Size2(320, 0) * EDSCALE);
+	replication_display->set_custom_minimum_size(Size2(280, 0) * EDSCALE);
 	replication_display->set_v_size_flags(SIZE_EXPAND_FILL);
 	replication_display->set_h_size_flags(SIZE_EXPAND_FILL);
 	replication_display->set_hide_folding(true);


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/102024, but for `EditorNetworkProfiler` bar.
Separated from https://github.com/godotengine/godot/pull/102301.
Fixes  https://github.com/godotengine/godot/issues/97784.

This should prevent the editor GUI from breaking when the `NetworkProfiler` tab is opened and the window is small.
| Before - part of right (`Inspector`) dock is _out of screen_ | After |
| --- | --- |
| ![Godot_v4 4-beta3_win64_FINjX97Ooo](https://github.com/user-attachments/assets/50a7a96c-3e03-414e-9828-9f0ea4c35603) | ![godot windows editor dev x86_64_IizQ3sUjtT](https://github.com/user-attachments/assets/865c6606-576f-48c8-8985-00d86dad8328) |


This is how it looks "in motion" on FullHD monitor with maximized window (to compare before-after appearance difference):

https://github.com/user-attachments/assets/104e4181-63f5-4546-afe0-9836eacbfab2