### PR TITLE
Reduce frequency of `save_default_environment()` calls

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1890,6 +1890,12 @@ int EditorNode::_save_external_resources(bool p_also_save_external_data) {
 		}
 	}
 
+	Ref<Environment> environment = get_tree()->get_root()->get_world_3d()->get_fallback_environment();
+	if (environment.is_valid() && environment->is_edited()) {
+		// Save default environment if it wasn't saved already.
+		save_default_environment();
+	}
+
 	EditorUndoRedoManager::get_singleton()->set_history_as_saved(EditorUndoRedoManager::GLOBAL_HISTORY);
 
 	return saved;
@@ -1947,7 +1953,6 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	scene->propagate_notification(NOTIFICATION_EDITOR_PRE_SAVE);
 
 	editor_data.apply_changes_in_editors();
-	save_default_environment();
 	List<Pair<AnimationMixer *, Ref<AnimatedValuesBackup>>> anim_backups;
 	_reset_animation_mixers(scene, &anim_backups);
 	_save_editor_states(p_file, idx);
@@ -2141,7 +2146,6 @@ void EditorNode::_dialog_action(String p_file) {
 					return;
 				}
 
-				save_default_environment();
 				_save_scene_with_preview(p_file, scene_idx);
 				_add_to_recent_scenes(p_file);
 				save_editor_layout_delayed();
@@ -2158,7 +2162,6 @@ void EditorNode::_dialog_action(String p_file) {
 
 		case FILE_SAVE_AND_RUN: {
 			if (file->get_file_mode() == EditorFileDialog::FILE_MODE_SAVE_FILE) {
-				save_default_environment();
 				_save_scene_with_preview(p_file);
 				project_run_bar->play_custom_scene(p_file);
 			}
@@ -2169,7 +2172,6 @@ void EditorNode::_dialog_action(String p_file) {
 			ProjectSettings::get_singleton()->save();
 
 			if (file->get_file_mode() == EditorFileDialog::FILE_MODE_SAVE_FILE) {
-				save_default_environment();
 				_save_scene_with_preview(p_file);
 				project_run_bar->play_main_scene((bool)pick_main_scene->get_meta("from_native", false));
 			}


### PR DESCRIPTION
Currently default environment is saved when scene is saved, when scene is saved before running, when all scenes are saved etc. I didn't test, but pretty sure the editor saves it multiple times per any save action. It's excessive.

The PR reduces it to single call inside `_save_external_resources()`. I'm not sure why `save_default_environment()` even exists tbh, it runs some extra code which should already be handled by regular resource saving.

I confirmed that the environment is still saved correctly after the change.