### PR TITLE
OpenXR: Emulated alpha blend mode should override the real blend mode

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -3641,10 +3641,10 @@ void OpenXRAPI::set_emulate_environment_blend_mode_alpha_blend(bool p_enabled) {
 }
 
 OpenXRAPI::OpenXRAlphaBlendModeSupport OpenXRAPI::is_environment_blend_mode_alpha_blend_supported() {
-	if (is_environment_blend_mode_supported(XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND)) {
-		return OPENXR_ALPHA_BLEND_MODE_SUPPORT_REAL;
-	} else if (emulate_environment_blend_mode_alpha_blend) {
+	if (emulate_environment_blend_mode_alpha_blend) {
 		return OPENXR_ALPHA_BLEND_MODE_SUPPORT_EMULATING;
+	} else if (is_environment_blend_mode_supported(XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND)) {
+		return OPENXR_ALPHA_BLEND_MODE_SUPPORT_REAL;
 	}
 	return OPENXR_ALPHA_BLEND_MODE_SUPPORT_NONE;
 }


### PR DESCRIPTION
Back in PR https://github.com/godotengine/godot/pull/87630 (released with Godot 4.3), we added the ability for GDExtensions to "emulate" the alpha blend mode, so that passthrough could be enabled via the standard OpenXR way on all headsets, even those that don't have real support for alpha blend mode.

For example, we have the `XR_FB_passthrough` and `XR_HTC_passthrough` extension in the 'godot_openxr_vendors' GDExtension, that will emulate it on Meta and HTC headsets.

However, this can cause some problems on headsets that support _both_ the alpha blend mode _and_ one of the passthrough extensions. For example, Pico headsets support `XR_FB_passthrough` and a real alpha blend mode.

The current code in Godot favors the real blend mode, and report that it's using that, even if an extension has told Godot that it is emulating it. This PR reverses that.

This is because the extensions can support more features than just turning passthrough on and off (which is all the alpha blend can do). So, the idea is, if one of the passthrough extensions is enabled and doing emulation, that should be used rather than the real alpha blend mode.