### PR TITLE
Fix voxelizer normals

### DIFF
--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -399,6 +399,9 @@ int Voxelizer::get_bake_steps(Ref<Mesh> &p_mesh) const {
 Voxelizer::BakeResult Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material, BakeStepFunc p_bake_step_func) {
 	ERR_FAIL_COND_V_MSG(!p_xform.is_finite(), BAKE_RESULT_INVALID_PARAMETER, "Invalid mesh bake transform.");
 
+	// Precalculate for transforming vertex normals
+	Basis normal_xform = p_xform.basis.inverse().transposed();
+
 	int bake_total = get_bake_steps(p_mesh), bake_current = 0;
 
 	for (int i = 0; i < p_mesh->get_surface_count(); i++) {
@@ -463,7 +466,7 @@ Voxelizer::BakeResult Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh>
 
 				if (nr) {
 					for (int k = 0; k < 3; k++) {
-						normal[k] = nr[ir[j * 3 + k]];
+						normal[k] = normal_xform.xform(nr[ir[j * 3 + k]]).normalized();
 					}
 				}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #102407 

This PR fixes VoxelGI baking for rotated meshes
| Before | After |
|-|-|
| <img width="1512" alt="Screenshot 2025-02-15 at 16 01 52" src="https://github.com/user-attachments/assets/e3b51294-9642-40c1-b0c0-d7af22686c60" /> | <img width="1512" alt="Screenshot 2025-02-15 at 16 03 05" src="https://github.com/user-attachments/assets/8fbe117f-2edc-4a68-861c-44fbd048dbbc" /> |

