### PR TITLE
Clarify units for reverb HPF

### DIFF
--- a/doc/classes/AudioEffectReverb.xml
+++ b/doc/classes/AudioEffectReverb.xml
@@ -17,8 +17,11 @@
 		<member name="dry" type="float" setter="set_dry" getter="get_dry" default="1.0">
 			Output percent of original sound. At 0, only modified sound is outputted. Value can range from 0 to 1.
 		</member>
-		<member name="hipass" type="float" setter="set_hpf" getter="get_hpf" default="0.0">
+		<member name="hipass" type="float" setter="set_hpf" getter="get_hpf" default="0.0" deprecated="Use [member hipass_hz] instead.">
 			High-pass filter passes signals with a frequency higher than a certain cutoff frequency and attenuates signals with frequencies lower than the cutoff frequency. Value can range from 0 to 1.
+		</member>
+		<member name="hipass_hz" type="float" setter="set_hpf_hz" getter="get_hpf_hz" default="0.0">
+			High-pass filter passes signals with a frequency higher than a certain cutoff frequency and attenuates signals with frequencies lower than the cutoff frequency. Value can range from 0 to 6000.
 		</member>
 		<member name="predelay_feedback" type="float" setter="set_predelay_feedback" getter="get_predelay_feedback" default="0.4">
 			Output percent of predelay. Value can range from 0 to 1.

--- a/servers/audio/effects/audio_effect_reverb.cpp
+++ b/servers/audio/effects/audio_effect_reverb.cpp
@@ -114,8 +114,12 @@ void AudioEffectReverb::set_wet(float p_wet) {
 	wet = p_wet;
 }
 
+void AudioEffectReverb::set_hpf_hz(float p_hpf_hz) {
+	hpf = p_hpf_hz;
+}
+
 void AudioEffectReverb::set_hpf(float p_hpf) {
-	hpf = p_hpf;
+	hpf = p_hpf * 6000;
 }
 
 float AudioEffectReverb::get_predelay_msec() const {
@@ -146,8 +150,12 @@ float AudioEffectReverb::get_wet() const {
 	return wet;
 }
 
-float AudioEffectReverb::get_hpf() const {
+float AudioEffectReverb::get_hpf_hz() const {
 	return hpf;
+}
+
+float AudioEffectReverb::get_hpf() const {
+	return hpf / 6000;
 }
 
 void AudioEffectReverb::_bind_methods() {
@@ -172,8 +180,13 @@ void AudioEffectReverb::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_wet", "amount"), &AudioEffectReverb::set_wet);
 	ClassDB::bind_method(D_METHOD("get_wet"), &AudioEffectReverb::get_wet);
 
+	ClassDB::bind_method(D_METHOD("set_hpf_hz", "amount"), &AudioEffectReverb::set_hpf_hz);
+	ClassDB::bind_method(D_METHOD("get_hpf_hz"), &AudioEffectReverb::get_hpf_hz);
+
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_hpf", "amount"), &AudioEffectReverb::set_hpf);
 	ClassDB::bind_method(D_METHOD("get_hpf"), &AudioEffectReverb::get_hpf);
+#endif // DISABLE_DEPRECATED
 
 	ADD_GROUP("Predelay", "predelay_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "predelay_msec", PROPERTY_HINT_RANGE, "20,500,1,suffix:ms"), "set_predelay_msec", "get_predelay_msec");
@@ -182,7 +195,10 @@ void AudioEffectReverb::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "room_size", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_room_size", "get_room_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "damping", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_damping", "get_damping");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "spread", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_spread", "get_spread");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "hipass", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_hpf", "get_hpf");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "hipass_hz", PROPERTY_HINT_RANGE, "0,6000,1,suffix:Hz"), "set_hpf_hz", "get_hpf_hz");
+#ifndef DISABLE_DEPRECATED
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "hipass", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_hpf", "get_hpf");
+#endif // DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dry", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_dry", "get_dry");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "wet", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_wet", "get_wet");
 }

--- a/servers/audio/effects/audio_effect_reverb.h
+++ b/servers/audio/effects/audio_effect_reverb.h
@@ -78,6 +78,7 @@ public:
 	void set_spread(float p_spread);
 	void set_dry(float p_dry);
 	void set_wet(float p_wet);
+	void set_hpf_hz(float p_hpf_hz);
 	void set_hpf(float p_hpf);
 
 	float get_predelay_msec() const;
@@ -87,6 +88,7 @@ public:
 	float get_spread() const;
 	float get_dry() const;
 	float get_wet() const;
+	float get_hpf_hz() const;
 	float get_hpf() const;
 
 	Ref<AudioEffectInstance> instantiate() override;

--- a/servers/audio/effects/reverb_filter.cpp
+++ b/servers/audio/effects/reverb_filter.cpp
@@ -90,7 +90,7 @@ void Reverb::process(float *p_src, float *p_dst, int p_frames) {
 	}
 
 	if (params.hpf > 0) {
-		float hpaux = expf(-Math_TAU * params.hpf * 6000 / params.mix_rate);
+		float hpaux = expf(-Math_TAU * params.hpf / params.mix_rate);
 		float hp_a1 = (1.0 + hpaux) / 2.0;
 		float hp_a2 = -(1.0 + hpaux) / 2.0;
 		float hp_b1 = hpaux;
@@ -204,8 +204,8 @@ void Reverb::set_predelay_feedback(float p_predelay_fb) {
 }
 
 void Reverb::set_highpass(float p_frq) {
-	if (p_frq > 1) {
-		p_frq = 1;
+	if (p_frq > 6000) {
+		p_frq = 6000;
 	}
 	if (p_frq < 0) {
 		p_frq = 0;


### PR DESCRIPTION
Switches the hi-pass parameter on `AudioEffectReverb` to directly use Hz, instead of an arbitrary 0.0-1.0 range.