### PR TITLE
Make LightmapProbe able to generate multiple probes per node

### DIFF
--- a/doc/classes/LightmapProbe.xml
+++ b/doc/classes/LightmapProbe.xml
@@ -1,13 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="LightmapProbe" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Represents a single manually placed probe for dynamic object lighting with [LightmapGI].
+		Represents a group of manually placed probes for dynamic object lighting with [LightmapGI].
 	</brief_description>
 	<description>
-		[LightmapProbe] represents the position of a single manually placed probe for dynamic object lighting with [LightmapGI]. Lightmap probes affect the lighting of [GeometryInstance3D]-derived nodes that have their [member GeometryInstance3D.gi_mode] set to [constant GeometryInstance3D.GI_MODE_DYNAMIC].
+		[LightmapProbe] represents the position of a group of manually placed probes for dynamic object lighting with [LightmapGI]. Lightmap probes affect the lighting of [GeometryInstance3D]-derived nodes that have their [member GeometryInstance3D.gi_mode] set to [constant GeometryInstance3D.GI_MODE_DYNAMIC].
 		Typically, [LightmapGI] probes are placed automatically by setting [member LightmapGI.generate_probes_subdiv] to a value other than [constant LightmapGI.GENERATE_PROBES_DISABLED]. By creating [LightmapProbe] nodes before baking lightmaps, you can add more probes in specific areas for greater detail, or disable automatic generation and rely only on manually placed probes instead.
 		[b]Note:[/b] [LightmapProbe] nodes that are placed after baking lightmaps are ignored by dynamic objects. You must bake lightmaps again after creating or modifying [LightmapProbe]s for the probes to be effective.
 	</description>
 	<tutorials>
 	</tutorials>
+	<members>
+		<member name="cell_size" type="Vector3" setter="set_cell_size" getter="get_cell_size" default="Vector3(2, 2, 2)">
+			The distance between probes in meters. Lower values result in more detailed dynamic object indirect light, at the cost of longer bake times and larger file sizes. Very low cell sizes may cause the lightmapper to crash, especially if the [member size] is also high.
+			The number of cells on a dimension is determined by the formula [code]floor(size / cell_size)[/code].
+			[b]Note:[/b] The actual cell size may increase slightly to ensure that probes are evenly distributed within the area defined by [member size], even if [member cell_size] is not a divisor of [member size].
+			[b]Note:[/b] If [member cell_size] is greater than [member size] on a given dimension, only a single probe is generated on that dimension and it will be centered. With the default [member cell_size] and [member size], only a single probe is placed.
+		</member>
+		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(1, 1, 1)">
+			The area in which probes should be placed.
+		</member>
+	</members>
 </class>

--- a/editor/plugins/gizmos/lightmap_probe_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/lightmap_probe_gizmo_plugin.cpp
@@ -33,15 +33,24 @@
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
+#include "editor/plugins/gizmos/gizmo_3d_helper.h"
+#include "editor/plugins/node_3d_editor_plugin.h"
 #include "scene/3d/lightmap_probe.h"
 
 LightmapProbeGizmoPlugin::LightmapProbeGizmoPlugin() {
-	create_icon_material("lightmap_probe_icon", EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GizmoLightmapProbe"), EditorStringName(EditorIcons)));
-
+	helper.instantiate();
 	Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/lightprobe_lines");
 
-	gizmo_color.a = 0.3;
-	create_material("lightprobe_lines", gizmo_color);
+	create_material("lightmap_probe_material", gizmo_color);
+
+	gizmo_color.a = 0.1;
+	create_material("lightmap_probe_solid_material", gizmo_color);
+
+	create_icon_material("lightmap_probe_icon", EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GizmoLightmapProbe"), EditorStringName(EditorIcons)));
+	create_handle_material("handles");
+}
+
+LightmapProbeGizmoPlugin::~LightmapProbeGizmoPlugin() {
 }
 
 bool LightmapProbeGizmoPlugin::has_gizmo(Node3D *p_spatial) {
@@ -56,66 +65,69 @@ int LightmapProbeGizmoPlugin::get_priority() const {
 	return -1;
 }
 
-void LightmapProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	Ref<Material> material_lines = get_material("lightprobe_lines", p_gizmo);
+String LightmapProbeGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {
+	return helper->box_get_handle_name(p_id);
+}
 
+Variant LightmapProbeGizmoPlugin::get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {
+	LightmapProbe *probe = Object::cast_to<LightmapProbe>(p_gizmo->get_node_3d());
+	return probe->get_size();
+}
+
+void LightmapProbeGizmoPlugin::begin_handle_action(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) {
+	helper->initialize_handle_action(get_handle_value(p_gizmo, p_id, p_secondary), p_gizmo->get_node_3d()->get_global_transform());
+}
+
+void LightmapProbeGizmoPlugin::set_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, Camera3D *p_camera, const Point2 &p_point) {
+	LightmapProbe *probe = Object::cast_to<LightmapProbe>(p_gizmo->get_node_3d());
+
+	Vector3 sg[2];
+	helper->get_segment(p_camera, p_point, sg);
+
+	Vector3 size = probe->get_size();
+	Vector3 position;
+	helper->box_set_handle(sg, p_id, size, position);
+	probe->set_size(size);
+	probe->set_global_position(position);
+}
+
+void LightmapProbeGizmoPlugin::commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel) {
+	helper->box_commit_handle(TTR("Change LightmapProbe Size"), p_cancel, p_gizmo->get_node_3d());
+}
+
+void LightmapProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	p_gizmo->clear();
 
-	Vector<Vector3> lines;
+	if (p_gizmo->is_selected()) {
+		LightmapProbe *probe = Object::cast_to<LightmapProbe>(p_gizmo->get_node_3d());
+		Vector<Vector3> lines;
+		Vector3 size = probe->get_size();
 
-	int stack_count = 8;
-	int sector_count = 16;
+		AABB aabb;
+		aabb.position = -size / 2;
+		aabb.size = size;
 
-	float sector_step = (Math_PI * 2.0) / sector_count;
-	float stack_step = Math_PI / stack_count;
-
-	Vector<Vector3> vertices;
-	float radius = 0.2;
-
-	for (int i = 0; i <= stack_count; ++i) {
-		float stack_angle = Math_PI / 2 - i * stack_step; // starting from pi/2 to -pi/2
-		float xy = radius * Math::cos(stack_angle); // r * cos(u)
-		float z = radius * Math::sin(stack_angle); // r * sin(u)
-
-		// add (sector_count+1) vertices per stack
-		// the first and last vertices have same position and normal, but different tex coords
-		for (int j = 0; j <= sector_count; ++j) {
-			float sector_angle = j * sector_step; // starting from 0 to 2pi
-
-			// vertex position (x, y, z)
-			float x = xy * Math::cos(sector_angle); // r * cos(u) * cos(v)
-			float y = xy * Math::sin(sector_angle); // r * cos(u) * sin(v)
-
-			Vector3 n = Vector3(x, z, y);
-			vertices.push_back(n);
+		for (int i = 0; i < 12; i++) {
+			Vector3 a, b;
+			aabb.get_edge(i, a, b);
+			lines.push_back(a);
+			lines.push_back(b);
 		}
+
+		Vector<Vector3> handles = helper->box_get_handles(probe->get_size());
+
+		Ref<Material> material = get_material("lightmap_probe_material", p_gizmo);
+
+		p_gizmo->add_lines(lines, material);
+
+		if (p_gizmo->is_selected()) {
+			Ref<Material> solid_material = get_material("lightmap_probe_solid_material", p_gizmo);
+			p_gizmo->add_solid_box(solid_material, probe->get_size());
+		}
+
+		p_gizmo->add_handles(handles, get_material("handles"));
 	}
 
-	for (int i = 0; i < stack_count; ++i) {
-		int k1 = i * (sector_count + 1); // beginning of current stack
-		int k2 = k1 + sector_count + 1; // beginning of next stack
-
-		for (int j = 0; j < sector_count; ++j, ++k1, ++k2) {
-			// 2 triangles per sector excluding first and last stacks
-			// k1 => k2 => k1+1
-			if (i != 0) {
-				lines.push_back(vertices[k1]);
-				lines.push_back(vertices[k2]);
-				lines.push_back(vertices[k1]);
-				lines.push_back(vertices[k1 + 1]);
-			}
-
-			if (i != (stack_count - 1)) {
-				lines.push_back(vertices[k1 + 1]);
-				lines.push_back(vertices[k2]);
-				lines.push_back(vertices[k2]);
-				lines.push_back(vertices[k2 + 1]);
-			}
-		}
-	}
-
-	const Ref<Material> icon = get_material("lightmap_probe_icon", p_gizmo);
-
-	p_gizmo->add_lines(lines, material_lines);
+	Ref<Material> icon = get_material("lightmap_probe_icon", p_gizmo);
 	p_gizmo->add_unscaled_billboard(icon, 0.05);
 }

--- a/editor/plugins/gizmos/lightmap_probe_gizmo_plugin.h
+++ b/editor/plugins/gizmos/lightmap_probe_gizmo_plugin.h
@@ -33,8 +33,12 @@
 
 #include "editor/plugins/node_3d_editor_gizmos.h"
 
+class Gizmo3DHelper;
+
 class LightmapProbeGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(LightmapProbeGizmoPlugin, EditorNode3DGizmoPlugin);
+
+	Ref<Gizmo3DHelper> helper;
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
@@ -42,7 +46,14 @@ public:
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const override;
+	void begin_handle_action(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, Camera3D *p_camera, const Point2 &p_point) override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel = false) override;
+
 	LightmapProbeGizmoPlugin();
+	~LightmapProbeGizmoPlugin();
 };
 
 #endif // LIGHTMAP_PROBE_GIZMO_PLUGIN_H

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -456,8 +456,35 @@ void LightmapGI::_find_meshes_and_lights(Node *p_at_node, Vector<MeshesFound> &m
 	LightmapProbe *probe = Object::cast_to<LightmapProbe>(p_at_node);
 
 	if (probe) {
-		Transform3D xf = get_global_transform().affine_inverse() * probe->get_global_transform();
-		probes.push_back(xf.origin);
+		const Transform3D xf = get_global_transform().affine_inverse() * probe->get_global_transform();
+
+		// Spawn a probe for each subdivision in the grid within the LightmapProbe's extents
+		// (at least one per dimension, even if cell size is greater than grid size).
+		const Vector3 size_div_cell_size = (probe->get_size() / probe->get_cell_size());
+		const Vector3i subdivisions = size_div_cell_size.floor();
+
+		// Enlarge cell size slightly if necessary so that the probe's extents are always fully covered by probes.
+		// For example, if probe size is 25×25×25 and cell size is 2x2x2, we can't fully cover the probe's extents
+		// using 12 subdivisions and a cell size of 2x2x2. Instead, we enlarge the cell size to roughly 2.083x2.083x2.083.
+		const Vector3 cell_enlarge_factor = (size_div_cell_size / subdivisions.max(Vector3(1, 1, 1)));
+
+		for (int subdiv_x = 0; subdiv_x <= subdivisions.x; subdiv_x++) {
+			for (int subdiv_y = 0; subdiv_y <= subdivisions.y; subdiv_y++) {
+				for (int subdiv_z = 0; subdiv_z <= subdivisions.z; subdiv_z++) {
+					// Center probe on the grid if it's the only one to be generated on each dimension.
+					// This means that a default configuration (1x1x1 size, 2x2x2 cell size) will only generate a single probe.
+					const Vector3 unique_offset = Vector3(
+							subdivisions.x == 0 ? probe->get_size().x * 0.5 : 0,
+							subdivisions.y == 0 ? probe->get_size().y * 0.5 : 0,
+							subdivisions.z == 0 ? probe->get_size().z * 0.5 : 0);
+
+					const Vector3 real_cell_size = probe->get_cell_size() * cell_enlarge_factor;
+
+					const Vector3 offset = -probe->get_size() * 0.5 + unique_offset + real_cell_size * Vector3i(subdiv_x, subdiv_y, subdiv_z);
+					probes.push_back(xf.translated_local(offset).origin);
+				}
+			}
+		}
 	}
 
 	for (int i = 0; i < p_at_node->get_child_count(); i++) {

--- a/scene/3d/lightmap_probe.cpp
+++ b/scene/3d/lightmap_probe.cpp
@@ -30,5 +30,34 @@
 
 #include "lightmap_probe.h"
 
+void LightmapProbe::set_size(Vector3 p_size) {
+	size = Vector3(MAX(0.001, p_size.x), MAX(0.001, p_size.y), MAX(0.001, p_size.z));
+	update_gizmos();
+}
+
+Vector3 LightmapProbe::get_size() const {
+	return size;
+}
+
+void LightmapProbe::set_cell_size(Vector3 p_cell_size) {
+	cell_size = Vector3(MAX(0.001, p_cell_size.x), MAX(0.001, p_cell_size.y), MAX(0.001, p_cell_size.z));
+	update_gizmos();
+}
+
+Vector3 LightmapProbe::get_cell_size() const {
+	return cell_size;
+}
+
+void LightmapProbe::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_size", "size"), &LightmapProbe::set_size);
+	ClassDB::bind_method(D_METHOD("get_size"), &LightmapProbe::get_size);
+
+	ClassDB::bind_method(D_METHOD("set_cell_size", "cell_size"), &LightmapProbe::set_cell_size);
+	ClassDB::bind_method(D_METHOD("get_cell_size"), &LightmapProbe::get_cell_size);
+
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size"), "set_size", "get_size");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "cell_size"), "set_cell_size", "get_cell_size");
+}
+
 LightmapProbe::LightmapProbe() {
 }

--- a/scene/3d/lightmap_probe.h
+++ b/scene/3d/lightmap_probe.h
@@ -35,7 +35,20 @@
 
 class LightmapProbe : public Node3D {
 	GDCLASS(LightmapProbe, Node3D)
+
+	Vector3 size = Vector3(1, 1, 1);
+	Vector3 cell_size = Vector3(2, 2, 2);
+
+protected:
+	static void _bind_methods();
+
 public:
+	void set_size(Vector3 p_size);
+	Vector3 get_size() const;
+
+	void set_cell_size(Vector3 p_cell_size);
+	Vector3 get_cell_size() const;
+
 	LightmapProbe();
 };
 


### PR DESCRIPTION
This has several upsides over relying on automatic probe generation alone, or placing individual probe nodes:

- You can choose where to place probes, so that you only place them in areas the player can reach.
- Less manual work is required, as you don't have to place as many nodes.
- Performance is improved in the editor as there are fewer nodes the editor needs to keep track of.
  - Additionally, having fewer nodes in the SceneTree improves runtime performance slightly, since we don't automatically remove LightmapProbe nodes in the exported project yet, even though they're editor-only helpers that have no effect after baking lightmaps.

This works with two new properties:

- **Size (defaults to 1x1x1):** The area in meters covered by the grid of reflection probes.
- **Cell Size (defaults to 2x2x2):** Lower values result in more detailed indirect lighting information for detailed objects.

Cell size is automatically adjusted so that the size is fully covered with probes, without any gaps or irregular spacing.

If cell size is greater than the size on any of the dimensions, only one probe is generated on that dimension, but it will be centered.

The default behavior is to use a size and cell size that generates a single probe in the middle, so that backwards compatibility is preserved.

Note that this does not automatically exclude probes that will be placed inside solid geometry. Something like https://github.com/godotengine/godot/pull/83420 would be more suited to this approach. (Also, this is likely better implemented in the lightmapper rather than the LightmapProbe node, so that it affects automatically generated probes too.)

- This closes https://github.com/godotengine/godot-proposals/issues/7938.

**Testing project:** [test_lightmap_probe_groups.zip](https://github.com/user-attachments/files/19134842/test_lightmap_probe_groups.zip)

## Preview

![Image](https://github.com/user-attachments/assets/3de19391-2e91-45bd-b318-66af83c8dda9)

## TODO

- [ ] Add a visualization for the chosen probe points (similar to the sphere wireframe previously), so you can see what the distribution looks like before baking lightmaps.
  - The gizmo could perhaps be made less intrusive at the same time, e.g. using a small circle/disc billboard icon. It would also be a bit faster to render this way.
- [ ] Write the number of probes the currently selected node will generate at the top of the 3D editor viewport, similar to the VoxelGI VRAM estimation label.
- [ ] Add a hard cap on the number of probes that may be generated per node (or clamp the cell size to a minimum value) to avoid situations where you accidentally add a very large amount of probes, making the bake times nearly infinite.