### PR TITLE
Update PinJoint2D option Angular Limit and Motor logic

### DIFF
--- a/modules/godot_physics_2d/godot_joints_2d.cpp
+++ b/modules/godot_physics_2d/godot_joints_2d.cpp
@@ -256,7 +256,7 @@ void GodotPinJoint2D::solve(real_t p_step) {
 		}
 	}
 
-	if (motor_enabled && !is_joint_at_limit && motor_target_velocity != 0.0 && B) {
+	if (motor_enabled && motor_target_velocity != 0.0 && B) {
 		if (A->get_inv_inertia() != 0.0) {
 			A->apply_torque_impulse(-motor_target_velocity * p_step / A->get_inv_inertia() / A->get_space()->get_solver_iterations());
 		}

--- a/modules/godot_physics_2d/godot_joints_2d.cpp
+++ b/modules/godot_physics_2d/godot_joints_2d.cpp
@@ -180,18 +180,18 @@ bool GodotPinJoint2D::pre_solve(real_t p_step) {
 	}
 	i_sum = 1.0 / (i_sum_local);
 	if (angular_limit_enabled && B) {
-		Vector2 diff_vector = B->get_transform().get_origin() - A->get_transform().get_origin();
-		diff_vector = diff_vector.rotated(-initial_angle);
-		real_t dist = diff_vector.angle();
+		real_t diff_vector = B->get_transform().get_rotation() - A->get_transform().get_rotation();
+		real_t dist = diff_vector - initial_angle;
 		real_t pdist = 0.0;
 		if (dist > angular_limit_upper) {
 			pdist = dist - angular_limit_upper;
 		} else if (dist < angular_limit_lower) {
 			pdist = dist - angular_limit_lower;
 		}
-		real_t error_bias = Math::pow(1.0 - 0.15, 60.0);
+
+		real_t error_bias = Math::pow(1.0 - 0.1, 60.0);
 		// Calculate bias velocity.
-		bias_velocity = -CLAMP((-1.0 - Math::pow(error_bias, p_step)) * pdist / p_step, -get_max_bias(), get_max_bias());
+		bias_velocity = CLAMP((-Math::pow(error_bias, p_step)) * pdist / p_step, -get_max_bias(), get_max_bias());
 		// If the bias velocity is 0, the joint is not at a limit.
 		if (bias_velocity >= -CMP_EPSILON && bias_velocity <= CMP_EPSILON) {
 			j_acc = 0;
@@ -216,32 +216,24 @@ void GodotPinJoint2D::solve(real_t p_step) {
 	} else {
 		rel_vel = -vA;
 	}
-	// Angle limits joint solve step taken from https://github.com/slembcke/Chipmunk2D/blob/d0239ef4599b3688a5a336373f7d0a68426414ba/src/cpRotaryLimitJoint.c
-	if ((angular_limit_enabled || motor_enabled) && B) {
-		// Compute relative rotational velocity.
-		real_t wr = B->get_angular_velocity() - A->get_angular_velocity();
-		// Motor solve part taken from https://github.com/slembcke/Chipmunk2D/blob/d0239ef4599b3688a5a336373f7d0a68426414ba/src/cpSimpleMotor.c
-		if (motor_enabled) {
-			wr -= motor_target_velocity;
-		}
-		real_t j_max = jn_max;
 
-		// Compute normal impulse.
-		real_t j = -(bias_velocity + wr) * i_sum;
-		real_t j_old = j_acc;
-		// Only enable the limits if we have to.
-		if (angular_limit_enabled && is_joint_at_limit) {
-			if (bias_velocity < 0.0) {
-				j_acc = CLAMP(j_old + j, 0.0, j_max);
-			} else {
-				j_acc = CLAMP(j_old + j, -j_max, 0.0);
-			}
-		} else {
-			j_acc = CLAMP(j_old + j, -j_max, j_max);
+	if ((angular_limit_enabled && is_joint_at_limit) && B) {
+		real_t wr = B->get_angular_velocity() - A->get_angular_velocity();
+		real_t j = bias_velocity - wr;
+		if (A->get_inv_inertia() != 0.0) {
+			A->apply_torque_impulse(-j / A->get_inv_inertia() / A->get_space()->get_solver_iterations());
 		}
-		j = j_acc - j_old;
-		A->apply_torque_impulse(-j * A->get_inv_inertia());
-		B->apply_torque_impulse(j * B->get_inv_inertia());
+		if (B->get_inv_inertia() != 0.0) {
+			B->apply_torque_impulse(j / B->get_inv_inertia() / B->get_space()->get_solver_iterations());
+		}
+	}
+	if (motor_enabled && !is_joint_at_limit && motor_target_velocity != 0.0 && B) {
+		if (A->get_inv_inertia() != 0.0) {
+			A->apply_torque_impulse(-motor_target_velocity * p_step / A->get_inv_inertia() / A->get_space()->get_solver_iterations());
+		}
+		if (B->get_inv_inertia() != 0.0) {
+			B->apply_torque_impulse(motor_target_velocity * p_step / B->get_inv_inertia() / B->get_space()->get_solver_iterations());
+		}
 	}
 
 	Vector2 impulse = M.basis_xform(bias - rel_vel - Vector2(softness, softness) * P);
@@ -324,7 +316,7 @@ GodotPinJoint2D::GodotPinJoint2D(const Vector2 &p_pos, GodotBody2D *p_body_a, Go
 	p_body_a->add_constraint(this, 0);
 	if (p_body_b) {
 		p_body_b->add_constraint(this, 1);
-		initial_angle = A->get_transform().get_origin().angle_to_point(B->get_transform().get_origin());
+		initial_angle = B->get_transform().get_rotation() - A->get_transform().get_rotation();
 	}
 }
 

--- a/modules/godot_physics_2d/godot_joints_2d.h
+++ b/modules/godot_physics_2d/godot_joints_2d.h
@@ -91,7 +91,8 @@ class GodotPinJoint2D : public GodotJoint2D {
 	real_t initial_angle = 0.0;
 	real_t bias_velocity = 0.0;
 	real_t jn_max = 0.0;
-	real_t j_acc = 0.0;
+	real_t j_acc_upper = 0.0;
+	real_t j_acc_lower = 0.0;
 	real_t i_sum = 0.0;
 	Vector2 P;
 	real_t softness = 0.0;
@@ -99,6 +100,8 @@ class GodotPinJoint2D : public GodotJoint2D {
 	real_t angular_limit_upper = 0.0;
 	real_t motor_target_velocity = 0.0;
 	bool is_joint_at_limit = false;
+	bool is_joint_at_limit_lower = false;
+	bool is_joint_at_limit_upper = false;
 	bool motor_enabled = false;
 	bool angular_limit_enabled = false;
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/91691, fixes https://github.com/godotengine/godot/issues/88481, fixes https://github.com/godotengine/godot/issues/87513

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
# Explanation
PinJoint2D option Angular Limit and Motor speed currently not working.
Make Angular Limit and Motor option work properly.

![rope_tscn_-_pin-joint-test_-_Godot_Engine](https://github.com/user-attachments/assets/863e89d4-3670-4e9b-89a1-00784cebb9b0)


# After fix



https://github.com/user-attachments/assets/0ab0d27a-699e-46fa-a68e-35007f18bceb




https://github.com/user-attachments/assets/449d8ab9-b205-47ca-af0b-3e50821f4a3b

# Mass difference simulation

Each square has different mass. Rotating same motor speed.

https://github.com/user-attachments/assets/f2be0ec8-c9ca-436d-a622-29f5eae15ca7

# Rope simulation

Use multiple PinJoint2D to make rope, set limit to 

- Upper: 0 (Left side)
- Lower: -45 (Right side)

The left side will not bend as much as possible. But right side will bend to -45 degrees each joint.

https://github.com/user-attachments/assets/35dd98a6-fee0-4ae0-95d7-adc849768729

