### PR TITLE
Android: Fix build with `disable_3d`

### DIFF
--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -49,6 +49,7 @@
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "main/main.h"
+#include "servers/rendering_server.h"
 
 #ifndef _3D_DISABLED
 #include "servers/xr_server.h"


### PR DESCRIPTION
Fixes #103516.

Haven't tested yet, but this should fix it. It was included by way of `xr_server.h` in 3D builds, so missing when 3D/XR are disabled.

*Edit:* Tested, this fixes the build.