### PR TITLE
Validate triviality of InstanceData struct in Mobile and Forward+ renderers

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -328,6 +328,9 @@ private:
 			float uv_scale[4];
 		};
 
+		static_assert(std::is_trivially_destructible_v<InstanceData>);
+		static_assert(std::is_trivially_constructible_v<InstanceData>);
+
 		UBO ubo;
 
 		LocalVector<RID> uniform_buffers;
@@ -391,6 +394,9 @@ private:
 		uint32_t uses_forward_gi : 1;
 		uint32_t lod_index : 8;
 	};
+
+	static_assert(std::is_trivially_destructible_v<RenderElementInfo>);
+	static_assert(std::is_trivially_constructible_v<RenderElementInfo>);
 
 	template <PassMode p_pass_mode, uint32_t p_color_pass_flags = 0>
 	_FORCE_INLINE_ void _render_list_template(RenderingDevice::DrawListID p_draw_list, RenderingDevice::FramebufferFormatID p_framebuffer_Format, RenderListParameters *p_params, uint32_t p_from_element, uint32_t p_to_element);

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -211,7 +211,7 @@ private:
 			uint32_t flags;
 			uint32_t instance_uniforms_ofs; // Base offset in global buffer for instance variables.
 			uint32_t gi_offset; // GI information when using lightmapping (VCT or lightmap index).
-			uint32_t layer_mask = 1;
+			uint32_t layer_mask;
 			float lightmap_uv_scale[4]; // Doubles as uv_offset when needed.
 			uint32_t reflection_probes[2]; // Packed reflection probes.
 			uint32_t omni_lights[2]; // Packed omni lights.
@@ -221,6 +221,9 @@ private:
 			float compressed_aabb_size[4];
 			float uv_scale[4];
 		};
+
+		static_assert(std::is_trivially_destructible_v<InstanceData>);
+		static_assert(std::is_trivially_constructible_v<InstanceData>);
 
 		RID instance_buffer[RENDER_LIST_MAX];
 		uint32_t instance_buffer_size[RENDER_LIST_MAX] = { 0, 0, 0 };
@@ -326,6 +329,9 @@ private:
 		uint32_t lod_index : 8;
 		uint32_t reserved : 23;
 	};
+
+	static_assert(std::is_trivially_destructible_v<RenderElementInfo>);
+	static_assert(std::is_trivially_constructible_v<RenderElementInfo>);
 
 	template <PassMode p_pass_mode>
 	_FORCE_INLINE_ void _render_list_template(RenderingDevice::DrawListID p_draw_list, RenderingDevice::FramebufferFormatID p_framebuffer_Format, RenderListParameters *p_params, uint32_t p_from_element, uint32_t p_to_element);


### PR DESCRIPTION
While discussing performance with @darksylinc I noticed that we have this bit of code that runs several times per frame: 

https://github.com/godotengine/godot/blob/9f68a816599412c56a4626dd6c47244ebc65ed1f/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp#L1838-L1839

This is called for every light in the scene (1-4 times per directional light, and 2 or 6 times per omnilight). The resize therefore is guaranteed to shrink the array once (and call a bunch of destructors) and increase the size of the array several times. In the typically case the overall size won't actual change much between frames. 

Importantly, `resize()` doesn't free memory, so after a couple of frames this stabilizes and no longer allocates memory. However, it still risks calling constructors and destructors if the memory type is not trivially constructable/destructable. 

https://github.com/godotengine/godot/blob/9f68a816599412c56a4626dd6c47244ebc65ed1f/core/templates/local_vector.h#L151-L172

I added the static asserts locally to check and surprise! `InstanceData` in the Mobile renderer was not trivially constructable! Therefore the constructor was being called for almost every element every frame unnecessarily. This PR fixes that and leaves the static asserts in so we don't accidentally make it non-trivially constructable again. 

CC @Ivorforce who might be interested