### PR TITLE
Fix rest translation space in `LookAtModifier3D`

### DIFF
--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -502,10 +502,10 @@ void LookAtModifier3D::_process_modification() {
 	int parent_bone = skeleton->get_bone_parent(bone);
 	if (parent_bone < 0) {
 		bone_rest_space = skeleton->get_global_transform();
-		bone_rest_space.origin += skeleton->get_bone_rest(bone).origin;
+		bone_rest_space.translate_local(skeleton->get_bone_rest(bone).origin);
 	} else {
 		bone_rest_space = skeleton->get_global_transform() * skeleton->get_bone_global_pose(parent_bone);
-		bone_rest_space.origin += skeleton->get_bone_rest(bone).origin;
+		bone_rest_space.translate_local(skeleton->get_bone_rest(bone).origin);
 	}
 
 	// Calculate forward_vector and destination.


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/104216
- Follow up https://github.com/godotengine/godot/pull/101311

Before #101311, LookAtModifier3D local translation was done in its own rotation space. After #101311, it now does global translation in the parent's rotational space, but it should correctly do local translation in the parent's rotational space.

Before:
![image](https://github.com/user-attachments/assets/a35c04da-894e-470b-92b6-bc856b28cc08)

After fixed:
![image](https://github.com/user-attachments/assets/dea02aec-1b2f-4300-bc23-c1a9f1b573ed)
