### PR TITLE
Add `resize()` function for Animation's track count

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -390,6 +390,15 @@
 				Removes a track by specifying the track index.
 			</description>
 		</method>
+		<method name="resize_tracks">
+			<return type="int" enum="Error" />
+			<param index="0" name="size" type="int" />
+			<description>
+				Sets the animation's number of tracks to [param size]. If [param size] is smaller than the animation's track size, the tracks at the end are removed. If [param size] is greater, new [constant TYPE_VALUE] tracks are added.
+				Returns [constant OK] on success, or one of the following [enum Error] constants if this method fails: [constant ERR_INVALID_PARAMETER] if the size is negative, or [constant ERR_OUT_OF_MEMORY] if allocations fail. Use [method get_track_count] to find the actual amount of tracks after resize.
+				[b]Note:[/b] Calling this method once and set the new tracks is faster than calling [method add_track] for every new track.
+			</description>
+		</method>
 		<method name="rotation_track_insert_key">
 			<return type="int" />
 			<param index="0" name="track_idx" type="int" />

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -941,65 +941,38 @@ int Animation::add_track(TrackType p_type, int p_at_pos) {
 }
 
 void Animation::remove_track(int p_track) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
-	Track *t = tracks[p_track];
-
-	switch (t->type) {
-		case TYPE_POSITION_3D: {
-			PositionTrack *tt = static_cast<PositionTrack *>(t);
-			ERR_FAIL_COND_MSG(tt->compressed_track >= 0, "Compressed tracks can't be manually removed. Call clear() to get rid of compression first.");
-			tt->positions.clear();
-
-		} break;
-		case TYPE_ROTATION_3D: {
-			RotationTrack *rt = static_cast<RotationTrack *>(t);
-			ERR_FAIL_COND_MSG(rt->compressed_track >= 0, "Compressed tracks can't be manually removed. Call clear() to get rid of compression first.");
-			rt->rotations.clear();
-
-		} break;
-		case TYPE_SCALE_3D: {
-			ScaleTrack *st = static_cast<ScaleTrack *>(t);
-			ERR_FAIL_COND_MSG(st->compressed_track >= 0, "Compressed tracks can't be manually removed. Call clear() to get rid of compression first.");
-			st->scales.clear();
-
-		} break;
-		case TYPE_BLEND_SHAPE: {
-			BlendShapeTrack *bst = static_cast<BlendShapeTrack *>(t);
-			ERR_FAIL_COND_MSG(bst->compressed_track >= 0, "Compressed tracks can't be manually removed. Call clear() to get rid of compression first.");
-			bst->blend_shapes.clear();
-
-		} break;
-		case TYPE_VALUE: {
-			ValueTrack *vt = static_cast<ValueTrack *>(t);
-			vt->values.clear();
-
-		} break;
-		case TYPE_METHOD: {
-			MethodTrack *mt = static_cast<MethodTrack *>(t);
-			mt->methods.clear();
-
-		} break;
-		case TYPE_BEZIER: {
-			BezierTrack *bz = static_cast<BezierTrack *>(t);
-			bz->values.clear();
-
-		} break;
-		case TYPE_AUDIO: {
-			AudioTrack *ad = static_cast<AudioTrack *>(t);
-			ad->values.clear();
-
-		} break;
-		case TYPE_ANIMATION: {
-			AnimationTrack *an = static_cast<AnimationTrack *>(t);
-			an->values.clear();
-
-		} break;
-	}
-
-	memdelete(t);
-	tracks.remove_at(p_track);
+	_remove_track(p_track);
 	emit_changed();
 	_check_capture_included();
+}
+
+Error Animation::resize_tracks(int p_size) {
+	ERR_FAIL_COND_V(p_size < 0, ERR_INVALID_PARAMETER);
+
+	int old_size = tracks.size();
+
+	bool changed_size = false;
+
+	for (int i = p_size; i < old_size; i++) {
+		_remove_track(i);
+		changed_size = true;
+	}
+
+	Error err = tracks.resize(p_size);
+
+	if (!err) {
+		for (int i = old_size; i < tracks.size(); i++) {
+			tracks.set(i, memnew(ValueTrack));
+			changed_size = true;
+		}
+	}
+
+	if (changed_size) {
+		emit_changed();
+		_check_capture_included();
+	}
+
+	return err;
 }
 
 bool Animation::is_capture_included() const {
@@ -1135,6 +1108,66 @@ int Animation::_marker_insert(double p_time, Vector<MarkerKey> &p_keys, const Ma
 	}
 
 	return -1;
+}
+
+void Animation::_remove_track(int p_track) {
+	ERR_FAIL_INDEX(p_track, tracks.size());
+	Track *t = tracks[p_track];
+
+	switch (t->type) {
+		case TYPE_POSITION_3D: {
+			PositionTrack *tt = static_cast<PositionTrack *>(t);
+			ERR_FAIL_COND_MSG(tt->compressed_track >= 0, "Compressed tracks can't be manually removed. Call clear() to get rid of compression first.");
+			tt->positions.clear();
+
+		} break;
+		case TYPE_ROTATION_3D: {
+			RotationTrack *rt = static_cast<RotationTrack *>(t);
+			ERR_FAIL_COND_MSG(rt->compressed_track >= 0, "Compressed tracks can't be manually removed. Call clear() to get rid of compression first.");
+			rt->rotations.clear();
+
+		} break;
+		case TYPE_SCALE_3D: {
+			ScaleTrack *st = static_cast<ScaleTrack *>(t);
+			ERR_FAIL_COND_MSG(st->compressed_track >= 0, "Compressed tracks can't be manually removed. Call clear() to get rid of compression first.");
+			st->scales.clear();
+
+		} break;
+		case TYPE_BLEND_SHAPE: {
+			BlendShapeTrack *bst = static_cast<BlendShapeTrack *>(t);
+			ERR_FAIL_COND_MSG(bst->compressed_track >= 0, "Compressed tracks can't be manually removed. Call clear() to get rid of compression first.");
+			bst->blend_shapes.clear();
+
+		} break;
+		case TYPE_VALUE: {
+			ValueTrack *vt = static_cast<ValueTrack *>(t);
+			vt->values.clear();
+
+		} break;
+		case TYPE_METHOD: {
+			MethodTrack *mt = static_cast<MethodTrack *>(t);
+			mt->methods.clear();
+
+		} break;
+		case TYPE_BEZIER: {
+			BezierTrack *bz = static_cast<BezierTrack *>(t);
+			bz->values.clear();
+
+		} break;
+		case TYPE_AUDIO: {
+			AudioTrack *ad = static_cast<AudioTrack *>(t);
+			ad->values.clear();
+
+		} break;
+		case TYPE_ANIMATION: {
+			AnimationTrack *an = static_cast<AnimationTrack *>(t);
+			an->values.clear();
+
+		} break;
+	}
+
+	memdelete(t);
+	tracks.remove_at(p_track);
 }
 
 ////
@@ -3941,6 +3974,7 @@ void Animation::copy_track(int p_track, Ref<Animation> p_to_animation) {
 void Animation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_track", "type", "at_position"), &Animation::add_track, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("remove_track", "track_idx"), &Animation::remove_track);
+	ClassDB::bind_method(D_METHOD("resize_tracks", "size"), &Animation::resize_tracks);
 	ClassDB::bind_method(D_METHOD("get_track_count"), &Animation::get_track_count);
 	ClassDB::bind_method(D_METHOD("track_get_type", "track_idx"), &Animation::track_get_type);
 	ClassDB::bind_method(D_METHOD("track_get_path", "track_idx"), &Animation::track_get_path);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -258,6 +258,8 @@ private:
 
 	int _marker_insert(double p_time, Vector<MarkerKey> &p_keys, const MarkerKey &p_value);
 
+	_FORCE_INLINE_ void _remove_track(int p_track);
+
 	template <typename K>
 
 	inline int _find(const Vector<K> &p_keys, double p_time, bool p_backward = false, bool p_limit = false) const;
@@ -408,6 +410,7 @@ protected:
 public:
 	int add_track(TrackType p_type, int p_at_pos = -1);
 	void remove_track(int p_track);
+	Error resize_tracks(int p_size);
 
 	_FORCE_INLINE_ const Vector<Track *> get_tracks() {
 		return tracks;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Add `Error Animation::resize_tracks(int p_size)` similar to array resize.

New tracks are of type `Animation::TrackType::TYPE_VALUE`.