### PR TITLE
GDScript: Fix for loop inline body highlighted as type

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -62,6 +62,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 	bool is_bin_notation = false;
 	bool in_member_variable = false;
 	bool in_lambda = false;
+	bool in_for_loop_header = false;
 
 	bool in_function_name = false; // Any call.
 	bool in_function_declaration = false; // Only declaration.
@@ -426,8 +427,11 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 				col = class_names[word];
 			} else if (reserved_keywords.has(word)) {
 				col = reserved_keywords[word];
-				// Don't highlight `list` as a type in `for elem: Type in list`.
-				expect_type = false;
+				if (in_for_loop_header) {
+					in_for_loop_header = false;
+					// Don't highlight 'list' as a type in `for elem: Type in list:`.
+					expect_type = false;
+				}
 			} else if (member_keywords.has(word)) {
 				col = member_keywords[word];
 			}
@@ -468,8 +472,10 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 					if (prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::FUNC)) {
 						in_function_declaration = true;
 					}
-				} else if (prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::VAR) || prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::FOR) || prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::TK_CONST)) {
+				} else if (prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::VAR) || prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::TK_CONST)) {
 					in_var_const_declaration = true;
+				} else if (prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::FOR)) {
+					in_for_loop_header = true;
 				}
 
 				// Check for lambda.
@@ -551,7 +557,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 					expect_type = true;
 					in_type_params = 0;
 				}
-				if ((is_after_var_const_declaration || (in_declaration_params == 1 && in_declaration_param_dicts == 0)) && str[j] == ':') {
+				if ((in_for_loop_header || is_after_var_const_declaration || (in_declaration_params == 1 && in_declaration_param_dicts == 0)) && str[j] == ':') {
 					expect_type = true;
 					in_type_params = 0;
 				}


### PR DESCRIPTION
- Fixes #102913 

**Before**
![base_small](https://github.com/user-attachments/assets/a97609ce-46b9-490d-abd0-44773e4cee3d)

**After** 
![try2_small](https://github.com/user-attachments/assets/004c78bc-7fe9-49d0-8c78-4ac76f569700)

Now correctly highlights inline for loop bodies instead of only being highlighted as a typed variable for loop.