### PR TITLE
Fix `ThemeEditor` being too wide for small screen or minimized window

### DIFF
--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3796,9 +3796,10 @@ ThemeEditor::ThemeEditor() {
 	main_hs->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(main_hs);
 
+	main_hs->set_split_offset(520 * EDSCALE);
+
 	VBoxContainer *preview_tabs_vb = memnew(VBoxContainer);
 	preview_tabs_vb->set_h_size_flags(SIZE_EXPAND_FILL);
-	preview_tabs_vb->set_custom_minimum_size(Size2(520, 0) * EDSCALE);
 	preview_tabs_vb->add_theme_constant_override("separation", 2 * EDSCALE);
 	main_hs->add_child(preview_tabs_vb);
 	HBoxContainer *preview_tabbar_hb = memnew(HBoxContainer);

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -250,7 +250,7 @@ ThemeEditorPreview::ThemeEditorPreview() {
 	picker_button->connect(SceneStringName(pressed), callable_mp(this, &ThemeEditorPreview::_picker_button_cbk));
 
 	MarginContainer *preview_body = memnew(MarginContainer);
-	preview_body->set_custom_minimum_size(Size2(480, 0) * EDSCALE);
+	preview_body->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 	preview_body->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(preview_body);
 


### PR DESCRIPTION
Partially extracted from / based on https://github.com/godotengine/godot/pull/102301

| Before | After |
| --- | --- |
| ![Godot_v4 4 1-rc1_win64_Gcxj9QVLsZ](https://github.com/user-attachments/assets/123c287a-fdb5-4431-9bdb-56f755278677) |  ![godot windows editor dev x86_64_9CnEne8Ayv](https://github.com/user-attachments/assets/f58b0b42-ccb1-4114-9d3b-0cb7d7965cbb) |

Compared to linked PR, does not change `ThemeEditor` being too tall for small screens / minimized window and does not change default height (what is the problem in the mentioned PR), so should be completely safe.