### PR TITLE
Allow TabBar drag and drop to be overridden and add tab mouse tests

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1360,26 +1360,35 @@ void TabBar::remove_tab(int p_idx) {
 }
 
 Variant TabBar::get_drag_data(const Point2 &p_point) {
-	if (!drag_to_rearrange_enabled) {
-		return Control::get_drag_data(p_point); // Allow stuff like TabContainer to override it.
+	Variant drag_data = Control::get_drag_data(p_point);
+	if (drag_data != Variant()) {
+		return drag_data;
 	}
-	return _handle_get_drag_data("tab_bar_tab", p_point);
+
+	if (drag_to_rearrange_enabled) {
+		return _handle_get_drag_data("tab_bar_tab", p_point);
+	}
+	return Variant();
 }
 
 bool TabBar::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
-	if (!drag_to_rearrange_enabled) {
-		return Control::can_drop_data(p_point, p_data); // Allow stuff like TabContainer to override it.
+	bool drop_override = Control::can_drop_data(p_point, p_data);
+	if (drop_override) {
+		return drop_override;
 	}
-	return _handle_can_drop_data("tab_bar_tab", p_point, p_data);
+
+	if (drag_to_rearrange_enabled) {
+		return _handle_can_drop_data("tab_bar_tab", p_point, p_data);
+	}
+	return false;
 }
 
 void TabBar::drop_data(const Point2 &p_point, const Variant &p_data) {
-	if (!drag_to_rearrange_enabled) {
-		Control::drop_data(p_point, p_data); // Allow stuff like TabContainer to override it.
-		return;
-	}
+	Control::drop_data(p_point, p_data);
 
-	_handle_drop_data("tab_bar_tab", p_point, p_data, callable_mp(this, &TabBar::move_tab), callable_mp(this, &TabBar::_move_tab_from));
+	if (drag_to_rearrange_enabled) {
+		_handle_drop_data("tab_bar_tab", p_point, p_data, callable_mp(this, &TabBar::move_tab), callable_mp(this, &TabBar::_move_tab_from));
+	}
 }
 
 Variant TabBar::_handle_get_drag_data(const String &p_type, const Point2 &p_point) {

--- a/tests/scene/test_tab_bar.h
+++ b/tests/scene/test_tab_bar.h
@@ -846,6 +846,297 @@ TEST_CASE("[SceneTree][TabBar] layout and offset") {
 	memdelete(tab_bar);
 }
 
-// FIXME: Add tests for mouse click, keyboard navigation, and drag and drop.
+TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
+	TabBar *tab_bar = memnew(TabBar);
+	SceneTree::get_singleton()->get_root()->add_child(tab_bar);
+
+	tab_bar->set_clip_tabs(false);
+	tab_bar->add_tab("tab0");
+	tab_bar->add_tab("tab1 ");
+	tab_bar->add_tab("tab2    ");
+	MessageQueue::get_singleton()->flush();
+
+	Vector<Rect2> tab_rects = {
+		tab_bar->get_tab_rect(0),
+		tab_bar->get_tab_rect(1),
+		tab_bar->get_tab_rect(2)
+	};
+
+	SIGNAL_WATCH(tab_bar, "active_tab_rearranged");
+	SIGNAL_WATCH(tab_bar, "tab_button_pressed");
+	SIGNAL_WATCH(tab_bar, "tab_changed");
+	SIGNAL_WATCH(tab_bar, "tab_clicked");
+	SIGNAL_WATCH(tab_bar, "tab_close_pressed");
+	SIGNAL_WATCH(tab_bar, "tab_hovered");
+	SIGNAL_WATCH(tab_bar, "tab_selected");
+
+	SUBCASE("[TabBar] Hover over tabs") {
+		// Default is -1.
+		CHECK(tab_bar->get_hovered_tab() == -1);
+
+		// Hover over the first tab.
+		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position, MouseButtonMask::NONE, Key::NONE);
+		SIGNAL_CHECK("tab_hovered", { { 0 } });
+		CHECK(tab_bar->get_hovered_tab() == 0);
+
+		// Hover over same tab won't send signal again.
+		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position + Point2(2, 2), MouseButtonMask::NONE, Key::NONE);
+		SIGNAL_CHECK_FALSE("tab_hovered");
+		CHECK(tab_bar->get_hovered_tab() == 0);
+
+		// Hover over different tab.
+		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[1].position, MouseButtonMask::NONE, Key::NONE);
+		SIGNAL_CHECK("tab_hovered", { { 1 } });
+		CHECK(tab_bar->get_hovered_tab() == 1);
+
+		// Exit area.
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2(-1, -1), MouseButtonMask::NONE, Key::NONE);
+		SIGNAL_CHECK_FALSE("tab_hovered");
+		CHECK(tab_bar->get_hovered_tab() == -1);
+	}
+
+	SUBCASE("[TabBar] Click to change current") {
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		// Click to set the current tab.
+		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[1].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_changed", { { 1 } });
+		SIGNAL_CHECK("tab_clicked", { { 1 } });
+
+		// Click on the same tab.
+		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[1].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 1);
+		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK_FALSE("tab_changed");
+		SIGNAL_CHECK("tab_clicked", { { 1 } });
+	}
+
+	SUBCASE("[TabBar] Click on close button") {
+		const Size2 close_button_size = tab_bar->get_theme_icon("close_icon")->get_size();
+		int h_separation = tab_bar->get_theme_constant("h_separation");
+		float margin = tab_bar->get_theme_stylebox("tab_hovered_style")->get_margin(SIDE_RIGHT);
+
+		tab_bar->set_tab_close_display_policy(TabBar::CLOSE_BUTTON_SHOW_ALWAYS);
+		MessageQueue::get_singleton()->flush();
+		tab_rects = { tab_bar->get_tab_rect(0), tab_bar->get_tab_rect(1), tab_bar->get_tab_rect(2) };
+
+		Point2 cb_pos = Size2(tab_rects[0].get_end().x - close_button_size.x - h_separation - margin + 1, tab_rects[0].position.y + (tab_rects[0].size.y - close_button_size.y) / 2 + 1);
+		SEND_GUI_MOUSE_MOTION_EVENT(cb_pos, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_EVENT(cb_pos, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(cb_pos, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		SIGNAL_CHECK("tab_close_pressed", { { 0 } });
+		SIGNAL_CHECK_FALSE("tab_clicked");
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+		SIGNAL_CHECK_FALSE("tab_button_pressed");
+		// It does not remove the tab.
+		CHECK(tab_bar->get_tab_count() == 3);
+	}
+
+	SUBCASE("[TabBar] Drag and drop internally") {
+		// Cannot drag if not enabled.
+		CHECK_FALSE(tab_bar->get_drag_to_rearrange_enabled());
+		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[1].position, MouseButtonMask::LEFT, Key::NONE);
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK_FALSE("tab_changed");
+		CHECK_FALSE(tab_bar->get_viewport()->gui_is_dragging());
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(tab_rects[1].position, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK_FALSE(tab_bar->get_viewport()->gui_is_dragging());
+		CHECK(tab_bar->get_tab_title(0) == "tab0");
+		CHECK(tab_bar->get_tab_title(1) == "tab1 ");
+		CHECK(tab_bar->get_tab_title(2) == "tab2    ");
+		SIGNAL_CHECK_FALSE("active_tab_rearranged");
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		tab_bar->set_drag_to_rearrange_enabled(true);
+		CHECK(tab_bar->get_drag_to_rearrange_enabled());
+
+		// Release over the same tab to not move.
+		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[1].position, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position, MouseButtonMask::LEFT, Key::NONE);
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK_FALSE("tab_changed");
+		CHECK(tab_bar->get_viewport()->gui_is_dragging());
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK_FALSE(tab_bar->get_viewport()->gui_is_dragging());
+		CHECK(tab_bar->get_tab_title(0) == "tab0");
+		CHECK(tab_bar->get_tab_title(1) == "tab1 ");
+		CHECK(tab_bar->get_tab_title(2) == "tab2    ");
+		SIGNAL_CHECK_FALSE("active_tab_rearranged");
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Move the first tab after the second.
+		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[1].position, MouseButtonMask::LEFT, Key::NONE);
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK_FALSE("tab_changed");
+		CHECK(tab_bar->get_viewport()->gui_is_dragging());
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(tab_rects[1].position + Point2(tab_rects[1].size.x / 2 + 1, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK_FALSE(tab_bar->get_viewport()->gui_is_dragging());
+		CHECK(tab_bar->get_tab_title(0) == "tab1 ");
+		CHECK(tab_bar->get_tab_title(1) == "tab0");
+		CHECK(tab_bar->get_tab_title(2) == "tab2    ");
+		CHECK(tab_bar->get_current_tab() == 1);
+		SIGNAL_CHECK("active_tab_rearranged", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		tab_rects = { tab_bar->get_tab_rect(0), tab_bar->get_tab_rect(1), tab_bar->get_tab_rect(2) };
+
+		// Move the last tab to be the first.
+		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[2].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position, MouseButtonMask::LEFT, Key::NONE);
+		SIGNAL_CHECK("tab_selected", { { 2 } });
+		SIGNAL_CHECK("tab_changed", { { 2 } });
+		CHECK(tab_bar->get_viewport()->gui_is_dragging());
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK_FALSE(tab_bar->get_viewport()->gui_is_dragging());
+		CHECK(tab_bar->get_tab_title(0) == "tab2    ");
+		CHECK(tab_bar->get_tab_title(1) == "tab1 ");
+		CHECK(tab_bar->get_tab_title(2) == "tab0");
+		CHECK(tab_bar->get_current_tab() == 0);
+		SIGNAL_CHECK("active_tab_rearranged", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK_FALSE("tab_changed");
+	}
+
+	SUBCASE("[TabBar] Drag and drop to different TabBar") {
+		TabBar *target_tab_bar = memnew(TabBar);
+		SceneTree::get_singleton()->get_root()->add_child(target_tab_bar);
+
+		target_tab_bar->set_clip_tabs(false);
+		target_tab_bar->add_tab("other_tab0");
+		MessageQueue::get_singleton()->flush();
+		target_tab_bar->set_position(tab_bar->get_size());
+		MessageQueue::get_singleton()->flush();
+
+		Vector<Rect2> target_tab_rects = { target_tab_bar->get_tab_rect(0) };
+		tab_bar->set_drag_to_rearrange_enabled(true);
+		tab_bar->set_tabs_rearrange_group(1);
+
+		Point2 target_tab_after_first = target_tab_bar->get_position() + target_tab_rects[0].position + Point2(target_tab_rects[0].size.x / 2 + 1, 0);
+
+		// Cannot drag to another TabBar that does not have drag to rearrange enabled.
+		CHECK_FALSE(target_tab_bar->get_drag_to_rearrange_enabled());
+		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(target_tab_after_first, MouseButtonMask::LEFT, Key::NONE);
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK_FALSE("tab_changed");
+		CHECK(tab_bar->get_viewport()->gui_is_dragging());
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab_after_first, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK_FALSE(tab_bar->get_viewport()->gui_is_dragging());
+		CHECK(tab_bar->get_tab_count() == 3);
+		CHECK(target_tab_bar->get_tab_count() == 1);
+		SIGNAL_CHECK_FALSE("active_tab_rearranged");
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Cannot drag to another TabBar that has a tabs rearrange group of -1.
+		target_tab_bar->set_drag_to_rearrange_enabled(true);
+		tab_bar->set_tabs_rearrange_group(-1);
+		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(target_tab_after_first, MouseButtonMask::LEFT, Key::NONE);
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK_FALSE("tab_changed");
+		CHECK(tab_bar->get_viewport()->gui_is_dragging());
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab_after_first, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK_FALSE(tab_bar->get_viewport()->gui_is_dragging());
+		CHECK(tab_bar->get_tab_count() == 3);
+		CHECK(target_tab_bar->get_tab_count() == 1);
+		SIGNAL_CHECK_FALSE("active_tab_rearranged");
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Cannot drag to another TabBar that has a different tabs rearrange group.
+		tab_bar->set_tabs_rearrange_group(1);
+		target_tab_bar->set_tabs_rearrange_group(2);
+		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(target_tab_after_first, MouseButtonMask::LEFT, Key::NONE);
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK_FALSE("tab_changed");
+		CHECK(tab_bar->get_viewport()->gui_is_dragging());
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab_after_first, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK_FALSE(tab_bar->get_viewport()->gui_is_dragging());
+		CHECK(tab_bar->get_tab_count() == 3);
+		CHECK(target_tab_bar->get_tab_count() == 1);
+		SIGNAL_CHECK_FALSE("active_tab_rearranged");
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Drag to target container.
+		target_tab_bar->set_tabs_rearrange_group(1);
+		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(target_tab_after_first, MouseButtonMask::LEFT, Key::NONE);
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK_FALSE("tab_changed");
+		CHECK(tab_bar->get_viewport()->gui_is_dragging());
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab_after_first, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK_FALSE(tab_bar->get_viewport()->gui_is_dragging());
+		CHECK(tab_bar->get_tab_count() == 2);
+		CHECK(target_tab_bar->get_tab_count() == 2);
+		CHECK(tab_bar->get_tab_title(0) == "tab1 ");
+		CHECK(tab_bar->get_tab_title(1) == "tab2    ");
+		CHECK(target_tab_bar->get_tab_title(0) == "other_tab0");
+		CHECK(target_tab_bar->get_tab_title(1) == "tab0");
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(target_tab_bar->get_current_tab() == 1);
+		SIGNAL_CHECK_FALSE("active_tab_rearranged");
+		SIGNAL_CHECK_FALSE("tab_selected"); // Does not send since tab was removed.
+		SIGNAL_CHECK("tab_changed", { { 0 } });
+
+		Point2 target_tab = target_tab_bar->get_position();
+
+		// Drag to target container at first index.
+		target_tab_bar->set_tabs_rearrange_group(1);
+		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(target_tab, MouseButtonMask::LEFT, Key::NONE);
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK_FALSE("tab_changed");
+		CHECK(tab_bar->get_viewport()->gui_is_dragging());
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK_FALSE(tab_bar->get_viewport()->gui_is_dragging());
+		CHECK(tab_bar->get_tab_count() == 1);
+		CHECK(target_tab_bar->get_tab_count() == 3);
+		CHECK(tab_bar->get_tab_title(0) == "tab2    ");
+		CHECK(target_tab_bar->get_tab_title(0) == "tab1 ");
+		CHECK(target_tab_bar->get_tab_title(1) == "other_tab0");
+		CHECK(target_tab_bar->get_tab_title(2) == "tab0");
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(target_tab_bar->get_current_tab() == 0);
+		SIGNAL_CHECK_FALSE("active_tab_rearranged");
+		SIGNAL_CHECK_FALSE("tab_selected"); // Does not send since tab was removed.
+		SIGNAL_CHECK("tab_changed", { { 0 } });
+
+		memdelete(target_tab_bar);
+	}
+
+	SIGNAL_UNWATCH(tab_bar, "active_tab_rearranged");
+	SIGNAL_UNWATCH(tab_bar, "tab_button_pressed");
+	SIGNAL_UNWATCH(tab_bar, "tab_changed");
+	SIGNAL_UNWATCH(tab_bar, "tab_clicked");
+	SIGNAL_UNWATCH(tab_bar, "tab_close_pressed");
+	SIGNAL_UNWATCH(tab_bar, "tab_hovered");
+	SIGNAL_UNWATCH(tab_bar, "tab_selected");
+
+	memdelete(tab_bar);
+}
+
+// FIXME: Add tests for keyboard navigation and other methods.
 
 } // namespace TestTabBar


### PR DESCRIPTION
- closes https://github.com/godotengine/godot-proposals/issues/8887
- Similar to #44349 and #75122

I could have removed TabContainer's `drag_to_rearrange_enabled` and used TabBar's, but then `_handle_drop_data` will be called twice for TabContainer. It isn't currently an issue since the `type` data is different between them, but it would be an issue with #103478.

Added basic drag and drop tests to TabBar and TabContainer, since there were issues the last time I messed with this #83637, https://github.com/godotengine/godot/pull/83966.