### PR TITLE
Link `Script` method documentation to details about returned dictionaries

### DIFF
--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -74,18 +74,21 @@
 			<return type="Dictionary[]" />
 			<description>
 				Returns the list of methods in this [Script].
+				[b]Note:[/b] The dictionaries returned by this method are formatted identically to those returned by [method Object.get_method_list].
 			</description>
 		</method>
 		<method name="get_script_property_list">
 			<return type="Dictionary[]" />
 			<description>
 				Returns the list of properties in this [Script].
+				[b]Note:[/b] The dictionaries returned by this method are formatted identically to those returned by [method Object.get_property_list].
 			</description>
 		</method>
 		<method name="get_script_signal_list">
 			<return type="Dictionary[]" />
 			<description>
 				Returns the list of user signals defined in this [Script].
+				[b]Note:[/b] The dictionaries returned by this method are formatted identically to those returned by [method Object.get_signal_list].
 			</description>
 		</method>
 		<method name="has_script_signal" qualifiers="const">


### PR DESCRIPTION
Added links for `get_script_method_list()`, `get_script_property_list()`, and `get_script_signal_list()` to corresponding `Object` method documentation that includes details about the entries in the returned dictionaries.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
