### PR TITLE
Fix viewport scaling at intermediate resolutions

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1002,10 +1002,10 @@ void Viewport::update_canvas_items() {
 	_update_canvas_items(this);
 }
 
-bool Viewport::_set_size(const Size2i &p_size, const Size2i &p_size_2d_override, bool p_allocated) {
+bool Viewport::_set_size(const Size2i &p_size, const Size2 &p_size_2d_override, bool p_allocated) {
 	Transform2D stretch_transform_new = Transform2D();
 	if (is_size_2d_override_stretch_enabled() && p_size_2d_override.width > 0 && p_size_2d_override.height > 0) {
-		Size2 scale = Size2(p_size) / Size2(p_size_2d_override);
+		Size2 scale = Size2(p_size) / p_size_2d_override;
 		stretch_transform_new.scale(scale);
 	}
 
@@ -1074,7 +1074,7 @@ Size2i Viewport::_get_size() const {
 	return size;
 }
 
-Size2i Viewport::_get_size_2d_override() const {
+Size2 Viewport::_get_size_2d_override() const {
 	return size_2d_override;
 }
 
@@ -1092,7 +1092,7 @@ Rect2 Viewport::get_visible_rect() const {
 		r = Rect2(Point2(), size);
 	}
 
-	if (size_2d_override != Size2i()) {
+	if (size_2d_override != Size2()) {
 		r.size = size_2d_override;
 	}
 
@@ -5223,7 +5223,10 @@ void SubViewport::set_size_2d_override(const Size2i &p_size) {
 
 Size2i SubViewport::get_size_2d_override() const {
 	ERR_READ_THREAD_GUARD_V(Size2i());
-	return _get_size_2d_override();
+	// Rounding will cause offset issues with the
+	// exact positioning of subwindows, but changing the
+	// type of size_2d_override would break compatibility.
+	return Size2i((_get_size_2d_override() + Size2(0.5, 0.5)).floor());
 }
 
 void SubViewport::set_size_2d_override_stretch(bool p_enable) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -252,7 +252,7 @@ private:
 	Transform2D stretch_transform;
 
 	Size2i size = Size2i(512, 512);
-	Size2i size_2d_override;
+	Size2 size_2d_override;
 	bool size_allocated = false;
 
 	RID contact_2d_debug;
@@ -492,10 +492,10 @@ private:
 	void _window_start_resize(SubWindowResize p_edge, Window *p_window);
 
 protected:
-	bool _set_size(const Size2i &p_size, const Size2i &p_size_2d_override, bool p_allocated);
+	bool _set_size(const Size2i &p_size, const Size2 &p_size_2d_override, bool p_allocated);
 
 	Size2i _get_size() const;
-	Size2i _get_size_2d_override() const;
+	Size2 _get_size_2d_override() const;
 	bool _is_size_allocated() const;
 
 	void _notification(int p_what);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1133,7 +1133,7 @@ void Window::_update_viewport_size() {
 	//update the viewport part
 
 	Size2i final_size;
-	Size2i final_size_override;
+	Size2 final_size_override;
 	Rect2i attach_to_screen_rect(Point2i(), size);
 	double font_oversampling = 1.0;
 	window_transform = Transform2D();


### PR DESCRIPTION
Fixes #102656: viewport scale is wrong at resolutions that are not integer multiples of content_scale_factor.

This is done by allowing size_2d_override to be Size2 instead of Size2i. This change is ~propagated to keep the exposed SubViewport consistent with the underlying implementation~ _not propagated_ to SubViewport to keep compatibility for now.

**Note:**
I see the output of `Viewport::get_visible_rect()` get treated as a Rect2i in some places, even though it returns a Rect2. Before this change, this might have been accidentally correct, since it was generated from either `size` or `size_2d_override`, which were both Size2i. It might need a second look to make sure it still works correctly, because I'm not exactly sure what all these code fragments do.