### PR TITLE
Wayland: Fix engine stalls while waiting frames

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1317,6 +1317,10 @@ void DisplayServerWayland::process_events() {
 				DEBUG_LOG_WAYLAND("Unsuspending from timeout.");
 			}
 		}
+
+		// Since we're not rendering, nothing is committing the windows'
+		// surfaces. We have to do it ourselves.
+		wayland_thread.commit_surfaces();
 	}
 
 #ifdef DBUS_ENABLED


### PR DESCRIPTION
Originally part of #101774.

There were two edge cases in the frame waiting logic (aka manual frame throttling or emulated vsync) which would cause the editor to stall in one way or another:

 1. Waiting right after starting the editor would cause a deadlock between both threads until something happened in the Wayland event queue, in turn unblocking the Wayland thread and kickstartin the whole thing;

 2. Starting the editor (and probably other long-loading stuff) without low consumption mode would suspend the window and never commit its surfaces, thus never signaling the compositor that we want frame events.

---

I'm kinda surprised nobody stumbled on the second one, it's quite bad when it happens.

Obviously, as with any good Wayland PR, most of the patch is actually just comments, so that this does not happen anymore... Hopefully :P