### PR TITLE
Do not iterate `Dictionary` with `get_key_at_index`

### DIFF
--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -794,8 +794,8 @@ public:
 			if (p_dict.has("enums")) {
 				enums = p_dict["enums"];
 			}
-			for (int i = 0; i < enums.size(); i++) {
-				doc.enums[enums.get_key_at_index(i)] = EnumDoc::from_dict(enums.get_value_at_index(i));
+			for (const KeyValue<Variant, Variant> &kv : enums) {
+				doc.enums[kv.key] = EnumDoc::from_dict(kv.value);
 			}
 
 			Array properties;

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -414,10 +414,10 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			Dictionary dictionary = p_var;
 			Array arr;
 
-			for (int i = 0; i < dictionary.size(); i++) {
+			for (const KeyValue<Variant, Variant> &kv : dictionary) {
 				DAP::Variable var;
-				var.name = dictionary.get_key_at_index(i);
-				Variant value = dictionary.get_value_at_index(i);
+				var.name = kv.key;
+				Variant value = kv.value;
 				var.type = Variant::get_type_name(value.get_type());
 				var.value = value;
 				var.variablesReference = parse_variant(value);

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -223,16 +223,16 @@ Error ResourceImporterDynamicFont::import(ResourceUID::ID p_source_id, const Str
 	font->set_keep_rounding_remainders(keep_rounding_remainders);
 
 	Dictionary langs = p_options["language_support"];
-	for (int i = 0; i < langs.size(); i++) {
-		String key = langs.get_key_at_index(i);
-		bool enabled = langs.get_value_at_index(i);
+	for (const KeyValue<Variant, Variant> &kv : langs) {
+		String key = kv.key;
+		bool enabled = kv.value;
 		font->set_language_support_override(key, enabled);
 	}
 
 	Dictionary scripts = p_options["script_support"];
-	for (int i = 0; i < scripts.size(); i++) {
-		String key = scripts.get_key_at_index(i);
-		bool enabled = scripts.get_value_at_index(i);
+	for (const KeyValue<Variant, Variant> &kv : scripts) {
+		String key = kv.key;
+		bool enabled = kv.value;
 		font->set_script_support_override(key, enabled);
 	}
 

--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -407,9 +407,9 @@ void EditorPropertyOTVariation::update_property() {
 
 	Dictionary supported = (fd.is_valid()) ? fd->get_supported_variation_list() : Dictionary();
 
-	for (int i = 0; i < supported.size(); i++) {
-		int name_tag = supported.get_key_at_index(i);
-		Vector3i range = supported.get_value_at_index(i);
+	for (const KeyValue<Variant, Variant> &kv : supported) {
+		const int &name_tag = kv.key;
+		const Vector3i &range = kv.value;
 		if ((dict.has(name_tag) && dict[name_tag].get_type() == Variant::NIL) || !dict.has(name_tag)) {
 			dict[name_tag] = range.z;
 		}

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -3784,20 +3784,20 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 			for (int i = 0; i < p.size(); i++) {
 				CompatibilityShapeData csd;
 				Dictionary d = p[i];
-				for (int j = 0; j < d.size(); j++) {
-					String key = d.get_key_at_index(j);
+				for (const KeyValue<Variant, Variant> &kv : d) {
+					String key = kv.key;
 					if (key == "autotile_coord") {
-						csd.autotile_coords = d[key];
+						csd.autotile_coords = kv.value;
 					} else if (key == "one_way") {
-						csd.one_way = d[key];
+						csd.one_way = kv.value;
 					} else if (key == "one_way_margin") {
-						csd.one_way_margin = d[key];
+						csd.one_way_margin = kv.value;
 					} else if (key == "shape") {
 #ifndef PHYSICS_2D_DISABLED
-						csd.shape = d[key];
+						csd.shape = kv.value;
 #endif // PHYSICS_2D_DISABLED
 					} else if (key == "shape_transform") {
-						csd.transform = d[key];
+						csd.transform = kv.value;
 					}
 				}
 				ctd->shapes.push_back(csd);

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -549,12 +549,12 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			bool convert_value = dict.get_typed_value_builtin() == Variant::OBJECT &&
 					ClassDB::is_parent_class(dict.get_typed_value_class_name(), "Node");
 
-			for (int i = 0; i < paths.size(); i++) {
-				Variant key = paths.get_key_at_index(i);
+			for (const KeyValue<Variant, Variant> &kv : paths) {
+				Variant key = kv.key;
 				if (convert_key) {
 					key = base->get_node_or_null(key);
 				}
-				Variant value = paths.get_value_at_index(i);
+				Variant value = kv.value;
 				if (convert_value) {
 					value = base->get_node_or_null(value);
 				}
@@ -881,14 +881,14 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 					use_deferred_node_path_bit = true;
 					Dictionary dict = value;
 					Dictionary new_dict;
-					for (int i = 0; i < dict.size(); i++) {
-						Variant new_key = dict.get_key_at_index(i);
+					for (const KeyValue<Variant, Variant> &kv : dict) {
+						Variant new_key = kv.key;
 						if (convert_key && new_key.get_type() == Variant::OBJECT) {
 							if (Node *n = Object::cast_to<Node>(new_key)) {
 								new_key = p_node->get_path_to(n);
 							}
 						}
-						Variant new_value = dict.get_value_at_index(i);
+						Variant new_value = kv.value;
 						if (convert_value && new_value.get_type() == Variant::OBJECT) {
 							if (Node *n = Object::cast_to<Node>(new_value)) {
 								new_value = p_node->get_path_to(n);


### PR DESCRIPTION
Follow up #104047, replacing more inefficient patterns.

Iterating `Dictionary` by `get_key_at_index()`/`get_value_at_index()` is $O(N^2)$ because `get_key_index()` iterate through the inner `HashMap` to fetch requested keys. Replace them with normal iteration.