### PR TITLE
Optimize reverb by removing stray `volatile` from the `undenormalize` function signature.

### DIFF
--- a/core/math/audio_frame.h
+++ b/core/math/audio_frame.h
@@ -33,7 +33,7 @@
 #include "core/math/vector2.h"
 #include "core/typedefs.h"
 
-static inline float undenormalize(volatile float f) {
+static _FORCE_INLINE_ float undenormalize(float f) {
 	union {
 		uint32_t i;
 		float f;


### PR DESCRIPTION
I profiled tps demo during gameplay. I noticed that `undenormalize` (called from `Reverb::process` took a substantial role in CPU load.

I optimized the function to reduce total CPU load of tps-demo by about 2.2%.

## Profile Results
The initial profile result on `master` (macOS, `template_debug`):
```
276.00 ms   3,9 %	0 s	  undenormalize(float)
49.00 ms   0,7 %	0 s	  Reverb::process(float*, float*, int)
```
I think the `volatile` keyword is unnecessary, and prevents optimization. I removed the keyword and forced inline of the function (it was already inlined, but it's not a bad idea to have it be inlined in dev builds, too). I profiled again:
```
163.00 ms   2,3 %	0 s	  Reverb::process(float*, float*, int)
4.00 ms   0,1 %	0 s	  undenormalize(float)
```
