### PR TITLE
Add a button to the Quick load dialog box to display the history file if the history file condition is not met

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -605,6 +605,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "filesystem/quick_open_dialog/max_results", 100, "0,10000,1", PROPERTY_USAGE_DEFAULT)
 	_initial_set("filesystem/quick_open_dialog/show_search_highlight", true);
 	_initial_set("filesystem/quick_open_dialog/enable_fuzzy_matching", true);
+	_initial_set("filesystem/quick_open_dialog/enable_history_file_mode", false);
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "filesystem/quick_open_dialog/max_fuzzy_misses", 2, "0,10,1", PROPERTY_USAGE_DEFAULT)
 	_initial_set("filesystem/quick_open_dialog/include_addons", false);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "filesystem/quick_open_dialog/default_display_mode", 0, "Adaptive,Last Used")

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -337,8 +337,10 @@ void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 
 	const bool fuzzy_matching = EDITOR_GET("filesystem/quick_open_dialog/enable_fuzzy_matching");
 	const bool include_addons = EDITOR_GET("filesystem/quick_open_dialog/include_addons");
+	const bool history_file_mode = EDITOR_GET("filesystem/quick_open_dialog/enable_history_file_mode");
 	fuzzy_search_toggle->set_pressed_no_signal(fuzzy_matching);
 	include_addons_toggle->set_pressed_no_signal(include_addons);
+	history_file_mode_toggle->set_pressed_no_signal(history_file_mode);
 	never_opened = false;
 
 	const bool enable_highlights = EDITOR_GET("filesystem/quick_open_dialog/show_search_highlight");
@@ -472,7 +474,7 @@ void QuickOpenResultContainer::update_results() {
 
 void QuickOpenResultContainer::_use_default_candidates() {
 	bool history_file_mode = EDITOR_GET("filesystem/quick_open_dialog/enable_history_file_mode");
-	if (filepaths.size() <= SHOW_ALL_FILES_THRESHOLD and history_file_mode != true) {
+	if (filepaths.size() <= SHOW_ALL_FILES_THRESHOLD && !history_file_mode) {
 		candidates.resize(filepaths.size());
 		QuickOpenResultCandidate *candidates_write = candidates.ptrw();
 		for (const String &filepath : filepaths) {

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -272,6 +272,13 @@ QuickOpenResultContainer::QuickOpenResultContainer() {
 		include_addons_toggle->connect(SceneStringName(toggled), callable_mp(this, &QuickOpenResultContainer::_toggle_include_addons));
 		bottom_bar->add_child(include_addons_toggle);
 
+		history_file_mode_toggle = memnew(CheckButton);
+		style_button(history_file_mode_toggle);
+		history_file_mode_toggle->set_text(TTR("Historical file mode"));
+		history_file_mode_toggle->set_tooltip_text(TTR("Enable the historical file mode"));
+		history_file_mode_toggle->connect(SceneStringName(toggled), callable_mp(this, &QuickOpenResultContainer::_toggle_history_file_mode));
+		bottom_bar->add_child(history_file_mode_toggle);
+
 		VSeparator *vsep = memnew(VSeparator);
 		vsep->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 		vsep->set_custom_minimum_size(Size2i(0, 14 * EDSCALE));
@@ -464,7 +471,8 @@ void QuickOpenResultContainer::update_results() {
 }
 
 void QuickOpenResultContainer::_use_default_candidates() {
-	if (filepaths.size() <= SHOW_ALL_FILES_THRESHOLD) {
+	bool history_file_mode = EDITOR_GET("filesystem/quick_open_dialog/enable_history_file_mode");
+	if (filepaths.size() <= SHOW_ALL_FILES_THRESHOLD and history_file_mode != true) {
 		candidates.resize(filepaths.size());
 		QuickOpenResultCandidate *candidates_write = candidates.ptrw();
 		for (const String &filepath : filepaths) {
@@ -656,6 +664,11 @@ void QuickOpenResultContainer::_item_input(const Ref<InputEvent> &p_ev, int p_in
 
 void QuickOpenResultContainer::_toggle_fuzzy_search(bool p_pressed) {
 	EditorSettings::get_singleton()->set("filesystem/quick_open_dialog/enable_fuzzy_matching", p_pressed);
+	update_results();
+}
+
+void QuickOpenResultContainer::_toggle_history_file_mode(bool p_pressed) {
+	EditorSettings::get_singleton()->set("filesystem/quick_open_dialog/enable_history_file_mode", p_pressed);
 	update_results();
 }
 

--- a/editor/gui/editor_quick_open_dialog.h
+++ b/editor/gui/editor_quick_open_dialog.h
@@ -143,6 +143,7 @@ private:
 	Button *display_mode_toggle = nullptr;
 	CheckButton *include_addons_toggle = nullptr;
 	CheckButton *fuzzy_search_toggle = nullptr;
+	CheckButton *history_file_mode_toggle = nullptr;
 
 	OAHashMap<StringName, Ref<Texture2D>> file_type_icons;
 
@@ -170,6 +171,7 @@ private:
 	void _toggle_display_mode();
 	void _toggle_include_addons(bool p_pressed);
 	void _toggle_fuzzy_search(bool p_pressed);
+	void _toggle_history_file_mode(bool p_pressed);
 	void _menu_option(int p_option);
 
 	String _get_cache_file_path() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
after #103713
When the user sets the SHOW_ALL_FILES_THRESHOLD threshold too high, the user is allowed to manually enable history file browsing mode in the quick load dialog
![屏幕截图 2025-03-08 225718](https://github.com/user-attachments/assets/98a2e682-1af2-4d2c-9ed7-e50ff220bd13)
![屏幕截图 2025-03-08 225711](https://github.com/user-attachments/assets/daefe69a-7104-4d3f-9c18-4bd4225e1de1)
![屏幕截图 2025-03-08 225650](https://github.com/user-attachments/assets/f1af7848-c128-43a4-8949-62dde7426820)
