### PR TITLE
Web: Fix editor build after `#pragma once` refactoring

### DIFF
--- a/platform/web/editor/web_tools_editor_plugin.h
+++ b/platform/web/editor/web_tools_editor_plugin.h
@@ -44,10 +44,3 @@ public:
 
 	WebToolsEditorPlugin();
 };
-
-#else
-
-class WebToolsEditorPlugin {
-public:
-	static void initialize() {}
-};


### PR DESCRIPTION
#102298 inadvertently broke the web editor build (which we don't test on CI), due to this weird setup for `WebToolsEditorPlugin`:

```cpp
#ifndef WEB_TOOLS_EDITOR_PLUGIN
#define WEB_TOOLS_EDITOR_PLUGIN

#include "core/io/zip_io.h"
#include "editor/plugins/editor_plugin.h"

class WebToolsEditorPlugin : public EditorPlugin {
	GDCLASS(WebToolsEditorPlugin, EditorPlugin);

private:
	void _download_zip();

public:
	static void initialize();

	WebToolsEditorPlugin();
};

#else

class WebToolsEditorPlugin {
public:
	static void initialize() {}
};

#endif
```

While replacing the header guard we missed the weird `#else` clause here.

This `#else` seems to be a bug after a past refactor, as the original class @Faless added in c54de7f5899 actually had this condition: `#if defined(TOOLS_ENABLED) && defined(JAVASCRIPT_ENABLED)`.

The condition was removed when refactoring how this file gets compiled via SCons so it's properly editor-only anyway, but the `#else` wasn't removed.