### PR TITLE
Fix NavBase properties not requesting sync

### DIFF
--- a/modules/navigation/nav_base.h
+++ b/modules/navigation/nav_base.h
@@ -52,16 +52,16 @@ public:
 	virtual void set_use_edge_connections(bool p_enabled) {}
 	virtual bool get_use_edge_connections() const { return false; }
 
-	void set_navigation_layers(uint32_t p_navigation_layers) { navigation_layers = p_navigation_layers; }
+	virtual void set_navigation_layers(uint32_t p_navigation_layers) {}
 	uint32_t get_navigation_layers() const { return navigation_layers; }
 
-	void set_enter_cost(real_t p_enter_cost) { enter_cost = MAX(p_enter_cost, 0.0); }
+	virtual void set_enter_cost(real_t p_enter_cost) {}
 	real_t get_enter_cost() const { return enter_cost; }
 
-	void set_travel_cost(real_t p_travel_cost) { travel_cost = MAX(p_travel_cost, 0.0); }
+	virtual void set_travel_cost(real_t p_travel_cost) {}
 	real_t get_travel_cost() const { return travel_cost; }
 
-	void set_owner_id(ObjectID p_owner_id) { owner_id = p_owner_id; }
+	virtual void set_owner_id(ObjectID p_owner_id) {}
 	ObjectID get_owner_id() const { return owner_id; }
 
 	virtual ~NavBase() {}

--- a/modules/navigation/nav_link.cpp
+++ b/modules/navigation/nav_link.cpp
@@ -94,6 +94,48 @@ void NavLink::set_end_position(const Vector3 p_position) {
 	request_sync();
 }
 
+void NavLink::set_navigation_layers(uint32_t p_navigation_layers) {
+	if (navigation_layers == p_navigation_layers) {
+		return;
+	}
+	navigation_layers = p_navigation_layers;
+	link_dirty = true;
+
+	request_sync();
+}
+
+void NavLink::set_enter_cost(real_t p_enter_cost) {
+	real_t new_enter_cost = MAX(p_enter_cost, 0.0);
+	if (enter_cost == new_enter_cost) {
+		return;
+	}
+	enter_cost = new_enter_cost;
+	link_dirty = true;
+
+	request_sync();
+}
+
+void NavLink::set_travel_cost(real_t p_travel_cost) {
+	real_t new_travel_cost = MAX(p_travel_cost, 0.0);
+	if (travel_cost == new_travel_cost) {
+		return;
+	}
+	travel_cost = new_travel_cost;
+	link_dirty = true;
+
+	request_sync();
+}
+
+void NavLink::set_owner_id(ObjectID p_owner_id) {
+	if (owner_id == p_owner_id) {
+		return;
+	}
+	owner_id = p_owner_id;
+	link_dirty = true;
+
+	request_sync();
+}
+
 bool NavLink::is_dirty() const {
 	return link_dirty;
 }

--- a/modules/navigation/nav_link.h
+++ b/modules/navigation/nav_link.h
@@ -86,6 +86,12 @@ public:
 		return end_position;
 	}
 
+	// NavBase properties.
+	virtual void set_navigation_layers(uint32_t p_navigation_layers) override;
+	virtual void set_enter_cost(real_t p_enter_cost) override;
+	virtual void set_travel_cost(real_t p_travel_cost) override;
+	virtual void set_owner_id(ObjectID p_owner_id) override;
+
 	bool is_dirty() const;
 	void sync();
 	void request_sync();

--- a/modules/navigation/nav_region.cpp
+++ b/modules/navigation/nav_region.cpp
@@ -141,10 +141,54 @@ Vector3 NavRegion::get_random_point(uint32_t p_navigation_layers, bool p_uniform
 	return NavMeshQueries3D::polygons_get_random_point(get_polygons(), p_navigation_layers, p_uniformly);
 }
 
+void NavRegion::set_navigation_layers(uint32_t p_navigation_layers) {
+	if (navigation_layers == p_navigation_layers) {
+		return;
+	}
+	navigation_layers = p_navigation_layers;
+	region_dirty = true;
+
+	request_sync();
+}
+
+void NavRegion::set_enter_cost(real_t p_enter_cost) {
+	real_t new_enter_cost = MAX(p_enter_cost, 0.0);
+	if (enter_cost == new_enter_cost) {
+		return;
+	}
+	enter_cost = new_enter_cost;
+	region_dirty = true;
+
+	request_sync();
+}
+
+void NavRegion::set_travel_cost(real_t p_travel_cost) {
+	real_t new_travel_cost = MAX(p_travel_cost, 0.0);
+	if (travel_cost == new_travel_cost) {
+		return;
+	}
+	travel_cost = new_travel_cost;
+	region_dirty = true;
+
+	request_sync();
+}
+
+void NavRegion::set_owner_id(ObjectID p_owner_id) {
+	if (owner_id == p_owner_id) {
+		return;
+	}
+	owner_id = p_owner_id;
+	region_dirty = true;
+
+	request_sync();
+}
+
 bool NavRegion::sync() {
 	RWLockWrite write_lock(region_rwlock);
 
-	bool something_changed = polygons_dirty /* || something_dirty? */;
+	bool something_changed = region_dirty || polygons_dirty;
+
+	region_dirty = false;
 
 	update_polygons();
 

--- a/modules/navigation/nav_region.h
+++ b/modules/navigation/nav_region.h
@@ -48,6 +48,7 @@ class NavRegion : public NavBase {
 
 	bool use_edge_connections = true;
 
+	bool region_dirty = true;
 	bool polygons_dirty = true;
 
 	LocalVector<gd::Polygon> navmesh_polygons;
@@ -77,10 +78,8 @@ public:
 		return map;
 	}
 
-	void set_use_edge_connections(bool p_enabled);
-	bool get_use_edge_connections() const {
-		return use_edge_connections;
-	}
+	virtual void set_use_edge_connections(bool p_enabled) override;
+	virtual bool get_use_edge_connections() const override { return use_edge_connections; }
 
 	void set_transform(Transform3D transform);
 	const Transform3D &get_transform() const {
@@ -99,6 +98,12 @@ public:
 
 	real_t get_surface_area() const { return surface_area; }
 	AABB get_bounds() const { return bounds; }
+
+	// NavBase properties.
+	virtual void set_navigation_layers(uint32_t p_navigation_layers) override;
+	virtual void set_enter_cost(real_t p_enter_cost) override;
+	virtual void set_travel_cost(real_t p_travel_cost) override;
+	virtual void set_owner_id(ObjectID p_owner_id) override;
 
 	bool sync();
 	void request_sync();


### PR DESCRIPTION
Fixes that setters of NavBase properties never made the link or region dirty and requested a sync.

Fixes https://github.com/godotengine/godot/issues/102745

Frankly that the NavBase setters never made the link or region dirty was already questionable, it was just not creating an immediate problem. It was not a problem before because everything, for better or worse, was reading directly from the link or region pointer. Now it is reading from an iteration and without a sync request this iteration never gets updated and that caused the bug.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
