### PR TITLE
Renderer: Fix texture size override

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1416,8 +1416,6 @@ void TextureStorage::texture_set_size_override(RID p_texture, int p_width, int p
 	ERR_FAIL_NULL(texture);
 	ERR_FAIL_COND(texture->is_render_target);
 
-	ERR_FAIL_COND(p_width <= 0 || p_width > 16384);
-	ERR_FAIL_COND(p_height <= 0 || p_height > 16384);
 	//real texture size is in alloc width and height
 	texture->width = p_width;
 	texture->height = p_height;

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -691,10 +691,8 @@ TextureStorage::CanvasTextureInfo TextureStorage::canvas_texture_get_info(RID p_
 			t = get_texture(ct->diffuse);
 			if (!t) {
 				ctc.diffuse = texture_rd_get_default(DEFAULT_RD_TEXTURE_WHITE);
-				ct->size_cache = Size2i(1, 1);
 			} else {
 				ctc.diffuse = t->rd_texture_srgb.is_valid() && p_use_srgb && !p_texture_is_data ? t->rd_texture_srgb : t->rd_texture;
-				ct->size_cache = Size2i(t->width_2d, t->height_2d);
 				if (t->render_target) {
 					t->render_target->was_used = true;
 				}
@@ -726,6 +724,10 @@ TextureStorage::CanvasTextureInfo TextureStorage::canvas_texture_get_info(RID p_
 				}
 			}
 		}
+	}
+	{
+		t = get_texture(ct->diffuse);
+		ct->size_cache = ctc.diffuse == texture_rd_get_default(DEFAULT_RD_TEXTURE_WHITE) ? Size2i(1, 1) : Size2i(t->width_2d, t->height_2d);
 	}
 
 	CanvasTextureInfo res;


### PR DESCRIPTION
Fixes #104500

Always updates canvas texture size cache in renderer_rd.
Removes the range check for size override in gles3, zero or negative  size override works both in renderer_rd and gles3.