### PR TITLE
Document TileMap/GridMap physics queries not being immediately effective in `_ready()`

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -8,6 +8,7 @@
 		For performance reasons, all TileMap updates are batched at the end of a frame. Notably, this means that scene tiles from a [TileSetScenesCollectionSource] may be initialized after their parent. This is only queued when inside the scene tree.
 		To force an update earlier on, call [method update_internals].
 		[b]Note:[/b] For performance and compatibility reasons, the coordinates serialized by [TileMap] are limited to 16-bit signed integers, i.e. the range for X and Y coordinates is from [code]-32768[/code] to [code]32767[/code]. When saving tile data, tiles outside this range are wrapped.
+		[b]Note:[/b] Physics queries against TileMap are only effective 2 physics frames after the TileMap has been added to the scene. This means that when performing physics queries in [method Node._ready], you need to wait for 2 physics frames before physics queries will acknowledge the TileMap's presence. This can be done by calling [code]await get_tree().physics_frame[/code] twice in a row [i]before[/i] performing physics queries.
 	</description>
 	<tutorials>
 		<link title="Using Tilemaps">$DOCS_URL/tutorials/2d/using_tilemaps.html</link>

--- a/doc/classes/TileMapLayer.xml
+++ b/doc/classes/TileMapLayer.xml
@@ -8,6 +8,7 @@
 		For performance reasons, all TileMap updates are batched at the end of a frame. Notably, this means that scene tiles from a [TileSetScenesCollectionSource] may be initialized after their parent. This is only queued when inside the scene tree.
 		To force an update earlier on, call [method update_internals].
 		[b]Note:[/b] For performance and compatibility reasons, the coordinates serialized by [TileMapLayer] are limited to 16-bit signed integers, i.e. the range for X and Y coordinates is from [code]-32768[/code] to [code]32767[/code]. When saving tile data, tiles outside this range are wrapped.
+		[b]Note:[/b] Physics queries against TileMapLayer are only effective 2 physics frames after the TileMapLayer has been added to the scene. This means that when performing physics queries in [method Node._ready], you need to wait for 2 physics frames before physics queries will acknowledge the TileMapLayer's presence. This can be done by calling [code]await get_tree().physics_frame[/code] twice in a row [i]before[/i] performing physics queries.
 	</description>
 	<tutorials>
 		<link title="Using Tilemaps">$DOCS_URL/tutorials/2d/using_tilemaps.html</link>

--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -9,6 +9,7 @@
 		A GridMap contains a collection of cells. Each grid cell refers to a tile in the [MeshLibrary]. All cells in the map have the same dimensions.
 		Internally, a GridMap is split into a sparse collection of octants for efficient rendering and physics processing. Every octant has the same dimensions and can contain several cells.
 		[b]Note:[/b] GridMap doesn't extend [VisualInstance3D] and therefore can't be hidden or cull masked based on [member VisualInstance3D.layers]. If you make a light not affect the first layer, the whole GridMap won't be lit by the light in question.
+		[b]Note:[/b] Physics queries against GridMap are only effective 2 physics frames after the GridMap has been added to the scene. This means that when performing physics queries in [method Node._ready], you need to wait for 2 physics frames before physics queries will acknowledge the GridMap's presence. This can be done by calling [code]await get_tree().physics_frame[/code] twice in a row [i]before[/i] performing physics queries.
 	</description>
 	<tutorials>
 		<link title="Using gridmaps">$DOCS_URL/tutorials/3d/using_gridmaps.html</link>


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot/issues/67679
and closes https://github.com/godotengine/godot/issues/76349.