### PR TITLE
Make embed floating window respect `Always On Top` configuration

### DIFF
--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -337,6 +337,9 @@ void GameView::_stop_pressed() {
 void GameView::_embedding_completed() {
 	_attach_script_debugger();
 	_update_ui();
+	if (make_floating_on_play) {
+		get_window()->set_flag(Window::FLAG_ALWAYS_ON_TOP, bool(GLOBAL_GET("display/window/size/always_on_top")));
+	}
 }
 
 void GameView::_embedding_failed() {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/101984

Makes the embed floating game window respect the `Always On Top` option.

Tested and working on Windows. 

https://github.com/user-attachments/assets/d8fd43de-fe9b-4fb0-819c-154a8c599f50

