### PR TITLE
Optimize `get_direct_inheriters_from_class` by avoiding duplicate key lookups and value copies.

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -298,7 +298,7 @@ void ClassDB::get_direct_inheriters_from_class(const StringName &p_class, List<S
 	OBJTYPE_RLOCK;
 
 	for (const KeyValue<StringName, ClassInfo> &E : classes) {
-		if (E.key != p_class && _get_parent_class(E.key) == p_class) {
+		if (E.key != p_class && E.value.inherits == p_class) {
 			p_classes->push_back(E.key);
 		}
 	}


### PR DESCRIPTION
Just a quick one that looked suspicious from a launch of godot editor.
This shaves off ~30ms from the launch time (1%).

The reason is an unnecessary dict lookup and a `StringName` copy / deconstruction for every iteration.

```
 ❯ hyperfine -m25 -iw1 "bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit" "bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit"
Benchmark 1: bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      4.741 s ±  0.147 s    [User: 3.253 s, System: 0.404 s]
  Range (min … max):    4.385 s …  5.096 s    25 runs

Benchmark 2: bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      4.708 s ±  0.156 s    [User: 3.242 s, System: 0.404 s]
  Range (min … max):    4.426 s …  4.929 s    25 runs

Summary
  bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit ran
    1.01 ± 0.05 times faster than bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit
```