### PR TITLE
Remove unneeded `read_only` check for `Array` const operator

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -88,11 +88,11 @@ Array::Iterator Array::end() {
 }
 
 Array::ConstIterator Array::begin() const {
-	return ConstIterator(_p->array.ptr(), _p->read_only);
+	return ConstIterator(_p->array.ptr());
 }
 
 Array::ConstIterator Array::end() const {
-	return ConstIterator(_p->array.ptr() + _p->array.size(), _p->read_only);
+	return ConstIterator(_p->array.ptr() + _p->array.size());
 }
 
 Variant &Array::operator[](int p_idx) {
@@ -104,10 +104,6 @@ Variant &Array::operator[](int p_idx) {
 }
 
 const Variant &Array::operator[](int p_idx) const {
-	if (unlikely(_p->read_only)) {
-		*_p->read_only = _p->array[p_idx];
-		return *_p->read_only;
-	}
 	return _p->array[p_idx];
 }
 

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -56,21 +56,19 @@ public:
 		_FORCE_INLINE_ bool operator==(const ConstIterator &p_other) const { return element_ptr == p_other.element_ptr; }
 		_FORCE_INLINE_ bool operator!=(const ConstIterator &p_other) const { return element_ptr != p_other.element_ptr; }
 
-		_FORCE_INLINE_ ConstIterator(const Variant *p_element_ptr, Variant *p_read_only = nullptr) :
-				element_ptr(p_element_ptr), read_only(p_read_only) {}
+		_FORCE_INLINE_ ConstIterator(const Variant *p_element_ptr) :
+				element_ptr(p_element_ptr) {}
 		_FORCE_INLINE_ ConstIterator() {}
 		_FORCE_INLINE_ ConstIterator(const ConstIterator &p_other) :
-				element_ptr(p_other.element_ptr), read_only(p_other.read_only) {}
+				element_ptr(p_other.element_ptr) {}
 
 		_FORCE_INLINE_ ConstIterator &operator=(const ConstIterator &p_other) {
 			element_ptr = p_other.element_ptr;
-			read_only = p_other.read_only;
 			return *this;
 		}
 
 	private:
 		const Variant *element_ptr = nullptr;
-		Variant *read_only = nullptr;
 	};
 
 	struct Iterator {
@@ -96,7 +94,7 @@ public:
 		}
 
 		operator ConstIterator() const {
-			return ConstIterator(element_ptr, read_only);
+			return ConstIterator(element_ptr);
 		}
 
 	private:

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -997,18 +997,10 @@ Array::Iterator &Array::Iterator::operator--() {
 }
 
 const Variant &Array::ConstIterator::operator*() const {
-	if (unlikely(read_only)) {
-		*read_only = *element_ptr;
-		return *read_only;
-	}
 	return *element_ptr;
 }
 
 const Variant *Array::ConstIterator::operator->() const {
-	if (unlikely(read_only)) {
-		*read_only = *element_ptr;
-		return read_only;
-	}
 	return element_ptr;
 }
 


### PR DESCRIPTION
After checking related PRs, I believe these checks are redundant. The `read_only` check in `ConstIterator` comes from #86518, intended to be consistent with the subscript operator, which was added in #61127 (read-only `Array`), based on #61087 (read-only `Dictionary`). However, `const Variant &Dictionary::operator[]` does not have a `read_only` check (not added in #61087 or subsequent PRs).  

Even if these checks are removed, the compiler will still prevent any modifications to container elements through these interfaces, so I think this change is safe.

*Bugsquad edit:*
- Fixes #93600.