### PR TITLE
Optimize `vformat` by using `Span` in `sprintf`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -5461,7 +5461,7 @@ String String::lpad(int min_length, const String &character) const {
 //   "fish %s pie" % "frog"
 //   "fish %s %d pie" % ["frog", 12]
 // In case of an error, the string returned is the error description and "error" is true.
-String String::sprintf(const Array &values, bool *error) const {
+String String::sprintf(const Span<Variant> &values, bool *error) const {
 	static const String ZERO("0");
 	static const String SPACE(" ");
 	static const String MINUS("-");
@@ -5470,7 +5470,7 @@ String String::sprintf(const Array &values, bool *error) const {
 	String formatted;
 	char32_t *self = (char32_t *)get_data();
 	bool in_format = false;
-	int value_index = 0;
+	uint64_t value_index = 0;
 	int min_chars = 0;
 	int min_decimals = 0;
 	bool in_decimals = false;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -438,7 +438,7 @@ public:
 	String trim_suffix(const char *p_suffix) const;
 	String lpad(int min_length, const String &character = " ") const;
 	String rpad(int min_length, const String &character = " ") const;
-	String sprintf(const Array &values, bool *error) const;
+	String sprintf(const Span<Variant> &values, bool *error) const;
 	String quote(const String &quotechar = "\"") const;
 	String unquote() const;
 	static String num(double p_num, int p_decimals = -1);

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -936,6 +936,10 @@ bool Array::is_read_only() const {
 	return _p->read_only != nullptr;
 }
 
+Span<Variant> Array::span() const {
+	return _p->array.span();
+}
+
 Array::Array(const Array &p_from) {
 	_p = nullptr;
 	_ref(p_from);

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/span.h"
 #include "core/typedefs.h"
 #include "core/variant/variant_deep_duplicate.h"
 
@@ -200,6 +201,11 @@ public:
 	void make_read_only();
 	bool is_read_only() const;
 	static Array create_read_only();
+
+	Span<Variant> span() const;
+	operator Span<Variant>() const {
+		return this->span();
+	}
 
 	Array(const Array &p_base, uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	Array(const Array &p_from);

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -925,14 +925,9 @@ const Variant::ObjData &Variant::_get_obj() const {
 template <typename... VarArgs>
 String vformat(const String &p_text, const VarArgs... p_args) {
 	Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
-	Array args_array;
-	args_array.resize(sizeof...(p_args));
-	for (uint32_t i = 0; i < sizeof...(p_args); i++) {
-		args_array[i] = args[i];
-	}
 
 	bool error = false;
-	String fmt = p_text.sprintf(args_array, &error);
+	String fmt = p_text.sprintf(Span(args, sizeof...(p_args)), &error);
 
 	ERR_FAIL_COND_V_MSG(error, String(), String("Formatting error in string \"") + p_text + "\": " + fmt + ".");
 


### PR DESCRIPTION
`vformat` is used throughout the codebase to log formatted messages. It currently has to allocate memory (`Array`) to call `sprintf`. Using `Span` in `sprintf` allows `vformat` to pass in a pointer to stack space, rather than having to allocate an `Array`. `Span` makes this easy to achieve.

There are other `sprintf` callers that are still passing in `Array`, but we can slowly convert if they are relevant. `vformat` feels especially relevant since it's called almost 4000 times throughout the codebase.

## Benchmark

I benchmarked an improvement of about 13% (1.3x speed):

```c++
	String s = "{}";
	String s1 = "Text";

	{
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < 2000000; i ++) {
			// Test
			vformat("ConfigFile parse error at %s:%d: %s.", s1, i, s1);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
```

- `1500ms` on master
- `1310ms` on this branch

## Note

The change required adding `Span` functionality to `Array` (to accomodate callers still passing in `Array`). `Array` currently has no `ptr()` function. We should probably discuss whether the data buffer should be exposed like this (I think it should!).
