### PR TITLE
SCons: Simplify Windows/MSVC detection

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -553,7 +553,7 @@ def glob_recursive(pattern, node="."):
 
 
 def precious_program(env, program, sources, **args):
-    program = env.ProgramOriginal(program, sources, **args)
+    program = env.Program(program, sources, **args)
     env.Precious(program)
     return program
 


### PR DESCRIPTION
Drastically simplifies the MSVC detection logic by utilizing the recently added `get_tools`. This allows us to pre-check architecture and msvc version *before* the tools are setup, removing the need for redundant followup assignments & hacky workarounds caused by running the tool twice. This has the added bonus of letting us simplify the tools provided for msvc, needing only three: `msvc`, `mslink`, and `mslib`. It also entirely removes the legacy, manual setup via `VCINSTALLDIR`, as SCons has since progressed to a point that it automates that entire process for us regardless of the environment the build started in.