### PR TITLE
OpenGL not checking for  WEBGL_compressed_texture_astc.

### DIFF
--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -78,7 +78,7 @@ Config::Config() {
 #endif
 
 	bptc_supported = extensions.has("GL_ARB_texture_compression_bptc") || extensions.has("EXT_texture_compression_bptc");
-	astc_supported = extensions.has("GL_KHR_texture_compression_astc") || extensions.has("GL_OES_texture_compression_astc") || extensions.has("GL_KHR_texture_compression_astc_ldr") || extensions.has("GL_KHR_texture_compression_astc_hdr");
+	astc_supported = extensions.has("WEBGL_compressed_texture_astc") || extensions.has("GL_KHR_texture_compression_astc") || extensions.has("GL_OES_texture_compression_astc") || extensions.has("GL_KHR_texture_compression_astc_ldr") || extensions.has("GL_KHR_texture_compression_astc_hdr");
 	astc_hdr_supported = extensions.has("GL_KHR_texture_compression_astc_hdr");
 	astc_layered_supported = extensions.has("GL_KHR_texture_compression_astc_sliced_3d");
 


### PR DESCRIPTION
WebGL supports astc, however the gles3 config, wasnt checking for the correct properties for WebGL.

Before:
![image](https://github.com/user-attachments/assets/27748fcf-de89-49a7-a180-1d53ff4018be)


After:
![image](https://github.com/user-attachments/assets/6363cdd6-7fe5-45df-ad26-d3d5e2d7ca3c)