### PR TITLE
Fix autoloaded scene loses their built-in script when upgrading to 4.4

### DIFF
--- a/editor/uid_upgrade_tool.cpp
+++ b/editor/uid_upgrade_tool.cpp
@@ -74,7 +74,7 @@ void UIDUpgradeTool::finish_upgrade() {
 
 	int step = 0;
 	for (const String &file_path : resave_paths) {
-		Ref<Resource> res = ResourceLoader::load(file_path);
+		Ref<Resource> res = ResourceLoader::load(file_path, "", ResourceFormatLoader::CACHE_MODE_REPLACE);
 		ep.step(TTR("Attempting to re-save ") + file_path, step++);
 		if (res.is_valid()) {
 			ResourceSaver::save(res);


### PR DESCRIPTION
- Fixes #103417

I'm not 100% certain why the modifications from #102636 afftected this issue but I think the issue is caused because with the modifications, the Player script in the MVP is now valid at the moment of the upgrade, causing the autoload script (BulletManager) to load while loading the Player script during the upgrade process.

In the `GDScriptCache::get_shallow_script`, the BulletManager script resource (which is an embedded script into the scene) is created but without it's scene unique id.

![Image](https://github.com/user-attachments/assets/8e644477-2142-491b-9a26-3a4a9fe8cd86)

That causes the save of the bullet_manager.tscn to create a new embedded script with a new id when resaving it in the upgrade process.

I fixed the issue by using the `ResourceFormatLoader::CACHE_MODE_REPLACE` cache mode to the `ResourceLoader::load` in `UIDUpgradeTool::finish_upgrade`:
```cpp
Ref<Resource> res = ResourceLoader::load(file_path, "", ResourceFormatLoader::CACHE_MODE_REPLACE);
```

That forces the scene and the script to be reloaded completely from the disk during the upgrade progress.