### PR TITLE
GDScript: More helpful error message when calling `new()` on an invalid GDScript

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -208,12 +208,9 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 Variant GDScript::_new(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	/* STEP 1, CREATE */
 
-	if (!valid) {
-		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
-		return Variant();
-	}
-
 	r_error.error = Callable::CallError::CALL_OK;
+	ERR_FAIL_COND_V_MSG(!valid, Variant(), "Can't instantiate an invalid GDScript.");
+
 	Ref<RefCounted> ref;
 	Object *owner = nullptr;
 


### PR DESCRIPTION
fixes https://github.com/godotengine/godot/issues/96065

when instantiating an invalid GDScript, instead of using `CALL_ERROR_INVALID_METHOD`, just print an error. so it doesn't seem like the method is strangely missing.
changes the error from:
`Invalid call. Nonexistent function 'new' in base 'GDScript'.`
to
`ERROR: Can't instantiate an invalid GDScript.`
