### PR TITLE
[Docs] Fix WorkerThreadPool wrong max thread value description.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3211,7 +3211,7 @@
 			The ratio of [WorkerThreadPool]'s threads that will be reserved for low-priority tasks. For example, if 10 threads are available and this value is set to [code]0.3[/code], 3 of the worker threads will be reserved for low-priority tasks. The actual value won't exceed the number of CPU cores minus one, and if possible, at least one worker thread will be dedicated to low-priority tasks.
 		</member>
 		<member name="threading/worker_pool/max_threads" type="int" setter="" getter="" default="-1">
-			Maximum number of threads to be used by [WorkerThreadPool]. Value of [code]-1[/code] means no limit.
+			Maximum number of threads to be used by [WorkerThreadPool]. Value of [code]-1[/code] means [code]1[/code] on Web, or a number of [i]logical[/i] CPU cores available on other platforms (see [method OS.get_processor_count]).
 		</member>
 		<member name="xr/openxr/binding_modifiers/analog_threshold" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], enables the analog threshold binding modifier if supported by the XR runtime.


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/102877

`-1` is using `get_default_thread_pool_size`:

https://github.com/godotengine/godot/blob/134da374975114ef8e05cf81d1d30eff645e310e/core/object/worker_thread_pool.cpp#L765-L767

which is:

https://github.com/godotengine/godot/blob/134da374975114ef8e05cf81d1d30eff645e310e/core/os/os.h#L324
https://github.com/godotengine/godot/blob/134da374975114ef8e05cf81d1d30eff645e310e/platform/web/os_web.h#L95