### PR TITLE
Compress textures with storage compression on import

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3149,6 +3149,10 @@
 			If [code]true[/code], uses nearest-neighbor mipmap filtering when using mipmaps (also called "bilinear filtering"), which will result in visible seams appearing between mipmap stages. This may increase performance in mobile as less memory bandwidth is used. If [code]false[/code], linear mipmap filtering (also called "trilinear filtering") is used.
 			[b]Note:[/b] This property is only read when the project starts. There is currently no way to change this setting at run-time.
 		</member>
+		<member name="rendering/textures/import/store_compressed" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], makes use of lossless [i]storage[/i] compression to further compress textures on import. This can save disk space and reduce the exported PCK file size at the cost of slightly longer import times.
+			[b]Note:[/b] Only textures with the [b]VRAM Compressed[/b], [b]VRAM Uncompressed[/b] and [b]Basis Universal[/b] are affected by this setting. [b]Lossless[/b] and [b]Lossy[/b] don't make use of storage compression, as the formats employed are already effectively compressed for small storage sizes.
+		</member>
 		<member name="rendering/textures/light_projectors/filter" type="int" setter="" getter="" default="3">
 			The filtering quality to use for [OmniLight3D] and [SpotLight3D] projectors. When using one of the anisotropic filtering modes, the anisotropic filtering level is controlled by [member rendering/textures/default_filters/anisotropic_filtering_level].
 		</member>

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -277,12 +277,14 @@ void ResourceImporterLayeredTexture::_save_tex(Vector<Ref<Image>> p_images, cons
 		p_compress_mode = COMPRESS_VRAM_UNCOMPRESSED; // These can't go as lossy.
 	}
 
+	const bool store_compressed = GLOBAL_GET("rendering/textures/import/store_compressed");
+
 	for (int i = 0; i < p_images.size(); i++) {
-		ResourceImporterTexture::save_to_ctex_format(f, p_images[i], ResourceImporterTexture::CompressMode(p_compress_mode), used_channels, p_vram_compression, p_lossy);
+		ResourceImporterTexture::save_to_ctex_format(f, p_images[i], ResourceImporterTexture::CompressMode(p_compress_mode), used_channels, p_vram_compression, p_lossy, store_compressed);
 	}
 
 	for (int i = 0; i < mipmap_images.size(); i++) {
-		ResourceImporterTexture::save_to_ctex_format(f, mipmap_images[i], ResourceImporterTexture::CompressMode(p_compress_mode), used_channels, p_vram_compression, p_lossy);
+		ResourceImporterTexture::save_to_ctex_format(f, mipmap_images[i], ResourceImporterTexture::CompressMode(p_compress_mode), used_channels, p_vram_compression, p_lossy, store_compressed);
 	}
 }
 

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -263,7 +263,7 @@ void ResourceImporterTexture::get_import_options(const String &p_path, List<Impo
 	}
 }
 
-void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<Image> &p_image, CompressMode p_compress_mode, Image::UsedChannels p_channels, Image::CompressMode p_compress_format, float p_lossy_quality) {
+void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<Image> &p_image, CompressMode p_compress_mode, Image::UsedChannels p_channels, Image::CompressMode p_compress_format, float p_lossy_quality, bool p_store_compressed) {
 	switch (p_compress_mode) {
 		case COMPRESS_LOSSLESS: {
 			bool lossless_force_png = GLOBAL_GET("rendering/textures/lossless_compression/force_png") || !Image::_webp_mem_loader_func; // WebP module disabled or png is forced.
@@ -315,7 +315,17 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 			f->store_16(image->get_height());
 			f->store_32(image->get_mipmap_count());
 			f->store_32(image->get_format());
-			f->store_buffer(image->get_data());
+
+			if (p_store_compressed) {
+				Vector<uint8_t> compressed;
+				compressed.resize(Compression::get_max_compressed_buffer_size(image->get_data().size()));
+				const int compressed_size = Compression::compress(compressed.ptrw(), image->ptr(), image->get_data().size());
+
+				f->store_32(compressed_size);
+				f->store_buffer(compressed.ptr(), compressed_size);
+			} else {
+				f->store_buffer(image->get_data());
+			}
 
 		} break;
 		case COMPRESS_VRAM_UNCOMPRESSED: {
@@ -324,7 +334,17 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 			f->store_16(p_image->get_height());
 			f->store_32(p_image->get_mipmap_count());
 			f->store_32(p_image->get_format());
-			f->store_buffer(p_image->get_data());
+
+			if (p_store_compressed) {
+				Vector<uint8_t> compressed;
+				compressed.resize(Compression::get_max_compressed_buffer_size(p_image->get_data().size()));
+				const int compressed_size = Compression::compress(compressed.ptrw(), p_image->ptr(), p_image->get_data().size());
+
+				f->store_32(compressed_size);
+				f->store_buffer(compressed.ptr(), compressed_size);
+			} else {
+				f->store_buffer(p_image->get_data());
+			}
 
 		} break;
 		case COMPRESS_BASIS_UNIVERSAL: {
@@ -336,14 +356,24 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 
 			Vector<uint8_t> data = Image::basis_universal_packer(p_image, p_channels);
 			const uint64_t data_size = data.size();
-
 			f->store_32(data_size);
-			f->store_buffer(data.ptr(), data_size);
+
+			if (p_store_compressed) {
+				Vector<uint8_t> compressed;
+				compressed.resize(Compression::get_max_compressed_buffer_size(data_size));
+				const int compressed_size = Compression::compress(compressed.ptrw(), data.ptr(), data_size);
+
+				f->store_32(compressed_size);
+				f->store_buffer(compressed.ptr(), compressed_size);
+			} else {
+				f->store_buffer(data.ptr(), data_size);
+			}
+
 		} break;
 	}
 }
 
-void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_roughness, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel) {
+void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_roughness, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel, bool p_store_compressed) {
 	Ref<FileAccess> f = FileAccess::open(p_to_path, FileAccess::WRITE);
 	ERR_FAIL_COND(f.is_null());
 
@@ -375,6 +405,9 @@ void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String
 	}
 	if (p_detect_normal) {
 		flags |= CompressedTexture2D::FORMAT_BIT_DETECT_NORMAL;
+	}
+	if (p_store_compressed) {
+		flags |= CompressedTexture2D::FORMAT_BIT_STORE_COMPRESSED;
 	}
 
 	f->store_32(flags);
@@ -423,7 +456,7 @@ void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String
 		used_channels = image->detect_used_channels(comp_source);
 	}
 
-	save_to_ctex_format(f, image, p_compress_mode, used_channels, p_vram_compression, p_lossy_quality);
+	save_to_ctex_format(f, image, p_compress_mode, used_channels, p_vram_compression, p_lossy_quality, p_store_compressed);
 }
 
 void ResourceImporterTexture::_save_editor_meta(const Dictionary &p_metadata, const String &p_to_path) {
@@ -647,6 +680,13 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 	bool force_normal = normal == 1;
 	bool srgb_friendly_pack = pack_channels == 0;
 
+	bool store_compressed = false;
+	if (compress_mode != COMPRESS_LOSSLESS && compress_mode != COMPRESS_LOSSY) {
+		// Never store lossless or lossy-compressed textures with compression, as this would perform double compression
+		// (which is slower for no size benefit).
+		store_compressed = GLOBAL_GET("rendering/textures/import/store_compressed");
+	}
+
 	Array formats_imported;
 
 	if (compress_mode == COMPRESS_VRAM_COMPRESSED) {
@@ -690,8 +730,11 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 		}
 
 		if (force_uncompressed) {
+			// The compressed storage project setting is still obeyed, even for VRAM-uncompressed format.
+			// This means the image will be compressed using Zstandard instead of PNG/WebP.
+			// This is faster to (de)compress at the cost of a worse compression ratio.
 			_save_ctex(image, p_save_path + ".ctex", COMPRESS_VRAM_UNCOMPRESSED, lossy, Image::COMPRESS_S3TC /* This is ignored. */,
-					mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
+					mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel, store_compressed);
 		} else {
 			if (can_s3tc_bptc) {
 				Image::CompressMode image_compress_mode;
@@ -705,7 +748,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 				}
 
 				_save_ctex(image, p_save_path + "." + image_compress_format + ".ctex", compress_mode, lossy, image_compress_mode, mipmaps, stream, detect_3d,
-						detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
+						detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel, store_compressed);
 				r_platform_variants->push_back(image_compress_format);
 			}
 
@@ -721,19 +764,19 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 				}
 
 				_save_ctex(image, p_save_path + "." + image_compress_format + ".ctex", compress_mode, lossy, image_compress_mode, mipmaps, stream, detect_3d,
-						detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
+						detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel, store_compressed);
 				r_platform_variants->push_back(image_compress_format);
 			}
 		}
 	} else {
 		// Import normally.
 		_save_ctex(image, p_save_path + ".ctex", compress_mode, lossy, Image::COMPRESS_S3TC /* This is ignored. */,
-				mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
+				mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel, store_compressed);
 	}
 
 	if (editor_image.is_valid()) {
 		_save_ctex(editor_image, p_save_path + ".editor.ctex", compress_mode, lossy, Image::COMPRESS_S3TC /* This is ignored. */,
-				mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel);
+				mipmaps, stream, detect_3d, detect_roughness, detect_normal, force_normal, srgb_friendly_pack, false, mipmap_limit, normal_image, roughness_channel, store_compressed);
 
 		// Generate and save editor-specific metadata, which we cannot save to the .import file.
 		Dictionary editor_meta;

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -72,7 +72,7 @@ protected:
 	static ResourceImporterTexture *singleton;
 	static const char *compression_formats[];
 
-	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
+	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel, bool p_store_compressed);
 	void _save_editor_meta(const Dictionary &p_metadata, const String &p_to_path);
 	Dictionary _load_editor_meta(const String &p_to_path) const;
 
@@ -81,7 +81,7 @@ protected:
 	static inline void _print_callback_message(const String &p_message);
 
 public:
-	static void save_to_ctex_format(Ref<FileAccess> f, const Ref<Image> &p_image, CompressMode p_compress_mode, Image::UsedChannels p_channels, Image::CompressMode p_compress_format, float p_lossy_quality);
+	static void save_to_ctex_format(Ref<FileAccess> f, const Ref<Image> &p_image, CompressMode p_compress_mode, Image::UsedChannels p_channels, Image::CompressMode p_compress_format, float p_lossy_quality, bool p_store_compressed);
 
 	static ResourceImporterTexture *get_singleton() { return singleton; }
 	virtual String get_importer_name() const override;

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -57,6 +57,7 @@ public:
 		//FORMAT_BIT_DETECT_SRGB = 1 << 25,
 		FORMAT_BIT_DETECT_NORMAL = 1 << 26,
 		FORMAT_BIT_DETECT_ROUGNESS = 1 << 27,
+		FORMAT_BIT_STORE_COMPRESSED = 1 << 28,
 	};
 
 private:
@@ -79,7 +80,7 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:
-	static Ref<Image> load_image_from_file(Ref<FileAccess> p_file, int p_size_limit);
+	static Ref<Image> load_image_from_file(Ref<FileAccess> p_file, int p_size_limit, bool p_compressed);
 
 	typedef void (*TextureFormatRequestCallback)(const Ref<CompressedTexture2D> &);
 	typedef void (*TextureFormatRoughnessRequestCallback)(const Ref<CompressedTexture2D> &, const String &p_normal_path, RS::TextureDetectRoughnessChannel p_roughness_channel);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3594,6 +3594,8 @@ void RenderingServer::init() {
 
 	GLOBAL_DEF("rendering/textures/lossless_compression/force_png", false);
 
+	GLOBAL_DEF(PropertyInfo(Variant::BOOL, "rendering/textures/import/store_compressed"), true);
+
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/textures/webp_compression/compression_method", PROPERTY_HINT_RANGE, "0,6,1"), 2);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/textures/webp_compression/lossless_compression_factor", PROPERTY_HINT_RANGE, "0,100,1"), 25);
 


### PR DESCRIPTION
This performs a compression step for textures that have the VRAM Compressed, VRAM Uncompressed and Basis Universal compression modes.

This usually reduces file size for each compressed texture by a factor of 2, without affecting the memory taken by the texture after it's loaded. This can make for significantly smaller PCK sizes and therefore faster downloads.

Additionally, for image pixel formats that cannot be VRAM-compressed (such as HDR + alpha), this allows having some form of storage compression to reduce file size by a potentially much larger factor.

This can be disabled in the Project Settings if having the fastest possible import/load times is desired, at the cost of larger PCK sizes.

- This closes https://github.com/godotengine/godot-proposals/issues/11852.

**Testing project:** [test_vram_compress_lossless.zip](https://github.com/user-attachments/files/19438036/test_vram_compress_lossless.zip)

## Preview

Using the testing project linked above.

### `.godot/imported` folder size

Before | After
-|-
36,355,412 bytes | 29,468,402 bytes

### Exported PCK size

Before | After
-|-
36,365,088 bytes | 29,478,096 bytes

### Individual file sizes in `.godot/imported`

#### Before

![Image](https://github.com/user-attachments/assets/0762cd30-6b47-471d-8aed-43b542f1a871)

#### After

![Image](https://github.com/user-attachments/assets/ccd1f782-05db-4f7c-8323-ff8508602d7f)