### PR TITLE
Fix `Camera2D` limits drawing

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -391,7 +391,7 @@ void Camera2D::_notification(int p_what) {
 					inv_camera_transform.xform(Vector2(0, screen_size.height))
 				};
 
-				Transform2D inv_transform = get_global_transform().affine_inverse(); // undo global space
+				Transform2D inv_transform = get_global_transform().affine_inverse(); // Undo global space.
 
 				for (int i = 0; i < 4; i++) {
 					draw_line(inv_transform.xform(screen_endpoints[i]), inv_transform.xform(screen_endpoints[(i + 1) % 4]), area_axis_color, area_axis_width);
@@ -405,13 +405,13 @@ void Camera2D::_notification(int p_what) {
 					limit_drawing_width = 3;
 				}
 
-				Vector2 camera_origin = get_global_position();
-				Vector2 camera_scale = get_global_scale().abs();
+				Transform2D inv_transform = get_global_transform().affine_inverse();
+
 				Vector2 limit_points[4] = {
-					(Vector2(limit[SIDE_LEFT], limit[SIDE_TOP]) - camera_origin) / camera_scale,
-					(Vector2(limit[SIDE_RIGHT], limit[SIDE_TOP]) - camera_origin) / camera_scale,
-					(Vector2(limit[SIDE_RIGHT], limit[SIDE_BOTTOM]) - camera_origin) / camera_scale,
-					(Vector2(limit[SIDE_LEFT], limit[SIDE_BOTTOM]) - camera_origin) / camera_scale
+					inv_transform.xform(Vector2(limit[SIDE_LEFT], limit[SIDE_TOP])),
+					inv_transform.xform(Vector2(limit[SIDE_RIGHT], limit[SIDE_TOP])),
+					inv_transform.xform(Vector2(limit[SIDE_RIGHT], limit[SIDE_BOTTOM])),
+					inv_transform.xform(Vector2(limit[SIDE_LEFT], limit[SIDE_BOTTOM]))
 				};
 
 				for (int i = 0; i < 4; i++) {
@@ -436,7 +436,7 @@ void Camera2D::_notification(int p_what) {
 					inv_camera_transform.xform(Vector2((screen_size.width / 2) - ((screen_size.width / 2) * drag_margin[SIDE_LEFT]), (screen_size.height / 2) + ((screen_size.height / 2) * drag_margin[SIDE_BOTTOM])))
 				};
 
-				Transform2D inv_transform = get_global_transform().affine_inverse(); // undo global space
+				Transform2D inv_transform = get_global_transform().affine_inverse(); // Undo global space.
 
 				for (int i = 0; i < 4; i++) {
 					draw_line(inv_transform.xform(margin_endpoints[i]), inv_transform.xform(margin_endpoints[(i + 1) % 4]), margin_drawing_color, margin_drawing_width);


### PR DESCRIPTION
`Camera2D` limits drawing should not be affected by skew and rotation.
Discovered during https://github.com/godotengine/godot/pull/101427#issuecomment-2639813575

Before:

https://github.com/user-attachments/assets/fedb185e-e8c0-49b7-88c6-5fbe77f8ec8b

After:

https://github.com/user-attachments/assets/3db4d67b-7737-4032-8237-599705cd0e88