### PR TITLE
Add check in `AnimationNodeOneShot` during fade-out to ensure signal fires

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -678,7 +678,7 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 	}
 
 	if (!p_seek) {
-		if (Animation::is_less_or_equal_approx(os_nti.get_remain(break_loop_at_end), 0) || (is_fading_out && Animation::is_less_or_equal_approx(cur_fade_out_remaining, 0))) {
+		if (Animation::is_less_or_equal_approx(os_nti.get_remain(break_loop_at_end), 0) || (is_fading_out && Animation::is_less_or_equal_approx(cur_fade_out_remaining, 0) && os_nti.length == os_nti.position)) {
 			set_parameter(internal_active, false);
 			set_parameter(active, false);
 			if (auto_restart) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/103070

I didn't use a floating point comparison here because it should match *exactly*. Also let me know if there would be any unintended side effects. Animation stuff is not my strong suit.  