### PR TITLE
Defend against directories without trailing slashes

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -3437,7 +3437,7 @@ Error EditorFileSystem::make_dir_recursive(const String &p_path, const String &p
 	ERR_FAIL_NULL_V(parent, ERR_FILE_NOT_FOUND);
 	folders_to_sort.insert(parent->get_instance_id());
 
-	const PackedStringArray folders = p_path.trim_prefix(path).trim_suffix("/").split("/");
+	const PackedStringArray folders = p_path.trim_prefix(path).split("/", false);
 	for (const String &folder : folders) {
 		const int current = parent->find_dir_index(folder);
 		if (current > -1) {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2743,7 +2743,13 @@ void FileSystemDock::focus_on_filter() {
 }
 
 void FileSystemDock::create_directory(const String &p_path, const String &p_base_dir) {
-	Error err = EditorFileSystem::get_singleton()->make_dir_recursive(p_path.trim_prefix(p_base_dir), p_base_dir);
+	String trimmed_path = p_path;
+	if (!p_base_dir.is_empty()) {
+		// Trims off the joining '/' if the base didn't end with one. If the base did have it
+		// and there's two slashes, the empty directory is safe to trim off anyways.
+		trimmed_path = trimmed_path.trim_prefix(p_base_dir).trim_prefix("/");
+	}
+	Error err = EditorFileSystem::get_singleton()->make_dir_recursive(trimmed_path, p_base_dir);
 	if (err != OK) {
 		EditorNode::get_singleton()->show_warning(vformat(TTR("Could not create folder: %s"), error_names[err]));
 	}


### PR DESCRIPTION
Fixes #103992

`FileSystemDock::create_directory` can get called with a `base_dir` that don't have a trailing slash in a couple ways.  It seemed like a footgun for it to require a trailing slash, so I fixed the issue by making it tolerant to either formatting. 

After that, I audited similar usages of trim combined with paths in the rest of the codebase since this seems like an easy mistake to make, and the editor_file_system change addresses the only one that seemed similarly easy to make a mistake with and is a cheap enough addition it seemed reasonable to add defensively.

This largely occurs because `String::get_base_dir` returns a result without a trailing slash. Since this is also a `base_dir`, it seems like it *should* accept things straight from `String::get_base_dir`. 