### PR TITLE
Fix `@export_multiline` for dictionaries

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4527,6 +4527,15 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 
 		if (export_type.builtin_type == Variant::DICTIONARY) {
 			variable->export_info.type = Variant::DICTIONARY;
+		} else if (is_dict) {
+			DataType value_type = export_type.get_container_element_type_or_variant(0);
+
+			// Ensure that the dictionary value type is string for typed dictionaries with `@export_multiline`
+			if (value_type.builtin_type != Variant::STRING) {
+				Vector<Variant::Type> expected_types = { Variant::STRING, Variant::DICTIONARY };
+				push_error(_get_annotation_error_string(p_annotation->name, expected_types, variable->get_datatype()), p_annotation);
+				return false;
+			}
 		}
 	} else if (p_annotation->name == SNAME("@export")) {
 		use_default_variable_type_check = false;
@@ -4603,90 +4612,6 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 			push_error(vformat(R"(Node export is only supported in Node-derived classes, but the current class inherits "%s".)", p_class->base_type.to_string()), p_annotation);
 			return false;
 		}
-
-		if (is_dict) {
-			String key_prefix = itos(variable->export_info.type);
-			if (variable->export_info.hint) {
-				key_prefix += "/" + itos(variable->export_info.hint);
-			}
-			key_prefix += ":" + variable->export_info.hint_string;
-
-			// Now parse value.
-			export_type = export_type.get_container_element_type(0);
-
-			if (export_type.is_variant() || export_type.has_no_type()) {
-				export_type.kind = GDScriptParser::DataType::BUILTIN;
-			}
-			switch (export_type.kind) {
-				case GDScriptParser::DataType::BUILTIN:
-					variable->export_info.type = export_type.builtin_type;
-					variable->export_info.hint = PROPERTY_HINT_NONE;
-					variable->export_info.hint_string = String();
-					break;
-				case GDScriptParser::DataType::NATIVE:
-				case GDScriptParser::DataType::SCRIPT:
-				case GDScriptParser::DataType::CLASS: {
-					const StringName class_name = _find_narrowest_native_or_global_class(export_type);
-					if (ClassDB::is_parent_class(export_type.native_type, SNAME("Resource"))) {
-						variable->export_info.type = Variant::OBJECT;
-						variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
-						variable->export_info.hint_string = class_name;
-					} else if (ClassDB::is_parent_class(export_type.native_type, SNAME("Node"))) {
-						variable->export_info.type = Variant::OBJECT;
-						variable->export_info.hint = PROPERTY_HINT_NODE_TYPE;
-						variable->export_info.hint_string = class_name;
-					} else {
-						push_error(R"(Export type can only be built-in, a resource, a node, or an enum.)", p_annotation);
-						return false;
-					}
-				} break;
-				case GDScriptParser::DataType::ENUM: {
-					if (export_type.is_meta_type) {
-						variable->export_info.type = Variant::DICTIONARY;
-					} else {
-						variable->export_info.type = Variant::INT;
-						variable->export_info.hint = PROPERTY_HINT_ENUM;
-
-						String enum_hint_string;
-						bool first = true;
-						for (const KeyValue<StringName, int64_t> &E : export_type.enum_values) {
-							if (!first) {
-								enum_hint_string += ",";
-							} else {
-								first = false;
-							}
-							enum_hint_string += E.key.operator String().capitalize().xml_escape();
-							enum_hint_string += ":";
-							enum_hint_string += String::num_int64(E.value).xml_escape();
-						}
-
-						variable->export_info.hint_string = enum_hint_string;
-						variable->export_info.usage |= PROPERTY_USAGE_CLASS_IS_ENUM;
-						variable->export_info.class_name = String(export_type.native_type).replace("::", ".");
-					}
-				} break;
-				default:
-					push_error(R"(Export type can only be built-in, a resource, a node, or an enum.)", p_annotation);
-					return false;
-			}
-
-			if (variable->export_info.hint == PROPERTY_HINT_NODE_TYPE && !ClassDB::is_parent_class(p_class->base_type.native_type, SNAME("Node"))) {
-				push_error(vformat(R"(Node export is only supported in Node-derived classes, but the current class inherits "%s".)", p_class->base_type.to_string()), p_annotation);
-				return false;
-			}
-
-			String value_prefix = itos(variable->export_info.type);
-			if (variable->export_info.hint) {
-				value_prefix += "/" + itos(variable->export_info.hint);
-			}
-			value_prefix += ":" + variable->export_info.hint_string;
-
-			variable->export_info.type = Variant::DICTIONARY;
-			variable->export_info.hint = PROPERTY_HINT_TYPE_STRING;
-			variable->export_info.hint_string = key_prefix + ";" + value_prefix;
-			variable->export_info.usage = PROPERTY_USAGE_DEFAULT;
-			variable->export_info.class_name = StringName();
-		}
 	} else if (p_annotation->name == SNAME("@export_enum")) {
 		use_default_variable_type_check = false;
 
@@ -4725,6 +4650,95 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 		variable->export_info.type = original_export_type_builtin;
 		variable->export_info.hint = PROPERTY_HINT_TYPE_STRING;
 		variable->export_info.hint_string = hint_prefix + ":" + variable->export_info.hint_string;
+		variable->export_info.usage = PROPERTY_USAGE_DEFAULT;
+		variable->export_info.class_name = StringName();
+	}
+
+	if (is_dict) {
+		bool is_multiline = variable->export_info.hint == PROPERTY_HINT_MULTILINE_TEXT;
+
+		String key_prefix = itos(variable->export_info.type);
+		if (!is_multiline && variable->export_info.hint) {
+			key_prefix += "/" + itos(variable->export_info.hint);
+		}
+		key_prefix += ":" + variable->export_info.hint_string;
+
+		// Now parse value.
+		export_type = export_type.get_container_element_type(0);
+
+		if (export_type.is_variant() || export_type.has_no_type()) {
+			export_type.kind = GDScriptParser::DataType::BUILTIN;
+		}
+		switch (export_type.kind) {
+			case GDScriptParser::DataType::BUILTIN:
+				variable->export_info.type = export_type.builtin_type;
+				variable->export_info.hint = PROPERTY_HINT_NONE;
+				variable->export_info.hint_string = String();
+				break;
+			case GDScriptParser::DataType::NATIVE:
+			case GDScriptParser::DataType::SCRIPT:
+			case GDScriptParser::DataType::CLASS: {
+				const StringName class_name = _find_narrowest_native_or_global_class(export_type);
+				if (ClassDB::is_parent_class(export_type.native_type, SNAME("Resource"))) {
+					variable->export_info.type = Variant::OBJECT;
+					variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
+					variable->export_info.hint_string = class_name;
+				} else if (ClassDB::is_parent_class(export_type.native_type, SNAME("Node"))) {
+					variable->export_info.type = Variant::OBJECT;
+					variable->export_info.hint = PROPERTY_HINT_NODE_TYPE;
+					variable->export_info.hint_string = class_name;
+				} else {
+					push_error(R"(Export type can only be built-in, a resource, a node, or an enum.)", p_annotation);
+					return false;
+				}
+			} break;
+			case GDScriptParser::DataType::ENUM: {
+				if (export_type.is_meta_type) {
+					variable->export_info.type = Variant::DICTIONARY;
+				} else {
+					variable->export_info.type = Variant::INT;
+					variable->export_info.hint = PROPERTY_HINT_ENUM;
+
+					String enum_hint_string;
+					bool first = true;
+					for (const KeyValue<StringName, int64_t> &E : export_type.enum_values) {
+						if (!first) {
+							enum_hint_string += ",";
+						} else {
+							first = false;
+						}
+						enum_hint_string += E.key.operator String().capitalize().xml_escape();
+						enum_hint_string += ":";
+						enum_hint_string += String::num_int64(E.value).xml_escape();
+					}
+
+					variable->export_info.hint_string = enum_hint_string;
+					variable->export_info.usage |= PROPERTY_USAGE_CLASS_IS_ENUM;
+					variable->export_info.class_name = String(export_type.native_type).replace("::", ".");
+				}
+			} break;
+			default:
+				push_error(R"(Export type can only be built-in, a resource, a node, or an enum.)", p_annotation);
+				return false;
+		}
+
+		if (variable->export_info.hint == PROPERTY_HINT_NODE_TYPE && !ClassDB::is_parent_class(p_class->base_type.native_type, SNAME("Node"))) {
+			push_error(vformat(R"(Node export is only supported in Node-derived classes, but the current class inherits "%s".)", p_class->base_type.to_string()), p_annotation);
+			return false;
+		}
+
+		String value_prefix = itos(variable->export_info.type);
+		if (is_multiline) {
+			variable->export_info.hint = PROPERTY_HINT_MULTILINE_TEXT;
+		}
+		if (variable->export_info.hint) {
+			value_prefix += "/" + itos(variable->export_info.hint);
+		}
+		value_prefix += ":" + variable->export_info.hint_string;
+
+		variable->export_info.type = Variant::DICTIONARY;
+		variable->export_info.hint = PROPERTY_HINT_TYPE_STRING;
+		variable->export_info.hint_string = key_prefix + ";" + value_prefix;
 		variable->export_info.usage = PROPERTY_USAGE_DEFAULT;
 		variable->export_info.class_name = StringName();
 	}


### PR DESCRIPTION
Currently dictionaries do not work correctly with `@export_multiline`. Typed dictionaries will display as an object representation which is uneditable. Untyped dictionaries will work normally, but not have the multiline string input for the value.

This PR shifts the typed dictionary logic out of the `@export` branch so it applies to all annotations, adds a check to disallow dictionaries with non-String values with `@export_multiline`, makes the multiline hint apply to dictionary values rather than keys, and adds logic to infer the dictionary value type to be String for untyped dictionaries annotated with `@export_multiline`.

Areas looking for feedback to improve this PR:
* Currently the inferred type for untyped dictionaries is `Dictionary[String, String]`. Ideally it would probably be `Dictionary[Variant, String]` given the dictionary is untyped, but I haven't been able to achieve this.
* Unsure if moving the typed dictionary logic out of the `@export` branch will have unintended consequences, so any input on this is welcome.
* Currently I am overriding the hint on the value type with the multiline hint. As far as I can tell the value type shouldn't have a hint if it is a string, so this should be fine, but happy to try something else if this is wrong.

Note: It seems like some of the other annotations also display odd behaviours with typed dictionaries. `@export_range` for instance has a different bug of displaying an unusable range input when applied to `Dictionary[float, float]`, and has the issue of the hint being applied to the key after these changes. Potentially the proper fix is to just always apply the hints to the values for typed dictionaries? Potentially some of the logic I've extracted needs to stay back under the `@export` annotation, and there may need to be some more special handling in other places.

This is a draft PR and I intend to keep working on it to try and improve things, I'm putting it up early to hopefully get some feedback.

Fixes #103905 