### PR TITLE
Add "Go Online" button on Export Template Manager

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -43,6 +43,7 @@
 #include "editor/progress_dialog.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/file_dialog.h"
+#include "scene/gui/link_button.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/tree.h"
@@ -56,9 +57,6 @@ enum DownloadsAvailability {
 
 static DownloadsAvailability _get_downloads_availability() {
 	const int network_mode = EDITOR_GET("network/connection/network_mode");
-	if (network_mode == EditorSettings::NETWORK_OFFLINE) {
-		return DOWNLOADS_NOT_AVAILABLE_IN_OFFLINE_MODE;
-	}
 
 	// Downloadable export templates are only available for stable and official alpha/beta/RC builds
 	// (which always have a number following their status, e.g. "alpha1").
@@ -69,6 +67,10 @@ static DownloadsAvailability _get_downloads_availability() {
 			String(VERSION_STATUS) == String("beta") ||
 			String(VERSION_STATUS) == String("rc")) {
 		return DOWNLOADS_NOT_AVAILABLE_FOR_DEV_BUILDS;
+	}
+
+	if (network_mode == EditorSettings::NETWORK_OFFLINE) {
+		return DOWNLOADS_NOT_AVAILABLE_IN_OFFLINE_MODE;
 	}
 
 	return DOWNLOADS_AVAILABLE;
@@ -333,6 +335,14 @@ void ExportTemplateManager::_refresh_mirrors_completed(int p_status, int p_code,
 
 		_download_template(mirror_url, true);
 	}
+}
+
+void ExportTemplateManager::_force_online_mode() {
+	EditorSettings::get_singleton()->set_setting("network/connection/network_mode", EditorSettings::NETWORK_ONLINE);
+	EditorSettings::get_singleton()->notify_changes();
+	EditorSettings::get_singleton()->save();
+
+	popup_manager();
 }
 
 bool ExportTemplateManager::_humanize_http_status(HTTPRequest *p_request, String *r_status, int *r_downloaded_bytes, int *r_total_bytes) {
@@ -694,6 +704,8 @@ void ExportTemplateManager::popup_manager() {
 			if (!is_downloading_templates) {
 				_refresh_mirrors();
 			}
+
+			enable_online_hb->hide();
 		} break;
 
 		case DOWNLOADS_NOT_AVAILABLE_IN_OFFLINE_MODE: {
@@ -708,6 +720,8 @@ void ExportTemplateManager::popup_manager() {
 
 			download_current_button->set_disabled(true);
 			download_current_button->set_tooltip_text(TTR("Template downloading is disabled in offline mode."));
+
+			enable_online_hb->show();
 		} break;
 
 		case DOWNLOADS_NOT_AVAILABLE_FOR_DEV_BUILDS: {
@@ -722,6 +736,8 @@ void ExportTemplateManager::popup_manager() {
 
 			download_current_button->set_disabled(true);
 			download_current_button->set_tooltip_text(TTR("Official export templates aren't available for development builds."));
+
+			enable_online_hb->hide();
 		} break;
 	}
 
@@ -1052,6 +1068,19 @@ ExportTemplateManager::ExportTemplateManager() {
 	install_file_button->set_tooltip_text(TTR("Install templates from a local file."));
 	install_file_hb->add_child(install_file_button);
 	install_file_button->connect(SceneStringName(pressed), callable_mp(this, &ExportTemplateManager::_install_file));
+
+	enable_online_hb = memnew(HBoxContainer);
+	install_options_vb->add_child(enable_online_hb);
+
+	Label *enable_online_label = memnew(Label);
+	enable_online_label->set_text(TTR("Online mode is needed to download the templates."));
+	enable_online_hb->add_child(enable_online_label);
+
+	LinkButton *enable_online_button = memnew(LinkButton);
+	enable_online_button->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
+	enable_online_button->set_text(TTR("Go Online"));
+	enable_online_hb->add_child(enable_online_button);
+	enable_online_button->connect(SceneStringName(pressed), callable_mp(this, &ExportTemplateManager::_force_online_mode));
 
 	// Templates are being downloaded; buttons unavailable.
 	download_progress_hb = memnew(HBoxContainer);

--- a/editor/export/export_template_manager.h
+++ b/editor/export/export_template_manager.h
@@ -68,6 +68,7 @@ class ExportTemplateManager : public AcceptDialog {
 	};
 
 	MenuButton *mirror_options_button = nullptr;
+	HBoxContainer *enable_online_hb = nullptr;
 	HBoxContainer *download_progress_hb = nullptr;
 	ProgressBar *download_progress_bar = nullptr;
 	Label *download_progress_label = nullptr;
@@ -96,6 +97,7 @@ class ExportTemplateManager : public AcceptDialog {
 	void _cancel_template_download();
 	void _refresh_mirrors();
 	void _refresh_mirrors_completed(int p_status, int p_code, const PackedStringArray &headers, const PackedByteArray &p_data);
+	void _force_online_mode();
 
 	bool _humanize_http_status(HTTPRequest *p_request, String *r_status, int *r_downloaded_bytes, int *r_total_bytes);
 	void _set_current_progress_status(const String &p_status, bool p_error = false);


### PR DESCRIPTION
Resolves godotengine/godot-proposals#11834

The code follows the one-click method of fixing the required ETC2/ASTC texture compression for Android export, with the same LinkButton that enables a project settings item (in this case, network mode) when clicked, and refresh the popup window (in this case, the Export Template Manager) afterwards. The addition is small enough and sufficient to be added to 4.4 before the stable version launches, since the main purpose of this feature is to make it less confusing for beginners to download export template with the new network mode that defaults to offline.

The label is written that way to avoid repeating the already established 'offline mode' on the mirrors OptionButton above it. It was placed below the "Install from File" button (instead on the same HboxContainer as it) to prevent them colliding and mess with the UI, especially with editors with bigger display scale. (Feel free to move it upward if that wouldn't be the case)

Tested on these devices:
`scons -j9 platform=windows dev_mode=yes debug_symbols=yes optimize=debug`
![image](https://github.com/user-attachments/assets/41165b36-239b-4926-98ed-0dc522115a04)

`scons platform=macos arch=arm64 -j4 target=editor optimize=debug`
![image](https://github.com/user-attachments/assets/124e3e67-069c-4de6-8c54-18b3da9efe57)

`scons -j9 platform=android target=editor optimize=size arch=arm32`
![image](https://github.com/user-attachments/assets/378b7318-5193-4e94-9ffd-c7148d424374)
