### PR TITLE
Add missing `ETR`/`TTR` markups

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5096,7 +5096,7 @@ void AnimationTrackEditor::_update_nearest_fps_label() {
 		nearest_fps_label->hide();
 	} else {
 		nearest_fps_label->show();
-		nearest_fps_label->set_text("Nearest FPS: " + itos(nearest_fps));
+		nearest_fps_label->set_text(vformat(TTR("Nearest FPS: %d"), nearest_fps));
 	}
 }
 
@@ -7696,6 +7696,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	fps_compat->connect(SceneStringName(toggled), callable_mp(this, &AnimationTrackEditor::_update_fps_compat_mode));
 
 	nearest_fps_label = memnew(Label);
+	nearest_fps_label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	bottom_hf->add_child(nearest_fps_label);
 
 	step = memnew(EditorSpinSlider);

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -871,9 +871,8 @@ ConnectDialog::ConnectDialog() {
 	hbc_method->add_child(dst_method);
 	register_text_enter(dst_method);
 
-	open_method_tree = memnew(Button);
+	open_method_tree = memnew(Button(TTRC("Pick")));
 	hbc_method->add_child(open_method_tree);
-	open_method_tree->set_text("Pick");
 	open_method_tree->connect(SceneStringName(pressed), callable_mp(this, &ConnectDialog::_open_method_popup));
 
 	advanced = memnew(CheckButton(TTR("Advanced")));

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2807,7 +2807,7 @@ ColorPicker::ColorPicker() {
 	swatches_vbc->add_child(palette_box);
 
 	btn_preset = memnew(Button);
-	btn_preset->set_text("Swatches");
+	btn_preset->set_text(ETR("Swatches"));
 	btn_preset->set_flat(true);
 	btn_preset->set_toggle_mode(true);
 	btn_preset->set_focus_mode(FOCUS_ALL);


### PR DESCRIPTION
- `Nearest FPS: %d`: Missing `TTR()` in the Animation tab.
- `Swatches`: Missing `ETR()` in the ColorPicker node.
- `Pick`: This string has been marked somewhere else, so there are currently no translation issues. But it should still be marked. Using `TTRC()` since it's now the preferred macro that can better leverage auto translation.