### PR TITLE
Improve `ScrollContainer::ensure_control_visible`

### DIFF
--- a/core/math/rect2.cpp
+++ b/core/math/rect2.cpp
@@ -286,6 +286,122 @@ next4:
 	return true;
 }
 
+Rect2 Rect2::intersection_transformed(const Transform2D &p_xform, const Rect2 &p_rect) const {
+#ifdef MATH_CHECKS
+	if (unlikely(size.x < 0 || size.y < 0 || p_rect.size.x < 0 || p_rect.size.y < 0)) {
+		ERR_PRINT("Rect2 size is negative, this is not supported. Use Rect2.abs() to get a Rect2 with a positive size.");
+	}
+#endif
+
+	if ((Math::is_zero_approx(p_xform.columns[0].y) && Math::is_zero_approx(p_xform.columns[1].x)) ||
+			(Math::is_zero_approx(p_xform.columns[0].x) && Math::is_zero_approx(p_xform.columns[1].y))) {
+		return intersection(p_xform.xform(p_rect));
+	}
+
+	if (!intersects_transformed(p_xform, p_rect)) {
+		return Rect2();
+	}
+
+	const Vector2 xf_points[4] = {
+		p_xform.xform(p_rect.position),
+		p_xform.xform(Vector2(p_rect.position.x + p_rect.size.x, p_rect.position.y)),
+		p_xform.xform(Vector2(p_rect.position.x + p_rect.size.x, p_rect.position.y + p_rect.size.y)),
+		p_xform.xform(Vector2(p_rect.position.x, p_rect.position.y + p_rect.size.y)),
+	};
+
+	// Use Sutherland–Hodgman algorithm.
+
+	Vector2 subject[8];
+	int subject_count = 4;
+	subject[0] = xf_points[0];
+	subject[1] = xf_points[1];
+	subject[2] = xf_points[2];
+	subject[3] = xf_points[3];
+
+	const Vector2 min = position;
+	const Vector2 max = position + size;
+	Vector2 intersected;
+
+	for (int edge = 0; edge < 4; edge++) {
+		const int axis = edge % 2;
+		const int another_axis = 1 - axis;
+		const bool is_min = (edge < 2);
+		intersected[axis] = is_min ? min[axis] : max[axis];
+
+		Vector2 output[8];
+		int output_count = 0;
+
+		Vector2 prev = subject[subject_count - 1];
+		bool prev_in_halfplane = is_min ? (prev[axis] >= intersected[axis]) : (prev[axis] <= intersected[axis]);
+
+		for (int i = 0; i < subject_count; i++) {
+			const Vector2 &curr = subject[i];
+			bool curr_in_halfplane = is_min ? (curr[axis] >= intersected[axis]) : (curr[axis] <= intersected[axis]);
+			if (prev_in_halfplane != curr_in_halfplane) {
+				// Entering/exiting the half-plane.
+				real_t t = (intersected[axis] - prev[axis]) / (curr[axis] - prev[axis]);
+				intersected[another_axis] = prev[another_axis] + (curr[another_axis] - prev[another_axis]) * t;
+				output[output_count++] = intersected;
+			}
+			if (curr_in_halfplane) {
+				output[output_count++] = curr;
+			}
+			prev = curr;
+			prev_in_halfplane = curr_in_halfplane;
+		}
+
+		for (int i = 0; i < output_count; i++) {
+			subject[i] = output[i];
+		}
+
+		subject_count = output_count;
+		if (subject_count == 0) {
+			break;
+		}
+	}
+
+	if (subject_count > 0) {
+		return Rect2::from_points(subject, subject_count);
+	}
+
+	// Perform a reverse containment test; the current rect may be inside the transformed rect.
+
+	const Vector2 corners[4] = {
+		position,
+		Vector2(max.x, min.y),
+		max,
+		Vector2(min.x, max.y)
+	};
+
+	Vector2 inside_points[4];
+	int inside_count = 0;
+
+	for (int point_idx = 0; point_idx < 4; point_idx++) {
+		bool has_pos = false;
+		bool has_neg = false;
+		for (int idx = 0; idx < 4; idx++) {
+			const int next_idx = (idx + 1) % 4;
+			Vector2 v0 = xf_points[next_idx] - xf_points[idx];
+			Vector2 v1 = corners[point_idx] - xf_points[idx];
+			real_t cross = v0.cross(v1);
+			if (cross > CMP_EPSILON) {
+				has_pos = true;
+			}
+			if (cross < -CMP_EPSILON) {
+				has_neg = true;
+			}
+			if (has_pos && has_neg) {
+				break;
+			}
+		}
+		if (!(has_pos && has_neg)) {
+			inside_points[inside_count++] = corners[point_idx];
+		}
+	}
+
+	return inside_count > 0 ? Rect2::from_points(inside_points, inside_count) : Rect2();
+}
+
 Rect2::operator String() const {
 	return "[P: " + position.operator String() + ", S: " + size.operator String() + "]";
 }

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -144,6 +144,8 @@ struct [[nodiscard]] Rect2 {
 		return size.x > 0.0f && size.y > 0.0f;
 	}
 
+	Rect2 intersection_transformed(const Transform2D &p_xform, const Rect2 &p_rect) const;
+
 	// Returns the intersection between two Rect2s or an empty Rect2 if there is no intersection.
 	inline Rect2 intersection(const Rect2 &p_rect) const {
 		Rect2 new_rect = p_rect;
@@ -368,6 +370,30 @@ struct [[nodiscard]] Rect2 {
 		h = hash_murmur3_one_real(size.x, h);
 		h = hash_murmur3_one_real(size.y, h);
 		return hash_fmix32(h);
+	}
+
+	static Rect2 from_points(const Vector2 *p_points, int p_point_count) {
+		Rect2 result;
+		ERR_FAIL_NULL_V_MSG(p_points, result, "The pointer of points passed in is invalid.");
+		ERR_FAIL_COND_V_MSG(p_point_count <= 0, result, "The number of points passed in is invalid.");
+		result.position = p_points[0];
+		Vector2 end = result.position;
+		for (int i = 1; i < p_point_count; i++) {
+			const Vector2 &p = p_points[i];
+
+			if (p.x < result.position.x) {
+				result.position.x = p.x;
+			} else if (p.x > end.x) {
+				end.x = p.x;
+			}
+			if (p.y < result.position.y) {
+				result.position.y = p.y;
+			} else if (p.y > end.y) {
+				end.y = p.y;
+			}
+		}
+		result.size = end - result.position;
+		return result;
 	}
 
 	Rect2() = default;

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -171,6 +171,16 @@ Rect2 ScrollContainer::_get_margins() const {
 	return Rect2(left_margin, top_margin, right_margin, bottom_margin);
 }
 
+Rect2 ScrollContainer::_get_local_visible_rect() const {
+	const float side_margin = v_scroll->is_visible() ? v_scroll->get_size().x : 0.0f;
+	const float bottom_margin = h_scroll->is_visible() ? h_scroll->get_size().y : 0.0f;
+
+	Point2 origin = Point2(is_layout_rtl() ? side_margin : 0.0f, 0.0f);
+	Size2 size = Size2(get_size().x - side_margin, get_size().y - bottom_margin);
+
+	return Rect2(origin, size);
+}
+
 void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 	ERR_FAIL_COND(p_gui_input.is_null());
 
@@ -352,7 +362,9 @@ void ScrollContainer::_update_scrollbar_position() {
 
 void ScrollContainer::_gui_focus_changed(Control *p_control) {
 	if (follow_focus && is_ancestor_of(p_control)) {
+		following = true;
 		ensure_control_visible(p_control);
+		following = false;
 	}
 	if (draw_focus_border) {
 		const bool _should_draw_focus_border = has_focus(true) || child_has_focus();
@@ -365,20 +377,92 @@ void ScrollContainer::_gui_focus_changed(Control *p_control) {
 void ScrollContainer::ensure_control_visible(Control *p_control) {
 	ERR_FAIL_COND_MSG(!is_ancestor_of(p_control), "Must be an ancestor of the control.");
 
-	// Just eliminate the rotation of this ScrollContainer.
-	Transform2D other_in_this = get_global_transform().affine_inverse() * p_control->get_global_transform();
+	// The less scroll the better. We can assume that only the final visible area is transformed.
+	// This can reduce the amount of unnecessary scrolling caused by invisible parts.
 
-	Size2 size = get_size();
-	Rect2 other_rect = other_in_this.xform(Rect2(Point2(), p_control->get_size()));
+	scroll_diff = Vector2(); // Clear the cache.
 
-	float side_margin = v_scroll->is_visible() ? v_scroll->get_size().x : 0.0f;
-	float bottom_margin = h_scroll->is_visible() ? h_scroll->get_size().y : 0.0f;
+	Control *target = p_control;
+	Transform2D target_in_sc;
 
-	Vector2 diff = Vector2(MAX(MIN(other_rect.position.x - (is_layout_rtl() ? side_margin : 0.0f), 0.0f), other_rect.position.x + other_rect.size.x - size.x + (!is_layout_rtl() ? side_margin : 0.0f)),
-			MAX(MIN(other_rect.position.y, 0.0f), other_rect.position.y + other_rect.size.y - size.y + bottom_margin));
+	// The rect of the visible area of p_control.
+	Rect2 target_rect_local = Rect2(Point2(), p_control->get_size());
 
-	set_h_scroll(get_h_scroll() + diff.x);
-	set_v_scroll(get_v_scroll() + diff.y);
+	CanvasItem *parent_item = p_control->get_parent_item();
+	while (parent_item) {
+		ScrollContainer *sc = Object::cast_to<ScrollContainer>(parent_item);
+		parent_item = parent_item->get_parent_item();
+
+		if (!sc) {
+			continue;
+		}
+
+		// The transformation of the target in sc.
+		target_in_sc = (sc->get_global_transform().affine_inverse() * target->get_global_transform()) * target_in_sc;
+
+		if (sc == this) {
+			break;
+		}
+
+		target = sc;
+
+		if (following) {
+			// For nested cases, the inner ScrollContainer will first call this method, but the control will not be transformed immediately.
+			// Here we need to take into account the transform that will be applied by the inner ScrollContainer scrolling.
+			target_in_sc = target_in_sc.translated(-sc->scroll_diff);
+		}
+
+		const Rect2 rect = sc->_get_local_visible_rect();
+		target_rect_local = target_rect_local.intersection_transformed(target_in_sc.affine_inverse(), rect);
+
+		if (!target_rect_local.has_area()) {
+			ERR_FAIL_MSG("Unable to make the control visible because it is obscured by the inner ScrollContainer.");
+		}
+	}
+
+	// Calculates the amount to scroll in this ScrollContainer.
+
+	const Rect2 visible_rect = _get_local_visible_rect();
+	const Rect2 target_rect = target_in_sc.xform(target_rect_local);
+
+	Vector2 begin_diff = target_rect.position - visible_rect.position;
+	Vector2 end_diff = target_rect.get_end() - visible_rect.get_end();
+
+	for (int axis = 0; axis < 2; axis++) {
+		if (visible_rect.size[axis] > target_rect.size[axis]) {
+			scroll_diff[axis] = (begin_diff[axis] <= 0.0f) ? begin_diff[axis] : ((end_diff[axis] <= 0.0f) ? 0.0f : end_diff[axis]);
+		} else {
+			scroll_diff[axis] = (begin_diff[axis] >= 0.0f) ? begin_diff[axis] : ((end_diff[axis] >= 0.0f) ? 0.0f : end_diff[axis]);
+		}
+	}
+
+	// In skewed or rotated case, check if more scrolling is needed.
+	if ((Math::is_zero_approx(target_in_sc.columns[0][1]) || Math::is_zero_approx(target_in_sc.columns[1][0])) &&
+			((Math::is_zero_approx(target_in_sc.columns[0][0]) || Math::is_zero_approx(target_in_sc.columns[1][1])))) {
+		// Check for intersection after scrolling is applied.
+		Transform2D t_scrolled = target_in_sc.translated(-scroll_diff).affine_inverse();
+		Rect2 rect_scrolled = t_scrolled.xform(visible_rect);
+		if (!target_rect_local.intersects(rect_scrolled)) {
+			// Pan the ScrollContainer to make part of the control visible.
+			begin_diff = rect_scrolled.position - target_rect_local.position;
+			end_diff = rect_scrolled.get_end() - target_rect_local.get_end();
+
+			for (int axis = 0; axis < 2; axis++) {
+				if (target_rect_local.size[axis] > rect_scrolled.size[axis]) {
+					scroll_diff[axis] = (begin_diff[axis] <= 0.0f) ? begin_diff[axis] : ((end_diff[axis] <= 0.0f) ? 0.0f : end_diff[axis]);
+				} else {
+					scroll_diff[axis] = (begin_diff[axis] >= 0.0f) ? begin_diff[axis] : ((end_diff[axis] >= 0.0f) ? 0.0f : end_diff[axis]);
+				}
+			}
+
+			t_scrolled = t_scrolled.translated(-scroll_diff).affine_inverse();
+
+			scroll_diff = target_rect.position - t_scrolled.xform(target_rect_local).position;
+		}
+	}
+
+	set_h_scroll(get_h_scroll() + scroll_diff.x);
+	set_v_scroll(get_v_scroll() + scroll_diff.y);
 }
 
 void ScrollContainer::_reposition_children() {

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -92,6 +92,9 @@ private:
 	ScrollHintMode scroll_hint_mode = SCROLL_HINT_MODE_DISABLED;
 	bool tile_scroll_hint = false;
 
+	bool following = false;
+	Vector2 scroll_diff;
+
 	struct ThemeCache {
 		Ref<StyleBox> panel_style;
 		Ref<StyleBox> focus_style;
@@ -118,6 +121,8 @@ private:
 	bool child_has_focus();
 
 	Size2 _get_minimum_size(bool p_use_desired_sizes) const;
+
+	Rect2 _get_local_visible_rect() const;
 
 protected:
 	Size2 get_minimum_size() const override;

--- a/tests/core/math/test_rect2.cpp
+++ b/tests/core/math/test_rect2.cpp
@@ -159,6 +159,104 @@ TEST_CASE("[Rect2] Intersection") {
 			"intersection() with non-enclosed Rect2 should return the expected result.");
 }
 
+TEST_CASE("[Rect2] Intersection with the transformed rect") {
+	Rect2 rect = Rect2(0, 100, 400, 300);
+	SUBCASE("Translated") {
+		Transform2D xform = Transform2D(0.0f, Point2(100, 100));
+
+		SUBCASE("intersection_transformed() with fully enclosed Rect2") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(0, 100, 100, 100)).is_equal_approx(Rect2(100, 200, 100, 100)));
+		}
+		SUBCASE("intersection_transformed() with partially enclosed Rect2") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(250, 150, 100, 100)).is_equal_approx(Rect2(350, 250, 50, 100)));
+		}
+		SUBCASE("intersection_transformed() with non-enclosed Rect2") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(350, 350, 100, 100)).is_equal_approx(Rect2()));
+		}
+		SUBCASE("intersection_transformed when fully enclosed") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(-150, -50, 500, 400)).is_equal_approx(rect));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(-150, -50, 500, 400)).is_equal_approx(rect.intersection(xform.xform(Rect2(-150, -50, 500, 400)))));
+		}
+		SUBCASE("intersection_transformed with no enclosed point") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(0, -150, 100, 500)).is_equal_approx(Rect2(100, 100, 100, 300)));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(0, -150, 100, 500)).is_equal_approx(rect.intersection(xform.xform(Rect2(0, -150, 100, 500)))));
+		}
+	}
+	SUBCASE("Scaled") {
+		Transform2D xform = Transform2D(0.0f, Size2(2.0f, 2.0f), 0.0f, Point2(0, 0));
+
+		SUBCASE("intersection_transformed() with fully enclosed Rect2") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(50, 75, 100, 100)).is_equal_approx(Rect2(100, 150, 200, 200)));
+		}
+		SUBCASE("intersection_transformed() with partially enclosed Rect2") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(175, 150, 100, 100)).is_equal_approx(Rect2(350, 300, 50, 100)));
+		}
+		SUBCASE("intersection_transformed() with non-enclosed Rect2") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(250, 220, 100, 100)).is_equal_approx(Rect2()));
+		}
+		SUBCASE("intersection_transformed when fully enclosed") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(-100, -50, 500, 400)).is_equal_approx(rect));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(-100, -50, 500, 400)).is_equal_approx(rect.intersection(xform.xform(Rect2(-100, -50, 500, 400)))));
+		}
+	}
+	SUBCASE("Rotated") {
+		Transform2D xform = Transform2D(Math::PI / 4, Point2());
+
+		SUBCASE("intersection_transformed() with fully enclosed Rect2") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(100, 50, 20, 20)).is_equal_approx(Rect2(15 * Math::SQRT2, 75 * Math::SQRT2, 20 * Math::SQRT2, 20 * Math::SQRT2)));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(100, 50, 20, 20)).is_equal_approx(rect.intersection(xform.xform(Rect2(100, 50, 20, 20)))));
+		}
+		SUBCASE("intersection_transformed() with partially enclosed Rect2") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(80, 90, 20, 20)).is_equal_approx(Rect2(0, 90 * Math::SQRT2, 5 * Math::SQRT2, 10 * Math::SQRT2)));
+			CHECK_UNARY_FALSE(rect.intersection_transformed(xform, Rect2(80, 90, 20, 20)).is_equal_approx(rect.intersection(xform.xform(Rect2(80, 90, 20, 20)))));
+		}
+		SUBCASE("intersection_transformed() with non-enclosed Rect2") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(575, -50, 100, 100)).is_equal_approx(Rect2()));
+			CHECK_UNARY_FALSE(rect.intersection_transformed(xform, Rect2(575, -50, 100, 100)).is_equal_approx(rect.intersection(xform.xform(Rect2(575, -50, 100, 100)))));
+		}
+		SUBCASE("intersection_transformed when fully enclosed") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(0, -250, 600, 600)).is_equal_approx(rect));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(0, -250, 600, 600)).is_equal_approx(rect.intersection(xform.xform(Rect2(0, -250, 600, 600)))));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(0, -250, 1000, 1000)).is_equal_approx(rect));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(0, -250, 1000, 1000)).is_equal_approx(rect.intersection(xform.xform(Rect2(0, -250, 1000, 1000)))));
+		}
+		SUBCASE("intersection_transformed with no enclosed point") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(75, 25, 500, 10)).is_equal_approx(Rect2(100 - 35 * Math::SQRT2, 100, 300 + 10 * Math::SQRT2, 300)));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(-50, -100, 600, 10)).is_equal_approx(Rect2(100 + 90 * Math::SQRT2, 100, 300 - 90 * Math::SQRT2, 300 - 90 * Math::SQRT2)));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(-50, -100, 1000, 10)).is_equal_approx(Rect2(100 + 90 * Math::SQRT2, 100, 300 - 90 * Math::SQRT2, 300 - 90 * Math::SQRT2)));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(-95, -100, 600, 10)).is_equal_approx(Rect2(100 + 90 * Math::SQRT2, 100, 300 - 90 * Math::SQRT2, 300 - 90 * Math::SQRT2)));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(-95, -100, 1000, 10)).is_equal_approx(Rect2(100 + 90 * Math::SQRT2, 100, 300 - 90 * Math::SQRT2, 300 - 90 * Math::SQRT2)));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(-200, -100, 1000, 10)).is_equal_approx(Rect2(100 + 90 * Math::SQRT2, 100, 300 - 90 * Math::SQRT2, 300 - 90 * Math::SQRT2)));
+		}
+	}
+	SUBCASE("Skewed") {
+		Transform2D xform = Transform2D(0, Size2(1, 1), Math::PI / 4, Vector2(0, 0));
+
+		SUBCASE("intersection_transformed() with fully enclosed Rect2") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(300, 200, 100, 50)).is_equal_approx(Rect2(300 - 125 * Math::SQRT2, 100 * Math::SQRT2, 100 + 25 * Math::SQRT2, 25 * Math::SQRT2)));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(300, 200, 100, 50)).is_equal_approx(rect.intersection(xform.xform(Rect2(300, 200, 100, 50)))));
+		}
+		SUBCASE("intersection_transformed() with partially enclosed Rect2") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(550, 200, 100, 50)).is_equal_approx(Rect2(550 - 125 * Math::SQRT2, 150, -150 + 125 * Math::SQRT2, -150 + 125 * Math::SQRT2)));
+			CHECK_UNARY_FALSE(rect.intersection_transformed(xform, Rect2(550, 200, 100, 50)).is_equal_approx(rect.intersection(xform.xform(Rect2(550, 200, 100, 50)))));
+		}
+		SUBCASE("intersection_transformed() with non-enclosed Rect2") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(810, 550, 100, 50)).is_equal_approx(Rect2()));
+			CHECK_UNARY_FALSE(rect.intersection_transformed(xform, Rect2(810, 550, 100, 50)).is_equal_approx(rect.intersection(xform.xform(Rect2(810, 550, 100, 50)))));
+		}
+		SUBCASE("intersection_transformed when fully enclosed") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(0, 0, 2000, 1000)).is_equal_approx(rect));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(0, 0, 2000, 1000)).is_equal_approx(rect.intersection(xform.xform(Rect2(0, 0, 2000, 1000)))));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(-3000, 0, 4000, 3000)).is_equal_approx(rect));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(-3000, 0, 4000, 3000)).is_equal_approx(rect.intersection(xform.xform(Rect2(-3000, 0, 4000, 3000)))));
+		}
+		SUBCASE("intersection_transformed with no enclosed point") {
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(-150, 130, 600, 450)).is_equal_approx(Rect2(0, 100, 350, 300)));
+			CHECK_UNARY(rect.intersection_transformed(xform, Rect2(450, 130, 600, 450)).is_equal_approx(Rect2(50, 100, 350, 300)));
+		}
+	}
+}
+
 TEST_CASE("[Rect2] Enclosing") {
 	CHECK_MESSAGE(
 			Rect2(0, 100, 1280, 720).encloses(Rect2(0, 300, 100, 100)),

--- a/tests/scene/test_scroll_container.cpp
+++ b/tests/scene/test_scroll_container.cpp
@@ -355,89 +355,123 @@ TEST_CASE("[SceneTree][ScrollContainer] Scroll values and property setters") {
 }
 
 TEST_CASE("[SceneTree][ScrollContainer] ensure_control_visible and follow_focus") {
+	const Size2 container_size = Size2(100, 100);
 	ScrollContainer *test_container = memnew(ScrollContainer);
+	test_container->set_size(container_size);
 	Window *root = SceneTree::get_singleton()->get_root();
 	root->add_child(test_container);
 
 	Control *content_control = memnew(Control);
-	content_control->set_custom_minimum_size(Size2(300, 300));
+	content_control->set_custom_minimum_size(Size2(1000, 1000));
 	test_container->add_child(content_control);
 
 	Control *target_control = memnew(Control);
 	target_control->set_focus_mode(Control::FOCUS_ALL);
-	target_control->set_custom_minimum_size(Size2(20, 20));
-	target_control->set_position(Point2(260, 250));
-	target_control->set_size(Size2(20, 20));
+
 	content_control->add_child(target_control);
 
-	test_container->set_size(Size2(100, 100));
-	test_container->set_h_scroll(0);
-	test_container->set_v_scroll(0);
+	REQUIRE_EQ(test_container->get_h_scroll(), 0);
+	REQUIRE_EQ(test_container->get_v_scroll(), 0);
+
 	SceneTree::get_singleton()->process(0);
 
-	CHECK_MESSAGE(
-			test_container->get_h_scroll() == 0,
-			"Horizontal scroll starts at 0 for this setup.");
+	const Point2 initial_scroll = Point2(450, 450);
+	test_container->set_h_scroll(initial_scroll.x);
+	test_container->set_v_scroll(initial_scroll.y);
 
-	CHECK_MESSAGE(
-			test_container->get_v_scroll() == 0,
-			"Vertical scroll starts at 0 for this setup.");
-
-	test_container->ensure_control_visible(target_control);
 	SceneTree::get_singleton()->process(0);
+	REQUIRE_EQ(test_container->get_h_scroll(), initial_scroll.x);
+	REQUIRE_EQ(test_container->get_v_scroll(), initial_scroll.y);
+	REQUIRE_UNARY(test_container->get_h_scroll_bar()->is_visible_in_tree());
+	REQUIRE_UNARY(test_container->get_v_scroll_bar()->is_visible_in_tree());
+	REQUIRE_UNARY_FALSE(test_container->is_following_focus());
+	REQUIRE_UNARY_FALSE(target_control->has_focus());
 
-	CHECK_MESSAGE(
-			test_container->get_h_scroll() > 0,
-			"ensure_control_visible() scrolls horizontally when target control is outside the visible area.");
+	SUBCASE("No scrolling when focused by default") {
+		target_control->grab_focus();
+		REQUIRE_UNARY(target_control->has_focus());
+		CHECK_EQ(test_container->get_h_scroll(), initial_scroll.x);
+		CHECK_EQ(test_container->get_v_scroll(), initial_scroll.y);
+	}
 
-	CHECK_MESSAGE(
-			test_container->get_v_scroll() > 0,
-			"ensure_control_visible() scrolls vertically when target control is outside the visible area.");
+	SUBCASE("Scrolling when ensure control visible by default") {
+		test_container->ensure_control_visible(target_control);
+		CHECK_EQ(test_container->get_h_scroll(), 0);
+		CHECK_EQ(test_container->get_v_scroll(), 0);
+	}
 
-	Rect2 target_rect(target_control->get_position(), target_control->get_size());
-	real_t side_margin = test_container->get_v_scroll_bar()->is_visible() ? test_container->get_v_scroll_bar()->get_size().x : 0.0f;
-	real_t bottom_margin = test_container->get_h_scroll_bar()->is_visible() ? test_container->get_h_scroll_bar()->get_size().y : 0.0f;
-	real_t visible_left = test_container->get_h_scroll();
-	real_t visible_top = test_container->get_v_scroll();
-	real_t visible_right = visible_left + test_container->get_size().x - side_margin;
-	real_t visible_bottom = visible_top + test_container->get_size().y - bottom_margin;
-
-	CHECK_MESSAGE(
-			(target_rect.position.x >= visible_left && (target_rect.position.x + target_rect.size.x) <= visible_right),
-			"ensure_control_visible() fully reveals target control horizontally.");
-
-	CHECK_MESSAGE(
-			(target_rect.position.y >= visible_top && (target_rect.position.y + target_rect.size.y) <= visible_bottom),
-			"ensure_control_visible() fully reveals target control vertically.");
-
-	test_container->set_h_scroll(0);
-	test_container->set_v_scroll(0);
 	test_container->set_follow_focus(true);
-	SceneTree::get_singleton()->process(0);
+	REQUIRE_UNARY(test_container->is_following_focus());
 
-	target_control->grab_focus();
-	SceneTree::get_singleton()->process(0);
+	const char *size_cases[2] = {
+		"The target control size is 50% of the container size",
+		"The target control size is 150% of the container size",
+	};
 
-	CHECK_MESSAGE(
-			test_container->get_h_scroll() > 0,
-			"follow_focus scrolls horizontally to focused descendants.");
+	const char *location_cases[9] = {
+		"Target control is in the upper left corner",
+		"Target control is directly above",
+		"Target control is in the upper right corner",
+		"Target control is on the left",
+		"Target control is in the center",
+		"Target control is on the right",
+		"Target control is in the lower left corner",
+		"Target control is directly below",
+		"Target control is in the lower right corner",
+	};
+	const Size2 scroll_bar_space = Size2(test_container->get_v_scroll_bar()->get_size().x, test_container->get_h_scroll_bar()->get_size().y);
 
-	CHECK_MESSAGE(
-			test_container->get_v_scroll() > 0,
-			"follow_focus scrolls vertically to focused descendants.");
+	for (int size_case_idx = 0; size_case_idx < 2; size_case_idx++) {
+		SUBCASE(size_cases[size_case_idx]) {
+			Size2 control_size = container_size / 2 + size_case_idx * container_size;
+			target_control->set_size(control_size);
+			REQUIRE_EQ(target_control->get_size(), control_size);
+			int size_flag = 2 * size_case_idx - 1; // Map 0~1 to -1~1.
 
-	visible_left = test_container->get_h_scroll();
-	visible_top = test_container->get_v_scroll();
-	visible_right = visible_left + test_container->get_size().x - side_margin;
-	visible_bottom = visible_top + test_container->get_size().y - bottom_margin;
+			for (int location_case_idx = 0; location_case_idx < 9; location_case_idx++) {
+				Point2i location_flag = Point2i(location_case_idx % 3 - 1, location_case_idx / 3 - 1);
+				// Ensure that the numeric type and the get_*_scroll value are of the same type.
+				Point2i control_position;
+				Point2i expected_scroll;
 
-	CHECK_MESSAGE(
-			(target_rect.position.x >= visible_left && (target_rect.position.x + target_rect.size.x) <= visible_right),
-			"follow_focus fully reveals focused target control horizontally.");
+				for (int axis = 0; axis < 2; axis++) {
+					real_t size_offset = (size_flag == -1) ? control_size[axis] / 2 : -control_size[axis] / 4; // The effect of size on offset.
+					control_position[axis] = initial_scroll[axis] + size_offset + location_flag[axis] * container_size[axis] * 3;
+					// The situation is reversed when the size is large versus when it is small.
+					const int com_flag = size_flag * location_flag[axis];
+					if (com_flag == 1) {
+						expected_scroll[axis] = control_position[axis];
+					} else if (com_flag == 0) {
+						expected_scroll[axis] = initial_scroll[axis];
+					} else if (com_flag == -1) {
+						expected_scroll[axis] = control_position[axis] + control_size[axis] - container_size[axis] + scroll_bar_space[axis];
+					}
+				}
+				SUBCASE(location_cases[location_case_idx]) {
+					target_control->set_position(control_position);
+					REQUIRE_EQ(target_control->get_position(), control_position);
 
-	CHECK_MESSAGE(
-			(target_rect.position.y >= visible_top && (target_rect.position.y + target_rect.size.y) <= visible_bottom),
-			"follow_focus fully reveals focused target control vertically.");
+					SUBCASE("Scrolling when grab focus") {
+						REQUIRE_EQ(test_container->get_h_scroll(), initial_scroll.x);
+						REQUIRE_EQ(test_container->get_v_scroll(), initial_scroll.y);
+						REQUIRE_UNARY_FALSE(target_control->has_focus());
+						target_control->grab_focus();
+						REQUIRE_UNARY(target_control->has_focus());
+						CHECK_EQ(test_container->get_h_scroll(), expected_scroll.x);
+						CHECK_EQ(test_container->get_v_scroll(), expected_scroll.y);
+					}
+
+					SUBCASE("Scrolling when ensure control visible") {
+						REQUIRE_EQ(test_container->get_h_scroll(), initial_scroll.x);
+						REQUIRE_EQ(test_container->get_v_scroll(), initial_scroll.y);
+						test_container->ensure_control_visible(target_control);
+						CHECK_EQ(test_container->get_h_scroll(), expected_scroll.x);
+						CHECK_EQ(test_container->get_v_scroll(), expected_scroll.y);
+					}
+				}
+			}
+		}
+	}
 
 	memdelete(target_control);
 	memdelete(content_control);


### PR DESCRIPTION
Ensure minimum scrolling and maximum visibility in a single axis.

When there is only one `ScrollContainer`, it behaves the same as https://github.com/godotengine/godot/issues/100695#issuecomment-2645755492. Add unit tests for this case.

For the case where `ScrollContainer` nesting exists, due to the occlusion of the internal `ScrollContainer`, the control may not be visible. 

The `ScrollContainer` with **follow focus** enabled will automatically adjust its own scroll value when the control is focused. The scrolling of each level of `ScrollContainer` needs to be considered during calculation.

TODO: For the case of rotation, it may be an edge case. Since the resulting `Rect2` may be enlarged after applying the rotation transformation, the resulting intersection `Rect2` is not accurate enough. The result may not be ideal in some extreme cases.

| | In ScrollContainer space | In control space |
| :----: | :------: |  :------: | 
|Image| ![001](https://github.com/user-attachments/assets/04123905-8739-487f-9d2d-315de386c1d0) |  ![002](https://github.com/user-attachments/assets/e2e2ea3a-b4db-4a09-91be-632c5ab49bee) | 
|The intersection rect| ABFG  |A'B'C'D|
| The ideal intersection rect | CEHI | DHJI |


`ScrollContainer`'s border is red. The control's border is blue. The polygon of the intersection is DHI. The intersection rect is larger than the ideal one.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
