### PR TITLE
SCons: Remove `check_c_headers`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1156,15 +1156,6 @@ if env["vsproj"]:
     env["CPPPATH"] = [Dir(path) for path in env["CPPPATH"]]
     methods.generate_vs_project(env, ARGUMENTS, env["vsproj_name"])
 
-# Check for the existence of headers
-conf = Configure(env)
-if "check_c_headers" in env:
-    headers = env["check_c_headers"]
-    for header in headers:
-        if conf.CheckCHeader(header):
-            env.AppendUnique(CPPDEFINES=[headers[header]])
-conf.Finish()
-
 # Miscellaneous & post-build methods.
 if not env.GetOption("clean") and not env.GetOption("help"):
     methods.dump(env)

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -4,5 +4,3 @@ from misc.utility.scons_hints import *
 Import("env")
 
 env.add_source_files(env.drivers_sources, "*.cpp")
-
-env["check_c_headers"] = {"mntent.h": "HAVE_MNTENT"}

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -46,7 +46,7 @@
 #include <sys/stat.h>
 #include <sys/statvfs.h>
 
-#ifdef HAVE_MNTENT
+#if __has_include(<mntent.h>)
 #include <mntent.h>
 #endif
 
@@ -192,7 +192,7 @@ void DirAccessUnix::list_dir_end() {
 	_cisdir = false;
 }
 
-#if defined(HAVE_MNTENT) && defined(LINUXBSD_ENABLED)
+#if __has_include(<mntent.h>) && defined(LINUXBSD_ENABLED)
 static bool _filter_drive(struct mntent *mnt) {
 	// Ignore devices that don't point to /dev
 	if (strncmp(mnt->mnt_fsname, "/dev", 4) != 0) {
@@ -216,7 +216,7 @@ static void _get_drives(List<String> *list) {
 	// Add root.
 	list->push_back("/");
 
-#if defined(HAVE_MNTENT) && defined(LINUXBSD_ENABLED)
+#if __has_include(<mntent.h>) && defined(LINUXBSD_ENABLED)
 	// Check /etc/mtab for the list of mounted partitions.
 	FILE *mtab = setmntent("/etc/mtab", "r");
 	if (mtab) {

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -76,7 +76,7 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 
-#ifdef HAVE_MNTENT
+#if __has_include(<mntent.h>)
 #include <mntent.h>
 #endif
 
@@ -999,7 +999,7 @@ static String get_mountpoint(const String &p_path) {
 		return "";
 	}
 
-#ifdef HAVE_MNTENT
+#if __has_include(<mntent.h>)
 	dev_t dev = s.st_dev;
 	FILE *fd = setmntent("/proc/mounts", "r");
 	if (!fd) {


### PR DESCRIPTION
Attempting a dry run of our buildsystem currently fails, as the `check_c_headers` evaluation requires writing to files. This can be entirely circumvented by taking advantage of `__has_include`[^1], a C++17 feature which achieves the same results natively. This PR implements those changes, and deprecates the `check_c_headers` evaluation explicitly.

[^1]: https://en.cppreference.com/w/cpp/preprocessor/include
