### PR TITLE
clipper2: Update to 1.5.2

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -200,7 +200,7 @@ License: MPL-2.0
 
 Files: thirdparty/clipper2/*
 Comment: Clipper2
-Copyright: 2010-2024, Angus Johnson
+Copyright: 2010-2025, Angus Johnson
 License: BSL-1.0
 
 Files: thirdparty/cvtt/*

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -107,7 +107,7 @@ Files extracted from upstream source:
 ## clipper2
 
 - Upstream: https://github.com/AngusJohnson/Clipper2
-- Version: 1.4.0 (736ddb0b53d97fd5f65dd3d9bbf8a0993eaf387c, 2024)
+- Version: 1.5.2 (6901921c4be75126d1de60bfd24bd86a61319fd0, 2025)
 - License: BSL 1.0
 
 Files extracted from upstream source:
@@ -118,7 +118,7 @@ Files extracted from upstream source:
 Patches:
 
 - `0001-disable-exceptions.patch` (GH-80796)
-- `0002-llvm-disable-int1280-math.patch` (GH-95964)
+- `0002-llvm-disable-int128-math.patch` (GH-95964)
 
 
 ## cvtt

--- a/thirdparty/clipper2/include/clipper2/clipper.engine.h
+++ b/thirdparty/clipper2/include/clipper2/clipper.engine.h
@@ -1,25 +1,19 @@
 /*******************************************************************************
 * Author    :  Angus Johnson                                                   *
-* Date      :  5 July 2024                                                     *
-* Website   :  http://www.angusj.com                                           *
+* Date      :  17 September 2024                                               *
+* Website   :  https://www.angusj.com                                          *
 * Copyright :  Angus Johnson 2010-2024                                         *
 * Purpose   :  This is the main polygon clipping module                        *
-* License   :  http://www.boost.org/LICENSE_1_0.txt                            *
+* License   :  https://www.boost.org/LICENSE_1_0.txt                           *
 *******************************************************************************/
 
 #ifndef CLIPPER_ENGINE_H
 #define CLIPPER_ENGINE_H
 
-#include <cstdlib>
-#include <stdint.h> //#541
-#include <iostream>
-#include <queue>
-#include <vector>
-#include <functional>
-#include <numeric>
-#include <memory>
-
 #include "clipper2/clipper.core.h"
+#include <queue>
+#include <functional>
+#include <memory>
 
 namespace Clipper2Lib {
 
@@ -32,13 +26,13 @@ namespace Clipper2Lib {
 	struct HorzSegment;
 
 	//Note: all clipping operations except for Difference are commutative.
-	enum class ClipType { None, Intersection, Union, Difference, Xor };
+	enum class ClipType { NoClip, Intersection, Union, Difference, Xor };
 
 	enum class PathType { Subject, Clip };
-	enum class JoinWith { None, Left, Right };
+	enum class JoinWith { NoJoin, Left, Right };
 
 	enum class VertexFlags : uint32_t {
-		None = 0, OpenStart = 1, OpenEnd = 2, LocalMax = 4, LocalMin = 8
+		Empty = 0, OpenStart = 1, OpenEnd = 2, LocalMax = 4, LocalMin = 8
 	};
 
 	constexpr enum VertexFlags operator &(enum VertexFlags a, enum VertexFlags b)
@@ -55,7 +49,7 @@ namespace Clipper2Lib {
 		Point64 pt;
 		Vertex* next = nullptr;
 		Vertex* prev = nullptr;
-		VertexFlags flags = VertexFlags::None;
+		VertexFlags flags = VertexFlags::Empty;
 	};
 
 	struct OutPt {
@@ -131,7 +125,7 @@ namespace Clipper2Lib {
 		Vertex* vertex_top = nullptr;
 		LocalMinima* local_min = nullptr;  // the bottom of an edge 'bound' (also Vatti)
 		bool is_left_bound = false;
-		JoinWith join_with = JoinWith::None;
+		JoinWith join_with = JoinWith::NoJoin;
 	};
 
 	struct LocalMinima {
@@ -167,7 +161,7 @@ namespace Clipper2Lib {
 	};
 
 #ifdef USINGZ
-		typedef std::function<void(const Point64& e1bot, const Point64& e1top,
+	typedef std::function<void(const Point64& e1bot, const Point64& e1top,
 		const Point64& e2bot, const Point64& e2top, Point64& pt)> ZCallback64;
 
 	typedef std::function<void(const PointD& e1bot, const PointD& e1top,
@@ -197,7 +191,7 @@ namespace Clipper2Lib {
 
 	class ClipperBase {
 	private:
-		ClipType cliptype_ = ClipType::None;
+		ClipType cliptype_ = ClipType::NoClip;
 		FillRule fillrule_ = FillRule::EvenOdd;
 		FillRule fillpos = FillRule::Positive;
 		int64_t bot_y_ = 0;
@@ -210,7 +204,7 @@ namespace Clipper2Lib {
 		std::vector<Vertex*> vertex_lists_;
 		std::priority_queue<int64_t> scanline_list_;
 		IntersectNodeList intersect_nodes_;
-    HorzSegmentList horz_seg_list_;
+        HorzSegmentList horz_seg_list_;
 		std::vector<HorzJoin> horz_join_list_;
 		void Reset();
 		inline void InsertScanline(int64_t y);

--- a/thirdparty/clipper2/include/clipper2/clipper.h
+++ b/thirdparty/clipper2/include/clipper2/clipper.h
@@ -1,24 +1,21 @@
 /*******************************************************************************
 * Author    :  Angus Johnson                                                   *
 * Date      :  27 April 2024                                                   *
-* Website   :  http://www.angusj.com                                           *
+* Website   :  https://www.angusj.com                                          *
 * Copyright :  Angus Johnson 2010-2024                                         *
 * Purpose   :  This module provides a simple interface to the Clipper Library  *
-* License   :  http://www.boost.org/LICENSE_1_0.txt                            *
+* License   :  https://www.boost.org/LICENSE_1_0.txt                           *
 *******************************************************************************/
 
 #ifndef CLIPPER_H
 #define CLIPPER_H
-
-#include <cstdlib>
-#include <type_traits>
-#include <vector>
 
 #include "clipper2/clipper.core.h"
 #include "clipper2/clipper.engine.h"
 #include "clipper2/clipper.offset.h"
 #include "clipper2/clipper.minkowski.h"
 #include "clipper2/clipper.rectclip.h"
+#include <type_traits>
 
 namespace Clipper2Lib {
 
@@ -272,14 +269,14 @@ namespace Clipper2Lib {
 
     inline void PolyPathToPaths64(const PolyPath64& polypath, Paths64& paths)
     {
-      paths.push_back(polypath.Polygon());
+      paths.emplace_back(polypath.Polygon());
       for (const auto& child : polypath)
         PolyPathToPaths64(*child, paths);
     }
 
     inline void PolyPathToPathsD(const PolyPathD& polypath, PathsD& paths)
     {
-      paths.push_back(polypath.Polygon());
+      paths.emplace_back(polypath.Polygon());
       for (const auto& child : polypath)
         PolyPathToPathsD(*child, paths);
     }
@@ -348,9 +345,9 @@ namespace Clipper2Lib {
       result.reserve(array_size / 2);
       for (size_t i = 0; i < array_size; i +=2)
 #ifdef USINGZ
-        result.push_back( U{ an_array[i], an_array[i + 1], 0} );
+        result.emplace_back( an_array[i], an_array[i + 1], 0 );
 #else
-        result.push_back( U{ an_array[i], an_array[i + 1]} );
+        result.emplace_back( an_array[i], an_array[i + 1] );
 #endif
     }
 
@@ -518,20 +515,20 @@ namespace Clipper2Lib {
     }
 
     prevIt = srcIt++;
-    dst.push_back(*prevIt);
+    dst.emplace_back(*prevIt);
     for (; srcIt != stop; ++srcIt)
     {
       if (!IsCollinear(*prevIt, *srcIt, *(srcIt + 1)))
       {
         prevIt = srcIt;
-        dst.push_back(*prevIt);
+        dst.emplace_back(*prevIt);
       }
     }
 
     if (is_open_path)
-      dst.push_back(*srcIt);
+      dst.emplace_back(*srcIt);
     else if (!IsCollinear(*prevIt, *stop, dst[0]))
-      dst.push_back(*stop);
+      dst.emplace_back(*stop);
     else
     {
       while (dst.size() > 2 &&
@@ -603,10 +600,10 @@ namespace Clipper2Lib {
     double dx = co, dy = si;
     Path<T> result;
     result.reserve(steps);
-    result.push_back(Point<T>(center.x + radiusX, static_cast<double>(center.y)));
+    result.emplace_back(center.x + radiusX, static_cast<double>(center.y));
     for (size_t i = 1; i < steps; ++i)
     {
-      result.push_back(Point<T>(center.x + radiusX * dx, center.y + radiusY * dy));
+      result.emplace_back(center.x + radiusX * dx, center.y + radiusY * dy);
       double x = dx * co - dy * si;
       dy = dy * co + dx * si;
       dx = x;
@@ -700,7 +697,7 @@ namespace Clipper2Lib {
     Path<T> result;
     result.reserve(len);
     for (typename Path<T>::size_type i = 0; i < len; ++i)
-      if (!flags[i]) result.push_back(path[i]);
+      if (!flags[i]) result.emplace_back(path[i]);
     return result;
   }
 
@@ -711,7 +708,7 @@ namespace Clipper2Lib {
     Paths<T> result;
     result.reserve(paths.size());
     for (const auto& path : paths)
-      result.push_back(SimplifyPath(path, epsilon, isClosedPath));
+      result.emplace_back(std::move(SimplifyPath(path, epsilon, isClosedPath)));
     return result;
   }
 
@@ -749,7 +746,7 @@ namespace Clipper2Lib {
     result.reserve(len);
     for (typename Path<T>::size_type i = 0; i < len; ++i)
       if (flags[i])
-        result.push_back(path[i]);
+        result.emplace_back(path[i]);
     return result;
   }
 

--- a/thirdparty/clipper2/include/clipper2/clipper.minkowski.h
+++ b/thirdparty/clipper2/include/clipper2/clipper.minkowski.h
@@ -1,18 +1,15 @@
 /*******************************************************************************
 * Author    :  Angus Johnson                                                   *
 * Date      :  1 November 2023                                                 *
-* Website   :  http://www.angusj.com                                           *
+* Website   :  https://www.angusj.com                                          *
 * Copyright :  Angus Johnson 2010-2023                                         *
 * Purpose   :  Minkowski Sum and Difference                                    *
-* License   :  http://www.boost.org/LICENSE_1_0.txt                            *
+* License   :  https://www.boost.org/LICENSE_1_0.txt                           *
 *******************************************************************************/
 
 #ifndef CLIPPER_MINKOWSKI_H
 #define CLIPPER_MINKOWSKI_H
 
-#include <cstdlib>
-#include <vector>
-#include <string>
 #include "clipper2/clipper.core.h"
 
 namespace Clipper2Lib
@@ -35,7 +32,7 @@ namespace Clipper2Lib
           Path64 path2(pattern.size());
           std::transform(pattern.cbegin(), pattern.cend(),
             path2.begin(), [p](const Point64& pt2) {return p + pt2; });
-          tmp.push_back(path2);
+          tmp.emplace_back(std::move(path2));
         }
       }
       else
@@ -45,7 +42,7 @@ namespace Clipper2Lib
           Path64 path2(pattern.size());
           std::transform(pattern.cbegin(), pattern.cend(),
             path2.begin(), [p](const Point64& pt2) {return p - pt2; });
-          tmp.push_back(path2);
+          tmp.emplace_back(std::move(path2));
         }
       }
 
@@ -59,14 +56,14 @@ namespace Clipper2Lib
           Path64 quad;
           quad.reserve(4);
           {
-            quad.push_back(tmp[g][h]);
-            quad.push_back(tmp[i][h]);
-            quad.push_back(tmp[i][j]);
-            quad.push_back(tmp[g][j]);
+            quad.emplace_back(tmp[g][h]);
+            quad.emplace_back(tmp[i][h]);
+            quad.emplace_back(tmp[i][j]);
+            quad.emplace_back(tmp[g][j]);
           };
           if (!IsPositive(quad))
             std::reverse(quad.begin(), quad.end());
-          result.push_back(quad);
+          result.emplace_back(std::move(quad));
           h = j;
         }
         g = i;

--- a/thirdparty/clipper2/include/clipper2/clipper.offset.h
+++ b/thirdparty/clipper2/include/clipper2/clipper.offset.h
@@ -1,10 +1,10 @@
 /*******************************************************************************
 * Author    :  Angus Johnson                                                   *
-* Date      :  24 March 2024                                                   *
-* Website   :  http://www.angusj.com                                           *
-* Copyright :  Angus Johnson 2010-2024                                         *
+* Date      :  22 January 2025                                                 *
+* Website   :  https://www.angusj.com                                          *
+* Copyright :  Angus Johnson 2010-2025                                         *
 * Purpose   :  Path Offset (Inflate/Shrink)                                    *
-* License   :  http://www.boost.org/LICENSE_1_0.txt                            *
+* License   :  https://www.boost.org/LICENSE_1_0.txt                           *
 *******************************************************************************/
 
 #ifndef CLIPPER_OFFSET_H_
@@ -12,6 +12,7 @@
 
 #include "clipper.core.h"
 #include "clipper.engine.h"
+#include <optional>
 
 namespace Clipper2Lib {
 
@@ -96,7 +97,7 @@ public:
 	void AddPaths(const Paths64& paths, JoinType jt_, EndType et_);
 	void Clear() { groups_.clear(); norms.clear(); };
 	
-	void Execute(double delta, Paths64& paths);
+	void Execute(double delta, Paths64& sols_64);
 	void Execute(double delta, PolyTree64& polytree);
 	void Execute(DeltaCallback64 delta_cb, Paths64& paths);
 

--- a/thirdparty/clipper2/include/clipper2/clipper.rectclip.h
+++ b/thirdparty/clipper2/include/clipper2/clipper.rectclip.h
@@ -1,19 +1,17 @@
 /*******************************************************************************
 * Author    :  Angus Johnson                                                   *
 * Date      :  5 July 2024                                                     *
-* Website   :  http://www.angusj.com                                           *
+* Website   :  https://www.angusj.com                                          *
 * Copyright :  Angus Johnson 2010-2024                                         *
 * Purpose   :  FAST rectangular clipping                                       *
-* License   :  http://www.boost.org/LICENSE_1_0.txt                            *
+* License   :  https://www.boost.org/LICENSE_1_0.txt                           *
 *******************************************************************************/
 
 #ifndef CLIPPER_RECTCLIP_H
 #define CLIPPER_RECTCLIP_H
 
-#include <cstdlib>
-#include <vector>
-#include <queue>
 #include "clipper2/clipper.core.h"
+#include <queue>
 
 namespace Clipper2Lib
 {

--- a/thirdparty/clipper2/include/clipper2/clipper.version.h
+++ b/thirdparty/clipper2/include/clipper2/clipper.version.h
@@ -1,6 +1,6 @@
 #ifndef CLIPPER_VERSION_H
 #define CLIPPER_VERSION_H
 
-constexpr auto CLIPPER2_VERSION = "1.4.0";
+constexpr auto CLIPPER2_VERSION = "1.5.2";
 
 #endif  // CLIPPER_VERSION_H

--- a/thirdparty/clipper2/patches/0001-disable-exceptions.patch
+++ b/thirdparty/clipper2/patches/0001-disable-exceptions.patch
@@ -1,17 +1,17 @@
 diff --git a/thirdparty/clipper2/include/clipper2/clipper.core.h b/thirdparty/clipper2/include/clipper2/clipper.core.h
-index 925c04685e..67dd731af6 100644
+index ab71aeb072..110bee4c10 100644
 --- a/thirdparty/clipper2/include/clipper2/clipper.core.h
 +++ b/thirdparty/clipper2/include/clipper2/clipper.core.h
-@@ -22,6 +22,8 @@
- #include <optional>
- #include "clipper2/clipper.version.h"
+@@ -19,6 +19,8 @@
+ #include <numeric>
+ #include <cmath>
  
 +#define CLIPPER2_THROW(exception) std::abort()
 +
  namespace Clipper2Lib
  {
  
-@@ -79,18 +81,18 @@ namespace Clipper2Lib
+@@ -76,21 +78,21 @@ namespace Clipper2Lib
      switch (error_code)
      {
      case precision_error_i:
@@ -29,6 +29,10 @@ index 925c04685e..67dd731af6 100644
      case range_error_i:
 -      throw Clipper2Exception(range_error);
 +      CLIPPER2_THROW(Clipper2Exception(range_error));
+     // Should never happen, but adding this to stop a compiler warning
+     default:
+-      throw Clipper2Exception("Unknown error");
++      CLIPPER2_THROW(Clipper2Exception("Unknown error"));
      }
  #else
 -    ++error_code; // only to stop compiler warning

--- a/thirdparty/clipper2/patches/0002-llvm-disable-int128-math.patch
+++ b/thirdparty/clipper2/patches/0002-llvm-disable-int128-math.patch
@@ -1,8 +1,8 @@
 diff --git a/thirdparty/clipper2/include/clipper2/clipper.core.h b/thirdparty/clipper2/include/clipper2/clipper.core.h
-index 67dd731af6..dd1b873d5d 100644
+index 110bee4c10..aa003bf032 100644
 --- a/thirdparty/clipper2/include/clipper2/clipper.core.h
 +++ b/thirdparty/clipper2/include/clipper2/clipper.core.h
-@@ -695,11 +695,13 @@ namespace Clipper2Lib
+@@ -715,11 +715,13 @@ namespace Clipper2Lib
    // returns true if (and only if) a * b == c * d
    inline bool ProductsAreEqual(int64_t a, int64_t b, int64_t c, int64_t d)
    {
@@ -13,15 +13,15 @@ index 67dd731af6..dd1b873d5d 100644
 -#else
 +// Work around LLVM issue: https://github.com/llvm/llvm-project/issues/16778
 +// Details: https://github.com/godotengine/godot/pull/95964#issuecomment-2306581804
-+//#if (defined(__clang__) || defined(__GNUC__)) && UINTPTR_MAX >= UINT64_MAX
-+//    const auto ab = static_cast<__int128_t>(a) * static_cast<__int128_t>(b);
-+//    const auto cd = static_cast<__int128_t>(c) * static_cast<__int128_t>(d);
-+//    return ab == cd;
-+//#else
++// #if (defined(__clang__) || defined(__GNUC__)) && UINTPTR_MAX >= UINT64_MAX
++//     const auto ab = static_cast<__int128_t>(a) * static_cast<__int128_t>(b);
++//     const auto cd = static_cast<__int128_t>(c) * static_cast<__int128_t>(d);
++//     return ab == cd;
++// #else
      // nb: unsigned values needed for calculating overflow carry
      const auto abs_a = static_cast<uint64_t>(std::abs(a));
      const auto abs_b = static_cast<uint64_t>(std::abs(b));
-@@ -714,7 +716,7 @@ namespace Clipper2Lib
+@@ -734,7 +736,7 @@ namespace Clipper2Lib
      const auto sign_cd = TriSign(c) * TriSign(d);
  
      return abs_ab == abs_cd && sign_ab == sign_cd;

--- a/thirdparty/clipper2/src/clipper.rectclip.cpp
+++ b/thirdparty/clipper2/src/clipper.rectclip.cpp
@@ -1,13 +1,12 @@
 /*******************************************************************************
 * Author    :  Angus Johnson                                                   *
 * Date      :  5 July 2024                                                     *
-* Website   :  http://www.angusj.com                                           *
+* Website   :  https://www.angusj.com                                          *
 * Copyright :  Angus Johnson 2010-2024                                         *
 * Purpose   :  FAST rectangular clipping                                       *
-* License   :  http://www.boost.org/LICENSE_1_0.txt                            *
+* License   :  https://www.boost.org/LICENSE_1_0.txt                           *
 *******************************************************************************/
 
-#include <cmath>
 #include "clipper2/clipper.h"
 #include "clipper2/clipper.rectclip.h"
 
@@ -282,7 +281,7 @@ namespace Clipper2Lib {
   {
     if (op->edge) return;
     op->edge = &edge;
-    edge.push_back(op);
+    edge.emplace_back(op);
   }
 
   inline void UncoupleEdge(OutPt2* op)
@@ -328,7 +327,7 @@ namespace Clipper2Lib {
       result->pt = pt;
       result->next = result;
       result->prev = result;
-      results_.push_back(result);
+      results_.emplace_back(result);
     }
     else
     {
@@ -489,7 +488,7 @@ namespace Clipper2Lib {
         {
           bool isClockw = IsClockwise(prev, loc, prev_pt, path[i], rect_mp_);
           do {
-            start_locs_.push_back(prev);
+            start_locs_.emplace_back(prev);
             prev = GetAdjacentLocation(prev, isClockw);
           } while (prev != loc);
           crossing_loc = crossing_prev; // still not crossed
@@ -514,7 +513,7 @@ namespace Clipper2Lib {
         if (first_cross_ == Location::Inside)
         {
           first_cross_ = crossing_loc;
-          start_locs_.push_back(prev);
+          start_locs_.emplace_back(prev);
         }
         else if (prev != crossing_loc)
         {
@@ -536,7 +535,7 @@ namespace Clipper2Lib {
         if (first_cross_ == Location::Inside)
         {
           first_cross_ = loc;
-          start_locs_.push_back(prev);
+          start_locs_.emplace_back(prev);
         }
 
         loc = crossing_loc;
@@ -750,7 +749,7 @@ namespace Clipper2Lib {
       if (!isRejoining)
       {
         size_t new_idx = results_.size();
-        results_.push_back(p1a);
+        results_.emplace_back(p1a);
         SetNewOwner(p1a, new_idx);
       }
 
@@ -861,11 +860,11 @@ namespace Clipper2Lib {
     if (!op2) return Path64();
 
     Path64 result;
-    result.push_back(op->pt);
+    result.emplace_back(op->pt);
     op2 = op->next;
     while (op2 != op)
     {
-      result.push_back(op2->pt);
+      result.emplace_back(op2->pt);
       op2 = op2->next;
     }
     return result;
@@ -885,7 +884,7 @@ namespace Clipper2Lib {
       else if (rect_.Contains(path_bounds_))
       {
         // the path must be completely inside rect_
-        result.push_back(path);
+        result.emplace_back(path);
         continue;
       }
 
@@ -898,7 +897,7 @@ namespace Clipper2Lib {
       {
         Path64 tmp = GetPath(op);
         if (!tmp.empty())
-          result.emplace_back(tmp);
+          result.emplace_back(std::move(tmp));
       }
 
       //clean up after every loop
@@ -930,7 +929,7 @@ namespace Clipper2Lib {
       {
         Path64 tmp = GetPath(op);
         if (!tmp.empty())
-          result.emplace_back(tmp);
+          result.emplace_back(std::move(tmp));
       }
       results_.clear();
 
@@ -1015,11 +1014,11 @@ namespace Clipper2Lib {
     Path64 result;
     if (!op || op == op->next) return result;
     op = op->next; // starting at path beginning
-    result.push_back(op->pt);
+    result.emplace_back(op->pt);
     OutPt2 *op2 = op->next;
     while (op2 != op)
     {
-      result.push_back(op2->pt);
+      result.emplace_back(op2->pt);
       op2 = op2->next;
     }
     return result;


### PR DESCRIPTION
[Clipper2 1.5.0](https://github.com/AngusJohnson/Clipper2/releases/tag/Clipper2_1.5.0):

- This release contains multiple minor bug fixes.

[Clipper2 1.5.2](https://github.com/AngusJohnson/Clipper2/releases/tag/Clipper2_1.5.2):

- CPP: tidied file header includes,
- CPP: `emplace_back()` replaces many `push_back()`,
- Fixed typos and broken links.

---

- Updated `COPYRIGHT.txt`
- Regenerated `patches`
