### PR TITLE
Fix SH lightmap coefficients for direct lights without L1 packing

### DIFF
--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -812,34 +812,34 @@ LightmapperRD::BakeError LightmapperRD::_dilate(RenderingDevice *rd, Ref<RDShade
 	return BAKE_OK;
 }
 
-LightmapperRD::BakeError LightmapperRD::_pack_l1(RenderingDevice *rd, Ref<RDShaderFile> &compute_shader, RID &compute_base_uniform_set, PushConstant &push_constant, RID &source_light_tex, RID &dest_light_tex, const Size2i &atlas_size, int atlas_slices) {
-	Vector<RD::Uniform> uniforms = dilate_or_denoise_common_uniforms(source_light_tex, dest_light_tex);
-
-	RID compute_shader_pack = rd->shader_create_from_spirv(compute_shader->get_spirv_stages("pack_coeffs"));
-	ERR_FAIL_COND_V(compute_shader_pack.is_null(), BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES); //internal check, should not happen
-	RID compute_shader_pack_pipeline = rd->compute_pipeline_create(compute_shader_pack);
-
-	RID dilate_uniform_set = rd->uniform_set_create(uniforms, compute_shader_pack, 1);
-
-	RD::ComputeListID compute_list = rd->compute_list_begin();
-	rd->compute_list_bind_compute_pipeline(compute_list, compute_shader_pack_pipeline);
-	rd->compute_list_bind_uniform_set(compute_list, compute_base_uniform_set, 0);
-	rd->compute_list_bind_uniform_set(compute_list, dilate_uniform_set, 1);
-	push_constant.region_ofs[0] = 0;
-	push_constant.region_ofs[1] = 0;
-	Vector3i group_size(Math::division_round_up(atlas_size.x, 8), Math::division_round_up(atlas_size.y, 8), 1); //restore group size
-
-	for (int i = 0; i < atlas_slices; i++) {
-		push_constant.atlas_slice = i;
-		rd->compute_list_set_push_constant(compute_list, &push_constant, sizeof(PushConstant));
-		rd->compute_list_dispatch(compute_list, group_size.x, group_size.y, group_size.z);
-		//no barrier, let them run all together
-	}
-	rd->compute_list_end();
-	rd->free(compute_shader_pack);
-
-	return BAKE_OK;
-}
+// LightmapperRD::BakeError LightmapperRD::_pack_l1(RenderingDevice *rd, Ref<RDShaderFile> &compute_shader, RID &compute_base_uniform_set, PushConstant &push_constant, RID &source_light_tex, RID &dest_light_tex, const Size2i &atlas_size, int atlas_slices) {
+// 	Vector<RD::Uniform> uniforms = dilate_or_denoise_common_uniforms(source_light_tex, dest_light_tex);
+//
+// 	RID compute_shader_pack = rd->shader_create_from_spirv(compute_shader->get_spirv_stages("pack_coeffs"));
+// 	ERR_FAIL_COND_V(compute_shader_pack.is_null(), BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES); //internal check, should not happen
+// 	RID compute_shader_pack_pipeline = rd->compute_pipeline_create(compute_shader_pack);
+//
+// 	RID dilate_uniform_set = rd->uniform_set_create(uniforms, compute_shader_pack, 1);
+//
+// 	RD::ComputeListID compute_list = rd->compute_list_begin();
+// 	rd->compute_list_bind_compute_pipeline(compute_list, compute_shader_pack_pipeline);
+// 	rd->compute_list_bind_uniform_set(compute_list, compute_base_uniform_set, 0);
+// 	rd->compute_list_bind_uniform_set(compute_list, dilate_uniform_set, 1);
+// 	push_constant.region_ofs[0] = 0;
+// 	push_constant.region_ofs[1] = 0;
+// 	Vector3i group_size(Math::division_round_up(atlas_size.x, 8), Math::division_round_up(atlas_size.y, 8), 1); //restore group size
+//
+// 	for (int i = 0; i < atlas_slices; i++) {
+// 		push_constant.atlas_slice = i;
+// 		rd->compute_list_set_push_constant(compute_list, &push_constant, sizeof(PushConstant));
+// 		rd->compute_list_dispatch(compute_list, group_size.x, group_size.y, group_size.z);
+// 		//no barrier, let them run all together
+// 	}
+// 	rd->compute_list_end();
+// 	rd->free(compute_shader_pack);
+//
+// 	return BAKE_OK;
+// }
 
 Error LightmapperRD::_store_pfm(RenderingDevice *p_rd, RID p_atlas_tex, int p_index, const Size2i &p_atlas_size, const String &p_name, bool p_shadowmask) {
 	Vector<uint8_t> data = p_rd->texture_get_data(p_atlas_tex, p_index);
@@ -2259,13 +2259,13 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		}
 	}
 
-	if (p_bake_sh) {
-		SWAP(light_accum_tex, light_accum_tex2);
-		BakeError error = _pack_l1(rd, compute_shader, compute_base_uniform_set, push_constant, light_accum_tex2, light_accum_tex, atlas_size, atlas_slices);
-		if (unlikely(error != BAKE_OK)) {
-			return error;
-		}
-	}
+	// if (p_bake_sh) {
+	// 	SWAP(light_accum_tex, light_accum_tex2);
+	// 	BakeError error = _pack_l1(rd, compute_shader, compute_base_uniform_set, push_constant, light_accum_tex2, light_accum_tex, atlas_size, atlas_slices);
+	// 	if (unlikely(error != BAKE_OK)) {
+	// 		return error;
+	// 	}
+	// }
 
 #ifdef DEBUG_TEXTURES
 

--- a/modules/lightmapper_rd/lightmapper_rd.h
+++ b/modules/lightmapper_rd/lightmapper_rd.h
@@ -282,7 +282,7 @@ class LightmapperRD : public Lightmapper {
 
 	BakeError _dilate(RenderingDevice *rd, Ref<RDShaderFile> &compute_shader, RID &compute_base_uniform_set, PushConstant &push_constant, RID &source_light_tex, RID &dest_light_tex, const Size2i &atlas_size, int atlas_slices);
 	BakeError _denoise(RenderingDevice *p_rd, Ref<RDShaderFile> &p_compute_shader, const RID &p_compute_base_uniform_set, PushConstant &p_push_constant, RID p_source_light_tex, RID p_source_normal_tex, RID p_dest_light_tex, float p_denoiser_strength, int p_denoiser_range, const Size2i &p_atlas_size, int p_atlas_slices, bool p_bake_sh, BakeStepFunc p_step_function, void *p_bake_userdata);
-	BakeError _pack_l1(RenderingDevice *rd, Ref<RDShaderFile> &compute_shader, RID &compute_base_uniform_set, PushConstant &push_constant, RID &source_light_tex, RID &dest_light_tex, const Size2i &atlas_size, int atlas_slices);
+	// BakeError _pack_l1(RenderingDevice *rd, Ref<RDShaderFile> &compute_shader, RID &compute_base_uniform_set, PushConstant &push_constant, RID &source_light_tex, RID &dest_light_tex, const Size2i &atlas_size, int atlas_slices);
 
 	Error _store_pfm(RenderingDevice *p_rd, RID p_atlas_tex, int p_index, const Size2i &p_atlas_size, const String &p_name, bool p_shadowmask);
 	Ref<Image> _read_pfm(const String &p_name, bool p_shadowmask);

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -64,7 +64,7 @@ private:
 	bool uses_spherical_harmonics = false;
 	bool interior = false;
 
-	bool _uses_packed_directional = false;
+	// bool _uses_packed_directional = false;
 
 	RID lightmap;
 	AABB bounds;
@@ -110,8 +110,8 @@ public:
 	void set_uses_spherical_harmonics(bool p_enable);
 	bool is_using_spherical_harmonics() const;
 
-	void _set_uses_packed_directional(bool p_enable);
-	bool _is_using_packed_directional() const;
+	// void _set_uses_packed_directional(bool p_enable);
+	// bool _is_using_packed_directional() const;
 
 	void update_shadowmask_mode(ShadowmaskMode p_mode);
 	ShadowmaskMode get_shadowmask_mode() const;
@@ -273,7 +273,7 @@ private:
 	void _plot_triangle_into_octree(GenProbesOctree *p_cell, float p_cell_size, const Vector3 *p_triangle);
 	void _gen_new_positions_from_octree(const GenProbesOctree *p_cell, float p_cell_size, const Vector<Vector3> &probe_positions, LocalVector<Vector3> &new_probe_positions, HashMap<Vector3i, bool> &positions_used, const AABB &p_bounds);
 
-	BakeError _save_and_reimport_atlas_textures(const Ref<Lightmapper> p_lightmapper, const String &p_base_name, TypedArray<TextureLayered> &r_textures, bool p_is_shadowmask = false) const;
+	BakeError _save_and_reimport_atlas_textures(const Ref<Lightmapper> p_lightmapper, const String &p_base_name, TypedArray<TextureLayered> &r_textures, bool p_is_shadowmask = false, bool p_compress = false) const;
 
 protected:
 	void _validate_property(PropertyInfo &p_property) const;

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1690,23 +1690,23 @@ void fragment_shader(in SceneData scene_data) {
 
 			if (sc_use_lightmap_bicubic_filter()) {
 				lm_light_l0 = textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 0.0), lightmaps.data[ofs].light_texture_size).rgb;
-				lm_light_l1n1 = (textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 1.0), lightmaps.data[ofs].light_texture_size).rgb - vec3(0.5)) * 2.0;
-				lm_light_l1_0 = (textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 2.0), lightmaps.data[ofs].light_texture_size).rgb - vec3(0.5)) * 2.0;
-				lm_light_l1p1 = (textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 3.0), lightmaps.data[ofs].light_texture_size).rgb - vec3(0.5)) * 2.0;
+				lm_light_l1n1 = textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 1.0), lightmaps.data[ofs].light_texture_size).rgb;
+				lm_light_l1_0 = textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 2.0), lightmaps.data[ofs].light_texture_size).rgb;
+				lm_light_l1p1 = textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 3.0), lightmaps.data[ofs].light_texture_size).rgb;
 			} else {
 				lm_light_l0 = textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 0.0), 0.0).rgb;
-				lm_light_l1n1 = (textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 1.0), 0.0).rgb - vec3(0.5)) * 2.0;
-				lm_light_l1_0 = (textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 2.0), 0.0).rgb - vec3(0.5)) * 2.0;
-				lm_light_l1p1 = (textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 3.0), 0.0).rgb - vec3(0.5)) * 2.0;
+				lm_light_l1n1 = textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 1.0), 0.0).rgb;
+				lm_light_l1_0 = textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 2.0), 0.0).rgb;
+				lm_light_l1p1 = textureLod(sampler2DArray(lightmap_textures[ofs], SAMPLER_LINEAR_CLAMP), uvw + vec3(0.0, 0.0, 3.0), 0.0).rgb;
 			}
 
 			vec3 n = normalize(lightmaps.data[ofs].normal_xform * normal);
 			float en = lightmaps.data[ofs].exposure_normalization;
 
 			ambient_light += lm_light_l0 * en;
-			ambient_light += lm_light_l1n1 * n.y * (lm_light_l0 * en * 4.0);
-			ambient_light += lm_light_l1_0 * n.z * (lm_light_l0 * en * 4.0);
-			ambient_light += lm_light_l1p1 * n.x * (lm_light_l0 * en * 4.0);
+			ambient_light += lm_light_l1n1 * n.y * en;
+			ambient_light += lm_light_l1_0 * n.z * en;
+			ambient_light += lm_light_l1p1 * n.x * en;
 
 		} else {
 			if (sc_use_lightmap_bicubic_filter()) {


### PR DESCRIPTION
Fixes #102300 without L1 packing

This PR changes the SH coefficients used for encoding direct light sources. This requires that the L1 packing method also should be adjusted since it is tightly coupled to the SH coefficients. This PR does this by disabling L1 packing all together effectively undoing #96114.

| Dynamic | Non-Directional | Current Directional | PR Directional|
|--------|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/4d04b807-b540-4593-9cc8-a5c1b4d97dc8) | ![image](https://github.com/user-attachments/assets/95a71f03-a8de-4daf-a83d-f2a02803138f) | ![image](https://github.com/user-attachments/assets/2f2002c0-4de1-438d-8ee1-32aace621194) | ![image](https://github.com/user-attachments/assets/9d589ddf-08af-43bb-85d3-0c74640aea67) |
|![image](https://github.com/user-attachments/assets/491f971a-a52c-41b9-9b28-ad335feb3974) | ![image](https://github.com/user-attachments/assets/71fe10c2-e126-427e-9a38-0df3113a0351) | ![image](https://github.com/user-attachments/assets/bdf885f3-9a7f-47b1-a30b-6d6b283ba0ae) | ![image](https://github.com/user-attachments/assets/4c89d2b5-e6ea-4780-95e2-b946476d48fc) | 