### PR TITLE
Add automatic C# build on editor focus

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -383,6 +383,29 @@ namespace GodotTools.Build
             return BuildProjectBlocking("Debug");
         }
 
+        public static bool IsBuildInProgress()
+        {
+            return _buildInProgress != null;
+        }
+
+        public static bool CSProjectFilesChanged()
+        {
+            if (!File.Exists(GodotSharpDirs.ProjectCsProjPath))
+                return false; // No CS project available to check.
+
+            if (File.GetLastWriteTime(GodotSharpDirs.ProjectCsProjPath) > LastValidBuildDateTime)
+                return true; // Project file has been updated.
+
+            string projectPath = ProjectSettings.GlobalizePath("res://");
+            foreach (string filePath in Directory.EnumerateFiles(projectPath, "*.cs", SearchOption.AllDirectories))
+            {
+                if (File.GetLastWriteTime(filePath) > LastValidBuildDateTime)
+                    return true;
+            }
+
+            return false;
+        }
+
         public static void Initialize()
         {
         }

--- a/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
@@ -17,21 +17,13 @@ namespace GodotTools
             {
                 RestartTimer();
 
-                if (Internal.IsAssembliesReloadingNeeded())
-                {
-                    BuildManager.UpdateLastValidBuildDateTime();
-                    Internal.ReloadAssemblies(softReload: false);
-                }
+                GodotSharpEditor.Instance.HotReloadScripts(true);
             }
         }
 
         private void TimerTimeout()
         {
-            if (Internal.IsAssembliesReloadingNeeded())
-            {
-                BuildManager.UpdateLastValidBuildDateTime();
-                Internal.ReloadAssemblies(softReload: false);
-            }
+            GodotSharpEditor.Instance.HotReloadScripts(false);
         }
 
         [UsedImplicitly]


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/2920

This PR aims to improve the usability of C# with an external IDE by automatically building the Mono project when Godot is focused and only if the CS files have changed. A new editor setting called `build_on_focus` which is disabled by default allows you toggle this feature on or off:

![image](https://github.com/user-attachments/assets/973b9198-37a0-41e1-9fe3-1f93eb22b432)

Thanks to https://github.com/godotengine/godot/pull/93431 which also had to solve the problem of detecting when CS files have changed, I was able to repurpose a snippet of that code and hook into the existing `HotReloadAssemblyWatcher` which can detect when the Godot Editor is focused in order to build the project at the correct time. Here's that in action:

https://github.com/user-attachments/assets/9baabafa-9903-4356-a29a-cfdfc16c2c2a

Another idea that could stem off of this would be automatically building the C# project when saving through the built in script editor, but that could get more annoying if you make changes to a lot of files, so if we were to tackle it, I believe it should be its own editor setting and its own PR. Plus, it seems like many C# users prefer to work with an IDE like Visual Studio and this functionality seems more relevant for them especially since its a familiar feature to other game engines.

Let me know if it all looks good, thanks!