### PR TITLE
Update CI `ruff` & `mypy` pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         stages: [manual] # Not automatically triggered, invoked via `pre-commit run --hook-stage manual clang-tidy`
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.4
+    rev: v0.9.10
     hooks:
       - id: ruff
         args: [--fix]
@@ -48,7 +48,7 @@ repos:
         types_or: [text]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.15.0
     hooks:
       - id: mypy
         files: \.py$


### PR DESCRIPTION
- `ruff`: 0.9.4 → ~0.9.7~ ~0.9.9~ [0.9.10](https://github.com/astral-sh/ruff/releases/tag/0.9.10)
- `mypy`: 1.14.1 → [1.15.0](https://github.com/python/mypy/releases/tag/v1.15.0)

---

No changes across the repo required, simple version bump.
