### PR TITLE
[Web] Fix issue when pausing an non-started sample

### DIFF
--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -735,6 +735,9 @@ class SampleNode {
 	 * @returns {void}
 	 */
 	_pause() {
+		if (!this.isStarted) {
+			return;
+		}
 		this.isPaused = true;
 		this.pauseTime = (GodotAudio.ctx.currentTime - this._sourceStartTime) / this.getPlaybackRate();
 		this._source.stop();


### PR DESCRIPTION
This PR makes sure that the sample source is at least started before calling `stop()` on it.

Fixes #102911.