### PR TITLE
Expose TriangleMesh api functions wrapped for scripting

### DIFF
--- a/core/math/triangle_mesh.h
+++ b/core/math/triangle_mesh.h
@@ -40,8 +40,11 @@ public:
 	struct Triangle {
 		Vector3 normal;
 		int indices[3];
-		int32_t surface_index;
+		int32_t surface_index = 0;
 	};
+
+protected:
+	static void _bind_methods();
 
 private:
 	Vector<Triangle> triangles;
@@ -50,10 +53,10 @@ private:
 	struct BVH {
 		AABB aabb;
 		Vector3 center; //used for sorting
-		int left;
-		int right;
+		int left = -1;
+		int right = -1;
 
-		int face_index;
+		int32_t face_index = -1;
 	};
 
 	struct BVHCmpX {
@@ -76,13 +79,13 @@ private:
 	int _create_bvh(BVH *p_bvh, BVH **p_bb, int p_from, int p_size, int p_depth, int &max_depth, int &max_alloc);
 
 	Vector<BVH> bvh;
-	int max_depth;
-	bool valid;
+	int max_depth = 0;
+	bool valid = false;
 
 public:
 	bool is_valid() const;
-	bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index = nullptr) const;
-	bool intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index = nullptr) const;
+	bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index = nullptr, int32_t *r_face_index = nullptr) const;
+	bool intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index = nullptr, int32_t *r_face_index = nullptr) const;
 	bool inside_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count, Vector3 p_scale = Vector3(1, 1, 1)) const;
 	Vector<Face3> get_faces() const;
 
@@ -91,5 +94,13 @@ public:
 	void get_indices(Vector<int> *r_triangles_indices) const;
 
 	void create(const Vector<Vector3> &p_faces, const Vector<int32_t> &p_surface_indices = Vector<int32_t>());
+
+	// Wrapped functions for compatibility with method bindings
+	// and user exposed script api that can't use more native types.
+	bool create_from_faces(const Vector<Vector3> &p_faces);
+	Dictionary intersect_segment_scriptwrap(const Vector3 &p_begin, const Vector3 &p_end) const;
+	Dictionary intersect_ray_scriptwrap(const Vector3 &p_begin, const Vector3 &p_dir) const;
+	Vector<Vector3> get_faces_scriptwrap() const;
+
 	TriangleMesh();
 };

--- a/doc/classes/TriangleMesh.xml
+++ b/doc/classes/TriangleMesh.xml
@@ -1,11 +1,58 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="TriangleMesh" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Internal mesh type.
+		Triangle geometry for efficient, physicsless intersection queries.
 	</brief_description>
 	<description>
-		Mesh type used internally for collision calculations.
+		Creates a bounding volume hierarchy (BVH) tree structure around triangle geometry.
+		The triangle BVH tree can be used for efficient intersection queries without involving a physics engine.
+		For example, this can be used in editor tools to select objects with complex shapes based on the mouse cursor position.
+		[b]Performance:[/b] Creating the BVH tree for complex geometry is a slow process and best done in a background thread.
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="create_from_faces">
+			<return type="bool" />
+			<param index="0" name="faces" type="PackedVector3Array" />
+			<description>
+				Creates the BVH tree from an array of faces. Each 3 vertices of the input [param faces] array represent one triangle (face).
+				Returns [code]true[/code] if the tree is successfully built, [code]false[/code] otherwise.
+			</description>
+		</method>
+		<method name="get_faces" qualifiers="const">
+			<return type="PackedVector3Array" />
+			<description>
+				Returns a copy of the geometry faces. Each 3 vertices of the array represent one triangle (face).
+			</description>
+		</method>
+		<method name="intersect_ray" qualifiers="const">
+			<return type="Dictionary" />
+			<param index="0" name="begin" type="Vector3" />
+			<param index="1" name="dir" type="Vector3" />
+			<description>
+				Tests for intersection with a ray starting at [param begin] and facing [param dir] and extending toward infinity.
+				If an intersection with a triangle happens, returns a [Dictionary] with the following fields:
+				[code]position[/code]: The position on the intersected triangle.
+				[code]normal[/code]: The normal of the intersected triangle.
+				[code]face_index[/code]: The index of the intersected triangle.
+				Returns an empty [Dictionary] if no intersection happens.
+				See also [method intersect_segment], which is similar but uses a finite-length segment.
+			</description>
+		</method>
+		<method name="intersect_segment" qualifiers="const">
+			<return type="Dictionary" />
+			<param index="0" name="begin" type="Vector3" />
+			<param index="1" name="end" type="Vector3" />
+			<description>
+				Tests for intersection with a segment going from [param begin] to [param end].
+				If an intersection with a triangle happens returns a [Dictionary] with the following fields:
+				[code]position[/code]: The position on the intersected triangle.
+				[code]normal[/code]: The normal of the intersected triangle.
+				[code]face_index[/code]: The index of the intersected triangle.
+				Returns an empty [Dictionary] if no intersection happens.
+				See also [method intersect_ray], which is similar but uses an infinite-length ray.
+			</description>
+		</method>
+	</methods>
 </class>

--- a/tests/core/math/test_triangle_mesh.h
+++ b/tests/core/math/test_triangle_mesh.h
@@ -1,0 +1,82 @@
+/**************************************************************************/
+/*  test_triangle_mesh.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/math/triangle_mesh.h"
+#include "scene/resources/3d/primitive_meshes.h"
+
+#include "tests/test_macros.h"
+
+namespace TestTriangleMesh {
+
+TEST_CASE("[SceneTree][TriangleMesh] BVH creation and intersection") {
+	Ref<BoxMesh> box_mesh;
+	box_mesh.instantiate();
+
+	const Vector<Face3> faces = box_mesh->get_faces();
+
+	Ref<TriangleMesh> triangle_mesh;
+	triangle_mesh.instantiate();
+	CHECK(triangle_mesh->create_from_faces(Variant(faces)));
+
+	const Vector3 begin = Vector3(0.0, 2.0, 0.0);
+	const Vector3 end = Vector3(0.0, -2.0, 0.0);
+
+	{
+		Vector3 point;
+		Vector3 normal;
+		int32_t *surf_index = nullptr;
+		int32_t face_index = -1;
+		const bool has_result = triangle_mesh->intersect_segment(begin, end, point, normal, surf_index, &face_index);
+		CHECK(has_result);
+		CHECK(point.is_equal_approx(Vector3(0.0, 0.5, 0.0)));
+		CHECK(normal.is_equal_approx(Vector3(0.0, 1.0, 0.0)));
+		CHECK(surf_index == nullptr);
+		REQUIRE(face_index != -1);
+		CHECK(face_index == 8);
+	}
+
+	{
+		Vector3 dir = begin.direction_to(end);
+		Vector3 point;
+		Vector3 normal;
+		int32_t *surf_index = nullptr;
+		int32_t face_index = -1;
+		const bool has_result = triangle_mesh->intersect_ray(begin, dir, point, normal, surf_index, &face_index);
+		CHECK(has_result);
+		CHECK(point.is_equal_approx(Vector3(0.0, 0.5, 0.0)));
+		CHECK(normal.is_equal_approx(Vector3(0.0, 1.0, 0.0)));
+		CHECK(surf_index == nullptr);
+		REQUIRE(face_index != -1);
+		CHECK(face_index == 8);
+	}
+}
+} // namespace TestTriangleMesh

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -161,6 +161,7 @@
 #endif // ADVANCED_GUI_DISABLED
 
 #ifndef _3D_DISABLED
+#include "tests/core/math/test_triangle_mesh.h"
 #include "tests/scene/test_arraymesh.h"
 #include "tests/scene/test_camera_3d.h"
 #include "tests/scene/test_gltf_document.h"


### PR DESCRIPTION
Adds script wrapped `TriangleMesh` api functions to create and query the triangle BVH tree.

`TriangleMesh` functionality is to create a triangle BVH tree for quick intersection and selection queries without involving any of the physics engines.

E.g. it is commonly used (and required) by the Editor and Plugins to do mouse picking of objects or to build working editor selection for custom 3d gizmos. 

There are very few options to create a TriangleMesh for script users without going through inefficient workarounds as the class itself has no functionality exposed. Main reason is that nearly all functions use more native C++ parameter types that do not work for script bindings.

This PR adds the functionality for script users with simplified parameters and wrapped inside functions that work for script bindings. Also adds an optional C++ parameter to the existing query functions to get the face index as that is useful information to remap the query result to other mappings.

```gdscript
var test_mesh: Mesh = BoxMesh.new()

var faces: PackedVector3Array = test_mesh.get_faces()

var triangle_mesh: TriangleMesh = TriangleMesh.new()
var build_successful: bool = triangle_mesh.create_from_faces(faces)

if build_successful:
	var begin: Vector3 = Vector3(0.0, 2.0, 0.0)
	var end: Vector3 = Vector3(0.0, -2.0, 0.0)
	
	var result: Dictionary = triangle_mesh.intersect_segment(begin, end)
	if not result.is_empty():
		print("intersect_segment")
		print("position: %s" % result["position"])
		print("normal: %s" % result["normal"])
		print("face_index: %s" % result["face_index"])

	var dir: Vector3 = begin.direction_to(end)
	var result2: Dictionary = triangle_mesh.intersect_ray(begin, dir)
	if not result2.is_empty():
		print("intersect_ray")
		print("position: %s" % result2["position"])
		print("normal: %s" % result2["normal"])
		print("face_index: %s" % result2["face_index"])
```

I wanted to make a custom 3d gizmo for an addon and couldnt create the selection collision because nothing is exposed for scripting. Creating and reading a slow Mesh resource to get to a TriangleMesh resulted in a major freeze due to GPU stalling.
So I made this PR to fix this for scripting and fix the documentation as well.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
