### PR TITLE
VideoStreamPlayer: Stop video on exit tree

### DIFF
--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -136,6 +136,7 @@ void VideoStreamPlayer::_notification(int p_notification) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
+			stop();
 			AudioServer::get_singleton()->remove_mix_callback(_mix_audios, this);
 		} break;
 


### PR DESCRIPTION
Fixes a minor issue when a VideoStreamPlayer is removed from the tree while playing, and then re-added and played again. When the node is removed from the tree, the data in the audio buffer keeps playing for the length of the buffer while the video isn't playing anymore, getting out of sync. With this change the audio stops playing immediately instead.

The [MRP](https://github.com/user-attachments/files/19027222/videostreamplayer.zip) for testing.
