### PR TITLE
Add changeable freelook speed in Game Window

### DIFF
--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -64,6 +64,7 @@ void GameViewDebugger::_session_started(Ref<EditorDebuggerSession> p_session) {
 	settings["editors/panning/warped_mouse_panning"] = EDITOR_GET("editors/panning/warped_mouse_panning");
 	settings["editors/panning/2d_editor_pan_speed"] = EDITOR_GET("editors/panning/2d_editor_pan_speed");
 	settings["canvas_item_editor/pan_view"] = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("canvas_item_editor/pan_view"));
+	settings["editors/3d/freelook/freelook_base_speed"] = EDITOR_GET("editors/3d/freelook/freelook_base_speed");
 	setup_data.append(settings);
 	p_session->send_message("scene:runtime_node_select_setup", setup_data);
 

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -255,6 +255,7 @@ private:
 
 	bool camera_first_override = true;
 	bool camera_freelook = false;
+	real_t freelook_speed = FREELOOK_BASE_SPEED;
 
 	Vector2 previous_mouse_position;
 
@@ -309,6 +310,7 @@ private:
 	bool _handle_3d_input(const Ref<InputEvent> &p_event);
 	void _set_camera_freelook_enabled(bool p_enabled);
 	void _cursor_scale_distance(real_t p_scale);
+	void _scale_freelook_speed(real_t p_scale);
 	void _cursor_look(Ref<InputEventWithModifiers> p_event);
 	void _cursor_pan(Ref<InputEventWithModifiers> p_event);
 	void _cursor_orbit(Ref<InputEventWithModifiers> p_event);


### PR DESCRIPTION
Add ability to change the freelook speed in the Game Window as you can do in the editor with scroll wheel up/down. 
This was mentioned as missing in https://github.com/godotengine/godot/issues/102694

This does not implement the visual speed indicator, like editor view has.
