### PR TITLE
Deprecate `CanvasItem::get_viewport_transform`

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -494,7 +494,7 @@
 				Returns the viewport's boundaries as a [Rect2].
 			</description>
 		</method>
-		<method name="get_viewport_transform" qualifiers="const">
+		<method name="get_viewport_transform" qualifiers="const" deprecated="Use [method get_canvas_transform] and [method Viewport.get_final_transform] to calculate the transform, instead.">
 			<return type="Transform2D" />
 			<description>
 				Returns the transform from the coordinate system of the canvas, this item is in, to the [Viewport]s embedders coordinate system.

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1335,7 +1335,9 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_transform"), &CanvasItem::get_transform);
 	ClassDB::bind_method(D_METHOD("get_global_transform"), &CanvasItem::get_global_transform);
 	ClassDB::bind_method(D_METHOD("get_global_transform_with_canvas"), &CanvasItem::get_global_transform_with_canvas);
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("get_viewport_transform"), &CanvasItem::get_viewport_transform);
+#endif // DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("get_viewport_rect"), &CanvasItem::get_viewport_rect);
 	ClassDB::bind_method(D_METHOD("get_canvas_transform"), &CanvasItem::get_canvas_transform);
 	ClassDB::bind_method(D_METHOD("get_screen_transform"), &CanvasItem::get_screen_transform);
@@ -1453,6 +1455,7 @@ Transform2D CanvasItem::get_canvas_transform() const {
 	}
 }
 
+#ifndef DISABLE_DEPRECATED
 Transform2D CanvasItem::get_viewport_transform() const {
 	ERR_READ_THREAD_GUARD_V(Transform2D());
 	ERR_FAIL_COND_V(!is_inside_tree(), Transform2D());
@@ -1463,6 +1466,7 @@ Transform2D CanvasItem::get_viewport_transform() const {
 		return get_viewport()->get_final_transform() * get_viewport()->get_canvas_transform();
 	}
 }
+#endif // DISABLE_DEPRECATED
 
 void CanvasItem::set_notify_local_transform(bool p_enable) {
 	ERR_THREAD_GUARD;

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -353,7 +353,9 @@ public:
 	bool is_block_transform_notify_enabled() const;
 
 	Transform2D get_canvas_transform() const;
+#ifndef DISABLE_DEPRECATED
 	Transform2D get_viewport_transform() const;
+#endif // DISABLE_DEPRECATED
 	Rect2 get_viewport_rect() const;
 	RID get_viewport_rid() const;
 	RID get_canvas() const;


### PR DESCRIPTION
Implement part of https://github.com/godotengine/godot-proposals/issues/4250
Implement https://github.com/godotengine/godot/pull/93735#discussion_r2001192903

The usability of this function is very disputable.

1. Based on its [incomprehensible documentation](https://github.com/godotengine/godot/pull/93735#discussion_r1659815486) it is likely that this functions intention is not widely understood or used
2. In order to understand the functionality, not only [basic knowledge](https://docs.godotengine.org/en/latest/tutorials/2d/2d_transforms.html) about transforms is necessary, but also [detailed internal knowledge](https://docs.godotengine.org/en/latest/contributing/development/core_and_modules/2d_coordinate_systems.html) about the engine is necessary. So this function should not have been exposed to the API in my personal opinion.
3. In order to [streamline access to transform2d](https://github.com/godotengine/godot-proposals/issues/4250), the current functionality should be removed.
4. The functionality of the function can be easily replicated in GDScript by accessing the canvas transform and the viewports final transform.