### PR TITLE
Introduce `Either` type

### DIFF
--- a/core/string/string_builder.h
+++ b/core/string/string_builder.h
@@ -31,17 +31,14 @@
 #pragma once
 
 #include "core/string/ustring.h"
+#include "core/templates/either.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/span.h"
 
 class StringBuilder {
 	uint32_t string_length = 0;
 
-	LocalVector<String> strings;
-	LocalVector<const char *> c_strings;
-
-	// -1 means it's a Godot String
-	// a natural number means C string.
-	LocalVector<int32_t> appended_strings;
+	LocalVector<Either<String, Span<char>>> strings;
 
 public:
 	StringBuilder &append(const String &p_string);
@@ -64,7 +61,7 @@ public:
 	}
 
 	_FORCE_INLINE_ int num_strings_appended() const {
-		return appended_strings.size();
+		return strings.size();
 	}
 
 	_FORCE_INLINE_ uint32_t get_string_length() const {

--- a/core/templates/either.h
+++ b/core/templates/either.h
@@ -1,0 +1,144 @@
+/**************************************************************************/
+/*  either.h                                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/error/error_macros.h"
+#include "core/os/memory.h"
+#include "core/typedefs.h"
+
+template <typename T1, typename T2>
+class Either {
+private:
+	typename std::aligned_storage<
+			(sizeof(T1) > sizeof(T2) ? sizeof(T1) : sizeof(T2)),
+			(alignof(T1) > alignof(T2) ? alignof(T1) : alignof(T2))>::type storage;
+	bool is_first;
+
+	void destroy() {
+		if (is_first) {
+			reinterpret_cast<T1 *>(&storage)->~T1();
+		} else {
+			reinterpret_cast<T2 *>(&storage)->~T2();
+		}
+	}
+
+public:
+	Either(const T1 &value) :
+			is_first(true) { memnew_placement(&storage, T1(value)); }
+	Either(const T2 &value) :
+			is_first(false) { memnew_placement(&storage, T2(value)); }
+
+	Either(T1 &&value) :
+			is_first(true) { memnew_placement(&storage, T1(std::move(value))); }
+	Either(T2 &&value) :
+			is_first(false) { memnew_placement(&storage, T2(std::move(value))); }
+
+	~Either() { destroy(); }
+
+	Either(const Either &other) :
+			is_first(other.is_first) {
+		if (is_first) {
+			memnew_placement(&storage, T1(*reinterpret_cast<const T1 *>(&other.storage)));
+		} else {
+			memnew_placement(&storage, T2(*reinterpret_cast<const T2 *>(&other.storage)));
+		}
+	}
+
+	Either &operator=(const Either &other) {
+		if (this != &other) {
+			destroy();
+			is_first = other.is_first;
+			if (is_first) {
+				memnew_placement(&storage, T1(*reinterpret_cast<const T1 *>(&other.storage)));
+			} else {
+				memnew_placement(&storage, T2(*reinterpret_cast<const T2 *>(&other.storage)));
+			}
+		}
+		return *this;
+	}
+
+	Either(Either &&other) :
+			is_first(other.is_first) {
+		if (is_first) {
+			memnew_placement(&storage, T1(std::move(*reinterpret_cast<T1 *>(&other.storage))));
+		} else {
+			memnew_placement(&storage, T2(std::move(*reinterpret_cast<T2 *>(&other.storage))));
+		}
+	}
+
+	Either &operator=(Either &&other) {
+		if (this != &other) {
+			destroy();
+			is_first = other.is_first;
+			if (is_first) {
+				memnew_placement(&storage, T1(std::move(*reinterpret_cast<T1 *>(&other.storage))));
+			} else {
+				memnew_placement(&storage, T2(std::move(*reinterpret_cast<T2 *>(&other.storage))));
+			}
+		}
+		return *this;
+	}
+
+	template <typename T>
+	bool is() const {
+		if constexpr (std::is_same_v<T, T1>) {
+			return is_first;
+		} else if constexpr (std::is_same_v<T, T2>) {
+			return !is_first;
+		}
+	}
+
+	template <typename T>
+	T &get() {
+		CRASH_COND(!is<T>());
+		return *reinterpret_cast<T *>(&storage);
+	}
+
+	template <typename T>
+	const T &get() const {
+		CRASH_COND(!is<T>());
+		return *reinterpret_cast<const T *>(&storage);
+	}
+
+	template <typename T>
+	T &get_unchecked() {
+		return *reinterpret_cast<T *>(&storage);
+	}
+
+	template <typename T>
+	const T &get_unchecked() const {
+		return *reinterpret_cast<const T *>(&storage);
+	}
+};
+
+// Either is zero-constructible if and only if both constrained types are zero-constructible.
+template <typename T1, typename T2>
+struct is_zero_constructible<Either<T1, T2>> : std::conjunction<is_zero_constructible<T1>, is_zero_constructible<T2>> {};

--- a/tests/core/templates/test_either.h
+++ b/tests/core/templates/test_either.h
@@ -1,0 +1,49 @@
+/**************************************************************************/
+/*  test_either.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/templates/either.h"
+
+#include "tests/test_macros.h"
+
+namespace TestEither {
+
+TEST_CASE("[Span] Constexpr Validators") {
+	Either<int, float> either = 5;
+	CHECK(either.is<int>());
+	CHECK(either.get<int>() == 5);
+
+	either = 10.0f;
+	CHECK(either.is<float>());
+	CHECK(either.get<float>() == 10.0f);
+}
+
+} // namespace TestEither

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -95,6 +95,7 @@
 #include "tests/core/string/test_translation_server.h"
 #include "tests/core/templates/test_a_hash_map.h"
 #include "tests/core/templates/test_command_queue.h"
+#include "tests/core/templates/test_either.h"
 #include "tests/core/templates/test_hash_map.h"
 #include "tests/core/templates/test_hash_set.h"
 #include "tests/core/templates/test_list.h"


### PR DESCRIPTION
Technically, this is a feature proposal, but I felt it was difficult to explain without code, so I submitted it as a PR.

`Either` is a type-safe union type that can conveniently represent two mutually exclusive states. It's usually used as two more common patterns: `Optional<T>` and `Result<T, Error>`.

One issue with C unions is that if a member contains a class with a destructor, the compiler cannot determine which destructor to call when the union is destructed. `Either` solves this problem by using an additional tag. (usually known as *tagged union*)

`Either` can be extended to support three or more types, but this may involve complex template techniques or code duplication.

The second commit showcases one possible use case for `Either`, where both `String` and C Strings can be stored in one `LocalVector`.

This is just an initial idea. Will continue to look for more use cases where `Either` could be useful.
