### PR TITLE
CI: Add workflow to cleanup PR caches when closed

### DIFF
--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -1,0 +1,28 @@
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
+name: 🧹 Cache Cleanup
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    name: Cleanup PR caches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          echo "Fetching list of cache key"
+          cache_keys_for_pr=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+          # Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cache_key in $cache_keys_for_pr; do
+            gh cache delete $cache_key
+            echo "Deleted: $cache_key"
+          done
+          echo "Done"


### PR DESCRIPTION
This is pretty much copied from the GitHub Actions documentation: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries

To test this properly, it needs to be merge so that it's active, and then we should monitor what happens when merging PRs. I've tested this in a non-Godot repo and it works fine there, but the cache setup is slightly different.

Related to #104076 but can be merged independently.