### PR TITLE
Avoid some excessive edits of resources

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1118,9 +1118,8 @@ void EditorAudioBuses::_notification(int p_what) {
 				}
 			}
 
-			AudioServer::get_singleton()->set_edited(false);
-
 			if (edited) {
+				AudioServer::get_singleton()->set_edited(false);
 				save_timer->start();
 			}
 		} break;

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -56,13 +56,13 @@ void EditorSettingsDialog::ok_pressed() {
 	if (!EditorSettings::get_singleton()) {
 		return;
 	}
-
 	_settings_save();
-	timer->stop();
 }
 
 void EditorSettingsDialog::_settings_changed() {
-	timer->start();
+	if (is_visible()) {
+		timer->start();
+	}
 }
 
 void EditorSettingsDialog::_settings_property_edited(const String &p_name) {
@@ -174,6 +174,9 @@ void EditorSettingsDialog::_set_shortcut_input(const String &p_name, Ref<InputEv
 }
 
 void EditorSettingsDialog::_settings_save() {
+	if (!timer->is_stopped()) {
+		timer->stop();
+	}
 	EditorSettings::get_singleton()->notify_changes();
 	EditorSettings::get_singleton()->save();
 }

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -653,7 +653,6 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	advanced = memnew(CheckButton);
 	advanced->set_text(TTR("Advanced Settings"));
-	advanced->connect(SceneStringName(toggled), callable_mp(this, &ProjectSettingsEditor::_advanced_toggled));
 	search_bar->add_child(advanced);
 
 	custom_properties = memnew(HBoxContainer);
@@ -774,6 +773,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	if (use_advanced) {
 		advanced->set_pressed(true);
 	}
+	advanced->connect(SceneStringName(toggled), callable_mp(this, &ProjectSettingsEditor::_advanced_toggled));
 
 	_update_advanced(use_advanced);
 


### PR DESCRIPTION
- Don't increment AudioServer's edited version *every frame*
- Don't save EditorSettings when opening project
- Don't start EditorSettings dialog timer if the settings were modified outside the dialog (to prevent saving twice)