### PR TITLE
Fix "Unicode parsing error" spam when opening editor.

### DIFF
--- a/core/os/keyboard.cpp
+++ b/core/os/keyboard.cpp
@@ -387,6 +387,10 @@ String keycode_get_string(Key p_code) {
 	}
 
 	p_code &= KeyModifierMask::CODE_MASK;
+	if ((char32_t)p_code == 0) {
+		// The key was just a modifier without any code.
+		return codestr;
+	}
 
 	const _KeyCodeText *kct = &_keycodes[0];
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/104098.

Arguably, this is not a complete fix of the underlying issue because `+` will be needlessly inserted. But this is equivalent to the previous behaviour before https://github.com/godotengine/godot/issues/104098.
I think a follow-up PR might want to fix the formatting to remove the `+`.