### PR TITLE
Fix `Tween.is_valid()` returning `true` after calling `kill()`

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -212,6 +212,7 @@ void Tween::play() {
 
 void Tween::kill() {
 	running = false; // For the sake of is_running().
+	valid = false;
 	dead = true;
 }
 


### PR DESCRIPTION
fix #103107 