### PR TITLE
[macOS] Release keys and regenerate mouse events after native popup menu tracking.

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -253,6 +253,7 @@ public:
 	void send_event(NSEvent *p_event);
 	void send_window_event(const WindowData &p_wd, WindowEvent p_event);
 	void release_pressed_events();
+	void sync_mouse_state();
 	void get_key_modifier_state(unsigned int p_macos_state, Ref<InputEventWithModifiers> r_state) const;
 	void update_mouse_pos(WindowData &p_wd, NSPoint p_location_in_window);
 	void push_to_key_event_buffer(const KeyEvent &p_event);

--- a/platform/macos/native_menu_macos.mm
+++ b/platform/macos/native_menu_macos.mm
@@ -294,6 +294,9 @@ void NativeMenuMacOS::popup(const RID &p_rid, const Vector2i &p_position) {
 		position /= ds->screen_get_max_scale();
 
 		[md->menu popUpMenuPositioningItem:nil atLocation:NSMakePoint(position.x, position.y - 5) inView:nil]; // Menu vertical position doesn't include rounded corners, add `5` display pixels to better align it with Godot buttons.
+
+		ds->release_pressed_events(); // Note: context menu block main loop and consume events, pressed keys and mouse buttons should be released manually.
+		ds->sync_mouse_state();
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/100962
