### PR TITLE
[.NET] Skip re-saving `.csproj` when TFM is unchanged

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectUtils.cs
@@ -191,6 +191,13 @@ namespace GodotTools.ProjectEditor
                 // Otherwise, it can be removed.
                 if (mainTfmVersion > minTfmVersion)
                 {
+                    var propertyTfmVersion = NuGetFramework.Parse(property.Value).Version;
+                    if (propertyTfmVersion == minTfmVersion)
+                    {
+                        // The 'TargetFramework' property already matches the minimum version.
+                        continue;
+                    }
+
                     property.Value = minTfmValue;
                 }
                 else


### PR DESCRIPTION
Avoids updating the platform-specific `TargetFramework` properties if they already match the minimum required version.

- Fixes https://github.com/godotengine/godot/issues/103690.