### PR TITLE
Optimize startup times by using `ubrk_clone` instead of `ubrk_open`.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -5664,7 +5664,8 @@ bool TextServerAdvanced::_shaped_text_update_breaks(const RID &p_shaped) {
 				i++;
 			}
 			int r_end = sd->spans[i].end;
-			UBreakIterator *bi = sd->_get_break_iterator_for_locale(language, &err);
+			UBreakIterator *bi = _create_line_break_iterator_for_locale(language, &err);
+
 			if (!U_FAILURE(err) && bi) {
 				ubrk_setText(bi, data + _convert_pos_inv(sd, r_start), _convert_pos_inv(sd, r_end - r_start), &err);
 			}
@@ -5697,6 +5698,7 @@ bool TextServerAdvanced::_shaped_text_update_breaks(const RID &p_shaped) {
 						sd->break_inserts++;
 					}
 				}
+				ubrk_close(bi);
 			}
 			i++;
 		}
@@ -6145,13 +6147,22 @@ _FORCE_INLINE_ void TextServerAdvanced::_add_featuers(const Dictionary &p_source
 	}
 }
 
-UBreakIterator *TextServerAdvanced::ShapedTextDataAdvanced::_get_break_iterator_for_locale(const String &p_language, UErrorCode *r_err) {
-	HashMap<String, UBreakIterator *>::Iterator key_value = line_break_iterators_per_language.find(p_language);
+UBreakIterator *TextServerAdvanced::_create_line_break_iterator_for_locale(const String &p_language, UErrorCode *r_err) const {
+	// Creating UBreakIterator (ubrk_open) is surprisingly costly.
+	// However, cloning (ubrk_clone) is cheaper, so we keep around blueprints to accelerate creating new ones.
+
+	const String language = p_language.is_empty() ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
+	_THREAD_SAFE_METHOD_
+	const HashMap<String, UBreakIterator *>::Iterator key_value = line_break_iterators_per_language.find(language);
 	if (key_value) {
-		return key_value->value;
+		return ubrk_clone(key_value->value, r_err);
 	}
-	UBreakIterator *brk = ubrk_open(UBRK_LINE, p_language.is_empty() ? TranslationServer::get_singleton()->get_tool_locale().ascii().get_data() : p_language.ascii().get_data(), nullptr, 0, r_err);
-	return line_break_iterators_per_language.insert(p_language, brk)->value;
+	UBreakIterator *bi = ubrk_open(UBRK_LINE, language.ascii().get_data(), nullptr, 0, r_err);
+	if (U_FAILURE(*r_err) || !bi) {
+		return nullptr;
+	}
+	line_break_iterators_per_language.insert(language, bi);
+	return ubrk_clone(bi, r_err);
 }
 
 void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_end, hb_script_t p_script, hb_direction_t p_direction, TypedArray<RID> p_fonts, int64_t p_span, int64_t p_fb_index, int64_t p_prev_start, int64_t p_prev_end, RID p_prev_font) {
@@ -7728,6 +7739,9 @@ TextServerAdvanced::~TextServerAdvanced() {
 	if (allowed != nullptr) {
 		uset_close(allowed);
 		allowed = nullptr;
+	}
+	for (const KeyValue<String, UBreakIterator *> &bi : line_break_iterators_per_language) {
+		ubrk_close(bi.value);
 	}
 
 	std::atexit(u_cleanup);

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -176,6 +176,10 @@ class TextServerAdvanced : public TextServerExtension {
 	mutable USpoofChecker *sc_spoof = nullptr;
 	mutable USpoofChecker *sc_conf = nullptr;
 
+	mutable HashMap<String, UBreakIterator *> line_break_iterators_per_language;
+
+	UBreakIterator *_create_line_break_iterator_for_locale(const String &p_language, UErrorCode *r_err) const;
+
 	// Font cache data.
 
 #ifdef MODULE_FREETYPE_ENABLED
@@ -545,11 +549,6 @@ class TextServerAdvanced : public TextServerExtension {
 		bool js_ops_valid = false;
 		bool chars_valid = false;
 
-		HashMap<String, UBreakIterator *> line_break_iterators_per_language;
-
-		// Creating UBreakIterator is surprisingly costly. To improve efficiency, we cache them.
-		UBreakIterator *_get_break_iterator_for_locale(const String &p_language, UErrorCode *r_err);
-
 		~ShapedTextDataAdvanced() {
 			for (int i = 0; i < bidi_iter.size(); i++) {
 				if (bidi_iter[i]) {
@@ -561,9 +560,6 @@ class TextServerAdvanced : public TextServerExtension {
 			}
 			if (hb_buffer) {
 				hb_buffer_destroy(hb_buffer);
-			}
-			for (const KeyValue<String, UBreakIterator *> &bi : line_break_iterators_per_language) {
-				ubrk_close(bi.value);
 			}
 		}
 	};


### PR DESCRIPTION
This decreases editor startup time by ~0.35s (8%).

It should be possible to safely cherry-pick this back to 4.4.

## Explanation 

I have previously profiled that `ubrk_open` was causing substantial delays in editor startup times (#102129).
I've dug a bit deeper into the code, and found that cloning `UBreakIterator` instances instead of creating them from scratch doesn't parse the locale (rules?) again (which was the slow part). So, in the interest of speed, I've implemented a method to cache a blueprint `UBreakIterator` for each locale, and only clone it when we need a new one. 

This is not only faster than #102129, but also better in terms of RAM use — because not every `FontAdvanced` instance needs their own `UBreakIterator` caches. Instead, we only have one for each locale globally.

## Benchmarks
I benchmarked a ~0.35s (8%) decrease in editor startup time:

```
 ❯ hyperfine -m25 -iw1 "bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit" "bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit"
Benchmark 1: bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      4.781 s ±  0.120 s    [User: 3.266 s, System: 0.406 s]
  Range (min … max):    4.469 s …  4.974 s    25 runs

Benchmark 2: bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      4.435 s ±  0.095 s    [User: 3.011 s, System: 0.387 s]
  Range (min … max):    4.250 s …  4.557 s    25 runs

Summary
  bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit ran
    1.08 ± 0.04 times faster than bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit
```
