### PR TITLE
Fix AudioEffectPitchShift issues when `pitch_scale` is set to 1

### DIFF
--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -288,6 +288,9 @@ void SMBPitchShift::smbFft(float *fftBuffer, long fftFrameSize, long sign)
 void AudioEffectPitchShiftInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
 	// Avoid distortion by skipping processing if pitch_scale is 1.0.
 	if (Math::is_equal_approx(base->pitch_scale, 1.0f)) {
+		for (int i = 0; i < p_frame_count; i++) {
+			p_dst_frames[i] = p_src_frames[i];
+		}
 		return;
 	}
 


### PR DESCRIPTION
Fixes #104072 and fixes #104036

Issue was originally introduced in https://github.com/godotengine/godot/pull/97109

Now the audio data is copied directly when pitch_scale is 1, so audio is correctly passed through the effect without modification.

(Also, let me know if it would be better to use memcpy - I used it at first but decided against it since it seemed like this was the preferred way to copy data).

Fixes #104036 (for github to hopefully associate it)