### PR TITLE
Fix Apple's incorrect mapping of Joy-Con (L) and Joy-Con (R) face buttons

### DIFF
--- a/drivers/apple/joypad_apple.h
+++ b/drivers/apple/joypad_apple.h
@@ -46,7 +46,8 @@ struct GameController {
 	RumbleContext *rumble_context API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) = nil;
 	NSInteger ff_effect_timestamp = 0;
 	bool force_feedback = false;
-	bool nintendo_button_layout = false;
+	bool double_nintendo_joycon_layout = false;
+	bool single_nintendo_joycon_layout = false;
 
 	bool axis_changed[(int)JoyAxis::MAX];
 	double axis_value[(int)JoyAxis::MAX];

--- a/drivers/apple/joypad_apple.mm
+++ b/drivers/apple/joypad_apple.mm
@@ -151,7 +151,11 @@ GameController::GameController(int p_joy_id, GCController *p_controller) :
 
 	if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, *)) {
 		if ([controller.productCategory isEqualToString:@"Switch Pro Controller"] || [controller.productCategory isEqualToString:@"Nintendo Switch Joy-Con (L/R)"]) {
-			nintendo_button_layout = true;
+			double_nintendo_joycon_layout = true;
+		}
+
+		if ([controller.productCategory isEqualToString:@"Nintendo Switch Joy-Con (L)"] || [controller.productCategory isEqualToString:@"Nintendo Switch Joy-Con (R)"]) {
+			single_nintendo_joycon_layout = true;
 		}
 	}
 
@@ -171,7 +175,7 @@ GameController::GameController(int p_joy_id, GCController *p_controller) :
 			GCControllerButtonInput *buttonB = profile.buttons[GCInputButtonB];
 			GCControllerButtonInput *buttonX = profile.buttons[GCInputButtonX];
 			GCControllerButtonInput *buttonY = profile.buttons[GCInputButtonY];
-			if (nintendo_button_layout) {
+			if (double_nintendo_joycon_layout) {
 				if (buttonA) {
 					buttonA.pressedChangedHandler = BUTTON(JoyButton::B);
 				}
@@ -183,6 +187,19 @@ GameController::GameController(int p_joy_id, GCController *p_controller) :
 				}
 				if (buttonY) {
 					buttonY.pressedChangedHandler = BUTTON(JoyButton::X);
+				}
+			} else if (single_nintendo_joycon_layout) {
+				if (buttonA) {
+					buttonA.pressedChangedHandler = BUTTON(JoyButton::A);
+				}
+				if (buttonB) {
+					buttonB.pressedChangedHandler = BUTTON(JoyButton::X);
+				}
+				if (buttonX) {
+					buttonX.pressedChangedHandler = BUTTON(JoyButton::B);
+				}
+				if (buttonY) {
+					buttonY.pressedChangedHandler = BUTTON(JoyButton::Y);
 				}
 			} else {
 				if (buttonA) {
@@ -318,11 +335,16 @@ GameController::GameController(int p_joy_id, GCController *p_controller) :
 	} else if (controller.extendedGamepad != nil) {
 		GCExtendedGamepad *gamepad = controller.extendedGamepad;
 
-		if (nintendo_button_layout) {
+		if (double_nintendo_joycon_layout) {
 			gamepad.buttonA.pressedChangedHandler = BUTTON(JoyButton::B);
 			gamepad.buttonB.pressedChangedHandler = BUTTON(JoyButton::A);
 			gamepad.buttonX.pressedChangedHandler = BUTTON(JoyButton::Y);
 			gamepad.buttonY.pressedChangedHandler = BUTTON(JoyButton::X);
+		} else if (single_nintendo_joycon_layout) {
+			gamepad.buttonA.pressedChangedHandler = BUTTON(JoyButton::A);
+			gamepad.buttonB.pressedChangedHandler = BUTTON(JoyButton::X);
+			gamepad.buttonX.pressedChangedHandler = BUTTON(JoyButton::B);
+			gamepad.buttonY.pressedChangedHandler = BUTTON(JoyButton::Y);
 		} else {
 			gamepad.buttonA.pressedChangedHandler = BUTTON(JoyButton::A);
 			gamepad.buttonB.pressedChangedHandler = BUTTON(JoyButton::B);


### PR DESCRIPTION
Apple's Game Controller mapping of the individual Joy-Con (L) and Joy-Con (R) controllers swaps the left and right face buttons. This PR detects the Joy-Cons and performs the necessary swap to have the face buttons correctly mapped.

It also renames the `nintendo_button_layout` variable to `double_nintendo_joycon_layout` to be more specific and accurate, since it specifically applies to "full" Nintendo controllers.