### PR TITLE
Optimize `LocalVector::push_back` for non-trivial objects

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -64,7 +64,7 @@ public:
 		}
 
 		if constexpr (!std::is_trivially_constructible_v<T> && !force_trivial) {
-			memnew_placement(&data[count++], T(p_elem));
+			memnew_placement(&data[count++], T(std::move(p_elem)));
 		} else {
 			data[count++] = std::move(p_elem);
 		}


### PR DESCRIPTION
I happened to stumble upon this discrepancy between how trivially constructible objects and non-trivially constructible objects were being constructed in `LocalVector::push_back`, where trivially constructible objects seemed to be using `std::move` (thus avoiding the redundant copy) and non-trivially constructible objects were not.

It seemed to be something that was missed as part of #100477, as mentioned by @Ivorforce [here](https://github.com/godotengine/godot/pull/100477#issuecomment-2755852311).

Some quick for-loop profiling using this code with MSVC...

```cpp
constexpr int N = 100000;
constexpr int M = 8;
LocalVector<Variant> vector;
vector.reserve(N * M);

Variant variants[M] = {
	true,
	42,
	42.0f,
	String("Lorem ipsum dolor sit amet, consectetur adipiscing elit."),
	Vector3(),
	Transform2D(),
	Transform3D(),
	Projection()
};

auto t0 = std::chrono::high_resolution_clock::now();
for (int i = 0; i < N; ++i) {
	for (int j = 0; j < M; ++j) {
		vector.push_back(variants[j]);
	}
}
auto t1 = std::chrono::high_resolution_clock::now();
std::cout << std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count() << "ms\n";
```

... yielded 15.48 ms without the change and 12.89 ms with the change, so roughly a 16% reduction for `Variant` specifically, but obviously depends greatly on what the object does in its copy constructor.

(This also seems to be the only thing standing in the way of `LocalVector` being able to contain move-only types.)