### PR TITLE
Condense Inspector layout for Arrays

### DIFF
--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -136,6 +136,11 @@ public:
 		COLORATION_EXTERNAL,
 	};
 
+	enum InlineControlSide {
+		INLINE_CONTROL_LEFT,
+		INLINE_CONTROL_RIGHT
+	};
+
 private:
 	String label;
 	int text_size;
@@ -158,6 +163,7 @@ private:
 	bool draw_prop_warning = false;
 	bool keying = false;
 	bool deletable = false;
+	bool label_overlayed = false;
 
 	Rect2 right_child_rect;
 	Rect2 bottom_child_rect;
@@ -198,6 +204,8 @@ private:
 	Control *label_reference = nullptr;
 	Control *bottom_editor = nullptr;
 	PopupMenu *menu = nullptr;
+	HBoxContainer *left_container = nullptr;
+	HBoxContainer *right_container = nullptr;
 
 	HashMap<StringName, Variant> cache;
 
@@ -283,6 +291,10 @@ public:
 	void select(int p_focusable = -1);
 	void deselect();
 	bool is_selected() const;
+
+	void add_inline_control(Control *p_control, InlineControlSide p_side);
+	HBoxContainer *get_inline_container(InlineControlSide p_side);
+	void set_label_overlayed(bool p_overlay);
 
 	void set_label_reference(Control *p_control);
 	void set_bottom_editor(Control *p_control);

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -305,35 +305,38 @@ void EditorPropertyArray::_create_new_property_slot() {
 	int idx = slots.size();
 	HBoxContainer *hbox = memnew(HBoxContainer);
 
+	EditorProperty *prop = memnew(EditorPropertyNil);
+
 	Button *reorder_button = memnew(Button);
 	reorder_button->set_accessibility_name(TTRC("Reorder"));
 	reorder_button->set_button_icon(get_editor_theme_icon(SNAME("TripleBar")));
 	reorder_button->set_default_cursor_shape(Control::CURSOR_MOVE);
 	reorder_button->set_disabled(is_read_only());
+	reorder_button->set_theme_type_variation(SceneStringName(FlatButton));
 	reorder_button->connect(SceneStringName(gui_input), callable_mp(this, &EditorPropertyArray::_reorder_button_gui_input));
 	reorder_button->connect(SNAME("button_up"), callable_mp(this, &EditorPropertyArray::_reorder_button_up));
 	reorder_button->connect(SNAME("button_down"), callable_mp(this, &EditorPropertyArray::_reorder_button_down).bind(idx));
 
-	hbox->add_child(reorder_button);
-	EditorProperty *prop = memnew(EditorPropertyNil);
 	hbox->add_child(prop);
 
 	bool is_untyped_array = object->get_array().get_type() == Variant::ARRAY && subtype == Variant::NIL;
 
+	Button *edit_btn = nullptr;
+	Button *remove_btn = nullptr;
 	if (is_untyped_array) {
-		Button *edit_btn = memnew(Button);
+		edit_btn = memnew(Button);
 		edit_btn->set_accessibility_name(TTRC("Edit"));
 		edit_btn->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
 		edit_btn->set_disabled(is_read_only());
+		edit_btn->set_theme_type_variation(SceneStringName(FlatButton));
 		edit_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyArray::_change_type).bind(edit_btn, idx));
-		hbox->add_child(edit_btn);
 	} else {
-		Button *remove_btn = memnew(Button);
+		remove_btn = memnew(Button);
 		remove_btn->set_accessibility_name(TTRC("Remove"));
 		remove_btn->set_button_icon(get_editor_theme_icon(SNAME("Remove")));
 		remove_btn->set_disabled(is_read_only());
+		remove_btn->set_theme_type_variation(SceneStringName(FlatButton));
 		remove_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyArray::_remove_pressed).bind(idx));
-		hbox->add_child(remove_btn);
 	}
 	property_vbox->add_child(hbox);
 
@@ -342,6 +345,8 @@ void EditorPropertyArray::_create_new_property_slot() {
 	slot.object = object;
 	slot.container = hbox;
 	slot.reorder_button = reorder_button;
+	slot.edit_button = edit_btn;
+	slot.remove_button = remove_btn;
 	slot.set_index(idx + page_index * page_length);
 	slots.push_back(slot);
 }
@@ -513,6 +518,17 @@ void EditorPropertyArray::update_property() {
 				new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyArray::_object_id_selected));
 				new_prop->set_h_size_flags(SIZE_EXPAND_FILL);
 				new_prop->set_read_only(is_read_only());
+
+				if (slot.reorder_button) {
+					new_prop->add_inline_control(slot.reorder_button, INLINE_CONTROL_LEFT);
+					slot.reorder_button->get_parent()->move_child(slot.reorder_button, 0);
+				}
+				if (slot.edit_button) {
+					new_prop->add_inline_control(slot.edit_button, INLINE_CONTROL_RIGHT);
+				} else if (slot.remove_button) {
+					new_prop->add_inline_control(slot.remove_button, INLINE_CONTROL_RIGHT);
+				}
+
 				slot.prop->add_sibling(new_prop, false);
 				slot.prop->queue_free();
 				slot.prop = new_prop;
@@ -1047,33 +1063,34 @@ void EditorPropertyDictionary::_create_new_property_slot(int p_idx) {
 	EditorProperty *prop_key = nullptr;
 	if (p_idx != EditorPropertyDictionaryObject::NEW_KEY_INDEX && p_idx != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
 		prop_key = memnew(EditorPropertyNil);
-		hbox->add_child(prop_key);
 	}
 
 	EditorProperty *prop = memnew(EditorPropertyNil);
 	prop->set_h_size_flags(SIZE_EXPAND_FILL);
-	if (p_idx != EditorPropertyDictionaryObject::NEW_KEY_INDEX && p_idx != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
-		prop->set_draw_label(false);
-	}
 	hbox->add_child(prop);
+	if (prop_key) {
+		prop->add_inline_control(prop_key, INLINE_CONTROL_LEFT);
+	}
 
 	bool use_key = p_idx == EditorPropertyDictionaryObject::NEW_KEY_INDEX;
 	bool is_untyped_dict = (use_key ? key_subtype : value_subtype) == Variant::NIL;
 
+	Button *edit_btn = nullptr;
+	Button *remove_btn = nullptr;
 	if (is_untyped_dict) {
-		Button *edit_btn = memnew(Button);
+		edit_btn = memnew(Button);
 		edit_btn->set_accessibility_name(TTRC("Edit"));
 		edit_btn->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
 		edit_btn->set_disabled(is_read_only());
+		edit_btn->set_theme_type_variation(SceneStringName(FlatButton));
 		edit_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyDictionary::_change_type).bind(edit_btn, slots.size()));
-		hbox->add_child(edit_btn);
 	} else if (p_idx >= 0) {
-		Button *remove_btn = memnew(Button);
+		remove_btn = memnew(Button);
 		remove_btn->set_accessibility_name(TTRC("Remove"));
 		remove_btn->set_button_icon(get_editor_theme_icon(SNAME("Remove")));
 		remove_btn->set_disabled(is_read_only());
+		remove_btn->set_theme_type_variation(SceneStringName(FlatButton));
 		remove_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyDictionary::_remove_pressed).bind(slots.size()));
-		hbox->add_child(remove_btn);
 	}
 
 	if (add_panel) {
@@ -1087,6 +1104,8 @@ void EditorPropertyDictionary::_create_new_property_slot(int p_idx) {
 	slot.prop_key = prop_key;
 	slot.object = object;
 	slot.container = hbox;
+	slot.edit_button = edit_btn;
+	slot.remove_button = remove_btn;
 	int index = p_idx + (p_idx >= 0 ? page_index * page_length : 0);
 	slot.set_index(index);
 	slots.push_back(slot);
@@ -1360,6 +1379,9 @@ void EditorPropertyDictionary::update_property() {
 						dict_prop->set_preview_value(true);
 					}
 					slot.set_key_prop(new_prop);
+					if (slot.prop) {
+						slot.prop->add_inline_control(new_prop, INLINE_CONTROL_LEFT);
+					}
 				}
 			}
 
@@ -1395,10 +1417,22 @@ void EditorPropertyDictionary::update_property() {
 				new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyDictionary::_object_id_selected));
 				new_prop->set_h_size_flags(SIZE_EXPAND_FILL);
 				if (slot.index != EditorPropertyDictionaryObject::NEW_KEY_INDEX && slot.index != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
-					new_prop->set_draw_label(false);
+					new_prop->set_label(" ");
+					new_prop->set_label_overlayed(true);
 				}
 				new_prop->set_read_only(is_read_only());
+				if (slot.remove_button) {
+					new_prop->add_inline_control(slot.remove_button, INLINE_CONTROL_RIGHT);
+				}
+				if (slot.edit_button) {
+					new_prop->add_inline_control(slot.edit_button, INLINE_CONTROL_RIGHT);
+				}
+				if (slot.prop_key) {
+					new_prop->add_inline_control(slot.prop_key, INLINE_CONTROL_LEFT);
+				}
+
 				slot.set_prop(new_prop);
+
 			} else if (slot.index != EditorPropertyDictionaryObject::NEW_KEY_INDEX && slot.index != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
 				Variant key = dict.get_key_at_index(slot.index);
 				String cs = key.get_construct_string();

--- a/editor/inspector/editor_properties_array_dict.h
+++ b/editor/inspector/editor_properties_array_dict.h
@@ -100,6 +100,8 @@ class EditorPropertyArray : public EditorProperty {
 		bool as_id = false;
 		EditorProperty *prop = nullptr;
 		Button *reorder_button = nullptr;
+		Button *edit_button = nullptr;
+		Button *remove_button = nullptr;
 
 		void set_index(int p_idx) {
 			String prop_name = "indices/" + itos(p_idx);
@@ -186,6 +188,8 @@ class EditorPropertyDictionary : public EditorProperty {
 		bool key_as_id = false;
 		EditorProperty *prop = nullptr;
 		EditorProperty *prop_key = nullptr;
+		Button *edit_button = nullptr;
+		Button *remove_button = nullptr;
 		String prop_name;
 		String key_name;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Mostly implements https://github.com/godotengine/godot-proposals/issues/10125

- Merges `+ Add Element` button and size modifier into 1 row, and moves it to the bottom of the list
- Moves array buttons & handles up to the property header, freeing up space in nested editors
- Adds an Editor Setting to enable or disable condensing the buttons (in some cases the old uncondensed layout is a bit clearer)
![image](https://github.com/user-attachments/assets/660d102d-c59c-4188-815f-f810cb7acb61)

- Fixes an issue where dragged/reordered element's folded states were not updated, so the wrong items were unfolded / folded after the drag

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/0686801f-0d00-4724-bd66-1b0ef0694e07) | ![image](https://github.com/user-attachments/assets/2ce837c7-9204-41fb-bd04-f1f10c2e45dd) |


<details>
<summary>Previous version</summary>

![image](https://github.com/user-attachments/assets/90fbcde1-f71a-4f8f-bd03-194130ae2eb5)

</details>

Also things I might have to address if desired:
- This doesn't affect dictionaries.
- This doesn't change the Array / Resource button design, which passivestar's design does.
- ~~This doesn't remove the Stylebox for the array buttons, which passivestars' design does.~~
- ~~It might be good to have another Editor Setting to keep the size row at the top,~~

Edit: Added array property's name to size label

<details>

~~<summary>Edit 2: Added setting for size controls to be at the top, bottom, or split like it was before:</summary>~~

![image](https://github.com/user-attachments/assets/b3ea9a84-639e-45db-bfac-355c66c16255)
| Top | Split |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/029e44f0-fe09-451d-952a-464993834ae9) | ![image](https://github.com/user-attachments/assets/14e92d56-6ec1-4263-8843-9a8655e7ec95) |

</details>

Edit 3: Renamed the setting to "embedded_list_buttons". Embedded buttons are now flat, and array button labels have shorter text as per the proposal design. Moved the "Add Element" button to the top alongside the array header button, to allow adding elements from both the top and bottom. Changed the setting from edit 2 to a bool called "condensed_size_controls_layout", when disabled just uses the old size controls layout.

Edit 4: fixed rtl layout