### PR TITLE
Don't close the debugger output until flushed

### DIFF
--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -71,6 +71,9 @@ void RemoteDebuggerPeerTCP::close() {
 	if (thread.is_started()) {
 		thread.wait_to_finish();
 	}
+	if (out_queue.size() > 0) {
+		_write_out();
+	}
 	tcp_client->disconnect_from_host();
 	out_buf.clear();
 	in_buf.clear();


### PR DESCRIPTION
- Fixes #79031
- Fixes #79184 

It looks alright to me but I don't have much experience using threads in C++.