### PR TITLE
[Windows] Fix unreachable code in `DisplayServer`

### DIFF
--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -1344,9 +1344,8 @@ bool DisplayServer::is_rendering_device_supported() {
 		return true;
 	} else {
 		supported_rendering_device = RenderingDeviceCreationStatus::FAILURE;
-		return false;
 	}
-#endif
+#else // WINDOWS_ENABLED
 
 	RenderingContextDriver *rcd = nullptr;
 
@@ -1391,6 +1390,7 @@ bool DisplayServer::is_rendering_device_supported() {
 		rcd = nullptr;
 	}
 
+#endif // WINDOWS_ENABLED
 #endif // RD_ENABLED
 	return false;
 }
@@ -1427,9 +1427,8 @@ bool DisplayServer::can_create_rendering_device() {
 		return true;
 	} else {
 		created_rendering_device = RenderingDeviceCreationStatus::FAILURE;
-		return false;
 	}
-#endif
+#else // WINDOWS_ENABLED
 
 	RenderingContextDriver *rcd = nullptr;
 
@@ -1474,6 +1473,7 @@ bool DisplayServer::can_create_rendering_device() {
 		rcd = nullptr;
 	}
 
+#endif // WINDOWS_ENABLED
 #endif // RD_ENABLED
 	return false;
 }


### PR DESCRIPTION
Regression from:
* https://github.com/godotengine/godot/pull/103245

Unsure why these weren't caught by CI, will see if I can check some settings to try and catch these
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
