### PR TITLE
Apply transforms for LineEdit, RichTextLabel, and TextEdit popup positions

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -399,7 +399,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 			if (context_menu_enabled) {
 				_update_context_menu();
-				menu->set_position(get_screen_position() + get_local_mouse_position());
+				menu->set_position(get_screen_transform().xform(get_local_mouse_position()));
 				menu->reset_size();
 				menu->popup();
 			}
@@ -630,7 +630,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		if (k->is_action("ui_menu", true)) {
 			_update_context_menu();
 			Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + theme_cache.font->get_height(theme_cache.font_size)) / 2);
-			menu->set_position(get_screen_position() + pos);
+			menu->set_position(get_screen_transform().xform(pos));
 			menu->reset_size();
 			menu->popup();
 			menu->grab_focus();

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2189,7 +2189,7 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (b->get_button_index() == MouseButton::RIGHT && context_menu_enabled) {
 			_update_context_menu();
-			menu->set_position(get_screen_position() + b->get_position());
+			menu->set_position(get_screen_transform().xform(b->get_position()));
 			menu->reset_size();
 			menu->popup();
 			grab_focus();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2006,7 +2006,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				if (context_menu_enabled) {
 					_update_context_menu();
-					menu->set_position(get_screen_position() + mpos);
+					menu->set_position(get_screen_transform().xform(mpos));
 					menu->reset_size();
 					menu->popup();
 					grab_focus();
@@ -2291,7 +2291,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			if (context_menu_enabled) {
 				_update_context_menu();
 				adjust_viewport_to_caret();
-				menu->set_position(get_screen_position() + get_caret_draw_pos());
+				menu->set_position(get_screen_transform().xform(get_caret_draw_pos()));
 				menu->reset_size();
 				menu->popup();
 				menu->grab_focus();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes second part of #103344.

This makes LineEdit, RichTextLabel, and TextEdit nodes adjust popup positions based on the node's global transform. These are only the 3 nodes Rindbee listed, but there may be others. 

I used `get_global_transform().basis_xform(offset)`.

Edit: Updated to work with other transforms, not just scale