### PR TITLE
Fix smooth scrolling being tied to physics process

### DIFF
--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -102,7 +102,7 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 
 				if (smooth_scroll_enabled) {
 					scrolling = true;
-					set_physics_process_internal(true);
+					set_process_internal(true);
 				} else {
 					scroll_to(target_scroll);
 				}
@@ -126,7 +126,7 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 
 				if (smooth_scroll_enabled) {
 					scrolling = true;
-					set_physics_process_internal(true);
+					set_process_internal(true);
 				} else {
 					scroll_to(target_scroll);
 				}
@@ -330,29 +330,29 @@ void ScrollBar::_notification(int p_what) {
 			drag_node = nullptr;
 		} break;
 
-		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (scrolling) {
 				if (get_value() != target_scroll) {
 					double target = target_scroll - get_value();
 					double dist = abs(target);
-					double vel = ((target / dist) * 500) * get_physics_process_delta_time();
+					double vel = ((target / dist) * 500) * get_process_delta_time();
 
 					if (Math::abs(vel) >= dist) {
 						scroll_to(target_scroll);
 						scrolling = false;
-						set_physics_process_internal(false);
+						set_process_internal(false);
 					} else {
 						scroll(vel);
 					}
 				} else {
 					scrolling = false;
-					set_physics_process_internal(false);
+					set_process_internal(false);
 				}
 
 			} else if (drag_node_touching) {
 				if (drag_node_touching_deaccel) {
 					Vector2 pos = Vector2(orientation == HORIZONTAL ? get_value() : 0, orientation == VERTICAL ? get_value() : 0);
-					pos += drag_node_speed * get_physics_process_delta_time();
+					pos += drag_node_speed * get_process_delta_time();
 
 					bool turnoff = false;
 
@@ -371,7 +371,7 @@ void ScrollBar::_notification(int p_what) {
 
 						float sgn_x = drag_node_speed.x < 0 ? -1 : 1;
 						float val_x = Math::abs(drag_node_speed.x);
-						val_x -= 1000 * get_physics_process_delta_time();
+						val_x -= 1000 * get_process_delta_time();
 
 						if (val_x < 0) {
 							turnoff = true;
@@ -394,7 +394,7 @@ void ScrollBar::_notification(int p_what) {
 
 						float sgn_y = drag_node_speed.y < 0 ? -1 : 1;
 						float val_y = Math::abs(drag_node_speed.y);
-						val_y -= 1000 * get_physics_process_delta_time();
+						val_y -= 1000 * get_process_delta_time();
 
 						if (val_y < 0) {
 							turnoff = true;
@@ -403,7 +403,7 @@ void ScrollBar::_notification(int p_what) {
 					}
 
 					if (turnoff) {
-						set_physics_process_internal(false);
+						set_process_internal(false);
 						drag_node_touching = false;
 						drag_node_touching_deaccel = false;
 					}
@@ -412,10 +412,10 @@ void ScrollBar::_notification(int p_what) {
 					if (time_since_motion == 0 || time_since_motion > 0.1) {
 						Vector2 diff = drag_node_accum - last_drag_node_accum;
 						last_drag_node_accum = drag_node_accum;
-						drag_node_speed = diff / get_physics_process_delta_time();
+						drag_node_speed = diff / get_process_delta_time();
 					}
 
-					time_since_motion += get_physics_process_delta_time();
+					time_since_motion += get_process_delta_time();
 				}
 			}
 		} break;
@@ -555,7 +555,7 @@ void ScrollBar::_drag_node_input(const Ref<InputEvent> &p_input) {
 			time_since_motion = 0;
 
 			if (drag_node_touching) {
-				set_physics_process_internal(true);
+				set_process_internal(true);
 				time_since_motion = 0;
 			}
 
@@ -564,7 +564,7 @@ void ScrollBar::_drag_node_input(const Ref<InputEvent> &p_input) {
 				if (drag_node_speed == Vector2()) {
 					drag_node_touching_deaccel = false;
 					drag_node_touching = false;
-					set_physics_process_internal(false);
+					set_process_internal(false);
 				} else {
 					drag_node_touching_deaccel = true;
 				}

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -77,7 +77,7 @@ Size2 ScrollContainer::get_minimum_size() const {
 }
 
 void ScrollContainer::_cancel_drag() {
-	set_physics_process_internal(false);
+	set_process_internal(false);
 	drag_touching_deaccel = false;
 	drag_touching = false;
 	drag_speed = Vector2();
@@ -185,7 +185,7 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 			drag_touching_deaccel = false;
 			beyond_deadzone = false;
 			time_since_motion = 0;
-			set_physics_process_internal(true);
+			set_process_internal(true);
 			time_since_motion = 0;
 
 		} else {
@@ -461,13 +461,11 @@ void ScrollContainer::_notification(int p_what) {
 					v_scroll->set_value(point.y);
 				}
 			}
-		} break;
 
-		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (drag_touching) {
 				if (drag_touching_deaccel) {
 					Vector2 pos = Vector2(h_scroll->get_value(), v_scroll->get_value());
-					pos += drag_speed * get_physics_process_delta_time();
+					pos += drag_speed * get_process_delta_time();
 
 					bool turnoff_h = false;
 					bool turnoff_v = false;
@@ -499,7 +497,7 @@ void ScrollContainer::_notification(int p_what) {
 
 					float sgn_x = drag_speed.x < 0 ? -1 : 1;
 					float val_x = Math::abs(drag_speed.x);
-					val_x -= 1000 * get_physics_process_delta_time();
+					val_x -= 1000 * get_process_delta_time();
 
 					if (val_x < 0) {
 						turnoff_h = true;
@@ -507,7 +505,7 @@ void ScrollContainer::_notification(int p_what) {
 
 					float sgn_y = drag_speed.y < 0 ? -1 : 1;
 					float val_y = Math::abs(drag_speed.y);
-					val_y -= 1000 * get_physics_process_delta_time();
+					val_y -= 1000 * get_process_delta_time();
 
 					if (val_y < 0) {
 						turnoff_v = true;
@@ -523,10 +521,10 @@ void ScrollContainer::_notification(int p_what) {
 					if (time_since_motion == 0 || time_since_motion > 0.1) {
 						Vector2 diff = drag_accum - last_drag_accum;
 						last_drag_accum = drag_accum;
-						drag_speed = diff / get_physics_process_delta_time();
+						drag_speed = diff / get_process_delta_time();
 					}
 
-					time_since_motion += get_physics_process_delta_time();
+					time_since_motion += get_process_delta_time();
 				}
 			}
 		} break;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -805,12 +805,12 @@ void TextEdit::_notification(int p_what) {
 			queue_redraw();
 		} break;
 
-		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (scrolling && get_v_scroll() != target_v_scroll) {
 				double target_y = target_v_scroll - get_v_scroll();
 				double dist = abs(target_y);
 				// To ensure minimap is responsive override the speed setting.
-				double vel = ((target_y / dist) * ((minimap_clicked) ? 3000 : v_scroll_speed)) * get_physics_process_delta_time();
+				double vel = ((target_y / dist) * ((minimap_clicked) ? 3000 : v_scroll_speed)) * get_process_delta_time();
 
 				// Prevent small velocities from blocking scrolling.
 				if (Math::abs(vel) < v_scroll->get_step()) {
@@ -821,14 +821,14 @@ void TextEdit::_notification(int p_what) {
 					set_v_scroll(target_v_scroll);
 					scrolling = false;
 					minimap_clicked = false;
-					set_physics_process_internal(false);
+					set_process_internal(false);
 				} else {
 					set_v_scroll(get_v_scroll() + vel);
 				}
 			} else {
 				scrolling = false;
 				minimap_clicked = false;
-				set_physics_process_internal(false);
+				set_process_internal(false);
 			}
 		} break;
 
@@ -8527,7 +8527,7 @@ void TextEdit::_scroll_up(real_t p_delta, bool p_animate) {
 			queue_accessibility_update();
 		} else {
 			scrolling = true;
-			set_physics_process_internal(true);
+			set_process_internal(true);
 		}
 	} else {
 		set_v_scroll(target_v_scroll);
@@ -8556,7 +8556,7 @@ void TextEdit::_scroll_down(real_t p_delta, bool p_animate) {
 			queue_accessibility_update();
 		} else {
 			scrolling = true;
-			set_physics_process_internal(true);
+			set_process_internal(true);
 		}
 	} else {
 		set_v_scroll(target_v_scroll);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/74274, fixes https://github.com/godotengine/godot/issues/28385.

Changes scrolling from relying on physics process to use process instead. This detaches it from the `Physics Ticks per Second` Project Setting, which would cause sluggishness when scrolling if this value was too low.

| Before (**2** ticks per second) | After (**2** ticks per second)|
| ------------- | ------------- |
|  <video src=https://github.com/user-attachments/assets/06fbd455-4380-435c-a90d-d7e02c0bde74></video> |  <video src=https://github.com/user-attachments/assets/4f2b35f4-3d8b-4703-9f1f-ff6b5dc16581></video> |






