### PR TITLE
Add custom shader support to SpriteBase3D

### DIFF
--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -63,6 +63,11 @@
 		<member name="centered" type="bool" setter="set_centered" getter="is_centered" default="true">
 			If [code]true[/code], texture will be centered.
 		</member>
+		<member name="custom_material" type="ShaderMaterial" setter="set_custom_material" getter="get_custom_material">
+			An optional shader material that can be used to render the texture instead of the default material.
+			[b]Note:[/b] This material's shader must contain the uniforms [code]sampler2D texture_albedo[/code] and [code]vec2i texture_albedo_size[/code]. Modifying these shader parameters on the material directly may result in visual errors, but they will be corrected when the [SpriteBase3D] redraws.
+			[b]Note:[/b] This material should be unique, otherwise other [SpriteBase3D] nodes using the same material may fail to display their textures correctly. When assigned in the editor, the material will be made unique automatically, duplicating it if necessary.
+		</member>
 		<member name="double_sided" type="bool" setter="set_draw_flag" getter="get_draw_flag" default="true">
 			If [code]true[/code], texture can be seen from the back as well, if [code]false[/code], it is invisible when looking at it from behind.
 		</member>

--- a/editor/shader/editor_shader_language_plugin.h
+++ b/editor/shader/editor_shader_language_plugin.h
@@ -46,8 +46,15 @@ public:
 	static Ref<EditorShaderLanguagePlugin> get_shader_language_for_index(int p_index);
 	static String get_file_extension_for_index(int p_index);
 
+	enum {
+		DEFAULT_TEMPLATE,
+		DEFAULT_TEMPLATE_MAX,
+	};
+
 	virtual Ref<Shader> create_new_shader(int p_variation_index, Shader::Mode p_shader_mode, int p_template_index) = 0;
 	virtual Ref<ShaderInclude> create_new_shader_include() { return Ref<ShaderInclude>(); }
 	virtual PackedStringArray get_language_variations() const = 0;
 	virtual String get_file_extension(int p_variation_index) const { return "tres"; }
+	virtual int get_template_count(Shader::Mode p_shader_mode) const { return DEFAULT_TEMPLATE_MAX; }
+	virtual bool get_template_option(Shader::Mode p_shader_mode, int p_template_index, StringName &r_icon_name, String &r_label) const { return false; }
 };

--- a/editor/shader/shader_create_dialog.cpp
+++ b/editor/shader/shader_create_dialog.cpp
@@ -113,11 +113,13 @@ void ShaderCreateDialog::_path_hbox_sorted() {
 void ShaderCreateDialog::_mode_changed(int p_mode) {
 	current_mode = p_mode;
 	EditorSettings::get_singleton()->set_project_metadata("shader_setup", "last_selected_mode", p_mode);
+
+	_update_templates();
 }
 
 void ShaderCreateDialog::_template_changed(int p_template) {
 	current_template = p_template;
-	EditorSettings::get_singleton()->set_project_metadata("shader_setup", "last_selected_template", p_template);
+	EditorSettings::get_singleton()->set_project_metadata("shader_setup", vformat("last_selected_template_%d", current_mode), p_template);
 }
 
 void ShaderCreateDialog::ok_pressed() {
@@ -238,13 +240,10 @@ void ShaderCreateDialog::_type_changed(int p_language) {
 	template_menu->clear();
 
 	if (shader_type_data.use_templates) {
-		int last_template = EditorSettings::get_singleton()->get_project_metadata("shader_setup", "last_selected_template", 0);
-
 		template_menu->add_item(TTRC("Default"));
 		template_menu->add_item(TTRC("Empty"));
 
-		template_menu->select(last_template);
-		current_template = last_template;
+		_update_templates();
 	} else {
 		template_menu->add_item(TTRC("N/A"));
 	}
@@ -377,12 +376,19 @@ void ShaderCreateDialog::config(const String &p_base_path, bool p_built_in_enabl
 		internal->set_pressed(EditorSettings::get_singleton()->get_project_metadata("shader_setup", "create_built_in_shader", false));
 	}
 
+	// Mode change should happen before type change because the list of templates also depends on the shader mode.
 	if (p_preferred_mode > -1) {
 		mode_menu->select(p_preferred_mode);
 		_mode_changed(p_preferred_mode);
 	}
 
-	_type_changed(current_type);
+	if (preferred_type > -1) {
+		type_menu->select(preferred_type);
+		_type_changed(preferred_type);
+	} else {
+		_type_changed(current_type);
+	}
+
 	_path_changed(file_path->get_text());
 }
 
@@ -470,6 +476,36 @@ void ShaderCreateDialog::_update_dialog() {
 		set_ok_button_text(TTR("Create"));
 		validation_panel->set_message(MSG_ID_PATH, TTRC("Shader file already exists."), EditorValidationPanel::MSG_ERROR);
 	}
+}
+
+void ShaderCreateDialog::_update_templates() {
+	int last_template = EditorSettings::get_singleton()->get_project_metadata("shader_setup", vformat("last_selected_template_%d", current_mode), 0);
+
+	// Remove previous mode-specific templates.
+	for (int i = template_menu->get_item_count() - 1; i >= EditorShaderLanguagePlugin::DEFAULT_TEMPLATE_MAX; i--) {
+		template_menu->remove_item(i);
+	}
+
+	const int type_index = type_menu->get_selected();
+	Ref<EditorShaderLanguagePlugin> shader_lang = EditorShaderLanguagePlugin::get_shader_language_for_index(type_index);
+	if (!type_menu->get_item_text(type_index).contains("Include")) {
+		// Add new mode-specific templates.
+		int template_count = shader_lang->get_template_count(Shader::Mode(current_mode));
+		for (int template_index = EditorShaderLanguagePlugin::DEFAULT_TEMPLATE_MAX; template_index < template_count; template_index++) {
+			StringName icon_name;
+			String label;
+			bool success = shader_lang->get_template_option(Shader::Mode(current_mode), template_index, icon_name, label);
+			ERR_FAIL_COND_MSG(!success, vformat("ShaderCreateDialog: Could not load template option at index: %d", template_index));
+			template_menu->add_icon_item(get_editor_theme_icon(icon_name), label);
+		}
+	}
+
+	if (last_template >= template_menu->get_item_count()) {
+		last_template = 0;
+	}
+
+	template_menu->select(last_template);
+	_template_changed(last_template);
 }
 
 void ShaderCreateDialog::_bind_methods() {

--- a/editor/shader/shader_create_dialog.h
+++ b/editor/shader/shader_create_dialog.h
@@ -50,6 +50,10 @@ class ShaderCreateDialog : public ConfirmationDialog {
 		MSG_ID_BUILT_IN,
 	};
 
+	enum {
+		TEMPLATE_SPATIAL_SPRITE3D = 2,
+	};
+
 	struct ShaderTypeData {
 		List<String> extensions;
 		String default_extension;
@@ -99,6 +103,7 @@ class ShaderCreateDialog : public ConfirmationDialog {
 	void _create_new();
 	void _load_exist();
 	void _update_dialog();
+	void _update_templates();
 
 protected:
 	void _notification(int p_what);

--- a/editor/shader/shader_create_dialog.h
+++ b/editor/shader/shader_create_dialog.h
@@ -96,6 +96,7 @@ class ShaderCreateDialog : public ConfirmationDialog {
 	void _create_new();
 	void _load_exist();
 	void _update_dialog();
+	void _update_templates();
 
 protected:
 	void _notification(int p_what);

--- a/editor/shader/text_shader_language_plugin.cpp
+++ b/editor/shader/text_shader_language_plugin.cpp
@@ -32,6 +32,7 @@
 
 #include "core/string/string_builder.h"
 #include "editor/shader/shader_text_editor.h"
+#include "scene/gui/option_button.h"
 #include "servers/rendering/shader_types.h"
 
 Ref<Shader> TextShaderLanguagePlugin::create_new_shader(int p_variation_index, Shader::Mode p_shader_mode, int p_template_index) {
@@ -42,7 +43,7 @@ Ref<Shader> TextShaderLanguagePlugin::create_new_shader(int p_variation_index, S
 	const String &shader_type = ShaderTypes::get_singleton()->get_types_list().get(p_shader_mode);
 	code += vformat("shader_type %s;\n", shader_type);
 
-	if (p_template_index == 0) { // Default template.
+	if (p_template_index == DEFAULT_TEMPLATE) { // Default template.
 		switch (p_shader_mode) {
 			case Shader::MODE_SPATIAL: {
 				code += R"(
@@ -115,6 +116,44 @@ void blit() {
 				ERR_FAIL_V_MSG(Ref<Shader>(), "Invalid shader mode for text shader editor.");
 			} break;
 		}
+	} else {
+		switch (p_shader_mode) {
+			case Shader::MODE_SPATIAL: {
+				switch (p_template_index) {
+					case TEMPLATE_SPATIAL_SPRITE_3D: {
+						code += R"(render_mode unshaded;
+
+uniform sampler2D texture_albedo : source_color; // Required for Sprite3D.
+uniform ivec2 albedo_texture_size; // Required for Sprite3D.
+
+void vertex() {
+	// Called for every vertex the material is visible on.
+
+	// Convert vertex color to SRGB.
+	COLOR.rgb = mix(
+		pow((COLOR.rgb + vec3(0.055)) * (1.0 / (1.0 + 0.055)), vec3(2.4)),
+		COLOR.rgb * (1.0 / 12.92),
+		lessThan(COLOR.rgb, vec3(0.04045)));
+}
+
+void fragment() {
+	// Called for every pixel the material is visible on.
+	vec4 col = COLOR * texture(texture_albedo, UV);
+	ALBEDO = col.rgb;
+	ALPHA = col.a;
+}
+
+//void light() {
+//	// Called for every pixel for every light affecting the material.
+//	// Uncomment to replace the default light processing function with this one.
+//}
+)";
+					} break;
+				}
+			} break;
+			default: {
+			} break;
+		}
 	}
 	shader->set_code(code.as_string());
 	return shader;
@@ -133,4 +172,33 @@ String TextShaderLanguagePlugin::get_file_extension(int p_variation_index) const
 		return "gdshaderinc";
 	}
 	return "tres";
+}
+
+int TextShaderLanguagePlugin::get_template_count(Shader::Mode p_shader_mode) const {
+	switch (p_shader_mode) {
+		case Shader::MODE_SPATIAL: {
+			return TEMPLATE_SPATIAL_MAX;
+		} break;
+		default: {
+			return DEFAULT_TEMPLATE_MAX;
+		} break;
+	}
+}
+
+bool TextShaderLanguagePlugin::get_template_option(Shader::Mode p_shader_mode, int p_template_index, StringName &r_icon_name, String &r_label) const {
+	switch (p_shader_mode) {
+		case Shader::MODE_SPATIAL: {
+			switch (p_template_index) {
+				case TEMPLATE_SPATIAL_SPRITE_3D: {
+					r_icon_name = SNAME("Sprite3D");
+					r_label = TTR("Spatial: Sprite3D");
+					return true;
+				} break;
+			}
+		} break;
+		default: {
+			return false;
+		} break;
+	}
+	return false;
 }

--- a/editor/shader/text_shader_language_plugin.h
+++ b/editor/shader/text_shader_language_plugin.h
@@ -40,4 +40,12 @@ public:
 	virtual Ref<ShaderInclude> create_new_shader_include() override;
 	virtual PackedStringArray get_language_variations() const override { return { "Shader", "ShaderInclude" }; }
 	virtual String get_file_extension(int p_variation_index) const override;
+	virtual int get_template_count(Shader::Mode p_shader_mode) const override;
+	virtual bool get_template_option(Shader::Mode p_shader_mode, int p_template_index, StringName &r_icon_name, String &r_label) const override;
+
+private:
+	enum {
+		TEMPLATE_SPATIAL_SPRITE_3D = DEFAULT_TEMPLATE_MAX,
+		TEMPLATE_SPATIAL_MAX,
+	};
 };

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -30,6 +30,9 @@
 
 #include "sprite_3d.h"
 
+#if TOOLS_ENABLED
+#include "editor/editor_node.h"
+#endif
 #include "core/config/engine.h"
 #include "core/math/triangle_mesh.h"
 #include "core/object/callable_mp.h"
@@ -69,6 +72,12 @@ void SpriteBase3D::_propagate_color_changed() {
 	}
 }
 
+void SpriteBase3D::_custom_material_changed() {
+	_queue_redraw();
+	notify_property_list_changed();
+	update_configuration_warnings();
+}
+
 void SpriteBase3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
@@ -93,6 +102,14 @@ void SpriteBase3D::_notification(int p_what) {
 				_propagate_color_changed();
 			}
 		} break;
+	}
+}
+
+void SpriteBase3D::_validate_property(PropertyInfo &p_property) const {
+	if (custom_material.is_valid()) {
+		if (p_property.name == "billboard" || p_property.name == "transparent" || p_property.name == "shaded" || p_property.name == "double_sided" || p_property.name == "no_depth_test" || p_property.name == "fixed_size" || p_property.name == "alpha_cut" || p_property.name == "alpha_scissor_threshold" || p_property.name == "alpha_hash_scale" || p_property.name == "alpha_antialiasing_mode" || p_property.name == "alpha_antialiasing_edge" || p_property.name == "texture_filter" || p_property.name == "render_priority") {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		}
 	}
 }
 
@@ -254,6 +271,24 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 		memcpy(&attribute_write_buffer[i * attrib_stride + mesh_surface_offsets[RSE::ARRAY_COLOR]], v_color, 4);
 	}
 
+	RID mesh_new = get_mesh();
+	RS::get_singleton()->mesh_surface_update_vertex_region(mesh_new, 0, 0, vertex_buffer);
+	RS::get_singleton()->mesh_surface_update_attribute_region(mesh_new, 0, 0, attribute_buffer);
+
+	if (custom_material.is_valid()) {
+		// For custom materials, don't calculate billboard AABB.
+		set_aabb(aabb_new);
+
+		RS::get_singleton()->mesh_surface_set_material(mesh, 0, custom_material->get_rid());
+
+		if (custom_material->get_shader_parameter("texture_albedo") != p_texture->get_rid()) {
+			custom_material->set_shader_parameter("texture_albedo", p_texture);
+			custom_material->set_shader_parameter("albedo_texture_size", Vector2i(p_texture->get_width(), p_texture->get_height()));
+		}
+
+		return;
+	}
+
 	switch (get_billboard_mode()) {
 		case StandardMaterial3D::BILLBOARD_ENABLED: {
 			real_t size_new = MAX(Math::abs(final_rect.position.x) * px_size, (final_rect.position.x + final_rect.size.x) * px_size);
@@ -274,10 +309,6 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 		default:
 			break;
 	}
-
-	RID mesh_new = get_mesh();
-	RS::get_singleton()->mesh_surface_update_vertex_region(mesh_new, 0, 0, vertex_buffer);
-	RS::get_singleton()->mesh_surface_update_attribute_region(mesh_new, 0, 0, attribute_buffer);
 
 	RS::get_singleton()->mesh_set_custom_aabb(mesh_new, aabb_new);
 	set_aabb(aabb_new);
@@ -515,6 +546,42 @@ Ref<TriangleMesh> SpriteBase3D::generate_triangle_mesh() const {
 	return triangle_mesh;
 }
 
+PackedStringArray SpriteBase3D::get_configuration_warnings() const {
+	PackedStringArray warnings = GeometryInstance3D::get_configuration_warnings();
+	if (custom_material.is_valid()) {
+#if TOOLS_ENABLED
+		if (EditorNode::get_singleton()->get_resource_count(custom_material) > 1) {
+			warnings.push_back(RTR("The custom material is not unique. Texture may not display correctly if other sprites using the same material are active."));
+		}
+#endif
+
+		RID shader = custom_material->get_shader_rid();
+		if (shader.is_null()) {
+			warnings.push_back(RTR("The custom material's shader is invalid."));
+		} else {
+			List<PropertyInfo> parameters;
+			RS::get_singleton()->get_shader_parameter_list(shader, &parameters);
+			bool found_texture_albedo = false;
+			bool found_albedo_texture_size = false;
+			for (const PropertyInfo &parameter : parameters) {
+				if (!found_texture_albedo && parameter.name == "texture_albedo" && parameter.type == Variant::OBJECT && parameter.hint_string == "Texture2D") {
+					found_texture_albedo = true;
+				} else if (!found_albedo_texture_size && parameter.name == "albedo_texture_size" && parameter.type == Variant::VECTOR2I) {
+					found_albedo_texture_size = true;
+				}
+			}
+
+			if (!found_texture_albedo) {
+				warnings.push_back(RTR("Custom sprite shaders must contain uniform \"texture_albedo\" of type: sampler2D."));
+			}
+			if (!found_albedo_texture_size) {
+				warnings.push_back(RTR("Custom sprite shaders must contain uniform \"albedo_texture_size\" of type: ivec2."));
+			}
+		}
+	}
+	return warnings;
+}
+
 void SpriteBase3D::set_draw_flag(DrawFlags p_flag, bool p_enable) {
 	ERR_FAIL_INDEX(p_flag, FLAG_MAX);
 
@@ -626,6 +693,33 @@ StandardMaterial3D::TextureFilter SpriteBase3D::get_texture_filter() const {
 	return texture_filter;
 }
 
+void SpriteBase3D::set_custom_material(const Ref<ShaderMaterial> &p_material) {
+	if (custom_material != p_material) {
+		if (custom_material.is_valid()) {
+			custom_material->disconnect_changed(callable_mp(this, &SpriteBase3D::_custom_material_changed));
+			custom_material->disconnect(CoreStringName(property_list_changed), callable_mp((Node *)this, &Node::update_configuration_warnings));
+		}
+		custom_material = p_material;
+#if TOOLS_ENABLED
+		// Automatically make assigned materials unique in the editor.
+		if (EditorNode::get_singleton()->get_resource_count(custom_material) > 0) {
+			// UndoRedo still thinks the original has been assigned, so we have to remove the reference from EditorNode again with a deferred call.
+			callable_mp(EditorNode::get_singleton(), &EditorNode::update_node_reference).call_deferred(custom_material, this, true);
+			custom_material = custom_material->duplicate();
+		}
+#endif
+		if (custom_material.is_valid()) {
+			custom_material->connect_changed(callable_mp(this, &SpriteBase3D::_custom_material_changed));
+			custom_material->connect(CoreStringName(property_list_changed), callable_mp((Node *)this, &Node::update_configuration_warnings));
+		}
+		_custom_material_changed();
+	}
+}
+
+Ref<ShaderMaterial> SpriteBase3D::get_custom_material() const {
+	return custom_material;
+}
+
 void SpriteBase3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_centered", "centered"), &SpriteBase3D::set_centered);
 	ClassDB::bind_method(D_METHOD("is_centered"), &SpriteBase3D::is_centered);
@@ -675,6 +769,9 @@ void SpriteBase3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture_filter", "mode"), &SpriteBase3D::set_texture_filter);
 	ClassDB::bind_method(D_METHOD("get_texture_filter"), &SpriteBase3D::get_texture_filter);
 
+	ClassDB::bind_method(D_METHOD("set_custom_material", "material"), &SpriteBase3D::set_custom_material);
+	ClassDB::bind_method(D_METHOD("get_custom_material"), &SpriteBase3D::get_custom_material);
+
 	ClassDB::bind_method(D_METHOD("get_item_rect"), &SpriteBase3D::get_item_rect);
 	ClassDB::bind_method(D_METHOD("generate_triangle_mesh"), &SpriteBase3D::generate_triangle_mesh);
 
@@ -685,6 +782,7 @@ void SpriteBase3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "modulate"), "set_modulate", "get_modulate");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pixel_size", PROPERTY_HINT_RANGE, "0.0001,128,0.0000001,suffix:m"), "set_pixel_size", "get_pixel_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "axis", PROPERTY_HINT_ENUM, "X-Axis,Y-Axis,Z-Axis"), "set_axis", "get_axis");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "custom_material", PROPERTY_HINT_RESOURCE_TYPE, ShaderMaterial::get_class_static()), "set_custom_material", "get_custom_material");
 	ADD_GROUP("Flags", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "billboard", PROPERTY_HINT_ENUM, "Disabled,Enabled,Y-Billboard"), "set_billboard_mode", "get_billboard_mode");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "transparent"), "set_draw_flag", "get_draw_flag", FLAG_TRANSPARENT);

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -102,6 +102,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 	virtual void _draw() = 0;
+	void _validate_property(PropertyInfo &p_property) const;
 	void draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect, Rect2 p_src_rect);
 	_FORCE_INLINE_ void set_aabb(const AABB &p_aabb) { aabb = p_aabb; }
 	_FORCE_INLINE_ RID &get_mesh() { return mesh; }
@@ -172,6 +173,7 @@ public:
 	virtual AABB get_aabb() const override;
 
 	virtual Ref<TriangleMesh> generate_triangle_mesh() const override;
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 	SpriteBase3D();
 	~SpriteBase3D();

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -82,6 +82,8 @@ private:
 	RID mesh;
 	RID material;
 
+	Ref<ShaderMaterial> custom_material;
+
 	RID last_shader;
 	RID last_texture;
 
@@ -98,12 +100,14 @@ private:
 	void _im_update();
 
 	void _propagate_color_changed();
+	void _custom_material_changed();
 
 protected:
 	Color _get_color_accum();
 	void _notification(int p_what);
 	static void _bind_methods();
 	virtual void _draw() = 0;
+	void _validate_property(PropertyInfo &p_property) const;
 	void draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect, Rect2 p_src_rect);
 	_FORCE_INLINE_ void set_aabb(const AABB &p_aabb) { aabb = p_aabb; }
 	_FORCE_INLINE_ RID &get_mesh() { return mesh; }
@@ -169,11 +173,15 @@ public:
 	void set_texture_filter(StandardMaterial3D::TextureFilter p_filter);
 	StandardMaterial3D::TextureFilter get_texture_filter() const;
 
+	void set_custom_material(const Ref<ShaderMaterial> &p_material);
+	Ref<ShaderMaterial> get_custom_material() const;
+
 	virtual Rect2 get_item_rect() const = 0;
 
 	virtual AABB get_aabb() const override;
 
 	virtual Ref<TriangleMesh> generate_triangle_mesh() const override;
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 	SpriteBase3D();
 	~SpriteBase3D();

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -209,6 +209,7 @@ VisualInstance3D::~VisualInstance3D() {
 }
 
 void GeometryInstance3D::set_material_override(const Ref<Material> &p_material) {
+	bool changed = material_override != p_material;
 	if (material_override.is_valid()) {
 		material_override->disconnect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
 	}
@@ -217,6 +218,10 @@ void GeometryInstance3D::set_material_override(const Ref<Material> &p_material) 
 		material_override->connect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
 	}
 	RS::get_singleton()->instance_geometry_set_material_override(get_instance(), p_material.is_valid() ? p_material->get_rid() : RID());
+	if (changed) {
+		notify_property_list_changed();
+		update_configuration_warnings();
+	}
 }
 
 Ref<Material> GeometryInstance3D::get_material_override() const {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes https://github.com/godotengine/godot-proposals/issues/3266

See https://github.com/godotengine/godot/pull/103274#issuecomment-5279657807 for the latest revision of this PR.

<details><summary><h3>Original version of the PR can be found here<h2></summary>
<p>

https://github.com/user-attachments/assets/b1237b71-8053-4bac-bc51-b035df48f8d9

This PR lets custom shaders (via Material Override) access the sprite texture used by SpriteBase3D. (and its child classes Sprite3D and AnimatedSprite3D by extension)

Validation is implemented to warn the user if a Material Override without the necessary uniforms (namely `uniform sampler2D texture_albedo` and `uniform ivec2 albedo_texture_size`) is being used. The "Flags" group properties of SpriteBase3D are also hidden when a Material Override is being used, as those properties are used in the default automatic material generation. (`StandardMaterial3D::get_material_for_2d()`) The user can reimplement those features in the custom shader code anyway, so they have been hidden.

Side note: This pattern of requiring the shader to have uniforms of specific names and types can be turned into a reusable "shader interface/trait" system if needed. Users could make their own high-level 3D nodes that send data to shaders like SpriteBase3D does. (Maybe a more advanced version of Sprite3D that assigns normal maps and SDF texture maps as uniforms) The main benefit of such a system would be to reduce the amount of builtin shader types, though. (No need to add a new `sprite_3d` shader type) Though this probably would have to be a separate proposal.

---

This PR was originally made to add custom shader support for AnimatedSprite3D in particular, but it is evident that implementing the support for SpriteBase3D makes more sense here.

</p>
</details> 