### PR TITLE
Bump the version of the openxr vendors plugin dependency

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -12,7 +12,8 @@ ext.versions = [
     javaVersion        : JavaVersion.VERSION_17,
     // Also update 'platform/android/detect.py#get_ndk_version()' when this is updated.
     ndkVersion         : '23.2.8568313',
-    splashscreenVersion: '1.0.1'
+    splashscreenVersion: '1.0.1',
+    openxrVendorsVersion: '3.1.2-stable'
 
 ]
 

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -188,7 +188,7 @@ dependencies {
     implementation "org.bouncycastle:bcprov-jdk15to18:1.78"
 
     // Meta dependencies
-    horizonosImplementation "org.godotengine:godot-openxr-vendors-meta:3.0.0-stable"
+    horizonosImplementation "org.godotengine:godot-openxr-vendors-meta:$versions.openxrVendorsVersion"
     // Pico dependencies
-    picoosImplementation "org.godotengine:godot-openxr-vendors-pico:3.0.1-stable"
+    picoosImplementation "org.godotengine:godot-openxr-vendors-pico:$versions.openxrVendorsVersion"
 }


### PR DESCRIPTION
Bumping the vendors plugin dependency version in preparation for the 4.4 upcoming stable release.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
