### PR TITLE
Change type of size_2d_override to Vector2

### DIFF
--- a/doc/classes/SubViewport.xml
+++ b/doc/classes/SubViewport.xml
@@ -30,7 +30,7 @@
 			The width and height of the sub-viewport. Must be set to a value greater than or equal to 2 pixels on both dimensions. Otherwise, nothing will be displayed.
 			[b]Note:[/b] If the parent node is a [SubViewportContainer] and its [member SubViewportContainer.stretch] is [code]true[/code], the viewport size cannot be changed manually.
 		</member>
-		<member name="size_2d_override" type="Vector2i" setter="set_size_2d_override" getter="get_size_2d_override" default="Vector2i(0, 0)">
+		<member name="size_2d_override" type="Vector2" setter="set_size_2d_override" getter="get_size_2d_override" default="Vector2(0, 0)">
 			The 2D size override of the sub-viewport. If either the width or height is [code]0[/code], the override is disabled.
 		</member>
 		<member name="size_2d_override_stretch" type="bool" setter="set_size_2d_override_stretch" getter="is_size_2d_override_stretch_enabled" default="false">

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -321,3 +321,12 @@ Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/a
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments': size changed value in new API, from 11 to 12.
 
 Optional argument added. Compatibility methods registered.
+
+
+GH-104601
+---------
+Validate extension JSON: Error: Field 'classes/SubViewport/methods/set_size_2d_override/arguments/0': type changed value in new API, from "Vector2i" to "Vector2".
+Validate extension JSON: Error: Field 'classes/SubViewport/methods/get_size_2d_override/return_value': type changed value in new API, from "Vector2i" to "Vector2".
+Validate extension JSON: Error: Field 'classes/SubViewport/properties/size_2d_override': type changed value in new API, from "Vector2i" to "Vector2".
+
+Changed type of `size_2d_override` in `SubViewport` from `Vector2i` to `Vector2`.

--- a/scene/main/viewport.compat.inc
+++ b/scene/main/viewport.compat.inc
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  viewport.compat.inc                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+Size2i SubViewport::_get_size_2d_override_bind_compat_104601() const {
+	// This implementation and comment is from when size_2d_override was a Size2i:
+	// Rounding will cause offset issues with the
+	// exact positioning of subwindows, but changing the
+	// type of size_2d_override would break compatibility.
+	return Size2i((get_size_2d_override() + Size2(0.5, 0.5)).floor());
+}
+
+void SubViewport::_set_size_2d_override_bind_compat_104601(const Size2i &p_size) {
+	set_size_2d_override(p_size);
+}
+
+void SubViewport::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_size_2d_override"), &SubViewport::_get_size_2d_override_bind_compat_104601);
+	ClassDB::bind_compatibility_method(D_METHOD("set_size_2d_override", "p_size"), &SubViewport::_set_size_2d_override_bind_compat_104601);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "viewport.h"
+#include "viewport.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
@@ -5409,17 +5410,14 @@ Size2i SubViewport::get_size() const {
 	return _get_size();
 }
 
-void SubViewport::set_size_2d_override(const Size2i &p_size) {
+void SubViewport::set_size_2d_override(const Size2 &p_size) {
 	ERR_MAIN_THREAD_GUARD;
 	_set_size(_get_size(), p_size, true);
 }
 
-Size2i SubViewport::get_size_2d_override() const {
-	ERR_READ_THREAD_GUARD_V(Size2i());
-	// Rounding will cause offset issues with the
-	// exact positioning of subwindows, but changing the
-	// type of size_2d_override would break compatibility.
-	return Size2i((_get_size_2d_override() + Size2(0.5, 0.5)).floor());
+Size2 SubViewport::get_size_2d_override() const {
+	ERR_READ_THREAD_GUARD_V(Size2());
+	return _get_size_2d_override();
 }
 
 void SubViewport::set_size_2d_override_stretch(bool p_enable) {
@@ -5542,7 +5540,7 @@ void SubViewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_clear_mode"), &SubViewport::get_clear_mode);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "size", PROPERTY_HINT_NONE, "suffix:px"), "set_size", "get_size");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "size_2d_override", PROPERTY_HINT_NONE, "suffix:px"), "set_size_2d_override", "get_size_2d_override");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size_2d_override", PROPERTY_HINT_NONE, "suffix:px"), "set_size_2d_override", "get_size_2d_override");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "size_2d_override_stretch"), "set_size_2d_override_stretch", "is_size_2d_override_stretch_enabled");
 	ADD_GROUP("Render Target", "render_target_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_target_clear_mode", PROPERTY_HINT_ENUM, "Always,Never,Next Frame"), "set_clear_mode", "get_clear_mode");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -886,13 +886,19 @@ protected:
 	virtual DisplayServer::WindowID get_window_id() const override;
 	void _notification(int p_what);
 
+#ifndef DISABLE_DEPRECATED
+	Size2i _get_size_2d_override_bind_compat_104601() const;
+	void _set_size_2d_override_bind_compat_104601(const Size2i &p_size);
+	static void _bind_compatibility_methods();
+#endif
+
 public:
 	void set_size(const Size2i &p_size);
 	Size2i get_size() const;
 	void set_size_force(const Size2i &p_size);
 
-	void set_size_2d_override(const Size2i &p_size);
-	Size2i get_size_2d_override() const;
+	void set_size_2d_override(const Size2 &p_size);
+	Size2 get_size_2d_override() const;
 
 	void set_size_2d_override_stretch(bool p_enable);
 	bool is_size_2d_override_stretch_enabled() const override;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/104601

Added compatibility methods that mimic the previous behavior.