### PR TITLE
ThorVG: Explicitly enable embedded texture support with `THORVG_FILE_IO_SUPPORT`

### DIFF
--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -69,6 +69,8 @@ env_svg.Prepend(CPPPATH=[thirdparty_dir + "inc"])
 
 # Enable ThorVG static object linking.
 env_svg.Append(CPPDEFINES=["TVG_STATIC"])
+# Explicit support for embedded images in svg.
+env_svg.Append(CPPDEFINES=["THORVG_FILE_IO_SUPPORT"])
 
 env_thirdparty = env_svg.Clone()
 env_thirdparty.disable_warnings()


### PR DESCRIPTION
This was made opt-in in 0.15.6 so we need to define it now.
https://github.com/thorvg/thorvg/releases/tag/v0.15.6

- Regression from #101347.
- Fixes #102721.