### PR TITLE
Convert linear vertex colors to sRGB when using compatibility renderer

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1131,6 +1131,15 @@ void vertex() {)";
 				lessThan(COLOR.rgb, vec3(0.04045)));
 	}
 )";
+	} else {
+		code += R"(
+	if (OUTPUT_IS_SRGB) {
+		COLOR.rgb = mix(
+				(pow(COLOR.rgb, vec3(1.0 / 2.4)) * (1.0 + 0.055)) - vec3(0.055),
+				COLOR.rgb * 12.92,
+				lessThan(COLOR.rgb, vec3(0.0031308)));
+	}
+)";
 	}
 	if (flags[FLAG_USE_POINT_SIZE]) {
 		code += R"(


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes https://github.com/godotengine/godot/issues/87486

The Compatibility renderer currently assumes that all vertex colours are stored as sRGB and uses them as is. For files where the vertex colours are stored as linear (e.g. glTF) this means they appear much darker than intended. This PR adds a linear -> sRGB conversion when `vertex_color_is_srgb` is false and Compatibility is being used.
