### PR TITLE
Validate custom type script before loading it

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3115,6 +3115,7 @@ void SceneTreeDock::_replace_node(Node *p_node, Node *p_by_node, bool p_keep_pro
 		// If we're dealing with a custom node type, we need to create a default instance of the custom type instead of the native type for property comparison.
 		if (oldnode->has_meta(SceneStringName(_custom_type_script))) {
 			Ref<Script> cts = PropertyUtils::get_custom_type_script(oldnode);
+			ERR_FAIL_COND_MSG(cts.is_null(), "Invalid custom type script.");
 			default_oldnode = Object::cast_to<Node>(get_editor_data()->script_class_instance(cts->get_global_name()));
 			if (default_oldnode) {
 				default_oldnode->set_name(cts->get_global_name());

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -306,5 +306,12 @@ Ref<Script> PropertyUtils::get_custom_type_script(const Object *p_object) {
 		return script_object;
 	}
 #endif
+	ResourceUID::ID id = ResourceUID::get_singleton()->text_to_id(custom_script);
+	if (unlikely(id == ResourceUID::INVALID_ID || !ResourceUID::get_singleton()->has_id(id))) {
+		const_cast<Object *>(p_object)->remove_meta(SceneStringName(_custom_type_script));
+		ERR_FAIL_V_MSG(Ref<Script>(), vformat("Invalid custom type script UID: %s. Removing.", custom_script.operator String()));
+	} else {
+		custom_script = ResourceUID::get_singleton()->get_id_path(id);
+	}
 	return ResourceLoader::load(custom_script);
 }


### PR DESCRIPTION
Fixes #103450

In unlikely scenario that the custom type script's UID is invalid, the engine will now remove the meta and return null instead of trying to load it.
As I noted in the issue though, the ResourceLoader shouldn't crash either way, so there might be a deeper issue here.