### PR TITLE
Clarify what is removed when removing a project in the project manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -677,7 +677,7 @@ void ProjectManager::_rename_project() {
 }
 
 void ProjectManager::_erase_project() {
-	const HashSet<String> &selected_list = project_list->get_selected_project_keys();
+	const Vector<ProjectList::Item> &selected_list = project_list->get_selected_projects();
 
 	if (selected_list.size() == 0) {
 		return;
@@ -685,18 +685,17 @@ void ProjectManager::_erase_project() {
 
 	String confirm_message;
 	if (selected_list.size() >= 2) {
-		confirm_message = vformat(TTR("Remove %d projects from the list?"), selected_list.size());
+		confirm_message = vformat(TTR("Remove %d projects from the list?") + "\n" + TTR("Project files and user data won't be removed from disk."), selected_list.size());
 	} else {
-		confirm_message = TTR("Remove this project from the list?");
+		confirm_message = vformat(TTR("Remove project \"%s\" from the list?") + "\n" + TTR("Project files and user data won't be removed from disk."), selected_list[0].project_name);
 	}
 
 	erase_ask_label->set_text(confirm_message);
-	//delete_project_contents->set_pressed(false);
 	erase_ask->popup_centered();
 }
 
 void ProjectManager::_erase_missing_projects() {
-	erase_missing_ask->set_text(TTR("Remove all missing projects from the list?\nThe project folders' contents won't be modified."));
+	erase_missing_ask->set_text(TTR("Remove all missing projects from the list?") + "\n" + TTR("Project files and user data won't be removed from disk."));
 	erase_missing_ask->popup_centered();
 }
 


### PR DESCRIPTION
- Show project name in confirmation dialog when a single project was selected for removal. If multiple projects were selected, show the number of selected projects in the confirmation dialog.

This closes https://github.com/godotengine/godot/issues/103740.

## Preview

![image](https://github.com/user-attachments/assets/5c443f74-7fa4-4844-9b46-94f744c54b02)

![image](https://github.com/user-attachments/assets/9f022ce0-6ba3-4995-b400-b460319d1df0)
