### PR TITLE
Fix issue of `AnimationPlayer` hiding bezier editor when re-selecting it

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -3934,7 +3934,7 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim, bool p_re
 	marker_edit->set_animation(p_anim, read_only);
 	marker_edit->set_play_position(timeline->get_play_position());
 
-	_cancel_bezier_edit();
+	_check_bezier_exist();
 	_update_tracks();
 
 	if (animation.is_valid()) {
@@ -3963,7 +3963,14 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim, bool p_re
 			}
 		}
 
-		_check_bezier_exist();
+		if (bezier_edit->is_visible()) {
+			for (int i = 0; i < animation->get_track_count(); ++i) {
+				if (animation->track_get_type(i) == Animation::TrackType::TYPE_BEZIER) {
+					_bezier_edit(i);
+					break;
+				}
+			}
+		}
 	} else {
 		hscroll->hide();
 		edit->set_disabled(true);
@@ -3984,10 +3991,12 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim, bool p_re
 
 void AnimationTrackEditor::_check_bezier_exist() {
 	bool is_exist = false;
-	for (int i = 0; i < animation->get_track_count(); i++) {
-		if (animation->track_get_type(i) == Animation::TrackType::TYPE_BEZIER) {
-			is_exist = true;
-			break;
+	if (animation.is_valid()) {
+		for (int i = 0; i < animation->get_track_count(); i++) {
+			if (animation->track_get_type(i) == Animation::TrackType::TYPE_BEZIER) {
+				is_exist = true;
+				break;
+			}
 		}
 	}
 	if (is_exist) {


### PR DESCRIPTION
Fixes #102654.

This fixes the issue of the Animation pane always switching away from the bezier view when clicking an `AnimationPlayer` instance, or when selecting another animation in the same `AnimationPlayer` instance.

This is achieved by swapping out the current use of `_cancel_bezier_edit()` in `AnimationTrackEditor::set_animation` with `_check_bezier_exist()` instead, which only closes the bezier view if there are no bezier tracks in the new animation, and then we call `_bezier_edit` on the first bezier track we find in the potentially new animation, to update the interface.

The `_check_bezier_exist()` method had to be slightly modified to be able to deal with an invalid `animation` reference as well.

Here's what it looked like before:

https://github.com/user-attachments/assets/35a0f996-2761-48d8-aecf-fc1d078227e8

Here's what it looks like with this PR:

https://github.com/user-attachments/assets/2746b6ab-bde8-4480-a84f-1b87e5731e8d