### PR TITLE
Fix build errors when building with `disable_xr=yes`

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -293,10 +293,12 @@
 #include "scene/3d/visible_on_screen_notifier_3d.h"
 #include "scene/3d/voxel_gi.h"
 #include "scene/3d/world_environment.h"
+#ifndef XR_DISABLED
 #include "scene/3d/xr/xr_body_modifier_3d.h"
 #include "scene/3d/xr/xr_face_modifier_3d.h"
 #include "scene/3d/xr/xr_hand_modifier_3d.h"
 #include "scene/3d/xr/xr_nodes.h"
+#endif // XR_DISABLED
 #include "scene/animation/root_motion_view.h"
 #include "scene/resources/3d/box_shape_3d.h"
 #include "scene/resources/3d/capsule_shape_3d.h"

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -91,6 +91,7 @@
 #include "physics_server_3d.h"
 #include "physics_server_3d_dummy.h"
 #include "servers/extensions/physics_server_3d_extension.h"
+#ifndef XR_DISABLED
 #include "xr/xr_body_tracker.h"
 #include "xr/xr_controller_tracker.h"
 #include "xr/xr_face_tracker.h"
@@ -99,6 +100,7 @@
 #include "xr/xr_interface_extension.h"
 #include "xr/xr_positional_tracker.h"
 #include "xr_server.h"
+#endif // XR_DISABLED
 #endif // _3D_DISABLED
 
 ShaderTypes *shader_types = nullptr;


### PR DESCRIPTION
Building with the following params (note: scu_build is enabled):

```
platform=linuxbsd builtin_embree=yes builtin_enet=no
builtin_freetype=yes builtin_graphite=yes builtin_harfbuzz=yes
builtin_libogg=no builtin_libpng=yes builtin_libtheora=no
builtin_libvorbis=no builtin_libwebp=no builtin_miniupnpc=no
builtin_pcre2=no builtin_zlib=yes builtin_zstd=no linker=mold
optimize=none debug_symbols=True tests=True dev_mode=True dev_build=True
use_llvm=yes use_lld=yes opengl3=no openxr=no disable_xr=yes -j 24
scu_build=yes scu_limit=256
```

Results in compiler errors:

```
In file included from servers/register_server_types.cpp:99:
servers/xr/xr_interface.h:52:7: error: redefinition of 'RefCounted'
   52 | class XRInterface : public RefCounted {
      |       ^
./servers/rendering/rendering_method.h:40:21: note: expanded from macro
'XRInterface'
   40 | #define XRInterface RefCounted
      |                     ^
./core/object/ref_counted.h:37:7: note: previous definition is here
   37 | class RefCounted : public Object {
      |       ^
```

This happens because of:

```
#ifdef XR_DISABLED
// RendererSceneCull::render_camera is empty when 3D is disabled, but
// it and RenderingMethod::render_camera have a parameter for
XRInterface.
#define XRInterface RefCounted
#else
#include "servers/xr/xr_interface.h"
#endif // XR_DISABLED
```

In rendering_method.h


The problem was introduced in #103267