### PR TITLE
ItemList multiselect with shift up & down arrow keys

### DIFF
--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -98,6 +98,7 @@ private:
 	int current = -1;
 	int hovered = -1;
 	int prev_hovered = -1;
+	int shift_anchor = -1;
 
 	bool shape_changed = true;
 
@@ -173,6 +174,7 @@ private:
 	void _scroll_changed(double);
 	void _shape_text(int p_idx);
 	void _mouse_exited();
+	void _shift_range_select(int p_from, int p_to);
 
 	String _atr(int p_idx, const String &p_text) const;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Implements https://github.com/godotengine/godot-proposals/issues/9314 for ItemLists. The tree pr is #103382. 

Just like with the tree version, this creates an anchor when shift + arrow key is pressed, and resets the anchor when shift is released.