### PR TITLE
[3.x] Physics Interpolation - Add 3D helper for using servers directly.

### DIFF
--- a/core/pooled_list.h
+++ b/core/pooled_list.h
@@ -110,7 +110,7 @@ public:
 		r_id = list.size();
 		list.resize(r_id + 1);
 
-		static_assert((!zero_on_first_request) || (__is_pod(T)), "zero_on_first_request requires trivial type");
+		static_assert((!zero_on_first_request) || (std::is_trivially_destructible<T>::value), "zero_on_first_request requires trivial type");
 		if (zero_on_first_request && __is_pod(T)) {
 			list[r_id] = {};
 		}

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -1108,6 +1108,53 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="fti_instance_create">
+			<return type="RID" />
+			<description>
+				FTI ("fixed timestep interpolation") instance provides a physics interpolation wrapper for users creating instances directly on the server rather than through Nodes.
+				[codeblock]
+				# Instance creation goes here, see the docs.
+				var instance = VisualServer.instance_create()
+
+				# Create an FTI instance and link it to the regular instance.
+				var fti_instance = VisualServer.fti_instance_create()
+				VisualServer.fti_instance_prepare(fti_instance, instance)
+
+				# Use this function instead of instance_set_transform().
+				VisualServer.fti_instance_set_transform(fti_instance, xform)
+
+				# This function provides reset_physics_interpolation().
+				VisualServer.fti_instance_reset(fti_instance)
+
+				# Be sure to free any RIDs on the server after use.
+				VisualServer.free_rid(fti_instance)
+				VisualServer.free_rid(instance)
+				[/codeblock]
+			</description>
+		</method>
+		<method name="fti_instance_prepare">
+			<return type="void" />
+			<argument index="0" name="fti_instance" type="RID" />
+			<argument index="1" name="instance" type="RID" />
+			<description>
+				An FTI instance must be linked with a regular instance before use.
+			</description>
+		</method>
+		<method name="fti_instance_reset">
+			<return type="void" />
+			<argument index="0" name="fti_instance" type="RID" />
+			<description>
+				Equivalent to reset_physics_interpolation() for Nodes.
+			</description>
+		</method>
+		<method name="fti_instance_set_transform">
+			<return type="void" />
+			<argument index="0" name="fti_instance" type="RID" />
+			<argument index="1" name="transform" type="Transform" />
+			<description>
+				Equivalent to instance_set_transform(), but provides automatic physics interpolation.
+			</description>
+		</method>
 		<method name="get_render_info">
 			<return type="int" />
 			<argument index="0" name="info" type="int" enum="VisualServer.RenderInfo" />

--- a/servers/visual/fti_helper.cpp
+++ b/servers/visual/fti_helper.cpp
@@ -1,0 +1,151 @@
+/**************************************************************************/
+/*  fti_helper.cpp                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "fti_helper.h"
+
+#include "core/engine.h"
+#include "core/math/transform_interpolator.h"
+#include "servers/visual_server.h"
+
+FTIHelper::Handle FTIHelper::instance_create(RID p_instance) {
+	Handle h;
+	Instance *i = _instances.request(h.id());
+	i->clear();
+	i->revision += 1;
+	h.set_revision(i->revision);
+	i->instance = p_instance;
+
+	return h;
+}
+
+bool FTIHelper::instance_free(Handle h_instance) {
+	ERR_FAIL_COND_V(!get_instance(h_instance), false);
+	_instances.free(h_instance.id());
+
+	// Remove from all lists.
+	_instance_frame_list.erase_multiple_unordered(h_instance);
+	_instance_tick_list_curr->erase_multiple_unordered(h_instance);
+	_instance_tick_list_prev->erase_multiple_unordered(h_instance);
+	return true;
+}
+
+FTIHelper::Instance *FTIHelper::get_instance(Handle h_instance) {
+	ERR_FAIL_COND_V(h_instance.id() >= _instances.reserved_size(), nullptr);
+	Instance &i = _instances[h_instance.id()];
+	ERR_FAIL_COND_V(h_instance.revision() != i.revision, nullptr);
+	return &i;
+}
+
+void FTIHelper::instance_changed(Instance &r_instance, Handle h_instance) {
+	// Add to tick list
+	if (!r_instance.on_tick_list) {
+		r_instance.on_tick_list = true;
+		_instance_tick_list_curr->push_back(h_instance);
+	}
+
+	// Add to frame list.
+	if (!r_instance.on_frame_list) {
+		r_instance.on_frame_list = true;
+		_instance_frame_list.push_back(h_instance);
+	}
+}
+
+void FTIHelper::instance_set_transform(Handle h_instance, const Transform &p_xform) {
+	Instance *i = get_instance(h_instance);
+	ERR_FAIL_NULL(i);
+	i->curr = p_xform;
+	instance_changed(*i, h_instance);
+}
+
+void FTIHelper::instance_reset_physics_interpolation(Handle h_instance) {
+	Instance *i = get_instance(h_instance);
+	ERR_FAIL_NULL(i);
+	i->pump();
+	instance_changed(*i, h_instance);
+}
+
+void FTIHelper::tick_update() {
+	LocalVector<Handle> &curr = *_instance_tick_list_curr;
+	LocalVector<Handle> &prev = *_instance_tick_list_prev;
+
+	// First detect on the previous list but not on this tick list.
+	for (uint32_t n = 0; n < prev.size(); n++) {
+		const Handle &h = prev[n];
+		Instance *i = get_instance(h);
+		if (i) {
+			if (!i->on_tick_list) {
+				// Needs a reset so jittering will stop.
+				i->pump();
+
+				// Remove from interpolation list.
+				if (i->on_frame_list) {
+					i->on_frame_list = false;
+					_instance_frame_list.erase_unordered(h);
+				}
+			}
+		}
+	}
+
+	// Now pump all on the current list.
+	for (uint32_t n = 0; n < curr.size(); n++) {
+		const Handle &h = curr[n];
+		Instance *i = get_instance(h);
+		if (i) {
+			// Reset, needs to be marked each tick.
+			i->on_tick_list = false;
+		}
+
+		// Pump.
+		i->pump();
+	}
+
+	// Clear previous list and flip.
+	prev.clear();
+
+	SWAP(_instance_tick_list_curr, _instance_tick_list_prev);
+}
+
+void FTIHelper::frame_update() {
+	float f = Engine::get_singleton()->get_physics_interpolation_fraction();
+
+	Transform x;
+	VisualServer *vs = VisualServer::get_singleton();
+
+	for (uint32_t n = 0; n < _instance_frame_list.size(); n++) {
+		const Handle &h = _instance_frame_list[n];
+		Instance *i = get_instance(h);
+		if (i) {
+			TransformInterpolator::interpolate_transform(i->prev, i->curr, x, f);
+
+			// Send to server.
+			vs->instance_set_transform(i->instance, x);
+		}
+	}
+}

--- a/servers/visual/fti_helper.h
+++ b/servers/visual/fti_helper.h
@@ -1,0 +1,110 @@
+/**************************************************************************/
+/*  fti_helper.h                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef FTI_HELPER_H
+#define FTI_HELPER_H
+
+#include "core/math/transform.h"
+#include "core/pooled_list.h"
+#include "core/rid.h"
+
+#include <cstdint>
+
+class FTIHelper {
+	struct Handle {
+		static const uint64_t INVALID = UINT64_MAX;
+
+		// conversion operator
+		operator uint64_t() const { return _data; }
+		Handle(uint64_t p_value) { _data = p_value; }
+		Handle() { _data = INVALID; }
+
+		union {
+			struct
+			{
+				uint32_t _id;
+				uint32_t _revision;
+			};
+			uint64_t _data;
+		};
+
+		void set_invalid() { _data = INVALID; }
+		bool is_invalid() const { return _data == INVALID; }
+		uint32_t id() const { return _id; }
+		uint32_t &id() { return _id; }
+		void set_id(uint32_t p_id) { _id = p_id; }
+		uint32_t revision() const { return _revision; }
+		void set_revision(uint32_t p_revision) { _revision = p_revision; }
+
+		bool operator==(const Handle &p_h) const { return _data == p_h._data; }
+		bool operator!=(const Handle &p_h) const { return (*this == p_h) == false; }
+	};
+
+	struct Instance {
+		uint32_t revision = 0;
+		RID instance;
+		Transform curr;
+		Transform prev;
+		bool on_frame_list = false;
+		bool on_tick_list = false;
+		void clear() {
+			instance = RID();
+			curr = Transform();
+			prev = Transform();
+			on_frame_list = false;
+			on_tick_list = false;
+		}
+		void pump() {
+			prev = curr;
+		}
+	};
+
+	PooledList<Instance, uint32_t, true, true> _instances;
+
+	LocalVector<Handle> _instance_frame_list;
+	LocalVector<Handle> _instance_tick_list[2];
+	LocalVector<Handle> *_instance_tick_list_curr = &_instance_tick_list[0];
+	LocalVector<Handle> *_instance_tick_list_prev = &_instance_tick_list[1];
+
+	// Check revisions etc. in case of user error.
+	Instance *get_instance(Handle h_instance);
+	void instance_changed(Instance &r_instance, Handle h_instance);
+
+public:
+	Handle instance_create(RID p_instance);
+	bool instance_free(Handle h_instance);
+	void instance_set_transform(Handle h_instance, const Transform &p_xform);
+	void instance_reset_physics_interpolation(Handle h_instance);
+
+	void tick_update();
+	void frame_update();
+};
+
+#endif // FTI_HELPER_H

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -588,6 +588,11 @@ public:
 
 	BIND2(instance_set_extra_visibility_margin, RID, real_t)
 
+	BIND0R(RID, fti_instance_create)
+	BIND2(fti_instance_prepare, RID, RID)
+	BIND2(fti_instance_set_transform, RID, const Transform &)
+	BIND1(fti_instance_reset, RID)
+
 	/* BLOB SHADOWS */
 	BIND0R(RID, capsule_shadow_create)
 	BIND5(capsule_shadow_update, RID, const Vector3 &, real_t, const Vector3 &, real_t)

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -45,6 +45,7 @@
 #include "visual_server_blob_shadows.h"
 
 class VisualServerLightCuller;
+class FTIHelper;
 
 class VisualServerScene {
 public:
@@ -59,6 +60,7 @@ public:
 
 	uint64_t render_pass;
 	static VisualServerScene *singleton;
+	FTIHelper *_fti_helper;
 
 	/* EVENT QUEUING */
 
@@ -675,6 +677,17 @@ public:
 	virtual void instance_set_exterior(RID p_instance, bool p_enabled);
 
 	virtual void instance_set_extra_visibility_margin(RID p_instance, real_t p_margin);
+
+	/* FTI HELPER API */
+	struct FTIInstance : RID_Data {
+		FTIHandle handle = UINT64_MAX;
+	};
+	RID_Owner<FTIInstance> fti_instance_owner;
+
+	RID fti_instance_create();
+	void fti_instance_prepare(RID p_fti_instance, RID p_linked_instance);
+	void fti_instance_set_transform(RID p_fti_instance, const Transform &p_transform);
+	void fti_instance_reset(RID p_fti_instance);
 
 	// Portals
 	virtual void instance_set_portal_mode(RID p_instance, VisualServer::InstancePortalMode p_mode);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -496,6 +496,12 @@ public:
 
 	FUNC2(instance_set_extra_visibility_margin, RID, real_t)
 
+	/* FTI HELPER API */
+	FUNCRID(fti_instance)
+	FUNC2(fti_instance_prepare, RID, RID)
+	FUNC2(fti_instance_set_transform, RID, const Transform &)
+	FUNC1(fti_instance_reset, RID)
+
 	/* BLOB SHADOWS */
 	FUNCRID(capsule_shadow)
 	FUNC5(capsule_shadow_update, RID, const Vector3 &, real_t, const Vector3 &, real_t)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2192,11 +2192,16 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("instances_cull_ray", "from", "to", "scenario"), &VisualServer::_instances_cull_ray_bind, DEFVAL(RID()));
 	ClassDB::bind_method(D_METHOD("instances_cull_convex", "convex", "scenario"), &VisualServer::_instances_cull_convex_bind, DEFVAL(RID()));
 
+	ClassDB::bind_method(D_METHOD("fti_instance_create"), &VisualServer::fti_instance_create);
+	ClassDB::bind_method(D_METHOD("fti_instance_prepare", "fti_instance", "instance"), &VisualServer::fti_instance_prepare);
+	ClassDB::bind_method(D_METHOD("fti_instance_set_transform", "fti_instance", "transform"), &VisualServer::fti_instance_set_transform);
+	ClassDB::bind_method(D_METHOD("fti_instance_reset", "fti_instance"), &VisualServer::fti_instance_reset);
+
 	ClassDB::bind_method(D_METHOD("blob_shadows_set_range", "range"), &VisualServer::blob_shadows_set_range);
 	ClassDB::bind_method(D_METHOD("blob_shadows_set_gamma", "gamma"), &VisualServer::blob_shadows_set_gamma);
 	ClassDB::bind_method(D_METHOD("blob_shadows_set_intensity", "intensity"), &VisualServer::blob_shadows_set_intensity);
-
 #endif
+
 	ClassDB::bind_method(D_METHOD("canvas_create"), &VisualServer::canvas_create);
 	ClassDB::bind_method(D_METHOD("canvas_set_item_mirroring", "canvas", "item", "mirroring"), &VisualServer::canvas_set_item_mirroring);
 	ClassDB::bind_method(D_METHOD("canvas_set_modulate", "canvas", "color"), &VisualServer::canvas_set_modulate);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -39,6 +39,8 @@
 #include "core/rid.h"
 #include "core/variant.h"
 
+using FTIHandle = uint64_t;
+
 class VisualServerCallbacks;
 
 class VisualServer : public Object {
@@ -900,6 +902,12 @@ public:
 	virtual void instance_set_exterior(RID p_instance, bool p_enabled) = 0;
 
 	virtual void instance_set_extra_visibility_margin(RID p_instance, real_t p_margin) = 0;
+
+	/* FTI HELPER API */
+	virtual RID fti_instance_create() = 0;
+	virtual void fti_instance_prepare(RID p_fti_instance, RID p_linked_instance) = 0;
+	virtual void fti_instance_set_transform(RID p_fti_instance, const Transform &p_transform) = 0;
+	virtual void fti_instance_reset(RID p_fti_instance) = 0;
 
 	/* BLOB SHADOWS API */
 	virtual RID capsule_shadow_create() = 0;


### PR DESCRIPTION
#103685 by design removes server side physics interpolation, which has the side effect of removing in-built physics interpolation for users who create 3D nodes directly using servers, rather than via `SceneTree` nodes, and ideally we don't want these users to feel they are "losing out".

This use case is far simpler than `SceneTree` interpolation, because only global xforms need be supported.

There are several options to deal with this area, including:
1) Provide no engine support and leave it to users (as was the case before physics interpolation PRs)
2) Provide support via an `addon`
3) Provide a simple helper in engine code to make this task much easier

This PR provides a simple solution for (3) for `instances` on the server, via a wrapper object called `fti_instance`.
It should be fairly simple to use, although admittedly there are a couple more lines to type than the old system.

The `fti_instance` is created in `VisualServer` like an instance, but must be linked to an `instance` via the `prepare()` call.
Then the user should call `fti_set_transform()` on the `fti_instance` instead of `instance_set_transform()`, and can call `fti_instance_reset()` to reset physics interpolation.

Everything else should work automagically. Nearly everything in 3D works via _instances_ so this should cover most cases. `Cameras` are not covered and would have to be interpolated manually, but as far as I remember this was also the case before #103685.

_Model at 5 ticks per second with FTI_

https://github.com/user-attachments/assets/1ce0407d-bb56-4664-ad4e-6d3b7a6e02da

## Usage Example
```gdscript
# VisualServer expects references to be kept around.
var _mesh
var _instance
var _fti_instance
var _time = 0

func _enter_tree():
	# Create a visual instance (for 3D).
	_instance = VisualServer.instance_create()
	
	# Set the scenario from the world, this ensures it
	# appears with the same objects as the scene.
	var scenario = get_world().scenario
	VisualServer.instance_set_scenario(_instance, scenario)
	
	# Add a mesh to it.
	# Remember, keep the reference.
	_mesh = load("res://Model/scarab.obj")
	VisualServer.instance_set_base(_instance, _mesh)
	
	# Create an FTI instance and link it to the actual instance,
	# so we can use the interpolation functionality.
	_fti_instance = VisualServer.fti_instance_create()
	VisualServer.fti_instance_prepare(_fti_instance, _instance)
	
func _exit_tree():
	# Make sure to free rids when we are finished,
	# to prevent memory leaks.
	VisualServer.free_rid(_fti_instance)
	_fti_instance = RID()
	
	VisualServer.free_rid(_instance)
	_instance = RID()

func _physics_process(delta):
	_time += delta

	# Move the model around.
	VisualServer.fti_instance_set_transform(_fti_instance, Transform(Basis(), Vector3(sin(_time) * 4, 0, 0)))
	
	# Test resetting.
	if Input.is_action_just_pressed("ui_accept"):
		VisualServer.fti_instance_reset(_fti_instance)
```


## Notes
* This also applies in 4.x so a port should also be made for #104269 if we merge the main PRs.
* I did test making the multithreaded versions of the functions just act single threaded and push the wrapped commands directly on the queue, but I *don't think* this should be necessary as the queue can add commands to the tail while being processed, and I don't see any obvious reason the ordering should matter. If there are any problems in the wild though it's fairly easy to change (and it won't cause anything catastrophic, worst case some jitter in multithread mode).
* There are admittedly several ways of doing this, and I'm happy to look at alternative approaches (especially if we can reduce boiler plate further for users), this is just the first that popped into my head.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
