### PR TITLE
[Editor] Set window position when running project in maximized or full-screen mode to ensure it is opened on the correct screen.

### DIFF
--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -290,9 +290,11 @@ EditorRun::WindowPlacement EditorRun::get_window_placement() {
 			} break;
 			case 3: { // force maximized
 				placement.force_maximized = true;
+				placement.position = (screen_rect.position) + ((screen_rect.size - placement.size) / 2).floor();
 			} break;
 			case 4: { // force fullscreen
 				placement.force_fullscreen = true;
+				placement.position = (screen_rect.position) + ((screen_rect.size - placement.size) / 2).floor();
 			} break;
 		}
 	} else {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/104245 (regression from https://github.com/godotengine/godot/pull/101807)