### PR TITLE
Fix multiple scene debugger messages arriving before scene tree exists

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -623,7 +623,8 @@ void RemoteDebugger::poll_events(bool p_is_idle) {
 		}
 
 		const String msg = cmd.substr(idx + 1);
-		capture_parse(cap, msg, arr[1], parsed);
+		Error err = capture_parse(cap, msg, arr[1], parsed);
+		ERR_CONTINUE_MSG(err != OK, vformat("Command '%s' returned error : '%d'.", cmd, err));
 	}
 
 	// Reload scripts during idle poll only.

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -414,8 +414,6 @@ void EditorDebuggerNode::_notification(int p_what) {
 					const Breakpoint &bp = E.key;
 					debugger->set_breakpoint(bp.source, bp.line, E.value);
 				} // Will arrive too late, how does the regular run work?
-
-				debugger->update_live_edit_root();
 			}
 		} break;
 	}

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -431,6 +431,11 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread
 			EditorDebuggerRemoteObjects *objs = inspector->set_objects(p_data);
 			emit_signal(SNAME("remote_objects_updated"), objs);
 		}
+	} else if (p_msg == "scene:scene_tree_loaded") {
+		Array quit_keys = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/stop_running_project"));
+		_put_msg("scene:setup_scene", quit_keys);
+
+		update_live_edit_root();
 	} else if (p_msg == "servers:memory_usage") {
 		vmem_tree->clear();
 		TreeItem *root = vmem_tree->create_item();
@@ -1073,9 +1078,6 @@ void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {
 	_set_reason_text(TTR("Debug session started."), MESSAGE_SUCCESS);
 	_update_buttons_state();
 	emit_signal(SNAME("started"));
-
-	Array quit_keys = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/stop_running_project"));
-	_put_msg("scene:setup_scene", quit_keys);
 
 	if (EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_profiler", false)) {
 		profiler->set_profiling(true);

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -77,6 +77,8 @@ public:
 	void reset_camera_2d_position();
 	void reset_camera_3d_position();
 
+	virtual bool has_capture(const String &p_capture) const override;
+	virtual bool capture(const String &p_message, const Array &p_data, int p_index) override;
 	virtual void setup_session(int p_session_id) override;
 
 	GameViewDebugger() {}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4350,6 +4350,10 @@ int Main::start() {
 			Engine::get_singleton()->set_recovery_mode_hint(true);
 		}
 #endif
+
+		if (EngineDebugger::is_active()) {
+			EngineDebugger::get_singleton()->send_message("scene:scene_tree_loaded", Array());
+		}
 	}
 
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_ICON) && !has_icon && OS::get_singleton()->get_bundle_icon_path().is_empty()) {


### PR DESCRIPTION
Fixes #102560

At the start of the engine, when loading a script that extends `SceneTree` and also has a static initializer, produces a call to `RemoteDebugger::poll_events`. This receives network messages from the debugger. 
Some of these messages need the `SceneTree`, of which construction is not done yet, since the script is not loaded.
So the messages are ignored, thus not connecting to the window_input event in the case of #102560, and not handling mouse events when an input happens. Fun bug :)

The messages that arrived before `SceneTree` was created, but also need it are "scene:runtime_node_[...]", "scene:setup_scene" and "scene:live_set_root". 
Also added an error log for when a message returns an error. Though I'm not sure if i've used the correct macro for the debugee side.