### PR TITLE
OpenXR: Expose more system info from `XrSystemProperties`

### DIFF
--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -420,6 +420,8 @@ public:
 	OpenXRGraphicsExtensionWrapper *get_graphics_extension() const { return graphics_extension; }
 	String get_runtime_name() const { return runtime_name; }
 	String get_runtime_version() const { return runtime_version; }
+	String get_system_name() const { return system_name; }
+	uint32_t get_vendor_id() const { return vendor_id; }
 
 	// helper method to convert an XrPosef to a Transform3D
 	Transform3D transform_from_pose(const XrPosef &p_pose);

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -705,6 +705,8 @@ Dictionary OpenXRInterface::get_system_info() {
 	if (openxr_api) {
 		dict[SNAME("XRRuntimeName")] = openxr_api->get_runtime_name();
 		dict[SNAME("XRRuntimeVersion")] = openxr_api->get_runtime_version();
+		dict[SNAME("OpenXRSystemName")] = openxr_api->get_system_name();
+		dict[SNAME("OpenXRVendorID")] = openxr_api->get_vendor_id();
 	}
 
 	return dict;


### PR DESCRIPTION
We're already gathering this info in `OpenXRAPI`, but just not exposing it via `get_system_info()`.

I used the `OpenXR*` prefix due to this note in the docs:

![Selection_270](https://github.com/user-attachments/assets/f63128af-d1fb-4979-80b1-72a4e32619c5)

It mandates some other keys starting with `XR*`, and I figured these counted as "additional entries [that] may be provided specific to interface", and I wanted to give those interface specific ones a prefix specific to this interface.