### PR TITLE
Add tooltip text to Polygon3DEditor buttons

### DIFF
--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -535,12 +535,14 @@ Polygon3DEditor::Polygon3DEditor() {
 
 	button_create = memnew(Button);
 	button_create->set_theme_type_variation(SceneStringName(FlatButton));
+	button_create->set_tooltip_text(TTRC("Create Polygon"));
 	add_child(button_create);
 	button_create->connect(SceneStringName(pressed), callable_mp(this, &Polygon3DEditor::_menu_option).bind(MODE_CREATE));
 	button_create->set_toggle_mode(true);
 
 	button_edit = memnew(Button);
 	button_edit->set_theme_type_variation(SceneStringName(FlatButton));
+	button_edit->set_tooltip_text(TTRC("Edit Polygon"));
 	add_child(button_edit);
 	button_edit->connect(SceneStringName(pressed), callable_mp(this, &Polygon3DEditor::_menu_option).bind(MODE_EDIT));
 	button_edit->set_toggle_mode(true);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/102759

After

[Screencast_20250210_052335.webm](https://github.com/user-attachments/assets/16f02468-3dfd-4090-b61d-c73cb95aa785)
