### PR TITLE
Fix Embedded Game window wrong first startup location and size

### DIFF
--- a/editor/plugins/embedded_process.cpp
+++ b/editor/plugins/embedded_process.cpp
@@ -95,9 +95,11 @@ void EmbeddedProcess::set_keep_aspect(bool p_keep_aspect) {
 	}
 }
 
-Rect2i EmbeddedProcess::_get_global_embedded_window_rect() {
-	Rect2i control_rect = get_global_rect();
-	control_rect = Rect2i(control_rect.position + margin_top_left, (control_rect.size - get_margins_size()).maxi(1));
+Rect2i EmbeddedProcess::get_adjusted_embedded_window_rect(Rect2i p_rect) {
+	Rect2i control_rect = Rect2i(p_rect.position + margin_top_left, (p_rect.size - get_margins_size()).maxi(1));
+	if (window) {
+		control_rect.position += window->get_position();
+	}
 	if (window_size != Size2i()) {
 		Rect2i desired_rect = Rect2i();
 		if (!keep_aspect && control_rect.size.x >= window_size.x && control_rect.size.y >= window_size.y) {
@@ -116,12 +118,7 @@ Rect2i EmbeddedProcess::_get_global_embedded_window_rect() {
 }
 
 Rect2i EmbeddedProcess::get_screen_embedded_window_rect() {
-	Rect2i rect = _get_global_embedded_window_rect();
-	if (window) {
-		rect.position += window->get_position();
-	}
-
-	return rect;
+	return get_adjusted_embedded_window_rect(get_global_rect());
 }
 
 int EmbeddedProcess::get_margin_size(Side p_side) const {

--- a/editor/plugins/embedded_process.h
+++ b/editor/plugins/embedded_process.h
@@ -83,6 +83,7 @@ public:
 	void set_keep_aspect(bool p_keep_aspect);
 	void queue_update_embedded_process();
 
+	Rect2i get_adjusted_embedded_window_rect(Rect2i p_rect);
 	Rect2i get_screen_embedded_window_rect();
 	int get_margin_size(Side p_side) const;
 	Size2 get_margins_size();


### PR DESCRIPTION
- Fixes #103096

This PR fixes the startup location and size on the first run. When the embedded control has never been displayed, the global rect is invalid so I calculated it manually.


https://github.com/user-attachments/assets/4e709318-ea4d-4ef5-be1a-309b466709a6

