### PR TITLE
SCons: Fix broken msvc conditional

### DIFF
--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -124,7 +124,7 @@ if env["d3d12"]:
             Copy("$TARGET", "$SOURCE"),
         )
 
-if not os.getenv("VCINSTALLDIR"):
+if not env.msvc:
     if env["debug_symbols"]:
         env.AddPostAction(prog, env.Run(platform_windows_builders.make_debug_mingw))
         if env["windows_subsystem"] == "gui":


### PR DESCRIPTION
- Fixes #104197 

Removes a deprecated conditional; now `env.msvc` is called exclusively