### PR TITLE
Remove outdated `vformat` comments/workarounds in `time.cpp`

### DIFF
--- a/core/os/time.cpp
+++ b/core/os/time.cpp
@@ -233,15 +233,8 @@ Dictionary Time::get_time_dict_from_unix_time(int64_t p_unix_time_val) const {
 String Time::get_datetime_string_from_unix_time(int64_t p_unix_time_val, bool p_use_space) const {
 	UNIX_TIME_TO_HMS
 	UNIX_TIME_TO_YMD
-	// vformat only supports up to 6 arguments, so we need to split this up into 2 parts.
-	String timestamp = vformat("%04d-%02d-%02d", year, (uint8_t)month, day);
-	if (p_use_space) {
-		timestamp = vformat("%s %02d:%02d:%02d", timestamp, hour, minute, second);
-	} else {
-		timestamp = vformat("%sT%02d:%02d:%02d", timestamp, hour, minute, second);
-	}
-
-	return timestamp;
+	const String format_string = p_use_space ? "%04d-%02d-%02d %02d:%02d:%02d" : "%04d-%02d-%02dT%02d:%02d:%02d";
+	return vformat(format_string, year, (uint8_t)month, day, hour, minute, second);
 }
 
 String Time::get_date_string_from_unix_time(int64_t p_unix_time_val) const {
@@ -277,14 +270,8 @@ String Time::get_datetime_string_from_datetime_dict(const Dictionary &p_datetime
 	ERR_FAIL_COND_V_MSG(p_datetime.is_empty(), "", "Invalid datetime Dictionary: Dictionary is empty.");
 	EXTRACT_FROM_DICTIONARY
 	VALIDATE_YMDHMS("")
-	// vformat only supports up to 6 arguments, so we need to split this up into 2 parts.
-	String timestamp = vformat("%04d-%02d-%02d", year, (uint8_t)month, day);
-	if (p_use_space) {
-		timestamp = vformat("%s %02d:%02d:%02d", timestamp, hour, minute, second);
-	} else {
-		timestamp = vformat("%sT%02d:%02d:%02d", timestamp, hour, minute, second);
-	}
-	return timestamp;
+	const String format_string = p_use_space ? "%04d-%02d-%02d %02d:%02d:%02d" : "%04d-%02d-%02dT%02d:%02d:%02d";
+	return vformat(format_string, year, (uint8_t)month, day, hour, minute, second);
 }
 
 int64_t Time::get_unix_time_from_datetime_dict(const Dictionary &p_datetime) const {
@@ -352,15 +339,8 @@ Dictionary Time::get_time_dict_from_system(bool p_utc) const {
 
 String Time::get_datetime_string_from_system(bool p_utc, bool p_use_space) const {
 	OS::DateTime dt = OS::get_singleton()->get_datetime(p_utc);
-	// vformat only supports up to 6 arguments, so we need to split this up into 2 parts.
-	String timestamp = vformat("%04d-%02d-%02d", dt.year, (uint8_t)dt.month, dt.day);
-	if (p_use_space) {
-		timestamp = vformat("%s %02d:%02d:%02d", timestamp, dt.hour, dt.minute, dt.second);
-	} else {
-		timestamp = vformat("%sT%02d:%02d:%02d", timestamp, dt.hour, dt.minute, dt.second);
-	}
-
-	return timestamp;
+	const String format_string = p_use_space ? "%04d-%02d-%02d %02d:%02d:%02d" : "%04d-%02d-%02dT%02d:%02d:%02d";
+	return vformat(format_string, dt.year, (uint8_t)dt.month, dt.day, dt.hour, dt.minute, dt.second);
 }
 
 String Time::get_date_string_from_system(bool p_utc) const {


### PR DESCRIPTION
`Time` methods returning Strings with both date and time values included were calling `vformat` twice, as older `vformat` implementation limited how many arguments could be passed in.  Updated these methods to just call `vformat` once.

This also makes these methods around 10-20% faster, compared with below gdscript:

```gdscript
func _ready() -> void:
	var start := Time.get_ticks_msec()
	for i in 100000:
		Time.get_datetime_string_from_system()
	var end := Time.get_ticks_msec()
	print("get_datetime_string_from_system: %dms" % [end - start])

	var unix_time = Time.get_unix_time_from_system()
	start = Time.get_ticks_msec()
	for i in 100000:
		Time.get_datetime_string_from_unix_time(unix_time)
	end = Time.get_ticks_msec()
	print("get_datetime_string_from_unix_time: %dms" % [end - start])
	
	var dictionary := {
		"year": 2025,
		"month": 1,
		"day": 2,
		"hour": 3,
		"minute": 4,
		"second": 5,
	}
	start = Time.get_ticks_msec()
	for i in 100000:
		Time.get_datetime_string_from_datetime_dict(dictionary, true)
	end = Time.get_ticks_msec()
	print("get_datetime_string_from_datetime_dict: %dms" % [end - start])
```

old:
```
get_datetime_string_from_system: 269ms
get_datetime_string_from_unix_time: 207ms
get_datetime_string_from_datetime_dict: 418ms
```

new:
```
get_datetime_string_from_system: 222ms
get_datetime_string_from_unix_time: 162ms
get_datetime_string_from_datetime_dict: 370ms
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
