### PR TITLE
Fix editor so frontmost item is always selected on click

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -55,6 +55,7 @@
 #include "scene/2d/polygon_2d.h"
 #include "scene/2d/skeleton_2d.h"
 #include "scene/2d/sprite_2d.h"
+#include "scene/2d/tile_map_layer.h"
 #include "scene/gui/base_button.h"
 #include "scene/gui/flow_container.h"
 #include "scene/gui/grid_container.h"
@@ -617,7 +618,7 @@ Rect2 CanvasItemEditor::_get_encompassing_rect(const Node *p_node) {
 	return rect;
 }
 
-void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_node, Vector<_SelectResult> &r_items, const Transform2D &p_parent_xform, const Transform2D &p_canvas_xform) {
+void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_node, Vector<_SelectResult> &r_items, const Transform2D &p_parent_xform, const Transform2D &p_canvas_xform, bool p_include_z_render) {
 	if (!p_node) {
 		return;
 	}
@@ -640,12 +641,12 @@ void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_no
 	for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
 		if (ci) {
 			if (!ci->is_set_as_top_level()) {
-				_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, p_parent_xform * ci->get_transform(), xform);
+				_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, p_parent_xform * ci->get_transform(), xform, p_include_z_render);
 			} else {
-				_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, ci->get_transform(), xform);
+				_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, ci->get_transform(), xform, p_include_z_render);
 			}
 		} else {
-			_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, Transform2D(), xform);
+			_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, Transform2D(), xform, p_include_z_render);
 		}
 	}
 
@@ -662,15 +663,26 @@ void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_no
 			res.item = ci;
 			res.z_index = node ? node->get_z_index() : 0;
 			res.has_z = node;
+			if (p_include_z_render) {
+				TileMapLayer *tml = Object::cast_to<TileMapLayer>(node);
+				if (tml) {
+					res.z_render = tml->get_z_render();
+				} else {
+					res.z_render = node ? RenderingServer::get_singleton()->canvas_item_get_z_render(node->get_canvas_item()) : 0;
+				}
+			} else {
+				res.z_render = 0;
+			}
+
 			r_items.push_back(res);
 		}
 	}
 }
 
-void CanvasItemEditor::_get_canvas_items_at_pos(const Point2 &p_pos, Vector<_SelectResult> &r_items, bool p_allow_locked) {
+void CanvasItemEditor::_get_canvas_items_at_pos(const Point2 &p_pos, Vector<_SelectResult> &r_items, bool p_allow_locked, bool p_include_z_render) {
 	Node *scene = EditorNode::get_singleton()->get_edited_scene();
 
-	_find_canvas_items_at_pos(p_pos, scene, r_items);
+	_find_canvas_items_at_pos(p_pos, scene, r_items, Transform2D(), Transform2D(), p_include_z_render);
 
 	//Remove invalid results
 	for (int i = 0; i < r_items.size(); i++) {
@@ -697,6 +709,9 @@ void CanvasItemEditor::_get_canvas_items_at_pos(const Point2 &p_pos, Vector<_Sel
 		bool duplicate = false;
 		for (int j = 0; j < i; j++) {
 			if (r_items[j].item == ci) {
+				if (r_items[j].z_render < r_items[i].z_render) {
+					r_items.write[j].z_render = r_items[i].z_render;
+				}
 				duplicate = true;
 				break;
 			}
@@ -2538,9 +2553,17 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 
 			Vector<_SelectResult> selection = Vector<_SelectResult>();
 			// Retrieve the canvas items.
-			_get_canvas_items_at_pos(click, selection);
+			_get_canvas_items_at_pos(click, selection, false, true);
 			if (!selection.is_empty()) {
 				ci = selection[0].item;
+				uint32_t z_final = selection[0].z_render;
+				for (int i = 1; i < selection.size(); i++) {
+					uint32_t z_current = selection[i].z_render;
+					if (z_current > z_final) {
+						z_final = z_current;
+						ci = selection[i].item;
+					}
+				}
 			}
 
 			// Shift also allows forcing box selection when item was clicked.

--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -267,6 +267,7 @@ private:
 	struct _SelectResult {
 		CanvasItem *item = nullptr;
 		real_t z_index = 0;
+		uint32_t z_render = 0;
 		bool has_z = true;
 		_FORCE_INLINE_ bool operator<(const _SelectResult &p_rr) const {
 			return has_z && p_rr.has_z ? p_rr.z_index < z_index : p_rr.has_z;
@@ -387,8 +388,8 @@ private:
 
 	bool _is_node_locked(const Node *p_node) const;
 	bool _is_node_movable(const Node *p_node, bool p_popup_warning = false);
-	void _find_canvas_items_at_pos(const Point2 &p_pos, Node *p_node, Vector<_SelectResult> &r_items, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
-	void _get_canvas_items_at_pos(const Point2 &p_pos, Vector<_SelectResult> &r_items, bool p_allow_locked = false);
+	void _find_canvas_items_at_pos(const Point2 &p_pos, Node *p_node, Vector<_SelectResult> &r_items, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D(), bool p_include_z_render = false);
+	void _get_canvas_items_at_pos(const Point2 &p_pos, Vector<_SelectResult> &r_items, bool p_allow_locked = false, bool p_include_z_render = false);
 
 	void _find_canvas_items_in_rect(const Rect2 &p_rect, Node *p_node, List<CanvasItem *> *r_items, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
 	bool _select_click_on_item(CanvasItem *item, Point2 p_click_pos, bool p_append);

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -2756,6 +2756,17 @@ void TileMapLayer::compute_transformed_tile_dest_rect(Rect2 &r_dest_rect, bool &
 	r_transpose = final_transpose;
 }
 
+uint32_t TileMapLayer::get_z_render() {
+	if (rendering_quadrant_map.is_empty()) {
+		return 0;
+	}
+	List<RID> items = rendering_quadrant_map.begin()->value->canvas_items;
+	if (items.is_empty()) {
+		return 0;
+	}
+	return RenderingServer::get_singleton()->canvas_item_get_z_render(items.front()->get());
+}
+
 void TileMapLayer::set_cell(const Vector2i &p_coords, int p_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile) {
 	// Set the current cell tile (using integer position).
 	Vector2i pk(p_coords);

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -547,6 +547,7 @@ public:
 
 	static void compute_transformed_tile_dest_rect(Rect2 &r_dest_rect, bool &r_transpose, const Vector2 &p_position, const Vector2 &p_dest_rect_size, const TileData *p_tile_data, int p_alternative_tile);
 	static void draw_tile(RID p_canvas_item, const Vector2 &p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile, int p_frame = -1, const TileData *p_tile_data_override = nullptr, real_t p_normalized_animation_offset = 0.0);
+	uint32_t get_z_render();
 
 	////////////// Exposed functions //////////////
 

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -667,6 +667,14 @@ uint32_t RendererCanvasCull::canvas_item_get_visibility_layer(RID p_item) {
 	return canvas_item->visibility_layer;
 }
 
+uint32_t RendererCanvasCull::canvas_item_get_z_render(RID p_item) {
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	if (!canvas_item) {
+		return 0;
+	}
+	return canvas_item->z_render;
+}
+
 void RendererCanvasCull::canvas_item_set_clip(RID p_item, bool p_clip) {
 	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
 	ERR_FAIL_NULL(canvas_item);

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -242,6 +242,7 @@ public:
 
 	void canvas_item_set_visibility_layer(RID p_item, uint32_t p_layer);
 	uint32_t canvas_item_get_visibility_layer(RID p_item);
+	uint32_t canvas_item_get_z_render(RID p_item);
 
 	void canvas_item_set_transform(RID p_item, const Transform2D &p_transform);
 	void canvas_item_set_clip(RID p_item, bool p_clip);

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -336,6 +336,7 @@ public:
 		bool use_canvas_group = false;
 		int light_mask;
 		int z_final;
+		uint32_t z_render;
 
 		mutable bool custom_rect;
 		mutable bool rect_dirty;
@@ -483,6 +484,7 @@ public:
 			light_masked = false;
 			update_when_visible = false;
 			z_final = 0;
+			z_render = 0;
 			texture_filter = RS::CANVAS_ITEM_TEXTURE_FILTER_DEFAULT;
 			texture_repeat = RS::CANVAS_ITEM_TEXTURE_REPEAT_DEFAULT;
 			repeat_source = false;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -511,6 +511,7 @@ void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p
 
 	r_sdf_used = false;
 	int item_count = 0;
+	uint32_t z_count = 0;
 
 	//setup canvas state uniforms if needed
 
@@ -908,6 +909,7 @@ void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p
 			item_count = 0;
 		}
 
+		ci->z_render = z_count++;
 		ci = ci->next;
 	}
 

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -1565,6 +1565,7 @@ public:
 	virtual void canvas_item_set_modulate(RID p_item, const Color &p_color) = 0;
 	virtual void canvas_item_set_self_modulate(RID p_item, const Color &p_color) = 0;
 	virtual void canvas_item_set_visibility_layer(RID p_item, uint32_t p_visibility_layer) = 0;
+	virtual uint32_t canvas_item_get_z_render(RID p_item) = 0;
 
 	virtual void canvas_item_set_draw_behind_parent(RID p_item, bool p_enable) = 0;
 	virtual void canvas_item_set_use_identity_transform(RID p_item, bool p_enabled) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -966,6 +966,8 @@ public:
 
 	FUNC2(canvas_item_set_visibility_layer, RID, uint32_t)
 
+	FUNC1R(uint32_t, canvas_item_get_z_render, RID)
+
 	FUNC2(canvas_item_set_update_when_visible, RID, bool)
 
 	FUNC2(canvas_item_set_transform, RID, const Transform2D &)


### PR DESCRIPTION
Fixes #96576 

This PR fixes the editor so the front most item is selected when clicking. It does this by storing the final Z value for each `CanvasItem` when rendering them. This `z_render` value that can be accessed through standard `RenderingServer` API.

Editor code was also edited to take advantage of this new functionality. 