### PR TITLE
Add shortcuts to reset position, rotation and scale in Spatial and Canvas Item Editor

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -364,6 +364,11 @@ private:
 		TRANSFORM_XZ,
 		TRANSFORM_XY,
 	};
+	enum TransformType {
+		POSITION,
+		ROTATION,
+		SCALE,
+	};
 
 	struct EditData {
 		TransformMode mode;
@@ -522,6 +527,8 @@ private:
 	void _project_settings_changed();
 
 	Transform3D _compute_transform(TransformMode p_mode, const Transform3D &p_original, const Transform3D &p_original_local, Vector3 p_motion, double p_extra, bool p_local, bool p_orthogonal);
+
+	void _reset_transform(TransformType p_type);
 
 	void begin_transform(TransformMode p_mode, bool instant);
 	void commit_transform();

--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -185,6 +185,12 @@ private:
 		GRID_VISIBILITY_HIDE,
 	};
 
+	enum TransformType {
+		POSITION,
+		ROTATION,
+		SCALE,
+	};
+
 	const String locked_transform_warning = TTRC("All selected CanvasItems are either invisible or locked in some way and can't be transformed.");
 
 	bool selection_menu_additive_selection = false;
@@ -380,6 +386,9 @@ private:
 	Ref<Shortcut> set_pivot_shortcut;
 	Ref<Shortcut> multiply_grid_step_shortcut;
 	Ref<Shortcut> divide_grid_step_shortcut;
+	Ref<Shortcut> reset_transform_position_shortcut;
+	Ref<Shortcut> reset_transform_rotation_shortcut;
+	Ref<Shortcut> reset_transform_scale_shortcut;
 
 	Ref<ViewPanner> panner;
 	void _pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event);
@@ -419,6 +428,7 @@ private:
 	bool _is_grid_visible() const;
 	void _prepare_grid_menu();
 	void _on_grid_menu_id_pressed(int p_id);
+	void _reset_transform(TransformType p_type);
 
 public:
 	enum ThemePreviewMode {


### PR DESCRIPTION
These changes allow resetting Node3D and Node2D transforms in the Spatial and Canvas Item Editor according to [proposal #11523](https://github.com/godotengine/godot-proposals/issues/11523).

The keybindings default to ALT+W (position), ALT+E (rotation) and ALT+R (scale) and  thus align with the default bindings to activate Move Mode (W), Rotate Mode (E) and Scale Mode (R).

Either a single selected node or multiple selected nodes can be reset and the reset can be undone.

The keybindings can be changed under Editor Settings -> Shortcuts.
![shortcuts](https://github.com/user-attachments/assets/a4ce4083-9e27-43d7-af02-5bd13e7a678e)

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/10612.*