### PR TITLE
Recycle `zstd` decompression context if possible, avoiding repeated allocations.

### DIFF
--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -42,6 +42,12 @@
 #include <brotli/decode.h>
 #endif
 
+// Caches for zstd.
+static BinaryMutex mutex;
+static ZSTD_DCtx *current_zstd_d_ctx = nullptr;
+static bool current_zstd_long_distance_matching;
+static int current_zstd_window_log_size;
+
 int Compression::compress(uint8_t *p_dst, const uint8_t *p_src, int p_src_size, Mode p_mode) {
 	switch (p_mode) {
 		case MODE_BROTLI: {
@@ -187,12 +193,22 @@ int Compression::decompress(uint8_t *p_dst, int p_dst_max_size, const uint8_t *p
 			return total;
 		} break;
 		case MODE_ZSTD: {
-			ZSTD_DCtx *dctx = ZSTD_createDCtx();
-			if (zstd_long_distance_matching) {
-				ZSTD_DCtx_setParameter(dctx, ZSTD_d_windowLogMax, zstd_window_log_size);
+			MutexLock lock(mutex);
+
+			if (!current_zstd_d_ctx || current_zstd_long_distance_matching != zstd_long_distance_matching || current_zstd_window_log_size != zstd_window_log_size) {
+				if (current_zstd_d_ctx) {
+					ZSTD_freeDCtx(current_zstd_d_ctx);
+				}
+
+				current_zstd_d_ctx = ZSTD_createDCtx();
+				if (zstd_long_distance_matching) {
+					ZSTD_DCtx_setParameter(current_zstd_d_ctx, ZSTD_d_windowLogMax, zstd_window_log_size);
+				}
+				current_zstd_long_distance_matching = zstd_long_distance_matching;
+				current_zstd_window_log_size = zstd_window_log_size;
 			}
-			int ret = ZSTD_decompressDCtx(dctx, p_dst, p_dst_max_size, p_src, p_src_size);
-			ZSTD_freeDCtx(dctx);
+
+			int ret = ZSTD_decompressDCtx(current_zstd_d_ctx, p_dst, p_dst_max_size, p_src, p_src_size);
 			return ret;
 		} break;
 	}


### PR DESCRIPTION
Today, I profiled allocations of tps demo.
Something peculiar caught my eye: zstd contexts made up for 3GB of allocations (and deallocations) throughout the launch! I rewrote the code to re-use the instance, reducing allocations massively and speeding up the game's launch time slightly.

All in all, this PR saves 3GB (30%) of allocations and deallocations of a tps-demo launch. This amounts to a tiny average of 0.006s improvement (0.34%) of the game's launch time. Even with such small speed gains, think it's worth it because it means far less memory may be churned by the OS, which should improve general system load.
To pay for it, only one `zstd` stream can be decompressed at once. In addition, the pointer to it will stay in memory. Napkin math suggests it's about 100kb.

## Details

I launched tps-demo and started the game. Upon successful launch, I immediately quit.

I profiled total allocations using Apple Instruments.
I inverted the call tree and found these top entries:
```
3304.22 MB      32.2%	35245	 	ZSTD_customMalloc
2086.02 MB      20.3%	3054587	 	Memory::alloc_static(unsigned long, bool)
1900.39 MB      18.5%	17745619	 	_malloc_type_malloc_outlined
 659.83 MB       6.4%	466	 	IOGPUResourceCreate
```

I implemented a very crude caching strategy that reuses the context as long as the parameters don't change. The instance will be lazily created on first zstd decompression, so it won't burden applications not using zstd.
I'm guessing the reallocation isn't necessary _at all_, technically. Somebody confirm it isn't and I will just set the parameter instead of reallocating on changes.

After my changes, the zstd entry disappears:
```
2099.70 MB      31.9%	3148754	 	Memory::alloc_static(unsigned long, bool)
1733.48 MB      26.3%	15592696	 	_malloc_type_malloc_outlined
 460.56 MB       7.0%	458	 	IOGPUResourceCreate
```

## Alternatives

It may be possible to cache a `Compression` instance in `ResourceLoaderBinary`, which is almost entirely the sole cause of decompression calls:
```
3304.22 MB      32.2%	35245	 	ZSTD_customMalloc
3304.22 MB      32.2%	35245	 	 Compression::decompress(unsigned char*, int, unsigned char const*, int, Compression::Mode)
3005.72 MB      29.2%	32061	 	  FileAccessCompressed::get_buffer(unsigned char*, unsigned long long) const
2942.06 MB      28.6%	31382	 	   ResourceLoaderBinary::parse_variant(Variant&)
```

Theoretically, this could save us from needing to keep a zstd instance in memory forever.
However, I don't see `ResourceLoaderBinary` being unloaded either, so it wouldn't really change anything. So I opted for the simple method and just keep zstd loaded statically.

