### PR TITLE
Add F2 hotkey to rename animation in SpriteFrames

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1302,6 +1302,15 @@ void SpriteFramesEditor::_animation_speed_changed(double p_value) {
 	undo_redo->commit_action();
 }
 
+void SpriteFramesEditor::_animation_list_gui_input(const Ref<InputEvent> &p_event) {
+	if (ED_IS_SHORTCUT("sprite_frames/rename_animation", p_event) && p_event->is_pressed() && !p_event->is_echo()) {
+		if (animations->get_selected()) {
+			animations->edit_selected();
+			accept_event();
+		}
+	}
+}
+
 void SpriteFramesEditor::_frame_list_gui_input(const Ref<InputEvent> &p_event) {
 	const Ref<InputEventMouseButton> mb = p_event;
 
@@ -1993,6 +2002,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	// HACK: The cell_selected signal is emitted before the FPS spinbox loses focus and applies the change.
 	animations->connect("cell_selected", callable_mp(this, &SpriteFramesEditor::_animation_selected), CONNECT_DEFERRED);
 	animations->connect("item_edited", callable_mp(this, &SpriteFramesEditor::_animation_name_edited));
+	animations->connect(SceneStringName(gui_input), callable_mp(this, &SpriteFramesEditor::_animation_list_gui_input));
 	animations->set_theme_type_variation("TreeSecondary");
 	animations->set_allow_reselect(true);
 
@@ -2002,6 +2012,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	duplicate_anim->set_shortcut(ED_SHORTCUT("sprite_frames/duplicate_animation", TTRC("Duplicate Animation"), KeyModifierMask::CMD_OR_CTRL | Key::D));
 	delete_anim->set_shortcut_context(animations);
 	delete_anim->set_shortcut(ED_SHORTCUT("sprite_frames/delete_animation", TTRC("Delete Animation"), Key::KEY_DELETE));
+	rename_anim = ED_SHORTCUT("sprite_frames/rename_animation", TTRC("Rename Animation"), Key::F2);
 
 	missing_anim_label = memnew(Label);
 	missing_anim_label->set_text(TTR("This resource does not have any animations."));

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -127,6 +127,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	Button *add_anim = nullptr;
 	Button *duplicate_anim = nullptr;
 	Button *delete_anim = nullptr;
+	Ref<Shortcut> rename_anim;
 	SpinBox *anim_speed = nullptr;
 	Button *anim_loop = nullptr;
 
@@ -224,6 +225,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _animation_loop_changed();
 	void _animation_speed_resized();
 	void _animation_speed_changed(double p_value);
+	void _animation_list_gui_input(const Ref<InputEvent> &p_event);
 
 	void _frame_list_gui_input(const Ref<InputEvent> &p_event);
 	void _frame_list_item_selected(int p_index, bool p_selected);


### PR DESCRIPTION
This PR adds F2 as a hotkey for "rename animation" action in animation list of Sprite Frames plugin.

Closes https://github.com/godotengine/godot-proposals/issues/9550

I agree with the issue; I often find myself pressing F2 by habit and failing to rename an animation. The list looks visually similar to both scene tree view and filesystem dock, and supports many similar hotkeys (create new, delete, duplicate), so it feels out of place that F2 doesn't work here.

Unlike other actions, there is no dedicated button for renaming an animation... Not sure if it's needed? Rename can already be done via double-click, and toolbar's already somewhat crowded.