### PR TITLE
Fix canvas group ysort

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -443,7 +443,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 			if (!use_canvas_group) {
 				ci->ysort_xform = Transform2D();
 				ci->ysort_modulate = Color(1, 1, 1, 1) / ci->modulate;
-			ci->ysort_index = 0;
+				ci->ysort_index = 0;
 				ci->ysort_parent_abs_z_index = parent_z;
 				child_items[0] = ci;
 				i = 1;


### PR DESCRIPTION
Question: The CanvasGroup node does not render correctly when ysort is enabled.

Test file: [demo.zip](https://github.com/user-attachments/files/19416561/demo.zip)

Current effect:
<img width="498" alt="image" src="https://github.com/user-attachments/assets/90fdd9fa-143c-444c-86cf-390d3391443b" />

Fix:

1. culling problem. As can be seen from the branches that disable ysort, the canvasgroup node itself does not need to participate in the culling directly. But all nodes need to participate in the culling by default in the ysort branch. Two branches actually have different actions.

after fix ysort branch for CanvasGroup
<img width="571" alt="image" src="https://github.com/user-attachments/assets/21fb4486-a843-410d-883f-0b4020c8af3b" />

~~2. modulate problem.  I think there is no need to transfer modulate through `_collect_ysort_children`. While it doesn't change effort, this isn't a big deal.~~ 

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/97682*
* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/91922*