### PR TITLE
Optimize `GDScriptLambdaCallable` by skipping the unnecessary `ObjectDB` lookup for `script`.

### DIFF
--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -45,7 +45,9 @@ bool GDScriptLambdaCallable::compare_less(const CallableCustom *p_a, const Calla
 }
 
 bool GDScriptLambdaCallable::is_valid() const {
-	return CallableCustom::is_valid() && function != nullptr;
+	// Don't need to call CallableCustom::is_valid():
+	// It just verifies our script exists, which we know to be true because it is RefCounted.
+	return function != nullptr;
 }
 
 uint32_t GDScriptLambdaCallable::hash() const {


### PR DESCRIPTION
For a [proposal](https://github.com/godotengine/godot-proposals/issues/11787), I profiled `Array.filter` calls.

11% of the time was spent on `GDScriptLambdaCallable::is_valid()`. I was able to optimize the function by skipping an unnecessary validation, speeding up the throughput of `Array.filter` by 10% (almost the full contribution of `is_valid`). This optimization affects all lambda calls, and thus functions operating on them.

The change should be safe for 4.4, but I'll let maintainers decide if they agree.

## Explanation

`GDScriptLambdaCallable::is_valid` holds its `script` as `Ref<GDScript>`. GDScript is `RefCounted`, so `GDScriptLambdaCallable` owns a reference to it. This guarantees that `script` is valid, and does not need to be further validated.