### PR TITLE
Switch occlusion culling to be based on depth instead of Euclidean distance

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -173,7 +173,9 @@ void RaycastOcclusionCull::RaycastHZBuffer::sort_rays(const Vector3 &p_camera_di
 					}
 					int k = tile_i * TILE_SIZE + tile_j;
 					int tile_index = i * tile_grid_size.x + j;
-					mips[0][y * buffer_size.x + x] = camera_rays[tile_index].ray.tfar[k];
+
+					Vector3 ray_dir(camera_rays[tile_index].ray.dir_x[k], camera_rays[tile_index].ray.dir_y[k], camera_rays[tile_index].ray.dir_z[k]);
+					mips[0][y * buffer_size.x + x] = camera_rays[tile_index].ray.tfar[k] * p_camera_dir.dot(ray_dir); // Store z-depth in view space.
 				}
 			}
 		}

--- a/servers/rendering/renderer_scene_occlusion_cull.h
+++ b/servers/rendering/renderer_scene_occlusion_cull.h
@@ -71,7 +71,7 @@ public:
 				return false;
 			}
 
-			float min_depth = (closest_point - p_cam_position).length();
+			float min_depth = -closest_point_view.z;
 
 			Vector2 rect_min = Vector2(FLT_MAX, FLT_MAX);
 			Vector2 rect_max = Vector2(FLT_MIN, FLT_MIN);
@@ -82,12 +82,9 @@ public:
 				Vector3 corner = Vector3(p_bounds[0] * c.x + p_bounds[3] * nc.x, p_bounds[1] * c.y + p_bounds[4] * nc.y, p_bounds[2] * c.z + p_bounds[5] * nc.z);
 				Vector3 view = p_cam_inv_transform.xform(corner);
 
-				if (p_cam_projection.is_orthogonal()) {
-					min_depth = MIN(min_depth, -view.z);
-				}
-
 				Plane vp = Plane(view, 1.0);
 				Plane projected = p_cam_projection.xform4(vp);
+				min_depth = MIN(min_depth, -view.z);
 
 				float w = projected.d;
 				if (w < 1.0) {


### PR DESCRIPTION
Resolves #94210 while undoing #98257 to improve behavior of #99986

Main reasons this change in approach as stated by @Flarkk in #97712 are:
> 1. the edge case discussed above is in my opinion not worth the overhead introduced by moving the whole buffer to euclidiant distance (see [Store view depth instead of ray length in occlusion buffer #100907](https://github.com/godotengine/godot/pull/100907))
> 
>  2. it ensures occlusion culling still works with very far away objects (see [Enable rendering with unbounded far distance #99986 (comment)](https://github.com/godotengine/godot/pull/99986#issuecomment-2688194684))

Tested using:
 - [MRP-A.zip](https://github.com/user-attachments/files/19142229/MRP-A.zip) (From #94210)
 - [MRP-B.zip](https://github.com/user-attachments/files/19142230/MRP-B.zip) (To ensure orthogonal cameras still work)

This is a re-implementation of #97712 since I was unable to reopen it. 