### PR TITLE
Path2D prefer control points for outward curve

### DIFF
--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -96,6 +96,10 @@ class Path2DEditor : public HBoxContainer {
 	Vector2 edge_point;
 	Vector2 original_mouse_pos;
 
+	// Number of control points in range of the last click.
+	// 0, 1, or 2.
+	int control_points_in_range = 0;
+
 	void _mode_selected(int p_mode);
 	void _handle_option_pressed(int p_option);
 	void _cancel_current_action();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Implements https://github.com/godotengine/godot-proposals/issues/11570 for Path2D. When control points overlap, choose the right one to make an outward curve by default