### PR TITLE
Fix GPU particles not emitting at some configured rates when scale curve is zero

### DIFF
--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -1121,9 +1121,16 @@ void ParticleProcessMaterial::_update_shader() {
 		code += "		params.scale *= texture(scale_over_velocity_curve, vec2(0.0)).rgb;\n";
 		code += "	}\n";
 	}
-	code += "	TRANSFORM[0].xyz *= sign(params.scale.x) * max(abs(params.scale.x), 0.001);\n";
-	code += "	TRANSFORM[1].xyz *= sign(params.scale.y) * max(abs(params.scale.y), 0.001);\n";
-	code += "	TRANSFORM[2].xyz *= sign(params.scale.z) * max(abs(params.scale.z), 0.001);\n";
+	// A scale of 0 results in no emission at some emission amounts (including 3 and 6).
+	// `sign(scale)` is unsuitable, because sign(0) returns 0, nullifying the minimum value.
+	// The following evaluates to 1 when scale is 0, falling back to a positive minimum value.
+	code += "	float scale_sign_x = params.scale.x < 0.0 ? -1.0 : 1.0;\n";
+	code += "	float scale_sign_y = params.scale.y < 0.0 ? -1.0 : 1.0;\n";
+	code += "	float scale_sign_z = params.scale.z < 0.0 ? -1.0 : 1.0;\n";
+	code += "	float scale_minimum = 0.001;\n";
+	code += "	TRANSFORM[0].xyz *= scale_sign_x * max(abs(params.scale.x), scale_minimum);\n";
+	code += "	TRANSFORM[1].xyz *= scale_sign_y * max(abs(params.scale.y), scale_minimum);\n";
+	code += "	TRANSFORM[2].xyz *= scale_sign_z * max(abs(params.scale.z), scale_minimum);\n";
 	code += "\n";
 	code += "	CUSTOM.z = params.animation_offset + lifetime_percent * params.animation_speed;\n\n";
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/103140

This PR re-fixes GPU particles not emitting at the configured rate when using a scale curve that starts or ends at a value of 0.

### Demonstration

Master:

https://github.com/user-attachments/assets/41d56cdb-447d-441e-85d1-c1505eae47b5

This PR:

https://github.com/user-attachments/assets/35c4d336-0522-48d1-b0b5-455f61159257

### Explanation

The cause was the use of `sign()`, under the expectation that it would result in a value that is exclusively either `-1` or `1`. However, `sign()` returns `0` when given `0`. So, when that was multiplied by the minimum value, instead of applying the sign of the original scale (which had no sign), it just nullified the minimum value entirely. So, the whole expression did nothing at all.

This has been fixed before (see the related section in [the associated issue](https://github.com/godotengine/godot/issues/103140)). So, I added a descriptive comment to give this a better chance of staying fixed.