### PR TITLE
Allow multiple EditorNode3DGizmo collision meshes

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -56,7 +56,7 @@ class EditorNode3DGizmo : public Node3DGizmo {
 	bool selected;
 
 	Vector<Vector3> collision_segments;
-	Ref<TriangleMesh> collision_mesh;
+	LocalVector<Ref<TriangleMesh>> collision_meshes;
 
 	Vector<Vector3> handles;
 	Vector<int> handle_ids;


### PR DESCRIPTION
Allows to add multiple `TriangleMesh` collision meshes to a 3D gizmo.

The function `add_collision_triangles()` has the ADD literally in the name after all, not replace or set.

The similar `add_collision_segments() `function has already the correct behavior and appends to the existing segments when called multiple times.

Having multiple collision meshes makes it easier to cache and reuse them on more complex gizmos, especially since creating custom TriangleMeshes is not well supported atm without https://github.com/godotengine/godot/pull/104625.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
