### PR TITLE
Allow Spacebar pan gesture to work with the TileMapLayer editor

### DIFF
--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -668,7 +668,7 @@ bool TileMapLayerEditorTilesPlugin::forward_canvas_gui_input(const Ref<InputEven
 		drag_last_mouse_pos = mpos;
 		CanvasItemEditor::get_singleton()->update_viewport();
 
-		return true;
+		return drag_type != DRAG_TYPE_NONE;
 	}
 
 	Ref<InputEventMouseButton> mb = p_event;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This addresses KoBeWi's comment here https://github.com/godotengine/godot-proposals/issues/9166#issuecomment-2129889164. The TileMapLayer editor was blocking the InputEvent that let you use the spacebar pan gesture

https://github.com/user-attachments/assets/22d7c1c2-5b8e-48be-9503-e03bb4e7bb3a
