### PR TITLE
Fix Line2D not rendering anything when total length is not computed

### DIFF
--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -112,7 +112,7 @@ void LineBuilder::build() {
 		}
 	}
 
-	if (Math::is_zero_approx(total_distance)) {
+	if (point_count < 2 || (distance_required && Math::is_zero_approx(total_distance))) {
 		// Zero-length line, nothing to build.
 		return;
 	}


### PR DESCRIPTION
This fixes a regression caused by #102778.

That PR caused Line2Ds to not render at all if the conditions for `distance_required` are not met. (https://github.com/KoBeWi/godot/blob/842421ea61562f10ca932bf19b902202438789a7/scene/2d/line_builder.cpp#L92)