### PR TITLE
Don't send `TRANSLATION_CHANGED` outside tree

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1378,7 +1378,10 @@ void Node::_propagate_translation_domain_dirty() {
 			child->_propagate_translation_domain_dirty();
 		}
 	}
-	notification(NOTIFICATION_TRANSLATION_CHANGED);
+
+	if (is_inside_tree() && data.auto_translate_mode != AUTO_TRANSLATE_MODE_DISABLED) {
+		notification(NOTIFICATION_TRANSLATION_CHANGED);
+	}
 }
 
 StringName Node::get_name() const {


### PR DESCRIPTION
Setting translation domain will always send NOTIFICATION_TRANSLATION_CHANGED, even if the node is outside tree. This is unnecessary, because Nodes will always receive this notification when entering scene tree. The double notification can be observed e.g. in Project Manager and EditorNode.

This PR prevents that. I also added check for AUTO_TRANSLATE_MODE_DISABLED, because setting domain with disabled translating has no effect. This is consistent with
https://github.com/godotengine/godot/blob/36d90c73a843afa2807a0b8dcbfbf52bdb8a759c/scene/main/node.cpp#L146-L149