### PR TITLE
Fix incorrect guards in `VisibleOnScreenNotifier2D`

### DIFF
--- a/scene/2d/visible_on_screen_notifier_2d.cpp
+++ b/scene/2d/visible_on_screen_notifier_2d.cpp
@@ -30,7 +30,7 @@
 
 #include "visible_on_screen_notifier_2d.h"
 
-#ifdef DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
 Dictionary VisibleOnScreenNotifier2D::_edit_get_state() const {
 	Dictionary state = Node2D::_edit_get_state();
 	state["rect"] = rect;
@@ -46,7 +46,9 @@ void VisibleOnScreenNotifier2D::_edit_set_state(const Dictionary &p_state) {
 void VisibleOnScreenNotifier2D::_edit_set_rect(const Rect2 &p_edit_rect) {
 	set_rect(p_edit_rect);
 }
+#endif // TOOLS_ENABLED
 
+#ifdef DEBUG_ENABLED
 Rect2 VisibleOnScreenNotifier2D::_edit_get_rect() const {
 	return rect;
 }

--- a/scene/2d/visible_on_screen_notifier_2d.h
+++ b/scene/2d/visible_on_screen_notifier_2d.h
@@ -54,13 +54,16 @@ protected:
 	static void _bind_methods();
 
 public:
-#ifdef DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
 	virtual Dictionary _edit_get_state() const override;
 	virtual void _edit_set_state(const Dictionary &p_state) override;
 
 	virtual Vector2 _edit_get_minimum_size() const override { return Vector2(); }
 
 	virtual void _edit_set_rect(const Rect2 &p_edit_rect) override;
+#endif // TOOLS_ENABLED
+
+#ifdef DEBUG_ENABLED
 	virtual Rect2 _edit_get_rect() const override;
 
 	virtual bool _edit_use_rect() const override;


### PR DESCRIPTION
Some methods used `DEBUG_ENABLED` instead of `TOOLS_ENABLED`.

Regression from:
* https://github.com/godotengine/godot/pull/100874

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
