### PR TITLE
Improve 3D editor's preview sun and environment UX

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -955,6 +955,45 @@
 			Directory that contains the [code].sln[/code] file. By default, the [code].sln[/code] files is in the root of the project directory, next to the [code]project.godot[/code] and [code].csproj[/code] files.
 			Changing this value allows setting up a multi-project scenario where there are multiple [code].csproj[/code]. Keep in mind that the Godot project is considered one of the C# projects in the workspace and it's root directory should contain the [code]project.godot[/code] and [code].csproj[/code] next to each other.
 		</member>
+		<member name="editor/3d/preview_environment/default_ao" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], ambient occlusion is enabled by default for the preview environment in the 3D editor.
+		</member>
+		<member name="editor/3d/preview_environment/default_gi" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], global illumination is enabled by default for the preview environment in the 3D editor.
+		</member>
+		<member name="editor/3d/preview_environment/default_glow" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], glow is enabled by default for the preview environment in the 3D editor.
+		</member>
+		<member name="editor/3d/preview_environment/default_ground_color" type="Color" setter="" getter="" default="Color(0.2, 0.169, 0.133, 1)">
+			Default ground color for the preview environment in the 3D editor.
+		</member>
+		<member name="editor/3d/preview_environment/default_sky_color" type="Color" setter="" getter="" default="Color(0.385, 0.454, 0.55, 1)">
+			Default sky color for the preview environment in the 3D editor.
+		</member>
+		<member name="editor/3d/preview_environment/default_sky_energy" type="float" setter="" getter="" default="1.0">
+			Default sky energy multiplier for the preview environment in the 3D editor.
+		</member>
+		<member name="editor/3d/preview_environment/default_tonemap" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], tonemapping is enabled by default for the preview environment in the 3D editor.
+		</member>
+		<member name="editor/3d/preview_sun/default_angle_altitude" type="float" setter="" getter="" default="60.0">
+			Default altitude (in degrees) for the preview sun in the 3D editor.
+		</member>
+		<member name="editor/3d/preview_sun/default_angle_azimuth" type="float" setter="" getter="" default="30.0">
+			Default azimuth (in degrees) for the preview sun in the 3D editor.
+		</member>
+		<member name="editor/3d/preview_sun/default_color" type="Color" setter="" getter="" default="Color(1, 1, 1, 1)">
+			Default color for the preview sun in the 3D editor.
+		</member>
+		<member name="editor/3d/preview_sun/default_energy" type="float" setter="" getter="" default="1.0">
+			Default energy for the preview sun in the 3D editor.
+		</member>
+		<member name="editor/3d/preview_sun/default_shadow_enabled" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], shadows are enabled by default for the preview sun in the 3D editor.
+		</member>
+		<member name="editor/3d/preview_sun/default_shadow_max_distance" type="float" setter="" getter="" default="100.0">
+			Default max shadow distance for the preview sun in the 3D editor.
+		</member>
 		<member name="editor/export/convert_text_resources_to_binary" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], text resource ([code]tres[/code]) and text scene ([code]tscn[/code]) files are converted to their corresponding binary format on export. This decreases file sizes and speeds up loading slightly.
 			[b]Note:[/b] Because a resource's file extension may change in an exported project, it is heavily recommended to use [method @GDScript.load] or [ResourceLoader] instead of [FileAccess] to load resources dynamically.

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -42,6 +42,7 @@
 
 class AcceptDialog;
 class CheckBox;
+class CheckButton;
 class ColorPickerButton;
 class ConfirmationDialog;
 class DirectionalLight3D;
@@ -845,7 +846,9 @@ private:
 	EditorSpinSlider *sun_angle_azimuth = nullptr;
 	ColorPickerButton *sun_color = nullptr;
 	EditorSpinSlider *sun_energy = nullptr;
-	EditorSpinSlider *sun_max_distance = nullptr;
+	CheckButton *sun_shadow_enabled = nullptr;
+	EditorSpinSlider *sun_shadow_max_distance = nullptr;
+	Button *sun_revert = nullptr;
 	Button *sun_add_to_scene = nullptr;
 
 	void _sun_direction_draw();
@@ -863,11 +866,12 @@ private:
 	VBoxContainer *environ_vb = nullptr;
 	ColorPickerButton *environ_sky_color = nullptr;
 	ColorPickerButton *environ_ground_color = nullptr;
-	EditorSpinSlider *environ_energy = nullptr;
+	EditorSpinSlider *environ_sky_energy = nullptr;
 	Button *environ_ao_button = nullptr;
 	Button *environ_glow_button = nullptr;
 	Button *environ_tonemap_button = nullptr;
 	Button *environ_gi_button = nullptr;
+	Button *environ_revert = nullptr;
 	Button *environ_add_to_scene = nullptr;
 
 	Button *sun_environ_settings = nullptr;
@@ -882,20 +886,22 @@ private:
 
 	bool sun_environ_updating = false;
 
-	void _load_default_preview_settings();
+	void _load_default_preview_settings(bool p_sun = true, bool p_environ = true);
 	void _update_preview_environment();
 
 	void _preview_settings_changed();
 	void _sun_environ_settings_pressed();
 
+	void _revert_preview_sun();
+	void _revert_preview_environ();
 	void _add_sun_to_scene(bool p_already_added_environment = false);
 	void _add_environment_to_scene(bool p_already_added_sun = false);
 
 	void _update_theme();
+	void _project_settings_changed();
 
 protected:
 	void _notification(int p_what);
-	//void _gui_input(InputEvent p_event);
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 	static void _bind_methods();

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -290,6 +290,20 @@ void register_editor_types() {
 	GLOBAL_DEF("editor/version_control/plugin_name", "");
 	GLOBAL_DEF("editor/version_control/autoload_on_startup", false);
 
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "editor/3d/preview_sun/default_angle_altitude", PROPERTY_HINT_RANGE, "-90,90,0.1,degrees"), 60.0);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "editor/3d/preview_sun/default_angle_azimuth", PROPERTY_HINT_RANGE, "-180,180,0.1,or_greater,or_less,degrees"), 30.0);
+	GLOBAL_DEF("editor/3d/preview_sun/default_color", Color(1, 1, 1));
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "editor/3d/preview_sun/default_energy", PROPERTY_HINT_RANGE, "0,16,0.001,or_greater"), 1.0);
+	GLOBAL_DEF("editor/3d/preview_sun/default_shadow_enabled", true);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "editor/3d/preview_sun/default_shadow_max_distance", PROPERTY_HINT_RANGE, "0,8192,0.1,or_greater,exp"), 100.0);
+	GLOBAL_DEF("editor/3d/preview_environment/default_sky_color", Color(0.385, 0.454, 0.55));
+	GLOBAL_DEF("editor/3d/preview_environment/default_ground_color", Color(0.2, 0.169, 0.133));
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "editor/3d/preview_environment/default_sky_energy", PROPERTY_HINT_RANGE, "0,64,0.01"), 1.0);
+	GLOBAL_DEF("editor/3d/preview_environment/default_glow", true);
+	GLOBAL_DEF("editor/3d/preview_environment/default_tonemap", true);
+	GLOBAL_DEF("editor/3d/preview_environment/default_ao", false);
+	GLOBAL_DEF("editor/3d/preview_environment/default_gi", false);
+
 	EditorInterface::create();
 	Engine::Singleton ei_singleton = Engine::Singleton("EditorInterface", EditorInterface::get_singleton());
 	ei_singleton.editor_only = true;


### PR DESCRIPTION
This PR aims to make some improvements to the preview sun and preview environment (henceforth called preview sun/env) for the 3D editor.
### Project Defaults
Previously, users would have no choice in what preview sun/env were applied to new scenes. This is problematic because art direction and graphics needs differ between projects, so having every scene preview by default with glow and color correction enabled creates error-prone workflows where artists cannot see a correct "neutral". It is also tedious to change every scene by hand. This PR adds project settings which allow the user to edit the default values for preview sun/env settings.

![Screenshot 2025-02-12 021429](https://github.com/user-attachments/assets/4435fb17-37ca-4bfc-beb9-b3eb126d1cd0)
### Shadow Toggle
For projects that do not use shadows, it was previously _impossible_ to disable shadows for the preview sun. As before, this is problematic because it does not allow the user to edit props or objects in a correct neutral _for their game_. This PR adds a toggle for shadows.
### Revert Buttons
Previously, it was impossible to quickly revert to default preview settings, meaning the user had to not only remember what the defaults are, but also manually enter them. This PR adds revert buttons at the top of each of the preview sun/env sections.

![Untitled-1](https://github.com/user-attachments/assets/710188f0-9001-4abe-b703-7fa6d121f67f)
### Other Fixes
- Previously, when a new scene was created, the last known state of preview sun/env (from whatever other scene was visited last) was carried over into the new scene. This is arbitrary and error-prone. This PR makes it so that new scenes get the default preview settings applied.
- Previously, the glow button state was not always correctly set in some cases. This PR handles them.