### PR TITLE
GLTF: Fix wrong color space for GLTFLight on export

### DIFF
--- a/doc/classes/Light3D.xml
+++ b/doc/classes/Light3D.xml
@@ -64,7 +64,7 @@
 			[b]Note:[/b] Meshes' global illumination mode will also affect the global illumination rendering. See [member GeometryInstance3D.gi_mode].
 		</member>
 		<member name="light_color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
-			The light's color. An [i]overbright[/i] color can be used to achieve a result equivalent to increasing the light's [member light_energy].
+			The light's color in the nonlinear sRGB color space. An [i]overbright[/i] color can be used to achieve a result equivalent to increasing the light's [member light_energy].
 		</member>
 		<member name="light_cull_mask" type="int" setter="set_cull_mask" getter="get_cull_mask" default="4294967295">
 			The light will affect objects in the selected layers.

--- a/modules/gltf/doc_classes/GLTFLight.xml
+++ b/modules/gltf/doc_classes/GLTFLight.xml
@@ -53,7 +53,8 @@
 	</methods>
 	<members>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)" keywords="colour">
-			The [Color] of the light. Defaults to white. A black color causes the light to have no effect.
+			The [Color] of the light in linear space. Defaults to white. A black color causes the light to have no effect.
+			This value is linear to match glTF, but will be converted to nonlinear sRGB when creating a Godot [Light3D] node upon import, or converted to linear when exporting a Godot [Light3D] to glTF.
 		</member>
 		<member name="inner_cone_angle" type="float" setter="set_inner_cone_angle" getter="get_inner_cone_angle" default="0.0">
 			The inner angle of the cone in a spotlight. Must be less than or equal to the outer cone angle.


### PR DESCRIPTION
Oh my goodness, I wrote this 2 months ago and forgot to submit it as a PR... 🤦‍♂️ 

[glTF uses linear color space for lights](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_lights_punctual#light-shared-properties), while Godot's Light3D node uses sRGB color space ([the docs don't specify](https://docs.godotengine.org/en/stable/classes/class_light3d.html#class-light3d-property-light-color), but I tested how it visually looks, and well, it's either sRGB or close to it).

In the past I had only tested lights with trivial colors, such as pure white or pure red. Or maybe I've only tested importing lights, and not exporting them. Godot performs a color space conversion during import, but does not perform the reverse on export. This means that the color of lights does not survive a round-trip. Additionally, the conversion was performed at the wrong step, leading to the GLTFLight data not matching the data in the glTF light. This PR fixes both of these problems. Now the color space is correctly converted when generating new nodes and when converting existing nodes.

To test this, I made a Light3D node and set its color to (0.75, 0.5, 0.25). In the current master, it incorrectly exports the Light3D color value as-is without performing a conversion, resulting in this file that doesn't visually match Godot:

```gltf
{
    "asset": { "version": "2.0" },
    "extensions": {
        "KHR_lights_punctual": {
            "lights": [{ "color": [0.75, 0.5, 0.25], "type": "point" }]
        }
    },
    "extensionsUsed": ["KHR_lights_punctual"],
    "nodes": [
        {
            "extensions": { "KHR_lights_punctual": { "light": 0 } },
            "name": "OrangeLight"
        }
    ],
    "scene": 0,
    "scenes": [{ "nodes": [0] }]
}
```

With this PR, exporting the same scene gives almost the same file but with a color of `[0.522521495819092, 0.214041143655777, 0.0508760772645473]`, which is the correct linear version of the sRGB `(0.75, 0.5, 0.25)`, and then after import Godot reads the color as `(0.75, 0.5, 0.25)` again. With this PR, the exported glTF looks the same in Godot as it does in online glTF viewers such as [glTF Viewer](https://gltf-viewer.donmccurdy.com/) and [glTF Sample Viewer](https://github.khronos.org/glTF-Sample-Viewer-Release/).

Additionally, this PR adds the above color space information to the Light3D and GLTFLight documentation.