### PR TITLE
Hide debug keystore export settings

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2042,6 +2042,9 @@ bool EditorExportPlatformAndroid::get_export_option_visibility(const EditorExpor
 			p_option == "command_line/extra_args" ||
 			p_option == "permissions/custom_permissions" ||
 			p_option == "gradle_build/compress_native_libraries" ||
+			p_option == "keystore/debug" ||
+			p_option == "keystore/debug_user" ||
+			p_option == "keystore/debug_password" ||
 			p_option == "package/retain_data_on_uninstall" ||
 			p_option == "package/exclude_from_recents" ||
 			p_option == "package/show_in_app_library" ||


### PR DESCRIPTION
This PR moves the debug keystore settings under `Advanced Options`.  

These settings are only needed for users who want separate debug keystore for their projects, as there is already an option in the Editor Settings to configure the debug keystore. Also, after PR https://github.com/godotengine/godot/pull/90611, a debug keystore is automatically generated, and its path is set in the Editor Settings.
