### PR TITLE
TextureEditors: Compile shader/material only once

### DIFF
--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -302,6 +302,13 @@ void register_editor_types() {
 	ei_singleton.editor_only = true;
 	Engine::get_singleton()->add_singleton(ei_singleton);
 
+	if (RenderingServer::get_singleton()) {
+		// RenderingServer needs to exist for this to succeed.
+		Texture3DEditor::init_shaders();
+		TextureLayeredEditor::init_shaders();
+		TexturePreview::init_shaders();
+	}
+
 	// Required as GDExtensions can register docs at init time way before this
 	// class is actually instantiated.
 	EditorHelp::init_gdext_pointers();
@@ -311,6 +318,10 @@ void register_editor_types() {
 
 void unregister_editor_types() {
 	OS::get_singleton()->benchmark_begin_measure("Editor", "Unregister Types");
+
+	Texture3DEditor::finish_shaders();
+	TextureLayeredEditor::finish_shaders();
+	TexturePreview::finish_shaders();
 
 	EditorNode::cleanup();
 	EditorInterface::free();

--- a/editor/scene/texture/texture_3d_editor_plugin.h
+++ b/editor/scene/texture/texture_3d_editor_plugin.h
@@ -49,8 +49,8 @@ class Texture3DEditor : public Control {
 	Label *info = nullptr;
 	Ref<Texture3D> texture;
 
-	Ref<Shader> shader;
-	Ref<ShaderMaterial> material;
+	static inline Ref<Shader> texture_shader;
+	Ref<ShaderMaterial> texture_material;
 
 	Control *texture_rect = nullptr;
 
@@ -59,8 +59,6 @@ class Texture3DEditor : public Control {
 	bool setting = false;
 
 	void _draw_outline();
-
-	void _make_shaders();
 
 	void _layer_changed(double) {
 		if (!setting) {
@@ -82,6 +80,9 @@ protected:
 	void _notification(int p_what);
 
 public:
+	static void init_shaders();
+	static void finish_shaders();
+
 	void edit(Ref<Texture3D> p_texture);
 
 	Texture3DEditor();

--- a/editor/scene/texture/texture_editor_plugin.cpp
+++ b/editor/scene/texture/texture_editor_plugin.cpp
@@ -44,11 +44,11 @@
 #include "scene/resources/portable_compressed_texture.h"
 #include "scene/resources/style_box_flat.h"
 
-constexpr const char *texture_2d_shader = R"(
+constexpr const char *texture_2d_shader_code = R"(
 shader_type canvas_item;
 render_mode blend_mix;
 
-uniform vec4 u_channel_factors = vec4(1.0);
+instance uniform vec4 u_channel_factors = vec4(1.0);
 
 vec4 filter_preview_colors(vec4 input_color, vec4 factors) {
 	// Filter RGB.
@@ -72,6 +72,20 @@ void fragment() {
 	COLOR = filter_preview_colors(texture(TEXTURE, UV), u_channel_factors);
 }
 )";
+
+void TexturePreview::init_shaders() {
+	texture_material.instantiate();
+
+	Ref<Shader> texture_shader;
+	texture_shader.instantiate();
+	texture_shader->set_code(texture_2d_shader_code);
+
+	texture_material->set_shader(texture_shader);
+}
+
+void TexturePreview::finish_shaders() {
+	texture_material.unref();
+}
 
 TextureRect *TexturePreview::get_texture_display() {
 	return texture_display;
@@ -212,7 +226,7 @@ void TexturePreview::_update_metadata_label_text() {
 }
 
 void TexturePreview::on_selected_channels_changed() {
-	material->set_shader_parameter("u_channel_factors", channel_selector->get_selected_channel_factors());
+	texture_display->set_instance_shader_parameter("u_channel_factors", channel_selector->get_selected_channel_factors());
 }
 
 TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
@@ -239,21 +253,12 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 	checkerboard->set_texture_repeat(CanvasItem::TEXTURE_REPEAT_ENABLED);
 	centering_container->add_child(checkerboard);
 
-	{
-		Ref<Shader> shader;
-		shader.instantiate();
-		shader->set_code(texture_2d_shader);
-
-		material.instantiate();
-		material->set_shader(shader);
-		material->set_shader_parameter("u_channel_factors", Vector4(1, 1, 1, 1));
-	}
-
 	texture_display = memnew(TextureRect);
 	texture_display->set_texture_filter(TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);
 	texture_display->set_texture(p_texture);
 	texture_display->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
-	texture_display->set_material(material);
+	texture_display->set_material(texture_material);
+	texture_display->set_instance_shader_parameter("u_channel_factors", Vector4(1, 1, 1, 1));
 	centering_container->add_child(texture_display);
 
 	// Creating a separate control so it is not affected by the filtering shader.

--- a/editor/scene/texture/texture_editor_plugin.h
+++ b/editor/scene/texture/texture_editor_plugin.h
@@ -57,7 +57,8 @@ private:
 	ColorRect *bg_rect = nullptr;
 	TextureRect *checkerboard = nullptr;
 	Label *metadata_label = nullptr;
-	Ref<ShaderMaterial> material;
+
+	static inline Ref<ShaderMaterial> texture_material;
 
 	ColorChannelSelector *channel_selector = nullptr;
 
@@ -71,6 +72,9 @@ protected:
 	void on_selected_channels_changed();
 
 public:
+	static void init_shaders();
+	static void finish_shaders();
+
 	TextureRect *get_texture_display();
 	TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata);
 };

--- a/editor/scene/texture/texture_layered_editor_plugin.cpp
+++ b/editor/scene/texture/texture_layered_editor_plugin.cpp
@@ -302,16 +302,7 @@ void TextureLayeredEditor::_draw_outline() {
 	draw_rect(outline_rect, theme_cache.outline_color, false, outline_width);
 }
 
-void TextureLayeredEditor::_make_shaders() {
-	shaders[0].instantiate();
-	shaders[0]->set_code(array_2d_shader);
-
-	shaders[1].instantiate();
-	shaders[1]->set_code(cubemap_shader);
-
-	shaders[2].instantiate();
-	shaders[2]->set_code(cubemap_array_shader);
-
+void TextureLayeredEditor::_make_materials() {
 	for (int i = 0; i < 3; i++) {
 		materials[i].instantiate();
 		materials[i]->set_shader(shaders[i]);
@@ -343,6 +334,23 @@ void TextureLayeredEditor::_texture_rect_update_area() {
 	texture_rect->set_size(Vector2(tex_width, tex_height));
 }
 
+void TextureLayeredEditor::init_shaders() {
+	shaders[0].instantiate();
+	shaders[0]->set_code(array_2d_shader);
+
+	shaders[1].instantiate();
+	shaders[1]->set_code(cubemap_shader);
+
+	shaders[2].instantiate();
+	shaders[2]->set_code(cubemap_array_shader);
+}
+
+void TextureLayeredEditor::finish_shaders() {
+	shaders[0].unref();
+	shaders[1].unref();
+	shaders[2].unref();
+}
+
 void TextureLayeredEditor::edit(Ref<TextureLayered> p_texture) {
 	if (texture.is_valid()) {
 		texture->disconnect_changed(callable_mp(this, &TextureLayeredEditor::_texture_changed));
@@ -351,8 +359,8 @@ void TextureLayeredEditor::edit(Ref<TextureLayered> p_texture) {
 	texture = p_texture;
 
 	if (texture.is_valid()) {
-		if (shaders[0].is_null()) {
-			_make_shaders();
+		if (materials[0].is_null()) {
+			_make_materials();
 		}
 
 		texture->connect_changed(callable_mp(this, &TextureLayeredEditor::_texture_changed));

--- a/editor/scene/texture/texture_layered_editor_plugin.h
+++ b/editor/scene/texture/texture_layered_editor_plugin.h
@@ -49,7 +49,7 @@ class TextureLayeredEditor : public Control {
 	Label *info = nullptr;
 	Ref<TextureLayered> texture;
 
-	Ref<Shader> shaders[3];
+	static inline Ref<Shader> shaders[3];
 	Ref<ShaderMaterial> materials[3];
 
 	float x_rot = 0;
@@ -62,7 +62,7 @@ class TextureLayeredEditor : public Control {
 
 	void _draw_outline();
 
-	void _make_shaders();
+	void _make_materials();
 	void _update_material(bool p_texture_changed);
 
 	void _layer_changed(double) {
@@ -85,6 +85,9 @@ protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
+	static void init_shaders();
+	static void finish_shaders();
+
 	void edit(Ref<TextureLayered> p_texture);
 
 	TextureLayeredEditor();


### PR DESCRIPTION
Compile shaders only once for `TexturePreview`, `TextureLayeredEditor` and `Texture3DEditor`. For `TexturePreview` entire material is compiled (instance uniform used).
This was suggested in https://github.com/godotengine/godot/pull/100157#discussion_r1912274195

Some benchmarks results:

<details>
  <summary>PC spec</summary>
CPU: AMD Ryzen 5 5600X (underclocked 75% to reduce coolers noise and CPU temperature)
GPU: NVIDIA GeForce RTX 3070
RAM: 32 GB (2×16 GB DDR4-2666)
SSD: ADATA SX8200 Pro
OS: Windows 10 (build 19045)
</details>

<details>
  <summary>Startup benchmarks results</summary>
  
  ```powershell
  hyperfine -m25 -iw1 "godot.windows.editor.x86_64.2303ce8.exe -e --path G:\media\projects\godot\ClickMaskMinimal --quit" "godot.windows.editor.x86_64.pr.exe -e --path G:\media\projects\godot\ClickMaskMinimal --quit"
Benchmark 1: godot.windows.editor.x86_64.2303ce8.exe -e --path G:\media\projects\godot\ClickMaskMinimal --quit
  Time (mean ± σ):     14.316 s ±  0.131 s    [User: 11.495 s, System: 1.052 s]
  Range (min … max):   14.229 s … 14.713 s    25 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 2: godot.windows.editor.x86_64.pr.exe -e --path G:\media\projects\godot\ClickMaskMinimal --quit
  Time (mean ± σ):     14.365 s ±  0.124 s    [User: 11.550 s, System: 1.019 s]
  Range (min … max):   14.219 s … 14.697 s    25 runs

Summary
  godot.windows.editor.x86_64.2303ce8.exe -e --path G:\media\projects\godot\ClickMaskMinimal --quit ran
    1.00 ± 0.01 times faster than
  ```
  
</details>

Shaders init/deinit on editor startup/quit:
```
register_editor_types - init_shaders, dev, avg for 5 runs: 7445 us
register_editor_types - init_shaders, production, avg for 5 runs: 3158 us

unregister_editor_types - finish_shaders, dev, avg for 5 runs: 121 us
unregister_editor_types - finish_shaders, production, avg for 5 runs: 64 us
```
I.e. +7ms on dev build and +3ms on production build for editor startup.

Selecting textures (show in Inspector dock) before:
```
TexturePreview::TexturePreview, production, avg for 10 samples: ~2930 us
Texture3DEditor::edit, production, avg for 10 samples: ~7521 us
TextureLayeredEditor::edit, production, avg for 10 samples: ~2616 us
```

Selecting textures (show in Inspector dock) after:
```
TexturePreview::TexturePreview, production, avg for 10 samples: ~472 us
Texture3DEditor::edit, production, avg for 10 samples: ~51 us
TextureLayeredEditor::edit, production, avg for 10 samples: ~68 us
```
I suppose for `TexturePreview` it is almost the same as in 4.3 (there was no shader in 4.3).
