### PR TITLE
Register editor classes normally, rather than via `ClassDB::set_current_api()`

### DIFF
--- a/modules/fbx/register_types.cpp
+++ b/modules/fbx/register_types.cpp
@@ -61,10 +61,6 @@ void initialize_fbx_module(ModuleInitializationLevel p_level) {
 
 #ifdef TOOLS_ENABLED
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
-		// Editor-specific API.
-		ClassDB::APIType prev_api = ClassDB::get_current_api();
-		ClassDB::set_current_api(ClassDB::API_EDITOR);
-
 		GDREGISTER_CLASS(EditorSceneFormatImporterUFBX);
 
 		GLOBAL_DEF_RST_BASIC("filesystem/import/fbx2gltf/enabled", true);
@@ -72,7 +68,6 @@ void initialize_fbx_module(ModuleInitializationLevel p_level) {
 		GLOBAL_DEF_RST("filesystem/import/fbx2gltf/enabled.android", false);
 		GLOBAL_DEF_RST("filesystem/import/fbx2gltf/enabled.web", false);
 
-		ClassDB::set_current_api(prev_api);
 		EditorNode::add_init_callback(_editor_init);
 	}
 #endif // TOOLS_ENABLED

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -162,12 +162,7 @@ void initialize_gdscript_module(ModuleInitializationLevel p_level) {
 		gdscript_translation_parser_plugin.instantiate();
 		EditorTranslationParser::get_singleton()->add_parser(gdscript_translation_parser_plugin, EditorTranslationParser::STANDARD);
 	} else if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
-		ClassDB::APIType prev_api = ClassDB::get_current_api();
-		ClassDB::set_current_api(ClassDB::API_EDITOR);
-
 		GDREGISTER_CLASS(GDScriptSyntaxHighlighter);
-
-		ClassDB::set_current_api(prev_api);
 	}
 #endif // TOOLS_ENABLED
 }

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -135,10 +135,6 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 
 #ifdef TOOLS_ENABLED
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
-		// Editor-specific API.
-		ClassDB::APIType prev_api = ClassDB::get_current_api();
-		ClassDB::set_current_api(ClassDB::API_EDITOR);
-
 		GDREGISTER_CLASS(EditorSceneFormatImporterGLTF);
 		EditorPlugins::add_by_type<SceneExporterGLTFPlugin>();
 
@@ -149,10 +145,8 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 		GLOBAL_DEF_RST("filesystem/import/blender/enabled.android", false);
 		GLOBAL_DEF_RST("filesystem/import/blender/enabled.web", false);
 
-		ClassDB::set_current_api(prev_api);
 		EditorNode::add_init_callback(_editor_init);
 	}
-
 #endif // TOOLS_ENABLED
 }
 

--- a/modules/minimp3/register_types.cpp
+++ b/modules/minimp3/register_types.cpp
@@ -33,39 +33,30 @@
 #include "audio_stream_mp3.h"
 
 #ifdef TOOLS_ENABLED
-#include "resource_importer_mp3.h"
-#endif
-
-#ifdef TOOLS_ENABLED
 #include "core/config/engine.h"
+#include "editor/editor_node.h"
+#include "resource_importer_mp3.h"
+
+static void _editor_init() {
+	Ref<ResourceImporterMP3> mp3_import;
+	mp3_import.instantiate();
+	ResourceFormatImporter::get_singleton()->add_importer(mp3_import);
+}
 #endif
 
 void initialize_minimp3_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		GDREGISTER_CLASS(AudioStreamMP3);
 	}
 
 #ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
-		Ref<ResourceImporterMP3> mp3_import;
-		mp3_import.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(mp3_import);
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		GDREGISTER_CLASS(ResourceImporterMP3);
+
+		EditorNode::add_init_callback(_editor_init);
 	}
-
-	ClassDB::APIType prev_api = ClassDB::get_current_api();
-	ClassDB::set_current_api(ClassDB::API_EDITOR);
-
-	// Required to document import options in the class reference.
-	GDREGISTER_CLASS(ResourceImporterMP3);
-
-	ClassDB::set_current_api(prev_api);
 #endif
-
-	GDREGISTER_CLASS(AudioStreamMP3);
 }
 
 void uninitialize_minimp3_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
 }

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -225,21 +225,17 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 				openxr_interface->initialize();
 			}
 		}
+	}
 
 #ifdef TOOLS_ENABLED
-		// Register as "editor", not "core".
-		ClassDB::APIType prev_api = ClassDB::get_current_api();
-		ClassDB::set_current_api(ClassDB::API_EDITOR);
-
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
 		GDREGISTER_ABSTRACT_CLASS(OpenXRInteractionProfileEditorBase);
 		GDREGISTER_CLASS(OpenXRInteractionProfileEditor);
 		GDREGISTER_CLASS(OpenXRBindingModifierEditor);
 
-		ClassDB::set_current_api(prev_api);
-
 		EditorNode::add_init_callback(_editor_init);
-#endif
 	}
+#endif
 }
 
 void uninitialize_openxr_module(ModuleInitializationLevel p_level) {

--- a/modules/vorbis/register_types.cpp
+++ b/modules/vorbis/register_types.cpp
@@ -33,36 +33,30 @@
 #include "audio_stream_ogg_vorbis.h"
 
 #ifdef TOOLS_ENABLED
+#include "editor/editor_node.h"
 #include "resource_importer_ogg_vorbis.h"
+
+static void _editor_init() {
+	Ref<ResourceImporterOggVorbis> ogg_vorbis_importer;
+	ogg_vorbis_importer.instantiate();
+	ResourceFormatImporter::get_singleton()->add_importer(ogg_vorbis_importer);
+}
 #endif
 
 void initialize_vorbis_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		GDREGISTER_CLASS(AudioStreamOggVorbis);
+		GDREGISTER_CLASS(AudioStreamPlaybackOggVorbis);
 	}
 
 #ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
-		Ref<ResourceImporterOggVorbis> ogg_vorbis_importer;
-		ogg_vorbis_importer.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(ogg_vorbis_importer);
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		GDREGISTER_CLASS(ResourceImporterOggVorbis);
+
+		EditorNode::add_init_callback(_editor_init);
 	}
-
-	ClassDB::APIType prev_api = ClassDB::get_current_api();
-	ClassDB::set_current_api(ClassDB::API_EDITOR);
-
-	// Required to document import options in the class reference.
-	GDREGISTER_CLASS(ResourceImporterOggVorbis);
-
-	ClassDB::set_current_api(prev_api);
 #endif
-
-	GDREGISTER_CLASS(AudioStreamOggVorbis);
-	GDREGISTER_CLASS(AudioStreamPlaybackOggVorbis);
 }
 
 void uninitialize_vorbis_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
 }


### PR DESCRIPTION
As brought up on PR https://github.com/godotengine/godot/pull/103869, there were a number of modules that were using `ClassDB::set_current_api()` in order to register editor classes, rather than correctly registering them when the level was `MODULE_INITIALIZATION_LEVEL_EDITOR`.

This PR fixes that, and also attempts to standardize these modules `register_types.cpp` a little bit.

For example, all the modules were registering their resource format importers in a callback via `EditorNode::add_init_callback()` except for MP3 and OGG, so I modified those to do it that way as well. I tested re-importing MP3 and OGG files in a real project and everything seemed to be working fine!

I generated an `extension_api.json` both before and after this PR, and got the exact same result, so all the classes still seem to be registered at the correct API level.