### PR TITLE
Fix regressions regarding multiple remote object selection

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -271,7 +271,7 @@ EditorDebuggerRemoteObjects *EditorDebuggerInspector::set_objects(const Array &p
 	remote_objects->prop_list.clear();
 	int new_props_added = 0;
 	HashSet<String> changed;
-	for (const KeyValue<String, UsageData> &KV : usage) {
+	for (KeyValue<String, UsageData> &KV : usage) {
 		const PropertyInfo &pinfo = KV.value.prop.first;
 		Variant var = KV.value.values[remote_objects->remote_object_ids[0]];
 
@@ -287,6 +287,7 @@ EditorDebuggerRemoteObjects *EditorDebuggerInspector::set_objects(const Array &p
 					}
 				}
 				var = ResourceLoader::load(path);
+				KV.value.values[remote_objects->remote_object_ids[0]] = var;
 
 				if (pinfo.hint_string == "Script") {
 					if (remote_objects->get_script() != var) {

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -116,6 +116,7 @@ ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
 	node->connect("remote_tree_updated", callable_mp(this, &EditorDebuggerNode::_remote_tree_updated).bind(id));
 	node->connect("remote_objects_updated", callable_mp(this, &EditorDebuggerNode::_remote_objects_updated).bind(id));
 	node->connect("remote_object_property_updated", callable_mp(this, &EditorDebuggerNode::_remote_object_property_updated).bind(id));
+	node->connect("remote_objects_requested", callable_mp(this, &EditorDebuggerNode::_remote_objects_requested).bind(id));
 	node->connect("set_breakpoint", callable_mp(this, &EditorDebuggerNode::_breakpoint_set_in_tree).bind(id));
 	node->connect("clear_breakpoints", callable_mp(this, &EditorDebuggerNode::_breakpoints_cleared_in_tree).bind(id));
 	node->connect("errors_cleared", callable_mp(this, &EditorDebuggerNode::_update_errors));
@@ -679,8 +680,6 @@ void EditorDebuggerNode::request_remote_tree() {
 }
 
 void EditorDebuggerNode::set_remote_selection(const TypedArray<int64_t> &p_ids) {
-	remote_scene_tree->select_nodes(p_ids);
-
 	stop_waiting_inspection();
 	get_current_debugger()->request_remote_objects(p_ids);
 }

--- a/editor/debugger/editor_expression_evaluator.cpp
+++ b/editor/debugger/editor_expression_evaluator.cpp
@@ -74,7 +74,9 @@ void EditorExpressionEvaluator::_clear() {
 }
 
 void EditorExpressionEvaluator::_remote_object_selected(ObjectID p_id) {
-	editor_debugger->emit_signal(SNAME("remote_object_requested"), p_id);
+	Array arr;
+	arr.append(p_id);
+	editor_debugger->emit_signal(SNAME("remote_objects_requested"), arr);
 }
 
 void EditorExpressionEvaluator::_on_expression_input_changed(const String &p_expression) {

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -217,8 +217,8 @@ private:
 	void _msg_servers_profile_frame(uint64_t p_thread_id, const Array &p_data);
 	void _msg_servers_profile_total(uint64_t p_thread_id, const Array &p_data);
 	void _msg_request_quit(uint64_t p_thread_id, const Array &p_data);
-	void _msg_remote_nodes_clicked(uint64_t p_thread_id, const Array &p_data);
-	void _msg_remote_nothing_clicked(uint64_t p_thread_id, const Array &p_data);
+	void _msg_remote_objects_selected(uint64_t p_thread_id, const Array &p_data);
+	void _msg_remote_nothing_selected(uint64_t p_thread_id, const Array &p_data);
 	void _msg_remote_selection_invalidated(uint64_t p_thread_id, const Array &p_data);
 	void _msg_show_selection_limit_warning(uint64_t p_thread_id, const Array &p_data);
 	void _msg_performance_profile_names(uint64_t p_thread_id, const Array &p_data);

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -407,9 +407,9 @@ void SceneDebugger::_send_object_ids(const Vector<ObjectID> &p_ids, bool p_updat
 		arr.append(invalid_selection);
 		EngineDebugger::get_singleton()->send_message("remote_selection_invalidated", arr);
 
-		EngineDebugger::get_singleton()->send_message(objs.is_empty() ? "remote_nothing_clicked" : "remote_nodes_clicked", objs);
+		EngineDebugger::get_singleton()->send_message(objs.is_empty() ? "remote_nothing_selected" : "remote_objects_selected", objs);
 	} else {
-		EngineDebugger::get_singleton()->send_message("scene:inspect_objects", objs);
+		EngineDebugger::get_singleton()->send_message(p_update_selection ? "remote_objects_selected" : "scene:inspect_objects", objs);
 	}
 }
 
@@ -1652,7 +1652,7 @@ void RuntimeNodeSelect::_physics_frame() {
 #else
 				if (!selected_ci_nodes.is_empty() || !selected_3d_nodes.is_empty()) {
 #endif // _3D_DISABLED
-					EngineDebugger::get_singleton()->send_message("remote_nothing_clicked", Array());
+					EngineDebugger::get_singleton()->send_message("remote_nothing_selected", Array());
 					_clear_selection();
 				}
 
@@ -1714,7 +1714,7 @@ void RuntimeNodeSelect::_send_ids(const Vector<Node *> &p_picked_nodes, bool p_i
 			message.append(arr);
 		}
 
-		EngineDebugger::get_singleton()->send_message("remote_nodes_clicked", message);
+		EngineDebugger::get_singleton()->send_message("remote_objects_selected", message);
 		_set_selected_nodes(picked_nodes);
 
 		return;
@@ -1778,7 +1778,7 @@ void RuntimeNodeSelect::_send_ids(const Vector<Node *> &p_picked_nodes, bool p_i
 	}
 
 	if (ids.is_empty()) {
-		EngineDebugger::get_singleton()->send_message("remote_nothing_clicked", message);
+		EngineDebugger::get_singleton()->send_message("remote_nothing_selected", message);
 	} else {
 		for (const ObjectID &id : ids) {
 			SceneDebuggerObject obj(id);
@@ -1787,7 +1787,7 @@ void RuntimeNodeSelect::_send_ids(const Vector<Node *> &p_picked_nodes, bool p_i
 			message.append(arr);
 		}
 
-		EngineDebugger::get_singleton()->send_message("remote_nodes_clicked", message);
+		EngineDebugger::get_singleton()->send_message("remote_objects_selected", message);
 	}
 
 	_set_selected_nodes(nodes);


### PR DESCRIPTION
- Fix clicking a remote object variable not showing it in the inspector (closes #104445).
- Fix variable resources not showing up in the remote inspector (closes #104469).
- Fix remote inspector data not refreshing.