### PR TITLE
Remove redundant `ClassDB::locker` declaration

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -175,7 +175,6 @@ public:
 			~Lock();
 		};
 	};
-	inline static Locker locker;
 
 	static HashMap<StringName, ClassInfo> classes;
 	static HashMap<StringName, StringName> resource_base_extensions;


### PR DESCRIPTION
Followup to https://github.com/godotengine/godot/pull/102449

This removes the redundant `inline static Locker locker;` declaration, which appears unnecessary since all relevant members (`RWLock lock` and `thread_state`) are already declared as `static` or `thread_local`.

Tested with my own projects, as I am not sure, which example projects cover edge cases the best.

I'm not 100% sure this is correct, so I'd like to ask the OP, @RandomShaper, for review.

Thanks!