### PR TITLE
Simplify minimum size of PanelContainer and MarginContainer

### DIFF
--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -33,27 +33,17 @@
 #include "scene/theme/theme_db.h"
 
 Size2 MarginContainer::get_minimum_size() const {
-	Size2 max;
-
+	Size2 ms;
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = as_sortable_control(get_child(i), SortableVisibilityMode::VISIBLE);
-		if (!c) {
-			continue;
-		}
-
-		Size2 s = c->get_combined_minimum_size();
-		if (s.width > max.width) {
-			max.width = s.width;
-		}
-		if (s.height > max.height) {
-			max.height = s.height;
+		if (c) {
+			ms = ms.max(c->get_combined_minimum_size());
 		}
 	}
+	ms.width += theme_cache.margin_left + theme_cache.margin_right;
+	ms.height += theme_cache.margin_top + theme_cache.margin_bottom;
 
-	max.width += (theme_cache.margin_left + theme_cache.margin_right);
-	max.height += (theme_cache.margin_top + theme_cache.margin_bottom);
-
-	return max;
+	return ms;
 }
 
 Vector<int> MarginContainer::get_allowed_size_flags_horizontal() const {

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -36,12 +36,9 @@ Size2 PanelContainer::get_minimum_size() const {
 	Size2 ms;
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = as_sortable_control(get_child(i), SortableVisibilityMode::VISIBLE);
-		if (!c) {
-			continue;
+		if (c) {
+			ms = ms.max(c->get_combined_minimum_size());
 		}
-
-		Size2 minsize = c->get_combined_minimum_size();
-		ms = ms.max(minsize);
 	}
 
 	if (theme_cache.panel_style.is_valid()) {


### PR DESCRIPTION
- Unifies the minimum size code for both classes (they are the same)
- Removes unnecessary Size2