### PR TITLE
Update `MultiNodeEdit` property list on edited nodes' property list changed

### DIFF
--- a/editor/multi_node_edit.h
+++ b/editor/multi_node_edit.h
@@ -37,12 +37,15 @@ class MultiNodeEdit : public RefCounted {
 	GDCLASS(MultiNodeEdit, RefCounted);
 
 	LocalVector<NodePath> nodes;
+	bool notify_property_list_changed_pending = false;
 	struct PLData {
 		int uses = 0;
 		PropertyInfo info;
 	};
 
 	bool _set_impl(const StringName &p_name, const Variant &p_value, const String &p_field);
+	void _queue_notify_property_list_changed();
+	void _notify_property_list_changed();
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Makes `MultiNodeEdit` property list react to e.g. toggling conditional sections/properties:

Before<br>(v4.4.stable.official [4c311cbee])|After<br>(this PR)
-|-
![tNke75p0Rt](https://github.com/user-attachments/assets/1ce9b901-a379-452d-97cc-3a918b815e3f)|![TiO6XqBU5j](https://github.com/user-attachments/assets/9350e09f-897e-40c7-810e-060209dc31fa)

