### PR TITLE
Shortcut should not be accepted if focus_owner is Tree

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1034,6 +1034,11 @@ void EditorProperty::shortcut_input(const Ref<InputEvent> &p_event) {
 
 	const Ref<InputEventKey> k = p_event;
 
+	Control *focus_owner = get_viewport()->gui_get_focus_owner();
+	if (focus_owner && Object::cast_to<Tree>(focus_owner)) {
+		return;
+	}
+
 	if (k.is_valid() && k->is_pressed()) {
 		if (ED_IS_SHORTCUT("property_editor/copy_value", p_event)) {
 			menu_option(MENU_COPY_VALUE);


### PR DESCRIPTION
Fixes #104313, fixes #99524, fixes #88234

The reason why the copy-paste fail is because the even is captured by Editor Inspector. 
Shortcut should not be accepted in **void EditorProperty::shortcut_input(const Ref<InputEvent> &p_event)** when **focus_owner** is **Tree**



