### PR TITLE
Tweak GDScript error message for static class method calls

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3612,7 +3612,8 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			}
 		} else if (!is_self && base_type.is_meta_type && !p_call->is_static) {
 			base_type.is_meta_type = false; // For `to_string()`.
-			push_error(vformat(R"*(Cannot call non-static function "%s()" on the class "%s" directly. Make an instance instead.)*", p_call->function_name, base_type.to_string()), p_call);
+			const String base_class_name = base_type.to_string();
+			push_error(vformat(R"*(Cannot call non-static function "%s()" on the class "%s" directly. Make an instance using "var %s = %s.new()" and call functions on this instance.)*", p_call->function_name, base_class_name, base_class_name.to_snake_case(), base_class_name), p_call);
 		} else if (is_self && !p_call->is_static) {
 			mark_lambda_use_self();
 		}

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -270,7 +270,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 
 	if (!method) {
 		if (r_error.error == Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL) {
-			ERR_PRINT(vformat(R"(Cannot call static function "%s" on Java class "%s" directly. Make an instance instead.)", p_method, java_class_name));
+			ERR_PRINT(vformat(R"*(Cannot call static function "%s" on Java class "%s" directly. Make an instance instead using "var %s = %s.new()" and call functions on the instance.)*", p_method, java_class_name, java_class_name.to_snake_case(), java_class_name));
 		}
 		return true; //no version convinces
 	}


### PR DESCRIPTION
This mentions how to create an instance explicitly.

While `Class.new().method()` is valid as well, it's generally better to assign the instance to a variable so it can be reused for multiple calls.

## Preview

![image](https://github.com/user-attachments/assets/6e7a6f98-3f97-455e-bc0b-348557896cab)
