### PR TITLE
Fix TileMapLayer bug where dirty cells could be marked twice

### DIFF
--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1413,7 +1413,7 @@ void TileMapLayer::_build_runtime_update_tile_data_for_cell(CellData &r_cell_dat
 
 						tile_map_node->GDVIRTUAL_CALL(_tile_data_runtime_update, layer_index_in_tile_map_node, r_cell_data.coords, tile_data_runtime_use);
 
-						if (p_auto_add_to_dirty_list) {
+						if (p_auto_add_to_dirty_list && !r_cell_data.dirty_list_element.in_list()) {
 							dirty.cell_list.add(&r_cell_data.dirty_list_element);
 						}
 					}
@@ -1428,7 +1428,7 @@ void TileMapLayer::_build_runtime_update_tile_data_for_cell(CellData &r_cell_dat
 
 						GDVIRTUAL_CALL(_tile_data_runtime_update, r_cell_data.coords, tile_data_runtime_use);
 
-						if (p_auto_add_to_dirty_list) {
+						if (p_auto_add_to_dirty_list && !r_cell_data.dirty_list_element.in_list()) {
 							dirty.cell_list.add(&r_cell_data.dirty_list_element);
 						}
 					}


### PR DESCRIPTION
### Summary

* Fixes https://github.com/godotengine/godot/issues/96339

Adds additional checks to `TileMapLayer::_build_runtime_update_tile_data_for_cell` to ensure that dirty cells have not already been added to the dirty cells list before calling `dirty.cell_list.add(...)`. Previously, updating a cell and calling `notify_runtime_tile_data_update` in the same frame or through coroutines could cause ordering issues here resulting in a large number of error messages being printed.

Using the [MRC provided in the linked issue](https://github.com/godotengine/godot/issues/96339#issuecomment-2381320465), I verified that the errors are no longer being printed, and calling `notify_runtime_tile_data_update` using `call_deferred` is no longer necessary

I'm also attaching an MRC to this PR for the case where messages can still be printed when using `call_deferred` if coroutines are involved. Adding these additional checks prevent the error messages in this MRC as well: [Coroutine MRC](https://github.com/user-attachments/files/18745103/gh-96339.zip)
