### PR TITLE
[Core] Fix `AHashMap` constructors reserving too few elements

### DIFF
--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -666,7 +666,9 @@ public:
 	}
 
 	AHashMap(const HashMap<TKey, TValue> &p_other) {
-		reserve(p_other.size());
+		if (p_other.size() > get_capacity()) {
+			reserve(p_other.size());
+		}
 		for (const KeyValue<TKey, TValue> &E : p_other) {
 			uint32_t hash = _hash(E.key);
 			_insert_element(E.key, E.value, hash);
@@ -704,7 +706,9 @@ public:
 	}
 
 	AHashMap(std::initializer_list<KeyValue<TKey, TValue>> p_init) {
-		reserve(p_init.size());
+		if (p_init.size() > get_capacity()) {
+			reserve(p_init.size());
+		}
 		for (const KeyValue<TKey, TValue> &E : p_init) {
 			insert(E.key, E.value);
 		}


### PR DESCRIPTION
Ensures that the reserved capacity in these cases is not smaller than the minimum, same check as in the assignment operator.

* Closes: https://github.com/godotengine/godot/issues/103654
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
