### PR TITLE
Reuse Sprite3D meshes across nodes when possible.

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -33,6 +33,9 @@
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/mesh.h"
 
+static bool sprite_sharing_enabled = false;
+static HashMap<SpriteMeshKey, SpriteBase3D *, SpriteMeshKey> shared_sprites;
+
 Color SpriteBase3D::_get_color_accum() {
 	if (!color_dirty) {
 		return color_accum;
@@ -63,6 +66,64 @@ void SpriteBase3D::_propagate_color_changed() {
 	for (SpriteBase3D *&E : children) {
 		E->_propagate_color_changed();
 	}
+}
+
+void SpriteBase3D::_start_sharing_sprite() {
+	shared_sprites.insert(last_sprite_mesh_key, this);
+	sharing_own_mesh = true;
+}
+
+void SpriteBase3D::_stop_sharing_sprite() {
+	shared_sprites.erase(last_sprite_mesh_key);
+	sharing_own_mesh = false;
+	if (!users.is_empty()) {
+		// Select a successor and make every other user use that successor's mesh instead.
+		SpriteBase3D *successor = nullptr;
+		int i = 0;
+		for (; i < users.size(); i++) {
+			// There may be sprites that have changed the sprite they're using earlier this frame, so we have to filter them out.
+			if (users[i] && users[i]->using_sprite == this) {
+				successor = users[i];
+				successor->_start_sharing_sprite();
+				// Copy mesh data to successor. Need to store data in vertex and attribute buffer and not just update the RenderingServer mesh directly so they can be copied again later.
+				// memcpy is used directly because buffer sizes are guaranteed to be identical across all SpriteBase3Ds.
+				memcpy(successor->vertex_buffer.ptrw(), vertex_buffer.ptr(), vertex_buffer.size());
+				memcpy(successor->attribute_buffer.ptrw(), attribute_buffer.ptr(), attribute_buffer.size());
+				RS::get_singleton()->mesh_surface_update_vertex_region(successor->mesh, 0, 0, successor->vertex_buffer);
+				RS::get_singleton()->mesh_surface_update_attribute_region(successor->mesh, 0, 0, successor->attribute_buffer);
+				RS::get_singleton()->mesh_set_custom_aabb(successor->mesh, aabb);
+				successor->using_sprite = nullptr;
+				successor->set_base(successor->mesh);
+				successor->set_aabb(aabb);
+				i++; // Skip the successor for the next for-loop.
+				break;
+			}
+		}
+		// Propagate the change to remaining users that haven't changed their using_sprite.
+		// Note: This works even if the same user is registered twice. Very rare but can still happen.
+		for (; i < users.size(); i++) {
+			if (users[i] && users[i]->using_sprite == this) {
+				users[i]->_start_using_sprite(successor);
+			}
+		}
+		// Now every user has moved on, we can clear the users list.
+		users.clear();
+	}
+}
+
+void SpriteBase3D::_start_using_sprite(SpriteBase3D *p_using_sprite) {
+	using_sprite = p_using_sprite;
+	using_sprite_user_index = using_sprite->users.size();
+	set_base(using_sprite->mesh);
+	set_aabb(using_sprite->aabb);
+	using_sprite->users.push_back(this);
+	// We don't need to remove this sprite from the previous shared sprite's users list,
+	// as setting using_sprite means they will be detected and filtered out later.
+}
+
+void SpriteBase3D::_stop_using_sprite() {
+	using_sprite->users.write[using_sprite_user_index] = nullptr;
+	using_sprite = nullptr;
 }
 
 void SpriteBase3D::_notification(int p_what) {
@@ -224,6 +285,79 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 		uint8_t(CLAMP(color.a * 255.0, 0.0, 255.0))
 	};
 
+	BaseMaterial3D::Transparency mat_transparency = BaseMaterial3D::Transparency::TRANSPARENCY_DISABLED;
+	if (get_draw_flag(FLAG_TRANSPARENT)) {
+		if (get_alpha_cut_mode() == ALPHA_CUT_DISCARD) {
+			mat_transparency = BaseMaterial3D::Transparency::TRANSPARENCY_ALPHA_SCISSOR;
+		} else if (get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS) {
+			mat_transparency = BaseMaterial3D::Transparency::TRANSPARENCY_ALPHA_DEPTH_PRE_PASS;
+		} else if (get_alpha_cut_mode() == ALPHA_CUT_HASH) {
+			mat_transparency = BaseMaterial3D::Transparency::TRANSPARENCY_ALPHA_HASH;
+		} else {
+			mat_transparency = BaseMaterial3D::Transparency::TRANSPARENCY_ALPHA;
+		}
+	}
+
+	RID shader_rid;
+	StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, false, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), get_texture_filter(), alpha_antialiasing_mode, texture_repeat, &shader_rid);
+
+	if (last_shader != shader_rid) {
+		RS::get_singleton()->material_set_shader(get_material(), shader_rid);
+		last_shader = shader_rid;
+	}
+	if (last_texture != p_texture->get_rid()) {
+		RS::get_singleton()->material_set_param(get_material(), "texture_albedo", p_texture->get_rid());
+		RS::get_singleton()->material_set_param(get_material(), "albedo_texture_size", Vector2i(p_texture->get_width(), p_texture->get_height()));
+		last_texture = p_texture->get_rid();
+	}
+
+	if (sprite_sharing_enabled) {
+		SpriteMeshKey sprite_mesh_key;
+		sprite_mesh_key.final_rect = final_rect;
+		sprite_mesh_key.final_src_rect = final_src_rect;
+		sprite_mesh_key.v_color = *(uint32_t *)v_color;
+		sprite_mesh_key.v_normal = v_normal;
+		sprite_mesh_key.shader = last_shader;
+		sprite_mesh_key.texture = last_texture;
+		sprite_mesh_key.px_size = px_size;
+		sprite_mesh_key.render_priority = render_priority;
+		sprite_mesh_key.axis = axis;
+		sprite_mesh_key.hflip = hflip;
+		sprite_mesh_key.vflip = vflip;
+		sprite_mesh_key.alpha_cut_disabled = get_alpha_cut_mode() == ALPHA_CUT_DISABLED;
+		sprite_mesh_key.alpha_antialiasing_edge = alpha_antialiasing_edge;
+		sprite_mesh_key.alpha_hash_scale = alpha_hash_scale;
+		sprite_mesh_key.alpha_scissor_threshold = alpha_scissor_threshold;
+		if (sharing_own_mesh) {
+			if (last_sprite_mesh_key != sprite_mesh_key) {
+				// Sprite mesh data changed.
+				_stop_sharing_sprite();
+			} else {
+				// Sprite mesh data unchanged.
+				return;
+			}
+		}
+		// Try to see if there's any sprite whose mesh can be used instead.
+		SpriteBase3D **sprite_ptr = shared_sprites.getptr(sprite_mesh_key);
+		last_sprite_mesh_key = sprite_mesh_key;
+		if (sprite_ptr) {
+			if (*sprite_ptr != using_sprite) {
+				// Found new sprite that can be reused.
+				_start_using_sprite(*sprite_ptr);
+				return;
+			} else {
+				// Keep using same sprite.
+				return;
+			}
+		}
+		// Otherwise, setup mesh data and register this sprite's mesh for sharing.
+		_start_sharing_sprite();
+		if (using_sprite) {
+			// This sprite may have been sharing another sprite's mesh before, so we need to stop that here.
+			_stop_using_sprite();
+		}
+	}
+
 	for (int i = 0; i < 4; i++) {
 		Vector3 vtx;
 		vtx[x_axis] = vertices[i][0];
@@ -267,7 +401,8 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 			break;
 	}
 
-	RID mesh_new = get_mesh();
+	RID mesh_new = mesh;
+	set_base(mesh_new);
 	RS::get_singleton()->mesh_surface_update_vertex_region(mesh_new, 0, 0, vertex_buffer);
 	RS::get_singleton()->mesh_surface_update_attribute_region(mesh_new, 0, 0, attribute_buffer);
 
@@ -278,31 +413,6 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 	RS::get_singleton()->material_set_param(get_material(), "alpha_hash_scale", alpha_hash_scale);
 	RS::get_singleton()->material_set_param(get_material(), "alpha_antialiasing_edge", alpha_antialiasing_edge);
 
-	BaseMaterial3D::Transparency mat_transparency = BaseMaterial3D::Transparency::TRANSPARENCY_DISABLED;
-	if (get_draw_flag(FLAG_TRANSPARENT)) {
-		if (get_alpha_cut_mode() == ALPHA_CUT_DISCARD) {
-			mat_transparency = BaseMaterial3D::Transparency::TRANSPARENCY_ALPHA_SCISSOR;
-		} else if (get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS) {
-			mat_transparency = BaseMaterial3D::Transparency::TRANSPARENCY_ALPHA_DEPTH_PRE_PASS;
-		} else if (get_alpha_cut_mode() == ALPHA_CUT_HASH) {
-			mat_transparency = BaseMaterial3D::Transparency::TRANSPARENCY_ALPHA_HASH;
-		} else {
-			mat_transparency = BaseMaterial3D::Transparency::TRANSPARENCY_ALPHA;
-		}
-	}
-
-	RID shader_rid;
-	StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, false, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), get_texture_filter(), alpha_antialiasing_mode, texture_repeat, &shader_rid);
-
-	if (last_shader != shader_rid) {
-		RS::get_singleton()->material_set_shader(get_material(), shader_rid);
-		last_shader = shader_rid;
-	}
-	if (last_texture != p_texture->get_rid()) {
-		RS::get_singleton()->material_set_param(get_material(), "texture_albedo", p_texture->get_rid());
-		RS::get_singleton()->material_set_param(get_material(), "albedo_texture_size", Vector2i(p_texture->get_width(), p_texture->get_height()));
-		last_texture = p_texture->get_rid();
-	}
 	if (get_alpha_cut_mode() == ALPHA_CUT_DISABLED) {
 		RS::get_singleton()->material_set_render_priority(get_material(), get_render_priority());
 		RS::get_singleton()->mesh_surface_set_material(mesh, 0, get_material());
@@ -706,6 +816,13 @@ void SpriteBase3D::_bind_methods() {
 }
 
 SpriteBase3D::SpriteBase3D() {
+	static bool static_initialized = false;
+	if (!static_initialized) {
+		static_initialized = true;
+		// Auto-instancing isn't supported in the compatibility renderer.
+		sprite_sharing_enabled = RS::get_singleton()->get_current_rendering_method() != "gl_compatibility";
+	}
+
 	for (int i = 0; i < FLAG_MAX; i++) {
 		flags[i] = i == FLAG_TRANSPARENT || i == FLAG_DOUBLE_SIDED;
 	}
@@ -783,6 +900,14 @@ SpriteBase3D::~SpriteBase3D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free_rid(mesh);
 	RenderingServer::get_singleton()->free_rid(material);
+
+	if (sprite_sharing_enabled && sharing_own_mesh) {
+		_stop_sharing_sprite();
+	}
+
+	if (using_sprite) {
+		_stop_using_sprite();
+	}
 }
 
 ///////////////////////////////////////////

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -33,6 +33,41 @@
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/resources/sprite_frames.h"
 
+// Must be packed so uninitialized padding bytes won't be included in memcmp.
+#pragma pack(push, 1)
+struct SpriteMeshKey {
+	// Mesh vertices are derived from final_rect.position, final_rect.size, axis, and px_size
+	// axis and px_size are moved down to improve struct packing.
+	Rect2 final_rect;
+	// Mesh uvs are derived from final_src_rect.position, final_src_rect.size, hflip, vflip and texture size
+	// Texture size depends on the texture, and we're already including the texture for material checks,
+	// so we won't include texture size here.
+	Rect2 final_src_rect;
+	uint32_t v_color;
+	uint32_t v_normal;
+	RID shader;
+	RID texture;
+	real_t px_size;
+	int render_priority;
+	uint8_t axis; // Vector3::Axis will only ever have 3 members. We store it as a uint8_t instead of int to save space.
+	bool hflip;
+	bool vflip;
+	bool alpha_cut_disabled;
+	float alpha_scissor_threshold;
+	float alpha_hash_scale;
+	float alpha_antialiasing_edge;
+	static uint32_t hash(const SpriteMeshKey &p_key) {
+		return hash_djb2_buffer((const uint8_t *)&p_key, sizeof(SpriteMeshKey));
+	}
+	bool operator==(const SpriteMeshKey &p_other) const {
+		return memcmp(this, &p_other, sizeof(SpriteMeshKey)) == 0;
+	}
+	bool operator!=(const SpriteMeshKey &p_other) const {
+		return memcmp(this, &p_other, sizeof(SpriteMeshKey)) != 0;
+	}
+};
+#pragma pack(pop)
+
 class SpriteBase3D : public GeometryInstance3D {
 	GDCLASS(SpriteBase3D, GeometryInstance3D);
 
@@ -58,6 +93,12 @@ public:
 	};
 
 private:
+	Vector<SpriteBase3D *> users;
+	SpriteMeshKey last_sprite_mesh_key;
+	SpriteBase3D *using_sprite = nullptr;
+	int using_sprite_user_index = -1; // Used to invalidate this sprite's entry in another sprite's users vector.
+	bool sharing_own_mesh = false;
+
 	bool color_dirty = true;
 	Color color_accum;
 
@@ -97,6 +138,10 @@ private:
 	void _im_update();
 
 	void _propagate_color_changed();
+	void _start_sharing_sprite();
+	void _stop_sharing_sprite();
+	void _start_using_sprite(SpriteBase3D *p_using_sprite);
+	void _stop_using_sprite();
 
 protected:
 	Color _get_color_accum();
@@ -105,7 +150,7 @@ protected:
 	virtual void _draw() = 0;
 	void draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect, Rect2 p_src_rect);
 	_FORCE_INLINE_ void set_aabb(const AABB &p_aabb) { aabb = p_aabb; }
-	_FORCE_INLINE_ RID &get_mesh() { return mesh; }
+	_FORCE_INLINE_ RID &get_mesh() { return using_sprite ? using_sprite->mesh : mesh; }
 	_FORCE_INLINE_ RID &get_material() { return material; }
 
 	uint32_t mesh_surface_offsets[RS::ARRAY_MAX];

--- a/tests/scene/test_sprite_3d.h
+++ b/tests/scene/test_sprite_3d.h
@@ -1,0 +1,444 @@
+/**************************************************************************/
+/*  test_sprite_3d.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/3d/sprite_3d.h"
+#include "scene/resources/image_texture.h"
+#include "tests/test_macros.h"
+
+namespace TestSprite3D {
+
+TEST_CASE("[SceneTree][Sprite3D] Sprite Reuse") {
+	constexpr double DELTA_TIME = 1.0 / 60.0;
+	// Enable sprite reuse by setting the current rendering method to anything that's not gl_compatibility.
+	const String default_rendering_method = OS::get_singleton()->get_current_rendering_method();
+	OS::get_singleton()->set_current_rendering_method("forward_plus");
+	Sprite3D *sprite_0 = memnew(Sprite3D);
+	Sprite3D *sprite_1 = memnew(Sprite3D);
+	Sprite3D *sprite_2 = memnew(Sprite3D);
+	const Ref<Image> image = memnew(Image(16, 32, false, Image::FORMAT_RGB8));
+	const Ref<ImageTexture> image_texture = ImageTexture::create_from_image(image);
+	sprite_0->set_texture(image_texture);
+	sprite_1->set_texture(image_texture);
+	sprite_2->set_texture(image_texture);
+
+	SceneTree::get_singleton()->get_root()->add_child(sprite_0);
+	SceneTree::get_singleton()->get_root()->add_child(sprite_1);
+	SceneTree::get_singleton()->get_root()->add_child(sprite_2);
+
+	SUBCASE("[Sprite3D] New sprites using the same texture should be using the same mesh.") {
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+
+		Sprite3D *new_sprite = memnew(Sprite3D);
+		new_sprite->set_texture(image_texture);
+		SceneTree::get_singleton()->get_root()->add_child(new_sprite);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+		CHECK_EQ(sprite_2->get_base(), new_sprite->get_base());
+
+		memdelete(new_sprite);
+	}
+
+	SUBCASE("[Sprite3D] Destroying sprites should not cause other sprites to have invalid meshes.") {
+		memdelete(sprite_0);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(RS::get_singleton()->mesh_get_surface_count(sprite_1->get_base()), 0);
+		CHECK_NE(RS::get_singleton()->mesh_get_surface_count(sprite_2->get_base()), 0);
+
+		memdelete(sprite_1);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(RS::get_singleton()->mesh_get_surface_count(sprite_2->get_base()), 0);
+
+		sprite_0 = memnew(Sprite3D);
+		sprite_1 = memnew(Sprite3D);
+		sprite_0->set_texture(image_texture);
+		sprite_1->set_texture(image_texture);
+		SceneTree::get_singleton()->get_root()->add_child(sprite_0);
+		SceneTree::get_singleton()->get_root()->add_child(sprite_1);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+	}
+
+	SUBCASE("[Sprite3D] Sprites with different draw flags should not be using the same mesh.") {
+		const bool default_flag_transparent = sprite_0->get_draw_flag(SpriteBase3D::FLAG_TRANSPARENT);
+		const bool default_flag_shaded = sprite_0->get_draw_flag(SpriteBase3D::FLAG_SHADED);
+		sprite_0->set_draw_flag(SpriteBase3D::FLAG_TRANSPARENT, !default_flag_transparent);
+		sprite_0->set_draw_flag(SpriteBase3D::FLAG_SHADED, !default_flag_shaded);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_1->set_draw_flag(SpriteBase3D::FLAG_TRANSPARENT, !default_flag_transparent);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+		CHECK_NE(sprite_0->get_base(), sprite_2->get_base());
+
+		sprite_0->set_draw_flag(SpriteBase3D::FLAG_TRANSPARENT, default_flag_transparent);
+		sprite_0->set_draw_flag(SpriteBase3D::FLAG_SHADED, default_flag_shaded);
+		sprite_1->set_draw_flag(SpriteBase3D::FLAG_TRANSPARENT, default_flag_transparent);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+	}
+
+	SUBCASE("[Sprite3D] Sprites with different textures should not be using the same mesh.") {
+		const Ref<Image> other_image = memnew(Image(image->get_width(), image->get_height(), false, Image::FORMAT_RGB8));
+		const Ref<ImageTexture> other_image_texture = ImageTexture::create_from_image(other_image);
+		sprite_2->set_texture(other_image_texture);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_texture(other_image_texture);
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_2->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_texture(image_texture);
+		sprite_2->set_texture(image_texture);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+	}
+
+	SUBCASE("[Sprite3D] Sprites with different modulate values should not be using the same mesh.") {
+		const Color default_modulate = sprite_0->get_modulate();
+		Color red(1, 0, 0);
+		Color green(0, 1, 0);
+		sprite_0->set_modulate(red);
+		sprite_1->set_modulate(green);
+		sprite_2->set_modulate(red);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_2->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_modulate(red);
+		sprite_1->set_modulate(green);
+		sprite_2->set_modulate(green);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_modulate(default_modulate);
+		sprite_1->set_modulate(default_modulate);
+		sprite_2->set_modulate(default_modulate);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+	}
+
+	SUBCASE("[Sprite3D] Sprites of different pixel sizes should not be using the same mesh.") {
+		const real_t default_pixel_size = sprite_0->get_pixel_size();
+		sprite_0->set_pixel_size(MAX(default_pixel_size, 0.01f) / 2);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_1->set_pixel_size(sprite_0->get_pixel_size());
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_pixel_size(default_pixel_size);
+		sprite_1->set_pixel_size(default_pixel_size);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+	}
+
+	SUBCASE("[Sprite3D] Sprites with different render priorities should not be using the same mesh.") {
+		const int default_render_priority = sprite_0->get_render_priority();
+		sprite_0->set_render_priority(default_render_priority + 1);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_1->set_render_priority(sprite_0->get_render_priority());
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_render_priority(default_render_priority);
+		sprite_1->set_render_priority(default_render_priority);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+	}
+
+	SUBCASE("[Sprite3D] Sprites with different axes should not be using the same mesh.") {
+		const Vector3::Axis default_axis = sprite_0->get_axis();
+		sprite_0->set_axis(Vector3::AXIS_X);
+		sprite_1->set_axis(Vector3::AXIS_Y);
+		sprite_2->set_axis(Vector3::AXIS_Y);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_FALSE(sprite_0->get_aabb().is_equal_approx(sprite_1->get_aabb()));
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+		CHECK(sprite_1->get_aabb().is_equal_approx(sprite_2->get_aabb()));
+
+		sprite_0->set_axis(Vector3::AXIS_Z);
+		sprite_1->set_axis(Vector3::AXIS_X);
+		sprite_2->set_axis(Vector3::AXIS_Z);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_FALSE(sprite_0->get_aabb().is_equal_approx(sprite_1->get_aabb()));
+		CHECK_EQ(sprite_0->get_base(), sprite_2->get_base());
+		CHECK(sprite_0->get_aabb().is_equal_approx(sprite_2->get_aabb()));
+
+		sprite_0->set_axis(default_axis);
+		sprite_1->set_axis(default_axis);
+		sprite_2->set_axis(default_axis);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK(sprite_0->get_aabb().is_equal_approx(sprite_1->get_aabb()));
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+		CHECK(sprite_1->get_aabb().is_equal_approx(sprite_2->get_aabb()));
+	}
+
+	SUBCASE("[Sprite3D] Sprites with different flip_h/flip_v values should not be using the same mesh.") {
+		REQUIRE_FALSE(sprite_0->is_flipped_h());
+		REQUIRE_FALSE(sprite_1->is_flipped_v());
+
+		sprite_0->set_flip_h(true);
+		sprite_1->set_flip_v(true);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+		CHECK_NE(sprite_0->get_base(), sprite_2->get_base());
+
+		sprite_2->set_flip_v(true);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_flip_v(true);
+		sprite_1->set_flip_h(true);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_flip_h(false);
+		sprite_0->set_flip_v(false);
+		sprite_1->set_flip_h(false);
+		sprite_1->set_flip_v(false);
+		sprite_2->set_flip_v(false);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+	}
+
+	SUBCASE("[Sprite3D] Sprites with different alpha cut settings should not be using the same mesh.") {
+		REQUIRE_EQ(sprite_0->get_alpha_cut_mode(), SpriteBase3D::ALPHA_CUT_DISABLED);
+		const float default_alpha_hash_scale = sprite_0->get_alpha_hash_scale();
+		const float default_alpha_scissor_threshold = sprite_0->get_alpha_scissor_threshold();
+
+		sprite_0->set_alpha_cut_mode(SpriteBase3D::ALPHA_CUT_HASH);
+		sprite_0->set_alpha_hash_scale(MAX(default_alpha_hash_scale, 0.5f) / 2);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_1->set_alpha_cut_mode(SpriteBase3D::ALPHA_CUT_HASH);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+		CHECK_NE(sprite_0->get_base(), sprite_2->get_base());
+
+		sprite_1->set_alpha_hash_scale(sprite_0->get_alpha_hash_scale());
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_alpha_scissor_threshold(MAX(default_alpha_scissor_threshold, 0.5f) / 2);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+		CHECK_NE(sprite_0->get_base(), sprite_2->get_base());
+
+		sprite_1->set_alpha_scissor_threshold(sprite_0->get_alpha_scissor_threshold());
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_alpha_cut_mode(SpriteBase3D::ALPHA_CUT_DISABLED);
+		sprite_0->set_alpha_hash_scale(default_alpha_hash_scale);
+		sprite_0->set_alpha_scissor_threshold(default_alpha_scissor_threshold);
+		sprite_1->set_alpha_cut_mode(SpriteBase3D::ALPHA_CUT_DISABLED);
+		sprite_1->set_alpha_hash_scale(default_alpha_hash_scale);
+		sprite_1->set_alpha_scissor_threshold(default_alpha_scissor_threshold);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+	}
+
+	SUBCASE("[Sprite3D] Sprites with different alpha antialiasing settings should not be using the same mesh.") {
+		REQUIRE_EQ(sprite_0->get_alpha_antialiasing(), BaseMaterial3D::ALPHA_ANTIALIASING_OFF);
+		const float default_alpha_antialiasing_edge = sprite_0->get_alpha_antialiasing_edge();
+
+		sprite_0->set_alpha_antialiasing(BaseMaterial3D::ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE);
+		sprite_0->set_alpha_antialiasing_edge(MAX(default_alpha_antialiasing_edge, 0.5f) / 2);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_1->set_alpha_antialiasing(sprite_0->get_alpha_antialiasing());
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+		CHECK_NE(sprite_0->get_base(), sprite_2->get_base());
+
+		sprite_1->set_alpha_antialiasing_edge(sprite_0->get_alpha_antialiasing_edge());
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+	}
+
+	SUBCASE("[Sprite3D] Sprites with different billboard modes should not be using the same mesh.") {
+		const BaseMaterial3D::BillboardMode default_billboard_mode = sprite_0->get_billboard_mode();
+
+		sprite_0->set_billboard_mode(BaseMaterial3D::BILLBOARD_ENABLED);
+		sprite_1->set_billboard_mode(BaseMaterial3D::BILLBOARD_ENABLED);
+		sprite_2->set_billboard_mode(BaseMaterial3D::BILLBOARD_DISABLED);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_NE(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_billboard_mode(default_billboard_mode);
+		sprite_1->set_billboard_mode(default_billboard_mode);
+		sprite_2->set_billboard_mode(default_billboard_mode);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+	}
+
+	SUBCASE("[Sprite3D] Sprites with different texture filters should not be using the same mesh.") {
+		const BaseMaterial3D::TextureFilter default_texture_filter = sprite_0->get_texture_filter();
+
+		sprite_0->set_texture_filter(BaseMaterial3D::TEXTURE_FILTER_LINEAR);
+		sprite_1->set_texture_filter(BaseMaterial3D::TEXTURE_FILTER_NEAREST);
+		sprite_2->set_texture_filter(BaseMaterial3D::TEXTURE_FILTER_NEAREST);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_NE(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_texture_filter(default_texture_filter);
+		sprite_1->set_texture_filter(default_texture_filter);
+		sprite_2->set_texture_filter(default_texture_filter);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+	}
+
+	SUBCASE("[Sprite3D] Sprites with different material overrides should be allowed to share the same mesh.") {
+		REQUIRE(sprite_0->get_material_override().is_null());
+
+		Ref<PlaceholderMaterial> material_override;
+		material_override.instantiate();
+		sprite_0->set_material_override(material_override);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_material_override(nullptr);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+	}
+
+	SUBCASE("[Sprite3D] Sprites with different material overlays should be allowed to share the same mesh.") {
+		REQUIRE(sprite_0->get_material_overlay().is_null());
+
+		Ref<PlaceholderMaterial> material_overlay;
+		material_overlay.instantiate();
+		sprite_0->set_material_overlay(material_overlay);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+
+		sprite_0->set_material_overlay(nullptr);
+
+		SceneTree::get_singleton()->process(DELTA_TIME);
+		CHECK_EQ(sprite_0->get_base(), sprite_1->get_base());
+		CHECK_EQ(sprite_1->get_base(), sprite_2->get_base());
+	}
+
+	memdelete(sprite_0);
+	memdelete(sprite_1);
+	memdelete(sprite_2);
+
+	OS::get_singleton()->set_current_rendering_method(default_rendering_method);
+}
+
+} // namespace TestSprite3D

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -184,6 +184,7 @@
 #include "tests/scene/test_primitives.h"
 #include "tests/scene/test_skeleton_3d.h"
 #include "tests/scene/test_sky.h"
+#include "tests/scene/test_sprite_3d.h"
 #endif // _3D_DISABLED
 
 #ifndef PHYSICS_3D_DISABLED


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes https://github.com/godotengine/godot-proposals/issues/9947

This PR implements the proposal above, making Sprite3Ds (SpriteBase3Ds to be precise) reuse meshes whenever possible.

There's still some overhead associated with this reuse system, (on top of Sprite3D's existing overhead) so the performance isn't completely identical to using MeshInstance3Ds, but the performance gain is still very noticeable. See the results attached below.

Benchmarking is performed using the [project](https://github.com/Calinou/godot-sprite3d-vs-meshinstance3d) provided in the proposal. Though in this case the Renderdoc captures should be enough to confirm the performance increase.
<details><summary>10000 Quad MeshInstance3Ds (which already use instancing) (40~ FPS)</summary>
<p>

![mesh_instance_3d](https://github.com/user-attachments/assets/624c45d9-6a3a-4bc4-8e64-e960dba60fc7)

![mesh_instance_3d_renderdoc](https://github.com/user-attachments/assets/e687f7df-6eed-4e39-a028-19fe56c7d5ae)

</p>
</details> 

<details><summary>10000 Sprite3Ds without Instancing (< 1 FPS)</summary>
<p>

![sprite_3d](https://github.com/user-attachments/assets/49281214-6da4-4a50-9f5f-dce9238f3fd0)

![sprite_3d_renderdoc](https://github.com/user-attachments/assets/d28f8c9c-6e32-4039-b1bb-acb8159be123)


</p>
</details> 
<details><summary>10000 Sprite3Ds with Instancing (30~ FPS)</summary>
<p>

![sprite_3d_instancing](https://github.com/user-attachments/assets/cc20730e-5ba0-469d-92c4-b046a1431331)

![sprite_3d_instancing_renderdoc](https://github.com/user-attachments/assets/cc02d364-4f35-47af-8641-6af1b8b20552)
</p>
</details> 

Implementation details:
- To avoid having to create and destroy meshes frequently, this PR does not create any new mesh.
- A SpriteBase3D will try to use the mesh of an existing SpriteBase3D with the same SpriteMeshKey.
  - SpriteMeshKey being a small POD struct that identifies a Sprite mesh configuration.
  - This key is defined a bit differently than the hash proposed in the proposal above, but should be more accurate and probably a bit more memory-efficient.
  - SpriteMeshKeys are generated and recorded every time `draw_texture_rect` is called.
- If no such SpriteBase3D can be found, it will fallback to using its own mesh, and registering itself to the static HashMap `shared_sprites` so other SpriteBase3Ds can share its mesh.
- When a SpriteBase3D wants to share another SpriteBase3D's mesh, it adds itself to its users vector.
- When a SpriteBase3D that's sharing its mesh wants to update its own mesh, it will pick a "successor" and copy its mesh data to the successor, then let every other user share the successor's mesh instead. Afterwards, the users vector is cleared.
- When a SpriteBase3D that's sharing someone else's mesh wants to update its own mesh, it will not bother removing itself from the previous sprite's users vector, as there are mechanisms in place that allow a SpriteBase3D to ignore invalid users.
  - See the source code for more detail.

Remaining issues:
- Instancing isn't supported in the Compatibility renderer, (at the moment) in which case this optimization would add additional overhead without performance gains. However, currently there doesn't seem to be a fast way to check if mesh instancing is supported. (outside of checking `RS::get_singleton()->get_current_rendering_method() == "gl_compatibility"`, which would add significant overhead on its own)
  - Perhaps there should be an option to turn off Sprite3D instancing altogether, and this optimization can be configured in the project's Rendering settings.
  - In this case, what should the option be called? Maybe `rendering/3d/optimization/automatic_sprite_3d_instancing`?