### PR TITLE
Fix `GraphEdit::frame_rect_changed` signal parameter type

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -469,7 +469,7 @@
 		</signal>
 		<signal name="frame_rect_changed">
 			<param index="0" name="frame" type="GraphFrame" />
-			<param index="1" name="new_rect" type="Vector2" />
+			<param index="1" name="new_rect" type="Rect2" />
 			<description>
 				Emitted when the [GraphFrame] [param frame] is resized to [param new_rect].
 			</description>

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -319,3 +319,10 @@ GH-100913
 Validate extension JSON: Error: Field 'classes/TextEdit/methods/get_line_column_at_pos/arguments': size changed value in new API, from 2 to 3.
 
 Added optional argument to disallow positions that are outside the column range of the line. Compatibility method registered.
+
+
+GH-102796
+---------
+Validate extension JSON: Error: Field 'classes/GraphEdit/signals/frame_rect_changed/arguments/1': type changed value in new API, from "Vector2" to "Rect2".
+
+Previous type was incorrect. No compatibility system for signal arguments.

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2834,7 +2834,7 @@ void GraphEdit::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("node_selected", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("node_deselected", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
-	ADD_SIGNAL(MethodInfo("frame_rect_changed", PropertyInfo(Variant::OBJECT, "frame", PROPERTY_HINT_RESOURCE_TYPE, "GraphFrame"), PropertyInfo(Variant::VECTOR2, "new_rect")));
+	ADD_SIGNAL(MethodInfo("frame_rect_changed", PropertyInfo(Variant::OBJECT, "frame", PROPERTY_HINT_RESOURCE_TYPE, "GraphFrame"), PropertyInfo(Variant::RECT2, "new_rect")));
 
 	ADD_SIGNAL(MethodInfo("popup_request", PropertyInfo(Variant::VECTOR2, "at_position")));
 


### PR DESCRIPTION
Changes the binding's parameter type from `Vector2` to `Rect2`, which is what is actually emitted.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
