### PR TITLE
Add 'additional_nodes' property to LightmapGI

### DIFF
--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -10,12 +10,15 @@
 		[b]Note:[/b] Due to how lightmaps work, most properties only have a visible effect once lightmaps are baked again.
 		[b]Note:[/b] Lightmap baking on [CSGShape3D]s and [PrimitiveMesh]es is not supported, as these cannot store UV2 data required for baking.
 		[b]Note:[/b] If no custom lightmappers are installed, [LightmapGI] can only be baked from devices that support the Forward+ or Mobile renderers.
-		[b]Note:[/b] The [LightmapGI] node only bakes light data for child nodes of its parent. Nodes further up the hierarchy of the scene will not be baked.
+		[b]Note:[/b] The [LightmapGI] node bakes light data for child nodes of its parent or arbitrary node hierarchies explicitly added to the [member LightmapGI.additional_nodes] array. Nodes further up the hierarchy of the scene will not be baked.
 	</description>
 	<tutorials>
 		<link title="Using Lightmap global illumination">$DOCS_URL/tutorials/3d/global_illumination/using_lightmap_gi.html</link>
 	</tutorials>
 	<members>
+		<member name="additional_nodes" type="NodePath[]" setter="set_additional_nodes" getter="get_additional_nodes" default="[]">
+			A list of additional nodes to be included in the baking process.
+		</member>
 		<member name="bias" type="float" setter="set_bias" getter="get_bias" default="0.0005">
 			The bias to use when computing shadows. Increasing [member bias] can fix shadow acne on the resulting baked lightmap, but can introduce peter-panning (shadows not connecting to their casters). Real-time [Light3D] shadows are not affected by this [member bias] property.
 		</member>

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1089,6 +1089,12 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 	{
 		Vector<MeshesFound> meshes_found;
 		_find_meshes_and_lights(p_from_node ? p_from_node : get_parent(), meshes_found, lights_found, probes_found);
+		for (const NodePath &node_path : additional_nodes) {
+			Node *node = get_node(node_path);
+			if (node) {
+				_find_meshes_and_lights(node, meshes_found, lights_found, probes_found);
+			}
+		}
 
 		if (meshes_found.is_empty()) {
 			return BAKE_ERROR_NO_MESHES;
@@ -1998,6 +2004,21 @@ Ref<CameraAttributes> LightmapGI::get_camera_attributes() const {
 	return camera_attributes;
 }
 
+void LightmapGI::set_additional_nodes(const TypedArray<NodePath> &p_additional_nodes) {
+	additional_nodes.clear();
+	for (int i = 0; i < p_additional_nodes.size(); i++) {
+		additional_nodes.append(p_additional_nodes[i]);
+	}
+}
+
+TypedArray<NodePath> LightmapGI::get_additional_nodes() const {
+	TypedArray<NodePath> ret;
+	for (const NodePath &path : additional_nodes) {
+		ret.push_back(path);
+	}
+	return ret;
+}
+
 PackedStringArray LightmapGI::get_configuration_warnings() const {
 	PackedStringArray warnings = VisualInstance3D::get_configuration_warnings();
 
@@ -2118,6 +2139,9 @@ void LightmapGI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_camera_attributes", "camera_attributes"), &LightmapGI::set_camera_attributes);
 	ClassDB::bind_method(D_METHOD("get_camera_attributes"), &LightmapGI::get_camera_attributes);
 
+	ClassDB::bind_method(D_METHOD("set_additional_nodes", "additional_nodes"), &LightmapGI::set_additional_nodes);
+	ClassDB::bind_method(D_METHOD("get_additional_nodes"), &LightmapGI::get_additional_nodes);
+
 	//	ClassDB::bind_method(D_METHOD("bake", "from_node"), &LightmapGI::bake, DEFVAL(Variant()));
 
 	ADD_GROUP("Tweaks", "");
@@ -2142,6 +2166,7 @@ void LightmapGI::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "environment_custom_color", PROPERTY_HINT_COLOR_NO_ALPHA), "set_environment_custom_color", "get_environment_custom_color");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "environment_custom_energy", PROPERTY_HINT_RANGE, "0,64,0.01"), "set_environment_custom_energy", "get_environment_custom_energy");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "camera_attributes", PROPERTY_HINT_RESOURCE_TYPE, "CameraAttributesPractical,CameraAttributesPhysical"), "set_camera_attributes", "get_camera_attributes");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "additional_nodes", PROPERTY_HINT_NONE, ""), "set_additional_nodes", "get_additional_nodes");
 	ADD_GROUP("Gen Probes", "generate_probes_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "generate_probes_subdiv", PROPERTY_HINT_ENUM, "Disabled,4,8,16,32"), "set_generate_probes", "get_generate_probes");
 	ADD_GROUP("Data", "");

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -208,6 +208,7 @@ private:
 	LightmapGIData::ShadowmaskMode shadowmask_mode = LightmapGIData::SHADOWMASK_MODE_NONE;
 	GenerateProbes gen_probes = GENERATE_PROBES_SUBDIV_8;
 	Ref<CameraAttributes> camera_attributes;
+	Vector<NodePath> additional_nodes;
 
 	Ref<LightmapGIData> light_data;
 	Node *last_owner = nullptr;
@@ -350,6 +351,9 @@ public:
 
 	void set_camera_attributes(const Ref<CameraAttributes> &p_camera_attributes);
 	Ref<CameraAttributes> get_camera_attributes() const;
+
+	void set_additional_nodes(const TypedArray<NodePath> &p_additional_nodes);
+	TypedArray<NodePath> get_additional_nodes() const;
 
 	AABB get_aabb() const override;
 


### PR DESCRIPTION
This improvement gives more control in deciding which nodes should be used by the lightmapper during lightmap bake. Currently, only siblings of the LightmapGI node are included but there are cases where more granular control is needed.

For example cases where there are multiple LightmapGI nodes in the scene and certain light sources must contribute to all the lightmaps.

Setting this property is optional. Not configuring additional nodes will keep the original behavior as before.

The screenshot below shows this enhancement in practice. Two separate LightmapGI nodes being correctly lit by shared Directional Light even though the light is not a sibling to any of the LightmapGI node.
  
![image](https://github.com/user-attachments/assets/31f169e5-c3f2-461d-8ea4-d0ffe90c57b1)
