### PR TITLE
[macOS] Replace custom main loop with `[NSApp run]` and `CFRunLoop` observer.

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -441,6 +441,7 @@ public:
 	virtual Key keyboard_get_label_from_physical(Key p_keycode) const override;
 	virtual void show_emoji_and_symbol_picker() const override;
 
+	void _process_events(bool p_pump);
 	virtual void process_events() override;
 	virtual void force_process_and_drop_events() override;
 

--- a/platform/macos/godot_application_delegate.h
+++ b/platform/macos/godot_application_delegate.h
@@ -36,8 +36,8 @@
 #import <Foundation/Foundation.h>
 
 @interface GodotApplicationDelegate : NSObject <NSUserInterfaceItemSearching, NSApplicationDelegate>
+- (void)activate;
 - (void)forceUnbundledWindowActivationHackStep1;
 - (void)forceUnbundledWindowActivationHackStep2;
 - (void)forceUnbundledWindowActivationHackStep3;
-- (void)handleAppleEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent;
 @end

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -59,36 +59,12 @@ int main(int argc, char **argv) {
 		}
 	}
 
-	OS_MacOS os;
-	Error err;
+	OS_MacOS os(argv[0], argc - first_arg, &argv[first_arg]);
 
 	// We must override main when testing is enabled.
 	TEST_MAIN_OVERRIDE
 
-	@autoreleasepool {
-		err = Main::setup(argv[0], argc - first_arg, &argv[first_arg]);
-	}
-
-	if (err != OK) {
-		if (err == ERR_HELP) { // Returned by --help and --version, so success.
-			return EXIT_SUCCESS;
-		}
-		return EXIT_FAILURE;
-	}
-
-	int ret;
-	@autoreleasepool {
-		ret = Main::start();
-	}
-	if (ret == EXIT_SUCCESS) {
-		os.run();
-	} else {
-		os.set_exit_code(EXIT_FAILURE);
-	}
-
-	@autoreleasepool {
-		Main::cleanup();
-	}
+	os.run(); // Note: This function will never return.
 
 	return os.get_exit_code();
 }

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -40,6 +40,13 @@
 #include "servers/audio_server.h"
 
 class OS_MacOS : public OS_Unix {
+	const char *execpath = nullptr;
+	int argc = 0;
+	char **argv = nullptr;
+
+	id delegate = nullptr;
+	bool should_terminate = false;
+
 	JoypadApple *joypad_apple = nullptr;
 
 #ifdef COREAUDIO_ENABLED
@@ -51,7 +58,7 @@ class OS_MacOS : public OS_Unix {
 
 	CrashHandler crash_handler;
 
-	CFRunLoopObserverRef pre_wait_observer;
+	CFRunLoopObserverRef pre_wait_observer = nil;
 
 	MainLoop *main_loop = nullptr;
 
@@ -63,6 +70,8 @@ class OS_MacOS : public OS_Unix {
 
 	static _FORCE_INLINE_ String get_framework_executable(const String &p_path);
 	static void pre_wait_observer_cb(CFRunLoopObserverRef p_observer, CFRunLoopActivity p_activiy, void *p_context);
+
+	void terminate();
 
 protected:
 	virtual void initialize_core() override;
@@ -131,8 +140,13 @@ public:
 	virtual String get_system_ca_certificates() override;
 	virtual OS::PreferredTextureFormat get_preferred_texture_format() const override;
 
-	void run();
+	void run(); // Runs macOS native event loop.
+	void start_main(); // Initializes and runs Godot main loop.
+	void activate();
+	void cleanup();
+	bool os_should_terminate() const { return should_terminate; }
+	int get_cmd_argc() const { return argc; }
 
-	OS_MacOS();
+	OS_MacOS(const char *p_execpath, int p_argc, char **p_argv);
 	~OS_MacOS();
 };


### PR DESCRIPTION
Replaces custom main loop with standard `[NSApp run]` loop, and `CFRunLoop` observer hook. Should prevent main loop from getting block while using native menu/native popups.

Might fix window activation issues when running from console, and required to properly support native macOS menus in https://github.com/godotengine/godot/pull/76829.