### PR TITLE
Remove `TOOLS_ENABLED` checks from `editor/`

### DIFF
--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -747,7 +747,6 @@ bool EditorInterface::is_movie_maker_enabled() const {
 	return EditorRunBar::get_singleton()->is_movie_maker_enabled();
 }
 
-#ifdef TOOLS_ENABLED
 void EditorInterface::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
@@ -763,7 +762,6 @@ void EditorInterface::get_argument_options(const StringName &p_function, int p_i
 	}
 	Object::get_argument_options(p_function, p_idx, r_options);
 }
-#endif
 
 // Base.
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -190,9 +190,7 @@ public:
 	void set_movie_maker_enabled(bool p_enabled);
 	bool is_movie_maker_enabled() const;
 
-#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
-#endif
 
 	// Base.
 	static void create();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -2122,7 +2122,6 @@ void EditorSettings::notify_changes() {
 	root->propagate_notification(NOTIFICATION_EDITOR_SETTINGS_CHANGED);
 }
 
-#ifdef TOOLS_ENABLED
 void EditorSettings::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
@@ -2149,7 +2148,6 @@ void EditorSettings::get_argument_options(const StringName &p_function, int p_id
 	}
 	Object::get_argument_options(p_function, p_idx, r_options);
 }
-#endif
 
 void EditorSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_setting", "name"), &EditorSettings::has_setting);

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -204,9 +204,7 @@ public:
 
 	void notify_changes();
 
-#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
-#endif
 
 	EditorSettings();
 };

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -83,9 +83,7 @@ void ResourceImporterTexture::_texture_reimport_normal(const Ref<CompressedTextu
 }
 
 inline void ResourceImporterTexture::_print_callback_message(const String &p_message) {
-#ifdef TOOLS_ENABLED
 	EditorToaster::get_singleton()->popup_str(p_message);
-#endif
 	print_line(p_message);
 }
 

--- a/editor/plugins/camera_2d_editor_plugin.cpp
+++ b/editor/plugins/camera_2d_editor_plugin.cpp
@@ -100,9 +100,7 @@ Camera2DEditor::Camera2DEditor() {
 
 	options->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &Camera2DEditor::_menu_option));
 
-#ifdef TOOLS_ENABLED
 	add_user_signal(MethodInfo("_editor_theme_changed"));
-#endif
 }
 
 void Camera2DEditorPlugin::_update_approach_text_visibility() {

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -1121,12 +1121,11 @@ void Skeleton3DEditor::_notification(int p_what) {
 			joint_tree->connect(SceneStringName(item_selected), callable_mp(this, &Skeleton3DEditor::_joint_tree_selection_changed));
 			joint_tree->connect("item_mouse_selected", callable_mp(this, &Skeleton3DEditor::_joint_tree_rmb_select));
 			joint_tree->connect("button_clicked", callable_mp(this, &Skeleton3DEditor::_joint_tree_button_clicked));
-#ifdef TOOLS_ENABLED
+
 			skeleton->connect(SceneStringName(pose_updated), callable_mp(this, &Skeleton3DEditor::_draw_gizmo));
 			skeleton->connect(SceneStringName(pose_updated), callable_mp(this, &Skeleton3DEditor::_update_properties));
 			skeleton->connect(SceneStringName(bone_enabled_changed), callable_mp(this, &Skeleton3DEditor::_bone_enabled_changed));
 			skeleton->connect(SceneStringName(show_rest_only_changed), callable_mp(this, &Skeleton3DEditor::_update_gizmo_visible));
-#endif
 
 			get_tree()->connect("node_removed", callable_mp(this, &Skeleton3DEditor::_node_removed), Object::CONNECT_ONE_SHOT);
 		} break;
@@ -1149,13 +1148,12 @@ void Skeleton3DEditor::_notification(int p_what) {
 		case NOTIFICATION_PREDELETE: {
 			if (skeleton) {
 				select_bone(-1); // Requires that the joint_tree has not been deleted.
-#ifdef TOOLS_ENABLED
 				skeleton->disconnect(SceneStringName(show_rest_only_changed), callable_mp(this, &Skeleton3DEditor::_update_gizmo_visible));
 				skeleton->disconnect(SceneStringName(bone_enabled_changed), callable_mp(this, &Skeleton3DEditor::_bone_enabled_changed));
 				skeleton->disconnect(SceneStringName(pose_updated), callable_mp(this, &Skeleton3DEditor::_draw_gizmo));
 				skeleton->disconnect(SceneStringName(pose_updated), callable_mp(this, &Skeleton3DEditor::_update_properties));
 				skeleton->set_transform_gizmo_visible(true);
-#endif
+
 				if (handles_mesh_instance->get_parent()) {
 					handles_mesh_instance->get_parent()->remove_child(handles_mesh_instance);
 				}
@@ -1437,22 +1435,16 @@ void Skeleton3DEditor::_update_gizmo_visible() {
 	_subgizmo_selection_change();
 	if (edit_mode) {
 		if (selected_bone == -1) {
-#ifdef TOOLS_ENABLED
 			skeleton->set_transform_gizmo_visible(false);
-#endif
 		} else {
-#ifdef TOOLS_ENABLED
 			if (skeleton->is_bone_enabled(selected_bone) && !skeleton->is_show_rest_only()) {
 				skeleton->set_transform_gizmo_visible(true);
 			} else {
 				skeleton->set_transform_gizmo_visible(false);
 			}
-#endif
 		}
 	} else {
-#ifdef TOOLS_ENABLED
 		skeleton->set_transform_gizmo_visible(true);
-#endif
 	}
 	_draw_gizmo();
 }

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -30,8 +30,6 @@
 
 #include "csg_gizmos.h"
 
-#ifdef TOOLS_ENABLED
-
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_undo_redo_manager.h"
@@ -508,5 +506,3 @@ EditorPluginCSG::EditorPluginCSG() {
 	csg_shape_editor = memnew(CSGShapeEditor);
 	EditorNode::get_singleton()->get_gui_base()->add_child(csg_shape_editor);
 }
-
-#endif // TOOLS_ENABLED

--- a/modules/csg/editor/csg_gizmos.h
+++ b/modules/csg/editor/csg_gizmos.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "../csg_shape.h"
 
 #include "editor/plugins/editor_plugin.h"
@@ -103,5 +101,3 @@ public:
 
 	EditorPluginCSG();
 };
-
-#endif // TOOLS_ENABLED

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
@@ -30,8 +30,6 @@
 
 #include "editor_scene_importer_fbx2gltf.h"
 
-#ifdef TOOLS_ENABLED
-
 #include "core/config/project_settings.h"
 #include "editor/editor_settings.h"
 #include "editor_scene_importer_ufbx.h"
@@ -142,5 +140,3 @@ void EditorSceneFormatImporterFBX2GLTF::handle_compatibility_options(HashMap<Str
 		p_import_params["fbx/importer"] = EditorSceneFormatImporterUFBX::FBX_IMPORTER_UFBX;
 	}
 }
-
-#endif // TOOLS_ENABLED

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.h
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "editor/import/3d/resource_importer_scene.h"
 
 class Animation;
@@ -51,5 +49,3 @@ public:
 			const HashMap<StringName, Variant> &p_options) override;
 	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const override;
 };
-
-#endif // TOOLS_ENABLED

--- a/modules/fbx/editor/editor_scene_importer_ufbx.cpp
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.cpp
@@ -30,8 +30,6 @@
 
 #include "editor_scene_importer_ufbx.h"
 
-#ifdef TOOLS_ENABLED
-
 #include "../fbx_document.h"
 #include "editor_scene_importer_fbx2gltf.h"
 
@@ -104,5 +102,3 @@ void EditorSceneFormatImporterUFBX::handle_compatibility_options(HashMap<StringN
 		p_import_params["fbx/importer"] = EditorSceneFormatImporterUFBX::FBX_IMPORTER_FBX2GLTF;
 	}
 }
-
-#endif // TOOLS_ENABLED

--- a/modules/fbx/editor/editor_scene_importer_ufbx.h
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "editor/import/3d/resource_importer_scene.h"
 
 class Animation;
@@ -55,4 +53,3 @@ public:
 			const HashMap<StringName, Variant> &p_options) override;
 	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const override;
 };
-#endif // TOOLS_ENABLED

--- a/modules/gltf/editor/editor_import_blend_runner.cpp
+++ b/modules/gltf/editor/editor_import_blend_runner.cpp
@@ -30,8 +30,6 @@
 
 #include "editor_import_blend_runner.h"
 
-#ifdef TOOLS_ENABLED
-
 #include "core/io/http_client.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_node.h"
@@ -392,5 +390,3 @@ EditorImportBlendRunner::EditorImportBlendRunner() {
 
 	EditorFileSystem::get_singleton()->connect("resources_reimported", callable_mp(this, &EditorImportBlendRunner::_resources_reimported));
 }
-
-#endif // TOOLS_ENABLED

--- a/modules/gltf/editor/editor_import_blend_runner.h
+++ b/modules/gltf/editor/editor_import_blend_runner.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "core/io/http_client.h"
 #include "core/os/os.h"
 #include "scene/main/node.h"
@@ -65,5 +63,3 @@ public:
 
 	EditorImportBlendRunner();
 };
-
-#endif // TOOLS_ENABLED

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
@@ -30,8 +30,6 @@
 
 #include "editor_scene_exporter_gltf_plugin.h"
 
-#ifdef TOOLS_ENABLED
-
 #include "editor_scene_exporter_gltf_settings.h"
 
 #include "editor/editor_file_system.h"
@@ -118,5 +116,3 @@ void SceneExporterGLTFPlugin::_export_scene_as_gltf(const String &p_file_path) {
 	}
 	EditorFileSystem::get_singleton()->scan_changes();
 }
-
-#endif // TOOLS_ENABLED

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "../gltf_document.h"
 #include "editor_scene_exporter_gltf_settings.h"
 
@@ -55,5 +53,3 @@ public:
 	bool has_main_screen() const override;
 	SceneExporterGLTFPlugin();
 };
-
-#endif // TOOLS_ENABLED

--- a/modules/gltf/editor/editor_scene_exporter_gltf_settings.h
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_settings.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "../gltf_document.h"
 
 class EditorSceneExporterGLTFSettings : public RefCounted {
@@ -62,5 +60,3 @@ public:
 	double get_bake_fps() const;
 	void set_bake_fps(const double p_bake_fps);
 };
-
-#endif // TOOLS_ENABLED

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -30,8 +30,6 @@
 
 #include "editor_scene_importer_blend.h"
 
-#ifdef TOOLS_ENABLED
-
 #include "../gltf_defines.h"
 #include "../gltf_document.h"
 #include "editor_import_blend_runner.h"
@@ -598,5 +596,3 @@ bool EditorFileSystemImportFormatSupportQueryBlend::query() {
 
 EditorFileSystemImportFormatSupportQueryBlend::EditorFileSystemImportFormatSupportQueryBlend() {
 }
-
-#endif // TOOLS_ENABLED

--- a/modules/gltf/editor/editor_scene_importer_blend.h
+++ b/modules/gltf/editor/editor_scene_importer_blend.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "editor/editor_file_system.h"
 #include "editor/import/3d/resource_importer_scene.h"
 
@@ -110,5 +108,3 @@ public:
 
 	EditorFileSystemImportFormatSupportQueryBlend();
 };
-
-#endif // TOOLS_ENABLED

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -30,8 +30,6 @@
 
 #include "editor_scene_importer_gltf.h"
 
-#ifdef TOOLS_ENABLED
-
 #include "../gltf_defines.h"
 #include "../gltf_document.h"
 
@@ -103,5 +101,3 @@ Variant EditorSceneFormatImporterGLTF::get_option_visibility(const String &p_pat
 		const String &p_option, const HashMap<StringName, Variant> &p_options) {
 	return true;
 }
-
-#endif // TOOLS_ENABLED

--- a/modules/gltf/editor/editor_scene_importer_gltf.h
+++ b/modules/gltf/editor/editor_scene_importer_gltf.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "editor/import/3d/resource_importer_scene.h"
 
 class Animation;
@@ -51,5 +49,3 @@ public:
 	virtual Variant get_option_visibility(const String &p_path, const String &p_scene_import_type,
 			const String &p_option, const HashMap<StringName, Variant> &p_options) override;
 };
-
-#endif // TOOLS_ENABLED

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -30,8 +30,6 @@
 
 #include "grid_map_editor_plugin.h"
 
-#ifdef TOOLS_ENABLED
-
 #include "core/os/keyboard.h"
 #include "editor/editor_command_palette.h"
 #include "editor/editor_main_screen.h"
@@ -1883,5 +1881,3 @@ GridMapEditorPlugin::GridMapEditorPlugin() {
 
 GridMapEditorPlugin::~GridMapEditorPlugin() {
 }
-
-#endif // TOOLS_ENABLED

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "../grid_map.h"
 
 #include "editor/plugins/editor_plugin.h"
@@ -298,5 +296,3 @@ public:
 	GridMapEditorPlugin();
 	~GridMapEditorPlugin();
 };
-
-#endif // TOOLS_ENABLED

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -30,7 +30,7 @@
 
 #include "bindings_generator.h"
 
-#if defined(DEBUG_METHODS_ENABLED) && defined(TOOLS_ENABLED)
+#ifdef DEBUG_METHODS_ENABLED
 
 #include "../godotsharp_defs.h"
 #include "../utils/naming_utils.h"

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -32,7 +32,7 @@
 
 #include "core/typedefs.h" // DEBUG_METHODS_ENABLED
 
-#if defined(DEBUG_METHODS_ENABLED) && defined(TOOLS_ENABLED)
+#ifdef DEBUG_METHODS_ENABLED
 
 #include "core/doc_data.h"
 #include "core/object/class_db.h"

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -68,19 +68,11 @@ void godot_icall_GodotSharpDirs_MonoUserDir(godot_string *r_dest) {
 }
 
 void godot_icall_GodotSharpDirs_BuildLogsDirs(godot_string *r_dest) {
-#ifdef TOOLS_ENABLED
 	memnew_placement(r_dest, String(GodotSharpDirs::get_build_logs_dir()));
-#else
-	return nullptr;
-#endif
 }
 
 void godot_icall_GodotSharpDirs_DataEditorToolsDir(godot_string *r_dest) {
-#ifdef TOOLS_ENABLED
 	memnew_placement(r_dest, String(GodotSharpDirs::get_data_editor_tools_dir()));
-#else
-	return nullptr;
-#endif
 }
 
 void godot_icall_GodotSharpDirs_CSharpProjectName(godot_string *r_dest) {

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
@@ -30,8 +30,6 @@
 
 #include "navigation_mesh_editor_plugin.h"
 
-#ifdef TOOLS_ENABLED
-
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "scene/3d/navigation_region_3d.h"
@@ -181,5 +179,3 @@ NavigationMeshEditorPlugin::NavigationMeshEditorPlugin() {
 
 NavigationMeshEditorPlugin::~NavigationMeshEditorPlugin() {
 }
-
-#endif // TOOLS_ENABLED

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.h
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "editor/plugins/editor_plugin.h"
 
 class AcceptDialog;
@@ -82,5 +80,3 @@ public:
 	NavigationMeshEditorPlugin();
 	~NavigationMeshEditorPlugin();
 };
-
-#endif // TOOLS_ENABLED

--- a/modules/noise/SCsub
+++ b/modules/noise/SCsub
@@ -14,5 +14,7 @@ env_noise.Prepend(CPPPATH=[thirdparty_dir])
 module_obj = []
 
 env_noise.add_source_files(module_obj, "*.cpp")
-env_noise.add_source_files(module_obj, "editor/*.cpp")
+if env.editor_build:
+    env_noise.add_source_files(module_obj, "editor/*.cpp")
+
 env.modules_sources += module_obj

--- a/modules/noise/editor/noise_editor_plugin.cpp
+++ b/modules/noise/editor/noise_editor_plugin.cpp
@@ -30,8 +30,6 @@
 
 #include "noise_editor_plugin.h"
 
-#ifdef TOOLS_ENABLED
-
 #include "../noise.h"
 #include "../noise_texture_2d.h"
 
@@ -148,5 +146,3 @@ NoiseEditorPlugin::NoiseEditorPlugin() {
 	plugin.instantiate();
 	add_inspector_plugin(plugin);
 }
-
-#endif // TOOLS_ENABLED

--- a/modules/noise/editor/noise_editor_plugin.h
+++ b/modules/noise/editor/noise_editor_plugin.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "editor/plugins/editor_plugin.h"
 
 class NoiseEditorPlugin : public EditorPlugin {
@@ -42,5 +40,3 @@ public:
 
 	NoiseEditorPlugin();
 };
-
-#endif // TOOLS_ENABLED

--- a/modules/websocket/editor/editor_debugger_server_websocket.cpp
+++ b/modules/websocket/editor/editor_debugger_server_websocket.cpp
@@ -30,8 +30,6 @@
 
 #include "editor_debugger_server_websocket.h"
 
-#ifdef TOOLS_ENABLED
-
 #include "../remote_debugger_peer_websocket.h"
 
 #include "editor/editor_log.h"
@@ -135,5 +133,3 @@ EditorDebuggerServer *EditorDebuggerServerWebSocket::create(const String &p_prot
 	ERR_FAIL_COND_V(p_protocol != "ws://", nullptr);
 	return memnew(EditorDebuggerServerWebSocket);
 }
-
-#endif // TOOLS_ENABLED

--- a/modules/websocket/editor/editor_debugger_server_websocket.h
+++ b/modules/websocket/editor/editor_debugger_server_websocket.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "../websocket_peer.h"
 
 #include "core/io/tcp_server.h"
@@ -63,5 +61,3 @@ public:
 	EditorDebuggerServerWebSocket();
 	~EditorDebuggerServerWebSocket();
 };
-
-#endif // TOOLS_ENABLED


### PR DESCRIPTION
`editor/` files are only compiled if TOOLS_ENABLED is defined, so any additional checks are redundant.
I assume it's the same for modules. EDIT: Looks like it's not.