### PR TITLE
Remove macros from FontFile test case

### DIFF
--- a/tests/scene/test_fontfile.h
+++ b/tests/scene/test_fontfile.h
@@ -37,70 +37,53 @@
 
 namespace TestFontfile {
 
+TEST_CASE("[FontFile] Load Dynamic Font - getters") {
 #ifdef MODULE_FREETYPE_ENABLED
-// Macro to generate tests for getters.
-#define GETTER_TEST(m_name, m_getter, m_default_value)                                                                                          \
-	TEST_CASE("[FontFile] Load Dynamic Font - get-set " m_name) {                                                                               \
-		String test_dynamic_font = "thirdparty/fonts/NotoSansHebrew_Regular.woff2";                                                             \
-		Ref<FontFile> ff;                                                                                                                       \
-		ff.instantiate();                                                                                                                       \
-		CHECK(ff->load_dynamic_font(test_dynamic_font) == OK);                                                                                  \
-		CHECK_MESSAGE(ff->m_getter == m_default_value, "Unexpected original value for ", m_name, " : ", ff->m_getter, " != ", m_default_value); \
-	}
+	String test_dynamic_font = "thirdparty/fonts/NotoSansHebrew_Regular.woff2";
+	Ref<FontFile> ff;
+	ff.instantiate();
+	CHECK(ff->load_dynamic_font(test_dynamic_font) == OK);
 
-#define GETTER_TEST_REAL(m_name, m_getter, m_default_value)                                                                                                      \
-	TEST_CASE("[FontFile] Load Dynamic Font - get-set " m_name) {                                                                                                \
-		String test_dynamic_font = "thirdparty/fonts/NotoSansHebrew_Regular.woff2";                                                                              \
-		Ref<FontFile> ff;                                                                                                                                        \
-		ff.instantiate();                                                                                                                                        \
-		CHECK(ff->load_dynamic_font(test_dynamic_font) == OK);                                                                                                   \
-		CHECK_MESSAGE(ff->m_getter == doctest::Approx(m_default_value), "Unexpected original value for ", m_name, " : ", ff->m_getter, " != ", m_default_value); \
-	}
+	// These properties come from the font file itself.
+	CHECK(ff->get_font_name() == "Noto Sans Hebrew");
+	CHECK(ff->get_font_style_name() == "Regular");
+	CHECK(ff->get_font_weight() == 400);
+	CHECK(ff->get_font_stretch() == 100);
+	CHECK(ff->get_opentype_features() == Dictionary());
 
-Dictionary expected_ot_name_strings() {
-	Dictionary d = Dictionary();
-	d["en"] = Dictionary();
-	((Dictionary)d["en"])["copyright"] = "Copyright 2022 The Noto Project Authors (https://github.com/notofonts/hebrew)";
-	((Dictionary)d["en"])["family_name"] = "Noto Sans Hebrew";
-	((Dictionary)d["en"])["subfamily_name"] = "Regular";
-	((Dictionary)d["en"])["full_name"] = "Noto Sans Hebrew Regular";
-	((Dictionary)d["en"])["unique_identifier"] = "2.003;GOOG;NotoSansHebrew-Regular";
-	((Dictionary)d["en"])["version"] = "Version 2.003";
-	((Dictionary)d["en"])["postscript_name"] = "NotoSansHebrew-Regular";
-	((Dictionary)d["en"])["trademark"] = "Noto is a trademark of Google Inc.";
-	((Dictionary)d["en"])["license"] = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://scripts.sil.org/OFL";
-	((Dictionary)d["en"])["license_url"] = "https://scripts.sil.org/OFL";
-	((Dictionary)d["en"])["designer"] = "Monotype Design Team";
-	((Dictionary)d["en"])["designer_url"] = "http://www.monotype.com/studio";
-	((Dictionary)d["en"])["description"] = "Designed by Monotype design team.";
-	((Dictionary)d["en"])["manufacturer"] = "Monotype Imaging Inc.";
-	((Dictionary)d["en"])["vendor_url"] = "http://www.google.com/get/noto/";
+	Dictionary expected_ot_name_strings;
+	Dictionary en_dict;
+	en_dict["copyright"] = "Copyright 2022 The Noto Project Authors (https://github.com/notofonts/hebrew)";
+	en_dict["family_name"] = "Noto Sans Hebrew";
+	en_dict["subfamily_name"] = "Regular";
+	en_dict["full_name"] = "Noto Sans Hebrew Regular";
+	en_dict["unique_identifier"] = "2.003;GOOG;NotoSansHebrew-Regular";
+	en_dict["version"] = "Version 2.003";
+	en_dict["postscript_name"] = "NotoSansHebrew-Regular";
+	en_dict["trademark"] = "Noto is a trademark of Google Inc.";
+	en_dict["license"] = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://scripts.sil.org/OFL";
+	en_dict["license_url"] = "https://scripts.sil.org/OFL";
+	en_dict["designer"] = "Monotype Design Team";
+	en_dict["designer_url"] = "http://www.monotype.com/studio";
+	en_dict["description"] = "Designed by Monotype design team.";
+	en_dict["manufacturer"] = "Monotype Imaging Inc.";
+	en_dict["vendor_url"] = "http://www.google.com/get/noto/";
+	expected_ot_name_strings["en"] = en_dict;
+	CHECK(ff->get_ot_name_strings() == expected_ot_name_strings);
 
-	return d;
-}
-
-// These properties come from the font file itself.
-GETTER_TEST("font_name", get_font_name(), "Noto Sans Hebrew")
-GETTER_TEST("font_style_name", get_font_style_name(), "Regular")
-GETTER_TEST("font_weight", get_font_weight(), 400)
-GETTER_TEST("font_stretch", get_font_stretch(), 100)
-GETTER_TEST("opentype_features", get_opentype_features(), Dictionary())
-GETTER_TEST("ot_name_strings", get_ot_name_strings(), expected_ot_name_strings())
-
-// These are dependent on size and potentially other state. Act as regression tests based of arbitrary small size 10 and large size 100.
-GETTER_TEST_REAL("height-small", get_height(10), (real_t)14)
-GETTER_TEST_REAL("ascent-small", get_ascent(10), (real_t)11)
-GETTER_TEST_REAL("descent-small", get_descent(10), (real_t)3)
-GETTER_TEST_REAL("underline_position-small", get_underline_position(10), (real_t)1.25)
-GETTER_TEST_REAL("underline_thickness-small", get_underline_thickness(10), (real_t)0.5)
-
-GETTER_TEST_REAL("height-large", get_height(100), (real_t)137)
-GETTER_TEST_REAL("ascent-large", get_ascent(100), (real_t)107)
-GETTER_TEST_REAL("descent-large", get_descent(100), (real_t)30)
-GETTER_TEST_REAL("underline_position-large", get_underline_position(100), (real_t)12.5)
-GETTER_TEST_REAL("underline_thickness-large", get_underline_thickness(100), (real_t)5)
-
+	// These are dependent on size and potentially other state. Act as regression tests based of arbitrary small size 10 and large size 100.
+	CHECK(ff->get_height(10) == doctest::Approx((real_t)14));
+	CHECK(ff->get_ascent(10) == doctest::Approx((real_t)11));
+	CHECK(ff->get_descent(10) == doctest::Approx((real_t)3));
+	CHECK(ff->get_underline_position(10) == doctest::Approx((real_t)1.25));
+	CHECK(ff->get_underline_thickness(10) == doctest::Approx((real_t)0.5));
+	CHECK(ff->get_height(100) == doctest::Approx((real_t)137));
+	CHECK(ff->get_ascent(100) == doctest::Approx((real_t)107));
+	CHECK(ff->get_descent(100) == doctest::Approx((real_t)30));
+	CHECK(ff->get_underline_position(100) == doctest::Approx((real_t)12.5));
+	CHECK(ff->get_underline_thickness(100) == doctest::Approx((real_t)5));
 #endif
+}
 
 TEST_CASE("[FontFile] Create font file and check data") {
 	// Create test instance.


### PR DESCRIPTION
- related https://github.com/godotengine/godot/pull/81503

Improves codestyle for the FontFile tests.
Macros are not needed here, and it is easier to use and debug without them.
The font only needs to be loaded once so I put them all in one test case.
Also removed the custom message since it doesn't really add any information compared to the default CHECK.