### PR TITLE
Bandaid fix for dim lightmaps when using directional toggle

### DIFF
--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -467,7 +467,11 @@ void trace_direct_light(vec3 p_position, vec3 p_normal, uint p_light_index, bool
 		}
 	}
 
+#ifdef USE_SH_LIGHTMAPS
+	attenuation *= sqrt(max(0.0, dot(p_normal, r_light_dir)));
+#else
 	attenuation *= max(0.0, dot(p_normal, r_light_dir));
+#endif
 	if (attenuation <= 0.0001) {
 		return;
 	}


### PR DESCRIPTION
Fixes #102300, Although not properly.

I changed a attenuation factor from `dot(p_normal, r_light_dir)` to be `sqrt(dot(p_normal, r_light_dir))`. This only gets applied to omni and spot lights in the directional case. This seemed to minimize the differences between other lighting methods. 

The example shown where baked with a texel scale of 16 using the mrp in #102300:
[lightmap4dot4beta2.zip](https://github.com/user-attachments/files/18757495/lightmap4dot4beta2.zip)

Spotlight:
| Directional | Non-Directional | Real Time |
|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/0bca2f86-0cb8-4b95-81de-6ac99c221fa3) | ![image](https://github.com/user-attachments/assets/14d76ca1-d3ce-4584-a4cf-25b3774e48d7) | ![image](https://github.com/user-attachments/assets/153ffc70-1570-48d0-84fd-eb6c9f12dbec) | 

Omnilight:
| Directional | Non-Directional | Real Time |
|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/5d428859-e8e4-4241-96f3-5d2f04f0390a) | ![image](https://github.com/user-attachments/assets/2278625b-21d0-47c8-8539-1395d2bf159a) | ![image](https://github.com/user-attachments/assets/6ef8d599-6d37-4a03-8074-b7d1d5eded0c) | 