### PR TITLE
Use fallback locale from project settings instead of hardcoded "en" for TextServer.

### DIFF
--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -503,7 +503,7 @@ String TranslationServer::get_tool_locale() {
 		// Look for best matching loaded translation.
 		Ref<Translation> t = main_domain->get_translation_object(locale);
 		if (t.is_null()) {
-			return "en";
+			return fallback;
 		}
 		return t->get_locale();
 	}


### PR DESCRIPTION
`TextServer` use locale for some features (line breaking, number formatting, contextual shaping, case conversion, fallback font selection, base direction detection). If translation files are missing, it was using hardcode "en". This PR changes it to use user controllable `internationalization/locale/fallback` project setting (defaults to "en") instead.

Should allow workaround for issues like https://github.com/godotengine/godot/issues/100642 without adding translation files (this is not a full fix, which should be based on https://github.com/godotengine/godot/pull/97918 and involve some API changes).