### PR TITLE
Implement class detection in GDScript for build configuration

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -654,6 +654,7 @@ public:
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;
+	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes) override;
 };
 
 class ResourceFormatSaverGDScript : public ResourceFormatSaver {


### PR DESCRIPTION
The "Compilation Configuration Profile" manager can detect which classes are being used by your project, so the ones that aren't can be toggled off. One of the ways this is done is by using a feature from `ResourceFormatLoader`, which tells what is being used by a resource it can load.

Before, this wasn't implemented for `ResourceFormatLoaderGDScript`, so there was no way for it to know if a class was being used by scripts or not. This PR implements that.

**Sponsored By:** 🐺 Lone Wolf Technology / 🍀 W4 Games.