### PR TITLE
Make EditorPropertyColor popup draggable

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2616,12 +2616,34 @@ void EditorPropertyColor::_popup_opening() {
 	EditorNode::get_singleton()->setup_color_picker(picker->get_picker());
 	last_color = picker->get_pick_color();
 	was_checked = !is_checkable() || is_checked();
+
+	PopupPanel *popup = picker->get_popup();
+	if (popup->get_mode() == Window::MODE_MINIMIZED) {
+		popup->set_mode(Window::MODE_WINDOWED);
+	}
+
+	if (!was_setup) {
+		popup->set_flag(Window::FLAG_BORDERLESS, false);
+		popup->connect("visibility_changed", callable_mp(this, &EditorPropertyColor::_popup_visibility_changed));
+	}
+	was_setup = true;
 }
 
 void EditorPropertyColor::_popup_closed() {
 	get_edited_object()->set(get_edited_property(), was_checked ? Variant(last_color) : Variant());
 	if (!picker->get_pick_color().is_equal_approx(last_color)) {
 		emit_changed(get_edited_property(), picker->get_pick_color(), "", false);
+	}
+}
+
+void EditorPropertyColor::_popup_visibility_changed() {
+	PopupPanel *popup = picker->get_popup();
+	// Shift popup so it doesn't cover the button.
+	if (popup && popup->is_visible()) {
+		Point2 pos = popup->get_position();
+		int title_size = pos.y - popup->get_position_with_decorations().y;
+		bool below = (picker->get_screen_position().y <= pos.y);
+		popup->set_position(Point2(pos.x, MAX(title_size, pos.y + (below ? title_size : 0))));
 	}
 }
 

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -595,10 +595,12 @@ class EditorPropertyColor : public EditorProperty {
 	void _picker_created();
 	void _popup_opening();
 	void _popup_closed();
+	void _popup_visibility_changed();
 
 	Color last_color;
 	bool live_changes_enabled = true;
 	bool was_checked = false;
+	bool was_setup = false;
 
 protected:
 	virtual void _set_read_only(bool p_read_only) override;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes https://github.com/godotengine/godot-proposals/issues/5764

This sets the popup's `borderless` value to `false`. Since bordered windows can be minimized, this also unminimizes the popup before opening again (preventing glitchy behavior). Finally it readjusts the position of the popup so the borders don't cover the original button