### PR TITLE
Android: Enable support for volume button events

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1612,6 +1612,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC("input_devices/pointing/android/enable_long_press_as_right_click", false);
 	GLOBAL_DEF_BASIC("input_devices/pointing/android/enable_pan_and_scale_gestures", false);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "input_devices/pointing/android/rotary_input_scroll_axis", PROPERTY_HINT_ENUM, "Horizontal,Vertical"), 1);
+	GLOBAL_DEF("input_devices/pointing/android/override_volume_buttons", false);
 
 	// These properties will not show up in the dialog. If you want to exclude whole groups, use add_hidden_prefix().
 	GLOBAL_DEF_INTERNAL("application/config/features", PackedStringArray());

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1444,6 +1444,9 @@
 		<member name="input_devices/pointing/android/enable_pan_and_scale_gestures" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], multi-touch pan and scale gestures are enabled on Android devices.
 		</member>
+		<member name="input_devices/pointing/android/override_volume_buttons" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], system volume changes are disabled when the buttons are used within the app.
+		</member>
 		<member name="input_devices/pointing/android/rotary_input_scroll_axis" type="int" setter="" getter="" default="1">
 			On Wear OS devices, defines which axis of the mouse wheel rotary input is mapped to. This rotary input is usually performed by rotating the physical or virtual (touch-based) bezel on a smartwatch.
 		</member>

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -258,12 +258,14 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		super.onGodotSetupCompleted()
 		val longPressEnabled = enableLongPressGestures()
 		val panScaleEnabled = enablePanAndScaleGestures()
+		val overrideVolumeButtonsEnabled = overrideVolumeButtons()
 
 		runOnUiThread {
 			// Enable long press, panning and scaling gestures
 			godotFragment?.godot?.renderView?.inputHandler?.apply {
 				enableLongPress(longPressEnabled)
 				enablePanningAndScalingGestures(panScaleEnabled)
+				setOverrideVolumeButtons(overrideVolumeButtonsEnabled)
 			}
 		}
 	}
@@ -481,6 +483,8 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 	 * The Godot Android Editor sets its own orientation via its AndroidManifest
 	 */
 	protected open fun overrideOrientationRequest() = true
+
+	protected open fun overrideVolumeButtons() = false
 
 	/**
 	 * Enable long press gestures for the Godot Android editor.

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
@@ -46,6 +46,8 @@ abstract class BaseGodotGame: GodotEditor() {
 		private val TAG = BaseGodotGame::class.java.simpleName
 	}
 
+	override fun overrideVolumeButtons() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/override_volume_buttons"))
+
 	override fun enableLongPressGestures() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_long_press_as_right_click"))
 
 	override fun enablePanAndScaleGestures() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_pan_and_scale_gestures"))

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -714,11 +714,13 @@ class Godot(private val context: Context) {
 		val longPressEnabled = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_long_press_as_right_click"))
 		val panScaleEnabled = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_pan_and_scale_gestures"))
 		val rotaryInputAxisValue = GodotLib.getGlobal("input_devices/pointing/android/rotary_input_scroll_axis")
+		val overrideVolumeButtons = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/override_volume_buttons"))
 
 		runOnUiThread {
 			renderView?.inputHandler?.apply {
 				enableLongPress(longPressEnabled)
 				enablePanningAndScalingGestures(panScaleEnabled)
+				setOverrideVolumeButtons(overrideVolumeButtons)
 				try {
 					setRotaryInputAxis(Integer.parseInt(rotaryInputAxisValue))
 				} catch (e: NumberFormatException) {

--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
@@ -88,6 +88,7 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 	private int rotaryInputAxis = ROTARY_INPUT_VERTICAL_AXIS;
 
 	private int cachedRotation = -1;
+	private boolean overrideVolumeButtons = false;
 
 	public GodotInputHandler(Context context, Godot godot) {
 		this.godot = godot;
@@ -136,6 +137,10 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 		rotaryInputAxis = axis;
 	}
 
+	public void setOverrideVolumeButtons(boolean value) {
+		overrideVolumeButtons = value;
+	}
+
 	boolean hasHardwareKeyboard() {
 		return !mHardwareKeyboardIds.isEmpty();
 	}
@@ -157,10 +162,6 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 	}
 
 	public boolean onKeyUp(final int keyCode, KeyEvent event) {
-		if (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
-			return false;
-		}
-
 		int source = event.getSource();
 		if (isKeyEventGameDevice(source)) {
 			// Check if the device exists
@@ -178,14 +179,14 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 			handleKeyEvent(physical_keycode, unicode, key_label, false, event.getRepeatCount() > 0);
 		};
 
+		if (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
+			return overrideVolumeButtons;
+		}
+
 		return true;
 	}
 
 	public boolean onKeyDown(final int keyCode, KeyEvent event) {
-		if (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
-			return false;
-		}
-
 		int source = event.getSource();
 
 		final int deviceId = event.getDeviceId();
@@ -204,6 +205,10 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 			final int unicode = event.getUnicodeChar();
 			final int key_label = event.getDisplayLabel();
 			handleKeyEvent(physical_keycode, unicode, key_label, true, event.getRepeatCount() > 0);
+		}
+
+		if (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
+			return overrideVolumeButtons;
 		}
 
 		return true;


### PR DESCRIPTION
- Enable events KEY_VOLUMEUP and KEY_VOLUMEDOWN on Android.

- Adds a project setting to override volume buttons. It would disable system volume changes when the buttons are used within the project.

~**Note**: I'm not entirely sure whether adding a project setting to override volume buttons is necessary. I'm leaving it here for now and will hold off on finalizing it until I have more confidence in the implementation.~

closes https://github.com/godotengine/godot-proposals/issues/11260