### PR TITLE
Reset button state when button is disabled

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -213,6 +213,7 @@ void BaseButton::set_disabled(bool p_disabled) {
 		}
 		status.press_attempt = false;
 		status.pressing_inside = false;
+		status.pressed_down_with_focus = false;
 	}
 	queue_redraw();
 	update_minimum_size();


### PR DESCRIPTION
This PR changes how button down/up signals work when button gets temporarily disabled.

My problem is that I have a UI where player presses a button to assign bonus points to player's attributes and I'm using the `button_down` signal instead of `pressed` signal (that's a design choice). When there are no more points to assign, the button is disabled. After a while the button is enabled again. Now the bug happens, button doesn't send `button_down` signal with the first click. I need to click the button twice to get a `button_down` signal. 

Currently button works like this:

![kuva](https://github.com/user-attachments/assets/6a38328a-d497-4890-a133-574e7e48267c)

This PR resets button's `pressed_down_with_focus` value to `false` when button is disabled. Now things work like this:

![kuva](https://github.com/user-attachments/assets/15fee070-b9f6-4b0f-b9a9-f88b1e2ef2da)

However, It could be argued that this can break some existing applications. In cases where the button is temporarily disabled, it is currently possible to keep the mouse button pressed and when the button is enabled again, release the mouse button and get the `button_up` signal.

![kuva](https://github.com/user-attachments/assets/71cbbf80-9f11-4ddc-9d82-d6fc05d1fe5e)

After this PR, you don't get the button_up signal in these cases:

![kuva](https://github.com/user-attachments/assets/702820e3-56c9-4f78-a981-9160b8991da6)

This first button in the following test application can be used to test my initial use case. Clicking the button disables the button for 2 seconds. After the button is enabled again, you need to click the button twice to get a `button_down` signal. This PR fixes that so now every mouse button click counts, as expected.

[button_signal_test.zip](https://github.com/user-attachments/files/19162817/button_signal_test.zip)

(This PR _might_ be related to issue https://github.com/godotengine/godot/issues/98491, but I couldn't reproduce that issue with v4.4.stable.mono.official [4c311cbee].)