### PR TITLE
GLTF: Use scene root nodes for root nodes, don't include orphan nodes

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -690,7 +690,9 @@ Error GLTFDocument::_parse_nodes(Ref<GLTFState> p_state) {
 }
 
 void GLTFDocument::_compute_node_heights(Ref<GLTFState> p_state) {
-	p_state->root_nodes.clear();
+	if (_naming_version < 2) {
+		p_state->root_nodes.clear();
+	}
 	for (GLTFNodeIndex node_i = 0; node_i < p_state->nodes.size(); ++node_i) {
 		Ref<GLTFNode> node = p_state->nodes[node_i];
 		node->height = 0;
@@ -704,8 +706,11 @@ void GLTFDocument::_compute_node_heights(Ref<GLTFState> p_state) {
 			current_i = parent_i;
 		}
 
-		if (node->height == 0) {
-			p_state->root_nodes.push_back(node_i);
+		if (_naming_version < 2) {
+			// This is incorrect, but required for compatibility with previous Godot versions.
+			if (node->height == 0) {
+				p_state->root_nodes.push_back(node_i);
+			}
 		}
 	}
 }


### PR DESCRIPTION
This fixes a bug noticed by the Blender Project DogWalk team where Godot was including orphan nodes as root nodes. This is incorrect, only the nodes actually indicated as scene root nodes should be used as root nodes. https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#scenes

Luckily the fix was pretty simple, just remove the code that re-assigns top orphan nodes as root nodes. Test file:

```gltf
{
	"asset": {
		"version": "2.0"
	},
	"nodes": [
		{ "name": "A" },
		{ "name": "B" }
	],
	"scenes": [
		{ "nodes": [0] },
		{ "nodes": [1] }
	],
	"scene": 0
}
```

In master: Imports both A and B as glTF root nodes as children of the Godot root node (incorrect).
With this PR: Imports only A as the glTF root node as a child of the Godot root node as indicated by the scene (correct).

I also looked into the general root node handling logic. Currently Godot does not correctly handle the case of a file not specifying scenes or scene root nodes, and will error when trying to parse anything that doesn't look like a scene. This will need to be improved for https://github.com/godotengine/godot-proposals/issues/7494, but for this PR I kept things limited to just this bug fix.