### PR TITLE
Add path query region filters

### DIFF
--- a/doc/classes/NavigationPathQueryParameters2D.xml
+++ b/doc/classes/NavigationPathQueryParameters2D.xml
@@ -10,6 +10,14 @@
 		<link title="Using NavigationPathQueryObjects">$DOCS_URL/tutorials/navigation/navigation_using_navigationpathqueryobjects.html</link>
 	</tutorials>
 	<members>
+		<member name="excluded_regions" type="RID[]" setter="set_excluded_regions" getter="get_excluded_regions" default="[]">
+			The list of region [RID]s that will be excluded from the path query. Use [method NavigationRegion2D.get_rid] to get the [RID] associated with a [NavigationRegion2D] node.
+			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then set it to the property again.
+		</member>
+		<member name="included_regions" type="RID[]" setter="set_included_regions" getter="get_included_regions" default="[]">
+			The list of region [RID]s that will be included by the path query. Use [method NavigationRegion2D.get_rid] to get the [RID] associated with a [NavigationRegion2D] node. If left empty all regions are included. If a region ends up being both included and excluded at the same time it will be excluded.
+			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then set it to the property again.
+		</member>
 		<member name="map" type="RID" setter="set_map" getter="get_map" default="RID()">
 			The navigation map [RID] used in the path query.
 		</member>

--- a/doc/classes/NavigationPathQueryParameters3D.xml
+++ b/doc/classes/NavigationPathQueryParameters3D.xml
@@ -10,6 +10,14 @@
 		<link title="Using NavigationPathQueryObjects">$DOCS_URL/tutorials/navigation/navigation_using_navigationpathqueryobjects.html</link>
 	</tutorials>
 	<members>
+		<member name="excluded_regions" type="RID[]" setter="set_excluded_regions" getter="get_excluded_regions" default="[]">
+			The list of region [RID]s that will be excluded from the path query. Use [method NavigationRegion3D.get_rid] to get the [RID] associated with a [NavigationRegion3D] node.
+			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then set it to the property again.
+		</member>
+		<member name="included_regions" type="RID[]" setter="set_included_regions" getter="get_included_regions" default="[]">
+			The list of region [RID]s that will be included by the path query. Use [method NavigationRegion3D.get_rid] to get the [RID] associated with a [NavigationRegion3D] node. If left empty all regions are included. If a region ends up being both included and excluded at the same time it will be excluded.
+			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then set it to the property again.
+		</member>
 		<member name="map" type="RID" setter="set_map" getter="get_map" default="RID()">
 			The navigation map [RID] used in the path query.
 		</member>

--- a/modules/navigation/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation/2d/godot_navigation_server_2d.cpp
@@ -513,6 +513,8 @@ void GodotNavigationServer2D::query_path(const Ref<NavigationPathQueryParameters
 	query_parameters->set_metadata_flags((int64_t)p_query_parameters->get_metadata_flags());
 	query_parameters->set_simplify_path(p_query_parameters->get_simplify_path());
 	query_parameters->set_simplify_epsilon(p_query_parameters->get_simplify_epsilon());
+	query_parameters->set_excluded_regions(p_query_parameters->get_excluded_regions());
+	query_parameters->set_included_regions(p_query_parameters->get_included_regions());
 
 	Ref<NavigationPathQueryResult3D> query_result;
 	query_result.instantiate();

--- a/modules/navigation/3d/nav_base_iteration_3d.h
+++ b/modules/navigation/3d/nav_base_iteration_3d.h
@@ -31,6 +31,8 @@
 #ifndef NAV_BASE_ITERATION_3D_H
 #define NAV_BASE_ITERATION_3D_H
 
+#include "../nav_utils.h"
+
 #include "servers/navigation/navigation_utilities.h"
 
 struct NavBaseIteration {
@@ -43,6 +45,7 @@ struct NavBaseIteration {
 	ObjectID owner_object_id;
 	RID owner_rid;
 	bool owner_use_edge_connections = false;
+	LocalVector<gd::Polygon> navmesh_polygons;
 
 	bool get_enabled() const { return enabled; }
 	NavigationUtilities::PathSegmentType get_type() const { return owner_type; }
@@ -52,6 +55,7 @@ struct NavBaseIteration {
 	real_t get_enter_cost() const { return enter_cost; }
 	real_t get_travel_cost() const { return travel_cost; }
 	bool get_use_edge_connections() const { return owner_use_edge_connections; }
+	const LocalVector<gd::Polygon> &get_navmesh_polygons() const { return navmesh_polygons; }
 };
 
 #endif // NAV_BASE_ITERATION_3D_H

--- a/modules/navigation/3d/nav_mesh_queries_3d.h
+++ b/modules/navigation/3d/nav_mesh_queries_3d.h
@@ -71,6 +71,10 @@ public:
 		PathPostProcessing path_postprocessing = PathPostProcessing::PATH_POSTPROCESSING_CORRIDORFUNNEL;
 		bool simplify_path = false;
 		real_t simplify_epsilon = 0.0;
+		bool exclude_regions = false;
+		bool include_regions = false;
+		LocalVector<RID> excluded_regions;
+		LocalVector<RID> included_regions;
 
 		// Path building.
 		Vector3 begin_position;

--- a/modules/navigation/3d/nav_region_iteration_3d.h
+++ b/modules/navigation/3d/nav_region_iteration_3d.h
@@ -38,12 +38,10 @@
 
 struct NavRegionIteration : NavBaseIteration {
 	Transform3D transform;
-	LocalVector<gd::Polygon> navmesh_polygons;
 	real_t surface_area = 0.0;
 	AABB bounds;
 
 	const Transform3D &get_transform() const { return transform; }
-	const LocalVector<gd::Polygon> &get_navmesh_polygons() const { return navmesh_polygons; }
 	real_t get_surface_area() const { return surface_area; }
 	AABB get_bounds() const { return bounds; }
 };

--- a/modules/navigation/nav_link.h
+++ b/modules/navigation/nav_link.h
@@ -39,7 +39,6 @@ struct NavLinkIteration : NavBaseIteration {
 	bool bidirectional = true;
 	Vector3 start_position;
 	Vector3 end_position;
-	LocalVector<gd::Polygon> navmesh_polygons;
 
 	Vector3 get_start_position() const { return start_position; }
 	Vector3 get_end_position() const { return end_position; }

--- a/servers/navigation/navigation_path_query_parameters_2d.cpp
+++ b/servers/navigation/navigation_path_query_parameters_2d.cpp
@@ -102,6 +102,38 @@ real_t NavigationPathQueryParameters2D::get_simplify_epsilon() const {
 	return simplify_epsilon;
 }
 
+void NavigationPathQueryParameters2D::set_included_regions(const TypedArray<RID> &p_regions) {
+	_included_regions.resize(p_regions.size());
+	for (uint32_t i = 0; i < _included_regions.size(); i++) {
+		_included_regions[i] = p_regions[i];
+	}
+}
+
+TypedArray<RID> NavigationPathQueryParameters2D::get_included_regions() const {
+	TypedArray<RID> r_regions;
+	r_regions.resize(_included_regions.size());
+	for (uint32_t i = 0; i < _included_regions.size(); i++) {
+		r_regions[i] = _included_regions[i];
+	}
+	return r_regions;
+}
+
+void NavigationPathQueryParameters2D::set_excluded_regions(const TypedArray<RID> &p_regions) {
+	_excluded_regions.resize(p_regions.size());
+	for (uint32_t i = 0; i < _excluded_regions.size(); i++) {
+		_excluded_regions[i] = p_regions[i];
+	}
+}
+
+TypedArray<RID> NavigationPathQueryParameters2D::get_excluded_regions() const {
+	TypedArray<RID> r_regions;
+	r_regions.resize(_excluded_regions.size());
+	for (uint32_t i = 0; i < _excluded_regions.size(); i++) {
+		r_regions[i] = _excluded_regions[i];
+	}
+	return r_regions;
+}
+
 void NavigationPathQueryParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pathfinding_algorithm", "pathfinding_algorithm"), &NavigationPathQueryParameters2D::set_pathfinding_algorithm);
 	ClassDB::bind_method(D_METHOD("get_pathfinding_algorithm"), &NavigationPathQueryParameters2D::get_pathfinding_algorithm);
@@ -130,6 +162,12 @@ void NavigationPathQueryParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_simplify_epsilon", "epsilon"), &NavigationPathQueryParameters2D::set_simplify_epsilon);
 	ClassDB::bind_method(D_METHOD("get_simplify_epsilon"), &NavigationPathQueryParameters2D::get_simplify_epsilon);
 
+	ClassDB::bind_method(D_METHOD("set_included_regions", "regions"), &NavigationPathQueryParameters2D::set_included_regions);
+	ClassDB::bind_method(D_METHOD("get_included_regions"), &NavigationPathQueryParameters2D::get_included_regions);
+
+	ClassDB::bind_method(D_METHOD("set_excluded_regions", "regions"), &NavigationPathQueryParameters2D::set_excluded_regions);
+	ClassDB::bind_method(D_METHOD("get_excluded_regions"), &NavigationPathQueryParameters2D::get_excluded_regions);
+
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "map"), "set_map", "get_map");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "start_position"), "set_start_position", "get_start_position");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "target_position"), "set_target_position", "get_target_position");
@@ -139,6 +177,8 @@ void NavigationPathQueryParameters2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "metadata_flags", PROPERTY_HINT_FLAGS, "Include Types,Include RIDs,Include Owners"), "set_metadata_flags", "get_metadata_flags");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "simplify_path"), "set_simplify_path", "get_simplify_path");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "simplify_epsilon"), "set_simplify_epsilon", "get_simplify_epsilon");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "excluded_regions", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_excluded_regions", "get_excluded_regions");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "included_regions", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_included_regions", "get_included_regions");
 
 	BIND_ENUM_CONSTANT(PATHFINDING_ALGORITHM_ASTAR);
 

--- a/servers/navigation/navigation_path_query_parameters_2d.h
+++ b/servers/navigation/navigation_path_query_parameters_2d.h
@@ -69,6 +69,8 @@ private:
 	BitField<PathMetadataFlags> metadata_flags = PATH_METADATA_INCLUDE_ALL;
 	bool simplify_path = false;
 	real_t simplify_epsilon = 0.0;
+	LocalVector<RID> _excluded_regions;
+	LocalVector<RID> _included_regions;
 
 public:
 	void set_pathfinding_algorithm(const PathfindingAlgorithm p_pathfinding_algorithm);
@@ -97,6 +99,12 @@ public:
 
 	void set_simplify_epsilon(real_t p_epsilon);
 	real_t get_simplify_epsilon() const;
+
+	void set_excluded_regions(const TypedArray<RID> &p_regions);
+	TypedArray<RID> get_excluded_regions() const;
+
+	void set_included_regions(const TypedArray<RID> &p_regions);
+	TypedArray<RID> get_included_regions() const;
 };
 
 VARIANT_ENUM_CAST(NavigationPathQueryParameters2D::PathfindingAlgorithm);

--- a/servers/navigation/navigation_path_query_parameters_3d.cpp
+++ b/servers/navigation/navigation_path_query_parameters_3d.cpp
@@ -102,6 +102,38 @@ real_t NavigationPathQueryParameters3D::get_simplify_epsilon() const {
 	return simplify_epsilon;
 }
 
+void NavigationPathQueryParameters3D::set_included_regions(const TypedArray<RID> &p_regions) {
+	_included_regions.resize(p_regions.size());
+	for (uint32_t i = 0; i < _included_regions.size(); i++) {
+		_included_regions[i] = p_regions[i];
+	}
+}
+
+TypedArray<RID> NavigationPathQueryParameters3D::get_included_regions() const {
+	TypedArray<RID> r_regions;
+	r_regions.resize(_included_regions.size());
+	for (uint32_t i = 0; i < _included_regions.size(); i++) {
+		r_regions[i] = _included_regions[i];
+	}
+	return r_regions;
+}
+
+void NavigationPathQueryParameters3D::set_excluded_regions(const TypedArray<RID> &p_regions) {
+	_excluded_regions.resize(p_regions.size());
+	for (uint32_t i = 0; i < _excluded_regions.size(); i++) {
+		_excluded_regions[i] = p_regions[i];
+	}
+}
+
+TypedArray<RID> NavigationPathQueryParameters3D::get_excluded_regions() const {
+	TypedArray<RID> r_regions;
+	r_regions.resize(_excluded_regions.size());
+	for (uint32_t i = 0; i < _excluded_regions.size(); i++) {
+		r_regions[i] = _excluded_regions[i];
+	}
+	return r_regions;
+}
+
 void NavigationPathQueryParameters3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pathfinding_algorithm", "pathfinding_algorithm"), &NavigationPathQueryParameters3D::set_pathfinding_algorithm);
 	ClassDB::bind_method(D_METHOD("get_pathfinding_algorithm"), &NavigationPathQueryParameters3D::get_pathfinding_algorithm);
@@ -130,6 +162,12 @@ void NavigationPathQueryParameters3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_simplify_epsilon", "epsilon"), &NavigationPathQueryParameters3D::set_simplify_epsilon);
 	ClassDB::bind_method(D_METHOD("get_simplify_epsilon"), &NavigationPathQueryParameters3D::get_simplify_epsilon);
 
+	ClassDB::bind_method(D_METHOD("set_included_regions", "regions"), &NavigationPathQueryParameters3D::set_included_regions);
+	ClassDB::bind_method(D_METHOD("get_included_regions"), &NavigationPathQueryParameters3D::get_included_regions);
+
+	ClassDB::bind_method(D_METHOD("set_excluded_regions", "regions"), &NavigationPathQueryParameters3D::set_excluded_regions);
+	ClassDB::bind_method(D_METHOD("get_excluded_regions"), &NavigationPathQueryParameters3D::get_excluded_regions);
+
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "map"), "set_map", "get_map");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "start_position"), "set_start_position", "get_start_position");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "target_position"), "set_target_position", "get_target_position");
@@ -139,6 +177,8 @@ void NavigationPathQueryParameters3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "metadata_flags", PROPERTY_HINT_FLAGS, "Include Types,Include RIDs,Include Owners"), "set_metadata_flags", "get_metadata_flags");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "simplify_path"), "set_simplify_path", "get_simplify_path");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "simplify_epsilon"), "set_simplify_epsilon", "get_simplify_epsilon");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "excluded_regions", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_excluded_regions", "get_excluded_regions");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "included_regions", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_included_regions", "get_included_regions");
 
 	BIND_ENUM_CONSTANT(PATHFINDING_ALGORITHM_ASTAR);
 

--- a/servers/navigation/navigation_path_query_parameters_3d.h
+++ b/servers/navigation/navigation_path_query_parameters_3d.h
@@ -69,6 +69,8 @@ private:
 	BitField<PathMetadataFlags> metadata_flags = PATH_METADATA_INCLUDE_ALL;
 	bool simplify_path = false;
 	real_t simplify_epsilon = 0.0;
+	LocalVector<RID> _excluded_regions;
+	LocalVector<RID> _included_regions;
 
 public:
 	void set_pathfinding_algorithm(const PathfindingAlgorithm p_pathfinding_algorithm);
@@ -97,6 +99,12 @@ public:
 
 	void set_simplify_epsilon(real_t p_epsilon);
 	real_t get_simplify_epsilon() const;
+
+	void set_excluded_regions(const TypedArray<RID> &p_regions);
+	TypedArray<RID> get_excluded_regions() const;
+
+	void set_included_regions(const TypedArray<RID> &p_regions);
+	TypedArray<RID> get_included_regions() const;
 };
 
 VARIANT_ENUM_CAST(NavigationPathQueryParameters3D::PathfindingAlgorithm);

--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -794,6 +794,54 @@ TEST_SUITE("[Navigation]") {
 			CHECK_EQ(query_result->get_path_owner_ids().size(), 0);
 		}
 
+		SUBCASE("Elaborate query with excluded region should yield empty path") {
+			Ref<NavigationPathQueryParameters3D> query_parameters;
+			query_parameters.instantiate();
+			query_parameters->set_map(map);
+			query_parameters->set_start_position(Vector3(10, 0, 10));
+			query_parameters->set_target_position(Vector3(0, 0, 0));
+			Array excluded_regions;
+			excluded_regions.push_back(region);
+			query_parameters->set_excluded_regions(excluded_regions);
+			Ref<NavigationPathQueryResult3D> query_result;
+			query_result.instantiate();
+			navigation_server->query_path(query_parameters, query_result);
+			CHECK_EQ(query_result->get_path().size(), 0);
+		}
+
+		SUBCASE("Elaborate query with included region should yield path") {
+			Ref<NavigationPathQueryParameters3D> query_parameters;
+			query_parameters.instantiate();
+			query_parameters->set_map(map);
+			query_parameters->set_start_position(Vector3(10, 0, 10));
+			query_parameters->set_target_position(Vector3(0, 0, 0));
+			Array included_regions;
+			included_regions.push_back(region);
+			query_parameters->set_included_regions(included_regions);
+			Ref<NavigationPathQueryResult3D> query_result;
+			query_result.instantiate();
+			navigation_server->query_path(query_parameters, query_result);
+			CHECK_NE(query_result->get_path().size(), 0);
+		}
+
+		SUBCASE("Elaborate query with excluded and included region should yield empty path") {
+			Ref<NavigationPathQueryParameters3D> query_parameters;
+			query_parameters.instantiate();
+			query_parameters->set_map(map);
+			query_parameters->set_start_position(Vector3(10, 0, 10));
+			query_parameters->set_target_position(Vector3(0, 0, 0));
+			Array excluded_regions;
+			excluded_regions.push_back(region);
+			query_parameters->set_excluded_regions(excluded_regions);
+			Array included_regions;
+			included_regions.push_back(region);
+			query_parameters->set_included_regions(included_regions);
+			Ref<NavigationPathQueryResult3D> query_result;
+			query_result.instantiate();
+			navigation_server->query_path(query_parameters, query_result);
+			CHECK_EQ(query_result->get_path().size(), 0);
+		}
+
 		navigation_server->free(region);
 		navigation_server->free(map);
 		navigation_server->process(0.0); // Give server some cycles to commit.


### PR DESCRIPTION
Adds filter lists to `exclude` or `include` specific regions in path queries.

This is close to usability that users know from the physics queries exclude lists.

Currently the path queries run over all the enabled regions in the navigation map. The only current way to filter anything is with the `navigation_layers` bitmask which has its limits. This does not really work well for large maps or when users only want to consider specific regions for a path.

If a region RID is inside the `exclude` list all the region navmesh polygons (including navlinks that connect from or to them)  will not be considered in the path query no matter what (even if in the include list).

As default if the `include` list is kept empty all regions are used. If a single region RID is added to the include list the path query will only consider region polygons from that list (that are also not in the exclude list).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
