### PR TITLE
Texture2DRD Global RenderingDevice Documentation

### DIFF
--- a/doc/classes/Texture2DRD.xml
+++ b/doc/classes/Texture2DRD.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Texture2DRD" inherits="Texture2D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Texture for 2D that is bound to a texture created on the [RenderingDevice].
+		Texture for 2D that is bound to a texture created on the global [RenderingDevice].
 	</brief_description>
 	<description>
-		This texture class allows you to use a 2D texture created directly on the [RenderingDevice] as a texture for materials, meshes, etc.
+		This texture class allows you to use a 2D texture created directly on the global [RenderingDevice] as a texture for materials, meshes, etc.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="texture_rd_rid" type="RID" setter="set_texture_rd_rid" getter="get_texture_rd_rid">
-			The RID of the texture object created on the [RenderingDevice].
+			The RID of the texture object created on the global [RenderingDevice].
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Updated documentation to specify that Texture2DRD is only supported by the global rendering device.

Example:

In ...
texture_rd.cpp
_set_texture_rd_rid()

ERR_FAIL_COND(!RD::get_singleton()->texture_is_valid(p_texture_rd_rid));

This fail condition ensures that the rendering device global singleton owns the RID that is being assigned to the Texture2DRD, and errors if it is owned by another rendering device (is designated as not valid).

There are many other instances in texture_rd.cpp that call RD::get_singleton() as well.