### PR TITLE
ResourceFormatImporter: Add fallbacks when feature-bound resources cannot be loaded

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -420,6 +420,10 @@ void OS::set_has_server_feature_callback(HasServerFeatureCallback p_callback) {
 }
 
 bool OS::has_feature(const String &p_feature) {
+	return has_native_feature(p_feature) || ProjectSettings::get_singleton()->has_custom_feature(p_feature);
+}
+
+bool OS::has_native_feature(const String &p_feature) {
 	// Feature tags are always lowercase for consistency.
 	if (p_feature == get_identifier()) {
 		return true;
@@ -581,10 +585,6 @@ bool OS::has_feature(const String &p_feature) {
 	}
 
 	if (has_server_feature_callback && has_server_feature_callback(p_feature)) {
-		return true;
-	}
-
-	if (ProjectSettings::get_singleton()->has_custom_feature(p_feature)) {
 		return true;
 	}
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -320,6 +320,7 @@ public:
 	virtual String get_unique_id() const;
 
 	bool has_feature(const String &p_feature);
+	bool has_native_feature(const String &p_feature);
 
 	virtual bool is_sandboxed() const;
 


### PR DESCRIPTION
Adds a set of fallbacks when loading imported resources that are bound to a specific feature to ensure that the most optimal one is prioritized, and that when all features are missing the first existing one is used.