### PR TITLE
Add custom minimum size for shader tabs

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -833,6 +833,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	left_panel->set_custom_minimum_size(Size2(100, 300) * EDSCALE);
 
 	shader_tabs = memnew(TabContainer);
+	shader_tabs->set_custom_minimum_size(Size2(460, 300) * EDSCALE);
 	shader_tabs->set_tabs_visible(false);
 	shader_tabs->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	main_split->add_child(shader_tabs);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/102814
Partially extracted from https://github.com/godotengine/godot/pull/102301


| Before, minimized | After, minimized |
| --- | --- |
| ![Godot_v4 4-beta3_win64_6CCEWCPCRK](https://github.com/user-attachments/assets/d2d7f48f-0942-46df-9e58-107ff5995424) | ![godot windows editor dev x86_64_4o34VRnS4G](https://github.com/user-attachments/assets/a966d097-a43e-42ce-92e3-4b4b36d80989) |
