### PR TITLE
Restore "Show in File Manager" button functionality in `ProjectManager`

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -68,10 +68,13 @@ void ProjectListItemControl::_notification(int p_what) {
 			project_unsupported_features->set_texture(get_editor_theme_icon(SNAME("NodeWarning")));
 
 			favorite_button->set_texture_normal(get_editor_theme_icon(SNAME("Favorites")));
+
 			if (project_is_missing) {
 				explore_button->set_button_icon(get_editor_theme_icon(SNAME("FileBroken")));
+#if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
 			} else {
 				explore_button->set_button_icon(get_editor_theme_icon(SNAME("Load")));
+#endif
 			}
 		} break;
 
@@ -190,9 +193,6 @@ void ProjectListItemControl::set_is_favorite(bool p_favorite) {
 }
 
 void ProjectListItemControl::set_is_missing(bool p_missing) {
-	if (project_is_missing == p_missing) {
-		return;
-	}
 	project_is_missing = p_missing;
 
 	if (project_is_missing) {
@@ -201,10 +201,8 @@ void ProjectListItemControl::set_is_missing(bool p_missing) {
 		explore_button->set_button_icon(get_editor_theme_icon(SNAME("FileBroken")));
 		explore_button->set_tooltip_text(TTR("Error: Project is missing on the filesystem."));
 	} else {
-		project_icon->set_modulate(Color(1, 1, 1, 1.0));
-
-		explore_button->set_button_icon(get_editor_theme_icon(SNAME("Load")));
 #if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
+		explore_button->set_button_icon(get_editor_theme_icon(SNAME("Load")));
 		explore_button->set_tooltip_text(TTR("Show in File Manager"));
 #else
 		// Opening the system file manager is not supported on the Android and web editors.


### PR DESCRIPTION
- now "Show in File Manager" button is invisible on Android and web(as it should be) when project path is valid.
- tooltip is visible again.

As I see, this is regression from https://github.com/godotengine/godot/pull/74729 which is included into every 4.x release except 4.0.x - setting tooltip and icon (+its visibility) was moved to `set_is_missing()` and `if (project_is_missing == p_missing)` check was added which leads to skipping function for not missing projects.

| Before | After |
| --- | --- |
| ![Godot_v4 4-rc2_win64_cBOv2zsk1Q](https://github.com/user-attachments/assets/0cbba235-9167-4bd8-9a42-f16c5d0b7e31) | ![godot windows editor x86_64_n3jy8riLAa](https://github.com/user-attachments/assets/23a8e02b-b57b-4b14-8f1d-a7c468c2b781) |