### PR TITLE
Add EditorAcceptDialog for easier handling of UndoRedo

### DIFF
--- a/editor/animation/animation_library_editor.cpp
+++ b/editor/animation/animation_library_editor.cpp
@@ -929,27 +929,6 @@ void AnimationLibraryEditor::_update_editor(Object *p_mixer) {
 	emit_signal("update_editor", p_mixer);
 }
 
-void AnimationLibraryEditor::shortcut_input(const Ref<InputEvent> &p_event) {
-	const Ref<InputEventKey> k = p_event;
-	if (k.is_valid() && k->is_pressed()) {
-		bool handled = false;
-
-		if (ED_IS_SHORTCUT("ui_undo", p_event)) {
-			EditorNode::get_singleton()->undo();
-			handled = true;
-		}
-
-		if (ED_IS_SHORTCUT("ui_redo", p_event)) {
-			EditorNode::get_singleton()->redo();
-			handled = true;
-		}
-
-		if (handled) {
-			set_input_as_handled();
-		}
-	}
-}
-
 void AnimationLibraryEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_editor", "mixer"), &AnimationLibraryEditor::_update_editor);
 	ADD_SIGNAL(MethodInfo("update_editor"));
@@ -957,7 +936,6 @@ void AnimationLibraryEditor::_bind_methods() {
 
 AnimationLibraryEditor::AnimationLibraryEditor() {
 	set_title(TTRC("Edit Animation Libraries"));
-	set_process_shortcut_input(true);
 
 	file_dialog = memnew(EditorFileDialog);
 	add_child(file_dialog);

--- a/editor/animation/animation_library_editor.h
+++ b/editor/animation/animation_library_editor.h
@@ -32,16 +32,16 @@
 
 #include "core/io/config_file.h"
 #include "core/templates/vector.h"
+#include "editor/gui/editor_accept_dialog.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/animation/animation_mixer.h"
-#include "scene/gui/dialogs.h"
 #include "scene/gui/tree.h"
 
 class AnimationMixer;
 class EditorFileDialog;
 
-class AnimationLibraryEditor : public AcceptDialog {
-	GDCLASS(AnimationLibraryEditor, AcceptDialog)
+class AnimationLibraryEditor : public EditorAcceptDialog {
+	GDCLASS(AnimationLibraryEditor, EditorAcceptDialog)
 
 	enum {
 		LIB_BUTTON_ADD,
@@ -117,7 +117,6 @@ class AnimationLibraryEditor : public AcceptDialog {
 protected:
 	void _notification(int p_what);
 	void _update_editor(Object *p_mixer);
-	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	static void _bind_methods();
 
 public:

--- a/editor/gui/editor_accept_dialog.cpp
+++ b/editor/gui/editor_accept_dialog.cpp
@@ -1,0 +1,55 @@
+/**************************************************************************/
+/*  editor_accept_dialog.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_accept_dialog.h"
+
+#include "editor/editor_node.h"
+#include "editor/settings/editor_settings.h"
+
+void EditorAcceptDialog::shortcut_input(const Ref<InputEvent> &p_event) {
+	const Ref<InputEventKey> k = p_event;
+	if (k.is_null() || !k->is_pressed()) {
+		return;
+	}
+
+	if (ED_IS_SHORTCUT("ui_undo", p_event)) {
+		EditorNode::get_singleton()->undo();
+		set_input_as_handled();
+	}
+
+	if (ED_IS_SHORTCUT("ui_redo", p_event)) {
+		EditorNode::get_singleton()->redo();
+		set_input_as_handled();
+	}
+}
+
+EditorAcceptDialog::EditorAcceptDialog() {
+	set_process_shortcut_input(true);
+}

--- a/editor/gui/editor_accept_dialog.h
+++ b/editor/gui/editor_accept_dialog.h
@@ -1,0 +1,43 @@
+/**************************************************************************/
+/*  editor_accept_dialog.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/gui/dialogs.h"
+
+class EditorAcceptDialog : public AcceptDialog {
+	GDCLASS(EditorAcceptDialog, AcceptDialog);
+
+protected:
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+
+public:
+	EditorAcceptDialog();
+};

--- a/editor/scene/gui/theme_editor_plugin.h
+++ b/editor/scene/gui/theme_editor_plugin.h
@@ -32,9 +32,9 @@
 
 #include "core/templates/rb_map.h"
 #include "editor/docks/editor_dock.h"
+#include "editor/gui/editor_accept_dialog.h"
 #include "editor/plugins/editor_plugin.h"
 #include "editor/scene/gui/theme_editor_preview.h"
-#include "scene/gui/dialogs.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/tree.h"
 #include "scene/resources/theme.h"
@@ -191,8 +191,8 @@ public:
 
 class ThemeTypeEditor;
 
-class ThemeItemEditorDialog : public AcceptDialog {
-	GDCLASS(ThemeItemEditorDialog, AcceptDialog);
+class ThemeItemEditorDialog : public EditorAcceptDialog {
+	GDCLASS(ThemeItemEditorDialog, EditorAcceptDialog);
 
 	ThemeTypeEditor *theme_type_editor = nullptr;
 

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -220,7 +220,6 @@ void EditorSettingsDialog::popup_edit_settings() {
 	inspector->get_inspector()->update_tree();
 
 	_update_shortcuts();
-	set_process_shortcut_input(true);
 
 	// Restore valid window bounds or pop up at default size.
 	Rect2 saved_size;
@@ -256,7 +255,6 @@ void EditorSettingsDialog::_notification(int p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible() && !_is_in_project_manager()) {
 				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "editor_settings", Rect2(get_position(), get_size()));
-				set_process_shortcut_input(false);
 			}
 		} break;
 
@@ -308,26 +306,13 @@ void EditorSettingsDialog::_notification(int p_what) {
 void EditorSettingsDialog::shortcut_input(const Ref<InputEvent> &p_event) {
 	const Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && k->is_pressed()) {
-		bool handled = false;
-
-		if (EditorNode::get_singleton()) {
-			if (ED_IS_SHORTCUT("ui_undo", p_event)) {
-				EditorNode::get_singleton()->undo();
-				handled = true;
-			}
-
-			if (ED_IS_SHORTCUT("ui_redo", p_event)) {
-				EditorNode::get_singleton()->redo();
-				handled = true;
-			}
+		EditorAcceptDialog::shortcut_input(p_event);
+		if (is_input_handled()) {
+			return;
 		}
 
 		if (k->is_match(InputEventKey::create_reference(KeyModifierMask::CMD_OR_CTRL | Key::F))) {
 			_focus_current_search_box();
-			handled = true;
-		}
-
-		if (handled) {
 			set_input_as_handled();
 		}
 	}

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -30,8 +30,8 @@
 
 #pragma once
 
+#include "editor/gui/editor_accept_dialog.h"
 #include "editor/inspector/editor_inspector.h"
-#include "scene/gui/dialogs.h"
 
 class CheckButton;
 class EditorEventSearchBar;
@@ -44,8 +44,8 @@ class TextureRect;
 class Tree;
 class TreeItem;
 
-class EditorSettingsDialog : public AcceptDialog {
-	GDCLASS(EditorSettingsDialog, AcceptDialog);
+class EditorSettingsDialog : public EditorAcceptDialog {
+	GDCLASS(EditorSettingsDialog, EditorAcceptDialog);
 
 	TabContainer *tabs = nullptr;
 	Control *tab_general = nullptr;

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -60,7 +60,6 @@ void ProjectSettingsEditor::popup_project_settings(bool p_clear_filter) {
 
 	_add_feature_overrides();
 	general_settings_inspector->update_category_list();
-	set_process_shortcut_input(true);
 
 	localization_editor->update_translations();
 	autoload_settings->update_autoload();
@@ -288,19 +287,14 @@ void ProjectSettingsEditor::_select_type(Variant::Type p_type) {
 }
 
 void ProjectSettingsEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	EditorAcceptDialog::shortcut_input(p_event);
+	if (is_input_handled()) {
+		return;
+	}
+
 	const Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && k->is_pressed()) {
 		bool handled = false;
-
-		if (ED_IS_SHORTCUT("ui_undo", p_event)) {
-			EditorNode::get_singleton()->undo();
-			handled = true;
-		}
-
-		if (ED_IS_SHORTCUT("ui_redo", p_event)) {
-			EditorNode::get_singleton()->redo();
-			handled = true;
-		}
 
 		if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
 			_focus_current_search_box();

--- a/editor/settings/project_settings_editor.h
+++ b/editor/settings/project_settings_editor.h
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "editor/editor_data.h"
+#include "editor/gui/editor_accept_dialog.h"
 #include "editor/import/import_defaults_editor.h"
 #include "editor/inspector/editor_sectioned_inspector.h"
 #include "editor/plugins/editor_plugin_settings.h"
@@ -47,8 +48,8 @@
 class EditorVariantTypeOptionButton;
 class FileSystemDock;
 
-class ProjectSettingsEditor : public AcceptDialog {
-	GDCLASS(ProjectSettingsEditor, AcceptDialog);
+class ProjectSettingsEditor : public EditorAcceptDialog {
+	GDCLASS(ProjectSettingsEditor, EditorAcceptDialog);
 
 	inline static ProjectSettingsEditor *singleton = nullptr;
 


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/93898#discussion_r1665469657
Also adds undo/redo support for theme import dialog. If you have your favorite dialog that doesn't support undo/redo, comment so I can change it too.