### PR TITLE
EditorHelpBit: Workaround crash renaming named class inheriting `@tool` class

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1017,7 +1017,8 @@ void EditorHelp::_update_doc() {
 			class_desc->add_text(nbsp); // Otherwise icon borrows hyperlink from `_add_type()`.
 			_add_type(inherits);
 
-			inherits = doc->class_list[inherits].inherits;
+			const DocData::ClassDoc *base_class_doc = doc->class_list.getptr(inherits);
+			inherits = base_class_doc ? base_class_doc->inherits : String();
 
 			if (!inherits.is_empty()) {
 				class_desc->add_text(" < ");
@@ -3713,7 +3714,8 @@ void EditorHelpBit::_update_labels() {
 
 						_add_type_to_title({ inherits, String(), false });
 
-						inherits = class_list[inherits].inherits;
+						const DocData::ClassDoc *base_class_doc = class_list.getptr(inherits);
+						inherits = base_class_doc ? base_class_doc->inherits : String();
 					}
 
 					title->pop(); // font_size


### PR DESCRIPTION
This only addresses the symptom, not the root cause of the problem.

In the MRP of the linked issue, the parent class seems to not be found in DocData after renaming its child class, which seems weird. Force opening the docs of the parent class can work it around, so we seem to have inconsistent state.

Changed the same code in EditorHelp for good measure.

- Fixes #102718.
- Fixes #102319.

---

A more proper fix would be to ensure that the parent class isn't lost from the DocData when renaming the child class. Maybe we're lacking some explicit update somewhere.

The problem might also be related to the fact that the parent class is `@tool` in the MRP, but the derived class isn't:

```
$ cat mytool.gd
@tool
class_name MyTool
extends Node
```

```
$ cat test.gd
class_name Test500
extends MyTool
```