### PR TITLE
Prevent off-thread errors when generating resource previews for animation nodes

### DIFF
--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -234,7 +234,8 @@ bool AnimationTreeEditor::can_edit(const Ref<AnimationNode> &p_node) const {
 }
 
 Vector<String> AnimationTreeEditor::get_animation_list() {
-	if (!singleton->tree || !singleton->is_visible()) {
+	// This can be called off the main thread due to resource preview generation. Quit early in that case.
+	if (!singleton->tree || !Thread::is_main_thread() || !singleton->is_visible()) {
 		// When tree is empty, singleton not in the main thread.
 		return Vector<String>();
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/102106

This check could be moved to [`AnimationTreeEditor::get_animation_list`](https://github.com/godotengine/godot/blob/master/editor/plugins/animation_tree_editor_plugin.cpp#L237) if that's preferred.