### PR TITLE
Improve/fix `TileMap` and `TileSet` editors UI

### DIFF
--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -2371,6 +2371,7 @@ TileMapLayerEditorTilesPlugin::TileMapLayerEditorTilesPlugin() {
 
 	missing_source_label = memnew(Label);
 	missing_source_label->set_text(TTR("This TileMap's TileSet has no Tile Source configured. Go to the TileSet bottom panel to add one."));
+	missing_source_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	missing_source_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	missing_source_label->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	missing_source_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
@@ -2489,8 +2490,9 @@ TileMapLayerEditorTilesPlugin::TileMapLayerEditorTilesPlugin() {
 
 	patterns_help_label = memnew(Label);
 	patterns_help_label->set_text(TTR("Drag and drop or paste a TileMap selection here to store a pattern."));
+	patterns_help_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	patterns_help_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	patterns_help_label->set_anchors_and_offsets_preset(Control::PRESET_CENTER);
+	patterns_help_label->set_anchors_and_offsets_preset(Control::PRESET_HCENTER_WIDE);
 	patterns_item_list->add_child(patterns_help_label);
 
 	// Update.
@@ -4113,6 +4115,7 @@ void TileMapLayerEditor::_tab_changed(int p_tab_id) {
 	// Graphical update.
 	tabs_data[tabs_bar->get_current_tab()].panel->queue_redraw();
 	CanvasItemEditor::get_singleton()->update_viewport();
+	_update_bottom_panel();
 }
 
 void TileMapLayerEditor::_layers_select_next_or_previous(bool p_next) {
@@ -4521,6 +4524,8 @@ TileMapLayerEditor::TileMapLayerEditor() {
 
 	// A label for editing errors.
 	cant_edit_label = memnew(Label);
+	cant_edit_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
+	cant_edit_label->set_anchors_and_offsets_preset(Control::PRESET_HCENTER_WIDE);
 	cant_edit_label->set_h_size_flags(SIZE_EXPAND_FILL);
 	cant_edit_label->set_v_size_flags(SIZE_EXPAND_FILL);
 	cant_edit_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -968,7 +968,15 @@ void TileSetAtlasSourceEditor::_update_atlas_view() {
 	if (tile_set.is_null()) {
 		return;
 	} else {
-		tile_create_help->set_visible(tools_button_group->get_pressed_button() == tool_setup_atlas_source_button);
+		if (tools_button_group->get_pressed_button() == tool_setup_atlas_source_button) {
+			help_label->set_visible(true);
+			help_label->set_text(TTR("Hold Ctrl to create multiple tiles.") + "\n" + TTR("Hold Shift to create big tiles."));
+		} else if (tools_button_group->get_pressed_button() == tool_select_button) {
+			help_label->set_visible(true);
+			help_label->set_text(TTRC("Hold Shift to select multiple regions."));
+		} else {
+			help_label->set_visible(false);
+		}
 	}
 
 	if (tools_button_group->get_pressed_button() != tool_paint_button) {
@@ -2685,18 +2693,12 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tile_atlas_view->connect("transform_changed", callable_mp(this, &TileSetAtlasSourceEditor::_tile_atlas_view_transform_changed).unbind(2));
 	right_panel->add_child(tile_atlas_view);
 
-	tile_create_help = memnew(VBoxContainer);
-	tile_atlas_view->add_child(tile_create_help);
-	tile_create_help->set_mouse_filter(MOUSE_FILTER_IGNORE);
-
-	Label *help_label = memnew(Label(TTR("Hold Ctrl to create multiple tiles.")));
-	tile_create_help->add_child(help_label);
-
-	help_label = memnew(Label(TTR("Hold Shift to create big tiles.")));
-	tile_create_help->add_child(help_label);
-
-	tile_create_help->set_anchors_and_offsets_preset(Control::PRESET_BOTTOM_LEFT, Control::PRESET_MODE_MINSIZE, 8);
-	tile_create_help->set_grow_direction_preset(Control::PRESET_BOTTOM_LEFT);
+	help_label = memnew(Label);
+	help_label->set_mouse_filter(MOUSE_FILTER_IGNORE);
+	help_label->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+	help_label->set_vertical_alignment(VERTICAL_ALIGNMENT_BOTTOM);
+	help_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
+	tile_atlas_view->add_child(help_label);
 
 	base_tile_popup_menu = memnew(PopupMenu);
 	base_tile_popup_menu->add_shortcut(ED_GET_SHORTCUT("tiles_editor/delete"), TILE_DELETE);

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -159,7 +159,7 @@ private:
 
 	// -- Atlas view --
 	TileAtlasView *tile_atlas_view = nullptr;
-	VBoxContainer *tile_create_help = nullptr;
+	Label *help_label = nullptr;
 
 	// Dragging
 	enum DragType {

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -914,6 +914,8 @@ TileSetEditor::TileSetEditor() {
 	// No source selected.
 	no_source_selected_label = memnew(Label);
 	no_source_selected_label->set_text(TTR("No TileSet source selected. Select or create a TileSet source.\nYou can create a new source by using the Add button on the left or by dropping a tileset texture onto the source list."));
+	no_source_selected_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
+	no_source_selected_label->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 	no_source_selected_label->set_h_size_flags(SIZE_EXPAND_FILL);
 	no_source_selected_label->set_v_size_flags(SIZE_EXPAND_FILL);
 	no_source_selected_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
@@ -953,8 +955,9 @@ TileSetEditor::TileSetEditor() {
 
 	patterns_help_label = memnew(Label);
 	patterns_help_label->set_text(TTR("Add new patterns in the TileMap editing mode."));
+	patterns_help_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	patterns_help_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	patterns_help_label->set_anchors_and_offsets_preset(Control::PRESET_CENTER);
+	patterns_help_label->set_anchors_and_offsets_preset(Control::PRESET_HCENTER_WIDE);
 	patterns_item_list->add_child(patterns_help_label);
 
 	// Expanded editor
@@ -978,6 +981,8 @@ void TileSourceInspectorPlugin::_show_id_edit_dialog(Object *p_for_source) {
 
 		Label *label = memnew(Label(TTR("Warning: Modifying a source ID will result in all TileMaps using that source to reference an invalid source instead. This may result in unexpected data loss. Change this ID carefully.")));
 		label->set_autowrap_mode(TextServer::AUTOWRAP_WORD);
+		// Workaround too tall popup window due to text autowrapping. See GH-83546.
+		label->set_custom_minimum_size(Vector2i(400, 0));
 		vbox->add_child(label);
 
 		id_input = memnew(SpinBox);

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -44,8 +44,8 @@ class SplitContainer;
 class EditorFileDialog;
 class EditorInspectorPlugin;
 
-class TileSetEditor : public Control {
-	GDCLASS(TileSetEditor, Control);
+class TileSetEditor : public MarginContainer {
+	GDCLASS(TileSetEditor, MarginContainer);
 
 	static TileSetEditor *singleton;
 


### PR DESCRIPTION
Actually, contains almost only bugfixes.
Partially extracted from https://github.com/godotengine/godot/pull/102301

1) Fix sizing issues for labels being cut when parent size is small by enabling autowrapping. For really long text trimming also enabled.

<details>
  <summary>Before\after</summary>

| | Before | After |
| --- | ---- | ---- |
| `TileSet` shortcuts info. Also here multiple labels in container are replaced with single label. | ![image](https://github.com/user-attachments/assets/4cc49244-9c5c-4667-9228-aa06fb3dd80a) | ![image](https://github.com/user-attachments/assets/4457e583-b56f-4e5e-aa21-9be9be029a3d) |
| `TileSet` patterns | ![image](https://github.com/user-attachments/assets/01be30cd-6218-42ef-a191-58d9bf1b5d9a) | ![image](https://github.com/user-attachments/assets/7a65dcc4-12f7-48b4-8605-d087256d59b2)  |
| `TileMap` patterns | ![image](https://github.com/user-attachments/assets/7c192cbb-33ec-4208-b7cd-67dc2580386e) | ![image](https://github.com/user-attachments/assets/045fbf14-fbc7-40b2-8fa9-d5e0c2e3a761)  |
| `TileSet`, no existing sources. Text trimming added to prevent editor going out of screen. | ![image](https://github.com/user-attachments/assets/30bb080f-ba61-401a-adcd-64cc4bde3e31) | ![image](https://github.com/user-attachments/assets/2a550c54-14c5-46eb-a0dd-a79a7b9ad5b4) |
| `TileMap`, no existing sources in `TileSet`. Leads to part of right inspector doc being out of screen when editor window size is minimized | ![image](https://github.com/user-attachments/assets/65e70736-d793-4fb6-b75c-3a39c80d88b9) | ![image](https://github.com/user-attachments/assets/d5f83d60-65d2-487e-936d-2f8881b16886) |

</details>

2) Fix sizing issues for `TileSet` editor when minimizing it. Solved by changing its from `Control` to `MarginContainer`, so it can not get smaller then needed to show all its content. 

<details>
  <summary>Before\after</summary>

| Before | After |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/560f72d9-01da-4ff3-86f1-8f26fd41511e) | ![image](https://github.com/user-attachments/assets/6f761e96-53cf-42e9-9dab-2a09f065602a) |

</details>

3) Fix `TileSet` source ID changing confirmation dialog being too tall when opening it first time (and, what is important, almost impossible to access on small-screen devices).

<details>
  <summary>Before\after</summary>

| Before | After |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/8ca9e9a3-d2c7-46c8-a813-7835e5563763) | ![image](https://github.com/user-attachments/assets/72d50a48-a9de-4679-a7fa-ccbb6d5dccf9) |

</details>

4) Fix tilemap editor panels being visible after disabling layer and switching to any tab:

![image](https://github.com/user-attachments/assets/11dc2c88-f0e4-4b3b-af10-1ee0fa4c80e2)

5) Add shortcut info label to tiles selection window.

![godot windows editor dev x86_64_esA5IxQlsv](https://github.com/user-attachments/assets/e20f2a41-fb9a-4d98-953e-167096801069)