### PR TITLE
Fix `friction` and `bounce` properties of `PhysicsMaterial`

### DIFF
--- a/scene/resources/physics_material.cpp
+++ b/scene/resources/physics_material.cpp
@@ -50,6 +50,7 @@ void PhysicsMaterial::_bind_methods() {
 }
 
 void PhysicsMaterial::set_friction(real_t p_val) {
+	ERR_FAIL_COND(p_val > 1.0);
 	friction = p_val;
 	emit_changed();
 }
@@ -60,6 +61,7 @@ void PhysicsMaterial::set_rough(bool p_val) {
 }
 
 void PhysicsMaterial::set_bounce(real_t p_val) {
+	ERR_FAIL_COND(p_val > 1.0);
 	bounce = p_val;
 	emit_changed();
 }

--- a/scene/resources/physics_material.cpp
+++ b/scene/resources/physics_material.cpp
@@ -43,9 +43,9 @@ void PhysicsMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_absorbent", "absorbent"), &PhysicsMaterial::set_absorbent);
 	ClassDB::bind_method(D_METHOD("is_absorbent"), &PhysicsMaterial::is_absorbent);
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "friction", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"), "set_friction", "get_friction");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "friction", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_friction", "get_friction");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rough"), "set_rough", "is_rough");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bounce", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"), "set_bounce", "get_bounce");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bounce", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_bounce", "get_bounce");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "absorbent"), "set_absorbent", "is_absorbent");
 }
 


### PR DESCRIPTION
According to the Godot documentation, the FRICTION and BOUNCE properties of the PhysicsMaterial class can have a maximum value of 1.0, however, in the Godot inspector, it is possible to assign a value above 1.0 because of the "or_greater" when exporting these variables and it is also possible to assign values ​​above 1.0 via code (see image captured below). What I did was remove the "or_greater" when exporting these properties, add one more decimal place to both to make it easier for the user to slide with the mouse in the inspector and I added a condition in the set_bounce and set_friction methods so that they do not assign values ​​above 1.0 via code.


![Captura de tela 2025-02-20 182748](https://github.com/user-attachments/assets/71bdff8d-fa5c-4aac-867c-16165d7b747b)
