### PR TITLE
[GUI] Fix reparenting control does not update recursive mode cache properly

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1880,16 +1880,20 @@ void Control::set_mouse_recursive_behavior(RecursiveBehavior p_recursive_mouse_b
 	if (data.mouse_recursive_behavior == p_recursive_mouse_behavior) {
 		return;
 	}
+	_set_mouse_recursive_behavior_ignore_cache(p_recursive_mouse_behavior);
+}
+
+void Control::_set_mouse_recursive_behavior_ignore_cache(RecursiveBehavior p_recursive_mouse_behavior) {
 	data.mouse_recursive_behavior = p_recursive_mouse_behavior;
 	if (p_recursive_mouse_behavior == RECURSIVE_BEHAVIOR_INHERITED) {
 		Control *parent = get_parent_control();
 		if (parent) {
-			_apply_mouse_behavior_recursively(parent->data.parent_mouse_recursive_behavior, false);
+			_propagate_mouse_behavior_recursively(parent->data.parent_mouse_recursive_behavior, false);
 		} else {
-			_apply_mouse_behavior_recursively(RECURSIVE_BEHAVIOR_ENABLED, false);
+			_propagate_mouse_behavior_recursively(RECURSIVE_BEHAVIOR_ENABLED, false);
 		}
 	} else {
-		_apply_mouse_behavior_recursively(p_recursive_mouse_behavior, false);
+		_propagate_mouse_behavior_recursively(p_recursive_mouse_behavior, false);
 	}
 
 	if (get_viewport()) {
@@ -2064,16 +2068,20 @@ void Control::set_focus_recursive_behavior(RecursiveBehavior p_recursive_focus_b
 	if (data.focus_recursive_behavior == p_recursive_focus_behavior) {
 		return;
 	}
+	_set_focus_recursive_behavior_ignore_cache(p_recursive_focus_behavior);
+}
+
+void Control::_set_focus_recursive_behavior_ignore_cache(RecursiveBehavior p_recursive_focus_behavior) {
 	data.focus_recursive_behavior = p_recursive_focus_behavior;
 	if (p_recursive_focus_behavior == RECURSIVE_BEHAVIOR_INHERITED) {
 		Control *parent = get_parent_control();
 		if (parent) {
-			_apply_focus_behavior_recursively(parent->data.parent_focus_recursive_behavior, false);
+			_propagate_focus_behavior_recursively(parent->data.parent_focus_recursive_behavior, false);
 		} else {
-			_apply_focus_behavior_recursively(RECURSIVE_BEHAVIOR_ENABLED, false);
+			_propagate_focus_behavior_recursively(RECURSIVE_BEHAVIOR_ENABLED, false);
 		}
 	} else {
-		_apply_focus_behavior_recursively(p_recursive_focus_behavior, false);
+		_propagate_focus_behavior_recursively(p_recursive_focus_behavior, false);
 	}
 }
 
@@ -2449,7 +2457,7 @@ bool Control::_is_focus_disabled_recursively() const {
 	return false;
 }
 
-void Control::_apply_focus_behavior_recursively(RecursiveBehavior p_focus_recursive_behavior, bool p_skip_non_inherited) {
+void Control::_propagate_focus_behavior_recursively(RecursiveBehavior p_focus_recursive_behavior, bool p_skip_non_inherited) {
 	if (is_inside_tree() && (data.focus_recursive_behavior == RECURSIVE_BEHAVIOR_DISABLED || (data.focus_recursive_behavior == RECURSIVE_BEHAVIOR_INHERITED && p_focus_recursive_behavior == RECURSIVE_BEHAVIOR_DISABLED)) && has_focus()) {
 		release_focus();
 	}
@@ -2463,7 +2471,7 @@ void Control::_apply_focus_behavior_recursively(RecursiveBehavior p_focus_recurs
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *control = Object::cast_to<Control>(get_child(i));
 		if (control) {
-			control->_apply_focus_behavior_recursively(p_focus_recursive_behavior, true);
+			control->_propagate_focus_behavior_recursively(p_focus_recursive_behavior, true);
 		}
 	}
 }
@@ -2480,7 +2488,7 @@ bool Control::_is_parent_mouse_disabled() const {
 	return false;
 }
 
-void Control::_apply_mouse_behavior_recursively(RecursiveBehavior p_mouse_recursive_behavior, bool p_skip_non_inherited) {
+void Control::_propagate_mouse_behavior_recursively(RecursiveBehavior p_mouse_recursive_behavior, bool p_skip_non_inherited) {
 	if (p_skip_non_inherited && data.mouse_recursive_behavior != RECURSIVE_BEHAVIOR_INHERITED) {
 		return;
 	}
@@ -2490,7 +2498,7 @@ void Control::_apply_mouse_behavior_recursively(RecursiveBehavior p_mouse_recurs
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *control = Object::cast_to<Control>(get_child(i));
 		if (control) {
-			control->_apply_mouse_behavior_recursively(p_mouse_recursive_behavior, true);
+			control->_propagate_mouse_behavior_recursively(p_mouse_recursive_behavior, true);
 		}
 	}
 }
@@ -3450,8 +3458,8 @@ void Control::_notification(int p_notification) {
 
 			_update_layout_mode();
 
-			set_focus_recursive_behavior(data.focus_recursive_behavior);
-			set_mouse_recursive_behavior(data.mouse_recursive_behavior);
+			_set_focus_recursive_behavior_ignore_cache(data.focus_recursive_behavior);
+			_set_mouse_recursive_behavior_ignore_cache(data.mouse_recursive_behavior);
 		} break;
 
 		case NOTIFICATION_UNPARENTED: {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -330,8 +330,10 @@ private:
 	void _window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, const Rect2 &p_rect, const Rect2 &p_clamp, real_t p_min, real_t &r_closest_dist_squared, Control **r_closest);
 	Control *_get_focus_neighbor(Side p_side, int p_count = 0);
 	bool _is_focus_disabled_recursively() const;
-	void _apply_focus_behavior_recursively(RecursiveBehavior p_focus_recursive_behavior, bool p_force);
-	void _apply_mouse_behavior_recursively(RecursiveBehavior p_focus_recursive_behavior, bool p_force);
+	void _propagate_focus_behavior_recursively(RecursiveBehavior p_focus_recursive_behavior, bool p_force);
+	void _propagate_mouse_behavior_recursively(RecursiveBehavior p_focus_recursive_behavior, bool p_force);
+	void _set_mouse_recursive_behavior_ignore_cache(RecursiveBehavior p_recursive_mouse_behavior);
+	void _set_focus_recursive_behavior_ignore_cache(RecursiveBehavior p_recursive_mouse_behavior);
 
 	// Theming.
 


### PR DESCRIPTION
Fixes #104443

#97495 didn't correctly handle the internal cache update on reparenting (for example, if the control has its recursive mode set to `Disabled` and the cache is `Disabled,` it won't update the property at all).

This PR also renames the `_apply_xxx_behavior_recursively` to `_propagate_xxx_behavior_recursively` to better clarity.