### PR TITLE
AudioEffectCompressor: Recommend HardLimiter over deprecated Limiter

### DIFF
--- a/doc/classes/AudioEffectCompressor.xml
+++ b/doc/classes/AudioEffectCompressor.xml
@@ -7,7 +7,7 @@
 	<description>
 		Dynamic range compressor reduces the level of the sound when the amplitude goes over a certain threshold in Decibels. One of the main uses of a compressor is to increase the dynamic range by clipping as little as possible (when sound goes over 0dB).
 		Compressor has many uses in the mix:
-		- In the Master bus to compress the whole output (although an [AudioEffectLimiter] is probably better).
+		- In the Master bus to compress the whole output (although an [AudioEffectHardLimiter] is probably better).
 		- In voice channels to ensure they sound as balanced as possible.
 		- Sidechained. This can reduce the sound level sidechained with another audio bus for threshold detection. This technique is common in video game mixing to the level of music and SFX while voices are being heard.
 		- Accentuates transients by using a wider attack, making effects sound more punchy.


### PR DESCRIPTION
`AudioEffectLimiter` is subject to the #36631 issue, which was "fixed" by creating `AudioEffectHardLimiter` and deprecating the former.

But `AudioEffectCompressor` still suggests an `AudioEffectLimiter` to be used on the Master bus over it when `AudioEffectHardLimiter` should be the recommended one.