### PR TITLE
Renderer: Warn when images need to be converted due to their formats being unsupported by hardware

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -396,7 +396,6 @@ static inline Error _get_gl_uncompressed_format(const Ref<Image> &p_image, Image
 				r_gl_format = GL_RED;
 				r_gl_type = GL_FLOAT;
 			} else {
-				ERR_PRINT("R32 float texture not supported, converting to R16.");
 				if (p_image.is_valid()) {
 					p_image->convert(Image::FORMAT_RH);
 				}
@@ -412,7 +411,6 @@ static inline Error _get_gl_uncompressed_format(const Ref<Image> &p_image, Image
 				r_gl_format = GL_RG;
 				r_gl_type = GL_FLOAT;
 			} else {
-				ERR_PRINT("RG32 float texture not supported, converting to RG16.");
 				if (p_image.is_valid()) {
 					p_image->convert(Image::FORMAT_RGH);
 				}
@@ -428,7 +426,6 @@ static inline Error _get_gl_uncompressed_format(const Ref<Image> &p_image, Image
 				r_gl_format = GL_RGB;
 				r_gl_type = GL_FLOAT;
 			} else {
-				ERR_PRINT("RGB32 float texture not supported, converting to RGB16.");
 				if (p_image.is_valid()) {
 					p_image->convert(Image::FORMAT_RGBH);
 				}
@@ -444,7 +441,6 @@ static inline Error _get_gl_uncompressed_format(const Ref<Image> &p_image, Image
 				r_gl_format = GL_RGBA;
 				r_gl_type = GL_FLOAT;
 			} else {
-				ERR_PRINT("RGBA32 float texture not supported, converting to RGBA16.");
 				if (p_image.is_valid()) {
 					p_image->convert(Image::FORMAT_RGBAH);
 				}
@@ -497,6 +493,11 @@ Ref<Image> TextureStorage::_get_gl_image_and_format(const Ref<Image> &p_image, I
 	if (!Image::is_format_compressed(p_format)) {
 		Error err = _get_gl_uncompressed_format(p_image, p_format, r_real_format, r_gl_format, r_gl_internal_format, r_gl_type);
 		ERR_FAIL_COND_V_MSG(err != OK, Ref<Image>(), vformat("The image format %d is not supported by the Compatibility renderer.", p_format));
+
+		if (p_format != r_real_format) {
+			WARN_PRINT(vformat("Image format %s not supported by hardware, converting to %s.", Image::get_format_name(p_format), Image::get_format_name(r_real_format)));
+		}
+
 		return p_image;
 	}
 
@@ -745,6 +746,10 @@ Ref<Image> TextureStorage::_get_gl_image_and_format(const Ref<Image> &p_image, I
 
 			r_real_format = image->get_format();
 			r_compressed = false;
+
+			if (p_format != image->get_format()) {
+				WARN_PRINT(vformat("Image format %s not supported by hardware, converting to %s.", Image::get_format_name(p_format), Image::get_format_name(image->get_format())));
+			}
 		}
 
 		return image;

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1782,6 +1782,7 @@ uint64_t TextureStorage::texture_get_native_handle(RID p_texture, bool p_srgb) c
 }
 
 Ref<Image> TextureStorage::_validate_texture_format(const Ref<Image> &p_image, TextureToRDFormat &r_format) {
+	Image::Format original_format = p_image->get_format();
 	Ref<Image> image = p_image->duplicate();
 
 	switch (p_image->get_format()) {
@@ -2268,6 +2269,12 @@ Ref<Image> TextureStorage::_validate_texture_format(const Ref<Image> &p_image, T
 
 		default: {
 		}
+	}
+
+	// RGB formats are often not supported, only print warnings about them when launched with the --verbose flag.
+	const bool is_rgb_format = original_format == Image::FORMAT_RGB8 || original_format == Image::FORMAT_RGBH || original_format == Image::FORMAT_RGBF;
+	if ((is_print_verbose_enabled() || !is_rgb_format) && original_format != image->get_format()) {
+		WARN_PRINT(vformat("Image format %s not supported by hardware, converting to %s.", Image::get_format_name(original_format), Image::get_format_name(image->get_format())));
 	}
 
 	return image;


### PR DESCRIPTION
Prints an error when the renderer is given a texture whose format isn't natively supported by the hardware. This will help debug issues involving extensions not supported by certain renderers