### PR TITLE
SCons: Expand `NoCache` coverage

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -79,12 +79,12 @@ if lib_arch_dir != "":
         lib_tools_dir = ""
 
     out_dir = "#platform/android/java/lib/libs/" + lib_tools_dir + lib_type_dir + "/" + lib_arch_dir
-    env_android.Command(out_dir + "/libgodot_android.so", lib, Move("$TARGET", "$SOURCE"))
+    env_android.CommandNoCache(out_dir + "/libgodot_android.so", lib, Move("$TARGET", "$SOURCE"))
 
     stl_lib_path = (
         str(env["ANDROID_NDK_ROOT"]) + "/sources/cxx-stl/llvm-libc++/libs/" + lib_arch_dir + "/libc++_shared.so"
     )
-    env_android.Command(out_dir + "/libc++_shared.so", stl_lib_path, Copy("$TARGET", "$SOURCE"))
+    env_android.CommandNoCache(out_dir + "/libc++_shared.so", stl_lib_path, Copy("$TARGET", "$SOURCE"))
 
     def generate_apk(target, source, env):
         gradle_process = []
@@ -112,6 +112,4 @@ if lib_arch_dir != "":
         )
 
     if env["generate_apk"]:
-        generate_apk_command = env_android.Command("generate_apk", [], generate_apk)
-        command = env_android.AlwaysBuild(generate_apk_command)
-        env_android.Depends(command, [lib])
+        env_android.AlwaysBuild(env_android.CommandNoCache("generate_apk", lib, env.Run(generate_apk)))

--- a/platform/ios/SCsub
+++ b/platform/ios/SCsub
@@ -97,9 +97,9 @@ def combine_libs(target=None, source=None, env=None):
     )
 
 
-combine_command = env_ios.Command("#bin/libgodot" + env_ios["LIBSUFFIX"], [ios_lib] + env_ios["LIBS"], combine_libs)
+combine_command = env_ios.CommandNoCache(
+    "#bin/libgodot" + env_ios["LIBSUFFIX"], [ios_lib] + env_ios["LIBS"], env.Run(combine_libs)
+)
 
 if env["generate_bundle"]:
-    generate_bundle_command = env.Command("generate_bundle", [], generate_bundle)
-    command = env.AlwaysBuild(generate_bundle_command)
-    env.Depends(command, [combine_command])
+    env.AlwaysBuild(env.CommandNoCache("generate_bundle", combine_command, env.Run(generate_bundle)))

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -144,6 +144,4 @@ if env["debug_symbols"] and env["separate_debug_symbols"]:
     env.AddPostAction(prog, env.Run(platform_macos_builders.make_debug_macos))
 
 if env["generate_bundle"]:
-    generate_bundle_command = env.Command("generate_bundle", [], generate_bundle)
-    command = env.AlwaysBuild(generate_bundle_command)
-    env.Depends(command, [prog])
+    env.AlwaysBuild(env.CommandNoCache("generate_bundle", prog, env.Run(generate_bundle)))

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -86,7 +86,7 @@ if env["dlink_enabled"]:
     sys_env["LINKFLAGS"].remove("-fvisibility=hidden")
 
     # The main emscripten runtime, with exported standard libraries.
-    sys = sys_env.Program(build_targets, ["web_runtime.cpp"])
+    sys = sys_env.add_program(build_targets, ["web_runtime.cpp"])
 
     # The side library, containing all Godot code.
     wasm = env.add_program("#bin/godot.side${PROGSUFFIX}.wasm", web_files)
@@ -94,7 +94,7 @@ if env["dlink_enabled"]:
 else:
     # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
     sys_env.Append(LIBS=["idbfs.js"])
-    build = sys_env.Program(build_targets, web_files + ["web_runtime.cpp"])
+    build = sys_env.add_program(build_targets, web_files + ["web_runtime.cpp"])
 
 sys_env.Depends(build[0], sys_env["JS_LIBS"])
 sys_env.Depends(build[0], sys_env["JS_PRE"])
@@ -114,7 +114,9 @@ wrap_list = [
     build[0],
     js_engine,
 ]
-js_wrapped = env.Textfile("#bin/godot", [env.File(f) for f in wrap_list], TEXTFILESUFFIX="${PROGSUFFIX}.wrapped.js")
+js_wrapped = env.NoCache(
+    env.Textfile("#bin/godot", [env.File(f) for f in wrap_list], TEXTFILESUFFIX="${PROGSUFFIX}.wrapped.js")
+)
 
 # 0 - unwrapped js file (use wrapped one instead)
 # 1 - wasm file

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -102,12 +102,14 @@ def create_template_zip(env, js, wasm, side):
         in_files.append("#misc/dist/html/offline-export.html")
         out_files.append(zip_dir.File("godot.offline.html"))
 
-    zip_files = env.InstallAs(out_files, in_files)
-    env.Zip(
-        "#bin/godot",
-        zip_files,
-        ZIPROOT=zip_dir,
-        ZIPSUFFIX="${PROGSUFFIX}${ZIPSUFFIX}",
+    zip_files = env.NoCache(env.InstallAs(out_files, in_files))
+    env.NoCache(
+        env.Zip(
+            "#bin/godot",
+            zip_files,
+            ZIPROOT=zip_dir,
+            ZIPSUFFIX="${PROGSUFFIX}${ZIPSUFFIX}",
+        )
     )
 
 

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -112,7 +112,7 @@ if env["d3d12"]:
         # Whether these are loaded from arch-specific directory or not has to be known at build time.
         target_dir = arch_bin_dir if env["agility_sdk_multiarch"] else "#bin"
         for dll in agility_dlls:
-            env.Command(
+            env.CommandNoCache(
                 target_dir + "/" + dll,
                 env["agility_sdk_path"] + "/build/native/bin/" + agility_arch_subdir + "/" + dll,
                 Copy("$TARGET", "$SOURCE"),
@@ -121,7 +121,7 @@ if env["d3d12"]:
     # PIX
     if env["use_pix"]:
         pix_dll = "WinPixEventRuntime.dll"
-        env.Command(
+        env.CommandNoCache(
             "#bin/" + pix_dll,
             env["pix_path"] + "/bin/" + dxc_arch_subdir + "/" + pix_dll,
             Copy("$TARGET", "$SOURCE"),


### PR DESCRIPTION
Recent cache CI changes have revealed that quite a few builds still have moderately sized caches for PRs, despite the fact that they should be stripping anything not on the default branch. One possible reason for this is how some commands/builds weren't using their `NoCache` equivalents, which is what this PR addresses. This could be expanded to applying `NoCache` to emitters in the future, removing the need for our custom functions entirely, but that's better suited for a separate PR