### PR TITLE
Skip `Object::to_string` when Jolt Physics is on separate thread

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2330,6 +2330,7 @@
 		</member>
 		<member name="physics/3d/run_on_separate_thread" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the 3D physics server runs on a separate thread, making better use of multi-core CPUs. If [code]false[/code], the 3D physics server runs on the main thread. Running the physics server on a separate thread can increase performance, but restricts API access to only physics process.
+			[b]Note:[/b] When [member physics/3d/physics_engine] is set to [code]Jolt Physics[/code], enabling this setting will prevent the 3D physics server from being able to provide any context when reporting errors and warnings, and will instead always refer to nodes as [code]&lt;unknown&gt;[/code].
 		</member>
 		<member name="physics/3d/sleep_threshold_angular" type="float" setter="" getter="" default="0.139626">
 			Threshold angular velocity under which a 3D physics body will be considered inactive. See [constant PhysicsServer3D.SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD].

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -421,6 +421,7 @@ public:
 
 	virtual int get_process_info(PhysicsServer3D::ProcessInfo p_process_info) override;
 
+	bool is_on_separate_thread() const { return on_separate_thread; }
 	bool is_active() const { return active; }
 
 	void free_space(JoltSpace3D *p_space);

--- a/modules/jolt_physics/objects/jolt_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_object_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "jolt_object_3d.h"
 
+#include "../jolt_physics_server_3d.h"
 #include "../jolt_project_settings.h"
 #include "../spaces/jolt_layers.h"
 #include "../spaces/jolt_space_3d.h"
@@ -137,6 +138,12 @@ bool JoltObject3D::can_interact_with(const JoltObject3D &p_other) const {
 }
 
 String JoltObject3D::to_string() const {
+	static const String fallback_name = "<unknown>";
+
+	if (JoltPhysicsServer3D::get_singleton()->is_on_separate_thread()) {
+		return fallback_name; // Calling `Object::to_string` is not thread-safe.
+	}
+
 	Object *instance = get_instance();
-	return instance != nullptr ? instance->to_string() : "<unknown>";
+	return instance != nullptr ? instance->to_string() : fallback_name;
 }

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -727,8 +727,3 @@ bool JoltSoftBody3D::is_vertex_pinned(int p_index) const {
 
 	return pinned_vertices.has(physics_index);
 }
-
-String JoltSoftBody3D::to_string() const {
-	Object *instance = get_instance();
-	return instance != nullptr ? instance->to_string() : "<unknown>";
-}

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -167,8 +167,6 @@ public:
 	void unpin_all_vertices();
 
 	bool is_vertex_pinned(int p_index) const;
-
-	String to_string() const;
 };
 
 #endif // JOLT_SOFT_BODY_3D_H


### PR DESCRIPTION
Fixes #102638.
Supersedes #102717.

This PR changes the error reporting happening in `modules/jolt_physics` so as to not fetch the actual object/node name when using `physics/3d/run_on_separate_thread`, but instead just fall back to using `<unknown>` as the name, as `Object::to_string` is not thread-safe.

(I also removed `JoltSoftBody3D::to_string`, which seemed to be entirely redundant.)