### PR TITLE
Add `is_inside_tree()` check to SpringBoneSimulator3D

### DIFF
--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -1344,6 +1344,9 @@ void SpringBoneSimulator3D::_find_collisions() {
 }
 
 void SpringBoneSimulator3D::_process_collisions() {
+	if (!is_inside_tree()) {
+		return;
+	}
 	for (const ObjectID &oid : collisions) {
 		Object *t_obj = ObjectDB::get_instance(oid);
 		if (!t_obj) {
@@ -1467,6 +1470,10 @@ void SpringBoneSimulator3D::_set_active(bool p_active) {
 }
 
 void SpringBoneSimulator3D::_process_modification() {
+	if (!is_inside_tree()) {
+		return;
+	}
+
 	Skeleton3D *skeleton = get_skeleton();
 	if (!skeleton) {
 		return;
@@ -1488,6 +1495,9 @@ void SpringBoneSimulator3D::_process_modification() {
 }
 
 void SpringBoneSimulator3D::reset() {
+	if (!is_inside_tree()) {
+		return;
+	}
 	Skeleton3D *skeleton = get_skeleton();
 	if (!skeleton) {
 		return;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/103818
- Fixes https://github.com/godotengine/godot/issues/101707

A `SkeletonModifier3D` that may get the global transform of the external Node target needs an `is_inside_tree()` check, `LookAtModifier3D` already has this check in `_process_modification()`, so it is not a problem.

I think it is debatable whether the base class `SkeletonModifier3D` should have a check in `_process_modification()`. For now, my opinion is that it is okay to have individual checks, since there is no issue with `SkeletonModifier3D` which does not target external Nodes.