### PR TITLE
Load decompressable texture format if no supported one is found.

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2699,6 +2699,19 @@ Error Image::decompress() {
 	return OK;
 }
 
+bool Image::can_decompress(const String &p_format_tag) {
+	if (p_format_tag == "astc") {
+		return _image_decompress_astc != nullptr;
+	} else if (p_format_tag == "bptc") {
+		return _image_decompress_bptc != nullptr;
+	} else if (p_format_tag == "etc2") {
+		return _image_decompress_etc2 != nullptr;
+	} else if (p_format_tag == "s3tc") {
+		return _image_decompress_bc != nullptr;
+	}
+	return false;
+}
+
 Error Image::compress(CompressMode p_mode, CompressSource p_source, ASTCFormat p_astc_format) {
 	ERR_FAIL_INDEX_V_MSG(p_mode, COMPRESS_MAX, ERR_INVALID_PARAMETER, "Invalid compress mode.");
 	ERR_FAIL_INDEX_V_MSG(p_source, COMPRESS_SOURCE_MAX, ERR_INVALID_PARAMETER, "Invalid compress source.");

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -380,6 +380,8 @@ public:
 	bool is_compressed() const;
 	static bool is_format_compressed(Format p_format);
 
+	static bool can_decompress(const String &p_format_tag);
+
 	void fix_alpha_edges();
 	void premultiply_alpha();
 	void srgb_to_linear();

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -48,7 +48,7 @@ class ResourceFormatImporter : public ResourceFormatLoader {
 		ResourceUID::ID uid = ResourceUID::INVALID_ID;
 	};
 
-	Error _get_path_and_type(const String &p_path, PathAndType &r_path_and_type, bool *r_valid = nullptr) const;
+	Error _get_path_and_type(const String &p_path, PathAndType &r_path_and_type, bool p_load, bool *r_valid = nullptr) const;
 
 	static ResourceFormatImporter *singleton;
 


### PR DESCRIPTION
Partially fixes https://github.com/godotengine/godot/issues/102533 (other part is fixed by https://github.com/godotengine/godot/pull/104575)

When loading textures, check if there's a decompressable format and use it if no supported formats found.