### PR TITLE
[DisplayServer] Implement `get_accent_color` on Linux.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -195,7 +195,7 @@
 			<return type="Color" />
 			<description>
 				Returns OS theme accent color. Returns [code]Color(0, 0, 0, 0)[/code], if accent color is unknown.
-				[b]Note:[/b] This method is implemented on macOS, Windows, and Android.
+				[b]Note:[/b] This method is implemented on macOS, Windows, Android, and Linux (X11/Wayland).
 			</description>
 		</method>
 		<method name="get_base_color" qualifiers="const">

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -44,9 +44,14 @@ class FreeDesktopPortalDesktop : public Object {
 private:
 	bool unsupported = false;
 
-	static bool try_parse_variant(DBusMessage *p_reply_message, int p_type, void *r_value);
+	enum ReadVariantType {
+		VAR_TYPE_UINT32, // u
+		VAR_TYPE_COLOR, // (ddd)
+	};
+
+	static bool try_parse_variant(DBusMessage *p_reply_message, ReadVariantType p_type, void *r_value);
 	// Read a setting from org.freekdesktop.portal.Settings
-	bool read_setting(const char *p_namespace, const char *p_key, int p_type, void *r_value);
+	bool read_setting(const char *p_namespace, const char *p_key, ReadVariantType p_type, void *r_value);
 
 	static void append_dbus_string(DBusMessageIter *p_iter, const String &p_string);
 	static void append_dbus_dict_options(DBusMessageIter *p_iter, const TypedArray<Dictionary> &p_options, HashMap<String, String> &r_ids);
@@ -108,6 +113,7 @@ public:
 	// 1: Prefer dark appearance.
 	// 2: Prefer light appearance.
 	uint32_t get_appearance_color_scheme();
+	Color get_appearance_accent_color();
 	void set_system_theme_change_callback(const Callable &p_system_theme_changed) {
 		system_theme_changed = p_system_theme_changed;
 	}

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -302,6 +302,10 @@ bool DisplayServerWayland::is_dark_mode() const {
 	}
 }
 
+Color DisplayServerWayland::get_accent_color() const {
+	return portal_desktop->get_appearance_accent_color();
+}
+
 void DisplayServerWayland::set_system_theme_change_callback(const Callable &p_callable) {
 	portal_desktop->set_system_theme_change_callback(p_callable);
 }

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -184,6 +184,7 @@ public:
 #ifdef DBUS_ENABLED
 	virtual bool is_dark_mode_supported() const override;
 	virtual bool is_dark_mode() const override;
+	virtual Color get_accent_color() const override;
 	virtual void set_system_theme_change_callback(const Callable &p_callable) override;
 
 	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, WindowID p_window_id) override;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -398,6 +398,10 @@ bool DisplayServerX11::is_dark_mode() const {
 	}
 }
 
+Color DisplayServerX11::get_accent_color() const {
+	return portal_desktop->get_appearance_accent_color();
+}
+
 void DisplayServerX11::set_system_theme_change_callback(const Callable &p_callable) {
 	portal_desktop->set_system_theme_change_callback(p_callable);
 }

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -419,6 +419,7 @@ public:
 #if defined(DBUS_ENABLED)
 	virtual bool is_dark_mode_supported() const override;
 	virtual bool is_dark_mode() const override;
+	virtual Color get_accent_color() const override;
 	virtual void set_system_theme_change_callback(const Callable &p_callable) override;
 
 	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, WindowID p_window_id) override;


### PR DESCRIPTION
Implements and closes https://github.com/godotengine/godot-proposals/issues/11980

Not sure if it's universally supported by all DEs, but seems to work fine on Fedora 41.

https://github.com/user-attachments/assets/c7029041-af93-44d8-9e51-8528fa2fe2f8
