### PR TITLE
Rename GDExtensionClassMethodInfo's arguments_info to arguments

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -181,7 +181,7 @@ public:
 
 		List<PropertyInfo>::ConstIterator itr = arguments_info.begin();
 		for (uint32_t i = 0; i < p_method_info->argument_count; ++itr, ++i) {
-			if (itr->type != (Variant::Type)p_method_info->arguments_info[i].type) {
+			if (itr->type != (Variant::Type)p_method_info->arguments[i].type) {
 				return false;
 			}
 		}
@@ -209,7 +209,7 @@ public:
 		arguments_info.clear();
 		arguments_metadata.clear();
 		for (uint32_t i = 0; i < p_method_info->argument_count; i++) {
-			arguments_info.push_back(PropertyInfo(p_method_info->arguments_info[i]));
+			arguments_info.push_back(PropertyInfo(p_method_info->arguments[i]));
 			arguments_metadata.push_back(GodotTypeInfo::Metadata(p_method_info->arguments_metadata[i]));
 		}
 

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -442,19 +442,17 @@ typedef struct {
 
 	/* If `has_return_value` is false, `return_value_info` and `return_value_metadata` are ignored.
 	 *
-	 * @todo Consider dropping `has_return_value` and making the other two properties match `GDExtensionMethodInfo` and `GDExtensionClassVirtualMethod` for consistency in future version of this struct.
+	 * @todo Consider dropping `has_return_value` and making the other two properties match `GDExtensionMethodInfo` and `GDExtensionClassVirtualMethodInfo` for consistency in future version of this struct.
 	 */
 	GDExtensionBool has_return_value;
 	GDExtensionPropertyInfo *return_value_info;
 	GDExtensionClassMethodArgumentMetadata return_value_metadata;
 
-	/* Arguments: `arguments_info` and `arguments_metadata` are array of size `argument_count`.
+	/* Arguments: `arguments` and `arguments_metadata` are array of size `argument_count`.
 	 * Name and hint information for the argument can be omitted in release builds. Class name should always be present if it applies.
-	 *
-	 * @todo Consider renaming `arguments_info` to `arguments` for consistency in future version of this struct.
 	 */
 	uint32_t argument_count;
-	GDExtensionPropertyInfo *arguments_info;
+	GDExtensionPropertyInfo *arguments;
 	GDExtensionClassMethodArgumentMetadata *arguments_metadata;
 
 	/* Default arguments: `default_arguments` is an array of size `default_argument_count`. */


### PR DESCRIPTION
Also fixed GDExtensionClassVirtualMethodInfo name in another TODO.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
