### PR TITLE
Tree: Fix dragging unselected item when a selection already exists

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3012,6 +3012,9 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 						int icount = _count_selected_items(root);
 
 						if (select_mode == SELECT_MULTI && icount > 1 && p_button != MouseButton::RIGHT) {
+							if (!already_selected) {
+								select_single_item(p_item, root, col);
+							}
 							single_select_defer = p_item;
 							single_select_defer_column = col;
 						} else {


### PR DESCRIPTION
Trying to close [103858](https://github.com/godotengine/godot/issues/103858)
After investigating this was not linked to parenting but instead to selected tree items.
I discussed on godot contributor chat and this was not expected behaviour (see GIF)
![Drag](https://github.com/user-attachments/assets/f804266d-d5eb-458f-90fa-66252b61ad50)
It should now be working properly