### PR TITLE
Expose `String` as `Godot::String`

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -652,6 +652,12 @@ public:
 	}
 };
 
+// This exposes `String` as `Godot::String`.
+// This solves GH-104038.
+namespace Godot {
+using String = String;
+}
+
 // Zero-constructing String initializes _cowdata.ptr() to nullptr and thus empty.
 template <>
 struct is_zero_constructible<String> : std::true_type {};


### PR DESCRIPTION
This exposes `String` as `Godot::String`.

Fixes #104038.

> [!NOTE]
> It doesn't fix the ambiguity _per se_.
> It enables users to use `Godot::String("Hello")` if they want to create a `String` in the debugger prompt.
