### PR TITLE
Fix `Marshalls.utf8_to_base64` shows `"ret.is_empty()" is true` error for empty string

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1241,6 +1241,9 @@ Vector<uint8_t> Marshalls::base64_to_raw(const String &p_str) {
 }
 
 String Marshalls::utf8_to_base64(const String &p_str) {
+	if (p_str.is_empty()) {
+		return String();
+	}
 	CharString cstr = p_str.utf8();
 	String ret = CryptoCore::b64_encode_str((unsigned char *)cstr.get_data(), cstr.length());
 	ERR_FAIL_COND_V(ret.is_empty(), ret);


### PR DESCRIPTION
Fixes #99457

Previously, calling `Marshalls.utf8_to_base64` on an empty string resulted in the error: `Condition "ret.is_empty()" is true. Returning: ret`.
This has been fixed by returning an empty string when the input string is empty.