### PR TITLE
Implement a conversion plugin to bake noise textures

### DIFF
--- a/doc/classes/EditorResourceConversionPlugin.xml
+++ b/doc/classes/EditorResourceConversionPlugin.xml
@@ -32,7 +32,7 @@
 			<param index="0" name="resource" type="Resource" />
 			<description>
 				Takes an input [Resource] and converts it to the type given in [method _converts_to]. The returned [Resource] is the result of the conversion, and the input [Resource] remains unchanged.
-				Returns [code]null[/code] if the plugin only supports asynchrnous conversions using [method _convert_async].
+				Returns [code]null[/code] if the plugin only supports asynchronous conversions using [method _convert_async].
 			</description>
 		</method>
 		<method name="_convert_async" qualifiers="virtual const">
@@ -40,7 +40,7 @@
 			<param index="0" name="resource" type="Resource" />
 			<param index="1" name="on_complete" type="Callable" />
 			<description>
-				Takes an input [Resource] and asynchronously converts it to the type given in [method _converts_to]. When the conversion is complete, [code]on_complete[/code] is called with the resulting [Resource].
+				Takes an input [Resource] and asynchronously converts it to the type given in [method _converts_to]. When the conversion is complete, [param on_complete] is called with the resulting [Resource].
 				Returns [code]null[/code] if the plugin only supports normal conversions using [method _convert].
 			</description>
 		</method>

--- a/doc/classes/EditorResourceConversionPlugin.xml
+++ b/doc/classes/EditorResourceConversionPlugin.xml
@@ -32,6 +32,16 @@
 			<param index="0" name="resource" type="Resource" />
 			<description>
 				Takes an input [Resource] and converts it to the type given in [method _converts_to]. The returned [Resource] is the result of the conversion, and the input [Resource] remains unchanged.
+				Returns [code]null[/code] if the plugin only supports asynchrnous conversions using [method _convert_async].
+			</description>
+		</method>
+		<method name="_convert_async" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="resource" type="Resource" />
+			<param index="1" name="on_complete" type="Callable" />
+			<description>
+				Takes an input [Resource] and asynchronously converts it to the type given in [method _converts_to]. When the conversion is complete, [code]on_complete[/code] is called with the resulting [Resource].
+				Returns [code]null[/code] if the plugin only supports normal conversions using [method _convert].
 			</description>
 		</method>
 		<method name="_converts_to" qualifiers="virtual const">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -148,6 +148,7 @@
 #include "editor/plugins/material_editor_plugin.h"
 #include "editor/plugins/mesh_library_editor_plugin.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
+#include "editor/plugins/noise_texture_conversion_plugin.h"
 #include "editor/plugins/packed_scene_translation_parser_plugin.h"
 #include "editor/plugins/particle_process_material_editor_plugin.h"
 #include "editor/plugins/plugin_config_dialog.h"
@@ -8220,6 +8221,10 @@ EditorNode::EditorNode() {
 		Ref<VisualShaderConversionPlugin> vshader_convert;
 		vshader_convert.instantiate();
 		resource_conversion_plugins.push_back(vshader_convert);
+
+		Ref<NoiseTextureConversionPlugin> noise_tex_convert;
+		noise_tex_convert.instantiate();
+		resource_conversion_plugins.push_back(noise_tex_convert);
 	}
 
 	update_spinner_step_msec = OS::get_singleton()->get_ticks_msec();

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -314,6 +314,11 @@ void EditorResourcePicker::_update_menu_items() {
 	}
 }
 
+void EditorResourcePicker::_edit_convert_resource_complete(Ref<Resource> p_new_resource) {
+	edited_resource = p_new_resource;
+	_resource_changed();
+}
+
 void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 	switch (p_which) {
 		case OBJ_MENU_LOAD: {
@@ -461,8 +466,15 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 				Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin_for_resource(edited_resource);
 				ERR_FAIL_INDEX(to_type, conversions.size());
 
-				edited_resource = conversions[to_type]->convert(edited_resource);
-				_resource_changed();
+				Ref<Resource> converted_resource = conversions[to_type]->convert(edited_resource);
+				if (!converted_resource.is_null()) {
+					edited_resource = converted_resource;
+					_resource_changed();
+				} else {
+					Callable convert_callback = callable_mp(this, &EditorResourcePicker::_edit_convert_resource_complete);
+					conversions[to_type]->convert_async(edited_resource, convert_callback);
+				}
+
 				break;
 			}
 

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -94,6 +94,7 @@ class EditorResourcePicker : public HBoxContainer {
 
 	void _update_menu();
 	void _update_menu_items();
+	void _edit_convert_resource_complete(Ref<Resource> p_new_resource);
 	void _edit_menu_cbk(int p_which);
 
 	void _button_draw();

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1855,6 +1855,15 @@ void FileSystemDock::_overwrite_dialog_action(bool p_overwrite) {
 	_move_operation_confirm(to_move_path, to_move_or_copy, p_overwrite ? OVERWRITE_REPLACE : OVERWRITE_RENAME);
 }
 
+void FileSystemDock::_convert_async_cbk(Ref<Resource> p_new_res, Ref<Resource> p_old_res) {
+	EditorNode::get_singleton()->replace_resources_in_scenes({ p_old_res }, { p_new_res });
+
+	const String old_res_path = p_old_res->get_path();
+	const String rmpath = OS::get_singleton()->get_resource_dir() + old_res_path.replace_first("res://", "/");
+	OS::get_singleton()->move_to_trash(rmpath);
+	EditorFileSystem::get_singleton()->update_file(old_res_path);
+}
+
 void FileSystemDock::_convert_dialog_action() {
 	Vector<Ref<Resource>> selected_resources;
 	for (const String &S : to_convert) {
@@ -1871,11 +1880,17 @@ void FileSystemDock::_convert_dialog_action() {
 			int conversion_id = 0;
 			for (const String &target : cached_valid_conversion_targets) {
 				if (conversion_id == selected_conversion_id && conversion->converts_to() == target) {
-					Ref<Resource> converted_res = conversion->convert(res);
 					ERR_FAIL_COND(res.is_null());
-					converted_resources.push_back(converted_res);
-					resources_to_erase_history_for.insert(res);
-					break;
+					Ref<Resource> converted_res = conversion->convert(res);
+					if (!converted_res.is_null()) {
+						converted_resources.push_back(converted_res);
+						resources_to_erase_history_for.insert(res);
+						break;
+					} else {
+						Callable cbk = callable_mp(this, &FileSystemDock::_convert_async_cbk).bind(res);
+						conversion->convert_async(res, cbk);
+						break;
+					}
 				}
 				conversion_id++;
 			}

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -293,6 +293,7 @@ private:
 	void _rename_operation_confirm();
 	void _duplicate_operation_confirm(const String &p_path);
 	void _overwrite_dialog_action(bool p_overwrite);
+	void _convert_async_cbk(Ref<Resource> p_old_res, Ref<Resource> p_new_res);
 	void _convert_dialog_action();
 	Vector<String> _check_existing();
 	void _move_operation_confirm(const String &p_to_path, bool p_copy = false, Overwrite p_overwrite = OVERWRITE_UNDECIDED);

--- a/editor/plugins/editor_resource_conversion_plugin.cpp
+++ b/editor/plugins/editor_resource_conversion_plugin.cpp
@@ -34,6 +34,7 @@ void EditorResourceConversionPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_converts_to);
 	GDVIRTUAL_BIND(_handles, "resource");
 	GDVIRTUAL_BIND(_convert, "resource");
+	GDVIRTUAL_BIND(_convert_async, "resource", "on_complete");
 }
 
 String EditorResourceConversionPlugin::converts_to() const {
@@ -51,5 +52,11 @@ bool EditorResourceConversionPlugin::handles(const Ref<Resource> &p_resource) co
 Ref<Resource> EditorResourceConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<Resource> ret;
 	GDVIRTUAL_CALL(_convert, p_resource, ret);
+	return ret;
+}
+
+bool EditorResourceConversionPlugin::convert_async(const Ref<Resource> &p_resource, const Callable &p_on_complete) {
+	bool ret = false;
+	GDVIRTUAL_CALL(_convert_async, p_resource, p_on_complete, ret);
 	return ret;
 }

--- a/editor/plugins/noise_texture_conversion_plugin.cpp
+++ b/editor/plugins/noise_texture_conversion_plugin.cpp
@@ -1,0 +1,212 @@
+/**************************************************************************/
+/*  noise_texture_conversion_plugin.cpp                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "noise_texture_conversion_plugin.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/resource_importer.h"
+#include "editor/editor_file_system.h"
+#include "editor/editor_string_names.h"
+#include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_validation_panel.h"
+#include "editor/themes/editor_scale.h"
+#include "modules/noise/noise_texture_2d.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/grid_container.h"
+#include "scene/gui/line_edit.h"
+#include "scene/resources/image_texture.h"
+
+String NoiseTextureConversionPlugin::converts_to() const {
+	return "CompressedTexture2D";
+}
+
+bool NoiseTextureConversionPlugin::handles(const Ref<Resource> &p_resource) const {
+	Ref<NoiseTexture2D> mat = p_resource;
+	return mat.is_valid();
+}
+
+void ConvertTextureDialog::_check_file_path() {
+	validation_panel->set_message(MSG_ID_INFO_0, TTR("The image data from the resource will be saved as a PNG to the path specified."), EditorValidationPanel::MSG_INFO);
+	validation_panel->set_message(MSG_ID_INFO_1, TTR("The new image will be imported as a CompressedTexture2D which will replace the original resource."), EditorValidationPanel::MSG_INFO);
+
+	String file_path_text = file_path->get_text().strip_edges();
+	if (file_path_text.is_empty()) {
+		validation_panel->set_message(MSG_ID_PATH, TTR("Image path is empty."), EditorValidationPanel::MSG_ERROR);
+		return;
+	} else if (file_path_text.get_file().get_basename().is_empty()) {
+		validation_panel->set_message(MSG_ID_PATH, TTR("Image file name is empty."), EditorValidationPanel::MSG_ERROR);
+		return;
+	} else if (!file_path_text.get_file().get_basename().is_valid_filename()) {
+		validation_panel->set_message(MSG_ID_PATH, TTR("Image file name is invalid."), EditorValidationPanel::MSG_ERROR);
+		return;
+	}
+	file_path_text = ProjectSettings::get_singleton()->localize_path(file_path_text);
+	if (!file_path_text.begins_with("res://")) {
+		validation_panel->set_message(MSG_ID_PATH, TTR("Path is not local."), EditorValidationPanel::MSG_ERROR);
+	} else {
+		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		if (da->dir_exists(file_path_text) || da->file_exists(file_path_text)) {
+			validation_panel->set_message(MSG_ID_PATH, TTR("A file or directory with the same name exists."), EditorValidationPanel::MSG_ERROR);
+		}
+		if (!da->dir_exists(file_path_text.get_base_dir())) {
+			validation_panel->set_message(MSG_ID_PATH, TTR("Parent directory does not exist."), EditorValidationPanel::MSG_ERROR);
+		}
+	}
+}
+
+void ConvertTextureDialog::_browse_path_selected(String selected_path) {
+	file_path->set_text(selected_path);
+	validation_panel->update();
+}
+
+void ConvertTextureDialog::_browse_path() {
+	file_browse->set_current_path(file_path->get_text());
+	file_browse->popup_file_dialog();
+}
+
+ConvertTextureDialog::ConvertTextureDialog() {
+	GridContainer *gc = memnew(GridContainer);
+	gc->set_columns(2);
+
+	validation_panel = memnew(EditorValidationPanel);
+	validation_panel->add_line(MSG_ID_PATH, TTR("Image path/name is valid."));
+	validation_panel->add_line(MSG_ID_INFO_0);
+	validation_panel->add_line(MSG_ID_INFO_1);
+	validation_panel->set_update_callback(callable_mp(this, &ConvertTextureDialog::_check_file_path));
+	validation_panel->set_accept_button(get_ok_button());
+	validation_panel->update();
+
+	VBoxContainer *vb = memnew(VBoxContainer);
+	vb->add_child(gc);
+	vb->add_child(validation_panel);
+	add_child(vb);
+
+	HBoxContainer *hb = memnew(HBoxContainer);
+	file_path = memnew(LineEdit);
+	file_path->connect(SceneStringName(text_changed), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
+	file_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	hb->add_child(file_path);
+	hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	register_text_enter(file_path);
+	path_button = memnew(Button);
+
+	path_button->connect(SceneStringName(pressed), callable_mp(this, &ConvertTextureDialog::_browse_path));
+	hb->add_child(path_button);
+	Label *label = memnew(Label(TTR("New Image Path:")));
+	gc->add_child(label);
+	gc->add_child(hb);
+
+	gc->set_custom_minimum_size(Size2(650, 0) * EDSCALE);
+	set_title(TTR("Convert to CompressedTexture2D"));
+
+	file_browse = memnew(EditorFileDialog);
+	file_browse->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
+	// We don't want to allow overwriting, but that gets handled in the main dialog.
+	file_browse->set_disable_overwrite_warning(true);
+	file_browse->set_filters({ "*.png" });
+	file_browse->connect(SNAME("file_selected"), callable_mp(this, &ConvertTextureDialog::_browse_path_selected));
+	add_child(file_browse);
+}
+
+ConvertTextureDialog *NoiseTextureConversionPlugin::create_confirmation_dialog() {
+	dialog = memnew(ConvertTextureDialog);
+	dialog->connect(SceneStringName(confirmed), callable_mp(this, &NoiseTextureConversionPlugin::_confirm_conversion));
+	return dialog;
+}
+
+void ConvertTextureDialog::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			path_button->set_button_icon(get_editor_theme_icon(SNAME("Folder")));
+		} break;
+	}
+}
+
+void ConvertTextureDialog::config(const Ref<Resource> &p_resource) {
+	resource = p_resource;
+	file_path->set_text(resource->get_path().get_basename() + ".png");
+}
+
+void NoiseTextureConversionPlugin::_confirm_conversion() {
+	Ref<NoiseTexture2D> noise_tex = resource;
+	if (noise_tex.is_null()) {
+		callback.call(Ref<Resource>({}));
+		return;
+	}
+
+	auto base_image = noise_tex->get_image();
+	base_image->save_png(dialog->get_file_path());
+	base_image->notify_property_list_changed();
+	pending_updates.append({ callback, dialog->get_file_path() });
+	EditorFileSystem::get_singleton()->scan_changes();
+
+	return;
+}
+
+void NoiseTextureConversionPlugin::_on_filesystem_updated() {
+	// Keep track of resource updates that haven't completed yet.
+	Vector<PendingResourceUpdate> remaining_updates;
+
+	for (PendingResourceUpdate &update : pending_updates) {
+		Ref<Resource> new_img = ResourceLoader::load(dialog->get_file_path(), "image");
+		if (new_img.is_null()) {
+			remaining_updates.push_back(update);
+		} else {
+			update.cb.call(new_img);
+		}
+	}
+	pending_updates = remaining_updates;
+	if (pending_updates.size() == 0) {
+		EditorFileSystem::get_singleton()->disconnect(SNAME("filesystem_changed"),
+				callable_mp(this, &NoiseTextureConversionPlugin::_on_filesystem_updated));
+	}
+}
+
+bool NoiseTextureConversionPlugin::convert_async(const Ref<Resource> &p_resource, const Callable &p_on_complete) {
+	resource = p_resource;
+	callback = p_on_complete;
+	EditorNode::get_singleton()->add_child(create_confirmation_dialog());
+	dialog->popup_centered();
+	dialog->config(p_resource);
+
+	// The callback may already be set by an in-flight conversion.
+	Callable cb = callable_mp(this, &NoiseTextureConversionPlugin::_on_filesystem_updated);
+	if (!EditorFileSystem::get_singleton()->is_connected(SNAME("filesystem_changed"), cb)) {
+		EditorFileSystem::get_singleton()->connect(SNAME("filesystem_changed"), cb);
+	}
+
+	return true;
+}
+
+Ref<Resource> NoiseTextureConversionPlugin::convert(const Ref<Resource> &p_resource) const {
+	// Synchronous conversions not supported.
+	return nullptr;
+}

--- a/editor/plugins/noise_texture_conversion_plugin.h
+++ b/editor/plugins/noise_texture_conversion_plugin.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_resource_conversion_plugin.h                                   */
+/*  noise_texture_conversion_plugin.h                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,25 +28,72 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#ifndef NOISE_TEXTURE_CONVERSION_PLUGIN_H
+#define NOISE_TEXTURE_CONVERSION_PLUGIN_H
 
-#include "core/io/resource.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "editor/editor_node.h"
+#include "editor/plugins/editor_resource_conversion_plugin.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/line_edit.h"
 
-class EditorResourceConversionPlugin : public RefCounted {
-	GDCLASS(EditorResourceConversionPlugin, RefCounted);
+class ConvertTextureDialog;
+class EditorValidationPanel;
+class LineEdit;
 
-protected:
-	static void _bind_methods();
+class NoiseTextureConversionPlugin : public EditorResourceConversionPlugin {
+	GDCLASS(NoiseTextureConversionPlugin, EditorResourceConversionPlugin);
 
-	GDVIRTUAL0RC(String, _converts_to)
-	GDVIRTUAL1RC(bool, _handles, Ref<Resource>)
-	GDVIRTUAL1RC(Ref<Resource>, _convert, Ref<Resource>)
-	GDVIRTUAL2RC(bool, _convert_async, Ref<Resource>, Callable)
+	struct PendingResourceUpdate {
+		Callable cb;
+		String fpath;
+	};
 
 public:
-	virtual String converts_to() const;
-	virtual bool handles(const Ref<Resource> &p_resource) const;
-	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const;
-	virtual bool convert_async(const Ref<Resource> &p_resource, const Callable &p_on_complete);
+	virtual String converts_to() const override;
+	virtual bool handles(const Ref<Resource> &p_resource) const override;
+	Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
+	bool convert_async(const Ref<Resource> &p_resource, const Callable &p_on_complete) override;
+	ConvertTextureDialog *create_confirmation_dialog();
+
+private:
+	void _confirm_conversion();
+	void _on_filesystem_updated();
+	ConvertTextureDialog *dialog;
+	Callable callback;
+	Ref<Resource> resource;
+	Vector<PendingResourceUpdate> pending_updates;
 };
+
+class ConvertTextureDialog : public ConfirmationDialog {
+	GDCLASS(ConvertTextureDialog, ConfirmationDialog);
+
+	enum {
+		MSG_ID_PATH,
+		MSG_ID_INFO_0,
+		MSG_ID_INFO_1
+	};
+
+	Ref<Resource> resource = nullptr;
+	EditorValidationPanel *validation_panel = nullptr;
+	EditorFileDialog *file_browse = nullptr;
+	LineEdit *file_path;
+	Button *path_button;
+	CheckBox *preserve_mipmap = nullptr;
+
+public:
+	ConvertTextureDialog();
+	String get_file_path() const { return file_path->get_text(); }
+
+	void config(const Ref<Resource> &p_resource);
+
+protected:
+	void _notification(int p_what);
+
+private:
+	void _browse_path();
+	void _browse_path_selected(String selected_path);
+	void _check_file_path();
+};
+
+#endif // NOISE_TEXTURE_CONVERSION_PLUGIN_H

--- a/editor/plugins/noise_texture_conversion_plugin.h
+++ b/editor/plugins/noise_texture_conversion_plugin.h
@@ -70,6 +70,7 @@ class ConvertTextureDialog : public ConfirmationDialog {
 
 	enum {
 		MSG_ID_PATH,
+		MSG_ID_EMPTY,
 		MSG_ID_INFO_0,
 		MSG_ID_INFO_1
 	};
@@ -77,9 +78,9 @@ class ConvertTextureDialog : public ConfirmationDialog {
 	Ref<Resource> resource = nullptr;
 	EditorValidationPanel *validation_panel = nullptr;
 	EditorFileDialog *file_browse = nullptr;
-	LineEdit *file_path;
-	Button *path_button;
-	CheckBox *preserve_mipmap = nullptr;
+	LineEdit *file_path = nullptr;
+	Button *path_button = nullptr;
+	CheckBox *checkbox_overwrite = nullptr;
 
 public:
 	ConvertTextureDialog();
@@ -93,7 +94,8 @@ protected:
 private:
 	void _browse_path();
 	void _browse_path_selected(String selected_path);
-	void _check_file_path();
+	void _overwrite_button_pressed();
+	void _check_path_and_content();
 };
 
 #endif // NOISE_TEXTURE_CONVERSION_PLUGIN_H

--- a/editor/plugins/noise_texture_conversion_plugin.h
+++ b/editor/plugins/noise_texture_conversion_plugin.h
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef NOISE_TEXTURE_CONVERSION_PLUGIN_H
-#define NOISE_TEXTURE_CONVERSION_PLUGIN_H
+#pragma once
 
 #include "editor/editor_node.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
@@ -97,5 +96,3 @@ private:
 	void _overwrite_button_pressed();
 	void _check_path_and_content();
 };
-
-#endif // NOISE_TEXTURE_CONVERSION_PLUGIN_H


### PR DESCRIPTION
### Overview
Implements a conversion plugin that allows NoiseTexture2D resources to be converted to WebP or PNG files and reimported as CompressedTexture2D.

The motivating use case for this is using a high-resolution noise texture that does not need to be altered after being initially configured - e.g. driving a wave effect in a shader. NoiseTexture2Ds are regenerated when the scene is loaded, and can take many seconds at high resolutions, which can be really annoying when trying to iterate quickly during development, or adversely impact load times in finished projects.

In my own use cases I rarely need to modify a noise texture after setting it up, and if that is required it's still simple enough to recreate it. I assume this is true of many users.

This is my first PR so please excuse me if I missed something obvious!

### Implementation
The existing conversion plugin design does not allow interactivity - conversions are performed immediately and cannot prompt the user for input. This PR also adds the necessary plumbing for asynchronous conversions. Plugins can optionally implement the `convert_async` function which calls a callback when the conversion is complete.

The new `NoiseTextureConversionPlugin` implements this. It opens a dialog to allow the user to select the save location of the new file.

### Alternative implementations
I considered 3 possible implementations of async conversions:
* Add a new `EditorResourceAsyncConversionPlugin` in addition to the existing `EditorResourceConversionPlugin`. Because the interface is different it would require doubling up all the places conversion plugins are currently plumbed in (the filesystem dock, the resource picker, the `find_resource_conversion_plugin` functions etc) with an async version of each.
* Modify the existing `EditorResourceConversionPlugin` to always support asynchronous conversions. `EditorResourceConversionPlugin::convert` would always take a callback, and the existing non-async plugins could just call it immediately.
* Add `convert_async` to the existing `EditorResourceConversionPlugin`, which may return null when the plugin doesn't support async conversions. Likewise, plugins could return null for `convert` if they don't support normal conversions. This way users can try an async conversion if a normal conversion fails.

I opted for the third option because it involved the smallest change to existing code. Option one would involve a lot of almost-duplicate code which didn't seem very elegant. Option two is probably the cleanest but would be an API break and involve changing all existing conversion plugins - I'm a first-time contributor so I don't know what the appetite is for this kind of change

I am more than happy to try one of the other proposed implementations (or indeed anything else) if that would be more desirable.