### PR TITLE
Add missing `String + char *` function, to avoid unnecessary right side allocation to `String`.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -365,6 +365,24 @@ String String::operator+(const String &p_str) const {
 	return res;
 }
 
+String String::operator+(const char *p_str) const {
+	String res = *this;
+	res += p_str;
+	return res;
+}
+
+String String::operator+(const wchar_t *p_str) const {
+	String res = *this;
+	res += p_str;
+	return res;
+}
+
+String String::operator+(const char32_t *p_str) const {
+	String res = *this;
+	res += p_str;
+	return res;
+}
+
 String String::operator+(char32_t p_char) const {
 	String res = *this;
 	res += p_char;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -330,6 +330,9 @@ public:
 	bool operator==(const String &p_str) const;
 	bool operator!=(const String &p_str) const;
 	String operator+(const String &p_str) const;
+	String operator+(const char *p_char) const;
+	String operator+(const wchar_t *p_char) const;
+	String operator+(const char32_t *p_char) const;
 	String operator+(char32_t p_char) const;
 
 	String &operator+=(const String &);


### PR DESCRIPTION
I found this when profiling tps-demo.

Adding this function:
- Reduces tps-demo string allocations throughout a launch from `~1577153` to `~1470533` (~7%).
- Reduces the size of Godot from 173,4mb to 172,7 (0.7mb, 0.4%).

It does not affect launch times (as much as I can measure).

The function has never existed (I think), so I recommend cherry-picking this to relevant branches.

## Explanation
Because this function was missing, callers needed to implicitly upgrade the right hand side of `String + char *` to `String` temporarily, like here:
https://github.com/godotengine/godot/blob/0028fd625e2c5b202e204bc12828cbca043213d3/servers/rendering/renderer_rd/shader_rd.cpp#L99

This resulted in hundreds of thousands of unnecessary allocations.