### PR TITLE
Make project manager's "last edited" field display use local time instead of UTC

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -869,7 +869,7 @@ void ProjectList::_create_project_item_control(int p_index) {
 	hb->set_tags(item.tags, this);
 	hb->set_unsupported_features(item.unsupported_features.duplicate());
 	hb->set_project_version(item.project_version);
-	hb->set_last_edited_info(!item.missing ? Time::get_singleton()->get_datetime_string_from_unix_time(item.last_edited, true) : TTR("Missing Date"));
+	hb->set_last_edited_info(item.get_last_edited_string());
 
 	hb->set_is_favorite(item.favorite);
 	hb->set_is_missing(item.missing);

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/config_file.h"
+#include "core/os/time.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/scroll_container.h"
 
@@ -160,6 +161,15 @@ public:
 
 		_FORCE_INLINE_ bool operator==(const Item &l) const {
 			return path == l.path;
+		}
+
+		String get_last_edited_string() const {
+			if (missing) {
+				return TTR("Missing Date");
+			}
+
+			OS::TimeZoneInfo tz = OS::get_singleton()->get_time_zone_info();
+			return Time::get_singleton()->get_datetime_string_from_unix_time(last_edited + tz.bias * 60, true);
 		}
 	};
 


### PR DESCRIPTION
This also adds a core (Time) method to display a unix timestamp using the system timezone. Unsure if this should be added but I imagine this more general solution could be useful in games too?

Fixes #103808