### PR TITLE
Fix crash with SDFGI when zfar is very large

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/gi.glsl
@@ -313,7 +313,7 @@ void sdfgi_process(vec3 vertex, vec3 normal, vec3 reflection, float roughness, o
 	for (uint i = 0; i < sdfgi.max_cascades; i++) {
 		cascade_pos = (cam_pos - sdfgi.cascades[i].position) * sdfgi.cascades[i].to_probe;
 
-		if (any(lessThan(cascade_pos, vec3(0.0))) || any(greaterThanEqual(cascade_pos, sdfgi.cascade_probe_size))) {
+		if (any(lessThan(cascade_pos, vec3(0.0))) || any(greaterThanEqual(cascade_pos, sdfgi.cascade_probe_size)) || any(isnan(cascade_pos))) {
 			continue; //skip cascade
 		}
 


### PR DESCRIPTION
Fixes #99967

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/119933*