### PR TITLE
Implement alignment (size-relative offset) for sprite nodes

### DIFF
--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -74,6 +74,12 @@
 		</method>
 	</methods>
 	<members>
+		<member name="alignment" type="Vector2" setter="set_alignment" getter="get_alignment" default="Vector2(0, 0)">
+			The texture's drawing offset relative to the texture size.
+			For example, setting this to [code]Vector2(0.5, -0.5)[/code] would align the sprite's bottom-left corner with its pivot position (assuming [member centered] is [code]true[/code]).
+			[b]Note:[/b] For games with a pixel art aesthetic, textures may appear deformed when [code]alignment.x[/code] or [code]alignment.y[/code] is not a whole number. This is caused by their position being between pixels. To prevent this, use only whole numbers with this property, or consider enabling [member ProjectSettings.rendering/2d/snap/snap_2d_vertices_to_pixel] and [member ProjectSettings.rendering/2d/snap/snap_2d_transforms_to_pixel].
+			See also [member offset].
+		</member>
 		<member name="animation" type="StringName" setter="set_animation" getter="get_animation" default="&amp;&quot;default&quot;">
 			The current animation from the [member sprite_frames] resource. If this value is changed, the [member frame] counter and the [member frame_progress] are reset.
 		</member>
@@ -97,7 +103,8 @@
 			The progress value between [code]0.0[/code] and [code]1.0[/code] until the current frame transitions to the next frame. If the animation is playing backwards, the value transitions from [code]1.0[/code] to [code]0.0[/code].
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
-			The texture's drawing offset.
+			The texture's drawing offset in pixels.
+			See also [member alignment].
 		</member>
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
 			The speed scaling ratio. For example, if this value is [code]1[/code], then the animation plays at normal speed. If it's [code]0.5[/code], then it plays at half speed. If it's [code]2[/code], then it plays at double speed.

--- a/doc/classes/Sprite2D.xml
+++ b/doc/classes/Sprite2D.xml
@@ -50,6 +50,12 @@
 		</method>
 	</methods>
 	<members>
+		<member name="alignment" type="Vector2" setter="set_alignment" getter="get_alignment" default="Vector2(0, 0)">
+			The texture's drawing offset relative to the texture size.
+			For example, setting this to [code]Vector2(0.5, -0.5)[/code] would align the sprite's bottom-left corner with its pivot position (assuming [member centered] is [code]true[/code]).
+			[b]Note:[/b] For games with a pixel art aesthetic, textures may appear deformed when [code]alignment.x[/code] or [code]alignment.y[/code] is not a whole number. This is caused by their position being between pixels. To prevent this, use only whole numbers with this property, or consider enabling [member ProjectSettings.rendering/2d/snap/snap_2d_vertices_to_pixel] and [member ProjectSettings.rendering/2d/snap/snap_2d_transforms_to_pixel].
+			See also [member offset].
+		</member>
 		<member name="centered" type="bool" setter="set_centered" getter="is_centered" default="true">
 			If [code]true[/code], texture is centered.
 			[b]Note:[/b] For games with a pixel art aesthetic, textures may appear deformed when centered. This is caused by their position being between pixels. To prevent this, set this property to [code]false[/code], or consider enabling [member ProjectSettings.rendering/2d/snap/snap_2d_vertices_to_pixel] and [member ProjectSettings.rendering/2d/snap/snap_2d_transforms_to_pixel].
@@ -70,7 +76,8 @@
 			The number of columns in the sprite sheet. When this property is changed, [member frame] is adjusted so that the same visual frame is maintained (same row and column). If that's impossible, [member frame] is reset to [code]0[/code].
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
-			The texture's drawing offset.
+			The texture's drawing offset in pixels.
+			See also [member alignment].
 		</member>
 		<member name="region_enabled" type="bool" setter="set_region_enabled" getter="is_region_enabled" default="false">
 			If [code]true[/code], texture is cut from a larger atlas texture. See [member region_rect].

--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -38,6 +38,11 @@
 		</method>
 	</methods>
 	<members>
+		<member name="alignment" type="Vector2" setter="set_alignment" getter="get_alignment" default="Vector2(0, 0)">
+			The texture's drawing offset relative to the texture size.
+			For example, setting this to [code]Vector2(0.5, 0.5)[/code] would align the sprite's bottom-left corner with its pivot position (assuming [member centered] is [code]true[/code]).
+			See also [member offset].
+		</member>
 		<member name="alpha_antialiasing_edge" type="float" setter="set_alpha_antialiasing_edge" getter="get_alpha_antialiasing_edge" default="0.0">
 			Threshold at which antialiasing will be applied on the alpha channel.
 		</member>
@@ -84,7 +89,8 @@
 			If [code]true[/code], depth testing is disabled and the object will be drawn in render order.
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
-			The texture's drawing offset.
+			The texture's drawing offset in pixels.
+			See also [member alignment].
 		</member>
 		<member name="pixel_size" type="float" setter="set_pixel_size" getter="get_pixel_size" default="0.01">
 			The size of one pixel's width on the sprite to scale it in 3D.

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -218,7 +218,7 @@ void Sprite2DEditor::_update_mesh_data() {
 				if (node->is_flipped_v()) {
 					vtx.y = rect.size.y - vtx.y;
 				}
-				vtx += node->get_offset();
+				vtx += node->get_offset() + node->get_alignment() * rect.size;
 				if (node->is_centered()) {
 					vtx -= rect.size / 2.0;
 				}
@@ -268,6 +268,7 @@ void Sprite2DEditor::_update_mesh_data() {
 				if (selected_menu_item != MENU_OPTION_CONVERT_TO_POLYGON_2D) {
 					vtx += node->get_offset();
 				}
+				vtx += node->get_alignment() * rect.size;
 				if (node->is_centered()) {
 					vtx -= rect.size / 2.0;
 				}

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -100,7 +100,7 @@ Rect2 AnimatedSprite2D::_get_rect() const {
 	}
 	Size2 s = t->get_size();
 
-	Point2 ofs = offset;
+	Point2 ofs = offset + alignment * s;
 	if (centered) {
 		ofs -= s / 2;
 	}
@@ -115,6 +115,15 @@ Rect2 AnimatedSprite2D::_get_rect() const {
 void AnimatedSprite2D::_validate_property(PropertyInfo &p_property) const {
 	if (frames.is_null()) {
 		return;
+	}
+
+	if (p_property.name == "alignment") {
+		p_property.hint = PROPERTY_HINT_RANGE;
+		if (centered) {
+			p_property.hint_string = "-0.5,0.5,0.01,or_greater,or_lower";
+		} else {
+			p_property.hint_string = "-1,0,0.01,or_greater,or_lower";
+		}
 	}
 
 	if (p_property.name == "animation") {
@@ -263,7 +272,7 @@ void AnimatedSprite2D::_notification(int p_what) {
 			RID ci = get_canvas_item();
 
 			Size2 s = texture->get_size();
-			Point2 ofs = offset;
+			Point2 ofs = offset + alignment * s;
 			if (centered) {
 				ofs -= s / 2;
 			}
@@ -390,6 +399,7 @@ void AnimatedSprite2D::set_centered(bool p_center) {
 	centered = p_center;
 	queue_redraw();
 	item_rect_changed();
+	notify_property_list_changed();
 }
 
 bool AnimatedSprite2D::is_centered() const {
@@ -408,6 +418,20 @@ void AnimatedSprite2D::set_offset(const Point2 &p_offset) {
 
 Point2 AnimatedSprite2D::get_offset() const {
 	return offset;
+}
+
+void AnimatedSprite2D::set_alignment(const Vector2 &p_alignment) {
+	if (alignment == p_alignment) {
+		return;
+	}
+
+	alignment = p_alignment;
+	queue_redraw();
+	item_rect_changed();
+}
+
+Vector2 AnimatedSprite2D::get_alignment() const {
+	return alignment;
 }
 
 void AnimatedSprite2D::set_flip_h(bool p_flip) {
@@ -629,6 +653,9 @@ void AnimatedSprite2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_offset", "offset"), &AnimatedSprite2D::set_offset);
 	ClassDB::bind_method(D_METHOD("get_offset"), &AnimatedSprite2D::get_offset);
 
+	ClassDB::bind_method(D_METHOD("set_alignment", "alignment"), &AnimatedSprite2D::set_alignment);
+	ClassDB::bind_method(D_METHOD("get_alignment"), &AnimatedSprite2D::get_alignment);
+
 	ClassDB::bind_method(D_METHOD("set_flip_h", "flip_h"), &AnimatedSprite2D::set_flip_h);
 	ClassDB::bind_method(D_METHOD("is_flipped_h"), &AnimatedSprite2D::is_flipped_h);
 
@@ -663,6 +690,7 @@ void AnimatedSprite2D::_bind_methods() {
 	ADD_GROUP("Offset", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "centered"), "set_centered", "is_centered");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), "set_offset", "get_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "alignment"), "set_alignment", "get_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
 }

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -47,6 +47,7 @@ class AnimatedSprite2D : public Node2D {
 
 	bool centered = true;
 	Point2 offset;
+	Vector2 alignment;
 
 	real_t frame_speed_scale = 1.0;
 	real_t frame_progress = 0.0;
@@ -120,6 +121,9 @@ public:
 
 	void set_offset(const Point2 &p_offset);
 	Point2 get_offset() const;
+
+	void set_alignment(const Vector2 &p_alignment);
+	Vector2 get_alignment() const;
 
 	void set_flip_h(bool p_flip);
 	bool is_flipped_h() const;

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -94,7 +94,7 @@ void Sprite2D::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_c
 	r_src_rect.size = frame_size;
 	r_src_rect.position = base_rect.position + frame_offset;
 
-	Point2 dest_offset = offset;
+	Point2 dest_offset = offset + alignment * frame_size;
 	if (centered) {
 		dest_offset -= frame_size / 2;
 	}
@@ -163,6 +163,7 @@ void Sprite2D::set_centered(bool p_center) {
 	centered = p_center;
 	queue_redraw();
 	item_rect_changed();
+	notify_property_list_changed();
 }
 
 bool Sprite2D::is_centered() const {
@@ -181,6 +182,20 @@ void Sprite2D::set_offset(const Point2 &p_offset) {
 
 Point2 Sprite2D::get_offset() const {
 	return offset;
+}
+
+void Sprite2D::set_alignment(const Vector2 &p_alignment) {
+	if (alignment == p_alignment) {
+		return;
+	}
+
+	alignment = p_alignment;
+	queue_redraw();
+	item_rect_changed();
+}
+
+Vector2 Sprite2D::get_alignment() const {
+	return alignment;
 }
 
 void Sprite2D::set_flip_h(bool p_flip) {
@@ -396,7 +411,7 @@ Rect2 Sprite2D::get_rect() const {
 
 	s = s / Point2(hframes, vframes);
 
-	Point2 ofs = offset;
+	Point2 ofs = offset + alignment * s;
 	if (centered) {
 		ofs -= Size2(s) / 2;
 	}
@@ -413,6 +428,15 @@ Rect2 Sprite2D::get_rect() const {
 }
 
 void Sprite2D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "alignment") {
+		p_property.hint = PROPERTY_HINT_RANGE;
+		if (centered) {
+			p_property.hint_string = "-0.5,0.5,0.01,or_greater,or_lower";
+		} else {
+			p_property.hint_string = "-1,0,0.01,or_greater,or_lower";
+		}
+	}
+
 	if (p_property.name == "frame") {
 		p_property.hint = PROPERTY_HINT_RANGE;
 		p_property.hint_string = "0," + itos(vframes * hframes - 1) + ",1";
@@ -445,6 +469,9 @@ void Sprite2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_offset", "offset"), &Sprite2D::set_offset);
 	ClassDB::bind_method(D_METHOD("get_offset"), &Sprite2D::get_offset);
+
+	ClassDB::bind_method(D_METHOD("set_alignment", "alignment"), &Sprite2D::set_alignment);
+	ClassDB::bind_method(D_METHOD("get_alignment"), &Sprite2D::get_alignment);
 
 	ClassDB::bind_method(D_METHOD("set_flip_h", "flip_h"), &Sprite2D::set_flip_h);
 	ClassDB::bind_method(D_METHOD("is_flipped_h"), &Sprite2D::is_flipped_h);
@@ -484,6 +511,7 @@ void Sprite2D::_bind_methods() {
 	ADD_GROUP("Offset", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "centered"), "set_centered", "is_centered");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), "set_offset", "get_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "alignment"), "set_alignment", "get_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
 	ADD_GROUP("Animation", "");

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -42,6 +42,7 @@ class Sprite2D : public Node2D {
 
 	bool centered = true;
 	Point2 offset;
+	Vector2 alignment;
 
 	bool hflip = false;
 	bool vflip = false;
@@ -92,6 +93,9 @@ public:
 
 	void set_offset(const Point2 &p_offset);
 	Point2 get_offset() const;
+
+	void set_alignment(const Vector2 &p_alignment);
+	Vector2 get_alignment() const;
 
 	void set_flip_h(bool p_flip);
 	bool is_flipped_h() const;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -87,6 +87,17 @@ void SpriteBase3D::_notification(int p_what) {
 	}
 }
 
+void SpriteBase3D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "alignment") {
+		p_property.hint = PROPERTY_HINT_RANGE;
+		if (centered) {
+			p_property.hint_string = "-0.5,0.5,0.01,or_greater,or_lower";
+		} else {
+			p_property.hint_string = "-1,0,0.01,or_greater,or_lower";
+		}
+	}
+}
+
 void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect, Rect2 p_src_rect) {
 	ERR_FAIL_COND(p_texture.is_null());
 
@@ -292,6 +303,7 @@ void SpriteBase3D::set_centered(bool p_center) {
 
 	centered = p_center;
 	_queue_redraw();
+	notify_property_list_changed();
 }
 
 bool SpriteBase3D::is_centered() const {
@@ -309,6 +321,19 @@ void SpriteBase3D::set_offset(const Point2 &p_offset) {
 
 Point2 SpriteBase3D::get_offset() const {
 	return offset;
+}
+
+void SpriteBase3D::set_alignment(const Vector2 &p_alignment) {
+	if (alignment == p_alignment) {
+		return;
+	}
+
+	alignment = p_alignment;
+	_queue_redraw();
+}
+
+Vector2 SpriteBase3D::get_alignment() const {
+	return alignment;
 }
 
 void SpriteBase3D::set_flip_h(bool p_flip) {
@@ -595,6 +620,9 @@ void SpriteBase3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_offset", "offset"), &SpriteBase3D::set_offset);
 	ClassDB::bind_method(D_METHOD("get_offset"), &SpriteBase3D::get_offset);
 
+	ClassDB::bind_method(D_METHOD("set_alignment", "alignment"), &SpriteBase3D::set_alignment);
+	ClassDB::bind_method(D_METHOD("get_alignment"), &SpriteBase3D::get_alignment);
+
 	ClassDB::bind_method(D_METHOD("set_flip_h", "flip_h"), &SpriteBase3D::set_flip_h);
 	ClassDB::bind_method(D_METHOD("is_flipped_h"), &SpriteBase3D::is_flipped_h);
 
@@ -642,6 +670,7 @@ void SpriteBase3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "centered"), "set_centered", "is_centered");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), "set_offset", "get_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "alignment"), "set_alignment", "get_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "modulate"), "set_modulate", "get_modulate");
@@ -780,7 +809,7 @@ void Sprite3D::_draw() {
 	Size2 frame_size = base_rect.size / Size2(hframes, vframes);
 	Point2 frame_offset = Point2(frame % hframes, frame / hframes) * frame_size;
 
-	Point2 dst_offset = get_offset();
+	Point2 dst_offset = get_offset() + get_alignment() * frame_size;
 	if (is_centered()) {
 		dst_offset -= frame_size / 2.0f;
 	}
@@ -930,7 +959,7 @@ Rect2 Sprite3D::get_item_rect() const {
 		s = s / Point2(hframes, vframes);
 	}
 
-	Point2 ofs = get_offset();
+	Point2 ofs = get_offset() + get_alignment() * s;
 	if (is_centered()) {
 		ofs -= s / 2;
 	}
@@ -1021,7 +1050,7 @@ void AnimatedSprite3D::_draw() {
 	Rect2 src_rect;
 	src_rect.size = tsize;
 
-	Point2 ofs = get_offset();
+	Point2 ofs = get_offset() + get_alignment() * tsize;
 	if (is_centered()) {
 		ofs -= tsize / 2;
 	}
@@ -1284,7 +1313,7 @@ Rect2 AnimatedSprite3D::get_item_rect() const {
 	}
 	Size2 s = t->get_size();
 
-	Point2 ofs = get_offset();
+	Point2 ofs = get_offset() + get_alignment() * s;
 	if (is_centered()) {
 		ofs -= s / 2;
 	}

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -67,6 +67,7 @@ private:
 
 	bool centered = true;
 	Point2 offset;
+	Vector2 alignment;
 
 	bool hflip = false;
 	bool vflip = false;
@@ -102,6 +103,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 	virtual void _draw() = 0;
+	void _validate_property(PropertyInfo &p_property) const;
 	void draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect, Rect2 p_src_rect);
 	_FORCE_INLINE_ void set_aabb(const AABB &p_aabb) { aabb = p_aabb; }
 	_FORCE_INLINE_ RID &get_mesh() { return mesh; }
@@ -124,6 +126,9 @@ public:
 
 	void set_offset(const Point2 &p_offset);
 	Point2 get_offset() const;
+
+	void set_alignment(const Vector2 &p_alignment);
+	Vector2 get_alignment() const;
 
 	void set_flip_h(bool p_flip);
 	bool is_flipped_h() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Closes https://github.com/godotengine/godot-proposals/issues/9222.

Introduces a new property to all sprite nodes (Sprite2D, AnimatedSprite2D, Sprite3D & AnimatedSprite3D) that acts an offset relative to (i.e multiplied by) the texture dimensions. This provides a convenient way to easily align pivots to any corner or border of the sprite without needing to take size into account, in a way that still works well alongside the existing `centered` property (for compatibility, even though that property is arguably made redundant by this feature).

The property can be set to any vector2, but to support the intended common case the slider in the inspector has the range needed to allow aligning to any corner and no more -- which means -0.5..0.5 when `centered` is true, and -1.0..0 when it's false. For example, this means you can easily align a sprite's pivot to its center-bottom by dragging the `alignment.y` slider to the leftmost position

I'm not entirely sure on the name `alignment`, but it's the best I could think of that is succinct and clearly distinguishes it from `offset`.

This MR implements an (incompatible) alternative solution to parts of https://github.com/godotengine/godot/pull/93538