### PR TITLE
Fix: Prevent PackedScene duplicate signal connection for CONNECT_PERSIST

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1447,6 +1447,12 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 		if (p_flags & CONNECT_REFERENCE_COUNTED) {
 			s->slot_map[*p_callable.get_base_comparator()].reference_count++;
 			return OK;
+		} else if (p_flags & CONNECT_PERSIST) {
+#ifdef DEBUG_ENABLED
+			WARN_PRINT(vformat("Signal '%s' already connected to callable '%s'. Skipping duplicate persistent connection.",
+					p_signal, p_callable));
+#endif
+			return OK;
 		} else {
 			ERR_FAIL_V_MSG(ERR_INVALID_PARAMETER, vformat("Signal '%s' is already connected to given callable '%s' in that object.", p_signal, p_callable));
 		}


### PR DESCRIPTION
### Fix: Prevent PackedScene duplicate signal connection for CONNECT_PERSIST occured in issue **#103453**

#### **Issue**
- When a PackedScene is instantiated, it automatically restores CONNECT_PERSIST signals.
- However, if `SceneState::instantiate` calls `connect()`, it triggers a "Signal already connected" error.

#### **Solution**
- Modified `Object::connect()` to check for CONNECT_PERSIST before reporting duplicate connections.
- If the signal is already connected and has CONNECT_PERSIST, it will **skip reconnection instead of throwing an error**.

Note:
This is my first PR to the Godot project. If there are any issues or areas for improvement, please let me know—I’m happy to make adjustments and learn from your feedback! Thank you for your patience and guidance.

* *Bugsquad edit, closes: #103453*
