### PR TITLE
Inform that Android sensors must be enabled for MobileVR support

### DIFF
--- a/modules/mobile_vr/doc_classes/MobileVRInterface.xml
+++ b/modules/mobile_vr/doc_classes/MobileVRInterface.xml
@@ -12,6 +12,7 @@
 		if interface and interface.initialize():
 		    get_viewport().use_xr = true
 		[/codeblock]
+		[b]Note:[/b] For Android, [member ProjectSettings.input_devices/sensors/enable_accelerometer], [member ProjectSettings.input_devices/sensors/enable_gravity], [member ProjectSettings.input_devices/sensors/enable_gyroscope] and [member ProjectSettings.input_devices/sensors/enable_magnetometer] must be enabled.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/94799

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
