### PR TITLE
Fix delete Tile Source with delete key

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -42,6 +42,10 @@ void TileAtlasView::gui_input(const Ref<InputEvent> &p_event) {
 	if (panner->gui_input(p_event, get_global_rect())) {
 		accept_event();
 	}
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
+		center_container->grab_focus();
+	}
 }
 
 void TileAtlasView::_pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event) {

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -451,6 +451,16 @@ void TileSetEditor::_update_patterns_list() {
 	patterns_help_label->set_visible(patterns_item_list->get_item_count() == 0);
 }
 
+void TileSetEditor::_sources_list_gui_input(const Ref<InputEvent> &p_event) {
+	if (sources_list->get_item_count() < 1) {
+		return;
+	}
+	if (ED_IS_SHORTCUT("tiles_editor/delete", p_event) && p_event->is_pressed() && !p_event->is_echo()) {
+		_source_delete_pressed();
+		sources_list->accept_event();
+	}
+}
+
 void TileSetEditor::_tile_set_changed() {
 	tile_set_changed_needs_update = true;
 }
@@ -866,6 +876,7 @@ TileSetEditor::TileSetEditor() {
 	sources_list->connect(SceneStringName(visibility_changed), callable_mp(TilesEditorUtils::get_singleton(), &TilesEditorUtils::synchronize_sources_list).bind(sources_list, source_sort_button));
 	sources_list->add_user_signal(MethodInfo("sort_request"));
 	sources_list->connect("sort_request", callable_mp(this, &TileSetEditor::_update_sources_list).bind(-1));
+	sources_list->connect(SceneStringName(gui_input), callable_mp(this, &TileSetEditor::_sources_list_gui_input));
 	sources_list->set_texture_filter(CanvasItem::TEXTURE_FILTER_NEAREST);
 	SET_DRAG_FORWARDING_CDU(sources_list, TileSetEditor);
 	split_container_left_side->add_child(sources_list);

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -84,6 +84,7 @@ private:
 	void _source_add_id_pressed(int p_id_pressed);
 	void _sources_advanced_menu_id_pressed(int p_id_pressed);
 	void _set_source_sort(int p_sort);
+	void _sources_list_gui_input(const Ref<InputEvent> &p_event);
 
 	EditorFileDialog *texture_file_dialog = nullptr;
 	AtlasMergingDialog *atlas_merging_dialog = nullptr;

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -237,6 +237,16 @@ void TileSetScenesCollectionSourceEditor::_scenes_list_item_activated(int p_inde
 	}
 }
 
+void TileSetScenesCollectionSourceEditor::_scene_tiles_list_gui_input(const Ref<InputEvent> &p_event) {
+	if (scene_tiles_list->get_item_count() < 1) {
+		return;
+	}
+	if (ED_IS_SHORTCUT("tiles_editor/delete", p_event) && p_event->is_pressed() && !p_event->is_echo()) {
+		_source_delete_pressed();
+		scene_tiles_list->accept_event();
+	}
+}
+
 void TileSetScenesCollectionSourceEditor::_source_add_pressed() {
 	if (!scene_select_dialog) {
 		scene_select_dialog = memnew(EditorFileDialog);
@@ -564,6 +574,7 @@ TileSetScenesCollectionSourceEditor::TileSetScenesCollectionSourceEditor() {
 	scene_tiles_list->connect(SceneStringName(item_selected), callable_mp(this, &TileSetScenesCollectionSourceEditor::_update_tile_inspector).unbind(1));
 	scene_tiles_list->connect(SceneStringName(item_selected), callable_mp(this, &TileSetScenesCollectionSourceEditor::_update_action_buttons).unbind(1));
 	scene_tiles_list->connect("item_activated", callable_mp(this, &TileSetScenesCollectionSourceEditor::_scenes_list_item_activated));
+	scene_tiles_list->connect(SceneStringName(gui_input), callable_mp(this, &TileSetScenesCollectionSourceEditor::_scene_tiles_list_gui_input));
 	scene_tiles_list->set_texture_filter(CanvasItem::TEXTURE_FILTER_NEAREST);
 	right_vbox_container->add_child(scene_tiles_list);
 

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
@@ -121,6 +121,7 @@ private:
 	void _scenes_collection_source_proxy_object_changed(const String &p_what);
 	void _scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_ud);
 	void _scenes_list_item_activated(int p_index);
+	void _scene_tiles_list_gui_input(const Ref<InputEvent> &p_event);
 
 	void _source_add_pressed();
 	void _scene_file_selected(const String &p_path);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/83638

Feels like a lot of code for a small feature. 

You can now delete a selected Tile Source by pressing delete key when the Tile Sources ItemList has focus.

[Screencast_20250210_163741.webm](https://github.com/user-attachments/assets/350f39f0-dd8b-4b9c-b819-18684b49dac2)


### This however introduced a new problem. 
When you selected a tile in the tile view (to the right of the ItemList) you could use delete to remove that tile. As the action about selecting tiles did not change focus. The result now was that you deleted the source instead of the selected tile.

To fix this I made the tile view grab focus on left mouse button press (Another method could be to change focus on mouse motion instead of press?). Hopefully this does not affect any other workflow. 

This also made the delete selected tile with delete key more reliable to work, and not try to delete the TileMapLayer if TileSet editor had lost focus and you selected a new tile.

**Delete selected tile**
Before:

[Screencast_20250210_162257.webm](https://github.com/user-attachments/assets/9c82534e-a1bb-4ea0-816a-93bbbde7a5f7)

After:

[Screencast_20250210_162335.webm](https://github.com/user-attachments/assets/0c804b55-0f84-46ef-a05a-8ea2e1709ef2)


Another small benefit of the change in focus is that the E (erase) shortcut in Setup mode now works after you have selected a tile. This did not work if there was no other control that had focus in the tile editor. 

### Scenes Collection list
Add support for delete key. As it felt strange that it wouldn't work there too. 