### PR TITLE
Use UID instead of path for scene instances

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -364,7 +364,7 @@ void Node::_propagate_enter_tree() {
 	data.blocked--;
 
 #ifdef DEBUG_ENABLED
-	SceneDebugger::add_to_cache(data.scene_file_path, this);
+	SceneDebugger::add_to_cache(get_scene_file_path(), this);
 #endif
 	// enter groups
 }
@@ -392,9 +392,9 @@ void Node::_propagate_exit_tree() {
 	//block while removing children
 
 #ifdef DEBUG_ENABLED
-	if (!data.scene_file_path.is_empty()) {
+	if (data.scene_file_uid != ResourceUID::INVALID_ID) {
 		// Only remove if file path is set (optimization).
-		SceneDebugger::remove_from_cache(data.scene_file_path, this);
+		SceneDebugger::remove_from_cache(get_scene_file_path(), this);
 	}
 #endif
 	data.blocked++;
@@ -2606,12 +2606,19 @@ Ref<Tween> Node::create_tween() {
 
 void Node::set_scene_file_path(const String &p_scene_file_path) {
 	ERR_THREAD_GUARD
-	data.scene_file_path = p_scene_file_path;
+	data.scene_file_uid = ResourceLoader::get_resource_uid(p_scene_file_path);
 	_emit_editor_state_changed();
 }
 
 String Node::get_scene_file_path() const {
-	return data.scene_file_path;
+	if (data.scene_file_uid == ResourceUID::INVALID_ID) {
+		return String();
+	}
+	return ResourceUID::get_singleton()->get_id_path(data.scene_file_uid);
+}
+
+ResourceUID::ID Node::get_scene_file_uid() const {
+	return data.scene_file_uid;
 }
 
 void Node::set_editor_description(const String &p_editor_description) {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -160,7 +160,7 @@ private:
 
 	// This Data struct is to avoid namespace pollution in derived classes.
 	struct Data {
-		String scene_file_path;
+		ResourceUID::ID scene_file_uid = ResourceUID::INVALID_ID;
 		Ref<SceneState> instance_state;
 		Ref<SceneState> inherited_state;
 
@@ -575,6 +575,7 @@ public:
 
 	void set_scene_file_path(const String &p_scene_file_path);
 	String get_scene_file_path() const;
+	ResourceUID::ID get_scene_file_uid() const;
 
 	void set_editor_description(const String &p_editor_description);
 	String get_editor_description() const;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -768,8 +768,9 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 
 	if (!p_node->get_scene_file_path().is_empty() && p_node->get_owner() == p_owner && instantiated_by_owner) {
 		if (p_node->get_scene_instance_load_placeholder()) {
-			//it's a placeholder, use the placeholder path
-			nd.instance = _vm_get_variant(p_node->get_scene_file_path(), variant_map);
+			// It's a placeholder, use the placeholder path.
+			ResourceUID::ID scene_id = p_node->get_scene_file_uid();
+			nd.instance = _vm_get_variant(ResourceUID::get_singleton()->id_to_text(scene_id), variant_map);
 			nd.instance |= FLAG_INSTANCE_IS_PLACEHOLDER;
 		} else {
 			//must instance ourselves


### PR DESCRIPTION
Replaces Node's `scene_file_path` with `scene_file_uid`, so nodes now refer to their base scene with UID. This makes them use minimally less memory (as String is replaced by ID), but `get_scene_file_path()` is now slightly slower, because it gets the path from UID. Most engine usages only fetch the path to check whether it's empty, so #100437 makes even more sense now.

Fixes #37818
Supersedes #75103

Needs testing.