### PR TITLE
CI: Don't include commit sha in cache key, ensure caches don't stay reserved

### DIFF
--- a/.github/actions/godot-cache-restore/action.yml
+++ b/.github/actions/godot-cache-restore/action.yml
@@ -36,17 +36,15 @@ runs:
     # We try to match an existing cache to restore from it. Each potential key is checked against
     # all existing caches as a prefix. E.g. 'linux-template-minimal' would match any cache that
     # starts with "linux-template-minimal", such as
-    # "linux-template-minimal|master|6588a4a29af1621086feac0117d5d4d37af957fd".
+    # "linux-template-minimal|master".
     #
     # We check these prefixes in this order:
-    #   1. An exact match for the base branch, reference name, and SHA hash.
-    #   2. A partial match for the same cache name and reference name.
-    #   3. A partial match for the same cache name and default branch name.
+    #   1. An exact match for the same cache name and reference name.
+    #   2. A partial match for the same cache name and default branch name.
     - name: Restore SCons cache directory
       uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.scons-cache }}
-        key: ${{ inputs.cache-name }}|${{ github.ref_name }}|${{ github.sha }}
+        key: ${{ inputs.cache-name }}|${{ github.ref_name }}
         restore-keys: |
-          ${{ inputs.cache-name }}|${{ github.ref_name }}
           ${{ inputs.cache-name }}|${{ github.event.repository.default_branch }}

--- a/.github/actions/godot-cache-save/action.yml
+++ b/.github/actions/godot-cache-save/action.yml
@@ -15,4 +15,4 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: ${{ inputs.scons-cache }}
-        key: ${{ inputs.cache-name }}|${{ github.ref_name }}|${{ github.sha }}
+        key: ${{ inputs.cache-name }}|${{ github.ref_name }}

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -48,12 +48,6 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Restore Godot build cache
-        uses: ./.github/actions/godot-cache-restore
-        with:
-          cache-name: ${{ matrix.cache-name }}
-        continue-on-error: true
-
       - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
@@ -68,6 +62,12 @@ jobs:
       - name: Extract pre-built Android Swappy Frame Pacing Library
         run: 7za x -y swappy/godot-swappy.7z -o${{github.workspace}}/thirdparty/swappy-frame-pacing
 
+      - name: Restore Godot build cache
+        uses: ./.github/actions/godot-cache-restore
+        with:
+          cache-name: ${{ matrix.cache-name }}
+        continue-on-error: true
+
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:
@@ -78,6 +78,7 @@ jobs:
           scons-cache-limit: ${{ matrix.cache-limit }}
 
       - name: Save Godot build cache
+        if: always()
         uses: ./.github/actions/godot-cache-save
         with:
           cache-name: ${{ matrix.cache-name }}

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -18,12 +18,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup Python and SCons
+        uses: ./.github/actions/godot-deps
+
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore
         continue-on-error: true
-
-      - name: Setup Python and SCons
-        uses: ./.github/actions/godot-deps
 
       - name: Compilation (arm64)
         uses: ./.github/actions/godot-build
@@ -35,6 +35,7 @@ jobs:
           scons-cache-limit: 1
 
       - name: Save Godot build cache
+        if: always()
         uses: ./.github/actions/godot-cache-save
         continue-on-error: true
 

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -128,12 +128,6 @@ jobs:
           sudo rm -rf /usr/local/lib/android
           echo "Disk usage after:" && df -h
 
-      - name: Restore Godot build cache
-        uses: ./.github/actions/godot-cache-restore
-        with:
-          cache-name: ${{ matrix.cache-name }}
-        continue-on-error: true
-
       - name: Setup Python and SCons
         if: "!matrix.legacy-scons"
         uses: ./.github/actions/godot-deps
@@ -158,6 +152,12 @@ jobs:
           # Targeting the oldest version we want to support to ensure it still builds.
           dotnet-version: 8.0.100
 
+      - name: Restore Godot build cache
+        uses: ./.github/actions/godot-cache-restore
+        with:
+          cache-name: ${{ matrix.cache-name }}
+        continue-on-error: true
+
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:
@@ -176,6 +176,7 @@ jobs:
           godot-cpp-branch: ${{ env.GODOT_CPP_BRANCH }}
 
       - name: Save Godot build cache
+        if: always()
         uses: ./.github/actions/godot-cache-save
         with:
           cache-name: ${{ matrix.cache-name }}

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -36,15 +36,16 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup Python and SCons
+        uses: ./.github/actions/godot-deps
+
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore
         with:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
 
-      - name: Setup Python and SCons
-        uses: ./.github/actions/godot-deps
-
+        # This also gets cached.
       - name: Setup Vulkan SDK
         run: |
           sh misc/scripts/install_vulkan_sdk_macos.sh
@@ -68,6 +69,7 @@ jobs:
           scons-cache-limit: ${{ matrix.cache-limit }}
 
       - name: Save Godot build cache
+        if: always()
         uses: ./.github/actions/godot-cache-save
         with:
           cache-name: ${{ matrix.cache-name }}

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -46,14 +46,14 @@ jobs:
         run: |
           emcc -v
 
+      - name: Setup Python and SCons
+        uses: ./.github/actions/godot-deps
+
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore
         with:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
-
-      - name: Setup Python and SCons
-        uses: ./.github/actions/godot-deps
 
       - name: Compilation
         uses: ./.github/actions/godot-build
@@ -65,6 +65,7 @@ jobs:
           scons-cache-limit: 0.5
 
       - name: Save Godot build cache
+        if: always()
         uses: ./.github/actions/godot-cache-save
         with:
           cache-name: ${{ matrix.cache-name }}

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -62,12 +62,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Restore Godot build cache
-        uses: ./.github/actions/godot-cache-restore
-        with:
-          cache-name: ${{ matrix.cache-name }}
-        continue-on-error: true
-
       - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
@@ -85,6 +79,12 @@ jobs:
       - name: Extract pre-built ANGLE static libraries
         run: Expand-Archive -Force angle/angle.zip ${{ github.workspace }}/
 
+      - name: Restore Godot build cache
+        uses: ./.github/actions/godot-cache-restore
+        with:
+          cache-name: ${{ matrix.cache-name }}
+        continue-on-error: true
+
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:
@@ -95,6 +95,7 @@ jobs:
           scons-cache-limit: ${{ matrix.cache-limit }}
 
       - name: Save Godot build cache
+        if: always()
         uses: ./.github/actions/godot-cache-save
         with:
           cache-name: ${{ matrix.cache-name }}


### PR DESCRIPTION
Including the commit sha in the cache key means that we create a new unique cache for every PR commit push or merge event. Previous caches for obsolete commits don't get cleaned up until after 7 days and so our cache quota gets filled extremely fast, occasionally leading to losing our `master` branch cache.

Through some tests, I found that it works fine to just use the branch ref as part of the cache key, and thus expect that:
- Only the latest commit in the `master` or other dev branches has a cache.
- Only the latest commit in a PR has a cache.

So cache keys take the form:
```
linux-template-minimal|master
linux-template-minimal|104076/merge
```

When e.g. merging a PR in `master`, its CI workflow will reuse the existing `linux-template-minimal|master` cache, and then replace it with an updated cache using the same key (so the old cache is discarded).

There's a potential problem though, which is that when restoring a cache, [GitHub Actions puts a "reserved" lock on it](https://github.com/actions/cache/issues/485#issuecomment-744145040) to prevent concurrent access from other workflows. This lock is removed when saving the cache in the same job, but if an intermediate step fails and terminates the job before that, the cache stays stuck in a reserved state (at least for one hour).
Subsequent workflows can't save to it, instead getting an error like this:
```
Failed to save: Unable to reserve cache with key linux-template-minimal|104076/merge, another job may be creating this cache.
```

We work it around by ensuring that the `cache/save` action always run even if previous steps failed, so that the lock is removed, if there's any.

This should drastically reduce our cache congestion.