### PR TITLE
Use `get_file_uid()` where applicable

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2014,7 +2014,7 @@ void FileSystemDock::_before_move(HashMap<String, ResourceUID::ID> &r_uids, Hash
 	for (int i = 0; i < to_move.size(); i++) {
 		if (to_move[i].is_file) {
 			renamed_files.insert(to_move[i].path);
-			ResourceUID::ID uid = ResourceLoader::get_resource_uid(to_move[i].path);
+			ResourceUID::ID uid = EditorFileSystem::get_singleton()->get_file_uid(to_move[i].path);
 			if (uid != ResourceUID::INVALID_ID) {
 				r_uids[to_move[i].path] = uid;
 			}
@@ -2028,7 +2028,7 @@ void FileSystemDock::_before_move(HashMap<String, ResourceUID::ID> &r_uids, Hash
 				for (int j = 0; j < current_folder->get_file_count(); j++) {
 					const String file_path = current_folder->get_file_path(j);
 					renamed_files.insert(file_path);
-					ResourceUID::ID uid = ResourceLoader::get_resource_uid(file_path);
+					ResourceUID::ID uid = EditorFileSystem::get_singleton()->get_file_uid(file_path);
 					if (uid != ResourceUID::INVALID_ID) {
 						r_uids[file_path] = uid;
 					}
@@ -2580,7 +2580,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 
 		case FILE_MENU_COPY_UID: {
 			if (!p_selected.is_empty()) {
-				ResourceUID::ID uid = ResourceLoader::get_resource_uid(p_selected[0]);
+				ResourceUID::ID uid = EditorFileSystem::get_singleton()->get_file_uid(p_selected[0]);
 				if (uid != ResourceUID::INVALID_ID) {
 					String uid_string = ResourceUID::get_singleton()->id_to_text(uid);
 					DisplayServer::get_singleton()->clipboard_set(uid_string);
@@ -3374,7 +3374,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 	if (p_paths.size() == 1) {
 		p_popup->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionCopy")), ED_GET_SHORTCUT("filesystem_dock/copy_path"), FILE_MENU_COPY_PATH);
 		p_popup->add_shortcut(ED_GET_SHORTCUT("filesystem_dock/copy_absolute_path"), FILE_MENU_COPY_ABSOLUTE_PATH);
-		if (ResourceLoader::get_resource_uid(p_paths[0]) != ResourceUID::INVALID_ID) {
+		if (EditorFileSystem::get_singleton()->get_file_uid(p_paths[0]) != ResourceUID::INVALID_ID) {
 			p_popup->add_icon_shortcut(get_editor_theme_icon(SNAME("Instance")), ED_GET_SHORTCUT("filesystem_dock/copy_uid"), FILE_MENU_COPY_UID);
 		}
 		if (root_path_not_selected) {

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -3100,7 +3100,7 @@ Error EditorFileSystem::_copy_file(const String &p_from, const String &p_to) {
 
 		// Make sure it's immediately added to the map so we can remap dependencies if we want to after this.
 		ResourceUID::get_singleton()->add_id(res_uid, p_to);
-	} else if (ResourceLoader::get_resource_uid(p_from) == ResourceUID::INVALID_ID) {
+	} else if (get_file_uid(p_from) == ResourceUID::INVALID_ID) {
 		// Files which do not use an uid can just be copied.
 		Error err = da->copy(p_from, p_to);
 		if (err != OK) {

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -36,6 +36,7 @@
 #include "editor/docks/scene_tree_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
+#include "editor/file_system/editor_file_system.h"
 #include "editor/gui/create_dialog.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_spin_slider.h"
@@ -577,7 +578,7 @@ void EditorPropertyPath::_path_selected(const String &p_path) {
 	String full_path = p_path;
 
 	if (enable_uid) {
-		const ResourceUID::ID id = ResourceLoader::get_resource_uid(full_path);
+		const ResourceUID::ID id = EditorFileSystem::get_singleton()->get_file_uid(full_path);
 		if (id != ResourceUID::INVALID_ID) {
 			full_path = ResourceUID::get_singleton()->id_to_text(id);
 		}

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -979,7 +979,7 @@ void ScriptEditor::_copy_script_uid() {
 	ScriptEditorBase *se = _get_current_editor();
 	if (se) {
 		Ref<Resource> scr = se->get_edited_resource();
-		ResourceUID::ID uid = ResourceLoader::get_resource_uid(scr->get_path());
+		ResourceUID::ID uid = EditorFileSystem::get_singleton()->get_file_uid(scr->get_path());
 		DisplayServer::get_singleton()->clipboard_set(ResourceUID::get_singleton()->id_to_text(uid));
 	}
 }
@@ -1758,7 +1758,7 @@ void ScriptEditor::_prepare_file_menu() {
 
 	menu->set_item_disabled(menu->get_item_index(FILE_MENU_SOFT_RELOAD_TOOL), res.is_null());
 	menu->set_item_disabled(menu->get_item_index(FILE_MENU_COPY_PATH), res.is_null() || res->get_path().is_empty());
-	menu->set_item_disabled(menu->get_item_index(FILE_MENU_COPY_UID), res.is_null() || ResourceLoader::get_resource_uid(res->get_path()) == ResourceUID::INVALID_ID);
+	menu->set_item_disabled(menu->get_item_index(FILE_MENU_COPY_UID), res.is_null() || EditorFileSystem::get_singleton()->get_file_uid(res->get_path()) == ResourceUID::INVALID_ID);
 	menu->set_item_disabled(menu->get_item_index(FILE_MENU_SHOW_IN_FILE_SYSTEM), res.is_null());
 
 	menu->set_item_disabled(menu->get_item_index(FILE_MENU_HISTORY_PREV), history_pos <= 0);
@@ -3524,7 +3524,7 @@ void ScriptEditor::_make_script_list_context_menu() {
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/copy_path"), FILE_MENU_COPY_PATH);
 		context_menu->set_item_disabled(-1, se->get_edited_resource()->get_path().is_empty());
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/copy_uid"), FILE_MENU_COPY_UID);
-		context_menu->set_item_disabled(-1, ResourceLoader::get_resource_uid(se->get_edited_resource()->get_path()) == ResourceUID::INVALID_ID);
+		context_menu->set_item_disabled(-1, EditorFileSystem::get_singleton()->get_file_uid(se->get_edited_resource()->get_path()) == ResourceUID::INVALID_ID);
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/show_in_file_system"), FILE_MENU_SHOW_IN_FILE_SYSTEM);
 		context_menu->add_separator();
 	}


### PR DESCRIPTION
Replaces `get_resource_uid()` with `get_file_uid()` added in #102678 wherever possible.