### PR TITLE
Physics Interpolation - Add editor configuration warnings

### DIFF
--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -169,3 +169,13 @@ void PhysicsBody2D::remove_collision_exception_with(Node *p_node) {
 	ERR_FAIL_NULL_MSG(physics_body, "Collision exception only works between two nodes that inherit from PhysicsBody2D.");
 	PhysicsServer2D::get_singleton()->body_remove_collision_exception(get_rid(), physics_body->get_rid());
 }
+
+PackedStringArray PhysicsBody2D::get_configuration_warnings() const {
+	PackedStringArray warnings = CollisionObject2D::get_configuration_warnings();
+
+	if (!is_physics_interpolated()) {
+		warnings.push_back(RTR("PhysicsBody2D will not work correctly on a non-interpolated branch of the SceneTree.\nCheck the node's inherited physics_interpolation_mode."));
+	}
+
+	return warnings;
+}

--- a/scene/2d/physics/physics_body_2d.h
+++ b/scene/2d/physics/physics_body_2d.h
@@ -47,6 +47,8 @@ protected:
 	Ref<KinematicCollision2D> _move(const Vector2 &p_motion, bool p_test_only = false, real_t p_margin = 0.08, bool p_recovery_as_collision = false);
 
 public:
+	PackedStringArray get_configuration_warnings() const override;
+
 	bool move_and_collide(const PhysicsServer2D::MotionParameters &p_parameters, PhysicsServer2D::MotionResult &r_result, bool p_test_only = false, bool p_cancel_sliding = true);
 	bool test_move(const Transform2D &p_from, const Vector2 &p_motion, const Ref<KinematicCollision2D> &r_collision = Ref<KinematicCollision2D>(), real_t p_margin = 0.08, bool p_recovery_as_collision = false);
 	Vector2 get_gravity() const;

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -210,6 +210,16 @@ real_t PhysicsBody3D::get_inverse_mass() const {
 	return 0;
 }
 
+PackedStringArray PhysicsBody3D::get_configuration_warnings() const {
+	PackedStringArray warnings = CollisionObject3D::get_configuration_warnings();
+
+	if (!is_physics_interpolated()) {
+		warnings.push_back(RTR("PhysicsBody3D will not work correctly on a non-interpolated branch of the SceneTree.\nCheck the node's inherited physics_interpolation_mode."));
+	}
+
+	return warnings;
+}
+
 ///////////////////////////////////////
 
 //so, if you pass 45 as limit, avoid numerical precision errors when angle is 45.

--- a/scene/3d/physics/physics_body_3d.h
+++ b/scene/3d/physics/physics_body_3d.h
@@ -49,6 +49,8 @@ protected:
 	Ref<KinematicCollision3D> _move(const Vector3 &p_motion, bool p_test_only = false, real_t p_margin = 0.001, bool p_recovery_as_collision = false, int p_max_collisions = 1);
 
 public:
+	PackedStringArray get_configuration_warnings() const override;
+
 	bool move_and_collide(const PhysicsServer3D::MotionParameters &p_parameters, PhysicsServer3D::MotionResult &r_result, bool p_test_only = false, bool p_cancel_sliding = true);
 	bool test_move(const Transform3D &p_from, const Vector3 &p_motion, const Ref<KinematicCollision3D> &r_collision = Ref<KinematicCollision3D>(), real_t p_margin = 0.001, bool p_recovery_as_collision = false, int p_max_collisions = 1);
 	Vector3 get_gravity() const;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -520,6 +520,8 @@ void Node::_propagate_physics_interpolated(bool p_interpolated) {
 	// Allow a call to the RenderingServer etc. in derived classes.
 	_physics_interpolated_changed();
 
+	update_configuration_warnings();
+
 	data.blocked++;
 	for (KeyValue<StringName, Node *> &K : data.children) {
 		K.value->_propagate_physics_interpolated(p_interpolated);


### PR DESCRIPTION
* For physics bodies that are on non-interpolated branches

4.x version of #103355
Helps address https://github.com/godotengine/godot/issues/103232#issuecomment-2687414358

![non_interp_warning_4](https://github.com/user-attachments/assets/85394632-23d4-439d-8182-2383bd0992b8)

## Notes
* I had not encountered this before, but it may not be obvious to users that physics bodies won't work correctly on non-interpolated branches of the scene tree.
* This is simple to add and warns of the problem, and how to fix it.
* The warning will show even in projects not using physics interpolation, but in most cases users will not have been changing `physics_interpolation_mode` except by accident. There's not a super easy way to check the global interpolation switch in the editor (except via the project setting) as it is hard coded OFF in the editor.
* It is also possible to add some warnings at runtime for this (perhaps if the user switches interpolation mode of a branch at runtime) but seems less likely and can be added in a follow up PR.
* Feel free to suggest changes to the wording / text formatting.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
