### PR TITLE
Bind `SceneState` methods `get_path` and `get_base_scene_state`

### DIFF
--- a/doc/classes/SceneState.xml
+++ b/doc/classes/SceneState.xml
@@ -10,6 +10,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_base_scene_state" qualifiers="const">
+			<return type="SceneState" />
+			<description>
+				Returns the [SceneState] of the scene that this scene inherits from, or [code]null[/code] if it doesn't inherit from any scene.
+			</description>
+		</method>
 		<method name="get_connection_binds" qualifiers="const">
 			<return type="Array" />
 			<param index="0" name="idx" type="int" />
@@ -153,6 +159,12 @@
 			<param index="0" name="idx" type="int" />
 			<description>
 				Returns the type of the node at [param idx].
+			</description>
+		</method>
+		<method name="get_path" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the resource path to the represented [PackedScene].
 			</description>
 		</method>
 		<method name="is_node_instance_placeholder" qualifiers="const">

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -2092,6 +2092,8 @@ Vector<String> SceneState::_get_node_groups(int p_idx) const {
 void SceneState::_bind_methods() {
 	//unbuild API
 
+	ClassDB::bind_method(D_METHOD("get_path"), &SceneState::get_path);
+	ClassDB::bind_method(D_METHOD("get_base_scene_state"), &SceneState::get_base_scene_state);
 	ClassDB::bind_method(D_METHOD("get_node_count"), &SceneState::get_node_count);
 	ClassDB::bind_method(D_METHOD("get_node_type", "idx"), &SceneState::get_node_type);
 	ClassDB::bind_method(D_METHOD("get_node_name", "idx"), &SceneState::get_node_name);


### PR DESCRIPTION
It is (as far as I know) currently not possible to traverse the inheritance chain of a `PackedScene` through scripts, due to `SceneState::get_base_scene_state` not being bound.

However, even with `SceneState::get_base_scene_state` exposed, there's no way to know which scene's `SceneState` you're actually looking at, due to `SceneState::get_path` not being bound.

This pull request resolves this by simply binding both of those methods.

EDIT: Closes godotengine/godot-proposals#12061.