### PR TITLE
Fix modified time when LSP reload script

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2843,10 +2843,13 @@ void ScriptEditor::_reload_scripts(bool p_refresh_only) {
 		Ref<Resource> edited_res = se->get_edited_resource();
 
 		if (edited_res->is_built_in()) {
-			continue; //internal script, who cares
+			continue; // Internal script, who cares.
 		}
 
-		if (!p_refresh_only) {
+		if (p_refresh_only) {
+			// Make sure the modified time is correct.
+			se->edited_file_data.last_modified_time = FileAccess::get_modified_time(edited_res->get_path());
+		} else {
 			uint64_t last_date = se->edited_file_data.last_modified_time;
 			uint64_t date = FileAccess::get_modified_time(edited_res->get_path());
 


### PR DESCRIPTION
*Probably* fixes #102752

When LSP is connected and script changes externally, the editor would reload it with `p_refresh_only` being `true`. It seems to force-reload script without asking at all. Questionable 🤷‍♂️but requires updating modified time.

I'm not sure if that's the problem reported in #102752 and if other mentioned problems are the same thing.