### PR TITLE
Fix TextEdit scrolls wrong on text selection

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6081,7 +6081,7 @@ void TextEdit::adjust_viewport_to_caret(int p_caret) {
 		set_line_as_last_visible(cur_line, cur_wrap);
 	}
 
-	_adjust_viewport_to_caret_horizontally(p_caret);
+	_adjust_viewport_to_caret_horizontally(p_caret, false);
 }
 
 void TextEdit::center_viewport_to_caret(int p_caret) {
@@ -8186,7 +8186,7 @@ void TextEdit::_scroll_lines_down() {
 	merge_overlapping_carets();
 }
 
-void TextEdit::_adjust_viewport_to_caret_horizontally(int p_caret) {
+void TextEdit::_adjust_viewport_to_caret_horizontally(int p_caret, bool p_maximize_selection) {
 	if (get_line_wrapping_mode() != LineWrappingMode::LINE_WRAPPING_NONE) {
 		first_visible_col = 0;
 		h_scroll->set_value(first_visible_col);
@@ -8220,7 +8220,7 @@ void TextEdit::_adjust_viewport_to_caret_horizontally(int p_caret) {
 		int ime_end_column = get_caret_column(p_caret) + (ime_selection.y > 0 ? ime_selection.x + ime_selection.y : ime_text.length());
 		caret_end_pos = _get_column_x_offset_for_line(ime_end_column, get_caret_line(p_caret), ime_end_column);
 		prioritize_end = false;
-	} else if (has_selection(p_caret) && get_selection_from_line(p_caret) == get_selection_to_line(p_caret)) {
+	} else if (p_maximize_selection && has_selection(p_caret) && get_selection_from_line(p_caret) == get_selection_to_line(p_caret)) {
 		// Use selection if it is on one line.
 		caret_start_pos = _get_column_x_offset_for_line(get_selection_from_column(p_caret), get_caret_line(p_caret), get_selection_from_column(p_caret));
 		caret_end_pos = _get_column_x_offset_for_line(get_selection_to_column(p_caret), get_caret_line(p_caret), get_selection_to_column(p_caret));

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -539,7 +539,7 @@ private:
 	void _scroll_lines_up();
 	void _scroll_lines_down();
 
-	void _adjust_viewport_to_caret_horizontally(int p_caret = 0);
+	void _adjust_viewport_to_caret_horizontally(int p_caret = 0, bool p_maximize_selection = true);
 
 	// Minimap.
 	bool draw_minimap = false;


### PR DESCRIPTION
- fixes #103401

The issue also occurs when selecting left to right on a single line if it is longer than the view, and also happens with keyboard.

Some uses of `adjust_viewport_to_caret` should try to maximize the amount of selected text on screen and some shouldn't. I made it always just ignore the selection when adjusting for now. 
In the future it can be changed so that actions like undo or select next occurrence take into account the selection.
