### PR TITLE
[DRAFT] Renderer hacks to allow Meta enivornment depth API to work from GDExtension

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -2618,6 +2618,17 @@ void TextureStorage::_texture_format_from_rd(RD::DataFormat p_rd_format, Texture
 
 		} break; // astc 8x8
 
+		// DRS: Add support for the depth format we need to use.
+		case RD::DATA_FORMAT_D16_UNORM: {
+			// Not the real image format.
+			r_format.image_format = Image::FORMAT_RH;
+			r_format.rd_format = RD::DATA_FORMAT_D16_UNORM;
+			r_format.swizzle_r = RD::TEXTURE_SWIZZLE_R;
+			r_format.swizzle_g = RD::TEXTURE_SWIZZLE_G;
+			r_format.swizzle_b = RD::TEXTURE_SWIZZLE_B;
+			r_format.swizzle_a = RD::TEXTURE_SWIZZLE_A;
+		} break;
+
 		default: {
 			ERR_FAIL_MSG("Unsupported image format");
 		}

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -837,6 +837,9 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 				// render...
 				RSG::scene->set_debug_draw_mode(vp->debug_draw);
 
+				// DRS: Update materials so that changes we made to uniforms in xr_interface->pre_draw_viewport() take effect.
+				RSG::scene->update();
+
 				// and draw viewport
 				_draw_viewport(vp);
 


### PR DESCRIPTION
**This is a DRAFT that will never be merged!**

I'm just making this PR to share some hacks necessary to implement Meta's environment depth API entirely from a GDExtension.

Ultimately, I think it makes sense to have some support for this in Godot itself, that different APIs (some from GDExtension) could plug into, and that will be the solution we actually merge. But I don't know what that should look like yet :-)

See https://github.com/GodotVR/godot_openxr_vendors/pull/273 for the actual depth API implementation

~~_Note: This hack doesn't work for Vulkan - I'm not sure why yet, it may need something additional_~~

**UPDATE (2025-02-25):** I figured out the missing piece for Vulkan! We needed to allow adding a texture from a native handle that uses a depth format.