### PR TITLE
Fix tooltip lookup on scrolled PopupMenu.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1460,7 +1460,9 @@ String Viewport::_gui_get_tooltip(Control *p_control, const Vector2 &p_pos, Cont
 		// Temporary solution for PopupMenus.
 		PopupMenu *menu = Object::cast_to<PopupMenu>(this);
 		if (menu) {
-			tooltip = menu->get_tooltip(pos);
+			// PopupMenu::get_tooltip requires position in viewport coordinates.
+			const Vector2 pos_viewport = p_control->get_global_transform_with_canvas().xform(pos);
+			tooltip = menu->get_tooltip(pos_viewport);
 		}
 
 		if (r_tooltip_owner) {


### PR DESCRIPTION
PopupMenu::get_tooltip requires position passed be relative to PopupMenu Viewport (rather than Control node the mouse is over, for similar get_tooltip methods).

Fixes #104262

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
