### PR TITLE
Emit `changed` signal after baking navigation mesh

### DIFF
--- a/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
@@ -93,6 +93,7 @@ void NavMeshGenerator2D::sync() {
 				if (generator_task->callback.is_valid()) {
 					generator_emit_callback(generator_task->callback);
 				}
+				generator_task->navigation_mesh->emit_changed();
 				memdelete(generator_task);
 			}
 		}
@@ -150,6 +151,7 @@ void NavMeshGenerator2D::bake_from_source_geometry_data(Ref<NavigationPolygon> p
 		if (p_callback.is_valid()) {
 			generator_emit_callback(p_callback);
 		}
+		p_navigation_mesh->emit_changed();
 		return;
 	}
 
@@ -169,6 +171,8 @@ void NavMeshGenerator2D::bake_from_source_geometry_data(Ref<NavigationPolygon> p
 	if (p_callback.is_valid()) {
 		generator_emit_callback(p_callback);
 	}
+
+	p_navigation_mesh->emit_changed();
 }
 
 void NavMeshGenerator2D::bake_from_source_geometry_data_async(Ref<NavigationPolygon> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, const Callable &p_callback) {
@@ -180,6 +184,7 @@ void NavMeshGenerator2D::bake_from_source_geometry_data_async(Ref<NavigationPoly
 		if (p_callback.is_valid()) {
 			generator_emit_callback(p_callback);
 		}
+		p_navigation_mesh->emit_changed();
 		return;
 	}
 

--- a/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
@@ -92,6 +92,7 @@ void NavMeshGenerator3D::sync() {
 				if (generator_task->callback.is_valid()) {
 					generator_emit_callback(generator_task->callback);
 				}
+				generator_task->navigation_mesh->emit_changed();
 				memdelete(generator_task);
 			}
 		}
@@ -149,6 +150,7 @@ void NavMeshGenerator3D::bake_from_source_geometry_data(Ref<NavigationMesh> p_na
 		if (p_callback.is_valid()) {
 			generator_emit_callback(p_callback);
 		}
+		p_navigation_mesh->emit_changed();
 		return;
 	}
 
@@ -168,6 +170,8 @@ void NavMeshGenerator3D::bake_from_source_geometry_data(Ref<NavigationMesh> p_na
 	if (p_callback.is_valid()) {
 		generator_emit_callback(p_callback);
 	}
+
+	p_navigation_mesh->emit_changed();
 }
 
 void NavMeshGenerator3D::bake_from_source_geometry_data_async(Ref<NavigationMesh> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, const Callable &p_callback) {
@@ -179,6 +183,7 @@ void NavMeshGenerator3D::bake_from_source_geometry_data_async(Ref<NavigationMesh
 		if (p_callback.is_valid()) {
 			generator_emit_callback(p_callback);
 		}
+		p_navigation_mesh->emit_changed();
 		return;
 	}
 

--- a/scene/2d/navigation/navigation_region_2d.h
+++ b/scene/2d/navigation/navigation_region_2d.h
@@ -111,7 +111,7 @@ public:
 	PackedStringArray get_configuration_warnings() const override;
 
 	void bake_navigation_polygon(bool p_on_thread);
-	void _bake_finished(Ref<NavigationPolygon> p_navigation_polygon);
+	void _bake_finished();
 	bool is_baking() const;
 
 	Rect2 get_bounds() const { return bounds; }

--- a/scene/3d/navigation/navigation_region_3d.h
+++ b/scene/3d/navigation/navigation_region_3d.h
@@ -106,7 +106,7 @@ public:
 	/// Bakes the navigation mesh; once done, automatically
 	/// sets the new navigation mesh and emits a signal
 	void bake_navigation_mesh(bool p_on_thread);
-	void _bake_finished(Ref<NavigationMesh> p_navigation_mesh);
+	void _bake_finished();
 	bool is_baking() const;
 
 	PackedStringArray get_configuration_warnings() const override;


### PR DESCRIPTION
Emits `changed` signal after baking navigation mesh.

This is only emitted at the end of a navmesh baking process.

E.g. to update debug on regions correctly without need for calling the setter again. It is common that users ask why their regions are not updating when they rebake the navmesh using the server, but it is only the debug that does not update because nothing calls the node setter again.

We can't have a changed signal directly on both NavigationMesh and NavigationPolygon setters because both classes are legacy lunatic classes. Half the time those classes are in a broken desync with their internal vertices and polygon arrays or locked by threads.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
