### PR TITLE
Improve editor 2D/3D main screen auto-switching logic

### DIFF
--- a/editor/editor_main_screen.cpp
+++ b/editor/editor_main_screen.cpp
@@ -233,6 +233,25 @@ EditorPlugin *EditorMainScreen::get_plugin_by_name(const String &p_plugin_name) 
 	return main_editor_plugins[p_plugin_name];
 }
 
+bool EditorMainScreen::can_auto_switch_screens() const {
+	if (selected_plugin == nullptr) {
+		return true;
+	}
+	// Only allow auto-switching if the selected button is to the left of the Script button.
+	for (int i = 0; i < button_hb->get_child_count(); i++) {
+		Button *button = Object::cast_to<Button>(button_hb->get_child(i));
+		if (button->get_text() == "Script") {
+			// Selected button is at or after the Script button.
+			return false;
+		}
+		if (button->get_text() == selected_plugin->get_plugin_name()) {
+			// Selected button is before the Script button.
+			return true;
+		}
+	}
+	return false;
+}
+
 VBoxContainer *EditorMainScreen::get_control() const {
 	return main_screen_vbox;
 }

--- a/editor/editor_main_screen.h
+++ b/editor/editor_main_screen.h
@@ -81,6 +81,7 @@ public:
 	int get_plugin_index(EditorPlugin *p_editor) const;
 	EditorPlugin *get_selected_plugin() const;
 	EditorPlugin *get_plugin_by_name(const String &p_plugin_name) const;
+	bool can_auto_switch_screens() const;
 
 	VBoxContainer *get_control() const;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2719,7 +2719,11 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 			SceneTreeDock::get_singleton()->set_selection({ current_node });
 			InspectorDock::get_singleton()->update(current_node);
 			if (!inspector_only && !skip_main_plugin) {
-				skip_main_plugin = stay_in_script_editor_on_node_selected && !ScriptEditor::get_singleton()->is_editor_floating() && ScriptEditor::get_singleton()->is_visible_in_tree();
+				if (!ScriptEditor::get_singleton()->is_editor_floating() && ScriptEditor::get_singleton()->is_visible_in_tree()) {
+					skip_main_plugin = stay_in_script_editor_on_node_selected;
+				} else {
+					skip_main_plugin = !editor_main_screen->can_auto_switch_screens();
+				}
 			}
 		} else {
 			NodeDock::get_singleton()->set_node(nullptr);
@@ -2798,9 +2802,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 				if (!changing_scene) {
 					main_plugin->edit(current_obj);
 				}
-			}
-
-			else if (main_plugin != editor_plugin_screen && (!ScriptEditor::get_singleton() || !ScriptEditor::get_singleton()->is_visible_in_tree() || ScriptEditor::get_singleton()->can_take_away_focus())) {
+			} else if (main_plugin != editor_plugin_screen) {
 				// Unedit previous plugin.
 				editor_plugin_screen->edit(nullptr);
 				active_plugins[editor_owner_id].erase(editor_plugin_screen);
@@ -3998,18 +4000,15 @@ void EditorNode::_set_main_scene_state(Dictionary p_state, Node *p_for_scene) {
 	changing_scene = false;
 
 	if (get_edited_scene()) {
-		int current_tab = editor_main_screen->get_selected_index();
-		if (current_tab < 2) {
+		if (editor_main_screen->can_auto_switch_screens()) {
 			// Switch between 2D and 3D if currently in 2D or 3D.
 			Node *selected_node = SceneTreeDock::get_singleton()->get_tree_editor()->get_selected();
 			if (!selected_node) {
 				selected_node = get_edited_scene();
 			}
-
-			if (Object::cast_to<CanvasItem>(selected_node)) {
-				editor_main_screen->select(EditorMainScreen::EDITOR_2D);
-			} else if (Object::cast_to<Node3D>(selected_node)) {
-				editor_main_screen->select(EditorMainScreen::EDITOR_3D);
+			const int plugin_index = editor_main_screen->get_plugin_index(editor_data.get_handling_main_editor(selected_node));
+			if (plugin_index >= 0) {
+				editor_main_screen->select(plugin_index);
 			}
 		}
 	}
@@ -7710,6 +7709,7 @@ EditorNode::EditorNode() {
 
 	HBoxContainer *main_editor_button_hb = memnew(HBoxContainer);
 	main_editor_button_hb->set_mouse_filter(Control::MOUSE_FILTER_STOP);
+	main_editor_button_hb->set_name("EditorMainScreenButtons");
 	editor_main_screen->set_button_container(main_editor_button_hb);
 	title_bar->add_child(main_editor_button_hb);
 	title_bar->set_center_control(main_editor_button_hb);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1849,15 +1849,6 @@ void ScriptEditor::_notification(int p_what) {
 	}
 }
 
-bool ScriptEditor::can_take_away_focus() const {
-	ScriptEditorBase *current = _get_current_editor();
-	if (current) {
-		return current->can_lose_focus_on_node_selection();
-	} else {
-		return true;
-	}
-}
-
 void ScriptEditor::_close_builtin_scripts_from_scene(const String &p_scene) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -208,7 +208,6 @@ public:
 	virtual void add_callback(const String &p_function, const PackedStringArray &p_args) = 0;
 	virtual void update_settings() = 0;
 	virtual void set_debugger_active(bool p_active) = 0;
-	virtual bool can_lose_focus_on_node_selection() { return true; }
 	virtual void update_toggle_files_button() {}
 
 	virtual bool show_members_overview() = 0;
@@ -588,8 +587,6 @@ public:
 
 	void trigger_live_script_reload(const String &p_script_path);
 	void trigger_live_script_reload_all();
-
-	bool can_take_away_focus() const;
 
 	VSplitContainer *get_left_list_split() { return list_split; }
 

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -141,7 +141,6 @@ public:
 	virtual void tag_saved_version() override;
 	virtual void update_settings() override;
 	virtual bool show_members_overview() override;
-	virtual bool can_lose_focus_on_node_selection() override { return true; }
 	virtual void set_debugger_active(bool p_active) override;
 	virtual void set_tooltip_request_func(const Callable &p_toolip_callback) override;
 	virtual void add_callback(const String &p_function, const PackedStringArray &p_args) override;


### PR DESCRIPTION
In master, Godot has a feature where the main screen tabs may auto-switch depending on the node type being edited.

* When editing a 2D scene or selecting a 2D node, and the 3D tab is selected, switch to 2D.
* When editing a 3D scene or selecting a 3D node, and the 2D tab is selected, switch to 3D.
* When creating a new 2D or 3D scene, and the tab isn't the script editor (2D/3D/Game/AssetLib/custom), switch.

Seems simple enough. However, the code currently has the following problems:

* There is a hard-coded assumption that the script editor is at index 2.
* Instead of using `func _handles` on each plugin, there is hard-coded logic to check for CanvasItem and Node3D.
* The logic does not behave the same when creating scenes as it does when editing scenes or nodes.
* There is some dead code in the script editor for deciding when to switch (it always returns true, but never happens).

https://github.com/user-attachments/assets/4661d7e1-34de-41e3-b18c-b4e21813f897

This PR makes the following changes:

* New function `bool EditorMainScreen::can_auto_switch_screens() const`.
    * This is used both when editing nodes/scenes and when creating new ones, so now the logic is unified.
    * Instead of hard-coding an index for Script, check what position it's at. The new logic is that any tab to the left of Script is considered auto-switch-away-able, and auto-switch-to-able is determined by `func _handles`.
    * For the built-in tabs, this does change behavior in one case: creating a new scene when either the Game or AssetLib tabs are active will keep you on those tabs, just like editing a scene already does.
* Set a human-readable unique name for the EditorMainScreenButtons HBoxContainer.
* Remove the dead `can_take_away_focus` and `can_lose_focus_on_node_selection` functions.

This now works correctly for custom node types and main screen tabs placed to the left of Script:

https://github.com/user-attachments/assets/bfb16b61-b4a3-466c-8955-ac2319dbb1cf

Implements and closes https://github.com/godotengine/godot-proposals/issues/12154

