### PR TITLE
GDExtension: Add mechanism to get which classes an extension is using

### DIFF
--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -93,6 +93,7 @@ class GDExtension : public Resource {
 	static void _register_extension_class_signal(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_signal_name, const GDExtensionPropertyInfo *p_argument_info, GDExtensionInt p_argument_count);
 	static void _unregister_extension_class(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name);
 	static void _get_library_path(GDExtensionClassLibraryPtr p_library, GDExtensionStringPtr r_path);
+	static void _register_get_classes_used_callback(GDExtensionClassLibraryPtr p_library, GDExtensionEditorGetClassesUsedCallback p_callback);
 
 	GDExtensionInitialization initialization;
 	int32_t level_initialized = -1;
@@ -101,6 +102,7 @@ class GDExtension : public Resource {
 	bool is_reloading = false;
 	Vector<GDExtensionMethodBind *> invalid_methods;
 	Vector<ObjectID> instance_bindings;
+	GDExtensionEditorGetClassesUsedCallback get_classes_used_callback = nullptr;
 
 	static void _track_instance(void *p_user_data, void *p_instance);
 	static void _untrack_instance(void *p_user_data, void *p_instance);
@@ -155,6 +157,8 @@ public:
 
 	void track_instance_binding(Object *p_object);
 	void untrack_instance_binding(Object *p_object);
+
+	PackedStringArray get_classes_used() const;
 #endif
 
 	InitializationLevel get_minimum_library_initialization_level() const;

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -400,6 +400,9 @@ typedef struct {
 
 typedef void *GDExtensionClassLibraryPtr;
 
+/* Passed a pointer to a PackedStringArray that should be filled with the classes that may be used by the GDExtension. */
+typedef void (*GDExtensionEditorGetClassesUsedCallback)(GDExtensionTypePtr p_packed_string_array);
+
 /* Method */
 
 typedef enum {
@@ -3110,6 +3113,22 @@ typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8Chars)(const char *
  * @param p_size The number of bytes (not code units).
  */
 typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8CharsAndLen)(const char *p_data, GDExtensionInt p_size);
+
+/**
+ * @name editor_register_get_classes_used_callback
+ * @since 4.5
+ *
+ * Registers a callback that Godot can call to get the list of all classes (from ClassDB) that may be used by the calling GDExtension.
+ *
+ * This is used by the editor to generate a build profile (in "Tools" > "Engine Compilation Configuration Editor..." > "Detect from project"),
+ * in order to recompile Godot with only the classes used.
+ * In the provided callback, the GDExtension should provide the list of classes that _may_ be used statically, thus the time of invocation shouldn't matter.
+ * If a GDExtension doesn't register a callback, Godot will assume that it could be using any classes.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_callback The callback to retrieve the list of classes used.
+ */
+typedef void (*GDExtensionInterfaceEditorRegisterGetClassesUsedCallback)(GDExtensionClassLibraryPtr p_library, GDExtensionEditorGetClassesUsedCallback p_callback);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This adds a GDExtension interface function, that allows a GDExtension to register a callback, that can be called by the Godot editor to determine which classes it's using.

I created this to help @YeldhamDev with the work he's doing to allow recompiling Godot with only the classes used by a particular project.

It worked for me in a quick test!

I'd appreciate feedback on the name of the new function: `editor_register_get_used_classes_callback`

It ends up with quite a few prefixes and suffixes in there. :-) I put "editor" since the only use I can think of for this is in the editor, but it wouldn't really be a problem to allow this always?

PR https://github.com/godotengine/godot-cpp/pull/1743 implements this for godot-cpp