### PR TITLE
Add game embed setting that toggles distraction-free mode

### DIFF
--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -335,6 +335,13 @@ void GameView::_play_pressed() {
 	}
 
 	if (embed_on_play && _get_embed_available() == EMBED_AVAILABLE) {
+		PopupMenu *menu = embed_options_menu->get_popup();
+
+		distraction_free_on_play = menu->is_item_checked(menu->get_item_index(EMBED_DISTRACTION_FREE_MODE)) && !EditorInterface::get_singleton()->is_distraction_free_mode_enabled();
+		if (distraction_free_on_play && !make_floating_on_play) {
+			EditorInterface::get_singleton()->set_distraction_free_mode(true);
+		}
+
 		// It's important to disable the low power mode when unfocused because otherwise
 		// the button in the editor are not responsive and if the user moves the mouse quickly,
 		// the mouse clicks are not registered.
@@ -358,6 +365,10 @@ void GameView::_stop_pressed() {
 
 	_detach_script_debugger();
 	paused = false;
+
+	if (embed_on_play && distraction_free_on_play) {
+		EditorInterface::get_singleton()->set_distraction_free_mode(false);
+	}
 
 	EditorNode::get_singleton()->set_unfocused_low_processor_usage_mode_enabled(true);
 	embedded_process->reset();
@@ -498,6 +509,13 @@ void GameView::_embed_options_menu_menu_id_pressed(int p_id) {
 				EditorSettings::get_singleton()->set_project_metadata("game_view", "make_floating_on_play", make_floating_on_play);
 			}
 		} break;
+		case EMBED_DISTRACTION_FREE_MODE: {
+			distraction_free_on_play = !distraction_free_on_play;
+			int game_mode = EDITOR_GET("run/window_placement/game_embed_mode");
+			if (game_mode == 0) { // Save only if not overridden by editor.
+				EditorSettings::get_singleton()->set_project_metadata("game_view", "distraction_free_on_play", distraction_free_on_play);
+			}
+		} break;
 	}
 	_update_embed_menu_options();
 	_update_ui();
@@ -604,8 +622,10 @@ void GameView::_update_embed_menu_options() {
 	PopupMenu *menu = embed_options_menu->get_popup();
 	menu->set_item_checked(menu->get_item_index(EMBED_RUN_GAME_EMBEDDED), embed_on_play);
 	menu->set_item_checked(menu->get_item_index(EMBED_MAKE_FLOATING_ON_PLAY), make_floating_on_play && is_multi_window);
+	menu->set_item_checked(menu->get_item_index(EMBED_DISTRACTION_FREE_MODE), distraction_free_on_play);
 
 	menu->set_item_disabled(menu->get_item_index(EMBED_MAKE_FLOATING_ON_PLAY), !embed_on_play || !is_multi_window);
+	menu->set_item_disabled(menu->get_item_index(EMBED_DISTRACTION_FREE_MODE), !embed_on_play || (make_floating_on_play && is_multi_window));
 
 	fixed_size_button->set_pressed(embed_size_mode == SIZE_MODE_FIXED);
 	keep_aspect_button->set_pressed(embed_size_mode == SIZE_MODE_KEEP_ASPECT);
@@ -728,18 +748,22 @@ void GameView::_notification(int p_what) {
 					case -1: { // Disabled.
 						embed_on_play = false;
 						make_floating_on_play = false;
+						distraction_free_on_play = false;
 					} break;
 					case 1: { // Embed.
 						embed_on_play = true;
 						make_floating_on_play = false;
+						distraction_free_on_play = false;
 					} break;
 					case 2: { // Floating.
 						embed_on_play = true;
 						make_floating_on_play = true;
+						distraction_free_on_play = false;
 					} break;
 					default: {
 						embed_on_play = EditorSettings::get_singleton()->get_project_metadata("game_view", "embed_on_play", true);
 						make_floating_on_play = EditorSettings::get_singleton()->get_project_metadata("game_view", "make_floating_on_play", true);
+						distraction_free_on_play = EditorSettings::get_singleton()->get_project_metadata("game_view", "distraction_free_on_play", false);
 					} break;
 				}
 				embed_size_mode = (EmbedSizeMode)(int)EditorSettings::get_singleton()->get_project_metadata("game_view", "embed_size_mode", SIZE_MODE_FIXED);
@@ -1128,6 +1152,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	menu->connect(SceneStringName(id_pressed), callable_mp(this, &GameView::_embed_options_menu_menu_id_pressed));
 	menu->add_check_item(TTRC("Embed Game on Next Play"), EMBED_RUN_GAME_EMBEDDED);
 	menu->add_check_item(TTRC("Make Game Workspace Floating on Next Play"), EMBED_MAKE_FLOATING_ON_PLAY);
+	menu->add_check_item(TTRC("Distraction Free Mode on Next Play"), EMBED_DISTRACTION_FREE_MODE);
 
 	main_menu_hbox->add_spacer();
 

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -95,6 +95,7 @@ class GameView : public VBoxContainer {
 		CAMERA_MODE_EDITORS,
 		EMBED_RUN_GAME_EMBEDDED,
 		EMBED_MAKE_FLOATING_ON_PLAY,
+		EMBED_DISTRACTION_FREE_MODE,
 	};
 
 	enum EmbedSizeMode {
@@ -125,6 +126,7 @@ class GameView : public VBoxContainer {
 
 	bool embed_on_play = true;
 	bool make_floating_on_play = true;
+	bool distraction_free_on_play = true;
 	EmbedSizeMode embed_size_mode = SIZE_MODE_FIXED;
 	bool paused = false;
 	Size2 size_paused;


### PR DESCRIPTION
Adds an additional option to Embedding Options that will enable Distraction Free Mode when running the game and disabling when stopping.

# Preview
https://github.com/user-attachments/assets/c7a1188b-d698-4947-a552-f104815e3da8