### PR TITLE
Change sRGB -> linear conversions to be more accurate in the compatibility renderer

### DIFF
--- a/drivers/gles3/shaders/tonemap_inc.glsl
+++ b/drivers/gles3/shaders/tonemap_inc.glsl
@@ -21,8 +21,7 @@ vec3 linear_to_srgb(vec3 color) {
 
 // This expects 0-1 range input, outside that range it behaves poorly.
 vec3 srgb_to_linear(vec3 color) {
-	// Approximation from http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
-	return color * (color * (color * 0.305306011 + 0.682171111) + 0.012522878);
+	return mix(pow((color.rgb + vec3(0.055)) * (1.0 / (1.0 + 0.055)), vec3(2.4)), color.rgb * (1.0 / 12.92), lessThan(color.rgb, vec3(0.04045)));
 }
 
 #ifdef APPLY_TONEMAPPING


### PR DESCRIPTION
Fixes #103124 .
Fixes #94863 

The current sRGB <-> linear conversion functions in the compatibility renderer are cheaper approximations of the actual ones. These approximations, as evidenced by both the bug and a later comment on the blog post they're sourced from, cause color distortion when a round trip is performed. 

Since the compatibility renderer performs an sRGB -> linear -> sRGB conversion every frame, the image in #103124 gets increasingly distorted. 

Based on #103124, only the sRGB -> linear function needs to be replaced to allow for stable round trips, so this only updates that one. It does add a pow to a function that didn't have one before, but the reverse function already includes a use of pow, so hopefully this one is alright to add.

The updated sRGB conversion function is sourced from [another renderer](https://github.com/godotengine/godot/blob/4254946de93bab0cc1fb36a7b9039c9ec43be924/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl#L129). If there's a good way to share the function let me know, sticking to the existing structure for now.