### PR TITLE
Add error handling for array get method

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -96,6 +96,7 @@ Array::ConstIterator Array::end() const {
 }
 
 Variant &Array::operator[](int p_idx) {
+	ERR_FAIL_INDEX_MSG(p_idx, size(), _p->array[0]);
 	if (unlikely(_p->read_only)) {
 		*_p->read_only = _p->array[p_idx];
 		return *_p->read_only;
@@ -104,6 +105,7 @@ Variant &Array::operator[](int p_idx) {
 }
 
 const Variant &Array::operator[](int p_idx) const {
+	ERR_FAIL_INDEX_MSG(p_idx, size(), _p->array[0]);
 	if (unlikely(_p->read_only)) {
 		*_p->read_only = _p->array[p_idx];
 		return *_p->read_only;
@@ -493,6 +495,7 @@ void Array::set(int p_idx, const Variant &p_value) {
 }
 
 const Variant &Array::get(int p_idx) const {
+	ERR_FAIL_INDEX_MSG(p_idx, size(), Variant());
 	return operator[](p_idx);
 }
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -95,22 +95,22 @@ Array::ConstIterator Array::end() const {
 	return ConstIterator(_p->array.ptr() + _p->array.size(), _p->read_only);
 }
 
-Variant &Array::operator[](int p_idx) {
-	ERR_FAIL_INDEX_MSG(p_idx, size(), _p->array[0]);
-	if (unlikely(_p->read_only)) {
-		*_p->read_only = _p->array[p_idx];
-		return *_p->read_only;
-	}
-	return _p->array.write[p_idx];
+Variant Array::operator[](int p_idx) {
+    ERR_FAIL_INDEX_V_MSG(p_idx < 0 || p_idx >= size(), Variant());
+    if (unlikely(_p->read_only)) {
+        *_p->read_only = _p->array[p_idx];
+        return *_p->read_only;
+    }
+    return _p->array[p_idx];
 }
 
-const Variant &Array::operator[](int p_idx) const {
-	ERR_FAIL_INDEX_MSG(p_idx, size(), _p->array[0]);
-	if (unlikely(_p->read_only)) {
-		*_p->read_only = _p->array[p_idx];
-		return *_p->read_only;
-	}
-	return _p->array[p_idx];
+const Variant Array::operator[](int p_idx) const {
+    ERR_FAIL_INDEX_V_MSG(p_idx < 0 || p_idx >= size(), Variant());
+    if (unlikely(_p->read_only)) {
+        *_p->read_only = _p->array[p_idx];
+        return *_p->read_only;
+    }
+    return _p->array[p_idx];
 }
 
 int Array::size() const {
@@ -494,9 +494,9 @@ void Array::set(int p_idx, const Variant &p_value) {
 	operator[](p_idx) = value;
 }
 
-const Variant &Array::get(int p_idx) const {
-	ERR_FAIL_INDEX_MSG(p_idx, size(), Variant());
-	return operator[](p_idx);
+Variant Array::get(int p_idx) const {
+    ERR_FAIL_INDEX_V_MSG(p_idx < 0 || p_idx >= size(), Variant());
+    return operator[](p_idx);
 }
 
 Array Array::duplicate(bool p_deep) const {


### PR DESCRIPTION
Issue: The `Array::get(int p_idx)` function in Godot calls `operator[](p_idx)`, which does not perform bounds checking, leading to a crash when accessing an out-of-bounds index.

Solution: Add `ERR_FAIL_INDEX_MSG(p_idx, size(), Variant());` in `get()` and `operator[]` to prevent invalid memory access and ensure safe error handling.

Fixes #103328


PR adds bounds checking to both `Array::get(int p_idx)` and `Array::operator[](int p_idx)` so that invalid accesses are caught and handled with a proper error message. `operator[]` could probably be reverted to its previous state for performance reasons if necessary.
