### PR TITLE
Use `Viewport`'s default texture filter/repeat in GUI tooltips

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1546,6 +1546,8 @@ void Viewport::_gui_show_tooltip() {
 	panel->set_flag(Window::FLAG_POPUP, false);
 	panel->set_flag(Window::FLAG_MOUSE_PASSTHROUGH, true);
 	panel->set_wrap_controls(true);
+	panel->set_default_canvas_item_texture_filter(get_default_canvas_item_texture_filter());
+	panel->set_default_canvas_item_texture_repeat(get_default_canvas_item_texture_repeat());
 	panel->add_child(base_tooltip);
 	panel->gui_parent = this;
 


### PR DESCRIPTION
Fixes #103552.

Note I'm propagating tooltip's parent Viewport's filter/repeat instead of the project setting.

Before<br>(v4.4.stable.official [4c311cbee])|After<br>(this PR)
-|-
![Godot_v4 4-stable_win64_n77iVDQqf3](https://github.com/user-attachments/assets/918a58b2-047f-402c-9fd8-3659e9b16bf2)|![godot windows editor dev x86_64_DgdBnWwhYL](https://github.com/user-attachments/assets/edc23e64-da8b-48a0-bf6c-ce89cd752299)
