### PR TITLE
Add fallback `default_transition` for travel requests among non-connected states

### DIFF
--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -165,6 +165,9 @@
 		<member name="allow_transition_to_self" type="bool" setter="set_allow_transition_to_self" getter="is_allow_transition_to_self" default="false">
 			If [code]true[/code], allows teleport to the self state with [method AnimationNodeStateMachinePlayback.travel]. When the reset option is enabled in [method AnimationNodeStateMachinePlayback.travel], the animation is restarted. If [code]false[/code], nothing happens on the teleportation to the self state.
 		</member>
+		<member name="default_transition" type="AnimationNodeStateMachineTransition" setter="set_default_transition" getter="get_default_transition">
+			Transition used whenever the state machine teleports.
+		</member>
 		<member name="reset_ends" type="bool" setter="set_reset_ends" getter="are_ends_reset" default="false">
 			If [code]true[/code], treat the cross-fade to the start and end nodes as a blend with the RESET animation.
 			In most cases, when additional cross-fades are performed in the parent [AnimationNode] of the state machine, setting this property to [code]false[/code] and matching the cross-fade time of the parent [AnimationNode] and the state machine's start node and end node gives good results.

--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -91,7 +91,22 @@
 			<return type="void" />
 			<param index="0" name="to_node" type="StringName" />
 			<description>
-				Transitions from the current state to another one, using the state machine's default transition to jump to the destination state.
+				Transitions from the current state directly to another one, using the state machine's default transition if a direct connection is not available.
+			</description>
+		</method>
+		<method name="queue_travel">
+			<return type="void" />
+			<param index="0" name="to_node" type="StringName" />
+			<description>
+				Appends a series of transitions from the last state in the current travel path to another one, following the shortest path.
+				If the path does not connect, the state machine's default transition will be used to jump to the destination state.
+			</description>
+		</method>
+		<method name="queue_jump">
+			<return type="void" />
+			<param index="0" name="to_node" type="StringName" />
+			<description>
+				Appends a single transition to the requested state to the end of the current state machine travel path, using the state machine's default transition if a direct connection is not available.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -100,6 +100,8 @@
 			<param index="0" name="to_node" type="StringName" />
 			<description>
 				Queues the requested state, using the state machine's default transition if a direct connection is not available.
+
+				You can emulate traveling with a transition by calling [code]clear_path()[/code] beforehand.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -84,14 +84,7 @@
 			<param index="0" name="to_node" type="StringName" />
 			<description>
 				Transitions from the current state to another one, following the shortest path.
-				If the path does not connect from the current state, the state machine's default transition will be used to jump to the destination state.
-			</description>
-		</method>
-		<method name="jump">
-			<return type="void" />
-			<param index="0" name="to_node" type="StringName" />
-			<description>
-				Transitions from the current state directly to another one, using the state machine's default transition if a direct connection is not available.
+				If the path does not connect from the current state, the state machine's default transition will be used to jump directly to the destination state.
 			</description>
 		</method>
 		<method name="queue_travel">

--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -102,11 +102,11 @@
 				If the path does not connect, the state machine's default transition will be used to jump to the destination state.
 			</description>
 		</method>
-		<method name="queue_jump">
+		<method name="queue">
 			<return type="void" />
 			<param index="0" name="to_node" type="StringName" />
 			<description>
-				Appends a single transition to the requested state to the end of the current state machine travel path, using the state machine's default transition if a direct connection is not available.
+				Queues the requested state, using the state machine's default transition if a direct connection is not available.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -82,13 +82,16 @@
 		<method name="travel">
 			<return type="void" />
 			<param index="0" name="to_node" type="StringName" />
-			<param index="1" name="reset_on_teleport" type="bool" default="true" />
-			<param index="2" name="force_jump" type="bool" default="false" />
 			<description>
 				Transitions from the current state to another one, following the shortest path.
-				If the path does not connect from the current state, the animation will play after the state teleports.
-				If [param reset_on_teleport] is [code]true[/code], the animation is played from the beginning when the travel cause a teleportation.
-				If [param force_jump] is [code]true[/code], the state machine will use its [code]default_transition[/code] to move directly to the requested state.
+				If the path does not connect from the current state, the state machine's default transition will be used to jump to the destination state.
+			</description>
+		</method>
+		<method name="jump">
+			<return type="void" />
+			<param index="0" name="to_node" type="StringName" />
+			<description>
+				Transitions from the current state to another one, using the state machine's default transition to jump to the destination state.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -83,10 +83,12 @@
 			<return type="void" />
 			<param index="0" name="to_node" type="StringName" />
 			<param index="1" name="reset_on_teleport" type="bool" default="true" />
+			<param index="2" name="force_jump" type="bool" default="false" />
 			<description>
 				Transitions from the current state to another one, following the shortest path.
 				If the path does not connect from the current state, the animation will play after the state teleports.
 				If [param reset_on_teleport] is [code]true[/code], the animation is played from the beginning when the travel cause a teleportation.
+				If [param force_jump] is [code]true[/code], the state machine will use its [code]default_transition[/code] to move directly to the requested state.
 			</description>
 		</method>
 	</methods>

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1055,11 +1055,18 @@ AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_
 		}
 		// There is no transition that ends at the next state in the state machine. We can use the default transition
 		next.node = path[0];
-		next.xfade = p_state_machine->default_transition->get_xfade_time();
-		next.curve = p_state_machine->default_transition->get_xfade_curve();
-		next.switch_mode = p_state_machine->default_transition->get_switch_mode();
-		next.is_reset = p_state_machine->default_transition->is_reset();
-		next.break_loop_at_end = p_state_machine->default_transition->is_loop_broken_at_end();
+		if (p_state_machine->default_transition == nullptr) {
+			next.xfade = 0;
+			next.switch_mode = AnimationNodeStateMachineTransition::SWITCH_MODE_IMMEDIATE;
+			next.is_reset = false;
+			next.break_loop_at_end = false;
+		} else {
+			next.xfade = p_state_machine->default_transition->get_xfade_time();
+			next.curve = p_state_machine->default_transition->get_xfade_curve();
+			next.switch_mode = p_state_machine->default_transition->get_switch_mode();
+			next.is_reset = p_state_machine->default_transition->is_reset();
+			next.break_loop_at_end = p_state_machine->default_transition->is_loop_broken_at_end();
+		}
 		return next; // Once we have the information we need, we can actually just return that info
 	} else {
 		int auto_advance_to = -1;
@@ -1317,9 +1324,7 @@ bool AnimationNodeStateMachine::are_ends_reset() const {
 }
 
 void AnimationNodeStateMachine::set_default_transition(Ref<AnimationNodeStateMachineTransition> p_transition) {
-	if (p_transition != NULL) {
-		default_transition = p_transition->duplicate();
-	}
+	default_transition = p_transition;
 }
 
 Ref<AnimationNodeStateMachineTransition> AnimationNodeStateMachine::get_default_transition() {
@@ -1874,7 +1879,4 @@ AnimationNodeStateMachine::AnimationNodeStateMachine() {
 	end.node = e;
 	end.position = Vector2(900, 100);
 	states[SceneStringName(End)] = end;
-
-	Ref<AnimationNodeStateMachineTransition> t;
-	set_teleport_transition(t);
 }

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1070,7 +1070,7 @@ AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_
 		}
 		// There is no transition that ends at the next state in the state machine. We can use the default transition
 		next.node = path[0];
-		if (p_state_machine->default_transition == nullptr) {
+		if (p_state_machine->default_transition.is_null()) {
 			next.xfade = 0;
 			next.switch_mode = AnimationNodeStateMachineTransition::SWITCH_MODE_IMMEDIATE;
 			next.is_reset = false;

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1843,7 +1843,7 @@ void AnimationNodeStateMachine::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "state_machine_type", PROPERTY_HINT_ENUM, "Root,Nested,Grouped"), "set_state_machine_type", "get_state_machine_type");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_transition_to_self"), "set_allow_transition_to_self", "is_allow_transition_to_self");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reset_ends"), "set_reset_ends", "are_ends_reset");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "default_transition", PROPERTY_HINT_RESOURCE_TYPE, ""), "set_default_transition", "get_default_transition");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "default_transition", PROPERTY_HINT_RESOURCE_TYPE, "AnimationNodeStateMachineTransition"), "set_default_transition", "get_default_transition");
 
 	BIND_ENUM_CONSTANT(STATE_MACHINE_TYPE_ROOT);
 	BIND_ENUM_CONSTANT(STATE_MACHINE_TYPE_NESTED);

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -760,7 +760,7 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(const St
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 
 	if (travel_request != StringName()) {
-				String travel_target = _validate_path(p_state_machine, travel_request);
+		String travel_target = _validate_path(p_state_machine, travel_request);
 		Vector<String> travel_path = travel_target.split("/");
 		travel_request = travel_path[0];
 		StringName temp_travel_request = travel_request; // For the case that can't travel.

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1312,11 +1312,9 @@ bool AnimationNodeStateMachine::are_ends_reset() const {
 }
 
 void AnimationNodeStateMachine::set_default_transition(Ref<AnimationNodeStateMachineTransition> p_transition) {
-	default_transition.instantiate();
-	default_transition->set_xfade_time(0);
-	default_transition->set_reset(true);
-	default_transition->set_advance_mode(AnimationNodeStateMachineTransition::ADVANCE_MODE_AUTO);
-	default_transition->set_switch_mode(AnimationNodeStateMachineTransition::SWITCH_MODE_IMMEDIATE);
+	if (p_transition != NULL) {
+		default_transition = p_transition->duplicate();
+	}
 }
 
 Ref<AnimationNodeStateMachineTransition> AnimationNodeStateMachine::get_default_transition() {
@@ -1871,4 +1869,7 @@ AnimationNodeStateMachine::AnimationNodeStateMachine() {
 	end.node = e;
 	end.position = Vector2(900, 100);
 	states[SceneStringName(End)] = end;
+
+	Ref<AnimationNodeStateMachineTransition> t;
+	set_teleport_transition(t);
 }

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -254,10 +254,16 @@ void AnimationNodeStateMachinePlayback::_set_grouped(bool p_is_grouped) {
 	is_grouped = p_is_grouped;
 }
 
-void AnimationNodeStateMachinePlayback::travel(const StringName &p_state, bool p_reset_on_teleport, bool p_force_jump) {
+void AnimationNodeStateMachinePlayback::travel(const StringName &p_state) {
 	ERR_FAIL_COND_EDMSG(is_grouped, "Grouped AnimationNodeStateMachinePlayback must be handled by parent AnimationNodeStateMachinePlayback. You need to retrieve the parent Root/Nested AnimationNodeStateMachine.");
 	ERR_FAIL_COND_EDMSG(String(p_state).contains("/Start") || String(p_state).contains("/End"), "Grouped AnimationNodeStateMachinePlayback doesn't allow to play Start/End directly. Instead, play the prev or next state of group in the parent AnimationNodeStateMachine.");
-	_travel_main(p_state, p_reset_on_teleport, p_force_jump);
+	_travel_main(p_state, false, false);
+}
+
+void AnimationNodeStateMachinePlayback::jump(const StringName &p_state) {
+	ERR_FAIL_COND_EDMSG(is_grouped, "Grouped AnimationNodeStateMachinePlayback must be handled by parent AnimationNodeStateMachinePlayback. You need to retrieve the parent Root/Nested AnimationNodeStateMachine.");
+	ERR_FAIL_COND_EDMSG(String(p_state).contains("/Start") || String(p_state).contains("/End"), "Grouped AnimationNodeStateMachinePlayback doesn't allow to play Start/End directly. Instead, play the prev or next state of group in the parent AnimationNodeStateMachine.");
+	_travel_main(p_state, false, true);
 }
 
 void AnimationNodeStateMachinePlayback::start(const StringName &p_state, bool p_reset) {

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -760,10 +760,15 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(const St
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 
 	if (travel_request != StringName()) {
-		String travel_target = _validate_path(p_state_machine, travel_request);
+				String travel_target = _validate_path(p_state_machine, travel_request);
 		Vector<String> travel_path = travel_target.split("/");
 		travel_request = travel_path[0];
 		StringName temp_travel_request = travel_request; // For the case that can't travel.
+
+		// Do not use transitions to move to and from special states:
+		if (String(current).contains("/Start") || String(current).contains("/End") || String(temp_travel_request).contains("/Start") || String(temp_travel_request).contains("/End")) {
+			teleport_request = true;
+		}
 
 		// If we are already not planning to use the pathfinder, we can skip the expensive A* attempt.
 		if (!teleport_request && !jump_request) {

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -271,7 +271,7 @@ void AnimationNodeStateMachinePlayback::queue_travel(const StringName &p_state) 
 	_travel_main(p_state, false, false, false);
 }
 
-void AnimationNodeStateMachinePlayback::queue_jump(const StringName &p_state) {
+void AnimationNodeStateMachinePlayback::queue(const StringName &p_state) {
 	ERR_FAIL_COND_EDMSG(is_grouped, "Grouped AnimationNodeStateMachinePlayback must be handled by parent AnimationNodeStateMachinePlayback. You need to retrieve the parent Root/Nested AnimationNodeStateMachine.");
 	ERR_FAIL_COND_EDMSG(String(p_state).contains("/Start") || String(p_state).contains("/End"), "Grouped AnimationNodeStateMachinePlayback doesn't allow to play Start/End directly. Instead, play the prev or next state of group in the parent AnimationNodeStateMachine.");
 	_travel_main(p_state, false, true, false);

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -260,11 +260,6 @@ void AnimationNodeStateMachinePlayback::travel(const StringName &p_state) {
 	_travel_main(p_state, false, false, true);
 }
 
-void AnimationNodeStateMachinePlayback::jump(const StringName &p_state) {
-	ERR_FAIL_COND_EDMSG(is_grouped, "Grouped AnimationNodeStateMachinePlayback must be handled by parent AnimationNodeStateMachinePlayback. You need to retrieve the parent Root/Nested AnimationNodeStateMachine.");
-	ERR_FAIL_COND_EDMSG(String(p_state).contains("/Start") || String(p_state).contains("/End"), "Grouped AnimationNodeStateMachinePlayback doesn't allow to play Start/End directly. Instead, play the prev or next state of group in the parent AnimationNodeStateMachine.");
-	_travel_main(p_state, false, true, true);
-}
 void AnimationNodeStateMachinePlayback::queue_travel(const StringName &p_state) {
 	ERR_FAIL_COND_EDMSG(is_grouped, "Grouped AnimationNodeStateMachinePlayback must be handled by parent AnimationNodeStateMachinePlayback. You need to retrieve the parent Root/Nested AnimationNodeStateMachine.");
 	ERR_FAIL_COND_EDMSG(String(p_state).contains("/Start") || String(p_state).contains("/End"), "Grouped AnimationNodeStateMachinePlayback doesn't allow to play Start/End directly. Instead, play the prev or next state of group in the parent AnimationNodeStateMachine.");

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -774,7 +774,7 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(const St
 			// Can't travel, then teleport.
 			if (p_state_machine->states.has(temp_travel_request)) {
 				path.clear();
-				if (current != temp_travel_request) {
+				if (p_state_machine->is_allow_transition_to_self() || current != temp_travel_request) {
 					path.push_back(temp_travel_request);
 				}
 			} else {
@@ -786,21 +786,8 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(const St
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 
 	if (teleport_request) {
+		_transition_to_next_recursive(tree, p_state_machine, p_delta, p_test_only);
 		teleport_request = false;
-		// // Clear fadeing on teleport.
-		// fading_from = StringName();
-		// fadeing_from_nti = AnimationNode::NodeTimeInfo();
-		// fading_pos = 0;
-		// // Init current length.
-		// pi.time = 0;
-		// pi.seeked = true;
-		// pi.is_external_seeking = false;
-		// pi.weight = 0;
-		// current_nti = p_state_machine->blend_node(p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, true);
-		// // Don't process first node if not necessary, instead process next node.
-		// _transition_to_next_recursive(tree, p_state_machine, p_delta, p_test_only);
-
-		// path.push_back(travel_request);
 	}
 
 	// Check current node existence.

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -136,6 +136,7 @@ private:
 		Ref<AnimationNodeStateMachineTransition> transition;
 	};
 
+	Ref<AnimationNodeStateMachineTransition> default_transition;
 	Vector<Transition> transitions;
 
 	StringName playback = "playback";
@@ -206,6 +207,9 @@ public:
 	void set_reset_ends(bool p_enable);
 	bool are_ends_reset() const;
 
+	void set_default_transition(Ref<AnimationNodeStateMachineTransition> p_transition);
+	Ref<AnimationNodeStateMachineTransition> get_default_transition();
+
 	bool can_edit_node(const StringName &p_name) const;
 
 	void set_graph_offset(const Vector2 &p_offset);
@@ -259,7 +263,6 @@ class AnimationNodeStateMachinePlayback : public Resource {
 		bool is_reset = false;
 	};
 
-	Ref<AnimationNodeStateMachineTransition> default_transition;
 	String base_path;
 
 	AnimationNode::NodeTimeInfo current_nti;

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -333,7 +333,7 @@ public:
 	void travel(const StringName &p_state);
 	void jump(const StringName &p_state);
 	void queue_travel(const StringName &p_state);
-	void queue_jump(const StringName &p_state);
+	void queue(const StringName &p_state);
 	void start(const StringName &p_state, bool p_reset = true);
 	void next();
 	void stop();

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -329,7 +329,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void travel(const StringName &p_state, bool p_reset_on_teleport = true, bool p_force_jump = false);
+	void travel(const StringName &p_state);
+	void jump(const StringName &p_state);
 	void start(const StringName &p_state, bool p_reset = true);
 	void next();
 	void stop();

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -289,10 +289,11 @@ class AnimationNodeStateMachinePlayback : public Resource {
 	bool stop_request = false;
 	bool teleport_request = false;
 	bool jump_request = false;
+	bool retain_path_request = false;
 
 	bool is_grouped = false;
 
-	void _travel_main(const StringName &p_state, bool p_reset_on_teleport = true, bool p_force_jump = false);
+	void _travel_main(const StringName &p_state, bool p_reset_on_teleport = true, bool p_force_jump = false, bool p_retain_path = false);
 	void _start_main(const StringName &p_state, bool p_reset = true);
 	void _next_main();
 	void _stop_main();
@@ -331,6 +332,8 @@ protected:
 public:
 	void travel(const StringName &p_state);
 	void jump(const StringName &p_state);
+	void queue_travel(const StringName &p_state);
+	void queue_jump(const StringName &p_state);
 	void start(const StringName &p_state, bool p_reset = true);
 	void next();
 	void stop();

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -331,7 +331,6 @@ protected:
 
 public:
 	void travel(const StringName &p_state);
-	void jump(const StringName &p_state);
 	void queue_travel(const StringName &p_state);
 	void queue(const StringName &p_state);
 	void start(const StringName &p_state, bool p_reset = true);

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -287,6 +287,7 @@ class AnimationNodeStateMachinePlayback : public Resource {
 	bool _reset_request_for_fading_from = false;
 	bool next_request = false;
 	bool stop_request = false;
+	bool request_jump_instead = false;
 	bool teleport_request = false;
 	bool jump_request = false;
 	bool retain_path_request = false;
@@ -330,7 +331,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void travel(const StringName &p_state);
+	void travel(const StringName &p_state, bool p_reset_on_teleport = true);
 	void queue_travel(const StringName &p_state);
 	void queue(const StringName &p_state);
 	void start(const StringName &p_state, bool p_reset = true);

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -288,10 +288,11 @@ class AnimationNodeStateMachinePlayback : public Resource {
 	bool next_request = false;
 	bool stop_request = false;
 	bool teleport_request = false;
+	bool jump_request = false;
 
 	bool is_grouped = false;
 
-	void _travel_main(const StringName &p_state, bool p_reset_on_teleport = true);
+	void _travel_main(const StringName &p_state, bool p_reset_on_teleport = true, bool p_force_jump = false);
 	void _start_main(const StringName &p_state, bool p_reset = true);
 	void _next_main();
 	void _stop_main();
@@ -328,7 +329,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void travel(const StringName &p_state, bool p_reset_on_teleport = true);
+	void travel(const StringName &p_state, bool p_reset_on_teleport = true, bool p_force_jump = false);
 	void start(const StringName &p_state, bool p_reset = true);
 	void next();
 	void stop();


### PR DESCRIPTION
Arbitrary/code-driven animation transitions powered by a state machine are not currently compatible with the complex blending behavior provided by AnimationTree (AnimationPlayer does not accept BlendSpace2d, for example).
AnimationTreeStateMachine is compatible with all the AnimationNode classes to support complex blending, but are not compatible with arbitrary state machines (the only thing missing is smoothing between AnimationNodes).

The latter approach was chosen for being much simpler to implement. It does require the user to add all animations to an AnimationNodeStateMachine, but the user is no longer required to specify n^2 transitions to get reasonable blending between any two states.

Commit bd32776 adds additional functionality to the "default_transition" field that was present but unused in AnimationNodeStateMachinePlayback. It is now located in AnimationNodeStateMachine and used whenever the StateMachine wishes to teleport.
The default value of the AnimationNodeStateMachineTransition as provided by the GUI is identical to the previous teleporting behavior.

Commit cc87b83 is intended as a predecessor to a loop_blend_time field that will allow imperfect animations to loop a little smoother; although being able to restart animations without completely pausing the animator is useful for my projects as well.

_Bugsquad edited:_
- Closes https://github.com/godotengine/godot-proposals/issues/11769