### PR TITLE
SCons: Implement minor fixes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1082,11 +1082,11 @@ if "check_c_headers" in env:
     for header in headers:
         if conf.CheckCHeader(header):
             env.AppendUnique(CPPDEFINES=[headers[header]])
+conf.Finish()
 
-
-methods.show_progress(env)
-# TODO: replace this with `env.Dump(format="json")`
-# once we start requiring SCons 4.0 as min version.
-methods.dump(env)
-methods.prepare_purge(env)
-methods.prepare_timer()
+# Miscellaneous & post-build methods.
+if not env.GetOption("clean") and not env.GetOption("help"):
+    methods.dump(env)
+    methods.show_progress(env)
+    methods.prepare_purge(env)
+    methods.prepare_timer()


### PR DESCRIPTION
Integrates a handful of adjustments to the SCons buildsystem:
- Ensure scope of `Configure` is properly closed. This is "handled" automatically by SCons, but it recommends this practice & will prevent accidental breakage if wanting to further configure down the road.
- Wrap post-build functions behind check for `clean` and `help` commands, so they only run when it's appropriate.
- Use SCons 4.0+ implementation of dumping environment information
- Ensure initial warning for lack of progress percentage is shown
- Ensure elapsed time centiseconds won't crop leading zeros