### PR TITLE
Set editor's translation domain at root node

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6848,8 +6848,6 @@ EditorNode::EditorNode() {
 	DEV_ASSERT(!singleton);
 	singleton = this;
 
-	set_translation_domain("godot.editor");
-
 	Resource::_get_local_scene_func = _resource_get_edited_scene;
 
 	{

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1162,8 +1162,6 @@ void ProjectManager::_titlebar_resized() {
 ProjectManager::ProjectManager(bool p_custom_res) {
 	singleton = this;
 
-	set_translation_domain("godot.editor");
-
 	// Turn off some servers we aren't going to be using in the Project Manager.
 	NavigationServer3D::get_singleton()->set_active(false);
 	PhysicsServer3D::get_singleton()->set_active(false);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4115,6 +4115,7 @@ int Main::start() {
 		if (editor) {
 			OS::get_singleton()->benchmark_begin_measure("Startup", "Editor");
 
+			sml->get_root()->set_translation_domain("godot.editor");
 			if (editor_pseudolocalization) {
 				translation_server->get_editor_domain()->set_pseudolocalization_enabled(true);
 			}
@@ -4312,6 +4313,7 @@ int Main::start() {
 			OS::get_singleton()->benchmark_begin_measure("Startup", "Project Manager");
 			Engine::get_singleton()->set_editor_hint(true);
 
+			sml->get_root()->set_translation_domain("godot.editor");
 			if (editor_pseudolocalization) {
 				translation_server->get_editor_domain()->set_pseudolocalization_enabled(true);
 			}


### PR DESCRIPTION
@KoBeWi [found](https://chat.godotengine.org/channel/editor?msg=WyHwYBGXxsQbxAc7J) that some strings in the save file confirm dialog are not translated (e.g. window title):

![image](https://github.com/user-attachments/assets/906edaa8-92be-46c9-96e5-b4f1a153f745)

This is because the dialog has recently been given the possibility to be reparented to the root node. However, the translation domain of the editor only takes effect on the `EditorNode` node, so auto translation won't work.

https://github.com/godotengine/godot/blob/15ff450680a40391aabbffde0a57ead2cd84db56/editor/editor_node.cpp#L5750-L5754

Changing the translation domain to be set at the root node can also help to resolve other potential similar issues as well.

*Bugsquad edit:* Fixes #103321