### PR TITLE
Correctly register editor-only `OpenXR*` classes' `api_type`

### DIFF
--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -225,9 +225,15 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 		}
 
 #ifdef TOOLS_ENABLED
+		// Register as "editor", not "core".
+		ClassDB::APIType prev_api = ClassDB::get_current_api();
+		ClassDB::set_current_api(ClassDB::API_EDITOR);
+
 		GDREGISTER_ABSTRACT_CLASS(OpenXRInteractionProfileEditorBase);
 		GDREGISTER_CLASS(OpenXRInteractionProfileEditor);
 		GDREGISTER_CLASS(OpenXRBindingModifierEditor);
+
+		ClassDB::set_current_api(prev_api);
 
 		EditorNode::add_init_callback(_editor_init);
 #endif


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/103867, by registering the three following classes with `api_type = "editor"` instead of `"core"`:

- `OpenXRInteractionProfileEditorBase`
- `OpenXRBindingModifierEditor`
- `OpenXRInteractionProfileEditor`

Follows the same approach as https://github.com/godotengine/godot/pull/86209.