### PR TITLE
Use reserved scroll mode for inspector

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -53,6 +53,7 @@
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
 		<member name="follow_focus" type="bool" setter="set_follow_focus" getter="is_following_focus" overrides="ScrollContainer" default="true" />
 		<member name="horizontal_scroll_mode" type="int" setter="set_horizontal_scroll_mode" getter="get_horizontal_scroll_mode" overrides="ScrollContainer" enum="ScrollContainer.ScrollMode" default="0" />
+		<member name="vertical_scroll_mode" type="int" setter="set_vertical_scroll_mode" getter="get_vertical_scroll_mode" overrides="ScrollContainer" enum="ScrollContainer.ScrollMode" default="4" />
 	</members>
 	<signals>
 		<signal name="edited_object_changed">

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4778,7 +4778,6 @@ void EditorInspector::_notification(int p_what) {
 			ERR_FAIL_NULL(EditorFeatureProfileManager::get_singleton());
 			EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &EditorInspector::_feature_profile_changed));
 			set_process(is_visible_in_tree());
-			add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
 			if (!is_sub_inspector()) {
 				get_tree()->connect("node_removed", callable_mp(this, &EditorInspector::_node_removed));
 			}
@@ -5044,4 +5043,5 @@ EditorInspector::EditorInspector() {
 
 	set_draw_focus_border(true);
 	set_scroll_on_drag_hover(true);
+	set_vertical_scroll_shrink(true);
 }

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -5015,6 +5015,7 @@ EditorInspector::EditorInspector() {
 	base_vbox->add_child(main_vbox);
 
 	set_horizontal_scroll_mode(SCROLL_MODE_DISABLED);
+	set_vertical_scroll_mode(SCROLL_MODE_RESERVE);
 	set_follow_focus(true);
 
 	changing = 0;

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -2198,6 +2198,10 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 
 	// Editor inspector.
 	{
+		Ref<StyleBoxFlat> inspector_panel = p_config.tree_panel_style->duplicate();
+		inspector_panel->set_content_margin(SIDE_RIGHT, 0);
+		p_theme->set_stylebox(SceneStringName(panel), "EditorInspector", inspector_panel);
+
 		// Vertical separation between inspector categories and sections.
 		p_theme->set_constant("v_separation", "EditorInspector", 0);
 

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -37,6 +37,8 @@
 class ScrollContainer : public Container {
 	GDCLASS(ScrollContainer, Container);
 
+	inline static constexpr real_t SHRINK_FACTOR = 0.4;
+
 public:
 	enum ScrollMode {
 		SCROLL_MODE_DISABLED = 0,
@@ -49,6 +51,7 @@ public:
 private:
 	HScrollBar *h_scroll = nullptr;
 	VScrollBar *v_scroll = nullptr;
+	Control *v_scroll_expander = nullptr;
 
 	mutable Size2 largest_child_min_size; // The largest one among the min sizes of all available child controls.
 
@@ -71,6 +74,7 @@ private:
 	bool follow_focus = false;
 	int scroll_border = 20;
 	int scroll_speed = 12;
+	bool vertical_scroll_shrink = false;
 
 	struct ThemeCache {
 		Ref<StyleBox> panel_style;
@@ -136,6 +140,8 @@ public:
 
 	void set_draw_focus_border(bool p_draw);
 	bool get_draw_focus_border();
+
+	void set_vertical_scroll_shrink(bool p_enabled);
 
 	ScrollContainer();
 };


### PR DESCRIPTION
Prevents content jumping when scroll bar appears, at the cost of some horizontal space when the scroll bar is invisible.
| Before | After |
| --- | --- |
|![godot windows editor dev x86_64_AfiVxquK7h-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/b4932658-27a8-4db4-ac9b-0173ad1296ff)|![qPftxUQeQS-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/38fb7086-f33a-470c-b3c6-fefdc9b82fcc)|