### PR TITLE
Fix typo in MacOS and iOS export settings

### DIFF
--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -131,7 +131,7 @@ static const DataCollectionInfo data_collect_type_info[] = {
 	{ "customer_support", "NSPrivacyCollectedDataTypeCustomerSupport" },
 	{ "other_user_content", "NSPrivacyCollectedDataTypeOtherUserContent" },
 	{ "browsing_history", "NSPrivacyCollectedDataTypeBrowsingHistory" },
-	{ "search_hhistory", "NSPrivacyCollectedDataTypeSearchHistory" },
+	{ "search_history", "NSPrivacyCollectedDataTypeSearchHistory" },
 	{ "user_id", "NSPrivacyCollectedDataTypeUserID" },
 	{ "device_id", "NSPrivacyCollectedDataTypeDeviceID" },
 	{ "purchase_history", "NSPrivacyCollectedDataTypePurchaseHistory" },

--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -662,16 +662,16 @@
 		<member name="privacy/collected_data/purchase_history/used_for_tracking" type="bool" setter="" getter="">
 			Indicates whether your app uses purchase history for tracking.
 		</member>
-		<member name="privacy/collected_data/search_hhistory/collected" type="bool" setter="" getter="">
+		<member name="privacy/collected_data/search_history/collected" type="bool" setter="" getter="">
 			Indicates whether your app collects search history.
 		</member>
-		<member name="privacy/collected_data/search_hhistory/collection_purposes" type="int" setter="" getter="">
+		<member name="privacy/collected_data/search_history/collection_purposes" type="int" setter="" getter="">
 			The reasons your app collects search history. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
 		</member>
-		<member name="privacy/collected_data/search_hhistory/linked_to_user" type="bool" setter="" getter="">
+		<member name="privacy/collected_data/search_history/linked_to_user" type="bool" setter="" getter="">
 			Indicates whether your app links search history to the user's identity.
 		</member>
-		<member name="privacy/collected_data/search_hhistory/used_for_tracking" type="bool" setter="" getter="">
+		<member name="privacy/collected_data/search_history/used_for_tracking" type="bool" setter="" getter="">
 			Indicates whether your app uses search history for tracking.
 		</member>
 		<member name="privacy/collected_data/sensitive_info/collected" type="bool" setter="" getter="">

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -612,16 +612,16 @@
 		<member name="privacy/collected_data/purchase_history/used_for_tracking" type="bool" setter="" getter="">
 			Indicates whether your app uses purchase history for tracking.
 		</member>
-		<member name="privacy/collected_data/search_hhistory/collected" type="bool" setter="" getter="">
+		<member name="privacy/collected_data/search_history/collected" type="bool" setter="" getter="">
 			Indicates whether your app collects search history.
 		</member>
-		<member name="privacy/collected_data/search_hhistory/collection_purposes" type="int" setter="" getter="">
+		<member name="privacy/collected_data/search_history/collection_purposes" type="int" setter="" getter="">
 			The reasons your app collects search history. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
 		</member>
-		<member name="privacy/collected_data/search_hhistory/linked_to_user" type="bool" setter="" getter="">
+		<member name="privacy/collected_data/search_history/linked_to_user" type="bool" setter="" getter="">
 			Indicates whether your app links search history to the user's identity.
 		</member>
-		<member name="privacy/collected_data/search_hhistory/used_for_tracking" type="bool" setter="" getter="">
+		<member name="privacy/collected_data/search_history/used_for_tracking" type="bool" setter="" getter="">
 			Indicates whether your app uses search history for tracking.
 		</member>
 		<member name="privacy/collected_data/sensitive_info/collected" type="bool" setter="" getter="">

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -436,7 +436,7 @@ static const DataCollectionInfo data_collect_type_info[] = {
 	{ "customer_support", "NSPrivacyCollectedDataTypeCustomerSupport" },
 	{ "other_user_content", "NSPrivacyCollectedDataTypeOtherUserContent" },
 	{ "browsing_history", "NSPrivacyCollectedDataTypeBrowsingHistory" },
-	{ "search_hhistory", "NSPrivacyCollectedDataTypeSearchHistory" },
+	{ "search_history", "NSPrivacyCollectedDataTypeSearchHistory" },
 	{ "user_id", "NSPrivacyCollectedDataTypeUserID" },
 	{ "device_id", "NSPrivacyCollectedDataTypeDeviceID" },
 	{ "purchase_history", "NSPrivacyCollectedDataTypePurchaseHistory" },

--- a/platform/visionos/doc_classes/EditorExportPlatformVisionOS.xml
+++ b/platform/visionos/doc_classes/EditorExportPlatformVisionOS.xml
@@ -514,16 +514,16 @@
 		<member name="privacy/collected_data/purchase_history/used_for_tracking" type="bool" setter="" getter="">
 			Indicates whether your app uses purchase history for tracking.
 		</member>
-		<member name="privacy/collected_data/search_hhistory/collected" type="bool" setter="" getter="">
+		<member name="privacy/collected_data/search_history/collected" type="bool" setter="" getter="">
 			Indicates whether your app collects search history.
 		</member>
-		<member name="privacy/collected_data/search_hhistory/collection_purposes" type="int" setter="" getter="">
+		<member name="privacy/collected_data/search_history/collection_purposes" type="int" setter="" getter="">
 			The reasons your app collects search history. See [url=https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests]Describing data use in privacy manifests[/url].
 		</member>
-		<member name="privacy/collected_data/search_hhistory/linked_to_user" type="bool" setter="" getter="">
+		<member name="privacy/collected_data/search_history/linked_to_user" type="bool" setter="" getter="">
 			Indicates whether your app links search history to the user's identity.
 		</member>
-		<member name="privacy/collected_data/search_hhistory/used_for_tracking" type="bool" setter="" getter="">
+		<member name="privacy/collected_data/search_history/used_for_tracking" type="bool" setter="" getter="">
 			Indicates whether your app uses search history for tracking.
 		</member>
 		<member name="privacy/collected_data/sensitive_info/collected" type="bool" setter="" getter="">


### PR DESCRIPTION
### Description 

While looking at the options for exporting to mac I noticed that there was a section `Search Hhistory`.
<img width="264" alt="image" src="https://github.com/user-attachments/assets/dffed3cf-9b46-463b-a6f8-578798df9865" />

Although I'm not 100% sure the ins and outs of the exporting system, this feels like a typo. 

Question for anyone reviewing / better knowledge of this area: Should there be some backwards compatibility supplied for moving any existing `search_hhistory` config forward to `search_history`? 
