### PR TITLE
Allow save instantiated scene as new scene.

### DIFF
--- a/editor/new_scene_from_dialog.cpp
+++ b/editor/new_scene_from_dialog.cpp
@@ -1,0 +1,318 @@
+/**************************************************************************/
+/*  new_scene_from_dialog.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor/new_scene_from_dialog.h"
+
+#include "core/config/project_settings.h"
+#include "editor/editor_node.h"
+#include "editor/editor_settings.h"
+#include "scene/2d/node_2d.h"
+#include "scene/gui/grid_container.h"
+#include "scene/gui/item_list.h"
+#include "scene/resources/packed_scene.h"
+
+NewSceneFromDialog::NewSceneFromDialog() {
+	// Configure self
+	set_ok_button_text(TTR("Create"));
+	// Main Container
+	VBoxContainer *vb = memnew(VBoxContainer);
+	GridContainer *gc = memnew(GridContainer);
+	gc->set_columns(2);
+	vb->add_child(gc);
+	add_child(vb);
+
+	// Root Name Text Edit
+	root_name_edit = memnew(LineEdit);
+	root_name_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	register_text_enter(root_name_edit);
+	gc->add_child(memnew(Label(TTR("Root Name:"))));
+	gc->add_child(root_name_edit);
+
+	// Inheritance Dropdown
+	ancestor_options = memnew(OptionButton);
+	ancestor_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	ancestor_options->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	gc->add_child(memnew(Label(TTR("Inherits:"))));
+	gc->add_child(ancestor_options);
+
+	// File Path Edit and Button
+	HBoxContainer *hb = memnew(HBoxContainer);
+	file_path_edit = memnew(LineEdit);
+	file_path_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	path_button = memnew(Button);
+	register_text_enter(file_path_edit);
+	path_button->connect(SceneStringName(pressed), callable_mp(this, &NewSceneFromDialog::_browse_file));
+	hb->add_child(file_path_edit);
+	hb->add_child(path_button);
+	gc->add_child(memnew(Label(TTR("Path:"))));
+	gc->add_child(hb);
+
+	// Set up File Browser:
+	file_browser = memnew(EditorFileDialog);
+	add_child(file_browser);
+	file_browser->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
+	Ref<PackedScene> sd = memnew(PackedScene);
+	ResourceSaver::get_recognized_extensions(sd, &extensions);
+	for (const String &extension : extensions) {
+		file_browser->add_filter("*." + extension, extension.to_upper());
+	}
+	file_browser->set_title(TTR("Save New Scene As..."));
+
+	file_browser->connect("file_selected", callable_mp(this, &NewSceneFromDialog::_file_selected));
+
+	// TODO: Add reset options
+	GridContainer *checkbox_gc = memnew(GridContainer);
+	checkbox_gc->set_columns(2);
+	reset_position_cb = memnew(CheckBox(TTR("Reset Position")));
+	reset_rotation_cb = memnew(CheckBox(TTR("Reset Rotation")));
+	reset_scale_cb = memnew(CheckBox(TTR("Reset Scale")));
+	remove_script_cb = memnew(CheckBox(TTR("Remove Script")));
+	checkbox_gc->add_child(reset_position_cb);
+	checkbox_gc->add_child(reset_rotation_cb);
+	checkbox_gc->add_child(reset_scale_cb);
+	checkbox_gc->add_child(remove_script_cb);
+	gc->add_child(memnew(Label(TTR("Configs:"))));
+	gc->add_child(checkbox_gc);
+
+	// Accept dialog
+	accept = memnew(AcceptDialog);
+	add_child(accept);
+
+	set_title(TTR("Create New Scene From..."));
+}
+
+void NewSceneFromDialog::config(Node *p_selected_node) {
+	selected_node = p_selected_node;
+	// Set Root Name
+	String root_name = p_selected_node->get_name();
+	root_name_edit->set_text(root_name);
+
+	String path_name = p_selected_node->get_owner()->get_scene_file_path().get_base_dir().path_join(root_name.to_snake_case() + ".tscn");
+	// Set Path Name
+	// String existing;
+	// if (extensions.size()) {
+	// 	String root_name(p_selected_node->get_name());
+	// 	root_name = EditorNode::adjust_scene_name_casing(root_name);
+	// 	existing = root_name + "." + extensions.begin()->to_lower();
+	// }
+	// TODO - The correct default_path
+	file_path_edit->set_text(path_name);
+	// TODO - Change the path when the base name changed
+
+	//ANCHOR - set option buttons
+	//NOTE - Need testing
+	ancestor_options->clear();
+	ancestor_options->add_item(p_selected_node->get_class_name(), 0);
+	ancestor_options->set_item_tooltip(0, "New");
+
+	int item_count = 1;
+	if (p_selected_node->get_scene_instance_state().is_valid()) {
+		Vector<Node *> instances;
+		Ref<SceneState> scene_state = p_selected_node->get_scene_instance_state();
+		while (scene_state.is_valid()) {
+			Ref<PackedScene> pack_data = ResourceLoader::load(scene_state->get_path());
+			if (!pack_data.is_valid()) {
+				break;
+			}
+			// QUESTION - GEN_EDIT_STATE_INSTANCE?
+			Node *current_node = pack_data->instantiate(PackedScene::GEN_EDIT_STATE_INSTANCE);
+			String name = current_node->get_name();
+			String ancestor_path_name = current_node->get_scene_file_path();
+			String class_name = current_node->get_class_name();
+			instances.push_back(current_node);
+			ancestor_options->add_item(name, item_count);
+			ancestor_options->set_item_tooltip(item_count, ancestor_path_name);
+			ancestor_options->set_item_metadata(item_count, scene_state);
+
+			scene_state = current_node->get_scene_inherited_state();
+			item_count++;
+		};
+		for (Node *instance : instances) {
+			memdelete(instance);
+		}
+	}
+	ancestor_options->select(0);
+}
+
+Ref<SceneState> NewSceneFromDialog::get_selected_scene_state() const {
+	return ancestor_options->get_selected_metadata();
+}
+
+String NewSceneFromDialog::get_new_node_name() const {
+	return root_name_edit->get_text();
+}
+
+void NewSceneFromDialog::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			path_button->set_button_icon(get_editor_theme_icon(SNAME("Folder")));
+		} break;
+	}
+}
+
+void NewSceneFromDialog::_bind_methods() {
+	ADD_SIGNAL(MethodInfo(SNAME("create_branch_scene"),
+			PropertyInfo(Variant::STRING, "file_path")));
+}
+
+void NewSceneFromDialog::_browse_file() {
+	// TODO: set a default path
+	file_browser->popup_file_dialog();
+}
+
+void NewSceneFromDialog::_file_selected(const String &p_file) {
+	String path = ProjectSettings::get_singleton()->localize_path(p_file);
+	file_path_edit->set_text(path);
+	// _path_changed(path);
+
+	String filename = path.get_file().get_basename();
+	int select_start = path.rfind(filename);
+	file_path_edit->select(select_start, select_start + filename.length());
+	file_path_edit->set_caret_column(select_start + filename.length());
+	file_path_edit->grab_focus();
+}
+
+void NewSceneFromDialog::_create_new_node() {
+	String lpath = ProjectSettings::get_singleton()->localize_path(file_path_edit->get_text());
+	if (EditorNode::get_singleton()->is_scene_open(lpath)) {
+		accept->set_text(TTR("Can't overwrite scene that is still open!"));
+		accept->popup_centered();
+		return;
+	}
+
+	// TODO - There's some problem with the selected node. The selected node actually shouldn't be here?
+	Node *base = selected_node;
+
+	HashMap<const Node *, Node *> duplimap;
+	HashMap<const Node *, Node *> inverse_duplimap;
+	Node *copy = base->duplicate_from_editor(duplimap);
+
+	for (const KeyValue<const Node *, Node *> &item : duplimap) {
+		inverse_duplimap[item.value] = const_cast<Node *>(item.key);
+	}
+
+	if (copy) {
+		// Handle Unique Nodes.
+		for (int i = 0; i < copy->get_child_count(false); i++) {
+			_set_node_owner_recursive(copy->get_child(i, false), copy, inverse_duplimap);
+		}
+		// Root node cannot ever be unique name in its own Scene!
+		copy->set_unique_name_in_owner(false);
+
+		bool reset_position = reset_scale_cb->is_pressed();
+		bool reset_scale = reset_scale_cb->is_pressed();
+		bool reset_rotation = reset_rotation_cb->is_pressed();
+		// TODO - implementing remove_script
+		bool remove_script = remove_script_cb->is_pressed();
+
+		Node2D *copy_2d = Object::cast_to<Node2D>(copy);
+		if (copy_2d != nullptr) {
+			if (reset_position) {
+				copy_2d->set_position(Vector2(0, 0));
+			}
+			if (reset_rotation) {
+				copy_2d->set_rotation(0);
+			}
+			if (reset_scale) {
+				copy_2d->set_scale(Size2(1, 1));
+			}
+		}
+		Node3D *copy_3d = Object::cast_to<Node3D>(copy);
+		if (copy_3d != nullptr) {
+			if (reset_position) {
+				copy_3d->set_position(Vector3(0, 0, 0));
+			}
+			if (reset_rotation) {
+				copy_3d->set_rotation(Vector3(0, 0, 0));
+			}
+			if (reset_scale) {
+				copy_3d->set_scale(Vector3(1, 1, 1));
+			}
+		}
+		Ref<SceneState> inherited_state = ancestor_options->get_selected_metadata();
+		if (inherited_state.is_valid()) {
+			copy->set_scene_inherited_state(inherited_state);
+		}
+
+		copy->set_name(root_name_edit->get_text());
+
+		Ref<PackedScene> sdata = memnew(PackedScene);
+		Error err = sdata->pack(copy);
+		memdelete(copy);
+
+		if (err != OK) {
+			accept->set_text(TTR("Couldn't save new scene. Likely dependencies (instances) couldn't be satisfied."));
+			accept->popup_centered();
+			return;
+		}
+
+		int flg = 0;
+		if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+			flg |= ResourceSaver::FLAG_COMPRESS;
+		}
+
+		// TODO: check file duplication!
+
+		err = ResourceSaver::save(sdata, lpath, flg);
+		if (err != OK) {
+			accept->set_text(TTR("Error saving scene."));
+			accept->popup_centered();
+			return;
+		}
+
+		emit_signal(SNAME("create_branch_scene"), lpath);
+
+	} else {
+		// TODO: change to early return;
+		accept->set_text(TTR("Error duplicating scene to save it."));
+		accept->popup_centered();
+		return;
+	}
+}
+
+void NewSceneFromDialog::_set_node_owner_recursive(Node *p_node, Node *p_owner, const HashMap<const Node *, Node *> &p_inverse_duplimap) {
+	HashMap<const Node *, Node *>::ConstIterator E = p_inverse_duplimap.find(p_node);
+
+	if (E) {
+		const Node *original = E->value;
+		if (original->get_owner()) {
+			p_node->set_owner(p_owner);
+		}
+	}
+
+	for (int i = 0; i < p_node->get_child_count(false); i++) {
+		_set_node_owner_recursive(p_node->get_child(i, false), p_owner, p_inverse_duplimap);
+	}
+}
+
+void NewSceneFromDialog::ok_pressed() {
+	_create_new_node();
+}

--- a/editor/new_scene_from_dialog.h
+++ b/editor/new_scene_from_dialog.h
@@ -1,0 +1,78 @@
+/**************************************************************************/
+/*  new_scene_from_dialog.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/gui/editor_file_dialog.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/option_button.h"
+#include "scene/gui/panel_container.h"
+
+class NewSceneFromDialog : public ConfirmationDialog {
+	GDCLASS(NewSceneFromDialog, ConfirmationDialog);
+
+private:
+	List<String> extensions;
+	// ItemList *ancestor_list = nullptr;
+	OptionButton *ancestor_options = nullptr;
+	LineEdit *root_name_edit = nullptr;
+	LineEdit *file_path_edit = nullptr;
+	// VBoxContainer *sidemenu = nullptr;
+	// VBoxContainer *ancestor_sidemenu = nullptr;
+	EditorFileDialog *file_browser = nullptr;
+	Button *path_button;
+
+	CheckBox *reset_position_cb;
+	CheckBox *reset_rotation_cb;
+	CheckBox *reset_scale_cb;
+	CheckBox *remove_script_cb;
+
+	AcceptDialog *accept = nullptr;
+
+	Node *selected_node;
+
+	void _browse_file();
+	void _file_selected(const String &p_file);
+	void _create_new_node();
+	void _set_node_owner_recursive(Node *p_node, Node *p_owner, const HashMap<const Node *, Node *> &p_inverse_duplimap);
+	virtual void ok_pressed() override;
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	NewSceneFromDialog();
+	void config(Node *p_selected_node);
+	Ref<SceneState> get_selected_scene_state() const;
+	String get_new_node_name() const;
+};

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1163,12 +1163,6 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			if (tocopy != editor_data->get_edited_scene_root() && !tocopy->get_scene_file_path().is_empty()) {
-				accept->set_text(TTR("Can't save the branch of an already instantiated scene.\nTo create a variation of a scene, you can make an inherited scene based on the instantiated scene using Scene > New Inherited Scene... instead."));
-				accept->popup_centered();
-				break;
-			}
-
 			if (tocopy->get_owner() != scene) {
 				accept->set_text(TTR("Can't save a branch which is a child of an already instantiated scene.\nTo save this branch into its own scene, open the original scene, right click on this branch, and select \"Save Branch as Scene\"."));
 				accept->popup_centered();
@@ -1180,32 +1174,34 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				accept->popup_centered();
 				break;
 			}
+			// TODO - I will keep these for now since the file browse is not finished yet
+			// new_scene_from_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
+			// if (determine_path_automatically) {
+			// 	new_scene_from_dialog->set_current_dir(editor_data->get_edited_scene_root()->get_scene_file_path().get_base_dir());
+			// } else {
+			// 	determine_path_automatically = true;
+			// }
 
-			new_scene_from_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
-			if (determine_path_automatically) {
-				new_scene_from_dialog->set_current_dir(editor_data->get_edited_scene_root()->get_scene_file_path().get_base_dir());
-			} else {
-				determine_path_automatically = true;
-			}
+			// List<String> extensions;
+			// Ref<PackedScene> sd = memnew(PackedScene);
+			// ResourceSaver::get_recognized_extensions(sd, &extensions);
+			// new_scene_from_dialog->clear_filters();
+			// for (const String &extension : extensions) {
+			// 	new_scene_from_dialog->add_filter("*." + extension, extension.to_upper());
+			// }
 
-			List<String> extensions;
-			Ref<PackedScene> sd = memnew(PackedScene);
-			ResourceSaver::get_recognized_extensions(sd, &extensions);
-			new_scene_from_dialog->clear_filters();
-			for (const String &extension : extensions) {
-				new_scene_from_dialog->add_filter("*." + extension, extension.to_upper());
-			}
+			// String existing;
+			// if (extensions.size()) {
+			// 	String root_name(tocopy->get_name());
+			// 	root_name = EditorNode::adjust_scene_name_casing(root_name);
+			// 	existing = root_name + "." + extensions.front()->get().to_lower();
+			// }
+			// new_scene_from_dialog->set_current_path(existing);
 
-			String existing;
-			if (extensions.size()) {
-				String root_name(tocopy->get_name());
-				root_name = EditorNode::adjust_scene_name_casing(root_name);
-				existing = root_name + "." + extensions.front()->get().to_lower();
-			}
-			new_scene_from_dialog->set_current_path(existing);
-
-			new_scene_from_dialog->set_title(TTR("Save New Scene As..."));
-			new_scene_from_dialog->popup_file_dialog();
+			// new_scene_from_dialog->set_title(TTR("Save New Scene As..."));
+			// new_scene_from_dialog->popup_file_dialog();
+			new_scene_from_dialog->config(tocopy);
+			new_scene_from_dialog->popup_centered();
 		} break;
 		case TOOL_COPY_NODE_PATH: {
 			List<Node *> selection = editor_selection->get_top_selected_node_list();
@@ -3360,6 +3356,7 @@ void SceneTreeDock::set_selected(Node *p_node, bool p_emit_selected) {
 }
 
 void SceneTreeDock::_new_scene_from(const String &p_file) {
+	// FIXME - [] The validation should be done before the operation was initialized. The data should probably be transferred someway instead of getting the node separately that might cause inconsistency.
 	List<Node *> selection = editor_selection->get_top_selected_node_list();
 
 	if (selection.size() != 1) {
@@ -3376,79 +3373,7 @@ void SceneTreeDock::_new_scene_from(const String &p_file) {
 
 	Node *base = selection.front()->get();
 
-	HashMap<const Node *, Node *> duplimap;
-	HashMap<const Node *, Node *> inverse_duplimap;
-	Node *copy = base->duplicate_from_editor(duplimap);
-
-	for (const KeyValue<const Node *, Node *> &item : duplimap) {
-		inverse_duplimap[item.value] = const_cast<Node *>(item.key);
-	}
-
-	if (copy) {
-		// Handle Unique Nodes.
-		for (int i = 0; i < copy->get_child_count(false); i++) {
-			_set_node_owner_recursive(copy->get_child(i, false), copy, inverse_duplimap);
-		}
-		// Root node cannot ever be unique name in its own Scene!
-		copy->set_unique_name_in_owner(false);
-
-		const Dictionary dict = new_scene_from_dialog->get_selected_options();
-		bool reset_position = dict.get(TTR("Reset Position"), true);
-		bool reset_scale = dict.get(TTR("Reset Scale"), false);
-		bool reset_rotation = dict.get(TTR("Reset Rotation"), false);
-
-		Node2D *copy_2d = Object::cast_to<Node2D>(copy);
-		if (copy_2d != nullptr) {
-			if (reset_position) {
-				copy_2d->set_position(Vector2(0, 0));
-			}
-			if (reset_rotation) {
-				copy_2d->set_rotation(0);
-			}
-			if (reset_scale) {
-				copy_2d->set_scale(Size2(1, 1));
-			}
-		}
-		Node3D *copy_3d = Object::cast_to<Node3D>(copy);
-		if (copy_3d != nullptr) {
-			if (reset_position) {
-				copy_3d->set_position(Vector3(0, 0, 0));
-			}
-			if (reset_rotation) {
-				copy_3d->set_rotation(Vector3(0, 0, 0));
-			}
-			if (reset_scale) {
-				copy_3d->set_scale(Vector3(1, 1, 1));
-			}
-		}
-
-		Ref<PackedScene> sdata = memnew(PackedScene);
-		Error err = sdata->pack(copy);
-		memdelete(copy);
-
-		if (err != OK) {
-			accept->set_text(TTR("Couldn't save new scene. Likely dependencies (instances) couldn't be satisfied."));
-			accept->popup_centered();
-			return;
-		}
-
-		int flg = 0;
-		if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
-			flg |= ResourceSaver::FLAG_COMPRESS;
-		}
-
-		err = ResourceSaver::save(sdata, p_file, flg);
-		if (err != OK) {
-			accept->set_text(TTR("Error saving scene."));
-			accept->popup_centered();
-			return;
-		}
-		_replace_with_branch_scene(p_file, base);
-	} else {
-		accept->set_text(TTR("Error duplicating scene to save it."));
-		accept->popup_centered();
-		return;
-	}
+	_replace_with_branch_scene(p_file, base);
 }
 
 void SceneTreeDock::_set_node_owner_recursive(Node *p_node, Node *p_owner, const HashMap<const Node *, Node *> &p_inverse_duplimap) {
@@ -4077,8 +4002,9 @@ void SceneTreeDock::set_filter(const String &p_filter) {
 }
 
 void SceneTreeDock::save_branch_to_file(const String &p_directory) {
-	new_scene_from_dialog->set_current_dir(p_directory);
-	determine_path_automatically = false;
+	// TODO - I will keep the code for now
+	// new_scene_from_dialog->set_current_dir(p_directory);
+	// determine_path_automatically = false;
 	_tool_selected(TOOL_NEW_SCENE_FROM);
 }
 
@@ -4683,6 +4609,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	ED_SHORTCUT("scene_tree/reparent_to_new_node", TTRC("Reparent to New Node..."));
 	ED_SHORTCUT("scene_tree/make_root", TTRC("Make Scene Root"));
 	ED_SHORTCUT("scene_tree/save_branch_as_scene", TTRC("Save Branch as Scene..."));
+	ED_SHORTCUT("scene_tree/save_branch_as_new_variant", TTRC("Save Branch as a New Variant Scene..."));
 	ED_SHORTCUT("scene_tree/copy_node_path", TTRC("Copy Node Path"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::C);
 	ED_SHORTCUT("scene_tree/show_in_file_system", TTRC("Show in FileSystem"));
 	ED_SHORTCUT("scene_tree/toggle_unique_name", TTRC("Toggle Access as Unique Name"));
@@ -4871,13 +4798,14 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	add_child(placeholder_editable_instance_remove_dialog);
 	placeholder_editable_instance_remove_dialog->connect(SceneStringName(confirmed), callable_mp(this, &SceneTreeDock::_toggle_placeholder_from_selection));
 
-	new_scene_from_dialog = memnew(EditorFileDialog);
-	new_scene_from_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
-	new_scene_from_dialog->add_option(TTR("Reset Position"), Vector<String>(), true);
-	new_scene_from_dialog->add_option(TTR("Reset Rotation"), Vector<String>(), false);
-	new_scene_from_dialog->add_option(TTR("Reset Scale"), Vector<String>(), false);
+	new_scene_from_dialog = memnew(NewSceneFromDialog);
+	// new_scene_from_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
+	// new_scene_from_dialog->add_option(TTR("Reset Position"), Vector<String>(), true);
+	// new_scene_from_dialog->add_option(TTR("Reset Rotation"), Vector<String>(), false);
+	// new_scene_from_dialog->add_option(TTR("Reset Scale"), Vector<String>(), false);
 	add_child(new_scene_from_dialog);
-	new_scene_from_dialog->connect("file_selected", callable_mp(this, &SceneTreeDock::_new_scene_from));
+	// TODO: Add a signal to create new scene
+	new_scene_from_dialog->connect(SNAME("create_branch_scene"), callable_mp(this, &SceneTreeDock::_new_scene_from));
 
 	menu = memnew(PopupMenu);
 	add_child(menu);

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "editor/gui/scene_tree_editor.h"
+#include "editor/new_scene_from_dialog.h"
 #include "editor/script_create_dialog.h"
 #include "scene/gui/box_container.h"
 #include "scene/resources/animation.h"
@@ -151,7 +152,7 @@ class SceneTreeDock : public VBoxContainer {
 	ConfirmationDialog *placeholder_editable_instance_remove_dialog = nullptr;
 
 	ReparentDialog *reparent_dialog = nullptr;
-	EditorFileDialog *new_scene_from_dialog = nullptr;
+	NewSceneFromDialog *new_scene_from_dialog = nullptr;
 
 	enum FilterMenuItems {
 		FILTER_BY_TYPE = 64, // Used in the same menus as the Tool enum.


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/183ba300-a12a-4296-b8fe-61d2403bd6d5)

A new dialogue is created for save branch as new scene.

---

Allow user to tweak an instantiated scene and save that branch as a new scene. The user can choose which ancestor scene they want their new branch to inherit from. At the same time, the user can rename the newly created inherited scene.

The work is still in progress. I'm not sure if this is the desired implementation, so please share your suggestions.

Closes https://github.com/godotengine/godot-proposals/issues/5171
Closes https://github.com/godotengine/godot-proposals/issues/10565
