### PR TITLE
CanvasItem always pick resize handle that allows dragging in the direction of initial mouse movement

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1789,6 +1789,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 
 					DragType resize_drag = DRAG_NONE;
 					real_t radius = (select_handle->get_size().width / 2) * 1.5;
+					handles_in_range.clear();
 
 					for (int i = 0; i < 4; i++) {
 						int prev = (i + 3) % 4;
@@ -1799,6 +1800,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 						ofs += endpoints[i];
 						if (ofs.distance_to(b->get_position()) < radius) {
 							resize_drag = dragger[i * 2];
+							handles_in_range.set_flag(1 << resize_drag);
 						}
 
 						ofs = (endpoints[i] + endpoints[next]) / 2;
@@ -1853,6 +1855,23 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 
 			Point2 drag_begin = xform.affine_inverse().xform(drag_to_snapped_begin);
 			Point2 drag_end = xform.affine_inverse().xform(drag_to_snapped_end);
+
+			if (handles_in_range > 0) {
+				real_t min_angle = Math_TAU;
+				Point2 delta = m->get_relative();
+				const DragType draggers[4] = { DRAG_TOP_LEFT, DRAG_TOP_RIGHT, DRAG_BOTTOM_RIGHT, DRAG_BOTTOM_LEFT };
+				const Vector2 drag_dirs[4] = { Vector2(-1, -1), Vector2(1, -1), Vector2(1, 1), Vector2(-1, 1) };
+				for (int i = 0; i < 4; i++) {
+					if (handles_in_range.has_flag(1 << draggers[i])) {
+						real_t new_angle = abs(delta.angle_to(drag_dirs[i]));
+						if (new_angle < min_angle) {
+							min_angle = new_angle;
+							drag_type = draggers[i];
+						}
+					}
+				}
+				handles_in_range = 0;
+			}
 
 			// Horizontal resize
 			if (drag_type == DRAG_LEFT || drag_type == DRAG_TOP_LEFT || drag_type == DRAG_BOTTOM_LEFT) {

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -358,6 +358,7 @@ private:
 	Point2 drag_from;
 	Point2 drag_to;
 	Point2 drag_rotation_center;
+	BitField<int> handles_in_range = 0;
 	List<CanvasItem *> drag_selection;
 	int dragged_guide_index = -1;
 	Point2 dragged_guide_pos;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes https://github.com/godotengine/godot-proposals/issues/11559

https://github.com/user-attachments/assets/921e6f93-7a8d-4d11-b757-08473bd134dc

