### PR TITLE
Optimize `ClassDB::get_direct_inheriters_from_class`

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -298,7 +298,7 @@ void ClassDB::get_direct_inheriters_from_class(const StringName &p_class, List<S
 	OBJTYPE_RLOCK;
 
 	for (const KeyValue<StringName, ClassInfo> &E : classes) {
-		if (E.key != p_class && _get_parent_class(E.key) == p_class) {
+		if (E.value.inherits == p_class) {
 			p_classes->push_back(E.key);
 		}
 	}


### PR DESCRIPTION
This function shows a small hot spot in editor cold startup, it does an extra hashmap lookup to obtain value while we already know the value should be `E.value`.
<details>
<summary>Before</summary>

![屏幕截图 2025-03-19 170313](https://github.com/user-attachments/assets/2c301aa4-8c43-49cd-9a9e-e6bde52d460c)
</details>

<details>
<summary>After</summary>

![屏幕截图 2025-03-19 170056](https://github.com/user-attachments/assets/3b5cce2c-4125-4472-9f07-15c49253052a)
</details>

To reproduce this, one need to delete `editor_data/cache/editor_doc_cache-4.5.res`, this function is used in editor doc generation.
