### PR TITLE
Additional error handling when synchronizing more than 64 properties at once

### DIFF
--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -428,7 +428,7 @@ List<Variant> MultiplayerSynchronizer::get_delta_state(uint64_t p_cur_usec, uint
 			continue;
 		}
 
-		ERR_BREAK_MSG(i >= (sizeof(uint64_t) * 8), "Cannot process more replicated properties.");
+		ERR_BREAK_MSG(i >= static_cast<int>(sizeof(uint64_t) * 8), "Cannot process more replicated properties."); 
 		out.push_back(w.value);
 		r_indexes |= 1ULL << i;
 	}
@@ -441,7 +441,7 @@ List<NodePath> MultiplayerSynchronizer::get_delta_properties(uint64_t p_indexes)
 	const List<NodePath> watch_props = replication_config->get_watch_properties();
 	int idx = 0;
 	for (const NodePath &prop : watch_props) {
-		ERR_BREAK_MSG(idx >= (sizeof(uint64_t) * 8), "Cannot process more replicated properties.");
+		ERR_BREAK_MSG(idx >= static_cast<int>(sizeof(uint64_t) * 8), "Cannot process more replicated properties.");
 		if ((p_indexes & (1ULL << idx++)) == 0) {
 			continue;
 		}

--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -427,6 +427,8 @@ List<Variant> MultiplayerSynchronizer::get_delta_state(uint64_t p_cur_usec, uint
 		if (w.last_change_usec <= p_last_usec) {
 			continue;
 		}
+
+		ERR_BREAK_MSG(i >= (sizeof(uint64_t) * 8), "Cannot process more replicated properties.");
 		out.push_back(w.value);
 		r_indexes |= 1ULL << i;
 	}
@@ -439,6 +441,7 @@ List<NodePath> MultiplayerSynchronizer::get_delta_properties(uint64_t p_indexes)
 	const List<NodePath> watch_props = replication_config->get_watch_properties();
 	int idx = 0;
 	for (const NodePath &prop : watch_props) {
+		ERR_BREAK_MSG(idx >= (sizeof(uint64_t) * 8), "Cannot process more replicated properties.");
 		if ((p_indexes & (1ULL << idx++)) == 0) {
 			continue;
 		}

--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -428,7 +428,7 @@ List<Variant> MultiplayerSynchronizer::get_delta_state(uint64_t p_cur_usec, uint
 			continue;
 		}
 
-		ERR_BREAK_MSG(i >= static_cast<int>(sizeof(uint64_t) * 8), "Cannot process more replicated properties."); 
+		ERR_BREAK_MSG(i >= static_cast<int>(sizeof(uint64_t) * 8), "Cannot process more replicated properties.");
 		out.push_back(w.value);
 		r_indexes |= 1ULL << i;
 	}

--- a/modules/multiplayer/scene_replication_config.cpp
+++ b/modules/multiplayer/scene_replication_config.cpp
@@ -239,6 +239,7 @@ void SceneReplicationConfig::_update() {
 				sync_props.push_back(prop.name);
 				break;
 			case REPLICATION_MODE_ON_CHANGE:
+				ERR_BREAK_MSG(watch_props.size() >= (sizeof(uint64_t) * 8), "Reached limit of 64 properties with 'REPLICATION_MODE_ON_CHANGE' mode per single object. Ignoring this property.");
 				watch_props.push_back(prop.name);
 				break;
 			default:

--- a/modules/multiplayer/scene_replication_config.cpp
+++ b/modules/multiplayer/scene_replication_config.cpp
@@ -239,7 +239,7 @@ void SceneReplicationConfig::_update() {
 				sync_props.push_back(prop.name);
 				break;
 			case REPLICATION_MODE_ON_CHANGE:
-				ERR_BREAK_MSG(watch_props.size() >= (sizeof(uint64_t) * 8), "Reached limit of 64 properties with 'REPLICATION_MODE_ON_CHANGE' mode per single object. Ignoring this property.");
+				ERR_BREAK_MSG(watch_props.size() >= static_cast<int>(sizeof(uint64_t) * 8), "Reached limit of 64 properties with 'REPLICATION_MODE_ON_CHANGE' mode per single object. Ignoring this property.");
 				watch_props.push_back(prop.name);
 				break;
 			default:


### PR DESCRIPTION
Prevent hitting undefined behavior with bit shift during properties replication. Also print additional errors.

Described here:  [issue](https://github.com/godotengine/godot/issues/103938) 

Edit: Link updated, wrong issue linked.