### PR TITLE
Fix multiple issues with 'add alternative tile' tileset editor button

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -253,6 +253,7 @@ private:
 	PopupMenu *alternative_tile_popup_menu = nullptr;
 	Control *alternative_tiles_control = nullptr;
 	Control *alternative_tiles_control_unscaled = nullptr;
+	void _tile_alternatives_create_button_pressed(const Vector2i &p_atlas_coords);
 	void _tile_alternatives_control_draw();
 	void _tile_alternatives_control_unscaled_draw();
 	void _tile_alternatives_control_mouse_exited();


### PR DESCRIPTION
Fix multiple issues with 'add alternative tile' tileset editor button in "Alternative tiles" section:
1. Fix button being oversized and not rendered properly on small (texture region size < 12px) tilesets (fixes #99764)
2. Stop button from interfering with MMB panning
3. Fix undo not working on tiles created with this button
4. Stop the button from appearing while painting tile properties

The undo doesn't undo increments in `next_alternative_id` counter within TileSetAtlasSource, but that's an existing issue that also happens when creating alternative tiles via RMB.

Before/after:
![image](https://github.com/user-attachments/assets/6f063c43-e7a2-4393-aede-d3186200a0f9)

