### PR TITLE
Fix hash issue with OptimizedTranslation caused by signed char

### DIFF
--- a/core/string/optimized_translation.h
+++ b/core/string/optimized_translation.h
@@ -64,7 +64,7 @@ class OptimizedTranslation : public Translation {
 			d = 0x1000193;
 		}
 		while (*p_str) {
-			d = (d * 0x1000193) ^ uint32_t(*p_str);
+			d = (d * 0x1000193) ^ static_cast<uint8_t>(*p_str);
 			p_str++;
 		}
 


### PR DESCRIPTION
- Fixes #86849

According to https://github.com/godotengine/godot/pull/78580#issuecomment-1732571557, non-ASCII characters have different hash depending on platform. Use `static_cast` to ensure correct handling for keys.

NOTE: After the fix, csv translations that use non-ASCII keys need to be re-imported.

MRP: 
[translation_key_issue.zip](https://github.com/user-attachments/files/19269792/translation_key_issue.zip)

<img src="https://github.com/user-attachments/assets/ef802253-170a-4601-81da-1addc6f20fae" alt="image" width="300">