### PR TITLE
Fix visible avoidance debug rendering in NavigationRegion2D

### DIFF
--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -181,7 +181,7 @@ void NavigationRegion2D::_notification(int p_what) {
 
 		case NOTIFICATION_DRAW: {
 #ifdef DEBUG_ENABLED
-			if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || NavigationServer2D::get_singleton()->get_debug_enabled()) && navigation_polygon.is_valid()) {
+			if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || (NavigationServer2D::get_singleton()->get_debug_enabled() && NavigationServer2D::get_singleton()->get_debug_navigation_enabled())) && navigation_polygon.is_valid()) {
 				_update_debug_mesh();
 				_update_debug_edge_connections_mesh();
 				_update_debug_baking_rect();


### PR DESCRIPTION
This PR fixes an issue where enabling Visible Avoidance also makes the navigation mesh visible, regardless of whether Visible Navigation is enabled. The fix adds an additional check for get_debug_navigation_enabled() in the draw function of NavigationRegion2D.

Closes #103620

