### PR TITLE
`FindReplaceBar`: Fix "Replace (All)" buttons repositioning, improve "Hide" button visual feedback

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -137,10 +137,7 @@ void FindReplaceBar::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			find_prev->set_button_icon(get_editor_theme_icon(SNAME("MoveUp")));
 			find_next->set_button_icon(get_editor_theme_icon(SNAME("MoveDown")));
-			hide_button->set_texture_normal(get_editor_theme_icon(SNAME("Close")));
-			hide_button->set_texture_hover(get_editor_theme_icon(SNAME("Close")));
-			hide_button->set_texture_pressed(get_editor_theme_icon(SNAME("Close")));
-			hide_button->set_custom_minimum_size(hide_button->get_texture_normal()->get_size());
+			hide_button->set_button_icon(get_editor_theme_icon(SNAME("Close")));
 			_update_toggle_replace_button(replace_text->is_visible_in_tree());
 		} break;
 
@@ -752,7 +749,7 @@ FindReplaceBar::FindReplaceBar() {
 	toggle_replace_button->set_focus_mode(FOCUS_NONE);
 	toggle_replace_button->connect(SceneStringName(pressed), callable_mp(this, &FindReplaceBar::_toggle_replace_pressed));
 
-	vbc_lineedit = memnew(VBoxContainer);
+	VBoxContainer *vbc_lineedit = memnew(VBoxContainer);
 	add_child(vbc_lineedit);
 	vbc_lineedit->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 	vbc_lineedit->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -762,18 +759,20 @@ FindReplaceBar::FindReplaceBar() {
 	add_child(vbc_option);
 
 	HBoxContainer *hbc_button_search = memnew(HBoxContainer);
-	vbc_button->add_child(hbc_button_search);
+	hbc_button_search->set_v_size_flags(SIZE_EXPAND_FILL);
 	hbc_button_search->set_alignment(BoxContainer::ALIGNMENT_END);
+	vbc_button->add_child(hbc_button_search);
 	hbc_button_replace = memnew(HBoxContainer);
-	vbc_button->add_child(hbc_button_replace);
+	hbc_button_replace->set_v_size_flags(SIZE_EXPAND_FILL);
 	hbc_button_replace->set_alignment(BoxContainer::ALIGNMENT_END);
+	vbc_button->add_child(hbc_button_replace);
 
 	HBoxContainer *hbc_option_search = memnew(HBoxContainer);
 	vbc_option->add_child(hbc_option_search);
 	hbc_option_replace = memnew(HBoxContainer);
 	vbc_option->add_child(hbc_option_replace);
 
-	// Search toolbar
+	// Search toolbar.
 	search_text = memnew(LineEdit);
 	search_text->set_keep_editing_on_text_submit(true);
 	vbc_lineedit->add_child(search_text);
@@ -813,7 +812,7 @@ FindReplaceBar::FindReplaceBar() {
 	whole_words->set_focus_mode(FOCUS_NONE);
 	whole_words->connect(SceneStringName(toggled), callable_mp(this, &FindReplaceBar::_search_options_changed));
 
-	// Replace toolbar
+	// Replace toolbar.
 	replace_text = memnew(LineEdit);
 	vbc_lineedit->add_child(replace_text);
 	replace_text->set_placeholder(TTR("Replace"));
@@ -837,12 +836,13 @@ FindReplaceBar::FindReplaceBar() {
 	selection_only->set_focus_mode(FOCUS_NONE);
 	selection_only->connect(SceneStringName(toggled), callable_mp(this, &FindReplaceBar::_search_options_changed));
 
-	hide_button = memnew(TextureButton);
-	add_child(hide_button);
+	hide_button = memnew(Button);
+	hide_button->set_flat(true);
 	hide_button->set_tooltip_text(TTR("Hide"));
 	hide_button->set_focus_mode(FOCUS_NONE);
 	hide_button->connect(SceneStringName(pressed), callable_mp(this, &FindReplaceBar::_hide_bar));
 	hide_button->set_v_size_flags(SIZE_SHRINK_CENTER);
+	add_child(hide_button);
 }
 
 /*** CODE EDITOR ****/

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -79,14 +79,13 @@ class FindReplaceBar : public HBoxContainer {
 	Button *find_next = nullptr;
 	CheckBox *case_sensitive = nullptr;
 	CheckBox *whole_words = nullptr;
-	TextureButton *hide_button = nullptr;
+	Button *hide_button = nullptr;
 
 	LineEdit *replace_text = nullptr;
 	Button *replace = nullptr;
 	Button *replace_all = nullptr;
 	CheckBox *selection_only = nullptr;
 
-	VBoxContainer *vbc_lineedit = nullptr;
 	HBoxContainer *hbc_button_replace = nullptr;
 	HBoxContainer *hbc_option_replace = nullptr;
 


### PR DESCRIPTION
"Replace" and "Replace All" buttons now do not change their position depending on the availability of search results.
This is how it was before (look at "Replace (All)" buttons):

https://github.com/user-attachments/assets/772a9a0c-73be-47c0-905a-22977922879f

This is how it looks now:

https://github.com/user-attachments/assets/66e0b1aa-1b99-4845-beeb-3382df93163c

Additional changes:
- `VBoxContainer *vbc_lineedit` declaration has been removed from the header because it is not used outside the `FindReplaceBar` constructor.
- `hide_button` was changed from `TextureButton` to `Button` for consistency with other buttons - this allows to visually see the feedback when hovering and pressing and also not set its icon 3 times instead of 1. But at the same time, it takes up a little more space around the icon - I think it should be fine.

| Before | After |
| --- | --- |
| ![Godot_v4 4-stable_win64_hmNFa1foGS](https://github.com/user-attachments/assets/6de6a81e-8705-436b-a371-b4b1dafb0729) | ![godot windows editor dev x86_64_mbDYuogE1l](https://github.com/user-attachments/assets/eddfb16f-e7b9-4c0d-b1f1-390aaa28cfdc) |