### PR TITLE
Allow the `filename_filter` property to be changed.

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1095,9 +1095,6 @@ void FileDialog::clear_filename_filter() {
 
 void FileDialog::update_filename_filter_gui() {
 	filename_filter_box->set_visible(show_filename_filter);
-	if (!show_filename_filter) {
-		file_name_filter.clear();
-	}
 	if (filename_filter->get_text() == file_name_filter) {
 		return;
 	}


### PR DESCRIPTION
This fixes #104067 in a hacky way.

![image](https://github.com/user-attachments/assets/bd9cb590-ced5-4b7a-9b21-f1522236a20f)
![image](https://github.com/user-attachments/assets/bd2ed2a3-9a5d-44a0-96b7-ff8a467d0021)
![image](https://github.com/user-attachments/assets/910f6828-c738-4d79-ac11-7f4f00da85fc)

A downside of this PR is that if the property is hidden away using this code
```gdscript
@tool
extends FileDialog

func _validate_property(property:Dictionary):
	if property.name == "filename_filter":
		property.usage = PROPERTY_USAGE_NO_EDITOR
```
The `filename_filter` property persists and still works. I could not find a fix for this, but suggestions are welcome. Using the code in commit `14f519f47425a2062542f1f70aa68622be617e88` does not work due to some unknown reason. I even tried doing it like this
```cpp
	if (!filename_filter_box->is_visible()) {
		file_name_filter.clear();
	}
```
However that failed to provide the desired effect. As of now, it seems that removing the faulty code is the only way to proceed. 

It appears that using `!show_filename_filter` makes the box permanently uneditable as it is being cleared all the time, and using `show_filename_filter` allows editing but does not clear the box when it is hidden away then un-hidden. Truly quite a deep problem. I couldn't figure out how to print messages so that I could debug the state of `show_filename_filter`, and exactly pinpoint what was going wrong.

NOTE : Ready to merge.