### PR TITLE
Fix file handle leak in ZipArchive and FileAccessZip

### DIFF
--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -174,7 +174,6 @@ bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint6
 
 	Package pkg;
 	pkg.filename = p_path;
-	pkg.zfile = zfile;
 	packages.push_back(pkg);
 	int pkg_num = packages.size() - 1;
 
@@ -201,6 +200,8 @@ bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint6
 		}
 	}
 
+	unzClose(zfile);
+
 	return true;
 }
 
@@ -225,10 +226,6 @@ ZipArchive::ZipArchive() {
 }
 
 ZipArchive::~ZipArchive() {
-	for (int i = 0; i < packages.size(); i++) {
-		unzClose(packages[i].zfile);
-	}
-
 	packages.clear();
 }
 

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -47,7 +47,6 @@ public:
 private:
 	struct Package {
 		String filename;
-		unzFile zfile = nullptr;
 	};
 	Vector<Package> packages;
 


### PR DESCRIPTION
I'm developing a game that supports user content with generic file formats (GLB, PNG, and more). We have an Asset Optimization Pipeline that converts these assets into Godot ZIP Packages. When loading thousands of these ZIPs (with ProjectSettings.load_resource_pack), we encountered issues with too many open file handles due to this bug.

# Fix:
Previously, zfile was stored in a global variable inside the ZipArchive singleton, leading to a potential file handle leak when handling ZIP archives.

Since zfile is not needed at runtime, there is no reason to store it. This change ensures that the file handle is properly closed after processing, preventing unnecessary open file accumulation.

This fix ensures that file handles are properly closed, improving resource management and stability when dealing with a large number of ZIP archives.