### PR TITLE
CI: Ensure `scons-cache` exists before parsing

### DIFF
--- a/.github/actions/godot-cache-restore/action.yml
+++ b/.github/actions/godot-cache-restore/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Log default cache files
       if: github.ref_name != github.event.repository.default_branch
       shell: sh
-      run: find "${{ inputs.scons-cache }}" >> redundant.txt
+      run: test -d "${{ inputs.scons-cache }}" && find "${{ inputs.scons-cache }}" >> redundant.txt
 
     # This is done after pulling the default cache so that PRs can integrate any potential changes
     # from the default branch without conflicting with whatever local changes were already made.


### PR DESCRIPTION
In cases where no default cache exists, `.scons_cache` would not be created; this change makes it so the redundancy check doesn't shut the action down prematurely