### PR TITLE
Deactivate the `CameraServer` by default.

### DIFF
--- a/doc/classes/CameraServer.xml
+++ b/doc/classes/CameraServer.xml
@@ -45,6 +45,12 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="monitoring_feeds" type="bool" setter="set_monitoring_feeds" getter="is_monitoring_feeds" default="false">
+			If [code]true[/code], the server is actively monitoring available camera feeds.
+			This has a performance cost, so only set it to [code]true[/code] when you're actively accessing the camera.
+		</member>
+	</members>
 	<signals>
 		<signal name="camera_feed_added">
 			<param index="0" name="id" type="int" />

--- a/modules/camera/camera_linux.cpp
+++ b/modules/camera/camera_linux.cpp
@@ -162,11 +162,25 @@ bool CameraLinux::_can_query_format(int p_file_descriptor, int p_type) {
 	return ioctl(p_file_descriptor, VIDIOC_G_FMT, &format) != -1;
 }
 
-CameraLinux::CameraLinux() {
-	camera_thread.start(CameraLinux::camera_thread_func, this);
+inline void CameraLinux::set_monitoring_feeds(bool p_monitoring_feeds) {
+	if (p_monitoring_feeds == monitoring_feeds) {
+		return;
+	}
+
+	CameraServer::set_monitoring_feeds(p_monitoring_feeds);
+	if (p_monitoring_feeds) {
+		camera_thread.start(CameraLinux::camera_thread_func, this);
+	} else {
+		exit_flag.set();
+		if (camera_thread.is_started()) {
+			camera_thread.wait_to_finish();
+		}
+	}
 }
 
 CameraLinux::~CameraLinux() {
 	exit_flag.set();
-	camera_thread.wait_to_finish();
+	if (camera_thread.is_started()) {
+		camera_thread.wait_to_finish();
+	}
 }

--- a/modules/camera/camera_linux.h
+++ b/modules/camera/camera_linux.h
@@ -52,6 +52,8 @@ private:
 	bool _can_query_format(int p_file_descriptor, int p_type);
 
 public:
-	CameraLinux();
+	CameraLinux() = default;
 	~CameraLinux();
+
+	void set_monitoring_feeds(bool p_monitoring_feeds) override;
 };

--- a/modules/camera/camera_macos.h
+++ b/modules/camera/camera_macos.h
@@ -37,7 +37,8 @@
 
 class CameraMacOS : public CameraServer {
 public:
-	CameraMacOS();
+	CameraMacOS() = default;
 
 	void update_feeds();
+	void set_monitoring_feeds(bool p_monitoring_feeds) override;
 };

--- a/modules/camera/camera_macos.mm
+++ b/modules/camera/camera_macos.mm
@@ -359,10 +359,20 @@ void CameraMacOS::update_feeds() {
 	};
 }
 
-CameraMacOS::CameraMacOS() {
-	// Find available cameras we have at this time
-	update_feeds();
+void CameraMacOS::set_monitoring_feeds(bool p_monitoring_feeds) {
+	if (p_monitoring_feeds == monitoring_feeds) {
+		return;
+	}
 
-	// should only have one of these....
-	device_notifications = [[MyDeviceNotifications alloc] initForServer:this];
+	CameraServer::set_monitoring_feeds(p_monitoring_feeds);
+	if (p_monitoring_feeds) {
+		// Find available cameras we have at this time.
+		update_feeds();
+
+		// Get notified on feed changes.
+		device_notifications = [[MyDeviceNotifications alloc] initForServer:this];
+	} else {
+		// Stop monitoring feed changes.
+		device_notifications = nil;
+	}
 }

--- a/servers/camera_server.cpp
+++ b/servers/camera_server.cpp
@@ -39,6 +39,10 @@
 CameraServer::CreateFunc CameraServer::create_func = nullptr;
 
 void CameraServer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_monitoring_feeds", "is_monitoring_feeds"), &CameraServer::set_monitoring_feeds);
+	ClassDB::bind_method(D_METHOD("is_monitoring_feeds"), &CameraServer::is_monitoring_feeds);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "monitoring_feeds"), "set_monitoring_feeds", "is_monitoring_feeds");
+
 	ClassDB::bind_method(D_METHOD("get_feed", "index"), &CameraServer::get_feed);
 	ClassDB::bind_method(D_METHOD("get_feed_count"), &CameraServer::get_feed_count);
 	ClassDB::bind_method(D_METHOD("feeds"), &CameraServer::get_feeds);
@@ -61,6 +65,10 @@ CameraServer *CameraServer::get_singleton() {
 	return singleton;
 }
 
+void CameraServer::set_monitoring_feeds(bool p_monitoring_feeds) {
+	monitoring_feeds = p_monitoring_feeds;
+}
+
 int CameraServer::get_free_id() {
 	bool id_exists = true;
 	int newid = 0;
@@ -80,6 +88,8 @@ int CameraServer::get_free_id() {
 }
 
 int CameraServer::get_feed_index(int p_id) {
+	ERR_FAIL_COND_V_MSG(!monitoring_feeds, -1, "CameraServer is not actively monitoring feeds; call set_monitoring_feeds(true) first.");
+
 	for (int i = 0; i < feeds.size(); i++) {
 		if (feeds[i]->get_id() == p_id) {
 			return i;
@@ -90,6 +100,8 @@ int CameraServer::get_feed_index(int p_id) {
 }
 
 Ref<CameraFeed> CameraServer::get_feed_by_id(int p_id) {
+	ERR_FAIL_COND_V_MSG(!monitoring_feeds, nullptr, "CameraServer is not actively monitoring feeds; call set_monitoring_feeds(true) first.");
+
 	int index = get_feed_index(p_id);
 
 	if (index == -1) {
@@ -129,16 +141,19 @@ void CameraServer::remove_feed(const Ref<CameraFeed> &p_feed) {
 }
 
 Ref<CameraFeed> CameraServer::get_feed(int p_index) {
+	ERR_FAIL_COND_V_MSG(!monitoring_feeds, nullptr, "CameraServer is not actively monitoring feeds; call set_monitoring_feeds(true) first.");
 	ERR_FAIL_INDEX_V(p_index, feeds.size(), nullptr);
 
 	return feeds[p_index];
 }
 
 int CameraServer::get_feed_count() {
+	ERR_FAIL_COND_V_MSG(!monitoring_feeds, 0, "CameraServer is not actively monitoring feeds; call set_monitoring_feeds(true) first.");
 	return feeds.size();
 }
 
 TypedArray<CameraFeed> CameraServer::get_feeds() {
+	ERR_FAIL_COND_V_MSG(!monitoring_feeds, {}, "CameraServer is not actively monitoring feeds; call set_monitoring_feeds(true) first.");
 	TypedArray<CameraFeed> return_feeds;
 	int cc = get_feed_count();
 	return_feeds.resize(cc);
@@ -151,6 +166,7 @@ TypedArray<CameraFeed> CameraServer::get_feeds() {
 }
 
 RID CameraServer::feed_texture(int p_id, CameraServer::FeedImage p_texture) {
+	ERR_FAIL_COND_V_MSG(!monitoring_feeds, RID(), "CameraServer is not actively monitoring feeds; call set_monitoring_feeds(true) first.");
 	int index = get_feed_index(p_id);
 	ERR_FAIL_COND_V(index == -1, RID());
 

--- a/servers/camera_server.h
+++ b/servers/camera_server.h
@@ -64,6 +64,7 @@ private:
 protected:
 	static CreateFunc create_func;
 
+	bool monitoring_feeds = false;
 	Vector<Ref<CameraFeed>> feeds;
 
 	static CameraServer *singleton;
@@ -87,6 +88,9 @@ public:
 		CameraServer *server = create_func ? create_func() : memnew(CameraServer);
 		return server;
 	}
+
+	virtual void set_monitoring_feeds(bool p_monitoring_feeds);
+	_FORCE_INLINE_ bool is_monitoring_feeds() const { return monitoring_feeds; }
 
 	// Right now we identify our feed by it's ID when it's used in the background.
 	// May see if we can change this to purely relying on CameraFeed objects or by name.


### PR DESCRIPTION
I profiled the launch of tps demo. I noticed that launching the `CameraServer` took 12% (120ms) of the total CPU time (on macOS). I found this curious because tps-demo should not access my camera. 

I propose deactivating the `CameraServer` by default. I think this is appropriate for most games: Most do not need to monitor cameras, and monitoring the feeds as a game that does not use cameras is questionable at best.

The `CameraServer` can be activated in games that need it with `set_is_monitoring_feeds`, and queried with `is_monitoring_feeds`. 
Most games will not activate monitoring and thus won't pay for it. For games that do need the camera, I think it is still appropriate to be able to activate and deactive feed monitoring, because they may not need to monitor the feeds all the time.

## Notes

This PR should be tested on Linux before merging. It should also be tested if the changes break camera monitoring, because I have no project to conveniently test it with.

It's also likely this PR (in its current state) will cause problems with the Godot editor itself, which may want to monitor feeds for editor purposes. I'm open to suggestions for where / how to support that.

This PR is a breaking change to games that use the camera feed. When they update, they'll need to start activating the server somewhere in their code.

## Profiling
I profiled tps demo and found it to launch 8% (0.14s) faster on average on macOS:
```
Benchmark 1: bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/tps-demo --quit
  Time (mean ± σ):      1.772 s ±  0.034 s    [User: 0.597 s, System: 0.224 s]
  Range (min … max):    1.710 s …  1.859 s    25 runs

Benchmark 2: bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/tps-demo --quit
  Time (mean ± σ):      1.635 s ±  0.041 s    [User: 0.558 s, System: 0.168 s]
  Range (min … max):    1.537 s …  1.715 s    25 runs

Summary
  bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/tps-demo --quit ran
    1.08 ± 0.03 times faster than bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/tps-demo --quit
``` 

Linux uses an asynchronous approach to monitoring feeds, so it should benefit asynchronously instead of on launch time.
Windows does not benefit because `CameraServer` is not implemented for it.

## Addendum
It may be appropriate to move the `CameraServer` to a GDExtension because it is very self-contained, and it is questionable that code to monitor cameras even ships with all Godot games in the first place.
However, this is out of scope for this PR, and likely won't provide much more tangible benefit than what is suggested here (as the camera module is very small).