### PR TITLE
Add Array::erase_custom(func)

### DIFF
--- a/core/templates/erase_array.h
+++ b/core/templates/erase_array.h
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  erase_array.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef ERASE_ARRAY_H
+#define ERASE_ARRAY_H
+
+#include "core/typedefs.h"
+
+template <typename T, typename Predicate>
+struct EraseArray {
+	Predicate predicate;
+
+	inline int64_t find_first(T *p_array, int64_t p_len) {
+		for (int64_t i = 0; i < p_len; i++) {
+			if (predicate(p_array[i])) {
+				return i;
+			}
+		}
+		return p_len;
+	}
+
+	inline int64_t erase(T *p_array, int64_t p_len) {
+		int64_t first = find_first(p_array, p_len);
+		if (first == p_len) {
+			return p_len;
+		}
+
+		for (int64_t i = first + 1; i < p_len; i++) {
+			if (!predicate(p_array[i])) {
+				p_array[first++] = std::move(p_array[i]);
+			}
+		}
+		return first; // new length
+	}
+};
+
+#endif // ERASE_ARRAY_H

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -42,6 +42,7 @@
 #include "core/error/error_macros.h"
 #include "core/os/memory.h"
 #include "core/templates/cowdata.h"
+#include "core/templates/erase_array.h"
 #include "core/templates/search_array.h"
 #include "core/templates/sort_array.h"
 
@@ -84,6 +85,14 @@ public:
 			return true;
 		}
 		return false;
+	}
+	template <typename Predicate, typename... Args>
+	Size erase_custom(Args &&...args) {
+		EraseArray<T, Predicate> erase_array{ args... };
+		Size old_size = size();
+		Size new_size = erase_array.erase(ptrw(), size());
+		resize(new_size);
+		return old_size - new_size;
 	}
 
 	void reverse();

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -329,6 +329,11 @@ void Array::erase(const Variant &p_value) {
 	_p->array.erase(value);
 }
 
+int Array::erase_custom(const Callable &p_callable) {
+	ERR_FAIL_COND_V_MSG(_p->read_only, 0, "Array is in read-only state.");
+	return _p->array.erase_custom<CallablePredicate>(p_callable);
+}
+
 Variant Array::front() const {
 	ERR_FAIL_COND_V_MSG(_p->array.is_empty(), Variant(), "Can't take value from empty array.");
 	return operator[](0);

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -160,6 +160,7 @@ public:
 	bool has(const Variant &p_value) const;
 
 	void erase(const Variant &p_value);
+	int erase_custom(const Callable &p_callable);
 
 	void push_front(const Variant &p_value);
 	Variant pop_back();

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -603,3 +603,13 @@ bool CallableComparator::operator()(const Variant &p_l, const Variant &p_r) cons
 			"Error calling compare method: " + Variant::get_callable_error_text(func, args, 2, err));
 	return res;
 }
+
+bool CallablePredicate::operator()(const Variant &p) const {
+	const Variant *args[1] = { &p };
+	Callable::CallError err;
+	Variant res;
+	func.callp(args, 1, res, err);
+	ERR_FAIL_COND_V_MSG(err.error != Callable::CallError::CALL_OK, false,
+			"Error calling predicate method: " + Variant::get_callable_error_text(func, args, 1, err));
+	return res;
+}

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -207,4 +207,10 @@ struct CallableComparator {
 	bool operator()(const Variant &p_l, const Variant &p_r) const;
 };
 
+struct CallablePredicate {
+	const Callable &func;
+
+	bool operator()(const Variant &p_l) const;
+};
+
 #endif // CALLABLE_H

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2365,6 +2365,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(Array, remove_at, sarray("position"), varray());
 	bind_method(Array, fill, sarray("value"), varray());
 	bind_method(Array, erase, sarray("value"), varray());
+	bind_method(Array, erase_custom, sarray("func"), varray());
 	bind_method(Array, front, sarray(), varray());
 	bind_method(Array, back, sarray(), varray());
 	bind_method(Array, pick_random, sarray(), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -344,6 +344,20 @@
 				[b]Note:[/b] Erasing elements while iterating over arrays is [b]not[/b] supported and will result in unpredictable behavior.
 			</description>
 		</method>
+		<method name="erase_custom">
+			<return type="int" />
+			<param index="0" name="func" type="Callable" />
+			<description>
+				Finds and removes all the elements which satisfy the predicate [param func]. Returns the number of elements removed.
+				[codeblocks]
+				[gdscript]
+				var array: Array[int] = [ 0, 1, 2, 3, 10 ]
+				var remove_count: int = array.erase_custom(func(v: int): return v % 2 == 0)
+				print(remove_count, " ", array) # Prints 3 [1, 3]
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="fill">
 			<return type="void" />
 			<param index="0" name="value" type="Variant" />

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -652,6 +652,21 @@ TEST_CASE("[Array] Test rfind_custom") {
 	CHECK_EQ(index, 4);
 }
 
+static bool _erase_custom_callable(const Variant &p_val) {
+	return (int)p_val % 2 == 0;
+}
+
+TEST_CASE("[Array] Test erase_custom") {
+	Array a1 = build_array(0, 1, 2, 3, 4, 5, 8, 9, 10);
+	// Removes 5 elements.
+	int removed = a1.erase_custom(callable_mp_static(_erase_custom_callable));
+	CHECK_EQ(removed, 5);
+	CHECK_EQ(a1[0], Variant(1));
+	CHECK_EQ(a1[1], Variant(3));
+	CHECK_EQ(a1[2], Variant(5));
+	CHECK_EQ(a1[3], Variant(9));
+}
+
 } // namespace TestArray
 
 #endif // TEST_ARRAY_H


### PR DESCRIPTION
Adds a new method for `Array`, which removes all the elements which satisfy the specified predicate.

```gd
var array: Array[int] = [ 0, 1, 2, 3, 10 ]
var remove_count: int = array.erase_custom(func(v: int): return v % 2 == 0)
print(remove_count, " ", array) # Prints 3 [1, 3]
```

<hr>

Currently I don't think there is a good way to remove elements from an Array in a loop. You can either remove by iterating from the end ...
```gd
var array: Array[int] = [0, 1, 2, 3, 4, 5]
for i in range(array.size()-1, -1, -1):
	array.remove_at(i)
```
... or just design around the idea, that you'll not be able to do so.