### PR TITLE
Fix tree selecting hidden items

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2841,7 +2841,9 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 	TreeItem *c = p_current->first_child;
 
 	while (c) {
-		select_single_item(p_selected, c, p_col, p_prev, r_in_range, p_current->is_collapsed() || p_force_deselect);
+		if (c->is_visible()) {
+			select_single_item(p_selected, c, p_col, p_prev, r_in_range, p_current->is_collapsed() || p_force_deselect);
+		}
 		c = c->next;
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/102713

[Screencast_20250210_023921.webm](https://github.com/user-attachments/assets/e6da4784-87d0-45bc-831f-f8b40b92d246)


Also looks like it prevents this issue https://github.com/godotengine/godot/issues/102690 from happening.

