### PR TITLE
Add `constexpr` to `RID` and move `RID` tests to compile time

### DIFF
--- a/core/templates/rid.h
+++ b/core/templates/rid.h
@@ -39,37 +39,37 @@ class RID {
 	uint64_t _id = 0;
 
 public:
-	_ALWAYS_INLINE_ bool operator==(const RID &p_rid) const {
+	_ALWAYS_CONSTEXPR_INLINE_ bool operator==(const RID &p_rid) const {
 		return _id == p_rid._id;
 	}
-	_ALWAYS_INLINE_ bool operator<(const RID &p_rid) const {
+	_ALWAYS_CONSTEXPR_INLINE_ bool operator<(const RID &p_rid) const {
 		return _id < p_rid._id;
 	}
-	_ALWAYS_INLINE_ bool operator<=(const RID &p_rid) const {
+	_ALWAYS_CONSTEXPR_INLINE_ bool operator<=(const RID &p_rid) const {
 		return _id <= p_rid._id;
 	}
-	_ALWAYS_INLINE_ bool operator>(const RID &p_rid) const {
+	_ALWAYS_CONSTEXPR_INLINE_ bool operator>(const RID &p_rid) const {
 		return _id > p_rid._id;
 	}
-	_ALWAYS_INLINE_ bool operator>=(const RID &p_rid) const {
+	_ALWAYS_CONSTEXPR_INLINE_ bool operator>=(const RID &p_rid) const {
 		return _id >= p_rid._id;
 	}
-	_ALWAYS_INLINE_ bool operator!=(const RID &p_rid) const {
+	_ALWAYS_CONSTEXPR_INLINE_ bool operator!=(const RID &p_rid) const {
 		return _id != p_rid._id;
 	}
-	_ALWAYS_INLINE_ bool is_valid() const { return _id != 0; }
-	_ALWAYS_INLINE_ bool is_null() const { return _id == 0; }
+	_ALWAYS_CONSTEXPR_INLINE_ bool is_valid() const { return _id != 0; }
+	_ALWAYS_CONSTEXPR_INLINE_ bool is_null() const { return _id == 0; }
 
-	_ALWAYS_INLINE_ uint32_t get_local_index() const { return _id & 0xFFFFFFFF; }
+	_ALWAYS_CONSTEXPR_INLINE_ uint32_t get_local_index() const { return _id & 0xFFFFFFFF; }
 
-	static _ALWAYS_INLINE_ RID from_uint64(uint64_t p_id) {
+	static _ALWAYS_CONSTEXPR_INLINE_ RID from_uint64(uint64_t p_id) {
 		RID _rid;
 		_rid._id = p_id;
 		return _rid;
 	}
-	_ALWAYS_INLINE_ uint64_t get_id() const { return _id; }
+	_ALWAYS_CONSTEXPR_INLINE_ uint64_t get_id() const { return _id; }
 
-	_ALWAYS_INLINE_ RID() {}
+	_ALWAYS_CONSTEXPR_INLINE_ RID() {}
 };
 
 template <>

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -93,6 +93,15 @@ static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
 #endif
 #endif
 
+// Convenient macros to specify inline and constexpr simultaneously.
+#ifndef _ALWAYS_CONSTEXPR_INLINE_
+#define _ALWAYS_CONSTEXPR_INLINE_ _ALWAYS_INLINE_ constexpr
+#endif
+
+#ifndef _FORCE_CONSTEXPR_INLINE_
+#define _FORCE_CONSTEXPR_INLINE_ _FORCE_INLINE_ constexpr
+#endif
+
 // In some cases [[nodiscard]] will get false positives,
 // we can prevent the warning in specific cases by preceding the call with a cast.
 #ifndef _ALLOW_DISCARD_

--- a/tests/core/templates/test_rid.h
+++ b/tests/core/templates/test_rid.h
@@ -53,64 +53,64 @@
 
 namespace TestRID {
 TEST_CASE("[RID] Default Constructor") {
-	RID rid;
+	constexpr RID rid;
 
-	CHECK(rid.get_id() == 0);
+	static_assert(rid.get_id() == 0);
 }
 
 TEST_CASE("[RID] Factory method") {
-	RID rid = RID::from_uint64(1);
+	constexpr RID rid = RID::from_uint64(1);
 
-	CHECK(rid.get_id() == 1);
+	static_assert(rid.get_id() == 1);
 }
 
 TEST_CASE("[RID] Operators") {
-	RID rid = RID::from_uint64(1);
+	constexpr RID rid = RID::from_uint64(1);
 
-	RID rid_zero = RID::from_uint64(0);
-	RID rid_one = RID::from_uint64(1);
-	RID rid_two = RID::from_uint64(2);
+	constexpr RID rid_zero = RID::from_uint64(0);
+	constexpr RID rid_one = RID::from_uint64(1);
+	constexpr RID rid_two = RID::from_uint64(2);
 
-	CHECK_FALSE(rid == rid_zero);
-	CHECK(rid == rid_one);
-	CHECK_FALSE(rid == rid_two);
+	static_assert(!(rid == rid_zero));
+	static_assert(rid == rid_one);
+	static_assert(!(rid == rid_two));
 
-	CHECK_FALSE(rid < rid_zero);
-	CHECK_FALSE(rid < rid_one);
-	CHECK(rid < rid_two);
+	static_assert(!(rid < rid_zero));
+	static_assert(!(rid < rid_one));
+	static_assert(rid < rid_two);
 
-	CHECK_FALSE(rid <= rid_zero);
-	CHECK(rid <= rid_one);
-	CHECK(rid <= rid_two);
+	static_assert(!(rid <= rid_zero));
+	static_assert(rid <= rid_one);
+	static_assert(rid <= rid_two);
 
-	CHECK(rid > rid_zero);
-	CHECK_FALSE(rid > rid_one);
-	CHECK_FALSE(rid > rid_two);
+	static_assert(rid > rid_zero);
+	static_assert(!(rid > rid_one));
+	static_assert(!(rid > rid_two));
 
-	CHECK(rid >= rid_zero);
-	CHECK(rid >= rid_one);
-	CHECK_FALSE(rid >= rid_two);
+	static_assert(rid >= rid_zero);
+	static_assert(rid >= rid_one);
+	static_assert(!(rid >= rid_two));
 
-	CHECK(rid != rid_zero);
-	CHECK_FALSE(rid != rid_one);
-	CHECK(rid != rid_two);
+	static_assert(rid != rid_zero);
+	static_assert(!(rid != rid_one));
+	static_assert(rid != rid_two);
 }
 
 TEST_CASE("[RID] 'is_valid' & 'is_null'") {
-	RID rid_zero = RID::from_uint64(0);
-	RID rid_one = RID::from_uint64(1);
+	constexpr RID rid_zero = RID::from_uint64(0);
+	constexpr RID rid_one = RID::from_uint64(1);
 
-	CHECK_FALSE(rid_zero.is_valid());
-	CHECK(rid_zero.is_null());
+	static_assert(!rid_zero.is_valid());
+	static_assert(rid_zero.is_null());
 
-	CHECK(rid_one.is_valid());
-	CHECK_FALSE(rid_one.is_null());
+	static_assert(rid_one.is_valid());
+	static_assert(!rid_one.is_null());
 }
 
 TEST_CASE("[RID] 'get_local_index'") {
-	CHECK(RID::from_uint64(1).get_local_index() == 1);
-	CHECK(RID::from_uint64(4'294'967'295).get_local_index() == 4'294'967'295);
-	CHECK(RID::from_uint64(4'294'967'297).get_local_index() == 1);
+	static_assert(RID::from_uint64(1).get_local_index() == 1);
+	static_assert(RID::from_uint64(4'294'967'295).get_local_index() == 4'294'967'295);
+	static_assert(RID::from_uint64(4'294'967'297).get_local_index() == 1);
 }
 
 // This case would let sanitizers realize data races.


### PR DESCRIPTION
Suggested by https://github.com/godotengine/godot-proposals/discussions/11654#discussion-7883134.

I agree with the idea of utilizing `constexpr` and `static_assert` more widely. Here is a small proof-of-concept PR to show what we can gain from this approach.

`RID` is a relative simple struct with no heap allocation, making compile time evaluation possible.

Bonus point: linux template release is slightly smaller.

- master: 76,109,296 bytes
- PR: 76,105,200 bytes (-4KB)

Note `_ALWAYS_INLINE_` still matters. Removing them make binary size 2KB larger than this PR.