### PR TITLE
Expose 3D editor snap settings to EditorInterface

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -156,6 +156,24 @@
 				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
+		<method name="get_node_3d_rotate_snap" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the amount of degrees the 3D editor's rotational snapping is set to.
+			</description>
+		</method>
+		<method name="get_node_3d_scale_snap" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the amount of units the 3D editor's scale snapping is set to.
+			</description>
+		</method>
+		<method name="get_node_3d_translate_snap" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the amount of units the 3D editor's translation snapping is set to.
+			</description>
+		</method>
 		<method name="get_open_scene_roots" qualifiers="const">
 			<return type="Node[]" />
 			<description>
@@ -221,6 +239,12 @@
 				- [member EditorSettings.interface/multi_window/enable] is [code]true[/code].
 				- [member EditorSettings.interface/editor/single_window_mode] is [code]false[/code].
 				- [member Viewport.gui_embed_subwindows] is [code]false[/code]. This is forced to [code]true[/code] on platforms that don't support multiple windows such as Web, or when the [code]--single-window[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url] is used.
+			</description>
+		</method>
+		<method name="is_node_3d_snap_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the 3D editor currently has snapping mode enabled, and [code]false[/code] otherwise.
 			</description>
 		</method>
 		<method name="is_playing_scene" qualifiers="const">

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -415,6 +415,22 @@ float EditorInterface::get_editor_scale() const {
 	return EDSCALE;
 }
 
+bool EditorInterface::is_node_3d_snap_enabled() const {
+	return Node3DEditor::get_singleton()->is_snap_enabled();
+}
+
+real_t EditorInterface::get_node_3d_translate_snap() const {
+	return Node3DEditor::get_singleton()->get_translate_snap();
+}
+
+real_t EditorInterface::get_node_3d_rotate_snap() const {
+	return Node3DEditor::get_singleton()->get_rotate_snap();
+}
+
+real_t EditorInterface::get_node_3d_scale_snap() const {
+	return Node3DEditor::get_singleton()->get_scale_snap();
+}
+
 void EditorInterface::popup_dialog(Window *p_dialog, const Rect2i &p_screen_rect) {
 	p_dialog->popup_exclusive(EditorNode::get_singleton(), p_screen_rect);
 }
@@ -802,6 +818,11 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_multi_window_enabled"), &EditorInterface::is_multi_window_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_editor_scale"), &EditorInterface::get_editor_scale);
+
+	ClassDB::bind_method(D_METHOD("is_node_3d_snap_enabled"), &EditorInterface::is_node_3d_snap_enabled);
+	ClassDB::bind_method(D_METHOD("get_node_3d_translate_snap"), &EditorInterface::get_node_3d_translate_snap);
+	ClassDB::bind_method(D_METHOD("get_node_3d_rotate_snap"), &EditorInterface::get_node_3d_rotate_snap);
+	ClassDB::bind_method(D_METHOD("get_node_3d_scale_snap"), &EditorInterface::get_node_3d_scale_snap);
 
 	ClassDB::bind_method(D_METHOD("popup_dialog", "dialog", "rect"), &EditorInterface::popup_dialog, DEFVAL(Rect2i()));
 	ClassDB::bind_method(D_METHOD("popup_dialog_centered", "dialog", "minsize"), &EditorInterface::popup_dialog_centered, DEFVAL(Size2i()));

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -132,6 +132,11 @@ public:
 
 	float get_editor_scale() const;
 
+	bool is_node_3d_snap_enabled() const;
+	real_t get_node_3d_translate_snap() const;
+	real_t get_node_3d_rotate_snap() const;
+	real_t get_node_3d_scale_snap() const;
+
 	void popup_dialog(Window *p_dialog, const Rect2i &p_screen_rect = Rect2i());
 	void popup_dialog_centered(Window *p_dialog, const Size2i &p_minsize = Size2i());
 	void popup_dialog_centered_ratio(Window *p_dialog, float p_ratio = 0.8);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Implements [#10704](https://github.com/godotengine/godot-proposals/issues/10704)
Modified version of [#96763](https://github.com/godotengine/godot/pull/96763)

Adds methods to the EditorInterface (Instead of EditorPlugin) to get 3D editor snap settings.  Snap values are affected by the shift key being held down when methods are called, decided against putting this in documentation as it is an intended interaction.   