### PR TITLE
Fix error when packing node in tree with children

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -716,8 +716,13 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 	// given the complexity of this process, an attempt will be made to properly
 	// document it. if you fail to understand something, please ask!
 
-	//discard nodes that do not belong to be processed
-	if (p_node != p_owner && p_node->get_owner() != p_owner && !p_owner->is_editable_instance(p_node->get_owner())) {
+	// discard nodes that are not owned by scene owner
+	if (p_node != p_owner && p_node->get_owner() != p_owner) {
+		return OK;
+	}
+
+	// discard nodes that belong to non-editable subscenes
+	if (p_node != p_owner && p_node->get_owner() && p_owner->is_ancestor_of(p_node->get_owner()) && !p_owner->is_editable_instance(p_node->get_owner())) {
 		return OK;
 	}
 
@@ -1034,7 +1039,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 
 Error SceneState::_parse_connections(Node *p_owner, Node *p_node, HashMap<StringName, int> &name_map, HashMap<Variant, int, VariantHasher, VariantComparator> &variant_map, HashMap<Node *, int> &node_map, HashMap<Node *, int> &nodepath_map) {
 	// Ignore nodes that are within a scene instance.
-	if (p_node != p_owner && p_node->get_owner() && p_node->get_owner() != p_owner && !p_owner->is_editable_instance(p_node->get_owner())) {
+	if (p_node != p_owner && p_node->get_owner() && p_node->get_owner() != p_owner && p_owner->is_ancestor_of(p_node->get_owner()) && !p_owner->is_editable_instance(p_node->get_owner())) {
 		return OK;
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
**EDIT: Not sure if this always works actually, I need to do some more testing**

---

fixes #104074

When packing a node from code that has any child, I got this error unless I first remove the node I'm packing from the scene tree.
```
E 0:00:00:284   root.gd:6 @ _ready(): Condition "!is_ancestor_of(p_node)" is true. Returning: false
  <C++ Source>  scene/main/node.cpp:2622 @ is_editable_instance()
```

 I think it's become a normal practice to just remove a node from the tree before packing it, but I don't think that was the original intention?