### PR TITLE
Prevent `changed` signal spam on resource reload.

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -36,12 +36,30 @@
 #include "scene/main/node.h" //only so casting works
 
 void Resource::emit_changed() {
+	if (emit_changed_state != EMIT_CHANGED_UNBLOCKED) {
+		emit_changed_state = EMIT_CHANGED_BLOCKED_PENDING_EMIT;
+		return;
+	}
 	if (ResourceLoader::is_within_load() && !Thread::is_main_thread()) {
 		ResourceLoader::resource_changed_emit(this);
 		return;
 	}
 
 	emit_signal(CoreStringName(changed));
+}
+
+void Resource::_block_emit_changed() {
+	if (emit_changed_state == EMIT_CHANGED_UNBLOCKED) {
+		emit_changed_state = EMIT_CHANGED_BLOCKED;
+	}
+}
+
+void Resource::_unblock_emit_changed() {
+	bool emit = (emit_changed_state == EMIT_CHANGED_BLOCKED_PENDING_EMIT);
+	emit_changed_state = EMIT_CHANGED_UNBLOCKED;
+	if (emit) {
+		emit_changed();
+	}
 }
 
 void Resource::_resource_path_changed() {
@@ -205,6 +223,8 @@ Error Resource::copy_from(const Ref<Resource> &p_resource) {
 		return ERR_INVALID_PARAMETER;
 	}
 
+	_block_emit_changed();
+
 	reset_state(); // May want to reset state.
 
 	List<PropertyInfo> pi;
@@ -220,6 +240,9 @@ Error Resource::copy_from(const Ref<Resource> &p_resource) {
 
 		set(E.name, p_resource->get(E.name));
 	}
+
+	_unblock_emit_changed();
+
 	return OK;
 }
 

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -72,6 +72,12 @@ private:
 	String import_path;
 #endif
 
+	enum EmitChangedState {
+		EMIT_CHANGED_UNBLOCKED,
+		EMIT_CHANGED_BLOCKED,
+		EMIT_CHANGED_BLOCKED_PENDING_EMIT,
+	};
+	EmitChangedState emit_changed_state = EMIT_CHANGED_UNBLOCKED;
 	bool local_to_scene = false;
 	friend class SceneState;
 	Node *local_scene = nullptr;
@@ -84,6 +90,9 @@ private:
 protected:
 	virtual void _resource_path_changed();
 	static void _bind_methods();
+
+	void _block_emit_changed();
+	void _unblock_emit_changed();
 
 	void _set_path(const String &p_path);
 	void _take_over_path(const String &p_path);


### PR DESCRIPTION
Partially fixes https://github.com/godotengine/godot/issues/102609, now reimporting default theme font will reload theme only 4 times (probably something to do with old font sending changed signals to the new one, will check it later) instead of 20+.

I'm not sure this change is entirely safe, something might rely on getting `changed` signal immediately.