### PR TITLE
Fix libtheora optimizations causing errors in calling function for x86_64 Windows

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -732,7 +732,7 @@ def configure_mingw(env: "SConsEnvironment"):
         if env["use_static_cpp"]:
             env.Append(LINKFLAGS=["-static"])
 
-    if env["arch"] in ["x86_32", "x86_64"]:
+    if env["arch"] == "x86_32":
         env["x86_libtheora_opt_gcc"] = True
 
     env.Append(CCFLAGS=["-ffp-contract=off"])


### PR DESCRIPTION
libtheora clobbers registers xmm6/xmm7 when `OC_X86_ASM` (set in Godot with `x86_libtheora_opt_gcc` or `x86_libtheora_opt_vc`) or `OC_X86_64_ASM` is set. This matches the calling convention in all systems except 64-bit Windows. This PR disables Theora optimizations on x86_64 Windows GCC. VC already had this behavior:

https://github.com/godotengine/godot/blob/394508d26dcf1b7a9362453f9009c07d969f1a7e/platform/windows/detect.py#L445-L446

- Fixes #103106 (most recent discussion)
- Fixes #102982
- May fix #102867 (needs testing)
- Follow-up to #103077 (needs testing)

When testing reproducibility, please run `scons --clean` before each build: LTO is dependent on already-generated object files.