### PR TITLE
Timer unit test

### DIFF
--- a/tests/test_timer.cpp
+++ b/tests/test_timer.cpp
@@ -1,0 +1,26 @@
+#ifndef TEST_STRING_H
+#define TEST_STRING_H
+
+#include "tests/test_macros.h"
+#include "scene/main/timer.h"
+
+
+TEST_CASE("[SceneTree][Timer] Testing Autostart and Pause Behavior") {
+	Timer timer;
+
+	// starting the timer
+    timer.set_autostart(true);
+
+	// checking if the timer is not running (it should be running)
+	CHECK_FALSE(timer.is_stopped() == true);
+    
+	// pauses the timer and checks if it pauses
+    timer.set_paused(true);
+	CHECK_FALSE(timer.is_paused() == false);
+    
+	// unpauses the time and checks if it resumes 
+    timer.set_paused(false);
+	CHECK_FALSE(timer.is_paused() == true);
+}
+
+#endif 


### PR DESCRIPTION
This PR adds a unit tests for Timer autostart and pause behavior as part of issue #43440 :
- It makes sure Timer starts when autostart is enabled
- It makes sure that pausing and unpausing the Timer works correctly
Related to #97794 

