### PR TITLE
RenderingDevice: Delay expensive operations to `get_perf_report`

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -612,16 +612,17 @@ Error RenderingDevice::driver_callback_add(RDD::DriverCallback p_callback, void 
 }
 
 String RenderingDevice::get_perf_report() const {
+	String perf_report_text;
+	perf_report_text += " gpu:" + String::num_int64(prev_gpu_copy_count);
+	perf_report_text += " bytes:" + String::num_int64(prev_copy_bytes_count);
+
+	perf_report_text += " lazily alloc:" + String::num_int64(driver->get_lazily_memory_used());
 	return perf_report_text;
 }
 
 void RenderingDevice::update_perf_report() {
-	perf_report_text = "";
-	perf_report_text += " gpu:" + String::num_int64(gpu_copy_count);
-	perf_report_text += " bytes:" + String::num_int64(copy_bytes_count);
-
-	perf_report_text += " lazily alloc:" + String::num_int64(driver->get_lazily_memory_used());
-
+	prev_gpu_copy_count = gpu_copy_count;
+	prev_copy_bytes_count = copy_bytes_count;
 	gpu_copy_count = 0;
 	copy_bytes_count = 0;
 }

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -203,7 +203,8 @@ private:
 	bool split_swapchain_into_its_own_cmd_buffer = true;
 	uint32_t gpu_copy_count = 0;
 	uint32_t copy_bytes_count = 0;
-	String perf_report_text;
+	uint32_t prev_gpu_copy_count = 0;
+	uint32_t prev_copy_bytes_count = 0;
 
 	RID_Owner<Buffer, true> uniform_buffer_owner;
 	RID_Owner<Buffer, true> storage_buffer_owner;


### PR DESCRIPTION
The function update_perf_report() is expensive and is called every frame.
Most of it is not necessary unless the user calls get_perf_report

Affects #102173
