### PR TITLE
Improve BaseMaterial3D/Label3D/SpriteBase3D's `fixed_size` documentation

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -215,7 +215,7 @@
 			Texture that specifies how much surface emits light at a given point.
 		</member>
 		<member name="fixed_size" type="bool" setter="set_flag" getter="get_flag" default="false">
-			If [code]true[/code], the object is rendered at the same size regardless of distance.
+			If [code]true[/code], the object is rendered at the same size regardless of distance. The object's size on screen is the same as if the camera was [code]1.0[/code] units away from the object's origin, regardless of the actual distance from the camera. The [Camera3D]'s field of view (or [member Camera3D.size] when in orthogonal/frustum mode) still affects the size the object is drawn at.
 		</member>
 		<member name="grow" type="bool" setter="set_grow_enabled" getter="is_grow_enabled" default="false">
 			If [code]true[/code], enables the vertex grow setting. This can be used to create mesh-based outlines using a second material pass and its [member cull_mode] set to [constant CULL_FRONT]. See also [member grow_amount].

--- a/doc/classes/Label3D.xml
+++ b/doc/classes/Label3D.xml
@@ -59,7 +59,7 @@
 			If [code]true[/code], text can be seen from the back as well, if [code]false[/code], it is invisible when looking at it from behind.
 		</member>
 		<member name="fixed_size" type="bool" setter="set_draw_flag" getter="get_draw_flag" default="false">
-			If [code]true[/code], the label is rendered at the same size regardless of distance.
+			If [code]true[/code], the label is rendered at the same size regardless of distance. The label's size on screen is the same as if the camera was [code]1.0[/code] units away from the label's origin, regardless of the actual distance from the camera. The [Camera3D]'s field of view (or [member Camera3D.size] when in orthogonal/frustum mode) still affects the size the label is drawn at.
 		</member>
 		<member name="font" type="Font" setter="set_font" getter="get_font">
 			Font configuration used to display text.

--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -67,7 +67,7 @@
 			If [code]true[/code], texture can be seen from the back as well, if [code]false[/code], it is invisible when looking at it from behind.
 		</member>
 		<member name="fixed_size" type="bool" setter="set_draw_flag" getter="get_draw_flag" default="false">
-			If [code]true[/code], the label is rendered at the same size regardless of distance.
+			If [code]true[/code], the texture is rendered at the same size regardless of distance. The texture's size on screen is the same as if the camera was [code]1.0[/code] units away from the texture's origin, regardless of the actual distance from the camera. The [Camera3D]'s field of view (or [member Camera3D.size] when in orthogonal/frustum mode) still affects the size the sprite is drawn at.
 		</member>
 		<member name="flip_h" type="bool" setter="set_flip_h" getter="is_flipped_h" default="false">
 			If [code]true[/code], texture is flipped horizontally.


### PR DESCRIPTION
This documents the behavior more precisely and fixes a typo in SpriteBase3D where it referred to a label instead of a sprite.

**Testing project:** [test_fixed_size.zip](https://github.com/user-attachments/files/19099507/test_fixed_size.zip)
