### PR TITLE
Fix `shape` always being zero with `get_rest_info` when using Jolt Physics

### DIFF
--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -787,7 +787,6 @@ bool JoltPhysicsDirectSpaceState3D::rest_info(const ShapeParameters &p_parameter
 	r_info->normal = to_godot(-hit.mPenetrationAxis.Normalized());
 	r_info->rid = object->get_rid();
 	r_info->collider_id = object->get_instance_id();
-	r_info->shape = 0;
 	r_info->linear_velocity = object->get_velocity_at_position(hit_point);
 
 	return true;


### PR DESCRIPTION
Fixes #104563.

Somehow I managed to copy this line (to ~15 lines above this one) instead of cutting it when doing some refactoring while porting the Jolt module, resulting in the `shape` index in the `get_rest_info` results always being zero.