### PR TITLE
Fix black bars appearing when using `background_color` on a TextEdit/CodeEdit.

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -884,12 +884,10 @@ void TextEdit::_notification(int p_what) {
 
 					Color line_background_color = text.get_line_background_color(minimap_line);
 
-					if (line_background_color != theme_cache.background_color) {
-						// Make non-default background colors more visible, such as error markers.
-						line_background_color.a = 1.0;
-					} else {
-						line_background_color.a *= 0.6;
-					}
+					// Make non-default background colors more visible, such as error markers.
+					// If a line background color is being applied, like in an error marker, the alpha is set to 1.0.
+					// Else, it stays zero.
+					line_background_color.a = 1.0 * (line_background_color != Color(0, 0, 0, 0));
 
 					Color current_color = editable ? theme_cache.font_color : theme_cache.font_readonly_color;
 


### PR DESCRIPTION
Fixes #102844  by equating the line_background_color in a slightly different way before applying alpha. 
This preserves editor error highlighting and fixes the above mentioned bug in a simple way. 
Editor error highlighting preserved. (See Minimap)
![image](https://github.com/user-attachments/assets/8476e8c2-ce31-45ff-b60c-c9dafb8e1d49)
Bug is eradicated.
![image](https://github.com/user-attachments/assets/ae57f317-f9ec-41b0-9bce-ca2019a82f21)
![image](https://github.com/user-attachments/assets/18735409-58c4-4cbf-98c1-a3d132758370)
![image](https://github.com/user-attachments/assets/9a07dac0-3a81-4bf2-8c39-90f97c615eb8)

_In theory this is not the best way to solve it._ Ideally, the user should be using the Stylebox in the theme settings to change the background colour of the Text Edit, but since this option exists, and removing it might break existing projects, I decided to fix it this way instead. **This issue may not fix other issues with regards to setting the `background_color`** property in a theme, this is only intended as a fix for #102844. 

The previous solution was checking if the `line_background_color` was not equal to the theme's `background_color` property. `line_background_color` is usually `#00000000`, with the notable exception of errors. I am not sure where else this property is used. However, on setting the `background_color` in the theme, it becomes something other than `#00000000` which makes the resulting if statement return `true` instead, and it's alpha gets set to `1`, giving the resultant `#000000ff` and hence, the signature black bars. By checking it against `#00000000` directly, the if statement will return `false` unless `line_background_color` is being set.

P.S. This is my first commit to Godot. Please let me know how I can improve future commits (if any) and what I should be doing differently. 


