### PR TITLE
Fix BBCode list parsing issue with invalid tags

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4448,9 +4448,6 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 			if (tag_stack.front()->get() == "i") {
 				in_italics = false;
 			}
-			if ((tag_stack.front()->get() == "indent") || (tag_stack.front()->get() == "ol") || (tag_stack.front()->get() == "ul")) {
-				current_frame->indent_level--;
-			}
 
 			if (!tag_ok) {
 				txt += "[" + tag;
@@ -4459,6 +4456,10 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 				after_list_close_tag = false;
 				pos = brk_end;
 				continue;
+			}
+
+			if ((tag_stack.front()->get() == "indent") || (tag_stack.front()->get() == "ol") || (tag_stack.front()->get() == "ul")) {
+				current_frame->indent_level--;
 			}
 
 			if (txt.is_empty() && after_list_open_tag) {


### PR DESCRIPTION
This fix ensures that invalid tags do not interfere with list functionality in Godot 4.4stable and 4.5 dev.
![fix](https://github.com/user-attachments/assets/ae8f4066-8a62-4535-8dff-8643cf8d96d6)

Previously, when adding an invalid tag like [/wqeqweq12] or a longer string in invalid tag between [ul] and [/ul] or other list function inside brackets would break the list rendering completely, and you had to restart the Godot, now the invalid tag won´t make that error again.