### PR TITLE
Add editor settings to close/restore the bottom panel when starting/stopping a project

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -385,7 +385,7 @@ void EditorNode::shortcut_input(const Ref<InputEvent> &p_event) {
 		} else if (ED_IS_SHORTCUT("editor/command_palette", p_event)) {
 			_open_command_palette();
 		} else if (ED_IS_SHORTCUT("editor/toggle_last_opened_bottom_panel", p_event)) {
-			bottom_panel->toggle_last_opened_bottom_panel();
+			bottom_panel->show_last_opened_bottom_panel(true);
 		} else {
 			is_handled = false;
 		}
@@ -4736,11 +4736,15 @@ void EditorNode::_project_run_started() {
 		log->clear();
 	}
 
+	bottom_panel_was_visible_on_project_run = bottom_panel->is_any_bottom_panel_visible();
+
 	int action_on_play = EDITOR_GET("run/bottom_panel/action_on_play");
 	if (action_on_play == ACTION_ON_PLAY_OPEN_OUTPUT) {
 		bottom_panel->make_item_visible(log);
 	} else if (action_on_play == ACTION_ON_PLAY_OPEN_DEBUGGER) {
 		bottom_panel->make_item_visible(EditorDebuggerNode::get_singleton());
+	} else if (action_on_play == ACTION_ON_PLAY_CLOSE_BOTTOM_PANEL) {
+		bottom_panel->hide_bottom_panel();
 	}
 }
 
@@ -4748,6 +4752,10 @@ void EditorNode::_project_run_stopped() {
 	int action_on_stop = EDITOR_GET("run/bottom_panel/action_on_stop");
 	if (action_on_stop == ACTION_ON_STOP_CLOSE_BUTTOM_PANEL) {
 		bottom_panel->hide_bottom_panel();
+	} else if (action_on_stop == ACTION_ON_STOP_RESTORE_LAST_USED_BUTTOM_PANEL) {
+		if (bottom_panel_was_visible_on_project_run) {
+			bottom_panel->show_last_opened_bottom_panel();
+		}
 	}
 }
 
@@ -4759,8 +4767,8 @@ void EditorNode::add_io_error(const String &p_error) {
 	DEV_ASSERT(Thread::get_caller_id() == Thread::get_main_id());
 	singleton->load_errors->add_image(singleton->theme->get_icon(SNAME("Error"), EditorStringName(EditorIcons)));
 	singleton->load_errors->add_text(p_error + "\n");
-	// When a progress dialog is displayed, we will wait for it ot close before displaying
-	// the io errors to prevent the io popup to set it's parent to the progress dialog.
+	// When a progress dialog is displayed, we will wait for it to close before displaying
+	// the io errors to prevent the io popup to set its parent to the progress dialog.
 	if (singleton->progress_dialog->is_visible()) {
 		singleton->load_errors_queued_to_display = true;
 	} else {
@@ -4772,8 +4780,8 @@ void EditorNode::add_io_warning(const String &p_warning) {
 	DEV_ASSERT(Thread::get_caller_id() == Thread::get_main_id());
 	singleton->load_errors->add_image(singleton->theme->get_icon(SNAME("Warning"), EditorStringName(EditorIcons)));
 	singleton->load_errors->add_text(p_warning + "\n");
-	// When a progress dialog is displayed, we will wait for it ot close before displaying
-	// the io errors to prevent the io popup to set it's parent to the progress dialog.
+	// When a progress dialog is displayed, we will wait for it to close before displaying
+	// the io errors to prevent the io popup to set its parent to the progress dialog.
 	if (singleton->progress_dialog->is_visible()) {
 		singleton->load_errors_queued_to_display = true;
 	} else {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -123,11 +123,13 @@ public:
 		ACTION_ON_PLAY_DO_NOTHING,
 		ACTION_ON_PLAY_OPEN_OUTPUT,
 		ACTION_ON_PLAY_OPEN_DEBUGGER,
+		ACTION_ON_PLAY_CLOSE_BOTTOM_PANEL,
 	};
 
 	enum ActionOnStop {
 		ACTION_ON_STOP_DO_NOTHING,
 		ACTION_ON_STOP_CLOSE_BUTTOM_PANEL,
+		ACTION_ON_STOP_RESTORE_LAST_USED_BUTTOM_PANEL,
 	};
 
 	enum MenuOptions {
@@ -408,6 +410,7 @@ private:
 	Callable palette_file_selected_callback;
 
 	EditorBottomPanel *bottom_panel = nullptr;
+	bool bottom_panel_was_visible_on_project_run = false;
 
 	Tree *disk_changed_list = nullptr;
 	ConfirmationDialog *disk_changed = nullptr;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -982,8 +982,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("run/auto_save/save_before_running", true, true);
 
 	// Bottom panel
-	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "run/bottom_panel/action_on_play", EditorNode::ACTION_ON_PLAY_OPEN_OUTPUT, "Do Nothing,Open Output,Open Debugger")
-	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "run/bottom_panel/action_on_stop", EditorNode::ACTION_ON_STOP_DO_NOTHING, "Do Nothing,Close Bottom Panel")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "run/bottom_panel/action_on_play", EditorNode::ACTION_ON_PLAY_OPEN_OUTPUT, "Do Nothing,Open Output,Open Debugger,Close Bottom Panel")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "run/bottom_panel/action_on_stop", EditorNode::ACTION_ON_STOP_DO_NOTHING, "Do Nothing,Close Bottom Panel,Restore Last Used Bottom Panel")
 
 	// Output
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "run/output/font_size", 13, "8,48,1")

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -282,11 +282,15 @@ void EditorBottomPanel::hide_bottom_panel() {
 	}
 }
 
-void EditorBottomPanel::toggle_last_opened_bottom_panel() {
+bool EditorBottomPanel::is_any_bottom_panel_visible() const {
+	return last_opened_control && last_opened_control->is_visible();
+}
+
+void EditorBottomPanel::show_last_opened_bottom_panel(bool p_toggle) {
 	// Select by control instead of index, so that the last bottom panel is opened correctly
 	// if it's been reordered since.
 	if (last_opened_control) {
-		_switch_by_control(!last_opened_control->is_visible(), last_opened_control, true);
+		_switch_by_control(p_toggle ? !last_opened_control->is_visible() : true, last_opened_control, true);
 	} else {
 		// Open the first panel in the list if no panel was opened this session.
 		_switch_to_item(true, 0, true);

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -84,7 +84,8 @@ public:
 	void make_item_visible(Control *p_item, bool p_visible = true, bool p_ignore_lock = false);
 	void move_item_to_end(Control *p_item);
 	void hide_bottom_panel();
-	void toggle_last_opened_bottom_panel();
+	bool is_any_bottom_panel_visible() const;
+	void show_last_opened_bottom_panel(bool p_toggle = false);
 	void set_expanded(bool p_expanded);
 
 	EditorBottomPanel();


### PR DESCRIPTION
This can be used in tandem with game embedding to maximize the screen real estate available for the game viewport.

- This closes https://github.com/godotengine/godot-proposals/issues/12021.

## Preview

https://github.com/user-attachments/assets/766ec6a7-2e5e-46ea-bac2-7ea3c7634d00

