### PR TITLE
Tweak the fallback 3D material's appearance

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This class serves as a default material with a wide variety of rendering features and properties without the need to write shader code. See the tutorial below for details.
+		[b]Fallback material:[/b] Meshes which don't have any material assigned will use a [i]fallback material[/i]. This material uses an [member albedo_color] set to [code]Color(0.5, 0.5, 0.5)[/code] and [member roughness] set to [code]0.5[/code]. All other parameters are identical to the defaults here. In contrast, newly created [BaseMaterial3D]s will use an [member albedo_color] of [code]Color(1.0, 1.0, 1.0)[/code] and [member roughness] of [code]1.0[/code], so they will appear brighter and less reflective.
 	</description>
 	<tutorials>
 		<link title="Standard Material 3D and ORM Material 3D">$DOCS_URL/tutorials/3d/standard_material_3d.html</link>

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4245,13 +4245,13 @@ RasterizerSceneGLES3::RasterizerSceneGLES3() {
 shader_type spatial;
 
 void vertex() {
-	ROUGHNESS = 0.8;
+	ROUGHNESS = 0.5;
 }
 
 void fragment() {
-	ALBEDO = vec3(0.6);
-	ROUGHNESS = 0.8;
-	METALLIC = 0.2;
+	ALBEDO = vec3(0.5);
+	ROUGHNESS = 0.5;
+	METALLIC = 0.0;
 }
 )");
 		scene_globals.default_material = material_storage->material_allocate();

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -790,13 +790,13 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 shader_type spatial;
 
 void vertex() {
-	ROUGHNESS = 0.8;
+	ROUGHNESS = 0.5;
 }
 
 void fragment() {
-	ALBEDO = vec3(0.6);
-	ROUGHNESS = 0.8;
-	METALLIC = 0.2;
+	ALBEDO = vec3(0.5);
+	ROUGHNESS = 0.5;
+	METALLIC = 0.0;
 }
 )");
 		default_material = material_storage->material_allocate();

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -724,13 +724,13 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 shader_type spatial;
 
 void vertex() {
-	ROUGHNESS = 0.8;
+	ROUGHNESS = 0.5;
 }
 
 void fragment() {
-	ALBEDO = vec3(0.6);
-	ROUGHNESS = 0.8;
-	METALLIC = 0.2;
+	ALBEDO = vec3(0.5);
+	ROUGHNESS = 0.5;
+	METALLIC = 0.0;
 }
 )");
 		default_material = material_storage->material_allocate();


### PR DESCRIPTION
Replaces #62756

### **Description**
- Decrease roughness from 0.8 to 0.5 to match Blender's default.
- Decrease metallic from 0.2 to 0.0.
  - In real life, materials are either fully dielectric or fully metallic.
- Darken albedo from `Color(0.6, 0.6, 0.6)` to `Color(0.5, 0.5, 0.5)`.
  - This compensates for the roughness/metallic change, but also makes the fallback material a tad darker overall. It now better corresponds to materials that are typically used in scenes, leading to a more accurate lighting preview (especially when the Debug Lighting draw mode is used).