### PR TITLE
Fix `GridMap` shortcuts being triggered during freelook (mouse captured)

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -674,7 +674,9 @@ void GridMapEditor::_show_viewports_transform_gizmo(bool p_value) {
 }
 
 EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D *p_camera, const Ref<InputEvent> &p_event) {
-	if (!node) {
+	// If the mouse is currently captured, we are most likely in freelook mode.
+	// In this case, disable shortcuts to avoid conflicts with freelook navigation.
+	if (!node || Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
 		return EditorPlugin::AFTER_GUI_INPUT_PASS;
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes: https://github.com/godotengine/godot/issues/104122