### PR TITLE
Bypass numpad emulation when modifier keys are used

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1674,8 +1674,23 @@ void Node3DEditorViewport::input(const Ref<InputEvent> &p_event) {
 }
 
 void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
+	const Ref<InputEventKey> k = p_event;
+
+	if (k.is_valid() && k->is_pressed() && EDITOR_GET("editors/3d/navigation/emulate_numpad")) {
+		bool is_shift = Input::get_singleton()->is_key_pressed(Key::SHIFT);
+		bool is_ctrl = Input::get_singleton()->is_key_pressed(Key::CTRL);
+		bool is_alt = Input::get_singleton()->is_key_pressed(Key::ALT);
+		if (!is_shift && !is_ctrl && !is_alt) {
+			const Key code = k->get_physical_keycode();
+			if (code >= Key::KEY_0 && code <= Key::KEY_9) {
+				k->set_keycode(code - Key::KEY_0 + Key::KP_0);
+			}
+		}
+	}
+
 	if (previewing || get_viewport()->gui_get_drag_data()) {
-		return; //do NONE
+		// Disable all input actions when previewing a camera or during drag-and-drop.
+		return;
 	}
 
 	EditorPlugin::AfterGUIInput after = EditorPlugin::AFTER_GUI_INPUT_PASS;
@@ -2247,8 +2262,6 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		}
 	}
 
-	Ref<InputEventKey> k = p_event;
-
 	if (k.is_valid()) {
 		if (!k->is_pressed()) {
 			return;
@@ -2288,13 +2301,6 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 				set_process_input(false);
 				accept_event();
 				return;
-			}
-		}
-
-		if (EDITOR_GET("editors/3d/navigation/emulate_numpad")) {
-			const Key code = k->get_physical_keycode();
-			if (code >= Key::KEY_0 && code <= Key::KEY_9) {
-				k->set_keycode(code - Key::KEY_0 + Key::KP_0);
 			}
 		}
 


### PR DESCRIPTION
This PR includes PR #93724.

Keyboard shortcuts using modifier keys (SHIFT, CTRL, ALT) don't work with numpad emulation enabled. It's for example not possible to change the viewports with CTRL+1, CTRL+2, CTRL+ALT+2 and others.

This change bypasses numpad emulation if a modifier key is pressed and thus makes other shortcuts accessible.

<i>Bugsquad edit:</i>
- Fix https://github.com/godotengine/godot/issues/103205