### PR TITLE
[ENet] Explicitly destroy hosts on close

### DIFF
--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -301,6 +301,7 @@ void ENetMultiplayerPeer::close() {
 	}
 	for (KeyValue<int, Ref<ENetConnection>> &E : hosts) {
 		E.value->flush();
+		E.value->destroy();
 	}
 
 	active_mode = MODE_NONE;


### PR DESCRIPTION
To ensure we free up the UDP port even if a script is holding a reference to the underlying host, we need to explicitly destroy it on close.

This is a partial fix to #102822 .

We can't really properly fix it if C# keeps references to RefCounted objects longer than their lifetime, but we can at least make sure that if you hold a reference to the underlying host, and you explicitly call ENetMultiplayerPeer::close, the underlying socket gets properly closed.