### PR TITLE
Fix textures used in decals and light projectors not detected as used in 3D

### DIFF
--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -146,6 +146,8 @@ Error CompressedTexture2D::load(const String &p_path) {
 	} else {
 		texture = RS::get_singleton()->texture_2d_create(image);
 	}
+	RS::get_singleton()->texture_set_path(texture, get_path());
+
 	if (lw || lh) {
 		RS::get_singleton()->texture_set_size_override(texture, lw, lh);
 	}

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -248,6 +248,12 @@ void LightStorage::light_set_projector(RID p_light, RID p_texture) {
 
 	if (light->type != RS::LIGHT_DIRECTIONAL) {
 		if (light->projector.is_valid()) {
+#ifdef TOOLS_ENABLED
+			TextureStorage::Texture *tex = TextureStorage::get_singleton()->get_texture(p_texture);
+			if (tex->detect_3d_callback) {
+				tex->detect_3d_callback(tex->detect_3d_callback_ud);
+			}
+#endif
 			texture_storage->texture_add_to_decal_atlas(light->projector, light->type == RS::LIGHT_OMNI);
 		}
 		light->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_LIGHT_SOFT_SHADOW_AND_PROJECTOR);

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -2673,6 +2673,23 @@ void TextureStorage::decal_set_texture(RID p_decal, RS::DecalTexture p_type, RID
 	decal->textures[p_type] = p_texture;
 
 	if (decal->textures[p_type].is_valid()) {
+#ifdef TOOLS_ENABLED
+		Texture *tex = get_texture(p_texture);
+		if (tex->detect_3d_callback) {
+			tex->detect_3d_callback(tex->detect_3d_callback_ud);
+		}
+		if (p_type == RS::DecalTexture::DECAL_TEXTURE_NORMAL && tex->detect_normal_callback) {
+			tex->detect_normal_callback(tex->detect_normal_callback_ud);
+		}
+
+		if (p_type == RS::DecalTexture::DECAL_TEXTURE_NORMAL || p_type == RS::DecalTexture::DECAL_TEXTURE_ORM) {
+			Texture *normal_tex = get_texture(decal->textures[RS::DecalTexture::DECAL_TEXTURE_NORMAL]);
+			Texture *orm_tex = get_texture(decal->textures[RS::DecalTexture::DECAL_TEXTURE_ORM]);
+			if (orm_tex && normal_tex && !normal_tex->path.is_empty() && orm_tex->detect_roughness_callback) {
+				orm_tex->detect_roughness_callback(orm_tex->detect_roughness_callback_ud, normal_tex->path, RS::TEXTURE_DETECT_ROUGHNESS_G);
+			}
+		}
+#endif
 		texture_add_to_decal_atlas(decal->textures[p_type]);
 	}
 


### PR DESCRIPTION
Fix #62031
Fix #62032

For why the change in `CompressedTexture2D` is necessary, see #102622 and #102626. The path is needs to be preserved after reimport because the roughness callback uses it.
