### PR TITLE
Fix editor layout direction change on translation change.

### DIFF
--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -504,10 +504,10 @@ String TranslationServer::get_tool_locale() {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint() || Engine::get_singleton()->is_project_manager_hint()) {
 		const PackedStringArray &locales = editor_domain->get_loaded_locales();
-		if (locales.is_empty()) {
-			return "en";
+		if (locales.has(locale)) {
+			return locale;
 		}
-		return locales[0];
+		return "en";
 	} else {
 #else
 	{

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -621,6 +621,10 @@ void EditorNode::update_preview_themes(int p_mode) {
 
 void EditorNode::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			callable_mp(this, &EditorNode::_titlebar_resized).call_deferred();
+		} break;
+
 		case NOTIFICATION_POSTINITIALIZE: {
 			EditorHelp::generate_doc();
 #if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -97,6 +97,10 @@ void ProjectManager::_notification(int p_what) {
 			_titlebar_resized();
 		} break;
 
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			_titlebar_resized();
+		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			set_process_shortcut_input(is_visible_in_tree());
 		} break;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/104690
- Fixes macOS title bar layout on editor translation change (when direction is changing).