### PR TITLE
[.NET] Add caching for dotnet TFM validation result

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2540,6 +2540,9 @@ bool EditorExportPlatformAndroid::has_valid_username_and_password(const Ref<Edit
 }
 
 #ifdef MODULE_MONO_ENABLED
+static uint64_t _last_validate_tfm_time = 0;
+static String _last_validate_tfm = "";
+
 bool _validate_dotnet_tfm(const String &required_tfm, String &r_error) {
 	String assembly_name = Path::get_csharp_project_name();
 	String project_path = ProjectSettings::get_singleton()->globalize_path("res://" + assembly_name + ".csproj");
@@ -2548,28 +2551,39 @@ bool _validate_dotnet_tfm(const String &required_tfm, String &r_error) {
 		return true;
 	}
 
-	String pipe;
-	List<String> args;
-	args.push_back("build");
-	args.push_back(project_path);
-	args.push_back("--getProperty:TargetFramework");
+	uint64_t modified_time = FileAccess::get_modified_time(project_path);
+	String tfm;
 
-	int exitcode;
-	Error err = OS::get_singleton()->execute("dotnet", args, &pipe, &exitcode, true);
-	if (err != OK || exitcode != 0) {
-		if (err != OK) {
-			WARN_PRINT("Failed to execute dotnet command. Error " + String(error_names[err]));
-		} else if (exitcode != 0) {
-			print_line(pipe);
-			WARN_PRINT("dotnet command exited with code " + itos(exitcode) + ". See output above for more details.");
-		}
-		r_error += vformat(TTR("Unable to determine the C# project's TFM, it may be incompatible. The export template only supports '%s'. Make sure the project targets '%s' or consider using gradle builds instead."), required_tfm, required_tfm) + "\n";
+	if (modified_time == _last_validate_tfm_time) {
+		tfm = _last_validate_tfm;
 	} else {
-		String tfm = pipe.strip_edges();
-		if (tfm != required_tfm) {
-			r_error += vformat(TTR("C# project targets '%s' but the export template only supports '%s'. Consider using gradle builds instead."), tfm, required_tfm) + "\n";
-			return false;
+		String pipe;
+		List<String> args;
+		args.push_back("build");
+		args.push_back(project_path);
+		args.push_back("--getProperty:TargetFramework");
+
+		int exitcode;
+		Error err = OS::get_singleton()->execute("dotnet", args, &pipe, &exitcode, true);
+		if (err != OK || exitcode != 0) {
+			if (err != OK) {
+				WARN_PRINT("Failed to execute dotnet command. Error " + String(error_names[err]));
+			} else if (exitcode != 0) {
+				print_line(pipe);
+				WARN_PRINT("dotnet command exited with code " + itos(exitcode) + ". See output above for more details.");
+			}
+			r_error += vformat(TTR("Unable to determine the C# project's TFM, it may be incompatible. The export template only supports '%s'. Make sure the project targets '%s' or consider using gradle builds instead."), required_tfm, required_tfm) + "\n";
+			return true;
+		} else {
+			tfm = pipe.strip_edges();
+			_last_validate_tfm_time = modified_time;
+			_last_validate_tfm = tfm;
 		}
+	}
+
+	if (tfm != required_tfm) {
+		r_error += vformat(TTR("C# project targets '%s' but the export template only supports '%s'. Consider using gradle builds instead."), tfm, required_tfm) + "\n";
+		return false;
 	}
 
 	return true;


### PR DESCRIPTION
- Close: #104285

After #102627, exporting Android runs `dotnet build <project.csproj> --getProperty:TargetFramework` to check the TFM. However, in export dialog, **EVERY INPUT** do trigger `has_valid_export_configuration`, which makes the interface very sticky.

This PR adds caching for TFM checks, only using command line when export dialog is first opened and when `project.csproj` is modified.

| Before   | After  |
|---------|---------|
| ![fix_before](https://github.com/user-attachments/assets/08dcec77-c40d-41ed-baa0-fb3924c49b32) | ![fix_after](https://github.com/user-attachments/assets/5aef4688-7d4c-4caf-b026-3f3adb77af6a) |
