### PR TITLE
LSP: Don't respond to non-GDScript files

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -64,6 +64,9 @@ void GDScriptTextDocument::_bind_methods() {
 
 void GDScriptTextDocument::didOpen(const Variant &p_param) {
 	lsp::TextDocumentItem doc = load_document_item(p_param);
+	if (!is_valid_gd_file(doc)) {
+		return;
+	}
 	sync_script_content(doc.uri, doc.text);
 }
 
@@ -74,6 +77,10 @@ void GDScriptTextDocument::didClose(const Variant &p_param) {
 
 void GDScriptTextDocument::didChange(const Variant &p_param) {
 	lsp::TextDocumentItem doc = load_document_item(p_param);
+	if (!is_valid_gd_file(doc)) {
+		return;
+	}
+
 	Dictionary dict = p_param;
 	Array contentChanges = dict["contentChanges"];
 	for (int i = 0; i < contentChanges.size(); ++i) {
@@ -86,6 +93,9 @@ void GDScriptTextDocument::didChange(const Variant &p_param) {
 
 void GDScriptTextDocument::willSaveWaitUntil(const Variant &p_param) {
 	lsp::TextDocumentItem doc = load_document_item(p_param);
+	if (!is_valid_gd_file(doc)) {
+		return;
+	}
 
 	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(doc.uri);
 	Ref<Script> scr = ResourceLoader::load(path);
@@ -96,6 +106,10 @@ void GDScriptTextDocument::willSaveWaitUntil(const Variant &p_param) {
 
 void GDScriptTextDocument::didSave(const Variant &p_param) {
 	lsp::TextDocumentItem doc = load_document_item(p_param);
+	if (!is_valid_gd_file(doc)) {
+		return;
+	}
+
 	Dictionary dict = p_param;
 	String text = dict["text"];
 
@@ -131,6 +145,11 @@ lsp::TextDocumentItem GDScriptTextDocument::load_document_item(const Variant &p_
 	Dictionary params = p_param;
 	doc.load(params["textDocument"]);
 	return doc;
+}
+
+bool GDScriptTextDocument::is_valid_gd_file(const lsp::TextDocumentItem &p_doc) {
+	// LanguageId isn't always set, but check it for good practice
+	return p_doc.languageId == "gdscript" || p_doc.uri.ends_with(".gd");
 }
 
 void GDScriptTextDocument::notify_client_show_symbol(const lsp::DocumentSymbol *symbol) {

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -60,6 +60,7 @@ protected:
 private:
 	Array find_symbols(const lsp::TextDocumentPositionParams &p_location, List<const lsp::DocumentSymbol *> &r_list);
 	lsp::TextDocumentItem load_document_item(const Variant &p_param);
+	bool is_valid_gd_file(const lsp::TextDocumentItem &p_doc);
 	void notify_client_show_symbol(const lsp::DocumentSymbol *symbol);
 
 public:


### PR DESCRIPTION
- Fixes GDQuest/zed-gdscript#6 but may also apply to other LSP clients.


### Background
When an LSP client saves, Godot's LSP server receives a `textDocument/didSave` notification. Depending on how the LSP client is implemented, it may send this notification for any file, not necessarily only GDScript files. Godot's LSP server wouldn't do any checking on the file type received from this notification, so it would send back syntax errors for whatever file was saved.

According to the LSP spec, unless the server has previously sent `TextDocumentSaveRegistrationOptions`, the LSP client should send the `textDocument/didSave` notification for all files saved. See: [the LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didSave) and zed-industries/zed/pull/19183. (Can someone more familiar with LSP spec confirm this?)

Godot's LSP mostly uses static registrations during initialization for its LSP server capabilities, but `TextDocumentSaveRegistrationOptions` is only available as a dynamic registration. This makes implementing the fix that way a bit uglier than just checking file types when receiving notifications.

### Fix
We will now check for a file being a valid GDScript file, via the language ID or file extension, before processing it any further. While this fix was specifically for the `textDocument/didSave` notification, I added checks for other related notifications as well.