### PR TITLE
Optimize `array.filter` by attempting to no-op the result on consistent filters.

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -559,28 +559,85 @@ Array Array::slice(int p_begin, int p_end, int p_step, bool p_deep) const {
 }
 
 Array Array::filter(const Callable &p_callable) const {
-	Array new_arr;
-	new_arr.resize(size());
-	new_arr._p->typed = _p->typed;
-	int accepted_count = 0;
+	int index = 0;
 
+	// Variables used for the calls later.
 	const Variant *argptrs[1];
-	for (int i = 0; i < size(); i++) {
-		argptrs[0] = &get(i);
+	Variant result;
+	Callable::CallError ce;
 
-		Variant result;
-		Callable::CallError ce;
+	// This first part is an optimization:
+	// We try to iterate the full array without allocating yet.
+	// If all elements are filtered, we can just return an empty array.
+	// If no elements are filtered, we can just return a CoW copy.
+	bool all_so_far_are_retained = false; // Defaults to true for the empty array.
+	for (; index < size(); index++) {
+		argptrs[0] = &get(index);
+
+		p_callable.callp(argptrs, 1, result, ce);
+		if (ce.error != Callable::CallError::CALL_OK) {
+			ERR_FAIL_V_MSG(Array(), vformat("Error calling method from 'filter': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
+		}
+
+		if (index == 0) {
+			all_so_far_are_retained = result.operator bool();
+		} else if (all_so_far_are_retained != result.operator bool()) {
+			// At least one value was filtered, and one retained.
+			// We'll need to create a full copy (implemented below).
+			break;
+		}
+		// else we're still consistent with the filter behavior so far.
+	}
+
+	if (index == size()) {
+		// No inconsistencies of return values, we can shortcut with a fast result.
+		return all_so_far_are_retained ? duplicate(false) : Array();
+	}
+
+	// We need to actually create a full copy (slow path).
+	Array new_arr;
+	new_arr._p->typed = _p->typed;
+	int accepted_count;
+
+	if (all_so_far_are_retained) {
+		// We know so far, we've added all but one element.
+		// The rest, we don't know yet.
+		new_arr.resize(size() - 1);
+
+		// Add all elements so far, except the latest.
+		for (int i = 0; i < index; i++) {
+			new_arr[i] = get(i);
+		}
+		accepted_count = index;
+	} else {
+		// We know that so far, we've only added the latest element.
+		// The rest, we don't know yet.
+		new_arr.resize(size() - index);
+
+		// Add just the latest element.
+		new_arr[0] = get(index);
+		accepted_count = 1;
+	}
+
+	// Skip the latest entry.
+	index++;
+
+	// Iterate the rest.
+	for (; index < size(); index++) {
+		argptrs[0] = &get(index);
+
 		p_callable.callp(argptrs, 1, result, ce);
 		if (ce.error != Callable::CallError::CALL_OK) {
 			ERR_FAIL_V_MSG(Array(), vformat("Error calling method from 'filter': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
 		}
 
 		if (result.operator bool()) {
-			new_arr[accepted_count] = get(i);
+			new_arr[accepted_count] = get(index);
 			accepted_count++;
 		}
 	}
 
+	// Trim the result to actually needed size.
 	new_arr.resize(accepted_count);
 
 	return new_arr;


### PR DESCRIPTION
`array.filter` is a function that filters or retains elements from an `Array` based on some function.

We can speed it up when elements are consistently filtered:
- all `true`: We can return a shallow CoW copy. This is instantaneous, and will only be slow if it is modified after, forcing a full copy.
- all `false`: We can return an empty Array, which is instantaneous.
- The first X are `false`: We can make the resulting array smaller by X, speeding up allocation.

This PR was motivated by https://github.com/godotengine/godot/pull/102915 (https://github.com/godotengine/godot/pull/102915#issuecomment-2661478451).

## Benchmarks
I benchmarked a 4% improvement for affected cases in GDScript:
```gdscript
func _ready() -> void:
	const ITERATIONS = 100
	var array := range(100000)

	# Warmup
	var ignored = array.filter(func(v): v % 2)

	var begin := Time.get_ticks_usec()
	for i in ITERATIONS:
		var other = array.filter(func(v): v < 0)
	print("%dms for %d iterations (filter none)" % [(Time.get_ticks_usec() - begin) / 1000, ITERATIONS])

	begin = Time.get_ticks_usec()
	for i in ITERATIONS:
		var other = array.filter(func(v): v >= 0)
	print("%dms for %d iterations (filter all)" % [(Time.get_ticks_usec() - begin) / 1000, ITERATIONS])

	begin = Time.get_ticks_usec()
	for i in ITERATIONS:
		var other = array.filter(func(v): v < 500)
	print("%dms for %d iterations (filter first half)" % [(Time.get_ticks_usec() - begin) / 1000, ITERATIONS])

	begin = Time.get_ticks_usec()
	for i in ITERATIONS:
		var other = array.filter(func(v): v > 500)
	print("%dms for %d iterations (filter second half)" % [(Time.get_ticks_usec() - begin) / 1000, ITERATIONS])

	begin = Time.get_ticks_usec()
	for i in ITERATIONS:
		var other = array.filter(func(v): v % 2)
	print("%dms for %d iterations (filter interspersed)" % [(Time.get_ticks_usec() - begin) / 1000, ITERATIONS])
```

On `master`, this prints:
```
939ms for 100 iterations (filter none)
932ms for 100 iterations (filter all)
934ms for 100 iterations (filter first half)
932ms for 100 iterations (filter second half)
999ms for 100 iterations (filter interspersed)
```

On this PR, this prints:
```
908ms for 100 iterations (filter none)
904ms for 100 iterations (filter all)
903ms for 100 iterations (filter first half)
904ms for 100 iterations (filter second half)
967ms for 100 iterations (filter interspersed)
```

(edit: seems I forgot to edit the "half case" comparisons for larger array sizes; this explains why they are about the same speed. Though that's not important for the overall observations.)

### Observations
The speedup is _much_ less than I expected. I attribute this to `callp` being slow, because GDScript is forced to establish function frames. Arguably, this makes this PR too complicated for little gain, and `GDScript` function calls need a look first. Still, 10% is nothing to sneeze at.

Interestingly, even the `interspersed` case is still sped up by ~`3%`, even though it's not an optimized case. I attribute this to re-using `result` and `ce` instead of re-assigning them each iteration. Still, it's a little odd to me that `filter_interspersed` ended up being the slowest, but in any case, the speed ups are small to be fully sure that the values are consistent.