### PR TITLE
Clear Orphaned Node Connections.

### DIFF
--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -73,6 +73,8 @@ void NodeDock::_notification(int p_what) {
 void NodeDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_save_layout_to_config"), &NodeDock::_save_layout_to_config);
 	ClassDB::bind_method(D_METHOD("_load_layout_from_config"), &NodeDock::_load_layout_from_config);
+
+	ClassDB::bind_method(D_METHOD("update_lists"), &NodeDock::update_lists);
 }
 
 void NodeDock::update_lists() {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -30,6 +30,7 @@
 
 #include "scene_tree_dock.h"
 
+#include "connections_dialog.h"
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/io/resource_saver.h"
@@ -2777,6 +2778,7 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 		}
 
 		//delete for read
+		bool connections_changed = false;
 		for (Node *n : remove_list) {
 			if (!n->is_inside_tree() || !n->get_parent()) {
 				continue;
@@ -2787,6 +2789,22 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 			Array owners;
 			for (Node *F : owned) {
 				owners.push_back(F);
+			}
+
+			// Cleanup any signals connected to this node.
+			List<Connection> connections_for_removed_node;
+			n->get_signals_connected_to_this(&connections_for_removed_node);
+			for (Connection conn : connections_for_removed_node) {
+				ConnectDialog::ConnectionData cd = conn;
+				if (!remove_list.find(cd.source)) {
+					Node *source = cd.source;
+					Callable callable = cd.get_callable();
+
+					undo_redo->add_do_method(source, "disconnect", cd.signal, callable);
+					undo_redo->add_undo_method(source, "connect", cd.signal, callable, cd.flags);
+
+					connections_changed = true;
+				}
 			}
 
 			undo_redo->add_do_method(n->get_parent(), "remove_child", n);
@@ -2801,6 +2819,10 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 			EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
 			undo_redo->add_do_method(ed, "live_debug_remove_and_keep_node", edited_scene->get_path_to(n), n->get_instance_id());
 			undo_redo->add_undo_method(ed, "live_debug_restore_node", n->get_instance_id(), edited_scene->get_path_to(n->get_parent()), n->get_index(false));
+		}
+		if (connections_changed) {
+			undo_redo->add_do_method(NodeDock::get_singleton(), "update_lists");
+			undo_redo->add_undo_method(NodeDock::get_singleton(), "update_lists");
 		}
 	}
 	undo_redo->commit_action();


### PR DESCRIPTION
Fully closes https://github.com/godotengine/godot/issues/101854

While we just merged a PR which will prevent a crash, this should provide the correct way of handling orphaned signals when casually deleting nodes via the SceneTreeDock. Ensures that node connections are properly disconnected/reconnected when deleting nodes via UndoRedo. Orphaned signal connections are properly removed upon saving a scene, so removing them immediately should be fine and will prevent cryptic errors from popping up.