### PR TITLE
Fix clicks when AudioStreamPlayer3D routes to an Area3D's reverb send

### DIFF
--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -292,6 +292,11 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 				AudioServer::get_singleton()->start_playback_stream(setplayback, bus_map, setplay.get(), actual_pitch_scale, linear_attenuation, attenuation_filter_cutoff_hz);
 				setplayback.unref();
 				setplay.set(-1);
+				// Call `_update_panning()` immediately after starting the stream.
+				// This re-sets bus levels to ensure they are correct for the first few frames.
+				// (These levels may be initialized incorrectly due to the call to start_playback_stream
+				// ignoring the Area3D's bus options.)
+				_update_panning();
 			}
 
 			if (!internal->stream_playbacks.is_empty() && internal->active.is_set()) {
@@ -486,6 +491,8 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 			if (area->is_overriding_audio_bus()) {
 				//override audio bus
 				bus_volumes[area->get_audio_bus_name()] = output_volume_vector;
+			} else {
+				bus_volumes[internal->bus] = output_volume_vector;
 			}
 
 			if (area->is_using_reverb_bus()) {


### PR DESCRIPTION
This PR makes two changes to resolve issues when an `AudioStreamPlayer3D` plays its stream while routing to buses specified by an `Area3D`:
1. `_update_panning` is now called immediately after starting the stream. This re-sets bus levels to ensure they are correct for the first few frames. (These levels may be initialized incorrectly due to the call to `start_playback_stream` ignoring the `Area3D`'s bus options).
2. If the `Area3D` provides a reverb send but not a bus override, the `AudioStreamPlayer3D` would previously only output to the reverb send (and not its own bus). This has been fixed so that the stream now goes to both the reverb send and the `AudioStreamPlayer3D`'s bus.

Fixes #104337.
Fixes #96480.

#### PS
This is obviously not the most efficient possible implementation for (1), as `_update_panning` is called twice in quick succession.
A better solution would likely involve a larger rewrite clarifying `_update_panning`'s usage by making it `void`.
This tweak is presented along with a more generic `sends` parameter in #104096.