### PR TITLE
Implement an explicit virtual method mark for GDScript

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -577,6 +577,18 @@
 		<member name="debug/gdscript/warnings/onready_with_export" type="int" setter="" getter="" default="2">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when the [code]@onready[/code] annotation is used together with the [code]@export[/code] annotation, since it may not behave as expected.
 		</member>
+		<member name="debug/gdscript/warnings/override_inexistent_method_from_base" type="int" setter="" getter="" default="2">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a method annotated with an [code]@override[/code] annotation is trying to override a inexistent one from the base class.
+		</member>
+		<member name="debug/gdscript/warnings/override_non_virtual_method" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a method tries to override the one that is not annotated with a [code]@virtual[/code] from the base class, since such behavior will lead to unexpected and unsafe behaviors, unless you know what you are doing.
+		</member>
+		<member name="debug/gdscript/warnings/override_without_override_annotation" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a method tries to override the one annotated with a [code]@virtual[/code] from the base class, without an explicit [code]@override[/code] annotation.
+		</member>
+		<member name="debug/gdscript/warnings/property_used_as_function" type="int" setter="" getter="" default="1" deprecated="This warning is never produced. Instead, an error is generated if the expression type is known at compile time.">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when using a property as if it is a function.
+		</member>
 		<member name="debug/gdscript/warnings/redundant_await" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a function that is not a coroutine is called with await.
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -586,9 +586,6 @@
 		<member name="debug/gdscript/warnings/override_without_override_annotation" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a method tries to override the one annotated with a [code]@virtual[/code] from the base class, without an explicit [code]@override[/code] annotation.
 		</member>
-		<member name="debug/gdscript/warnings/property_used_as_function" type="int" setter="" getter="" default="1" deprecated="This warning is never produced. Instead, an error is generated if the expression type is known at compile time.">
-			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when using a property as if it is a function.
-		</member>
 		<member name="debug/gdscript/warnings/redundant_await" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a function that is not a coroutine is called with await.
 		</member>

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -150,12 +150,6 @@ static void _add_qualifiers_to_rt(const String &p_qualifiers, RichTextLabel *p_r
 			hint = TTR("This method is called by the engine.\nIt can be overridden to customize built-in behavior.");
 		} else if (qualifier == "required") {
 			hint = TTR("This method is required to be overridden when extending its base class.");
-		} else if (qualifier == "virtual_annotated") {
-			hint = TTR("This method is annotated to be allowed be overridden to customize user-defined behavior.");
-			qualifier = "virtual";
-		} else if (qualifier == "virtual_annotated_underscored") {
-			hint = TTR("This method is annotated to be called by user-defined behavior.\nIt can be overridden to customize new behavior.");
-			qualifier = "virtual";
 		} else if (qualifier == "const") {
 			hint = TTR("This method has no side effects.\nIt does not modify the object in any way.");
 		} else if (qualifier == "static") {

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -785,7 +785,7 @@
 		<annotation name="@override">
 			<return type="void" />
 			<description>
-				Mark that the following method overrides the one annotated by [annotation @virtual] from the base class.
+				Mark that the following method overrides the one annotated by [annotation @virtual] or modified by [code]abstract[/code] from the base class.
 				If you override a method from the base class without this annotation, you will get a warning (or an error).
 				[codeblock]
 				func _init():
@@ -799,8 +799,15 @@
 				class B extends A:
 				    func test():
 				        print("B") # Warning (or an error) about overriding a virtual method without explicit overriding.
+
+				abstract class C:
+					abstract func test():
+
+				class D extends C:
+				    func test():
+				        print("D") # Warning (or an error) about overriding an abstract method without explicit overriding.
 				[/codeblock]
-				You can ignore the warning as long as you know what you are doing.
+				Due to that this annotation improves code readability, it is recommended to use it whenever possible. You can ignore the warning as long as you know what you are doing.
 			</description>
 		</annotation>
 		<annotation name="@rpc">
@@ -880,7 +887,7 @@
 				    func test():
 				        print("B") # Warning (or an error) about overriding a non-virtual method.
 				[/codeblock]
-				You can ignore the warning as long as you know what you are doing.
+				Due to that this annotation improves code readability, it is recommended to use it whenever possible. You can ignore the warning as long as you know what you are doing.
 			</description>
 		</annotation>
 		<annotation name="@warning_ignore" qualifiers="vararg">

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -782,6 +782,27 @@
 				[/codeblock]
 			</description>
 		</annotation>
+		<annotation name="@override">
+			<return type="void" />
+			<description>
+				Mark that the following method overrides the one annotated by [annotation @virtual] from the base class.
+				If you override a method from the base class without this annotation, you will get a warning (or an error).
+				[codeblock]
+				func _init():
+				    B.new().test() # Prints B
+
+
+				class A:
+				    @virtual func test():
+				        print("A")
+
+				class B extends A:
+				    func test():
+				        print("B") # Warning (or an error) about overriding a virtual method without explicit overriding.
+				[/codeblock]
+				You can ignore the warning as long as you know what you are doing.
+			</description>
+		</annotation>
 		<annotation name="@rpc">
 			<return type="void" />
 			<param index="0" name="mode" type="String" default="&quot;authority&quot;" />
@@ -825,6 +846,41 @@
 				extends Node
 				[/codeblock]
 				[b]Note:[/b] As annotations describe their subject, the [annotation @tool] annotation must be placed before the class definition and inheritance.
+			</description>
+		</annotation>
+		<annotation name="@virtual">
+			<return type="void" />
+			<description>
+				Mark a method as a virtual method. A virtual method is a method that can be overridden by subclasses.
+				To override a virtual method, it is better to use an [annotation @override] annotation for the method in the subclass.
+				[codeblock]
+				func _init():
+				    B.new().test() # Prints B.
+
+
+				class A:
+				    @virtual func test():
+				        print("A")
+
+				class B extends A:
+				    @override func test():
+				        print("B")
+				[/codeblock]
+				If a method is trying to override a non-virtual method, a warning (or an error) will be thrown.
+				[codeblock]
+				func _init():
+				    B.new().test() # Prints B
+
+
+				class A:
+				    func test():
+				        print("A")
+
+				class B extends A:
+				    func test():
+				        print("B") # Warning (or an error) about overriding a non-virtual method.
+				[/codeblock]
+				You can ignore the warning as long as you know what you are doing.
 			</description>
 		</annotation>
 		<annotation name="@warning_ignore" qualifiers="vararg">

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -425,6 +425,11 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 						method_doc.qualifiers += " ";
 					}
 					method_doc.qualifiers += "abstract";
+				} else if (m_func->is_annotated_virtual) {
+					if (!method_doc.qualifiers.is_empty()) {
+						method_doc.qualifiers += " ";
+					}
+					method_doc.qualifiers += String(m_func->identifier->name).begins_with("_") ? "virtual_annotated" : "virtual_annotated_underscored";
 				}
 				if (m_func->is_static) {
 					if (!method_doc.qualifiers.is_empty()) {

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -429,7 +429,7 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 					if (!method_doc.qualifiers.is_empty()) {
 						method_doc.qualifiers += " ";
 					}
-					method_doc.qualifiers += String(m_func->identifier->name).begins_with("_") ? "virtual_annotated" : "virtual_annotated_underscored";
+					method_doc.qualifiers += String(m_func->identifier->name).begins_with("_") ? "virtual_annotated_underscored" : "virtual_annotated";
 				}
 				if (m_func->is_static) {
 					if (!method_doc.qualifiers.is_empty()) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4420,7 +4420,10 @@ bool GDScriptParser::virtual_annotation(AnnotationNode *p_annotation, Node *p_ta
 	ERR_FAIL_COND_V_MSG(p_target->type == Node::LAMBDA, false, R"("@virtual" annotation cannot be applied to lambdas.)");
 
 	FunctionNode *method = static_cast<FunctionNode *>(p_target);
-	if (method->is_annotated_virtual) {
+	if (method->is_abstract) {
+		push_error(R"(The usage of "@virtual" annotation conflicts with the "abstract" keyword. Either remove the "@virtual" annotation or "abstract" keyword from the method's declaration.)", p_annotation);
+		return false;
+	} else if (method->is_annotated_virtual) {
 		push_error(R"("@virtual" annotation can only be used once per method.)", p_annotation);
 		return false;
 	}

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -857,6 +857,8 @@ public:
 		bool is_abstract = false;
 		bool is_static = false; // For lambdas it's determined in the analyzer.
 		bool is_coroutine = false;
+		bool is_annotated_virtual = false;
+		bool is_annotated_overriding = false;
 		Variant rpc_config;
 		MethodInfo info;
 		LambdaNode *source_lambda = nullptr;
@@ -1525,6 +1527,8 @@ private:
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool abstract_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool virtual_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool override_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_storage_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -162,6 +162,15 @@ String GDScriptWarning::get_message() const {
 			return vformat(R"*(The default value uses "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
 		case ONREADY_WITH_EXPORT:
 			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
+		case OVERRIDE_NON_VIRTUAL_METHOD:
+			CHECK_SYMBOLS(1);
+			return vformat(R"*(The method "%s()" overrides a non-virtual method from the base class. This may cause unexpected and unsafe behaviors.)*", symbols[0]);
+		case OVERRIDE_WITHOUT_OVERRIDE_ANNOTATION:
+			CHECK_SYMBOLS(1);
+			return vformat(R"*(The method "%s()" overrides a virtual method from the base class without the "@override" annotation. Annotating the method with the annotation can better help you understand and clarify the code structure.)*", symbols[0]);
+		case OVERRIDE_INEXISTENT_METHOD_FROM_BASE:
+			CHECK_SYMBOLS(1);
+			return vformat(R"*(The method "%s()" is annotated with the "@override" annotation, but the method is not found in the base class. Consider removing the "@override" annotation in this case.)*", symbols[0]);
 #ifndef DISABLE_DEPRECATED
 		// Never produced. These warnings migrated from 3.x by mistake.
 		case PROPERTY_USED_AS_FUNCTION: // There is already an error.
@@ -238,6 +247,9 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		PNAME("NATIVE_METHOD_OVERRIDE"),
 		PNAME("GET_NODE_DEFAULT_WITHOUT_ONREADY"),
 		PNAME("ONREADY_WITH_EXPORT"),
+		PNAME("OVERRIDE_NON_VIRTUAL_METHOD"),
+		PNAME("OVERRIDE_WITHOUT_OVERRIDE_ANNOTATION"),
+		PNAME("OVERRIDE_INEXISTENT_METHOD_FROM_BASE"),
 #ifndef DISABLE_DEPRECATED
 		"PROPERTY_USED_AS_FUNCTION",
 		"CONSTANT_USED_AS_FUNCTION",

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -167,7 +167,7 @@ String GDScriptWarning::get_message() const {
 			return vformat(R"*(The method "%s()" overrides a non-virtual method from the base class. This may cause unexpected and unsafe behaviors.)*", symbols[0]);
 		case OVERRIDE_WITHOUT_OVERRIDE_ANNOTATION:
 			CHECK_SYMBOLS(1);
-			return vformat(R"*(The method "%s()" overrides a virtual method from the base class without the "@override" annotation. Annotating the method with the annotation can better help you understand and clarify the code structure.)*", symbols[0]);
+			return vformat(R"*(The method "%s()" overrides a virtual or an abstract method from the base class without the "@override" annotation. Annotating the method with the annotation can better help you understand and clarify the code structure.)*", symbols[0]);
 		case OVERRIDE_INEXISTENT_METHOD_FROM_BASE:
 			CHECK_SYMBOLS(1);
 			return vformat(R"*(The method "%s()" is annotated with the "@override" annotation, but the method is not found in the base class. Consider removing the "@override" annotation in this case.)*", symbols[0]);

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -89,6 +89,9 @@ public:
 		NATIVE_METHOD_OVERRIDE, // The script method overrides a native one, this may not work as intended.
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
 		ONREADY_WITH_EXPORT, // The `@onready` annotation will set the value after `@export` which is likely not intended.
+		OVERRIDE_NON_VIRTUAL_METHOD, // The class method overrides a non-virtual one, which would cause potential problems.
+		OVERRIDE_WITHOUT_OVERRIDE_ANNOTATION, // The class method overrides a virtual one without the `@override` annotation.
+		OVERRIDE_INEXISTENT_METHOD_FROM_BASE, // The class method overrides a non-existent method from the base class.
 #ifndef DISABLE_DEPRECATED
 		PROPERTY_USED_AS_FUNCTION, // Function not found, but there's a property with the same name.
 		CONSTANT_USED_AS_FUNCTION, // Function not found, but there's a constant with the same name.
@@ -146,6 +149,9 @@ public:
 		ERROR, // NATIVE_METHOD_OVERRIDE // May not work as expected.
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.
 		ERROR, // ONREADY_WITH_EXPORT // May not work as expected.
+		WARN, // OVERRIDE_NON_VIRTUAL_METHOD
+		WARN, // OVERRIDE_WITHOUT_OVERRIDE_ANNOTATION
+		ERROR, // OVERRIDE_INEXISTENT_METHOD_FROM_BASE
 #ifndef DISABLE_DEPRECATED
 		WARN, // PROPERTY_USED_AS_FUNCTION
 		WARN, // CONSTANT_USED_AS_FUNCTION

--- a/modules/gdscript/tests/scripts/analyzer/features/external_inner_base.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/external_inner_base.gd
@@ -1,4 +1,4 @@
 extends "inner_base.gd".InnerA.InnerAB
 
-func test():
+@override func test():
 	super.test()

--- a/modules/gdscript/tests/scripts/analyzer/features/function_match_parent_signature_with_default_dict_void.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/function_match_parent_signature_with_default_dict_void.gd
@@ -6,9 +6,9 @@ func test():
 	print("No failure")
 
 class Parent:
-	func my_function(_par1: Dictionary = {}) -> void:
+	@virtual func my_function(_par1: Dictionary = {}) -> void:
 		pass
 
 class Child extends Parent:
-	func my_function(_par1: Dictionary = {}) -> void:
+	@override func my_function(_par1: Dictionary = {}) -> void:
 		pass

--- a/modules/gdscript/tests/scripts/analyzer/features/function_match_parent_signature_with_extra_parameters.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/function_match_parent_signature_with_extra_parameters.gd
@@ -9,9 +9,9 @@ func test():
 	Utils.check(result == 0)
 
 class Parent:
-	func my_function(par1: int) -> int:
+	@virtual func my_function(par1: int) -> int:
 		return par1
 
 class Child extends Parent:
-	func my_function(_par1: int, par2: int = 0) -> int:
+	@override func my_function(_par1: int, par2: int = 0) -> int:
 		return par2

--- a/modules/gdscript/tests/scripts/analyzer/features/function_param_type_contravariance.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/function_param_type_contravariance.gd
@@ -1,20 +1,20 @@
 class A:
-	func int_to_variant(_p: int): pass
-	func node_to_variant(_p: Node): pass
-	func node_2d_to_node(_p: Node2D): pass
+	@virtual func int_to_variant(_p: int): pass
+	@virtual func node_to_variant(_p: Node): pass
+	@virtual func node_2d_to_node(_p: Node2D): pass
 
-	func variant_to_untyped(_p: Variant): pass
-	func int_to_untyped(_p: int): pass
-	func node_to_untyped(_p: Node): pass
+	@virtual func variant_to_untyped(_p: Variant): pass
+	@virtual func int_to_untyped(_p: int): pass
+	@virtual func node_to_untyped(_p: Node): pass
 
 class B extends A:
-	func int_to_variant(_p: Variant): pass
-	func node_to_variant(_p: Variant): pass
-	func node_2d_to_node(_p: Node): pass
+	@override func int_to_variant(_p: Variant): pass
+	@override func node_to_variant(_p: Variant): pass
+	@override func node_2d_to_node(_p: Node): pass
 
-	func variant_to_untyped(_p): pass
-	func int_to_untyped(_p): pass
-	func node_to_untyped(_p): pass
+	@override func variant_to_untyped(_p): pass
+	@override func int_to_untyped(_p): pass
+	@override func node_to_untyped(_p): pass
 
 func test():
 	pass

--- a/modules/gdscript/tests/scripts/analyzer/features/function_return_type_covariance.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/function_return_type_covariance.gd
@@ -1,32 +1,32 @@
 class A:
-	func variant_to_int() -> Variant: return 0
-	func variant_to_node() -> Variant: return null
-	func node_to_node_2d() -> Node: return null
+	@virtual func variant_to_int() -> Variant: return 0
+	@virtual func variant_to_node() -> Variant: return null
+	@virtual func node_to_node_2d() -> Node: return null
 
-	func untyped_to_void(): pass
-	func untyped_to_variant(): pass
-	func untyped_to_int(): pass
-	func untyped_to_node(): pass
+	@virtual func untyped_to_void(): pass
+	@virtual func untyped_to_variant(): pass
+	@virtual func untyped_to_int(): pass
+	@virtual func untyped_to_node(): pass
 
-	func void_to_untyped() -> void: pass
-	func variant_to_untyped() -> Variant: return null
-	func int_to_untyped() -> int: return 0
-	func node_to_untyped() -> Node: return null
+	@virtual func void_to_untyped() -> void: pass
+	@virtual func variant_to_untyped() -> Variant: return null
+	@virtual func int_to_untyped() -> int: return 0
+	@virtual func node_to_untyped() -> Node: return null
 
 class B extends A:
-	func variant_to_int() -> int: return 0
-	func variant_to_node() -> Node: return null
-	func node_to_node_2d() -> Node2D: return null
+	@override func variant_to_int() -> int: return 0
+	@override func variant_to_node() -> Node: return null
+	@override func node_to_node_2d() -> Node2D: return null
 
-	func untyped_to_void() -> void: pass
-	func untyped_to_variant() -> Variant: return null
-	func untyped_to_int() -> int: return 0
-	func untyped_to_node() -> Node: return null
+	@override func untyped_to_void() -> void: pass
+	@override func untyped_to_variant() -> Variant: return null
+	@override func untyped_to_int() -> int: return 0
+	@override func untyped_to_node() -> Node: return null
 
-	func void_to_untyped(): pass
-	func variant_to_untyped(): pass
-	func int_to_untyped(): pass
-	func node_to_untyped(): pass
+	@override func void_to_untyped(): pass
+	@override func variant_to_untyped(): pass
+	@override func int_to_untyped(): pass
+	@override func node_to_untyped(): pass
 
 func test():
 	pass

--- a/modules/gdscript/tests/scripts/analyzer/features/global_enums.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/global_enums.gd
@@ -18,13 +18,13 @@ func test():
 	duper.set_direction(COUNTERCLOCKWISE)
 
 class Super:
-	func set_type(type: Variant.Type) -> void:
+	@virtual func set_type(type: Variant.Type) -> void:
 		print(type)
-	func set_direction(dir: ClockDirection) -> void:
+	@virtual func set_direction(dir: ClockDirection) -> void:
 		print(dir)
 
 class Duper extends Super:
-	func set_type(type: Variant.Type) -> void:
+	@override func set_type(type: Variant.Type) -> void:
 		print(type)
-	func set_direction(dir: ClockDirection) -> void:
+	@override func set_direction(dir: ClockDirection) -> void:
 		print(dir)

--- a/modules/gdscript/tests/scripts/analyzer/features/inner_base.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/inner_base.gd
@@ -1,18 +1,18 @@
 extends InnerA
 
-func test():
+@override func test():
 	super.test()
 
 class InnerA extends InnerAB:
-	func test():
+	@virtual @override func test():
 		print("InnerA.test")
 		super.test()
 
 	class InnerAB extends InnerB:
-		func test():
+		@virtual @override func test():
 			print("InnerA.InnerAB.test")
 			super.test()
 
 class InnerB:
-	func test():
+	@virtual func test():
 		print("InnerB.test")

--- a/modules/gdscript/tests/scripts/analyzer/features/lookup_signal.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/lookup_signal.gd
@@ -12,11 +12,11 @@ class A:
 	class B:
 		signal hello
 
-		func get_signal() -> Signal:
+		@virtual func get_signal() -> Signal:
 			return hello
 
 class C extends A.B:
-	func get_signal() -> Signal:
+	@override func get_signal() -> Signal:
 		return hello
 
 func test():

--- a/modules/gdscript/tests/scripts/analyzer/features/out_of_order.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/out_of_order.gd
@@ -17,11 +17,11 @@ func test():
 var v1 := InnerA.new().fn()
 
 class InnerA extends InnerAB:
-	func fn(p2 := E1.V2) -> String:
+	@override func fn(p2 := E1.V2) -> String:
 		return "%s, p2=%s" % [super.fn(), p2]
 
 	class InnerAB:
-		func fn(p1 := c1) -> String:
+		@virtual func fn(p1 := c1) -> String:
 			return "p1=%s" % p1
 
 var v2 := f()

--- a/modules/gdscript/tests/scripts/analyzer/features/out_of_order.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/out_of_order.out
@@ -1,5 +1,4 @@
 GDTEST_OK
-~~ WARNING at line 20: (OVERRIDE_NON_VIRTUAL_METHOD) The method "fn()" overrides a non-virtual method from the base class. This may cause unexpected and unsafe behaviors.
 v1: p1=4, p2=3
 v1 is String: true
 v2: true

--- a/modules/gdscript/tests/scripts/analyzer/features/out_of_order.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/out_of_order.out
@@ -1,4 +1,5 @@
 GDTEST_OK
+~~ WARNING at line 20: (OVERRIDE_NON_VIRTUAL_METHOD) The method "fn()" overrides a non-virtual method from the base class. This may cause unexpected and unsafe behaviors.
 v1: p1=4, p2=3
 v1 is String: true
 v2: true

--- a/modules/gdscript/tests/scripts/analyzer/features/out_of_order_external.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/out_of_order_external.gd
@@ -19,7 +19,7 @@ func test():
 var v1 := Inner.new().fn()
 
 class Inner extends B.Inner:
-	func fn(p2 := E1.V2) -> String:
+	@override func fn(p2 := E1.V2) -> String:
 		return "%s, p2=%s" % [super.fn(), p2]
 
 var v2 := B.new().f()

--- a/modules/gdscript/tests/scripts/analyzer/features/out_of_order_external_a.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/out_of_order_external_a.notest.gd
@@ -1,7 +1,7 @@
 const A = preload("out_of_order_external.gd")
 
 class Inner:
-	func fn(p1 := A.c1) -> String:
+	@virtual func fn(p1 := A.c1) -> String:
 		return "p1=%s" % p1
 
 func f(p := A.c1) -> bool:

--- a/modules/gdscript/tests/scripts/analyzer/features/virtual_method_implemented.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/virtual_method_implemented.gd
@@ -1,5 +1,5 @@
 class BaseClass:
-	func _get_property_list():
+	@virtual func _get_property_list():
 		return {"property" : "definition"}
 
 class SuperClassMethodsRecognized extends BaseClass:
@@ -8,7 +8,7 @@ class SuperClassMethodsRecognized extends BaseClass:
 		var _x = _get_property_list()
 
 class SuperMethodsRecognized extends BaseClass:
-	func _get_property_list():
+	@override func _get_property_list():
 		# Recognizes super method.
 		var result = super()
 		result["new"] = "new"

--- a/modules/gdscript/tests/scripts/analyzer/warnings/override_non_virtual_method.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/override_non_virtual_method.gd
@@ -1,0 +1,28 @@
+class Parent:
+    func test():
+        pass
+
+class ParentSafe:
+    @virtual func test():
+        pass
+
+class Child extends Parent:
+    func test():
+        pass
+
+class ChildSafe extends ParentSafe:
+    func test():
+        pass
+
+class ChildCompletelySafe extends ParentSafe:
+    @override func test():
+        pass
+
+
+class ChildOverrideInexistentMethod extends ParentSafe:
+    @override func test_():
+        pass
+
+
+func test():
+    pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/override_non_virtual_method.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/override_non_virtual_method.gd
@@ -23,9 +23,9 @@ class ChildOverrideInexistentMethod extends ParentSafe:
     @override func test_():
         pass
 
-abstract class AbstractParent:
-    abstract func test()
-    abstract func test2()
+@abstract class AbstractParent:
+    @abstract func test()
+    @abstract func test2()
 
 class ChildAbstract extends AbstractParent:
     func test():

--- a/modules/gdscript/tests/scripts/analyzer/warnings/override_non_virtual_method.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/override_non_virtual_method.gd
@@ -23,6 +23,17 @@ class ChildOverrideInexistentMethod extends ParentSafe:
     @override func test_():
         pass
 
+abstract class AbstractParent:
+    abstract func test()
+    abstract func test2()
+
+class ChildAbstract extends AbstractParent:
+    func test():
+        pass
+
+    @override func test2():
+        pass
+
 
 func test():
     pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/override_non_virtual_method.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/override_non_virtual_method.out
@@ -1,4 +1,5 @@
 GDTEST_OK
 ~~ WARNING at line 10: (OVERRIDE_NON_VIRTUAL_METHOD) The method "test()" overrides a non-virtual method from the base class. This may cause unexpected and unsafe behaviors.
-~~ WARNING at line 14: (OVERRIDE_WITHOUT_OVERRIDE_ANNOTATION) The method "test()" overrides a virtual method from the base class without the "@override" annotation. Annotating the method with the annotation can better help you understand and clarify the code structure.
+~~ WARNING at line 14: (OVERRIDE_WITHOUT_OVERRIDE_ANNOTATION) The method "test()" overrides a virtual or an abstract method from the base class without the "@override" annotation. Annotating the method with the annotation can better help you understand and clarify the code structure.
 ~~ WARNING at line 23: (OVERRIDE_INEXISTENT_METHOD_FROM_BASE) The method "test_()" is annotated with the "@override" annotation, but the method is not found in the base class. Consider removing the "@override" annotation in this case.
+~~ WARNING at line 31: (OVERRIDE_WITHOUT_OVERRIDE_ANNOTATION) The method "test()" overrides a virtual or an abstract method from the base class without the "@override" annotation. Annotating the method with the annotation can better help you understand and clarify the code structure.

--- a/modules/gdscript/tests/scripts/analyzer/warnings/override_non_virtual_method.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/override_non_virtual_method.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+~~ WARNING at line 10: (OVERRIDE_NON_VIRTUAL_METHOD) The method "test()" overrides a non-virtual method from the base class. This may cause unexpected and unsafe behaviors.
+~~ WARNING at line 14: (OVERRIDE_WITHOUT_OVERRIDE_ANNOTATION) The method "test()" overrides a virtual method from the base class without the "@override" annotation. Annotating the method with the annotation can better help you understand and clarify the code structure.
+~~ WARNING at line 23: (OVERRIDE_INEXISTENT_METHOD_FROM_BASE) The method "test_()" is annotated with the "@override" annotation, but the method is not found in the base class. Consider removing the "@override" annotation in this case.

--- a/modules/gdscript/tests/scripts/parser/features/super.gd
+++ b/modules/gdscript/tests/scripts/parser/features/super.gd
@@ -1,11 +1,11 @@
 class Say:
 	var prefix = "S"
 
-	func greet():
+	@virtual func greet():
 		prefix = "S Greeted"
 		print("hello")
 
-	func say(name):
+	@virtual func say(name):
 		print(prefix, " say something ", name)
 
 
@@ -13,11 +13,11 @@ class SayAnotherThing extends Say:
 	# This currently crashes the engine.
 	#var prefix = "SAT"
 
-	func greet():
+	@override func greet():
 		prefix = "SAT Greeted"
 		print("hi")
 
-	func say(name):
+	@override func say(name):
 		print(prefix, " say another thing ", name)
 
 
@@ -25,7 +25,7 @@ class SayNothing extends Say:
 	# This currently crashes the engine.
 	#var prefix = "SN"
 
-	func greet():
+	@override func greet():
 		super()
 		prefix = "SN Greeted"
 		print("howdy, see above")
@@ -35,7 +35,7 @@ class SayNothing extends Say:
 		super.greet()
 		print("howdy, see above")
 
-	func say(name):
+	@override func say(name):
 		@warning_ignore("unsafe_call_argument")
 		super(name + " super'd")
 		print(prefix, " say nothing... or not? ", name)

--- a/modules/gdscript/tests/scripts/runtime/features/abstract_methods.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/abstract_methods.gd
@@ -13,14 +13,14 @@
 		print(get_text_1())
 
 @abstract class B extends A:
-	func get_text_1() -> String:
+	@override func get_text_1() -> String:
 		return "text_1b"
 
 	func print_text_2() -> void:
 		print(get_text_2())
 
 class C extends B:
-	func get_text_2() -> String:
+	@virtual @override func get_text_2() -> String:
 		return "text_2c"
 
 	func func_with_param(param: int) -> int: return param
@@ -33,11 +33,11 @@ class C extends B:
 @abstract class D extends C:
 	@abstract func get_text_1() -> String
 
-	func get_text_2() -> String:
+	@override func get_text_2() -> String:
 		return super() + " text_2d"
 
 class E extends D:
-	func get_text_1() -> String:
+	@override func get_text_1() -> String:
 		return "text_1e"
 
 func test():

--- a/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.gd
@@ -5,8 +5,8 @@
 @abstract class A:
 	@abstract func test_abstract_func_1()
 	@abstract func test_abstract_func_2()
-	func test_override_func_1(): pass
-	func test_override_func_2(): pass
+	@virtual func test_override_func_1(): pass
+	@virtual func test_override_func_2(): pass
 
 class B extends A:
 	static var test_static_var_b1
@@ -15,10 +15,10 @@ class B extends A:
 	var test_var_b2
 	static func test_static_func_b1(): pass
 	static func test_static_func_b2(): pass
-	func test_abstract_func_1(): pass
-	func test_abstract_func_2(): pass
-	func test_override_func_1(): pass
-	func test_override_func_2(): pass
+	@virtual @override func test_abstract_func_1(): pass
+	@virtual @override func test_abstract_func_2(): pass
+	@virtual @override func test_override_func_1(): pass
+	@virtual @override func test_override_func_2(): pass
 	func test_func_b1(): pass
 	func test_func_b2(): pass
 	signal test_signal_b1()
@@ -31,10 +31,10 @@ class C extends B:
 	var test_var_c2
 	static func test_static_func_c1(): pass
 	static func test_static_func_c2(): pass
-	func test_abstract_func_1(): pass
-	func test_abstract_func_2(): pass
-	func test_override_func_1(): pass
-	func test_override_func_2(): pass
+	@override func test_abstract_func_1(): pass
+	@override func test_abstract_func_2(): pass
+	@override func test_override_func_1(): pass
+	@override func test_override_func_2(): pass
 	func test_func_c1(): pass
 	func test_func_c2(): pass
 	signal test_signal_c1()

--- a/modules/gdscript/tests/scripts/runtime/features/variadic_functions.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/variadic_functions.gd
@@ -1,17 +1,17 @@
 class A:
-	func f(x: int) -> void:
+	@virtual func f(x: int) -> void:
 		print(x)
 
 class B extends A:
-	func f(x: int, ...args: Array) -> void:
+	@virtual @override func f(x: int, ...args: Array) -> void:
 		prints(x, args)
 
 class C extends B:
-	func f(x: int, y: int = 0, ...args: Array) -> void:
+	@virtual @override func f(x: int, y: int = 0, ...args: Array) -> void:
 		prints(x, y, args)
 
 class D extends C:
-	func f(...args: Array) -> void:
+	@override func f(...args: Array) -> void:
 		print(args)
 
 func test_func(x: int, y: int = 0, ...args: Array) -> void:


### PR DESCRIPTION
Implements and closes https://github.com/godotengine/godot-proposals/issues/1631
Related PRs: #103768, #106409
See also: #93787 for other types of class members.

GDScript is a language where all methods are born with overridability, which brings confusion when it comes to user-defined `_`-prefixed methods (private methods). This pr implements an explicit way to mark a method, in GDScript, defined by user as a virtual method that can be overridden by subclasses. All old-fashioned overriding behaviors will be warned by the editor to maintain the compatibility with previous versions.

## Why not making it a key word?

Honestly, making it a key word sounds better than turning it into an annotation. However, being a key word means forced checking and forced error if you don't follow the rule, which greatly breaks compatibility with previous versions of Godot. To maintain the compatibility at the most extent, annotation doesn't sound a disaster for old scripts, so I selected making it an annotation instead of a key word with an error.

## Does it mean that we cannot directly override an method without this mark?
You can still do this, as long as you welcome warnings to live with you 😏 

## Is this conflict with PR #106409 that introduces `abstract` methods?
No, since you cannot annotate an abstract method as virtual because it is born to be overridden; while virtual methods are ones that are optional to be overridden, which means that you can also omit overriding the method in subclasses. **A virtual mark cannot be used for an abstract method.**

## Is there any difference between an abstract method and a virtual one?
An abstract method **must be overridden** in a subclass, with any kind of implementation inside the function body, while virtual methods (or we can say all custom methods defined in GDScript) are **optional** to be overridden in subclasses.

## Methods are all overridable already, so isn't this pointless?
No, this is not a pointless pr. As said before, this is a pr that helps make overriding a method explicit. Especially if you have checked #103768, you may realize that `_`-prefixed methods will be confusing when it comes to whether it is virtual+private or private only. This mark clarifies this and separate them apart from each other.

## Preview and demo
```GDScript
class A:
    func test():
        pass

class B extends A:
    func test(): # Warning: trying to override a non-virtual method, which will lead to unexpected behaviors.
        pass
```
If you mark `test()` as virtual
```GDScript
class A:
    @virtual func test():
        pass

class B extends A:
    @override func test(): # Safe without the warning.
        pass
```
Notice that you are also supposed to add `@override` to explicitly annotate that the method overrides the virtual base method. Otherwise, a warning will be thrown.

## Extra info about `@virtual` and `@override`

Both are **language modifiers**, belonging to the same category as `@abstract` (and `@final`) because they only modifies how engine treat the code instead of introducing (kinda-)revolutional updates like adding new syntactic elements. Recently, based on the discussion among most of members, modifiers should be treated as annotations.