### PR TITLE
Fix incomplete description for `ResourceLoader.list_directory()`

### DIFF
--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -79,7 +79,13 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="directory_path" type="String" />
 			<description>
-				Lists a directory (as example: "res://assets/enemies"), returning all resources contained within. The resource files are the original file names as visible in the editor before exporting.
+				Lists a directory, returning all resources and subdirectories contained within. The resource files have the original file names as visible in the editor before exporting. The directories have [code]"/"[/code] appended.
+				[codeblock]
+				print(ResourceLoader.list_directory("res://assets/enemies/slime"))
+				# Prints ["extra_data/", "model.gltf", "model.tscn", "model_slime.png"]
+				[/codeblock]
+				[b]Note:[/b] The order of files and directories returned by this method is not deterministic, and can vary between operating systems.
+				[b]Note:[/b] To normally traverse the filesystem, see [DirAccess].
 			</description>
 		</method>
 		<method name="load">


### PR DESCRIPTION
Description of `ResourceLoader.list_directory()` is bad.
 - Doesn't say it includes directories. The fact it just says "returning all resources contained within" implies it only includes files that are resources.
 - The way it appends `/` at the end of directories isn't in common with `DirAccess`(it's just the folder name), which seems like an inconsistency... but regardless it should be mentioned.
 - Doesn't say that the order is not deterministic (Uses `DirAccess.list_dir_begin()`, so I copy pasted part of its description).
 - Should probably refer to `DirAccess` as the standard way of interacting with the filesystem.

My edit should cover the bases.