### PR TITLE
Texture2D: Add virtual `get_mipmaps()` and `get_format()` methods

### DIFF
--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -386,6 +386,22 @@ RID NoiseTexture2D::get_rid() const {
 	return texture;
 }
 
+bool NoiseTexture2D::has_mipmaps() const {
+	if (image.is_valid()) {
+		return image->has_mipmaps();
+	}
+
+	return false;
+}
+
+Image::Format NoiseTexture2D::get_format() const {
+	if (image.is_valid()) {
+		return image->get_format();
+	}
+
+	return Image::FORMAT_MAX;
+}
+
 Ref<Image> NoiseTexture2D::get_image() const {
 	return image;
 }

--- a/modules/noise/noise_texture_2d.h
+++ b/modules/noise/noise_texture_2d.h
@@ -117,6 +117,9 @@ public:
 	virtual RID get_rid() const override;
 	virtual bool has_alpha() const override { return false; }
 
+	virtual bool has_mipmaps() const override;
+	virtual Image::Format get_format() const override;
+
 	virtual Ref<Image> get_image() const override;
 
 	NoiseTexture2D();

--- a/scene/resources/animated_texture.cpp
+++ b/scene/resources/animated_texture.cpp
@@ -205,6 +205,26 @@ bool AnimatedTexture::has_alpha() const {
 	return frames[current_frame].texture->has_alpha();
 }
 
+bool AnimatedTexture::has_mipmaps() const {
+	RWLockRead r(rw_lock);
+
+	if (frames[current_frame].texture.is_null()) {
+		return false;
+	}
+
+	return frames[current_frame].texture->has_mipmaps();
+}
+
+Image::Format AnimatedTexture::get_format() const {
+	RWLockRead r(rw_lock);
+
+	if (frames[current_frame].texture.is_null()) {
+		return Image::FORMAT_MAX;
+	}
+
+	return frames[current_frame].texture->get_format();
+}
+
 Ref<Image> AnimatedTexture::get_image() const {
 	RWLockRead r(rw_lock);
 

--- a/scene/resources/animated_texture.h
+++ b/scene/resources/animated_texture.h
@@ -97,6 +97,8 @@ public:
 	virtual RID get_rid() const override;
 
 	virtual bool has_alpha() const override;
+	virtual bool has_mipmaps() const override;
+	virtual Image::Format get_format() const override;
 
 	virtual Ref<Image> get_image() const override;
 

--- a/scene/resources/atlas_texture.cpp
+++ b/scene/resources/atlas_texture.cpp
@@ -68,6 +68,22 @@ bool AtlasTexture::has_alpha() const {
 	return false;
 }
 
+bool AtlasTexture::has_mipmaps() const {
+	if (atlas.is_valid()) {
+		return atlas->has_mipmaps();
+	}
+
+	return false;
+}
+
+Image::Format AtlasTexture::get_format() const {
+	if (atlas.is_valid()) {
+		return atlas->get_format();
+	}
+
+	return Image::FORMAT_MAX;
+}
+
 void AtlasTexture::set_atlas(const Ref<Texture2D> &p_atlas) {
 	ERR_FAIL_COND(p_atlas == this);
 	if (atlas == p_atlas) {

--- a/scene/resources/atlas_texture.h
+++ b/scene/resources/atlas_texture.h
@@ -52,6 +52,8 @@ public:
 	virtual RID get_rid() const override;
 
 	virtual bool has_alpha() const override;
+	virtual bool has_mipmaps() const override;
+	virtual Image::Format get_format() const override;
 
 	void set_atlas(const Ref<Texture2D> &p_atlas);
 	Ref<Texture2D> get_atlas() const;

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -152,6 +152,7 @@ Error CompressedTexture2D::load(const String &p_path) {
 
 	w = lw;
 	h = lh;
+	mipmaps = image->has_mipmaps();
 	path_to_file = p_path;
 	format = image->get_format();
 
@@ -234,6 +235,10 @@ void CompressedTexture2D::draw_rect_region(RID p_canvas_item, const Rect2 &p_rec
 
 bool CompressedTexture2D::has_alpha() const {
 	return false;
+}
+
+bool CompressedTexture2D::has_mipmaps() const {
+	return mipmaps;
 }
 
 Ref<Image> CompressedTexture2D::get_image() const {

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -65,6 +65,7 @@ private:
 	Image::Format format = Image::FORMAT_L8;
 	int w = 0;
 	int h = 0;
+	bool mipmaps = false;
 	mutable Ref<BitMap> alpha_cache;
 
 	Error _load_data(const String &p_path, int &r_width, int &r_height, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &mipmap_limit, int p_size_limit = 0);
@@ -88,13 +89,15 @@ public:
 	static TextureFormatRoughnessRequestCallback request_roughness_callback;
 	static TextureFormatRequestCallback request_normal_callback;
 
-	Image::Format get_format() const;
 	Error load(const String &p_path);
 	String get_load_path() const;
 
 	int get_width() const override;
 	int get_height() const override;
 	virtual RID get_rid() const override;
+
+	virtual bool has_mipmaps() const override;
+	virtual Image::Format get_format() const;
 
 	virtual void set_path(const String &p_path, bool p_take_over) override;
 

--- a/scene/resources/external_texture.cpp
+++ b/scene/resources/external_texture.cpp
@@ -76,6 +76,14 @@ bool ExternalTexture::has_alpha() const {
 	return false;
 }
 
+bool ExternalTexture::has_mipmaps() const {
+	return false;
+}
+
+Image::Format ExternalTexture::get_format() const {
+	return Image::FORMAT_MAX;
+}
+
 RID ExternalTexture::get_rid() const {
 	if (!texture.is_valid()) {
 		texture = RenderingServer::get_singleton()->texture_2d_placeholder_create();

--- a/scene/resources/external_texture.h
+++ b/scene/resources/external_texture.h
@@ -61,6 +61,9 @@ public:
 	virtual RID get_rid() const override;
 	virtual bool has_alpha() const override;
 
+	virtual bool has_mipmaps() const override;
+	virtual Image::Format get_format() const override;
+
 	ExternalTexture();
 	~ExternalTexture();
 };

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -152,6 +152,10 @@ bool ImageTexture::has_alpha() const {
 	return (format == Image::FORMAT_LA8 || format == Image::FORMAT_RGBA8);
 }
 
+bool ImageTexture::has_mipmaps() const {
+	return mipmaps;
+}
+
 void ImageTexture::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate, bool p_transpose) const {
 	if ((w | h) == 0) {
 		return;
@@ -227,7 +231,6 @@ void ImageTexture::set_path(const String &p_path, bool p_take_over) {
 
 void ImageTexture::_bind_methods() {
 	ClassDB::bind_static_method("ImageTexture", D_METHOD("create_from_image", "image"), &ImageTexture::create_from_image);
-	ClassDB::bind_method(D_METHOD("get_format"), &ImageTexture::get_format);
 
 	ClassDB::bind_method(D_METHOD("set_image", "image"), &ImageTexture::set_image);
 	ClassDB::bind_method(D_METHOD("update", "image"), &ImageTexture::update);

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -60,8 +60,6 @@ public:
 	void set_image(const Ref<Image> &p_image);
 	static Ref<ImageTexture> create_from_image(const Ref<Image> &p_image);
 
-	Image::Format get_format() const;
-
 	void update(const Ref<Image> &p_image);
 	Ref<Image> get_image() const override;
 
@@ -71,6 +69,9 @@ public:
 	virtual RID get_rid() const override;
 
 	bool has_alpha() const override;
+	bool has_mipmaps() const override;
+	Image::Format get_format() const override;
+
 	virtual void draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;
 	virtual void draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;
 	virtual void draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = true) const override;

--- a/scene/resources/portable_compressed_texture.cpp
+++ b/scene/resources/portable_compressed_texture.cpp
@@ -204,6 +204,10 @@ void PortableCompressedTexture2D::create_from_image(const Ref<Image> &p_image, C
 	_set_data(buffer);
 }
 
+bool PortableCompressedTexture2D::has_mipmaps() const {
+	return mipmaps;
+}
+
 Image::Format PortableCompressedTexture2D::get_format() const {
 	return format;
 }

--- a/scene/resources/portable_compressed_texture.h
+++ b/scene/resources/portable_compressed_texture.h
@@ -80,8 +80,6 @@ public:
 	CompressionMode get_compression_mode() const;
 	void create_from_image(const Ref<Image> &p_image, CompressionMode p_compression_mode, bool p_normal_map = false, float p_lossy_quality = 0.8);
 
-	Image::Format get_format() const;
-
 	void update(const Ref<Image> &p_image);
 	Ref<Image> get_image() const override;
 
@@ -89,6 +87,9 @@ public:
 	int get_height() const override;
 
 	virtual RID get_rid() const override;
+
+	virtual bool has_mipmaps() const override;
+	virtual Image::Format get_format() const override;
 
 	bool has_alpha() const override;
 	virtual void draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -60,6 +60,18 @@ bool Texture2D::has_alpha() const {
 	return ret;
 }
 
+Image::Format Texture2D::get_format() const {
+	Image::Format ret = Image::FORMAT_MAX;
+	GDVIRTUAL_CALL(_get_format, ret);
+	return ret;
+}
+
+bool Texture2D::has_mipmaps() const {
+	bool ret = false;
+	GDVIRTUAL_CALL(_has_mipmaps, ret);
+	return ret;
+}
+
 void Texture2D::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate, bool p_transpose) const {
 	if (GDVIRTUAL_CALL(_draw, p_canvas_item, p_pos, p_modulate, p_transpose)) {
 		return;
@@ -99,6 +111,8 @@ void Texture2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_height"), &Texture2D::get_height);
 	ClassDB::bind_method(D_METHOD("get_size"), &Texture2D::get_size);
 	ClassDB::bind_method(D_METHOD("has_alpha"), &Texture2D::has_alpha);
+	ClassDB::bind_method(D_METHOD("has_mipmaps"), &Texture2D::has_mipmaps);
+	ClassDB::bind_method(D_METHOD("get_format"), &Texture2D::get_format);
 	ClassDB::bind_method(D_METHOD("draw", "canvas_item", "position", "modulate", "transpose"), &Texture2D::draw, DEFVAL(Color(1, 1, 1)), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("draw_rect", "canvas_item", "rect", "tile", "modulate", "transpose"), &Texture2D::draw_rect, DEFVAL(Color(1, 1, 1)), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("draw_rect_region", "canvas_item", "rect", "src_rect", "modulate", "transpose", "clip_uv"), &Texture2D::draw_rect_region, DEFVAL(Color(1, 1, 1)), DEFVAL(false), DEFVAL(true));
@@ -111,6 +125,8 @@ void Texture2D::_bind_methods() {
 	GDVIRTUAL_BIND(_get_height);
 	GDVIRTUAL_BIND(_is_pixel_opaque, "x", "y");
 	GDVIRTUAL_BIND(_has_alpha);
+	GDVIRTUAL_BIND(_has_mipmaps);
+	GDVIRTUAL_BIND(_get_format);
 
 	GDVIRTUAL_BIND(_draw, "to_canvas_item", "pos", "modulate", "transpose")
 	GDVIRTUAL_BIND(_draw_rect, "to_canvas_item", "rect", "tile", "modulate", "transpose")

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -55,6 +55,8 @@ protected:
 	GDVIRTUAL0RC_REQUIRED(int, _get_height)
 	GDVIRTUAL2RC(bool, _is_pixel_opaque, int, int)
 	GDVIRTUAL0RC(bool, _has_alpha)
+	GDVIRTUAL0RC(bool, _has_mipmaps)
+	GDVIRTUAL0RC(Image::Format, _get_format)
 
 	GDVIRTUAL4C(_draw, RID, Point2, Color, bool)
 	GDVIRTUAL5C(_draw_rect, RID, Rect2, bool, Color, bool)
@@ -65,8 +67,10 @@ public:
 	virtual int get_height() const;
 	virtual Size2 get_size() const;
 
-	virtual bool is_pixel_opaque(int p_x, int p_y) const;
+	virtual Image::Format get_format() const;
+	virtual bool has_mipmaps() const;
 
+	virtual bool is_pixel_opaque(int p_x, int p_y) const;
 	virtual bool has_alpha() const;
 
 	virtual void draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const;


### PR DESCRIPTION
Adds optional virtual methods for getting the mipmaps and the format of Texture2D derived classes. Previously, these functions were implemented in certain classes only

TODO:
- [ ] Fix the documentation,
- [ ] Testing