### PR TITLE
[Editor] Prevent deferred tooltip update crash

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1170,6 +1170,9 @@ void SceneTreeEditor::_compute_hash(Node *p_node, uint64_t &hash) {
 }
 
 void SceneTreeEditor::_reset() {
+	// Stop any waiting change to tooltip.
+	update_node_tooltip_delay->stop();
+
 	tree->clear();
 	node_cache.clear();
 }


### PR DESCRIPTION
Caused by `TreeItem`s being accessed after clearing the tree on reset.

Can largely confirm this at least on 4.3, though without debug symbols I'm not sure if it is the same issue, can't reliably on 4.2, but hard to tell exactly why. I can reliably trigger it on debug builds, and with a few scenes in 4.4.beta3

Considered using `ObjectID` but I think this is a case where things should be solved by catching the problem at the source. This might still occur in edge cases where the timer fires during other updates, but this at least solves the issue reliably for me.

To trigger this bug:
* Open several scenes
* Edit the editor description of one of the root nodes
* Switch quickly between the tabs

The editor should crash, caused by various errors of memory access related to `TreeItem` nodes, this would be because the deferred tooltip update holding a reference to a now freed `TreeItem`, relevant code is:
https://github.com/godotengine/godot/blob/261e7d32d37445de3ef3a9804346552fdac6096e/editor/gui/scene_tree_editor.cpp#L642-L650
Where the timer set up, and:
https://github.com/godotengine/godot/blob/261e7d32d37445de3ef3a9804346552fdac6096e/editor/gui/scene_tree_editor.cpp#L657-L667
Where the crash is triggered, due to accessing internal data of a freed node

Ability to trigger this might vary based on hardware and general performance as this is a timing issue

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
