### PR TITLE
Change the random pitch on the audio stream randomizer to be in semitones, not a frequency multiplier. 

### DIFF
--- a/doc/classes/AudioStreamRandomizer.xml
+++ b/doc/classes/AudioStreamRandomizer.xml
@@ -69,7 +69,12 @@
 			Controls how this AudioStreamRandomizer picks which AudioStream to play next.
 		</member>
 		<member name="random_pitch" type="float" setter="set_random_pitch" getter="get_random_pitch" default="1.0">
-			The intensity of random pitch variation. A value of 1 means no variation.
+			The largest possible frequency multiplier of the random pitch variation. A value of [code]1.0[/code] means no variation.
+			[b]Note:[/b] Setting this property also sets [member random_pitch_semitones].
+		</member>
+		<member name="random_pitch_semitones" type="float" setter="set_random_pitch_semitones" getter="get_random_pitch_semitones" default="0.0">
+			The largest possible distance, in semitones, of the random pitch variation. A value of [code]0.0[/code] means no variation.
+			[b]Note:[/b] Setting this property also sets [member random_pitch].
 		</member>
 		<member name="random_volume_offset_db" type="float" setter="set_random_volume_offset_db" getter="get_random_volume_offset_db" default="0.0">
 			The intensity of random volume variation. A value of 0 means no variation.

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -568,6 +568,14 @@ float AudioStreamRandomizer::get_random_pitch() const {
 	return random_pitch_scale;
 }
 
+void AudioStreamRandomizer::set_random_pitch_semitones(float p_semitones) {
+	random_pitch_scale = powf(2, p_semitones * 0.08333333f);
+}
+
+float AudioStreamRandomizer::get_random_pitch_semitones() const {
+	return 12.0f * log2f(MAX(1.0f, random_pitch_scale));
+}
+
 void AudioStreamRandomizer::set_random_volume_offset_db(float p_volume_offset_db) {
 	if (p_volume_offset_db < 0) {
 		p_volume_offset_db = 0;
@@ -752,6 +760,9 @@ void AudioStreamRandomizer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_random_pitch", "scale"), &AudioStreamRandomizer::set_random_pitch);
 	ClassDB::bind_method(D_METHOD("get_random_pitch"), &AudioStreamRandomizer::get_random_pitch);
 
+	ClassDB::bind_method(D_METHOD("set_random_pitch_semitones", "semitones"), &AudioStreamRandomizer::set_random_pitch_semitones);
+	ClassDB::bind_method(D_METHOD("get_random_pitch_semitones"), &AudioStreamRandomizer::get_random_pitch_semitones);
+
 	ClassDB::bind_method(D_METHOD("set_random_volume_offset_db", "db_offset"), &AudioStreamRandomizer::set_random_volume_offset_db);
 	ClassDB::bind_method(D_METHOD("get_random_volume_offset_db"), &AudioStreamRandomizer::get_random_volume_offset_db);
 
@@ -759,7 +770,8 @@ void AudioStreamRandomizer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_playback_mode"), &AudioStreamRandomizer::get_playback_mode);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_mode", PROPERTY_HINT_ENUM, "Random (Avoid Repeats),Random,Sequential"), "set_playback_mode", "get_playback_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "random_pitch", PROPERTY_HINT_RANGE, "1,16,0.01"), "set_random_pitch", "get_random_pitch");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "random_pitch", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_random_pitch", "get_random_pitch");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "random_pitch_semitones", PROPERTY_HINT_RANGE, "0,24,0.001,or_greater,suffix:Semitones", PROPERTY_USAGE_EDITOR), "set_random_pitch_semitones", "get_random_pitch_semitones");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "random_volume_offset_db", PROPERTY_HINT_RANGE, "0,40,0.01,suffix:dB"), "set_random_volume_offset_db", "get_random_volume_offset_db");
 	ADD_ARRAY("streams", "stream_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "streams_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_streams_count", "get_streams_count");

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -325,6 +325,9 @@ public:
 	void set_streams_count(int p_count);
 	int get_streams_count() const;
 
+	void set_random_pitch_semitones(float p_pitch_semitones);
+	float get_random_pitch_semitones() const;
+
 	void set_random_pitch(float p_pitch_scale);
 	float get_random_pitch() const;
 


### PR DESCRIPTION
Currently, the value for the audio stream's random pitch is represented as a frequency multiplier. This has two issues:

- This is a non-linear scale, so changes near 0 have dramatic effect, while changes far from 0 have diminishing returns. This can make it tricky to "dial-in" subtle pitch randomization, and is also arguably strange from a UX perspective. To set the range to approximately one semi-tone, the value needs to be 1.06, which is a subtle difference on the current 1-16 scale.
- As mentioned in [this proposal](https://github.com/godotengine/godot-proposals/discussions/10238), the current system is biased towards picking higher-pitched random pitches.

By switching to using semitones for this value, it becomes easier to dial in subtle changes. In addition, since it is a linear system, the random pitch selection isn't biased.

This all being said, this update would cause issues when upgrading from an earlier engine version. Any values used in the randomizer would need to be re-entered, and code that sets or gets the random values would need to be updated (it could be useful to have functions like freq_to_semitone() and semitone_to_freq() for easy converting between the two.)