### PR TITLE
Add support for sending audio sources to multiple buses

### DIFF
--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -75,6 +75,10 @@
 		<member name="audio_bus_override" type="bool" setter="set_audio_bus_override" getter="is_overriding_audio_bus" default="false">
 			If [code]true[/code], the area's audio bus overrides the default audio bus.
 		</member>
+		<member name="audio_sends" type="Dictionary" setter="set_audio_sends" getter="get_audio_sends" default="{}">
+			The names of the area's audio sends.
+			[b]Note:[/b] Has no effect when using the [code]sample[/code] playback type.
+		</member>
 		<member name="gravity" type="float" setter="set_gravity" getter="get_gravity" default="980.0">
 			The area's gravity intensity (in pixels per second squared). This value multiplies the gravity direction. This is useful to alter the force of gravity without altering its direction.
 		</member>

--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -398,7 +398,7 @@
 		<constant name="PLAYBACK_TYPE_SAMPLE" value="2" enum="PlaybackType" experimental="">
 			Force the playback to be considered as a sample. This can provide lower latency and more stable playback (with less risk of audio crackling), at the cost of having less flexibility.
 			[b]Note:[/b] Only currently supported on the web platform.
-			[b]Note:[/b] [AudioEffect]s are not supported when playback is considered as a sample.
+			[b]Note:[/b] [AudioEffect]s and bus sends are not supported when playback is considered as a sample.
 		</constant>
 		<constant name="PLAYBACK_TYPE_MAX" value="3" enum="PlaybackType" experimental="">
 			Represents the size of the [enum PlaybackType] enum.

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -63,7 +63,7 @@
 			If [code]true[/code], this node calls [method play] when entering the tree.
 		</member>
 		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="&amp;&quot;Master&quot;">
-			The target bus name. All sounds from this node will be playing on this bus.
+			The target bus name. All sounds from this node will be playing on this bus. See also [member sends].
 			[b]Note:[/b] At runtime, if no bus with the given name exists, all sounds will fall back on [code]"Master"[/code]. See also [method AudioServer.get_bus_name].
 		</member>
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
@@ -81,6 +81,10 @@
 		<member name="playing" type="bool" setter="set_playing" getter="is_playing" default="false">
 			If [code]true[/code], this node is playing sounds. Setting this property has the same effect as [method play] and [method stop].
 		</member>
+		<member name="sends" type="Dictionary" setter="set_sends" getter="get_sends" default="{}">
+			The target sends' names. All sounds from this node will be sent to these buses in addition to the node's primary output bus. See also [member bus].
+			[b]Note:[/b] Has no effect when using the [code]sample[/code] playback type.
+		</member>
 		<member name="stream" type="AudioStream" setter="set_stream" getter="get_stream">
 			The [AudioStream] resource to be played. Setting this property stops all currently playing sounds. If left empty, the [AudioStreamPlayer] does not work.
 		</member>
@@ -89,7 +93,7 @@
 			[b]Note:[/b] This property is automatically changed when exiting or entering the tree, or this node is paused (see [member Node.process_mode]).
 		</member>
 		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" default="0.0">
-			Volume of sound, in decibels. This is an offset of the [member stream]'s volume.
+			Volume of sound, in decibels. This is an offset of the [member stream]'s volume. The gain is applied pre-send, so it also affects the volume of [member sends].
 			[b]Note:[/b] To convert between decibel and linear energy (like most volume sliders do), use [member volume_linear], or [method @GlobalScope.db_to_linear] and [method @GlobalScope.linear_to_db].
 		</member>
 		<member name="volume_linear" type="float" setter="set_volume_linear" getter="get_volume_linear">

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -63,7 +63,7 @@
 			If [code]true[/code], audio plays when added to scene tree.
 		</member>
 		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="&amp;&quot;Master&quot;">
-			Bus on which this audio is playing.
+			Bus on which this audio is playing. See also [member sends].
 			[b]Note:[/b] When setting this property, keep in mind that no validation is performed to see if the given name matches an existing bus. This is because audio bus layouts might be loaded after this property is set. If this given name can't be resolved at runtime, it will fall back to [code]"Master"[/code].
 		</member>
 		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" default="2000.0">
@@ -84,6 +84,10 @@
 		<member name="playing" type="bool" setter="set_playing" getter="is_playing" default="false">
 			If [code]true[/code], audio is playing or is queued to be played (see [method play]).
 		</member>
+		<member name="sends" type="Dictionary" setter="set_sends" getter="get_sends" default="{}">
+			The sends on which this audio plays in addition to its primary bus. See also [member bus].
+			[b]Note:[/b] Has no effect when using the [code]sample[/code] playback type.
+		</member>
 		<member name="stream" type="AudioStream" setter="set_stream" getter="get_stream">
 			The [AudioStream] object to be played.
 		</member>
@@ -91,7 +95,7 @@
 			If [code]true[/code], the playback is paused. You can resume it by setting [member stream_paused] to [code]false[/code].
 		</member>
 		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" default="0.0">
-			Base volume before attenuation, in decibels.
+			Base volume before attenuation, in decibels. The gain is applied pre-send, so it also affects the volume of [member sends].
 		</member>
 		<member name="volume_linear" type="float" setter="set_volume_linear" getter="get_volume_linear">
 			Base volume before attenuation, as a linear value.

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -69,7 +69,7 @@
 			If [code]true[/code], audio plays when the AudioStreamPlayer3D node is added to scene tree.
 		</member>
 		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="&amp;&quot;Master&quot;">
-			The bus on which this audio is playing.
+			The bus on which this audio is playing. See also [member sends].
 			[b]Note:[/b] When setting this property, keep in mind that no validation is performed to see if the given name matches an existing bus. This is because audio bus layouts might be loaded after this property is set. If this given name can't be resolved at runtime, it will fall back to [code]"Master"[/code].
 		</member>
 		<member name="doppler_tracking" type="int" setter="set_doppler_tracking" getter="get_doppler_tracking" enum="AudioStreamPlayer3D.DopplerTracking" default="0">
@@ -107,6 +107,10 @@
 		<member name="playing" type="bool" setter="set_playing" getter="is_playing" default="false">
 			If [code]true[/code], audio is playing or is queued to be played (see [method play]).
 		</member>
+		<member name="sends" type="Dictionary" setter="set_sends" getter="get_sends" default="{}">
+			The sends on which this audio plays in addition to its primary bus. See also [member bus].
+			[b]Note:[/b] Has no effect when using the [code]sample[/code] playback type.
+		</member>
 		<member name="stream" type="AudioStream" setter="set_stream" getter="get_stream">
 			The [AudioStream] resource to be played.
 		</member>
@@ -117,7 +121,7 @@
 			The factor for the attenuation effect. Higher values make the sound audible over a larger distance.
 		</member>
 		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" default="0.0">
-			The base sound level before attenuation, in decibels.
+			The base sound level before attenuation, in decibels. The gain is applied pre-send, so it also affects the volume of [member sends].
 		</member>
 		<member name="volume_linear" type="float" setter="set_volume_linear" getter="get_volume_linear">
 			The base sound level before attenuation, as a linear value.

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/variant/typed_dictionary.h"
 #include "scene/2d/node_2d.h"
 #include "servers/audio_server.h"
 
@@ -69,7 +70,7 @@ private:
 	void _set_playing(bool p_enable);
 	bool _is_active() const;
 
-	StringName _get_actual_bus();
+	TypedDictionary<StringName, float> _get_actual_buses();
 	void _update_panning();
 
 	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer2D *>(self)->force_update_panning = true; }
@@ -117,6 +118,9 @@ public:
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;
+
+	void set_sends(const TypedDictionary<StringName, float> &p_sends);
+	TypedDictionary<StringName, float> get_sends() const;
 
 	void set_autoplay(bool p_enable);
 	bool is_autoplay_enabled() const;

--- a/scene/2d/physics/area_2d.h
+++ b/scene/2d/physics/area_2d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/templates/vset.h"
+#include "core/variant/typed_dictionary.h"
 #include "scene/2d/physics/collision_object_2d.h"
 
 class Area2D : public CollisionObject2D {
@@ -130,6 +131,7 @@ private:
 
 	bool audio_bus_override = false;
 	StringName audio_bus;
+	TypedDictionary<StringName, float> audio_sends;
 
 protected:
 	static void _bind_methods();
@@ -191,6 +193,9 @@ public:
 
 	void set_audio_bus_name(const StringName &p_audio_bus);
 	StringName get_audio_bus_name() const;
+
+	void set_audio_sends(const TypedDictionary<StringName, float> &p_audio_sends);
+	TypedDictionary<StringName, float> get_audio_sends() const;
 
 	Area2D();
 	~Area2D();

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/variant/typed_dictionary.h"
 #include "scene/3d/node_3d.h"
 #include "servers/audio_server.h"
 
@@ -71,6 +72,8 @@ private:
 	SafeNumeric<float> setplay{ -1.0 };
 	Ref<AudioStreamPlayback> setplayback;
 
+	Vector<AudioFrame> volume_vector;
+
 	AttenuationModel attenuation_model = ATTENUATION_INVERSE_DISTANCE;
 	float unit_size = 10.0;
 	float max_db = 3.0;
@@ -91,11 +94,11 @@ private:
 
 	void _set_playing(bool p_enable);
 	bool _is_active() const;
-	StringName _get_actual_bus();
+	TypedDictionary<StringName, float> _get_actual_buses();
 #ifndef PHYSICS_3D_DISABLED
 	Area3D *_get_overriding_area();
 #endif // PHYSICS_3D_DISABLED
-	Vector<AudioFrame> _update_panning();
+	void _update_panning();
 
 	uint32_t area_mask = 1;
 
@@ -110,7 +113,6 @@ private:
 	float linear_attenuation = 0;
 
 	float max_distance = 0.0;
-	bool was_further_than_max_distance_last_frame = false;
 
 	Ref<VelocityTracker3D> velocity_tracker;
 
@@ -162,6 +164,9 @@ public:
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;
+
+	void set_sends(const TypedDictionary<StringName, float> &p_sends);
+	TypedDictionary<StringName, float> get_sends() const;
 
 	void set_max_polyphony(int p_max_polyphony);
 	int get_max_polyphony() const;

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/variant/typed_dictionary.h"
 #include "scene/main/node.h"
 #include "servers/audio_server.h"
 
@@ -57,6 +58,7 @@ private:
 	bool _is_active() const;
 
 	Vector<AudioFrame> _get_volume_vector();
+	HashMap<StringName, Vector<AudioFrame>> _get_all_bus_volume_vectors();
 
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
@@ -96,6 +98,9 @@ public:
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;
+
+	TypedDictionary<StringName, float> get_sends() const;
+	void set_sends(const TypedDictionary<StringName, float> &p_sends);
 
 	void set_autoplay(bool p_enable);
 	bool is_autoplay_enabled() const;

--- a/scene/audio/audio_stream_player_internal.h
+++ b/scene/audio/audio_stream_player_internal.h
@@ -32,6 +32,7 @@
 
 #include "core/object/ref_counted.h"
 #include "core/templates/safe_refcount.h"
+#include "core/variant/typed_dictionary.h"
 #include "servers/audio_server.h"
 
 class AudioStream;
@@ -75,6 +76,7 @@ public:
 	float volume_db = 0.0;
 	bool autoplay = false;
 	StringName bus;
+	TypedDictionary<StringName, float> sends;
 	int max_polyphony = 1;
 
 	void process();
@@ -91,6 +93,9 @@ public:
 	void set_max_polyphony(int p_max_polyphony);
 
 	StringName get_bus() const;
+	TypedDictionary<StringName, float> get_sends() const;
+	TypedDictionary<StringName, float> get_all_buses() const;
+	HashMap<StringName, Vector<AudioFrame>> get_all_bus_volume_vectors(const TypedDictionary<StringName, float> p_buses, const Vector<AudioFrame> p_volume_vector);
 
 	Ref<AudioStreamPlayback> play_basic();
 	void seek(float p_seconds);


### PR DESCRIPTION
This PR implements a `sends` parameter on `AudioStreamPlayer`, `AudioStreamPlayer2D`, `AudioStreamPlayer3D`, and `Area2D`, allowing these types to send their audio stream to more than one bus simultaneously.

Resolves https://github.com/godotengine/godot-proposals/issues/1836.
Supersedes #60316.

### Design

The parameter itself is a `Dictionary[StringName, float]`, where the key is the name of the bus, and the value is the send's gain.
This allows different buses to receive a node's stream at varying volume levels.

It is presented using a normal `Dictionary` inspector property, with its hint string configured to show an option picker for the name and a range slider for the gain.

The existing `bus` property keeps its purpose as the primary bus: while the `sends` dictionary can be empty, `bus` must be specified or it will default to "Master" (even if there are sends present).

All sends respect their node's panning and gain.

Sends are not overridden when an `AudioStreamPlayer2D`/`3D` enters an `Area2D`/`3D` with `audio_bus_override` enabled; in these cases, only the bus specified by `bus` will be overridden.

### Limitations

The most notable limitation is that sample playback is not supported in this current implementation. If using sample playback, audio will only be sent to the primary bus as specified by `bus`.

Additionally, sends on `Area3D` have not been implemented due to complexity with the already-existing reverb send parameter.

These might be good to follow up with in the future, although I don't believe they are central enough to preclude this feature.

### Compatibility

All preexisting outward API is unmodified, and care has been taken to preserve existing behavior, so this should not break compatibility.