### PR TITLE
Fix missing alpha input for visual shaders

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -3149,6 +3149,7 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::ports[] = {
 
 	// Node3D, Light
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_3D, "albedo", "ALBEDO" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "ALPHA" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_SCALAR, "attenuation", "ATTENUATION" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_3D, "backlight", "BACKLIGHT" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_SCALAR, "clip_space_far", "CLIP_SPACE_FAR" },


### PR DESCRIPTION
Easy 1 line fix https://github.com/godotengine/godot/issues/103885

This allows us to use the alpha channel as an accumulator across lighting passes for any given pixel when overriding the lighting function in the visual shader editor. Without this, the last light to run for a pixel can only overwrite the alpha completely.

As a demonstration this is the "Shadow to Opacity" recreated with this change [(for reference)](https://github.com/godotengine/godot/blob/4.0/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl#L235).

![godot windows editor dev x86_64_toCxXWojmA](https://github.com/user-attachments/assets/e3a93e62-794b-42a0-a68e-6ddd28885e70)
