### PR TITLE
Support more controllers on macOS 11+

### DIFF
--- a/drivers/apple/joypad_apple.mm
+++ b/drivers/apple/joypad_apple.mm
@@ -163,7 +163,159 @@ GameController::GameController(int p_joy_id, GCController *p_controller) :
 		};
 	};
 
-	if (controller.extendedGamepad != nil) {
+	if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
+		if (controller.physicalInputProfile != nil) {
+			GCPhysicalInputProfile *profile = controller.physicalInputProfile;
+
+			GCControllerButtonInput *buttonA = profile.buttons[GCInputButtonA];
+			GCControllerButtonInput *buttonB = profile.buttons[GCInputButtonB];
+			GCControllerButtonInput *buttonX = profile.buttons[GCInputButtonX];
+			GCControllerButtonInput *buttonY = profile.buttons[GCInputButtonY];
+			if (nintendo_button_layout) {
+				if (buttonA) {
+					buttonA.pressedChangedHandler = BUTTON(JoyButton::B);
+				}
+				if (buttonB) {
+					buttonB.pressedChangedHandler = BUTTON(JoyButton::A);
+				}
+				if (buttonX) {
+					buttonX.pressedChangedHandler = BUTTON(JoyButton::Y);
+				}
+				if (buttonY) {
+					buttonY.pressedChangedHandler = BUTTON(JoyButton::X);
+				}
+			} else {
+				if (buttonA) {
+					buttonA.pressedChangedHandler = BUTTON(JoyButton::A);
+				}
+				if (buttonB) {
+					buttonB.pressedChangedHandler = BUTTON(JoyButton::B);
+				}
+				if (buttonX) {
+					buttonX.pressedChangedHandler = BUTTON(JoyButton::X);
+				}
+				if (buttonY) {
+					buttonY.pressedChangedHandler = BUTTON(JoyButton::Y);
+				}
+			}
+
+			GCControllerButtonInput *leftThumbstickButton = profile.buttons[GCInputLeftThumbstickButton];
+			GCControllerButtonInput *rightThumbstickButton = profile.buttons[GCInputRightThumbstickButton];
+			if (leftThumbstickButton) {
+				leftThumbstickButton.pressedChangedHandler = BUTTON(JoyButton::LEFT_STICK);
+			}
+			if (rightThumbstickButton) {
+				rightThumbstickButton.pressedChangedHandler = BUTTON(JoyButton::RIGHT_STICK);
+			}
+
+			GCControllerButtonInput *leftShoulder = profile.buttons[GCInputLeftShoulder];
+			GCControllerButtonInput *rightShoulder = profile.buttons[GCInputRightShoulder];
+			if (leftShoulder) {
+				leftShoulder.pressedChangedHandler = BUTTON(JoyButton::LEFT_SHOULDER);
+			}
+			if (rightShoulder) {
+				rightShoulder.pressedChangedHandler = BUTTON(JoyButton::RIGHT_SHOULDER);
+			}
+
+			GCControllerButtonInput *leftTrigger = profile.buttons[GCInputLeftTrigger];
+			GCControllerButtonInput *rightTrigger = profile.buttons[GCInputRightTrigger];
+			if (leftTrigger) {
+				leftTrigger.valueChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
+					if (axis_value[(int)JoyAxis::TRIGGER_LEFT] != value) {
+						axis_changed[(int)JoyAxis::TRIGGER_LEFT] = true;
+						axis_value[(int)JoyAxis::TRIGGER_LEFT] = value;
+					}
+				};
+			}
+			if (rightTrigger) {
+				rightTrigger.valueChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
+					if (axis_value[(int)JoyAxis::TRIGGER_RIGHT] != value) {
+						axis_changed[(int)JoyAxis::TRIGGER_RIGHT] = true;
+						axis_value[(int)JoyAxis::TRIGGER_RIGHT] = value;
+					}
+				};
+			}
+
+			GCControllerButtonInput *buttonMenu = profile.buttons[GCInputButtonMenu];
+			GCControllerButtonInput *buttonHome = profile.buttons[GCInputButtonHome];
+			GCControllerButtonInput *buttonOptions = profile.buttons[GCInputButtonOptions];
+			if (buttonMenu) {
+				buttonMenu.pressedChangedHandler = BUTTON(JoyButton::START);
+			}
+			if (buttonHome) {
+				buttonHome.pressedChangedHandler = BUTTON(JoyButton::GUIDE);
+			}
+			if (buttonOptions) {
+				buttonOptions.pressedChangedHandler = BUTTON(JoyButton::BACK);
+			}
+
+			// Xbox controller buttons.
+			if (@available(macOS 12.0, iOS 15.0, tvOS 15.0, *)) {
+				GCControllerButtonInput *buttonShare = profile.buttons[GCInputButtonShare];
+				if (buttonShare) {
+					buttonShare.pressedChangedHandler = BUTTON(JoyButton::MISC1);
+				}
+			}
+
+			GCControllerButtonInput *paddleButton1 = profile.buttons[GCInputXboxPaddleOne];
+			GCControllerButtonInput *paddleButton2 = profile.buttons[GCInputXboxPaddleTwo];
+			GCControllerButtonInput *paddleButton3 = profile.buttons[GCInputXboxPaddleThree];
+			GCControllerButtonInput *paddleButton4 = profile.buttons[GCInputXboxPaddleFour];
+			if (paddleButton1) {
+				paddleButton1.pressedChangedHandler = BUTTON(JoyButton::PADDLE1);
+			}
+			if (paddleButton2) {
+				paddleButton2.pressedChangedHandler = BUTTON(JoyButton::PADDLE2);
+			}
+			if (paddleButton3) {
+				paddleButton3.pressedChangedHandler = BUTTON(JoyButton::PADDLE3);
+			}
+			if (paddleButton4) {
+				paddleButton4.pressedChangedHandler = BUTTON(JoyButton::PADDLE4);
+			}
+
+			GCControllerDirectionPad *leftThumbstick = profile.dpads[GCInputLeftThumbstick];
+			if (leftThumbstick) {
+				leftThumbstick.valueChangedHandler = ^(GCControllerDirectionPad *dpad, float xValue, float yValue) {
+					if (axis_value[(int)JoyAxis::LEFT_X] != xValue) {
+						axis_changed[(int)JoyAxis::LEFT_X] = true;
+						axis_value[(int)JoyAxis::LEFT_X] = xValue;
+					}
+					if (axis_value[(int)JoyAxis::LEFT_Y] != -yValue) {
+						axis_changed[(int)JoyAxis::LEFT_Y] = true;
+						axis_value[(int)JoyAxis::LEFT_Y] = -yValue;
+					}
+				};
+			}
+
+			GCControllerDirectionPad *rightThumbstick = profile.dpads[GCInputRightThumbstick];
+			if (rightThumbstick) {
+				rightThumbstick.valueChangedHandler = ^(GCControllerDirectionPad *dpad, float xValue, float yValue) {
+					if (axis_value[(int)JoyAxis::RIGHT_X] != xValue) {
+						axis_changed[(int)JoyAxis::RIGHT_X] = true;
+						axis_value[(int)JoyAxis::RIGHT_X] = xValue;
+					}
+					if (axis_value[(int)JoyAxis::RIGHT_Y] != -yValue) {
+						axis_changed[(int)JoyAxis::RIGHT_Y] = true;
+						axis_value[(int)JoyAxis::RIGHT_Y] = -yValue;
+					}
+				};
+			}
+
+			GCControllerDirectionPad *dpad = nil;
+			if (controller.extendedGamepad != nil) {
+				dpad = controller.extendedGamepad.dpad;
+			} else if (controller.microGamepad != nil) {
+				dpad = controller.microGamepad.dpad;
+			}
+			if (dpad) {
+				dpad.up.pressedChangedHandler = BUTTON(JoyButton::DPAD_UP);
+				dpad.down.pressedChangedHandler = BUTTON(JoyButton::DPAD_DOWN);
+				dpad.left.pressedChangedHandler = BUTTON(JoyButton::DPAD_LEFT);
+				dpad.right.pressedChangedHandler = BUTTON(JoyButton::DPAD_RIGHT);
+			}
+		}
+	} else if (controller.extendedGamepad != nil) {
 		GCExtendedGamepad *gamepad = controller.extendedGamepad;
 
 		if (nintendo_button_layout) {


### PR DESCRIPTION
TL;DR: This PR adds support for more controllers on macOS 11+, including individual Joy-Con (L) and Joy-Con (R) controllers.

---

A recent PR #103661 improved support for Nintendo Switch Joy-Con controllers when connected together, but I noticed that the support for an individual Joy-Con (L) or Joy-Con (R) was still lacking; only some of its buttons worked on macOS.

Looking into it more, I found that the current Game Controller support was only for the [`GCExtendedGamepad`](https://developer.apple.com/documentation/gamecontroller/gcextendedgamepad?language=objc) and [`GCMicroGamepad`](https://developer.apple.com/documentation/gamecontroller/gcmicrogamepad?language=objc) classes; however, macOS registered the individual Joy-Cons as [`GCGamepad`](https://developer.apple.com/documentation/gamecontroller/gcgamepad?language=objc). This is a deprecated class according to the online documentation, so I've no idea why it's being used here.

Anyways, on macOS 11+, `physicalInputProfile` exists, which allows us to get the full controller instead of it being boxed into either an extended gamepad or micro gamepad. From there, we can use some system-provided constants like `GCInputButtonA`, `GCInputLeftThumbstick`, and so on to find the relevant input items on whatever controller we're connecting.

The previously-existing `extendedGamepad` and `microGamepad` handling is kept intact, so that if a system isn't on macOS 11+, iOS 13+, or tvOS 13+, it can still fall back to how gamepads were handled before.

>[!NOTE]
> Despite the branch name and motivation, I can see that the Joy-Con (L) isn't *perfectly* mapped - the A (right) and Y (left) buttons are swapped. It looks like this is another one of Apple's silly mapping mistakes, but I think it might make more sense to address that specific issue in a later PR. This PR's main focus is just to more fully support controllers that don't fit into either the extended or micro gamepad profiles.
