### PR TITLE
Fix Movie Writer behavior with Viewport Display Mode + Window Size Override

### DIFF
--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -99,6 +99,18 @@ void MovieWriter::begin(const Size2i &p_movie_size, uint32_t p_fps, const String
 
 	print_line(vformat("Movie Maker mode enabled, recording movie at %d FPS...", p_fps));
 
+	// When using Display/Window/Stretch/Mode = Viewport, use the project's
+	// configured viewport size instead of the size of the window in the OS
+	Size2i actual_movie_size = p_movie_size;
+	String stretch_mode = GLOBAL_GET("display/window/stretch/mode");
+	if (stretch_mode == "viewport") {
+		actual_movie_size.width = GLOBAL_GET("display/window/size/viewport_width");
+		actual_movie_size.height = GLOBAL_GET("display/window/size/viewport_height");
+
+		print_line(vformat("Movie Maker mode using project viewport size: %dx%d",
+				actual_movie_size.width, actual_movie_size.height));
+	}
+
 	// Check for available disk space and warn the user if needed.
 	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	String path = p_base_path.get_basename();
@@ -125,7 +137,7 @@ void MovieWriter::begin(const Size2i &p_movie_size, uint32_t p_fps, const String
 	audio_channels = AudioDriverDummy::get_dummy_singleton()->get_channels();
 	audio_mix_buffer.resize(mix_rate * audio_channels / fps);
 
-	write_begin(p_movie_size, p_fps, p_base_path);
+	write_begin(actual_movie_size, p_fps, p_base_path);
 }
 
 void MovieWriter::_bind_methods() {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/71254.
Partial fix of https://github.com/godotengine/godot/issues/72760.

Fixes broken behavior when using Window_*Dimension*_Override + Viewport display mode.

I tested both jpeg and png videos with this, seems to work correctly. It would be nice if there was a way to nearest neighbor upscale the output, but a simple multiplication of the dimensions of the viewport resolution produces the same behavior as before, even with perfect aspect ratio mix.


Both of these videos are recorded in the same context, with same window size.

4.4.stable:

https://github.com/user-attachments/assets/cf404c24-5c6e-4855-a080-b506e3d41605

this PR:

https://github.com/user-attachments/assets/ffe6fcfe-59f8-41b2-92af-ad88af5676d0


Test project:

[movie_writer_viewport_fix.zip](https://github.com/user-attachments/files/19328550/movie_writer_viewport_fix.zip)