### PR TITLE
Use `increment` instead of `conditional_increment` for `SafeRefCount`.

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -439,7 +439,7 @@ Engine::Singleton::Singleton(const StringName &p_name, Object *p_ptr, const Stri
 		class_name(p_class_name) {
 #ifdef DEBUG_ENABLED
 	RefCounted *rc = Object::cast_to<RefCounted>(p_ptr);
-	if (rc && !rc->is_referenced()) {
+	if (rc && rc->get_reference_count() == 0) {
 		WARN_PRINT("You must use Ref<> to ensure the lifetime of a RefCounted object intended to be used as a singleton.");
 	}
 #endif

--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -164,7 +164,8 @@ void NodePath::operator=(const NodePath &p_path) {
 
 	unref();
 
-	if (p_path.data && p_path.data->refcount.ref()) {
+	if (p_path.data) {
+		p_path.data->refcount.ref();
 		data = p_path.data;
 	}
 }
@@ -371,7 +372,7 @@ NodePath::NodePath(const Vector<StringName> &p_path, bool p_absolute) {
 	}
 
 	data = memnew(Data);
-	data->refcount.init();
+	data->refcount.init(1);
 	data->absolute = p_absolute;
 	data->path = p_path;
 	data->hash_cache_valid = false;
@@ -383,7 +384,7 @@ NodePath::NodePath(const Vector<StringName> &p_path, const Vector<StringName> &p
 	}
 
 	data = memnew(Data);
-	data->refcount.init();
+	data->refcount.init(1);
 	data->absolute = p_absolute;
 	data->path = p_path;
 	data->subpath = p_subpath;
@@ -391,7 +392,8 @@ NodePath::NodePath(const Vector<StringName> &p_path, const Vector<StringName> &p
 }
 
 NodePath::NodePath(const NodePath &p_path) {
-	if (p_path.data && p_path.data->refcount.ref()) {
+	if (p_path.data) {
+		p_path.data->refcount.ref();
 		data = p_path.data;
 	}
 }
@@ -448,7 +450,7 @@ NodePath::NodePath(const String &p_path) {
 	}
 
 	data = memnew(Data);
-	data->refcount.init();
+	data->refcount.init(1);
 	data->absolute = absolute;
 	data->subpath = subpath;
 	data->hash_cache_valid = false;

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -236,7 +236,8 @@ StringName &StringName::operator=(const StringName &p_name) {
 
 	unref();
 
-	if (p_name._data && p_name._data->refcount.ref()) {
+	if (p_name._data) {
+		p_name._data->refcount.ref();
 		_data = p_name._data;
 	}
 
@@ -248,7 +249,8 @@ StringName::StringName(const StringName &p_name) {
 
 	ERR_FAIL_COND(!configured);
 
-	if (p_name._data && p_name._data->refcount.ref()) {
+	if (p_name._data) {
+		p_name._data->refcount.ref();
 		_data = p_name._data;
 	}
 }
@@ -283,7 +285,8 @@ StringName::StringName(const char *p_name, bool p_static) {
 		_data = _data->next;
 	}
 
-	if (_data && _data->refcount.ref()) {
+	if (_data) {
+		_data->refcount.ref();
 		// exists
 		if (p_static) {
 			_data->static_count.increment();
@@ -298,7 +301,7 @@ StringName::StringName(const char *p_name, bool p_static) {
 
 	_data = memnew(_Data);
 	_data->name = p_name;
-	_data->refcount.init();
+	_data->refcount.init(1);
 	_data->static_count.set(p_static ? 1 : 0);
 	_data->hash = hash;
 	_data->idx = idx;
@@ -340,7 +343,8 @@ StringName::StringName(const StaticCString &p_static_string, bool p_static) {
 		_data = _data->next;
 	}
 
-	if (_data && _data->refcount.ref()) {
+	if (_data) {
+		_data->refcount.ref();
 		// exists
 		if (p_static) {
 			_data->static_count.increment();
@@ -355,7 +359,7 @@ StringName::StringName(const StaticCString &p_static_string, bool p_static) {
 
 	_data = memnew(_Data);
 
-	_data->refcount.init();
+	_data->refcount.init(1);
 	_data->static_count.set(p_static ? 1 : 0);
 	_data->hash = hash;
 	_data->idx = idx;
@@ -397,7 +401,8 @@ StringName::StringName(const String &p_name, bool p_static) {
 		_data = _data->next;
 	}
 
-	if (_data && _data->refcount.ref()) {
+	if (_data) {
+		_data->refcount.ref();
 		// exists
 		if (p_static) {
 			_data->static_count.increment();
@@ -412,7 +417,7 @@ StringName::StringName(const String &p_name, bool p_static) {
 
 	_data = memnew(_Data);
 	_data->name = p_name;
-	_data->refcount.init();
+	_data->refcount.init(1);
 	_data->static_count.set(p_static ? 1 : 0);
 	_data->hash = hash;
 	_data->idx = idx;
@@ -455,7 +460,8 @@ StringName StringName::search(const char *p_name) {
 		_data = _data->next;
 	}
 
-	if (_data && _data->refcount.ref()) {
+	if (_data) {
+		_data->refcount.ref();
 #ifdef DEBUG_ENABLED
 		if (unlikely(debug_stringname)) {
 			_data->debug_references++;
@@ -490,7 +496,8 @@ StringName StringName::search(const char32_t *p_name) {
 		_data = _data->next;
 	}
 
-	if (_data && _data->refcount.ref()) {
+	if (_data) {
+		_data->refcount.ref();
 		return StringName(_data);
 	}
 
@@ -514,7 +521,9 @@ StringName StringName::search(const String &p_name) {
 		_data = _data->next;
 	}
 
-	if (_data && _data->refcount.ref()) {
+	if (_data) {
+		_data->refcount.ref();
+
 #ifdef DEBUG_ENABLED
 		if (unlikely(debug_stringname)) {
 			_data->debug_references++;

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -499,9 +499,8 @@ void CowData<T>::_ref(const CowData &p_from) {
 		return; //nothing to do
 	}
 
-	if (p_from._get_refcount()->conditional_increment() > 0) { // could reference
-		_ptr = p_from._ptr;
-	}
+	p_from._get_refcount()->increment();
+	_ptr = p_from._ptr;
 }
 
 template <typename T>

--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -134,18 +134,6 @@ public:
 		}
 	}
 
-	_ALWAYS_INLINE_ T conditional_increment() {
-		while (true) {
-			T c = value.load(std::memory_order_acquire);
-			if (c == 0) {
-				return 0;
-			}
-			if (value.compare_exchange_weak(c, c + 1, std::memory_order_acq_rel)) {
-				return c + 1;
-			}
-		}
-	}
-
 	_ALWAYS_INLINE_ explicit SafeNumeric(T p_value = static_cast<T>(0)) {
 		set(p_value);
 	}
@@ -192,12 +180,12 @@ class SafeRefCount {
 #endif
 
 public:
-	_ALWAYS_INLINE_ bool ref() { // true on success
-		return count.conditional_increment() != 0;
+	_ALWAYS_INLINE_ void ref() {
+		count.increment();
 	}
 
-	_ALWAYS_INLINE_ uint32_t refval() { // none-zero on success
-		return count.conditional_increment();
+	_ALWAYS_INLINE_ uint32_t refval() { // returns the new refcount
+		return count.increment();
 	}
 
 	_ALWAYS_INLINE_ bool unref() { // true if must be disposed of
@@ -218,7 +206,7 @@ public:
 		return count.get();
 	}
 
-	_ALWAYS_INLINE_ void init(uint32_t p_value = 1) {
+	_ALWAYS_INLINE_ void init(uint32_t p_value) {
 		count.set(p_value);
 	}
 };

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -56,10 +56,7 @@ void Array::_ref(const Array &p_from) const {
 		return; // whatever it is, nothing to do here move along
 	}
 
-	bool success = _fp->refcount.ref();
-
-	ERR_FAIL_COND(!success); // should really not happen either
-
+	_fp->refcount.ref();
 	_unref();
 
 	_p = _fp;
@@ -836,7 +833,7 @@ const void *Array::id() const {
 
 Array::Array(const Array &p_from, uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {
 	_p = memnew(ArrayPrivate);
-	_p->refcount.init();
+	_p->refcount.init(1);
 	set_typed(p_type, p_class_name, p_script);
 	assign(p_from);
 }
@@ -915,7 +912,7 @@ Array::Array(const Array &p_from) {
 
 Array::Array() {
 	_p = memnew(ArrayPrivate);
-	_p->refcount.init();
+	_p->refcount.init(1);
 }
 
 Array::~Array() {

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -335,9 +335,8 @@ void Callable::operator=(const Callable &p_callable) {
 	if (p_callable.is_custom()) {
 		method = StringName();
 		object = 0;
-		if (p_callable.custom->ref_count.ref()) {
-			custom = p_callable.custom;
-		}
+		p_callable.custom->ref_count.ref();
+		custom = p_callable.custom;
 	} else {
 		method = p_callable.method;
 		object = p_callable.object;
@@ -424,12 +423,9 @@ Callable::Callable(CallableCustom *p_custom) {
 
 Callable::Callable(const Callable &p_callable) {
 	if (p_callable.is_custom()) {
-		if (!p_callable.custom->ref_count.ref()) {
-			object = 0;
-		} else {
-			object = 0;
-			custom = p_callable.custom;
-		}
+		p_callable.custom->ref_count.ref();
+		object = 0;
+		custom = p_callable.custom;
 	} else {
 		method = p_callable.method;
 		object = p_callable.object;
@@ -483,7 +479,7 @@ int CallableCustom::get_unbound_arguments_count() const {
 }
 
 CallableCustom::CallableCustom() {
-	ref_count.init();
+	ref_count.init(1);
 }
 
 //////////////////////////////////

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -274,9 +274,7 @@ bool Dictionary::recursive_equal(const Dictionary &p_dictionary, int recursion_c
 
 void Dictionary::_ref(const Dictionary &p_from) const {
 	//make a copy first (thread safe)
-	if (!p_from._p->refcount.ref()) {
-		return; // couldn't copy
-	}
+	p_from._p->refcount.ref();
 
 	//if this is the same, unreference the other one
 	if (p_from._p == _p) {
@@ -698,7 +696,7 @@ const void *Dictionary::id() const {
 
 Dictionary::Dictionary(const Dictionary &p_base, uint32_t p_key_type, const StringName &p_key_class_name, const Variant &p_key_script, uint32_t p_value_type, const StringName &p_value_class_name, const Variant &p_value_script) {
 	_p = memnew(DictionaryPrivate);
-	_p->refcount.init();
+	_p->refcount.init(1);
 	set_typed(p_key_type, p_key_class_name, p_key_script, p_value_type, p_value_class_name, p_value_script);
 	assign(p_base);
 }
@@ -710,12 +708,12 @@ Dictionary::Dictionary(const Dictionary &p_from) {
 
 Dictionary::Dictionary() {
 	_p = memnew(DictionaryPrivate);
-	_p->refcount.init();
+	_p->refcount.init(1);
 }
 
 Dictionary::Dictionary(std::initializer_list<KeyValue<Variant, Variant>> p_init) {
 	_p = memnew(DictionaryPrivate);
-	_p->refcount.init();
+	_p->refcount.init(1);
 
 	for (const KeyValue<Variant, Variant> &E : p_init) {
 		operator[](E.key) = E.value;

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1094,9 +1094,7 @@ void Variant::ObjData::ref(const ObjData &p_from) {
 	if (id.is_ref_counted()) {
 		RefCounted *reference = static_cast<RefCounted *>(obj);
 		// Assuming reference is not null because id.is_ref_counted() was true.
-		if (!reference->reference()) {
-			*this = ObjData();
-		}
+		reference->reference();
 	}
 
 	cleanup_ref.unref();
@@ -1114,9 +1112,7 @@ void Variant::ObjData::ref_pointer(Object *p_object) {
 		*this = ObjData{ p_object->get_instance_id(), p_object };
 		if (p_object->is_ref_counted()) {
 			RefCounted *reference = static_cast<RefCounted *>(p_object);
-			if (!reference->init_ref()) {
-				*this = ObjData();
-			}
+			reference->reference();
 		}
 	} else {
 		*this = ObjData();

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -199,11 +199,8 @@ private:
 	struct PackedArrayRefBase {
 		SafeRefCount refcount;
 		_FORCE_INLINE_ PackedArrayRefBase *reference() {
-			if (refcount.ref()) {
-				return this;
-			} else {
-				return nullptr;
-			}
+			refcount.ref();
+			return this;
 		}
 		static _FORCE_INLINE_ PackedArrayRefBase *reference_from(PackedArrayRefBase *p_base, PackedArrayRefBase *p_from) {
 			if (p_base == p_from) {
@@ -246,10 +243,10 @@ private:
 
 		_FORCE_INLINE_ PackedArrayRef(const Vector<T> &p_from) {
 			array = p_from;
-			refcount.init();
+			refcount.init(1);
 		}
 		_FORCE_INLINE_ PackedArrayRef() {
-			refcount.init();
+			refcount.init(1);
 		}
 	};
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1371,10 +1371,8 @@ void CSharpLanguage::tie_native_managed_to_unmanaged(GCHandleIntPtr p_gchandle_i
 		// but the managed instance is alive, the refcount will be 1 instead of 0.
 		// See: godot_icall_RefCounted_Dtor(MonoObject *p_obj, Object *p_ptr)
 
-		// May not me referenced yet, so we must use init_ref() instead of reference()
-		if (rc->init_ref()) {
-			CSharpLanguage::get_singleton()->post_unsafe_reference(rc);
-		}
+		rc->reference();
+		CSharpLanguage::get_singleton()->post_unsafe_reference(rc);
 	}
 
 	// The object was just created, no script instance binding should have been attached
@@ -1699,11 +1697,9 @@ bool CSharpInstance::_reference_owner_unsafe() {
 	// but the managed instance is alive, the refcount will be 1 instead of 0.
 	// See: _unreference_owner_unsafe()
 
-	// May not be referenced yet, so we must use init_ref() instead of reference()
-	if (static_cast<RefCounted *>(owner)->init_ref()) {
-		CSharpLanguage::get_singleton()->post_unsafe_reference(owner);
-		unsafe_referenced = true;
-	}
+	static_cast<RefCounted *>(owner)->reference();
+	CSharpLanguage::get_singleton()->post_unsafe_reference(owner);
+	unsafe_referenced = true;
 
 	return unsafe_referenced;
 }

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1490,7 +1490,7 @@ void Node::_validate_child_name(Node *p_child, bool p_force_human_readable) {
 		}
 
 		if (!unique) {
-			ERR_FAIL_COND(!node_hrcr_count.ref());
+			node_hrcr_count.ref();
 			// Optimized version of the code below:
 			// String name = "@" + String(p_child->get_name()) + "@" + itos(node_hrcr_count.get());
 			uint32_t c = node_hrcr_count.get();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11795.

This simplifies `SafeRefCount::ref` calls to always succeed, eliminating logic. 

In particular, this PR will speed up `RefCounted::init_ref` calls (now `reference`), e.g. improving `GDScript` function call overhead by ~4%.

It should also slightly improve speed and reduce code of `reference` calls in general.

## Caveats
This commit introduces an edge case where the 2^32th reference will result in rollover, accidentally deallocating the object in question early.
It is unlikely this edge case is ever triggered for a real scenario, because 2^32 references would be 32GB of packed references (â 8 bytes), which is obviously nuts.