### PR TITLE
Use `memnew_arr_placement` for `memnew_arr`, to optimize creating types that are zero constructible.

### DIFF
--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -180,34 +180,6 @@ _FORCE_INLINE_ uint64_t *_get_element_count_ptr(uint8_t *p_ptr) {
 	return (uint64_t *)(p_ptr - Memory::DATA_OFFSET + Memory::ELEMENT_OFFSET);
 }
 
-template <typename T>
-T *memnew_arr_template(size_t p_elements) {
-	if (p_elements == 0) {
-		return nullptr;
-	}
-	/** overloading operator new[] cannot be done , because it may not return the real allocated address (it may pad the 'element count' before the actual array). Because of that, it must be done by hand. This is the
-	same strategy used by std::vector, and the Vector class, so it should be safe.*/
-
-	size_t len = sizeof(T) * p_elements;
-	uint8_t *mem = (uint8_t *)Memory::alloc_static(len, true);
-	T *failptr = nullptr; //get rid of a warning
-	ERR_FAIL_NULL_V(mem, failptr);
-
-	uint64_t *_elem_count_ptr = _get_element_count_ptr(mem);
-	*(_elem_count_ptr) = p_elements;
-
-	if constexpr (!std::is_trivially_constructible_v<T>) {
-		T *elems = (T *)mem;
-
-		/* call operator new */
-		for (size_t i = 0; i < p_elements; i++) {
-			::new (&elems[i]) T;
-		}
-	}
-
-	return (T *)mem;
-}
-
 // Fast alternative to a loop constructor pattern.
 template <typename T>
 _FORCE_INLINE_ void memnew_arr_placement(T *p_start, size_t p_num) {
@@ -242,6 +214,33 @@ _FORCE_INLINE_ void destruct_arr_placement(T *p_dst, size_t p_num) {
 			p_dst[i].~T();
 		}
 	}
+}
+
+template <typename T>
+T *memnew_arr_template(size_t p_elements) {
+	if (p_elements == 0) {
+		return nullptr;
+	}
+	/** overloading operator new[] cannot be done , because it may not return the real allocated address (it may pad the 'element count' before the actual array). Because of that, it must be done by hand. This is the
+	same strategy used by std::vector, and the Vector class, so it should be safe.*/
+
+	size_t len = sizeof(T) * p_elements;
+	uint8_t *mem;
+
+	if constexpr (std::is_trivially_constructible_v<T> || !is_zero_constructible_v<T>) {
+		mem = (uint8_t *)Memory::alloc_static(len, true);
+	} else {
+		mem = (uint8_t *)Memory::alloc_static_zeroed(len, true);
+	}
+
+	ERR_FAIL_NULL_V(mem, nullptr);
+	*_get_element_count_ptr(mem) = p_elements;
+
+	if constexpr (!std::is_trivially_constructible_v<T>) {
+		memnew_arr_placement((T *)mem, p_elements);
+	}
+
+	return (T *)mem;
 }
 
 /**

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -685,3 +685,7 @@ public:
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };
+
+// Initializes all pointers to null.
+template <>
+struct is_zero_constructible<GDScriptLanguage::CallLevel> : std::true_type {};


### PR DESCRIPTION
I had to move `memnew_arr_placement` above `memnew_arr_template`, but the implementation hasn't changed.

Also, I looked around a bit for candidates to mark as zero constructible. It seems the optimization won't hit many types right now, because most are either trivially constructible or don't default to 0.

There are a lot of potential candidates in rendering code, but I dared not touch them because marking a type as zero constructible risks bugs if the type changes to non zero constructible (but the mark is not removed alongside).
I did mark `GDScriptLanguage::CallLevel` as zero constructible because I think it may like the performance boost and it's probably safe to do so here.

## Note
This changes behavior to use `memnew_placement` instead of `new` in `memnew_arr_template`. This does the same, except that `memnew_placement` also calls `postinitialize_handler` (if it exists). I think the new behavior is correct (although no types constructed through `memnew_arr` seem to use post init handlers yet anyway).