### PR TITLE
Fix preset cache usage in ColorPicker

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -170,9 +170,10 @@ void ColorPicker::_notification(int p_what) {
 			// Adjust for the width of the "script" icon.
 			text_type->set_custom_minimum_size(Size2(28 * theme_cache.base_scale, 0));
 
-			_update_presets();
-			_update_recent_presets();
 			_update_controls();
+			// HACK: Deferring updating presets to ensure their size is correct when creating ColorPicker at runtime.
+			callable_mp(this, &ColorPicker::_update_presets).call_deferred();
+			callable_mp(this, &ColorPicker::_update_recent_presets).call_deferred();
 		} break;
 
 		case NOTIFICATION_WM_CLOSE_REQUEST: {
@@ -749,10 +750,10 @@ void ColorPicker::_update_color(bool p_update_sliders) {
 
 void ColorPicker::_update_presets() {
 	int preset_size = _get_preset_size();
+	btn_add_preset->set_custom_minimum_size(Size2(preset_size, preset_size));
 	// Only update the preset button size if it has changed.
 	if (preset_size != prev_preset_size) {
 		prev_preset_size = preset_size;
-		btn_add_preset->set_custom_minimum_size(Size2(preset_size, preset_size));
 		for (int i = 1; i < preset_container->get_child_count(); i++) {
 			ColorPresetButton *cpb = Object::cast_to<ColorPresetButton>(preset_container->get_child(i));
 			cpb->set_custom_minimum_size(Size2(preset_size, preset_size));
@@ -764,7 +765,10 @@ void ColorPicker::_update_presets() {
 		String cached_name = editor_settings->call(SNAME("get_project_metadata"), "color_picker", "palette_name", String());
 		palette_path = editor_settings->call(SNAME("get_project_metadata"), "color_picker", "palette_path", String());
 		bool palette_edited = editor_settings->call(SNAME("get_project_metadata"), "color_picker", "palette_edited", false);
-		if (!cached_name.is_empty()) {
+		if (cached_name.is_empty()) {
+			palette_path = String();
+			palette_name->hide();
+		} else {
 			palette_name->set_text(cached_name);
 			if (btn_preset->is_pressed() && !presets.is_empty()) {
 				palette_name->show();
@@ -778,14 +782,17 @@ void ColorPicker::_update_presets() {
 	}
 #endif
 
-	// Rebuild swatch color buttons, keeping the add-preset button in the first position.
-	for (int i = 1; i < preset_container->get_child_count(); i++) {
-		preset_container->get_child(i)->queue_free();
-	}
+	if (presets_just_loaded || presets.is_empty() || Engine::get_singleton()->is_editor_hint()) {
+		// Rebuild swatch color buttons, keeping the add-preset button in the first position.
+		for (int i = 1; i < preset_container->get_child_count(); i++) {
+			preset_container->get_child(i)->queue_free();
+		}
 
-	presets = preset_cache;
-	for (const Color &preset : preset_cache) {
-		_add_preset_button(preset_size, preset);
+		presets = preset_cache;
+		for (const Color &preset : presets) {
+			_add_preset_button(preset_size, preset);
+		}
+		presets_just_loaded = false;
 	}
 
 	_notification(NOTIFICATION_VISIBILITY_CHANGED);
@@ -956,6 +963,7 @@ void ColorPicker::_palette_file_selected(const String &p_path) {
 				preset_cache.push_back(saved_preset);
 				presets.push_back(saved_preset);
 			}
+			presets_just_loaded = true;
 
 #ifdef TOOLS_ENABLED
 			if (editor_settings) {
@@ -992,7 +1000,9 @@ void ColorPicker::_palette_file_selected(const String &p_path) {
 		editor_settings->call(SNAME("set_project_metadata"), "color_picker", "palette_edited", false);
 	}
 #endif
-	_update_presets();
+	if (file_dialog->get_file_mode() == FileDialog::FileMode::FILE_MODE_OPEN_FILE) {
+		_update_presets();
+	}
 }
 
 void ColorPicker::_show_hide_preset(const bool &p_is_btn_pressed, Button *p_btn_preset, Container *p_preset_container) {

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -212,6 +212,7 @@ private:
 	Button *btn_pick = nullptr;
 	Label *palette_name = nullptr;
 	String palette_path;
+	bool presets_just_loaded = false;
 	Button *btn_preset = nullptr;
 	Button *btn_recent_preset = nullptr;
 	PopupMenu *shape_popup = nullptr;


### PR DESCRIPTION
Fixes #104223

<details>
<summary>It also fixes two additional bugs (click to expand)</summary>

1. Palette name was not being cleared in editor in other `ColorPicker`s. Video of incorrect behaviour from 4.4.stable:

https://github.com/user-attachments/assets/89b9943f-dc5b-45fc-9216-0ff14d28861e


2. Cached presets had wrong size when adding `ColorPicker` in runtime. Video of incorrect behaviour from 4.4.stable:

https://github.com/user-attachments/assets/e0fe1684-e9c4-4dc3-9ea0-1255dd5b4a36

</details>

**Correct behaviour, fixed with this PR**:

https://github.com/user-attachments/assets/90e0cf48-8300-43ef-80f7-6aa8284f66f9


https://github.com/user-attachments/assets/558267ff-80ae-4baa-bea5-44f94d9ec496

