### PR TITLE
[GDScript]: Fix some off by one stack space checks in various opcodes.

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -940,7 +940,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_SET_KEYED) {
-				CHECK_SPACE(3);
+				CHECK_SPACE(4);
 
 				GET_VARIANT_PTR(dst, 0);
 				GET_VARIANT_PTR(index, 1);
@@ -986,7 +986,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_SET_KEYED_VALIDATED) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(dst, 0);
 				GET_VARIANT_PTR(index, 1);
@@ -1020,7 +1020,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_SET_INDEXED_VALIDATED) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(dst, 0);
 				GET_VARIANT_PTR(index, 1);
@@ -1056,7 +1056,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_GET_KEYED) {
-				CHECK_SPACE(3);
+				CHECK_SPACE(4);
 
 				GET_VARIANT_PTR(src, 0);
 				GET_VARIANT_PTR(index, 1);
@@ -1092,7 +1092,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_GET_KEYED_VALIDATED) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(src, 0);
 				GET_VARIANT_PTR(key, 1);
@@ -1128,7 +1128,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_GET_INDEXED_VALIDATED) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(src, 0);
 				GET_VARIANT_PTR(index, 1);
@@ -1160,7 +1160,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_SET_NAMED) {
-				CHECK_SPACE(3);
+				CHECK_SPACE(4);
 
 				GET_VARIANT_PTR(dst, 0);
 				GET_VARIANT_PTR(value, 1);
@@ -1197,7 +1197,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_SET_NAMED_VALIDATED) {
-				CHECK_SPACE(3);
+				CHECK_SPACE(4);
 
 				GET_VARIANT_PTR(dst, 0);
 				GET_VARIANT_PTR(value, 1);
@@ -1242,7 +1242,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_GET_NAMED_VALIDATED) {
-				CHECK_SPACE(3);
+				CHECK_SPACE(4);
 
 				GET_VARIANT_PTR(src, 0);
 				GET_VARIANT_PTR(dst, 1);
@@ -1689,8 +1689,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 			OPCODE(OPCODE_CONSTRUCT) {
 				LOAD_INSTRUCTION_ARGS
-				CHECK_SPACE(2 + instr_arg_count);
-
+				CHECK_SPACE(3 + instr_arg_count);
 				ip += instr_arg_count;
 
 				int argc = _code_ptr[ip + 1];
@@ -1717,7 +1716,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 			OPCODE(OPCODE_CONSTRUCT_VALIDATED) {
 				LOAD_INSTRUCTION_ARGS
-				CHECK_SPACE(2 + instr_arg_count);
+				CHECK_SPACE(3 + instr_arg_count);
 				ip += instr_arg_count;
 
 				int argc = _code_ptr[ip + 1];
@@ -1738,7 +1737,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 			OPCODE(OPCODE_CONSTRUCT_ARRAY) {
 				LOAD_INSTRUCTION_ARGS
-				CHECK_SPACE(1 + instr_arg_count);
+				CHECK_SPACE(2 + instr_arg_count);
 				ip += instr_arg_count;
 
 				int argc = _code_ptr[ip + 1];
@@ -1760,7 +1759,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 			OPCODE(OPCODE_CONSTRUCT_TYPED_ARRAY) {
 				LOAD_INSTRUCTION_ARGS
-				CHECK_SPACE(3 + instr_arg_count);
+				CHECK_SPACE(4 + instr_arg_count);
 				ip += instr_arg_count;
 
 				int argc = _code_ptr[ip + 1];
@@ -2518,6 +2517,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 					if (result.get_type() != Variant::SIGNAL) {
 						// Not async, return immediately using the target from OPCODE_AWAIT_RESUME.
+						CHECK_SPACE(2 + 2);
 						GET_VARIANT_PTR(target, 2);
 						*target = result;
 						ip += 4; // Skip OPCODE_AWAIT_RESUME and its data.
@@ -2947,7 +2947,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			}
 
 			OPCODE(OPCODE_ITERATE_BEGIN) {
-				CHECK_SPACE(8); // Space for this and a regular iterate.
+				CHECK_SPACE(3 + 5); // Space for this and a regular iterate.
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -2981,7 +2981,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_BEGIN_INT) {
-				CHECK_SPACE(8); // Check space for iterate instruction too.
+				CHECK_SPACE(3 + 5); // Check space for iterate instruction too.
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3008,7 +3008,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_BEGIN_FLOAT) {
-				CHECK_SPACE(8); // Check space for iterate instruction too.
+				CHECK_SPACE(3 + 5); // Check space for iterate instruction too.
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3035,7 +3035,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_BEGIN_VECTOR2) {
-				CHECK_SPACE(8); // Check space for iterate instruction too.
+				CHECK_SPACE(3 + 5); // Check space for iterate instruction too.
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3062,7 +3062,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_BEGIN_VECTOR2I) {
-				CHECK_SPACE(8); // Check space for iterate instruction too.
+				CHECK_SPACE(3 + 5); // Check space for iterate instruction too.
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3089,7 +3089,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_BEGIN_VECTOR3) {
-				CHECK_SPACE(8); // Check space for iterate instruction too.
+				CHECK_SPACE(3 + 5); // Check space for iterate instruction too.
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3121,7 +3121,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_BEGIN_VECTOR3I) {
-				CHECK_SPACE(8); // Check space for iterate instruction too.
+				CHECK_SPACE(3 + 5); // Check space for iterate instruction too.
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3153,7 +3153,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_BEGIN_STRING) {
-				CHECK_SPACE(8); // Check space for iterate instruction too.
+				CHECK_SPACE(3 + 5); // Check space for iterate instruction too.
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3180,7 +3180,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_BEGIN_DICTIONARY) {
-				CHECK_SPACE(8); // Check space for iterate instruction too.
+				CHECK_SPACE(3 + 5); // Check space for iterate instruction too.
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3205,7 +3205,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_BEGIN_ARRAY) {
-				CHECK_SPACE(8); // Check space for iterate instruction too.
+				CHECK_SPACE(3 + 5); // Check space for iterate instruction too.
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3232,7 +3232,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 #define OPCODE_ITERATE_BEGIN_PACKED_ARRAY(m_var_type, m_elem_type, m_get_func, m_var_ret_type, m_ret_type, m_ret_get_func) \
 	OPCODE(OPCODE_ITERATE_BEGIN_PACKED_##m_var_type##_ARRAY) {                                                             \
-		CHECK_SPACE(8);                                                                                                    \
+		CHECK_SPACE(3 + 5);                                                                                                \
 		GET_VARIANT_PTR(counter, 0);                                                                                       \
 		GET_VARIANT_PTR(container, 1);                                                                                     \
 		Vector<m_elem_type> *array = VariantInternal::m_get_func(container);                                               \
@@ -3264,7 +3264,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			OPCODE_ITERATE_BEGIN_PACKED_ARRAY(VECTOR4, Vector4, get_vector4_array, VECTOR4, Vector4, get_vector4);
 
 			OPCODE(OPCODE_ITERATE_BEGIN_OBJECT) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3324,7 +3324,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3356,7 +3356,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_INT) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3380,7 +3380,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_FLOAT) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3404,7 +3404,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_VECTOR2) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3428,7 +3428,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_VECTOR2I) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3452,7 +3452,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_VECTOR3) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3476,7 +3476,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_VECTOR3I) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3500,7 +3500,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_STRING) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3523,7 +3523,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_DICTIONARY) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3546,7 +3546,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_ITERATE_ARRAY) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);
@@ -3570,7 +3570,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 #define OPCODE_ITERATE_PACKED_ARRAY(m_var_type, m_elem_type, m_get_func, m_ret_get_func)            \
 	OPCODE(OPCODE_ITERATE_PACKED_##m_var_type##_ARRAY) {                                            \
-		CHECK_SPACE(4);                                                                             \
+		CHECK_SPACE(5);                                                                             \
 		GET_VARIANT_PTR(counter, 0);                                                                \
 		GET_VARIANT_PTR(container, 1);                                                              \
 		const Vector<m_elem_type> *array = VariantInternal::m_get_func((const Variant *)container); \
@@ -3600,7 +3600,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			OPCODE_ITERATE_PACKED_ARRAY(VECTOR4, Vector4, get_vector4_array, get_vector4);
 
 			OPCODE(OPCODE_ITERATE_OBJECT) {
-				CHECK_SPACE(4);
+				CHECK_SPACE(5);
 
 				GET_VARIANT_PTR(counter, 0);
 				GET_VARIANT_PTR(container, 1);


### PR DESCRIPTION
Some of the `CHECK_SPACE` calls seem to be off by one. To read `code[ip + x]` within an opcode, `CHECK_SPACE(x + 1)` has to have been verified to ensure a read doesn't occur out of bounds.

---

A good already well-behaving opcode is `OPCODE_TYPE_TEST_BUILTIN`, it looks like this:
```
0: OPCODE_TYPE_TEST_BUILTIN
1: <destination>
2: <value>
3: <builtin type>
```
It only ever reads up to `code[ip + 3]` and does `CHECK_SPACE(4)` to make sure it is safe.

---

The `LOAD_INSTRUCTION_ARGS` opcodes also have a similar off by one because they have to read `[opcode][argc][arg0][arg1]...`. Even though the IP has been advanced by that macro it still has to `+1` for stepping over `[argc]` in the same way as it would have for `[opcode]`. So I also fixed those in the same manner.