### PR TITLE
Fix `Control.set_position` resizes offsets/anchors (reverted)

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -867,6 +867,13 @@ void Control::_compute_offsets(Rect2 p_rect, const real_t p_anchors[4], real_t (
 	r_offsets[3] = p_rect.position.y + p_rect.size.y - (p_anchors[3] * parent_rect_size.y);
 }
 
+void Control::_compute_edge_positions(Rect2 p_rect, real_t (&r_edge_positions)[4]) {
+	for (int i = 0; i < 4; i++) {
+		real_t area = p_rect.size[i & 1];
+		r_edge_positions[i] = data.offset[i] + (data.anchor[i] * area);
+	}
+}
+
 /// Presets and layout modes.
 
 void Control::_set_layout_mode(LayoutMode p_mode) {
@@ -1392,10 +1399,13 @@ void Control::set_position(const Point2 &p_point, bool p_keep_offsets) {
 	}
 #endif // TOOLS_ENABLED
 
+	real_t edge_pos[4];
+	_compute_edge_positions(get_parent_anchorable_rect(), edge_pos);
+	Size2 offset_size(edge_pos[2] - edge_pos[0], edge_pos[3] - edge_pos[1]);
 	if (p_keep_offsets) {
-		_compute_anchors(Rect2(p_point, data.size_cache), data.offset, data.anchor);
+		_compute_anchors(Rect2(p_point, offset_size), data.offset, data.anchor);
 	} else {
-		_compute_offsets(Rect2(p_point, data.size_cache), data.anchor, data.offset);
+		_compute_offsets(Rect2(p_point, offset_size), data.anchor, data.offset);
 	}
 	_size_changed();
 }
@@ -1682,14 +1692,8 @@ Size2 Control::get_combined_minimum_size() const {
 
 void Control::_size_changed() {
 	Rect2 parent_rect = get_parent_anchorable_rect();
-
 	real_t edge_pos[4];
-
-	for (int i = 0; i < 4; i++) {
-		real_t area = parent_rect.size[i & 1];
-		edge_pos[i] = data.offset[i] + (data.anchor[i] * area);
-	}
-
+	_compute_edge_positions(parent_rect, edge_pos);
 	Point2 new_pos_cache = Point2(edge_pos[0], edge_pos[1]);
 	Size2 new_size_cache = Point2(edge_pos[2], edge_pos[3]) - new_pos_cache;
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -300,6 +300,7 @@ private:
 
 	void _compute_offsets(Rect2 p_rect, const real_t p_anchors[4], real_t (&r_offsets)[4]);
 	void _compute_anchors(Rect2 p_rect, const real_t p_offsets[4], real_t (&r_anchors)[4]);
+	void _compute_edge_positions(Rect2 p_rect, real_t (&r_edge_positions)[4]);
 
 	void _set_layout_mode(LayoutMode p_mode);
 	void _update_layout_mode();

--- a/tests/scene/test_control.h
+++ b/tests/scene/test_control.h
@@ -990,6 +990,38 @@ TEST_CASE("[SceneTree][Control] Anchoring") {
 	memdelete(test_control);
 }
 
+TEST_CASE("[SceneTree][Control] Set position does not cause size side-effects") {
+	Control *test_control = memnew(Control);
+	test_control->set_size(Size2(1, 1));
+	test_control->set_custom_minimum_size(Size2(2, 2));
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(test_control);
+
+	SUBCASE("Shrinks after setting position and smaller custom minimum size (without keeping offsets)") {
+		test_control->set_position(Point2(10, 10), false);
+		SceneTree::get_singleton()->process(0);
+
+		test_control->set_custom_minimum_size(Size2(0, 0));
+		SceneTree::get_singleton()->process(0);
+		CHECK_MESSAGE(
+				test_control->get_size().is_equal_approx(Vector2(1, 1)),
+				"Should shrink to original size after setting a smaller custom minimum size.");
+	}
+
+	SUBCASE("Shrinks after setting position and smaller custom minimum size (while keeping offsets)") {
+		test_control->set_position(Point2(10, 10), true);
+		SceneTree::get_singleton()->process(0);
+
+		test_control->set_custom_minimum_size(Size2(0, 0));
+		SceneTree::get_singleton()->process(0);
+		CHECK_MESSAGE(
+				test_control->get_size().is_equal_approx(Vector2(1, 1)),
+				"Should shrink to original size after setting a smaller custom minimum size.");
+	}
+
+	memdelete(test_control);
+}
+
 TEST_CASE("[SceneTree][Control] Custom minimum size") {
 	Control *test_control = memnew(Control);
 	test_control->set_custom_minimum_size(Size2(4, 2));


### PR DESCRIPTION
Fixes #100536
Currently, the Control set_position method uses the object's "size_cache" field in order to recompute its anchors/offsets. However, the size_cache is set in _size_changed() to be at least as large as the combined minimum size of the Control, meaning that setting its position while the combined minimum size is larger than the the bounding rectangle given by the offsets and anchors essentially resizes it.
This makes the Control unable to automatically shrink as seen with the GraphNode in the original issue this addresses. The issue focused mostly on the GraphEdit and GraphNode, but it can actually occur with other kinds of object as illustrated here (the rectangle on the left is a HBoxContainer):

https://github.com/user-attachments/assets/c6ec0e65-eef3-4a58-b5fe-c6b0bcd7010f

To fix this, I made it so set_position is based solely on the size obtained through the offsets and anchors instead of the size_cache:

https://github.com/user-attachments/assets/e1a0c836-8801-4d2e-a586-1f515c51cc2c

I have also added a new test case to make sure Control objects are able to shrink in this scenario.