### PR TITLE
Fix ownership when pasting non root with child nodes in new scene

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -4268,7 +4268,7 @@ List<Node *> SceneTreeDock::paste_nodes(bool p_paste_as_sibling) {
 			// and added to the node_clipboard_edited_scene_owned list.
 			if (d != dup && E2.key->get_owner() == nullptr) {
 				if (node_clipboard_edited_scene_owned.find(const_cast<Node *>(E2.key))) {
-					ur->add_do_method(d, "set_owner", edited_scene);
+					ur->add_do_method(d, "set_owner", owner);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/103656
while keeping the fix from https://github.com/godotengine/godot/pull/83596 as far as I can tell.
Though I discovered another bug while working on this that was existing prior of the fix mentioned above and that is still present now. EDIT : seems to be https://github.com/godotengine/godot/issues/102573
Apart from that I haven't noticed any issue.