### PR TITLE
Fix typo in EditorTranslationParserPlugin docs

### DIFF
--- a/doc/classes/EditorTranslationParserPlugin.xml
+++ b/doc/classes/EditorTranslationParserPlugin.xml
@@ -19,7 +19,7 @@
 		    var text = file.get_as_text()
 		    var split_strs = text.split(",", false)
 		    for s in split_strs:
-		        msgids.append(PackedStringArray([s]))
+		        ret.append(PackedStringArray([s]))
 		        #print("Extracted string: " + s)
 
 		    return ret


### PR DESCRIPTION
This fixes a typo in the usage docs for the `EditorTranslationParserPlugin` that seems to be left over from before the recent changes.