### PR TITLE
Fix Image format RGB565 conversion and rendering

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3200,9 +3200,9 @@ Color Image::_get_color_at_ofs(const uint8_t *ptr, uint32_t ofs) const {
 		}
 		case FORMAT_RGB565: {
 			uint16_t u = ((uint16_t *)ptr)[ofs];
-			float r = (u & 0x1F) / 31.0;
+			float r = ((u >> 11) & 0x1F) / 31.0;
 			float g = ((u >> 5) & 0x3F) / 63.0;
-			float b = ((u >> 11) & 0x1F) / 31.0;
+			float b = (u & 0x1F) / 31.0;
 			return Color(r, g, b, 1.0);
 		}
 		case FORMAT_RF: {
@@ -3299,9 +3299,9 @@ void Image::_set_color_at_ofs(uint8_t *ptr, uint32_t ofs, const Color &p_color) 
 		case FORMAT_RGB565: {
 			uint16_t rgba = 0;
 
-			rgba = uint16_t(CLAMP(p_color.r * 31.0, 0, 31));
+			rgba = uint16_t(CLAMP(p_color.r * 31.0, 0, 31)) << 11;
 			rgba |= uint16_t(CLAMP(p_color.g * 63.0, 0, 63)) << 5;
-			rgba |= uint16_t(CLAMP(p_color.b * 31.0, 0, 31)) << 11;
+			rgba |= uint16_t(CLAMP(p_color.b * 31.0, 0, 31));
 
 			((uint16_t *)ptr)[ofs] = rgba;
 		} break;

--- a/modules/dds/dds_enums.h
+++ b/modules/dds/dds_enums.h
@@ -195,7 +195,7 @@ static const DDSFormatInfo dds_format_info[DDS_MAX] = {
 	{ "BGRA8", false, 1, 4, Image::FORMAT_RGBA8 },
 	{ "BGRX8", false, 1, 4, Image::FORMAT_RGB8 },
 	{ "BGR5A1", false, 1, 2, Image::FORMAT_RGBA8 },
-	{ "BGR565", false, 1, 2, Image::FORMAT_RGB8 },
+	{ "BGR565", false, 1, 2, Image::FORMAT_RGB565 },
 	{ "B2GR3", false, 1, 1, Image::FORMAT_RGB8 },
 	{ "B2GR3A8", false, 1, 2, Image::FORMAT_RGBA8 },
 	{ "BGR10A2", false, 1, 4, Image::FORMAT_RGBA8 },

--- a/modules/dds/image_saver_dds.cpp
+++ b/modules/dds/image_saver_dds.cpp
@@ -366,7 +366,7 @@ Vector<uint8_t> save_dds_buffer(const Ref<Image> &p_img) {
 		stream_buffer->put_32(b_mask);
 		stream_buffer->put_32(a_mask);
 
-		if (image->get_format() == Image::FORMAT_RGBA4444 || image->get_format() == Image::FORMAT_RGB565 || image->get_format() == Image::FORMAT_RGB8) {
+		if (image->get_format() == Image::FORMAT_RGBA4444 || image->get_format() == Image::FORMAT_RGB8) {
 			needs_pixeldata_swap = true;
 		}
 	} else if (format_type == DDFT_FOURCC) {
@@ -441,23 +441,6 @@ Vector<uint8_t> save_dds_buffer(const Ref<Image> &p_img) {
 
 					wb[data_i + 1] = ((ar & 0x0F) << 4) | ((gb & 0xF0) >> 4);
 					wb[data_i + 0] = ((ar & 0xF0) >> 4) | ((gb & 0x0F) << 4);
-				}
-			} else if (mip_image->get_format() == Image::FORMAT_RGB565) {
-				// RGB565 to BGR565
-				const int64_t data_size = data.size();
-				uint8_t *wb = data.ptrw();
-
-				for (int64_t data_i = 0; data_i < data_size; data_i += 2) {
-					uint16_t px = wb[data_i] | (wb[data_i + 1] << 8);
-
-					uint8_t r = (px >> 11) & 0x1F;
-					uint8_t g = (px >> 5) & 0x3F;
-					uint8_t b = px & 0x1F;
-
-					uint16_t out_px = (b << 11) | (g << 5) | r;
-
-					wb[data_i + 0] = out_px & 0xFF;
-					wb[data_i + 1] = (out_px >> 8) & 0xFF;
 				}
 			} else if (mip_image->get_format() == Image::FORMAT_RGB8) {
 				// RGB8 to BGR8

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -172,10 +172,6 @@ static Ref<Image> _dds_load_layer(Ref<FileAccess> p_file, DDSFormat p_dds_format
 
 		// Calculate the space these formats will take up after decoding.
 		switch (p_dds_format) {
-			case DDS_BGR565:
-				size = size * 3 / 2;
-				break;
-
 			case DDS_BGR5A1:
 			case DDS_B2GR3A8:
 			case DDS_LUMINANCE_ALPHA_4:
@@ -212,24 +208,6 @@ static Ref<Image> _dds_load_layer(Ref<FileAccess> p_file, DDSFormat p_dds_format
 					wb[dst_ofs + 1] = g << 3;
 					wb[dst_ofs + 2] = b << 3;
 					wb[dst_ofs + 3] = a ? 255 : 0;
-				}
-
-			} break;
-			case DDS_BGR565: {
-				// To RGB8.
-				int colcount = size / 3;
-
-				for (int i = colcount - 1; i >= 0; i--) {
-					int src_ofs = i * 2;
-					int dst_ofs = i * 3;
-
-					uint8_t b = wb[src_ofs] & 0x1F;
-					uint8_t g = (wb[src_ofs] >> 5) | ((wb[src_ofs + 1] & 0x7) << 3);
-					uint8_t r = wb[src_ofs + 1] >> 3;
-
-					wb[dst_ofs + 0] = r << 3;
-					wb[dst_ofs + 1] = g << 2;
-					wb[dst_ofs + 2] = b << 3;
 				}
 
 			} break;


### PR DESCRIPTION
Swaps the red and blue channels of RGB565 images in the `_get_pixel`/`_set_pixel` functions. This fixes their appearance across all renderers. 
The dds loader/saver now also directly loads/saves RGB565 data without converting it.

I initially marked this as compatibility breaking, though I don't think it will affect many users as it affects a very niche use case that would otherwise require a workaround from the user.
Note that this does not affect existing images, only new ones.

| old | fixed |
|-----|-------|
| <img width="1159" height="661" alt="old" src="https://github.com/user-attachments/assets/3f39f46b-3160-4f87-8e5c-05399a55c5eb" /> | <img width="1169" height="660" alt="new" src="https://github.com/user-attachments/assets/26e718e0-d9ef-47e7-829f-da25c76803c6" /> |

MRP: [rgb-565-test.zip](https://github.com/user-attachments/files/21566533/rgb-565-test.zip)

