### PR TITLE
Fix drag and drop regression on touchscreens in `Tree`

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -351,6 +351,9 @@
 		<member name="columns" type="int" setter="set_columns" getter="get_columns" default="1">
 			The number of columns.
 		</member>
+		<member name="drag_scrolling_enabled" type="bool" setter="set_drag_scrolling_enabled" getter="is_drag_scrolling_enabled" default="false">
+			If [code]true[/code], enables scrolling by dragging on touchscreen devices. This disables drag and drop functionality while active.
+		</member>
 		<member name="drop_mode_flags" type="int" setter="set_drop_mode_flags" getter="get_drop_mode_flags" default="0">
 			The drop mode as an OR combination of flags. See [enum DropModeFlags] constants. Once dropping is done, reverts to [constant DROP_MODE_DISABLED]. Setting this during [method Control._can_drop_data] is recommended.
 			This controls the drop sections, i.e. the decision and drawing of possible drop locations based on the mouse position.

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3926,8 +3926,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 					drag_speed = 0;
 					drag_accum = 0;
 					drag_from = v_scroll->get_value();
-
-					drag_touching = DisplayServer::get_singleton()->is_touchscreen_available();
+					drag_touching = drag_scrolling_enabled && DisplayServer::get_singleton()->is_touchscreen_available();
 					drag_touching_deaccel = false;
 					if (drag_touching) {
 						set_process_internal(true);
@@ -3977,15 +3976,17 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventPanGesture> pan_gesture = p_event;
 	if (pan_gesture.is_valid()) {
-		double prev_v = v_scroll->get_value();
-		v_scroll->set_value(v_scroll->get_value() + v_scroll->get_page() * pan_gesture->get_delta().y / 8);
-
-		double prev_h = h_scroll->get_value();
+		//TODO: Calculate the appropriate value depending on the screen resolution, etc. (on Android `scroll_scale` = 8.0f is too inaccurate / too fast).
+		float scroll_scale = 32.0f;
+		Vector2 pan_gesture_scale = pan_gesture->get_delta() / scroll_scale;
 		if (is_layout_rtl()) {
-			h_scroll->set_value(h_scroll->get_value() + h_scroll->get_page() * -pan_gesture->get_delta().x / 8);
-		} else {
-			h_scroll->set_value(h_scroll->get_value() + h_scroll->get_page() * pan_gesture->get_delta().x / 8);
+			pan_gesture_scale.x = -pan_gesture_scale.x;
 		}
+
+		double prev_v = v_scroll->get_value();
+		double prev_h = h_scroll->get_value();
+		v_scroll->set_value(prev_v + v_scroll->get_page() * pan_gesture_scale.y);
+		h_scroll->set_value(prev_h + h_scroll->get_page() * pan_gesture_scale.x);
 
 		if (v_scroll->get_value() != prev_v || h_scroll->get_value() != prev_h) {
 			accept_event();
@@ -5284,6 +5285,18 @@ bool Tree::is_v_scroll_enabled() const {
 	return v_scroll_enabled;
 }
 
+void Tree::set_drag_scrolling_enabled(bool p_enable) {
+	if (drag_scrolling_enabled == p_enable) {
+		return;
+	}
+
+	drag_scrolling_enabled = p_enable;
+}
+
+bool Tree::is_drag_scrolling_enabled() const {
+	return drag_scrolling_enabled;
+}
+
 TreeItem *Tree::_search_item_text(TreeItem *p_at, const String &p_find, int *r_col, bool p_selectable, bool p_backwards) {
 	TreeItem *from = p_at;
 	TreeItem *loop = nullptr; // Safe-guard against infinite loop.
@@ -5645,8 +5658,8 @@ int Tree::get_drop_section_at_position(const Point2 &p_pos) const {
 }
 
 bool Tree::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
-	if (drag_touching) {
-		// Disable data drag & drop when touch dragging.
+	if (drag_scrolling_enabled) {
+		// Disable data drag & drop while performing drag scrolling.
 		return false;
 	}
 
@@ -5654,8 +5667,8 @@ bool Tree::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
 }
 
 Variant Tree::get_drag_data(const Point2 &p_point) {
-	if (drag_touching) {
-		// Disable data drag & drop when touch dragging.
+	if (drag_scrolling_enabled) {
+		// Disable data drag & drop while performing drag scrolling.
 		return Variant();
 	}
 
@@ -5880,6 +5893,9 @@ void Tree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_v_scroll_enabled", "h_scroll"), &Tree::set_v_scroll_enabled);
 	ClassDB::bind_method(D_METHOD("is_v_scroll_enabled"), &Tree::is_v_scroll_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_drag_scrolling_enabled", "enable"), &Tree::set_drag_scrolling_enabled);
+	ClassDB::bind_method(D_METHOD("is_drag_scrolling_enabled"), &Tree::is_drag_scrolling_enabled);
+
 	ClassDB::bind_method(D_METHOD("set_hide_folding", "hide"), &Tree::set_hide_folding);
 	ClassDB::bind_method(D_METHOD("is_folding_hidden"), &Tree::is_folding_hidden);
 
@@ -5913,6 +5929,7 @@ void Tree::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "select_mode", PROPERTY_HINT_ENUM, "Single,Row,Multi"), "set_select_mode", "get_select_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_horizontal_enabled"), "set_h_scroll_enabled", "is_h_scroll_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_vertical_enabled"), "set_v_scroll_enabled", "is_v_scroll_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_scrolling_enabled"), "set_drag_scrolling_enabled", "is_drag_scrolling_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_tooltip"), "set_auto_tooltip", "is_auto_tooltip_enabled");
 
 	ADD_SIGNAL(MethodInfo("item_selected"));

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -686,6 +686,7 @@ private:
 	bool click_handled = false;
 	bool allow_rmb_select = false;
 	bool scrolling = false;
+	bool drag_scrolling_enabled = false;
 
 	bool allow_reselect = false;
 	bool allow_search = true;
@@ -804,6 +805,8 @@ public:
 	bool is_h_scroll_enabled() const;
 	void set_v_scroll_enabled(bool p_enable);
 	bool is_v_scroll_enabled() const;
+	void set_drag_scrolling_enabled(bool p_enable);
+	bool is_drag_scrolling_enabled() const;
 
 	void set_cursor_can_exit_tree(bool p_enable);
 


### PR DESCRIPTION
Fixes #102256
Fixes #100393

This concerns the user actions `drag scrolling` and `drag & drop.` There were conflicts, and drag & drop was disabled 8 months ago. There are several options for scrolling but none for drag and drop on touchscreens.

More details: https://github.com/godotengine/godot/pull/94422#issuecomment-2751781391

This PR includes:
- new property `drag_scrolling_enabled` (default = false)
- `InputEventPanGesture` adaptation for Android touchscreens (TODO)

-----------



Test project: [bug_102256_treedragtest.zip](https://github.com/user-attachments/files/19471797/bug_102256_treedragtest.zip)

<details> <summary>14s video, Test on MacOS</summary>

--------------------

with `Emulate Touch From Mouse`

https://github.com/user-attachments/assets/4adcf1e4-0aa5-4b05-bed4-407a5095a07c
</details>


-------------------------

Android Editor (arm32 + arm64):
https://github.com/Alex2782/godot/releases/tag/android_editor.v4.5-2025-04-27


-------------------------

**TODOs:**

- [ ] `scrolling is the default behavior` [comment](https://github.com/godotengine/godot/pull/94422#issuecomment-2806655661)
- [ ] more tests on Android
- [ ] `scroll_scale` = 32 for `InputEventPanGesture` ok with `Apple Magic Trackpad / Mouse / Android Touchscreens` ?
- [ ] Android Editor: `drag_scrolling_enabled = true`, where drag and drop is not possible ?
