### PR TITLE
Add inspector property reordering & regroup CameraAttribute auto_exposure props

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2979,13 +2979,15 @@
 			The property is checked in the [EditorInspector].
 		</constant>
 		<constant name="PROPERTY_USAGE_GROUP" value="64" enum="PropertyUsageFlags" is_bitfield="true">
-			Used to group properties together in the editor. See [EditorInspector].
+			Used to group properties together in the editor. See [EditorInspector]. The hint string may contain commas, separating it into up to 3 elements.
+			- The first element is the substring each property in the group should start with. [br]- The second element is the indentation amount for the group. [br]- The 3rd element can be 1, -1, or 0. This element is used to reorder properties in the inspector. The name of the group is the destination, where all the items inside the group will be sent. A value of 1 sends the items to right below the last property with that destination name, and -1 sends them to right above it. 0 does nothing.
+			For example, if a group is named [code]texture_filter[/code] has 3 properties inside it, and a hint string of [code],,1[/code], all 3 of those properties will be taken outside the group and moved to the last property that is called [code]texture_filter[/code] (if one exists).
 		</constant>
 		<constant name="PROPERTY_USAGE_CATEGORY" value="128" enum="PropertyUsageFlags" is_bitfield="true">
 			Used to categorize properties together in the editor.
 		</constant>
 		<constant name="PROPERTY_USAGE_SUBGROUP" value="256" enum="PropertyUsageFlags" is_bitfield="true">
-			Used to group properties together in the editor in a subgroup (under a group). See [EditorInspector].
+			Used to group properties together in the editor in a subgroup (under a group). See [EditorInspector]. This accepts the same hint string as [constant PROPERTY_USAGE_GROUP].
 		</constant>
 		<constant name="PROPERTY_USAGE_CLASS_IS_BITFIELD" value="512" enum="PropertyUsageFlags" is_bitfield="true">
 			The property is a bitfield, i.e. it contains multiple flags represented as bits.

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2049,7 +2049,7 @@ Control *EditorInspectorSection::make_custom_tooltip(const String &p_text) const
 	return nullptr;
 }
 
-void EditorInspectorSection::setup(const String &p_section, const String &p_label, Object *p_object, const Color &p_bg_color, bool p_foldable, int p_indent_depth, int p_level) {
+void EditorInspectorSection::setup(const String &p_section, const String &p_label, Object *p_object, const Color &p_bg_color, bool p_foldable, int p_indent_depth, int p_level, int p_reorder_placement) {
 	section = p_section;
 	label = p_label;
 	object = p_object;
@@ -2057,6 +2057,7 @@ void EditorInspectorSection::setup(const String &p_section, const String &p_labe
 	foldable = p_foldable;
 	indent_depth = p_indent_depth;
 	level = p_level;
+	reorder_placement = p_reorder_placement;
 
 	_test_unfold();
 
@@ -2148,6 +2149,10 @@ void EditorInspectorSection::_accessibility_action_collapse(const Variant &p_dat
 
 void EditorInspectorSection::_accessibility_action_expand(const Variant &p_data) {
 	unfold();
+}
+
+int EditorInspectorSection::get_reorder_placement() const {
+	return reorder_placement;
 }
 
 void EditorInspectorSection::unfold() {
@@ -3477,6 +3482,10 @@ void EditorInspector::update_tree() {
 	HashMap<String, EditorInspectorArray *> editor_inspector_array_per_prefix;
 	HashMap<String, HashMap<String, LocalVector<EditorProperty *>>> favorites_to_add;
 
+	int section_reorder_placement = 0;
+	String section_reorder_name;
+	HashMap<String, Vector<EditorInspectorSection *>> reorder_map;
+
 	Color sscolor = get_theme_color(SNAME("prop_subsection"), EditorStringName(Editor));
 	bool sub_inspectors_enabled = EDITOR_GET("interface/inspector/open_resources_in_current_inspector");
 
@@ -3499,6 +3508,8 @@ void EditorInspector::update_tree() {
 		if (p.usage & PROPERTY_USAGE_SUBGROUP) {
 			// Setup a property sub-group.
 			subgroup = p.name;
+			section_reorder_placement = 0;
+			section_reorder_name = "";
 
 			Vector<String> hint_parts = p.hint_string.split(",");
 			subgroup_base = hint_parts[0];
@@ -3507,12 +3518,18 @@ void EditorInspector::update_tree() {
 			} else {
 				section_depth = 0;
 			}
+			if (hint_parts.size() > 2) {
+				section_reorder_placement = hint_parts[2].to_int();
+				section_reorder_name = p.name;
+			}
 
 			continue;
 
 		} else if (p.usage & PROPERTY_USAGE_GROUP) {
 			// Setup a property group.
 			group = p.name;
+			section_reorder_placement = 0;
+			section_reorder_name = "";
 
 			Vector<String> hint_parts = p.hint_string.split(",");
 			group_base = hint_parts[0];
@@ -3520,6 +3537,10 @@ void EditorInspector::update_tree() {
 				section_depth = hint_parts[1].to_int();
 			} else {
 				section_depth = 0;
+			}
+			if (hint_parts.size() > 2) {
+				section_reorder_placement = hint_parts[2].to_int();
+				section_reorder_name = p.name;
 			}
 
 			subgroup = "";
@@ -3822,6 +3843,13 @@ void EditorInspector::update_tree() {
 				current_vbox->add_child(section);
 				sections.push_back(section);
 
+				if (section_reorder_placement != 0) {
+					if (!reorder_map.has(section_reorder_name)) {
+						reorder_map.insert(section_reorder_name, Vector<EditorInspectorSection *>());
+					}
+					reorder_map.get(section_reorder_name).append(section);
+				}
+
 				String label;
 				String tooltip;
 
@@ -3847,8 +3875,10 @@ void EditorInspector::update_tree() {
 
 				Color c = sscolor;
 				c.a /= level;
-				section->setup(acc_path, label, object, c, use_folding, section_depth, level);
+				section->setup(acc_path, label, object, c, use_folding, section_depth, level, section_reorder_placement);
 				section->set_tooltip_text(tooltip);
+				section_reorder_placement = 0;
+				section_reorder_name = "";
 
 				section->connect("section_toggled_by_user", callable_mp(this, &EditorInspector::_section_toggled_by_user));
 
@@ -4222,6 +4252,24 @@ void EditorInspector::update_tree() {
 						ep->select(current_focusable);
 					}
 				}
+			}
+		}
+
+		// Reorder properties.
+		if (reorder_map.has(p.name)) {
+			int index = current_vbox->get_child_count();
+			for (EditorInspectorSection *section : reorder_map.get(p.name)) {
+				for (Variant c : section->get_vbox()->get_children()) {
+					Control *child = Object::cast_to<Control>(c);
+					if (child) {
+						child->reparent(current_vbox);
+						if (section->get_reorder_placement() < 0) {
+							current_vbox->move_child(child, MAX(0, index - editors.size()));
+							index += 1;
+						}
+					}
+				}
+				section->hide();
 			}
 		}
 	}

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -342,6 +342,7 @@ class EditorInspectorSection : public Container {
 	bool checked = false;
 	int indent_depth = 0;
 	int level = 1;
+	int reorder_placement = 0;
 	String related_enable_property;
 
 	Timer *dropping_unfold_timer = nullptr;
@@ -374,10 +375,11 @@ public:
 	virtual Size2 get_minimum_size() const override;
 	virtual Control *make_custom_tooltip(const String &p_text) const override;
 
-	void setup(const String &p_section, const String &p_label, Object *p_object, const Color &p_bg_color, bool p_foldable, int p_indent_depth = 0, int p_level = 1);
+	void setup(const String &p_section, const String &p_label, Object *p_object, const Color &p_bg_color, bool p_foldable, int p_indent_depth = 0, int p_level = 1, int p_reorder_placement = 0);
 	String get_section() const;
 	String get_label() const { return label; }
 	VBoxContainer *get_vbox();
+	int get_reorder_placement() const;
 	void unfold();
 	void fold();
 	void set_bg_color(const Color &p_bg_color);

--- a/scene/resources/camera_attributes.cpp
+++ b/scene/resources/camera_attributes.cpp
@@ -292,7 +292,7 @@ void CameraAttributesPractical::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_near_transition", PROPERTY_HINT_RANGE, "-1,8192,0.01"), "set_dof_blur_near_transition", "get_dof_blur_near_transition");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_amount", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_dof_blur_amount", "get_dof_blur_amount");
 
-	ADD_GROUP("Auto Exposure", "auto_exposure_");
+	ADD_GROUP("auto_exposure_speed", "auto_exposure_,0,1");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "auto_exposure_min_sensitivity", PROPERTY_HINT_RANGE, "0,1600,0.01,or_greater,suffic:ISO"), "set_auto_exposure_min_sensitivity", "get_auto_exposure_min_sensitivity");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "auto_exposure_max_sensitivity", PROPERTY_HINT_RANGE, "0,64000,0.1,or_greater,suffic:ISO"), "set_auto_exposure_max_sensitivity", "get_auto_exposure_max_sensitivity");
 }
@@ -484,7 +484,7 @@ void CameraAttributesPhysical::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "exposure_aperture", PROPERTY_HINT_RANGE, "0.5,64.0,0.01,exp,suffix:f-stop"), "set_aperture", "get_aperture");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "exposure_shutter_speed", PROPERTY_HINT_RANGE, "0.1,8000.0,0.001,suffix:1/s"), "set_shutter_speed", "get_shutter_speed");
 
-	ADD_GROUP("Auto Exposure", "auto_exposure_");
+	ADD_GROUP("auto_exposure_speed", "auto_exposure_,0,1");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "auto_exposure_min_exposure_value", PROPERTY_HINT_RANGE, "-16.0,16.0,0.01,or_greater,suffix:EV100"), "set_auto_exposure_min_exposure_value", "get_auto_exposure_min_exposure_value");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "auto_exposure_max_exposure_value", PROPERTY_HINT_RANGE, "-16.0,16.0,0.01,or_greater,suffix:EV100"), "set_auto_exposure_max_exposure_value", "get_auto_exposure_max_exposure_value");
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #101467. This adds general support for reordering properties in the inspector. There's an extra parameter in the hint string for `PROPERTY_USAGE_GROUP` and `PROPERTY_USAGE_SUBGROUP`. So there can be up to 3 comma-separated elements:
1. (Unchanged) The prefix every property in the group should have
2. (Unchanged) The indentation level of the group
3. (New) A value of either 1, -1, or 0. 
0 does nothing. If it's a 1 or -1, the group will instead send all its properties to a different property, whose name is the group's name. A value of 1 will put them below the destination property, and -1 will put them above it

The new feature is used to fix duplicate groups in `CameraAttributesPhysical` & `CameraAttributesPractical`
| Before (from issue) | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/74f4ae19-4ed4-423f-9317-c26b6e23f81c) | ![image](https://github.com/user-attachments/assets/5b786fd3-afc5-4df7-83c1-79d935a430c3) |

Here's how the group definition changed:
```c++
// Before
ADD_GROUP("Auto Exposure", "auto_exposure_");
// After
ADD_GROUP("auto_exposure_speed", "auto_exposure_,0,1");
```
So rather than having another group called "Auto Exposure", all the properties that would normally belong to that group, are instead transported to under the property called "auto_exposure_speed". Letting you add to parent groups, from a child class

In GDScript it would look like this:
```gdscript
@export_group("auto_exposure_speed", "auto_exposure,0,1")
```


<details>
<summary>Old implementation</summary>

~~Rather than adding additional methods to Object itself, I opted to allow it inside `_validate_property` or `_get_property_list`, through `EditorInspector` from `EditorInterface`.~~

~~You first check if it's running in the editor, then you get the inspector and call `set_reorder_prop`~~

```c++
if (Engine::get_singleton()->is_editor_hint()) {
	EditorInspector *inspector = EditorInterface::get_singleton()->get_inspector();

	if (inspector) {
		inspector->set_reorder_prop(p_property.name, "auto_exposure_enabled");
	}
}
```
</details>