### PR TITLE
Make Vector<T>::bsearch use a const receiver

### DIFF
--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -127,14 +127,14 @@ public:
 		sorter.sort(data, len);
 	}
 
-	Size bsearch(const T &p_value, bool p_before) {
+	Size bsearch(const T &p_value, bool p_before) const {
 		return bsearch_custom<_DefaultComparator<T>>(p_value, p_before);
 	}
 
 	template <typename Comparator, typename Value, typename... Args>
-	Size bsearch_custom(const Value &p_value, bool p_before, Args &&...args) {
+	Size bsearch_custom(const Value &p_value, bool p_before, Args &&...args) const {
 		SearchArray<T, Comparator> search{ args... };
-		return search.bisect(ptrw(), size(), p_value, p_before);
+		return search.bisect(ptr(), size(), p_value, p_before);
 	}
 
 	Vector<T> duplicate() {

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -47,7 +47,7 @@
 				Appends a [PackedByteArray] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="int" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -51,7 +51,7 @@
 				Appends a [PackedColorArray] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Color" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -47,7 +47,7 @@
 				Appends a [PackedFloat32Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="float" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -48,7 +48,7 @@
 				Appends a [PackedFloat64Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="float" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -47,7 +47,7 @@
 				Appends a [PackedInt32Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="int" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -48,7 +48,7 @@
 				Appends a [PackedInt64Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="int" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -54,7 +54,7 @@
 				Appends a [PackedStringArray] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="String" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -52,7 +52,7 @@
 				Appends a [PackedVector2Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Vector2" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -51,7 +51,7 @@
 				Appends a [PackedVector3Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Vector3" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedVector4Array.xml
+++ b/doc/classes/PackedVector4Array.xml
@@ -51,7 +51,7 @@
 				Appends a [PackedVector4Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Vector4" />
 			<param index="1" name="before" type="bool" default="true" />


### PR DESCRIPTION
Allows binary searches on `const Vector<T>` values.

This matches `const Array`.

See also godotengine/godot-cpp#1711.