### PR TITLE
Improve default/no query quick open dialog behavior

### DIFF
--- a/editor/gui/editor_quick_open_dialog.h
+++ b/editor/gui/editor_quick_open_dialog.h
@@ -106,7 +106,6 @@ protected:
 	void _notification(int p_what);
 
 private:
-	static constexpr int SHOW_ALL_FILES_THRESHOLD = 30;
 	static constexpr int MAX_HISTORY_SIZE = 20;
 
 	Vector<FuzzySearchResult> search_results;
@@ -116,13 +115,13 @@ private:
 	Vector<QuickOpenResultCandidate> candidates;
 
 	OAHashMap<StringName, Vector<QuickOpenResultCandidate>> selected_history;
+	HashSet<String> history_set;
 
 	String query;
 	int selection_index = -1;
 	int num_visible_results = 0;
 	int max_total_results = 0;
 
-	bool showing_history = false;
 	bool never_opened = true;
 	Ref<ConfigFile> history_file;
 
@@ -148,9 +147,11 @@ private:
 	static QuickOpenDisplayMode get_adaptive_display_mode(const Vector<StringName> &p_base_types);
 
 	void _ensure_result_vector_capacity();
+	void _sort_filepaths(int p_max_results);
 	void _create_initial_results();
 	void _find_filepaths_in_folder(EditorFileSystemDirectory *p_directory, bool p_include_addons);
 
+	Vector<QuickOpenResultCandidate> *_get_history();
 	void _setup_candidate(QuickOpenResultCandidate &p_candidate, const String &p_filepath);
 	void _setup_candidate(QuickOpenResultCandidate &p_candidate, const FuzzySearchResult &p_result);
 	void _update_fuzzy_search_results();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/99672
Close #103558

This change primarily removes `SHOW_ALL_FILES_THRESHOLD` and was motivated by someone thinking quick open had a regression after having saved 31 instances of some resource. The two default/empty query behaviors (show all, show history) are combined such that up to `filesystem/quick_open_dialog/max_results` results are shown, prioritizing items in history and matching the tie-break ordering used by fuzzy search.

Separately, this fixes a minor bug where elements in history try to get a resource preview using their uid string and end up displaying the default icon. The cache file still saves by uid rather than by path.

Performance wise (on a project with ~700 resource files) this adds 1ms to the initialization time for the popup but saves 3ms while updating the results (for both popup and query changes). Both versions have a 360ms first launch time and 100ms display mode switch time; maybe those could be improved in the future.