### PR TITLE
Fix connections dialog connecting to signal before adding new script function

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -981,13 +981,6 @@ void ConnectionsDock::_make_or_edit_connection() {
 		}
 	}
 
-	if (connect_dialog->is_editing()) {
-		_disconnect(connect_dialog->get_source_connection_data());
-		_connect(cd);
-	} else {
-		_connect(cd);
-	}
-
 	if (add_script_function_request) {
 		PackedStringArray script_function_args = connect_dialog->get_signal_args();
 		script_function_args.resize(script_function_args.size() - cd.unbinds);
@@ -996,6 +989,13 @@ void ConnectionsDock::_make_or_edit_connection() {
 		}
 
 		EditorNode::get_singleton()->emit_signal(SNAME("script_add_function_request"), target, cd.method, script_function_args);
+	}
+
+	if (connect_dialog->is_editing()) {
+		_disconnect(connect_dialog->get_source_connection_data());
+		_connect(cd);
+	} else {
+		_connect(cd);
 	}
 
 	update_tree();


### PR DESCRIPTION
Fixes part of (?) #85528, specifically https://github.com/godotengine/godot/issues/85528#issuecomment-2355347392 (I've tested only with GDScript though).

https://github.com/godotengine/godot/issues/85528#issuecomment-1836988143 pinpointed the issue well, a Callable with binds failed to be connected because of a different check when connecting:
https://github.com/godotengine/godot/blob/ef1153baf3343470b65258421a163c92455d32b3/core/object/object.cpp#L1421-L1428

Specifically `p_callable.is_valid()` fails because `get_custom()->is_valid()`  fails, which fails because `custom->get_object()->has_method(get_method())` fails:
https://github.com/godotengine/godot/blob/ef1153baf3343470b65258421a163c92455d32b3/core/variant/callable.cpp#L152-L158

But why does the object has no method which we've just told the dialog to create? Turns out the connections dialog firstly tries to connect the method, then it adds the method. This PR swaps the order of these. No idea if/why connecting would need to happen before adding the method. :thinking: