### PR TITLE
Fix EditorProperty shortcuts being global and unintentionally triggering

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -579,6 +579,12 @@ void EditorProperty::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
+			EditorInspector *inspector = get_parent_inspector();
+			if (inspector) {
+				inspector = inspector->get_root_inspector();
+			}
+			set_shortcut_context(inspector);
+
 			if (has_borders) {
 				get_parent()->connect(SceneStringName(theme_changed), callable_mp(this, &EditorProperty::_update_property_bg));
 				_update_property_bg();


### PR DESCRIPTION
Hi again, it's been a while.

See my comment here for further context: https://github.com/godotengine/godot/pull/104366#issuecomment-2745278021

Fixes #104313
Fixes #99524
Fixes #88234

In addition to my above comment, if you whack a breakpoint down and look at `resolved_nodes_without_context`, it contains a list of all nodes without a "context", i.e. global. May want to review which of these should actually be global. Note that this list will change as different parts of the editor are loaded, if context has not been set. The list in the pic below are just from initial load.

![image](https://github.com/user-attachments/assets/e20de80a-ad60-4594-83c6-e7274916cc8e)

Note that the changes to `SceneTree` are optional I think. They are an improvement on the default behaviour (somewhat), but if there are still shortcuts unintentionally being registered as global then it does nothing to stop them from being triggered.

I'll also specifically quote part of my comment from above to possibly drive further discussion about this feature (might warrant an issue/proposal):
> I think part of the problem with the "shortcut context" system is that by default, every single node will have its shortcut_input be global unless it opts-in to the context system by using set_shortcut_context. This means if someone forgets to use set_shortcut_context when writing some UI, the shortcuts can be pretty messed up since everything is considered global.

>This doesn't seem like it is leading developers to the "pit of success". I'm not sure if there is a good way to fix it, but perhaps the logic should somehow be flipped so that being a global shortcut is opt-in. In this scenario, by default all controls would essentially have set_shortcut_context(this) in their constructor. That could be overridden on a case-by-case basis to give shortcuts a larger scope.