### PR TITLE
Fix file order issue with enumerated file-names

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -780,7 +780,7 @@ static _FORCE_INLINE_ signed char natural_cmp_common(const char32_t *&r_this_str
 	return 0;
 }
 
-static _FORCE_INLINE_ signed char naturalcasecmp_to_base(const char32_t *p_this_str, const char32_t *p_that_str) {
+static _FORCE_INLINE_ signed char naturalcasecmp_to_base(const char32_t *p_this_str, const char32_t *p_that_str, bool p_file) {
 	if (p_this_str && p_that_str) {
 		while (*p_this_str == '.' || *p_that_str == '.') {
 			if (*p_this_str++ != '.') {
@@ -800,6 +800,15 @@ static _FORCE_INLINE_ signed char naturalcasecmp_to_base(const char32_t *p_this_
 		while (*p_this_str) {
 			if (!*p_that_str) {
 				return 1;
+			} else if (p_file && (*p_this_str == '.' || *p_that_str == '.')) {
+				if (*p_this_str != '.') {
+					return 1;
+				}
+				if (*p_that_str != '.') {
+					return -1;
+				}
+				p_this_str++;
+				p_that_str++;
 			} else if (is_digit(*p_this_str)) {
 				if (!is_digit(*p_that_str)) {
 					return -1;
@@ -834,10 +843,10 @@ signed char String::naturalcasecmp_to(const String &p_str) const {
 	const char32_t *this_str = get_data();
 	const char32_t *that_str = p_str.get_data();
 
-	return naturalcasecmp_to_base(this_str, that_str);
+	return naturalcasecmp_to_base(this_str, that_str, false);
 }
 
-static _FORCE_INLINE_ signed char naturalnocasecmp_to_base(const char32_t *p_this_str, const char32_t *p_that_str) {
+static _FORCE_INLINE_ signed char naturalnocasecmp_to_base(const char32_t *p_this_str, const char32_t *p_that_str, bool p_file) {
 	if (p_this_str && p_that_str) {
 		while (*p_this_str == '.' || *p_that_str == '.') {
 			if (*p_this_str++ != '.') {
@@ -857,6 +866,15 @@ static _FORCE_INLINE_ signed char naturalnocasecmp_to_base(const char32_t *p_thi
 		while (*p_this_str) {
 			if (!*p_that_str) {
 				return 1;
+			} else if (p_file && (*p_this_str == '.' || *p_that_str == '.')) {
+				if (*p_this_str != '.') {
+					return 1;
+				}
+				if (*p_that_str != '.') {
+					return -1;
+				}
+				p_this_str++;
+				p_that_str++;
 			} else if (is_digit(*p_this_str)) {
 				if (!is_digit(*p_that_str)) {
 					return -1;
@@ -891,7 +909,7 @@ signed char String::naturalnocasecmp_to(const String &p_str) const {
 	const char32_t *this_str = get_data();
 	const char32_t *that_str = p_str.get_data();
 
-	return naturalnocasecmp_to_base(this_str, that_str);
+	return naturalnocasecmp_to_base(this_str, that_str, false);
 }
 
 static _FORCE_INLINE_ signed char file_cmp_common(const char32_t *&r_this_str, const char32_t *&r_that_str) {
@@ -919,7 +937,7 @@ signed char String::filecasecmp_to(const String &p_str) const {
 		return ret;
 	}
 
-	return naturalcasecmp_to_base(this_str, that_str);
+	return naturalcasecmp_to_base(this_str, that_str, true);
 }
 
 signed char String::filenocasecmp_to(const String &p_str) const {
@@ -931,7 +949,7 @@ signed char String::filenocasecmp_to(const String &p_str) const {
 		return ret;
 	}
 
-	return naturalnocasecmp_to_base(this_str, that_str);
+	return naturalnocasecmp_to_base(this_str, that_str, true);
 }
 
 const char32_t *String::get_data() const {


### PR DESCRIPTION
Same as #99245, but applied only to file names.

Fixes #99235