### PR TITLE
Remove `load_steps` from `resource_format_text.cpp`

### DIFF
--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -75,6 +75,7 @@ private:
 
 	int resources_total = 0;
 	int resource_current = 0;
+
 	String resource_type;
 	String script_class;
 
@@ -97,6 +98,7 @@ private:
 
 	Error _parse_sub_resource(VariantParser::Stream *p_stream, Ref<Resource> &r_res, int &line, String &r_err_str);
 	Error _parse_ext_resource(VariantParser::Stream *p_stream, Ref<Resource> &r_res, int &line, String &r_err_str);
+	void _count_resources();
 
 	struct DummyReadData {
 		bool no_placeholders = false;


### PR DESCRIPTION
I propose to remove the `load_step` tag stored in the tscn files that make versioning the project tedious, especially during rebase.

Let's take an example where I commit changes to the main.tscn file:

- the first change increase the `load_step` go from 3 to 5
- the second change increase the `load_step` from 5 to 6.

If I decide to reorder this two commits, I will have a conflict on the load step value and will have to manually set it.

The current change I propose is just a simple removal. It has a drawback that the progress won't be displayed properly, which is fine for my Godot fork.

I could eventually restore the feature by parsing the whole file to pre compute the `resources_total` value.

I'd like to have the team feedback on this change before I proceed.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/11802*