### PR TITLE
Fix captured mouse trying to grab SplitContainer during freelook

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5987,7 +5987,7 @@ void Node3DEditorViewportContainer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			if (mouseover) {
+			if (mouseover && Input::get_singleton()->get_mouse_mode() != Input::MOUSE_MODE_CAPTURED) {
 				Ref<Texture2D> h_grabber = get_theme_icon(SNAME("grabber"), SNAME("HSplitContainer"));
 				Ref<Texture2D> v_grabber = get_theme_icon(SNAME("grabber"), SNAME("VSplitContainer"));
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Trying to fix a bigger issue, but not sure about solution, so will submit the stuff that does make sense at least. 

Note the center of the video where the splitter container grabbers are. They show up because the captured mouse is at the center of the screen. 

Before: 

https://github.com/user-attachments/assets/c471d693-b59e-40f8-88b1-b4391670c1a9

After:


https://github.com/user-attachments/assets/daab435d-a214-4ded-9956-ff6f9d047406

