### PR TITLE
[macOS/iOS] Ensure only one axis change event is produced during single `process_joypads()` call.

### DIFF
--- a/drivers/apple/joypad_apple.h
+++ b/drivers/apple/joypad_apple.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/input/input.h"
+#include "core/input/input_enums.h"
 
 #define Key _QKey
 #import <GameController/GameController.h>
@@ -46,6 +47,9 @@ struct GameController {
 	NSInteger ff_effect_timestamp = 0;
 	bool force_feedback = false;
 	bool nintendo_button_layout = false;
+
+	bool axis_changed[(int)JoyAxis::MAX];
+	double axis_value[(int)JoyAxis::MAX];
 
 	GameController(int p_joy_id, GCController *p_controller);
 	~GameController();


### PR DESCRIPTION
Instead of sending events directly from OS callbacks, save it and send from `process_joypads()` to ensure only one event is sent during a single physics frame (necessary for `is_action_just_pressed` checks).

Fixes https://github.com/godotengine/godot/issues/103898