### PR TITLE
[3.x] Physics Interpolation - Fix global switch hidden nodes

### DIFF
--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -226,6 +226,7 @@ private:
 	void _call_input_pause(const StringName &p_group, const StringName &p_method, const Ref<InputEvent> &p_input);
 	Variant _call_group_flags(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 	Variant _call_group(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
+	void _find_and_show_hidden_nodes(Node *p_node, LocalVector<Node *> &r_hidden_nodes) const;
 
 	void _flush_delete_queue();
 	//optimization


### PR DESCRIPTION
Ensure hidden nodes get reset when switching global physics interpolation on / off.

Fixes #101192 for hidden nodes.

## Notes
* It had been a while since I looked at it, and it turns out for 2D and 3D transforms *are* currently kept up to date for hidden items, so the general case unhiding already seems to work fine. (I had already added a special case for 3D with physics interpolation, although this whole area may be revisited.)
* This means for now, fix for this issue can purely be for addressing the rare case of switching on / off global physics interpolation at runtime.
* Localized to `SceneTree` so no changes are needed within nodes.
* Also applicable to 4.x.

## Discussion
Another alternative (as @akien-mga suggested) is just to unexpose the function which allows changing physics interpolation at runtime, and withdraw support, and get users to restart the engine with a cfg file.

That alternative is available in #102762 .

Similar problems could also theoretically occur when changing branches interpolation mode at runtime, but this is intended to be design time decision (I'll probably look at adding this to the docs), I'm not sure there is a use case for this at runtime.

It is also possible to put logic in the nodes themselves just for this settings change (e.g. checking a global state before checking visibility), but imo it would be better to avoid complicating the code and maintenance for such a rare use case (we only have one user asking for the feature).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
