### PR TITLE
Add missing Projection constructor with 16 `real_t` values

### DIFF
--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -984,6 +984,13 @@ Projection::Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_
 	columns[3] = p_w;
 }
 
+Projection::Projection(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_xw, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_yw, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_zw, real_t p_wx, real_t p_wy, real_t p_wz, real_t p_ww) {
+	columns[0] = Vector4(p_xx, p_xy, p_xz, p_xw);
+	columns[1] = Vector4(p_yx, p_yy, p_yz, p_yw);
+	columns[2] = Vector4(p_zx, p_zy, p_zz, p_zw);
+	columns[3] = Vector4(p_wx, p_wy, p_wz, p_ww);
+}
+
 Projection::Projection(const Transform3D &p_transform) {
 	const Transform3D &tr = p_transform;
 	real_t *m = &columns[0][0];

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -153,6 +153,7 @@ struct [[nodiscard]] Projection {
 
 	Projection();
 	Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_z, const Vector4 &p_w);
+	Projection(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_xw, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_yw, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_zw, real_t p_wx, real_t p_wy, real_t p_wz, real_t p_ww);
 	Projection(const Transform3D &p_transform);
 	~Projection();
 };

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -846,6 +846,33 @@ namespace Godot
         }
 
         /// <summary>
+        /// Constructs a projection from 16 scalars.
+        /// </summary>
+        /// <param name="xx">The X column vector's X component, accessed via <c>p.X.X</c> or <c>[0][0]</c>.</param>
+        /// <param name="xy">The X column vector's Y component, accessed via <c>p.X.Y</c> or <c>[0][1]</c>.</param>
+        /// <param name="xz">The X column vector's Z component, accessed via <c>p.X.Z</c> or <c>[0][2]</c>.</param>
+        /// <param name="xw">The X column vector's W component, accessed via <c>p.X.W</c> or <c>[0][3]</c>.</param>
+        /// <param name="yx">The Y column vector's X component, accessed via <c>p.Y.X</c> or <c>[1][0]</c>.</param>
+        /// <param name="yy">The Y column vector's Y component, accessed via <c>p.Y.Y</c> or <c>[1][1]</c>.</param>
+        /// <param name="yz">The Y column vector's Z component, accessed via <c>p.Y.Z</c> or <c>[1][2]</c>.</param>
+        /// <param name="yw">The Y column vector's W component, accessed via <c>p.Y.W</c> or <c>[1][3]</c>.</param>
+        /// <param name="zx">The Z column vector's X component, accessed via <c>p.Z.X</c> or <c>[2][0]</c>.</param>
+        /// <param name="zy">The Z column vector's Y component, accessed via <c>p.Z.Y</c> or <c>[2][1]</c>.</param>
+        /// <param name="zz">The Z column vector's Z component, accessed via <c>p.Z.Z</c> or <c>[2][2]</c>.</param>
+        /// <param name="zw">The Z column vector's W component, accessed via <c>p.Z.W</c> or <c>[2][3]</c>.</param>
+        /// <param name="wx">The W column vector's X component, accessed via <c>p.W.X</c> or <c>[3][0]</c>.</param>
+        /// <param name="wy">The W column vector's Y component, accessed via <c>p.W.Y</c> or <c>[3][1]</c>.</param>
+        /// <param name="wz">The W column vector's Z component, accessed via <c>p.W.Z</c> or <c>[3][2]</c>.</param>
+        /// <param name="ww">The W column vector's W component, accessed via <c>p.W.W</c> or <c>[3][3]</c>.</param>
+        public Projection(real_t xx, real_t xy, real_t xz, real_t xw, real_t yx, real_t yy, real_t yz, real_t yw, real_t zx, real_t zy, real_t zz, real_t zw, real_t wx, real_t wy, real_t wz, real_t ww)
+        {
+            X = new Vector4(xx, xy, xz, xw);
+            Y = new Vector4(yx, yy, yz, yw);
+            Z = new Vector4(zx, zy, zz, zw);
+            W = new Vector4(wx, wy, wz, ww);
+        }
+
+        /// <summary>
         /// Constructs a new <see cref="Projection"/> from a <see cref="Transform3D"/>.
         /// </summary>
         /// <param name="transform">The <see cref="Transform3D"/>.</param>


### PR DESCRIPTION
When GDExtension generates bindings, it creates C++ code based on the API JSON. Values are serialized into literals constructed with numbers matching the value, for example, `Vector3(0, 1, 0)`. This includes default values for function parameters. Projection default values are serialized like `Projection(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)`. However, Godot is missing a constructor for Projection, so the generated C++ code doesn't compile:

<img width="800" alt="Screenshot 2025-03-14 at 2 41 03 AM" src="https://github.com/user-attachments/assets/8ce0ceab-04ab-4f97-a724-15e01494e3cd" />

I encountered this problem when the CI checks for godot-cpp failed to compile with my 4D module, because one of the bound methods includes a Projection default value, which cannot be constructed, as seen in the above image. This wasn't a problem in the engine before because the engine doesn't have any Projection default values in parameters.

Note: I believe to fix the *exact* problem, it only needs to be added to godot-cpp (see https://github.com/godotengine/godot-cpp/pull/1742). However, we should make the same change in the engine for consistency. I also added this to C# but not GDScript since we do the same for other similar types (Transform2D/Transform3D/Basis).