### PR TITLE
Add optional UID comments for GDScript

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -129,6 +129,10 @@ bool ResourceFormatLoader::has_custom_uid_support() const {
 	return GDVIRTUAL_IS_OVERRIDDEN(_get_resource_uid);
 }
 
+bool ResourceFormatLoader::should_create_uid_file(const String &p_path) const {
+	return !has_custom_uid_support();
+}
+
 void ResourceFormatLoader::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
 	if (p_type.is_empty() || handles_type(p_type)) {
 		get_recognized_extensions(p_extensions);
@@ -1224,7 +1228,7 @@ bool ResourceLoader::should_create_uid_file(const String &p_path) {
 
 	for (int i = 0; i < loader_count; i++) {
 		if (loader[i]->recognize_path(local_path)) {
-			return !loader[i]->has_custom_uid_support();
+			return loader[i]->should_create_uid_file(p_path);
 		}
 	}
 	return false;

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -84,6 +84,7 @@ public:
 	virtual String get_resource_script_class(const String &p_path) const;
 	virtual ResourceUID::ID get_resource_uid(const String &p_path) const;
 	virtual bool has_custom_uid_support() const;
+	virtual bool should_create_uid_file(const String &p_path) const;
 	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false);
 	virtual Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map);
 	virtual bool is_import_valid(const String &p_path) const { return true; }

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -648,6 +648,8 @@ public:
 };
 
 class ResourceFormatLoaderGDScript : public ResourceFormatLoader {
+	ResourceUID::ID _get_embedded_uid(const String &p_path) const;
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
@@ -655,6 +657,9 @@ public:
 	virtual String get_resource_type(const String &p_path) const override;
 	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes) override;
+	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
+	virtual bool has_custom_uid_support() const override;
+	virtual bool should_create_uid_file(const String &p_path) const override;
 };
 
 class ResourceFormatSaverGDScript : public ResourceFormatSaver {


### PR DESCRIPTION
Alternative to #99090
Inspired by the [UID feedback discussion](https://github.com/godotengine/godot-proposals/discussions/11574)

Allows one to optionally specify the UID of a GDScript file with a first line comment. This PR is a minimalist approach that intends to keep things simple in the engine while allowing users do the rest with editor plugins or such. I have coded such a plugin for myself to test this, and I'm quite happy with the approach.

The UID of a GDScript is determined in the following way if this PR is merged:

1. If a GDScript file has a corresponding UID file, then the UID file is used just like before. This keeps things smooth and backwards compatible for users who are happy with UID files.
2. If the first line of the GDScript file contains a valid UID comment of form `# uid://abcd`, then the UID in the comment is used and no UID file is generated.
3. Otherwise, a new UID file is generated and used just like before.