### PR TITLE
Reimplement SignedAngleTo to be invariant along the rotation axis

### DIFF
--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -315,10 +315,10 @@ real_t Vector3::angle_to(const Vector3 &p_to) const {
 }
 
 real_t Vector3::signed_angle_to(const Vector3 &p_to, const Vector3 &p_axis) const {
-	Vector3 cross_to = cross(p_to);
-	real_t unsigned_angle = Math::atan2(cross_to.length(), dot(p_to));
-	real_t sign = cross_to.dot(p_axis);
-	return (sign < 0) ? -unsigned_angle : unsigned_angle;
+	Vector3 axis_norm = p_axis.normalized();
+	Vector3 vy = p_axis.cross(*this);
+	Vector3 vx = vy.cross(axis_norm);
+	return Math::atan2(p_to.dot(vy), p_to.dot(vx));
 }
 
 Vector3 Vector3::direction_to(const Vector3 &p_to) const {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -666,10 +666,10 @@ namespace Godot
         /// <returns>The signed angle between the two vectors, in radians.</returns>
         public readonly real_t SignedAngleTo(Vector3 to, Vector3 axis)
         {
-            Vector3 crossTo = Cross(to);
-            real_t unsignedAngle = Mathf.Atan2(crossTo.Length(), Dot(to));
-            real_t sign = crossTo.Dot(axis);
-            return (sign < 0) ? -unsignedAngle : unsignedAngle;
+            var axisNorm = axis.Normalized();
+            var vY = axis.Cross(this);
+            var vX = vY.Cross(axisNorm);
+            return Mathf.Atan2(to.Dot(vY), to.Dot(vX));
         }
 
         /// <summary>

--- a/tests/core/math/test_vector3.h
+++ b/tests/core/math/test_vector3.h
@@ -51,6 +51,7 @@ TEST_CASE("[Vector3] Angle methods") {
 	const Vector3 vector_x = Vector3(1, 0, 0);
 	const Vector3 vector_y = Vector3(0, 1, 0);
 	const Vector3 vector_yz = Vector3(0, 1, 1);
+	const Vector3 vector_out_of_plane = Vector3(-1, 1, 1);
 	CHECK_MESSAGE(
 			vector_x.angle_to(vector_y) == doctest::Approx((real_t)Math_TAU / 4),
 			"Vector3 angle_to should work as expected.");
@@ -72,6 +73,10 @@ TEST_CASE("[Vector3] Angle methods") {
 			"Vector3 signed_angle_to should work as expected.");
 	CHECK_MESSAGE(
 			vector_yz.signed_angle_to(vector_x, vector_y) == doctest::Approx((real_t)Math_TAU / 4),
+			"Vector3 signed_angle_to should work as expected.");
+
+	CHECK_MESSAGE(
+			vector_x.signed_angle_to(vector_out_of_plane, vector_y) == doctest::Approx((real_t)Math_PI * -0.75),
 			"Vector3 signed_angle_to should work as expected.");
 }
 


### PR DESCRIPTION
Fixes #103022.

I don't have time to set up a build environment - needs validation.

No tests for dotnet impl?

This is potentially dangerous, as it does change existing behavior. I noticed commentary on #83650 that suggests this might be intentional. Maybe this could be reworked as a "signed_planar_angle" or similar.