### PR TITLE
CI: Build macOS binary without Vulkan if Vulkan SDK fails installing

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -44,13 +44,20 @@ jobs:
         uses: ./.github/actions/godot-deps
 
       - name: Setup Vulkan SDK
+        id: vulkan-sdk
         run: |
-          sh misc/scripts/install_vulkan_sdk_macos.sh
+          if sh misc/scripts/install_vulkan_sdk_macos.sh; then
+            echo "VULKAN_ENABLED=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::macOS: Vulkan SDK installation failed, building without Vulkan support."
+            echo "VULKAN_ENABLED=no" >> "$GITHUB_OUTPUT"
+          fi
+        continue-on-error: true
 
       - name: Compilation (x86_64)
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=x86_64
+          sconsflags: ${{ env.SCONSFLAGS }} arch=x86_64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
           platform: macos
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
@@ -58,7 +65,7 @@ jobs:
       - name: Compilation (arm64)
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
+          sconsflags: ${{ env.SCONSFLAGS }} arch=arm64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
           platform: macos
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}


### PR DESCRIPTION
It's not rare for this step to fail, either due to network errors, or occasional changes in how the Vulkan SDK is distributed which require editing our script.

Today it started failing because https://sdk.lunarg.com/ returns error 502: Bad Gateway.

A drawback of this change is that if the Vulkan SDK does change setup and the step fails due to other aspects than network errors, we won't catch it right away. We'd need to manually check the log once in a while to confirm that it's still being installed and enabled fine. But it's probably ok.