### PR TITLE
Fix inspector theme not updating when theme changed

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -569,6 +569,8 @@ class EditorInspector : public ScrollContainer {
 	int property_focusable;
 	int update_scroll_request;
 
+	bool updating_theme = false;
+
 	struct DocCacheInfo {
 		String doc_path;
 		String theme_item_name;
@@ -605,6 +607,8 @@ class EditorInspector : public ScrollContainer {
 	void _update_current_favorites();
 	void _set_property_favorited(const String &p_path, bool p_favorited);
 	void _clear_current_favorites();
+
+	void _update_theme();
 
 	void _node_removed(Node *p_node);
 


### PR DESCRIPTION
Previously, an `EditorInspector` would refresh its theme only when the editor settings were changed, which fails to account for certain cases (eg when the system OS switches light/dark mode).

This PR allows the style to update in all cases by connecting to the "theme changed" notification.

### Demo

Here are screenshots of the interface after switching from light to dark mode in macOS System Settings, with `interface/theme/follow_system_theme` enabled.

Without this PR:

![Previous behavior](https://github.com/user-attachments/assets/3d74f838-e2d2-448e-9bc6-615b68d8c92a)

With this PR:

![New behavior](https://github.com/user-attachments/assets/87efd92c-0288-4f70-ba88-ca97c174ead3)
