### PR TITLE
AudioStreamPlayer3D: Correct amplitude panning

### DIFF
--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -60,6 +60,8 @@ public:
 			w[speaker_num].direction = speaker_directions[speaker_num];
 			w[speaker_num].squared_gain = 0.0;
 			w[speaker_num].effective_number_of_speakers = 0.0;
+		}
+		for (unsigned int speaker_num = 0; speaker_num < speaker_count; speaker_num++) {
 			for (unsigned int other_speaker_num = 0; other_speaker_num < speaker_count; other_speaker_num++) {
 				w[speaker_num].effective_number_of_speakers += 0.5 * (1.0 + w[speaker_num].direction.dot(w[other_speaker_num].direction));
 			}


### PR DESCRIPTION
The effective number of speakers was being calculated on uninitialized parameters. It worked by chance for 2 channels, but it fails for more channels.

Before this change the front/center speakers would have less volume and the side speakers would be unbalanced.

I don't have a multiple speaker setup, so my testing is limited to hearing only two channels at a time.

Effective number of speakers calculation for 7.1 before this PR:

channel 0: 4.000000 (front left)
channel 1: 4.000000 ( front right)
channel 2: 4.707107 (center)
channel 3: 3.146447 (rear left)
channel 4: 3.146446 (rear right)
channel 5: 4.000000 (side left)
channel 6: 3.500000 (side right)

And after:

channel 0: 3.853553 (front left)
channel 1: 3.853553 (front right)
channel 2: 4.000000 (center)
channel 3: 3.146447 (rear left)
channel 4: 3.146446 (rear right)
channel 5: 3.500000 (side left)
channel 6: 3.500000 (side right)
