### PR TITLE
Fix incorrect parameters passed to VMA

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -1547,6 +1547,10 @@ RDD::BufferID RenderingDeviceDriverVulkan::buffer_create(uint64_t p_size, BitFie
 		} break;
 		case MEMORY_ALLOCATION_TYPE_GPU: {
 			vma_usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+			if (!Engine::get_singleton()->is_extra_gpu_memory_tracking_enabled()) {
+				// We must set it right now or else vmaFindMemoryTypeIndexForBufferInfo will use wrong parameters.
+				alloc_create_info.usage = vma_usage;
+			}
 			alloc_create_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 			if (p_size <= SMALL_ALLOCATION_MAX_SIZE) {
 				uint32_t mem_type_index = 0;


### PR DESCRIPTION
If the allocation is small enough that it enters the `if (p_size <= SMALL_ALLOCATION_MAX_SIZE) {}` block, Godot would call vmaFindMemoryTypeIndexForBufferInfo with the wrong parameters.

This can cause vmaFindMemoryTypeIndexForBufferInfo to potentially misbehave on some cards or drivers.

Fixes regression introduced in #102830
Might potentially reopen #101850 (I doubt it, but it's possible)

Must be backported to 4.4

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
