### PR TITLE
Increase size of Offset field in audio import dialog

### DIFF
--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -544,7 +544,9 @@ AudioStreamImportSettingsDialog::AudioStreamImportSettingsDialog() {
 	loop_offset = memnew(SpinBox);
 	loop_offset->set_max(10000);
 	loop_offset->set_step(0.001);
-	loop_offset->set_suffix("sec");
+	loop_offset->set_suffix("s");
+	loop_offset->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	loop_offset->set_stretch_ratio(0.33);
 	loop_offset->set_tooltip_text(TTR("Loop offset (from beginning). Note that if BPM is set, this setting will be ignored."));
 	loop_offset->connect(SceneStringName(value_changed), callable_mp(this, &AudioStreamImportSettingsDialog::_settings_changed).unbind(1));
 	loop_hb->add_child(loop_offset);


### PR DESCRIPTION
I found the field annoyingly small and hide information, so I made it bigger.
Before:
![image](https://github.com/user-attachments/assets/a3a193f6-4dc8-47c2-b13a-9474f943b9ee)
After:
![image](https://github.com/user-attachments/assets/ec0e8aa1-cabb-4b3a-92fa-2d92ff0c5ce2)
(same value)
I also changed the suffix to s.

Somewhat related to #64538