### PR TITLE
Add clarifications to PhysicsDirectSpaceState docs on how to get their instance

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Provides direct access to a physics space in the [PhysicsServer2D]. It's used mainly to do queries against objects and areas residing in a given space.
+		[b]Note:[/b] This class is not meant to be instantiated directly. Use [member World2D.direct_space_state] to get the world's physics 2D space state.
 	</description>
 	<tutorials>
 		<link title="Physics introduction">$DOCS_URL/tutorials/physics/physics_introduction.html</link>

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Provides direct access to a physics space in the [PhysicsServer3D]. It's used mainly to do queries against objects and areas residing in a given space.
+		[b]Note:[/b] This class is not meant to be instantiated directly. Use [member World3D.direct_space_state] to get the world's physics 3D space state.
 	</description>
 	<tutorials>
 		<link title="Physics introduction">$DOCS_URL/tutorials/physics/physics_introduction.html</link>


### PR DESCRIPTION
The page https://docs.godotengine.org/en/stable/tutorials/physics/ray-casting.html is excellent to teach users how to use some lower level physics of the game engine, but, it is easy to ignore that page and get lost if the user is not trying to use ray cast (was my case), or prefer to just use the class reference over any tutorial (which is also my case)

So I added a note to some classes in how you are supposed to get their instances, and then use them. Basically giving the user a paper trail if they want to figure out how to use them by themselves.

Please, if there are any other classes that are like that, please give me a heads up so I can also add notes to them.

Also give me a heads up if the wording can be improved. Not native English speaker and all that.