### PR TITLE
Rendering: SPIR-V reflection incorrectly determined `writable` state

### DIFF
--- a/servers/rendering/rendering_device_driver.cpp
+++ b/servers/rendering/rendering_device_driver.cpp
@@ -161,7 +161,11 @@ Error RenderingDeviceDriver::_reflect_spirv(VectorView<ShaderStageSPIRVData> p_s
 					}
 
 					if (may_be_writable) {
-						uniform.writable = !(binding.type_description->decoration_flags & SPV_REFLECT_DECORATION_NON_WRITABLE) && !(binding.block.decoration_flags & SPV_REFLECT_DECORATION_NON_WRITABLE);
+						if (binding.descriptor_type == SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+							uniform.writable = !(binding.decoration_flags & SPV_REFLECT_DECORATION_NON_WRITABLE);
+						} else {
+							uniform.writable = !(binding.decoration_flags & SPV_REFLECT_DECORATION_NON_WRITABLE) && !(binding.block.decoration_flags & SPV_REFLECT_DECORATION_NON_WRITABLE);
+						}
 					} else {
 						uniform.writable = false;
 					}


### PR DESCRIPTION
Identified from testing #101696

Resolves a bug in `RenderingDeviceDriver::_reflect_spirv`:

https://github.com/godotengine/godot/blob/1af1edf60c1c317f6953c4fa78e0743a0729704d/servers/rendering/rendering_device_driver.cpp#L163-L167

When reflecting an image type, the `binding.block` struct is _invalid_, as that only applies to `struct` types. Here is the dumped value of the `binding` variable from the debugger, abbreviated:

```
{
  spirv_id = 65
  name = 0x000000011c28fd80 "current_image"
  binding = 0
  input_attachment_index = 0
  set = 0
  descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_IMAGE
  resource_type = SPV_REFLECT_RESOURCE_FLAG_UAV
  image = (dim = SpvDim2D, depth = 0, arrayed = 0, ms = 0, sampled = 2, image_format = SpvImageFormatR32f)
  block = {
    spirv_id = 0
    name = 0x0000000000000000
    offset = 0
    absolute_offset = 0
    size = 0
    padded_size = 0
    decoration_flags = 0
    flags = 0
    member_count = 0
    members = nullptr
    type_description = nullptr
    word_offset = (offset = 0)
  }
  count = 1
  accessed = 1
  uav_counter_id = 4294967295
  uav_counter_binding = nullptr
  byte_address_buffer_offset_count = 0
  byte_address_buffer_offsets = 0x0000000000000000
  type_description = 0x000000011c295470
  word_offset = (binding = 175, set = 171)
  decoration_flags = 128
  user_type = SPV_REFLECT_USER_TYPE_INVALID
}
```

Note that the the entire `binding.block` struct is `0`, which means this will evaluate to `true`, as the second part of the expression does not have the `SPV_REFLECT_DECORATION_NON_WRITABLE` bit set, as it is invalid and always `0`:

```cpp
uniform.writable = !(binding.type_description->decoration_flags & SPV_REFLECT_DECORATION_NON_WRITABLE) && !(binding.block.decoration_flags & SPV_REFLECT_DECORATION_NON_WRITABLE);
```

Metal has its own implementation to reflect the SPIR-V, which distinguishes the types:

https://github.com/godotengine/godot/blob/d89cc01e0028e9dff488cdf768f62fdf31b1743e/drivers/metal/rendering_device_driver_metal.mm#L1787-L1796

> [!NOTE]
>
> SPIR-V cross throws an exception if you try to fetch the block metadata for an image.