### PR TITLE
EditorHelpBit: Fix symbol type name capitalization for text files

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -4136,7 +4136,7 @@ void EditorHelpBit::parse_symbol(const String &p_symbol, const String &p_prologu
 			help_data.doc_type.type = ResourceLoader::get_resource_type(path);
 			if (help_data.doc_type.type.is_empty()) {
 				const Vector<String> textfile_ext = ((String)(EDITOR_GET("docks/filesystem/textfile_extensions"))).split(",", false);
-				symbol_type = textfile_ext.has(path.get_extension()) ? TTR("TextFile") : TTR("File");
+				symbol_type = textfile_ext.has(path.get_extension()) ? TTR("Text File") : TTR("File");
 			} else {
 				symbol_type = TTR("Resource");
 				symbol_hint = SYMBOL_HINT_ASSIGNABLE;


### PR DESCRIPTION
`symbol_type` is the text that appears at the top of the `EditorHelpBit` tooltip.

![image](https://github.com/user-attachments/assets/7f4b61fa-d713-4769-beb0-9654b81f812e)

Using `TextFile` is confusing for translators since `TextFile` is usually used as an untranslatable class name in other places.

CamelCase naming is also inconsistent with other symbol types.

https://github.com/godotengine/godot/blob/134da374975114ef8e05cf81d1d30eff645e310e/editor/editor_help.cpp#L4090-L4092