### PR TITLE
Style: Convert namespaces to PascalCase

### DIFF
--- a/core/core_bind.compat.inc
+++ b/core/core_bind.compat.inc
@@ -30,7 +30,7 @@
 
 #ifndef DISABLE_DEPRECATED
 
-namespace core_bind {
+namespace CoreBind {
 
 // Semaphore
 
@@ -59,6 +59,6 @@ void OS::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("execute_with_pipe", "path", "arguments"), &OS::_execute_with_pipe_bind_compat_94434);
 }
 
-} // namespace core_bind
+} // namespace CoreBind
 
 #endif // DISABLE_DEPRECATED

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -42,7 +42,7 @@
 #include "core/os/thread_safe.h"
 #include "core/variant/typed_array.h"
 
-namespace core_bind {
+namespace CoreBind {
 
 ////// ResourceLoader //////
 
@@ -1422,7 +1422,7 @@ void Thread::_bind_methods() {
 	BIND_ENUM_CONSTANT(PRIORITY_HIGH);
 }
 
-namespace special {
+namespace Special {
 
 ////// ClassDB //////
 
@@ -1749,7 +1749,7 @@ void ClassDB::_bind_methods() {
 	BIND_ENUM_CONSTANT(API_NONE);
 }
 
-} // namespace special
+} // namespace Special
 
 ////// Engine //////
 
@@ -2193,4 +2193,4 @@ void EngineDebugger::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_breakpoints"), &EngineDebugger::clear_breakpoints);
 }
 
-} // namespace core_bind
+} // namespace CoreBind

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -41,7 +41,7 @@ class MainLoop;
 template <typename T>
 class TypedArray;
 
-namespace core_bind {
+namespace CoreBind {
 
 class ResourceLoader : public Object {
 	GDCLASS(ResourceLoader, Object);
@@ -457,7 +457,7 @@ public:
 	static void set_thread_safety_checks_enabled(bool p_enabled);
 };
 
-namespace special {
+namespace Special {
 
 class ClassDB : public Object {
 	GDCLASS(ClassDB, Object);
@@ -523,7 +523,7 @@ public:
 	~ClassDB() {}
 };
 
-} // namespace special
+} // namespace Special
 
 class Engine : public Object {
 	GDCLASS(Engine, Object);
@@ -651,21 +651,21 @@ public:
 	~EngineDebugger();
 };
 
-} // namespace core_bind
+} // namespace CoreBind
 
-VARIANT_ENUM_CAST(core_bind::ResourceLoader::ThreadLoadStatus);
-VARIANT_ENUM_CAST(core_bind::ResourceLoader::CacheMode);
+VARIANT_ENUM_CAST(CoreBind::ResourceLoader::ThreadLoadStatus);
+VARIANT_ENUM_CAST(CoreBind::ResourceLoader::CacheMode);
 
-VARIANT_BITFIELD_CAST(core_bind::ResourceSaver::SaverFlags);
+VARIANT_BITFIELD_CAST(CoreBind::ResourceSaver::SaverFlags);
 
-VARIANT_ENUM_CAST(core_bind::OS::RenderingDriver);
-VARIANT_ENUM_CAST(core_bind::OS::SystemDir);
-VARIANT_ENUM_CAST(core_bind::OS::StdHandleType);
+VARIANT_ENUM_CAST(CoreBind::OS::RenderingDriver);
+VARIANT_ENUM_CAST(CoreBind::OS::SystemDir);
+VARIANT_ENUM_CAST(CoreBind::OS::StdHandleType);
 
-VARIANT_ENUM_CAST(core_bind::Geometry2D::PolyBooleanOperation);
-VARIANT_ENUM_CAST(core_bind::Geometry2D::PolyJoinType);
-VARIANT_ENUM_CAST(core_bind::Geometry2D::PolyEndType);
+VARIANT_ENUM_CAST(CoreBind::Geometry2D::PolyBooleanOperation);
+VARIANT_ENUM_CAST(CoreBind::Geometry2D::PolyJoinType);
+VARIANT_ENUM_CAST(CoreBind::Geometry2D::PolyEndType);
 
-VARIANT_ENUM_CAST(core_bind::Thread::Priority);
+VARIANT_ENUM_CAST(CoreBind::Thread::Priority);
 
-VARIANT_ENUM_CAST(core_bind::special::ClassDB::APIType);
+VARIANT_ENUM_CAST(CoreBind::Special::ClassDB::APIType);

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -905,8 +905,8 @@ Ref<Resource> ResourceLoader::_load_complete_inner(LoadToken &p_load_token, Erro
 						}
 					}
 					if (!import_thread) { // Main thread is blocked by initial resource reimport, do not wait.
-						core_bind::Semaphore done;
-						MessageQueue::get_main_singleton()->push_callable(callable_mp(&done, &core_bind::Semaphore::post).bind(1));
+						CoreBind::Semaphore done;
+						MessageQueue::get_main_singleton()->push_callable(callable_mp(&done, &CoreBind::Semaphore::post).bind(1));
 						done.wait();
 					}
 				}

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -35,7 +35,7 @@
 #include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
 
-namespace core_bind {
+namespace CoreBind {
 class ResourceLoader;
 }
 
@@ -104,7 +104,7 @@ typedef void (*ResourceLoadedCallback)(Ref<Resource> p_resource, const String &p
 
 class ResourceLoader {
 	friend class LoadToken;
-	friend class core_bind::ResourceLoader;
+	friend class CoreBind::ResourceLoader;
 
 	enum {
 		MAX_LOADERS = 64

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -92,19 +92,19 @@ static Ref<GDExtensionResourceLoader> resource_loader_gdextension;
 static Ref<ResourceFormatSaverJSON> resource_saver_json;
 static Ref<ResourceFormatLoaderJSON> resource_loader_json;
 
-static core_bind::ResourceLoader *_resource_loader = nullptr;
-static core_bind::ResourceSaver *_resource_saver = nullptr;
-static core_bind::OS *_os = nullptr;
-static core_bind::Engine *_engine = nullptr;
-static core_bind::special::ClassDB *_classdb = nullptr;
-static core_bind::Marshalls *_marshalls = nullptr;
-static core_bind::EngineDebugger *_engine_debugger = nullptr;
+static CoreBind::ResourceLoader *_resource_loader = nullptr;
+static CoreBind::ResourceSaver *_resource_saver = nullptr;
+static CoreBind::OS *_os = nullptr;
+static CoreBind::Engine *_engine = nullptr;
+static CoreBind::Special::ClassDB *_classdb = nullptr;
+static CoreBind::Marshalls *_marshalls = nullptr;
+static CoreBind::EngineDebugger *_engine_debugger = nullptr;
 
 static IP *ip = nullptr;
 static Time *_time = nullptr;
 
-static core_bind::Geometry2D *_geometry_2d = nullptr;
-static core_bind::Geometry3D *_geometry_3d = nullptr;
+static CoreBind::Geometry2D *_geometry_2d = nullptr;
+static CoreBind::Geometry3D *_geometry_3d = nullptr;
 
 static WorkerThreadPool *worker_thread_pool = nullptr;
 
@@ -251,9 +251,9 @@ void register_core_types() {
 
 	GDREGISTER_ABSTRACT_CLASS(FileAccess);
 	GDREGISTER_ABSTRACT_CLASS(DirAccess);
-	GDREGISTER_CLASS(core_bind::Thread);
-	GDREGISTER_CLASS(core_bind::Mutex);
-	GDREGISTER_CLASS(core_bind::Semaphore);
+	GDREGISTER_CLASS(CoreBind::Thread);
+	GDREGISTER_CLASS(CoreBind::Mutex);
+	GDREGISTER_CLASS(CoreBind::Semaphore);
 
 	GDREGISTER_CLASS(XMLParser);
 	GDREGISTER_CLASS(JSON);
@@ -293,16 +293,16 @@ void register_core_types() {
 
 	ip = IP::create();
 
-	_geometry_2d = memnew(core_bind::Geometry2D);
-	_geometry_3d = memnew(core_bind::Geometry3D);
+	_geometry_2d = memnew(CoreBind::Geometry2D);
+	_geometry_3d = memnew(CoreBind::Geometry3D);
 
-	_resource_loader = memnew(core_bind::ResourceLoader);
-	_resource_saver = memnew(core_bind::ResourceSaver);
-	_os = memnew(core_bind::OS);
-	_engine = memnew(core_bind::Engine);
-	_classdb = memnew(core_bind::special::ClassDB);
-	_marshalls = memnew(core_bind::Marshalls);
-	_engine_debugger = memnew(core_bind::EngineDebugger);
+	_resource_loader = memnew(CoreBind::ResourceLoader);
+	_resource_saver = memnew(CoreBind::ResourceSaver);
+	_os = memnew(CoreBind::OS);
+	_engine = memnew(CoreBind::Engine);
+	_classdb = memnew(CoreBind::Special::ClassDB);
+	_marshalls = memnew(CoreBind::Marshalls);
+	_engine_debugger = memnew(CoreBind::EngineDebugger);
 
 	GDREGISTER_NATIVE_STRUCT(ObjectID, "uint64_t id = 0");
 	GDREGISTER_NATIVE_STRUCT(AudioFrame, "float left;float right");
@@ -324,14 +324,14 @@ void register_core_settings() {
 }
 
 void register_early_core_singletons() {
-	GDREGISTER_CLASS(core_bind::Engine);
-	Engine::get_singleton()->add_singleton(Engine::Singleton("Engine", core_bind::Engine::get_singleton()));
+	GDREGISTER_CLASS(CoreBind::Engine);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Engine", CoreBind::Engine::get_singleton()));
 
 	GDREGISTER_CLASS(ProjectSettings);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ProjectSettings", ProjectSettings::get_singleton()));
 
-	GDREGISTER_CLASS(core_bind::OS);
-	Engine::get_singleton()->add_singleton(Engine::Singleton("OS", core_bind::OS::get_singleton()));
+	GDREGISTER_CLASS(CoreBind::OS);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("OS", CoreBind::OS::get_singleton()));
 
 	GDREGISTER_CLASS(Time);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Time", Time::get_singleton()));
@@ -341,29 +341,29 @@ void register_core_singletons() {
 	OS::get_singleton()->benchmark_begin_measure("Core", "Register Singletons");
 
 	GDREGISTER_ABSTRACT_CLASS(IP);
-	GDREGISTER_CLASS(core_bind::Geometry2D);
-	GDREGISTER_CLASS(core_bind::Geometry3D);
-	GDREGISTER_CLASS(core_bind::ResourceLoader);
-	GDREGISTER_CLASS(core_bind::ResourceSaver);
-	GDREGISTER_CLASS(core_bind::special::ClassDB);
-	GDREGISTER_CLASS(core_bind::Marshalls);
+	GDREGISTER_CLASS(CoreBind::Geometry2D);
+	GDREGISTER_CLASS(CoreBind::Geometry3D);
+	GDREGISTER_CLASS(CoreBind::ResourceLoader);
+	GDREGISTER_CLASS(CoreBind::ResourceSaver);
+	GDREGISTER_CLASS(CoreBind::Special::ClassDB);
+	GDREGISTER_CLASS(CoreBind::Marshalls);
 	GDREGISTER_CLASS(TranslationServer);
 	GDREGISTER_ABSTRACT_CLASS(Input);
 	GDREGISTER_CLASS(InputMap);
 	GDREGISTER_CLASS(Expression);
-	GDREGISTER_CLASS(core_bind::EngineDebugger);
+	GDREGISTER_CLASS(CoreBind::EngineDebugger);
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("IP", IP::get_singleton(), "IP"));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("Geometry2D", core_bind::Geometry2D::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("Geometry3D", core_bind::Geometry3D::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceLoader", core_bind::ResourceLoader::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceSaver", core_bind::ResourceSaver::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Geometry2D", CoreBind::Geometry2D::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Geometry3D", CoreBind::Geometry3D::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceLoader", CoreBind::ResourceLoader::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceSaver", CoreBind::ResourceSaver::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ClassDB", _classdb));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("Marshalls", core_bind::Marshalls::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Marshalls", CoreBind::Marshalls::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("TranslationServer", TranslationServer::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Input", Input::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("InputMap", InputMap::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("EngineDebugger", core_bind::EngineDebugger::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("EngineDebugger", CoreBind::EngineDebugger::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GDExtensionManager", GDExtensionManager::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceUID", ResourceUID::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("WorkerThreadPool", worker_thread_pool));

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -209,8 +209,8 @@ struct GetTypeInfo<T *, std::enable_if_t<std::is_base_of_v<Object, T>>> {
 	}
 };
 
-namespace godot {
-namespace details {
+namespace GodotTypeInfo {
+namespace Internal {
 inline String enum_qualified_name_to_class_info_name(const String &p_qualified_name) {
 	Vector<String> parts = p_qualified_name.split("::", false);
 	if (parts.size() <= 2) {
@@ -219,8 +219,8 @@ inline String enum_qualified_name_to_class_info_name(const String &p_qualified_n
 	// Contains namespace. We only want the class and enum names.
 	return parts[parts.size() - 2] + "." + parts[parts.size() - 1];
 }
-} // namespace details
-} // namespace godot
+} // namespace Internal
+} // namespace GodotTypeInfo
 
 #define TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_impl)                                                                                            \
 	template <>                                                                                                                              \
@@ -229,7 +229,7 @@ inline String enum_qualified_name_to_class_info_name(const String &p_qualified_n
 		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                        \
 		static inline PropertyInfo get_class_info() {                                                                                        \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_ENUM, \
-					godot::details::enum_qualified_name_to_class_info_name(String(#m_enum)));                                                \
+					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum)));                                       \
 		}                                                                                                                                    \
 	};
 
@@ -278,7 +278,7 @@ struct is_zero_constructible<BitField<T>> : std::true_type {};
 		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                            \
 		static inline PropertyInfo get_class_info() {                                                                                            \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_BITFIELD, \
-					godot::details::enum_qualified_name_to_class_info_name(String(#m_enum)));                                                    \
+					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum)));                                           \
 		}                                                                                                                                        \
 	};                                                                                                                                           \
 	template <>                                                                                                                                  \
@@ -287,7 +287,7 @@ struct is_zero_constructible<BitField<T>> : std::true_type {};
 		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                            \
 		static inline PropertyInfo get_class_info() {                                                                                            \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_BITFIELD, \
-					godot::details::enum_qualified_name_to_class_info_name(String(#m_enum)));                                                    \
+					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum)));                                           \
 		}                                                                                                                                        \
 	};
 

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -50,12 +50,12 @@
 #define JOIN_SYMBOLS(p_path, name) ((p_path) + SYMBOL_SEPARATOR + (name))
 #endif
 
-typedef HashMap<String, const lsp::DocumentSymbol *> ClassMembers;
+typedef HashMap<String, const LSP::DocumentSymbol *> ClassMembers;
 
 /**
- * Represents a Position as used by GDScript Parser. Used for conversion to and from `lsp::Position`.
+ * Represents a Position as used by GDScript Parser. Used for conversion to and from `LSP::Position`.
  *
- * Difference to `lsp::Position`:
+ * Difference to `LSP::Position`:
  * * Line & Char/column: 1-based
  * 		* LSP: both 0-based
  * * Tabs are expanded to columns using tab size (`text_editor/behavior/indent/size`).
@@ -79,8 +79,8 @@ struct GodotPosition {
 	GodotPosition(int p_line, int p_column) :
 			line(p_line), column(p_column) {}
 
-	lsp::Position to_lsp(const Vector<String> &p_lines) const;
-	static GodotPosition from_lsp(const lsp::Position p_pos, const Vector<String> &p_lines);
+	LSP::Position to_lsp(const Vector<String> &p_lines) const;
+	static GodotPosition from_lsp(const LSP::Position p_pos, const Vector<String> &p_lines);
 
 	bool operator==(const GodotPosition &p_other) const {
 		return line == p_other.line && column == p_other.column;
@@ -98,8 +98,8 @@ struct GodotRange {
 	GodotRange(GodotPosition p_start, GodotPosition p_end) :
 			start(p_start), end(p_end) {}
 
-	lsp::Range to_lsp(const Vector<String> &p_lines) const;
-	static GodotRange from_lsp(const lsp::Range &p_range, const Vector<String> &p_lines);
+	LSP::Range to_lsp(const Vector<String> &p_lines) const;
+	static GodotRange from_lsp(const LSP::Range &p_range, const Vector<String> &p_lines);
 
 	bool operator==(const GodotRange &p_other) const {
 		return start == p_other.start && end == p_other.end;
@@ -114,41 +114,41 @@ class ExtendGDScriptParser : public GDScriptParser {
 	String path;
 	Vector<String> lines;
 
-	lsp::DocumentSymbol class_symbol;
-	Vector<lsp::Diagnostic> diagnostics;
-	List<lsp::DocumentLink> document_links;
+	LSP::DocumentSymbol class_symbol;
+	Vector<LSP::Diagnostic> diagnostics;
+	List<LSP::DocumentLink> document_links;
 	ClassMembers members;
 	HashMap<String, ClassMembers> inner_classes;
 
-	lsp::Range range_of_node(const GDScriptParser::Node *p_node) const;
+	LSP::Range range_of_node(const GDScriptParser::Node *p_node) const;
 
 	void update_diagnostics();
 
 	void update_symbols();
 	void update_document_links(const String &p_code);
-	void parse_class_symbol(const GDScriptParser::ClassNode *p_class, lsp::DocumentSymbol &r_symbol);
-	void parse_function_symbol(const GDScriptParser::FunctionNode *p_func, lsp::DocumentSymbol &r_symbol);
+	void parse_class_symbol(const GDScriptParser::ClassNode *p_class, LSP::DocumentSymbol &r_symbol);
+	void parse_function_symbol(const GDScriptParser::FunctionNode *p_func, LSP::DocumentSymbol &r_symbol);
 
 	Dictionary dump_function_api(const GDScriptParser::FunctionNode *p_func) const;
 	Dictionary dump_class_api(const GDScriptParser::ClassNode *p_class) const;
 
-	const lsp::DocumentSymbol *search_symbol_defined_at_line(int p_line, const lsp::DocumentSymbol &p_parent, const String &p_symbol_name = "") const;
+	const LSP::DocumentSymbol *search_symbol_defined_at_line(int p_line, const LSP::DocumentSymbol &p_parent, const String &p_symbol_name = "") const;
 
 	Array member_completions;
 
 public:
 	_FORCE_INLINE_ const String &get_path() const { return path; }
 	_FORCE_INLINE_ const Vector<String> &get_lines() const { return lines; }
-	_FORCE_INLINE_ const lsp::DocumentSymbol &get_symbols() const { return class_symbol; }
-	_FORCE_INLINE_ const Vector<lsp::Diagnostic> &get_diagnostics() const { return diagnostics; }
+	_FORCE_INLINE_ const LSP::DocumentSymbol &get_symbols() const { return class_symbol; }
+	_FORCE_INLINE_ const Vector<LSP::Diagnostic> &get_diagnostics() const { return diagnostics; }
 	_FORCE_INLINE_ const ClassMembers &get_members() const { return members; }
 	_FORCE_INLINE_ const HashMap<String, ClassMembers> &get_inner_classes() const { return inner_classes; }
 
-	Error get_left_function_call(const lsp::Position &p_position, lsp::Position &r_func_pos, int &r_arg_index) const;
+	Error get_left_function_call(const LSP::Position &p_position, LSP::Position &r_func_pos, int &r_arg_index) const;
 
-	String get_text_for_completion(const lsp::Position &p_cursor) const;
-	String get_text_for_lookup_symbol(const lsp::Position &p_cursor, const String &p_symbol = "", bool p_func_required = false) const;
-	String get_identifier_under_position(const lsp::Position &p_position, lsp::Range &r_range) const;
+	String get_text_for_completion(const LSP::Position &p_cursor) const;
+	String get_text_for_lookup_symbol(const LSP::Position &p_cursor, const String &p_symbol = "", bool p_func_required = false) const;
+	String get_identifier_under_position(const LSP::Position &p_position, LSP::Range &r_range) const;
 	String get_uri() const;
 
 	/**
@@ -159,9 +159,9 @@ public:
 	 * -> Without `p_symbol_name`: returns `handle_arg`. Even if parameter (`arg`) is wanted.
 	 *    With `p_symbol_name`: symbol name MUST match `p_symbol_name`: returns `arg`.
 	 */
-	const lsp::DocumentSymbol *get_symbol_defined_at_line(int p_line, const String &p_symbol_name = "") const;
-	const lsp::DocumentSymbol *get_member_symbol(const String &p_name, const String &p_subclass = "") const;
-	const List<lsp::DocumentLink> &get_document_links() const;
+	const LSP::DocumentSymbol *get_symbol_defined_at_line(int p_line, const String &p_symbol_name = "") const;
+	const LSP::DocumentSymbol *get_member_symbol(const String &p_name, const String &p_subclass = "") const;
+	const List<LSP::DocumentLink> &get_document_links() const;
 
 	const Array &get_member_completions();
 	Dictionary generate_api() const;

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -171,7 +171,7 @@ void GDScriptLanguageProtocol::_bind_methods() {
 }
 
 Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
-	lsp::InitializeResult ret;
+	LSP::InitializeResult ret;
 
 	String root_uri = p_params["rootUri"];
 	String root = p_params["rootPath"];
@@ -213,11 +213,11 @@ Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 }
 
 void GDScriptLanguageProtocol::initialized(const Variant &p_params) {
-	lsp::GodotCapabilities capabilities;
+	LSP::GodotCapabilities capabilities;
 
 	DocTools *doc = EditorHelp::get_doc_data();
 	for (const KeyValue<String, DocData::ClassDoc> &E : doc->class_list) {
-		lsp::GodotNativeClassInfo gdclass;
+		LSP::GodotNativeClassInfo gdclass;
 		gdclass.name = E.value.name;
 		gdclass.class_doc = &(E.value);
 		if (ClassDB::ClassInfo *ptr = ClassDB::classes.getptr(StringName(E.value.name))) {

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -57,9 +57,9 @@ protected:
 	Array native_member_completions;
 
 private:
-	Array find_symbols(const lsp::TextDocumentPositionParams &p_location, List<const lsp::DocumentSymbol *> &r_list);
-	lsp::TextDocumentItem load_document_item(const Variant &p_param);
-	void notify_client_show_symbol(const lsp::DocumentSymbol *symbol);
+	Array find_symbols(const LSP::TextDocumentPositionParams &p_location, List<const LSP::DocumentSymbol *> &r_list);
+	LSP::TextDocumentItem load_document_item(const Variant &p_param);
+	void notify_client_show_symbol(const LSP::DocumentSymbol *symbol);
 
 public:
 	Variant nativeSymbol(const Dictionary &p_params);

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -48,12 +48,12 @@ protected:
 	static void _bind_methods();
 	void remove_cache_parser(const String &p_path);
 	bool initialized = false;
-	HashMap<StringName, lsp::DocumentSymbol> native_symbols;
+	HashMap<StringName, LSP::DocumentSymbol> native_symbols;
 
-	const lsp::DocumentSymbol *get_native_symbol(const String &p_class, const String &p_member = "") const;
-	const lsp::DocumentSymbol *get_script_symbol(const String &p_path) const;
-	const lsp::DocumentSymbol *get_parameter_symbol(const lsp::DocumentSymbol *p_parent, const String &symbol_identifier);
-	const lsp::DocumentSymbol *get_local_symbol_at(const ExtendGDScriptParser *p_parser, const String &p_symbol_identifier, const lsp::Position p_position);
+	const LSP::DocumentSymbol *get_native_symbol(const String &p_class, const String &p_member = "") const;
+	const LSP::DocumentSymbol *get_script_symbol(const String &p_path) const;
+	const LSP::DocumentSymbol *get_parameter_symbol(const LSP::DocumentSymbol *p_parent, const String &symbol_identifier);
+	const LSP::DocumentSymbol *get_local_symbol_at(const ExtendGDScriptParser *p_parser, const String &p_symbol_identifier, const LSP::Position p_position);
 
 	void reload_all_workspace_scripts();
 
@@ -82,19 +82,19 @@ public:
 	String get_file_uri(const String &p_path) const;
 
 	void publish_diagnostics(const String &p_path);
-	void completion(const lsp::CompletionParams &p_params, List<ScriptLanguage::CodeCompletionOption> *r_options);
+	void completion(const LSP::CompletionParams &p_params, List<ScriptLanguage::CodeCompletionOption> *r_options);
 
-	const lsp::DocumentSymbol *resolve_symbol(const lsp::TextDocumentPositionParams &p_doc_pos, const String &p_symbol_name = "", bool p_func_required = false);
-	void resolve_related_symbols(const lsp::TextDocumentPositionParams &p_doc_pos, List<const lsp::DocumentSymbol *> &r_list);
-	const lsp::DocumentSymbol *resolve_native_symbol(const lsp::NativeSymbolInspectParams &p_params);
-	void resolve_document_links(const String &p_uri, List<lsp::DocumentLink> &r_list);
+	const LSP::DocumentSymbol *resolve_symbol(const LSP::TextDocumentPositionParams &p_doc_pos, const String &p_symbol_name = "", bool p_func_required = false);
+	void resolve_related_symbols(const LSP::TextDocumentPositionParams &p_doc_pos, List<const LSP::DocumentSymbol *> &r_list);
+	const LSP::DocumentSymbol *resolve_native_symbol(const LSP::NativeSymbolInspectParams &p_params);
+	void resolve_document_links(const String &p_uri, List<LSP::DocumentLink> &r_list);
 	Dictionary generate_script_api(const String &p_path);
-	Error resolve_signature(const lsp::TextDocumentPositionParams &p_doc_pos, lsp::SignatureHelp &r_signature);
+	Error resolve_signature(const LSP::TextDocumentPositionParams &p_doc_pos, LSP::SignatureHelp &r_signature);
 	void did_delete_files(const Dictionary &p_params);
-	Dictionary rename(const lsp::TextDocumentPositionParams &p_doc_pos, const String &new_name);
-	bool can_rename(const lsp::TextDocumentPositionParams &p_doc_pos, lsp::DocumentSymbol &r_symbol, lsp::Range &r_range);
-	Vector<lsp::Location> find_usages_in_file(const lsp::DocumentSymbol &p_symbol, const String &p_file_path);
-	Vector<lsp::Location> find_all_usages(const lsp::DocumentSymbol &p_symbol);
+	Dictionary rename(const LSP::TextDocumentPositionParams &p_doc_pos, const String &new_name);
+	bool can_rename(const LSP::TextDocumentPositionParams &p_doc_pos, LSP::DocumentSymbol &r_symbol, LSP::Range &r_range);
+	Vector<LSP::Location> find_usages_in_file(const LSP::DocumentSymbol &p_symbol, const String &p_file_path);
+	Vector<LSP::Location> find_all_usages(const LSP::DocumentSymbol &p_symbol);
 
 	GDScriptWorkspace();
 	~GDScriptWorkspace();

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -34,7 +34,7 @@
 #include "core/object/class_db.h"
 #include "core/templates/list.h"
 
-namespace lsp {
+namespace LSP {
 
 typedef String DocumentUri;
 
@@ -383,7 +383,7 @@ struct Command {
 };
 
 // Use namespace instead of enumeration to follow the LSP specifications.
-// `lsp::EnumName::EnumValue` is OK but `lsp::EnumValue` is not.
+// `LSP::EnumName::EnumValue` is OK but `LSP::EnumValue` is not.
 
 namespace TextDocumentSyncKind {
 /**
@@ -860,7 +860,7 @@ struct MarkupContent {
 };
 
 // Use namespace instead of enumeration to follow the LSP specifications
-// `lsp::EnumName::EnumValue` is OK but `lsp::EnumValue` is not.
+// `LSP::EnumName::EnumValue` is OK but `LSP::EnumValue` is not.
 // And here C++ compilers are unhappy with our enumeration name like `Color`, `File`, `RefCounted` etc.
 /**
  * The kind of a completion entry.
@@ -1117,7 +1117,7 @@ struct CompletionList {
 };
 
 // Use namespace instead of enumeration to follow the LSP specifications
-// `lsp::EnumName::EnumValue` is OK but `lsp::EnumValue` is not
+// `LSP::EnumName::EnumValue` is OK but `LSP::EnumValue` is not
 // And here C++ compilers are unhappy with our enumeration name like `String`, `Array`, `Object` etc
 /**
  * A symbol kind.
@@ -1258,7 +1258,7 @@ struct DocumentSymbol {
 	}
 
 	_FORCE_INLINE_ CompletionItem make_completion_item(bool resolved = false) const {
-		lsp::CompletionItem item;
+		LSP::CompletionItem item;
 		item.label = name;
 
 		if (resolved) {
@@ -1266,33 +1266,33 @@ struct DocumentSymbol {
 		}
 
 		switch (kind) {
-			case lsp::SymbolKind::Enum:
-				item.kind = lsp::CompletionItemKind::Enum;
+			case LSP::SymbolKind::Enum:
+				item.kind = LSP::CompletionItemKind::Enum;
 				break;
-			case lsp::SymbolKind::Class:
-				item.kind = lsp::CompletionItemKind::Class;
+			case LSP::SymbolKind::Class:
+				item.kind = LSP::CompletionItemKind::Class;
 				break;
-			case lsp::SymbolKind::Property:
-				item.kind = lsp::CompletionItemKind::Property;
+			case LSP::SymbolKind::Property:
+				item.kind = LSP::CompletionItemKind::Property;
 				break;
-			case lsp::SymbolKind::Method:
-			case lsp::SymbolKind::Function:
-				item.kind = lsp::CompletionItemKind::Method;
+			case LSP::SymbolKind::Method:
+			case LSP::SymbolKind::Function:
+				item.kind = LSP::CompletionItemKind::Method;
 				break;
-			case lsp::SymbolKind::Event:
-				item.kind = lsp::CompletionItemKind::Event;
+			case LSP::SymbolKind::Event:
+				item.kind = LSP::CompletionItemKind::Event;
 				break;
-			case lsp::SymbolKind::Constant:
-				item.kind = lsp::CompletionItemKind::Constant;
+			case LSP::SymbolKind::Constant:
+				item.kind = LSP::CompletionItemKind::Constant;
 				break;
-			case lsp::SymbolKind::Variable:
-				item.kind = lsp::CompletionItemKind::Variable;
+			case LSP::SymbolKind::Variable:
+				item.kind = LSP::CompletionItemKind::Variable;
 				break;
-			case lsp::SymbolKind::File:
-				item.kind = lsp::CompletionItemKind::File;
+			case LSP::SymbolKind::File:
+				item.kind = LSP::CompletionItemKind::File;
 				break;
 			default:
-				item.kind = lsp::CompletionItemKind::Text;
+				item.kind = LSP::CompletionItemKind::Text;
 				break;
 		}
 
@@ -1952,4 +1952,4 @@ static String marked_documentation(const String &p_bbcode) {
 	}
 	return markdown;
 }
-} // namespace lsp
+} // namespace LSP

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -55,15 +55,15 @@
 #include "thirdparty/doctest/doctest.h"
 
 template <>
-struct doctest::StringMaker<lsp::Position> {
-	static doctest::String convert(const lsp::Position &p_val) {
+struct doctest::StringMaker<LSP::Position> {
+	static doctest::String convert(const LSP::Position &p_val) {
 		return p_val.to_string().utf8().get_data();
 	}
 };
 
 template <>
-struct doctest::StringMaker<lsp::Range> {
-	static doctest::String convert(const lsp::Range &p_val) {
+struct doctest::StringMaker<LSP::Range> {
+	static doctest::String convert(const LSP::Range &p_val) {
 		return p_val.to_string().utf8().get_data();
 	}
 };
@@ -105,32 +105,32 @@ GDScriptLanguageProtocol *initialize(const String &p_root) {
 	return proto;
 }
 
-lsp::Position pos(const int p_line, const int p_character) {
-	lsp::Position p;
+LSP::Position pos(const int p_line, const int p_character) {
+	LSP::Position p;
 	p.line = p_line;
 	p.character = p_character;
 	return p;
 }
 
-lsp::Range range(const lsp::Position p_start, const lsp::Position p_end) {
-	lsp::Range r;
+LSP::Range range(const LSP::Position p_start, const LSP::Position p_end) {
+	LSP::Range r;
 	r.start = p_start;
 	r.end = p_end;
 	return r;
 }
 
-lsp::TextDocumentPositionParams pos_in(const lsp::DocumentUri &p_uri, const lsp::Position p_pos) {
-	lsp::TextDocumentPositionParams params;
+LSP::TextDocumentPositionParams pos_in(const LSP::DocumentUri &p_uri, const LSP::Position p_pos) {
+	LSP::TextDocumentPositionParams params;
 	params.textDocument.uri = p_uri;
 	params.position = p_pos;
 	return params;
 }
 
-const lsp::DocumentSymbol *test_resolve_symbol_at(const String &p_uri, const lsp::Position p_pos, const String &p_expected_uri, const String &p_expected_name, const lsp::Range &p_expected_range) {
+const LSP::DocumentSymbol *test_resolve_symbol_at(const String &p_uri, const LSP::Position p_pos, const String &p_expected_uri, const String &p_expected_name, const LSP::Range &p_expected_range) {
 	Ref<GDScriptWorkspace> workspace = GDScriptLanguageProtocol::get_singleton()->get_workspace();
 
-	lsp::TextDocumentPositionParams params = pos_in(p_uri, p_pos);
-	const lsp::DocumentSymbol *symbol = workspace->resolve_symbol(params);
+	LSP::TextDocumentPositionParams params = pos_in(p_uri, p_pos);
+	const LSP::DocumentSymbol *symbol = workspace->resolve_symbol(params);
 	CHECK(symbol);
 
 	if (symbol) {
@@ -143,7 +143,7 @@ const lsp::DocumentSymbol *test_resolve_symbol_at(const String &p_uri, const lsp
 }
 
 struct InlineTestData {
-	lsp::Range range;
+	LSP::Range range;
 	String text;
 	String name;
 	String ref;
@@ -260,7 +260,7 @@ void test_resolve_symbol(const String &p_uri, const InlineTestData &p_test_data,
 		REQUIRE_MESSAGE(target, vformat("No target for ref '%s'", p_test_data.ref));
 
 		Ref<GDScriptWorkspace> workspace = GDScriptLanguageProtocol::get_singleton()->get_workspace();
-		lsp::Position pos = p_test_data.range.start;
+		LSP::Position pos = p_test_data.range.start;
 
 		SUBCASE("start of identifier") {
 			pos.character = p_test_data.range.start.character;
@@ -311,17 +311,17 @@ void assert_no_errors_in(const String &p_path) {
 	REQUIRE_MESSAGE(err == OK, vformat("Errors while analyzing '%s'", p_path));
 }
 
-inline lsp::Position lsp_pos(int line, int character) {
-	lsp::Position p;
+inline LSP::Position lsp_pos(int line, int character) {
+	LSP::Position p;
 	p.line = line;
 	p.character = character;
 	return p;
 }
 
-void test_position_roundtrip(lsp::Position p_lsp, GodotPosition p_gd, const PackedStringArray &p_lines) {
+void test_position_roundtrip(LSP::Position p_lsp, GodotPosition p_gd, const PackedStringArray &p_lines) {
 	GodotPosition actual_gd = GodotPosition::from_lsp(p_lsp, p_lines);
 	CHECK_EQ(p_gd, actual_gd);
-	lsp::Position actual_lsp = p_gd.to_lsp(p_lines);
+	LSP::Position actual_lsp = p_gd.to_lsp(p_lines);
 	CHECK_EQ(p_lsp, actual_lsp);
 }
 
@@ -346,25 +346,25 @@ func f():
 		PackedStringArray lines = code.split("\n");
 
 		SUBCASE("line after end") {
-			lsp::Position lsp = lsp_pos(7, 0);
+			LSP::Position lsp = lsp_pos(7, 0);
 			GodotPosition gd(8, 1);
 			test_position_roundtrip(lsp, gd, lines);
 		}
 		SUBCASE("first char in first line") {
-			lsp::Position lsp = lsp_pos(0, 0);
+			LSP::Position lsp = lsp_pos(0, 0);
 			GodotPosition gd(1, 1);
 			test_position_roundtrip(lsp, gd, lines);
 		}
 
 		SUBCASE("with tabs") {
 			// On `v` in `value` in `var value := ...`.
-			lsp::Position lsp = lsp_pos(5, 6);
+			LSP::Position lsp = lsp_pos(5, 6);
 			GodotPosition gd(6, 13);
 			test_position_roundtrip(lsp, gd, lines);
 		}
 
 		SUBCASE("doesn't fail with column outside of character length") {
-			lsp::Position lsp = lsp_pos(2, 100);
+			LSP::Position lsp = lsp_pos(2, 100);
 			GodotPosition::from_lsp(lsp, lines);
 
 			GodotPosition gd(3, 100);
@@ -372,7 +372,7 @@ func f():
 		}
 
 		SUBCASE("doesn't fail with line outside of line length") {
-			lsp::Position lsp = lsp_pos(200, 100);
+			LSP::Position lsp = lsp_pos(200, 100);
 			GodotPosition::from_lsp(lsp, lines);
 
 			GodotPosition gd(300, 100);
@@ -381,26 +381,26 @@ func f():
 
 		SUBCASE("special case: zero column for root class") {
 			GodotPosition gd(1, 0);
-			lsp::Position expected = lsp_pos(0, 0);
-			lsp::Position actual = gd.to_lsp(lines);
+			LSP::Position expected = lsp_pos(0, 0);
+			LSP::Position actual = gd.to_lsp(lines);
 			CHECK_EQ(actual, expected);
 		}
 		SUBCASE("special case: zero line and column for root class") {
 			GodotPosition gd(0, 0);
-			lsp::Position expected = lsp_pos(0, 0);
-			lsp::Position actual = gd.to_lsp(lines);
+			LSP::Position expected = lsp_pos(0, 0);
+			LSP::Position actual = gd.to_lsp(lines);
 			CHECK_EQ(actual, expected);
 		}
 		SUBCASE("special case: negative line for root class") {
 			GodotPosition gd(-1, 0);
-			lsp::Position expected = lsp_pos(0, 0);
-			lsp::Position actual = gd.to_lsp(lines);
+			LSP::Position expected = lsp_pos(0, 0);
+			LSP::Position actual = gd.to_lsp(lines);
 			CHECK_EQ(actual, expected);
 		}
 		SUBCASE("special case: lines.length() + 1 for root class") {
 			GodotPosition gd(lines.size() + 1, 0);
-			lsp::Position expected = lsp_pos(lines.size(), 0);
-			lsp::Position actual = gd.to_lsp(lines);
+			LSP::Position expected = lsp_pos(lines.size(), 0);
+			LSP::Position actual = gd.to_lsp(lines);
 			CHECK_EQ(actual, expected);
 		}
 	}
@@ -502,7 +502,7 @@ func f():
 				GDScriptLanguageProtocol::get_singleton()->get_workspace()->parse_local_script(path);
 				ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_workspace()->parse_results[path];
 				REQUIRE(parser);
-				lsp::DocumentSymbol cls = parser->get_symbols();
+				LSP::DocumentSymbol cls = parser->get_symbols();
 
 				REQUIRE(((cls.range.start.line == cls.selectionRange.start.line && cls.range.start.character <= cls.selectionRange.start.character) || (cls.range.start.line < cls.selectionRange.start.line)));
 				REQUIRE(((cls.range.end.line == cls.selectionRange.end.line && cls.range.end.character >= cls.selectionRange.end.character) || (cls.range.end.line > cls.selectionRange.end.line)));

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -613,7 +613,7 @@ bool CSharpLanguage::is_assembly_reloading_needed() {
 			return false; // Already up to date
 		}
 	} else {
-		String assembly_name = path::get_csharp_project_name();
+		String assembly_name = Path::get_csharp_project_name();
 
 		assembly_path = GodotSharpDirs::get_res_temp_assemblies_dir()
 								.path_join(assembly_name + ".dll");

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1740,8 +1740,8 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 	da->make_dir("Generated");
 	da->make_dir("Generated/GodotObjects");
 
-	String base_gen_dir = path::join(p_proj_dir, "Generated");
-	String godot_objects_gen_dir = path::join(base_gen_dir, "GodotObjects");
+	String base_gen_dir = Path::join(p_proj_dir, "Generated");
+	String godot_objects_gen_dir = Path::join(base_gen_dir, "GodotObjects");
 
 	Vector<String> compile_items;
 
@@ -1749,7 +1749,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 	{
 		StringBuilder constants_source;
 		_generate_global_constants(constants_source);
-		String output_file = path::join(base_gen_dir, BINDINGS_GLOBAL_SCOPE_CLASS "_constants.cs");
+		String output_file = Path::join(base_gen_dir, BINDINGS_GLOBAL_SCOPE_CLASS "_constants.cs");
 		Error save_err = _save_file(output_file, constants_source);
 		if (save_err != OK) {
 			return save_err;
@@ -1762,7 +1762,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 	{
 		StringBuilder extensions_source;
 		_generate_array_extensions(extensions_source);
-		String output_file = path::join(base_gen_dir, BINDINGS_GLOBAL_SCOPE_CLASS "_extensions.cs");
+		String output_file = Path::join(base_gen_dir, BINDINGS_GLOBAL_SCOPE_CLASS "_extensions.cs");
 		Error save_err = _save_file(output_file, extensions_source);
 		if (save_err != OK) {
 			return save_err;
@@ -1778,7 +1778,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 			continue;
 		}
 
-		String output_file = path::join(godot_objects_gen_dir, itype.proxy_name + ".cs");
+		String output_file = Path::join(godot_objects_gen_dir, itype.proxy_name + ".cs");
 		Error err = _generate_cs_type(itype, output_file);
 
 		if (err == ERR_SKIP) {
@@ -1845,7 +1845,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 
 		cs_built_in_ctors_content.append(CLOSE_BLOCK);
 
-		String constructors_file = path::join(base_gen_dir, BINDINGS_CLASS_CONSTRUCTOR ".cs");
+		String constructors_file = Path::join(base_gen_dir, BINDINGS_CLASS_CONSTRUCTOR ".cs");
 		Error err = _save_file(constructors_file, cs_built_in_ctors_content);
 
 		if (err != OK) {
@@ -1888,7 +1888,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 
 	cs_icalls_content.append(CLOSE_BLOCK);
 
-	String internal_methods_file = path::join(base_gen_dir, BINDINGS_CLASS_NATIVECALLS ".cs");
+	String internal_methods_file = Path::join(base_gen_dir, BINDINGS_CLASS_NATIVECALLS ".cs");
 
 	Error err = _save_file(internal_methods_file, cs_icalls_content);
 	if (err != OK) {
@@ -1904,14 +1904,14 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 								  "  <ItemGroup>\n");
 
 	for (int i = 0; i < compile_items.size(); i++) {
-		String include = path::relative_to(compile_items[i], p_proj_dir).replace("/", "\\");
+		String include = Path::relative_to(compile_items[i], p_proj_dir).replace("/", "\\");
 		includes_props_content.append("    <Compile Include=\"" + include + "\" />\n");
 	}
 
 	includes_props_content.append("  </ItemGroup>\n"
 								  "</Project>\n");
 
-	String includes_props_file = path::join(base_gen_dir, "GeneratedIncludes.props");
+	String includes_props_file = Path::join(base_gen_dir, "GeneratedIncludes.props");
 
 	err = _save_file(includes_props_file, includes_props_content);
 	if (err != OK) {
@@ -1936,8 +1936,8 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 	da->make_dir("Generated");
 	da->make_dir("Generated/GodotObjects");
 
-	String base_gen_dir = path::join(p_proj_dir, "Generated");
-	String godot_objects_gen_dir = path::join(base_gen_dir, "GodotObjects");
+	String base_gen_dir = Path::join(p_proj_dir, "Generated");
+	String godot_objects_gen_dir = Path::join(base_gen_dir, "GodotObjects");
 
 	Vector<String> compile_items;
 
@@ -1948,7 +1948,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 			continue;
 		}
 
-		String output_file = path::join(godot_objects_gen_dir, itype.proxy_name + ".cs");
+		String output_file = Path::join(godot_objects_gen_dir, itype.proxy_name + ".cs");
 		Error err = _generate_cs_type(itype, output_file);
 
 		if (err == ERR_SKIP) {
@@ -2003,7 +2003,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 
 		cs_built_in_ctors_content.append(CLOSE_BLOCK);
 
-		String constructors_file = path::join(base_gen_dir, BINDINGS_CLASS_CONSTRUCTOR_EDITOR ".cs");
+		String constructors_file = Path::join(base_gen_dir, BINDINGS_CLASS_CONSTRUCTOR_EDITOR ".cs");
 		Error err = _save_file(constructors_file, cs_built_in_ctors_content);
 
 		if (err != OK) {
@@ -2048,7 +2048,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 
 	cs_icalls_content.append(CLOSE_BLOCK);
 
-	String internal_methods_file = path::join(base_gen_dir, BINDINGS_CLASS_NATIVECALLS_EDITOR ".cs");
+	String internal_methods_file = Path::join(base_gen_dir, BINDINGS_CLASS_NATIVECALLS_EDITOR ".cs");
 
 	Error err = _save_file(internal_methods_file, cs_icalls_content);
 	if (err != OK) {
@@ -2064,14 +2064,14 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 								  "  <ItemGroup>\n");
 
 	for (int i = 0; i < compile_items.size(); i++) {
-		String include = path::relative_to(compile_items[i], p_proj_dir).replace("/", "\\");
+		String include = Path::relative_to(compile_items[i], p_proj_dir).replace("/", "\\");
 		includes_props_content.append("    <Compile Include=\"" + include + "\" />\n");
 	}
 
 	includes_props_content.append("  </ItemGroup>\n"
 								  "</Project>\n");
 
-	String includes_props_file = path::join(base_gen_dir, "GeneratedIncludes.props");
+	String includes_props_file = Path::join(base_gen_dir, "GeneratedIncludes.props");
 
 	err = _save_file(includes_props_file, includes_props_content);
 	if (err != OK) {
@@ -2084,7 +2084,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 Error BindingsGenerator::generate_cs_api(const String &p_output_dir) {
 	ERR_FAIL_COND_V(!initialized, ERR_UNCONFIGURED);
 
-	String output_dir = path::abspath(path::realpath(p_output_dir));
+	String output_dir = Path::abspath(Path::realpath(p_output_dir));
 
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	ERR_FAIL_COND_V(da.is_null(), ERR_CANT_CREATE);

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -76,7 +76,7 @@ void godot_icall_GodotSharpDirs_DataEditorToolsDir(godot_string *r_dest) {
 }
 
 void godot_icall_GodotSharpDirs_CSharpProjectName(godot_string *r_dest) {
-	memnew_placement(r_dest, String(path::get_csharp_project_name()));
+	memnew_placement(r_dest, String(Path::get_csharp_project_name()));
 }
 
 void godot_icall_EditorProgress_Create(const godot_string *p_task, const godot_string *p_label, int32_t p_amount, bool p_can_cancel) {
@@ -144,7 +144,7 @@ bool godot_icall_Internal_IsAssembliesReloadingNeeded() {
 
 void godot_icall_Internal_ReloadAssemblies(bool p_soft_reload) {
 #ifdef GD_MONO_HOT_RELOAD
-	callable_mp(mono_bind::GodotSharp::get_singleton(), &mono_bind::GodotSharp::reload_assemblies).call_deferred(p_soft_reload);
+	callable_mp(MonoBind::GodotSharp::get_singleton(), &MonoBind::GodotSharp::reload_assemblies).call_deferred(p_soft_reload);
 #endif
 }
 

--- a/modules/mono/editor/hostfxr_resolver.cpp
+++ b/modules/mono/editor/hostfxr_resolver.cpp
@@ -119,8 +119,8 @@ bool get_latest_fxr(const String &fxr_root, String &r_fxr_path) {
 		return false;
 	}
 
-	String fxr_with_ver = path::join(fxr_root, latest_ver_str);
-	String hostfxr_file_path = path::join(fxr_with_ver, get_hostfxr_file_name());
+	String fxr_with_ver = Path::join(fxr_root, latest_ver_str);
+	String hostfxr_file_path = Path::join(fxr_with_ver, get_hostfxr_file_name());
 
 	ERR_FAIL_COND_V_MSG(!FileAccess::exists(hostfxr_file_path), false, "Missing hostfxr library in directory: " + fxr_with_ver);
 
@@ -188,22 +188,22 @@ bool get_default_installation_dir(String &r_dotnet_root) {
 
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
 	// When emulating x64 on arm
-	String dotnet_root_emulated = path::join(program_files_dir, "dotnet", "x64");
-	if (FileAccess::exists(path::join(dotnet_root_emulated, "dotnet.exe"))) {
+	String dotnet_root_emulated = Path::join(program_files_dir, "dotnet", "x64");
+	if (FileAccess::exists(Path::join(dotnet_root_emulated, "dotnet.exe"))) {
 		r_dotnet_root = dotnet_root_emulated;
 		return true;
 	}
 #endif
 
-	r_dotnet_root = path::join(program_files_dir, "dotnet");
+	r_dotnet_root = Path::join(program_files_dir, "dotnet");
 	return true;
 #elif defined(MACOS_ENABLED)
 	r_dotnet_root = "/usr/local/share/dotnet";
 
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
 	// When emulating x64 on arm
-	String dotnet_root_emulated = path::join(r_dotnet_root, "x64");
-	if (FileAccess::exists(path::join(dotnet_root_emulated, "dotnet"))) {
+	String dotnet_root_emulated = Path::join(r_dotnet_root, "x64");
+	if (FileAccess::exists(Path::join(dotnet_root_emulated, "dotnet"))) {
 		r_dotnet_root = dotnet_root_emulated;
 		return true;
 	}
@@ -266,7 +266,7 @@ bool get_dotnet_self_registered_dir(String &r_dotnet_root) {
 	RegCloseKey(hkey);
 	return true;
 #else
-	String install_location_file = path::join("/etc/dotnet", "install_location_" + get_dotnet_arch().to_lower());
+	String install_location_file = Path::join("/etc/dotnet", "install_location_" + get_dotnet_arch().to_lower());
 	if (get_install_location_from_file(install_location_file, r_dotnet_root)) {
 		return true;
 	}
@@ -276,7 +276,7 @@ bool get_dotnet_self_registered_dir(String &r_dotnet_root) {
 		return false;
 	}
 
-	String legacy_install_location_file = path::join("/etc/dotnet", "install_location");
+	String legacy_install_location_file = Path::join("/etc/dotnet", "install_location");
 	return get_install_location_from_file(legacy_install_location_file, r_dotnet_root);
 #endif
 }
@@ -285,7 +285,7 @@ bool get_file_path_from_env(const String &p_env_key, String &r_dotnet_root) {
 	String env_value = OS::get_singleton()->get_environment(p_env_key);
 
 	if (!env_value.is_empty()) {
-		env_value = path::realpath(env_value);
+		env_value = Path::realpath(env_value);
 
 		if (DirAccess::exists(env_value)) {
 			r_dotnet_root = env_value;
@@ -321,7 +321,7 @@ bool get_dotnet_root_from_env(String &r_dotnet_root) {
 } //namespace
 
 bool godotsharp::hostfxr_resolver::try_get_path_from_dotnet_root(const String &p_dotnet_root, String &r_fxr_path) {
-	String fxr_dir = path::join(p_dotnet_root, "host", "fxr");
+	String fxr_dir = Path::join(p_dotnet_root, "host", "fxr");
 	if (!DirAccess::exists(fxr_dir)) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			ERR_PRINT("The host fxr folder does not exist: " + fxr_dir + ".");

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -167,7 +167,7 @@ private:
 #else // TOOLS_ENABLED
 		String platform = _get_platform_name();
 		String arch = Engine::get_singleton()->get_architecture_name();
-		String appname_safe = path::get_csharp_project_name();
+		String appname_safe = Path::get_csharp_project_name();
 		String packed_path = "res://.godot/mono/publish/" + arch;
 		if (DirAccess::exists(packed_path)) {
 			// The dotnet publish data is packed in the pck/zip.

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -101,11 +101,11 @@ String find_hostfxr() {
 
 	// hostfxr_resolver doesn't look for dotnet in `PATH`. If it fails, we try to find the dotnet
 	// executable in `PATH` here and pass its location as `dotnet_root` to `get_hostfxr_path`.
-	String dotnet_exe = path::find_executable("dotnet");
+	String dotnet_exe = Path::find_executable("dotnet");
 
 	if (!dotnet_exe.is_empty()) {
 		// The file found in PATH may be a symlink
-		dotnet_exe = path::abspath(path::realpath(dotnet_exe));
+		dotnet_exe = Path::abspath(Path::realpath(dotnet_exe));
 
 		// TODO:
 		// Sometimes, the symlink may not point to the dotnet executable in the dotnet root.
@@ -385,7 +385,7 @@ godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime
 godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime_initialized) {
 	godot_plugins_initialize_fn godot_plugins_initialize = nullptr;
 
-	String assembly_name = path::get_csharp_project_name();
+	String assembly_name = Path::get_csharp_project_name();
 
 	HostFxrCharString assembly_path = str_to_hostfxr(GodotSharpDirs::get_api_assemblies_dir()
 					.path_join(assembly_name + ".dll"));
@@ -410,7 +410,7 @@ godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime
 }
 
 godot_plugins_initialize_fn try_load_native_aot_library(void *&r_aot_dll_handle) {
-	String assembly_name = path::get_csharp_project_name();
+	String assembly_name = Path::get_csharp_project_name();
 
 #if defined(WINDOWS_ENABLED)
 	String native_aot_so_path = GodotSharpDirs::get_api_assemblies_dir().path_join(assembly_name + ".dll");
@@ -463,7 +463,7 @@ String make_tpa_list() {
 godot_plugins_initialize_fn initialize_coreclr_and_godot_plugins(bool &r_runtime_initialized) {
 	godot_plugins_initialize_fn godot_plugins_initialize = nullptr;
 
-	String assembly_name = path::get_csharp_project_name();
+	String assembly_name = Path::get_csharp_project_name();
 
 	String tpa_list = make_tpa_list();
 	const char *prop_keys[] = { "TRUSTED_PLATFORM_ASSEMBLIES" };
@@ -627,7 +627,7 @@ void GDMono::_init_godot_api_hashes() {
 
 #ifdef TOOLS_ENABLED
 bool GDMono::_load_project_assembly() {
-	String assembly_name = path::get_csharp_project_name();
+	String assembly_name = Path::get_csharp_project_name();
 
 	String assembly_path = GodotSharpDirs::get_res_temp_assemblies_dir()
 								   .path_join(assembly_name + ".dll");
@@ -658,7 +658,7 @@ void GDMono::reload_failure() {
 
 		ERR_PRINT_ED(".NET: Giving up on assembly reloading. Please restart the editor if unloading was failing.");
 
-		String assembly_name = path::get_csharp_project_name();
+		String assembly_name = Path::get_csharp_project_name();
 		String assembly_path = GodotSharpDirs::get_res_temp_assemblies_dir().path_join(assembly_name + ".dll");
 		assembly_path = ProjectSettings::get_singleton()->globalize_path(assembly_path);
 		project_assembly_path = assembly_path.simplify_path();
@@ -716,7 +716,7 @@ GDMono::~GDMono() {
 	singleton = nullptr;
 }
 
-namespace mono_bind {
+namespace MonoBind {
 
 GodotSharp *GodotSharp::singleton = nullptr;
 
@@ -739,4 +739,4 @@ GodotSharp::~GodotSharp() {
 	singleton = nullptr;
 }
 
-} // namespace mono_bind
+} // namespace MonoBind

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -161,7 +161,7 @@ public:
 	~GDMono();
 };
 
-namespace mono_bind {
+namespace MonoBind {
 
 class GodotSharp : public Object {
 	GDCLASS(GodotSharp, Object);
@@ -178,4 +178,4 @@ public:
 	~GodotSharp();
 };
 
-} // namespace mono_bind
+} // namespace MonoBind

--- a/modules/mono/register_types.cpp
+++ b/modules/mono/register_types.cpp
@@ -38,7 +38,7 @@ CSharpLanguage *script_language_cs = nullptr;
 Ref<ResourceFormatLoaderCSharpScript> resource_loader_cs;
 Ref<ResourceFormatSaverCSharpScript> resource_saver_cs;
 
-mono_bind::GodotSharp *_godotsharp = nullptr;
+MonoBind::GodotSharp *_godotsharp = nullptr;
 
 void initialize_mono_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
@@ -47,7 +47,7 @@ void initialize_mono_module(ModuleInitializationLevel p_level) {
 
 	GDREGISTER_CLASS(CSharpScript);
 
-	_godotsharp = memnew(mono_bind::GodotSharp);
+	_godotsharp = memnew(MonoBind::GodotSharp);
 
 	script_language_cs = memnew(CSharpLanguage);
 	script_language_cs->set_language_index(ScriptServer::get_language_count());

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -49,7 +49,7 @@
 #define ENV_PATH_SEP ":"
 #endif
 
-namespace path {
+namespace Path {
 
 String find_executable(const String &p_name) {
 #ifdef WINDOWS_ENABLED
@@ -62,7 +62,7 @@ String find_executable(const String &p_name) {
 	}
 
 	for (int i = 0; i < env_path.size(); i++) {
-		String p = path::join(env_path[i], p_name);
+		String p = Path::join(env_path[i], p_name);
 
 #ifdef WINDOWS_ENABLED
 		for (int j = 0; j < exts.size(); j++) {
@@ -117,7 +117,7 @@ String abspath(const String &p_path) {
 	if (p_path.is_absolute_path()) {
 		return p_path.simplify_path();
 	} else {
-		return path::join(path::cwd(), p_path).simplify_path();
+		return Path::join(Path::cwd(), p_path).simplify_path();
 	}
 }
 
@@ -186,11 +186,11 @@ String join(const String &p_a, const String &p_b) {
 }
 
 String join(const String &p_a, const String &p_b, const String &p_c) {
-	return path::join(path::join(p_a, p_b), p_c);
+	return Path::join(Path::join(p_a, p_b), p_c);
 }
 
 String join(const String &p_a, const String &p_b, const String &p_c, const String &p_d) {
-	return path::join(path::join(path::join(p_a, p_b), p_c), p_d);
+	return Path::join(Path::join(Path::join(p_a, p_b), p_c), p_d);
 }
 
 String relative_to_impl(const String &p_path, const String &p_relative_to) {
@@ -263,4 +263,4 @@ String get_csharp_project_name() {
 	return name;
 }
 
-} // namespace path
+} // namespace Path

--- a/modules/mono/utils/path_utils.h
+++ b/modules/mono/utils/path_utils.h
@@ -32,7 +32,7 @@
 
 #include "core/string/ustring.h"
 
-namespace path {
+namespace Path {
 
 String find_executable(const String &p_name);
 
@@ -58,4 +58,4 @@ String realpath(const String &p_path);
 String relative_to(const String &p_path, const String &p_relative_to);
 
 String get_csharp_project_name();
-} // namespace path
+} // namespace Path

--- a/modules/navigation/3d/nav_base_iteration_3d.h
+++ b/modules/navigation/3d/nav_base_iteration_3d.h
@@ -44,7 +44,7 @@ struct NavBaseIteration3D {
 	ObjectID owner_object_id;
 	RID owner_rid;
 	bool owner_use_edge_connections = false;
-	LocalVector<nav_3d::Polygon> navmesh_polygons;
+	LocalVector<Nav3D::Polygon> navmesh_polygons;
 
 	bool get_enabled() const { return enabled; }
 	NavigationUtilities::PathSegmentType get_type() const { return owner_type; }
@@ -54,5 +54,5 @@ struct NavBaseIteration3D {
 	real_t get_enter_cost() const { return enter_cost; }
 	real_t get_travel_cost() const { return travel_cost; }
 	bool get_use_edge_connections() const { return owner_use_edge_connections; }
-	const LocalVector<nav_3d::Polygon> &get_navmesh_polygons() const { return navmesh_polygons; }
+	const LocalVector<Nav3D::Polygon> &get_navmesh_polygons() const { return navmesh_polygons; }
 };

--- a/modules/navigation/3d/nav_map_builder_3d.cpp
+++ b/modules/navigation/3d/nav_map_builder_3d.cpp
@@ -38,7 +38,7 @@
 #include "nav_map_iteration_3d.h"
 #include "nav_region_iteration_3d.h"
 
-using namespace nav_3d;
+using namespace Nav3D;
 
 PointKey NavMapBuilder3D::get_point_key(const Vector3 &p_pos, const Vector3 &p_cell_size) {
 	const int x = static_cast<int>(Math::floor(p_pos.x / p_cell_size.x));

--- a/modules/navigation/3d/nav_map_builder_3d.h
+++ b/modules/navigation/3d/nav_map_builder_3d.h
@@ -43,7 +43,7 @@ class NavMapBuilder3D {
 	static void _build_update_map_iteration(NavMapIterationBuild3D &r_build);
 
 public:
-	static nav_3d::PointKey get_point_key(const Vector3 &p_pos, const Vector3 &p_cell_size);
+	static Nav3D::PointKey get_point_key(const Vector3 &p_pos, const Vector3 &p_cell_size);
 
 	static void build_navmap_iteration(NavMapIterationBuild3D &r_build);
 };

--- a/modules/navigation/3d/nav_map_iteration_3d.h
+++ b/modules/navigation/3d/nav_map_iteration_3d.h
@@ -47,12 +47,12 @@ struct NavMapIterationBuild3D {
 	bool use_edge_connections = true;
 	real_t edge_connection_margin;
 	real_t link_connection_radius;
-	nav_3d::PerformanceData performance_data;
+	Nav3D::PerformanceData performance_data;
 	int polygon_count = 0;
 	int free_edge_count = 0;
 
-	HashMap<nav_3d::EdgeKey, nav_3d::EdgeConnectionPair, nav_3d::EdgeKey> iter_connection_pairs_map;
-	LocalVector<nav_3d::Edge::Connection> iter_free_edges;
+	HashMap<Nav3D::EdgeKey, Nav3D::EdgeConnectionPair, Nav3D::EdgeKey> iter_connection_pairs_map;
+	LocalVector<Nav3D::Edge::Connection> iter_free_edges;
 
 	NavMapIteration3D *map_iteration = nullptr;
 
@@ -77,7 +77,7 @@ struct NavMapIteration3D {
 	RWLock rwlock;
 
 	Vector3 map_up;
-	LocalVector<nav_3d::Polygon> link_polygons;
+	LocalVector<Nav3D::Polygon> link_polygons;
 
 	LocalVector<NavRegionIteration3D> region_iterations;
 	LocalVector<NavLinkIteration3D> link_iterations;
@@ -86,7 +86,7 @@ struct NavMapIteration3D {
 	int link_polygon_count = 0;
 
 	// The edge connections that the map builds on top with the edge connection margin.
-	HashMap<uint32_t, LocalVector<nav_3d::Edge::Connection>> external_region_connections;
+	HashMap<uint32_t, LocalVector<Nav3D::Edge::Connection>> external_region_connections;
 
 	HashMap<NavRegion3D *, uint32_t> region_ptr_to_region_id;
 

--- a/modules/navigation/3d/nav_mesh_queries_3d.cpp
+++ b/modules/navigation/3d/nav_mesh_queries_3d.cpp
@@ -39,7 +39,7 @@
 #include "core/math/geometry_3d.h"
 #include "servers/navigation/navigation_utilities.h"
 
-using namespace nav_3d;
+using namespace Nav3D;
 
 #define THREE_POINTS_CROSS_PRODUCT(m_a, m_b, m_c) (((m_c) - (m_a)).cross((m_b) - (m_a)))
 

--- a/modules/navigation/3d/nav_mesh_queries_3d.h
+++ b/modules/navigation/3d/nav_mesh_queries_3d.h
@@ -46,8 +46,8 @@ struct NavMapIteration3D;
 class NavMeshQueries3D {
 public:
 	struct PathQuerySlot {
-		LocalVector<nav_3d::NavigationPoly> path_corridor;
-		Heap<nav_3d::NavigationPoly *, nav_3d::NavPolyTravelCostGreaterThan, nav_3d::NavPolyHeapIndexer> traversable_polys;
+		LocalVector<Nav3D::NavigationPoly> path_corridor;
+		Heap<Nav3D::NavigationPoly *, Nav3D::NavPolyTravelCostGreaterThan, Nav3D::NavPolyHeapIndexer> traversable_polys;
 		bool in_use = false;
 		uint32_t slot_index = 0;
 	};
@@ -78,8 +78,8 @@ public:
 		// Path building.
 		Vector3 begin_position;
 		Vector3 end_position;
-		const nav_3d::Polygon *begin_polygon = nullptr;
-		const nav_3d::Polygon *end_polygon = nullptr;
+		const Nav3D::Polygon *begin_polygon = nullptr;
+		const Nav3D::Polygon *end_polygon = nullptr;
 		uint32_t least_cost_id = 0;
 
 		// Map.
@@ -115,31 +115,31 @@ public:
 
 	static bool emit_callback(const Callable &p_callback);
 
-	static Vector3 polygons_get_random_point(const LocalVector<nav_3d::Polygon> &p_polygons, uint32_t p_navigation_layers, bool p_uniformly);
+	static Vector3 polygons_get_random_point(const LocalVector<Nav3D::Polygon> &p_polygons, uint32_t p_navigation_layers, bool p_uniformly);
 
-	static Vector3 polygons_get_closest_point_to_segment(const LocalVector<nav_3d::Polygon> &p_polygons, const Vector3 &p_from, const Vector3 &p_to, const bool p_use_collision);
-	static Vector3 polygons_get_closest_point(const LocalVector<nav_3d::Polygon> &p_polygons, const Vector3 &p_point);
-	static Vector3 polygons_get_closest_point_normal(const LocalVector<nav_3d::Polygon> &p_polygons, const Vector3 &p_point);
-	static nav_3d::ClosestPointQueryResult polygons_get_closest_point_info(const LocalVector<nav_3d::Polygon> &p_polygons, const Vector3 &p_point);
-	static RID polygons_get_closest_point_owner(const LocalVector<nav_3d::Polygon> &p_polygons, const Vector3 &p_point);
+	static Vector3 polygons_get_closest_point_to_segment(const LocalVector<Nav3D::Polygon> &p_polygons, const Vector3 &p_from, const Vector3 &p_to, const bool p_use_collision);
+	static Vector3 polygons_get_closest_point(const LocalVector<Nav3D::Polygon> &p_polygons, const Vector3 &p_point);
+	static Vector3 polygons_get_closest_point_normal(const LocalVector<Nav3D::Polygon> &p_polygons, const Vector3 &p_point);
+	static Nav3D::ClosestPointQueryResult polygons_get_closest_point_info(const LocalVector<Nav3D::Polygon> &p_polygons, const Vector3 &p_point);
+	static RID polygons_get_closest_point_owner(const LocalVector<Nav3D::Polygon> &p_polygons, const Vector3 &p_point);
 
 	static Vector3 map_iteration_get_closest_point_to_segment(const NavMapIteration3D &p_map_iteration, const Vector3 &p_from, const Vector3 &p_to, const bool p_use_collision);
 	static Vector3 map_iteration_get_closest_point(const NavMapIteration3D &p_map_iteration, const Vector3 &p_point);
 	static Vector3 map_iteration_get_closest_point_normal(const NavMapIteration3D &p_map_iteration, const Vector3 &p_point);
 	static RID map_iteration_get_closest_point_owner(const NavMapIteration3D &p_map_iteration, const Vector3 &p_point);
-	static nav_3d::ClosestPointQueryResult map_iteration_get_closest_point_info(const NavMapIteration3D &p_map_iteration, const Vector3 &p_point);
+	static Nav3D::ClosestPointQueryResult map_iteration_get_closest_point_info(const NavMapIteration3D &p_map_iteration, const Vector3 &p_point);
 	static Vector3 map_iteration_get_random_point(const NavMapIteration3D &p_map_iteration, uint32_t p_navigation_layers, bool p_uniformly);
 
 	static void map_query_path(NavMap3D *map, const Ref<NavigationPathQueryParameters3D> &p_query_parameters, Ref<NavigationPathQueryResult3D> p_query_result, const Callable &p_callback);
 
 	static void query_task_map_iteration_get_path(NavMeshPathQueryTask3D &p_query_task, const NavMapIteration3D &p_map_iteration);
-	static void _query_task_push_back_point_with_metadata(NavMeshPathQueryTask3D &p_query_task, const Vector3 &p_point, const nav_3d::Polygon *p_point_polygon);
+	static void _query_task_push_back_point_with_metadata(NavMeshPathQueryTask3D &p_query_task, const Vector3 &p_point, const Nav3D::Polygon *p_point_polygon);
 	static void _query_task_find_start_end_positions(NavMeshPathQueryTask3D &p_query_task, const NavMapIteration3D &p_map_iteration);
 	static void _query_task_build_path_corridor(NavMeshPathQueryTask3D &p_query_task);
 	static void _query_task_post_process_corridorfunnel(NavMeshPathQueryTask3D &p_query_task);
 	static void _query_task_post_process_edgecentered(NavMeshPathQueryTask3D &p_query_task);
 	static void _query_task_post_process_nopostprocessing(NavMeshPathQueryTask3D &p_query_task);
-	static void _query_task_clip_path(NavMeshPathQueryTask3D &p_query_task, const nav_3d::NavigationPoly *from_poly, const Vector3 &p_to_point, const nav_3d::NavigationPoly *p_to_poly);
+	static void _query_task_clip_path(NavMeshPathQueryTask3D &p_query_task, const Nav3D::NavigationPoly *from_poly, const Vector3 &p_to_point, const Nav3D::NavigationPoly *p_to_poly);
 	static void _query_task_simplified_path_points(NavMeshPathQueryTask3D &p_query_task);
 	static bool _query_task_is_connection_owner_usable(const NavMeshPathQueryTask3D &p_query_task, const NavBaseIteration3D *p_owner);
 

--- a/modules/navigation/nav_map_3d.cpp
+++ b/modules/navigation/nav_map_3d.cpp
@@ -43,7 +43,7 @@
 
 #include <Obstacle2d.h>
 
-using namespace nav_3d;
+using namespace Nav3D;
 
 #ifdef DEBUG_ENABLED
 #define NAVMAP_ITERATION_ZERO_ERROR_MSG() \

--- a/modules/navigation/nav_map_3d.h
+++ b/modules/navigation/nav_map_3d.h
@@ -110,7 +110,7 @@ class NavMap3D : public NavRid3D {
 	bool avoidance_use_high_priority_threads = true;
 
 	// Performance Monitor
-	nav_3d::PerformanceData performance_data;
+	Nav3D::PerformanceData performance_data;
 
 	struct {
 		SelfList<NavRegion3D>::List regions;
@@ -178,7 +178,7 @@ public:
 		return link_connection_radius;
 	}
 
-	nav_3d::PointKey get_point_key(const Vector3 &p_pos) const;
+	Nav3D::PointKey get_point_key(const Vector3 &p_pos) const;
 	const Vector3 &get_merge_rasterizer_cell_size() const;
 
 	void query_path(NavMeshQueries3D::NavMeshPathQueryTask3D &p_query_task);
@@ -186,7 +186,7 @@ public:
 	Vector3 get_closest_point_to_segment(const Vector3 &p_from, const Vector3 &p_to, const bool p_use_collision) const;
 	Vector3 get_closest_point(const Vector3 &p_point) const;
 	Vector3 get_closest_point_normal(const Vector3 &p_point) const;
-	nav_3d::ClosestPointQueryResult get_closest_point_info(const Vector3 &p_point) const;
+	Nav3D::ClosestPointQueryResult get_closest_point_info(const Vector3 &p_point) const;
 	RID get_closest_point_owner(const Vector3 &p_point) const;
 
 	void add_region(NavRegion3D *p_region);

--- a/modules/navigation/nav_region_3d.cpp
+++ b/modules/navigation/nav_region_3d.cpp
@@ -36,7 +36,7 @@
 #include "3d/nav_mesh_queries_3d.h"
 #include "3d/nav_region_iteration_3d.h"
 
-using namespace nav_3d;
+using namespace Nav3D;
 
 void NavRegion3D::set_map(NavMap3D *p_map) {
 	if (map == p_map) {

--- a/modules/navigation/nav_region_3d.h
+++ b/modules/navigation/nav_region_3d.h
@@ -50,7 +50,7 @@ class NavRegion3D : public NavBase3D {
 	bool region_dirty = true;
 	bool polygons_dirty = true;
 
-	LocalVector<nav_3d::Polygon> navmesh_polygons;
+	LocalVector<Nav3D::Polygon> navmesh_polygons;
 
 	real_t surface_area = 0.0;
 	AABB bounds;
@@ -87,12 +87,12 @@ public:
 
 	void set_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh);
 
-	LocalVector<nav_3d::Polygon> const &get_polygons() const {
+	LocalVector<Nav3D::Polygon> const &get_polygons() const {
 		return navmesh_polygons;
 	}
 
 	Vector3 get_closest_point_to_segment(const Vector3 &p_from, const Vector3 &p_to, bool p_use_collision) const;
-	nav_3d::ClosestPointQueryResult get_closest_point_info(const Vector3 &p_point) const;
+	Nav3D::ClosestPointQueryResult get_closest_point_info(const Vector3 &p_point) const;
 	Vector3 get_random_point(uint32_t p_navigation_layers, bool p_uniformly) const;
 
 	real_t get_surface_area() const { return surface_area; }

--- a/modules/navigation/nav_utils_3d.h
+++ b/modules/navigation/nav_utils_3d.h
@@ -38,7 +38,7 @@
 
 struct NavBaseIteration3D;
 
-namespace nav_3d {
+namespace Nav3D {
 struct Polygon;
 
 union PointKey {
@@ -213,4 +213,4 @@ struct PerformanceData {
 	}
 };
 
-} // namespace nav_3d
+} // namespace Nav3D

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2536,7 +2536,7 @@ bool EditorExportPlatformAndroid::has_valid_username_and_password(const Ref<Edit
 
 #ifdef MODULE_MONO_ENABLED
 bool _validate_dotnet_tfm(const String &required_tfm, String &r_error) {
-	String assembly_name = path::get_csharp_project_name();
+	String assembly_name = Path::get_csharp_project_name();
 	String project_path = ProjectSettings::get_singleton()->globalize_path("res://" + assembly_name + ".csproj");
 
 	if (!FileAccess::exists(project_path)) {

--- a/scene/animation/easing_equations.h
+++ b/scene/animation/easing_equations.h
@@ -54,13 +54,13 @@
  * SOFTWARE.
  */
 
-namespace linear {
+namespace Linear {
 static real_t in(real_t t, real_t b, real_t c, real_t d) {
 	return c * t / d + b;
 }
-}; // namespace linear
+}; // namespace Linear
 
-namespace sine {
+namespace Sine {
 static real_t in(real_t t, real_t b, real_t c, real_t d) {
 	return -c * cos(t / d * (Math_PI / 2)) + c + b;
 }
@@ -80,9 +80,9 @@ static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 	real_t h = c / 2;
 	return in(t * 2 - d, b + h, h, d);
 }
-}; // namespace sine
+}; // namespace Sine
 
-namespace quint {
+namespace Quint {
 static real_t in(real_t t, real_t b, real_t c, real_t d) {
 	return c * pow(t / d, 5) + b;
 }
@@ -107,9 +107,9 @@ static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 	real_t h = c / 2;
 	return in(t * 2 - d, b + h, h, d);
 }
-}; // namespace quint
+}; // namespace Quint
 
-namespace quart {
+namespace Quart {
 static real_t in(real_t t, real_t b, real_t c, real_t d) {
 	return c * pow(t / d, 4) + b;
 }
@@ -134,9 +134,9 @@ static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 	real_t h = c / 2;
 	return in(t * 2 - d, b + h, h, d);
 }
-}; // namespace quart
+}; // namespace Quart
 
-namespace quad {
+namespace Quad {
 static real_t in(real_t t, real_t b, real_t c, real_t d) {
 	return c * pow(t / d, 2) + b;
 }
@@ -162,9 +162,9 @@ static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 	real_t h = c / 2;
 	return in(t * 2 - d, b + h, h, d);
 }
-}; // namespace quad
+}; // namespace Quad
 
-namespace expo {
+namespace Expo {
 static real_t in(real_t t, real_t b, real_t c, real_t d) {
 	if (t == 0) {
 		return b;
@@ -203,9 +203,9 @@ static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 	real_t h = c / 2;
 	return in(t * 2 - d, b + h, h, d);
 }
-}; // namespace expo
+}; // namespace Expo
 
-namespace elastic {
+namespace Elastic {
 static real_t in(real_t t, real_t b, real_t c, real_t d) {
 	if (t == 0) {
 		return b;
@@ -271,9 +271,9 @@ static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 	real_t h = c / 2;
 	return in(t * 2 - d, b + h, h, d);
 }
-}; // namespace elastic
+}; // namespace Elastic
 
-namespace cubic {
+namespace Cubic {
 static real_t in(real_t t, real_t b, real_t c, real_t d) {
 	t /= d;
 	return c * t * t * t + b;
@@ -301,9 +301,9 @@ static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 	real_t h = c / 2;
 	return in(t * 2 - d, b + h, h, d);
 }
-}; // namespace cubic
+}; // namespace Cubic
 
-namespace circ {
+namespace Circ {
 static real_t in(real_t t, real_t b, real_t c, real_t d) {
 	t /= d;
 	return -c * (sqrt(1 - t * t) - 1) + b;
@@ -331,9 +331,9 @@ static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 	real_t h = c / 2;
 	return in(t * 2 - d, b + h, h, d);
 }
-}; // namespace circ
+}; // namespace Circ
 
-namespace bounce {
+namespace Bounce {
 static real_t out(real_t t, real_t b, real_t c, real_t d) {
 	t /= d;
 
@@ -374,9 +374,9 @@ static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 	real_t h = c / 2;
 	return in(t * 2 - d, b + h, h, d);
 }
-}; // namespace bounce
+}; // namespace Bounce
 
-namespace back {
+namespace Back {
 static real_t in(real_t t, real_t b, real_t c, real_t d) {
 	float s = 1.70158f;
 	t /= d;
@@ -410,9 +410,9 @@ static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 	real_t h = c / 2;
 	return in(t * 2 - d, b + h, h, d);
 }
-}; // namespace back
+}; // namespace Back
 
-namespace spring {
+namespace Spring {
 static real_t out(real_t t, real_t b, real_t c, real_t d) {
 	t /= d;
 	real_t s = 1.0 - t;
@@ -439,4 +439,4 @@ static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 	real_t h = c / 2;
 	return in(t * 2 - d, b + h, h, d);
 }
-}; // namespace spring
+}; // namespace Spring

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -39,18 +39,18 @@
 	ERR_FAIL_COND_V_MSG(started, nullptr, "Can't append to a Tween that has started. Use stop() first.");
 
 Tween::interpolater Tween::interpolaters[Tween::TRANS_MAX][Tween::EASE_MAX] = {
-	{ &linear::in, &linear::in, &linear::in, &linear::in }, // Linear is the same for each easing.
-	{ &sine::in, &sine::out, &sine::in_out, &sine::out_in },
-	{ &quint::in, &quint::out, &quint::in_out, &quint::out_in },
-	{ &quart::in, &quart::out, &quart::in_out, &quart::out_in },
-	{ &quad::in, &quad::out, &quad::in_out, &quad::out_in },
-	{ &expo::in, &expo::out, &expo::in_out, &expo::out_in },
-	{ &elastic::in, &elastic::out, &elastic::in_out, &elastic::out_in },
-	{ &cubic::in, &cubic::out, &cubic::in_out, &cubic::out_in },
-	{ &circ::in, &circ::out, &circ::in_out, &circ::out_in },
-	{ &bounce::in, &bounce::out, &bounce::in_out, &bounce::out_in },
-	{ &back::in, &back::out, &back::in_out, &back::out_in },
-	{ &spring::in, &spring::out, &spring::in_out, &spring::out_in },
+	{ &Linear::in, &Linear::in, &Linear::in, &Linear::in }, // Linear is the same for each easing.
+	{ &Sine::in, &Sine::out, &Sine::in_out, &Sine::out_in },
+	{ &Quint::in, &Quint::out, &Quint::in_out, &Quint::out_in },
+	{ &Quart::in, &Quart::out, &Quart::in_out, &Quart::out_in },
+	{ &Quad::in, &Quad::out, &Quad::in_out, &Quad::out_in },
+	{ &Expo::in, &Expo::out, &Expo::in_out, &Expo::out_in },
+	{ &Elastic::in, &Elastic::out, &Elastic::in_out, &Elastic::out_in },
+	{ &Cubic::in, &Cubic::out, &Cubic::in_out, &Cubic::out_in },
+	{ &Circ::in, &Circ::out, &Circ::in_out, &Circ::out_in },
+	{ &Bounce::in, &Bounce::out, &Bounce::in_out, &Bounce::out_in },
+	{ &Back::in, &Back::out, &Back::in_out, &Back::out_in },
+	{ &Spring::in, &Spring::out, &Spring::in_out, &Spring::out_in },
 };
 
 void Tweener::set_tween(const Ref<Tween> &p_tween) {


### PR DESCRIPTION
Based off a recent core meeting, this aims to standardize PascalCase as the de-facto namespace casing across the repo. Excludes a handful of driver/module specific instances where it'd be too much of an overhaul/headache to try to change the existing names.