### PR TITLE
Add str.strip(), deprecate str.strip_edges(), improve lstrip()/rstrip()

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4245,6 +4245,41 @@ String String::dedent() const {
 	return new_string;
 }
 
+String String::strip(const String &p_chars) const {
+	int len = length();
+	int end = len - 1;
+	int beg = 0;
+
+	if (p_chars.is_empty()) {
+		// Strip non-printable characters by default.
+		for (; beg < len; beg++) {
+			if (get(beg) > 32) {
+				break;
+			}
+		}
+		for (; end >= beg; end--) {
+			if (get(end) > 32) {
+				break;
+			}
+		}
+	} else {
+		// Strip given characters.
+		for (; beg < len; beg++) {
+			if (p_chars.find_char(get(beg)) == -1) {
+				break;
+			}
+		}
+
+		for (; end >= beg; end--) {
+			if (p_chars.find_char(get(end)) == -1) {
+				break;
+			}
+		}
+	}
+
+	return substr(beg, end - beg + 1);
+}
+
 String String::strip_edges(bool left, bool right) const {
 	int len = length();
 	int beg = 0, end = len;
@@ -4269,10 +4304,6 @@ String String::strip_edges(bool left, bool right) const {
 		}
 	}
 
-	if (beg == 0 && end == len) {
-		return *this;
-	}
-
 	return substr(beg, end - beg);
 }
 
@@ -4293,9 +4324,17 @@ String String::lstrip(const String &p_chars) const {
 	int len = length();
 	int beg;
 
-	for (beg = 0; beg < len; beg++) {
-		if (p_chars.find_char(get(beg)) == -1) {
-			break;
+	if (p_chars.is_empty()) {
+		for (beg = 0; beg < len; beg++) {
+			if (get(beg) > 32) {
+				break;
+			}
+		}
+	} else {
+		for (beg = 0; beg < len; beg++) {
+			if (p_chars.find_char(get(beg)) == -1) {
+				break;
+			}
 		}
 	}
 
@@ -4310,9 +4349,17 @@ String String::rstrip(const String &p_chars) const {
 	int len = length();
 	int end;
 
-	for (end = len - 1; end >= 0; end--) {
-		if (p_chars.find_char(get(end)) == -1) {
-			break;
+	if (p_chars.is_empty()) {
+		for (end = len - 1; end >= 0; end--) {
+			if (get(end) > 32) {
+				break;
+			}
+		}
+	} else {
+		for (end = len - 1; end >= 0; end--) {
+			if (p_chars.find_char(get(end)) == -1) {
+				break;
+			}
 		}
 	}
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -511,10 +511,11 @@ public:
 	String right(int p_len) const;
 	String indent(const String &p_prefix) const;
 	String dedent() const;
+	String strip(const String &p_chars = "") const;
 	String strip_edges(bool left = true, bool right = true) const;
 	String strip_escapes() const;
-	String lstrip(const String &p_chars) const;
-	String rstrip(const String &p_chars) const;
+	String lstrip(const String &p_chars = "") const;
+	String rstrip(const String &p_chars = "") const;
 	String get_extension() const;
 	String get_basename() const;
 	String path_join(const String &p_file) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1744,10 +1744,13 @@ static void _register_variant_builtin_methods_string() {
 	bind_string_method(left, sarray("length"), varray());
 	bind_string_method(right, sarray("length"), varray());
 
+	bind_string_method(strip, sarray("chars"), varray(""));
+#ifndef DISABLE_DEPRECATED
 	bind_string_method(strip_edges, sarray("left", "right"), varray(true, true));
+#endif // DISABLE_DEPRECATED
 	bind_string_method(strip_escapes, sarray(), varray());
-	bind_string_method(lstrip, sarray("chars"), varray());
-	bind_string_method(rstrip, sarray("chars"), varray());
+	bind_string_method(lstrip, sarray("chars"), varray(""));
+	bind_string_method(rstrip, sarray("chars"), varray(""));
 	bind_string_method(get_extension, sarray(), varray());
 	bind_string_method(get_basename, sarray(), varray());
 	bind_string_method(path_join, sarray("file"), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -613,9 +613,10 @@
 		</method>
 		<method name="lstrip" qualifiers="const">
 			<return type="String" />
-			<param index="0" name="chars" type="String" />
+			<param index="0" name="chars" type="String" default="&quot;&quot;" />
 			<description>
-				Removes a set of characters defined in [param chars] from the string's beginning. See also [method rstrip].
+				Removes a set of characters defined in [param chars] from the string's beginning. See also [method rstrip], [method strip].
+				If [param chars] is empty, non-printable characters are stripped. These include spaces, tabulations ([code]\t[/code]), and newlines ([code]\n[/code] [code]\r[/code]).
 				[b]Note:[/b] [param chars] is not a prefix. Use [method trim_prefix] to remove a single prefix, rather than a set of characters.
 			</description>
 		</method>
@@ -853,9 +854,10 @@
 		</method>
 		<method name="rstrip" qualifiers="const">
 			<return type="String" />
-			<param index="0" name="chars" type="String" />
+			<param index="0" name="chars" type="String" default="&quot;&quot;" />
 			<description>
-				Removes a set of characters defined in [param chars] from the string's end. See also [method lstrip].
+				Removes a set of characters defined in [param chars] from the string's end. See also [method lstrip], [method strip].
+				If [param chars] is empty, non-printable characters are stripped. These include spaces, tabulations ([code]\t[/code]), and newlines ([code]\n[/code] [code]\r[/code]).
 				[b]Note:[/b] [param chars] is not a suffix. Use [method trim_suffix] to remove a single suffix, rather than a set of characters.
 			</description>
 		</method>
@@ -950,7 +952,17 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="strip_edges" qualifiers="const">
+		<method name="strip" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="chars" type="String" default="&quot;&quot;" />
+			<description>
+				Removes the set of characters defined in [param chars] from the beginning and end of the string.
+				If [param chars] is empty, non-printable characters are stripped. These include spaces, tabulations ([code]\t[/code]), and newlines ([code]\n[/code] [code]\r[/code]).
+				[method lstrip] and [method rstrip] can be used to only strip the beginning or end of the string.
+				[b]Note:[/b] [param chars] is a set of characters, not a string to remove. Use [method trim_prefix] and [method trim_suffix] to remove strings, rather than a set of characters.
+			</description>
+		</method>
+		<method name="strip_edges" qualifiers="const" deprecated="Prefer using [method strip], [method lstrip] and [method rstrip] instead.">
 			<return type="String" />
 			<param index="0" name="left" type="bool" default="true" />
 			<param index="1" name="right" type="bool" default="true" />

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -588,9 +588,10 @@
 		</method>
 		<method name="lstrip" qualifiers="const">
 			<return type="String" />
-			<param index="0" name="chars" type="String" />
+			<param index="0" name="chars" type="String" default="&quot;&quot;" />
 			<description>
-				Removes a set of characters defined in [param chars] from the string's beginning. See also [method rstrip].
+				Removes a set of characters defined in [param chars] from the string's beginning. See also [method rstrip], [method strip].
+				If [param chars] is empty, non-printable characters are stripped. These include spaces, tabulations ([code]\t[/code]), and newlines ([code]\n[/code] [code]\r[/code]).
 				[b]Note:[/b] [param chars] is not a prefix. Use [method trim_prefix] to remove a single prefix, rather than a set of characters.
 			</description>
 		</method>
@@ -761,9 +762,10 @@
 		</method>
 		<method name="rstrip" qualifiers="const">
 			<return type="String" />
-			<param index="0" name="chars" type="String" />
+			<param index="0" name="chars" type="String" default="&quot;&quot;" />
 			<description>
-				Removes a set of characters defined in [param chars] from the string's end. See also [method lstrip].
+				Removes a set of characters defined in [param chars] from the string's end. See also [method lstrip], [method strip].
+				If [param chars] is empty, non-printable characters are stripped. These include spaces, tabulations ([code]\t[/code]), and newlines ([code]\n[/code] [code]\r[/code]).
 				[b]Note:[/b] [param chars] is not a suffix. Use [method trim_suffix] to remove a single suffix, rather than a set of characters.
 			</description>
 		</method>
@@ -858,7 +860,17 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="strip_edges" qualifiers="const">
+		<method name="strip" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="chars" type="String" default="&quot;&quot;" />
+			<description>
+				Removes the set of characters defined in [param chars] from the beginning and end of the string.
+				If [param chars] is empty, non-printable characters are stripped. These include spaces, tabulations ([code]\t[/code]), and newlines ([code]\n[/code] [code]\r[/code]).
+				[method lstrip] and [method rstrip] can be used to only strip the beginning or end of the string.
+				[b]Note:[/b] [param chars] is a set of characters, not a string to remove. Use [method trim_prefix] and [method trim_suffix] to remove strings, rather than a set of characters.
+			</description>
+		</method>
+		<method name="strip_edges" qualifiers="const" deprecated="Prefer using [method strip], [method lstrip] and [method rstrip] instead.">
 			<return type="String" />
 			<param index="0" name="left" type="bool" default="true" />
 			<param index="1" name="right" type="bool" default="true" />

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1490,8 +1490,12 @@ TEST_CASE("[String] lstrip and rstrip") {
 	bool state = true;
 
 	// strip none
-	STRIP_TEST(String("abc").lstrip("") == "abc");
-	STRIP_TEST(String("abc").rstrip("") == "abc");
+	STRIP_TEST(String("abc").lstrip() == "abc");
+	STRIP_TEST(String("abc").rstrip() == "abc");
+	// strip whitespace
+	STRIP_TEST(String("abc ").lstrip() == "abc ");
+	STRIP_TEST(String("abc").lstrip() == "abc");
+	STRIP_TEST(String(" abc ").rstrip() == " abc");
 	// strip one
 	STRIP_TEST(String("abc").lstrip("a") == "bc");
 	STRIP_TEST(String("abc").rstrip("c") == "ab");
@@ -1788,6 +1792,14 @@ TEST_CASE("[String] Similarity") {
 	String b = "West";
 	String c = "Toad";
 	CHECK(a.similarity(b) > a.similarity(c));
+}
+
+TEST_CASE("[String] Strip") {
+	String s = "\t Test Test   ";
+	CHECK(s.strip() == "Test Test");
+	CHECK(s.strip().strip("T") == "est Test");
+	CHECK(s.strip().strip("Tt") == "est Tes");
+	CHECK(String("Test").strip() == "Test");
 }
 
 TEST_CASE("[String] Strip edges") {


### PR DESCRIPTION
This adds a new `str.strip()` method, deprecating the old `str.strip_edges()`.
`str.strip()` adds the amazing technology of being able to set the characters to strip, instead of only stripping non-printable characters.

It also makes `lstrip()`/`rstrip()` more consistent with the above methods, making their `char` param optional and having them strip non-printable characters if it is omitted/empty, just like `strip_edges()`/`strip()`. This is a (very minor) compat breakage, as calling them with an empty string previously was a NOOP.

---

I often find myself having to `str.lstrip(char).rstrip(char)`. Unquoting is especially common. Would be amazing if I could just `strip(char)` instead.

Wait, `strip_edges()` exists! But while `lstrip()` and `rstrip()` take a character set, `strip_edges()` for some reason does not (probably due to the method being a decade old, with those two added only way later).

We can just add an optional `chars` param to `strip_edges()`! Sadly, that method already has two optional boolean params to strip only `left` and `right`. So... 
`str.lstrip(char).rstrip(char)` 
would become
`str.strip_edges(True, True, char)`

Not much of an improvement. Way less readable. In fact, `str.strip_edges(True)` does not seem particularly readable in the first place. Also, why is it `strip_edges()` instead of `strip()`, but not `strip_left_edge()` and `strip_right_edge()`?

The cleanest solution seems to be to deprecate the current `strip_edges()`, *especially* with its boolean params, and recommend users prefer `lstrip()`, `rstrip()` and a newly added `strip()` that is just `strip_edges()` without the boolean params, and with the added option to pass in a char set, just like for `lstrip()` and `rstrip()`.

This means making the `chars` param optional for `lstrip()`/`rstrip()` too, having them remove non-printable chars if called without. Makes everything feel more consistent too, IMO. This *does* introduce a very minor compat breakage however: previously, calling `lstrip()`/`rstrip()` with an empty string was a NOOP, now it strips whitespace. Thankfully, as it makes no sense to do that, it shouldn't affect many users, if any at all.

`str.strip(char)`. Nice. Also nicely matches Python.