### PR TITLE
GUI: Fix focus cycle through window

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -467,7 +467,7 @@ AcceptDialog::AcceptDialog() {
 	message_label->set_anchor(SIDE_BOTTOM, Control::ANCHOR_END);
 	add_child(message_label, false, INTERNAL_MODE_FRONT);
 
-	add_child(buttons_hbox, false, INTERNAL_MODE_FRONT);
+	add_child(buttons_hbox, false, INTERNAL_MODE_BACK);
 
 	buttons_hbox->add_spacer();
 	ok_button = memnew(Button);

--- a/tests/scene/test_control.h
+++ b/tests/scene/test_control.h
@@ -162,7 +162,54 @@ TEST_CASE("[SceneTree][Control] Find next/prev valid focus") {
 			CHECK_UNARY(ctrl->has_focus());
 		}
 
-		SUBCASE("[SceneTree][Control] Has a sibling control but the parent node is not a control") {
+		SUBCASE("[SceneTree][Control] Has a sibling control and the parent is a window") {
+			Control *ctrl1 = memnew(Control);
+			Control *ctrl2 = memnew(Control);
+			Control *ctrl3 = memnew(Control);
+			Window *win = SceneTree::get_singleton()->get_root();
+
+			ctrl1->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+			ctrl2->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+			ctrl3->set_focus_mode(Control::FocusMode::FOCUS_ALL);
+
+			ctrl2->add_child(ctrl3);
+			win->add_child(ctrl1);
+			win->add_child(ctrl2);
+
+			SUBCASE("[SceneTree][Control] Focus Next") {
+				ctrl1->grab_focus();
+				CHECK_UNARY(ctrl1->has_focus());
+
+				SEND_GUI_ACTION("ui_focus_next");
+				CHECK_UNARY(ctrl2->has_focus());
+
+				SEND_GUI_ACTION("ui_focus_next");
+				CHECK_UNARY(ctrl3->has_focus());
+
+				SEND_GUI_ACTION("ui_focus_next");
+				CHECK_UNARY(ctrl1->has_focus());
+			}
+
+			SUBCASE("[SceneTree][Control] Focus Prev") {
+				ctrl1->grab_focus();
+				CHECK_UNARY(ctrl1->has_focus());
+
+				SEND_GUI_ACTION("ui_focus_prev");
+				CHECK_UNARY(ctrl3->has_focus());
+
+				SEND_GUI_ACTION("ui_focus_prev");
+				CHECK_UNARY(ctrl2->has_focus());
+
+				SEND_GUI_ACTION("ui_focus_prev");
+				CHECK_UNARY(ctrl1->has_focus());
+			}
+
+			memdelete(ctrl3);
+			memdelete(ctrl1);
+			memdelete(ctrl2);
+		}
+
+		SUBCASE("[SceneTree][Control] Has a sibling control but the parent node is not a control or window") {
 			Control *other_ctrl = memnew(Control);
 			intermediate->add_child(other_ctrl);
 


### PR DESCRIPTION
Fixes #103227

The issue was actually introduced with the 4.0 release. The code to cycle through the focus was only accounting for `Control` but starting with 4.0 dialogs are not `Control`s anymore. This PR adds special handling for direct `Control` subtrees of a `Window` which allows jumping between those subtrees.