### PR TITLE
Add `format` property to SpinBox and deprecate `prefix`/`suffix`

### DIFF
--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -59,16 +59,23 @@
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true" keywords="readonly, disabled, enabled">
 			If [code]true[/code], the [SpinBox] will be editable. Otherwise, it will be read only.
 		</member>
-		<member name="prefix" type="String" setter="set_prefix" getter="get_prefix" default="&quot;&quot;">
-			Adds the specified prefix string before the numerical value of the [SpinBox].
+		<member name="format" type="String" setter="set_format" getter="get_format" default="&quot;&quot;">
+			The formatting of the displayed numeric value, using the same rules as [String]'s [code]%[/code] operator (see [url=$DOCS_URL/tutorials/scripting/gdscript/gdscript_format_string.html]GDScript format strings[/url]). If empty, the value is displayed with no special formatting. If the format string is invalid, the [SpinBox] will display [code]"ERROR"[/code], with the error message available as a configuration warning.
+			The following format strings can be used as examples:
+			- [code]"(%s)"[/code] displays as a number in parentheses (e.g. [code](6.9)[/code]).
+			- [code]"%d ms"[/code] displays as an integer with milliseconds unit (e.g. [code]420 ms[/code]).
+			- [code]"%0.2f%%"[/code] displays as a percentage, with 2 decimal places of precision (e.g. [code]21.37%[/code]).
+		</member>
+		<member name="prefix" type="String" setter="set_prefix" getter="get_prefix" default="&quot;&quot;" deprecated="Use [member format] instead.">
+			Adds the specified prefix string before the numerical value of the [SpinBox]. This is used only if [member format] is empty.
 		</member>
 		<member name="select_all_on_focus" type="bool" setter="set_select_all_on_focus" getter="is_select_all_on_focus" default="false">
 			If [code]true[/code], the [SpinBox] will select the whole text when the [LineEdit] gains focus. Clicking the up and down arrows won't trigger this behavior.
 		</member>
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" enum="Control.SizeFlags" is_bitfield="true" default="1" />
 		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="1.0" />
-		<member name="suffix" type="String" setter="set_suffix" getter="get_suffix" default="&quot;&quot;">
-			Adds the specified suffix string after the numerical value of the [SpinBox].
+		<member name="suffix" type="String" setter="set_suffix" getter="get_suffix" default="&quot;&quot;" deprecated="Use [member format] instead.">
+			Adds the specified suffix string after the numerical value of the [SpinBox]. This is used only if [member format] is empty.
 		</member>
 		<member name="update_on_text_changed" type="bool" setter="set_update_on_text_changed" getter="get_update_on_text_changed" default="false">
 			Sets the value of the [Range] for this [SpinBox] when the [LineEdit] text is [i]changed[/i] instead of [i]submitted[/i]. See [signal LineEdit.text_changed] and [signal LineEdit.text_submitted].

--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -1025,7 +1025,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	cyclic_length_value->set_max(99.0);
 	cyclic_length_value->set_step(0.001);
 	cyclic_length_value->set_allow_greater(true);
-	cyclic_length_value->set_suffix("s");
+	cyclic_length_value->set_format("%s s");
 	cyclic_length_value->set_accessibility_name(TTRC("Cyclic Length"));
 	cyclic_length_value->set_tooltip_text(TTR("Cycle length in seconds for cyclic sync. All animations are time-scaled to complete one cycle in this duration."));
 	top_hb->add_child(cyclic_length_value);

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -1261,7 +1261,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	snap_x = memnew(SpinBox);
 	top_hb->add_child(snap_x);
-	snap_x->set_prefix("x:");
+	snap_x->set_format("x: %s");
 	snap_x->set_min(0.01);
 	snap_x->set_step(0.01);
 	snap_x->set_max(1000);
@@ -1269,7 +1269,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	snap_y = memnew(SpinBox);
 	top_hb->add_child(snap_y);
-	snap_y->set_prefix("y:");
+	snap_y->set_format("y: %s");
 	snap_y->set_min(0.01);
 	snap_y->set_step(0.01);
 	snap_y->set_max(1000);

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -1263,7 +1263,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	snap_x = memnew(SpinBox);
 	top_hf->add_child(snap_x);
-	snap_x->set_prefix("x:");
+	snap_x->set_format("x: %s");
 	snap_x->set_min(0.01);
 	snap_x->set_step(0.01);
 	snap_x->set_max(1000);
@@ -1271,7 +1271,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	snap_y = memnew(SpinBox);
 	top_hf->add_child(snap_y);
-	snap_y->set_prefix("y:");
+	snap_y->set_format("y: %s");
 	snap_y->set_min(0.01);
 	snap_y->set_step(0.01);
 	snap_y->set_max(1000);
@@ -1293,7 +1293,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	cyclic_length_value->set_max(99.0);
 	cyclic_length_value->set_step(0.001);
 	cyclic_length_value->set_allow_greater(true);
-	cyclic_length_value->set_suffix("s");
+	cyclic_length_value->set_format("%s s");
 	cyclic_length_value->set_accessibility_name(TTRC("Cyclic Length"));
 	cyclic_length_value->set_tooltip_text(TTR("Cycle length in seconds for cyclic sync. All animations are time-scaled to complete one cycle in this duration."));
 	top_hf->add_child(cyclic_length_value);

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1870,7 +1870,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	patch_delta_min_reduction->set_min(0.0);
 	patch_delta_min_reduction->set_max(100.0);
 	patch_delta_min_reduction->set_step(1.0);
-	patch_delta_min_reduction->set_suffix("%");
+	patch_delta_min_reduction->set_format("%s%%");
 	patch_delta_min_reduction->set_tooltip_text(TTRC("How much smaller, when compared to the new file, a delta-encoded patch needs to be for it to be exported.\n"
 													 "If the patch is not at least this much smaller, the new file will be exported as-is."));
 	patch_delta_min_reduction->connect(SceneStringName(value_changed), callable_mp(this, &ProjectExportDialog::_patch_delta_min_reduction_changed));

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -587,7 +587,7 @@ AudioStreamImportSettingsDialog::AudioStreamImportSettingsDialog() {
 	loop_offset->set_accessibility_name(TTRC("Offset:"));
 	loop_offset->set_max(10000);
 	loop_offset->set_step(0.001);
-	loop_offset->set_suffix("s");
+	loop_offset->set_format("%s s");
 	loop_offset->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	loop_offset->set_stretch_ratio(0.33);
 	loop_offset->set_tooltip_text(TTR("The loop start position, in seconds.\nThis is the position the stream's playback will return to when the end of the loop is reached."));

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -1500,7 +1500,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	sb_off_x->set_max(256);
 	sb_off_x->set_step(1);
 	sb_off_x->set_value(snap_offset.x);
-	sb_off_x->set_suffix("px");
+	sb_off_x->set_format("%s px");
 	sb_off_x->connect(SceneStringName(value_changed), callable_mp(this, &Polygon2DEditor::_set_snap_off_x));
 	sb_off_x->set_accessibility_name(TTRC("Grid Offset X:"));
 	grid_settings_vb->add_margin_child(TTR("Grid Offset X:"), sb_off_x);
@@ -1510,7 +1510,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	sb_off_y->set_max(256);
 	sb_off_y->set_step(1);
 	sb_off_y->set_value(snap_offset.y);
-	sb_off_y->set_suffix("px");
+	sb_off_y->set_format("%s px");
 	sb_off_y->connect(SceneStringName(value_changed), callable_mp(this, &Polygon2DEditor::_set_snap_off_y));
 	sb_off_y->set_accessibility_name(TTRC("Grid Offset Y:"));
 	grid_settings_vb->add_margin_child(TTR("Grid Offset Y:"), sb_off_y);
@@ -1520,7 +1520,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	sb_step_x->set_max(256);
 	sb_step_x->set_step(1);
 	sb_step_x->set_value(snap_step.x);
-	sb_step_x->set_suffix("px");
+	sb_step_x->set_format("%s px");
 	sb_step_x->connect(SceneStringName(value_changed), callable_mp(this, &Polygon2DEditor::_set_snap_step_x));
 	sb_step_x->set_accessibility_name(TTRC("Grid Step X:"));
 	grid_settings_vb->add_margin_child(TTR("Grid Step X:"), sb_step_x);
@@ -1530,7 +1530,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	sb_step_y->set_max(256);
 	sb_step_y->set_step(1);
 	sb_step_y->set_value(snap_step.y);
-	sb_step_y->set_suffix("px");
+	sb_step_y->set_format("%s px");
 	sb_step_y->connect(SceneStringName(value_changed), callable_mp(this, &Polygon2DEditor::_set_snap_step_y));
 	sb_step_y->set_accessibility_name(TTRC("Grid Step Y:"));
 	grid_settings_vb->add_margin_child(TTR("Grid Step Y:"), sb_step_y);

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -1526,7 +1526,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	sb_off_x->set_max(256);
 	sb_off_x->set_step(1);
 	sb_off_x->set_value(snap_offset.x);
-	sb_off_x->set_suffix("px");
+	sb_off_x->set_format("%s px");
 	sb_off_x->connect(SceneStringName(value_changed), callable_mp(this, &Polygon2DEditor::_set_snap_off_x));
 	sb_off_x->set_accessibility_name(TTRC("Grid Offset X:"));
 	grid_settings_vb->add_margin_child(TTR("Grid Offset X:"), sb_off_x);
@@ -1536,7 +1536,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	sb_off_y->set_max(256);
 	sb_off_y->set_step(1);
 	sb_off_y->set_value(snap_offset.y);
-	sb_off_y->set_suffix("px");
+	sb_off_y->set_format("%s px");
 	sb_off_y->connect(SceneStringName(value_changed), callable_mp(this, &Polygon2DEditor::_set_snap_off_y));
 	sb_off_y->set_accessibility_name(TTRC("Grid Offset Y:"));
 	grid_settings_vb->add_margin_child(TTR("Grid Offset Y:"), sb_off_y);
@@ -1546,7 +1546,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	sb_step_x->set_max(256);
 	sb_step_x->set_step(1);
 	sb_step_x->set_value(snap_step.x);
-	sb_step_x->set_suffix("px");
+	sb_step_x->set_format("%s px");
 	sb_step_x->connect(SceneStringName(value_changed), callable_mp(this, &Polygon2DEditor::_set_snap_step_x));
 	sb_step_x->set_accessibility_name(TTRC("Grid Step X:"));
 	grid_settings_vb->add_margin_child(TTR("Grid Step X:"), sb_step_x);
@@ -1556,7 +1556,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	sb_step_y->set_max(256);
 	sb_step_y->set_step(1);
 	sb_step_y->set_value(snap_step.y);
-	sb_step_y->set_suffix("px");
+	sb_step_y->set_format("%s px");
 	sb_step_y->connect(SceneStringName(value_changed), callable_mp(this, &Polygon2DEditor::_set_snap_step_y));
 	sb_step_y->set_accessibility_name(TTRC("Grid Step Y:"));
 	grid_settings_vb->add_margin_child(TTR("Grid Step Y:"), sb_step_y);

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -131,7 +131,7 @@ public:
 		grid_offset_x->set_max(SPIN_BOX_GRID_RANGE);
 		grid_offset_x->set_allow_lesser(true);
 		grid_offset_x->set_allow_greater(true);
-		grid_offset_x->set_suffix("px");
+		grid_offset_x->set_format("%s px");
 		grid_offset_x->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		grid_offset_x->set_select_all_on_focus(true);
 		grid_offset_x->set_accessibility_name(TTRC("X Offset"));
@@ -142,7 +142,7 @@ public:
 		grid_offset_y->set_max(SPIN_BOX_GRID_RANGE);
 		grid_offset_y->set_allow_lesser(true);
 		grid_offset_y->set_allow_greater(true);
-		grid_offset_y->set_suffix("px");
+		grid_offset_y->set_format("%s px");
 		grid_offset_y->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		grid_offset_y->set_select_all_on_focus(true);
 		grid_offset_y->set_accessibility_name(TTRC("Y Offset"));
@@ -157,7 +157,7 @@ public:
 		grid_step_x->set_min(1);
 		grid_step_x->set_max(SPIN_BOX_GRID_RANGE);
 		grid_step_x->set_allow_greater(true);
-		grid_step_x->set_suffix("px");
+		grid_step_x->set_format("%s px");
 		grid_step_x->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		grid_step_x->set_select_all_on_focus(true);
 		grid_step_x->set_accessibility_name(TTRC("X Step"));
@@ -167,7 +167,7 @@ public:
 		grid_step_y->set_min(1);
 		grid_step_y->set_max(SPIN_BOX_GRID_RANGE);
 		grid_step_y->set_allow_greater(true);
-		grid_step_y->set_suffix("px");
+		grid_step_y->set_format("%s px");
 		grid_step_y->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		grid_step_y->set_select_all_on_focus(true);
 		grid_step_y->set_accessibility_name(TTRC("X Step"));
@@ -183,7 +183,7 @@ public:
 		primary_grid_step_x->set_step(1);
 		primary_grid_step_x->set_max(SPIN_BOX_GRID_RANGE);
 		primary_grid_step_x->set_allow_greater(true);
-		primary_grid_step_x->set_suffix("steps");
+		primary_grid_step_x->set_format("%s steps");
 		primary_grid_step_x->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		primary_grid_step_x->set_select_all_on_focus(true);
 		primary_grid_step_x->set_accessibility_name(TTRC("X Primary Step"));
@@ -194,7 +194,7 @@ public:
 		primary_grid_step_y->set_step(1);
 		primary_grid_step_y->set_max(SPIN_BOX_GRID_RANGE);
 		primary_grid_step_y->set_allow_greater(true);
-		primary_grid_step_y->set_suffix(TTRC("steps")); // TODO: Add suffix auto-translation.
+		primary_grid_step_y->set_format(TTRC("%s steps")); // TODO: Add format auto-translation.
 		primary_grid_step_y->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		primary_grid_step_y->set_select_all_on_focus(true);
 		primary_grid_step_y->set_accessibility_name(TTRC("Y Primary Step"));
@@ -216,7 +216,7 @@ public:
 		rotation_offset = memnew(SpinBox);
 		rotation_offset->set_min(-SPIN_BOX_ROTATION_RANGE);
 		rotation_offset->set_max(SPIN_BOX_ROTATION_RANGE);
-		rotation_offset->set_suffix(U"°");
+		rotation_offset->set_format(U"%s°");
 		rotation_offset->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		rotation_offset->set_select_all_on_focus(true);
 		rotation_offset->set_accessibility_name(TTRC("Rotation Offset:"));
@@ -230,7 +230,7 @@ public:
 		rotation_step = memnew(SpinBox);
 		rotation_step->set_min(-SPIN_BOX_ROTATION_RANGE);
 		rotation_step->set_max(SPIN_BOX_ROTATION_RANGE);
-		rotation_step->set_suffix(U"°");
+		rotation_step->set_format(U"%s°");
 		rotation_step->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		rotation_step->set_select_all_on_focus(true);
 		rotation_step->set_accessibility_name(TTRC("Rotation Step:"));

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -134,7 +134,7 @@ public:
 		grid_offset_x->set_max(SPIN_BOX_GRID_RANGE);
 		grid_offset_x->set_allow_lesser(true);
 		grid_offset_x->set_allow_greater(true);
-		grid_offset_x->set_suffix("px");
+		grid_offset_x->set_format("%s px");
 		grid_offset_x->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		grid_offset_x->set_select_all_on_focus(true);
 		grid_offset_x->set_accessibility_name(TTRC("X Offset"));
@@ -145,7 +145,7 @@ public:
 		grid_offset_y->set_max(SPIN_BOX_GRID_RANGE);
 		grid_offset_y->set_allow_lesser(true);
 		grid_offset_y->set_allow_greater(true);
-		grid_offset_y->set_suffix("px");
+		grid_offset_y->set_format("%s px");
 		grid_offset_y->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		grid_offset_y->set_select_all_on_focus(true);
 		grid_offset_y->set_accessibility_name(TTRC("Y Offset"));
@@ -160,7 +160,7 @@ public:
 		grid_step_x->set_min(1);
 		grid_step_x->set_max(SPIN_BOX_GRID_RANGE);
 		grid_step_x->set_allow_greater(true);
-		grid_step_x->set_suffix("px");
+		grid_step_x->set_format("%s px");
 		grid_step_x->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		grid_step_x->set_select_all_on_focus(true);
 		grid_step_x->set_accessibility_name(TTRC("X Step"));
@@ -170,7 +170,7 @@ public:
 		grid_step_y->set_min(1);
 		grid_step_y->set_max(SPIN_BOX_GRID_RANGE);
 		grid_step_y->set_allow_greater(true);
-		grid_step_y->set_suffix("px");
+		grid_step_y->set_format("%s px");
 		grid_step_y->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		grid_step_y->set_select_all_on_focus(true);
 		grid_step_y->set_accessibility_name(TTRC("X Step"));
@@ -186,7 +186,7 @@ public:
 		primary_grid_step_x->set_step(1);
 		primary_grid_step_x->set_max(SPIN_BOX_GRID_RANGE);
 		primary_grid_step_x->set_allow_greater(true);
-		primary_grid_step_x->set_suffix("steps");
+		primary_grid_step_x->set_format("%s steps");
 		primary_grid_step_x->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		primary_grid_step_x->set_select_all_on_focus(true);
 		primary_grid_step_x->set_accessibility_name(TTRC("X Primary Step"));
@@ -197,7 +197,7 @@ public:
 		primary_grid_step_y->set_step(1);
 		primary_grid_step_y->set_max(SPIN_BOX_GRID_RANGE);
 		primary_grid_step_y->set_allow_greater(true);
-		primary_grid_step_y->set_suffix(TTRC("steps")); // TODO: Add suffix auto-translation.
+		primary_grid_step_y->set_format(TTRC("%s steps")); // TODO: Add format auto-translation.
 		primary_grid_step_y->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		primary_grid_step_y->set_select_all_on_focus(true);
 		primary_grid_step_y->set_accessibility_name(TTRC("Y Primary Step"));
@@ -219,7 +219,7 @@ public:
 		rotation_offset = memnew(SpinBox);
 		rotation_offset->set_min(-SPIN_BOX_ROTATION_RANGE);
 		rotation_offset->set_max(SPIN_BOX_ROTATION_RANGE);
-		rotation_offset->set_suffix(U"°");
+		rotation_offset->set_format(U"%s°");
 		rotation_offset->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		rotation_offset->set_select_all_on_focus(true);
 		rotation_offset->set_accessibility_name(TTRC("Rotation Offset:"));
@@ -233,7 +233,7 @@ public:
 		rotation_step = memnew(SpinBox);
 		rotation_step->set_min(-SPIN_BOX_ROTATION_RANGE);
 		rotation_step->set_max(SPIN_BOX_ROTATION_RANGE);
-		rotation_step->set_suffix(U"°");
+		rotation_step->set_format(U"%s°");
 		rotation_step->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		rotation_step->set_select_all_on_focus(true);
 		rotation_step->set_accessibility_name(TTRC("Rotation Step:"));

--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -2237,7 +2237,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	hbc_animlist->add_child(anim_loop);
 
 	anim_speed = memnew(SpinBox);
-	anim_speed->set_suffix(TTR("FPS"));
+	anim_speed->set_format(TTR("%s FPS"));
 	anim_speed->set_min(0);
 	anim_speed->set_max(120);
 	anim_speed->set_step(0.01);
@@ -2398,7 +2398,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	hbc_frame_duration->add_child(label);
 
 	frame_duration = memnew(SpinBox);
-	frame_duration->set_prefix(String::utf8("×"));
+	frame_duration->set_format(U"×%s");
 	frame_duration->set_min(SPRITE_FRAME_MINIMUM_DURATION); // Avoid zero div.
 	frame_duration->set_max(10);
 	frame_duration->set_step(0.01);
@@ -2680,7 +2680,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_size_x->set_h_size_flags(SIZE_EXPAND_FILL);
 	split_sheet_size_x->set_min(1);
 	split_sheet_size_x->set_step(1);
-	split_sheet_size_x->set_suffix("px");
+	split_sheet_size_x->set_format("%s px");
 	split_sheet_size_x->set_select_all_on_focus(true);
 	split_sheet_size_x->set_accessibility_name(TTRC("X Size"));
 	split_sheet_size_x->connect(SceneStringName(value_changed), callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed).bind(PARAM_SIZE));
@@ -2689,7 +2689,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_size_y->set_h_size_flags(SIZE_EXPAND_FILL);
 	split_sheet_size_y->set_min(1);
 	split_sheet_size_y->set_step(1);
-	split_sheet_size_y->set_suffix("px");
+	split_sheet_size_y->set_format("%s px");
 	split_sheet_size_y->set_select_all_on_focus(true);
 	split_sheet_size_y->set_accessibility_name(TTRC("Y Size"));
 	split_sheet_size_y->connect(SceneStringName(value_changed), callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed).bind(PARAM_SIZE));
@@ -2710,7 +2710,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_sep_x = memnew(SpinBox);
 	split_sheet_sep_x->set_min(0);
 	split_sheet_sep_x->set_step(1);
-	split_sheet_sep_x->set_suffix("px");
+	split_sheet_sep_x->set_format("%s px");
 	split_sheet_sep_x->set_select_all_on_focus(true);
 	split_sheet_sep_x->set_accessibility_name(TTRC("X Separation"));
 	split_sheet_sep_x->connect(SceneStringName(value_changed), callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed).bind(PARAM_USE_CURRENT));
@@ -2718,7 +2718,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_sep_y = memnew(SpinBox);
 	split_sheet_sep_y->set_min(0);
 	split_sheet_sep_y->set_step(1);
-	split_sheet_sep_y->set_suffix("px");
+	split_sheet_sep_y->set_format("%s px");
 	split_sheet_sep_y->set_select_all_on_focus(true);
 	split_sheet_sep_y->set_accessibility_name(TTRC("Y Separation"));
 	split_sheet_sep_y->connect(SceneStringName(value_changed), callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed).bind(PARAM_USE_CURRENT));
@@ -2739,7 +2739,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_offset_x = memnew(SpinBox);
 	split_sheet_offset_x->set_min(0);
 	split_sheet_offset_x->set_step(1);
-	split_sheet_offset_x->set_suffix("px");
+	split_sheet_offset_x->set_format("%s px");
 	split_sheet_offset_x->set_select_all_on_focus(true);
 	split_sheet_offset_x->set_accessibility_name(TTRC("X Offset"));
 	split_sheet_offset_x->connect(SceneStringName(value_changed), callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed).bind(PARAM_USE_CURRENT));
@@ -2747,7 +2747,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_offset_y = memnew(SpinBox);
 	split_sheet_offset_y->set_min(0);
 	split_sheet_offset_y->set_step(1);
-	split_sheet_offset_y->set_suffix("px");
+	split_sheet_offset_y->set_format("%s px");
 	split_sheet_offset_y->set_select_all_on_focus(true);
 	split_sheet_offset_y->set_accessibility_name(TTRC("Y Offset"));
 	split_sheet_offset_y->connect(SceneStringName(value_changed), callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed).bind(PARAM_USE_CURRENT));

--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -741,7 +741,7 @@ void SpriteFramesEditor::_notification(int p_what) {
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			_update_show_settings();
-			anim_speed->set_suffix(TTR("FPS"));
+			anim_speed->set_format("%s FPS");
 
 			// Similar to `_update_library_impl()`, but only updates text for "empty" items.
 			if (frames.is_valid()) {
@@ -2237,7 +2237,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	hbc_animlist->add_child(anim_loop);
 
 	anim_speed = memnew(SpinBox);
-	anim_speed->set_suffix(TTR("FPS"));
+	anim_speed->set_format(TTR("%s FPS"));
 	anim_speed->set_min(0);
 	anim_speed->set_max(120);
 	anim_speed->set_step(0.01);
@@ -2398,7 +2398,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	hbc_frame_duration->add_child(label);
 
 	frame_duration = memnew(SpinBox);
-	frame_duration->set_prefix(String::utf8("×"));
+	frame_duration->set_format(U"×%s");
 	frame_duration->set_min(SPRITE_FRAME_MINIMUM_DURATION); // Avoid zero div.
 	frame_duration->set_max(10);
 	frame_duration->set_step(0.01);
@@ -2680,7 +2680,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_size_x->set_h_size_flags(SIZE_EXPAND_FILL);
 	split_sheet_size_x->set_min(1);
 	split_sheet_size_x->set_step(1);
-	split_sheet_size_x->set_suffix("px");
+	split_sheet_size_x->set_format("%s px");
 	split_sheet_size_x->set_select_all_on_focus(true);
 	split_sheet_size_x->set_accessibility_name(TTRC("X Size"));
 	split_sheet_size_x->connect(SceneStringName(value_changed), callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed).bind(PARAM_SIZE));
@@ -2689,7 +2689,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_size_y->set_h_size_flags(SIZE_EXPAND_FILL);
 	split_sheet_size_y->set_min(1);
 	split_sheet_size_y->set_step(1);
-	split_sheet_size_y->set_suffix("px");
+	split_sheet_size_y->set_format("%s px");
 	split_sheet_size_y->set_select_all_on_focus(true);
 	split_sheet_size_y->set_accessibility_name(TTRC("Y Size"));
 	split_sheet_size_y->connect(SceneStringName(value_changed), callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed).bind(PARAM_SIZE));
@@ -2710,7 +2710,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_sep_x = memnew(SpinBox);
 	split_sheet_sep_x->set_min(0);
 	split_sheet_sep_x->set_step(1);
-	split_sheet_sep_x->set_suffix("px");
+	split_sheet_sep_x->set_format("%s px");
 	split_sheet_sep_x->set_select_all_on_focus(true);
 	split_sheet_sep_x->set_accessibility_name(TTRC("X Separation"));
 	split_sheet_sep_x->connect(SceneStringName(value_changed), callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed).bind(PARAM_USE_CURRENT));
@@ -2718,7 +2718,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_sep_y = memnew(SpinBox);
 	split_sheet_sep_y->set_min(0);
 	split_sheet_sep_y->set_step(1);
-	split_sheet_sep_y->set_suffix("px");
+	split_sheet_sep_y->set_format("%s px");
 	split_sheet_sep_y->set_select_all_on_focus(true);
 	split_sheet_sep_y->set_accessibility_name(TTRC("Y Separation"));
 	split_sheet_sep_y->connect(SceneStringName(value_changed), callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed).bind(PARAM_USE_CURRENT));
@@ -2739,7 +2739,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_offset_x = memnew(SpinBox);
 	split_sheet_offset_x->set_min(0);
 	split_sheet_offset_x->set_step(1);
-	split_sheet_offset_x->set_suffix("px");
+	split_sheet_offset_x->set_format("%s px");
 	split_sheet_offset_x->set_select_all_on_focus(true);
 	split_sheet_offset_x->set_accessibility_name(TTRC("X Offset"));
 	split_sheet_offset_x->connect(SceneStringName(value_changed), callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed).bind(PARAM_USE_CURRENT));
@@ -2747,7 +2747,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_offset_y = memnew(SpinBox);
 	split_sheet_offset_y->set_min(0);
 	split_sheet_offset_y->set_step(1);
-	split_sheet_offset_y->set_suffix("px");
+	split_sheet_offset_y->set_format("%s px");
 	split_sheet_offset_y->set_select_all_on_focus(true);
 	split_sheet_offset_y->set_accessibility_name(TTRC("Y Offset"));
 	split_sheet_offset_y->connect(SceneStringName(value_changed), callable_mp(this, &SpriteFramesEditor::_sheet_spin_changed).bind(PARAM_USE_CURRENT));

--- a/editor/scene/texture/texture_region_editor_plugin.cpp
+++ b/editor/scene/texture/texture_region_editor_plugin.cpp
@@ -1248,14 +1248,14 @@ TextureRegionEditor::TextureRegionEditor() {
 
 	sb_off_x = memnew(SpinBox);
 	sb_off_x->set_step(1);
-	sb_off_x->set_suffix("px");
+	sb_off_x->set_format("%s px");
 	sb_off_x->connect(SceneStringName(value_changed), callable_mp(this, &TextureRegionEditor::_set_snap_off_x));
 	sb_off_x->set_accessibility_name(TTRC("Offset X"));
 	hb_grid->add_child(sb_off_x);
 
 	sb_off_y = memnew(SpinBox);
 	sb_off_y->set_step(1);
-	sb_off_y->set_suffix("px");
+	sb_off_y->set_format("%s px");
 	sb_off_y->connect(SceneStringName(value_changed), callable_mp(this, &TextureRegionEditor::_set_snap_off_y));
 	sb_off_y->set_accessibility_name(TTRC("Offset Y"));
 	hb_grid->add_child(sb_off_y);
@@ -1266,7 +1266,7 @@ TextureRegionEditor::TextureRegionEditor() {
 	sb_step_x = memnew(SpinBox);
 	sb_step_x->set_min(0);
 	sb_step_x->set_step(1);
-	sb_step_x->set_suffix("px");
+	sb_step_x->set_format("%s px");
 	sb_step_x->connect(SceneStringName(value_changed), callable_mp(this, &TextureRegionEditor::_set_snap_step_x));
 	sb_step_x->set_accessibility_name(TTRC("Step X"));
 	hb_grid->add_child(sb_step_x);
@@ -1274,7 +1274,7 @@ TextureRegionEditor::TextureRegionEditor() {
 	sb_step_y = memnew(SpinBox);
 	sb_step_y->set_min(0);
 	sb_step_y->set_step(1);
-	sb_step_y->set_suffix("px");
+	sb_step_y->set_format("%s px");
 	sb_step_y->connect(SceneStringName(value_changed), callable_mp(this, &TextureRegionEditor::_set_snap_step_y));
 	sb_step_y->set_accessibility_name(TTRC("Step Y"));
 	hb_grid->add_child(sb_step_y);
@@ -1285,7 +1285,7 @@ TextureRegionEditor::TextureRegionEditor() {
 	sb_sep_x = memnew(SpinBox);
 	sb_sep_x->set_min(0);
 	sb_sep_x->set_step(1);
-	sb_sep_x->set_suffix("px");
+	sb_sep_x->set_format("%s px");
 	sb_sep_x->connect(SceneStringName(value_changed), callable_mp(this, &TextureRegionEditor::_set_snap_sep_x));
 	sb_sep_x->set_accessibility_name(TTRC("Separation X"));
 	hb_grid->add_child(sb_sep_x);
@@ -1293,7 +1293,7 @@ TextureRegionEditor::TextureRegionEditor() {
 	sb_sep_y = memnew(SpinBox);
 	sb_sep_y->set_min(0);
 	sb_sep_y->set_step(1);
-	sb_sep_y->set_suffix("px");
+	sb_sep_y->set_format("%s px");
 	sb_sep_y->connect(SceneStringName(value_changed), callable_mp(this, &TextureRegionEditor::_set_snap_sep_y));
 	sb_sep_y->set_accessibility_name(TTRC("Separation Y"));
 	hb_grid->add_child(sb_sep_y);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -432,7 +432,7 @@ void ColorPicker::_slider_value_changed() {
 		color_normalized = modes[current_mode]->get_color();
 	}
 	_normalized_apply_intensity_to_color();
-	intensity_value->set_prefix(intensity < 0 ? "" : "+");
+	intensity_value->set_format(intensity < 0 ? "" : "+%s");
 
 	modes[current_mode]->_value_changed();
 
@@ -743,7 +743,7 @@ void ColorPicker::_update_color(bool p_update_sliders) {
 		alpha_slider->set_step(step);
 		alpha_slider->set_value(modes[current_mode]->get_alpha_slider_value());
 		intensity_slider->set_value(intensity);
-		intensity_value->set_prefix(intensity < 0 ? "" : "+");
+		intensity_value->set_format(intensity < 0 ? "" : "+%s");
 	}
 
 	_update_text_value();

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -97,6 +97,18 @@ Size2 SpinBox::get_minimum_size() const {
 }
 
 void SpinBox::_update_text(bool p_only_update_if_value_changed) {
+	if (!line_edit->is_editing() && !format.is_empty() && !use_default_format) {
+		const Variant current_value = get_value();
+		bool error = false;
+		const String text = format.sprintf(Span(&current_value, 1), &error);
+		if (error) {
+			line_edit->set_text_with_selection(RTR("<Invalid>"));
+			return;
+		}
+		line_edit->set_text_with_selection(text);
+		return;
+	}
+
 	double step = get_step();
 	String value = String::num(get_value(), Math::range_step_decimals(step));
 	if (is_localizing_numeral_system()) {
@@ -109,11 +121,23 @@ void SpinBox::_update_text(bool p_only_update_if_value_changed) {
 	last_text_value = value;
 
 	if (!line_edit->is_editing()) {
-		if (!prefix.is_empty()) {
-			value = prefix + " " + value;
-		}
-		if (!suffix.is_empty()) {
-			value += " " + suffix;
+		if (!format.is_empty()) {
+			const Variant current_value = value;
+			bool error = false;
+			value = format.sprintf(Span(&current_value, 1), &error);
+			if (error) {
+				line_edit->set_text_with_selection(RTR("<Invalid>"));
+				return;
+			}
+#ifndef DISABLE_DEPRECATED
+		} else {
+			if (!prefix.is_empty()) {
+				value = prefix + " " + value;
+			}
+			if (!suffix.is_empty()) {
+				value += " " + suffix;
+			}
+#endif
 		}
 	}
 
@@ -152,8 +176,6 @@ void SpinBox::_text_submitted(const String &p_string) {
 	const String &lang = _get_locale();
 	text = text.replace_char(';', ',');
 	text = TranslationServer::get_singleton()->parse_number(text, lang);
-	// Ignore the prefix and suffix in the expression.
-	text = text.trim_prefix(prefix + " ").trim_suffix(" " + suffix);
 
 	Error err = expr->parse(text);
 
@@ -161,7 +183,6 @@ void SpinBox::_text_submitted(const String &p_string) {
 		// If the expression failed try without converting commas to dots - they might have been for parameter separation.
 		text = p_string;
 		text = TranslationServer::get_singleton()->parse_number(text, lang);
-		text = text.trim_prefix(prefix + " ").trim_suffix(" " + suffix);
 
 		err = expr->parse(text);
 		if (err != OK) {
@@ -383,7 +404,6 @@ void SpinBox::_line_edit_editing_toggled(bool p_toggled_on) {
 		if (Input::get_singleton()->is_action_pressed("ui_cancel") || line_edit->get_text().is_empty()) {
 			_update_text(); // Revert text if editing was canceled.
 		} else {
-			line_edit->set_text(line_edit->get_text().trim_suffix(".").trim_suffix(","));
 			_update_text(true); // Update text in case value was changed this frame (e.g. on `focus_exited`).
 			_text_submitted(line_edit->get_text());
 		}
@@ -558,6 +578,22 @@ HorizontalAlignment SpinBox::get_horizontal_alignment() const {
 	return line_edit->get_horizontal_alignment();
 }
 
+void SpinBox::set_format(const String &p_format) {
+	if (format == p_format) {
+		return;
+	}
+	format = p_format;
+	use_default_format = p_format.contains("%s");
+
+	_update_text();
+	update_configuration_warnings();
+}
+
+String SpinBox::get_format() const {
+	return format;
+}
+
+#ifndef DISABLE_DEPRECATED
 void SpinBox::set_suffix(const String &p_suffix) {
 	if (suffix == p_suffix) {
 		return;
@@ -583,6 +619,7 @@ void SpinBox::set_prefix(const String &p_prefix) {
 String SpinBox::get_prefix() const {
 	return prefix;
 }
+#endif
 
 void SpinBox::set_update_on_text_changed(bool p_enabled) {
 	if (update_on_text_changed == p_enabled) {
@@ -644,6 +681,20 @@ void SpinBox::_value_changed(double p_value) {
 	Range::_value_changed(p_value);
 }
 
+PackedStringArray SpinBox::get_configuration_warnings() const {
+	PackedStringArray warnings = Range::get_configuration_warnings();
+
+	if (!format.is_empty()) {
+		bool error = false;
+		const Variant test_value = 0.0;
+		const String error_str = format.sprintf(Span(&test_value, 1), &error);
+		if (error) {
+			warnings.push_back(vformat(RTR("The format property is not valid: %s."), error_str));
+		}
+	}
+	return warnings;
+}
+
 void SpinBox::_update_buttons_state_for_current_value() {
 	double value = get_value();
 	bool should_disable_up = value == get_max() && !is_greater_allowed();
@@ -665,10 +716,14 @@ void SpinBox::_validate_property(PropertyInfo &p_property) const {
 void SpinBox::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_horizontal_alignment", "alignment"), &SpinBox::set_horizontal_alignment);
 	ClassDB::bind_method(D_METHOD("get_horizontal_alignment"), &SpinBox::get_horizontal_alignment);
+	ClassDB::bind_method(D_METHOD("set_format", "format"), &SpinBox::set_format);
+	ClassDB::bind_method(D_METHOD("get_format"), &SpinBox::get_format);
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_suffix", "suffix"), &SpinBox::set_suffix);
 	ClassDB::bind_method(D_METHOD("get_suffix"), &SpinBox::get_suffix);
 	ClassDB::bind_method(D_METHOD("set_prefix", "prefix"), &SpinBox::set_prefix);
 	ClassDB::bind_method(D_METHOD("get_prefix"), &SpinBox::get_prefix);
+#endif
 	ClassDB::bind_method(D_METHOD("set_editable", "enabled"), &SpinBox::set_editable);
 	ClassDB::bind_method(D_METHOD("set_custom_arrow_step", "arrow_step"), &SpinBox::set_custom_arrow_step);
 	ClassDB::bind_method(D_METHOD("get_custom_arrow_step"), &SpinBox::get_custom_arrow_step);
@@ -685,8 +740,11 @@ void SpinBox::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alignment", PROPERTY_HINT_ENUM, "Left,Center,Right,Fill"), "set_horizontal_alignment", "get_horizontal_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editable"), "set_editable", "is_editable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "update_on_text_changed"), "set_update_on_text_changed", "get_update_on_text_changed");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "format", PROPERTY_HINT_PLACEHOLDER_TEXT, "%s"), "set_format", "get_format");
+#ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "prefix"), "set_prefix", "get_prefix");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "suffix"), "set_suffix", "get_suffix");
+#endif
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_arrow_step", PROPERTY_HINT_RANGE, "0,10000,0.0001,or_greater"), "set_custom_arrow_step", "get_custom_arrow_step");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "custom_arrow_round"), "set_custom_arrow_round", "is_custom_arrow_rounding");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "select_all_on_focus"), "set_select_all_on_focus", "is_select_all_on_focus");

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -97,6 +97,18 @@ Size2 SpinBox::get_minimum_size() const {
 }
 
 void SpinBox::_update_text(bool p_only_update_if_value_changed) {
+	if (!line_edit->is_editing() && !format.is_empty() && !use_default_format) {
+		const Variant current_value = get_value();
+		bool error = false;
+		const String text = format.sprintf(Span(&current_value, 1), &error);
+		if (error) {
+			line_edit->set_text_with_selection(RTR("<ERROR: Invalid format string>"));
+			return;
+		}
+		line_edit->set_text_with_selection(text);
+		return;
+	}
+
 	double step = get_step();
 	String value = String::num(get_value(), Math::range_step_decimals(step));
 	if (is_localizing_numeral_system()) {
@@ -109,11 +121,23 @@ void SpinBox::_update_text(bool p_only_update_if_value_changed) {
 	last_text_value = value;
 
 	if (!line_edit->is_editing()) {
-		if (!prefix.is_empty()) {
-			value = prefix + " " + value;
-		}
-		if (!suffix.is_empty()) {
-			value += " " + suffix;
+		if (!format.is_empty()) {
+			const Variant current_value = value;
+			bool error = false;
+			value = format.sprintf(Span(&current_value, 1), &error);
+			if (error) {
+				line_edit->set_text_with_selection(RTR("<ERROR: Invalid format string>"));
+				return;
+			}
+#ifndef DISABLE_DEPRECATED
+		} else {
+			if (!prefix.is_empty()) {
+				value = prefix + " " + value;
+			}
+			if (!suffix.is_empty()) {
+				value += " " + suffix;
+			}
+#endif
 		}
 	}
 
@@ -152,8 +176,6 @@ void SpinBox::_text_submitted(const String &p_string) {
 	const String &lang = _get_locale();
 	text = text.replace_char(';', ',');
 	text = TranslationServer::get_singleton()->parse_number(text, lang);
-	// Ignore the prefix and suffix in the expression.
-	text = text.trim_prefix(prefix + " ").trim_suffix(" " + suffix);
 
 	Error err = expr->parse(text);
 
@@ -161,7 +183,6 @@ void SpinBox::_text_submitted(const String &p_string) {
 		// If the expression failed try without converting commas to dots - they might have been for parameter separation.
 		text = p_string;
 		text = TranslationServer::get_singleton()->parse_number(text, lang);
-		text = text.trim_prefix(prefix + " ").trim_suffix(" " + suffix);
 
 		err = expr->parse(text);
 		if (err != OK) {
@@ -383,7 +404,6 @@ void SpinBox::_line_edit_editing_toggled(bool p_toggled_on) {
 		if (Input::get_singleton()->is_action_pressed("ui_cancel") || line_edit->get_text().is_empty()) {
 			_update_text(); // Revert text if editing was canceled.
 		} else {
-			line_edit->set_text(line_edit->get_text().trim_suffix(".").trim_suffix(","));
 			_update_text(true); // Update text in case value was changed this frame (e.g. on `focus_exited`).
 			_text_submitted(line_edit->get_text());
 		}
@@ -558,6 +578,22 @@ HorizontalAlignment SpinBox::get_horizontal_alignment() const {
 	return line_edit->get_horizontal_alignment();
 }
 
+void SpinBox::set_format(const String &p_format) {
+	if (format == p_format) {
+		return;
+	}
+	format = p_format;
+	use_default_format = p_format.contains("%s");
+
+	_update_text();
+	update_configuration_warnings();
+}
+
+String SpinBox::get_format() const {
+	return format;
+}
+
+#ifndef DISABLE_DEPRECATED
 void SpinBox::set_suffix(const String &p_suffix) {
 	if (suffix == p_suffix) {
 		return;
@@ -583,6 +619,7 @@ void SpinBox::set_prefix(const String &p_prefix) {
 String SpinBox::get_prefix() const {
 	return prefix;
 }
+#endif
 
 void SpinBox::set_update_on_text_changed(bool p_enabled) {
 	if (update_on_text_changed == p_enabled) {
@@ -644,6 +681,20 @@ void SpinBox::_value_changed(double p_value) {
 	Range::_value_changed(p_value);
 }
 
+PackedStringArray SpinBox::get_configuration_warnings() const {
+	PackedStringArray warnings = Range::get_configuration_warnings();
+
+	if (!format.is_empty()) {
+		bool error = false;
+		const Variant test_value = 0.0;
+		const String error_str = format.sprintf(Span(&test_value, 1), &error);
+		if (error) {
+			warnings.push_back(vformat(RTR("The format property is not valid: %s."), error_str));
+		}
+	}
+	return warnings;
+}
+
 void SpinBox::_update_buttons_state_for_current_value() {
 	double value = get_value();
 	bool should_disable_up = value == get_max() && !is_greater_allowed();
@@ -665,10 +716,14 @@ void SpinBox::_validate_property(PropertyInfo &p_property) const {
 void SpinBox::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_horizontal_alignment", "alignment"), &SpinBox::set_horizontal_alignment);
 	ClassDB::bind_method(D_METHOD("get_horizontal_alignment"), &SpinBox::get_horizontal_alignment);
+	ClassDB::bind_method(D_METHOD("set_format", "format"), &SpinBox::set_format);
+	ClassDB::bind_method(D_METHOD("get_format"), &SpinBox::get_format);
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_suffix", "suffix"), &SpinBox::set_suffix);
 	ClassDB::bind_method(D_METHOD("get_suffix"), &SpinBox::get_suffix);
 	ClassDB::bind_method(D_METHOD("set_prefix", "prefix"), &SpinBox::set_prefix);
 	ClassDB::bind_method(D_METHOD("get_prefix"), &SpinBox::get_prefix);
+#endif
 	ClassDB::bind_method(D_METHOD("set_editable", "enabled"), &SpinBox::set_editable);
 	ClassDB::bind_method(D_METHOD("set_custom_arrow_step", "arrow_step"), &SpinBox::set_custom_arrow_step);
 	ClassDB::bind_method(D_METHOD("get_custom_arrow_step"), &SpinBox::get_custom_arrow_step);
@@ -685,8 +740,11 @@ void SpinBox::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alignment", PROPERTY_HINT_ENUM, "Left,Center,Right,Fill"), "set_horizontal_alignment", "get_horizontal_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editable"), "set_editable", "is_editable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "update_on_text_changed"), "set_update_on_text_changed", "get_update_on_text_changed");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "format", PROPERTY_HINT_PLACEHOLDER_TEXT, "%s"), "set_format", "get_format");
+#ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "prefix"), "set_prefix", "get_prefix");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "suffix"), "set_suffix", "get_suffix");
+#endif
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_arrow_step", PROPERTY_HINT_RANGE, "0,10000,0.0001,or_greater"), "set_custom_arrow_step", "get_custom_arrow_step");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "custom_arrow_round"), "set_custom_arrow_round", "is_custom_arrow_rounding");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "select_all_on_focus"), "set_select_all_on_focus", "is_select_all_on_focus");

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -72,11 +72,16 @@ class SpinBox : public Range {
 	void _arrow_clicked(bool p_up);
 
 	void _update_text(bool p_only_update_if_value_changed = false);
+	void _set_error(const String &p_error);
 	void _text_submitted(const String &p_string);
 	void _text_changed(const String &p_string);
 
+	String format;
+	bool use_default_format = false;
+#ifndef DISABLE_DEPRECATED
 	String prefix;
 	String suffix;
+#endif
 	String last_text_value;
 	double custom_arrow_step = 0.0;
 	bool custom_arrow_round = false;
@@ -152,8 +157,9 @@ class SpinBox : public Range {
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _value_changed(double p_value) override;
-	void _validate_property(PropertyInfo &p_property) const;
+	virtual PackedStringArray get_configuration_warnings() const override;
 
+	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 	static void _bind_methods();
 
@@ -168,11 +174,16 @@ public:
 	void set_editable(bool p_enabled);
 	bool is_editable() const;
 
+	void set_format(const String &p_format);
+	String get_format() const;
+
+#ifndef DISABLE_DEPRECATED
 	void set_suffix(const String &p_suffix);
 	String get_suffix() const;
 
 	void set_prefix(const String &p_prefix);
 	String get_prefix() const;
+#endif
 
 	void set_update_on_text_changed(bool p_enabled);
 	bool get_update_on_text_changed() const;

--- a/tests/scene/test_spin_box.cpp
+++ b/tests/scene/test_spin_box.cpp
@@ -80,8 +80,7 @@ TEST_CASE("[SceneTree][SpinBox] Range clamping and allow flags") {
 
 TEST_CASE("[SceneTree][SpinBox] Prefix and suffix in line edit text") {
 	SpinBox *spin = memnew(SpinBox);
-	spin->set_prefix("px");
-	spin->set_suffix("deg");
+	spin->set_format("px %s deg");
 	spin->set_value(42.0);
 
 	Window *root = SceneTree::get_singleton()->get_root();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4478 without breaking compatibility. `prefix`/`suffix` is used normally if `format` is not specified.

https://github.com/user-attachments/assets/ae1a9494-70b9-41f9-b851-22ea5b12322b