### PR TITLE
Fix console errors and crash in cleanup code for PhysicalBoneSimulator3D

### DIFF
--- a/scene/3d/physical_bone_simulator_3d.cpp
+++ b/scene/3d/physical_bone_simulator_3d.cpp
@@ -73,9 +73,14 @@ void PhysicalBoneSimulator3D::_pose_updated() {
 	if (!skeleton || simulating) {
 		return;
 	}
-	ERR_FAIL_COND(skeleton->get_bone_count() != bones.size());
-	for (int i = 0; i < skeleton->get_bone_count(); i++) {
-		_bone_pose_updated(skeleton, i);
+	// If this triggers that means that we likely haven't rebuilt the bone list yet.
+	if (skeleton->get_bone_count() != bones.size()) {
+		// NOTE: this is re-entrant and will call _pose_updated again.
+		_bone_list_changed();
+	} else {
+		for (int i = 0; i < skeleton->get_bone_count(); i++) {
+			_bone_pose_updated(skeleton, i);
+		}
 	}
 }
 

--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -752,8 +752,9 @@ void PhysicalBone3D::_get_property_list(List<PropertyInfo> *p_list) const {
 
 void PhysicalBone3D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
-		case NOTIFICATION_PARENTED:
+		// We need to wait until the bone has finished being added to the tree
+		// or none of the global transform calls will work correctly.
+		case NOTIFICATION_POST_ENTER_TREE:
 			_update_simulator_path();
 			update_bone_id();
 			reset_to_rest_position();
@@ -763,6 +764,9 @@ void PhysicalBone3D::_notification(int p_what) {
 			}
 			break;
 
+		// If we're detached from the skeleton we need to
+		// clear our references to it.
+		case NOTIFICATION_UNPARENTED:
 		case NOTIFICATION_EXIT_TREE: {
 			PhysicalBoneSimulator3D *simulator = get_simulator();
 			if (simulator) {

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -838,6 +838,13 @@ bool Skeleton3D::is_show_rest_only() const {
 void Skeleton3D::clear_bones() {
 	bones.clear();
 	name_to_bone_index.clear();
+
+	// All these structures contain references to now invalid bone indices.
+	skin_bindings.clear();
+	bone_global_pose_dirty.clear();
+	parentless_bones.clear();
+	nested_set_offset_to_bone_index.clear();
+
 	process_order_dirty = true;
 	version++;
 	_make_dirty();
@@ -1090,6 +1097,8 @@ void Skeleton3D::force_update_bone_children_transforms(int p_bone_idx) {
 void Skeleton3D::_force_update_bone_children_transforms(int p_bone_idx) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone_idx, bone_size);
+
+	_update_process_order();
 
 	Bone *bonesptr = bones.ptr();
 


### PR DESCRIPTION
# Skeleton3D/PhysicalBoneSimulator does not clean up internal state when removing bones
- Reproduced in 4.3, 4.4b3, 4.4
- Windows 11, Godot-4.4beta3, Godot-4.4

## Description
There is a bug which prevents dynamically removing and then adding bones to a skeleton.

The use case for dynamically constructing skeletons is in creating generative creatures, mechanism, and so on.
For my example, I use a ball and chain simulation with dynamic number of links. The scene componentry builds a chain link up from a link template and a ball template. This repo is a test case for demonstrating the behavior.

The Chain.gd file creates a ball-and-chain simulation with a dynamic number of links that can be changed directly within the editor. It is the only script file of interest for the project.

# Project for reproducing:
[https://github.com/mikest/godot-chain/](https://github.com/mikest/godot-chain/)

## Steps to reproduce crash
1. Open project.
2. Open Scene "Chain.tscn". You should see a monkey head on a chain.
3. Select the root node.
4. In the properties panel there is a counter for the number of chain links.
5. Increase the counter by one.

## Results:
1. Editor segfaults and exits.

# Investigation
`Skeleton3D`, `PhysicalBoneSimulator3D`, and `PhysicalBone3D` all maintain a set of internal caching structures that appear to be there as speed optimizations. These caching structures are not properly kept in sync when removing physical bones or when calling `Skeleton3D::clear_bones()` to remove logical bones. In most cases, this results in numerous errors logged in the console, but on occasion, it can also result in crashes.

This PR is an attempt to reduce those errors and to reduce the conditions which trigger spurious console logging from cache size misses due to stale cache data.

To address this, I included more cache invalidation in `Skeleton3D::clear_bones()`.

I also fixed cache sync problems with the `bone_global_pose_dirty` and `nested_set_offset_to_bone_index` in `Skeleton3D::add_bone(const String &p_name)`.

Many of the logging errors that arrise after removing and adding a bone are due to caches being rebuilt before the `PhysicalBone3D` has been added to the tree. I have moved the cache rebuild to `NOTIFICATION_POST_ENTER_TREE`. This fixes the errors from `_reload_joints`.

The last change I made was to the `PhysicalBoneSimulator3D::_pose_updated()` call, which when detecting a cache size mismatch between the skeleton bone count and the internal `bones` cache will rebuild it. This happens when a physical bone is still attached and the Skeleton clears the bones and then rebuilds them to a different size. The simulator will make pose updates and cause cache misses.


## Related Issues
Fix error spam at start with Skeleton3D modifiers #102030
https://github.com/godotengine/godot/pull/102030

_NOTE: I'm not terribly familiar with the godot internals and this is my first PR, so extra attention is probably warranted._



