### PR TITLE
GDScript: Fix head class range to include `class_name`

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -672,14 +672,16 @@ void GDScriptParser::parse_program() {
 		}
 	}
 
+	if (current.type == GDScriptTokenizer::Token::CLASS_NAME || current.type == GDScriptTokenizer::Token::EXTENDS) {
+		// Set range of the class to only start at extends or class_name if present.
+		reset_extents(head, current);
+	}
+
 	while (can_have_class_or_extends) {
 		// Order here doesn't matter, but there should be only one of each at most.
 		switch (current.type) {
 			case GDScriptTokenizer::Token::CLASS_NAME:
 				PUSH_PENDING_ANNOTATIONS_TO_HEAD;
-				if (head->start_line == 1) {
-					reset_extents(head, current);
-				}
 				advance();
 				if (head->identifier != nullptr) {
 					push_error(R"("class_name" can only be used once.)");
@@ -689,9 +691,6 @@ void GDScriptParser::parse_program() {
 				break;
 			case GDScriptTokenizer::Token::EXTENDS:
 				PUSH_PENDING_ANNOTATIONS_TO_HEAD;
-				if (head->start_line == 1) {
-					reset_extents(head, current);
-				}
 				advance();
 				if (head->extends_used) {
 					push_error(R"("extends" can only be used once.)");

--- a/modules/gdscript/tests/scripts/lsp/first_line_class_name.gd
+++ b/modules/gdscript/tests/scripts/lsp/first_line_class_name.gd
@@ -1,0 +1,5 @@
+class_name Test
+extends Node
+
+func _init():
+	pass

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -488,15 +488,21 @@ func f():
 		REQUIRE(proto);
 
 		SUBCASE("selectionRange of root class must be inside range") {
-			String path = "res://lsp/first_line_comment.gd";
-			assert_no_errors_in(path);
-			GDScriptLanguageProtocol::get_singleton()->get_workspace()->parse_local_script(path);
-			ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_workspace()->parse_results[path];
-			REQUIRE(parser);
-			lsp::DocumentSymbol cls = parser->get_symbols();
+			LocalVector<String> paths = {
+				"res://lsp/first_line_comment.gd", // Comment on first line
+				"res://lsp/first_line_class_name.gd", // class_name (and thus selection range) before extends
+			};
 
-			REQUIRE(((cls.range.start.line == cls.selectionRange.start.line && cls.range.start.character <= cls.selectionRange.start.character) || (cls.range.start.line < cls.selectionRange.start.line)));
-			REQUIRE(((cls.range.end.line == cls.selectionRange.end.line && cls.range.end.character >= cls.selectionRange.end.character) || (cls.range.end.line > cls.selectionRange.end.line)));
+			for (const String &path : paths) {
+				assert_no_errors_in(path);
+				GDScriptLanguageProtocol::get_singleton()->get_workspace()->parse_local_script(path);
+				ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_workspace()->parse_results[path];
+				REQUIRE(parser);
+				lsp::DocumentSymbol cls = parser->get_symbols();
+
+				REQUIRE(((cls.range.start.line == cls.selectionRange.start.line && cls.range.start.character <= cls.selectionRange.start.character) || (cls.range.start.line < cls.selectionRange.start.line)));
+				REQUIRE(((cls.range.end.line == cls.selectionRange.end.line && cls.range.end.character >= cls.selectionRange.end.character) || (cls.range.end.line > cls.selectionRange.end.line)));
+			}
 		}
 
 		memdelete(proto);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-vscode-plugin/issues/820

The parsing code would reset the beginning of the class whenever encountering `class_name` or `extends`, there is a check to prevent this from happening twice but it is faulty. It checks whether the current beginning position is on line 1 (the default). But this also means the extents will be reset if either `extends` or `class_name` are found on the first line, which means the corresponding statement would not be inside the range anymore.

This leads to problems with the lsp spec, since `class_name` as selection target MUST be within the symbol range.

This PR changes this behavior to only apply to the first of both that is encountered (regardless of line). It is still a bit inconsistent with classes that don't have either, because for those, the annotations are part of the range. But that isn't really related to the issue and does not cause any problems I'm aware of.
