### PR TITLE
Expose `ImporterMesh.create_shadow_mesh()` to scripting

### DIFF
--- a/doc/classes/ImporterMesh.xml
+++ b/doc/classes/ImporterMesh.xml
@@ -42,6 +42,14 @@
 				Removes all surfaces and blend shapes from this [ImporterMesh].
 			</description>
 		</method>
+		<method name="create_shadow_mesh">
+			<return type="void" />
+			<description>
+				Generates a mesh containing only the [constant Mesh.ARRAY_VERTEX] and [constant Mesh.ARRAY_INDEX] arrays added via [method add_surface].
+				If the [ImporterMesh] contains blend shapes or a surface with [constant Mesh.ARRAY_BONES] or [constant Mesh.ARRAY_WEIGHTS], no shadow mesh is generated.
+				The generated shadow mesh can be retrieved using [method get_shadow_mesh] or as [member ArrayMesh.shadow_mesh] on the object returned by [method get_mesh].
+			</description>
+		</method>
 		<method name="generate_lods">
 			<return type="void" />
 			<param index="0" name="normal_merge_angle" type="float" />
@@ -87,6 +95,12 @@
 				Returns the mesh data represented by this [ImporterMesh] as a usable [ArrayMesh].
 				This method caches the returned mesh, and subsequent calls will return the cached data until [method clear] is called.
 				If not yet cached and [param base_mesh] is provided, [param base_mesh] will be used and mutated.
+			</description>
+		</method>
+		<method name="get_shadow_mesh" qualifiers="const">
+			<return type="ImporterMesh" />
+			<description>
+				Returns the generated shadow mesh, if any. See [method create_shadow_mesh].
 			</description>
 		</method>
 		<method name="get_surface_arrays" qualifiers="const">

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -1210,5 +1210,8 @@ void ImporterMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_lightmap_size_hint", "size"), &ImporterMesh::set_lightmap_size_hint);
 	ClassDB::bind_method(D_METHOD("get_lightmap_size_hint"), &ImporterMesh::get_lightmap_size_hint);
 
+	ClassDB::bind_method(D_METHOD("create_shadow_mesh"), &ImporterMesh::create_shadow_mesh);
+	ClassDB::bind_method(D_METHOD("get_shadow_mesh"), &ImporterMesh::get_shadow_mesh);
+
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
 }


### PR DESCRIPTION
This is #96836 with the rebase repaired and the author email address in the commit attached to the correct GitHub account.