### PR TITLE
Call plugin edit before making visible

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -943,12 +943,12 @@ void EditorNode::_remove_plugin_from_enabled(const String &p_name) {
 void EditorNode::_plugin_over_edit(EditorPlugin *p_plugin, Object *p_object) {
 	if (p_object) {
 		editor_plugins_over->add_plugin(p_plugin);
-		p_plugin->make_visible(true);
 		p_plugin->edit(p_object);
+		p_plugin->make_visible(true);
 	} else {
 		editor_plugins_over->remove_plugin(p_plugin);
-		p_plugin->make_visible(false);
 		p_plugin->edit(nullptr);
+		p_plugin->make_visible(false);
 	}
 }
 


### PR DESCRIPTION
Fixes the errors mentioned in #104305 (only the errors)

While the fix makes sense, it *may* break plugins that rely on the current order (hopefully none, and not even sure how would that work). The new order makes more sense, because editor shouldn't appear before its state is initialized.

Bugsquad edit: Fixes #87348