### PR TITLE
Fix LineEdit only being editable via keyboard and mouse

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -660,13 +660,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	Ref<InputEventKey> k = p_event;
-
-	if (k.is_null()) {
-		return;
-	}
-
-	if (editable && !editing && k->is_action_pressed("ui_text_submit", false)) {
+	if (editable && !editing && p_event->is_action_pressed("ui_text_submit", false)) {
 		edit();
 		emit_signal(SNAME("editing_toggled"), true);
 		accept_event();
@@ -675,7 +669,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 	// Open context menu.
 	if (context_menu_enabled) {
-		if (k->is_action("ui_menu", true)) {
+		if (p_event->is_action("ui_menu", true)) {
 			_update_context_menu();
 			Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + theme_cache.font->get_height(theme_cache.font_size)) / 2);
 			menu->set_position(get_screen_transform().xform(pos));
@@ -689,19 +683,19 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (is_shortcut_keys_enabled()) {
-		if (k->is_action("ui_copy", true)) {
+		if (p_event->is_action("ui_copy", true)) {
 			copy_text();
 			accept_event();
 			return;
 		}
 
-		if (k->is_action("ui_text_select_all", true)) {
+		if (p_event->is_action("ui_text_select_all", true)) {
 			select();
 			accept_event();
 			return;
 		}
 
-		if (k->is_action("ui_cut", true)) {
+		if (p_event->is_action("ui_cut", true)) {
 			if (editable) {
 				cut_text();
 			} else {
@@ -713,6 +707,12 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (!editing) {
+		return;
+	}
+
+	Ref<InputEventKey> k = p_event;
+
+	if (k.is_null()) {
 		return;
 	}
 


### PR DESCRIPTION
Currently ``LineEdit`` actions can only be submitted from Keyboard and Mouse.  This is because the event it is listening for is required to be an ``InputEventKey``.  To add gamepad support, we just need to move the ``InputEventKey`` check below the action checks.  I discovered this when I was pressing "submit" on my gamepad and the ``LineEdit`` wasn't entering edit mode.  When inspecting the source code, I noticed that it required the event be ``InputEventKey`` too early.  Here's a video of our in game keyboard.  We forked it from https://github.com/martinfuchs/Godot-Onscreen-Keyboard.  We added gamepad support in our fork here: https://github.com/Lange-Studios/Godot-Onscreen-Keyboard/tree/gamepad-support


https://github.com/user-attachments/assets/77ab91e2-dd12-4005-8d2a-b65dd646f15b

