### PR TITLE
Add stricter detection for `#region` and `#endregion` keywords.

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -722,6 +722,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Behavior: Documentation
 	_initial_set("text_editor/behavior/documentation/enable_tooltips", true, true);
 
+	// Behavior: Comments
+	_initial_set("text_editor/behavior/comments/regex_code_region_excluded_suffixes", "\\w=+\\-*\\/\\[.");
+
 	// Script list
 	_initial_set("text_editor/script_list/show_members_overview", true, true);
 	_initial_set("text_editor/script_list/sort_members_outline_alphabetically", false, true);

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -38,6 +38,8 @@
 #include "editor/themes/editor_theme_manager.h"
 #include "scene/gui/text_edit.h"
 
+#include "modules/regex/regex.h"
+
 Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 	Dictionary color_map;
 
@@ -148,6 +150,15 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 							if (start_key[k] != str[from + k]) {
 								match = false;
 								break;
+							}
+						}
+						if (color_regions[c].type == ColorRegion::TYPE_CODE_REGION) {
+							String es = EditorSettings::get_singleton()->get("text_editor/behavior/comments/regex_code_region_excluded_suffixes");
+							RegEx re_region = RegEx("^\\s*#region(?![" + es + "])");
+							RegEx re_endregion = RegEx("^\\s*#endregion(?![" + es + "])");
+
+							if (re_region.search(str).is_null() && re_endregion.search(str).is_null()) {
+								match = false;
 							}
 						}
 						if (!match) {

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -35,6 +35,8 @@
 #include "core/os/keyboard.h"
 #include "core/string/string_builder.h"
 #include "core/string/ustring.h"
+#include "editor/editor_settings.h"
+#include "modules/regex/regex.h"
 #include "scene/theme/theme_db.h"
 
 void CodeEdit::_apply_project_settings() {
@@ -1872,7 +1874,11 @@ bool CodeEdit::is_line_code_region_start(int p_line) const {
 	if (is_in_string(p_line) != -1) {
 		return false;
 	}
-	return get_line(p_line).strip_edges().begins_with(code_region_start_string);
+
+	String es = EditorSettings::get_singleton()->get("text_editor/behavior/comments/regex_code_region_excluded_suffixes");
+	RegEx re = RegEx("^\\s*" + code_region_start_string + "(?![" + es + "])");
+
+	return re.search(get_line(p_line)).is_valid();
 }
 
 bool CodeEdit::is_line_code_region_end(int p_line) const {
@@ -1883,7 +1889,11 @@ bool CodeEdit::is_line_code_region_end(int p_line) const {
 	if (is_in_string(p_line) != -1) {
 		return false;
 	}
-	return get_line(p_line).strip_edges().begins_with(code_region_end_string);
+
+	String es = EditorSettings::get_singleton()->get("text_editor/behavior/comments/regex_code_region_excluded_suffixes");
+	RegEx re = RegEx("^\\s*" + code_region_end_string + "(?![" + es + "])");
+
+	return re.search(get_line(p_line)).is_valid();
 }
 
 /* Delimiters */


### PR DESCRIPTION
fixes #101187
builds upon #101319

Updated the `is_line_code_region_start()` and `is_line_code_region_end()` to use RegEx to detect if `#region`/`#endregion` is followed by `text_editor/behavior/comments/regex_code_region_excluded_suffixes` Editor Setting (`\w=+\-*\/\[.` by default).

Also updated highlighting in `gdscript_highlighter.cpp` to match the detection for code regions in `code_edit.cpp`.

Before:
![image](https://github.com/user-attachments/assets/dfb7c2a5-423b-42e6-aa23-0868f5bd2af5)
After:
![image](https://github.com/user-attachments/assets/5edd7235-0951-4f4b-9f60-f1fe36204e64)
