### PR TITLE
Fix godot hanging on exit / race condition

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -529,7 +529,7 @@ void WorkerThreadPool::_switch_runlevel(Runlevel p_runlevel) {
 	runlevel = p_runlevel;
 	memset(&runlevel_data, 0, sizeof(runlevel_data));
 	for (uint32_t i = 0; i < threads.size(); i++) {
-		threads[i].cond_var.notify_one();
+		threads[i].cond_var.notify_all();
 		threads[i].signaled = true;
 	}
 	control_cond_var.notify_all();


### PR DESCRIPTION
Context can be found here: https://chat.godotengine.org/channel/devel?msg=BPv5MDneed3MhtuT7

This PR fixes a race condition that can occur if there are multiple tasks being awaited upon when quitting / exiting.  It may result in one task being awoken but not the one we need (which is to clean up and exit).  Changing to "notify_all" rather than "notify_one" fixes this race condition.  It become more obvious when compiling godot with zig 0.14.0 / LLVM 19.1.7.  It is present in existing versions of godot but occurs extremely rarely.  I suspect whatever changes were made in LLVM 19.1.7 simply make it occur more often.