### PR TITLE
Add Jolt distance constraint

### DIFF
--- a/doc/classes/DistanceJoint3D.xml
+++ b/doc/classes/DistanceJoint3D.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DistanceJoint3D" inherits="Joint3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A physics constraint which moves two bodies such that their distance is between a minimum and maximum distance.
+	</brief_description>
+	<description>
+		A physics constraint which moves two bodies such that their distance is between a minimum and maximum distance. For example, "Body A" can be a [StaticBody3D] representing a ceiling while "Body B" can be a [RigidBody3D] representing a hanging chandelier which can swing when hit.
+		[b]Note:[/b] This constraint is only supported by the Jolt Physics engine. To switch to Jolt Physics, set [member ProjectSettings.physics/3d/physics_engine] to [b]Jolt Physics[/b].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_global_point" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="point" type="int" enum="DistanceJoint3D.PointParam" />
+			<description>
+				Returns the global position of the point specified.
+			</description>
+		</method>
+		<method name="get_param" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="param" type="int" enum="DistanceJoint3D.Param" />
+			<description>
+				Returns the value of the specified parameter.
+			</description>
+		</method>
+		<method name="get_point_param" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="point" type="int" enum="DistanceJoint3D.PointParam" />
+			<description>
+				Returns the local point on the [PhysicsBody3D] where the constraint is attached.
+			</description>
+		</method>
+		<method name="set_param">
+			<return type="void" />
+			<param index="0" name="param" type="int" enum="DistanceJoint3D.Param" />
+			<param index="1" name="value" type="float" />
+			<description>
+				Sets the value of the specified parameter.
+			</description>
+		</method>
+		<method name="set_point_param">
+			<return type="void" />
+			<param index="0" name="point" type="int" enum="DistanceJoint3D.PointParam" />
+			<param index="1" name="value" type="Vector3" />
+			<description>
+				Sets the local point on the [PhysicsBody3D] where the constraint is attached.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="anchor/a" type="Vector3" setter="set_point_param" getter="get_point_param" default="Vector3(0, 0, 0)">
+			The local point on Node A where the constraint is attached.
+		</member>
+		<member name="anchor/b" type="Vector3" setter="set_point_param" getter="get_point_param" default="Vector3(0, 0, 0)">
+			The local point on Node B where the constraint is attached.
+		</member>
+		<member name="distance/max" type="float" setter="set_param" getter="get_param" default="inf">
+			The maximum distance between points A and B. If the distance between A and B exceeds [member distance/max] a spring will be used to move the points closer.
+		</member>
+		<member name="distance/min" type="float" setter="set_param" getter="get_param" default="0.0">
+			The minimum distance between points A and B. If the distance between A and B does not exceed [member distance/min] a spring will be used to move the points further apart.
+		</member>
+		<member name="spring/damping" type="float" setter="set_param" getter="get_param" default="0.0">
+			The damping of the spring pulling the bodies together. (0 = no damping, 1 = critical damping). Set to zero if you don't want to pull the bodies together with a spring.
+		</member>
+		<member name="spring/stiffness" type="float" setter="set_param" getter="get_param" default="0.0">
+			The strength of the spring pulling the bodies together. Increase this value to pull the bodies together faster. Set to zero if you don't want to pull the bodies together with a spring.
+		</member>
+	</members>
+	<constants>
+		<constant name="PARAM_LIMITS_SPRING_STIFFNESS" value="0" enum="Param">
+			The strength of the spring pulling the bodies together. Increase this value to pull the bodies together faster. Set to zero if you don't want to pull the bodies together with a spring.
+		</constant>
+		<constant name="PARAM_LIMITS_SPRING_DAMPING" value="1" enum="Param">
+			The damping of the spring pulling the bodies together. (0 = no damping, 1 = critical damping). Set to zero if you don't want to pull the bodies together with a spring.
+		</constant>
+		<constant name="PARAM_DISTANCE_MIN" value="2" enum="Param">
+			The minimum distance of the constraint.
+		</constant>
+		<constant name="PARAM_DISTANCE_MAX" value="3" enum="Param">
+			The maximum distance of the constraint.
+		</constant>
+		<constant name="PARAM_MAX" value="4" enum="Param">
+			Represents the size of the [enum Param] enum.
+		</constant>
+		<constant name="POINT_PARAM_A" value="0" enum="PointParam">
+			The point on Node A where the distance constraint is attached.
+		</constant>
+		<constant name="POINT_PARAM_B" value="1" enum="PointParam">
+			The point on Node B where the distance constraint is attached.
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -752,6 +752,15 @@
 				Creates a 3D cylinder shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the cylinder's height and radius.
 			</description>
 		</method>
+		<method name="distance_joint_set_param">
+			<return type="void" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="param" type="int" enum="PhysicsServer3D.DistanceJointParam" />
+			<param index="2" name="value" type="float" />
+			<description>
+				Sets a distance_joint parameter (see [enum DistanceJointParam] constants).
+			</description>
+		</method>
 		<method name="free_rid">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
@@ -892,6 +901,17 @@
 			<param index="3" name="body_B" type="RID" />
 			<param index="4" name="local_ref_B" type="Transform3D" />
 			<description>
+			</description>
+		</method>
+		<method name="joint_make_distance">
+			<return type="void" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="body_A" type="RID" />
+			<param index="2" name="local_ref_A" type="Vector3" />
+			<param index="3" name="body_B" type="RID" />
+			<param index="4" name="local_ref_B" type="Vector3" />
+			<description>
+				Make the joint a distance constraint. Use [method distance_joint_set_param] to set the joint's parameters.
 			</description>
 		</method>
 		<method name="joint_make_generic_6dof">
@@ -1453,7 +1473,11 @@
 		<constant name="JOINT_TYPE_6DOF" value="4" enum="JointType">
 			The [Joint3D] is a [Generic6DOFJoint3D].
 		</constant>
-		<constant name="JOINT_TYPE_MAX" value="5" enum="JointType">
+		<constant name="JOINT_TYPE_DISTANCE_JOINT" value="5" enum="JointType">
+			The [Joint3D] is a [DistanceJoint3D].
+			[b]Note:[/b] This only works with the Jolt Physics engine.
+		</constant>
+		<constant name="JOINT_TYPE_MAX" value="6" enum="JointType">
 			Represents the size of the [enum JointType] enum.
 		</constant>
 		<constant name="PIN_JOINT_BIAS" value="0" enum="PinJointParam">
@@ -1666,6 +1690,18 @@
 		</constant>
 		<constant name="G6DOF_JOINT_FLAG_MAX" value="6" enum="G6DOFJointAxisFlag">
 			Represents the size of the [enum G6DOFJointAxisFlag] enum.
+		</constant>
+		<constant name="DISTANCE_JOINT_LIMITS_SPRING_STIFFNESS" value="0" enum="DistanceJointParam">
+			The strength of the spring pulling the bodies together. Increase this value to pull the bodies together faster. Set to zero if you don't want to pull the bodies together with a spring.
+		</constant>
+		<constant name="DISTANCE_JOINT_LIMITS_SPRING_DAMPING" value="1" enum="DistanceJointParam">
+			The damping of the spring pulling the bodies together. (0 = no damping, 1 = critical damping). Set to zero if you don't want to pull the bodies together with a spring.
+		</constant>
+		<constant name="DISTANCE_JOINT_DISTANCE_MIN" value="2" enum="DistanceJointParam">
+			The minimum distance of the constraint.
+		</constant>
+		<constant name="DISTANCE_JOINT_DISTANCE_MAX" value="3" enum="DistanceJointParam">
+			The maximum distance of the constraint.
 		</constant>
 		<constant name="SHAPE_WORLD_BOUNDARY" value="0" enum="ShapeType">
 			Constant for creating a world boundary shape (used by the [WorldBoundaryShape3D] resource).

--- a/editor/icons/DistanceJoint3D.svg
+++ b/editor/icons/DistanceJoint3D.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke="#fc7f7f" stroke-width="2" d="M2 8v6h6M8 2h6v6M2 14 14 2"/></svg>

--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
@@ -33,6 +33,7 @@
 #include "editor/editor_node.h"
 #include "editor/settings/editor_settings.h"
 #include "scene/3d/physics/joints/cone_twist_joint_3d.h"
+#include "scene/3d/physics/joints/distance_joint_3d.h"
 #include "scene/3d/physics/joints/generic_6dof_joint_3d.h"
 #include "scene/3d/physics/joints/hinge_joint_3d.h"
 #include "scene/3d/physics/joints/pin_joint_3d.h"
@@ -276,6 +277,17 @@ void JointGizmosDrawer::draw_cone(const Transform3D &p_offset, const Basis &p_ba
 	}
 }
 
+void JointGizmosDrawer::draw_cross(const Transform3D &p_offset, const Vector3 &p_origin, Vector<Vector3> &r_points) {
+	float cs = 0.25;
+
+	r_points.push_back(p_offset.translated_local(p_origin + Vector3(+cs, 0, 0)).origin);
+	r_points.push_back(p_offset.translated_local(p_origin + Vector3(-cs, 0, 0)).origin);
+	r_points.push_back(p_offset.translated_local(p_origin + Vector3(0, +cs, 0)).origin);
+	r_points.push_back(p_offset.translated_local(p_origin + Vector3(0, -cs, 0)).origin);
+	r_points.push_back(p_offset.translated_local(p_origin + Vector3(0, 0, +cs)).origin);
+	r_points.push_back(p_offset.translated_local(p_origin + Vector3(0, 0, -cs)).origin);
+}
+
 ////
 
 Joint3DGizmoPlugin::Joint3DGizmoPlugin() {
@@ -457,17 +469,32 @@ void Joint3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		p_gizmo->add_lines(body_a_points, body_a_material);
 		p_gizmo->add_lines(body_b_points, body_b_material);
 	}
+
+	DistanceJoint3D *dist = Object::cast_to<DistanceJoint3D>(joint);
+	if (dist) {
+		CreateGenericDistanceJointGizmo(
+				Transform3D(),
+				dist->get_global_transform(),
+				dist->get_global_point(DistanceJoint3D::POINT_PARAM_A),
+				dist->get_global_point(DistanceJoint3D::POINT_PARAM_B),
+				dist->get_param(DistanceJoint3D::PARAM_DISTANCE_MIN),
+				dist->get_param(DistanceJoint3D::PARAM_DISTANCE_MAX),
+				points,
+				body_a_points,
+				body_b_points);
+
+		p_gizmo->add_collision_segments(points);
+		p_gizmo->add_collision_segments(body_a_points);
+		p_gizmo->add_collision_segments(body_b_points);
+
+		p_gizmo->add_lines(points, common_material);
+		p_gizmo->add_lines(body_a_points, body_a_material);
+		p_gizmo->add_lines(body_b_points, body_b_material);
+	}
 }
 
 void Joint3DGizmoPlugin::CreatePinJointGizmo(const Transform3D &p_offset, Vector<Vector3> &r_cursor_points) {
-	float cs = 0.25;
-
-	r_cursor_points.push_back(p_offset.translated_local(Vector3(+cs, 0, 0)).origin);
-	r_cursor_points.push_back(p_offset.translated_local(Vector3(-cs, 0, 0)).origin);
-	r_cursor_points.push_back(p_offset.translated_local(Vector3(0, +cs, 0)).origin);
-	r_cursor_points.push_back(p_offset.translated_local(Vector3(0, -cs, 0)).origin);
-	r_cursor_points.push_back(p_offset.translated_local(Vector3(0, 0, +cs)).origin);
-	r_cursor_points.push_back(p_offset.translated_local(Vector3(0, 0, -cs)).origin);
+	JointGizmosDrawer::draw_cross(p_offset, Vector3(0., 0., 0.), r_cursor_points);
 }
 
 void Joint3DGizmoPlugin::CreateHingeJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, const Transform3D &p_trs_body_a, const Transform3D &p_trs_body_b, real_t p_limit_lower, real_t p_limit_upper, bool p_use_limit, Vector<Vector3> &r_common_points, Vector<Vector3> *r_body_a_points, Vector<Vector3> *r_body_b_points) {
@@ -721,4 +748,25 @@ void Joint3DGizmoPlugin::CreateGeneric6DOFJointGizmo(
 	}
 
 #undef ADD_VTX
+}
+
+void Joint3DGizmoPlugin::CreateGenericDistanceJointGizmo(const Transform3D &p_offset,
+		const Transform3D &p_trs_joint,
+		const Vector3 &p_vec_global_a,
+		const Vector3 &p_vec_global_b,
+		real_t distance_min,
+		real_t distance_max,
+		Vector<Vector3> &r_cursor_points,
+		Vector<Vector3> &r_body_points_a,
+		Vector<Vector3> &r_body_points_b) {
+	const Transform3D inv_trs_joint = p_trs_joint.affine_inverse();
+	const Vector3 vec_local_a = inv_trs_joint.xform(p_vec_global_a);
+	const Vector3 vec_local_b = inv_trs_joint.xform(p_vec_global_b);
+
+	JointGizmosDrawer::draw_cross(p_offset, vec_local_a, r_body_points_a);
+	JointGizmosDrawer::draw_cross(p_offset, vec_local_b, r_body_points_b);
+
+	const Vector3 dir = (vec_local_b - vec_local_a).normalized();
+	r_cursor_points.push_back(vec_local_a + dir * distance_min);
+	r_cursor_points.push_back(vec_local_a + dir * distance_max);
 }

--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h
@@ -78,6 +78,15 @@ public:
 			Vector<Vector3> &r_points,
 			Vector<Vector3> *r_body_a_points,
 			Vector<Vector3> *r_body_b_points);
+	void CreateGenericDistanceJointGizmo(const Transform3D &p_offset,
+			const Transform3D &p_trs_joint,
+			const Vector3 &p_vec_global_a,
+			const Vector3 &p_vec_global_b,
+			real_t distance_min,
+			real_t distance_max,
+			Vector<Vector3> &r_cursor_points,
+			Vector<Vector3> &r_body_points_a,
+			Vector<Vector3> &r_body_points_b);
 
 	Joint3DGizmoPlugin();
 };
@@ -95,4 +104,5 @@ public:
 	// Draw circle around p_axis
 	static void draw_circle(Vector3::Axis p_axis, real_t p_radius, const Transform3D &p_offset, const Basis &p_base, real_t p_limit_lower, real_t p_limit_upper, Vector<Vector3> &r_points, bool p_inverse = false);
 	static void draw_cone(const Transform3D &p_offset, const Basis &p_base, real_t p_swing, real_t p_twist, Vector<Vector3> &r_points);
+	static void draw_cross(const Transform3D &p_offset, const Vector3 &p_origin, Vector<Vector3> &r_points);
 };

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1596,6 +1596,14 @@ bool GodotPhysicsServer3D::generic_6dof_joint_get_flag(RID p_joint, Vector3::Axi
 	return generic_6dof_joint->get_flag(p_axis, p_flag);
 }
 
+void GodotPhysicsServer3D::joint_make_distance(RID p_joint, RID p_body_a, const Vector3 &p_local_a, RID p_body_b, const Vector3 &p_local_b) {
+	ERR_FAIL_MSG("GodotPhysicsServer3D does not support distance constraint.");
+}
+
+void GodotPhysicsServer3D::distance_joint_set_param(RID p_joint, DistanceJointParam p_param, real_t p_value) {
+	ERR_FAIL_MSG("GodotPhysicsServer3D does not support distance constraint.");
+}
+
 void GodotPhysicsServer3D::free_rid(RID p_rid) {
 	_update_shapes(); //just in case
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -361,6 +361,10 @@ public:
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) override;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const override;
 
+	virtual void joint_make_distance(RID p_joint, RID p_body_a, const Vector3 &p_local_a, RID p_body_b, const Vector3 &p_local_b) override;
+
+	virtual void distance_joint_set_param(RID p_joint, DistanceJointParam p_param, real_t p_value) override;
+
 	virtual JointType joint_get_type(RID p_joint) const override;
 
 	virtual void joint_set_solver_priority(RID p_joint, int p_priority) override;

--- a/modules/jolt_physics/joints/jolt_distance_joint_3d.cpp
+++ b/modules/jolt_physics/joints/jolt_distance_joint_3d.cpp
@@ -1,0 +1,177 @@
+/**************************************************************************/
+/*  jolt_distance_joint_3d.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "jolt_distance_joint_3d.h"
+
+#include "../misc/jolt_type_conversions.h"
+#include "../objects/jolt_body_3d.h"
+#include "../spaces/jolt_space_3d.h"
+
+#include "Jolt/Physics/Constraints/DistanceConstraint.h"
+
+JoltDistanceJoint3D::JoltDistanceJoint3D(
+		const JoltJoint3D &p_old_joint,
+		JoltBody3D *p_body_a,
+		JoltBody3D *p_body_b,
+		const Vector3 &p_local_a,
+		const Vector3 &p_local_b) :
+		JoltJoint3D(
+				p_old_joint,
+				p_body_a,
+				p_body_b,
+				Transform3D({}, p_local_a),
+				Transform3D({}, p_local_b)) {
+	rebuild();
+}
+
+float JoltDistanceJoint3D::get_jolt_param(Param p_param) const {
+	switch (p_param) {
+		case JoltPhysicsServer3D::DISTANCE_JOINT_LIMITS_SPRING_STIFFNESS: {
+			return limit_spring_stiffness;
+		} break;
+		case JoltPhysicsServer3D::DISTANCE_JOINT_LIMITS_SPRING_DAMPING: {
+			return limit_spring_damping;
+		} break;
+		case JoltPhysicsServer3D::DISTANCE_JOINT_DISTANCE_MIN: {
+			return distance_min;
+		} break;
+		case JoltPhysicsServer3D::DISTANCE_JOINT_DISTANCE_MAX: {
+			return distance_max;
+		} break;
+		default: {
+			ERR_FAIL_V_MSG(0.0, vformat("Unhandled parameter: '%d'. This should not happen. Please report this.", p_param));
+		} break;
+	}
+}
+
+void JoltDistanceJoint3D::set_jolt_param(Param p_param, float p_value) {
+	switch (p_param) {
+		case JoltPhysicsServer3D::DISTANCE_JOINT_LIMITS_SPRING_STIFFNESS: {
+			limit_spring_stiffness = p_value;
+			_limit_spring_changed();
+		} break;
+		case JoltPhysicsServer3D::DISTANCE_JOINT_LIMITS_SPRING_DAMPING: {
+			limit_spring_damping = p_value;
+			_limit_spring_changed();
+		} break;
+		case JoltPhysicsServer3D::DISTANCE_JOINT_DISTANCE_MIN: {
+			distance_min = p_value;
+			_distance_changed();
+		} break;
+		case JoltPhysicsServer3D::DISTANCE_JOINT_DISTANCE_MAX: {
+			distance_max = p_value;
+			_distance_changed();
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'. This should not happen. Please report this.", p_param));
+		} break;
+	}
+}
+
+float JoltDistanceJoint3D::get_applied_force() const {
+	JPH::DistanceConstraint *constraint = static_cast<JPH::DistanceConstraint *>(jolt_ref.GetPtr());
+	ERR_FAIL_NULL_V(constraint, 0.0f);
+
+	JoltSpace3D *space = get_space();
+	ERR_FAIL_NULL_V(space, 0.0f);
+
+	const float last_step = space->get_last_step();
+	if (unlikely(last_step == 0.0f)) {
+		return 0.0f;
+	}
+
+	return constraint->GetTotalLambdaPosition() / last_step;
+}
+
+void JoltDistanceJoint3D::rebuild() {
+	destroy();
+
+	JoltSpace3D *space = get_space();
+
+	if (space == nullptr) {
+		return;
+	}
+
+	JPH::Body *jolt_body_a = body_a != nullptr ? body_a->get_jolt_body() : nullptr;
+	JPH::Body *jolt_body_b = body_b != nullptr ? body_b->get_jolt_body() : nullptr;
+
+	ERR_FAIL_COND(jolt_body_a == jolt_body_b);
+
+	Transform3D shifted_ref_a;
+	Transform3D shifted_ref_b;
+
+	_shift_reference_frames(Vector3(), Vector3(), shifted_ref_a, shifted_ref_b);
+
+	jolt_ref = _build_constraint(jolt_body_a, jolt_body_b, shifted_ref_a, shifted_ref_b);
+
+	space->add_joint(this);
+
+	_update_enabled();
+	_update_iterations();
+}
+
+JPH::Constraint *JoltDistanceJoint3D::_build_constraint(
+		JPH::Body *p_jolt_body_a,
+		JPH::Body *p_jolt_body_b,
+		const Transform3D &p_shifted_ref_a,
+		const Transform3D &p_shifted_ref_b) {
+	JPH::DistanceConstraintSettings constraint_settings;
+	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
+	constraint_settings.mPoint1 = to_jolt_r(p_shifted_ref_a.origin);
+	constraint_settings.mPoint2 = to_jolt_r(p_shifted_ref_b.origin);
+	constraint_settings.mMinDistance = distance_min;
+	constraint_settings.mMaxDistance = distance_max;
+	constraint_settings.mLimitsSpringSettings.mMode = JPH::ESpringMode::StiffnessAndDamping;
+	constraint_settings.mLimitsSpringSettings.mStiffness = limit_spring_stiffness;
+	constraint_settings.mLimitsSpringSettings.mDamping = limit_spring_damping;
+
+	if (p_jolt_body_a == nullptr) {
+		return constraint_settings.Create(JPH::Body::sFixedToWorld, *p_jolt_body_b);
+	} else if (p_jolt_body_b == nullptr) {
+		return constraint_settings.Create(*p_jolt_body_a, JPH::Body::sFixedToWorld);
+	} else {
+		return constraint_settings.Create(*p_jolt_body_a, *p_jolt_body_b);
+	}
+}
+
+void JoltDistanceJoint3D::_limit_spring_changed() {
+	rebuild();
+	_wake_up_bodies();
+}
+
+void JoltDistanceJoint3D::_limit_distance_changed() {
+	rebuild();
+	_wake_up_bodies();
+}
+
+void JoltDistanceJoint3D::_distance_changed() {
+	rebuild();
+	_wake_up_bodies();
+}

--- a/modules/jolt_physics/joints/jolt_distance_joint_3d.h
+++ b/modules/jolt_physics/joints/jolt_distance_joint_3d.h
@@ -1,0 +1,77 @@
+/**************************************************************************/
+/*  jolt_distance_joint_3d.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "../jolt_physics_server_3d.h"
+#include "jolt_joint_3d.h"
+
+#include "Jolt/Jolt.h"
+
+#include "Jolt/Physics/Body/Body.h"
+
+class JoltDistanceJoint3D final : public JoltJoint3D {
+	typedef PhysicsServer3D::DistanceJointParam Param;
+
+	JPH::Constraint *_build_constraint(
+			JPH::Body *p_jolt_body_a,
+			JPH::Body *p_jolt_body_b,
+			const Transform3D &p_shifted_ref_a,
+			const Transform3D &p_shifted_ref_b);
+
+	void _limit_spring_changed();
+	void _limit_distance_changed();
+	void _distance_changed();
+
+	float limit_spring_stiffness = 0.0;
+	float limit_spring_damping = 0.0;
+	float distance_min = 0.0;
+	float distance_max = INFINITY;
+
+public:
+	JoltDistanceJoint3D(
+			const JoltJoint3D &p_old_joint,
+			JoltBody3D *p_body_a,
+			JoltBody3D *p_body_b,
+			const Vector3 &p_local_a,
+			const Vector3 &p_local_b);
+
+	virtual PhysicsServer3D::JointType get_type() const override { return PhysicsServer3D::JOINT_TYPE_DISTANCE_JOINT; }
+
+	float get_jolt_param(Param p_param) const;
+	void set_jolt_param(Param p_param, float p_value);
+
+	Vector3 get_local_a() const { return local_ref_a.origin; }
+	Vector3 get_local_b() const { return local_ref_b.origin; }
+
+	float get_applied_force() const;
+
+	virtual void rebuild() override;
+};

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -31,6 +31,7 @@
 #include "jolt_physics_server_3d.h"
 
 #include "joints/jolt_cone_twist_joint_3d.h"
+#include "joints/jolt_distance_joint_3d.h"
 #include "joints/jolt_generic_6dof_joint_3d.h"
 #include "joints/jolt_hinge_joint_3d.h"
 #include "joints/jolt_joint_3d.h"
@@ -1547,6 +1548,41 @@ bool JoltPhysicsServer3D::generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis
 	return g6dof_joint->get_flag(p_axis, p_flag);
 }
 
+void JoltPhysicsServer3D::joint_make_distance(
+		RID p_joint,
+		RID p_body_a,
+		const Vector3 &p_local_a,
+		RID p_body_b,
+		const Vector3 &p_local_b) {
+	JoltJoint3D *old_joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(old_joint);
+
+	JoltBody3D *body_a = body_owner.get_or_null(p_body_a);
+	JoltBody3D *body_b = body_owner.get_or_null(p_body_b);
+	ERR_FAIL_COND(body_a == body_b);
+
+	JoltJoint3D *new_joint = memnew(
+			JoltDistanceJoint3D(*old_joint, body_a, body_b, p_local_a, p_local_b));
+
+	memdelete(old_joint);
+	old_joint = nullptr;
+
+	joint_owner.replace(p_joint, new_joint);
+}
+
+void JoltPhysicsServer3D::distance_joint_set_param(
+		RID p_joint,
+		PhysicsServer3D::DistanceJointParam p_param,
+		real_t p_value) {
+	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_DISTANCE_JOINT);
+	auto *distance_joint = static_cast<JoltDistanceJoint3D *>(joint);
+
+	return distance_joint->set_jolt_param(p_param, p_value);
+}
+
 PhysicsServer3D::JointType JoltPhysicsServer3D::joint_get_type(RID p_joint) const {
 	const JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, JOINT_TYPE_PIN);
@@ -2024,4 +2060,14 @@ float JoltPhysicsServer3D::generic_6dof_joint_get_applied_torque(RID p_joint) {
 	JoltGeneric6DOFJoint3D *g6dof_joint = static_cast<JoltGeneric6DOFJoint3D *>(joint);
 
 	return g6dof_joint->get_applied_torque();
+}
+
+float JoltPhysicsServer3D::distance_joint_get_applied_force(RID p_joint) {
+	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, 0.0f);
+
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_DISTANCE_JOINT, 0.0f);
+	JoltDistanceJoint3D *distance_joint = static_cast<JoltDistanceJoint3D *>(joint);
+
+	return distance_joint->get_applied_force();
 }

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -405,6 +405,10 @@ public:
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag, bool p_enable) override;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag) const override;
 
+	virtual void joint_make_distance(RID p_joint, RID p_body_a, const Vector3 &p_local_a, RID p_body_b, const Vector3 &p_local_b) override;
+
+	virtual void distance_joint_set_param(RID p_joint, DistanceJointParam p_param, real_t p_value) override;
+
 	virtual PhysicsServer3D::JointType joint_get_type(RID p_joint) const override;
 
 	virtual void joint_set_solver_priority(RID p_joint, int p_priority) override;
@@ -498,6 +502,8 @@ public:
 
 	float generic_6dof_joint_get_applied_force(RID p_joint);
 	float generic_6dof_joint_get_applied_torque(RID p_joint);
+
+	float distance_joint_get_applied_force(RID p_joint);
 };
 
 VARIANT_ENUM_CAST(JoltPhysicsServer3D::HingeJointParamJolt)

--- a/scene/3d/physics/joints/distance_joint_3d.cpp
+++ b/scene/3d/physics/joints/distance_joint_3d.cpp
@@ -1,0 +1,140 @@
+/**************************************************************************/
+/*  distance_joint_3d.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "distance_joint_3d.h"
+
+void DistanceJoint3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_param", "param", "value"), &DistanceJoint3D::set_param);
+	ClassDB::bind_method(D_METHOD("get_param", "param"), &DistanceJoint3D::get_param);
+	ClassDB::bind_method(D_METHOD("set_point_param", "point", "value"), &DistanceJoint3D::set_point_param);
+	ClassDB::bind_method(D_METHOD("get_point_param", "point"), &DistanceJoint3D::get_point_param);
+	ClassDB::bind_method(D_METHOD("get_global_point", "point"), &DistanceJoint3D::get_global_point);
+
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "spring/stiffness", PROPERTY_HINT_RANGE, "0,100,or_greater,hide_control,suffix:N/m"), "set_param", "get_param", PARAM_LIMITS_SPRING_STIFFNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "spring/damping", PROPERTY_HINT_RANGE, "0,2,or_greater,hide_control"), "set_param", "get_param", PARAM_LIMITS_SPRING_DAMPING);
+
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "distance/min", PROPERTY_HINT_RANGE, "0,100,or_greater,suffix:m"), "set_param", "get_param", PARAM_DISTANCE_MIN);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "distance/max", PROPERTY_HINT_RANGE, "0,100,or_greater,suffix:m"), "set_param", "get_param", PARAM_DISTANCE_MAX);
+
+	ADD_PROPERTYI(PropertyInfo(Variant::VECTOR3, "anchor/a"), "set_point_param", "get_point_param", POINT_PARAM_A);
+	ADD_PROPERTYI(PropertyInfo(Variant::VECTOR3, "anchor/b"), "set_point_param", "get_point_param", POINT_PARAM_B);
+
+	BIND_ENUM_CONSTANT(PARAM_LIMITS_SPRING_STIFFNESS);
+	BIND_ENUM_CONSTANT(PARAM_LIMITS_SPRING_DAMPING);
+	BIND_ENUM_CONSTANT(PARAM_DISTANCE_MIN);
+	BIND_ENUM_CONSTANT(PARAM_DISTANCE_MAX);
+	BIND_ENUM_CONSTANT(PARAM_MAX);
+
+	BIND_ENUM_CONSTANT(POINT_PARAM_A);
+	BIND_ENUM_CONSTANT(POINT_PARAM_B);
+}
+
+void DistanceJoint3D::set_param(Param p_param, real_t p_value) {
+	ERR_FAIL_INDEX(p_param, PARAM_MAX);
+	params[p_param] = p_value;
+	if (is_configured()) {
+		PhysicsServer3D::get_singleton()->distance_joint_set_param(get_rid(), PhysicsServer3D::DistanceJointParam(p_param), p_value);
+	}
+}
+
+real_t DistanceJoint3D::get_param(Param p_param) const {
+	ERR_FAIL_INDEX_V(p_param, PARAM_MAX, 0);
+	return params[p_param];
+}
+
+void DistanceJoint3D::set_point_param(PointParam p_param, const Vector3 &p_value) {
+	ERR_FAIL_INDEX(p_param, POINT_PARAM_MAX);
+	point_params[p_param] = p_value;
+	if (is_configured()) {
+		_disconnect_signals();
+		_update_joint();
+	}
+}
+
+Vector3 DistanceJoint3D::get_point_param(PointParam p_param) const {
+	ERR_FAIL_INDEX_V(p_param, POINT_PARAM_MAX, Vector3());
+	return point_params[p_param];
+}
+
+Vector3 DistanceJoint3D::get_global_point(PointParam p_param) const {
+	const PhysicsBody3D *body = _get_body_from_param(p_param);
+	const Vector3 local_point = get_point_param(p_param);
+	if (body == nullptr) {
+		return to_global(local_point);
+	}
+	return body->to_global(local_point);
+}
+
+PhysicsBody3D *DistanceJoint3D::_get_body_from_param(PointParam p_param) const {
+	const NodePath node_path = p_param == POINT_PARAM_A ? get_node_a() : get_node_b();
+	Node *node = get_node_or_null(node_path);
+	return Object::cast_to<PhysicsBody3D>(node);
+}
+
+void DistanceJoint3D::_configure_joint(RID p_joint, PhysicsBody3D * /*p_body_a is unused*/, PhysicsBody3D * /*p_body_b is unused*/) {
+	PhysicsServer3D *physics_server = PhysicsServer3D::get_singleton();
+	ERR_FAIL_NULL(physics_server);
+
+	const PhysicsBody3D *body_a = _get_body_from_param(POINT_PARAM_A);
+	const PhysicsBody3D *body_b = _get_body_from_param(POINT_PARAM_B);
+	const Vector3 point_a = get_point_param(POINT_PARAM_A);
+	const Vector3 point_b = get_point_param(POINT_PARAM_B);
+
+	physics_server->joint_make_distance(
+			p_joint,
+			body_a != nullptr ? body_a->get_rid() : RID(),
+			body_a != nullptr ? point_a : get_global_point(POINT_PARAM_A),
+			body_b != nullptr ? body_b->get_rid() : RID(),
+			body_b != nullptr ? point_b : get_global_point(POINT_PARAM_B));
+
+	for (int i = 0; i < PARAM_MAX; i++) {
+		physics_server->distance_joint_set_param(p_joint, PhysicsServer3D::DistanceJointParam(i), params[i]);
+	}
+}
+
+PackedStringArray DistanceJoint3D::get_configuration_warnings() const {
+	PackedStringArray warnings = Joint3D::get_configuration_warnings();
+
+	JoltPhysicsServer3D *jolt_physics_server = JoltPhysicsServer3D::get_singleton();
+	if (!jolt_physics_server) {
+		warnings.push_back(RTR("DistanceJoint3D is only compatible with Jolt Physics. Please change your Physics Engine in Project Settings."));
+	}
+	return warnings;
+}
+
+DistanceJoint3D::DistanceJoint3D() {
+	params[PARAM_LIMITS_SPRING_STIFFNESS] = 0.0;
+	params[PARAM_LIMITS_SPRING_DAMPING] = 0.0;
+	params[PARAM_DISTANCE_MIN] = 0.0;
+	params[PARAM_DISTANCE_MAX] = INFINITY;
+
+	point_params[POINT_PARAM_A] = Vector3(0.0, 0.0, 0.0);
+	point_params[POINT_PARAM_B] = Vector3(0.0, 0.0, 0.0);
+}

--- a/scene/3d/physics/joints/distance_joint_3d.h
+++ b/scene/3d/physics/joints/distance_joint_3d.h
@@ -1,0 +1,77 @@
+/**************************************************************************/
+/*  distance_joint_3d.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/3d/physics/joints/joint_3d.h"
+
+#include "modules/jolt_physics/jolt_physics_server_3d.h"
+
+class DistanceJoint3D : public Joint3D {
+	GDCLASS(DistanceJoint3D, Joint3D);
+
+public:
+	enum Param {
+		PARAM_LIMITS_SPRING_STIFFNESS = PhysicsServer3D::DISTANCE_JOINT_LIMITS_SPRING_STIFFNESS,
+		PARAM_LIMITS_SPRING_DAMPING = PhysicsServer3D::DISTANCE_JOINT_LIMITS_SPRING_DAMPING,
+		PARAM_DISTANCE_MIN = PhysicsServer3D::DISTANCE_JOINT_DISTANCE_MIN,
+		PARAM_DISTANCE_MAX = PhysicsServer3D::DISTANCE_JOINT_DISTANCE_MAX,
+		PARAM_MAX
+	};
+
+	enum PointParam {
+		POINT_PARAM_A,
+		POINT_PARAM_B,
+		POINT_PARAM_MAX
+	};
+
+protected:
+	real_t params[PARAM_MAX];
+	Vector3 point_params[POINT_PARAM_MAX];
+
+	virtual void _configure_joint(RID p_joint, PhysicsBody3D *p_body_a, PhysicsBody3D *p_body_b) override;
+	static void _bind_methods();
+	PhysicsBody3D *_get_body_from_param(PointParam p_param) const;
+
+public:
+	void set_param(Param p_param, real_t p_value);
+	real_t get_param(Param p_param) const;
+
+	void set_point_param(PointParam p_param, const Vector3 &p_value);
+	Vector3 get_point_param(PointParam p_param) const;
+	Vector3 get_global_point(PointParam p_param) const;
+
+	virtual PackedStringArray get_configuration_warnings() const override;
+
+	DistanceJoint3D();
+};
+
+VARIANT_ENUM_CAST(DistanceJoint3D::Param);
+VARIANT_ENUM_CAST(DistanceJoint3D::PointParam);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -340,6 +340,7 @@
 #include "scene/3d/physics/collision_polygon_3d.h"
 #include "scene/3d/physics/collision_shape_3d.h"
 #include "scene/3d/physics/joints/cone_twist_joint_3d.h"
+#include "scene/3d/physics/joints/distance_joint_3d.h"
 #include "scene/3d/physics/joints/generic_6dof_joint_3d.h"
 #include "scene/3d/physics/joints/hinge_joint_3d.h"
 #include "scene/3d/physics/joints/joint_3d.h"
@@ -757,6 +758,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(SliderJoint3D);
 	GDREGISTER_CLASS(ConeTwistJoint3D);
 	GDREGISTER_CLASS(Generic6DOFJoint3D);
+	GDREGISTER_CLASS(DistanceJoint3D);
 #endif // PHYSICS_3D_DISABLED
 
 #ifndef NAVIGATION_3D_DISABLED

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -918,6 +918,7 @@ void PhysicsServer3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(JOINT_TYPE_SLIDER);
 	BIND_ENUM_CONSTANT(JOINT_TYPE_CONE_TWIST);
 	BIND_ENUM_CONSTANT(JOINT_TYPE_6DOF);
+	BIND_ENUM_CONSTANT(JOINT_TYPE_DISTANCE_JOINT);
 	BIND_ENUM_CONSTANT(JOINT_TYPE_MAX);
 
 	ClassDB::bind_method(D_METHOD("joint_make_pin", "joint", "body_A", "local_A", "body_B", "local_B"), &PhysicsServer3D::joint_make_pin);
@@ -1042,6 +1043,15 @@ void PhysicsServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("generic_6dof_joint_set_flag", "joint", "axis", "flag", "enable"), &PhysicsServer3D::generic_6dof_joint_set_flag);
 	ClassDB::bind_method(D_METHOD("generic_6dof_joint_get_flag", "joint", "axis", "flag"), &PhysicsServer3D::generic_6dof_joint_get_flag);
+
+	BIND_ENUM_CONSTANT(DISTANCE_JOINT_LIMITS_SPRING_STIFFNESS);
+	BIND_ENUM_CONSTANT(DISTANCE_JOINT_LIMITS_SPRING_DAMPING);
+	BIND_ENUM_CONSTANT(DISTANCE_JOINT_DISTANCE_MIN);
+	BIND_ENUM_CONSTANT(DISTANCE_JOINT_DISTANCE_MAX);
+
+	ClassDB::bind_method(D_METHOD("joint_make_distance", "joint", "body_A", "local_ref_A", "body_B", "local_ref_B"), &PhysicsServer3D::joint_make_distance);
+
+	ClassDB::bind_method(D_METHOD("distance_joint_set_param", "joint", "param", "value"), &PhysicsServer3D::distance_joint_set_param);
 
 	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &PhysicsServer3D::free_rid);
 

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -643,8 +643,8 @@ public:
 		JOINT_TYPE_SLIDER,
 		JOINT_TYPE_CONE_TWIST,
 		JOINT_TYPE_6DOF,
+		JOINT_TYPE_DISTANCE_JOINT,
 		JOINT_TYPE_MAX,
-
 	};
 
 	virtual RID joint_create() = 0;
@@ -793,6 +793,17 @@ public:
 
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) = 0;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const = 0;
+
+	enum DistanceJointParam {
+		DISTANCE_JOINT_LIMITS_SPRING_STIFFNESS,
+		DISTANCE_JOINT_LIMITS_SPRING_DAMPING,
+		DISTANCE_JOINT_DISTANCE_MIN,
+		DISTANCE_JOINT_DISTANCE_MAX,
+	};
+
+	virtual void joint_make_distance(RID p_joint, RID p_body_a, const Vector3 &p_local_a, RID p_body_b, const Vector3 &p_local_b) = 0;
+
+	virtual void distance_joint_set_param(RID p_joint, DistanceJointParam p_param, real_t p_value) = 0;
 
 	/* QUERY API */
 
@@ -1070,5 +1081,6 @@ VARIANT_ENUM_CAST(PhysicsServer3D::SliderJointParam);
 VARIANT_ENUM_CAST(PhysicsServer3D::ConeTwistJointParam);
 VARIANT_ENUM_CAST(PhysicsServer3D::G6DOFJointAxisParam);
 VARIANT_ENUM_CAST(PhysicsServer3D::G6DOFJointAxisFlag);
+VARIANT_ENUM_CAST(PhysicsServer3D::DistanceJointParam);
 VARIANT_ENUM_CAST(PhysicsServer3D::AreaBodyStatus);
 VARIANT_ENUM_CAST(PhysicsServer3D::ProcessInfo);

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -423,6 +423,10 @@ public:
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) override {}
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const override { return false; }
 
+	virtual void joint_make_distance(RID p_joint, RID p_body_a, const Vector3 &p_local_a, RID p_body_b, const Vector3 &p_local_b) override {}
+
+	virtual void distance_joint_set_param(RID p_joint, DistanceJointParam p_param, real_t p_value) override {}
+
 	/* MISC */
 
 	virtual void free_rid(RID p_rid) override {}

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -522,6 +522,10 @@ public:
 	EXBIND4(generic_6dof_joint_set_flag, RID, Vector3::Axis, G6DOFJointAxisFlag, bool)
 	EXBIND3RC(bool, generic_6dof_joint_get_flag, RID, Vector3::Axis, G6DOFJointAxisFlag)
 
+	EXBIND5(joint_make_distance, RID, RID, const Vector3 &, RID, const Vector3 &)
+
+	EXBIND3(distance_joint_set_param, RID, DistanceJointParam, real_t)
+
 	EXBIND1RC(JointType, joint_get_type, RID)
 
 	EXBIND2(joint_set_solver_priority, RID, int)

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -384,6 +384,10 @@ public:
 	FUNC4(generic_6dof_joint_set_flag, RID, Vector3::Axis, G6DOFJointAxisFlag, bool)
 	FUNC3RC(bool, generic_6dof_joint_get_flag, RID, Vector3::Axis, G6DOFJointAxisFlag)
 
+	FUNC5(joint_make_distance, RID, RID, const Vector3 &, RID, const Vector3 &)
+
+	FUNC3(distance_joint_set_param, RID, DistanceJointParam, real_t)
+
 	FUNC1RC(JointType, joint_get_type, RID);
 
 	FUNC2(joint_set_solver_priority, RID, int);


### PR DESCRIPTION
Relevant Proposal: [Implement extra physics constraints (joints) from Jolt #11338](https://github.com/godotengine/godot-proposals/issues/11338)

This PR exposes Jolt's Distance Constraint to Godot.

### Why add Distance Constraint?
Distance constraint is incredibly useful because it implements behavior similar to a rope, by constraining the distance between two objects.
Distance constraint's behavior cannot be replicated with the existing joints. While it might seem like Distance Constraint's behavior can be replicated with 6DoF joint, there are important differences:
- 6DOF - If you set linear limits of x, y, & z to [-1, 1] then the bounds of the constraint act like a cube.
- 6DOF - If you set the linear limits of x & z to 0 and linear limits of y to [-1, 1] the bounds of the constraint act like a cone pointing down.
- Distance Constraint - the bounds of the constraint are shaped like a sphere.


Image example of Distance Constraint in action:
- Left: `StaticBody3D` connected to `RigidBody3D`
- Middle: global point connected to `RigidBody3D`
- Right: `RigidBody3D` connected to `RigidBody3D`

https://github.com/user-attachments/assets/e9cbcb22-ed95-4f2a-81e7-9196ab5594a5



### Gizmo
The `DistanceConstraint3D` Gizmo creates a cross at the points which are being constrained. Then draws a line from Point A to Point B. The line starts `distance_min` from Point A and ends `distance_max` from Point A; such that the distance constraint is communicated to users.

Image example of `DistanceConstraint3D` Gizmo in editor:

![DistanceConstraintGizmoExample](https://github.com/user-attachments/assets/102b4d7c-cc64-4d94-a75f-23764952660a)


### Implementation
The parameters of the Contraint which are exposed to users are:
- Spring Frequency
- Spring Damping
- Distance Max/Min
- Body A/B
- Point A/B (on Body A/B respectively)

It is possible to expose Stiffness as a replacement for Frequency, but this was not included for the sake of simplicity at the moment.

An important part of the implementation has to do with "How best to communicate to users that DistanceConstraint3D is only compatible with Jolt Physics engine."
(All approaches provide clear notes in the docs, error messages, and configuration warnings to communicate to users that the distance constraint is only compatible with Jolt).

Approach 1 (Connect directly to JoltPhysics Server) - Name the component `JoltDistanceConstraint3D` and connect it directly to the `JoltPhysicsServer3D`. Always show the component in the "Create new node" dialog. This approach was not chosen because of how different it is from the implementation of the other Godot joints.

Approach 2 (Hide constraint sometimes) - Name the component `DistanceConstraint3D` and expose distance constraint functions in `PhysicsServer3D.` Hide the `DistanceConstraint3D` component when the user is not using Jolt Physics engine. This would be done by setting the `GDCLASS`'s `exposed = false` in `ClassDb`. Then set `exposed = true` when Jolt Physics engine starts. This would hide the class for default physics engine.
This approach was not chosen because it would require special modifications to `doctool` to prevent the docs for `DistanceConstraint3D` from getting removed automatically. It also may lead to some confusion for users when they know `DistanceConstraint3D` should exist, but they can't find it in the "Create new node" dialog.

Approach 3 (Always show constraint) - Name the component `DistanceConstraint3D` and expose distance constraint functions in `PhysicsServer3D. Always expose `DistanceConstraint3D` to users. This way the user can always find the `DistanceConstraint3D` and they will know what requirements must be met in order to use the constraint based on the docs, error messages, and configuration warnings.

Image example of error messages when using `DistanceConstraint3D` with `GodotPhysicsServer3D`.
![DistanceConstraintErrorMsg](https://github.com/user-attachments/assets/c76a40b4-e6e3-47e4-9916-cbb771f8dde6)