### PR TITLE
Compress LightmapGIData, VoxelGIData and baked ArrayOccluder3D in the editor

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1258,7 +1258,7 @@ void EditorAudioBuses::_drop_at_index(int p_bus, int p_index) {
 
 void EditorAudioBuses::_server_save() {
 	Ref<AudioBusLayout> state = AudioServer::get_singleton()->generate_bus_layout();
-	ResourceSaver::save(state, edited_path);
+	ResourceSaver::save(state, edited_path, ResourceSaver::FLAG_COMPRESS);
 }
 
 void EditorAudioBuses::_select_layout() {
@@ -1301,7 +1301,7 @@ void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
 			AudioServer::get_singleton()->set_bus_layout(empty_state);
 		}
 
-		Error err = ResourceSaver::save(AudioServer::get_singleton()->generate_bus_layout(), p_string);
+		Error err = ResourceSaver::save(AudioServer::get_singleton()->generate_bus_layout(), p_string, ResourceSaver::FLAG_COMPRESS);
 		if (err != OK) {
 			EditorNode::get_singleton()->show_warning(vformat(TTR("Error saving file: %s"), p_string));
 			return;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2308,7 +2308,7 @@ void EditorNode::_dialog_action(String p_file) {
 
 			MeshLibraryEditor::update_library_file(editor_data.get_edited_scene_root(), ml, merge_with_existing_library, apply_mesh_instance_transforms);
 
-			Error err = ResourceSaver::save(ml, p_file);
+			Error err = ResourceSaver::save(ml, p_file, ResourceSaver::FLAG_COMPRESS);
 			if (err) {
 				show_accept(TTR("Error saving MeshLibrary!"), TTR("OK"));
 				return;

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -663,7 +663,7 @@ void Skeleton3DEditor::_file_selected(const String &p_file) {
 		}
 	}
 
-	Error err = ResourceSaver::save(sp, p_file);
+	Error err = ResourceSaver::save(sp, p_file, ResourceSaver::FLAG_COMPRESS);
 
 	if (err != OK) {
 		EditorNode::get_singleton()->show_warning(vformat(TTR("Error saving file: %s"), p_file));

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -173,7 +173,7 @@ void VoxelGIEditorPlugin::_voxel_gi_save_path_and_bake(const String &p_path) {
 		Ref<VoxelGIData> voxel_gi_data = voxel_gi->get_probe_data();
 		ERR_FAIL_COND(voxel_gi_data.is_null());
 		voxel_gi_data->set_path(p_path);
-		ResourceSaver::save(voxel_gi_data, p_path, ResourceSaver::FLAG_CHANGE_PATH);
+		ResourceSaver::save(voxel_gi_data, p_path, ResourceSaver::FLAG_CHANGE_PATH | ResourceSaver::FLAG_COMPRESS);
 	}
 }
 

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1468,7 +1468,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 	}
 
 	gi_data->set_path(p_image_data_path, true);
-	Error err = ResourceSaver::save(gi_data);
+	Error err = ResourceSaver::save(gi_data, "", ResourceSaver::FLAG_COMPRESS);
 
 	if (err != OK) {
 		return BAKE_ERROR_CANT_CREATE_IMAGE;

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -678,7 +678,7 @@ OccluderInstance3D::BakeError OccluderInstance3D::bake_scene(Node *p_from_node, 
 
 	occ->set_arrays(vertices, indices);
 
-	Error err = ResourceSaver::save(occ, p_occluder_path);
+	Error err = ResourceSaver::save(occ, p_occluder_path, ResourceSaver::FLAG_COMPRESS);
 
 	if (err != OK) {
 		return BAKE_ERROR_CANT_SAVE;


### PR DESCRIPTION
This results in smaller files that are present outside `.godot/`, and therefore committed to version control. Since these files are regularly updated in projects, this adds up to significant size savings when using Git (and therefore faster repository clones).

Additionally, other formats that may be saved as binary from the editor and committed to version control will now use compression. This does not affect files that use text-based formats.

Exported PCKs are also smaller if these resources are used in the project. (ZIPs are mostly unaffected because they're already compressed, but PCKs themselves are not compressed.)

Example on Truck Town:

- VoxelGIData: 9,159,442 -> **2,244,616 bytes** (-6.9 MB, 4.1x smaller)
- LightmapGIData: 588,031 -> **319,785 bytes** (-268 KB, 1.8x smaller)
- ArrayOccluder3D: 253,480 -> **109,887 bytes** (-144 KB, 2.3x smaller)

Example PCK size when exporting Truck Town with the above resources included:

- Before: 119,741,648 -> **112,414,960 bytes** (-7.3 MB, 1.06x smaller)

The compression is lossless.

- This closes https://github.com/godotengine/godot-proposals/issues/4979.

**Testing project:** [truck_town.zip](https://github.com/user-attachments/files/18967492/truck_town.zip)
