### PR TITLE
Add `Span` conversion to `LocalVector`.

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -48,13 +48,12 @@ private:
 	T *data = nullptr;
 
 public:
-	T *ptr() {
-		return data;
-	}
+	_FORCE_INLINE_ T *ptr() { return data; }
+	_FORCE_INLINE_ const T *ptr() const { return data; }
+	_FORCE_INLINE_ U size() const { return count; }
 
-	const T *ptr() const {
-		return data;
-	}
+	_FORCE_INLINE_ Span<T> span() const { return Span(data, count); }
+	_FORCE_INLINE_ operator Span<T>() const { return span(); }
 
 	// Must take a copy instead of a reference (see GH-31736).
 	_FORCE_INLINE_ void push_back(T p_elem) {
@@ -146,7 +145,6 @@ public:
 		}
 	}
 
-	_FORCE_INLINE_ U size() const { return count; }
 	void resize(U p_size) {
 		if (p_size < count) {
 			if constexpr (!std::is_trivially_destructible_v<T> && !force_trivial) {


### PR DESCRIPTION
This brings it in-line with `Vector` and `String`.

Probably should have been part of https://github.com/godotengine/godot/pull/100293, but I forgot.

I'm also taking the opportunity to move `size` up and forcing inline on the pointer functions, to match the other types better.