### PR TITLE
Physics Interpolation - Auto-reset on `set_physics_interpolation_mode()`

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -300,6 +300,7 @@ void Camera2D::_notification(int p_what) {
 			// Force the limits etc. to update.
 			_interpolation_data.xform_curr = get_camera_transform();
 			_interpolation_data.xform_prev = _interpolation_data.xform_curr;
+			_update_process_callback();
 		} break;
 
 		case NOTIFICATION_SUSPENDED:

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -230,6 +230,7 @@ void Camera3D::_notification(int p_what) {
 			if (is_inside_tree()) {
 				_interpolation_data.xform_curr = get_global_transform();
 				_interpolation_data.xform_prev = _interpolation_data.xform_curr;
+				_update_process_mode();
 			}
 		} break;
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -921,12 +921,12 @@ void Node::set_physics_interpolation_mode(PhysicsInterpolationMode p_mode) {
 		} break;
 	}
 
-	// If swapping from interpolated to non-interpolated, use this as an extra means to cause a reset.
-	if (is_physics_interpolated() && !interpolate && is_inside_tree()) {
+	_propagate_physics_interpolated(interpolate);
+
+	// Auto-reset on changing interpolation mode.
+	if (is_physics_interpolated() && is_inside_tree()) {
 		propagate_notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
 	}
-
-	_propagate_physics_interpolated(interpolate);
 }
 
 void Node::reset_physics_interpolation() {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -482,6 +482,11 @@ void SceneTree::set_physics_interpolation_enabled(bool p_enabled) {
 
 	_physics_interpolation_enabled = p_enabled;
 	RenderingServer::get_singleton()->set_physics_interpolation_enabled(p_enabled);
+
+	// Perform an auto reset on the root node for convenience for the user.
+	if (root) {
+		root->reset_physics_interpolation();
+	}
 }
 
 bool SceneTree::is_physics_interpolation_enabled() const {


### PR DESCRIPTION
Fixes historical bug where auto-reset wasn't working correctly. Also fixes process modes on Cameras when mode is changed.

Forward port of #101218 (see that PR for more details)
Helps address #101192

Doesn't address hidden nodes - these will likely be addressed generally as part of unhiding as the problem of whether or not to reset on unhiding is common to several situations.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
