### PR TITLE
Clarify that `Vector2.angle_to` returns a signed angle

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -67,7 +67,7 @@
 			<return type="float" />
 			<param index="0" name="to" type="Vector2" />
 			<description>
-				Returns the angle to the given vector, in radians.
+				Returns the signed angle to the given vector, in radians.
 				[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/vector2_angle_to.png]Illustration of the returned angle.[/url]
 			</description>
 		</method>


### PR DESCRIPTION
Added a minor detail to the description of "angle_to" so that it specifies that the returned angle is signed. Hopefully helps others not to waste several hours not realizing this.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
