### PR TITLE
`CheckButton` checked/unchecked icon can be on both sides

### DIFF
--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -20,6 +20,11 @@
 		<theme_item name="button_unchecked_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The color of the unchecked icon when the checkbox is not pressed.
 		</theme_item>
+		<theme_item name="check_position" data_type="constant" type="int" default="0">
+			If [code]0[/code] [theme_item checked]/[theme_item unchecked] will be drawn in the right for left-to-right layouts or in the left for right-to-left layouts.
+			If [code]1[/code] [theme_item checked]/[theme_item unchecked] will be drawn in the left regardless of the layout direction.
+			If [code]2[/code] [theme_item checked]/[theme_item unchecked] will be drawn in the right regardless of the layout direction.
+		</theme_item>
 		<theme_item name="check_v_offset" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the toggle icons (in pixels).
 		</theme_item>

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -83,6 +83,24 @@ Size2 CheckButton::get_minimum_size() const {
 	return minsize;
 }
 
+void CheckButton::_set_left_and_right_internal_margins() {
+	Side icon_side = SIDE_RIGHT;
+	switch (theme_cache.check_position) {
+		case CHECK_POSITION_AUTO:
+			icon_side = is_layout_rtl() ? SIDE_LEFT : SIDE_RIGHT;
+			break;
+		case CHECK_POSITION_LEFT:
+			icon_side = SIDE_LEFT;
+			break;
+		case CHECK_POSITION_RIGHT:
+			icon_side = SIDE_RIGHT;
+			break;
+	}
+	_set_internal_margin(icon_side, get_icon_size().width);
+	// Reset opposite side margin
+	_set_internal_margin(icon_side == SIDE_LEFT ? SIDE_RIGHT : SIDE_LEFT, 0.f);
+}
+
 void CheckButton::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ACCESSIBILITY_UPDATE: {
@@ -95,13 +113,7 @@ void CheckButton::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			if (is_layout_rtl()) {
-				_set_internal_margin(SIDE_LEFT, get_icon_size().width);
-				_set_internal_margin(SIDE_RIGHT, 0.f);
-			} else {
-				_set_internal_margin(SIDE_LEFT, 0.f);
-				_set_internal_margin(SIDE_RIGHT, get_icon_size().width);
-			}
+			_set_left_and_right_internal_margins();
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -132,7 +144,7 @@ void CheckButton::_notification(int p_what) {
 			Vector2 ofs;
 			Size2 tex_size = get_icon_size();
 
-			if (rtl) {
+			if ((theme_cache.check_position == CHECK_POSITION_AUTO && rtl) || theme_cache.check_position == CHECK_POSITION_LEFT) {
 				ofs.x = theme_cache.normal_style->get_margin(SIDE_LEFT);
 			} else {
 				ofs.x = get_size().width - (tex_size.width + theme_cache.normal_style->get_margin(SIDE_RIGHT));
@@ -151,6 +163,7 @@ void CheckButton::_notification(int p_what) {
 void CheckButton::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, CheckButton, h_separation);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, CheckButton, check_v_offset);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, CheckButton, check_position);
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, CheckButton, normal_style, "normal");
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckButton, checked);
@@ -172,11 +185,19 @@ CheckButton::CheckButton(const String &p_text) :
 
 	set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 
-	if (is_layout_rtl()) {
-		_set_internal_margin(SIDE_LEFT, get_icon_size().width);
-	} else {
-		_set_internal_margin(SIDE_RIGHT, get_icon_size().width);
+	Side icon_side = SIDE_RIGHT;
+	switch (theme_cache.check_position) {
+		case CHECK_POSITION_AUTO:
+			icon_side = is_layout_rtl() ? SIDE_LEFT : SIDE_RIGHT;
+			break;
+		case CHECK_POSITION_LEFT:
+			icon_side = SIDE_LEFT;
+			break;
+		case CHECK_POSITION_RIGHT:
+			icon_side = SIDE_RIGHT;
+			break;
 	}
+	_set_internal_margin(icon_side, get_icon_size().width);
 }
 
 CheckButton::~CheckButton() {

--- a/scene/gui/check_button.h
+++ b/scene/gui/check_button.h
@@ -35,9 +35,16 @@
 class CheckButton : public Button {
 	GDCLASS(CheckButton, Button);
 
+	enum CheckPosition {
+		CHECK_POSITION_AUTO,
+		CHECK_POSITION_LEFT,
+		CHECK_POSITION_RIGHT
+	};
+
 	struct ThemeCache {
 		int h_separation = 0;
 		int check_v_offset = 0;
+		CheckPosition check_position = CHECK_POSITION_AUTO;
 		Ref<StyleBox> normal_style;
 
 		Ref<Texture2D> checked;
@@ -52,6 +59,8 @@ class CheckButton : public Button {
 		Color button_checked_color;
 		Color button_unchecked_color;
 	} theme_cache;
+
+	void _set_left_and_right_internal_margins();
 
 protected:
 	Size2 get_icon_size() const;


### PR DESCRIPTION
![CheckButtonLTR](https://github.com/user-attachments/assets/354d8f01-c747-4821-99ef-6105ba5f5904)
![CheckButtonRTL](https://github.com/user-attachments/assets/a9b345e2-992b-4c5e-8b53-c53339f33b05)

The position of checked/unchecked icon can controlled with `check_position` theme item.
If `check_position` is `CHECK_POSITION_AUTO` checked/unchecked icon will be drawn in the right for left-to-right layouts or in the left for right-to-left layouts.
If `check_position` is `CHECK_POSITION_LEFT` checked/unchecked icon will be drawn in the left regardless of the layout direction.
If `check_position` is `CHECK_POSITION_RIGHT` checked/unchecked icon will be drawn in the right regardless of the layout direction.

Naming is hard, so I'm open to name changes.

Inspiration: https://youtu.be/cJ5Rkk5fnGg?list=PLeG_dAglpVo6TS0q858NajyeglRuvb7hs&t=923

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
