### PR TITLE
Tweak high-end mark in the visual shader editor's node creation dialog

### DIFF
--- a/doc/classes/VisualShaderNodeCustom.xml
+++ b/doc/classes/VisualShaderNodeCustom.xml
@@ -184,8 +184,8 @@
 		<method name="_is_highend" qualifiers="virtual const">
 			<return type="bool" />
 			<description>
-				Override this method to enable high-end mark in the Visual Shader Editor's members dialog.
-				Defining this method is [b]optional[/b]. If not overridden, it's [code]false[/code].
+				Override this method to enable the high-end mark in the Visual Shader Editor's members dialog. This should return [code]true[/code] for nodes that only work when using the Forward+ and Mobile renderers.
+				Defining this method is [b]optional[/b]. If not overridden, it's [code]false[/code], which indicates this node works with all renderers (including Compatibility).
 			</description>
 		</method>
 		<method name="get_option_index" qualifiers="const">

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -5283,7 +5283,7 @@ void VisualShaderEditor::_notification(int p_what) {
 
 		case NOTIFICATION_THEME_CHANGED: {
 			site_search->set_button_icon(get_editor_theme_icon(SNAME("ExternalLink")));
-			highend_label->set_modulate(get_theme_color(SNAME("highend_color"), EditorStringName(Editor)));
+			highend_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
 
 			param_filter->set_right_icon(Control::get_editor_theme_icon(SNAME("Search")));
 			node_filter->set_right_icon(Control::get_editor_theme_icon(SNAME("Search")));
@@ -6927,9 +6927,9 @@ VisualShaderEditor::VisualShaderEditor() {
 	highend_label->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	desc_hbox->add_child(highend_label);
 	highend_label->set_visible(false);
-	highend_label->set_text("Vulkan");
+	highend_label->set_text(TTRC("Forward+/Mobile"));
 	highend_label->set_mouse_filter(Control::MOUSE_FILTER_STOP);
-	highend_label->set_tooltip_text(TTR("High-end node"));
+	highend_label->set_tooltip_text(TTR("Only supported in the Forward+ and Mobile rendering methods, not Compatibility."));
 
 	node_desc = memnew(RichTextLabel);
 	members_vb->add_child(node_desc);

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -180,12 +180,6 @@ void ThemeClassic::populate_shared_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_color("forward_plus_color", EditorStringName(Editor), Color::hex(0x5d8c3fff));
 		p_theme->set_color("mobile_color", EditorStringName(Editor), Color::hex(0xa5557dff));
 		p_theme->set_color("gl_compatibility_color", EditorStringName(Editor), Color::hex(0x5586a4ff));
-
-		if (p_config.dark_theme) {
-			p_theme->set_color("highend_color", EditorStringName(Editor), Color(1.0, 0.0, 0.0));
-		} else {
-			p_theme->set_color("highend_color", EditorStringName(Editor), Color::hex(0xad1128ff));
-		}
 	}
 
 	// Constants.

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -203,12 +203,6 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_color("forward_plus_color", EditorStringName(Editor), Color::hex(0x5d8c3fff));
 		p_theme->set_color("mobile_color", EditorStringName(Editor), Color::hex(0xa5557dff));
 		p_theme->set_color("gl_compatibility_color", EditorStringName(Editor), Color::hex(0x5586a4ff));
-
-		if (p_config.dark_theme) {
-			p_theme->set_color("highend_color", EditorStringName(Editor), Color(1.0, 0.0, 0.0));
-		} else {
-			p_theme->set_color("highend_color", EditorStringName(Editor), Color::hex(0xad1128ff));
-		}
 	}
 
 	// Constants.


### PR DESCRIPTION
- Use Forward+/Mobile terminology as support actually depends on the rendering method used, not the rendering driver.
- Use a standard warning color as this is no longer indicated as Vulkan-specific.
- Fix color on light theme (the text was being modulated instead of having its color overridden).

## Preview

### Dark theme

Before | After
-|-
![Screenshot_20250227_013503](https://github.com/user-attachments/assets/a2a9cadc-8df5-40a3-953f-e60842556f4a) | ![Screenshot_20250227_014053](https://github.com/user-attachments/assets/106ac71b-fd65-47dc-a19a-33f1020070d7)

### Light theme

Before | After
-|-
![Screenshot_20250227_014011](https://github.com/user-attachments/assets/e6c045d3-8f44-4a88-a128-1044cdd1c366) | ![Screenshot_20250227_014038](https://github.com/user-attachments/assets/243a7314-ae21-4158-beb2-391a208e1e5c)
