### PR TITLE
Add support for embedding subwindows and dual screen GameViews

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -430,6 +430,15 @@ bool Engine::is_embedded_in_editor() const {
 	return embedded_in_editor;
 }
 
+void Engine::add_embedded_subwindow(const String &p_subwindow_title, int64_t p_parent_id) {
+	embedded_subwindows[p_subwindow_title] = p_parent_id;
+}
+
+int64_t Engine::get_embedded_subwindow(const String &p_subwindow_title) {
+	const int64_t *ret = embedded_subwindows.getptr(p_subwindow_title);
+	return ret ? *ret : 0;
+}
+
 Engine::Engine() {
 	singleton = this;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -93,6 +93,7 @@ private:
 	bool project_manager_hint = false;
 	bool extension_reloading = false;
 	bool embedded_in_editor = false;
+	HashMap<String, int64_t> embedded_subwindows;
 	bool recovery_mode_hint = false;
 
 	bool _print_header = true;
@@ -159,6 +160,8 @@ public:
 	void set_frame_delay(uint32_t p_msec);
 	uint32_t get_frame_delay() const;
 
+	void add_embedded_subwindow(const String &p_subwindow_title, int64_t p_parent_id);
+	int64_t get_embedded_subwindow(const String &p_subwindow_title);
 	void add_singleton(const Singleton &p_singleton);
 	void get_singletons(List<Singleton> *p_singletons);
 	bool has_singleton(const StringName &p_name) const;

--- a/editor/run/embedded_process.cpp
+++ b/editor/run/embedded_process.cpp
@@ -186,7 +186,7 @@ int EmbeddedProcess::get_embedded_pid() const {
 	return current_process_id;
 }
 
-void EmbeddedProcess::embed_process(OS::ProcessID p_pid) {
+void EmbeddedProcess::embed_process(OS::ProcessID p_pid, const String &p_embedded_window) {
 	if (!window) {
 		return;
 	}
@@ -201,6 +201,7 @@ void EmbeddedProcess::embed_process(OS::ProcessID p_pid) {
 	reset();
 
 	current_process_id = p_pid;
+	current_embedded_window = p_embedded_window;
 	start_embedding_time = OS::get_singleton()->get_ticks_msec();
 	embedding_grab_focus = has_focus();
 	timer_update_embedded_process->start();
@@ -214,7 +215,7 @@ void EmbeddedProcess::embed_process(OS::ProcessID p_pid) {
 
 void EmbeddedProcess::reset() {
 	if (current_process_id != 0 && embedding_completed) {
-		DisplayServer::get_singleton()->remove_embedded_process(current_process_id);
+		DisplayServer::get_singleton()->remove_embedded_process(current_process_id, current_embedded_window);
 	}
 	current_process_id = 0;
 	embedding_completed = false;
@@ -235,7 +236,7 @@ void EmbeddedProcess::request_close() {
 
 void EmbeddedProcess::_try_embed_process() {
 	bool is_visible = is_visible_in_tree();
-	Error err = DisplayServer::get_singleton()->embed_process(window->get_window_id(), current_process_id, get_screen_embedded_window_rect(), is_visible, is_visible && application_has_focus && embedding_grab_focus);
+	Error err = DisplayServer::get_singleton()->embed_process(window->get_window_id(), current_process_id, current_embedded_window, get_screen_embedded_window_rect(), is_visible, is_visible && application_has_focus && embedding_grab_focus);
 	if (err == OK) {
 		embedding_completed = true;
 		queue_redraw();
@@ -294,7 +295,7 @@ void EmbeddedProcess::_update_embedded_process() {
 		last_updated_embedded_process_focused = focus;
 	}
 
-	DisplayServer::get_singleton()->embed_process(window->get_window_id(), current_process_id, get_screen_embedded_window_rect(), is_visible_in_tree(), must_grab_focus);
+	DisplayServer::get_singleton()->embed_process(window->get_window_id(), current_process_id, current_embedded_window, get_screen_embedded_window_rect(), is_visible_in_tree(), must_grab_focus);
 	emit_signal(SNAME("embedded_process_updated"));
 }
 

--- a/editor/run/embedded_process.h
+++ b/editor/run/embedded_process.h
@@ -63,7 +63,7 @@ public:
 	virtual bool is_embedding_completed() const = 0;
 	virtual bool is_embedding_in_progress() const = 0;
 	virtual bool is_process_focused() const = 0;
-	virtual void embed_process(OS::ProcessID p_pid) = 0;
+	virtual void embed_process(OS::ProcessID p_pid, const String &p_embedded_window) = 0;
 	virtual int get_embedded_pid() const = 0;
 	virtual void reset() = 0;
 	virtual void request_close() = 0;
@@ -87,6 +87,7 @@ class EmbeddedProcess : public EmbeddedProcessBase {
 	uint64_t last_application_focus_time = 0;
 	OS::ProcessID focused_process_id = 0;
 	OS::ProcessID current_process_id = 0;
+	String current_embedded_window;
 	bool embedding_grab_focus = false;
 	bool embedding_completed = false;
 	uint64_t start_embedding_time = 0;
@@ -116,8 +117,8 @@ public:
 	bool is_embedding_in_progress() const override;
 	bool is_embedding_completed() const override;
 	bool is_process_focused() const override;
-	void embed_process(OS::ProcessID p_pid) override;
 	int get_embedded_pid() const override;
+	void embed_process(OS::ProcessID p_pid, const String &p_embedded_window) override;
 	void reset() override;
 	void request_close() override;
 	void queue_update_embedded_process() override;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -631,6 +631,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--xr-mode <mode>", "Select XR (Extended Reality) mode [\"default\", \"off\", \"on\"].\n");
 #endif
 	print_help_option("--wid <window_id>", "Request parented to window.\n");
+	print_help_option("--swid <subwindow_title>,<window_id>", "Request that a subwindow with the provided title be parented to another window.\n");
 	print_help_option("--accessibility <mode>", "Select accessibility mode ['auto' (when screen reader is running, default), 'always', 'disabled'].\n");
 
 	print_help_title("Debug options");
@@ -1973,6 +1974,26 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
+		} else if (arg == "--swid") {
+			if (N) {
+				String vm = N->get();
+
+				if (!vm.contains_char(',')) {
+					OS::get_singleton()->print("Invalid data '%s', it should be e.g. '<subwindow_title>,<window_id>'.\n",
+							vm.utf8().get_data());
+					goto error;
+				}
+
+				String title = vm.get_slicec(',', 0);
+				int64_t window_index = vm.get_slicec(',', 1).to_int();
+
+				Engine::get_singleton()->add_embedded_subwindow(title, window_index);
+
+				N = N->next();
+			} else {
+				OS::get_singleton()->print("Missing <subwindow_title>,<window_id> argument for --swid <subwindow_title>,<window_id>.\n");
+				goto error;
+			}
 		} else if (arg == "--" || arg == "++") {
 			adding_user_args = true;
 		} else {

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -717,7 +717,7 @@ Vector<DisplayServer::WindowID> DisplayServerWayland::get_window_list() const {
 	return ret;
 }
 
-DisplayServer::WindowID DisplayServerWayland::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, bool p_exclusive, WindowID p_transient_parent) {
+DisplayServer::WindowID DisplayServerWayland::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, bool p_exclusive, WindowID p_transient_parent, int64_t p_parent) {
 	WindowID id = ++window_id_counter;
 	WindowData &wd = windows[id];
 
@@ -1508,7 +1508,7 @@ bool DisplayServerWayland::get_swap_cancel_ok() {
 	return swap_cancel_ok;
 }
 
-Error DisplayServerWayland::embed_process(WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
+Error DisplayServerWayland::embed_process(WindowID p_window, OS::ProcessID p_pid, const String &p_embedded_window, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
 	MutexLock mutex_lock(wayland_thread.mutex);
 
 	struct godot_embedding_compositor *ec = wayland_thread.get_embedding_compositor();
@@ -1580,7 +1580,7 @@ Error DisplayServerWayland::request_close_embedded_process(OS::ProcessID p_pid) 
 	return OK;
 }
 
-Error DisplayServerWayland::remove_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServerWayland::remove_embedded_process(OS::ProcessID p_pid, const String &p_embedded_window) {
 	return request_close_embedded_process(p_pid);
 }
 

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -246,7 +246,7 @@ public:
 
 	virtual Vector<DisplayServer::WindowID> get_window_list() const override;
 
-	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID) override;
+	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID, int64_t p_parent = 0) override;
 	virtual void show_window(WindowID p_id) override;
 	virtual void delete_sub_window(WindowID p_id) override;
 
@@ -328,9 +328,9 @@ public:
 
 	virtual bool get_swap_cancel_ok() override;
 
-	virtual Error embed_process(WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) override;
+	virtual Error embed_process(WindowID p_window, OS::ProcessID p_pid, const String &p_embedded_window, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) override;
 	virtual Error request_close_embedded_process(OS::ProcessID p_pid) override;
-	virtual Error remove_embedded_process(OS::ProcessID p_pid) override;
+	virtual Error remove_embedded_process(OS::ProcessID p_pid, const String &p_embedded_window) override;
 	virtual OS::ProcessID get_focused_process_id() override;
 
 	virtual int keyboard_get_layout_count() const override;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1904,7 +1904,7 @@ Vector<DisplayServer::WindowID> DisplayServerX11::get_window_list() const {
 	return ret;
 }
 
-DisplayServer::WindowID DisplayServerX11::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, bool p_exclusive, WindowID p_transient_parent) {
+DisplayServer::WindowID DisplayServerX11::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, bool p_exclusive, WindowID p_transient_parent, int64_t p_parent) {
 	_THREAD_SAFE_METHOD_
 
 	WindowID id = _create_window(p_mode, p_vsync_mode, p_flags, p_rect, 0);
@@ -6029,7 +6029,7 @@ void DisplayServerX11::_set_window_taskbar_pager_enabled(Window p_window, bool p
 	XSendEvent(x11_display, DefaultRootWindow(x11_display), False, SubstructureRedirectMask | SubstructureNotifyMask, (XEvent *)&xev);
 }
 
-Error DisplayServerX11::embed_process(WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
+Error DisplayServerX11::embed_process(WindowID p_window, OS::ProcessID p_pid, const String &p_embedded_window, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_COND_V(!windows.has(p_window), FAILED);
@@ -6198,7 +6198,7 @@ Error DisplayServerX11::request_close_embedded_process(OS::ProcessID p_pid) {
 	return OK;
 }
 
-Error DisplayServerX11::remove_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServerX11::remove_embedded_process(OS::ProcessID p_pid, const String &p_embedded_window) {
 	_THREAD_SAFE_METHOD_
 
 	if (!embedded_processes.has(p_pid)) {

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -472,7 +472,7 @@ public:
 
 	virtual Vector<DisplayServer::WindowID> get_window_list() const override;
 
-	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID) override;
+	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID, int64_t p_parent = 0) override;
 	virtual void show_window(WindowID p_id) override;
 	virtual void delete_sub_window(WindowID p_id) override;
 
@@ -550,9 +550,9 @@ public:
 	virtual void window_start_drag(WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_start_resize(WindowResizeEdge p_edge, WindowID p_window) override;
 
-	virtual Error embed_process(WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) override;
+	virtual Error embed_process(WindowID p_window, OS::ProcessID p_pid, const String &p_embedded_window, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) override;
 	virtual Error request_close_embedded_process(OS::ProcessID p_pid) override;
-	virtual Error remove_embedded_process(OS::ProcessID p_pid) override;
+	virtual Error remove_embedded_process(OS::ProcessID p_pid, const String &p_embedded_window) override;
 	virtual OS::ProcessID get_focused_process_id() override;
 
 	virtual void cursor_set_shape(CursorShape p_shape) override;

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -343,7 +343,7 @@ public:
 
 	virtual Vector<int> get_window_list() const override;
 
-	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID) override;
+	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID, int64_t p_parent = 0) override;
 	virtual void show_window(WindowID p_id) override;
 	virtual void delete_sub_window(WindowID p_id) override;
 
@@ -442,7 +442,7 @@ public:
 	Error embed_process_update(WindowID p_window, EmbeddedProcessMacOS *p_process);
 #endif
 	virtual Error request_close_embedded_process(OS::ProcessID p_pid) override;
-	virtual Error remove_embedded_process(OS::ProcessID p_pid) override;
+	virtual Error remove_embedded_process(OS::ProcessID p_pid, const String &p_embedded_window) override;
 
 	void _process_events(bool p_pump);
 	virtual void process_events() override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -1835,7 +1835,7 @@ Vector<DisplayServer::WindowID> DisplayServerMacOS::get_window_list() const {
 	return ret;
 }
 
-DisplayServer::WindowID DisplayServerMacOS::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, bool p_exclusive, WindowID p_transient_parent) {
+DisplayServer::WindowID DisplayServerMacOS::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, bool p_exclusive, WindowID p_transient_parent, int64_t p_parent) {
 	_THREAD_SAFE_METHOD_
 
 	WindowID id = _create_window(p_mode, p_vsync_mode, p_rect);
@@ -3231,7 +3231,7 @@ Error DisplayServerMacOS::request_close_embedded_process(OS::ProcessID p_pid) {
 	return OK;
 }
 
-Error DisplayServerMacOS::remove_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServerMacOS::remove_embedded_process(OS::ProcessID p_pid, const String &p_embedded_window) {
 	_THREAD_SAFE_METHOD_
 
 	EmbeddedProcessData *ed;

--- a/platform/macos/editor/embedded_game_view_plugin.mm
+++ b/platform/macos/editor/embedded_game_view_plugin.mm
@@ -160,12 +160,15 @@ GameViewPluginMacOS::GameViewPluginMacOS() {
 		return;
 	}
 
-	EmbeddedProcessMacOS *embedded_process = memnew(EmbeddedProcessMacOS);
+	EmbeddedProcessMacOS *setup_embedded_process = memnew(EmbeddedProcessMacOS);
+	EmbeddedProcessMacOS *setup_top_embedded_process = memnew(EmbeddedProcessMacOS);
 
-	Ref<GameViewDebuggerMacOS> debugger;
-	debugger.instantiate(embedded_process);
+	Ref<GameViewDebuggerMacOS> setup_debugger;
+	setup_debugger.instantiate(setup_embedded_process);
+	Ref<GameViewDebuggerMacOS> setup_top_debugger;
+	setup_top_debugger.instantiate(setup_top_embedded_process);
 
-	setup(debugger, embedded_process);
+	setup(setup_debugger, setup_top_debugger, setup_embedded_process, setup_top_embedded_process);
 }
 
 extern "C" GameViewPluginBase *get_game_view_plugin() {

--- a/platform/macos/editor/embedded_process_macos.h
+++ b/platform/macos/editor/embedded_process_macos.h
@@ -114,12 +114,12 @@ public:
 		return embedding_state == EmbeddingState::COMPLETED;
 	}
 
-	bool is_process_focused() const override { return layer_host->has_focus(); }
-	void embed_process(OS::ProcessID p_pid) override;
-	int get_embedded_pid() const override { return current_process_id; }
-	void reset() override;
-	void request_close() override;
-	void queue_update_embedded_process() override { update_embedded_process(); }
+	virtual bool is_process_focused() const override { return layer_host->has_focus(); }
+	virtual void embed_process(OS::ProcessID p_pid, const String &p_embedded_window) override;
+	virtual int get_embedded_pid() const override { return current_process_id; }
+	virtual void reset() override;
+	virtual void request_close() override;
+	virtual void queue_update_embedded_process() override { update_embedded_process(); }
 
 	Rect2i get_adjusted_embedded_window_rect(const Rect2i &p_rect) const override;
 

--- a/platform/macos/editor/embedded_process_macos.mm
+++ b/platform/macos/editor/embedded_process_macos.mm
@@ -79,7 +79,7 @@ void EmbeddedProcessMacOS::set_script_debugger(ScriptEditorDebugger *p_debugger)
 	_try_embed_process();
 }
 
-void EmbeddedProcessMacOS::embed_process(OS::ProcessID p_pid) {
+void EmbeddedProcessMacOS::embed_process(OS::ProcessID p_pid, const String &p_embedded_window) {
 	if (!window) {
 		return;
 	}
@@ -103,7 +103,7 @@ void EmbeddedProcessMacOS::reset() {
 		ds = static_cast<DisplayServerMacOS *>(DisplayServer::get_singleton());
 	}
 	if (current_process_id != 0 && is_embedding_completed()) {
-		ds->remove_embedded_process(current_process_id);
+		ds->remove_embedded_process(current_process_id, "");
 	}
 	current_process_id = 0;
 	embedding_state = EmbeddingState::IDLE;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -150,6 +150,7 @@ bool DisplayServerWindows::has_feature(Feature p_feature) const {
 		case FEATURE_SCREEN_CAPTURE:
 		case FEATURE_STATUS_INDICATOR:
 		case FEATURE_WINDOW_EMBEDDING:
+		case FEATURE_SUBWINDOW_EMBEDDING:
 		case FEATURE_WINDOW_DRAG:
 			return true;
 		case FEATURE_SCREEN_EXCLUDE_FROM_CAPTURE:
@@ -1610,7 +1611,7 @@ DisplayServer::WindowID DisplayServerWindows::get_window_at_screen_position(cons
 	return INVALID_WINDOW_ID;
 }
 
-DisplayServer::WindowID DisplayServerWindows::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, bool p_exclusive, WindowID p_transient_parent) {
+DisplayServer::WindowID DisplayServerWindows::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, bool p_exclusive, WindowID p_transient_parent, int64_t p_parent) {
 	_THREAD_SAFE_METHOD_
 
 	bool no_redirection_bitmap = false;
@@ -1619,7 +1620,11 @@ DisplayServer::WindowID DisplayServerWindows::create_sub_window(WindowMode p_mod
 #endif
 
 	WindowID window_id = window_id_counter;
-	Error err = _create_window(window_id, p_mode, p_flags, p_rect, p_exclusive, p_transient_parent, NULL, no_redirection_bitmap);
+	HWND parent_hwnd = NULL;
+	if (p_parent) {
+		parent_hwnd = (HWND)p_parent;
+	}
+	Error err = _create_window(window_id, p_mode, p_flags, p_rect, p_exclusive, p_transient_parent, parent_hwnd, no_redirection_bitmap);
 	ERR_FAIL_COND_V_MSG(err != OK, INVALID_WINDOW_ID, "Failed to create sub window.");
 	++window_id_counter;
 
@@ -3105,6 +3110,7 @@ struct WindowEnumData {
 	DWORD process_id;
 	HWND parent_hWnd;
 	HWND hWnd;
+	String window_title;
 };
 
 static BOOL CALLBACK _enum_proc_find_window_from_process_id_callback(HWND hWnd, LPARAM lParam) {
@@ -3117,6 +3123,12 @@ static BOOL CALLBACK _enum_proc_find_window_from_process_id_callback(HWND hWnd, 
 			return TRUE;
 		}
 
+		wchar_t this_window_title[256];
+		GetWindowTextW(hWnd, this_window_title, sizeof(this_window_title) / sizeof(this_window_title[0]));
+		if (!ed.window_title.is_empty() && String(this_window_title) != ed.window_title) {
+			return TRUE;
+		}
+
 		// Found it.
 		ed.hWnd = hWnd;
 		SetLastError(ERROR_SUCCESS);
@@ -3126,9 +3138,9 @@ static BOOL CALLBACK _enum_proc_find_window_from_process_id_callback(HWND hWnd, 
 	return TRUE;
 }
 
-HWND DisplayServerWindows::_find_window_from_process_id(OS::ProcessID p_pid, HWND p_current_hwnd) {
+HWND DisplayServerWindows::_find_window_from_process_id(OS::ProcessID p_pid, HWND p_current_hwnd, const String &p_window_title) {
 	DWORD pid = p_pid;
-	WindowEnumData ed = { pid, p_current_hwnd, NULL };
+	WindowEnumData ed = { pid, p_current_hwnd, NULL, p_window_title };
 
 	// First, check our own child, maybe it's already embedded.
 	if (!EnumChildWindows(p_current_hwnd, _enum_proc_find_window_from_process_id_callback, (LPARAM)&ed) && (GetLastError() == ERROR_SUCCESS)) {
@@ -3145,7 +3157,7 @@ HWND DisplayServerWindows::_find_window_from_process_id(OS::ProcessID p_pid, HWN
 	return NULL;
 }
 
-Error DisplayServerWindows::embed_process(WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
+Error DisplayServerWindows::embed_process(WindowID p_window, OS::ProcessID p_pid, const String &p_embedded_window, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_COND_V(!windows.has(p_window), FAILED);
@@ -3153,11 +3165,12 @@ Error DisplayServerWindows::embed_process(WindowID p_window, OS::ProcessID p_pid
 	const WindowData &wd = windows[p_window];
 
 	EmbeddedProcessData *ep = nullptr;
-	if (embedded_processes.has(p_pid)) {
-		ep = embedded_processes.get(p_pid);
+	int existing_process_index = get_embedded_process(p_pid, p_embedded_window);
+	if (existing_process_index >= 0) {
+		ep = embedded_processes.get(existing_process_index);
 	} else {
 		// New process, trying to find the window.
-		HWND handle_to_embed = _find_window_from_process_id(p_pid, wd.hWnd);
+		HWND handle_to_embed = _find_window_from_process_id(p_pid, wd.hWnd, p_embedded_window);
 		if (!handle_to_embed) {
 			return ERR_DOES_NOT_EXIST;
 		}
@@ -3165,11 +3178,14 @@ Error DisplayServerWindows::embed_process(WindowID p_window, OS::ProcessID p_pid
 		const DWORD style = GetWindowLongPtr(handle_to_embed, GWL_STYLE);
 
 		ep = memnew(EmbeddedProcessData);
+		ep->process_id = p_pid;
+		ep->window_title = p_embedded_window;
+
 		ep->window_handle = handle_to_embed;
 		ep->parent_window_handle = wd.hWnd;
 		ep->is_visible = (style & WS_VISIBLE) == WS_VISIBLE;
 
-		embedded_processes.insert(p_pid, ep);
+		embedded_processes.push_back(ep);
 	}
 
 	if (p_rect.size.x <= 100 || p_rect.size.y <= 100) {
@@ -3204,11 +3220,12 @@ Error DisplayServerWindows::embed_process(WindowID p_window, OS::ProcessID p_pid
 Error DisplayServerWindows::request_close_embedded_process(OS::ProcessID p_pid) {
 	_THREAD_SAFE_METHOD_
 
-	if (!embedded_processes.has(p_pid)) {
+	int existing_process_index = get_embedded_process(p_pid, "");
+	if (existing_process_index < 0) {
 		return ERR_DOES_NOT_EXIST;
 	}
 
-	EmbeddedProcessData *ep = embedded_processes.get(p_pid);
+	EmbeddedProcessData *ep = embedded_processes.get(existing_process_index);
 
 	// Send a close message to gracefully close the process.
 	PostMessage(ep->window_handle, WM_CLOSE, 0, 0);
@@ -3216,14 +3233,15 @@ Error DisplayServerWindows::request_close_embedded_process(OS::ProcessID p_pid) 
 	return OK;
 }
 
-Error DisplayServerWindows::remove_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServerWindows::remove_embedded_process(OS::ProcessID p_pid, const String &p_embedded_window) {
 	_THREAD_SAFE_METHOD_
 
-	if (!embedded_processes.has(p_pid)) {
+	int existing_process_index = get_embedded_process(p_pid, p_embedded_window);
+	if (existing_process_index < 0) {
 		return ERR_DOES_NOT_EXIST;
 	}
 
-	EmbeddedProcessData *ep = embedded_processes.get(p_pid);
+	EmbeddedProcessData *ep = embedded_processes.get(existing_process_index);
 
 	request_close_embedded_process(p_pid);
 
@@ -3260,10 +3278,21 @@ Error DisplayServerWindows::remove_embedded_process(OS::ProcessID p_pid) {
 
 	SetForegroundWindow(ep->parent_window_handle);
 
-	embedded_processes.erase(p_pid);
+	embedded_processes.erase(ep);
 	memdelete(ep);
 
 	return OK;
+}
+
+int DisplayServerWindows::get_embedded_process(OS::ProcessID p_pid, const String &p_embedded_window) {
+	int i = 0;
+	for (List<EmbeddedProcessData *>::Iterator itr = embedded_processes.begin(); itr != embedded_processes.end(); ++itr, i++) {
+		EmbeddedProcessData *this_process = *itr;
+		if (this_process->process_id == p_pid && this_process->window_title == p_embedded_window) {
+			return i;
+		}
+	}
+	return -1;
 }
 
 OS::ProcessID DisplayServerWindows::get_focused_process_id() {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -521,13 +521,17 @@ class DisplayServerWindows : public DisplayServer {
 	String _get_klid(HKL p_hkl) const;
 
 	struct EmbeddedProcessData {
+		OS::ProcessID process_id = 0;
+		String window_title;
+
 		HWND window_handle = 0;
 		HWND parent_window_handle = 0;
 		bool is_visible = false;
 	};
-	HashMap<OS::ProcessID, EmbeddedProcessData *> embedded_processes;
+	List<EmbeddedProcessData *> embedded_processes;
+	int get_embedded_process(OS::ProcessID p_pid, const String &p_embedded_window);
 
-	HWND _find_window_from_process_id(OS::ProcessID p_pid, HWND p_current_hwnd);
+	HWND _find_window_from_process_id(OS::ProcessID p_pid, HWND p_current_hwnd, const String &p_window_title);
 
 	void initialize_tts() const;
 
@@ -596,7 +600,7 @@ public:
 
 	virtual Vector<DisplayServer::WindowID> get_window_list() const override;
 
-	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID) override;
+	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID, int64_t p_parent = 0) override;
 	virtual void show_window(WindowID p_window) override;
 	virtual void delete_sub_window(WindowID p_window) override;
 
@@ -686,9 +690,9 @@ public:
 	virtual bool get_swap_cancel_ok() override;
 
 	virtual void enable_for_stealing_focus(OS::ProcessID pid) override;
-	virtual Error embed_process(WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) override;
+	virtual Error embed_process(WindowID p_window, OS::ProcessID p_pid, const String &p_embedded_window, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) override;
 	virtual Error request_close_embedded_process(OS::ProcessID p_pid) override;
-	virtual Error remove_embedded_process(OS::ProcessID p_pid) override;
+	virtual Error remove_embedded_process(OS::ProcessID p_pid, const String &p_embedded_window) override;
 	virtual OS::ProcessID get_focused_process_id() override;
 
 	virtual Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) override;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -665,10 +665,15 @@ void Window::_make_window() {
 		window_rect = Rect2i(DisplayServer::get_singleton()->screen_get_position(DisplayServer::SCREEN_WITH_KEYBOARD_FOCUS) + (DisplayServer::get_singleton()->screen_get_size(DisplayServer::SCREEN_WITH_KEYBOARD_FOCUS) - size) / 2, size);
 	}
 
-	window_id = DisplayServer::get_singleton()->create_sub_window(DisplayServer::WindowMode(mode), vsync_mode, f, window_rect, is_in_edited_scene_root() ? false : exclusive, transient_parent ? transient_parent->window_id : DisplayServer::INVALID_WINDOW_ID);
+	// Add parent window if --swid told us to embed a window with this title.
+	int64_t parent_handle = Engine::get_singleton()->get_embedded_subwindow(get_title());
+
+	window_id = DisplayServer::get_singleton()->create_sub_window(DisplayServer::WindowMode(mode), vsync_mode, f, window_rect, is_in_edited_scene_root() ? false : exclusive, transient_parent ? transient_parent->window_id : DisplayServer::INVALID_WINDOW_ID, parent_handle);
 	ERR_FAIL_COND(window_id == DisplayServer::INVALID_WINDOW_ID);
-	DisplayServer::get_singleton()->window_set_max_size(Size2i(), window_id);
-	DisplayServer::get_singleton()->window_set_min_size(Size2i(), window_id);
+	if (!parent_handle) {
+		DisplayServer::get_singleton()->window_set_max_size(Size2i(), window_id);
+		DisplayServer::get_singleton()->window_set_min_size(Size2i(), window_id);
+	}
 	DisplayServer::get_singleton()->window_set_mouse_passthrough(mpath, window_id);
 	DisplayServer::get_singleton()->window_set_title(displayed_title, window_id);
 	DisplayServer::get_singleton()->window_attach_instance_id(get_instance_id(), window_id);
@@ -1169,8 +1174,11 @@ void Window::_update_window_size() {
 
 		embedder->_sub_window_update(this);
 	} else if (window_id != DisplayServer::INVALID_WINDOW_ID) {
-		// When main window embedded in the editor, we can't resize the main window.
-		if (window_id != DisplayServer::MAIN_WINDOW_ID || !Engine::get_singleton()->is_embedded_in_editor()) {
+		// When a window is embedded in the editor, we can't resize it.
+		bool is_main_window = window_id == DisplayServer::MAIN_WINDOW_ID;
+		int64_t parent_handle = Engine::get_singleton()->get_embedded_subwindow(get_title());
+
+		if ((is_main_window && !Engine::get_singleton()->is_embedded_in_editor()) || (!is_main_window && !parent_handle)) {
 			if (reset_min_first && wrap_controls) {
 				// Avoid an error if setting max_size to a value between min_size and the previous size_limit.
 				DisplayServer::get_singleton()->window_set_min_size(Size2i(), window_id);

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -600,7 +600,7 @@ int DisplayServer::get_screen_from_rect(const Rect2 &p_rect) const {
 	return pos_screen;
 }
 
-DisplayServer::WindowID DisplayServer::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, bool p_exclusive, WindowID p_transient_parent) {
+DisplayServer::WindowID DisplayServer::create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, bool p_exclusive, WindowID p_transient_parent, int64_t p_parent) {
 	ERR_FAIL_V_MSG(INVALID_WINDOW_ID, "Sub-windows not supported by this display server.");
 }
 
@@ -1127,7 +1127,7 @@ bool DisplayServer::get_swap_cancel_ok() {
 void DisplayServer::enable_for_stealing_focus(OS::ProcessID pid) {
 }
 
-Error DisplayServer::embed_process(WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
+Error DisplayServer::embed_process(WindowID p_window, OS::ProcessID p_pid, const String &p_embedded_window, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
 	WARN_PRINT("Embedded process not supported by this display server.");
 	return ERR_UNAVAILABLE;
 }
@@ -1137,7 +1137,7 @@ Error DisplayServer::request_close_embedded_process(OS::ProcessID p_pid) {
 	return ERR_UNAVAILABLE;
 }
 
-Error DisplayServer::remove_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServer::remove_embedded_process(OS::ProcessID p_pid, const String &p_embedded_window) {
 	WARN_PRINT("Embedded process not supported by this display server.");
 	return ERR_UNAVAILABLE;
 }

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -168,6 +168,7 @@ public:
 		FEATURE_NATIVE_COLOR_PICKER,
 		FEATURE_SELF_FITTING_WINDOWS,
 		FEATURE_ACCESSIBILITY_SCREEN_READER,
+		FEATURE_SUBWINDOW_EMBEDDING,
 	};
 
 	virtual bool has_feature(Feature p_feature) const = 0;
@@ -433,7 +434,7 @@ public:
 		WINDOW_FLAG_MAXIMIZE_DISABLED_BIT = (1 << WINDOW_FLAG_MAXIMIZE_DISABLED),
 	};
 
-	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID);
+	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID, int64_t p_parent = 0);
 	virtual void show_window(WindowID p_id);
 	virtual void delete_sub_window(WindowID p_id);
 
@@ -808,9 +809,9 @@ public:
 
 	virtual void enable_for_stealing_focus(OS::ProcessID pid);
 
-	virtual Error embed_process(WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus);
+	virtual Error embed_process(WindowID p_window, OS::ProcessID p_pid, const String &p_embedded_window, const Rect2i &p_rect, bool p_visible, bool p_grab_focus);
 	virtual Error request_close_embedded_process(OS::ProcessID p_pid);
-	virtual Error remove_embedded_process(OS::ProcessID p_pid);
+	virtual Error remove_embedded_process(OS::ProcessID p_pid, const String &p_embedded_window);
 	virtual OS::ProcessID get_focused_process_id();
 
 	virtual Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback);

--- a/servers/display/display_server_headless.h
+++ b/servers/display/display_server_headless.h
@@ -86,7 +86,7 @@ public:
 
 	Vector<DisplayServer::WindowID> get_window_list() const override { return Vector<DisplayServer::WindowID>(); }
 
-	WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID) override { return 0; }
+	WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, WindowID p_transient_parent = INVALID_WINDOW_ID, int64_t p_parent = 0) override { return 0; }
 	void show_window(WindowID p_id) override {}
 	void delete_sub_window(WindowID p_id) override {}
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11091

Thanks to guidance from @Hilderin this PR adds two new features to the Game tab and embedding tools that were introduced in Godot 4.4. The first change extends the embedding functionality to allow embedding of "subwindows" (as they're known in `DisplayServer`) when provided with a unique window name. The user can now select whether to embed the main window or a custom window that matches the name provided via a text box in the GameView:

https://github.com/user-attachments/assets/3abf1bf9-cbf6-422e-9cfa-a80aef3a6843

This allows developers of multi-window games to embed the game window that makes the most sense for their project rather than being stuck with the main window. This is accomplished through modifications to the display server so that a subwindow can be parented much the same as the main window. In order to send the parenting data to the built game, a new `--swid` (subwindow ID) command line parameter was created that matches the `--wid` implementation for the main window. Then, when the `GameView` modifies the instance parameters, it can optionally send the `--swid` with the user provided window name.

As suggested by @Hilderin , I took the next step in the proposal to better utilize subwindow embedding here by adding an option to split the Game tab into two GameViews for better visibility while debugging. This was largely done by splitting out functionality that used to be handled by the `GameView` into the `GameViewPlugin` and having the plugin manage two instances, but all together it works pretty cleanly! A button in the embed options popup lets you split the view and the layout is saved as project metadata, with the default setting being the regular single view that people are familiar with:

https://github.com/user-attachments/assets/462f88d1-00c5-409b-9334-e6716db84516

Since this PR was already looking like a lot to review, one step I left for a future PR was getting the secondary view's game debugger working properly. This proved challenging to do immediately because we would either need to make the RuntimeSelect stuff not a singleton or we'd need to pass window data through every message sent via the debugger, but I'm certain that one of these solutions will be easier to work out when this initial PR is wrapped up. Besides that, the regular debugger controls for the main GameView are still fully functional:

https://github.com/user-attachments/assets/d6c88390-028c-46e4-86bf-3a5d54ccdbd0

**Note:** This PR only implements subwindow embedding for the Windows display server. Sadly I don't have a Linux machine to test on but Hilderin said it was fine to leave it like this so that a follow up PR can tackle the Linux/Android support which I believe shouldn't be too tough to match from Windows.

Thank you to everyone who offered ideas about the future of embedding in https://github.com/godotengine/godot/pull/99010 and I hope this new functionality proves to be helpful for developers looking for more debugging options! Let me know if there's anything I've missed and I'll be happy to make adjustments :)