### PR TITLE
Fix recovery mode lock file not being cleared on import/export

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4662,6 +4662,12 @@ void Main::cleanup(bool p_force) {
 	ResourceSaver::remove_custom_savers();
 	PropertyListHelper::clear_base_helpers();
 
+	// Remove the lock file if the engine exits successfully. Some automated processes such as
+	// --export/--import can bypass and/or finish faster than the existing check to remove the lock file.
+	if (OS::get_singleton()->get_exit_code() == EXIT_SUCCESS) {
+		OS::get_singleton()->remove_lock_file();
+	}
+
 	// Flush before uninitializing the scene, but delete the MessageQueue as late as possible.
 	message_queue->flush();
 


### PR DESCRIPTION
Fixes #103528.

Running `--import/--export` implies `--editor`, and so the recovery mode functionality is active. However, the lock file is only cleared 1 second after the engine finished initialization. For these automated processes, that is too late, since the engine automatically closes itself once it is finished.

To address this and other similar cases, this changes it to also remove the lock file on cleanup, _iff_ the exit code indicated success.