### PR TITLE
Add space for BBCode Ordered Lists

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -254,7 +254,7 @@ String RichTextLabel::_get_prefix(Item *p_item, const Vector<int> &p_list_index,
 		}
 		prefix = segment + prefix;
 	}
-	return prefix;
+	return prefix + " ";
 }
 
 void RichTextLabel::_update_line_font(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size) {


### PR DESCRIPTION
For both [ol] and [ul] now there is the space by default
Fixes #103433 

<img width="633" alt="Captura de ecrã 2025-03-04 163806" src="https://github.com/user-attachments/assets/9a8dfee9-3513-445b-b1cc-d0bb482185ca" />


The absence of a space that would seperate the number and text was due to the prefix not having the space  " " , by adding it at the end of the return of the prefix should fix it.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
