### PR TITLE
Tweak a few miscellaneous localization strings

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1391,6 +1391,7 @@ void EditorProperty::_update_popup() {
 			menu->add_icon_item(get_editor_theme_icon(SNAME("Unfavorite")), TTR("Unfavorite Property"), MENU_FAVORITE_PROPERTY);
 			menu->set_item_tooltip(menu->get_item_index(MENU_FAVORITE_PROPERTY), TTR("Make this property be put back at its original place."));
 		} else {
+			// TRANSLATORS: This is a menu item to add a property to the favorites.
 			menu->add_icon_item(get_editor_theme_icon(SNAME("Favorites")), TTR("Favorite Property"), MENU_FAVORITE_PROPERTY);
 			menu->set_item_tooltip(menu->get_item_index(MENU_FAVORITE_PROPERTY), TTR("Make this property be placed at the top for all objects of this class."));
 		}

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -135,10 +135,7 @@ Error EditorRunNative::start_run_native(int p_id) {
 		bool is_arch_enabled = preset->get(preset_arch);
 
 		if (!is_arch_enabled) {
-			String warning_message = vformat(TTR("Warning: The CPU architecture \"%s\" is not active in your export preset.\n\n"), Variant(architecture));
-			warning_message += TTR("Run \"Remote Deploy\" anyway?");
-
-			run_native_confirm->set_text(warning_message);
+			run_native_confirm->set_text(vformat(TTR("Warning: The CPU architecture \"%s\" is not active in your export preset.\n\nRun \"Remote Deploy\" anyway?"), architecture));
 			run_native_confirm->popup_centered();
 			return OK;
 		}

--- a/modules/openxr/editor/openxr_binding_modifier_editor.cpp
+++ b/modules/openxr/editor/openxr_binding_modifier_editor.cpp
@@ -261,7 +261,7 @@ OpenXRBindingModifierEditor::OpenXRBindingModifierEditor() {
 	header_hb->add_child(binding_modifier_title);
 
 	rem_binding_modifier_btn = memnew(Button);
-	rem_binding_modifier_btn->set_tooltip_text(TTR("Remove binding modifier."));
+	rem_binding_modifier_btn->set_tooltip_text(TTR("Remove this binding modifier."));
 	rem_binding_modifier_btn->connect(SceneStringName(pressed), callable_mp(this, &OpenXRBindingModifierEditor::_on_remove_binding_modifier));
 	rem_binding_modifier_btn->set_flat(true);
 	header_hb->add_child(rem_binding_modifier_btn);

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -67,7 +67,7 @@ Error EditorExportPlatformLinuxBSD::export_project(const Ref<EditorExportPreset>
 	if (!template_path.is_empty()) {
 		String exe_arch = _get_exe_arch(template_path);
 		if (arch != exe_arch) {
-			add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Templates"), vformat(TTR("Mismatching custom export template executable architecture, found \"%s\", expected \"%s\"."), exe_arch, arch));
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Templates"), vformat(TTR("Mismatching custom export template executable architecture: found \"%s\", expected \"%s\"."), exe_arch, arch));
 			return ERR_CANT_CREATE;
 		}
 	}


### PR DESCRIPTION
This PR tweaks a few localization strings in my notes. You wouldn't know they are a bit problematic until you try translating them without context.

- Some languages have translated the `"Favorite Property"` menu item assuming "_Favourite_" is an adjective. I added a note to mitigate this.
- `"Warning: The CPU architecture \"%s\" is not active in your export preset."` contains trailing new lines that probably shouldn't exist and have been moved out of the localization string.
- There's both `"Remove binding modifier."` and `"Remove binding modifier."` (notice the period). One is an UndoRedo action, the other is a _tooltip_. While I am not sure what more could be said, I tweaked it slightly to make this more obvious.
- The `"Mismatching custom export template executable architecture"` string already exists elsewhere, with the only difference being... `:` instead of `,`. That's it. It was really confusing at first.