### PR TITLE
Add custom camera scale to rendering server

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -173,6 +173,14 @@
 				Sets camera to use perspective projection. Objects on the screen becomes smaller when they are far away.
 			</description>
 		</method>
+		<method name="camera_set_scale" experimental="This will be replaced by a more general camera method in future.">
+			<return type="void" />
+			<param index="0" name="camera" type="RID" />
+			<param index="1" name="scale" type="Vector2" />
+			<description>
+				Set camera scale, modifying aspect ratio.
+			</description>
+		</method>
 		<method name="camera_set_transform">
 			<return type="void" />
 			<param index="0" name="camera" type="RID" />

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -106,6 +106,15 @@ void RendererSceneCull::camera_set_frustum(RID p_camera, float p_size, Vector2 p
 	camera->zfar = p_z_far;
 }
 
+void RendererSceneCull::camera_set_scale(RID p_camera, Vector2 p_scale) {
+	Camera *camera = camera_owner.get_or_null(p_camera);
+	ERR_FAIL_NULL(camera);
+	ERR_FAIL_COND(p_scale.is_zero_approx());
+	ERR_FAIL_COND(p_scale.x < 0.0 || p_scale.y < 0.0);
+	camera->scale = p_scale;
+	camera->use_scale = (p_scale != Vector2(1.0, 1.0));
+}
+
 void RendererSceneCull::camera_set_transform(RID p_camera, const Transform3D &p_transform) {
 	Camera *camera = camera_owner.get_or_null(p_camera);
 	ERR_FAIL_NULL(camera);
@@ -2654,7 +2663,10 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 				is_frustum = true;
 			} break;
 		}
-
+		if (camera->use_scale) {
+			projection.columns[0][0] *= camera->scale.x;
+			projection.columns[1][1] *= camera->scale.y;
+		}
 		camera_data.set_camera(transform, projection, is_orthogonal, is_frustum, vaspect, jitter, taa_frame_count, camera->visible_layers);
 #ifndef XR_DISABLED
 	} else {

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -81,12 +81,15 @@ public:
 		float znear, zfar;
 		float size;
 		Vector2 offset;
+		Vector2 scale = Vector2(1.0, 1.0);
 		uint32_t visible_layers;
 		bool vaspect;
+		bool use_scale = false;
 		RID env;
 		RID attributes;
 		RID compositor;
 
+		Projection projection;
 		Transform3D transform;
 
 		Camera() {
@@ -109,6 +112,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far);
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far);
+	virtual void camera_set_scale(RID p_camera, Vector2 p_scale);
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform);
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers);
 	virtual void camera_set_environment(RID p_camera, RID p_env);

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -49,6 +49,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_scale(RID p_camera, Vector2 p_scale) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -672,6 +672,7 @@ public:
 	FUNC4(camera_set_perspective, RID, float, float, float)
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC5(camera_set_frustum, RID, float, Vector2, float, float)
+	FUNC2(camera_set_scale, RID, Vector2)
 	FUNC2(camera_set_transform, RID, const Transform3D &)
 	FUNC2(camera_set_cull_mask, RID, uint32_t)
 	FUNC2(camera_set_environment, RID, RID)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2811,6 +2811,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("camera_set_perspective", "camera", "fovy_degrees", "z_near", "z_far"), &RenderingServer::camera_set_perspective);
 	ClassDB::bind_method(D_METHOD("camera_set_orthogonal", "camera", "size", "z_near", "z_far"), &RenderingServer::camera_set_orthogonal);
 	ClassDB::bind_method(D_METHOD("camera_set_frustum", "camera", "size", "offset", "z_near", "z_far"), &RenderingServer::camera_set_frustum);
+	ClassDB::bind_method(D_METHOD("camera_set_scale", "camera", "scale"), &RenderingServer::camera_set_scale);
 	ClassDB::bind_method(D_METHOD("camera_set_transform", "camera", "transform"), &RenderingServer::camera_set_transform);
 	ClassDB::bind_method(D_METHOD("camera_set_cull_mask", "camera", "layers"), &RenderingServer::camera_set_cull_mask);
 	ClassDB::bind_method(D_METHOD("camera_set_environment", "camera", "env"), &RenderingServer::camera_set_environment);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -913,6 +913,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_scale(RID p_camera, Vector2 p_scale) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;


### PR DESCRIPTION
Partially Implement https://github.com/godotengine/godot-proposals/issues/2713, https://github.com/godotengine/godot-proposals/issues/11436

Effectively allows the user to override the aspect ratio.

Example usage:
```gdscript
extends Camera3D

func _ready() -> void:
	# set oblique projection (camera should be rotated -45 degrees x axis)
	RenderingServer.camera_set_scale(get_camera_rid(), Vector2(1.0, sqrt(2.0))
```

- *Production Edit: This closes https://github.com/godotengine/godot-proposals/issues/1250.*