### PR TITLE
Fix files modified outside Godot dialog exclusive window conflict

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5798,9 +5798,9 @@ void EditorNode::_cancel_close_scene_tab() {
 	}
 }
 
-void EditorNode::_prepare_save_confirmation_popup() {
-	if (save_confirmation->get_window() != get_last_exclusive_window()) {
-		save_confirmation->reparent(get_last_exclusive_window());
+void EditorNode::_prepare_confirmation_dialog(ConfirmationDialog *dialog) {
+	if (dialog->get_window() != get_last_exclusive_window()) {
+		dialog->reparent(get_last_exclusive_window());
 	}
 }
 
@@ -7814,7 +7814,7 @@ EditorNode::EditorNode() {
 	save_confirmation->connect(SceneStringName(confirmed), callable_mp(this, &EditorNode::_menu_confirm_current));
 	save_confirmation->connect("custom_action", callable_mp(this, &EditorNode::_discard_changes));
 	save_confirmation->connect("canceled", callable_mp(this, &EditorNode::_cancel_close_scene_tab));
-	save_confirmation->connect("about_to_popup", callable_mp(this, &EditorNode::_prepare_save_confirmation_popup));
+	save_confirmation->connect("about_to_popup", callable_mp(this, &EditorNode::_prepare_confirmation_dialog).bind(save_confirmation));
 
 	gradle_build_manage_templates = memnew(ConfirmationDialog);
 	gradle_build_manage_templates->set_text(TTR("Android build template is missing, please install relevant templates."));
@@ -7928,6 +7928,7 @@ EditorNode::EditorNode() {
 
 		disk_changed->add_button(TTR("Ignore external changes"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
 		disk_changed->connect("custom_action", callable_mp(this, &EditorNode::_resave_scenes));
+		disk_changed->connect("about_to_popup", callable_mp(this, &EditorNode::_prepare_confirmation_dialog).bind(disk_changed));
 	}
 
 	gui_base->add_child(disk_changed);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -575,7 +575,7 @@ private:
 	void _scene_tab_closed(int p_tab);
 	void _cancel_close_scene_tab();
 
-	void _prepare_save_confirmation_popup();
+	void _prepare_confirmation_dialog(ConfirmationDialog *dialog);
 
 	void _inherit_request(String p_file);
 	void _instantiate_request(const Vector<String> &p_files);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Similar issue and solution as: https://github.com/godotengine/godot/pull/102070

Fixes this error when this dialog pops up when another exclusive window such as the editor setting is open:

![image](https://github.com/user-attachments/assets/2e904090-e04b-4752-8423-c97c5b6fb337)


![image](https://github.com/user-attachments/assets/8e433765-bd2f-439d-948e-88d7e0f2eb4a)


