### PR TITLE
Input: Change default deadzone back to 0.5 for `ui_*` actions and axis `pressed` state

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1439,7 +1439,7 @@ void ProjectSettings::_add_builtin_input_map() {
 			}
 
 			Dictionary action;
-			action["deadzone"] = Variant(InputMap::DEFAULT_DEADZONE);
+			action["deadzone"] = Variant(InputMap::DEFAULT_TOGGLE_DEADZONE);
 			action["events"] = events;
 
 			String action_name = "input/" + E.key;

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1104,7 +1104,7 @@ JoyAxis InputEventJoypadMotion::get_axis() const {
 
 void InputEventJoypadMotion::set_axis_value(float p_value) {
 	axis_value = p_value;
-	pressed = Math::abs(axis_value) >= InputMap::DEFAULT_DEADZONE;
+	pressed = Math::abs(axis_value) >= InputMap::DEFAULT_TOGGLE_DEADZONE;
 	emit_changed();
 }
 

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -55,6 +55,8 @@ public:
 	};
 
 	static constexpr float DEFAULT_DEADZONE = 0.2f;
+	// Keep bigger deadzone for toggle actions (default `ui_*` actions, axis `pressed`) (GH-103360).
+	static constexpr float DEFAULT_TOGGLE_DEADZONE = 0.5f;
 
 private:
 	static InputMap *singleton;


### PR DESCRIPTION
Fixes #103360.
Partial revert of changes in #97281 and #99135.

CC @Calinou @wareya @rptfrg @Meorge 