### PR TITLE
Improve path handling in EditorQuickOpenDialog

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1948,6 +1948,16 @@ EditorFileSystemDirectory *EditorFileSystem::find_file(const String &p_file, int
 	return fs;
 }
 
+ResourceUID::ID EditorFileSystem::get_file_uid(const String &p_path) const {
+	int file_idx;
+	EditorFileSystemDirectory *directory = find_file(p_path, &file_idx);
+
+	if (!directory) {
+		return ResourceUID::INVALID_ID;
+	}
+	return directory->files[file_idx]->uid;
+}
+
 EditorFileSystemDirectory *EditorFileSystem::get_filesystem_path(const String &p_path) {
 	if (!filesystem || scanning) {
 		return nullptr;

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -401,6 +401,7 @@ public:
 	EditorFileSystemDirectory *get_filesystem_path(const String &p_path);
 	String get_file_type(const String &p_file) const;
 	EditorFileSystemDirectory *find_file(const String &p_file, int *r_index) const;
+	ResourceUID::ID get_file_uid(const String &p_path) const;
 
 	void reimport_files(const Vector<String> &p_files);
 	Error reimport_append(const String &p_file, const HashMap<StringName, Variant> &p_custom_options, const String &p_custom_importer, Variant p_generator_parameters);


### PR DESCRIPTION
- Store path history as UIDs
  - Allows "auto-update" paths when files are moved, so your history items won't break
- Support UID paths in the dialog
- When loading history, remove files that no longer exist
  - Only happens at first opening. If a file is gone between openings and you try to open wrong file, error dialog appears and the entry is deleted

I also added `get_file_uid()` method to EditorFileSystem, which is faster than going through ResourceLoader. We should use it from now where applicable.