### PR TITLE
Add toggle to Game view for resetting input mode on stop

### DIFF
--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -328,6 +328,10 @@ void GameView::_stop_pressed() {
 	}
 
 	screen_index_before_start = -1;
+
+	if (reset_input_on_stop) {
+		_node_type_pressed(RuntimeNodeSelect::NODE_TYPE_NONE);
+	}
 }
 
 void GameView::_embedding_completed() {
@@ -425,6 +429,10 @@ void GameView::_embed_options_menu_menu_id_pressed(int p_id) {
 				EditorSettings::get_singleton()->set_project_metadata("game_view", "make_floating_on_play", make_floating_on_play);
 			}
 		} break;
+		case EMBED_RESET_INPUT_MODE_ON_STOP: {
+			reset_input_on_stop = !reset_input_on_stop;
+			EditorSettings::get_singleton()->set_project_metadata("game_view", "reset_input_on_stop", reset_input_on_stop);
+		} break;
 	}
 	_update_embed_menu_options();
 	_update_ui();
@@ -520,6 +528,7 @@ void GameView::_update_embed_menu_options() {
 	PopupMenu *menu = embed_options_menu->get_popup();
 	menu->set_item_checked(menu->get_item_index(EMBED_RUN_GAME_EMBEDDED), embed_on_play);
 	menu->set_item_checked(menu->get_item_index(EMBED_MAKE_FLOATING_ON_PLAY), make_floating_on_play && is_multi_window);
+	menu->set_item_checked(menu->get_item_index(EMBED_RESET_INPUT_MODE_ON_STOP), reset_input_on_stop);
 
 	menu->set_item_disabled(menu->get_item_index(EMBED_MAKE_FLOATING_ON_PLAY), !embed_on_play || !is_multi_window);
 
@@ -642,6 +651,7 @@ void GameView::_notification(int p_what) {
 				}
 				embed_size_mode = (EmbedSizeMode)(int)EditorSettings::get_singleton()->get_project_metadata("game_view", "embed_size_mode", SIZE_MODE_FIXED);
 				keep_aspect_button->set_pressed(EditorSettings::get_singleton()->get_project_metadata("game_view", "keep_aspect", true));
+				reset_input_on_stop = EditorSettings::get_singleton()->get_project_metadata("game_view", "reset_input_on_stop", false);
 				_update_embed_menu_options();
 
 				EditorRunBar::get_singleton()->connect("play_pressed", callable_mp(this, &GameView::_play_pressed));
@@ -996,6 +1006,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, WindowWrapper *p_wrapper) {
 	menu->connect(SceneStringName(id_pressed), callable_mp(this, &GameView::_embed_options_menu_menu_id_pressed));
 	menu->add_check_item(TTR("Embed Game on Next Play"), EMBED_RUN_GAME_EMBEDDED);
 	menu->add_check_item(TTR("Make Game Workspace Floating on Next Play"), EMBED_MAKE_FLOATING_ON_PLAY);
+	menu->add_check_item(TTR("Reset Input Mode on Stop"), EMBED_RESET_INPUT_MODE_ON_STOP);
 
 	main_menu_hbox->add_spacer();
 

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -93,6 +93,7 @@ class GameView : public VBoxContainer {
 		CAMERA_MODE_EDITORS,
 		EMBED_RUN_GAME_EMBEDDED,
 		EMBED_MAKE_FLOATING_ON_PLAY,
+		EMBED_RESET_INPUT_MODE_ON_STOP,
 	};
 
 	enum EmbedSizeMode {
@@ -122,6 +123,7 @@ class GameView : public VBoxContainer {
 
 	bool embed_on_play = true;
 	bool make_floating_on_play = true;
+	bool reset_input_on_stop = false;
 	EmbedSizeMode embed_size_mode = SIZE_MODE_FIXED;
 	bool paused = false;
 	Size2 size_paused;


### PR DESCRIPTION
This is a tentative change based on [a discussion](https://chat.godotengine.org/channel/editor?msg=N99zqt5p8o34BABqB) on the contributor's chat about the current behavior of the "Game" view's input mode.

Some users have reported finding the current behavior, where the selected input mode (Input/2D/3D) persists across debugging sessions, to be frustrating, as you can sometimes miss that you've left the input mode in 2D/3D when launching a new debugging session and not understand why the game doesn't respond to input.

There are several potential ways to address this, but this PR takes the approach of adding another toggle to the "triple dot" menu called "Reset Input Mode on Stop", which (like the name suggests) resets the input mode back to game input as soon as a debugging session is stopped.

This new toggle defaults to being disabled, meaning the input mode will (just like now) persist across debugging sessions by default. Its value is however persisted in the project metadata, so won't need to be enabled every editor session.

The naming and placement of all of this is of course up for discussion.

Note that the way this is implemented does not seem to apply to the "Remote Deploy" feature, like when launching the a "Runnable" export on mobile devices. I'm not sure if there's any good delineation for "stopping" a debugging session in the same way, which might perhaps mean that this needs a different approach.