### PR TITLE
LSP: Fix file URI handling + warn about workspace project mismatch

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1934,9 +1934,16 @@ bool EditorFileSystem::_find_file(const String &p_file, EditorFileSystemDirector
 
 	int cpos = -1;
 	for (int i = 0; i < fs->files.size(); i++) {
-		if (fs->files[i]->file == file) {
-			cpos = i;
-			break;
+		if (fs_case_sensitive) {
+			if (fs->files[i]->file == file) {
+				cpos = i;
+				break;
+			}
+		} else {
+			if (fs->files[i]->file.to_lower() == file.to_lower()) {
+				cpos = i;
+				break;
+			}
 		}
 	}
 

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -494,12 +494,14 @@ Array GDScriptTextDocument::find_symbols(const LSP::TextDocumentPositionParams &
 	if (symbol) {
 		LSP::Location location;
 		location.uri = symbol->uri;
-		location.range = symbol->selectionRange;
-		const String &path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(symbol->uri);
-		if (file_checker->file_exists(path)) {
-			arr.push_back(location.to_json());
+		if (!location.uri.is_empty()) {
+			location.range = symbol->selectionRange;
+			const String &path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(symbol->uri);
+			if (file_checker->file_exists(path)) {
+				arr.push_back(location.to_json());
+			}
+			r_list.push_back(symbol);
 		}
-		r_list.push_back(symbol);
 	} else if (GDScriptLanguageProtocol::get_singleton()->is_smart_resolve_enabled()) {
 		List<const LSP::DocumentSymbol *> list;
 		GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_related_symbols(p_location, list);

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -50,6 +50,9 @@ protected:
 	bool initialized = false;
 	HashMap<StringName, LSP::DocumentSymbol> native_symbols;
 
+	// Absolute paths that are known to point to res://
+	HashSet<String> absolute_res_paths;
+
 	const LSP::DocumentSymbol *get_native_symbol(const String &p_class, const String &p_member = "") const;
 	const LSP::DocumentSymbol *get_script_symbol(const String &p_path) const;
 	const LSP::DocumentSymbol *get_parameter_symbol(const LSP::DocumentSymbol *p_parent, const String &symbol_identifier);
@@ -78,7 +81,7 @@ public:
 	Error parse_script(const String &p_path, const String &p_content);
 	Error parse_local_script(const String &p_path);
 
-	String get_file_path(const String &p_uri) const;
+	String get_file_path(const String &p_uri);
 	String get_file_uri(const String &p_path) const;
 
 	void publish_diagnostics(const String &p_path);

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -238,6 +238,25 @@ struct ReferenceContext {
 	bool includeDeclaration = false;
 };
 
+struct ShowMessageParams {
+	/**
+	 * The message type. See {@link MessageType}.
+	 */
+	int type;
+
+	/**
+	 * The actual message.
+	 */
+	String message;
+
+	_FORCE_INLINE_ Dictionary to_json() const {
+		Dictionary dict;
+		dict["type"] = type;
+		dict["message"] = message;
+		return dict;
+	}
+};
+
 struct ReferenceParams : TextDocumentPositionParams {
 	ReferenceContext context;
 };
@@ -404,6 +423,25 @@ static const int Full = 1;
  */
 static const int Incremental = 2;
 }; // namespace TextDocumentSyncKind
+
+namespace MessageType {
+/**
+ * An error message.
+ */
+static const int Error = 1;
+/**
+ * A warning message.
+ */
+static const int Warning = 2;
+/**
+ * An information message.
+ */
+static const int Info = 3;
+/**
+ * A log message.
+ */
+static const int Log = 4;
+}; // namespace MessageType
 
 /**
  * Completion options.

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -334,7 +334,7 @@ void test_position_roundtrip(LSP::Position p_lsp, GodotPosition p_gd, const Pack
 // * Line & Char:
 //   * LSP: both 0-based
 //   * Godot: both 1-based
-TEST_SUITE("[Modules][GDScript][LSP]") {
+TEST_SUITE("[Modules][GDScript][LSP][Editor]") {
 	TEST_CASE("Can convert positions to and from Godot") {
 		String code = R"(extends Node
 
@@ -405,6 +405,7 @@ func f():
 		}
 	}
 	TEST_CASE("[workspace][resolve_symbol]") {
+		EditorFileSystem *efs = memnew(EditorFileSystem);
 		GDScriptLanguageProtocol *proto = initialize(root);
 		REQUIRE(proto);
 		Ref<GDScriptWorkspace> workspace = GDScriptLanguageProtocol::get_singleton()->get_workspace();
@@ -485,9 +486,11 @@ func f():
 		}
 
 		memdelete(proto);
+		memdelete(efs);
 		finish_language();
 	}
 	TEST_CASE("[workspace][document_symbol]") {
+		EditorFileSystem *efs = memnew(EditorFileSystem);
 		GDScriptLanguageProtocol *proto = initialize(root);
 		REQUIRE(proto);
 
@@ -524,6 +527,7 @@ func f():
 		}
 
 		memdelete(proto);
+		memdelete(efs);
 		finish_language();
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/103565
Fixes https://github.com/godotengine/godot/issues/92248
Fixes #105000

Might have an influence on:
https://github.com/godotengine/godot-vscode-plugin/issues/649
https://github.com/godotengine/godot-vscode-plugin/issues/650

This PR does two things:

- Replaces the file URI handling from the language server with an implementation based on rfc3986 and rfc8089. So that the URI is properly read and decoded.

- Do stuff to convert the absolute URI path to a valid res path, taking into account projects in symlinked directories and case insensitive file systems. This should solve a lot of problems with duplicate class name errors when using the language server.

Also adds a warning if the root location of the workspace does not match the project which is open in Godot.



TODO:
- [x] Test on windows (drive letters might need special handling, since the absolute path from the URI might contain a leading slash before the drive letter. We might need to strip it).

> This was only briefly tested on a Windows VM. Further Windows testing might be helpful.

> This PR changes the behavior of exposed methods. I'm working under the assumption that the language server is experimental (not the feature, but the exposed API). See #105016
