### PR TITLE
Fix crash in split_floats and related functions when called on empty strings or similar

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1311,6 +1311,14 @@ Vector<String> String::split(const char *p_splitter, bool p_allow_empty, int p_m
 
 Vector<String> String::rsplit(const String &p_splitter, bool p_allow_empty, int p_maxsplit) const {
 	Vector<String> ret;
+
+	if (is_empty()) {
+		if (p_allow_empty) {
+			ret.push_back("");
+		}
+		return ret;
+	}
+
 	const int len = length();
 	int remaining_len = len;
 
@@ -1353,6 +1361,14 @@ Vector<String> String::rsplit(const String &p_splitter, bool p_allow_empty, int 
 
 Vector<String> String::rsplit(const char *p_splitter, bool p_allow_empty, int p_maxsplit) const {
 	Vector<String> ret;
+
+	if (is_empty()) {
+		if (p_allow_empty) {
+			ret.push_back("");
+		}
+		return ret;
+	}
+
 	const int len = length();
 	const int splitter_length = strlen(p_splitter);
 	int remaining_len = len;
@@ -1395,6 +1411,10 @@ Vector<String> String::rsplit(const char *p_splitter, bool p_allow_empty, int p_
 }
 
 Vector<double> String::split_floats(const String &p_splitter, bool p_allow_empty) const {
+	if (is_empty()) {
+		return Vector<double>();
+	}
+
 	Vector<double> ret;
 	int from = 0;
 	int len = length();
@@ -1422,6 +1442,10 @@ Vector<double> String::split_floats(const String &p_splitter, bool p_allow_empty
 }
 
 Vector<float> String::split_floats_mk(const Vector<String> &p_splitters, bool p_allow_empty) const {
+	if (is_empty()) {
+		return Vector<float>();
+	}
+
 	Vector<float> ret;
 	int from = 0;
 	int len = length();
@@ -1454,6 +1478,10 @@ Vector<float> String::split_floats_mk(const Vector<String> &p_splitters, bool p_
 }
 
 Vector<int> String::split_ints(const String &p_splitter, bool p_allow_empty) const {
+	if (is_empty()) {
+		return Vector<int>();
+	}
+
 	Vector<int> ret;
 	int from = 0;
 	int len = length();
@@ -1478,6 +1506,10 @@ Vector<int> String::split_ints(const String &p_splitter, bool p_allow_empty) con
 }
 
 Vector<int> String::split_ints_mk(const Vector<String> &p_splitters, bool p_allow_empty) const {
+	if (is_empty()) {
+		return Vector<int>();
+	}
+
 	Vector<int> ret;
 	int from = 0;
 	int len = length();


### PR DESCRIPTION
This PR fixes issue where calling split_floats (and related functions like split_ints) on an empty string or similar would cause a crash. The problem occurs because the functions do not handle empty inputs properly.

- Added checks for empty strings or arrays in split_floats, split_floats_mk ,split_ints, split_ints_mk, and rsplit
- Functions now return an empty array if the input is empty, preventing crashes.

Closes #103809