### PR TITLE
Make `EditorProperty` and its child `EditorProperty` behave like sibling nodes when handling mouse events

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -51,6 +51,7 @@
 	<members>
 		<member name="draw_focus_border" type="bool" setter="set_draw_focus_border" getter="get_draw_focus_border" overrides="ScrollContainer" default="true" />
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
+		<member name="follow_focus" type="bool" setter="set_follow_focus" getter="is_following_focus" overrides="ScrollContainer" default="true" />
 		<member name="horizontal_scroll_mode" type="int" setter="set_horizontal_scroll_mode" getter="get_horizontal_scroll_mode" overrides="ScrollContainer" enum="ScrollContainer.ScrollMode" default="0" />
 	</members>
 	<signals>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -918,6 +918,9 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (me.is_valid()) {
 		Vector2 mpos = me->get_position();
+		if (bottom_child_rect.has_point(mpos)) {
+			return; // Makes child EditorProperties behave like sibling nodes when handling mouse events.
+		}
 		if (is_layout_rtl()) {
 			mpos.x = get_size().x - mpos.x;
 		}
@@ -2714,8 +2717,6 @@ VBoxContainer *EditorInspectorArray::get_vbox(int p_index) {
 
 EditorInspectorArray::EditorInspectorArray(bool p_read_only) {
 	read_only = p_read_only;
-
-	set_mouse_filter(Control::MOUSE_FILTER_STOP);
 
 	odd_style.instantiate();
 	even_style.instantiate();

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4528,14 +4528,6 @@ void EditorInspector::_node_removed(Node *p_node) {
 	}
 }
 
-void EditorInspector::_gui_focus_changed(Control *p_control) {
-	if (!is_visible_in_tree() && !is_following_focus()) {
-		return;
-	}
-	// Don't follow focus when the inspector nor any of its children is focused. Prevents potential jumping when gaining focus.
-	set_follow_focus(has_focus() || child_has_focus());
-}
-
 void EditorInspector::_update_current_favorites() {
 	current_favorites.clear();
 	if (!can_favorite) {
@@ -4733,10 +4725,6 @@ void EditorInspector::_notification(int p_what) {
 			if (!is_sub_inspector()) {
 				get_tree()->connect("node_removed", callable_mp(this, &EditorInspector::_node_removed));
 			}
-
-			Viewport *viewport = get_viewport();
-			ERR_FAIL_NULL(viewport);
-			viewport->connect("gui_focus_changed", callable_mp(this, &EditorInspector::_gui_focus_changed));
 		} break;
 
 		case NOTIFICATION_PREDELETE: {
@@ -4818,6 +4806,15 @@ void EditorInspector::_notification(int p_what) {
 			if (needs_update) {
 				update_tree();
 			}
+		} break;
+
+		case NOTIFICATION_FOCUS_ENTER: {
+			set_follow_focus(true);
+		} break;
+
+		case NOTIFICATION_FOCUS_EXIT: {
+			// Don't follow focus when the inspector is not focused. Prevents potential jumping when gaining focus.
+			set_follow_focus(false);
 		} break;
 	}
 }

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3046,7 +3046,6 @@ void EditorInspector::update_tree() {
 	int current_focusable = -1;
 
 	// Temporarily disable focus following on the root inspector to avoid jumping while the inspector is updating.
-	bool was_following = get_root_inspector()->is_following_focus();
 	get_root_inspector()->set_follow_focus(false);
 
 	if (property_focusable != -1) {
@@ -3075,7 +3074,7 @@ void EditorInspector::update_tree() {
 	_clear(!object);
 
 	if (!object) {
-		get_root_inspector()->set_follow_focus(was_following);
+		get_root_inspector()->set_follow_focus(true);
 		return;
 	}
 
@@ -3954,7 +3953,7 @@ void EditorInspector::update_tree() {
 		EditorNode::get_singleton()->hide_unused_editors();
 	}
 
-	get_root_inspector()->set_follow_focus(was_following);
+	get_root_inspector()->set_follow_focus(true);
 }
 
 void EditorInspector::update_property(const String &p_prop) {
@@ -4807,15 +4806,6 @@ void EditorInspector::_notification(int p_what) {
 				update_tree();
 			}
 		} break;
-
-		case NOTIFICATION_FOCUS_ENTER: {
-			set_follow_focus(true);
-		} break;
-
-		case NOTIFICATION_FOCUS_EXIT: {
-			// Don't follow focus when the inspector is not focused. Prevents potential jumping when gaining focus.
-			set_follow_focus(false);
-		} break;
 	}
 }
 
@@ -4972,6 +4962,7 @@ EditorInspector::EditorInspector() {
 	base_vbox->add_child(main_vbox);
 
 	set_horizontal_scroll_mode(SCROLL_MODE_DISABLED);
+	set_follow_focus(true);
 
 	changing = 0;
 	search_box = nullptr;

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -606,7 +606,6 @@ class EditorInspector : public ScrollContainer {
 	void _clear_current_favorites();
 
 	void _node_removed(Node *p_node);
-	void _gui_focus_changed(Control *p_control);
 
 	HashMap<StringName, int> per_array_page;
 	void _page_change_request(int p_new_page, const StringName &p_array_prefix);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3303,11 +3303,11 @@ void EditorPropertyResource::update_property() {
 				sub_inspector->set_use_folding(is_using_folding());
 
 				sub_inspector->set_draw_focus_border(false);
+				sub_inspector->set_focus_mode(FocusMode::FOCUS_NONE);
 
 				sub_inspector->set_use_filter(use_filter);
 				sub_inspector->register_text_enter(parent_inspector->search_box);
 
-				sub_inspector->set_mouse_filter(MOUSE_FILTER_STOP);
 				add_child(sub_inspector);
 				set_bottom_editor(sub_inspector);
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -430,7 +430,6 @@ void EditorPropertyArray::update_property() {
 
 		if (!container) {
 			container = memnew(PanelContainer);
-			container->set_mouse_filter(MOUSE_FILTER_STOP);
 			add_child(container);
 			set_bottom_editor(container);
 
@@ -1208,7 +1207,6 @@ void EditorPropertyDictionary::update_property() {
 
 		if (!container) {
 			container = memnew(PanelContainer);
-			container->set_mouse_filter(MOUSE_FILTER_STOP);
 			add_child(container);
 			set_bottom_editor(container);
 

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -82,6 +82,7 @@ private:
 
 	bool draw_focus_border = false;
 	bool focus_border_is_drawn = false;
+	bool child_has_focus();
 
 protected:
 	Size2 get_minimum_size() const override;
@@ -98,7 +99,6 @@ protected:
 
 public:
 	virtual void gui_input(const Ref<InputEvent> &p_gui_input) override;
-	bool child_has_focus();
 
 	void set_h_scroll(int p_pos);
 	int get_h_scroll() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Let `EditorProperty::gui_input()` no longer handle mouse events that occur in the child EditorProperty rect (`bottom_child_rect`).

This is another way to solve issues like #88848 , but avoids #100695 .

Bugsquad edit:
Fix #103578