### PR TITLE
Change `.build` extension for engine build profiles to `.gdbuild`

### DIFF
--- a/editor/editor_build_profile.cpp
+++ b/editor/editor_build_profile.cpp
@@ -866,7 +866,7 @@ EditorBuildProfileManager::EditorBuildProfileManager() {
 	import_profile = memnew(EditorFileDialog);
 	add_child(import_profile);
 	import_profile->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-	import_profile->add_filter("*.build", TTR("Engine Compilation Profile"));
+	import_profile->add_filter("*.gdbuild,*.build", TTR("Engine Compilation Profile"));
 	import_profile->connect("files_selected", callable_mp(this, &EditorBuildProfileManager::_import_profile));
 	import_profile->set_title(TTR("Load Profile"));
 	import_profile->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
@@ -874,7 +874,7 @@ EditorBuildProfileManager::EditorBuildProfileManager() {
 	export_profile = memnew(EditorFileDialog);
 	add_child(export_profile);
 	export_profile->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
-	export_profile->add_filter("*.build", TTR("Engine Compilation Profile"));
+	export_profile->add_filter("*.gdbuild,*.build", TTR("Engine Compilation Profile"));
 	export_profile->connect("file_selected", callable_mp(this, &EditorBuildProfileManager::_export_profile));
 	export_profile->set_title(TTR("Export Profile"));
 	export_profile->set_access(EditorFileDialog::ACCESS_FILESYSTEM);


### PR DESCRIPTION
`.build` was already used by the Meson buildsystem for its build file. Using a unique file extension for Godot avoids ambiguity and allows third-party tools to reliably detect its file formats.

The previous file extension is still accepted in the load/save dialog, so this change is backwards-compatible. The buildsystem doesn't care about the file extension, so no changes are required on that end.

- This closes https://github.com/godotengine/godot-proposals/issues/11816.

## Preview

![image](https://github.com/user-attachments/assets/3356b5ba-508a-4147-8e79-8d0079ba52f9)
