### PR TITLE
Fix navmesh `border_size` precision warnings

### DIFF
--- a/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
@@ -327,7 +327,7 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(Ref<Navigation
 	cfg.detailSampleDist = MAX(p_navigation_mesh->get_cell_size() * p_navigation_mesh->get_detail_sample_distance(), 0.1f);
 	cfg.detailSampleMaxError = p_navigation_mesh->get_cell_height() * p_navigation_mesh->get_detail_sample_max_error();
 
-	if (p_navigation_mesh->get_border_size() > 0.0 && Math::fmod(p_navigation_mesh->get_border_size(), p_navigation_mesh->get_cell_size()) != 0.0) {
+	if (p_navigation_mesh->get_border_size() > 0.0 && !Math::is_zero_approx(Math::fmod(p_navigation_mesh->get_border_size(), p_navigation_mesh->get_cell_size()))) {
 		WARN_PRINT("Property border_size is ceiled to cell_size voxel units and loses precision.");
 	}
 	if (!Math::is_equal_approx((float)cfg.walkableHeight * cfg.ch, p_navigation_mesh->get_agent_height())) {


### PR DESCRIPTION
Minor comparison update when generating navigation meshes, updating the cell_size and border_size float values in godot might generate imprecise float numbers when the code reaches

```
Math::fmod(p_navigation_mesh->get_border_size(), p_navigation_mesh->get_cell_size()) != 0.0
```

Which will always raise a warning even if the fmod would supposedly be 0.0

Been wanting to do this PR in a bit
