### PR TITLE
Implementation of a default parameter inside hash map.

### DIFF
--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -343,6 +343,28 @@ public:
 		return nullptr;
 	}
 
+	TValue &get(const TKey &p_key, const TValue &p_default) {
+		uint32_t pos = 0;
+		uint32_t hash_pos = 0;
+		bool exists = _lookup_pos(p_key, pos, hash_pos);
+
+		if (unlikely(!exists)) {
+			return elements[_insert_element(p_key, p_default, _hash(p_key))].value;
+		}
+		return elements[pos].value;
+	}
+
+	TValue *getptr(const TKey &p_key, const TValue &p_default) {
+		uint32_t pos = 0;
+		uint32_t hash_pos = 0;
+		bool exists = _lookup_pos(p_key, pos, hash_pos);
+
+		if (likely(exists)) {
+			return &elements[pos].value;
+		}
+		return &elements[_insert_element(p_key, p_default, _hash(p_key))].value;
+	}
+
 	bool has(const TKey &p_key) const {
 		uint32_t _pos = 0;
 		uint32_t h_pos = 0;

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -348,6 +348,25 @@ public:
 		return nullptr;
 	}
 
+	TValue &get(const TKey &p_key, const TValue &p_default) {
+		uint32_t pos = 0;
+		bool exists = _lookup_pos(p_key, pos);
+		if (unlikely(!exists)) {
+			return _insert(p_key, p_default)->data.value;
+		}
+		return elements[pos]->data.value;
+	}
+
+	TValue *getptr(const TKey &p_key, const TValue &p_default) {
+		uint32_t pos = 0;
+		bool exists = _lookup_pos(p_key, pos);
+
+		if (likely(exists)) {
+			return &elements[pos]->data.value;
+		}
+		return &_insert(p_key, p_default)->data.value;
+	}
+
 	_FORCE_INLINE_ bool has(const TKey &p_key) const {
 		uint32_t _pos = 0;
 		return _lookup_pos(p_key, _pos);


### PR DESCRIPTION
Makes the code fit in better, it optimizes a call to check if it exists first and then indexing by allowing to provide a default directly.