### PR TITLE
CI: Use correct godot-cpp branch

### DIFF
--- a/.github/actions/godot-cpp-build/action.yml
+++ b/.github/actions/godot-cpp-build/action.yml
@@ -1,9 +1,6 @@
 name: Build godot-cpp
 description: Build godot-cpp with the provided options.
 
-env:
-  GODOT_CPP_BRANCH: 4.4
-
 inputs:
   bin:
     description: Path to the Godot binary.
@@ -16,6 +13,10 @@ inputs:
     description: The SCons cache path.
     default: ${{ github.workspace }}/.scons_cache/
     type: string
+  godot-cpp-branch:
+    description: The godot-cpp branch.
+    default: master
+    type: string
 
 runs:
   using: composite
@@ -25,7 +26,7 @@ runs:
       with:
         submodules: recursive
         repository: godotengine/godot-cpp
-        ref: ${{ env.GODOT_CPP_BRANCH }}
+        ref: ${{ inputs.godot-cpp-branch }}
         path: godot-cpp
 
     - name: Extract API

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -6,6 +6,7 @@ on:
 env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
+  GODOT_CPP_BRANCH: 4.4
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes strict_checks=yes
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -174,6 +175,7 @@ jobs:
         with:
           bin: ${{ matrix.bin }}
           scons-flags: target=template_debug dev_build=yes verbose=yes
+          godot-cpp-branch: ${{ env.GODOT_CPP_BRANCH }}
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save


### PR DESCRIPTION
Currently, it seems like CI using the `master` branch of godot-cpp, rather than the one we have configured.

Let's see if this works!