### PR TITLE
[DRAFT] Allow android/xr editor to begin gradle builds

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7452,8 +7452,8 @@ EditorNode::EditorNode() {
 	project_menu->add_separator();
 	project_menu->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/export", TTRC("Export..."), Key::NONE, TTRC("Export")), PROJECT_EXPORT);
 	project_menu->add_item(TTR("Pack Project as ZIP..."), PROJECT_PACK_AS_ZIP);
-#ifndef ANDROID_ENABLED
 	project_menu->add_item(TTR("Install Android Build Template..."), PROJECT_INSTALL_ANDROID_SOURCE);
+#ifndef ANDROID_ENABLED
 	project_menu->add_item(TTR("Open User Data Folder"), PROJECT_OPEN_USER_DATA_FOLDER);
 #endif
 

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -51,15 +51,15 @@ void register_android_exporter() {
 	EDITOR_DEF_BASIC("export/android/debug_keystore_pass", DEFAULT_ANDROID_KEYSTORE_DEBUG_PASSWORD);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/debug_keystore_pass", PROPERTY_HINT_PASSWORD));
 
-#ifdef ANDROID_ENABLED
-	EDITOR_DEF_BASIC("export/android/install_exported_apk", !OS::get_singleton()->has_feature("horizonos"));
-#else
 	EDITOR_DEF_BASIC("export/android/java_sdk_path", OS::get_singleton()->get_environment("JAVA_HOME"));
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/java_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
 
 	EDITOR_DEF_BASIC("export/android/android_sdk_path", OS::get_singleton()->has_environment("ANDROID_HOME") ? OS::get_singleton()->get_environment("ANDROID_HOME") : get_default_android_sdk_path());
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/android_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
 
+#ifdef ANDROID_ENABLED
+	EDITOR_DEF_BASIC("export/android/install_exported_apk", !OS::get_singleton()->has_feature("horizonos"));
+#else
 	EDITOR_DEF("export/android/force_system_user", false);
 
 	EDITOR_DEF("export/android/shutdown_adb_on_exit", true);

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -184,6 +184,40 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	static bool _uses_vulkan();
 
+	// Temporary variables for testing.
+	List<String> gradle_build_args;
+	String _build_path;
+	List<String> gradle_copy_args;
+	const String _termux_home = "/data/data/com.termux/files/home";
+	const String _termux_sh = "/data/data/com.termux/files/usr/bin/sh";
+
+	void _termux_verify_openjdk();
+	void _termux_verify_openjdk_callback(int p_error_code, const String &p_stdout, const String &p_stderr);
+
+	void _termux_install_openjdk();
+	void _termux_install_openjdk_callback(int p_error_code, const String &p_stdout, const String &p_stderr);
+
+	void _termux_verify_android_sdk();
+	void _termux_verify_android_sdk_callback(int p_error_code, const String &p_stdout, const String &p_stderr);
+
+	void _termux_install_android_sdk();
+	void _termux_install_android_sdk_callback(int p_error_code, const String &p_stdout, const String &p_stderr);
+
+	void _termux_verify_aapt2();
+	void _termux_verify_aapt2_callback(int p_error_code, const String &p_stdout, const String &p_stderr);
+
+	void _termux_install_aapt2();
+	void _termux_install_aapt2_callback(int p_error_code, const String &p_stdout, const String &p_stderr);
+
+	void _termux_begin_gradle_build();
+	void _termux_begin_gradle_build_callback(int p_error_code, const String &p_stdout, const String &p_stderr);
+
+	void _termux_redo_gradle_build();
+	void _termux_redo_gradle_build_callback(int p_error_code, const String &p_stdout, const String &p_stderr);
+
+	void _termux_gradle_copy_and_rename();
+	void _termux_gradle_copy_and_rename_callback(int p_error_code, const String &p_stdout, const String &p_stderr);
+
 protected:
 	void _notification(int p_what);
 

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -278,6 +278,63 @@ task validateJavaVersion {
     }
 }
 
+task installTermuxDependencies {
+    doLast {
+        def androidHome = "/data/data/com.termux/files/home/android-sdk"
+
+        // Ensure wget and unzip are installed.
+        exec {
+            commandLine "pkg", "install", "wget", "unzip", "-y"
+        }
+
+        // Download the Android SDK command-line tools.
+        exec {
+            commandLine "wget", "https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip", "-O", "cmdline-tools.zip"
+        }
+
+        // Unzip the downloaded tools.
+        exec {
+            commandLine "unzip", "-o", "cmdline-tools.zip", "-d", "${androidHome}"
+        }
+
+        // Match the expected Android cmdline-tools directory structure.
+        exec {
+            commandLine "sh", "-c", "mkdir -p ${androidHome}/cmdline-tools/latest && cd ${androidHome}/cmdline-tools && find . -mindepth 1 -maxdepth 1 ! -name latest -exec mv {} latest/ \\;"
+        }
+
+        // Accept Android licenses.
+        exec {
+            commandLine "sh", "-c", "yes | sh ${androidHome}/cmdline-tools/latest/bin/sdkmanager --sdk_root=${androidHome} --licenses"
+        }
+
+        // Install other Android dependencies.
+        exec {
+            commandLine "sh", "${androidHome}/cmdline-tools/latest/bin/sdkmanager", "--sdk_root=${androidHome}", "platform-tools", "build-tools;34.0.0", "platforms;android-34", "ndk;23.2.8568313"
+        }
+    }
+}
+
+task updateAAPT2Jars {
+    doLast {
+        def aapt2Files = fileTree(System.getProperty('user.home') + '/.gradle')
+            .matching {
+                include '**/aapt2-*-linux.jar'
+            }
+            .files
+
+        if (aapt2Files.isEmpty()) {
+            return
+        }
+
+        aapt2Files.each { file ->
+            def execResult = exec {
+                commandLine 'jar', '-u', '-f', file.absolutePath, '-C', System.getProperty('user.home') + '/../usr/bin', 'aapt2'
+                ignoreExitValue = true
+            }
+        }
+    }
+}
+
 /*
 When they're scheduled to run, the copy*AARToAppModule tasks generate dependencies for the 'app'
 module, so we're ensuring the ':app:preBuild' task is set to run after those tasks.

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto">
 
+    <queries>
+        <package android:name="com.termux" />
+    </queries>
+
     <supports-screens
         android:largeScreens="true"
         android:normalScreens="true"
@@ -26,6 +30,8 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
+    <uses-permission android:name="com.termux.permission.RUN_COMMAND" />
 
     <application
         android:allowBackup="false"
@@ -98,6 +104,7 @@
             android:resizeableActivity="false"
             android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
         </activity>
+        <service android:name=".TermuxResultService" />
     </application>
 
 </manifest>

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/TermuxResultService.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/TermuxResultService.kt
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  Callable.kt                                                           */
+/*  TermuxResultService.kt                                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,67 +28,60 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-package org.godotengine.godot.variant
+package org.godotengine.editor
 
-import androidx.annotation.Keep
+import android.app.IntentService
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import java.util.concurrent.ConcurrentHashMap
+import org.godotengine.godot.variant.Callable
 
-/**
- * Android version of a Godot built-in Callable type representing a method or a standalone function.
- */
-@Keep
-class Callable private constructor(private val nativeCallablePointer: Long) {
+class TermuxResultService : IntentService(PLUGIN_SERVICE_LABEL) {
 
 	companion object {
-		/**
-		 * Invoke method [methodName] on the Godot object specified by [godotObjectId]
-		 */
-		@JvmStatic
-		fun call(godotObjectId: Long, methodName: String, vararg methodParameters: Any): Any? {
-			return nativeCallObject(godotObjectId, methodName, methodParameters)
+		const val EXTRA_EXECUTION_ID = "execution_id"
+		const val PLUGIN_SERVICE_LABEL = "TermuxResultService"
+		private const val LOG_TAG = "TermuxResultService"
+		private var EXECUTION_ID = 1000
+		private val executionMap = ConcurrentHashMap<Int, Callable>()
+
+		@Synchronized
+		fun getNextExecutionId(resultCallback: Callable): Int {
+			val id = EXECUTION_ID++
+			executionMap[id] = resultCallback
+			return id
 		}
-
-		/**
-		 * Invoke method [methodName] on the Godot object specified by [godotObjectId] during idle time.
-		 */
-		@JvmStatic
-		fun callDeferred(godotObjectId: Long, methodName: String, vararg methodParameters: Any) {
-			nativeCallObjectDeferred(godotObjectId, methodName, methodParameters)
-		}
-
-		@JvmStatic
-		private external fun nativeCall(pointer: Long, params: Array<out Any>): Any?
-
-		@JvmStatic
-		private external fun nativeCallObject(godotObjectId: Long, methodName: String, params: Array<out Any>): Any?
-
-		@JvmStatic
-		private external fun nativeCallObjectDeferred(godotObjectId: Long, methodName: String, params: Array<out Any>)
-
-		@JvmStatic
-		private external fun releaseNativePointer(nativePointer: Long)
 	}
 
-	/**
-	 * Calls the method represented by this [Callable]. Arguments can be passed and should match the method's signature.
-	 */
-	fun call(vararg params: Any): Any? {
-		if (nativeCallablePointer == 0L) {
-			return null
+	override fun onHandleIntent(intent: Intent?) {
+		if (intent == null) return
+
+		Log.d(LOG_TAG, "$PLUGIN_SERVICE_LABEL received execution result")
+
+		val resultBundle = intent.getBundleExtra("result")
+		if (resultBundle == null) {
+			Log.e(LOG_TAG, "The intent does not contain the result bundle at the \"result\" key.")
+			return
 		}
 
-		return nativeCall(nativeCallablePointer, params)
-	}
+		val executionId = intent.getIntExtra(EXTRA_EXECUTION_ID, 0)
+		val resultCallback = executionMap.remove(executionId)
 
-	/**
-	 * Used to provide access to the native callable pointer to the native logic.
-	 */
-	private fun getNativePointer() = nativeCallablePointer
+		// @todo This should use constants
+		val exitCode = resultBundle.getInt("exitCode") ?: 127;
+		var stdout = resultBundle.getString("stdout") ?: "";
+		val stderr = resultBundle.getString("stderr") ?: "";
+		val err = resultBundle.getInt("err") ?: 0;
+		val errmsg = resultBundle.getString("errmsg") ?: "";
 
-	/** Note that [finalize] is deprecated and shouldn't be used, unfortunately its replacement,
-	 * [java.lang.ref.Cleaner], is only available on Android api 33 and higher.
-	 * So we resort to using it for the time being until our min api catches up to api 33.
-	 **/
-	protected fun finalize() {
-		releaseNativePointer(nativeCallablePointer)
+		Log.d(LOG_TAG, "Execution id $executionId result:\n" +
+				"errCode: " + exitCode.toString() + "\n" +
+				"stdout:\n" + stdout + "\n" +
+				"stderr:\n" + stderr + "\n" +
+				"err:\n" + err + "\n" +
+				"errmsg:\n" + errmsg + "\n")
+
+		resultCallback?.call(exitCode, stdout, stderr)
 	}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -73,6 +73,7 @@ import org.godotengine.godot.utils.benchmarkFile
 import org.godotengine.godot.utils.dumpBenchmark
 import org.godotengine.godot.utils.endBenchmarkMeasure
 import org.godotengine.godot.utils.useBenchmark
+import org.godotengine.godot.variant.Callable
 import org.godotengine.godot.xr.XRMode
 import java.io.File
 import java.io.FileInputStream
@@ -1194,5 +1195,11 @@ class Godot(private val context: Context) {
 	@Keep
 	private fun nativeOnEditorWorkspaceSelected(workspace: String) {
 		primaryHost?.onEditorWorkspaceSelected(workspace)
+	}
+
+	@Keep
+	private fun nativeTermuxExecute(path: String, arguments: Array<String>, workDir: String, background: Boolean, resultCallback: Callable): Boolean {
+		// @todo I don't know if the indirection to primaryHost makes sense, but everyone else was doing it...
+		return primaryHost?.termuxExecute(path, arguments, workDir, background, resultCallback) ?: false
 	}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
@@ -33,6 +33,7 @@ package org.godotengine.godot;
 import org.godotengine.godot.error.Error;
 import org.godotengine.godot.plugin.GodotPlugin;
 import org.godotengine.godot.utils.BenchmarkUtils;
+import org.godotengine.godot.variant.Callable;
 
 import android.app.Activity;
 import android.app.PendingIntent;
@@ -515,5 +516,13 @@ public class GodotFragment extends Fragment implements IDownloaderClient, GodotH
 		if (parentHost != null) {
 			parentHost.onEditorWorkspaceSelected(workspace);
 		}
+	}
+
+	@Override
+	public boolean termuxExecute(@NonNull String path, @NonNull String[] arguments, @NonNull String workDir, boolean background, Callable resultCallback) {
+		if (parentHost != null) {
+			return parentHost.termuxExecute(path, arguments, workDir, background, resultCallback);
+		}
+		return false;
 	}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotHost.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotHost.java
@@ -32,6 +32,7 @@ package org.godotengine.godot;
 
 import org.godotengine.godot.error.Error;
 import org.godotengine.godot.plugin.GodotPlugin;
+import org.godotengine.godot.variant.Callable;
 
 import android.app.Activity;
 
@@ -150,4 +151,17 @@ public interface GodotHost {
 	 * Invoked on the render thread when an editor workspace has been selected.
 	 */
 	default void onEditorWorkspaceSelected(String workspace) {}
+
+	/**
+	 * Invoked to execute a command via Termux.
+	 *
+	 * @param path Path to the command
+	 * @param arguments The argument for the command
+	 * @param workDir The working directory to use when executing the command
+	 * @param background Whether or not to run in the background
+	 * @return The exit code from the command
+	 */
+	default boolean termuxExecute(@NonNull String path, @NonNull String[] arguments, @NonNull String workDir, boolean background, Callable resultCallback) {
+		return false;
+	}
 }

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -30,6 +30,8 @@
 
 #include "java_godot_wrapper.h"
 
+#include "jni_utils.h"
+
 // JNIEnv is only valid within the thread it belongs to, in a multi threading environment
 // we can't cache it.
 // For Godot we call most access methods from our thread and we thus get a valid JNIEnv
@@ -94,6 +96,7 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_
 	_enable_immersive_mode = p_env->GetMethodID(godot_class, "nativeEnableImmersiveMode", "(Z)V");
 	_is_in_immersive_mode = p_env->GetMethodID(godot_class, "isInImmersiveMode", "()Z");
 	_on_editor_workspace_selected = p_env->GetMethodID(godot_class, "nativeOnEditorWorkspaceSelected", "(Ljava/lang/String;)V");
+	_termux_execute = p_env->GetMethodID(godot_class, "nativeTermuxExecute", "(Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;ZLorg/godotengine/godot/variant/Callable;)Z");
 }
 
 GodotJavaWrapper::~GodotJavaWrapper() {
@@ -598,4 +601,35 @@ void GodotJavaWrapper::on_editor_workspace_selected(const String &p_workspace) {
 		jstring j_workspace = env->NewStringUTF(p_workspace.utf8().get_data());
 		env->CallVoidMethod(godot_instance, _on_editor_workspace_selected, j_workspace);
 	}
+}
+
+bool GodotJavaWrapper::termux_execute(const String &p_path, const List<String> &p_arguments, const String p_work_dir, bool p_background, const Callable &p_result_callback) {
+	if (_termux_execute) {
+		JNIEnv *env = get_jni_env();
+
+		jstring j_path = env->NewStringUTF(p_path.utf8().get_data());
+		jobjectArray j_args = env->NewObjectArray(p_arguments.size(), env->FindClass("java/lang/String"), nullptr);
+		print_line(p_work_dir);
+		print_line(p_path);
+		for (int i = 0; i < p_arguments.size(); i++) {
+			print_line(p_arguments.get(i));
+			jstring j_arg = env->NewStringUTF(p_arguments.get(i).utf8().get_data());
+			env->SetObjectArrayElement(j_args, i, j_arg);
+			env->DeleteLocalRef(j_arg);
+		}
+		jstring j_work_dir = env->NewStringUTF(p_work_dir.utf8().get_data());
+		jboolean j_background = p_background;
+		jobject j_result_callback = callable_to_jcallable(env, p_result_callback);
+
+		jboolean result = env->CallBooleanMethod(godot_instance, _termux_execute, j_path, j_args, j_work_dir, j_background, j_result_callback);
+
+		env->DeleteLocalRef(j_path);
+		env->DeleteLocalRef(j_args);
+		env->DeleteLocalRef(j_work_dir);
+		env->DeleteLocalRef(j_result_callback);
+
+		return result;
+	}
+
+	return false;
 }

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -85,6 +85,7 @@ private:
 	jmethodID _enable_immersive_mode = nullptr;
 	jmethodID _is_in_immersive_mode = nullptr;
 	jmethodID _on_editor_workspace_selected = nullptr;
+	jmethodID _termux_execute = nullptr;
 
 public:
 	GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_godot_instance);
@@ -140,6 +141,8 @@ public:
 	bool is_in_immersive_mode();
 
 	void on_editor_workspace_selected(const String &p_workspace);
+
+	bool termux_execute(const String &p_path, const List<String> &p_arguments, const String p_work_dir, bool p_background, const Callable &p_result_callback);
 };
 
 #endif // JAVA_GODOT_WRAPPER_H


### PR DESCRIPTION
*Edit 2025-04-23: Adding new setup instructions / comments to the top of PR description*

This PR is a proof of concept at this point, that with some minimal setup Godot can have termux install all the needed dependencies and then build an APK.  **Note: this process currently automatically accepts android SDK license agreements**, this is temporary and just for ease of testing.

Here's some info on how to set it up if you'd like to give it a try, do note that on first run the build will take quite a while, at least five or six minutes for me on Quest 3. After an initial successful build, another build takes maybe around a minute.

### Setup
- Download the latest [Termux arm64 apk](https://github.com/termux/termux-app/releases/tag/v0.118.2) and install on your device (I've only tested this on Meta Quest 3)
- Open up termux and run the command `termux-setup-storage`
- Edit the `~/.termux/termux.properties` file and uncomment the line `allow-external-apps = true`
- Grant the com.termux.permission.RUN_COMMAND permission to Godot with adb:
```
adb shell pm grant org.godotengine.editor.v4.meta.debug com.termux.permission.RUN_COMMAND
```
- Install the android build templates built from this branch, or you can just use the 4.4-stable build template and replace the `build.gradle` file by hand

After that, it _should_ be able to execute a build, but I will not be surprised at all if I've missed something and people bump into issues.

### Current Termux Command Flow on Build
- Check if OpenJDK 17 is installed
  - If not, install it with `pkg`
- Check if all android sdk packages are installed with `sdkmanager`
  - If this fails, it will run a gradle task to install `wget`, `unzip`, `sdkmanager`, and all the other android sdk stuff.
- Check if aapt2 is installed
  - If not, install it with `pkg`
- Run a gradle build with an extra task added to find and replace any aapt2 files found in `~/.gradle`
  - If it fails (and it will fail the first time ever attempted) it will attempt once more. This is just a hacky workaround for the time being. After that initial fail, aapt2 will be swapped and it shouldn't fail again.
- Copy and rename the built file with gradle

---
*Edit 2025-04-23: Outdated initial PR description*

At the moment this PR is just for testing purposes. These changes allow android devices to install android build templates and then begin the gradle build process, staging the necessary files for a gradle build, but will exit before actually attempting the gradle build command.

I've only tested with this patched to https://github.com/godotengine/godot/commit/4c311cbee68c0b66ff8ebb8b0defdd9979dd2a41 on the XR Editor.