### PR TITLE
Handle incorrect values after type change and print error

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -31,6 +31,7 @@
 #include "editor_properties.h"
 
 #include "core/config/project_settings.h"
+#include "core/error/error_macros.h"
 #include "editor/create_dialog.h"
 #include "editor/editor_node.h"
 #include "editor/editor_properties_array_dict.h"
@@ -2873,24 +2874,50 @@ void EditorPropertyNodePath::update_property() {
 	const NodePath &p = _get_node_path();
 	assign->set_tooltip_text(p);
 
-	if (p.is_empty()) {
+	if (p.is_empty() || valid_types.is_empty()) {
 		assign->set_button_icon(Ref<Texture2D>());
 		assign->set_text(TTR("Assign..."));
 		assign->set_flat(false);
-		return;
-	}
-	assign->set_flat(true);
-
-	if (!base_node || !base_node->has_node(p)) {
-		assign->set_button_icon(Ref<Texture2D>());
-		assign->set_text(p);
 		return;
 	}
 
 	const Node *target_node = base_node->get_node(p);
 	ERR_FAIL_NULL(target_node);
 
-	if (String(target_node->get_name()).contains_char('@')) {
+	bool is_correct_class = false;
+
+	for (const StringName &E : valid_types) {
+		if (target_node->is_class(E) ||
+				EditorNode::get_singleton()->is_object_of_custom_type(target_node, E)) {
+			is_correct_class = true;
+			break;
+		} else {
+			Ref<Script> node_script = target_node->get_script();
+			while (node_script.is_valid()) {
+				if (node_script->get_path() == E) {
+					is_correct_class = true;
+					break;
+				}
+				node_script = node_script->get_base_script();
+			}
+			if (is_correct_class) {
+				break;
+			}
+		}
+	}
+
+	if (!is_correct_class) {
+		assign->set_button_icon(Ref<Texture2D>());
+		assign->set_text(TTR("Assign..."));
+		assign->set_flat(false);
+		assign->set_tooltip_text("");
+		ERR_FAIL_MSG(vformat("Failed to set a resource of the type '%s' because this EditorPropertyNodePath only accepts '%s' and its derivatives.", target_node->get_class(), valid_types));
+		return;
+	}
+
+	assign->set_flat(true);
+
+	if (!base_node || !base_node->has_node(p) || String(target_node->get_name()).contains_char('@')) {
 		assign->set_button_icon(Ref<Texture2D>());
 		assign->set_text(p);
 		return;
@@ -3369,7 +3396,7 @@ void EditorPropertyResource::update_property() {
 		}
 	}
 
-	resource_picker->set_edited_resource_no_check(res);
+	resource_picker->set_edited_resource(res);
 }
 
 void EditorPropertyResource::collapse_all_folding() {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes: #104323.

First PR to Godot. Really nervous.

#### Some notes
- I took the code in editor/editor_properties.cpp:2889-2907 from editor/gui/scene_tree_editor.cpp:986-1007. I am unsure if it  can be put into a single function.
- The inserted error message is also mostly a copy from editor/editor_resource_picker.cpp:945. Could be better?