### PR TITLE
Add specific errors for use of keywords removed in Godot 4

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1087,7 +1087,27 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 				// Display a completion with identifiers.
 				make_completion_context(COMPLETION_IDENTIFIER, nullptr);
 				advance();
-				push_error(vformat(R"(Unexpected %s in class body.)", previous.get_debug_name()));
+				if (previous.get_identifier() == "export") {
+					push_error(R"(The "export" keyword was removed in Godot 4. Use an export annotation ("@export", "@export_range", etc.) instead.)");
+				} else if (previous.get_identifier() == "tool") {
+					push_error(R"(The "tool" keyword was removed in Godot 4. Use the "@tool" annotation instead.)");
+				} else if (previous.get_identifier() == "onready") {
+					push_error(R"(The "onready" keyword was removed in Godot 4. Use the "@onready" annotation instead.)");
+				} else if (previous.get_identifier() == "remote") {
+					push_error(R"(The "remote" keyword was removed in Godot 4. Use the "@rpc" annotation with "any_peer" instead.)");
+				} else if (previous.get_identifier() == "remotesync") {
+					push_error(R"(The "remotesync" keyword was removed in Godot 4. Use the "@rpc" annotation with "any_peer" and "call_local" instead.)");
+				} else if (previous.get_identifier() == "puppet") {
+					push_error(R"(The "puppet" keyword was removed in Godot 4. Use the "@rpc" annotation with "authority" instead.)");
+				} else if (previous.get_identifier() == "puppetsync") {
+					push_error(R"(The "puppetsync" keyword was removed in Godot 4. Use the "@rpc" annotation with "authority" and "call_local" instead.)");
+				} else if (previous.get_identifier() == "master") {
+					push_error(R"(The "master" keyword was removed in Godot 4. Use the "@rpc" annotation with "any_peer" and perform a check inside the function instead.)");
+				} else if (previous.get_identifier() == "mastersync") {
+					push_error(R"(The "mastersync" keyword was removed in Godot 4. Use the "@rpc" annotation with "any_peer" and "call_local", and perform a check inside the function instead.)");
+				} else {
+					push_error(vformat(R"(Unexpected %s in class body.)", previous.get_debug_name()));
+				}
 				break;
 		}
 		if (token.type != GDScriptTokenizer::Token::STATIC) {

--- a/modules/gdscript/tests/scripts/parser/errors/export_godot3_syntax.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/export_godot3_syntax.gd
@@ -1,0 +1,5 @@
+export var test = 3
+
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/parser/errors/export_godot3_syntax.out
+++ b/modules/gdscript/tests/scripts/parser/errors/export_godot3_syntax.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+The "export" keyword was removed in Godot 4. Use an export annotation ("@export", "@export_range", etc.) instead.

--- a/modules/gdscript/tests/scripts/parser/errors/export_godot3_syntax_with_args.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/export_godot3_syntax_with_args.gd
@@ -1,0 +1,5 @@
+export(int, "a", "b", "c") var test = 3
+
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/parser/errors/export_godot3_syntax_with_args.out
+++ b/modules/gdscript/tests/scripts/parser/errors/export_godot3_syntax_with_args.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+The "export" keyword was removed in Godot 4. Use an export annotation ("@export", "@export_range", etc.) instead.


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11542.

This PR adds a special error message for when keywords from Godot 3 that were removed in Godot 4 are used.
Keywords included are:
- `export`
- `tool`
- `onready`
- `remote`
- `remotesync`
- `puppet`
- `puppetsync`
- `master`
- `mastersync`

The error messages explain suitable replacements for the use of these keywords.