### PR TITLE
2d: Use dynamic buffers for instance data

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -2138,7 +2138,17 @@
 		<constant name="UNIFORM_TYPE_INPUT_ATTACHMENT" value="9" enum="UniformType">
 			Input attachment uniform.
 		</constant>
-		<constant name="UNIFORM_TYPE_MAX" value="10" enum="UniformType">
+		<constant name="UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC" value="10" enum="UniformType">
+			Same as UNIFORM_TYPE_UNIFORM_BUFFER but for buffers created with BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT.
+			[b]Note:[/b] This flag is not available to GD users due to being too dangerous (i.e. wrong usage can result in visual glitches).
+			It's exposed in case GD users receive from Godot a buffer created with such flag.
+		</constant>
+		<constant name="UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC" value="11" enum="UniformType">
+			Same as UNIFORM_TYPE_STORAGE_BUFFER but for buffers created with BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT.
+			[b]Note:[/b] This flag is not available to GD users due to being too dangerous (i.e. wrong usage can result in visual glitches).
+			It's exposed in case GD users receive from Godot a buffer created with such flag.
+		</constant>
+		<constant name="UNIFORM_TYPE_MAX" value="12" enum="UniformType">
 			Represents the size of the [enum UniformType] enum.
 		</constant>
 		<constant name="RENDER_PRIMITIVE_POINTS" value="0" enum="RenderPrimitive">

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -47,6 +47,7 @@ class RenderingContextDriverMetal;
 
 class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) RenderingDeviceDriverMetal : public RenderingDeviceDriver {
 	friend struct ShaderCacheEntry;
+	friend class MDCommandBuffer;
 
 	template <typename T>
 	using Result = std::variant<T, Error>;
@@ -58,6 +59,10 @@ class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) RenderingDeviceDriverMet
 	id<MTLDevice> device = nil;
 
 	uint32_t frame_count = 1;
+	/// frame_index is a cyclic counter derived from the current frame number modulo frame_count,
+	/// cycling through values from 0 to frame_count - 1
+	uint32_t frame_index = 0;
+	uint32_t frames_drawn = 0;
 
 	uint32_t version_major = 2;
 	uint32_t version_minor = 0;

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -57,6 +57,8 @@
 static const uint32_t BREADCRUMB_BUFFER_ENTRIES = 512u;
 #endif
 
+static const uint32_t MAX_DYNAMIC_BUFFERS = 8u; // Minimum guaranteed by Vulkan.
+
 static const VkFormat RD_TO_VK_FORMAT[RDD::DATA_FORMAT_MAX] = {
 	VK_FORMAT_R4G4_UNORM_PACK8,
 	VK_FORMAT_R4G4B4A4_UNORM_PACK16,
@@ -1467,7 +1469,7 @@ Error RenderingDeviceDriverVulkan::initialize(uint32_t p_device_index, uint32_t 
 	max_descriptor_sets_per_pool = GLOBAL_GET("rendering/rendering_device/vulkan/max_descriptors_per_pool");
 
 #if defined(DEBUG_ENABLED) || defined(DEV_ENABLED)
-	breadcrumb_buffer = buffer_create(2u * sizeof(uint32_t) * BREADCRUMB_BUFFER_ENTRIES, BufferUsageBits::BUFFER_USAGE_TRANSFER_TO_BIT, MemoryAllocationType::MEMORY_ALLOCATION_TYPE_CPU);
+	breadcrumb_buffer = buffer_create(2u * sizeof(uint32_t) * BREADCRUMB_BUFFER_ENTRIES, BufferUsageBits::BUFFER_USAGE_TRANSFER_TO_BIT, MemoryAllocationType::MEMORY_ALLOCATION_TYPE_CPU, UINT64_MAX);
 #endif
 
 #if defined(SWAPPY_FRAME_PACING_ENABLED)
@@ -1530,11 +1532,28 @@ static_assert(ENUM_MEMBERS_EQUAL(RDD::BUFFER_USAGE_VERTEX_BIT, VK_BUFFER_USAGE_V
 static_assert(ENUM_MEMBERS_EQUAL(RDD::BUFFER_USAGE_INDIRECT_BIT, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT));
 static_assert(ENUM_MEMBERS_EQUAL(RDD::BUFFER_USAGE_DEVICE_ADDRESS_BIT, VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT));
 
-RDD::BufferID RenderingDeviceDriverVulkan::buffer_create(uint64_t p_size, BitField<BufferUsageBits> p_usage, MemoryAllocationType p_allocation_type) {
+RDD::BufferID RenderingDeviceDriverVulkan::buffer_create(uint64_t p_size, BitField<BufferUsageBits> p_usage, MemoryAllocationType p_allocation_type, uint64_t p_frames_drawn) {
+	uint32_t alignment = 16u; // 16 bytes is reasonable.
+	if (p_usage.has_flag(BUFFER_USAGE_UNIFORM_BIT)) {
+		// Some GPUs (e.g. NVIDIA) have absurdly high alignments, like 256 bytes.
+		alignment = MAX(alignment, physical_device_properties.limits.minUniformBufferOffsetAlignment);
+	}
+	if (p_usage.has_flag(BUFFER_USAGE_STORAGE_BIT)) {
+		// This shouldn't be a problem since it's often <= 16 bytes. But do it just in case.
+		alignment = MAX(alignment, physical_device_properties.limits.minStorageBufferOffsetAlignment);
+	}
+	// Align the size. This is specially important for BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT buffers.
+	// For the rest, it should work thanks to VMA taking care of the details. But still align just in case.
+	p_size = STEPIFY(p_size, alignment);
+
+	const size_t original_size = p_size;
+	if (p_usage.has_flag(BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT)) {
+		p_size = p_size * frame_count;
+	}
 	VkBufferCreateInfo create_info = {};
 	create_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
 	create_info.size = p_size;
-	create_info.usage = p_usage;
+	create_info.usage = p_usage & ~BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT;
 	create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
 	VmaMemoryUsage vma_usage = VMA_MEMORY_USAGE_UNKNOWN;
@@ -1566,6 +1585,9 @@ RDD::BufferID RenderingDeviceDriverVulkan::buffer_create(uint64_t p_size, BitFie
 				// We must set it right now or else vmaFindMemoryTypeIndexForBufferInfo will use wrong parameters.
 				alloc_create_info.usage = vma_usage;
 			}
+			if (p_usage.has_flag(BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT)) {
+				alloc_create_info.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
+			}
 			alloc_create_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 			if (p_size <= SMALL_ALLOCATION_MAX_SIZE) {
 				uint32_t mem_type_index = 0;
@@ -1594,11 +1616,26 @@ RDD::BufferID RenderingDeviceDriverVulkan::buffer_create(uint64_t p_size, BitFie
 	}
 
 	// Bookkeep.
-	BufferInfo *buf_info = VersatileResource::allocate<BufferInfo>(resources_allocator);
+	BufferInfo *buf_info;
+	if (p_usage.has_flag(BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT)) {
+		void *persistent_ptr = nullptr;
+		VkResult err = vmaMapMemory(allocator, allocation, &persistent_ptr);
+		ERR_FAIL_COND_V_MSG(err, BufferID(), "vmaMapMemory failed with error " + itos(err) + ".");
+
+		BufferDynamicInfo *dyn_buffer = VersatileResource::allocate<BufferDynamicInfo>(resources_allocator);
+		buf_info = dyn_buffer;
+#ifdef DEBUG_ENABLED
+		dyn_buffer->last_frame_mapped = p_frames_drawn - 1ul;
+#endif
+		dyn_buffer->frame_idx = 0u;
+		dyn_buffer->persistent_ptr = (uint8_t *)persistent_ptr;
+	} else {
+		buf_info = VersatileResource::allocate<BufferInfo>(resources_allocator);
+	}
 	buf_info->vk_buffer = vk_buffer;
 	buf_info->allocation.handle = allocation;
 	buf_info->allocation.size = alloc_info.size;
-	buf_info->size = p_size;
+	buf_info->size = original_size;
 
 	return BufferID(buf_info);
 }
@@ -1626,6 +1663,10 @@ void RenderingDeviceDriverVulkan::buffer_free(BufferID p_buffer) {
 		vkDestroyBufferView(vk_device, buf_info->vk_view, VKC::get_allocation_callbacks(VK_OBJECT_TYPE_BUFFER_VIEW));
 	}
 
+	if (buf_info->is_dynamic()) {
+		vmaUnmapMemory(allocator, buf_info->allocation.handle);
+	}
+
 	if (!Engine::get_singleton()->is_extra_gpu_memory_tracking_enabled()) {
 		vmaDestroyBuffer(allocator, buf_info->vk_buffer, buf_info->allocation.handle);
 	} else {
@@ -1633,7 +1674,11 @@ void RenderingDeviceDriverVulkan::buffer_free(BufferID p_buffer) {
 		vmaFreeMemory(allocator, buf_info->allocation.handle);
 	}
 
-	VersatileResource::free(resources_allocator, buf_info);
+	if (buf_info->is_dynamic()) {
+		VersatileResource::free(resources_allocator, (BufferDynamicInfo *)buf_info);
+	} else {
+		VersatileResource::free(resources_allocator, buf_info);
+	}
 }
 
 uint64_t RenderingDeviceDriverVulkan::buffer_get_allocation_size(BufferID p_buffer) {
@@ -1643,6 +1688,7 @@ uint64_t RenderingDeviceDriverVulkan::buffer_get_allocation_size(BufferID p_buff
 
 uint8_t *RenderingDeviceDriverVulkan::buffer_map(BufferID p_buffer) {
 	const BufferInfo *buf_info = (const BufferInfo *)p_buffer.id;
+	ERR_FAIL_COND_V_MSG(buf_info->is_dynamic(), nullptr, "Buffer must NOT have BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT. Use buffer_persistent_map_advance() instead.");
 	void *data_ptr = nullptr;
 	VkResult err = vmaMapMemory(allocator, buf_info->allocation.handle, &data_ptr);
 	ERR_FAIL_COND_V_MSG(err, nullptr, "vmaMapMemory failed with error " + itos(err) + ".");
@@ -1652,6 +1698,38 @@ uint8_t *RenderingDeviceDriverVulkan::buffer_map(BufferID p_buffer) {
 void RenderingDeviceDriverVulkan::buffer_unmap(BufferID p_buffer) {
 	const BufferInfo *buf_info = (const BufferInfo *)p_buffer.id;
 	vmaUnmapMemory(allocator, buf_info->allocation.handle);
+}
+
+uint8_t *RenderingDeviceDriverVulkan::buffer_persistent_map_advance(BufferID p_buffer, uint64_t p_frames_drawn) {
+	BufferDynamicInfo *buf_info = (BufferDynamicInfo *)p_buffer.id;
+	ERR_FAIL_COND_V_MSG(!buf_info->is_dynamic(), nullptr, "Buffer must have BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT. Use buffer_map() instead.");
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_V_MSG(buf_info->last_frame_mapped == p_frames_drawn, nullptr, "Buffers with BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT must only be mapped once per frame. Otherwise there could be race conditions with the GPU. Amalgamate all data uploading into one map(), use an extra buffer or remove the bit.");
+	buf_info->last_frame_mapped = p_frames_drawn;
+#endif
+	buf_info->frame_idx = (buf_info->frame_idx + 1u) % frame_count;
+	return buf_info->persistent_ptr + buf_info->frame_idx * buf_info->size;
+}
+
+void RenderingDeviceDriverVulkan::buffer_flush(BufferID p_buffer) {
+	BufferDynamicInfo *buf_info = (BufferDynamicInfo *)p_buffer.id;
+
+	VkMemoryPropertyFlags memPropFlags;
+	vmaGetAllocationMemoryProperties(allocator, buf_info->allocation.handle, &memPropFlags);
+
+	const bool needs_flushing = !(memPropFlags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+
+	if (needs_flushing) {
+		if (buf_info->is_dynamic()) {
+			pending_flushes.allocations.push_back(buf_info->allocation.handle);
+			pending_flushes.offsets.push_back(buf_info->frame_idx * buf_info->size);
+			pending_flushes.sizes.push_back(buf_info->size);
+		} else {
+			pending_flushes.allocations.push_back(buf_info->allocation.handle);
+			pending_flushes.offsets.push_back(0u);
+			pending_flushes.sizes.push_back(VK_WHOLE_SIZE);
+		}
+	}
 }
 
 uint64_t RenderingDeviceDriverVulkan::buffer_get_device_address(BufferID p_buffer) {
@@ -2595,6 +2673,18 @@ Error RenderingDeviceDriverVulkan::command_queue_execute_and_present(CommandQueu
 		// FIXME: Allow specifying the stage mask in more detail.
 		wait_semaphores.push_back(VkSemaphore(p_wait_semaphores[i].id));
 		wait_semaphores_stages.push_back(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+	}
+
+	if (!pending_flushes.allocations.is_empty()) {
+		// We must do this now, even if p_cmd_buffers is empty; because afterwards pending_flushes.allocations
+		// could become dangling. We cannot delay this call for the next frame(s).
+		err = vmaFlushAllocations(allocator, pending_flushes.allocations.size(),
+				pending_flushes.allocations.ptr(), pending_flushes.offsets.ptr(),
+				pending_flushes.sizes.ptr());
+		pending_flushes.allocations.clear();
+		pending_flushes.offsets.clear();
+		pending_flushes.sizes.clear();
+		ERR_FAIL_COND_V(err != VK_SUCCESS, FAILED);
 	}
 
 	if (p_cmd_buffers.size() > 0) {
@@ -3614,7 +3704,7 @@ Vector<uint8_t> RenderingDeviceDriverVulkan::shader_compile_binary_from_spirv(Ve
 	return ret;
 }
 
-RDD::ShaderID RenderingDeviceDriverVulkan::shader_create_from_bytecode(const Vector<uint8_t> &p_shader_binary, ShaderDescription &r_shader_desc, String &r_name, const Vector<ImmutableSampler> &p_immutable_samplers) {
+RDD::ShaderID RenderingDeviceDriverVulkan::shader_create_from_bytecode(const Vector<uint8_t> &p_shader_binary, ShaderDescription &r_shader_desc, String &r_name, const Vector<ImmutableSampler> &p_immutable_samplers, const Vector<uint64_t> &p_dynamic_buffers) {
 	r_shader_desc = {}; // Driver-agnostic.
 	ShaderInfo shader_info; // Driver-specific.
 
@@ -3721,10 +3811,28 @@ RDD::ShaderID RenderingDeviceDriverVulkan::shader_create_from_bytecode(const Vec
 					layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
 				} break;
 				case UNIFORM_TYPE_UNIFORM_BUFFER: {
-					layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+					const uint64_t key = DynamicBuffer::encode(i, layout_binding.binding);
+					if (p_dynamic_buffers.find(key) >= 0) {
+						layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
+						info.type = UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC;
+					} else {
+						layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+					}
+				} break;
+				case UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC: {
+					layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
 				} break;
 				case UNIFORM_TYPE_STORAGE_BUFFER: {
-					layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+					const uint64_t key = DynamicBuffer::encode(i, layout_binding.binding);
+					if (p_dynamic_buffers.find(key) >= 0) {
+						layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
+						info.type = UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC;
+					} else {
+						layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+					}
+				} break;
+				case UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC: {
+					layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
 				} break;
 				case UNIFORM_TYPE_INPUT_ATTACHMENT: {
 					layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
@@ -3990,10 +4098,24 @@ VkDescriptorPool RenderingDeviceDriverVulkan::_descriptor_set_pool_find_or_creat
 			curr_vk_size++;
 			vk_sizes_count++;
 		}
+		if (p_key.uniform_type[UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC]) {
+			*curr_vk_size = {};
+			curr_vk_size->type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
+			curr_vk_size->descriptorCount = p_key.uniform_type[UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC] * max_descriptor_sets_per_pool;
+			curr_vk_size++;
+			vk_sizes_count++;
+		}
 		if (p_key.uniform_type[UNIFORM_TYPE_STORAGE_BUFFER]) {
 			*curr_vk_size = {};
 			curr_vk_size->type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
 			curr_vk_size->descriptorCount = p_key.uniform_type[UNIFORM_TYPE_STORAGE_BUFFER] * max_descriptor_sets_per_pool;
+			curr_vk_size++;
+			vk_sizes_count++;
+		}
+		if (p_key.uniform_type[UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC]) {
+			*curr_vk_size = {};
+			curr_vk_size->type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
+			curr_vk_size->descriptorCount = p_key.uniform_type[UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC] * max_descriptor_sets_per_pool;
 			curr_vk_size++;
 			vk_sizes_count++;
 		}
@@ -4060,6 +4182,12 @@ RDD::UniformSetID RenderingDeviceDriverVulkan::uniform_set_create(VectorView<Bou
 		p_linear_pool_index = -1;
 	}
 	DescriptorSetPoolKey pool_key;
+
+	// We first gather dynamic arrays in a local array because TightLocalVector's
+	// growth is not efficient when the number of elements is unknown.
+	BufferInfo const *dynamic_buffers[MAX_DYNAMIC_BUFFERS];
+	uint32_t num_dynamic_buffers = 0u;
+
 	// Immutable samplers will be skipped so we need to track the number of vk_writes used.
 	VkWriteDescriptorSet *vk_writes = ALLOCA_ARRAY(VkWriteDescriptorSet, p_uniforms.size());
 	uint32_t writes_amount = 0;
@@ -4195,7 +4323,26 @@ RDD::UniformSetID RenderingDeviceDriverVulkan::uniform_set_create(VectorView<Bou
 				vk_buf_info->buffer = buf_info->vk_buffer;
 				vk_buf_info->range = buf_info->size;
 
+				ERR_FAIL_COND_V_MSG(buf_info->is_dynamic(), UniformSetID(),
+						"Sent a buffer with BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT but binding (" + itos(uniform.binding) + "), set (" + itos(p_set_index) + ") is UNIFORM_TYPE_UNIFORM_BUFFER instead of UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC.");
+
 				vk_writes[writes_amount].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+				vk_writes[writes_amount].pBufferInfo = vk_buf_info;
+			} break;
+			case UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC: {
+				const BufferInfo *buf_info = (const BufferInfo *)uniform.ids[0].id;
+				VkDescriptorBufferInfo *vk_buf_info = ALLOCA_SINGLE(VkDescriptorBufferInfo);
+				*vk_buf_info = {};
+				vk_buf_info->buffer = buf_info->vk_buffer;
+				vk_buf_info->range = buf_info->size;
+
+				ERR_FAIL_COND_V_MSG(!buf_info->is_dynamic(), UniformSetID(),
+						"Sent a buffer without BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT but binding (" + itos(uniform.binding) + "), set (" + itos(p_set_index) + ") is UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC instead of UNIFORM_TYPE_UNIFORM_BUFFER.");
+				ERR_FAIL_COND_V_MSG(num_dynamic_buffers >= MAX_DYNAMIC_BUFFERS, UniformSetID(),
+						"Uniform set exceeded the limit of dynamic/persistent buffers. (" + itos(MAX_DYNAMIC_BUFFERS) + ").");
+
+				dynamic_buffers[num_dynamic_buffers++] = buf_info;
+				vk_writes[writes_amount].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
 				vk_writes[writes_amount].pBufferInfo = vk_buf_info;
 			} break;
 			case UNIFORM_TYPE_STORAGE_BUFFER: {
@@ -4205,7 +4352,26 @@ RDD::UniformSetID RenderingDeviceDriverVulkan::uniform_set_create(VectorView<Bou
 				vk_buf_info->buffer = buf_info->vk_buffer;
 				vk_buf_info->range = buf_info->size;
 
+				ERR_FAIL_COND_V_MSG(buf_info->is_dynamic(), UniformSetID(),
+						"Sent a buffer with BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT but binding (" + itos(uniform.binding) + "), set (" + itos(p_set_index) + ") is UNIFORM_TYPE_STORAGE_BUFFER instead of UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC.");
+
 				vk_writes[writes_amount].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+				vk_writes[writes_amount].pBufferInfo = vk_buf_info;
+			} break;
+			case UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC: {
+				const BufferInfo *buf_info = (const BufferInfo *)uniform.ids[0].id;
+				VkDescriptorBufferInfo *vk_buf_info = ALLOCA_SINGLE(VkDescriptorBufferInfo);
+				*vk_buf_info = {};
+				vk_buf_info->buffer = buf_info->vk_buffer;
+				vk_buf_info->range = buf_info->size;
+
+				ERR_FAIL_COND_V_MSG(!buf_info->is_dynamic(), UniformSetID(),
+						"Sent a buffer without BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT but binding (" + itos(uniform.binding) + "), set (" + itos(p_set_index) + ") is UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC instead of UNIFORM_TYPE_STORAGE_BUFFER.");
+				ERR_FAIL_COND_V_MSG(num_dynamic_buffers >= MAX_DYNAMIC_BUFFERS, UniformSetID(),
+						"Uniform set exceeded the limit of dynamic/persistent buffers. (" + itos(MAX_DYNAMIC_BUFFERS) + ").");
+
+				dynamic_buffers[num_dynamic_buffers++] = buf_info;
+				vk_writes[writes_amount].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
 				vk_writes[writes_amount].pBufferInfo = vk_buf_info;
 			} break;
 			case UNIFORM_TYPE_INPUT_ATTACHMENT: {
@@ -4271,6 +4437,10 @@ RDD::UniformSetID RenderingDeviceDriverVulkan::uniform_set_create(VectorView<Bou
 		usi->vk_descriptor_pool = vk_pool;
 	}
 	usi->pool_sets_it = pool_sets_it;
+	usi->dynamic_buffers.resize(num_dynamic_buffers);
+	for (uint32_t i = 0u; i < num_dynamic_buffers; ++i) {
+		usi->dynamic_buffers[i] = dynamic_buffers[i];
+	}
 
 	return UniformSetID(usi);
 }
@@ -4853,7 +5023,17 @@ void RenderingDeviceDriverVulkan::command_bind_render_pipeline(CommandBufferID p
 void RenderingDeviceDriverVulkan::command_bind_render_uniform_set(CommandBufferID p_cmd_buffer, UniformSetID p_uniform_set, ShaderID p_shader, uint32_t p_set_index) {
 	const ShaderInfo *shader_info = (const ShaderInfo *)p_shader.id;
 	const UniformSetInfo *usi = (const UniformSetInfo *)p_uniform_set.id;
-	vkCmdBindDescriptorSets((VkCommandBuffer)p_cmd_buffer.id, VK_PIPELINE_BIND_POINT_GRAPHICS, shader_info->vk_pipeline_layout, p_set_index, 1, &usi->vk_descriptor_set, 0, nullptr);
+
+	// At this point this assert should already have been validated.
+	DEV_ASSERT(usi->dynamic_buffers.size() <= MAX_DYNAMIC_BUFFERS);
+
+	uint32_t dynamic_offsets[MAX_DYNAMIC_BUFFERS];
+	const uint32_t dynamic_offset_count = usi->dynamic_buffers.size();
+	for (uint32_t i = 0u; i < dynamic_offset_count; ++i) {
+		dynamic_offsets[i] = uint32_t(usi->dynamic_buffers[i]->frame_idx * usi->dynamic_buffers[i]->size);
+	}
+
+	vkCmdBindDescriptorSets((VkCommandBuffer)p_cmd_buffer.id, VK_PIPELINE_BIND_POINT_GRAPHICS, shader_info->vk_pipeline_layout, p_set_index, 1, &usi->vk_descriptor_set, dynamic_offset_count, dynamic_offsets);
 }
 
 void RenderingDeviceDriverVulkan::command_bind_render_uniform_sets(CommandBufferID p_cmd_buffer, VectorView<UniformSetID> p_uniform_sets, ShaderID p_shader, uint32_t p_first_set_index, uint32_t p_set_count) {
@@ -4865,12 +5045,25 @@ void RenderingDeviceDriverVulkan::command_bind_render_uniform_sets(CommandBuffer
 	sets.clear();
 	sets.resize(p_set_count);
 
+	uint32_t dynamic_offsets[MAX_DYNAMIC_BUFFERS];
+	uint32_t curr_dynamic_offset = 0u;
+
 	for (uint32_t i = 0; i < p_set_count; i++) {
-		sets[i] = ((const UniformSetInfo *)p_uniform_sets[i].id)->vk_descriptor_set;
+		const UniformSetInfo *usi = (const UniformSetInfo *)p_uniform_sets[i].id;
+
+		sets[i] = usi->vk_descriptor_set;
+
+		// At this point this assert should already have been validated.
+		DEV_ASSERT(curr_dynamic_offset + usi->dynamic_buffers.size() <= MAX_DYNAMIC_BUFFERS);
+
+		const uint32_t dynamic_offset_count = usi->dynamic_buffers.size();
+		for (uint32_t j = 0u; j < dynamic_offset_count; ++j) {
+			dynamic_offsets[curr_dynamic_offset++] = uint32_t(usi->dynamic_buffers[j]->frame_idx * usi->dynamic_buffers[j]->size);
+		}
 	}
 
 	const ShaderInfo *shader_info = (const ShaderInfo *)p_shader.id;
-	vkCmdBindDescriptorSets((VkCommandBuffer)p_cmd_buffer.id, VK_PIPELINE_BIND_POINT_GRAPHICS, shader_info->vk_pipeline_layout, p_first_set_index, p_set_count, &sets[0], 0, nullptr);
+	vkCmdBindDescriptorSets((VkCommandBuffer)p_cmd_buffer.id, VK_PIPELINE_BIND_POINT_GRAPHICS, shader_info->vk_pipeline_layout, p_first_set_index, p_set_count, &sets[0], curr_dynamic_offset, dynamic_offsets);
 }
 
 void RenderingDeviceDriverVulkan::command_render_draw(CommandBufferID p_cmd_buffer, uint32_t p_vertex_count, uint32_t p_instance_count, uint32_t p_base_vertex, uint32_t p_first_instance) {
@@ -5285,7 +5478,17 @@ void RenderingDeviceDriverVulkan::command_bind_compute_pipeline(CommandBufferID 
 void RenderingDeviceDriverVulkan::command_bind_compute_uniform_set(CommandBufferID p_cmd_buffer, UniformSetID p_uniform_set, ShaderID p_shader, uint32_t p_set_index) {
 	const ShaderInfo *shader_info = (const ShaderInfo *)p_shader.id;
 	const UniformSetInfo *usi = (const UniformSetInfo *)p_uniform_set.id;
-	vkCmdBindDescriptorSets((VkCommandBuffer)p_cmd_buffer.id, VK_PIPELINE_BIND_POINT_COMPUTE, shader_info->vk_pipeline_layout, p_set_index, 1, &usi->vk_descriptor_set, 0, nullptr);
+
+	// At this point this assert should already have been validated.
+	DEV_ASSERT(usi->dynamic_buffers.size() <= MAX_DYNAMIC_BUFFERS);
+
+	uint32_t dynamic_offsets[MAX_DYNAMIC_BUFFERS];
+	const uint32_t dynamic_offset_count = usi->dynamic_buffers.size();
+	for (uint32_t i = 0u; i < dynamic_offset_count; ++i) {
+		dynamic_offsets[i] = uint32_t(usi->dynamic_buffers[i]->frame_idx * usi->dynamic_buffers[i]->size);
+	}
+
+	vkCmdBindDescriptorSets((VkCommandBuffer)p_cmd_buffer.id, VK_PIPELINE_BIND_POINT_COMPUTE, shader_info->vk_pipeline_layout, p_set_index, 1, &usi->vk_descriptor_set, dynamic_offset_count, dynamic_offsets);
 }
 
 void RenderingDeviceDriverVulkan::command_bind_compute_uniform_sets(CommandBufferID p_cmd_buffer, VectorView<UniformSetID> p_uniform_sets, ShaderID p_shader, uint32_t p_first_set_index, uint32_t p_set_count) {
@@ -5297,12 +5500,25 @@ void RenderingDeviceDriverVulkan::command_bind_compute_uniform_sets(CommandBuffe
 	sets.clear();
 	sets.resize(p_set_count);
 
+	uint32_t dynamic_offsets[MAX_DYNAMIC_BUFFERS];
+	uint32_t curr_dynamic_offset = 0u;
+
 	for (uint32_t i = 0; i < p_set_count; i++) {
-		sets[i] = ((const UniformSetInfo *)p_uniform_sets[i].id)->vk_descriptor_set;
+		const UniformSetInfo *usi = (const UniformSetInfo *)p_uniform_sets[i].id;
+
+		sets[i] = usi->vk_descriptor_set;
+
+		// At this point this assert should already have been validated.
+		DEV_ASSERT(curr_dynamic_offset + usi->dynamic_buffers.size() <= MAX_DYNAMIC_BUFFERS);
+
+		const uint32_t dynamic_offset_count = usi->dynamic_buffers.size();
+		for (uint32_t j = 0u; j < dynamic_offset_count; ++j) {
+			dynamic_offsets[curr_dynamic_offset++] = uint32_t(usi->dynamic_buffers[j]->frame_idx * usi->dynamic_buffers[j]->size);
+		}
 	}
 
 	const ShaderInfo *shader_info = (const ShaderInfo *)p_shader.id;
-	vkCmdBindDescriptorSets((VkCommandBuffer)p_cmd_buffer.id, VK_PIPELINE_BIND_POINT_COMPUTE, shader_info->vk_pipeline_layout, p_first_set_index, p_set_count, &sets[0], 0, nullptr);
+	vkCmdBindDescriptorSets((VkCommandBuffer)p_cmd_buffer.id, VK_PIPELINE_BIND_POINT_COMPUTE, shader_info->vk_pipeline_layout, p_first_set_index, p_set_count, &sets[0], curr_dynamic_offset, dynamic_offsets);
 }
 
 void RenderingDeviceDriverVulkan::command_compute_dispatch(CommandBufferID p_cmd_buffer, uint32_t p_x_groups, uint32_t p_y_groups, uint32_t p_z_groups) {

--- a/servers/rendering/multi_uma_buffer.h
+++ b/servers/rendering/multi_uma_buffer.h
@@ -1,0 +1,385 @@
+/**************************************************************************/
+/*  multi_uma_buffer.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "servers/rendering_server.h"
+
+class MultiUmaBufferBase {
+protected:
+	LocalVector<RID> buffers;
+	uint32_t curr_idx = UINT32_MAX;
+	uint64_t last_frame_mapped = UINT64_MAX;
+	const uint32_t max_extra_buffers;
+#ifdef DEBUG_ENABLED
+	const char *debug_name;
+#endif
+
+	MultiUmaBufferBase(uint32_t p_max_extra_buffers, const char *p_debug_name) :
+			max_extra_buffers(p_max_extra_buffers)
+#ifdef DEBUG_ENABLED
+			,
+			debug_name(p_debug_name)
+#endif
+	{
+	}
+
+#ifdef DEV_ENABLED
+	~MultiUmaBufferBase() {
+		DEV_ASSERT(buffers.is_empty() && "Forgot to call uninit()!");
+	}
+#endif
+
+public:
+	void uninit() {
+		if (is_print_verbose_enabled()) {
+			print_line("MultiUmaBuffer '"
+#ifdef DEBUG_ENABLED
+					+ String(debug_name) +
+#else
+					   "{DEBUG_ENABLED unavailable}"
+#endif
+					"' used a total of " + itos(buffers.size()) +
+					" buffers. A large number may indicate a waste of VRAM and can be brought down by tweaking MAX_EXTRA_BUFFERS for this buffer.");
+		}
+
+		RenderingDevice *rd = RD::RenderingDevice::get_singleton();
+
+		for (RID buffer : buffers) {
+			if (buffer.is_valid()) {
+				rd->free(buffer);
+			}
+		}
+
+		buffers.clear();
+	}
+
+	void shrink_to_max_extra_buffers() {
+		DEV_ASSERT(curr_idx == 0u && "This function can only be called after reset and before being upload_and_advance again!");
+
+		RenderingDevice *rd = RD::RenderingDevice::get_singleton();
+
+		uint32_t elem_count = buffers.size();
+
+		if (elem_count > max_extra_buffers) {
+			if (is_print_verbose_enabled()) {
+				print_line("MultiUmaBuffer '"
+#ifdef DEBUG_ENABLED
+						+ String(debug_name) +
+#else
+						   "{DEBUG_ENABLED unavailable}"
+#endif
+						"' peaked to " + itos(elem_count) + " elements and shrinking it to " + itos(max_extra_buffers) +
+						". If you see this message often, then something is wrong with rendering or MAX_EXTRA_BUFFERS needs to be increased.");
+			}
+		}
+
+		while (elem_count > max_extra_buffers) {
+			--elem_count;
+			if (buffers[elem_count].is_valid()) {
+				rd->free(buffers[elem_count]);
+			}
+			buffers.remove_at(elem_count);
+		}
+	}
+};
+
+/// Interface for making it easier to work with UMA.
+///
+/// # What is UMA?
+///
+/// It stands for Unified Memory Architecture. There are two kinds of UMA:
+///	 1. HW UMA. This is the case of iGPUs (specially Android, iOS, Apple ARM-based macOS, PS4 & PS5)
+///		The CPU and GPU share the same die and same memory. So regular RAM and VRAM are internally the
+///		same thing. There may be some differences between them in practice due to cache synchronization
+///		behaviors or the regular BW RAM may be purposely throttled (as is the case of PS4 & PS5).
+///  2. "Pretended UMA". On PC Desktop GPUs with ReBAR enabled can pretend VRAM behaves like normal
+///		RAM, while internally the data is moved across the PCIe Bus. This can cause differences
+///		in execution time of the routines that write to GPU buffers as the region is often uncached
+///		(i.e. write-combined) and PCIe latency and BW is vastly different from regular RAM.
+///		Without ReBAR, the amount of UMA memory is limited to 256MB (shared by the entire system).
+///
+/// Since often this type of memory is uncached, it is not well-suited for downloading GPU -> CPU,
+/// but rather for uploading CPU -> GPU.
+///
+/// # When to use UMA buffers?
+///
+/// UMA buffers have various caveats and improper usage might lead to visual glitches. Therefore they
+/// should be used sparingly, where it makes a difference. Does all of the following check?:
+///	  1. Data is uploaded from CPU to GPU every (or almost every) frame.
+///   2. Data is always uploaded from scratch. Partial uploads are unsupported.
+///	  3. If uploading multiple times per frame (e.g. for multiple passes). The amount of times
+///      per frame is relatively stable (occasional spikes are fine if using MAX_EXTRA_BUFFERS).
+///
+/// # Why the caveats?
+///
+///	This is due to our inability to detect race conditions. If you write to an UMA buffer, submit
+///	GPU commands and then write more data to it, we can't guarantee that you won't be writing to a
+/// region the GPU is currently reading from. Tools like the validation layers cannot detect this
+/// race condition at all, making it very hard to troubleshoot.
+///
+/// Therefore the safest approach is to use an interface that forces users to upload everything at once.
+/// There is one exception for performance: map_raw_for_upload() will return a pointer, and it is your
+/// responsibility to make sure you don't use that pointer again after submitting.
+/// USE THIS API CALL SPARINGLY AND WITH CARE.
+///
+/// Since we forbid uploading more data after we've uploaded to it, this Interface will create
+/// more buffers. This means users will need more UniformSets (i.e. uniform_set_create).
+///
+/// # How to use
+///
+/// Example code 01:
+///		MultiUmaBuffer<1> uma_buffer = MultiUmaBuffer<1>("Debug name displayed if run with --verbose");
+///		uma_buffer.set_size(0, max_size_bytes, false);
+///
+///		for(uint32_t i = 0u; i < num_passes; ++i) {
+///			uma_buffer.prepare_for_upload(); // Creates a new buffer (if none exists already)
+///											 // of max_size_bytes. Must be called.
+///			uma_buffer.upload(0, src_data, size_bytes);
+///
+///			if(!uniform_set[i]) {
+///				RD::Uniform u;
+///				u.binding = 1;
+///				u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC;
+///				u.append_id(uma_buffer._get(0u));
+///				uniform_set[i] = rd->uniform_set_create( ... );
+///			}
+///		}
+///
+///	  // On shutdown (or if you need to call set_size again).
+///	  uma_buffer.uninit();
+///
+/// Example code 02:
+///
+///		uma_buffer.prepare_for_upload();
+///		RID rid = uma_buffer.get_for_upload(0u);
+///		rd->buffer_update(rid, 0, sizeof(BakeParameters), &bake_parameters);
+///		RD::Uniform u; // Skipping full initialization of u. See Example 01.
+///		u.append_id(rid);
+///
+/// Example code 03:
+///
+///		void *dst_data = uma_buffer.map_raw_for_upload(0u);
+///		memcpy(dst_data, src_data, size_bytes);
+///		rd->buffer_flush(uma_buffer._get(0u));
+///		RD::Uniform u; // Skipping full initialization of u. See Example 01.
+///		u.append_id(rid);
+///
+/// # Tricks
+///
+///	Godot's shadow mapping code calls uma_buffer.uniform_buffers._get(-p_pass_offset) (i.e. a negative value)
+/// because for various reasons its shadow mapping code was written like this:
+///
+///		for( uint32_t i = 0u; i < num_passes; ++i ) {
+///			uma_buffer.prepare_for_upload();
+///			uma_buffer.upload(0, src_data, size_bytes);
+///		}
+///		for( uint32_t i = 0u; i < num_passes; ++i ) {
+///			RD::Uniform u;
+///			u.binding = 1;
+///			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC;
+///			u.append_id(uma_buffer._get(-(num_passes - 1u - i)));
+///			uniform_set[i] = rd->uniform_set_create( ... );
+///		}
+///
+/// Every time prepare_for_upload() is called, uma_buffer._get(-idx) will return a different RID(*).
+/// Thus with a negative value we can address previous ones. This is fine as long as the value idx
+/// doesn't exceed the number of times the user called prepare_for_upload() for this frame.
+///
+/// (*)This RID will be returned again on the next frame after the same amount of prepare_for_upload()
+/// calls; unless the number of times it was called exceeded MAX_EXTRA_BUFFERS.
+///
+/// # Template parameters
+///
+///	## NUM_BUFFERS
+///
+/// How many buffers we should track. e.g. instead of doing this:
+///		MultiUmaBuffer<1> omni_lights = /*...*/;
+///		MultiUmaBuffer<1> spot_lights = /*...*/;
+///		MultiUmaBuffer<1> directional_lights = /*...*/;
+///
+///		omni_lights.set_size(0u, omni_size);
+///		spot_lights.set_size(0u, spot_size);
+///		directional_lights.set_size(0u, dir_size);
+///
+///		omni_lights.prepare_for_upload();
+///		spot_lights.prepare_for_upload();
+///		directional_lights.prepare_for_upload();
+///
+/// You can do this:
+///
+///		MultiUmaBuffer<3> lights = /*...*/;
+///
+///		lights.set_size(0u, omni_size);
+///		lights.set_size(1u, spot_size);
+///		lights.set_size(2u, dir_size);
+///
+///		lights.prepare_for_upload();
+///
+/// This approach works as long as all buffers would call prepare_for_upload() at the same time.
+/// It saves some overhead.
+///
+/// ## MAX_EXTRA_BUFFERS
+///
+/// Upper limit on the number of buffers per frame.
+///
+/// There are times where rendering might spike for exceptional reasons, calling prepare_for_upload()
+/// too many times, never to do that again. This will cause an increase in memory usage that will
+/// never be reclaimed until shutdown.
+///
+/// MAX_EXTRA_BUFFERS can be used to handle such spikes, by deallocating the extra buffers.
+/// Example:
+///		MultiUmaBuffer<1, 6> buffer;
+///
+///		// Normal frame (assuming up to 6 passes is considered normal):
+///		for(uint32_t i = 0u; i < 6u; ++i) {
+///			buffer.prepare_for_upload();
+///			...
+///			buffer.upload(...);
+///		}
+///
+///		// Exceptional frame:
+///		for(uint32_t i = 0u; i < 24u; ++i) {
+///			buffer.prepare_for_upload();
+///			...
+///			buffer.upload(...);
+///		}
+///
+///	After the frame is done, those extra 18 buffers will be deleted.
+/// Launching godot with --verbose will print diagnostic information.
+template <uint32_t NUM_BUFFERS, uint32_t MAX_EXTRA_BUFFERS = UINT32_MAX>
+class MultiUmaBuffer : public MultiUmaBufferBase {
+private:
+	uint32_t buffer_sizes[NUM_BUFFERS] = {};
+#ifdef DEV_ENABLED
+	bool can_upload[NUM_BUFFERS] = {};
+#endif
+
+	void push() {
+		RenderingDevice *rd = RD::RenderingDevice::get_singleton();
+		for (uint32_t i = 0u; i < NUM_BUFFERS; ++i) {
+			const bool is_storage = buffer_sizes[i] & 0x80000000u;
+			const uint32_t size_bytes = buffer_sizes[i] & ~0x80000000u;
+			RID buffer;
+			if (is_storage) {
+				buffer = rd->storage_buffer_create(size_bytes, Vector<uint8_t>(), 0, RD::BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT);
+			} else {
+				buffer = rd->uniform_buffer_create(size_bytes, Vector<uint8_t>(), RD::BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT);
+			}
+			buffers.push_back(buffer);
+		}
+	}
+
+public:
+	MultiUmaBuffer(const char *p_debug_name) :
+			MultiUmaBufferBase(MAX_EXTRA_BUFFERS, p_debug_name) {}
+
+	uint32_t get_curr_idx() const { return curr_idx; }
+
+	void set_size(uint32_t idx, uint32_t p_size_bytes, bool p_is_storage) {
+		DEV_ASSERT(buffers.is_empty());
+		buffer_sizes[idx] = p_size_bytes | (p_is_storage ? 0x80000000u : 0u);
+		curr_idx = UINT32_MAX;
+		last_frame_mapped = UINT64_MAX;
+	}
+
+	uint32_t get_size(uint32_t idx) const { return buffer_sizes[idx] & ~0x80000000u; }
+
+	// Gets the raw buffer. Use with care.
+	// If you call this function, make sure to have called prepare_for_upload() first.
+	// Do not call _get() then prepare_for_upload().
+	RID _get(uint32_t idx) {
+		return buffers[curr_idx * NUM_BUFFERS + idx];
+	}
+
+	/**
+	 * @param p_append	True if you wish to append more data to existing buffer.
+	 * @return			True if it's possible to append. False if the internal buffer changed.
+	 */
+	bool prepare_for_map(bool p_append) {
+		RenderingDevice *rd = RD::RenderingDevice::get_singleton();
+		const uint64_t frames_drawn = rd->get_frames_drawn();
+
+		if (last_frame_mapped == frames_drawn) {
+			if (!p_append) {
+				++curr_idx;
+			}
+		} else {
+			p_append = false;
+			curr_idx = 0u;
+			if (max_extra_buffers != UINT32_MAX) {
+				shrink_to_max_extra_buffers();
+			}
+		}
+		last_frame_mapped = frames_drawn;
+		if (curr_idx * NUM_BUFFERS >= buffers.size()) {
+			push();
+		}
+
+#ifdef DEV_ENABLED
+		if (!p_append) {
+			for (size_t i = 0u; i < NUM_BUFFERS; ++i) {
+				can_upload[i] = true;
+			}
+		}
+#endif
+		return !p_append;
+	}
+
+	void prepare_for_upload() {
+		prepare_for_map(false);
+	}
+
+	void *map_raw_for_upload(uint32_t idx) {
+#ifdef DEV_ENABLED
+		DEV_ASSERT(can_upload[idx] && "Forgot to prepare_for_upload first! Or called get_for_upload/upload() twice.");
+		can_upload[idx] = false;
+#endif
+		RenderingDevice *rd = RD::RenderingDevice::get_singleton();
+		return rd->buffer_persistent_map_advance(buffers[curr_idx * NUM_BUFFERS + idx]);
+	}
+
+	RID get_for_upload(uint32_t idx) {
+#ifdef DEV_ENABLED
+		DEV_ASSERT(can_upload[idx] && "Forgot to prepare_for_upload first! Or called get_for_upload/upload() twice.");
+		can_upload[idx] = false;
+#endif
+		return buffers[curr_idx * NUM_BUFFERS + idx];
+	}
+
+	void upload(uint32_t idx, const void *p_src_data, uint32_t size_bytes) {
+#ifdef DEV_ENABLED
+		DEV_ASSERT(can_upload[idx] && "Forgot to prepare_for_upload first! Or called get_for_upload/upload() twice.");
+		can_upload[idx] = false;
+#endif
+		RenderingDevice *rd = RD::RenderingDevice::get_singleton();
+		rd->buffer_update(buffers[curr_idx * NUM_BUFFERS + idx], 0, size_bytes, p_src_data, true);
+	}
+};

--- a/servers/rendering/push_constants_emu.h
+++ b/servers/rendering/push_constants_emu.h
@@ -1,0 +1,255 @@
+/**************************************************************************/
+/*  push_constants_emu.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "servers/rendering_server.h"
+
+class PushConstantsEmuBase {
+public:
+	struct ParamsUniform {
+		RID buffer;
+		RID set;
+	};
+
+protected:
+	LocalVector<ParamsUniform> params_uniform;
+	uint32_t curr_idx = 0u;
+	const uint32_t max_extra_buffers;
+#ifdef DEBUG_ENABLED
+	const char *debug_name;
+#endif
+
+	PushConstantsEmuBase(uint32_t p_max_extra_buffers, const char *p_debug_name) :
+			max_extra_buffers(p_max_extra_buffers)
+#ifdef DEBUG_ENABLED
+			,
+			debug_name(p_debug_name)
+#endif
+	{
+	}
+
+#ifdef DEV_ENABLED
+	~PushConstantsEmuBase() {
+		DEV_ASSERT(params_uniform.is_empty() && "Forgot to call uninit()!");
+	}
+#endif
+
+	void init_base() {
+		RenderingDevice *rd = RD::RenderingDevice::get_singleton();
+		rd->_register_push_constant_emu(this);
+	}
+
+	void uninit_base() {
+		if (is_print_verbose_enabled()) {
+			print_line("PushConstantsEmu '"
+#ifdef DEBUG_ENABLED
+					+ String(debug_name) +
+#else
+					   "{DEBUG_ENABLED unavailable}"
+#endif
+					"' used a total of " + itos(params_uniform.size()) +
+					" buffers. A large number may indicate a waste of VRAM and can be brought down by tweaking MAX_EXTRA_BUFFERS for this buffer.");
+		}
+
+		RenderingDevice *rd = RD::RenderingDevice::get_singleton();
+
+		rd->_unregister_push_constant_emu(this);
+
+		for (const ParamsUniform &pu : params_uniform) {
+			if (pu.set.is_valid()) {
+				rd->free(pu.set);
+			}
+			if (pu.buffer.is_valid()) {
+				rd->free(pu.buffer);
+			}
+		}
+
+		params_uniform.clear();
+	}
+
+	void shrink_to_max_extra_buffers() {
+		DEV_ASSERT(curr_idx == 0u && "This function can only be called after reset and before being upload_and_advance again!");
+
+		RenderingDevice *rd = RD::RenderingDevice::get_singleton();
+
+		uint32_t elem_count = params_uniform.size();
+
+		if (elem_count > max_extra_buffers) {
+			if (is_print_verbose_enabled()) {
+				print_line("PushConstantsEmu '"
+#ifdef DEBUG_ENABLED
+						+ String(debug_name) +
+#else
+						   "{DEBUG_ENABLED unavailable}"
+#endif
+						"' peaked to " + itos(elem_count) + " elements and shrinking it to " + itos(max_extra_buffers) +
+						". If you see this message often, then something is wrong with rendering or MAX_EXTRA_BUFFERS needs to be increased.");
+			}
+		}
+
+		while (elem_count > max_extra_buffers) {
+			--elem_count;
+			if (params_uniform[elem_count].set.is_valid()) {
+				rd->free(params_uniform[elem_count].set);
+			}
+			if (params_uniform[elem_count].buffer.is_valid()) {
+				rd->free(params_uniform[elem_count].buffer);
+			}
+			params_uniform.remove_at(elem_count);
+		}
+	}
+
+public:
+	void _reset() {
+		curr_idx = 0u;
+		if (max_extra_buffers != UINT32_MAX) {
+			shrink_to_max_extra_buffers();
+		}
+	}
+};
+
+/// See MultiUmaBuffer documentation. This is extremely similar, but specifically tailored for PushConstants.
+template <typename T, uint32_t SET_IDX = 1u, uint32_t MAX_EXTRA_BUFFERS = UINT32_MAX>
+class PushConstantsEmu : public PushConstantsEmuBase {
+private:
+	RID shader;
+
+	void push() {
+		RenderingDevice *rd = RD::RenderingDevice::get_singleton();
+
+		ParamsUniform pu;
+		pu.buffer = rd->uniform_buffer_create(sizeof(T), Vector<uint8_t>(), RD::BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT);
+
+		Vector<RD::Uniform> params_uniforms;
+		RD::Uniform u;
+		u.binding = 0;
+		u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC;
+		u.append_id(pu.buffer);
+		params_uniforms.push_back(u);
+
+		pu.set = rd->uniform_set_create(params_uniforms, shader, SET_IDX);
+
+		params_uniform.push_back(pu);
+	}
+
+public:
+	PushConstantsEmu(const char *p_debug_name) :
+			PushConstantsEmuBase(MAX_EXTRA_BUFFERS, p_debug_name) {}
+
+	void init(RID p_shader) {
+		init_base();
+		shader = p_shader;
+	}
+
+	void uninit() {
+		shader = RID();
+		uninit_base();
+	}
+
+	static uint32_t set_idx() { return SET_IDX; }
+
+	ParamsUniform upload_and_advance(const T &p_src_data) {
+		if (curr_idx >= params_uniform.size()) {
+			push();
+		}
+
+		RD::RenderingDevice::get_singleton()->buffer_update(params_uniform[curr_idx].buffer, 0, sizeof(T), &p_src_data, true);
+
+		return params_uniform[curr_idx++];
+	}
+};
+
+/// See PushConstantsEmu. The difference is that PushConstantsEmu creates the set (which is exclusively
+/// used for the push constant) while this version can be used to share the emulated push constants with
+/// other sets.
+///
+/// This code expects that class S implements _create_push_constant_uniform_set(RID) like this:
+///
+///		class MyEffect
+///		{
+///		public:
+///			RID _create_push_constant_uniform_set(RID buffer) {
+///				RD::Uniform u;
+///				u.binding = ...;
+///				u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC;
+///				u.append_id(buffer);
+///				return rd->uniform_set_create(...);
+///			}
+///		};
+///
+///		PushConstantsEmuEmbedded<MyParams, MyEffect> buffer =
+///										PushConstantsEmuEmbedded<MyParams, MyEffect>("debug name");
+template <typename T, typename S, uint32_t MAX_EXTRA_BUFFERS = UINT32_MAX>
+class PushConstantsEmuEmbedded : public PushConstantsEmuBase {
+private:
+#ifdef DEV_ENABLED
+	bool initialized = false;
+#endif
+
+	void push(S *p_embed_owner) {
+		RenderingDevice *rd = RD::RenderingDevice::get_singleton();
+
+		ParamsUniform pu;
+		pu.buffer = rd->uniform_buffer_create(sizeof(T), Vector<uint8_t>(), RD::BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT);
+		pu.set = p_embed_owner->_create_push_constant_uniform_set(pu.buffer);
+		params_uniform.push_back(pu);
+	}
+
+public:
+	PushConstantsEmuEmbedded(const char *p_debug_name) :
+			PushConstantsEmuBase(MAX_EXTRA_BUFFERS, p_debug_name) {}
+
+	void init() {
+#ifdef DEV_ENABLED
+		initialized = true;
+#endif
+		init_base();
+	}
+
+	void uninit() {
+#ifdef DEV_ENABLED
+		initialized = false;
+#endif
+		uninit_base();
+	}
+
+	ParamsUniform upload_and_advance(const T &p_src_data, S *p_embed_owner) {
+		DEV_ASSERT(initialized);
+
+		if (curr_idx >= params_uniform.size()) {
+			push(p_embed_owner);
+		}
+
+		RD::RenderingDevice::get_singleton()->buffer_update(params_uniform[curr_idx].buffer, 0, sizeof(T), &p_src_data, true);
+
+		return params_uniform[curr_idx++];
+	}
+};

--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -39,6 +39,8 @@ using namespace RendererRD;
 
 CopyEffects *CopyEffects::singleton = nullptr;
 
+thread_local LocalVector<RD::Uniform> CopyEffects::uniforms;
+
 CopyEffects *CopyEffects::get_singleton() {
 	return singleton;
 }
@@ -58,14 +60,17 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 		blur_modes.push_back("\n#define MODE_COPY\n"); // BLUR_MODE_COPY
 		blur_modes.push_back("\n#define MODE_SET_COLOR\n"); // BLUR_MODE_SET_COLOR
 
-		blur_raster.shader.initialize(blur_modes);
-		memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
+		Vector<uint64_t> dynamic_buffers;
+		dynamic_buffers.push_back(RDD::DynamicBuffer::encode(blur_raster.push_constant.set_idx(), 0));
+
+		blur_raster.shader.initialize(blur_modes, "", Vector<RD::PipelineImmutableSampler>(), dynamic_buffers);
 		blur_raster.shader_version = blur_raster.shader.version_create();
 
 		for (int i = 0; i < BLUR_MODE_MAX; i++) {
 			blur_raster.pipelines[i].setup(blur_raster.shader.version_get_shader(blur_raster.shader_version, i), RD::RENDER_PRIMITIVE_TRIANGLES, RD::PipelineRasterizationState(), RD::PipelineMultisampleState(), RD::PipelineDepthStencilState(), RD::PipelineColorBlendState::create_disabled(), 0);
 		}
 
+		blur_raster.push_constant.init(blur_raster.shader.version_get_shader(blur_raster.shader_version, 0));
 	} else {
 		// not used in clustered
 		for (int i = 0; i < BLUR_MODE_MAX; i++) {
@@ -74,24 +79,33 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 	}
 
 	{
+		// All the variants use either:
+		//	- 2 textures (src + dst).
+		//	- 3 textures (src + dst + auto exposure).
+		//	- 1 textures (dst) (the "set color" variants).
+#define COPY_SHADER_SOURCE_PLUS_DEST "#define SOURCE_COLOR_SLOT 0\n#define DEST_BUFFER 1\n"
+#define COPY_SHADER_ALL_3 "#define SOURCE_COLOR_SLOT 0\n#define DEST_BUFFER 1\n#define SOURCE_AUTO_EXPOSURE 2\n"
+#define COPY_SHADER_DEST_ONLY "#define DEST_BUFFER 0\n"
+
 		Vector<String> copy_modes;
-		copy_modes.push_back("\n#define MODE_GAUSSIAN_BLUR\n");
-		copy_modes.push_back("\n#define MODE_GAUSSIAN_BLUR\n#define DST_IMAGE_8BIT\n");
-		copy_modes.push_back("\n#define MODE_GAUSSIAN_BLUR\n#define MODE_GLOW\n");
-		copy_modes.push_back("\n#define MODE_GAUSSIAN_BLUR\n#define MODE_GLOW\n#define GLOW_USE_AUTO_EXPOSURE\n");
-		copy_modes.push_back("\n#define MODE_SIMPLE_COPY\n");
-		copy_modes.push_back("\n#define MODE_SIMPLE_COPY\n#define DST_IMAGE_8BIT\n");
-		copy_modes.push_back("\n#define MODE_SIMPLE_COPY_DEPTH\n");
-		copy_modes.push_back("\n#define MODE_SET_COLOR\n");
-		copy_modes.push_back("\n#define MODE_SET_COLOR\n#define DST_IMAGE_8BIT\n");
-		copy_modes.push_back("\n#define MODE_MIPMAP\n");
-		copy_modes.push_back("\n#define MODE_LINEARIZE_DEPTH_COPY\n");
-		copy_modes.push_back("\n#define MODE_CUBEMAP_TO_PANORAMA\n");
-		copy_modes.push_back("\n#define MODE_CUBEMAP_ARRAY_TO_PANORAMA\n");
+		copy_modes.push_back("\n#define MODE_GAUSSIAN_BLUR\n" COPY_SHADER_SOURCE_PLUS_DEST);
+		copy_modes.push_back("\n#define MODE_GAUSSIAN_BLUR\n#define DST_IMAGE_8BIT\n" COPY_SHADER_SOURCE_PLUS_DEST);
+		copy_modes.push_back("\n#define MODE_GAUSSIAN_BLUR\n#define MODE_GLOW\n" COPY_SHADER_SOURCE_PLUS_DEST);
+		copy_modes.push_back("\n#define MODE_GAUSSIAN_BLUR\n#define MODE_GLOW\n#define GLOW_USE_AUTO_EXPOSURE\n" COPY_SHADER_ALL_3);
+		copy_modes.push_back("\n#define MODE_SIMPLE_COPY\n" COPY_SHADER_SOURCE_PLUS_DEST);
+		copy_modes.push_back("\n#define MODE_SIMPLE_COPY\n#define DST_IMAGE_8BIT\n" COPY_SHADER_SOURCE_PLUS_DEST);
+		copy_modes.push_back("\n#define MODE_SIMPLE_COPY_DEPTH\n" COPY_SHADER_SOURCE_PLUS_DEST);
+		copy_modes.push_back("\n#define MODE_SET_COLOR\n" COPY_SHADER_DEST_ONLY);
+		copy_modes.push_back("\n#define MODE_SET_COLOR\n#define DST_IMAGE_8BIT\n" COPY_SHADER_DEST_ONLY);
+		copy_modes.push_back("\n#define MODE_MIPMAP\n" COPY_SHADER_SOURCE_PLUS_DEST);
+		copy_modes.push_back("\n#define MODE_LINEARIZE_DEPTH_COPY\n" COPY_SHADER_SOURCE_PLUS_DEST);
+		copy_modes.push_back("\n#define MODE_CUBEMAP_TO_PANORAMA\n" COPY_SHADER_SOURCE_PLUS_DEST);
+		copy_modes.push_back("\n#define MODE_CUBEMAP_ARRAY_TO_PANORAMA\n" COPY_SHADER_SOURCE_PLUS_DEST);
 
-		copy.shader.initialize(copy_modes);
-		memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+		Vector<uint64_t> dynamic_buffers;
+		dynamic_buffers.push_back(RDD::DynamicBuffer::encode(copy.push_constant.set_idx(), 0));
 
+		copy.shader.initialize(copy_modes, "", Vector<RD::PipelineImmutableSampler>(), dynamic_buffers);
 		copy.shader_version = copy.shader.version_create();
 
 		for (int i = 0; i < COPY_MODE_MAX; i++) {
@@ -99,6 +113,13 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 				copy.pipelines[i] = RD::get_singleton()->compute_pipeline_create(copy.shader.version_get_shader(copy.shader_version, i));
 			}
 		}
+
+		// <TF>
+		// @ShadyTF
+		// replace push constants with UBO
+		// prepare uniform set and buffer
+		copy.push_constant.init(copy.shader.version_get_shader(copy.shader_version, 0));
+		// </TF>
 	}
 
 	{
@@ -110,7 +131,10 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 		copy_modes.push_back("\n#define USE_MULTIVIEW\n"); // COPY_TO_FB_MULTIVIEW
 		copy_modes.push_back("\n#define USE_MULTIVIEW\n#define MODE_TWO_SOURCES\n"); // COPY_TO_FB_MULTIVIEW_WITH_DEPTH
 
-		copy_to_fb.shader.initialize(copy_modes);
+		Vector<uint64_t> dynamic_buffers;
+		dynamic_buffers.push_back(RDD::DynamicBuffer::encode(copy_to_fb.push_constant.set_idx(), 0));
+
+		copy_to_fb.shader.initialize(copy_modes, "", Vector<RD::PipelineImmutableSampler>(), dynamic_buffers);
 
 		if (!RendererCompositorRD::get_singleton()->is_xr_enabled()) {
 			copy_to_fb.shader.set_variant_enabled(COPY_TO_FB_MULTIVIEW, false);
@@ -128,6 +152,13 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 				copy_to_fb.pipelines[i].clear();
 			}
 		}
+
+		// <TF>
+		// @ShadyTF
+		// replace push constants with UBO
+		// prepare uniform set and buffer
+		copy_to_fb.push_constant.init(copy_to_fb.shader.version_get_shader(copy_to_fb.shader_version, 0));
+		// </TF>
 	}
 
 	{
@@ -135,7 +166,10 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 		Vector<String> copy_modes;
 		copy_modes.push_back("\n");
 
-		cube_to_dp.shader.initialize(copy_modes);
+		Vector<uint64_t> dynamic_buffers;
+		dynamic_buffers.push_back(RDD::DynamicBuffer::encode(cube_to_dp.push_constant.set_idx(), 0));
+
+		cube_to_dp.shader.initialize(copy_modes, "", Vector<RD::PipelineImmutableSampler>(), dynamic_buffers);
 
 		cube_to_dp.shader_version = cube_to_dp.shader.version_create();
 		RID shader = cube_to_dp.shader.version_get_shader(cube_to_dp.shader_version, 0);
@@ -144,6 +178,12 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 		dss.depth_compare_operator = RD::COMPARE_OP_ALWAYS;
 		dss.enable_depth_write = true;
 		cube_to_dp.pipeline.setup(shader, RD::RENDER_PRIMITIVE_TRIANGLES, RD::PipelineRasterizationState(), RD::PipelineMultisampleState(), dss, RD::PipelineColorBlendState(), 0);
+
+		// <TF>
+		// @ShadyTF
+		// prepare uniform set and buffer
+		cube_to_dp.push_constant.init(cube_to_dp.shader.version_get_shader(cube_to_dp.shader_version, 0));
+		// </TF>
 	}
 
 	{
@@ -202,7 +242,7 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 				}
 			}
 
-			Vector<RD::Uniform> uniforms;
+			uniforms.clear();
 			{
 				RD::Uniform u;
 				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
@@ -220,7 +260,7 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 				filter.raster_pipelines[i].clear();
 			}
 
-			Vector<RD::Uniform> uniforms;
+			uniforms.clear();
 			{
 				RD::Uniform u;
 				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
@@ -306,6 +346,11 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 }
 
 CopyEffects::~CopyEffects() {
+	copy_to_fb.push_constant.uninit();
+	cube_to_dp.push_constant.uninit();
+	copy.push_constant.uninit();
+	blur_raster.push_constant.uninit();
+
 	if (prefer_raster_effects) {
 		blur_raster.shader.version_free(blur_raster.shader_version);
 		cubemap_downsampler.raster_shader.version_free(cubemap_downsampler.shader_version);
@@ -342,45 +387,51 @@ void CopyEffects::copy_to_rect(RID p_source_rd_texture, RID p_dest_texture, cons
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	CopyPushConstant push_constant = {};
 	if (p_flip_y) {
-		copy.push_constant.flags |= COPY_FLAG_FLIP_Y;
+		push_constant.flags |= COPY_FLAG_FLIP_Y;
 	}
 
 	if (p_force_luminance) {
-		copy.push_constant.flags |= COPY_FLAG_FORCE_LUMINANCE;
+		push_constant.flags |= COPY_FLAG_FORCE_LUMINANCE;
 	}
 
 	if (p_all_source) {
-		copy.push_constant.flags |= COPY_FLAG_ALL_SOURCE;
+		push_constant.flags |= COPY_FLAG_ALL_SOURCE;
 	}
 
 	if (p_alpha_to_one) {
-		copy.push_constant.flags |= COPY_FLAG_ALPHA_TO_ONE;
+		push_constant.flags |= COPY_FLAG_ALPHA_TO_ONE;
 	}
 
-	copy.push_constant.section[0] = p_rect.position.x;
-	copy.push_constant.section[1] = p_rect.position.y;
-	copy.push_constant.section[2] = p_rect.size.width;
-	copy.push_constant.section[3] = p_rect.size.height;
-	copy.push_constant.target[0] = p_rect.position.x;
-	copy.push_constant.target[1] = p_rect.position.y;
+	push_constant.section[0] = p_rect.position.x;
+	push_constant.section[1] = p_rect.position.y;
+	push_constant.section[2] = p_rect.size.width;
+	push_constant.section[3] = p_rect.size.height;
+	push_constant.target[0] = p_rect.position.x;
+	push_constant.target[1] = p_rect.position.y;
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
 	RD::Uniform u_source_rd_texture(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_rd_texture }));
-	RD::Uniform u_dest_texture(RD::UNIFORM_TYPE_IMAGE, 0, p_dest_texture);
+	RD::Uniform u_dest_texture(RD::UNIFORM_TYPE_IMAGE, 1, p_dest_texture);
+
+	uniforms.clear();
+	uniforms.push_back(u_source_rd_texture);
+	uniforms.push_back(u_dest_texture);
 
 	CopyMode mode = p_8_bit_dst ? COPY_MODE_SIMPLY_COPY_8BIT : COPY_MODE_SIMPLY_COPY;
 	RID shader = copy.shader.version_get_shader(copy.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 
+	// Update buffer and uniform set
+	const PushConstantsEmuBase::ParamsUniform params_uniform = copy.push_constant.upload_and_advance(push_constant);
+
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, copy.pipelines[mode]);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 3, u_dest_texture), 3);
-	RD::get_singleton()->compute_list_set_push_constant(compute_list, &copy.push_constant, sizeof(CopyPushConstant));
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache_vec(shader, 0, uniforms), 0);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, params_uniform.set, 1);
 	RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_rect.size.width, p_rect.size.height, 1);
 	RD::get_singleton()->compute_list_end();
 }
@@ -391,31 +442,37 @@ void CopyEffects::copy_cubemap_to_panorama(RID p_source_cube, RID p_dest_panoram
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	CopyPushConstant push_constant = {};
 
-	copy.push_constant.section[0] = 0;
-	copy.push_constant.section[1] = 0;
-	copy.push_constant.section[2] = p_panorama_size.width;
-	copy.push_constant.section[3] = p_panorama_size.height;
-	copy.push_constant.target[0] = 0;
-	copy.push_constant.target[1] = 0;
-	copy.push_constant.camera_z_far = p_lod;
+	push_constant.section[0] = 0;
+	push_constant.section[1] = 0;
+	push_constant.section[2] = p_panorama_size.width;
+	push_constant.section[3] = p_panorama_size.height;
+	push_constant.target[0] = 0;
+	push_constant.target[1] = 0;
+	push_constant.camera_z_far = p_lod;
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
 	RD::Uniform u_source_cube(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_cube }));
-	RD::Uniform u_dest_panorama(RD::UNIFORM_TYPE_IMAGE, 0, p_dest_panorama);
+	RD::Uniform u_dest_panorama(RD::UNIFORM_TYPE_IMAGE, 1, p_dest_panorama);
+
+	uniforms.clear();
+	uniforms.push_back(u_source_cube);
+	uniforms.push_back(u_dest_panorama);
 
 	CopyMode mode = p_is_array ? COPY_MODE_CUBE_ARRAY_TO_PANORAMA : COPY_MODE_CUBE_TO_PANORAMA;
 	RID shader = copy.shader.version_get_shader(copy.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 
+	// Update buffer and uniform set
+	const PushConstantsEmuBase::ParamsUniform params_uniform = copy.push_constant.upload_and_advance(push_constant);
+
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, copy.pipelines[mode]);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_source_cube), 0);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 3, u_dest_panorama), 3);
-	RD::get_singleton()->compute_list_set_push_constant(compute_list, &copy.push_constant, sizeof(CopyPushConstant));
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache_vec(shader, 0, uniforms), 0);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, params_uniform.set, 1);
 	RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_panorama_size.width, p_panorama_size.height, 1);
 	RD::get_singleton()->compute_list_end();
 }
@@ -426,33 +483,39 @@ void CopyEffects::copy_depth_to_rect(RID p_source_rd_texture, RID p_dest_texture
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	CopyPushConstant push_constant = {};
 	if (p_flip_y) {
-		copy.push_constant.flags |= COPY_FLAG_FLIP_Y;
+		push_constant.flags |= COPY_FLAG_FLIP_Y;
 	}
 
-	copy.push_constant.section[0] = 0;
-	copy.push_constant.section[1] = 0;
-	copy.push_constant.section[2] = p_rect.size.width;
-	copy.push_constant.section[3] = p_rect.size.height;
-	copy.push_constant.target[0] = p_rect.position.x;
-	copy.push_constant.target[1] = p_rect.position.y;
+	push_constant.section[0] = 0;
+	push_constant.section[1] = 0;
+	push_constant.section[2] = p_rect.size.width;
+	push_constant.section[3] = p_rect.size.height;
+	push_constant.target[0] = p_rect.position.x;
+	push_constant.target[1] = p_rect.position.y;
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
 	RD::Uniform u_source_rd_texture(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_rd_texture }));
-	RD::Uniform u_dest_texture(RD::UNIFORM_TYPE_IMAGE, 0, p_dest_texture);
+	RD::Uniform u_dest_texture(RD::UNIFORM_TYPE_IMAGE, 1, p_dest_texture);
+
+	uniforms.clear();
+	uniforms.push_back(u_source_rd_texture);
+	uniforms.push_back(u_dest_texture);
 
 	CopyMode mode = COPY_MODE_SIMPLY_COPY_DEPTH;
 	RID shader = copy.shader.version_get_shader(copy.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 
+	// Update buffer and uniform set
+	const PushConstantsEmuBase::ParamsUniform params_uniform = copy.push_constant.upload_and_advance(push_constant);
+
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, copy.pipelines[mode]);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 3, u_dest_texture), 3);
-	RD::get_singleton()->compute_list_set_push_constant(compute_list, &copy.push_constant, sizeof(CopyPushConstant));
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache_vec(shader, 0, uniforms), 0);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, params_uniform.set, 1);
 	RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_rect.size.width, p_rect.size.height, 1);
 	RD::get_singleton()->compute_list_end();
 }
@@ -463,35 +526,42 @@ void CopyEffects::copy_depth_to_rect_and_linearize(RID p_source_rd_texture, RID 
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	CopyPushConstant push_constant = {};
+
 	if (p_flip_y) {
-		copy.push_constant.flags |= COPY_FLAG_FLIP_Y;
+		push_constant.flags |= COPY_FLAG_FLIP_Y;
 	}
 
-	copy.push_constant.section[0] = 0;
-	copy.push_constant.section[1] = 0;
-	copy.push_constant.section[2] = p_rect.size.width;
-	copy.push_constant.section[3] = p_rect.size.height;
-	copy.push_constant.target[0] = p_rect.position.x;
-	copy.push_constant.target[1] = p_rect.position.y;
-	copy.push_constant.camera_z_far = p_z_far;
-	copy.push_constant.camera_z_near = p_z_near;
+	push_constant.section[0] = 0;
+	push_constant.section[1] = 0;
+	push_constant.section[2] = p_rect.size.width;
+	push_constant.section[3] = p_rect.size.height;
+	push_constant.target[0] = p_rect.position.x;
+	push_constant.target[1] = p_rect.position.y;
+	push_constant.camera_z_far = p_z_far;
+	push_constant.camera_z_near = p_z_near;
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
 	RD::Uniform u_source_rd_texture(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_rd_texture }));
-	RD::Uniform u_dest_texture(RD::UNIFORM_TYPE_IMAGE, 0, p_dest_texture);
+	RD::Uniform u_dest_texture(RD::UNIFORM_TYPE_IMAGE, 1, p_dest_texture);
+
+	uniforms.clear();
+	uniforms.push_back(u_source_rd_texture);
+	uniforms.push_back(u_dest_texture);
 
 	CopyMode mode = COPY_MODE_LINEARIZE_DEPTH;
 	RID shader = copy.shader.version_get_shader(copy.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 
+	// Update buffer and uniform set
+	const PushConstantsEmuBase::ParamsUniform params_uniform = copy.push_constant.upload_and_advance(push_constant);
+
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, copy.pipelines[mode]);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 3, u_dest_texture), 3);
-	RD::get_singleton()->compute_list_set_push_constant(compute_list, &copy.push_constant, sizeof(CopyPushConstant));
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache_vec(shader, 0, uniforms), 0);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, params_uniform.set, 1);
 	RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_rect.size.width, p_rect.size.height, 1);
 	RD::get_singleton()->compute_list_end();
 }
@@ -502,19 +572,19 @@ void CopyEffects::copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuff
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy_to_fb.push_constant, 0, sizeof(CopyToFbPushConstant));
+	CopyToFbPushConstant push_constant = {};
 
-	copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_USE_SECTION;
-	copy_to_fb.push_constant.section[0] = p_uv_rect.position.x;
-	copy_to_fb.push_constant.section[1] = p_uv_rect.position.y;
-	copy_to_fb.push_constant.section[2] = p_uv_rect.size.x;
-	copy_to_fb.push_constant.section[3] = p_uv_rect.size.y;
+	push_constant.flags |= COPY_TO_FB_FLAG_USE_SECTION;
+	push_constant.section[0] = p_uv_rect.position.x;
+	push_constant.section[1] = p_uv_rect.position.y;
+	push_constant.section[2] = p_uv_rect.size.x;
+	push_constant.section[3] = p_uv_rect.size.y;
 
 	if (p_flip_y) {
-		copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_FLIP_Y;
+		push_constant.flags |= COPY_TO_FB_FLAG_FLIP_Y;
 	}
 
-	copy_to_fb.push_constant.luminance_multiplier = 1.0;
+	push_constant.luminance_multiplier = 1.0;
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
@@ -525,11 +595,13 @@ void CopyEffects::copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuff
 	RID shader = copy_to_fb.shader.version_get_shader(copy_to_fb.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 
+	const PushConstantsEmuBase::ParamsUniform params_uniform = copy_to_fb.push_constant.upload_and_advance(push_constant);
+
 	RD::DrawListID draw_list = p_draw_list;
 	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, copy_to_fb.pipelines[mode].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(p_dest_framebuffer)));
 	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, params_uniform.set, 1);
 	RD::get_singleton()->draw_list_bind_index_array(draw_list, material_storage->get_quad_index_array());
-	RD::get_singleton()->draw_list_set_push_constant(draw_list, &copy_to_fb.push_constant, sizeof(CopyToFbPushConstant));
 	RD::get_singleton()->draw_list_draw(draw_list, true);
 }
 
@@ -539,41 +611,41 @@ void CopyEffects::copy_to_fb_rect(RID p_source_rd_texture, RID p_dest_framebuffe
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy_to_fb.push_constant, 0, sizeof(CopyToFbPushConstant));
-	copy_to_fb.push_constant.luminance_multiplier = 1.0;
+	CopyToFbPushConstant push_constant = {};
+	push_constant.luminance_multiplier = 1.0;
 
 	if (p_flip_y) {
-		copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_FLIP_Y;
+		push_constant.flags |= COPY_TO_FB_FLAG_FLIP_Y;
 	}
 	if (p_force_luminance) {
-		copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_FORCE_LUMINANCE;
+		push_constant.flags |= COPY_TO_FB_FLAG_FORCE_LUMINANCE;
 	}
 	if (p_alpha_to_zero) {
-		copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_ALPHA_TO_ZERO;
+		push_constant.flags |= COPY_TO_FB_FLAG_ALPHA_TO_ZERO;
 	}
 	if (p_srgb) {
-		copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_SRGB;
+		push_constant.flags |= COPY_TO_FB_FLAG_SRGB;
 	}
 	if (p_alpha_to_one) {
-		copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_ALPHA_TO_ONE;
+		push_constant.flags |= COPY_TO_FB_FLAG_ALPHA_TO_ONE;
 	}
 	if (p_linear) {
 		// Used for copying to a linear buffer. In the mobile renderer we divide the contents of the linear buffer
 		// to allow for a wider effective range.
-		copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_LINEAR;
-		copy_to_fb.push_constant.luminance_multiplier = prefer_raster_effects ? 2.0 : 1.0;
+		push_constant.flags |= COPY_TO_FB_FLAG_LINEAR;
+		push_constant.luminance_multiplier = prefer_raster_effects ? 2.0 : 1.0;
 	}
 
 	if (p_normal) {
-		copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_NORMAL;
+		push_constant.flags |= COPY_TO_FB_FLAG_NORMAL;
 	}
 
 	if (p_src_rect != Rect2()) {
-		copy_to_fb.push_constant.section[0] = p_src_rect.position.x;
-		copy_to_fb.push_constant.section[1] = p_src_rect.position.y;
-		copy_to_fb.push_constant.section[2] = p_src_rect.size.x;
-		copy_to_fb.push_constant.section[3] = p_src_rect.size.y;
-		copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_USE_SRC_SECTION;
+		push_constant.section[0] = p_src_rect.position.x;
+		push_constant.section[1] = p_src_rect.position.y;
+		push_constant.section[2] = p_src_rect.size.x;
+		push_constant.section[3] = p_src_rect.size.y;
+		push_constant.flags |= COPY_TO_FB_FLAG_USE_SRC_SECTION;
 	}
 
 	// setup our uniforms
@@ -591,16 +663,21 @@ void CopyEffects::copy_to_fb_rect(RID p_source_rd_texture, RID p_dest_framebuffe
 	RID shader = copy_to_fb.shader.version_get_shader(copy_to_fb.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 
-	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(p_dest_framebuffer, RD::DRAW_DEFAULT_ALL, Vector<Color>(), 1.0f, 0, p_rect);
-	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, copy_to_fb.pipelines[mode].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(p_dest_framebuffer)));
-	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
+	uniforms.clear();
+	uniforms.push_back(u_source_rd_texture);
 	if (p_secondary.is_valid()) {
 		// TODO may need to do this differently when reading from depth buffer for multiview
-		RD::Uniform u_secondary(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_secondary }));
-		RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 1, u_secondary), 1);
+		RD::Uniform u_secondary(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 1, Vector<RID>({ default_sampler, p_secondary }));
+		uniforms.push_back(u_secondary);
 	}
+
+	const PushConstantsEmuBase::ParamsUniform params_uniform = copy_to_fb.push_constant.upload_and_advance(push_constant);
+
+	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(p_dest_framebuffer, RD::DRAW_DEFAULT_ALL, Vector<Color>(), 1.0f, 0, p_rect);
+	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, copy_to_fb.pipelines[mode].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(p_dest_framebuffer)));
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache_vec(shader, 0, uniforms), 0);
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, params_uniform.set, 1);
 	RD::get_singleton()->draw_list_bind_index_array(draw_list, material_storage->get_quad_index_array());
-	RD::get_singleton()->draw_list_set_push_constant(draw_list, &copy_to_fb.push_constant, sizeof(CopyToFbPushConstant));
 	RD::get_singleton()->draw_list_draw(draw_list, true);
 	RD::get_singleton()->draw_list_end();
 }
@@ -611,14 +688,14 @@ void CopyEffects::copy_to_drawlist(RD::DrawListID p_draw_list, RD::FramebufferFo
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy_to_fb.push_constant, 0, sizeof(CopyToFbPushConstant));
-	copy_to_fb.push_constant.luminance_multiplier = 1.0;
+	CopyToFbPushConstant push_constant = {};
+	push_constant.luminance_multiplier = 1.0;
 
 	if (p_linear) {
 		// Used for copying to a linear buffer. In the mobile renderer we divide the contents of the linear buffer
 		// to allow for a wider effective range.
-		copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_LINEAR;
-		copy_to_fb.push_constant.luminance_multiplier = prefer_raster_effects ? 2.0 : 1.0;
+		push_constant.flags |= COPY_TO_FB_FLAG_LINEAR;
+		push_constant.luminance_multiplier = prefer_raster_effects ? 2.0 : 1.0;
 	}
 
 	// setup our uniforms
@@ -632,10 +709,12 @@ void CopyEffects::copy_to_drawlist(RD::DrawListID p_draw_list, RD::FramebufferFo
 	RID shader = copy_to_fb.shader.version_get_shader(copy_to_fb.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 
+	const PushConstantsEmuBase::ParamsUniform params_uniform = copy_to_fb.push_constant.upload_and_advance(push_constant);
+
 	RD::get_singleton()->draw_list_bind_render_pipeline(p_draw_list, copy_to_fb.pipelines[mode].get_render_pipeline(RD::INVALID_ID, p_fb_format));
 	RD::get_singleton()->draw_list_bind_uniform_set(p_draw_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
+	RD::get_singleton()->draw_list_bind_uniform_set(p_draw_list, params_uniform.set, 1);
 	RD::get_singleton()->draw_list_bind_index_array(p_draw_list, material_storage->get_quad_index_array());
-	RD::get_singleton()->draw_list_set_push_constant(p_draw_list, &copy_to_fb.push_constant, sizeof(CopyToFbPushConstant));
 	RD::get_singleton()->draw_list_draw(p_draw_list, true);
 }
 
@@ -647,7 +726,12 @@ void CopyEffects::copy_raster(RID p_source_texture, RID p_dest_framebuffer) {
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
+	// <TF>
+	// @ShadyTF
+	// replace push constants with UBO
+	BlurRasterPushConstant push_constant{};
+	const PushConstantsEmuBase::ParamsUniform params_uniform = blur_raster.push_constant.upload_and_advance(push_constant);
+	// </TF>
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
@@ -661,7 +745,14 @@ void CopyEffects::copy_raster(RID p_source_texture, RID p_dest_framebuffer) {
 	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(p_dest_framebuffer);
 	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, blur_raster.pipelines[BLUR_MODE_COPY].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(p_dest_framebuffer)));
 	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 0, u_source_texture), 0);
-	RD::get_singleton()->draw_list_set_push_constant(draw_list, &blur_raster.push_constant, sizeof(BlurRasterPushConstant));
+	RD::get_singleton()->draw_list_bind_index_array(draw_list, material_storage->get_quad_index_array());
+	// <TF>
+	// @ShadyTF
+	// replace push constants with UBO
+	// Was:
+	//	RD::get_singleton()->draw_list_set_push_constant(draw_list, &blur_raster.push_constant, sizeof(BlurRasterPushConstant));
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, params_uniform.set, 1);
+	// </TF>
 
 	RD::get_singleton()->draw_list_draw(draw_list, false, 1u, 3u);
 	RD::get_singleton()->draw_list_end();
@@ -675,31 +766,36 @@ void CopyEffects::gaussian_blur(RID p_source_rd_texture, RID p_texture, const Re
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	CopyPushConstant push_constant = {};
 
-	copy.push_constant.section[0] = p_region.position.x;
-	copy.push_constant.section[1] = p_region.position.y;
-	copy.push_constant.target[0] = p_region.position.x;
-	copy.push_constant.target[1] = p_region.position.y;
-	copy.push_constant.section[2] = p_size.width;
-	copy.push_constant.section[3] = p_size.height;
+	push_constant.section[0] = p_region.position.x;
+	push_constant.section[1] = p_region.position.y;
+	push_constant.target[0] = p_region.position.x;
+	push_constant.target[1] = p_region.position.y;
+	push_constant.section[2] = p_size.width;
+	push_constant.section[3] = p_size.height;
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
 	RD::Uniform u_source_rd_texture(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_rd_texture }));
-	RD::Uniform u_texture(RD::UNIFORM_TYPE_IMAGE, 0, p_texture);
+	RD::Uniform u_texture(RD::UNIFORM_TYPE_IMAGE, 1, p_texture);
+
+	uniforms.clear();
+	uniforms.push_back(u_source_rd_texture);
+	uniforms.push_back(u_texture);
 
 	CopyMode mode = p_8bit_dst ? COPY_MODE_GAUSSIAN_COPY_8BIT : COPY_MODE_GAUSSIAN_COPY;
 	RID shader = copy.shader.version_get_shader(copy.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 
+	// Update buffer and uniform set
+	const PushConstantsEmuBase::ParamsUniform params_uniform = copy.push_constant.upload_and_advance(push_constant);
+
 	RD::DrawListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, copy.pipelines[mode]);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 3, u_texture), 3);
-
-	RD::get_singleton()->compute_list_set_push_constant(compute_list, &copy.push_constant, sizeof(CopyPushConstant));
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache_vec(shader, 0, uniforms), 0);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, params_uniform.set, 1);
 
 	RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_region.size.width, p_region.size.height, 1);
 
@@ -716,12 +812,17 @@ void CopyEffects::gaussian_blur_raster(RID p_source_rd_texture, RID p_dest_textu
 
 	RID dest_framebuffer = FramebufferCacheRD::get_singleton()->get_cache(p_dest_texture);
 
-	memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
-
 	BlurRasterMode blur_mode = BLUR_MODE_GAUSSIAN_BLUR;
 
-	blur_raster.push_constant.pixel_size[0] = 1.0 / float(p_size.x);
-	blur_raster.push_constant.pixel_size[1] = 1.0 / float(p_size.y);
+	BlurRasterPushConstant push_constant{};
+	push_constant.pixel_size[0] = 1.0 / float(p_size.x);
+	push_constant.pixel_size[1] = 1.0 / float(p_size.y);
+
+	// <TF>
+	// @ShadyTF
+	// replace push constants with UBO
+	const PushConstantsEmuBase::ParamsUniform params_uniform = blur_raster.push_constant.upload_and_advance(push_constant);
+	// </TF>
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
@@ -735,7 +836,13 @@ void CopyEffects::gaussian_blur_raster(RID p_source_rd_texture, RID p_dest_textu
 	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, blur_raster.pipelines[blur_mode].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(dest_framebuffer)));
 	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
 
-	RD::get_singleton()->draw_list_set_push_constant(draw_list, &blur_raster.push_constant, sizeof(BlurRasterPushConstant));
+	// <TF>
+	// @ShadyTF
+	// replace push constants with UBO
+	// Was:
+	//	RD::get_singleton()->draw_list_set_push_constant(draw_list, &blur_raster.push_constant, sizeof(BlurRasterPushConstant));
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, params_uniform.set, 1);
+	// </TF>
 
 	RD::get_singleton()->draw_list_draw(draw_list, false, 1u, 3u);
 	RD::get_singleton()->draw_list_end();
@@ -749,45 +856,49 @@ void CopyEffects::gaussian_glow(RID p_source_rd_texture, RID p_back_texture, con
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	CopyPushConstant push_constant = {};
 
 	CopyMode copy_mode = p_first_pass && p_auto_exposure.is_valid() ? COPY_MODE_GAUSSIAN_GLOW_AUTO_EXPOSURE : COPY_MODE_GAUSSIAN_GLOW;
 	uint32_t base_flags = 0;
 
-	copy.push_constant.section[2] = p_size.x;
-	copy.push_constant.section[3] = p_size.y;
+	push_constant.section[2] = p_size.x;
+	push_constant.section[3] = p_size.y;
 
-	copy.push_constant.glow_strength = p_strength;
-	copy.push_constant.glow_bloom = p_bloom;
-	copy.push_constant.glow_hdr_threshold = p_hdr_bleed_threshold;
-	copy.push_constant.glow_hdr_scale = p_hdr_bleed_scale;
-	copy.push_constant.glow_exposure = p_exposure;
-	copy.push_constant.glow_white = 0; //actually unused
-	copy.push_constant.glow_luminance_cap = p_luminance_cap;
+	push_constant.glow_strength = p_strength;
+	push_constant.glow_bloom = p_bloom;
+	push_constant.glow_hdr_threshold = p_hdr_bleed_threshold;
+	push_constant.glow_hdr_scale = p_hdr_bleed_scale;
+	push_constant.glow_exposure = p_exposure;
+	push_constant.glow_white = 0; //actually unused
+	push_constant.glow_luminance_cap = p_luminance_cap;
 
-	copy.push_constant.glow_auto_exposure_scale = p_auto_exposure_scale; //unused also
+	push_constant.glow_auto_exposure_scale = p_auto_exposure_scale; //unused also
+	push_constant.flags = base_flags | (p_first_pass ? COPY_FLAG_GLOW_FIRST_PASS : 0);
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
 	RD::Uniform u_source_rd_texture(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_rd_texture }));
-	RD::Uniform u_back_texture(RD::UNIFORM_TYPE_IMAGE, 0, p_back_texture);
+	RD::Uniform u_back_texture(RD::UNIFORM_TYPE_IMAGE, 1, p_back_texture);
+
+	uniforms.clear();
+	uniforms.push_back(u_source_rd_texture);
+	uniforms.push_back(u_back_texture);
+	if (p_auto_exposure.is_valid() && p_first_pass) {
+		RD::Uniform u_auto_exposure(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 2, Vector<RID>({ default_sampler, p_auto_exposure }));
+		uniforms.push_back(u_auto_exposure);
+	}
 
 	RID shader = copy.shader.version_get_shader(copy.shader_version, copy_mode);
 	ERR_FAIL_COND(shader.is_null());
 
+	// Update buffer and uniform set
+	const PushConstantsEmuBase::ParamsUniform params_uniform = copy.push_constant.upload_and_advance(push_constant);
+
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, copy.pipelines[copy_mode]);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 3, u_back_texture), 3);
-	if (p_auto_exposure.is_valid() && p_first_pass) {
-		RD::Uniform u_auto_exposure(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_auto_exposure }));
-		RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 1, u_auto_exposure), 1);
-	}
-
-	copy.push_constant.flags = base_flags | (p_first_pass ? COPY_FLAG_GLOW_FIRST_PASS : 0);
-	RD::get_singleton()->compute_list_set_push_constant(compute_list, &copy.push_constant, sizeof(CopyPushConstant));
-
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache_vec(shader, 0, uniforms), 0);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, params_uniform.set, 1);
 	RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_size.width, p_size.height, 1);
 	RD::get_singleton()->compute_list_end();
 }
@@ -803,25 +914,24 @@ void CopyEffects::gaussian_glow_raster(RID p_source_rd_texture, RID p_half_textu
 	RID half_framebuffer = FramebufferCacheRD::get_singleton()->get_cache(p_half_texture);
 	RID dest_framebuffer = FramebufferCacheRD::get_singleton()->get_cache(p_dest_texture);
 
-	memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
-
 	BlurRasterMode blur_mode = p_first_pass && p_auto_exposure.is_valid() ? BLUR_MODE_GAUSSIAN_GLOW_AUTO_EXPOSURE : BLUR_MODE_GAUSSIAN_GLOW;
 	uint32_t base_flags = 0;
 
-	blur_raster.push_constant.pixel_size[0] = 1.0 / float(p_size.x);
-	blur_raster.push_constant.pixel_size[1] = 1.0 / float(p_size.y);
+	BlurRasterPushConstant push_constant{};
+	push_constant.pixel_size[0] = 1.0 / float(p_size.x);
+	push_constant.pixel_size[1] = 1.0 / float(p_size.y);
 
-	blur_raster.push_constant.glow_strength = p_strength;
-	blur_raster.push_constant.glow_bloom = p_bloom;
-	blur_raster.push_constant.glow_hdr_threshold = p_hdr_bleed_threshold;
-	blur_raster.push_constant.glow_hdr_scale = p_hdr_bleed_scale;
-	blur_raster.push_constant.glow_exposure = p_exposure;
-	blur_raster.push_constant.glow_white = 0; //actually unused
-	blur_raster.push_constant.glow_luminance_cap = p_luminance_cap;
+	push_constant.glow_strength = p_strength;
+	push_constant.glow_bloom = p_bloom;
+	push_constant.glow_hdr_threshold = p_hdr_bleed_threshold;
+	push_constant.glow_hdr_scale = p_hdr_bleed_scale;
+	push_constant.glow_exposure = p_exposure;
+	push_constant.glow_white = 0; //actually unused
+	push_constant.glow_luminance_cap = p_luminance_cap;
 
-	blur_raster.push_constant.glow_auto_exposure_scale = p_auto_exposure_scale; //unused also
+	push_constant.glow_auto_exposure_scale = p_auto_exposure_scale; //unused also
 
-	blur_raster.push_constant.luminance_multiplier = p_luminance_multiplier;
+	push_constant.luminance_multiplier = p_luminance_multiplier;
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
@@ -832,18 +942,31 @@ void CopyEffects::gaussian_glow_raster(RID p_source_rd_texture, RID p_half_textu
 	RID shader = blur_raster.shader.version_get_shader(blur_raster.shader_version, blur_mode);
 	ERR_FAIL_COND(shader.is_null());
 
-	//HORIZONTAL
-	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(half_framebuffer);
-	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, blur_raster.pipelines[blur_mode].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(half_framebuffer)));
-	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
+	uniforms.clear();
+	uniforms.push_back(u_source_rd_texture);
 	if (p_auto_exposure.is_valid() && p_first_pass) {
-		RD::Uniform u_auto_exposure(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_auto_exposure }));
-		RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 1, u_auto_exposure), 1);
+		RD::Uniform u_auto_exposure(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 1, Vector<RID>({ default_sampler, p_auto_exposure }));
+		uniforms.push_back(u_auto_exposure);
 	}
 
-	blur_raster.push_constant.flags = base_flags | BLUR_FLAG_HORIZONTAL | (p_first_pass ? BLUR_FLAG_GLOW_FIRST_PASS : 0);
-	RD::get_singleton()->draw_list_set_push_constant(draw_list, &blur_raster.push_constant, sizeof(BlurRasterPushConstant));
-
+	//HORIZONTAL
+	// <TF>
+	// @ShadyTF
+	// replace push constants with UBO
+	push_constant.flags = base_flags | BLUR_FLAG_HORIZONTAL | (p_first_pass ? BLUR_FLAG_GLOW_FIRST_PASS : 0);
+	PushConstantsEmuBase::ParamsUniform params_uniform = blur_raster.push_constant.upload_and_advance(push_constant);
+	// </TF>
+	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(half_framebuffer);
+	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, blur_raster.pipelines[blur_mode].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(half_framebuffer)));
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache_vec(shader, 0, uniforms), 0);
+	// <TF>
+	// @ShadyTF
+	// replace push constants with UBO
+	// was:
+	//blur_raster.push_constant.flags = base_flags | BLUR_FLAG_HORIZONTAL | (p_first_pass ? BLUR_FLAG_GLOW_FIRST_PASS : 0);
+	//RD::get_singleton()->draw_list_set_push_constant(draw_list, &blur_raster.push_constant, sizeof(BlurRasterPushConstant));
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, params_uniform.set, 1);
+	// </TF>
 	RD::get_singleton()->draw_list_draw(draw_list, false, 1u, 3u);
 	RD::get_singleton()->draw_list_end();
 
@@ -853,13 +976,23 @@ void CopyEffects::gaussian_glow_raster(RID p_source_rd_texture, RID p_half_textu
 	ERR_FAIL_COND(shader.is_null());
 
 	//VERTICAL
+	// <TF>
+	// @ShadyTF
+	// replace push constants with UBO
+	push_constant.flags = base_flags;
+	params_uniform = blur_raster.push_constant.upload_and_advance(push_constant);
+	// </TF>
 	draw_list = RD::get_singleton()->draw_list_begin(dest_framebuffer);
 	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, blur_raster.pipelines[blur_mode].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(dest_framebuffer)));
 	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 0, u_half_texture), 0);
-
-	blur_raster.push_constant.flags = base_flags;
-	RD::get_singleton()->draw_list_set_push_constant(draw_list, &blur_raster.push_constant, sizeof(BlurRasterPushConstant));
-
+	// <TF>
+	// @ShadyTF
+	// replace push constants with UBO
+	// Was:
+	//blur_raster.push_constant.flags = base_flags;
+	//RD::get_singleton()->draw_list_set_push_constant(draw_list, &blur_raster.push_constant, sizeof(BlurRasterPushConstant));
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, params_uniform.set, 1);
+	// </TF>
 	RD::get_singleton()->draw_list_draw(draw_list, false, 1u, 3u);
 	RD::get_singleton()->draw_list_end();
 }
@@ -872,28 +1005,34 @@ void CopyEffects::make_mipmap(RID p_source_rd_texture, RID p_dest_texture, const
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	CopyPushConstant push_constant = {};
 
-	copy.push_constant.section[0] = 0;
-	copy.push_constant.section[1] = 0;
-	copy.push_constant.section[2] = p_size.width;
-	copy.push_constant.section[3] = p_size.height;
+	push_constant.section[0] = 0;
+	push_constant.section[1] = 0;
+	push_constant.section[2] = p_size.width;
+	push_constant.section[3] = p_size.height;
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
 	RD::Uniform u_source_rd_texture(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_rd_texture }));
-	RD::Uniform u_dest_texture(RD::UNIFORM_TYPE_IMAGE, 0, p_dest_texture);
+	RD::Uniform u_dest_texture(RD::UNIFORM_TYPE_IMAGE, 1, p_dest_texture);
+
+	uniforms.clear();
+	uniforms.push_back(u_source_rd_texture);
+	uniforms.push_back(u_dest_texture);
 
 	CopyMode mode = COPY_MODE_MIPMAP;
 	RID shader = copy.shader.version_get_shader(copy.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 
+	// Update buffer and uniform set
+	const PushConstantsEmuBase::ParamsUniform params_uniform = copy.push_constant.upload_and_advance(push_constant);
+
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, copy.pipelines[mode]);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 3, u_dest_texture), 3);
-	RD::get_singleton()->compute_list_set_push_constant(compute_list, &copy.push_constant, sizeof(CopyPushConstant));
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache_vec(shader, 0, uniforms), 0);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, params_uniform.set, 1);
 	RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_size.width, p_size.height, 1);
 	RD::get_singleton()->compute_list_end();
 }
@@ -908,12 +1047,12 @@ void CopyEffects::make_mipmap_raster(RID p_source_rd_texture, RID p_dest_texture
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
-
 	BlurRasterMode mode = BLUR_MIPMAP;
 
-	blur_raster.push_constant.pixel_size[0] = 1.0 / float(p_size.x);
-	blur_raster.push_constant.pixel_size[1] = 1.0 / float(p_size.y);
+	BlurRasterPushConstant push_constant{};
+	push_constant.pixel_size[0] = 1.0f / float(p_size.x);
+	push_constant.pixel_size[1] = 1.0f / float(p_size.y);
+	const PushConstantsEmuBase::ParamsUniform params_uniform = blur_raster.push_constant.upload_and_advance(push_constant);
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
@@ -926,7 +1065,8 @@ void CopyEffects::make_mipmap_raster(RID p_source_rd_texture, RID p_dest_texture
 	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(dest_framebuffer);
 	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, blur_raster.pipelines[mode].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(dest_framebuffer)));
 	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
-	RD::get_singleton()->draw_list_set_push_constant(draw_list, &blur_raster.push_constant, sizeof(BlurRasterPushConstant));
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, params_uniform.set, 1);
+	RD::get_singleton()->draw_list_bind_index_array(draw_list, material_storage->get_quad_index_array());
 
 	RD::get_singleton()->draw_list_draw(draw_list, false, 1u, 3u);
 	RD::get_singleton()->draw_list_end();
@@ -938,18 +1078,18 @@ void CopyEffects::set_color(RID p_dest_texture, const Color &p_color, const Rect
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
 	ERR_FAIL_NULL(uniform_set_cache);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	CopyPushConstant push_constant = {};
 
-	copy.push_constant.section[0] = 0;
-	copy.push_constant.section[1] = 0;
-	copy.push_constant.section[2] = p_region.size.width;
-	copy.push_constant.section[3] = p_region.size.height;
-	copy.push_constant.target[0] = p_region.position.x;
-	copy.push_constant.target[1] = p_region.position.y;
-	copy.push_constant.set_color[0] = p_color.r;
-	copy.push_constant.set_color[1] = p_color.g;
-	copy.push_constant.set_color[2] = p_color.b;
-	copy.push_constant.set_color[3] = p_color.a;
+	push_constant.section[0] = 0;
+	push_constant.section[1] = 0;
+	push_constant.section[2] = p_region.size.width;
+	push_constant.section[3] = p_region.size.height;
+	push_constant.target[0] = p_region.position.x;
+	push_constant.target[1] = p_region.position.y;
+	push_constant.set_color[0] = p_color.r;
+	push_constant.set_color[1] = p_color.g;
+	push_constant.set_color[2] = p_color.b;
+	push_constant.set_color[3] = p_color.a;
 
 	// setup our uniforms
 	RD::Uniform u_dest_texture(RD::UNIFORM_TYPE_IMAGE, 0, p_dest_texture);
@@ -958,10 +1098,13 @@ void CopyEffects::set_color(RID p_dest_texture, const Color &p_color, const Rect
 	RID shader = copy.shader.version_get_shader(copy.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 
+	// Update buffer and uniform set
+	const PushConstantsEmuBase::ParamsUniform params_uniform = copy.push_constant.upload_and_advance(push_constant);
+
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, copy.pipelines[mode]);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 3, u_dest_texture), 3);
-	RD::get_singleton()->compute_list_set_push_constant(compute_list, &copy.push_constant, sizeof(CopyPushConstant));
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_dest_texture), 0);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, params_uniform.set, 1);
 	RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_region.size.width, p_region.size.height, 1);
 	RD::get_singleton()->compute_list_end();
 }
@@ -974,12 +1117,12 @@ void CopyEffects::set_color_raster(RID p_dest_texture, const Color &p_color, con
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy_to_fb.push_constant, 0, sizeof(CopyToFbPushConstant));
+	CopyToFbPushConstant push_constant = {};
 
-	copy_to_fb.push_constant.set_color[0] = p_color.r;
-	copy_to_fb.push_constant.set_color[1] = p_color.g;
-	copy_to_fb.push_constant.set_color[2] = p_color.b;
-	copy_to_fb.push_constant.set_color[3] = p_color.a;
+	push_constant.set_color[0] = p_color.r;
+	push_constant.set_color[1] = p_color.g;
+	push_constant.set_color[2] = p_color.b;
+	push_constant.set_color[3] = p_color.a;
 
 	RID dest_framebuffer = FramebufferCacheRD::get_singleton()->get_cache(p_dest_texture);
 
@@ -988,10 +1131,12 @@ void CopyEffects::set_color_raster(RID p_dest_texture, const Color &p_color, con
 	RID shader = copy_to_fb.shader.version_get_shader(copy_to_fb.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 
+	const PushConstantsEmuBase::ParamsUniform params_uniform = copy_to_fb.push_constant.upload_and_advance(push_constant);
+
 	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(dest_framebuffer, RD::DRAW_DEFAULT_ALL, Vector<Color>(), 1.0f, 0, p_region);
 	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, copy_to_fb.pipelines[mode].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(dest_framebuffer)));
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, params_uniform.set, 1);
 	RD::get_singleton()->draw_list_bind_index_array(draw_list, material_storage->get_quad_index_array());
-	RD::get_singleton()->draw_list_set_push_constant(draw_list, &copy_to_fb.push_constant, sizeof(CopyToFbPushConstant));
 	RD::get_singleton()->draw_list_draw(draw_list, true);
 	RD::get_singleton()->draw_list_end();
 }
@@ -1017,6 +1162,8 @@ void CopyEffects::copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuf
 	push_constant.texel_size[1] = 1.0f / p_dst_size.height;
 	push_constant.texel_size[0] *= p_dp_flip ? -1.0f : 1.0f; // Encode dp flip as x size sign
 
+	const PushConstantsEmuBase::ParamsUniform params_uniform = cube_to_dp.push_constant.upload_and_advance(push_constant);
+
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
@@ -1030,7 +1177,13 @@ void CopyEffects::copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuf
 	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
 	RD::get_singleton()->draw_list_bind_index_array(draw_list, material_storage->get_quad_index_array());
 
-	RD::get_singleton()->draw_list_set_push_constant(draw_list, &push_constant, sizeof(CopyToDPPushConstant));
+	// <TF>
+	// @ShadyTF
+	// replace push constants with UBO
+	// Was:
+	//RD::get_singleton()->draw_list_set_push_constant(draw_list, &push_constant, sizeof(CopyToDPPushConstant));
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, params_uniform.set, 1);
+	// </TF>
 	RD::get_singleton()->draw_list_draw(draw_list, true);
 	RD::get_singleton()->draw_list_end();
 }
@@ -1050,15 +1203,18 @@ void CopyEffects::cubemap_downsample(RID p_source_cubemap, RID p_dest_cubemap, c
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
 	RD::Uniform u_source_cubemap(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_cubemap }));
-	RD::Uniform u_dest_cubemap(RD::UNIFORM_TYPE_IMAGE, 0, Vector<RID>({ p_dest_cubemap }));
+	RD::Uniform u_dest_cubemap(RD::UNIFORM_TYPE_IMAGE, 1, Vector<RID>({ p_dest_cubemap }));
+
+	uniforms.clear();
+	uniforms.push_back(u_source_cubemap);
+	uniforms.push_back(u_dest_cubemap);
 
 	RID shader = cubemap_downsampler.compute_shader.version_get_shader(cubemap_downsampler.shader_version, 0);
 	ERR_FAIL_COND(shader.is_null());
 
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, cubemap_downsampler.compute_pipeline);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_source_cubemap), 0);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 1, u_dest_cubemap), 1);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache_vec(shader, 0, uniforms), 0);
 
 	int x_groups = Math::division_round_up(p_size.x, 8);
 	int y_groups = Math::division_round_up(p_size.y, 8);
@@ -1108,7 +1264,7 @@ void CopyEffects::cubemap_filter(RID p_source_cubemap, Vector<RID> p_dest_cubema
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	Vector<RD::Uniform> uniforms;
+	uniforms.clear();
 	for (int i = 0; i < p_dest_cubemap.size(); i++) {
 		RD::Uniform u;
 		u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
@@ -1201,7 +1357,11 @@ void CopyEffects::cubemap_roughness(RID p_source_rd_texture, RID p_dest_texture,
 	RID default_mipmap_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
 	RD::Uniform u_source_rd_texture(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_mipmap_sampler, p_source_rd_texture }));
-	RD::Uniform u_dest_texture(RD::UNIFORM_TYPE_IMAGE, 0, Vector<RID>({ p_dest_texture }));
+	RD::Uniform u_dest_texture(RD::UNIFORM_TYPE_IMAGE, 1, Vector<RID>({ p_dest_texture }));
+
+	uniforms.clear();
+	uniforms.push_back(u_source_rd_texture);
+	uniforms.push_back(u_dest_texture);
 
 	RID shader = roughness.compute_shader.version_get_shader(roughness.shader_version, 0);
 	ERR_FAIL_COND(shader.is_null());
@@ -1209,8 +1369,7 @@ void CopyEffects::cubemap_roughness(RID p_source_rd_texture, RID p_dest_texture,
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, roughness.compute_pipeline);
 
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_source_rd_texture), 0);
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 1, u_dest_texture), 1);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache_vec(shader, 0, uniforms), 0);
 
 	RD::get_singleton()->compute_list_set_push_constant(compute_list, &roughness.push_constant, sizeof(CubemapRoughnessPushConstant));
 

--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "servers/rendering/push_constants_emu.h"
 #include "servers/rendering/renderer_rd/pipeline_cache_rd.h"
 #include "servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/effects/copy.glsl.gen.h"
@@ -51,6 +52,8 @@ namespace RendererRD {
 class CopyEffects {
 private:
 	bool prefer_raster_effects;
+
+	static thread_local LocalVector<RD::Uniform> uniforms;
 
 	// Blur raster shader
 
@@ -96,10 +99,14 @@ private:
 	};
 
 	struct BlurRaster {
-		BlurRasterPushConstant push_constant;
 		BlurRasterShaderRD shader;
 		RID shader_version;
 		PipelineCacheRD pipelines[BLUR_MODE_MAX];
+		// <TF>
+		// @ShadyTF
+		// replace push constants with UBO
+		PushConstantsEmu<BlurRasterPushConstant> push_constant = { "blur_raster" };
+		// </TF>
 	} blur_raster;
 
 	// Copy shader
@@ -158,11 +165,12 @@ private:
 	};
 
 	struct Copy {
-		CopyPushConstant push_constant;
 		CopyShaderRD shader;
+
 		RID shader_version;
 		RID pipelines[COPY_MODE_MAX];
 
+		PushConstantsEmu<CopyPushConstant> push_constant = { "copy" };
 	} copy;
 
 	// Copy to FB shader
@@ -203,10 +211,15 @@ private:
 	};
 
 	struct CopyToFb {
-		CopyToFbPushConstant push_constant;
 		CopyToFbShaderRD shader;
 		RID shader_version;
 		PipelineCacheRD pipelines[COPY_TO_FB_MAX];
+
+		// <TF>
+		// @ShadyTF
+		// replace push constants with UBO
+		PushConstantsEmu<CopyToFbPushConstant> push_constant = { "copy_to_fb" };
+		// </TF>
 
 	} copy_to_fb;
 
@@ -222,6 +235,11 @@ private:
 		CubeToDpShaderRD shader;
 		RID shader_version;
 		PipelineCacheRD pipeline;
+		// <TF>
+		// @ShadyTF
+		// replace push constants with UBO
+		PushConstantsEmu<CopyToDPPushConstant> push_constant = { "cube_to_dp" };
+		// </TF>
 	} cube_to_dp;
 
 	// Cubemap effects

--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -54,7 +54,10 @@ ToneMapper::ToneMapper() {
 		tonemap_modes.push_back("\n#define USE_MULTIVIEW\n#define SUBPASS\n");
 		tonemap_modes.push_back("\n#define USE_MULTIVIEW\n#define SUBPASS\n#define USE_1D_LUT\n");
 
-		tonemap.shader.initialize(tonemap_modes);
+		Vector<uint64_t> dynamic_buffers;
+		dynamic_buffers.push_back(RDD::DynamicBuffer::encode(tonemap.push_constant.set_idx(), 0));
+
+		tonemap.shader.initialize(tonemap_modes, "", Vector<RD::PipelineImmutableSampler>(), dynamic_buffers);
 
 		if (!RendererCompositorRD::get_singleton()->is_xr_enabled()) {
 			tonemap.shader.set_variant_enabled(TONEMAP_MODE_NORMAL_MULTIVIEW, false);
@@ -74,10 +77,17 @@ ToneMapper::ToneMapper() {
 				tonemap.pipelines[i].clear();
 			}
 		}
+
+		// <TF>
+		// @ShadyTF
+		// prepare uniform set and buffer
+		tonemap.push_constant.init(tonemap.shader.version_get_shader(tonemap.shader_version, 0));
+		// </TF>
 	}
 }
 
 ToneMapper::~ToneMapper() {
+	tonemap.push_constant.uninit();
 	tonemap.shader.version_free(tonemap.shader_version);
 }
 
@@ -87,47 +97,49 @@ void ToneMapper::tonemapper(RID p_source_color, RID p_dst_framebuffer, const Ton
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&tonemap.push_constant, 0, sizeof(TonemapPushConstant));
+	TonemapPushConstant push_constant{};
 
-	tonemap.push_constant.flags |= p_settings.use_bcs ? TONEMAP_FLAG_USE_BCS : 0;
-	tonemap.push_constant.bcs[0] = p_settings.brightness;
-	tonemap.push_constant.bcs[1] = p_settings.contrast;
-	tonemap.push_constant.bcs[2] = p_settings.saturation;
+	push_constant.flags |= p_settings.use_bcs ? TONEMAP_FLAG_USE_BCS : 0;
+	push_constant.bcs[0] = p_settings.brightness;
+	push_constant.bcs[1] = p_settings.contrast;
+	push_constant.bcs[2] = p_settings.saturation;
 
-	tonemap.push_constant.flags |= p_settings.use_glow ? TONEMAP_FLAG_USE_GLOW : 0;
-	tonemap.push_constant.glow_intensity = p_settings.glow_intensity;
-	tonemap.push_constant.glow_map_strength = p_settings.glow_map_strength;
-	tonemap.push_constant.glow_levels[0] = p_settings.glow_levels[0]; // clean this up to just pass by pointer or something
-	tonemap.push_constant.glow_levels[1] = p_settings.glow_levels[1];
-	tonemap.push_constant.glow_levels[2] = p_settings.glow_levels[2];
-	tonemap.push_constant.glow_levels[3] = p_settings.glow_levels[3];
-	tonemap.push_constant.glow_levels[4] = p_settings.glow_levels[4];
-	tonemap.push_constant.glow_levels[5] = p_settings.glow_levels[5];
-	tonemap.push_constant.glow_levels[6] = p_settings.glow_levels[6];
-	tonemap.push_constant.glow_texture_size[0] = p_settings.glow_texture_size.x;
-	tonemap.push_constant.glow_texture_size[1] = p_settings.glow_texture_size.y;
-	tonemap.push_constant.glow_mode = p_settings.glow_mode;
+	push_constant.flags |= p_settings.use_glow ? TONEMAP_FLAG_USE_GLOW : 0;
+	push_constant.glow_intensity = p_settings.glow_intensity;
+	push_constant.glow_map_strength = p_settings.glow_map_strength;
+	push_constant.glow_levels[0] = p_settings.glow_levels[0]; // clean this up to just pass by pointer or something
+	push_constant.glow_levels[1] = p_settings.glow_levels[1];
+	push_constant.glow_levels[2] = p_settings.glow_levels[2];
+	push_constant.glow_levels[3] = p_settings.glow_levels[3];
+	push_constant.glow_levels[4] = p_settings.glow_levels[4];
+	push_constant.glow_levels[5] = p_settings.glow_levels[5];
+	push_constant.glow_levels[6] = p_settings.glow_levels[6];
+	push_constant.glow_texture_size[0] = p_settings.glow_texture_size.x;
+	push_constant.glow_texture_size[1] = p_settings.glow_texture_size.y;
+	push_constant.glow_mode = p_settings.glow_mode;
 
 	int mode = p_settings.glow_use_bicubic_upscale ? TONEMAP_MODE_BICUBIC_GLOW_FILTER : TONEMAP_MODE_NORMAL;
 	if (p_settings.use_1d_color_correction) {
 		mode += 2;
 	}
 
-	tonemap.push_constant.tonemapper = p_settings.tonemap_mode;
-	tonemap.push_constant.flags |= p_settings.use_auto_exposure ? TONEMAP_FLAG_USE_AUTO_EXPOSURE : 0;
-	tonemap.push_constant.exposure = p_settings.exposure;
-	tonemap.push_constant.white = p_settings.white;
-	tonemap.push_constant.auto_exposure_scale = p_settings.auto_exposure_scale;
-	tonemap.push_constant.luminance_multiplier = p_settings.luminance_multiplier;
+	push_constant.tonemapper = p_settings.tonemap_mode;
+	push_constant.flags |= p_settings.use_auto_exposure ? TONEMAP_FLAG_USE_AUTO_EXPOSURE : 0;
+	push_constant.exposure = p_settings.exposure;
+	push_constant.white = p_settings.white;
+	push_constant.auto_exposure_scale = p_settings.auto_exposure_scale;
+	push_constant.luminance_multiplier = p_settings.luminance_multiplier;
 
-	tonemap.push_constant.flags |= p_settings.use_color_correction ? TONEMAP_FLAG_USE_COLOR_CORRECTION : 0;
+	push_constant.flags |= p_settings.use_color_correction ? TONEMAP_FLAG_USE_COLOR_CORRECTION : 0;
 
-	tonemap.push_constant.flags |= p_settings.use_fxaa ? TONEMAP_FLAG_USE_FXAA : 0;
-	tonemap.push_constant.flags |= p_settings.use_debanding ? TONEMAP_FLAG_USE_DEBANDING : 0;
-	tonemap.push_constant.pixel_size[0] = 1.0 / p_settings.texture_size.x;
-	tonemap.push_constant.pixel_size[1] = 1.0 / p_settings.texture_size.y;
+	push_constant.flags |= p_settings.use_fxaa ? TONEMAP_FLAG_USE_FXAA : 0;
+	push_constant.flags |= p_settings.use_debanding ? TONEMAP_FLAG_USE_DEBANDING : 0;
+	push_constant.pixel_size[0] = 1.0 / p_settings.texture_size.x;
+	push_constant.pixel_size[1] = 1.0 / p_settings.texture_size.y;
 
-	tonemap.push_constant.flags |= p_settings.convert_to_srgb ? TONEMAP_FLAG_CONVERT_TO_SRGB : 0;
+	push_constant.flags |= p_settings.convert_to_srgb ? TONEMAP_FLAG_CONVERT_TO_SRGB : 0;
+
+	PushConstantsEmuBase::ParamsUniform params_uniform = tonemap.push_constant.upload_and_advance(push_constant);
 
 	if (p_settings.view_count > 1) {
 		// Use USE_MULTIVIEW versions
@@ -137,43 +149,64 @@ void ToneMapper::tonemapper(RID p_source_color, RID p_dst_framebuffer, const Ton
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 	RID default_mipmap_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
-	RD::Uniform u_source_color(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_color }));
+	thread_local LocalVector<RD::Uniform> uniforms;
+	uniforms.clear();
 
-	RD::Uniform u_exposure_texture;
-	u_exposure_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_exposure_texture.binding = 0;
-	u_exposure_texture.append_id(default_sampler);
-	u_exposure_texture.append_id(p_settings.exposure_texture);
+	{
+		RD::Uniform u_source_color(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_color }));
+		uniforms.push_back(u_source_color);
+	}
 
-	RD::Uniform u_glow_texture;
-	u_glow_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_glow_texture.binding = 0;
-	u_glow_texture.append_id(default_mipmap_sampler);
-	u_glow_texture.append_id(p_settings.glow_texture);
+	{
+		RD::Uniform u_exposure_texture;
+		u_exposure_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+		u_exposure_texture.binding = 1;
+		u_exposure_texture.append_id(default_sampler);
+		u_exposure_texture.append_id(p_settings.exposure_texture);
+		uniforms.push_back(u_exposure_texture);
+	}
 
-	RD::Uniform u_glow_map;
-	u_glow_map.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_glow_map.binding = 1;
-	u_glow_map.append_id(default_mipmap_sampler);
-	u_glow_map.append_id(p_settings.glow_map);
+	{
+		RD::Uniform u_glow_texture;
+		u_glow_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+		u_glow_texture.binding = 2;
+		u_glow_texture.append_id(default_mipmap_sampler);
+		u_glow_texture.append_id(p_settings.glow_texture);
+		uniforms.push_back(u_glow_texture);
+	}
 
-	RD::Uniform u_color_correction_texture;
-	u_color_correction_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_color_correction_texture.binding = 0;
-	u_color_correction_texture.append_id(default_sampler);
-	u_color_correction_texture.append_id(p_settings.color_correction_texture);
+	{
+		RD::Uniform u_glow_map;
+		u_glow_map.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+		u_glow_map.binding = 3;
+		u_glow_map.append_id(default_mipmap_sampler);
+		u_glow_map.append_id(p_settings.glow_map);
+		uniforms.push_back(u_glow_map);
+	}
+
+	{
+		RD::Uniform u_color_correction_texture;
+		u_color_correction_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+		u_color_correction_texture.binding = 4;
+		u_color_correction_texture.append_id(default_sampler);
+		u_color_correction_texture.append_id(p_settings.color_correction_texture);
+		uniforms.push_back(u_color_correction_texture);
+	}
 
 	RID shader = tonemap.shader.version_get_shader(tonemap.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 
 	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(p_dst_framebuffer);
 	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, tonemap.pipelines[mode].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(p_dst_framebuffer), false, RD::get_singleton()->draw_list_get_current_pass()));
-	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 0, u_source_color), 0);
-	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 1, u_exposure_texture), 1);
-	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 2, u_glow_texture, u_glow_map), 2);
-	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 3, u_color_correction_texture), 3);
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache_vec(shader, 0, uniforms), 0);
 
-	RD::get_singleton()->draw_list_set_push_constant(draw_list, &tonemap.push_constant, sizeof(TonemapPushConstant));
+	// <TF>
+	// @ShadyTF
+	// replace push constant with UBO
+	// was:
+	//RD::get_singleton()->draw_list_set_push_constant(draw_list, &tonemap.push_constant, sizeof(TonemapPushConstant));
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, params_uniform.set, 1);
+	// </TF>
 	RD::get_singleton()->draw_list_draw(draw_list, false, 1u, 3u);
 	RD::get_singleton()->draw_list_end();
 }
@@ -184,15 +217,15 @@ void ToneMapper::tonemapper(RD::DrawListID p_subpass_draw_list, RID p_source_col
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&tonemap.push_constant, 0, sizeof(TonemapPushConstant));
+	TonemapPushConstant push_constant{};
 
-	tonemap.push_constant.flags |= p_settings.use_bcs ? TONEMAP_FLAG_USE_BCS : 0;
-	tonemap.push_constant.bcs[0] = p_settings.brightness;
-	tonemap.push_constant.bcs[1] = p_settings.contrast;
-	tonemap.push_constant.bcs[2] = p_settings.saturation;
+	push_constant.flags |= p_settings.use_bcs ? TONEMAP_FLAG_USE_BCS : 0;
+	push_constant.bcs[0] = p_settings.brightness;
+	push_constant.bcs[1] = p_settings.contrast;
+	push_constant.bcs[2] = p_settings.saturation;
 
 	ERR_FAIL_COND_MSG(p_settings.use_glow, "Glow is not supported when using subpasses.");
-	tonemap.push_constant.flags |= p_settings.use_glow ? TONEMAP_FLAG_USE_GLOW : 0;
+	push_constant.flags |= p_settings.use_glow ? TONEMAP_FLAG_USE_GLOW : 0;
 
 	int mode = p_settings.use_1d_color_correction ? TONEMAP_MODE_SUBPASS_1D_LUT : TONEMAP_MODE_SUBPASS;
 	if (p_settings.view_count > 1) {
@@ -200,60 +233,83 @@ void ToneMapper::tonemapper(RD::DrawListID p_subpass_draw_list, RID p_source_col
 		mode += 6;
 	}
 
-	tonemap.push_constant.tonemapper = p_settings.tonemap_mode;
-	tonemap.push_constant.flags |= p_settings.use_auto_exposure ? TONEMAP_FLAG_USE_AUTO_EXPOSURE : 0;
-	tonemap.push_constant.exposure = p_settings.exposure;
-	tonemap.push_constant.white = p_settings.white;
-	tonemap.push_constant.auto_exposure_scale = p_settings.auto_exposure_scale;
+	push_constant.tonemapper = p_settings.tonemap_mode;
+	push_constant.flags |= p_settings.use_auto_exposure ? TONEMAP_FLAG_USE_AUTO_EXPOSURE : 0;
+	push_constant.exposure = p_settings.exposure;
+	push_constant.white = p_settings.white;
+	push_constant.auto_exposure_scale = p_settings.auto_exposure_scale;
 
-	tonemap.push_constant.flags |= p_settings.use_color_correction ? TONEMAP_FLAG_USE_COLOR_CORRECTION : 0;
+	push_constant.flags |= p_settings.use_color_correction ? TONEMAP_FLAG_USE_COLOR_CORRECTION : 0;
 
-	tonemap.push_constant.flags |= p_settings.use_debanding ? TONEMAP_FLAG_USE_DEBANDING : 0;
-	tonemap.push_constant.luminance_multiplier = p_settings.luminance_multiplier;
+	push_constant.flags |= p_settings.use_debanding ? TONEMAP_FLAG_USE_DEBANDING : 0;
+	push_constant.luminance_multiplier = p_settings.luminance_multiplier;
 
-	tonemap.push_constant.flags |= p_settings.convert_to_srgb ? TONEMAP_FLAG_CONVERT_TO_SRGB : 0;
+	push_constant.flags |= p_settings.convert_to_srgb ? TONEMAP_FLAG_CONVERT_TO_SRGB : 0;
+
+	PushConstantsEmuBase::ParamsUniform params_uniform = tonemap.push_constant.upload_and_advance(push_constant);
 
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 	RID default_mipmap_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
-	RD::Uniform u_source_color;
-	u_source_color.uniform_type = RD::UNIFORM_TYPE_INPUT_ATTACHMENT;
-	u_source_color.binding = 0;
-	u_source_color.append_id(p_source_color);
+	thread_local LocalVector<RD::Uniform> uniforms;
+	uniforms.clear();
 
-	RD::Uniform u_exposure_texture;
-	u_exposure_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_exposure_texture.binding = 0;
-	u_exposure_texture.append_id(default_sampler);
-	u_exposure_texture.append_id(p_settings.exposure_texture);
+	{
+		RD::Uniform u_source_color;
+		u_source_color.uniform_type = RD::UNIFORM_TYPE_INPUT_ATTACHMENT;
+		u_source_color.binding = 0;
+		u_source_color.append_id(p_source_color);
+		uniforms.push_back(u_source_color);
+	}
 
-	RD::Uniform u_glow_texture;
-	u_glow_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_glow_texture.binding = 0;
-	u_glow_texture.append_id(default_mipmap_sampler);
-	u_glow_texture.append_id(p_settings.glow_texture);
+	{
+		RD::Uniform u_exposure_texture;
+		u_exposure_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+		u_exposure_texture.binding = 1;
+		u_exposure_texture.append_id(default_sampler);
+		u_exposure_texture.append_id(p_settings.exposure_texture);
+		uniforms.push_back(u_exposure_texture);
+	}
 
-	RD::Uniform u_glow_map;
-	u_glow_map.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_glow_map.binding = 1;
-	u_glow_map.append_id(default_mipmap_sampler);
-	u_glow_map.append_id(p_settings.glow_map);
+	{
+		RD::Uniform u_glow_texture;
+		u_glow_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+		u_glow_texture.binding = 2;
+		u_glow_texture.append_id(default_mipmap_sampler);
+		u_glow_texture.append_id(p_settings.glow_texture);
+		uniforms.push_back(u_glow_texture);
+	}
 
-	RD::Uniform u_color_correction_texture;
-	u_color_correction_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_color_correction_texture.binding = 0;
-	u_color_correction_texture.append_id(default_sampler);
-	u_color_correction_texture.append_id(p_settings.color_correction_texture);
+	{
+		RD::Uniform u_glow_map;
+		u_glow_map.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+		u_glow_map.binding = 3;
+		u_glow_map.append_id(default_mipmap_sampler);
+		u_glow_map.append_id(p_settings.glow_map);
+		uniforms.push_back(u_glow_map);
+	}
+
+	{
+		RD::Uniform u_color_correction_texture;
+		u_color_correction_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+		u_color_correction_texture.binding = 4;
+		u_color_correction_texture.append_id(default_sampler);
+		u_color_correction_texture.append_id(p_settings.color_correction_texture);
+		uniforms.push_back(u_color_correction_texture);
+	}
 
 	RID shader = tonemap.shader.version_get_shader(tonemap.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 
 	RD::get_singleton()->draw_list_bind_render_pipeline(p_subpass_draw_list, tonemap.pipelines[mode].get_render_pipeline(RD::INVALID_ID, p_dst_format_id, false, RD::get_singleton()->draw_list_get_current_pass()));
-	RD::get_singleton()->draw_list_bind_uniform_set(p_subpass_draw_list, uniform_set_cache->get_cache(shader, 0, u_source_color), 0);
-	RD::get_singleton()->draw_list_bind_uniform_set(p_subpass_draw_list, uniform_set_cache->get_cache(shader, 1, u_exposure_texture), 1); // should be set to a default texture, it's ignored
-	RD::get_singleton()->draw_list_bind_uniform_set(p_subpass_draw_list, uniform_set_cache->get_cache(shader, 2, u_glow_texture, u_glow_map), 2); // should be set to a default texture, it's ignored
-	RD::get_singleton()->draw_list_bind_uniform_set(p_subpass_draw_list, uniform_set_cache->get_cache(shader, 3, u_color_correction_texture), 3);
+	RD::get_singleton()->draw_list_bind_uniform_set(p_subpass_draw_list, uniform_set_cache->get_cache_vec(shader, 0, uniforms), 0);
 
-	RD::get_singleton()->draw_list_set_push_constant(p_subpass_draw_list, &tonemap.push_constant, sizeof(TonemapPushConstant));
+	// <TF>
+	// @ShadyTF
+	// replace push constant with UBO
+	// was:
+	//RD::get_singleton()->draw_list_set_push_constant(p_subpass_draw_list, &tonemap.push_constant, sizeof(TonemapPushConstant));
+	RD::get_singleton()->draw_list_bind_uniform_set(p_subpass_draw_list, params_uniform.set, 1);
+	// </TF>
 	RD::get_singleton()->draw_list_draw(p_subpass_draw_list, false, 1u, 3u);
 }

--- a/servers/rendering/renderer_rd/effects/tone_mapper.h
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "servers/rendering/push_constants_emu.h"
 #include "servers/rendering/renderer_rd/pipeline_cache_rd.h"
 #include "servers/rendering/renderer_rd/shaders/effects/tonemap.glsl.gen.h"
 
@@ -79,9 +80,16 @@ private:
 		float glow_intensity; //  4 - 44
 		float glow_map_strength; //  4 - 48
 
-		uint32_t glow_mode; //  4 - 52
-		float glow_levels[7]; // 28 - 80
-
+		// <TF>
+		// @ShadyTF
+		// replace push constants with UBO
+		// swap the members order to correct alignment of UBO
+		// Was:
+		//		uint32_t glow_mode; //  4 - 52
+		//		float glow_levels[7]; // 28 - 80
+		float glow_levels[7]; // 28 - 76
+		uint32_t glow_mode; //  4 - 80
+		// </TF>
 		float exposure; //  4 - 84
 		float white; //  4 - 88
 		float auto_exposure_scale; //  4 - 92
@@ -93,7 +101,7 @@ private:
 	 * compute, as that framebuffer might be in different formats
 	 */
 	struct Tonemap {
-		TonemapPushConstant push_constant;
+		PushConstantsEmu<TonemapPushConstant> push_constant = { "tonemap" };
 		TonemapShaderRD shader;
 		RID shader_version;
 		PipelineCacheRD pipelines[TONEMAP_MODE_MAX];

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -210,6 +210,51 @@ static _FORCE_INLINE_ void store_transform_3x3(const Basis &p_basis, float *p_ar
 	p_array[11] = 0;
 }
 
+// <TF>
+// @ShadyTF
+// replacing push constants with uniform buffer
+RID SkyRD::_create_push_constant_uniform_set(RID p_params_uniform_buffer) {
+	Vector<RD::Uniform> uniforms;
+
+	{
+		RD::Uniform u;
+		u.binding = 0;
+		u.append_id(p_params_uniform_buffer);
+		u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC;
+		uniforms.push_back(u);
+	}
+
+	{
+		RD::Uniform u;
+		u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+		u.binding = 1;
+		u.append_id(RendererRD::MaterialStorage::get_singleton()->global_shader_uniforms_get_storage_buffer());
+		uniforms.push_back(u);
+	}
+
+	{
+		RD::Uniform u;
+		u.binding = 2;
+		u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+		u.append_id(sky_scene_state.uniform_buffer);
+		uniforms.push_back(u);
+	}
+
+	{
+		RD::Uniform u;
+		u.binding = 3;
+		u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+		u.append_id(sky_scene_state.directional_light_buffer);
+		uniforms.push_back(u);
+	}
+
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+	material_storage->samplers_rd_get_default().append_uniforms(uniforms, SAMPLERS_BINDING_FIRST_INDEX);
+
+	return RD::get_singleton()->uniform_set_create(uniforms, sky_shader.default_shader_rd, SKY_SET_UNIFORMS);
+}
+
+// </TF>
 void SkyRD::_render_sky(RD::DrawListID p_list, float p_time, RID p_fb, PipelineCacheRD *p_pipeline, RID p_uniform_set, RID p_texture_set, const Projection &p_projection, const Basis &p_orientation, const Vector3 &p_position, float p_luminance_multiplier, float p_brightness_multiplier) {
 	SkyPushConstant sky_push_constant;
 
@@ -229,6 +274,8 @@ void SkyRD::_render_sky(RD::DrawListID p_list, float p_time, RID p_fb, PipelineC
 	sky_push_constant.brightness_multiplier = p_brightness_multiplier;
 	store_transform_3x3(p_orientation, sky_push_constant.orientation);
 
+	const PushConstantsEmuBase::ParamsUniform params_uniform = sky_scene_state.push_constant.upload_and_advance(sky_push_constant, this);
+
 	RenderingDevice::FramebufferFormatID fb_format = RD::get_singleton()->framebuffer_get_format(p_fb);
 
 	RD::DrawListID draw_list = p_list;
@@ -237,7 +284,7 @@ void SkyRD::_render_sky(RD::DrawListID p_list, float p_time, RID p_fb, PipelineC
 
 	// Update uniform sets.
 	{
-		RD::get_singleton()->draw_list_bind_uniform_set(draw_list, sky_scene_state.uniform_set, SKY_SET_UNIFORMS);
+		RD::get_singleton()->draw_list_bind_uniform_set(draw_list, params_uniform.set, SKY_SET_UNIFORMS);
 		if (p_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(p_uniform_set)) { // Material may not have a uniform set.
 			RD::get_singleton()->draw_list_bind_uniform_set(draw_list, p_uniform_set, SKY_SET_MATERIAL);
 		}
@@ -249,8 +296,15 @@ void SkyRD::_render_sky(RD::DrawListID p_list, float p_time, RID p_fb, PipelineC
 			RD::get_singleton()->draw_list_bind_uniform_set(draw_list, sky_scene_state.default_fog_uniform_set, SKY_SET_FOG);
 		}
 	}
-
-	RD::get_singleton()->draw_list_set_push_constant(draw_list, &sky_push_constant, sizeof(SkyPushConstant));
+	// <TF>
+	// @ShadyTF
+	// replacing push constants with uniform buffer
+	// Was:
+	//	RD::get_singleton()->draw_list_set_push_constant(draw_list, &sky_push_constant, sizeof(SkyPushConstant));
+	if (use_push_constants) {
+		RD::get_singleton()->draw_list_set_push_constant(draw_list, &sky_push_constant, sizeof(SkyPushConstant));
+	}
+	// </TF>
 
 	RD::get_singleton()->draw_list_draw(draw_list, false, 1u, 3u);
 }
@@ -740,6 +794,13 @@ void SkyRD::init() {
 		String defines = "\n#define MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS " + itos(sky_scene_state.max_directional_lights) + "\n";
 		defines += "\n#define SAMPLERS_BINDING_FIRST_INDEX " + itos(SAMPLERS_BINDING_FIRST_INDEX) + "\n";
 
+		// <TF>
+		// @ShadyTF
+		// replacing push constants with uniform buffer
+		if (use_push_constants) {
+			defines += "\n#define USE_PUSH_CONSTANTS \n";
+		}
+		// </TF>
 		// Initialize sky
 		Vector<String> sky_modes;
 		sky_modes.push_back(""); // Full size
@@ -753,7 +814,12 @@ void SkyRD::init() {
 		sky_modes.push_back("\n#define USE_HALF_RES_PASS\n#define USE_MULTIVIEW\n"); // Half Res multiview
 		sky_modes.push_back("\n#define USE_QUARTER_RES_PASS\n#define USE_MULTIVIEW\n"); // Quarter res multiview
 
-		sky_shader.shader.initialize(sky_modes, defines);
+		Vector<uint64_t> dynamic_buffers;
+		dynamic_buffers.push_back(RDD::DynamicBuffer::encode(0, 0)); // sky_scene_state.push_constant.
+
+		sky_shader.shader.initialize(sky_modes, defines, Vector<RD::PipelineImmutableSampler>(), dynamic_buffers);
+
+		sky_scene_state.push_constant.init();
 
 		if (!RendererCompositorRD::get_singleton()->is_xr_enabled()) {
 			sky_shader.shader.set_variant_enabled(SKY_VERSION_BACKGROUND_MULTIVIEW, false);
@@ -847,38 +913,7 @@ void sky() {
 
 		SkyMaterialData *md = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_shader.default_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 		sky_shader.default_shader_rd = sky_shader.shader.version_get_shader(md->shader_data->version, SKY_VERSION_BACKGROUND);
-
 		sky_scene_state.uniform_buffer = RD::get_singleton()->uniform_buffer_create(sizeof(SkySceneState::UBO));
-
-		Vector<RD::Uniform> uniforms;
-
-		{
-			RD::Uniform u;
-			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
-			u.binding = 1;
-			u.append_id(RendererRD::MaterialStorage::get_singleton()->global_shader_uniforms_get_storage_buffer());
-			uniforms.push_back(u);
-		}
-
-		{
-			RD::Uniform u;
-			u.binding = 2;
-			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
-			u.append_id(sky_scene_state.uniform_buffer);
-			uniforms.push_back(u);
-		}
-
-		{
-			RD::Uniform u;
-			u.binding = 3;
-			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
-			u.append_id(sky_scene_state.directional_light_buffer);
-			uniforms.push_back(u);
-		}
-
-		material_storage->samplers_rd_get_default().append_uniforms(uniforms, SAMPLERS_BINDING_FIRST_INDEX);
-
-		sky_scene_state.uniform_set = RD::get_singleton()->uniform_set_create(uniforms, sky_shader.default_shader_rd, SKY_SET_UNIFORMS);
 	}
 
 	{
@@ -962,9 +997,7 @@ SkyRD::~SkyRD() {
 	material_storage->shader_free(sky_scene_state.fog_shader);
 	material_storage->material_free(sky_scene_state.fog_material);
 
-	if (RD::get_singleton()->uniform_set_is_valid(sky_scene_state.uniform_set)) {
-		RD::get_singleton()->free(sky_scene_state.uniform_set);
-	}
+	sky_scene_state.push_constant.uninit();
 
 	if (RD::get_singleton()->uniform_set_is_valid(sky_scene_state.default_fog_uniform_set)) {
 		RD::get_singleton()->free(sky_scene_state.default_fog_uniform_set);

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/templates/rid_owner.h"
+#include "servers/rendering/push_constants_emu.h"
 #include "servers/rendering/renderer_compositor.h"
 #include "servers/rendering/renderer_rd/pipeline_cache_rd.h"
 #include "servers/rendering/renderer_rd/shaders/environment/sky.glsl.gen.h"
@@ -136,6 +137,13 @@ private:
 	void _render_sky(RD::DrawListID p_list, float p_time, RID p_fb, PipelineCacheRD *p_pipeline, RID p_uniform_set, RID p_texture_set, const Projection &p_projection, const Basis &p_orientation, const Vector3 &p_position, float p_luminance_multiplier, float p_brightness_modifier);
 
 public:
+	// <TF>
+	// @ShadyTF
+	// replacing push constants with uniform buffer
+	// update uniform buffers
+	RID _create_push_constant_uniform_set(RID p_params_uniform_buffer);
+	// </TF>
+
 	struct SkySceneState {
 		struct UBO {
 			float combined_reprojection[RendererSceneRender::MAX_RENDER_VIEWS][16]; // 2 x 64 - 128
@@ -172,10 +180,16 @@ public:
 		uint32_t max_directional_lights;
 		uint32_t last_frame_directional_light_count;
 		RID directional_light_buffer;
-		RID uniform_set;
 		RID uniform_buffer;
 		RID fog_uniform_set;
 		RID default_fog_uniform_set;
+
+		// <TF>
+		// @ShadyTF
+		// replacing push constants with uniform buffer
+		// Only keep up to 6 (i.e. a cubemap) since that should be the general case. Peak may be much bigger though.
+		PushConstantsEmuEmbedded<SkyPushConstant, SkyRD, 6u> push_constant = { "sky_scene_state" };
+		// </TF>
 
 		RID fog_shader;
 		RID fog_material;
@@ -284,6 +298,11 @@ public:
 	mutable RID_Owner<Sky, true> sky_owner;
 	int roughness_layers;
 
+	// <TF>
+	// @ShadyTF
+	// replacing push constants with uniform buffer
+	bool use_push_constants = true;
+	// </TF>
 	RendererRD::MaterialStorage::ShaderData *_create_sky_shader_func();
 	static RendererRD::MaterialStorage::ShaderData *_create_sky_shader_funcs();
 

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -763,25 +763,37 @@ void RenderForwardClustered::_setup_environment(const RenderDataRD *p_render_dat
 	RD::get_singleton()->buffer_update(scene_state.implementation_uniform_buffers[p_index], 0, sizeof(SceneState::UBO), &scene_state.ubo);
 }
 
-void RenderForwardClustered::_update_instance_data_buffer(RenderListType p_render_list) {
-	if (scene_state.instance_data[p_render_list].size() > 0) {
-		if (scene_state.instance_buffer[p_render_list] == RID() || scene_state.instance_buffer_size[p_render_list] < scene_state.instance_data[p_render_list].size()) {
-			if (scene_state.instance_buffer[p_render_list] != RID()) {
-				RD::get_singleton()->free(scene_state.instance_buffer[p_render_list]);
-			}
-			uint32_t new_size = nearest_power_of_2_templated(MAX(uint64_t(INSTANCE_DATA_BUFFER_MIN_SIZE), scene_state.instance_data[p_render_list].size()));
-			scene_state.instance_buffer[p_render_list] = RD::get_singleton()->storage_buffer_create(new_size * sizeof(SceneState::InstanceData));
-			scene_state.instance_buffer_size[p_render_list] = new_size;
+void RenderForwardClustered::SceneState::grow_instance_buffer(RenderListType p_render_list, uint32_t p_req_element_count, bool p_append) {
+	if (p_req_element_count > 0) {
+		if (instance_buffer[p_render_list].get_size(0u) < p_req_element_count * sizeof(SceneState::InstanceData)) {
+			instance_buffer[p_render_list].uninit();
+			uint32_t new_size = nearest_power_of_2_templated(MAX(uint64_t(INSTANCE_DATA_BUFFER_MIN_SIZE), p_req_element_count));
+			instance_buffer[p_render_list].set_size(0u, new_size * sizeof(SceneState::InstanceData), true);
+			curr_gpu_ptr[p_render_list] = nullptr;
 		}
-		RD::get_singleton()->buffer_update(scene_state.instance_buffer[p_render_list], 0, sizeof(SceneState::InstanceData) * scene_state.instance_data[p_render_list].size(), scene_state.instance_data[p_render_list].ptr());
+
+		const bool must_remap = instance_buffer[p_render_list].prepare_for_map(p_append);
+		if (must_remap) {
+			curr_gpu_ptr[p_render_list] = nullptr;
+		}
 	}
 }
+
 void RenderForwardClustered::_fill_instance_data(RenderListType p_render_list, int *p_render_info, uint32_t p_offset, int32_t p_max_elements, bool p_update_buffer) {
 	RenderList *rl = &render_list[p_render_list];
 	uint32_t element_total = p_max_elements >= 0 ? uint32_t(p_max_elements) : rl->elements.size();
 
-	scene_state.instance_data[p_render_list].resize(p_offset + element_total);
 	rl->element_info.resize(p_offset + element_total);
+
+	// If p_offset == 0, grow_instance_buffer resets and increment the buffer.
+	// If this behavior ever changes, _render_shadow_begin may need to change.
+	scene_state.grow_instance_buffer(p_render_list, p_offset + element_total, p_offset != 0u);
+	if (!scene_state.curr_gpu_ptr[p_render_list] && element_total > 0u) {
+		// The old buffer was replaced for another larger one. We must start copying from scratch.
+		element_total += p_offset;
+		p_offset = 0u;
+		scene_state.curr_gpu_ptr[p_render_list] = reinterpret_cast<SceneState::InstanceData *>(scene_state.instance_buffer[p_render_list].map_raw_for_upload(0u));
+	}
 
 	if (p_render_info) {
 		p_render_info[RS::VIEWPORT_RENDER_INFO_OBJECTS_IN_FRAME] += element_total;
@@ -793,7 +805,7 @@ void RenderForwardClustered::_fill_instance_data(RenderListType p_render_list, i
 		GeometryInstanceSurfaceDataCache *surface = rl->elements[i + p_offset];
 		GeometryInstanceForwardClustered *inst = surface->owner;
 
-		SceneState::InstanceData &instance_data = scene_state.instance_data[p_render_list][i + p_offset];
+		SceneState::InstanceData instance_data;
 
 		if (likely(inst->store_transform_cache)) {
 			RendererRD::MaterialStorage::store_transform(inst->transform, instance_data.transform);
@@ -829,7 +841,9 @@ void RenderForwardClustered::_fill_instance_data(RenderListType p_render_list, i
 		instance_data.set_compressed_aabb(surface_aabb);
 		instance_data.set_uv_scale(uv_scale);
 
-		bool cant_repeat = instance_data.flags & INSTANCE_DATA_FLAG_MULTIMESH || inst->mesh_instance.is_valid();
+		scene_state.curr_gpu_ptr[p_render_list][i + p_offset] = instance_data;
+
+		const bool cant_repeat = instance_data.flags & INSTANCE_DATA_FLAG_MULTIMESH || inst->mesh_instance.is_valid();
 
 		if (prev_surface != nullptr && !cant_repeat && prev_surface->sort.sort_key1 == surface->sort.sort_key1 && prev_surface->sort.sort_key2 == surface->sort.sort_key2 && inst->mirror == prev_surface->owner->mirror && repeats < RenderElementInfo::MAX_REPEATS) {
 			//this element is the same as the previous one, count repeats to draw it using instancing
@@ -863,8 +877,8 @@ void RenderForwardClustered::_fill_instance_data(RenderListType p_render_list, i
 		}
 	}
 
-	if (p_update_buffer) {
-		_update_instance_data_buffer(p_render_list);
+	if (p_update_buffer && element_total > 0u) {
+		RenderingDevice::get_singleton()->buffer_flush(scene_state.instance_buffer[p_render_list]._get(0u));
 	}
 }
 
@@ -2708,7 +2722,8 @@ void RenderForwardClustered::_render_shadow_begin() {
 	_update_render_base_uniform_set();
 
 	render_list[RENDER_LIST_SECONDARY].clear();
-	scene_state.instance_data[RENDER_LIST_SECONDARY].clear();
+	// No need to reset scene_state.curr_gpu_ptr or scene_state.instance_buffer[RENDER_LIST_SECONDARY]
+	// because _fill_instance_data will do that if it detects p_offset == 0u.
 }
 
 void RenderForwardClustered::_render_shadow_append(RID p_framebuffer, const PagedArray<RenderGeometryInstance *> &p_instances, const Projection &p_projection, const Transform3D &p_transform, float p_zfar, float p_bias, float p_normal_bias, bool p_reverse_cull_face, bool p_use_dp, bool p_use_dp_flip, bool p_use_pancake, float p_lod_distance_multiplier, float p_screen_mesh_lod_threshold, const Rect2i &p_rect, bool p_flip_y, bool p_clear_region, bool p_begin, bool p_end, RenderingMethod::RenderInfo *p_render_info, const Size2i &p_viewport_size, const Transform3D &p_main_cam_transform) {
@@ -2782,7 +2797,11 @@ void RenderForwardClustered::_render_shadow_append(RID p_framebuffer, const Page
 }
 
 void RenderForwardClustered::_render_shadow_process() {
-	_update_instance_data_buffer(RENDER_LIST_SECONDARY);
+	RenderingDevice *rd = RenderingDevice::get_singleton();
+	if (scene_state.instance_buffer[RENDER_LIST_SECONDARY].get_size(0u) > 0u) {
+		rd->buffer_flush(scene_state.instance_buffer[RENDER_LIST_SECONDARY]._get(0u));
+	}
+
 	//render shadows one after the other, so this can be done un-barriered and the driver can optimize (as well as allow us to run compute at the same time)
 
 	for (uint32_t i = 0; i < scene_state.shadow_passes.size(); i++) {
@@ -3234,11 +3253,14 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 	{
 		RD::Uniform u;
 		u.binding = 2;
-		u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
-		RID instance_buffer = scene_state.instance_buffer[p_render_list];
-		if (instance_buffer == RID()) {
-			instance_buffer = scene_shader.default_vec4_xform_buffer; // any buffer will do since its not used
+		u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC;
+		if (scene_state.instance_buffer[p_render_list].get_size(0u) == 0u) {
+			// Any buffer will do since its not used, so just create one.
+			// We can't use scene_shader.default_vec4_xform_buffer because't it's not dynamic.
+			scene_state.instance_buffer[p_render_list].set_size(0u, INSTANCE_DATA_BUFFER_MIN_SIZE * sizeof(SceneState::InstanceData), true);
+			scene_state.instance_buffer[p_render_list].prepare_for_upload();
 		}
+		RID instance_buffer = scene_state.instance_buffer[p_render_list]._get(0u);
 		u.append_id(instance_buffer);
 		uniforms.push_back(u);
 	}
@@ -3568,11 +3590,14 @@ RID RenderForwardClustered::_setup_sdfgi_render_pass_uniform_set(RID p_albedo_te
 	{
 		RD::Uniform u;
 		u.binding = 2;
-		u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
-		RID instance_buffer = scene_state.instance_buffer[RENDER_LIST_SECONDARY];
-		if (instance_buffer == RID()) {
-			instance_buffer = scene_shader.default_vec4_xform_buffer; // any buffer will do since its not used
+		u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC;
+		if (scene_state.instance_buffer[RENDER_LIST_SECONDARY].get_size(0u) == 0u) {
+			// Any buffer will do since its not used, so just create one.
+			// We can't use scene_shader.default_vec4_xform_buffer because't it's not dynamic.
+			scene_state.instance_buffer[RENDER_LIST_SECONDARY].set_size(0u, INSTANCE_DATA_BUFFER_MIN_SIZE * sizeof(SceneState::InstanceData), true);
+			scene_state.instance_buffer[RENDER_LIST_SECONDARY].prepare_for_upload();
 		}
+		RID instance_buffer = scene_state.instance_buffer[RENDER_LIST_SECONDARY]._get(0u);
 		u.append_id(instance_buffer);
 		uniforms.push_back(u);
 	}
@@ -4980,9 +5005,7 @@ RenderForwardClustered::~RenderForwardClustered() {
 		RD::get_singleton()->free(scene_state.lightmap_buffer);
 		RD::get_singleton()->free(scene_state.lightmap_capture_buffer);
 		for (uint32_t i = 0; i < RENDER_LIST_MAX; i++) {
-			if (scene_state.instance_buffer[i] != RID()) {
-				RD::get_singleton()->free(scene_state.instance_buffer[i]);
-			}
+			scene_state.instance_buffer[i].uninit();
 		}
 		memdelete_arr(scene_state.lightmap_captures);
 	}

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/templates/paged_allocator.h"
+#include "servers/rendering/multi_uma_buffer.h"
 #include "servers/rendering/renderer_rd/cluster_builder_rd.h"
 #include "servers/rendering/renderer_rd/effects/fsr2.h"
 #ifdef METAL_ENABLED
@@ -384,9 +385,8 @@ private:
 		uint32_t max_lightmaps;
 		RID lightmap_buffer;
 
-		RID instance_buffer[RENDER_LIST_MAX];
-		uint32_t instance_buffer_size[RENDER_LIST_MAX] = { 0, 0, 0 };
-		LocalVector<InstanceData> instance_data[RENDER_LIST_MAX];
+		MultiUmaBuffer<1u> instance_buffer[RENDER_LIST_MAX] = { MultiUmaBuffer<1u>("RENDER_LIST_OPAQUE"), MultiUmaBuffer<1u>("RENDER_LIST_MOTION"), MultiUmaBuffer<1u>("RENDER_LIST_ALPHA"), MultiUmaBuffer<1u>("RENDER_LIST_SECONDARY") };
+		InstanceData *curr_gpu_ptr[RENDER_LIST_MAX] = {};
 
 		LightmapCaptureData *lightmap_captures = nullptr;
 		uint32_t max_lightmap_captures;
@@ -418,6 +418,7 @@ private:
 
 		LocalVector<ShadowPass> shadow_passes;
 
+		void grow_instance_buffer(RenderListType p_render_list, uint32_t p_req_element_count, bool p_append);
 	} scene_state;
 
 	static RenderForwardClustered *singleton;
@@ -449,7 +450,6 @@ private:
 	void _render_list(RenderingDevice::DrawListID p_draw_list, RenderingDevice::FramebufferFormatID p_framebuffer_Format, RenderListParameters *p_params, uint32_t p_from_element, uint32_t p_to_element);
 	void _render_list_with_draw_list(RenderListParameters *p_params, RID p_framebuffer, BitField<RD::DrawFlags> p_draw_flags = RD::DRAW_DEFAULT_ALL, const Vector<Color> &p_clear_color_values = Vector<Color>(), float p_clear_depth_value = 0.0, uint32_t p_clear_stencil_value = 0, const Rect2 &p_region = Rect2());
 
-	void _update_instance_data_buffer(RenderListType p_render_list);
 	void _fill_instance_data(RenderListType p_render_list, int *p_render_info = nullptr, uint32_t p_offset = 0, int32_t p_max_elements = -1, bool p_update_buffer = true);
 	void _fill_render_list(RenderListType p_render_list, const RenderDataRD *p_render_data, PassMode p_pass_mode, bool p_using_sdfgi = false, bool p_using_opaque_gi = false, bool p_using_motion_pass = false, bool p_append = false);
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -573,7 +573,9 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 			shader_versions.push_back(ShaderRD::VariantDefine(group, version, false));
 		}
 
-		shader.initialize(shader_versions, p_defines);
+		Vector<uint64_t> dynamic_buffers;
+		dynamic_buffers.push_back(RDD::DynamicBuffer::encode(RenderForwardClustered::RENDER_PASS_UNIFORM_SET, 2));
+		shader.initialize(shader_versions, p_defines, dynamic_buffers);
 
 		if (RendererCompositorRD::get_singleton()->is_xr_enabled()) {
 			shader.enable_group(SHADER_GROUP_MULTIVIEW);

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -381,12 +381,9 @@ bool RenderForwardMobile::_render_buffers_can_be_storage() {
 	return false;
 }
 
-RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_list, const RenderDataRD *p_render_data, RID p_radiance_texture, const RendererRD::MaterialStorage::Samplers &p_samplers, bool p_use_directional_shadow_atlas, int p_index) {
+RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_list, const RenderDataRD *p_render_data, RID p_radiance_texture, const RendererRD::MaterialStorage::Samplers &p_samplers, bool p_use_directional_shadow_atlas, uint32_t p_pass_offset) {
 	RendererRD::LightStorage *light_storage = RendererRD::LightStorage::get_singleton();
 	RendererRD::TextureStorage *texture_storage = RendererRD::TextureStorage::get_singleton();
-
-	//there should always be enough uniform buffers for render passes, otherwise bugs
-	ERR_FAIL_INDEX_V(p_index, (int)scene_state.uniform_buffers.size(), RID());
 
 	bool is_multiview = false;
 
@@ -411,19 +408,26 @@ RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_
 	{
 		RD::Uniform u;
 		u.binding = 0;
-		u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
-		u.append_id(scene_state.uniform_buffers[p_index]);
+		u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC;
+		// Negative on purpose. We've created multiple uniform_buffers by calling prepare_for_upload()
+		// many times in a row, now we must reference those.
+		// We use 0u - p_pass_offset instead of -p_pass_offset to make MSVC warnings shut up.
+		// See the "Tricks" section of MultiUmaBuffer documentation.
+		u.append_id(scene_state.uniform_buffers._get(uint32_t(0u - p_pass_offset)));
 		uniforms.push_back(u);
 	}
 
 	{
 		RD::Uniform u;
 		u.binding = 1;
-		u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
-		RID instance_buffer = scene_state.instance_buffer[p_render_list];
-		if (instance_buffer == RID()) {
-			instance_buffer = scene_shader.default_vec4_xform_buffer; // Any buffer will do since its not used.
+		u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC;
+		if (scene_state.instance_buffer[p_render_list].get_size(0u) == 0u) {
+			// Any buffer will do since its not used, so just create one.
+			// We can't use scene_shader.default_vec4_xform_buffer because't it's not dynamic.
+			scene_state.instance_buffer[p_render_list].set_size(0u, INSTANCE_DATA_BUFFER_MIN_SIZE * sizeof(SceneState::InstanceData), true);
+			scene_state.instance_buffer[p_render_list].prepare_for_upload();
 		}
+		RID instance_buffer = scene_state.instance_buffer[p_render_list]._get(0u);
 		u.append_id(instance_buffer);
 		uniforms.push_back(u);
 	}
@@ -843,6 +847,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 	_fill_render_list(RENDER_LIST_OPAQUE, p_render_data, PASS_MODE_COLOR);
 	render_list[RENDER_LIST_OPAQUE].sort_by_key();
 	render_list[RENDER_LIST_ALPHA].sort_by_reverse_depth_and_priority();
+
 	_fill_instance_data(RENDER_LIST_OPAQUE);
 	_fill_instance_data(RENDER_LIST_ALPHA);
 
@@ -1419,12 +1424,9 @@ void RenderForwardMobile::_render_shadow_begin() {
 	_update_render_base_uniform_set();
 
 	render_list[RENDER_LIST_SECONDARY].clear();
-	scene_state.instance_data[RENDER_LIST_SECONDARY].clear();
 }
 
 void RenderForwardMobile::_render_shadow_append(RID p_framebuffer, const PagedArray<RenderGeometryInstance *> &p_instances, const Projection &p_projection, const Transform3D &p_transform, float p_zfar, float p_bias, float p_normal_bias, bool p_use_dp, bool p_use_dp_flip, bool p_use_pancake, float p_lod_distance_multiplier, float p_screen_mesh_lod_threshold, const Rect2i &p_rect, bool p_flip_y, bool p_clear_region, bool p_begin, bool p_end, RenderingMethod::RenderInfo *p_render_info, const Transform3D &p_main_cam_transform) {
-	uint32_t shadow_pass_index = scene_state.shadow_passes.size();
-
 	SceneState::ShadowPass shadow_pass;
 
 	if (p_render_info) {
@@ -1451,7 +1453,7 @@ void RenderForwardMobile::_render_shadow_append(RID p_framebuffer, const PagedAr
 	render_data.instances = &p_instances;
 	render_data.render_info = p_render_info;
 
-	_setup_environment(&render_data, true, Vector2(1, 1), Color(), false, p_use_pancake, shadow_pass_index);
+	_setup_environment(&render_data, true, Vector2(1, 1), Color(), false, p_use_pancake);
 
 	if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_DISABLE_LOD) {
 		scene_data.screen_mesh_lod_threshold = 0.0;
@@ -1492,13 +1494,17 @@ void RenderForwardMobile::_render_shadow_append(RID p_framebuffer, const PagedAr
 }
 
 void RenderForwardMobile::_render_shadow_process() {
-	_update_instance_data_buffer(RENDER_LIST_SECONDARY);
+	RenderingDevice *rd = RenderingDevice::get_singleton();
+	if (scene_state.instance_buffer[RENDER_LIST_SECONDARY].get_size(0u) > 0u) {
+		rd->buffer_flush(scene_state.instance_buffer[RENDER_LIST_SECONDARY]._get(0u));
+	}
+
 	//render shadows one after the other, so this can be done un-barriered and the driver can optimize (as well as allow us to run compute at the same time)
 
 	for (uint32_t i = 0; i < scene_state.shadow_passes.size(); i++) {
 		//render passes need to be configured after instance buffer is done, since they need the latest version
 		SceneState::ShadowPass &shadow_pass = scene_state.shadow_passes[i];
-		shadow_pass.rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_SECONDARY, nullptr, RID(), RendererRD::MaterialStorage::get_singleton()->samplers_rd_get_default(), false, i);
+		shadow_pass.rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_SECONDARY, nullptr, RID(), RendererRD::MaterialStorage::get_singleton()->samplers_rd_get_default(), false, scene_state.shadow_passes.size() - 1u - i);
 	}
 
 	RD::get_singleton()->draw_command_end_label();
@@ -1811,17 +1817,19 @@ RID RenderForwardMobile::_render_buffers_get_velocity_texture(Ref<RenderSceneBuf
 	return RID();
 }
 
-void RenderForwardMobile::_update_instance_data_buffer(RenderListType p_render_list) {
-	if (scene_state.instance_data[p_render_list].size() > 0) {
-		if (scene_state.instance_buffer[p_render_list] == RID() || scene_state.instance_buffer_size[p_render_list] < scene_state.instance_data[p_render_list].size()) {
-			if (scene_state.instance_buffer[p_render_list] != RID()) {
-				RD::get_singleton()->free(scene_state.instance_buffer[p_render_list]);
-			}
-			uint32_t new_size = nearest_power_of_2_templated(MAX(uint64_t(INSTANCE_DATA_BUFFER_MIN_SIZE), scene_state.instance_data[p_render_list].size()));
-			scene_state.instance_buffer[p_render_list] = RD::get_singleton()->storage_buffer_create(new_size * sizeof(SceneState::InstanceData));
-			scene_state.instance_buffer_size[p_render_list] = new_size;
+void RenderForwardMobile::SceneState::grow_instance_buffer(RenderListType p_render_list, uint32_t p_req_element_count, bool p_append) {
+	if (p_req_element_count > 0) {
+		if (instance_buffer[p_render_list].get_size(0u) < p_req_element_count * sizeof(SceneState::InstanceData)) {
+			instance_buffer[p_render_list].uninit();
+			uint32_t new_size = nearest_power_of_2_templated(MAX(uint64_t(INSTANCE_DATA_BUFFER_MIN_SIZE), p_req_element_count));
+			instance_buffer[p_render_list].set_size(0u, new_size * sizeof(SceneState::InstanceData), true);
+			curr_gpu_ptr[p_render_list] = nullptr;
 		}
-		RD::get_singleton()->buffer_update(scene_state.instance_buffer[p_render_list], 0, sizeof(SceneState::InstanceData) * scene_state.instance_data[p_render_list].size(), scene_state.instance_data[p_render_list].ptr());
+
+		const bool must_remap = instance_buffer[p_render_list].prepare_for_map(p_append);
+		if (must_remap) {
+			curr_gpu_ptr[p_render_list] = nullptr;
+		}
 	}
 }
 
@@ -1829,14 +1837,21 @@ void RenderForwardMobile::_fill_instance_data(RenderListType p_render_list, uint
 	RenderList *rl = &render_list[p_render_list];
 	uint32_t element_total = p_max_elements >= 0 ? uint32_t(p_max_elements) : rl->elements.size();
 
-	scene_state.instance_data[p_render_list].resize(p_offset + element_total);
 	rl->element_info.resize(p_offset + element_total);
+
+	scene_state.grow_instance_buffer(p_render_list, p_offset + element_total, p_offset != 0u);
+	if (!scene_state.curr_gpu_ptr[p_render_list] && element_total > 0u) {
+		// The old buffer was replaced for another larger one. We must start copying from scratch.
+		element_total += p_offset;
+		p_offset = 0u;
+		scene_state.curr_gpu_ptr[p_render_list] = reinterpret_cast<SceneState::InstanceData *>(scene_state.instance_buffer[p_render_list].map_raw_for_upload(0u));
+	}
 
 	for (uint32_t i = 0; i < element_total; i++) {
 		GeometryInstanceSurfaceDataCache *surface = rl->elements[i + p_offset];
 		GeometryInstanceForwardMobile *inst = surface->owner;
 
-		SceneState::InstanceData &instance_data = scene_state.instance_data[p_render_list][i + p_offset];
+		SceneState::InstanceData instance_data;
 
 		if (inst->store_transform_cache) {
 			RendererRD::MaterialStorage::store_transform(inst->transform, instance_data.transform);
@@ -1872,14 +1887,16 @@ void RenderForwardMobile::_fill_instance_data(RenderListType p_render_list, uint
 		instance_data.set_compressed_aabb(surface_aabb);
 		instance_data.set_uv_scale(uv_scale);
 
+		scene_state.curr_gpu_ptr[p_render_list][i + p_offset] = instance_data;
+
 		RenderElementInfo &element_info = rl->element_info[p_offset + i];
 
 		// Sets lod_index and uses_lightmap at once.
 		element_info.value = uint32_t(surface->sort.sort_key1 & 0x1FF);
 	}
 
-	if (p_update_buffer) {
-		_update_instance_data_buffer(p_render_list);
+	if (p_update_buffer && element_total > 0u) {
+		RenderingDevice::get_singleton()->buffer_flush(scene_state.instance_buffer[p_render_list]._get(0u));
 	}
 }
 
@@ -2087,20 +2104,18 @@ void RenderForwardMobile::_fill_render_list(RenderListType p_render_list, const 
 	}
 }
 
-void RenderForwardMobile::_setup_environment(const RenderDataRD *p_render_data, bool p_no_fog, const Size2i &p_screen_size, const Color &p_default_bg_color, bool p_opaque_render_buffers, bool p_pancake_shadows, int p_index) {
+void RenderForwardMobile::_setup_environment(const RenderDataRD *p_render_data, bool p_no_fog, const Size2i &p_screen_size, const Color &p_default_bg_color, bool p_opaque_render_buffers, bool p_pancake_shadows) {
 	RID env = is_environment(p_render_data->environment) ? p_render_data->environment : RID();
 	RID reflection_probe_instance = p_render_data->reflection_probe.is_valid() ? RendererRD::LightStorage::get_singleton()->reflection_probe_instance_get_probe(p_render_data->reflection_probe) : RID();
 
 	// May do this earlier in RenderSceneRenderRD::render_scene
-	if (p_index >= (int)scene_state.uniform_buffers.size()) {
-		uint32_t from = scene_state.uniform_buffers.size();
-		scene_state.uniform_buffers.resize(p_index + 1);
-		for (uint32_t i = from; i < scene_state.uniform_buffers.size(); i++) {
-			scene_state.uniform_buffers[i] = p_render_data->scene_data->create_uniform_buffer();
-		}
+	if (scene_state.uniform_buffers.get_size(0u) == 0u) {
+		scene_state.uniform_buffers.set_size(0u, p_render_data->scene_data->get_uniform_buffer_size_bytes(), false);
 	}
 
-	p_render_data->scene_data->update_ubo(scene_state.uniform_buffers[p_index], get_debug_draw_mode(), env, reflection_probe_instance, p_render_data->camera_attributes, p_pancake_shadows, p_screen_size, p_default_bg_color, _render_buffers_get_luminance_multiplier(), p_opaque_render_buffers, false);
+	// Start a new setup.
+	scene_state.uniform_buffers.prepare_for_upload();
+	p_render_data->scene_data->update_ubo(scene_state.uniform_buffers.get_for_upload(0u), get_debug_draw_mode(), env, reflection_probe_instance, p_render_data->camera_attributes, p_pancake_shadows, p_screen_size, p_default_bg_color, _render_buffers_get_luminance_multiplier(), p_opaque_render_buffers, false);
 }
 
 /// RENDERING ///
@@ -3197,6 +3212,11 @@ RenderForwardMobile::RenderForwardMobile() {
 
 	sky.set_texture_format(_render_buffers_get_color_format());
 
+	// <TF>
+	// @ShadyTF
+	// replacing push constants with uniform buffer
+	sky.use_push_constants = false;
+	// </TF>
 	String defines;
 
 	defines += "\n#define MAX_ROUGHNESS_LOD " + itos(get_roughness_layers() - 1) + ".0\n";
@@ -3249,13 +3269,9 @@ RenderForwardMobile::~RenderForwardMobile() {
 	RSG::light_storage->directional_shadow_atlas_set_size(0);
 
 	{
-		for (const RID &rid : scene_state.uniform_buffers) {
-			RD::get_singleton()->free(rid);
-		}
+		scene_state.uniform_buffers.uninit();
 		for (uint32_t i = 0; i < RENDER_LIST_MAX; i++) {
-			if (scene_state.instance_buffer[i].is_valid()) {
-				RD::get_singleton()->free(scene_state.instance_buffer[i]);
-			}
+			scene_state.instance_buffer[i].uninit();
 		}
 		RD::get_singleton()->free(scene_state.lightmap_buffer);
 		RD::get_singleton()->free(scene_state.lightmap_capture_buffer);

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/templates/paged_allocator.h"
+#include "servers/rendering/multi_uma_buffer.h"
 #include "servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h"
 #include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
 
@@ -158,18 +159,17 @@ private:
 
 	/* Render Scene */
 
-	RID _setup_render_pass_uniform_set(RenderListType p_render_list, const RenderDataRD *p_render_data, RID p_radiance_texture, const RendererRD::MaterialStorage::Samplers &p_samplers, bool p_use_directional_shadow_atlas = false, int p_index = 0);
+	RID _setup_render_pass_uniform_set(RenderListType p_render_list, const RenderDataRD *p_render_data, RID p_radiance_texture, const RendererRD::MaterialStorage::Samplers &p_samplers, bool p_use_directional_shadow_atlas = false, uint32_t p_pass_offset = 0u);
 	void _pre_opaque_render(RenderDataRD *p_render_data);
 
 	uint64_t lightmap_texture_array_version = 0xFFFFFFFF;
 
 	void _update_render_base_uniform_set();
 
-	void _update_instance_data_buffer(RenderListType p_render_list);
 	void _fill_instance_data(RenderListType p_render_list, uint32_t p_offset = 0, int32_t p_max_elements = -1, bool p_update_buffer = true);
 	void _fill_render_list(RenderListType p_render_list, const RenderDataRD *p_render_data, PassMode p_pass_mode, bool p_append = false);
 
-	void _setup_environment(const RenderDataRD *p_render_data, bool p_no_fog, const Size2i &p_screen_size, const Color &p_default_bg_color, bool p_opaque_render_buffers = false, bool p_pancake_shadows = false, int p_index = 0);
+	void _setup_environment(const RenderDataRD *p_render_data, bool p_no_fog, const Size2i &p_screen_size, const Color &p_default_bg_color, bool p_opaque_render_buffers = false, bool p_pancake_shadows = false);
 	void _setup_lightmaps(const RenderDataRD *p_render_data, const PagedArray<RID> &p_lightmaps, const Transform3D &p_cam_transform);
 
 	RID render_base_uniform_set;
@@ -190,7 +190,7 @@ private:
 	/* Scene state */
 
 	struct SceneState {
-		LocalVector<RID> uniform_buffers;
+		MultiUmaBuffer<1u> uniform_buffers = MultiUmaBuffer<1u>("SceneState::uniform_buffers");
 
 		struct PushConstantUbershader {
 			SceneShaderForwardMobile::ShaderSpecialization specialization;
@@ -265,9 +265,8 @@ private:
 		static_assert(std::is_trivially_destructible_v<InstanceData>);
 		static_assert(std::is_trivially_constructible_v<InstanceData>);
 
-		RID instance_buffer[RENDER_LIST_MAX];
-		uint32_t instance_buffer_size[RENDER_LIST_MAX] = { 0, 0, 0 };
-		LocalVector<InstanceData> instance_data[RENDER_LIST_MAX];
+		MultiUmaBuffer<1u> instance_buffer[RENDER_LIST_MAX] = { MultiUmaBuffer<1u>("RENDER_LIST_OPAQUE"), MultiUmaBuffer<1u>("RENDER_LIST_ALPHA"), MultiUmaBuffer<1u>("RENDER_LIST_SECONDARY") };
+		InstanceData *curr_gpu_ptr[RENDER_LIST_MAX] = {};
 
 		// !BAS! We need to change lightmaps, we're not going to do this with a buffer but pushing the used lightmap in
 		LightmapData lightmaps[MAX_LIGHTMAPS];
@@ -303,6 +302,8 @@ private:
 		};
 
 		LocalVector<ShadowPass> shadow_passes;
+
+		void grow_instance_buffer(RenderListType p_render_list, uint32_t p_req_element_count, bool p_append);
 	} scene_state;
 
 	/* Render List */
@@ -318,7 +319,6 @@ private:
 		}
 
 		//should eventually be replaced by radix
-
 		struct SortByKey {
 			_FORCE_INLINE_ bool operator()(const GeometryInstanceSurfaceDataCache *A, const GeometryInstanceSurfaceDataCache *B) const {
 				return (A->sort.sort_key2 == B->sort.sort_key2) ? (A->sort.sort_key1 < B->sort.sort_key1) : (A->sort.sort_key2 < B->sort.sort_key2);

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -503,7 +503,10 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		immutable_shadow_sampler.append_id(shadow_sampler);
 		immutable_shadow_sampler.uniform_type = RenderingDeviceCommons::UNIFORM_TYPE_SAMPLER;
 		immutable_samplers.push_back(immutable_shadow_sampler);
-		shader.initialize(shader_versions, p_defines, immutable_samplers);
+		Vector<uint64_t> dynamic_buffers;
+		dynamic_buffers.push_back(RDD::DynamicBuffer::encode(RenderForwardMobile::RENDER_PASS_UNIFORM_SET, 0));
+		dynamic_buffers.push_back(RDD::DynamicBuffer::encode(RenderForwardMobile::RENDER_PASS_UNIFORM_SET, 1));
+		shader.initialize(shader_versions, p_defines, immutable_samplers, dynamic_buffers);
 		if (!RendererCompositorRD::get_singleton()->is_xr_enabled()) {
 			for (uint32_t ubershader = 0; ubershader < 2; ubershader++) {
 				uint32_t base_variant = ubershader ? SHADER_VERSION_MAX : 0;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -747,8 +747,6 @@ void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p
 	Item *canvas_group_owner = nullptr;
 	bool skip_item = false;
 
-	state.last_instance_index = 0;
-
 	bool update_skeletons = false;
 	bool time_used = false;
 
@@ -915,8 +913,13 @@ void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p
 	}
 
 	texture_info_map.clear();
-	state.current_data_buffer_index = (state.current_data_buffer_index + 1) % BATCH_DATA_BUFFER_COUNT;
-	state.current_instance_buffer_index = 0;
+	state.instance_data = nullptr;
+	if (state.instance_data_index > 0) {
+		// If there was any remaining instance data, it must be flushed.
+		RID buf = state.instance_buffers._get(0);
+		RD::get_singleton()->buffer_flush(buf);
+		state.instance_data_index = 0;
+	}
 }
 
 RID RendererCanvasRenderRD::light_create() {
@@ -1751,7 +1754,10 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 			variants.push_back(base_define + "#define USE_ATTRIBUTES\n#define USE_POINT_SIZE\n"); // SHADER_VARIANT_ATTRIBUTES_POINTS
 		}
 
-		shader.canvas_shader.initialize(variants, global_defines);
+		Vector<uint64_t> dynamic_buffers;
+		dynamic_buffers.push_back(RDD::DynamicBuffer::encode(BATCH_UNIFORM_SET, 4));
+
+		shader.canvas_shader.initialize(variants, global_defines, {}, dynamic_buffers);
 
 		shader.default_version_data = memnew(CanvasShaderData);
 		shader.default_version_data->version = shader.canvas_shader.version_create();
@@ -2062,13 +2068,9 @@ void fragment() {
 	{
 		state.max_instances_per_buffer = uint32_t(GLOBAL_GET("rendering/2d/batching/item_buffer_size"));
 		state.max_instance_buffer_size = state.max_instances_per_buffer * sizeof(InstanceData);
-		state.canvas_instance_batches.reserve(200);
 
-		for (uint32_t i = 0; i < BATCH_DATA_BUFFER_COUNT; i++) {
-			DataBuffer &db = state.canvas_instance_data_buffers[i];
-			db.instance_buffers.push_back(RD::get_singleton()->storage_buffer_create(state.max_instance_buffer_size));
-		}
-		state.instance_data_array = memnew_arr(InstanceData, state.max_instances_per_buffer);
+		state.canvas_instance_batches.reserve(200);
+		state.instance_buffers.set_size(0, state.max_instance_buffer_size, true);
 	}
 }
 
@@ -2127,7 +2129,6 @@ uint32_t RendererCanvasRenderRD::get_pipeline_compilations(RS::PipelineSource p_
 
 void RendererCanvasRenderRD::_render_batch_items(RenderTarget p_to_render_target, int p_item_count, const Transform2D &p_canvas_transform_inverse, Light *p_lights, bool &r_sdf_used, bool p_to_backbuffer, RenderingMethod::RenderInfo *r_render_info) {
 	// Record batches
-	uint32_t instance_index = 0;
 	{
 		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 		Item *current_clip = nullptr;
@@ -2137,7 +2138,7 @@ void RendererCanvasRenderRD::_render_batch_items(RenderTarget p_to_render_target
 		bool batch_broken = false;
 		Batch *current_batch = _new_batch(batch_broken);
 		// Override the start position and index as we want to start from where we finished off last time.
-		current_batch->start = state.last_instance_index;
+		current_batch->start = state.instance_data_index;
 
 		for (int i = 0; i < p_item_count; i++) {
 			Item *ci = items[i];
@@ -2178,7 +2179,7 @@ void RendererCanvasRenderRD::_render_batch_items(RenderTarget p_to_render_target
 
 			if (ci->repeat_source_item == nullptr || ci->repeat_size == Vector2()) {
 				Transform2D base_transform = p_canvas_transform_inverse * ci->final_transform;
-				_record_item_commands(ci, p_to_render_target, base_transform, current_clip, p_lights, instance_index, batch_broken, r_sdf_used, current_batch);
+				_record_item_commands(ci, p_to_render_target, base_transform, current_clip, p_lights, batch_broken, r_sdf_used, current_batch);
 			} else {
 				Point2 start_pos = ci->repeat_size * -(ci->repeat_times / 2);
 				Point2 offset;
@@ -2191,19 +2192,10 @@ void RendererCanvasRenderRD::_render_batch_items(RenderTarget p_to_render_target
 						Transform2D base_transform = ci->final_transform;
 						base_transform.columns[2] += ci->repeat_source_item->final_transform.basis_xform(offset);
 						base_transform = p_canvas_transform_inverse * base_transform;
-						_record_item_commands(ci, p_to_render_target, base_transform, current_clip, p_lights, instance_index, batch_broken, r_sdf_used, current_batch);
+						_record_item_commands(ci, p_to_render_target, base_transform, current_clip, p_lights, batch_broken, r_sdf_used, current_batch);
 					}
 				}
 			}
-		}
-
-		// Copy over remaining data needed for rendering.
-		if (instance_index > 0) {
-			RD::get_singleton()->buffer_update(
-					state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers[state.current_instance_buffer_index],
-					state.last_instance_index * sizeof(InstanceData),
-					instance_index * sizeof(InstanceData),
-					state.instance_data_array);
 		}
 	}
 
@@ -2289,62 +2281,27 @@ void RendererCanvasRenderRD::_render_batch_items(RenderTarget p_to_render_target
 
 	state.current_batch_index = 0;
 	state.canvas_instance_batches.clear();
-	state.last_instance_index += instance_index;
 }
 
-RendererCanvasRenderRD::InstanceData *RendererCanvasRenderRD::new_instance_data(float *p_world, uint32_t *p_lights, uint32_t p_base_flags, uint32_t p_index, uint32_t p_uniforms_ofs, TextureInfo *p_info) {
-	InstanceData *instance_data = &state.instance_data_array[p_index];
-	// Zero out most fields.
-	for (int i = 0; i < 4; i++) {
-		instance_data->modulation[i] = 0.0;
-		instance_data->ninepatch_margins[i] = 0.0;
-		instance_data->src_rect[i] = 0.0;
-		instance_data->dst_rect[i] = 0.0;
-	}
-
-	instance_data->pad[0] = 0.0;
-	instance_data->pad[1] = 0.0;
-
-	instance_data->lights[0] = p_lights[0];
-	instance_data->lights[1] = p_lights[1];
-	instance_data->lights[2] = p_lights[2];
-	instance_data->lights[3] = p_lights[3];
-
-	for (int i = 0; i < 6; i++) {
-		instance_data->world[i] = p_world[i];
-	}
-
-	instance_data->flags = p_base_flags; // Reset on each command for safety.
-
-	instance_data->color_texture_pixel_size[0] = p_info->texpixel_size.width;
-	instance_data->color_texture_pixel_size[1] = p_info->texpixel_size.height;
-
-	instance_data->instance_uniforms_ofs = p_uniforms_ofs;
-
-	return instance_data;
-}
-
-void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTarget p_render_target, const Transform2D &p_base_transform, Item *&r_current_clip, Light *p_lights, uint32_t &r_index, bool &r_batch_broken, bool &r_sdf_used, Batch *&r_current_batch) {
+void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTarget p_render_target, const Transform2D &p_base_transform, Item *&r_current_clip, Light *p_lights, bool &r_batch_broken, bool &r_sdf_used, Batch *&r_current_batch) {
 	const RenderingServer::CanvasItemTextureFilter texture_filter = p_item->texture_filter == RS::CANVAS_ITEM_TEXTURE_FILTER_DEFAULT ? default_filter : p_item->texture_filter;
 	const RenderingServer::CanvasItemTextureRepeat texture_repeat = p_item->texture_repeat == RS::CANVAS_ITEM_TEXTURE_REPEAT_DEFAULT ? default_repeat : p_item->texture_repeat;
 
 	Transform2D base_transform = p_base_transform;
 
-	float world[6];
+	InstanceData template_instance;
+	memset(&template_instance, 0, sizeof(InstanceData));
+
 	Transform2D draw_transform; // Used by transform command
-	_update_transform_2d_to_mat2x3(base_transform, world);
+	_update_transform_2d_to_mat2x3(base_transform, template_instance.world);
 
 	Color base_color = p_item->final_modulate;
 	bool use_linear_colors = p_render_target.use_linear_colors;
-	uint32_t base_flags = 0;
-	uint32_t uniforms_ofs = static_cast<uint32_t>(p_item->instance_allocated_shader_uniforms_offset);
+	template_instance.instance_uniforms_ofs = static_cast<uint32_t>(p_item->instance_allocated_shader_uniforms_offset);
 
 	bool reclip = false;
 
 	bool skipping = false;
-
-	// TODO: consider making lights a per-batch property and then baking light operations in the shader for better performance.
-	uint32_t lights[4] = { 0, 0, 0, 0 };
 
 	uint16_t light_count = 0;
 	uint16_t shadow_mask = 0;
@@ -2355,7 +2312,8 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 		while (light) {
 			if (light->render_index_cache >= 0 && p_item->light_mask & light->item_mask && p_item->z_final >= light->z_min && p_item->z_final <= light->z_max && p_item->global_rect_cache.intersects(light->rect_cache)) {
 				uint32_t light_index = light->render_index_cache;
-				lights[light_count >> 2] |= light_index << ((light_count & 3) * 8);
+				// TODO: consider making lights a per-batch property and then baking light operations in the shader for better performance.
+				template_instance.lights[light_count >> 2] |= light_index << ((light_count & 3) * 8);
 
 				if (p_item->light_mask & light->item_shadow_mask) {
 					shadow_mask |= 1 << light_count;
@@ -2370,8 +2328,8 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 			light = light->next_ptr;
 		}
 
-		base_flags |= light_count << INSTANCE_FLAGS_LIGHT_COUNT_SHIFT;
-		base_flags |= shadow_mask << INSTANCE_FLAGS_SHADOW_MASKED_SHIFT;
+		template_instance.flags |= light_count << INSTANCE_FLAGS_LIGHT_COUNT_SHIFT;
+		template_instance.flags |= shadow_mask << INSTANCE_FLAGS_SHADOW_MASKED_SHIFT;
 	}
 
 	bool use_lighting = (light_count > 0 || using_directional_lights);
@@ -2435,9 +2393,11 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				if (r_current_batch->tex_info != tex_info) {
 					r_current_batch = _new_batch(r_batch_broken);
 					r_current_batch->tex_info = tex_info;
+					template_instance.color_texture_pixel_size[0] = tex_info->texpixel_size.width;
+					template_instance.color_texture_pixel_size[1] = tex_info->texpixel_size.height;
 				}
 
-				InstanceData *instance_data = new_instance_data(world, lights, base_flags, r_index, uniforms_ofs, tex_info);
+				InstanceData *instance_data = new_instance_data(template_instance);
 				Rect2 src_rect;
 				Rect2 dst_rect;
 
@@ -2510,7 +2470,7 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				instance_data->dst_rect[2] = dst_rect.size.width;
 				instance_data->dst_rect[3] = dst_rect.size.height;
 
-				_add_to_batch(r_index, r_batch_broken, r_current_batch);
+				_add_to_batch(r_batch_broken, r_current_batch);
 			} break;
 
 			case Item::Command::TYPE_NINEPATCH: {
@@ -2536,9 +2496,11 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				if (r_current_batch->tex_info != tex_info) {
 					r_current_batch = _new_batch(r_batch_broken);
 					r_current_batch->tex_info = tex_info;
+					template_instance.color_texture_pixel_size[0] = tex_info->texpixel_size.width;
+					template_instance.color_texture_pixel_size[1] = tex_info->texpixel_size.height;
 				}
 
-				InstanceData *instance_data = new_instance_data(world, lights, base_flags, r_index, uniforms_ofs, tex_info);
+				InstanceData *instance_data = new_instance_data(template_instance);
 
 				Rect2 src_rect;
 				Rect2 dst_rect(np->rect.position.x, np->rect.position.y, np->rect.size.x, np->rect.size.y);
@@ -2587,7 +2549,7 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				instance_data->ninepatch_margins[2] = np->margin[SIDE_RIGHT];
 				instance_data->ninepatch_margins[3] = np->margin[SIDE_BOTTOM];
 
-				_add_to_batch(r_index, r_batch_broken, r_current_batch);
+				_add_to_batch(r_batch_broken, r_current_batch);
 			} break;
 
 			case Item::Command::TYPE_POLYGON: {
@@ -2611,6 +2573,8 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				if (r_current_batch->tex_info != tex_info) {
 					r_current_batch = _new_batch(r_batch_broken);
 					r_current_batch->tex_info = tex_info;
+					template_instance.color_texture_pixel_size[0] = tex_info->texpixel_size.width;
+					template_instance.color_texture_pixel_size[1] = tex_info->texpixel_size.height;
 				}
 
 				// pipeline variant
@@ -2620,7 +2584,7 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 					r_current_batch->render_primitive = _primitive_type_to_render_primitive(polygon->primitive);
 				}
 
-				InstanceData *instance_data = new_instance_data(world, lights, base_flags, r_index, uniforms_ofs, tex_info);
+				InstanceData *instance_data = new_instance_data(template_instance);
 
 				Color color = base_color;
 				if (use_linear_colors) {
@@ -2632,7 +2596,7 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				instance_data->modulation[2] = color.b;
 				instance_data->modulation[3] = color.a;
 
-				_add_to_batch(r_index, r_batch_broken, r_current_batch);
+				_add_to_batch(r_batch_broken, r_current_batch);
 			} break;
 
 			case Item::Command::TYPE_PRIMITIVE: {
@@ -2678,9 +2642,11 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				if (r_current_batch->tex_info != tex_info) {
 					r_current_batch = _new_batch(r_batch_broken);
 					r_current_batch->tex_info = tex_info;
+					template_instance.color_texture_pixel_size[0] = tex_info->texpixel_size.width;
+					template_instance.color_texture_pixel_size[1] = tex_info->texpixel_size.height;
 				}
 
-				InstanceData *instance_data = new_instance_data(world, lights, base_flags, r_index, uniforms_ofs, tex_info);
+				InstanceData *instance_data = new_instance_data(template_instance);
 
 				for (uint32_t j = 0; j < MIN(3u, primitive->point_count); j++) {
 					instance_data->points[j * 2 + 0] = primitive->points[j].x;
@@ -2695,10 +2661,10 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 					instance_data->colors[j * 2 + 1] = (uint32_t(Math::make_half_float(col.a)) << 16) | Math::make_half_float(col.b);
 				}
 
-				_add_to_batch(r_index, r_batch_broken, r_current_batch);
+				_add_to_batch(r_batch_broken, r_current_batch);
 
 				if (primitive->point_count == 4) {
-					instance_data = new_instance_data(world, lights, base_flags, r_index, uniforms_ofs, tex_info);
+					instance_data = new_instance_data(template_instance);
 
 					for (uint32_t j = 0; j < 3; j++) {
 						int offset = j == 0 ? 0 : 1;
@@ -2715,7 +2681,7 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 						instance_data->colors[j * 2 + 1] = (uint32_t(Math::make_half_float(col.a)) << 16) | Math::make_half_float(col.b);
 					}
 
-					_add_to_batch(r_index, r_batch_broken, r_current_batch);
+					_add_to_batch(r_batch_broken, r_current_batch);
 				}
 			} break;
 
@@ -2741,7 +2707,9 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 						_prepare_batch_texture_info(m->texture, tex_state, tex_info);
 					}
 					r_current_batch->tex_info = tex_info;
-					instance_data = new_instance_data(world, lights, base_flags, r_index, uniforms_ofs, tex_info);
+					template_instance.color_texture_pixel_size[0] = tex_info->texpixel_size.width;
+					template_instance.color_texture_pixel_size[1] = tex_info->texpixel_size.height;
+					instance_data = new_instance_data(template_instance);
 
 					r_current_batch->mesh_instance_count = 1;
 					_update_transform_2d_to_mat2x3(base_transform * draw_transform * m->transform, instance_data->world);
@@ -2768,7 +2736,9 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 						_prepare_batch_texture_info(mm->texture, tex_state, tex_info);
 					}
 					r_current_batch->tex_info = tex_info;
-					instance_data = new_instance_data(world, lights, base_flags, r_index, uniforms_ofs, tex_info);
+					template_instance.color_texture_pixel_size[0] = tex_info->texpixel_size.width;
+					template_instance.color_texture_pixel_size[1] = tex_info->texpixel_size.height;
+					instance_data = new_instance_data(template_instance);
 
 					r_current_batch->flags |= 1; // multimesh, trails disabled
 
@@ -2790,7 +2760,9 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 						_prepare_batch_texture_info(pt->texture, tex_state, tex_info);
 					}
 					r_current_batch->tex_info = tex_info;
-					instance_data = new_instance_data(world, lights, base_flags, r_index, uniforms_ofs, tex_info);
+					template_instance.color_texture_pixel_size[0] = tex_info->texpixel_size.width;
+					template_instance.color_texture_pixel_size[1] = tex_info->texpixel_size.height;
+					instance_data = new_instance_data(template_instance);
 
 					uint32_t divisor = 1;
 					r_current_batch->mesh_instance_count = particles_storage->particles_get_amount(pt->particles, divisor);
@@ -2833,13 +2805,13 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				instance_data->modulation[2] = modulated.b;
 				instance_data->modulation[3] = modulated.a;
 
-				_add_to_batch(r_index, r_batch_broken, r_current_batch);
+				_add_to_batch(r_batch_broken, r_current_batch);
 			} break;
 
 			case Item::Command::TYPE_TRANSFORM: {
 				const Item::CommandTransform *transform = static_cast<const Item::CommandTransform *>(c);
 				draw_transform = transform->xform;
-				_update_transform_2d_to_mat2x3(base_transform * transform->xform, world);
+				_update_transform_2d_to_mat2x3(base_transform * transform->xform, template_instance.world);
 			} break;
 
 			case Item::Command::TYPE_CLIP_IGNORE: {
@@ -2911,10 +2883,12 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 		if (r_current_batch->tex_info != tex_info) {
 			r_current_batch = _new_batch(r_batch_broken);
 			r_current_batch->tex_info = tex_info;
+			template_instance.color_texture_pixel_size[0] = tex_info->texpixel_size.width;
+			template_instance.color_texture_pixel_size[1] = tex_info->texpixel_size.height;
 		}
 
-		_update_transform_2d_to_mat2x3(base_transform, world);
-		InstanceData *instance_data = new_instance_data(world, lights, base_flags, r_index, uniforms_ofs, tex_info);
+		_update_transform_2d_to_mat2x3(base_transform, template_instance.world);
+		InstanceData *instance_data = new_instance_data(template_instance);
 
 		Rect2 src_rect;
 		Rect2 dst_rect;
@@ -2946,7 +2920,7 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 		instance_data->dst_rect[2] = dst_rect.size.width;
 		instance_data->dst_rect[3] = dst_rect.size.height;
 
-		_add_to_batch(r_index, r_batch_broken, r_current_batch);
+		_add_to_batch(r_batch_broken, r_current_batch);
 
 		p_item->debug_redraw_time -= RSG::rasterizer->get_frame_delta_time();
 
@@ -2989,9 +2963,7 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 	{
 		RendererRD::TextureStorage *ts = RendererRD::TextureStorage::get_singleton();
 
-		RIDSetKey key(
-				p_batch->tex_info->state,
-				state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers[p_batch->instance_buffer_index]);
+		RIDSetKey key(p_batch->tex_info->state, p_batch->instance_buffer);
 
 		const RID *uniform_set = rid_set_to_uniform_set.getptr(key);
 		if (uniform_set == nullptr) {
@@ -3000,7 +2972,7 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 			uniform_ptrw[1] = RD::Uniform(RD::UNIFORM_TYPE_TEXTURE, 1, p_batch->tex_info->normal);
 			uniform_ptrw[2] = RD::Uniform(RD::UNIFORM_TYPE_TEXTURE, 2, p_batch->tex_info->specular);
 			uniform_ptrw[3] = RD::Uniform(RD::UNIFORM_TYPE_SAMPLER, 3, p_batch->tex_info->sampler);
-			uniform_ptrw[4] = RD::Uniform(RD::UNIFORM_TYPE_STORAGE_BUFFER, 4, state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers[p_batch->instance_buffer_index]);
+			uniform_ptrw[4] = RD::Uniform(RD::UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC, 4, p_batch->instance_buffer);
 
 			RID rid = RD::get_singleton()->uniform_set_create(state.batch_texture_uniforms, shader.default_version_rd_shader, BATCH_UNIFORM_SET);
 			ERR_FAIL_COND_MSG(rid.is_null(), "Failed to create uniform set for batch.");
@@ -3199,10 +3171,24 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 	}
 }
 
+RendererCanvasRenderRD::InstanceData *RendererCanvasRenderRD::new_instance_data(const InstanceData &template_instance) {
+	DEV_ASSERT(state.instance_data != nullptr);
+
+	InstanceData *instance_data = &state.instance_data[state.instance_data_index];
+	memcpy(instance_data, &template_instance, sizeof(InstanceData));
+	return instance_data;
+}
+
 RendererCanvasRenderRD::Batch *RendererCanvasRenderRD::_new_batch(bool &r_batch_broken) {
 	if (state.canvas_instance_batches.size() == 0) {
 		Batch new_batch;
-		new_batch.instance_buffer_index = state.current_instance_buffer_index;
+		// This will still be a valid point when multiple calls to _render_batch_items
+		// are made in the same draw call.
+		if (state.instance_data == nullptr) {
+			// If there is no existing instance buffer, we must allocate a new one.
+			_allocate_instance_buffer();
+		}
+		new_batch.instance_buffer = state.instance_buffers._get(0);
 		state.canvas_instance_batches.push_back(new_batch);
 		return state.canvas_instance_batches.ptr();
 	}
@@ -3217,43 +3203,30 @@ RendererCanvasRenderRD::Batch *RendererCanvasRenderRD::_new_batch(bool &r_batch_
 	Batch new_batch = state.canvas_instance_batches[state.current_batch_index];
 	new_batch.instance_count = 0;
 	new_batch.start = state.canvas_instance_batches[state.current_batch_index].start + state.canvas_instance_batches[state.current_batch_index].instance_count;
-	new_batch.instance_buffer_index = state.current_instance_buffer_index;
 	state.current_batch_index++;
 	state.canvas_instance_batches.push_back(new_batch);
 	return &state.canvas_instance_batches[state.current_batch_index];
 }
 
-void RendererCanvasRenderRD::_add_to_batch(uint32_t &r_index, bool &r_batch_broken, Batch *&r_current_batch) {
+void RendererCanvasRenderRD::_add_to_batch(bool &r_batch_broken, Batch *&r_current_batch) {
 	r_current_batch->instance_count++;
-	r_index++;
-	if (r_index + state.last_instance_index >= state.max_instances_per_buffer) {
-		// Copy over all data needed for rendering right away
-		// then go back to recording item commands.
-		RD::get_singleton()->buffer_update(
-				state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers[state.current_instance_buffer_index],
-				state.last_instance_index * sizeof(InstanceData),
-				r_index * sizeof(InstanceData),
-				state.instance_data_array);
+	state.instance_data_index++;
+	if (state.instance_data_index >= state.max_instances_per_buffer) {
+		RD::get_singleton()->buffer_flush(r_current_batch->instance_buffer);
+		state.instance_data = nullptr;
 		_allocate_instance_buffer();
-		r_index = 0;
-		state.last_instance_index = 0;
+		state.instance_data_index = 0;
+		state.instance_data_index = 0;
 		r_batch_broken = false; // Force a new batch to be created
 		r_current_batch = _new_batch(r_batch_broken);
 		r_current_batch->start = 0;
+		r_current_batch->instance_buffer = state.instance_buffers._get(0);
 	}
 }
 
 void RendererCanvasRenderRD::_allocate_instance_buffer() {
-	state.current_instance_buffer_index++;
-
-	if (state.current_instance_buffer_index < state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers.size()) {
-		// We already allocated another buffer in a previous frame, so we can just use it.
-		return;
-	}
-
-	// Allocate a new buffer.
-	RID buf = RD::get_singleton()->storage_buffer_create(state.max_instance_buffer_size);
-	state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers.push_back(buf);
+	state.instance_buffers.prepare_for_upload();
+	state.instance_data = reinterpret_cast<InstanceData *>(state.instance_buffers.map_raw_for_upload(0));
 }
 
 void RendererCanvasRenderRD::_prepare_batch_texture_info(RID p_texture, TextureState &p_state, TextureInfo *p_info) {
@@ -3342,12 +3315,7 @@ RendererCanvasRenderRD::~RendererCanvasRenderRD() {
 		RD::get_singleton()->free(state.shadow_occluder_buffer);
 	}
 
-	memdelete_arr(state.instance_data_array);
-	for (uint32_t i = 0; i < BATCH_DATA_BUFFER_COUNT; i++) {
-		for (uint32_t j = 0; j < state.canvas_instance_data_buffers[i].instance_buffers.size(); j++) {
-			RD::get_singleton()->free(state.canvas_instance_data_buffers[i].instance_buffers[j]);
-		}
-	}
+	state.instance_buffers.uninit();
 
 	// Disable the callback, as we're tearing everything down
 	texture_storage->canvas_texture_set_invalidation_callback(default_canvas_texture, nullptr, nullptr);

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/templates/lru.h"
+#include "servers/rendering/multi_uma_buffer.h"
 #include "servers/rendering/renderer_canvas_render.h"
 #include "servers/rendering/renderer_rd/pipeline_hash_map_rd.h"
 #include "servers/rendering/renderer_rd/shaders/canvas.glsl.gen.h"
@@ -494,10 +495,12 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 	HashMap<RID, TightLocalVector<RID>> canvas_texture_to_uniform_set;
 
 	struct Batch {
-		// Position in the UBO measured in bytes
+		/// First instance index into the instance buffer for this batch.
 		uint32_t start = 0;
+		/// Number of instances in this batch.
 		uint32_t instance_count = 0;
-		uint32_t instance_buffer_index = 0;
+		/// Resource ID of the instance buffer for this batch.
+		RID instance_buffer; // UMA
 
 		TextureInfo *tex_info;
 
@@ -527,11 +530,6 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 
 	HashMap<TextureState, TextureInfo, HashableHasher<TextureState>, HashMapComparatorDefault<TextureState>, PagedAllocator<HashMapElement<TextureState, TextureInfo>>> texture_info_map;
 
-	// per-frame buffers
-	struct DataBuffer {
-		LocalVector<RID> instance_buffers;
-	};
-
 	struct State {
 		//state buffer
 		struct Buffer {
@@ -554,13 +552,17 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 			uint32_t pad2;
 		};
 
-		DataBuffer canvas_instance_data_buffers[BATCH_DATA_BUFFER_COUNT];
 		LocalVector<Batch> canvas_instance_batches;
-		uint32_t current_data_buffer_index = 0;
-		uint32_t current_instance_buffer_index = 0;
 		uint32_t current_batch_index = 0;
-		uint32_t last_instance_index = 0;
-		InstanceData *instance_data_array = nullptr;
+
+		static_assert(std::is_trivially_destructible_v<InstanceData>);
+		static_assert(std::is_trivially_constructible_v<InstanceData>);
+
+		MultiUmaBuffer<1u> instance_buffers = MultiUmaBuffer<1u>("CANVAS_INSTANCE_DATA");
+		/// A pointer to the current instance buffer retrieved from <c>instance_buffers</c>.
+		InstanceData *instance_data = nullptr;
+		/// The index of the next instance to be added to <c>instance_data</c>.
+		uint32_t instance_data_index = 0;
 
 		uint32_t max_instances_per_buffer = 16384;
 		uint32_t max_instance_buffer_size = 16384 * sizeof(InstanceData);
@@ -620,12 +622,14 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 
 	inline RID _get_pipeline_specialization_or_ubershader(CanvasShaderData *p_shader_data, PipelineKey &r_pipeline_key, PushConstant &r_push_constant, RID p_mesh_instance = RID(), void *p_surface = nullptr, uint32_t p_surface_index = 0, RID *r_vertex_array = nullptr);
 	void _render_batch_items(RenderTarget p_to_render_target, int p_item_count, const Transform2D &p_canvas_transform_inverse, Light *p_lights, bool &r_sdf_used, bool p_to_backbuffer = false, RenderingMethod::RenderInfo *r_render_info = nullptr);
-	void _record_item_commands(const Item *p_item, RenderTarget p_render_target, const Transform2D &p_base_transform, Item *&r_current_clip, Light *p_lights, uint32_t &r_index, bool &r_batch_broken, bool &r_sdf_used, Batch *&r_current_batch);
+	void _record_item_commands(const Item *p_item, RenderTarget p_render_target, const Transform2D &p_base_transform, Item *&r_current_clip, Light *p_lights, bool &r_batch_broken, bool &r_sdf_used, Batch *&r_current_batch);
 	void _render_batch(RD::DrawListID p_draw_list, CanvasShaderData *p_shader_data, RenderingDevice::FramebufferFormatID p_framebuffer_format, Light *p_lights, Batch const *p_batch, RenderingMethod::RenderInfo *r_render_info = nullptr);
 	void _prepare_batch_texture_info(RID p_texture, TextureState &p_state, TextureInfo *p_info);
-	InstanceData *new_instance_data(float *p_world, uint32_t *p_lights, uint32_t p_base_flags, uint32_t p_index, uint32_t p_uniforms_ofs, TextureInfo *p_info);
+
+	// non-UMA
+	InstanceData *new_instance_data(const InstanceData &template_instance);
 	[[nodiscard]] Batch *_new_batch(bool &r_batch_broken);
-	void _add_to_batch(uint32_t &r_index, bool &r_batch_broken, Batch *&r_current_batch);
+	void _add_to_batch(bool &r_batch_broken, Batch *&r_current_batch);
 	void _allocate_instance_buffer();
 
 	_FORCE_INLINE_ void _update_transform_2d_to_mat2x4(const Transform2D &p_transform, float *p_mat2x4);

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -74,30 +74,41 @@ void RendererCompositorRD::blit_render_targets_to_screen(DisplayServer::WindowID
 		const int screen_rotation_degrees = -RD::get_singleton()->screen_get_pre_rotation_degrees(p_screen);
 		float screen_rotation = Math::deg_to_rad((float)screen_rotation_degrees);
 
-		blit.push_constant.rotation_cos = Math::cos(screen_rotation);
-		blit.push_constant.rotation_sin = Math::sin(screen_rotation);
+		BlitPushConstant push_constant{};
+
+		push_constant.rotation_cos = Math::cos(screen_rotation);
+		push_constant.rotation_sin = Math::sin(screen_rotation);
 		// Swap width and height when the orientation is not the native one.
 		if (screen_rotation_degrees % 180 != 0) {
 			SWAP(screen_size.width, screen_size.height);
 		}
-		blit.push_constant.src_rect[0] = p_render_targets[i].src_rect.position.x;
-		blit.push_constant.src_rect[1] = p_render_targets[i].src_rect.position.y;
-		blit.push_constant.src_rect[2] = p_render_targets[i].src_rect.size.width;
-		blit.push_constant.src_rect[3] = p_render_targets[i].src_rect.size.height;
-		blit.push_constant.dst_rect[0] = p_render_targets[i].dst_rect.position.x / screen_size.width;
-		blit.push_constant.dst_rect[1] = p_render_targets[i].dst_rect.position.y / screen_size.height;
-		blit.push_constant.dst_rect[2] = p_render_targets[i].dst_rect.size.width / screen_size.width;
-		blit.push_constant.dst_rect[3] = p_render_targets[i].dst_rect.size.height / screen_size.height;
-		blit.push_constant.layer = p_render_targets[i].multi_view.layer;
-		blit.push_constant.eye_center[0] = p_render_targets[i].lens_distortion.eye_center.x;
-		blit.push_constant.eye_center[1] = p_render_targets[i].lens_distortion.eye_center.y;
-		blit.push_constant.k1 = p_render_targets[i].lens_distortion.k1;
-		blit.push_constant.k2 = p_render_targets[i].lens_distortion.k2;
-		blit.push_constant.upscale = p_render_targets[i].lens_distortion.upscale;
-		blit.push_constant.aspect_ratio = p_render_targets[i].lens_distortion.aspect_ratio;
-		blit.push_constant.convert_to_srgb = texture_storage->render_target_is_using_hdr(p_render_targets[i].render_target);
+		push_constant.src_rect[0] = p_render_targets[i].src_rect.position.x;
+		push_constant.src_rect[1] = p_render_targets[i].src_rect.position.y;
+		push_constant.src_rect[2] = p_render_targets[i].src_rect.size.width;
+		push_constant.src_rect[3] = p_render_targets[i].src_rect.size.height;
+		push_constant.dst_rect[0] = p_render_targets[i].dst_rect.position.x / screen_size.width;
+		push_constant.dst_rect[1] = p_render_targets[i].dst_rect.position.y / screen_size.height;
+		push_constant.dst_rect[2] = p_render_targets[i].dst_rect.size.width / screen_size.width;
+		push_constant.dst_rect[3] = p_render_targets[i].dst_rect.size.height / screen_size.height;
+		push_constant.layer = p_render_targets[i].multi_view.layer;
+		push_constant.eye_center[0] = p_render_targets[i].lens_distortion.eye_center.x;
+		push_constant.eye_center[1] = p_render_targets[i].lens_distortion.eye_center.y;
+		push_constant.k1 = p_render_targets[i].lens_distortion.k1;
+		push_constant.k2 = p_render_targets[i].lens_distortion.k2;
+		push_constant.upscale = p_render_targets[i].lens_distortion.upscale;
+		push_constant.aspect_ratio = p_render_targets[i].lens_distortion.aspect_ratio;
+		push_constant.convert_to_srgb = texture_storage->render_target_is_using_hdr(p_render_targets[i].render_target);
 
-		RD::get_singleton()->draw_list_set_push_constant(draw_list, &blit.push_constant, sizeof(BlitPushConstant));
+		const PushConstantsEmuBase::ParamsUniform params_uniform = blit.push_constant.upload_and_advance(push_constant);
+
+		// <TF>
+		// @ShadyTF
+		// replace push constants with UBO
+		// Was:
+		//RD::get_singleton()->draw_list_set_push_constant(draw_list, &blit.push_constant, sizeof(BlitPushConstant));
+		RD::get_singleton()->draw_list_bind_uniform_set(draw_list, params_uniform.set, 1);
+		// </TF>
+
 		RD::get_singleton()->draw_list_draw(draw_list, true);
 	}
 
@@ -129,9 +140,18 @@ void RendererCompositorRD::initialize() {
 		blit_modes.push_back("\n#define USE_LAYER\n#define APPLY_LENS_DISTORTION\n");
 		blit_modes.push_back("\n");
 
-		blit.shader.initialize(blit_modes);
+		Vector<uint64_t> dynamic_buffers;
+		dynamic_buffers.push_back(RDD::DynamicBuffer::encode(blit.push_constant.set_idx(), 0));
+
+		blit.shader.initialize(blit_modes, "", Vector<RD::PipelineImmutableSampler>(), dynamic_buffers);
 
 		blit.shader_version = blit.shader.version_create();
+
+		// <TF>
+		// @ShadyTF
+		// replace push constants with UBO
+		blit.push_constant.init(blit.shader.version_get_shader(blit.shader_version, 0));
+		// </TF>
 
 		for (int i = 0; i < BLIT_MODE_MAX; i++) {
 			blit.pipelines[i] = RD::get_singleton()->render_pipeline_create(blit.shader.version_get_shader(blit.shader_version, i), RD::get_singleton()->screen_get_framebuffer_format(DisplayServer::MAIN_WINDOW_ID), RD::INVALID_ID, RD::RENDER_PRIMITIVE_TRIANGLES, RD::PipelineRasterizationState(), RD::PipelineMultisampleState(), RD::PipelineDepthStencilState(), i == BLIT_MODE_NORMAL_ALPHA ? RenderingDevice::PipelineColorBlendState::create_blend() : RenderingDevice::PipelineColorBlendState::create_disabled(), 0);
@@ -174,6 +194,7 @@ void RendererCompositorRD::finalize() {
 	memdelete(utilities);
 
 	//only need to erase these, the rest are erased by cascade
+	blit.push_constant.uninit();
 	blit.shader.version_free(blit.shader_version);
 	RD::get_singleton()->free(blit.index_buffer);
 	RD::get_singleton()->free(blit.sampler);
@@ -225,6 +246,35 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 
 	screenrect.position /= window_size;
 	screenrect.size /= window_size;
+	// <TF>
+	// @ShadyTF
+	// replace push constants with UBO
+	const int screen_rotation_degrees = -RD::get_singleton()->screen_get_pre_rotation_degrees(DisplayServer::MAIN_WINDOW_ID);
+	float screen_rotation = Math::deg_to_rad((float)screen_rotation_degrees);
+
+	BlitPushConstant push_constant{};
+
+	push_constant.rotation_cos = Math::cos(screen_rotation);
+	push_constant.rotation_sin = Math::sin(screen_rotation);
+	push_constant.src_rect[0] = 0.0;
+	push_constant.src_rect[1] = 0.0;
+	push_constant.src_rect[2] = 1.0;
+	push_constant.src_rect[3] = 1.0;
+	push_constant.dst_rect[0] = screenrect.position.x;
+	push_constant.dst_rect[1] = screenrect.position.y;
+	push_constant.dst_rect[2] = screenrect.size.width;
+	push_constant.dst_rect[3] = screenrect.size.height;
+	push_constant.layer = 0;
+	push_constant.eye_center[0] = 0;
+	push_constant.eye_center[1] = 0;
+	push_constant.k1 = 0;
+	push_constant.k2 = 0;
+	push_constant.upscale = 1.0;
+	push_constant.aspect_ratio = 1.0;
+	push_constant.convert_to_srgb = false;
+
+	const PushConstantsEmuBase::ParamsUniform params_uniform = blit.push_constant.upload_and_advance(push_constant);
+	// </TF>
 
 	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin_for_screen(DisplayServer::MAIN_WINDOW_ID, p_color);
 
@@ -232,28 +282,8 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 	RD::get_singleton()->draw_list_bind_index_array(draw_list, blit.array);
 	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uset, 0);
 
-	const int screen_rotation_degrees = -RD::get_singleton()->screen_get_pre_rotation_degrees(DisplayServer::MAIN_WINDOW_ID);
-	float screen_rotation = Math::deg_to_rad((float)screen_rotation_degrees);
-	blit.push_constant.rotation_cos = Math::cos(screen_rotation);
-	blit.push_constant.rotation_sin = Math::sin(screen_rotation);
-	blit.push_constant.src_rect[0] = 0.0;
-	blit.push_constant.src_rect[1] = 0.0;
-	blit.push_constant.src_rect[2] = 1.0;
-	blit.push_constant.src_rect[3] = 1.0;
-	blit.push_constant.dst_rect[0] = screenrect.position.x;
-	blit.push_constant.dst_rect[1] = screenrect.position.y;
-	blit.push_constant.dst_rect[2] = screenrect.size.width;
-	blit.push_constant.dst_rect[3] = screenrect.size.height;
-	blit.push_constant.layer = 0;
-	blit.push_constant.eye_center[0] = 0;
-	blit.push_constant.eye_center[1] = 0;
-	blit.push_constant.k1 = 0;
-	blit.push_constant.k2 = 0;
-	blit.push_constant.upscale = 1.0;
-	blit.push_constant.aspect_ratio = 1.0;
-	blit.push_constant.convert_to_srgb = false;
-
-	RD::get_singleton()->draw_list_set_push_constant(draw_list, &blit.push_constant, sizeof(BlitPushConstant));
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, params_uniform.set, 1);
+	// </TF>
 	RD::get_singleton()->draw_list_draw(draw_list, true);
 
 	RD::get_singleton()->draw_list_end();

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/image.h"
+#include "servers/rendering/push_constants_emu.h"
 #include "servers/rendering/renderer_compositor.h"
 #include "servers/rendering/renderer_rd/environment/fog.h"
 #include "servers/rendering/renderer_rd/framebuffer_cache_rd.h"
@@ -81,18 +82,23 @@ protected:
 
 		float upscale;
 		float aspect_ratio;
+
 		uint32_t layer;
 		uint32_t convert_to_srgb;
 	};
 
 	struct Blit {
-		BlitPushConstant push_constant;
 		BlitShaderRD shader;
 		RID shader_version;
 		RID pipelines[BLIT_MODE_MAX];
 		RID index_buffer;
 		RID array;
 		RID sampler;
+		// <TF>
+		// @ShadyTF
+		// replace push constants with UBO
+		PushConstantsEmu<BlitPushConstant, 1u, 2u> push_constant = { "RendererCompositorRD::blit" };
+		// </TF>
 	} blit;
 
 	HashMap<RID, RID> render_target_descriptors;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1569,9 +1569,7 @@ RendererSceneRenderRD::~RendererSceneRenderRD() {
 	}
 #endif
 
-	if (sky.sky_scene_state.uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(sky.sky_scene_state.uniform_set)) {
-		RD::get_singleton()->free(sky.sky_scene_state.uniform_set);
-	}
+	sky.sky_scene_state.push_constant.uninit();
 
 	if (is_dynamic_gi_supported()) {
 		gi.free();

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -345,7 +345,7 @@ void ShaderRD::_compile_variant(uint32_t p_variant, CompileData p_data) {
 	{
 		MutexLock lock(variant_set_mutex);
 
-		p_data.version->variants.write[variant] = RD::get_singleton()->shader_create_from_bytecode_with_samplers(shader_data, p_data.version->variants[variant], immutable_samplers);
+		p_data.version->variants.write[variant] = RD::get_singleton()->shader_create_from_bytecode_with_samplers(shader_data, p_data.version->variants[variant], immutable_samplers, dynamic_buffers);
 		p_data.version->variant_data.write[variant] = shader_data;
 	}
 }
@@ -487,7 +487,7 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 		}
 		{
 			MutexLock lock(variant_set_mutex);
-			RID shader = RD::get_singleton()->shader_create_from_bytecode_with_samplers(p_version->variant_data[variant_id], p_version->variants[variant_id], immutable_samplers);
+			RID shader = RD::get_singleton()->shader_create_from_bytecode_with_samplers(p_version->variant_data[variant_id], p_version->variants[variant_id], immutable_samplers, dynamic_buffers);
 			if (shader.is_null()) {
 				for (uint32_t j = 0; j < i; j++) {
 					int variant_free_id = group_to_variant_map[p_group][j];
@@ -764,8 +764,9 @@ ShaderRD::ShaderRD() {
 	base_compute_defines = base_compute_define_text.ascii();
 }
 
-void ShaderRD::initialize(const Vector<String> &p_variant_defines, const String &p_general_defines, const Vector<RD::PipelineImmutableSampler> &r_immutable_samplers) {
+void ShaderRD::initialize(const Vector<String> &p_variant_defines, const String &p_general_defines, const Vector<RD::PipelineImmutableSampler> &r_immutable_samplers, const Vector<uint64_t> &p_dynamic_buffers) {
 	immutable_samplers = r_immutable_samplers;
+	dynamic_buffers = p_dynamic_buffers;
 	ERR_FAIL_COND(variant_defines.size());
 	ERR_FAIL_COND(p_variant_defines.is_empty());
 
@@ -828,7 +829,8 @@ void ShaderRD::_initialize_cache() {
 }
 
 // Same as above, but allows specifying shader compilation groups.
-void ShaderRD::initialize(const Vector<VariantDefine> &p_variant_defines, const String &p_general_defines) {
+void ShaderRD::initialize(const Vector<VariantDefine> &p_variant_defines, const String &p_general_defines, const Vector<uint64_t> &p_dynamic_buffers) {
+	dynamic_buffers = p_dynamic_buffers;
 	ERR_FAIL_COND(variant_defines.size());
 	ERR_FAIL_COND(p_variant_defines.is_empty());
 

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -61,6 +61,7 @@ private:
 	Vector<bool> group_enabled;
 
 	Vector<RD::PipelineImmutableSampler> immutable_samplers;
+	Vector<uint64_t> dynamic_buffers;
 
 	struct Version {
 		CharString uniforms;
@@ -210,8 +211,8 @@ public:
 
 	RS::ShaderNativeSourceCode version_get_native_source_code(RID p_version);
 
-	void initialize(const Vector<String> &p_variant_defines, const String &p_general_defines = "", const Vector<RD::PipelineImmutableSampler> &r_immutable_samplers = Vector<RD::PipelineImmutableSampler>());
-	void initialize(const Vector<VariantDefine> &p_variant_defines, const String &p_general_defines = "");
+	void initialize(const Vector<String> &p_variant_defines, const String &p_general_defines = "", const Vector<RD::PipelineImmutableSampler> &r_immutable_samplers = Vector<RD::PipelineImmutableSampler>(), const Vector<uint64_t> &p_dynamic_buffers = Vector<uint64_t>());
+	void initialize(const Vector<VariantDefine> &p_variant_defines, const String &p_general_defines = "", const Vector<uint64_t> &p_dynamic_buffers = Vector<uint64_t>());
 
 	virtual ~ShaderRD();
 };

--- a/servers/rendering/renderer_rd/shaders/blit.glsl
+++ b/servers/rendering/renderer_rd/shaders/blit.glsl
@@ -3,8 +3,13 @@
 #version 450
 
 #VERSION_DEFINES
-
-layout(push_constant, std140) uniform Pos {
+// <TF>
+// @ShadyTF
+// replace push constants with UBO
+// Was:
+//layout(push_constant, std140) uniform Pos {
+layout(set = 1, binding = 0, std140) uniform Pos {
+	// </TF>
 	vec4 src_rect;
 	vec4 dst_rect;
 
@@ -44,7 +49,13 @@ void main() {
 
 #VERSION_DEFINES
 
-layout(push_constant, std140) uniform Pos {
+// <TF>
+// @ShadyTF
+// replace push constants with UBO
+// Was:
+//layout(push_constant, std140) uniform Pos {
+layout(set = 1, binding = 0, std140) uniform Pos {
+	// </TF>
 	vec4 src_rect;
 	vec4 dst_rect;
 
@@ -115,7 +126,6 @@ void main() {
 #else
 	color = texture(src_rt, uv);
 #endif
-
 	if (data.convert_to_srgb) {
 		color.rgb = linear_to_srgb(color.rgb); // Regular linear -> SRGB conversion.
 	}

--- a/servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl
@@ -31,7 +31,7 @@ layout(location = 0) in vec2 uv_interp;
 layout(set = 0, binding = 0) uniform sampler2D source_color;
 
 #ifdef GLOW_USE_AUTO_EXPOSURE
-layout(set = 1, binding = 0) uniform sampler2D source_auto_exposure;
+layout(set = 0, binding = 1) uniform sampler2D source_auto_exposure;
 #endif
 
 layout(location = 0) out vec4 frag_color;

--- a/servers/rendering/renderer_rd/shaders/effects/blur_raster_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/blur_raster_inc.glsl
@@ -1,8 +1,13 @@
 #define FLAG_HORIZONTAL (1 << 0)
 #define FLAG_USE_ORTHOGONAL_PROJECTION (1 << 1)
 #define FLAG_GLOW_FIRST_PASS (1 << 2)
-
-layout(push_constant, std430) uniform Blur {
+// <TF>
+// @ShadyTF
+// replace push constants with UBO
+// Was:
+//layout(push_constant, std430) uniform Blur {
+layout(set = 1, binding = 0, std140) uniform Pos {
+	// </TF>
 	vec2 pixel_size; // 08 - 08
 	uint flags; // 04 - 12
 	uint pad; // 04 - 16

--- a/servers/rendering/renderer_rd/shaders/effects/copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy.glsl
@@ -16,7 +16,7 @@ layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 #define FLAG_COPY_ALL_SOURCE (1 << 7)
 #define FLAG_ALPHA_TO_ONE (1 << 8)
 
-layout(push_constant, std430) uniform Params {
+layout(set = 1, binding = 0, std140) uniform Params {
 	ivec4 section;
 	ivec2 target;
 	uint flags;
@@ -34,30 +34,30 @@ layout(push_constant, std430) uniform Params {
 	// DOF.
 	float camera_z_far;
 	float camera_z_near;
-	uint pad2[2];
+	ivec2 pad2;
 
 	vec4 set_color;
 }
 params;
 
 #ifdef MODE_CUBEMAP_ARRAY_TO_PANORAMA
-layout(set = 0, binding = 0) uniform samplerCubeArray source_color;
+layout(set = 0, binding = SOURCE_COLOR_SLOT) uniform samplerCubeArray source_color;
 #elif defined(MODE_CUBEMAP_TO_PANORAMA)
-layout(set = 0, binding = 0) uniform samplerCube source_color;
+layout(set = 0, binding = SOURCE_COLOR_SLOT) uniform samplerCube source_color;
 #elif !defined(MODE_SET_COLOR)
-layout(set = 0, binding = 0) uniform sampler2D source_color;
-#endif
-
-#ifdef GLOW_USE_AUTO_EXPOSURE
-layout(set = 1, binding = 0) uniform sampler2D source_auto_exposure;
+layout(set = 0, binding = SOURCE_COLOR_SLOT) uniform sampler2D source_color;
 #endif
 
 #if defined(MODE_LINEARIZE_DEPTH_COPY) || defined(MODE_SIMPLE_COPY_DEPTH)
-layout(r32f, set = 3, binding = 0) uniform restrict writeonly image2D dest_buffer;
+layout(r32f, set = 0, binding = DEST_BUFFER) uniform restrict writeonly image2D dest_buffer;
 #elif defined(DST_IMAGE_8BIT)
-layout(rgba8, set = 3, binding = 0) uniform restrict writeonly image2D dest_buffer;
+layout(rgba8, set = 0, binding = DEST_BUFFER) uniform restrict writeonly image2D dest_buffer;
 #else
-layout(rgba16f, set = 3, binding = 0) uniform restrict writeonly image2D dest_buffer;
+layout(rgba16f, set = 0, binding = DEST_BUFFER) uniform restrict writeonly image2D dest_buffer;
+#endif
+
+#ifdef GLOW_USE_AUTO_EXPOSURE
+layout(set = 0, binding = SOURCE_AUTO_EXPOSURE) uniform sampler2D source_auto_exposure;
 #endif
 
 #ifdef MODE_GAUSSIAN_BLUR

--- a/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
@@ -29,7 +29,10 @@ layout(location = 0) out vec3 uv_interp;
 layout(location = 0) out vec2 uv_interp;
 #endif
 
-layout(push_constant, std430) uniform Params {
+// <TF>
+// @ShadyTF
+// replace push constants with UBO
+layout(set = 1, binding = 0, std140) uniform Params {
 	vec4 section;
 	vec2 pixel_size;
 	float luminance_multiplier;
@@ -38,6 +41,7 @@ layout(push_constant, std430) uniform Params {
 	vec4 color;
 }
 params;
+// </TF>
 
 void main() {
 	vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
@@ -85,7 +89,10 @@ void main() {
 #define FLAG_LINEAR (1 << 6)
 #define FLAG_NORMAL (1 << 7)
 
-layout(push_constant, std430) uniform Params {
+// <TF>
+// @ShadyTF
+// replace push constants with UBO
+layout(set = 1, binding = 0, std140) uniform Params {
 	vec4 section;
 	vec2 pixel_size;
 	float luminance_multiplier;
@@ -94,6 +101,7 @@ layout(push_constant, std430) uniform Params {
 	vec4 color;
 }
 params;
+// </TF>
 
 #ifndef MODE_SET_COLOR
 #ifdef USE_MULTIVIEW
@@ -105,13 +113,13 @@ layout(location = 0) in vec2 uv_interp;
 #ifdef USE_MULTIVIEW
 layout(set = 0, binding = 0) uniform sampler2DArray source_color;
 #ifdef MODE_TWO_SOURCES
-layout(set = 1, binding = 0) uniform sampler2DArray source_depth;
+layout(set = 0, binding = 1) uniform sampler2DArray source_depth;
 layout(location = 1) out float depth;
 #endif /* MODE_TWO_SOURCES */
 #else /* USE_MULTIVIEW */
 layout(set = 0, binding = 0) uniform sampler2D source_color;
 #ifdef MODE_TWO_SOURCES
-layout(set = 1, binding = 0) uniform sampler2D source_color2;
+layout(set = 0, binding = 1) uniform sampler2D source_color2;
 #endif /* MODE_TWO_SOURCES */
 #endif /* USE_MULTIVIEW */
 #endif /* !SET_COLOR */

--- a/servers/rendering/renderer_rd/shaders/effects/cube_to_dp.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/cube_to_dp.glsl
@@ -4,7 +4,13 @@
 
 #VERSION_DEFINES
 
-layout(push_constant, std430) uniform Params {
+// <TF>
+// @ShadyTF
+// replace push constants with UBO
+// Was:
+//layout(push_constant, std430) uniform Params {
+layout(set = 1, binding = 0, std140) uniform Params {
+	// </TF>
 	float z_far;
 	float z_near;
 	vec2 texel_size;
@@ -29,7 +35,8 @@ layout(location = 0) in vec2 uv_interp;
 
 layout(set = 0, binding = 0) uniform samplerCube source_cube;
 
-layout(push_constant, std430) uniform Params {
+layout(set = 1, binding = 0, std140) uniform Params {
+	//layout(push_constant, std430) uniform Params {
 	float z_far;
 	float z_near;
 	vec2 texel_size;

--- a/servers/rendering/renderer_rd/shaders/effects/cubemap_downsampler.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/cubemap_downsampler.glsl
@@ -30,7 +30,7 @@ layout(local_size_x = BLOCK_SIZE, local_size_y = BLOCK_SIZE, local_size_z = 1) i
 
 layout(set = 0, binding = 0) uniform samplerCube source_cubemap;
 
-layout(rgba16f, set = 1, binding = 0) uniform restrict writeonly imageCube dest_cubemap;
+layout(rgba16f, set = 0, binding = 1) uniform restrict writeonly imageCube dest_cubemap;
 
 #include "cubemap_downsampler_inc.glsl"
 

--- a/servers/rendering/renderer_rd/shaders/effects/cubemap_roughness.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/cubemap_roughness.glsl
@@ -10,7 +10,7 @@ layout(local_size_x = GROUP_SIZE, local_size_y = GROUP_SIZE, local_size_z = 1) i
 
 layout(set = 0, binding = 0) uniform samplerCube source_cube;
 
-layout(rgba16f, set = 1, binding = 0) uniform restrict writeonly imageCube dest_cubemap;
+layout(rgba16f, set = 0, binding = 1) uniform restrict writeonly imageCube dest_cubemap;
 
 #include "cubemap_roughness_inc.glsl"
 

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -56,18 +56,18 @@ layout(set = 0, binding = 0) uniform sampler2DArray source_color;
 layout(set = 0, binding = 0) uniform sampler2D source_color;
 #endif
 
-layout(set = 1, binding = 0) uniform sampler2D source_auto_exposure;
+layout(set = 0, binding = 1) uniform sampler2D source_auto_exposure;
 #ifdef USE_MULTIVIEW
-layout(set = 2, binding = 0) uniform sampler2DArray source_glow;
+layout(set = 0, binding = 2) uniform sampler2DArray source_glow;
 #else
-layout(set = 2, binding = 0) uniform sampler2D source_glow;
+layout(set = 0, binding = 2) uniform sampler2D source_glow;
 #endif
-layout(set = 2, binding = 1) uniform sampler2D glow_map;
+layout(set = 0, binding = 3) uniform sampler2D glow_map;
 
 #ifdef USE_1D_LUT
-layout(set = 3, binding = 0) uniform sampler2D source_color_correction;
+layout(set = 0, binding = 4) uniform sampler2D source_color_correction;
 #else
-layout(set = 3, binding = 0) uniform sampler3D source_color_correction;
+layout(set = 0, binding = 4) uniform sampler3D source_color_correction;
 #endif
 
 #define FLAG_USE_BCS (1 << 0)
@@ -78,7 +78,13 @@ layout(set = 3, binding = 0) uniform sampler3D source_color_correction;
 #define FLAG_USE_DEBANDING (1 << 5)
 #define FLAG_CONVERT_TO_SRGB (1 << 6)
 
-layout(push_constant, std430) uniform Params {
+// <TF>
+// @ShadyTF
+// replace push constants with UBO
+// Was:
+//layout(push_constant, std430) uniform Params {
+layout(set = 1, binding = 0, std140) uniform Params {
+	// </TF>
 	vec3 bcs;
 	uint flags;
 
@@ -90,8 +96,17 @@ layout(push_constant, std430) uniform Params {
 	float glow_intensity;
 	float glow_map_strength;
 
+	// <TF>
+	// @ShadyTF
+	// replace push constants with UBO
+	// swap these to fix alignment for UBO
+	// Was :
+	//	uint glow_mode;
+	//	float glow_levels[7];
+	vec4 glow_levelsA;
+	vec3 glow_levelsB;
 	uint glow_mode;
-	float glow_levels[7];
+	// </TF>
 
 	float exposure;
 	float white;
@@ -373,34 +388,69 @@ vec3 gather_glow(sampler2D tex, vec2 uv) { // sample all selected glow levels
 #endif // defined(USE_MULTIVIEW)
 	vec3 glow = vec3(0.0f);
 
-	if (params.glow_levels[0] > 0.0001) {
-		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 0).rgb * params.glow_levels[0];
+	// <TF>
+	// @ShadyTF
+	// replace push constants with UBO
+	// fix alignment issues by reordering and using a vec4 and a vec3 for the 7 glow levels
+	// Was:
+	/*
+		if (params.glow_levels[0] > 0.0001) {
+			glow += GLOW_TEXTURE_SAMPLE(tex, uv, 0).rgb * params.glow_levels[0];
+		}
+
+		if (params.glow_levels[1] > 0.0001) {
+			glow += GLOW_TEXTURE_SAMPLE(tex, uv, 1).rgb * params.glow_levels[1];
+		}
+
+		if (params.glow_levels[2] > 0.0001) {
+			glow += GLOW_TEXTURE_SAMPLE(tex, uv, 2).rgb * params.glow_levels[2];
+		}
+
+		if (params.glow_levels[3] > 0.0001) {
+			glow += GLOW_TEXTURE_SAMPLE(tex, uv, 3).rgb * params.glow_levels[3];
+		}
+
+		if (params.glow_levels[4] > 0.0001) {
+			glow += GLOW_TEXTURE_SAMPLE(tex, uv, 4).rgb * params.glow_levels[4];
+		}
+
+		if (params.glow_levels[5] > 0.0001) {
+			glow += GLOW_TEXTURE_SAMPLE(tex, uv, 5).rgb * params.glow_levels[5];
+		}
+
+		if (params.glow_levels[6] > 0.0001) {
+			glow += GLOW_TEXTURE_SAMPLE(tex, uv, 6).rgb * params.glow_levels[6];
+		}
+	*/
+
+	if (params.glow_levelsA.x > 0.0001) {
+		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 0).rgb * params.glow_levelsA.x;
 	}
 
-	if (params.glow_levels[1] > 0.0001) {
-		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 1).rgb * params.glow_levels[1];
+	if (params.glow_levelsA.y > 0.0001) {
+		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 1).rgb * params.glow_levelsA.y;
 	}
 
-	if (params.glow_levels[2] > 0.0001) {
-		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 2).rgb * params.glow_levels[2];
+	if (params.glow_levelsA.z > 0.0001) {
+		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 2).rgb * params.glow_levelsA.z;
 	}
 
-	if (params.glow_levels[3] > 0.0001) {
-		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 3).rgb * params.glow_levels[3];
+	if (params.glow_levelsA.w > 0.0001) {
+		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 3).rgb * params.glow_levelsA.w;
 	}
 
-	if (params.glow_levels[4] > 0.0001) {
-		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 4).rgb * params.glow_levels[4];
+	if (params.glow_levelsB.x > 0.0001) {
+		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 4).rgb * params.glow_levelsB.x;
 	}
 
-	if (params.glow_levels[5] > 0.0001) {
-		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 5).rgb * params.glow_levels[5];
+	if (params.glow_levelsB.y > 0.0001) {
+		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 5).rgb * params.glow_levelsB.y;
 	}
 
-	if (params.glow_levels[6] > 0.0001) {
-		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 6).rgb * params.glow_levels[6];
+	if (params.glow_levelsB.z > 0.0001) {
+		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 6).rgb * params.glow_levelsB.z;
 	}
-
+	// </TF>
 	return glow;
 }
 

--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -12,7 +12,17 @@
 
 layout(location = 0) out vec2 uv_interp;
 
+// <TF>
+// @ShadyTF
+// replacing push constants with uniform buffer
+// Was:
+//layout(push_constant, std430) uniform Params {
+#ifdef USE_PUSH_CONSTANTS
 layout(push_constant, std430) uniform Params {
+#else
+layout(set = 0, binding = 0, std140) uniform Params {
+#endif
+	// </TF>
 	mat3 orientation;
 	vec4 projection; // only applicable if not multiview
 	vec3 position;
@@ -53,7 +63,17 @@ void main() {
 
 layout(location = 0) in vec2 uv_interp;
 
+// <TF>
+// @ShadyTF
+// replacing push constants with uniform buffer
+// Was:
+//layout(push_constant, std430) uniform Params {
+#ifdef USE_PUSH_CONSTANTS
 layout(push_constant, std430) uniform Params {
+#else
+layout(set = 0, binding = 0, std140) uniform Params {
+#endif
+	// </TF>
 	mat3 orientation;
 	vec4 projection; // only applicable if not multiview
 	vec3 position;

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -1088,25 +1088,18 @@ void MaterialStorage::MaterialData::free_parameters_uniform_set(RID p_uniform_se
 }
 
 bool MaterialStorage::MaterialData::update_parameters_uniform_set(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty, const HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> &p_uniforms, const uint32_t *p_uniform_offsets, const Vector<ShaderCompiler::GeneratedCode::Texture> &p_texture_uniforms, const HashMap<StringName, HashMap<int, RID>> &p_default_texture_params, uint32_t p_ubo_size, RID &uniform_set, RID p_shader, uint32_t p_shader_uniform_set, bool p_use_linear_color, bool p_3d_material) {
-	if ((uint32_t)ubo_data[p_use_linear_color].size() != p_ubo_size) {
-		p_uniform_dirty = true;
-		if (uniform_buffer[p_use_linear_color].is_valid()) {
-			RD::get_singleton()->free(uniform_buffer[p_use_linear_color]);
-			uniform_buffer[p_use_linear_color] = RID();
-		}
+	// <TF>
+	// @dark_sylinc: TheForge forces UBOs to update every time due to persistent storage.
+	p_uniform_dirty = true;
+	if (uniform_buffer[p_use_linear_color].is_valid()) {
+		RD::get_singleton()->free(uniform_buffer[p_use_linear_color]);
+		uniform_buffer[p_use_linear_color] = RID();
+	}
 
-		ubo_data[p_use_linear_color].resize(p_ubo_size);
-		if (ubo_data[p_use_linear_color].size()) {
-			uniform_buffer[p_use_linear_color] = RD::get_singleton()->uniform_buffer_create(ubo_data[p_use_linear_color].size());
-			memset(ubo_data[p_use_linear_color].ptrw(), 0, ubo_data[p_use_linear_color].size()); //clear
-		}
-
-		//clear previous uniform set
-		if (uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(uniform_set)) {
-			RD::get_singleton()->uniform_set_set_invalidation_callback(uniform_set, nullptr, nullptr);
-			RD::get_singleton()->free(uniform_set);
-			uniform_set = RID();
-		}
+	ubo_data[p_use_linear_color].resize(p_ubo_size);
+	if (ubo_data[p_use_linear_color].size()) {
+		uniform_buffer[p_use_linear_color] = RD::get_singleton()->uniform_buffer_create(ubo_data[p_use_linear_color].size());
+		memset(ubo_data[p_use_linear_color].ptrw(), 0, ubo_data[p_use_linear_color].size()); //clear
 	}
 
 	//check whether buffer changed
@@ -1124,13 +1117,6 @@ bool MaterialStorage::MaterialData::update_parameters_uniform_set(const HashMap<
 		texture_cache.resize(tex_uniform_count);
 		render_target_cache.clear();
 		p_textures_dirty = true;
-
-		//clear previous uniform set
-		if (uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(uniform_set)) {
-			RD::get_singleton()->uniform_set_set_invalidation_callback(uniform_set, nullptr, nullptr);
-			RD::get_singleton()->free(uniform_set);
-			uniform_set = RID();
-		}
 	}
 
 	if (p_textures_dirty && tex_uniform_count) {
@@ -1146,6 +1132,7 @@ bool MaterialStorage::MaterialData::update_parameters_uniform_set(const HashMap<
 		//no reason to update uniform set, only UBO (or nothing) was needed to update
 		return false;
 	}
+	// </TF>
 
 	Vector<RD::Uniform> uniforms;
 
@@ -1177,7 +1164,6 @@ bool MaterialStorage::MaterialData::update_parameters_uniform_set(const HashMap<
 	}
 
 	uniform_set = RD::get_singleton()->uniform_set_create(uniforms, p_shader, p_shader_uniform_set);
-
 	RD::get_singleton()->uniform_set_set_invalidation_callback(uniform_set, MaterialStorage::_material_uniform_set_erased, &self);
 
 	return true;

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
@@ -93,6 +93,8 @@ public:
 	void update_ubo(RID p_uniform_buffer, RS::ViewportDebugDraw p_debug_mode, RID p_env, RID p_reflection_probe_instance, RID p_camera_attributes, bool p_pancake_shadows, const Size2i &p_screen_size, const Color &p_default_bg_color, float p_luminance_multiplier, bool p_opaque_render_buffers, bool p_apply_alpha_multiplier);
 	virtual RID get_uniform_buffer() const override;
 
+	static uint32_t get_uniform_buffer_size_bytes() { return sizeof(UBODATA); }
+
 private:
 	RID uniform_buffer; // loaded into this uniform buffer (supplied externally)
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -31,6 +31,7 @@
 #include "rendering_device.h"
 #include "rendering_device.compat.inc"
 
+#include "push_constants_emu.h"
 #include "rendering_device_binds.h"
 #include "shader_include_db.h"
 
@@ -282,7 +283,7 @@ Error RenderingDevice::_buffer_initialize(Buffer *p_buffer, const uint8_t *p_dat
 Error RenderingDevice::_insert_staging_block(StagingBuffers &p_staging_buffers) {
 	StagingBufferBlock block;
 
-	block.driver_id = driver->buffer_create(p_staging_buffers.block_size, p_staging_buffers.usage_bits, RDD::MEMORY_ALLOCATION_TYPE_CPU);
+	block.driver_id = driver->buffer_create(p_staging_buffers.block_size, p_staging_buffers.usage_bits, RDD::MEMORY_ALLOCATION_TYPE_CPU, frames_drawn);
 	ERR_FAIL_COND_V(!block.driver_id, ERR_CANT_CREATE);
 
 	block.frame_used = 0;
@@ -470,18 +471,28 @@ Error RenderingDevice::buffer_copy(RID p_src_buffer, RID p_dst_buffer, uint32_t 
 	return OK;
 }
 
-Error RenderingDevice::buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p_size, const void *p_data) {
+Error RenderingDevice::buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p_size, const void *p_data, const bool p_skip_check) {
 	ERR_RENDER_THREAD_GUARD_V(ERR_UNAVAILABLE);
 
 	copy_bytes_count += p_size;
-	ERR_FAIL_COND_V_MSG(draw_list.active, ERR_INVALID_PARAMETER,
+
+	ERR_FAIL_COND_V_MSG(draw_list.active && !p_skip_check, ERR_INVALID_PARAMETER,
 			"Updating buffers is forbidden during creation of a draw list");
-	ERR_FAIL_COND_V_MSG(compute_list.active, ERR_INVALID_PARAMETER,
+	ERR_FAIL_COND_V_MSG(compute_list.active && !p_skip_check, ERR_INVALID_PARAMETER,
 			"Updating buffers is forbidden during creation of a compute list");
 
 	Buffer *buffer = _get_buffer_from_owner(p_buffer);
 	ERR_FAIL_NULL_V_MSG(buffer, ERR_INVALID_PARAMETER, "Buffer argument is not a valid buffer of any type.");
 	ERR_FAIL_COND_V_MSG(p_offset + p_size > buffer->size, ERR_INVALID_PARAMETER, "Attempted to write buffer (" + itos((p_offset + p_size) - buffer->size) + " bytes) past the end.");
+
+	if (buffer->usage.has_flag(RDD::BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT)) {
+		uint8_t *dst_data = driver->buffer_persistent_map_advance(buffer->driver_id, frames_drawn);
+
+		memcpy(dst_data + p_offset, p_data, p_size);
+		direct_copy_count++;
+		buffer_flush(p_buffer);
+		return OK;
+	}
 
 	_check_transfer_worker_buffer(buffer);
 
@@ -612,8 +623,9 @@ Error RenderingDevice::driver_callback_add(RDD::DriverCallback p_callback, void 
 
 String RenderingDevice::get_perf_report() const {
 	String perf_report_text;
-	perf_report_text += " gpu:" + String::num_int64(prev_gpu_copy_count);
-	perf_report_text += " bytes:" + String::num_int64(prev_copy_bytes_count);
+	perf_report_text += " gpu:" + String::num_int64(gpu_copy_count);
+	perf_report_text += " direct:" + String::num_int64(direct_copy_count);
+	perf_report_text += " bytes:" + String::num_int64(copy_bytes_count);
 
 	perf_report_text += " lazily alloc:" + String::num_int64(driver->get_lazily_memory_used());
 	return perf_report_text;
@@ -623,6 +635,7 @@ void RenderingDevice::update_perf_report() {
 	prev_gpu_copy_count = gpu_copy_count;
 	prev_copy_bytes_count = copy_bytes_count;
 	gpu_copy_count = 0;
+	direct_copy_count = 0;
 	copy_bytes_count = 0;
 }
 
@@ -674,7 +687,7 @@ Vector<uint8_t> RenderingDevice::buffer_get_data(RID p_buffer, uint32_t p_offset
 
 	_check_transfer_worker_buffer(buffer);
 
-	RDD::BufferID tmp_buffer = driver->buffer_create(buffer->size, RDD::BUFFER_USAGE_TRANSFER_TO_BIT, RDD::MEMORY_ALLOCATION_TYPE_CPU);
+	RDD::BufferID tmp_buffer = driver->buffer_create(buffer->size, RDD::BUFFER_USAGE_TRANSFER_TO_BIT, RDD::MEMORY_ALLOCATION_TYPE_CPU, frames_drawn);
 	ERR_FAIL_COND_V(!tmp_buffer, Vector<uint8_t>());
 
 	RDD::BufferCopyRegion region;
@@ -799,12 +812,38 @@ uint64_t RenderingDevice::buffer_get_device_address(RID p_buffer) {
 	return driver->buffer_get_device_address(buffer->driver_id);
 }
 
+uint8_t *RenderingDevice::buffer_persistent_map_advance(RID p_buffer) {
+	ERR_RENDER_THREAD_GUARD_V(0);
+
+	Buffer *buffer = _get_buffer_from_owner(p_buffer);
+	ERR_FAIL_NULL_V_MSG(buffer, nullptr, "Buffer argument is not a valid buffer of any type.");
+	direct_copy_count++;
+	return driver->buffer_persistent_map_advance(buffer->driver_id, frames_drawn);
+}
+
+void RenderingDevice::buffer_flush(RID p_buffer) {
+	ERR_RENDER_THREAD_GUARD();
+
+	Buffer *buffer = _get_buffer_from_owner(p_buffer);
+	ERR_FAIL_NULL_MSG(buffer, "Buffer argument is not a valid buffer of any type.");
+	driver->buffer_flush(buffer->driver_id);
+}
+
 RID RenderingDevice::storage_buffer_create(uint32_t p_size_bytes, const Vector<uint8_t> &p_data, BitField<StorageBufferUsage> p_usage, BitField<BufferCreationBits> p_creation_bits) {
 	ERR_FAIL_COND_V(p_data.size() && (uint32_t)p_data.size() != p_size_bytes, RID());
 
 	Buffer buffer;
 	buffer.size = p_size_bytes;
 	buffer.usage = (RDD::BUFFER_USAGE_TRANSFER_FROM_BIT | RDD::BUFFER_USAGE_TRANSFER_TO_BIT | RDD::BUFFER_USAGE_STORAGE_BIT);
+	if (p_creation_bits.has_flag(BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT)) {
+		buffer.usage.set_flag(RDD::BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT);
+
+		// This is a precaution: Persistent buffers are meant for frequent CPU -> GPU transfers.
+		// Writing to this buffer from GPU might cause sync issues if both CPU & GPU try to write at the
+		// same time. It's probably fine (since CPU always advances the pointer before writing) but let's
+		// stick to the known/intended use cases and scream if we deviate from it.
+		buffer.usage.clear_flag(RDD::BUFFER_USAGE_TRANSFER_TO_BIT);
+	}
 	if (p_usage.has_flag(STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT)) {
 		buffer.usage.set_flag(RDD::BUFFER_USAGE_INDIRECT_BIT);
 	}
@@ -816,7 +855,7 @@ RID RenderingDevice::storage_buffer_create(uint32_t p_size_bytes, const Vector<u
 
 		buffer.usage.set_flag(RDD::BUFFER_USAGE_DEVICE_ADDRESS_BIT);
 	}
-	buffer.driver_id = driver->buffer_create(buffer.size, buffer.usage, RDD::MEMORY_ALLOCATION_TYPE_GPU);
+	buffer.driver_id = driver->buffer_create(buffer.size, buffer.usage, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
 	ERR_FAIL_COND_V(!buffer.driver_id, RID());
 
 	// Storage buffers are assumed to be mutable.
@@ -848,7 +887,7 @@ RID RenderingDevice::texture_buffer_create(uint32_t p_size_elements, DataFormat 
 	Buffer texture_buffer;
 	texture_buffer.size = size_bytes;
 	BitField<RDD::BufferUsageBits> usage = (RDD::BUFFER_USAGE_TRANSFER_FROM_BIT | RDD::BUFFER_USAGE_TRANSFER_TO_BIT | RDD::BUFFER_USAGE_TEXEL_BIT);
-	texture_buffer.driver_id = driver->buffer_create(size_bytes, usage, RDD::MEMORY_ALLOCATION_TYPE_GPU);
+	texture_buffer.driver_id = driver->buffer_create(size_bytes, usage, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
 	ERR_FAIL_COND_V(!texture_buffer.driver_id, RID());
 
 	// Texture buffers are assumed to be immutable unless they don't have initial data.
@@ -1855,7 +1894,7 @@ void RenderingDevice::_texture_create_reinterpret_buffer(Texture *p_texture) {
 	uint32_t pixel_bytes = get_image_format_pixel_size(p_texture->format);
 	uint32_t row_pitch = STEPIFY(p_texture->width * pixel_bytes, row_pitch_step);
 	uint64_t buffer_size = STEPIFY(pixel_bytes * row_pitch * p_texture->height * p_texture->depth, transfer_alignment);
-	p_texture->shared_fallback->buffer = driver->buffer_create(buffer_size, RDD::BUFFER_USAGE_TRANSFER_FROM_BIT | RDD::BUFFER_USAGE_TRANSFER_TO_BIT, RDD::MEMORY_ALLOCATION_TYPE_GPU);
+	p_texture->shared_fallback->buffer = driver->buffer_create(buffer_size, RDD::BUFFER_USAGE_TRANSFER_FROM_BIT | RDD::BUFFER_USAGE_TRANSFER_TO_BIT, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
 	buffer_memory += driver->buffer_get_allocation_size(p_texture->shared_fallback->buffer);
 
 	RDG::ResourceTracker *tracker = RDG::resource_tracker_create();
@@ -1964,7 +2003,7 @@ Vector<uint8_t> RenderingDevice::texture_get_data(RID p_texture, uint32_t p_laye
 			work_buffer_size = STEPIFY(work_buffer_size, work_mip_alignment) + mip_layouts[i].size;
 		}
 
-		RDD::BufferID tmp_buffer = driver->buffer_create(work_buffer_size, RDD::BUFFER_USAGE_TRANSFER_TO_BIT, RDD::MEMORY_ALLOCATION_TYPE_CPU);
+		RDD::BufferID tmp_buffer = driver->buffer_create(work_buffer_size, RDD::BUFFER_USAGE_TRANSFER_TO_BIT, RDD::MEMORY_ALLOCATION_TYPE_CPU, frames_drawn);
 		ERR_FAIL_COND_V(!tmp_buffer, Vector<uint8_t>());
 
 		thread_local LocalVector<RDD::BufferTextureCopyRegion> command_buffer_texture_copy_regions_vector;
@@ -2995,7 +3034,7 @@ RID RenderingDevice::vertex_buffer_create(uint32_t p_size_bytes, const Vector<ui
 	if (p_creation_bits.has_flag(BUFFER_CREATION_DEVICE_ADDRESS_BIT)) {
 		buffer.usage.set_flag(RDD::BUFFER_USAGE_DEVICE_ADDRESS_BIT);
 	}
-	buffer.driver_id = driver->buffer_create(buffer.size, buffer.usage, RDD::MEMORY_ALLOCATION_TYPE_GPU);
+	buffer.driver_id = driver->buffer_create(buffer.size, buffer.usage, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
 	ERR_FAIL_COND_V(!buffer.driver_id, RID());
 
 	// Vertex buffers are assumed to be immutable unless they don't have initial data or they've been marked for storage explicitly.
@@ -3167,7 +3206,7 @@ RID RenderingDevice::index_buffer_create(uint32_t p_index_count, IndexBufferForm
 	if (p_creation_bits.has_flag(BUFFER_CREATION_DEVICE_ADDRESS_BIT)) {
 		index_buffer.usage.set_flag(RDD::BUFFER_USAGE_DEVICE_ADDRESS_BIT);
 	}
-	index_buffer.driver_id = driver->buffer_create(index_buffer.size, index_buffer.usage, RDD::MEMORY_ALLOCATION_TYPE_GPU);
+	index_buffer.driver_id = driver->buffer_create(index_buffer.size, index_buffer.usage, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
 	ERR_FAIL_COND_V(!index_buffer.driver_id, RID());
 
 	// Index buffers are assumed to be immutable unless they don't have initial data.
@@ -3222,7 +3261,7 @@ RID RenderingDevice::index_array_create(RID p_index_buffer, uint32_t p_index_off
 /****************/
 
 static const char *SHADER_UNIFORM_NAMES[RenderingDevice::UNIFORM_TYPE_MAX] = {
-	"Sampler", "CombinedSampler", "Texture", "Image", "TextureBuffer", "SamplerTextureBuffer", "ImageBuffer", "UniformBuffer", "StorageBuffer", "InputAttachment"
+	"Sampler", "CombinedSampler", "Texture", "Image", "TextureBuffer", "SamplerTextureBuffer", "ImageBuffer", "UniformBuffer", "UniformBufferDynamic", "StorageBuffer", "StorageBufferDynamic", "InputAttachment"
 };
 
 String RenderingDevice::_shader_uniform_debug(RID p_shader, int p_set) {
@@ -3260,7 +3299,7 @@ RID RenderingDevice::shader_create_from_bytecode(const Vector<uint8_t> &p_shader
 	return shader_create_from_bytecode_with_samplers(p_shader_binary, p_placeholder, immutable_samplers);
 }
 
-RID RenderingDevice::shader_create_from_bytecode_with_samplers(const Vector<uint8_t> &p_shader_binary, RID p_placeholder, const Vector<PipelineImmutableSampler> &p_immutable_samplers) {
+RID RenderingDevice::shader_create_from_bytecode_with_samplers(const Vector<uint8_t> &p_shader_binary, RID p_placeholder, const Vector<PipelineImmutableSampler> &p_immutable_samplers, const Vector<uint64_t> &p_dynamic_buffers) {
 	_THREAD_SAFE_METHOD_
 
 	ShaderDescription shader_desc;
@@ -3279,7 +3318,7 @@ RID RenderingDevice::shader_create_from_bytecode_with_samplers(const Vector<uint
 
 		driver_immutable_samplers.append(driver_sampler);
 	}
-	RDD::ShaderID shader_id = driver->shader_create_from_bytecode(p_shader_binary, shader_desc, name, driver_immutable_samplers);
+	RDD::ShaderID shader_id = driver->shader_create_from_bytecode(p_shader_binary, shader_desc, name, driver_immutable_samplers, p_dynamic_buffers);
 	ERR_FAIL_COND_V(!shader_id, RID());
 
 	// All good, let's create modules.
@@ -3384,7 +3423,16 @@ RID RenderingDevice::uniform_buffer_create(uint32_t p_size_bytes, const Vector<u
 	if (p_creation_bits.has_flag(BUFFER_CREATION_DEVICE_ADDRESS_BIT)) {
 		buffer.usage.set_flag(RDD::BUFFER_USAGE_DEVICE_ADDRESS_BIT);
 	}
-	buffer.driver_id = driver->buffer_create(buffer.size, buffer.usage, RDD::MEMORY_ALLOCATION_TYPE_GPU);
+	if (p_creation_bits.has_flag(BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT)) {
+		buffer.usage.set_flag(RDD::BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT);
+
+		// This is a precaution: Persistent buffers are meant for frequent CPU -> GPU transfers.
+		// Writing to this buffer from GPU might cause sync issues if both CPU & GPU try to write at the
+		// same time. It's probably fine (since CPU always advances the pointer before writing) but let's
+		// stick to the known/intended use cases and scream if we deviate from it.
+		buffer.usage.clear_flag(RDD::BUFFER_USAGE_TRANSFER_TO_BIT);
+	}
+	buffer.driver_id = driver->buffer_create(buffer.size, buffer.usage, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
 	ERR_FAIL_COND_V(!buffer.driver_id, RID());
 
 	// Uniform buffers are assumed to be immutable unless they don't have initial data.
@@ -3460,8 +3508,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 
 		const Uniform &uniform = uniforms[uniform_idx];
 
-		ERR_FAIL_COND_V_MSG(uniform.uniform_type != set_uniform.type, RID(),
-				"Mismatch uniform type for binding (" + itos(set_uniform.binding) + "), set (" + itos(p_shader_set) + "). Expected '" + SHADER_UNIFORM_NAMES[set_uniform.type] + "', supplied: '" + SHADER_UNIFORM_NAMES[uniform.uniform_type] + "'.");
+		ERR_FAIL_COND_V_MSG(uniform.uniform_type != set_uniform.type, RID(), "Shader '" + shader->name + "' Mismatch uniform type for binding (" + itos(set_uniform.binding) + "), set (" + itos(p_shader_set) + "). Expected '" + SHADER_UNIFORM_NAMES[set_uniform.type] + "', supplied: '" + SHADER_UNIFORM_NAMES[uniform.uniform_type] + "'.");
 
 		RDD::BoundUniform &driver_uniform = driver_uniforms[i];
 		driver_uniform.type = uniform.uniform_type;
@@ -3692,7 +3739,8 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 			case UNIFORM_TYPE_IMAGE_BUFFER: {
 				// Todo.
 			} break;
-			case UNIFORM_TYPE_UNIFORM_BUFFER: {
+			case UNIFORM_TYPE_UNIFORM_BUFFER:
+			case UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC: {
 				ERR_FAIL_COND_V_MSG(uniform.get_id_count() != 1, RID(),
 						"Uniform buffer supplied (binding: " + itos(uniform.binding) + ") must provide one ID (" + itos(uniform.get_id_count()) + " provided).");
 
@@ -3713,7 +3761,8 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 				driver_uniform.ids.push_back(buffer->driver_id);
 				_check_transfer_worker_buffer(buffer);
 			} break;
-			case UNIFORM_TYPE_STORAGE_BUFFER: {
+			case UNIFORM_TYPE_STORAGE_BUFFER:
+			case UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC: {
 				ERR_FAIL_COND_V_MSG(uniform.get_id_count() != 1, RID(),
 						"Storage buffer supplied (binding: " + itos(uniform.binding) + ") must provide one ID (" + itos(uniform.get_id_count()) + " provided).");
 
@@ -5559,7 +5608,7 @@ RenderingDevice::TransferWorker *RenderingDevice::_acquire_transfer_worker(uint3
 
 			uint32_t new_staging_buffer_size = next_power_of_2(expected_buffer_size);
 			transfer_worker->staging_buffer_size_allocated = new_staging_buffer_size;
-			transfer_worker->staging_buffer = driver->buffer_create(new_staging_buffer_size, RDD::BUFFER_USAGE_TRANSFER_FROM_BIT, RDD::MEMORY_ALLOCATION_TYPE_CPU);
+			transfer_worker->staging_buffer = driver->buffer_create(new_staging_buffer_size, RDD::BUFFER_USAGE_TRANSFER_FROM_BIT, RDD::MEMORY_ALLOCATION_TYPE_CPU, frames_drawn);
 		}
 	}
 
@@ -6272,6 +6321,10 @@ void RenderingDevice::_begin_frame(bool p_presented) {
 		driver->linear_uniform_set_pools_reset(frame);
 	}
 
+	for (PushConstantsEmuBase *push_constants_emu : registered_push_constant_emus) {
+		push_constants_emu->_reset();
+	}
+
 	// Begin recording on the frame's command buffers.
 	driver->begin_segment(frame, frames_drawn++);
 	driver->command_buffer_begin(frames[frame].command_buffer);
@@ -6507,6 +6560,16 @@ void RenderingDevice::_flush_and_stall_for_all_frames() {
 	_end_frame();
 	_execute_frame(false);
 	_begin_frame();
+}
+
+void RenderingDevice::_register_push_constant_emu(PushConstantsEmuBase *p_push_contstants_emu) {
+	ERR_RENDER_THREAD_GUARD();
+	registered_push_constant_emus.insert(p_push_contstants_emu);
+}
+
+void RenderingDevice::_unregister_push_constant_emu(PushConstantsEmuBase *p_push_contstants_emu) {
+	ERR_RENDER_THREAD_GUARD();
+	registered_push_constant_emus.remove(registered_push_constant_emus.find(p_push_contstants_emu));
 }
 
 Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServer::WindowID p_main_window) {
@@ -7683,6 +7746,8 @@ void RenderingDevice::_bind_methods() {
 
 	BIND_BITFIELD_FLAG(BUFFER_CREATION_DEVICE_ADDRESS_BIT);
 	BIND_BITFIELD_FLAG(BUFFER_CREATION_AS_STORAGE_BIT);
+	// Not exposed on purpose. This flag is to dangerous to be exposed to regular GD users.
+	// BIND_BITFIELD_FLAG(BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT);
 
 	BIND_ENUM_CONSTANT(UNIFORM_TYPE_SAMPLER); //for sampling only (sampler GLSL type)
 	BIND_ENUM_CONSTANT(UNIFORM_TYPE_SAMPLER_WITH_TEXTURE); // for sampling only); but includes a texture); (samplerXX GLSL type)); first a sampler then a texture
@@ -7694,6 +7759,8 @@ void RenderingDevice::_bind_methods() {
 	BIND_ENUM_CONSTANT(UNIFORM_TYPE_UNIFORM_BUFFER); //regular uniform buffer (or UBO).
 	BIND_ENUM_CONSTANT(UNIFORM_TYPE_STORAGE_BUFFER); //storage buffer ("buffer" qualifier) like UBO); but supports storage); for compute mostly
 	BIND_ENUM_CONSTANT(UNIFORM_TYPE_INPUT_ATTACHMENT); //used for sub-pass read/write); for mobile mostly
+	BIND_ENUM_CONSTANT(UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC); // Exposed in case a BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT buffer created by C++ makes it into GD users.
+	BIND_ENUM_CONSTANT(UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC); // Exposed in case a BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT buffer created by C++ makes it into GD users.
 	BIND_ENUM_CONSTANT(UNIFORM_TYPE_MAX);
 
 	BIND_ENUM_CONSTANT(RENDER_PRIMITIVE_POINTS);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -41,6 +41,7 @@
 #include "servers/rendering/rendering_device_driver.h"
 #include "servers/rendering/rendering_device_graph.h"
 
+class PushConstantsEmuBase;
 class RDTextureFormat;
 class RDTextureView;
 class RDAttachmentFormat;
@@ -201,6 +202,7 @@ private:
 	// swapchain semaphore to be signaled (which causes bubbles).
 	bool split_swapchain_into_its_own_cmd_buffer = true;
 	uint32_t gpu_copy_count = 0;
+	uint32_t direct_copy_count = 0;
 	uint32_t copy_bytes_count = 0;
 	uint32_t prev_gpu_copy_count = 0;
 	uint32_t prev_copy_bytes_count = 0;
@@ -218,11 +220,55 @@ private:
 
 public:
 	Error buffer_copy(RID p_src_buffer, RID p_dst_buffer, uint32_t p_src_offset, uint32_t p_dst_offset, uint32_t p_size);
-	Error buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p_size, const void *p_data);
+	/**
+	 * @brief Updates the given GPU buffer at offset and size with the given CPU data.
+	 * @remarks
+	 *	Buffer update is queued into the render graph. The render graph will reorder this operation so
+	 *	that it happens together with other buffer_update() in bulk and before rendering operations
+	 *	(or compute dispatches) that need it.
+	 *
+	 *	This means that the following will not work as intended:
+	 *	@code
+	 *		buffer_update(buffer_a, ..., data_source_x, ...);
+	 *		draw_list_draw(buffer_a);							// render data_render_x.
+	 *		buffer_update(buffer_a, ..., data_source_y, ...);
+	 *		draw_list_draw(buffer_a);							// render data_source_y.
+	 *	@endcode
+	 *
+	 *	Because it will be *reordered* to become the following:
+	 *	@code
+	 *		buffer_update(buffer_a, ..., data_source_x, ...);
+	 *		buffer_update(buffer_a, ..., data_source_y, ...);
+	 *		draw_list_draw(buffer_a); // render data_source_y. <-- Oops! should be data_source_x
+	 *		draw_list_draw(buffer_a); // render data_source_y.
+	 *	@endcode
+	 *
+	 *	When p_skip_check = true, we will perform checks to prevent this situation from happening
+	 *	(buffer_update must not be called while creating a draw or compute list).
+	 *	Do NOT set it to false for user-facing public API because users had trouble understanding
+	 *  this problem when manually creating draw lists.
+	 *
+	 *  Godot internally can set p_skip_check = true when it believes it will only update
+	 *  the buffer once and it needs to be done while a draw/compute list is being created.
+	 *
+	 *  Important: The Vulkan & Metal APIs do not allow issuing copies while inside a RenderPass.
+	 *  We can do it because Godot's render graph will reorder them.
+	 *
+	 * @param p_buffer		GPU buffer to update.
+	 * @param p_offset		Offset in bytes (relative to p_buffer).
+	 * @param p_size		Size in bytes of the data.
+	 * @param p_data		CPU data to transfer to GPU.
+	 *						Pointer can be deleted after buffer_update returns.
+	 * @param p_skip_check	Must always be false for user-facing public API. See remarks.
+	 * @return				Status result of the operation.
+	 */
+	Error buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p_size, const void *p_data, const bool p_skip_check = false);
 	Error buffer_clear(RID p_buffer, uint32_t p_offset, uint32_t p_size);
 	Vector<uint8_t> buffer_get_data(RID p_buffer, uint32_t p_offset = 0, uint32_t p_size = 0); // This causes stall, only use to retrieve large buffers for saving.
 	Error buffer_get_data_async(RID p_buffer, const Callable &p_callback, uint32_t p_offset = 0, uint32_t p_size = 0);
 	uint64_t buffer_get_device_address(RID p_buffer);
+	uint8_t *buffer_persistent_map_advance(RID p_buffer);
+	void buffer_flush(RID p_buffer);
 
 private:
 	/******************/
@@ -757,6 +803,7 @@ public:
 	enum BufferCreationBits {
 		BUFFER_CREATION_DEVICE_ADDRESS_BIT = (1 << 0),
 		BUFFER_CREATION_AS_STORAGE_BIT = (1 << 1),
+		BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT = (1 << 2),
 	};
 
 	enum StorageBufferUsage {
@@ -1015,7 +1062,7 @@ public:
 	};
 
 	typedef Uniform PipelineImmutableSampler;
-	RID shader_create_from_bytecode_with_samplers(const Vector<uint8_t> &p_shader_binary, RID p_placeholder = RID(), const Vector<PipelineImmutableSampler> &p_immutable_samplers = Vector<PipelineImmutableSampler>());
+	RID shader_create_from_bytecode_with_samplers(const Vector<uint8_t> &p_shader_binary, RID p_placeholder = RID(), const Vector<PipelineImmutableSampler> &p_immutable_samplers = Vector<PipelineImmutableSampler>(), const Vector<uint64_t> &p_dynamic_buffers = LocalVector<uint64_t>());
 
 private:
 	static const uint32_t MAX_UNIFORM_SETS = 16;
@@ -1534,6 +1581,8 @@ private:
 	uint64_t texture_memory = 0;
 	uint64_t buffer_memory = 0;
 
+	HashSet<PushConstantsEmuBase *> registered_push_constant_emus;
+
 protected:
 	void execute_chained_cmds(bool p_present_swap_chain,
 			RenderingDeviceDriver::FenceID p_draw_fence,
@@ -1547,6 +1596,9 @@ public:
 	void _stall_for_frame(uint32_t p_frame);
 	void _stall_for_previous_frames();
 	void _flush_and_stall_for_all_frames();
+
+	void _register_push_constant_emu(PushConstantsEmuBase *p_push_contstants_emu);
+	void _unregister_push_constant_emu(PushConstantsEmuBase *p_push_contstants_emu);
 
 	template <typename T>
 	void _free_rids(T &p_owner, const char *p_type);
@@ -1608,6 +1660,8 @@ public:
 	String get_device_api_name() const;
 	String get_device_api_version() const;
 	String get_device_pipeline_cache_uuid() const;
+
+	uint64_t get_frames_drawn() const { return frames_drawn; }
 
 	bool is_composite_alpha_supported() const;
 

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1062,7 +1062,7 @@ public:
 	};
 
 	typedef Uniform PipelineImmutableSampler;
-	RID shader_create_from_bytecode_with_samplers(const Vector<uint8_t> &p_shader_binary, RID p_placeholder = RID(), const Vector<PipelineImmutableSampler> &p_immutable_samplers = Vector<PipelineImmutableSampler>(), const Vector<uint64_t> &p_dynamic_buffers = LocalVector<uint64_t>());
+	RID shader_create_from_bytecode_with_samplers(const Vector<uint8_t> &p_shader_binary, RID p_placeholder = RID(), const Vector<PipelineImmutableSampler> &p_immutable_samplers = Vector<PipelineImmutableSampler>(), const Vector<uint64_t> &p_dynamic_buffers = Vector<uint64_t>());
 
 private:
 	static const uint32_t MAX_UNIFORM_SETS = 16;

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -570,8 +570,21 @@ public:
 		UNIFORM_TYPE_UNIFORM_BUFFER, // Regular uniform buffer (or UBO).
 		UNIFORM_TYPE_STORAGE_BUFFER, // Storage buffer ("buffer" qualifier) like UBO, but supports storage, for compute mostly.
 		UNIFORM_TYPE_INPUT_ATTACHMENT, // Used for sub-pass read/write, for mobile mostly.
+		UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC, // Same as UNIFORM but created with BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT.
+		UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC, // Same as STORAGE but created with BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT.
 		UNIFORM_TYPE_MAX
 	};
+
+	static UniformType uniform_type_to_dynamic(UniformType ut) {
+		switch (ut) {
+			case UNIFORM_TYPE_UNIFORM_BUFFER:
+				return UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC;
+			case UNIFORM_TYPE_STORAGE_BUFFER:
+				return UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC;
+			default:
+				return ut;
+		}
+	}
 
 	/******************/
 	/**** PIPELINE ****/


### PR DESCRIPTION
> [!IMPORTANT] 
>
> Depends on 
>
> - #103779

# Summary

This PR updates the 2D canvas renderer to utilise dynamic buffers for instance data, per the changes in 7861cdde. 

I modified the Canvas 2D renderer to use dynamic buffers for the `InstanceData` (similar to what @darksylinc did for forward / mobile renderers). This change removes two copies, so the instance data is written once (on UMA devices):

- one to upload the `InstanceData` to the GPU, and 
- a second to BLIT the instance data from the staging to the private GPU storage buffers. 

I modified the 1x1 sprite benchmark in @Calinou's [comment](https://github.com/godotengine/godot/pull/92797#pullrequestreview-2100153431), to draw 20,000 textured rectangles, which still batches, but reduces the CPU bottleneck of rendering 20,000 individual canvas items, to demonstrate the advantages of this PR. TileMaps is an example that will benefit from these changes. 

<details>
<summary>Modified code</summary>

```gdscript
extends Node2D

const ITERATIONS = 20_000

@onready var spr: Sprite2D = $Sprite2D as Sprite2D

var draw_instances := false

func _ready() -> void:
	# Use fixed seed for reproducibility.
	seed(0x60d07)

	if draw_instances:
		for i in ITERATIONS:
			var sprite: Sprite2D
			sprite = spr.duplicate() as Sprite2D
			sprite.position.x = randf_range(0, 1152)
			sprite.position.y = randf_range(0, 648)
			add_child(sprite)

func _draw() -> void:
	if !draw_instances:
		var tex: Texture2D = spr.texture
		var pos: Vector2 = Vector2.ZERO
		for i in ITERATIONS:
			pos.x = randf_range(0, 1152)
			pos.y = randf_range(0, 648)
			draw_texture(tex, pos)
```
</details>

About a 10% improvement. The average FPS went from **3161 FPS** to **3487 FPS**