### PR TITLE
Add `Viewport` methods to find `Control` nodes and subwindows at global position

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -142,6 +142,15 @@
 				Cancels the drag operation that was previously started through [method Control._get_drag_data] or forced with [method Control.force_drag].
 			</description>
 		</method>
+		<method name="gui_get_control_at_position">
+			<return type="Control" />
+			<param index="0" name="position" type="Vector2" />
+			<param index="1" name="ignore_subwindows" type="bool" default="false" />
+			<description>
+				Returns the [Control] at the global position, ignoring [Control]s with [member Control.mouse_filter] set to [constant Control.MOUSE_FILTER_IGNORE]. If [param ignore_subwindows] is false, then this will return controls from embedded subwindows.
+				This behavior mirrors [method gui_get_hovered_control].
+			</description>
+		</method>
 		<method name="gui_get_drag_data" qualifiers="const">
 			<return type="Variant" />
 			<description>
@@ -159,6 +168,13 @@
 			<description>
 				Returns the [Control] that the mouse is currently hovering over in this viewport. If no [Control] has the cursor, returns [code]null[/code].
 				Typically the leaf [Control] node or deepest level of the subtree which claims hover. This is very useful when used together with [method Node.is_ancestor_of] to find if the mouse is within a control tree.
+			</description>
+		</method>
+		<method name="gui_get_window_at_position">
+			<return type="Window" />
+			<param index="0" name="position" type="Vector2" />
+			<description>
+				Returns the embedded subwindow at the global position, if any.
 			</description>
 		</method>
 		<method name="gui_is_drag_successful" qualifiers="const">

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1706,6 +1706,27 @@ void Viewport::_gui_call_notification(Control *p_control, int p_what) {
 	}
 }
 
+Control *Viewport::gui_get_control_at_position(const Vector2 &p_global, bool p_ignore_subwindows) {
+	Window *window = p_ignore_subwindows ? nullptr : gui_get_window_at_position(p_global);
+	if (window) {
+		return window->gui_get_control_at_position(window->get_final_transform().affine_inverse().xform(p_global - window->get_position()));
+	} else {
+		return gui_find_control(p_global);
+	}
+}
+
+Window *Viewport::gui_get_window_at_position(const Vector2 &p_global) {
+	for (int i = 0; i < gui.sub_windows.size(); i++) {
+		Viewport::SubWindow sw = gui.sub_windows[i];
+		Rect2i sw_rect = Rect2i(sw.window->get_position_with_decorations(), sw.window->get_size_with_decorations());
+		if (sw_rect.has_point(p_global)) {
+			return sw.window;
+		}
+	}
+
+	return nullptr;
+}
+
 // `gui_find_control` doesn't take embedded windows into account. So the caller of this function
 // needs to make sure, that there is no embedded window at the specified position.
 Control *Viewport::gui_find_control(const Point2 &p_global) {
@@ -4869,6 +4890,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("gui_release_focus"), &Viewport::gui_release_focus);
 	ClassDB::bind_method(D_METHOD("gui_get_focus_owner"), &Viewport::gui_get_focus_owner);
 	ClassDB::bind_method(D_METHOD("gui_get_hovered_control"), &Viewport::gui_get_hovered_control);
+
+	ClassDB::bind_method(D_METHOD("gui_get_control_at_position", "position", "ignore_subwindows"), &Viewport::gui_get_control_at_position, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("gui_get_window_at_position", "position"), &Viewport::gui_get_window_at_position);
 
 	ClassDB::bind_method(D_METHOD("set_disable_input", "disable"), &Viewport::set_disable_input);
 	ClassDB::bind_method(D_METHOD("is_input_disabled"), &Viewport::is_input_disabled);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -656,6 +656,8 @@ public:
 	bool gui_is_drag_successful() const;
 	void gui_cancel_drag();
 
+	Control *gui_get_control_at_position(const Vector2 &p_global, bool ignore_subwindows = false);
+	Window *gui_get_window_at_position(const Vector2 &p_global);
 	Control *gui_find_control(const Point2 &p_global);
 
 	void set_sdf_oversize(SDFOversize p_sdf_oversize);


### PR DESCRIPTION
This is an alternative implementation of #86343 based on [this comment](https://github.com/godotengine/godot/pull/86343#issuecomment-2523783494) suggesting that a new `Viewport::gui_find_node_at_position` method be created that mimics the behavior of `Viewport::gui_find_control` but returns any blocking subwindows at the position. For easier type handling, this PR splits that suggested method into `gui_get_control_at_position` for `Control` nodes and `gui_get_window_at_position` for embedded subwindows.

@cdoise-vbg I don't want to step anyone's toes, so I'm happy to close this if you're still working on that PR.

**Use Case:** Mimicking/simulating mouse inputs (e.g., a local multiplayer game where each user has their own cursor); creating alternative ways to interact with UI (e.g., throwing a box at a screen).

**Partially Adresses:** [GIP#8408](https://github.com/godotengine/godot-proposals/issues/8408) (allows finding **_one_** but not all `Control` nodes at a point).

**New Methods:**
`Viewport.gui_get_control_at_position(position, ignore_subwindows)`: Gets the `Control` node at the position, optionally including if the node is within an embedded subwindow.

`Viewport.gui_get_window_at_position(position)`: Gets the embedded subwindow at the position.