### PR TITLE
Fix global classes can't be used in the Evaluator

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -544,25 +544,60 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 					break;
 				}
 
+				PackedStringArray input_names;
+				Array input_vals;
+
 				List<String> locals;
 				List<Variant> local_vals;
-
 				script_debugger->get_break_language()->debug_get_stack_level_locals(frame, &locals, &local_vals);
 				ERR_FAIL_COND(locals.size() != local_vals.size());
 
-				PackedStringArray locals_vector;
 				for (const String &S : locals) {
-					locals_vector.append(S);
+					input_names.append(S);
 				}
 
-				Array local_vals_array;
 				for (const Variant &V : local_vals) {
-					local_vals_array.append(V);
+					input_vals.append(V);
+				}
+
+				List<String> globals;
+				List<Variant> globals_vals;
+				script_debugger->get_break_language()->debug_get_globals(&globals, &globals_vals);
+				ERR_FAIL_COND(globals.size() != globals_vals.size());
+
+				for (const String &S : globals) {
+					input_names.append(S);
+				}
+
+				for (const Variant &V : globals_vals) {
+					input_vals.append(V);
+				}
+
+				List<StringName> native_types;
+				ClassDB::get_class_list(&native_types);
+				for (const StringName &E : native_types) {
+					if (!ClassDB::is_class_exposed(E) || !Engine::get_singleton()->has_singleton(E) || Engine::get_singleton()->is_singleton_editor_only(E)) {
+						continue;
+					}
+
+					input_names.append(E);
+					input_vals.append(Engine::get_singleton()->get_singleton_object(E));
+				}
+
+				List<StringName> user_types;
+				ScriptServer::get_global_class_list(&user_types);
+				for (const StringName &S : user_types) {
+					String scr_path = ScriptServer::get_global_class_path(S);
+					Ref<Script> scr = ResourceLoader::load(scr_path, "Script");
+					ERR_CONTINUE_MSG(scr.is_null(), vformat(R"(Could not load the global class %s from resource path: "%s".)", S, scr_path));
+
+					input_names.append(S);
+					input_vals.append(scr);
 				}
 
 				Expression expression;
-				expression.parse(expression_str, locals_vector);
-				const Variant return_val = expression.execute(local_vals_array, breaked_instance->get_owner());
+				expression.parse(expression_str, input_names);
+				const Variant return_val = expression.execute(input_vals, breaked_instance->get_owner());
 
 				DebuggerMarshalls::ScriptStackVariable stvar;
 				stvar.name = expression_str;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/103963
- Fixes https://github.com/godotengine/godot/issues/99004

Makes built-in, user-defined, and autoload classes available for static access in the Evaluator.