### PR TITLE
Fix Tree Mouse hover position

### DIFF
--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -670,9 +670,18 @@ private:
 	TreeItem *_search_item_text(TreeItem *p_at, const String &p_find, int *r_col, bool p_selectable, bool p_backwards = false);
 
 	TreeItem *_find_item_at_pos(TreeItem *p_item, const Point2 &p_pos, int &r_column, int &r_height, int &r_section) const;
-	int _get_item_h_offset(TreeItem *p_item) const;
 
-	void _find_button_at_pos(const Point2 &p_pos, TreeItem *&r_item, int &r_column, int &r_index) const;
+	void _find_button_at_pos(const Point2 &p_pos, TreeItem *&r_item, int &r_column, int &r_index, int &r_section) const;
+
+	struct FindColumnButtonResult {
+		int column_index = -1;
+		int button_index = -1;
+		int column_width = -1;
+		int column_offset = -1;
+		int pos_x = -1;
+	};
+
+	FindColumnButtonResult _find_column_and_button_at_pos(int p_x, const TreeItem *p_item, int p_x_ofs, int p_x_limit) const;
 
 	/*	float drag_speed;
 	float drag_accum;


### PR DESCRIPTION
- Fixes #102194

This PR should fixes the hovered, tooltip and click position for trees button.

The PR includes:
- A simplification of the `_determine_hovered_item` to use the `_find_button_at_pos` method which tried to do exactly the same thing, aka finding the button at a position.
- The space used by the scrollbar was not correctly calculated. At first, I tried to simply add the missing `scrollbar_h_separation` but there's some calculations in `_get_content_rect` that manage a situation where the scrollbar is inside the panel margin (when theme `scrollbar_margin_right` is >= 0). I simply used `_get_content_rect` directly like a lot of other places in the tree code. This fix was added in `_range_click_timeout`, `gui_input`, and `_find_button_at_pos`.
- The condition to check if the mouse position was hover a button was always off 2 pixels to the right because of a missing >= and a -1 needed because is a comparaison between a zero based position and a size. This fix was added in `_find_button_at_pos` and `propagate_mouse_event`.
- The margin area of the scrollbar was considered the last column and button.
- In RTL mode, the panel offset was calculated before the adjustment to `pos.x` in `_find_button_at_pos` causing an offset of a couple of pixels in RTL mode.
- Finally, I added -1 when adjusting the position in RTL mode in `_find_button_at_pos` to have the exact position. Ex: If the position is 99,0 and the size is 100,0 the actual position to use is 0,0. If the position is 0,0, the actual position to use is 99,0. I changed every place in the Tree code where these adjustments were present.


I tested in Window with the MRP from the issue and with different settings. I'm not familiar with the Tree control so I strongly suggest more test are done.

Note: There still some duplicate code between `_find_button_at_pos` and `propagate_mouse_event` but everything seems to work fine as is, I'm really not confident I can refactor this without any side effect, especially just before a new release.


https://github.com/user-attachments/assets/b6cac137-e7ad-4687-9585-7184fce5c63b


