### PR TITLE
Don't disable IME on focus out

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4890,10 +4890,9 @@ void DisplayServerX11::process_events() {
 					MutexLock mutex_lock(events_mutex);
 					XUnsetICFocus(wd.xic);
 					XUnmapWindow(x11_display, wd.x11_xim_window);
-					wd.ime_active = false;
+					wd.ime_in_progress = false;
 					im_text = String();
 					im_selection = Vector2i();
-					OS_Unix::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
 				}
 				wd.focused = false;
 


### PR DESCRIPTION
Fixes #89285

When the editor looses focus on Linux to another text field or another window, the editor scrolls to the caret position. It can be very annoying when switching repeatedly in and out of the Godot editor. This behavior was introduced in #70052.

Maybe the intention wasn't disabling IME but to cancel any input in progress. Doing this, the unwanted scrolling doesn't happen and testing with the composition key on Gnome, any in-progress composed input is cancelled.

Could @bruvzg or @raulsntos confirm this?