### PR TITLE
Fix macOS mouse tracking in tooltip popups

### DIFF
--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -622,7 +622,7 @@
 		[self removeTrackingArea:tracking_area];
 	}
 
-	NSTrackingAreaOptions options = NSTrackingMouseEnteredAndExited | NSTrackingActiveInKeyWindow | NSTrackingCursorUpdate | NSTrackingInVisibleRect;
+	NSTrackingAreaOptions options = NSTrackingMouseEnteredAndExited | NSTrackingActiveWhenFirstResponder | NSTrackingCursorUpdate | NSTrackingInVisibleRect;
 	tracking_area = [[NSTrackingArea alloc] initWithRect:[self bounds] options:options owner:self userInfo:nil];
 
 	[self addTrackingArea:tracking_area];


### PR DESCRIPTION
Fixes #100682.

On macOS, `EditorHelpBitTooltip` would never receive `NOTIFICATION_WM_MOUSE_ENTER` or `NOTIFICATION_WM_MOUSE_EXIT`, causing the faulty behavior described in the linked issue.

This is due to an underlying problem with the popups' instances of `GodotContentView` (the `NSView` subclass that hosts their window content)—these instances would never receive their `mouseEntered` or `mouseExited` messages.

~~I was unable to determine exactly why these messages were not being sent—here were a few items I checked:~~
- ~~The view correctly sets its `frame` and tracking area~~
- ~~The view always returns `YES` from `acceptsFirstResponder`~~
- ~~There don't seem to be any other overlapping `NSView`s on top that could intercept the events~~

It seems a popup's window never becomes the key window, so it would not receive events due to the `NSTrackingActiveInKeyWindow` option (per Apple docs: "The owner receives messages when the view is in the key window").

This PR replaces `NSTrackingActiveInKeyWindow` with `NSTrackingActiveWhenFirstResponder` in the tracking area options, which allows the popups to receive these events due to their first responder status, despite not being in the key window.

I'm unsure if this change would cause adverse side effects—
This is roughly the edge of my Godot/AppKit knowledge so any further insight is appreciated!

Edit: The PR has been updated to no longer use the blanket-coverage "always active" tracking option, as the more narrow "first responder" option seems to solve the issue just as well