### PR TITLE
Lightmapper: Compress albedo and emission atlases with Betsy if available

### DIFF
--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -317,6 +317,20 @@ void BetsyCompressor::finish() {
 	}
 }
 
+void ensure_betsy_exists() {
+	betsy_mutex.lock();
+	if (betsy == nullptr) {
+		betsy = memnew(BetsyCompressor);
+		betsy->init();
+	}
+	betsy_mutex.unlock();
+}
+
+BetsyCompressor *BetsyCompressor::get_singleton() {
+	ensure_betsy_exists();
+	return betsy;
+}
+
 // Helper functions.
 
 static int get_next_multiple(int n, int m) {
@@ -841,15 +855,6 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 					OS::get_singleton()->get_ticks_msec() - start_time));
 
 	return OK;
-}
-
-void ensure_betsy_exists() {
-	betsy_mutex.lock();
-	if (betsy == nullptr) {
-		betsy = memnew(BetsyCompressor);
-		betsy->init();
-	}
-	betsy_mutex.unlock();
 }
 
 Error _betsy_compress_bptc(Image *r_img, Image::UsedChannels p_channels) {

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -329,6 +329,20 @@ void BetsyCompressor::finish() {
 	}
 }
 
+void ensure_betsy_exists() {
+	betsy_mutex.lock();
+	if (betsy == nullptr) {
+		betsy = memnew(BetsyCompressor);
+		betsy->init();
+	}
+	betsy_mutex.unlock();
+}
+
+BetsyCompressor *BetsyCompressor::get_singleton() {
+	ensure_betsy_exists();
+	return betsy;
+}
+
 // Helper functions.
 
 static int get_next_multiple(int n, int m) {
@@ -853,15 +867,6 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 					OS::get_singleton()->get_ticks_msec() - start_time));
 
 	return OK;
-}
-
-void ensure_betsy_exists() {
-	betsy_mutex.lock();
-	if (betsy == nullptr) {
-		betsy = memnew(BetsyCompressor);
-		betsy->init();
-	}
-	betsy_mutex.unlock();
 }
 
 Error _betsy_compress_bptc(Image *r_img, Image::UsedChannels p_channels, Image::BPTCFormat p_bptc_format) {

--- a/modules/betsy/image_compress_betsy.h
+++ b/modules/betsy/image_compress_betsy.h
@@ -138,4 +138,6 @@ public:
 		command_queue.push_and_ret(this, &BetsyCompressor::_compress, &err, p_format, r_img);
 		return err;
 	}
+
+	static BetsyCompressor *get_singleton();
 };

--- a/modules/betsy/image_compress_betsy.h
+++ b/modules/betsy/image_compress_betsy.h
@@ -131,4 +131,6 @@ public:
 		command_queue.push_and_ret(this, &BetsyCompressor::_compress, &err, p_format, r_img);
 		return err;
 	}
+
+	static BetsyCompressor *get_singleton();
 };

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -50,6 +50,12 @@
 #include "drivers/metal/rendering_context_driver_metal.h"
 #endif
 
+#include "modules/modules_enabled.gen.h" // For Betsy.
+
+#ifdef MODULE_BETSY_ENABLED
+#include "modules/betsy/image_compress_betsy.h"
+#endif
+
 //uncomment this if you want to see textures from all the process saved
 //#define DEBUG_TEXTURES
 
@@ -1183,10 +1189,43 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	}
 
 	{ // create all textures
-
 		Vector<Vector<uint8_t>> albedo_data;
 		Vector<Vector<uint8_t>> emission_data;
+
+#ifdef MODULE_BETSY_ENABLED
+		const bool compress_albedo = rd->texture_is_format_supported_for_usage(RD::DATA_FORMAT_BC3_UNORM_BLOCK, RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT);
+		const bool compress_emission = rd->texture_is_format_supported_for_usage(RD::DATA_FORMAT_BC6H_UFLOAT_BLOCK, RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT);
+
+		BetsyCompressor *betsy = BetsyCompressor::get_singleton();
+#else
+		const bool compress_albedo = false;
+		const bool compress_emission = false;
+#endif
+
+		bool has_signed_emission = false;
+
+#ifdef MODULE_BETSY_ENABLED
+		if (compress_emission) {
+			for (int i = 0; i < atlas_slices; i++) {
+				if (emission_images[i]->detect_signed()) {
+					has_signed_emission = true;
+					break;
+				}
+			}
+		}
+#endif
+
 		for (int i = 0; i < atlas_slices; i++) {
+#ifdef MODULE_BETSY_ENABLED
+			if (compress_albedo) {
+				betsy->compress(BetsyFormat::BETSY_FORMAT_BC3, albedo_images.write[i].ptr());
+			}
+
+			if (compress_emission) {
+				betsy->compress(has_signed_emission ? BetsyFormat::BETSY_FORMAT_BC6_SIGNED : BetsyFormat::BETSY_FORMAT_BC6_UNSIGNED, emission_images.write[i].ptr());
+			}
+#endif
+
 			albedo_data.push_back(albedo_images[i]->get_data());
 			emission_data.push_back(emission_images[i]->get_data());
 		}
@@ -1197,13 +1236,14 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		tf.array_layers = atlas_slices;
 		tf.texture_type = RD::TEXTURE_TYPE_2D_ARRAY;
 		tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
-		tf.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
 
+		tf.format = compress_albedo ? RD::DATA_FORMAT_BC3_UNORM_BLOCK : RD::DATA_FORMAT_R8G8B8A8_UNORM;
 		albedo_array_tex = rd->texture_create(tf, RD::TextureView(), albedo_data);
 
-		tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
-
+		tf.format = compress_emission ? (has_signed_emission ? RD::DATA_FORMAT_BC6H_SFLOAT_BLOCK : RD::DATA_FORMAT_BC6H_UFLOAT_BLOCK) : RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
 		emission_array_tex = rd->texture_create(tf, RD::TextureView(), emission_data);
+
+		tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
 
 		//this will be rastered to
 		tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -54,6 +54,12 @@
 #include "drivers/metal/rendering_context_driver_metal.h"
 #endif
 
+#include "modules/modules_enabled.gen.h" // For Betsy.
+
+#ifdef MODULE_BETSY_ENABLED
+#include "modules/betsy/image_compress_betsy.h"
+#endif
+
 //uncomment this if you want to see textures from all the process saved
 //#define DEBUG_TEXTURES
 
@@ -1240,10 +1246,43 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	}
 
 	{ // create all textures
-
 		Vector<Vector<uint8_t>> albedo_data;
 		Vector<Vector<uint8_t>> emission_data;
+
+#ifdef MODULE_BETSY_ENABLED
+		const bool compress_albedo = rd->texture_is_format_supported_for_usage(RD::DATA_FORMAT_BC3_UNORM_BLOCK, RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT);
+		const bool compress_emission = rd->texture_is_format_supported_for_usage(RD::DATA_FORMAT_BC6H_UFLOAT_BLOCK, RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT);
+
+		BetsyCompressor *betsy = BetsyCompressor::get_singleton();
+#else
+		const bool compress_albedo = false;
+		const bool compress_emission = false;
+#endif
+
+		bool has_signed_emission = false;
+
+#ifdef MODULE_BETSY_ENABLED
+		if (compress_emission) {
+			for (int i = 0; i < atlas_slices; i++) {
+				if (emission_images[i]->detect_signed()) {
+					has_signed_emission = true;
+					break;
+				}
+			}
+		}
+#endif
+
 		for (int i = 0; i < atlas_slices; i++) {
+#ifdef MODULE_BETSY_ENABLED
+			if (compress_albedo) {
+				betsy->compress(BetsyFormat::BETSY_FORMAT_BC3, albedo_images.write[i].ptr());
+			}
+
+			if (compress_emission) {
+				betsy->compress(has_signed_emission ? BetsyFormat::BETSY_FORMAT_BC6_SIGNED : BetsyFormat::BETSY_FORMAT_BC6_UNSIGNED, emission_images.write[i].ptr());
+			}
+#endif
+
 			albedo_data.push_back(albedo_images[i]->get_data());
 			emission_data.push_back(emission_images[i]->get_data());
 		}
@@ -1254,13 +1293,14 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		tf.array_layers = atlas_slices;
 		tf.texture_type = RD::TEXTURE_TYPE_2D_ARRAY;
 		tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
-		tf.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
 
+		tf.format = compress_albedo ? RD::DATA_FORMAT_BC3_UNORM_BLOCK : RD::DATA_FORMAT_R8G8B8A8_UNORM;
 		albedo_array_tex = rd->texture_create(tf, RD::TextureView(), albedo_data);
 
-		tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
-
+		tf.format = compress_emission ? (has_signed_emission ? RD::DATA_FORMAT_BC6H_SFLOAT_BLOCK : RD::DATA_FORMAT_BC6H_UFLOAT_BLOCK) : RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
 		emission_array_tex = rd->texture_create(tf, RD::TextureView(), emission_data);
+
+		tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
 
 		//this will be rastered to
 		tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;


### PR DESCRIPTION
An attempt to decrease the VRAM usage during the lightmap baking process by utilizing Betsy.

Due to how the lightmapper works, albedo and emissive data from affected objects has to be rendered into atlases with the same resolution as the resulting baked lightmaps, using UV2 coordinates. These textures often contain huge black/transparent chunks due to none of the meshes overlapping said segments, meaning a lot of VRAM is effectively wasted on data that is never used.

For instance, a 4096x4096x4 lightmap needs 4x4096 RGBA8 and 4x4096 RGBAH atlases for baking. That amounts to 256mb of albedo and 512mb of emission, so 768mb in total.

This PR makes it so the aforementioned atlases are compressed in memory by default, then sent to the GPU, which results in a significantly reduced memory footprint:

Expected VRAM savings:
- Albedo: 25% of the original VRAM (RGBA8 -> BC3),
- Emission: 12,5% of the original VRAM (RGBAH -> BC6U).

With the previous example, the VRAM taken is 64mb for both albedo and emission, so 128mb in total.

Currently, the albedo atlases are compressed into BC3 and emission into either BC6U or BC6S.

This technique also improves baking times due to the lower bandwidth usage, and it has no noticeable visual downgrades.