### PR TITLE
Make Game view follow more editor settings

### DIFF
--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -65,7 +65,18 @@ void GameViewDebugger::_session_started(Ref<EditorDebuggerSession> p_session) {
 	settings["editors/panning/warped_mouse_panning"] = EDITOR_GET("editors/panning/warped_mouse_panning");
 	settings["editors/panning/2d_editor_pan_speed"] = EDITOR_GET("editors/panning/2d_editor_pan_speed");
 	settings["canvas_item_editor/pan_view"] = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("canvas_item_editor/pan_view"));
+#ifndef _3D_DISABLED
+	settings["editors/3d/default_fov"] = EDITOR_GET("editors/3d/default_fov");
+	settings["editors/3d/default_z_near"] = EDITOR_GET("editors/3d/default_z_near");
+	settings["editors/3d/default_z_far"] = EDITOR_GET("editors/3d/default_z_far");
+	settings["editors/3d/navigation/invert_x_axis"] = EDITOR_GET("editors/3d/navigation/invert_x_axis");
+	settings["editors/3d/navigation/invert_y_axis"] = EDITOR_GET("editors/3d/navigation/invert_y_axis");
+	settings["editors/3d/navigation/warped_mouse_panning"] = EDITOR_GET("editors/3d/navigation/warped_mouse_panning");
 	settings["editors/3d/freelook/freelook_base_speed"] = EDITOR_GET("editors/3d/freelook/freelook_base_speed");
+	settings["editors/3d/freelook/freelook_sensitivity"] = EDITOR_GET("editors/3d/freelook/freelook_sensitivity");
+	settings["editors/3d/navigation_feel/orbit_sensitivity"] = EDITOR_GET("editors/3d/navigation_feel/orbit_sensitivity");
+	settings["editors/3d/navigation_feel/translation_sensitivity"] = EDITOR_GET("editors/3d/navigation_feel/translation_sensitivity");
+#endif // _3D_DISABLED
 	setup_data.append(settings);
 	p_session->send_message("scene:runtime_node_select_setup", setup_data);
 

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -242,20 +242,26 @@ private:
 	const double VIEW_3D_MAX_ZOOM = 1'000'000'000'000;
 #else
 	const float VIEW_3D_MAX_ZOOM = 10'000;
-#endif
-	const float CAMERA_ZNEAR = 0.05;
-	const float CAMERA_ZFAR = 4'000;
+#endif // REAL_T_IS_DOUBLE
 
-	const float CAMERA_BASE_FOV = 75;
 	const float CAMERA_MIN_FOV_SCALE = 0.1;
 	const float CAMERA_MAX_FOV_SCALE = 2.5;
 
-	const float FREELOOK_BASE_SPEED = 4;
-	const float RADS_PER_PIXEL = 0.004;
-
 	bool camera_first_override = true;
 	bool camera_freelook = false;
-	real_t freelook_speed = FREELOOK_BASE_SPEED;
+
+	real_t camera_fov = 0;
+	real_t camera_znear = 0;
+	real_t camera_zfar = 0;
+
+	bool invert_x_axis = false;
+	bool invert_y_axis = false;
+	bool warped_mouse_panning_3d = false;
+
+	real_t freelook_base_speed = 0;
+	real_t freelook_sensitivity = 0;
+	real_t orbit_sensitivity = 0;
+	real_t translation_sensitivity = 0;
 
 	Vector2 previous_mouse_position;
 
@@ -267,7 +273,7 @@ private:
 	RID sbox_3d_instance_xray_ofs;
 	Transform3D sbox_3d_xform;
 	AABB sbox_3d_bounds;
-#endif
+#endif // _3D_DISABLED
 
 	Point2 selection_position = Point2(INFINITY, INFINITY);
 	bool list_shortcut_pressed = false;
@@ -314,6 +320,7 @@ private:
 	void _cursor_look(Ref<InputEventWithModifiers> p_event);
 	void _cursor_pan(Ref<InputEventWithModifiers> p_event);
 	void _cursor_orbit(Ref<InputEventWithModifiers> p_event);
+	Point2 _get_warped_mouse_motion(const Ref<InputEventMouseMotion> &p_event, Rect2 p_border) const;
 	Transform3D _get_cursor_transform();
 	void _reset_camera_3d();
 #endif


### PR DESCRIPTION
This PR adds some more editor settings related to 3D camera control that are no-brainers for the Game view to follow. It isn't _all_ of them, as to avoid even more code duplication and to keep the code simple.

Closes #103668.