### PR TITLE
Allow attaching scripts to nodes in the Advanced Import Settings dialog

### DIFF
--- a/doc/classes/ResourceImporterScene.xml
+++ b/doc/classes/ResourceImporterScene.xml
@@ -80,6 +80,9 @@
 		<member name="nodes/root_scale" type="float" setter="" getter="" default="1.0">
 			The uniform scale to use for the scene root. The default value of [code]1.0[/code] will not perform any rescaling. See [member nodes/apply_root_scale] for details of how this scale is applied.
 		</member>
+		<member name="nodes/root_script" type="Script" setter="" getter="" default="null">
+			If set to a valid script, attaches the script to the root node of the imported scene. If the type of the root node is not compatible with the script, the root node will be replaced with a type that is compatible with the script. This setting can also be used on other non-mesh nodes in the scene to attach scripts to them.
+		</member>
 		<member name="nodes/root_type" type="String" setter="" getter="" default="&quot;&quot;">
 			Override for the root node type. If empty, the root node will use what the scene specifies, or [Node3D] if the scene does not specify a root type. Using a node type that inherits from [Node3D] is recommended. Otherwise, you'll lose the ability to position the node directly in the 3D editor.
 		</member>

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -216,6 +216,7 @@ class ResourceImporterScene : public ResourceImporter {
 	Node *_generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<Vector<uint8_t>> &r_lightmap_caches);
 	void _add_shapes(Node *p_node, const Vector<Ref<Shape3D>> &p_shapes);
 	void _copy_meta(Object *p_src_object, Object *p_dst_object);
+	Node *_replace_node_with_type_and_script(Node *p_node, String p_node_type, Ref<Script> p_script);
 
 	enum AnimationImportTracks {
 		ANIMATION_IMPORT_TRACKS_IF_PRESENT,

--- a/modules/gltf/tests/test_gltf.h
+++ b/modules/gltf/tests/test_gltf.h
@@ -78,6 +78,7 @@ static Node *gltf_import(const String &p_file) {
 	HashMap<StringName, Variant> options(21);
 	options["nodes/root_type"] = "";
 	options["nodes/root_name"] = "";
+	options["nodes/root_script"] = Variant();
 	options["nodes/apply_root_scale"] = true;
 	options["nodes/root_scale"] = 1.0;
 	options["meshes/ensure_tangents"] = true;


### PR DESCRIPTION
The Blender Project DogWalk team has been using scenes with an imported glTF scene as a child node in order to attach scripts to the nodes and save that. This is a good use case for inherited scenes, and the editable children checkbox, but there are currently some issues with those.

Regardless of improving imported scenes, being able to attach scripts to nodes in imported scenes within the import process itself is a highly useful feature. We already allow customizing mesh nodes with common things like physics, but other nodes are missing customizability. For many things like physics, ideally users would use glTF extensions. However, there will always be a need for custom game-specific scripts that do not make sense to store in the glTF at all.

This PR adds the ability to use the Advanced Import Settings dialog to attach scripts to nodes so they are available when directly dragging the glTF into the scene. Here's a video showcasing using this feature. The node type will automatically change to accommodate the script if needed, or will use the user-specified type when possible.

https://github.com/user-attachments/assets/c8c7d735-7f1b-45a9-b95f-ba23c281b7a5

Essentially, for any node type or script that can't be determined in the green circle, this PR allows attaching the script or setting node type in the orange circle, instead of using an inherited scene or other scene to attach the script. Also, in the red part, you can't change the type of an existing node if the script would require a different base Godot node type.

![attach_scripts](https://github.com/user-attachments/assets/8bf18c33-3297-4088-9c88-8751be0d8878)







