### PR TITLE
Possibly fix deadlock in WorkerThreadPool when updating shaders

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1959,11 +1959,17 @@ void BaseMaterial3D::_check_material_rid() {
 }
 
 void BaseMaterial3D::flush_changes() {
-	MutexLock lock(material_mutex);
-
-	while (dirty_materials.first()) {
-		dirty_materials.first()->self()->_update_shader();
-		dirty_materials.first()->remove_from_list();
+	List<BaseMaterial3D *> shaders_to_update;
+	{
+		MutexLock lock(material_mutex);
+		while (dirty_materials.first()) {
+			shaders_to_update.push_back(dirty_materials.first()->self());
+			dirty_materials.first()->remove_from_list();
+		}
+	}
+	while (!shaders_to_update.is_empty()) {
+		shaders_to_update.front()->get()->_update_shader();
+		shaders_to_update.pop_front();
 	}
 }
 


### PR DESCRIPTION
I've been digging into recently reported deadlocks and/or massive slowdowns in the TPS demo when loading the game.

Several stack traces showing evidence of deadlocks were shared, but the deadlock pattern seem to be different in each case. I'm not able to say with confidence yet whether those different patterns are symptoms of the same root cause :
- @bruvzg's https://github.com/godotengine/godot/issues/102812#issuecomment-2676378276 : the freeze seem to involve `SceneShaderForwardClustered::singleton_mutex`. Hangs when progress bar shows 100%
- @huwpascoe's https://github.com/godotengine/godot/issues/102877#issuecomment-2692469643 : the freeze seem to involve `BaseMaterial3D::material_mutex;`. Hands when progress bar shows 75%
- I was able to get my own stack trace (https://gist.github.com/Flarkk/9184eff43180f84bb0d2b6d8c9529479) which is very similar to @huwpascoe's : freeze involving `BaseMaterial3D::material_mutex;` when progress bar shows 75%.

I believe I've managed to eliminate the deadlock involving `BaseMaterial3D::material_mutex` by moving the call to BaseMaterial3D::_update_shader() outside the lock scope. I assume this is safe, though I'm not entirely sure which resources the mutex is meant to protect.

I can't confidently say yet whether the freeze disappeared as a side effect of reduced stalling in `WorkerThreadPool` or if this actually addresses the root cause.

Nonetheless, I wanted to share this so others can take a look, test it, and provide further insights.

Related to #102877, #102812