### PR TITLE
Editor: Replace TextEdit with EditorSpinSlider for XR Action Set Priority

### DIFF
--- a/modules/openxr/editor/openxr_action_set_editor.cpp
+++ b/modules/openxr/editor/openxr_action_set_editor.cpp
@@ -31,8 +31,14 @@
 #include "openxr_action_set_editor.h"
 
 #include "editor/editor_string_names.h"
+#include "editor/gui/editor_spin_slider.h"
 #include "editor/themes/editor_scale.h"
 #include "openxr_action_editor.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/panel_container.h"
+#include "scene/gui/text_edit.h"
 
 void OpenXRActionSetEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_do_set_name", "name"), &OpenXRActionSetEditor::_do_set_name);
@@ -127,8 +133,8 @@ void OpenXRActionSetEditor::_do_set_localized_name(const String p_new_text) {
 	action_set_localized_name->set_text(p_new_text);
 }
 
-void OpenXRActionSetEditor::_on_action_set_priority_changed(const String p_new_text) {
-	int64_t value = p_new_text.to_int();
+void OpenXRActionSetEditor::_on_action_set_priority_changed(const double p_new_value) {
+	int64_t value = (int64_t)p_new_value;
 
 	if (action_set->get_priority() != value) {
 		undo_redo->create_action(TTR("Change Action Sets priority"));
@@ -143,7 +149,7 @@ void OpenXRActionSetEditor::_on_action_set_priority_changed(const String p_new_t
 
 void OpenXRActionSetEditor::_do_set_priority(int64_t p_value) {
 	action_set->set_priority(p_value);
-	action_set_priority->set_text(itos(p_value));
+	action_set_priority->set_value_no_signal(p_value);
 }
 
 void OpenXRActionSetEditor::_on_add_action() {
@@ -260,11 +266,14 @@ OpenXRActionSetEditor::OpenXRActionSetEditor(Ref<OpenXRActionMap> p_action_map, 
 	action_set_localized_name->set_accessibility_name(TTRC("Action Set Localized Name"));
 	action_set_hb->add_child(action_set_localized_name);
 
-	action_set_priority = memnew(TextEdit);
-	action_set_priority->set_text(itos(action_set->get_priority()));
+	action_set_priority = memnew(EditorSpinSlider);
 	action_set_priority->set_tooltip_text(TTR("Priority of the action set. If multiple action sets bind to the same input, the action set with the highest priority will be updated."));
-	action_set_priority->set_custom_minimum_size(Size2(50.0 * EDSCALE, 0.0));
-	action_set_priority->connect(SceneStringName(text_changed), callable_mp(this, &OpenXRActionSetEditor::_on_action_set_priority_changed));
+	action_set_priority->set_editing_integer(true);
+	action_set_priority->set_min(2147483647.0);
+	action_set_priority->set_min(-2147483648.0);
+	action_set_priority->set_value_no_signal(action_set->get_priority());
+	action_set_priority->set_custom_minimum_size(Size2(75.0 * EDSCALE, 0.0));
+	action_set_priority->connect(SceneStringName(value_changed), callable_mp(this, &OpenXRActionSetEditor::_on_action_set_priority_changed));
 	action_set_priority->set_accessibility_name(TTRC("Action Set Priority"));
 	action_set_hb->add_child(action_set_priority);
 

--- a/modules/openxr/editor/openxr_action_set_editor.h
+++ b/modules/openxr/editor/openxr_action_set_editor.h
@@ -34,11 +34,12 @@
 #include "../action_map/openxr_action_set.h"
 #include "openxr_action_editor.h"
 
-#include "scene/gui/box_container.h"
-#include "scene/gui/button.h"
-#include "scene/gui/line_edit.h"
-#include "scene/gui/panel_container.h"
-#include "scene/gui/text_edit.h"
+class EditorSpinSlider;
+class BoxContainer;
+class Button;
+class LineEdit;
+class PanelContainer;
+class TextEdit;
 
 class OpenXRActionSetEditor : public HBoxContainer {
 	GDCLASS(OpenXRActionSetEditor, HBoxContainer);
@@ -56,7 +57,7 @@ private:
 	HBoxContainer *action_set_hb = nullptr;
 	LineEdit *action_set_name = nullptr;
 	LineEdit *action_set_localized_name = nullptr;
-	TextEdit *action_set_priority = nullptr;
+	EditorSpinSlider *action_set_priority = nullptr;
 	Button *add_action = nullptr;
 	Button *rem_action_set = nullptr;
 	VBoxContainer *actions_vb = nullptr;
@@ -68,7 +69,7 @@ private:
 	void _on_toggle_expand();
 	void _on_action_set_name_changed(const String p_new_text);
 	void _on_action_set_localized_name_changed(const String p_new_text);
-	void _on_action_set_priority_changed(const String p_new_text);
+	void _on_action_set_priority_changed(const double p_new_value);
 	void _on_add_action();
 	void _on_remove_action_set();
 


### PR DESCRIPTION
In the editor UI for Action Sets, the priority of an Action Set is currently changed with a TextEdit node, this commit changes it to an EditorSpinSlider. This clarifies the internal structure of the Action Set by making it clear inside the editor that the priority is an integer.

In order to test this change, create a new project and go to Project Settings -> XR -> OpenXR -> Enabled, and enable XR. This should create a tab on the bottom bar labeled "OpenXR Action Map." This tab is where the change is visible, directly to the left of the `plus` button in the Godot action set.

Before the change:
<img width="1073" alt="Image of the TextEdit with the rest of the UI" src="https://github.com/user-attachments/assets/140e8dc6-822f-4c05-ae34-cc9295a56d63" />

After the change:
<img width="980" alt="Image of the EditorSpinSlider with the rest of the UI" src="https://github.com/user-attachments/assets/72154e84-ace6-4f50-a81e-ec951e0c4297" />
