### PR TITLE
Script Editor: Add option to disable documentation tooltips

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1237,6 +1237,9 @@
 		<member name="text_editor/appearance/whitespace/line_spacing" type="int" setter="" getter="">
 			The space to add between lines (in pixels). Greater line spacing can help improve readability at the cost of displaying fewer lines on screen.
 		</member>
+		<member name="text_editor/behavior/documentation/enable_tooltips" type="bool" setter="" getter="">
+			If [code]true[/code], documentation tooltips will appear when hovering over a symbol.
+		</member>
 		<member name="text_editor/behavior/files/auto_reload_and_parse_scripts_on_save" type="bool" setter="" getter="">
 			If [code]true[/code], tool scripts will be automatically soft-reloaded after they are saved.
 		</member>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -719,6 +719,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/files/auto_reload_and_parse_scripts_on_save", true);
 	_initial_set("text_editor/behavior/files/open_dominant_script_on_scene_change", false, true);
 
+	// Behavior: Documentation
+	_initial_set("text_editor/behavior/documentation/enable_tooltips", true, true);
+
 	// Script list
 	_initial_set("text_editor/script_list/show_members_overview", true, true);
 	_initial_set("text_editor/script_list/sort_members_outline_alphabetically", false, true);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -440,6 +440,7 @@ class ScriptEditor : public PanelContainer {
 	void _goto_script_line(Ref<RefCounted> p_script, int p_line);
 	void _set_execution(Ref<RefCounted> p_script, int p_line);
 	void _clear_execution(Ref<RefCounted> p_script);
+	String _get_debug_tooltip(const String &p_text, Node *p_se);
 	void _breaked(bool p_breaked, bool p_can_debug);
 	void _script_created(Ref<Script> p_script);
 	void _set_breakpoint(Ref<RefCounted> p_script, int p_line, bool p_enabled);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1103,6 +1103,10 @@ void ScriptTextEditor::_validate_symbol(const String &p_symbol) {
 }
 
 void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, int p_column) {
+	if (!EDITOR_GET("text_editor/behavior/documentation/enable_tooltips").booleanize()) {
+		return;
+	}
+
 	if (p_symbol.begins_with("res://") || p_symbol.begins_with("uid://")) {
 		EditorHelpBitTooltip::show_tooltip(code_editor->get_text_editor(), "resource||" + p_symbol);
 		return;
@@ -1203,19 +1207,14 @@ void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, i
 		}
 	}
 
+	// NOTE: See also `ScriptEditor::_get_debug_tooltip()` for documentation tooltips disabled.
 	String debug_value = EditorDebuggerNode::get_singleton()->get_var_value(p_symbol);
 	if (!debug_value.is_empty()) {
 		constexpr int DISPLAY_LIMIT = 1024;
 		if (debug_value.size() > DISPLAY_LIMIT) {
 			debug_value = debug_value.left(DISPLAY_LIMIT) + "... " + TTR("(truncated)");
 		}
-		debug_value = debug_value.replace("[", "[lb]");
-
-		if (doc_symbol.is_empty()) {
-			debug_value = p_symbol + ": " + debug_value;
-		} else {
-			debug_value = TTR("Current value: ") + debug_value;
-		}
+		debug_value = TTR("Current value: ") + debug_value.replace("[", "[lb]");
 	}
 
 	if (!doc_symbol.is_empty() || !debug_value.is_empty()) {


### PR DESCRIPTION
* See https://github.com/godotengine/godot/pull/91060#issuecomment-2646026349.
* This PR adds the setting `text_editor/behavior/documentation/enable_tooltips` that allows you to disable documentation tooltips for the Script Editor only (Inspector, Project Settings, etc. still show tooltips).
* In my opinion, this option makes sense regardless of the MacOS bugs, since some users may want to disable tooltips even if there are no bugs, if the tooltips annoy them. For Inspector, tooltips have the current behavior since 4.3.
* Simple debugger tooltips are shown if documentation tooltips are disabled. Partially reverts #101156 to this.