### PR TITLE
Avoid doctools attempting to query the `CameraServer` to infer a default value for `camera_is_active`

### DIFF
--- a/scene/resources/camera_texture.cpp
+++ b/scene/resources/camera_texture.cpp
@@ -45,6 +45,7 @@ void CameraTexture::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "camera_feed_id"), "set_camera_feed_id", "get_camera_feed_id");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "which_feed"), "set_which_feed", "get_which_feed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "camera_is_active"), "set_camera_active", "get_camera_active");
+	ADD_PROPERTY_DEFAULT("camera_is_active", false);
 }
 
 void CameraTexture::_on_format_changed() {


### PR DESCRIPTION
Fixes #104577 
