### PR TITLE
Fix interpolation on the end edge in non-loop animation

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2562,11 +2562,13 @@ T Animation::_interpolate(const Vector<TKey<T>> &p_keys, double p_time, Interpol
 		if (is_start_edge) {
 			idx = p_backward ? maxi : 0;
 		}
-		next = CLAMP(idx + (p_backward ? -1 : 1), 0, maxi);
+		int len2 = MIN(len, p_keys.size() - 1);
+		next = CLAMP(idx + (p_backward ? -1 : 1), 0, len2);
 		if (use_cubic) {
-			pre = CLAMP(idx + (p_backward ? 1 : -1), 0, maxi);
-			post = CLAMP(idx + (p_backward ? -2 : 2), 0, maxi);
+			pre = CLAMP(idx + (p_backward ? 1 : -1), 0, len2);
+			post = CLAMP(idx + (p_backward ? -2 : 2), 0, len2);
 		}
+		is_end_edge = p_backward ? idx == 0 : idx >= len2; // TODO: The process needs to be commonized early on without overriding, but all other branches need to be refactored to prevent to collapse loop_wrap key acquisition.
 	} else if (loop_mode == LOOP_LINEAR) {
 		if (is_start_edge) {
 			idx = p_backward ? 0 : maxi;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/102707

However, this code is a stopgap. In order to get a clean code, it looks like a total rework is needed, and it would be risky to do it in beta. I have added a note to the TODO comment.

Also, related to #102707, I found a problem with loop_wrap collapsing when keyed at negative time. I think we need to address those at the same time when we rework it.