### PR TITLE
Add tests for toggle mode of `Button`

### DIFF
--- a/tests/scene/test_button.h
+++ b/tests/scene/test_button.h
@@ -65,7 +65,7 @@ TEST_CASE("[SceneTree][Button] is_hovered()") {
 TEST_CASE("[SceneTree][Button] Check toggle mode") {
 	Button *button = memnew(Button);
 
-	SUBCASE("button_pressed not works if toggle mode is off."){
+	SUBCASE("button_pressed stay false if toggle mode is off.") {
 		button->set_toggle_mode(false);
 		CHECK(button->is_toggle_mode() == false);
 	
@@ -75,7 +75,7 @@ TEST_CASE("[SceneTree][Button] Check toggle mode") {
 		CHECK(button->is_pressed() == false);
 	}
 
-	SUBCASE("button_pressed works if toggle mode is on."){
+	SUBCASE("button_pressed changes if toggle mode is on.") {
 		button->set_toggle_mode(true);
 		CHECK(button->is_toggle_mode() == true);
 	
@@ -85,7 +85,7 @@ TEST_CASE("[SceneTree][Button] Check toggle mode") {
 		CHECK(button->is_pressed() == false);
 	}
 
-	SUBCASE("Disabling toggle mode resets is_pressed to false."){
+	SUBCASE("Disabling toggle mode resets button_pressed to false.") {
 		button->set_toggle_mode(true);
 		button->set_pressed(true);
 		button->set_toggle_mode(false);

--- a/tests/scene/test_button.h
+++ b/tests/scene/test_button.h
@@ -68,7 +68,7 @@ TEST_CASE("[SceneTree][Button] Check toggle mode") {
 	SUBCASE("button_pressed stay false if toggle mode is off.") {
 		button->set_toggle_mode(false);
 		CHECK(button->is_toggle_mode() == false);
-	
+
 		button->set_pressed(false);
 		CHECK(button->is_pressed() == false);
 		button->set_pressed(true);
@@ -78,7 +78,7 @@ TEST_CASE("[SceneTree][Button] Check toggle mode") {
 	SUBCASE("button_pressed changes if toggle mode is on.") {
 		button->set_toggle_mode(true);
 		CHECK(button->is_toggle_mode() == true);
-	
+
 		button->set_pressed(true);
 		CHECK(button->is_pressed() == true);
 		button->set_pressed(false);

--- a/tests/scene/test_button.h
+++ b/tests/scene/test_button.h
@@ -62,5 +62,38 @@ TEST_CASE("[SceneTree][Button] is_hovered()") {
 	memdelete(button);
 }
 
+TEST_CASE("[SceneTree][Button] Check toggle mode") {
+	Button *button = memnew(Button);
+
+	SUBCASE("button_pressed not works if toggle mode is off."){
+		button->set_toggle_mode(false);
+		CHECK(button->is_toggle_mode() == false);
+	
+		button->set_pressed(false);
+		CHECK(button->is_pressed() == false);
+		button->set_pressed(true);
+		CHECK(button->is_pressed() == false);
+	}
+
+	SUBCASE("button_pressed works if toggle mode is on."){
+		button->set_toggle_mode(true);
+		CHECK(button->is_toggle_mode() == true);
+	
+		button->set_pressed(true);
+		CHECK(button->is_pressed() == true);
+		button->set_pressed(false);
+		CHECK(button->is_pressed() == false);
+	}
+
+	SUBCASE("Disabling toggle mode resets is_pressed to false."){
+		button->set_toggle_mode(true);
+		button->set_pressed(true);
+		button->set_toggle_mode(false);
+		CHECK(button->is_pressed() == false);
+	}
+
+	memdelete(button);
+}
+
 } //namespace TestButton
 #endif // TEST_BUTTON_H


### PR DESCRIPTION
This is part of issue #43440.

Added unit tests for the toggle mode functionality of `Button`:
* `button_pressed` stay `false` if toggle mode is off.
* `button_pressed` changes by pressing if toggle mode is on.
* Disabling toggle mode resets `button_pressed` to `false`.