### PR TITLE
Rename "file" param for str.path_join() to "path"

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -517,7 +517,7 @@ public:
 	String rstrip(const String &p_chars) const;
 	String get_extension() const;
 	String get_basename() const;
-	String path_join(const String &p_file) const;
+	String path_join(const String &p_path) const;
 	char32_t unicode_at(int p_idx) const;
 
 	CharString ascii(bool p_allow_extended = false) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1750,7 +1750,7 @@ static void _register_variant_builtin_methods_string() {
 	bind_string_method(rstrip, sarray("chars"), varray());
 	bind_string_method(get_extension, sarray(), varray());
 	bind_string_method(get_basename, sarray(), varray());
-	bind_string_method(path_join, sarray("file"), varray());
+	bind_string_method(path_join, sarray("path"), varray());
 	bind_string_method(unicode_at, sarray("at"), varray());
 	bind_string_method(indent, sarray("prefix"), varray());
 	bind_string_method(dedent, sarray(), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -757,9 +757,9 @@
 		</method>
 		<method name="path_join" qualifiers="const">
 			<return type="String" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<description>
-				Concatenates [param file] at the end of the string as a subpath, adding [code]/[/code] if necessary.
+				Concatenates [param path] at the end of the string as a subpath, adding [code]/[/code] if necessary.
 				[b]Example:[/b] [code]"this/is".path_join("path") == "this/is/path"[/code].
 			</description>
 		</method>

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -665,9 +665,9 @@
 		</method>
 		<method name="path_join" qualifiers="const">
 			<return type="String" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<description>
-				Concatenates [param file] at the end of the string as a subpath, adding [code]/[/code] if necessary.
+				Concatenates [param path] at the end of the string as a subpath, adding [code]/[/code] if necessary.
 				[b]Example:[/b] [code]"this/is".path_join("path") == "this/is/path"[/code].
 			</description>
 		</method>


### PR DESCRIPTION
Make it clear that `str.path_join(path)` works with paths too, not only file names.