### PR TITLE
Validate split spaces to prevent crash.

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -151,10 +151,12 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 							}
 						}
 						// "#region" and "#endregion" only highlighted if they're the first region on the line.
-						if (color_regions[c].type == ColorRegion::TYPE_CODE_REGION &&
-								str.strip_edges().split_spaces()[0] != "#region" &&
-								str.strip_edges().split_spaces()[0] != "#endregion") {
-							match = false;
+						if (color_regions[c].type == ColorRegion::TYPE_CODE_REGION) {
+							Vector<String> split_spaces = str.strip_edges().split_spaces();
+							if (split_spaces.size() == 0 ||
+									(split_spaces[0] != "#region" && split_spaces[0] != "#endregion")) {
+								match = false;
+							}
 						}
 						if (!match) {
 							continue;


### PR DESCRIPTION
This fixes a crash I encountered where no split spaces are extracted from the string in the original code resulting in a crash caused by checking outside of the array bounds. Unfortunately, I have not been able to reliably reproduce the conditions which causes this crash, but this extra validation step should prevent the crash occuring regardless.