### PR TITLE
Documentation - RenderingDevice.xml update

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -188,7 +188,7 @@
 			<param index="1" name="buffer" type="PackedByteArray" />
 			<param index="2" name="size_bytes" type="int" />
 			<description>
-				Sets the push constant data to [param buffer] for the specified [param compute_list]. The shader determines how this binary data is used. The buffer must be 16 byte aligned, padded if need be. The buffer's size in bytes must also be specified in [param size_bytes] (this can be obtained by calling the [method PackedByteArray.size] method on the passed [param buffer]). 
+				Sets the push constant data to [param buffer] for the specified [param compute_list]. The shader determines how this binary data is used. The buffer must be 16 byte aligned. The buffer's size in bytes must also be specified in [param size_bytes] (this can be obtained by calling the [method PackedByteArray.size] method on the passed [param buffer]). 
 			</description>
 		</method>
 		<method name="compute_pipeline_create">

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -188,7 +188,7 @@
 			<param index="1" name="buffer" type="PackedByteArray" />
 			<param index="2" name="size_bytes" type="int" />
 			<description>
-				Sets the push constant data to [param buffer] for the specified [param compute_list]. The shader determines how this binary data is used. The buffer's size in bytes must also be specified in [param size_bytes] (this can be obtained by calling the [method PackedByteArray.size] method on the passed [param buffer]).
+				Sets the push constant data to [param buffer] for the specified [param compute_list]. The shader determines how this binary data is used. The buffer must be 16 byte aligned, padded if need be. The buffer's size in bytes must also be specified in [param size_bytes] (this can be obtained by calling the [method PackedByteArray.size] method on the passed [param buffer]). 
 			</description>
 		</method>
 		<method name="compute_pipeline_create">


### PR DESCRIPTION
Adds some documentation mentioning that `compute_list_set_push_constant `requires the passed array to be 16 byte aligned. This is mentioned in the Compositor tutorial but is fairly easy to miss.