### PR TITLE
LineEdit: Fix `caret_force_displayed`

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -252,7 +252,7 @@
 			The caret's column position inside the [LineEdit]. When set, the text may scroll to accommodate it.
 		</member>
 		<member name="caret_force_displayed" type="bool" setter="set_caret_force_displayed" getter="is_caret_force_displayed" default="false">
-			If [code]true[/code], the [LineEdit] will always show the caret, even if focus is lost.
+			If [code]true[/code], the [LineEdit] will always show the caret, even if not editing or focus is lost.
 		</member>
 		<member name="caret_mid_grapheme" type="bool" setter="set_caret_mid_grapheme_enabled" getter="is_caret_mid_grapheme_enabled" default="false">
 			Allow moving caret, selecting and removing the individual composite character components.

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1733,7 +1733,7 @@ void LineEdit::_validate_caret_can_draw() {
 		draw_caret = true;
 		caret_blink_timer = 0.0;
 	}
-	caret_can_draw = editing && (window_has_focus || (menu && menu->has_focus())) && (has_focus() || caret_force_displayed);
+	caret_can_draw = (caret_force_displayed && !is_part_of_edited_scene()) || (editing && (window_has_focus || (menu && menu->has_focus())) && has_focus());
 }
 
 void LineEdit::delete_char() {


### PR DESCRIPTION
After #87674 `caret_force_displayed` would only take effect when LineEdit is being edited, but not focused, which means never 🤷‍♂️
This PR makes it really force the caret, and as a bonus it won't draw inside editor like it used to (it only causes unnecessary redraws).

Fixes #103427

Note that, since the caret will draw when LineEdit is not editing, it can cause confusing behavior where the LineEdit "won't take input" until you press Enter to enter edit mode, which doesn't have visible difference. Maybe caret should display a bit differently in this state? E.g. with less alpha.