### PR TITLE
De-duplicate `String` single-char constructor

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -347,29 +347,6 @@ void String::parse_utf32(const Span<char32_t> &p_cstr) {
 	*dst = 0;
 }
 
-void String::parse_utf32(const char32_t &p_char) {
-	if (p_char == 0) {
-		print_unicode_error("NUL character", true);
-		return;
-	}
-
-	resize(2);
-
-	char32_t *dst = ptrw();
-
-	if ((p_char & 0xfffff800) == 0xd800) {
-		print_unicode_error(vformat("Unpaired surrogate (%x)", (uint32_t)p_char));
-		dst[0] = _replacement_char;
-	} else if (p_char > 0x10ffff) {
-		print_unicode_error(vformat("Invalid unicode codepoint (%x)", (uint32_t)p_char));
-		dst[0] = _replacement_char;
-	} else {
-		dst[0] = p_char;
-	}
-
-	dst[1] = 0;
-}
-
 // assumes the following have already been validated:
 // p_char != nullptr
 // p_length > 0

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -436,7 +436,7 @@ public:
 	static String num_uint64(uint64_t p_num, int base = 10, bool capitalize_hex = false);
 	static String chr(char32_t p_char) {
 		String string;
-		string.parse_utf32(p_char);
+		string.parse_utf32(Span(&p_char, 1));
 		return string;
 	}
 	static String md5(const uint8_t *p_md5);
@@ -540,7 +540,6 @@ public:
 	static String utf16(const Span<char16_t> &p_range) { return utf16(p_range.ptr(), p_range.size()); }
 
 	void parse_utf32(const Span<char32_t> &p_cstr);
-	void parse_utf32(const char32_t &p_char);
 
 	static uint32_t hash(const char32_t *p_cstr, int p_len); /* hash the string */
 	static uint32_t hash(const char32_t *p_cstr); /* hash the string */


### PR DESCRIPTION
This PR removes an implementation for `String` from a single `char32_t`, in favour of just using the `Span<char32_t>`  based one.

`String::chr` is very fast even when using the `Span` based implementation. I don't think it's worth keeping around an entire separate implementation for a tiny speed benefit (measured below). I don't think this difference is likely to cause a bottleneck. 

This PR includes https://github.com/godotengine/godot/pull/100314 which made the first step in this direction.

## Benchmark

I measured a 3.8% (1 nanosecond per call) performance regression for `String::chr` (comparing to https://github.com/godotengine/godot/pull/100314):
```c++
	auto t0 = std::chrono::high_resolution_clock::now();
	for (int i = 0; i < 50000000; i ++) {
		// Test
		String s1 = String::chr('a');
	}
	auto t1 = std::chrono::high_resolution_clock::now();
	std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
```

This printed
- `1362ms` on the reference (https://github.com/godotengine/godot/pull/100314)
- `1414ms` on this branch

Notably, `master` currently calls a `strlen` based implementation right now, which is likely a bit slower than both of the implementations I tested. So in total, this PR should still speed up `String::chr` by a tiny fraction.

I also measured a somewhat surprising 31kb reduction in the binary size due to the change. No idea where that's coming from; at this point I think the compiler might just be having a giggle or something.

## Caveats

This PR changes behavior when a `\0` character is passed into `String::chr`. Previously, it would return an empty string. Now, it will return a String of length 1, with `0xfffd` as the only symbol (designated replacement char). I think it unlikely anybody is relying on the old behavior, and I think the new behavior is more desirable.