### PR TITLE
Fix nested GodotObject class in generic class lead to source generator errors in C#

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/NestedInGenericTest.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/NestedInGenericTest.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace Godot.SourceGenerators.Tests;
+
+public class NestedInGenericTest
+{
+    [Fact]
+    public async void GenerateScriptMethodsTest()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptMethodsGenerator>.Verify(
+            "NestedInGeneric.cs",
+            "GenericClass(Of T).NestedClass_ScriptMethods.generated.cs"
+        );
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/GenericClass(Of T).NestedClass_ScriptMethods.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/GenericClass(Of T).NestedClass_ScriptMethods.generated.cs
@@ -1,0 +1,16 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class GenericClass<T>
+{
+partial class NestedClass
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the methods contained in this class, for fast lookup.
+    /// </summary>
+    public new class MethodName : global::Godot.GodotObject.MethodName {
+    }
+#pragma warning restore CS0109
+}
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/NestedInGeneric.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/NestedInGeneric.cs
@@ -1,0 +1,9 @@
+using Godot;
+
+public partial class GenericClass<T>
+{
+	public partial class NestedClass : GodotObject
+	{
+
+	}
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -183,7 +183,7 @@ namespace Godot.SourceGenerators
 
         public static string NameWithTypeParameters(this INamedTypeSymbol symbol)
         {
-            return symbol.IsGenericType ?
+            return symbol.IsGenericType && symbol.TypeParameters.Length > 0 ?
                 string.Concat(symbol.Name, "<", string.Join(", ", symbol.TypeParameters), ">") :
                 symbol.Name;
         }

--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/ExtensionMethods.cs
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/ExtensionMethods.cs
@@ -96,7 +96,7 @@ internal static class ExtensionMethods
 
     public static string NameWithTypeParameters(this INamedTypeSymbol symbol)
     {
-        return symbol.IsGenericType ?
+        return symbol.IsGenericType && symbol.TypeParameters.Length > 0 ?
             string.Concat(symbol.Name, "<", string.Join(", ", symbol.TypeParameters), ">") :
             symbol.Name;
     }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Correctly generate the names of types nested in generic types
If a non-generic class nested in generic types, Type.IsGenericType on it will return true but Type.TypeParameters can't get any generic parameter. Finally we get things like TypeName<>. Need a check of TypeParameters.Length to get correct type name

Fixes : https://github.com/godotengine/godot/issues/104268