### PR TITLE
Remove `build_array()` and `build_dictionary()` from tests

### DIFF
--- a/modules/multiplayer/tests/test_multiplayer_spawner.h
+++ b/modules/multiplayer/tests/test_multiplayer_spawner.h
@@ -36,17 +36,6 @@
 #include "../multiplayer_spawner.h"
 
 namespace TestMultiplayerSpawner {
-
-static inline Array build_array() {
-	return Array();
-}
-template <typename... Targs>
-static inline Array build_array(Variant item, Targs... Fargs) {
-	Array a = build_array(Fargs...);
-	a.push_front(item);
-	return a;
-}
-
 class Wasp : public Node {
 	GDCLASS(Wasp, Node);
 

--- a/modules/multiplayer/tests/test_scene_multiplayer.h
+++ b/modules/multiplayer/tests/test_scene_multiplayer.h
@@ -36,17 +36,6 @@
 #include "../scene_multiplayer.h"
 
 namespace TestSceneMultiplayer {
-
-static inline Array build_array() {
-	return Array();
-}
-template <typename... Targs>
-static inline Array build_array(Variant item, Targs... Fargs) {
-	Array a = build_array(Fargs...);
-	a.push_front(item);
-	return a;
-}
-
 TEST_CASE("[Multiplayer][SceneMultiplayer] Defaults") {
 	Ref<SceneMultiplayer> scene_multiplayer;
 	scene_multiplayer.instantiate();
@@ -175,7 +164,7 @@ TEST_CASE("[Multiplayer][SceneMultiplayer][SceneTree] Send Authentication") {
 		Ref<MultiplayerPeer> multiplayer_peer = scene_multiplayer->get_multiplayer_peer();
 		int peer_id = 42;
 		multiplayer_peer->emit_signal(SNAME("peer_connected"), peer_id);
-		SIGNAL_CHECK("peer_authenticating", build_array(build_array(peer_id)));
+		SIGNAL_CHECK("peer_authenticating", { { peer_id } });
 
 		CHECK_EQ(scene_multiplayer->send_auth(peer_id, String("It's me").to_ascii_buffer()), Error::OK);
 
@@ -193,7 +182,7 @@ TEST_CASE("[Multiplayer][SceneMultiplayer][SceneTree] Send Authentication") {
 		int peer_id = 42;
 		multiplayer_peer->emit_signal(SNAME("peer_connected"), peer_id);
 		multiplayer_peer->emit_signal(SNAME("peer_disconnected"), peer_id);
-		SIGNAL_CHECK("peer_authentication_failed", build_array(build_array(peer_id)));
+		SIGNAL_CHECK("peer_authentication_failed", { { peer_id } });
 
 		SIGNAL_UNWATCH(scene_multiplayer.ptr(), "peer_authentication_failed");
 	}
@@ -215,7 +204,7 @@ TEST_CASE("[Multiplayer][SceneMultiplayer][SceneTree] Send Authentication") {
 
 		CHECK_EQ(scene_multiplayer->poll(), Error::OK);
 
-		SIGNAL_CHECK("peer_authentication_failed", build_array(build_array(first_peer_id), build_array(second_peer_id)));
+		SIGNAL_CHECK("peer_authentication_failed", Array({ { first_peer_id }, { second_peer_id } }));
 
 		SIGNAL_UNWATCH(scene_multiplayer.ptr(), "peer_authentication_failed");
 	}

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -35,26 +35,6 @@
 #include "tests/test_tools.h"
 
 namespace TestArray {
-
-static inline Array build_array() {
-	return Array();
-}
-template <typename... Targs>
-static inline Array build_array(Variant item, Targs... Fargs) {
-	Array a = build_array(Fargs...);
-	a.push_front(item);
-	return a;
-}
-static inline Dictionary build_dictionary() {
-	return Dictionary();
-}
-template <typename... Targs>
-static inline Dictionary build_dictionary(Variant key, Variant item, Targs... Fargs) {
-	Dictionary d = build_dictionary(Fargs...);
-	d[key] = item;
-	return d;
-}
-
 TEST_CASE("[Array] initializer list") {
 	Array arr = { 0, 1, "test", true, { 0.0, 1.0 } };
 	CHECK(arr.size() == 5);
@@ -348,7 +328,7 @@ TEST_CASE("[Array] slice()") {
 
 TEST_CASE("[Array] Duplicate array") {
 	// a = [1, [2, 2], {3: 3}]
-	Array a = build_array(1, build_array(2, 2), build_dictionary(3, 3));
+	Array a = { 1, { 2, 2 }, Dictionary({ { 3, 3 } }) };
 
 	// Deep copy
 	Array deep_a = a.duplicate(true);
@@ -411,7 +391,7 @@ TEST_CASE("[Array] Duplicate recursive array") {
 
 TEST_CASE("[Array] Hash array") {
 	// a = [1, [2, 2], {3: 3}]
-	Array a = build_array(1, build_array(2, 2), build_dictionary(3, 3));
+	Array a = { 1, { 2, 2 }, Dictionary({ { 3, 3 } }) };
 	uint32_t original_hash = a.hash();
 
 	a.push_back(1);
@@ -461,9 +441,9 @@ TEST_CASE("[Array] Empty comparison") {
 }
 
 TEST_CASE("[Array] Flat comparison") {
-	Array a1 = build_array(1);
-	Array a2 = build_array(1);
-	Array other_a = build_array(2);
+	Array a1 = { 1 };
+	Array a2 = { 1 };
+	Array other_a = { 2 };
 
 	// test both operator== and operator!=
 	CHECK_EQ(a1, a1); // compare self
@@ -476,12 +456,12 @@ TEST_CASE("[Array] Flat comparison") {
 
 TEST_CASE("[Array] Nested array comparison") {
 	// a1 = [[[1], 2], 3]
-	Array a1 = build_array(build_array(build_array(1), 2), 3);
+	Array a1 = { { { 1 }, 2 }, 3 };
 
 	Array a2 = a1.duplicate(true);
 
 	// other_a = [[[1, 0], 2], 3]
-	Array other_a = build_array(build_array(build_array(1, 0), 2), 3);
+	Array other_a = { { { 1, 0 }, 2 }, 3 };
 
 	// test both operator== and operator!=
 	CHECK_EQ(a1, a1); // compare self
@@ -494,12 +474,12 @@ TEST_CASE("[Array] Nested array comparison") {
 
 TEST_CASE("[Array] Nested dictionary comparison") {
 	// a1 = [{1: 2}, 3]
-	Array a1 = build_array(build_dictionary(1, 2), 3);
+	Array a1 = { Dictionary({ { 1, 2 } }), 3 };
 
 	Array a2 = a1.duplicate(true);
 
 	// other_a = [{1: 0}, 3]
-	Array other_a = build_array(build_dictionary(1, 0), 3);
+	Array other_a = { Dictionary({ { 1, 0 } }), 3 };
 
 	// test both operator== and operator!=
 	CHECK_EQ(a1, a1); // compare self
@@ -561,8 +541,8 @@ TEST_CASE("[Array] Recursive self comparison") {
 }
 
 TEST_CASE("[Array] Iteration") {
-	Array a1 = build_array(1, 2, 3);
-	Array a2 = build_array(1, 2, 3);
+	Array a1 = { 1, 2, 3 };
+	Array a2 = { 1, 2, 3 };
 
 	int idx = 0;
 	for (Variant &E : a1) {
@@ -585,10 +565,10 @@ TEST_CASE("[Array] Iteration") {
 }
 
 TEST_CASE("[Array] Iteration and modification") {
-	Array a1 = build_array(1, 2, 3);
-	Array a2 = build_array(2, 3, 4);
-	Array a3 = build_array(1, 2, 3);
-	Array a4 = build_array(1, 2, 3);
+	Array a1 = { 1, 2, 3 };
+	Array a2 = { 2, 3, 4 };
+	Array a3 = { 1, 2, 3 };
+	Array a4 = { 1, 2, 3 };
 	a3.make_read_only();
 
 	int idx = 0;
@@ -651,14 +631,14 @@ static bool _find_custom_callable(const Variant &p_val) {
 }
 
 TEST_CASE("[Array] Test find_custom") {
-	Array a1 = build_array(1, 3, 4, 5, 8, 9);
+	Array a1 = { 1, 3, 4, 5, 8, 9 };
 	// Find first even number.
 	int index = a1.find_custom(callable_mp_static(_find_custom_callable));
 	CHECK_EQ(index, 2);
 }
 
 TEST_CASE("[Array] Test rfind_custom") {
-	Array a1 = build_array(1, 3, 4, 5, 8, 9);
+	Array a1 = { 1, 3, 4, 5, 8, 9 };
 	// Find last even number.
 	int index = a1.rfind_custom(callable_mp_static(_find_custom_callable));
 	CHECK_EQ(index, 4);

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -34,26 +34,6 @@
 #include "tests/test_macros.h"
 
 namespace TestDictionary {
-
-static inline Array build_array() {
-	return Array();
-}
-template <typename... Targs>
-static inline Array build_array(Variant item, Targs... Fargs) {
-	Array a = build_array(Fargs...);
-	a.push_front(item);
-	return a;
-}
-static inline Dictionary build_dictionary() {
-	return Dictionary();
-}
-template <typename... Targs>
-static inline Dictionary build_dictionary(Variant key, Variant item, Targs... Fargs) {
-	Dictionary d = build_dictionary(Fargs...);
-	d[key] = item;
-	return d;
-}
-
 TEST_CASE("[Dictionary] Assignment using bracket notation ([])") {
 	Dictionary map;
 	map["Hello"] = 0;
@@ -202,9 +182,13 @@ TEST_CASE("[Dictionary] keys() and values()") {
 
 TEST_CASE("[Dictionary] Duplicate dictionary") {
 	// d = {1: {1: 1}, {2: 2}: [2], [3]: 3}
-	Dictionary k2 = build_dictionary(2, 2);
-	Array k3 = build_array(3);
-	Dictionary d = build_dictionary(1, build_dictionary(1, 1), k2, build_array(2), k3, 3);
+	Dictionary k2 = { { 2, 2 } };
+	Array k3 = { 3 };
+	Dictionary d = {
+		{ 1, Dictionary({ { 1, 1 } }) },
+		{ k2, Array({ 2 }) },
+		{ k3, 3 }
+	};
 
 	// Deep copy
 	Dictionary deep_d = d.duplicate(true);
@@ -322,9 +306,13 @@ TEST_CASE("[Dictionary] Duplicate recursive dictionary on keys") {
 
 TEST_CASE("[Dictionary] Hash dictionary") {
 	// d = {1: {1: 1}, {2: 2}: [2], [3]: 3}
-	Dictionary k2 = build_dictionary(2, 2);
-	Array k3 = build_array(3);
-	Dictionary d = build_dictionary(1, build_dictionary(1, 1), k2, build_array(2), k3, 3);
+	Dictionary k2 = { { 2, 2 } };
+	Array k3 = { 3 };
+	Dictionary d = {
+		{ 1, Dictionary({ { 1, 1 } }) },
+		{ k2, Array({ 2 }) },
+		{ k3, 3 }
+	};
 	uint32_t original_hash = d.hash();
 
 	// Modify dict change the hash
@@ -394,9 +382,9 @@ TEST_CASE("[Dictionary] Empty comparison") {
 }
 
 TEST_CASE("[Dictionary] Flat comparison") {
-	Dictionary d1 = build_dictionary(1, 1);
-	Dictionary d2 = build_dictionary(1, 1);
-	Dictionary other_d = build_dictionary(2, 1);
+	Dictionary d1 = { { 1, 1 } };
+	Dictionary d2 = { { 1, 1 } };
+	Dictionary other_d = { { 2, 1 } };
 
 	// test both operator== and operator!=
 	CHECK_EQ(d1, d1); // compare self
@@ -409,12 +397,12 @@ TEST_CASE("[Dictionary] Flat comparison") {
 
 TEST_CASE("[Dictionary] Nested dictionary comparison") {
 	// d1 = {1: {2: {3: 4}}}
-	Dictionary d1 = build_dictionary(1, build_dictionary(2, build_dictionary(3, 4)));
+	Dictionary d1 = { { 1, Dictionary({ { 2, Dictionary({ { 3, 4 } }) } }) } };
 
 	Dictionary d2 = d1.duplicate(true);
 
 	// other_d = {1: {2: {3: 0}}}
-	Dictionary other_d = build_dictionary(1, build_dictionary(2, build_dictionary(3, 0)));
+	Dictionary other_d = { { 1, Dictionary({ { 2, Dictionary({ { 3, 0 } }) } }) } };
 
 	// test both operator== and operator!=
 	CHECK_EQ(d1, d1); // compare self
@@ -427,12 +415,12 @@ TEST_CASE("[Dictionary] Nested dictionary comparison") {
 
 TEST_CASE("[Dictionary] Nested array comparison") {
 	// d1 = {1: [2, 3]}
-	Dictionary d1 = build_dictionary(1, build_array(2, 3));
+	Dictionary d1 = { { 1, { 2, 3 } } };
 
 	Dictionary d2 = d1.duplicate(true);
 
 	// other_d = {1: [2, 0]}
-	Dictionary other_d = build_dictionary(1, build_array(2, 0));
+	Dictionary other_d = { { 1, { 2, 0 } } };
 
 	// test both operator== and operator!=
 	CHECK_EQ(d1, d1); // compare self
@@ -589,8 +577,8 @@ TEST_CASE("[Dictionary] Typed copying") {
 }
 
 TEST_CASE("[Dictionary] Iteration") {
-	Dictionary a1 = build_dictionary(1, 2, 3, 4, 5, 6);
-	Dictionary a2 = build_dictionary(1, 2, 3, 4, 5, 6);
+	Dictionary a1 = { { 1, 2 }, { 3, 4 }, { 5, 6 } };
+	Dictionary a2 = { { 1, 2 }, { 3, 4 }, { 5, 6 } };
 
 	int idx = 0;
 

--- a/tests/core/variant/test_variant.h
+++ b/tests/core/variant/test_variant.h
@@ -36,26 +36,6 @@
 #include "tests/test_macros.h"
 
 namespace TestVariant {
-
-static inline Array build_array() {
-	return Array();
-}
-template <typename... Targs>
-static inline Array build_array(Variant item, Targs... Fargs) {
-	Array a = build_array(Fargs...);
-	a.push_front(item);
-	return a;
-}
-static inline Dictionary build_dictionary() {
-	return Dictionary();
-}
-template <typename... Targs>
-static inline Dictionary build_dictionary(Variant key, Variant item, Targs... Fargs) {
-	Dictionary d = build_dictionary(Fargs...);
-	d[key] = item;
-	return d;
-}
-
 TEST_CASE("[Variant] Writer and parser integer") {
 	int64_t a32 = 2147483648; // 2^31, so out of bounds for 32-bit signed int [-2^31, +2^31-1].
 	String a32_str;
@@ -1787,7 +1767,7 @@ TEST_CASE("[Variant] Writer and parser Vector2") {
 }
 
 TEST_CASE("[Variant] Writer and parser array") {
-	Array a = build_array(1, String("hello"), build_array(Variant()));
+	Array a = { 1, String("hello"), Array({ Variant() }) };
 	String a_str;
 	VariantWriter::write_to_string(a, a_str);
 
@@ -1838,7 +1818,7 @@ TEST_CASE("[Variant] Writer recursive array") {
 
 TEST_CASE("[Variant] Writer and parser dictionary") {
 	// d = {{1: 2}: 3, 4: "hello", 5: {null: []}}
-	Dictionary d = build_dictionary(build_dictionary(1, 2), 3, 4, String("hello"), 5, build_dictionary(Variant(), build_array()));
+	Dictionary d = { { Dictionary({ { 1, 2 } }), 3 }, { 4, String("hello") }, { 5, Dictionary({ { Variant(), Array() } }) } };
 	String d_str;
 	VariantWriter::write_to_string(d, d_str);
 
@@ -1856,7 +1836,7 @@ TEST_CASE("[Variant] Writer and parser dictionary") {
 }
 
 TEST_CASE("[Variant] Writer key sorting") {
-	Dictionary d = build_dictionary(StringName("C"), 3, "A", 1, StringName("B"), 2, "D", 4);
+	Dictionary d = { { StringName("C"), 3 }, { "A", 1 }, { StringName("B"), 2 }, { "D", 4 } };
 	String d_str;
 	VariantWriter::write_to_string(d, d_str);
 
@@ -2145,9 +2125,9 @@ TEST_CASE("[Variant] Identity comparison") {
 }
 
 TEST_CASE("[Variant] Nested array comparison") {
-	Array a1 = build_array(1, build_array(2, 3));
-	Array a2 = build_array(1, build_array(2, 3));
-	Array a_other = build_array(1, build_array(2, 4));
+	Array a1 = { 1, { 2, 3 } };
+	Array a2 = { 1, { 2, 3 } };
+	Array a_other = { 1, { 2, 4 } };
 	Variant v_a1 = a1;
 	Variant v_a1_ref2 = a1;
 	Variant v_a2 = a2;
@@ -2165,10 +2145,10 @@ TEST_CASE("[Variant] Nested array comparison") {
 }
 
 TEST_CASE("[Variant] Nested dictionary comparison") {
-	Dictionary d1 = build_dictionary(build_dictionary(1, 2), build_dictionary(3, 4));
-	Dictionary d2 = build_dictionary(build_dictionary(1, 2), build_dictionary(3, 4));
-	Dictionary d_other_key = build_dictionary(build_dictionary(1, 0), build_dictionary(3, 4));
-	Dictionary d_other_val = build_dictionary(build_dictionary(1, 2), build_dictionary(3, 0));
+	Dictionary d1 = { { Dictionary({ { 1, 2 } }), Dictionary({ { 3, 4 } }) } };
+	Dictionary d2 = { { Dictionary({ { 1, 2 } }), Dictionary({ { 3, 4 } }) } };
+	Dictionary d_other_key = { { Dictionary({ { 1, 0 } }), Dictionary({ { 3, 4 } }) } };
+	Dictionary d_other_val = { { Dictionary({ { 1, 2 } }), Dictionary({ { 3, 0 } }) } };
 	Variant v_d1 = d1;
 	Variant v_d1_ref2 = d1;
 	Variant v_d2 = d2;

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -35,16 +35,6 @@
 #include "tests/test_macros.h"
 
 namespace TestCodeEdit {
-static inline Array build_array() {
-	return Array();
-}
-template <typename... Targs>
-static inline Array build_array(Variant item, Targs... Fargs) {
-	Array a = build_array(Fargs...);
-	a.push_front(item);
-	return a;
-}
-
 TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 	CodeEdit *code_edit = memnew(CodeEdit);
 	SceneTree::get_singleton()->get_root()->add_child(code_edit);
@@ -75,7 +65,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			ERR_PRINT_ON;
 
-			Array args = build_array(build_array(0));
+			Array args = { { 0 } };
 
 			code_edit->set_line_as_breakpoint(0, true);
 			CHECK(code_edit->is_line_breakpointed(0));
@@ -91,7 +81,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->clear_breakpointed_lines();
 			SIGNAL_CHECK_FALSE("breakpoint_toggled");
 
-			Array args = build_array(build_array(0));
+			Array args = { { 0 } };
 
 			code_edit->set_line_as_breakpoint(0, true);
 			CHECK(code_edit->is_line_breakpointed(0));
@@ -103,7 +93,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and set text") {
-			Array args = build_array(build_array(0));
+			Array args = { { 0 } };
 
 			code_edit->set_text("test\nline");
 			code_edit->set_line_as_breakpoint(0, true);
@@ -120,7 +110,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->clear_breakpointed_lines();
 			SIGNAL_DISCARD("breakpoint_toggled")
 
-			args = build_array(build_array(1));
+			args = { { 1 } };
 			code_edit->set_text("test\nline");
 			code_edit->set_line_as_breakpoint(1, true);
 			CHECK(code_edit->is_line_breakpointed(1));
@@ -136,7 +126,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and clear") {
-			Array args = build_array(build_array(0));
+			Array args = { { 0 } };
 
 			code_edit->set_text("test\nline");
 			code_edit->set_line_as_breakpoint(0, true);
@@ -153,7 +143,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->clear_breakpointed_lines();
 			SIGNAL_DISCARD("breakpoint_toggled")
 
-			args = build_array(build_array(1));
+			args = { { 1 } };
 			code_edit->set_text("test\nline");
 			code_edit->set_line_as_breakpoint(1, true);
 			CHECK(code_edit->is_line_breakpointed(1));
@@ -169,7 +159,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and new lines no text") {
-			Array args = build_array(build_array(0));
+			Array args = { { 0 } };
 
 			/* No text moves breakpoint. */
 			code_edit->set_line_as_breakpoint(0, true);
@@ -177,7 +167,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Normal.
-			args = build_array(build_array(0), build_array(1));
+			args = { { 0 }, { 1 } };
 
 			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line_count() == 2);
@@ -186,7 +176,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Non-Breaking.
-			args = build_array(build_array(1), build_array(2));
+			args = { { 1 }, { 2 } };
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line_count() == 3);
 			CHECK_FALSE(code_edit->is_line_breakpointed(1));
@@ -194,7 +184,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Above.
-			args = build_array(build_array(2), build_array(3));
+			args = { { 2 }, { 3 } };
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line_count() == 4);
 			CHECK_FALSE(code_edit->is_line_breakpointed(2));
@@ -203,7 +193,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and new lines with text") {
-			Array args = build_array(build_array(0));
+			Array args = { { 0 } };
 
 			/* Having text does not move breakpoint. */
 			code_edit->insert_text_at_caret("text");
@@ -227,7 +217,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK_FALSE("breakpoint_toggled");
 
 			// Above does move.
-			args = build_array(build_array(0), build_array(1));
+			args = { { 0 }, { 1 } };
 
 			code_edit->set_caret_line(0);
 			SEND_GUI_ACTION("ui_text_newline_above");
@@ -238,7 +228,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and backspace") {
-			Array args = build_array(build_array(1));
+			Array args = { { 1 } };
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(1, true);
@@ -261,7 +251,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Backspace above breakpointed line moves it.
-			args = build_array(build_array(2));
+			args = { { 2 } };
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(2, true);
@@ -270,7 +260,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			code_edit->set_caret_line(1);
 
-			args = build_array(build_array(2), build_array(1));
+			args = { { 2 }, { 1 } };
 			SEND_GUI_ACTION("ui_text_backspace");
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(2));
@@ -280,7 +270,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and delete") {
-			Array args = build_array(build_array(1));
+			Array args = { { 1 } };
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(1, true);
@@ -304,7 +294,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Delete above breakpointed line moves it.
-			args = build_array(build_array(2));
+			args = { { 2 } };
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(2, true);
@@ -313,7 +303,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			code_edit->set_caret_line(0);
 
-			args = build_array(build_array(2), build_array(1));
+			args = { { 2 }, { 1 } };
 			SEND_GUI_ACTION("ui_text_delete");
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(2));
@@ -323,7 +313,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and delete selection") {
-			Array args = build_array(build_array(1));
+			Array args = { { 1 } };
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(1, true);
@@ -337,7 +327,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Should handle breakpoint move when deleting selection by adding less text then removed.
-			args = build_array(build_array(9));
+			args = { { 9 } };
 
 			code_edit->set_text("\n\n\n\n\n\n\n\n\n");
 			code_edit->set_line_as_breakpoint(9, true);
@@ -346,7 +336,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			code_edit->select(0, 0, 6, 0);
 
-			args = build_array(build_array(9), build_array(4));
+			args = { { 9 }, { 4 } };
 			SEND_GUI_ACTION("ui_text_newline");
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(9));
@@ -355,7 +345,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Should handle breakpoint move when deleting selection by adding more text then removed.
-			args = build_array(build_array(9), build_array(14));
+			args = { { 9 }, { 14 } };
 
 			code_edit->insert_text_at_caret("\n\n\n\n\n");
 			MessageQueue::get_singleton()->flush();
@@ -370,7 +360,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and undo") {
-			Array args = build_array(build_array(1));
+			Array args = { { 1 } };
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(1, true);
@@ -4543,7 +4533,7 @@ TEST_CASE("[SceneTree][CodeEdit] symbol lookup") {
 		SEND_GUI_KEY_EVENT(Key::CTRL);
 #endif
 
-		Array signal_args = build_array(build_array("some"));
+		Array signal_args = { { "some" } };
 		SIGNAL_CHECK("symbol_validate", signal_args);
 
 		SIGNAL_UNWATCH(code_edit, "symbol_validate");

--- a/tests/scene/test_tab_bar.h
+++ b/tests/scene/test_tab_bar.h
@@ -36,16 +36,6 @@
 #include "tests/test_macros.h"
 
 namespace TestTabBar {
-static inline Array build_array() {
-	return Array();
-}
-template <typename... Targs>
-static inline Array build_array(Variant item, Targs... Fargs) {
-	Array a = build_array(Fargs...);
-	a.push_front(item);
-	return a;
-}
-
 TEST_CASE("[SceneTree][TabBar] tab operations") {
 	TabBar *tab_bar = memnew(TabBar);
 	SceneTree::get_singleton()->get_root()->add_child(tab_bar);
@@ -66,8 +56,8 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK(tab_bar->get_tab_count() == 1);
 		CHECK(tab_bar->get_current_tab() == 0);
 		CHECK(tab_bar->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_changed", { { 0 } });
 
 		tab_bar->add_tab("tab1");
 		CHECK(tab_bar->get_tab_count() == 2);
@@ -204,7 +194,7 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK(tab_bar->get_current_tab() == -1);
 		CHECK(tab_bar->get_previous_tab() == -1);
 		SIGNAL_CHECK_FALSE("tab_selected");
-		SIGNAL_CHECK("tab_changed", build_array(build_array(-1)));
+		SIGNAL_CHECK("tab_changed", { { -1 } });
 
 		// Remove current tab when there are other tabs.
 		tab_bar->add_tab("tab0");
@@ -223,7 +213,7 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK(tab_bar->get_current_tab() == 1);
 		CHECK(tab_bar->get_previous_tab() == 1);
 		SIGNAL_CHECK_FALSE("tab_selected");
-		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_changed", { { 1 } });
 	}
 
 	SUBCASE("[TabBar] move tabs") {
@@ -273,21 +263,21 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		tab_bar->add_tab("tab2");
 		CHECK(tab_bar->get_current_tab() == 0);
 		CHECK(tab_bar->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_changed", { { 0 } });
 
 		// Set the current tab.
 		tab_bar->set_current_tab(1);
 		CHECK(tab_bar->get_current_tab() == 1);
 		CHECK(tab_bar->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_changed", { { 1 } });
 
 		// Set to same tab.
 		tab_bar->set_current_tab(1);
 		CHECK(tab_bar->get_current_tab() == 1);
 		CHECK(tab_bar->get_previous_tab() == 1);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_selected", { { 1 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 
 		// Out of bounds.
@@ -327,8 +317,8 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		tab_bar->set_current_tab(-1);
 		CHECK(tab_bar->get_current_tab() == -1);
 		CHECK(tab_bar->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(-1)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(-1)));
+		SIGNAL_CHECK("tab_selected", { { -1 } });
+		SIGNAL_CHECK("tab_changed", { { -1 } });
 
 		// Adding a tab will still set the current tab to 0.
 		tab_bar->clear_tabs();
@@ -341,8 +331,8 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK(tab_bar->get_tab_count() == 3);
 		CHECK(tab_bar->get_current_tab() == 0);
 		CHECK(tab_bar->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_changed", { { 0 } });
 
 		tab_bar->set_current_tab(-1);
 		SIGNAL_DISCARD("tab_selected");
@@ -353,8 +343,8 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK_FALSE(tab_bar->get_deselect_enabled());
 		CHECK(tab_bar->get_current_tab() == 0);
 		CHECK(tab_bar->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_changed", { { 0 } });
 
 		// Cannot set to -1 if disabled.
 		ERR_PRINT_OFF;
@@ -375,8 +365,8 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		tab_bar->set_deselect_enabled(false);
 		CHECK(tab_bar->get_current_tab() == 2);
 		CHECK(tab_bar->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(2)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(2)));
+		SIGNAL_CHECK("tab_selected", { { 2 } });
+		SIGNAL_CHECK("tab_changed", { { 2 } });
 	}
 
 	SUBCASE("[TabBar] hidden tabs") {
@@ -472,15 +462,15 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK(tab_bar->select_next_available());
 		CHECK(tab_bar->get_current_tab() == 1);
 		CHECK(tab_bar->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_changed", { { 1 } });
 
 		// Skips over disabled and hidden tabs.
 		CHECK(tab_bar->select_next_available());
 		CHECK(tab_bar->get_current_tab() == 4);
 		CHECK(tab_bar->get_previous_tab() == 1);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(4)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(4)));
+		SIGNAL_CHECK("tab_selected", { { 4 } });
+		SIGNAL_CHECK("tab_changed", { { 4 } });
 
 		// Does not wrap around.
 		CHECK_FALSE(tab_bar->select_next_available());
@@ -548,15 +538,15 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK(tab_bar->select_previous_available());
 		CHECK(tab_bar->get_current_tab() == 3);
 		CHECK(tab_bar->get_previous_tab() == 4);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(3)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(3)));
+		SIGNAL_CHECK("tab_selected", { { 3 } });
+		SIGNAL_CHECK("tab_changed", { { 3 } });
 
 		// Skips over disabled and hidden tabs.
 		CHECK(tab_bar->select_previous_available());
 		CHECK(tab_bar->get_current_tab() == 0);
 		CHECK(tab_bar->get_previous_tab() == 3);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_changed", { { 0 } });
 
 		// Does not wrap around.
 		CHECK_FALSE(tab_bar->select_previous_available());
@@ -630,8 +620,8 @@ TEST_CASE("[SceneTree][TabBar] initialization") {
 		CHECK(tab_bar->get_tab_count() == 2);
 		CHECK(tab_bar->get_current_tab() == 1);
 		CHECK(tab_bar->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_changed", { { 1 } });
 
 		// Does not work again.
 		ERR_PRINT_OFF;

--- a/tests/scene/test_tab_container.h
+++ b/tests/scene/test_tab_container.h
@@ -35,16 +35,6 @@
 #include "tests/test_macros.h"
 
 namespace TestTabContainer {
-static inline Array build_array() {
-	return Array();
-}
-template <typename... Targs>
-static inline Array build_array(Variant item, Targs... Fargs) {
-	Array a = build_array(Fargs...);
-	a.push_front(item);
-	return a;
-}
-
 TEST_CASE("[SceneTree][TabContainer] tab operations") {
 	TabContainer *tab_container = memnew(TabContainer);
 	SceneTree::get_singleton()->get_root()->add_child(tab_container);
@@ -70,8 +60,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		CHECK(tab_container->get_tab_count() == 1);
 		CHECK(tab_container->get_current_tab() == 0);
 		CHECK(tab_container->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_changed", { { 0 } });
 
 		// Add second tab child.
 		tab_container->add_child(tab1);
@@ -136,7 +126,7 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		CHECK(tab_container->get_current_tab() == -1);
 		CHECK(tab_container->get_previous_tab() == -1);
 		SIGNAL_CHECK_FALSE("tab_selected");
-		SIGNAL_CHECK("tab_changed", build_array(build_array(-1)));
+		SIGNAL_CHECK("tab_changed", { { -1 } });
 
 		// Remove current tab when there are other tabs.
 		tab_container->add_child(tab0);
@@ -155,7 +145,7 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 1);
 		SIGNAL_CHECK_FALSE("tab_selected");
-		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_changed", { { 1 } });
 	}
 
 	SUBCASE("[TabContainer] move tabs by moving children") {
@@ -195,8 +185,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab_container->add_child(tab2);
 		CHECK(tab_container->get_current_tab() == 0);
 		CHECK(tab_container->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_changed", { { 0 } });
 		MessageQueue::get_singleton()->flush();
 		CHECK(tab0->is_visible());
 		CHECK_FALSE(tab1->is_visible());
@@ -206,8 +196,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab_container->set_current_tab(1);
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_changed", { { 1 } });
 		MessageQueue::get_singleton()->flush();
 		CHECK_FALSE(tab0->is_visible());
 		CHECK(tab1->is_visible());
@@ -217,7 +207,7 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab_container->set_current_tab(1);
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 1);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_selected", { { 1 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		MessageQueue::get_singleton()->flush();
 		CHECK_FALSE(tab0->is_visible());
@@ -263,8 +253,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab1->show();
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_changed", { { 1 } });
 		MessageQueue::get_singleton()->flush();
 		CHECK_FALSE(tab0->is_visible());
 		CHECK(tab1->is_visible());
@@ -274,8 +264,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab1->hide();
 		CHECK(tab_container->get_current_tab() == 2);
 		CHECK(tab_container->get_previous_tab() == 1);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(2)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(2)));
+		SIGNAL_CHECK("tab_selected", { { 2 } });
+		SIGNAL_CHECK("tab_changed", { { 2 } });
 		MessageQueue::get_singleton()->flush();
 		CHECK_FALSE(tab0->is_visible());
 		CHECK_FALSE(tab1->is_visible());
@@ -285,8 +275,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab2->hide();
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 2);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_changed", { { 1 } });
 		MessageQueue::get_singleton()->flush();
 		CHECK_FALSE(tab0->is_visible());
 		CHECK(tab1->is_visible());
@@ -315,8 +305,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab0->hide();
 		CHECK(tab_container->get_current_tab() == -1);
 		CHECK(tab_container->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(-1)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(-1)));
+		SIGNAL_CHECK("tab_selected", { { -1 } });
+		SIGNAL_CHECK("tab_changed", { { -1 } });
 		MessageQueue::get_singleton()->flush();
 		CHECK_FALSE(tab0->is_visible());
 	}
@@ -400,8 +390,8 @@ TEST_CASE("[SceneTree][TabContainer] initialization") {
 		CHECK(tab_container->get_tab_count() == 3);
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_changed", { { 1 } });
 		CHECK_FALSE(tab0->is_visible());
 		CHECK(tab1->is_visible());
 		CHECK_FALSE(tab2->is_visible());
@@ -479,8 +469,8 @@ TEST_CASE("[SceneTree][TabContainer] initialization") {
 		CHECK(tab_container->get_tab_count() == 2);
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_changed", { { 1 } });
 		CHECK_FALSE(tab0->is_visible());
 		CHECK(tab1->is_visible());
 	}
@@ -515,8 +505,8 @@ TEST_CASE("[SceneTree][TabContainer] initialization") {
 		CHECK(tab_container->get_tab_count() == 3);
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
-		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_changed", { { 1 } });
 		CHECK_FALSE(tab0->is_visible());
 		CHECK(tab1->is_visible());
 		CHECK_FALSE(tab2->is_visible());

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -35,15 +35,6 @@
 #include "tests/test_macros.h"
 
 namespace TestTextEdit {
-static inline Array build_array() {
-	return Array();
-}
-template <typename... Targs>
-static inline Array build_array(Variant item, Targs... Fargs) {
-	Array a = build_array(Fargs...);
-	a.push_front(item);
-	return a;
-}
 static inline Array reverse_nested(Array array) {
 	Array reversed_array = array.duplicate(true);
 	reversed_array.reverse();
@@ -69,7 +60,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		SIGNAL_WATCH(text_edit, "lines_edited_from");
 		SIGNAL_WATCH(text_edit, "caret_changed");
 
-		Array lines_edited_args = build_array(build_array(0, 0), build_array(0, 0));
+		Array lines_edited_args = { { 0, 0 }, { 0, 0 } };
 
 		SUBCASE("[TextEdit] clear and set text") {
 			// "text_changed" should not be emitted on clear / set.
@@ -134,7 +125,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			// Can clear even if not editable.
 			text_edit->set_editable(false);
 
-			Array lines_edited_clear_args = build_array(build_array(1, 0));
+			Array lines_edited_clear_args = { { 1, 0 } };
 
 			text_edit->clear();
 			MessageQueue::get_singleton()->flush();
@@ -232,7 +223,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_set");
 
 			// Insert text when there is no text.
-			lines_edited_args = build_array(build_array(0, 0));
+			lines_edited_args = { { 0, 0 } };
 
 			text_edit->insert_text("tes", 0, 0);
 			MessageQueue::get_singleton()->flush();
@@ -245,7 +236,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_set");
 
 			// Insert multiple lines.
-			lines_edited_args = build_array(build_array(0, 1));
+			lines_edited_args = { { 0, 1 } };
 
 			text_edit->insert_text("t\ninserting text", 0, 3);
 			MessageQueue::get_singleton()->flush();
@@ -258,7 +249,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_set");
 
 			// Can insert even if not editable.
-			lines_edited_args = build_array(build_array(1, 1));
+			lines_edited_args = { { 1, 1 } };
 
 			text_edit->set_editable(false);
 			text_edit->insert_text("mid", 1, 2);
@@ -300,7 +291,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(1, 4, 1, 6, 2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 2));
+			lines_edited_args = { { 1, 2 } };
 
 			text_edit->insert_text("\n ", 1, 2);
 			MessageQueue::get_singleton()->flush();
@@ -334,7 +325,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0));
+			lines_edited_args = { { 0, 0 } };
 
 			text_edit->insert_text("a", 0, 4, true, false);
 			MessageQueue::get_singleton()->flush();
@@ -361,7 +352,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0));
+			lines_edited_args = { { 0, 0 } };
 
 			text_edit->insert_text("a", 0, 4, false, false);
 			MessageQueue::get_singleton()->flush();
@@ -388,7 +379,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0));
+			lines_edited_args = { { 0, 0 } };
 
 			text_edit->insert_text("a", 0, 4, true, true);
 			MessageQueue::get_singleton()->flush();
@@ -415,7 +406,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0));
+			lines_edited_args = { { 0, 0 } };
 
 			text_edit->insert_text("a", 0, 4, false, true);
 			MessageQueue::get_singleton()->flush();
@@ -429,7 +420,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] remove text") {
-			lines_edited_args = build_array(build_array(0, 0), build_array(0, 2));
+			lines_edited_args = { { 0, 0 }, { 0, 2 } };
 
 			text_edit->set_text("test\nremoveing text\nthird line");
 			MessageQueue::get_singleton()->flush();
@@ -454,7 +445,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(10);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(2, 1));
+			lines_edited_args = { { 2, 1 } };
 
 			text_edit->remove_text(1, 9, 2, 2);
 			MessageQueue::get_singleton()->flush();
@@ -467,7 +458,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_set");
 
 			// Can remove even if not editable.
-			lines_edited_args = build_array(build_array(1, 1));
+			lines_edited_args = { { 1, 1 } };
 
 			text_edit->set_editable(false);
 			text_edit->remove_text(1, 5, 1, 6);
@@ -683,7 +674,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0), build_array(0, 1));
+			lines_edited_args = { { 0, 0 }, { 0, 1 } };
 
 			text_edit->set_line(0, "multiple\nlines");
 			MessageQueue::get_singleton()->flush();
@@ -702,7 +693,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] swap lines") {
-			lines_edited_args = build_array(build_array(0, 0), build_array(0, 1));
+			lines_edited_args = { { 0, 0 }, { 0, 1 } };
 
 			text_edit->set_text("testing\nswap");
 			MessageQueue::get_singleton()->flush();
@@ -716,7 +707,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			// Emitted twice for each line.
-			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0), build_array(1, 1), build_array(1, 1));
+			lines_edited_args = { { 0, 0 }, { 0, 0 }, { 1, 1 }, { 1, 1 } };
 
 			// Order does not matter. Works when not editable.
 			text_edit->set_editable(false);
@@ -770,7 +761,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->add_caret(1, 6);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 1), build_array(1, 1), build_array(0, 0), build_array(0, 0));
+			lines_edited_args = { { 1, 1 }, { 1, 1 }, { 0, 0 }, { 0, 0 } };
 
 			text_edit->swap_lines(0, 1);
 			MessageQueue::get_singleton()->flush();
@@ -799,7 +790,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("text_changed");
-			lines_edited_args = build_array(build_array(2, 2), build_array(2, 2), build_array(0, 0), build_array(0, 0));
+			lines_edited_args = { { 2, 2 }, { 2, 2 }, { 0, 0 }, { 0, 0 } };
 
 			text_edit->swap_lines(0, 2);
 			MessageQueue::get_singleton()->flush();
@@ -813,7 +804,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] insert line at") {
-			lines_edited_args = build_array(build_array(0, 0), build_array(0, 1));
+			lines_edited_args = { { 0, 0 }, { 0, 1 } };
 
 			text_edit->set_text("testing\nswap");
 			MessageQueue::get_singleton()->flush();
@@ -832,7 +823,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Insert line at inserts a line before and moves caret and selection. Works when not editable.
 			text_edit->set_editable(false);
-			lines_edited_args = build_array(build_array(0, 1));
+			lines_edited_args = { { 0, 1 } };
 			text_edit->insert_line_at(0, "new");
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "new\ntesting\nswap");
@@ -875,7 +866,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_from_line() == 0);
 			CHECK(text_edit->get_selection_to_line() == 2);
 			SIGNAL_CHECK_FALSE("caret_changed");
-			lines_edited_args = build_array(build_array(2, 3));
+			lines_edited_args = { { 2, 3 } };
 
 			text_edit->insert_line_at(2, "after");
 			MessageQueue::get_singleton()->flush();
@@ -907,7 +898,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(0, 1, 2, 2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(2, 4));
+			lines_edited_args = { { 2, 4 } };
 
 			text_edit->insert_line_at(2, "multiple\nlines");
 			MessageQueue::get_singleton()->flush();
@@ -924,7 +915,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] remove line at") {
-			lines_edited_args = build_array(build_array(0, 0), build_array(0, 5));
+			lines_edited_args = { { 0, 0 }, { 0, 5 } };
 			text_edit->set_text("testing\nremove line at\n\tremove\nlines\n\ntest");
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "testing\nremove line at\n\tremove\nlines\n\ntest");
@@ -943,7 +934,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->add_caret(1, 5);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(3, 2));
+			lines_edited_args = { { 3, 2 } };
 
 			text_edit->remove_line_at(2, true);
 			MessageQueue::get_singleton()->flush();
@@ -978,7 +969,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->add_caret(4, 4);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 0));
+			lines_edited_args = { { 1, 0 } };
 
 			text_edit->remove_line_at(0, false);
 			MessageQueue::get_singleton()->flush();
@@ -999,7 +990,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(0);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(3, 2));
+			lines_edited_args = { { 3, 2 } };
 
 			text_edit->remove_line_at(2, false);
 			MessageQueue::get_singleton()->flush();
@@ -1016,7 +1007,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(2, 1));
+			lines_edited_args = { { 2, 1 } };
 
 			text_edit->remove_line_at(2, true);
 			MessageQueue::get_singleton()->flush();
@@ -1052,7 +1043,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 0));
+			lines_edited_args = { { 1, 0 } };
 
 			text_edit->remove_line_at(1, false);
 			MessageQueue::get_singleton()->flush();
@@ -1092,7 +1083,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(10);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0));
+			lines_edited_args = { { 0, 0 } };
 
 			text_edit->remove_line_at(0);
 			MessageQueue::get_singleton()->flush();
@@ -1107,7 +1098,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] insert text at caret") {
-			lines_edited_args = build_array(build_array(0, 1));
+			lines_edited_args = { { 0, 1 } };
 
 			// Insert text at caret can insert multiple lines.
 			text_edit->insert_text_at_caret("testing\nswap");
@@ -1126,7 +1117,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
-			lines_edited_args = build_array(build_array(0, 0));
+			lines_edited_args = { { 0, 0 } };
 			text_edit->insert_text_at_caret("mid");
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "temidsting\nswap");
@@ -1140,7 +1131,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			// Selections are deleted then text is inserted. It also works even if not editable.
 			text_edit->select(0, 0, 0, text_edit->get_line(0).length());
 			CHECK(text_edit->has_selection());
-			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0));
+			lines_edited_args = { { 0, 0 }, { 0, 0 } };
 
 			text_edit->set_editable(false);
 			text_edit->insert_text_at_caret("new line");
@@ -1213,7 +1204,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		SIGNAL_WATCH(text_edit, "lines_edited_from");
 		SIGNAL_WATCH(text_edit, "caret_changed");
 
-		Array lines_edited_args = build_array(build_array(0, 0), build_array(0, 0));
+		Array lines_edited_args = { { 0, 0 }, { 0, 0 } };
 
 		SUBCASE("[TextEdit] select all") {
 			// Select when there is no text does not select.
@@ -2822,7 +2813,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		SIGNAL_WATCH(text_edit, "lines_edited_from");
 		SIGNAL_WATCH(text_edit, "caret_changed");
 
-		Array lines_edited_args = build_array(build_array(0, 0));
+		Array lines_edited_args = { { 0, 0 } };
 
 		SUBCASE("[TextEdit] backspace") {
 			text_edit->set_text("this is\nsome\n");
@@ -2846,7 +2837,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(0);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(2, 1));
+			lines_edited_args = { { 2, 1 } };
 
 			text_edit->backspace();
 			MessageQueue::get_singleton()->flush();
@@ -2858,7 +2849,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			// Backspace removes a character.
-			lines_edited_args = build_array(build_array(1, 1));
+			lines_edited_args = { { 1, 1 } };
 			text_edit->backspace();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "this is\nsom");
@@ -2925,7 +2916,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 0));
+			lines_edited_args = { { 1, 0 } };
 
 			text_edit->cut();
 			MessageQueue::get_singleton()->flush();
@@ -2967,7 +2958,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0));
+			lines_edited_args = { { 0, 0 } };
 
 			SEND_GUI_ACTION("ui_cut");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3015,7 +3006,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 0), build_array(1, 0));
+			lines_edited_args = { { 1, 0 }, { 1, 0 } };
 
 			text_edit->cut();
 			MessageQueue::get_singleton()->flush();
@@ -3042,7 +3033,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0));
+			lines_edited_args = { { 0, 0 } };
 
 			text_edit->cut();
 			MessageQueue::get_singleton()->flush();
@@ -3078,7 +3069,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 0), build_array(3, 2), build_array(2, 1));
+			lines_edited_args = { { 1, 0 }, { 3, 2 }, { 2, 1 } };
 
 			text_edit->cut();
 			MessageQueue::get_singleton()->flush();
@@ -3107,7 +3098,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 1), build_array(4, 3), build_array(0, 0));
+			lines_edited_args = { { 1, 1 }, { 4, 3 }, { 0, 0 } };
 
 			text_edit->cut();
 			MessageQueue::get_singleton()->flush();
@@ -3273,7 +3264,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 1));
+			lines_edited_args = { { 1, 1 } };
 			DS->clipboard_set("paste");
 
 			text_edit->paste();
@@ -3318,7 +3309,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(2, 2));
+			lines_edited_args = { { 2, 2 } };
 			DS->clipboard_set("paste2");
 
 			SEND_GUI_ACTION("ui_paste");
@@ -3339,7 +3330,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 0), build_array(0, 0));
+			lines_edited_args = { { 1, 0 }, { 0, 0 } };
 			DS->clipboard_set("paste");
 
 			text_edit->paste();
@@ -3362,7 +3353,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 3));
+			lines_edited_args = { { 0, 3 } };
 			DS->clipboard_set("multi\n\nline\npaste");
 
 			text_edit->paste();
@@ -3384,7 +3375,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 2));
+			lines_edited_args = { { 1, 2 } };
 			DS->clipboard_set("");
 			text_edit->copy();
 			text_edit->set_caret_column(3);
@@ -3411,7 +3402,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 1));
+			lines_edited_args = { { 0, 1 } };
 			DS->clipboard_set("paste\n");
 
 			text_edit->paste();
@@ -3435,7 +3426,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 1), build_array(2, 3), build_array(5, 6));
+			lines_edited_args = { { 0, 1 }, { 2, 3 }, { 5, 6 } };
 			DS->clipboard_set("paste\ntest");
 
 			text_edit->paste();
@@ -3465,7 +3456,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1), build_array(3, 3));
+			lines_edited_args = { { 0, 0 }, { 1, 1 }, { 3, 3 } };
 			DS->clipboard_set("paste\ntest\n1");
 
 			text_edit->paste();
@@ -3546,7 +3537,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(3, 4));
+			lines_edited_args = { { 3, 4 } };
 
 			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(3, 2).get_center() + Point2i(2, 0), MouseButton::MIDDLE, MouseButtonMask::MIDDLE, Key::NONE);
 			CHECK(DS->clipboard_get_primary() == "is is\nsom");
@@ -3567,7 +3558,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 			DS->clipboard_set_primary("paste");
-			lines_edited_args = build_array(build_array(0, 0));
+			lines_edited_args = { { 0, 0 } };
 
 			text_edit->paste_primary_clipboard();
 			MessageQueue::get_singleton()->flush();
@@ -3592,7 +3583,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 			DS->clipboard_set_primary("paste");
-			lines_edited_args = build_array(build_array(1, 1), build_array(2, 2));
+			lines_edited_args = { { 1, 1 }, { 2, 2 } };
 
 			text_edit->paste_primary_clipboard();
 			MessageQueue::get_singleton()->flush();
@@ -3693,7 +3684,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		SIGNAL_WATCH(text_edit, "lines_edited_from");
 		SIGNAL_WATCH(text_edit, "caret_changed");
 
-		Array lines_edited_args = build_array(build_array(0, 0));
+		Array lines_edited_args = { { 0, 0 } };
 
 		SUBCASE("[TextEdit] ui_text_newline_above") {
 			text_edit->set_text("this is some test text.\nthis is some test text.");
@@ -3709,7 +3700,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_count() == 2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 1), build_array(2, 3));
+			lines_edited_args = { { 0, 1 }, { 2, 3 } };
 
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3781,7 +3772,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(1, 10, 0, 0);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 1), build_array(4, 5));
+			lines_edited_args = { { 0, 1 }, { 4, 5 } };
 
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3806,7 +3797,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 1), build_array(1, 2));
+			lines_edited_args = { { 0, 1 }, { 1, 2 } };
 
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3835,7 +3826,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_count() == 2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 1), build_array(2, 3));
+			lines_edited_args = { { 0, 1 }, { 2, 3 } };
 
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3906,7 +3897,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 1), build_array(0, 1));
+			lines_edited_args = { { 0, 1 }, { 0, 1 } };
 
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3937,7 +3928,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 			// Lines edited: deletion, insert line, insert line.
-			lines_edited_args = build_array(build_array(0, 0), build_array(0, 1), build_array(2, 3));
+			lines_edited_args = { { 0, 0 }, { 0, 1 }, { 2, 3 } };
 
 			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4015,7 +4006,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(5);
 			text_edit->add_caret(1, 2);
 			text_edit->add_caret(1, 8);
-			lines_edited_args = build_array(build_array(1, 1));
+			lines_edited_args = { { 1, 1 } };
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
@@ -4066,7 +4057,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(3, 7, 3, 4, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(3, 3), build_array(1, 1));
+			lines_edited_args = { { 3, 3 }, { 1, 1 } };
 
 			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4087,7 +4078,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(0, false, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(3, 2), build_array(1, 0));
+			lines_edited_args = { { 3, 2 }, { 1, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4126,7 +4117,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_editable(true);
 
 			// Remove entire line content when at the end of the line.
-			lines_edited_args = build_array(build_array(1, 1), build_array(0, 0));
+			lines_edited_args = { { 1, 1 }, { 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4189,7 +4180,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(3, 10, 3, 6, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(3, 3), build_array(1, 1));
+			lines_edited_args = { { 3, 3 }, { 1, 1 } };
 
 			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4206,7 +4197,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			text_edit->end_complex_operation();
 
-			lines_edited_args = build_array(build_array(3, 2), build_array(1, 0));
+			lines_edited_args = { { 3, 2 }, { 1, 0 } };
 
 			// Start of line should also be a normal backspace.
 			text_edit->set_caret_column(0);
@@ -4253,7 +4244,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(12, false, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 1), build_array(0, 0));
+			lines_edited_args = { { 1, 1 }, { 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4359,7 +4350,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
-			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0));
+			lines_edited_args = { { 0, 0 }, { 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4423,7 +4414,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(3, 5, 3, 2, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(3, 3), build_array(1, 1));
+			lines_edited_args = { { 3, 3 }, { 1, 1 } };
 
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4478,7 +4469,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(0, false, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(3, 2), build_array(1, 0));
+			lines_edited_args = { { 3, 2 }, { 1, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4550,7 +4541,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->start_action(TextEdit::ACTION_NONE);
 
 			// Backspace removes character to the left.
-			lines_edited_args = build_array(build_array(1, 1), build_array(0, 0));
+			lines_edited_args = { { 1, 1 }, { 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4582,7 +4573,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			// Undo both backspaces.
-			lines_edited_args = build_array(build_array(1, 1), build_array(0, 0), build_array(1, 1), build_array(0, 0));
+			lines_edited_args = { { 1, 1 }, { 0, 0 }, { 1, 1 }, { 0, 0 } };
 
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
@@ -4621,7 +4612,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->add_caret(0, 9);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0), build_array(0, 0));
+			lines_edited_args = { { 0, 0 }, { 0, 0 }, { 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4640,7 +4631,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(1, text_edit->get_line(1).length(), 1, 0, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 1), build_array(0, 0));
+			lines_edited_args = { { 1, 1 }, { 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_text() == "\n");
@@ -4692,7 +4683,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->add_caret(0, 20);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0));
+			lines_edited_args = { { 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4706,7 +4697,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			// Undo.
-			lines_edited_args = build_array(build_array(0, 0));
+			lines_edited_args = { { 0, 0 } };
 
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
@@ -4743,7 +4734,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(1, 8, 1, 4, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1));
+			lines_edited_args = { { 0, 0 }, { 1, 1 } };
 
 			SEND_GUI_ACTION("ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4836,7 +4827,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(2, 10, 2, 6, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0), build_array(2, 2));
+			lines_edited_args = { { 0, 0 }, { 2, 2 } };
 
 			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4857,7 +4848,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(text_edit->get_line(2).length(), false, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 0), build_array(2, 1));
+			lines_edited_args = { { 1, 0 }, { 2, 1 } };
 
 			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4899,7 +4890,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->start_action(TextEdit::ACTION_NONE);
 
 			// Delete to the end of the word right of the caret.
-			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1));
+			lines_edited_args = { { 0, 0 }, { 1, 1 } };
 
 			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4952,7 +4943,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(6);
 			text_edit->add_caret(0, 9);
 			text_edit->add_caret(0, 3);
-			lines_edited_args = build_array(build_array(0, 0));
+			lines_edited_args = { { 0, 0 } };
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
@@ -5030,7 +5021,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
-			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0));
+			lines_edited_args = { { 0, 0 }, { 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -5046,7 +5037,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0));
+			lines_edited_args = { { 0, 0 }, { 0, 0 } };
 
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
@@ -5100,7 +5091,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(2, 5, 2, 2, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(0, 0), build_array(2, 2));
+			lines_edited_args = { { 0, 0 }, { 2, 2 } };
 
 			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -5156,7 +5147,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(text_edit->get_line(2).length(), false, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = build_array(build_array(1, 0), build_array(2, 1));
+			lines_edited_args = { { 1, 0 }, { 2, 1 } };
 
 			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -5228,7 +5219,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->start_action(TextEdit::EditAction::ACTION_NONE);
 
 			// Delete removes character to the right.
-			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1));
+			lines_edited_args = { { 0, 0 }, { 1, 1 } };
 
 			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -5260,7 +5251,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			// Undo both deletes.
-			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1), build_array(0, 0), build_array(1, 1));
+			lines_edited_args = { { 0, 0 }, { 1, 1 }, { 0, 0 }, { 1, 1 } };
 
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
@@ -6291,7 +6282,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1));
+			lines_edited_args = { { 0, 0 }, { 1, 1 } };
 
 			SEND_GUI_KEY_EVENT(Key::A);
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -6334,7 +6325,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
-			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0), build_array(1, 1), build_array(1, 1));
+			lines_edited_args = { { 0, 0 }, { 0, 0 }, { 1, 1 }, { 1, 1 } };
 
 			text_edit->select(0, 0, 0, 1);
 			text_edit->select(1, 0, 1, 1, 1);
@@ -6371,7 +6362,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_overtype_mode_enabled(false);
 			CHECK_FALSE(text_edit->is_overtype_mode_enabled());
 
-			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1));
+			lines_edited_args = { { 0, 0 }, { 1, 1 } };
 
 			SEND_GUI_KEY_EVENT(Key::TAB);
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -8252,12 +8243,12 @@ TEST_CASE("[SceneTree][TextEdit] gutters") {
 		// Click on gutter.
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(5, line_height / 2), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		CHECK(text_edit->get_hovered_gutter() == Vector2i(0, 0));
-		SIGNAL_CHECK("gutter_clicked", build_array(build_array(0, 0)));
+		SIGNAL_CHECK("gutter_clicked", Array({ { 0, 0 } }));
 
 		// Click on gutter on another line.
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(5, line_height * 3 + line_height / 2), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		CHECK(text_edit->get_hovered_gutter() == Vector2i(0, 3));
-		SIGNAL_CHECK("gutter_clicked", build_array(build_array(3, 0)));
+		SIGNAL_CHECK("gutter_clicked", Array({ { 3, 0 } }));
 
 		// Unclickable gutter can be hovered.
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2(15, line_height + line_height / 2), MouseButtonMask::NONE, Key::NONE);
@@ -8268,7 +8259,7 @@ TEST_CASE("[SceneTree][TextEdit] gutters") {
 		// Unclickable gutter can be clicked.
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(15, line_height * 2 + line_height / 2), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		CHECK(text_edit->get_hovered_gutter() == Vector2i(1, 2));
-		SIGNAL_CHECK("gutter_clicked", build_array(build_array(2, 1)));
+		SIGNAL_CHECK("gutter_clicked", Array({ { 2, 1 } }));
 		CHECK(DS->get_cursor_shape() == DisplayServer::CURSOR_ARROW);
 
 		// Hover past last line.

--- a/tests/servers/test_navigation_server_2d.h
+++ b/tests/servers/test_navigation_server_2d.h
@@ -53,16 +53,6 @@ public:
 	Variant function1_latest_arg0;
 };
 
-static inline Array build_array() {
-	return Array();
-}
-template <typename... Targs>
-static inline Array build_array(Variant item, Targs... Fargs) {
-	Array a = build_array(Fargs...);
-	a.push_front(item);
-	return a;
-}
-
 struct GreaterThan {
 	bool operator()(int p_a, int p_b) const { return p_a > p_b; }
 };
@@ -634,7 +624,7 @@ TEST_SUITE("[Navigation2D]") {
 			SIGNAL_WATCH(navigation_server, "map_changed");
 			SIGNAL_CHECK_FALSE("map_changed");
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
-			SIGNAL_CHECK("map_changed", build_array(build_array(map)));
+			SIGNAL_CHECK("map_changed", { { map } });
 			SIGNAL_UNWATCH(navigation_server, "map_changed");
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector2(0, 0)), Vector2(0, 0));
 		}

--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -50,16 +50,6 @@ public:
 	Variant function1_latest_arg0;
 };
 
-static inline Array build_array() {
-	return Array();
-}
-template <typename... Targs>
-static inline Array build_array(Variant item, Targs... Fargs) {
-	Array a = build_array(Fargs...);
-	a.push_front(item);
-	return a;
-}
-
 TEST_SUITE("[Navigation3D]") {
 	TEST_CASE("[NavigationServer3D] Server should be empty when initialized") {
 		NavigationServer3D *navigation_server = NavigationServer3D::get_singleton();
@@ -565,7 +555,7 @@ TEST_SUITE("[Navigation3D]") {
 			SIGNAL_WATCH(navigation_server, "map_changed");
 			SIGNAL_CHECK_FALSE("map_changed");
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
-			SIGNAL_CHECK("map_changed", build_array(build_array(map)));
+			SIGNAL_CHECK("map_changed", { { map } });
 			SIGNAL_UNWATCH(navigation_server, "map_changed");
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector3(0, 0, 0)), Vector3(0, 0, 0));
 		}
@@ -661,7 +651,7 @@ TEST_SUITE("[Navigation3D]") {
 			SIGNAL_WATCH(navigation_server, "map_changed");
 			SIGNAL_CHECK_FALSE("map_changed");
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
-			SIGNAL_CHECK("map_changed", build_array(build_array(map)));
+			SIGNAL_CHECK("map_changed", { { map } });
 			SIGNAL_UNWATCH(navigation_server, "map_changed");
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector3(0, 0, 0)), Vector3(0, 0, 0));
 		}


### PR DESCRIPTION
Removed all `build_array()` and `build_dictionary()` helpers in test files.
Replaced with initializer lists (https://github.com/godotengine/godot/pull/86015, https://github.com/godotengine/godot/pull/89782).

