### PR TITLE
Fix focus being lost after adding a new input map entry in the editor

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -570,6 +570,7 @@ ActionMapEditor::ActionMapEditor() {
 	add_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	add_edit->set_placeholder(TTR("Add New Action"));
 	add_edit->set_clear_button_enabled(true);
+	add_edit->set_keep_editing_on_text_submit(true);
 	add_edit->connect(SceneStringName(text_changed), callable_mp(this, &ActionMapEditor::_add_edit_text_changed));
 	add_edit->connect(SceneStringName(text_submitted), callable_mp(this, &ActionMapEditor::_add_action));
 	add_hbox->add_child(add_edit);


### PR DESCRIPTION
This allows adding multiple actions in a row by pressing Enter after each action, without needing to click the field again every time.

- This closes https://github.com/godotengine/godot/issues/101307.

## Preview

https://github.com/user-attachments/assets/39b0753f-a6fc-4814-a2c1-eb750448a076

