### PR TITLE
Core: Fix translation remaps incorrectly falling back

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1249,7 +1249,9 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 		}
 
 		// Fallback to p_path if new_path does not exist.
-		if (!FileAccess::exists(new_path + ".import") && !FileAccess::exists(new_path)) {
+		if (!FileAccess::exists(new_path + ".import") &&
+				!FileAccess::exists(new_path + ".remap") &&
+				!FileAccess::exists(new_path)) {
 			WARN_PRINT(vformat("Translation remap '%s' does not exist. Falling back to '%s'.", new_path, p_path));
 			new_path = p_path;
 		}


### PR DESCRIPTION
The remaps system of translation doesn't work when exporting an executable.

When exporting a `.pck` that uses translation, some resource remaps have the extension `.remap` rather than the usual `.import`. This makes godot incorrectly fallback to the default translation.

To fix this, I believe that the `.remap` extension should also be considered before falling back

Fixes #97263 


For example, if you create a theme remaps as below, this will work while debugging but not after exporting

![image](https://github.com/user-attachments/assets/f35c435e-039b-4479-99f7-50ef5988c281)
