### PR TITLE
String function `rstrip` no longer strips too much from the desired string

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4308,19 +4308,16 @@ String String::lstrip(const String &p_chars) const {
 
 String String::rstrip(const String &p_chars) const {
 	int len = length();
-	int end;
+	int end = len - p_chars.length();
 
-	for (end = len - 1; end >= 0; end--) {
-		if (p_chars.find_char(get(end)) == -1) {
-			break;
-		}
-	}
-
-	if (end == len - 1) {
+	if (end < 0) {
 		return *this;
 	}
 
-	return substr(0, end + 1);
+	String head = substr(0, end);
+	String tail = substr(end, len);
+
+	return tail == p_chars ? head : *this;
 }
 
 bool String::is_network_share_path() const {


### PR DESCRIPTION
rstrip now properly strips the string if the desired string ends in a character that is contained in the undesired string.

The function will split the string in two substrings based on the length of the undesired string.
If the undesired string is longer than the desired string, the function will return the original string.
If the second half of the split string matches the undesired string, the first half of the split is returned. otherwise the original string is returned