### PR TITLE
Tests: Refactor handling of module .cpp tests

### DIFF
--- a/modules/SCsub
+++ b/modules/SCsub
@@ -76,7 +76,17 @@ register_module_types = env.CommandNoCache(
 )
 
 
-test_headers = []
+# Handle module tests .cpp files in a dedicated env.
+if env["tests"]:
+    env_module_tests = env_modules.Clone()
+    env_module_tests.test_headers = []
+    # Copied from tests/SCsub.
+    if env["platform"] == "windows":
+        env_module_tests.Append(CPPDEFINES=[("DOCTEST_THREAD_LOCAL", "")])
+    if env["disable_exceptions"]:
+        env_module_tests.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])
+
+
 # libmodule_<name>.a for each active module.
 for name, path in env.module_list.items():
     env.modules_sources = []
@@ -89,12 +99,16 @@ for name, path in env.module_list.items():
     env.Prepend(LIBS=[lib])
 
     if env["tests"]:
-        # Lookup potential headers in `tests` subfolder.
+        # Lookup potential headers and source files in `tests` subfolder.
         import glob
 
         module_tests = sorted(glob.glob(os.path.join(base_path, "tests", "*.h")))
+        module_tests_cpp = sorted(glob.glob(os.path.join(base_path, "tests", "*.cpp")))
         if module_tests != []:
-            test_headers += module_tests
+            env_module_tests.test_headers += module_tests
+        if module_tests_cpp != []:
+            lib = env_module_tests.add_library("module_%s_tests" % name, module_tests_cpp)
+            env.Prepend(LIBS=[lib])
 
 
 # Generate header to be included in `tests/test_main.cpp` to run module-specific tests.
@@ -106,7 +120,7 @@ if env["tests"]:
             for header in headers:
                 file.write(f'#include "{header}"\n')
 
-    env.CommandNoCache("modules_tests.gen.h", test_headers, env.Run(modules_tests_builder))
+    env.CommandNoCache("modules_tests.gen.h", env_module_tests.test_headers, env.Run(modules_tests_builder))
 
 # libmodules.a with only register_module_types.
 # Must be last so that all libmodule_<name>.a libraries are on the right side

--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -25,5 +25,5 @@ if env.editor_build:
 
 
 if env["tests"]:
+    # GDScriptTestRunner requires some injection in GDScriptLanguage.
     env_gdscript.Append(CPPDEFINES=["TESTS_ENABLED"])
-    env_gdscript.add_source_files(env.modules_sources, "./tests/*.cpp")

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -45,10 +45,6 @@
 #endif
 #endif // TOOLS_ENABLED
 
-#ifdef TESTS_ENABLED
-#include "tests/test_gdscript.h"
-#endif
-
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
 
@@ -61,10 +57,6 @@
 #include "core/config/engine.h"
 #endif
 #endif // TOOLS_ENABLED
-
-#ifdef TESTS_ENABLED
-#include "tests/test_macros.h"
-#endif
 
 GDScriptLanguage *script_language_gd = nullptr;
 Ref<ResourceFormatLoaderGDScript> resource_loader_gd;
@@ -196,31 +188,3 @@ void uninitialize_gdscript_module(ModuleInitializationLevel p_level) {
 	}
 #endif // TOOLS_ENABLED
 }
-
-#ifdef TESTS_ENABLED
-void test_tokenizer() {
-	GDScriptTests::test(GDScriptTests::TestType::TEST_TOKENIZER);
-}
-
-void test_tokenizer_buffer() {
-	GDScriptTests::test(GDScriptTests::TestType::TEST_TOKENIZER_BUFFER);
-}
-
-void test_parser() {
-	GDScriptTests::test(GDScriptTests::TestType::TEST_PARSER);
-}
-
-void test_compiler() {
-	GDScriptTests::test(GDScriptTests::TestType::TEST_COMPILER);
-}
-
-void test_bytecode() {
-	GDScriptTests::test(GDScriptTests::TestType::TEST_BYTECODE);
-}
-
-REGISTER_TEST_COMMAND("gdscript-tokenizer", &test_tokenizer);
-REGISTER_TEST_COMMAND("gdscript-tokenizer-buffer", &test_tokenizer_buffer);
-REGISTER_TEST_COMMAND("gdscript-parser", &test_parser);
-REGISTER_TEST_COMMAND("gdscript-compiler", &test_compiler);
-REGISTER_TEST_COMMAND("gdscript-bytecode", &test_bytecode);
-#endif

--- a/modules/gdscript/tests/register_test_commands.cpp
+++ b/modules/gdscript/tests/register_test_commands.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  register_test_commands.cpp                                            */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,62 +28,32 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#include "test_gdscript.h"
 
-#include "crypto_mbedtls.h"
-#include "dtls_server_mbedtls.h"
-#include "packet_peer_mbed_dtls.h"
-#include "stream_peer_mbedtls.h"
+#include "tests/test_macros.h"
 
-#include "core/config/project_settings.h"
-
-#if MBEDTLS_VERSION_MAJOR >= 3
-#include <psa/crypto.h>
-#endif
-
-static bool godot_mbedtls_initialized = false;
-
-void initialize_mbedtls_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-
-	GLOBAL_DEF("network/tls/enable_tls_v1.3", true);
-
-#if MBEDTLS_VERSION_MAJOR >= 3
-	int status = psa_crypto_init();
-	ERR_FAIL_COND_MSG(status != PSA_SUCCESS, "Failed to initialize psa crypto. The mbedTLS modules will not work.");
-#endif
-
-#ifdef DEBUG_ENABLED
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		mbedtls_debug_set_threshold(1);
-	}
-#endif
-
-	godot_mbedtls_initialized = true;
-
-	CryptoMbedTLS::initialize_crypto();
-	StreamPeerMbedTLS::initialize_tls();
-	PacketPeerMbedDTLS::initialize_dtls();
-	DTLSServerMbedTLS::initialize();
+void test_tokenizer() {
+	GDScriptTests::test(GDScriptTests::TestType::TEST_TOKENIZER);
 }
 
-void uninitialize_mbedtls_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-
-	if (!godot_mbedtls_initialized) {
-		return;
-	}
-
-#if MBEDTLS_VERSION_MAJOR >= 3
-	mbedtls_psa_crypto_free();
-#endif
-
-	DTLSServerMbedTLS::finalize();
-	PacketPeerMbedDTLS::finalize_dtls();
-	StreamPeerMbedTLS::finalize_tls();
-	CryptoMbedTLS::finalize_crypto();
+void test_tokenizer_buffer() {
+	GDScriptTests::test(GDScriptTests::TestType::TEST_TOKENIZER_BUFFER);
 }
+
+void test_parser() {
+	GDScriptTests::test(GDScriptTests::TestType::TEST_PARSER);
+}
+
+void test_compiler() {
+	GDScriptTests::test(GDScriptTests::TestType::TEST_COMPILER);
+}
+
+void test_bytecode() {
+	GDScriptTests::test(GDScriptTests::TestType::TEST_BYTECODE);
+}
+
+REGISTER_TEST_COMMAND("gdscript-tokenizer", &test_tokenizer);
+REGISTER_TEST_COMMAND("gdscript-tokenizer-buffer", &test_tokenizer_buffer);
+REGISTER_TEST_COMMAND("gdscript-parser", &test_parser);
+REGISTER_TEST_COMMAND("gdscript-compiler", &test_compiler);
+REGISTER_TEST_COMMAND("gdscript-bytecode", &test_bytecode);

--- a/modules/jsonrpc/SCsub
+++ b/modules/jsonrpc/SCsub
@@ -6,10 +6,3 @@ Import("env_modules")
 
 env_jsonrpc = env_modules.Clone()
 env_jsonrpc.add_source_files(env.modules_sources, "*.cpp")
-
-if env["tests"]:
-    env_jsonrpc.Append(CPPDEFINES=["TESTS_ENABLED"])
-    env_jsonrpc.add_source_files(env.modules_sources, "./tests/*.cpp")
-
-    if env["disable_exceptions"]:
-        env_jsonrpc.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])

--- a/modules/mbedtls/SCsub
+++ b/modules/mbedtls/SCsub
@@ -137,14 +137,6 @@ if env["builtin_mbedtls"]:
 module_obj = []
 
 env_mbed_tls.add_source_files(module_obj, "*.cpp")
-
-if env["tests"]:
-    env_mbed_tls.Append(CPPDEFINES=["TESTS_ENABLED"])
-    env_mbed_tls.add_source_files(module_obj, "./tests/*.cpp")
-
-    if env["disable_exceptions"]:
-        env_mbed_tls.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])
-
 env.modules_sources += module_obj
 
 # Needed to force rebuilding the module files when the thirdparty library is updated.

--- a/modules/multiplayer/SCsub
+++ b/modules/multiplayer/SCsub
@@ -5,18 +5,7 @@ Import("env")
 Import("env_modules")
 
 env_mp = env_modules.Clone()
-
-module_obj = []
-env_mp.add_source_files(module_obj, "*.cpp")
+env_mp.add_source_files(env.modules_sources, "*.cpp")
 
 if env.editor_build:
-    env_mp.add_source_files(module_obj, "editor/*.cpp")
-
-env.modules_sources += module_obj
-
-if env["tests"]:
-    env_mp.Append(CPPDEFINES=["TESTS_ENABLED"])
-    env_mp.add_source_files(env.modules_sources, "./tests/*.cpp")
-
-    if env["disable_exceptions"]:
-        env_mp.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])
+    env_mp.add_source_files(env.modules_sources, "editor/*.cpp")


### PR DESCRIPTION
They are now centralized in `modules/SCsub` and compiled in `lib<name>_tests` libraries.

So for most modules, adding new tests (whether .h or .cpp) just implies adding files in the `tests` subfolder of their module, and the rest is automatic.

The only exception is GDScript as its test suite is a bit more intrusive and requires some custom code in GDScriptLanguage and the LSP.