### PR TITLE
Consistently update texture paths in rendering server

### DIFF
--- a/modules/noise/noise_texture_3d.cpp
+++ b/modules/noise/noise_texture_3d.cpp
@@ -106,6 +106,8 @@ void NoiseTexture3D::_set_texture_data(const TypedArray<Image> &p_data) {
 		} else {
 			texture = RS::get_singleton()->texture_3d_create(data[0]->get_format(), data[0]->get_width(), data[0]->get_height(), data.size(), false, data);
 		}
+		RS::get_singleton()->texture_set_path(texture, get_path());
+
 		format = data[0]->get_format();
 	}
 	emit_changed();

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -146,6 +146,8 @@ Error CompressedTexture2D::load(const String &p_path) {
 	} else {
 		texture = RS::get_singleton()->texture_2d_create(image);
 	}
+	RS::get_singleton()->texture_set_path(texture, get_path());
+
 	if (lw || lh) {
 		RS::get_singleton()->texture_set_size_override(texture, lw, lh);
 	}
@@ -567,6 +569,7 @@ Error CompressedTexture3D::load(const String &p_path) {
 	} else {
 		texture = RS::get_singleton()->texture_3d_create(tfmt, tw, th, td, tmm, data);
 	}
+	RS::get_singleton()->texture_set_path(texture, get_path());
 
 	w = tw;
 	h = th;
@@ -756,6 +759,7 @@ Error CompressedTextureLayered::load(const String &p_path) {
 	} else {
 		texture = RS::get_singleton()->texture_2d_layered_create(images, RS::TextureLayeredType(layered_type));
 	}
+	RS::get_singleton()->texture_set_path(texture, get_path());
 
 	w = images[0]->get_width();
 	h = images[0]->get_height();

--- a/scene/resources/curve_texture.cpp
+++ b/scene/resources/curve_texture.cpp
@@ -134,6 +134,8 @@ void CurveTexture::_update() {
 	} else {
 		_texture = RS::get_singleton()->texture_2d_create(image);
 	}
+	RS::get_singleton()->texture_set_path(_texture, get_path());
+
 	_current_texture_mode = texture_mode;
 	_current_width = _width;
 
@@ -336,6 +338,8 @@ void CurveXYZTexture::_update() {
 	} else {
 		_texture = RS::get_singleton()->texture_2d_create(image);
 	}
+	RS::get_singleton()->texture_set_path(_texture, get_path());
+
 	_current_width = _width;
 
 	emit_changed();

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -95,6 +95,8 @@ void ImageTexture::set_image(const Ref<Image> &p_image) {
 		RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_image);
 		RenderingServer::get_singleton()->texture_replace(texture, new_texture);
 	}
+	RS::get_singleton()->texture_set_path(texture, get_path());
+
 	notify_property_list_changed();
 	emit_changed();
 
@@ -325,6 +327,7 @@ Error ImageTextureLayered::create_from_images(Vector<Ref<Image>> p_images) {
 		texture = RS::get_singleton()->texture_2d_layered_create(p_images, RS::TextureLayeredType(layered_type));
 		ERR_FAIL_COND_V(!texture.is_valid(), ERR_CANT_CREATE);
 	}
+	RS::get_singleton()->texture_set_path(texture, get_path());
 
 	format = new_format;
 	width = new_width;
@@ -428,6 +431,7 @@ Error ImageTexture3D::create(Image::Format p_format, int p_width, int p_height, 
 	} else {
 		texture = tex;
 	}
+	RS::get_singleton()->texture_set_path(texture, get_path());
 
 	format = p_format;
 	width = p_width;


### PR DESCRIPTION
Fixes #102622

Since texture creation and replacement invalidates the rendering server path, update it right after that to avoid inconsistencies. `NoiseTexture2D` and `GradientTexture` already do this.