### PR TITLE
Fix tangent baking for curves when cubic derivatives are 0

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -881,12 +881,22 @@ void Curve2D::_bake_segment2d_even_length(RBMap<real_t, Vector2> &r_bake, real_t
 
 Vector2 Curve2D::_calculate_tangent(const Vector2 &p_begin, const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, const real_t p_t) {
 	// Handle corner cases.
-	if (Math::is_zero_approx(p_t - 0.0f) && p_control_1.is_equal_approx(p_begin)) {
-		return (p_end - p_begin).normalized();
-	}
-
-	if (Math::is_zero_approx(p_t - 1.0f) && p_control_2.is_equal_approx(p_end)) {
-		return (p_end - p_begin).normalized();
+	if (Math::is_zero_approx(p_t - 0.0f)) {
+		if (p_control_1.is_equal_approx(p_begin)) {
+			if (p_control_1.is_equal_approx(p_control_2)) {
+				return (p_end - p_begin).normalized();
+			} else {
+				return (p_control_2 - p_begin).normalized();
+			}
+		}
+	} else if (Math::is_zero_approx(p_t - 1.0f)) {
+		if (p_control_2.is_equal_approx(p_end)) {
+			if (p_control_2.is_equal_approx(p_control_1)) {
+				return (p_end - p_begin).normalized();
+			} else {
+				return (p_end - p_control_1).normalized();
+			}
+		}
 	}
 
 	return p_begin.bezier_derivative(p_control_1, p_control_2, p_end, p_t).normalized();
@@ -1620,12 +1630,22 @@ void Curve3D::_bake_segment3d_even_length(RBMap<real_t, Vector3> &r_bake, real_t
 
 Vector3 Curve3D::_calculate_tangent(const Vector3 &p_begin, const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) {
 	// Handle corner cases.
-	if (Math::is_zero_approx(p_t - 0.0f) && p_control_1.is_equal_approx(p_begin)) {
-		return (p_end - p_begin).normalized();
-	}
-
-	if (Math::is_zero_approx(p_t - 1.0f) && p_control_2.is_equal_approx(p_end)) {
-		return (p_end - p_begin).normalized();
+	if (Math::is_zero_approx(p_t - 0.0f)) {
+		if (p_control_1.is_equal_approx(p_begin)) {
+			if (p_control_1.is_equal_approx(p_control_2)) {
+				return (p_end - p_begin).normalized();
+			} else {
+				return (p_control_2 - p_begin).normalized();
+			}
+		}
+	} else if (Math::is_zero_approx(p_t - 1.0f)) {
+		if (p_control_2.is_equal_approx(p_end)) {
+			if (p_control_2.is_equal_approx(p_control_1)) {
+				return (p_end - p_begin).normalized();
+			} else {
+				return (p_end - p_control_1).normalized();
+			}
+		}
 	}
 
 	return p_begin.bezier_derivative(p_control_1, p_control_2, p_end, p_t).normalized();

--- a/tests/scene/test_path_follow_3d.h
+++ b/tests/scene/test_path_follow_3d.h
@@ -45,7 +45,8 @@ bool is_equal_approx(const Vector3 &p_a, const Vector3 &p_b) {
 }
 
 TEST_CASE("[SceneTree][PathFollow3D] Sampling with progress ratio") {
-	Ref<Curve3D> curve = memnew(Curve3D);
+	Ref<Curve3D> curve;
+	curve.instantiate();
 	curve->add_point(Vector3(0, 0, 0));
 	curve->add_point(Vector3(100, 0, 0));
 	curve->add_point(Vector3(100, 100, 0));
@@ -89,7 +90,8 @@ TEST_CASE("[SceneTree][PathFollow3D] Sampling with progress ratio") {
 }
 
 TEST_CASE("[SceneTree][PathFollow3D] Sampling with progress") {
-	Ref<Curve3D> curve = memnew(Curve3D);
+	Ref<Curve3D> curve;
+	curve.instantiate();
 	curve->add_point(Vector3(0, 0, 0));
 	curve->add_point(Vector3(100, 0, 0));
 	curve->add_point(Vector3(100, 100, 0));
@@ -133,7 +135,8 @@ TEST_CASE("[SceneTree][PathFollow3D] Sampling with progress") {
 }
 
 TEST_CASE("[SceneTree][PathFollow3D] Removal of a point in curve") {
-	Ref<Curve3D> curve = memnew(Curve3D);
+	Ref<Curve3D> curve;
+	curve.instantiate();
 	curve->add_point(Vector3(0, 0, 0));
 	curve->add_point(Vector3(100, 0, 0));
 	curve->add_point(Vector3(100, 100, 0));
@@ -157,7 +160,8 @@ TEST_CASE("[SceneTree][PathFollow3D] Removal of a point in curve") {
 }
 
 TEST_CASE("[SceneTree][PathFollow3D] Progress ratio out of range") {
-	Ref<Curve3D> curve = memnew(Curve3D);
+	Ref<Curve3D> curve;
+	curve.instantiate();
 	curve->add_point(Vector3(0, 0, 0));
 	curve->add_point(Vector3(100, 0, 0));
 	Path3D *path = memnew(Path3D);
@@ -194,7 +198,8 @@ TEST_CASE("[SceneTree][PathFollow3D] Progress ratio out of range") {
 }
 
 TEST_CASE("[SceneTree][PathFollow3D] Progress out of range") {
-	Ref<Curve3D> curve = memnew(Curve3D);
+	Ref<Curve3D> curve;
+	curve.instantiate();
 	curve->add_point(Vector3(0, 0, 0));
 	curve->add_point(Vector3(100, 0, 0));
 	Path3D *path = memnew(Path3D);
@@ -232,7 +237,8 @@ TEST_CASE("[SceneTree][PathFollow3D] Progress out of range") {
 
 TEST_CASE("[SceneTree][PathFollow3D] Calculate forward vector") {
 	const real_t dist_cube_100 = 100 * Math::sqrt(3.0);
-	Ref<Curve3D> curve = memnew(Curve3D);
+	Ref<Curve3D> curve;
+	curve.instantiate();
 	curve->add_point(Vector3(0, 0, 0));
 	curve->add_point(Vector3(100, 0, 0));
 	curve->add_point(Vector3(200, 100, -100));
@@ -283,4 +289,52 @@ TEST_CASE("[SceneTree][PathFollow3D] Calculate forward vector") {
 
 	memdelete(path);
 }
+
+TEST_CASE("[SceneTree][PathFollow3D] Calculate forward vector with degenerate curves") {
+	Ref<Curve3D> curve;
+	curve.instantiate();
+	curve->add_point(Vector3(0, 0, 1), Vector3(), Vector3(1, 0, 0));
+	curve->add_point(Vector3(1, 0, 0), Vector3(0, 0, 0), Vector3(0, 0, 0));
+	curve->add_point(Vector3(0, 0, -1), Vector3(1, 0, 0), Vector3(-1, 0, 0));
+	curve->add_point(Vector3(-1, 0, 0), Vector3(0, 0, 0), Vector3(0, 0, 0));
+	curve->add_point(Vector3(0, 0, 1), Vector3(-1, 0, 0), Vector3());
+	Path3D *path = memnew(Path3D);
+	path->set_curve(curve);
+	PathFollow3D *path_follow_3d = memnew(PathFollow3D);
+	path->add_child(path_follow_3d);
+	SceneTree::get_singleton()->get_root()->add_child(path);
+
+	path_follow_3d->set_loop(false);
+	path_follow_3d->set_rotation_mode(PathFollow3D::RotationMode::ROTATION_ORIENTED);
+
+	path_follow_3d->set_progress_ratio(0.00);
+	CHECK(is_equal_approx(Vector3(-1, 0, 0), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress_ratio(0.25);
+	CHECK(is_equal_approx(Vector3(0, 0, 1), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress_ratio(0.50);
+	CHECK(is_equal_approx(Vector3(1, 0, 0), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress_ratio(0.75);
+	CHECK(is_equal_approx(Vector3(0, 0, -1), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress_ratio(1.00);
+	CHECK(is_equal_approx(Vector3(-1, 0, 0), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress_ratio(0.125);
+	CHECK(is_equal_approx(Vector3(-0.688375, 0, 0.725355), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress_ratio(0.375);
+	CHECK(is_equal_approx(Vector3(0.688375, 0, 0.725355), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress_ratio(0.625);
+	CHECK(is_equal_approx(Vector3(0.688375, 0, -0.725355), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	path_follow_3d->set_progress_ratio(0.875);
+	CHECK(is_equal_approx(Vector3(-0.688375, 0, -0.725355), path_follow_3d->get_transform().get_basis().get_column(2)));
+
+	memdelete(path);
+}
+
 } // namespace TestPathFollow3D


### PR DESCRIPTION
This attempts to fix the [issue](https://github.com/godotengine/godot/issues/100590) where the path-follower does not smoothly follow the curve due to the tangent being computed incorrectly when there are collinear control points.

The problem can be most easily understood with the scenario where one of the control points is collinear with the anchor points and the other is not.  In this case the control points form a quadratic bezier curve but is treated as a linear curve.

For example given `begin`, `c1`, `c2`, `end` if `begin` and `c1` are the same but `c2` and `end` are distinct from the other points the current code will return `end` - `begin` when it should return `c2` - `begin` (when `t` is 0).

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/100590*
* Fixes #82658