### PR TITLE
Use single RNG instance for `FileAccessEncrypted` IV generation.

### DIFF
--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -30,8 +30,16 @@
 
 #include "file_access_encrypted.h"
 
-#include "core/crypto/crypto_core.h"
 #include "core/variant/variant.h"
+
+CryptoCore::RandomGenerator *FileAccessEncrypted::_fae_static_rng = nullptr;
+
+void FileAccessEncrypted::deinitialize() {
+	if (_fae_static_rng) {
+		memdelete(_fae_static_rng);
+		_fae_static_rng = nullptr;
+	}
+}
 
 Error FileAccessEncrypted::open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic, const Vector<uint8_t> &p_iv) {
 	ERR_FAIL_COND_V_MSG(file.is_valid(), ERR_ALREADY_IN_USE, vformat("Can't open file while another file from path '%s' is open.", file->get_path_absolute()));
@@ -48,9 +56,15 @@ Error FileAccessEncrypted::open_and_parse(Ref<FileAccess> p_base, const Vector<u
 		key = p_key;
 		if (p_iv.is_empty()) {
 			iv.resize(16);
-			CryptoCore::RandomGenerator rng;
-			ERR_FAIL_COND_V_MSG(rng.init(), FAILED, "Failed to initialize random number generator.");
-			Error err = rng.get_random_bytes(iv.ptrw(), 16);
+			if (unlikely(!_fae_static_rng)) {
+				_fae_static_rng = memnew(CryptoCore::RandomGenerator);
+				if (_fae_static_rng->init() != OK) {
+					memdelete(_fae_static_rng);
+					_fae_static_rng = nullptr;
+					ERR_FAIL_V_MSG(FAILED, "Failed to initialize random number generator.");
+				}
+			}
+			Error err = _fae_static_rng->get_random_bytes(iv.ptrw(), 16);
 			ERR_FAIL_COND_V(err != OK, err);
 		} else {
 			ERR_FAIL_COND_V(p_iv.size() != 16, ERR_INVALID_PARAMETER);

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -31,6 +31,7 @@
 #ifndef FILE_ACCESS_ENCRYPTED_H
 #define FILE_ACCESS_ENCRYPTED_H
 
+#include "core/crypto/crypto_core.h"
 #include "core/io/file_access.h"
 
 #define ENCRYPTED_HEADER_MAGIC 0x43454447
@@ -56,6 +57,8 @@ private:
 	bool use_magic = true;
 
 	void _close();
+
+	static CryptoCore::RandomGenerator *_fae_static_rng;
 
 public:
 	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
@@ -96,6 +99,8 @@ public:
 	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override;
 
 	virtual void close() override;
+
+	static void deinitialize();
 
 	FileAccessEncrypted() {}
 	~FileAccessEncrypted();

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -45,6 +45,7 @@
 #include "core/io/config_file.h"
 #include "core/io/dir_access.h"
 #include "core/io/dtls_server.h"
+#include "core/io/file_access_encrypted.h"
 #include "core/io/http_client.h"
 #include "core/io/image_loader.h"
 #include "core/io/json.h"
@@ -454,6 +455,8 @@ void unregister_core_types() {
 	ClassDB::cleanup();
 	CoreStringNames::free();
 	StringName::cleanup();
+
+	FileAccessEncrypted::deinitialize();
 
 	OS::get_singleton()->benchmark_end_measure("Core", "Unregister Types");
 }


### PR DESCRIPTION
Instead of creating a new RNG instance for every encrypted file IV, use a single static instance.

This should prevent excessive entropy usage and fix issues like https://github.com/godotengine/godot/issues/103392

*Bugsquad edit:*
- Fixes #103392.