### PR TITLE
Don't hard-code setting list in DependencyEditor

### DIFF
--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -120,6 +120,8 @@ class DependencyRemoveDialog : public ConfirmationDialog {
 		}
 	};
 
+	LocalVector<StringName> path_project_settings;
+
 	void _find_files_in_removed_folder(EditorFileSystemDirectory *efsd, const String &p_folder);
 	void _find_all_removed_dependencies(EditorFileSystemDirectory *efsd, Vector<RemovedDependency> &p_removed);
 	void _find_localization_remaps_of_removed_files(Vector<RemovedDependency> &p_removed);


### PR DESCRIPTION
Instead of manually checking every relevant project setting whether the file was removed, the list is first prepared using PROPERTY_HINT_FILE and then the files are checked using HashMap lookup. The code is now more maintainable and more performant.