### PR TITLE
[.NET] Skip serializing delegates with a disposed target

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -690,8 +690,14 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 
 			if (success) {
 				ManagedCallable::instances_pending_reload.insert(managed_callable, serialized_data);
-			} else if (OS::get_singleton()->is_stdout_verbose()) {
-				OS::get_singleton()->print("Failed to serialize delegate\n");
+			} else {
+				if (OS::get_singleton()->is_stdout_verbose()) {
+					OS::get_singleton()->print("Failed to serialize delegate.\n");
+				}
+
+				// We failed to serialize the delegate but we still have to release it;
+				// otherwise, we won't be able to unload the assembly.
+				managed_callable->release_delegate_handle();
 			}
 		}
 	}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
@@ -166,6 +166,12 @@ namespace Godot
                 }
                 case GodotObject godotObject:
                 {
+                    if (!GodotObject.IsInstanceValid(godotObject))
+                    {
+                        // If the delegate's target has been freed we can't serialize it.
+                        return false;
+                    }
+
                     using (var stream = new MemoryStream())
                     using (var writer = new BinaryWriter(stream))
                     {


### PR DESCRIPTION
When reloading assemblies, we serialize the managed delegates so we can recreate the callables later. If the delegate's target is a GodotObject that has already been disposed, we can't serialize the delegate.

Before this change, trying to serialize one of these delegates throws an exception and prevents releasing its strong GCHandle, so the assembly can't be unloaded.

With this change, we don't serialize the delegates and release them anyway. This means some delegates may get lost on reloading assemblies, but if their target was already freed it's probably fine.

- Fixes https://github.com/godotengine/godot/issues/102484.