### PR TITLE
Compress all binary resources on import when the editor setting is enabled

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -881,7 +881,7 @@ String EditorExportPlatform::_export_customize(const String &p_path, LocalVector
 			Ref<PackedScene> s;
 			s.instantiate();
 			s->pack(node);
-			Error err = ResourceSaver::save(s, save_path);
+			Error err = ResourceSaver::save(s, save_path, ResourceSaver::FLAG_COMPRESS);
 			ERR_FAIL_COND_V_MSG(err != OK, p_path, "Unable to save export scene file to: " + save_path);
 		}
 
@@ -913,7 +913,7 @@ String EditorExportPlatform::_export_customize(const String &p_path, LocalVector
 			String base_file = p_path.get_file().get_basename() + ".res"; // use RES for saving (binary)
 			save_path = export_base_path.path_join("export-" + p_path.md5_text() + "-" + base_file);
 
-			Error err = ResourceSaver::save(res, save_path);
+			Error err = ResourceSaver::save(res, save_path, ResourceSaver::FLAG_COMPRESS);
 			ERR_FAIL_COND_V_MSG(err != OK, p_path, "Unable to save export resource file to: " + save_path);
 		}
 	}

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/file_access.h"
 #include "core/io/resource_saver.h"
+#include "editor/editor_settings.h"
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/3d/node_3d.h"
 #include "scene/resources/3d/importer_mesh.h"
@@ -649,7 +650,9 @@ Error ResourceImporterOBJ::import(ResourceUID::ID p_source_id, const String &p_s
 
 	Error err;
 	{
-		src_lightmap_cache = FileAccess::get_file_as_bytes(p_source_file + ".unwrap_cache", &err);
+		const uint8_t *unwrap_cache_file = FileAccess::get_file_as_bytes(p_source_file + ".unwrap_cache", &err).ptr();
+		Compression::decompress(src_lightmap_cache.ptrw(), Compression::get_max_compressed_buffer_size(src_lightmap_cache.size()), unwrap_cache_file, sizeof(unwrap_cache_file));
+
 		if (err != OK) {
 			src_lightmap_cache.clear();
 		}
@@ -658,7 +661,7 @@ Error ResourceImporterOBJ::import(ResourceUID::ID p_source_id, const String &p_s
 	err = _parse_obj(p_source_file, meshes, true, p_options["generate_tangents"], p_options["generate_lods"], p_options["generate_shadow_mesh"], p_options["generate_lightmap_uv2"], p_options["generate_lightmap_uv2_texel_size"], src_lightmap_cache, p_options["scale_mesh"], p_options["offset_mesh"], p_options["force_disable_mesh_compression"], mesh_lightmap_caches, nullptr);
 
 	if (mesh_lightmap_caches.size()) {
-		Ref<FileAccess> f = FileAccess::open(p_source_file + ".unwrap_cache", FileAccess::WRITE);
+		Ref<FileAccess> f = FileAccess::open_compressed(p_source_file + ".unwrap_cache", FileAccess::WRITE, FileAccess::COMPRESSION_ZSTD);
 		if (f.is_valid()) {
 			f->store_32(mesh_lightmap_caches.size());
 			for (int i = 0; i < mesh_lightmap_caches.size(); i++) {
@@ -674,7 +677,11 @@ Error ResourceImporterOBJ::import(ResourceUID::ID p_source_id, const String &p_s
 
 	String save_path = p_save_path + ".mesh";
 
-	err = ResourceSaver::save(meshes.front()->get()->get_mesh(), save_path);
+	int flags = 0;
+	if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+		flags |= ResourceSaver::FLAG_COMPRESS;
+	}
+	err = ResourceSaver::save(meshes.front()->get()->get_mesh(), save_path, flags);
 
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save Mesh to file '" + save_path + "'.");
 

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1812,7 +1812,11 @@ Ref<Animation> ResourceImporterScene::_save_animation_to_file(Ref<Animation> ani
 		}
 	}
 	anim->set_path(p_save_to_path, true); // Set path to save externally.
-	Error err = ResourceSaver::save(anim, p_save_to_path, ResourceSaver::FLAG_CHANGE_PATH);
+	int flags = ResourceSaver::FLAG_CHANGE_PATH;
+	if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+		flags |= ResourceSaver::FLAG_COMPRESS;
+	}
+	Error err = ResourceSaver::save(anim, p_save_to_path, flags);
 	ERR_FAIL_COND_V_MSG(err != OK, anim, "Saving of animation failed: " + p_save_to_path);
 	return anim;
 }
@@ -2591,7 +2595,11 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 					}
 					mesh = src_mesh_node->get_mesh()->get_mesh(existing);
 
-					ResourceSaver::save(mesh, save_to_file); //override
+					int flags = 0;
+					if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+						flags |= ResourceSaver::FLAG_COMPRESS;
+					}
+					ResourceSaver::save(mesh, save_to_file, flags); //override
 
 					mesh->set_path(save_to_file, true); //takeover existing, if needed
 
@@ -3076,7 +3084,8 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 	Vector<Vector<uint8_t>> mesh_lightmap_caches;
 
 	{
-		src_lightmap_cache = FileAccess::get_file_as_bytes(p_source_file + ".unwrap_cache", &err);
+		const uint8_t *unwrap_cache_file = FileAccess::get_file_as_bytes(p_source_file + ".unwrap_cache", &err).ptr();
+		Compression::decompress(src_lightmap_cache.ptrw(), Compression::get_max_compressed_buffer_size(src_lightmap_cache.size()), unwrap_cache_file, sizeof(unwrap_cache_file));
 		if (err != OK) {
 			src_lightmap_cache.clear();
 		}
@@ -3085,7 +3094,7 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 	scene = _generate_meshes(scene, mesh_data, gen_lods, create_shadow_meshes, LightBakeMode(light_bake_mode), lightmap_texel_size, src_lightmap_cache, mesh_lightmap_caches);
 
 	if (mesh_lightmap_caches.size()) {
-		Ref<FileAccess> f = FileAccess::open(p_source_file + ".unwrap_cache", FileAccess::WRITE);
+		Ref<FileAccess> f = FileAccess::open_compressed(p_source_file + ".unwrap_cache", FileAccess::WRITE, FileAccess::COMPRESSION_ZSTD);
 		if (f.is_valid()) {
 			f->store_32(mesh_lightmap_caches.size());
 			for (int i = 0; i < mesh_lightmap_caches.size(); i++) {
@@ -3151,7 +3160,7 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 	progress.step(TTR("Saving..."), 104);
 
 	int flags = 0;
-	if (EditorSettings::get_singleton() && EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+	if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
 		flags |= ResourceSaver::FLAG_COMPRESS;
 	}
 

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1596,7 +1596,7 @@ void SceneImportSettingsDialog::_save_dir_confirm() {
 				ERR_CONTINUE(!material_map.has(id));
 				MaterialData &md = material_map[id];
 
-				Error err = ResourceSaver::save(md.material, path);
+				Error err = ResourceSaver::save(md.material, path, ResourceSaver::FLAG_COMPRESS);
 				if (err != OK) {
 					EditorNode::get_singleton()->add_io_error(TTR("Can't make material external to file, write error:") + "\n\t" + path);
 					continue;

--- a/editor/import/resource_importer_bitmask.cpp
+++ b/editor/import/resource_importer_bitmask.cpp
@@ -33,6 +33,7 @@
 #include "core/io/image.h"
 #include "core/io/image_loader.h"
 #include "core/io/resource_saver.h"
+#include "editor/editor_settings.h"
 #include "scene/resources/bit_map.h"
 
 String ResourceImporterBitMap::get_importer_name() const {
@@ -103,7 +104,11 @@ Error ResourceImporterBitMap::import(ResourceUID::ID p_source_id, const String &
 		}
 	}
 
-	return ResourceSaver::save(bitmap, p_save_path + ".res");
+	int flags = 0;
+	if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+		flags |= ResourceSaver::FLAG_COMPRESS;
+	}
+	return ResourceSaver::save(bitmap, p_save_path + ".res", flags);
 }
 
 ResourceImporterBitMap::ResourceImporterBitMap() {

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -34,6 +34,7 @@
 #include "core/io/resource_saver.h"
 #include "core/string/optimized_translation.h"
 #include "core/string/translation_server.h"
+#include "editor/editor_settings.h"
 
 String ResourceImporterCSVTranslation::get_importer_name() const {
 	return "csv_translation";
@@ -150,7 +151,11 @@ Error ResourceImporterCSVTranslation::import(ResourceUID::ID p_source_id, const 
 			save_path = ResourceUID::get_singleton()->get_id_path(save_id);
 		}
 
-		ResourceSaver::save(xlt, save_path);
+		int flags = 0;
+		if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+			flags |= ResourceSaver::FLAG_COMPRESS;
+		}
+		ResourceSaver::save(xlt, save_path, flags);
 		if (r_gen_files) {
 			r_gen_files->push_back(save_path);
 		}

--- a/editor/import/resource_importer_shader_file.cpp
+++ b/editor/import/resource_importer_shader_file.cpp
@@ -33,6 +33,7 @@
 #include "core/io/file_access.h"
 #include "core/io/resource_saver.h"
 #include "editor/editor_node.h"
+#include "editor/editor_settings.h"
 #include "editor/plugins/shader_file_editor_plugin.h"
 #include "servers/rendering/rendering_device_binds.h"
 
@@ -110,7 +111,11 @@ Error ResourceImporterShaderFile::import(ResourceUID::ID p_source_id, const Stri
 		}
 	}
 
-	ResourceSaver::save(shader_file, p_save_path + ".res");
+	int flags = 0;
+	if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+		flags |= ResourceSaver::FLAG_COMPRESS;
+	}
+	ResourceSaver::save(shader_file, p_save_path + ".res", flags);
 
 	return OK;
 }

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -36,6 +36,7 @@
 #include "core/io/resource_saver.h"
 #include "core/math/geometry_2d.h"
 #include "editor/editor_atlas_packer.h"
+#include "editor/editor_settings.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/bit_map.h"
 #include "scene/resources/image_texture.h"
@@ -97,7 +98,11 @@ Error ResourceImporterTextureAtlas::import(ResourceUID::ID p_source_id, const St
 	//use an xpm because it's size independent, the editor images are vector and size dependent
 	//it's a simple hack
 	Ref<Image> broken = memnew(Image((const char **)atlas_import_failed_xpm));
-	ResourceSaver::save(ImageTexture::create_from_image(broken), p_save_path + ".tex");
+	int flags = 0;
+	if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+		flags |= ResourceSaver::FLAG_COMPRESS;
+	}
+	ResourceSaver::save(ImageTexture::create_from_image(broken), p_save_path + ".tex", flags);
 
 	return OK;
 }
@@ -398,7 +403,11 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 		}
 
 		String save_path = p_base_paths[E.key] + ".res";
-		ResourceSaver::save(texture, save_path);
+		int flags = 0;
+		if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+			flags |= ResourceSaver::FLAG_COMPRESS;
+		}
+		ResourceSaver::save(texture, save_path, flags);
 		idx++;
 	}
 

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -31,6 +31,7 @@
 #include "resource_importer_wav.h"
 
 #include "core/io/resource_saver.h"
+#include "editor/editor_settings.h"
 
 String ResourceImporterWAV::get_importer_name() const {
 	return "wav";
@@ -95,7 +96,11 @@ Error ResourceImporterWAV::import(ResourceUID::ID p_source_id, const String &p_s
 	}
 
 	Ref<AudioStreamWAV> sample = AudioStreamWAV::load_from_file(p_source_file, options);
-	ResourceSaver::save(sample, p_save_path + ".sample");
+	int flags = 0;
+	if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+		flags |= ResourceSaver::FLAG_COMPRESS;
+	}
+	ResourceSaver::save(sample, p_save_path + ".sample", flags);
 	return OK;
 }
 

--- a/modules/minimp3/resource_importer_mp3.cpp
+++ b/modules/minimp3/resource_importer_mp3.cpp
@@ -34,6 +34,7 @@
 #include "core/io/resource_saver.h"
 
 #ifdef TOOLS_ENABLED
+#include "editor/editor_settings.h"
 #include "editor/import/audio_stream_import_settings.h"
 #endif
 
@@ -112,7 +113,13 @@ Error ResourceImporterMP3::import(ResourceUID::ID p_source_id, const String &p_s
 	mp3_stream->set_beat_count(beat_count);
 	mp3_stream->set_bar_beats(bar_beats);
 
-	return ResourceSaver::save(mp3_stream, p_save_path + ".mp3str");
+	int flags = ResourceSaver::FLAG_COMPRESS;
+#ifdef TOOLS_ENABLED
+	if (!EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+		flags &= ~ResourceSaver::FLAG_COMPRESS;
+	}
+#endif
+	return ResourceSaver::save(mp3_stream, p_save_path + ".mp3str", flags);
 }
 
 ResourceImporterMP3::ResourceImporterMP3() {

--- a/modules/vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/vorbis/resource_importer_ogg_vorbis.cpp
@@ -34,6 +34,7 @@
 #include "core/io/resource_saver.h"
 
 #ifdef TOOLS_ENABLED
+#include "editor/editor_settings.h"
 #include "editor/import/audio_stream_import_settings.h"
 #endif
 
@@ -111,7 +112,13 @@ Error ResourceImporterOggVorbis::import(ResourceUID::ID p_source_id, const Strin
 	ogg_vorbis_stream->set_beat_count(beat_count);
 	ogg_vorbis_stream->set_bar_beats(bar_beats);
 
-	return ResourceSaver::save(ogg_vorbis_stream, p_save_path + ".oggvorbisstr");
+	int flags = ResourceSaver::FLAG_COMPRESS;
+#ifdef TOOLS_ENABLED
+	if (!EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+		flags &= ~ResourceSaver::FLAG_COMPRESS;
+	}
+#endif
+	return ResourceSaver::save(ogg_vorbis_stream, p_save_path + ".oggvorbisstr", flags);
 }
 
 #ifndef DISABLE_DEPRECATED


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/103284
(can be merged independently).

The **Compress Binary Resources** editor setting (which is enabled by default) was previously used in a few resource types, but it was missing in a lot of places, which reduced its potential.

This adds it to all resource types that are imported as binary. This reduces the `.godot/` folder and exported PCK size. (ZIPs are mostly unaffected because they're already compressed, but PCKs themselves are not compressed.)

The lightmap UV unwrap cache generated on import is now also compressed. On Truck Town, this reduces its file size from 661 KB down to 330 KB.

Remember to remove `.godot/` in your project then reopen the editor to fully benefit from these changes.

Platformer 3D PCK size: 2,789,744 -> **2,529,024 bytes** (-261 KB, 1.1x smaller)

- This closes https://github.com/godotengine/godot-proposals/issues/11847.