### PR TITLE
Add single-reference constructor to `Span`, creating a `Span` of length 1.

### DIFF
--- a/core/templates/span.h
+++ b/core/templates/span.h
@@ -65,6 +65,10 @@ public:
 		}
 	}
 
+	// This constructor allows passing a single value as a Span with size 1.
+	_FORCE_INLINE_ constexpr Span(const T &p_value) :
+			_ptr(&p_value), _len(1) {}
+
 	_FORCE_INLINE_ constexpr uint64_t size() const { return _len; }
 	_FORCE_INLINE_ constexpr bool is_empty() const { return _len == 0; }
 


### PR DESCRIPTION
One more constructor!

This one can create a `Span` from a single element by l-value reference. Given
```c++
void function_taking_span(const Span<int> span) {
    // [...]
}
```

You can call it like:
```c++
void main() {
    function_taking_span(5);
}
```

It's analogous to the existing `VectorView` constructor with the same semantics:
https://github.com/godotengine/godot/blob/30bb49ec1ff3b3fc463074b8d28bc97d4db50b9f/servers/rendering/rendering_device_driver.h#L72-L75

## Discussion

An alternative to the constructor proposed here would be to just use https://github.com/godotengine/godot/pull/103920:

```c++
void main() {
    function_taking_span({ 5 });
}
```

It's a bits less convenient. Arguably, it's clearer as to what's happening, but at the same time, it's already pretty clear what's happening when passing a single value. 

I'm not sure where I stand myself. Let's hear if anybody's got opinions on this one!