### PR TITLE
GDExtension: Include precision in `extension_api.json`

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -118,6 +118,12 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 		header["version_build"] = VERSION_BUILD;
 		header["version_full_name"] = VERSION_FULL_NAME;
 
+#if REAL_T_IS_DOUBLE
+		header["precision"] = "double";
+#else
+		header["precision"] = "single";
+#endif
+
 		api_dump["header"] = header;
 	}
 


### PR DESCRIPTION
We regularly get bug reports from folks who compile their GDExtension with `precision=double`, but use an `extension_api.json` from a single precision build of Godot.

(The hashes for any methods that use `real_t` will be different depending on precision, so you need be sure to use an `extension_api.json` from a double precision build of Godot if you want to build with `precision=double` and get a working result)

This PR adds the precision of the build of Godot that was used to generate it, which would allow godot-cpp (or other language bindings) to validate that developers are using the correct `extension_api.json`

Here's the companion godot-cpp PR: https://github.com/godotengine/godot-cpp/pull/1714