### PR TITLE
Add Toki Pona (tok) to language/locale list.

### DIFF
--- a/core/string/locales.h
+++ b/core/string/locales.h
@@ -916,6 +916,7 @@ static const char *language_list[][2] = {
 	{ "tmh", "Tamashek" },
 	{ "tn", "Tswana" },
 	{ "to", "Tongan" },
+	{ "tok", "Toki Pona" },
 	{ "tog", "Nyasa Tonga" },
 	{ "tpi", "Tok Pisin" },
 	{ "tr", "Turkish" },


### PR DESCRIPTION
Add Toki Pona (tok) to the language list/locale list, as [it is a officially recognized language](https://iso639-3.sil.org/code/tok).

