### PR TITLE
Expose `ClassDB::is_class_exposed` to scripting

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1670,6 +1670,10 @@ bool ClassDB::is_class_enabled(const StringName &p_class) const {
 	return ::ClassDB::is_class_enabled(p_class);
 }
 
+bool ClassDB::is_class_exposed(const StringName &p_class) const {
+	return ::ClassDB::is_class_exposed(p_class);
+}
+
 #ifdef TOOLS_ENABLED
 void ClassDB::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	const String pf = p_function;
@@ -1682,7 +1686,7 @@ void ClassDB::get_argument_options(const StringName &p_function, int p_idx, List
 				pf == "class_has_method" || pf == "class_get_method_list" ||
 				pf == "class_get_integer_constant_list" || pf == "class_has_integer_constant" || pf == "class_get_integer_constant" ||
 				pf == "class_has_enum" || pf == "class_get_enum_list" || pf == "class_get_enum_constants" || pf == "class_get_integer_constant_enum" ||
-				pf == "is_class_enabled" || pf == "is_class_enum_bitfield" || pf == "class_get_api_type");
+				pf == "is_class_enabled" || pf == "is_class_exposed" || pf == "is_class_enum_bitfield" || pf == "class_get_api_type");
 	}
 	if (first_argument_is_class || pf == "is_parent_class") {
 		for (const String &E : get_class_list()) {
@@ -1738,6 +1742,8 @@ void ClassDB::_bind_methods() {
 	::ClassDB::bind_method(D_METHOD("is_class_enum_bitfield", "class", "enum", "no_inheritance"), &ClassDB::is_class_enum_bitfield, DEFVAL(false));
 
 	::ClassDB::bind_method(D_METHOD("is_class_enabled", "class"), &ClassDB::is_class_enabled);
+
+	::ClassDB::bind_method(D_METHOD("is_class_exposed", "class"), &ClassDB::is_class_exposed);
 
 	BIND_ENUM_CONSTANT(API_CORE);
 	BIND_ENUM_CONSTANT(API_EDITOR);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -516,6 +516,8 @@ public:
 
 	bool is_class_enabled(const StringName &p_class) const;
 
+	bool is_class_exposed(const StringName &p_class) const;
+
 #ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 #endif

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -240,6 +240,13 @@
 				Returns whether [param class] (or its ancestor classes if [param no_inheritance] is [code]false[/code]) has an enum called [param enum] that is a bitfield.
 			</description>
 		</method>
+		<method name="is_class_exposed" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="class" type="StringName" />
+			<description>
+				Returns whether this [param class] is accessible to scripting languages or not.
+			</description>
+		</method>
 		<method name="is_parent_class" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="class" type="StringName" />


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/10216
**Does not close, but allows working around these:** https://github.com/godotengine/godot-proposals/issues/9160 and https://github.com/godotengine/godot-proposals/issues/7281

This function is useful to any type of dynamic workflow that may want to create scripts during runtime that uses classes from ClassDB.

Exposing it can prevent parsing errors by filtering out unavailable classes.

## Changes
- Added bindings in `core_bind.h` and `core_bind.cpp`
- Added function documentation in `ClassDB.xml`

I'm not well versed in the engine code and in advanced C++, so I copied the implementation of `ClassDB::is_class_enabled`.

## Sample Project
[exposed-test.zip](https://github.com/user-attachments/files/18880532/exposed-test.zip)
This project shows two ways of listing available classes. Use the buttons available in the inspector to test them.

The first is the current and only way, by brute forcing. It uses a dynamic script that runs for every class in ClassDB and identifies the ones that don't throw errors.
It results in 850 parse errors, and it must cache the failing names to not crash during runtime.

The second is using the exposed function to filter out unavailable classes before running the dynamic script.
It results in only 3 errors that only happen due to 3 classes with known problems (see https://github.com/godotengine/godot/issues/52162 and https://github.com/godotengine/godot/issues/86132), and it does not require any caching for runtime.