### PR TITLE
Expose rand_weighted in global rng instance

### DIFF
--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -57,6 +57,10 @@ double Math::randfn(double mean, double deviation) {
 	return default_rand.randfn(mean, deviation);
 }
 
+int64_t Math::rand_weighted(const Vector<float> &p_weights) {
+	return default_rand.rand_weighted(p_weights);
+}
+
 int Math::step_decimals(double p_step) {
 	static const int maxn = 10;
 	static const double sd[maxn] = {

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -565,6 +565,7 @@ public:
 	static _ALWAYS_INLINE_ double randd() { return (double)rand() / (double)Math::RANDOM_32BIT_MAX; }
 	static _ALWAYS_INLINE_ float randf() { return (float)rand() / (float)Math::RANDOM_32BIT_MAX; }
 	static double randfn(double mean, double deviation);
+	static int64_t rand_weighted(const Vector<float> &p_weights);
 
 	static double random(double from, double to);
 	static float random(float from, float to);

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -797,6 +797,10 @@ double VariantUtilityFunctions::randf_range(double from, double to) {
 	return Math::random(from, to);
 }
 
+int64_t VariantUtilityFunctions::rand_weighted(const Vector<float> &p_weights) {
+	return Math::rand_weighted(p_weights);
+}
+
 void VariantUtilityFunctions::seed(int64_t s) {
 	return Math::seed(s);
 }
@@ -1815,6 +1819,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(randi_range, sarray("from", "to"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBINDR(randf_range, sarray("from", "to"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBINDR(randfn, sarray("mean", "deviation"), Variant::UTILITY_FUNC_TYPE_RANDOM);
+	FUNCBINDR(rand_weighted, sarray("weights"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBIND(seed, sarray("base"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBINDR(rand_from_seed, sarray("seed"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -121,6 +121,7 @@ struct VariantUtilityFunctions {
 	static double randfn(double mean, double deviation);
 	static int64_t randi_range(int64_t from, int64_t to);
 	static double randf_range(double from, double to);
+	static int64_t rand_weighted(const Vector<float> &p_weights);
 	static void seed(int64_t s);
 	static PackedInt64Array rand_from_seed(int64_t seed);
 	// Utility

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1004,6 +1004,23 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="rand_weighted">
+			<return type="int" />
+			<param index="0" name="weights" type="PackedFloat32Array" />
+			<description>
+				Returns a random index with non-uniform weights. Prints an error and returns [code]-1[/code] if the array is empty.
+				[codeblocks]
+				[gdscript]
+				var my_array = ["one", "two", "three", "four"]
+				var weights = PackedFloat32Array([0.5, 1, 1, 2])
+
+				# Prints one of the four elements in `my_array`.
+				# It is more likely to print "four", and less likely to print "one".
+				print(my_array[rand_weighted(weights)])
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="randf">
 			<return type="float" />
 			<description>


### PR DESCRIPTION
Currently to use rand_weighted you are forced to create RandomNumberGenerator instances. This is something that should be exposed in the global instance, just like all of the other rand* methods from RandomNumberGenerator are.