### PR TITLE
GDScript: Fix unexpected error with preload and typed arrays

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4786,7 +4786,7 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 
 		// If the base is a metatype, use the analyzer instead.
 		if (p_subscript->base->is_constant && !base_type.is_meta_type) {
-			// GH-92534. If the base is a GDScript, use the analyzer instead.
+			// GH-92534. If the base is a GDScript, try to find the specific class and use the analyzer instead.
 			bool base_is_gdscript = false;
 			if (p_subscript->base->reduced_value.get_type() == Variant::OBJECT) {
 				Ref<GDScript> gdscript = Object::cast_to<GDScript>(p_subscript->base->reduced_value.get_validated_object());
@@ -4794,25 +4794,17 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 					base_is_gdscript = true;
 					// Makes a metatype from a constant GDScript, since `base_type` is not a metatype.
 					GDScriptParser::DataType base_type_meta = type_from_variant(gdscript, p_subscript);
-					// First try to reduce the attribute from the metatype.
-					reduce_identifier_from_base(p_subscript->attribute, &base_type_meta);
-					GDScriptParser::DataType attr_type = p_subscript->attribute->get_datatype();
-					if (attr_type.is_set()) {
-						valid = !attr_type.is_pseudo_type || p_can_be_pseudo_type;
-						result_type = attr_type;
-						p_subscript->is_constant = p_subscript->attribute->is_constant;
-						p_subscript->reduced_value = p_subscript->attribute->reduced_value;
-					}
-					if (!valid) {
-						// If unsuccessful, reset and return to the normal route.
-						p_subscript->attribute->set_datatype(GDScriptParser::DataType());
+					if (base_type_meta.kind == GDScriptParser::DataType::CLASS) {
+						base_type = base_type_meta;
 					}
 				}
 			}
 			if (!base_is_gdscript) {
 				// Just try to get it.
-				Variant value = p_subscript->base->reduced_value.get_named(p_subscript->attribute->name, valid);
-				if (valid) {
+				bool is_const_valid = false;
+				Variant value = p_subscript->base->reduced_value.get_named(p_subscript->attribute->name, is_const_valid);
+				if (is_const_valid) {
+					valid = true;
 					p_subscript->is_constant = true;
 					p_subscript->reduced_value = value;
 					result_type = type_from_variant(value, p_subscript);
@@ -5708,7 +5700,7 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_variant(const Variant &p_va
 	if (p_value.get_type() == Variant::ARRAY) {
 		const Array &array = p_value;
 		if (array.get_typed_script()) {
-			result.set_container_element_type(0, type_from_metatype(type_from_script(array.get_typed_script(), p_source, true)));
+			result.set_container_element_type(0, type_from_metatype(type_from_variant(array.get_typed_script(), p_source)));
 		} else if (array.get_typed_class_name()) {
 			result.set_container_element_type(0, type_from_metatype(make_native_meta_type(array.get_typed_class_name())));
 		} else if (array.get_typed_builtin() != Variant::NIL) {
@@ -5717,14 +5709,14 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_variant(const Variant &p_va
 	} else if (p_value.get_type() == Variant::DICTIONARY) {
 		const Dictionary &dict = p_value;
 		if (dict.get_typed_key_script()) {
-			result.set_container_element_type(0, type_from_metatype(type_from_script(dict.get_typed_key_script(), p_source, true)));
+			result.set_container_element_type(0, type_from_metatype(type_from_variant(dict.get_typed_key_script(), p_source)));
 		} else if (dict.get_typed_key_class_name()) {
 			result.set_container_element_type(0, type_from_metatype(make_native_meta_type(dict.get_typed_key_class_name())));
 		} else if (dict.get_typed_key_builtin() != Variant::NIL) {
 			result.set_container_element_type(0, type_from_metatype(make_builtin_meta_type((Variant::Type)dict.get_typed_key_builtin())));
 		}
 		if (dict.get_typed_value_script()) {
-			result.set_container_element_type(1, type_from_metatype(type_from_script(dict.get_typed_value_script(), p_source, true)));
+			result.set_container_element_type(1, type_from_metatype(type_from_variant(dict.get_typed_value_script(), p_source)));
 		} else if (dict.get_typed_value_class_name()) {
 			result.set_container_element_type(1, type_from_metatype(make_native_meta_type(dict.get_typed_value_class_name())));
 		} else if (dict.get_typed_value_builtin() != Variant::NIL) {

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_script_resource.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_script_resource.notest.gd
@@ -1,0 +1,1 @@
+class_name SomeResource extends Resource

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_script_resource_holder.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_script_resource_holder.notest.gd
@@ -1,0 +1,3 @@
+extends Resource
+
+var list: Array[SomeResource] = []

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_script_resource_holder.tres
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_script_resource_holder.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class="SomeResourceList" load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://analyzer/features/preload_script_resource.notest.gd" id="1_lsaa1"]
+[ext_resource type="Script" path="res://analyzer/features/preload_script_resource_holder.notest.gd" id="1_t40yp"]
+
+[resource]
+script = ExtResource("1_t40yp")

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_subscript_typed_array_global_class.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_subscript_typed_array_global_class.gd
@@ -1,0 +1,3 @@
+func test():
+	var v: Array[SomeResource] = preload("preload_script_resource_holder.tres").list
+	print(v)

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_subscript_typed_array_global_class.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_subscript_typed_array_global_class.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+[]


### PR DESCRIPTION
fixes https://github.com/godotengine/godot/issues/95568
fixes https://github.com/godotengine/godot/issues/95851

when resolving `constant.member`, uses the regular code path with a more specified type instead of using its own custom code path to find the type of a member of a constant gdscript

and when it reaches `type_from_variant()` it now properly creates a `CLASS` datatype and not a `SCRIPT` datatype
