### PR TITLE
Improve generic constraints

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
@@ -38,13 +38,13 @@ namespace Godot
         /// <exception cref="InvalidCastException">
         /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+        /// <typeparam name="T">The <see cref="Node"/> type to cast to.</typeparam>
         /// <returns>
         /// The <see cref="Node"/> at the given <paramref name="path"/>.
         /// </returns>
-        public T GetNode<T>(NodePath path) where T : class
+        public T GetNode<T>(NodePath path) where T : Node
         {
-            return (T)(object)GetNode(path);
+            return (T)GetNode(path);
         }
 
         /// <summary>
@@ -73,11 +73,11 @@ namespace Godot
         /// </example>
         /// <seealso cref="GetNode{T}(NodePath)"/>
         /// <param name="path">The path to the node to fetch.</param>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+        /// <typeparam name="T">The <see cref="Node"/> type to cast to.</typeparam>
         /// <returns>
         /// The <see cref="Node"/> at the given <paramref name="path"/>, or <see langword="null"/> if not found.
         /// </returns>
-        public T GetNodeOrNull<T>(NodePath path) where T : class
+        public T GetNodeOrNull<T>(NodePath path) where T : Node
         {
             return GetNodeOrNull(path) as T;
         }
@@ -97,13 +97,13 @@ namespace Godot
         /// <exception cref="InvalidCastException">
         /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+        /// <typeparam name="T">The <see cref="Node"/> type to cast to.</typeparam>
         /// <returns>
         /// The child <see cref="Node"/> at the given index <paramref name="idx"/>.
         /// </returns>
-        public T GetChild<T>(int idx, bool includeInternal = false) where T : class
+        public T GetChild<T>(int idx, bool includeInternal = false) where T : Node
         {
-            return (T)(object)GetChild(idx, includeInternal);
+            return (T)GetChild(idx, includeInternal);
         }
 
         /// <summary>
@@ -118,11 +118,11 @@ namespace Godot
         /// If <see langword="false"/>, internal children are skipped (see <c>internal</c>
         /// parameter in <see cref="AddChild(Node, bool, InternalMode)"/>).
         /// </param>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+        /// <typeparam name="T">The <see cref="Node"/> type to cast to.</typeparam>
         /// <returns>
         /// The child <see cref="Node"/> at the given index <paramref name="idx"/>, or <see langword="null"/> if not found.
         /// </returns>
-        public T GetChildOrNull<T>(int idx, bool includeInternal = false) where T : class
+        public T GetChildOrNull<T>(int idx, bool includeInternal = false) where T : Node
         {
             int count = GetChildCount(includeInternal);
             return idx >= -count && idx < count ? GetChild(idx, includeInternal) as T : null;
@@ -139,13 +139,13 @@ namespace Godot
         /// <exception cref="InvalidCastException">
         /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+        /// <typeparam name="T">The <see cref="Node"/> type to cast to.</typeparam>
         /// <returns>
         /// The owner <see cref="Node"/>.
         /// </returns>
-        public T GetOwner<T>() where T : class
+        public T GetOwner<T>() where T : Node
         {
-            return (T)(object)Owner;
+            return (T)Owner;
         }
 
         /// <summary>
@@ -173,13 +173,13 @@ namespace Godot
         /// <exception cref="InvalidCastException">
         /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+        /// <typeparam name="T">The <see cref="Node"/> type to cast to.</typeparam>
         /// <returns>
         /// The parent <see cref="Node"/>.
         /// </returns>
-        public T GetParent<T>() where T : class
+        public T GetParent<T>() where T : Node
         {
-            return (T)(object)GetParent();
+            return (T)GetParent();
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/PackedSceneExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/PackedSceneExtensions.cs
@@ -10,14 +10,12 @@ namespace Godot
         /// <see cref="Node.NotificationSceneInstantiated"/> notification on the root node.
         /// </summary>
         /// <seealso cref="InstantiateOrNull{T}(GenEditState)"/>
-        /// <exception cref="InvalidCastException">
-        /// The instantiated node can't be casted to the given type <typeparamref name="T"/>.
-        /// </exception>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+        /// <exception cref="InvalidCastException">The instantiated node can't be casted to the given type <typeparamref name="T"/>.</exception>
+        /// <typeparam name="T">The <see cref="Node"/> type to cast to.</typeparam>
         /// <returns>The instantiated scene.</returns>
-        public T Instantiate<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
+        public T Instantiate<T>(GenEditState editState = default) where T : Node
         {
-            return (T)(object)Instantiate(editState);
+            return (T)Instantiate(editState);
         }
 
         /// <summary>
@@ -26,9 +24,9 @@ namespace Godot
         /// <see cref="Node.NotificationSceneInstantiated"/> notification on the root node.
         /// </summary>
         /// <seealso cref="Instantiate{T}(GenEditState)"/>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+        /// <typeparam name="T">The <see cref="Node"/> type to cast to.</typeparam>
         /// <returns>The instantiated scene.</returns>
-        public T InstantiateOrNull<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
+        public T InstantiateOrNull<T>(GenEditState editState = default) where T : Node
         {
             return Instantiate(editState) as T;
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ResourceLoaderExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ResourceLoaderExtensions.cs
@@ -21,10 +21,10 @@ namespace Godot
         /// <exception cref="InvalidCastException">
         /// The loaded resource can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Resource"/>.</typeparam>
-        public static T Load<T>(string path, string typeHint = null, CacheMode cacheMode = CacheMode.Reuse) where T : class
+        /// <typeparam name="T">The <see cref="Resource"/> type to cast to..</typeparam>
+        public static T Load<T>(string path, string typeHint = null, CacheMode cacheMode = CacheMode.Reuse) where T : Resource
         {
-            return (T)(object)Load(path, typeHint, cacheMode);
+            return (T)Load(path, typeHint, cacheMode);
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -123,8 +123,8 @@ namespace Godot
         /// </code>
         /// </example>
         /// <param name="path">Path of the <see cref="Resource"/> to load.</param>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Resource"/>.</typeparam>
-        public static T Load<T>(string path) where T : class
+        /// <typeparam name="T">The <see cref="Resource"/> type to cast to.</typeparam>
+        public static T Load<T>(string path) where T : Resource
         {
             return ResourceLoader.Load<T>(path);
         }


### PR DESCRIPTION
Improves the generic constraints for methods like `GD.Load<T>`, `GetNode<T>`, `Instantiate<T>` so that `T` must be `Resource` or `Node` rather than just `class`.

This has a nice benefit of not needing to cast to `object`.

This is a breaking change if people are passing generic types of `class` to these methods.