### PR TITLE
Add project setting to disable printing of shader contents on error

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -652,6 +652,10 @@
 		<member name="debug/settings/stdout/verbose_stdout" type="bool" setter="" getter="" default="false">
 			Print more information to standard output when running. It displays information such as memory leaks, which scenes and resources are being loaded, etc. This can also be enabled using the [code]--verbose[/code] or [code]-v[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url], even on an exported project. See also [method OS.is_stdout_verbose] and [method @GlobalScope.print_verbose].
 		</member>
+		<member name="debug/shader_language/errors/output_shader_contents_on_error" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the contents of shader files containing invalid code will be printed to standard output.
+			[b]Warning:[/b] Enabling this setting can cause the editor to stall for a long time while editing shader include files. This is due to the contents of the including files being printed alongside the contents of the included files. Nesting includes further multiplies the output.
+		</member>
 		<member name="debug/shader_language/warnings/device_limit_exceeded" type="bool" setter="" getter="" default="true">
 			When set to [code]true[/code], produces a warning when the shader exceeds certain device limits. Currently, the only device limit checked is the limit on uniform buffer size. More device limits will be added in the future.
 		</member>

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -30,6 +30,7 @@
 
 #include "shader_compiler.h"
 
+#include "core/config/project_settings.h"
 #include "servers/rendering/rendering_server_globals.h"
 #include "servers/rendering/shader_types.h"
 
@@ -1472,59 +1473,63 @@ Error ShaderCompiler::compile(RS::ShaderMode p_mode, const String &p_code, Ident
 	if (err != OK) {
 		Vector<ShaderLanguage::FilePosition> include_positions = parser.get_include_positions();
 
-		String current;
-		HashMap<String, Vector<String>> includes;
-		includes[""] = Vector<String>();
-		Vector<String> include_stack;
-		Vector<String> shader_lines = p_code.split("\n");
+		bool should_print_contents = GLOBAL_GET("debug/shader_language/errors/output_shader_contents_on_error");
 
-		// Reconstruct the files.
-		for (int i = 0; i < shader_lines.size(); i++) {
-			String l = shader_lines[i];
-			if (l.begins_with("@@>")) {
-				String inc_path = l.replace_first("@@>", "");
+		if (should_print_contents) {
+			String current;
+			HashMap<String, Vector<String>> includes;
+			includes[""] = Vector<String>();
+			Vector<String> include_stack;
+			Vector<String> shader_lines = p_code.split("\n");
 
-				l = "#include \"" + inc_path + "\"";
-				includes[current].append("#include \"" + inc_path + "\""); // Restore the include directive
-				include_stack.push_back(current);
-				current = inc_path;
-				includes[inc_path] = Vector<String>();
+			// Reconstruct the files.
+			for (int i = 0; i < shader_lines.size(); i++) {
+				String l = shader_lines[i];
+				if (l.begins_with("@@>")) {
+					String inc_path = l.replace_first("@@>", "");
 
-			} else if (l.begins_with("@@<")) {
-				if (include_stack.size()) {
-					current = include_stack[include_stack.size() - 1];
-					include_stack.resize(include_stack.size() - 1);
-				}
-			} else {
-				includes[current].push_back(l);
-			}
-		}
+					l = "#include \"" + inc_path + "\"";
+					includes[current].append("#include \"" + inc_path + "\""); // Restore the include directive
+					include_stack.push_back(current);
+					current = inc_path;
+					includes[inc_path] = Vector<String>();
 
-		// Print the files.
-		for (const KeyValue<String, Vector<String>> &E : includes) {
-			if (E.key.is_empty()) {
-				if (p_path == "") {
-					print_line("--Main Shader--");
+				} else if (l.begins_with("@@<")) {
+					if (include_stack.size()) {
+						current = include_stack[include_stack.size() - 1];
+						include_stack.resize(include_stack.size() - 1);
+					}
 				} else {
-					print_line("--" + p_path + "--");
-				}
-			} else {
-				print_line("--" + E.key + "--");
-			}
-			int err_line = -1;
-			for (int i = 0; i < include_positions.size(); i++) {
-				if (include_positions[i].file == E.key) {
-					err_line = include_positions[i].line;
+					includes[current].push_back(l);
 				}
 			}
-			const Vector<String> &V = E.value;
-			for (int i = 0; i < V.size(); i++) {
-				if (i == err_line - 1) {
-					// Mark the error line to be visible without having to look at
-					// the trace at the end.
-					print_line(vformat("E%4d-> %s", i + 1, V[i]));
+
+			// Print the files.
+			for (const KeyValue<String, Vector<String>> &E : includes) {
+				if (E.key.is_empty()) {
+					if (p_path == "") {
+						print_line("--Main Shader--");
+					} else {
+						print_line("--" + p_path + "--");
+					}
 				} else {
-					print_line(vformat("%5d | %s", i + 1, V[i]));
+					print_line("--" + E.key + "--");
+				}
+				int err_line = -1;
+				for (int i = 0; i < include_positions.size(); i++) {
+					if (include_positions[i].file == E.key) {
+						err_line = include_positions[i].line;
+					}
+				}
+				const Vector<String> &V = E.value;
+				for (int i = 0; i < V.size(); i++) {
+					if (i == err_line - 1) {
+						// Mark the error line to be visible without having to look at
+						// the trace at the end.
+						print_line(vformat("E%4d-> %s", i + 1, V[i]));
+					} else {
+						print_line(vformat("%5d | %s", i + 1, V[i]));
+					}
 				}
 			}
 		}

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3735,6 +3735,8 @@ void RenderingServer::init() {
 
 	GLOBAL_DEF_RST_BASIC("xr/shaders/enabled", false);
 
+	GLOBAL_DEF("debug/shader_language/errors/output_shader_contents_on_error", false);
+
 	GLOBAL_DEF("debug/shader_language/warnings/enable", true);
 	GLOBAL_DEF("debug/shader_language/warnings/treat_warnings_as_errors", false);
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/103109

Adds a new advanced project setting: `debug/shader_language/errors/output_shader_contents_on_error`. This neatly joins the `debug/shader_language/warnings` family of advanced project settings.

The setting is `false` by default, because any project making use of shader include files is likely to have serious performance issues with it enabled. And, the error messages (which this PR leaves alone) are already enough to locate problems without the extreme console spam.

Implementing it as a project setting, rather than an editor setting, respects the engine's ideal dependency chain. See the following for details:

- https://github.com/godotengine/godot/issues/53295
- https://github.com/godotengine/godot/issues/29730

The files changed may look a bit messy, but it's mostly just indentation due to the new `should_print_contents` condition wrapping a block of otherwise unchanged code.