### PR TITLE
Implement border condition on Rect2 has_point

### DIFF
--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -179,24 +179,39 @@ struct [[nodiscard]] Rect2 {
 		return new_rect;
 	}
 
-	inline bool has_point(const Point2 &p_point) const {
+	inline bool has_point(const Point2 &p_point, bool p_include_all_borders = false) const {
 #ifdef MATH_CHECKS
 		if (unlikely(size.x < 0 || size.y < 0)) {
 			ERR_PRINT("Rect2 size is negative, this is not supported. Use Rect2.abs() to get a Rect2 with a positive size.");
 		}
 #endif
-		if (p_point.x < position.x) {
-			return false;
+		if (p_include_all_borders) {
+			if (p_point.x < position.x) {
+				return false;
+			}
+			if (p_point.y < position.y) {
+				return false;
+			}
+			if (p_point.x > (position.x + size.x)) {
+				return false;
+			}
+			if (p_point.y > (position.y + size.y)) {
+				return false;
+			}
 		}
-		if (p_point.y < position.y) {
-			return false;
-		}
-
-		if (p_point.x >= (position.x + size.x)) {
-			return false;
-		}
-		if (p_point.y >= (position.y + size.y)) {
-			return false;
+		else {
+			if (p_point.x < position.x) {
+				return false;
+			}
+			if (p_point.y < position.y) {
+				return false;
+			}
+			if (p_point.x >= (position.x + size.x)) {
+				return false;
+			}
+			if (p_point.y >= (position.y + size.y)) {
+				return false;
+			}
 		}
 
 		return true;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1900,7 +1900,7 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Rect2, get_center, sarray(), varray());
 	bind_method(Rect2, get_area, sarray(), varray());
 	bind_method(Rect2, has_area, sarray(), varray());
-	bind_method(Rect2, has_point, sarray("point"), varray());
+	bind_method(Rect2, has_point, sarray("point", "include_all_borders"), varray(false));
 	bind_method(Rect2, is_equal_approx, sarray("rect"), varray());
 	bind_method(Rect2, is_finite, sarray(), varray());
 	bind_method(Rect2, intersects, sarray("b", "include_borders"), varray(false));

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -163,8 +163,10 @@
 		<method name="has_point" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="point" type="Vector2" />
+			<param index="1" name="include_all_borders" type="bool" default="false" />
 			<description>
 				Returns [code]true[/code] if the rectangle contains the given [param point]. By convention, points on the right and bottom edges are [b]not[/b] included.
+				Set [param include_all_borders] to [code]true[/code] include points on all edges
 				[b]Note:[/b] This method is not reliable for [Rect2] with a [i]negative[/i] [member size]. Use [method abs] first to get a valid rectangle.
 			</description>
 		</method>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Closes https://github.com/godotengine/godot-proposals/issues/11754

Added the "include_all_borders" parameter to the rect2.has_point function. Uses a default argument to mantain the default convention, but if the parameter is set to true, the function considers all points in the any of the edges of the rectangle as a part of it. 

The implemented solution is the same that was used on the rect2.intersects function
 