### PR TITLE
Add `std::initializer_list` constructor to `Span`.

### DIFF
--- a/core/templates/span.h
+++ b/core/templates/span.h
@@ -65,6 +65,13 @@ public:
 		}
 	}
 
+	// This constructor makes it possible to construct Span like {a, b, c, ...}.
+	// Note: ONLY use this constructor in a function call, like function({a, b, c}).
+	//       A Span created like this must not be assigned to a variable.
+	//       Doing so will lead to undefined behavior, and may result in a crash.
+	_FORCE_INLINE_ constexpr Span(std::initializer_list<T> p_init) :
+			_ptr(p_init.size() > 0 ? p_init.begin() : nullptr), _len(p_init.size()) {}
+
 	_FORCE_INLINE_ constexpr uint64_t size() const { return _len; }
 	_FORCE_INLINE_ constexpr bool is_empty() const { return _len == 0; }
 


### PR DESCRIPTION
A little bit of code to argue over =)

Given this function:
```c++
void function_taking_span(const Span<int> span) {
    // [...]
}
```

The idea of this PR is to be able to call it with the following code:

```c++
void main() {
    function_taking_span({ 1, 2, 3});
}
```

I have tested it works generally, and I'm _fairly_ sure it's safe to use like this.
However, I'm pretty sure this is illegal code:

```c++
void main() {
    Span<int> span = { 1, 2, 3};
    // UB / crash?
    function_taking_span(span);
}
```

By adding this constructor, we'd be allowing the former (good) but also possibly risking the latter (bad). I think it's worth it. But let's discuss!

## Use-Case Example

There exists this function in the codebase:
```c++
template <typename T>
void Vector<T>::append_array(Vector<T> p_other) {
    // [...] copy the other's elements into us
}
```

Most callers pass in `Vector`, but `codesign.cpp` is passing in initializer lists:
https://github.com/godotengine/godot/blob/1ba4dbb164078561c58dcd432529062bea51457e/editor/export/codesign.cpp#L443-L447

Clearly, it is convenient to use this to extend the array. But it's very slow, because with the current code, 3 temporary `Vector` objects are unknowingly allocated and subsequently deallocated. This is because `Vector` is not a fitting parameter type for the function. It would be better to accept `Span`:

```c++
template <typename T>
void Vector<T>::append_array(const Span<T> &p_other) {
    // [...] copy the other's elements into us
}
```

The goal of this PR would be to still allow the convenience of `blob.append_array({ 0xFA, 0xDE, 0x0C, 0x01 });` in this case. Without `initializer_list` constructors, one would have to choose another type (ideally stack based) to instantiate and have converted to `Span`.