### PR TITLE
OpenXR: Fix OpenGL version warning when using GLES

### DIFF
--- a/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
@@ -141,7 +141,12 @@ XrGraphicsBindingEGLMNDX OpenXROpenGLExtension::graphics_binding_egl;
 #endif
 
 void *OpenXROpenGLExtension::set_session_create_and_get_next_pointer(void *p_next_pointer) {
-	XrVersion desired_version = XR_MAKE_VERSION(3, 3, 0);
+	GLint gl_version_major = 0;
+	GLint gl_version_minor = 0;
+	glGetIntegerv(GL_MAJOR_VERSION, &gl_version_major);
+	glGetIntegerv(GL_MINOR_VERSION, &gl_version_minor);
+
+	XrVersion desired_version = XR_MAKE_VERSION(gl_version_major, gl_version_minor, 0);
 
 	if (!check_graphics_api_support(desired_version)) {
 		print_line("OpenXR: Trying to initialize with OpenGL anyway...");


### PR DESCRIPTION
This fixes this warning that we've had forever on some platforms (for example, Meta Quest):

```
OpenXR: Requested OpenGL version exceeds the maximum version this runtime has been tested on and is known to support.
- desired_version  3.3.0
- minApiVersionSupported  3.0.0
- maxApiVersionSupported  3.2.0
```

This warning is from asking the OpenXR runtime which versions of OpenGL it supports, and then comparing that with the version of OpenGL that we're using.

We've had our OpenGL version hardcoded at 3.3 -- which is true if we're on desktop and doing "GLES over GL" -- however, on mobile we're actually using GLES and could be using any version of GLES3 (on Android, at least, we're only requesting version 3 and not getting more specific than that).

So, this PR will actually check the OpenGL version we're using, rather than just hard-coding it to 3.3.

This fixes the warning for me on Meta Quest, where we're actually using GLES 3.2, which falls within the supported range of 3.0 to 3.2.

_(Note: this finally occurred to me based on something @akien-mga wrote [here](https://github.com/godotengine/godot/issues/103915#issuecomment-2713886521) - thanks Akien! Maybe we can get rid of this annoying warning that has been confusing users for a long time :-))_