### PR TITLE
Sprite2D: Use correct name to hide `region_filter_clip_enabled`

### DIFF
--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -423,7 +423,7 @@ void Sprite2D::_validate_property(PropertyInfo &p_property) const {
 		p_property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
 	}
 
-	if (!region_enabled && (p_property.name == "region_rect" || p_property.name == "region_filter_clip")) {
+	if (!region_enabled && (p_property.name == "region_rect" || p_property.name == "region_filter_clip_enabled")) {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }


### PR DESCRIPTION
The `Sprite2D::_validate_property` function used the incorrect name for the `region_filter_clip_enabled` property, so it was incorrectly visible when `region_enabled` was false.