### PR TITLE
Fix TileMapLayer editor preview alignment in a CanvasLayer with "Follow Viewport" enabled

### DIFF
--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -798,7 +798,7 @@ void TileMapLayerEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p
 	}
 
 	Transform2D xform = CanvasItemEditor::get_singleton()->get_canvas_transform() * edited_layer->get_global_transform_with_canvas();
-	Vector2 mpos = edited_layer->get_local_mouse_position();
+	Vector2 mpos = xform.affine_inverse().xform(CanvasItemEditor::get_singleton()->get_viewport_control()->get_local_mouse_position());
 	Vector2i tile_shape_size = tile_set->get_tile_size();
 	bool drawing_rect = false;
 
@@ -3166,7 +3166,7 @@ void TileMapLayerEditorTerrainsPlugin::forward_canvas_draw_over_viewport(Control
 	}
 
 	Transform2D xform = CanvasItemEditor::get_singleton()->get_canvas_transform() * edited_layer->get_global_transform_with_canvas();
-	Vector2 mpos = edited_layer->get_local_mouse_position();
+	Vector2 mpos = xform.affine_inverse().xform(CanvasItemEditor::get_singleton()->get_viewport_control()->get_local_mouse_position());
 	Vector2i tile_shape_size = tile_set->get_tile_size();
 
 	// Handle the preview of the tiles to be placed.

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -154,7 +154,7 @@ void CanvasItem::_redraw_callback() {
 Transform2D CanvasItem::get_global_transform_with_canvas() const {
 	ERR_READ_THREAD_GUARD_V(Transform2D());
 	if (canvas_layer) {
-		return canvas_layer->get_final_transform() * get_global_transform();
+		return canvas_layer->get_transform() * get_global_transform();
 	} else if (is_inside_tree()) {
 		return get_viewport()->get_canvas_transform() * get_global_transform();
 	} else {


### PR DESCRIPTION
Fixes #99909

When a TileMapLayer node is a child of a CanvasLayer node and the CanvasLayer's "Follow Viewport" property is enabled, there is an issue with how the editor preview elements are drawn (such as the grid, tile preview, etc.).

By fixing the way transforms are applied, this commit ensures behavior identical to that of Godot 3.6.

<img width="953" alt="fixed-grid-and-preview" src="https://github.com/user-attachments/assets/e1e85270-60b5-41b1-8311-868906745ccd" />