### PR TITLE
Move dock initialization to EditorDockManager

### DIFF
--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -799,34 +799,83 @@ void EditorDockManager::set_tab_icon_max_width(int p_max_width) {
 	}
 }
 
-void EditorDockManager::add_vsplit(DockSplitContainer *p_split) {
-	vsplits.push_back(p_split);
-	p_split->connect("dragged", callable_mp(this, &EditorDockManager::_dock_split_dragged));
+void EditorDockManager::initialize_layout(Node *p_main_parent, DockSplitContainer **r_center_split) {
+	ERR_FAIL_NULL(r_center_split);
+
+	DockSplitContainer *left_l_hsplit = _create_split(false, p_main_parent, "DockHSplitLeftL");
+	left_l_hsplit->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+
+	DockSplitContainer *left_l_vsplit = _create_split(true, left_l_hsplit, "DockVSplitLeftL");
+	_create_dock_slot(DOCK_SLOT_LEFT_UL, left_l_vsplit, "DockSlotLeftUL");
+	_create_dock_slot(DOCK_SLOT_LEFT_BL, left_l_vsplit, "DockSlotLeftBL");
+
+	DockSplitContainer *left_r_hsplit = _create_split(false, left_l_hsplit, "DockHSplitLeftR");
+
+	DockSplitContainer *left_r_vsplit = _create_split(true, left_r_hsplit, "DockVSplitLeftR");
+	_create_dock_slot(DOCK_SLOT_LEFT_UR, left_r_vsplit, "DockSlotLeftUR");
+	_create_dock_slot(DOCK_SLOT_LEFT_BR, left_r_vsplit, "DockSlotLeftBR");
+
+	DockSplitContainer *main_hsplit = _create_split(false, left_r_hsplit, "DockHSplitMain");
+	VBoxContainer *center_vb = memnew(VBoxContainer);
+	center_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	main_hsplit->add_child(center_vb);
+
+	DockSplitContainer *center_split = _create_split(true, center_vb, "DockVSplitCenter");
+	center_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	center_split->set_collapsed(false);
+	*r_center_split = center_split;
+
+	DockSplitContainer *right_hsplit = _create_split(false, main_hsplit, "DockHSplitRight");
+
+	DockSplitContainer *right_l_vsplit = _create_split(true, right_hsplit, "DockVSplitRightL");
+	_create_dock_slot(DOCK_SLOT_RIGHT_UL, right_l_vsplit, "DockSlotRightUL");
+	_create_dock_slot(DOCK_SLOT_RIGHT_BL, right_l_vsplit, "DockSlotRightBL");
+
+	DockSplitContainer *right_r_vsplit = _create_split(true, right_hsplit, "DockVSplitRightR");
+	_create_dock_slot(DOCK_SLOT_RIGHT_UR, right_r_vsplit, "DockSlotRightUR");
+	_create_dock_slot(DOCK_SLOT_RIGHT_BR, right_r_vsplit, "DockSlotRightBR");
+
+	// Add some offsets to left_r and main hsplits to make LEFT_R and RIGHT_L docks wider than minsize.
+	left_r_hsplit->set_split_offset(270 * EDSCALE);
+	main_hsplit->set_split_offset(-270 * EDSCALE);
 }
 
-void EditorDockManager::add_hsplit(DockSplitContainer *p_split) {
-	hsplits.push_back(p_split);
-	p_split->connect("dragged", callable_mp(this, &EditorDockManager::_dock_split_dragged));
+DockSplitContainer *EditorDockManager::_create_split(bool p_vertical, Node *p_parent, const String &p_name) {
+	DockSplitContainer *split = memnew(DockSplitContainer);
+	split->set_name(p_name);
+	split->set_vertical(p_vertical);
+	p_parent->add_child(split);
+
+	if (p_vertical) {
+		vsplits.push_back(split);
+	} else {
+		hsplits.push_back(split);
+	}
+	split->connect("dragged", callable_mp(this, &EditorDockManager::_dock_split_dragged));
+	return split;
 }
 
-void EditorDockManager::register_dock_slot(DockSlot p_dock_slot, TabContainer *p_tab_container) {
-	ERR_FAIL_NULL(p_tab_container);
+void EditorDockManager::_create_dock_slot(DockSlot p_dock_slot, Node *p_parent, const String &p_name) {
 	ERR_FAIL_INDEX(p_dock_slot, DOCK_SLOT_MAX);
 
-	dock_slot[p_dock_slot] = p_tab_container;
+	TabContainer *tab_container = memnew(TabContainer);
+	tab_container->set_name(p_name);
+	dock_slot[p_dock_slot] = tab_container;
 
-	p_tab_container->set_custom_minimum_size(Size2(170, 0) * EDSCALE);
-	p_tab_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	p_tab_container->set_popup(dock_context_popup);
-	p_tab_container->connect("pre_popup_pressed", callable_mp(dock_context_popup, &DockContextPopup::select_current_dock_in_dock_slot).bind(p_dock_slot));
-	p_tab_container->set_drag_to_rearrange_enabled(true);
-	p_tab_container->set_tabs_rearrange_group(1);
-	p_tab_container->connect("tab_changed", callable_mp(this, &EditorDockManager::_update_layout).unbind(1));
-	p_tab_container->connect("active_tab_rearranged", callable_mp(this, &EditorDockManager::_update_layout).unbind(1));
-	p_tab_container->connect("child_order_changed", callable_mp(this, &EditorDockManager::_dock_container_update_visibility).bind(p_tab_container));
-	p_tab_container->set_use_hidden_tabs_for_min_size(true);
-	p_tab_container->get_tab_bar()->connect(SceneStringName(gui_input), callable_mp(this, &EditorDockManager::_dock_container_gui_input).bind(p_tab_container));
-	p_tab_container->hide();
+	tab_container->set_custom_minimum_size(Size2(170, 0) * EDSCALE);
+	tab_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tab_container->set_popup(dock_context_popup);
+	tab_container->connect("pre_popup_pressed", callable_mp(dock_context_popup, &DockContextPopup::select_current_dock_in_dock_slot).bind(p_dock_slot));
+	tab_container->set_drag_to_rearrange_enabled(true);
+	tab_container->set_tabs_rearrange_group(1);
+	tab_container->connect("tab_changed", callable_mp(this, &EditorDockManager::_update_layout).unbind(1));
+	tab_container->connect("active_tab_rearranged", callable_mp(this, &EditorDockManager::_update_layout).unbind(1));
+	tab_container->connect("child_order_changed", callable_mp(this, &EditorDockManager::_dock_container_update_visibility).bind(tab_container));
+	tab_container->set_use_hidden_tabs_for_min_size(true);
+	tab_container->get_tab_bar()->connect(SceneStringName(gui_input), callable_mp(this, &EditorDockManager::_dock_container_gui_input).bind(tab_container));
+	tab_container->hide();
+
+	p_parent->add_child(tab_container);
 }
 
 int EditorDockManager::get_vsplit_count() const {

--- a/editor/editor_dock_manager.h
+++ b/editor/editor_dock_manager.h
@@ -107,6 +107,9 @@ private:
 	Vector<Control *> docks_menu_docks;
 	Control *closed_dock_parent = nullptr;
 
+	DockSplitContainer *_create_split(bool p_vertical, Node *p_parent, const String &p_name);
+	void _create_dock_slot(DockSlot p_dock_slot, Node *p_parent, const String &p_name);
+
 	void _dock_split_dragged(int p_offset);
 	void _dock_container_gui_input(const Ref<InputEvent> &p_input, TabContainer *p_dock_container);
 	void _bottom_dock_button_gui_input(const Ref<InputEvent> &p_input, Control *p_dock, Button *p_bottom_button);
@@ -136,9 +139,7 @@ public:
 	void update_tab_styles();
 	void set_tab_icon_max_width(int p_max_width);
 
-	void add_vsplit(DockSplitContainer *p_split);
-	void add_hsplit(DockSplitContainer *p_split);
-	void register_dock_slot(DockSlot p_dock_slot, TabContainer *p_tab_container);
+	void initialize_layout(Node *p_main_parent, DockSplitContainer **r_center_split);
 	int get_vsplit_count() const;
 	PopupMenu *get_docks_menu();
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7154,96 +7154,8 @@ EditorNode::EditorNode() {
 	title_bar = memnew(EditorTitleBar);
 	main_vbox->add_child(title_bar);
 
-	left_l_hsplit = memnew(DockSplitContainer);
-	left_l_hsplit->set_name("DockHSplitLeftL");
-	main_vbox->add_child(left_l_hsplit);
-
-	left_l_hsplit->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-
-	left_l_vsplit = memnew(DockSplitContainer);
-	left_l_vsplit->set_name("DockVSplitLeftL");
-	left_l_vsplit->set_vertical(true);
-	left_l_hsplit->add_child(left_l_vsplit);
-
-	TabContainer *dock_slot[EditorDockManager::DOCK_SLOT_MAX];
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_UL] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_UL]->set_name("DockSlotLeftUL");
-	left_l_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_LEFT_UL]);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_BL] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_BL]->set_name("DockSlotLeftBL");
-	left_l_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_LEFT_BL]);
-
-	left_r_hsplit = memnew(DockSplitContainer);
-	left_r_hsplit->set_name("DockHSplitLeftR");
-	left_l_hsplit->add_child(left_r_hsplit);
-	left_r_vsplit = memnew(DockSplitContainer);
-	left_r_vsplit->set_name("DockVSplitLeftR");
-	left_r_vsplit->set_vertical(true);
-	left_r_hsplit->add_child(left_r_vsplit);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_UR] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_UR]->set_name("DockSlotLeftUR");
-	left_r_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_LEFT_UR]);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_BR] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_BR]->set_name("DockSlotLeftBR");
-	left_r_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_LEFT_BR]);
-
-	main_hsplit = memnew(DockSplitContainer);
-	main_hsplit->set_name("DockHSplitMain");
-	left_r_hsplit->add_child(main_hsplit);
-	VBoxContainer *center_vb = memnew(VBoxContainer);
-	main_hsplit->add_child(center_vb);
-
-	center_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-
-	center_split = memnew(DockSplitContainer);
-	center_split->set_name("DockVSplitCenter");
-	center_split->set_vertical(true);
-	center_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	center_split->set_collapsed(false);
-	center_vb->add_child(center_split);
-
-	right_hsplit = memnew(DockSplitContainer);
-	right_hsplit->set_name("DockHSplitRight");
-	main_hsplit->add_child(right_hsplit);
-
-	right_l_vsplit = memnew(DockSplitContainer);
-	right_l_vsplit->set_name("DockVSplitRightL");
-	right_l_vsplit->set_vertical(true);
-	right_hsplit->add_child(right_l_vsplit);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_UL] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_UL]->set_name("DockSlotRightUL");
-	right_l_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_UL]);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_BL] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_BL]->set_name("DockSlotRightBL");
-	right_l_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_BL]);
-
-	right_r_vsplit = memnew(DockSplitContainer);
-	right_r_vsplit->set_name("DockVSplitRightR");
-	right_r_vsplit->set_vertical(true);
-	right_hsplit->add_child(right_r_vsplit);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_UR] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_UR]->set_name("DockSlotRightUR");
-	right_r_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_UR]);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_BR] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_BR]->set_name("DockSlotRightBR");
-	right_r_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_BR]);
-
 	editor_dock_manager = memnew(EditorDockManager);
-
-	// Save the splits for easier access.
-	editor_dock_manager->add_vsplit(left_l_vsplit);
-	editor_dock_manager->add_vsplit(left_r_vsplit);
-	editor_dock_manager->add_vsplit(right_l_vsplit);
-	editor_dock_manager->add_vsplit(right_r_vsplit);
-
-	editor_dock_manager->add_hsplit(left_l_hsplit);
-	editor_dock_manager->add_hsplit(left_r_hsplit);
-	editor_dock_manager->add_hsplit(main_hsplit);
-	editor_dock_manager->add_hsplit(right_hsplit);
-
-	for (int i = 0; i < EditorDockManager::DOCK_SLOT_MAX; i++) {
-		editor_dock_manager->register_dock_slot((EditorDockManager::DockSlot)i, dock_slot[i]);
-	}
+	editor_dock_manager->initialize_layout(main_vbox, &center_split);
 
 	editor_layout_save_delay_timer = memnew(Timer);
 	add_child(editor_layout_save_delay_timer);
@@ -7700,10 +7612,6 @@ EditorNode::EditorNode() {
 
 	// History: Full height right, behind Node.
 	editor_dock_manager->add_dock(history_dock, TTR("History"), EditorDockManager::DOCK_SLOT_RIGHT_UL, nullptr, "History");
-
-	// Add some offsets to left_r and main hsplits to make LEFT_R and RIGHT_L docks wider than minsize.
-	left_r_hsplit->set_split_offset(270 * EDSCALE);
-	main_hsplit->set_split_offset(-270 * EDSCALE);
 
 	// Define corresponding default layout.
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -285,15 +285,6 @@ private:
 	int renderer_current = 0;
 	String renderer_request;
 
-	// Split containers.
-	DockSplitContainer *left_l_hsplit = nullptr;
-	DockSplitContainer *left_l_vsplit = nullptr;
-	DockSplitContainer *left_r_hsplit = nullptr;
-	DockSplitContainer *left_r_vsplit = nullptr;
-	DockSplitContainer *main_hsplit = nullptr;
-	DockSplitContainer *right_hsplit = nullptr;
-	DockSplitContainer *right_l_vsplit = nullptr;
-	DockSplitContainer *right_r_vsplit = nullptr;
 	DockSplitContainer *center_split = nullptr;
 
 	// Main tabs.


### PR DESCRIPTION
EditorNode was basically initializing EditorDockManager manually using public methods. However the only relevant thing for EditorNode was the base node for docks, everything else can be handled by the manager. The code could as well be moved to the constructor, but since it has a return value, it's cleaner to have a single initialization method.