### PR TITLE
Fix EditorObjectSelector popup size

### DIFF
--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -99,10 +99,7 @@ void EditorObjectSelector::_show_popup() {
 	Point2 gp = get_screen_position();
 	gp.y += size.y;
 
-	sub_objects_menu->set_position(gp);
-	sub_objects_menu->set_size(Size2(size.width, 1));
-
-	sub_objects_menu->popup();
+	sub_objects_menu->popup(Rect2(gp, Size2(size.width, 0)));
 }
 
 void EditorObjectSelector::_about_to_show() {


### PR DESCRIPTION
PR https://github.com/godotengine/godot/pull/101876 made the popup size for OptionButtons be as wide as the button itself.

This did not apply to EditorObjectSelectors PopupMenu. Becuase it's just a button that looks like an OptionButton.
This PR makes the Popup behave like it does for mentioned PR above. 

Before:

[Screencast_20250219_053311.webm](https://github.com/user-attachments/assets/2ae01dd6-55f4-4b70-9bf7-82b2140e93d4)


After:

[Screencast_20250219_053329.webm](https://github.com/user-attachments/assets/143cbdf1-0071-449d-a158-562b4c5105a8)



_Another solution could probably be to change EditorObjectSelector to an OptionButton, but not sure why it's currently a Button and what affects that would have._ 

