### PR TITLE
Variadic form of MIN and MAX function templates.

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2866,8 +2866,8 @@ void Image::_get_clipped_src_and_dest_rects(const Ref<Image> &p_src, const Rect2
 		r_clipped_dest_rect.position.y = 0;
 	}
 
-	r_clipped_src_rect.size.x = MAX(0, MIN(r_clipped_src_rect.size.x, MIN(p_src->width - r_clipped_src_rect.position.x, width - r_clipped_dest_rect.position.x)));
-	r_clipped_src_rect.size.y = MAX(0, MIN(r_clipped_src_rect.size.y, MIN(p_src->height - r_clipped_src_rect.position.y, height - r_clipped_dest_rect.position.y)));
+	r_clipped_src_rect.size.x = MAX(0, MIN(r_clipped_src_rect.size.x, p_src->width - r_clipped_src_rect.position.x, width - r_clipped_dest_rect.position.x));
+	r_clipped_src_rect.size.y = MAX(0, MIN(r_clipped_src_rect.size.y, p_src->height - r_clipped_src_rect.position.y, height - r_clipped_dest_rect.position.y));
 
 	r_clipped_dest_rect.size.x = r_clipped_src_rect.size.x;
 	r_clipped_dest_rect.size.y = r_clipped_src_rect.size.y;

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -141,7 +141,7 @@ struct [[nodiscard]] Color {
 		const float _b = CLAMP(b, 0.0f, kMaxVal);
 
 		// Compute the maximum channel, no less than 1.0*2^-15
-		const float MaxChannel = MAX(MAX(_r, _g), MAX(_b, kMinVal));
+		const float MaxChannel = MAX(_r, _g, _b, kMinVal);
 
 		// Take the exponent of the maximum channel (rounding up the 9th bit) and
 		// add 15 to it.  When added to the channels, it causes the implicit '1.0'

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -119,6 +119,10 @@ static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
 #undef MAX
 #undef CLAMP
 
+// Discourage system headers included after us from defining there own versions.
+#define MIN MIN
+#define MAX MAX
+
 template <typename T>
 constexpr const T SIGN(const T m_v) {
 	return m_v > 0 ? +1.0f : (m_v < 0 ? -1.0f : 0.0f);
@@ -129,9 +133,19 @@ constexpr auto MIN(const T m_a, const T2 m_b) {
 	return m_a < m_b ? m_a : m_b;
 }
 
+template <typename T, typename T2, typename... Rest>
+constexpr auto MIN(const T m_a, const T2 m_b, const Rest... m_others) {
+	return MIN(MIN(m_a, m_b), m_others...);
+}
+
 template <typename T, typename T2>
 constexpr auto MAX(const T m_a, const T2 m_b) {
 	return m_a > m_b ? m_a : m_b;
+}
+
+template <typename T, typename T2, typename... Rest>
+constexpr auto MAX(const T m_a, const T2 m_b, const Rest... m_others) {
+	return MAX(MAX(m_a, m_b), m_others...);
 }
 
 template <typename T, typename T2, typename T3>

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -77,7 +77,7 @@ static Error _parse_material_library(const String &p_path, HashMap<String, Ref<S
 			float r = v[1].to_float();
 			float g = v[2].to_float();
 			float b = v[3].to_float();
-			float metalness = MAX(r, MAX(g, b));
+			float metalness = MAX(r, g, b);
 			current->set_metallic(metalness);
 		} else if (l.begins_with("Ns ")) {
 			//normal

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3240,14 +3240,14 @@ void CanvasItemEditor::_draw_ruler_tool() {
 					: (end_to_begin.y < 0 ? 3.0 * Math_PI / 2.0 : Math_PI / 2.0 - vertical_angle_rad);
 			real_t arc_1_end_angle = arc_1_start_angle + vertical_angle_rad;
 			// Constrain arc to triangle height & max size.
-			real_t arc_1_radius = MIN(MIN(arc_radius_max_length_percent * ruler_length, Math::abs(end_to_begin.y)), arc_max_radius);
+			real_t arc_1_radius = MIN(arc_radius_max_length_percent * ruler_length, Math::abs(end_to_begin.y), arc_max_radius);
 
 			real_t arc_2_start_angle = end_to_begin.x < 0
 					? (end_to_begin.y < 0 ? 0.0 : -horizontal_angle_rad)
 					: (end_to_begin.y < 0 ? Math_PI - horizontal_angle_rad : Math_PI);
 			real_t arc_2_end_angle = arc_2_start_angle + horizontal_angle_rad;
 			// Constrain arc to triangle width & max size.
-			real_t arc_2_radius = MIN(MIN(arc_radius_max_length_percent * ruler_length, Math::abs(end_to_begin.x)), arc_max_radius);
+			real_t arc_2_radius = MIN(arc_radius_max_length_percent * ruler_length, Math::abs(end_to_begin.x), arc_max_radius);
 
 			viewport->draw_arc(begin, arc_1_radius, arc_1_start_angle, arc_1_end_angle, arc_point_count, ruler_primary_color, Math::round(EDSCALE * arc_line_width));
 			viewport->draw_arc(end, arc_2_radius, arc_2_start_angle, arc_2_end_angle, arc_point_count, ruler_primary_color, Math::round(EDSCALE * arc_line_width));
@@ -3290,13 +3290,13 @@ void CanvasItemEditor::_draw_ruler_tool() {
 				h_angle_text_pos.y = end.y + text_height * 1.5;
 				if (Math::abs(text_pos2.x - h_angle_text_pos.x) < text_width) {
 					int height_multiplier = 1.5 + (int)grid_snap_active;
-					h_angle_text_pos.y = MAX(text_pos.y + height_multiplier * text_height, MAX(end.y + text_height * 1.5, text_pos2.y + height_multiplier * text_height));
+					h_angle_text_pos.y = MAX(text_pos.y + height_multiplier * text_height, end.y + text_height * 1.5, text_pos2.y + height_multiplier * text_height);
 				}
 			} else {
 				h_angle_text_pos.y = end.y - text_height * 0.5;
 				if (Math::abs(text_pos2.x - h_angle_text_pos.x) < text_width) {
 					int height_multiplier = 1 + (int)grid_snap_active;
-					h_angle_text_pos.y = MIN(text_pos.y - height_multiplier * text_height, MIN(end.y - text_height * 0.5, text_pos2.y - height_multiplier * text_height));
+					h_angle_text_pos.y = MIN(text_pos.y - height_multiplier * text_height, end.y - text_height * 0.5, text_pos2.y - height_multiplier * text_height);
 				}
 			}
 			viewport->draw_string_outline(font, h_angle_text_pos, TS->format_number(vformat(U"%d°", horizontal_angle)), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, outline_size, outline_color);

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -947,7 +947,7 @@ void TileMapLayerEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p
 							float right_opacity = CLAMP(Math::inverse_lerp((float)drawn_grid_rect.size.x, (float)(drawn_grid_rect.size.x - fading), (float)(pos_in_rect.x + 1)), 0.0f, 1.0f);
 							float top_opacity = CLAMP(Math::inverse_lerp(0.0f, (float)fading, (float)pos_in_rect.y), 0.0f, 1.0f);
 							float bottom_opacity = CLAMP(Math::inverse_lerp((float)drawn_grid_rect.size.y, (float)(drawn_grid_rect.size.y - fading), (float)(pos_in_rect.y + 1)), 0.0f, 1.0f);
-							float opacity = CLAMP(MIN(left_opacity, MIN(right_opacity, MIN(top_opacity, bottom_opacity))) + 0.1, 0.0f, 1.0f);
+							float opacity = CLAMP(MIN(left_opacity, right_opacity, top_opacity, bottom_opacity) + 0.1, 0.0f, 1.0f);
 
 							Transform2D tile_xform;
 							tile_xform.set_origin(tile_set->map_to_local(Vector2(x, y)));
@@ -3256,7 +3256,7 @@ void TileMapLayerEditorTerrainsPlugin::forward_canvas_draw_over_viewport(Control
 							float right_opacity = CLAMP(Math::inverse_lerp((float)drawn_grid_rect.size.x, (float)(drawn_grid_rect.size.x - fading), (float)(pos_in_rect.x + 1)), 0.0f, 1.0f);
 							float top_opacity = CLAMP(Math::inverse_lerp(0.0f, (float)fading, (float)pos_in_rect.y), 0.0f, 1.0f);
 							float bottom_opacity = CLAMP(Math::inverse_lerp((float)drawn_grid_rect.size.y, (float)(drawn_grid_rect.size.y - fading), (float)(pos_in_rect.y + 1)), 0.0f, 1.0f);
-							float opacity = CLAMP(MIN(left_opacity, MIN(right_opacity, MIN(top_opacity, bottom_opacity))) + 0.1, 0.0f, 1.0f);
+							float opacity = CLAMP(MIN(left_opacity, right_opacity, top_opacity, bottom_opacity) + 0.1, 0.0f, 1.0f);
 
 							Transform2D tile_xform;
 							tile_xform.set_origin(tile_set->map_to_local(Vector2(x, y)));
@@ -4354,7 +4354,7 @@ void TileMapLayerEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 				float right_opacity = CLAMP(Math::inverse_lerp((float)displayed_rect.size.x, (float)(displayed_rect.size.x - fading), (float)(pos_in_rect.x + 1)), 0.0f, 1.0f);
 				float top_opacity = CLAMP(Math::inverse_lerp(0.0f, (float)fading, (float)pos_in_rect.y), 0.0f, 1.0f);
 				float bottom_opacity = CLAMP(Math::inverse_lerp((float)displayed_rect.size.y, (float)(displayed_rect.size.y - fading), (float)(pos_in_rect.y + 1)), 0.0f, 1.0f);
-				float opacity = CLAMP(MIN(left_opacity, MIN(right_opacity, MIN(top_opacity, bottom_opacity))) + 0.1, 0.0f, 1.0f);
+				float opacity = CLAMP(MIN(left_opacity, right_opacity, top_opacity, bottom_opacity) + 0.1, 0.0f, 1.0f);
 
 				Transform2D tile_xform;
 				tile_xform.set_origin(tile_set->map_to_local(Vector2(x, y)));

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -7408,7 +7408,7 @@ float GLTFDocument::get_max_component(const Color &p_color) {
 	const float g = p_color.g;
 	const float b = p_color.b;
 
-	return MAX(MAX(r, g), b);
+	return MAX(r, g, b);
 }
 
 void GLTFDocument::_process_mesh_instances(Ref<GLTFState> p_state, Node *p_scene_root) {

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -4609,8 +4609,8 @@ bool TextServerAdvanced::_shaped_text_resize_object(const RID &p_shaped, const V
 			} else {
 				if (gl.font_rid.is_valid()) {
 					if (sd->orientation == ORIENTATION_HORIZONTAL) {
-						sd->ascent = MAX(sd->ascent, MAX(_font_get_ascent(gl.font_rid, gl.font_size) + _font_get_spacing(gl.font_rid, SPACING_TOP), -gl.y_off));
-						sd->descent = MAX(sd->descent, MAX(_font_get_descent(gl.font_rid, gl.font_size) + _font_get_spacing(gl.font_rid, SPACING_BOTTOM), gl.y_off));
+						sd->ascent = MAX(sd->ascent, _font_get_ascent(gl.font_rid, gl.font_size) + _font_get_spacing(gl.font_rid, SPACING_TOP), -gl.y_off);
+						sd->descent = MAX(sd->descent, _font_get_descent(gl.font_rid, gl.font_size) + _font_get_spacing(gl.font_rid, SPACING_BOTTOM), gl.y_off);
 					} else {
 						sd->ascent = MAX(sd->ascent, Math::round(_font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).x * 0.5));
 						sd->descent = MAX(sd->descent, Math::round(_font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).x * 0.5));
@@ -4889,8 +4889,8 @@ bool TextServerAdvanced::_shape_substr(ShapedTextDataAdvanced *p_new_sd, const S
 						} else {
 							if (gl.font_rid.is_valid()) {
 								if (p_new_sd->orientation == ORIENTATION_HORIZONTAL) {
-									p_new_sd->ascent = MAX(p_new_sd->ascent, MAX(_font_get_ascent(gl.font_rid, gl.font_size) + _font_get_spacing(gl.font_rid, SPACING_TOP), -gl.y_off));
-									p_new_sd->descent = MAX(p_new_sd->descent, MAX(_font_get_descent(gl.font_rid, gl.font_size) + _font_get_spacing(gl.font_rid, SPACING_BOTTOM), gl.y_off));
+									p_new_sd->ascent = MAX(p_new_sd->ascent, _font_get_ascent(gl.font_rid, gl.font_size) + _font_get_spacing(gl.font_rid, SPACING_TOP), -gl.y_off);
+									p_new_sd->descent = MAX(p_new_sd->descent, _font_get_descent(gl.font_rid, gl.font_size) + _font_get_spacing(gl.font_rid, SPACING_BOTTOM), gl.y_off);
 								} else {
 									p_new_sd->ascent = MAX(p_new_sd->ascent, Math::round(_font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).x * 0.5));
 									p_new_sd->descent = MAX(p_new_sd->descent, Math::round(_font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).x * 0.5));

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -308,7 +308,7 @@ float DisplayServerAndroid::screen_get_scale(int p_screen) const {
 	if (screen_size != Size2i()) {
 		float width_scale = screen_size.width / (float)OS_Android::DEFAULT_WINDOW_WIDTH;
 		float height_scale = screen_size.height / (float)OS_Android::DEFAULT_WINDOW_HEIGHT;
-		screen_scale = MIN(screen_scale, MIN(width_scale, height_scale));
+		screen_scale = MIN(screen_scale, width_scale, height_scale);
 	}
 
 	return screen_scale;

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -313,9 +313,9 @@ void GPUParticlesCollisionSDF3D::_find_closest_distance(const Vector3 &p_pos, co
 
 			inside_d = Math::sqrt(
 					(SIGN(ba.cross(nor).dot(pa)) + SIGN(cb.cross(nor).dot(pb)) + SIGN(ac.cross(nor).dot(pc)) < 2.0)
-							? MIN(MIN(
-										  Vector3_dot2(ba * CLAMP(ba.dot(pa) / Vector3_dot2(ba), 0.0, 1.0) - pa),
-										  Vector3_dot2(cb * CLAMP(cb.dot(pb) / Vector3_dot2(cb), 0.0, 1.0) - pb)),
+							? MIN(
+									  Vector3_dot2(ba * CLAMP(ba.dot(pa) / Vector3_dot2(ba), 0.0, 1.0) - pa),
+									  Vector3_dot2(cb * CLAMP(cb.dot(pb) / Vector3_dot2(cb), 0.0, 1.0) - pb),
 									  Vector3_dot2(ac * CLAMP(ac.dot(pc) / Vector3_dot2(ac), 0.0, 1.0) - pc))
 							: nor.dot(pa) * nor.dot(pa) / Vector3_dot2(nor));
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -3705,8 +3705,8 @@ void CodeEdit::_lines_edited_from(int p_from_line, int p_to_line) {
 	}
 
 	lines_edited_changed += p_to_line - p_from_line;
-	lines_edited_from = (lines_edited_from == -1) ? MIN(p_from_line, p_to_line) : MIN(lines_edited_from, MIN(p_from_line, p_to_line));
-	lines_edited_to = (lines_edited_to == -1) ? MAX(p_from_line, p_to_line) : MAX(lines_edited_from, MAX(p_from_line, p_to_line));
+	lines_edited_from = (lines_edited_from == -1) ? MIN(p_from_line, p_to_line) : MIN(lines_edited_from, p_from_line, p_to_line);
+	lines_edited_to = (lines_edited_to == -1) ? MAX(p_from_line, p_to_line) : MAX(lines_edited_from, p_from_line, p_to_line);
 }
 
 void CodeEdit::_text_set() {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -289,7 +289,7 @@ int PopupMenu::_get_item_height(int p_idx) const {
 	Size2 icon_size = _get_item_icon_size(p_idx);
 	int icon_height = icon_size.height;
 	if (items[p_idx].checkable_type && !items[p_idx].separator) {
-		icon_height = MAX(icon_height, MAX(theme_cache.checked->get_height(), theme_cache.radio_checked->get_height()));
+		icon_height = MAX(icon_height, theme_cache.checked->get_height(), theme_cache.radio_checked->get_height());
 	}
 
 	int text_height = items[p_idx].text_buf->get_size().height;
@@ -299,10 +299,13 @@ int PopupMenu::_get_item_height(int p_idx) const {
 
 	int separator_height = 0;
 	if (items[p_idx].separator) {
-		separator_height = MAX(theme_cache.separator_style->get_minimum_size().height, MAX(theme_cache.labeled_separator_left->get_minimum_size().height, theme_cache.labeled_separator_right->get_minimum_size().height));
+		separator_height = MAX(
+				theme_cache.separator_style->get_minimum_size().height,
+				theme_cache.labeled_separator_left->get_minimum_size().height,
+				theme_cache.labeled_separator_right->get_minimum_size().height);
 	}
 
-	return MAX(separator_height, MAX(text_height, icon_height));
+	return MAX(separator_height, text_height, icon_height);
 }
 
 int PopupMenu::_get_items_total_height() const {

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -43,7 +43,11 @@ Size2 TabBar::get_minimum_size() const {
 		return ms;
 	}
 
-	int y_margin = MAX(MAX(MAX(theme_cache.tab_unselected_style->get_minimum_size().height, theme_cache.tab_hovered_style->get_minimum_size().height), theme_cache.tab_selected_style->get_minimum_size().height), theme_cache.tab_disabled_style->get_minimum_size().height);
+	int y_margin = MAX(
+			theme_cache.tab_unselected_style->get_minimum_size().height,
+			theme_cache.tab_hovered_style->get_minimum_size().height,
+			theme_cache.tab_selected_style->get_minimum_size().height,
+			theme_cache.tab_disabled_style->get_minimum_size().height);
 
 	for (int i = 0; i < tabs.size(); i++) {
 		if (tabs[i].hidden) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -201,9 +201,9 @@ float TextEdit::Text::get_indent_offset(int p_line, bool p_rtl) const {
 		Vector<Vector2> sel = TS->shaped_text_get_selection(text_rid, 0, char_count);
 		for (const Vector2 v : sel) {
 			if (p_rtl) {
-				offset = MIN(v.x, MIN(v.y, offset));
+				offset = MIN(v.x, v.y, offset);
 			} else {
-				offset = MAX(v.x, MAX(v.y, offset));
+				offset = MAX(v.x, v.y, offset);
 			}
 		}
 		text_line.indent_ofs = (p_rtl) ? TS->shaped_text_get_size(text_rid).x - offset : offset;

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -1061,7 +1061,10 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 	float height_v = height / vertical_length;
 	float padding_v = p_uv2_padding / vertical_length;
 
-	float horizontal_length = MAX(MAX(2.0 * (top_radius + bottom_radius + p_uv2_padding), top_circumference + p_uv2_padding), bottom_circumference + p_uv2_padding);
+	float horizontal_length = MAX(
+			2.0 * (top_radius + bottom_radius + p_uv2_padding),
+			top_circumference + p_uv2_padding,
+			bottom_circumference + p_uv2_padding);
 	float center_h = 0.5 * (horizontal_length - p_uv2_padding) / horizontal_length;
 	float top_h = top_circumference / horizontal_length;
 	float bottom_h = bottom_circumference / horizontal_length;

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -72,7 +72,7 @@ void StyleBoxFlat::set_border_width_all(int p_size) {
 }
 
 int StyleBoxFlat::get_border_width_min() const {
-	return MIN(MIN(border_width[0], border_width[1]), MIN(border_width[2], border_width[3]));
+	return MIN(border_width[0], border_width[1], border_width[2], border_width[3]);
 }
 
 void StyleBoxFlat::set_border_width(Side p_side, int p_width) {
@@ -434,8 +434,8 @@ inline void adapt_values(int p_index_a, int p_index_b, real_t *adapted_values, c
 	real_t value_a = p_values[p_index_a];
 	real_t value_b = p_values[p_index_b];
 	real_t factor = MIN(1.0, p_width / (value_a + value_b));
-	adapted_values[p_index_a] = MIN(MIN(value_a * factor, p_max_a), adapted_values[p_index_a]);
-	adapted_values[p_index_b] = MIN(MIN(value_b * factor, p_max_b), adapted_values[p_index_b]);
+	adapted_values[p_index_a] = MIN(value_a * factor, p_max_a, adapted_values[p_index_a]);
+	adapted_values[p_index_b] = MIN(value_b * factor, p_max_b, adapted_values[p_index_b]);
 }
 
 Rect2 StyleBoxFlat::get_draw_rect(const Rect2 &p_rect) const {

--- a/servers/rendering/renderer_geometry_instance.cpp
+++ b/servers/rendering/renderer_geometry_instance.cpp
@@ -73,8 +73,8 @@ void RenderGeometryInstanceBase::set_transform(const Transform3D &p_transform, c
 	Vector3 model_scale_vec = p_transform.basis.get_scale_abs();
 	// handle non uniform scale here
 
-	float max_scale = MAX(model_scale_vec.x, MAX(model_scale_vec.y, model_scale_vec.z));
-	float min_scale = MIN(model_scale_vec.x, MIN(model_scale_vec.y, model_scale_vec.z));
+	float max_scale = MAX(model_scale_vec.x, model_scale_vec.y, model_scale_vec.z);
+	float min_scale = MIN(model_scale_vec.x, model_scale_vec.y, model_scale_vec.z);
 	non_uniform_scale = max_scale >= 0.0 && (min_scale / max_scale) < 0.9;
 
 	lod_model_scale = max_scale;

--- a/servers/rendering/renderer_rd/effects/fsr2.cpp
+++ b/servers/rendering/renderer_rd/effects/fsr2.cpp
@@ -216,7 +216,7 @@ static FfxErrorCode create_resource_rd(FfxFsr2Interface *p_backend_interface, co
 
 	if (res_desc.mipCount == 0) {
 		// Mipmap count must be derived from the resource's dimensions.
-		res_desc.mipCount = uint32_t(1 + floor(log2(MAX(MAX(res_desc.width, res_desc.height), res_desc.depth))));
+		res_desc.mipCount = uint32_t(1 + floor(log2(MAX(res_desc.width, res_desc.height, res_desc.depth))));
 	}
 
 	Vector<PackedByteArray> initial_data;

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -2653,7 +2653,7 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 			}
 
 			{
-				uint32_t dynamic_map_size = MAX(MAX(octree_size.x, octree_size.y), octree_size.z);
+				uint32_t dynamic_map_size = MAX(octree_size.x, octree_size.y, octree_size.z);
 				uint32_t oversample = nearest_power_of_2_templated(4);
 				int mipmap_index = 0;
 
@@ -3038,7 +3038,7 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 
 	if (p_dynamic_objects.size() && dynamic_maps.size()) {
 		Vector3i octree_size = gi->voxel_gi_get_octree_size(probe);
-		int multiplier = dynamic_maps[0].size / MAX(MAX(octree_size.x, octree_size.y), octree_size.z);
+		int multiplier = dynamic_maps[0].size / MAX(octree_size.x, octree_size.y, octree_size.z);
 
 		Transform3D oversample_scale;
 		oversample_scale.basis.scale(Vector3(multiplier, multiplier, multiplier));

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2167,7 +2167,7 @@ void RendererSceneCull::_update_instance_lightmap_captures(Instance *p_instance)
 
 		Vector3 inner_pos = ((lm_pos - bounds.position) / bounds.size) * 2.0 - Vector3(1.0, 1.0, 1.0);
 
-		real_t blend = MAX(Math::abs(inner_pos.x), MAX(Math::abs(inner_pos.y), Math::abs(inner_pos.z)));
+		real_t blend = MAX(Math::abs(inner_pos.x), Math::abs(inner_pos.y), Math::abs(inner_pos.z));
 		//make blend more rounded
 		blend = Math::lerp(inner_pos.length(), blend, blend);
 		blend *= blend;

--- a/tests/scene/test_tab_bar.h
+++ b/tests/scene/test_tab_bar.h
@@ -805,7 +805,7 @@ TEST_CASE("[SceneTree][TabBar] layout and offset") {
 		CHECK(tab_bar->get_tab_offset() == 0);
 		CHECK(tab_bar->get_minimum_size() == tab_bar->get_size());
 		CHECK(tab_bar->get_size().x == tab_rects[0].size.x + tab_rects[1].size.x + tab_rects[2].size.x);
-		CHECK(tab_bar->get_size().y == MAX(tab_rects[0].size.y, MAX(tab_rects[1].size.y, tab_rects[2].size.y)));
+		CHECK(tab_bar->get_size().y == MAX(tab_rects[0].size.y, tab_rects[1].size.y, tab_rects[2].size.y));
 
 		tab_bar->set_clip_tabs(true);
 		CHECK(tab_bar->get_clip_tabs());


### PR DESCRIPTION
Noticed there are a few instances of `MIN(a, MIN(b, c))` about the place, such as:

https://github.com/godotengine/godot/blob/594d64ec244b6b99321e2096987d4d69de4c8845/scene/gui/text_edit.cpp#L204
https://github.com/godotengine/godot/blob/594d64ec244b6b99321e2096987d4d69de4c8845/core/io/image.cpp#L2869

that might be more readable as `MIN(a, b, c)`.

No rush to substitute in existing code, but maybe nice to have in the future.