### PR TITLE
Avoid multiple lookups in `Dictionary::operator[]`

### DIFF
--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -101,10 +101,12 @@ Variant &Dictionary::operator[](const Variant &p_key) {
 		}
 		return *_p->read_only;
 	} else {
-		if (unlikely(!_p->variant_map.has(key))) {
-			VariantInternal::initialize(&_p->variant_map[key], _p->typed_value.type);
+		const uint32_t old_size = _p->variant_map.size();
+		Variant &value = _p->variant_map[key];
+		if (_p->variant_map.size() > old_size) {
+			VariantInternal::initialize(&value, _p->typed_value.type);
 		}
-		return _p->variant_map[key];
+		return value;
 	}
 }
 


### PR DESCRIPTION
Updated `Dictionary::operator[]` to get reference to value once to avoid multiple `HashMap` lookups.

Makes creating new dictionaries, merging, and duplicating dictionaries from gdscript around 5-10% faster, along with some improvements to functions that return dictionaries.

Tested with gdscript below:

```gdscript
func _ready() -> void:
	run_test("new_dictionary")
	run_test("merge_dictionary")
	run_test("duplicate_dictionary")
	run_test("method_list")

func new_dictionary():
	for i in 1000000:
		{1: 1, "key": "value"}

func merge_dictionary():
	var d1 := { 1: 1, 3: 3, 5: 5, 7: 7, 9: 9 }
	var d2 := { 0: 0, 2: 2, 4: 4, 6: 6, 8: 8 }
	for i in 100000:
		var d3 := d1.merged(d2)

func duplicate_dictionary():
	var d := {
		1: 1,
		"key": "value",
		"array": [1, 2, 3, 4, 5]
	}
	for i in 1000000:
		d.duplicate()

func method_list():
	for i in 100:
		get_method_list()

func run_test(p_func_name : String):
	var start := Time.get_ticks_msec()
	call(p_func_name)
	var end := Time.get_ticks_msec()
	print("%s: %dms" % [p_func_name, end - start])
```

old:
```
new_dictionary: 575ms
merge_dictionary: 181ms
duplicate_dictionary: 848ms
method_list: 365ms
```

new:
```
new_dictionary: 548ms
merge_dictionary: 165ms
duplicate_dictionary: 788ms
method_list: 334ms

```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
