### PR TITLE
Clear Editor Plugins for Folded Inspector Sub-Properties.

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3221,6 +3221,27 @@ bool EditorPropertyResource::_should_stop_editing() const {
 	return !resource_picker->is_toggle_pressed();
 }
 
+bool EditorPropertyResource::_is_editor_opened_in_sub_properties() const {
+	if (sub_inspector) {
+		for (const KeyValue<StringName, List<EditorProperty *>> &F : sub_inspector->editor_property_map) {
+			for (EditorProperty *E : F.value) {
+				EditorPropertyResource *res = Object::cast_to<EditorPropertyResource>(E);
+				if (res) {
+					if (res->opened_editor) {
+						return true;
+					} else {
+						if (res->_is_editor_opened_in_sub_properties()) {
+							return true;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return false;
+}
+
 void EditorPropertyResource::_viewport_selected(const NodePath &p_path) {
 	Node *to_node = get_node(p_path);
 	if (!Object::cast_to<Viewport>(to_node)) {
@@ -3334,6 +3355,10 @@ void EditorPropertyResource::update_property() {
 			}
 
 		} else if (sub_inspector) {
+			if (!opened_editor) {
+				opened_editor = _is_editor_opened_in_sub_properties();
+			}
+
 			set_bottom_editor(nullptr);
 			memdelete(sub_inspector);
 			sub_inspector = nullptr;

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -688,6 +688,8 @@ class EditorPropertyResource : public EditorProperty {
 	void _update_preferred_shader();
 	bool _should_stop_editing() const;
 
+	bool _is_editor_opened_in_sub_properties() const;
+
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/103976

Possibly addresses this issue https://github.com/godotengine/godot/issues/103615, but more testing is required.

This PR fixes a minor bug where the EditorPropertyResources which had corresponding editor plugins associated with a descendent properties, would not cleanup editor plugins from the list if the ancestor property was folded. It does this now by simply walking the sub-inspector and recursively checking the property maps beneath it until it finds another EditorPropertyResource with the 'opened_editor' flag set. If one is found, it will perform the cleanup hide_unused_editors method. An example of this error occurring is when opening a Shader resource inside a ShaderMaterial resource assigned to a MeshInstance, then selecting and deselecting the ShaderMaterial property in the inspector.