### PR TITLE
[3.x] Physics Interpolation - Move 3D FTI to `SceneTree`

### DIFF
--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -104,6 +104,15 @@ public:
 		}
 	}
 
+	bool erase_unordered(const T &p_val) {
+		int64_t idx = find(p_val);
+		if (idx >= 0) {
+			remove_unordered(idx);
+			return true;
+		}
+		return false;
+	}
+
 	U erase_multiple_unordered(const T &p_val) {
 		U from = 0;
 		U count = 0;

--- a/doc/classes/BoneAttachment.xml
+++ b/doc/classes/BoneAttachment.xml
@@ -14,6 +14,7 @@
 		<member name="bone_name" type="String" setter="set_bone_name" getter="get_bone_name" default="&quot;&quot;">
 			The name of the attached bone.
 		</member>
+		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="1" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VehicleWheel.xml
+++ b/doc/classes/VehicleWheel.xml
@@ -52,6 +52,7 @@
 			[b]Note:[/b] The simulation does not take the effect of gears into account, you will need to add logic for this if you wish to simulate gears.
 			A negative value will result in the wheel reversing.
 		</member>
+		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="1" />
 		<member name="steering" type="float" setter="set_steering" getter="get_steering" default="0.0">
 			The steering angle for the wheel. Setting this to a non-zero value will result in the vehicle turning when it's moving.
 		</member>

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -1488,14 +1488,6 @@
 				Sets a material that will override the material for all surfaces on the mesh associated with this instance. Equivalent to [member GeometryInstance.material_override].
 			</description>
 		</method>
-		<method name="instance_reset_physics_interpolation">
-			<return type="void" />
-			<argument index="0" name="instance" type="RID" />
-			<description>
-				Prevents physics interpolation for the current physics tick.
-				This is useful when moving an instance to a new location, to give an instantaneous change rather than interpolation from the previous location.
-			</description>
-		</method>
 		<method name="instance_set_base">
 			<return type="void" />
 			<argument index="0" name="instance" type="RID" />
@@ -1535,14 +1527,6 @@
 			<argument index="1" name="margin" type="float" />
 			<description>
 				Sets a margin to increase the size of the AABB when culling objects from the view frustum. This allows you to avoid culling objects that fall outside the view frustum. Equivalent to [member GeometryInstance.extra_cull_margin].
-			</description>
-		</method>
-		<method name="instance_set_interpolated">
-			<return type="void" />
-			<argument index="0" name="instance" type="RID" />
-			<argument index="1" name="interpolated" type="bool" />
-			<description>
-				Turns on and off physics interpolation for the instance.
 			</description>
 		</method>
 		<method name="instance_set_layer_mask">

--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -613,7 +613,7 @@ void ARVROrigin::_notification(int p_what) {
 		}; break;
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			// set our world origin to our node transform
-			arvr_server->set_world_origin(get_global_transform());
+			arvr_server->set_world_origin(get_global_transform_interpolated());
 
 			// check if we have a primary interface
 			Ref<ARVRInterface> arvr_interface = arvr_server->get_primary_interface();

--- a/scene/3d/bone_attachment.cpp
+++ b/scene/3d/bone_attachment.cpp
@@ -105,6 +105,7 @@ void BoneAttachment::_notification(int p_what) {
 }
 
 BoneAttachment::BoneAttachment() {
+	set_physics_interpolation_mode(PHYSICS_INTERPOLATION_MODE_OFF);
 	bound = false;
 }
 

--- a/scene/3d/camera.h
+++ b/scene/3d/camera.h
@@ -91,25 +91,9 @@ private:
 	Ref<SpatialVelocityTracker> velocity_tracker;
 	bool affect_lod = true;
 
-	///////////////////////////////////////////////////////
-	// INTERPOLATION FUNCTIONS
-	void _physics_interpolation_ensure_transform_calculated(bool p_force = false) const;
-	void _physics_interpolation_ensure_data_flipped();
-
-	// These can be set by derived Cameras,
-	// if they wish to do processing (while still
-	// allowing physics interpolation to function).
+	// These can be set by derived Cameras.
 	bool _desired_process_internal = false;
 	bool _desired_physics_process_internal = false;
-
-	mutable struct InterpolationData {
-		Transform xform_curr;
-		Transform xform_prev;
-		Transform xform_interpolated;
-		Transform camera_xform_interpolated; // After modification according to camera type.
-		uint32_t last_update_physics_tick = 0;
-		uint32_t last_update_frame = UINT32_MAX;
-	} _interpolation_data;
 
 	void _update_process_mode();
 
@@ -118,9 +102,6 @@ protected:
 	// This is because physics interpolation may need to request process modes additionally.
 	void set_desired_process_modes(bool p_process_internal, bool p_physics_process_internal);
 
-	// Opportunity for derived classes to interpolate extra attributes.
-	virtual void physics_interpolation_flip_data() {}
-
 	virtual void _physics_interpolated_changed();
 	virtual Transform _get_adjusted_camera_transform(const Transform &p_xform) const;
 	///////////////////////////////////////////////////////
@@ -128,6 +109,7 @@ protected:
 	void _update_camera();
 	virtual void _request_camera_update();
 	void _update_camera_mode();
+	virtual void fti_update_servers();
 
 	void _notification(int p_what);
 	virtual void _validate_property(PropertyInfo &p_property) const;
@@ -248,8 +230,9 @@ private:
 
 protected:
 	virtual Transform _get_adjusted_camera_transform(const Transform &p_xform) const;
-	virtual void physics_interpolation_flip_data();
+	virtual void fti_pump();
 	virtual void _physics_interpolated_changed();
+	virtual void fti_update_servers();
 	///////////////////////////////////////////////////////
 
 	void _notification(int p_what);

--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -44,7 +44,7 @@ public:
 
 	real_t getDiagonal() const { return m_Adiag; }
 
-	btVehicleJacobianEntry(){};
+	btVehicleJacobianEntry() {}
 	//constraint between two different rigidbodies
 	btVehicleJacobianEntry(
 			const Basis &world2A,
@@ -366,6 +366,8 @@ VehicleWheel::VehicleWheel() {
 	m_raycastInfo.m_suspensionLength = 0.0;
 
 	body = nullptr;
+
+	set_physics_interpolation_mode(PHYSICS_INTERPOLATION_MODE_OFF);
 }
 
 void VehicleBody::_update_wheel_transform(VehicleWheel &wheel, PhysicsDirectBodyState *s) {

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -82,6 +82,12 @@ void VisualInstance::set_instance_use_identity_transform(bool p_enable) {
 	}
 }
 
+void VisualInstance::fti_update_servers() {
+	if (!_is_using_identity_transform()) {
+		VisualServer::get_singleton()->instance_set_transform(get_instance(), _get_cached_global_transform_interpolated());
+	}
+}
+
 void VisualInstance::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_WORLD: {
@@ -97,31 +103,24 @@ void VisualInstance::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			if (_is_vi_visible() || is_physics_interpolated_and_enabled()) {
+			if (_is_vi_visible()) {
 				if (!_is_using_identity_transform()) {
-					VisualServer::get_singleton()->instance_set_transform(instance, get_global_transform());
-
-					// For instance when first adding to the tree, when the previous transform is
-					// unset, to prevent streaking from the origin.
-					if (_is_physics_interpolation_reset_requested() && is_physics_interpolated_and_enabled() && is_inside_tree()) {
-						if (_is_vi_visible()) {
-							_notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
+					// Physics interpolated VIs don't need to send their transform immediately after setting,
+					// indeed it is counterproductive, because the interpolated transform will be sent
+					// to the VisualServer immediately prior to rendering.
+					if (!is_physics_interpolated_and_enabled()) {
+						VisualServer::get_singleton()->instance_set_transform(instance, get_global_transform());
+					} else {
+						// For instance when first adding to the tree, when the previous transform is
+						// unset, to prevent streaking from the origin.
+						if (_is_physics_interpolation_reset_requested() && is_inside_tree()) {
+							if (_is_vi_visible()) {
+								_notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
+							}
+							_set_physics_interpolation_reset_requested(false);
 						}
-						_set_physics_interpolation_reset_requested(false);
 					}
 				}
-			}
-		} break;
-		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
-			if (_is_vi_visible() && is_physics_interpolated() && is_inside_tree()) {
-				// We must ensure the VisualServer transform is up to date before resetting.
-				// This is because NOTIFICATION_TRANSFORM_CHANGED is deferred,
-				// and cannot be relied to be called in order before NOTIFICATION_RESET_PHYSICS_INTERPOLATION.
-				if (!_is_using_identity_transform()) {
-					VisualServer::get_singleton()->instance_set_transform(instance, get_global_transform());
-				}
-
-				VisualServer::get_singleton()->instance_reset_physics_interpolation(instance);
 			}
 		} break;
 		case NOTIFICATION_EXIT_WORLD: {
@@ -138,10 +137,6 @@ void VisualInstance::_notification(int p_what) {
 			_update_visibility();
 		} break;
 	}
-}
-
-void VisualInstance::_physics_interpolated_changed() {
-	VisualServer::get_singleton()->instance_set_interpolated(instance, is_physics_interpolated());
 }
 
 RID VisualInstance::get_instance() const {

--- a/scene/3d/visual_instance.h
+++ b/scene/3d/visual_instance.h
@@ -51,8 +51,8 @@ class VisualInstance : public CullInstance {
 protected:
 	void _update_visibility();
 	virtual void _refresh_portal_mode();
-	virtual void _physics_interpolated_changed();
 	void set_instance_use_identity_transform(bool p_enable);
+	virtual void fti_update_servers();
 
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/animation/skeleton_ik.cpp
+++ b/scene/animation/skeleton_ik.cpp
@@ -276,7 +276,7 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 	p_task->skeleton->set_bone_global_pose_override(p_task->chain.chain_root.bone, Transform(), 0.0, false);
 	Vector3 origin_pos = p_task->skeleton->get_bone_global_pose(p_task->chain.chain_root.bone).origin;
 
-	make_goal(p_task, p_task->skeleton->get_global_transform().affine_inverse(), blending_delta);
+	make_goal(p_task, p_task->skeleton->get_global_transform_interpolated().affine_inverse(), blending_delta);
 
 	if (p_use_magnet && p_task->chain.middle_chain_item) {
 		p_task->chain.magnet_position = p_task->chain.middle_chain_item->initial_transform.origin.linear_interpolate(p_magnet_position, blending_delta);

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -35,6 +35,7 @@
 #include "core/os/main_loop.h"
 #include "core/os/thread_safe.h"
 #include "core/self_list.h"
+#include "scene/main/scene_tree_fti.h"
 #include "scene/resources/mesh.h"
 #include "scene/resources/world.h"
 #include "scene/resources/world_2d.h"
@@ -160,6 +161,7 @@ private:
 	StretchAspect stretch_aspect;
 	Size2i stretch_min;
 	real_t stretch_scale;
+	SceneTreeFTI scene_tree_fti;
 
 	void _update_font_oversampling(float p_ratio);
 	void _update_root_rect();
@@ -437,6 +439,8 @@ public:
 
 	void client_physics_interpolation_add_spatial(SelfList<Spatial> *p_elem);
 	void client_physics_interpolation_remove_spatial(SelfList<Spatial> *p_elem);
+
+	SceneTreeFTI &get_scene_tree_fti() { return scene_tree_fti; }
 
 	static void add_idle_callback(IdleCallback p_callback);
 	SceneTree();

--- a/scene/main/scene_tree_fti.cpp
+++ b/scene/main/scene_tree_fti.cpp
@@ -1,0 +1,288 @@
+/**************************************************************************/
+/*  scene_tree_fti.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef _3D_DISABLED
+
+#include "scene_tree_fti.h"
+#include "core/engine.h"
+#include "core/error_macros.h"
+#include "core/math/transform_interpolator.h"
+#include "core/os/os.h"
+#include "scene/3d/spatial.h"
+#include "scene/3d/visual_instance.h"
+
+void SceneTreeFTI::_reset_flags(Node *p_node) {
+	Spatial *s = Object::cast_to<Spatial>(p_node);
+
+	if (s) {
+		s->data.fti_on_frame_list = false;
+		s->data.fti_on_tick_list = false;
+
+		// In most cases the later  NOTIFICATION_RESET_PHYSICS_INTERPOLATION
+		// will reset this, but this should help cover hidden nodes.
+		s->data.local_transform_prev = s->data.local_transform;
+	}
+
+	for (int n = 0; n < p_node->get_child_count(); n++) {
+		_reset_flags(p_node->get_child(n));
+	}
+}
+
+void SceneTreeFTI::set_enabled(Node *p_root, bool p_enabled) {
+	if (data.enabled == p_enabled) {
+		return;
+	}
+
+	data.spatial_tick_list[0].clear();
+	data.spatial_tick_list[1].clear();
+
+	// Spatial flags must be reset.
+	if (p_root) {
+		_reset_flags(p_root);
+	}
+
+	data.enabled = p_enabled;
+}
+
+void SceneTreeFTI::tick_update() {
+	if (!data.enabled) {
+		return;
+	}
+
+	uint32_t curr_mirror = data.mirror;
+	uint32_t prev_mirror = curr_mirror ? 0 : 1;
+
+	LocalVector<Spatial *> &curr = data.spatial_tick_list[curr_mirror];
+	LocalVector<Spatial *> &prev = data.spatial_tick_list[prev_mirror];
+
+	// First detect on the previous list but not on this tick list.
+	for (uint32_t n = 0; n < prev.size(); n++) {
+		Spatial *s = prev[n];
+		if (!s->data.fti_on_tick_list) {
+			// Needs a reset so jittering will stop.
+			s->fti_pump();
+
+			// This may not get updated so set it to the same as global xform.
+			// TODO: double check this is the best value.
+			s->data.global_transform_interpolated = s->get_global_transform();
+
+			// Remove from interpolation list.
+			if (s->data.fti_on_frame_list) {
+				s->data.fti_on_frame_list = false;
+			}
+		}
+	}
+
+	// Now pump all on the current list.
+	for (uint32_t n = 0; n < curr.size(); n++) {
+		Spatial *s = curr[n];
+
+		// Reset, needs to be marked each tick.
+		s->data.fti_on_tick_list = false;
+
+		// Pump.
+		s->fti_pump();
+	}
+
+	// Clear previous list and flip.
+	prev.clear();
+	data.mirror = prev_mirror;
+}
+
+void SceneTreeFTI::_spatial_notify_set_transform(Spatial &r_spatial) {
+	// This may be checked by the calling routine already,
+	// but needs to be double checked for custom SceneTrees.
+	if (!data.enabled || !r_spatial.is_physics_interpolated()) {
+		return;
+	}
+
+	if (!r_spatial.data.fti_on_tick_list) {
+		r_spatial.data.fti_on_tick_list = true;
+		data.spatial_tick_list[data.mirror].push_back(&r_spatial);
+	}
+
+	if (!r_spatial.data.fti_on_frame_list) {
+		r_spatial.data.fti_on_frame_list = true;
+	}
+}
+
+void SceneTreeFTI::spatial_notify_delete(Spatial *p_spatial) {
+	if (!data.enabled) {
+		return;
+	}
+
+	if (p_spatial->data.fti_on_frame_list) {
+		p_spatial->data.fti_on_frame_list = false;
+	}
+
+	// This can potentially be optimized for large scenes with large churn,
+	// as it will be doing a linear search through the lists.
+	data.spatial_tick_list[0].erase_unordered(p_spatial);
+	data.spatial_tick_list[1].erase_unordered(p_spatial);
+}
+
+void SceneTreeFTI::_update_dirty_spatials(Node *p_node, uint32_t p_current_frame, float p_interpolation_fraction, bool p_active, const Transform *p_parent_global_xform, int p_depth) {
+	Spatial *s = Object::cast_to<Spatial>(p_node);
+
+	// Don't recurse into hidden branches.
+	if (s && !s->is_visible()) {
+		// NOTE : If we change from recursing entire tree, we should do an is_visible_in_tree()
+		// check for the first of the branch.
+		return;
+	}
+
+	// Not a Spatial.
+	// Could be e.g. a viewport or something
+	// so we should still recurse to children.
+	if (!s) {
+		for (int n = 0; n < p_node->get_child_count(); n++) {
+			_update_dirty_spatials(p_node->get_child(n), p_current_frame, p_interpolation_fraction, p_active, nullptr, p_depth + 1);
+		}
+		return;
+	}
+
+	// Start the active interpolation chain from here onwards
+	// as we recurse further into the SceneTree.
+	// Once we hit an active (interpolated) node, we have to fully
+	// process all ancestors because their xform will also change.
+	// Anything not moving (inactive) higher in the tree need not be processed.
+	if (!p_active) {
+		if (data.frame_start) {
+			// On the frame start, activate whenever we hit something that requests interpolation.
+			if (s->data.fti_on_frame_list) {
+				p_active = true;
+			}
+		} else {
+			// On the frame end, we want to re-interpolate *anything* that has moved
+			// since the frame start.
+			if (s->data.dirty & Spatial::DIRTY_GLOBAL_INTERPOLATED) {
+				p_active = true;
+			}
+		}
+	}
+
+	if (data.frame_start) {
+		// Mark on the Spatial whether we have set global_transform_interp.
+		// This can later be used when calling `get_global_transform_interpolated()`
+		// to know which xform to return.
+		s->data.fti_global_xform_interp_set = p_active;
+	}
+
+	if (p_active) {
+#if 0
+		bool dirty = s->data.dirty & Spatial::DIRTY_GLOBAL_INTERP;
+
+		if (data.debug) {
+			String sz;
+			for (int n = 0; n < p_depth; n++) {
+				sz += "\t";
+			}
+			print_line(sz + p_node->get_name() + (dirty ? " DIRTY" : ""));
+		}
+#endif
+
+		// First calculate our local xform.
+		// This will either use interpolation, or just use the current local if not interpolated.
+		Transform local_interp;
+		if (s->is_physics_interpolated()) {
+			TransformInterpolator::interpolate_transform(s->data.local_transform_prev, s->data.local_transform, local_interp, p_interpolation_fraction);
+		} else {
+			local_interp = s->data.local_transform;
+		}
+
+		// Concatenate parent xform.
+		if (!s->is_set_as_toplevel()) {
+			if (p_parent_global_xform) {
+				s->data.global_transform_interpolated = (*p_parent_global_xform) * local_interp;
+			} else {
+				const Spatial *parent = s->get_parent_spatial();
+
+				if (parent) {
+					const Transform &parent_glob = parent->data.fti_global_xform_interp_set ? parent->data.global_transform_interpolated : parent->data.global_transform;
+					s->data.global_transform_interpolated = parent_glob * local_interp;
+				} else {
+					s->data.global_transform_interpolated = local_interp;
+				}
+			}
+		} else {
+			s->data.global_transform_interpolated = local_interp;
+		}
+
+		// Upload to VisualServer the interpolated global xform.
+		s->fti_update_servers();
+
+	} // if active.
+
+	// Remove the dirty interp flag from EVERYTHING as we go.
+	s->data.dirty &= ~Spatial::DIRTY_GLOBAL_INTERPOLATED;
+
+	// Recurse to children.
+	for (int n = 0; n < p_node->get_child_count(); n++) {
+		_update_dirty_spatials(p_node->get_child(n), p_current_frame, p_interpolation_fraction, p_active, s->data.fti_global_xform_interp_set ? &s->data.global_transform_interpolated : &s->data.global_transform, p_depth + 1);
+	}
+}
+
+void SceneTreeFTI::frame_update(Node *p_root, bool p_frame_start) {
+	if (!data.enabled || !p_root) {
+		return;
+	}
+
+	data.frame_start = p_frame_start;
+
+	float f = Engine::get_singleton()->get_physics_interpolation_fraction();
+	uint32_t frame = Engine::get_singleton()->get_frames_drawn();
+
+// #define SCENE_TREE_FTI_TAKE_TIMINGS
+#ifdef SCENE_TREE_FTI_TAKE_TIMINGS
+	uint64_t before = OS::get_singleton()->get_ticks_usec();
+#endif
+
+	if (data.debug) {
+		print_line(String("\nScene: ") + (data.frame_start ? "start" : "end") + "\n");
+	}
+
+	// Probably not the most optimal approach as we traverse the entire SceneTree
+	// but simple and foolproof.
+	// Can be optimized later.
+	_update_dirty_spatials(p_root, frame, f, false);
+
+	if (!p_frame_start && data.debug) {
+		data.debug = false;
+	}
+
+#ifdef SCENE_TREE_FTI_TAKE_TIMINGS
+	uint64_t after = OS::get_singleton()->get_ticks_usec();
+	if ((Engine::get_singleton()->get_frames_drawn() % 60) == 0) {
+		print_line("Took " + itos(after - before) + " usec " + (data.frame_start ? "start" : "end"));
+	}
+#endif
+}
+
+#endif // ndef _3D_DISABLED

--- a/scene/main/scene_tree_fti.h
+++ b/scene/main/scene_tree_fti.h
@@ -1,0 +1,112 @@
+/**************************************************************************/
+/*  scene_tree_fti.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef SCENE_TREE_FTI_H
+#define SCENE_TREE_FTI_H
+
+#include <core/local_vector.h>
+#include <core/os/mutex.h>
+
+class Spatial;
+class Node;
+class Transform;
+
+#ifdef _3D_DISABLED
+// Stubs
+class SceneTreeFTI {
+public:
+	void frame_update(Node *p_root, bool p_frame_start) {}
+	void tick_update() {}
+	void set_enabled(Node *p_root, bool p_enabled) {}
+	bool is_enabled() const { return false; }
+
+	void spatial_notify_set_transform(Spatial &r_spatial) {}
+	void spatial_notify_delete(Spatial *p_spatial) {}
+};
+#else
+
+// Important.
+// This class uses raw pointers, so it is essential that on deletion, this class is notified
+// so that any references can be cleared up to prevent dangling pointer access.
+
+// This class can be used from a custom SceneTree.
+
+// Note we could potentially make SceneTreeFTI static / global to avoid the lookup through scene tree,
+// but this covers the custom case of multiple scene trees.
+
+// This class is not thread safe, but can be made thread safe easily with a mutex as in the 4.x version.
+
+class SceneTreeFTI {
+	struct Data {
+		// Prev / Curr lists of spatials having local xforms pumped.
+		LocalVector<Spatial *> spatial_tick_list[2];
+		uint32_t mirror = 0;
+
+		bool enabled = false;
+
+		// Whether we are in physics ticks, or in a frame.
+		bool in_frame = false;
+
+		// Updating at the start of the frame, or the end on second pass.
+		bool frame_start = true;
+
+		bool debug = false;
+	} data;
+
+	void _update_dirty_spatials(Node *p_node, uint32_t p_current_frame, float p_interpolation_fraction, bool p_active, const Transform *p_parent_global_xform = nullptr, int p_depth = 0);
+	void _reset_flags(Node *p_node);
+	void _spatial_notify_set_transform(Spatial &r_spatial);
+
+public:
+	// Hottest function, allow inlining the data.enabled check.
+	void spatial_notify_set_transform(Spatial &r_spatial) {
+		if (!data.enabled) {
+			return;
+		}
+		_spatial_notify_set_transform(r_spatial);
+	}
+
+	void spatial_notify_delete(Spatial *p_spatial);
+
+	// Calculate interpolated xforms, send to visual server.
+	void frame_update(Node *p_root, bool p_frame_start);
+
+	// Update local xform pumps.
+	void tick_update();
+
+	void set_enabled(Node *p_root, bool p_enabled);
+	bool is_enabled() const { return data.enabled; }
+
+	void set_debug_next_frame() { data.debug = true; }
+};
+
+#endif // ndef _3D_DISABLED
+
+#endif // SCENE_TREE_FTI_H

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -92,15 +92,7 @@ public:
 		RID material_override;
 		RID material_overlay;
 
-		// This is the main transform to be drawn with ..
-		// This will either be the interpolated transform (when using fixed timestep interpolation)
-		// or the ONLY transform (when not using FTI).
 		Transform transform;
-
-		// for interpolation we store the current transform (this physics tick)
-		// and the transform in the previous tick
-		Transform transform_curr;
-		Transform transform_prev;
 
 		int depth_layer;
 		uint32_t layer_mask;
@@ -122,16 +114,6 @@ public:
 		bool visible : 1;
 		bool baked_light : 1; //this flag is only to know if it actually did use baked light
 		bool redraw_if_visible : 1;
-
-		bool on_interpolate_list : 1;
-		bool on_interpolate_transform_list : 1;
-		bool interpolated : 1;
-		TransformInterpolator::Method interpolation_method : 3;
-
-		// For fixed timestep interpolation.
-		// Note 32 bits is plenty for checksum, no need for real_t
-		float transform_checksum_curr;
-		float transform_checksum_prev;
 
 		float depth; //used for sorting
 
@@ -158,12 +140,6 @@ public:
 			lightmap_capture = nullptr;
 			lightmap_slice = -1;
 			lightmap_uv_rect = Rect2(0, 0, 1, 1);
-			on_interpolate_list = false;
-			on_interpolate_transform_list = false;
-			interpolated = true;
-			interpolation_method = TransformInterpolator::INTERP_LERP;
-			transform_checksum_curr = 0.0;
-			transform_checksum_prev = 0.0;
 		}
 	};
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -573,8 +573,6 @@ public:
 	BIND2(instance_set_layer_mask, RID, uint32_t)
 	BIND3(instance_set_pivot_data, RID, float, bool)
 	BIND2(instance_set_transform, RID, const Transform &)
-	BIND2(instance_set_interpolated, RID, bool)
-	BIND1(instance_reset_physics_interpolation, RID)
 	BIND2(instance_attach_object_instance_id, RID, ObjectID)
 	BIND3(instance_set_blend_shape_weight, RID, int, float)
 	BIND3(instance_set_surface_material, RID, int, RID)

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -397,12 +397,6 @@ public:
 	virtual void set_physics_interpolation_enabled(bool p_enabled);
 
 	struct InterpolationData {
-		void notify_free_instance(RID p_rid, Instance &r_instance);
-		LocalVector<RID> instance_interpolate_update_list;
-		LocalVector<RID> instance_transform_update_lists[2];
-		LocalVector<RID> *instance_transform_update_list_curr = &instance_transform_update_lists[0];
-		LocalVector<RID> *instance_transform_update_list_prev = &instance_transform_update_lists[1];
-
 		bool interpolation_enabled = false;
 	} _interpolation_data;
 
@@ -662,8 +656,6 @@ public:
 	virtual void instance_set_layer_mask(RID p_instance, uint32_t p_mask);
 	virtual void instance_set_pivot_data(RID p_instance, float p_sorting_offset, bool p_use_aabb_center);
 	virtual void instance_set_transform(RID p_instance, const Transform &p_transform);
-	virtual void instance_set_interpolated(RID p_instance, bool p_interpolated);
-	virtual void instance_reset_physics_interpolation(RID p_instance);
 	virtual void instance_attach_object_instance_id(RID p_instance, ObjectID p_id);
 	virtual void instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight);
 	virtual void instance_set_surface_material(RID p_instance, int p_surface, RID p_material);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -481,8 +481,6 @@ public:
 	FUNC2(instance_set_layer_mask, RID, uint32_t)
 	FUNC3(instance_set_pivot_data, RID, float, bool)
 	FUNC2(instance_set_transform, RID, const Transform &)
-	FUNC2(instance_set_interpolated, RID, bool)
-	FUNC1(instance_reset_physics_interpolation, RID)
 	FUNC2(instance_attach_object_instance_id, RID, ObjectID)
 	FUNC3(instance_set_blend_shape_weight, RID, int, float)
 	FUNC3(instance_set_surface_material, RID, int, RID)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2172,8 +2172,6 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("instance_set_scenario", "instance", "scenario"), &VisualServer::instance_set_scenario);
 	ClassDB::bind_method(D_METHOD("instance_set_layer_mask", "instance", "mask"), &VisualServer::instance_set_layer_mask);
 	ClassDB::bind_method(D_METHOD("instance_set_transform", "instance", "transform"), &VisualServer::instance_set_transform);
-	ClassDB::bind_method(D_METHOD("instance_set_interpolated", "instance", "interpolated"), &VisualServer::instance_set_interpolated);
-	ClassDB::bind_method(D_METHOD("instance_reset_physics_interpolation", "instance"), &VisualServer::instance_reset_physics_interpolation);
 	ClassDB::bind_method(D_METHOD("instance_attach_object_instance_id", "instance", "id"), &VisualServer::instance_attach_object_instance_id);
 	ClassDB::bind_method(D_METHOD("instance_set_blend_shape_weight", "instance", "shape", "weight"), &VisualServer::instance_set_blend_shape_weight);
 	ClassDB::bind_method(D_METHOD("instance_set_surface_material", "instance", "surface", "material"), &VisualServer::instance_set_surface_material);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -878,8 +878,6 @@ public:
 	virtual void instance_set_layer_mask(RID p_instance, uint32_t p_mask) = 0;
 	virtual void instance_set_pivot_data(RID p_instance, float p_sorting_offset, bool p_use_aabb_center) = 0;
 	virtual void instance_set_transform(RID p_instance, const Transform &p_transform) = 0;
-	virtual void instance_set_interpolated(RID p_instance, bool p_interpolated) = 0;
-	virtual void instance_reset_physics_interpolation(RID p_instance) = 0;
 	virtual void instance_attach_object_instance_id(RID p_instance, ObjectID p_id) = 0;
 	virtual void instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight) = 0;
 	virtual void instance_set_surface_material(RID p_instance, int p_surface, RID p_material) = 0;


### PR DESCRIPTION
Moves 3D interpolation from `VisualServer` to the client code (`SceneTree`).
Complete rework of 3D physics interpolation, but using the same user API.

* API compatible / backward compatible with old system
* Solves a large number of bugs with complex cases
* Much easier user experience with `physics_interpolation_mode` OFF branches
* Accurately renders scene tree pivot relationships

Fixes #103683 (for 3.x)
Fixes #104198 (for 3.x)
Fixes #103724 (for 3.x)
Fixes #103025 (for 3.x)
May help address #101823 (for 3.x)

Adds a `SceneTreeFTI` class with the intention of being used by third parties that write their own custom `SceneTree`, so 
even custom versions of Godot can easily integrate FTI.

Fixes IK with root motion, Wheels, Pivot relationships, OFF branches

https://github.com/user-attachments/assets/a3dab46a-c407-4040-8124-12513ad97cb2

## Notes
* Intention is to try this in 3.x, then port to 4.x if successful.
* This will benefit greatly from #103708 as `cast_to` is one of the bottlenecks in scene tree traversal. Waiting for that PR to be reviewed etc before porting it to 3.x.
* The two passes of scene tree traversal *is expensive* on large scenes (~700ns for TPS demo on my machine) so I have some ideas for optimizing that significantly, but I don't want to do that in this PR (and introduce more potential for bugs at this stage).

## Interpolating custom properties
_Note: This section is aimed at maintainers rather than users._

The new system allows fairly simply interpolating a new property.
Let's say for example we want to interpolate a light color:
* Define a current and previous value in your code:
e.g.
```
Color light_col_prev;
Color light_col_curr;
```
* Set your current value when the user changes this, and call `fti_notify_node_changed()`
* Implement `fti_pump()`, this will handle pumping and resets automatically:
```
void MyClass::fti_pump() {
light_col_prev = light_col_curr;
Spatial::fti_pump(); // Call the parent class to ensure all data is pumped.
}
```
* Implement `fti_update_servers()`:
```
void MyClass::fti_update_servers() {
Color col = lerp(light_col_prev, light_col_curr, Engine::get_singleton()->get_physics_interpolation_fraction());
VisualServer::get_singleton()->light_update_color(instance, col);
VisualInstance::fti_update_servers(); // Call the parent class to ensure all data is sent to servers. 
}
```

## Two passes
There is a chicken egg problem with `get_global_transform_interpolated()`. Ideally we want to concatenate scene tree xforms to calculate interpolated versions _once_ after idle and immediately prior to rendering. _However_ that would mean getting the interpolated xform during `idle` would be at best one frame out of date.

The solution to that is some clever management. First of all we do a pass _before_ idle. This ensures that any initial calls to `get_global_transform_interpolated()` are up to date. When we change node xforms during idle, as part of the normal propagate we add a `DIRTY_GLOBAL_INTERPOLATED` flag to those altered nodes.

Then during the second pass, we refresh _only those nodes_ that have this flag set. Thus we minimize any recalculation of moved nodes.

Strictly speaking we also can make subsequent calls to `get_global_transform_interpolated()` correct as to previous calls which may have set transforms during idle. This can be done by checking the dirty flag, and recalculating any dirty chains. I'm not sure yet whether this will be necessary.

The scene tree traversals in each pass are currently quite expensive. This is due to a number of factors, but primarily there is usually no need to traverse the whole tree, only altered branches, so this can be significantly optimized in future. Scene tree traversal itself is expensive due to `cast_to` and likely jumping around in memory and cache misses due to the nodes being stored in random memory locations.


## Discussion
_I'll refer to physics interpolation here by the more accurate name, Fixed Timestep Interpolation (abbreviated to FTI)._

Although 3D FTI has been present in 3.x for 3 years, it hasn't had a lot of testing, and we are finally getting some decent testing in 4.x which has led me to propose changing the architecture to fix a number of areas / bug potential.

### FTI in the VisualServer
The original decision for having the FTI take place in `VisualServer` was made by @reduz after I presented a number of alternative approaches. Note that 2D works completely differently from 3D, we only discuss 3D here.

There are some proposed advantages to having it take place in the server:
* In the situation where FPS is higher than the physics tick rate, the traffic over the client-server command queue is reduced,  there is the potential (in theory) to use less CPU.
* FTI calculations can be done on the render thread instead of the main thread.
* There is at least the potential that users of the `VisualServer` interface directly could take advantage of the existing machinery in the server.

In return there are a number of disadvantages:
* The major disadvantage is that interpolated xforms are not available to scene side code. Retrieving them from the server is not an option due to synchronization and stalls.
* Parent child relationships are not sent to `VisualServer` and only the global xform is sent. As a result PIVOT relationships in the scene tree cannot be accurately represented, and must be approximated, which results in a lot of visual anomalies. These can be reduced (but not eliminated) by running at high tick rate.

I was not convinced this approach was the best at the time, and tried my best to voice concern, but was ultimately only allowed to implement it in the server.

### Alternatives
The obvious alternatives were:

1) Perform FTI scene tree side (this is what my [smoothing addon](https://github.com/lawnjelly/smoothing-addon) does)
2) Send parent child relationships to the server, along with local xforms, and either calculate global xforms on the server or send both from the client

(2) is the approach used by 2D already (it calculates the global xforms during the render pass in the server), but there was a fear that changing the 3D to do the same would require significant rework.

### Problems and special cases
Now some time has passed and we are getting a clearer idea of the problems, the biggest problem we face is that certain scene tree nodes require access to interpolated xforms in order to work, and they also need to operate with `physics_interpolation_mode` OFF, i.e. on the frame instead of on the tick.

Some examples:
* Mouse controlled cameras
* IK
* Ragdoll
* XR
* Skeleton attachments
* Following nodes
* Skeletons in general

### Workarounds
To this end I started adding workarounds to this problem, including the ability to try and duplicate the interpolation calculation for specific nodes in the scene tree using the `get_global_transform_interpolated()` machinery.

This works to an extend but there is a large bug surface particularly for when the flow of xforms is interrupted.

In order to sensibly work with branches that set their `physics_interpolation_mode` to OFF we want them to inherit the _interpolated xform_ from their parent, but with the old system they inherit the _physics xform_ which only moves each physics tick. This means we need to either have to burden the user with writing gdscript to do this, or manage the engine so that these nodes can automatically do client side FTI for their parent nodes, which is inefficient, error prone, and a potential user experience nightmare.

We are now facing a number of bugs in these above systems which _other maintainers_ have to look at, and it is difficult to get their heads around the whole client / server separation of interpolation data, which makes me question, there must be a better way of addressing this, rather than adding more workarounds, bug surface, and future maintenance burden.

### Revisiting the scene side approach
Earlier this week a user trying to convert their project from `smoothing addon` asked me the very valid question:

> Why is the smoothing addon easier to use than core interpolation?

I started with the excuses about being constrained etc ... but realised that ultimately, for Godot, the user experience should trump everything else.

If USERS find it more difficult to use the current approach, then this alone should provide sufficient reason for us to explore alternative implementations, according to the Godot philosophy.

So this week we have come around to the bold idea that the simplest and most practical longterm solution for the engine may be to move the 3D FTI to be done scene side, and remove it from the server (_with some small exceptions like multimesh for performance reasons_).

I wrote a testbed this week, and it took just a day to implement the basic system that was far more robust and reliable than the server side system, and contained a lot less code. I then discussed with various other maintainers and we agreed that it likely made sense to proceed with this new method, initially in 3.x with a view to also changing in 4.x if the tests were successful.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
