### PR TITLE
Skeleton3D/PhysicalBoneSimulator does not clean up internal state when removing bones, crashes on further updates.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -514,24 +514,6 @@ void ProjectSettings::_convert_to_last_version(int p_from_version) {
 			}
 		}
 	}
-	if (p_from_version == 5) {
-		// Converts the device in events from -3 to -1.
-		// -3 was introduced in GH-97707 as a way to prevent a clash in device IDs, but as reported in GH-99243, this leads to problems.
-		// -3 was used during dev-releases, so this conversion helps to revert such affected projects.
-		// This conversion doesn't affect any other projects, since -3 is not used otherwise.
-		for (KeyValue<StringName, ProjectSettings::VariantContainer> &E : props) {
-			if (String(E.key).begins_with("input/")) {
-				Dictionary action = E.value.variant;
-				Array events = action["events"];
-				for (int i = 0; i < events.size(); i++) {
-					Ref<InputEvent> ev = events[i];
-					if (ev.is_valid() && ev->get_device() == -3) {
-						ev->set_device(-1);
-					}
-				}
-			}
-		}
-	}
 #endif // DISABLE_DEPRECATED
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2057,45 +2057,7 @@ void EditorNode::try_autosave() {
 }
 
 void EditorNode::restart_editor(bool p_goto_project_manager) {
-	exiting = true;
-
-	if (project_run_bar->is_playing()) {
-		project_run_bar->stop_playing();
-	}
-
-	String to_reopen;
-	if (!p_goto_project_manager && get_tree()->get_edited_scene_root()) {
-		to_reopen = get_tree()->get_edited_scene_root()->get_scene_file_path();
-	}
-
-	_exit_editor(EXIT_SUCCESS);
-
-	List<String> args;
-	for (const String &a : Main::get_forwardable_cli_arguments(Main::CLI_SCOPE_TOOL)) {
-		args.push_back(a);
-	}
-
-	if (p_goto_project_manager) {
-		args.push_back("--project-manager");
-
-		// Setup working directory.
-		const String exec_dir = OS::get_singleton()->get_executable_path().get_base_dir();
-		if (!exec_dir.is_empty()) {
-			args.push_back("--path");
-			args.push_back(exec_dir);
-		}
-	} else {
-		args.push_back("--path");
-		args.push_back(ProjectSettings::get_singleton()->get_resource_path());
-
-		args.push_back("-e");
-	}
-
-	if (!to_reopen.is_empty()) {
-		args.push_back(to_reopen);
-	}
-
-	OS::get_singleton()->set_restart_on_exit(true, args);
+	_menu_option_confirm(p_goto_project_manager ? PROJECT_QUIT_TO_PROJECT_MANAGER : PROJECT_RELOAD_CURRENT_PROJECT, false);
 }
 
 void EditorNode::_save_all_scenes() {
@@ -3480,10 +3442,10 @@ void EditorNode::_discard_changes(const String &p_str) {
 
 		} break;
 		case PROJECT_QUIT_TO_PROJECT_MANAGER: {
-			restart_editor(true);
+			_restart_editor(true);
 		} break;
 		case PROJECT_RELOAD_CURRENT_PROJECT: {
-			restart_editor();
+			_restart_editor();
 		} break;
 	}
 }
@@ -5508,11 +5470,11 @@ bool EditorNode::has_scenes_in_session() {
 }
 
 void EditorNode::undo() {
-	trigger_menu_option(FILE_UNDO, true);
+	_menu_option_confirm(FILE_UNDO, true);
 }
 
 void EditorNode::redo() {
-	trigger_menu_option(FILE_REDO, true);
+	_menu_option_confirm(FILE_REDO, true);
 }
 
 bool EditorNode::ensure_main_scene(bool p_from_native) {
@@ -5678,6 +5640,48 @@ void EditorNode::_proceed_closing_scene_tabs() {
 
 bool EditorNode::_is_closing_editor() const {
 	return tab_closing_menu_option == FILE_QUIT || tab_closing_menu_option == PROJECT_QUIT_TO_PROJECT_MANAGER || tab_closing_menu_option == PROJECT_RELOAD_CURRENT_PROJECT;
+}
+
+void EditorNode::_restart_editor(bool p_goto_project_manager) {
+	exiting = true;
+
+	if (project_run_bar->is_playing()) {
+		project_run_bar->stop_playing();
+	}
+
+	String to_reopen;
+	if (!p_goto_project_manager && get_tree()->get_edited_scene_root()) {
+		to_reopen = get_tree()->get_edited_scene_root()->get_scene_file_path();
+	}
+
+	_exit_editor(EXIT_SUCCESS);
+
+	List<String> args;
+	for (const String &a : Main::get_forwardable_cli_arguments(Main::CLI_SCOPE_TOOL)) {
+		args.push_back(a);
+	}
+
+	if (p_goto_project_manager) {
+		args.push_back("--project-manager");
+
+		// Setup working directory.
+		const String exec_dir = OS::get_singleton()->get_executable_path().get_base_dir();
+		if (!exec_dir.is_empty()) {
+			args.push_back("--path");
+			args.push_back(exec_dir);
+		}
+	} else {
+		args.push_back("--path");
+		args.push_back(ProjectSettings::get_singleton()->get_resource_path());
+
+		args.push_back("-e");
+	}
+
+	if (!to_reopen.is_empty()) {
+		args.push_back(to_reopen);
+	}
+
+	OS::get_singleton()->set_restart_on_exit(true, args);
 }
 
 void EditorNode::_scene_tab_closed(int p_tab) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -624,6 +624,7 @@ private:
 
 	void _proceed_closing_scene_tabs();
 	bool _is_closing_editor() const;
+	void _restart_editor(bool p_goto_project_manager = false);
 
 	Dictionary _get_main_scene_state();
 	void _set_main_scene_state(Dictionary p_state, Node *p_for_scene);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -103,14 +103,6 @@ bool EditorSettings::_set_only(const StringName &p_name, const Variant &p_value)
 
 			builtin_action_overrides[action_name].clear();
 			for (int ev_idx = 0; ev_idx < events.size(); ev_idx++) {
-#ifndef DISABLE_DEPRECATED
-				// -3 was introduced in GH-97707 as a way to prevent a clash in device IDs, but as reported in GH-99243, this leads to problems.
-				// -3 was used during dev-releases, so this conversion helps to revert such affected editor shortcuts.
-				Ref<InputEvent> x = events[ev_idx];
-				if (x.is_valid() && x->get_device() == -3) {
-					x->set_device(-1);
-				}
-#endif // DISABLE_DEPRECATED
 				im->action_add_event(action_name, events[ev_idx]);
 				builtin_action_overrides[action_name].push_back(events[ev_idx]);
 			}

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -74,7 +74,8 @@ void VideoStreamPlaybackTheora::video_write(th_ycbcr_buffer yuv) {
 		yuv420_2_rgb8888((uint8_t *)dst, (uint8_t *)yuv[0].data + y_offset, (uint8_t *)yuv[1].data + uv_offset, (uint8_t *)yuv[2].data + uv_offset, region.size.x, region.size.y, yuv[0].stride, yuv[1].stride, region.size.x << 2);
 	}
 
-	Ref<Image> img = memnew(Image(region.size.x, region.size.y, false, Image::FORMAT_RGBA8, frame_data)); //zero copy image creation
+	Ref<Image> img;
+	img.instantiate(region.size.x, region.size.y, false, Image::FORMAT_RGBA8, frame_data); //zero copy image creation
 
 	texture->update(img); //zero copy send to rendering server
 }

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -41,27 +41,20 @@
 
 class ImageTexture;
 
-//#define THEORA_USE_THREAD_STREAMING
-
 class VideoStreamPlaybackTheora : public VideoStreamPlayback {
 	GDCLASS(VideoStreamPlaybackTheora, VideoStreamPlayback);
 
-	enum {
-		MAX_FRAMES = 4,
-	};
-
-	//Image frames[MAX_FRAMES];
 	Image::Format format = Image::Format::FORMAT_L8;
 	Vector<uint8_t> frame_data;
 	int frames_pending = 0;
 	Ref<FileAccess> file;
 	String file_name;
-	int audio_frames_wrote = 0;
 	Point2i size;
+	Rect2i region;
 
 	int buffer_data();
 	int queue_page(ogg_page *page);
-	void video_write();
+	void video_write(th_ycbcr_buffer yuv);
 	double get_time() const;
 
 	bool theora_eos = false;
@@ -79,42 +72,29 @@ class VideoStreamPlaybackTheora : public VideoStreamPlayback {
 	vorbis_block vb;
 	vorbis_comment vc;
 	th_pixel_fmt px_fmt;
-	double videobuf_time = 0;
-	int pp_inc = 0;
+	double frame_duration;
 
 	int theora_p = 0;
 	int vorbis_p = 0;
 	int pp_level_max = 0;
 	int pp_level = 0;
-	int videobuf_ready = 0;
+	int pp_inc = 0;
 
 	bool playing = false;
 	bool buffering = false;
+	bool paused = false;
 
-	double last_update_time = 0;
+	bool dup_frame = false;
+	bool video_ready = false;
+	bool video_done = false;
+	bool audio_done = false;
+
 	double time = 0;
+	double next_frame_time = 0;
+	double current_frame_time = 0;
 	double delay_compensation = 0;
 
 	Ref<ImageTexture> texture;
-
-	bool paused = false;
-
-#ifdef THEORA_USE_THREAD_STREAMING
-
-	enum {
-		RB_SIZE_KB = 1024
-	};
-
-	RingBuffer<uint8_t> ring_buffer;
-	Vector<uint8_t> read_buffer;
-	bool thread_eof = false;
-	Semaphore *thread_sem = nullptr;
-	Thread thread;
-	SafeFlag thread_exit;
-
-	static void _streaming_thread(void *ud);
-
-#endif
 
 	int audio_track = 0;
 

--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -735,6 +735,9 @@ class SampleNode {
 	 * @returns {void}
 	 */
 	_pause() {
+		if (!this.isStarted) {
+			return;
+		}
 		this.isPaused = true;
 		this.pauseTime = (GodotAudio.ctx.currentTime - this._sourceStartTime) / this.getPlaybackRate();
 		this._source.stop();

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1646,7 +1646,6 @@ DisplayServer::WindowID DisplayServerWindows::create_sub_window(WindowMode p_mod
 		rendering_device->screen_create(window_id);
 	}
 #endif
-	wd.initialized = true;
 	return window_id;
 }
 
@@ -1674,6 +1673,7 @@ void DisplayServerWindows::show_window(WindowID p_id) {
 	if (p_id != MAIN_WINDOW_ID) {
 		_update_window_style(p_id);
 	}
+	wd.initialized = true;
 
 	if (wd.maximized) {
 		ShowWindow(wd.hWnd, SW_SHOWMAXIMIZED);
@@ -6998,7 +6998,6 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 		}
 	}
 
-	windows[MAIN_WINDOW_ID].initialized = true;
 	show_window(MAIN_WINDOW_ID);
 
 #if defined(RD_ENABLED)

--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -755,7 +755,7 @@ void PhysicalBone3D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_PARENTED:
 			break;
-		
+
 		// ESTEE: We need to wait until the bone has finished
 		// being added to the tree or none of the global transform
 		// calls will work correctly

--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -754,6 +754,12 @@ void PhysicalBone3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_PARENTED:
+			break;
+		
+		// ESTEE: We need to wait until the bone has finished
+		// being added to the tree or none of the global transform
+		// calls will work correctly
+		case NOTIFICATION_POST_ENTER_TREE:
 			_update_simulator_path();
 			update_bone_id();
 			reset_to_rest_position();
@@ -763,6 +769,9 @@ void PhysicalBone3D::_notification(int p_what) {
 			}
 			break;
 
+		// If we're detached from the skeleton we need to
+		// clear our references to it.
+		case NOTIFICATION_UNPARENTED:
 		case NOTIFICATION_EXIT_TREE: {
 			PhysicalBoneSimulator3D *simulator = get_simulator();
 			if (simulator) {

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -621,12 +621,6 @@ int Skeleton3D::add_bone(const String &p_name) {
 	Bone b;
 	b.name = p_name;
 	bones.push_back(b);
-
-	// update ancellary data, see also: clear_bones()
-	bone_global_pose_dirty.push_back(true);
-	// ESTEE: this seems to work set to zero, but I'm not sure it is correct.
-	nested_set_offset_to_bone_index.push_back(0);
-
 	int new_idx = bones.size() - 1;
 	name_to_bone_index.insert(p_name, new_idx);
 	process_order_dirty = true;
@@ -845,9 +839,7 @@ void Skeleton3D::clear_bones() {
 	bones.clear();
 	name_to_bone_index.clear();
 
-	// clear ancellary data when bones are cleared,
-	// without this we end up with cache mismatches
-	// see also: add_bone()
+	// All these structures contain references to now invalid bone indices.
 	skin_bindings.clear();
 	bone_global_pose_dirty.clear();
 	parentless_bones.clear();
@@ -1105,6 +1097,9 @@ void Skeleton3D::force_update_bone_children_transforms(int p_bone_idx) {
 void Skeleton3D::_force_update_bone_children_transforms(int p_bone_idx) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone_idx, bone_size);
+
+	// from https://github.com/detomon/godot/commit/5203489d6c10945a35bbb82b149a4d32b25ab7b8
+	_update_process_order();
 
 	Bone *bonesptr = bones.ptr();
 

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -621,6 +621,12 @@ int Skeleton3D::add_bone(const String &p_name) {
 	Bone b;
 	b.name = p_name;
 	bones.push_back(b);
+
+	// update ancellary data, see also: clear_bones()
+	bone_global_pose_dirty.push_back(true);
+	// ESTEE: this seems to work set to zero, but I'm not sure it is correct.
+	nested_set_offset_to_bone_index.push_back(0);
+
 	int new_idx = bones.size() - 1;
 	name_to_bone_index.insert(p_name, new_idx);
 	process_order_dirty = true;
@@ -838,6 +844,15 @@ bool Skeleton3D::is_show_rest_only() const {
 void Skeleton3D::clear_bones() {
 	bones.clear();
 	name_to_bone_index.clear();
+	
+	// clear ancellary data when bones are cleared,
+	// without this we end up with cache mismatches
+	// see also: add_bone()
+	skin_bindings.clear();
+	bone_global_pose_dirty.clear();
+	parentless_bones.clear();
+	nested_set_offset_to_bone_index.clear();
+
 	process_order_dirty = true;
 	version++;
 	_make_dirty();

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -844,7 +844,7 @@ bool Skeleton3D::is_show_rest_only() const {
 void Skeleton3D::clear_bones() {
 	bones.clear();
 	name_to_bone_index.clear();
-	
+
 	// clear ancellary data when bones are cleared,
 	// without this we end up with cache mismatches
 	// see also: add_bone()

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -670,9 +670,18 @@ private:
 	TreeItem *_search_item_text(TreeItem *p_at, const String &p_find, int *r_col, bool p_selectable, bool p_backwards = false);
 
 	TreeItem *_find_item_at_pos(TreeItem *p_item, const Point2 &p_pos, int &r_column, int &r_height, int &r_section) const;
-	int _get_item_h_offset(TreeItem *p_item) const;
 
-	void _find_button_at_pos(const Point2 &p_pos, TreeItem *&r_item, int &r_column, int &r_index) const;
+	void _find_button_at_pos(const Point2 &p_pos, TreeItem *&r_item, int &r_column, int &r_index, int &r_section) const;
+
+	struct FindColumnButtonResult {
+		int column_index = -1;
+		int button_index = -1;
+		int column_width = -1;
+		int column_offset = -1;
+		int pos_x = -1;
+	};
+
+	FindColumnButtonResult _find_column_and_button_at_pos(int p_x, const TreeItem *p_item, int p_x_ofs, int p_x_limit) const;
 
 	/*	float drag_speed;
 	float drag_accum;

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -158,6 +158,7 @@ void VideoStreamPlayer::_notification(int p_notification) {
 			playback->update(delta); // playback->is_playing() returns false in the last video frame
 
 			if (!playback->is_playing()) {
+				resampler.flush();
 				if (loop) {
 					play();
 					return;

--- a/servers/audio/audio_rb_resampler.h
+++ b/servers/audio/audio_rb_resampler.h
@@ -86,7 +86,7 @@ public:
 		} else if (w < r) {
 			space = r - w - 1;
 		} else {
-			space = (rb_len - r) + w - 1;
+			space = rb_len - w + r - 1;
 		}
 
 		return space;

--- a/servers/audio/audio_rb_resampler.h
+++ b/servers/audio/audio_rb_resampler.h
@@ -86,7 +86,7 @@ public:
 		} else if (w < r) {
 			space = r - w - 1;
 		} else {
-			space = rb_len - w + r - 1;
+			space = (rb_len - w) + (r - 1);
 		}
 
 		return space;


### PR DESCRIPTION
# Skeleton3D/PhysicalBoneSimulator does not clean up internal state when removing bones
- Reproduced in 4.3, 4.4b3
- Windows 11, Godot-4.4beta3

## Description
There is a bug which prevents dynamically removing and then adding bones to a skeleton.

The use case for dynamically constructing skeletons is in creating generative creatures, mechanism, and so on.
For my example, I use a ball and chain simulation with dynamic number of links. The scene componentry builds a chain link up from a link template and a ball template. This repo is a test case for demonstrating the behavior.

The Chain.gd file creates a ball-and-chain simulation with a dynamic number of links that can be changed directly within the editor. It is the only script file of interest for the project.

# Project for reproducing:
[https://github.com/mikest/godot-chain/](https://github.com/mikest/godot-chain/)

## Steps to reproduce crash
1. Open project.
2. Open Scene "Chain.tscn". You should see a monkey head on a chain.
3. Select the root node.
4. In the properties panel there is a counter for the number of chain links.
5. Increase the counter by one.

## Results:
1. Editor segfaults and exits.

# Investigation
`Skeleton3D`, `PhysicalBoneSimulator3D`, and `PhysicalBone3D` all maintain a set of internal caching structures that appear to be there as speed optimizations. These caching structures are not properly kept in sync when removing physical bones or when calling `Skeleton3D::clear_bones()` to remove logical bones. In most cases, this results in numerous errors logged in the console, but on occasion, it can also result in crashes.

This PR is an attempt to reduce those errors and to reduce the conditions which trigger spurious console logging from cache size misses due to stale cache data.

To address this, I included more cache invalidation in `Skeleton3D::clear_bones()`.

I also fixed cache sync problems with the `bone_global_pose_dirty` and `nested_set_offset_to_bone_index` in `Skeleton3D::add_bone(const String &p_name)`.

Many of the logging errors that arrise after removing and adding a bone are due to caches being rebuilt before the `PhysicalBone3D` has been added to the tree. I have moved the cache rebuild to `NOTIFICATION_POST_ENTER_TREE`. This fixes the errors from `_reload_joints`.

The last change I made was to the `PhysicalBoneSimulator3D::_pose_updated()` call, which when detecting a cache size mismatch between the skeleton bone count and the internal `bones` cache will rebuild it. This happens when a physical bone is still attached and the Skeleton clears the bones and then rebuilds them to a different size. The simulator will make pose updates and cause cache misses.


## Related Issues
Fix error spam at start with Skeleton3D modifiers #102030
https://github.com/godotengine/godot/pull/102030

_NOTE: I'm not terribly familiar with the godot internals and this is my first PR, so extra attention is probably warranted._



