### PR TITLE
Physics Interpolation - reduce xforms in non-interpolated nodes

### DIFF
--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -151,6 +151,7 @@ private:
 	void _update_gizmos();
 	void _notify_dirty();
 	void _propagate_transform_changed(Node3D *p_origin);
+	void _propagate_transform_changed(Node3D *p_origin, bool p_check_physics_interpolation_state);
 
 	void _propagate_visibility_changed();
 


### PR DESCRIPTION
In the specific case of non-interpolated nodes, if ancestor nodes were moved on the physics tick this would lead to unnecessary NOTIFICATION_TRANSFORM_CHANGED and calls to `VisualServer`.

This would lower performance and lead to unwanted physics interpolation warnings about movement on physics ticks.

Here we remove these unnecessary notifications.

Forward port of #103331
(see that PR for more details)

Fixes #103330
Relevant to #103232
Relevant to #103025
Relevant to #101823

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
