### PR TITLE
Use `LocalVector` buckets for `StringName`, optimizing by up to 10%

### DIFF
--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -49,9 +49,8 @@ class StringName {
 		uint32_t debug_references = 0;
 #endif
 
+		uint32_t index_in_bucket = 0;
 		uint32_t hash = 0;
-		_Data *prev = nullptr;
-		_Data *next = nullptr;
 		_Data() {}
 	};
 
@@ -134,10 +133,6 @@ public:
 
 		return String();
 	}
-
-	static StringName search(const char *p_name);
-	static StringName search(const char32_t *p_name);
-	static StringName search(const String &p_name);
 
 	struct AlphCompare {
 		template <typename LT, typename RT>


### PR DESCRIPTION
If I haven't made any mistakes, this change can speed up `Node` creation by ~10% (see benchmarks).
The changes should carry over to many other parts of the engine that are relying on `StringName`.

## Explanation
The slowest part of code is often RAM cache misses, costing several hundred clock cycles per miss[^1]. It is therefore important to localize memory in a program, to reduce the number of cache misses. This is the main reason why linked lists are slow on modern CPUs.

`StringName::_Data` is currently implemented as a linked lists. This makes looking up entries very slow. I localized access, which sped up looking up `StringName` entries immensely.

Unfortunately, `StringName::_Data` cannot be fully localized because the pointer of existing `StringName` instances must not be invalidated.
However, it is still possible to localize surrogates for equality, namely the `hash`. Only when the `hash` is equal do we need to dereference more data, which should be extremely rare on account of few collisions in `2^32` possible hash values.

By these changes, `StringName` creation must only dereference the `StringName` entry table, the relevant `LocalVector` buffer, and usually only a single `_Data` and its `String` or `const char *`. Before, the table would be dereferenced, and every single `_Data` in the respective index' linked list (usually 2 to 7).
`LocalVector` resizes cost a bit of performance on the first few accesses of the table, but should even out over time because the buffer is never shrunk, only grown when needed.

## Profiling and Benchmark

I started by trying to optimize something else, and ended up profiling `Node` creation:
```c++
	Node *parent = memnew(Node);

	auto t0 = std::chrono::high_resolution_clock::now();
	for (int i = 0; i < 2000000; i ++) {
		Node *child = memnew(Node);
		parent->add_child(child);
	}
	auto t1 = std::chrono::high_resolution_clock::now();
	std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
```

I noticed that `StringName` constructors took a combined 45% of CPU time in this code:
```
1.14 s  28,6 %	0 s	   StringName::StringName(char const*, bool)
581.00 ms  14,6 %	0 s	   StringName::StringName(String const&, bool)
```

 I stared at the detailed profile results for a while:
```
670.00 ms  17,6 %	577.00 ms	         StringName::StringName(String const&, bool)
47.00 ms   1,2 %	2.00 ms	          operator new(unsigned long, char const*)
18.00 ms   0,5 %	0 s	          MutexLock<MutexImpl<std::__1::recursive_mutex>>::MutexLock(MutexImpl<std::__1::recursive_mutex> const&)
12.00 ms   0,3 %	12.00 ms	          String::hash() const
10.00 ms   0,3 %	0 s	          MutexLock<MutexImpl<std::__1::recursive_mutex>>::~MutexLock()
5.00 ms   0,1 %	0 s	          String::operator=(String const&)
1.00 ms   0,0 %	0 s	          String::is_empty() const
```

Finally it dawned on me that the extremely large self time of `StringName` was so high because of cache misses.
I implemented the localized solution presented here, and benchmarked the code again. I got these results:
- `3757ms` on `master`
- `2533ms` on this branch

I think it can be concluded that this change can speed up `Node` creation by ~30%.
I ran another sanity check by profiling the benchmark and checking the impact of `StringName` construction. The entries shrank to a combined 14%:
```
339.00 ms  12,5 %	0 s	   StringName::StringName(char const*, bool)
55.00 ms   2,0 %	0 s	   StringName::StringName(String const&, bool)
```

Note that `Node` creation is not a bottleneck in either tps-demo or the editor itself. I benchmarked both and they weren't substantially improved by this change (perhaps on the magnitude of ~1%).

## Notes
I removed `StringName::search` because it would have been bothersome to reimplement. The functions had existed since godot was made open source and currently don't have a single caller. If a reason to use them emerges, we can reimplement these functions.

I also took the opportunity to hide implementation details about `StringName` from the header. Further optimizations should be easier to make without needing to recompile the full source code.

## Addendum

The largest contributor to `Node` creation is `HashMap` entries now, at about 35% in `_add_child_nocheck`. There are a few open PRs for that, so hopefully we'll be able to cut this down soon too!

[^1]: https://www.agner.org/optimize/optimizing_cpp.pdf
