### PR TITLE
GDScript: Fix error on operator `"member" in Class`

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3115,6 +3115,13 @@ void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_o
 	}
 #endif // DEBUG_ENABLED
 
+	bool lhs_is_stringy = left_type.kind == GDScriptParser::DataType::BUILTIN && (left_type.builtin_type == Variant::STRING || left_type.builtin_type == Variant::STRING_NAME);
+	bool rhs_is_meta_class = right_type.kind == GDScriptParser::DataType::CLASS && right_type.is_meta_type;
+	if (lhs_is_stringy && p_binary_op->variant_op == Variant::OP_IN && rhs_is_meta_class) {
+		// TODO: Some script members presence could be determined here.
+		return;
+	}
+
 	if (p_binary_op->left_operand->is_constant &&
 			p_binary_op->right_operand->is_constant &&
 			!p_binary_op->left_operand->reduced_value.is_shared() &&

--- a/modules/gdscript/tests/scripts/analyzer/features/operator_constant_string_in_class.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/operator_constant_string_in_class.gd
@@ -1,0 +1,6 @@
+class MyClass:
+	static func my_static():
+		print("my_static")
+
+func test():
+	print("my_static" in MyClass)

--- a/modules/gdscript/tests/scripts/analyzer/features/operator_constant_string_in_class.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/operator_constant_string_in_class.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+true


### PR DESCRIPTION
partially fixes https://github.com/godotengine/godot/issues/89350 (because its really an amalgam of inconsistencies in GDScript)

avoids trying to reduce an expression like `"member" in Class`. bc the normal codepath for evaluating at analysis time doesn't understand the script might not be compiled yet. its definitely possible to determine some class member presence at analysis time, but i didn't venture for that