### PR TITLE
Disable `ResourceFormatLoader/Saver`s of disabled classes

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -563,4 +563,6 @@ _FORCE_INLINE_ Vector<Error> errarray(P... p_args) {
 
 #define GDREGISTER_NATIVE_STRUCT(m_class, m_code) ClassDB::register_native_struct(#m_class, m_code, sizeof(m_class))
 
+#define GD_IS_CLASS_ENABLED(m_class) m_class::_class_is_enabled
+
 #include "core/disabled_classes.gen.h"

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -137,8 +137,10 @@ void register_core_types() {
 
 	CoreStringNames::create();
 
-	resource_format_po.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_format_po);
+	if (GD_IS_CLASS_ENABLED(Translation)) {
+		resource_format_po.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_format_po);
+	}
 
 	resource_saver_binary.instantiate();
 	ResourceSaver::add_resource_format_saver(resource_saver_binary);
@@ -151,8 +153,10 @@ void register_core_types() {
 	resource_format_importer_saver.instantiate();
 	ResourceSaver::add_resource_format_saver(resource_format_importer_saver);
 
-	resource_format_image.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_format_image);
+	if (GD_IS_CLASS_ENABLED(Image)) {
+		resource_format_image.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_format_image);
+	}
 
 	GDREGISTER_CLASS(Object);
 
@@ -219,16 +223,21 @@ void register_core_types() {
 	ClassDB::register_custom_instance_class<PacketPeerDTLS>();
 	ClassDB::register_custom_instance_class<DTLSServer>();
 
-	resource_format_saver_crypto.instantiate();
-	ResourceSaver::add_resource_format_saver(resource_format_saver_crypto);
-	resource_format_loader_crypto.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_format_loader_crypto);
+	if (GD_IS_CLASS_ENABLED(Crypto)) {
+		resource_format_saver_crypto.instantiate();
+		ResourceSaver::add_resource_format_saver(resource_format_saver_crypto);
 
-	resource_loader_json.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_loader_json);
+		resource_format_loader_crypto.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_format_loader_crypto);
+	}
 
-	resource_saver_json.instantiate();
-	ResourceSaver::add_resource_format_saver(resource_saver_json);
+	if (GD_IS_CLASS_ENABLED(JSON)) {
+		resource_saver_json.instantiate();
+		ResourceSaver::add_resource_format_saver(resource_saver_json);
+
+		resource_loader_json.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_json);
+	}
 
 	GDREGISTER_CLASS(MainLoop);
 	GDREGISTER_CLASS(Translation);
@@ -277,8 +286,10 @@ void register_core_types() {
 
 	gdextension_manager = memnew(GDExtensionManager);
 
-	resource_loader_gdextension.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_loader_gdextension);
+	if (GD_IS_CLASS_ENABLED(GDExtension)) {
+		resource_loader_gdextension.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_gdextension);
+	}
 
 	ip = IP::create();
 
@@ -409,8 +420,10 @@ void unregister_core_types() {
 		memdelete(ip);
 	}
 
-	ResourceLoader::remove_resource_format_loader(resource_format_image);
-	resource_format_image.unref();
+	if (GD_IS_CLASS_ENABLED(Image)) {
+		ResourceLoader::remove_resource_format_loader(resource_format_image);
+		resource_format_image.unref();
+	}
 
 	ResourceSaver::remove_resource_format_saver(resource_saver_binary);
 	resource_saver_binary.unref();
@@ -424,22 +437,31 @@ void unregister_core_types() {
 	ResourceSaver::remove_resource_format_saver(resource_format_importer_saver);
 	resource_format_importer_saver.unref();
 
-	ResourceLoader::remove_resource_format_loader(resource_format_po);
-	resource_format_po.unref();
+	if (GD_IS_CLASS_ENABLED(Translation)) {
+		ResourceLoader::remove_resource_format_loader(resource_format_po);
+		resource_format_po.unref();
+	}
 
-	ResourceSaver::remove_resource_format_saver(resource_format_saver_crypto);
-	resource_format_saver_crypto.unref();
-	ResourceLoader::remove_resource_format_loader(resource_format_loader_crypto);
-	resource_format_loader_crypto.unref();
+	if (GD_IS_CLASS_ENABLED(Crypto)) {
+		ResourceSaver::remove_resource_format_saver(resource_format_saver_crypto);
+		resource_format_saver_crypto.unref();
 
-	ResourceSaver::remove_resource_format_saver(resource_saver_json);
-	resource_saver_json.unref();
+		ResourceLoader::remove_resource_format_loader(resource_format_loader_crypto);
+		resource_format_loader_crypto.unref();
+	}
 
-	ResourceLoader::remove_resource_format_loader(resource_loader_json);
-	resource_loader_json.unref();
+	if (GD_IS_CLASS_ENABLED(JSON)) {
+		ResourceSaver::remove_resource_format_saver(resource_saver_json);
+		resource_saver_json.unref();
 
-	ResourceLoader::remove_resource_format_loader(resource_loader_gdextension);
-	resource_loader_gdextension.unref();
+		ResourceLoader::remove_resource_format_loader(resource_loader_json);
+		resource_loader_json.unref();
+	}
+
+	if (GD_IS_CLASS_ENABLED(GDExtension)) {
+		ResourceLoader::remove_resource_format_loader(resource_loader_gdextension);
+		resource_loader_gdextension.unref();
+	}
 
 	ResourceLoader::finalize();
 

--- a/modules/dds/register_types.cpp
+++ b/modules/dds/register_types.cpp
@@ -33,6 +33,8 @@
 #include "image_saver_dds.h"
 #include "texture_loader_dds.h"
 
+#include "scene/resources/texture.h"
+
 static Ref<ResourceFormatDDS> resource_loader_dds;
 
 void initialize_dds_module(ModuleInitializationLevel p_level) {
@@ -43,8 +45,10 @@ void initialize_dds_module(ModuleInitializationLevel p_level) {
 	Image::save_dds_func = save_dds;
 	Image::save_dds_buffer_func = save_dds_buffer;
 
-	resource_loader_dds.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_loader_dds);
+	if (GD_IS_CLASS_ENABLED(Texture)) {
+		resource_loader_dds.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_dds);
+	}
 }
 
 void uninitialize_dds_module(ModuleInitializationLevel p_level) {
@@ -52,8 +56,11 @@ void uninitialize_dds_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	ResourceLoader::remove_resource_format_loader(resource_loader_dds);
-	resource_loader_dds.unref();
+	if (GD_IS_CLASS_ENABLED(Texture)) {
+		ResourceLoader::remove_resource_format_loader(resource_loader_dds);
+		resource_loader_dds.unref();
+	}
+
 	Image::save_dds_func = nullptr;
 	Image::save_dds_buffer_func = nullptr;
 }

--- a/modules/gltf/tests/test_gltf.h
+++ b/modules/gltf/tests/test_gltf.h
@@ -70,8 +70,10 @@ static Node *gltf_import(const String &p_file) {
 
 	// Once editor import convert pngs to ctex, we will need to load it as ctex resource.
 	Ref<ResourceFormatLoaderCompressedTexture2D> resource_loader_stream_texture;
-	resource_loader_stream_texture.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_loader_stream_texture);
+	if (GD_IS_CLASS_ENABLED(CompressedTexture2D)) {
+		resource_loader_stream_texture.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_stream_texture);
+	}
 
 	HashMap<StringName, Variant> options(21);
 	options["nodes/root_type"] = "";
@@ -105,7 +107,10 @@ static Node *gltf_import(const String &p_file) {
 
 	ResourceImporterScene::remove_scene_importer(import_gltf);
 	ResourceFormatImporter::get_singleton()->remove_importer(import_texture);
-	ResourceLoader::remove_resource_format_loader(resource_loader_stream_texture);
+	if (GD_IS_CLASS_ENABLED(CompressedTexture2D)) {
+		ResourceLoader::remove_resource_format_loader(resource_loader_stream_texture);
+		resource_loader_stream_texture.unref();
+	}
 	return p_scene;
 }
 

--- a/modules/ktx/register_types.cpp
+++ b/modules/ktx/register_types.cpp
@@ -32,6 +32,8 @@
 
 #include "texture_loader_ktx.h"
 
+#include "scene/resources/image_texture.h"
+
 static Ref<ResourceFormatKTX> resource_loader_ktx;
 
 void initialize_ktx_module(ModuleInitializationLevel p_level) {
@@ -39,8 +41,10 @@ void initialize_ktx_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	resource_loader_ktx.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_loader_ktx);
+	if (GD_IS_CLASS_ENABLED(ImageTexture)) {
+		resource_loader_ktx.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_ktx);
+	}
 }
 
 void uninitialize_ktx_module(ModuleInitializationLevel p_level) {
@@ -48,6 +52,8 @@ void uninitialize_ktx_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	ResourceLoader::remove_resource_format_loader(resource_loader_ktx);
-	resource_loader_ktx.unref();
+	if (GD_IS_CLASS_ENABLED(ImageTexture)) {
+		ResourceLoader::remove_resource_format_loader(resource_loader_ktx);
+		resource_loader_ktx.unref();
+	}
 }

--- a/modules/mono/register_types.cpp
+++ b/modules/mono/register_types.cpp
@@ -53,11 +53,12 @@ void initialize_mono_module(ModuleInitializationLevel p_level) {
 	script_language_cs->set_language_index(ScriptServer::get_language_count());
 	ScriptServer::register_language(script_language_cs);
 
-	resource_loader_cs.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_loader_cs);
-
-	resource_saver_cs.instantiate();
-	ResourceSaver::add_resource_format_saver(resource_saver_cs);
+	if (GD_IS_CLASS_ENABLED(CSharpScript)) {
+		resource_loader_cs.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_cs);
+		resource_saver_cs.instantiate();
+		ResourceSaver::add_resource_format_saver(resource_saver_cs);
+	}
 }
 
 void uninitialize_mono_module(ModuleInitializationLevel p_level) {
@@ -71,11 +72,12 @@ void uninitialize_mono_module(ModuleInitializationLevel p_level) {
 		memdelete(script_language_cs);
 	}
 
-	ResourceLoader::remove_resource_format_loader(resource_loader_cs);
-	resource_loader_cs.unref();
-
-	ResourceSaver::remove_resource_format_saver(resource_saver_cs);
-	resource_saver_cs.unref();
+	if (GD_IS_CLASS_ENABLED(CSharpScript)) {
+		ResourceLoader::remove_resource_format_loader(resource_loader_cs);
+		resource_loader_cs.unref();
+		ResourceSaver::remove_resource_format_saver(resource_saver_cs);
+		resource_saver_cs.unref();
+	}
 
 	if (_godotsharp) {
 		memdelete(_godotsharp);

--- a/modules/multiplayer/register_types.cpp
+++ b/modules/multiplayer/register_types.cpp
@@ -48,8 +48,10 @@ void initialize_multiplayer_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(MultiplayerSynchronizer);
 		GDREGISTER_CLASS(OfflineMultiplayerPeer);
 		GDREGISTER_CLASS(SceneMultiplayer);
-		MultiplayerAPI::set_default_interface("SceneMultiplayer");
-		MultiplayerDebugger::initialize();
+		if (GD_IS_CLASS_ENABLED(MultiplayerAPI)) {
+			MultiplayerAPI::set_default_interface("SceneMultiplayer");
+			MultiplayerDebugger::initialize();
+		}
 	}
 #ifdef TOOLS_ENABLED
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
@@ -59,5 +61,7 @@ void initialize_multiplayer_module(ModuleInitializationLevel p_level) {
 }
 
 void uninitialize_multiplayer_module(ModuleInitializationLevel p_level) {
-	MultiplayerDebugger::deinitialize();
+	if (GD_IS_CLASS_ENABLED(MultiplayerAPI)) {
+		MultiplayerDebugger::deinitialize();
+	}
 }

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -340,14 +340,20 @@ void register_scene_types() {
 
 	Node::init_node_hrcr();
 
-	resource_loader_stream_texture.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_loader_stream_texture);
+	if (GD_IS_CLASS_ENABLED(CompressedTexture2D)) {
+		resource_loader_stream_texture.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_stream_texture);
+	}
 
-	resource_loader_texture_layered.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_loader_texture_layered);
+	if (GD_IS_CLASS_ENABLED(TextureLayered)) {
+		resource_loader_texture_layered.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_texture_layered);
+	}
 
-	resource_loader_texture_3d.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_loader_texture_3d);
+	if (GD_IS_CLASS_ENABLED(Texture3D)) {
+		resource_loader_texture_3d.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_texture_3d);
+	}
 
 	resource_saver_text.instantiate();
 	ResourceSaver::add_resource_format_saver(resource_saver_text, true);
@@ -355,17 +361,21 @@ void register_scene_types() {
 	resource_loader_text.instantiate();
 	ResourceLoader::add_resource_format_loader(resource_loader_text, true);
 
-	resource_saver_shader.instantiate();
-	ResourceSaver::add_resource_format_saver(resource_saver_shader, true);
+	if (GD_IS_CLASS_ENABLED(Shader)) {
+		resource_saver_shader.instantiate();
+		ResourceSaver::add_resource_format_saver(resource_saver_shader, true);
 
-	resource_loader_shader.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_loader_shader, true);
+		resource_loader_shader.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_shader, true);
+	}
 
-	resource_saver_shader_include.instantiate();
-	ResourceSaver::add_resource_format_saver(resource_saver_shader_include, true);
+	if (GD_IS_CLASS_ENABLED(ShaderInclude)) {
+		resource_saver_shader_include.instantiate();
+		ResourceSaver::add_resource_format_saver(resource_saver_shader_include, true);
 
-	resource_loader_shader_include.instantiate();
-	ResourceLoader::add_resource_format_loader(resource_loader_shader_include, true);
+		resource_loader_shader_include.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_shader_include, true);
+	}
 
 	OS::get_singleton()->yield(); // may take time to init
 
@@ -1284,14 +1294,20 @@ void unregister_scene_types() {
 
 	SceneDebugger::deinitialize();
 
-	ResourceLoader::remove_resource_format_loader(resource_loader_texture_layered);
-	resource_loader_texture_layered.unref();
+	if (GD_IS_CLASS_ENABLED(TextureLayered)) {
+		ResourceLoader::remove_resource_format_loader(resource_loader_texture_layered);
+		resource_loader_texture_layered.unref();
+	}
 
-	ResourceLoader::remove_resource_format_loader(resource_loader_texture_3d);
-	resource_loader_texture_3d.unref();
+	if (GD_IS_CLASS_ENABLED(Texture3D)) {
+		ResourceLoader::remove_resource_format_loader(resource_loader_texture_3d);
+		resource_loader_texture_3d.unref();
+	}
 
-	ResourceLoader::remove_resource_format_loader(resource_loader_stream_texture);
-	resource_loader_stream_texture.unref();
+	if (GD_IS_CLASS_ENABLED(CompressedTexture2D)) {
+		ResourceLoader::remove_resource_format_loader(resource_loader_stream_texture);
+		resource_loader_stream_texture.unref();
+	}
 
 	ResourceSaver::remove_resource_format_saver(resource_saver_text);
 	resource_saver_text.unref();
@@ -1299,17 +1315,21 @@ void unregister_scene_types() {
 	ResourceLoader::remove_resource_format_loader(resource_loader_text);
 	resource_loader_text.unref();
 
-	ResourceSaver::remove_resource_format_saver(resource_saver_shader);
-	resource_saver_shader.unref();
+	if (GD_IS_CLASS_ENABLED(Shader)) {
+		ResourceSaver::remove_resource_format_saver(resource_saver_shader);
+		resource_saver_shader.unref();
 
-	ResourceLoader::remove_resource_format_loader(resource_loader_shader);
-	resource_loader_shader.unref();
+		ResourceLoader::remove_resource_format_loader(resource_loader_shader);
+		resource_loader_shader.unref();
+	}
 
-	ResourceSaver::remove_resource_format_saver(resource_saver_shader_include);
-	resource_saver_shader_include.unref();
+	if (GD_IS_CLASS_ENABLED(ShaderInclude)) {
+		ResourceSaver::remove_resource_format_saver(resource_saver_shader_include);
+		resource_saver_shader_include.unref();
 
-	ResourceLoader::remove_resource_format_loader(resource_loader_shader_include);
-	resource_loader_shader_include.unref();
+		ResourceLoader::remove_resource_format_loader(resource_loader_shader_include);
+		resource_loader_shader_include.unref();
+	}
 
 	// StandardMaterial3D is not initialized when 3D is disabled, so it shouldn't be cleaned up either
 #ifndef _3D_DISABLED


### PR DESCRIPTION
Due to how `ResourceFormatLoader`s work, they were always instantiated, even if the resource they are tied with is disabled. This PR makes so that a check is made, so instantiation only happens for active resources.

**Sponsored By:** 🐺 Lone Wolf Technology / 🍀 W4 Games.