### PR TITLE
Android Editor: Fix expand button black bar issue

### DIFF
--- a/platform/android/java/editor/src/main/res/values/themes.xml
+++ b/platform/android/java/editor/src/main/res/values/themes.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<style name="GodotEditorTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar.Fullscreen">
-		<item name ="android:windowDrawsSystemBarBackgrounds">false</item>
+		<item name="android:statusBarColor">@android:color/transparent</item>
+		<item name ="android:navigationBarColor">@android:color/transparent</item>
 	</style>
 
 	<style name="GodotEditorSplashScreenTheme" parent="Theme.SplashScreen.IconBackground">


### PR DESCRIPTION
**Before:**


https://github.com/user-attachments/assets/2e4665de-db7d-4dd5-b125-fcd4837f5572

**After:**

https://github.com/user-attachments/assets/c20ac5a1-3434-4f40-bc09-ee91014c12e2

