### PR TITLE
[macOS] Fix cleanup with some command line tools.

### DIFF
--- a/platform/macos/godot_application_delegate.mm
+++ b/platform/macos/godot_application_delegate.mm
@@ -240,7 +240,7 @@
 
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender {
 	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
-	if (ds) {
+	if (ds && ds->has_window(DisplayServerMacOS::MAIN_WINDOW_ID)) {
 		ds->send_window_event(ds->get_window(DisplayServerMacOS::MAIN_WINDOW_ID), DisplayServerMacOS::WINDOW_EVENT_CLOSE_REQUEST);
 	}
 	OS_MacOS *os = (OS_MacOS *)OS::get_singleton();

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -882,9 +882,9 @@ void OS_MacOS::terminate() {
 void OS_MacOS::cleanup() {
 	if (main_loop) {
 		main_loop->finalize();
-		@autoreleasepool {
-			Main::cleanup();
-		}
+	}
+	@autoreleasepool {
+		Main::cleanup();
 	}
 }
 


### PR DESCRIPTION
Fixes cleanup step after https://github.com/godotengine/godot/pull/104397 with some command line tools, causing error spam on exit.