### PR TITLE
Fix Game and editor freeze when clicking on the game's title bar

### DIFF
--- a/editor/window_wrapper.cpp
+++ b/editor/window_wrapper.cpp
@@ -338,6 +338,14 @@ Size2 WindowWrapper::get_margins_size() {
 	return Size2(margins->get_margin_size(SIDE_LEFT) + margins->get_margin_size(SIDE_RIGHT), margins->get_margin_size(SIDE_TOP) + margins->get_margin_size(SIDE_RIGHT));
 }
 
+Size2 WindowWrapper::get_margins_top_left() {
+	if (!margins) {
+		return Size2();
+	}
+
+	return Size2(margins->get_margin_size(SIDE_LEFT), margins->get_margin_size(SIDE_TOP));
+}
+
 void WindowWrapper::grab_window_focus() {
 	if (get_window_enabled() && is_visible()) {
 		window->grab_focus();

--- a/editor/window_wrapper.h
+++ b/editor/window_wrapper.h
@@ -86,6 +86,7 @@ public:
 	void set_window_title(const String &p_title);
 	void set_margins_enabled(bool p_enabled);
 	Size2 get_margins_size();
+	Size2 get_margins_top_left();
 	void grab_window_focus();
 
 	void set_override_close_request(bool p_enabled);

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -6172,6 +6172,15 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 
 		wd.parent_hwnd = p_parent_hwnd;
 
+		// Detach the input queue from the parent window.
+		// This prevents the embedded window from waiting on the main window's input queue,
+		// causing lags input lags when resizing or moving the main window.
+		if (p_parent_hwnd) {
+			DWORD mainThreadId = GetWindowThreadProcessId(owner_hwnd, nullptr);
+			DWORD embeddedThreadId = GetCurrentThreadId();
+			AttachThreadInput(embeddedThreadId, mainThreadId, FALSE);
+		}
+
 		if (p_mode == WINDOW_MODE_FULLSCREEN || p_mode == WINDOW_MODE_EXCLUSIVE_FULLSCREEN) {
 			wd.fullscreen = true;
 			if (p_mode == WINDOW_MODE_FULLSCREEN) {


### PR DESCRIPTION
- Fixes #102724

Ok, that was a tricky problem!! After commetted most of the code in `display_server_windows.cpp` and `embedded_process.cpp` and still reproducing the issue, I found out the cause of the problem!! The problem was caused by the fact that the input queues of the editor and the game window were on the same thread. I still don't understand why the issue was visible only when trying to move the floating window, but detaching these input queues fixed the issue.

The reel fix is the addition of these lines in `display_server_windows.cpp`:
```cpp
if (p_parent_hwnd) {
	DWORD mainThreadId = GetWindowThreadProcessId(owner_hwnd, nullptr);
	DWORD embeddedThreadId = GetCurrentThreadId();
	AttachThreadInput(embeddedThreadId, mainThreadId, FALSE);
}
```

The other modifications come from some side effects of the modification. Turns out, that detaching the input queue make the floating window a lot more responsive, causing to see some issues with the starting location passed to the embedded game when using the Floating Window.