### PR TITLE
Add tab spacing modifier for tabs in TabBar and TabContainer

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -395,6 +395,9 @@
 			The size of the tab text outline.
 			[b]Note:[/b] If using a font with [member FontFile.multichannel_signed_distance_field] enabled, its [member FontFile.msdf_pixel_range] must be set to at least [i]twice[/i] the value of [theme_item outline_size] for outline rendering to look correct. Otherwise, the outline may appear to be cut off earlier than intended.
 		</theme_item>
+		<theme_item name="tab_separation" data_type="constant" type="int" default="0">
+			The space between tabs in the tab bar.
+		</theme_item>
 		<theme_item name="font" data_type="font" type="Font">
 			The font used to draw tab names.
 		</theme_item>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -330,6 +330,9 @@
 			The space at the left or right edges of the tab bar, accordingly with the current [member tab_alignment].
 			The margin is ignored with [constant TabBar.ALIGNMENT_RIGHT] if the tabs are clipped (see [member clip_tabs]) or a popup has been set (see [method set_popup]). The margin is always ignored with [constant TabBar.ALIGNMENT_CENTER].
 		</theme_item>
+		<theme_item name="tab_separation" data_type="constant" type="int" default="0">
+			The space between tabs in the tab bar.
+		</theme_item>
 		<theme_item name="font" data_type="font" type="Font">
 			The font used to draw tab names.
 		</theme_item>

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -127,6 +127,7 @@ private:
 
 	struct ThemeCache {
 		int h_separation = 0;
+		int tab_separation = 0;
 		int icon_max_width = 0;
 
 		Ref<StyleBox> tab_unselected_style;
@@ -225,6 +226,7 @@ public:
 	Ref<Texture2D> get_tab_button_icon(int p_tab) const;
 
 	int get_tab_idx_at_point(const Point2 &p_point) const;
+	int get_closest_tab_idx_to_point(const Point2 &p_point) const;
 
 	void set_tab_alignment(AlignmentMode p_alignment);
 	AlignmentMode get_tab_alignment() const;

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -247,6 +247,7 @@ void TabContainer::_on_theme_changed() {
 	tab_bar->add_theme_font_size_override(SceneStringName(font_size), theme_cache.tab_font_size);
 
 	tab_bar->add_theme_constant_override(SNAME("h_separation"), theme_cache.icon_separation);
+	tab_bar->add_theme_constant_override(SNAME("tab_separation"), theme_cache.tab_separation);
 	tab_bar->add_theme_constant_override(SNAME("icon_max_width"), theme_cache.icon_max_width);
 	tab_bar->add_theme_constant_override(SNAME("outline_size"), theme_cache.outline_size);
 
@@ -1078,6 +1079,7 @@ void TabContainer::_bind_methods() {
 	BIND_ENUM_CONSTANT(POSITION_MAX);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, TabContainer, side_margin);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, TabContainer, tab_separation);
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, TabContainer, panel_style, "panel");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, TabContainer, tabbar_style, "tabbar_background");

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -71,6 +71,7 @@ private:
 
 		// TabBar overrides.
 		int icon_separation = 0;
+		int tab_separation = 0;
 		int icon_max_width = 0;
 		int outline_size = 0;
 


### PR DESCRIPTION
Adds support for spacing between tabs.

- [x] LTR support
- [x] RTL support
- [x] Left/Center/Right Alignment support
- [x] Rearrange tab support
- [x] Clipping support
- [x] Allows both positive and negative values for design flexibility

Closes [proposal #10057](https://github.com/godotengine/godot-proposals/issues/10057).