### PR TITLE
TextureRD: Ignore invalid free error and keep rid unchanged when replacing rd texture

### DIFF
--- a/scene/resources/texture_rd.cpp
+++ b/scene/resources/texture_rd.cpp
@@ -51,7 +51,7 @@ int Texture2DRD::get_height() const {
 RID Texture2DRD::get_rid() const {
 	if (texture_rid.is_null()) {
 		// We are in trouble, create something temporary.
-		texture_rid = RenderingServer::get_singleton()->texture_2d_placeholder_create();
+		texture_rid = RS::get_singleton()->texture_2d_placeholder_create();
 	}
 
 	return texture_rid;
@@ -76,11 +76,8 @@ void Texture2DRD::set_texture_rd_rid(RID p_texture_rd_rid) {
 	if (p_texture_rd_rid.is_valid()) {
 		RS::get_singleton()->call_on_render_thread(callable_mp(this, &Texture2DRD::_set_texture_rd_rid).bind(p_texture_rd_rid));
 	} else if (texture_rid.is_valid()) {
-		RS::get_singleton()->free(texture_rid);
-		texture_rid = RID();
-		size = Size2i();
+		RS::get_singleton()->texture_replace(texture_rid, RS::get_singleton()->texture_2d_placeholder_create());
 
-		notify_property_list_changed();
 		emit_changed();
 	}
 }
@@ -105,7 +102,6 @@ void Texture2DRD::_set_texture_rd_rid(RID p_texture_rd_rid) {
 		texture_rid = RS::get_singleton()->texture_rd_create(p_texture_rd_rid);
 	}
 
-	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -162,7 +158,7 @@ bool TextureLayeredRD::has_mipmaps() const {
 RID TextureLayeredRD::get_rid() const {
 	if (texture_rid.is_null()) {
 		// We are in trouble, create something temporary.
-		texture_rid = RenderingServer::get_singleton()->texture_2d_placeholder_create();
+		texture_rid = RS::get_singleton()->texture_2d_placeholder_create();
 	}
 
 	return texture_rid;
@@ -179,14 +175,13 @@ void TextureLayeredRD::set_texture_rd_rid(RID p_texture_rd_rid) {
 	if (p_texture_rd_rid.is_valid()) {
 		RS::get_singleton()->call_on_render_thread(callable_mp(this, &TextureLayeredRD::_set_texture_rd_rid).bind(p_texture_rd_rid));
 	} else if (texture_rid.is_valid()) {
-		RS::get_singleton()->free(texture_rid);
-		texture_rid = RID();
+		RS::get_singleton()->texture_replace(texture_rid, RS::get_singleton()->texture_2d_placeholder_create());
+
 		image_format = Image::FORMAT_MAX;
 		size = Size2i();
 		layers = 0;
 		mipmaps = 0;
 
-		notify_property_list_changed();
 		emit_changed();
 	}
 }
@@ -232,7 +227,6 @@ void TextureLayeredRD::_set_texture_rd_rid(RID p_texture_rd_rid) {
 
 	image_format = RS::get_singleton()->texture_get_format(texture_rid);
 
-	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -289,7 +283,7 @@ bool Texture3DRD::has_mipmaps() const {
 RID Texture3DRD::get_rid() const {
 	if (texture_rid.is_null()) {
 		// We are in trouble, create something temporary.
-		texture_rid = RenderingServer::get_singleton()->texture_2d_placeholder_create();
+		texture_rid = RS::get_singleton()->texture_2d_placeholder_create();
 	}
 
 	return texture_rid;
@@ -301,13 +295,12 @@ void Texture3DRD::set_texture_rd_rid(RID p_texture_rd_rid) {
 	if (p_texture_rd_rid.is_valid()) {
 		RS::get_singleton()->call_on_render_thread(callable_mp(this, &Texture3DRD::_set_texture_rd_rid).bind(p_texture_rd_rid));
 	} else if (texture_rid.is_valid()) {
-		RS::get_singleton()->free(texture_rid);
-		texture_rid = RID();
+		RS::get_singleton()->texture_replace(texture_rid, RS::get_singleton()->texture_2d_placeholder_create());
+
 		image_format = Image::FORMAT_MAX;
 		size = Vector3i();
 		mipmaps = 0;
 
-		notify_property_list_changed();
 		emit_changed();
 	}
 }
@@ -335,7 +328,6 @@ void Texture3DRD::_set_texture_rd_rid(RID p_texture_rd_rid) {
 
 	image_format = RS::get_singleton()->texture_get_format(texture_rid);
 
-	notify_property_list_changed();
 	emit_changed();
 }
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1541,10 +1541,13 @@ void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {
 		return;
 	}
 
-	if (tex->rd_texture_srgb.is_valid()) {
+	if (tex->rd_texture_srgb.is_valid() && RD::get_singleton()->texture_is_valid(tex->rd_texture_srgb)) {
 		RD::get_singleton()->free(tex->rd_texture_srgb);
 	}
-	RD::get_singleton()->free(tex->rd_texture);
+
+	if (RD::get_singleton()->texture_is_valid(tex->rd_texture)) {
+		RD::get_singleton()->free(tex->rd_texture);
+	}
 
 	if (tex->canvas_texture) {
 		memdelete(tex->canvas_texture);


### PR DESCRIPTION
Fixes #95273. Fixes #85989.

- Don't change TextureRD's rid when assigned an empty `texture_rd_rid`, Instead, repalce its texture by a placeholder texture. 
- Check if rd texture is valid to avoid printing errors when users have freed `texture_rd_rid` of TextureRD and replace the rd texture.