### PR TITLE
Fix vbox separation in sections with `PROPERTY_USAGE_ARRAY` (reverted)

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3440,6 +3440,8 @@ void EditorInspector::update_tree() {
 		// Recreate the category vbox if it was reset.
 		if (category_vbox == nullptr) {
 			category_vbox = memnew(VBoxContainer);
+			int separation = get_theme_constant(SNAME("v_separation"), SNAME("EditorInspector"));
+			category_vbox->add_theme_constant_override(SNAME("separation"), separation);
 			category_vbox->hide();
 			main_vbox->add_child(category_vbox);
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
fixes #101838 
![image](https://github.com/user-attachments/assets/71f30a65-7f26-4abf-9224-ebd56fa175f0)

It was a problem where any section with PROPERTY_USAGE_ARRAY was added to a VBoxContainer, whose `separation` value wasn't updated like the other vboxes