### PR TITLE
Fix SH lightmap coefficients for direct lights with packing

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1690,23 +1690,27 @@ void fragment_shader(in SceneData scene_data) {
 
 			if (sc_use_lightmap_bicubic_filter()) {
 				lm_light_l0 = textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 0.0), lightmaps.data[ofs].light_texture_size).rgb;
-				lm_light_l1n1 = (textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 1.0), lightmaps.data[ofs].light_texture_size).rgb - vec3(0.5)) * 2.0;
-				lm_light_l1_0 = (textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 2.0), lightmaps.data[ofs].light_texture_size).rgb - vec3(0.5)) * 2.0;
-				lm_light_l1p1 = (textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 3.0), lightmaps.data[ofs].light_texture_size).rgb - vec3(0.5)) * 2.0;
+				lm_light_l1n1 = textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 1.0), lightmaps.data[ofs].light_texture_size).rgb;
+				lm_light_l1_0 = textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 2.0), lightmaps.data[ofs].light_texture_size).rgb;
+				lm_light_l1p1 = textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 3.0), lightmaps.data[ofs].light_texture_size).rgb;
 			} else {
 				lm_light_l0 = textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 0.0), 0.0).rgb;
-				lm_light_l1n1 = (textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 1.0), 0.0).rgb - vec3(0.5)) * 2.0;
-				lm_light_l1_0 = (textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 2.0), 0.0).rgb - vec3(0.5)) * 2.0;
-				lm_light_l1p1 = (textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 3.0), 0.0).rgb - vec3(0.5)) * 2.0;
+				lm_light_l1n1 = textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 1.0), 0.0).rgb;
+				lm_light_l1_0 = textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 2.0), 0.0).rgb;
+				lm_light_l1p1 = textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 3.0), 0.0).rgb;
 			}
 
+			// Undoing sigmoid function packing
+			lm_light_l1n1 = -log((1.0 / lm_light_l1n1) - 1) / 5.0;
+			lm_light_l1_0 = -log((1.0 / lm_light_l1_0) - 1) / 5.0;
+			lm_light_l1p1 = -log((1.0 / lm_light_l1p1) - 1) / 5.0;
 			vec3 n = normalize(lightmaps.data[ofs].normal_xform * normal);
 			float en = lightmaps.data[ofs].exposure_normalization;
 
 			ambient_light += lm_light_l0 * en;
-			ambient_light += lm_light_l1n1 * n.y * (lm_light_l0 * en * 4.0);
-			ambient_light += lm_light_l1_0 * n.z * (lm_light_l0 * en * 4.0);
-			ambient_light += lm_light_l1p1 * n.x * (lm_light_l0 * en * 4.0);
+			ambient_light += lm_light_l1n1 * n.y * en;
+			ambient_light += lm_light_l1_0 * n.z * en;
+			ambient_light += lm_light_l1p1 * n.x * en;
 
 		} else {
 			if (sc_use_lightmap_bicubic_filter()) {


### PR DESCRIPTION
Fixes #102300

This PR changes the SH coefficients used for encoding direct light sources. This requires that the L1 packing method also should be adjusted since it is tightly coupled to the SH coefficients. 

L1 packing requires that the L1 coefficients are scaled between 0 and 1. This PR achieves this with a sigmoid function. Specifically the logistics function. 

Since the new SH coefficients effectively have no average component (`L0 = 0`) significant packing artifacts can be seen as only L1 coefficients are packed. I have made some attempts to alleviate this issue but they are still quite prominent.

| Dynamic | Non-Directional | Current Directional | PR Directional|
|--------|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/e19aa90c-8397-4c26-9fe6-dae4a20ea78b) | ![image](https://github.com/user-attachments/assets/164e38e8-e1d6-4b65-9a7b-da453be1c60c) | ![image](https://github.com/user-attachments/assets/2f2002c0-4de1-438d-8ee1-32aace621194) | ![image](https://github.com/user-attachments/assets/5ae06084-17ff-40e3-9c51-0585ce60c6b1) |
| ![image](https://github.com/user-attachments/assets/f200f097-ce82-4f57-8ab8-b60c3f34308a) | ![image](https://github.com/user-attachments/assets/945be16d-e383-490a-b12b-5c9c4d22d125) | ![image](https://github.com/user-attachments/assets/bdf885f3-9a7f-47b1-a30b-6d6b283ba0ae) | ![image](https://github.com/user-attachments/assets/47c41a77-9969-463d-889c-f856e6e698a1) | 