### PR TITLE
Optimize startup times by avoiding loading fonts twice.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1419,25 +1419,17 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_f
 			fargs.flags = FT_OPEN_MEMORY;
 			fargs.stream = &fd->stream;
 
-			int max_index = 0;
-			FT_Face tmp_face = nullptr;
-			error = FT_Open_Face(ft_library, &fargs, -1, &tmp_face);
-			if (tmp_face && error == 0) {
-				max_index = tmp_face->num_faces - 1;
-			}
-			if (tmp_face) {
-				FT_Done_Face(tmp_face);
-			}
-
-			error = FT_Open_Face(ft_library, &fargs, CLAMP(p_font_data->face_index, 0, max_index), &fd->face);
+			error = FT_Open_Face(ft_library, &fargs, p_font_data->face_index, &fd->face);
 			if (error) {
-				FT_Done_Face(fd->face);
-				fd->face = nullptr;
+				if (fd->face) {
+					FT_Done_Face(fd->face);
+					fd->face = nullptr;
+				}
 				memdelete(fd);
 				if (p_silent) {
 					return false;
 				} else {
-					ERR_FAIL_V_MSG(false, "FreeType: Error loading font: '" + String(FT_Error_String(error)) + "'.");
+					ERR_FAIL_V_MSG(false, "FreeType: Error loading font: '" + String(FT_Error_String(error)) + "' (face_index=" + String::num_int64(p_font_data->face_index) + ").");
 				}
 			}
 		}


### PR DESCRIPTION
This change decreases editor startup time by ~0.44s (10%).

I believe this fixes a regression introduced by #61772 (so technically a `4.0` regression).

It should be possible to cherry-pick this change to earlier versions, but it's technically a behavior change (fonts that were previously loaded may error now, if an invalid font face index was provided). I'll let folks be the judge if that's worth it.

I tested loading fonts with an invalid font face index. It returns early from the function and prints an error, as expected.

## Explanation
When prompted to load a font, `TextServerAdv` first finds the number of available faces in the font by passing `-1` into `FT_Open_Face`. This feature is [documented](https://freetype.org/freetype2/docs/reference/ft2-face_creation.html#ft_open_face) in the function's description. Unfortunately, the function description does not mention that the function still fully loads the font. In effect, this means we've been loading fonts twice as often as needed. 

## Benchmark
I profiled a ~0.44s decrease in editor startup time:
```
 ❯ hyperfine -m25 -iw1 "bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit" "bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit"
Benchmark 1: bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      4.738 s ±  0.146 s    [User: 3.250 s, System: 0.400 s]
  Range (min … max):    4.357 s …  4.925 s    25 runs

Benchmark 2: bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      4.297 s ±  0.093 s    [User: 2.827 s, System: 0.394 s]
  Range (min … max):    4.133 s …  4.386 s    25 runs
```

## Addendum
Font loading is still a large contributor to editor startup time (6%). It may be possible to further decrease the amount of times fonts are loaded. But this would require a more invasive change.