### PR TITLE
SCons: Refactor `color.py`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -58,7 +58,7 @@ import gles3_builders
 import glsl_builders
 import methods
 import scu_builders
-from misc.utility.color import STDERR_COLOR, print_error, print_info, print_warning
+from misc.utility.color import is_stderr_color, print_error, print_info, print_warning
 from platform_methods import architecture_aliases, architectures, compatibility_platform_aliases
 
 if ARGUMENTS.get("target", "editor") == "editor":
@@ -704,9 +704,9 @@ if env["arch"] == "x86_32":
 
 # Explicitly specify colored output.
 if methods.using_gcc(env):
-    env.AppendUnique(CCFLAGS=["-fdiagnostics-color" if STDERR_COLOR else "-fno-diagnostics-color"])
+    env.AppendUnique(CCFLAGS=["-fdiagnostics-color" if is_stderr_color() else "-fno-diagnostics-color"])
 elif methods.using_clang(env) or methods.using_emcc(env):
-    env.AppendUnique(CCFLAGS=["-fcolor-diagnostics" if STDERR_COLOR else "-fno-color-diagnostics"])
+    env.AppendUnique(CCFLAGS=["-fcolor-diagnostics" if is_stderr_color() else "-fno-color-diagnostics"])
     if sys.platform == "win32":
         env.AppendUnique(CCFLAGS=["-fansi-escape-codes"])
 

--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -10,14 +10,14 @@ from typing import Dict, List, Set
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../"))
 
-from misc.utility.color import NO_COLOR, STDOUT_COLOR, Ansi, toggle_color
+from misc.utility.color import Ansi, force_stdout_color, is_stdout_color
 
 ################################################################################
 #                                    Config                                    #
 ################################################################################
 
 flags = {
-    "c": STDOUT_COLOR,
+    "c": is_stdout_color(),
     "b": False,
     "g": False,
     "s": False,
@@ -114,7 +114,7 @@ def validate_tag(elem: ET.Element, tag: str) -> None:
 
 
 def color(color: str, string: str) -> str:
-    if NO_COLOR:
+    if not is_stdout_color():
         return string
     color_format = "".join([str(x) for x in colors[color]])
     return f"{color_format}{string}{Ansi.RESET}"
@@ -332,8 +332,7 @@ if flags["u"]:
     table_column_names.append("Docs URL")
     table_columns.append("url")
 
-if flags["c"]:
-    toggle_color(True)
+force_stdout_color(flags["c"])
 
 ################################################################################
 #                                     Help                                     #

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, TextIO, Tuple, Union
 sys.path.insert(0, root_directory := os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../"))
 
 import version
-from misc.utility.color import Ansi, toggle_color
+from misc.utility.color import Ansi, force_stderr_color, force_stdout_color
 
 # $DOCS_URL/path/to/page.html(#fragment-tag)
 GODOT_DOCS_PATTERN = re.compile(r"^\$DOCS_URL/(.*)\.html(#.*)?$")
@@ -698,7 +698,8 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.color:
-        toggle_color(True)
+        force_stdout_color(True)
+        force_stderr_color(True)
 
     # Retrieve heading translations for the given language.
     if not args.dry_run and args.lang != "en":

--- a/methods.py
+++ b/methods.py
@@ -428,9 +428,9 @@ def use_windows_spawn_fix(self, platform=None):
 
 
 def no_verbose(env):
-    from misc.utility.color import Ansi
+    from misc.utility.color import Ansi, is_stdout_color
 
-    colors = [Ansi.BLUE, Ansi.BOLD, Ansi.REGULAR, Ansi.RESET]
+    colors = [Ansi.BLUE, Ansi.BOLD, Ansi.REGULAR, Ansi.RESET] if is_stdout_color() else ["", "", "", ""]
 
     # There is a space before "..." to ensure that source file names can be
     # Ctrl + clicked in the VS Code terminal.

--- a/misc/scripts/install_d3d12_sdk_windows.py
+++ b/misc/scripts/install_d3d12_sdk_windows.py
@@ -8,7 +8,7 @@ import urllib.request
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../"))
 
-from misc.utility.color import Ansi
+from misc.utility.color import Ansi, color_print
 
 # Base Godot dependencies path
 # If cross-compiling (no LOCALAPPDATA), we install in `bin`
@@ -42,7 +42,7 @@ if not os.path.exists(deps_folder):
     os.makedirs(deps_folder)
 
 # Mesa NIR
-print(f"{Ansi.BOLD}[1/3] Mesa NIR{Ansi.RESET}")
+color_print(f"{Ansi.BOLD}[1/3] Mesa NIR")
 if os.path.isfile(mesa_archive):
     os.remove(mesa_archive)
 print(f"Downloading Mesa NIR {mesa_filename} ...")
@@ -69,7 +69,7 @@ if dlltool == "":
     dlltool = shutil.which("x86_64-w64-mingw32-dlltool") or ""
 has_mingw = gendef != "" and dlltool != ""
 
-print(f"{Ansi.BOLD}[2/3] WinPixEventRuntime{Ansi.RESET}")
+color_print(f"{Ansi.BOLD}[2/3] WinPixEventRuntime")
 if os.path.isfile(pix_archive):
     os.remove(pix_archive)
 print(f"Downloading WinPixEventRuntime {pix_version} ...")
@@ -100,7 +100,7 @@ else:
 print(f"WinPixEventRuntime {pix_version} installed successfully.\n")
 
 # DirectX 12 Agility SDK
-print(f"{Ansi.BOLD}[3/3] DirectX 12 Agility SDK{Ansi.RESET}")
+color_print(f"{Ansi.BOLD}[3/3] DirectX 12 Agility SDK")
 if os.path.isfile(agility_sdk_archive):
     os.remove(agility_sdk_archive)
 print(f"Downloading DirectX 12 Agility SDK {agility_sdk_version} ...")
@@ -116,5 +116,5 @@ os.remove(agility_sdk_archive)
 print(f"DirectX 12 Agility SDK {agility_sdk_version} installed successfully.\n")
 
 # Complete message
-print(f'{Ansi.GREEN}All Direct3D 12 SDK components were installed to "{deps_folder}" successfully!{Ansi.RESET}')
-print(f'{Ansi.GREEN}You can now build Godot with Direct3D 12 support enabled by running "scons d3d12=yes".{Ansi.RESET}')
+color_print(f'{Ansi.GREEN}All Direct3D 12 SDK components were installed to "{deps_folder}" successfully!')
+color_print(f'{Ansi.GREEN}You can now build Godot with Direct3D 12 support enabled by running "scons d3d12=yes".')


### PR DESCRIPTION
- Followup to #104524

Expands the coverage of environmental overrides for colors even further, by making a proper color detection function to pull from. Now the global variables represent either the initial state or current override state explicitly, being prepended with underscores so they're clearly internal. Also upgrades the existing info/warning/error print functions to call to universal functions that handle color codes automatically. Lastly, this explicitly resolves color status on non-verbose SCons output & d3d12 sdk install, which previously would've use ANSI codes regardless of support.