### PR TITLE
Android Editor: Fix game layout resize and respect window mode setting in embed mode

### DIFF
--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/EmbeddedGodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/EmbeddedGodotGame.kt
@@ -143,7 +143,6 @@ class EmbeddedGodotGame : GodotGame() {
 	override fun isAlwaysOnTopSupported() = hasPiPSystemFeature()
 
 	override fun onFullScreenUpdated(enabled: Boolean) {
-		godot?.enableImmersiveMode(enabled)
 		isFullscreen = enabled
 		if (enabled) {
 			layoutWidthInPx = FULL_SCREEN_WIDTH

--- a/platform/android/java/editor/src/main/res/values/themes.xml
+++ b/platform/android/java/editor/src/main/res/values/themes.xml
@@ -14,5 +14,8 @@
 	</style>
 
 	<style name="GodotEmbeddedGameTheme" parent="@android:style/Theme.DeviceDefault.Panel">
+		<item name="android:windowIsFloating">false</item>
+		<item name="android:statusBarColor">@android:color/transparent</item>
+		<item name="android:navigationBarColor">@android:color/transparent</item>
 	</style>
 </resources>


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/1d688934-b806-4450-b6d7-1a5ef2b157e9

After

https://github.com/user-attachments/assets/26685397-1801-455f-a394-b1574b8b8bc7

