### PR TITLE
Core: Include `intrin.h` for MSVC

### DIFF
--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -55,6 +55,10 @@
 #include "core/templates/rid.h"
 #include "core/typedefs.h"
 
+#ifdef _MSC_VER
+#include <intrin.h> // Needed for `__umulh` below.
+#endif
+
 /**
  * Hashing functions
  */


### PR DESCRIPTION
Fixes [this issue](https://chat.godotengine.org/channel/devel?msg=8CmpMfrTsExjTrSm5) brought up in RocketChat