### PR TITLE
Fix `GPUParticles3D` spawn angle does not work when particle `one_shot` is true

### DIFF
--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -51,6 +51,7 @@ void GPUParticles3D::set_emitting(bool p_emitting) {
 			signal_canceled = false;
 			emission_time = lifetime;
 			active_time = lifetime * (2 - explosiveness_ratio);
+			set_seed(Math::rand());
 		} else {
 			signal_canceled = true;
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

fixes #102885