### PR TITLE
Fix GLES3 `gaussian_blur` mipmap setup.

### DIFF
--- a/drivers/gles3/effects/copy_effects.cpp
+++ b/drivers/gles3/effects/copy_effects.cpp
@@ -243,7 +243,7 @@ void CopyEffects::gaussian_blur(GLuint p_source_texture, int p_mipmap_count, con
 
 		glBindTexture(GL_TEXTURE_2D, p_source_texture);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, i - 1);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, i - 1);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, i);
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, p_source_texture, i);
 #ifdef DEV_ENABLED
 		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/91717

Extend max level to include `i` for writing and so fb is complete and avoid resulting errors like:
"Framebuffer is incomplete: Attachment level is not in the [base level, max level] range".

~~Removed redundant glBindTexture and moved mipmap level config outside of loop. Main bug was that base and max were set to 'i-1' but glFramebufferTexture2D used 'i' resulting in errors like: "Framebuffer is incomplete: Attachment level is not in the [base level, max level] range".~~

Tested with `--display-driver windows --rendering-driver opengl3_angle` and web build.