### PR TITLE
Optimize `Object::notification` by avoiding runtime branches

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -544,16 +544,17 @@ protected:                                                                      
 	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) {                                                                         \
 		return (void(Object::*)(int)) & m_class::_notification;                                                                             \
 	}                                                                                                                                       \
-	virtual void _notificationv(int p_notification, bool p_reversed) override {                                                             \
-		if (!p_reversed) {                                                                                                                  \
-			m_inherits::_notificationv(p_notification, p_reversed);                                                                         \
-		}                                                                                                                                   \
+	virtual void _notification_forwardv(int p_notification) override {                                                                      \
+		m_inherits::_notification_forwardv(p_notification);                                                                                 \
 		if (m_class::_get_notification() != m_inherits::_get_notification()) {                                                              \
 			_notification(p_notification);                                                                                                  \
 		}                                                                                                                                   \
-		if (p_reversed) {                                                                                                                   \
-			m_inherits::_notificationv(p_notification, p_reversed);                                                                         \
+	}                                                                                                                                       \
+	virtual void _notification_backwardv(int p_notification) override {                                                                     \
+		if (m_class::_get_notification() != m_inherits::_get_notification()) {                                                              \
+			_notification(p_notification);                                                                                                  \
 		}                                                                                                                                   \
+		m_inherits::_notification_backwardv(p_notification);                                                                                \
 	}                                                                                                                                       \
                                                                                                                                             \
 private:
@@ -697,7 +698,11 @@ protected:
 	virtual void _validate_propertyv(PropertyInfo &p_property) const {}
 	virtual bool _property_can_revertv(const StringName &p_name) const { return false; }
 	virtual bool _property_get_revertv(const StringName &p_name, Variant &r_property) const { return false; }
-	virtual void _notificationv(int p_notification, bool p_reversed) {}
+
+	void _notification_forward(int p_notification);
+	void _notification_backward(int p_notification);
+	virtual void _notification_forwardv(int p_notification) {}
+	virtual void _notification_backwardv(int p_notification) {}
 
 	static void _bind_methods();
 	static void _bind_compatibility_methods() {}
@@ -895,7 +900,17 @@ public:
 		return (cerr.error == Callable::CallError::CALL_OK) ? ret : Variant();
 	}
 
-	void notification(int p_notification, bool p_reversed = false);
+	// Depending on the boolean, we call either the virtual function _notification_backward or _notification_forward.
+	// - Forward calls subclasses in descending order (e.g. Object -> Node -> Node3D -> extension -> script).
+	//   Backward calls subclasses in descending order (e.g. script -> extension -> Node3D -> Node -> Object).
+	_FORCE_INLINE_ void notification(int p_notification, bool p_reversed = false) {
+		if (p_reversed) {
+			_notification_backward(p_notification);
+		} else {
+			_notification_forward(p_notification);
+		}
+	}
+
 	virtual String to_string();
 
 	// Used mainly by script, get and set all INCLUDING string.

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -465,72 +465,75 @@ TEST_CASE("[Object] Signals") {
 	}
 }
 
-class NotificationObject1 : public Object {
-	GDCLASS(NotificationObject1, Object);
+class NotificationObjectSuperclass : public Object {
+	GDCLASS(NotificationObjectSuperclass, Object);
 
 protected:
 	void _notification(int p_what) {
-		switch (p_what) {
-			case 12345: {
-				order_internal1 = order_global++;
-			} break;
-		}
+		order_superclass = ++order_global;
 	}
 
 public:
-	static int order_global;
-	int order_internal1 = -1;
-
-	void reset_order() {
-		order_internal1 = -1;
-		order_global = 1;
-	}
+	static inline int order_global = 0;
+	int order_superclass = -1;
 };
 
-int NotificationObject1::order_global = 1;
-
-class NotificationObject2 : public NotificationObject1 {
-	GDCLASS(NotificationObject2, NotificationObject1);
+class NotificationObjectSubclass : public NotificationObjectSuperclass {
+	GDCLASS(NotificationObjectSubclass, NotificationObjectSuperclass);
 
 protected:
 	void _notification(int p_what) {
-		switch (p_what) {
-			case 12345: {
-				order_internal2 = order_global++;
-			} break;
-		}
+		order_subclass = ++order_global;
 	}
 
 public:
-	int order_internal2 = -1;
-	void reset_order() {
-		NotificationObject1::reset_order();
-		order_internal2 = -1;
+	int order_subclass = -1;
+};
+
+class NotificationScriptInstance : public _MockScriptInstance {
+	void notification(int p_notification, bool p_reversed) override {
+		order_script = ++NotificationObjectSuperclass::order_global;
 	}
+
+public:
+	int order_script = -1;
 };
 
 TEST_CASE("[Object] Notification order") { // GH-52325
-	NotificationObject2 *test_notification_object = memnew(NotificationObject2);
+	NotificationObjectSubclass *object = memnew(NotificationObjectSubclass);
+
+	NotificationScriptInstance *script = memnew(NotificationScriptInstance);
+	object->set_script_instance(script);
 
 	SUBCASE("regular order") {
-		test_notification_object->notification(12345, false);
+		NotificationObjectSubclass::order_global = 0;
+		object->order_superclass = -1;
+		object->order_subclass = -1;
+		script->order_script = -1;
+		object->notification(12345, false);
 
-		CHECK_EQ(test_notification_object->order_internal1, 1);
-		CHECK_EQ(test_notification_object->order_internal2, 2);
-
-		test_notification_object->reset_order();
+		CHECK_EQ(object->order_superclass, 1);
+		CHECK_EQ(object->order_subclass, 2);
+		// TODO If an extension is attached, it should come here.
+		CHECK_EQ(script->order_script, 3);
+		CHECK_EQ(NotificationObjectSubclass::order_global, 3);
 	}
 
 	SUBCASE("reverse order") {
-		test_notification_object->notification(12345, true);
+		NotificationObjectSubclass::order_global = 0;
+		object->order_superclass = -1;
+		object->order_subclass = -1;
+		script->order_script = -1;
+		object->notification(12345, true);
 
-		CHECK_EQ(test_notification_object->order_internal1, 2);
-		CHECK_EQ(test_notification_object->order_internal2, 1);
-
-		test_notification_object->reset_order();
+		CHECK_EQ(script->order_script, 1);
+		// TODO If an extension is attached, it should come here.
+		CHECK_EQ(object->order_subclass, 2);
+		CHECK_EQ(object->order_superclass, 3);
+		CHECK_EQ(NotificationObjectSubclass::order_global, 3);
 	}
 
-	memdelete(test_notification_object);
+	memdelete(object);
 }
 
 TEST_CASE("[Object] Destruction at the end of the call chain is safe") {


### PR DESCRIPTION
Follow-up of / supersedes https://github.com/godotengine/godot/pull/94239.

Benchmarks suggests this change improves `Object::notification` performance by 17% / 12% over https://github.com/godotengine/godot/pull/94239.

`Object::notification` is called quite a lot, so it needs to be _really_ fast. The idea for improvement is the same as what @CrazyRoka suggested doing in https://github.com/godotengine/godot/pull/94239: Reduce runtime branching by branching statically instead, Normally, a simple `bool` check doesn't make a difference, but because it's called so often, it does make a difference here.

Therefore, forward and reverse notifications are split into two separate virtual functions. They're still automatically generated (as before) for convenience, but the branch this creates should be optimized out by the compiler (because it's statically evaluatable).

## Practical Test
I tested with the MRP from https://github.com/godotengine/godot/pull/94239.

I tested `master`, https://github.com/godotengine/godot/pull/94239 (rebased onto master) and this PR against one another by launching 3 instances of the same scene with 10k cubes.
The performance impact was rather small, but measurable:

<img width="1180" alt="SCR-20250319-tghj" src="https://github.com/user-attachments/assets/ae5d6d2f-d375-4a12-baf7-fe1c1f103196" />

The fps fluctuated somewhat, so the screenshot is a bit of a lie, but I'm pretty sure it pretty consistently ranks as `master`, https://github.com/godotengine/godot/pull/94239, `this PR` in order of increasing fps.

## Benchmark

My benchmark suggests a 17% improvement over `master`, and a 12% improvement over #94239.

```c++
	Node3D *node = memnew(Node3D);

	auto t0 = std::chrono::high_resolution_clock::now();
	for (int i = 0; i < 500000000; i ++) {
		node->notification(Node::NOTIFICATION_VP_MOUSE_ENTER);
	}
	auto t1 = std::chrono::high_resolution_clock::now();
	std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
```

This yielded:
- `2415ms` on this pr 
- `2727ms` on #94239
- `2891ms` on master
