### PR TITLE
Fix a few GDScript warning messages for grammar and consistency

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3011,7 +3011,7 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 		GDScriptParser::IdentifierNode *id = static_cast<GDScriptParser::IdentifierNode *>(p_assignment->assignee);
 		// Use == 1 here because this assignment was already counted in the beginning of the function.
 		if (id->source == GDScriptParser::IdentifierNode::LOCAL_VARIABLE && id->variable_source && id->variable_source->assignments == 1) {
-			parser->push_warning(p_assignment, GDScriptWarning::UNASSIGNED_VARIABLE_OP_ASSIGN, id->name);
+			parser->push_warning(p_assignment, GDScriptWarning::UNASSIGNED_VARIABLE_OP_ASSIGN, id->name, Variant::get_operator_name(p_assignment->variant_op));
 		}
 	}
 #endif

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -40,10 +40,10 @@ String GDScriptWarning::get_message() const {
 	switch (code) {
 		case UNASSIGNED_VARIABLE:
 			CHECK_SYMBOLS(1);
-			return vformat(R"(The variable "%s" was used before being assigned a value.)", symbols[0]);
+			return vformat(R"(The variable "%s" is used before being assigned a value.)", symbols[0]);
 		case UNASSIGNED_VARIABLE_OP_ASSIGN:
-			CHECK_SYMBOLS(1);
-			return vformat(R"(Using assignment with operation but the variable "%s" was not previously assigned a value.)", symbols[0]);
+			CHECK_SYMBOLS(2);
+			return vformat(R"(The variable "%s" is modified with the compound-assignment operator "%s=" but was not previously initialized.)", symbols[0], symbols[1]);
 		case UNUSED_VARIABLE:
 			CHECK_SYMBOLS(1);
 			return vformat(R"(The local variable "%s" is declared but never used in the block. If this is intended, prefix it with an underscore: "_%s".)", symbols[0], symbols[0]);
@@ -79,7 +79,7 @@ String GDScriptWarning::get_message() const {
 		case STANDALONE_EXPRESSION:
 			return "Standalone expression (the line may have no effect).";
 		case STANDALONE_TERNARY:
-			return "Standalone ternary operator: the return value is being discarded.";
+			return "Standalone ternary operator (the return value is being discarded).";
 		case INCOMPATIBLE_TERNARY:
 			return "Values of the ternary operator are not mutually compatible.";
 		case UNTYPED_DECLARATION:
@@ -117,17 +117,17 @@ String GDScriptWarning::get_message() const {
 		case REDUNDANT_STATIC_UNLOAD:
 			return R"(The "@static_unload" annotation is redundant because the file does not have a class with static variables.)";
 		case REDUNDANT_AWAIT:
-			return R"("await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.)";
+			return R"("await" keyword is unnecessary because the expression isn't a coroutine nor a signal.)";
 		case ASSERT_ALWAYS_TRUE:
 			return "Assert statement is redundant because the expression is always true.";
 		case ASSERT_ALWAYS_FALSE:
 			return "Assert statement will raise an error because the expression is always false.";
 		case INTEGER_DIVISION:
-			return "Integer division, decimal part will be discarded.";
+			return "Integer division. Decimal part will be discarded.";
 		case NARROWING_CONVERSION:
 			return "Narrowing conversion (float is converted to int and loses precision).";
 		case INT_AS_ENUM_WITHOUT_CAST:
-			return "Integer used when an enum value is expected. If this is intended cast the integer to the enum type.";
+			return "Integer used when an enum value is expected. If this is intended, cast the integer to the enum type using the \"as\" keyword.";
 		case INT_AS_ENUM_WITHOUT_MATCH:
 			CHECK_SYMBOLS(3);
 			return vformat(R"(Cannot %s %s as Enum "%s": no enum member has matching value.)", symbols[0], symbols[1], symbols[2]);
@@ -138,7 +138,7 @@ String GDScriptWarning::get_message() const {
 			return "Empty script file.";
 		case DEPRECATED_KEYWORD:
 			CHECK_SYMBOLS(2);
-			return vformat(R"(The "%s" keyword is deprecated and will be removed in a future release, please replace its uses by "%s".)", symbols[0], symbols[1]);
+			return vformat(R"(The "%s" keyword is deprecated and will be removed in a future release. Please replace it with "%s".)", symbols[0], symbols[1]);
 		case CONFUSABLE_IDENTIFIER:
 			CHECK_SYMBOLS(1);
 			return vformat(R"(The identifier "%s" has misleading characters and might be confused with something else.)", symbols[0]);
@@ -159,7 +159,7 @@ String GDScriptWarning::get_message() const {
 			return vformat(R"*(The method "%s()" overrides a method from native class "%s". This won't be called by the engine and may not work as expected.)*", symbols[0], symbols[1]);
 		case GET_NODE_DEFAULT_WITHOUT_ONREADY:
 			CHECK_SYMBOLS(1);
-			return vformat(R"*(The default value is using "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
+			return vformat(R"*(The default value uses "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
 		case ONREADY_WITH_EXPORT:
 			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
 #ifndef DISABLE_DEPRECATED

--- a/modules/gdscript/tests/scripts/analyzer/warnings/get_node_without_onready.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/get_node_without_onready.out
@@ -1,11 +1,11 @@
 GDTEST_OK
-~~ WARNING at line 5: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "$" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
-~~ WARNING at line 6: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "get_node()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
-~~ WARNING at line 7: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "get_node()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
-~~ WARNING at line 8: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "get_node()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
-~~ WARNING at line 9: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "$" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
-~~ WARNING at line 11: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "%" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
-~~ WARNING at line 12: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "$" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
-~~ WARNING at line 13: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "get_node()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
-~~ WARNING at line 14: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value is using "%" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+~~ WARNING at line 5: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value uses "$" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+~~ WARNING at line 6: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value uses "get_node()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+~~ WARNING at line 7: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value uses "get_node()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+~~ WARNING at line 8: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value uses "get_node()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+~~ WARNING at line 9: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value uses "$" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+~~ WARNING at line 11: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value uses "%" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+~~ WARNING at line 12: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value uses "$" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+~~ WARNING at line 13: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value uses "get_node()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+~~ WARNING at line 14: (GET_NODE_DEFAULT_WITHOUT_ONREADY) The default value uses "%" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
 warn

--- a/modules/gdscript/tests/scripts/analyzer/warnings/redundant_await.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/redundant_await.out
@@ -1,10 +1,10 @@
 GDTEST_OK
-~~ WARNING at line 26: (REDUNDANT_AWAIT) "await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.
-~~ WARNING at line 28: (REDUNDANT_AWAIT) "await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.
-~~ WARNING at line 32: (REDUNDANT_AWAIT) "await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.
-~~ WARNING at line 38: (REDUNDANT_AWAIT) "await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.
-~~ WARNING at line 44: (REDUNDANT_AWAIT) "await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.
-~~ WARNING at line 45: (REDUNDANT_AWAIT) "await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.
-~~ WARNING at line 46: (REDUNDANT_AWAIT) "await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.
-~~ WARNING at line 51: (REDUNDANT_AWAIT) "await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.
-~~ WARNING at line 53: (REDUNDANT_AWAIT) "await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.
+~~ WARNING at line 26: (REDUNDANT_AWAIT) "await" keyword is unnecessary because the expression isn't a coroutine nor a signal.
+~~ WARNING at line 28: (REDUNDANT_AWAIT) "await" keyword is unnecessary because the expression isn't a coroutine nor a signal.
+~~ WARNING at line 32: (REDUNDANT_AWAIT) "await" keyword is unnecessary because the expression isn't a coroutine nor a signal.
+~~ WARNING at line 38: (REDUNDANT_AWAIT) "await" keyword is unnecessary because the expression isn't a coroutine nor a signal.
+~~ WARNING at line 44: (REDUNDANT_AWAIT) "await" keyword is unnecessary because the expression isn't a coroutine nor a signal.
+~~ WARNING at line 45: (REDUNDANT_AWAIT) "await" keyword is unnecessary because the expression isn't a coroutine nor a signal.
+~~ WARNING at line 46: (REDUNDANT_AWAIT) "await" keyword is unnecessary because the expression isn't a coroutine nor a signal.
+~~ WARNING at line 51: (REDUNDANT_AWAIT) "await" keyword is unnecessary because the expression isn't a coroutine nor a signal.
+~~ WARNING at line 53: (REDUNDANT_AWAIT) "await" keyword is unnecessary because the expression isn't a coroutine nor a signal.

--- a/modules/gdscript/tests/scripts/parser/features/nested_arithmetic.out
+++ b/modules/gdscript/tests/scripts/parser/features/nested_arithmetic.out
@@ -1,21 +1,21 @@
 GDTEST_OK
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
-~~ WARNING at line 19: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
+~~ WARNING at line 19: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.
 2.718
 
 2.718

--- a/modules/gdscript/tests/scripts/parser/warnings/enum_assign_int_without_casting.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/enum_assign_int_without_casting.out
@@ -1,8 +1,8 @@
 GDTEST_OK
-~~ WARNING at line 5: (INT_AS_ENUM_WITHOUT_CAST) Integer used when an enum value is expected. If this is intended cast the integer to the enum type.
-~~ WARNING at line 9: (INT_AS_ENUM_WITHOUT_CAST) Integer used when an enum value is expected. If this is intended cast the integer to the enum type.
-~~ WARNING at line 12: (INT_AS_ENUM_WITHOUT_CAST) Integer used when an enum value is expected. If this is intended cast the integer to the enum type.
-~~ WARNING at line 14: (INT_AS_ENUM_WITHOUT_CAST) Integer used when an enum value is expected. If this is intended cast the integer to the enum type.
+~~ WARNING at line 5: (INT_AS_ENUM_WITHOUT_CAST) Integer used when an enum value is expected. If this is intended, cast the integer to the enum type using the "as" keyword.
+~~ WARNING at line 9: (INT_AS_ENUM_WITHOUT_CAST) Integer used when an enum value is expected. If this is intended, cast the integer to the enum type using the "as" keyword.
+~~ WARNING at line 12: (INT_AS_ENUM_WITHOUT_CAST) Integer used when an enum value is expected. If this is intended, cast the integer to the enum type using the "as" keyword.
+~~ WARNING at line 14: (INT_AS_ENUM_WITHOUT_CAST) Integer used when an enum value is expected. If this is intended, cast the integer to the enum type using the "as" keyword.
 0
 1
 0

--- a/modules/gdscript/tests/scripts/parser/warnings/integer_division.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/integer_division.out
@@ -1,2 +1,2 @@
 GDTEST_OK
-~~ WARNING at line 3: (INTEGER_DIVISION) Integer division, decimal part will be discarded.
+~~ WARNING at line 3: (INTEGER_DIVISION) Integer division. Decimal part will be discarded.

--- a/modules/gdscript/tests/scripts/parser/warnings/standalone_ternary.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/standalone_ternary.out
@@ -1,4 +1,4 @@
 GDTEST_OK
-~~ WARNING at line 2: (STANDALONE_TERNARY) Standalone ternary operator: the return value is being discarded.
-~~ WARNING at line 3: (STANDALONE_TERNARY) Standalone ternary operator: the return value is being discarded.
+~~ WARNING at line 2: (STANDALONE_TERNARY) Standalone ternary operator (the return value is being discarded).
+~~ WARNING at line 3: (STANDALONE_TERNARY) Standalone ternary operator (the return value is being discarded).
 1

--- a/modules/gdscript/tests/scripts/parser/warnings/unassigned_variable.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/unassigned_variable.out
@@ -1,7 +1,7 @@
 GDTEST_OK
-~~ WARNING at line 3: (UNASSIGNED_VARIABLE) The variable "unassigned" was used before being assigned a value.
-~~ WARNING at line 7: (UNASSIGNED_VARIABLE) The variable "a" was used before being assigned a value.
-~~ WARNING at line 8: (UNASSIGNED_VARIABLE) The variable "a" was used before being assigned a value.
+~~ WARNING at line 3: (UNASSIGNED_VARIABLE) The variable "unassigned" is used before being assigned a value.
+~~ WARNING at line 7: (UNASSIGNED_VARIABLE) The variable "a" is used before being assigned a value.
+~~ WARNING at line 8: (UNASSIGNED_VARIABLE) The variable "a" is used before being assigned a value.
 <null>
 <null>
 <null>

--- a/modules/gdscript/tests/scripts/parser/warnings/unassigned_variable_op_assign.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/unassigned_variable_op_assign.out
@@ -1,2 +1,2 @@
 GDTEST_OK
-~~ WARNING at line 4: (UNASSIGNED_VARIABLE_OP_ASSIGN) Using assignment with operation but the variable "__" was not previously assigned a value.
+~~ WARNING at line 4: (UNASSIGNED_VARIABLE_OP_ASSIGN) The variable "__" is modified with the compound-assignment operator "+=" but was not previously initialized.

--- a/modules/gdscript/tests/scripts/runtime/features/await_without_coroutine.out
+++ b/modules/gdscript/tests/scripts/runtime/features/await_without_coroutine.out
@@ -1,3 +1,3 @@
 GDTEST_OK
-~~ WARNING at line 4: (REDUNDANT_AWAIT) "await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.
+~~ WARNING at line 4: (REDUNDANT_AWAIT) "await" keyword is unnecessary because the expression isn't a coroutine nor a signal.
 awaited


### PR DESCRIPTION
This PR slightly changes a few of the GDScript warning messages to have better grammar and consistency with the rest of the messages.
- `UNASSIGNED_VARIABLE`
- `UNASSIGNED_VARIABLE_OP_ASSIGN`
- `STANDALONE_TERNARY`
- `REDUNDANT_AWAIT`
- `INTEGER_DIVISION`
- `INT_AS_ENUM_WITHOUT_CAST`
- `DEPRECATED_KEYWORD`

>[!NOTE]
> With the wording and grammar being changed, this could possibly make it more difficult for people to research these warnings, depending on how much leeway search engines give. I think it *should* be fine, but it may be something to consider before merging.