### PR TITLE
Fix excessively calling resized and floating point errors in Control.

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1727,8 +1727,11 @@ void Control::_size_changed() {
 		new_size_cache.height = minimum_size.height;
 	}
 
-	bool pos_changed = !new_pos_cache.is_equal_approx(data.pos_cache);
-	bool size_changed = !new_size_cache.is_equal_approx(data.size_cache);
+	bool pos_changed = new_pos_cache != data.pos_cache;
+	bool size_changed = new_size_cache != data.size_cache;
+	// Below helps in getting rid of floating point errors for signaling resized.
+	bool approx_pos_changed = !new_pos_cache.is_equal_approx(data.pos_cache);
+	bool approx_size_changed = !new_size_cache.is_equal_approx(data.size_cache);
 
 	if (pos_changed) {
 		data.pos_cache = new_pos_cache;
@@ -1738,13 +1741,13 @@ void Control::_size_changed() {
 	}
 
 	if (is_inside_tree()) {
-		if (pos_changed || size_changed) {
+		if (approx_pos_changed || approx_size_changed) {
 			// Ensure global transform is marked as dirty before `NOTIFICATION_RESIZED` / `item_rect_changed` signal
 			// so an up to date global transform could be obtained when handling these.
 			_notify_transform();
 
-			item_rect_changed(size_changed);
-			if (size_changed) {
+			item_rect_changed(approx_size_changed);
+			if (approx_size_changed) {
 				notification(NOTIFICATION_RESIZED);
 			}
 		}


### PR DESCRIPTION
This introduces two new booleans approx_pos_changed and approx_size_changed which are the pos_changed and size_changed booleans that are immune to floating point errors.

This aims to fix two bugs in one shot. #93832 and #48935.


This is a re-make of #104173 , as I had ruined the commit history due to my lack of experience with git and github in general. Apologies.

All in all, the fix is the same. This builds upon the hack that is used to do `set_size()`. Again, this splits the logic in such a way that the `resized` is called only if the approx position is changed, but the position and size is changed regardless of any approximations. This is a bodge on a bodge. Ideally `set_size()` should be tweaked to fix this error. 

Here's how they work in action. I wrote a script with the following GDScript
```
extends Control

func _ready() -> void:
	size = Vector2(120, 40.0003)
	print("start => ", size)
	size.y = 40
	print("40 => ", size)
	size = Vector2(120, 40)
	print("(120, 40) => ", size)
	size = Vector2(121, 40)
	print("(121, 40) => ", size)

func print_new():
	print("Uh Oh! I was resized!!!")
```
I put this on a random control in the scene tree and set up a graph node as below. 
![image](https://github.com/user-attachments/assets/3004d662-217b-49f8-99d0-0bb992c0cc5a)

I connected the `resize` signal to `print_new()`
You can see that it passes #100112 as the output is as expected, and the size is set properly.  (See final image)

In 4.4 (stable), this bug exists.
![image](https://github.com/user-attachments/assets/62d6b288-f0d2-46eb-a301-53cf6b225b7e)

---

Upon scrolling (I did not take a video due to my computer being too weak to take videos), and zooming in and out, even up to extreme limits, the `print_new()` was never called. 
![image](https://github.com/user-attachments/assets/eacdd29a-18ec-4a5c-b521-da07426a1c21)

*Bugsquad edit:* Fixes https://github.com/godotengine/godot/issues/100112