### PR TITLE
Rename global transform notification to contain the word "global"

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -562,16 +562,22 @@
 				Hide the [CanvasItem] if it's currently visible. This is equivalent to setting [member visible] to [code]false[/code].
 			</description>
 		</method>
+		<method name="is_global_transform_notification_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if global transform notifications are communicated to children.
+			</description>
+		</method>
 		<method name="is_local_transform_notification_enabled" qualifiers="const">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the node receives [constant NOTIFICATION_LOCAL_TRANSFORM_CHANGED] whenever its local transform changes. This is enabled with [method set_notify_local_transform].
 			</description>
 		</method>
-		<method name="is_transform_notification_enabled" qualifiers="const">
+		<method name="is_transform_notification_enabled" qualifiers="const" deprecated="Use [method is_global_transform_notification_enabled] instead.">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the node receives [constant NOTIFICATION_TRANSFORM_CHANGED] whenever its global transform changes. This is enabled with [method set_notify_transform].
+				Returns [code]true[/code] if the node receives [constant NOTIFICATION_GLOBAL_TRANSFORM_CHANGED] whenever its global transform changes. This is enabled with [method set_notify_transform].
 			</description>
 		</method>
 		<method name="is_visible_in_tree" qualifiers="const">
@@ -622,6 +628,13 @@
 				[b]Note:[/b] [param name] is case-sensitive and must match the name of the uniform in the code exactly (not the capitalized name in the inspector).
 			</description>
 		</method>
+		<method name="set_notify_global_transform">
+			<return type="void" />
+			<param index="0" name="enable" type="bool" />
+			<description>
+				If [param enable] is [code]true[/code], this node will receive [constant NOTIFICATION_GLOBAL_TRANSFORM_CHANGED] when its global transform changes.
+			</description>
+		</method>
 		<method name="set_notify_local_transform">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
@@ -630,11 +643,11 @@
 				[b]Note:[/b] Many canvas items such as [Bone2D] or [CollisionShape2D] automatically enable this in order to function correctly.
 			</description>
 		</method>
-		<method name="set_notify_transform">
+		<method name="set_notify_transform" deprecated="Use [method set_notify_global_transform] instead.">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				If [code]true[/code], the node will receive [constant NOTIFICATION_TRANSFORM_CHANGED] whenever its global transform changes.
+				If [code]true[/code], the node will receive [constant NOTIFICATION_GLOBAL_TRANSFORM_CHANGED] whenever its global transform changes.
 				[b]Note:[/b] Many canvas items such as [Camera2D] or [Light2D] automatically enable this in order to function correctly.
 			</description>
 		</method>
@@ -740,9 +753,12 @@
 		</signal>
 	</signals>
 	<constants>
-		<constant name="NOTIFICATION_TRANSFORM_CHANGED" value="2000">
-			Notification received when this node's global transform changes, if [method is_transform_notification_enabled] is [code]true[/code]. See also [method set_notify_transform] and [method get_transform].
+		<constant name="NOTIFICATION_GLOBAL_TRANSFORM_CHANGED" value="2000" keywords="NOTIFICATION_TRANSFORM_CHANGED">
+			Notification received when this node's global transform changes, if [method is_global_transform_notification_enabled] is [code]true[/code]. See also [method set_notify_global_transform] and [method get_transform].
 			[b]Note:[/b] Many canvas items such as [Camera2D] or [CollisionObject2D] automatically enable this in order to function correctly.
+		</constant>
+		<constant name="NOTIFICATION_TRANSFORM_CHANGED" value="2000" deprecated="Use [constant NOTIFICATION_GLOBAL_TRANSFORM_CHANGED] instead.">
+			The [CanvasItem]'s global transform has changed. This notification is only received if enabled by [method set_notify_global_transform].
 		</constant>
 		<constant name="NOTIFICATION_LOCAL_TRANSFORM_CHANGED" value="35">
 			Notification received when this node's transform changes, if [method is_local_transform_notification_enabled] is [code]true[/code]. This is not received when a parent [Node2D]'s transform changes. See also [method set_notify_local_transform].

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -37,7 +37,7 @@
 		<method name="force_update_transform">
 			<return type="void" />
 			<description>
-				Forces the node's [member global_transform] to update, by sending [constant NOTIFICATION_TRANSFORM_CHANGED]. Fails if the node is not inside the tree.
+				Forces the node's [member global_transform] to update, by sending [constant NOTIFICATION_GLOBAL_TRANSFORM_CHANGED]. Fails if the node is not inside the tree.
 				[b]Note:[/b] For performance reasons, transform changes are usually accumulated and applied [i]once[/i] at the end of the frame. The update propagates through [Node3D] children, as well. Therefore, use this method only when you need an up-to-date transform (such as during physics operations).
 			</description>
 		</method>
@@ -98,6 +98,12 @@
 				Prevents this node from being rendered. Equivalent to setting [member visible] to [code]false[/code]. This is the opposite of [method show].
 			</description>
 		</method>
+		<method name="is_global_transform_notification_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the node receives [constant NOTIFICATION_GLOBAL_TRANSFORM_CHANGED] whenever [member global_transform] changes. This is enabled with [method set_notify_global_transform].
+			</description>
+		</method>
 		<method name="is_local_transform_notification_enabled" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -111,10 +117,10 @@
 				[b]Note:[/b] [member transform] is not affected by this setting.
 			</description>
 		</method>
-		<method name="is_transform_notification_enabled" qualifiers="const">
+		<method name="is_transform_notification_enabled" qualifiers="const" deprecated="Use [method is_global_transform_notification_enabled] instead.">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the node receives [constant NOTIFICATION_TRANSFORM_CHANGED] whenever [member global_transform] changes. This is enabled with [method set_notify_transform].
+				Returns [code]true[/code] if the node receives [constant NOTIFICATION_GLOBAL_TRANSFORM_CHANGED] whenever [member global_transform] changes. This is enabled with [method set_notify_global_transform].
 			</description>
 		</method>
 		<method name="is_visible_in_tree" qualifiers="const">
@@ -215,8 +221,17 @@
 			<return type="void" />
 			<param index="0" name="enabled" type="bool" />
 			<description>
-				If [code]true[/code], the node will not receive [constant NOTIFICATION_TRANSFORM_CHANGED] or [constant NOTIFICATION_LOCAL_TRANSFORM_CHANGED].
+				If [code]true[/code], the node will not receive [constant NOTIFICATION_GLOBAL_TRANSFORM_CHANGED] or [constant NOTIFICATION_LOCAL_TRANSFORM_CHANGED].
 				It may useful to call this method when handling these notifications to prevent infinite recursion.
+			</description>
+		</method>
+		<method name="set_notify_global_transform" keywords="set_notify_global_transform">
+			<return type="void" />
+			<param index="0" name="enable" type="bool" />
+			<description>
+				If [code]true[/code], the node will receive [constant NOTIFICATION_GLOBAL_TRANSFORM_CHANGED] whenever [member global_transform] changes.
+				[b]Note:[/b] Most 3D nodes such as [VisualInstance3D] or [CollisionObject3D] automatically enable this to function correctly.
+				[b]Note:[/b] In the editor, nodes will propagate this notification to their children if a gizmo is attached (see [method add_gizmo]).
 			</description>
 		</method>
 		<method name="set_notify_local_transform">
@@ -227,11 +242,11 @@
 				[b]Note:[/b] Some 3D nodes such as [CSGShape3D] or [CollisionShape3D] automatically enable this to function correctly.
 			</description>
 		</method>
-		<method name="set_notify_transform" keywords="set_notify_global_transform">
+		<method name="set_notify_transform" deprecated="Use [method set_notify_global_transform] instead.">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				If [code]true[/code], the node will receive [constant NOTIFICATION_TRANSFORM_CHANGED] whenever [member global_transform] changes.
+				If [code]true[/code], the node will receive [constant NOTIFICATION_GLOBAL_TRANSFORM_CHANGED] whenever [member global_transform] changes.
 				[b]Note:[/b] Most 3D nodes such as [VisualInstance3D] or [CollisionObject3D] automatically enable this to function correctly.
 				[b]Note:[/b] In the editor, nodes will propagate this notification to their children if a gizmo is attached (see [method add_gizmo]).
 			</description>
@@ -370,8 +385,13 @@
 		</signal>
 	</signals>
 	<constants>
-		<constant name="NOTIFICATION_TRANSFORM_CHANGED" value="2000" keywords="NOTIFICATION_GLOBAL_TRANSFORM_CHANGED">
-			Notification received when this node's [member global_transform] changes, if [method is_transform_notification_enabled] is [code]true[/code]. See also [method set_notify_transform].
+		<constant name="NOTIFICATION_GLOBAL_TRANSFORM_CHANGED" value="2000" keywords="NOTIFICATION_TRANSFORM_CHANGED">
+			Notification received when this node's [member global_transform] changes, if [method is_global_transform_notification_enabled] is [code]true[/code]. See also [method set_notify_global_transform].
+			[b]Note:[/b] Most 3D nodes such as [VisualInstance3D] or [CollisionObject3D] automatically enable this to function correctly.
+			[b]Note:[/b] In the editor, nodes will propagate this notification to their children if a gizmo is attached (see [method add_gizmo]).
+		</constant>
+		<constant name="NOTIFICATION_TRANSFORM_CHANGED" value="2000" deprecated="Use [constant NOTIFICATION_GLOBAL_TRANSFORM_CHANGED] instead.">
+			Notification received when this node's [member global_transform] changes, if [method is_global_transform_notification_enabled] is [code]true[/code]. See also [method set_notify_global_transform].
 			[b]Note:[/b] Most 3D nodes such as [VisualInstance3D] or [CollisionObject3D] automatically enable this to function correctly.
 			[b]Note:[/b] In the editor, nodes will propagate this notification to their children if a gizmo is attached (see [method add_gizmo]).
 		</constant>

--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -144,7 +144,7 @@ void EditorToaster::_notification(int p_what) {
 			error_panel_style_progress->set_border_color(get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			_update_vbox_position();
 			_update_disable_notifications_button();
 		} break;
@@ -572,7 +572,7 @@ EditorToaster *EditorToaster::get_singleton() {
 }
 
 EditorToaster::EditorToaster() {
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 
 	// VBox.
 	vbox_container = memnew(VBoxContainer);

--- a/editor/run/embedded_process.cpp
+++ b/editor/run/embedded_process.cpp
@@ -208,7 +208,7 @@ void EmbeddedProcess::embed_process(ProcessID p_pid) {
 	embedding_grab_focus = has_focus();
 	timer_update_embedded_process->start();
 	set_process(true);
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 
 	// Attempt to embed the process, but if it has just started and the window is not ready yet,
 	// we will retry in this case.
@@ -225,7 +225,7 @@ void EmbeddedProcess::reset() {
 	embedding_grab_focus = false;
 	reset_timers();
 	set_process(false);
-	set_notify_transform(false);
+	set_notify_global_transform(false);
 	queue_redraw();
 }
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1056,7 +1056,7 @@ void CSGShape3D::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if (use_collision && is_root_shape() && root_collision_body.is_valid()) {
 				PhysicsServer3D::get_singleton()->body_set_state(root_collision_body, PS3DE::BODY_STATE_TRANSFORM, get_global_transform());
 			}

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -1239,7 +1239,7 @@ void GridMap::_notification(int p_what) {
 		} break;
 #endif
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			Transform3D new_xform = get_global_transform();
 			if (new_xform == last_transform) {
 				break;
@@ -1908,7 +1908,7 @@ bool GridMap::get_debug_show_octants() const {
 }
 
 GridMap::GridMap() {
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 #if defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
 	NavigationServer3D::get_singleton()->connect("map_changed", callable_mp(this, &GridMap::_navigation_map_changed));
 	NavigationServer3D::get_singleton()->connect("navigation_debug_changed", callable_mp(this, &GridMap::_update_navigation_debug_edge_connections));

--- a/modules/openxr/scene/openxr_composition_layer.cpp
+++ b/modules/openxr/scene/openxr_composition_layer.cpp
@@ -737,7 +737,7 @@ void OpenXRCompositionLayer::_notification(int p_what) {
 			update_configuration_warnings();
 		} break;
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			update_transform();
 			update_configuration_warnings();
 		} break;
@@ -751,12 +751,12 @@ void OpenXRCompositionLayer::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_PARENTED: {
 			// Enables NOTIFICATION_LOCAL_TRANSFORM_CHANGED when XROrigin3D or XRCamera3D are the parents
-			// since that notification happens less frequently than NOTIFICATION_TRANSFORM_CHANGED.
+			// since that notification happens less frequently than NOTIFICATION_GLOBAL_TRANSFORM_CHANGED.
 			bool parent_is_xr_camera = Object::cast_to<XRCamera3D>(get_parent()) != nullptr;
 			bool parent_is_xr_origin = Object::cast_to<XROrigin3D>(get_parent()) != nullptr;
 			bool enable_local_transform_notification = parent_is_xr_camera || parent_is_xr_origin;
 			set_notify_local_transform(enable_local_transform_notification);
-			set_notify_transform(!enable_local_transform_notification);
+			set_notify_global_transform(!enable_local_transform_notification);
 
 			update_transform();
 		} break;

--- a/modules/tilemap/tile_map_layer.cpp
+++ b/modules/tilemap/tile_map_layer.cpp
@@ -495,7 +495,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 
 void TileMapLayer::_rendering_notification(int p_what) {
 	RenderingServer *rs = RenderingServer::get_singleton();
-	if (p_what == NOTIFICATION_TRANSFORM_CHANGED || p_what == NOTIFICATION_ENTER_CANVAS || p_what == NOTIFICATION_VISIBILITY_CHANGED) {
+	if (p_what == NOTIFICATION_GLOBAL_TRANSFORM_CHANGED || p_what == NOTIFICATION_ENTER_CANVAS || p_what == NOTIFICATION_VISIBILITY_CHANGED) {
 		if (tile_set.is_valid()) {
 			Transform2D tilemap_xform = get_global_transform();
 			for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
@@ -1055,7 +1055,7 @@ void TileMapLayer::_physics_notification(int p_what) {
 	PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
 
 	switch (p_what) {
-		case NOTIFICATION_TRANSFORM_CHANGED:
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED:
 			// Move the collisison shapes along with the TileMap.
 			if (is_inside_tree() && tile_set.is_valid()) {
 				for (KeyValue<Vector2i, Ref<PhysicsQuadrant>> &kv : physics_quadrant_map) {
@@ -1356,7 +1356,7 @@ void TileMapLayer::_navigation_update(bool p_force_cleanup) {
 }
 
 void TileMapLayer::_navigation_notification(int p_what) {
-	if (p_what == NOTIFICATION_TRANSFORM_CHANGED) {
+	if (p_what == NOTIFICATION_GLOBAL_TRANSFORM_CHANGED) {
 		if (tile_set.is_valid()) {
 			Transform2D tilemap_xform = get_global_transform();
 			for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
@@ -3604,7 +3604,7 @@ void TileMapLayer::navmesh_parse_source_geometry(const Ref<NavigationPolygon> &p
 #endif // NAVIGATION_2D_DISABLED
 
 TileMapLayer::TileMapLayer() {
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 }
 
 TileMapLayer::~TileMapLayer() {

--- a/platform/macos/editor/embedded_process_macos.mm
+++ b/platform/macos/editor/embedded_process_macos.mm
@@ -46,9 +46,9 @@
 void EmbeddedProcessMacOS::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			set_notify_transform(true);
+			set_notify_global_transform(true);
 		} break;
-		case NOTIFICATION_TRANSFORM_CHANGED:
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED:
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			update_embedded_process();
 		} break;

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -272,8 +272,8 @@ Transform2D Camera2D::get_camera_transform() {
 void Camera2D::_ensure_update_interpolation_data() {
 	// The "curr -> previous" update can either occur
 	// on NOTIFICATION_INTERNAL_PHYSICS_PROCESS, OR
-	// on NOTIFICATION_TRANSFORM_CHANGED,
-	// if NOTIFICATION_TRANSFORM_CHANGED takes place earlier than
+	// on NOTIFICATION_GLOBAL_TRANSFORM_CHANGED,
+	// if NOTIFICATION_GLOBAL_TRANSFORM_CHANGED takes place earlier than
 	// NOTIFICATION_INTERNAL_PHYSICS_PROCESS on a tick.
 	// This is to ensure that the data keeps flowing, but the new data
 	// doesn't overwrite before prev has been set.
@@ -325,7 +325,7 @@ void Camera2D::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if ((!position_smoothing_enabled && !is_physics_interpolated_and_enabled()) || is_part_of_edited_scene()) {
 				_update_scroll();
 			}
@@ -1006,6 +1006,6 @@ void Camera2D::_bind_methods() {
 }
 
 Camera2D::Camera2D() {
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 	set_hide_clip_children(true);
 }

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -119,13 +119,13 @@ void CPUParticles2D::set_use_local_coordinates(bool p_enable) {
 	// and inform the RenderingServer to use identity mode.
 	set_canvas_item_use_identity_transform(!local_coords);
 
-	// We only need NOTIFICATION_TRANSFORM_CHANGED
+	// We only need NOTIFICATION_GLOBAL_TRANSFORM_CHANGED
 	// when following an interpolated target.
 
 #ifdef TOOLS_ENABLED
-	set_notify_transform(_interpolation_data.interpolated_follow || (Engine::get_singleton()->is_editor_hint() && !local_coords));
+	set_notify_global_transform(_interpolation_data.interpolated_follow || (Engine::get_singleton()->is_editor_hint() && !local_coords));
 #else
-	set_notify_transform(_interpolation_data.interpolated_follow);
+	set_notify_global_transform(_interpolation_data.interpolated_follow);
 #endif
 
 	queue_redraw();
@@ -1351,7 +1351,7 @@ void CPUParticles2D::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if (_interpolation_data.interpolated_follow) {
 				// If the transform has been updated AFTER the physics tick, keep data flowing.
 				if (Engine::get_singleton()->is_in_physics_frame()) {

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -132,7 +132,7 @@ void GPUParticles2D::set_visibility_rect(const Rect2 &p_visibility_rect) {
 void GPUParticles2D::set_use_local_coordinates(bool p_enable) {
 	local_coords = p_enable;
 	RS::get_singleton()->particles_set_use_local_coordinates(particles, local_coords);
-	set_notify_transform(!p_enable);
+	set_notify_global_transform(!p_enable);
 	if (!p_enable && is_inside_tree()) {
 		_update_particle_emission_transform();
 	}
@@ -779,7 +779,7 @@ void GPUParticles2D::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			_update_particle_emission_transform();
 		} break;
 

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -212,7 +212,7 @@ void Light2D::_notification(int p_what) {
 			_update_light_visibility();
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			RS::get_singleton()->canvas_light_set_transform(canvas_light, get_global_transform());
 		} break;
 
@@ -223,7 +223,7 @@ void Light2D::_notification(int p_what) {
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
 			if (is_visible_in_tree() && is_physics_interpolated_and_enabled()) {
 				// Explicitly make sure the transform is up to date in RenderingServer before
-				// resetting. This is necessary because NOTIFICATION_TRANSFORM_CHANGED
+				// resetting. This is necessary because NOTIFICATION_GLOBAL_TRANSFORM_CHANGED
 				// is normally deferred, and a client change to transform will not always be sent
 				// before the reset, so we need to guarantee this.
 				RS::get_singleton()->canvas_light_set_transform(canvas_light, get_global_transform());
@@ -335,7 +335,7 @@ void Light2D::_bind_methods() {
 
 Light2D::Light2D() {
 	canvas_light = RenderingServer::get_singleton()->canvas_light_create();
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 }
 
 Light2D::~Light2D() {

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -174,7 +174,7 @@ void LightOccluder2D::_notification(int p_what) {
 			RS::get_singleton()->canvas_light_occluder_set_enabled(occluder, is_visible_in_tree());
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			RS::get_singleton()->canvas_light_occluder_set_transform(occluder, get_global_transform());
 		} break;
 
@@ -211,7 +211,7 @@ void LightOccluder2D::_notification(int p_what) {
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
 			if (is_visible_in_tree() && is_physics_interpolated_and_enabled()) {
 				// Explicitly make sure the transform is up to date in RenderingServer before
-				// resetting. This is necessary because NOTIFICATION_TRANSFORM_CHANGED
+				// resetting. This is necessary because NOTIFICATION_GLOBAL_TRANSFORM_CHANGED
 				// is normally deferred, and a client change to transform will not always be sent
 				// before the reset, so we need to guarantee this.
 				RS::get_singleton()->canvas_light_occluder_set_transform(occluder, get_global_transform());
@@ -306,7 +306,7 @@ void LightOccluder2D::_bind_methods() {
 LightOccluder2D::LightOccluder2D() {
 	occluder = RS::get_singleton()->canvas_light_occluder_create();
 
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 	set_as_sdf_collision(true);
 }
 

--- a/scene/2d/navigation/navigation_link_2d.cpp
+++ b/scene/2d/navigation/navigation_link_2d.cpp
@@ -113,7 +113,7 @@ void NavigationLink2D::_notification(int p_what) {
 			_link_enter_navigation_map();
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			_link_update_transform();
 		} break;
 
@@ -426,7 +426,7 @@ NavigationLink2D::NavigationLink2D() {
 	NavigationServer2D::get_singleton()->link_set_bidirectional(link, bidirectional);
 	NavigationServer2D::get_singleton()->link_set_enabled(link, enabled);
 
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 	set_hide_clip_children(true);
 }
 

--- a/scene/2d/navigation/navigation_region_2d.cpp
+++ b/scene/2d/navigation/navigation_region_2d.cpp
@@ -164,7 +164,7 @@ void NavigationRegion2D::_notification(int p_what) {
 			_region_enter_navigation_map();
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			_region_update_transform();
 		} break;
 
@@ -376,7 +376,7 @@ bool NavigationRegion2D::_get(const StringName &p_name, Variant &r_ret) const {
 #endif // DISABLE_DEPRECATED
 
 NavigationRegion2D::NavigationRegion2D() {
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 	set_hide_clip_children(true);
 
 	region = NavigationServer2D::get_singleton()->region_create();

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -78,7 +78,7 @@ void CollisionObject2D::_notification(int p_what) {
 			_update_pickable();
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if (only_update_transform_changes) {
 				return;
 			}
@@ -684,7 +684,7 @@ CollisionObject2D::CollisionObject2D(RID p_rid, bool p_area) {
 	rid = p_rid;
 	area = p_area;
 	pickable = true;
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 	set_hide_clip_children(true);
 	total_subshapes = 0;
 	only_update_transform_changes = false;
@@ -701,7 +701,7 @@ CollisionObject2D::CollisionObject2D() {
 	_define_ancestry(AncestralClass::COLLISION_OBJECT_2D);
 	//owner=
 
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 }
 
 CollisionObject2D::~CollisionObject2D() {

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -110,12 +110,12 @@ void Polygon2D::_skeleton_bone_setup_changed() {
 }
 
 void Polygon2D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_TRANSFORM_CHANGED && !Engine::get_singleton()->is_editor_hint()) {
-		return; // Mesh recreation for NOTIFICATION_TRANSFORM_CHANGED is only needed in editor.
+	if (p_what == NOTIFICATION_GLOBAL_TRANSFORM_CHANGED && !Engine::get_singleton()->is_editor_hint()) {
+		return; // Mesh recreation for NOTIFICATION_GLOBAL_TRANSFORM_CHANGED is only needed in editor.
 	}
 
 	switch (p_what) {
-		case NOTIFICATION_TRANSFORM_CHANGED:
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED:
 		case NOTIFICATION_DRAW: {
 			if (polygon.size() < 3) {
 				return;

--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -127,7 +127,7 @@ void RemoteTransform2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if (!is_inside_tree()) {
 				break;
 			}
@@ -163,7 +163,7 @@ void RemoteTransform2D::set_use_global_coordinates(const bool p_enable) {
 	}
 
 	use_global_coordinates = p_enable;
-	set_notify_transform(use_global_coordinates);
+	set_notify_global_transform(use_global_coordinates);
 	set_notify_local_transform(!use_global_coordinates);
 	_update_remote();
 }
@@ -247,7 +247,7 @@ void RemoteTransform2D::_bind_methods() {
 }
 
 RemoteTransform2D::RemoteTransform2D() {
-	set_notify_transform(use_global_coordinates);
+	set_notify_global_transform(use_global_coordinates);
 	set_notify_local_transform(!use_global_coordinates);
 	set_hide_clip_children(true);
 }

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -676,7 +676,7 @@ void Skeleton2D::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if (is_physics_interpolated_and_enabled()) {
 				_ensure_update_interpolation_data();
 				if (Engine::get_singleton()->is_in_physics_frame()) {
@@ -836,7 +836,7 @@ void Skeleton2D::_bind_methods() {
 
 Skeleton2D::Skeleton2D() {
 	skeleton = RS::get_singleton()->skeleton_create();
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 	set_hide_clip_children(true);
 }
 

--- a/scene/3d/audio_listener_3d.cpp
+++ b/scene/3d/audio_listener_3d.cpp
@@ -87,7 +87,7 @@ void AudioListener3D::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			_request_listener_update();
 			if (doppler_tracking != DOPPLER_TRACKING_DISABLED) {
 				velocity_tracker->update_position(get_global_transform().origin);
@@ -186,7 +186,7 @@ Vector3 AudioListener3D::get_doppler_tracked_velocity() const {
 }
 
 AudioListener3D::AudioListener3D() {
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 	velocity_tracker.instantiate();
 }
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -274,7 +274,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 			AudioServer::get_singleton()->remove_listener_changed_callback(_listener_changed_cb, this);
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if (doppler_tracking != DOPPLER_TRACKING_DISABLED) {
 				velocity_tracker->update_position(get_global_transform().origin);
 			}
@@ -792,13 +792,13 @@ void AudioStreamPlayer3D::set_doppler_tracking(DopplerTracking p_tracking) {
 	doppler_tracking = p_tracking;
 
 	if (doppler_tracking != DOPPLER_TRACKING_DISABLED) {
-		set_notify_transform(true);
+		set_notify_global_transform(true);
 		velocity_tracker->set_track_physics_step(doppler_tracking == DOPPLER_TRACKING_PHYSICS_STEP);
 		if (is_inside_tree()) {
 			velocity_tracker->reset(get_global_transform().origin);
 		}
 	} else {
-		set_notify_transform(false);
+		set_notify_global_transform(false);
 	}
 }
 

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -231,7 +231,7 @@ void BoneAttachment3D::set_override_pose(bool p_override_pose) {
 	}
 
 	override_pose = p_override_pose;
-	set_notify_transform(override_pose);
+	set_notify_global_transform(override_pose);
 	set_process_internal(override_pose);
 	if (!override_pose && bone_idx >= 0) {
 		Skeleton3D *sk = get_skeleton();
@@ -287,7 +287,7 @@ void BoneAttachment3D::_notification(int p_what) {
 			_check_unbind();
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			_transform_changed();
 		} break;
 

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -215,7 +215,7 @@ void Camera3D::_notification(int p_what) {
 #endif
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 #if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
 			if (is_physics_interpolated_and_enabled()) {
 				if (!Engine::get_singleton()->is_in_physics_frame()) {
@@ -878,7 +878,7 @@ Camera3D::Camera3D() {
 	RenderingServer::get_singleton()->camera_set_cull_mask(camera, layers);
 	//active=false;
 	velocity_tracker.instantiate();
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 	set_disable_scale(true);
 }
 

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -1414,8 +1414,8 @@ void CPUParticles3D::_notification(int p_what) {
 			_update_internal();
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
-			Transform3D global_transform = get_global_transform();
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
+			const Transform3D global_transform = get_global_transform();
 			if (unlikely(global_transform.basis.determinant() == 0)) {
 				return;
 			}
@@ -1814,7 +1814,7 @@ void CPUParticles3D::_bind_methods() {
 }
 
 CPUParticles3D::CPUParticles3D() {
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 
 	multimesh = RenderingServer::get_singleton()->multimesh_create();
 	RenderingServer::get_singleton()->multimesh_set_visible_instances(multimesh, 0);

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -709,7 +709,7 @@ void GPUParticlesCollisionHeightField3D::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			RS::get_singleton()->particles_collision_height_field_update(_get_collision());
 		} break;
 	}

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -315,7 +315,7 @@ void Light3D::_update_visibility() {
 
 void Light3D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			update_configuration_warnings();
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED:

--- a/scene/3d/navigation/navigation_link_3d.cpp
+++ b/scene/3d/navigation/navigation_link_3d.cpp
@@ -254,7 +254,7 @@ void NavigationLink3D::_notification(int p_what) {
 			_link_enter_navigation_map();
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			_link_update_transform();
 		} break;
 
@@ -280,7 +280,7 @@ NavigationLink3D::NavigationLink3D() {
 	NavigationServer3D::get_singleton()->link_set_bidirectional(link, bidirectional);
 	NavigationServer3D::get_singleton()->link_set_enabled(link, enabled);
 
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 }
 
 NavigationLink3D::~NavigationLink3D() {

--- a/scene/3d/navigation/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation/navigation_obstacle_3d.cpp
@@ -112,7 +112,7 @@ void NavigationObstacle3D::_notification(int p_what) {
 		} break;
 
 #ifdef TOOLS_ENABLED
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			update_gizmos();
 		} break;
 #endif // TOOLS_ENABLED
@@ -229,7 +229,7 @@ NavigationObstacle3D::NavigationObstacle3D() {
 #endif // DEBUG_ENABLED
 
 #ifdef TOOLS_ENABLED
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 #endif // TOOLS_ENABLED
 }
 

--- a/scene/3d/navigation/navigation_region_3d.cpp
+++ b/scene/3d/navigation/navigation_region_3d.cpp
@@ -172,7 +172,7 @@ void NavigationRegion3D::_notification(int p_what) {
 			_region_enter_navigation_map();
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			_region_update_transform();
 		} break;
 
@@ -417,7 +417,7 @@ void NavigationRegion3D::_region_update_transform() {
 }
 
 NavigationRegion3D::NavigationRegion3D() {
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 
 	region = NavigationServer3D::get_singleton()->region_create();
 	NavigationServer3D::get_singleton()->region_set_owner_id(region, get_instance_id());

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -80,9 +80,9 @@ Node3DGizmo::Node3DGizmo() {
 
 void Node3D::_notify_dirty() {
 #ifdef TOOLS_ENABLED
-	if ((!data.gizmos.is_empty() || data.notify_transform) && !data.ignore_notification && !xform_change.in_list()) {
+	if ((!data.gizmos.is_empty() || data.notify_global_transform) && !data.ignore_notification && !xform_change.in_list()) {
 #else
-	if (data.notify_transform && !data.ignore_notification && !xform_change.in_list()) {
+	if (data.notify_global_transform && !data.ignore_notification && !xform_change.in_list()) {
 
 #endif
 		get_tree()->xform_change_list.add(&xform_change);
@@ -124,9 +124,9 @@ void Node3D::_propagate_transform_changed(Node3D *p_origin) {
 	}
 
 #ifdef TOOLS_ENABLED
-	if ((!data.gizmos.is_empty() || data.notify_transform) && !data.ignore_notification && !xform_change.in_list()) {
+	if ((!data.gizmos.is_empty() || data.notify_global_transform) && !data.ignore_notification && !xform_change.in_list()) {
 #else
-	if (data.notify_transform && !data.ignore_notification && !xform_change.in_list()) {
+	if (data.notify_global_transform && !data.ignore_notification && !xform_change.in_list()) {
 #endif
 		// SceneTree::xform_change_list is not thread safe to modify, and is read by the main thread when processings are done.
 		if (Thread::is_main_thread()) {
@@ -271,7 +271,7 @@ void Node3D::_notification(int p_what) {
 			data.inside_world = false;
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			ERR_THREAD_GUARD;
 
 #ifdef TOOLS_ENABLED
@@ -1269,14 +1269,14 @@ Vector3 Node3D::to_global(Vector3 p_local) const {
 	return get_global_transform().xform(p_local);
 }
 
-void Node3D::set_notify_transform(bool p_enabled) {
+void Node3D::set_notify_global_transform(bool p_enabled) {
 	ERR_THREAD_GUARD;
-	data.notify_transform = p_enabled;
+	data.notify_global_transform = p_enabled;
 }
 
-bool Node3D::is_transform_notification_enabled() const {
+bool Node3D::is_global_transform_notification_enabled() const {
 	ERR_READ_THREAD_GUARD_V(false);
-	return data.notify_transform;
+	return data.notify_global_transform;
 }
 
 void Node3D::set_notify_local_transform(bool p_enabled) {
@@ -1297,7 +1297,7 @@ void Node3D::force_update_transform() {
 	}
 	get_tree()->xform_change_list.remove(&xform_change);
 
-	notification(NOTIFICATION_TRANSFORM_CHANGED);
+	notification(NOTIFICATION_GLOBAL_TRANSFORM_CHANGED);
 }
 
 void Node3D::_update_visibility_parent(bool p_update_root) {
@@ -1482,8 +1482,12 @@ void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_notify_local_transform", "enable"), &Node3D::set_notify_local_transform);
 	ClassDB::bind_method(D_METHOD("is_local_transform_notification_enabled"), &Node3D::is_local_transform_notification_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_notify_transform", "enable"), &Node3D::set_notify_transform);
-	ClassDB::bind_method(D_METHOD("is_transform_notification_enabled"), &Node3D::is_transform_notification_enabled);
+	ClassDB::bind_method(D_METHOD("set_notify_global_transform", "enable"), &Node3D::set_notify_global_transform);
+	ClassDB::bind_method(D_METHOD("is_global_transform_notification_enabled"), &Node3D::is_global_transform_notification_enabled);
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("set_notify_transform", "enable"), &Node3D::set_notify_global_transform);
+	ClassDB::bind_method(D_METHOD("is_transform_notification_enabled"), &Node3D::is_global_transform_notification_enabled);
+#endif // DISABLE_DEPRECATED
 
 	ClassDB::bind_method(D_METHOD("rotate", "axis", "angle"), &Node3D::rotate);
 	ClassDB::bind_method(D_METHOD("global_rotate", "axis", "angle"), &Node3D::global_rotate);
@@ -1505,7 +1509,10 @@ void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("to_local", "global_point"), &Node3D::to_local);
 	ClassDB::bind_method(D_METHOD("to_global", "local_point"), &Node3D::to_global);
 
-	BIND_CONSTANT(NOTIFICATION_TRANSFORM_CHANGED);
+	BIND_CONSTANT(NOTIFICATION_GLOBAL_TRANSFORM_CHANGED);
+#ifndef DISABLE_DEPRECATED
+	BIND_CONSTANT(NOTIFICATION_TRANSFORM_CHANGED); // Alias for old name.
+#endif // DISABLE_DEPRECATED
 	BIND_CONSTANT(NOTIFICATION_ENTER_WORLD);
 	BIND_CONSTANT(NOTIFICATION_EXIT_WORLD);
 	BIND_CONSTANT(NOTIFICATION_VISIBILITY_CHANGED);
@@ -1550,7 +1557,7 @@ Node3D::Node3D() :
 
 	data.ignore_notification = false;
 	data.notify_local_transform = false;
-	data.notify_transform = false;
+	data.notify_global_transform = false;
 
 	data.visible = true;
 	data.disable_scale = false;

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -134,7 +134,7 @@ private:
 
 		bool ignore_notification : 1;
 		bool notify_local_transform : 1;
-		bool notify_transform : 1;
+		bool notify_global_transform : 1;
 
 		bool visible : 1;
 		bool disable_scale : 1;
@@ -232,7 +232,10 @@ protected:
 
 public:
 	enum {
-		NOTIFICATION_TRANSFORM_CHANGED = 2000, // Keep in sync with SceneTree.
+		NOTIFICATION_GLOBAL_TRANSFORM_CHANGED = 2000, // Keep in sync with SceneTree.
+#ifndef DISABLE_DEPRECATED
+		NOTIFICATION_TRANSFORM_CHANGED = NOTIFICATION_GLOBAL_TRANSFORM_CHANGED, // Alias for old name.
+#endif // DISABLE_DEPRECATED
 		NOTIFICATION_ENTER_WORLD = 41,
 		NOTIFICATION_EXIT_WORLD = 42,
 		NOTIFICATION_VISIBILITY_CHANGED = 43,
@@ -333,8 +336,12 @@ public:
 	Vector3 to_local(Vector3 p_global) const;
 	Vector3 to_global(Vector3 p_local) const;
 
-	void set_notify_transform(bool p_enabled);
-	bool is_transform_notification_enabled() const;
+	void set_notify_global_transform(bool p_enabled);
+	bool is_global_transform_notification_enabled() const;
+#ifndef DISABLE_DEPRECATED
+	void set_notify_transform(bool p_enabled) { set_notify_global_transform(p_enabled); }
+	bool is_transform_notification_enabled() const { return is_global_transform_notification_enabled(); }
+#endif // DISABLE_DEPRECATED
 
 	void set_notify_local_transform(bool p_enabled);
 	bool is_local_transform_notification_enabled() const;

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -41,7 +41,7 @@ Path3D::Path3D() {
 	SceneTree *st = SceneTree::get_singleton();
 	if (st && st->is_debugging_paths_hint()) {
 		debug_instance = RS::get_singleton()->instance_create();
-		set_notify_transform(true);
+		set_notify_global_transform(true);
 		_update_debug_mesh();
 	}
 }
@@ -77,7 +77,7 @@ void Path3D::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if (is_inside_tree()) {
 				if (debug_instance.is_valid()) {
 					RS::get_singleton()->instance_set_transform(debug_instance, get_global_transform());

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -94,7 +94,7 @@ void CollisionObject3D::_notification(int p_what) {
 			update_configuration_warnings();
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if (only_update_transform_changes) {
 				return;
 			}
@@ -719,7 +719,7 @@ uint32_t CollisionObject3D::shape_find_owner(int p_shape_index) const {
 CollisionObject3D::CollisionObject3D(RID p_rid, bool p_area) {
 	rid = p_rid;
 	area = p_area;
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 	_define_ancestry(AncestralClass::COLLISION_OBJECT_3D);
 
 	if (p_area) {
@@ -756,7 +756,7 @@ PackedStringArray CollisionObject3D::get_configuration_warnings() const {
 CollisionObject3D::CollisionObject3D() {
 	_define_ancestry(AncestralClass::COLLISION_OBJECT_3D);
 
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 	//owner=
 
 	//set_transform_notify(true);

--- a/scene/3d/physics/joints/joint_3d.cpp
+++ b/scene/3d/physics/joints/joint_3d.cpp
@@ -236,7 +236,7 @@ void Joint3D::_bind_methods() {
 }
 
 Joint3D::Joint3D() {
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 	joint = PhysicsServer3D::get_singleton()->joint_create();
 }
 

--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -782,7 +782,7 @@ void PhysicalBone3D::_notification(int p_what) {
 			PhysicsServer3D::get_singleton()->joint_clear(joint);
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if (Engine::get_singleton()->is_editor_hint()) {
 				update_offset();
 			}

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -285,7 +285,7 @@ void SoftBody3D::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if (Engine::get_singleton()->is_editor_hint()) {
 				_reset_points_offsets();
 				return;
@@ -293,11 +293,11 @@ void SoftBody3D::_notification(int p_what) {
 
 			PhysicsServer3D::get_singleton()->soft_body_set_transform(physics_rid, get_global_transform());
 
-			set_notify_transform(false);
+			set_notify_global_transform(false);
 			// Required to be top level with Transform at center of world in order to modify RenderingServer only to support custom Transform
 			set_as_top_level(true);
 			set_transform(Transform3D());
-			set_notify_transform(true);
+			set_notify_global_transform(true);
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {

--- a/scene/3d/remote_transform_3d.cpp
+++ b/scene/3d/remote_transform_3d.cpp
@@ -118,7 +118,7 @@ void RemoteTransform3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if (!is_inside_tree()) {
 				break;
 			}
@@ -155,7 +155,7 @@ void RemoteTransform3D::set_use_global_coordinates(const bool p_enable) {
 
 	use_global_coordinates = p_enable;
 
-	set_notify_transform(use_global_coordinates);
+	set_notify_global_transform(use_global_coordinates);
 	set_notify_local_transform(!use_global_coordinates);
 	_update_remote();
 }
@@ -239,6 +239,6 @@ void RemoteTransform3D::_bind_methods() {
 }
 
 RemoteTransform3D::RemoteTransform3D() {
-	set_notify_transform(use_global_coordinates);
+	set_notify_global_transform(use_global_coordinates);
 	set_notify_local_transform(!use_global_coordinates);
 }

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -94,7 +94,7 @@ void VisualInstance3D::_notification(int p_what) {
 			_update_visibility();
 		} break;
 
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			// ToDo : Can we turn off notify transform for physics interpolated cases?
 			if (_is_vi_visible() && !(is_inside_tree() && get_tree()->is_physics_interpolation_enabled()) && !_is_using_identity_transform()) {
 				// Physics interpolation global off, always send.
@@ -207,7 +207,7 @@ VisualInstance3D::VisualInstance3D() {
 
 	instance = RenderingServer::get_singleton()->instance_create();
 	RenderingServer::get_singleton()->instance_attach_object_instance_id(instance, get_instance_id());
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 }
 
 VisualInstance3D::~VisualInstance3D() {

--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -749,7 +749,7 @@ void XROrigin3D::_set_current(bool p_enabled, bool p_update_others) {
 
 	// Notify us of any transform changes
 	set_notify_local_transform(current);
-	set_notify_transform(current);
+	set_notify_global_transform(current);
 
 	// update XRServer with our current position
 	if (current) {
@@ -832,7 +832,7 @@ void XROrigin3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if (current && !Engine::get_singleton()->is_editor_hint() && !is_physics_interpolated_and_enabled()) {
 				xr_server->set_world_origin(get_global_transform());
 			}

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5723,7 +5723,7 @@ void Tree::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_RESIZED:
-		case NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_GLOBAL_TRANSFORM_CHANGED: {
 			if (popup_edited_item != nullptr && popup_editor->is_visible()) {
 				Rect2 rect = _get_item_focus_rect(popup_edited_item);
 
@@ -7720,7 +7720,7 @@ Tree::Tree() {
 	text_editor->connect(SceneStringName(gui_input), callable_mp(this, &Tree::_text_editor_gui_input));
 	popup_editor->connect("popup_hide", callable_mp(this, &Tree::_text_editor_popup_modal_close));
 
-	set_notify_transform(true);
+	set_notify_global_transform(true);
 
 	set_mouse_filter(MOUSE_FILTER_STOP);
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1150,7 +1150,7 @@ void CanvasItem::draw_char_outline(RequiredParam<Font> rp_font, const Point2 &p_
 }
 
 void CanvasItem::_notify_transform_deferred() {
-	if (is_inside_tree() && notify_transform && !xform_change.in_list()) {
+	if (is_inside_tree() && notify_global_transform && !xform_change.in_list()) {
 		get_tree()->xform_change_list.add(&xform_change);
 	}
 }
@@ -1170,7 +1170,7 @@ void CanvasItem::_notify_transform(CanvasItem *p_node) {
 
 	p_node->_set_global_invalid(true);
 
-	if (p_node->notify_transform && !p_node->xform_change.in_list()) {
+	if (p_node->notify_global_transform && !p_node->xform_change.in_list()) {
 		if (!p_node->block_transform_notify) {
 			if (p_node->is_inside_tree()) {
 				if (is_accessible_from_caller_thread()) {
@@ -1378,7 +1378,7 @@ void CanvasItem::force_update_transform() {
 
 	get_tree()->xform_change_list.remove(&xform_change);
 
-	notification(NOTIFICATION_TRANSFORM_CHANGED);
+	notification(NOTIFICATION_GLOBAL_TRANSFORM_CHANGED);
 }
 
 void CanvasItem::_validate_property(PropertyInfo &p_property) const {
@@ -1537,8 +1537,12 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_notify_local_transform", "enable"), &CanvasItem::set_notify_local_transform);
 	ClassDB::bind_method(D_METHOD("is_local_transform_notification_enabled"), &CanvasItem::is_local_transform_notification_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_notify_transform", "enable"), &CanvasItem::set_notify_transform);
-	ClassDB::bind_method(D_METHOD("is_transform_notification_enabled"), &CanvasItem::is_transform_notification_enabled);
+	ClassDB::bind_method(D_METHOD("set_notify_global_transform", "enable"), &CanvasItem::set_notify_global_transform);
+	ClassDB::bind_method(D_METHOD("is_global_transform_notification_enabled"), &CanvasItem::is_global_transform_notification_enabled);
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("set_notify_transform", "enable"), &CanvasItem::set_notify_global_transform);
+	ClassDB::bind_method(D_METHOD("is_transform_notification_enabled"), &CanvasItem::is_global_transform_notification_enabled);
+#endif // DISABLE_DEPRECATED
 
 	ClassDB::bind_method(D_METHOD("force_update_transform"), &CanvasItem::force_update_transform);
 
@@ -1597,7 +1601,10 @@ void CanvasItem::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("hidden"));
 	ADD_SIGNAL(MethodInfo("item_rect_changed"));
 
-	BIND_CONSTANT(NOTIFICATION_TRANSFORM_CHANGED);
+	BIND_CONSTANT(NOTIFICATION_GLOBAL_TRANSFORM_CHANGED);
+#ifndef DISABLE_DEPRECATED
+	BIND_CONSTANT(NOTIFICATION_TRANSFORM_CHANGED); // Alias for old name.
+#endif // DISABLE_DEPRECATED
 	BIND_CONSTANT(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
 	BIND_CONSTANT(NOTIFICATION_DRAW);
 	BIND_CONSTANT(NOTIFICATION_VISIBILITY_CHANGED);
@@ -1665,23 +1672,23 @@ bool CanvasItem::is_local_transform_notification_enabled() const {
 	return notify_local_transform;
 }
 
-void CanvasItem::set_notify_transform(bool p_enable) {
+void CanvasItem::set_notify_global_transform(bool p_enable) {
 	ERR_THREAD_GUARD;
-	if (notify_transform == p_enable) {
+	if (notify_global_transform == p_enable) {
 		return;
 	}
 
-	notify_transform = p_enable;
+	notify_global_transform = p_enable;
 
-	if (notify_transform && is_inside_tree()) {
+	if (notify_global_transform && is_inside_tree()) {
 		// This ensures that invalid globals get resolved, so notifications can be received.
 		_ALLOW_DISCARD_ get_global_transform();
 	}
 }
 
-bool CanvasItem::is_transform_notification_enabled() const {
+bool CanvasItem::is_global_transform_notification_enabled() const {
 	ERR_READ_THREAD_GUARD_V(false);
-	return notify_transform;
+	return notify_global_transform;
 }
 
 int CanvasItem::get_canvas_layer() const {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -124,7 +124,7 @@ private:
 	bool behind = false;
 	bool use_parent_material = false;
 	bool notify_local_transform = false;
-	bool notify_transform = false;
+	bool notify_global_transform = false;
 	bool hide_clip_children = false;
 #ifdef TOOLS_ENABLED
 	mutable HashMap<StringName, StringName> instance_parameter_cache;
@@ -232,7 +232,10 @@ protected:
 
 public:
 	enum {
-		NOTIFICATION_TRANSFORM_CHANGED = 2000, // Keep in sync with SceneTree.
+		NOTIFICATION_GLOBAL_TRANSFORM_CHANGED = 2000, // Keep in sync with SceneTree.
+#ifndef DISABLE_DEPRECATED
+		NOTIFICATION_TRANSFORM_CHANGED = NOTIFICATION_GLOBAL_TRANSFORM_CHANGED, // Alias for old name.
+#endif // DISABLE_DEPRECATED
 		NOTIFICATION_DRAW = 30,
 		NOTIFICATION_VISIBILITY_CHANGED = 31,
 		NOTIFICATION_ENTER_CANVAS = 32,
@@ -421,8 +424,12 @@ public:
 	void set_notify_local_transform(bool p_enable);
 	bool is_local_transform_notification_enabled() const;
 
-	void set_notify_transform(bool p_enable);
-	bool is_transform_notification_enabled() const;
+	void set_notify_global_transform(bool p_enable);
+	bool is_global_transform_notification_enabled() const;
+#ifndef DISABLE_DEPRECATED
+	void set_notify_transform(bool p_enabled) { set_notify_global_transform(p_enabled); }
+	bool is_transform_notification_enabled() const { return is_global_transform_notification_enabled(); }
+#endif // DISABLE_DEPRECATED
 
 	void force_update_transform();
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -206,7 +206,7 @@ void SceneTree::flush_transform_notifications() {
 		SelfList<Node> *nx = n->next();
 		xform_change_list.remove(n);
 		n = nx;
-		node->notification(NOTIFICATION_TRANSFORM_CHANGED);
+		node->notification(NOTIFICATION_GLOBAL_TRANSFORM_CHANGED);
 	}
 }
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -290,7 +290,7 @@ protected:
 public:
 	enum {
 		// Keep in sync with CanvasItem and Node3D.
-		NOTIFICATION_TRANSFORM_CHANGED = 2000
+		NOTIFICATION_GLOBAL_TRANSFORM_CHANGED = 2000
 	};
 
 	enum GroupCallFlags {

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_ccdik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_ccdik.cpp
@@ -234,7 +234,7 @@ void SkeletonModification2DCCDIK::_execute_ccdik_joint(int p_joint_idx, Node2D *
 	// Set the local pose override, and to make sure child bones are also updated, set the transform of the bone.
 	stack->skeleton->set_bone_local_pose_override(ccdik_data.bone_idx, operation_transform, stack->strength, true);
 	operation_bone->set_transform(operation_transform);
-	operation_bone->notification(operation_bone->NOTIFICATION_TRANSFORM_CHANGED);
+	operation_bone->notification(operation_bone->NOTIFICATION_GLOBAL_TRANSFORM_CHANGED);
 }
 
 void SkeletonModification2DCCDIK::_setup_modification(SkeletonModificationStack2D *p_stack) {


### PR DESCRIPTION
I briefly mentioned this here: https://github.com/godotengine/godot/pull/87440#discussion_r1996861675

Now the global transform notification has "global" or "GLOBAL" in its name, matching `global_transform` and such, mirroring the "local" versions. The old names are kept as deprecated aliases for compatibility.