### PR TITLE
Metal: Compile `MTLLibrary` on demand when pipeline is created

### DIFF
--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -4082,9 +4082,14 @@ RenderingDeviceDriverMetal::RenderingDeviceDriverMetal(RenderingContextDriverMet
 		context_driver(p_context_driver) {
 	DEV_ASSERT(p_context_driver != nullptr);
 
+#if TARGET_OS_OSX
 	if (String res = OS::get_singleton()->get_environment("GODOT_MTL_SHADER_LOAD_STRATEGY"); res == U"lazy") {
 		_shader_load_strategy = ShaderLoadStrategy::LAZY;
 	}
+#else
+	// Always use the lazy strategy on other OSs like iOS, tvOS, or visionOS.
+	_shader_load_strategy = ShaderLoadStrategy::LAZY;
+#endif
 }
 
 RenderingDeviceDriverMetal::~RenderingDeviceDriverMetal() {


### PR DESCRIPTION
Closes #103006

This changes the default shader loading strategy for mobile Apple platforms, implemented in the Metal driver, to compile the `MTLLibrary` on demand when the pipeline is created. This reduces cold startup time on IPHONE target OSs (iOS, tvOS and visionOS).

Normally, the `MTLLibrary` is compiled from Metal source asynchronously when Godot calls
`RenderingDeviceDriverMetal::shader_create_from_bytecode`; however, this changes this behaviour on mobile platforms to do it on demand when the pipeline is created. As noted in #96052, Godot will ask to create many more shaders from bytecode than are initially required. Mobile OSs like iOS are limited to compiling two shader libraries concurrently, which results in a significant bottleneck.

This is not the default for macOS, as it can concurrently compile many shaders at once, resulting in faster startup times for the Godot editor.