### PR TITLE
Fix Tree buttons jiggle on horizontal scrolling

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2184,7 +2184,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					buttons_width += button_texture->get_size().width + theme_cache.button_pressed->get_minimum_size().width + theme_cache.button_margin;
 				}
 
-				int total_ofs = ofs - theme_cache.offset.x;
+				double total_ofs = ofs - theme_cache.offset.x;
 
 				// If part of the column is beyond the right side of the control due to scrolling, clamp the label width
 				// so that all buttons attached to the cell remain within view.


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/100645

After:

[Screencast_20250214_234930.webm](https://github.com/user-attachments/assets/3f1bd00b-2735-43fe-8a96-a14bc28312c7)

test file to test in: 
[treejiggle.zip](https://github.com/user-attachments/files/18805320/treejiggle.zip)


Before:

[Screencast_20250214_235242.webm](https://github.com/user-attachments/assets/e04a63da-fd33-4d41-889a-a74f5791260f)

After:

[Screencast_20250214_235141.webm](https://github.com/user-attachments/assets/3511cda1-e39a-4d85-826d-a772c2e8d591)


The editor SceneTree makes the buttons/row jump slightly to the left at end of the scroll when the vertical scroll is visible (was there before too) not sure what makes that happen. Feels like another issue that can be fixed in a separate PR. 

[Screencast_20250214_235844.webm](https://github.com/user-attachments/assets/a82fa1e8-ea02-491c-8902-6c823356d8b9)


