### PR TITLE
[iOS] Sync the boot splash and the launch screen image scale modes

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -222,6 +222,23 @@ uint64_t OS::get_embedded_pck_offset() const {
 	return 0;
 }
 
+// Default boot screen rect scale mode is "Keep Aspect Centered"
+Rect2 OS::calculate_boot_screen_rect(const Size2 &p_window_size, const Size2 &p_imgrect_size) const {
+	Rect2 screenrect;
+	if (p_window_size.width > p_window_size.height) {
+		// Scale horizontally.
+		screenrect.size.y = p_window_size.height;
+		screenrect.size.x = p_imgrect_size.x * p_window_size.height / p_imgrect_size.y;
+		screenrect.position.x = (p_window_size.width - screenrect.size.x) / 2;
+	} else {
+		// Scale vertically.
+		screenrect.size.x = p_window_size.width;
+		screenrect.size.y = p_imgrect_size.y * p_window_size.width / p_imgrect_size.x;
+		screenrect.position.y = (p_window_size.height - screenrect.size.y) / 2;
+	}
+	return screenrect;
+}
+
 // Helper function to ensure that a dir name/path will be valid on the OS
 String OS::get_safe_dir_name(const String &p_dir_name, bool p_allow_paths) const {
 	String safe_dir_name = p_dir_name;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -161,6 +161,8 @@ public:
 	virtual void open_midi_inputs();
 	virtual void close_midi_inputs();
 
+	virtual Rect2 calculate_boot_screen_rect(const Size2 &p_window_size, const Size2 &p_imgrect_size) const;
+
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 
 	struct GDExtensionData {

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1525,7 +1525,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		custom_list.append_array(export_plugins[i]->_get_export_features(Ref<EditorExportPlatform>(this), p_debug));
 	}
 
-	ProjectSettings::CustomMap custom_map;
+	ProjectSettings::CustomMap custom_map = get_custom_project_settings(p_preset);
 	if (path_remaps.size()) {
 		if (true) { //new remap mode, use always as it's friendlier with multiple .pck exports
 			for (int i = 0; i < path_remaps.size(); i += 2) {

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -336,6 +336,7 @@ public:
 	virtual void get_platform_features(List<String> *r_features) const = 0;
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) {}
 	virtual String get_debug_protocol() const { return "tcp://"; }
+	virtual HashMap<String, Variant> get_custom_project_settings(const Ref<EditorExportPreset> &p_preset) const { return HashMap<String, Variant>(); }
 
 	EditorExportPlatform();
 };

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -201,6 +201,8 @@ public:
 		return list;
 	}
 
+	virtual HashMap<String, Variant> get_custom_project_settings(const Ref<EditorExportPreset> &p_preset) const override;
+
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
 
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;

--- a/platform/ios/os_ios.h
+++ b/platform/ios/os_ios.h
@@ -132,6 +132,8 @@ public:
 
 	void on_enter_background();
 	void on_exit_background();
+
+	virtual Rect2 calculate_boot_screen_rect(const Size2 &p_window_size, const Size2 &p_imgrect_size) const override;
 };
 
 #endif // IOS_ENABLED

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -216,18 +216,7 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 	Rect2 imgrect(0, 0, p_image->get_width(), p_image->get_height());
 	Rect2 screenrect;
 	if (p_scale) {
-		if (window_size.width > window_size.height) {
-			//scale horizontally
-			screenrect.size.y = window_size.height;
-			screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
-			screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
-
-		} else {
-			//scale vertically
-			screenrect.size.x = window_size.width;
-			screenrect.size.y = imgrect.size.y * window_size.width / imgrect.size.x;
-			screenrect.position.y = (window_size.height - screenrect.size.y) / 2;
-		}
+		screenrect = OS::get_singleton()->calculate_boot_screen_rect(window_size, imgrect.size);
 	} else {
 		screenrect = imgrect;
 		screenrect.position += ((window_size - screenrect.size) / 2.0).floor();


### PR DESCRIPTION
# What does this PR address?

Using iOS launch screens for the boot splash is not aligned with how Godot renders the boot splash.

On iOS the splash screen with launch images happens in two stages:
- show the launch screen (the export template allows modifying the scale mode - aspect fit, aspect fill etc.)
- afterwards Godot takes over, and renders the splash screen. **Godot does not take into account the iOS splash scale mode** so when it takes over, there is a visual tear as the splash changes dimensions and position.

This is partially addressing https://github.com/godotengine/godot/issues/81389 (though this PR does not address any compatibility issues with the legacy renderer)

# Change outline

- I added two methods in `Vector2` for fitting Vector2 inside another Vector2, either with aspect-fit-center or aspect-fit-cover modes (analogous to what the TextureRect exposes)
- I added Vector2 tests to verify the calculated areas
- I refactored `RendererCompositorRD` to allow the `OS` singleton to calculate the splash area. The iOS singleton will fetch the aspect mode from `Info.plist` and calculate a matching area. Others will keep existing behavior.

# Testing

Here's some visual examples of the effect.

## Landscape - export template specifies "scale to fill"

Before the changes:

https://github.com/user-attachments/assets/1b82b336-e04c-4a85-aed5-d863bcd4b734

After the changes:

https://github.com/user-attachments/assets/ac174b36-c712-4247-b431-481256eed518

## Portrait - export template specifies "scale"

Before the changes:

https://github.com/user-attachments/assets/74276062-2922-459d-a431-5488cdb42a28

After the changes:

https://github.com/user-attachments/assets/2d593f19-661c-4d68-9632-fdd4be92f334





