### PR TITLE
Remove dictionary sort in VariantWriter

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3372,11 +3372,11 @@ void Image::_set_data(const Dictionary &p_data) {
 
 Dictionary Image::_get_data() const {
 	Dictionary d;
-	d["width"] = width;
-	d["height"] = height;
-	d["format"] = get_format_name(format);
-	d["mipmaps"] = mipmaps;
 	d["data"] = data;
+	d["format"] = get_format_name(format);
+	d["height"] = height;
+	d["mipmaps"] = mipmaps;
+	d["width"] = width;
 	return d;
 }
 

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -2303,30 +2303,29 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				ERR_PRINT("Max recursion reached");
 				p_store_string_func(p_store_string_ud, "{}");
 			} else {
-				LocalVector<Variant> keys = dict.get_key_list();
-				keys.sort_custom<StringLikeVariantOrder>();
-
-				if (keys.is_empty()) {
+				if (dict.is_empty()) {
 					// Avoid unnecessary line break.
 					p_store_string_func(p_store_string_ud, "{}");
 				} else {
 					p_recursion_count++;
 
-					p_store_string_func(p_store_string_ud, "{\n");
+					p_store_string_func(p_store_string_ud, "{");
 
-					for (uint32_t i = 0; i < keys.size(); i++) {
-						const Variant &key = keys[i];
-						write(key, p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
-						p_store_string_func(p_store_string_ud, ": ");
-						write(dict[key], p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
-						if (i + 1 < keys.size()) {
-							p_store_string_func(p_store_string_ud, ",\n");
+					bool first = true;
+					for (const KeyValue<Variant, Variant> &kv : dict) {
+						if (first) {
+							first = false;
 						} else {
-							p_store_string_func(p_store_string_ud, "\n");
+							p_store_string_func(p_store_string_ud, ",");
 						}
+						p_store_string_func(p_store_string_ud, "\n");
+
+						write(kv.key, p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
+						p_store_string_func(p_store_string_ud, ": ");
+						write(kv.value, p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
 					}
 
-					p_store_string_func(p_store_string_ud, "}");
+					p_store_string_func(p_store_string_ud, "\n}");
 				}
 			}
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -3915,11 +3915,11 @@ CodeEdit::CodeEdit() {
 	auto_indent_prefixes.insert('(');
 
 	/* Auto brace completion */
-	add_auto_brace_completion_pair("(", ")");
 	add_auto_brace_completion_pair("{", "}");
 	add_auto_brace_completion_pair("[", "]");
-	add_auto_brace_completion_pair("\"", "\"");
+	add_auto_brace_completion_pair("(", ")");
 	add_auto_brace_completion_pair("\'", "\'");
+	add_auto_brace_completion_pair("\"", "\"");
 
 	/* Delimiter tracking */
 	add_string_delimiter("\"", "\"", false);

--- a/tests/core/variant/test_variant.cpp
+++ b/tests/core/variant/test_variant.cpp
@@ -1823,7 +1823,7 @@ TEST_CASE("[Variant] Writer and parser dictionary") {
 	String d_str;
 	VariantWriter::write_to_string(d, d_str);
 
-	CHECK_EQ(d_str, "{\n4: \"hello\",\n5: {\nnull: []\n},\n{\n1: 2\n}: 3\n}");
+	CHECK_EQ(d_str, "{\n{\n1: 2\n}: 3,\n4: \"hello\",\n5: {\nnull: []\n}\n}");
 
 	VariantParser::StreamString ss;
 	String errs;
@@ -1836,12 +1836,12 @@ TEST_CASE("[Variant] Writer and parser dictionary") {
 	CHECK_MESSAGE(d_parsed == Variant(d), "Should parse back.");
 }
 
-TEST_CASE("[Variant] Writer key sorting") {
+TEST_CASE("[Variant] Writer key preserves insertion order") {
 	Dictionary d = { { StringName("C"), 3 }, { "A", 1 }, { StringName("B"), 2 }, { "D", 4 } };
 	String d_str;
 	VariantWriter::write_to_string(d, d_str);
 
-	CHECK_EQ(d_str, "{\n\"A\": 1,\n&\"B\": 2,\n&\"C\": 3,\n\"D\": 4\n}");
+	CHECK_EQ(d_str, "{\n&\"C\": 3,\n\"A\": 1,\n&\"B\": 2,\n\"D\": 4\n}");
 }
 
 TEST_CASE("[Variant] Writer recursive dictionary") {


### PR DESCRIPTION
Implements an optimization introduced in #104047, fixes #90142

Recommended by @YYF233333, see this comment for more details: https://github.com/godotengine/godot/issues/90142#issuecomment-2722702279