### PR TITLE
Make pause hotkey work while game is focused

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -46,6 +46,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/filesystem_dock.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_run_bar.h"
 #include "editor/gui/editor_toaster.h"
 #include "editor/inspector_dock.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
@@ -853,6 +854,15 @@ void ScriptEditorDebugger::_msg_request_quit(uint64_t p_thread_id, const Array &
 	_stop_and_notify();
 }
 
+void ScriptEditorDebugger::_msg_request_pause(uint64_t p_thread_id, const Array &p_data) {
+	if (EditorRunBar::get_singleton()->get_pause_button()->is_pressed()) {
+		EditorRunBar::get_singleton()->get_pause_button()->set_pressed(false);
+	} else {
+		EditorRunBar::get_singleton()->get_pause_button()->set_pressed(true);
+	}
+	EditorRunBar::get_singleton()->get_pause_button()->emit_signal(SceneStringNames::get_singleton()->pressed);
+}
+
 void ScriptEditorDebugger::_msg_remote_objects_selected(uint64_t p_thread_id, const Array &p_data) {
 	ERR_FAIL_COND(p_data.is_empty());
 	EditorDebuggerRemoteObjects *objs = inspector->set_objects(p_data);
@@ -945,6 +955,7 @@ void ScriptEditorDebugger::_init_parse_message_handlers() {
 	parse_message_handlers["servers:profile_frame"] = &ScriptEditorDebugger::_msg_servers_profile_frame;
 	parse_message_handlers["servers:profile_total"] = &ScriptEditorDebugger::_msg_servers_profile_total;
 	parse_message_handlers["request_quit"] = &ScriptEditorDebugger::_msg_request_quit;
+	parse_message_handlers["request_pause"] = &ScriptEditorDebugger::_msg_request_pause;
 	parse_message_handlers["remote_objects_selected"] = &ScriptEditorDebugger::_msg_remote_objects_selected;
 	parse_message_handlers["remote_nothing_selected"] = &ScriptEditorDebugger::_msg_remote_nothing_selected;
 	parse_message_handlers["remote_selection_invalidated"] = &ScriptEditorDebugger::_msg_remote_selection_invalidated;
@@ -1157,6 +1168,8 @@ void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {
 
 	Array quit_keys = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/stop_running_project"));
 	_put_msg("scene:setup_scene", quit_keys);
+	Array pause_keys = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/pause_running_project"));
+	_put_msg("scene:pause_scene", pause_keys);
 
 	if (EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_profiler", false)) {
 		profiler->set_profiling(true);

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -217,6 +217,7 @@ private:
 	void _msg_servers_profile_frame(uint64_t p_thread_id, const Array &p_data);
 	void _msg_servers_profile_total(uint64_t p_thread_id, const Array &p_data);
 	void _msg_request_quit(uint64_t p_thread_id, const Array &p_data);
+	void _msg_request_pause(uint64_t p_thread_id, const Array &p_data);
 	void _msg_remote_objects_selected(uint64_t p_thread_id, const Array &p_data);
 	void _msg_remote_nothing_selected(uint64_t p_thread_id, const Array &p_data);
 	void _msg_remote_selection_invalidated(uint64_t p_thread_id, const Array &p_data);

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -109,6 +109,13 @@ void SceneDebugger::_handle_input(const Ref<InputEvent> &p_event, const Ref<Shor
 	}
 }
 
+void SceneDebugger::_handle_pause_input(const Ref<InputEvent> &p_event, const Ref<Shortcut> &p_shortcut) {
+	Ref<InputEventKey> k = p_event;
+	if (p_shortcut.is_valid() && k.is_valid() && k->is_pressed() && !k->is_echo() && p_shortcut->matches_event(k)) {
+		EngineDebugger::get_singleton()->send_message("request_pause", Array());
+	}
+}
+
 Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured) {
 	SceneTree *scene_tree = SceneTree::get_singleton();
 	if (!scene_tree) {
@@ -127,6 +134,9 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 	r_captured = true;
 	if (p_msg == "setup_scene") {
 		SceneTree::get_singleton()->get_root()->connect(SceneStringName(window_input), callable_mp_static(SceneDebugger::_handle_input).bind(DebuggerMarshalls::deserialize_key_shortcut(p_args)));
+	}
+	if (p_msg == "pause_scene") {
+		SceneTree::get_singleton()->get_root()->connect(SceneStringName(window_input), callable_mp_static(SceneDebugger::_handle_pause_input).bind(DebuggerMarshalls::deserialize_key_shortcut(p_args)));
 
 	} else if (p_msg == "request_scene_tree") { /// Scene Tree
 		live_editor->_send_tree();

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -62,6 +62,7 @@ public:
 #ifdef DEBUG_ENABLED
 private:
 	static void _handle_input(const Ref<InputEvent> &p_event, const Ref<Shortcut> &p_shortcut);
+	static void _handle_pause_input(const Ref<InputEvent> &p_event, const Ref<Shortcut> &p_shortcut);
 
 	static void _save_node(ObjectID id, const String &p_path);
 	static void _set_node_owner_recursive(Node *p_node, Node *p_owner);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11875

This makes the `Pause Running Project` (F7) hotkey work while the game is being played.
_(When the pause hotkey is pressed, the game is paused and minimized. But you can enable always on top to prevent this behavior)_

https://github.com/user-attachments/assets/0dc0545f-6f8c-476b-9c07-74e9112d7894


**Notes:**
This does not address the pause button from the embeded window as its pause works in a different way.
It can pause the embed window, but that's because the hotkey is calling the pause button from the EditorRunBar. 
_I think this inconsistency is a bug and should be handled in a different PR_

