### PR TITLE
Reduce allocation counts when using the `metal` and in the renderer by using `AHashMap` instead of `HashMap`.

### DIFF
--- a/drivers/metal/metal_objects.h
+++ b/drivers/metal/metal_objects.h
@@ -53,6 +53,7 @@
 #import "metal_device_properties.h"
 #import "metal_utils.h"
 #import "pixel_formats.h"
+#import "core/templates/a_hash_map.h"
 
 #include "servers/rendering/rendering_device_driver.h"
 
@@ -606,7 +607,7 @@ struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) BindingInfo {
 
 using RDC = RenderingDeviceCommons;
 
-typedef API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) HashMap<RDC::ShaderStage, BindingInfo> BindingInfoMap;
+typedef API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) AHashMap<RDC::ShaderStage, BindingInfo> BindingInfoMap;
 
 struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) UniformInfo {
 	uint32_t binding;

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -1177,6 +1177,15 @@ public:
 		}
 	}
 
+	template <typename K, typename V>
+	void write(AHashMap<K, V> const &p_map) {
+		write(p_map.size());
+		for (KeyValue<K, V> const &e : p_map) {
+			write(e.key);
+			write(e.value);
+		}
+	}
+
 	uint64_t get_pos() const {
 		return pos;
 	}
@@ -1336,6 +1345,21 @@ public:
 
 	template <typename K, typename V>
 	void read(HashMap<K, V> &p_map) {
+		uint32_t len;
+		read(len);
+		CHECK(len);
+		p_map.reserve(len);
+		for (uint32_t i = 0; i < len; i++) {
+			K key;
+			read(key);
+			V value;
+			read(value);
+			p_map[key] = value;
+		}
+	}
+
+	template <typename K, typename V>
+	void read(AHashMap<K, V> &p_map) {
 		uint32_t len;
 		read(len);
 		CHECK(len);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -164,7 +164,7 @@ void RenderingDevice::_free_dependencies(RID p_id) {
 
 	// Direct dependencies must be freed.
 
-	HashMap<RID, HashSet<RID>>::Iterator E = dependency_map.find(p_id);
+	AHashMap<RID, HashSet<RID>>::Iterator E = dependency_map.find(p_id);
 	if (E) {
 		while (E->value.size()) {
 			free(*E->value.begin());
@@ -177,7 +177,7 @@ void RenderingDevice::_free_dependencies(RID p_id) {
 
 	if (E) {
 		for (const RID &F : E->value) {
-			HashMap<RID, HashSet<RID>>::Iterator G = dependency_map.find(F);
+			AHashMap<RID, HashSet<RID>>::Iterator G = dependency_map.find(F);
 			ERR_CONTINUE(!G);
 			ERR_CONTINUE(!G->value.has(p_id));
 			G->value.erase(p_id);
@@ -5880,7 +5880,7 @@ bool RenderingDevice::_dependency_make_mutable(RID p_id, RID p_resource_id, RDG:
 
 bool RenderingDevice::_dependencies_make_mutable_recursive(RID p_id, RDG::ResourceTracker *p_resource_tracker) {
 	bool made_mutable = false;
-	HashMap<RID, HashSet<RID>>::Iterator E = dependency_map.find(p_id);
+	AHashMap<RID, HashSet<RID>>::Iterator E = dependency_map.find(p_id);
 	if (E) {
 		for (RID rid : E->value) {
 			made_mutable = _dependency_make_mutable(rid, p_id, p_resource_tracker) || made_mutable;

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/worker_thread_pool.h"
+#include "core/templates/a_hash_map.h"
 #include "core/os/condition_variable.h"
 #include "core/os/thread_safe.h"
 #include "core/templates/local_vector.h"
@@ -121,8 +122,8 @@ public:
 	};
 
 private:
-	HashMap<RID, HashSet<RID>> dependency_map; // IDs to IDs that depend on it.
-	HashMap<RID, HashSet<RID>> reverse_dependency_map; // Same as above, but in reverse.
+	AHashMap<RID, HashSet<RID>> dependency_map; // IDs to IDs that depend on it.
+	AHashMap<RID, HashSet<RID>> reverse_dependency_map; // Same as above, but in reverse.
 
 	void _add_dependency(RID p_id, RID p_depends_on);
 	void _free_dependencies(RID p_id);


### PR DESCRIPTION
I used Apple Instruments to check allocations counts.
I found that almost half of them were caused by `HashMap` use, creating hundreds of thousands of small objects.

This behavior fragments memory, which increases total memory use and burdens the allocator. In addition, it's likely slower than to use contiguous memory (although I have not tested this yet).

## Tests

On `master`, I found the following top entrants in the inverse call tree when sorting by allocation count:
```
 192.85 MB      15.8%	428082	 	Memory::alloc_static(unsigned long, bool)
  39.56 MB       3.2%	336400	 	Memory::alloc_static(unsigned long, bool)
 189.05 MB      15.5%	79635	 	_malloc_type_malloc_outlined
  13.77 MB       1.1%	72825	 	_malloc_type_calloc_outlined
```

On this PR, I found them to have reduced substantially:
```
  70.10 MB      23.5%	206646	 	_malloc_type_malloc_outlined
  66.38 MB      22.2%	176276	 	Memory::alloc_static(unsigned long, bool)
  13.92 MB       4.6%	120385	 	Memory::alloc_static(unsigned long, bool)
   4.72 MB       1.5%	30080	 	_malloc_type_calloc_outlined
```

This comparison is not entirely fair though because I did not systematically test with a launch and `--quit`. Why didn't I do that? See the next section.

## Why is this in Draft Mode?

`AHashMap` destruction seems to be broken right now, compared to `HashMap`. The game works fine, but when quitting, I'm getting tons of 'invalid x destruction' messages. The game then freezes instead of quitting. This should be addressed before we can consider this PR to be mergable (cc @Nazarwadim, perhaps you have an idea what's broken?). When it's fixed, I will systematically test allocations again.
Edit: Possibly, it's because `HashMap` keeps the insertion order but `AHashMap` doesn't? Perhaps I'll just remove the `RenderDevice` change and concentrate on Metal.

Additionally, I'm getting tons of error messages about capacity (#103654, to be fixed by #103698).