### PR TITLE
LineEdit: Fix selection rectangle when text overflows container

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1202,7 +1202,8 @@ void LineEdit::_notification(int p_what) {
 					if (rect.position.x < x_ofs) {
 						rect.size.x -= (x_ofs - rect.position.x);
 						rect.position.x = x_ofs;
-					} else if (rect.position.x + rect.size.x > ofs_max) {
+					}
+					if (rect.position.x + rect.size.x > ofs_max) {
 						rect.size.x = ofs_max - rect.position.x;
 					}
 					RenderingServer::get_singleton()->canvas_item_add_rect(ci, rect, selection_color);


### PR DESCRIPTION
Close https://github.com/godotengine/godot/issues/104257
Before : 
![select](https://github.com/user-attachments/assets/05ec9e79-ad84-4227-9c78-e933586724fd)
After :
![select2](https://github.com/user-attachments/assets/3dedca5f-2633-4aff-9415-38f518fde205)
