### PR TITLE
GridMap: fix cell scale not applying to the cursor mesh

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -250,7 +250,7 @@ void GridMapEditor::_update_cursor_transform() {
 
 	if (mode_buttons_group->get_pressed_button() == paint_mode_button) {
 		// Rotation is only applied in paint mode, we don't want the cursor box to rotate otherwise.
-		cursor_transform.basis = node->get_basis_with_orthogonal_index(cursor_rot);
+		cursor_transform.basis *= node->get_basis_with_orthogonal_index(cursor_rot);
 		if (selected_palette >= 0 && node && node->get_mesh_library().is_valid()) {
 			cursor_transform *= node->get_mesh_library()->get_item_mesh_transform(selected_palette);
 		}


### PR DESCRIPTION
Cursor's basis gets scaled by cell's scale, but then gets overwritten when the code enters the if statement. I changed = to *= to keep the scale.

Fixes #104247