### PR TITLE
JavaClassWrapper: Fix mistake in last fix for `org.godotengine.godot.Dictionary` conversion

### DIFF
--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -1078,7 +1078,7 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 
 			if (java_class_wrapped.is_valid()) {
 				String cn = java_class_wrapped->get_java_class_name();
-				if (cn == "org/godotengine/godot/Dictionary" || cn == "java.util.HashMap") {
+				if (cn == "org.godotengine.godot.Dictionary" || cn == "java.util.HashMap") {
 					var = _jobject_to_variant(env, obj);
 				} else {
 					Ref<JavaObject> ret = Ref<JavaObject>(memnew(JavaObject(java_class_wrapped, obj)));
@@ -1442,7 +1442,7 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 
 					if (java_class_wrapped.is_valid()) {
 						String cn = java_class_wrapped->get_java_class_name();
-						if (cn == "org/godotengine/godot/Dictionary" || cn == "java.util.HashMap") {
+						if (cn == "org.godotengine.godot.Dictionary" || cn == "java.util.HashMap") {
 							ret[i] = _jobject_to_variant(env, obj);
 						} else {
 							Ref<JavaObject> java_obj_wrapped = Ref<JavaObject>(memnew(JavaObject(java_class_wrapped, obj)));


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/104150

This was caused by a dumb mistake that I made in PR https://github.com/godotengine/godot/pull/103733, which I didn't notice because of an equally dumb mistake that I made in my test project :-/

Sorry, Everyone!

**Note:** There is another place in this file with `"org/godotengine/godot/Dictionary"` - this is intentional and doesn't need to be changed. When we're working directly with JNI, it uses slashes, but `JavaClass.get_java_class_name()` returns it with dots. That certainly doesn't make it easier to catch these sort of mistakes :-)
