### PR TITLE
Replace `size() == 0` with `is_empty()`

### DIFF
--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -242,7 +242,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 		} else if (line.begins_with("br") || line.begins_with("break")) {
 			if (line.get_slice_count(" ") <= 1) {
 				const HashMap<int, HashSet<StringName>> &breakpoints = script_debugger->get_breakpoints();
-				if (breakpoints.size() == 0) {
+				if (breakpoints.is_empty()) {
 					print_line("No Breakpoints.");
 					continue;
 				}

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -533,7 +533,7 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 				ERR_FAIL_COND(data.is_empty());
 				script_debugger->set_skip_breakpoints(data[0]);
 			} else if (command == "set_ignore_error_breaks") {
-				ERR_FAIL_COND(data.size() < 1);
+				ERR_FAIL_COND(data.is_empty());
 				script_debugger->set_ignore_error_breaks(data[0]);
 			} else if (command == "evaluate") {
 				String expression_str = data[0];
@@ -675,7 +675,7 @@ Error RemoteDebugger::_core_capture(const String &p_cmd, const Array &p_data, bo
 		ERR_FAIL_COND_V(p_data.is_empty(), ERR_INVALID_DATA);
 		script_debugger->set_skip_breakpoints(p_data[0]);
 	} else if (p_cmd == "set_ignore_error_breaks") {
-		ERR_FAIL_COND_V(p_data.size() < 1, ERR_INVALID_DATA);
+		ERR_FAIL_COND_V(p_data.is_empty(), ERR_INVALID_DATA);
 		script_debugger->set_ignore_error_breaks(p_data[0]);
 	} else if (p_cmd == "break") {
 		script_debugger->debug(script_debugger->get_break_language());

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -96,7 +96,7 @@ void RemoteDebuggerPeerTCP::_write_out() {
 	while (tcp_client->get_status() == StreamPeerTCP::STATUS_CONNECTED && tcp_client->wait(NetSocket::POLL_TYPE_OUT) == OK) {
 		uint8_t *buf = out_buf.ptrw();
 		if (out_left <= 0) {
-			if (out_queue.size() == 0) {
+			if (out_queue.is_empty()) {
 				break; // Nothing left to send
 			}
 			mutex.lock();

--- a/core/debugger/script_debugger.cpp
+++ b/core/debugger/script_debugger.cpp
@@ -58,7 +58,7 @@ void ScriptDebugger::remove_breakpoint(int p_line, const StringName &p_source) {
 	}
 
 	breakpoints[p_line].erase(p_source);
-	if (breakpoints[p_line].size() == 0) {
+	if (breakpoints[p_line].is_empty()) {
 		breakpoints.erase(p_line);
 	}
 }

--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -114,7 +114,7 @@ public:
 				// Must be an operator or a constructor since there is no other overloading
 				if (name.left(8) == "operator") {
 					if (arguments.size() == p_method.arguments.size()) {
-						if (arguments.size() == 0) {
+						if (arguments.is_empty()) {
 							return false;
 						}
 						return arguments[0].type < p_method.arguments[0].type;
@@ -126,7 +126,7 @@ public:
 					// - 1. Default constructor: Foo()
 					// - 2. Copy constructor: Foo(Foo)
 					// - 3+. Other constructors Foo(Bar, ...) based on first argument's name
-					if (arguments.size() == 0 || p_method.arguments.size() == 0) { // 1.
+					if (arguments.is_empty() || p_method.arguments.is_empty()) { // 1.
 						return arguments.size() < p_method.arguments.size();
 					}
 					if (arguments[0].type == return_type || p_method.arguments[0].type == p_method.return_type) { // 2.

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -573,7 +573,7 @@ static bool _are_formats_compatible(Image::Format p_format0, Image::Format p_for
 void Image::convert(Format p_new_format) {
 	ERR_FAIL_INDEX_MSG(p_new_format, FORMAT_MAX, vformat("The Image format specified (%d) is out of range. See Image's Format enum.", p_new_format));
 
-	if (data.size() == 0 || p_new_format == format) {
+	if (data.is_empty() || p_new_format == format) {
 		return;
 	}
 
@@ -2177,7 +2177,7 @@ void Image::clear_mipmaps() {
 }
 
 bool Image::is_empty() const {
-	return (data.size() == 0);
+	return (data.is_empty());
 }
 
 Vector<uint8_t> Image::get_data() const {
@@ -3096,7 +3096,7 @@ void Image::_repeat_pixel_over_subsequent_memory(uint8_t *p_pixel, int p_pixel_s
 }
 
 void Image::fill(const Color &p_color) {
-	if (data.size() == 0) {
+	if (data.is_empty()) {
 		return;
 	}
 	ERR_FAIL_COND_MSG(is_compressed(), "Cannot fill in compressed image formats.");
@@ -3112,7 +3112,7 @@ void Image::fill(const Color &p_color) {
 }
 
 void Image::fill_rect(const Rect2i &p_rect, const Color &p_color) {
-	if (data.size() == 0) {
+	if (data.is_empty()) {
 		return;
 	}
 	ERR_FAIL_COND_MSG(is_compressed(), "Cannot fill rect in compressed image formats.");
@@ -3734,7 +3734,7 @@ void Image::normal_map_to_xy() {
 }
 
 Ref<Image> Image::rgbe_to_srgb() {
-	if (data.size() == 0) {
+	if (data.is_empty()) {
 		return Ref<Image>();
 	}
 
@@ -3856,7 +3856,7 @@ bool Image::detect_signed(bool p_include_mips) const {
 }
 
 void Image::srgb_to_linear() {
-	if (data.size() == 0) {
+	if (data.is_empty()) {
 		return;
 	}
 
@@ -3887,7 +3887,7 @@ void Image::srgb_to_linear() {
 }
 
 void Image::linear_to_srgb() {
-	if (data.size() == 0) {
+	if (data.is_empty()) {
 		return;
 	}
 
@@ -3918,7 +3918,7 @@ void Image::linear_to_srgb() {
 }
 
 void Image::premultiply_alpha() {
-	if (data.size() == 0) {
+	if (data.is_empty()) {
 		return;
 	}
 
@@ -3940,7 +3940,7 @@ void Image::premultiply_alpha() {
 }
 
 void Image::fix_alpha_edges() {
-	if (data.size() == 0) {
+	if (data.is_empty()) {
 		return;
 	}
 

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -406,7 +406,7 @@ public:
 		}
 
 		Vector<Vector3> convex_points = Geometry3D::compute_convex_mesh_points(&p_convex[0], p_convex.size());
-		if (convex_points.size() == 0) {
+		if (convex_points.is_empty()) {
 			return 0;
 		}
 

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -2237,7 +2237,7 @@ real_t ConvexHullComputer::compute(const Vector3 *p_coords, int32_t p_count, rea
 Error ConvexHullComputer::convex_hull(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_mesh) {
 	r_mesh = Geometry3D::MeshData(); // clear
 
-	if (p_points.size() == 0) {
+	if (p_points.is_empty()) {
 		return FAILED; // matches QuickHull
 	}
 

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -484,7 +484,7 @@ public:
 			LOC_OUTSIDE = -1
 		};
 
-		if (polygon.size() == 0) {
+		if (polygon.is_empty()) {
 			return polygon;
 		}
 

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -323,7 +323,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 
 		for (List<Face>::Element *&E : new_faces) {
 			Face &f2 = E->get();
-			if (f2.points_over.size() == 0) {
+			if (f2.points_over.is_empty()) {
 				faces.move_to_front(E);
 			}
 		}

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -226,7 +226,7 @@ void CallQueue::_call_function(const Callable &p_callable, const Variant *p_args
 Error CallQueue::flush() {
 	LOCK_MUTEX;
 
-	if (pages.size() == 0) {
+	if (pages.is_empty()) {
 		// Never allocated
 		UNLOCK_MUTEX;
 		return OK; // Do nothing.
@@ -308,7 +308,7 @@ Error CallQueue::flush() {
 void CallQueue::clear() {
 	LOCK_MUTEX;
 
-	if (pages.size() == 0) {
+	if (pages.is_empty()) {
 		UNLOCK_MUTEX;
 		return; // Nothing to clear.
 	}

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1900,7 +1900,7 @@ Variant::Type Object::get_static_property_type(const StringName &p_property, boo
 }
 
 Variant::Type Object::get_static_property_type_indexed(const Vector<StringName> &p_path, bool *r_valid) const {
-	if (p_path.size() == 0) {
+	if (p_path.is_empty()) {
 		if (r_valid) {
 			*r_valid = false;
 		}

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -513,7 +513,7 @@ public:
 	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override {
 		Dictionary ret;
 		GDVIRTUAL_CALL(_debug_get_stack_level_locals, p_level, p_max_subitems, p_max_depth, ret);
-		if (ret.size() == 0) {
+		if (ret.is_empty()) {
 			return;
 		}
 		if (p_locals != nullptr && ret.has("locals")) {
@@ -533,7 +533,7 @@ public:
 	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override {
 		Dictionary ret;
 		GDVIRTUAL_CALL(_debug_get_stack_level_members, p_level, p_max_subitems, p_max_depth, ret);
-		if (ret.size() == 0) {
+		if (ret.is_empty()) {
 			return;
 		}
 		if (p_members != nullptr && ret.has("members")) {
@@ -560,7 +560,7 @@ public:
 	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override {
 		Dictionary ret;
 		GDVIRTUAL_CALL(_debug_get_globals, p_max_subitems, p_max_depth, ret);
-		if (ret.size() == 0) {
+		if (ret.is_empty()) {
 			return;
 		}
 		if (p_globals != nullptr && ret.has("globals")) {

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -221,7 +221,7 @@ void WorkerThreadPool::_post_tasks(Task **p_tasks, uint32_t p_count, bool p_high
 	// Fall back to processing on the calling thread if there are no worker threads.
 	// Separated into its own variable to make it easier to extend this logic
 	// in custom builds.
-	bool process_on_calling_thread = threads.size() == 0;
+	bool process_on_calling_thread = threads.is_empty();
 	if (process_on_calling_thread) {
 		p_lock.temp_unlock();
 		for (uint32_t i = 0; i < p_count; i++) {
@@ -789,7 +789,7 @@ void WorkerThreadPool::init(int p_thread_count, float p_low_priority_task_ratio)
 }
 
 void WorkerThreadPool::exit_languages_threads() {
-	if (threads.size() == 0) {
+	if (threads.is_empty()) {
 		return;
 	}
 
@@ -809,7 +809,7 @@ void WorkerThreadPool::exit_languages_threads() {
 }
 
 void WorkerThreadPool::finish() {
-	if (threads.size() == 0) {
+	if (threads.is_empty()) {
 		return;
 	}
 

--- a/core/os/keyboard.cpp
+++ b/core/os/keyboard.cpp
@@ -410,7 +410,7 @@ String keycode_get_string(Key p_code) {
 Key find_keycode(const String &p_codestr) {
 	Key keycode = Key::NONE;
 	Vector<String> code_parts = p_codestr.split("+");
-	if (code_parts.size() < 1) {
+	if (code_parts.is_empty()) {
 		return keycode;
 	}
 

--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -350,7 +350,7 @@ void NodePath::simplify() {
 			data->path.remove_at(i - 1);
 			data->path.remove_at(i - 1);
 			i -= 2;
-			if (data->path.size() == 0) {
+			if (data->path.is_empty()) {
 				data->path.push_back(".");
 				break;
 			}
@@ -366,7 +366,7 @@ NodePath NodePath::simplified() const {
 }
 
 NodePath::NodePath(const Vector<StringName> &p_path, bool p_absolute) {
-	if (p_path.size() == 0 && !p_absolute) {
+	if (p_path.is_empty() && !p_absolute) {
 		return;
 	}
 
@@ -378,7 +378,7 @@ NodePath::NodePath(const Vector<StringName> &p_path, bool p_absolute) {
 }
 
 NodePath::NodePath(const Vector<StringName> &p_path, const Vector<StringName> &p_subpath, bool p_absolute) {
-	if (p_path.size() == 0 && p_subpath.size() == 0 && !p_absolute) {
+	if (p_path.is_empty() && p_subpath.is_empty() && !p_absolute) {
 		return;
 	}
 

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -110,7 +110,7 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 		const Vector<Pair<int, CharString>> &b = buckets[i];
 		HashMap<uint32_t, int> &t = table.write[i];
 
-		if (b.size() == 0) {
+		if (b.is_empty()) {
 			continue;
 		}
 
@@ -148,7 +148,7 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 
 	for (int i = 0; i < size; i++) {
 		const HashMap<uint32_t, int> &t = table[i];
-		if (t.size() == 0) {
+		if (t.is_empty()) {
 			htw[i] = 0xFFFFFFFF; //nothing
 			continue;
 		}

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3298,7 +3298,7 @@ int String::findmk(const Vector<String> &p_keys, int p_from, int *r_key) const {
 	if (p_from < 0) {
 		return -1;
 	}
-	if (p_keys.size() == 0) {
+	if (p_keys.is_empty()) {
 		return -1;
 	}
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -345,7 +345,7 @@ Variant Array::pick_random() const {
 }
 
 int Array::find(const Variant &p_value, int p_from) const {
-	if (_p->array.size() == 0) {
+	if (_p->array.is_empty()) {
 		return -1;
 	}
 	Variant value = p_value;
@@ -396,7 +396,7 @@ int Array::find_custom(const Callable &p_callable, int p_from) const {
 }
 
 int Array::rfind(const Variant &p_value, int p_from) const {
-	if (_p->array.size() == 0) {
+	if (_p->array.is_empty()) {
 		return -1;
 	}
 	Variant value = p_value;
@@ -421,7 +421,7 @@ int Array::rfind(const Variant &p_value, int p_from) const {
 }
 
 int Array::rfind_custom(const Callable &p_callable, int p_from) const {
-	if (_p->array.size() == 0) {
+	if (_p->array.is_empty()) {
 		return -1;
 	}
 
@@ -458,7 +458,7 @@ int Array::rfind_custom(const Callable &p_callable, int p_from) const {
 int Array::count(const Variant &p_value) const {
 	Variant value = p_value;
 	ERR_FAIL_COND_V(!_p->typed.validate(value, "count"), 0);
-	if (_p->array.size() == 0) {
+	if (_p->array.is_empty()) {
 		return 0;
 	}
 

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -984,34 +984,34 @@ bool Variant::is_zero() const {
 
 		// Arrays.
 		case PACKED_BYTE_ARRAY: {
-			return PackedArrayRef<uint8_t>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<uint8_t>::get_array(_data.packed_array).is_empty();
 		}
 		case PACKED_INT32_ARRAY: {
-			return PackedArrayRef<int32_t>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<int32_t>::get_array(_data.packed_array).is_empty();
 		}
 		case PACKED_INT64_ARRAY: {
-			return PackedArrayRef<int64_t>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<int64_t>::get_array(_data.packed_array).is_empty();
 		}
 		case PACKED_FLOAT32_ARRAY: {
-			return PackedArrayRef<float>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<float>::get_array(_data.packed_array).is_empty();
 		}
 		case PACKED_FLOAT64_ARRAY: {
-			return PackedArrayRef<double>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<double>::get_array(_data.packed_array).is_empty();
 		}
 		case PACKED_STRING_ARRAY: {
-			return PackedArrayRef<String>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<String>::get_array(_data.packed_array).is_empty();
 		}
 		case PACKED_VECTOR2_ARRAY: {
-			return PackedArrayRef<Vector2>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<Vector2>::get_array(_data.packed_array).is_empty();
 		}
 		case PACKED_VECTOR3_ARRAY: {
-			return PackedArrayRef<Vector3>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<Vector3>::get_array(_data.packed_array).is_empty();
 		}
 		case PACKED_COLOR_ARRAY: {
-			return PackedArrayRef<Color>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<Color>::get_array(_data.packed_array).is_empty();
 		}
 		case PACKED_VECTOR4_ARRAY: {
-			return PackedArrayRef<Vector4>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<Vector4>::get_array(_data.packed_array).is_empty();
 		}
 		default: {
 		}

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1572,7 +1572,7 @@ void RasterizerCanvasGLES3::_add_to_batch(uint32_t &r_index, bool &r_batch_broke
 }
 
 void RasterizerCanvasGLES3::_new_batch(bool &r_batch_broken) {
-	if (state.canvas_instance_batches.size() == 0) {
+	if (state.canvas_instance_batches.is_empty()) {
 		Batch new_batch;
 		new_batch.instance_buffer_index = state.current_instance_buffer_index;
 		state.canvas_instance_batches.push_back(new_batch);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3218,11 +3218,11 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 						spec_constants |= SceneShaderGLES3::DISABLE_LIGHT_DIRECTIONAL;
 						spec_constants |= SceneShaderGLES3::DISABLE_LIGHTMAP;
 					} else {
-						if (inst->omni_light_gl_cache.size() == 0) {
+						if (inst->omni_light_gl_cache.is_empty()) {
 							spec_constants |= SceneShaderGLES3::DISABLE_LIGHT_OMNI;
 						}
 
-						if (inst->spot_light_gl_cache.size() == 0) {
+						if (inst->spot_light_gl_cache.is_empty()) {
 							spec_constants |= SceneShaderGLES3::DISABLE_LIGHT_SPOT;
 						}
 
@@ -3230,7 +3230,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 							spec_constants |= SceneShaderGLES3::DISABLE_LIGHT_DIRECTIONAL;
 						}
 
-						if (inst->reflection_probe_rid_cache.size() == 0) {
+						if (inst->reflection_probe_rid_cache.is_empty()) {
 							// We don't have any probes.
 							spec_constants |= SceneShaderGLES3::DISABLE_REFLECTION_PROBE;
 						} else if (inst->reflection_probe_rid_cache.size() > 1) {

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -690,7 +690,7 @@ void ShaderGLES3::_save_to_cache(Version *p_version) {
 
 void ShaderGLES3::_clear_version(Version *p_version) {
 	// Variants not compiled yet, just return
-	if (p_version->variants.size() == 0) {
+	if (p_version->variants.is_empty()) {
 		return;
 	}
 

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -188,7 +188,7 @@ protected:
 		Version *version = version_owner.get_or_null(p_version);
 		ERR_FAIL_NULL_V(version, false);
 
-		if (version->variants.size() == 0) {
+		if (version->variants.is_empty()) {
 			_initialize_version(version); //may lack initialization
 		}
 

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -2042,7 +2042,7 @@ void AnimationBezierTrackEdit::_menu_selected(int p_index) {
 }
 
 void AnimationBezierTrackEdit::duplicate_selected_keys(real_t p_ofs, bool p_ofs_valid) {
-	if (selection.size() == 0) {
+	if (selection.is_empty()) {
 		return;
 	}
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -6623,7 +6623,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			}
 		} break;
 		case EDIT_PASTE_TRACKS: {
-			if (track_clipboard.size() == 0) {
+			if (track_clipboard.is_empty()) {
 				EditorNode::get_singleton()->show_warning(TTR("Clipboard is empty!"));
 				break;
 			}

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1730,7 +1730,7 @@ void CodeTextEditor::toggle_bookmark() {
 
 void CodeTextEditor::goto_next_bookmark() {
 	PackedInt32Array bmarks = text_editor->get_bookmarked_lines();
-	if (bmarks.size() <= 0) {
+	if (bmarks.is_empty()) {
 		return;
 	}
 
@@ -1746,7 +1746,7 @@ void CodeTextEditor::goto_next_bookmark() {
 
 void CodeTextEditor::goto_prev_bookmark() {
 	PackedInt32Array bmarks = text_editor->get_bookmarked_lines();
-	if (bmarks.size() <= 0) {
+	if (bmarks.is_empty()) {
 		return;
 	}
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -371,7 +371,7 @@ void ScriptEditorDebugger::_msg_debug_exit(uint64_t p_thread_id, const Array &p_
 	threads_debugged.erase(p_thread_id);
 	if (p_thread_id == debugging_thread_id) {
 		_clear_execution();
-		if (threads_debugged.size() == 0) {
+		if (threads_debugged.is_empty()) {
 			debugging_thread_id = Thread::UNASSIGNED_ID;
 		} else {
 			// Find next thread to debug.
@@ -1667,7 +1667,7 @@ void ScriptEditorDebugger::_error_selected() {
 	}
 
 	Array meta = selected->get_metadata(0);
-	if (meta.size() == 0) {
+	if (meta.is_empty()) {
 		return;
 	}
 

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -613,7 +613,7 @@ void DependencyRemoveDialog::ok_pressed() {
 		ProjectSettings::get_singleton()->save();
 	}
 
-	if (dirs_to_delete.size() == 0) {
+	if (dirs_to_delete.is_empty()) {
 		// If we only deleted files we should only need to tell the file system about the files we touched.
 		for (int i = 0; i < files_to_delete.size(); ++i) {
 			EditorFileSystem::get_singleton()->update_file(files_to_delete[i]);

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -628,7 +628,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 					// Don't skip parametric setters and getters, i.e. method which require
 					// one or more parameters to define what property should be set or retrieved.
 					// E.g. CPUParticles3D::set_param(Parameter param, float value).
-					if (E.arguments.size() == 0 /* getter */ || (E.arguments.size() == 1 && E.return_val.type == Variant::NIL /* setter */)) {
+					if (E.arguments.is_empty() /* getter */ || (E.arguments.size() == 1 && E.return_val.type == Variant::NIL /* setter */)) {
 						continue;
 					}
 				}

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -621,7 +621,7 @@ Variant EditorAutoloadSettings::get_drag_data_fw(const Point2 &p_point, Control 
 		next = tree->get_next_selected(next);
 	}
 
-	if (autoloads.size() == 0 || autoloads.size() == autoload_cache.size()) {
+	if (autoloads.is_empty() || autoloads.size() == autoload_cache.size()) {
 		return Variant();
 	}
 

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -802,7 +802,7 @@ Vector<String> EditorFileSystem::_get_import_dest_paths(const String &p_path) {
 }
 
 bool EditorFileSystem::_scan_import_support(const Vector<String> &reimports) {
-	if (import_support_queries.size() == 0) {
+	if (import_support_queries.is_empty()) {
 		return false;
 	}
 	HashMap<String, int> import_support_test;
@@ -818,7 +818,7 @@ bool EditorFileSystem::_scan_import_support(const Vector<String> &reimports) {
 		}
 	}
 
-	if (import_support_test.size() == 0) {
+	if (import_support_test.is_empty()) {
 		return false; //well nothing to do
 	}
 
@@ -1858,7 +1858,7 @@ bool EditorFileSystem::_find_file(const String &p_file, EditorFileSystemDirector
 
 	Vector<String> path = f.split("/");
 
-	if (path.size() == 0) {
+	if (path.is_empty()) {
 		return false;
 	}
 	String file = path[path.size() - 1];
@@ -1991,7 +1991,7 @@ EditorFileSystemDirectory *EditorFileSystem::get_filesystem_path(const String &p
 
 	Vector<String> path = f.split("/");
 
-	if (path.size() == 0) {
+	if (path.is_empty()) {
 		return nullptr;
 	}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3816,7 +3816,7 @@ void EditorNode::_update_addon_config() {
 		enabled_addons.push_back(E.key);
 	}
 
-	if (enabled_addons.size() == 0) {
+	if (enabled_addons.is_empty()) {
 		ProjectSettings::get_singleton()->set("editor_plugins/enabled", Variant());
 	} else {
 		enabled_addons.sort();
@@ -6342,7 +6342,7 @@ void EditorNode::preload_reimporting_with_path_in_edited_scenes(const List<Strin
 }
 
 void EditorNode::reload_instances_with_path_in_edited_scenes() {
-	if (scenes_modification_table.size() == 0) {
+	if (scenes_modification_table.is_empty()) {
 		return;
 	}
 	EditorProgress progress("reloading_scene", TTR("Scenes reloading"), editor_data.get_edited_scene_count());

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -573,7 +573,7 @@ void EditorPropertyPath::_drop_data_fw(const Point2 &p_point, const Variant &p_d
 		return;
 	}
 	const Vector<String> filesPaths = drag_data["files"];
-	if (filesPaths.size() == 0) {
+	if (filesPaths.is_empty()) {
 		return;
 	}
 
@@ -589,7 +589,7 @@ bool EditorPropertyPath::_can_drop_data_fw(const Point2 &p_point, const Variant 
 		return false;
 	}
 	const Vector<String> filesPaths = drag_data["files"];
-	if (filesPaths.size() == 0) {
+	if (filesPaths.is_empty()) {
 		return false;
 	}
 

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -262,7 +262,7 @@ const Dictionary EditorResourcePreview::get_preview_metadata(const String &p_pat
 void EditorResourcePreview::_iterate() {
 	preview_mutex.lock();
 
-	if (queue.size() == 0) {
+	if (queue.is_empty()) {
 		preview_mutex.unlock();
 		return;
 	}

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1572,7 +1572,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		Vector<uint8_t> array;
 		if (GDExtension::get_extension_list_config_file() == forced_export[i]) {
 			array = _filter_extension_list_config_file(forced_export[i], paths);
-			if (array.size() == 0) {
+			if (array.is_empty()) {
 				continue;
 			}
 		} else {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3840,7 +3840,7 @@ void FileSystemDock::_update_import_dock() {
 		imports.push_back(fpath);
 	}
 
-	if (imports.size() == 0) {
+	if (imports.is_empty()) {
 		ImportDock::get_singleton()->clear();
 	} else if (imports.size() == 1) {
 		ImportDock::get_singleton()->set_edit_path(imports[0]);

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -117,7 +117,7 @@ void FindInFiles::start() {
 		emit_signal(SceneStringName(finished));
 		return;
 	}
-	if (_extension_filter.size() == 0) {
+	if (_extension_filter.is_empty()) {
 		print_verbose("Nothing to search, filter matches no files");
 		emit_signal(SceneStringName(finished));
 		return;
@@ -183,7 +183,7 @@ void FindInFiles::_iterate() {
 			pop_back(_folders_stack);
 			_current_dir = _current_dir.get_base_dir();
 
-			if (_folders_stack.size() == 0) {
+			if (_folders_stack.is_empty()) {
 				// All folders scanned.
 				_initial_files_count = _files_to_scan.size();
 			}

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -770,7 +770,7 @@ void EditorFileDialog::_items_clear_selection(const Vector2 &p_pos, MouseButton 
 void EditorFileDialog::_push_history() {
 	local_history.resize(local_history_pos + 1);
 	String new_path = dir_access->get_current_dir();
-	if (local_history.size() == 0 || new_path != local_history[local_history_pos]) {
+	if (local_history.is_empty() || new_path != local_history[local_history_pos]) {
 		local_history.push_back(new_path);
 		local_history_pos++;
 		dir_prev->set_disabled(local_history_pos == 0);
@@ -940,7 +940,7 @@ bool EditorFileDialog::_is_open_should_be_disabled() {
 	}
 
 	Vector<int> items = item_list->get_selected_items();
-	if (items.size() == 0) {
+	if (items.is_empty()) {
 		return mode != FILE_MODE_OPEN_DIR; // In "Open folder" mode, having nothing selected picks the current folder.
 	}
 

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -447,7 +447,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 			_set_item_custom_color(p_item, accent);
 		}
 	} else if (p_part_of_subscene) {
-		if (valid_types.size() == 0) {
+		if (valid_types.is_empty()) {
 			_set_item_custom_color(p_item, get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
 		}
 	} else if (marked.has(p_node)) {
@@ -1865,7 +1865,7 @@ bool SceneTreeEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 	if (String(d["type"]) == "files") {
 		Vector<String> files = d["files"];
 
-		if (files.size() == 0) {
+		if (files.is_empty()) {
 			return false; // TODO Weird?
 		}
 

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -706,7 +706,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 					}
 				}
 
-				if (weights.size() == 0 || total == 0) { //if nothing, add a weight to bone 0
+				if (weights.is_empty() || total == 0) { //if nothing, add a weight to bone 0
 					//no weights assigned
 					Collada::Vertex::Weight w;
 					w.bone_idx = 0;
@@ -1278,7 +1278,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 					mesh_unique_names.insert(name);
 
 					mesh->set_name(name);
-					Error err = _create_mesh_surfaces(morphs.size() == 0, mesh, ng2->material_map, meshdata, apply_xform, bone_remap, skin, morph, morphs, p_use_compression, use_mesh_builtin_materials);
+					Error err = _create_mesh_surfaces(morphs.is_empty(), mesh, ng2->material_map, meshdata, apply_xform, bone_remap, skin, morph, morphs, p_use_compression, use_mesh_builtin_materials);
 					ERR_FAIL_COND_V_MSG(err, err, "Cannot create mesh surface.");
 
 					mesh_cache[meshid] = mesh;

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -402,7 +402,7 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 			//groups are too annoying
 			if (surf_tool->get_vertex_array().size()) {
 				//another group going on, commit it
-				if (normals.size() == 0) {
+				if (normals.is_empty()) {
 					surf_tool->generate_normals();
 				}
 

--- a/editor/plugins/bone_map_editor_plugin.cpp
+++ b/editor/plugins/bone_map_editor_plugin.cpp
@@ -665,7 +665,7 @@ void BoneMapper::auto_mapping_process(Ref<BoneMap> &p_bone_map) {
 		search_path.push_back(bone_idx);
 		bone_idx = skeleton->get_bone_parent(bone_idx);
 	}
-	if (search_path.size() == 0) {
+	if (search_path.is_empty()) {
 		bone_idx = -1;
 	} else if (search_path.size() == 1) {
 		bone_idx = search_path[0]; // It is only one bone which can be root.
@@ -1329,7 +1329,7 @@ void BoneMapper::auto_mapping_process(Ref<BoneMap> &p_bone_map) {
 		bone_idx = skeleton->get_bone_parent(bone_idx);
 	}
 	search_path.reverse();
-	if (search_path.size() == 0) {
+	if (search_path.is_empty()) {
 		p_bone_map->_set_skeleton_bone_name("Spine", skeleton->get_bone_name(chest_or_upper_chest)); // Maybe chibi model...?
 	} else if (search_path.size() == 1) {
 		p_bone_map->_set_skeleton_bone_name("Spine", skeleton->get_bone_name(search_path[0]));

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -6273,7 +6273,7 @@ void CanvasItemEditorViewport::drop_data(const Point2 &p_point, const Variant &p
 	if (d.has("type") && String(d["type"]) == "files") {
 		selected_files = d["files"];
 	}
-	if (selected_files.size() == 0) {
+	if (selected_files.is_empty()) {
 		return;
 	}
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -6063,7 +6063,7 @@ bool CanvasItemEditorViewport::_create_instance(Node *p_parent, const String &p_
 }
 
 void CanvasItemEditorViewport::_perform_drop_data() {
-	ERR_FAIL_COND(selected_files.size() <= 0);
+	ERR_FAIL_COND(selected_files.is_empty());
 
 	_remove_preview();
 

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -330,7 +330,7 @@ void EditorPropertySizeFlags::update_property() {
 void EditorPropertySizeFlags::setup(const Vector<String> &p_options, bool p_vertical) {
 	vertical = p_vertical;
 
-	if (p_options.size() == 0) {
+	if (p_options.is_empty()) {
 		flag_presets->clear();
 		flag_presets->add_item(TTR("Container Default"));
 		flag_presets->set_disabled(true);

--- a/editor/plugins/gizmos/lightmap_gi_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/lightmap_gi_gizmo_plugin.cpp
@@ -88,7 +88,7 @@ void LightmapGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	HashSet<Vector2i> lines_found;
 
 	Vector<Vector3> points = data->get_capture_points();
-	if (points.size() == 0) {
+	if (points.is_empty()) {
 		return;
 	}
 	Vector<Color> sh = data->get_capture_sh();

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -394,7 +394,7 @@ void MeshInstance3DEditor::_create_uv_lines(int p_layer) {
 		Array a = mesh->surface_get_arrays(i);
 
 		Vector<Vector2> uv = a[p_layer == 0 ? Mesh::ARRAY_TEX_UV : Mesh::ARRAY_TEX_UV2];
-		if (uv.size() == 0) {
+		if (uv.is_empty()) {
 			err_dialog->set_text(vformat(TTR("Mesh has no UV in layer %d."), p_layer + 1));
 			err_dialog->popup_centered();
 			return;
@@ -440,7 +440,7 @@ void MeshInstance3DEditor::_create_uv_lines(int p_layer) {
 }
 
 void MeshInstance3DEditor::_debug_uv_draw() {
-	if (uv_lines.size() == 0) {
+	if (uv_lines.is_empty()) {
 		return;
 	}
 

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -120,7 +120,7 @@ void MultiMeshEditor::_populate() {
 
 	Vector<Face3> geometry = ss_instance->get_mesh()->get_faces();
 
-	if (geometry.size() == 0) {
+	if (geometry.is_empty()) {
 		err_dialog->set_text(TTR("Surface source is invalid (no faces)."));
 		err_dialog->popup_centered();
 		return;

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -656,7 +656,7 @@ void Particles3DEditorPlugin::_node_selected(const NodePath &p_path) {
 	}
 
 	geometry = mi->get_mesh()->get_faces();
-	if (geometry.size() == 0) {
+	if (geometry.is_empty()) {
 		EditorNode::get_singleton()->show_warning(vformat(TTR("\"%s\" doesn't contain face geometry."), sel->get_name()));
 		return;
 	}

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -182,7 +182,7 @@ void Polygon2DEditor::_sync_bones() {
 				}
 			}
 
-			if (weights.size() == 0) { //create them
+			if (weights.is_empty()) { //create them
 				weights.resize(wc);
 				float *w = weights.ptrw();
 				for (int j = 0; j < wc; j++) {
@@ -311,7 +311,7 @@ void Polygon2DEditor::_edit_menu_option(int p_option) {
 	switch (p_option) {
 		case MENU_POLYGON_TO_UV: {
 			Vector<Vector2> points = node->get_polygon();
-			if (points.size() == 0) {
+			if (points.is_empty()) {
 				break;
 			}
 			Vector<Vector2> uvs = node->get_uv();
@@ -323,7 +323,7 @@ void Polygon2DEditor::_edit_menu_option(int p_option) {
 		case MENU_UV_TO_POLYGON: {
 			Vector<Vector2> points = node->get_polygon();
 			Vector<Vector2> uvs = node->get_uv();
-			if (uvs.size() == 0) {
+			if (uvs.is_empty()) {
 				break;
 			}
 
@@ -334,7 +334,7 @@ void Polygon2DEditor::_edit_menu_option(int p_option) {
 		} break;
 		case MENU_UV_CLEAR: {
 			Vector<Vector2> uvs = node->get_uv();
-			if (uvs.size() == 0) {
+			if (uvs.is_empty()) {
 				break;
 			}
 			undo_redo->create_action(TTR("Create UV Map"));

--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -462,7 +462,7 @@ void Polygon3DEditor::_polygon_draw() {
 
 	imesh->surface_end();
 
-	if (poly.size() == 0) {
+	if (poly.is_empty()) {
 		return;
 	}
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3206,7 +3206,7 @@ bool ScriptEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data
 
 	if (String(d["type"]) == "nodes") {
 		Array nodes = d["nodes"];
-		if (nodes.size() == 0) {
+		if (nodes.is_empty()) {
 			return false;
 		}
 		Node *node = get_node((nodes[0]));
@@ -3224,7 +3224,7 @@ bool ScriptEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data
 	if (String(d["type"]) == "files") {
 		Vector<String> files = d["files"];
 
-		if (files.size() == 0) {
+		if (files.is_empty()) {
 			return false; //weird
 		}
 
@@ -3282,7 +3282,7 @@ void ScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 
 	if (String(d["type"]) == "nodes") {
 		Array nodes = d["nodes"];
-		if (nodes.size() == 0) {
+		if (nodes.is_empty()) {
 			return;
 		}
 		Node *node = get_node(nodes[0]);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -760,7 +760,7 @@ void ScriptTextEditor::_update_bookmark_list() {
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_bookmark"), BOOKMARK_GOTO_PREV);
 
 	PackedInt32Array bookmark_list = code_editor->get_text_editor()->get_bookmarked_lines();
-	if (bookmark_list.size() == 0) {
+	if (bookmark_list.is_empty()) {
 		return;
 	}
 
@@ -915,7 +915,7 @@ void ScriptTextEditor::_update_breakpoint_list() {
 	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_breakpoint"), DEBUG_GOTO_PREV_BREAKPOINT);
 
 	PackedInt32Array breakpoint_list = code_editor->get_text_editor()->get_breakpointed_lines();
-	if (breakpoint_list.size() == 0) {
+	if (breakpoint_list.is_empty()) {
 		return;
 	}
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1696,7 +1696,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 		} break;
 		case DEBUG_GOTO_NEXT_BREAKPOINT: {
 			PackedInt32Array bpoints = tx->get_breakpointed_lines();
-			if (bpoints.size() <= 0) {
+			if (bpoints.is_empty()) {
 				return;
 			}
 
@@ -1711,7 +1711,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 		} break;
 		case DEBUG_GOTO_PREV_BREAKPOINT: {
 			PackedInt32Array bpoints = tx->get_breakpointed_lines();
-			if (bpoints.size() <= 0) {
+			if (bpoints.is_empty()) {
 				return;
 			}
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -646,7 +646,7 @@ bool ShaderEditorPlugin::can_drop_data_fw(const Point2 &p_point, const Variant &
 	if (String(d["type"]) == "files") {
 		Vector<String> files = d["files"];
 
-		if (files.size() == 0) {
+		if (files.is_empty()) {
 			return false;
 		}
 

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -166,7 +166,7 @@ void ShaderFileEditor::_update_options() {
 		}
 	}
 
-	if (version_list.size() == 0) {
+	if (version_list.is_empty()) {
 		for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
 			stages[i]->set_disabled(true);
 		}

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -131,7 +131,7 @@ void SpriteFramesEditor::_sheet_preview_draw() {
 	}
 	_draw_shadowed_line(split_sheet_preview, draw_offset + Vector2(0, draw_size.y), Vector2(draw_size.x, 0), Vector2(0, 1), line_color, shadow_color);
 
-	if (frames_selected.size() == 0) {
+	if (frames_selected.is_empty()) {
 		split_sheet_dialog->get_ok_button()->set_disabled(true);
 		split_sheet_dialog->set_ok_button_text(TTR("No Frames Selected"));
 		return;
@@ -1699,7 +1699,7 @@ bool SpriteFramesEditor::can_drop_data_fw(const Point2 &p_point, const Variant &
 	if (String(d["type"]) == "files") {
 		Vector<String> files = d["files"];
 
-		if (files.size() == 0) {
+		if (files.is_empty()) {
 			return false;
 		}
 

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -216,7 +216,7 @@ void TextEditor::_update_bookmark_list() {
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_bookmark"), BOOKMARK_GOTO_PREV);
 
 	PackedInt32Array bookmark_list = code_editor->get_text_editor()->get_bookmarked_lines();
-	if (bookmark_list.size() == 0) {
+	if (bookmark_list.is_empty()) {
 		return;
 	}
 

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -1062,7 +1062,7 @@ void TextShaderEditor::_update_bookmark_list() {
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_bookmark"), BOOKMARK_GOTO_PREV);
 
 	PackedInt32Array bookmark_list = code_editor->get_text_editor()->get_bookmarked_lines();
-	if (bookmark_list.size() == 0) {
+	if (bookmark_list.is_empty()) {
 		return;
 	}
 

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -136,7 +136,7 @@ void ThemeItemImportTree::_update_items_tree() {
 				filtered_names.push_back(F);
 			}
 
-			if (filtered_names.size() == 0) {
+			if (filtered_names.is_empty()) {
 				continue;
 			}
 
@@ -734,7 +734,7 @@ void ThemeItemImportTree::_deselect_all_data_type_pressed(int p_data_type) {
 }
 
 void ThemeItemImportTree::_import_selected() {
-	if (selected_items.size() == 0) {
+	if (selected_items.is_empty()) {
 		EditorNode::get_singleton()->show_accept(TTR("Nothing was selected for the import."), TTR("OK"));
 		return;
 	}

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -836,7 +836,7 @@ void GenericTilePolygonEditor::remove_polygon(int p_index) {
 	ERR_FAIL_INDEX(p_index, (int)polygons.size());
 	polygons.remove_at(p_index);
 
-	if (polygons.size() == 0) {
+	if (polygons.is_empty()) {
 		button_create->set_pressed(true);
 	}
 	base_control->queue_redraw();

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -80,7 +80,7 @@ bool TileSetEditor::_can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 		if (String(d["type"]) == "files") {
 			Vector<String> files = d["files"];
 
-			if (files.size() == 0) {
+			if (files.is_empty()) {
 				return false;
 			}
 

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -483,7 +483,7 @@ bool TileSetScenesCollectionSourceEditor::_can_drop_data_fw(const Point2 &p_poin
 		if (String(d["type"]) == "files") {
 			Vector<String> files = d["files"];
 
-			if (files.size() == 0) {
+			if (files.is_empty()) {
 				return false;
 			}
 

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -302,7 +302,7 @@ void TileSetScenesCollectionSourceEditor::_update_tile_inspector() {
 
 void TileSetScenesCollectionSourceEditor::_update_action_buttons() {
 	Vector<int> selected_indices = scene_tiles_list->get_selected_items();
-	scene_tile_delete_button->set_disabled(selected_indices.size() <= 0 || read_only);
+	scene_tile_delete_button->set_disabled(selected_indices.is_empty() || read_only);
 }
 
 void TileSetScenesCollectionSourceEditor::_update_scenes_list() {

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -74,7 +74,7 @@ void TilesEditorUtils::_thread() {
 		pattern_preview_sem.wait();
 
 		pattern_preview_mutex.lock();
-		if (pattern_preview_queue.size() == 0) {
+		if (pattern_preview_queue.is_empty()) {
 			pattern_preview_mutex.unlock();
 		} else {
 			QueueItem item = pattern_preview_queue.front()->get();

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -7979,7 +7979,7 @@ Control *VisualShaderNodePluginDefault::create_editor(const Ref<Resource> &p_par
 	}
 
 	Vector<StringName> properties = p_node->get_editable_properties();
-	if (properties.size() == 0) {
+	if (properties.is_empty()) {
 		return nullptr;
 	}
 
@@ -7996,7 +7996,7 @@ Control *VisualShaderNodePluginDefault::create_editor(const Ref<Resource> &p_par
 		}
 	}
 
-	if (pinfo.size() == 0) {
+	if (pinfo.is_empty()) {
 		return nullptr;
 	}
 

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -2226,7 +2226,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
-			if (parts.size() == 0) {
+			if (parts.is_empty()) {
 				line = line.substr(0, start) + "DisplayServer.get_display_safe_area()" + line.substr(end + start);
 			}
 		}

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -673,7 +673,7 @@ void ProjectManager::_new_project() {
 void ProjectManager::_rename_project() {
 	const Vector<ProjectList::Item> &selected_list = project_list->get_selected_projects();
 
-	if (selected_list.size() == 0) {
+	if (selected_list.is_empty()) {
 		return;
 	}
 
@@ -688,7 +688,7 @@ void ProjectManager::_rename_project() {
 void ProjectManager::_erase_project() {
 	const HashSet<String> &selected_list = project_list->get_selected_project_keys();
 
-	if (selected_list.size() == 0) {
+	if (selected_list.is_empty()) {
 		return;
 	}
 

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1046,7 +1046,7 @@ void ProjectList::select_first_visible_project() {
 
 Vector<ProjectList::Item> ProjectList::get_selected_projects() const {
 	Vector<Item> items;
-	if (_selected_project_paths.size() == 0) {
+	if (_selected_project_paths.is_empty()) {
 		return items;
 	}
 	items.resize(_selected_project_paths.size());
@@ -1067,7 +1067,7 @@ const HashSet<String> &ProjectList::get_selected_project_keys() const {
 }
 
 int ProjectList::get_single_selected_index() const {
-	if (_selected_project_paths.size() == 0) {
+	if (_selected_project_paths.is_empty()) {
 		// Default selection
 		return 0;
 	}
@@ -1088,7 +1088,7 @@ int ProjectList::get_single_selected_index() const {
 }
 
 void ProjectList::erase_selected_projects(bool p_delete_project_contents) {
-	if (_selected_project_paths.size() == 0) {
+	if (_selected_project_paths.is_empty()) {
 		return;
 	}
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -659,7 +659,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			List<Node *> selection = editor_selection->get_top_selected_node_list();
-			if (selection.size() == 0) {
+			if (selection.is_empty()) {
 				break;
 			}
 
@@ -887,7 +887,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			List<Node *> selection = editor_selection->get_top_selected_node_list();
-			if (selection.size() == 0) {
+			if (selection.is_empty()) {
 				break;
 			}
 
@@ -2333,7 +2333,7 @@ void SceneTreeDock::_node_reparent(NodePath p_path, bool p_keep_global_xform) {
 void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, Vector<Node *> p_nodes, bool p_keep_global_xform) {
 	ERR_FAIL_NULL(p_new_parent);
 
-	if (p_nodes.size() == 0) {
+	if (p_nodes.is_empty()) {
 		return; // Nothing to reparent.
 	}
 
@@ -3748,7 +3748,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	List<Node *> selection = editor_selection->get_top_selected_node_list();
 	List<Node *> full_selection = editor_selection->get_full_selected_node_list(); // Above method only returns nodes with common parent.
 
-	if (selection.size() == 0) {
+	if (selection.is_empty()) {
 		return;
 	}
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2106,7 +2106,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->add_logger(memnew(RotatedFileLogger(base_path, max_files)));
 	}
 
-	if (main_args.size() == 0 && String(GLOBAL_GET("application/run/main_scene")) == "") {
+	if (main_args.is_empty() && String(GLOBAL_GET("application/run/main_scene")) == "") {
 #ifdef TOOLS_ENABLED
 		if (!editor && !project_manager) {
 #endif

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1135,13 +1135,13 @@ CSGBrush *CSGMesh3D::_build_brush() {
 
 		Array arrays = mesh->surface_get_arrays(i);
 
-		if (arrays.size() == 0) {
+		if (arrays.is_empty()) {
 			_make_dirty();
 			ERR_FAIL_COND_V(arrays.is_empty(), memnew(CSGBrush));
 		}
 
 		Vector<Vector3> avertices = arrays[Mesh::ARRAY_VERTEX];
-		if (avertices.size() == 0) {
+		if (avertices.is_empty()) {
 			continue;
 		}
 
@@ -1257,7 +1257,7 @@ CSGBrush *CSGMesh3D::_build_brush() {
 		}
 	}
 
-	if (vertices.size() == 0) {
+	if (vertices.is_empty()) {
 		return memnew(CSGBrush);
 	}
 

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -379,7 +379,7 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 	Vector<Vector3> faces = cs->get_brush_faces();
 
-	if (faces.size() == 0) {
+	if (faces.is_empty()) {
 		return;
 	}
 

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1080,7 +1080,7 @@ Error FBXDocument::_parse_images(Ref<FBXState> p_state, const String &p_base_pat
 			}
 			// Fallback to loading as byte array.
 			data = FileAccess::get_file_as_bytes(path);
-			if (data.size() == 0) {
+			if (data.is_empty()) {
 				WARN_PRINT(vformat("FBX: Image index '%d' couldn't be loaded from path: %s because there was no data to load. Skipping it.", texture_i, path));
 				p_state->images.push_back(Ref<Texture2D>()); // Placeholder to keep count.
 				p_state->source_images.push_back(Ref<Image>());

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2846,7 +2846,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 		while (subclass) {
 			if (subclass->extends_used) {
 				if (!subclass->extends_path.is_empty()) {
-					if (subclass->extends.size() == 0) {
+					if (subclass->extends.is_empty()) {
 						get_global_class_name(subclass->extends_path, r_base_type);
 						subclass = nullptr;
 						break;

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2157,7 +2157,7 @@ void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 			GDScriptParser::IdentifierNode *callee = static_cast<GDScriptParser::IdentifierNode *>(call->callee);
 			if (callee->name == "range") {
 				list_resolved = true;
-				if (call->arguments.size() < 1) {
+				if (call->arguments.is_empty()) {
 					push_error(R"*(Invalid call for "range()" function. Expected at least 1 argument, none given.)*", call->callee);
 				} else if (call->arguments.size() > 3) {
 					push_error(vformat(R"*(Invalid call for "range()" function. Expected at most 3 arguments, %d given.)*", call->arguments.size()), call->callee);

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -741,7 +741,7 @@ Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state, const String &p_p
 		if (file.is_null()) {
 			return err;
 		}
-		if (buffer_data.size() == 0) {
+		if (buffer_data.is_empty()) {
 			return OK;
 		}
 		file->create(FileAccess::ACCESS_RESOURCES);
@@ -773,7 +773,7 @@ Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state, const String &p_
 		if (file.is_null()) {
 			return err;
 		}
-		if (buffer_data.size() == 0) {
+		if (buffer_data.is_empty()) {
 			return OK;
 		}
 		file->create(FileAccess::ACCESS_RESOURCES);
@@ -1647,7 +1647,7 @@ Vector<double> GLTFDocument::_decode_accessor(Ref<GLTFState> p_state, const GLTF
 }
 
 GLTFAccessorIndex GLTFDocument::_encode_accessor_as_ints(Ref<GLTFState> p_state, const Vector<int32_t> p_attribs, const bool p_for_vertex, const bool p_for_vertex_indices) {
-	if (p_attribs.size() == 0) {
+	if (p_attribs.is_empty()) {
 		return -1;
 	}
 	const int element_count = 1;
@@ -1712,7 +1712,7 @@ Vector<int> GLTFDocument::_decode_accessor_as_ints(Ref<GLTFState> p_state, const
 	const Vector<double> attribs = _decode_accessor(p_state, p_accessor, p_for_vertex);
 	Vector<int> ret;
 
-	if (attribs.size() == 0) {
+	if (attribs.is_empty()) {
 		return ret;
 	}
 
@@ -1737,7 +1737,7 @@ Vector<float> GLTFDocument::_decode_accessor_as_floats(Ref<GLTFState> p_state, c
 	const Vector<double> attribs = _decode_accessor(p_state, p_accessor, p_for_vertex);
 	Vector<float> ret;
 
-	if (attribs.size() == 0) {
+	if (attribs.is_empty()) {
 		return ret;
 	}
 
@@ -1768,7 +1768,7 @@ void GLTFDocument::_round_min_max_components(Vector<double> &r_type_min, Vector<
 }
 
 GLTFAccessorIndex GLTFDocument::_encode_accessor_as_vec2(Ref<GLTFState> p_state, const Vector<Vector2> p_attribs, const bool p_for_vertex) {
-	if (p_attribs.size() == 0) {
+	if (p_attribs.is_empty()) {
 		return -1;
 	}
 	const int element_count = 2;
@@ -1818,7 +1818,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_vec2(Ref<GLTFState> p_state,
 }
 
 GLTFAccessorIndex GLTFDocument::_encode_accessor_as_color(Ref<GLTFState> p_state, const Vector<Color> p_attribs, const bool p_for_vertex) {
-	if (p_attribs.size() == 0) {
+	if (p_attribs.is_empty()) {
 		return -1;
 	}
 
@@ -1884,7 +1884,7 @@ void GLTFDocument::_calc_accessor_min_max(int p_i, const int p_element_count, Ve
 }
 
 GLTFAccessorIndex GLTFDocument::_encode_accessor_as_weights(Ref<GLTFState> p_state, const Vector<Color> p_attribs, const bool p_for_vertex) {
-	if (p_attribs.size() == 0) {
+	if (p_attribs.is_empty()) {
 		return -1;
 	}
 
@@ -1938,7 +1938,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_weights(Ref<GLTFState> p_sta
 }
 
 GLTFAccessorIndex GLTFDocument::_encode_accessor_as_joints(Ref<GLTFState> p_state, const Vector<Color> p_attribs, const bool p_for_vertex) {
-	if (p_attribs.size() == 0) {
+	if (p_attribs.is_empty()) {
 		return -1;
 	}
 
@@ -1989,7 +1989,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_joints(Ref<GLTFState> p_stat
 }
 
 GLTFAccessorIndex GLTFDocument::_encode_accessor_as_quaternions(Ref<GLTFState> p_state, const Vector<Quaternion> p_attribs, const bool p_for_vertex) {
-	if (p_attribs.size() == 0) {
+	if (p_attribs.is_empty()) {
 		return -1;
 	}
 	const int element_count = 4;
@@ -2045,7 +2045,7 @@ Vector<Vector2> GLTFDocument::_decode_accessor_as_vec2(Ref<GLTFState> p_state, c
 	const Vector<double> attribs = _decode_accessor(p_state, p_accessor, p_for_vertex);
 	Vector<Vector2> ret;
 
-	if (attribs.size() == 0) {
+	if (attribs.is_empty()) {
 		return ret;
 	}
 
@@ -2068,7 +2068,7 @@ Vector<Vector2> GLTFDocument::_decode_accessor_as_vec2(Ref<GLTFState> p_state, c
 }
 
 GLTFAccessorIndex GLTFDocument::_encode_accessor_as_floats(Ref<GLTFState> p_state, const Vector<double> p_attribs, const bool p_for_vertex) {
-	if (p_attribs.size() == 0) {
+	if (p_attribs.is_empty()) {
 		return -1;
 	}
 	const int element_count = 1;
@@ -2117,7 +2117,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_floats(Ref<GLTFState> p_stat
 }
 
 GLTFAccessorIndex GLTFDocument::_encode_accessor_as_vec3(Ref<GLTFState> p_state, const Vector<Vector3> p_attribs, const bool p_for_vertex) {
-	if (p_attribs.size() == 0) {
+	if (p_attribs.is_empty()) {
 		return -1;
 	}
 	const int element_count = 3;
@@ -2167,7 +2167,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_vec3(Ref<GLTFState> p_state,
 }
 
 GLTFAccessorIndex GLTFDocument::_encode_sparse_accessor_as_vec3(Ref<GLTFState> p_state, const Vector<Vector3> p_attribs, const Vector<Vector3> p_reference_attribs, const float p_reference_multiplier, const bool p_for_vertex, const GLTFAccessorIndex p_reference_accessor) {
-	if (p_attribs.size() == 0) {
+	if (p_attribs.is_empty()) {
 		return -1;
 	}
 
@@ -2276,7 +2276,7 @@ GLTFAccessorIndex GLTFDocument::_encode_sparse_accessor_as_vec3(Ref<GLTFState> p
 }
 
 GLTFAccessorIndex GLTFDocument::_encode_accessor_as_xform(Ref<GLTFState> p_state, const Vector<Transform3D> p_attribs, const bool p_for_vertex) {
-	if (p_attribs.size() == 0) {
+	if (p_attribs.is_empty()) {
 		return -1;
 	}
 	const int element_count = 16;
@@ -2351,7 +2351,7 @@ Vector<Vector3> GLTFDocument::_decode_accessor_as_vec3(Ref<GLTFState> p_state, c
 	const Vector<double> attribs = _decode_accessor(p_state, p_accessor, p_for_vertex);
 	Vector<Vector3> ret;
 
-	if (attribs.size() == 0) {
+	if (attribs.is_empty()) {
 		return ret;
 	}
 
@@ -2377,7 +2377,7 @@ Vector<Color> GLTFDocument::_decode_accessor_as_color(Ref<GLTFState> p_state, co
 	const Vector<double> attribs = _decode_accessor(p_state, p_accessor, p_for_vertex);
 	Vector<Color> ret;
 
-	if (attribs.size() == 0) {
+	if (attribs.is_empty()) {
 		return ret;
 	}
 
@@ -2409,7 +2409,7 @@ Vector<Quaternion> GLTFDocument::_decode_accessor_as_quaternion(Ref<GLTFState> p
 	const Vector<double> attribs = _decode_accessor(p_state, p_accessor, p_for_vertex);
 	Vector<Quaternion> ret;
 
-	if (attribs.size() == 0) {
+	if (attribs.is_empty()) {
 		return ret;
 	}
 
@@ -2428,7 +2428,7 @@ Vector<Transform2D> GLTFDocument::_decode_accessor_as_xform2d(Ref<GLTFState> p_s
 	const Vector<double> attribs = _decode_accessor(p_state, p_accessor, p_for_vertex);
 	Vector<Transform2D> ret;
 
-	if (attribs.size() == 0) {
+	if (attribs.is_empty()) {
 		return ret;
 	}
 
@@ -2445,7 +2445,7 @@ Vector<Basis> GLTFDocument::_decode_accessor_as_basis(Ref<GLTFState> p_state, co
 	const Vector<double> attribs = _decode_accessor(p_state, p_accessor, p_for_vertex);
 	Vector<Basis> ret;
 
-	if (attribs.size() == 0) {
+	if (attribs.is_empty()) {
 		return ret;
 	}
 
@@ -2463,7 +2463,7 @@ Vector<Transform3D> GLTFDocument::_decode_accessor_as_xform(Ref<GLTFState> p_sta
 	const Vector<double> attribs = _decode_accessor(p_state, p_accessor, p_for_vertex);
 	Vector<Transform3D> ret;
 
-	if (attribs.size() == 0) {
+	if (attribs.is_empty()) {
 		return ret;
 	}
 
@@ -4148,7 +4148,7 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> p_state, const String &p_base_p
 				// Fallback to loading as byte array. This enables us to support the
 				// spec's requirement that we honor mimetype regardless of file URI.
 				data = FileAccess::get_file_as_bytes(resource_uri);
-				if (data.size() == 0) {
+				if (data.is_empty()) {
 					WARN_PRINT(vformat("glTF: Image index '%d' couldn't be loaded as a buffer of MIME type '%s' from URI: %s because there was no data to load. Skipping it.", i, mime_type, resource_uri));
 					p_state->images.push_back(Ref<Texture2D>()); // Placeholder to keep count.
 					p_state->source_images.push_back(Ref<Image>());

--- a/modules/gltf/skin_tool.cpp
+++ b/modules/gltf/skin_tool.cpp
@@ -520,7 +520,7 @@ Error SkinTool::_determine_skeleton_roots(
 
 	skeleton->roots = roots;
 
-	if (roots.size() == 0) {
+	if (roots.is_empty()) {
 		return FAILED;
 	} else if (roots.size() == 1) {
 		return OK;

--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -626,7 +626,7 @@ void GodotBody2D::integrate_velocities(real_t p_step) {
 	if (mode == PhysicsServer2D::BODY_MODE_KINEMATIC) {
 		_set_transform(new_transform, false);
 		_set_inv_transform(new_transform.affine_inverse());
-		if (contacts.size() == 0 && linear_velocity == Vector2() && angular_velocity == 0) {
+		if (contacts.is_empty() && linear_velocity == Vector2() && angular_velocity == 0) {
 			set_active(false); //stopped moving, deactivate
 		}
 		return;

--- a/modules/godot_physics_2d/godot_shape_2d.cpp
+++ b/modules/godot_physics_2d/godot_shape_2d.cpp
@@ -665,7 +665,7 @@ bool GodotConcavePolygonShape2D::contains_point(const Vector2 &p_point) const {
 }
 
 bool GodotConcavePolygonShape2D::intersect_segment(const Vector2 &p_begin, const Vector2 &p_end, Vector2 &r_point, Vector2 &r_normal) const {
-	if (segments.size() == 0 || points.size() == 0) {
+	if (segments.is_empty() || points.is_empty()) {
 		return false;
 	}
 
@@ -919,7 +919,7 @@ void GodotConcavePolygonShape2D::cull(const Rect2 &p_local_aabb, QueryCallback p
 		stack[i]=0;
 	*/
 
-	if (segments.size() == 0 || points.size() == 0 || bvh.size() == 0) {
+	if (segments.is_empty() || points.is_empty() || bvh.is_empty()) {
 		return;
 	}
 

--- a/modules/godot_physics_3d/godot_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_3d.cpp
@@ -701,7 +701,7 @@ void GodotBody3D::integrate_velocities(real_t p_step) {
 	if (mode == PhysicsServer3D::BODY_MODE_KINEMATIC) {
 		_set_transform(new_transform, false);
 		_set_inv_transform(new_transform.affine_inverse());
-		if (contacts.size() == 0 && linear_velocity == Vector3() && angular_velocity == Vector3()) {
+		if (contacts.is_empty() && linear_velocity == Vector3() && angular_velocity == Vector3()) {
 			set_active(false); //stopped moving, deactivate
 		}
 

--- a/modules/godot_physics_3d/godot_shape_3d.cpp
+++ b/modules/godot_physics_3d/godot_shape_3d.cpp
@@ -838,7 +838,7 @@ void GodotConvexPolygonShape3D::project_range(const Vector3 &p_normal, const Tra
 
 Vector3 GodotConvexPolygonShape3D::get_support(const Vector3 &p_normal) const {
 	// Skip if there are no vertices in the mesh
-	if (mesh.vertices.size() == 0) {
+	if (mesh.vertices.is_empty()) {
 		return Vector3();
 	}
 
@@ -1369,7 +1369,7 @@ void GodotConcavePolygonShape3D::_cull_segment(int p_idx, _SegmentCullParams *p_
 }
 
 bool GodotConcavePolygonShape3D::intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const {
-	if (faces.size() == 0) {
+	if (faces.is_empty()) {
 		return false;
 	}
 
@@ -1449,7 +1449,7 @@ bool GodotConcavePolygonShape3D::_cull(int p_idx, _CullParams *p_params) const {
 
 void GodotConcavePolygonShape3D::cull(const AABB &p_local_aabb, QueryCallback p_callback, void *p_userdata, bool p_invert_backface_collision) const {
 	// make matrix local to concave
-	if (faces.size() == 0) {
+	if (faces.is_empty()) {
 		return;
 	}
 

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -605,7 +605,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 	}
 	g.multimesh_instances.clear();
 
-	if (g.cells.size() == 0) {
+	if (g.cells.is_empty()) {
 		//octant no longer needed
 		_octant_clean_up(p_key);
 		return true;
@@ -637,7 +637,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 		xform.basis = _ortho_bases[c.rot];
 		xform.set_origin(cellpos * cell_size + ofs);
 		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
-		if (baked_meshes.size() == 0) {
+		if (baked_meshes.is_empty()) {
 			if (mesh_library->get_item_mesh(c.item).is_valid()) {
 				if (!multimesh_items.has(c.item)) {
 					multimesh_items[c.item] = List<Pair<Transform3D, IndexKey>>();
@@ -716,7 +716,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 #endif // defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
 
 	//update multimeshes, only if not baked
-	if (baked_meshes.size() == 0) {
+	if (baked_meshes.is_empty()) {
 		for (const KeyValue<int, List<Pair<Transform3D, IndexKey>>> &E : multimesh_items) {
 			Octant::MultimeshInstance mmi;
 
@@ -1642,7 +1642,7 @@ void GridMap::_update_octant_navigation_debug_edge_connections_mesh(const Octant
 		}
 	}
 
-	if (vertex_array.size() == 0) {
+	if (vertex_array.is_empty()) {
 		return;
 	}
 

--- a/modules/interactive_music/editor/audio_stream_interactive_editor_plugin.cpp
+++ b/modules/interactive_music/editor/audio_stream_interactive_editor_plugin.cpp
@@ -115,7 +115,7 @@ void AudioStreamInteractiveTransitionEditor::_update_selection() {
 	filler_clip->set_disabled(selected.is_empty());
 	hold_previous->set_disabled(selected.is_empty());
 
-	if (selected.size() == 0) {
+	if (selected.is_empty()) {
 		return;
 	}
 

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -645,19 +645,19 @@ void LightmapperRD::_create_acceleration_structures(RenderingDevice *rd, Size2i 
 		r_cluster_aabbs_buffer = rd->storage_buffer_create(cab.size(), cab);
 
 		Vector<uint8_t> lb = lights.to_byte_array();
-		if (lb.size() == 0) {
+		if (lb.is_empty()) {
 			lb.resize(sizeof(Light)); //even if no lights, the buffer must exist
 		}
 		lights_buffer = rd->storage_buffer_create(lb.size(), lb);
 
 		Vector<uint8_t> sb = seam_buffer_vec.to_byte_array();
-		if (sb.size() == 0) {
+		if (sb.is_empty()) {
 			sb.resize(sizeof(Vector2i) * 2); //even if no seams, the buffer must exist
 		}
 		seams_buffer = rd->storage_buffer_create(sb.size(), sb);
 
 		Vector<uint8_t> pb = p_probe_positions.to_byte_array();
-		if (pb.size() == 0) {
+		if (pb.is_empty()) {
 			pb.resize(sizeof(Probe));
 		}
 		probe_positions_buffer = rd->storage_buffer_create(pb.size(), pb);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -650,7 +650,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 
 		for (SelfList<CSharpScript> *elem = script_list.first(); elem; elem = elem->next()) {
 			// Do not reload scripts with only non-collectible instances to avoid disrupting event subscriptions and such.
-			bool is_reloadable = elem->self()->instances.size() == 0;
+			bool is_reloadable = elem->self()->instances.is_empty();
 			for (Object *obj : elem->self()->instances) {
 				ERR_CONTINUE(!obj->get_script_instance());
 				CSharpInstance *csi = static_cast<CSharpInstance *>(obj->get_script_instance());

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -3200,7 +3200,7 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 
 	// Generate signal
 	{
-		bool is_parameterless = p_isignal.arguments.size() == 0;
+		bool is_parameterless = p_isignal.arguments.is_empty();
 
 		// Delegate name is [SignalName]EventHandler
 		String delegate_name = is_parameterless ? "Action" : p_isignal.proxy_name + "EventHandler";

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -249,7 +249,7 @@ String BindingsGenerator::bbcode_to_text(const String &p_bbcode, const TypeInter
 
 			const Vector<String> link_target_parts = link_target.split(".");
 
-			if (link_target_parts.size() <= 0 || link_target_parts.size() > 2) {
+			if (link_target_parts.is_empty() || link_target_parts.size() > 2) {
 				ERR_PRINT("Invalid reference format: '" + tag + "'.");
 
 				output.append(tag);
@@ -561,7 +561,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 
 			const Vector<String> link_target_parts = link_target.split(".");
 
-			if (link_target_parts.size() <= 0 || link_target_parts.size() > 2) {
+			if (link_target_parts.is_empty() || link_target_parts.size() > 2) {
 				ERR_PRINT("Invalid reference format: '" + tag + "'.");
 
 				xml_output.append("<c>");

--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -376,7 +376,7 @@ Error MultiplayerSynchronizer::_watch_changes(uint64_t p_usec) {
 	if (props.size() != watchers.size()) {
 		watchers.resize(props.size());
 	}
-	if (props.size() == 0) {
+	if (props.is_empty()) {
 		return OK;
 	}
 	Node *node = get_root_node();

--- a/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
@@ -71,7 +71,7 @@ NavMeshGenerator2D::~NavMeshGenerator2D() {
 }
 
 void NavMeshGenerator2D::sync() {
-	if (generator_tasks.size() == 0) {
+	if (generator_tasks.is_empty()) {
 		return;
 	}
 

--- a/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
@@ -70,7 +70,7 @@ NavMeshGenerator3D::~NavMeshGenerator3D() {
 }
 
 void NavMeshGenerator3D::sync() {
-	if (generator_tasks.size() == 0) {
+	if (generator_tasks.is_empty()) {
 		return;
 	}
 

--- a/modules/noise/noise.cpp
+++ b/modules/noise/noise.cpp
@@ -54,7 +54,7 @@ Vector<Ref<Image>> Noise::_get_seamless_image(int p_width, int p_height, int p_d
 
 Ref<Image> Noise::get_seamless_image(int p_width, int p_height, bool p_invert, bool p_in_3d_space, real_t p_blend_skirt, bool p_normalize) const {
 	Vector<Ref<Image>> images = _get_seamless_image(p_width, p_height, 1, p_invert, p_in_3d_space, p_blend_skirt, p_normalize);
-	if (images.size() == 0) {
+	if (images.is_empty()) {
 		return Ref<Image>();
 	}
 	return images[0];

--- a/modules/openxr/action_map/openxr_action_set.cpp
+++ b/modules/openxr/action_map/openxr_action_set.cpp
@@ -84,7 +84,7 @@ int OpenXRActionSet::get_action_count() const {
 
 void OpenXRActionSet::clear_actions() {
 	// Actions held within our action set should be released and destroyed but just in case they are still used some where else
-	if (actions.size() == 0) {
+	if (actions.is_empty()) {
 		return;
 	}
 

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -69,7 +69,7 @@ String RegExMatch::get_subject() const {
 }
 
 int RegExMatch::get_group_count() const {
-	if (data.size() == 0) {
+	if (data.is_empty()) {
 		return 0;
 	}
 	return data.size() - 1;

--- a/modules/tinyexr/image_saver_tinyexr.cpp
+++ b/modules/tinyexr/image_saver_tinyexr.cpp
@@ -285,7 +285,7 @@ Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale) {
 
 Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) {
 	const Vector<uint8_t> buffer = save_exr_buffer(p_img, p_grayscale);
-	if (buffer.size() == 0) {
+	if (buffer.is_empty()) {
 		print_error(String("Saving EXR failed."));
 		return ERR_FILE_CANT_WRITE;
 	} else {

--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -64,7 +64,7 @@ bool WebRTCMultiplayerPeer::is_server() const {
 }
 
 void WebRTCMultiplayerPeer::poll() {
-	if (peer_map.size() == 0) {
+	if (peer_map.is_empty()) {
 		return;
 	}
 

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -451,7 +451,7 @@ bool WSLPeer::_verify_server_response() {
 	WSL_CHECK_NC("sec-websocket-accept", _compute_key_response(session_key));
 #undef WSL_CHECK_NC
 #undef WSL_CHECK
-	if (supported_protocols.size() == 0) {
+	if (supported_protocols.is_empty()) {
 		// We didn't request a custom protocol
 		ERR_FAIL_COND_V_MSG(headers.has("sec-websocket-protocol"), false, "Received unrequested sub-protocol -> " + headers["sec-websocket-protocol"]);
 	} else {

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -294,7 +294,7 @@ bool WebXRInterfaceJS::initialize() {
 			return false;
 		}
 
-		if (requested_reference_space_types.size() == 0) {
+		if (requested_reference_space_types.is_empty()) {
 			return false;
 		}
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2092,7 +2092,7 @@ void DisplayServerX11::_update_window_mouse_passthrough(WindowID p_window) {
 			Region region = XCreateRegion();
 			XShapeCombineRegion(x11_display, windows[p_window].x11_window, ShapeInput, 0, 0, region, ShapeSet);
 			XDestroyRegion(region);
-		} else if (region_path.size() == 0) {
+		} else if (region_path.is_empty()) {
 			XShapeCombineMask(x11_display, windows[p_window].x11_window, ShapeInput, 0, 0, None, ShapeSet);
 		} else {
 			XPoint *points = (XPoint *)memalloc(sizeof(XPoint) * region_path.size());

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -95,7 +95,7 @@ void AudioDriverWeb::_audio_driver_process(int p_from, int p_samples) {
 }
 
 void AudioDriverWeb::_audio_driver_capture(int p_from, int p_samples) {
-	if (get_input_buffer().size() == 0) {
+	if (get_input_buffer().is_empty()) {
 		return; // Input capture stopped.
 	}
 	const int max_samples = memarr_len(input_rb);

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -420,7 +420,7 @@ public:
 		int gid = ctl_id++;
 		int cid = ctl_id++;
 
-		if (p_options.size() == 0) {
+		if (p_options.is_empty()) {
 			// Add check box.
 			p_pfdc->StartVisualGroup(gid, L"");
 			p_pfdc->AddCheckButton(cid, (LPCWSTR)p_name.utf16().get_data(), p_default);

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -301,7 +301,7 @@ void AnimatedSprite2D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 
 		List<StringName> al;
 		frames->get_animation_list(&al);
-		if (al.size() == 0) {
+		if (al.is_empty()) {
 			set_animation(StringName());
 			autoplay = String();
 		} else {

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -675,7 +675,7 @@ static real_t rand_from_seed(uint32_t &seed) {
 }
 
 void CPUParticles2D::_update_internal() {
-	if (particles.size() == 0 || !is_visible_in_tree()) {
+	if (particles.is_empty() || !is_visible_in_tree()) {
 		_set_do_redraw(false);
 		return;
 	}

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -51,7 +51,7 @@ Rect2 OccluderPolygon2D::_edit_get_rect() const {
 			}
 			rect_cache_dirty = false;
 		} else {
-			if (polygon.size() == 0) {
+			if (polygon.is_empty()) {
 				item_rect = Rect2();
 			} else {
 				Vector2 d = Vector2(LINE_GRAB_WIDTH, LINE_GRAB_WIDTH);
@@ -270,7 +270,7 @@ PackedStringArray LightOccluder2D::get_configuration_warnings() const {
 		warnings.push_back(RTR("An occluder polygon must be set (or drawn) for this occluder to take effect."));
 	}
 
-	if (occluder_polygon.is_valid() && occluder_polygon->get_polygon().size() == 0) {
+	if (occluder_polygon.is_valid() && occluder_polygon->get_polygon().is_empty()) {
 		warnings.push_back(RTR("The occluder polygon for this occluder is empty. Please draw a polygon."));
 	}
 

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -38,7 +38,7 @@ Line2D::Line2D() {
 
 #ifdef DEBUG_ENABLED
 Rect2 Line2D::_edit_get_rect() const {
-	if (_points.size() == 0) {
+	if (_points.is_empty()) {
 		return Rect2(0, 0, 0, 0);
 	}
 	Vector2 min = _points[0];

--- a/scene/2d/navigation/navigation_agent_2d.cpp
+++ b/scene/2d/navigation/navigation_agent_2d.cpp
@@ -594,7 +594,7 @@ Vector2 NavigationAgent2D::get_next_path_position() {
 	_update_navigation();
 
 	const Vector<Vector2> &navigation_path = navigation_result->get_path();
-	if (navigation_path.size() == 0) {
+	if (navigation_path.is_empty()) {
 		ERR_FAIL_NULL_V_MSG(agent_parent, Vector2(), "The agent has no parent.");
 		return agent_parent->get_global_position();
 	} else {
@@ -632,7 +632,7 @@ Vector2 NavigationAgent2D::get_final_position() {
 
 Vector2 NavigationAgent2D::_get_final_position() const {
 	const Vector<Vector2> &navigation_path = navigation_result->get_path();
-	if (navigation_path.size() == 0) {
+	if (navigation_path.is_empty()) {
 		return Vector2();
 	}
 	return navigation_path[navigation_path.size() - 1];
@@ -685,7 +685,7 @@ void NavigationAgent2D::_update_navigation() {
 
 	if (NavigationServer2D::get_singleton()->agent_is_map_changed(agent)) {
 		reload_path = true;
-	} else if (navigation_result->get_path().size() == 0) {
+	} else if (navigation_result->get_path().is_empty()) {
 		reload_path = true;
 	} else {
 		// Check if too far from the navigation path
@@ -724,7 +724,7 @@ void NavigationAgent2D::_update_navigation() {
 		emit_signal(SNAME("path_changed"));
 	}
 
-	if (navigation_result->get_path().size() == 0) {
+	if (navigation_result->get_path().is_empty()) {
 		return;
 	}
 

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -509,7 +509,7 @@ Ref<KinematicCollision2D> CharacterBody2D::_get_slide_collision(int p_bounce) {
 }
 
 Ref<KinematicCollision2D> CharacterBody2D::_get_last_slide_collision() {
-	if (motion_results.size() == 0) {
+	if (motion_results.is_empty()) {
 		return Ref<KinematicCollision2D>();
 	}
 	return _get_slide_collision(motion_results.size() - 1);

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -295,7 +295,7 @@ uint32_t CollisionObject2D::create_shape_owner(Object *p_owner) {
 	ShapeData sd;
 	uint32_t id;
 
-	if (shapes.size() == 0) {
+	if (shapes.is_empty()) {
 		id = 0;
 	} else {
 		id = shapes.back()->key() + 1;

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -157,7 +157,7 @@ void Polygon2D::_notification(int p_what) {
 			Vector<float> weights;
 
 			int len = polygon.size();
-			if ((invert || polygons.size() == 0) && internal_vertices > 0) {
+			if ((invert || polygons.is_empty()) && internal_vertices > 0) {
 				//if no polygons are around, internal vertices must not be drawn, else let them be
 				len -= internal_vertices;
 			}
@@ -327,7 +327,7 @@ void Polygon2D::_notification(int p_what) {
 
 			Vector<int> index_array;
 
-			if (invert || polygons.size() == 0) {
+			if (invert || polygons.is_empty()) {
 				index_array = Geometry2D::triangulate_polygon(points);
 			} else {
 				//draw individual polygons

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -647,7 +647,7 @@ static real_t rand_from_seed(uint32_t &seed) {
 }
 
 void CPUParticles3D::_update_internal() {
-	if (particles.size() == 0 || !is_visible_in_tree()) {
+	if (particles.is_empty() || !is_visible_in_tree()) {
 		_set_redraw(false);
 		return;
 	}

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -698,7 +698,7 @@ int32_t LightmapGI::_compute_bsp_tree(const Vector<Vector3> &p_points, const Loc
 	BSPNode node;
 	node.plane = best_plane;
 
-	if (indices_under.size() == 0) {
+	if (indices_under.is_empty()) {
 		//nothing to do here
 		node.under = BSPNode::EMPTY_LEAF;
 	} else if (indices_under.size() == 1) {
@@ -707,7 +707,7 @@ int32_t LightmapGI::_compute_bsp_tree(const Vector<Vector3> &p_points, const Loc
 		node.under = _compute_bsp_tree(p_points, p_planes, planes_tested, p_simplices, indices_under, bsp_nodes);
 	}
 
-	if (indices_over.size() == 0) {
+	if (indices_over.is_empty()) {
 		//nothing to do here
 		node.over = BSPNode::EMPTY_LEAF;
 	} else if (indices_over.size() == 1) {
@@ -916,7 +916,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 		Vector<MeshesFound> meshes_found;
 		_find_meshes_and_lights(p_from_node ? p_from_node : get_parent(), meshes_found, lights_found, probes_found);
 
-		if (meshes_found.size() == 0) {
+		if (meshes_found.is_empty()) {
 			return BAKE_ERROR_NO_MESHES;
 		}
 		// create mesh data for insert
@@ -1023,8 +1023,8 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 				const Vector3 *nr = nullptr;
 				Vector<int> index = a[Mesh::ARRAY_INDEX];
 
-				ERR_CONTINUE(uv.size() == 0);
-				ERR_CONTINUE(normals.size() == 0);
+				ERR_CONTINUE(uv.is_empty());
+				ERR_CONTINUE(normals.is_empty());
 
 				uvr = uv.ptr();
 				nr = normals.ptr();

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -437,11 +437,11 @@ MeshInstance3D *MeshInstance3D::create_debug_tangents_node() {
 
 		Vector<Vector3> verts = arrays[Mesh::ARRAY_VERTEX];
 		Vector<Vector3> norms = arrays[Mesh::ARRAY_NORMAL];
-		if (norms.size() == 0) {
+		if (norms.is_empty()) {
 			continue;
 		}
 		Vector<float> tangents = arrays[Mesh::ARRAY_TANGENT];
-		if (tangents.size() == 0) {
+		if (tangents.is_empty()) {
 			continue;
 		}
 

--- a/scene/3d/navigation/navigation_agent_3d.cpp
+++ b/scene/3d/navigation/navigation_agent_3d.cpp
@@ -658,7 +658,7 @@ Vector3 NavigationAgent3D::get_next_path_position() {
 	_update_navigation();
 
 	const Vector<Vector3> &navigation_path = navigation_result->get_path();
-	if (navigation_path.size() == 0) {
+	if (navigation_path.is_empty()) {
 		ERR_FAIL_NULL_V_MSG(agent_parent, Vector3(), "The agent has no parent.");
 		return agent_parent->get_global_position();
 	} else {
@@ -696,7 +696,7 @@ Vector3 NavigationAgent3D::get_final_position() {
 
 Vector3 NavigationAgent3D::_get_final_position() const {
 	const Vector<Vector3> &navigation_path = navigation_result->get_path();
-	if (navigation_path.size() == 0) {
+	if (navigation_path.is_empty()) {
 		return Vector3();
 	}
 	return navigation_path[navigation_path.size() - 1] - Vector3(0, path_height_offset, 0);
@@ -751,7 +751,7 @@ void NavigationAgent3D::_update_navigation() {
 
 	if (NavigationServer3D::get_singleton()->agent_is_map_changed(agent)) {
 		reload_path = true;
-	} else if (navigation_result->get_path().size() == 0) {
+	} else if (navigation_result->get_path().is_empty()) {
 		reload_path = true;
 	} else {
 		// Check if too far from the navigation path
@@ -792,7 +792,7 @@ void NavigationAgent3D::_update_navigation() {
 		emit_signal(SNAME("path_changed"));
 	}
 
-	if (navigation_result->get_path().size() == 0) {
+	if (navigation_result->get_path().is_empty()) {
 		return;
 	}
 

--- a/scene/3d/navigation/navigation_region_3d.cpp
+++ b/scene/3d/navigation/navigation_region_3d.cpp
@@ -504,7 +504,7 @@ void NavigationRegion3D::_update_debug_mesh() {
 	debug_mesh->clear_surfaces();
 
 	Vector<Vector3> vertices = navigation_mesh->get_vertices();
-	if (vertices.size() == 0) {
+	if (vertices.is_empty()) {
 		return;
 	}
 
@@ -720,7 +720,7 @@ void NavigationRegion3D::_update_debug_edge_connections_mesh() {
 		vertex_array_ptrw[vertex_array_index++] = right_end_pos;
 	}
 
-	if (vertex_array.size() == 0) {
+	if (vertex_array.is_empty()) {
 		return;
 	}
 

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -521,7 +521,7 @@ void OccluderInstance3D::_bake_surface(const Transform3D &p_transform, Array p_s
 	PackedVector3Array vertices = p_surface_arrays[Mesh::ARRAY_VERTEX];
 	PackedInt32Array indices = p_surface_arrays[Mesh::ARRAY_INDEX];
 
-	if (vertices.size() == 0 || indices.size() == 0) {
+	if (vertices.is_empty() || indices.is_empty()) {
 		return;
 	}
 

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -717,7 +717,7 @@ Ref<KinematicCollision3D> CharacterBody3D::_get_slide_collision(int p_bounce) {
 }
 
 Ref<KinematicCollision3D> CharacterBody3D::_get_last_slide_collision() {
-	if (motion_results.size() == 0) {
+	if (motion_results.is_empty()) {
 		return Ref<KinematicCollision3D>();
 	}
 	return _get_slide_collision(motion_results.size() - 1);

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -519,7 +519,7 @@ uint32_t CollisionObject3D::create_shape_owner(Object *p_owner) {
 	ShapeData sd;
 	uint32_t id;
 
-	if (shapes.size() == 0) {
+	if (shapes.is_empty()) {
 		id = 0;
 	} else {
 		id = shapes.back()->key() + 1;

--- a/scene/3d/physics/collision_polygon_3d.cpp
+++ b/scene/3d/physics/collision_polygon_3d.cpp
@@ -41,12 +41,12 @@ void CollisionPolygon3D::_build_polygon() {
 
 	collision_object->shape_owner_clear_shapes(owner_id);
 
-	if (polygon.size() == 0) {
+	if (polygon.is_empty()) {
 		return;
 	}
 
 	Vector<Vector<Vector2>> decomp = Geometry2D::decompose_polygon_in_convex(polygon);
-	if (decomp.size() == 0) {
+	if (decomp.is_empty()) {
 		return;
 	}
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1186,7 +1186,7 @@ void AnimatedSprite3D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 
 		List<StringName> al;
 		frames->get_animation_list(&al);
-		if (al.size() == 0) {
+		if (al.is_empty()) {
 			set_animation(StringName());
 			autoplay = String();
 		} else {

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -367,7 +367,7 @@ void AnimationNodeBlendSpace2D::_update_triangles() {
 Vector2 AnimationNodeBlendSpace2D::get_closest_point(const Vector2 &p_point) {
 	_update_triangles();
 
-	if (triangles.size() == 0) {
+	if (triangles.is_empty()) {
 		return Vector2();
 	}
 

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1998,7 +1998,7 @@ void AnimationMixer::_blend_apply() {
 					for (uint32_t erase_idx = 0; erase_idx < erase_streams.size(); erase_idx++) {
 						map.erase(erase_streams[erase_idx]);
 					}
-					if (map.size() == 0) {
+					if (map.is_empty()) {
 						erase_maps.push_back(L.key);
 					}
 				}

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -563,7 +563,7 @@ bool AnimationNodeStateMachinePlayback::_make_travel_path(AnimationTree *p_tree,
 
 	// Begin astar.
 	while (!found_route) {
-		if (open_list.size() == 0) {
+		if (open_list.is_empty()) {
 			break; // No path found.
 		}
 

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -475,7 +475,7 @@ void SceneDebugger::remove_from_cache(const String &p_filename, Node *p_node) {
 	HashMap<String, HashSet<Node *>>::Iterator E = edit_cache.find(p_filename);
 	if (E) {
 		E->value.erase(p_node);
-		if (E->value.size() == 0) {
+		if (E->value.is_empty()) {
 			edit_cache.remove(E);
 		}
 	}
@@ -1178,7 +1178,7 @@ void LiveEditor::_restore_node_func(ObjectID p_id, const NodePath &p_at, int p_a
 
 		EN->value.remove(FN);
 
-		if (EN->value.size() == 0) {
+		if (EN->value.is_empty()) {
 			live_edit_remove_list.remove(EN);
 		}
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -963,7 +963,7 @@ void CodeEdit::indent_lines() {
 	for (Point2i line_range : line_ranges) {
 		for (int i = line_range.x; i <= line_range.y; i++) {
 			const String line_text = get_line(i);
-			if (line_text.size() == 0) {
+			if (line_text.is_empty()) {
 				// Ignore empty lines.
 				continue;
 			}
@@ -1599,7 +1599,7 @@ bool CodeEdit::can_fold_line(int p_line) const {
 		return false;
 	}
 
-	if (p_line + 1 >= get_line_count() || get_line(p_line).strip_edges().size() == 0) {
+	if (p_line + 1 >= get_line_count() || get_line(p_line).strip_edges().is_empty()) {
 		return false;
 	}
 
@@ -1658,7 +1658,7 @@ bool CodeEdit::can_fold_line(int p_line) const {
 	/* Otherwise check indent levels. */
 	int start_indent = get_indent_level(p_line);
 	for (int i = p_line + 1; i < get_line_count(); i++) {
-		if (is_in_string(i) != -1 || is_in_comment(i) != -1 || get_line(i).strip_edges().size() == 0) {
+		if (is_in_string(i) != -1 || is_in_comment(i) != -1 || get_line(i).strip_edges().is_empty()) {
 			continue;
 		}
 		return (get_indent_level(i) > start_indent);
@@ -1711,7 +1711,7 @@ void CodeEdit::fold_line(int p_line) {
 		} else {
 			int start_indent = get_indent_level(p_line);
 			for (int i = p_line + 1; i <= line_count; i++) {
-				if (get_line(i).strip_edges().size() == 0) {
+				if (get_line(i).strip_edges().is_empty()) {
 					continue;
 				}
 				if (get_indent_level(i) > start_indent) {
@@ -1958,7 +1958,7 @@ String CodeEdit::get_delimiter_end_key(int p_delimiter_idx) const {
 }
 
 Point2 CodeEdit::get_delimiter_start_position(int p_line, int p_column) const {
-	if (delimiters.size() == 0) {
+	if (delimiters.is_empty()) {
 		return Point2(-1, -1);
 	}
 	ERR_FAIL_INDEX_V(p_line, get_line_count(), Point2(-1, -1));
@@ -2009,7 +2009,7 @@ Point2 CodeEdit::get_delimiter_start_position(int p_line, int p_column) const {
 }
 
 Point2 CodeEdit::get_delimiter_end_position(int p_line, int p_column) const {
-	if (delimiters.size() == 0) {
+	if (delimiters.is_empty()) {
 		return Point2(-1, -1);
 	}
 	ERR_FAIL_INDEX_V(p_line, get_line_count(), Point2(-1, -1));
@@ -3060,7 +3060,7 @@ void CodeEdit::_update_code_region_tags() {
 
 /* Delimiters */
 void CodeEdit::_update_delimiter_cache(int p_from_line, int p_to_line) {
-	if (delimiters.size() == 0) {
+	if (delimiters.is_empty()) {
 		return;
 	}
 
@@ -3210,7 +3210,7 @@ void CodeEdit::_update_delimiter_cache(int p_from_line, int p_to_line) {
 }
 
 int CodeEdit::_is_in_delimiter(int p_line, int p_column, DelimiterType p_type) const {
-	if (delimiters.size() == 0 || p_line >= delimiter_cache.size()) {
+	if (delimiters.is_empty() || p_line >= delimiter_cache.size()) {
 		return -1;
 	}
 	ERR_FAIL_INDEX_V(p_line, get_line_count(), 0);
@@ -3424,7 +3424,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 		GDVIRTUAL_CALL(_filter_code_completion_candidates, completion_options_sources, completion_options);
 
 		/* No options to complete, cancel. */
-		if (completion_options.size() == 0) {
+		if (completion_options.is_empty()) {
 			cancel_code_completion();
 			return;
 		}
@@ -3656,7 +3656,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 	}
 
 	/* No options to complete, cancel. */
-	if (code_completion_options_new.size() == 0) {
+	if (code_completion_options_new.is_empty()) {
 		cancel_code_completion();
 		return;
 	}

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -486,7 +486,7 @@ void FileDialog::_post_popup() {
 void FileDialog::_push_history() {
 	local_history.resize(local_history_pos + 1);
 	String new_path = dir_access->get_current_dir();
-	if (local_history.size() == 0 || new_path != local_history[local_history_pos]) {
+	if (local_history.is_empty() || new_path != local_history[local_history_pos]) {
 		local_history.push_back(new_path);
 		local_history_pos++;
 		dir_prev->set_disabled(local_history_pos == 0);

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -429,7 +429,7 @@ void ItemList::deselect(int p_idx) {
 }
 
 void ItemList::deselect_all() {
-	if (items.size() < 1) {
+	if (items.is_empty()) {
 		return;
 	}
 

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -279,7 +279,7 @@ void Range::_ref_shared(Shared *p_shared) {
 void Range::_unref_shared() {
 	if (shared) {
 		shared->owners.erase(this);
-		if (shared->owners.size() == 0) {
+		if (shared->owners.is_empty()) {
 			memdelete(shared);
 			shared = nullptr;
 		}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -5532,7 +5532,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 
 		} else {
 			Vector<String> &expr = split_tag_block;
-			if (expr.size() < 1) {
+			if (expr.is_empty()) {
 				add_text("[");
 				pos = brk_pos + 1;
 			} else {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -5819,7 +5819,7 @@ bool RichTextLabel::_search_line(ItemFrame *p_frame, int p_line, const String &p
 bool RichTextLabel::search(const String &p_string, bool p_from_selection, bool p_search_previous) {
 	ERR_FAIL_COND_V(!selection.enabled, false);
 
-	if (p_string.size() == 0) {
+	if (p_string.is_empty()) {
 		selection.active = false;
 		return false;
 	}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4596,7 +4596,7 @@ Rect2i TextEdit::get_rect_at_line_column(int p_line, int p_column) const {
 		return Rect2i();
 	}
 
-	if (line_drawing_cache.size() == 0 || !line_drawing_cache.has(p_line)) {
+	if (line_drawing_cache.is_empty() || !line_drawing_cache.has(p_line)) {
 		// Line is not in the cache, which means it's outside of the viewing area.
 		return Rect2i(-1, -1, 0, 0);
 	}

--- a/scene/main/multiplayer_peer.cpp
+++ b/scene/main/multiplayer_peer.cpp
@@ -137,7 +137,7 @@ Error MultiplayerPeerExtension::get_packet(const uint8_t **r_buffer, int &r_buff
 			return FAILED;
 		}
 
-		if (script_buffer.size() == 0) {
+		if (script_buffer.is_empty()) {
 			return Error::ERR_UNAVAILABLE;
 		}
 

--- a/scene/main/shader_globals_override.cpp
+++ b/scene/main/shader_globals_override.cpp
@@ -228,7 +228,7 @@ void ShaderGlobalsOverride::_activate() {
 	ERR_FAIL_NULL(get_tree());
 	List<Node *> nodes;
 	get_tree()->get_nodes_in_group(SceneStringName(shader_overrides_group_active), &nodes);
-	if (nodes.size() == 0) {
+	if (nodes.is_empty()) {
 		//good we are the only override, enable all
 		active = true;
 		add_to_group(SceneStringName(shader_overrides_group_active));

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -294,7 +294,7 @@ void Viewport::_sub_window_register(Window *p_window) {
 		ERR_FAIL_COND(gui.sub_windows[i].window == p_window);
 	}
 
-	if (gui.sub_windows.size() == 0) {
+	if (gui.sub_windows.is_empty()) {
 		subwindow_canvas = RS::get_singleton()->canvas_create();
 		RS::get_singleton()->viewport_attach_canvas(viewport, subwindow_canvas);
 		RS::get_singleton()->viewport_set_canvas_stacking(viewport, subwindow_canvas, SUBWINDOW_CANVAS_LAYER, 0);
@@ -465,7 +465,7 @@ void Viewport::_sub_window_remove(Window *p_window) {
 	RS::get_singleton()->free(sw.canvas_item);
 	gui.sub_windows.remove_at(index);
 
-	if (gui.sub_windows.size() == 0) {
+	if (gui.sub_windows.is_empty()) {
 		RS::get_singleton()->free(subwindow_canvas);
 		subwindow_canvas = RID();
 	}

--- a/scene/resources/2d/polygon_path_finder.cpp
+++ b/scene/resources/2d/polygon_path_finder.cpp
@@ -295,7 +295,7 @@ Vector<Vector2> PolygonPathFinder::find_path(const Vector2 &p_from, const Vector
 	bool found_route = false;
 
 	while (true) {
-		if (open_list.size() == 0) {
+		if (open_list.is_empty()) {
 			print_verbose("Open list empty.");
 			break;
 		}

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
@@ -238,7 +238,7 @@ void SkeletonModification2DPhysicalBones::_update_simulation_state() {
 	}
 	_simulation_state_dirty = false;
 
-	if (_simulation_state_dirty_names.size() <= 0) {
+	if (_simulation_state_dirty_names.is_empty()) {
 		for (int i = 0; i < physical_bone_chain.size(); i++) {
 			PhysicalBone2D *physical_bone = Object::cast_to<PhysicalBone2D>(stack->skeleton->get_node(physical_bone_chain[i].physical_bone_node));
 			if (!physical_bone) {

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -874,7 +874,7 @@ Ref<ConvexPolygonShape3D> ImporterMesh::create_convex_shape(bool p_clean, bool p
 
 Ref<ConcavePolygonShape3D> ImporterMesh::create_trimesh_shape() const {
 	Vector<Face3> faces = get_faces();
-	if (faces.size() == 0) {
+	if (faces.is_empty()) {
 		return Ref<ConcavePolygonShape3D>();
 	}
 
@@ -896,7 +896,7 @@ Ref<ConcavePolygonShape3D> ImporterMesh::create_trimesh_shape() const {
 
 Ref<NavigationMesh> ImporterMesh::create_navigation_mesh() {
 	Vector<Face3> faces = get_faces();
-	if (faces.size() == 0) {
+	if (faces.is_empty()) {
 		return Ref<NavigationMesh>();
 	}
 

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -2972,7 +2972,7 @@ void TextMesh::_generate_glyph_mesh_data(const GlyphMeshKey &p_key, const Glyph 
 	PackedInt32Array contours = d["contours"];
 	bool orientation = d["orientation"];
 
-	if (points.size() < 3 || contours.size() < 1) {
+	if (points.size() < 3 || contours.is_empty()) {
 		return; // No full contours, only glyph control points (or nothing), ignore.
 	}
 

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -103,7 +103,7 @@ void PrimitiveMesh::_update() const {
 		Vector<Vector2> uv = arr[RS::ARRAY_TEX_UV];
 		Vector<Vector2> uv2 = arr[RS::ARRAY_TEX_UV2];
 
-		if (uv.size() > 0 && uv2.size() == 0) {
+		if (uv.size() > 0 && uv2.is_empty()) {
 			Vector2 uv2_scale = get_uv2_scale();
 			uv2.resize(uv.size());
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -4335,7 +4335,7 @@ void Animation::_value_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 	ERR_FAIL_INDEX(p_idx, tracks.size());
 	ERR_FAIL_COND(tracks[p_idx]->type != TYPE_VALUE);
 	ValueTrack *vt = static_cast<ValueTrack *>(tracks[p_idx]);
-	if (vt->values.size() == 0) {
+	if (vt->values.is_empty()) {
 		return;
 	}
 	Variant::Type type = vt->values[0].value.get_type();
@@ -4582,7 +4582,7 @@ struct AnimationCompressionDataState {
 	}
 
 	uint32_t get_temp_packet_size() const {
-		if (temp_packets.size() == 0) {
+		if (temp_packets.is_empty()) {
 			return 0;
 		} else if (temp_packets.size() == 1) {
 			return components == 1 ? 4 : 8; // 1 component packet is 16 bits and 16 bits unused. 3 component packets is 48 bits and 16 bits unused
@@ -4624,7 +4624,7 @@ struct AnimationCompressionDataState {
 	}
 
 	void commit_temp_packets() {
-		if (temp_packets.size() == 0) {
+		if (temp_packets.is_empty()) {
 			return; // Nothing to do.
 		}
 //#define DEBUG_PACKET_PUSH
@@ -4890,7 +4890,7 @@ void Animation::compress(uint32_t p_page_size, uint32_t p_fps, float p_split_tol
 		track_bounds.push_back(bounds);
 	}
 
-	if (tracks_to_compress.size() == 0) {
+	if (tracks_to_compress.is_empty()) {
 		return; //nothing to compress
 	}
 
@@ -5045,7 +5045,7 @@ void Animation::compress(uint32_t p_page_size, uint32_t p_fps, float p_split_tol
 				uint32_t total_page_size = 0;
 
 				for (uint32_t i = 0; i < data_tracks.size(); i++) {
-					if (data_tracks[i].temp_packets.size() == 0 || (data_tracks[i].temp_packets[data_tracks[i].temp_packets.size() - 1].frame) < finalizer_local_frame) {
+					if (data_tracks[i].temp_packets.is_empty() || (data_tracks[i].temp_packets[data_tracks[i].temp_packets.size() - 1].frame) < finalizer_local_frame) {
 						// Add finalizer frame if it makes sense
 						Vector3i values = _compress_key(tracks_to_compress[i], track_bounds[i], -1, page_end_frame * frame_len);
 

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -65,7 +65,7 @@ int Curve::_add_point(Vector2 p_position, real_t p_left_tangent, real_t p_right_
 
 	int ret = -1;
 
-	if (_points.size() == 0) {
+	if (_points.is_empty()) {
 		_points.push_back(Point(p_position, p_left_tangent, p_right_tangent, p_left_mode, p_right_mode));
 		ret = 0;
 
@@ -377,7 +377,7 @@ void Curve::set_max_domain(real_t p_max) {
 }
 
 real_t Curve::sample(real_t p_offset) const {
-	if (_points.size() == 0) {
+	if (_points.is_empty()) {
 		return 0;
 	}
 	if (_points.size() == 1) {
@@ -539,8 +539,8 @@ real_t Curve::sample_baked(real_t p_offset) const {
 	}
 
 	// Special cases if the cache is too small.
-	if (_baked_cache.size() == 0) {
-		if (_points.size() == 0) {
+	if (_baked_cache.is_empty()) {
+		if (_points.is_empty()) {
 			return 0;
 		}
 		return _points[0].position.y;
@@ -569,7 +569,7 @@ real_t Curve::sample_baked(real_t p_offset) const {
 }
 
 void Curve::ensure_default_setup(real_t p_min, real_t p_max) {
-	if (_points.size() == 0 && _min_value == 0 && _max_value == 1) {
+	if (_points.is_empty() && _min_value == 0 && _max_value == 1) {
 		add_point(Vector2(0, 1));
 		add_point(Vector2(1, 1));
 		set_min_value(p_min);
@@ -910,7 +910,7 @@ void Curve2D::_bake() const {
 	baked_max_ofs = 0;
 	baked_cache_dirty = false;
 
-	if (points.size() == 0) {
+	if (points.is_empty()) {
 		baked_point_cache.clear();
 		baked_dist_cache.clear();
 		baked_forward_vector_cache.clear();
@@ -1259,7 +1259,7 @@ void Curve2D::_set_data(const Dictionary &p_data) {
 PackedVector2Array Curve2D::tessellate(int p_max_stages, real_t p_tolerance) const {
 	PackedVector2Array tess;
 
-	if (points.size() == 0) {
+	if (points.is_empty()) {
 		return tess;
 	}
 
@@ -1309,7 +1309,7 @@ PackedVector2Array Curve2D::tessellate_even_length(int p_max_stages, real_t p_le
 	PackedVector2Array tess;
 
 	Vector<RBMap<real_t, Vector2>> midpoints = _tessellate_even_length(p_max_stages, p_length);
-	if (midpoints.size() == 0) {
+	if (midpoints.is_empty()) {
 		return tess;
 	}
 
@@ -1659,7 +1659,7 @@ void Curve3D::_bake() const {
 	baked_max_ofs = 0;
 	baked_cache_dirty = false;
 
-	if (points.size() == 0) {
+	if (points.is_empty()) {
 #ifdef TOOLS_ENABLED
 		points_in_cache.clear();
 #endif
@@ -2293,7 +2293,7 @@ void Curve3D::_set_data(const Dictionary &p_data) {
 PackedVector3Array Curve3D::tessellate(int p_max_stages, real_t p_tolerance) const {
 	PackedVector3Array tess;
 
-	if (points.size() == 0) {
+	if (points.is_empty()) {
 		return tess;
 	}
 	Vector<RBMap<real_t, Vector3>> midpoints;
@@ -2356,7 +2356,7 @@ PackedVector3Array Curve3D::tessellate_even_length(int p_max_stages, real_t p_le
 	PackedVector3Array tess;
 
 	Vector<RBMap<real_t, Vector3>> midpoints = _tessellate_even_length(p_max_stages, p_length);
-	if (midpoints.size() == 0) {
+	if (midpoints.is_empty()) {
 		return tess;
 	}
 

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -565,7 +565,7 @@ Ref<ConvexPolygonShape3D> Mesh::create_convex_shape(bool p_clean, bool p_simplif
 
 Ref<ConcavePolygonShape3D> Mesh::create_trimesh_shape() const {
 	Vector<Face3> faces = get_faces();
-	if (faces.size() == 0) {
+	if (faces.is_empty()) {
 		return Ref<ConcavePolygonShape3D>();
 	}
 
@@ -617,7 +617,7 @@ Ref<Mesh> Mesh::create_outline(float p_margin) const {
 						if (j == ARRAY_VERTEX) {
 							vcount = src.size();
 						}
-						if (dst.size() == 0 || src.size() == 0) {
+						if (dst.is_empty() || src.is_empty()) {
 							arrays[j] = Variant();
 							continue;
 						}
@@ -629,7 +629,7 @@ Ref<Mesh> Mesh::create_outline(float p_margin) const {
 					case ARRAY_WEIGHTS: {
 						Vector<real_t> dst = arrays[j];
 						Vector<real_t> src = a[j];
-						if (dst.size() == 0 || src.size() == 0) {
+						if (dst.is_empty() || src.is_empty()) {
 							arrays[j] = Variant();
 							continue;
 						}
@@ -640,7 +640,7 @@ Ref<Mesh> Mesh::create_outline(float p_margin) const {
 					case ARRAY_COLOR: {
 						Vector<Color> dst = arrays[j];
 						Vector<Color> src = a[j];
-						if (dst.size() == 0 || src.size() == 0) {
+						if (dst.is_empty() || src.is_empty()) {
 							arrays[j] = Variant();
 							continue;
 						}
@@ -652,7 +652,7 @@ Ref<Mesh> Mesh::create_outline(float p_margin) const {
 					case ARRAY_TEX_UV2: {
 						Vector<Vector2> dst = arrays[j];
 						Vector<Vector2> src = a[j];
-						if (dst.size() == 0 || src.size() == 0) {
+						if (dst.is_empty() || src.is_empty()) {
 							arrays[j] = Variant();
 							continue;
 						}
@@ -663,7 +663,7 @@ Ref<Mesh> Mesh::create_outline(float p_margin) const {
 					case ARRAY_INDEX: {
 						Vector<int> dst = arrays[j];
 						Vector<int> src = a[j];
-						if (dst.size() == 0 || src.size() == 0) {
+						if (dst.is_empty() || src.is_empty()) {
 							arrays[j] = Variant();
 							continue;
 						}
@@ -2032,7 +2032,7 @@ AABB ArrayMesh::get_custom_aabb() const {
 }
 
 void ArrayMesh::regen_normal_maps() {
-	if (surfaces.size() == 0) {
+	if (surfaces.is_empty()) {
 		return;
 	}
 	Vector<Ref<SurfaceTool>> surfs;

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -51,7 +51,7 @@ void NavigationMesh::create_from_mesh(const Ref<Mesh> &p_mesh) {
 
 		Vector<Vector3> varr = arr[Mesh::ARRAY_VERTEX];
 		Vector<int> iarr = arr[Mesh::ARRAY_INDEX];
-		if (varr.size() == 0 || iarr.size() == 0) {
+		if (varr.is_empty() || iarr.is_empty()) {
 			WARN_PRINT("A mesh surface was skipped when creating a NavigationMesh due to an empty vertex or index array.");
 			continue;
 		}
@@ -398,7 +398,7 @@ Ref<ArrayMesh> NavigationMesh::get_debug_mesh() {
 		debug_mesh->clear_surfaces();
 	}
 
-	if (vertices.size() == 0) {
+	if (vertices.is_empty()) {
 		return debug_mesh;
 	}
 

--- a/scene/resources/portable_compressed_texture.cpp
+++ b/scene/resources/portable_compressed_texture.cpp
@@ -35,7 +35,7 @@
 #include "scene/resources/bit_map.h"
 
 void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
-	if (p_data.size() == 0) {
+	if (p_data.is_empty()) {
 		return; //nothing to do
 	}
 

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -772,7 +772,7 @@ void SurfaceTool::index() {
 }
 
 void SurfaceTool::deindex() {
-	if (index_array.size() == 0) {
+	if (index_array.is_empty()) {
 		return; //nothing to deindex
 	}
 
@@ -1020,7 +1020,7 @@ void SurfaceTool::create_from_blend_shape(const Ref<Mesh> &p_existing, int p_sur
 void SurfaceTool::append_from(const Ref<Mesh> &p_existing, int p_surface, const Transform3D &p_xform) {
 	ERR_FAIL_COND_MSG(p_existing.is_null(), "First argument in SurfaceTool::append_from() must be a valid object of type Mesh");
 
-	if (vertex_array.size() == 0) {
+	if (vertex_array.is_empty()) {
 		primitive = p_existing->surface_get_primitive_type(p_surface);
 		format = 0;
 	}

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -461,7 +461,7 @@ void VisualShaderNodeParticleMeshEmitter::_update_texture(const Vector<Vector2> 
 	Ref<Image> image;
 	image.instantiate();
 
-	if (p_array.size() == 0) {
+	if (p_array.is_empty()) {
 		image->initialize_data(1, 1, false, Image::Format::FORMAT_RGBF);
 	} else {
 		image->initialize_data(p_array.size(), 1, false, Image::Format::FORMAT_RGBF);
@@ -471,7 +471,7 @@ void VisualShaderNodeParticleMeshEmitter::_update_texture(const Vector<Vector2> 
 		Vector2 v = p_array[i];
 		image->set_pixel(i, 0, Color(v.x, v.y, 0));
 	}
-	if (r_texture->get_width() != p_array.size() || p_array.size() == 0) {
+	if (r_texture->get_width() != p_array.size() || p_array.is_empty()) {
 		r_texture->set_image(image);
 	} else {
 		r_texture->update(image);
@@ -482,7 +482,7 @@ void VisualShaderNodeParticleMeshEmitter::_update_texture(const Vector<Vector3> 
 	Ref<Image> image;
 	image.instantiate();
 
-	if (p_array.size() == 0) {
+	if (p_array.is_empty()) {
 		image->initialize_data(1, 1, false, Image::Format::FORMAT_RGBF);
 	} else {
 		image->initialize_data(p_array.size(), 1, false, Image::Format::FORMAT_RGBF);
@@ -492,7 +492,7 @@ void VisualShaderNodeParticleMeshEmitter::_update_texture(const Vector<Vector3> 
 		Vector3 v = p_array[i];
 		image->set_pixel(i, 0, Color(v.x, v.y, v.z));
 	}
-	if (r_texture->get_width() != p_array.size() || p_array.size() == 0) {
+	if (r_texture->get_width() != p_array.size() || p_array.is_empty()) {
 		r_texture->set_image(image);
 	} else {
 		r_texture->update(image);
@@ -503,7 +503,7 @@ void VisualShaderNodeParticleMeshEmitter::_update_texture(const Vector<Color> &p
 	Ref<Image> image;
 	image.instantiate();
 
-	if (p_array.size() == 0) {
+	if (p_array.is_empty()) {
 		image->initialize_data(1, 1, false, Image::Format::FORMAT_RGBA8);
 	} else {
 		image->initialize_data(p_array.size(), 1, false, Image::Format::FORMAT_RGBA8);
@@ -512,7 +512,7 @@ void VisualShaderNodeParticleMeshEmitter::_update_texture(const Vector<Color> &p
 	for (int i = 0; i < p_array.size(); i++) {
 		image->set_pixel(i, 0, p_array[i]);
 	}
-	if (r_texture->get_width() != p_array.size() || p_array.size() == 0) {
+	if (r_texture->get_width() != p_array.size() || p_array.is_empty()) {
 		r_texture->set_image(image);
 	} else {
 		r_texture->update(image);

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -500,7 +500,7 @@ const Vector<Ref<Theme>> ThemeContext::get_themes() const {
 
 Ref<Theme> ThemeContext::get_fallback_theme() const {
 	// We expect all contexts to be valid and non-empty, but just in case...
-	if (themes.size() == 0) {
+	if (themes.is_empty()) {
 		return ThemeDB::get_singleton()->get_default_theme();
 	}
 

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -2676,13 +2676,13 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 					dtf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
 					dtf.usage_bits = RD::TEXTURE_USAGE_STORAGE_BIT;
 
-					if (dynamic_maps.size() == 0) {
+					if (dynamic_maps.is_empty()) {
 						dtf.usage_bits |= RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
 					}
 					dmap.texture = RD::get_singleton()->texture_create(dtf, RD::TextureView());
 					RD::get_singleton()->set_resource_name(dmap.texture, "VoxelGI Instance DMap Texture");
 
-					if (dynamic_maps.size() == 0) {
+					if (dynamic_maps.is_empty()) {
 						// Render depth for first one.
 						// Use 16-bit depth when supported to improve performance.
 						dtf.format = RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_D16_UNORM, RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) ? RD::DATA_FORMAT_D16_UNORM : RD::DATA_FORMAT_X8_D24_UNORM_PACK32;
@@ -2698,7 +2698,7 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 					dmap.depth = RD::get_singleton()->texture_create(dtf, RD::TextureView());
 					RD::get_singleton()->set_resource_name(dmap.depth, "VoxelGI Instance DMap Depth");
 
-					if (dynamic_maps.size() == 0) {
+					if (dynamic_maps.is_empty()) {
 						dtf.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
 						dtf.usage_bits = RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
 						dmap.albedo = RD::get_singleton()->texture_create(dtf, RD::TextureView());
@@ -3279,7 +3279,7 @@ void GI::VoxelGIInstance::free_resources() {
 void GI::VoxelGIInstance::debug(RD::DrawListID p_draw_list, RID p_framebuffer, const Projection &p_camera_with_transform, bool p_lighting, bool p_emission, float p_alpha) {
 	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 
-	if (mipmaps.size() == 0) {
+	if (mipmaps.is_empty()) {
 		return;
 	}
 

--- a/servers/rendering/renderer_rd/framebuffer_cache_rd.h
+++ b/servers/rendering/renderer_rd/framebuffer_cache_rd.h
@@ -207,7 +207,7 @@ public:
 			const Cache *c = hash_table[table_idx];
 
 			while (c) {
-				if (c->hash == h && c->passes.size() == 0 && c->textures.size() == sizeof...(Args) && c->views == 1 && _compare_args(0, c->textures, args...)) {
+				if (c->hash == h && c->passes.is_empty() && c->textures.size() == sizeof...(Args) && c->views == 1 && _compare_args(0, c->textures, args...)) {
 					return c->cache;
 				}
 				c = c->next;
@@ -235,7 +235,7 @@ public:
 			const Cache *c = hash_table[table_idx];
 
 			while (c) {
-				if (c->hash == h && c->passes.size() == 0 && c->textures.size() == sizeof...(Args) && c->views == p_views && _compare_args(0, c->textures, args...)) {
+				if (c->hash == h && c->passes.is_empty() && c->textures.size() == sizeof...(Args) && c->views == p_views && _compare_args(0, c->textures, args...)) {
 					return c->cache;
 				}
 				c = c->next;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1299,7 +1299,7 @@ void RendererCanvasRenderRD::occluder_polygon_set_shape(RID p_occluder, const Ve
 		}
 	}
 
-	if ((oc->line_point_count != lines.size() || lines.size() == 0) && oc->vertex_array.is_valid()) {
+	if ((oc->line_point_count != lines.size() || lines.is_empty()) && oc->vertex_array.is_valid()) {
 		RD::get_singleton()->free(oc->vertex_array);
 		RD::get_singleton()->free(oc->vertex_buffer);
 		RD::get_singleton()->free(oc->index_array);
@@ -1404,7 +1404,7 @@ void RendererCanvasRenderRD::occluder_polygon_set_shape(RID p_occluder, const Ve
 		}
 	}
 
-	if (((oc->sdf_index_count != sdf_indices.size() && oc->sdf_point_count != p_points.size()) || p_points.size() == 0) && oc->sdf_vertex_array.is_valid()) {
+	if (((oc->sdf_index_count != sdf_indices.size() && oc->sdf_point_count != p_points.size()) || p_points.is_empty()) && oc->sdf_vertex_array.is_valid()) {
 		RD::get_singleton()->free(oc->sdf_vertex_array);
 		RD::get_singleton()->free(oc->sdf_vertex_buffer);
 		RD::get_singleton()->free(oc->sdf_index_array);
@@ -3200,7 +3200,7 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 }
 
 RendererCanvasRenderRD::Batch *RendererCanvasRenderRD::_new_batch(bool &r_batch_broken) {
-	if (state.canvas_instance_batches.size() == 0) {
+	if (state.canvas_instance_batches.is_empty()) {
 		Batch new_batch;
 		new_batch.instance_buffer_index = state.current_instance_buffer_index;
 		state.canvas_instance_batches.push_back(new_batch);

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -282,7 +282,7 @@ void ShaderRD::_compile_variant(uint32_t p_variant, CompileData p_data) {
 		current_source = builder.as_string();
 		RD::ShaderStageSPIRVData stage;
 		stage.spirv = RD::get_singleton()->shader_compile_spirv_from_source(RD::SHADER_STAGE_VERTEX, current_source, RD::SHADER_LANGUAGE_GLSL, &error);
-		if (stage.spirv.size() == 0) {
+		if (stage.spirv.is_empty()) {
 			build_ok = false;
 		} else {
 			stage.shader_stage = RD::SHADER_STAGE_VERTEX;
@@ -300,7 +300,7 @@ void ShaderRD::_compile_variant(uint32_t p_variant, CompileData p_data) {
 		current_source = builder.as_string();
 		RD::ShaderStageSPIRVData stage;
 		stage.spirv = RD::get_singleton()->shader_compile_spirv_from_source(RD::SHADER_STAGE_FRAGMENT, current_source, RD::SHADER_LANGUAGE_GLSL, &error);
-		if (stage.spirv.size() == 0) {
+		if (stage.spirv.is_empty()) {
 			build_ok = false;
 		} else {
 			stage.shader_stage = RD::SHADER_STAGE_FRAGMENT;
@@ -319,7 +319,7 @@ void ShaderRD::_compile_variant(uint32_t p_variant, CompileData p_data) {
 
 		RD::ShaderStageSPIRVData stage;
 		stage.spirv = RD::get_singleton()->shader_compile_spirv_from_source(RD::SHADER_STAGE_COMPUTE, current_source, RD::SHADER_LANGUAGE_GLSL, &error);
-		if (stage.spirv.size() == 0) {
+		if (stage.spirv.is_empty()) {
 			build_ok = false;
 		} else {
 			stage.shader_stage = RD::SHADER_STAGE_COMPUTE;

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -1137,7 +1137,7 @@ bool MaterialStorage::MaterialData::update_parameters_uniform_set(const HashMap<
 		update_textures(p_parameters, p_default_texture_params, p_texture_uniforms, texture_cache.ptrw(), p_use_linear_color, p_3d_material);
 	}
 
-	if (p_ubo_size == 0 && (p_texture_uniforms.size() == 0)) {
+	if (p_ubo_size == 0 && (p_texture_uniforms.is_empty())) {
 		// This material does not require an uniform set, so don't create it.
 		return false;
 	}

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -3717,7 +3717,7 @@ RID TextureStorage::render_target_get_rd_texture_slice(RID p_render_target, uint
 		return rt->color;
 	} else {
 		ERR_FAIL_UNSIGNED_INDEX_V(p_layer, rt->view_count, RID());
-		if (rt->color_slices.size() == 0) {
+		if (rt->color_slices.is_empty()) {
 			for (uint32_t v = 0; v < rt->view_count; v++) {
 				RID slice = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), rt->color, v, 0);
 				rt->color_slices.push_back(slice);

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2121,7 +2121,7 @@ void RendererSceneCull::_update_instance_aabb(Instance *p_instance) const {
 }
 
 void RendererSceneCull::_update_instance_lightmap_captures(Instance *p_instance) const {
-	bool first_set = p_instance->lightmap_sh.size() == 0;
+	bool first_set = p_instance->lightmap_sh.is_empty();
 	p_instance->lightmap_sh.resize(9); //using SH
 	p_instance->lightmap_target_sh.resize(9); //using SH
 	Color *instance_sh = p_instance->lightmap_target_sh.ptrw();

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -6922,7 +6922,7 @@ void RenderingDevice::_save_pipeline_cache(void *p_data) {
 	Vector<uint8_t> cache_blob = self->driver->pipeline_cache_serialize();
 	self->_thread_safe_.unlock();
 
-	if (cache_blob.size() == 0) {
+	if (cache_blob.is_empty()) {
 		return;
 	}
 	print_verbose(vformat("Updated PSO cache (%.1f MiB)", cache_blob.size() / (1024.0f * 1024.0f)));

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -133,7 +133,7 @@ void ShaderPreprocessor::Tokenizer::skip_whitespace() {
 
 bool ShaderPreprocessor::Tokenizer::consume_empty_line() {
 	// Read until newline and return true if the content was all whitespace/empty.
-	return tokens_to_string(advance('\n')).strip_edges().size() == 0;
+	return tokens_to_string(advance('\n')).strip_edges().is_empty();
 }
 
 String ShaderPreprocessor::Tokenizer::get_identifier(bool *r_is_cursor, bool p_started) {

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -924,7 +924,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 		// Create AABBs for each detected bone.
 		int total_bones = max_bone + 1;
 
-		bool first = r_bone_aabb.size() == 0;
+		bool first = r_bone_aabb.is_empty();
 
 		r_bone_aabb.resize(total_bones);
 

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -965,7 +965,7 @@ PackedInt32Array TextServer::shaped_text_get_line_breaks_adv(const RID &p_shaped
 	}
 
 	if (l_size > 0) {
-		if (lines.size() == 0 || (lines[lines.size() - 1] < range.y && prev_safe_break < l_size)) {
+		if (lines.is_empty() || (lines[lines.size() - 1] < range.y && prev_safe_break < l_size)) {
 			if (p_break_flags.has_flag(BREAK_TRIM_START_EDGE_SPACES)) {
 				int start_pos = (prev_safe_break < l_size) ? prev_safe_break : l_size - 1;
 				if (last_end <= l_gl[start_pos].start) {
@@ -1152,7 +1152,7 @@ PackedInt32Array TextServer::shaped_text_get_line_breaks(const RID &p_shaped, do
 	}
 
 	if (l_size > 0) {
-		if (lines.size() == 0 || (lines[lines.size() - 1] < range.y && prev_safe_break < l_size)) {
+		if (lines.is_empty() || (lines[lines.size() - 1] < range.y && prev_safe_break < l_size)) {
 			if (p_break_flags.has_flag(BREAK_TRIM_START_EDGE_SPACES)) {
 				int start_pos = (prev_safe_break < l_size) ? prev_safe_break : l_size - 1;
 				if (last_end <= l_gl[start_pos].start) {

--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -389,7 +389,7 @@ PackedStringArray XRServer::get_suggested_tracker_names() const {
 		}
 	}
 
-	if (arr.size() == 0) {
+	if (arr.is_empty()) {
 		// no suggestions from our tracker? include our defaults
 		arr.push_back(String("head"));
 		arr.push_back(String("left_hand"));
@@ -412,7 +412,7 @@ PackedStringArray XRServer::get_suggested_pose_names(const StringName &p_tracker
 		}
 	}
 
-	if (arr.size() == 0) {
+	if (arr.is_empty()) {
 		// no suggestions from our tracker? include our defaults
 		arr.push_back(String("default"));
 


### PR DESCRIPTION
This is mainly for `CowData` because it stores size information in its buffer, which makes its `size()` method a bit heavy. In contrast, `CowData::is_empty()` check buffer pointer directly and avoid accessing heap memory so it should be faster.

I use search and replace so there are other types of containers involved in. I think it won't cause problem as `size() == 0` and `is_empty()` should be sementically equal anyway, also `is_empty()` is created exactly for this pattern.