### PR TITLE
Fix Embedded Game over expanded bottom panel, by resetting expanded bottom panel on Play

### DIFF
--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -293,6 +293,10 @@ void EditorBottomPanel::toggle_last_opened_bottom_panel() {
 	}
 }
 
+void EditorBottomPanel::set_expanded(bool p_expanded) {
+	expand_button->set_pressed(p_expanded);
+}
+
 EditorBottomPanel::EditorBottomPanel() {
 	item_vbox = memnew(VBoxContainer);
 	add_child(item_vbox);

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -86,6 +86,7 @@ public:
 	void move_item_to_end(Control *p_item);
 	void hide_bottom_panel();
 	void toggle_last_opened_bottom_panel();
+	void set_expanded(bool p_expanded);
 
 	EditorBottomPanel();
 };

--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -42,6 +42,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
+#include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_run_bar.h"
 #include "editor/plugins/embedded_process.h"
 #include "editor/themes/editor_scale.h"
@@ -300,6 +301,8 @@ void GameView::_play_pressed() {
 		_update_embed_window_size();
 		if (!window_wrapper->get_window_enabled()) {
 			EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_GAME);
+			// Reset the normal size of the bottom panel when fully expanded.
+			EditorNode::get_singleton()->get_bottom_panel()->set_expanded(false);
 			embedded_process->grab_focus();
 		}
 		embedded_process->embed_process(current_process_id);


### PR DESCRIPTION
- Fixes #102901

This is a simpler version to fix the issue compared to https://github.com/godotengine/godot/pull/102921

It fixes the principal issue by resetting the expanded panel bottom to its "normal" size when the game starts and the game is embedded in the editor.  So close of the 4.4 release, this solution is less risky then the other PR and the other PR still needs a lot of work to be 100% functional.