### PR TITLE
Revert finalizing `GodotHost#getCommandLine()` public API

### DIFF
--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -300,14 +300,12 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		}
 	}
 
-	@CallSuper
-	override fun updateCommandLineParams(args: Array<String>) {
-		val args = if (BuildConfig.BUILD_TYPE == "dev") {
-			args + "--benchmark"
-		} else {
-			args
+	override fun getCommandLine(): MutableList<String> {
+		val params = super.getCommandLine()
+		if (BuildConfig.BUILD_TYPE == "dev" && !params.contains("--benchmark")) {
+			params.add("--benchmark")
 		}
-		super.updateCommandLineParams(args);
+		return params
 	}
 
 	protected fun retrieveEditorWindowInfo(args: Array<String>, gameEmbedMode: GameEmbedMode): EditorWindowInfo {

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotXRGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotXRGame.kt
@@ -40,18 +40,16 @@ open class GodotXRGame: BaseGodotGame() {
 
 	override fun overrideOrientationRequest() = true
 
-	override fun updateCommandLineParams(args: Array<String>) {
-		val updatedArgs = ArrayList<String>()
-		if (!args.contains(XRMode.OPENXR.cmdLineArg)) {
+	override fun getCommandLine(): MutableList<String> {
+		val updatedArgs = super.getCommandLine()
+		if (!updatedArgs.contains(XRMode.OPENXR.cmdLineArg)) {
 			updatedArgs.add(XRMode.OPENXR.cmdLineArg)
 		}
-		if (!args.contains(XR_MODE_ARG)) {
+		if (!updatedArgs.contains(XR_MODE_ARG)) {
 			updatedArgs.add(XR_MODE_ARG)
 			updatedArgs.add("on")
 		}
-		updatedArgs.addAll(args)
-
-		super.updateCommandLineParams(updatedArgs.toTypedArray())
+		return updatedArgs
 	}
 
 	override fun getEditorWindowInfo() = XR_RUN_GAME_INFO

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotActivity.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotActivity.kt
@@ -75,7 +75,7 @@ abstract class GodotActivity : FragmentActivity(), GodotHost {
 	override fun onCreate(savedInstanceState: Bundle?) {
 		val params = intent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
 		Log.d(TAG, "Starting intent $intent with parameters ${params.contentToString()}")
-		updateCommandLineParams(params ?: emptyArray())
+		commandLineParams.addAll(params ?: emptyArray())
 
 		super.onCreate(savedInstanceState)
 
@@ -215,14 +215,5 @@ abstract class GodotActivity : FragmentActivity(), GodotHost {
 		return GodotFragment()
 	}
 
-	@CallSuper
-	protected open fun updateCommandLineParams(args: Array<String>) {
-		// Update the list of command line params with the new args
-		commandLineParams.clear()
-		if (args.isNotEmpty()) {
-			commandLineParams.addAll(args)
-		}
-	}
-
-	final override fun getCommandLine() = commandLineParams
+	override fun getCommandLine(): MutableList<String> = commandLineParams
 }


### PR DESCRIPTION
Fix API regression issue reported in https://github.com/GodotVR/godot_openxr_vendors/pull/264

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
