### PR TITLE
X11: Fix check for `is_maximized` to require both horizontal and vertical

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2563,7 +2563,8 @@ bool DisplayServerX11::_window_maximize_check(WindowID p_window, const char *p_a
 		Atom *atoms = (Atom *)data;
 		Atom wm_act_max_horz;
 		Atom wm_act_max_vert;
-		if (strcmp(p_atom_name, "_NET_WM_STATE") == 0) {
+		bool checking_state = strcmp(p_atom_name, "_NET_WM_STATE") == 0;
+		if (checking_state) {
 			wm_act_max_horz = XInternAtom(x11_display, "_NET_WM_STATE_MAXIMIZED_HORZ", False);
 			wm_act_max_vert = XInternAtom(x11_display, "_NET_WM_STATE_MAXIMIZED_VERT", False);
 		} else {
@@ -2581,9 +2582,16 @@ bool DisplayServerX11::_window_maximize_check(WindowID p_window, const char *p_a
 				found_wm_act_max_vert = true;
 			}
 
-			if (found_wm_act_max_horz || found_wm_act_max_vert) {
-				retval = true;
-				break;
+			if (checking_state) {
+				if (found_wm_act_max_horz && found_wm_act_max_vert) {
+					retval = true;
+					break;
+				}
+			} else {
+				if (found_wm_act_max_horz || found_wm_act_max_vert) {
+					retval = true;
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
Persistent window state doesn't work if your window is 'tiled' in X11 gnome (snapped/docked left or right)

3.x checks for `horz && vert`
https://github.com/godotengine/godot/blob/4396e98834f159da59ec790f2ff64fb65dacd9ce/platform/x11/os_x11.cpp#L1708

4.x also checked `horz && vert` until this change where it was switched to `horz || vert`
https://github.com/godotengine/godot/commit/524f061c015b8070de73381bf6b7932514de79de#diff-05f85bc3bf96d384f6b96260c758e63e10bbdd52b04f8ccb34649372e7bc1f48R1382

The corrected logic is:
Check `horz && vert` for 'is_maximized'
Check `horz || vert` for 'can_maximize'

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
