### PR TITLE
Fix 2D quad primitive missing lighting data in GLES3 renderer

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1152,6 +1152,12 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 					// Reset base data.
 					_update_transform_2d_to_mat2x3(base_transform * draw_transform, state.instance_data_array[r_index].world);
 					_prepare_canvas_texture(state.canvas_instance_batches[state.current_batch_index].tex, state.canvas_instance_batches[state.current_batch_index].filter, state.canvas_instance_batches[state.current_batch_index].repeat, r_index, texpixel_size);
+					state.instance_data_array[r_index].lights[0] = lights[0];
+					state.instance_data_array[r_index].lights[1] = lights[1];
+					state.instance_data_array[r_index].lights[2] = lights[2];
+					state.instance_data_array[r_index].lights[3] = lights[3];
+					state.instance_data_array[r_index].flags = base_flags;
+					state.instance_data_array[r_index].instance_uniforms_ofs = p_item->instance_allocated_shader_uniforms_offset;
 
 					for (uint32_t j = 0; j < 3; j++) {
 						int offset = j == 0 ? 0 : 1;


### PR DESCRIPTION
Fixes #95421.


(top is `CanvasItem.draw_line()`, bottom is `Line2D`)
| Before<br>(v4.4.beta3.official [06acfccf8])| After<br>(this PR)|
|--------|--------|
![Hta5LOz1bY](https://github.com/user-attachments/assets/6b540561-1f3f-421a-bbf9-371250dd8521)|![Wa7eDZEJtm](https://github.com/user-attachments/assets/1e5d64af-8386-4149-aef0-fe69c2547db8)

---

In GLES3/compatibility renderer 4-point CommandPrimitive is drawn as 2 separate triangles within the batch (at different `r_index`), but not all data set for the first triangle:
https://github.com/godotengine/godot/blob/f42e612da286b14b3a50eff7935615b3bc132c37/drivers/gles3/rasterizer_canvas_gles3.cpp#L892-L914
was set for the second triangle. Added missing stuff.
