### PR TITLE
Fix error panel auto-hiding

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1668,9 +1668,9 @@ void CodeTextEditor::set_error_count(int p_error_count) {
 	error_button->set_text(itos(p_error_count));
 	error_button->set_visible(p_error_count > 0);
 	if (p_error_count > 0) {
-		_set_show_errors_panel(false);
 		idle->set_wait_time(idle_time_with_errors); // Parsing should happen sooner.
 	} else {
+		_set_show_errors_panel(false);
 		idle->set_wait_time(idle_time);
 	}
 }


### PR DESCRIPTION
Fixes a minor regression introduced in https://github.com/godotengine/godot/commit/02cc187

Before this commit, the error panel would auto-hide if the error count dropped to zero, but would keep its previous state if there were still errors. When this change was made, the call to `_set_show_errors_panel` was put in the wrong place (can also be seen relative to the behaviour in `set_warning_count` below), meaning the error panel is automatically hidden when the error count changes as long as it is above 0, and makes it impossible to close the error panel when the error count reduces to 0.

Fixes #104147
