### PR TITLE
Improve current_scene assignment.

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1499,7 +1499,7 @@ Node *SceneTree::get_edited_scene_root() const {
 
 void SceneTree::set_current_scene(Node *p_scene) {
 	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "Changing scene can only be done from the main thread.");
-	ERR_FAIL_COND(p_scene && p_scene->get_parent() != root);
+	ERR_FAIL_COND_MSG(p_scene && !root->is_ancestor_of(p_scene), "Scene must be a descendent of the scene tree's root.");
 	current_scene = p_scene;
 }
 


### PR DESCRIPTION
Currently, documentation implies that the `current_scene` may not be a direct child of the root. This allows that to be the case, while also improving the error messaging.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
