### PR TITLE
Fix ItemList docs for the focus Stylebox's draw order

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -536,7 +536,7 @@
 			[StyleBox] used for the cursor, when the [ItemList] is not being focused.
 		</theme_item>
 		<theme_item name="focus" data_type="style" type="StyleBox">
-			The focused style for the [ItemList], drawn on top of the background, but below everything else.
+			The focused style for the [ItemList], drawn on top of everything.
 		</theme_item>
 		<theme_item name="hovered" data_type="style" type="StyleBox">
 			[StyleBox] for the hovered, but not selected items.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Updates the docs for #103640