### PR TITLE
`ColorChannelSelector`: add tooltip, fix `toggle_button` repositioning and channels autotranslation

### DIFF
--- a/editor/plugins/color_channel_selector.cpp
+++ b/editor/plugins/color_channel_selector.cpp
@@ -41,7 +41,9 @@ ColorChannelSelector::ColorChannelSelector() {
 	toggle_button->set_flat(true);
 	toggle_button->set_toggle_mode(true);
 	toggle_button->connect(SceneStringName(toggled), callable_mp(this, &ColorChannelSelector::on_toggled));
-	toggle_button->add_theme_style_override("focus", memnew(StyleBoxEmpty));
+	toggle_button->set_tooltip_text(TTRC("Toggle color channel preview selection."));
+	toggle_button->set_v_size_flags(Control::SIZE_SHRINK_BEGIN);
+	toggle_button->set_theme_type_variation("PreviewLightButton");
 	add_child(toggle_button);
 
 	panel = memnew(PanelContainer);
@@ -71,11 +73,10 @@ void ColorChannelSelector::_notification(int p_what) {
 		ERR_FAIL_COND(bg_style.is_null());
 		bg_style = bg_style->duplicate();
 		// The default content margin makes the widget become a bit too large. It should be like mini-toolbar.
-		const float editor_scale = EditorScale::get_scale();
-		bg_style->set_content_margin(SIDE_LEFT, 1.0f * editor_scale);
-		bg_style->set_content_margin(SIDE_RIGHT, 1.0f * editor_scale);
-		bg_style->set_content_margin(SIDE_TOP, 1.0f * editor_scale);
-		bg_style->set_content_margin(SIDE_BOTTOM, 1.0f * editor_scale);
+		bg_style->set_content_margin(SIDE_LEFT, 1.0f * EDSCALE);
+		bg_style->set_content_margin(SIDE_RIGHT, 1.0f * EDSCALE);
+		bg_style->set_content_margin(SIDE_TOP, 1.0f * EDSCALE);
+		bg_style->set_content_margin(SIDE_BOTTOM, 1.0f * EDSCALE);
 		panel->add_theme_style_override(SceneStringName(panel), bg_style);
 
 		Ref<Texture2D> icon = get_editor_theme_icon(SNAME("TexturePreviewChannels"));
@@ -110,7 +111,7 @@ uint32_t ColorChannelSelector::get_selected_channels_mask() const {
 Vector4 ColorChannelSelector::get_selected_channel_factors() const {
 	Vector4 channel_factors;
 	const uint32_t mask = get_selected_channels_mask();
-	for (unsigned int i = 0; i < 4; ++i) {
+	for (unsigned int i = 0; i < CHANNEL_COUNT; ++i) {
 		if ((mask & (1 << i)) != 0) {
 			channel_factors[i] = 1;
 		}
@@ -123,6 +124,7 @@ void ColorChannelSelector::create_button(unsigned int p_channel_index, const Str
 	ERR_FAIL_COND(channel_buttons[p_channel_index] != nullptr);
 	Button *button = memnew(Button);
 	button->set_text(p_text);
+	button->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	button->set_toggle_mode(true);
 	button->set_pressed(true);
 


### PR DESCRIPTION
Changes: 
- Fixed issue with `toggle_button` changing its position, caused by the panel size.
- Added tooltip for `toggle_button` to clarify its purpose.
- Prevented accidental translation of color channel names in certain languages (e.g., Arabic).
- Updated `toggle_button` theming to use "PreviewLightButton" type variation, aligning it with similar buttons (like in `MaterialEditor`).
- Code cleanup: `EditorScale::get_scale()` replaced with more common `EDSCALE`, ~~removed `CHANNEL_COUNT` (it was inconsistentty used anyway), removed debug error checks from `create_button()` (redundant, the function is only called in constructor and with known arguments)~~ use `CHANNEL_COUNT` everywhere (see https://github.com/godotengine/godot/pull/104474#issuecomment-2980234301).

4.5dev1:

https://github.com/user-attachments/assets/33ffaccc-a9f3-4bce-a9f4-ae38a3bf2f46

This PR:

https://github.com/user-attachments/assets/a5814c9a-2019-41a9-8185-2934c913f0e0