### PR TITLE
Add option to change `virtual keyboard type` for all text input nodes

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -359,7 +359,7 @@
 		<member name="virtual_keyboard_enabled" type="bool" setter="set_virtual_keyboard_enabled" getter="is_virtual_keyboard_enabled" default="true">
 			If [code]true[/code], the native virtual keyboard is shown when focused on platforms that support it.
 		</member>
-		<member name="virtual_keyboard_type" type="int" setter="set_virtual_keyboard_type" getter="get_virtual_keyboard_type" enum="LineEdit.VirtualKeyboardType" default="0">
+		<member name="virtual_keyboard_type" type="int" setter="set_virtual_keyboard_type" getter="get_virtual_keyboard_type" enum="DisplayServer.VirtualKeyboardType" default="0">
 			Specifies the type of virtual keyboard to show.
 		</member>
 	</members>
@@ -486,31 +486,6 @@
 		</constant>
 		<constant name="MENU_MAX" value="31" enum="MenuItems">
 			Represents the size of the [enum MenuItems] enum.
-		</constant>
-		<constant name="KEYBOARD_TYPE_DEFAULT" value="0" enum="VirtualKeyboardType">
-			Default text virtual keyboard.
-		</constant>
-		<constant name="KEYBOARD_TYPE_MULTILINE" value="1" enum="VirtualKeyboardType">
-			Multiline virtual keyboard.
-		</constant>
-		<constant name="KEYBOARD_TYPE_NUMBER" value="2" enum="VirtualKeyboardType">
-			Virtual number keypad, useful for PIN entry.
-		</constant>
-		<constant name="KEYBOARD_TYPE_NUMBER_DECIMAL" value="3" enum="VirtualKeyboardType">
-			Virtual number keypad, useful for entering fractional numbers.
-		</constant>
-		<constant name="KEYBOARD_TYPE_PHONE" value="4" enum="VirtualKeyboardType">
-			Virtual phone number keypad.
-		</constant>
-		<constant name="KEYBOARD_TYPE_EMAIL_ADDRESS" value="5" enum="VirtualKeyboardType">
-			Virtual keyboard with additional keys to assist with typing email addresses.
-		</constant>
-		<constant name="KEYBOARD_TYPE_PASSWORD" value="6" enum="VirtualKeyboardType">
-			Virtual keyboard for entering a password. On most platforms, this should disable autocomplete and autocapitalization.
-			[b]Note:[/b] This is not supported on Web. Instead, this behaves identically to [constant KEYBOARD_TYPE_DEFAULT].
-		</constant>
-		<constant name="KEYBOARD_TYPE_URL" value="7" enum="VirtualKeyboardType">
-			Virtual keyboard with additional keys to assist with typing URLs.
 		</constant>
 	</constants>
 	<theme_items>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1395,6 +1395,9 @@
 		<member name="virtual_keyboard_enabled" type="bool" setter="set_virtual_keyboard_enabled" getter="is_virtual_keyboard_enabled" default="true">
 			If [code]true[/code], the native virtual keyboard is shown when focused on platforms that support it.
 		</member>
+		<member name="virtual_keyboard_type" type="int" setter="set_virtual_keyboard_type" getter="get_virtual_keyboard_type" enum="DisplayServer.VirtualKeyboardType" default="1">
+			Specifies the type of virtual keyboard to show.
+		</member>
 		<member name="wrap_mode" type="int" setter="set_line_wrapping_mode" getter="get_line_wrapping_mode" enum="TextEdit.LineWrappingMode" default="0">
 			Sets the line wrapping mode to use.
 		</member>

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2467,11 +2467,11 @@ bool LineEdit::is_virtual_keyboard_enabled() const {
 	return virtual_keyboard_enabled;
 }
 
-void LineEdit::set_virtual_keyboard_type(VirtualKeyboardType p_type) {
+void LineEdit::set_virtual_keyboard_type(DisplayServer::VirtualKeyboardType p_type) {
 	virtual_keyboard_type = p_type;
 }
 
-LineEdit::VirtualKeyboardType LineEdit::get_virtual_keyboard_type() const {
+DisplayServer::VirtualKeyboardType LineEdit::get_virtual_keyboard_type() const {
 	return virtual_keyboard_type;
 }
 
@@ -2954,15 +2954,6 @@ void LineEdit::_bind_methods() {
 	BIND_ENUM_CONSTANT(MENU_INSERT_SHY);
 	BIND_ENUM_CONSTANT(MENU_EMOJI_AND_SYMBOL);
 	BIND_ENUM_CONSTANT(MENU_MAX);
-
-	BIND_ENUM_CONSTANT(KEYBOARD_TYPE_DEFAULT);
-	BIND_ENUM_CONSTANT(KEYBOARD_TYPE_MULTILINE);
-	BIND_ENUM_CONSTANT(KEYBOARD_TYPE_NUMBER);
-	BIND_ENUM_CONSTANT(KEYBOARD_TYPE_NUMBER_DECIMAL);
-	BIND_ENUM_CONSTANT(KEYBOARD_TYPE_PHONE);
-	BIND_ENUM_CONSTANT(KEYBOARD_TYPE_EMAIL_ADDRESS);
-	BIND_ENUM_CONSTANT(KEYBOARD_TYPE_PASSWORD);
-	BIND_ENUM_CONSTANT(KEYBOARD_TYPE_URL);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text"), "set_text", "get_text");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "placeholder_text"), "set_placeholder", "get_placeholder");

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -72,17 +72,6 @@ public:
 		MENU_MAX
 	};
 
-	enum VirtualKeyboardType {
-		KEYBOARD_TYPE_DEFAULT,
-		KEYBOARD_TYPE_MULTILINE,
-		KEYBOARD_TYPE_NUMBER,
-		KEYBOARD_TYPE_NUMBER_DECIMAL,
-		KEYBOARD_TYPE_PHONE,
-		KEYBOARD_TYPE_EMAIL_ADDRESS,
-		KEYBOARD_TYPE_PASSWORD,
-		KEYBOARD_TYPE_URL
-	};
-
 private:
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_LEFT;
 
@@ -138,7 +127,7 @@ private:
 	bool shortcut_keys_enabled = true;
 
 	bool virtual_keyboard_enabled = true;
-	VirtualKeyboardType virtual_keyboard_type = KEYBOARD_TYPE_DEFAULT;
+	DisplayServer::VirtualKeyboardType virtual_keyboard_type = DisplayServer::KEYBOARD_TYPE_DEFAULT;
 
 	bool middle_mouse_paste_enabled = true;
 
@@ -381,8 +370,8 @@ public:
 	void set_virtual_keyboard_enabled(bool p_enable);
 	bool is_virtual_keyboard_enabled() const;
 
-	void set_virtual_keyboard_type(VirtualKeyboardType p_type);
-	VirtualKeyboardType get_virtual_keyboard_type() const;
+	void set_virtual_keyboard_type(DisplayServer::VirtualKeyboardType p_type);
+	DisplayServer::VirtualKeyboardType get_virtual_keyboard_type() const;
 
 	void set_middle_mouse_paste_enabled(bool p_enabled);
 	bool is_middle_mouse_paste_enabled() const;
@@ -417,4 +406,3 @@ public:
 };
 
 VARIANT_ENUM_CAST(LineEdit::MenuItems);
-VARIANT_ENUM_CAST(LineEdit::VirtualKeyboardType);

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -652,6 +652,7 @@ void SpinBox::_bind_methods() {
 SpinBox::SpinBox() {
 	line_edit = memnew(LineEdit);
 	line_edit->set_emoji_menu_enabled(false);
+	line_edit->set_virtual_keyboard_type(DisplayServer::KEYBOARD_TYPE_NUMBER_DECIMAL);
 	add_child(line_edit, false, INTERNAL_MODE_FRONT);
 
 	line_edit->set_theme_type_variation("SpinBoxInnerLineEdit");

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3031,7 +3031,7 @@ void TextEdit::_show_virtual_keyboard() {
 			caret_end = caret_start + post_text.length();
 		}
 
-		DisplayServer::get_singleton()->virtual_keyboard_show(get_text(), get_global_rect(), DisplayServer::KEYBOARD_TYPE_MULTILINE, -1, caret_start, caret_end);
+		DisplayServer::get_singleton()->virtual_keyboard_show(get_text(), get_global_rect(), DisplayServer::VirtualKeyboardType(virtual_keyboard_type), -1, caret_start, caret_end);
 	}
 }
 
@@ -3401,6 +3401,14 @@ void TextEdit::set_virtual_keyboard_enabled(bool p_enabled) {
 
 bool TextEdit::is_virtual_keyboard_enabled() const {
 	return virtual_keyboard_enabled;
+}
+
+void TextEdit::set_virtual_keyboard_type(DisplayServer::VirtualKeyboardType p_type) {
+	virtual_keyboard_type = p_type;
+}
+
+DisplayServer::VirtualKeyboardType TextEdit::get_virtual_keyboard_type() const {
+	return virtual_keyboard_type;
 }
 
 void TextEdit::set_middle_mouse_paste_enabled(bool p_enabled) {
@@ -6601,6 +6609,9 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_virtual_keyboard_enabled", "enabled"), &TextEdit::set_virtual_keyboard_enabled);
 	ClassDB::bind_method(D_METHOD("is_virtual_keyboard_enabled"), &TextEdit::is_virtual_keyboard_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_virtual_keyboard_type", "type"), &TextEdit::set_virtual_keyboard_type);
+	ClassDB::bind_method(D_METHOD("get_virtual_keyboard_type"), &TextEdit::get_virtual_keyboard_type);
+
 	ClassDB::bind_method(D_METHOD("set_middle_mouse_paste_enabled", "enabled"), &TextEdit::set_middle_mouse_paste_enabled);
 	ClassDB::bind_method(D_METHOD("is_middle_mouse_paste_enabled"), &TextEdit::is_middle_mouse_paste_enabled);
 
@@ -7002,6 +7013,7 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_on_focus_loss_enabled"), "set_deselect_on_focus_loss_enabled", "is_deselect_on_focus_loss_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_and_drop_selection_enabled"), "set_drag_and_drop_selection_enabled", "is_drag_and_drop_selection_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "virtual_keyboard_enabled"), "set_virtual_keyboard_enabled", "is_virtual_keyboard_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "virtual_keyboard_type", PROPERTY_HINT_ENUM, "Default,Multiline,Number,Decimal,Phone,Email,Password,URL"), "set_virtual_keyboard_type", "get_virtual_keyboard_type");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "middle_mouse_paste_enabled"), "set_middle_mouse_paste_enabled", "is_middle_mouse_paste_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "empty_selection_clipboard_enabled"), "set_empty_selection_clipboard_enabled", "is_empty_selection_clipboard_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "wrap_mode", PROPERTY_HINT_ENUM, "None,Boundary"), "set_line_wrapping_mode", "get_line_wrapping_mode");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -320,6 +320,7 @@ private:
 	bool emoji_menu_enabled = true;
 	bool shortcut_keys_enabled = true;
 	bool virtual_keyboard_enabled = true;
+	DisplayServer::VirtualKeyboardType virtual_keyboard_type = DisplayServer::KEYBOARD_TYPE_MULTILINE;
 	bool middle_mouse_paste_enabled = true;
 	bool empty_selection_clipboard_enabled = true;
 
@@ -780,6 +781,9 @@ public:
 
 	void set_virtual_keyboard_enabled(bool p_enabled);
 	bool is_virtual_keyboard_enabled() const;
+
+	void set_virtual_keyboard_type(DisplayServer::VirtualKeyboardType p_type);
+	DisplayServer::VirtualKeyboardType get_virtual_keyboard_type() const;
 
 	void set_middle_mouse_paste_enabled(bool p_enabled);
 	bool is_middle_mouse_paste_enabled() const;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11996 and closes https://github.com/godotengine/godot-proposals/issues/7449

- Added option to change `virtual keyboard type` in **TextEdit** and **CodeEdit**.
- Set `virtual keyboard type` default to KEYBOARD_TYPE_NUMBER_DECIMAL for **SpinBox**.
