### PR TITLE
macOS: Update mouse-entered state when subwindow closes

### DIFF
--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -1913,6 +1913,8 @@ void DisplayServerMacOS::delete_sub_window(WindowID p_id) {
 
 	[wd.window_object setContentView:nil];
 	[wd.window_object close];
+
+	mouse_enter_window(get_window_at_screen_position(mouse_get_position()));
 }
 
 void DisplayServerMacOS::window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window) {


### PR DESCRIPTION
When closing a sub-window, `mouse_enter_window` is now called, which allows the parent to regain mouse-entered status if the mouse was inside the sub-window.

Fixes #104324.