### PR TITLE
Fix shadow acne when DirectionalLight3D Shadow Blur is set to a value near `0.0`

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -712,7 +712,8 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 
 						Projection shadow_mtx = rectm * bias * matrix * modelview;
 						light_data.shadow_split_offsets[j] = split;
-						float bias_scale = light_instance->shadow_transform[j].bias_scale * light_data.soft_shadow_scale;
+						// Ensure the bias scale multiplier isn't too close to zero, as it can cause shadow acne.
+						float bias_scale = light_instance->shadow_transform[j].bias_scale * MAX(0.05, light_data.soft_shadow_scale);
 						light_data.shadow_bias[j] = light->param[RS::LIGHT_PARAM_SHADOW_BIAS] / 100.0 * bias_scale;
 						light_data.shadow_normal_bias[j] = light->param[RS::LIGHT_PARAM_SHADOW_NORMAL_BIAS] * light_instance->shadow_transform[j].shadow_texel_size;
 						light_data.shadow_transmittance_bias[j] = light->param[RS::LIGHT_PARAM_TRANSMITTANCE_BIAS] / 100.0 * bias_scale;


### PR DESCRIPTION
This clamps the bias adjustments to a minimum of `0.05`, so that blur values lower than `0.05` won't cause shadow acne. I've empirically found that values like `0.01` and `0.02` still exhibit acne at some angles, while `0.05` is free of acne at any angle I could test.

I couldn't find where SpotLight3D bias is adjusted according to blur, so I didn't fix that issue though. The testing project includes an invisible SpotLight3D if you want to help investigate this.

- This closes https://github.com/godotengine/godot/issues/103165.
- See https://github.com/godotengine/godot/pull/68339 where the bias adjustment was originally added.

**Testing project:** [test_shadow_bias_blur.zip](https://github.com/user-attachments/files/19061937/test_shadow_bias_blur.zip)

## Preview

Before | After
-|-
![Screenshot_20250304_005004](https://github.com/user-attachments/assets/57d5fc1e-caa0-48c6-8e2a-68828144309d) | ![Screenshot_20250304_005020](https://github.com/user-attachments/assets/4dcf8506-c4df-423c-95ce-a286ca073951)

