### PR TITLE
Fix inspector follow focus when child is focused

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4465,6 +4465,14 @@ void EditorInspector::_node_removed(Node *p_node) {
 	}
 }
 
+void EditorInspector::_gui_focus_changed(Control *p_control) {
+	if (!is_visible_in_tree() && !is_following_focus()) {
+		return;
+	}
+	// Don't follow focus when the inspector nor any of its children is focused. Prevents potential jumping when gaining focus.
+	set_follow_focus(has_focus() || child_has_focus());
+}
+
 void EditorInspector::_update_current_favorites() {
 	current_favorites.clear();
 	if (!can_favorite) {
@@ -4662,6 +4670,10 @@ void EditorInspector::_notification(int p_what) {
 			if (!is_sub_inspector()) {
 				get_tree()->connect("node_removed", callable_mp(this, &EditorInspector::_node_removed));
 			}
+
+			Viewport *viewport = get_viewport();
+			ERR_FAIL_NULL(viewport);
+			viewport->connect("gui_focus_changed", callable_mp(this, &EditorInspector::_gui_focus_changed));
 		} break;
 
 		case NOTIFICATION_PREDELETE: {
@@ -4743,15 +4755,6 @@ void EditorInspector::_notification(int p_what) {
 			if (needs_update) {
 				update_tree();
 			}
-		} break;
-
-		case NOTIFICATION_FOCUS_ENTER: {
-			set_follow_focus(true);
-		} break;
-
-		case NOTIFICATION_FOCUS_EXIT: {
-			// Don't follow focus when the inspector is not focused. Prevents potential jumping when gaining focus.
-			set_follow_focus(false);
 		} break;
 	}
 }

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -606,6 +606,7 @@ class EditorInspector : public ScrollContainer {
 	void _clear_current_favorites();
 
 	void _node_removed(Node *p_node);
+	void _gui_focus_changed(Control *p_control);
 
 	HashMap<StringName, int> per_array_page;
 	void _page_change_request(int p_new_page, const StringName &p_array_prefix);

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -82,7 +82,6 @@ private:
 
 	bool draw_focus_border = false;
 	bool focus_border_is_drawn = false;
-	bool child_has_focus();
 
 protected:
 	Size2 get_minimum_size() const override;
@@ -99,6 +98,7 @@ protected:
 
 public:
 	virtual void gui_input(const Ref<InputEvent> &p_gui_input) override;
+	bool child_has_focus();
 
 	void set_h_scroll(int p_pos);
 	int get_h_scroll() const;


### PR DESCRIPTION
Fixes #102558

https://github.com/godotengine/godot/issues/100695#issuecomment-2645755492 likely points to better fix though.