### PR TITLE
VideoStreamPlayer: Redraw when stream resolution changes

### DIFF
--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -51,6 +51,8 @@ class VideoStreamPlayer : public Control {
 	RID stream_rid;
 
 	Ref<Texture2D> texture;
+	Size2 texture_size;
+	void texture_changed(const Ref<Texture2D> &p_texture);
 
 	AudioRBResampler resampler;
 	Vector<AudioFrame> mix_buffer;


### PR DESCRIPTION
Currently, if the VideoStreamPlayback instance changes the texture's size after playback has begun, VideoStreamPlayer does not redraw or call `Control::update_minimum_size`, causing the texture to be shown stretched to it's original size.

This PR makes the VideoStreamPlayer connect to the texture's `changed` signal, keeps track of its size and calls `CanvasItem::queue_redraw` and `update_minimum_size` if it changed.

Since VideoStreaTheora doesn't change its resolution dynamically, I've created a small GDExtension for you to test my changes. You can download a MRP with this GDExtension installed [here](https://github.com/unvermuthet/dynamic-video-stream/releases/). You can also compile it yourself like any other GDExtension. https://github.com/unvermuthet/dynamic-video-stream/

It adds a `VideoStreamPlayback` that cycles from texture size (0, 500) to (500, 500) with a 100px step every second.

```cpp
void VideoStreamPlaybackDynamic::_update(double p_delta) {
    time += p_delta;
    texture->set_size(Vector2(((int32_t)time % 6) * 100, 500));
}
```

Here are some screen captures demonstrating the problem:

### Behavior on master:

Resizing the window will force a redraw bypassing the problem momentarily. Other than that, the texture does update every second no matter what but the size it’s being draw at doesn't, leading to stretching, which isn't apparent with the texture I chose.

https://github.com/user-attachments/assets/4c56bc08-8f9a-4516-b6f0-ee1211d14275

### With this PR:

https://github.com/user-attachments/assets/f4fb7187-2c62-4eec-a470-dc5ba4d11921


