### PR TITLE
Fix 2D instance params crashing using outside of `main()`

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1837,7 +1837,7 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 		actions.base_varying_index = 5;
 
 		actions.global_buffer_array_variable = "global_shader_uniforms.data";
-		actions.instance_uniform_index_variable = "draw_data.instance_uniforms_ofs";
+		actions.instance_uniform_index_variable = "instances.data[instance_index].instance_uniforms_ofs";
 
 		shader.compiler.initialize(actions);
 	}

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -48,6 +48,8 @@ layout(set = 1, binding = 0, std140) uniform MaterialUniforms {
 /* clang-format on */
 #endif
 
+uint instance_index;
+
 #GLOBALS
 
 #ifdef USE_ATTRIBUTES
@@ -66,9 +68,9 @@ void main() {
 #endif
 
 #ifdef USE_ATTRIBUTES
-	uint instance_index = params.base_instance_index;
+	instance_index = params.base_instance_index;
 #else
-	uint instance_index = gl_InstanceIndex + params.base_instance_index;
+	instance_index = gl_InstanceIndex + params.base_instance_index;
 	instance_index_interp = instance_index;
 #endif // USE_ATTRIBUTES
 	const InstanceData draw_data = instances.data[instance_index];
@@ -240,7 +242,7 @@ void main() {
 #include "canvas_uniforms_inc.glsl"
 
 #ifndef USE_ATTRIBUTES
-layout(location = 4) in flat uint instance_index;
+layout(location = 4) in flat uint instance_index_interp;
 #endif // USE_ATTRIBUTES
 
 layout(location = 0) in vec2 uv_interp;
@@ -286,6 +288,8 @@ vec2 texture_sdf_normal(vec2 p_sdf) {
 vec2 sdf_to_screen_uv(vec2 p_sdf) {
 	return p_sdf * canvas_data.sdf_to_screen;
 }
+
+uint instance_index;
 
 #GLOBALS
 
@@ -461,10 +465,11 @@ void main() {
 	vec2 vertex = vertex_interp;
 
 #ifdef USE_ATTRIBUTES
-	const InstanceData draw_data = instances.data[params.base_instance_index];
+	instance_index = params.base_instance_index;
 #else
-	const InstanceData draw_data = instances.data[instance_index];
+	instance_index = instance_index_interp;
 #endif // USE_ATTRIBUTES
+	const InstanceData draw_data = instances.data[instance_index];
 
 #if !defined(USE_ATTRIBUTES) && !defined(USE_PRIMITIVE)
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/103108