### PR TITLE
Add missing `initializer_list` constructor to TypedDictionary

### DIFF
--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -85,6 +85,10 @@ class Ref {
 
 	//virtual RefCounted * get_reference() const { return reference; }
 public:
+	static _FORCE_INLINE_ String get_class_static() {
+		return T::get_class_static();
+	}
+
 	_FORCE_INLINE_ bool operator==(const T *p_ptr) const {
 		return reference == p_ptr;
 	}

--- a/core/variant/typed_dictionary.h
+++ b/core/variant/typed_dictionary.h
@@ -189,6 +189,13 @@ struct GetTypeInfo<const TypedDictionary<K, V> &> {
 		_FORCE_INLINE_ TypedDictionary() {                                                                                                         \
 			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, T::get_class_static(), Variant());                                 \
 		}                                                                                                                                          \
+		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<m_type, T>> p_init) :                                                        \
+				Dictionary() {                                                                                                                     \
+			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, std::remove_pointer<T>::type::get_class_static(), Variant());      \
+			for (const KeyValue<m_type, T> &E : p_init) {                                                                                          \
+				operator[](E.key) = E.value;                                                                                                       \
+			}                                                                                                                                      \
+		}                                                                                                                                          \
 	};                                                                                                                                             \
 	template <typename T>                                                                                                                          \
 	struct GetTypeInfo<TypedDictionary<m_type, T>> {                                                                                               \

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -606,4 +606,28 @@ TEST_CASE("[Dictionary] Iteration") {
 	a2.clear();
 }
 
+TEST_CASE("[Dictionary] Object value init") {
+	Object *a = memnew(Object);
+	Object *b = memnew(Object);
+	TypedDictionary<double, Object *> tdict = {
+		{ 0.0, a },
+		{ 5.0, b },
+	};
+	CHECK_EQ(tdict[0.0], Variant(a));
+	CHECK_EQ(tdict[5.0], Variant(b));
+	memdelete(a);
+	memdelete(b);
+}
+
+TEST_CASE("[Dictionary] RefCounted value init") {
+	Ref<RefCounted> a = memnew(RefCounted);
+	Ref<RefCounted> b = memnew(RefCounted);
+	TypedDictionary<double, Ref<RefCounted>> tdict = {
+		{ 0.0, a },
+		{ 5.0, b },
+	};
+	CHECK_EQ(tdict[0.0], Variant(a));
+	CHECK_EQ(tdict[5.0], Variant(b));
+}
+
 } // namespace TestDictionary


### PR DESCRIPTION
Noticed while adding initializer_list support to godot-cpp https://github.com/godotengine/godot-cpp/pull/1750

This PR adds initializer list support to dictionarys for object and refcounted types, less useful in Godot, but will be very useful in gdextensions, it just needs to get merged here first.

After this PR goes in, I also want to add support for object and refcounted types as dictionary keys, this PR currently only supports them as values.