### PR TITLE
Force the default theme when using `--import`.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -190,6 +190,7 @@ static bool single_window = false;
 static bool editor = false;
 static bool project_manager = false;
 static bool cmdline_tool = false;
+static bool force_default_theme = false;
 static String locale;
 static String log_file;
 static bool show_help = false;
@@ -1483,6 +1484,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (arg == "--import") {
 			editor = true;
 			cmdline_tool = true;
+			force_default_theme = true;
 			wait_for_import = true;
 			quit_after = 1;
 		} else if (arg == "--export-release" || arg == "--export-debug" ||
@@ -3481,7 +3483,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 #endif
 
-	theme_db->initialize_theme();
+	theme_db->initialize_theme(force_default_theme);
 	audio_server->load_default_bus_layout();
 
 #if defined(MODULE_MONO_ENABLED) && defined(TOOLS_ENABLED)

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -65,8 +65,7 @@ void ThemeDB::initialize_theme(bool force_default_theme) {
 	// Attempt to load custom project theme and font.
 
 	Ref<Font> project_font;
-	if (!force_default_theme)
-	{
+	if (!force_default_theme) {
 		if (!project_theme_path.is_empty()) {
 			Ref<Theme> theme = ResourceLoader::load(project_theme_path);
 			if (theme.is_valid()) {

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -43,7 +43,7 @@
 
 // Default engine theme creation and configuration.
 
-void ThemeDB::initialize_theme() {
+void ThemeDB::initialize_theme(bool force_default_theme) {
 	// Default theme-related project settings.
 
 	// Allow creating the default theme at a different scale to suit higher/lower base resolutions.
@@ -64,22 +64,25 @@ void ThemeDB::initialize_theme() {
 
 	// Attempt to load custom project theme and font.
 
-	if (!project_theme_path.is_empty()) {
-		Ref<Theme> theme = ResourceLoader::load(project_theme_path);
-		if (theme.is_valid()) {
-			set_project_theme(theme);
-		} else {
-			ERR_PRINT("Error loading custom project theme '" + project_theme_path + "'");
-		}
-	}
-
 	Ref<Font> project_font;
-	if (!project_font_path.is_empty()) {
-		project_font = ResourceLoader::load(project_font_path);
-		if (project_font.is_valid()) {
-			set_fallback_font(project_font);
-		} else {
-			ERR_PRINT("Error loading custom project font '" + project_font_path + "'");
+	if (!force_default_theme)
+	{
+		if (!project_theme_path.is_empty()) {
+			Ref<Theme> theme = ResourceLoader::load(project_theme_path);
+			if (theme.is_valid()) {
+				set_project_theme(theme);
+			} else {
+				ERR_PRINT("Error loading custom project theme '" + project_theme_path + "'");
+			}
+		}
+
+		if (!project_font_path.is_empty()) {
+			project_font = ResourceLoader::load(project_font_path);
+			if (project_font.is_valid()) {
+				set_fallback_font(project_font);
+			} else {
+				ERR_PRINT("Error loading custom project font '" + project_font_path + "'");
+			}
 		}
 	}
 

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -126,7 +126,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void initialize_theme();
+	void initialize_theme(bool force_default_theme = false);
 	void initialize_theme_noproject();
 	void finalize_theme();
 


### PR DESCRIPTION
This prevents an issue from trying to load a custom theme when the assets for the custom theme have not yet been imported.

Fixes #103930 
