### PR TITLE
GDScript: Return early when parsing invalid super call

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3301,7 +3301,11 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_call(ExpressionNode *p_pre
 			IdentifierNode *identifier = parse_identifier();
 			call->callee = identifier;
 			call->function_name = identifier->name;
-			consume(GDScriptTokenizer::Token::PARENTHESIS_OPEN, R"(Expected "(" after function name.)");
+			if (!consume(GDScriptTokenizer::Token::PARENTHESIS_OPEN, R"(Expected "(" after function name.)")) {
+				pop_multiline();
+				complete_extents(call);
+				return nullptr;
+			}
 		}
 	} else {
 		call->callee = p_previous_operand;

--- a/modules/gdscript/tests/scripts/completion/common/invalid_super_call_1.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/invalid_super_call_1.cfg
@@ -1,0 +1,5 @@
+[output]
+include=[
+    ; GDScript: class_a.notest.gd
+    {"display": "func_of_a()"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/invalid_super_call_1.gd
+++ b/modules/gdscript/tests/scripts/completion/common/invalid_super_call_1.gd
@@ -1,0 +1,7 @@
+extends "res://completion/class_a.notest.gd"
+
+func test():
+	super.➡
+
+	if true:
+		pass

--- a/modules/gdscript/tests/scripts/completion/common/invalid_super_call_2.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/invalid_super_call_2.cfg
@@ -1,0 +1,5 @@
+[output]
+include=[
+    ; GDScript: class_a.notest.gd
+    {"display": "func_of_a()"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/invalid_super_call_2.gd
+++ b/modules/gdscript/tests/scripts/completion/common/invalid_super_call_2.gd
@@ -1,0 +1,7 @@
+extends "res://completion/class_a.notest.gd"
+
+func test():
+	super.f➡
+
+	if true:
+		pass


### PR DESCRIPTION
Fixes #104499

When parsing a super call and not finding an open parenthesis the parser would still try to parse function arguments, which would push a new and wrong completion context.
