### PR TITLE
Add `get_*_rect()` functions to `Projection`

### DIFF
--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -424,6 +424,15 @@ Vector2 Projection::get_viewport_half_extents() const {
 	return Vector2(w / columns[0][0], w / columns[1][1]);
 }
 
+Rect2 Projection::get_viewport_rect() const {
+	// NOTE: This assumes a rectangular projection plane, i.e. that :
+	// - the matrix is a projection across z-axis (i.e. is invertible and columns[0][1], [0][3], [1][0] and [1][3] == 0)
+	// - the projection plane is rectangular (i.e. columns[0][2] and [1][2] == 0 if columns[2][3] != 0)
+	Size2 half_extents = get_viewport_half_extents();
+	Point2 bottom_left = -half_extents * Vector2(columns[3][0] * columns[3][3] + columns[2][0] * columns[2][3] + 1, columns[3][1] * columns[3][3] + columns[2][1] * columns[2][3] + 1);
+	return Rect2(bottom_left, 2 * half_extents);
+}
+
 Vector2 Projection::get_far_plane_half_extents() const {
 	// NOTE: This assumes a symmetrical frustum, i.e. that :
 	// - the matrix is a projection across z-axis (i.e. is invertible and columns[0][1], [0][3], [1][0] and [1][3] == 0)
@@ -431,6 +440,15 @@ Vector2 Projection::get_far_plane_half_extents() const {
 	// - there is no offset / skew (i.e. columns[2][0] == columns[2][1] == 0)
 	real_t w = -get_z_far() * columns[2][3] + columns[3][3];
 	return Vector2(w / columns[0][0], w / columns[1][1]);
+}
+
+Rect2 Projection::get_far_plane_rect() const {
+	// NOTE: This assumes a rectangular projection plane, i.e. that :
+	// - the matrix is a projection across z-axis (i.e. is invertible and columns[0][1], [0][3], [1][0] and [1][3] == 0)
+	// - the projection plane is rectangular (i.e. columns[0][2] and [1][2] == 0 if columns[2][3] != 0)
+	Size2 half_extents = get_far_plane_half_extents();
+	Point2 bottom_left = -half_extents * Vector2(columns[3][0] * columns[3][3] + columns[2][0] * columns[2][3] + 1, columns[3][1] * columns[3][3] + columns[2][1] * columns[2][3] + 1);
+	return Rect2(bottom_left, 2 * half_extents);
 }
 
 bool Projection::get_endpoints(const Transform3D &p_transform, Vector3 *p_8points) const {

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -109,7 +109,9 @@ struct [[nodiscard]] Projection {
 
 	bool get_endpoints(const Transform3D &p_transform, Vector3 *p_8points) const;
 	Vector2 get_viewport_half_extents() const;
+	Rect2 get_viewport_rect() const;
 	Vector2 get_far_plane_half_extents() const;
+	Rect2 get_far_plane_rect() const;
 
 	void invert();
 	Projection inverse() const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2309,7 +2309,9 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Projection, is_orthogonal, sarray(), varray());
 
 	bind_method(Projection, get_viewport_half_extents, sarray(), varray());
+	bind_method(Projection, get_viewport_rect, sarray(), varray());
 	bind_method(Projection, get_far_plane_half_extents, sarray(), varray());
+	bind_method(Projection, get_far_plane_rect, sarray(), varray());
 
 	bind_method(Projection, inverse, sarray(), varray());
 	bind_method(Projection, get_pixels_per_meter, sarray("for_pixel_width"), varray());

--- a/doc/classes/Projection.xml
+++ b/doc/classes/Projection.xml
@@ -182,6 +182,12 @@
 				Returns the dimensions of the far clipping plane of the projection, divided by two.
 			</description>
 		</method>
+		<method name="get_far_plane_rect" qualifiers="const">
+			<return type="Rect2" />
+			<description>
+				Returns the bottom-left corner and the dimensions of the far clipping plane of the projection.
+			</description>
+		</method>
 		<method name="get_fov" qualifiers="const">
 			<return type="float" />
 			<description>
@@ -222,6 +228,12 @@
 			<return type="Vector2" />
 			<description>
 				Returns the dimensions of the viewport plane that this [Projection] projects positions onto, divided by two.
+			</description>
+		</method>
+		<method name="get_viewport_rect" qualifiers="const">
+			<return type="Rect2" />
+			<description>
+				Returns the bottom-left corner and the dimensions of the viewport plane that this [Projection] projects positions onto.
 			</description>
 		</method>
 		<method name="get_z_far" qualifiers="const">

--- a/tests/core/math/test_projection.h
+++ b/tests/core/math/test_projection.h
@@ -558,44 +558,87 @@ TEST_CASE("[Projection] Planes extraction") {
 	CHECK(plane_array[Projection::PLANE_BOTTOM].normalized().is_equal_approx(planes[Projection::PLANE_BOTTOM].normalized()));
 }
 
-TEST_CASE("[Projection] Perspective Half extents") {
+TEST_CASE("[Projection] Perspective extents") {
 	constexpr real_t sqrt3 = 1.7320508;
 	Projection persp = Projection::create_perspective(90, 1, 1, 40, false);
 	Vector2 ne = persp.get_viewport_half_extents();
 	Vector2 fe = persp.get_far_plane_half_extents();
+	Rect2 nr = persp.get_viewport_rect();
+	Rect2 fr = persp.get_far_plane_rect();
 
 	CHECK(ne.is_equal_approx(Vector2(1, 1) * 1));
 	CHECK(fe.is_equal_approx(Vector2(1, 1) * 40));
+	CHECK(nr.is_equal_approx(Rect2(-Vector2(1, 1), 2 * Vector2(1, 1))));
+	CHECK(fr.is_equal_approx(Rect2(-Vector2(1, 1) * 40, 2 * Vector2(1, 1) * 40)));
 
 	persp.set_perspective(120, sqrt3, 0.8, 10, true);
 	ne = persp.get_viewport_half_extents();
 	fe = persp.get_far_plane_half_extents();
+	nr = persp.get_viewport_rect();
+	fr = persp.get_far_plane_rect();
 
 	CHECK(ne.is_equal_approx(Vector2(sqrt3, 1.0) * 0.8));
 	CHECK(fe.is_equal_approx(Vector2(sqrt3, 1.0) * 10));
+	CHECK(nr.is_equal_approx(Rect2(-Vector2(sqrt3, 1.0) * 0.8, 2 * Vector2(sqrt3, 1.0) * 0.8)));
+	CHECK(fr.is_equal_approx(Rect2(-Vector2(sqrt3, 1.0) * 10, 2 * Vector2(sqrt3, 1.0) * 10)));
 
 	persp.set_perspective(60, 1.2, 0.5, 15, false);
 	ne = persp.get_viewport_half_extents();
 	fe = persp.get_far_plane_half_extents();
+	nr = persp.get_viewport_rect();
+	fr = persp.get_far_plane_rect();
 
 	CHECK(ne.is_equal_approx(Vector2(sqrt3 / 3 * 1.2, sqrt3 / 3) * 0.5));
 	CHECK(fe.is_equal_approx(Vector2(sqrt3 / 3 * 1.2, sqrt3 / 3) * 15));
+	CHECK(nr.is_equal_approx(Rect2(-Vector2(sqrt3 / 3 * 1.2, sqrt3 / 3) * 0.5, 2 * Vector2(sqrt3 / 3 * 1.2, sqrt3 / 3) * 0.5)));
+	CHECK(fr.is_equal_approx(Rect2(-Vector2(sqrt3 / 3 * 1.2, sqrt3 / 3) * 15, 2 * Vector2(sqrt3 / 3 * 1.2, sqrt3 / 3) * 15)));
 }
 
-TEST_CASE("[Projection] Orthographic Half extents") {
+TEST_CASE("[Projection] Orthographic extents") {
 	Projection ortho = Projection::create_orthogonal(-3, 3, -1.5, 1.5, 1.2, 15);
 	Vector2 ne = ortho.get_viewport_half_extents();
 	Vector2 fe = ortho.get_far_plane_half_extents();
+	Rect2 nr = ortho.get_viewport_rect();
+	Rect2 fr = ortho.get_far_plane_rect();
 
 	CHECK(ne.is_equal_approx(Vector2(3, 1.5)));
 	CHECK(fe.is_equal_approx(Vector2(3, 1.5)));
+	CHECK(nr.is_equal_approx(Rect2(Vector2(-3, -1.5), 2 * Vector2(3, 1.5))));
+	CHECK(fr.is_equal_approx(Rect2(Vector2(-3, -1.5), 2 * Vector2(3, 1.5))));
 
 	ortho.set_orthogonal(-7, 7, -2.5, 2.5, 0.5, 6);
 	ne = ortho.get_viewport_half_extents();
 	fe = ortho.get_far_plane_half_extents();
+	nr = ortho.get_viewport_rect();
+	fr = ortho.get_far_plane_rect();
 
 	CHECK(ne.is_equal_approx(Vector2(7, 2.5)));
 	CHECK(fe.is_equal_approx(Vector2(7, 2.5)));
+	CHECK(nr.is_equal_approx(Rect2(Vector2(-7, -2.5), 2 * Vector2(7, 2.5))));
+	CHECK(fr.is_equal_approx(Rect2(Vector2(-7, -2.5), 2 * Vector2(7, 2.5))));
+
+	ortho.set_orthogonal(-2, 6, -3.5, 0.5, 1.5, 5.5);
+	nr = ortho.get_viewport_rect();
+	fr = ortho.get_far_plane_rect();
+
+	CHECK(nr.is_equal_approx(Rect2(Vector2(-2, -3.5), Vector2(8, 4))));
+	CHECK(fr.is_equal_approx(Rect2(Vector2(-2, -3.5), Vector2(8, 4))));
+}
+
+TEST_CASE("[Projection] Frustum extents") {
+	Projection frustum = Projection::create_frustum(-3, 3, -1.5, 1.5, 1.2, 15);
+	Rect2 nr = frustum.get_viewport_rect();
+	Rect2 fr = frustum.get_far_plane_rect();
+
+	CHECK(nr.is_equal_approx(Rect2(Vector2(-3, -1.5), 2 * Vector2(3, 1.5))));
+	CHECK(fr.is_equal_approx(Rect2(12.5 * Vector2(-3, -1.5), 25 * Vector2(3, 1.5))));
+
+	frustum.set_frustum(-2, 6, -3.5, 0.5, 2, 6);
+	nr = frustum.get_viewport_rect();
+	fr = frustum.get_far_plane_rect();
+
+	CHECK(nr.is_equal_approx(Rect2(Vector2(-2, -3.5), Vector2(8, 4))));
+	CHECK(fr.is_equal_approx(Rect2(3 * Vector2(-2, -3.5), 3 * Vector2(8, 4))));
 }
 
 TEST_CASE("[Projection] Endpoints") {


### PR DESCRIPTION
These functions allow retrieving the bottom-left corner and the dimensions of the viewport.

It's especially useful when the viewport is not symmetrical (e.g. in `Camera3D` `FRUSTUM` mode or with OpenXR).
Under those circumstances, `get_viewport_half_extents()` is not enough to fully determine the 4 corners of the viewport, yet it is often mistakenly used across the codebase.

### TODO
- [ ] Replace https://github.com/godotengine/godot/blob/11c659338f37c4c0ec2378710efeabcd134ade4d/modules/raycast/raycast_occlusion_cull.cpp#L584-L592 by this PR's `get_viewport_rect()` whenever #104249 gets merged.