### PR TITLE
Update BoneAttachment3D transform when setting the bone index

### DIFF
--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -143,7 +143,7 @@ void BoneAttachment3D::_check_bind() {
 		if (bone_idx != -1) {
 			sk->connect(SceneStringName(skeleton_updated), callable_mp(this, &BoneAttachment3D::on_skeleton_update));
 			bound = true;
-			callable_mp(this, &BoneAttachment3D::on_skeleton_update);
+			on_skeleton_update();
 		}
 	}
 }
@@ -220,7 +220,7 @@ void BoneAttachment3D::set_bone_idx(const int &p_idx) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (bone_idx <= -1 || bone_idx >= sk->get_bone_count()) {
-			WARN_PRINT("Bone index out of range! Cannot connect BoneAttachment to node!");
+			WARN_PRINT("Bone index " + itos(bone_idx) + " out of range! Cannot connect BoneAttachment to node!");
 			bone_idx = -1;
 		} else {
 			bone_name = sk->get_bone_name(bone_idx);
@@ -229,6 +229,8 @@ void BoneAttachment3D::set_bone_idx(const int &p_idx) {
 
 	if (is_inside_tree()) {
 		_check_bind();
+	} else {
+		on_skeleton_update();
 	}
 
 	notify_property_list_changed();
@@ -336,6 +338,7 @@ void BoneAttachment3D::on_skeleton_update() {
 	}
 	updating = false;
 }
+
 #ifdef TOOLS_ENABLED
 void BoneAttachment3D::notify_skeleton_bones_renamed(Node *p_base_scene, Skeleton3D *p_skeleton, Dictionary p_rename_map) {
 	const Skeleton3D *parent = nullptr;


### PR DESCRIPTION
Fixes #95751, fixes #105616

This PR fixes an issue encountered by the Blender Project DogWalk team where BoneAttachment3D nodes were not reading the transform of their attached bones when the bone was set. This is rarely noticeable in practice because there are other events that can cause the transform to update, such as opening the scene in the editor, or playing an animation.

However, the transform was not being updated during import of 3D scenes such as glTF files. If you viewed the imported scene in the editor, it would appear fine, because the editor causes the transform to update. But when directly using an imported glTF scene with a non-animated skeleton, the bug occurs.

Also, even if you do edit and save the scene using editable children or inherited scenes, this will create dozens of entries in that new scene since the BoneAttachment3D transform is considered different than the base file, causing version control noise, and more importantly, headaches where the transform is unexpectedly overridden to an older value. Imagine how frustrating it would be for people if they change the transform in Blender and nothing happens in Godot because Godot decided to overwrite the transform with the same value thanks to this bug.