### PR TITLE
Update `issue template` to request Target device details when applicable

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,6 +40,17 @@ body:
     validations:
       required: true
 
+  - type: input
+    attributes:
+      label: Target device information (optional)
+      description: |
+        - Please provide the target device details if the issue occurs on or is related to Android/iOS.
+        - If using a Samsung device, check if it has a Snapdragon or Exynos SoC as well. Samsung devices sold in the US, Canada and China typically have a Snapdragon SoC, while devices sold elsewhere typically have an Exynos SoC.
+        - You can check your device information in the system settings.
+      placeholder: Pixel 6 - Android 12 - Google Tensor - Mali-G78 MP20 - 8 GB RAM, iPhone 15 Pro
+    validations:
+      required: false
+
   - type: textarea
     attributes:
       label: Issue description


### PR DESCRIPTION
Many issues related to Android are **device/hardware specific**, but users often only provide details about the OS they are running the editor on.

This PR adds an _optional_ field in the issue template to request Target device details for Android/iOS.

This would help in diagnosing Android/iOS related issues.