### PR TITLE
Vulkan: Re-enable Mesa device select layer

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2535,7 +2535,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			"DISABLE_SAMPLE_LAYER", // GH-104154.
 			"DISABLE_GAMEPP_LAYER", // GH-104154.
 			"DISABLE_VK_LAYER_TENCENT_wegame_cross_overlay_1", // GH-104154.
-			"NODEVICE_SELECT", // GH-104154.
+			// "NODEVICE_SELECT", // Kept as it's useful - GH-104592.
 			"VK_LAYER_bandicam_helper_DEBUG_1", // GH-101480.
 			"DISABLE_VK_LAYER_bandicam_helper_1", // GH-101480.
 			"DISABLE_VK_LAYER_reshade_1", // GH-70849.


### PR DESCRIPTION
We got this from RenderDoc which had an issue with it 5 years ago, but it's not a given that Godot is also affected.

This layer is actually quite convenient to be able to change what default Vulkan capable GPU should be used for applications via environment variables: https://docs.mesa3d.org/envvars.html#vulkan-mesa-device-select-layer-environment-variables

In my case:
```
$ MESA_VK_DEVICE_SELECT=list vulkaninfo 
selectable devices:
  GPU 0: 1002:7480 "AMD Radeon RX 7600M XT (RADV NAVI33)" discrete GPU 0000:03:00.0
  GPU 1: 1002:1900 "AMD Radeon Graphics (RADV PHOENIX)" integrated GPU 0000:69:00.0
  GPU 2: 10005:0 "llvmpipe (LLVM 19.1.7, 256 bits)" CPU 0000:00:00.0
```

I want to default to the integrated GPU to reduce power consumption/fan usage when I don't need full high performance (I mostly have Godot running in the background when I tried to reproduce a bug and then forgot to close the instance).

So I can set
```
export MESA_VK_DEVICE_SELECT="1002:1900!"
```
in my `~/.bashrc`, and have Godot and other Vulkan applications automatically use the iGPU, unless requested explicitly with another override. I defined those aliases for that:
```
alias vkdgpu="MESA_VK_DEVICE_SELECT='1002:7480!' $@"
alias vkigpu="MESA_VK_DEVICE_SELECT='1002:1900!' $@"
alias vklvp="MESA_VK_DEVICE_SELECT='10005:0!' $@
```

---

The RenderDoc disable was due to this bug: https://github.com/baldurk/renderdoc/issues/2093

I'm not aware of such issues affecting us up until now, and we included this from RenderDoc in #104154 pretty recently (4.5-dev1 and 4.4.1). So it seems safe to revert this part, and just keep an eye on potential Linux + Mesa crash reports which we could trace back to such an issue (we can ask users to test with `NODEVICE_SELECT=1 godot --rendering-driver vulkan`).