### PR TITLE
Optimize `Object::cast_to` by assuming no virtual and multiple inheritance, gaining 7x throughput over `dynamic_cast`.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -860,7 +860,12 @@ else:  # GCC, Clang
     common_warnings = []
 
     if methods.using_gcc(env):
-        common_warnings += ["-Wshadow", "-Wno-misleading-indentation"]
+        common_warnings += [
+            "-Wshadow",
+            "-Wno-misleading-indentation",
+            # For optimized Object::cast_to / object.inherits_from()
+            "-Wvirtual-inheritance",
+        ]
         if cc_version_major < 11:
             # Regression in GCC 9/10, spams so much in our variadic templates
             # that we need to outright disable it.

--- a/scene/gui/dialogs.compat.inc
+++ b/scene/gui/dialogs.compat.inc
@@ -30,6 +30,8 @@
 
 #ifndef DISABLE_DEPRECATED
 
+#include "scene/gui/line_edit.h"
+
 void AcceptDialog::_register_text_enter_bind_compat_89419(Control *p_line_edit) {
 	register_text_enter(Object::cast_to<LineEdit>(p_line_edit));
 }


### PR DESCRIPTION
`Object::cast_to` is used to check if an object is of a certain type. Its current implementation uses `dynamic_cast` to accomplish this. `dynamic_cast` is notoriously slow, and can be optimized under certain assumptions.

`Object::cast_to` is called ~2500 times across the codebase, so this should affect many areas of the engine, [including scene tree traversal](https://github.com/godotengine/godot/pull/103693#issuecomment-2703898864).

(This implementation is almost as fast as https://github.com/godotengine/godot/pull/103693, but applies to _all_ Object classes, not just final classes.)

### Explanation

To find out why `dynamic_cast` is so slow, I watched [this cppcon talk](https://www.youtube.com/watch?v=QzJL-8WbpuU) by Arthur O'Dwyer, but TL;DR is:
- It needs to account for virtual subclasses
- It needs to account for multiple inheritance
- It needs to account for access modifiers
- Implementations are suboptimal

For `Object`, we can assume simple, linear inheritance. In essence, we should only need to check 2 or 3 values for everything we pass in.
To implement this simplification, I used the `virtual` method trick as in [the talk](https://www.youtube.com/watch?v=QzJL-8WbpuU), but simplified it further to just _ignore_ all the problematic parts that could slow it down. The compiler will inline calls and simplify to a few int comparisons, making the implementation _extremely_ fast.

### Benchmarks

I benchmarked a performance difference of about `7x` for both hits and misses:

<details>
<summary>Code</summary>

(notably out-of-project for quick iteration)

```c++
struct Object {
	virtual ~Object() = default;
	virtual void a() {}
	virtual bool derives_from(const std::type_info &type_info) {
		return typeid(decltype(this)) == type_info;
	}
};

struct B : public Object {
	void a() override {}
	virtual bool derives_from(const std::type_info &type_info) {
		return typeid(decltype(this)) == type_info || Object::derives_from(type_info);
	}
};

struct C : public B {
	void a() override {}
	__attribute__ ((noinline)) void test() {}
	virtual bool derives_from(const std::type_info &type_info) {
		return typeid(decltype(this)) == type_info || B::derives_from(type_info);
	}
};

template <typename T>
static T *cast_to_old(Object *p_object) {
	return dynamic_cast<T *>(p_object);
}

template <typename T>
__attribute__ ((noinline)) void test_old(Object *a) {
	for (int i = 0; i < 100000000; ++i) {
		T *c = cast_to_old<T>(a);
		if (c) {
			c->test();
		}
	}
}

template <typename T>
static T *cast_to_virtual(Object *p_object) {
	return p_object->derives_from(typeid(T)) ? static_cast<T *>(p_object) : nullptr;
}

template <typename T>
__attribute__ ((noinline)) void test_virtual(Object *a) {
	for (int i = 0; i < 100000000; ++i) {
		T *c = cast_to_virtual<T>(a);
		if (c) {
			c->test();
		}
	}
}

int main()
{
	{
		auto t0 = std::chrono::high_resolution_clock::now();
		test_old<C>(new C());
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
	{
		auto t0 = std::chrono::high_resolution_clock::now();
		test_old<C>(new B());
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}


	{
		auto t0 = std::chrono::high_resolution_clock::now();
		test_virtual<C>(new C());
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
	{
		auto t0 = std::chrono::high_resolution_clock::now();
		test_virtual<C>(new B());
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
}
```
</details>

This printed:
```
(old implementation)
973ms (hit: cast C to C)
760ms (miss: cast B to C)

(new implementation)
110ms (hit: cast C to C)
90ms (miss: cast B to C)
```

Edit: I now also tested in-project differences in speed, it's comparable to the example above:
<details>
<summary>Code</summary>

```c++
__attribute__ ((noinline)) void test(Object *obj) {

}

template <typename T>
static T *cast_to_old(Object *p_object) {
	return dynamic_cast<T *>(p_object);
}

template <typename T>
__attribute__ ((noinline)) void test_old(Object *a) {
	for (int i = 0; i < 100000000; ++i) {
		T *c = cast_to_old<T>(a);
		if (c) {
			test(c);
		}
	}
}

template <typename T>
__attribute__ ((noinline)) void test_new(Object *a) {
	for (int i = 0; i < 100000000; ++i) {
		T *c = Object::cast_to<T>(a);
		if (c) {
			test(c);
		}
	}
}

int test_main(int argc, char *argv[]) {
	Object *obj = memnew(Node3D);

	{
		auto t0 = std::chrono::high_resolution_clock::now();
		test_old<Node3D>(obj);
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
	{
		auto t0 = std::chrono::high_resolution_clock::now();
		test_new<Node3D>(obj);
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
```
</details>

This printed:
- `539ms` (test_old)
- `126ms` (test_new)

### Caveats

This optimizations bars us from virtual inheritance for `Object` derived classes.
I don't think this is bad. For one, the current `GDCLASS` system doesn't support it anyway. In addition, it would arguably be bad code to do so. In any case, I added `-Wvirtual-inheritance` to compiler warnings as a sanity check.

I think this change would break compatibility with GDExtension, as they would now be required to override `derives_from` in `GDCLASS` as well. (Edit: Or it may not practically, see https://github.com/godotengine/godot/pull/103708#issuecomment-2704390632).

It's possible that other compilers fare worse than clang, especially without optimization, because parent calls to `derives_from` may not be inlined. I'm not sure if it's possible to `FORCE_INLINE` a virtual function call (or at least, a static call to a virtual function).

This PR also seems to increase binary size by ~800kb for me. I think it's worth it, and I might be able to cut that down again in a follow up PR.