### PR TITLE
Account for relative extends paths in a GDScript utility function

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2727,15 +2727,19 @@ String GDScriptLanguage::_get_global_class_name(const String &p_path, String *r_
 		while (subclass) {
 			if (subclass->extends_used) {
 				if (!subclass->extends_path.is_empty()) {
+					String subpath = subclass->extends_path;
+					if (subpath.is_relative_path()) {
+						subpath = path.get_base_dir().path_join(subpath).simplify_path();
+					}
 					if (subclass->extends.is_empty()) {
 						// We only care about the referenced class_name.
-						_ALLOW_DISCARD_ _get_global_class_name(subclass->extends_path, r_base_type, nullptr, nullptr, nullptr, r_visited);
+						_ALLOW_DISCARD_ _get_global_class_name(subpath, r_base_type, nullptr, nullptr, nullptr, r_visited);
 						subclass = nullptr;
 						break;
 					} else {
 						Vector<GDScriptParser::IdentifierNode *> extend_classes = subclass->extends;
 
-						Ref<FileAccess> subfile = FileAccess::open(subclass->extends_path, FileAccess::READ);
+						Ref<FileAccess> subfile = FileAccess::open(subpath, FileAccess::READ);
 						if (subfile.is_null()) {
 							break;
 						}
@@ -2743,10 +2747,6 @@ String GDScriptLanguage::_get_global_class_name(const String &p_path, String *r_
 
 						if (subsource.is_empty()) {
 							break;
-						}
-						String subpath = subclass->extends_path;
-						if (subpath.is_relative_path()) {
-							subpath = path.get_base_dir().path_join(subpath).simplify_path();
 						}
 
 						if (OK != subparser.parse(subsource, subpath, false)) {


### PR DESCRIPTION
Fixes #103970 

This function attempts to calculate the class a script inherits from, but it fails if the path is relative and the script is in a subdirectory since it uses the current working directory. Moving the resolution of the relative path earlier solves the problem.

This also fixes the script create dialog, which had the same problem, and probably other things since this is also used in editor_file_system.cpp. 

This change is inside a block of code with [a comment](https://github.com/precup/godot/blob/ee56228d0b3bef90d6c9fc8c7829316d6ca5ccfb/modules/gdscript/gdscript.cpp#L2842) that says "WARNING... Before changing this function, please ask the current maintainer of EditorFileSystem."