### PR TITLE
Move `CowData` `find`, `rfind` and `count` to `Span`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3329,7 +3329,7 @@ int String::find(const char *p_str, int p_from) const {
 }
 
 int String::find_char(char32_t p_char, int p_from) const {
-	return _cowdata.find(p_char, p_from);
+	return span().find(p_char, p_from);
 }
 
 int String::findmk(const Vector<String> &p_keys, int p_from, int *r_key) const {
@@ -3566,7 +3566,7 @@ int String::rfind(const char *p_str, int p_from) const {
 }
 
 int String::rfind_char(char32_t p_char, int p_from) const {
-	return _cowdata.rfind(p_char, p_from);
+	return span().rfind(p_char, p_from);
 }
 
 int String::rfindn(const String &p_str, int p_from) const {

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -252,10 +252,6 @@ public:
 	_FORCE_INLINE_ operator Span<T>() const { return Span<T>(ptr(), size()); }
 	_FORCE_INLINE_ Span<T> span() const { return operator Span<T>(); }
 
-	Size find(const T &p_val, Size p_from = 0) const;
-	Size rfind(const T &p_val, Size p_from = -1) const;
-	Size count(const T &p_val) const;
-
 	_FORCE_INLINE_ CowData() {}
 	_FORCE_INLINE_ ~CowData() { _unref(); }
 	_FORCE_INLINE_ CowData(std::initializer_list<T> p_init);
@@ -428,54 +424,6 @@ Error CowData<T>::_realloc(Size p_alloc_size) {
 	_ptr = _data_ptr;
 
 	return OK;
-}
-
-template <typename T>
-typename CowData<T>::Size CowData<T>::find(const T &p_val, Size p_from) const {
-	Size ret = -1;
-
-	if (p_from < 0 || size() == 0) {
-		return ret;
-	}
-
-	for (Size i = p_from; i < size(); i++) {
-		if (get(i) == p_val) {
-			ret = i;
-			break;
-		}
-	}
-
-	return ret;
-}
-
-template <typename T>
-typename CowData<T>::Size CowData<T>::rfind(const T &p_val, Size p_from) const {
-	const Size s = size();
-
-	if (p_from < 0) {
-		p_from = s + p_from;
-	}
-	if (p_from < 0 || p_from >= s) {
-		p_from = s - 1;
-	}
-
-	for (Size i = p_from; i >= 0; i--) {
-		if (get(i) == p_val) {
-			return i;
-		}
-	}
-	return -1;
-}
-
-template <typename T>
-typename CowData<T>::Size CowData<T>::count(const T &p_val) const {
-	Size amount = 0;
-	for (Size i = 0; i < size(); i++) {
-		if (get(i) == p_val) {
-			amount++;
-		}
-	}
-	return amount;
 }
 
 template <typename T>

--- a/core/templates/span.h
+++ b/core/templates/span.h
@@ -62,4 +62,54 @@ public:
 
 	_FORCE_INLINE_ constexpr const T *begin() const { return _ptr; }
 	_FORCE_INLINE_ constexpr const T *end() const { return _ptr + _len; }
+
+	// Algorithms.
+	constexpr int64_t find(const T &p_val, int64_t p_from = 0) const;
+	constexpr int64_t rfind(const T &p_val, int64_t p_from = 0) const;
+	constexpr uint64_t count(const T &p_val) const;
 };
+
+template <typename T>
+constexpr int64_t Span<T>::find(const T &p_val, int64_t p_from) const {
+	if (p_from < 0 || size() == 0) {
+		return -1;
+	}
+
+	for (uint64_t i = p_from; i < size(); i++) {
+		if (ptr()[i] == p_val) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+template <typename T>
+constexpr int64_t Span<T>::rfind(const T &p_val, int64_t p_from) const {
+	const int64_t s = size();
+
+	if (p_from < 0) {
+		p_from = s + p_from;
+	}
+	if (p_from < 0 || p_from >= s) {
+		p_from = s - 1;
+	}
+
+	for (int64_t i = p_from; i >= 0; i--) {
+		if (ptr()[i] == p_val) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+template <typename T>
+constexpr uint64_t Span<T>::count(const T &p_val) const {
+	uint64_t amount = 0;
+	for (uint64_t i = 0; i < size(); i++) {
+		if (ptr()[i] == p_val) {
+			amount++;
+		}
+	}
+	return amount;
+}

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -105,9 +105,9 @@ public:
 	_FORCE_INLINE_ const T &operator[](Size p_index) const { return _cowdata.get(p_index); }
 	// Must take a copy instead of a reference (see GH-31736).
 	Error insert(Size p_pos, T p_val) { return _cowdata.insert(p_pos, p_val); }
-	Size find(const T &p_val, Size p_from = 0) const { return _cowdata.find(p_val, p_from); }
-	Size rfind(const T &p_val, Size p_from = -1) const { return _cowdata.rfind(p_val, p_from); }
-	Size count(const T &p_val) const { return _cowdata.count(p_val); }
+	Size find(const T &p_val, Size p_from = 0) const { return span().find(p_val, p_from); }
+	Size rfind(const T &p_val, Size p_from = -1) const { return span().rfind(p_val, p_from); }
+	Size count(const T &p_val) const { return span().count(p_val); }
 
 	// Must take a copy instead of a reference (see GH-31736).
 	void append_array(Vector<T> p_other);


### PR DESCRIPTION
The idea of this PR is to establish `span_algorithms.h`, where we can put algorithms that run on spans.

There are 3 that are currently defined in `CowData`, which could be better defined on `Span`. In this way, people owning a `LocalVector` (or perhaps even something else, like Array) could use e.g. `spans::find` to find data in the container without re-implementing the algorithm. This is especially important because the algorithms are optimized for speed, while new implementations probably won't be.
In addition, the new implementations are substantially faster (same improvement / reason as https://github.com/godotengine/godot/pull/102059).

If we agree to go ahead with this, we can move a _lot_ more functions to the `spans` namespace, to start deduplicating `Vector`, `LocalVector` and `String` code.

Helps address https://github.com/godotengine/godot-proposals/issues/5144
