### PR TITLE
Make NavigationLink3D properly update on visibility change

### DIFF
--- a/scene/3d/navigation_link_3d.cpp
+++ b/scene/3d/navigation_link_3d.cpp
@@ -262,6 +262,12 @@ void NavigationLink3D::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			_link_exit_navigation_map();
 		} break;
+
+#ifdef DEBUG_ENABLED
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			_update_debug_mesh();
+		} break;
+#endif // DEBUG_ENABLED
 	}
 }
 


### PR DESCRIPTION
Fixes #103500.

Tested this by following the same steps on my branch as on 4.4-stable. The issue seems to be fixed, the debug rendering is visible now.