### PR TITLE
Set interactive music streams as meta streams

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.h
+++ b/modules/interactive_music/audio_stream_interactive.h
@@ -182,6 +182,8 @@ public:
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
 	virtual String get_stream_name() const override;
 	virtual double get_length() const override { return 0; }
+	virtual bool is_meta_stream() const override { return true; }
+
 	AudioStreamInteractive();
 
 protected:

--- a/modules/interactive_music/audio_stream_playlist.h
+++ b/modules/interactive_music/audio_stream_playlist.h
@@ -69,6 +69,7 @@ public:
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
 	virtual String get_stream_name() const override;
 	virtual double get_length() const override;
+	virtual bool is_meta_stream() const override { return true; }
 
 protected:
 	static void _bind_methods();

--- a/modules/interactive_music/audio_stream_synchronized.h
+++ b/modules/interactive_music/audio_stream_synchronized.h
@@ -65,6 +65,8 @@ public:
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
 	virtual String get_stream_name() const override;
 	virtual double get_length() const override;
+	virtual bool is_meta_stream() const override { return true; }
+
 	AudioStreamSynchronized();
 
 protected:


### PR DESCRIPTION
Interactive music audio streams (`AudioStreamInteractive`, `AudioStreamPlaylist`, and `AudioStreamSynchronized`) were mistakenly not set as "meta streams", which mean streams of streams. This would make Godot throw warnings when trying to play samples using these streams as a base.

Fixes #103612