### PR TITLE
Fix `Game` view visual streaking when selecting nodes with `Physics Interpolation` enabled

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -1991,6 +1991,11 @@ void RuntimeNodeSelect::_update_selection() {
 		RS::get_singleton()->instance_set_transform(sb->instance_ofs, t_offset);
 		RS::get_singleton()->instance_set_transform(sb->instance_xray, t);
 		RS::get_singleton()->instance_set_transform(sb->instance_xray_ofs, t_offset);
+
+		RS::get_singleton()->instance_reset_physics_interpolation(sb->instance);
+		RS::get_singleton()->instance_reset_physics_interpolation(sb->instance_ofs);
+		RS::get_singleton()->instance_reset_physics_interpolation(sb->instance_xray);
+		RS::get_singleton()->instance_reset_physics_interpolation(sb->instance_xray_ofs);
 	}
 #endif // _3D_DISABLED
 }
@@ -2027,12 +2032,14 @@ void RuntimeNodeSelect::_update_selection_drag(const Point2 &p_end_pos) {
 	if (root->is_canvas_transform_override_enabled()) {
 		Transform2D xform = root->get_canvas_transform_override();
 		RS::get_singleton()->canvas_item_set_transform(sel_drag_ci, xform);
+		RS::get_singleton()->canvas_item_reset_physics_interpolation(sel_drag_ci);
 
 		selection_drawing.position = xform.affine_inverse().xform(selection_drag_area.position);
 		selection_drawing.size = xform.affine_inverse().xform(p_end_pos);
 		thickness = MAX(1, Math::ceil(1 / view_2d_zoom));
 	} else {
 		RS::get_singleton()->canvas_item_set_transform(sel_drag_ci, Transform2D());
+		RS::get_singleton()->canvas_item_reset_physics_interpolation(sel_drag_ci);
 
 		selection_drawing.position = selection_drag_area.position;
 		selection_drawing.size = p_end_pos;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/104088

| Before (Notice selection box delay) | After |
| ------------- | ------------- |
|  <video src=https://github.com/user-attachments/assets/4abce6b4-584d-4618-b819-092f577ea92d></video> | <video src=https://github.com/user-attachments/assets/1eb8547a-42d0-4ea4-9034-9b018fdb0964></video> |


