### PR TITLE
Fix CurveEdit not notifying about all changes

### DIFF
--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -546,14 +546,16 @@ void CurveEdit::set_point_position(int p_index, const Vector2 &p_pos) {
 	// Pretend the point started from its old place.
 	curve->set_point_value(p_index, initial_grab_pos.y);
 	curve->set_point_offset(p_index, initial_grab_pos.x);
-	// Note: Changing the offset may modify the order.
+
+	// Note: Changing the offset may modify the order so
+	// we're using the final index in set_point_value after the offset.
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Modify Curve Point"));
-	undo_redo->add_do_method(*curve, "set_point_value", initial_grab_index, p_pos.y);
 	undo_redo->add_do_method(*curve, "set_point_offset", initial_grab_index, p_pos.x);
+	undo_redo->add_do_method(*curve, "set_point_value", p_index, p_pos.y);
 	undo_redo->add_do_method(this, "set_selected_index", p_index);
-	undo_redo->add_undo_method(*curve, "set_point_value", p_index, initial_grab_pos.y);
 	undo_redo->add_undo_method(*curve, "set_point_offset", p_index, initial_grab_pos.x);
+	undo_redo->add_undo_method(*curve, "set_point_value", initial_grab_index, initial_grab_pos.y);
 	undo_redo->add_undo_method(this, "set_selected_index", initial_grab_index);
 	undo_redo->commit_action();
 }


### PR DESCRIPTION
Closes #103831

Unlike `Curve::set_point_value()`, `Curve::set_point_offset()` doesn't mark curve as dirty which causes problems with `CurveEdit::set_point_position()` that calls them out of order and causes `CurveTexture` resource to not use the latest data of its `Curve`

This could be solved by adding `mark_dirty()` to `Curve::set_point_offset` but that would double the amount of calls to heavy `CurveTexture::_update`. So instead we're reversing the order of calls in `CurveEdit::set_point_position`. I made sure `set_point_value` is using the correct index (it's known in advance because drag has already happened)