### PR TITLE
Make RST: Exclude godot-cpp test project files

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -777,6 +777,10 @@ def main() -> None:
 
         if os.path.basename(path) in ["modules", "platform"]:
             for subdir, dirs, _ in os.walk(path):
+                # Exclude godot-cpp test project files for the case of
+                # third-party modules with godot-cpp inside of them.
+                if "/godot-cpp/test" in subdir.replace("\\\\", "/"):
+                    continue
                 if "doc_classes" in dirs:
                     doc_dir = os.path.join(subdir, "doc_classes")
                     class_file_names = (f for f in os.listdir(doc_dir) if f.endswith(".xml"))


### PR DESCRIPTION
This is required to avoid erroring in the case of multiple third-party modules that can build as both GDExtension and engine modules while those modules also have godot-cpp cloned inside of them. Without this PR, `make_rst.py` will give an error about duplicate classes from the multiple godot-cpp test projects.

```
ERROR: modules/1d/addons/nd/src/godot-cpp/test/doc_classes/Example.xml: Duplicate class "Example".
ERROR: modules/2pt5d/addons/2pt5d/src/godot-cpp/test/doc_classes/Example.xml: Duplicate class "Example".
ERROR: modules/4d/addons/nd/src/godot-cpp/test/doc_classes/Example.xml: Duplicate class "Example".
ERROR: modules/nd/addons/nd/src/godot-cpp/test/doc_classes/Example.xml: Duplicate class "Example".
```

I know this is a niche thing, but it would be nice to have the script working and CI passing in this case.