### PR TITLE
Export: Change unportable `echo` in the Linux/macOS debug launcher script

### DIFF
--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -50,7 +50,7 @@ Error EditorExportPlatformLinuxBSD::_export_debug_script(const Ref<EditorExportP
 	}
 
 	f->store_line("#!/bin/sh");
-	f->store_line("echo -ne '\\033c\\033]0;" + p_app_name + "\\a'");
+	f->store_line("printf '\\033c\\033]0;%s\\a' " + p_app_name);
 	f->store_line("base_path=\"$(dirname \"$(realpath \"$0\")\")\"");
 	f->store_line("\"$base_path/" + p_pkg_name + "\" \"$@\"");
 

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -1500,7 +1500,7 @@ Error EditorExportPlatformMacOS::_export_debug_script(const Ref<EditorExportPres
 	}
 
 	f->store_line("#!/bin/sh");
-	f->store_line("echo -ne '\\033c\\033]0;" + p_app_name + "\\a'");
+	f->store_line("printf '\\033c\\033]0;%s\\a' " + p_app_name);
 	f->store_line("");
 	f->store_line("function app_realpath() {");
 	f->store_line("    SOURCE=$1");


### PR DESCRIPTION
judging by the use of `/bin/sh` i am assuming that this script should be posix compliant
`-n` and `-e` are not guaranteed to be supported by posix `echo`, and instead `printf` should be used, this PR does exactly that
this should be a small enough change to warrant not opening an issue and going straight for a PR, right?