### PR TITLE
Add `Span` equality (`==` and `!=`) operators.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -303,28 +303,8 @@ String &String::operator+=(char32_t p_char) {
 }
 
 bool String::operator==(const char *p_str) const {
-	// compare Latin-1 encoded c-string
-	int len = strlen(p_str);
-
-	if (length() != len) {
-		return false;
-	}
-	if (is_empty()) {
-		return true;
-	}
-
-	int l = length();
-
-	const char32_t *dst = get_data();
-
-	// Compare char by char
-	for (int i = 0; i < l; i++) {
-		if ((char32_t)p_str[i] != dst[i]) {
-			return false;
-		}
-	}
-
-	return true;
+	// Compare Latin-1 encoded c-string.
+	return span() == Span(p_str, strlen(p_str)).reinterpret<uint8_t>();
 }
 
 bool String::operator==(const wchar_t *p_str) const {
@@ -338,40 +318,16 @@ bool String::operator==(const wchar_t *p_str) const {
 }
 
 bool String::operator==(const char32_t *p_str) const {
-	const int len = strlen(p_str);
-
-	if (length() != len) {
-		return false;
-	}
-	if (is_empty()) {
-		return true;
-	}
-
-	return memcmp(ptr(), p_str, len * sizeof(char32_t)) == 0;
+	// Compare UTF-32 encoded c-string.
+	return span() == Span(p_str, strlen(p_str));
 }
 
 bool String::operator==(const String &p_str) const {
-	if (length() != p_str.length()) {
-		return false;
-	}
-	if (is_empty()) {
-		return true;
-	}
-
-	return memcmp(ptr(), p_str.ptr(), length() * sizeof(char32_t)) == 0;
+	return span() == p_str.span();
 }
 
 bool String::operator==(const Span<char32_t> &p_str_range) const {
-	const int len = p_str_range.size();
-
-	if (length() != len) {
-		return false;
-	}
-	if (is_empty()) {
-		return true;
-	}
-
-	return memcmp(ptr(), p_str_range.ptr(), len * sizeof(char32_t)) == 0;
+	return span() == p_str_range;
 }
 
 bool operator==(const char *p_chr, const String &p_str) {
@@ -384,7 +340,7 @@ bool operator==(const wchar_t *p_chr, const String &p_str) {
 	return p_str == String::utf16((const char16_t *)p_chr);
 #else
 	// wchar_t is 32-bi
-	return p_str == String((const char32_t *)p_chr);
+	return p_str == (const char32_t *)p_chr;
 #endif
 }
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -211,12 +211,7 @@ public:
 	_FORCE_INLINE_ CharStringT(const T *p_cstr) { copy_from(p_cstr); }
 	_FORCE_INLINE_ void operator=(const T *p_cstr) { copy_from(p_cstr); }
 
-	_FORCE_INLINE_ bool operator==(const CharStringT<T> &p_other) const {
-		if (length() != p_other.length()) {
-			return false;
-		}
-		return memcmp(ptr(), p_other.ptr(), length() * sizeof(T)) == 0;
-	}
+	_FORCE_INLINE_ bool operator==(const CharStringT<T> &p_other) const { return span() == p_other.span(); }
 	_FORCE_INLINE_ bool operator!=(const CharStringT<T> &p_other) const { return !(*this == p_other); }
 	_FORCE_INLINE_ bool operator<(const CharStringT<T> &p_other) const {
 		if (length() == 0) {

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -248,31 +248,8 @@ public:
 		return result;
 	}
 
-	bool operator==(const Vector<T> &p_arr) const {
-		Size s = size();
-		if (s != p_arr.size()) {
-			return false;
-		}
-		for (Size i = 0; i < s; i++) {
-			if (operator[](i) != p_arr[i]) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	bool operator!=(const Vector<T> &p_arr) const {
-		Size s = size();
-		if (s != p_arr.size()) {
-			return true;
-		}
-		for (Size i = 0; i < s; i++) {
-			if (operator[](i) != p_arr[i]) {
-				return true;
-			}
-		}
-		return false;
-	}
+	bool operator==(const Vector<T> &p_arr) const { return span() == p_arr.span(); }
+	bool operator!=(const Vector<T> &p_arr) const { return span() != p_arr.span(); }
 
 	struct Iterator {
 		_FORCE_INLINE_ T &operator*() const {

--- a/tests/core/templates/test_span.h
+++ b/tests/core/templates/test_span.h
@@ -61,6 +61,10 @@ TEST_CASE("[Span] Constexpr Validators") {
 	static_assert(span_string[0] == U'1');
 	static_assert(span_string[span_string.size() - 1] == U'5');
 
+	CHECK_EQ(span_string, span_string); // Same identity / ptr.
+	CHECK_EQ(span_string, Span(U"1223456", 6)); // Different ptr.
+	CHECK_EQ(span_string, Span("122345").reinterpret<uint8_t>()); // Different type.
+
 	int idx = 0;
 	for (const char32_t &chr : span_string) {
 		CHECK_EQ(chr, span_string[idx++]);


### PR DESCRIPTION
This happens to allow us to deduplicate a bunch of `operator==` from `String` and `Vector`.
It might be possible to remove explicit overloads in those functions, instead relying on implicit conversions to `Span`, but this is a bit risky compilation wise and thus out of scope for this PR. Will revisit this in a future PR.

`Span<char32_t>` comparison to `Span<char>` is somewhat questionable from a `String` perspective, because it implicitly interprets the `Span<char>` as `latin1`, although it's usually `ascii` (still correct) or utf-8 (incorrect). 
Still, from a `Span` perspective this is entirely reasonable, because individual elements report equality. It is up to callers to differentiate encodings if they matter.

## Benchmark

This PR happens to optimize the equality checks of `Packed*Array` (fundamentally typed `Vector`). The reason is that the old implementation lacked a `memcmp` optimization. I naively benchmarked a ~4x improvement on my computer. The improvement is likely to be better on modern `x86_64` machines, due to wider SIMD support (up to 16x).

I benchmarked this code:
```gdscript
extends Node2D

func _ready() -> void:
	var a := PackedInt32Array()
	a.resize(500000000)
	var b := PackedInt32Array()
	b.resize(500000000)

	for i in 20:
		a == b
```

This resulted in:
```
 ❯ hyperfine -m5 -iw1 "bin/godot.macos.editor.arm64.master --path /Users/lukas/new-game-project --quit" "bin/godot.macos.editor.arm64 --path /Users/lukas/new-game-project --quit"
Benchmark 1: bin/godot.macos.editor.arm64.master --path /Users/lukas/new-game-project --quit
  Time (mean ± σ):     11.970 s ±  0.092 s    [User: 10.632 s, System: 0.543 s]
  Range (min … max):   11.856 s … 12.081 s    5 runs

Benchmark 2: bin/godot.macos.editor.arm64 --path /Users/lukas/new-game-project --quit
  Time (mean ± σ):      3.168 s ±  0.035 s    [User: 1.863 s, System: 0.512 s]
  Range (min … max):    3.129 s …  3.221 s    5 runs

Summary
  bin/godot.macos.editor.arm64 --path /Users/lukas/new-game-project --quit ran
    3.78 ± 0.05 times faster than bin/godot.macos.editor.arm64.master --path /Users/lukas/new-game-project --quit
```