### PR TITLE
[3.x] Physics Interpolation - Add editor warning for non-interpolated `PhysicsBody`

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -60,6 +60,19 @@ void PhysicsBody2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layers", PROPERTY_HINT_LAYERS_2D_PHYSICS, "", 0), "_set_layers", "_get_layers"); //for backwards compat
 }
 
+String PhysicsBody2D::get_configuration_warning() const {
+	String warning = CollisionObject2D::get_configuration_warning();
+
+	if (!is_physics_interpolated()) {
+		if (!warning.empty()) {
+			warning += "\n\n";
+		}
+		warning += TTR("PhysicsBody2D will not work correctly on a non-interpolated branch of the SceneTree.\nCheck the node's inherited physics_interpolation_mode.");
+	}
+
+	return warning;
+}
+
 PhysicsBody2D::PhysicsBody2D(Physics2DServer::BodyMode p_mode) :
 		CollisionObject2D(RID_PRIME(Physics2DServer::get_singleton()->body_create()), false) {
 	Physics2DServer::get_singleton()->body_set_mode(get_rid(), p_mode);
@@ -808,7 +821,7 @@ void RigidBody2D::_notification(int p_what) {
 String RigidBody2D::get_configuration_warning() const {
 	Transform2D t = get_transform();
 
-	String warning = CollisionObject2D::get_configuration_warning();
+	String warning = PhysicsBody2D::get_configuration_warning();
 
 	if ((get_mode() == MODE_RIGID || get_mode() == MODE_CHARACTER) && (ABS(t.elements[0].length() - 1.0) > 0.05 || ABS(t.elements[1].length() - 1.0) > 0.05)) {
 		if (warning != String()) {

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -51,6 +51,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual String get_configuration_warning() const;
+
 	Array get_collision_exceptions();
 	void add_collision_exception_with(Node *p_node); //must be physicsbody
 	void remove_collision_exception_with(Node *p_node);

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -98,6 +98,19 @@ void PhysicsBody::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_get_layers"), &PhysicsBody::_get_layers);
 }
 
+String PhysicsBody::get_configuration_warning() const {
+	String warning = CollisionObject::get_configuration_warning();
+
+	if (!is_physics_interpolated()) {
+		if (!warning.empty()) {
+			warning += "\n\n";
+		}
+		warning += TTR("PhysicsBody will not work correctly on a non-interpolated branch of the SceneTree.\nCheck the node's inherited physics_interpolation_mode.");
+	}
+
+	return warning;
+}
+
 PhysicsBody::PhysicsBody(PhysicsServer::BodyMode p_mode) :
 		CollisionObject(RID_PRIME(PhysicsServer::get_singleton()->body_create(p_mode)), false) {
 }
@@ -783,7 +796,7 @@ Array RigidBody::get_colliding_bodies() const {
 String RigidBody::get_configuration_warning() const {
 	Transform t = get_transform();
 
-	String warning = CollisionObject::get_configuration_warning();
+	String warning = PhysicsBody::get_configuration_warning();
 
 	if ((get_mode() == MODE_RIGID || get_mode() == MODE_CHARACTER) && (ABS(t.basis.get_axis(0).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(1).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(2).length() - 1.0) > 0.05)) {
 		if (warning != String()) {

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -49,6 +49,8 @@ protected:
 	PhysicsBody(PhysicsServer::BodyMode p_mode);
 
 public:
+	virtual String get_configuration_warning() const;
+
 	virtual Vector3 get_linear_velocity() const;
 	virtual Vector3 get_angular_velocity() const;
 	virtual float get_inverse_mass() const;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -219,6 +219,8 @@ void Node::_propagate_physics_interpolated(bool p_interpolated) {
 	// allow a call to the VisualServer etc in derived classes
 	_physics_interpolated_changed();
 
+	update_configuration_warning();
+
 	data.blocked++;
 	for (int i = 0; i < data.children.size(); i++) {
 		data.children[i]->_propagate_physics_interpolated(p_interpolated);


### PR DESCRIPTION
Helps address https://github.com/godotengine/godot/issues/103232#issuecomment-2687414358

![non_interp_warning](https://github.com/user-attachments/assets/1446c2c0-a1ee-4771-b0a9-2c22b590d768)

## Notes
* I had not encountered this before, but it may not be obvious to users that physics bodies won't work correctly on non-interpolated branches of the scene tree.
* This is simple to add and warns of the problem, and how to fix it.
* The warning will show even in projects not using physics interpolation, but in most cases users will not have been changing `physics_interpolation_mode` except by accident. There's not a super easy way to check the global interpolation switch in the editor (except via the project setting) as it is hard coded OFF in the editor.
* It is also possible to add some warnings at runtime for this (perhaps if the user switches interpolation mode of a branch at runtime) but seems less likely and can be added in a follow up PR.
* Also relevant to 4.x.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
