### PR TITLE
Warn if setting non-existent shader parameter

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -454,6 +454,18 @@ void ShaderMaterial::set_shader_parameter(const StringName &p_param, const Varia
 	} else {
 		Variant *v = param_cache.getptr(p_param);
 		if (!v) {
+#ifdef TOOLS_ENABLED
+			bool missing = true;
+			if (param_cache.is_empty()) {
+				// Build parameter cache.
+				List<PropertyInfo> l;
+				_get_property_list(&l);
+				missing = !param_cache.has(p_param);
+			}
+			if (missing) {
+				WARN_PRINT(vformat("Shader parameter \"%s\" not found in Shader.", p_param));
+			}
+#endif
 			// Never assigned, also update the remap cache.
 			remap_cache["shader_parameter/" + p_param.operator String()] = p_param;
 			param_cache.insert(p_param, p_value);


### PR DESCRIPTION
Closes #57971

![image](https://github.com/user-attachments/assets/6ce49002-55be-4104-987b-3bdd5fb7deea)

The warning requires parameter cache to be rebuilt (once per ShaderMaterial), which can be costly, so the check is done only in editor builds.