### PR TITLE
Support a `NO_COLOR` environment variable in `doc_status.py`

### DIFF
--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Set
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../"))
 
-from misc.utility.color import STDOUT_COLOR, Ansi, toggle_color
+from misc.utility.color import NO_COLOR, STDOUT_COLOR, Ansi, toggle_color
 
 ################################################################################
 #                                    Config                                    #
@@ -114,6 +114,8 @@ def validate_tag(elem: ET.Element, tag: str) -> None:
 
 
 def color(color: str, string: str) -> str:
+    if NO_COLOR:
+        return string
     color_format = "".join([str(x) for x in colors[color]])
     return f"{color_format}{string}{Ansi.RESET}"
 

--- a/misc/utility/color.py
+++ b/misc/utility/color.py
@@ -9,6 +9,7 @@ from typing import Final
 # to a file, it won't contain color codes. Colors are always enabled on continuous integration.
 
 IS_CI: Final[bool] = bool(os.environ.get("CI"))
+NO_COLOR: Final[bool] = bool(os.environ.get("NO_COLOR"))
 STDOUT_TTY: Final[bool] = bool(sys.stdout.isatty())
 STDERR_TTY: Final[bool] = bool(sys.stderr.isatty())
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixing godotengine/doc-status#29, and [further to this suggestion](https://github.com/godotengine/doc-status/pull/30#issuecomment-2746342443) by @Calinou, this PR adds [`NO_COLOR` support](https://no-color.org/) to `misc/utility/color.py` and consumes it in `doc/tools/doc_status.py`.