### PR TITLE
`EditorResourcePicker`: Add `Quick Load` button

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -88,6 +88,7 @@ void EditorResourcePicker::_update_resource() {
 	}
 
 	assign_button->set_disabled(!editable && edited_resource.is_null());
+	quick_load_button->set_visible(editable && edited_resource.is_null());
 }
 
 void EditorResourcePicker::_update_resource_preview(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, ObjectID p_obj) {
@@ -855,6 +856,7 @@ void EditorResourcePicker::_notification(int p_what) {
 				edit_menu->add_theme_constant_override("icon_max_width", icon_width);
 			}
 
+			quick_load_button->set_button_icon(get_editor_theme_icon(SNAME("Load")));
 			edit_button->set_button_icon(get_theme_icon(SNAME("select_arrow"), SNAME("Tree")));
 		} break;
 
@@ -996,6 +998,7 @@ void EditorResourcePicker::set_resource_owner(Object *p_object) {
 void EditorResourcePicker::set_editable(bool p_editable) {
 	editable = p_editable;
 	assign_button->set_disabled(!editable && edited_resource.is_null());
+	quick_load_button->set_visible(editable && edited_resource.is_null());
 	edit_button->set_visible(editable);
 }
 
@@ -1119,6 +1122,11 @@ EditorResourcePicker::EditorResourcePicker(bool p_hide_assign_button_controls) {
 		preview_rect->set_texture_filter(TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);
 		assign_button->add_child(preview_rect);
 	}
+
+	quick_load_button = memnew(Button);
+	quick_load_button->set_tooltip_text(TTRC("Quick Load"));
+	add_child(quick_load_button);
+	quick_load_button->connect(SceneStringName(pressed), callable_mp(this, &EditorResourcePicker::_edit_menu_cbk).bind(OBJ_MENU_QUICKLOAD));
 
 	edit_button = memnew(Button);
 	edit_button->set_flat(false);

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -56,6 +56,7 @@ class EditorResourcePicker : public HBoxContainer {
 	Button *assign_button = nullptr;
 	TextureRect *preview_rect = nullptr;
 	Button *edit_button = nullptr;
+	Button *quick_load_button = nullptr;
 	EditorFileDialog *file_dialog = nullptr;
 
 	ConfirmationDialog *duplicate_resources_dialog = nullptr;


### PR DESCRIPTION
Restore part of functionality of reverted PR https://github.com/godotengine/godot/pull/97860. 
As I see from discussion, several concerns were raised about the original changes:
- The viewable area became too short when the field was not empty (https://github.com/godotengine/godot/pull/97860#pullrequestreview-2350629401, https://github.com/godotengine/godot/pull/97860#issuecomment-2599105410)
- Load options were removed from dropdown menu.

As described in https://github.com/godotengine/godot/pull/102196:

> User feedback has shown that this change isn't always a clear improvement, because:
> 
> 1. The icon eats up horizontal space that's already limited here, cutting the text or previews significantly.
> 2. The "Load" functionality was completely removed, while it's still useful for many.
> 3. It breaks user expectations to no longer have load options next to Clear/Save/etc.

In this PR:
 - (1) is addressed by only displaying the "Quick Load" button when the field is empty.
 - (2) and (3) are avoided entirely, as the existing code for load options is preserved.
 
So now current functionality has not degraded and at the same time initial setup for empty field became quicker. While this may be a not complete solution, it is still usability improvement (Perfect is the enemy of good).

I'm sure there could be other opinions, so feedback is welcome.

Preview:

https://github.com/user-attachments/assets/161f897f-88f3-4a0d-883f-673493b5516f