### PR TITLE
[RTL] Add option to override autowrap mode per paragraph.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -502,6 +502,7 @@
 			<param index="3" name="st_parser" type="int" enum="TextServer.StructuredTextParser" default="0" />
 			<param index="4" name="justification_flags" type="int" enum="TextServer.JustificationFlag" is_bitfield="true" default="163" />
 			<param index="5" name="tab_stops" type="PackedFloat32Array" default="PackedFloat32Array()" />
+			<param index="6" name="autowrap_mode" type="int" enum="RichTextLabel.AutowrapMode" default="4" />
 			<description>
 				Adds a [code skip-lint][p][/code] tag to the tag stack.
 			</description>
@@ -774,6 +775,21 @@
 		</constant>
 		<constant name="LIST_DOTS" value="3" enum="ListType">
 			Each list item has a filled circle marker.
+		</constant>
+		<constant name="AUTOWRAP_OFF" value="0" enum="AutowrapMode">
+			Autowrap is disabled.
+		</constant>
+		<constant name="AUTOWRAP_ARBITRARY" value="1" enum="AutowrapMode">
+			Wraps the text inside the node's bounding rectangle by allowing to break lines at arbitrary positions, which is useful when very limited space is available.
+		</constant>
+		<constant name="AUTOWRAP_WORD" value="2" enum="AutowrapMode">
+			Wraps the text inside the node's bounding rectangle by soft-breaking between words.
+		</constant>
+		<constant name="AUTOWRAP_WORD_SMART" value="3" enum="AutowrapMode">
+			Behaves similarly to [constant AUTOWRAP_WORD], but force-breaks a word if that single word does not fit in one line.
+		</constant>
+		<constant name="AUTOWRAP_INHERITED" value="4" enum="AutowrapMode">
+			Use default [RichTextLabel] autowrap mode, see [member autowrap_mode].
 		</constant>
 		<constant name="MENU_COPY" value="0" enum="MenuItems">
 			Copies the selected text.

--- a/misc/extension_api_validation/4.0-stable_4.1-stable.expected
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable.expected
@@ -255,7 +255,7 @@ Function was made `const`. No adjustments should be necessary.
 GH-75250 & GH-76401
 -------------------
 Validate extension JSON: Error: Hash changed for 'classes/RichTextLabel/methods/push_paragraph', from 3DD1D1C2 to BFDC71FE. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_paragraph/arguments': size changed value in new API, from 4 to 6.
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_paragraph/arguments': size changed value in new API, from 4 to 7.
 
 Added a optional parameters with default values. No adjustments should be necessary.
 

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -24,3 +24,10 @@ Validate extension JSON: Error: Field 'classes/OpenXRAPIExtension/methods/regist
 Validate extension JSON: Error: Field 'classes/OpenXRAPIExtension/methods/unregister_projection_views_extension/arguments/0': type changed value in new API, from "OpenXRExtensionWrapperExtension" to "OpenXRExtensionWrapper".
 
 Switched from `OpenXRExtensionWrapperExtension` to parent `OpenXRExtensionWrapper`. Compatibility methods registered.
+
+
+GH-1XXXXXX
+----------
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_paragraph/arguments': size changed value in new API, from 6 to 7.
+
+Optional argument added. Compatibility method registered.

--- a/scene/gui/rich_text_label.compat.inc
+++ b/scene/gui/rich_text_label.compat.inc
@@ -58,6 +58,10 @@ bool RichTextLabel::_remove_paragraph_bind_compat_91098(int p_paragraph) {
 	return remove_paragraph(p_paragraph, false);
 }
 
+void RichTextLabel::_push_paragraph_bind_compat_1XXXXX(HorizontalAlignment p_alignment, Control::TextDirection p_direction, const String &p_language, TextServer::StructuredTextParser p_st_parser, BitField<TextServer::JustificationFlag> p_jst_flags, const PackedFloat32Array &p_tab_stops) {
+	push_paragraph(p_alignment, p_direction, p_language, p_st_parser, p_jst_flags, p_tab_stops, AUTOWRAP_INHERITED);
+}
+
 void RichTextLabel::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("push_font", "font", "font_size"), &RichTextLabel::_push_font_bind_compat_79053);
 	ClassDB::bind_compatibility_method(D_METHOD("set_table_column_expand", "column", "expand", "ratio"), &RichTextLabel::_set_table_column_expand_bind_compat_79053);
@@ -66,6 +70,7 @@ void RichTextLabel::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("push_meta", "data"), &RichTextLabel::_push_meta_bind_compat_89024);
 	ClassDB::bind_compatibility_method(D_METHOD("add_image", "image", "width", "height", "color", "inline_align", "region"), &RichTextLabel::_add_image_bind_compat_80410, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()));
 	ClassDB::bind_compatibility_method(D_METHOD("remove_paragraph", "paragraph"), &RichTextLabel::_remove_paragraph_bind_compat_91098);
+	ClassDB::bind_compatibility_method(D_METHOD("push_paragraph", "alignment", "base_direction", "language", "st_parser", "justification_flags", "tab_stops"), &RichTextLabel::_push_paragraph_bind_compat_1XXXXX, DEFVAL(TextServer::DIRECTION_AUTO), DEFVAL(""), DEFVAL(TextServer::STRUCTURED_TEXT_DEFAULT), DEFVAL(TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_SKIP_LAST_LINE | TextServer::JUSTIFICATION_DO_NOT_SKIP_SINGLE_LINE), DEFVAL(PackedFloat32Array()));
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -66,6 +66,14 @@ public:
 		META_UNDERLINE_ON_HOVER,
 	};
 
+	enum AutowrapMode {
+		AUTOWRAP_OFF = TextServer::AUTOWRAP_OFF,
+		AUTOWRAP_ARBITRARY = TextServer::AUTOWRAP_ARBITRARY,
+		AUTOWRAP_WORD = TextServer::AUTOWRAP_WORD,
+		AUTOWRAP_WORD_SMART = TextServer::AUTOWRAP_WORD_SMART,
+		AUTOWRAP_INHERITED,
+	};
+
 	enum ItemType {
 		ITEM_FRAME,
 		ITEM_TEXT,
@@ -139,6 +147,7 @@ protected:
 	void _add_image_bind_compat_80410(const Ref<Texture2D> &p_image, const int p_width, const int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region);
 	bool _remove_paragraph_bind_compat_91098(int p_paragraph);
 	void _set_table_column_expand_bind_compat_101482(int p_column, bool p_expand, int p_ratio);
+	void _push_paragraph_bind_compat_1XXXXX(HorizontalAlignment p_alignment, Control::TextDirection p_direction, const String &p_language, TextServer::StructuredTextParser p_st_parser, BitField<TextServer::JustificationFlag> p_jst_flags, const PackedFloat32Array &p_tab_stops);
 	static void _bind_compatibility_methods();
 #endif
 
@@ -317,6 +326,7 @@ private:
 		Control::TextDirection direction = Control::TEXT_DIRECTION_AUTO;
 		TextServer::StructuredTextParser st_parser = TextServer::STRUCTURED_TEXT_DEFAULT;
 		BitField<TextServer::JustificationFlag> jst_flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_SKIP_LAST_LINE | TextServer::JUSTIFICATION_DO_NOT_SKIP_SINGLE_LINE;
+		AutowrapMode autowrap_mode = AUTOWRAP_INHERITED;
 		PackedFloat32Array tab_stops;
 		ItemParagraph() { type = ITEM_PARAGRAPH; }
 	};
@@ -594,6 +604,7 @@ private:
 	int _find_margin(Item *p_item, const Ref<Font> &p_base_font, int p_base_font_size);
 	PackedFloat32Array _find_tab_stops(Item *p_item);
 	HorizontalAlignment _find_alignment(Item *p_item);
+	AutowrapMode _find_aw_flags(Item *p_item);
 	BitField<TextServer::JustificationFlag> _find_jst_flags(Item *p_item);
 	TextServer::Direction _find_direction(Item *p_item);
 	TextServer::StructuredTextParser _find_stt(Item *p_item);
@@ -713,7 +724,7 @@ public:
 	void push_underline();
 	void push_strikethrough();
 	void push_language(const String &p_language);
-	void push_paragraph(HorizontalAlignment p_alignment, Control::TextDirection p_direction = Control::TEXT_DIRECTION_INHERITED, const String &p_language = "", TextServer::StructuredTextParser p_st_parser = TextServer::STRUCTURED_TEXT_DEFAULT, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_SKIP_LAST_LINE | TextServer::JUSTIFICATION_DO_NOT_SKIP_SINGLE_LINE, const PackedFloat32Array &p_tab_stops = PackedFloat32Array());
+	void push_paragraph(HorizontalAlignment p_alignment, Control::TextDirection p_direction = Control::TEXT_DIRECTION_INHERITED, const String &p_language = "", TextServer::StructuredTextParser p_st_parser = TextServer::STRUCTURED_TEXT_DEFAULT, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_SKIP_LAST_LINE | TextServer::JUSTIFICATION_DO_NOT_SKIP_SINGLE_LINE, const PackedFloat32Array &p_tab_stops = PackedFloat32Array(), AutowrapMode p_autowrap_mode = AUTOWRAP_INHERITED);
 	void push_indent(int p_level);
 	void push_list(int p_level, ListType p_list, bool p_capitalize, const String &p_bullet = String::utf8("•"));
 	void push_meta(const Variant &p_meta, MetaUnderline p_underline_mode = META_UNDERLINE_ALWAYS, const String &p_tooltip = String());
@@ -894,6 +905,7 @@ public:
 };
 
 VARIANT_ENUM_CAST(RichTextLabel::ListType);
+VARIANT_ENUM_CAST(RichTextLabel::AutowrapMode);
 VARIANT_ENUM_CAST(RichTextLabel::MenuItems);
 VARIANT_ENUM_CAST(RichTextLabel::MetaUnderline);
 VARIANT_BITFIELD_CAST(RichTextLabel::ImageUpdateMask);


### PR DESCRIPTION
Allow overriding autowrap mode for paragraphs (e.g., in table cells):

```bbcode
[p aw=a]Lorem ipsum.[/p]

[p aw=w]Lorem ipsum.[/p]

[p aw=o]Lorem ipsum.[/p]
```
<img width="86" alt="Screenshot 2025-03-27 at 12 10 14" src="https://github.com/user-attachments/assets/e1e8e042-a6f9-4463-a59d-fd7847403c5b" />
