### PR TITLE
Add `_late_physics_process`

### DIFF
--- a/core/os/main_loop.cpp
+++ b/core/os/main_loop.cpp
@@ -46,6 +46,7 @@ void MainLoop::_bind_methods() {
 
 	GDVIRTUAL_BIND(_initialize);
 	GDVIRTUAL_BIND(_physics_process, "delta");
+	GDVIRTUAL_BIND(_late_physics_process, "delta");
 	GDVIRTUAL_BIND(_process, "delta");
 	GDVIRTUAL_BIND(_finalize);
 }
@@ -57,6 +58,12 @@ void MainLoop::initialize() {
 bool MainLoop::physics_process(double p_time) {
 	bool quit = false;
 	GDVIRTUAL_CALL(_physics_process, p_time, quit);
+	return quit;
+}
+
+bool MainLoop::late_physics_process(double p_time) {
+	bool quit = false;
+	GDVIRTUAL_CALL(_late_physics_process, p_time, quit);
 	return quit;
 }
 

--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -43,6 +43,7 @@ protected:
 
 	GDVIRTUAL0(_initialize)
 	GDVIRTUAL1R(bool, _physics_process, double)
+	GDVIRTUAL1R(bool, _late_physics_process, double)
 	GDVIRTUAL1R(bool, _process, double)
 	GDVIRTUAL0(_finalize)
 
@@ -64,6 +65,7 @@ public:
 	virtual void initialize();
 	virtual void iteration_prepare() {}
 	virtual bool physics_process(double p_time);
+	virtual bool late_physics_process(double p_time);
 	virtual void iteration_end() {}
 	virtual bool process(double p_time);
 	virtual void finalize();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4456,6 +4456,32 @@ bool Main::iteration() {
 
 		message_queue->flush();
 
+#ifndef _3D_DISABLED
+		PhysicsServer3D::get_singleton()->sync();
+		PhysicsServer3D::get_singleton()->flush_queries();
+#endif // _3D_DISABLED
+
+		PhysicsServer2D::get_singleton()->sync();
+		PhysicsServer2D::get_singleton()->flush_queries();
+
+		if (OS::get_singleton()->get_main_loop()->late_physics_process(physics_step * time_scale)) {
+#ifndef _3D_DISABLED
+			PhysicsServer3D::get_singleton()->end_sync();
+#endif // _3D_DISABLED
+			PhysicsServer2D::get_singleton()->end_sync();
+
+			Engine::get_singleton()->_in_physics = false;
+			exit = true;
+			break;
+		}
+
+#ifndef _3D_DISABLED
+		PhysicsServer3D::get_singleton()->end_sync();
+#endif // _3D_DISABLED
+		PhysicsServer2D::get_singleton()->end_sync();
+
+		message_queue->flush();
+
 		OS::get_singleton()->get_main_loop()->iteration_end();
 
 		physics_process_ticks = MAX(physics_process_ticks, OS::get_singleton()->get_ticks_usec() - physics_begin); // keep the largest one for reference

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -59,6 +59,10 @@ void Node::_notification(int p_notification) {
 			GDVIRTUAL_CALL(_physics_process, get_physics_process_delta_time());
 		} break;
 
+		case NOTIFICATION_LATE_PHYSICS_PROCESS: {
+			GDVIRTUAL_CALL(_late_physics_process, get_physics_process_delta_time());
+		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			ERR_FAIL_NULL(get_viewport());
 			ERR_FAIL_NULL(get_tree());
@@ -222,6 +226,9 @@ void Node::_notification(int p_notification) {
 			}
 			if (GDVIRTUAL_IS_OVERRIDDEN(_physics_process)) {
 				set_physics_process(true);
+			}
+			if (GDVIRTUAL_IS_OVERRIDDEN(_late_physics_process)) {
+				set_late_physics_process(true);
 			}
 
 			GDVIRTUAL_CALL(_ready);
@@ -595,6 +602,32 @@ void Node::set_physics_process(bool p_process) {
 	}
 }
 
+bool Node::is_late_physics_processing() const {
+	return data.late_physics_process;
+}
+
+void Node::set_late_physics_process(bool p_process) {
+	ERR_THREAD_GUARD
+	if (data.late_physics_process == p_process) {
+		return;
+	}
+
+	if (!is_inside_tree()) {
+		data.late_physics_process = p_process;
+		return;
+	}
+
+	if (_is_any_processing()) {
+		_remove_from_process_thread_group();
+	}
+
+	data.late_physics_process = p_process;
+
+	if (_is_any_processing()) {
+		_add_to_process_thread_group();
+	}
+}
+
 bool Node::is_physics_processing() const {
 	return data.physics_process;
 }
@@ -858,6 +891,8 @@ bool Node::can_process_notification(int p_what) const {
 			return data.process_internal;
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS:
 			return data.physics_process_internal;
+		case NOTIFICATION_LATE_PHYSICS_PROCESS:
+			return data.late_physics_process;
 	}
 
 	return true;
@@ -3655,6 +3690,8 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_physics_process", "enable"), &Node::set_physics_process);
 	ClassDB::bind_method(D_METHOD("get_physics_process_delta_time"), &Node::get_physics_process_delta_time);
 	ClassDB::bind_method(D_METHOD("is_physics_processing"), &Node::is_physics_processing);
+	ClassDB::bind_method(D_METHOD("set_late_physics_process", "enable"), &Node::set_late_physics_process);
+	ClassDB::bind_method(D_METHOD("is_late_physics_processing"), &Node::is_late_physics_processing);
 	ClassDB::bind_method(D_METHOD("get_process_delta_time"), &Node::get_process_delta_time);
 	ClassDB::bind_method(D_METHOD("set_process", "enable"), &Node::set_process);
 	ClassDB::bind_method(D_METHOD("set_process_priority", "priority"), &Node::set_process_priority);
@@ -3805,6 +3842,7 @@ void Node::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_POST_ENTER_TREE);
 	BIND_CONSTANT(NOTIFICATION_DISABLED);
 	BIND_CONSTANT(NOTIFICATION_ENABLED);
+	BIND_CONSTANT(NOTIFICATION_LATE_PHYSICS_PROCESS);
 	BIND_CONSTANT(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
 
 	BIND_CONSTANT(NOTIFICATION_EDITOR_PRE_SAVE);
@@ -3902,6 +3940,7 @@ void Node::_bind_methods() {
 
 	GDVIRTUAL_BIND(_process, "delta");
 	GDVIRTUAL_BIND(_physics_process, "delta");
+	GDVIRTUAL_BIND(_late_physics_process, "delta");
 	GDVIRTUAL_BIND(_enter_tree);
 	GDVIRTUAL_BIND(_exit_tree);
 	GDVIRTUAL_BIND(_ready);
@@ -3935,6 +3974,7 @@ Node::Node() {
 	data.physics_interpolation_mode = PHYSICS_INTERPOLATION_MODE_INHERIT;
 
 	data.physics_process = false;
+	data.late_physics_process = false;
 	data.process = false;
 
 	data.physics_process_internal = false;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -209,6 +209,7 @@ private:
 		PhysicsInterpolationMode physics_interpolation_mode : 2;
 
 		bool physics_process : 1;
+		bool late_physics_process : 1;
 		bool process : 1;
 
 		bool physics_process_internal : 1;
@@ -386,6 +387,7 @@ protected:
 
 	GDVIRTUAL1(_process, double)
 	GDVIRTUAL1(_physics_process, double)
+	GDVIRTUAL1(_late_physics_process, double)
 	GDVIRTUAL0(_enter_tree)
 	GDVIRTUAL0(_exit_tree)
 	GDVIRTUAL0(_ready)
@@ -420,6 +422,7 @@ public:
 		NOTIFICATION_DISABLED = 28,
 		NOTIFICATION_ENABLED = 29,
 		NOTIFICATION_RESET_PHYSICS_INTERPOLATION = 2001, // A GodotSpace Odyssey.
+		NOTIFICATION_LATE_PHYSICS_PROCESS = 2002,
 		// Keep these linked to Node.
 		NOTIFICATION_WM_MOUSE_ENTER = 1002,
 		NOTIFICATION_WM_MOUSE_EXIT = 1003,
@@ -584,6 +587,9 @@ public:
 	double get_physics_process_delta_time() const;
 	bool is_physics_processing() const;
 
+	void set_late_physics_process(bool p_process);
+	bool is_late_physics_processing() const;
+
 	void set_process(bool p_process);
 	double get_process_delta_time() const;
 	bool is_processing() const;
@@ -616,7 +622,7 @@ public:
 	bool is_processing_unhandled_key_input() const;
 
 	_FORCE_INLINE_ bool _is_any_processing() const {
-		return data.process || data.process_internal || data.physics_process || data.physics_process_internal;
+		return data.process || data.process_internal || data.physics_process || data.physics_process_internal || data.late_physics_process;
 	}
 	_FORCE_INLINE_ bool is_accessible_from_caller_thread() const {
 		if (current_process_thread_group == nullptr) {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -530,13 +530,35 @@ bool SceneTree::physics_process(double p_time) {
 
 	call_group(SNAME("_picking_viewports"), SNAME("_process_picking"));
 
-	_process(true);
+	_process(PROCESS_KIND_PHYSICS);
 
 	_flush_ugc();
 	MessageQueue::get_singleton()->flush(); //small little hack
 
 	process_timers(p_time, true); //go through timers
 	process_tweens(p_time, true);
+
+	flush_transform_notifications();
+
+	// This should happen last because any processing that deletes something beforehand might expect the object to be removed in the same frame.
+	_flush_delete_queue();
+	_call_idle_callbacks();
+
+	return _quit;
+}
+
+bool SceneTree::late_physics_process(double p_time) {
+	flush_transform_notifications();
+
+	if (MainLoop::late_physics_process(p_time)) {
+		_quit = true;
+	}
+	emit_signal(SNAME("late_physics_frame"));
+
+	_process(PROCESS_KIND_LATE_PHYSICS);
+
+	_flush_ugc();
+	MessageQueue::get_singleton()->flush(); //small little hack
 
 	flush_transform_notifications();
 
@@ -575,7 +597,7 @@ bool SceneTree::process(double p_time) {
 
 	flush_transform_notifications();
 
-	_process(false);
+	_process(PROCESS_KIND_IDLE);
 
 	_flush_ugc();
 	MessageQueue::get_singleton()->flush(); //small little hack
@@ -1004,27 +1026,39 @@ bool SceneTree::is_suspended() const {
 	return suspended;
 }
 
-void SceneTree::_process_group(ProcessGroup *p_group, bool p_physics) {
+void SceneTree::_process_group(ProcessGroup *p_group, ProcessKind p_processKind) {
 	// When reading this function, keep in mind that this code must work in a way where
 	// if any node is removed, this needs to continue working.
 
 	p_group->call_queue.flush(); // Flush messages before processing.
 
-	Vector<Node *> &nodes = p_physics ? p_group->physics_nodes : p_group->nodes;
+	Vector<Node *> &nodes = (p_processKind == PROCESS_KIND_IDLE) ? p_group->nodes
+			: (p_processKind == PROCESS_KIND_PHYSICS)			 ? p_group->physics_nodes
+																 : p_group->late_physics_nodes;
+
 	if (nodes.is_empty()) {
 		return;
 	}
 
-	if (p_physics) {
-		if (p_group->physics_node_order_dirty) {
-			nodes.sort_custom<Node::ComparatorWithPhysicsPriority>();
-			p_group->physics_node_order_dirty = false;
-		}
-	} else {
-		if (p_group->node_order_dirty) {
-			nodes.sort_custom<Node::ComparatorWithPriority>();
-			p_group->node_order_dirty = false;
-		}
+	switch (p_processKind) {
+		case PROCESS_KIND_IDLE:
+			if (p_group->node_order_dirty) {
+				nodes.sort_custom<Node::ComparatorWithPriority>();
+				p_group->node_order_dirty = false;
+			}
+			break;
+		case PROCESS_KIND_PHYSICS:
+			if (p_group->physics_node_order_dirty) {
+				nodes.sort_custom<Node::ComparatorWithPhysicsPriority>();
+				p_group->physics_node_order_dirty = false;
+			}
+			break;
+		case PROCESS_KIND_LATE_PHYSICS:
+			if (p_group->late_physics_node_order_dirty) {
+				nodes.sort_custom<Node::ComparatorWithPhysicsPriority>();
+				p_group->late_physics_node_order_dirty = false;
+			}
+			break;
 	}
 
 	// Make a copy, so if nodes are added/removed from process, this does not break
@@ -1045,33 +1079,41 @@ void SceneTree::_process_group(ProcessGroup *p_group, bool p_physics) {
 			continue;
 		}
 
-		if (p_physics) {
-			if (n->is_physics_processing_internal()) {
-				n->notification(Node::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
-			}
-			if (n->is_physics_processing()) {
-				n->notification(Node::NOTIFICATION_PHYSICS_PROCESS);
-			}
-		} else {
-			if (n->is_processing_internal()) {
-				n->notification(Node::NOTIFICATION_INTERNAL_PROCESS);
-			}
-			if (n->is_processing()) {
-				n->notification(Node::NOTIFICATION_PROCESS);
-			}
+		switch (p_processKind) {
+			case PROCESS_KIND_IDLE:
+				if (n->is_processing_internal()) {
+					n->notification(Node::NOTIFICATION_INTERNAL_PROCESS);
+				}
+				if (n->is_processing()) {
+					n->notification(Node::NOTIFICATION_PROCESS);
+				}
+				break;
+			case PROCESS_KIND_PHYSICS:
+				if (n->is_physics_processing_internal()) {
+					n->notification(Node::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
+				}
+				if (n->is_physics_processing()) {
+					n->notification(Node::NOTIFICATION_PHYSICS_PROCESS);
+				}
+				break;
+			case PROCESS_KIND_LATE_PHYSICS:
+				if (n->is_late_physics_processing()) {
+					n->notification(Node::NOTIFICATION_LATE_PHYSICS_PROCESS);
+				}
+				break;
 		}
 	}
 
 	p_group->call_queue.flush(); // Flush messages also after processing (for potential deferred calls).
 }
 
-void SceneTree::_process_groups_thread(uint32_t p_index, bool p_physics) {
+void SceneTree::_process_groups_thread(uint32_t p_index, ProcessKind p_processKind) {
 	Node::current_process_thread_group = local_process_group_cache[p_index]->owner;
-	_process_group(local_process_group_cache[p_index], p_physics);
+	_process_group(local_process_group_cache[p_index], p_processKind);
 	Node::current_process_thread_group = nullptr;
 }
 
-void SceneTree::_process(bool p_physics) {
+void SceneTree::_process(ProcessKind p_processKind) {
 	if (process_groups_dirty) {
 		{
 			// First, remove dirty groups.
@@ -1134,13 +1176,13 @@ void SceneTree::_process(bool p_physics) {
 						if (using_threads) {
 							local_process_group_cache.push_back(process_groups[j]);
 						} else {
-							_process_group(process_groups[j], p_physics);
+							_process_group(process_groups[j], p_processKind);
 						}
 					}
 				}
 
 				if (using_threads) {
-					WorkerThreadPool::GroupID id = WorkerThreadPool::get_singleton()->add_template_group_task(this, &SceneTree::_process_groups_thread, p_physics, local_process_group_cache.size(), -1, true);
+					WorkerThreadPool::GroupID id = WorkerThreadPool::get_singleton()->add_template_group_task(this, &SceneTree::_process_groups_thread, p_processKind, local_process_group_cache.size(), -1, true);
 					WorkerThreadPool::get_singleton()->wait_for_group_task_completion(id);
 				}
 			}
@@ -1163,18 +1205,28 @@ void SceneTree::_process(bool p_physics) {
 
 		// Validate group for processing
 		bool process_valid = false;
-		if (p_physics) {
-			if (!pg->physics_nodes.is_empty()) {
-				process_valid = true;
-			} else if ((pg == &default_process_group || (pg->owner != nullptr && pg->owner->data.process_thread_messages.has_flag(Node::FLAG_PROCESS_THREAD_MESSAGES_PHYSICS))) && pg->call_queue.has_messages()) {
-				process_valid = true;
-			}
-		} else {
-			if (!pg->nodes.is_empty()) {
-				process_valid = true;
-			} else if ((pg == &default_process_group || (pg->owner != nullptr && pg->owner->data.process_thread_messages.has_flag(Node::FLAG_PROCESS_THREAD_MESSAGES))) && pg->call_queue.has_messages()) {
-				process_valid = true;
-			}
+		switch (p_processKind) {
+			case PROCESS_KIND_IDLE:
+				if (!pg->nodes.is_empty()) {
+					process_valid = true;
+				} else if ((pg == &default_process_group || (pg->owner != nullptr && pg->owner->data.process_thread_messages.has_flag(Node::FLAG_PROCESS_THREAD_MESSAGES))) && pg->call_queue.has_messages()) {
+					process_valid = true;
+				}
+				break;
+			case PROCESS_KIND_PHYSICS:
+				if (!pg->physics_nodes.is_empty()) {
+					process_valid = true;
+				} else if ((pg == &default_process_group || (pg->owner != nullptr && pg->owner->data.process_thread_messages.has_flag(Node::FLAG_PROCESS_THREAD_MESSAGES_PHYSICS))) && pg->call_queue.has_messages()) {
+					process_valid = true;
+				}
+				break;
+			case PROCESS_KIND_LATE_PHYSICS:
+				if (!pg->late_physics_nodes.is_empty()) {
+					process_valid = true;
+				} else if ((pg == &default_process_group || (pg->owner != nullptr && pg->owner->data.process_thread_messages.has_flag(Node::FLAG_PROCESS_THREAD_MESSAGES_PHYSICS))) && pg->call_queue.has_messages()) {
+					process_valid = true;
+				}
+				break;
 		}
 
 		if (process_valid) {
@@ -1240,6 +1292,11 @@ void SceneTree::_remove_node_from_process_group(Node *p_node, Node *p_owner) {
 		bool found = pg->physics_nodes.erase(p_node);
 		ERR_FAIL_COND(!found);
 	}
+
+	if (p_node->is_late_physics_processing()) {
+		bool found = pg->late_physics_nodes.erase(p_node);
+		ERR_FAIL_COND(!found);
+	}
 }
 
 void SceneTree::_add_node_to_process_group(Node *p_node, Node *p_owner) {
@@ -1254,6 +1311,11 @@ void SceneTree::_add_node_to_process_group(Node *p_node, Node *p_owner) {
 	if (p_node->is_physics_processing() || p_node->is_physics_processing_internal()) {
 		pg->physics_nodes.push_back(p_node);
 		pg->physics_node_order_dirty = true;
+	}
+
+	if (p_node->is_late_physics_processing()) {
+		pg->late_physics_nodes.push_back(p_node);
+		pg->late_physics_node_order_dirty = true;
 	}
 }
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -96,8 +96,10 @@ private:
 		CallQueue call_queue;
 		Vector<Node *> nodes;
 		Vector<Node *> physics_nodes;
+		Vector<Node *> late_physics_nodes;
 		bool node_order_dirty = true;
 		bool physics_node_order_dirty = true;
+		bool late_physics_node_order_dirty = true;
 		bool removed = false;
 		Node *owner = nullptr;
 		uint64_t last_pass = 0;
@@ -121,6 +123,12 @@ private:
 	struct Group {
 		Vector<Node *> nodes;
 		bool changed = false;
+	};
+
+	enum ProcessKind {
+		PROCESS_KIND_IDLE,
+		PROCESS_KIND_PHYSICS,
+		PROCESS_KIND_LATE_PHYSICS,
 	};
 
 #ifndef _3D_DISABLED
@@ -225,9 +233,9 @@ private:
 	void remove_from_group(const StringName &p_group, Node *p_node);
 	void make_group_changed(const StringName &p_group);
 
-	void _process_group(ProcessGroup *p_group, bool p_physics);
-	void _process_groups_thread(uint32_t p_index, bool p_physics);
-	void _process(bool p_physics);
+	void _process_group(ProcessGroup *p_group, ProcessKind p_processKind);
+	void _process_groups_thread(uint32_t p_index, ProcessKind p_processKind);
+	void _process(ProcessKind p_processKind);
 
 	void _remove_process_group(Node *p_node);
 	void _add_process_group(Node *p_node);
@@ -326,6 +334,7 @@ public:
 	virtual void iteration_prepare() override;
 
 	virtual bool physics_process(double p_time) override;
+	virtual bool late_physics_process(double p_time) override;
 	virtual void iteration_end() override;
 	virtual bool process(double p_time) override;
 


### PR DESCRIPTION
This implements https://github.com/godotengine/godot-proposals/issues/6795 and https://github.com/godotengine/godot-proposals/issues/10815: A new method `_late_physics_process` is called after the physics engine step. 

The following is still missing, but I can add this if there is interest in merging this implementation:
- Unit tests
- Documentation
- Proper handling of the new `"late_physics_frame"` signal
- Updating the editor to enable/disable late physics processing where needed

Right now, `Node::FLAG_PROCESS_THREAD_MESSAGES_PHYSICS` and `physics_process_priority` are used for both physics processing and late physics processing calls. If needed, we could add separate flags/properties for late physics processing instead.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/6795*