### PR TITLE
Remove empty constructors and destructors from `editor/`

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -8118,9 +8118,6 @@ AnimationTrackKeyEditEditor::AnimationTrackKeyEditEditor(Ref<Animation> p_animat
 	spinner->connect("value_focus_exited", callable_mp(this, &AnimationTrackKeyEditEditor::_time_edit_exited), CONNECT_DEFERRED);
 }
 
-AnimationTrackKeyEditEditor::~AnimationTrackKeyEditEditor() {
-}
-
 void AnimationMarkerEdit::_zoom_changed() {
 	queue_redraw();
 	play_position->queue_redraw();
@@ -9109,9 +9106,6 @@ AnimationMarkerEdit::AnimationMarkerEdit() {
 	marker_rename_confirm->add_child(marker_rename_error_dialog);
 }
 
-AnimationMarkerEdit::~AnimationMarkerEdit() {
-}
-
 float AnimationMarkerKeyEdit::get_time() const {
 	return animation->get_marker_time(marker_name);
 }
@@ -9298,7 +9292,4 @@ AnimationMarkerKeyEditEditor::AnimationMarkerKeyEditEditor(Ref<Animation> p_anim
 
 	spinner->connect("ungrabbed", callable_mp(this, &AnimationMarkerKeyEditEditor::_time_edit_exited), CONNECT_DEFERRED);
 	spinner->connect("value_focus_exited", callable_mp(this, &AnimationMarkerKeyEditEditor::_time_edit_exited), CONNECT_DEFERRED);
-}
-
-AnimationMarkerKeyEditEditor::~AnimationMarkerKeyEditEditor() {
 }

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -403,7 +403,6 @@ public:
 	void _clear_selection(bool p_update);
 
 	AnimationMarkerEdit();
-	~AnimationMarkerEdit();
 };
 
 class AnimationTrackEdit : public Control {
@@ -983,7 +982,6 @@ class AnimationTrackKeyEditEditor : public EditorProperty {
 
 public:
 	AnimationTrackKeyEditEditor(Ref<Animation> p_animation, int p_track, real_t p_key_ofs, bool p_use_fps);
-	~AnimationTrackKeyEditEditor();
 };
 
 // AnimationMarkerKeyEditEditorPlugin
@@ -1001,5 +999,4 @@ class AnimationMarkerKeyEditEditor : public EditorProperty {
 
 public:
 	AnimationMarkerKeyEditEditor(Ref<Animation> p_animation, const StringName &p_name, bool p_use_fps);
-	~AnimationMarkerKeyEditEditor();
 };

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -1322,9 +1322,6 @@ void AnimationTrackEditTypeAnimation::set_node(Object *p_object) {
 	id = p_object->get_instance_id();
 }
 
-AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
-}
-
 /////////
 AnimationTrackEdit *AnimationTrackEditDefaultPlugin::create_value_track_edit(Object *p_object, Variant::Type p_type, const String &p_property, PropertyHint p_hint, const String &p_hint_string, int p_usage) {
 	if (p_property == "playing" && (p_object->is_class("AudioStreamPlayer") || p_object->is_class("AudioStreamPlayer2D") || p_object->is_class("AudioStreamPlayer3D"))) {

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -87,8 +87,6 @@ public:
 
 	void set_node(Object *p_object);
 	void set_as_coords();
-
-	AnimationTrackEditSpriteFrame() {}
 };
 
 class AnimationTrackEditSubAnim : public AnimationTrackEdit {
@@ -145,7 +143,6 @@ public:
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 	void set_node(Object *p_object);
-	AnimationTrackEditTypeAnimation();
 };
 
 class AnimationTrackEditVolumeDB : public AnimationTrackEdit {

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -1662,6 +1662,3 @@ ConnectionsDock::ConnectionsDock() {
 
 	add_theme_constant_override("separation", 3 * EDSCALE);
 }
-
-ConnectionsDock::~ConnectionsDock() {
-}

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -268,5 +268,4 @@ public:
 	void update_tree();
 
 	ConnectionsDock();
-	~ConnectionsDock();
 };

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -63,8 +63,6 @@ public:
 	}
 
 	void update() { notify_property_list_changed(); }
-
-	EditorDebuggerRemoteObjects() {}
 };
 
 class EditorDebuggerInspector : public EditorInspector {

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -37,8 +37,6 @@
 #include "editor/themes/editor_theme_manager.h"
 #include "main/performance.h"
 
-EditorPerformanceProfiler::Monitor::Monitor() {}
-
 EditorPerformanceProfiler::Monitor::Monitor(const String &p_name, const String &p_base, int p_frame_index, Performance::MonitorType p_type, TreeItem *p_item) {
 	type = p_type;
 	item = p_item;

--- a/editor/debugger/editor_performance_profiler.h
+++ b/editor/debugger/editor_performance_profiler.h
@@ -51,7 +51,7 @@ private:
 		Performance::MonitorType type = Performance::MONITOR_TYPE_QUANTITY;
 		int frame_index = 0;
 
-		Monitor();
+		Monitor() {}
 		Monitor(const String &p_name, const String &p_base, int p_frame_index, Performance::MonitorType p_type, TreeItem *p_item);
 		void update_value(float p_value);
 		void reset();

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -340,5 +340,3 @@ EditorAbout::EditorAbout() {
 	tpl_ti_all->select(0);
 	_tpl_text->set_text(tpl_ti_all->get_metadata(0));
 }
-
-EditorAbout::~EditorAbout() {}

--- a/editor/editor_about.h
+++ b/editor/editor_about.h
@@ -61,5 +61,4 @@ protected:
 
 public:
 	EditorAbout();
-	~EditorAbout();
 };

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1050,9 +1050,6 @@ void EditorAudioBusDrop::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("dropped"));
 }
 
-EditorAudioBusDrop::EditorAudioBusDrop() {
-}
-
 void EditorAudioBuses::_rebuild_buses() {
 	for (int i = bus_hb->get_child_count() - 1; i >= 0; i--) {
 		EditorAudioBus *audio_bus = Object::cast_to<EditorAudioBus>(bus_hb->get_child(i));
@@ -1406,9 +1403,6 @@ void AudioBusesEditorPlugin::make_visible(bool p_visible) {
 
 AudioBusesEditorPlugin::AudioBusesEditorPlugin(EditorAudioBuses *p_node) {
 	audio_bus_editor = p_node;
-}
-
-AudioBusesEditorPlugin::~AudioBusesEditorPlugin() {
 }
 
 void EditorAudioMeterNotches::add_notch(float p_normalized_offset, float p_db_value, bool p_render_value) {

--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -145,9 +145,6 @@ class EditorAudioBusDrop : public Control {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
-
-public:
-	EditorAudioBusDrop();
 };
 
 class EditorAudioBuses : public VBoxContainer {
@@ -262,9 +259,6 @@ private:
 	static void _bind_methods();
 	void _notification(int p_what);
 	void _draw_audio_notches();
-
-public:
-	EditorAudioMeterNotches() {}
 };
 
 class AudioBusesEditorPlugin : public EditorPlugin {
@@ -280,5 +274,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	AudioBusesEditorPlugin(EditorAudioBuses *p_node);
-	~AudioBusesEditorPlugin();
 };

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1356,9 +1356,6 @@ void EditorSelection::clear() {
 	node_list_changed = true;
 }
 
-EditorSelection::EditorSelection() {
-}
-
 EditorSelection::~EditorSelection() {
 	clear();
 }

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -324,6 +324,5 @@ public:
 	// Returns the map of selected objects and their metadata.
 	HashMap<Node *, Object *> &get_selection() { return selection; }
 
-	EditorSelection();
 	~EditorSelection();
 };

--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -294,6 +294,3 @@ void EditorFolding::unfold_scene(Node *p_scene) {
 	HashSet<Ref<Resource>> resources;
 	_do_node_unfolds(p_scene, p_scene, resources);
 }
-
-EditorFolding::EditorFolding() {
-}

--- a/editor/editor_folding.h
+++ b/editor/editor_folding.h
@@ -51,6 +51,4 @@ public:
 	void unfold_scene(Node *p_scene);
 
 	bool has_folding_data(const String &p_path);
-
-	EditorFolding();
 };

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -3367,9 +3367,6 @@ EditorHelp::EditorHelp() {
 	class_desc->hide();
 }
 
-EditorHelp::~EditorHelp() {
-}
-
 /// EditorHelpBit ///
 
 #define HANDLE_DOC(m_string) ((is_native ? DTR(m_string) : (m_string)).strip_edges())

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -269,7 +269,6 @@ public:
 	static void init_gdext_pointers();
 
 	EditorHelp();
-	~EditorHelp();
 };
 
 class EditorHelpBit : public VBoxContainer {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8317,9 +8317,3 @@ bool EditorPluginList::is_empty() {
 void EditorPluginList::clear() {
 	plugins_list.clear();
 }
-
-EditorPluginList::EditorPluginList() {
-}
-
-EditorPluginList::~EditorPluginList() {
-}

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -985,9 +985,6 @@ public:
 	void remove_plugin(EditorPlugin *p_plugin);
 	void clear();
 	bool is_empty();
-
-	EditorPluginList();
-	~EditorPluginList();
 };
 
 struct EditorProgressBG {

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -94,9 +94,6 @@ Variant EditorPropertyArrayObject::get_array() {
 	return array;
 }
 
-EditorPropertyArrayObject::EditorPropertyArrayObject() {
-}
-
 ///////////////////
 
 bool EditorPropertyDictionaryObject::_set(const StringName &p_name, const Variant &p_value) {
@@ -231,9 +228,6 @@ String EditorPropertyDictionaryObject::get_label_for_index(int p_index) {
 			return dict.get_key_at_index(p_index).get_construct_string();
 			break;
 	}
-}
-
-EditorPropertyDictionaryObject::EditorPropertyDictionaryObject() {
 }
 
 ///////////////////// ARRAY ///////////////////////////

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -53,8 +53,6 @@ public:
 
 	void set_array(const Variant &p_array);
 	Variant get_array();
-
-	EditorPropertyArrayObject();
 };
 
 class EditorPropertyDictionaryObject : public RefCounted {
@@ -88,8 +86,6 @@ public:
 	String get_label_for_index(int p_index);
 	String get_property_name_for_index(int p_index);
 	String get_key_name_for_index(int p_index);
-
-	EditorPropertyDictionaryObject();
 };
 
 class EditorPropertyArray : public EditorProperty {

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -1175,9 +1175,6 @@ void EditorScriptPicker::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "script_owner", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_NONE), "set_script_owner", "get_script_owner");
 }
 
-EditorScriptPicker::EditorScriptPicker() {
-}
-
 // EditorShaderPicker
 
 void EditorShaderPicker::set_create_options(Object *p_menu_node) {
@@ -1216,9 +1213,6 @@ ShaderMaterial *EditorShaderPicker::get_edited_material() const {
 
 void EditorShaderPicker::set_preferred_mode(int p_mode) {
 	preferred_mode = p_mode;
-}
-
-EditorShaderPicker::EditorShaderPicker() {
 }
 
 //////////////

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -169,8 +169,6 @@ public:
 
 	void set_script_owner(Node *p_owner);
 	Node *get_script_owner() const;
-
-	EditorScriptPicker();
 };
 
 class EditorShaderPicker : public EditorResourcePicker {
@@ -190,8 +188,6 @@ public:
 	void set_edited_material(ShaderMaterial *p_material);
 	ShaderMaterial *get_edited_material() const;
 	void set_preferred_mode(int p_preferred_mode);
-
-	EditorShaderPicker();
 };
 
 class EditorAudioStreamPicker : public EditorResourcePicker {

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -93,9 +93,6 @@ void EditorResourcePreviewGenerator::_bind_methods() {
 	GDVIRTUAL_BIND(_can_generate_small_preview);
 }
 
-EditorResourcePreviewGenerator::EditorResourcePreviewGenerator() {
-}
-
 void EditorResourcePreviewGenerator::DrawRequester::request_and_wait(RID p_viewport) {
 	Callable request_vp_update_once = callable_mp(RS::get_singleton(), &RS::viewport_set_update_mode).bind(p_viewport, RS::VIEWPORT_UPDATE_ONCE);
 

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -68,8 +68,6 @@ public:
 
 	virtual bool generate_small_preview_automatically() const;
 	virtual bool can_generate_small_preview() const;
-
-	EditorResourcePreviewGenerator();
 };
 
 class EditorResourcePreview : public Node {

--- a/editor/editor_script.h
+++ b/editor/editor_script.h
@@ -51,6 +51,4 @@ public:
 	EditorInterface *get_editor_interface() const;
 
 	virtual void run();
-
-	EditorScript() {}
 };

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -1003,6 +1003,3 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorSettingsDialog::_settings_changed));
 	set_ok_button_text(TTR("Close"));
 }
-
-EditorSettingsDialog::~EditorSettingsDialog() {
-}

--- a/editor/editor_settings_dialog.h
+++ b/editor/editor_settings_dialog.h
@@ -136,5 +136,4 @@ public:
 	static void update_navigation_preset();
 
 	EditorSettingsDialog();
-	~EditorSettingsDialog();
 };

--- a/editor/editor_translation_parser.cpp
+++ b/editor/editor_translation_parser.cpp
@@ -179,9 +179,6 @@ EditorTranslationParser *EditorTranslationParser::get_singleton() {
 	return singleton;
 }
 
-EditorTranslationParser::EditorTranslationParser() {
-}
-
 EditorTranslationParser::~EditorTranslationParser() {
 	memdelete(singleton);
 	singleton = nullptr;

--- a/editor/editor_translation_parser.h
+++ b/editor/editor_translation_parser.h
@@ -74,6 +74,5 @@ public:
 	void remove_parser(const Ref<EditorTranslationParserPlugin> &p_parser, ParserType p_type);
 	void clean_parsers();
 
-	EditorTranslationParser();
 	~EditorTranslationParser();
 };

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -453,6 +453,3 @@ EditorExport::EditorExport() {
 	singleton = this;
 	set_process(true);
 }
-
-EditorExport::~EditorExport() {
-}

--- a/editor/export/editor_export.h
+++ b/editor/export/editor_export.h
@@ -83,5 +83,4 @@ public:
 	void connect_presets_runnable_updated(const Callable &p_target);
 
 	EditorExport();
-	~EditorExport();
 };

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -2500,6 +2500,3 @@ void EditorExportPlatform::_bind_methods() {
 	BIND_BITFIELD_FLAG(DEBUG_FLAG_VIEW_COLLISIONS);
 	BIND_BITFIELD_FLAG(DEBUG_FLAG_VIEW_NAVIGATION);
 }
-
-EditorExportPlatform::EditorExportPlatform() {
-}

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -336,8 +336,6 @@ public:
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) {}
 	virtual String get_debug_protocol() const { return "tcp://"; }
 	virtual HashMap<String, Variant> get_custom_project_settings(const Ref<EditorExportPreset> &p_preset) const { return HashMap<String, Variant>(); }
-
-	EditorExportPlatform();
 };
 
 VARIANT_ENUM_CAST(EditorExportPlatform::ExportMessageType)

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -561,5 +561,3 @@ String EditorExportPreset::get_version(const StringName &p_preset_string, bool p
 
 	return result;
 }
-
-EditorExportPreset::EditorExportPreset() {}

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -194,8 +194,6 @@ public:
 
 	const HashMap<StringName, PropertyInfo> &get_properties() const { return properties; }
 	const HashMap<StringName, Variant> &get_values() const { return values; }
-
-	EditorExportPreset();
 };
 
 VARIANT_ENUM_CAST(EditorExportPreset::ExportFilter);

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1804,6 +1804,3 @@ ProjectExportDialog::ProjectExportDialog() {
 		}
 	}
 }
-
-ProjectExportDialog::~ProjectExportDialog() {
-}

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -221,5 +221,4 @@ public:
 	bool is_exporting() const { return exporting; }
 
 	ProjectExportDialog();
-	~ProjectExportDialog();
 };

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -869,6 +869,3 @@ GroupsEditor::GroupsEditor() {
 
 	ProjectSettingsEditor::get_singleton()->get_group_settings()->connect("group_changed", callable_mp(this, &GroupsEditor::_update_groups_and_tree));
 }
-
-GroupsEditor::~GroupsEditor() {
-}

--- a/editor/groups_editor.h
+++ b/editor/groups_editor.h
@@ -137,5 +137,4 @@ public:
 	void set_current(Node *p_node);
 
 	GroupsEditor();
-	~GroupsEditor();
 };

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -2341,9 +2341,6 @@ SceneTreeDialog::SceneTreeDialog() {
 	tree->connect("node_selected", callable_mp(this, &SceneTreeDialog::_selected_changed));
 }
 
-SceneTreeDialog::~SceneTreeDialog() {
-}
-
 /******** CACHE *********/
 
 HashMap<Node *, SceneTreeEditor::CachedNode>::Iterator SceneTreeEditor::NodeCache::add(Node *p_node, TreeItem *p_item) {

--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -290,5 +290,4 @@ public:
 	LineEdit *get_filter_line_edit() { return filter; }
 
 	SceneTreeDialog();
-	~SceneTreeDialog();
 };

--- a/editor/import/3d/collada.cpp
+++ b/editor/import/3d/collada.cpp
@@ -2379,6 +2379,3 @@ Error Collada::load(const String &p_path, int p_flags) {
 	_optimize();
 	return OK;
 }
-
-Collada::Collada() {
-}

--- a/editor/import/3d/collada.h
+++ b/editor/import/3d/collada.h
@@ -56,7 +56,6 @@ public:
 			int uv_idx = 0;
 			String texture;
 			Color color;
-			Channel() {}
 		};
 
 		Channel diffuse, specular, emission, bump;
@@ -116,8 +115,6 @@ public:
 
 		float spot_angle = 45;
 		float spot_exp = 1;
-
-		LightData() {}
 	};
 
 	struct MeshData {
@@ -153,8 +150,6 @@ public:
 
 		bool found_double_sided = false;
 		bool double_sided = true;
-
-		MeshData() {}
 	};
 
 	struct CurveData {
@@ -170,8 +165,6 @@ public:
 		HashMap<String, Source> sources;
 
 		HashMap<String, String> control_vertices;
-
-		CurveData() {}
 	};
 
 	struct SkinControllerData {
@@ -184,7 +177,6 @@ public:
 			Vector<String> sarray; //maybe for names
 			Vector<float> array;
 			int stride = 1;
-			Source() {}
 		};
 
 		HashMap<String, Source> sources;
@@ -207,8 +199,6 @@ public:
 		} weights;
 
 		HashMap<String, Transform3D> bone_rest_map;
-
-		SkinControllerData() {}
 	};
 
 	struct MorphControllerData {
@@ -219,13 +209,11 @@ public:
 			int stride = 1;
 			Vector<String> sarray; //maybe for names
 			Vector<float> array;
-			Source() {}
 		};
 
 		HashMap<String, Source> sources;
 
 		HashMap<String, String> targets;
-		MorphControllerData() {}
 	};
 
 	struct Vertex {
@@ -303,8 +291,6 @@ public:
 				return uid < p_vert.uid;
 			}
 		}
-
-		Vertex() {}
 	};
 
 	struct Node {
@@ -350,7 +336,6 @@ public:
 
 		bool ignore_anim = false;
 
-		Node() {}
 		virtual ~Node() {
 			for (int i = 0; i < children.size(); i++) {
 				memdelete(children[i]);
@@ -412,8 +397,6 @@ public:
 		float begin = 0;
 		float end = 1;
 		Vector<String> tracks;
-
-		AnimationClip() {}
 	};
 
 	struct AnimationTrack {
@@ -439,15 +422,11 @@ public:
 			Point2 in_tangent;
 			Point2 out_tangent;
 			InterpolationType interp_type = INTERP_LINEAR;
-
-			Key() {}
 		};
 
 		Vector<float> get_value_at_time(float p_time) const;
 
 		Vector<Key> keys;
-
-		AnimationTrack() {}
 	};
 
 	/****************/
@@ -505,13 +484,9 @@ public:
 		HashMap<String, Vector<int>> by_id_tracks;
 
 		float animation_length = 0;
-
-		State() {}
 	} state;
 
 	Error load(const String &p_path, int p_flags = 0);
-
-	Collada();
 
 	Transform3D fix_transform(const Transform3D &p_transform);
 

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -1855,6 +1855,3 @@ Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint3
 
 	return state.scene;
 }
-
-EditorSceneFormatImporterCollada::EditorSceneFormatImporterCollada() {
-}

--- a/editor/import/3d/editor_import_collada.h
+++ b/editor/import/3d/editor_import_collada.h
@@ -38,6 +38,4 @@ class EditorSceneFormatImporterCollada : public EditorSceneFormatImporter {
 public:
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps = nullptr, Error *r_err = nullptr) override;
-
-	EditorSceneFormatImporterCollada();
 };

--- a/editor/import/3d/post_import_plugin_skeleton_renamer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_renamer.cpp
@@ -245,6 +245,3 @@ void PostImportPluginSkeletonRenamer::internal_process(InternalImportCategory p_
 		}
 	}
 }
-
-PostImportPluginSkeletonRenamer::PostImportPluginSkeletonRenamer() {
-}

--- a/editor/import/3d/post_import_plugin_skeleton_renamer.h
+++ b/editor/import/3d/post_import_plugin_skeleton_renamer.h
@@ -40,6 +40,4 @@ public:
 	virtual void internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, Ref<Resource> p_resource, const Dictionary &p_options) override;
 
 	void _internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, Ref<Resource> p_resource, const Dictionary &p_options, const HashMap<String, String> &p_rename_map);
-
-	PostImportPluginSkeletonRenamer();
 };

--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
@@ -972,6 +972,3 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 		memdelete(prof_skeleton);
 	}
 }
-
-PostImportPluginSkeletonRestFixer::PostImportPluginSkeletonRestFixer() {
-}

--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.h
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.h
@@ -39,6 +39,4 @@ public:
 	virtual void get_internal_import_options(InternalImportCategory p_category, List<ResourceImporter::ImportOption> *r_options) override;
 	virtual Variant get_internal_option_visibility(InternalImportCategory p_category, const String &p_scene_import_type, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 	virtual void internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, Ref<Resource> p_resource, const Dictionary &p_options) override;
-
-	PostImportPluginSkeletonRestFixer();
 };

--- a/editor/import/3d/post_import_plugin_skeleton_track_organizer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_track_organizer.cpp
@@ -153,6 +153,3 @@ void PostImportPluginSkeletonTrackOrganizer::internal_process(InternalImportCate
 		}
 	}
 }
-
-PostImportPluginSkeletonTrackOrganizer::PostImportPluginSkeletonTrackOrganizer() {
-}

--- a/editor/import/3d/post_import_plugin_skeleton_track_organizer.h
+++ b/editor/import/3d/post_import_plugin_skeleton_track_organizer.h
@@ -38,6 +38,4 @@ class PostImportPluginSkeletonTrackOrganizer : public EditorScenePostImportPlugi
 public:
 	virtual void get_internal_import_options(InternalImportCategory p_category, List<ResourceImporter::ImportOption> *r_options) override;
 	virtual void internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, Ref<Resource> p_resource, const Dictionary &p_options) override;
-
-	PostImportPluginSkeletonTrackOrganizer();
 };

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -584,9 +584,6 @@ void EditorOBJImporter::get_extensions(List<String> *r_extensions) const {
 	r_extensions->push_back("obj");
 }
 
-EditorOBJImporter::EditorOBJImporter() {
-}
-
 ////////////////////////////////////////////////////
 
 String ResourceImporterOBJ::get_importer_name() const {
@@ -681,7 +678,4 @@ Error ResourceImporterOBJ::import(ResourceUID::ID p_source_id, const String &p_s
 	r_gen_files->push_back(save_path);
 
 	return OK;
-}
-
-ResourceImporterOBJ::ResourceImporterOBJ() {
 }

--- a/editor/import/3d/resource_importer_obj.h
+++ b/editor/import/3d/resource_importer_obj.h
@@ -38,8 +38,6 @@ class EditorOBJImporter : public EditorSceneFormatImporter {
 public:
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr) override;
-
-	EditorOBJImporter();
 };
 
 class ResourceImporterOBJ : public ResourceImporter {
@@ -60,6 +58,4 @@ public:
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
 	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
-
-	ResourceImporterOBJ();
 };

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -146,9 +146,6 @@ void EditorScenePostImport::init(const String &p_source_file) {
 	source_file = p_source_file;
 }
 
-EditorScenePostImport::EditorScenePostImport() {
-}
-
 ///////////////////////////////////////////////////////
 
 Variant EditorScenePostImportPlugin::get_option_value(const StringName &p_name) const {

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -80,8 +80,6 @@ public:
 	virtual void get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options);
 	virtual Variant get_option_visibility(const String &p_path, const String &p_scene_import_type, const String &p_option, const HashMap<StringName, Variant> &p_options);
 	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {}
-
-	EditorSceneFormatImporter() {}
 };
 
 class EditorScenePostImport : public RefCounted {
@@ -98,7 +96,6 @@ public:
 	String get_source_file() const;
 	virtual Node *post_import(Node *p_scene);
 	virtual void init(const String &p_source_file);
-	EditorScenePostImport();
 };
 
 class EditorScenePostImportPlugin : public RefCounted {
@@ -150,8 +147,6 @@ public:
 
 	virtual void pre_process(Node *p_scene, const HashMap<StringName, Variant> &p_options);
 	virtual void post_process(Node *p_scene, const HashMap<StringName, Variant> &p_options);
-
-	EditorScenePostImportPlugin() {}
 };
 
 VARIANT_ENUM_CAST(EditorScenePostImportPlugin::InternalImportCategory)

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -33,9 +33,6 @@
 #include "core/object/script_language.h"
 #include "editor/editor_file_system.h"
 
-EditorImportPlugin::EditorImportPlugin() {
-}
-
 String EditorImportPlugin::get_importer_name() const {
 	String ret;
 	if (GDVIRTUAL_CALL(_get_importer_name, ret)) {

--- a/editor/import/editor_import_plugin.h
+++ b/editor/import/editor_import_plugin.h
@@ -57,7 +57,6 @@ protected:
 	Error _append_import_external_resource(const String &p_file, const Dictionary &p_custom_options = Dictionary(), const String &p_custom_importer = String(), Variant p_generator_parameters = Variant());
 
 public:
-	EditorImportPlugin();
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;

--- a/editor/import/resource_importer_bitmask.cpp
+++ b/editor/import/resource_importer_bitmask.cpp
@@ -105,9 +105,3 @@ Error ResourceImporterBitMap::import(ResourceUID::ID p_source_id, const String &
 
 	return ResourceSaver::save(bitmap, p_save_path + ".res");
 }
-
-ResourceImporterBitMap::ResourceImporterBitMap() {
-}
-
-ResourceImporterBitMap::~ResourceImporterBitMap() {
-}

--- a/editor/import/resource_importer_bitmask.h
+++ b/editor/import/resource_importer_bitmask.h
@@ -50,7 +50,4 @@ public:
 	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
-
-	ResourceImporterBitMap();
-	~ResourceImporterBitMap();
 };

--- a/editor/import/resource_importer_bmfont.cpp
+++ b/editor/import/resource_importer_bmfont.cpp
@@ -109,6 +109,3 @@ Error ResourceImporterBMFont::import(ResourceUID::ID p_source_id, const String &
 	print_verbose("Done saving to: " + p_save_path + ".fontdata");
 	return OK;
 }
-
-ResourceImporterBMFont::ResourceImporterBMFont() {
-}

--- a/editor/import/resource_importer_bmfont.h
+++ b/editor/import/resource_importer_bmfont.h
@@ -50,6 +50,4 @@ public:
 	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
-
-	ResourceImporterBMFont();
 };

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -162,6 +162,3 @@ Error ResourceImporterCSVTranslation::import(ResourceUID::ID p_source_id, const 
 
 	return OK;
 }
-
-ResourceImporterCSVTranslation::ResourceImporterCSVTranslation() {
-}

--- a/editor/import/resource_importer_csv_translation.h
+++ b/editor/import/resource_importer_csv_translation.h
@@ -51,6 +51,4 @@ public:
 	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
-
-	ResourceImporterCSVTranslation();
 };

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -271,6 +271,3 @@ Error ResourceImporterDynamicFont::import(ResourceUID::ID p_source_id, const Str
 	print_verbose("Done saving to: " + p_save_path + ".fontdata");
 	return OK;
 }
-
-ResourceImporterDynamicFont::ResourceImporterDynamicFont() {
-}

--- a/editor/import/resource_importer_dynamic_font.h
+++ b/editor/import/resource_importer_dynamic_font.h
@@ -60,6 +60,4 @@ public:
 	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
-
-	ResourceImporterDynamicFont();
 };

--- a/editor/import/resource_importer_image.cpp
+++ b/editor/import/resource_importer_image.cpp
@@ -92,6 +92,3 @@ Error ResourceImporterImage::import(ResourceUID::ID p_source_id, const String &p
 
 	return OK;
 }
-
-ResourceImporterImage::ResourceImporterImage() {
-}

--- a/editor/import/resource_importer_image.h
+++ b/editor/import/resource_importer_image.h
@@ -52,6 +52,4 @@ public:
 	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
-
-	ResourceImporterImage();
 };

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -344,6 +344,3 @@ Error ResourceImporterImageFont::import(ResourceUID::ID p_source_id, const Strin
 	print_verbose("Done saving to: " + p_save_path + ".fontdata");
 	return OK;
 }
-
-ResourceImporterImageFont::ResourceImporterImageFont() {
-}

--- a/editor/import/resource_importer_imagefont.h
+++ b/editor/import/resource_importer_imagefont.h
@@ -50,6 +50,4 @@ public:
 	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
-
-	ResourceImporterImageFont();
 };

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -53,7 +53,6 @@ public:
 	bool mipmaps = true;
 	bool high_quality = false;
 	Image::UsedChannels used_channels = Image::USED_CHANNELS_RGBA;
-	virtual ~LayeredTextureImport() {}
 };
 
 class ResourceImporterLayeredTexture : public ResourceImporter {

--- a/editor/import/resource_importer_shader_file.cpp
+++ b/editor/import/resource_importer_shader_file.cpp
@@ -114,6 +114,3 @@ Error ResourceImporterShaderFile::import(ResourceUID::ID p_source_id, const Stri
 
 	return OK;
 }
-
-ResourceImporterShaderFile::ResourceImporterShaderFile() {
-}

--- a/editor/import/resource_importer_shader_file.h
+++ b/editor/import/resource_importer_shader_file.h
@@ -51,6 +51,4 @@ public:
 	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
-
-	ResourceImporterShaderFile();
 };

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -404,6 +404,3 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 
 	return OK;
 }
-
-ResourceImporterTextureAtlas::ResourceImporterTextureAtlas() {
-}

--- a/editor/import/resource_importer_texture_atlas.h
+++ b/editor/import/resource_importer_texture_atlas.h
@@ -67,6 +67,4 @@ public:
 	virtual Error import_group_file(const String &p_group_file, const HashMap<String, HashMap<StringName, Variant>> &p_source_file_options, const HashMap<String, String> &p_base_paths) override;
 
 	virtual bool can_import_threaded() const override { return true; }
-
-	ResourceImporterTextureAtlas();
 };

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -98,6 +98,3 @@ Error ResourceImporterWAV::import(ResourceUID::ID p_source_id, const String &p_s
 	ResourceSaver::save(sample, p_save_path + ".sample");
 	return OK;
 }
-
-ResourceImporterWAV::ResourceImporterWAV() {
-}

--- a/editor/import/resource_importer_wav.h
+++ b/editor/import/resource_importer_wav.h
@@ -52,6 +52,4 @@ public:
 	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
-
-	ResourceImporterWAV();
 };

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -295,6 +295,3 @@ void MultiNodeEdit::_bind_methods() {
 	ClassDB::bind_method("_hide_metadata_from_inspector", &MultiNodeEdit::_hide_metadata_from_inspector);
 	ClassDB::bind_method("_get_editor_name", &MultiNodeEdit::_get_editor_name);
 }
-
-MultiNodeEdit::MultiNodeEdit() {
-}

--- a/editor/multi_node_edit.h
+++ b/editor/multi_node_edit.h
@@ -79,5 +79,4 @@ public:
 
 		return true;
 	}
-	MultiNodeEdit();
 };

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -783,6 +783,3 @@ AbstractPolygon2DEditorPlugin::AbstractPolygon2DEditorPlugin(AbstractPolygon2DEd
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(polygon_editor);
 	polygon_editor->hide();
 }
-
-AbstractPolygon2DEditorPlugin::~AbstractPolygon2DEditorPlugin() {
-}

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -162,5 +162,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	AbstractPolygon2DEditorPlugin(AbstractPolygon2DEditor *p_polygon_editor, const String &p_class);
-	~AbstractPolygon2DEditorPlugin();
 };

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -1271,9 +1271,6 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	EditorInspector::add_inspector_plugin(animation_node_inspector_plugin);
 }
 
-AnimationNodeBlendTreeEditor::~AnimationNodeBlendTreeEditor() {
-}
-
 // EditorPluginAnimationNodeAnimation
 
 void AnimationNodeAnimationEditor::_open_set_custom_timeline_from_marker_dialog() {
@@ -1370,9 +1367,6 @@ AnimationNodeAnimationEditor::AnimationNodeAnimationEditor(Ref<AnimationNodeAnim
 	bottom_spacer->set_custom_minimum_size(Size2(0, 2) * EDSCALE);
 }
 
-AnimationNodeAnimationEditor::~AnimationNodeAnimationEditor() {
-}
-
 void AnimationNodeAnimationEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
@@ -1425,7 +1419,4 @@ AnimationNodeAnimationEditorDialog::AnimationNodeAnimationEditorDialog() {
 	grid->add_child(select_end);
 	select_end->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	select_end->set_stretch_ratio(2);
-}
-
-AnimationNodeAnimationEditorDialog::~AnimationNodeAnimationEditorDialog() {
 }

--- a/editor/plugins/animation_blend_tree_editor_plugin.h
+++ b/editor/plugins/animation_blend_tree_editor_plugin.h
@@ -168,7 +168,6 @@ public:
 	void update_graph();
 
 	AnimationNodeBlendTreeEditor();
-	~AnimationNodeBlendTreeEditor();
 };
 
 // EditorPluginAnimationNodeAnimation
@@ -191,7 +190,6 @@ class AnimationNodeAnimationEditorDialog : public ConfirmationDialog {
 
 public:
 	AnimationNodeAnimationEditorDialog();
-	~AnimationNodeAnimationEditorDialog();
 };
 
 class AnimationNodeAnimationEditor : public VBoxContainer {
@@ -206,7 +204,6 @@ class AnimationNodeAnimationEditor : public VBoxContainer {
 
 public:
 	AnimationNodeAnimationEditor(Ref<AnimationNodeAnimation> p_animation_node_animation);
-	~AnimationNodeAnimationEditor();
 
 protected:
 	void _notification(int p_what);

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -326,6 +326,4 @@ protected:
 
 public:
 	void add_transition(const StringName &p_from, const StringName &p_to, Ref<AnimationNodeStateMachineTransition> p_transition);
-
-	EditorAnimationMultiTransitionEdit() {}
 };

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -308,6 +308,3 @@ AnimationTreeEditorPlugin::AnimationTreeEditorPlugin() {
 	button = EditorNode::get_bottom_panel()->add_item(TTR("AnimationTree"), anim_tree_editor, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_animation_tree_bottom_panel", TTRC("Toggle AnimationTree Bottom Panel")));
 	button->hide();
 }
-
-AnimationTreeEditorPlugin::~AnimationTreeEditorPlugin() {
-}

--- a/editor/plugins/animation_tree_editor_plugin.h
+++ b/editor/plugins/animation_tree_editor_plugin.h
@@ -106,5 +106,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	AnimationTreeEditorPlugin();
-	~AnimationTreeEditorPlugin();
 };

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1801,6 +1801,3 @@ AssetLibraryEditorPlugin::AssetLibraryEditorPlugin() {
 	addon_library->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	addon_library->hide();
 }
-
-AssetLibraryEditorPlugin::~AssetLibraryEditorPlugin() {
-}

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -348,5 +348,4 @@ public:
 	//virtual void set_state(const Dictionary& p_state);
 
 	AssetLibraryEditorPlugin();
-	~AssetLibraryEditorPlugin();
 };

--- a/editor/plugins/audio_stream_randomizer_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_randomizer_editor_plugin.cpp
@@ -119,5 +119,3 @@ void AudioStreamRandomizerEditorPlugin::_move_stream_array_element(Object *p_und
 AudioStreamRandomizerEditorPlugin::AudioStreamRandomizerEditorPlugin() {
 	EditorNode::get_editor_data().add_move_array_element_function(SNAME("AudioStreamRandomizer"), callable_mp(this, &AudioStreamRandomizerEditorPlugin::_move_stream_array_element));
 }
-
-AudioStreamRandomizerEditorPlugin::~AudioStreamRandomizerEditorPlugin() {}

--- a/editor/plugins/audio_stream_randomizer_editor_plugin.h
+++ b/editor/plugins/audio_stream_randomizer_editor_plugin.h
@@ -46,5 +46,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	AudioStreamRandomizerEditorPlugin();
-	~AudioStreamRandomizerEditorPlugin();
 };

--- a/editor/plugins/bone_map_editor_plugin.cpp
+++ b/editor/plugins/bone_map_editor_plugin.cpp
@@ -104,9 +104,6 @@ BoneMapperButton::BoneMapperButton(const StringName &p_profile_bone_name, bool p
 	selected = p_selected;
 }
 
-BoneMapperButton::~BoneMapperButton() {
-}
-
 void BoneMapperItem::create_editor() {
 	HBoxContainer *hbox = memnew(HBoxContainer);
 	add_child(hbox);
@@ -163,9 +160,6 @@ void BoneMapperItem::_bind_methods() {
 BoneMapperItem::BoneMapperItem(Ref<BoneMap> &p_bone_map, const StringName &p_profile_bone_name) {
 	bone_map = p_bone_map;
 	profile_bone_name = p_profile_bone_name;
-}
-
-BoneMapperItem::~BoneMapperItem() {
 }
 
 void BonePicker::create_editors() {
@@ -264,9 +258,6 @@ void BonePicker::_notification(int p_what) {
 
 BonePicker::BonePicker(Skeleton3D *p_skeleton) {
 	skeleton = p_skeleton;
-}
-
-BonePicker::~BonePicker() {
 }
 
 void BoneMapper::create_editor() {
@@ -1407,9 +1398,6 @@ BoneMapper::BoneMapper(Skeleton3D *p_skeleton, Ref<BoneMap> &p_bone_map) {
 	bone_map = p_bone_map;
 }
 
-BoneMapper::~BoneMapper() {
-}
-
 void BoneMapEditor::create_editors() {
 	if (!skeleton) {
 		return;
@@ -1455,9 +1443,6 @@ void BoneMapEditor::_notification(int p_what) {
 
 BoneMapEditor::BoneMapEditor(Ref<BoneMap> &p_bone_map) {
 	bone_map = p_bone_map;
-}
-
-BoneMapEditor::~BoneMapEditor() {
 }
 
 bool EditorInspectorPluginBoneMap::can_handle(Object *p_object) {

--- a/editor/plugins/bone_map_editor_plugin.h
+++ b/editor/plugins/bone_map_editor_plugin.h
@@ -73,7 +73,6 @@ public:
 	bool is_require() const;
 
 	BoneMapperButton(const StringName &p_profile_bone_name, bool p_require, bool p_selected);
-	~BoneMapperButton();
 };
 
 class BoneMapperItem : public VBoxContainer {
@@ -100,7 +99,6 @@ public:
 	void assign_button_id(int p_button_id);
 
 	BoneMapperItem(Ref<BoneMap> &p_bone_map, const StringName &p_profile_bone_name = StringName());
-	~BoneMapperItem();
 };
 
 class BonePicker : public AcceptDialog {
@@ -124,7 +122,6 @@ private:
 
 public:
 	BonePicker(Skeleton3D *p_skeleton);
-	~BonePicker();
 };
 
 class BoneMapper : public VBoxContainer {
@@ -189,7 +186,6 @@ public:
 	int get_current_bone_idx() const;
 
 	BoneMapper(Skeleton3D *p_skeleton, Ref<BoneMap> &p_bone_map);
-	~BoneMapper();
 };
 
 class BoneMapEditor : public VBoxContainer {
@@ -207,7 +203,6 @@ protected:
 
 public:
 	BoneMapEditor(Ref<BoneMap> &p_bone_map);
-	~BoneMapEditor();
 };
 
 class EditorInspectorPluginBoneMap : public EditorInspectorPlugin {

--- a/editor/plugins/camera_3d_editor_plugin.cpp
+++ b/editor/plugins/camera_3d_editor_plugin.cpp
@@ -126,6 +126,3 @@ Camera3DEditorPlugin::Camera3DEditorPlugin() {
 	plugin.instantiate();
 	add_inspector_plugin(plugin);
 }
-
-Camera3DEditorPlugin::~Camera3DEditorPlugin() {
-}

--- a/editor/plugins/camera_3d_editor_plugin.h
+++ b/editor/plugins/camera_3d_editor_plugin.h
@@ -84,5 +84,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	Camera3DEditorPlugin();
-	~Camera3DEditorPlugin();
 };

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5793,9 +5793,6 @@ CanvasItemEditorPlugin::CanvasItemEditorPlugin() {
 	canvas_item_editor->hide();
 }
 
-CanvasItemEditorPlugin::~CanvasItemEditorPlugin() {
-}
-
 void CanvasItemEditorViewport::_on_mouse_exit() {
 	if (!texture_node_type_selector->is_visible()) {
 		_remove_preview();

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -67,8 +67,6 @@ public:
 	List<Dictionary> pre_drag_bones_undo_state;
 
 	Dictionary undo_state;
-
-	CanvasItemEditorSelectedItem() {}
 };
 
 class CanvasItemEditor : public VBoxContainer {
@@ -614,7 +612,6 @@ public:
 	CanvasItemEditor *get_canvas_item_editor() { return canvas_item_editor; }
 
 	CanvasItemEditorPlugin();
-	~CanvasItemEditorPlugin();
 };
 
 class CanvasItemEditorViewport : public Control {

--- a/editor/plugins/collision_polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_2d_editor_plugin.cpp
@@ -38,8 +38,6 @@ void CollisionPolygon2DEditor::_set_node(Node *p_polygon) {
 	node = Object::cast_to<CollisionPolygon2D>(p_polygon);
 }
 
-CollisionPolygon2DEditor::CollisionPolygon2DEditor() {}
-
 CollisionPolygon2DEditorPlugin::CollisionPolygon2DEditorPlugin() :
 		AbstractPolygon2DEditorPlugin(memnew(CollisionPolygon2DEditor), "CollisionPolygon2D") {
 }

--- a/editor/plugins/collision_polygon_2d_editor_plugin.h
+++ b/editor/plugins/collision_polygon_2d_editor_plugin.h
@@ -41,9 +41,6 @@ class CollisionPolygon2DEditor : public AbstractPolygon2DEditor {
 protected:
 	virtual Node2D *_get_node() const override;
 	virtual void _set_node(Node *p_polygon) override;
-
-public:
-	CollisionPolygon2DEditor();
 };
 
 class CollisionPolygon2DEditorPlugin : public AbstractPolygon2DEditorPlugin {

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -664,6 +664,3 @@ CollisionShape2DEditorPlugin::CollisionShape2DEditorPlugin() {
 	collision_shape_2d_editor = memnew(CollisionShape2DEditor);
 	EditorNode::get_singleton()->get_gui_base()->add_child(collision_shape_2d_editor);
 }
-
-CollisionShape2DEditorPlugin::~CollisionShape2DEditorPlugin() {
-}

--- a/editor/plugins/collision_shape_2d_editor_plugin.h
+++ b/editor/plugins/collision_shape_2d_editor_plugin.h
@@ -111,5 +111,4 @@ public:
 	virtual void make_visible(bool visible) override;
 
 	CollisionShape2DEditorPlugin();
-	~CollisionShape2DEditorPlugin();
 };

--- a/editor/plugins/control_editor_plugin.h
+++ b/editor/plugins/control_editor_plugin.h
@@ -170,9 +170,6 @@ protected:
 
 	void _add_row_button(HBoxContainer *p_row, const int p_preset, const String &p_name);
 	void _add_separator(BoxContainer *p_box, Separator *p_separator);
-
-public:
-	ControlEditorPresetPicker() {}
 };
 
 class AnchorPresetPicker : public ControlEditorPresetPicker {

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -254,9 +254,6 @@ public:
 
 	void enable_plugin();
 	void disable_plugin();
-
-	EditorPlugin() {}
-	virtual ~EditorPlugin() {}
 };
 
 VARIANT_ENUM_CAST(EditorPlugin::CustomControlContainer);

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -182,9 +182,6 @@ Ref<Texture2D> EditorTexturePreviewPlugin::generate(const Ref<Resource> &p_from,
 	return ImageTexture::create_from_image(img);
 }
 
-EditorTexturePreviewPlugin::EditorTexturePreviewPlugin() {
-}
-
 ////////////////////////////////////////////////////////////////////////////
 
 bool EditorImagePreviewPlugin::handles(const String &p_type) const {
@@ -220,9 +217,6 @@ Ref<Texture2D> EditorImagePreviewPlugin::generate(const Ref<Resource> &p_from, c
 	post_process_preview(img);
 
 	return ImageTexture::create_from_image(img);
-}
-
-EditorImagePreviewPlugin::EditorImagePreviewPlugin() {
 }
 
 bool EditorImagePreviewPlugin::generate_small_preview_automatically() const {
@@ -287,9 +281,6 @@ bool EditorBitmapPreviewPlugin::generate_small_preview_automatically() const {
 	return true;
 }
 
-EditorBitmapPreviewPlugin::EditorBitmapPreviewPlugin() {
-}
-
 ///////////////////////////////////////////////////////////////////////////
 
 bool EditorPackedScenePreviewPlugin::handles(const String &p_type) const {
@@ -323,9 +314,6 @@ Ref<Texture2D> EditorPackedScenePreviewPlugin::generate_from_path(const String &
 	} else {
 		return Ref<Texture2D>();
 	}
-}
-
-EditorPackedScenePreviewPlugin::EditorPackedScenePreviewPlugin() {
 }
 
 //////////////////////////////////////////////////////////////////
@@ -649,9 +637,6 @@ Ref<Texture2D> EditorScriptPreviewPlugin::_generate_from_source_code(const Scrip
 	return ImageTexture::create_from_image(img);
 }
 
-EditorScriptPreviewPlugin::EditorScriptPreviewPlugin() {
-}
-
 ///////////////////////////////////////////////////////////////////
 
 bool EditorAudioStreamPreviewPlugin::handles(const String &p_type) const {
@@ -729,9 +714,6 @@ Ref<Texture2D> EditorAudioStreamPreviewPlugin::generate(const Ref<Resource> &p_f
 
 	Ref<Image> image = Image::create_from_data(w, h, false, Image::FORMAT_RGB8, img);
 	return ImageTexture::create_from_image(image);
-}
-
-EditorAudioStreamPreviewPlugin::EditorAudioStreamPreviewPlugin() {
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -951,7 +933,4 @@ Ref<Texture2D> EditorGradientPreviewPlugin::generate(const Ref<Resource> &p_from
 		return ImageTexture::create_from_image(ptex->get_image());
 	}
 	return Ref<Texture2D>();
-}
-
-EditorGradientPreviewPlugin::EditorGradientPreviewPlugin() {
 }

--- a/editor/plugins/editor_preview_plugins.h
+++ b/editor/plugins/editor_preview_plugins.h
@@ -43,8 +43,6 @@ public:
 	virtual bool handles(const String &p_type) const override;
 	virtual bool generate_small_preview_automatically() const override;
 	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size, Dictionary &p_metadata) const override;
-
-	EditorTexturePreviewPlugin();
 };
 
 class EditorImagePreviewPlugin : public EditorResourcePreviewGenerator {
@@ -54,8 +52,6 @@ public:
 	virtual bool handles(const String &p_type) const override;
 	virtual bool generate_small_preview_automatically() const override;
 	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size, Dictionary &p_metadata) const override;
-
-	EditorImagePreviewPlugin();
 };
 
 class EditorBitmapPreviewPlugin : public EditorResourcePreviewGenerator {
@@ -65,8 +61,6 @@ public:
 	virtual bool handles(const String &p_type) const override;
 	virtual bool generate_small_preview_automatically() const override;
 	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size, Dictionary &p_metadata) const override;
-
-	EditorBitmapPreviewPlugin();
 };
 
 class EditorPackedScenePreviewPlugin : public EditorResourcePreviewGenerator {
@@ -76,8 +70,6 @@ public:
 	virtual bool handles(const String &p_type) const override;
 	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size, Dictionary &p_metadata) const override;
 	virtual Ref<Texture2D> generate_from_path(const String &p_path, const Size2 &p_size, Dictionary &p_metadata) const override;
-
-	EditorPackedScenePreviewPlugin();
 };
 
 class EditorMaterialPreviewPlugin : public EditorResourcePreviewGenerator {
@@ -115,8 +107,6 @@ public:
 	virtual bool handles(const String &p_type) const override;
 	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size, Dictionary &p_metadata) const override;
 	virtual Ref<Texture2D> generate_from_path(const String &p_path, const Size2 &p_size, Dictionary &p_metadata) const override;
-
-	EditorScriptPreviewPlugin();
 };
 
 class EditorAudioStreamPreviewPlugin : public EditorResourcePreviewGenerator {
@@ -125,8 +115,6 @@ class EditorAudioStreamPreviewPlugin : public EditorResourcePreviewGenerator {
 public:
 	virtual bool handles(const String &p_type) const override;
 	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size, Dictionary &p_metadata) const override;
-
-	EditorAudioStreamPreviewPlugin();
 };
 
 class EditorMeshPreviewPlugin : public EditorResourcePreviewGenerator {
@@ -179,6 +167,4 @@ public:
 	virtual bool handles(const String &p_type) const override;
 	virtual bool generate_small_preview_automatically() const override;
 	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size, Dictionary &p_metadata) const override;
-
-	EditorGradientPreviewPlugin();
 };

--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -973,9 +973,6 @@ void FontPreview::_preview_changed() {
 	queue_redraw();
 }
 
-FontPreview::FontPreview() {
-}
-
 /*************************************************************************/
 /* EditorInspectorPluginFontPreview                                      */
 /*************************************************************************/

--- a/editor/plugins/font_config_plugin.h
+++ b/editor/plugins/font_config_plugin.h
@@ -48,8 +48,6 @@ protected:
 public:
 	void set_dict(const Dictionary &p_dict);
 	Dictionary get_dict();
-
-	EditorPropertyFontMetaObject() {}
 };
 
 /*************************************************************************/
@@ -72,8 +70,6 @@ public:
 
 	void set_defaults(const Dictionary &p_dict);
 	Dictionary get_defaults();
-
-	EditorPropertyFontOTObject() {}
 };
 
 /*************************************************************************/
@@ -228,8 +224,6 @@ public:
 	virtual Size2 get_minimum_size() const override;
 
 	void set_data(const Ref<Font> &p_f);
-
-	FontPreview();
 };
 
 /*************************************************************************/

--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -1180,6 +1180,3 @@ GameViewPlugin::GameViewPlugin() {
 
 	EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &GameViewPlugin::_feature_profile_changed));
 }
-
-GameViewPlugin::~GameViewPlugin() {
-}

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -78,8 +78,6 @@ public:
 	void reset_camera_3d_position();
 
 	virtual void setup_session(int p_session_id) override;
-
-	GameViewDebugger() {}
 };
 
 class GameView : public VBoxContainer {
@@ -246,5 +244,4 @@ public:
 #endif // ANDROID_ENABLED
 
 	GameViewPlugin();
-	~GameViewPlugin();
 };

--- a/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
@@ -58,9 +58,6 @@ CollisionShape3DGizmoPlugin::CollisionShape3DGizmoPlugin() {
 	create_handle_material("handles");
 }
 
-CollisionShape3DGizmoPlugin::~CollisionShape3DGizmoPlugin() {
-}
-
 void CollisionShape3DGizmoPlugin::create_collision_material(const String &p_name, float p_alpha) {
 	Vector<Ref<StandardMaterial3D>> mats;
 

--- a/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.h
+++ b/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.h
@@ -54,5 +54,4 @@ public:
 	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel = false) override;
 
 	CollisionShape3DGizmoPlugin();
-	~CollisionShape3DGizmoPlugin();
 };

--- a/editor/plugins/gizmos/decal_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/decal_gizmo_plugin.cpp
@@ -47,9 +47,6 @@ DecalGizmoPlugin::DecalGizmoPlugin() {
 	create_handle_material("handles");
 }
 
-DecalGizmoPlugin::~DecalGizmoPlugin() {
-}
-
 bool DecalGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<Decal>(p_spatial) != nullptr;
 }

--- a/editor/plugins/gizmos/decal_gizmo_plugin.h
+++ b/editor/plugins/gizmos/decal_gizmo_plugin.h
@@ -52,5 +52,4 @@ public:
 	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel = false) override;
 
 	DecalGizmoPlugin();
-	~DecalGizmoPlugin();
 };

--- a/editor/plugins/gizmos/fog_volume_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/fog_volume_gizmo_plugin.cpp
@@ -48,9 +48,6 @@ FogVolumeGizmoPlugin::FogVolumeGizmoPlugin() {
 	create_handle_material("handles");
 }
 
-FogVolumeGizmoPlugin::~FogVolumeGizmoPlugin() {
-}
-
 bool FogVolumeGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return (Object::cast_to<FogVolume>(p_spatial) != nullptr);
 }

--- a/editor/plugins/gizmos/fog_volume_gizmo_plugin.h
+++ b/editor/plugins/gizmos/fog_volume_gizmo_plugin.h
@@ -52,5 +52,4 @@ public:
 	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel = false) override;
 
 	FogVolumeGizmoPlugin();
-	~FogVolumeGizmoPlugin();
 };

--- a/editor/plugins/gizmos/geometry_instance_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/geometry_instance_3d_gizmo_plugin.cpp
@@ -33,9 +33,6 @@
 #include "editor/editor_settings.h"
 #include "scene/3d/visual_instance_3d.h"
 
-GeometryInstance3DGizmoPlugin::GeometryInstance3DGizmoPlugin() {
-}
-
 bool GeometryInstance3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<GeometryInstance3D>(p_spatial) != nullptr;
 }

--- a/editor/plugins/gizmos/geometry_instance_3d_gizmo_plugin.h
+++ b/editor/plugins/gizmos/geometry_instance_3d_gizmo_plugin.h
@@ -41,6 +41,4 @@ public:
 	virtual int get_priority() const override;
 
 	virtual void redraw(EditorNode3DGizmo *p_gizmo) override;
-
-	GeometryInstance3DGizmoPlugin();
 };

--- a/editor/plugins/gizmos/gpu_particles_collision_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/gpu_particles_collision_3d_gizmo_plugin.cpp
@@ -52,9 +52,6 @@ GPUParticlesCollision3DGizmoPlugin::GPUParticlesCollision3DGizmoPlugin() {
 	create_handle_material("handles");
 }
 
-GPUParticlesCollision3DGizmoPlugin::~GPUParticlesCollision3DGizmoPlugin() {
-}
-
 bool GPUParticlesCollision3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return (Object::cast_to<GPUParticlesCollision3D>(p_spatial) != nullptr) || (Object::cast_to<GPUParticlesAttractor3D>(p_spatial) != nullptr);
 }

--- a/editor/plugins/gizmos/gpu_particles_collision_3d_gizmo_plugin.h
+++ b/editor/plugins/gizmos/gpu_particles_collision_3d_gizmo_plugin.h
@@ -52,5 +52,4 @@ public:
 	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel = false) override;
 
 	GPUParticlesCollision3DGizmoPlugin();
-	~GPUParticlesCollision3DGizmoPlugin();
 };

--- a/editor/plugins/gizmos/label_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/label_3d_gizmo_plugin.cpp
@@ -32,9 +32,6 @@
 
 #include "scene/3d/label_3d.h"
 
-Label3DGizmoPlugin::Label3DGizmoPlugin() {
-}
-
 bool Label3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<Label3D>(p_spatial) != nullptr;
 }

--- a/editor/plugins/gizmos/label_3d_gizmo_plugin.h
+++ b/editor/plugins/gizmos/label_3d_gizmo_plugin.h
@@ -41,6 +41,4 @@ public:
 	int get_priority() const override;
 	bool can_be_hidden() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
-
-	Label3DGizmoPlugin();
 };

--- a/editor/plugins/gizmos/mesh_instance_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/mesh_instance_3d_gizmo_plugin.cpp
@@ -35,9 +35,6 @@
 #include "scene/3d/soft_body_3d.h"
 #include "scene/resources/3d/primitive_meshes.h"
 
-MeshInstance3DGizmoPlugin::MeshInstance3DGizmoPlugin() {
-}
-
 bool MeshInstance3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<MeshInstance3D>(p_spatial) != nullptr && Object::cast_to<SoftBody3D>(p_spatial) == nullptr;
 }

--- a/editor/plugins/gizmos/mesh_instance_3d_gizmo_plugin.h
+++ b/editor/plugins/gizmos/mesh_instance_3d_gizmo_plugin.h
@@ -41,6 +41,4 @@ public:
 	int get_priority() const override;
 	bool can_be_hidden() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
-
-	MeshInstance3DGizmoPlugin();
 };

--- a/editor/plugins/gizmos/reflection_probe_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/reflection_probe_gizmo_plugin.cpp
@@ -51,9 +51,6 @@ ReflectionProbeGizmoPlugin::ReflectionProbeGizmoPlugin() {
 	create_handle_material("handles");
 }
 
-ReflectionProbeGizmoPlugin::~ReflectionProbeGizmoPlugin() {
-}
-
 bool ReflectionProbeGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<ReflectionProbe>(p_spatial) != nullptr;
 }

--- a/editor/plugins/gizmos/reflection_probe_gizmo_plugin.h
+++ b/editor/plugins/gizmos/reflection_probe_gizmo_plugin.h
@@ -52,5 +52,4 @@ public:
 	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel = false) override;
 
 	ReflectionProbeGizmoPlugin();
-	~ReflectionProbeGizmoPlugin();
 };

--- a/editor/plugins/gizmos/sprite_base_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/sprite_base_3d_gizmo_plugin.cpp
@@ -32,9 +32,6 @@
 
 #include "scene/3d/sprite_3d.h"
 
-SpriteBase3DGizmoPlugin::SpriteBase3DGizmoPlugin() {
-}
-
 bool SpriteBase3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<SpriteBase3D>(p_spatial) != nullptr;
 }

--- a/editor/plugins/gizmos/sprite_base_3d_gizmo_plugin.h
+++ b/editor/plugins/gizmos/sprite_base_3d_gizmo_plugin.h
@@ -41,6 +41,4 @@ public:
 	int get_priority() const override;
 	bool can_be_hidden() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
-
-	SpriteBase3DGizmoPlugin();
 };

--- a/editor/plugins/gizmos/voxel_gi_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/voxel_gi_gizmo_plugin.cpp
@@ -51,9 +51,6 @@ VoxelGIGizmoPlugin::VoxelGIGizmoPlugin() {
 	create_handle_material("handles");
 }
 
-VoxelGIGizmoPlugin::~VoxelGIGizmoPlugin() {
-}
-
 bool VoxelGIGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<VoxelGI>(p_spatial) != nullptr;
 }

--- a/editor/plugins/gizmos/voxel_gi_gizmo_plugin.h
+++ b/editor/plugins/gizmos/voxel_gi_gizmo_plugin.h
@@ -52,5 +52,4 @@ public:
 	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel = false) override;
 
 	VoxelGIGizmoPlugin();
-	~VoxelGIGizmoPlugin();
 };

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -199,6 +199,3 @@ GPUParticlesCollisionSDF3DEditorPlugin::GPUParticlesCollisionSDF3DEditorPlugin()
 	GPUParticlesCollisionSDF3D::bake_step_function = bake_func_step;
 	GPUParticlesCollisionSDF3D::bake_end_function = bake_func_end;
 }
-
-GPUParticlesCollisionSDF3DEditorPlugin::~GPUParticlesCollisionSDF3DEditorPlugin() {
-}

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
@@ -67,5 +67,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	GPUParticlesCollisionSDF3DEditorPlugin();
-	~GPUParticlesCollisionSDF3DEditorPlugin();
 };

--- a/editor/plugins/light_occluder_2d_editor_plugin.cpp
+++ b/editor/plugins/light_occluder_2d_editor_plugin.cpp
@@ -106,8 +106,6 @@ void LightOccluder2DEditor::_create_resource() {
 	_menu_option(MODE_CREATE);
 }
 
-LightOccluder2DEditor::LightOccluder2DEditor() {}
-
 LightOccluder2DEditorPlugin::LightOccluder2DEditorPlugin() :
 		AbstractPolygon2DEditorPlugin(memnew(LightOccluder2DEditor), "LightOccluder2D") {
 }

--- a/editor/plugins/light_occluder_2d_editor_plugin.h
+++ b/editor/plugins/light_occluder_2d_editor_plugin.h
@@ -53,9 +53,6 @@ protected:
 
 	virtual bool _has_resource() const override;
 	virtual void _create_resource() override;
-
-public:
-	LightOccluder2DEditor();
 };
 
 class LightOccluder2DEditorPlugin : public AbstractPolygon2DEditorPlugin {

--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -214,6 +214,3 @@ LightmapGIEditorPlugin::LightmapGIEditorPlugin() {
 	file_dialog->connect("file_selected", callable_mp(this, &LightmapGIEditorPlugin::_bake_select_file));
 	bake->add_child(file_dialog);
 }
-
-LightmapGIEditorPlugin::~LightmapGIEditorPlugin() {
-}

--- a/editor/plugins/lightmap_gi_editor_plugin.h
+++ b/editor/plugins/lightmap_gi_editor_plugin.h
@@ -63,5 +63,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	LightmapGIEditorPlugin();
-	~LightmapGIEditorPlugin();
 };

--- a/editor/plugins/line_2d_editor_plugin.cpp
+++ b/editor/plugins/line_2d_editor_plugin.cpp
@@ -59,8 +59,6 @@ void Line2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, con
 	undo_redo->add_undo_method(_node, "set_points", p_previous);
 }
 
-Line2DEditor::Line2DEditor() {}
-
 Line2DEditorPlugin::Line2DEditorPlugin() :
 		AbstractPolygon2DEditorPlugin(memnew(Line2DEditor), "Line2D") {
 }

--- a/editor/plugins/line_2d_editor_plugin.h
+++ b/editor/plugins/line_2d_editor_plugin.h
@@ -46,9 +46,6 @@ protected:
 	virtual Variant _get_polygon(int p_idx) const override;
 	virtual void _set_polygon(int p_idx, const Variant &p_polygon) const override;
 	virtual void _action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) override;
-
-public:
-	Line2DEditor();
 };
 
 class Line2DEditorPlugin : public AbstractPolygon2DEditorPlugin {

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -730,6 +730,3 @@ MeshInstance3DEditorPlugin::MeshInstance3DEditorPlugin() {
 
 	mesh_editor->options->hide();
 }
-
-MeshInstance3DEditorPlugin::~MeshInstance3DEditorPlugin() {
-}

--- a/editor/plugins/mesh_instance_3d_editor_plugin.h
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.h
@@ -119,5 +119,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	MeshInstance3DEditorPlugin();
-	~MeshInstance3DEditorPlugin();
 };

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -388,6 +388,3 @@ MultiMeshEditorPlugin::MultiMeshEditorPlugin() {
 
 	multimesh_editor->options->hide();
 }
-
-MultiMeshEditorPlugin::~MultiMeshEditorPlugin() {
-}

--- a/editor/plugins/multimesh_editor_plugin.h
+++ b/editor/plugins/multimesh_editor_plugin.h
@@ -97,5 +97,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	MultiMeshEditorPlugin();
-	~MultiMeshEditorPlugin();
 };

--- a/editor/plugins/navigation_obstacle_2d_editor_plugin.cpp
+++ b/editor/plugins/navigation_obstacle_2d_editor_plugin.cpp
@@ -66,8 +66,6 @@ void NavigationObstacle2DEditor::_action_set_polygon(int p_idx, const Variant &p
 	undo_redo->add_undo_method(node, "set_vertices", node->get_vertices());
 }
 
-NavigationObstacle2DEditor::NavigationObstacle2DEditor() {}
-
 NavigationObstacle2DEditorPlugin::NavigationObstacle2DEditorPlugin() :
 		AbstractPolygon2DEditorPlugin(memnew(NavigationObstacle2DEditor), "NavigationObstacle2D") {
 }

--- a/editor/plugins/navigation_obstacle_2d_editor_plugin.h
+++ b/editor/plugins/navigation_obstacle_2d_editor_plugin.h
@@ -48,9 +48,6 @@ protected:
 	virtual void _action_add_polygon(const Variant &p_polygon) override;
 	virtual void _action_remove_polygon(int p_idx) override;
 	virtual void _action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) override;
-
-public:
-	NavigationObstacle2DEditor();
 };
 
 class NavigationObstacle2DEditorPlugin : public AbstractPolygon2DEditorPlugin {

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -9730,6 +9730,3 @@ Node3DEditorPlugin::Node3DEditorPlugin() {
 
 	spatial_editor->hide();
 }
-
-Node3DEditorPlugin::~Node3DEditorPlugin() {
-}

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -1042,7 +1042,6 @@ public:
 	virtual void edited_scene_changed() override;
 
 	Node3DEditorPlugin();
-	~Node3DEditorPlugin();
 };
 
 class ViewportNavigationControl : public Control {

--- a/editor/plugins/occluder_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/occluder_instance_3d_editor_plugin.cpp
@@ -119,6 +119,3 @@ OccluderInstance3DEditorPlugin::OccluderInstance3DEditorPlugin() {
 	file_dialog->connect("file_selected", callable_mp(this, &OccluderInstance3DEditorPlugin::_bake_select_file));
 	bake->add_child(file_dialog);
 }
-
-OccluderInstance3DEditorPlugin::~OccluderInstance3DEditorPlugin() {
-}

--- a/editor/plugins/occluder_instance_3d_editor_plugin.h
+++ b/editor/plugins/occluder_instance_3d_editor_plugin.h
@@ -59,5 +59,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	OccluderInstance3DEditorPlugin();
-	~OccluderInstance3DEditorPlugin();
 };

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -787,6 +787,3 @@ Path2DEditorPlugin::Path2DEditorPlugin() {
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(path2d_editor);
 	path2d_editor->hide();
 }
-
-Path2DEditorPlugin::~Path2DEditorPlugin() {
-}

--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -136,5 +136,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	Path2DEditorPlugin();
-	~Path2DEditorPlugin();
 };

--- a/editor/plugins/physical_bone_3d_editor_plugin.cpp
+++ b/editor/plugins/physical_bone_3d_editor_plugin.cpp
@@ -82,8 +82,6 @@ void PhysicalBone3DEditor::show() {
 	spatial_editor_hb->show();
 }
 
-PhysicalBone3DEditorPlugin::PhysicalBone3DEditorPlugin() {}
-
 void PhysicalBone3DEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		physical_bone_editor.show();

--- a/editor/plugins/physical_bone_3d_editor_plugin.h
+++ b/editor/plugins/physical_bone_3d_editor_plugin.h
@@ -50,7 +50,6 @@ private:
 
 public:
 	PhysicalBone3DEditor();
-	~PhysicalBone3DEditor() {}
 
 	void set_selected(PhysicalBone3D *p_pb);
 
@@ -69,6 +68,4 @@ public:
 	virtual bool handles(Object *p_object) const override { return p_object->is_class("PhysicalBone3D"); }
 	virtual void make_visible(bool p_visible) override;
 	virtual void edit(Object *p_node) override;
-
-	PhysicalBone3DEditorPlugin();
 };

--- a/editor/plugins/plugin_config_dialog.cpp
+++ b/editor/plugins/plugin_config_dialog.cpp
@@ -340,6 +340,3 @@ PluginConfigDialog::PluginConfigDialog() {
 	subfolder_edit->connect(SceneStringName(text_changed), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
 	script_edit->connect(SceneStringName(text_changed), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
 }
-
-PluginConfigDialog::~PluginConfigDialog() {
-}

--- a/editor/plugins/plugin_config_dialog.h
+++ b/editor/plugins/plugin_config_dialog.h
@@ -81,5 +81,4 @@ public:
 	void config(const String &p_config_path);
 
 	PluginConfigDialog();
-	~PluginConfigDialog();
 };

--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -611,6 +611,3 @@ Polygon3DEditorPlugin::Polygon3DEditorPlugin() {
 
 	polygon_editor->hide();
 }
-
-Polygon3DEditorPlugin::~Polygon3DEditorPlugin() {
-}

--- a/editor/plugins/polygon_3d_editor_plugin.h
+++ b/editor/plugins/polygon_3d_editor_plugin.h
@@ -110,5 +110,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	Polygon3DEditorPlugin();
-	~Polygon3DEditorPlugin();
 };

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -427,6 +427,3 @@ ResourcePreloaderEditorPlugin::ResourcePreloaderEditorPlugin() {
 	button = EditorNode::get_bottom_panel()->add_item("ResourcePreloader", preloader_editor, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_resource_preloader_bottom_panel", TTRC("Toggle ResourcePreloader Bottom Panel")));
 	button->hide();
 }
-
-ResourcePreloaderEditorPlugin::~ResourcePreloaderEditorPlugin() {
-}

--- a/editor/plugins/resource_preloader_editor_plugin.h
+++ b/editor/plugins/resource_preloader_editor_plugin.h
@@ -94,5 +94,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	ResourcePreloaderEditorPlugin();
-	~ResourcePreloaderEditorPlugin();
 };

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -389,8 +389,6 @@ public:
 
 		return E->value.cache;
 	}
-
-	virtual ~EditorScriptCodeCompletionCache() {}
 };
 
 void ScriptEditorQuickOpen::popup_dialog(const Vector<String> &p_functions, bool p_dontclear) {
@@ -4710,7 +4708,4 @@ ScriptEditorPlugin::ScriptEditorPlugin() {
 	window_wrapper->connect("window_visibility_changed", callable_mp(this, &ScriptEditorPlugin::_window_visibility_changed));
 
 	ScriptServer::set_reload_scripts_on_save(EDITOR_GET("text_editor/behavior/files/auto_reload_and_parse_scripts_on_save"));
-}
-
-ScriptEditorPlugin::~ScriptEditorPlugin() {
 }

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -222,8 +222,6 @@ public:
 	virtual CodeTextEditor *get_code_editor() const = 0;
 
 	virtual void validate() = 0;
-
-	ScriptEditorBase() {}
 };
 
 typedef ScriptEditorBase *(*CreateScriptEditorFunc)(const Ref<Resource> &p_resource);
@@ -642,5 +640,4 @@ public:
 	virtual void edited_scene_changed() override;
 
 	ScriptEditorPlugin();
-	~ScriptEditorPlugin();
 };

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -848,6 +848,3 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	shader_create_dialog->connect("shader_created", callable_mp(this, &ShaderEditorPlugin::_shader_created));
 	shader_create_dialog->connect("shader_include_created", callable_mp(this, &ShaderEditorPlugin::_shader_include_created));
 }
-
-ShaderEditorPlugin::~ShaderEditorPlugin() {
-}

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -145,5 +145,4 @@ public:
 	virtual void apply_changes() override;
 
 	ShaderEditorPlugin();
-	~ShaderEditorPlugin();
 };

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -319,6 +319,3 @@ ShaderFileEditorPlugin::ShaderFileEditorPlugin() {
 	button = EditorNode::get_bottom_panel()->add_item(TTR("ShaderFile"), shader_editor, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_shader_file_bottom_panel", TTRC("Toggle ShaderFile Bottom Panel")));
 	button->hide();
 }
-
-ShaderFileEditorPlugin::~ShaderFileEditorPlugin() {
-}

--- a/editor/plugins/shader_file_editor_plugin.h
+++ b/editor/plugins/shader_file_editor_plugin.h
@@ -81,5 +81,4 @@ public:
 	ShaderFileEditor *get_shader_editor() const { return shader_editor; }
 
 	ShaderFileEditorPlugin();
-	~ShaderFileEditorPlugin();
 };

--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -133,6 +133,3 @@ Skeleton2DEditorPlugin::Skeleton2DEditorPlugin() {
 
 	//sprite_editor->options->hide();
 }
-
-Skeleton2DEditorPlugin::~Skeleton2DEditorPlugin() {
-}

--- a/editor/plugins/skeleton_2d_editor_plugin.h
+++ b/editor/plugins/skeleton_2d_editor_plugin.h
@@ -75,5 +75,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	Skeleton2DEditorPlugin();
-	~Skeleton2DEditorPlugin();
 };

--- a/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
@@ -83,5 +83,3 @@ SkeletonIK3DEditorPlugin::SkeletonIK3DEditorPlugin() {
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, play_btn);
 	skeleton_ik = nullptr;
 }
-
-SkeletonIK3DEditorPlugin::~SkeletonIK3DEditorPlugin() {}

--- a/editor/plugins/skeleton_ik_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_ik_3d_editor_plugin.h
@@ -52,5 +52,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	SkeletonIK3DEditorPlugin();
-	~SkeletonIK3DEditorPlugin();
 };

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -684,6 +684,3 @@ Sprite2DEditorPlugin::Sprite2DEditorPlugin() {
 
 	//sprite_editor->options->hide();
 }
-
-Sprite2DEditorPlugin::~Sprite2DEditorPlugin() {
-}

--- a/editor/plugins/sprite_2d_editor_plugin.h
+++ b/editor/plugins/sprite_2d_editor_plugin.h
@@ -127,5 +127,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	Sprite2DEditorPlugin();
-	~Sprite2DEditorPlugin();
 };

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -2536,6 +2536,3 @@ SpriteFramesEditorPlugin::SpriteFramesEditorPlugin() {
 	button = EditorNode::get_bottom_panel()->add_item(TTR("SpriteFrames"), frames_editor, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_sprite_frames_bottom_panel", TTRC("Toggle SpriteFrames Bottom Panel")));
 	button->hide();
 }
-
-SpriteFramesEditorPlugin::~SpriteFramesEditorPlugin() {
-}

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -301,5 +301,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	SpriteFramesEditorPlugin();
-	~SpriteFramesEditorPlugin();
 };

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -415,9 +415,6 @@ TextureLayeredEditor::TextureLayeredEditor() {
 	add_child(info);
 }
 
-TextureLayeredEditor::~TextureLayeredEditor() {
-}
-
 bool EditorInspectorPluginLayeredTexture::can_handle(Object *p_object) {
 	return Object::cast_to<TextureLayered>(p_object) != nullptr;
 }

--- a/editor/plugins/texture_layered_editor_plugin.h
+++ b/editor/plugins/texture_layered_editor_plugin.h
@@ -82,7 +82,6 @@ public:
 	void edit(Ref<TextureLayered> p_texture);
 
 	TextureLayeredEditor();
-	~TextureLayeredEditor();
 };
 
 class EditorInspectorPluginLayeredTexture : public EditorInspectorPlugin {

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -2497,9 +2497,6 @@ TileMapLayerEditorTilesPlugin::TileMapLayerEditorTilesPlugin() {
 	_update_source_display();
 }
 
-TileMapLayerEditorTilesPlugin::~TileMapLayerEditorTilesPlugin() {
-}
-
 void TileMapLayerEditorTerrainsPlugin::tile_set_changed() {
 	_update_terrains_cache();
 	_update_terrains_tree();
@@ -3628,9 +3625,6 @@ TileMapLayerEditorTerrainsPlugin::TileMapLayerEditorTerrainsPlugin() {
 	bucket_contiguous_checkbox->set_text(TTR("Contiguous"));
 	bucket_contiguous_checkbox->set_pressed(true);
 	tools_settings->add_child(bucket_contiguous_checkbox);
-}
-
-TileMapLayerEditorTerrainsPlugin::~TileMapLayerEditorTerrainsPlugin() {
 }
 
 TileMapLayer *TileMapLayerEditor::_get_edited_layer() const {

--- a/editor/plugins/tiles/tile_map_layer_editor.h
+++ b/editor/plugins/tiles/tile_map_layer_editor.h
@@ -239,7 +239,6 @@ public:
 	virtual void edit(ObjectID p_tile_map_layer_id) override;
 
 	TileMapLayerEditorTilesPlugin();
-	~TileMapLayerEditorTilesPlugin();
 };
 
 class TileMapLayerEditorTerrainsPlugin : public TileMapLayerSubEditorPlugin {
@@ -331,7 +330,6 @@ public:
 	virtual void edit(ObjectID p_tile_map_layer_id) override;
 
 	TileMapLayerEditorTerrainsPlugin();
-	~TileMapLayerEditorTerrainsPlugin();
 };
 
 class TileMapLayerEditor : public VBoxContainer {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1491,9 +1491,6 @@ void VisualShaderGraphPlugin::disconnect_nodes(VisualShader::Type p_type, int p_
 	}
 }
 
-VisualShaderGraphPlugin::~VisualShaderGraphPlugin() {
-}
-
 /////////////////
 
 void VisualShaderEditedProperty::_bind_methods() {

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -178,7 +178,6 @@ public:
 	VisualShader::Type get_shader_type() const;
 
 	VisualShaderGraphPlugin();
-	~VisualShaderGraphPlugin();
 };
 
 class VisualShaderEditedProperty : public RefCounted {
@@ -193,8 +192,6 @@ protected:
 public:
 	void set_edited_property(const Variant &p_variant);
 	Variant get_edited_property() const;
-
-	VisualShaderEditedProperty() {}
 };
 
 class VisualShaderEditor : public ShaderEditor {

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -203,6 +203,3 @@ VoxelGIEditorPlugin::VoxelGIEditorPlugin() {
 	VoxelGI::bake_step_function = bake_func_step;
 	VoxelGI::bake_end_function = bake_func_end;
 }
-
-VoxelGIEditorPlugin::~VoxelGIEditorPlugin() {
-}

--- a/editor/plugins/voxel_gi_editor_plugin.h
+++ b/editor/plugins/voxel_gi_editor_plugin.h
@@ -66,5 +66,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	VoxelGIEditorPlugin();
-	~VoxelGIEditorPlugin();
 };

--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -249,9 +249,6 @@ POTGenerator *POTGenerator::get_singleton() {
 	return singleton;
 }
 
-POTGenerator::POTGenerator() {
-}
-
 POTGenerator::~POTGenerator() {
 	memdelete(singleton);
 	singleton = nullptr;

--- a/editor/pot_generator.h
+++ b/editor/pot_generator.h
@@ -60,6 +60,5 @@ public:
 	static POTGenerator *get_singleton();
 	void generate_pot(const String &p_file);
 
-	POTGenerator();
 	~POTGenerator();
 };

--- a/editor/progress_dialog.h
+++ b/editor/progress_dialog.h
@@ -59,8 +59,6 @@ public:
 	void add_task(const String &p_task, const String &p_label, int p_steps);
 	void task_step(const String &p_task, int p_step = -1);
 	void end_task(const String &p_task);
-
-	BackgroundProgress() {}
 };
 
 class PanelContainer;

--- a/editor/reparent_dialog.cpp
+++ b/editor/reparent_dialog.cpp
@@ -87,6 +87,3 @@ ReparentDialog::ReparentDialog() {
 
 	set_ok_button_text(TTR("Reparent"));
 }
-
-ReparentDialog::~ReparentDialog() {
-}

--- a/editor/reparent_dialog.h
+++ b/editor/reparent_dialog.h
@@ -52,5 +52,4 @@ public:
 	void set_current(const HashSet<Node *> &p_selection);
 
 	ReparentDialog();
-	~ReparentDialog();
 };

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -185,9 +185,6 @@ CSGShape3DGizmoPlugin::CSGShape3DGizmoPlugin() {
 	create_handle_material("handles");
 }
 
-CSGShape3DGizmoPlugin::~CSGShape3DGizmoPlugin() {
-}
-
 String CSGShape3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {
 	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_node_3d());
 

--- a/modules/csg/editor/csg_gizmos.h
+++ b/modules/csg/editor/csg_gizmos.h
@@ -59,7 +59,6 @@ public:
 	virtual void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel) override;
 
 	CSGShape3DGizmoPlugin();
-	~CSGShape3DGizmoPlugin();
 };
 
 class CSGShapeEditor : public Control {

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -593,6 +593,3 @@ bool EditorFileSystemImportFormatSupportQueryBlend::query() {
 
 	return false;
 }
-
-EditorFileSystemImportFormatSupportQueryBlend::EditorFileSystemImportFormatSupportQueryBlend() {
-}

--- a/modules/gltf/editor/editor_scene_importer_blend.h
+++ b/modules/gltf/editor/editor_scene_importer_blend.h
@@ -105,6 +105,4 @@ public:
 	virtual bool is_active() const override;
 	virtual Vector<String> get_file_extensions() const override;
 	virtual bool query() override;
-
-	EditorFileSystemImportFormatSupportQueryBlend();
 };

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1875,9 +1875,3 @@ int GridMapEditorPlugin::get_selected_palette_item() const {
 		return -1;
 	}
 }
-
-GridMapEditorPlugin::GridMapEditorPlugin() {
-}
-
-GridMapEditorPlugin::~GridMapEditorPlugin() {
-}

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -292,7 +292,4 @@ public:
 	Array get_selected_cells() const;
 	void set_selected_palette_item(int p_item) const;
 	int get_selected_palette_item() const;
-
-	GridMapEditorPlugin();
-	~GridMapEditorPlugin();
 };

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.h
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.h
@@ -50,8 +50,6 @@ public:
 	virtual bool has_capture(const String &p_capture) const override;
 	virtual bool capture(const String &p_message, const Array &p_data, int p_index) override;
 	virtual void setup_session(int p_session_id) override;
-
-	MultiplayerEditorDebugger() {}
 };
 
 class ReplicationEditor;

--- a/modules/multiplayer/editor/replication_editor.h
+++ b/modules/multiplayer/editor/replication_editor.h
@@ -101,5 +101,4 @@ public:
 
 	Button *get_pin() { return pin; }
 	ReplicationEditor();
-	~ReplicationEditor() {}
 };

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
@@ -147,9 +147,6 @@ NavigationMeshEditor::NavigationMeshEditor() {
 	node = nullptr;
 }
 
-NavigationMeshEditor::~NavigationMeshEditor() {
-}
-
 void NavigationMeshEditorPlugin::edit(Object *p_object) {
 	navigation_mesh_editor->edit(Object::cast_to<NavigationRegion3D>(p_object));
 }
@@ -175,7 +172,4 @@ NavigationMeshEditorPlugin::NavigationMeshEditorPlugin() {
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, navigation_mesh_editor->bake_hbox);
 	navigation_mesh_editor->hide();
 	navigation_mesh_editor->bake_hbox->hide();
-}
-
-NavigationMeshEditorPlugin::~NavigationMeshEditorPlugin() {
 }

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.h
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.h
@@ -62,7 +62,6 @@ protected:
 public:
 	void edit(NavigationRegion3D *p_nav_region);
 	NavigationMeshEditor();
-	~NavigationMeshEditor();
 };
 
 class NavigationMeshEditorPlugin : public EditorPlugin {
@@ -78,5 +77,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	NavigationMeshEditorPlugin();
-	~NavigationMeshEditorPlugin();
 };

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -496,6 +496,3 @@ OpenXRActionMapEditor::OpenXRActionMapEditor() {
 	// So load our action map and if it doesn't exist, create it right away.
 	_load_action_map(GLOBAL_GET("xr/openxr/default_action_map"), true);
 }
-
-OpenXRActionMapEditor::~OpenXRActionMapEditor() {
-}

--- a/modules/openxr/editor/openxr_action_map_editor.h
+++ b/modules/openxr/editor/openxr_action_map_editor.h
@@ -110,5 +110,4 @@ public:
 	void open_action_map(String p_path);
 
 	OpenXRActionMapEditor();
-	~OpenXRActionMapEditor();
 };

--- a/modules/openxr/editor/openxr_editor_plugin.cpp
+++ b/modules/openxr/editor/openxr_editor_plugin.cpp
@@ -64,6 +64,3 @@ OpenXREditorPlugin::OpenXREditorPlugin() {
 	add_control_to_container(CONTAINER_TOOLBAR, select_runtime);
 #endif
 }
-
-OpenXREditorPlugin::~OpenXREditorPlugin() {
-}

--- a/modules/openxr/editor/openxr_editor_plugin.h
+++ b/modules/openxr/editor/openxr_editor_plugin.h
@@ -53,5 +53,4 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	OpenXREditorPlugin();
-	~OpenXREditorPlugin();
 };


### PR DESCRIPTION
For whatever reason the codebase is full of empty constructors and destructors. If a class doesn't have any other constructor, a default public constructor is generated implicitly, so adding explicit one is useless. They aren't even added consistently.

I've been removing them whenever I spotted in a file I was editing, but this PR just handles them all at once.

It's limited to `editor/`, because initially I had a file filter enabled by mistake when searching. Then I realized that outside `editor/` there is twice as much cases, so I left it like that to limit the amount changes.