### PR TITLE
Fix evaluation of `pos_changed` and `size_changed`.

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1727,8 +1727,8 @@ void Control::_size_changed() {
 		new_size_cache.height = minimum_size.height;
 	}
 
-	bool pos_changed = !new_pos_cache.is_equal_approx(data.pos_cache);
-	bool size_changed = !new_size_cache.is_equal_approx(data.size_cache);
+	bool pos_changed = new_pos_cache != data.pos_cache;
+	bool size_changed = new_size_cache != data.size_cache;
 
 	if (pos_changed) {
 		data.pos_cache = new_pos_cache;


### PR DESCRIPTION
This aims to close #100112  by using a more accurate evaluation of size_changed and pos_changed, as suggested by @kleonc .

![image](https://github.com/user-attachments/assets/1e4c8dd5-1602-4dc8-8505-062b3b781576)
The test case provided in the issue seems to pass without much issue. 

Hopefully this does not cause more regression, as I am not sure why the author decided to use `is_equal_approx` instead of `!=`

Output, for those who cannot see the image.
```
start => (120.0, 40.0003)
40 => (120.0, 40.0)
(120, 40) => (120.0, 40.0)
(121, 40) => (121.0, 40.0)
```

