### PR TITLE
Add move semantics to `Ref`

### DIFF
--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -127,6 +127,15 @@ public:
 		ref(p_from);
 	}
 
+	void operator=(Ref &&p_from) {
+		if (reference == p_from.reference) {
+			return;
+		}
+		unref();
+		reference = p_from.reference;
+		p_from.reference = nullptr;
+	}
+
 	template <typename T_Other>
 	void operator=(const Ref<T_Other> &p_from) {
 		ref_pointer<false>(Object::cast_to<T>(p_from.ptr()));
@@ -157,6 +166,11 @@ public:
 
 	Ref(const Ref &p_from) {
 		this->operator=(p_from);
+	}
+
+	Ref(Ref &&p_from) {
+		reference = p_from.reference;
+		p_from.reference = nullptr;
 	}
 
 	template <typename T_Other>


### PR DESCRIPTION
Small one that should get this type to benefit from move semantics (e.g. vector resizes, sorting, etc.).
It's used quite a lot in the codebase so it should be worth it.

Binary size decreases a tiny bit by this (100kb), differences in launch times are negligible for me.

Edit: I originally had `Array` and `Dictionary` too, but that's been too dangerous for me regarding `TypedDictionary` and `TypedArray`, so I removed them. `Ref` is more important anyway probably.