### PR TITLE
Bind `Node` method for getting its `SceneState`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -550,6 +550,13 @@
 				Returns [code]true[/code] if this node is an instance load placeholder. See [InstancePlaceholder] and [method set_scene_instance_load_placeholder].
 			</description>
 		</method>
+		<method name="get_scene_instance_state" qualifiers="const">
+			<return type="SceneState" />
+			<description>
+				Returns the [SceneState] of the scene that instantiated this node, if it was instantiated from a [PackedScene], otherwise returns [code]null[/code].
+				[b]Note:[/b] Only available in editor builds.
+			</description>
+		</method>
 		<method name="get_tree" qualifiers="const">
 			<return type="SceneTree" />
 			<description>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2739,6 +2739,9 @@ void Node::set_scene_instance_state(const Ref<SceneState> &p_state) {
 }
 
 Ref<SceneState> Node::get_scene_instance_state() const {
+#ifndef TOOLS_ENABLED
+	ERR_FAIL_V_MSG(Ref<SceneState>(), "Scene instance state is only available in editor builds.");
+#endif
 	return data.instance_state;
 }
 
@@ -3803,6 +3806,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("duplicate", "flags"), &Node::duplicate, DEFVAL(DUPLICATE_USE_INSTANTIATION | DUPLICATE_SIGNALS | DUPLICATE_GROUPS | DUPLICATE_SCRIPTS));
 	ClassDB::bind_method(D_METHOD("replace_by", "node", "keep_groups"), &Node::replace_by, DEFVAL(false));
 
+	ClassDB::bind_method(D_METHOD("get_scene_instance_state"), &Node::get_scene_instance_state);
 	ClassDB::bind_method(D_METHOD("set_scene_instance_load_placeholder", "load_placeholder"), &Node::set_scene_instance_load_placeholder);
 	ClassDB::bind_method(D_METHOD("get_scene_instance_load_placeholder"), &Node::get_scene_instance_load_placeholder);
 	ClassDB::bind_method(D_METHOD("set_editable_instance", "node", "is_editable"), &Node::set_editable_instance);


### PR DESCRIPTION
Closes godotengine/godot-proposals#12080.

This adds `Node::get_scene_instance_state` ~~and `Node::get_scene_inherited_state`~~ to the script bindings, for the reasons laid out in the proposal linked above.

~~`Node::get_scene_inherited_state` is of course somewhat redundant, given the newly exposed `SceneState.get_base_scene_state`, but the two seemed to go hand-in-hand, so I figured why not.~~