### PR TITLE
Better clarify BaseButton shortcuts

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -68,7 +68,7 @@
 			[b]Note:[/b] This property only affects the button's visual appearance. Signals will be emitted at the same moment regardless of this property's value.
 		</member>
 		<member name="shortcut" type="Shortcut" setter="set_shortcut" getter="get_shortcut">
-			[Shortcut] associated to the button.
+			[Shortcut] associated to the button. The button gets pressed when the shortcut is matched in shortcut input (see [method Node._shortcut_input]).
 		</member>
 		<member name="shortcut_feedback" type="bool" setter="set_shortcut_feedback" getter="is_shortcut_feedback" default="true">
 			If [code]true[/code], the button will highlight for a short amount of time when its shortcut is activated. If [code]false[/code] and [member toggle_mode] is [code]false[/code], the shortcut will activate without any visual feedback.


### PR DESCRIPTION
Closes #38500
The shortcut is matched in `shortcut_input`, which filters out mouse events:

https://github.com/godotengine/godot/blob/134da374975114ef8e05cf81d1d30eff645e310e/scene/main/viewport.cpp#L3321-L3324

It's not a bug.