### PR TITLE
[3.x] Fix button icon size when stylebox margin is asymmetrical

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -201,7 +201,7 @@ void Button::_notification(int p_what) {
 				style_offset.y = style->get_margin(MARGIN_TOP);
 
 				if (expand_icon) {
-					Size2 _size = get_size() - style->get_offset() * 2;
+					Size2 _size = get_size() - style->get_minimum_size();
 					int icon_text_separation = text.empty() ? 0 : get_constant("h_separation");
 					_size.width -= icon_text_separation + icon_ofs_region;
 					if (!clip_text && icon_align != ALIGN_CENTER) {


### PR DESCRIPTION
When `expand_icon` is enabled and the stylebox has asymmetrical content margin, the icon size is wrong.

In the screenshot below, stylebox has 16px top margin and 8px bottom margin (height of the white rects). The resulting icon size is 8px smaller than expected:

![ksnip_20250219-172739](https://github.com/user-attachments/assets/aa5d0152-fd57-494e-a681-0546dfe3776e)

MRP: [content-margin.zip](https://github.com/user-attachments/files/18865443/content-margin.zip)

This is because the available space for the icon to expand is always calculated as double the top-left margin, so it only works when the margins are symmetrical:

https://github.com/godotengine/godot/blob/9ce78ca5c2ec6d6a6e32da300f6694d496a26f32/scene/gui/button.cpp#L203-L204

This issue has already been fixed in 4.x:

https://github.com/godotengine/godot/blob/e567f49cbb292dd6bb628348e67c1f3c2a3a5f99/scene/gui/button.cpp#L249-L252