### PR TITLE
Implement `DirAccess.is_equivalent` method.

### DIFF
--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -626,6 +626,10 @@ bool DirAccess::is_case_sensitive(const String &p_path) const {
 	return true;
 }
 
+bool DirAccess::is_equivalent(const String &p_path_a, const String &p_path_b) const {
+	return p_path_a == p_path_b;
+}
+
 void DirAccess::_bind_methods() {
 	ClassDB::bind_static_method("DirAccess", D_METHOD("open", "path"), &DirAccess::_open);
 	ClassDB::bind_static_method("DirAccess", D_METHOD("get_open_error"), &DirAccess::get_open_error);
@@ -671,6 +675,7 @@ void DirAccess::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_include_hidden"), &DirAccess::get_include_hidden);
 
 	ClassDB::bind_method(D_METHOD("is_case_sensitive", "path"), &DirAccess::is_case_sensitive);
+	ClassDB::bind_method(D_METHOD("is_equivalent", "path_a", "path_b"), &DirAccess::is_equivalent);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "include_navigational"), "set_include_navigational", "get_include_navigational");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "include_hidden"), "set_include_hidden", "get_include_hidden");

--- a/core/io/dir_access.h
+++ b/core/io/dir_access.h
@@ -168,6 +168,7 @@ public:
 
 	virtual bool is_case_sensitive(const String &p_path) const;
 	virtual bool is_bundle(const String &p_file) const { return false; }
+	virtual bool is_equivalent(const String &p_path_a, const String &p_path_b) const;
 
 public:
 	DirAccess() {}

--- a/doc/classes/DirAccess.xml
+++ b/doc/classes/DirAccess.xml
@@ -248,6 +248,14 @@
 				[b]Note:[/b] This method is implemented on macOS, Linux (for EXT4 and F2FS filesystems only) and Windows. On other platforms, it always returns [code]true[/code].
 			</description>
 		</method>
+		<method name="is_equivalent" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="path_a" type="String" />
+			<param index="1" name="path_b" type="String" />
+			<description>
+				Returns [code]true[/code] if paths [param path_a] and [param path_b] resolve to the same file system object. Returns [code]false[/code] otherwise, even if the files are bit-for-bit identical (e.g., identical copies of the file that are not symbolic links).
+			</description>
+		</method>
 		<method name="is_link">
 			<return type="bool" />
 			<param index="0" name="path" type="String" />

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -43,6 +43,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <sys/statvfs.h>
 
 #ifdef HAVE_MNTENT
@@ -542,6 +543,24 @@ bool DirAccessUnix::is_case_sensitive(const String &p_path) const {
 	}
 #endif
 	return true;
+}
+
+bool DirAccessUnix::is_equivalent(const String &p_path_a, const String &p_path_b) const {
+	String f1 = fix_path(p_path_a);
+	struct stat st1 = {};
+	int err = stat(f1.utf8().get_data(), &st1);
+	if (err) {
+		return DirAccess::is_equivalent(p_path_a, p_path_b);
+	}
+
+	String f2 = fix_path(p_path_b);
+	struct stat st2 = {};
+	err = stat(f2.utf8().get_data(), &st2);
+	if (err) {
+		return DirAccess::is_equivalent(p_path_a, p_path_b);
+	}
+
+	return (st1.st_dev == st2.st_dev) && (st1.st_ino == st2.st_ino);
 }
 
 DirAccessUnix::DirAccessUnix() {

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -85,6 +85,7 @@ public:
 	virtual Error create_link(String p_source, String p_target) override;
 
 	virtual bool is_case_sensitive(const String &p_path) const override;
+	virtual bool is_equivalent(const String &p_path_a, const String &p_path_b) const override;
 
 	virtual uint64_t get_space_left() override;
 

--- a/drivers/windows/dir_access_windows.h
+++ b/drivers/windows/dir_access_windows.h
@@ -84,6 +84,7 @@ public:
 
 	virtual String get_filesystem_type() const override;
 	virtual bool is_case_sensitive(const String &p_path) const override;
+	virtual bool is_equivalent(const String &p_path_a, const String &p_path_b) const override;
 
 	DirAccessWindows();
 	~DirAccessWindows();


### PR DESCRIPTION
*Bugsquad edit:* Returns `true` if two paths resolve to the same file system object. Returns `false` otherwise, even if the files are bit-for-bit identical (e.g. identical copies of the file that are not symbolic links).