### PR TITLE
CallableCustomMethodPointerBase: Make `_setup` strict-aliasing safe

### DIFF
--- a/core/object/callable_method_pointer.h
+++ b/core/object/callable_method_pointer.h
@@ -37,7 +37,7 @@
 #include <type_traits>
 
 class CallableCustomMethodPointerBase : public CallableCustom {
-	uint32_t *comp_ptr = nullptr;
+	const uint8_t *comp_ptr = nullptr;
 	uint32_t comp_size;
 	uint32_t h;
 #ifdef DEBUG_METHODS_ENABLED
@@ -47,7 +47,7 @@ class CallableCustomMethodPointerBase : public CallableCustom {
 	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
 
 protected:
-	void _setup(uint32_t *p_base_ptr, uint32_t p_ptr_size);
+	void _setup(const uint8_t *p_base_ptr, uint32_t p_ptr_size);
 
 public:
 	virtual StringName get_method() const {
@@ -112,7 +112,7 @@ public:
 		data.instance = p_instance;
 		data.object_id = p_instance->get_instance_id();
 		data.method = p_method;
-		_setup((uint32_t *)&data, sizeof(Data));
+		_setup((const uint8_t *)&data, sizeof(Data));
 	}
 };
 
@@ -182,7 +182,7 @@ public:
 		data.instance = p_instance;
 		data.object_id = p_instance->get_instance_id();
 		data.method = p_method;
-		_setup((uint32_t *)&data, sizeof(Data));
+		_setup((const uint8_t *)&data, sizeof(Data));
 	}
 };
 
@@ -254,7 +254,7 @@ public:
 	CallableCustomStaticMethodPointer(R (*p_method)(P...)) {
 		memset(&data, 0, sizeof(Data)); // Clear beforehand, may have padding bytes.
 		data.method = p_method;
-		_setup((uint32_t *)&data, sizeof(Data));
+		_setup((const uint8_t *)&data, sizeof(Data));
 	}
 };
 

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -201,17 +201,19 @@ static _FORCE_INLINE_ uint32_t hash_fmix32(uint32_t h) {
 static _FORCE_INLINE_ uint32_t hash_murmur3_buffer(const void *key, int length, const uint32_t seed = HASH_MURMUR3_SEED) {
 	// Although not required, this is a random prime number.
 	const uint8_t *data = (const uint8_t *)key;
-	const int nblocks = length / 4;
+	const int nblocks = length / sizeof(uint32_t);
 
 	uint32_t h1 = seed;
 
 	const uint32_t c1 = 0xcc9e2d51;
 	const uint32_t c2 = 0x1b873593;
 
-	const uint32_t *blocks = (const uint32_t *)(data + nblocks * 4);
+	const uint8_t *blocks = data + nblocks * sizeof(uint32_t);
 
 	for (int i = -nblocks; i; i++) {
-		uint32_t k1 = blocks[i];
+		uint32_t k1;
+		// Use memcpy to avoid UB with strict-aliasing.
+		memcpy(&k1, &blocks[i * sizeof(uint32_t)], sizeof(uint32_t));
 
 		k1 *= c1;
 		k1 = hash_rotl32(k1, 15);
@@ -222,7 +224,7 @@ static _FORCE_INLINE_ uint32_t hash_murmur3_buffer(const void *key, int length, 
 		h1 = h1 * 5 + 0xe6546b64;
 	}
 
-	const uint8_t *tail = (const uint8_t *)(data + nblocks * 4);
+	const uint8_t *tail = data + nblocks * sizeof(uint32_t);
 
 	uint32_t k1 = 0;
 


### PR DESCRIPTION
I found a bug when compiling a production build of godot 4 (template) for x86_64-linux using GCC 14:

```
ERROR: Signal 'changed' is already connected to given callable '' in that object.
   at: connect (core/object/object.cpp:1451)
```

I tracked this down to incorrect optimisation of  `CallableCustomMethodPointerBase::_setup`, caused by invalid pointer aliasing.

There are various ways this could be fixed.  I went with one that gives the same results as the current implementation.  I chose to use `char` since the language spec references it, but `uint8_t` would probably also be okay in practice.

I can provide a repro as a nix expression, but it's very sensitive to the compiler configuration, so it might be difficult to reproduce otherwise.

`hash_murmur3_buffer` might be a good candidate if we don't mind changing the result.  However, it looks like it also uses invalid aliasing:

```
static _FORCE_INLINE_ uint32_t hash_murmur3_buffer(const void *key, int length, const uint32_t seed = HASH_MURMUR3_SEED) {
	// Although not required, this is a random prime number.
	const uint8_t *data = (const uint8_t *)key;
	const int nblocks = length / 4;

	uint32_t h1 = seed;

	const uint32_t c1 = 0xcc9e2d51;
	const uint32_t c2 = 0x1b873593;

	const uint32_t *blocks = (const uint32_t *)(data + nblocks * 4);
```

I'm not sure if it's worth trying to proactively fix things like this, do a more exhaustive search, or just turn on `-fno-strict-aliasing`.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
