### PR TITLE
Fix BBCode tag for NativeMenu class reference

### DIFF
--- a/doc/classes/NativeMenu.xml
+++ b/doc/classes/NativeMenu.xml
@@ -374,7 +374,7 @@
 			<param index="0" name="rid" type="RID" />
 			<description>
 				Returns global menu open callback.
-				b]Note:[/b] This method is implemented only on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="get_size" qualifiers="const">


### PR DESCRIPTION
Also searched the codebase with `rg '^[^\[]+\]' -t xml`. This seems to be the only one.