### PR TITLE
Delete SHOW_ALL_FILES_THRESHOLD and the corresponding logic, and add a switch to enable and disable the history file mode in the fast loading.

### DIFF
--- a/editor/gui/editor_quick_open_dialog.h
+++ b/editor/gui/editor_quick_open_dialog.h
@@ -107,7 +107,6 @@ protected:
 	void _notification(int p_what);
 
 private:
-	static constexpr int SHOW_ALL_FILES_THRESHOLD = 30;
 	static constexpr int MAX_HISTORY_SIZE = 20;
 
 	Vector<FuzzySearchResult> search_results;
@@ -124,6 +123,7 @@ private:
 	int max_total_results = 0;
 
 	bool showing_history = false;
+	bool enable_showing_history = false;
 	bool never_opened = true;
 	Ref<ConfigFile> history_file;
 
@@ -143,6 +143,7 @@ private:
 	Button *display_mode_toggle = nullptr;
 	CheckButton *include_addons_toggle = nullptr;
 	CheckButton *fuzzy_search_toggle = nullptr;
+	CheckButton *showing_history_toggle = nullptr;
 
 	OAHashMap<StringName, Ref<Texture2D>> file_type_icons;
 
@@ -170,6 +171,7 @@ private:
 	void _toggle_display_mode();
 	void _toggle_include_addons(bool p_pressed);
 	void _toggle_fuzzy_search(bool p_pressed);
+	void _toggle_showing_history_toggle(bool p_pressed);
 	void _menu_option(int p_option);
 
 	String _get_cache_file_path() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
I removed SHOW_ALL_FILES_THRESHOLD and added a new variable in the QuickOpenResultContainer class, enable_showing_history, to switch the history file mode.

I added a new switch in the Bottom bar of the quick load dialog that I can use to update the enable_showing_history and update the contents of the quick load dialog.

The effect is as follows

![image](https://github.com/user-attachments/assets/c414270e-0da8-4b09-bca1-ddb54b680fb5)
![image](https://github.com/user-attachments/assets/29ed8bb9-f0c6-4fc3-a842-9ccd0171dc17)

- #103558 