### PR TITLE
Fix debugger's memory leak when project closes itself

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -1034,6 +1034,7 @@ void DebugAdapterProtocol::on_debug_paused() {
 void DebugAdapterProtocol::on_debug_stopped() {
 	notify_exited();
 	notify_terminated();
+	reset_ids();
 }
 
 void DebugAdapterProtocol::on_debug_output(const String &p_message, int p_type) {


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/78526
- Fixes https://github.com/godotengine/godot/issues/104011

The DAP clears variables when we close the project through the editor but not when the project closes itself (windows's close button, `scene_tree.quit()`).
The memory leak probably dates back to 4.0 and was introduced in https://github.com/godotengine/godot/pull/51639.
