### PR TITLE
[C#] Improve Documentation for Typed `Godot.Collections` Wrappers

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -1035,12 +1035,17 @@ namespace Godot.Collections
     }
 
     /// <summary>
-    /// Typed wrapper around Godot's Array class, an array of Variant
-    /// typed elements allocated in the engine in C++. Useful when
-    /// interfacing with the engine. Otherwise prefer .NET collections
+    /// Typed wrapper around Godot's Array class, an array of <typeparamref name="T"/>
+    /// annotated, Variant typed elements allocated in the engine in C++.
+    /// Useful when interfacing with the engine. Otherwise prefer .NET collections
     /// such as arrays or <see cref="List{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of the array.</typeparam>
+    /// <remarks>
+    /// While the elements are statically annotated to <typeparamref name="T"/>,
+    /// the underlying array still stores <see cref="Variant"/>, which has the same
+    /// memory footprint per element as an untyped <see cref="Array"/>.
+    /// </remarks>
     [DebuggerTypeProxy(typeof(ArrayDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
     [SuppressMessage("ReSharper", "RedundantExtendsListEntry")]

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -476,13 +476,18 @@ namespace Godot.Collections
     }
 
     /// <summary>
-    /// Typed wrapper around Godot's Dictionary class, a dictionary of Variant
-    /// typed elements allocated in the engine in C++. Useful when
-    /// interfacing with the engine. Otherwise prefer .NET collections
+    /// Typed wrapper around Godot's Dictionary class, a dictionary of <typeparamref name="TKey"/>
+    /// and <typeparamref name="TValue"/> annotated, Variant typed elements allocated in the engine in C++.
+    /// Useful when interfacing with the engine. Otherwise prefer .NET collections
     /// such as <see cref="System.Collections.Generic.Dictionary{TKey, TValue}"/>.
     /// </summary>
     /// <typeparam name="TKey">The type of the dictionary's keys.</typeparam>
     /// <typeparam name="TValue">The type of the dictionary's values.</typeparam>
+    /// <remarks>
+    /// While the elements are statically annotated to <typeparamref name="TKey"/> and <typeparamref name="TValue"/>,
+    /// the underlying dictionary still stores <see cref="Variant"/>, which has the same memory footprint per element
+    /// as an untyped <see cref="Dictionary"/>.
+    /// </remarks>
     [DebuggerTypeProxy(typeof(DictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
     [SuppressMessage("Design", "CA1001", MessageId = "Types that own disposable fields should be disposable",


### PR DESCRIPTION
Closes #102753 

This pull request includes updates to the documentation comments for the `Godot.Collections.Array<[MustBeVariant] T>` and `Godot.Collections.Dictionary<[MustBeVariant] TKey, [MustBeVariant] TValue>` wrapper types to improve clarity and accuracy.

Documentation improvements:

* [`modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs`](diffhunk://#diff-7b222db775bbaf1eb3d1102d64652196b35cef13053ca8b5a92cba18a1fd2bd2L1038-R1038): Updated the summary comment to specify that the array contains elements of type `<typeparamref name="T"/>`.
* [`modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs`](diffhunk://#diff-6ad5c52c284ba0bb55706e339e12e6a0f0ece132a0bd9cb4f67203937077223cL479-R479): Updated the summary comment to specify that the dictionary contains elements of types `<typeparamref name="TKey"/>` and `<typeparamref name="TValue"/>`.