### PR TITLE
Add clearing of `static_gdscript_cache` to `GDScriptCache`

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -485,6 +485,7 @@ void GDScriptCache::clear() {
 	parser_map_refs.clear();
 	singleton->shallow_gdscript_cache.clear();
 	singleton->full_gdscript_cache.clear();
+	singleton->static_gdscript_cache.clear();
 }
 
 GDScriptCache::GDScriptCache() {


### PR DESCRIPTION
As talked about [on Rocket Chat](https://chat.godotengine.org/channel/gdscript?msg=ijWSqXL3nynEmw4t4), this relates to an issue that I've been trying to debug for a few days now, but have so far been unsuccessful in figuring out what the exact cause is, hence why I can't provide an issue/MRP for it.

## Description

In short, in the relatively large project I'm working with there seems to be some issue where a significant amount of `GDScript` instances are somehow ending up in a strange state where they're being kept alive by `GDScriptCache::static_gdscript_cache`, but are somehow not in `GDScriptLanguage::script_list`, which (as far as I can tell) should rightfully hold every non-freed `GDScript` instance.

This then leads to these `GDScript` instances having `GDScript::clear` called on them too late in the program flow, resulting in this error being tripped in `SelfList::List::remove`, for every single function in these classes, due to redundant removals from `GDScriptLanguage::function_list`:

https://github.com/godotengine/godot/blob/9e6ee9c5c3c2037187e7b9a84b41a4119fb6b625/core/templates/self_list.h#L79

The common denominator between these classes seems to be that they all have `static` variables in them.

I've so far only seen this problem manifest when deleting the `.godot` folder and opening the project in the editor and then closing it, meaning it's reproducible with `--import`, with or without `--headless`, which means we're getting a lot of these errors when doing `--headless --import` in a CI context.

As best I can tell, this is most likely a regression in 4.4, as this only started happening after we migrated this project from 4.3-stable to 4.4-stable, and latest `master` (4ef0cd689f as of writing this) does not resolve the issue.

Unfortunately, bisecting this particular issue would take a considerable amount of effort, due to the time it takes to do a clean import in this particular project, along with some other complications, so I can't tell you where the regression originated from at this time.

## Sequence of events

As mentioned, the loop here in `GDScriptLanguage::finish` never seems to iterate over these particular `GDScript` instances, for reasons I don't quite understand:

https://github.com/godotengine/godot/blob/9e6ee9c5c3c2037187e7b9a84b41a4119fb6b625/modules/gdscript/gdscript.cpp#L2330-L2357

... which means that `GDScript::clear` isn't called for them here:

https://github.com/godotengine/godot/blob/9e6ee9c5c3c2037187e7b9a84b41a4119fb6b625/modules/gdscript/gdscript.cpp#L2354

... which means that their member functions are not freed as part of that either, as found here:

https://github.com/godotengine/godot/blob/9e6ee9c5c3c2037187e7b9a84b41a4119fb6b625/modules/gdscript/gdscript.cpp#L1615-L1617

... which means we'll end up clearing `GDScriptLanguage::function_list` before any `GDScript::clear` happens:

https://github.com/godotengine/godot/blob/9e6ee9c5c3c2037187e7b9a84b41a4119fb6b625/modules/gdscript/gdscript.cpp#L2359

... and then `GDScriptCache` will end up being freed as part of `uninitialize_gdscript_module`, here:

https://github.com/godotengine/godot/blob/9e6ee9c5c3c2037187e7b9a84b41a4119fb6b625/modules/gdscript/register_types.cpp#L174-L176

... which will cause `GDScriptCache::static_gdscript_cache` to be destroyed as well, thereby freeing the `Ref<GDScript>` it seems to be holding, which in turn leads to `GDScript::clear` being called from its destructor, as seen here:

https://github.com/godotengine/godot/blob/9e6ee9c5c3c2037187e7b9a84b41a4119fb6b625/modules/gdscript/gdscript.cpp#L1641

... which then actually frees the member functions (too late) and emits the error from `SelfList::List::remove`:

https://github.com/godotengine/godot/blob/9e6ee9c5c3c2037187e7b9a84b41a4119fb6b625/modules/gdscript/gdscript.cpp#L1615-L1617

## Fix/workaround

This pull request fixes this issue by adding what seems to be a missing clearing of `GDScriptCache::static_gdscript_cache` in `GDScriptCache::clear`, which according to @vnen might have been left out by mistake.

This results in the affected `GDScript` instances being freed/cleared as part of `GDScriptCache::clear` _before_ we go to clear `GDScriptLanguage::function_list`, thereby preventing this redundant removal from happening, and thus preventing the `SelfList` error from being reported.

While this change does resolve the problem, and might still be warranted on its own, it still seems like a bit of a workaround to what might be a bigger issue here.