### PR TITLE
Improve Popup `content_scale_factor`

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3036,14 +3036,18 @@ void PopupMenu::popup(const Rect2i &p_bounds) {
 
 		moved = Vector2();
 		popup_time_msec = OS::get_singleton()->get_ticks_msec();
-		if (!is_embedded()) {
-			float win_scale = get_parent_visible_window()->get_content_scale_factor();
-			set_content_scale_factor(win_scale);
-			Size2 minsize = get_contents_minimum_size() * win_scale;
-			minsize.height = Math::ceil(minsize.height); // Ensures enough height at fractional content scales to prevent the v_scroll_bar from showing.
-			set_min_size(minsize); // `height` is truncated here by the cast to Size2i for Window.min_size.
-			set_size(Vector2(0, 0)); // Shrinkwraps to min size.
+
+		Size2 scale = get_parent_viewport()->get_popup_base_transform().get_scale();
+		CanvasItem *c = Object::cast_to<CanvasItem>(get_parent());
+		if (c) {
+			scale *= c->get_global_transform_with_canvas().get_scale();
 		}
+		real_t popup_scale = MIN(scale.x, scale.y);
+		set_content_scale_factor(popup_scale);
+		Size2 minsize = get_contents_minimum_size() * popup_scale;
+		minsize.height = Math::ceil(minsize.height); // Ensures enough height at fractional content scales to prevent the v_scroll_bar from showing.
+		set_min_size(minsize); // `height` is truncated here by the cast to Size2i for Window.min_size.
+		set_size(Vector2(0, 0)); // Shrinkwraps to min size.
 		Popup::popup(p_bounds);
 	}
 }

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4092,7 +4092,9 @@ bool Tree::edit_selected(bool p_force_edit) {
 		return false;
 	}
 
-	real_t popup_scale = popup_editor->is_embedded() ? 1.0 : popup_editor->get_parent_visible_window()->get_content_scale_factor();
+	Size2 scale = popup_editor->get_parent_viewport()->get_popup_base_transform().get_scale() * get_global_transform_with_canvas().get_scale();
+	real_t popup_scale = MIN(scale.x, scale.y);
+
 	Rect2 rect = _get_item_focus_rect(s);
 	rect.position *= popup_scale;
 	popup_edited_item = s;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1562,20 +1562,19 @@ void Viewport::_gui_show_tooltip() {
 	if (!window) { // Not embedded.
 		window = gui.tooltip_popup->get_parent_visible_window();
 	}
-	float win_scale = window->content_scale_factor;
+	Size2 scale = get_popup_base_transform().get_scale();
+	real_t popup_scale = MIN(scale.x, scale.y);
 	Point2 tooltip_offset = GLOBAL_GET("display/mouse_cursor/tooltip_position_offset");
-	if (!gui.tooltip_popup->is_embedded()) {
-		tooltip_offset *= win_scale;
-	}
+	tooltip_offset *= popup_scale;
 	Rect2 r(gui.tooltip_pos + tooltip_offset, gui.tooltip_popup->get_contents_minimum_size());
 	Rect2i vr;
 	if (gui.tooltip_popup->is_embedded()) {
 		vr = gui.tooltip_popup->get_embedder()->get_visible_rect();
 	} else {
-		panel->content_scale_factor = win_scale;
-		r.size *= win_scale;
 		vr = window->get_usable_parent_rect();
 	}
+	panel->content_scale_factor = popup_scale;
+	r.size *= popup_scale;
 	r.size = r.size.ceil();
 	r.size = r.size.min(panel->get_max_size());
 


### PR DESCRIPTION
Change the content_scale_factor used by some Popups from being retrieved from the parent Window to being retrieved from the parent Viewport.

Fix #69749
Fix #69171
Fix #98672

master:
![图片](https://github.com/user-attachments/assets/78a8b268-6848-455e-93a0-2e91ffb493b8)
![图片](https://github.com/user-attachments/assets/a4cc2eb5-cb2c-407d-8166-cb7a68974976)


this pr:
![图片](https://github.com/user-attachments/assets/fe1f4436-f670-4db3-84b8-c75668d6d1c9)
![图片](https://github.com/user-attachments/assets/f6b0807e-6d4e-4094-997d-5e4074822338)


test:
![图片](https://github.com/user-attachments/assets/36befbb3-fde6-45c1-93dd-e686d08b793a)

[popup_test_2025-03-20_23-17-23.zip](https://github.com/user-attachments/files/19369994/popup_test_2025-03-20_23-17-23.zip)

