### PR TITLE
Remove non-existent IPUnix conversion

### DIFF
--- a/editor/renames_map_3_to_4.cpp
+++ b/editor/renames_map_3_to_4.cpp
@@ -1523,7 +1523,6 @@ const char *RenamesMap3To4::class_renames[][2] = {
 	{ "GradientTexture", "GradientTexture2D" },
 	{ "HeightMapShape", "HeightMapShape3D" },
 	{ "HingeJoint", "HingeJoint3D" },
-	{ "IP_Unix", "IPUnix" },
 	{ "ImmediateGeometry", "ImmediateMesh" },
 	{ "ImmediateGeometry3D", "ImmediateMesh" },
 	{ "InterpolatedCamera", "Camera3D" },


### PR DESCRIPTION
Fixes #102050 (or at least the errors)
The converter was failing on validation, because IPUnix class no longer exists. This means it was just broken for unknown amount of time (I only found that class was removed *probably* between 4.1 and 4.2 stable, though I couldn't even find it in 3.6).