### PR TITLE
Improve docs for `EditorResourcePicker::_set_create_options`

### DIFF
--- a/doc/classes/EditorResourcePicker.xml
+++ b/doc/classes/EditorResourcePicker.xml
@@ -21,8 +21,9 @@
 			<return type="void" />
 			<param index="0" name="menu_node" type="Object" />
 			<description>
-				This virtual method is called when updating the context menu of [EditorResourcePicker]. Implement this method to override the "New ..." items with your own options. [param menu_node] is a reference to the [PopupMenu] node.
+				This virtual method is called when updating the context menu of an [member editable] [EditorResourcePicker]. Implement this method to override the "New" items section with your own options. [param menu_node] is a reference to the [PopupMenu] node.
 				[b]Note:[/b] Implement [method _handle_menu_selected] to handle these custom items.
+				[b]Note:[/b] Relevant built-in options ("Load", "Copy", "Paste", etc.) are automatically added to the [param menu_node] afterwards, using their hard-coded IDs starting from [code]0[/code]. Custom options need to use non-colliding IDs to be handled properly. Using [code]id = 100 + custom_option_index[/code] is safe (this is what the default items in the "New" section use).
 			</description>
 		</method>
 		<method name="get_allowed_types" qualifiers="const">


### PR DESCRIPTION
Adding custom options with `EditorResourcePicker::_set_create_options` with IDs starting from 0 results in conflicts with the built-in options ("Load", "Copy", "Paste", etc.), and hence the custom options not working correctly.

This PR adds a note explaining how to avoid such ID collisions.