### PR TITLE
Show enum integer values in inspector tooltips

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3737,7 +3737,7 @@ EditorHelpBit::HelpData EditorHelpBit::_get_property_help_data(const StringName 
 							if (item_descr.is_empty()) {
 								item_descr = "[color=<EditorHelpBitCommentColor>][i]" + TTR("No description available.") + "[/i][/color]";
 							}
-							current.description += vformat("\n[b]%s:[/b] %s", item_name, item_descr);
+							current.description += vformat("\n[b]%s[/b] [color=<EditorHelpBitCommentColor>]=[/color] %s[color=<EditorHelpBitCommentColor>]:[/color] %s", item_name, constant.value, item_descr);
 						}
 					}
 					current.description = current.description.lstrip("\n");


### PR DESCRIPTION
Adds `= int_value` per enum entry in the in-inspector tooltips. Should help avoiding confusion in case of non-unique values (see #96368).

Not sure about exact formatting, feedback welcome.

| Before<br>(v4.4.beta3.official [06acfccf8]) | After<br>(this PR) |
|--------|--------|
![godot windows editor dev x86_64_s1HOGIiMM1](https://github.com/user-attachments/assets/226ce383-2ceb-4d7b-a109-81384af19da7)|![godot windows editor dev x86_64_w8tnFtbadf](https://github.com/user-attachments/assets/cbe14609-c4b3-4779-b2fb-c7f1444393b6)
![godot windows editor dev x86_64_sdR7aElTQc](https://github.com/user-attachments/assets/668dcd6c-4243-4bdb-a103-ffd8e51f6062)|![godot windows editor dev x86_64_h1WNe2V8lj](https://github.com/user-attachments/assets/3d0cdf88-92c1-4cbf-ab1d-ef1aa490816e)
