### PR TITLE
AudioStreamPlayer3D: Improve spatialization in stereo

### DIFF
--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -111,6 +111,9 @@
 		<member name="stream_paused" type="bool" setter="set_stream_paused" getter="get_stream_paused" default="false">
 			If [code]true[/code], the playback is paused. You can resume it by setting [member stream_paused] to [code]false[/code].
 		</member>
+		<member name="tightness" type="float" setter="set_tightness" getter="get_tightness" default="1.0">
+			How steeply the signal dies off relative to angle from the source.
+		</member>
 		<member name="unit_size" type="float" setter="set_unit_size" getter="get_unit_size" default="10.0">
 			The factor for the attenuation effect. Higher values make the sound audible over a larger distance.
 		</member>

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -114,6 +114,12 @@
 		<member name="tightness" type="float" setter="set_tightness" getter="get_tightness" default="1.0">
 			How steeply the signal dies off relative to angle from the source.
 		</member>
+		<member name="rear_attenuation" type="float" setter="set_rear_attenuation" getter="get_rear_attenuation" default="-3.0">
+			Attenuation applied to the rear channels when downmixing to stereo or 3.1.
+		</member>
+		<member name="equalpower_model" type="bool" setter="set_equalpower_model" getter="get_equalpower_model" default="false">
+			Use equalpower model.
+		</member>
 		<member name="unit_size" type="float" setter="set_unit_size" getter="get_unit_size" default="10.0">
 			The factor for the attenuation effect. Higher values make the sound audible over a larger distance.
 		</member>

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -76,7 +76,8 @@ public:
 		return speakers.ptr()[index].direction;
 	}
 
-	void calculate(const Vector3 &source_direction, real_t tightness, unsigned int volume_count, real_t *volumes) const {
+	void calculate(const Vector3 &source_direction, real_t tightness, real_t *volumes) const {
+		const unsigned int volume_count = get_speaker_count();
 		const Speaker *r = speakers.ptr();
 		real_t sum_squared_gains = 0.0;
 		for (unsigned int speaker_num = 0; speaker_num < (unsigned int)speakers.size(); speaker_num++) {
@@ -102,28 +103,33 @@ static const Vector3 speaker_directions[7] = {
 	Vector3(1.0, 0.0, 0.0).normalized(), // side-right
 };
 
-void AudioStreamPlayer3D::_calc_output_vol(const Vector3 &source_dir, real_t tightness, Vector<AudioFrame> &output) {
-	unsigned int speaker_count = 0; // only main speakers (no LFE)
-	switch (AudioServer::get_singleton()->get_speaker_mode()) {
-		case AudioServer::SPEAKER_MODE_STEREO:
-			speaker_count = 2;
-			break;
-		case AudioServer::SPEAKER_SURROUND_31:
-			speaker_count = 3;
-			break;
-		case AudioServer::SPEAKER_SURROUND_51:
-			speaker_count = 5;
-			break;
-		case AudioServer::SPEAKER_SURROUND_71:
-			speaker_count = 7;
-			break;
+void AudioStreamPlayer3D::update_volumes(const Vector3 &source_dir, real_t *volumes) {
+	std::unique_ptr<Spcap> spcap;
+	AudioServer::SpeakerMode speaker_mode = AudioServer::get_singleton()->get_speaker_mode();
+
+	if (spcap == nullptr || cached_speaker_mode != speaker_mode) {
+		cached_speaker_mode = speaker_mode;
+		switch (speaker_mode) {
+			case AudioServer::SPEAKER_MODE_STEREO:
+			case AudioServer::SPEAKER_SURROUND_31:
+			case AudioServer::SPEAKER_SURROUND_51:
+				speaker_count = 5;
+				break;
+			case AudioServer::SPEAKER_SURROUND_71:
+				speaker_count = 7;
+				break;
+		}
+		spcap = std::unique_ptr<Spcap>(new Spcap(speaker_count, speaker_directions));
 	}
 
-	Spcap spcap(speaker_count, speaker_directions); //TODO: should only be created/recreated once the speaker mode / speaker positions changes
-	real_t volumes[7];
-	spcap.calculate(source_dir, tightness, speaker_count, volumes);
+	spcap->calculate(source_dir, tightness, volumes);
+}
 
-	switch (AudioServer::get_singleton()->get_speaker_mode()) {
+void AudioStreamPlayer3D::_calc_output_vol(const Vector3 &source_dir, Vector<AudioFrame> &output) {
+	real_t volumes[7];
+	update_volumes(source_dir, volumes);
+
+	switch (cached_speaker_mode) {
 		case AudioServer::SPEAKER_SURROUND_71:
 			output.write[3].left = volumes[5]; // side-left
 			output.write[3].right = volumes[6]; // side-right
@@ -131,14 +137,20 @@ void AudioStreamPlayer3D::_calc_output_vol(const Vector3 &source_dir, real_t tig
 		case AudioServer::SPEAKER_SURROUND_51:
 			output.write[2].left = volumes[3]; // rear-left
 			output.write[2].right = volumes[4]; // rear-right
-			[[fallthrough]];
+			output.write[1].right = 1.0; // LFE - always full power
+			output.write[1].left = volumes[2]; // center
+			output.write[0].right = volumes[1]; // front-right
+			output.write[0].left = volumes[0]; // front-left
+			break;
 		case AudioServer::SPEAKER_SURROUND_31:
 			output.write[1].right = 1.0; // LFE - always full power
 			output.write[1].left = volumes[2]; // center
-			[[fallthrough]];
+			output.write[0].left = volumes[0] + volumes[3] / 2.; // front-left
+			output.write[0].right = volumes[1] + volumes[4] / 2.; // front-right
+			break;
 		case AudioServer::SPEAKER_MODE_STEREO:
-			output.write[0].right = volumes[1]; // front-right
-			output.write[0].left = volumes[0]; // front-left
+			output.write[0].left = volumes[0] + volumes[2] / Math_SQRT2 + volumes[3] / 2.; // front-left
+			output.write[0].right = volumes[1] + volumes[2] / Math_SQRT2 + volumes[4] / 2.; // front-right
 			break;
 	}
 }
@@ -337,9 +349,6 @@ StringName AudioStreamPlayer3D::_get_actual_bus() {
 Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 	Vector<AudioFrame> output_volume_vector;
 	output_volume_vector.resize(4);
-	for (AudioFrame &frame : output_volume_vector) {
-		frame = AudioFrame(0, 0);
-	}
 
 	if (!internal->active.is_set() || internal->stream.is_null()) {
 		return output_volume_vector;
@@ -437,13 +446,20 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 		for (Ref<AudioStreamPlayback> &playback : internal->stream_playbacks) {
 			AudioServer::get_singleton()->set_playback_highshelf_params(playback, linear_attenuation, attenuation_filter_cutoff_hz);
 		}
-		// Bake in a constant factor here to allow the project setting defaults for 2d and 3d to be normalized to 1.0.
-		float tightness = cached_global_panning_strength * 2.0f;
-		tightness *= panning_strength;
-		_calc_output_vol(local_pos.normalized(), tightness, output_volume_vector);
 
+		_calc_output_vol(local_pos.normalized(), output_volume_vector);
+
+		// Apply panning effect.
+		float panning = CLAMP(panning_strength * cached_global_panning_strength, 0., 1.) / 2.;
 		for (unsigned int k = 0; k < 4; k++) {
-			output_volume_vector.write[k] = multiplier * output_volume_vector[k];
+			AudioFrame volume(multiplier, multiplier);
+			if (k != 1) {
+				volume.left *= (0.5 + panning) * output_volume_vector[k].left + (0.5 - panning) * output_volume_vector[k].right;
+				volume.right *= (0.5 - panning) * output_volume_vector[k].left + (0.5 + panning) * output_volume_vector[k].right;
+			} else {
+				volume *= output_volume_vector[k];
+			}
+			output_volume_vector.write[k] = volume;
 		}
 
 		HashMap<StringName, Vector<AudioFrame>> bus_volumes;
@@ -745,6 +761,14 @@ float AudioStreamPlayer3D::get_panning_strength() const {
 	return panning_strength;
 }
 
+void AudioStreamPlayer3D::set_tightness(float p_tightness) {
+	tightness = p_tightness;
+}
+
+float AudioStreamPlayer3D::get_tightness() const {
+	return tightness;
+}
+
 AudioServer::PlaybackType AudioStreamPlayer3D::get_playback_type() const {
 	return internal->get_playback_type();
 }
@@ -835,6 +859,9 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_panning_strength", "panning_strength"), &AudioStreamPlayer3D::set_panning_strength);
 	ClassDB::bind_method(D_METHOD("get_panning_strength"), &AudioStreamPlayer3D::get_panning_strength);
 
+	ClassDB::bind_method(D_METHOD("set_tightness", "tightness"), &AudioStreamPlayer3D::set_tightness);
+	ClassDB::bind_method(D_METHOD("get_tightness"), &AudioStreamPlayer3D::get_tightness);
+
 	ClassDB::bind_method(D_METHOD("has_stream_playback"), &AudioStreamPlayer3D::has_stream_playback);
 	ClassDB::bind_method(D_METHOD("get_stream_playback"), &AudioStreamPlayer3D::get_stream_playback);
 
@@ -854,6 +881,7 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_distance", PROPERTY_HINT_RANGE, "0,4096,0.01,or_greater,suffix:m"), "set_max_distance", "get_max_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_polyphony", PROPERTY_HINT_NONE, ""), "set_max_polyphony", "get_max_polyphony");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "panning_strength", PROPERTY_HINT_RANGE, "0,3,0.01,or_greater"), "set_panning_strength", "get_panning_strength");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tightness", PROPERTY_HINT_EXP_EASING, "tightness"), "set_tightness", "get_tightness");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bus", PROPERTY_HINT_ENUM, ""), "set_bus", "get_bus");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "area_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_area_mask", "get_area_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_type", PROPERTY_HINT_ENUM, "Default,Stream,Sample"), "set_playback_type", "get_playback_type");

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -60,6 +60,8 @@ public:
 			w[speaker_num].direction = speaker_directions[speaker_num];
 			w[speaker_num].squared_gain = 0.0;
 			w[speaker_num].effective_number_of_speakers = 0.0;
+		}
+		for (unsigned int speaker_num = 0; speaker_num < speaker_count; speaker_num++) {
 			for (unsigned int other_speaker_num = 0; other_speaker_num < speaker_count; other_speaker_num++) {
 				w[speaker_num].effective_number_of_speakers += 0.5 * (1.0 + w[speaker_num].direction.dot(w[other_speaker_num].direction));
 			}

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -78,11 +78,13 @@ private:
 	uint64_t last_mix_count = -1;
 	bool force_update_panning = false;
 
-	static void _calc_output_vol(const Vector3 &source_dir, real_t tightness, Vector<AudioFrame> &output);
+	void _calc_output_vol(const Vector3 &source_dir, Vector<AudioFrame> &output);
 
 	void _calc_reverb_vol(Area3D *area, Vector3 listener_area_pos, Vector<AudioFrame> direct_path_vol, Vector<AudioFrame> &reverb_vol);
 
 	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer3D *>(self)->force_update_panning = true; }
+
+	void update_volumes(const Vector3 &source_dir, real_t *volumes);
 
 	void _set_playing(bool p_enable);
 	bool _is_active() const;
@@ -113,6 +115,11 @@ private:
 
 	float panning_strength = 1.0f;
 	float cached_global_panning_strength = 0.5f;
+
+	real_t tightness = 1.0f;
+
+	AudioServer::SpeakerMode cached_speaker_mode;
+	unsigned int speaker_count = 0; // only main speakers (no LFE)
 
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
@@ -194,6 +201,9 @@ public:
 
 	void set_panning_strength(float p_panning_strength);
 	float get_panning_strength() const;
+
+	void set_tightness(float p_tightness);
+	float get_tightness() const;
 
 	bool has_stream_playback();
 	Ref<AudioStreamPlayback> get_stream_playback();

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -85,6 +85,7 @@ private:
 	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer3D *>(self)->force_update_panning = true; }
 
 	void update_volumes(const Vector3 &source_dir, real_t *volumes);
+	void update_volumes2(Vector3 source_dir, real_t *volumes);
 
 	void _set_playing(bool p_enable);
 	bool _is_active() const;
@@ -117,6 +118,8 @@ private:
 	float cached_global_panning_strength = 0.5f;
 
 	real_t tightness = 1.0f;
+	real_t rear_attenuation = -3.0;
+	bool equalpower_model = false;
 
 	AudioServer::SpeakerMode cached_speaker_mode;
 	unsigned int speaker_count = 0; // only main speakers (no LFE)
@@ -204,6 +207,12 @@ public:
 
 	void set_tightness(float p_tightness);
 	float get_tightness() const;
+
+	void set_rear_attenuation(float p_rear_attenuation);
+	float get_rear_attenuation() const;
+
+	void set_equalpower_model(bool p_equalpower_model);
+	bool get_equalpower_model() const;
 
 	bool has_stream_playback();
 	Ref<AudioStreamPlayback> get_stream_playback();


### PR DESCRIPTION
- Fixes #103989.

I think that using the tightness parameter of the SPCAP model as the panning strength was a mistake. Panning strength is an effect that should be applied at the end of the processing to change the final mix. I've done that and I've exposed the tightness parameter in the inspector for more flexibility.

Also, the SPCAP model seems to be developed for 5.1 setups and up. But the [paper](https://apps.dtic.mil/sti/tr/pdf/ADA464895.pdf) says that the resulting output is good to be downmixed for setups with less speakers. I've used the 5.1 speaker setup internally, and downmixed for the stereo and 3.1 setups.

With these changes, the audio positioning should be better in stereo and 3.1 setups, also the headphone output, and the panning strength should work more as intended. Tested only with stereo speakers and headphones. Needs more testing with more setups.

With panning strength at 1.0, no speaker will be muted, but I think it wouldn't make sense to forcibly mute any speakers for this case. We achieve maximum stereo separation though, as output by SPCAP. For further separation of channels, tightness can be increased.

This PR will work better together with #103856.