### PR TITLE
[RTL] Fix custom effects not updating.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -525,6 +525,12 @@
 				Adds a [code skip-lint][u][/code] tag to the tag stack.
 			</description>
 		</method>
+		<method name="reload_effects">
+			<return type="void" />
+			<description>
+				Reloads custom effects. Useful when [member custom_effects] is modified manually.
+			</description>
+		</method>
 		<method name="remove_paragraph">
 			<return type="bool" />
 			<param index="0" name="paragraph" type="int" />

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -6356,9 +6356,7 @@ float RichTextLabel::get_visible_ratio() const {
 
 void RichTextLabel::set_effects(Array p_effects) {
 	custom_effects = p_effects;
-	if (!stack_externally_modified && use_bbcode) {
-		parse_bbcode(atr(text));
-	}
+	reload_effects();
 }
 
 Array RichTextLabel::get_effects() {
@@ -6371,8 +6369,14 @@ void RichTextLabel::install_effect(const Variant effect) {
 
 	ERR_FAIL_COND_MSG(rteffect.is_null(), "Invalid RichTextEffect resource.");
 	custom_effects.push_back(effect);
+	reload_effects();
+}
+
+void RichTextLabel::reload_effects() {
 	if (!stack_externally_modified && use_bbcode) {
+		internal_stack_editing = true;
 		parse_bbcode(atr(text));
+		internal_stack_editing = false;
 	}
 }
 
@@ -6580,6 +6584,7 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_effects", "effects"), &RichTextLabel::set_effects);
 	ClassDB::bind_method(D_METHOD("get_effects"), &RichTextLabel::get_effects);
 	ClassDB::bind_method(D_METHOD("install_effect", "effect"), &RichTextLabel::install_effect);
+	ClassDB::bind_method(D_METHOD("reload_effects"), &RichTextLabel::reload_effects);
 
 	ClassDB::bind_method(D_METHOD("get_menu"), &RichTextLabel::get_menu);
 	ClassDB::bind_method(D_METHOD("is_menu_visible"), &RichTextLabel::is_menu_visible);

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -881,6 +881,7 @@ public:
 	Array get_effects();
 
 	void install_effect(const Variant effect);
+	void reload_effects();
 
 	virtual Size2 get_minimum_size() const override;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/103630

- Fixes `install_effect` not updating label text (`INSTALL_EFFECT` case).
- There's no reliable way to track external `Array` changes, so I have added `reload_effects` method to use after such changes (`APPEND_ARRAY` case).
```gdscript
	custom_effects.append(load("uid://c2vp3pnlokpg2"))
	custom_effects.append(load("uid://3ke1uaie6igq"))
	custom_effects.append(load("uid://dsfc7ow5qjeet"))
	reload_effects()
```