### PR TITLE
Clarify `XRController3D` `get_input` name corresponds to actions in the action set

### DIFF
--- a/doc/classes/XRController3D.xml
+++ b/doc/classes/XRController3D.xml
@@ -7,7 +7,7 @@
 		This is a helper 3D node that is linked to the tracking of controllers. It also offers several handy passthroughs to the state of buttons and such on the controllers.
 		Controllers are linked by their ID. You can create controller nodes before the controllers are available. If your game always uses two controllers (one for each hand), you can predefine the controllers with ID 1 and 2; they will become active as soon as the controllers are identified. If you expect additional controllers to be used, you should react to the signals and add XRController3D nodes to your scene.
 		The position of the controller node is automatically updated by the [XRServer]. This makes this node ideal to add child nodes to visualize the controller.
-		As many XR runtimes now use a configurable action map all inputs are named.
+		The current [XRInterface] defines the names of inputs. In the case of OpenXR, these are the names of actions in the current action set from the OpenXR action map.
 	</description>
 	<tutorials>
 		<link title="XR documentation index">$DOCS_URL/tutorials/xr/index.html</link>
@@ -18,6 +18,7 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Returns a numeric value for the input with the given [param name]. This is used for triggers and grip sensors.
+				[b]Note:[/b] The current [XRInterface] defines the [param name] for each input. In the case of OpenXR, these are the names of actions in the current action set.
 			</description>
 		</method>
 		<method name="get_input" qualifiers="const">
@@ -25,6 +26,7 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Returns a [Variant] for the input with the given [param name]. This works for any input type, the variant will be typed according to the actions configuration.
+				[b]Note:[/b] The current [XRInterface] defines the [param name] for each input. In the case of OpenXR, these are the names of actions in the current action set.
 			</description>
 		</method>
 		<method name="get_tracker_hand" qualifiers="const">
@@ -38,6 +40,7 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Returns a [Vector2] for the input with the given [param name]. This is used for thumbsticks and thumbpads found on many controllers.
+				[b]Note:[/b] The current [XRInterface] defines the [param name] for each input. In the case of OpenXR, these are the names of actions in the current action set.
 			</description>
 		</method>
 		<method name="is_button_pressed" qualifiers="const">
@@ -45,6 +48,7 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Returns [code]true[/code] if the button with the given [param name] is pressed.
+				[b]Note:[/b] The current [XRInterface] defines the [param name] for each input. In the case of OpenXR, these are the names of actions in the current action set.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Clarify that the parameter `name` for the methods `get_input`, `get_float`, `get_vector2`, and `is_button_pressed` corresponds to the internal name of an action in the current action map. Current docs call it the `name` of an input.