### PR TITLE
Improve the `PhysicsShapeQueryParameters3D`'s description

### DIFF
--- a/doc/classes/PhysicsShapeQueryParameters2D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters2D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PhysicsShapeQueryParameters2D" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Provides parameters for [method PhysicsDirectSpaceState2D.intersect_shape].
+		Provides parameters for [PhysicsDirectSpaceState2D]'s methods.
 	</brief_description>
 	<description>
-		By changing various properties of this object, such as the shape, you can configure the parameters for [method PhysicsDirectSpaceState2D.intersect_shape].
+		By changing various properties of this object, such as the shape, you can configure the parameters for [PhysicsDirectSpaceState2D]'s methods.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -30,6 +30,7 @@
 		</member>
 		<member name="shape" type="Resource" setter="set_shape" getter="get_shape">
 			The [Shape2D] that will be used for collision/intersection queries. This stores the actual reference which avoids the shape to be released while being used for queries, so always prefer using this over [member shape_rid].
+			[b]Note:[/b] Only some methods of [PhysicsDirectSpaceState2D] that take this class as parameter make use of this property. See their respective descriptions for details.
 		</member>
 		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid" default="RID()">
 			The queried shape's [RID] that will be used for collision/intersection queries. Use this over [member shape] if you want to optimize for performance using the Servers API:

--- a/doc/classes/PhysicsShapeQueryParameters2D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters2D.xml
@@ -30,7 +30,6 @@
 		</member>
 		<member name="shape" type="Resource" setter="set_shape" getter="get_shape">
 			The [Shape2D] that will be used for collision/intersection queries. This stores the actual reference which avoids the shape to be released while being used for queries, so always prefer using this over [member shape_rid].
-			[b]Note:[/b] Only some methods of [PhysicsDirectSpaceState2D] that take this class as parameter make use of this property. See their respective descriptions for details.
 		</member>
 		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid" default="RID()">
 			The queried shape's [RID] that will be used for collision/intersection queries. Use this over [member shape] if you want to optimize for performance using the Servers API:

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -27,6 +27,7 @@
 		</member>
 		<member name="motion" type="Vector3" setter="set_motion" getter="get_motion" default="Vector3(0, 0, 0)">
 			The motion of the shape being queried for.
+			[b]Note:[/b] Many methods ignore this property.
 		</member>
 		<member name="shape" type="Resource" setter="set_shape" getter="get_shape">
 			The [Shape3D] that will be used for collision/intersection queries. This stores the actual reference which avoids the shape to be released while being used for queries, so always prefer using this over [member shape_rid].

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -27,7 +27,6 @@
 		</member>
 		<member name="motion" type="Vector3" setter="set_motion" getter="get_motion" default="Vector3(0, 0, 0)">
 			The motion of the shape being queried for.
-			[b]Note:[/b] Only some methods of [PhysicsDirectSpaceState3D] that take this class as parameter make use of this property. See their respective descriptions for details.
 		</member>
 		<member name="shape" type="Resource" setter="set_shape" getter="get_shape">
 			The [Shape3D] that will be used for collision/intersection queries. This stores the actual reference which avoids the shape to be released while being used for queries, so always prefer using this over [member shape_rid].

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PhysicsShapeQueryParameters3D" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Provides parameters for [method PhysicsDirectSpaceState3D.intersect_shape].
+		Provides parameters for [PhysicsDirectSpaceState3D]'s methods.
 	</brief_description>
 	<description>
 		By changing various properties of this object, such as the shape, you can configure the parameters for [method PhysicsDirectSpaceState3D.intersect_shape].

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -4,7 +4,7 @@
 		Provides parameters for [PhysicsDirectSpaceState3D]'s methods.
 	</brief_description>
 	<description>
-		By changing various properties of this object, such as the shape, you can configure the parameters for [method PhysicsDirectSpaceState3D.intersect_shape].
+		By changing various properties of this object, such as the shape, you can configure the parameters for [PhysicsDirectSpaceState3D]'s methods.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -27,7 +27,7 @@
 		</member>
 		<member name="motion" type="Vector3" setter="set_motion" getter="get_motion" default="Vector3(0, 0, 0)">
 			The motion of the shape being queried for.
-			[b]Note:[/b] Many methods ignore this property.
+			[b]Note:[/b] Only some methods of [PhysicsDirectSpaceState3D] that take this class as parameter make use of this property. See their respective descriptions for details.
 		</member>
 		<member name="shape" type="Resource" setter="set_shape" getter="get_shape">
 			The [Shape3D] that will be used for collision/intersection queries. This stores the actual reference which avoids the shape to be released while being used for queries, so always prefer using this over [member shape_rid].


### PR DESCRIPTION
Made it clearer that this class is used in several of PhysicsDirectSpaceState3D's methods and not just on intersect_shape()

As you can see, this was looking kinda contradictory :

![question_godot_motion](https://github.com/user-attachments/assets/300fbf0d-fe26-425f-8d53-a3d6fde1ca3e)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
