### PR TITLE
Add import option to preserve alpha test coverage

### DIFF
--- a/core/io/image.compat.inc
+++ b/core/io/image.compat.inc
@@ -51,6 +51,10 @@ Error Image::_compress_from_channels_bind_compat_115003(CompressMode p_mode, Use
 	return compress_from_channels(p_mode, p_channels, _astc_format_to_compress_profile(p_format));
 }
 
+Error Image::_generate_mipmaps_bind_compat_104289(bool p_renormalize) {
+	return generate_mipmaps(p_renormalize, false, 0.5f);
+}
+
 Vector<uint8_t> Image::_save_exr_to_buffer_bind_compat_117800(bool p_grayscale) const {
 	return save_exr_to_buffer(p_grayscale);
 }
@@ -62,6 +66,7 @@ Error Image::_save_exr_bind_compat_117800(const String &p_path, bool p_grayscale
 void Image::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("compress", "mode", "source", "astc_format"), &Image::_compress_bind_compat_115003, DEFVAL(COMPRESS_SOURCE_GENERIC), DEFVAL(ASTC_FORMAT_4x4));
 	ClassDB::bind_compatibility_method(D_METHOD("compress_from_channels", "mode", "channels", "astc_format"), &Image::_compress_from_channels_bind_compat_115003, DEFVAL(ASTC_FORMAT_4x4));
+	ClassDB::bind_compatibility_method(D_METHOD("generate_mipmaps", "renormalize"), &Image::_generate_mipmaps_bind_compat_104289, DEFVAL(false));
 	ClassDB::bind_compatibility_method(D_METHOD("save_exr", "path", "grayscale"), &Image::_save_exr_bind_compat_117800, DEFVAL(false));
 	ClassDB::bind_compatibility_method(D_METHOD("save_exr_to_buffer", "grayscale"), &Image::_save_exr_to_buffer_bind_compat_117800, DEFVAL(false));
 }

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -1824,7 +1824,7 @@ static void _generate_po2_mipmap(const Component *p_src, Component *p_dst, uint3
 	}
 }
 
-void Image::_generate_mipmap_from_format(Image::Format p_format, const uint8_t *p_src, uint8_t *p_dst, uint32_t p_width, uint32_t p_height, bool p_renormalize) {
+void Image::_generate_mipmap_from_format(Image::Format p_format, const uint8_t *p_src, uint8_t *p_dst, uint32_t p_width, uint32_t p_height, bool p_renormalize, bool p_preserve_alpha_test_coverage) {
 	const float *src_float = reinterpret_cast<const float *>(p_src);
 	float *dst_float = reinterpret_cast<float *>(p_dst);
 
@@ -1959,7 +1959,82 @@ void Image::normalize() {
 	}
 }
 
-Error Image::generate_mipmaps(bool p_renormalize) {
+float Image::alpha_test_coverage(uint8_t *p_dst, uint32_t p_width, uint32_t p_height, float alphaRef, float alphaScale) const {
+	int right_step = (p_width == 1) ? 0 : 1;
+	int down_step = (p_height == 1) ? 0 : p_width;
+
+	float coverage = 0.0f;
+
+	const uint32_t n = 4;
+
+	for (uint32_t y = 0; y < p_height - 1; y++) {
+		for (uint32_t x = 0; x < p_width - 1; x++) {
+			uint32_t i = y * p_width + x;
+
+			float alpha00 = _get_color_at_ofs(p_dst, i).a * alphaScale;
+			float alpha10 = _get_color_at_ofs(p_dst, i + right_step).a * alphaScale;
+			float alpha01 = _get_color_at_ofs(p_dst, i + down_step).a * alphaScale;
+			float alpha11 = _get_color_at_ofs(p_dst, i + right_step + down_step).a * alphaScale;
+
+			float texel_coverage = 0.0f;
+			for (uint32_t sy = 0; sy < n; sy++) {
+				float fy = (sy + 0.5f) / n;
+				for (uint32_t sx = 0; sx < n; sx++) {
+					float fx = (sx + 0.5f) / n;
+					float alpha = alpha00 * (1 - fx) * (1 - fy) + alpha10 * fx * (1 - fy) + alpha01 * (1 - fx) * fy + alpha11 * fx * fy;
+					if (alpha > alphaRef) {
+						texel_coverage += 1.0f;
+					}
+				}
+			}
+			coverage += texel_coverage / (n * n);
+		}
+	}
+	return coverage / float((p_width - 1) * (p_height - 1));
+}
+
+void Image::scale_alpha_to_coverage(uint8_t *p_dst, uint32_t p_width, uint32_t p_height, float desiredCoverage, float alphaRef) {
+	float minAlphaScale = 0.0f;
+	float maxAlphaScale = 4.0f;
+	float alphaScale = 1.0f;
+	float bestAlphaScale = 1.0f;
+	float bestError = 999999.9f;
+
+	// Determine desired scale using a binary search. Hardcoded to 10 steps max.
+	for (int i = 0; i < 10; i++) {
+		float currentCoverage = alpha_test_coverage(p_dst, p_width, p_height, alphaRef, alphaScale);
+
+		float error = fabsf(currentCoverage - desiredCoverage);
+		if (error < bestError) {
+			bestError = error;
+			bestAlphaScale = alphaScale;
+		}
+
+		if (currentCoverage < desiredCoverage) {
+			minAlphaScale = alphaScale;
+		} else if (currentCoverage > desiredCoverage) {
+			maxAlphaScale = alphaScale;
+		} else {
+			break;
+		}
+
+		alphaScale = (minAlphaScale + maxAlphaScale) * 0.5f;
+	}
+
+	// Scale alpha channel.
+	scale_mipmap_alpha_bias(p_dst, p_width, p_height, bestAlphaScale, 0.0f);
+}
+
+void Image::scale_mipmap_alpha_bias(uint8_t *p_dst, uint32_t p_width, uint32_t p_height, float scale, float bias) {
+	for (uint32_t i = 0; i < p_width * p_height; i++) {
+		Color c = _get_color_at_ofs(p_dst, i);
+		c.a = CLAMP(c.a * scale + bias, 0.0f, 1.0f);
+		// how do I clamp this?
+		_set_color_at_ofs(p_dst, i, c);
+	}
+}
+
+Error Image::generate_mipmaps(bool p_renormalize, bool p_preserve_alpha_test_coverage, float target_coverage) {
 	ERR_FAIL_COND_V_MSG(is_compressed(), ERR_UNAVAILABLE, "Cannot generate mipmaps from compressed image formats.");
 	ERR_FAIL_COND_V_MSG(format == FORMAT_RGBA4444, ERR_UNAVAILABLE, "Cannot generate mipmaps from RGBA4444 format.");
 	ERR_FAIL_COND_V_MSG(width == 0 || height == 0, ERR_UNCONFIGURED, "Cannot generate mipmaps with width or height equal to 0.");
@@ -1974,12 +2049,20 @@ Error Image::generate_mipmaps(bool p_renormalize) {
 	int prev_h = height;
 	int prev_w = width;
 
+	if (p_preserve_alpha_test_coverage) {
+		desired_atc = alpha_test_coverage(wp, width, height, target_coverage, 1.0);
+	}
+
 	for (int i = 1; i <= gen_mipmap_count; i++) {
 		int64_t ofs;
 		int w, h;
 		_get_mipmap_offset_and_size(i, ofs, w, h);
 
-		_generate_mipmap_from_format(format, wp + prev_ofs, wp + ofs, prev_w, prev_h, p_renormalize);
+		_generate_mipmap_from_format(format, wp + prev_ofs, wp + ofs, prev_w, prev_h, p_renormalize, p_preserve_alpha_test_coverage);
+
+		if (p_preserve_alpha_test_coverage) {
+			scale_alpha_to_coverage(wp + ofs, w, h, desired_atc, target_coverage);
+		}
 
 		prev_ofs = ofs;
 		prev_w = w;

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2181,7 +2181,84 @@ void Image::normalize() {
 	}
 }
 
-Error Image::generate_mipmaps(bool p_renormalize) {
+float Image::_alpha_test_coverage(const uint8_t *p_dst, uint32_t p_width, uint32_t p_height, float p_alpha_ref, float p_alpha_scale) const {
+	int right_step = (p_width == 1) ? 0 : 1;
+	int down_step = (p_height == 1) ? 0 : p_width;
+
+	float coverage = 0.0f;
+
+	const uint32_t n = 4;
+
+	// Guard against textures that are only 1px in either dimension
+	uint32_t cell_w = MAX(1u, p_width - 1);
+	uint32_t cell_h = MAX(1u, p_height - 1);
+
+	for (uint32_t y = 0; y < cell_h; y++) {
+		for (uint32_t x = 0; x < cell_w; x++) {
+			uint32_t i = y * cell_w + x;
+
+			float alpha00 = CLAMP(_get_color_at_ofs(p_dst, i).a * p_alpha_scale, 0.0, 1.0);
+			float alpha10 = CLAMP(_get_color_at_ofs(p_dst, i + right_step).a * p_alpha_scale, 0.0, 1.0);
+			float alpha01 = CLAMP(_get_color_at_ofs(p_dst, i + down_step).a * p_alpha_scale, 0.0, 1.0);
+			float alpha11 = CLAMP(_get_color_at_ofs(p_dst, i + right_step + down_step).a * p_alpha_scale, 0.0, 1.0);
+
+			float texel_coverage = 0.0f;
+			for (uint32_t sy = 0; sy < n; sy++) {
+				float fy = (sy + 0.5f) / n;
+				for (uint32_t sx = 0; sx < n; sx++) {
+					float fx = (sx + 0.5f) / n;
+					float alpha = alpha00 * (1 - fx) * (1 - fy) + alpha10 * fx * (1 - fy) + alpha01 * (1 - fx) * fy + alpha11 * fx * fy;
+					if (alpha > p_alpha_ref) {
+						texel_coverage += 1.0f;
+					}
+				}
+			}
+			coverage += texel_coverage / (n * n);
+		}
+	}
+	return coverage / float(cell_w * cell_h);
+}
+
+void Image::_scale_alpha_to_coverage(uint8_t *p_dst, uint32_t p_width, uint32_t p_height, float p_desired_coverage, float p_alpha_ref) {
+	float min_alpha_scale = 0.0f;
+	float max_alpha_scale = 4.0f;
+	float alpha_scale = 1.0f;
+	float best_alpha_scale = 1.0f;
+	float best_error = 999999.9f;
+
+	// Determine desired scale using a binary search. Hardcoded to 10 steps max.
+	for (int i = 0; i < 10; i++) {
+		float current_coverage = _alpha_test_coverage(p_dst, p_width, p_height, p_alpha_ref, alpha_scale);
+
+		float error = Math::abs(current_coverage - p_desired_coverage);
+		if (error < best_error) {
+			best_error = error;
+			best_alpha_scale = alpha_scale;
+		}
+
+		if (current_coverage < p_desired_coverage) {
+			min_alpha_scale = alpha_scale;
+		} else if (current_coverage > p_desired_coverage) {
+			max_alpha_scale = alpha_scale;
+		} else {
+			break;
+		}
+
+		alpha_scale = (min_alpha_scale + max_alpha_scale) * 0.5f;
+	}
+
+	_scale_mipmap_alpha_bias(p_dst, p_width, p_height, best_alpha_scale, 0.0f);
+}
+
+void Image::_scale_mipmap_alpha_bias(uint8_t *p_dst, uint32_t p_width, uint32_t p_height, float p_scale, float p_bias) {
+	for (uint32_t i = 0; i < p_width * p_height; i++) {
+		Color c = _get_color_at_ofs(p_dst, i);
+		c.a = CLAMP(c.a * p_scale + p_bias, 0.0f, 1.0f);
+		_set_color_at_ofs(p_dst, i, c);
+	}
+}
+
+Error Image::generate_mipmaps(bool p_renormalize, bool p_preserve_alpha_test_coverage, float p_alpha_test_threshold) {
 	ERR_FAIL_COND_V_MSG(is_compressed(), ERR_UNAVAILABLE, "Cannot generate mipmaps from compressed image formats.");
 	ERR_FAIL_COND_V_MSG(width == 0 || height == 0, ERR_UNCONFIGURED, "Cannot generate mipmaps with width or height equal to 0.");
 
@@ -2195,12 +2272,21 @@ Error Image::generate_mipmaps(bool p_renormalize) {
 	int prev_h = height;
 	int prev_w = width;
 
+	float desired_atc = 0.0f;
+	if (p_preserve_alpha_test_coverage) {
+		desired_atc = _alpha_test_coverage(wp, width, height, p_alpha_test_threshold, 1.0);
+	}
+
 	for (int i = 1; i <= gen_mipmap_count; i++) {
 		int64_t ofs;
 		int w, h;
 		_get_mipmap_offset_and_size(i, ofs, w, h);
 
 		_generate_mipmap_from_format(format, wp + prev_ofs, wp + ofs, prev_w, prev_h, p_renormalize);
+
+		if (p_preserve_alpha_test_coverage) {
+			_scale_alpha_to_coverage(wp + ofs, w, h, desired_atc, p_alpha_test_threshold);
+		}
 
 		prev_ofs = ofs;
 		prev_w = w;
@@ -3893,7 +3979,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("crop", "width", "height"), &Image::crop);
 	ClassDB::bind_method(D_METHOD("flip_x"), &Image::flip_x);
 	ClassDB::bind_method(D_METHOD("flip_y"), &Image::flip_y);
-	ClassDB::bind_method(D_METHOD("generate_mipmaps", "renormalize"), &Image::generate_mipmaps, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("generate_mipmaps", "renormalize", "preserve_alpha_test_coverage", "alpha_test_threshold"), &Image::generate_mipmaps, DEFVAL(false), DEFVAL(false), DEFVAL(0.5f));
 	ClassDB::bind_method(D_METHOD("clear_mipmaps"), &Image::clear_mipmaps);
 
 #ifndef DISABLE_DEPRECATED

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -247,6 +247,7 @@ private:
 	int width = 0;
 	int height = 0;
 	bool mipmaps = false;
+	float desired_atc;
 
 	void _copy_internals_from(const Image &p_image);
 
@@ -269,7 +270,7 @@ private:
 
 	Error _load_from_buffer(const Vector<uint8_t> &p_array, ImageMemLoadFunc p_loader);
 
-	_FORCE_INLINE_ void _generate_mipmap_from_format(Image::Format p_format, const uint8_t *p_src, uint8_t *p_dst, uint32_t p_width, uint32_t p_height, bool p_renormalize = false);
+	_FORCE_INLINE_ void _generate_mipmap_from_format(Image::Format p_format, const uint8_t *p_src, uint8_t *p_dst, uint32_t p_width, uint32_t p_height, bool p_renormalize = false, bool p_preserve_alpha_test_coverage = false);
 
 	static void average_4_uint8(uint8_t &p_out, const uint8_t &p_a, const uint8_t &p_b, const uint8_t &p_c, const uint8_t &p_d);
 	static void average_4_float(float &p_out, const float &p_a, const float &p_b, const float &p_c, const float &p_d);
@@ -317,12 +318,16 @@ public:
 	void flip_y();
 
 	// Generate a mipmap chain of an image (creates an image 1/4 the size, with averaging of 4->1).
-	Error generate_mipmaps(bool p_renormalize = false);
+	Error generate_mipmaps(bool p_renormalize = false, bool p_preserve_alpha_test_coverage = false, float target_coverage = 0.5);
 
 	Error generate_mipmap_roughness(RoughnessChannel p_roughness_channel, const Ref<Image> &p_normal_map);
 
 	void clear_mipmaps();
 	void normalize();
+
+	float alpha_test_coverage(uint8_t *p_dst, uint32_t p_width, uint32_t p_height, float alphaRef, float alphaScale) const;
+	void scale_alpha_to_coverage(uint8_t *p_dst, uint32_t p_width, uint32_t p_height, float desiredCoverage, float alphaRef);
+	void scale_mipmap_alpha_bias(uint8_t *p_dst, uint32_t p_width, uint32_t p_height, float scale, float bias);
 
 	// Creates new internal image data of a given size and format. Current image will be lost.
 	void initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format);

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -280,6 +280,7 @@ protected:
 	Error _compress_from_channels_bind_compat_115003(CompressMode p_mode, UsedChannels p_channels, ASTCFormat p_format);
 	Vector<uint8_t> _save_exr_to_buffer_bind_compat_117800(bool p_grayscale = false) const;
 	Error _save_exr_bind_compat_117800(const String &p_path, bool p_grayscale = false) const;
+	Error _generate_mipmaps_bind_compat_104289(bool p_renormalize);
 
 	static void _bind_compatibility_methods();
 #endif
@@ -313,6 +314,10 @@ private:
 	Error _load_from_buffer(const Vector<uint8_t> &p_array, ImageMemLoadFunc p_loader);
 
 	_FORCE_INLINE_ void _generate_mipmap_from_format(Image::Format p_format, const uint8_t *p_src, uint8_t *p_dst, uint32_t p_width, uint32_t p_height, bool p_renormalize = false);
+
+	float _alpha_test_coverage(const uint8_t *p_dst, uint32_t p_width, uint32_t p_height, float p_alpha_ref, float p_alpha_scale) const;
+	void _scale_alpha_to_coverage(uint8_t *p_dst, uint32_t p_width, uint32_t p_height, float p_desired_coverage, float p_alpha_ref);
+	void _scale_mipmap_alpha_bias(uint8_t *p_dst, uint32_t p_width, uint32_t p_height, float p_scale, float p_bias);
 
 	static void average_4_uint8(uint8_t &p_out, const uint8_t &p_a, const uint8_t &p_b, const uint8_t &p_c, const uint8_t &p_d);
 	static void average_4_float(float &p_out, const float &p_a, const float &p_b, const float &p_c, const float &p_d);
@@ -364,7 +369,7 @@ public:
 	void flip_y();
 
 	// Generate a mipmap chain of an image (creates an image 1/4 the size, with averaging of 4->1).
-	Error generate_mipmaps(bool p_renormalize = false);
+	Error generate_mipmaps(bool p_renormalize = false, bool p_preserve_alpha_test_coverage = false, float p_alpha_test_threshold = 0.5);
 
 	Error generate_mipmap_roughness(RoughnessChannel p_roughness_channel, const Ref<Image> &p_normal_map);
 

--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -585,7 +585,7 @@
 			The material will use the texture's alpha values for transparency. This is the slowest to render, and disables shadow casting.
 		</constant>
 		<constant name="TRANSPARENCY_ALPHA_SCISSOR" value="2" enum="Transparency" keywords="TRANSPARENCY_ALPHA_TEST">
-			The material will cut off all values below a threshold, the rest will remain opaque. The opaque portions will be rendered in the depth prepass. This is faster to render than alpha blending, but slower than opaque rendering. This also supports casting shadows.
+			The material will cut off all values below a threshold, the rest will remain opaque. The opaque portions will be rendered in the depth prepass. This is faster to render than alpha blending, but slower than opaque rendering. This also supports casting shadows. For textures using this mode see the [code]Preserve Alpha Test Coverage[/code] option in the texture import settings to improve distant rendering and popping.
 		</constant>
 		<constant name="TRANSPARENCY_ALPHA_HASH" value="3" enum="Transparency">
 			The material will cut off all values below a spatially-deterministic threshold, the rest will remain opaque. This is faster to render than alpha blending, but slower than opaque rendering. This also supports casting shadows. Alpha hashing is suited for hair rendering.

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -217,9 +217,13 @@
 		<method name="generate_mipmaps">
 			<return type="int" enum="Error" />
 			<param index="0" name="renormalize" type="bool" default="false" />
+			<param index="1" name="preserve_alpha_test_coverage" type="bool" default="false" />
+			<param index="2" name="alpha_test_threshold" type="float" default="0.5" />
 			<description>
 				Generates mipmaps for the image. Mipmaps are precalculated lower-resolution copies of the image that are automatically used if the image needs to be scaled down when rendered. They help improve image quality and performance when rendering. This method returns an error if the image is compressed, in a custom format, or if the image's width/height is [code]0[/code]. Enabling [param renormalize] when generating mipmaps for normal map textures will make sure all resulting vector values are normalized.
 				It is possible to check if the image has mipmaps by calling [method has_mipmaps] or [method get_mipmap_count]. Calling [method generate_mipmaps] on an image that already has mipmaps will replace existing mipmaps in the image.
+				If [param preserve_alpha_test_coverage] is [code]true[/code] it automatically adjusts alpha values to maintain consistent coverage when alpha testing is used. This is especially useful for hair, foliage, or other alpha-tested materials, as it prevents fading or popping artifacts across mipmap levels (LODs). This option is intended for color textures and clamps the alpha channel in the 0.0 - 1.0 range.
+				The [param alpha_test_threshold] parameter is the alpha threshold used when preserving alpha test coverage across mipmap levels. The coverage is measured at mipmap 0 using the setting and the lower mipmaps are adjusted to match that coverage. Higher values preserve more detail, lower values create softer edges. Note that this threshold is independent from the [code]Alpha Scissor Threshold[/code] set on the material and they both may need to be tuned for optimal results.
 			</description>
 		</method>
 		<method name="get_data" qualifiers="const">

--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -65,6 +65,16 @@
 		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
 			Unimplemented. This currently has no effect when changed.
 		</member>
+		<member name="mipmaps/preserve_alpha_test_coverage" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], automatically adjusts alpha values to maintain consistent coverage when alpha testing is used. This is especially useful for hair, foliage, or other alpha-tested materials, as it prevents fading or popping artifacts across mipmap levels (LODs).
+		</member>
+		<member name="mipmaps/target_coverage" type="float" setter="" getter="" default="0.5">
+			The fraction of pixels (0.0 to 1.0) that should pass the alpha test at full resolution (mip 0). For example:
+			- [b]0.5[/b] (default) - 50% of pixels pass, balancing detail and smooth transitions.
+			- [b]Higher values[/b] (e.g., 0.7) - Preserve more fine details (e.g., thin hair strands).
+			- [b]Lower values[/b] (e.g., 0.3) - Softer edges, but may lose small features.
+			The alpha channel is scaled uniformly across all mipmaps to approximate this coverage, ensuring consistent visuals at different distances.
+		</member>
 		<member name="process/fix_alpha_border" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], puts pixels of the same surrounding color in transition from transparent to opaque areas. For textures displayed with bilinear filtering, this helps to reduce the outline effect when exporting images from an image editor.
 			It's recommended to leave this enabled (as it is by default), unless this causes issues for a particular image.

--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -71,6 +71,9 @@
 			If [code]true[/code], scales the imported image to match [member EditorSettings.interface/editor/appearance/custom_display_scale]. This should be enabled for editor plugin icons and custom class icons, but should be left disabled otherwise.
 			[b]Note:[/b] Only available for SVG images.
 		</member>
+		<member name="mipmaps/alpha_test_threshold" type="float" setter="" getter="" default="0.5">
+			The alpha threshold used when preserving alpha test coverage across mipmap levels. The coverage is measured at mipmap 0 using the setting and the lower mipmaps are adjusted to match that coverage. Higher values preserve more detail, lower values create softer edges. Note that this threshold is independent from the [code]Alpha Scissor Threshold[/code] set on the material and they both may need to be tuned for optimal results.
+		</member>
 		<member name="mipmaps/generate" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], smaller versions of the texture are generated on import. For example, a 64×64 texture will generate 6 mipmaps (32×32, 16×16, 8×8, 4×4, 2×2, 1×1). This has several benefits:
 			- Textures will not become grainy in the distance (in 3D), or if scaled down due to [Camera2D] zoom or [CanvasItem] scale (in 2D).
@@ -80,6 +83,9 @@
 		</member>
 		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
 			Unimplemented. This currently has no effect when changed.
+		</member>
+		<member name="mipmaps/preserve_alpha_test_coverage" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], automatically adjusts alpha values to maintain consistent coverage when alpha testing is used. This is especially useful for hair, foliage, or other alpha-tested materials, as it prevents fading or popping artifacts across mipmap levels (LODs). This option is intended for color textures and clamps the alpha channel in the 0.0 - 1.0 range.
 		</member>
 		<member name="process/channel_remap/alpha" type="int" setter="" getter="" default="3">
 			Specifies the data source of the output image's alpha channel.

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -237,6 +237,12 @@ bool ResourceImporterTexture::get_option_visibility(const String &p_path, const 
 
 	} else if (p_option == "compress/uastc_level" || p_option == "compress/rdo_quality_loss") {
 		return int(p_options["compress/mode"]) == COMPRESS_BASIS_UNIVERSAL;
+
+	} else if (p_option == "mipmaps/preserve_alpha_test_coverage") {
+		return p_options["mipmaps/generate"];
+
+	} else if (p_option == "mipmaps/alpha_test_threshold") {
+		return p_options["mipmaps/generate"] && p_options["mipmaps/preserve_alpha_test_coverage"];
 	}
 
 	return true;
@@ -271,6 +277,8 @@ void ResourceImporterTexture::get_import_options(const String &p_path, List<Impo
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/channel_pack", PROPERTY_HINT_ENUM, "sRGB Friendly,Optimized"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "mipmaps/generate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), (p_preset == PRESET_3D ? true : false)));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "mipmaps/limit", PROPERTY_HINT_RANGE, "-1,256"), -1));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "mipmaps/preserve_alpha_test_coverage", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "mipmaps/alpha_test_threshold", PROPERTY_HINT_RANGE, "0.01,0.99,0.01"), 0.5));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "roughness/mode", PROPERTY_HINT_ENUM, "Detect,Disabled,Red,Green,Blue,Alpha,Gray"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "roughness/src_normal", PROPERTY_HINT_FILE, "*.bmp,*.dds,*.exr,*.jpeg,*.jpg,*.hdr,*.png,*.svg,*.tga,*.webp"), ""));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "process/channel_remap/red", PROPERTY_HINT_ENUM, "Red,Green,Blue,Alpha,Inverted Red,Inverted Green,Inverted Blue,Inverted Alpha,Unused,Zero,One"), 0));
@@ -378,7 +386,7 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 	}
 }
 
-void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, Image::CompressProfile p_vram_compression_profile, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_roughness, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel) {
+void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, Image::CompressProfile p_vram_compression_profile, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_roughness, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel, bool p_preserve_alpha_test_coverage, float p_alpha_test_coverage) {
 	Ref<FileAccess> f = FileAccess::open(p_to_path, FileAccess::WRITE);
 	ERR_FAIL_COND(f.is_null());
 
@@ -428,7 +436,7 @@ void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String
 
 	if (p_mipmaps) {
 		if (!image->has_mipmaps() || p_force_normal) {
-			image->generate_mipmaps(p_force_normal);
+			image->generate_mipmaps(p_force_normal, p_preserve_alpha_test_coverage, p_alpha_test_coverage);
 		}
 
 	} else {
@@ -737,6 +745,8 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 	// Mipmaps.
 	const bool mipmaps = p_options["mipmaps/generate"];
 	const uint32_t mipmap_limit = mipmaps ? uint32_t(p_options["mipmaps/limit"]) : uint32_t(-1);
+	const bool mipmaps_preserve_alpha_test_coverage = p_options["mipmaps/preserve_alpha_test_coverage"];
+	const float mipmaps_alpha_test_threshold = p_options["mipmaps/alpha_test_threshold"];
 
 	// Roughness.
 	const int roughness = p_options["roughness/mode"];
@@ -950,7 +960,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 
 		if (force_uncompressed) {
 			_save_ctex(image, p_save_path + ".ctex", COMPRESS_VRAM_UNCOMPRESSED, lossy, basisu_params, Image::COMPRESS_S3TC /* This is ignored. */, Image::COMPRESS_PROFILE_AUTOMATIC /* This is ignored. */,
-					mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, mipmap_limit, normal_image, roughness_channel);
+					mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, mipmap_limit, normal_image, roughness_channel, mipmaps_preserve_alpha_test_coverage, mipmaps_alpha_test_threshold);
 		} else {
 			if (can_s3tc_bptc) {
 				Image::CompressMode image_compress_mode;
@@ -965,7 +975,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 				}
 
 				_save_ctex(image, p_save_path + "." + image_compress_format + ".ctex", compress_mode, lossy, basisu_params, image_compress_mode, image_compress_profile, mipmaps,
-						stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, mipmap_limit, normal_image, roughness_channel);
+						stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, mipmap_limit, normal_image, roughness_channel, mipmaps_preserve_alpha_test_coverage, mipmaps_alpha_test_threshold);
 				r_platform_variants->push_back(image_compress_format);
 			}
 
@@ -982,19 +992,19 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 				}
 
 				_save_ctex(image, p_save_path + "." + image_compress_format + ".ctex", compress_mode, lossy, basisu_params, image_compress_mode, image_compress_profile, mipmaps, stream, detect_3d,
-						detect_roughness, detect_normal, force_normal, srgb_friendly_pack, mipmap_limit, normal_image, roughness_channel);
+						detect_roughness, detect_normal, force_normal, srgb_friendly_pack, mipmap_limit, normal_image, roughness_channel, mipmaps_preserve_alpha_test_coverage, mipmaps_alpha_test_threshold);
 				r_platform_variants->push_back(image_compress_format);
 			}
 		}
 	} else {
 		// Import normally.
 		_save_ctex(image, p_save_path + ".ctex", compress_mode, lossy, basisu_params, Image::COMPRESS_S3TC /* This is ignored. */, Image::COMPRESS_PROFILE_AUTOMATIC /* This is ignored. */,
-				mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, mipmap_limit, normal_image, roughness_channel);
+				mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, mipmap_limit, normal_image, roughness_channel, mipmaps_preserve_alpha_test_coverage, mipmaps_alpha_test_threshold);
 	}
 
 	if (editor_image.is_valid()) {
 		_save_ctex(editor_image, p_save_path + ".editor.ctex", compress_mode, lossy, basisu_params, Image::COMPRESS_S3TC /* This is ignored. */, Image::COMPRESS_PROFILE_AUTOMATIC /* This is ignored. */,
-				mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, mipmap_limit, normal_image, roughness_channel);
+				mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, mipmap_limit, normal_image, roughness_channel, mipmaps_preserve_alpha_test_coverage, mipmaps_alpha_test_threshold);
 
 		// Generate and save editor-specific metadata, which we cannot save to the .import file.
 		Dictionary editor_meta;

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -72,7 +72,7 @@ protected:
 	static ResourceImporterTexture *singleton;
 	static const char *compression_formats[];
 
-	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
+	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel, bool p_preserve_alpha_test_coverage, float target_corverage);
 	void _save_editor_meta(const Dictionary &p_metadata, const String &p_to_path);
 	Dictionary _load_editor_meta(const String &p_to_path) const;
 

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -86,7 +86,7 @@ protected:
 	static ResourceImporterTexture *singleton;
 	static const char *compression_formats[];
 
-	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, Image::CompressProfile p_vram_compression_profile, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
+	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, Image::CompressProfile p_vram_compression_profile, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel, bool p_preserve_alpha_test_coverage, float p_alpha_test_threshold);
 	void _save_editor_meta(const Dictionary &p_metadata, const String &p_to_path);
 	Dictionary _load_editor_meta(const String &p_to_path) const;
 

--- a/misc/extension_api_validation/4.7-stable/GH-104289.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-104289.txt
@@ -1,0 +1,6 @@
+GH-104289
+--------------
+
+Validate extension JSON: Error: Field 'classes/Image/methods/generate_mipmaps/arguments': size changed value in new API, from 1 to 3.
+
+Added two additional parameters to _generate_mipmaps. Compatibility method registered.


### PR DESCRIPTION
This will close https://github.com/godotengine/godot-proposals/issues/9152

https://github.com/user-attachments/assets/e97d51ba-d0a7-4a74-b9cf-faa3ec5ea7ad

Implementation is based on: https://github.com/castano/nvidia-texture-tools/blob/aeddd65f81d36d8cb7b169b469ef25156666077e/src/nvimage/FloatImage.cpp#L1379

example scene: 
[preserve-alpha-examples.zip](https://github.com/user-attachments/files/19297786/preserve-alpha-examples.zip)

- [x] Implement the import option
- [x] Ensure the setting is stored correctly in the import file?
- [x] Documentation
- [x] Investigate having the option enable with detection instead when using alpha clipping - no doesn't make sense to do.