### PR TITLE
Allow comparing to project's initial values in ProjectSettings.save_custom()

### DIFF
--- a/core/config/project_settings.compat.inc
+++ b/core/config/project_settings.compat.inc
@@ -1,0 +1,48 @@
+/**************************************************************************/
+/*  project_settings.compat.inc                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "core/object/class_db.h"
+
+void ProjectSettings::set_initial_value_bind_compat_103421(const String &p_name, const Variant &p_value) {
+	set_initial_value(p_name, p_value, false);
+}
+
+Error ProjectSettings::_save_custom_bnd_bind_compat_103421(const String &p_file) {
+	return _save_custom_bnd(p_file, false);
+}
+
+void ProjectSettings::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_initial_value", "name", "value"), &ProjectSettings::set_initial_value_bind_compat_103421);
+	ClassDB::bind_compatibility_method(D_METHOD("save_custom", "file"), &ProjectSettings::_save_custom_bnd_bind_compat_103421);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "project_settings.h"
+#include "project_settings.compat.inc"
 
 #include "core/core_bind.h" // For Compression enum.
 #include "core/input/input_map.h"
@@ -215,11 +216,15 @@ String ProjectSettings::localize_path(const String &p_path) const {
 	}
 }
 
-void ProjectSettings::set_initial_value(const String &p_name, const Variant &p_value) {
+void ProjectSettings::set_initial_value(const String &p_name, const Variant &p_value, bool p_initial_project) {
 	ERR_FAIL_COND_MSG(!props.has(p_name), vformat("Request for nonexistent project setting: '%s'.", p_name));
 
 	// Duplicate so that if value is array or dictionary, changing the setting will not change the stored initial value.
-	props[p_name].initial = p_value.duplicate();
+	if (p_initial_project) {
+		props[p_name].initial_project = p_value.duplicate();
+	} else {
+		props[p_name].initial = p_value.duplicate();
+	}
 }
 
 void ProjectSettings::set_restart_if_changed(const String &p_name, bool p_restart) {
@@ -929,6 +934,9 @@ Error ProjectSettings::_load_settings_binary(const String &p_path) {
 		err = decode_variant(value, d.ptr(), d.size(), nullptr, true);
 		ERR_CONTINUE_MSG(err != OK, vformat("Error decoding property: '%s'.", key));
 		set(key, value);
+		if (p_path.get_file() == "project.binary") {
+			set_initial_value(key, value, true);
+		}
 	}
 
 	return OK;
@@ -978,8 +986,14 @@ Error ProjectSettings::_load_settings_text(const String &p_path) {
 			} else {
 				if (section.is_empty()) {
 					set(assign, value);
+					if (p_path.get_file() == "project.godot") {
+						set_initial_value(assign, value, true);
+					}
 				} else {
 					set(section + "/" + assign, value);
+					if (p_path.get_file() == "project.godot") {
+						set_initial_value(section + "/" + assign, value, true);
+					}
 				}
 			}
 		} else if (!next_tag.name.is_empty()) {
@@ -1186,8 +1200,8 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const RBMap<Str
 	return OK;
 }
 
-Error ProjectSettings::_save_custom_bnd(const String &p_file) { // add other params as dictionary and array?
-	return save_custom(p_file);
+Error ProjectSettings::_save_custom_bnd(const String &p_file, bool p_merge_initial_project) { // add other params as dictionary and array?
+	return save_custom(p_file, CustomMap(), Vector<String>(), true, p_merge_initial_project);
 }
 
 #ifdef TOOLS_ENABLED
@@ -1208,7 +1222,7 @@ bool _csproj_exists(const String &p_root_dir) {
 }
 #endif // TOOLS_ENABLED
 
-Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_custom, const Vector<String> &p_custom_features, bool p_merge_with_current) {
+Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_custom, const Vector<String> &p_custom_features, bool p_merge_with_current, bool p_merge_initial_project) {
 	ERR_FAIL_COND_V_MSG(p_path.is_empty(), ERR_INVALID_PARAMETER, "Project settings save path cannot be empty.");
 
 #ifdef TOOLS_ENABLED
@@ -1260,7 +1274,11 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 			vc.order = v->order;
 			vc.type = v->variant.get_type();
 			vc.flags = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE;
-			if (v->variant == v->initial) {
+			if (p_merge_initial_project && v->initial_project != Variant()) {
+				if (v->variant == v->initial_project) {
+					continue;
+				}
+			} else if (v->variant == v->initial) {
 				continue;
 			}
 
@@ -1619,7 +1637,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_setting_with_override_and_custom_features", "name", "features"), &ProjectSettings::get_setting_with_override_and_custom_features);
 	ClassDB::bind_method(D_METHOD("set_order", "name", "position"), &ProjectSettings::set_order);
 	ClassDB::bind_method(D_METHOD("get_order", "name"), &ProjectSettings::get_order);
-	ClassDB::bind_method(D_METHOD("set_initial_value", "name", "value"), &ProjectSettings::set_initial_value);
+	ClassDB::bind_method(D_METHOD("set_initial_value", "name", "value", "initial_project"), &ProjectSettings::set_initial_value, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("set_as_basic", "name", "basic"), &ProjectSettings::set_as_basic);
 	ClassDB::bind_method(D_METHOD("set_as_internal", "name", "internal"), &ProjectSettings::set_as_internal);
 	ClassDB::bind_method(D_METHOD("add_property_info", "hint"), &ProjectSettings::_add_property_info_bind);
@@ -1630,7 +1648,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
 	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"), &ProjectSettings::load_resource_pack, DEFVAL(true), DEFVAL(0));
 
-	ClassDB::bind_method(D_METHOD("save_custom", "file"), &ProjectSettings::_save_custom_bnd);
+	ClassDB::bind_method(D_METHOD("save_custom", "file", "compare_to_project"), &ProjectSettings::_save_custom_bnd, DEFVAL(false));
 
 	// Change tracking methods
 	ClassDB::bind_method(D_METHOD("get_changed_settings"), &ProjectSettings::get_changed_settings);

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -78,6 +78,7 @@ protected:
 		bool internal = false;
 		Variant variant;
 		Variant initial;
+		Variant initial_project;
 		bool hide_from_editor = false;
 		bool restart_if_changed = false;
 #ifdef DEBUG_ENABLED
@@ -135,7 +136,7 @@ protected:
 	Error _save_settings_text(const String &p_file, const RBMap<String, List<String>> &props, const CustomMap &p_custom = CustomMap(), const String &p_custom_features = String());
 	Error _save_settings_binary(const String &p_file, const RBMap<String, List<String>> &props, const CustomMap &p_custom = CustomMap(), const String &p_custom_features = String());
 
-	Error _save_custom_bnd(const String &p_file);
+	Error _save_custom_bnd(const String &p_file, bool p_merge_initial_project = false);
 
 #ifdef TOOLS_ENABLED
 	const static PackedStringArray _get_supported_features();
@@ -156,6 +157,12 @@ protected:
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	void set_initial_value_bind_compat_103421(const String &p_name, const Variant &p_value);
+	Error _save_custom_bnd_bind_compat_103421(const String &p_path);
+	static void _bind_compatibility_methods();
+#endif
+
 public:
 	static const int CONFIG_VERSION = 5;
 
@@ -174,7 +181,7 @@ public:
 	String localize_path(const String &p_path) const;
 	String globalize_path(const String &p_path) const;
 
-	void set_initial_value(const String &p_name, const Variant &p_value);
+	void set_initial_value(const String &p_name, const Variant &p_value, bool p_initial_project = false);
 	void set_as_basic(const String &p_name, bool p_basic);
 	void set_as_internal(const String &p_name, bool p_internal);
 	void set_restart_if_changed(const String &p_name, bool p_restart);
@@ -198,7 +205,7 @@ public:
 	Error setup(const String &p_path, const String &p_main_pack, bool p_upwards = false, bool p_ignore_override = false);
 
 	Error load_custom(const String &p_path);
-	Error save_custom(const String &p_path = "", const CustomMap &p_custom = CustomMap(), const Vector<String> &p_custom_features = Vector<String>(), bool p_merge_with_current = true);
+	Error save_custom(const String &p_path = "", const CustomMap &p_custom = CustomMap(), const Vector<String> &p_custom_features = Vector<String>(), bool p_merge_with_current = true, bool p_merge_initial_project = false);
 	Error save();
 	void set_custom_property_info(const PropertyInfo &p_info);
 	const HashMap<StringName, PropertyInfo> &get_custom_property_info() const;

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -195,8 +195,10 @@
 		<method name="save_custom">
 			<return type="int" enum="Error" />
 			<param index="0" name="file" type="String" />
+			<param index="1" name="compare_to_project" type="bool" default="false" />
 			<description>
 				Saves the configuration to a custom file. The file extension must be [code].godot[/code] (to save in text-based [ConfigFile] format) or [code].binary[/code] (to save in binary format). You can also save [code]override.cfg[/code] file, which is also text, but can be used in exported projects unlike other formats.
+				[b]Note:[/b] Setting the optional [param compare_to_project] parameter to [code]true[/code] will compare the currently set values against the values loaded from [code]project.godot[/code] or [code]project.binary[/code] instead of the engine's default values when determining if a value should be present in the specified file.
 			</description>
 		</method>
 		<method name="set_as_basic">
@@ -219,6 +221,7 @@
 			<return type="void" />
 			<param index="0" name="name" type="String" />
 			<param index="1" name="value" type="Variant" />
+			<param index="2" name="initial_project" type="bool" default="false" />
 			<description>
 				Sets the specified setting's initial value. This is the value the setting reverts to. The setting should already exist before calling this method. Note that project settings equal to their default value are not saved, so your code needs to account for that.
 				[codeblock]
@@ -234,6 +237,7 @@
 					ProjectSettings.set_initial_value(SETTING_NAME, SETTING_DEFAULT)
 				[/codeblock]
 				If you have a project setting defined by an [EditorPlugin], but want to use it in a running project, you will need a similar code at runtime.
+				[b]Note:[/b] If the optional [param initial_project] parameter is [code]true[/code] the method will set the project's initial value instead of the engine's initial value. The project's initial values are loaded from [code]project.godot[/code] or [code]project.binary[/code] at startup.
 			</description>
 		</method>
 		<method name="set_order">

--- a/misc/extension_api_validation/4.6-stable/GH-103421.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-103421.txt
@@ -1,0 +1,6 @@
+GH-103421
+---------
+Validate extension JSON: Error: Field 'classes/ProjectSettings/methods/save_custom/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/ProjectSettings/methods/set_initial_value/arguments': size changed value in new API, from 2 to 3.
+
+Added argument to save_custom and set_initial_value methods of ProjectSettings to operate on initial values of project instead of initial values of the engine.


### PR DESCRIPTION
Part of improvements to ProjectSettings that I've been using for my own project. This commit adds an initial per-project value for each setting which is set from project.godot or project.binary. It adds an optional parameter to save_custom to compare values against the project defaults instead of engine ones. This would solve https://github.com/godotengine/godot/issues/83494.

<i>Bugsquad edit:</i>
- Fix #83494