### PR TITLE
Fix stale VoxelGI warnings.

### DIFF
--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -275,6 +275,7 @@ void VoxelGI::set_probe_data(const Ref<VoxelGIData> &p_data) {
 	}
 
 	probe_data = p_data;
+	update_configuration_warnings();
 }
 
 Ref<VoxelGIData> VoxelGI::get_probe_data() const {


### PR DESCRIPTION
Fix for https://github.com/godotengine/godot/issues/102841

Easy 1 line fix, just need to call update_configuration_warnings() any time fields related to our warning concerns get changed. In this case we just need to be concerned about calling this whenever the voxel data field changes for any reason.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
