### PR TITLE
Add notes to AStar2D and AStar3D documentation

### DIFF
--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -279,6 +279,7 @@
 			<param index="0" name="num_nodes" type="int" />
 			<description>
 				Reserves space internally for [param num_nodes] points. Useful if you're adding a known large number of points at once, such as points on a grid. The new capacity must be greater or equal to the old capacity.
+				[b]Note:[/b] The default point capacity is 64.
 			</description>
 		</method>
 		<method name="set_point_disabled">

--- a/doc/classes/AStar3D.xml
+++ b/doc/classes/AStar3D.xml
@@ -319,6 +319,7 @@
 			<param index="0" name="num_nodes" type="int" />
 			<description>
 				Reserves space internally for [param num_nodes] points. Useful if you're adding a known large number of points at once, such as points on a grid. New capacity must be greater or equals to old capacity.
+				[b]Note:[/b] The default point capacity is 64.
 			</description>
 		</method>
 		<method name="set_point_disabled">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Addresses #102612

Added a note to the `reserve_space()` function to both the AStar2D and AStar3D class documentation to state that the default point capacity of the classes is 64, preventing confusion from users when they attempt to reserve space with points fewer than 64.

Please let me know if any changes in wording are needed. Thanks!