### PR TITLE
Fix uninitialized member vars in CommandQueueMT and RasterizerSceneGLES3

### DIFF
--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -113,7 +113,7 @@ class CommandQueueMT {
 	uint32_t sync_awaiters = 0;
 	WorkerThreadPool::TaskID pump_task_id = WorkerThreadPool::INVALID_TASK_ID;
 	uint64_t flush_read_ptr = 0;
-	std::atomic<bool> pending;
+	std::atomic<bool> pending{ false };
 
 	template <typename T, typename... Args>
 	_FORCE_INLINE_ void create_command(Args &&...p_args) {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -739,7 +739,7 @@ protected:
 		float baked_exposure = 1.0;
 
 		//State to track when radiance cubemap needs updating
-		GLES3::SkyMaterialData *prev_material;
+		GLES3::SkyMaterialData *prev_material = nullptr;
 		Vector3 prev_position = Vector3(0.0, 0.0, 0.0);
 		float prev_time = 0.0f;
 	};


### PR DESCRIPTION
Fixes a couple of uninitialised member variables, (to clean up Valgrind output).