### PR TITLE
Convert VisualShader resources to Shader on export

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1077,6 +1077,9 @@
 			[b]Note:[/b] Because a resource's file extension may change in an exported project, it is heavily recommended to use [method @GDScript.load] or [ResourceLoader] instead of [FileAccess] to load resources dynamically.
 			[b]Note:[/b] The project settings file ([code]project.godot[/code]) will always be converted to binary on export, regardless of this setting.
 		</member>
+		<member name="editor/export/convert_visual_shaders_to_text_shaders" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], [VisualShader] resources will be converted to [Shader] resources on project export. The resulting text shaders are smaller, so this option can save space.
+		</member>
 		<member name="editor/import/atlas_max_width" type="int" setter="" getter="" default="2048">
 			The maximum width to use when importing textures as an atlas. The value will be rounded to the nearest power of two when used. Use this to prevent imported textures from growing too large in the other direction.
 		</member>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8703,6 +8703,10 @@ EditorNode::EditorNode() {
 
 	EditorExport::get_singleton()->add_export_plugin(dedicated_server_export_plugin);
 
+	Ref<EditorExportVisualShader> visual_shader_export;
+	visual_shader_export.instantiate();
+	EditorExport::get_singleton()->add_export_plugin(visual_shader_export);
+
 	Ref<ShaderBakerExportPlugin> shader_baker_export_plugin;
 	shader_baker_export_plugin.instantiate();
 

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -293,6 +293,7 @@ void register_editor_types() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/import/atlas_max_width", PROPERTY_HINT_RANGE, "128,8192,1,or_greater"), 2048);
 
 	GLOBAL_DEF("editor/export/convert_text_resources_to_binary", true);
+	GLOBAL_DEF("editor/export/convert_visual_shaders_to_text_shaders", true);
 
 	GLOBAL_DEF("editor/version_control/plugin_name", "");
 	GLOBAL_DEF("editor/version_control/autoload_on_startup", false);

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -8470,3 +8470,18 @@ Ref<Resource> VisualShaderConversionPlugin::convert(const Ref<Resource> &p_resou
 
 	return shader;
 }
+
+bool EditorExportVisualShader::_begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) {
+	return GLOBAL_GET("editor/export/convert_visual_shaders_to_text_shaders");
+}
+
+Ref<Resource> EditorExportVisualShader::_customize_resource(const Ref<Resource> &p_resource, const String &p_path) {
+	Ref<VisualShader> visual_shader = p_resource;
+	if (visual_shader.is_valid() && !visual_shader->has_node_embeds()) {
+		Ref<Shader> shader;
+		shader.instantiate();
+		shader->set_code(visual_shader->get_code());
+		return shader;
+	}
+	return Ref<Resource>();
+}

--- a/editor/shader/visual_shader_editor_plugin.h
+++ b/editor/shader/visual_shader_editor_plugin.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "editor/editor_properties.h"
+#include "editor/export/editor_export_plugin.h"
 #include "editor/inspector/editor_properties.h"
 #include "editor/plugins/editor_plugin.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
@@ -51,6 +53,19 @@ class Tree;
 
 class VisualShaderEditor;
 class MaterialEditor;
+
+class EditorExportVisualShader : public EditorExportPlugin {
+	GDCLASS(EditorExportVisualShader, EditorExportPlugin);
+
+	bool convert_shaders = true;
+
+protected:
+	virtual bool _begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) override;
+	virtual Ref<Resource> _customize_resource(const Ref<Resource> &p_resource, const String &p_path) override;
+
+public:
+	virtual String get_name() const override { return "VisualShader"; }
+};
 
 class VisualShaderNodePlugin : public RefCounted {
 	GDCLASS(VisualShaderNodePlugin, RefCounted);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11561

Adds a new `editor/export/convert_visual_shaders_to_text_shaders` project setting.

Probably not a good idea until #101375 is resolved.