### PR TITLE
Handle overflow properly (extreme edge case)

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -357,7 +357,7 @@ Error RenderingDevice::_staging_buffer_allocate(StagingBuffers &p_staging_buffer
 				}
 			}
 
-		} else if (p_staging_buffers.blocks[p_staging_buffers.current].frame_used <= frames_drawn - frames.size()) {
+		} else if (frames_drawn - p_staging_buffers.blocks[p_staging_buffers.current].frame_used >= frames.size()) {
 			// This is an old block, which was already processed, let's reuse.
 			p_staging_buffers.blocks.write[p_staging_buffers.current].frame_used = frames_drawn;
 			p_staging_buffers.blocks.write[p_staging_buffers.current].fill_amount = 0;


### PR DESCRIPTION
The code would misbehave if `frames_drawn` overflows.

Realistically this should not happen since UINT64_MAX is a lot of frames, Godot could probably render until the end of the universe before it triggers.

However any future intentional tampering with `frames_drawn` could trigger this.

You can test it with the following program:

```cpp
#include <inttypes.h>
#include <stdio.h>
#include <vector>

struct Frame
{
};

int main()
{
	std::vector<Frame> frames;

	const size_t numFrames = 3u;
	frames.resize( numFrames );

	uint64_t frames_drawn = 2u;
	uint64_t frame_used = frames_drawn - numFrames;

	while( frame_used != frames_drawn )
	{
		if( frame_used <= frames_drawn - frames.size() )
		{
			int64_t diff = int64_t( frames_drawn - frame_used );
			if( diff < numFrames )
				printf( "ERROR: " );
			printf( "Can reuse frames_drawn = %" PRIu64 "; frame_used = %" PRIu64 "; diff = %" PRIi64
					"\n",
					frames_drawn, frame_used, diff );
		}

		if( frames_drawn - frame_used >= frames.size() )
		{
			int64_t diff = int64_t( frames_drawn - frame_used );
			if( diff < numFrames )
				printf( "ERROR: " );
			printf( "ALT Can reuse frames_drawn = %" PRIu64 "; frame_used = %" PRIu64 "; diff = %" PRIi64
					"\n",
					frames_drawn, frame_used, diff );
		}

		frame_used++;
	}
}
```

Which prints:

```cpp
Can reuse frames_drawn = 2; frame_used = 18446744073709551615; diff = 3
ALT Can reuse frames_drawn = 2; frame_used = 18446744073709551615; diff = 3
ERROR: Can reuse frames_drawn = 2; frame_used = 0; diff = 2
ERROR: Can reuse frames_drawn = 2; frame_used = 1; diff = 1
```

Additionally if somehow `frames_drawn` somehow gets too far away (e.g. `frames_drawn` was increased without calling this function) a lot of buffers would be missed.

Setting:

```cpp
uint64_t frames_drawn = 3u;
uint64_t frame_used = frames_drawn - 10;
```

Prints:

```
ALT Can reuse frames_drawn = 3; frame_used = 18446744073709551609; diff = 10
ALT Can reuse frames_drawn = 3; frame_used = 18446744073709551610; diff = 9
ALT Can reuse frames_drawn = 3; frame_used = 18446744073709551611; diff = 8
ALT Can reuse frames_drawn = 3; frame_used = 18446744073709551612; diff = 7
ALT Can reuse frames_drawn = 3; frame_used = 18446744073709551613; diff = 6
ALT Can reuse frames_drawn = 3; frame_used = 18446744073709551614; diff = 5
ALT Can reuse frames_drawn = 3; frame_used = 18446744073709551615; diff = 4
Can reuse frames_drawn = 3; frame_used = 0; diff = 3
ALT Can reuse frames_drawn = 3; frame_used = 0; diff = 3
```

Which means the original code ignores a lot of blocks that could be reused.

This is a low priority PR and can be merged after 4.4 since the likelihood of triggering is ridiculously small and we don't have enough time to test it for 4.4's release.

**Edit:** Technically the new code could misbehave too if the gap between `frames_drawn - frame_used` is so large it overflows. However the chances of that happening should be even lower; and it would mean that `frame_used > frames_drawn` which is a far worse problem and probably everything in the codebase would break if such thing were to happen.