### PR TITLE
Fix invisible ItemList cursor in editor theme

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1051,7 +1051,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 
 			Ref<StyleBoxFlat> style_itemlist_cursor = p_config.base_style->duplicate();
 			style_itemlist_cursor->set_draw_center(false);
-			style_itemlist_cursor->set_border_width_all(p_config.border_width);
+			style_itemlist_cursor->set_border_width_all(MAX(1 * EDSCALE, p_config.border_width));
 			style_itemlist_cursor->set_border_color(p_config.highlight_color);
 
 			Ref<StyleBoxFlat> style_itemlist_hover = style_tree_selected->duplicate();


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/11394

Navigation is working but cursor is not visible similar to this issue https://github.com/godotengine/godot/issues/46502


Pressing right arrow until ItemList loses focus
Before:

[Screencast_20250224_034819.webm](https://github.com/user-attachments/assets/be3a4d07-9218-497b-8f2c-4e2309fbd727)

After:

[Screencast_20250224_034847.webm](https://github.com/user-attachments/assets/791e6f7a-1141-4670-8178-c1f0260eb926)


