### PR TITLE
Add missing default values to the `read_*_from_stdin` binds.

### DIFF
--- a/core/core_bind.compat.inc
+++ b/core/core_bind.compat.inc
@@ -53,6 +53,8 @@ Dictionary OS::_execute_with_pipe_bind_compat_94434(const String &p_path, const 
 }
 
 void OS::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("read_string_from_stdin", "buffer_size"), &OS::read_string_from_stdin);
+	ClassDB::bind_compatibility_method(D_METHOD("read_buffer_from_stdin", "buffer_size"), &OS::read_buffer_from_stdin);
 	ClassDB::bind_compatibility_method(D_METHOD("read_string_from_stdin"), &OS::_read_string_from_stdin_bind_compat_91201);
 	ClassDB::bind_compatibility_method(D_METHOD("execute_with_pipe", "path", "arguments"), &OS::_execute_with_pipe_bind_compat_94434);
 }

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -657,8 +657,8 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_system_font_path_for_text", "font_name", "text", "locale", "script", "weight", "stretch", "italic"), &OS::get_system_font_path_for_text, DEFVAL(String()), DEFVAL(String()), DEFVAL(400), DEFVAL(100), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_executable_path"), &OS::get_executable_path);
 
-	ClassDB::bind_method(D_METHOD("read_string_from_stdin", "buffer_size"), &OS::read_string_from_stdin);
-	ClassDB::bind_method(D_METHOD("read_buffer_from_stdin", "buffer_size"), &OS::read_buffer_from_stdin);
+	ClassDB::bind_method(D_METHOD("read_string_from_stdin", "buffer_size"), &OS::read_string_from_stdin, DEFVAL(1024));
+	ClassDB::bind_method(D_METHOD("read_buffer_from_stdin", "buffer_size"), &OS::read_buffer_from_stdin, DEFVAL(1024));
 	ClassDB::bind_method(D_METHOD("get_stdin_type"), &OS::get_stdin_type);
 	ClassDB::bind_method(D_METHOD("get_stdout_type"), &OS::get_stdout_type);
 	ClassDB::bind_method(D_METHOD("get_stderr_type"), &OS::get_stderr_type);

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -720,7 +720,7 @@
 		</method>
 		<method name="read_buffer_from_stdin">
 			<return type="PackedByteArray" />
-			<param index="0" name="buffer_size" type="int" />
+			<param index="0" name="buffer_size" type="int" default="1024" />
 			<description>
 				Reads a user input as raw data from the standard input. This operation can be [i]blocking[/i], which causes the window to freeze if [method read_string_from_stdin] is called on the main thread.
 				- If standard input is console, this method will block until the program receives a line break in standard input (usually by the user pressing [kbd]Enter[/kbd]).
@@ -732,7 +732,7 @@
 		</method>
 		<method name="read_string_from_stdin">
 			<return type="String" />
-			<param index="0" name="buffer_size" type="int" />
+			<param index="0" name="buffer_size" type="int" default="1024" />
 			<description>
 				Reads a user input as a UTF-8 encoded string from the standard input. This operation can be [i]blocking[/i], which causes the window to freeze if [method read_string_from_stdin] is called on the main thread.
 				- If standard input is console, this method will block until the program receives a line break in standard input (usually by the user pressing [kbd]Enter[/kbd]).


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/103550 (migration guide should be updated as well, since it's not accurate for 4.4).
