### PR TITLE
Change `MethodInfo::arguments` to `LocalVector`

### DIFF
--- a/core/doc_data.cpp
+++ b/core/doc_data.cpp
@@ -137,7 +137,7 @@ void DocData::method_doc_from_methodinfo(DocData::MethodDoc &p_method, const Met
 	return_doc_from_retinfo(p_method, p_methodinfo.return_val);
 
 	int i = 0;
-	for (List<PropertyInfo>::ConstIterator itr = p_methodinfo.arguments.begin(); itr != p_methodinfo.arguments.end(); ++itr, ++i) {
+	for (LocalVector<PropertyInfo>::ConstIterator itr = p_methodinfo.arguments.begin(); itr != p_methodinfo.arguments.end(); ++itr, ++i) {
 		DocData::ArgumentDoc argument;
 		argument_doc_from_arginfo(argument, *itr);
 		int default_arg_index = i - (p_methodinfo.arguments.size() - p_methodinfo.default_arguments.size());

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -1054,7 +1054,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 
 						Array arguments;
 						int i = 0;
-						for (List<PropertyInfo>::ConstIterator itr = mi.arguments.begin(); itr != mi.arguments.end(); ++itr, ++i) {
+						for (LocalVector<PropertyInfo>::ConstIterator itr = mi.arguments.begin(); itr != mi.arguments.end(); ++itr, ++i) {
 							const PropertyInfo &pinfo = *itr;
 							Dictionary d3;
 
@@ -1181,7 +1181,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 					Array arguments;
 
 					int i = 0;
-					for (List<PropertyInfo>::ConstIterator itr = F.arguments.begin(); itr != F.arguments.end(); ++itr, ++i) {
+					for (LocalVector<PropertyInfo>::ConstIterator itr = F.arguments.begin(); itr != F.arguments.end(); ++itr, ++i) {
 						Dictionary d3;
 						d3["name"] = itr->name;
 						d3["type"] = get_property_info_type_name(*itr);

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -2011,9 +2011,8 @@ void ClassDB::add_virtual_method(const StringName &p_class, const MethodInfo &p_
 		if (p_arg_names.size() != mi.arguments.size()) {
 			WARN_PRINT(vformat("Mismatch argument name count for virtual method: '%s::%s'.", String(p_class), p_method.name));
 		} else {
-			List<PropertyInfo>::Iterator itr = mi.arguments.begin();
-			for (int i = 0; i < p_arg_names.size(); ++itr, ++i) {
-				itr->name = p_arg_names[i];
+			for (int i = 0; i < p_arg_names.size(); ++i) {
+				mi.arguments[i].name = p_arg_names[i];
 			}
 		}
 	}

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -150,8 +150,8 @@ public:
 	virtual PropertyInfo _gen_argument_type_info(int p_arg) const override {
 		if (p_arg < 0) {
 			return _gen_return_type_info();
-		} else if (p_arg < method_info.arguments.size()) {
-			return method_info.arguments.get(p_arg);
+		} else if (p_arg < (int)method_info.arguments.size()) {
+			return method_info.arguments[p_arg];
 		} else {
 			return PropertyInfo(Variant::NIL, "arg_" + itos(p_arg), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 		}
@@ -193,7 +193,7 @@ public:
 			names.resize(method_info.arguments.size());
 #endif
 			int i = 0;
-			for (List<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++i) {
+			for (LocalVector<PropertyInfo>::Iterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++i) {
 				at[i + 1] = itr->type;
 #ifdef DEBUG_METHODS_ENABLED
 				names.write[i] = itr->name;

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -38,6 +38,7 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/string/translation_server.h"
+#include "core/variant/dictionary.h"
 #include "core/variant/typed_array.h"
 
 #ifdef DEBUG_ENABLED
@@ -118,7 +119,11 @@ TypedArray<Dictionary> convert_property_list(const List<PropertyInfo> *p_list) {
 MethodInfo::operator Dictionary() const {
 	Dictionary d;
 	d["name"] = name;
-	d["args"] = convert_property_list(&arguments);
+	TypedArray<Dictionary> args;
+	for (const PropertyInfo &arg : arguments) {
+		args.push_back(Dictionary(arg));
+	}
+	d["args"] = args;
 	Array da;
 	for (int i = 0; i < default_arguments.size(); i++) {
 		da.push_back(default_arguments[i]);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -226,13 +226,13 @@ struct MethodInfo {
 	PropertyInfo return_val;
 	uint32_t flags = METHOD_FLAGS_DEFAULT;
 	int id = 0;
-	List<PropertyInfo> arguments;
+	LocalVector<PropertyInfo> arguments;
 	Vector<Variant> default_arguments;
 	int return_val_metadata = 0;
 	Vector<int> arguments_metadata;
 
 	int get_argument_meta(int p_arg) const {
-		ERR_FAIL_COND_V(p_arg < -1 || p_arg > arguments.size(), 0);
+		ERR_FAIL_COND_V(p_arg < -1 || p_arg > (int)arguments.size(), 0);
 		if (p_arg == -1) {
 			return return_val_metadata;
 		}

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5631,7 +5631,7 @@ void AnimationTrackEditor::_add_method_key(const String &p_method) {
 			int first_defarg = E.arguments.size() - E.default_arguments.size();
 
 			int i = 0;
-			for (List<PropertyInfo>::ConstIterator itr = E.arguments.begin(); itr != E.arguments.end(); ++itr, ++i) {
+			for (LocalVector<PropertyInfo>::ConstIterator itr = E.arguments.begin(); itr != E.arguments.end(); ++itr, ++i) {
 				if (i >= first_defarg) {
 					Variant arg = E.default_arguments[i - first_defarg];
 					params.push_back(arg);

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -284,8 +284,8 @@ List<MethodInfo> ConnectDialog::_filter_method_list(const List<MethodInfo> &p_me
 
 	List<Pair<Variant::Type, StringName>> effective_args;
 	int unbind = get_unbinds();
-	for (int i = 0; i < p_signal.arguments.size() - unbind; i++) {
-		PropertyInfo pi = p_signal.arguments.get(i);
+	for (int i = 0; i < (int)p_signal.arguments.size() - unbind; i++) {
+		PropertyInfo pi = p_signal.arguments[i];
 		effective_args.push_back(Pair(pi.type, pi.class_name));
 	}
 	if (unbind == 0) {
@@ -307,22 +307,22 @@ List<MethodInfo> ConnectDialog::_filter_method_list(const List<MethodInfo> &p_me
 		}
 
 		if (check_signal) {
-			if (mi.arguments.size() != effective_args.size()) {
+			if ((int)mi.arguments.size() != effective_args.size()) {
 				continue;
 			}
 
 			bool type_mismatch = false;
 			const List<Pair<Variant::Type, StringName>>::Element *E = effective_args.front();
-			for (const List<PropertyInfo>::Element *F = mi.arguments.front(); F; F = F->next(), E = E->next()) {
+			for (uint32_t i = 0; i < mi.arguments.size(); i++, E = E->next()) {
 				Variant::Type stype = E->get().first;
-				Variant::Type mtype = F->get().type;
+				Variant::Type mtype = mi.arguments[i].type;
 
 				if (stype != Variant::NIL && mtype != Variant::NIL && stype != mtype) {
 					type_mismatch = true;
 					break;
 				}
 
-				if (stype == Variant::OBJECT && mtype == Variant::OBJECT && !ClassDB::is_parent_class(E->get().second, F->get().class_name)) {
+				if (stype == Variant::OBJECT && mtype == Variant::OBJECT && !ClassDB::is_parent_class(E->get().second, mi.arguments[i].class_name)) {
 					type_mismatch = true;
 					break;
 				}
@@ -547,7 +547,7 @@ String ConnectDialog::get_signature(const MethodInfo &p_method, PackedStringArra
 	signature.append("(");
 
 	int i = 0;
-	for (List<PropertyInfo>::ConstIterator itr = p_method.arguments.begin(); itr != p_method.arguments.end(); ++itr, ++i) {
+	for (LocalVector<PropertyInfo>::ConstIterator itr = p_method.arguments.begin(); itr != p_method.arguments.end(); ++itr, ++i) {
 		if (itr != p_method.arguments.begin()) {
 			signature.append(", ");
 		}

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -651,8 +651,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 				for (List<MethodInfo>::Element *EV = signal_list.front(); EV; EV = EV->next()) {
 					DocData::MethodDoc signal;
 					signal.name = EV->get().name;
-					for (List<PropertyInfo>::Element *EA = EV->get().arguments.front(); EA; EA = EA->next()) {
-						const PropertyInfo &arginfo = EA->get();
+					for (const PropertyInfo &arginfo : EV->get().arguments) {
 						DocData::ArgumentDoc argument;
 						DocData::argument_doc_from_arginfo(argument, arginfo);
 
@@ -845,7 +844,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 			method.name = mi.name;
 
 			int j = 0;
-			for (List<PropertyInfo>::ConstIterator itr = mi.arguments.begin(); itr != mi.arguments.end(); ++itr, ++j) {
+			for (LocalVector<PropertyInfo>::ConstIterator itr = mi.arguments.begin(); itr != mi.arguments.end(); ++itr, ++j) {
 				PropertyInfo arginfo = *itr;
 				DocData::ArgumentDoc ad;
 				DocData::argument_doc_from_arginfo(ad, arginfo);
@@ -1058,7 +1057,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 				DocData::return_doc_from_retinfo(md, mi.return_val);
 
 				int j = 0;
-				for (List<PropertyInfo>::ConstIterator itr = mi.arguments.begin(); itr != mi.arguments.end(); ++itr, ++j) {
+				for (LocalVector<PropertyInfo>::ConstIterator itr = mi.arguments.begin(); itr != mi.arguments.end(); ++itr, ++j) {
 					DocData::ArgumentDoc ad;
 					DocData::argument_doc_from_arginfo(ad, *itr);
 
@@ -1104,7 +1103,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 				DocData::return_doc_from_retinfo(atd, ai.return_val);
 
 				int j = 0;
-				for (List<PropertyInfo>::ConstIterator itr = ai.arguments.begin(); itr != ai.arguments.end(); ++itr, ++j) {
+				for (LocalVector<PropertyInfo>::ConstIterator itr = ai.arguments.begin(); itr != ai.arguments.end(); ++itr, ++j) {
 					DocData::ArgumentDoc ad;
 					DocData::argument_doc_from_arginfo(ad, *itr);
 

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -269,7 +269,7 @@ void PropertySelector::_update_search() {
 
 			desc += vformat(" %s(", mi.name);
 
-			for (List<PropertyInfo>::Iterator arg_itr = mi.arguments.begin(); arg_itr != mi.arguments.end(); ++arg_itr) {
+			for (LocalVector<PropertyInfo>::Iterator arg_itr = mi.arguments.begin(); arg_itr != mi.arguments.end(); ++arg_itr) {
 				if (arg_itr != mi.arguments.begin()) {
 					desc += ", ";
 				}

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1640,13 +1640,13 @@ void GDScriptAnalyzer::resolve_annotation(GDScriptParser::AnnotationNode *p_anno
 
 	const MethodInfo &annotation_info = parser->valid_annotations[p_annotation->name].info;
 
-	const List<PropertyInfo>::Element *E = annotation_info.arguments.front();
+	uint32_t argument_info_idx = 0;
 	for (int i = 0; i < p_annotation->arguments.size(); i++) {
 		GDScriptParser::ExpressionNode *argument = p_annotation->arguments[i];
-		const PropertyInfo &argument_info = E->get();
+		const PropertyInfo &argument_info = annotation_info.arguments[argument_info_idx];
 
-		if (E->next() != nullptr) {
-			E = E->next();
+		if (argument_info_idx + 1 < annotation_info.arguments.size()) {
+			argument_info_idx++;
 		}
 
 		reduce_expression(argument);
@@ -3324,7 +3324,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 					bool types_match = true;
 
 					{
-						List<PropertyInfo>::ConstIterator arg_itr = info.arguments.begin();
+						LocalVector<PropertyInfo>::ConstIterator arg_itr = info.arguments.begin();
 						for (int i = 0; i < p_call->arguments.size(); ++arg_itr, ++i) {
 							GDScriptParser::DataType par_type = type_from_property(*arg_itr, true);
 							GDScriptParser::DataType arg_type = p_call->arguments[i]->get_datatype();
@@ -3342,7 +3342,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 					}
 
 					if (types_match) {
-						List<PropertyInfo>::ConstIterator arg_itr = info.arguments.begin();
+						LocalVector<PropertyInfo>::ConstIterator arg_itr = info.arguments.begin();
 						for (int i = 0; i < p_call->arguments.size(); ++arg_itr, ++i) {
 							GDScriptParser::DataType par_type = type_from_property(*arg_itr, true);
 							if (p_call->arguments[i]->is_constant) {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -244,7 +244,7 @@ static bool _can_use_validate_call(const MethodBind *p_method, const Vector<GDSc
 	MethodInfo info;
 	ClassDB::get_method_info(p_method->get_instance_class(), p_method->get_name(), &info);
 	int i = 0;
-	for (List<PropertyInfo>::ConstIterator itr = info.arguments.begin(); itr != info.arguments.end(); ++itr, ++i) {
+	for (LocalVector<PropertyInfo>::Iterator itr = info.arguments.begin(); itr != info.arguments.end(); ++itr, ++i) {
 		if (!_is_exact_type(*itr, p_arguments[i].type)) {
 			return false;
 		}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -770,11 +770,11 @@ static String _make_arguments_hint(const MethodInfo &p_info, int p_arg_idx, bool
 		if (p_info.arguments.size() > 0) {
 			arghint += ", ";
 		}
-		if (p_arg_idx >= p_info.arguments.size()) {
+		if (p_arg_idx >= (int)p_info.arguments.size()) {
 			arghint += String::chr(0xFFFF);
 		}
 		arghint += "...";
-		if (p_arg_idx >= p_info.arguments.size()) {
+		if (p_arg_idx >= (int)p_info.arguments.size()) {
 			arghint += String::chr(0xFFFF);
 		}
 	}
@@ -2839,9 +2839,9 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 								// Handle user preference.
 								if (opt.is_quoted()) {
 									opt = opt.unquote().quote(quote_style);
-									if (use_string_names && info.arguments.get(p_argidx).type == Variant::STRING_NAME) {
+									if (use_string_names && info.arguments[p_argidx].type == Variant::STRING_NAME) {
 										opt = "&" + opt;
-									} else if (use_node_paths && info.arguments.get(p_argidx).type == Variant::NODE_PATH) {
+									} else if (use_node_paths && info.arguments[p_argidx].type == Variant::NODE_PATH) {
 										opt = "^" + opt;
 									}
 								}
@@ -2852,7 +2852,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					}
 
 					if (p_argidx < method_args) {
-						const PropertyInfo &arg_info = info.arguments.get(p_argidx);
+						const PropertyInfo &arg_info = info.arguments[p_argidx];
 						if (arg_info.usage & (PROPERTY_USAGE_CLASS_IS_ENUM | PROPERTY_USAGE_CLASS_IS_BITFIELD)) {
 							_find_enumeration_candidates(p_context, arg_info.class_name, r_result);
 						}
@@ -3134,7 +3134,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 				v.get_method_list(&methods);
 
 				for (MethodInfo &E : methods) {
-					if (p_argidx >= E.arguments.size()) {
+					if (p_argidx >= (int)E.arguments.size()) {
 						continue;
 					}
 					if (E.name == call->function_name) {
@@ -3175,7 +3175,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 
 		int i = 0;
 		for (const MethodInfo &E : constructors) {
-			if (p_argidx >= E.arguments.size()) {
+			if (p_argidx >= (int)E.arguments.size()) {
 				continue;
 			}
 			if (i > 0) {
@@ -3495,7 +3495,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 				}
 				method_hint += "(";
 
-				for (List<PropertyInfo>::ConstIterator arg_itr = mi.arguments.begin(); arg_itr != mi.arguments.end(); ++arg_itr) {
+				for (LocalVector<PropertyInfo>::ConstIterator arg_itr = mi.arguments.begin(); arg_itr != mi.arguments.end(); ++arg_itr) {
 					if (arg_itr != mi.arguments.begin()) {
 						method_hint += ", ";
 					}

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -624,8 +624,8 @@ StringName GDScriptUtilityFunctions::get_function_return_class(const StringName 
 Variant::Type GDScriptUtilityFunctions::get_function_argument_type(const StringName &p_function, int p_arg) {
 	GDScriptUtilityFunctionInfo *info = utility_function_table.lookup_ptr(p_function);
 	ERR_FAIL_NULL_V(info, Variant::NIL);
-	ERR_FAIL_COND_V(p_arg >= info->info.arguments.size(), Variant::NIL);
-	return info->info.arguments.get(p_arg).type;
+	ERR_FAIL_COND_V(p_arg >= (int)info->info.arguments.size(), Variant::NIL);
+	return info->info.arguments[p_arg].type;
 }
 
 int GDScriptUtilityFunctions::get_function_argument_count(const StringName &p_function) {

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -81,7 +81,7 @@ TEST_CASE("[Modules][GDScript] Validate built-in API") {
 	SUBCASE("[Modules][GDScript] Validate built-in methods") {
 		for (const MethodInfo &mi : builtin_methods) {
 			int i = 0;
-			for (List<PropertyInfo>::ConstIterator itr = mi.arguments.begin(); itr != mi.arguments.end(); ++itr, ++i) {
+			for (LocalVector<PropertyInfo>::ConstIterator itr = mi.arguments.begin(); itr != mi.arguments.end(); ++itr, ++i) {
 				TEST_COND((itr->name.is_empty() || itr->name.begins_with("_unnamed_arg")),
 						vformat("Unnamed argument in position %d of built-in method '%s'.", i, mi.name));
 			}
@@ -95,7 +95,7 @@ TEST_CASE("[Modules][GDScript] Validate built-in API") {
 	SUBCASE("[Modules][GDScript] Validate built-in annotations") {
 		for (const MethodInfo &ai : builtin_annotations) {
 			int i = 0;
-			for (List<PropertyInfo>::ConstIterator itr = ai.arguments.begin(); itr != ai.arguments.end(); ++itr, ++i) {
+			for (LocalVector<PropertyInfo>::ConstIterator itr = ai.arguments.begin(); itr != ai.arguments.end(); ++itr, ++i) {
 				TEST_COND((itr->name.is_empty() || itr->name.begins_with("_unnamed_arg")),
 						vformat("Unnamed argument in position %d of built-in annotation '%s'.", i, ai.name));
 			}

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -4112,7 +4112,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			}
 
 			int idx = 0;
-			for (List<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++idx) {
+			for (LocalVector<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++idx) {
 				const PropertyInfo &arginfo = *itr;
 
 				String orig_arg_name = arginfo.name;
@@ -4244,7 +4244,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			isignal.cname = method_info.name;
 
 			int idx = 0;
-			for (List<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++idx) {
+			for (LocalVector<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++idx) {
 				const PropertyInfo &arginfo = *itr;
 
 				String orig_arg_name = arginfo.name;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3744,7 +3744,7 @@ void Node::_bind_methods() {
 		mi.name = "rpc";
 		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "rpc", &Node::_rpc_bind, mi);
 
-		mi.arguments.push_front(PropertyInfo(Variant::INT, "peer_id"));
+		mi.arguments.insert(0, PropertyInfo(Variant::INT, "peer_id"));
 
 		mi.name = "rpc_id";
 		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "rpc_id", &Node::_rpc_id_bind, mi);

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -658,7 +658,7 @@ void add_exposed_classes(Context &r_context) {
 			}
 
 			int i = 0;
-			for (List<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++i) {
+			for (LocalVector<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++i) {
 				const PropertyInfo &arg_info = *itr;
 
 				String orig_arg_name = arg_info.name;
@@ -732,7 +732,7 @@ void add_exposed_classes(Context &r_context) {
 					"Signal name is not a valid identifier: '", exposed_class.name, ".", signal.name, "'.");
 
 			int i = 0;
-			for (List<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++i) {
+			for (LocalVector<PropertyInfo>::ConstIterator itr = method_info.arguments.begin(); itr != method_info.arguments.end(); ++itr, ++i) {
 				const PropertyInfo &arg_info = *itr;
 
 				String orig_arg_name = arg_info.name;


### PR DESCRIPTION
`MethodInfo::arguments` is used at various places, including some core functionalities like `ClassDB` and `MethodBind`. Using a `LocalVector` gives us better performance in iteration and random accessing.