### PR TITLE
Unfold tree items on hover while drag-n-dropping

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -824,6 +824,9 @@
 		<member name="interface/editor/dock_tab_style" type="int" setter="" getter="">
 			Tab style of editor docks.
 		</member>
+		<member name="interface/editor/dragging_unfold_wait_seconds" type="float" setter="" getter="">
+			During a drag-and-drop, this is how long to wait over a section before the section unfolds to show nested items.
+		</member>
 		<member name="interface/editor/editor_language" type="String" setter="" getter="">
 			The language to use for the editor interface.
 			Translations are provided by the community. If you spot a mistake, [url=$DOCS_URL/contributing/documentation/editor_and_docs_localization.html]contribute to editor translations on Weblate![/url]

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -355,6 +355,9 @@
 			The drop mode as an OR combination of flags. See [enum DropModeFlags] constants. Once dropping is done, reverts to [constant DROP_MODE_DISABLED]. Setting this during [method Control._can_drop_data] is recommended.
 			This controls the drop sections, i.e. the decision and drawing of possible drop locations based on the mouse position.
 		</member>
+		<member name="enable_drag_unfolding" type="bool" setter="set_enable_drag_unfolding" getter="is_drag_unfolding_enabled" default="true">
+			If [code]true[/code], tree items will unfold when hovered over during a drag-and-drop.
+		</member>
 		<member name="enable_recursive_folding" type="bool" setter="set_enable_recursive_folding" getter="is_recursive_folding_enabled" default="true">
 			If [code]true[/code], recursive folding is enabled for this [Tree]. Holding down [kbd]Shift[/kbd] while clicking the fold arrow or using [code]ui_right[/code]/[code]ui_left[/code] shortcuts collapses or uncollapses the [TreeItem] and all its descendants.
 		</member>
@@ -541,6 +544,9 @@
 		</theme_item>
 		<theme_item name="children_hl_line_width" data_type="constant" type="int" default="1">
 			The width of the relationship lines between the selected [TreeItem] and its children.
+		</theme_item>
+		<theme_item name="dragging_unfold_wait_msec" data_type="constant" type="int" default="500">
+			During a drag-and-drop, this is how many milliseconds to wait over a section before the section unfolds.
 		</theme_item>
 		<theme_item name="draw_guides" data_type="constant" type="int" default="1">
 			Draws the guidelines if not zero, this acts as a boolean. The guideline is a horizontal line drawn at the bottom of each item.

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1790,7 +1790,7 @@ void EditorInspectorSection::_notification(int p_what) {
 
 		case NOTIFICATION_MOUSE_ENTER: {
 			if (dropping_for_unfold) {
-				dropping_unfold_timer->start();
+				dropping_unfold_timer->start(EDITOR_GET("interface/editor/dragging_unfold_wait_seconds"));
 			}
 			queue_redraw();
 		} break;
@@ -1953,7 +1953,7 @@ EditorInspectorSection::EditorInspectorSection() {
 	vbox = memnew(VBoxContainer);
 
 	dropping_unfold_timer = memnew(Timer);
-	dropping_unfold_timer->set_wait_time(0.6);
+	dropping_unfold_timer->set_wait_time(EDITOR_GET("interface/editor/dragging_unfold_wait_seconds"));
 	dropping_unfold_timer->set_one_shot(true);
 	add_child(dropping_unfold_timer);
 	dropping_unfold_timer->connect("timeout", callable_mp(this, &EditorInspectorSection::unfold));

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1790,7 +1790,7 @@ void EditorInspectorSection::_notification(int p_what) {
 
 		case NOTIFICATION_MOUSE_ENTER: {
 			if (dropping_for_unfold) {
-				dropping_unfold_timer->start(EDITOR_GET("interface/editor/dragging_unfold_wait_seconds"));
+				dropping_unfold_timer->start();
 			}
 			queue_redraw();
 		} break;
@@ -1801,6 +1801,12 @@ void EditorInspectorSection::_notification(int p_what) {
 			}
 			queue_redraw();
 		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor")) {
+				dropping_unfold_timer->set_wait_time(EDITOR_GET("interface/editor/dragging_unfold_wait_seconds"));
+			}
+		}
 	}
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -821,6 +821,8 @@ void EditorNode::_notification(int p_what) {
 				recent_scenes->reset_size();
 			}
 
+			theme->set_constant("dragging_unfold_wait_msec", "Tree", (float)EDITOR_GET("interface/editor/dragging_unfold_wait_seconds") * 1000);
+
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/dock_tab_style")) {
 				editor_dock_manager->update_tab_styles();
 			}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -821,7 +821,9 @@ void EditorNode::_notification(int p_what) {
 				recent_scenes->reset_size();
 			}
 
+		if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor")) {
 			theme->set_constant("dragging_unfold_wait_msec", "Tree", (float)EDITOR_GET("interface/editor/dragging_unfold_wait_seconds") * 1000);
+		}
 
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/dock_tab_style")) {
 				editor_dock_manager->update_tab_styles();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -821,9 +821,9 @@ void EditorNode::_notification(int p_what) {
 				recent_scenes->reset_size();
 			}
 
-		if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor")) {
-			theme->set_constant("dragging_unfold_wait_msec", "Tree", (float)EDITOR_GET("interface/editor/dragging_unfold_wait_seconds") * 1000);
-		}
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor")) {
+				theme->set_constant("dragging_unfold_wait_msec", "Tree", (float)EDITOR_GET("interface/editor/dragging_unfold_wait_seconds") * 1000);
+			}
 
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/dock_tab_style")) {
 				editor_dock_manager->update_tab_styles();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -475,6 +475,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "interface/editor/main_font", "", "*.ttf,*.otf,*.woff,*.woff2,*.pfb,*.pfm")
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "interface/editor/main_font_bold", "", "*.ttf,*.otf,*.woff,*.woff2,*.pfb,*.pfm")
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "interface/editor/code_font", "", "*.ttf,*.otf,*.woff,*.woff2,*.pfb,*.pfm")
+
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/editor/dragging_unfold_wait_seconds", 0.5, "0.01,10,0.01,or_greater,suffix:s");
+
 	_initial_set("interface/editor/separate_distraction_mode", false, true);
 	_initial_set("interface/editor/automatically_open_screenshots", true, true);
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/single_window_mode", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING)

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -972,6 +972,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 			p_theme->set_constant("inner_item_margin_left", "Tree", p_config.increased_margin * EDSCALE);
 			p_theme->set_constant("inner_item_margin_right", "Tree", p_config.increased_margin * EDSCALE);
 			p_theme->set_constant("button_margin", "Tree", p_config.base_margin * EDSCALE);
+			p_theme->set_constant("dragging_unfold_wait_msec", "Tree", (float)EDITOR_GET("interface/editor/dragging_unfold_wait_seconds") * 1000);
 			p_theme->set_constant("scroll_border", "Tree", 40 * EDSCALE);
 			p_theme->set_constant("scroll_speed", "Tree", 12);
 			p_theme->set_constant("outline_size", "Tree", 0);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -133,8 +133,7 @@ void TreeItem::_change_tree(Tree *p_tree) {
 		}
 
 		if (tree->drop_mode_over == this) {
-			tree->drop_mode_over = nullptr;
-			tree->dropping_unfold_timer->stop();
+			tree->_reset_drop_mode_over();
 		}
 
 		if (tree->single_select_defer == this) {
@@ -4067,6 +4066,13 @@ void Tree::_on_dropping_unfold_timer_timeout() {
 	}
 }
 
+void Tree::_reset_drop_mode_over() {
+	drop_mode_over = nullptr;
+	if (!dropping_unfold_timer->is_stopped()) {
+		dropping_unfold_timer->stop();
+	}
+}
+
 bool Tree::edit_selected(bool p_force_edit) {
 	TreeItem *s = get_selected();
 	ERR_FAIL_NULL_V_MSG(s, false, "No item selected.");
@@ -5751,8 +5757,7 @@ void Tree::set_drop_mode_flags(int p_flags) {
 	}
 	drop_mode_flags = p_flags;
 	if (drop_mode_flags == 0) {
-		drop_mode_over = nullptr;
-		dropping_unfold_timer->stop();
+		_reset_drop_mode_over();
 	}
 
 	queue_redraw();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5744,7 +5744,9 @@ bool Tree::is_recursive_folding_enabled() const {
 
 void Tree::set_enable_drag_unfolding(bool p_enable) {
 	enable_drag_unfolding = p_enable;
-	dropping_unfold_timer->stop();
+	if (!dropping_unfold_timer->is_stopped()) {
+		dropping_unfold_timer->stop();
+	}
 }
 
 bool Tree::is_drag_unfolding_enabled() const {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4012,9 +4012,10 @@ void Tree::_determine_hovered_item() {
 		if (drop_mode_flags) {
 			if (it != drop_mode_over) {
 				drop_mode_over = it;
-				dropping_unfold_timer->stop();
 				if (enable_drag_unfolding) {
 					dropping_unfold_timer->start(theme_cache.dragging_unfold_wait_msec * 0.001);
+				} else if (!dropping_unfold_timer->is_stopped()) {
+					dropping_unfold_timer->stop();
 				}
 				queue_redraw();
 			}

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4061,7 +4061,7 @@ void Tree::_determine_hovered_item() {
 }
 
 void Tree::_on_dropping_unfold_timer_timeout() {
-	if (drop_mode_over && drop_mode_section == 0) {
+	if (enable_drag_unfolding && drop_mode_over && drop_mode_section == 0) {
 		drop_mode_over->set_collapsed(false);
 	}
 }
@@ -5737,6 +5737,7 @@ bool Tree::is_recursive_folding_enabled() const {
 
 void Tree::set_enable_drag_unfolding(bool p_enable) {
 	enable_drag_unfolding = p_enable;
+	dropping_unfold_timer->stop();
 }
 
 bool Tree::is_drag_unfolding_enabled() const {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -6054,7 +6054,7 @@ Tree::Tree() {
 	add_child(range_click_timer, false, INTERNAL_MODE_FRONT);
 
 	dropping_unfold_timer = memnew(Timer);
-	dropping_unfold_timer->set_wait_time(theme_cache.dragging_unfold_wait_msec * 0.001);
+	dropping_unfold_timer->set_one_shot(true);
 	dropping_unfold_timer->connect("timeout", callable_mp(this, &Tree::_on_dropping_unfold_timer_timeout));
 	add_child(dropping_unfold_timer);
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -714,6 +714,7 @@ private:
 	bool enable_drag_unfolding = true;
 	Timer *dropping_unfold_timer = nullptr;
 	void _on_dropping_unfold_timer_timeout();
+	void _reset_drop_mode_over();
 
 	bool enable_auto_tooltip = true;
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -612,6 +612,8 @@ private:
 		int parent_hl_line_margin = 0;
 		int draw_guides = 0;
 
+		int dragging_unfold_wait_msec = 500;
+
 		int scroll_border = 0;
 		int scroll_speed = 0;
 
@@ -708,6 +710,10 @@ private:
 	bool hide_folding = false;
 
 	bool enable_recursive_folding = true;
+
+	bool enable_drag_unfolding = true;
+	Timer *dropping_unfold_timer = nullptr;
+	void _on_dropping_unfold_timer_timeout();
 
 	bool enable_auto_tooltip = true;
 
@@ -827,6 +833,9 @@ public:
 
 	void set_enable_recursive_folding(bool p_enable);
 	bool is_recursive_folding_enabled() const;
+
+	void set_enable_drag_unfolding(bool p_enable);
+	bool is_drag_unfolding_enabled() const;
 
 	void set_drop_mode_flags(int p_flags);
 	int get_drop_mode_flags() const;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -904,6 +904,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("children_hl_line_width", "Tree", 1);
 	theme->set_constant("parent_hl_line_margin", "Tree", 0);
 	theme->set_constant("draw_guides", "Tree", 1);
+	theme->set_constant("dragging_unfold_wait_msec", "Tree", 500);
 	theme->set_constant("scroll_border", "Tree", Math::round(4 * scale));
 	theme->set_constant("scroll_speed", "Tree", 12);
 	theme->set_constant("outline_size", "Tree", 0);


### PR DESCRIPTION
my first contribution, hopefully ❤️ 

Closes https://github.com/godotengine/godot-proposals/issues/7589

The original proposal was to add unfold-on-drag to the file browser, but while looking into the code, I realized I could add unfold-on-drag to all tree controls. So I did that (and added a parameter on the Tree class to disable it)

https://github.com/user-attachments/assets/16910d5d-6b6f-45c0-b7a5-35dc1e9569e3

