### PR TITLE
Use `resize_zeroed` instead of `resize` then `fill(0)` in several places.

### DIFF
--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -118,8 +118,7 @@ Error PCKPacker::add_file_removal(const String &p_target_path) {
 	pf.size = 0;
 	pf.removal = true;
 
-	pf.md5.resize(16);
-	pf.md5.fill(0);
+	pf.md5.resize_zeroed(16);
 
 	files.push_back(pf);
 

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1642,8 +1642,7 @@ Error EditorExportPlatform::_remove_pack_file(void *p_userdata, const String &p_
 		pd->f->store_8(0);
 	}
 
-	sd.md5.resize(16);
-	sd.md5.fill(0);
+	sd.md5.resize_zeroed(16);
 
 	pd->file_ofs.push_back(sd);
 

--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -229,10 +229,8 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 		file->store_buffer(u8);
 
 		// Terminate string and fill the remaining part of the original string with the '\0'.
-		// Can be replaced by file->store_8('\0');
 		Vector<uint8_t> padding_buffer;
-		padding_buffer.resize((int64_t)original_path_size - u8.size());
-		padding_buffer.fill('\0');
+		padding_buffer.resize_zeroed((int64_t)original_path_size - u8.size());
 		file->store_buffer(padding_buffer);
 		ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Failed to write a new PDB path to '%s'.", p_dll_path));
 

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -645,8 +645,7 @@ Array SurfaceTool::commit_to_arrays() {
 			case Mesh::ARRAY_BONES: {
 				int count = skin_weights == SKIN_8_WEIGHTS ? 8 : 4;
 				Vector<int> array;
-				array.resize(varr_len * count);
-				array.fill(0);
+				array.resize_zeroed(varr_len * count);
 				int *w = array.ptrw();
 
 				for (uint32_t idx = 0; idx < vertex_array.size(); idx++) {
@@ -669,8 +668,7 @@ Array SurfaceTool::commit_to_arrays() {
 				Vector<float> array;
 				int count = skin_weights == SKIN_8_WEIGHTS ? 8 : 4;
 
-				array.resize(varr_len * count);
-				array.fill(0.0f);
+				array.resize_zeroed(varr_len * count);
 				float *w = array.ptrw();
 
 				for (uint32_t idx = 0; idx < vertex_array.size(); idx++) {

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -437,8 +437,7 @@ void Fog::VolumetricFog::init(const Vector3i &fog_size, RID p_sky_shader) {
 
 #if defined(MACOS_ENABLED) || defined(IOS_ENABLED)
 	Vector<uint8_t> dm;
-	dm.resize(fog_size.x * fog_size.y * fog_size.z * 4);
-	dm.fill(0);
+	dm.resize_zeroed(fog_size.x * fog_size.y * fog_size.z * 4);
 
 	density_map = RD::get_singleton()->storage_buffer_create(dm.size(), dm);
 	RD::get_singleton()->set_resource_name(density_map, "Fog density map");

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -187,8 +187,7 @@ void ShaderRD::_initialize_version(Version *p_version) {
 
 	p_version->variants.resize_zeroed(variant_defines.size());
 	p_version->variant_data.resize(variant_defines.size());
-	p_version->group_compilation_tasks.resize(group_enabled.size());
-	p_version->group_compilation_tasks.fill(0);
+	p_version->group_compilation_tasks.resize_zeroed(group_enabled.size());
 }
 
 void ShaderRD::_clear_version(Version *p_version) {


### PR DESCRIPTION
Small performance optimization.

`resize_zeroed` assures all-zero bytes. It's generally quite a bit faster than `resize` followed by `fill` (and could be made even faster in future implementations).
