### PR TITLE
Expose get_seed in the global rng instance

### DIFF
--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -45,6 +45,10 @@ void Math::seed(uint64_t x) {
 	default_rand.seed(x);
 }
 
+uint64_t Math::get_seed() {
+	return default_rand.get_seed();
+}
+
 void Math::randomize() {
 	default_rand.randomize();
 }

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -559,6 +559,7 @@ public:
 	static uint32_t larger_prime(uint32_t p_val);
 
 	static void seed(uint64_t x);
+	static uint64_t get_seed();
 	static void randomize();
 	static uint32_t rand_from_seed(uint64_t *seed);
 	static uint32_t rand();

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -801,6 +801,10 @@ void VariantUtilityFunctions::seed(int64_t s) {
 	return Math::seed(s);
 }
 
+int64_t VariantUtilityFunctions::get_seed() {
+	return Math::get_seed();
+}
+
 PackedInt64Array VariantUtilityFunctions::rand_from_seed(int64_t seed) {
 	uint64_t s = seed;
 	PackedInt64Array arr;
@@ -1816,6 +1820,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(randf_range, sarray("from", "to"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBINDR(randfn, sarray("mean", "deviation"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBIND(seed, sarray("base"), Variant::UTILITY_FUNC_TYPE_RANDOM);
+	FUNCBINDR(get_seed, sarray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBINDR(rand_from_seed, sarray("seed"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 
 	// Utility

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -122,6 +122,7 @@ struct VariantUtilityFunctions {
 	static int64_t randi_range(int64_t from, int64_t to);
 	static double randf_range(double from, double to);
 	static void seed(int64_t s);
+	static int64_t get_seed();
 	static PackedInt64Array rand_from_seed(int64_t seed);
 	// Utility
 	static Variant weakref(const Variant &obj, Callable::CallError &r_error);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -473,6 +473,12 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="get_seed">
+			<return type="int" />
+			<description>
+				Returns the current seed in use by the random number generator, set either by calling [method randomize] or setting the seed manually with [method seed].
+			</description>
+		</method>
 		<method name="hash">
 			<return type="int" />
 			<param index="0" name="variable" type="Variant" />


### PR DESCRIPTION
This allows for someone to use randomize() and then reproduce the results of the global rng instance later.