### PR TITLE
Fix *even* more miscellaneous oddities around the class reference

### DIFF
--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -54,7 +54,7 @@
 			<param index="0" name="frame" type="int" />
 			<param index="1" name="progress" type="float" />
 			<description>
-				Sets [member frame] the [member frame_progress] to the given values. Unlike setting [member frame], this method does not reset the [member frame_progress] to [code]0.0[/code] implicitly.
+				Sets [member frame] and [member frame_progress] to the given values. Unlike setting [member frame], this method does not reset the [member frame_progress] to [code]0.0[/code] implicitly.
 				[b]Example:[/b] Change the animation while keeping the same [member frame] and [member frame_progress]:
 				[codeblocks]
 				[gdscript]

--- a/doc/classes/AnimatedSprite3D.xml
+++ b/doc/classes/AnimatedSprite3D.xml
@@ -53,7 +53,7 @@
 			<param index="0" name="frame" type="int" />
 			<param index="1" name="progress" type="float" />
 			<description>
-				Sets [member frame] the [member frame_progress] to the given values. Unlike setting [member frame], this method does not reset the [member frame_progress] to [code]0.0[/code] implicitly.
+				Sets [member frame] and [member frame_progress] to the given values. Unlike setting [member frame], this method does not reset the [member frame_progress] to [code]0.0[/code] implicitly.
 				[b]Example:[/b] Change the animation while keeping the same [member frame] and [member frame_progress]:
 				[codeblocks]
 				[gdscript]

--- a/doc/classes/AnimationMixer.xml
+++ b/doc/classes/AnimationMixer.xml
@@ -135,7 +135,7 @@
 				    move_and_slide()
 				[/gdscript]
 				[/codeblocks]
-				If [member root_motion_local] is [code]true[/code], return the pre-multiplied translation value with the inverted rotation.
+				If [member root_motion_local] is [code]true[/code], returns the pre-multiplied translation value with the inverted rotation.
 				In this case, the code can be written as follows:
 				[codeblocks]
 				[gdscript]

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -90,7 +90,7 @@
 		<method name="has_section" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if an animation is currently playing with section.
+				Returns [code]true[/code] if an animation is currently playing with a section.
 			</description>
 		</method>
 		<method name="is_playing" qualifiers="const">
@@ -208,7 +208,7 @@
 		<method name="reset_section">
 			<return type="void" />
 			<description>
-				Resets the current section if section is set.
+				Resets the current section. Does nothing if a section has not been set.
 			</description>
 		</method>
 		<method name="seek">

--- a/doc/classes/AudioEffectPhaser.xml
+++ b/doc/classes/AudioEffectPhaser.xml
@@ -12,7 +12,7 @@
 	</tutorials>
 	<members>
 		<member name="depth" type="float" setter="set_depth" getter="get_depth" default="1.0">
-			Governs how high the filter frequencies sweep. Low value will primarily affect bass frequencies. High value can sweep high into the treble. Value can range from 0.1 to 4.
+			Determines how high the filter frequencies sweep. Low value will primarily affect bass frequencies. High value can sweep high into the treble. Value can range from [code]0.1[/code] to [code]4.0[/code].
 		</member>
 		<member name="feedback" type="float" setter="set_feedback" getter="get_feedback" default="0.7">
 			Output percent of modified sound. Value can range from 0.1 to 0.9.

--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -18,7 +18,7 @@
 		<method name="get_skeleton">
 			<return type="Skeleton3D" />
 			<description>
-				Get parent or external [Skeleton3D] node if found.
+				Returns the parent or external [Skeleton3D] node if it exists, otherwise returns [code]null[/code].
 			</description>
 		</method>
 		<method name="get_use_external_skeleton" qualifiers="const">

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -588,7 +588,7 @@
 			Set when a validated word from [signal symbol_validate] is clicked, the [signal symbol_lookup] should be emitted.
 		</member>
 		<member name="symbol_tooltip_on_hover" type="bool" setter="set_symbol_tooltip_on_hover_enabled" getter="is_symbol_tooltip_on_hover_enabled" default="false">
-			Set when a word is hovered, the [signal symbol_hovered] should be emitted.
+			If [code]true[/code], the [signal symbol_hovered] signal is emitted when hovering over a word.
 		</member>
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" overrides="TextEdit" enum="Control.TextDirection" default="1" />
 	</members>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -713,7 +713,7 @@
 		<method name="is_layout_rtl" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if layout is right-to-left. See also [member layout_direction].
+				Returns [code]true[/code] if the layout is right-to-left. See also [member layout_direction].
 			</description>
 		</method>
 		<method name="release_focus">

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -157,7 +157,7 @@
 			<description>
 				Displays OS native dialog for selecting files or directories in the file system.
 				Each filter string in the [param filters] array should be formatted like this: [code]*.png,*.jpg,*.jpeg;Image Files;image/png,image/jpeg[/code]. The description text of the filter is optional and can be omitted. It is recommended to set both file extension and MIME type. See also [member FileDialog.filters].
-				Callbacks have the following arguments: [code]status: bool, selected_paths: PackedStringArray, selected_filter_index: int[/code]. [b]On Android,[/b] callback argument [code]selected_filter_index[/code] is always zero.
+				Callbacks have the following arguments: [code]status: bool, selected_paths: PackedStringArray, selected_filter_index: int[/code]. [b]On Android,[/b] the third callback argument ([code]selected_filter_index[/code]) is always [code]0[/code].
 				[b]Note:[/b] This method is implemented if the display server has the [constant FEATURE_NATIVE_DIALOG_FILE] feature. Supported platforms include Linux (X11/Wayland), Windows, macOS, and Android.
 				[b]Note:[/b] [param current_directory] might be ignored.
 				[b]Note:[/b] Embedded file dialog and Windows file dialog support only file extensions, while Android, Linux, and macOS file dialogs also support MIME types.
@@ -918,8 +918,8 @@
 		<method name="has_hardware_keyboard" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if hardware keyboard is connected.
-				[b]Note:[/b] This method is implemented on Android and iOS, on other platforms this method always returns [code]true[/code].
+				Returns [code]true[/code] if a hardware keyboard is connected.
+				[b]Note:[/b] This method is implemented on Android and iOS. On other platforms, this method always returns [code]true[/code].
 			</description>
 		</method>
 		<method name="help_set_search_callbacks">
@@ -1088,18 +1088,18 @@
 			<return type="Image" />
 			<param index="0" name="screen" type="int" default="-1" />
 			<description>
-				Returns screenshot of the [param screen].
+				Returns a screenshot of the [param screen].
 				[b]Note:[/b] This method is implemented on Linux (X11), macOS, and Windows.
-				[b]Note:[/b] On macOS, this method requires "Screen Recording" permission, if permission is not granted it will return desktop wallpaper color.
+				[b]Note:[/b] On macOS, this method requires the "Screen Recording" permission. If permission is not granted, this method returns a screenshot that will not include other application windows or OS elements not related to the application.
 			</description>
 		</method>
 		<method name="screen_get_image_rect" qualifiers="const">
 			<return type="Image" />
 			<param index="0" name="rect" type="Rect2i" />
 			<description>
-				Returns screenshot of the screen [param rect].
+				Returns a screenshot of the screen region defined by [param rect].
 				[b]Note:[/b] This method is implemented on macOS and Windows.
-				[b]Note:[/b] On macOS, this method requires "Screen Recording" permission, if permission is not granted it will return desktop wallpaper color.
+				[b]Note:[/b] On macOS, this method requires the "Screen Recording" permission. If permission is not granted, this method returns a screenshot that will not include other application windows or OS elements not related to the application.
 			</description>
 		</method>
 		<method name="screen_get_max_scale" qualifiers="const">
@@ -1899,7 +1899,7 @@
 			Display server supports windows can use per-pixel transparency to make windows behind them partially or fully visible. [b]Windows, macOS, Linux (X11/Wayland)[/b]
 		</constant>
 		<constant name="FEATURE_HIDPI" value="12" enum="Feature">
-			Display server supports querying the operating system's display scale factor. This allows for [i]reliable[/i] automatic hiDPI display detection, as opposed to guessing based on the screen resolution and reported display DPI (which can be unreliable due to broken monitor EDID). [b]Windows, Linux (Wayland), macOS[/b]
+			Display server supports querying the operating system's display scale factor. This allows automatically detecting the hiDPI display [i]reliably[/i], instead of guessing based on the screen resolution and the display's reported DPI (which might be unreliable due to broken monitor EDID). [b]Windows, Linux (Wayland), macOS[/b]
 		</constant>
 		<constant name="FEATURE_ICON" value="13" enum="Feature">
 			Display server supports changing the window icon (usually displayed in the top-left corner). [b]Windows, macOS, Linux (X11)[/b]

--- a/doc/classes/EditorExportPreset.xml
+++ b/doc/classes/EditorExportPreset.xml
@@ -36,13 +36,13 @@
 		<method name="get_encrypt_directory" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code], PCK directory encryption is enabled in the export dialog.
+				Returns [code]true[/code] if PCK directory encryption is enabled in the export dialog.
 			</description>
 		</method>
 		<method name="get_encrypt_pck" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code], PCK encryption is enabled in the export dialog.
+				Returns [code]true[/code] if PCK encryption is enabled in the export dialog.
 			</description>
 		</method>
 		<method name="get_encryption_ex_filter" qualifiers="const">
@@ -140,7 +140,7 @@
 			<return type="bool" />
 			<param index="0" name="property" type="StringName" />
 			<description>
-				Returns [code]true[/code] if preset has specified property.
+				Returns [code]true[/code] if the preset has the property named [param property].
 			</description>
 		</method>
 		<method name="has_export_file">

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -359,7 +359,7 @@
 			Flag used to mark that the array contains 2D vertices.
 		</constant>
 		<constant name="ARRAY_FLAG_USE_DYNAMIC_UPDATE" value="67108864" enum="ArrayFormat" is_bitfield="true">
-			Flag indices that the mesh data will use [code]GL_DYNAMIC_DRAW[/code] on GLES. Unused on Vulkan.
+			Flag used to mark that the mesh data will use [code]GL_DYNAMIC_DRAW[/code] on GLES. Unused on Vulkan.
 		</constant>
 		<constant name="ARRAY_FLAG_USE_8_BONE_WEIGHTS" value="134217728" enum="ArrayFormat" is_bitfield="true">
 			Flag used to mark that the mesh contains up to 8 bone influences per vertex. This flag indicates that [constant ARRAY_BONES] and [constant ARRAY_WEIGHTS] elements will have double length.

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -471,14 +471,14 @@
 		<method name="get_stderr_type" qualifiers="const">
 			<return type="int" enum="OS.StdHandleType" />
 			<description>
-				Returns type of the standard error device.
+				Returns the type of the standard error device.
 				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.
 			</description>
 		</method>
 		<method name="get_stdin_type" qualifiers="const">
 			<return type="int" enum="OS.StdHandleType" />
 			<description>
-				Returns type of the standard input device.
+				Returns the type of the standard input device.
 				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.
 				[b]Note:[/b] On exported Windows builds, run the console wrapper executable to access the standard input. If you need a single executable with full console support, use a custom build compiled with the [code]windows_subsystem=console[/code] flag.
 			</description>
@@ -486,7 +486,7 @@
 		<method name="get_stdout_type" qualifiers="const">
 			<return type="int" enum="OS.StdHandleType" />
 			<description>
-				Returns type of the standard output device.
+				Returns the type of the standard output device.
 				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.
 			</description>
 		</method>
@@ -726,7 +726,7 @@
 			<return type="PackedByteArray" />
 			<param index="0" name="buffer_size" type="int" default="1024" />
 			<description>
-				Reads a user input as raw data from the standard input. This operation can be [i]blocking[/i], which causes the window to freeze if [method read_string_from_stdin] is called on the main thread.
+				Reads a user input as raw data from the standard input. This operation can be [i]blocking[/i], which causes the window to freeze if [method read_buffer_from_stdin] is called on the main thread.
 				- If standard input is console, this method will block until the program receives a line break in standard input (usually by the user pressing [kbd]Enter[/kbd]).
 				- If standard input is pipe, this method will block until a specific amount of data is read or pipe is closed.
 				- If standard input is a file, this method will read a specific amount of data (or less if end-of-file is reached) and return immediately.

--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -49,7 +49,7 @@
 			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.
 		</member>
 		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces" default="false">
-			If set, the order of the vertices in each triangle are reversed resulting in the backside of the mesh being drawn.
+			If [code]true[/code], the order of the vertices in each triangle is reversed, resulting in the backside of the mesh being drawn.
 			This gives the same result as using [constant BaseMaterial3D.CULL_FRONT] in [member BaseMaterial3D.cull_mode].
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -676,7 +676,7 @@
 		<method name="get_tracked_object_type_count" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns how many types of trackable objects are.
+				Returns how many types of trackable objects there are.
 				This is only used by Vulkan in debug builds. Godot must also be started with the [code]--extra-gpu-memory-tracking[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url].
 			</description>
 		</method>
@@ -1112,7 +1112,7 @@
 			<param index="1" name="data" type="PackedByteArray" default="PackedByteArray()" />
 			<param index="2" name="creation_bits" type="int" enum="RenderingDevice.BufferCreationBits" is_bitfield="true" default="0" />
 			<description>
-				It can be accessed with the RID that is returned.
+				Creates a new vertex buffer. It can be accessed with the RID that is returned.
 				Once finished with your RID, you will want to free the RID using the RenderingDevice's [method free_rid] method.
 			</description>
 		</method>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -4679,7 +4679,7 @@
 			Flag used to mark that the array contains 2D vertices.
 		</constant>
 		<constant name="ARRAY_FLAG_USE_DYNAMIC_UPDATE" value="67108864" enum="ArrayFormat" is_bitfield="true">
-			Flag indices that the mesh data will use [code]GL_DYNAMIC_DRAW[/code] on GLES. Unused on Vulkan.
+			Flag used to mark that the mesh data will use [code]GL_DYNAMIC_DRAW[/code] on GLES. Unused on Vulkan.
 		</constant>
 		<constant name="ARRAY_FLAG_USE_8_BONE_WEIGHTS" value="134217728" enum="ArrayFormat" is_bitfield="true">
 			Flag used to mark that the array uses 8 bone weights instead of 4.
@@ -4817,7 +4817,7 @@
 			Normal bias used to offset shadow lookup by object normal. Can be used to fix self-shadowing artifacts.
 		</constant>
 		<constant name="LIGHT_PARAM_SHADOW_BIAS" value="15" enum="LightParam">
-			Bias the shadow lookup to fix self-shadowing artifacts.
+			Bias for the shadow lookup to fix self-shadowing artifacts.
 		</constant>
 		<constant name="LIGHT_PARAM_SHADOW_PANCAKE_SIZE" value="16" enum="LightParam">
 			Sets the size of the directional shadow pancake. The pancake offsets the start of the shadow's camera frustum to provide a higher effective depth resolution for the shadow. However, a high pancake size can cause artifacts in the shadows of large objects that are close to the edge of the frustum. Reducing the pancake size can help. Setting the size to [code]0[/code] turns off the pancaking effect.
@@ -5032,17 +5032,17 @@
 			Use bilinear scaling for the viewport's 3D buffer. The amount of scaling can be set using [member Viewport.scaling_3d_scale]. Values less than [code]1.0[/code] will result in undersampling while values greater than [code]1.0[/code] will result in supersampling. A value of [code]1.0[/code] disables scaling.
 		</constant>
 		<constant name="VIEWPORT_SCALING_3D_MODE_FSR" value="1" enum="ViewportScaling3DMode">
-			Use AMD FidelityFX Super Resolution 1.0 upscaling for the viewport's 3D buffer. The amount of scaling can be set using [member Viewport.scaling_3d_scale]. Values less than [code]1.0[/code] will be result in the viewport being upscaled using FSR. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] disables scaling.
+			Use AMD FidelityFX Super Resolution 1.0 upscaling for the viewport's 3D buffer. The amount of scaling can be set using [member Viewport.scaling_3d_scale]. Values less than [code]1.0[/code] will result in the viewport being upscaled using FSR. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] disables scaling.
 		</constant>
 		<constant name="VIEWPORT_SCALING_3D_MODE_FSR2" value="2" enum="ViewportScaling3DMode">
-			Use AMD FidelityFX Super Resolution 2.2 upscaling for the viewport's 3D buffer. The amount of scaling can be set using [member Viewport.scaling_3d_scale]. Values less than [code]1.0[/code] will be result in the viewport being upscaled using FSR2. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] will use FSR2 at native resolution as a TAA solution.
+			Use AMD FidelityFX Super Resolution 2.2 upscaling for the viewport's 3D buffer. The amount of scaling can be set using [member Viewport.scaling_3d_scale]. Values less than [code]1.0[/code] will result in the viewport being upscaled using FSR2. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] will use FSR2 at native resolution as a TAA solution.
 		</constant>
 		<constant name="VIEWPORT_SCALING_3D_MODE_METALFX_SPATIAL" value="3" enum="ViewportScaling3DMode">
-			Use MetalFX spatial upscaling for the viewport's 3D buffer. The amount of scaling can be set using [member Viewport.scaling_3d_scale]. Values less than [code]1.0[/code] will be result in the viewport being upscaled using MetalFX. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] disables scaling.
+			Use MetalFX spatial upscaling for the viewport's 3D buffer. The amount of scaling can be set using [member Viewport.scaling_3d_scale]. Values less than [code]1.0[/code] will result in the viewport being upscaled using MetalFX. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] disables scaling.
 			[b]Note:[/b] Only supported when the Metal rendering driver is in use, which limits this scaling mode to macOS and iOS.
 		</constant>
 		<constant name="VIEWPORT_SCALING_3D_MODE_METALFX_TEMPORAL" value="4" enum="ViewportScaling3DMode">
-			Use MetalFX temporal upscaling for the viewport's 3D buffer. The amount of scaling can be set using [member Viewport.scaling_3d_scale]. Values less than [code]1.0[/code] will be result in the viewport being upscaled using MetalFX. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] will use MetalFX at native resolution as a TAA solution.
+			Use MetalFX temporal upscaling for the viewport's 3D buffer. The amount of scaling can be set using [member Viewport.scaling_3d_scale]. Values less than [code]1.0[/code] will result in the viewport being upscaled using MetalFX. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] will use MetalFX at native resolution as a TAA solution.
 			[b]Note:[/b] Only supported when the Metal rendering driver is in use, which limits this scaling mode to macOS and iOS.
 		</constant>
 		<constant name="VIEWPORT_SCALING_3D_MODE_MAX" value="5" enum="ViewportScaling3DMode">

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -104,14 +104,14 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="key" type="StringName" />
 			<description>
-				Returns bone metadata for [param bone_idx] with [param key].
+				Returns the metadata for the bone at index [param bone_idx] with [param key].
 			</description>
 		</method>
 		<method name="get_bone_meta_list" qualifiers="const">
 			<return type="StringName[]" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns a list of all metadata keys for [param bone_idx].
+				Returns the list of all metadata keys for the bone at index [param bone_idx].
 			</description>
 		</method>
 		<method name="get_bone_name" qualifiers="const">
@@ -191,7 +191,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="key" type="StringName" />
 			<description>
-				Returns whether there exists any bone metadata for [param bone_idx] with key [param key].
+				Returns [code]true[/code] if the bone at index [param bone_idx] has metadata with the key [param key].
 			</description>
 		</method>
 		<method name="is_bone_enabled" qualifiers="const">
@@ -292,7 +292,7 @@
 			<param index="1" name="key" type="StringName" />
 			<param index="2" name="value" type="Variant" />
 			<description>
-				Sets bone metadata for [param bone_idx], will set the [param key] meta to [param value].
+				Sets the metadata for the bone at index [param bone_idx], setting the [param key] meta to [param value].
 			</description>
 		</method>
 		<method name="set_bone_name">

--- a/doc/classes/SkeletonModifier3D.xml
+++ b/doc/classes/SkeletonModifier3D.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="SkeletonModifier3D" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A node that may modify Skeleton3D's bone.
+		A node that may modify a Skeleton3D's bones.
 	</brief_description>
 	<description>
 		[SkeletonModifier3D] retrieves a target [Skeleton3D] by having a [Skeleton3D] parent.
-		If there is [AnimationMixer], modification always performs after playback process of the [AnimationMixer].
+		If there is an [AnimationMixer], a modification always performs after playback process of the [AnimationMixer].
 		This node should be used to implement custom IK solvers, constraints, or skeleton physics.
 	</description>
 	<tutorials>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1859,7 +1859,7 @@
 		</constant>
 		<constant name="FONT_ANTIALIASING_LCD" value="2" enum="FontAntialiasing">
 			Font glyphs are rasterized for LCD screens.
-			LCD subpixel layout is determined by the value of [code]gui/theme/lcd_subpixel_layout[/code] project settings.
+			LCD subpixel layout is determined by the value of the [member ProjectSettings.gui/theme/lcd_subpixel_layout] setting.
 			LCD subpixel anti-aliasing mode is suitable only for rendering horizontal, unscaled text in 2D.
 		</constant>
 		<constant name="FONT_LCD_SUBPIXEL_LAYOUT_NONE" value="0" enum="FontLCDSubpixelLayout">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -512,22 +512,22 @@
 			Use bilinear scaling for the viewport's 3D buffer. The amount of scaling can be set using [member scaling_3d_scale]. Values less than [code]1.0[/code] will result in undersampling while values greater than [code]1.0[/code] will result in supersampling. A value of [code]1.0[/code] disables scaling.
 		</constant>
 		<constant name="SCALING_3D_MODE_FSR" value="1" enum="Scaling3DMode">
-			Use AMD FidelityFX Super Resolution 1.0 upscaling for the viewport's 3D buffer. The amount of scaling can be set using [member scaling_3d_scale]. Values less than [code]1.0[/code] will be result in the viewport being upscaled using FSR. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] disables scaling.
+			Use AMD FidelityFX Super Resolution 1.0 upscaling for the viewport's 3D buffer. The amount of scaling can be set using [member scaling_3d_scale]. Values less than [code]1.0[/code] will result in the viewport being upscaled using FSR. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] disables scaling.
 		</constant>
 		<constant name="SCALING_3D_MODE_FSR2" value="2" enum="Scaling3DMode">
-			Use AMD FidelityFX Super Resolution 2.2 upscaling for the viewport's 3D buffer. The amount of scaling can be set using [member Viewport.scaling_3d_scale]. Values less than [code]1.0[/code] will be result in the viewport being upscaled using FSR2. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] will use FSR2 at native resolution as a TAA solution.
+			Use AMD FidelityFX Super Resolution 2.2 upscaling for the viewport's 3D buffer. The amount of scaling can be set using [member Viewport.scaling_3d_scale]. Values less than [code]1.0[/code] will result in the viewport being upscaled using FSR2. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] will use FSR2 at native resolution as a TAA solution.
 		</constant>
 		<constant name="SCALING_3D_MODE_METALFX_SPATIAL" value="3" enum="Scaling3DMode">
 			Use the [url=https://developer.apple.com/documentation/metalfx/mtlfxspatialscaler#overview]MetalFX spatial upscaler[/url] for the viewport's 3D buffer.
 			The amount of scaling can be set using [member scaling_3d_scale].
-			Values less than [code]1.0[/code] will be result in the viewport being upscaled using MetalFX. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] disables scaling.
+			Values less than [code]1.0[/code] will result in the viewport being upscaled using MetalFX. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] disables scaling.
 			More information: [url=https://developer.apple.com/documentation/metalfx]MetalFX[/url].
 			[b]Note:[/b] Only supported when the Metal rendering driver is in use, which limits this scaling mode to macOS and iOS.
 		</constant>
 		<constant name="SCALING_3D_MODE_METALFX_TEMPORAL" value="4" enum="Scaling3DMode">
 			Use the [url=https://developer.apple.com/documentation/metalfx/mtlfxtemporalscaler#overview]MetalFX temporal upscaler[/url] for the viewport's 3D buffer.
 			The amount of scaling can be set using [member scaling_3d_scale]. To determine the minimum input scale, use the [method RenderingDevice.limit_get] method with [constant RenderingDevice.LIMIT_METALFX_TEMPORAL_SCALER_MIN_SCALE].
-			Values less than [code]1.0[/code] will be result in the viewport being upscaled using MetalFX. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] will use MetalFX at native resolution as a TAA solution.
+			Values less than [code]1.0[/code] will result in the viewport being upscaled using MetalFX. Values greater than [code]1.0[/code] are not supported and bilinear downsampling will be used instead. A value of [code]1.0[/code] will use MetalFX at native resolution as a TAA solution.
 			More information: [url=https://developer.apple.com/documentation/metalfx]MetalFX[/url].
 			[b]Note:[/b] Only supported when the Metal rendering driver is in use, which limits this scaling mode to macOS and iOS.
 		</constant>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -338,7 +338,7 @@
 		<method name="is_layout_rtl" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if layout is right-to-left.
+				Returns [code]true[/code] if the layout is right-to-left.
 			</description>
 		</method>
 		<method name="is_maximize_allowed" qualifiers="const">

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -107,7 +107,7 @@
 			<return type="Dictionary" />
 			<param index="0" name="instance" type="Object" />
 			<description>
-				Returns the passed [param instance] converted to a Dictionary. Can be useful for serializing.
+				Returns the passed [param instance] converted to a [Dictionary]. Can be useful for serializing.
 				[codeblock]
 				var foo = "bar"
 				func _ready():
@@ -133,7 +133,7 @@
 				- A constant from the [enum Variant.Type] enumeration, for example [constant TYPE_INT].
 				- An [Object]-derived class which exists in [ClassDB], for example [Node].
 				- A [Script] (you can use any class, including inner one).
-				Unlike the right operand of the [code]is[/code] operator, [param type] can be a non-constant value. The [code]is[/code] operator supports more features (such as typed arrays). Use the operator instead of this method if you do not need dynamic type checking.
+				Unlike the right operand of the [code]is[/code] operator, [param type] can be a non-constant value. The [code]is[/code] operator supports more features (such as typed arrays). Use the operator instead of this method if you do not need to check the type dynamically.
 				[b]Examples:[/b]
 				[codeblock]
 				print(is_instance_of(a, TYPE_INT))

--- a/modules/gltf/doc_classes/GLTFAccessor.xml
+++ b/modules/gltf/doc_classes/GLTFAccessor.xml
@@ -13,7 +13,7 @@
 	</tutorials>
 	<members>
 		<member name="accessor_type" type="int" setter="set_accessor_type" getter="get_accessor_type" enum="GLTFAccessor.GLTFAccessorType" default="0">
-			The glTF accessor type as an enum. Possible values are 0 for "SCALAR", 1 for "VEC2", 2 for "VEC3", 3 for "VEC4", 4 for "MAT2", 5 for "MAT3", and 6 for "MAT4".
+			The glTF accessor type, as an enum.
 		</member>
 		<member name="buffer_view" type="int" setter="set_buffer_view" getter="get_buffer_view" default="-1">
 			The index of the buffer view this accessor is referencing. If [code]-1[/code], this accessor is not referencing any buffer view.
@@ -55,7 +55,7 @@
 			The offset relative to the start of the bufferView in bytes.
 		</member>
 		<member name="type" type="int" setter="set_type" getter="get_type" deprecated="Use [member accessor_type] instead.">
-			The glTF accessor type as an enum. Use [member accessor_type] instead.
+			The glTF accessor type, as an [int]. Possible values are [code]0[/code] for "SCALAR", [code]1[/code] for "VEC2", [code]2[/code] for "VEC3", [code]3[/code] for "VEC4", [code]4[/code] for "MAT2", [code]5[/code] for "MAT3", and [code]6[/code] for "MAT4".
 		</member>
 	</members>
 	<constants>

--- a/modules/gltf/doc_classes/GLTFLight.xml
+++ b/modules/gltf/doc_classes/GLTFLight.xml
@@ -71,7 +71,7 @@
 			At this angle, the light drops off to zero brightness. Between the inner and outer cone angles, there is a transition from full brightness to zero brightness. If this angle is a half turn, then the spotlight emits in all directions. When creating a Godot [SpotLight3D], the outer cone angle is used as the angle of the spotlight.
 		</member>
 		<member name="range" type="float" setter="set_range" getter="get_range" default="inf">
-			The range of the light, beyond which the light has no effect. glTF lights with no range defined behave like physical lights (which have infinite range). When creating a Godot light, the range is clamped to 4096.
+			The range of the light, beyond which the light has no effect. glTF lights with no range defined behave like physical lights (which have infinite range). When creating a Godot light, the range is clamped to [code]4096.0[/code].
 		</member>
 	</members>
 </class>

--- a/modules/gltf/doc_classes/GLTFNode.xml
+++ b/modules/gltf/doc_classes/GLTFNode.xml
@@ -48,7 +48,7 @@
 	</methods>
 	<members>
 		<member name="camera" type="int" setter="set_camera" getter="get_camera" default="-1">
-			If this glTF node is a camera, the index of the [GLTFCamera] in the [GLTFState] that describes the camera's properties. If -1, this node is not a camera.
+			If this glTF node is a camera, the index of the [GLTFCamera] in the [GLTFState] that describes the camera's properties. If [code]-1[/code], this node is not a camera.
 		</member>
 		<member name="children" type="PackedInt32Array" setter="set_children" getter="get_children" default="PackedInt32Array()">
 			The indices of the child nodes in the [GLTFState]. If this glTF node has no children, this will be an empty array.

--- a/modules/gltf/doc_classes/GLTFPhysicsBody.xml
+++ b/modules/gltf/doc_classes/GLTFPhysicsBody.xml
@@ -43,7 +43,9 @@
 			The angular velocity of the physics body, in radians per second. This is only used when the body type is "rigid" or "vehicle".
 		</member>
 		<member name="body_type" type="String" setter="set_body_type" getter="get_body_type" default="&quot;rigid&quot;">
-			The type of the body. When importing, this controls what type of [CollisionObject3D] node Godot should generate. Valid values are "static", "animatable", "character", "rigid", "vehicle", and "trigger". When exporting, this will be squashed down to one of "static", "kinematic", or "dynamic" motion types, or the "trigger" property.
+			The type of the body.
+			When importing, this controls what type of [CollisionObject3D] node Godot should generate. Valid values are [code]"static"[/code], [code]"animatable"[/code], [code]"character"[/code], [code]"rigid"[/code], [code]"vehicle"[/code], and [code]"trigger"[/code].
+			When exporting, this will be squashed down to one of [code]"static"[/code], [code]"kinematic"[/code], or [code]"dynamic"[/code] motion types, or the [code]"trigger"[/code] property.
 		</member>
 		<member name="center_of_mass" type="Vector3" setter="set_center_of_mass" getter="get_center_of_mass" default="Vector3(0, 0, 0)">
 			The center of mass of the body, in meters. This is in local space relative to the body. By default, the center of the mass is the body's origin.

--- a/modules/gltf/doc_classes/GLTFPhysicsShape.xml
+++ b/modules/gltf/doc_classes/GLTFPhysicsShape.xml
@@ -56,26 +56,26 @@
 	</methods>
 	<members>
 		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
-			The height of the shape, in meters. This is only used when the shape type is "capsule" or "cylinder". This value should not be negative, and for "capsule" it should be at least twice the radius.
+			The height of the shape, in meters. This is only used when the shape type is [code]"capsule"[/code] or [code]"cylinder"[/code]. This value should not be negative, and for [code]"capsule"[/code] it should be at least twice the radius.
 		</member>
 		<member name="importer_mesh" type="ImporterMesh" setter="set_importer_mesh" getter="get_importer_mesh">
-			The [ImporterMesh] resource of the shape. This is only used when the shape type is "hull" (convex hull) or "trimesh" (concave trimesh).
+			The [ImporterMesh] resource of the shape. This is only used when the shape type is [code]"hull"[/code] (convex hull) or [code]"trimesh"[/code] (concave trimesh).
 		</member>
 		<member name="is_trigger" type="bool" setter="set_is_trigger" getter="get_is_trigger" default="false">
-			If [code]true[/code], indicates that this shape is a trigger. For Godot, this means that the shape should be a child of an Area3D node.
+			If [code]true[/code], indicates that this shape is a trigger. For Godot, this means that the shape should be a child of an [Area3D] node.
 			This is the only variable not used in the [method to_node] method, it's intended to be used alongside when deciding where to add the generated node as a child.
 		</member>
 		<member name="mesh_index" type="int" setter="set_mesh_index" getter="get_mesh_index" default="-1">
-			The index of the shape's mesh in the glTF file. This is only used when the shape type is "hull" (convex hull) or "trimesh" (concave trimesh).
+			The index of the shape's mesh in the glTF file. This is only used when the shape type is [code]"hull"[/code] (convex hull) or [code]"trimesh"[/code] (concave trimesh).
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
-			The radius of the shape, in meters. This is only used when the shape type is "capsule", "cylinder", or "sphere". This value should not be negative.
+			The radius of the shape, in meters. This is only used when the shape type is [code]"capsule"[/code], [code]"cylinder"[/code], or [code]"sphere"[/code]. This value should not be negative.
 		</member>
 		<member name="shape_type" type="String" setter="set_shape_type" getter="get_shape_type" default="&quot;&quot;">
-			The type of shape this shape represents. Valid values are "box", "capsule", "cylinder", "sphere", "hull", and "trimesh".
+			The type of shape this shape represents. Valid values are [code]"box"[/code], [code]"capsule"[/code], [code]"cylinder"[/code], [code]"sphere"[/code], [code]"hull"[/code], and [code]"trimesh"[/code].
 		</member>
 		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(1, 1, 1)">
-			The size of the shape, in meters. This is only used when the shape type is "box", and it represents the "diameter" of the box. This value should not be negative.
+			The size of the shape, in meters. This is only used when the shape type is [code]"box"[/code], and it represents the [code]"diameter"[/code] of the box. This value should not be negative.
 		</member>
 	</members>
 </class>

--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -25,7 +25,7 @@
 			<param index="0" name="data" type="PackedByteArray" />
 			<param index="1" name="deduplication" type="bool" />
 			<description>
-				Appends the given byte array data to the buffers and creates a [GLTFBufferView] for it. The index of the destination [GLTFBufferView] is returned. If [param deduplication] is [code]true[/code], the buffers will first be searched for duplicate data, otherwise new bytes will always be appended.
+				Appends the given byte array [param data] to the buffers and creates a [GLTFBufferView] for it. The index of the destination [GLTFBufferView] is returned. If [param deduplication] is [code]true[/code], the buffers are first searched for duplicate data, otherwise new bytes are always appended.
 			</description>
 		</method>
 		<method name="append_gltf_node">

--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -597,7 +597,7 @@
 			Allows an application to write to the user dictionary.
 		</member>
 		<member name="screen/immersive_mode" type="bool" setter="" getter="">
-			If [code]true[/code], hides navigation and status bar. See [method DisplayServer.window_set_mode] to toggle it at runtime.
+			If [code]true[/code], hides the navigation and status bar. Set [method DisplayServer.window_set_mode] to change this at runtime.
 		</member>
 		<member name="screen/support_large" type="bool" setter="" getter="">
 			Indicates whether the application supports larger screen form-factors.

--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -106,10 +106,10 @@
 			[/codeblock]
 		</member>
 		<member name="entitlements/game_center" type="bool" setter="" getter="">
-			Enable to allow access to Game Center features. [url=https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_game-center]com.apple.developer.game-center[/url].
+			If [code]true[/code], allows access to Game Center features. See [url=https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_game-center]com.apple.developer.game-center[/url].
 		</member>
 		<member name="entitlements/increased_memory_limit" type="bool" setter="" getter="">
-			Enable if app may perform better with a higher memory limit. [url=https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_kernel_increased-memory-limit]com.apple.developer.kernel.increased-memory-limit[/url].
+			If [code]true[/code], hints that the app might perform better with a higher memory limit. See [url=https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_kernel_increased-memory-limit]com.apple.developer.kernel.increased-memory-limit[/url].
 		</member>
 		<member name="entitlements/push_notifications" type="String" setter="" getter="">
 			Environment for Apple Push Notification service. See [url=https://developer.apple.com/documentation/bundleresources/entitlements/aps-environment]aps-environment[/url].


### PR DESCRIPTION
Continuation of https://github.com/godotengine/godot/pull/99002 and https://github.com/godotengine/godot/pull/95774

This PR addressed yet **yet** another huge chunk of class reference oddities I remembered to note down for later while localizing the class reference. Some of these are clear typos, some are inconsistencies, some are just awkward.

Oh boy this will be nasty for localization.

Of particular note:
- Replaced the single use of "govern" with a more common verb
- Elaborated slightly more on **DisplayServer**'s `screen_get_image` and `screen_get_image_rect`
- ~~Tweaked EditorExportPlatformAndroid's `screen/immersive_mode` to actually mention immersive mode~~
- Went ballistic on Skeleton3D's `metadata`-related descriptions
- Filled many glTF definitions with appropriate `[code]` tags.
- Fixed a common "will be return" typo in the **SCALING_MODE** constants
- Fixed some missing articles (especially where it looked inconsistent with the rest)
- Fixed `vertex_buffer_create` glaringly missing what it actually created.
- Fixed **OS**'s `read_buffer_from_stdin` mentioning the wrong method
- Fixed **GLTFAccessor**'s `accessor_type` mentioning corresponding **int** values even though it's an enum
	- The description was copied from the deprecated `type` property without accounting for this



