### PR TITLE
[3.x] Add `GLOBAL_GET` cached macros.

### DIFF
--- a/core/error_macros.cpp
+++ b/core/error_macros.cpp
@@ -145,7 +145,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 		warn_count = warn_max;
 		warn_timeout = time_now + warn_timeout_seconds;
 
-		if (GLOBAL_GET("debug/settings/physics_interpolation/enable_warnings")) {
+		if (GLOBAL_GET_CACHED(bool, "debug/settings/physics_interpolation/enable_warnings")) {
 			// UINT64_MAX means unused.
 			if (p_id == UINT64_MAX) {
 				_err_print_error(p_function, p_file, p_line, "[Physics interpolation] " + String(p_warn_string) + " (possibly benign).", ERR_HANDLER_WARNING);

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -193,6 +193,7 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 			for (int i = 0; i < custom_feature_array.size(); i++) {
 				custom_features.insert(custom_feature_array[i]);
 			}
+			_version++;
 			return true;
 		}
 
@@ -226,6 +227,7 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 		}
 	}
 
+	_version++;
 	return true;
 }
 bool ProjectSettings::_get(const StringName &p_name, Variant &r_ret) const {

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -275,7 +275,7 @@ void RasterizerGLES2::begin_frame(double frame_step) {
 		frame_step = 0.001;
 	}
 
-	double time_roll_over = GLOBAL_GET("rendering/limits/time/time_rollover_secs");
+	double time_roll_over = GLOBAL_GET_CACHED(double, "rendering/limits/time/time_rollover_secs");
 	time_total = Math::fmod(time_total, time_roll_over);
 
 	storage->frame.time[0] = time_total;

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -4129,9 +4129,9 @@ void RasterizerSceneGLES2::initialize() {
 }
 
 void RasterizerSceneGLES2::iteration() {
-	shadow_filter_mode = ShadowFilterMode(int(GLOBAL_GET("rendering/quality/shadows/filter_mode")));
+	shadow_filter_mode = ShadowFilterMode(int(GLOBAL_GET_CACHED(int32_t, "rendering/quality/shadows/filter_mode")));
 
-	const int directional_shadow_size_new = next_power_of_2(int(GLOBAL_GET("rendering/quality/directional_shadow/size")));
+	const int directional_shadow_size_new = next_power_of_2(GLOBAL_GET_CACHED(int32_t, "rendering/quality/directional_shadow/size"));
 	if (directional_shadow_size != directional_shadow_size_new) {
 		directional_shadow_size = directional_shadow_size_new;
 		directional_shadow_create();

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -2287,7 +2287,7 @@ void RasterizerStorageGLES2::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 	}
 
 	//bool has_morph = p_blend_shapes.size();
-	bool use_split_stream = GLOBAL_GET("rendering/misc/mesh_storage/split_stream") && !(p_format & VS::ARRAY_FLAG_USE_DYNAMIC_UPDATE);
+	bool use_split_stream = GLOBAL_GET_CACHED(bool, "rendering/misc/mesh_storage/split_stream") && !(p_format & VS::ARRAY_FLAG_USE_DYNAMIC_UPDATE);
 
 	Surface::Attrib attribs[VS::ARRAY_MAX];
 

--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -1225,7 +1225,7 @@ ShaderCompilerGLES2::ShaderCompilerGLES2() {
 	//actions[VS::SHADER_SPATIAL].render_mode_defines["cull_front"] = "#define DO_SIDE_CHECK\n";
 	//actions[VS::SHADER_SPATIAL].render_mode_defines["cull_disabled"] = "#define DO_SIDE_CHECK\n";
 
-	bool force_lambert = GLOBAL_GET("rendering/quality/shading/force_lambert_over_burley");
+	bool force_lambert = GLOBAL_GET_CACHED(bool, "rendering/quality/shading/force_lambert_over_burley");
 
 	if (!force_lambert) {
 		actions[VS::SHADER_SPATIAL].render_mode_defines["diffuse_burley"] = "#define DIFFUSE_BURLEY\n";
@@ -1235,7 +1235,7 @@ ShaderCompilerGLES2::ShaderCompilerGLES2() {
 	actions[VS::SHADER_SPATIAL].render_mode_defines["diffuse_lambert_wrap"] = "#define DIFFUSE_LAMBERT_WRAP\n";
 	actions[VS::SHADER_SPATIAL].render_mode_defines["diffuse_toon"] = "#define DIFFUSE_TOON\n";
 
-	bool force_blinn = GLOBAL_GET("rendering/quality/shading/force_blinn_over_ggx");
+	bool force_blinn = GLOBAL_GET_CACHED(bool, "rendering/quality/shading/force_blinn_over_ggx");
 
 	if (!force_blinn) {
 		actions[VS::SHADER_SPATIAL].render_mode_defines["specular_schlick_ggx"] = "#define SPECULAR_SCHLICK_GGX\n";

--- a/drivers/gles2/shader_gles2.cpp
+++ b/drivers/gles2/shader_gles2.cpp
@@ -177,7 +177,7 @@ ShaderGLES2::Version *ShaderGLES2::get_current_version() {
 	strings.push_back("#define USE_HIGHP_PRECISION\n");
 #endif
 
-	if (GLOBAL_GET("rendering/gles2/compatibility/enable_high_float.Android")) {
+	if (GLOBAL_GET_CACHED(bool, "rendering/gles2/compatibility/enable_high_float.Android")) {
 		// enable USE_HIGHP_PRECISION but safeguarded by an availability check as highp support is optional in GLES2
 		// see Section 4.5.4 of the GLSL_ES_Specification_1.00
 		strings.push_back("#ifdef GL_FRAGMENT_PRECISION_HIGH\n  #define USE_HIGHP_PRECISION\n#endif\n");

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -199,7 +199,7 @@ void RasterizerGLES3::begin_frame(double frame_step) {
 		frame_step = 0.001;
 	}
 
-	double time_roll_over = GLOBAL_GET("rendering/limits/time/time_rollover_secs");
+	double time_roll_over = GLOBAL_GET_CACHED(double, "rendering/limits/time/time_rollover_secs");
 	time_total = Math::fmod(time_total, time_roll_over);
 
 	storage->frame.time[0] = time_total;

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -5376,22 +5376,22 @@ void RasterizerSceneGLES3::initialize() {
 }
 
 void RasterizerSceneGLES3::iteration() {
-	shadow_filter_mode = ShadowFilterMode(int(GLOBAL_GET("rendering/quality/shadows/filter_mode")));
+	shadow_filter_mode = ShadowFilterMode(GLOBAL_GET_CACHED(int32_t, "rendering/quality/shadows/filter_mode"));
 
-	const int directional_shadow_size_new = next_power_of_2(int(GLOBAL_GET("rendering/quality/directional_shadow/size")));
+	const int directional_shadow_size_new = next_power_of_2(GLOBAL_GET_CACHED(int32_t, "rendering/quality/directional_shadow/size"));
 	if (directional_shadow_size != directional_shadow_size_new) {
 		directional_shadow_size = directional_shadow_size_new;
 		directional_shadow_create();
 	}
 
-	subsurface_scatter_follow_surface = GLOBAL_GET("rendering/quality/subsurface_scattering/follow_surface");
-	subsurface_scatter_weight_samples = GLOBAL_GET("rendering/quality/subsurface_scattering/weight_samples");
-	subsurface_scatter_quality = SubSurfaceScatterQuality(int(GLOBAL_GET("rendering/quality/subsurface_scattering/quality")));
-	subsurface_scatter_size = GLOBAL_GET("rendering/quality/subsurface_scattering/scale");
+	subsurface_scatter_follow_surface = GLOBAL_GET_CACHED(bool, "rendering/quality/subsurface_scattering/follow_surface");
+	subsurface_scatter_weight_samples = GLOBAL_GET_CACHED(bool, "rendering/quality/subsurface_scattering/weight_samples");
+	subsurface_scatter_quality = SubSurfaceScatterQuality(int(GLOBAL_GET_CACHED(int32_t, "rendering/quality/subsurface_scattering/quality")));
+	subsurface_scatter_size = GLOBAL_GET_CACHED(float, "rendering/quality/subsurface_scattering/scale");
 
-	storage->config.use_lightmap_filter_bicubic = GLOBAL_GET("rendering/quality/lightmapping/use_bicubic_sampling");
+	storage->config.use_lightmap_filter_bicubic = GLOBAL_GET_CACHED(bool, "rendering/quality/lightmapping/use_bicubic_sampling");
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_LIGHTMAP_FILTER_BICUBIC, storage->config.use_lightmap_filter_bicubic);
-	state.scene_shader.set_conditional(SceneShaderGLES3::VCT_QUALITY_HIGH, GLOBAL_GET("rendering/quality/voxel_cone_tracing/high_quality"));
+	state.scene_shader.set_conditional(SceneShaderGLES3::VCT_QUALITY_HIGH, GLOBAL_GET_CACHED(bool, "rendering/quality/voxel_cone_tracing/high_quality"));
 }
 
 void RasterizerSceneGLES3::finalize() {

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -3389,7 +3389,7 @@ void RasterizerStorageGLES3::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 	}
 
 	//bool has_morph = p_blend_shapes.size();
-	bool use_split_stream = GLOBAL_GET("rendering/misc/mesh_storage/split_stream") && !(p_format & VS::ARRAY_FLAG_USE_DYNAMIC_UPDATE);
+	bool use_split_stream = GLOBAL_GET_CACHED(bool, "rendering/misc/mesh_storage/split_stream") && !(p_format & VS::ARRAY_FLAG_USE_DYNAMIC_UPDATE);
 
 	Surface::Attrib attribs[VS::ARRAY_MAX];
 

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -1267,7 +1267,7 @@ ShaderCompilerGLES3::ShaderCompilerGLES3() {
 	actions[VS::SHADER_SPATIAL].render_mode_defines["cull_front"] = "#define DO_SIDE_CHECK\n";
 	actions[VS::SHADER_SPATIAL].render_mode_defines["cull_disabled"] = "#define DO_SIDE_CHECK\n";
 
-	bool force_lambert = GLOBAL_GET("rendering/quality/shading/force_lambert_over_burley");
+	bool force_lambert = GLOBAL_GET_CACHED(bool, "rendering/quality/shading/force_lambert_over_burley");
 
 	if (!force_lambert) {
 		actions[VS::SHADER_SPATIAL].render_mode_defines["diffuse_burley"] = "#define DIFFUSE_BURLEY\n";
@@ -1277,7 +1277,7 @@ ShaderCompilerGLES3::ShaderCompilerGLES3() {
 	actions[VS::SHADER_SPATIAL].render_mode_defines["diffuse_lambert_wrap"] = "#define DIFFUSE_LAMBERT_WRAP\n";
 	actions[VS::SHADER_SPATIAL].render_mode_defines["diffuse_toon"] = "#define DIFFUSE_TOON\n";
 
-	bool force_blinn = GLOBAL_GET("rendering/quality/shading/force_blinn_over_ggx");
+	bool force_blinn = GLOBAL_GET_CACHED(bool, "rendering/quality/shading/force_blinn_over_ggx");
 
 	if (!force_blinn) {
 		actions[VS::SHADER_SPATIAL].render_mode_defines["specular_schlick_ggx"] = "#define SPECULAR_SCHLICK_GGX\n";

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -417,12 +417,12 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 		tex_flags |= Texture::FLAG_REPEAT;
 
 		const bool min_gles3 = GLOBAL_GET("rendering/quality/driver/driver_name") == "GLES3" &&
-				!GLOBAL_GET("rendering/quality/driver/fallback_to_gles2");
+				!GLOBAL_GET_CACHED(bool, "rendering/quality/driver/fallback_to_gles2");
 		if (!min_gles3 && !image->is_size_po2()) {
 			// The project can be run using GLES2. GLES2 does not guarantee that
 			// repeating textures with a non-power-of-two size will be displayed
 			// without artifacts (due to upscaling to the nearest power of 2).
-			if (GLOBAL_GET("rendering/quality/driver/fallback_to_gles2")) {
+			if (GLOBAL_GET_CACHED(bool, "rendering/quality/driver/fallback_to_gles2")) {
 				WARN_PRINT(vformat("%s: Imported a repeating texture with a size of %dx%d, but the project is configured to allow falling back to GLES2.\nNon-power-of-2 repeating textures may not display correctly on some platforms such as HTML5. This is because GLES2 does not mandate support for non-power-of-2 repeating textures.",
 						p_source_file, image->get_width(), image->get_height()));
 			} else {

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1433,7 +1433,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2() {
 	// Render every past/future step with the capture shader.
 
 	VS::get_singleton()->canvas_item_set_material(onion.capture.canvas_item, onion.capture.material->get_rid());
-	onion.capture.material->set_shader_param("bkg_color", GLOBAL_GET("rendering/environment/default_clear_color"));
+	onion.capture.material->set_shader_param("bkg_color", GLOBAL_GET_CACHED(Color, "rendering/environment/default_clear_color"));
 	onion.capture.material->set_shader_param("differences_only", onion.differences_only);
 	onion.capture.material->set_shader_param("present", onion.differences_only ? VS::get_singleton()->viewport_get_texture(present_rid) : RID());
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4071,7 +4071,7 @@ void CanvasItemEditor::set_current_tool(Tool p_tool) {
 
 void CanvasItemEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_PHYSICS_PROCESS) {
-		EditorNode::get_singleton()->get_scene_root()->set_snap_controls_to_pixels(GLOBAL_GET("gui/common/snap_controls_to_pixels"));
+		EditorNode::get_singleton()->get_scene_root()->set_snap_controls_to_pixels(GLOBAL_GET_CACHED(bool, "gui/common/snap_controls_to_pixels"));
 
 		bool has_container_parents = false;
 		int nb_control = 0;

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -867,7 +867,7 @@ Ref<Texture> EditorFontPreviewPlugin::generate_from_path(const String &p_path, c
 
 	Ref<Font> font = sampled_font;
 
-	const Color c = GLOBAL_GET("rendering/environment/default_clear_color");
+	const Color c = GLOBAL_GET_CACHED(Color, "rendering/environment/default_clear_color");
 	const float fg = c.get_luminance() < 0.5 ? 1.0 : 0.0;
 	font->draw(canvas_item, pos, sampled_text, Color(fg, fg, fg));
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -590,7 +590,7 @@ void ScriptTextEditor::_validate_script() {
 	warnings_panel->clear();
 
 	// Add missing connections.
-	if (GLOBAL_GET("debug/gdscript/warnings/enable").booleanize()) {
+	if (GLOBAL_GET_CACHED(bool, "debug/gdscript/warnings/enable")) {
 		Node *base = get_tree()->get_edited_scene_root();
 		if (base && missing_connections.size() > 0) {
 			warnings_panel->push_table(1);

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -61,7 +61,7 @@ void ThemeEditorPreview::_propagate_redraw(Control *p_at) {
 
 void ThemeEditorPreview::_refresh_interval() {
 	// In case the project settings have changed.
-	preview_bg->set_frame_color(GLOBAL_GET("rendering/environment/default_clear_color"));
+	preview_bg->set_frame_color(GLOBAL_GET_CACHED(Color, "rendering/environment/default_clear_color"));
 
 	_propagate_redraw(preview_bg);
 	_propagate_redraw(preview_content);

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -86,7 +86,7 @@ void VersionControlEditorPlugin::_bind_methods() {
 void VersionControlEditorPlugin::_notification(int p_what) {
 	if (p_what == NOTIFICATION_READY) {
 		String installed_plugin = GLOBAL_GET("editor/version_control_plugin_name");
-		bool has_autoload_enable = GLOBAL_GET("editor/version_control_autoload_on_startup");
+		bool has_autoload_enable = GLOBAL_GET_CACHED(bool, "editor/version_control_autoload_on_startup");
 
 		if (installed_plugin != "" && has_autoload_enable) {
 			if (_load_plugin(installed_plugin)) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2480,7 +2480,7 @@ bool Main::iteration() {
 				if (print_fps) {
 					print_line(vformat("Editor FPS: %d (%s mspf)", frames, rtos(1000.0 / frames).pad_decimals(2)));
 				}
-			} else if (print_fps || GLOBAL_GET("debug/settings/stdout/print_fps")) {
+			} else if (print_fps || GLOBAL_GET_CACHED(bool, "debug/settings/stdout/print_fps")) {
 				print_line(vformat("Project FPS: %d (%s mspf)", frames, rtos(1000.0 / frames).pad_decimals(2)));
 			}
 		} else {

--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -422,7 +422,7 @@ void ConcavePolygonShapeBullet::setup(PoolVector<Vector3> p_faces) {
 
 		meshShape = bulletnew(btBvhTriangleMeshShape(shapeInterface, useQuantizedAabbCompression));
 
-		if (GLOBAL_GET("physics/3d/smooth_trimesh_collision")) {
+		if (GLOBAL_GET_CACHED(bool, "physics/3d/smooth_trimesh_collision")) {
 			btTriangleInfoMap *triangleInfoMap = new btTriangleInfoMap();
 			btGenerateInternalEdgeInfo(meshShape, triangleInfoMap);
 		}

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -58,7 +58,7 @@
 
 void EditorSceneImporterFBX::get_extensions(List<String> *r_extensions) const {
 	// register FBX as the one and only format for FBX importing
-	if (GLOBAL_GET("filesystem/import/fbx/use_fbx")) {
+	if (GLOBAL_GET_CACHED(bool, "filesystem/import/fbx/use_fbx")) {
 		r_extensions->push_back("fbx");
 	}
 }

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2077,7 +2077,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionContext &p_context
 
 				if (!_static) {
 					List<MethodInfo> methods;
-					bool is_autocompleting_getters = GLOBAL_GET("debug/gdscript/completion/autocomplete_setters_and_getters").booleanize();
+					bool is_autocompleting_getters = GLOBAL_GET_CACHED(bool, "debug/gdscript/completion/autocomplete_setters_and_getters");
 					ClassDB::get_method_list(type, &methods, false, !is_autocompleting_getters);
 					for (List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
 						if (E->get().name.begins_with("_")) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -8680,10 +8680,10 @@ void GDScriptParser::_add_warning(int p_code, int p_line, const String &p_symbol
 }
 
 void GDScriptParser::_add_warning(int p_code, int p_line, const Vector<String> &p_symbols) {
-	if (GLOBAL_GET("debug/gdscript/warnings/exclude_addons").booleanize() && base_path.begins_with("res://addons/")) {
+	if (GLOBAL_GET_CACHED(bool, "debug/gdscript/warnings/exclude_addons") && base_path.begins_with("res://addons/")) {
 		return;
 	}
-	if (tokenizer->is_ignoring_warnings() || !GLOBAL_GET("debug/gdscript/warnings/enable").booleanize()) {
+	if (tokenizer->is_ignoring_warnings() || !GLOBAL_GET_CACHED(bool, "debug/gdscript/warnings/enable")) {
 		return;
 	}
 	String warn_name = GDScriptWarning::get_name_from_code((GDScriptWarning::Code)p_code).to_lower();
@@ -8797,7 +8797,7 @@ Error GDScriptParser::_parse(const String &p_base_path) {
 
 	// Resolve warning ignores
 	Vector<Pair<int, String>> warning_skips = tokenizer->get_warning_skips();
-	bool warning_is_error = GLOBAL_GET("debug/gdscript/warnings/treat_warnings_as_errors").booleanize();
+	bool warning_is_error = GLOBAL_GET_CACHED(bool, "debug/gdscript/warnings/treat_warnings_as_errors");
 	for (List<GDScriptWarning>::Element *E = warnings.front(); E;) {
 		GDScriptWarning &w = E->get();
 		int skip_index = -1;

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -246,7 +246,7 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 			"android:resizeableActivity=\"%s\">\n",
 			bool_to_string(p_preset->get("package/exclude_from_recents")),
 			orientation,
-			bool_to_string(bool(GLOBAL_GET("display/window/size/resizable"))));
+			bool_to_string(GLOBAL_GET_CACHED(bool, "display/window/size/resizable")));
 	if (uses_xr) {
 		manifest_activity_text += "            <meta-data tools:node=\"replace\" android:name=\"com.oculus.vr.focusaware\" android:value=\"true\" />\n";
 	} else {

--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -184,12 +184,12 @@ void MeshInstance::_resolve_skeleton_path() {
 
 bool MeshInstance::_is_global_software_skinning_enabled() {
 	// Check if forced in project settings.
-	if (GLOBAL_GET("rendering/quality/skinning/force_software_skinning")) {
+	if (GLOBAL_GET_CACHED(bool, "rendering/quality/skinning/force_software_skinning")) {
 		return true;
 	}
 
 	// Check if enabled in project settings.
-	if (!GLOBAL_GET("rendering/quality/skinning/software_skinning_fallback")) {
+	if (!GLOBAL_GET_CACHED(bool, "rendering/quality/skinning/software_skinning_fallback")) {
 		return false;
 	}
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -595,7 +595,7 @@ bool SceneTree::iteration(float p_time) {
 	emit_signal("physics_frame");
 
 	_notify_group_pause("physics_process_internal", Node::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
-	if (GLOBAL_GET("physics/common/enable_pause_aware_picking")) {
+	if (GLOBAL_GET_CACHED(bool, "physics/common/enable_pause_aware_picking")) {
 		call_group_flags(GROUP_CALL_REALTIME, "_viewports", "_process_picking", true);
 	}
 	_notify_group_pause("physics_process", Node::NOTIFICATION_PHYSICS_PROCESS);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -171,14 +171,14 @@ class TooltipPanel : public PanelContainer {
 	GDCLASS(TooltipPanel, PanelContainer);
 
 public:
-	TooltipPanel(){};
+	TooltipPanel() {}
 };
 
 class TooltipLabel : public Label {
 	GDCLASS(TooltipLabel, Label);
 
 public:
-	TooltipLabel(){};
+	TooltipLabel() {}
 };
 
 /////////////////////////////////////
@@ -397,7 +397,7 @@ void Viewport::_notification(int p_what) {
 				}
 			}
 
-			if (!GLOBAL_GET("physics/common/enable_pause_aware_picking")) {
+			if (!GLOBAL_GET_CACHED(bool, "physics/common/enable_pause_aware_picking")) {
 				_process_picking(false);
 			}
 		} break;
@@ -3005,7 +3005,7 @@ void Viewport::set_disable_input(bool p_disable) {
 	if (p_disable == disable_input) {
 		return;
 	}
-	if (p_disable && GLOBAL_GET("gui/common/drop_mouse_on_gui_input_disabled")) {
+	if (p_disable && GLOBAL_GET_CACHED(bool, "gui/common/drop_mouse_on_gui_input_disabled")) {
 		_drop_mouse_focus();
 		_drop_mouse_over();
 		_gui_cancel_tooltip();

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2429,7 +2429,7 @@ Material3D::Material3D(bool p_orm) :
 		flags[i] = false;
 	}
 
-	force_vertex_shading = GLOBAL_GET("rendering/quality/shading/force_vertex_shading");
+	force_vertex_shading = GLOBAL_GET_CACHED(bool, "rendering/quality/shading/force_vertex_shading");
 
 	diffuse_mode = DIFFUSE_BURLEY;
 	specular_mode = SPECULAR_SCHLICK_GGX;

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -184,7 +184,7 @@ void AudioStreamPlaybackMicrophone::start(float p_from_pos) {
 		return;
 	}
 
-	if (!GLOBAL_GET("audio/enable_audio_input")) {
+	if (!GLOBAL_GET_CACHED(bool, "audio/enable_audio_input")) {
 		WARN_PRINT("Need to enable Project settings > Audio > Enable Audio Input option to use capturing.");
 		return;
 	}

--- a/servers/visual/portals/portal_occlusion_culler.cpp
+++ b/servers/visual/portals/portal_occlusion_culler.cpp
@@ -248,7 +248,7 @@ void PortalOcclusionCuller::prepare_generic(PortalRenderer &p_portal_renderer, c
 	// Bodge to keep settings up to date, until the project settings PR is merged
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint() && ((Engine::get_singleton()->get_frames_drawn() % 16) == 0)) {
-		_max_polys = GLOBAL_GET("rendering/misc/occlusion_culling/max_active_polygons");
+		_max_polys = GLOBAL_GET_CACHED(int32_t, "rendering/misc/occlusion_culling/max_active_polygons");
 	}
 #endif
 	_num_spheres = 0;

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -281,7 +281,7 @@ void VisualServerViewport::draw_viewports() {
 	}
 
 	if (Engine::get_singleton()->is_editor_hint()) {
-		clear_color = GLOBAL_GET("rendering/environment/default_clear_color");
+		clear_color = GLOBAL_GET_CACHED(Color, "rendering/environment/default_clear_color");
 	}
 
 	//sort viewports

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -873,7 +873,7 @@ uint32_t VisualServer::mesh_surface_get_format_stride(uint32_t p_format, int p_v
 }
 
 void VisualServer::mesh_surface_make_offsets_from_format(uint32_t p_format, int p_vertex_len, int p_index_len, uint32_t *r_offsets, uint32_t *r_strides) const {
-	bool use_split_stream = GLOBAL_GET("rendering/misc/mesh_storage/split_stream") && !(p_format & VS::ARRAY_FLAG_USE_DYNAMIC_UPDATE);
+	bool use_split_stream = GLOBAL_GET_CACHED(bool, "rendering/misc/mesh_storage/split_stream") && !(p_format & VS::ARRAY_FLAG_USE_DYNAMIC_UPDATE);
 
 	int attributes_base_offset = 0;
 	int attributes_stride = 0;
@@ -1251,7 +1251,7 @@ bool VisualServer::_mesh_find_format(VS::PrimitiveType p_primitive, const Array 
 }
 
 uint32_t VisualServer::mesh_find_format_from_arrays(PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes, uint32_t p_compress_format) {
-	bool use_split_stream = GLOBAL_GET("rendering/misc/mesh_storage/split_stream") && !(p_compress_format & VS::ARRAY_FLAG_USE_DYNAMIC_UPDATE);
+	bool use_split_stream = GLOBAL_GET_CACHED(bool, "rendering/misc/mesh_storage/split_stream") && !(p_compress_format & VS::ARRAY_FLAG_USE_DYNAMIC_UPDATE);
 
 	uint32_t offsets[VS::ARRAY_MAX];
 
@@ -1271,7 +1271,7 @@ uint32_t VisualServer::mesh_find_format_from_arrays(PrimitiveType p_primitive, c
 }
 
 void VisualServer::mesh_add_surface_from_arrays(RID p_mesh, PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes, uint32_t p_compress_format) {
-	bool use_split_stream = GLOBAL_GET("rendering/misc/mesh_storage/split_stream") && !(p_compress_format & VS::ARRAY_FLAG_USE_DYNAMIC_UPDATE);
+	bool use_split_stream = GLOBAL_GET_CACHED(bool, "rendering/misc/mesh_storage/split_stream") && !(p_compress_format & VS::ARRAY_FLAG_USE_DYNAMIC_UPDATE);
 
 	uint32_t offsets[VS::ARRAY_MAX];
 
@@ -1341,7 +1341,7 @@ void VisualServer::mesh_add_surface_from_arrays(RID p_mesh, PrimitiveType p_prim
 }
 
 Array VisualServer::_get_array_from_surface(uint32_t p_format, PoolVector<uint8_t> p_vertex_data, int p_vertex_len, PoolVector<uint8_t> p_index_data, int p_index_len) const {
-	bool use_split_stream = GLOBAL_GET("rendering/misc/mesh_storage/split_stream") && !(p_format & VS::ARRAY_FLAG_USE_DYNAMIC_UPDATE);
+	bool use_split_stream = GLOBAL_GET_CACHED(bool, "rendering/misc/mesh_storage/split_stream") && !(p_format & VS::ARRAY_FLAG_USE_DYNAMIC_UPDATE);
 
 	uint32_t offsets[ARRAY_MAX];
 	uint32_t strides[VS::ARRAY_MAX];


### PR DESCRIPTION
`GLOBAL_GET` is an expensive operation which should not be used each frame / tick.
This PR adds macros which do a cheaper revision check, and only call the expensive `GLOBAL_GET` when project settings have changed.

Updated version of #60926

* Recent profiling revealed some cases where we were still calling `GET_GLOBAL` per frame / tick or in bottlenecks.
* Some investigation revealed the true HORROR of misuse of `GET_GLOBAL`. :scream: 
* I would like to suggest we consider following up this PR by renaming `GET_GLOBAL` to something that forces contributors / reviewers to make a conscious choice here. Something like "GET_GLOBAL_UNCACHED" would do the job. 
* This may also be a problem in 4.x, and it may be worth doing the same there if we agree on using this method.

## Timings

Very rough and ready benchmark in release build (using attribute no inline and a counter to help prevent optimizing out) gives 860 usec for the new `GLOBAL_GET_CACHED` and 99039 usec for the old `GLOBAL_GET`, so approx 115x faster on Linux.

```
	// Benchmark proj settings
	uint64_t before = OS::get_singleton()->get_ticks_usec();
	for (uint32_t n = 0; n < 1000000; n++) {
		bool was_true = GLOBAL_GET_CACHED(bool, "debug/settings/stdout/print_fps");
	}
	uint64_t after = OS::get_singleton()->get_ticks_usec();

	uint64_t before2 = OS::get_singleton()->get_ticks_usec();
	for (uint32_t n = 0; n < 1000000; n++) {
		bool was_true = GLOBAL_GET("debug/settings/stdout/print_fps");
	}
	uint64_t after2 = OS::get_singleton()->get_ticks_usec();
	print_line("GET_CACHED : " + itos(after - before) + ", GET : " + itos(after2 - before2));
```

## Discussion
This problem keeps resurfacing - that contributors do not recognise that `GET_GLOBAL` is an expensive operation, and copy other code and end up using it per frame or tick where _it should not be used_.

There are a number of mechanisms to allow code to efficiently access `ProjectSettings` (including checking `is_changed()` and using the `project_settings_changed` signal). However these involve some boiler plate and aren't as convenient for contributors on a day to day basis as just calling `GET_GLOBAL()`.

At the time @reduz hoped that users would do this properly with the required boiler plate and cache the variables themselves. I was not convinced this would happen and indeed in the 3 years since, many PRs have been written since that inappropriately use `GET_GLOBAL`.

In #60926 I proposed an efficient macro to solve this problem in 99% of circumstances where contributors did not want to implement the full boiler plate.

We identified that there was one problem with this implementation - it inadvertently allowed creating static `Variants`, which won't work for some types (like `String`) because of order of construction / destruction issues.

We solve this here by having the call site specify the storage type, and `static_assert` that it is trivial. This prevents the creation of static `Variants` and also conveniently solves the same problem in most cases.

In 3.x this seems one of the most obvious and least error prone ways of solving this issue for existing code, and we should evaluate whether this makes sense in 4.x (assuming it is also expensive to call there).


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
