### PR TITLE
[Web] Refactor `mouse_mode` setters in display server

### DIFF
--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -576,9 +576,17 @@ void DisplayServerWeb::_mouse_update_mode() {
 
 void DisplayServerWeb::mouse_set_mode(MouseMode p_mode) {
 	ERR_FAIL_INDEX(p_mode, MouseMode::MOUSE_MODE_MAX);
-	if (p_mode == mouse_mode_base) {
+
+	if (mouse_mode_override_enabled) {
+		mouse_mode_base = p_mode;
+		// No need to update, as override is enabled.
 		return;
 	}
+	if (p_mode == mouse_mode_base && p_mode == mouse_get_mode()) {
+		// No need to update, as it is currently set as the correct mode.
+		return;
+	}
+
 	mouse_mode_base = p_mode;
 	_mouse_update_mode();
 }
@@ -596,9 +604,17 @@ DisplayServer::MouseMode DisplayServerWeb::mouse_get_mode() const {
 
 void DisplayServerWeb::mouse_set_mode_override(MouseMode p_mode) {
 	ERR_FAIL_INDEX(p_mode, MouseMode::MOUSE_MODE_MAX);
-	if (p_mode == mouse_mode_override) {
+
+	if (!mouse_mode_override_enabled) {
+		mouse_mode_override = p_mode;
+		// No need to update, as override is not enabled.
 		return;
 	}
+	if (p_mode == mouse_mode_override && p_mode == mouse_get_mode()) {
+		// No need to update, as it is currently set as the correct mode.
+		return;
+	}
+
 	mouse_mode_override = p_mode;
 	_mouse_update_mode();
 }


### PR DESCRIPTION
This PR refactors the `mouse_mode` ~~setters in display servers of various platforms in order to update the mouse_mode only when actually needed.~~ setter in the Web platform display server.

It also fixes an issue on the Web platform where the mouse mode would refuse to capture the mouse twice.

Fixes #102209.

Edit: reverted to a Web-only fix.