### PR TITLE
Android: Convert `compress_native_libraries` to a basic export option

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2040,7 +2040,6 @@ bool EditorExportPlatformAndroid::get_export_option_visibility(const EditorExpor
 	if (p_option == "graphics/opengl_debug" ||
 			p_option == "command_line/extra_args" ||
 			p_option == "permissions/custom_permissions" ||
-			p_option == "gradle_build/compress_native_libraries" ||
 			p_option == "keystore/debug" ||
 			p_option == "keystore/debug_user" ||
 			p_option == "keystore/debug_password" ||


### PR DESCRIPTION
This PR moves `compress_native_libraries` to the basic export options, making it more visible to users. This change helps prevent confusion, as seen in issue https://github.com/godotengine/godot/issues/104137, where a user switched to the Gradle build and saw their apk size _more than double_. While the size increase will still occur, this change ensures that more users are aware of the option to compress native libraries, rather than it being hidden behind the `Advanced Options` toggle.