### PR TITLE
Simplify and optimize `Math::absf` implementation to use `::fabs` and `::fabsf`.

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -628,24 +628,11 @@ public:
 	}
 
 	static _ALWAYS_INLINE_ float absf(float g) {
-		union {
-			float f;
-			uint32_t i;
-		} u;
-
-		u.f = g;
-		u.i &= 2147483647u;
-		return u.f;
+		return ::fabsf(g);
 	}
 
 	static _ALWAYS_INLINE_ double absd(double g) {
-		union {
-			double d;
-			uint64_t i;
-		} u;
-		u.d = g;
-		u.i &= (uint64_t)9223372036854775807ll;
-		return u.d;
+		return ::fabs(g);
 	}
 
 	// This function should be as fast as possible and rounding mode should not matter.


### PR DESCRIPTION
The previous implementation is clever, but it's not the canonical C / C++ way to calculate `abs` of a `float` or `double`.

I checked implementations on godbolt ([test code](https://godbolt.org/z/vWfdrEP7n)).
On all compilers and across optimization levels, `std::fabs` resulted in an optimal implementation. However, the current implementation Godot does not always result in optimal code.

## `clang` and `gcc`, `-O0`
Both implementation are unnecessarily complicated, but `std::fabs` is (probably) better (I'd have to test to be _absolutely_ sure):
```assembly
test1(float):
        push    {r11, lr}
        mov     r11, sp
        sub     sp, sp, #8
        vstr    s0, [sp, #4]
        vldr    s0, [sp, #4]
        bl      std::fabs(float)
        mov     sp, r11
        pop     {r11, pc}

test2(float):
        sub     sp, sp, #12
        vstr    s0, [sp]
        vldr    s0, [sp]
        vstr    s0, [sp, #8]
        vldr    s0, [sp, #8]
        vstr    s0, [sp, #4]
        ldr     r0, [sp, #4]
        ldr     r1, .LCPI2_0
        and     r0, r0, r1
        str     r0, [sp, #4]
        vldr    s0, [sp, #4]
        add     sp, sp, #12
        bx      lr
.LCPI2_0:
        .long   2147483647
```

## `clang` and `gcc`, `-O1` and `-O2`
The compilers understand what the code is trying to do and optimize with simplified assembly:
```assembly
test1(float):
        vabs.f32        s0, s0
        bx      lr

test2(float):
        vabs.f32        s0, s0
        bx      lr
```

## MSVC, `-O0`
The compiler doesn't even honor the `FORCE_INLINE` and generates a call:
```assembly
float absf(float) PROC                                  ; absf
        movss   DWORD PTR [rsp+8], xmm0
        sub     rsp, 24
        movss   xmm0, DWORD PTR g$[rsp]
        movss   DWORD PTR u$[rsp], xmm0
        mov     eax, DWORD PTR u$[rsp]
        btr     eax, 31
        mov     DWORD PTR u$[rsp], eax
        movss   xmm0, DWORD PTR u$[rsp]
        add     rsp, 24
        ret     0
float absf(float) ENDP                                  ; absf

f$ = 48
float test1(float) PROC                           ; test1
$LN3:
        movss   DWORD PTR [rsp+8], xmm0
        sub     rsp, 40                             ; 00000028H
        movss   xmm0, DWORD PTR f$[rsp]
        call    float fabs(float)                     ; fabs
        add     rsp, 40                             ; 00000028H
        ret     0
float test1(float) ENDP                           ; test1

f$ = 48
float test2(float) PROC                           ; test2
$LN3:
        movss   DWORD PTR [rsp+8], xmm0
        sub     rsp, 40                             ; 00000028H
        movss   xmm0, DWORD PTR f$[rsp]
        call    float absf(float)                     ; absf
        add     rsp, 40                             ; 00000028H
        ret     0
float test2(float) ENDP                           ; test2
```

## `MSVC`, `-O2`
The compiler does not fully understand the meaning of the code, and generates suboptimal assembly for `absf`:
```assembly
float test1(float) PROC                           ; test1, COMDAT
        andps   xmm0, DWORD PTR __xmm@7fffffff7fffffff7fffffff7fffffff
        ret     0
float test1(float) ENDP                           ; test1

float test2(float) PROC                           ; test2, COMDAT
        movss   DWORD PTR u$1[rsp], xmm0
        mov     eax, DWORD PTR u$1[rsp]
        btr     eax, 31
        movd    xmm0, eax
        ret     0
float test2(float) ENDP                           ; test2
```

## Verdict
I think it's better to just use standard functions for this kind of thing. Systems engineers have spent decades optimizing implementations, and the custom implementation may never have been a boon.