### PR TITLE
Add tooltip for `StyleBoxPreview` grid button

### DIFF
--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -112,6 +112,7 @@ StyleBoxPreview::StyleBoxPreview() {
 	grid_preview = memnew(Button);
 	// This theme variation works better than the normal theme because there's no focus highlight.
 	grid_preview->set_theme_type_variation("PreviewLightButton");
+	grid_preview->set_tooltip_text(TTRC("Toggle margins preview grid."));
 	grid_preview->set_toggle_mode(true);
 	grid_preview->connect(SceneStringName(toggled), callable_mp(this, &StyleBoxPreview::_grid_preview_toggled));
 	grid_preview->set_pressed(grid_preview_enabled);


### PR DESCRIPTION

| Before | After |
| --- | --- |
| ![Godot_v4 4-beta3_win64_628dH8xjVy](https://github.com/user-attachments/assets/7383cddd-ba5c-4ef4-9d14-4ef694da8fc5) | ![godot windows editor dev x86_64_eHpWStIJvO](https://github.com/user-attachments/assets/54ab7387-0c29-4c55-8d3e-6953e6e04c25) |

