### PR TITLE
Modify the description of get_locale_name to align it with its behavior.

### DIFF
--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -82,7 +82,7 @@
 			<return type="String" />
 			<param index="0" name="locale" type="String" />
 			<description>
-				Returns a locale's language and its variant (e.g. [code]"en_US"[/code] would return [code]"English (United States)"[/code]).
+				Returns a locale's language and its variant (e.g. [code]"en_US"[/code] would return [code]"English, United States of America"[/code]).
 			</description>
 		</method>
 		<method name="get_or_add_domain">


### PR DESCRIPTION
Fixes #103065

The parentheses are used to output the script of the locale, not the country. The documentation is modified accordingly.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
