### PR TITLE
Allow opening a project in verbose mode from the Project Manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -263,7 +263,8 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 			erase_missing_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
 
 			open_btn_container->add_theme_constant_override("separation", 0);
-			open_options_popup->set_item_icon(0, get_editor_theme_icon(SNAME("NodeWarning")));
+			open_options_popup->set_item_icon(0, get_editor_theme_icon(SNAME("Notification")));
+			open_options_popup->set_item_icon(1, get_editor_theme_icon(SNAME("NodeWarning")));
 		}
 
 		// Asset library popup.
@@ -500,6 +501,10 @@ void ProjectManager::_open_selected_projects() {
 			args.push_back("--recovery-mode");
 		}
 
+		if (open_in_verbose_mode) {
+			args.push_back("--verbose");
+		}
+
 		Error err = OS::get_singleton()->create_instance(args);
 		if (err != OK) {
 			loading_label->hide();
@@ -616,6 +621,7 @@ void ProjectManager::_open_selected_projects_check_recovery_mode() {
 		return;
 	}
 
+	open_in_verbose_mode = false;
 	open_in_recovery_mode = false;
 	// Check if the project failed to load during last startup.
 	if (project.recovery_mode) {
@@ -773,7 +779,11 @@ void ProjectManager::_on_projects_updated() {
 
 void ProjectManager::_on_open_options_selected(int p_option) {
 	switch (p_option) {
-		case 0: // Edit in recovery mode.
+		case 0: // Edit in verbose mode.
+			open_in_verbose_mode = true;
+			_open_selected_projects_check_warnings();
+			break;
+		case 1: // Edit in recovery mode.
 			_open_recovery_mode_ask(true);
 			break;
 	}
@@ -1477,7 +1487,8 @@ ProjectManager::ProjectManager() {
 			open_btn_container->add_child(open_options_btn);
 
 			open_options_popup = memnew(PopupMenu);
-			open_options_popup->add_item(TTR("Edit in recovery mode"));
+			open_options_popup->add_item(TTRC("Edit in verbose mode"));
+			open_options_popup->add_item(TTRC("Edit in recovery mode"));
 			open_options_popup->connect(SceneStringName(id_pressed), callable_mp(this, &ProjectManager::_on_open_options_selected));
 			open_options_btn->add_child(open_options_popup);
 

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -230,6 +230,7 @@ class ProjectManager : public Control {
 
 	String version_convert_feature;
 	bool open_in_recovery_mode = false;
+	bool open_in_verbose_mode = false;
 
 #ifndef DISABLE_DEPRECATED
 	void _minor_project_migrate();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11956.

**NOTE:** The description below is outdated. In its current state, this PR simply adds another item to the dropdown menu next to the Project Manager's "Edit" button for "Edit in verbose mode". The ability to hold the <kbd>Alt</kbd> key in order to activate verbose mode has been removed.

---

This PR adds the ability to open projects in verbose mode from the Project Manager. By holding down the Alt/Option key, the "Edit" and "Run" buttons become "Edit (Verbose)" and "Run (Verbose)". Clicking them while holding Alt/Option passes the `--verbose` flag to the Godot process that the Project Manager runs.

https://github.com/user-attachments/assets/c954b71b-b293-4845-a551-9f7b8748e56f

## Issues
- As can be seen in the video above, adding "(Verbose)" to the button labels causes the right-hand panel to change its width. This doesn't look very good to me, so I'd like to see if there's a way to keep the width consistent.
- If the user holds Alt/Option, then selects "Edit in recovery mode", the Project Manager loses track of the Alt/Option key's state. When they click "Cancel" from the recovery mode confirmation window, the Project Manager still thinks that Alt/Option is being held down, and doesn't return to regular "Edit" and "Run" buttons until the user presses and lets go of Alt/Option again.