### PR TITLE
Document what will fail if V-HACD is disabled

### DIFF
--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -118,6 +118,7 @@
 				Calculate a [ConvexPolygonShape3D] from the mesh.
 				If [param clean] is [code]true[/code] (default), duplicate and interior vertices are removed automatically. You can set it to [code]false[/code] to make the process faster if not needed.
 				If [param simplify] is [code]true[/code], the geometry can be further simplified to reduce the number of vertices. Disabled by default.
+				[b]Note:[/b] This method requires the V-HACD module to be enabled, otherwise it will return an empty shape.
 			</description>
 		</method>
 		<method name="create_outline" qualifiers="const">

--- a/doc/classes/MeshInstance3D.xml
+++ b/doc/classes/MeshInstance3D.xml
@@ -37,6 +37,7 @@
 				This helper creates a [StaticBody3D] child node with a [ConvexPolygonShape3D] collision shape calculated from the mesh geometry. It's mainly used for testing.
 				If [param clean] is [code]true[/code] (default), duplicate and interior vertices are removed automatically. You can set it to [code]false[/code] to make the process faster if not needed.
 				If [param simplify] is [code]true[/code], the geometry can be further simplified to reduce the number of vertices. Disabled by default.
+				[b]Note:[/b] This method requires the V-HACD module to be enabled, otherwise it will fail.
 			</description>
 		</method>
 		<method name="create_debug_tangents">

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -902,7 +902,7 @@ void Mesh::clear_cache() const {
 
 #ifndef _3D_DISABLED
 Vector<Ref<Shape3D>> Mesh::convex_decompose(const Ref<MeshConvexDecompositionSettings> &p_settings) const {
-	ERR_FAIL_NULL_V(convex_decomposition_function, Vector<Ref<Shape3D>>());
+	ERR_FAIL_NULL_V_MSG(convex_decomposition_function, Vector<Ref<Shape3D>>(), "The V-HACD module isn't enabled. Recompile the Godot editor or export template binary with the `module_vhacd_enabled=yes` SCons option.");
 
 	Ref<TriangleMesh> tm = generate_triangle_mesh();
 	ERR_FAIL_COND_V(tm.is_null(), Vector<Ref<Shape3D>>());

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -929,7 +929,7 @@ void Mesh::clear_cache() const {
 
 #ifndef PHYSICS_3D_DISABLED
 Vector<Ref<Shape3D>> Mesh::convex_decompose(const Ref<MeshConvexDecompositionSettings> &p_settings) const {
-	ERR_FAIL_NULL_V(convex_decomposition_function, Vector<Ref<Shape3D>>());
+	ERR_FAIL_NULL_V_MSG(convex_decomposition_function, Vector<Ref<Shape3D>>(), "The V-HACD module isn't enabled. Recompile the Godot editor or export template binary with the `module_vhacd_enabled=yes` SCons option.");
 
 	Ref<TriangleMesh> tm = generate_triangle_mesh();
 	ERR_FAIL_COND_V(tm.is_null(), Vector<Ref<Shape3D>>());


### PR DESCRIPTION
## What problem(s) does this PR solve?

The lack of mention of what V-HACD does in any place of the engine but the source code, given one looks carefully.

The V-HACD module is what allows `Mesh::create_convex_shape()` to work.

It creates a `convex_decompose()` static function, then provides it to `Mesh::convex_decomposition_function`, which makes `Mesh::convex_decompose()` not fail.

## Additional information

I have added in the documentation that V-HACD is needed to call functions that require it, as well as an error message to when the callback above is null instead of no message.