### PR TITLE
Use idiomatic templating vargs in a few places to reduce code.

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -542,13 +542,8 @@ public:
 
 #ifdef DEBUG_ENABLED
 
-template <typename... P>
-_FORCE_INLINE_ Vector<Error> errarray(P... p_args) {
-	return Vector<Error>({ p_args... });
-}
-
 #define BIND_METHOD_ERR_RETURN_DOC(m_method, ...) \
-	::ClassDB::set_method_error_return_values(get_class_static(), m_method, errarray(__VA_ARGS__));
+	::ClassDB::set_method_error_return_values(get_class_static(), m_method, Vector<Error>{ __VA_ARGS__ });
 
 #else
 

--- a/servers/rendering/renderer_rd/framebuffer_cache_rd.h
+++ b/servers/rendering/renderer_rd/framebuffer_cache_rd.h
@@ -137,16 +137,6 @@ class FramebufferCacheRD : public Object {
 		return _compare_args(idx + 1, textures, args...);
 	}
 
-	_FORCE_INLINE_ void _create_args(Vector<RID> &textures, const RID &arg) {
-		textures.push_back(arg);
-	}
-
-	template <typename... Args>
-	_FORCE_INLINE_ void _create_args(Vector<RID> &textures, const RID &arg, Args... args) {
-		textures.push_back(arg);
-		_create_args(textures, args...);
-	}
-
 	static FramebufferCacheRD *singleton;
 
 	uint32_t cache_instances_used = 0;
@@ -216,10 +206,7 @@ public:
 
 		// Not in cache, create:
 
-		Vector<RID> textures;
-		_create_args(textures, args...);
-
-		return _allocate_from_data(1, h, table_idx, textures, Vector<RD::FramebufferPass>());
+		return _allocate_from_data(1, h, table_idx, Vector<RID>{ args... }, Vector<RD::FramebufferPass>());
 	}
 
 	template <typename... Args>
@@ -244,10 +231,7 @@ public:
 
 		// Not in cache, create:
 
-		Vector<RID> textures;
-		_create_args(textures, args...);
-
-		return _allocate_from_data(p_views, h, table_idx, textures, Vector<RD::FramebufferPass>());
+		return _allocate_from_data(p_views, h, table_idx, Vector<RID>{ args... }, Vector<RD::FramebufferPass>());
 	}
 
 	RID get_cache_multipass(const Vector<RID> &p_textures, const Vector<RD::FramebufferPass> &p_passes, uint32_t p_views = 1) {

--- a/servers/rendering/renderer_rd/uniform_set_cache_rd.h
+++ b/servers/rendering/renderer_rd/uniform_set_cache_rd.h
@@ -107,16 +107,6 @@ class UniformSetCacheRD : public Object {
 		return _compare_args(idx + 1, uniforms, args...);
 	}
 
-	_FORCE_INLINE_ void _create_args(Vector<RD::Uniform> &uniforms, const RD::Uniform &arg) {
-		uniforms.push_back(arg);
-	}
-
-	template <typename... Args>
-	_FORCE_INLINE_ void _create_args(Vector<RD::Uniform> &uniforms, const RD::Uniform &arg, Args... args) {
-		uniforms.push_back(arg);
-		_create_args(uniforms, args...);
-	}
-
 	static UniformSetCacheRD *singleton;
 
 	uint32_t cache_instances_used = 0;
@@ -176,10 +166,7 @@ public:
 
 		// Not in cache, create:
 
-		Vector<RD::Uniform> uniforms;
-		_create_args(uniforms, args...);
-
-		return _allocate_from_uniforms(p_shader, p_set, h, table_idx, uniforms);
+		return _allocate_from_uniforms(p_shader, p_set, h, table_idx, Vector<RD::Uniform>{ args... });
 	}
 
 	template <typename... Args>


### PR DESCRIPTION
Just a small code style thing.
There are some more of these (`build_array` in test cases), but they could be better addressed once `Array` has a varargs constructor.

There is also `stringify_variants`, but that intersperses spaces so I didn't have an immediate idea for how to concatenate.