### PR TITLE
Fix `EditorDebuggerSession`'s `stopped` signal firing twice when using `Stop Running Project` hotkey from the game

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -806,7 +806,6 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread
 		}
 	} else if (p_msg == "request_quit") {
 		emit_signal(SNAME("stop_requested"));
-		_stop_and_notify();
 	} else if (p_msg == "remote_node_clicked") {
 		if (!p_data.is_empty()) {
 			emit_signal(SNAME("remote_tree_select_requested"), p_data[0]);


### PR DESCRIPTION
Fixes #102972 

The issue seems to be that when the editor receives a request to stop from the game, it fires a `stop_requested` signal, but also immediately performs the stop explicitly. Removing the latter seems to fix the problem, since the stop request already turns into a stop downstream anyway.