### PR TITLE
Make build profile project detection also set build options

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -862,6 +862,19 @@ String GDExtensionResourceLoader::get_resource_type(const String &p_path) const 
 }
 
 #ifdef TOOLS_ENABLED
+void GDExtensionResourceLoader::get_classes_used(const String &p_path, HashSet<StringName> *r_classes) {
+	Ref<GDExtension> gdext = ResourceLoader::load(p_path);
+	if (gdext.is_null()) {
+		return;
+	}
+
+	for (const StringName class_name : gdext->get_classes_used()) {
+		if (ClassDB::class_exists(class_name)) {
+			r_classes->insert(class_name);
+		}
+	}
+}
+
 bool GDExtension::has_library_changed() const {
 	return loader->has_library_changed();
 }

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -184,6 +184,9 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
+#ifdef TOOLS_ENABLED
+	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes) override;
+#endif // TOOLS_ENABLED
 };
 
 #ifdef TOOLS_ENABLED

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -78,6 +78,8 @@ public:
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes) override;
 	virtual bool exists(const String &p_path) const override;
 
+	void get_build_dependencies(const String &p_path, HashSet<String> *r_dependencies);
+
 	virtual int get_import_order(const String &p_path) const override;
 
 	Error get_import_order_threads_and_importer(const String &p_path, int &r_order, bool &r_can_threads, String &r_importer) const;
@@ -106,6 +108,8 @@ class ResourceImporter : public RefCounted {
 	GDCLASS(ResourceImporter, RefCounted);
 
 protected:
+	GDVIRTUAL1RC(Vector<String>, _get_build_dependencies, String)
+
 	static void _bind_methods();
 
 public:
@@ -155,6 +159,8 @@ public:
 	virtual Error import_group_file(const String &p_group_file, const HashMap<String, HashMap<StringName, Variant>> &p_source_file_options, const HashMap<String, String> &p_base_paths) { return ERR_UNAVAILABLE; }
 	virtual bool are_import_settings_valid(const String &p_path, const Dictionary &p_meta) const { return true; }
 	virtual String get_import_settings_string() const { return String(); }
+
+	virtual void get_build_dependencies(const String &p_path, HashSet<String> *r_build_dependencies);
 };
 
 VARIANT_ENUM_CAST(ResourceImporter::ImportOrder);

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -2152,6 +2152,30 @@ bool ClassDB::is_class_runtime(const StringName &p_class) {
 	return ti->is_runtime;
 }
 
+#ifdef TOOLS_ENABLED
+void ClassDB::add_class_dependency(const StringName &p_class, const StringName &p_dependency) {
+	Locker::Lock lock(Locker::STATE_WRITE);
+
+	ERR_FAIL_COND_MSG(!classes.has(p_class), vformat("Request for nonexistent class '%s'.", p_class));
+	if (classes[p_class].dependency_list.find(p_dependency)) {
+		ERR_FAIL();
+	}
+
+	classes[p_class].dependency_list.push_back(p_dependency);
+}
+
+void ClassDB::get_class_dependencies(const StringName &p_class, List<StringName> *r_rependencies) {
+	Locker::Lock lock(Locker::STATE_READ);
+
+	ClassInfo *ti = classes.getptr(p_class);
+	ERR_FAIL_NULL_MSG(ti, vformat("Cannot get class '%s'.", String(p_class)));
+
+	for (const StringName &dep : ti->dependency_list) {
+		r_rependencies->push_back(dep);
+	}
+}
+#endif // TOOLS_ENABLED
+
 void ClassDB::add_resource_base_extension(const StringName &p_extension, const StringName &p_class) {
 	if (resource_base_extensions.has(p_extension)) {
 		return;

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -118,6 +118,7 @@ public:
 		HashMap<StringName, MethodInfo> signal_map;
 		List<PropertyInfo> property_list;
 		HashMap<StringName, PropertyInfo> property_map;
+
 #ifdef DEBUG_ENABLED
 		List<StringName> constant_order;
 		List<StringName> method_order;
@@ -127,6 +128,11 @@ public:
 		HashMap<StringName, Vector<Error>> method_error_values;
 		HashMap<StringName, List<StringName>> linked_properties;
 #endif // DEBUG_ENABLED
+
+#ifdef TOOLS_ENABLED
+		List<StringName> dependency_list;
+#endif
+
 		HashMap<StringName, PropertySetGet> property_setget;
 		HashMap<StringName, Vector<uint32_t>> virtual_methods_compat;
 
@@ -498,6 +504,11 @@ public:
 	static bool is_class_exposed(const StringName &p_class);
 	static bool is_class_reloadable(const StringName &p_class);
 	static bool is_class_runtime(const StringName &p_class);
+
+#ifdef TOOLS_ENABLED
+	static void add_class_dependency(const StringName &p_class, const StringName &p_dependency);
+	static void get_class_dependencies(const StringName &p_class, List<StringName> *r_rependencies);
+#endif
 
 	static void add_resource_base_extension(const StringName &p_extension, const StringName &p_class);
 	static void get_resource_base_extensions(List<String> *p_extensions);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -147,6 +147,12 @@ enum PropertyUsageFlags {
 #define ADD_SUBGROUP_INDENT(m_name, m_prefix, m_depth) ::ClassDB::add_property_subgroup(get_class_static(), m_name, m_prefix, m_depth)
 #define ADD_LINKED_PROPERTY(m_property, m_linked_property) ::ClassDB::add_linked_property(get_class_static(), m_property, m_linked_property)
 
+#ifdef TOOLS_ENABLED
+#define ADD_CLASS_DEPENDENCY(m_class) ::ClassDB::add_class_dependency(get_class_static(), m_class)
+#else
+#define ADD_CLASS_DEPENDENCY(m_class)
+#endif
+
 #define ADD_ARRAY_COUNT(m_label, m_count_property, m_count_property_setter, m_count_property_getter, m_prefix) ClassDB::add_property_array_count(get_class_static(), m_label, m_count_property, StringName(m_count_property_setter), StringName(m_count_property_getter), m_prefix)
 #define ADD_ARRAY_COUNT_WITH_USAGE_FLAGS(m_label, m_count_property, m_count_property_setter, m_count_property_getter, m_prefix, m_property_usage_flags) ClassDB::add_property_array_count(get_class_static(), m_label, m_count_property, StringName(m_count_property_setter), StringName(m_count_property_getter), m_prefix, m_property_usage_flags)
 #define ADD_ARRAY(m_array_path, m_prefix) ClassDB::add_property_array(get_class_static(), m_array_path, m_prefix)
@@ -979,7 +985,6 @@ public:
 	bool editor_is_section_unfolded(const String &p_section);
 	const HashSet<String> &editor_get_section_folding() const { return editor_section_folding; }
 	void editor_clear_section_folding() { editor_section_folding.clear(); }
-
 #endif
 
 	// Used by script languages to store binding data.

--- a/doc/classes/ResourceImporter.xml
+++ b/doc/classes/ResourceImporter.xml
@@ -9,6 +9,25 @@
 	<tutorials>
 		<link title="Import plugins">$DOCS_URL/tutorials/plugins/editor/import_plugins.html</link>
 	</tutorials>
+	<methods>
+		<method name="_get_build_dependencies" qualifiers="virtual const">
+			<return type="PackedStringArray" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Called when the engine compilation profile editor wants to check what build options an imported resource needs. For example, [ResourceImporterDynamicFont] has a property called [member ResourceImporterDynamicFont.multichannel_signed_distance_field], that depends on the engine to be build with the "msdfgen" module. If that resource happened to be a custom one, it would be handled like this:
+				[codeblock]
+				func _get_build_dependencies(path):
+				    var resource = load(path)
+				    var dependencies = PackedStringArray()
+
+				    if resource.multichannel_signed_distance_field:
+				        dependencies.push_back("module_msdfgen_enabled")
+
+				    return dependencies
+				[/codeblock]
+			</description>
+		</method>
+	</methods>
 	<constants>
 		<constant name="IMPORT_ORDER_DEFAULT" value="0" enum="ImportOrder">
 			The default import order.

--- a/editor/editor_build_profile.h
+++ b/editor/editor_build_profile.h
@@ -41,13 +41,24 @@ class EditorBuildProfile : public RefCounted {
 public:
 	enum BuildOption {
 		BUILD_OPTION_3D,
-		BUILD_OPTION_PHYSICS_2D,
-		BUILD_OPTION_PHYSICS_3D,
-		BUILD_OPTION_NAVIGATION,
+		BUILD_OPTION_NAVIGATION_2D,
+		BUILD_OPTION_NAVIGATION_3D,
 		BUILD_OPTION_XR,
+		BUILD_OPTION_OPENXR,
+		BUILD_OPTION_WAYLAND,
+		BUILD_OPTION_X11,
 		BUILD_OPTION_RENDERING_DEVICE,
-		BUILD_OPTION_OPENGL,
+		BUILD_OPTION_FORWARD_RENDERER,
+		BUILD_OPTION_MOBILE_RENDERER,
 		BUILD_OPTION_VULKAN,
+		BUILD_OPTION_D3D12,
+		BUILD_OPTION_METAL,
+		BUILD_OPTION_OPENGL,
+		BUILD_OPTION_PHYSICS_2D,
+		BUILD_OPTION_PHYSICS_GODOT_2D,
+		BUILD_OPTION_PHYSICS_3D,
+		BUILD_OPTION_PHYSICS_GODOT_3D,
+		BUILD_OPTION_PHYSICS_JOLT,
 		BUILD_OPTION_TEXT_SERVER_FALLBACK,
 		BUILD_OPTION_TEXT_SERVER_ADVANCED,
 		BUILD_OPTION_DYNAMIC_FONTS,
@@ -59,6 +70,8 @@ public:
 
 	enum BuildOptionCategory {
 		BUILD_OPTION_CATEGORY_GENERAL,
+		BUILD_OPTION_CATEGORY_GRAPHICS,
+		BUILD_OPTION_CATEGORY_PHYSICS,
 		BUILD_OPTION_CATEGORY_TEXT_SERVER,
 		BUILD_OPTION_CATEGORY_MAX,
 	};
@@ -74,7 +87,11 @@ private:
 	static const char *build_option_identifiers[BUILD_OPTION_MAX];
 	static const bool build_option_disabled_by_default[BUILD_OPTION_MAX];
 	static const bool build_option_disable_values[BUILD_OPTION_MAX];
+	static const bool build_option_explicit_use[BUILD_OPTION_MAX];
 	static const BuildOptionCategory build_option_category[BUILD_OPTION_MAX];
+	static const HashMap<BuildOption, LocalVector<BuildOption>> build_option_dependencies;
+	static HashMap<BuildOption, HashMap<String, LocalVector<Variant>>> build_option_settings;
+	static const HashMap<BuildOption, LocalVector<String>> build_option_classes;
 
 	String _get_build_option_name(BuildOption p_build_option) { return get_build_option_name(p_build_option); }
 
@@ -91,6 +108,8 @@ public:
 	void set_disable_build_option(BuildOption p_build_option, bool p_disable);
 	bool is_build_option_disabled(BuildOption p_build_option) const;
 
+	void reset_build_options();
+
 	void set_force_detect_classes(const String &p_classes);
 	String get_force_detect_classes() const;
 
@@ -101,8 +120,13 @@ public:
 
 	static String get_build_option_name(BuildOption p_build_option);
 	static String get_build_option_description(BuildOption p_build_option);
+	static String get_build_option_identifier(BuildOption p_build_option);
 	static bool get_build_option_disable_value(BuildOption p_build_option);
+	static bool get_build_option_explicit_use(BuildOption p_build_option);
 	static BuildOptionCategory get_build_option_category(BuildOption p_build_option);
+	static LocalVector<BuildOption> get_build_option_dependencies(BuildOption p_build_option);
+	static HashMap<String, LocalVector<Variant>> get_build_option_settings(BuildOption p_build_option);
+	static LocalVector<String> get_build_option_classes(BuildOption p_build_option);
 
 	static String get_build_option_category_name(BuildOptionCategory p_build_option_category);
 
@@ -160,7 +184,10 @@ class EditorBuildProfileManager : public AcceptDialog {
 	void _class_list_item_selected();
 	void _class_list_item_edited();
 	void _class_list_item_collapsed(Object *p_item);
-	void _detect_classes();
+
+	bool project_scan_canceled = false;
+
+	void _detect_from_project();
 
 	void _force_detect_classes_changed(const String &p_text);
 
@@ -168,6 +195,7 @@ class EditorBuildProfileManager : public AcceptDialog {
 		uint32_t timestamp = 0;
 		String md5;
 		Vector<String> classes;
+		Vector<String> build_deps;
 	};
 
 	void _find_files(EditorFileSystemDirectory *p_dir, const HashMap<String, DetectedFile> &p_cache, HashMap<String, DetectedFile> &r_detected);

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -65,6 +65,13 @@ String ResourceImporterDynamicFont::get_resource_type() const {
 	return "FontFile";
 }
 
+void ResourceImporterDynamicFont::get_build_dependencies(const String &p_path, HashSet<String> *r_dependencies) {
+	Ref<FontFile> font = ResourceLoader::load(p_path);
+	if (font.is_valid() && font->is_multichannel_signed_distance_field()) {
+		r_dependencies->insert("module_msdfgen_enabled");
+	}
+}
+
 bool ResourceImporterDynamicFont::get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
 	if (p_option == "msdf_pixel_range" && !bool(p_options["multichannel_signed_distance_field"])) {
 		return false;

--- a/editor/import/resource_importer_dynamic_font.h
+++ b/editor/import/resource_importer_dynamic_font.h
@@ -47,6 +47,7 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
+	virtual void get_build_dependencies(const String &p_path, HashSet<String> *r_build_dependencies) override;
 
 	virtual int get_preset_count() const override;
 	virtual String get_preset_name(int p_idx) const override;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2114,6 +2114,10 @@ void ColorPicker::_bind_methods() {
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_normal, "tab_unselected", "TabContainer");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_pressed, "tab_selected", "TabContainer");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_hover, "tab_selected", "TabContainer");
+
+	ADD_CLASS_DEPENDENCY("LineEdit");
+	ADD_CLASS_DEPENDENCY("MenuButton");
+	ADD_CLASS_DEPENDENCY("PopupMenu");
 }
 
 ColorPicker::ColorPicker() {

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -443,6 +443,8 @@ void AcceptDialog::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, AcceptDialog, buttons_separation);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, AcceptDialog, buttons_min_width);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, AcceptDialog, buttons_min_height);
+
+	ADD_CLASS_DEPENDENCY("Button");
 }
 
 void AcceptDialog::_validate_property(PropertyInfo &p_property) const {
@@ -510,6 +512,8 @@ void ConfirmationDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_cancel_button_text"), &ConfirmationDialog::get_cancel_button_text);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "cancel_button_text"), "set_cancel_button_text", "get_cancel_button_text");
+
+	ADD_CLASS_DEPENDENCY("Button");
 }
 
 Button *ConfirmationDialog::get_cancel_button() {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1900,6 +1900,12 @@ void FileDialog::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::PACKED_STRING_ARRAY, "values"), defaults.values, &FileDialog::set_option_values, &FileDialog::get_option_values);
 	base_property_helper.register_property(PropertyInfo(Variant::INT, "default"), defaults.default_idx, &FileDialog::set_option_default, &FileDialog::get_option_default);
 	PropertyListHelper::register_base_helper(&base_property_helper);
+
+	ADD_CLASS_DEPENDENCY("Button");
+	ADD_CLASS_DEPENDENCY("ConfirmationDialog");
+	ADD_CLASS_DEPENDENCY("LineEdit");
+	ADD_CLASS_DEPENDENCY("OptionButton");
+	ADD_CLASS_DEPENDENCY("Tree");
 }
 
 void FileDialog::set_show_hidden_files(bool p_show) {

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -3129,6 +3129,13 @@ void GraphEdit::_bind_methods() {
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, GraphEdit, port_hotzone_inner_extent);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, GraphEdit, port_hotzone_outer_extent);
+
+	ADD_CLASS_DEPENDENCY("Button");
+	ADD_CLASS_DEPENDENCY("GraphFrame");
+	ADD_CLASS_DEPENDENCY("GraphNode");
+	ADD_CLASS_DEPENDENCY("HScrollBar");
+	ADD_CLASS_DEPENDENCY("SpinBox");
+	ADD_CLASS_DEPENDENCY("VScrollBar");
 }
 
 GraphEdit::GraphEdit() {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -3305,6 +3305,8 @@ void LineEdit::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, LineEdit, clear_icon, "clear");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, LineEdit, clear_button_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, LineEdit, clear_button_color_pressed);
+
+	ADD_CLASS_DEPENDENCY("PopupMenu");
 }
 
 LineEdit::LineEdit(const String &p_placeholder) {

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -763,6 +763,8 @@ void MenuBar::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, MenuBar, font_focus_color);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, MenuBar, h_separation);
+
+	ADD_CLASS_DEPENDENCY("PopupMenu");
 }
 
 void MenuBar::set_switch_on_hover(bool p_enabled) {

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -194,6 +194,8 @@ void MenuButton::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("about_to_popup"));
 
+	ADD_CLASS_DEPENDENCY("PopupMenu");
+
 	PopupMenu::Item defaults(true);
 
 	base_property_helper.set_prefix("popup/item_");

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -625,6 +625,8 @@ void OptionButton::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &OptionButton::_dummy_setter, &OptionButton::is_item_disabled);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "separator"), defaults.separator, &OptionButton::_dummy_setter, &OptionButton::is_item_separator);
 	PropertyListHelper::register_base_helper(&base_property_helper);
+
+	ADD_CLASS_DEPENDENCY("PopupMenu");
 }
 
 void OptionButton::set_disable_shortcuts(bool p_disabled) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -7416,6 +7416,8 @@ void RichTextLabel::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, RichTextLabel, table_odd_row_bg);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, RichTextLabel, table_even_row_bg);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, RichTextLabel, table_border);
+
+	ADD_CLASS_DEPENDENCY("PopupMenu");
 }
 
 TextServer::VisibleCharactersBehavior RichTextLabel::get_visible_characters_behavior() const {

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -691,6 +691,8 @@ void SpinBox::_bind_methods() {
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, SpinBox, field_and_buttons_separator, "field_and_buttons_separator");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, SpinBox, up_down_buttons_separator, "up_down_buttons_separator");
+
+	ADD_CLASS_DEPENDENCY("LineEdit");
 }
 
 SpinBox::SpinBox() {

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -1128,6 +1128,8 @@ void TabContainer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_focus_mode", PROPERTY_HINT_ENUM, "None,Click,All"), "set_tab_focus_mode", "get_tab_focus_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_enabled"), "set_deselect_enabled", "get_deselect_enabled");
 
+	ADD_CLASS_DEPENDENCY("TabBar");
+
 	BIND_ENUM_CONSTANT(POSITION_TOP);
 	BIND_ENUM_CONSTANT(POSITION_BOTTOM);
 	BIND_ENUM_CONSTANT(POSITION_MAX);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7629,6 +7629,12 @@ void TextEdit::_bind_methods() {
 	/* Settings. */
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "gui/timers/text_edit_idle_detect_sec", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater"), 3);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "gui/common/text_edit_undo_stack_max_size", PROPERTY_HINT_RANGE, "0,10000,1,or_greater"), 1024);
+
+	/* Dependencies */
+	ADD_CLASS_DEPENDENCY("HScrollBar");
+	ADD_CLASS_DEPENDENCY("PopupMenu");
+	ADD_CLASS_DEPENDENCY("Timer");
+	ADD_CLASS_DEPENDENCY("VScrollBar");
 }
 
 /* Internal API for CodeEdit. */

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -6655,6 +6655,14 @@ void Tree::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, title_button_pressed);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, title_button_hover);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Tree, title_button_color);
+
+	ADD_CLASS_DEPENDENCY("HScrollBar");
+	ADD_CLASS_DEPENDENCY("HSlider");
+	ADD_CLASS_DEPENDENCY("LineEdit");
+	ADD_CLASS_DEPENDENCY("Popup");
+	ADD_CLASS_DEPENDENCY("TextEdit");
+	ADD_CLASS_DEPENDENCY("Timer");
+	ADD_CLASS_DEPENDENCY("VScrollBar");
 }
 
 Tree::Tree() {

--- a/scene/resources/3d/world_3d.cpp
+++ b/scene/resources/3d/world_3d.cpp
@@ -177,18 +177,26 @@ World3D::World3D() {
 
 World3D::~World3D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
+
 #ifndef PHYSICS_3D_DISABLED
 	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
 #endif // PHYSICS_3D_DISABLED
+
+#ifndef NAVIGATION_3D_DISABLED
 	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
+#endif // NAVIGATION_3D_DISABLED
 
 	RenderingServer::get_singleton()->free(scenario);
+
 #ifndef PHYSICS_3D_DISABLED
 	if (space.is_valid()) {
 		PhysicsServer3D::get_singleton()->free(space);
 	}
 #endif // PHYSICS_3D_DISABLED
+
+#ifndef NAVIGATION_3D_DISABLED
 	if (navigation_map.is_valid()) {
 		NavigationServer3D::get_singleton()->free(navigation_map);
 	}
+#endif // NAVIGATION_3D_DISABLED
 }

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1223,14 +1223,9 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 			return error;
 		}
 
-		if (!next_tag.fields.has("type")) {
-			error = ERR_FILE_CORRUPT;
-			error_text = "Missing 'type' in external resource tag";
-			_printerr();
-			return error;
+		if (next_tag.fields.has("type")) {
+			r_classes->insert(next_tag.fields["type"]);
 		}
-
-		r_classes->insert(next_tag.fields["type"]);
 
 		while (true) {
 			String assign;
@@ -1447,9 +1442,9 @@ bool ResourceFormatLoaderText::handles_type(const String &p_type) const {
 }
 
 void ResourceFormatLoaderText::get_classes_used(const String &p_path, HashSet<StringName> *r_classes) {
-	String ext = p_path.get_extension().to_lower();
-	if (ext == "tscn") {
-		r_classes->insert("PackedScene");
+	const String type = get_resource_type(p_path);
+	if (!type.is_empty()) {
+		r_classes->insert(type);
 	}
 
 	// ...for anything else must test...


### PR DESCRIPTION
Currently, the build profile editor only updates the used classes when attempting to detect from the project. This PR makes so that the other settings are also updated from the project information with the following.

- Checking project settings.
- Checking classes that require them.
- And last but definitely not least, import settings. This one required me to add an extra functionality called `get_build_dependencies()`, that works like `get_classes_used()` but is geared towards resource importers. And just like the latter, the former is also exposed to scripting.

However, that are a couple of build options that I couldn't find a way to detect, because as far as I'm aware, there are no settings that could imply if the project is using them or not:
- ~X11/Wayland~
- SIL Graphite Fonts

This PR also fixes some issues necessary to make the feature to work properly:
- Fix error when scanning resource files.
- Fix loading profile files doing nothing.
- Hardcode some classes that are necessary for the engine to function.

**Sponsored By:** 🐺 Lone Wolf Technology / 🍀 W4 Games.