### PR TITLE
Support compiling without `MovieWriter`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -220,6 +220,7 @@ opts.Add("vsproj_name", "Name of the Visual Studio solution", "godot")
 opts.Add("import_env_vars", "A comma-separated list of environment variables to copy from the outer environment.", "")
 opts.Add(BoolVariable("disable_3d", "Disable 3D nodes for a smaller executable", False))
 opts.Add(BoolVariable("disable_advanced_gui", "Disable advanced GUI nodes and behaviors", False))
+opts.Add(BoolVariable("disable_movie_writer", "Disable the movie writer feature", False))
 opts.Add("build_profile", "Path to a file containing a feature build profile", "")
 opts.Add(BoolVariable("modules_enabled_by_default", "If no, disable all modules except ones explicitly enabled", True))
 opts.Add(BoolVariable("no_editor_splash", "Don't use the custom splash screen for the editor", True))
@@ -1003,6 +1004,8 @@ if env["disable_advanced_gui"]:
         Exit(255)
     else:
         env.Append(CPPDEFINES=["ADVANCED_GUI_DISABLED"])
+if env["disable_movie_writer"]:
+    env.Append(CPPDEFINES=["MOVIE_WRITER_DISABLED"])
 if env["minizip"]:
     env.Append(CPPDEFINES=["MINIZIP_ENABLED"])
 if env["brotli"]:

--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -385,6 +385,7 @@ void Engine::get_singletons(List<Singleton> *p_singletons) {
 	}
 }
 
+#ifndef MOVIE_WRITER_DISABLED
 String Engine::get_write_movie_path() const {
 	return write_movie_path;
 }
@@ -392,6 +393,7 @@ String Engine::get_write_movie_path() const {
 void Engine::set_write_movie_path(const String &p_path) {
 	write_movie_path = p_path;
 }
+#endif // MOVIE_WRITER_DISABLED
 
 void Engine::set_shader_cache_path(const String &p_path) {
 	shader_cache_path = p_path;

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -93,7 +93,9 @@ private:
 
 	static Engine *singleton;
 
+#ifndef MOVIE_WRITER_DISABLED
 	String write_movie_path;
+#endif // MOVIE_WRITER_DISABLED
 	String shader_cache_path;
 
 	static constexpr int SERVER_SYNC_FRAME_COUNT_WARNING = 5;
@@ -187,8 +189,10 @@ public:
 	Dictionary get_license_info() const;
 	String get_license_text() const;
 
+#ifndef MOVIE_WRITER_DISABLED
 	void set_write_movie_path(const String &p_path);
 	String get_write_movie_path() const;
+#endif // MOVIE_WRITER_DISABLED
 
 	String get_architecture_name() const;
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -752,7 +752,9 @@ void OS::_bind_methods() {
 	BIND_ENUM_CONSTANT(SYSTEM_DIR_DCIM);
 	BIND_ENUM_CONSTANT(SYSTEM_DIR_DOCUMENTS);
 	BIND_ENUM_CONSTANT(SYSTEM_DIR_DOWNLOADS);
+#ifndef MOVIE_WRITER_DISABLED
 	BIND_ENUM_CONSTANT(SYSTEM_DIR_MOVIES);
+#endif // MOVIE_WRITER_DISABLED
 	BIND_ENUM_CONSTANT(SYSTEM_DIR_MUSIC);
 	BIND_ENUM_CONSTANT(SYSTEM_DIR_PICTURES);
 	BIND_ENUM_CONSTANT(SYSTEM_DIR_RINGTONES);
@@ -1910,9 +1912,11 @@ bool Engine::is_embedded_in_editor() const {
 	return ::Engine::get_singleton()->is_embedded_in_editor();
 }
 
+#ifndef MOVIE_WRITER_DISABLED
 String Engine::get_write_movie_path() const {
 	return ::Engine::get_singleton()->get_write_movie_path();
 }
+#endif // MOVIE_WRITER_DISABLED
 
 void Engine::set_print_to_stdout(bool p_enabled) {
 	::Engine::get_singleton()->set_print_to_stdout(p_enabled);
@@ -1989,7 +1993,9 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_editor_hint"), &Engine::is_editor_hint);
 	ClassDB::bind_method(D_METHOD("is_embedded_in_editor"), &Engine::is_embedded_in_editor);
 
+#ifndef MOVIE_WRITER_DISABLED
 	ClassDB::bind_method(D_METHOD("get_write_movie_path"), &Engine::get_write_movie_path);
+#endif // MOVIE_WRITER_DISABLED
 
 	ClassDB::bind_method(D_METHOD("set_print_to_stdout", "enabled"), &Engine::set_print_to_stdout);
 	ClassDB::bind_method(D_METHOD("is_printing_to_stdout"), &Engine::is_printing_to_stdout);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -586,8 +586,10 @@ public:
 
 	bool is_embedded_in_editor() const;
 
+#ifndef MOVIE_WRITER_DISABLED
 	// `set_write_movie_path()` is not exposed to the scripting API as changing it at run-time has no effect.
 	String get_write_movie_path() const;
+#endif // MOVIE_WRITER_DISABLED
 
 	void set_print_to_stdout(bool p_enabled);
 	bool is_printing_to_stdout() const;

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -442,9 +442,11 @@ bool OS::has_feature(const String &p_feature) {
 		return true;
 	}
 
+#ifndef MOVIE_WRITER_DISABLED
 	if (p_feature == "movie") {
 		return _writing_movie;
 	}
+#endif // MOVIE_WRITER_DISABLED
 
 #ifdef DEBUG_ENABLED
 	if (p_feature == "debug") {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -60,7 +60,9 @@ class OS {
 	bool _allow_layered = false;
 	bool _stdout_enabled = true;
 	bool _stderr_enabled = true;
+#ifndef MOVIE_WRITER_DISABLED
 	bool _writing_movie = false;
+#endif // MOVIE_WRITER_DISABLED
 	bool _in_editor = false;
 	bool _embedded_in_editor = false;
 

--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -33,7 +33,7 @@
 #include "editor/debugger/debug_adapter/debug_adapter_types.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
-#include "editor/export/editor_export_platform.h"
+#include "editor/export/editor_export.h"
 #include "editor/gui/editor_run_bar.h"
 #include "editor/plugins/script_editor_plugin.h"
 

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -297,10 +297,12 @@ void EditorDebuggerNode::stop(bool p_force) {
 		server->stop();
 		EditorNode::get_log()->add_message("--- Debugging process stopped ---", EditorLog::MSG_TYPE_EDITOR);
 
+#ifndef MOVIE_WRITER_DISABLED
 		if (EditorRunBar::get_singleton()->is_movie_maker_enabled()) {
 			// Request attention in case the user was doing something else when movie recording is finished.
 			DisplayServer::get_singleton()->window_request_attention();
 		}
+#endif // MOVIE_WRITER_DISABLED
 
 		server.unref();
 	}

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -58,6 +58,7 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/control.h"
 #include "scene/main/window.h"
+#include "scene/resources/image_texture.h"
 #include "scene/resources/theme.h"
 
 EditorInterface *EditorInterface::singleton = nullptr;
@@ -728,6 +729,7 @@ String EditorInterface::get_playing_scene() const {
 	return EditorRunBar::get_singleton()->get_playing_scene();
 }
 
+#ifndef MOVIE_WRITER_DISABLED
 void EditorInterface::set_movie_maker_enabled(bool p_enabled) {
 	EditorRunBar::get_singleton()->set_movie_maker_enabled(p_enabled);
 }
@@ -735,6 +737,7 @@ void EditorInterface::set_movie_maker_enabled(bool p_enabled) {
 bool EditorInterface::is_movie_maker_enabled() const {
 	return EditorRunBar::get_singleton()->is_movie_maker_enabled();
 }
+#endif // MOVIE_WRITER_DISABLED
 
 #ifdef TOOLS_ENABLED
 void EditorInterface::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
@@ -847,10 +850,12 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_playing_scene"), &EditorInterface::is_playing_scene);
 	ClassDB::bind_method(D_METHOD("get_playing_scene"), &EditorInterface::get_playing_scene);
 
+#ifndef MOVIE_WRITER_DISABLED
 	ClassDB::bind_method(D_METHOD("set_movie_maker_enabled", "enabled"), &EditorInterface::set_movie_maker_enabled);
 	ClassDB::bind_method(D_METHOD("is_movie_maker_enabled"), &EditorInterface::is_movie_maker_enabled);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "movie_maker_enabled"), "set_movie_maker_enabled", "is_movie_maker_enabled");
+#endif // MOVIE_WRITER_DISABLED
 }
 
 void EditorInterface::create() {

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -187,8 +187,10 @@ public:
 	bool is_playing_scene() const;
 	String get_playing_scene() const;
 
+#ifndef MOVIE_WRITER_DISABLED
 	void set_movie_maker_enabled(bool p_enabled);
 	bool is_movie_maker_enabled() const;
+#endif // MOVIE_WRITER_DISABLED
 
 #ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -94,6 +94,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 		args.push_back("--debug-canvas-item-redraw");
 	}
 
+#ifndef MOVIE_WRITER_DISABLED
 	if (p_write_movie != "") {
 		args.push_back("--write-movie");
 		args.push_back(p_write_movie);
@@ -103,6 +104,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 			args.push_back("--disable-vsync");
 		}
 	}
+#endif // MOVIE_WRITER_DISABLED
 
 	WindowPlacement window_placement = get_window_placement();
 	if (window_placement.position != Point2i(INT_MAX, INT_MAX)) {

--- a/editor/gui/editor_run_bar.h
+++ b/editor/gui/editor_run_bar.h
@@ -32,7 +32,6 @@
 #define EDITOR_RUN_BAR_H
 
 #include "editor/editor_run.h"
-#include "editor/export/editor_export.h"
 #include "scene/gui/margin_container.h"
 
 class Button;
@@ -40,6 +39,7 @@ class EditorRunNative;
 class PanelContainer;
 class HBoxContainer;
 class AcceptDialog;
+class EditorExportPreset;
 
 class EditorRunBar : public MarginContainer {
 	GDCLASS(EditorRunBar, MarginContainer);
@@ -73,8 +73,10 @@ class EditorRunBar : public MarginContainer {
 	EditorRun editor_run;
 	EditorRunNative *run_native = nullptr;
 
+#ifndef MOVIE_WRITER_DISABLED
 	PanelContainer *write_movie_panel = nullptr;
 	Button *write_movie_button = nullptr;
+#endif // MOVIE_WRITER_DISABLED
 
 	RunMode current_mode = RunMode::STOPPED;
 	String run_custom_filename;
@@ -83,7 +85,9 @@ class EditorRunBar : public MarginContainer {
 	void _reset_play_buttons();
 	void _update_play_buttons();
 
+#ifndef MOVIE_WRITER_DISABLED
 	void _write_movie_toggled(bool p_enabled);
+#endif // MOVIE_WRITER_DISABLED
 	void _quick_run_selected(const String &p_file_path, int p_id = -1);
 
 	void _play_current_pressed(int p_id = -1);
@@ -121,8 +125,10 @@ public:
 	void stop_child_process(OS::ProcessID p_pid);
 	OS::ProcessID get_current_process() const;
 
+#ifndef MOVIE_WRITER_DISABLED
 	void set_movie_maker_enabled(bool p_enabled);
 	bool is_movie_maker_enabled() const;
+#endif // MOVIE_WRITER_DISABLED
 
 	void update_profiler_autostart_indicator();
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -40,7 +40,9 @@
 #include "editor/export/editor_export.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/check_button.h"
+#ifndef MOVIE_WRITER_DISABLED
 #include "servers/movie_writer/movie_writer.h"
+#endif // MOVIE_WRITER_DISABLED
 
 ProjectSettingsEditor *ProjectSettingsEditor::singleton = nullptr;
 
@@ -781,5 +783,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	import_defaults_editor->set_name(TTR("Import Defaults"));
 	tab_container->add_child(import_defaults_editor);
 
+#ifndef MOVIE_WRITER_DISABLED
 	MovieWriter::set_extensions_hint(); // ensure extensions are properly displayed.
+#endif // MOVIE_WRITER_DISABLED
 }

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1953,6 +1953,7 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		style_launch_pad_recovery_mode->set_border_width_all(Math::round(2 * EDSCALE));
 		p_theme->set_stylebox("LaunchPadRecoveryMode", EditorStringName(EditorStyles), style_launch_pad_recovery_mode);
 
+#ifndef MOVIE_WRITER_DISABLED
 		p_theme->set_stylebox("MovieWriterButtonNormal", EditorStringName(EditorStyles), make_empty_stylebox(0, 0, 0, 0));
 		Ref<StyleBoxFlat> style_write_movie_button = p_config.button_style_pressed->duplicate();
 		style_write_movie_button->set_bg_color(p_config.accent_color);
@@ -1969,6 +1970,7 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		p_theme->set_color("movie_writer_icon_pressed", EditorStringName(EditorStyles), Color(0, 0, 0, 0.84));
 		p_theme->set_color("movie_writer_icon_hover", EditorStringName(EditorStyles), Color(1, 1, 1, 0.9));
 		p_theme->set_color("movie_writer_icon_hover_pressed", EditorStringName(EditorStyles), Color(0, 0, 0, 0.84));
+#endif // MOVIE_WRITER_DISABLED
 
 		// Profiler autostart indicator panel.
 		Ref<StyleBoxFlat> style_profiler_autostart = style_launch_pad->duplicate();

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -21,10 +21,12 @@ SConscript("camera/SCsub")
 SConscript("debugger/SCsub")
 SConscript("display/SCsub")
 SConscript("extensions/SCsub")
-SConscript("movie_writer/SCsub")
 SConscript("navigation/SCsub")
 SConscript("rendering/SCsub")
 SConscript("text/SCsub")
+
+if not env["disable_movie_writer"]:
+    SConscript("movie_writer/SCsub")
 
 if not env["disable_3d"]:
     env.add_source_files(env.servers_sources, "physics_server_3d.cpp")

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -59,9 +59,11 @@
 #include "debugger/servers_debugger.h"
 #include "display/native_menu.h"
 #include "display_server.h"
+#ifndef MOVIE_WRITER_DISABLED
 #include "movie_writer/movie_writer.h"
 #include "movie_writer/movie_writer_mjpeg.h"
 #include "movie_writer/movie_writer_pngwav.h"
+#endif // MOVIE_WRITER_DISABLED
 #include "rendering/renderer_rd/framebuffer_cache_rd.h"
 #include "rendering/renderer_rd/storage_rd/render_data_rd.h"
 #include "rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h"
@@ -123,8 +125,10 @@ static bool has_server_feature_callback(const String &p_feature) {
 	return false;
 }
 
+#ifndef MOVIE_WRITER_DISABLED
 static MovieWriterMJPEG *writer_mjpeg = nullptr;
 static MovieWriterPNGWAV *writer_pngwav = nullptr;
+#endif // MOVIE_WRITER_DISABLED
 
 void register_server_types() {
 	OS::get_singleton()->benchmark_begin_measure("Servers", "Register Extensions");
@@ -244,7 +248,9 @@ void register_server_types() {
 
 	GDREGISTER_CLASS(CameraFeed);
 
+#ifndef MOVIE_WRITER_DISABLED
 	GDREGISTER_VIRTUAL_CLASS(MovieWriter);
+#endif // MOVIE_WRITER_DISABLED
 
 	ServersDebugger::initialize();
 
@@ -324,11 +330,13 @@ void register_server_types() {
 	GDREGISTER_CLASS(NavigationPathQueryParameters3D);
 	GDREGISTER_CLASS(NavigationPathQueryResult3D);
 
+#ifndef MOVIE_WRITER_DISABLED
 	writer_mjpeg = memnew(MovieWriterMJPEG);
 	MovieWriter::add_writer(writer_mjpeg);
 
 	writer_pngwav = memnew(MovieWriterPNGWAV);
 	MovieWriter::add_writer(writer_pngwav);
+#endif // MOVIE_WRITER_DISABLED
 
 	OS::get_singleton()->benchmark_end_measure("Servers", "Register Extensions");
 }
@@ -338,8 +346,10 @@ void unregister_server_types() {
 
 	ServersDebugger::deinitialize();
 	memdelete(shader_types);
+#ifndef MOVIE_WRITER_DISABLED
 	memdelete(writer_mjpeg);
 	memdelete(writer_pngwav);
+#endif // MOVIE_WRITER_DISABLED
 
 	OS::get_singleton()->benchmark_end_measure("Servers", "Unregister Extensions");
 }


### PR DESCRIPTION
@Calinou suggested that I took a look at making compilation of the `MovieWriter` feature optional, and so I did! Compiling the engine without it frees up a whopping... 0.05 MB. But hey, it's still something at least. 🫠

Comparison using `p=linuxbsd target=template_release production=yes`:
|Default|No `MovieWriter`|
|-|-|
|69.659.512 KB|69.606.264 KB|

**Sponsored By:** 🐺 Lone Wolf Technology / 🍀 W4 Games.