### PR TITLE
Unbind `CSGShape::_update_shape()` and make it public

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -208,13 +208,13 @@ float CSGShape3D::get_snap() const {
 
 void CSGShape3D::_make_dirty(bool p_parent_removing) {
 	if ((p_parent_removing || is_root_shape()) && !dirty) {
-		callable_mp(this, &CSGShape3D::_update_shape).call_deferred(); // Must be deferred; otherwise, is_root_shape() will use the previous parent.
+		callable_mp(this, &CSGShape3D::update_shape).call_deferred(); // Must be deferred; otherwise, is_root_shape() will use the previous parent.
 	}
 
 	if (!is_root_shape()) {
 		parent_shape->_make_dirty();
 	} else if (!dirty) {
-		callable_mp(this, &CSGShape3D::_update_shape).call_deferred();
+		callable_mp(this, &CSGShape3D::update_shape).call_deferred();
 	}
 
 	dirty = true;
@@ -550,7 +550,7 @@ void CSGShape3D::mikktSetTSpaceDefault(const SMikkTSpaceContext *pContext, const
 	surface.tansw[i++] = d < 0 ? -1 : 1;
 }
 
-void CSGShape3D::_update_shape() {
+void CSGShape3D::update_shape() {
 	if (!is_root_shape()) {
 		return;
 	}
@@ -969,13 +969,13 @@ Ref<TriangleMesh> CSGShape3D::generate_triangle_mesh() const {
 }
 
 void CSGShape3D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_update_shape"), &CSGShape3D::_update_shape);
 	ClassDB::bind_method(D_METHOD("is_root_shape"), &CSGShape3D::is_root_shape);
 
 	ClassDB::bind_method(D_METHOD("set_operation", "operation"), &CSGShape3D::set_operation);
 	ClassDB::bind_method(D_METHOD("get_operation"), &CSGShape3D::get_operation);
 
 #ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("_update_shape"), &CSGShape3D::update_shape);
 	ClassDB::bind_method(D_METHOD("set_snap", "snap"), &CSGShape3D::set_snap);
 	ClassDB::bind_method(D_METHOD("get_snap"), &CSGShape3D::get_snap);
 #endif // DISABLE_DEPRECATED

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -109,7 +109,6 @@ private:
 	static void mikktSetTSpaceDefault(const SMikkTSpaceContext *pContext, const float fvTangent[], const float fvBiTangent[], const float fMagS, const float fMagT,
 			const tbool bIsOrientationPreserving, const int iFace, const int iVert);
 
-	void _update_shape();
 	void _update_collision_faces();
 	bool _is_debug_collision_shape_visible();
 	void _update_debug_collision_shape();
@@ -132,6 +131,7 @@ protected:
 
 public:
 	Array get_meshes() const;
+	void update_shape();
 
 	void set_operation(Operation p_operation);
 	Operation get_operation() const;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5926,7 +5926,7 @@ void GLTFDocument::_convert_csg_shape_to_gltf(CSGShape3D *p_current, GLTFNodeInd
 	ERR_FAIL_MSG("csg module is disabled.");
 #else
 	CSGShape3D *csg = p_current;
-	csg->call("_update_shape");
+	csg->update_shape();
 	Array meshes = csg->get_meshes();
 	if (meshes.size() != 2) {
 		return;


### PR DESCRIPTION
Closes #39706

Looks like the method was only bound to circumvent it being private.