### PR TITLE
[Metal] Add missing stage info to shader description.

### DIFF
--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -2460,6 +2460,8 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_bytecode(const Vect
 	HashMap<ShaderStage, MDLibrary *> libraries;
 
 	for (ShaderStageData &shader_data : binary_data.stages) {
+		r_shader_desc.stages.push_back(shader_data.stage);
+
 		SHA256Digest key = SHA256Digest(shader_data.source.ptr(), shader_data.source.length());
 
 		if (ShaderCacheEntry **p = _shader_cache.getptr(key); p != nullptr) {


### PR DESCRIPTION
Fixes regression from https://github.com/godotengine/godot/pull/103480 (see comments)