### PR TITLE
CI: Run `apt install` before installing libxml2-utils, GHA cache got flaky

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -15,6 +15,7 @@ jobs:
 
       - name: Install APT dependencies
         run: |
+          sudo apt update
           sudo apt install -y libxml2-utils
 
       - name: Install Python dependencies and general setup


### PR DESCRIPTION
Should solve this error:
```
Err:2 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libxml2-utils amd64 2.9.14+dfsg-1.3ubuntu3.1
  404  Not Found [IP: 52.252.163.49 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/libx/libxml2/libxml2-utils_2.9.14%2bdfsg-1.3ubuntu3.1_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```