### PR TITLE
ClassDB: Keep MethodInfo for virtual methods in release mode

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -988,11 +988,11 @@ void ClassDB::get_method_list(const StringName &p_class, List<MethodInfo> *p_met
 			continue;
 		}
 
-#ifdef DEBUG_ENABLED
 		for (const MethodInfo &E : type->virtual_methods) {
 			p_methods->push_back(E);
 		}
 
+#ifdef DEBUG_ENABLED
 		for (const StringName &E : type->method_order) {
 			if (p_exclude_from_properties && type->methods_in_properties.has(E)) {
 				continue;
@@ -1034,12 +1034,12 @@ void ClassDB::get_method_list_with_compatibility(const StringName &p_class, List
 			continue;
 		}
 
-#ifdef DEBUG_ENABLED
 		for (const MethodInfo &E : type->virtual_methods) {
 			Pair<MethodInfo, uint32_t> pair(E, E.get_compatibility_hash());
 			p_methods->push_back(pair);
 		}
 
+#ifdef DEBUG_ENABLED
 		for (const StringName &E : type->method_order) {
 			if (p_exclude_from_properties && type->methods_in_properties.has(E)) {
 				continue;
@@ -1094,7 +1094,6 @@ bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_met
 			continue;
 		}
 
-#ifdef DEBUG_ENABLED
 		MethodBind **method = type->method_map.getptr(p_method);
 		if (method && *method) {
 			if (r_info != nullptr) {
@@ -1108,16 +1107,6 @@ bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_met
 			}
 			return true;
 		}
-#else
-		if (type->method_map.has(p_method)) {
-			if (r_info) {
-				MethodBind *m = type->method_map[p_method];
-				MethodInfo minfo = info_from_bind(m);
-				*r_info = minfo;
-			}
-			return true;
-		}
-#endif // DEBUG_ENABLED
 
 		if (p_no_inheritance) {
 			break;
@@ -1964,7 +1953,6 @@ void ClassDB::add_virtual_method(const StringName &p_class, const MethodInfo &p_
 
 	Locker::Lock lock(Locker::STATE_WRITE);
 
-#ifdef DEBUG_ENABLED
 	MethodInfo mi = p_method;
 	if (p_virtual) {
 		mi.flags |= METHOD_FLAG_VIRTUAL;
@@ -1989,8 +1977,6 @@ void ClassDB::add_virtual_method(const StringName &p_class, const MethodInfo &p_
 	}
 	classes[p_class].virtual_methods.push_back(mi);
 	classes[p_class].virtual_methods_map[p_method.name] = mi;
-
-#endif // DEBUG_ENABLED
 }
 
 void ClassDB::add_virtual_compatibility_method(const StringName &p_class, const MethodInfo &p_method, bool p_virtual, const Vector<String> &p_arg_names, bool p_object_core) {
@@ -2012,7 +1998,7 @@ void ClassDB::add_virtual_compatibility_method(const StringName &p_class, const 
 void ClassDB::get_virtual_methods(const StringName &p_class, List<MethodInfo> *p_methods, bool p_no_inheritance) {
 	ERR_FAIL_COND_MSG(!classes.has(p_class), vformat("Request for nonexistent class '%s'.", p_class));
 
-#ifdef DEBUG_ENABLED
+	Locker::Lock lock(Locker::STATE_READ);
 
 	ClassInfo *type = classes.getptr(p_class);
 	ClassInfo *check = type;
@@ -2026,8 +2012,6 @@ void ClassDB::get_virtual_methods(const StringName &p_class, List<MethodInfo> *p
 		}
 		check = check->inherits_ptr;
 	}
-
-#endif // DEBUG_ENABLED
 }
 
 Vector<uint32_t> ClassDB::get_virtual_method_compatibility_hashes(const StringName &p_class, const StringName &p_name) {
@@ -2052,7 +2036,6 @@ Vector<uint32_t> ClassDB::get_virtual_method_compatibility_hashes(const StringNa
 void ClassDB::add_extension_class_virtual_method(const StringName &p_class, const GDExtensionClassVirtualMethodInfo *p_method_info) {
 	ERR_FAIL_COND_MSG(!classes.has(p_class), vformat("Request for nonexistent class '%s'.", p_class));
 
-#ifdef DEBUG_ENABLED
 	PackedStringArray arg_names;
 
 	MethodInfo mi;
@@ -2068,7 +2051,6 @@ void ClassDB::add_extension_class_virtual_method(const StringName &p_class, cons
 	}
 
 	add_virtual_method(p_class, mi, true, arg_names);
-#endif // DEBUG_ENABLED
 }
 
 void ClassDB::set_class_enabled(const StringName &p_class, bool p_enable) {

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -130,12 +130,12 @@ public:
 
 		List<PropertyInfo> property_list;
 		HashMap<StringName, PropertyInfo> property_map;
+		List<MethodInfo> virtual_methods;
+		HashMap<StringName, MethodInfo> virtual_methods_map;
 
 #ifdef DEBUG_ENABLED
 		List<StringName> method_order;
 		HashSet<StringName> methods_in_properties;
-		List<MethodInfo> virtual_methods;
-		HashMap<StringName, MethodInfo> virtual_methods_map;
 		HashMap<StringName, Vector<Error>> method_error_values;
 		HashMap<StringName, List<StringName>> linked_properties;
 #endif // DEBUG_ENABLED

--- a/modules/gdscript/tests/scripts/analyzer/features/class_db_virtual_method_as_callable.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/class_db_virtual_method_as_callable.gd
@@ -1,0 +1,5 @@
+func test() -> void:
+	var o: Object = Object.new.call()
+	var free_callable: Callable = o.free
+	print(free_callable)
+	o.free()

--- a/modules/gdscript/tests/scripts/analyzer/features/class_db_virtual_method_as_callable.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/class_db_virtual_method_as_callable.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+Object::free


### PR DESCRIPTION
fixes https://github.com/godotengine/godot/issues/102710
fixes https://github.com/godotengine/godot/issues/101230
fixes https://github.com/godotengine/godot/issues/73036

it seems gdscript depends on the method info for `free` and `_init`, registered as virtual methods by `Object`
this PR keeps that method info in release builds

added tests, but tests dont run in release builds at the moment...

_Maintainer edit:_
_- probably fixes: https://github.com/godotengine/godot/issues/101124_