### PR TITLE
[3.x] Physics Interpolation - Unexpose `SceneTree` global switch

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -412,9 +412,9 @@
 		<method name="is_physics_interpolated_and_enabled" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if physics interpolation is enabled (see [member physics_interpolation_mode]) [b]and[/b] enabled in the [SceneTree].
+				Returns [code]true[/code] if physics interpolation is enabled (see [member physics_interpolation_mode]) on the Node [b]and[/b] enabled globally.
 				This is a convenience version of [method is_physics_interpolated] that also checks whether physics interpolation is enabled globally.
-				See [member SceneTree.physics_interpolation] and [member ProjectSettings.physics/common/physics_interpolation].
+				See [member ProjectSettings.physics/common/physics_interpolation].
 			</description>
 		</method>
 		<method name="is_physics_processing" qualifiers="const">

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -155,6 +155,12 @@
 				Returns [code]true[/code] if this [SceneTree]'s [member network_peer] is in server mode (listening for connections).
 			</description>
 		</method>
+		<method name="is_physics_interpolation_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if [member ProjectSettings.physics/common/physics_interpolation] has enabled physics interpolation globally in the project.
+			</description>
+		</method>
 		<method name="notify_group">
 			<return type="void" />
 			<argument index="0" name="group" type="String" />
@@ -263,9 +269,6 @@
 			If [code]true[/code], the [SceneTree] is paused. Doing so will have the following behavior:
 			- 2D and 3D physics will be stopped. This includes signals and collision detection.
 			- [method Node._process], [method Node._physics_process] and [method Node._input] will not be called anymore in nodes.
-		</member>
-		<member name="physics_interpolation" type="bool" setter="set_physics_interpolation_enabled" getter="is_physics_interpolation_enabled" default="false">
-			Although physics interpolation would normally be globally turned on and off using [member ProjectSettings.physics/common/physics_interpolation], this property allows control over interpolation at runtime.
 		</member>
 		<member name="quit_on_go_back" type="bool" setter="set_quit_on_go_back" getter="is_quit_on_go_back" default="true">
 			If [code]true[/code], the application quits automatically on going back (e.g. on Android).

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2091,7 +2091,6 @@ void SceneTree::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_screen_stretch", "mode", "aspect", "minsize", "scale"), &SceneTree::set_screen_stretch, DEFVAL(1));
 
-	ClassDB::bind_method(D_METHOD("set_physics_interpolation_enabled", "enabled"), &SceneTree::set_physics_interpolation_enabled);
 	ClassDB::bind_method(D_METHOD("is_physics_interpolation_enabled"), &SceneTree::is_physics_interpolation_enabled);
 
 	ClassDB::bind_method(D_METHOD("queue_delete", "obj"), &SceneTree::queue_delete);


### PR DESCRIPTION
Changing the global physics interpolation mode at runtime was originally intended for debugging, and requires extra code to make it work seamlessly. It hadn't been foreseen that users would attempt to use this in exported projects.

An alternative to adding extra code for this rare use case is simply to unexpose the ability to change at runtime, and force an engine restart to change this global switch.

Alternative to #102755
Fixes #101192

## Notes
* Suggested as a possibility by @akien-mga 
* Afaik Godot can override project settings by storing an "override.cfg"

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
