### PR TITLE
Refactor TextEdit line and color into struct

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -134,6 +134,11 @@ private:
 		Callable custom_draw_callback;
 	};
 
+	struct RegionStyle {
+		int64_t column;
+		Color color;
+	};
+
 	class Text {
 	public:
 		struct Gutter {
@@ -572,9 +577,9 @@ private:
 
 	/* Syntax highlighting. */
 	Ref<SyntaxHighlighter> syntax_highlighter;
-	HashMap<int, Vector<Pair<int64_t, Color>>> syntax_highlighting_cache;
+	HashMap<int, Vector<RegionStyle>> syntax_highlighting_cache;
 
-	Vector<Pair<int64_t, Color>> _get_line_syntax_highlighting(int p_line);
+	Vector<RegionStyle> _get_line_syntax_highlighting(int p_line);
 	void _clear_syntax_highlighting_cache();
 
 	/* Visual. */


### PR DESCRIPTION
I want to add more features to the TextEdit control outside of color.
This refactor is a simple restructuring of how data is stored for line syntax highlighting.
Now instead of a Pair there is a concrete type RegionStyle with explicit members column and color.

The plan is to extend this to include font so users can apply **bold** and *italics* in their editors.