### PR TITLE
Omit `+` when converting just modifiers to keycodes

### DIFF
--- a/core/os/keyboard.cpp
+++ b/core/os/keyboard.cpp
@@ -360,35 +360,38 @@ bool keycode_has_unicode(Key p_keycode) {
 }
 
 String keycode_get_string(Key p_code) {
+	ERR_FAIL_COND_V_MSG(p_code == Key::NONE, "", "Trying to convert Key::None to string.");
+
+#define APPEND_KEY_PART(m_part) \
+	if (!codestr.is_empty()) {  \
+		codestr += "+";         \
+	}                           \
+	codestr += m_part;
+
 	String codestr;
 	if ((p_code & KeyModifierMask::SHIFT) != Key::NONE) {
-		codestr += find_keycode_name(Key::SHIFT);
-		codestr += "+";
+		APPEND_KEY_PART(find_keycode_name(Key::SHIFT));
 	}
 	if ((p_code & KeyModifierMask::ALT) != Key::NONE) {
-		codestr += find_keycode_name(Key::ALT);
-		codestr += "+";
+		APPEND_KEY_PART(find_keycode_name(Key::ALT));
 	}
 	if ((p_code & KeyModifierMask::CMD_OR_CTRL) != Key::NONE) {
 		if (OS::get_singleton()->has_feature("macos") || OS::get_singleton()->has_feature("web_macos") || OS::get_singleton()->has_feature("web_ios")) {
-			codestr += find_keycode_name(Key::META);
+			APPEND_KEY_PART(find_keycode_name(Key::META));
 		} else {
-			codestr += find_keycode_name(Key::CTRL);
+			APPEND_KEY_PART(find_keycode_name(Key::CTRL));
 		}
-		codestr += "+";
 	}
 	if ((p_code & KeyModifierMask::CTRL) != Key::NONE) {
-		codestr += find_keycode_name(Key::CTRL);
-		codestr += "+";
+		APPEND_KEY_PART(find_keycode_name(Key::META));
 	}
 	if ((p_code & KeyModifierMask::META) != Key::NONE) {
-		codestr += find_keycode_name(Key::META);
-		codestr += "+";
+		APPEND_KEY_PART(find_keycode_name(Key::META));
 	}
 
 	p_code &= KeyModifierMask::CODE_MASK;
 	if ((char32_t)p_code == 0) {
-		// The key was just a modifier without any code.
+		// The key was just modifiers without any code.
 		return codestr;
 	}
 
@@ -396,13 +399,14 @@ String keycode_get_string(Key p_code) {
 
 	while (kct->text) {
 		if (kct->code == p_code) {
-			codestr += kct->text;
+			APPEND_KEY_PART(kct->text);
 			return codestr;
 		}
 		kct++;
 	}
 
-	codestr += String::chr((char32_t)p_code);
+	APPEND_KEY_PART(String::chr((char32_t)p_code));
+#undef APPEND_KEY_PART
 
 	return codestr;
 }


### PR DESCRIPTION
~Depends on https://github.com/godotengine/godot/pull/104107.~

This PR changes behavior somewhat when converting modifier keys to string: It will omit the final `+`.
For example: `keycode_get_string(Key::CTRL)` will now print `Ctrl` instead of `Ctrl+`.

In addition, it will now error out when trying to convert `0` (aka `Key::NONE`) because it is not a valid keycode.

## Note
I'm not 100% sure this change is wanted; it might be desirable behavior for modifier keys to be clearly marked as such by the trailing `+`. But at the same time, it might be confusing if something is _actually_ triggered by just a 'modifier key'. That's why I opened the PR.