### PR TITLE
CPUParticles2D: Fix physics interpolation after entering tree with `emitting = false`

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1194,8 +1194,6 @@ void CPUParticles2D::_notification(int p_what) {
 
 			_refresh_interpolation_state();
 
-			set_physics_process_internal(emitting && _interpolation_data.interpolated_follow);
-
 			// If we are interpolated following, then reset physics interpolation
 			// when first appearing. This won't be called by canvas item, as in the
 			// following mode, is_physics_interpolated() is actually FALSE.


### PR DESCRIPTION
This line was left over from earlier testing; the intended functionality is now contained in `_refresh_interpolation_state()`.

- Fixes https://github.com/godotengine/godot/issues/103916