### PR TITLE
Add a setting to control the limit of files in quick search

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -608,6 +608,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "filesystem/quick_open_dialog/max_fuzzy_misses", 2, "0,10,1", PROPERTY_USAGE_DEFAULT)
 	_initial_set("filesystem/quick_open_dialog/include_addons", false);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "filesystem/quick_open_dialog/default_display_mode", 0, "Adaptive,Last Used")
+	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "filesystem/quick_open_dialog/show_all_files_threshold", 30, "0,200,1", PROPERTY_USAGE_DEFAULT)
 
 	// Import (for glft module)
 	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "filesystem/import/blender/blender_path", "", "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING)

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -464,7 +464,8 @@ void QuickOpenResultContainer::update_results() {
 }
 
 void QuickOpenResultContainer::_use_default_candidates() {
-	if (filepaths.size() <= SHOW_ALL_FILES_THRESHOLD) {
+	int show_all_files_threshold = EDITOR_GET("filesystem/quick_open_dialog/show_all_files_threshold");
+	if (filepaths.size() <= show_all_files_threshold) {
 		candidates.resize(filepaths.size());
 		QuickOpenResultCandidate *candidates_write = candidates.ptrw();
 		for (const String &filepath : filepaths) {

--- a/editor/gui/editor_quick_open_dialog.h
+++ b/editor/gui/editor_quick_open_dialog.h
@@ -107,7 +107,6 @@ protected:
 	void _notification(int p_what);
 
 private:
-	static constexpr int SHOW_ALL_FILES_THRESHOLD = 30;
 	static constexpr int MAX_HISTORY_SIZE = 20;
 
 	Vector<FuzzySearchResult> search_results;


### PR DESCRIPTION
The current threshold for displaying all files in quick load is too small, so I added a value to the editor Settings to allow for a custom threshold

A show all files threshold attribute has been added to the editor Settings to replace the original SHOW_ALL_FILES_THRESHOLD, so that developers can customize the number of files displayed in the fast loading interface

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
![image](https://github.com/user-attachments/assets/5dbf4390-eb1b-40a4-a86c-010c1b60a03d)

- #103558
