### PR TITLE
Remove old comments from variant.h

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -876,9 +876,6 @@ public:
 	}
 };
 
-//typedef Dictionary Dictionary; no
-//typedef Array Array;
-
 template <typename... VarArgs>
 Vector<Variant> varray(VarArgs... p_args) {
 	Vector<Variant> v;


### PR DESCRIPTION
Removed Lines 879 and 880 in core/variant/variant.h:

```
//typedef Dictionary Dictionary; no
//typedef Array Array;
```

These comments seemingly originate from the beginning of the repository and do not appear to have any use.