### PR TITLE
Show enum property invalid value in inspector

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -321,6 +321,9 @@ void EditorPropertyTextEnum::update_property() {
 		}
 	} else {
 		option_button->select(default_option);
+		if (default_option < 0) {
+			option_button->set_text(current_value);
+		}
 	}
 }
 
@@ -699,6 +702,7 @@ void EditorPropertyEnum::update_property() {
 	Variant current = get_edited_property_value();
 	if (current.get_type() == Variant::NIL) {
 		options->select(-1);
+		options->set_text("<null>");
 		return;
 	}
 
@@ -709,6 +713,8 @@ void EditorPropertyEnum::update_property() {
 			return;
 		}
 	}
+	options->select(-1);
+	options->set_text(itos(which));
 }
 
 void EditorPropertyEnum::setup(const Vector<String> &p_options) {


### PR DESCRIPTION
Fixes #74123 (I've tested only with GDScript, so testing with C# welcomed; but AFAICT the fix should be language agnostic :thinking:).

_The fix seems safe to me, so probably fine for 4.4 and some cherry-picking, but leaving this for the production team to decide._

<details><summary>Test script</summary>
<p>

```gdscript
extends Node

enum CustomEnum {
	UNO = 1,
	DOS = 2,
	TRES = 3,
}

@export_group("@export :CustomEnum")
@export var typed_enum: CustomEnum
@export var typed_enum_0: CustomEnum = 0
@export var typed_enum_UNO: CustomEnum = CustomEnum.UNO
@export var typed_enum_2: CustomEnum = 2
@export var typed_enum_99: CustomEnum = 99

@export_group("@export :Array[CustomEnum]")
@export var typed_array_enum: Array[CustomEnum]
@export var typed_array_enum_0_UNO_2_99: Array[CustomEnum] = [0, CustomEnum.UNO, 2, 99]

@export_group("@export_enum")
@export_enum("One:1", "Two:2", "Three:3") var untyped
@export_enum("One:1", "Two:2", "Three:3") var typed_int: int
@export_enum("One:1", "Two:2", "Three:3") var typed_int_0: int = 0
@export_enum("One:1", "Two:2", "Three:3") var typed_int_1: int = 1
@export_enum("One:1", "Two:2", "Three:3") var typed_int_99: int = 99
@export_enum("One", "Two", "Three") var typed_string: String
@export_enum("One", "Two", "Three") var typed_string_one: String = "One"
@export_enum("One", "Two", "Three") var typed_string_unknown: String = "Unknown"

@export_group("@export_enum arrays")
@export_enum("One:1", "Two:2", "Three:3") var typed_packed_byte: PackedByteArray
@export_enum("One:1", "Two:2", "Three:3") var typed_packed_byte_0_1_99: PackedByteArray = [0, 1, 99]
@export_enum("One:1", "Two:2", "Three:3") var typed_packed_int32: PackedInt32Array
@export_enum("One:1", "Two:2", "Three:3") var typed_packed_int32_0_1_99: PackedInt32Array = [0, 1, 99]
@export_enum("One:1", "Two:2", "Three:3") var typed_packed_int64: PackedInt64Array
@export_enum("One:1", "Two:2", "Three:3") var typed_packed_int64_0_1_99: PackedInt64Array = [0, 1, 99]
@export_enum("One:1", "Two:2", "Three:3") var typed_array_int: Array[int]
@export_enum("One:1", "Two:2", "Three:3") var typed_array_int_0_1_99: Array[int] = [0, 1, 99]
@export_enum("One", "Two", "Three") var typed_array_string: Array[String]
@export_enum("One", "Two", "Three") var typed_array_string_one_unknown: Array[String] = ["One", "Unknown"]
```

</p>
</details> 


| Before<br>(v4.4.beta3.official [06acfccf8]) | After<br>(this PR)|
|--------|--------|
![iJQI4yOQ6c](https://github.com/user-attachments/assets/75a9f4da-4180-4d42-a90f-4d101d9aa564)|![snLZUMZ7pe](https://github.com/user-attachments/assets/72c692bf-154d-4215-b1f8-e4ca3d5865d5)
For invalid default value can't directly set the first value:<br>![3KIXmDgF28](https://github.com/user-attachments/assets/24c4d94f-229d-4c99-8984-07ba65300ad7)|For invalid default value can directly set the first value:<br>![hv01Tm2r53](https://github.com/user-attachments/assets/3ade0666-9eec-42ee-8d58-48ec03852c99)
For invalid default value reverting keeps selected entry unchanged:<br>![m3EIMucHcC](https://github.com/user-attachments/assets/270f20a5-2edc-4e5a-bb91-5549013b0f14)|Revert works fine:<br>![bMGEyD5V9M](https://github.com/user-attachments/assets/c305eccb-897b-4ddc-8016-b70696737be0)

I've tested it furter with the test script, AFAICT all works fine. Note that arrays are revertable as a whole, not per element (but it's the same before/after).

| Before<br>(v4.4.beta3.official [06acfccf8]) | After<br>(this PR)|
|--------|--------|
![OpuuK9m2AJ](https://github.com/user-attachments/assets/ce6689e4-4b2b-43e4-b2bd-bc9f0ca9bac2)|![jYZqfTiV0K](https://github.com/user-attachments/assets/9d493ae1-9bf9-46b5-b05f-876aee455f58)
