### PR TITLE
Fix memory leak caused by hidden tooltip controls

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1505,6 +1505,7 @@ void Viewport::_gui_show_tooltip() {
 	// This way, the custom tooltip from `ConnectionsDockTree` can create
 	// its own tooltip without conflicting with the default one, even an empty tooltip.
 	if (base_tooltip && !base_tooltip->is_visible()) {
+		memdelete(base_tooltip);
 		return;
 	}
 


### PR DESCRIPTION
Using hidden controls as flag can override the default tooltip behavior, but these controls are forgotten to be deleted.

You may get a message similar to the following when exiting the editor::

```
WARNING: 1 RID of type "CanvasItem" was leaked.
     at: _free_rids (servers/rendering/renderer_canvas_cull.cpp:2677)
WARNING: ObjectDB instances leaked at exit (run with --verbose for details).
     at: cleanup (core/object/object.cpp:2381)
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
