### PR TITLE
`texture_create_from_native_handle()` should return `RID` for texture from `RenderingServer`, not `RenderingDevice`

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3725,7 +3725,7 @@
 			<param index="7" name="layered_type" type="int" enum="RenderingServer.TextureLayeredType" default="0" />
 			<description>
 				Creates a texture based on a native handle that was created outside of Godot's renderer.
-				[b]Note:[/b] If using the rendering device renderer, using [method RenderingDevice.texture_create_from_extension] rather than this method is recommended. It will give you much more control over the texture's format and usage.
+				[b]Note:[/b] If using only the rendering device renderer, it's recommend to use [method RenderingDevice.texture_create_from_extension] together with [method RenderingServer.texture_rd_create], rather than this method. It will give you much more control over the texture's format and usage.
 			</description>
 		</method>
 		<method name="texture_get_format" qualifiers="const">

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1292,7 +1292,12 @@ RID TextureStorage::texture_create_from_native_handle(RS::TextureType p_type, Im
 	// Assumed to be a color attachment - see note above.
 	uint64_t usage_flags = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
 
-	return RD::get_singleton()->texture_create_from_extension(type, format, RD::TEXTURE_SAMPLES_1, usage_flags, p_native_handle, p_width, p_height, p_depth, p_layers);
+	RID rd_texture = RD::get_singleton()->texture_create_from_extension(type, format, RD::TEXTURE_SAMPLES_1, usage_flags, p_native_handle, p_width, p_height, p_depth, p_layers);
+
+	RID texture = texture_allocate();
+	texture_rd_initialize(texture, rd_texture, p_layered_type);
+
+	return texture;
 }
 
 void TextureStorage::_texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer, bool p_immediate) {


### PR DESCRIPTION
Right now, when using a rendering device renderer, `RenderingServer.texture_create_from_native_handle()` is returning an RID for an "RD texture" (aka a texture from `RenderingDevice`) rather than a texture from `RenderingServer`, like it's supposed to.

**This was my mistake!**

This function was introduced by my PR https://github.com/godotengine/godot/pull/96928, and I missed a step. Sorry about that!

This PR fixes the issue by wrapping the "RD texture" in a normal texture from `RenderingServer`.

I also attempted to clarify the note in the docs which explains that if you're targeting only the rendering device renderer, then you can get more control by using `RenderingDevice.texture_create_from_extension()` and `RenderServer.texture_rd_create()`.