### PR TITLE
Add tab key moves focus to TextEdit

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1370,6 +1370,9 @@
 			The syntax highlighter to use.
 			[b]Note:[/b] A [SyntaxHighlighter] instance should not be used across multiple [TextEdit] nodes.
 		</member>
+		<member name="tab_moves_focus_enabled" type="bool" setter="set_tab_moves_focus_enabled" getter="is_tab_moves_focus_enabled" default="false">
+			If [code]true[/code], Tab key will move focus out of this [TextEdit]. Otherwise, pressing Tab will insert the "tab" character.
+		</member>
 		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
 			String value of the [TextEdit].
 		</member>
@@ -1525,7 +1528,10 @@
 		<constant name="MENU_EMOJI_AND_SYMBOL" value="30" enum="MenuItems">
 			Opens system emoji and symbol picker.
 		</constant>
-		<constant name="MENU_MAX" value="31" enum="MenuItems">
+		<constant name="MENU_TAB_MOVES_FOCUS" value="31" enum="MenuItems">
+			Toggles tab key behavior.
+		</constant>
+		<constant name="MENU_MAX" value="32" enum="MenuItems">
 			Represents the size of the [enum MenuItems] enum.
 		</constant>
 		<constant name="ACTION_NONE" value="0" enum="EditAction">

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -170,6 +170,8 @@ class CodeTextEditor : public VBoxContainer {
 	Control *toggle_scripts_list = nullptr;
 	Button *error_button = nullptr;
 	Button *warning_button = nullptr;
+	Button *tab_moves_focus_button = nullptr;
+	bool is_tab_moving_focus = false;
 
 	MenuButton *zoom_button = nullptr;
 	Label *line_and_col_txt = nullptr;
@@ -215,6 +217,7 @@ class CodeTextEditor : public VBoxContainer {
 
 	void _error_button_pressed();
 	void _warning_button_pressed();
+	void _tab_moves_focus_button_pressed();
 	void _set_show_errors_panel(bool p_show);
 	void _set_show_warnings_panel(bool p_show);
 	void _error_pressed(const Ref<InputEvent> &p_event);
@@ -270,6 +273,9 @@ public:
 
 	bool is_previewing_navigation_change() const;
 	void set_preview_navigation_change(bool p_preview);
+
+	void set_tab_key_moving_focus(bool p_enabled);
+	bool is_tab_key_moving_focus();
 
 	void set_error_count(int p_error_count);
 	void set_warning_count(int p_warning_count);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6736,6 +6736,7 @@ void EditorNode::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("request_help_search"));
 	ADD_SIGNAL(MethodInfo("script_add_function_request", PropertyInfo(Variant::OBJECT, "obj"), PropertyInfo(Variant::STRING, "function"), PropertyInfo(Variant::PACKED_STRING_ARRAY, "args")));
+	ADD_SIGNAL(MethodInfo("script_tab_moves_focus", PropertyInfo(Variant::BOOL, "toggled_on")));
 	ADD_SIGNAL(MethodInfo("resource_saved", PropertyInfo(Variant::OBJECT, "obj")));
 	ADD_SIGNAL(MethodInfo("scene_saved", PropertyInfo(Variant::STRING, "path")));
 	ADD_SIGNAL(MethodInfo("scene_changed"));

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -159,6 +159,13 @@ void EditorPropertyMultilineText::_big_text_changed() {
 	emit_changed(get_edited_property(), big_text->get_text(), "", true);
 }
 
+void EditorPropertyMultilineText::_big_text_dialog_visibility_changed() {
+	if (big_text_dialog->is_visible()) {
+		return;
+	}
+	text->set_tab_moves_focus_enabled(big_text->is_tab_moves_focus_enabled());
+}
+
 void EditorPropertyMultilineText::_text_changed() {
 	text->set_tooltip_text(get_tooltip_string(text->get_text()));
 	emit_changed(get_edited_property(), text->get_text(), "", true);
@@ -175,6 +182,7 @@ void EditorPropertyMultilineText::_open_big_text() {
 		big_text->connect(SceneStringName(text_changed), callable_mp(this, &EditorPropertyMultilineText::_big_text_changed));
 		big_text->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
 		big_text_dialog = memnew(AcceptDialog);
+		big_text_dialog->connect(SceneStringName(visibility_changed), callable_mp(this, &EditorPropertyMultilineText::_big_text_dialog_visibility_changed));
 		big_text_dialog->add_child(big_text);
 		big_text_dialog->set_title(TTR("Edit Text:"));
 		add_child(big_text_dialog);
@@ -182,6 +190,7 @@ void EditorPropertyMultilineText::_open_big_text() {
 
 	big_text_dialog->popup_centered_clamped(Size2(1000, 900) * EDSCALE, 0.8);
 	big_text->set_text(text->get_text());
+	big_text->set_tab_moves_focus_enabled(text->is_tab_moves_focus_enabled());
 	big_text->grab_focus();
 }
 
@@ -232,6 +241,7 @@ EditorPropertyMultilineText::EditorPropertyMultilineText(bool p_expression) {
 	text = memnew(TextEdit);
 	text->connect(SceneStringName(text_changed), callable_mp(this, &EditorPropertyMultilineText::_text_changed));
 	text->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
+	text->set_tab_moves_focus_enabled(true);
 	add_focusable(text);
 	hb->add_child(text);
 	text->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -86,6 +86,7 @@ class EditorPropertyMultilineText : public EditorProperty {
 	void _big_text_changed();
 	void _text_changed();
 	void _open_big_text();
+	void _big_text_dialog_visibility_changed();
 	bool expression = false;
 
 protected:

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -595,6 +595,19 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	}
 
 	/* MISC */
+	if (is_tab_moves_focus_enabled()) {
+		if (k->is_action("ui_focus_next", true)) {
+			find_next_valid_focus()->grab_focus();
+			accept_event();
+			return;
+		}
+		if (k->is_action("ui_focus_prev", true)) {
+			find_prev_valid_focus()->grab_focus();
+			accept_event();
+			return;
+		}
+	}
+
 	if (!code_hint.is_empty() && k->is_action("ui_cancel", true)) {
 		set_code_hint("");
 		accept_event();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2126,6 +2126,19 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		// Check and handle all built-in shortcuts.
 
+		if (is_tab_moves_focus_enabled()) {
+			if (k->is_action("ui_focus_next", true)) {
+				find_next_valid_focus()->grab_focus();
+				accept_event();
+				return;
+			}
+			if (k->is_action("ui_focus_prev", true)) {
+				find_prev_valid_focus()->grab_focus();
+				accept_event();
+				return;
+			}
+		}
+
 		// NEWLINES.
 		if (k->is_action("ui_text_newline_above", true)) {
 			_new_line(false, true);
@@ -3378,6 +3391,18 @@ bool TextEdit::is_empty_selection_clipboard_enabled() const {
 	return empty_selection_clipboard_enabled;
 }
 
+void TextEdit::set_tab_moves_focus_enabled(bool p_enabled) {
+	tab_moves_focus_enabled = p_enabled;
+
+	if (menu) {
+		menu->set_item_checked(menu->get_item_index(MENU_TAB_MOVES_FOCUS), p_enabled);
+	}
+}
+
+bool TextEdit::is_tab_moves_focus_enabled() const {
+	return tab_moves_focus_enabled;
+}
+
 // Text manipulation
 void TextEdit::clear() {
 	setting_text = true;
@@ -4023,6 +4048,9 @@ void TextEdit::menu_option(int p_option) {
 		} break;
 		case MENU_EMOJI_AND_SYMBOL: {
 			show_emoji_and_symbol_picker();
+		} break;
+		case MENU_TAB_MOVES_FOCUS: {
+			set_tab_moves_focus_enabled(!is_tab_moves_focus_enabled());
 		} break;
 	}
 }
@@ -6519,6 +6547,9 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_empty_selection_clipboard_enabled", "enabled"), &TextEdit::set_empty_selection_clipboard_enabled);
 	ClassDB::bind_method(D_METHOD("is_empty_selection_clipboard_enabled"), &TextEdit::is_empty_selection_clipboard_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_tab_moves_focus_enabled", "enabled"), &TextEdit::set_tab_moves_focus_enabled);
+	ClassDB::bind_method(D_METHOD("is_tab_moves_focus_enabled"), &TextEdit::is_tab_moves_focus_enabled);
+
 	// Text manipulation
 	ClassDB::bind_method(D_METHOD("clear"), &TextEdit::clear);
 
@@ -6599,6 +6630,7 @@ void TextEdit::_bind_methods() {
 	BIND_ENUM_CONSTANT(MENU_INSERT_WJ);
 	BIND_ENUM_CONSTANT(MENU_INSERT_SHY);
 	BIND_ENUM_CONSTANT(MENU_EMOJI_AND_SYMBOL);
+	BIND_ENUM_CONSTANT(MENU_TAB_MOVES_FOCUS);
 	BIND_ENUM_CONSTANT(MENU_MAX);
 
 	/* Versioning */
@@ -6915,6 +6947,7 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "virtual_keyboard_enabled"), "set_virtual_keyboard_enabled", "is_virtual_keyboard_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "middle_mouse_paste_enabled"), "set_middle_mouse_paste_enabled", "is_middle_mouse_paste_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "empty_selection_clipboard_enabled"), "set_empty_selection_clipboard_enabled", "is_empty_selection_clipboard_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tab_moves_focus_enabled"), "set_tab_moves_focus_enabled", "is_tab_moves_focus_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "wrap_mode", PROPERTY_HINT_ENUM, "None,Boundary"), "set_line_wrapping_mode", "get_line_wrapping_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "autowrap_mode", PROPERTY_HINT_ENUM, "Arbitrary:1,Word:2,Word (Smart):3"), "set_autowrap_mode", "get_autowrap_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "indent_wrapped_lines"), "set_indent_wrapped_lines", "is_indent_wrapped_lines");
@@ -7378,6 +7411,8 @@ void TextEdit::_generate_context_menu() {
 	menu->add_separator();
 	menu->add_check_item(ETR("Display Control Characters"), MENU_DISPLAY_UCC);
 	menu->add_submenu_node_item(ETR("Insert Control Character"), menu_ctl, MENU_SUBMENU_INSERT_UCC);
+	menu->add_separator();
+	menu->add_check_item(ETR("Tab Key Moves Focus"), MENU_TAB_MOVES_FOCUS);
 
 	menu->connect(SceneStringName(id_pressed), callable_mp(this, &TextEdit::menu_option));
 	menu_dir->connect(SceneStringName(id_pressed), callable_mp(this, &TextEdit::menu_option));
@@ -7431,6 +7466,7 @@ void TextEdit::_update_context_menu() {
 	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_LTR, text_direction == TEXT_DIRECTION_LTR)
 	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_RTL, text_direction == TEXT_DIRECTION_RTL)
 	MENU_ITEM_CHECKED(menu, MENU_DISPLAY_UCC, draw_control_chars)
+	MENU_ITEM_CHECKED(menu, MENU_TAB_MOVES_FOCUS, tab_moves_focus_enabled)
 	MENU_ITEM_DISABLED(menu, MENU_SUBMENU_INSERT_UCC, !editable)
 
 #undef MENU_ITEM_ACTION_DISABLED

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -111,6 +111,7 @@ public:
 		MENU_INSERT_WJ,
 		MENU_INSERT_SHY,
 		MENU_EMOJI_AND_SYMBOL,
+		MENU_TAB_MOVES_FOCUS,
 		MENU_MAX
 
 	};
@@ -318,6 +319,7 @@ private:
 	bool virtual_keyboard_enabled = true;
 	bool middle_mouse_paste_enabled = true;
 	bool empty_selection_clipboard_enabled = true;
+	bool tab_moves_focus_enabled = false;
 
 	// Overridable actions.
 	String cut_copy_line = "";
@@ -779,6 +781,9 @@ public:
 
 	void set_empty_selection_clipboard_enabled(bool p_enabled);
 	bool is_empty_selection_clipboard_enabled() const;
+
+	void set_tab_moves_focus_enabled(bool p_enabled);
+	bool is_tab_moves_focus_enabled() const;
 
 	// Text manipulation
 	void clear();


### PR DESCRIPTION
Proposal: closes https://github.com/godotengine/godot-proposals/issues/3050

This PR adds a new option that lets you toggle the TextEdit/CodeEdit Tab trapping behavior. And a new shortcut to the Script/Shader editor to help out with keyboard navigation.

![Screenshot_20250208_205615](https://github.com/user-attachments/assets/e4343288-76fb-4e07-8bf5-257092bf4cf7)

![Screenshot_20250208_211344](https://github.com/user-attachments/assets/8614be22-c993-4264-b547-5404fcecab3d)

## Editor

### TextEdit
For TextEdit's used in the editor itself the setting has been set to true, going by this comment in the linked proposal:
> ...as most people won't be entering code in TextEdit nodes in projects.

Behavior can be changed by right clicking and changine the "Tab Key Moves Focus" option.

[Screencast_20250208_211957.webm](https://github.com/user-attachments/assets/06866aac-6f7a-48a1-85de-25a80f29c957)

## Script/Shader Editor
A new shortcut has been added (default Ctrl+M, same as [VS Code uses](https://code.visualstudio.com/docs/editor/accessibility#_tab-trapping))


[Screencast_20250208_221144.webm](https://github.com/user-attachments/assets/2b295632-5e3f-4fbd-a22d-6dd18ddba9b7)

