### PR TITLE
[Web] Add library emitter to make sources dependent of compiler version

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -89,7 +89,17 @@ def get_flags():
     }
 
 
+def library_emitter(target, source, env):
+    # Make every source file dependent on the compiler version.
+    # This makes sure that when emscripten is updated, that the cached files
+    # aren't used and are recompiled instead.
+    env.Depends(source, env.Value(get_compiler_version(env)))
+    return target, source
+
+
 def configure(env: "SConsEnvironment"):
+    env.Append(LIBEMITTER=library_emitter)
+
     # Validate arch.
     supported_arches = ["wasm32"]
     validate_arch(env["arch"], get_name(), supported_arches)


### PR DESCRIPTION
This simple PR makes the Web build sources dependent on the compiler version.

It also adds a compiler_version_cache in order to make the check once and speed up incedently the "Depends" process.

Supersedes #102491.