### PR TITLE
Document creating Texture2DArray, Cubemap and CubemapArray from code

### DIFF
--- a/doc/classes/Cubemap.xml
+++ b/doc/classes/Cubemap.xml
@@ -6,7 +6,8 @@
 	<description>
 		A cubemap is made of 6 textures organized in layers. They are typically used for faking reflections in 3D rendering (see [ReflectionProbe]). It can be used to make an object look as if it's reflecting its surroundings. This usually delivers much better performance than other reflection methods.
 		This resource is typically used as a uniform in custom shaders. Few core Godot methods make use of [Cubemap] resources.
-		To create such a texture file yourself, reimport your image files using the Godot Editor import presets. The expected image order is X+, X-, Y+, Y-, Z+, Z- (in Godot's coordinate system, so Y+ is "up" and Z- is "forward"). You can use one of the following templates as a base:
+		To create such a texture file yourself, reimport your image files using the Godot Editor import presets. To create a Cubemap from code, use [method ImageTextureLayered.create_from_images] on an instance of the Cubemap class.
+		The expected image order is X+, X-, Y+, Y-, Z+, Z- (in Godot's coordinate system, so Y+ is "up" and Z- is "forward"). You can use one of the following templates as a base:
 		- [url=https://raw.githubusercontent.com/godotengine/godot-docs/master/tutorials/assets_pipeline/img/cubemap_template_2x3.webp]2×3 cubemap template (default layout option)[/url]
 		- [url=https://raw.githubusercontent.com/godotengine/godot-docs/master/tutorials/assets_pipeline/img/cubemap_template_3x2.webp]3×2 cubemap template[/url]
 		- [url=https://raw.githubusercontent.com/godotengine/godot-docs/master/tutorials/assets_pipeline/img/cubemap_template_1x6.webp]1×6 cubemap template[/url]

--- a/doc/classes/CubemapArray.xml
+++ b/doc/classes/CubemapArray.xml
@@ -6,8 +6,15 @@
 	<description>
 		[CubemapArray]s are made of an array of [Cubemap]s. Like [Cubemap]s, they are made of multiple textures, the amount of which must be divisible by 6 (one for each face of the cube).
 		The primary benefit of [CubemapArray]s is that they can be accessed in shader code using a single texture reference. In other words, you can pass multiple [Cubemap]s into a shader using a single [CubemapArray]. [Cubemap]s are allocated in adjacent cache regions on the GPU, which makes [CubemapArray]s the most efficient way to store multiple [Cubemap]s.
-		[b]Note:[/b] Godot uses [CubemapArray]s internally for many effects, including the [Sky] if you set [member ProjectSettings.rendering/reflections/sky_reflections/texture_array_reflections] to [code]true[/code]. To create such a texture file yourself, reimport your image files using the import presets of the File System dock.
-		[b]Note:[/b] [CubemapArray] is not supported in the Compatibility renderer.
+		Godot uses [CubemapArray]s internally for many effects, including the [Sky] if you set [member ProjectSettings.rendering/reflections/sky_reflections/texture_array_reflections] to [code]true[/code].
+		To create such a texture file yourself, reimport your image files using the Godot Editor import presets. To create a CubemapArray from code, use [method ImageTextureLayered.create_from_images] on an instance of the CubemapArray class.
+		The expected image order is X+, X-, Y+, Y-, Z+, Z- (in Godot's coordinate system, so Y+ is "up" and Z- is "forward"). You can use one of the following templates as a base:
+		- [url=https://raw.githubusercontent.com/godotengine/godot-docs/master/tutorials/assets_pipeline/img/cubemap_template_2x3.webp]2×3 cubemap template (default layout option)[/url]
+		- [url=https://raw.githubusercontent.com/godotengine/godot-docs/master/tutorials/assets_pipeline/img/cubemap_template_3x2.webp]3×2 cubemap template[/url]
+		- [url=https://raw.githubusercontent.com/godotengine/godot-docs/master/tutorials/assets_pipeline/img/cubemap_template_1x6.webp]1×6 cubemap template[/url]
+		- [url=https://raw.githubusercontent.com/godotengine/godot-docs/master/tutorials/assets_pipeline/img/cubemap_template_6x1.webp]6×1 cubemap template[/url]
+		Multiple layers are stacked on top of each other when using the default vertical import option (with the first layer at the top). Alternatively, you can choose an horizontal layout in the import options (with the first layer at the left).
+		[b]Note:[/b] [CubemapArray] is not supported in the Compatibility renderer due to graphics API limitations.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/ImageTextureLayered.xml
+++ b/doc/classes/ImageTextureLayered.xml
@@ -15,6 +15,39 @@
 			<description>
 				Creates an [ImageTextureLayered] from an array of [Image]s. See [method Image.create] for the expected data format. The first image decides the width, height, image format and mipmapping setting. The other images [i]must[/i] have the same width, height, image format and mipmapping setting.
 				Each [Image] represents one [code]layer[/code].
+				[codeblock]
+				# Fill in an array of Images with different colors.
+				var images = []
+				const LAYERS = 6
+				for i in LAYERS:
+				    var image = Image.create_empty(128, 128, false, Image.FORMAT_RGB8)
+				    if i % 3 == 0:
+				        image.fill(Color.RED)
+				    elif i % 3 == 1:
+				        image.fill(Color.GREEN)
+				    else:
+				        image.fill(Color.BLUE)
+				    images.push_back(image)
+
+				# Create and save a 2D texture array. The array of images must have at least 1 Image.
+				var texture_2d_array = Texture2DArray.new()
+				texture_2d_array.create_from_images(images)
+				ResourceSaver.save(texture_2d_array, "res://texture_2d_array.res", ResourceSaver.FLAG_COMPRESS)
+
+				# Create and save a cubemap. The array of images must have exactly 6 Images.
+				# The cubemap's images are specified in this order: X+, X-, Y+, Y-, Z+, Z-
+				# (in Godot's coordinate system, so Y+ is "up" and Z- is "forward").
+				var cubemap = Cubemap.new()
+				cubemap.create_from_images(images)
+				ResourceSaver.save(cubemap, "res://cubemap.res", ResourceSaver.FLAG_COMPRESS)
+
+				# Create and save a cubemap array. The array of images must have a multiple of 6 Images.
+				# Each cubemap's images are specified in this order: X+, X-, Y+, Y-, Z+, Z-
+				# (in Godot's coordinate system, so Y+ is "up" and Z- is "forward").
+				var cubemap_array = CubemapArray.new()
+				cubemap_array.create_from_images(images)
+				ResourceSaver.save(cubemap_array, "res://cubemap_array.res", ResourceSaver.FLAG_COMPRESS)
+				[/codeblock]
 			</description>
 		</method>
 		<method name="update_layer">

--- a/doc/classes/Texture2DArray.xml
+++ b/doc/classes/Texture2DArray.xml
@@ -6,7 +6,7 @@
 	<description>
 		A Texture2DArray is different from a Texture3D: The Texture2DArray does not support trilinear interpolation between the [Image]s, i.e. no blending. See also [Cubemap] and [CubemapArray], which are texture arrays with specialized cubemap functions.
 		A Texture2DArray is also different from an [AtlasTexture]: In a Texture2DArray, all images are treated separately. In an atlas, the regions (i.e. the single images) can be of different sizes. Furthermore, you usually need to add a padding around the regions, to prevent accidental UV mapping to more than one region. The same goes for mipmapping: Mipmap chains are handled separately for each layer. In an atlas, the slicing has to be done manually in the fragment shader.
-		To create such a texture file yourself, reimport your image files using the Godot Editor import presets.
+		To create such a texture file yourself, reimport your image files using the Godot Editor import presets. To create a Texture2DArray from code, use [method ImageTextureLayered.create_from_images] on an instance of the Texture2DArray class.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
This also documents the expected texture layout when importing CubemapArrays from the editor.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/369#discussioncomment-12294647.
