### PR TITLE
jolt physics: to_jolt to use get_rotation_quaternion

### DIFF
--- a/modules/jolt_physics/misc/jolt_type_conversions.h
+++ b/modules/jolt_physics/misc/jolt_type_conversions.h
@@ -97,7 +97,7 @@ _FORCE_INLINE_ JPH::Vec3 to_jolt(const Vector3 &p_vec) {
 }
 
 _FORCE_INLINE_ JPH::Quat to_jolt(const Basis &p_basis) {
-	const Quaternion quat = p_basis.get_quaternion().normalized();
+	const Quaternion quat = p_basis.get_rotation_quaternion();
 	return JPH::Quat((float)quat.x, (float)quat.y, (float)quat.z, (float)quat.w);
 }
 

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -551,8 +551,6 @@ void JoltBody3D::set_transform(Transform3D p_transform) {
 		_shapes_changed();
 	}
 
-	p_transform.basis.orthonormalize();
-
 	if (!in_space()) {
 		jolt_settings->mPosition = to_jolt_r(p_transform.origin);
 		jolt_settings->mRotation = to_jolt(p_transform.basis);


### PR DESCRIPTION
The orthanormalized basis transform from set_transform sometimes has a negative determinant, so instead of calling orthonormalize within that routine, it's called within get_rotation_quaternion.

Fixes https://github.com/godotengine/godot/issues/103408