### PR TITLE
Error when draw list is not active in `draw_list_switch_to_next_pass`

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -4914,7 +4914,7 @@ uint32_t RenderingDevice::draw_list_get_current_pass() {
 RenderingDevice::DrawListID RenderingDevice::draw_list_switch_to_next_pass() {
 	ERR_RENDER_THREAD_GUARD_V(INVALID_ID);
 
-	ERR_FAIL_COND_V(draw_list.active, INVALID_FORMAT_ID);
+	ERR_FAIL_COND_V(!draw_list.active, INVALID_FORMAT_ID);
 	ERR_FAIL_COND_V(draw_list_current_subpass >= draw_list_subpass_count - 1, INVALID_FORMAT_ID);
 
 	draw_list_current_subpass++;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/104146

This was originally:
```
ERR_FAIL_NULL_MSG(draw_list, "Immediate draw list is already inactive.");
```

I.e. the error would trigger if `draw_list` was null. 

In https://github.com/godotengine/godot/pull/103889 I wrongly translated it to:
```
ERR_FAIL_COND_V(draw_list.active, INVALID_FORMAT_ID);
```
The new logic sets `active` to false instead of freeing the draw list. So the check needs to be if `active` is false, not if active is true. 

This bug will impact users of the mobile renderer who have post processing effects enabled. So it is pretty common and serious.
