### PR TITLE
Fix icons with non-ASCII file names in project manager.

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -311,7 +311,7 @@ String ResourceUID::get_path_from_cache(Ref<FileAccess> &p_cache_file, const Str
 		ERR_FAIL_COND_V(rl != len, String());
 
 		if (singleton->id_to_text(id) == p_uid_string) {
-			return String(cs.get_data());
+			return String::utf8(cs.get_data());
 		}
 	}
 	return String();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/104363