### PR TITLE
Add a dedicated editor for Camera2D limits

### DIFF
--- a/editor/plugins/camera_2d_editor_plugin.h
+++ b/editor/plugins/camera_2d_editor_plugin.h
@@ -52,7 +52,10 @@ class Camera2DEditor : public Control {
 		RIGHT,
 		BOTTOM,
 		CENTER,
-	} drag_type;
+	};
+	Drag drag_type = Drag::NONE;
+	Drag hover_type = Drag::NONE;
+
 	Rect2 drag_revert;
 	Vector2 center_drag_point;
 
@@ -64,6 +67,7 @@ class Camera2DEditor : public Control {
 	void _menu_option(int p_option);
 	void _snap_limits_to_viewport(Camera2D *p_camera);
 	void _update_overlays_if_needed(Camera2D *p_camera);
+	void _update_hover(const Vector2 &p_mouse_pos);
 
 protected:
 	static void _bind_methods();

--- a/editor/plugins/camera_2d_editor_plugin.h
+++ b/editor/plugins/camera_2d_editor_plugin.h
@@ -39,9 +39,22 @@ class MenuButton;
 class Camera2DEditor : public Control {
 	GDCLASS(Camera2DEditor, Control);
 
+	EditorPlugin *plugin = nullptr;
+
 	enum Menu {
 		MENU_SNAP_LIMITS_TO_VIEWPORT,
 	};
+
+	enum class Drag {
+		NONE,
+		LEFT,
+		TOP,
+		RIGHT,
+		BOTTOM,
+		CENTER,
+	} drag_type;
+	Rect2 drag_revert;
+	Vector2 center_drag_point;
 
 	Camera2D *selected_camera = nullptr;
 
@@ -49,8 +62,8 @@ class Camera2DEditor : public Control {
 	MenuButton *options = nullptr;
 
 	void _menu_option(int p_option);
-	void _snap_limits_to_viewport();
-	void _undo_snap_limits_to_viewport(const Rect2 &p_prev_rect);
+	void _snap_limits_to_viewport(Camera2D *p_camera);
+	void _update_overlays_if_needed(Camera2D *p_camera);
 
 protected:
 	static void _bind_methods();
@@ -58,7 +71,11 @@ protected:
 
 public:
 	void edit(Camera2D *p_camera);
-	Camera2DEditor();
+
+	bool forward_canvas_gui_input(const Ref<InputEvent> &p_event);
+	void forward_canvas_draw_over_viewport(Control *p_overlay);
+
+	Camera2DEditor(EditorPlugin *p_plugin);
 };
 
 class Camera2DEditorPlugin : public EditorPlugin {
@@ -66,15 +83,13 @@ class Camera2DEditorPlugin : public EditorPlugin {
 
 	Camera2DEditor *camera_2d_editor = nullptr;
 
-	Label *approach_to_move_rect = nullptr;
-
-	void _editor_theme_changed();
-	void _update_approach_text_visibility();
-
 public:
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
+
+	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return camera_2d_editor->forward_canvas_gui_input(p_event); }
+	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { camera_2d_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
 	Camera2DEditorPlugin();
 };

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2802,6 +2802,11 @@ void CanvasItemEditor::_gui_input_viewport(const Ref<InputEvent> &p_event) {
 }
 
 void CanvasItemEditor::_update_cursor() {
+	if (cursor_shape_override != CURSOR_ARROW) {
+		set_default_cursor_shape(cursor_shape_override);
+		return;
+	}
+
 	// Choose the correct default cursor.
 	CursorShape c = CURSOR_ARROW;
 	switch (tool) {
@@ -2863,6 +2868,14 @@ void CanvasItemEditor::_update_lock_and_group_button() {
 	group_button->set_disabled(!has_canvas_item);
 	ungroup_button->set_visible(all_group);
 	ungroup_button->set_disabled(!has_canvas_item);
+}
+
+void CanvasItemEditor::set_cursor_shape_override(CursorShape p_shape) {
+	if (cursor_shape_override == p_shape) {
+		return;
+	}
+	cursor_shape_override = p_shape;
+	_update_cursor();
 }
 
 Control::CursorShape CanvasItemEditor::get_cursor_shape(const Point2 &p_pos) const {

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -368,6 +368,7 @@ private:
 	Transform2D original_transform;
 
 	Point2 box_selecting_to;
+	CursorShape cursor_shape_override = CURSOR_ARROW;
 
 	Ref<StyleBoxTexture> select_sb;
 	Ref<Texture2D> select_handle;
@@ -584,6 +585,7 @@ public:
 	void focus_selection();
 	void center_at(const Point2 &p_pos);
 
+	void set_cursor_shape_override(CursorShape p_shape = CURSOR_ARROW);
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 
 	ThemePreviewMode get_theme_preview() const { return theme_preview; }

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -34,58 +34,6 @@
 #include "core/input/input.h"
 #include "scene/main/viewport.h"
 
-#ifdef TOOLS_ENABLED
-Dictionary Camera2D::_edit_get_state() const {
-	Dictionary state = Node2D::_edit_get_state();
-	state["limit_rect"] = get_limit_rect();
-	return state;
-}
-
-void Camera2D::_edit_set_state(const Dictionary &p_state) {
-	if (p_state.has("limit_rect")) {
-		_set_limit_rect(p_state["limit_rect"]);
-	}
-	Node2D::_edit_set_state(p_state);
-}
-
-void Camera2D::_edit_set_position(const Point2 &p_position) {
-	if (_is_dragging_limit_rect()) {
-		Rect2 rect = get_limit_rect();
-		rect.position = p_position;
-		_set_limit_rect(rect);
-	} else {
-		Node2D::_edit_set_position(p_position);
-	}
-}
-
-Point2 Camera2D::_edit_get_position() const {
-	return _is_dragging_limit_rect() ? get_limit_rect().position : Node2D::_edit_get_position();
-}
-
-void Camera2D::_edit_set_rect(const Rect2 &p_rect) {
-	ERR_FAIL_COND(limit_enabled && !_edit_use_rect());
-	Rect2 rect = p_rect;
-	Vector2 scl = get_global_scale().abs();
-	rect.size *= scl;
-	rect.position = (rect.position + get_global_position()) * scl;
-	_set_limit_rect(rect);
-}
-#endif // TOOLS_ENABLED
-
-#ifdef DEBUG_ENABLED
-Rect2 Camera2D::_edit_get_rect() const {
-	Rect2 rect = get_limit_rect();
-	Vector2 scl = get_global_scale().abs();
-	rect.size /= scl;
-	rect.position = (rect.position - get_global_position()) / scl;
-	return rect;
-}
-
-bool Camera2D::_edit_use_rect() const {
-	return limit_enabled;
-}
-#endif // DEBUG_ENABLED
-
 void Camera2D::_update_scroll() {
 	if (!is_inside_tree() || !viewport) {
 		return;
@@ -120,10 +68,6 @@ void Camera2D::_update_scroll() {
 }
 
 #ifdef TOOLS_ENABLED
-bool Camera2D::_is_dragging_limit_rect() const {
-	return _edit_use_rect() && Input::get_singleton()->is_key_pressed(Key::CTRL);
-}
-
 void Camera2D::_project_settings_changed() {
 	if (screen_drawing_enabled) {
 		queue_redraw();
@@ -470,18 +414,9 @@ void Camera2D::_notification(int p_what) {
 					limit_drawing_width = 3;
 				}
 
-				Transform2D inv_transform = get_global_transform().affine_inverse();
-
-				Vector2 limit_points[4] = {
-					inv_transform.xform(Vector2(limit[SIDE_LEFT], limit[SIDE_TOP])),
-					inv_transform.xform(Vector2(limit[SIDE_RIGHT], limit[SIDE_TOP])),
-					inv_transform.xform(Vector2(limit[SIDE_RIGHT], limit[SIDE_BOTTOM])),
-					inv_transform.xform(Vector2(limit[SIDE_LEFT], limit[SIDE_BOTTOM]))
-				};
-
-				for (int i = 0; i < 4; i++) {
-					draw_line(limit_points[i], limit_points[(i + 1) % 4], Color(1, 1, 0.25, 0.63), limit_drawing_width);
-				}
+				draw_set_transform_matrix(get_global_transform().affine_inverse());
+				draw_rect(get_limit_rect(), Color(1, 1, 0.25, 0.63), false, limit_drawing_width);
+				draw_set_transform_matrix(Transform2D());
 			}
 
 			if (margin_drawing_enabled) {
@@ -564,9 +499,6 @@ void Camera2D::set_limit_enabled(bool p_limit_enabled) {
 	}
 	limit_enabled = p_limit_enabled;
 	_update_scroll();
-#ifdef TOOLS_ENABLED
-	emit_signal("_camera_limit_enabled_updated"); // Used for Camera2DEditorPlugin.
-#endif
 }
 
 bool Camera2D::is_limit_enabled() const {
@@ -632,8 +564,8 @@ void Camera2D::_make_current(Object *p_which) {
 	}
 }
 
-void Camera2D::_set_limit_rect(const Rect2 &p_limit_rect) {
-	Point2 limit_rect_end = p_limit_rect.get_end();
+void Camera2D::set_limit_rect(const Rect2 &p_limit_rect) {
+	const Point2 limit_rect_end = p_limit_rect.get_end();
 	set_limit(SIDE_LEFT, p_limit_rect.position.x);
 	set_limit(SIDE_TOP, p_limit_rect.position.y);
 	set_limit(SIDE_RIGHT, limit_rect_end.x);
@@ -964,6 +896,7 @@ void Camera2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_limit", "margin", "limit"), &Camera2D::set_limit);
 	ClassDB::bind_method(D_METHOD("get_limit", "margin"), &Camera2D::get_limit);
+	ClassDB::bind_method(D_METHOD("_set_limit_rect", "rect"), &Camera2D::set_limit_rect);
 
 	ClassDB::bind_method(D_METHOD("set_limit_smoothing_enabled", "limit_smoothing_enabled"), &Camera2D::set_limit_smoothing_enabled);
 	ClassDB::bind_method(D_METHOD("is_limit_smoothing_enabled"), &Camera2D::is_limit_smoothing_enabled);
@@ -1066,8 +999,4 @@ void Camera2D::_bind_methods() {
 Camera2D::Camera2D() {
 	set_notify_transform(true);
 	set_hide_clip_children(true);
-
-#ifdef TOOLS_ENABLED
-	add_user_signal(MethodInfo("_camera_limit_enabled_updated")); // Camera2DEditorPlugin listens to this.
-#endif
 }

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -564,16 +564,16 @@ void Camera2D::_make_current(Object *p_which) {
 	}
 }
 
-void Camera2D::set_limit_rect(const Rect2 &p_limit_rect) {
-	const Point2 limit_rect_end = p_limit_rect.get_end();
+void Camera2D::set_limit_rect(const Rect2i &p_limit_rect) {
+	const Point2i limit_rect_end = p_limit_rect.get_end();
 	set_limit(SIDE_LEFT, p_limit_rect.position.x);
 	set_limit(SIDE_TOP, p_limit_rect.position.y);
 	set_limit(SIDE_RIGHT, limit_rect_end.x);
 	set_limit(SIDE_BOTTOM, limit_rect_end.y);
 }
 
-Rect2 Camera2D::get_limit_rect() const {
-	return Rect2(limit[SIDE_LEFT], limit[SIDE_TOP], limit[SIDE_RIGHT] - limit[SIDE_LEFT], limit[SIDE_BOTTOM] - limit[SIDE_TOP]);
+Rect2i Camera2D::get_limit_rect() const {
+	return Rect2i(limit[SIDE_LEFT], limit[SIDE_TOP], limit[SIDE_RIGHT] - limit[SIDE_LEFT], limit[SIDE_BOTTOM] - limit[SIDE_TOP]);
 }
 
 void Camera2D::make_current() {

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -90,7 +90,6 @@ protected:
 	void _update_scroll();
 
 #ifdef TOOLS_ENABLED
-	bool _is_dragging_limit_rect() const;
 	void _project_settings_changed();
 #endif
 
@@ -98,8 +97,6 @@ protected:
 	void _reset_just_exited() { just_exited_tree = false; }
 
 	void _update_process_internal_for_smoothing();
-
-	void _set_limit_rect(const Rect2 &p_limit_rect);
 
 	bool screen_drawing_enabled = true;
 	bool limit_drawing_enabled = false;
@@ -124,22 +121,7 @@ protected:
 	static void _bind_methods();
 
 public:
-#ifdef TOOLS_ENABLED
-	virtual Dictionary _edit_get_state() const override;
-	virtual void _edit_set_state(const Dictionary &p_state) override;
-
-	virtual void _edit_set_position(const Point2 &p_position) override;
-	virtual Point2 _edit_get_position() const override;
-
-	virtual void _edit_set_rect(const Rect2 &p_rect) override;
-	virtual Size2 _edit_get_minimum_size() const override { return Size2(); }
-#endif // TOOLS_ENABLED
-
-#ifdef DEBUG_ENABLED
-	virtual Rect2 _edit_get_rect() const override;
-	virtual bool _edit_use_rect() const override;
-#endif // DEBUG_ENABLED
-
+	void set_limit_rect(const Rect2 &p_limit_rect);
 	Rect2 get_limit_rect() const;
 
 	void set_offset(const Vector2 &p_offset);

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -121,8 +121,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_limit_rect(const Rect2 &p_limit_rect);
-	Rect2 get_limit_rect() const;
+	void set_limit_rect(const Rect2i &p_limit_rect);
+	Rect2i get_limit_rect() const;
 
 	void set_offset(const Vector2 &p_offset);
 	Vector2 get_offset() const;


### PR DESCRIPTION
This improves #101427 by replacing default rect edit with a dedicated editor (and also fixes multiple Camera2DEditor bugs). The main benefit is that camera is no longer selected when clicking within it's limit rectangle.
In a separate commit I added functionality for overriding 2D editor's cursor, which makes the editor much more friendly.

https://github.com/user-attachments/assets/ba9deb13-e1c0-4948-8938-1aafbe9090c5

We could apply it to other existing editors, e.g. CollisionShape2D editor.

Closes #105077
Fixes #107409