### PR TITLE
MeshLibraryEditor: Use `material_override` of MeshInstance3D

### DIFF
--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -146,9 +146,12 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 	p_mesh_instances[item_id] = mesh_instance_node;
 
 	Ref<Mesh> item_mesh = source_mesh->duplicate();
+	Ref<Material> material_override = mesh_instance_node->get_material_override();
 	for (int i = 0; i < item_mesh->get_surface_count(); i++) {
 		Ref<Material> surface_override_material = mesh_instance_node->get_surface_override_material(i);
-		if (surface_override_material.is_valid()) {
+		if (material_override.is_valid()) {
+			item_mesh->surface_set_material(i, material_override);
+		} else if (surface_override_material.is_valid()) {
 			item_mesh->surface_set_material(i, surface_override_material);
 		}
 	}


### PR DESCRIPTION
For Mesh with multiple surfaces, users may need to set the `material_override` of MeshInstance3D to override all the materials of surfaces at once. MeshLibraryEditor should read and use the `material_override`.

If this PR is approved and merged, the documentation should also update.
https://github.com/godotengine/godot-docs/blob/d80252eca9bdea460dc3a8b7ea1a0152eceff662/tutorials/3d/using_gridmaps.rst?plain=1#L92-L113
