### PR TITLE
Fix `RichTextLabel` table top padding

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -977,6 +977,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 									if (frame->lines.size() != 0 && row < row_count) {
 										Vector2 coff = frame->lines[0].offset;
 										coff.x -= frame->lines[0].indent;
+										coff.y += frame->padding.position.y;
 										if (rtl) {
 											coff.x = rect.size.width - table->columns[col].width - coff.x;
 										}
@@ -998,7 +999,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 									}
 
 									for (int j = 0; j < (int)frame->lines.size(); j++) {
-										_draw_line(frame, j, p_ofs + rect.position + off + Vector2(0, frame->lines[j].offset.y), rect.size.x, 0, p_base_color, p_outline_size, p_outline_color, p_font_shadow_color, p_shadow_outline_size, p_shadow_ofs, r_processed_glyphs);
+										_draw_line(frame, j, p_ofs + rect.position + off + Vector2(0, frame->lines[j].offset.y + frame->padding.position.y), rect.size.x, 0, p_base_color, p_outline_size, p_outline_color, p_font_shadow_color, p_shadow_outline_size, p_shadow_ofs, r_processed_glyphs);
 									}
 									idx++;
 								}
@@ -1609,7 +1610,7 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 									}
 									if (crect.has_point(p_click)) {
 										for (int j = 0; j < (int)frame->lines.size(); j++) {
-											_find_click_in_line(frame, j, rect.position + Vector2(frame->padding.position.x, frame->lines[j].offset.y), rect.size.x, 0, p_click, &table_click_frame, &table_click_line, &table_click_item, &table_click_char, true, p_meta);
+											_find_click_in_line(frame, j, rect.position + Vector2(frame->padding.position.x, frame->lines[j].offset.y + frame->padding.position.y), rect.size.x, 0, p_click, &table_click_frame, &table_click_line, &table_click_item, &table_click_char, true, p_meta);
 											if (table_click_frame && table_click_item) {
 												// Save cell detected cell hit data.
 												table_range = Vector2i(INT32_MAX, 0);


### PR DESCRIPTION
Fixes #103228.
Now while adding top padding to a cell, it no longer covers the cell above and no longer leaves a gap between
itself and the cell bellow. This was due to the position which the cell would be drawn being calculated incorrectly when there was a value of top padding different from 0.

Before when enabling BBCode on a RichTextLabel and populating with:
```
[table=1]
[cell bg=black padding=9,9,9,0]Padding of 9, 9, 9, 0[/cell]
[cell bg=black padding=9,0,9,0]Padding of 9, 0, 9, 0[/cell]
[cell bg=black padding=9,0,9,0]Padding of 9, 0, 9, 0[/cell]
[cell bg=black padding=9,0,9,9]Padding of 9, 0, 9, 9[/cell]
[/table]
```
It would generate the table:
![table1](https://github.com/user-attachments/assets/7b1a3bc8-0352-4a6a-8058-f2e9015cf79d)
Now it generates the table:
![table2](https://github.com/user-attachments/assets/baac75de-338f-4b5f-bfd7-d8e1f92ba47a)


<!--
Please t

arget the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
