### PR TITLE
Fix lag when resizing Floating Game Window

### DIFF
--- a/editor/plugins/embedded_process.cpp
+++ b/editor/plugins/embedded_process.cpp
@@ -40,6 +40,12 @@ void EmbeddedProcess::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			window = get_window();
 		} break;
+		case NOTIFICATION_PROCESS: {
+			if (updated_embedded_process_queued) {
+				updated_embedded_process_queued = false;
+				_update_embedded_process();
+			}
+		} break;
 		case NOTIFICATION_DRAW: {
 			_draw();
 		} break;
@@ -179,6 +185,7 @@ void EmbeddedProcess::embed_process(OS::ProcessID p_pid) {
 	start_embedding_time = OS::get_singleton()->get_ticks_msec();
 	embedding_grab_focus = has_focus();
 	timer_update_embedded_process->start();
+	set_process(true);
 	set_notify_transform(true);
 
 	// Attempt to embed the process, but if it has just started and the window is not ready yet,
@@ -196,6 +203,7 @@ void EmbeddedProcess::reset() {
 	embedding_grab_focus = false;
 	timer_embedding->stop();
 	timer_update_embedded_process->stop();
+	set_process(false);
 	set_notify_transform(false);
 	queue_redraw();
 }
@@ -250,11 +258,6 @@ void EmbeddedProcess::_timer_update_embedded_process_timeout() {
 			last_global_rect = new_global_rect;
 			queue_update_embedded_process();
 		}
-	}
-
-	if (updated_embedded_process_queued) {
-		updated_embedded_process_queued = false;
-		_update_embedded_process();
 	}
 }
 


### PR DESCRIPTION
- Fixes #102566

This PR reverts the frequency at which the update for the embedded process is performed. It is now executed again each time the floating window is resized or moved, significantly improving the user experience.

To avoid performing calculations on every frame and a deferred call, I retained the new timer to detect incorrectly focused windows/processes and mouse-over focus. These operations can be executed less frequently. The update for the embedded process now occurs in the `process` notification.

I retested this on my old computer, and the difference is mostly unnoticeable.

Fedora 41 KDE Plasma - Godot 4.4 Beta 3:

[Screencast_20250209_073251.webm](https://github.com/user-attachments/assets/14f0748e-cca4-406c-88a0-c9e3930674ee)

Fedora 41 KDE Plasma - Godot this PR:

[Screencast_20250209_073125.webm](https://github.com/user-attachments/assets/3cda644d-682d-49d0-9229-5f8bd8aa54c0)
