### PR TITLE
Set `unsupported` to true on error in `FreeDesktopScreenSaver`

### DIFF
--- a/platform/linuxbsd/freedesktop_screensaver.cpp
+++ b/platform/linuxbsd/freedesktop_screensaver.cpp
@@ -79,7 +79,7 @@ void FreeDesktopScreenSaver::inhibit() {
 	if (dbus_error_is_set(&error)) {
 		dbus_error_free(&error);
 		dbus_connection_unref(bus);
-		unsupported = false;
+		unsupported = true;
 		return;
 	}
 
@@ -116,6 +116,7 @@ void FreeDesktopScreenSaver::uninhibit() {
 			DBUS_TYPE_INVALID);
 
 	DBusMessage *reply = dbus_connection_send_with_reply_and_block(bus, message, 50, &error);
+	dbus_message_unref(message);
 	if (dbus_error_is_set(&error)) {
 		dbus_error_free(&error);
 		dbus_connection_unref(bus);
@@ -125,7 +126,6 @@ void FreeDesktopScreenSaver::uninhibit() {
 
 	print_verbose("FreeDesktopScreenSaver: Released screensaver inhibition cookie: " + uitos(cookie));
 
-	dbus_message_unref(message);
 	dbus_message_unref(reply);
 	dbus_connection_unref(bus);
 }


### PR DESCRIPTION
This avoids possible memory leaks when the editor exits.

<details>

<summary>memory leaks</summary>

```log
Direct leak of 184 byte(s) in 1 object(s) allocated from:
    #0 0x5ccca005541d in calloc (/opt/godot/godot/bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x1e82841d) (BuildId: 8cea5d685291829d751426bce6efca0aedda6040)
    #1 0x77677b352ddf  (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x22ddf) (BuildId: 47829078e4267099473c6cf5f5742f16ccb2644d)
    #2 0x77677b353bf4 in dbus_message_new_method_call (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x23bf4) (BuildId: 47829078e4267099473c6cf5f5742f16ccb2644d)
    #3 0x77677b34641c in dbus_bus_register (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x1641c) (BuildId: 47829078e4267099473c6cf5f5742f16ccb2644d)
    #4 0x77677b346707  (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x16707) (BuildId: 47829078e4267099473c6cf5f5742f16ccb2644d)
    #5 0x5ccca0113ef4 in FreeDesktopScreenSaver::inhibit() /opt/godot/godot/platform/linuxbsd/freedesktop_screensaver.cpp:55:24
    #6 0x5ccca0155d9b in DisplayServerX11::screen_set_keep_on(bool) /opt/godot/godot/platform/linuxbsd/x11/display_server_x11.cpp:1814:16
    #7 0x5ccca0200e5d in DisplayServerX11::DisplayServerX11(String const&, DisplayServer::WindowMode, DisplayServer::VSyncMode, unsigned int, Vector2i const*, Vector2i const&, int, DisplayServer::Context, long, Error&) /opt/godot/godot/platform/linuxbsd/x11/display_server_x11.cpp:7109:2
    #8 0x5ccca01ed975 in DisplayServerX11::create_func(String const&, DisplayServer::WindowMode, DisplayServer::VSyncMode, unsigned int, Vector2i const*, Vector2i const&, int, DisplayServer::Context, long, Error&) /opt/godot/godot/platform/linuxbsd/x11/display_server_x11.cpp:6046:22
    #9 0x5cccb964135d in DisplayServer::create(int, String const&, DisplayServer::WindowMode, DisplayServer::VSyncMode, unsigned int, Vector2i const*, Vector2i const&, int, DisplayServer::Context, long, Error&) /opt/godot/godot/servers/display_server.cpp:1281:9
    #10 0x5ccca04b43bf in Main::setup2(bool) /opt/godot/godot/main/main.cpp:3010:20
    #11 0x5ccca04aca32 in Main::setup(char const*, int, char**, bool) /opt/godot/godot/main/main.cpp:2684:14
    #12 0x5ccca00960ca in main /opt/godot/godot/platform/linuxbsd/godot_linuxbsd.cpp:74:14
    #13 0x77678bc2a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #14 0x77678bc2a28a in __libc_start_main csu/../csu/libc-start.c:360:3
    #15 0x5ccc9ffba3e4 in _start (/opt/godot/godot/bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x1e78d3e4) (BuildId: 8cea5d685291829d751426bce6efca0aedda6040)
```

```log
Indirect leak of 223 byte(s) in 1 object(s) allocated from:
    #0 0x5ccca0055650 in realloc (/opt/godot/godot/bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x1e828650) (BuildId: 8cea5d685291829d751426bce6efca0aedda6040)
    #1 0x77677b361075  (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x31075) (BuildId: 47829078e4267099473c6cf5f5742f16ccb2644d)
    #2 0x77677b361104  (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x31104) (BuildId: 47829078e4267099473c6cf5f5742f16ccb2644d)
    #3 0x77677b362b7b in _dbus_string_copy_len (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x32b7b) (BuildId: 47829078e4267099473c6cf5f5742f16ccb2644d)
    #4 0x77677b365076  (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x35076) (BuildId: 47829078e4267099473c6cf5f5742f16ccb2644d)
    #5 0x77677b34fca3 in _dbus_type_writer_write_basic (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x1fca3) (BuildId: 47829078e4267099473c6cf5f5742f16ccb2644d)
    #6 0x77677b3535b9 in dbus_message_iter_append_basic (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x235b9) (BuildId: 47829078e4267099473c6cf5f5742f16ccb2644d)
    #7 0x77677b354160 in dbus_message_new_error (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x24160) (BuildId: 47829078e4267099473c6cf5f5742f16ccb2644d)
    #8 0x77677b345dbc in dbus_connection_send_with_reply (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x15dbc) (BuildId: 47829078e4267099473c6cf5f5742f16ccb2644d)
    #9 0x77677b346183 in dbus_connection_send_with_reply_and_block (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x16183) (BuildId: 47829078e4267099473c6cf5f5742f16ccb2644d)
    #10 0x5ccca0114411 in FreeDesktopScreenSaver::inhibit() /opt/godot/godot/platform/linuxbsd/freedesktop_screensaver.cpp:77:23
    #11 0x5ccca0155d9b in DisplayServerX11::screen_set_keep_on(bool) /opt/godot/godot/platform/linuxbsd/x11/display_server_x11.cpp:1814:16
    #12 0x5ccca0200e5d in DisplayServerX11::DisplayServerX11(String const&, DisplayServer::WindowMode, DisplayServer::VSyncMode, unsigned int, Vector2i const*, Vector2i const&, int, DisplayServer::Context, long, Error&) /opt/godot/godot/platform/linuxbsd/x11/display_server_x11.cpp:7109:2
    #13 0x5ccca01ed975 in DisplayServerX11::create_func(String const&, DisplayServer::WindowMode, DisplayServer::VSyncMode, unsigned int, Vector2i const*, Vector2i const&, int, DisplayServer::Context, long, Error&) /opt/godot/godot/platform/linuxbsd/x11/display_server_x11.cpp:6046:22
    #14 0x5cccb964135d in DisplayServer::create(int, String const&, DisplayServer::WindowMode, DisplayServer::VSyncMode, unsigned int, Vector2i const*, Vector2i const&, int, DisplayServer::Context, long, Error&) /opt/godot/godot/servers/display_server.cpp:1281:9
    #15 0x5ccca04b43bf in Main::setup2(bool) /opt/godot/godot/main/main.cpp:3010:20
    #16 0x5ccca04aca32 in Main::setup(char const*, int, char**, bool) /opt/godot/godot/main/main.cpp:2684:14
    #17 0x5ccca00960ca in main /opt/godot/godot/platform/linuxbsd/godot_linuxbsd.cpp:74:14
    #18 0x77678bc2a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #19 0x77678bc2a28a in __libc_start_main csu/../csu/libc-start.c:360:3
    #20 0x5ccc9ffba3e4 in _start (/opt/godot/godot/bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x1e78d3e4) (BuildId: 8cea5d685291829d751426bce6efca0aedda6040)
```

</details>


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
