### PR TITLE
Fix `Color` precision error in the documentation generated on M4 macOS.

### DIFF
--- a/thirdparty/misc/ok_color.h
+++ b/thirdparty/misc/ok_color.h
@@ -541,6 +541,11 @@ static RGB okhsl_to_srgb(HSL hsl)
 
 static HSL srgb_to_okhsl(RGB rgb)
 {
+	// Fixes some precision errors.
+	if (rgb.r == 0.0f && rgb.g == 0.0f && rgb.b == 0.0f) {
+		return { 0.0f, 0.0f, 0.0f };
+	}
+
 	Lab lab = linear_srgb_to_oklab({
 		srgb_transfer_function_inv(rgb.r),
 		srgb_transfer_function_inv(rgb.g),

--- a/thirdparty/misc/patches/ok_color-0001-srgb_to_okhsl_precision.patch
+++ b/thirdparty/misc/patches/ok_color-0001-srgb_to_okhsl_precision.patch
@@ -1,0 +1,16 @@
+diff --git a/thirdparty/misc/ok_color.h b/thirdparty/misc/ok_color.h
+index 4d0f0049bd..2cc7f1ceef 100644
+--- a/thirdparty/misc/ok_color.h
++++ b/thirdparty/misc/ok_color.h
+@@ -541,6 +541,11 @@ static RGB okhsl_to_srgb(HSL hsl)
+ 
+ static HSL srgb_to_okhsl(RGB rgb)
+ {
++	// Fixes some precision errors.
++	if (rgb.r == 0.0f && rgb.g == 0.0f && rgb.b == 0.0f) {
++		return { 0.0f, 0.0f, 0.0f };
++	}
++
+ 	Lab lab = linear_srgb_to_oklab({
+ 		srgb_transfer_function_inv(rgb.r),
+ 		srgb_transfer_function_inv(rgb.g),


### PR DESCRIPTION
Running `doctool` on M4 Pro macOS (not reproducible on M1) result in unnecessary diffs.

The issue is related to use of `atan2f` and precision of π:

`ok_color.h` header define π as `3.1415926535897932384626433832795028841971693993751058209749445923078164062` which is rounded to the nearest representable `float` value `3.14159274101257324219`, but `atan2f(-0.0, -0.0)` (and some other math functions with negative argument) seems to round it the other way and return `3.14159250259399414062` (previous representable value, one bit less).