### PR TITLE
Enable composition layer fallback in panel mode

### DIFF
--- a/modules/openxr/scene/openxr_composition_layer.cpp
+++ b/modules/openxr/scene/openxr_composition_layer.cpp
@@ -192,7 +192,7 @@ void OpenXRCompositionLayer::_bind_methods() {
 }
 
 bool OpenXRCompositionLayer::_should_use_fallback_node() {
-	if (Engine::get_singleton()->is_editor_hint()) {
+	if (Engine::get_singleton()->is_editor_hint() || openxr_api == nullptr) {
 		return true;
 	} else if (openxr_session_running) {
 		return enable_hole_punch || (!is_natively_supported() && !use_android_surface);
@@ -399,7 +399,7 @@ bool OpenXRCompositionLayer::get_alpha_blend() const {
 }
 
 bool OpenXRCompositionLayer::is_natively_supported() const {
-	if (composition_layer_extension) {
+	if (composition_layer_extension && openxr_api) {
 		return composition_layer_extension->is_available(openxr_layer_provider->get_openxr_type());
 	}
 	return false;


### PR DESCRIPTION
Composition layer fallback is currently restricted to:
- In editor for visualization
- When hole punch is enabled as it's used to perform the hole punch
- When composition layer is not natively supported by an openxr runtime

This PR updates the logic to allow the use of composition layer fallback in regular 3D scenarios. This is useful for hybrid apps as it allows the use of composition layers for both the immersive and panel modes:
- In immersive mode, (when supported) the xr runtime composition layer is used
- In panel mode, the fallback mesh is used instead

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
