### PR TITLE
Fix crash related to #region/#endregion caused by trailing spaces

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1175,7 +1175,7 @@ String String::get_slicec(char32_t p_splitter, int p_slice) const {
 	}
 }
 
-Vector<String> String::split_spaces() const {
+Vector<String> String::split_spaces(int p_maxsplit) const {
 	Vector<String> ret;
 	int from = 0;
 	int i = 0;
@@ -1199,6 +1199,11 @@ Vector<String> String::split_spaces() const {
 		}
 
 		if (empty && inside) {
+			if (p_maxsplit > 0 && p_maxsplit == ret.size()) {
+				// Put rest of the string and leave cycle.
+				ret.push_back(substr(from));
+				break;
+			}
 			ret.push_back(substr(from, i - from));
 			inside = false;
 		}

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -486,7 +486,7 @@ public:
 	Vector<String> split(const char *p_splitter = "", bool p_allow_empty = true, int p_maxsplit = 0) const;
 	Vector<String> rsplit(const String &p_splitter = "", bool p_allow_empty = true, int p_maxsplit = 0) const;
 	Vector<String> rsplit(const char *p_splitter = "", bool p_allow_empty = true, int p_maxsplit = 0) const;
-	Vector<String> split_spaces() const;
+	Vector<String> split_spaces(int p_maxsplit = 0) const;
 	Vector<double> split_floats(const String &p_splitter, bool p_allow_empty = true) const;
 	Vector<float> split_floats_mk(const Vector<String> &p_splitters, bool p_allow_empty = true) const;
 	Vector<int> split_ints(const String &p_splitter, bool p_allow_empty = true) const;

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -151,10 +151,13 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 							}
 						}
 						// "#region" and "#endregion" only highlighted if they're the first region on the line.
-						if (color_regions[c].type == ColorRegion::TYPE_CODE_REGION &&
-								str.strip_edges().split_spaces()[0] != "#region" &&
-								str.strip_edges().split_spaces()[0] != "#endregion") {
-							match = false;
+						if (color_regions[c].type == ColorRegion::TYPE_CODE_REGION) {
+							Vector<String> str_stripped_split = str.strip_edges().split_spaces(1);
+							if (!str_stripped_split.is_empty() &&
+									str_stripped_split[0] != "#region" &&
+									str_stripped_split[0] != "#endregion") {
+								match = false;
+							}
 						}
 						if (!match) {
 							continue;

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1872,7 +1872,7 @@ bool CodeEdit::is_line_code_region_start(int p_line) const {
 	if (is_in_string(p_line) != -1) {
 		return false;
 	}
-	Vector<String> split = get_line(p_line).strip_edges().split_spaces();
+	Vector<String> split = get_line(p_line).strip_edges().split_spaces(1);
 	return split.size() > 0 && split[0] == code_region_start_string;
 }
 
@@ -1884,7 +1884,7 @@ bool CodeEdit::is_line_code_region_end(int p_line) const {
 	if (is_in_string(p_line) != -1) {
 		return false;
 	}
-	Vector<String> split = get_line(p_line).strip_edges().split_spaces();
+	Vector<String> split = get_line(p_line).strip_edges().split_spaces(1);
 	return split.size() > 0 && split[0] == code_region_end_string;
 }
 

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -713,6 +713,14 @@ TEST_CASE("[String] Splitting") {
 			CHECK(l[i] == slices[i]);
 		}
 	}
+	{
+		const String s = "Mars Jupiter Saturn Uranus";
+		const char *slices[2] = { "Mars", "Jupiter Saturn Uranus" };
+		Vector<String> l = s.split_spaces(1);
+		for (int i = 0; i < l.size(); i++) {
+			CHECK(l[i] == slices[i]);
+		}
+	}
 
 	{
 		const String s = "1.2;2.3 4.5";


### PR DESCRIPTION
Fixes #103797 
Issue introduced in #101319

(Also is mildly more efficient since it isn't redundantly splitting twice)