### PR TITLE
Add a background toggle button to tile atlas view

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -152,6 +152,11 @@ void TileAtlasView::_zoom_widget_changed() {
 	emit_signal(SNAME("transform_changed"), zoom_widget->get_zoom(), panning);
 }
 
+void TileAtlasView::_toggle_background() {
+	background_left->set_visible(!background_left->is_visible());
+	background_right->set_visible(!background_right->is_visible());
+}
+
 void TileAtlasView::_center_view() {
 	panning = Vector2();
 	button_center_view->set_disabled(true);
@@ -618,6 +623,7 @@ void TileAtlasView::_notification(int p_what) {
 
 		case NOTIFICATION_THEME_CHANGED: {
 			button_center_view->set_button_icon(theme_cache.center_view_icon);
+			background_toggle->set_button_icon(theme_cache.checkerboard);
 		} break;
 	}
 }
@@ -637,6 +643,14 @@ TileAtlasView::TileAtlasView() {
 	panel->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(panel);
 
+	HBoxContainer *hbox2 = memnew(HBoxContainer);
+	hbox2->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
+	hbox2->set_h_size_flags(SIZE_SHRINK_BEGIN);
+	hbox2->set_v_size_flags(SIZE_SHRINK_END);
+	hbox2->set_anchors_and_offsets_preset(Control::PRESET_TOP_RIGHT, Control::PRESET_MODE_MINSIZE, 5);
+	hbox2->set_grow_direction_preset(Control::PRESET_TOP_RIGHT);
+	add_child(hbox2);
+
 	zoom_widget = memnew(EditorZoomWidget);
 	add_child(zoom_widget);
 	zoom_widget->set_anchors_and_offsets_preset(Control::PRESET_TOP_LEFT, Control::PRESET_MODE_MINSIZE, 2 * EDSCALE);
@@ -650,7 +664,23 @@ TileAtlasView::TileAtlasView() {
 	button_center_view->set_flat(true);
 	button_center_view->set_disabled(true);
 	button_center_view->set_tooltip_text(TTR("Center View"));
-	add_child(button_center_view);
+	hbox2->add_child(button_center_view);
+
+	background_toggle = memnew(Button);
+	background_toggle->set_anchors_and_offsets_preset(Control::PRESET_TOP_RIGHT, Control::PRESET_MODE_MINSIZE, 5);
+	background_toggle->set_grow_direction_preset(Control::PRESET_TOP_RIGHT);
+	background_toggle->connect(SceneStringName(pressed), callable_mp(this, &TileAtlasView::_toggle_background));
+	background_toggle->set_flat(true);
+	background_toggle->set_tooltip_text(TTR("Toggle Background"));
+
+	// Retrieve the icon
+	Ref<Texture2D> checkerboard = get_editor_theme_icon(SNAME("Checkerboard"));
+
+	// Scale it to match center view icon
+	background_toggle->set_button_icon(checkerboard);
+	background_toggle->add_theme_constant_override("icon_max_width", get_editor_theme_icon(SNAME("CenterView"))->get_size().x * EDSCALE);
+
+	hbox2->add_child(background_toggle);
 
 	panner.instantiate();
 	panner->set_callbacks(callable_mp(this, &TileAtlasView::_pan_callback), callable_mp(this, &TileAtlasView::_zoom_callback));

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -61,6 +61,7 @@ private:
 	Vector2 panning;
 	void _update_zoom_and_panning(bool p_zoom_on_mouse_pos = false);
 	void _zoom_widget_changed();
+	void _toggle_background();
 	void _center_view();
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
@@ -81,6 +82,7 @@ private:
 	void _draw_background_left();
 	Control *background_right = nullptr;
 	void _draw_background_right();
+	Button *background_toggle = nullptr;
 
 	// Left side.
 	Control *base_tiles_root_control = nullptr;

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -36,6 +36,7 @@
 #include "scene/gui/button.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/label.h"
+#include "scene/gui/color_picker.h"
 #include "scene/gui/margin_container.h"
 #include "scene/resources/2d/tile_set.h"
 
@@ -57,11 +58,13 @@ private:
 	float previous_zoom = 1.0;
 	EditorZoomWidget *zoom_widget = nullptr;
 	Button *button_center_view = nullptr;
+	Panel *panel = nullptr;
+	ColorPickerButton *background_color_picker = nullptr;
 	CenterContainer *center_container = nullptr;
 	Vector2 panning;
 	void _update_zoom_and_panning(bool p_zoom_on_mouse_pos = false);
 	void _zoom_widget_changed();
-	void _toggle_background();
+	void _change_background_color(Color p_color);
 	void _center_view();
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
@@ -82,7 +85,6 @@ private:
 	void _draw_background_left();
 	Control *background_right = nullptr;
 	void _draw_background_right();
-	Button *background_toggle = nullptr;
 
 	// Left side.
 	Control *base_tiles_root_control = nullptr;


### PR DESCRIPTION
This pull request resolves a common issue when working with the tile atlas view in the editor: if you have light-colored tiles with transparent backgrounds, the checkerboard pattern makes it very difficult to view them.

Adding a simple toggle button to the view is the simplest and most convenient solution.

https://github.com/user-attachments/assets/5930416c-4cec-4bcc-9a05-8084b1da0e57

The checkerboard pattern introduces a lot of visual "noise" when viewing tiles with transparency and light color, making it difficult to parse details:
<img width="1055" alt="Screenshot 2025-02-08 044709" src="https://github.com/user-attachments/assets/85465c71-8604-490f-a014-d8eef965a832" />

This issue is exacerbated even more if the user happens to also be using a light theme:
<img width="1046" alt="light theme" src="https://github.com/user-attachments/assets/2effa280-c180-49ec-b77c-c59a7ae7902e" />

Simply disabling the checkerboard pattern fixes this entirely. Now everything is very clear:
<img width="1051" alt="Screenshot 2025-02-08 044733" src="https://github.com/user-attachments/assets/682e576c-4326-4643-9a93-f71c539dbbda" />

<img width="1046" alt="light theme 2" src="https://github.com/user-attachments/assets/7371fee0-9b05-42bb-a3ad-bc101ff44c83" />
