### PR TITLE
Add signals `scene_started` and `scene_stopped` to EditorInterface.

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -470,4 +470,16 @@
 			If [code]true[/code], the Movie Maker mode is enabled in the editor. See [MovieWriter] for more information.
 		</member>
 	</members>
+	<signals>
+		<signal name="scene_started">
+			<description>
+				Emitted when a scene has started playing.
+			</description>
+		</signal>
+		<signal name="scene_stopped">
+			<description>
+				Emitted when a scene has stopped playing.
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -747,6 +747,16 @@ bool EditorInterface::is_movie_maker_enabled() const {
 	return EditorRunBar::get_singleton()->is_movie_maker_enabled();
 }
 
+// Callback for EditorRunBar Play buttons.
+void EditorInterface::_on_project_run_started() {
+	emit_signal(SNAME("scene_started"));
+}
+
+// Callback for EditorRunBar Stop buttons.
+void EditorInterface::_on_project_run_stopped() {
+	emit_signal(SNAME("scene_stopped"));
+}
+
 void EditorInterface::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
@@ -859,6 +869,9 @@ void EditorInterface::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_movie_maker_enabled", "enabled"), &EditorInterface::set_movie_maker_enabled);
 	ClassDB::bind_method(D_METHOD("is_movie_maker_enabled"), &EditorInterface::is_movie_maker_enabled);
+
+	ADD_SIGNAL(MethodInfo("scene_started"));
+	ADD_SIGNAL(MethodInfo("scene_stopped"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "movie_maker_enabled"), "set_movie_maker_enabled", "is_movie_maker_enabled");
 }

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -190,6 +190,9 @@ public:
 	void set_movie_maker_enabled(bool p_enabled);
 	bool is_movie_maker_enabled() const;
 
+	void _on_project_run_started();
+	void _on_project_run_stopped();
+
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 
 	// Base.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7859,6 +7859,8 @@ EditorNode::EditorNode() {
 	title_bar->add_child(project_run_bar);
 	project_run_bar->connect("play_pressed", callable_mp(this, &EditorNode::_project_run_started));
 	project_run_bar->connect("stop_pressed", callable_mp(this, &EditorNode::_project_run_stopped));
+	project_run_bar->connect("play_pressed", callable_mp(EditorInterface::get_singleton(), &EditorInterface::_on_project_run_started));
+	project_run_bar->connect("stop_pressed", callable_mp(EditorInterface::get_singleton(), &EditorInterface::_on_project_run_stopped));
 
 	HBoxContainer *right_menu_hb = memnew(HBoxContainer);
 	right_menu_hb->set_mouse_filter(Control::MOUSE_FILTER_STOP);


### PR DESCRIPTION
Adds signals `scene_started` and `scene_stopped` to EditorInterface that are emitted when the EditorInterface has started or stopped playing a scene.

The purpose of this is particularly to allow EditorScripts to be notified when a scene has finished so that it can then continue with other work (such as playing another scene). 

You can find more discussion about this feature in this [forum post](https://forum.godotengine.org/t/how-to-make-multiple-movie-recordings-await-end-of-play/101069) and this [feature request](https://github.com/godotengine/godot-proposals/issues/3504). An alternative that might work is busy-waiting on `EditorInterface.is_playing_scene()`, but that seems clearly worse than providing a signal to await.

The implementation works by subscribing the EditorInterface to the EditorRunBar `play_pressed` and `stop_pressed` signals and forwarding them along.

Closes godotengine/godot-proposals#3504