### PR TITLE
Fix LoadToken memory leak caused by unused resources obtained using `load_threaded_request()`

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1394,7 +1394,10 @@ void ResourceLoader::clear_thread_load_tasks() {
 		DEV_ASSERT(user_token->user_rc > 0 && !user_token->user_path.is_empty());
 		user_token->user_path.clear();
 		user_token->user_rc = 0;
-		user_token->unreference();
+		if (user_token->unreference()) {
+			memdelete(user_token);
+			user_token = nullptr;
+		}
 	}
 
 	thread_load_tasks.clear();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/102476.

The `memdelete()` call is what actually matters here. This is done in the exact same manner in `load_threaded_get()` so I believe it was just an oversight.