### PR TITLE
Fix `Camera2DEditorPlugin` crash when reloading scene

### DIFF
--- a/editor/plugins/camera_2d_editor_plugin.cpp
+++ b/editor/plugins/camera_2d_editor_plugin.cpp
@@ -150,6 +150,16 @@ void Camera2DEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
+void Camera2DEditorPlugin::edited_scene_changed() {
+	Callable update_text = callable_mp(this, &Camera2DEditorPlugin::_update_approach_text_visibility);
+	StringName update_signal = SNAME("_camera_limit_enabled_updated");
+	Camera2D *prev_cam = camera_2d_editor->selected_camera;
+	if (prev_cam != nullptr && prev_cam->is_connected(update_signal, update_text)) {
+		prev_cam->disconnect(update_signal, update_text);
+		camera_2d_editor->selected_camera = nullptr;
+	}
+}
+
 Camera2DEditorPlugin::Camera2DEditorPlugin() {
 	camera_2d_editor = memnew(Camera2DEditor);
 	EditorNode::get_singleton()->get_gui_base()->add_child(camera_2d_editor);

--- a/editor/plugins/camera_2d_editor_plugin.h
+++ b/editor/plugins/camera_2d_editor_plugin.h
@@ -75,6 +75,7 @@ public:
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
+	virtual void edited_scene_changed() override;
 
 	Camera2DEditorPlugin();
 };


### PR DESCRIPTION
Fix a regression from #101427 that reloading a scene with Camera2D crashes the editor.

Edit: #104190 refactors the Camera2DEditorPlugin. I'm not sure if #104190 has fixed this issue, but before it is merged, I need this PR to resolve the issue first.