### PR TITLE
Fix CanvasLayer 'Follow Viewport' documentation to match its behavior

### DIFF
--- a/doc/classes/CanvasLayer.xml
+++ b/doc/classes/CanvasLayer.xml
@@ -45,7 +45,7 @@
 			The custom [Viewport] node assigned to the [CanvasLayer]. If [code]null[/code], uses the default viewport instead.
 		</member>
 		<member name="follow_viewport_enabled" type="bool" setter="set_follow_viewport" getter="is_following_viewport" default="false">
-			If enabled, the [CanvasLayer] stays in a fixed position on the screen. If disabled, the [CanvasLayer] maintains its position in world space.
+			If enabled, the [CanvasLayer] maintains its position in world space. If disabled, the [CanvasLayer] stays in a fixed position on the screen.
 			Together with [member follow_viewport_scale], this can be used for a pseudo-3D effect.
 		</member>
 		<member name="follow_viewport_scale" type="float" setter="set_follow_viewport_scale" getter="get_follow_viewport_scale" default="1.0">


### PR DESCRIPTION
Fixes #103031 
The doc of follow_viewport_enabled in #99754 tells the opposite thing. 
This PR swaped enabled/disabled description to match actual behavior.