### PR TITLE
[macOS] Fix running with `DisplayServerHeadless`.

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -64,7 +64,7 @@
 #undef CursorShape
 
 class DisplayServerMacOS : public DisplayServer {
-	// No need to register with GDCLASS, it's platform-specific and nothing is added.
+	GDCLASS(DisplayServerMacOS, DisplayServer); // Note: required for Object::cast_to.
 
 	_THREAD_SAFE_CLASS_
 

--- a/platform/macos/godot_application.mm
+++ b/platform/macos/godot_application.mm
@@ -81,7 +81,7 @@
 		} break;
 	}
 
-	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	DisplayServerMacOS *ds = Object::cast_to<DisplayServerMacOS>(DisplayServer::get_singleton());
 	if (ds && keycode != Key::NONE) {
 		DisplayServerMacOS::KeyEvent ke;
 
@@ -109,7 +109,7 @@
 		[self mediaKeyEvent:keyCode state:keyState repeat:keyRepeat];
 	}
 
-	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	DisplayServerMacOS *ds = Object::cast_to<DisplayServerMacOS>(DisplayServer::get_singleton());
 	if (ds) {
 		if ([event type] == NSEventTypeLeftMouseDown || [event type] == NSEventTypeRightMouseDown || [event type] == NSEventTypeOtherMouseDown) {
 			if (ds->mouse_process_popups()) {

--- a/platform/macos/godot_application_delegate.mm
+++ b/platform/macos/godot_application_delegate.mm
@@ -48,7 +48,7 @@
 - (void)searchForItemsWithSearchString:(NSString *)searchString resultLimit:(NSInteger)resultLimit matchedItemHandler:(void (^)(NSArray *items))handleMatchedItems {
 	NSMutableArray *found_items = [[NSMutableArray alloc] init];
 
-	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	DisplayServerMacOS *ds = Object::cast_to<DisplayServerMacOS>(DisplayServer::get_singleton());
 	if (ds && ds->_help_get_search_callback().is_valid()) {
 		Callable cb = ds->_help_get_search_callback();
 
@@ -77,7 +77,7 @@
 }
 
 - (void)performActionForItem:(id)item {
-	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	DisplayServerMacOS *ds = Object::cast_to<DisplayServerMacOS>(DisplayServer::get_singleton());
 	if (ds && ds->_help_get_action_callback().is_valid()) {
 		Callable cb = ds->_help_get_action_callback();
 
@@ -118,7 +118,7 @@
 }
 
 - (void)system_theme_changed:(NSNotification *)notification {
-	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	DisplayServerMacOS *ds = Object::cast_to<DisplayServerMacOS>(DisplayServer::get_singleton());
 	if (ds) {
 		ds->emit_system_theme_changed();
 	}
@@ -199,7 +199,7 @@
 }
 
 - (void)applicationDidResignActive:(NSNotification *)notification {
-	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	DisplayServerMacOS *ds = Object::cast_to<DisplayServerMacOS>(DisplayServer::get_singleton());
 	if (ds) {
 		ds->mouse_process_popups(true);
 	}
@@ -215,7 +215,7 @@
 }
 
 - (void)globalMenuCallback:(id)sender {
-	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	DisplayServerMacOS *ds = Object::cast_to<DisplayServerMacOS>(DisplayServer::get_singleton());
 	if (ds) {
 		return ds->menu_callback(sender);
 	}
@@ -239,7 +239,7 @@
 }
 
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender {
-	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	DisplayServerMacOS *ds = Object::cast_to<DisplayServerMacOS>(DisplayServer::get_singleton());
 	if (ds && ds->has_window(DisplayServerMacOS::MAIN_WINDOW_ID)) {
 		ds->send_window_event(ds->get_window(DisplayServerMacOS::MAIN_WINDOW_ID), DisplayServerMacOS::WINDOW_EVENT_CLOSE_REQUEST);
 	}

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -46,6 +46,7 @@ class OS_MacOS : public OS_Unix {
 
 	id delegate = nullptr;
 	bool should_terminate = false;
+	bool main_stared = false;
 
 	JoypadApple *joypad_apple = nullptr;
 


### PR DESCRIPTION
Fixes regression from https://github.com/godotengine/godot/pull/104397

Since macOS now using native run loop, this code can be executed even if `DisplayServerHeadless` is used and `static_cast` won't work.