### PR TITLE
Style: Begin integrating simple clangd fixes

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -5,7 +5,6 @@
 Diagnostics:
   Includes:
     IgnoreHeader:
-      - core/typedefs\.h # Our "main" header, featuring transitive includes; allow everywhere.
       - \.compat\.inc
 ---
 # Header-specific conditions.

--- a/core/error/error_macros.cpp
+++ b/core/error/error_macros.cpp
@@ -31,6 +31,7 @@
 #include "error_macros.h"
 
 #include "core/io/logger.h"
+#include "core/object/object_id.h"
 #include "core/os/os.h"
 #include "core/string/ustring.h"
 

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -30,12 +30,12 @@
 
 #pragma once
 
-#include "core/object/object_id.h"
 #include "core/typedefs.h"
 
-#include <atomic> // We'd normally use safe_refcount.h, but that would cause circular includes.
+#include <atomic> // IWYU pragma: keep // Used in macro. We'd normally use `safe_refcount.h`, but that would cause circular includes.
 
 class String;
+class ObjectID;
 
 enum ErrorHandlerType {
 	ERR_HANDLER_ERROR,

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -31,7 +31,6 @@
 #include "image.h"
 
 #include "core/config/project_settings.h"
-#include "core/error/error_list.h"
 #include "core/error/error_macros.h"
 #include "core/io/image_loader.h"
 #include "core/io/resource_loader.h"

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -51,6 +51,8 @@
 // and pairable_mask is either 0 if static, or set to all if non static
 
 #include "bvh_tree.h"
+
+#include "core/math/geometry_3d.h"
 #include "core/os/mutex.h"
 
 #define BVHTREE_CLASS BVH_Tree<T, NUM_TREES, 2, MAX_ITEMS, USER_PAIR_TEST_FUNCTION, USER_CULL_TEST_FUNCTION, USE_PAIRS, BOUNDS, POINT>

--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "core/math/aabb.h"
+
 // special optimized version of axis aligned bounding box
 template <typename BOUNDS = AABB, typename POINT = Vector3>
 struct BVH_ABB {

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -40,7 +40,6 @@
 
 #include "core/math/aabb.h"
 #include "core/math/bvh_abb.h"
-#include "core/math/geometry_3d.h"
 #include "core/math/vector3.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/pooled_list.h"

--- a/core/math/color_names.inc
+++ b/core/math/color_names.inc
@@ -36,6 +36,8 @@
 // the old way leaked memory
 // this is not used as often as for more performance to make sense
 
+#include "core/math/color.h"
+
 struct NamedColor {
 	const char *name;
 	Color color;

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -30,14 +30,13 @@
 
 #pragma once
 
-#include "core/io/file_access.h"
 #include "core/math/aabb.h"
 #include "core/math/projection.h"
 #include "core/math/vector3.h"
+#include "core/templates/list.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/oa_hash_map.h"
 #include "core/templates/vector.h"
-#include "core/variant/variant.h"
 
 #include "thirdparty/misc/r128.h"
 

--- a/core/math/disjoint_set.h
+++ b/core/math/disjoint_set.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/templates/rb_map.h"
+#include "core/templates/hash_map.h"
 #include "core/templates/vector.h"
 
 /* This DisjointSet class uses Find with path compression and Union by rank */

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -30,6 +30,8 @@
 
 #include "geometry_3d.h"
 
+#include "core/templates/hash_map.h"
+
 void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1, Vector3 &r_ps, Vector3 &r_qt) {
 	// Based on David Eberly's Computation of Distance Between Line Segments algorithm.
 

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -32,7 +32,6 @@
 
 #include "core/math/delaunay_3d.h"
 #include "core/math/face3.h"
-#include "core/object/object.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/vector.h"
 

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -35,8 +35,6 @@
 #include "core/math/random_pcg.h"
 #include "core/typedefs.h"
 
-#include "thirdparty/misc/pcg.h"
-
 #include <float.h>
 #include <math.h>
 

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -30,6 +30,9 @@
 
 #include "quick_hull.h"
 
+#include "core/templates/hash_map.h"
+#include "core/templates/hash_set.h"
+
 uint32_t QuickHull::debug_stop_after = 0xFFFFFFFF;
 
 Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_mesh) {

--- a/core/math/static_raycaster.h
+++ b/core/math/static_raycaster.h
@@ -32,16 +32,6 @@
 
 #include "core/object/ref_counted.h"
 
-#if !defined(__aligned)
-
-#if defined(_WIN32) && defined(_MSC_VER)
-#define __aligned(...) __declspec(align(__VA_ARGS__))
-#else
-#define __aligned(...) __attribute__((aligned(__VA_ARGS__)))
-#endif
-
-#endif
-
 class StaticRaycaster : public RefCounted {
 	GDCLASS(StaticRaycaster, RefCounted)
 protected:
@@ -49,7 +39,7 @@ protected:
 
 public:
 	// Compatible with embree4 rays.
-	struct __aligned(16) Ray {
+	struct alignas(16) Ray {
 		const static unsigned int INVALID_GEOMETRY_ID = ((unsigned int)-1); // from rtcore_common.h
 
 		/*! Default construction does nothing. */

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -211,8 +211,6 @@ def run(target, source, env):
 
 #include "core/object/script_instance.h"
 
-#include <utility>
-
 #ifdef TOOLS_ENABLED
 #define _GDVIRTUAL_TRACK(m_virtual, m_initialized)\\
 	if (_get_extension()->reloadable) {\\

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -33,9 +33,8 @@
 #include "core/error/error_macros.h"
 #include "core/templates/safe_refcount.h"
 
-#include <stddef.h>
 #include <cstring>
-#include <new>
+#include <new> // IWYU pragma: keep // `new` operators.
 #include <type_traits>
 
 class Memory {

--- a/core/os/semaphore.h
+++ b/core/os/semaphore.h
@@ -30,11 +30,8 @@
 
 #pragma once
 
-#include <cstdint>
-
 #ifdef THREADS_ENABLED
 
-#include "core/error/error_list.h"
 #include "core/typedefs.h"
 #ifdef DEBUG_ENABLED
 #include "core/error/error_macros.h"

--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -30,9 +30,9 @@
 
 #include "translation_po.h"
 
+#ifdef DEBUG_TRANSLATION_PO
 #include "core/io/file_access.h"
 
-#ifdef DEBUG_TRANSLATION_PO
 void TranslationPO::print_translation_map() {
 	Error err;
 	Ref<FileAccess> file = FileAccess::open("translation_map_print_test.txt", FileAccess::WRITE, &err);

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -32,7 +32,7 @@
 
 // Note: _GODOT suffix added to header guard to avoid conflict with ICU header.
 
-#include "core/string/char_utils.h"
+#include "core/string/char_utils.h" // IWYU pragma: export
 #include "core/templates/cowdata.h"
 #include "core/templates/vector.h"
 #include "core/typedefs.h"

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -38,7 +38,6 @@
 #include <string.h>
 #include <initializer_list>
 #include <type_traits>
-#include <utility>
 
 template <typename T>
 class Vector;

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -30,11 +30,8 @@
 
 #pragma once
 
-#include "core/math/math_funcs.h"
 #include "core/os/memory.h"
-#include "core/templates/hash_map.h"
 #include "core/templates/hashfuncs.h"
-#include "core/templates/paged_allocator.h"
 
 /**
  * Implementation of Set using a bidi indexed hash map.

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -277,7 +277,7 @@ public:
 	}
 
 	void sort() {
-		sort_custom<_DefaultComparator<T>>();
+		sort_custom<Comparator<T>>();
 	}
 
 	void ordered_insert(T p_val) {

--- a/core/templates/lru.h
+++ b/core/templates/lru.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/math/math_funcs.h"
 #include "hash_map.h"
 #include "list.h"
 

--- a/core/templates/oa_hash_map.h
+++ b/core/templates/oa_hash_map.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/math/math_funcs.h"
 #include "core/os/memory.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/pair.h"

--- a/core/templates/paged_allocator.h
+++ b/core/templates/paged_allocator.h
@@ -37,7 +37,7 @@
 #include "core/typedefs.h"
 
 #include <type_traits>
-#include <typeinfo>
+#include <typeinfo> // IWYU pragma: keep // Used in macro.
 
 template <typename T, bool thread_safe = false, uint32_t DEFAULT_PAGE_SIZE = 4096>
 class PagedAllocator {

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -38,7 +38,7 @@
 #include "core/templates/safe_refcount.h"
 
 #include <stdio.h>
-#include <typeinfo>
+#include <typeinfo> // IWYU pragma: keep // Used in macro.
 
 #ifdef SANITIZERS_ENABLED
 #ifdef __has_feature

--- a/core/templates/safe_list.h
+++ b/core/templates/safe_list.h
@@ -36,7 +36,6 @@
 #include <atomic>
 #include <functional>
 #include <initializer_list>
-#include <type_traits>
 
 // Design goals for these classes:
 // - Accessing this list with an iterator will never result in a use-after free,

--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -37,7 +37,7 @@
 #endif
 
 #include <atomic>
-#include <type_traits>
+#include <type_traits> // IWYU pragma: keep // Used in macro.
 
 // Design goals for these classes:
 // - No automatic conversions or arithmetic operators,

--- a/core/templates/search_array.h
+++ b/core/templates/search_array.h
@@ -30,9 +30,9 @@
 
 #pragma once
 
-#include <core/templates/sort_array.h>
+#include "core/typedefs.h"
 
-template <typename T, typename Comparator = _DefaultComparator<T>>
+template <typename T, typename Comparator = Comparator<T>>
 class SearchArray {
 public:
 	Comparator compare;

--- a/core/templates/sort_array.h
+++ b/core/templates/sort_array.h
@@ -39,18 +39,13 @@
 		break;                                                        \
 	}
 
-template <typename T>
-struct _DefaultComparator {
-	_FORCE_INLINE_ bool operator()(const T &a, const T &b) const { return (a < b); }
-};
-
 #ifdef DEBUG_ENABLED
 #define SORT_ARRAY_VALIDATE_ENABLED true
 #else
 #define SORT_ARRAY_VALIDATE_ENABLED false
 #endif
 
-template <typename T, typename Comparator = _DefaultComparator<T>, bool Validate = SORT_ARRAY_VALIDATE_ENABLED>
+template <typename T, typename Comparator = Comparator<T>, bool Validate = SORT_ARRAY_VALIDATE_ENABLED>
 class SortArray {
 	enum {
 		INTROSORT_THRESHOLD = 16

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -39,14 +39,11 @@
  */
 
 #include "core/error/error_macros.h"
-#include "core/os/memory.h"
 #include "core/templates/cowdata.h"
 #include "core/templates/search_array.h"
 #include "core/templates/sort_array.h"
 
-#include <climits>
 #include <initializer_list>
-#include <utility>
 
 template <typename T>
 class VectorWriteProxy {
@@ -131,7 +128,7 @@ public:
 	_FORCE_INLINE_ bool has(const T &p_val) const { return find(p_val) != -1; }
 
 	void sort() {
-		sort_custom<_DefaultComparator<T>>();
+		sort_custom<Comparator<T>>();
 	}
 
 	template <typename Comparator, bool Validate = SORT_ARRAY_VALIDATE_ENABLED, typename... Args>
@@ -147,7 +144,7 @@ public:
 	}
 
 	Size bsearch(const T &p_value, bool p_before) {
-		return bsearch_custom<_DefaultComparator<T>>(p_value, p_before);
+		return bsearch_custom<Comparator<T>>(p_value, p_before);
 	}
 
 	template <typename Comparator, typename Value, typename... Args>

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -30,22 +30,29 @@
 
 #pragma once
 
-#include <stddef.h>
-
 /**
  * Basic definitions and simple functions to be used everywhere.
  */
+
+// IWYU pragma: always_keep
+
+// Ensure that C++ standard is at least C++17.
+// If on MSVC, also ensures that the `Zc:__cplusplus` flag is present.
+static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
+
+// IWYU pragma: begin_exports
 
 // Include first in case the platform needs to pre-define/include some things.
 #include "platform_config.h"
 
 // Should be available everywhere.
 #include "core/error/error_list.h"
+
+#include <cstddef>
 #include <cstdint>
 #include <utility>
 
-// Ensure that C++ standard is at least C++17. If on MSVC, also ensures that the `Zc:__cplusplus` flag is present.
-static_assert(__cplusplus >= 201703L);
+// IWYU pragma: end_exports
 
 // Turn argument to string constant:
 // https://gcc.gnu.org/onlinedocs/cpp/Stringizing.html#Stringizing

--- a/core/version.h
+++ b/core/version.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/version_generated.gen.h"
+#include "core/version_generated.gen.h" // IWYU pragma: export
 
 #include <stdint.h>
 

--- a/drivers/d3d12/rendering_context_driver_d3d12.h
+++ b/drivers/d3d12/rendering_context_driver_d3d12.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/error/error_list.h"
 #include "core/os/mutex.h"
 #include "core/string/ustring.h"
 #include "core/templates/rid_owner.h"

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -35,8 +35,6 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 
-#include <stdint.h> // INT32_MAX
-
 #include <functiondiscoverykeys.h>
 
 #include <wrl/client.h>

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -38,7 +38,7 @@
 #include "core/object/script_language.h"
 #include "core/os/keyboard.h"
 #include "core/string/string_builder.h"
-#include "core/version_generated.gen.h"
+#include "core/version.h"
 #include "editor/doc_data_compressed.gen.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_main_screen.h"

--- a/editor/editor_translation_parser.h
+++ b/editor/editor_translation_parser.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/error/error_list.h"
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/ref_counted.h"
 #include "core/variant/typed_array.h"

--- a/main/main.h
+++ b/main/main.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/error/error_list.h"
 #include "core/os/thread.h"
 #include "core/typedefs.h"
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -59,8 +59,6 @@
 #include "editor/editor_paths.h"
 #endif
 
-#include <stdint.h>
-
 ///////////////////////////
 
 GDScriptNativeClass::GDScriptNativeClass(const StringName &p_name) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -79,7 +79,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <cstdint>
 
 constexpr int COMPONENT_COUNT_FOR_ACCESSOR_TYPE[7] = {
 	1, 2, 3, 4, 4, 9, 16

--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
@@ -43,7 +43,6 @@
 #include "Jolt/Physics/Collision/ContactListener.h"
 #include "Jolt/Physics/SoftBody/SoftBodyContactListener.h"
 
-#include <stdint.h>
 #include <new>
 
 class JoltShapedObject3D;

--- a/modules/jolt_physics/spaces/jolt_job_system.h
+++ b/modules/jolt_physics/spaces/jolt_job_system.h
@@ -38,7 +38,6 @@
 #include "Jolt/Core/FixedSizeFreeList.h"
 #include "Jolt/Core/JobSystemWithBarrier.h"
 
-#include <stdint.h>
 #include <atomic>
 
 class JoltJobSystem final : public JPH::JobSystemWithBarrier {

--- a/modules/jolt_physics/spaces/jolt_layers.h
+++ b/modules/jolt_physics/spaces/jolt_layers.h
@@ -38,8 +38,6 @@
 #include "Jolt/Physics/Collision/BroadPhase/BroadPhaseLayer.h"
 #include "Jolt/Physics/Collision/ObjectLayer.h"
 
-#include <stdint.h>
-
 class JoltLayers final
 		: public JPH::BroadPhaseLayerInterface,
 		  public JPH::ObjectLayerPairFilter,

--- a/modules/jolt_physics/spaces/jolt_space_3d.h
+++ b/modules/jolt_physics/spaces/jolt_space_3d.h
@@ -44,8 +44,6 @@
 #include "Jolt/Physics/Constraints/Constraint.h"
 #include "Jolt/Physics/PhysicsSystem.h"
 
-#include <stdint.h>
-
 class JoltArea3D;
 class JoltBody3D;
 class JoltContactListener3D;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -66,8 +66,6 @@
 #include "editor/node_dock.h"
 #endif
 
-#include <stdint.h>
-
 // Types that will be skipped over (in favor of their base types) when setting up instance bindings.
 // This must be a superset of `ignored_types` in bindings_generator.cpp.
 const Vector<String> ignored_types = {};

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -41,8 +41,6 @@
 #include "core/variant/dictionary.h"
 #include "core/variant/variant.h"
 
-#include <stdint.h>
-
 class CSharpScript;
 
 namespace GDMonoCache {

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -37,8 +37,6 @@
 #include "core/os/os.h"
 #endif
 
-#include <stdint.h>
-
 #ifdef DEBUG_ENABLED
 _FORCE_INLINE_ void SceneMultiplayer::_profile_bandwidth(const String &p_what, int p_value) {
 	if (EngineDebugger::is_profiling("multiplayer:bandwidth")) {

--- a/modules/websocket/emws_peer.h
+++ b/modules/websocket/emws_peer.h
@@ -35,7 +35,6 @@
 #include "packet_buffer.h"
 #include "websocket_peer.h"
 
-#include "core/error/error_list.h"
 #include "core/io/packet_peer.h"
 #include "core/templates/ring_buffer.h"
 

--- a/modules/websocket/websocket_multiplayer_peer.h
+++ b/modules/websocket/websocket_multiplayer_peer.h
@@ -32,7 +32,6 @@
 
 #include "websocket_peer.h"
 
-#include "core/error/error_list.h"
 #include "core/io/tcp_server.h"
 #include "core/templates/list.h"
 #include "scene/main/multiplayer_peer.h"

--- a/modules/websocket/websocket_peer.h
+++ b/modules/websocket/websocket_peer.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "core/crypto/crypto.h"
-#include "core/error/error_list.h"
 #include "core/io/packet_peer.h"
 
 class WebSocketPeer : public PacketPeer {

--- a/modules/websocket/wsl_peer.h
+++ b/modules/websocket/wsl_peer.h
@@ -36,7 +36,6 @@
 #include "websocket_peer.h"
 
 #include "core/crypto/crypto_core.h"
-#include "core/error/error_list.h"
 #include "core/io/stream_peer_tcp.h"
 
 #include <wslay/wslay.h>

--- a/platform/android/export/godot_plugin_config.h
+++ b/platform/android/export/godot_plugin_config.h
@@ -33,7 +33,6 @@
 #ifndef DISABLE_DEPRECATED
 
 #include "core/config/project_settings.h"
-#include "core/error/error_list.h"
 #include "core/io/config_file.h"
 #include "core/string/ustring.h"
 

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -30,7 +30,6 @@
 
 #include "java_godot_io_wrapper.h"
 
-#include "core/error/error_list.h"
 #include "core/math/rect2.h"
 #include "core/variant/variant.h"
 

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -40,7 +40,6 @@
 #include "core/io/zip_io.h"
 #include "core/os/os.h"
 #include "core/templates/safe_refcount.h"
-#include "core/version.h"
 #include "editor/editor_settings.h"
 #include "editor/export/editor_export_platform.h"
 #include "main/splash.gen.h"

--- a/platform/ios/export/godot_plugin_config.h
+++ b/platform/ios/export/godot_plugin_config.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/error/error_list.h"
 #include "core/io/config_file.h"
 #include "core/string/ustring.h"
 

--- a/platform/linuxbsd/x11/gl_manager_x11_egl.h
+++ b/platform/linuxbsd/x11/gl_manager_x11_egl.h
@@ -32,7 +32,6 @@
 
 #if defined(X11_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/error/error_list.h"
 #include "core/os/os.h"
 #include "core/templates/local_vector.h"
 #include "drivers/egl/egl_manager.h"

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -37,7 +37,6 @@
 #include "core/io/marshalls.h"
 #include "core/io/resource_saver.h"
 #include "core/os/os.h"
-#include "core/version.h"
 #include "editor/editor_settings.h"
 #include "editor/export/editor_export.h"
 

--- a/platform/macos/gl_manager_macos_angle.h
+++ b/platform/macos/gl_manager_macos_angle.h
@@ -32,7 +32,6 @@
 
 #if defined(MACOS_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/error/error_list.h"
 #include "core/os/os.h"
 #include "core/templates/local_vector.h"
 #include "drivers/egl/egl_manager.h"

--- a/platform/macos/gl_manager_macos_legacy.h
+++ b/platform/macos/gl_manager_macos_legacy.h
@@ -32,7 +32,6 @@
 
 #if defined(MACOS_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/error/error_list.h"
 #include "core/os/os.h"
 #include "core/templates/local_vector.h"
 #include "servers/display_server.h"

--- a/platform/windows/gl_manager_windows_angle.h
+++ b/platform/windows/gl_manager_windows_angle.h
@@ -32,7 +32,6 @@
 
 #if defined(WINDOWS_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/error/error_list.h"
 #include "core/os/os.h"
 #include "core/templates/local_vector.h"
 #include "drivers/egl/egl_manager.h"

--- a/platform/windows/gl_manager_windows_native.h
+++ b/platform/windows/gl_manager_windows_native.h
@@ -32,7 +32,6 @@
 
 #if defined(WINDOWS_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/error/error_list.h"
 #include "core/os/os.h"
 #include "core/templates/local_vector.h"
 #include "servers/display_server.h"

--- a/scene/3d/lightmapper.h
+++ b/scene/3d/lightmapper.h
@@ -34,16 +34,6 @@
 
 class Image;
 
-#if !defined(__aligned)
-
-#if defined(_WIN32) && defined(_MSC_VER)
-#define __aligned(...) __declspec(align(__VA_ARGS__))
-#else
-#define __aligned(...) __attribute__((aligned(__VA_ARGS__)))
-#endif
-
-#endif
-
 class LightmapDenoiser : public RefCounted {
 	GDCLASS(LightmapDenoiser, RefCounted)
 protected:
@@ -61,7 +51,7 @@ protected:
 
 public:
 	// Compatible with embree4 rays.
-	struct __aligned(16) Ray {
+	struct alignas(16) Ray {
 		const static unsigned int INVALID_GEOMETRY_ID = ((unsigned int)-1); // from rtcore_common.h
 
 		/*! Default construction does nothing. */

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -43,8 +43,6 @@
 #include "scene/resources/packed_scene.h"
 #include "viewport.h"
 
-#include <stdint.h>
-
 int Node::orphan_node_count = 0;
 
 thread_local Node *Node::current_process_thread_group = nullptr;

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -35,8 +35,6 @@
 #include "core/math/random_pcg.h"
 #include "scene/resources/surface_tool.h"
 
-#include <cstdint>
-
 String ImporterMesh::validate_blend_shape_name(const String &p_name) {
 	String name = p_name;
 	const char *characters = ":";

--- a/scene/resources/3d/importer_mesh.h
+++ b/scene/resources/3d/importer_mesh.h
@@ -36,8 +36,6 @@
 #include "scene/resources/mesh.h"
 #include "scene/resources/navigation_mesh.h"
 
-#include <cstdint>
-
 // The following classes are used by importers instead of ArrayMesh and MeshInstance3D
 // so the data is not registered (hence, quality loss), importing happens faster and
 // its easier to modify before saving


### PR DESCRIPTION
- Alternative to #100918

In contrast to the above PR, this aims to focus almost exclusively on basic header-related changes identified via clangd. So while a similar amount of files were touched, the actual functionality should be effectively identical & help address our header include issues. The only two non-header changes were replacing `_DefaultComparator` with `Comparator` (dependant files can now include `core/typedefs.h` instead of `core/templates/sort_array.h`) & replacing `__aligned` with the native `alignas` (fits the redundancy-removal theme).