### PR TITLE
Don't mark cached previously pinned AnimationMixers

### DIFF
--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -90,6 +90,7 @@ class SceneTreeEditor : public Control {
 
 		HashMap<Node *, CachedNode>::Iterator add(Node *p_node, TreeItem *p_item);
 		HashMap<Node *, CachedNode>::Iterator get(Node *p_node, bool p_deleted_ok = true);
+		bool has(Node *p_node);
 		void remove(Node *p_node, bool p_recursive = false);
 		void mark_dirty(Node *p_node, bool p_parents = true);
 		void mark_children_dirty(Node *p_node, bool p_recursive = false);


### PR DESCRIPTION
AnimationPlayerEditor will hold on to pointers to no-longer existing Nodes that were previously pinned. Make sure to not mark them as dirty if they are not already inside the cache.

This fixes #102108
