### PR TITLE
Windows: Fix crash if not compiled with Vulkan support

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -6806,54 +6806,60 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	fallback_to_vulkan = true; // Always enable fallback if engine was built w/o other driver support.
 #endif
 
-	if (rendering_context) {
-		if (rendering_context->initialize() != OK) {
-			bool failed = true;
+	if (rendering_context == nullptr || rendering_context->initialize() != OK) {
+		bool failed = true;
 #if defined(VULKAN_ENABLED)
-			if (failed && fallback_to_vulkan && rendering_driver != "vulkan") {
+		if (failed && fallback_to_vulkan && rendering_driver != "vulkan") {
+			if (rendering_context) {
 				memdelete(rendering_context);
-				rendering_context = memnew(RenderingContextDriverVulkanWindows);
-				tested_drivers.set_flag(DRIVER_ID_RD_VULKAN);
-				if (rendering_context->initialize() == OK) {
-					WARN_PRINT("Your video card drivers seem not to support Direct3D 12, switching to Vulkan.");
-					rendering_driver = "vulkan";
-					OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
-					failed = false;
-				}
 			}
-#endif
-#if defined(D3D12_ENABLED)
-			if (failed && fallback_to_d3d12 && rendering_driver != "d3d12") {
-				memdelete(rendering_context);
-				rendering_context = memnew(RenderingContextDriverD3D12);
-				tested_drivers.set_flag(DRIVER_ID_RD_D3D12);
-				if (rendering_context->initialize() == OK) {
-					WARN_PRINT("Your video card drivers seem not to support Vulkan, switching to Direct3D 12.");
-					rendering_driver = "d3d12";
-					OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
-					failed = false;
-				}
-			}
-#endif
-#if defined(GLES3_ENABLED)
-			bool fallback_to_opengl3 = GLOBAL_GET("rendering/rendering_device/fallback_to_opengl3");
-			if (failed && fallback_to_opengl3 && rendering_driver != "opengl3") {
-				memdelete(rendering_context);
-				rendering_context = nullptr;
-				tested_drivers.set_flag(DRIVER_ID_COMPAT_OPENGL3);
-				WARN_PRINT("Your video card drivers seem not to support Direct3D 12 or Vulkan, switching to OpenGL 3.");
-				rendering_driver = "opengl3";
-				OS::get_singleton()->set_current_rendering_method("gl_compatibility");
+			rendering_context = memnew(RenderingContextDriverVulkanWindows);
+			tested_drivers.set_flag(DRIVER_ID_RD_VULKAN);
+			if (rendering_context->initialize() == OK) {
+				WARN_PRINT("Your video card drivers seem not to support Direct3D 12, switching to Vulkan.");
+				rendering_driver = "vulkan";
 				OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
 				failed = false;
 			}
+		}
 #endif
-			if (failed) {
+#if defined(D3D12_ENABLED)
+		if (failed && fallback_to_d3d12 && rendering_driver != "d3d12") {
+			if (rendering_context) {
 				memdelete(rendering_context);
-				rendering_context = nullptr;
-				r_error = ERR_UNAVAILABLE;
-				return;
 			}
+			rendering_context = memnew(RenderingContextDriverD3D12);
+			tested_drivers.set_flag(DRIVER_ID_RD_D3D12);
+			if (rendering_context->initialize() == OK) {
+				WARN_PRINT("Your video card drivers seem not to support Vulkan, switching to Direct3D 12.");
+				rendering_driver = "d3d12";
+				OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+				failed = false;
+			}
+		}
+#endif
+#if defined(GLES3_ENABLED)
+		bool fallback_to_opengl3 = GLOBAL_GET("rendering/rendering_device/fallback_to_opengl3");
+		if (failed && fallback_to_opengl3 && rendering_driver != "opengl3") {
+			if (rendering_context) {
+				memdelete(rendering_context);
+			}
+			rendering_context = nullptr;
+			tested_drivers.set_flag(DRIVER_ID_COMPAT_OPENGL3);
+			WARN_PRINT("Your video card drivers seem not to support Direct3D 12 or Vulkan, switching to OpenGL 3.");
+			rendering_driver = "opengl3";
+			OS::get_singleton()->set_current_rendering_method("gl_compatibility");
+			OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+			failed = false;
+		}
+#endif
+		if (failed) {
+			if (rendering_context) {
+				memdelete(rendering_context);
+			}
+			rendering_context = nullptr;
+			r_error = ERR_UNAVAILABLE;
+			return;
 		}
 	}
 #endif

--- a/servers/rendering/renderer_compositor.cpp
+++ b/servers/rendering/renderer_compositor.cpp
@@ -39,6 +39,7 @@ RendererCompositor *(*RendererCompositor::_create_func)() = nullptr;
 bool RendererCompositor::low_end = false;
 
 RendererCompositor *RendererCompositor::create() {
+	ERR_FAIL_COND_V_MSG(_create_func == nullptr, nullptr, "A RendererCompositor _create_func hasn't been assigned.");
 	return _create_func();
 }
 


### PR DESCRIPTION
This commit made the issue more obvious: https://github.com/godotengine/godot/commit/b77423370a5a2d857ffe4ddf0afa2504e08fbd4c

The reason this commit made it more obvious is because it allowed exporting and configuring for renderers without necessarily requiring the host machine to support that renderer.  I agree with this change and was actually planning on opening an issue for it.  I'm glad to see it has already been addressed!  But then an issue arose in my fork:

In my fork, I build only for dx12.  I disable vulkan support on windows.  The issue occurs in these lines of code:

https://github.com/godotengine/godot/blob/fc827bbe256e47e1d7ec6945deb9c1e79724dac9/platform/windows/display_server_windows.cpp#L6790C1-L6889C3

The flow of what happens is if you don't compile with VULKAN_ENABLED, these lines won't ever get called: https://github.com/godotengine/godot/blob/fc827bbe256e47e1d7ec6945deb9c1e79724dac9/platform/windows/display_server_windows.cpp#L6794C1-L6801C7

```cpp
#if defined(VULKAN_ENABLED)
	if (rendering_driver == "vulkan") {
		rendering_context = memnew(RenderingContextDriverVulkanWindows);
		tested_drivers.set_flag(DRIVER_ID_RD_VULKAN);
	}
#else
	fallback_to_d3d12 = true; // Always enable fallback if engine was built w/o other driver support.
#endif
```

And this in particular is an issue if you have the renderer set to "vulkan" (which everyone does by default).  The rendering_context won't get initialized to a value and this if statement won't enter:

https://github.com/godotengine/godot/blob/fc827bbe256e47e1d7ec6945deb9c1e79724dac9/platform/windows/display_server_windows.cpp#L6811C1-L6812C47

The solution is to check for ``!= OK`` or ``nullptr``.

```cpp
if (rendering_context == nullptr || rendering_context->initialize() != OK) {
```

Debugging this was quite tricky.  The reason is because of a crash that occurs do to ``RendererCompositor::_create_func()`` not getting initialized due to the above bug.  Godot crashes and does not give a stacktrace.  Instead it outputs a bunch of nonsense and binary numbers.  Super weird crash.  But if you add a null check just above it, it outputs a human readable error AND outputs a nice stack trace :).

Let me know if you have any suggestions for change.  As always, much love from Lange Studios and myself personally :)