### PR TITLE
Fix PopupMenu clickable area with shadows

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -613,6 +613,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 	item_clickable_area.position.x += theme_cache.panel_style->get_margin(SIDE_LEFT);
 	item_clickable_area.position.y += theme_cache.panel_style->get_margin(SIDE_TOP);
 	item_clickable_area.position *= win_scale;
+	item_clickable_area.size.width -= theme_cache.panel_style->get_margin(SIDE_LEFT) + theme_cache.panel_style->get_margin(SIDE_RIGHT);
 	item_clickable_area.size.y -= theme_cache.panel_style->get_margin(SIDE_TOP) + theme_cache.panel_style->get_margin(SIDE_BOTTOM);
 	item_clickable_area.size *= win_scale;
 
@@ -626,7 +627,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 		if (button_idx == MouseButton::LEFT || initial_button_mask.has_flag(mouse_button_to_mask(button_idx))) {
 			if (b->is_pressed()) {
 				during_grabbed_click = false;
-				is_scrolling = is_layout_rtl() ? b->get_position().x < item_clickable_area.position.x : b->get_position().x > item_clickable_area.size.width;
+				is_scrolling = is_layout_rtl() ? b->get_position().x < item_clickable_area.position.x - item_clickable_area.size.width : b->get_position().x > item_clickable_area.size.width + item_clickable_area.position.x;
 
 				// Hide it if the shadows have been clicked.
 				if (get_flag(FLAG_POPUP)) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/103149

Not sure if these issues are already being tracked but this change makes them more obvious. 
Scrollbar was not being ignored when pressed. And if you set a panel margin right this is also not ignored. 
This PR should also fix these issues.


### No shadow
Before:

[Screencast_20250219_160121.webm](https://github.com/user-attachments/assets/8a86c01a-d80c-4ad4-98cb-9c15ee968787)


After:

[Screencast_20250219_160250.webm](https://github.com/user-attachments/assets/2937cb6e-73e3-45e9-ad22-a5c4effed07d)


### With shadow
Before:

[Screencast_20250219_160400.webm](https://github.com/user-attachments/assets/5272b6ba-0aba-49f5-8030-a98bc935d9ce)

After:

[Screencast_20250219_160515.webm](https://github.com/user-attachments/assets/c2c32943-3131-4883-93c4-ffb68fc5154e)

