### PR TITLE
Update scenarios in child viewports

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4639,15 +4639,34 @@ Ref<World3D> Viewport::find_world_3d() const {
 	}
 }
 
+void Viewport::_prepare_for_new_world_3d() {
+	if (is_inside_tree()) {
+		_propagate_exit_world_3d(this);
+	}
+
+	if (is_inside_tree()) {
+		RS::get_singleton()->viewport_set_scenario(viewport, RID());
+	}
+}
+
+void Viewport::_finish_world_3d_change() {
+	if (is_inside_tree()) {
+		_propagate_enter_world_3d(this);
+	}
+
+	if (is_inside_tree()) {
+		RS::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
+	}
+	_update_audio_listener_3d();
+}
+
 void Viewport::set_world_3d(const Ref<World3D> &p_world_3d) {
 	ERR_MAIN_THREAD_GUARD;
 	if (world_3d == p_world_3d) {
 		return;
 	}
 
-	if (is_inside_tree()) {
-		_propagate_exit_world_3d(this);
-	}
+	_prepare_for_new_world_3d();
 
 	if (own_world_3d.is_valid() && world_3d.is_valid()) {
 		world_3d->disconnect_changed(callable_mp(this, &Viewport::_own_world_3d_changed));
@@ -4664,36 +4683,16 @@ void Viewport::set_world_3d(const Ref<World3D> &p_world_3d) {
 		}
 	}
 
-	if (is_inside_tree()) {
-		_propagate_enter_world_3d(this);
-	}
-
-	if (is_inside_tree()) {
-		RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
-	}
-
-	_update_audio_listener_3d();
+	_finish_world_3d_change();
 }
 
 void Viewport::_own_world_3d_changed() {
 	ERR_FAIL_COND(world_3d.is_null());
 	ERR_FAIL_COND(own_world_3d.is_null());
 
-	if (is_inside_tree()) {
-		_propagate_exit_world_3d(this);
-	}
-
+	_prepare_for_new_world_3d();
 	own_world_3d = world_3d->duplicate();
-
-	if (is_inside_tree()) {
-		_propagate_enter_world_3d(this);
-	}
-
-	if (is_inside_tree()) {
-		RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
-	}
-
-	_update_audio_listener_3d();
+	_finish_world_3d_change();
 }
 
 void Viewport::set_use_own_world_3d(bool p_use_own_world_3d) {
@@ -4702,9 +4701,7 @@ void Viewport::set_use_own_world_3d(bool p_use_own_world_3d) {
 		return;
 	}
 
-	if (is_inside_tree()) {
-		_propagate_exit_world_3d(this);
-	}
+	_prepare_for_new_world_3d();
 
 	if (p_use_own_world_3d) {
 		if (world_3d.is_valid()) {
@@ -4720,15 +4717,7 @@ void Viewport::set_use_own_world_3d(bool p_use_own_world_3d) {
 		}
 	}
 
-	if (is_inside_tree()) {
-		_propagate_enter_world_3d(this);
-	}
-
-	if (is_inside_tree()) {
-		RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
-	}
-
-	_update_audio_listener_3d();
+	_finish_world_3d_change();
 }
 
 bool Viewport::is_using_own_world_3d() const {
@@ -4749,6 +4738,8 @@ void Viewport::_propagate_enter_world_3d(Node *p_node) {
 			if (v) {
 				if (v->world_3d.is_valid() || v->own_world_3d.is_valid()) {
 					return;
+				} else {
+					RS::get_singleton()->viewport_set_scenario(v->viewport, find_world_3d()->get_scenario());
 				}
 			}
 		}
@@ -4772,6 +4763,8 @@ void Viewport::_propagate_exit_world_3d(Node *p_node) {
 			if (v) {
 				if (v->world_3d.is_valid() || v->own_world_3d.is_valid()) {
 					return;
+				} else {
+					RS::get_singleton()->viewport_set_scenario(v->viewport, RID());
 				}
 			}
 		}

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -825,6 +825,8 @@ private:
 	void _own_world_3d_changed();
 	void _propagate_enter_world_3d(Node *p_node);
 	void _propagate_exit_world_3d(Node *p_node);
+	void _prepare_for_new_world_3d();
+	void _finish_world_3d_change();
 
 public:
 	AudioListener3D *get_audio_listener_3d() const;


### PR DESCRIPTION
Fixes #102016 

Viewports store references to the scenarios for the world they're displaying. When viewports are nested, the child viewports use the world of their parent if they don't have one of their own. The scenario reference in the child viewports wasn't being updated when changes to the parent's world occurred, leading to the child accessing potentially invalid memory.

This unsets the scenario in all child viewports before making changes to the current world in case we were holding the last reference to it. After the update, it then provides the updated scenario to all child viewports without their own worlds.
