### PR TITLE
Clarify FlowContainer get_line_count explanation in documentation

### DIFF
--- a/doc/classes/FlowContainer.xml
+++ b/doc/classes/FlowContainer.xml
@@ -13,7 +13,7 @@
 		<method name="get_line_count" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the current line count.
+				Returns the number of wrapped lines. (Not the number of items in a line.)
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Make it more obvious that it's not giving you the number of items in a line and avoid restating the name of the function as documentation.

This is godotengine/godot-docs/pull/10451 applied against the engine's xml doc files.
