### PR TITLE
Add "Paste as Unique" option to the editor resource picker dropdown

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -290,6 +290,7 @@ void EditorResourcePicker::_update_menu_items() {
 
 		if (paste_valid) {
 			edit_menu->add_item(TTR("Paste"), OBJ_MENU_PASTE);
+			edit_menu->add_item(TTRC("Paste as Unique"), OBJ_MENU_PASTE_AS_UNIQUE);
 		}
 	}
 
@@ -439,12 +440,20 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			EditorSettings::get_singleton()->set_resource_clipboard(edited_resource);
 		} break;
 
-		case OBJ_MENU_PASTE: {
+		case OBJ_MENU_PASTE:
+		case OBJ_MENU_PASTE_AS_UNIQUE: {
 			edited_resource = EditorSettings::get_singleton()->get_resource_clipboard();
-			if (edited_resource->is_built_in() && EditorNode::get_singleton()->get_edited_scene() &&
-					edited_resource->get_path().get_slice("::", 0) != EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path()) {
-				// Automatically make resource unique if it belongs to another scene.
-				_edit_menu_cbk(OBJ_MENU_MAKE_UNIQUE);
+			if (p_which == OBJ_MENU_PASTE_AS_UNIQUE ||
+					(EditorNode::get_singleton()->get_edited_scene() && edited_resource->is_built_in() && edited_resource->get_path().get_slice("::", 0) != EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path())) {
+				// Automatically make resource unique if it belongs to another scene,
+				// or if requested by the user with the Paste as Unique option.
+				if (p_which == OBJ_MENU_PASTE_AS_UNIQUE) {
+					// Use the recursive version when using Paste as Unique.
+					// This will show up a dialog to select which resources to make unique.
+					_edit_menu_cbk(OBJ_MENU_MAKE_UNIQUE_RECURSIVE);
+				} else {
+					_edit_menu_cbk(OBJ_MENU_MAKE_UNIQUE);
+				}
 				return;
 			}
 			_resource_changed();

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -75,6 +75,7 @@ class EditorResourcePicker : public HBoxContainer {
 		OBJ_MENU_SAVE_AS,
 		OBJ_MENU_COPY,
 		OBJ_MENU_PASTE,
+		OBJ_MENU_PASTE_AS_UNIQUE,
 		OBJ_MENU_SHOW_IN_FILE_SYSTEM,
 
 		TYPE_BASE_ID = 100,


### PR DESCRIPTION
This is equivalent to using **Paste**, then immediately using **Make Unique** afterwards. This saves time when pasting a resource that you know will need to be unique.

- This closes https://github.com/godotengine/godot-proposals/issues/7492.

## Preview

*If **Paste** was used instead of **Paste as Unique**, both meshes' colors would change at the same time at the end.*

https://github.com/user-attachments/assets/7c6ed58a-7514-49d1-aea5-5004788be642

