### PR TITLE
Path3D prefer control points for outward curve

### DIFF
--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -60,6 +60,10 @@ class Path3DGizmo : public EditorNode3DGizmo {
 	mutable float orig_out_length;
 	mutable float disk_size = 0.8;
 
+	// Index that should have swapped control points for achieving an outwards curve.
+	int swapped_control_points_idx = -1;
+	bool control_points_overlapped = false;
+
 	// Cache information of secondary handles.
 	Vector<HandleInfo> _secondary_handles_info;
 


### PR DESCRIPTION
Path3D implementation for https://github.com/godotengine/godot-proposals/issues/11570. I'm not used to 3D yet so not 100% sure if this works in all cases. 

The 2d implementation is here #103956 

*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/11570.