### PR TITLE
[TLS] Disable TLSv1.3 support by default

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2204,6 +2204,10 @@
 			The CA certificates bundle to use for TLS connections. If this is set to a non-empty value, this will [i]override[/i] Godot's default [url=https://github.com/godotengine/godot/blob/master/thirdparty/certs/ca-certificates.crt]Mozilla certificate bundle[/url]. If left empty, the default certificate bundle will be used.
 			If in doubt, leave this setting empty.
 		</member>
+		<member name="network/tls/enable_tls_v1.3" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], enable TLSv1.3 negotiation.
+			[b]Note:[/b] This is experimental, and may cause connections to fail in some cases (notably, if the remote server uses TLS handshake fragmentation).
+		</member>
 		<member name="physics/2d/default_angular_damp" type="float" setter="" getter="" default="1.0">
 			The default rotational motion damping in 2D. Damping is used to gradually slow down physical objects over time. RigidBodies will fall back to this value when combining their own damping values and no area damping value is present.
 			Suggested values are in the range [code]0[/code] to [code]30[/code]. At value [code]0[/code] objects will keep moving with the same velocity. Greater values will stop the object faster. A value equal to or greater than the physics tick rate ([member physics/common/physics_ticks_per_second]) will bring the object to a stop in one iteration.

--- a/modules/mbedtls/register_types.cpp
+++ b/modules/mbedtls/register_types.cpp
@@ -35,6 +35,8 @@
 #include "packet_peer_mbed_dtls.h"
 #include "stream_peer_mbedtls.h"
 
+#include "core/config/project_settings.h"
+
 #if MBEDTLS_VERSION_MAJOR >= 3
 #include <psa/crypto.h>
 #endif
@@ -49,6 +51,8 @@ void initialize_mbedtls_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
+
+	GLOBAL_DEF("network/tls/enable_tls_v1.3", false);
 
 #if MBEDTLS_VERSION_MAJOR >= 3
 	int status = psa_crypto_init();

--- a/modules/mbedtls/tls_context_mbedtls.cpp
+++ b/modules/mbedtls/tls_context_mbedtls.cpp
@@ -30,6 +30,8 @@
 
 #include "tls_context_mbedtls.h"
 
+#include "core/config/project_settings.h"
+
 static void my_debug(void *ctx, int level,
 		const char *file, int line,
 		const char *str) {
@@ -144,6 +146,11 @@ Error TLSContextMbedTLS::init_server(int p_transport, Ref<TLSOptions> p_options,
 		cookies = p_cookies;
 		mbedtls_ssl_conf_dtls_cookies(&conf, mbedtls_ssl_cookie_write, mbedtls_ssl_cookie_check, &(cookies->cookie_ctx));
 	}
+
+	if (Engine::get_singleton()->is_editor_hint() || !(bool)GLOBAL_GET("network/tls/enable_tls_v1.3")) {
+		mbedtls_ssl_conf_max_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_2);
+	}
+
 	mbedtls_ssl_setup(&tls, &conf);
 	return OK;
 }
@@ -185,6 +192,10 @@ Error TLSContextMbedTLS::init_client(int p_transport, const String &p_hostname, 
 			clear();
 			ERR_FAIL_V_MSG(ERR_UNCONFIGURED, "SSL module failed to initialize!");
 		}
+	}
+
+	if (Engine::get_singleton()->is_editor_hint() || !(bool)GLOBAL_GET("network/tls/enable_tls_v1.3")) {
+		mbedtls_ssl_conf_max_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_2);
 	}
 
 	// Set valid CAs


### PR DESCRIPTION
mbedTLS does not support TLS Handshake record layer fragmentation which seems enabled on some sites (notably, Meta's sites).

This PR makes TLSv1.3 optional (and disabled by default).

We should decide if we want to proceed with #102770 (which incorporates an upstream, yet unmerged, PR adding support for the aforementioned feature in mbedTLS -> https://github.com/Mbed-TLS/mbedtls/pull/9949) or merge this instead.

I also had another branch making the TLS min and max versions configurable via TLSOptions but I honestly think that's an overkill and adds a lot of API complexity for something that should just work out of the box.

Fixes #101910 .