### PR TITLE
CI: Bump SCons to latest (4.8.1 → 4.9.0)

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: x64
   scons-version:
     description: The SCons version to use.
-    default: 4.8.1
+    default: 4.9.0
 
 runs:
   using: composite


### PR DESCRIPTION
Changelog: https://scons.org/scons-490-is-available.html