### PR TITLE
RenderingDevice: Validate pre-raster (vertex) shader in `render_pipeline_create`

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -3850,6 +3850,9 @@ RID RenderingDevice::render_pipeline_create(RID p_shader, FramebufferFormatID p_
 	ERR_FAIL_NULL_V(shader, RID());
 	ERR_FAIL_COND_V_MSG(shader->is_compute, RID(), "Compute shaders can't be used in render pipelines");
 
+	// Validate pre-raster shader. One of stages must be vertex shader or mesh shader (not implemented yet).
+	ERR_FAIL_COND_V_MSG(!shader->stage_bits.has_flag(RDD::PIPELINE_STAGE_VERTEX_SHADER_BIT), RID(), "Pre-raster shader (vertex shader) is not provided for pipeline creation.");
+
 	FramebufferFormat fb_format;
 	{
 		_THREAD_SAFE_METHOD_


### PR DESCRIPTION
Fixes #103469.

If the ShaderRD for creating render pipeline does not include vertex shader, it counld crash ( crashes in linux and android in my tests ) and will cause the following errors (`--gpu-validation` enabled) :
```
ERROR: VALIDATION - Message Id Number: -1935553862 | Message Id Name: VUID-VkGraphicsPipelineCreateInfo-pStages-06896
        Validation Error: [ VUID-VkGraphicsPipelineCreateInfo-pStages-06896 ] | MessageID = 0x8ca1caba | vkCreateGraphicsPipelines(): pCreateInfos[0] contains pre-raster state, but stages (VK_SHADER_STAGE_FRAGMENT_BIT) does not contain any pre-raster shaders.
The Vulkan spec states: If the pipeline requires pre-rasterization shader state, all elements of pStages must have a stage set to a shader stage which participates in fragment shader state or pre-rasterization shader state (https://docs.vulkan.org/spec/latest/chapters/pipelines.html#VUID-VkGraphicsPipelineCreateInfo-pStages-06896)
```

According to the vulkan spec, a complete graphics pipeline always includes [pre-rasterization shader state](https://docs.vulkan.org/spec/latest/chapters/pipelines.html#pipelines-graphics-subsets-pre-rasterization) and one of the stages must be [vertex shader or mesh shader](https://docs.vulkan.org/spec/latest/chapters/pipelines.html#VUID-VkGraphicsPipelineCreateInfo-stage-02096). 

This PR adds a check for the vertex shader in `RenderingDevice.render_pipeline_create`, as mesh shader is not implemented yet https://github.com/godotengine/godot-proposals/issues/6822.