### PR TITLE
Fix crash when reimporting nested gltf scenes

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6457,6 +6457,18 @@ void EditorNode::reload_instances_with_path_in_edited_scenes() {
 
 			get_scene_editor_data_for_node(owner, original_node, scene_editor_data_table);
 
+			// The current node being reloaded may also be an additional node for another node
+			// that is in the process of being reloaded.
+			// Replacing the additional node with the new one prevents a crash where nodes
+			// in 'addition_list' are removed from the scene tree and queued for deletion.
+			for (InstanceModificationsEntry &im : scene_modifications->instance_list) {
+				for (AdditiveNodeEntry &additive_node_entry : im.addition_list) {
+					if (additive_node_entry.node == original_node) {
+						additive_node_entry.node = instantiated_node;
+					}
+				}
+			}
+
 			bool original_node_scene_instance_load_placeholder = original_node->get_scene_instance_load_placeholder();
 
 			// Delete all the remaining node children.


### PR DESCRIPTION
- Fixes #104203

The issue was caused by the fact that a reimported scene was also an added scene to another scene being reimported. The order in which the scenes are being processed is important to reproduce the issue. At some point an old node was being used to readd additional node to a reimported scene.

Tested with the MRP and retested with this test project with a lot of reimport test cases: 
[test-godot-blender-reimport-missing-node-v7.zip](https://github.com/user-attachments/files/19353681/test-godot-blender-reimport-missing-node-v7.zip)


Note: If it works well, I think this fix could be easily cherry picked for 4.4.1
