### PR TITLE
Remove scene context from errors/warnings in Jolt Physics module

### DIFF
--- a/modules/jolt_physics/joints/jolt_cone_twist_joint_3d.cpp
+++ b/modules/jolt_physics/joints/jolt_cone_twist_joint_3d.cpp
@@ -194,17 +194,17 @@ void JoltConeTwistJoint3D::set_param(PhysicsServer3D::ConeTwistJointParam p_para
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_BIAS)) {
-				WARN_PRINT(vformat("Cone twist joint bias is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Cone twist joint bias is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_SOFTNESS)) {
-				WARN_PRINT(vformat("Cone twist joint softness is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Cone twist joint softness is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_RELAXATION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_RELAXATION)) {
-				WARN_PRINT(vformat("Cone twist joint relaxation is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Cone twist joint relaxation is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		default: {
@@ -348,8 +348,7 @@ void JoltConeTwistJoint3D::rebuild() {
 	destroy();
 
 	JoltSpace3D *space = get_space();
-
-	if (space == nullptr) {
+	if (unlikely(space == nullptr)) {
 		return;
 	}
 

--- a/modules/jolt_physics/joints/jolt_generic_6dof_joint_3d.cpp
+++ b/modules/jolt_physics/joints/jolt_generic_6dof_joint_3d.cpp
@@ -351,17 +351,17 @@ void JoltGeneric6DOFJoint3D::set_param(Axis p_axis, Param p_param, double p_valu
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_LIMIT_SOFTNESS)) {
-				WARN_PRINT(vformat("6DOF joint linear limit softness is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("6DOF joint linear limit softness is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_RESTITUTION)) {
-				WARN_PRINT(vformat("6DOF joint linear restitution is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("6DOF joint linear restitution is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_DAMPING)) {
-				WARN_PRINT(vformat("6DOF joint linear damping is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("6DOF joint linear damping is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_MOTOR_TARGET_VELOCITY: {
@@ -394,27 +394,27 @@ void JoltGeneric6DOFJoint3D::set_param(Axis p_axis, Param p_param, double p_valu
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_SOFTNESS)) {
-				WARN_PRINT(vformat("6DOF joint angular limit softness is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("6DOF joint angular limit softness is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_DAMPING)) {
-				WARN_PRINT(vformat("6DOF joint angular damping is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("6DOF joint angular damping is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_RESTITUTION)) {
-				WARN_PRINT(vformat("6DOF joint angular restitution is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("6DOF joint angular restitution is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_FORCE_LIMIT: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_FORCE_LIMIT)) {
-				WARN_PRINT(vformat("6DOF joint angular force limit is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("6DOF joint angular force limit is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_ERP: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_ERP)) {
-				WARN_PRINT(vformat("6DOF joint angular ERP is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("6DOF joint angular ERP is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_MOTOR_TARGET_VELOCITY: {
@@ -652,7 +652,7 @@ void JoltGeneric6DOFJoint3D::rebuild() {
 	destroy();
 
 	JoltSpace3D *space = get_space();
-	if (space == nullptr) {
+	if (unlikely(space == nullptr)) {
 		return;
 	}
 

--- a/modules/jolt_physics/joints/jolt_hinge_joint_3d.cpp
+++ b/modules/jolt_physics/joints/jolt_hinge_joint_3d.cpp
@@ -205,7 +205,7 @@ void JoltHingeJoint3D::set_param(Parameter p_param, double p_value) {
 	switch (p_param) {
 		case PhysicsServer3D::HINGE_JOINT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_BIAS)) {
-				WARN_PRINT(vformat("Hinge joint bias is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Hinge joint bias is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_LIMIT_UPPER: {
@@ -218,17 +218,17 @@ void JoltHingeJoint3D::set_param(Parameter p_param, double p_value) {
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_LIMIT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LIMIT_BIAS)) {
-				WARN_PRINT(vformat("Hinge joint bias limit is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Hinge joint bias limit is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_SOFTNESS)) {
-				WARN_PRINT(vformat("Hinge joint softness is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Hinge joint softness is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_LIMIT_RELAXATION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_RELAXATION)) {
-				WARN_PRINT(vformat("Hinge joint relaxation is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Hinge joint relaxation is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_MOTOR_TARGET_VELOCITY: {
@@ -381,8 +381,7 @@ void JoltHingeJoint3D::rebuild() {
 	destroy();
 
 	JoltSpace3D *space = get_space();
-
-	if (space == nullptr) {
+	if (unlikely(space == nullptr)) {
 		return;
 	}
 

--- a/modules/jolt_physics/joints/jolt_joint_3d.cpp
+++ b/modules/jolt_physics/joints/jolt_joint_3d.cpp
@@ -98,10 +98,6 @@ void JoltJoint3D::_iterations_changed() {
 	_wake_up_bodies();
 }
 
-String JoltJoint3D::_bodies_to_string() const {
-	return vformat("'%s' and '%s'", body_a != nullptr ? body_a->to_string() : "<unknown>", body_b != nullptr ? body_b->to_string() : "<World>");
-}
-
 JoltJoint3D::JoltJoint3D(const JoltJoint3D &p_old_joint, JoltBody3D *p_body_a, JoltBody3D *p_body_b, const Transform3D &p_local_ref_a, const Transform3D &p_local_ref_b) :
 		enabled(p_old_joint.enabled),
 		collision_disabled(p_old_joint.collision_disabled),
@@ -146,11 +142,9 @@ JoltSpace3D *JoltJoint3D::get_space() const {
 		JoltSpace3D *space_a = body_a->get_space();
 		JoltSpace3D *space_b = body_b->get_space();
 
-		if (space_a == nullptr || space_b == nullptr) {
+		if (space_a == nullptr || space_b == nullptr || space_a != space_b) {
 			return nullptr;
 		}
-
-		ERR_FAIL_COND_V_MSG(space_a != space_b, nullptr, vformat("Joint was found to connect bodies in different physics spaces. This joint will effectively be disabled. This joint connects %s.", _bodies_to_string()));
 
 		return space_a;
 	} else if (body_a != nullptr) {
@@ -178,7 +172,7 @@ int JoltJoint3D::get_solver_priority() const {
 
 void JoltJoint3D::set_solver_priority(int p_priority) {
 	if (p_priority != DEFAULT_SOLVER_PRIORITY) {
-		WARN_PRINT(vformat("Joint solver priority is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+		WARN_PRINT_ONCE("Joint solver priority is not supported when using Jolt Physics. Any such value will be ignored.");
 	}
 }
 

--- a/modules/jolt_physics/joints/jolt_joint_3d.h
+++ b/modules/jolt_physics/joints/jolt_joint_3d.h
@@ -68,8 +68,6 @@ protected:
 	void _enabled_changed();
 	void _iterations_changed();
 
-	String _bodies_to_string() const;
-
 public:
 	JoltJoint3D() = default;
 	JoltJoint3D(const JoltJoint3D &p_old_joint, JoltBody3D *p_body_a, JoltBody3D *p_body_b, const Transform3D &p_local_ref_a, const Transform3D &p_local_ref_b);

--- a/modules/jolt_physics/joints/jolt_pin_joint_3d.cpp
+++ b/modules/jolt_physics/joints/jolt_pin_joint_3d.cpp
@@ -100,17 +100,17 @@ void JoltPinJoint3D::set_param(PhysicsServer3D::PinJointParam p_param, double p_
 	switch (p_param) {
 		case PhysicsServer3D::PIN_JOINT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_BIAS)) {
-				WARN_PRINT(vformat("Pin joint bias is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Pin joint bias is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::PIN_JOINT_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_DAMPING)) {
-				WARN_PRINT(vformat("Pin joint damping is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Pin joint damping is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::PIN_JOINT_IMPULSE_CLAMP: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_IMPULSE_CLAMP)) {
-				WARN_PRINT(vformat("Pin joint impulse clamp is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Pin joint impulse clamp is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		default: {
@@ -138,8 +138,7 @@ void JoltPinJoint3D::rebuild() {
 	destroy();
 
 	JoltSpace3D *space = get_space();
-
-	if (space == nullptr) {
+	if (unlikely(space == nullptr)) {
 		return;
 	}
 

--- a/modules/jolt_physics/joints/jolt_slider_joint_3d.cpp
+++ b/modules/jolt_physics/joints/jolt_slider_joint_3d.cpp
@@ -264,102 +264,102 @@ void JoltSliderJoint3D::set_param(PhysicsServer3D::SliderJointParam p_param, dou
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_LIMIT_SOFTNESS)) {
-				WARN_PRINT(vformat("Slider joint linear limit softness is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint linear limit softness is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_LIMIT_RESTITUTION)) {
-				WARN_PRINT(vformat("Slider joint linear limit restitution is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint linear limit restitution is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_LIMIT_DAMPING)) {
-				WARN_PRINT(vformat("Slider joint linear limit damping is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint linear limit damping is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_MOTION_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_MOTION_SOFTNESS)) {
-				WARN_PRINT(vformat("Slider joint linear motion softness is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint linear motion softness is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_MOTION_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_MOTION_RESTITUTION)) {
-				WARN_PRINT(vformat("Slider joint linear motion restitution is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint linear motion restitution is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_MOTION_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_MOTION_DAMPING)) {
-				WARN_PRINT(vformat("Slider joint linear motion damping is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint linear motion damping is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_ORTHOGONAL_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_ORTHO_SOFTNESS)) {
-				WARN_PRINT(vformat("Slider joint linear ortho softness is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint linear ortho softness is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_ORTHOGONAL_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_ORTHO_RESTITUTION)) {
-				WARN_PRINT(vformat("Slider joint linear ortho restitution is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint linear ortho restitution is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_ORTHOGONAL_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_ORTHO_DAMPING)) {
-				WARN_PRINT(vformat("Slider joint linear ortho damping is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint linear ortho damping is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_UPPER: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_UPPER)) {
-				WARN_PRINT(vformat("Slider joint angular limits are not supported when using Jolt Physics. Any such value will be ignored. Try using Generic6DOFJoint3D instead. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint angular limits are not supported when using Jolt Physics. Any such value will be ignored. Try using Generic6DOFJoint3D instead.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_LOWER: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_LOWER)) {
-				WARN_PRINT(vformat("Slider joint angular limits are not supported when using Jolt Physics. Any such value will be ignored. Try using Generic6DOFJoint3D instead. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint angular limits are not supported when using Jolt Physics. Any such value will be ignored. Try using Generic6DOFJoint3D instead.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_SOFTNESS)) {
-				WARN_PRINT(vformat("Slider joint angular limit softness is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint angular limit softness is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_RESTITUTION)) {
-				WARN_PRINT(vformat("Slider joint angular limit restitution is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint angular limit restitution is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_DAMPING)) {
-				WARN_PRINT(vformat("Slider joint angular limit damping is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint angular limit damping is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_MOTION_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_MOTION_SOFTNESS)) {
-				WARN_PRINT(vformat("Slider joint angular motion softness is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint angular motion softness is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_MOTION_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_MOTION_RESTITUTION)) {
-				WARN_PRINT(vformat("Slider joint angular motion restitution is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint angular motion restitution is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_MOTION_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_MOTION_DAMPING)) {
-				WARN_PRINT(vformat("Slider joint angular motion damping is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint angular motion damping is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_ORTHOGONAL_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_ORTHO_SOFTNESS)) {
-				WARN_PRINT(vformat("Slider joint angular ortho softness is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint angular ortho softness is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_ORTHOGONAL_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_ORTHO_RESTITUTION)) {
-				WARN_PRINT(vformat("Slider joint angular ortho restitution is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint angular ortho restitution is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_ORTHOGONAL_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_ORTHO_DAMPING)) {
-				WARN_PRINT(vformat("Slider joint angular ortho damping is not supported when using Jolt Physics. Any such value will be ignored. This joint connects %s.", _bodies_to_string()));
+				WARN_PRINT_ONCE("Slider joint angular ortho damping is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		default: {
@@ -494,8 +494,7 @@ void JoltSliderJoint3D::rebuild() {
 	destroy();
 
 	JoltSpace3D *space = get_space();
-
-	if (space == nullptr) {
+	if (unlikely(space == nullptr)) {
 		return;
 	}
 

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -128,7 +128,8 @@ RID JoltPhysicsServer3D::heightmap_shape_create() {
 }
 
 RID JoltPhysicsServer3D::custom_shape_create() {
-	ERR_FAIL_V_MSG(RID(), "Custom shapes are not supported.");
+	WARN_PRINT_ONCE("Custom shapes are not supported when using Jolt Physics.");
+	return RID();
 }
 
 void JoltPhysicsServer3D::shape_set_data(RID p_shape, const Variant &p_data) {
@@ -293,8 +294,7 @@ RID JoltPhysicsServer3D::area_get_space(RID p_area) const {
 	ERR_FAIL_NULL_V(area, RID());
 
 	const JoltSpace3D *space = area->get_space();
-
-	if (space == nullptr) {
+	if (unlikely(space == nullptr)) {
 		return RID();
 	}
 
@@ -525,8 +525,7 @@ RID JoltPhysicsServer3D::body_get_space(RID p_body) const {
 	ERR_FAIL_NULL_V(body, RID());
 
 	const JoltSpace3D *space = body->get_space();
-
-	if (space == nullptr) {
+	if (unlikely(space == nullptr)) {
 		return RID();
 	}
 
@@ -983,8 +982,7 @@ RID JoltPhysicsServer3D::soft_body_get_space(RID p_body) const {
 	ERR_FAIL_NULL_V(body, RID());
 
 	const JoltSpace3D *space = body->get_space();
-
-	if (space == nullptr) {
+	if (unlikely(space == nullptr)) {
 		return RID();
 	}
 
@@ -1326,7 +1324,7 @@ void JoltPhysicsServer3D::joint_make_hinge(RID p_joint, RID p_body_a, const Tran
 }
 
 void JoltPhysicsServer3D::joint_make_hinge_simple(RID p_joint, RID p_body_a, const Vector3 &p_pivot_a, const Vector3 &p_axis_a, RID p_body_b, const Vector3 &p_pivot_b, const Vector3 &p_axis_b) {
-	ERR_FAIL_MSG("Simple hinge joints are not supported when using Jolt Physics.");
+	WARN_PRINT_ONCE("Simple hinge joints are not supported when using Jolt Physics.");
 }
 
 void JoltPhysicsServer3D::hinge_joint_set_param(RID p_joint, HingeJointParam p_param, real_t p_value) {
@@ -1552,7 +1550,7 @@ void JoltPhysicsServer3D::free(RID p_rid) {
 	} else if (JoltSpace3D *space = space_owner.get_or_null(p_rid)) {
 		free_space(space);
 	} else {
-		ERR_FAIL_MSG("Failed to free RID: The specified RID has no owner.");
+		ERR_FAIL_MSG("Failed to free Jolt Physics RID. The provided RID has no owner.");
 	}
 }
 

--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -82,7 +82,7 @@ void JoltArea3D::_add_to_space() {
 
 	jolt_settings->SetShape(jolt_shape);
 
-	const JPH::BodyID new_jolt_id = space->add_rigid_body(*this, *jolt_settings);
+	const JPH::BodyID new_jolt_id = space->add_rigid_body(*jolt_settings);
 	if (new_jolt_id.IsInvalid()) {
 		return;
 	}
@@ -181,7 +181,7 @@ void JoltArea3D::_report_event(const Callable &p_callback, PhysicsServer3D::Area
 	p_callback.callp(args, 5, ret, ce);
 
 	if (unlikely(ce.error != Callable::CallError::CALL_OK)) {
-		ERR_PRINT_ONCE(vformat("Failed to call area monitor callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(p_callback, args, 5, ce)));
+		ERR_PRINT_ONCE(vformat("Failed to call area monitor callback. It returned the following error: '%s'.", Variant::get_callable_error_text(p_callback, args, 5, ce)));
 	}
 }
 
@@ -368,7 +368,7 @@ void JoltArea3D::set_default_area(bool p_value) {
 }
 
 void JoltArea3D::set_transform(Transform3D p_transform) {
-	JOLT_ENSURE_SCALE_NOT_ZERO(p_transform, vformat("An invalid transform was passed to area '%s'.", to_string()));
+	JOLT_ENSURE_SCALE_NOT_ZERO(p_transform, "An invalid transform was passed to a physics area.");
 
 	const Vector3 new_scale = p_transform.basis.get_scale();
 
@@ -472,22 +472,22 @@ void JoltArea3D::set_param(PhysicsServer3D::AreaParameter p_param, const Variant
 		} break;
 		case PhysicsServer3D::AREA_PARAM_WIND_FORCE_MAGNITUDE: {
 			if (!Math::is_equal_approx((double)p_value, DEFAULT_WIND_FORCE_MAGNITUDE)) {
-				WARN_PRINT(vformat("Invalid wind force magnitude for '%s'. Area wind force magnitude is not supported when using Jolt Physics. Any such value will be ignored.", to_string()));
+				WARN_PRINT_ONCE("Area wind force magnitude is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::AREA_PARAM_WIND_SOURCE: {
 			if (!((Vector3)p_value).is_equal_approx(DEFAULT_WIND_SOURCE)) {
-				WARN_PRINT(vformat("Invalid wind source for '%s'. Area wind source is not supported when using Jolt Physics. Any such value will be ignored.", to_string()));
+				WARN_PRINT_ONCE("Area wind source is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::AREA_PARAM_WIND_DIRECTION: {
 			if (!((Vector3)p_value).is_equal_approx(DEFAULT_WIND_DIRECTION)) {
-				WARN_PRINT(vformat("Invalid wind direction for '%s'. Area wind direction is not supported when using Jolt Physics. Any such value will be ignored.", to_string()));
+				WARN_PRINT_ONCE("Area wind direction is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		case PhysicsServer3D::AREA_PARAM_WIND_ATTENUATION_FACTOR: {
 			if (!Math::is_equal_approx((double)p_value, DEFAULT_WIND_ATTENUATION_FACTOR)) {
-				WARN_PRINT(vformat("Invalid wind attenuation for '%s'. Area wind attenuation is not supported when using Jolt Physics. Any such value will be ignored.", to_string()));
+				WARN_PRINT_ONCE("Area wind attenuation is not supported when using Jolt Physics. Any such value will be ignored.");
 			}
 		} break;
 		default: {

--- a/modules/jolt_physics/objects/jolt_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_object_3d.cpp
@@ -135,8 +135,3 @@ bool JoltObject3D::can_interact_with(const JoltObject3D &p_other) const {
 		ERR_FAIL_V_MSG(false, vformat("Unhandled object type: '%d'. This should not happen. Please report this.", p_other.get_type()));
 	}
 }
-
-String JoltObject3D::to_string() const {
-	Object *instance = get_instance();
-	return instance != nullptr ? instance->to_string() : "<unknown>";
-}

--- a/modules/jolt_physics/objects/jolt_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_object_3d.h
@@ -149,8 +149,6 @@ public:
 	virtual bool reports_contacts() const = 0;
 
 	virtual void pre_step(float p_step, JPH::Body &p_jolt_body) {}
-
-	String to_string() const;
 };
 
 #endif // JOLT_OBJECT_3D_H

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -167,8 +167,6 @@ public:
 	void unpin_all_vertices();
 
 	bool is_vertex_pinned(int p_index) const;
-
-	String to_string() const;
 };
 
 #endif // JOLT_SOFT_BODY_3D_H

--- a/modules/jolt_physics/shapes/jolt_box_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_box_shape_3d.cpp
@@ -42,7 +42,7 @@ JPH::ShapeRefC JoltBoxShape3D::_build() const {
 	const JPH::BoxShapeSettings shape_settings(to_jolt(half_extents), actual_margin);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 
-	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics box shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics box shape with %s. It returned the following error: '%s'", to_string(), to_godot(shape_result.GetError())));
 
 	return shape_result.Get();
 }

--- a/modules/jolt_physics/shapes/jolt_capsule_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_capsule_shape_3d.cpp
@@ -35,16 +35,16 @@
 #include "Jolt/Physics/Collision/Shape/CapsuleShape.h"
 
 JPH::ShapeRefC JoltCapsuleShape3D::_build() const {
-	ERR_FAIL_COND_V_MSG(radius <= 0.0f, nullptr, vformat("Failed to build Jolt Physics capsule shape with %s. Its radius must be greater than 0. This shape belongs to %s.", to_string(), _owners_to_string()));
-	ERR_FAIL_COND_V_MSG(height <= 0.0f, nullptr, vformat("Failed to build Jolt Physics capsule shape with %s. Its height must be greater than 0. This shape belongs to %s.", to_string(), _owners_to_string()));
-	ERR_FAIL_COND_V_MSG(height < radius * 2.0f, nullptr, vformat("Failed to build Jolt Physics capsule shape with %s. Its height must be at least double that of its radius. This shape belongs to %s.", to_string(), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(radius <= 0.0f, nullptr, vformat("Failed to build Jolt Physics capsule shape with %s. Its radius must be greater than 0.", to_string()));
+	ERR_FAIL_COND_V_MSG(height <= 0.0f, nullptr, vformat("Failed to build Jolt Physics capsule shape with %s. Its height must be greater than 0.", to_string()));
+	ERR_FAIL_COND_V_MSG(height < radius * 2.0f, nullptr, vformat("Failed to build Jolt Physics capsule shape with %s. Its height must be at least double that of its radius.", to_string()));
 
 	const float half_height = height / 2.0f;
 	const float cylinder_height = half_height - radius;
 
 	const JPH::CapsuleShapeSettings shape_settings(cylinder_height, radius);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
-	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics capsule shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics capsule shape with %s. It returned the following error: '%s'.", to_string(), to_godot(shape_result.GetError())));
 
 	return shape_result.Get();
 }

--- a/modules/jolt_physics/shapes/jolt_concave_polygon_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_concave_polygon_shape_3d.cpp
@@ -44,8 +44,8 @@ JPH::ShapeRefC JoltConcavePolygonShape3D::_build() const {
 		return nullptr;
 	}
 
-	ERR_FAIL_COND_V_MSG(vertex_count < 3, nullptr, vformat("Failed to build Jolt Physics concave polygon shape with %s. It must have a vertex count of at least 3. This shape belongs to %s.", to_string(), _owners_to_string()));
-	ERR_FAIL_COND_V_MSG(excess_vertex_count != 0, nullptr, vformat("Failed to build Jolt Physics concave polygon shape with %s. It must have a vertex count that is divisible by 3. This shape belongs to %s.", to_string(), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(vertex_count < 3, nullptr, vformat("Failed to build Jolt Physics concave polygon shape with %s. It must have a vertex count of at least 3.", to_string()));
+	ERR_FAIL_COND_V_MSG(excess_vertex_count != 0, nullptr, vformat("Failed to build Jolt Physics concave polygon shape with %s. It must have a vertex count that is divisible by 3.", to_string()));
 
 	JPH::TriangleList jolt_faces;
 	jolt_faces.reserve((size_t)face_count);
@@ -73,7 +73,7 @@ JPH::ShapeRefC JoltConcavePolygonShape3D::_build() const {
 	shape_settings.mPerTriangleUserData = JoltProjectSettings::enable_ray_cast_face_index();
 
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
-	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics concave polygon shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics concave polygon shape with %s. It returned the following error: '%s'.", to_string(), to_godot(shape_result.GetError())));
 
 	return JoltShape3D::with_double_sided(shape_result.Get(), back_face_collision);
 }

--- a/modules/jolt_physics/shapes/jolt_convex_polygon_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_convex_polygon_shape_3d.cpp
@@ -42,7 +42,7 @@ JPH::ShapeRefC JoltConvexPolygonShape3D::_build() const {
 		return nullptr;
 	}
 
-	ERR_FAIL_COND_V_MSG(vertex_count < 3, nullptr, vformat("Failed to build Jolt Physics convex polygon shape with %s. It must have a vertex count of at least 3. This shape belongs to %s.", to_string(), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(vertex_count < 3, nullptr, vformat("Failed to build Jolt Physics convex polygon shape with %s. It must have a vertex count of at least 3.", to_string()));
 
 	JPH::Array<JPH::Vec3> jolt_vertices;
 	jolt_vertices.reserve((size_t)vertex_count);
@@ -59,7 +59,7 @@ JPH::ShapeRefC JoltConvexPolygonShape3D::_build() const {
 
 	const JPH::ConvexHullShapeSettings shape_settings(jolt_vertices, actual_margin);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
-	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics convex polygon shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics convex polygon shape with %s. It returned the following error: '%s'.", to_string(), to_godot(shape_result.GetError())));
 
 	return shape_result.Get();
 }

--- a/modules/jolt_physics/shapes/jolt_cylinder_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_cylinder_shape_3d.cpp
@@ -42,7 +42,7 @@ JPH::ShapeRefC JoltCylinderShape3D::_build() const {
 
 	const JPH::CylinderShapeSettings shape_settings(half_height, radius, actual_margin);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
-	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics cylinder shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics cylinder shape with %s. It returned the following error: '%s'.", to_string(), to_godot(shape_result.GetError())));
 
 	return shape_result.Get();
 }

--- a/modules/jolt_physics/shapes/jolt_height_map_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_height_map_shape_3d.cpp
@@ -55,8 +55,8 @@ JPH::ShapeRefC JoltHeightMapShape3D::_build() const {
 		return nullptr;
 	}
 
-	ERR_FAIL_COND_V_MSG(height_count != width * depth, nullptr, vformat("Failed to build Jolt Physics height map shape with %s. Height count must be the product of width and depth. This shape belongs to %s.", to_string(), _owners_to_string()));
-	ERR_FAIL_COND_V_MSG(width < 2 || depth < 2, nullptr, vformat("Failed to build Jolt Physics height map shape with %s. The height map must be at least 2x2. This shape belongs to %s.", to_string(), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(height_count != width * depth, nullptr, vformat("Failed to build Jolt Physics height map shape with %s. Height count must be the product of width and depth.", to_string()));
+	ERR_FAIL_COND_V_MSG(width < 2 || depth < 2, nullptr, vformat("Failed to build Jolt Physics height map shape with %s. The height map must be at least 2x2.", to_string()));
 
 	if (width != depth) {
 		return JoltShape3D::with_double_sided(_build_mesh(), true);
@@ -109,7 +109,7 @@ JPH::ShapeRefC JoltHeightMapShape3D::_build_height_field() const {
 	shape_settings.mActiveEdgeCosThresholdAngle = JoltProjectSettings::get_active_edge_threshold();
 
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
-	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics height map shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics height map shape with %s. It returned the following error: '%s'.", to_string(), to_godot(shape_result.GetError())));
 
 	return with_scale(shape_result.Get(), Vector3(1, 1, -1));
 }
@@ -163,7 +163,7 @@ JPH::ShapeRefC JoltHeightMapShape3D::_build_mesh() const {
 	shape_settings.mActiveEdgeCosThresholdAngle = JoltProjectSettings::get_active_edge_threshold();
 
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
-	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics height map shape (as polygon) with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics height map shape (as polygon) with %s. It returned the following error: '%s'.", to_string(), to_godot(shape_result.GetError())));
 
 	return shape_result.Get();
 }

--- a/modules/jolt_physics/shapes/jolt_separation_ray_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_separation_ray_shape_3d.cpp
@@ -34,11 +34,11 @@
 #include "jolt_custom_ray_shape.h"
 
 JPH::ShapeRefC JoltSeparationRayShape3D::_build() const {
-	ERR_FAIL_COND_V_MSG(length <= 0.0f, nullptr, vformat("Failed to build Jolt Physics separation ray shape with %s. Its length must be greater than 0. This shape belongs to %s.", to_string(), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(length <= 0.0f, nullptr, vformat("Failed to build Jolt Physics separation ray shape with %s. Its length must be greater than 0.", to_string()));
 
 	const JoltCustomRayShapeSettings shape_settings(length, slide_on_slope);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
-	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics separation ray shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics separation ray shape with %s. It returned the following error: '%s'.", to_string(), to_godot(shape_result.GetError())));
 
 	return shape_result.Get();
 }

--- a/modules/jolt_physics/shapes/jolt_shape_3d.h
+++ b/modules/jolt_physics/shapes/jolt_shape_3d.h
@@ -48,8 +48,6 @@ protected:
 
 	virtual JPH::ShapeRefC _build() const = 0;
 
-	String _owners_to_string() const;
-
 public:
 	typedef PhysicsServer3D::ShapeType ShapeType;
 
@@ -91,46 +89,26 @@ public:
 	static JPH::ShapeRefC without_custom_shapes(const JPH::Shape *p_shape);
 
 	static Vector3 make_scale_valid(const JPH::Shape *p_shape, const Vector3 &p_scale);
-	static bool is_scale_valid(const Vector3 &p_scale, const Vector3 &p_valid_scale, real_t p_tolerance = 0.01f);
 };
 
 #ifdef DEBUG_ENABLED
 
-#define JOLT_ENSURE_SCALE_NOT_ZERO(m_transform, m_msg)                                                         \
-	if (unlikely((m_transform).basis.determinant() == 0.0f)) {                                                 \
-		WARN_PRINT(vformat("%s "                                                                               \
-						   "The basis of the transform was singular, which is not supported by Jolt Physics. " \
-						   "This is likely caused by one or more axes having a scale of zero. "                \
-						   "The basis (and thus its scale) will be treated as identity.",                      \
-				m_msg));                                                                                       \
-                                                                                                               \
-		(m_transform).basis = Basis();                                                                         \
-	} else                                                                                                     \
-		((void)0)
-
-#define ERR_PRINT_INVALID_SCALE_MSG(m_scale, m_valid_scale, m_msg)                               \
-	if (unlikely(!JoltShape3D::is_scale_valid(m_scale, valid_scale))) {                          \
-		ERR_PRINT(vformat("%s "                                                                  \
-						  "A scale of %v is not supported by Jolt Physics for this shape/body. " \
-						  "The scale will instead be treated as %v.",                            \
-				m_msg, m_scale, valid_scale));                                                   \
-	} else                                                                                       \
+#define JOLT_ENSURE_SCALE_NOT_ZERO(m_transform, m_msg)                                                        \
+	if (unlikely((m_transform).basis.determinant() == 0.0f)) {                                                \
+		ERR_PRINT(vformat("%s "                                                                               \
+						  "The basis of the transform was singular, which is not supported by Jolt Physics. " \
+						  "This is likely caused by one or more axes having a scale of zero. "                \
+						  "The basis (and thus its scale) will instead be treated as identity.",              \
+				m_msg));                                                                                      \
+                                                                                                              \
+		(m_transform).basis = Basis();                                                                        \
+	} else                                                                                                    \
 		((void)0)
 
 #else
 
 #define JOLT_ENSURE_SCALE_NOT_ZERO(m_transform, m_msg)
 
-#define ERR_PRINT_INVALID_SCALE_MSG(m_scale, m_valid_scale, m_msg)
-
 #endif
-
-#define JOLT_ENSURE_SCALE_VALID(m_shape, m_scale, m_msg)                             \
-	if (true) {                                                                      \
-		const Vector3 valid_scale = JoltShape3D::make_scale_valid(m_shape, m_scale); \
-		ERR_PRINT_INVALID_SCALE_MSG(m_scale, valid_scale, m_msg);                    \
-		(m_scale) = valid_scale;                                                     \
-	} else                                                                           \
-		((void)0)
 
 #endif // JOLT_SHAPE_3D_H

--- a/modules/jolt_physics/shapes/jolt_sphere_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_sphere_shape_3d.cpp
@@ -35,11 +35,11 @@
 #include "Jolt/Physics/Collision/Shape/SphereShape.h"
 
 JPH::ShapeRefC JoltSphereShape3D::_build() const {
-	ERR_FAIL_COND_V_MSG(radius <= 0.0f, nullptr, vformat("Failed to build Jolt Physics sphere shape with %s. Its radius must be greater than 0. This shape belongs to %s.", to_string(), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(radius <= 0.0f, nullptr, vformat("Failed to build Jolt Physics sphere shape with %s. Its radius must be greater than 0.", to_string()));
 
 	const JPH::SphereShapeSettings shape_settings(radius);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
-	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics sphere shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics sphere shape with %s. It returned the following error: '%s'.", to_string(), to_godot(shape_result.GetError())));
 
 	return shape_result.Get();
 }

--- a/modules/jolt_physics/shapes/jolt_world_boundary_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_world_boundary_shape_3d.cpp
@@ -37,12 +37,12 @@
 
 JPH::ShapeRefC JoltWorldBoundaryShape3D::_build() const {
 	const Plane normalized_plane = plane.normalized();
-	ERR_FAIL_COND_V_MSG(normalized_plane == Plane(), nullptr, vformat("Failed to build Jolt Physics world boundary shape with %s. The plane's normal must not be zero. This shape belongs to %s.", to_string(), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(normalized_plane == Plane(), nullptr, vformat("Failed to build Jolt Physics world boundary shape with %s. The plane's normal must not be zero.", to_string()));
 
 	const float half_size = JoltProjectSettings::get_world_boundary_shape_size() / 2.0f;
 	const JPH::PlaneShapeSettings shape_settings(to_jolt(normalized_plane), nullptr, half_size);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
-	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics world boundary shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics world boundary shape with %s. It returned the following error: '%s'.", to_string(), to_godot(shape_result.GetError())));
 
 	return shape_result.Get();
 }

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -273,8 +273,7 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_cast(const JoltBody3D &p_body, 
 		}
 
 		JoltShape3D *shape = p_body.get_shape(i);
-
-		if (!shape->is_convex()) {
+		if (unlikely(!shape->is_convex())) {
 			continue;
 		}
 
@@ -288,9 +287,7 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_cast(const JoltBody3D &p_body, 
 		const Transform3D transform_com_local = transform_local.translated_local(com_scaled);
 		Transform3D transform_com = body_transform * transform_com_local;
 
-		Vector3 scale = transform_com.basis.get_scale();
-		JOLT_ENSURE_SCALE_VALID(jolt_shape, scale, "body_test_motion was passed an invalid transform along with body '%s'. This results in invalid scaling for shape at index %d.");
-
+		const Vector3 scale = JoltShape3D::make_scale_valid(jolt_shape, transform_com.basis.get_scale());
 		transform_com.basis.orthonormalize();
 
 		real_t shape_safe_fraction = 1.0;
@@ -590,9 +587,7 @@ int JoltPhysicsDirectSpaceState3D::intersect_shape(const ShapeParameters &p_para
 	Transform3D transform = p_parameters.transform;
 	JOLT_ENSURE_SCALE_NOT_ZERO(transform, "intersect_shape was passed an invalid transform.");
 
-	Vector3 scale = transform.basis.get_scale();
-	JOLT_ENSURE_SCALE_VALID(jolt_shape, scale, "intersect_shape was passed an invalid transform.");
-
+	const Vector3 scale = JoltShape3D::make_scale_valid(jolt_shape, transform.basis.get_scale());
 	transform.basis.orthonormalize();
 
 	const Vector3 com_scaled = to_godot(jolt_shape->GetCenterOfMass());
@@ -647,9 +642,7 @@ bool JoltPhysicsDirectSpaceState3D::cast_motion(const ShapeParameters &p_paramet
 	Transform3D transform = p_parameters.transform;
 	JOLT_ENSURE_SCALE_NOT_ZERO(transform, "cast_motion (maybe from ShapeCast3D?) was passed an invalid transform.");
 
-	Vector3 scale = transform.basis.get_scale();
-	JOLT_ENSURE_SCALE_VALID(jolt_shape, scale, "cast_motion (maybe from ShapeCast3D?) was passed an invalid transform.");
-
+	const Vector3 scale = JoltShape3D::make_scale_valid(jolt_shape, transform.basis.get_scale());
 	transform.basis.orthonormalize();
 
 	const Vector3 com_scaled = to_godot(jolt_shape->GetCenterOfMass());
@@ -684,9 +677,7 @@ bool JoltPhysicsDirectSpaceState3D::collide_shape(const ShapeParameters &p_param
 	Transform3D transform = p_parameters.transform;
 	JOLT_ENSURE_SCALE_NOT_ZERO(transform, "collide_shape was passed an invalid transform.");
 
-	Vector3 scale = transform.basis.get_scale();
-	JOLT_ENSURE_SCALE_VALID(jolt_shape, scale, "collide_shape was passed an invalid transform.");
-
+	const Vector3 scale = JoltShape3D::make_scale_valid(jolt_shape, transform.basis.get_scale());
 	transform.basis.orthonormalize();
 
 	const Vector3 com_scaled = to_godot(jolt_shape->GetCenterOfMass());
@@ -754,9 +745,7 @@ bool JoltPhysicsDirectSpaceState3D::rest_info(const ShapeParameters &p_parameter
 	Transform3D transform = p_parameters.transform;
 	JOLT_ENSURE_SCALE_NOT_ZERO(transform, "get_rest_info (maybe from ShapeCast3D?) was passed an invalid transform.");
 
-	Vector3 scale = transform.basis.get_scale();
-	JOLT_ENSURE_SCALE_VALID(jolt_shape, scale, "get_rest_info (maybe from ShapeCast3D?) was passed an invalid transform.");
-
+	const Vector3 scale = JoltShape3D::make_scale_valid(jolt_shape, transform.basis.get_scale());
 	transform.basis.orthonormalize();
 
 	const Vector3 com_scaled = to_godot(jolt_shape->GetCenterOfMass());
@@ -888,7 +877,7 @@ bool JoltPhysicsDirectSpaceState3D::body_test_motion(const JoltBody3D &p_body, c
 	const int max_collisions = MIN(p_parameters.max_collisions, 32);
 
 	Transform3D transform = p_parameters.from;
-	JOLT_ENSURE_SCALE_NOT_ZERO(transform, vformat("body_test_motion (maybe from move_and_slide?) was passed an invalid transform along with body '%s'.", p_body.to_string()));
+	JOLT_ENSURE_SCALE_NOT_ZERO(transform, "body_test_motion (maybe from move_and_slide?) was passed an invalid transform.");
 
 	Vector3 scale = transform.basis.get_scale();
 	transform.basis.orthonormalize();

--- a/modules/jolt_physics/spaces/jolt_space_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_space_3d.cpp
@@ -346,14 +346,14 @@ void JoltSpace3D::set_default_area(JoltArea3D *p_area) {
 	}
 }
 
-JPH::BodyID JoltSpace3D::add_rigid_body(const JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings, bool p_sleeping) {
+JPH::BodyID JoltSpace3D::add_rigid_body(const JPH::BodyCreationSettings &p_settings, bool p_sleeping) {
 	const JPH::BodyID body_id = get_body_iface().CreateAndAddBody(p_settings, p_sleeping ? JPH::EActivation::DontActivate : JPH::EActivation::Activate);
 
 	if (unlikely(body_id.IsInvalid())) {
-		ERR_PRINT_ONCE(vformat("Failed to create underlying Jolt Physics body for '%s'. "
+		ERR_PRINT_ONCE(vformat("Failed to create underlying Jolt Physics body. "
 							   "Consider increasing maximum number of bodies in project settings. "
 							   "Maximum number of bodies is currently set to %d.",
-				p_object.to_string(), JoltProjectSettings::get_max_bodies()));
+				JoltProjectSettings::get_max_bodies()));
 
 		return JPH::BodyID();
 	}
@@ -363,14 +363,14 @@ JPH::BodyID JoltSpace3D::add_rigid_body(const JoltObject3D &p_object, const JPH:
 	return body_id;
 }
 
-JPH::BodyID JoltSpace3D::add_soft_body(const JoltObject3D &p_object, const JPH::SoftBodyCreationSettings &p_settings, bool p_sleeping) {
+JPH::BodyID JoltSpace3D::add_soft_body(const JPH::SoftBodyCreationSettings &p_settings, bool p_sleeping) {
 	const JPH::BodyID body_id = get_body_iface().CreateAndAddSoftBody(p_settings, p_sleeping ? JPH::EActivation::DontActivate : JPH::EActivation::Activate);
 
 	if (unlikely(body_id.IsInvalid())) {
-		ERR_PRINT_ONCE(vformat("Failed to create underlying Jolt Physics body for '%s'. "
+		ERR_PRINT_ONCE(vformat("Failed to create underlying Jolt Physics soft body. "
 							   "Consider increasing maximum number of bodies in project settings. "
 							   "Maximum number of bodies is currently set to %d.",
-				p_object.to_string(), JoltProjectSettings::get_max_bodies()));
+				JoltProjectSettings::get_max_bodies()));
 
 		return JPH::BodyID();
 	}

--- a/modules/jolt_physics/spaces/jolt_space_3d.h
+++ b/modules/jolt_physics/spaces/jolt_space_3d.h
@@ -131,8 +131,8 @@ public:
 
 	float get_last_step() const { return last_step; }
 
-	JPH::BodyID add_rigid_body(const JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings, bool p_sleeping = false);
-	JPH::BodyID add_soft_body(const JoltObject3D &p_object, const JPH::SoftBodyCreationSettings &p_settings, bool p_sleeping = false);
+	JPH::BodyID add_rigid_body(const JPH::BodyCreationSettings &p_settings, bool p_sleeping = false);
+	JPH::BodyID add_soft_body(const JPH::SoftBodyCreationSettings &p_settings, bool p_sleeping = false);
 
 	void remove_body(const JPH::BodyID &p_body_id);
 


### PR DESCRIPTION
Fixes #102638.
Supersedes #102726.

> [!WARNING]
> This PR is entirely untested as of writing this.

This PR removes any mention of specific scene nodes in the various error/warning messages found in `modules/jolt_physics`, due to calls to `Object::to_string` being problematic when using `physics/3d/run_on_separate_thread`.

This PR also changes most of these warnings to be `WARN_PRINT_ONCE` instead, since there's no real context provided anymore, and therefore no point in spamming the warning continuously.

I've also gone ahead and removed most of the errors related to invalid scaling (e.g. scaling a cylinder on anything but its height axis) as previously emitted by the `JOLT_ENSURE_SCALE_VALID` macro, as they were already adding some friction for some users, and without context they're likely to cause even more friction, especially when emitted during runtime.

Now instead we only do a `WARN_PRINT_ONCE` inside of `JoltShape3D::make_scale_valid` if a significant invalid scale is detected, and only for `DEV_ENABLED` builds. This should allow us to catch these kinds of errors when bugs are reported that suffer from this, but they won't bother end users.

I've left in the errors for zero-scaled transforms, as emitted by the `JOLT_ENSURE_SCALE_NOT_ZERO` macro, as they will typically cause a lot of problems and thus should be dealt with in some way, which I currently do by just resetting the entire `Basis` to identity. That seems to me like a significant enough of an intervention to warrant emitting an error, even without any context.