### PR TITLE
Fix TreeItem button tooltip trigger area offset

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5629,7 +5629,7 @@ void Tree::_find_button_at_pos(const Point2 &p_pos, TreeItem *&r_item, int &r_co
 	}
 
 	for (int i = 0; i < col; i++) {
-		const int col_w = get_column_width(i) + theme_cache.h_separation;
+		const int col_w = get_column_width(i);
 		pos.x -= col_w;
 		x_limit -= col_w;
 	}


### PR DESCRIPTION
Fixes #102421

This PR removes the `h_separation` addition when skipping columns, so the formula is the same as before #90839.

TBH, I don't really remember the exact problem I was trying to solve with `h_separation`. It was a long time ago. I was probably trying to solve a different offset problem when the separation was large, but now that I've restored the code, I can't reproduce the problem.