### PR TITLE
Use `LocalVector` in `RID_Owner::get_owned_list`

### DIFF
--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -33,7 +33,7 @@
 #include "core/os/memory.h"
 #include "core/os/mutex.h"
 #include "core/string/print_string.h"
-#include "core/templates/list.h"
+#include "core/templates/local_vector.h"
 #include "core/templates/rid.h"
 #include "core/templates/safe_refcount.h"
 
@@ -382,19 +382,21 @@ public:
 	_FORCE_INLINE_ uint32_t get_rid_count() const {
 		return alloc_count;
 	}
-	void get_owned_list(List<RID> *p_owned) const {
+	LocalVector<RID> get_owned_list() const {
+		LocalVector<RID> owned;
 		if constexpr (THREAD_SAFE) {
 			mutex.lock();
 		}
 		for (size_t i = 0; i < max_alloc; i++) {
 			uint64_t validator = chunks[i / elements_in_chunk][i % elements_in_chunk].validator;
 			if (validator != 0xFFFFFFFF) {
-				p_owned->push_back(_make_from_id((validator << 32) | i));
+				owned.push_back(_make_from_id((validator << 32) | i));
 			}
 		}
 		if constexpr (THREAD_SAFE) {
 			mutex.unlock();
 		}
+		return owned;
 	}
 
 	//used for fast iteration in the elements or RIDs
@@ -506,8 +508,8 @@ public:
 		return alloc.get_rid_count();
 	}
 
-	_FORCE_INLINE_ void get_owned_list(List<RID> *p_owned) const {
-		return alloc.get_owned_list(p_owned);
+	_FORCE_INLINE_ LocalVector<RID> get_owned_list() const {
+		return alloc.get_owned_list();
 	}
 
 	void fill_owned_buffer(RID *p_rid_buffer) const {
@@ -562,8 +564,8 @@ public:
 		return alloc.get_rid_count();
 	}
 
-	_FORCE_INLINE_ void get_owned_list(List<RID> *p_owned) const {
-		return alloc.get_owned_list(p_owned);
+	_FORCE_INLINE_ LocalVector<RID> get_owned_list() const {
+		return alloc.get_owned_list();
 	}
 	void fill_owned_buffer(RID *p_rid_buffer) const {
 		alloc.fill_owned_buffer(p_rid_buffer);

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -841,13 +841,11 @@ bool ShaderGLES3::shader_cache_save_compressed_zstd = true;
 bool ShaderGLES3::shader_cache_save_debug = true;
 
 ShaderGLES3::~ShaderGLES3() {
-	List<RID> remaining;
-	version_owner.get_owned_list(&remaining);
+	LocalVector<RID> remaining = version_owner.get_owned_list();
 	if (remaining.size()) {
 		ERR_PRINT(itos(remaining.size()) + " shaders of type " + name + " were never freed");
-		while (remaining.size()) {
-			version_free(remaining.front()->get());
-			remaining.pop_front();
+		for (RID &rid : remaining) {
+			version_free(rid);
 		}
 	}
 }

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1470,10 +1470,7 @@ void TextureStorage::texture_set_detect_roughness_callback(RID p_texture, RS::Te
 }
 
 void TextureStorage::texture_debug_usage(List<RS::TextureInfo> *r_info) {
-	List<RID> textures;
-	texture_owner.get_owned_list(&textures);
-
-	for (const RID &rid : textures) {
+	for (const RID &rid : texture_owner.get_owned_list()) {
 		Texture *t = texture_owner.get_or_null(rid);
 		if (!t) {
 			continue;

--- a/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
@@ -32,6 +32,7 @@
 
 #include "core/os/mutex.h"
 #include "scene/main/node.h"
+#include <cstdint>
 
 #ifdef CLIPPER2_ENABLED
 #include "nav_mesh_generator_2d.h"
@@ -193,11 +194,12 @@ void GodotNavigationServer2D::add_command(SetCommand2D *p_command) {
 
 TypedArray<RID> GodotNavigationServer2D::get_maps() const {
 	TypedArray<RID> all_map_rids;
-	List<RID> maps_owned;
-	map_owner.get_owned_list(&maps_owned);
-	if (maps_owned.size()) {
-		for (const RID &E : maps_owned) {
-			all_map_rids.push_back(E);
+	LocalVector<RID> maps_owned = map_owner.get_owned_list();
+	uint32_t map_count = maps_owned.size();
+	if (map_count) {
+		all_map_rids.resize(map_count);
+		for (uint32_t i = 0; i < map_count; i++) {
+			all_map_rids[i] = maps_owned[i];
 		}
 	}
 	return all_map_rids;

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
@@ -94,11 +94,12 @@ void GodotNavigationServer3D::add_command(SetCommand3D *command) {
 
 TypedArray<RID> GodotNavigationServer3D::get_maps() const {
 	TypedArray<RID> all_map_rids;
-	List<RID> maps_owned;
-	map_owner.get_owned_list(&maps_owned);
-	if (maps_owned.size()) {
-		for (const RID &E : maps_owned) {
-			all_map_rids.push_back(E);
+	LocalVector<RID> maps_owned = map_owner.get_owned_list();
+	uint32_t map_count = maps_owned.size();
+	if (map_count) {
+		all_map_rids.resize(map_count);
+		for (uint32_t i = 0; i < map_count; i++) {
+			all_map_rids[i] = maps_owned[i];
 		}
 	}
 	return all_map_rids;

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1415,9 +1415,7 @@ bool OpenXRAPI::on_state_synchronized() {
 	print_verbose("On state synchronized");
 
 	// Just in case, see if we already have active trackers...
-	List<RID> trackers;
-	tracker_owner.get_owned_list(&trackers);
-	for (const RID &tracker : trackers) {
+	for (const RID &tracker : tracker_owner.get_owned_list()) {
 		tracker_check_profile(tracker);
 	}
 
@@ -2066,9 +2064,7 @@ bool OpenXRAPI::poll_events() {
 
 				XrEventDataInteractionProfileChanged *event = (XrEventDataInteractionProfileChanged *)&runtimeEvent;
 
-				List<RID> trackers;
-				tracker_owner.get_owned_list(&trackers);
-				for (const RID &tracker : trackers) {
+				for (const RID &tracker : tracker_owner.get_owned_list()) {
 					tracker_check_profile(tracker, event->session);
 				}
 
@@ -2897,12 +2893,10 @@ XrPath OpenXRAPI::get_xr_path(const String &p_path) {
 }
 
 RID OpenXRAPI::get_tracker_rid(XrPath p_path) {
-	List<RID> current;
-	tracker_owner.get_owned_list(&current);
-	for (const RID &E : current) {
-		Tracker *tracker = tracker_owner.get_or_null(E);
+	for (const RID &tracker_rid : tracker_owner.get_owned_list()) {
+		Tracker *tracker = tracker_owner.get_or_null(tracker_rid);
 		if (tracker && tracker->toplevel_path == p_path) {
-			return E;
+			return tracker_rid;
 		}
 	}
 
@@ -2910,12 +2904,10 @@ RID OpenXRAPI::get_tracker_rid(XrPath p_path) {
 }
 
 RID OpenXRAPI::find_tracker(const String &p_name) {
-	List<RID> current;
-	tracker_owner.get_owned_list(&current);
-	for (const RID &E : current) {
-		Tracker *tracker = tracker_owner.get_or_null(E);
+	for (const RID &tracker_rid : tracker_owner.get_owned_list()) {
+		Tracker *tracker = tracker_owner.get_or_null(tracker_rid);
 		if (tracker && tracker->name == p_name) {
-			return E;
+			return tracker_rid;
 		}
 	}
 
@@ -3023,12 +3015,10 @@ RID OpenXRAPI::action_set_create(const String p_name, const String p_localized_n
 }
 
 RID OpenXRAPI::find_action_set(const String p_name) {
-	List<RID> current;
-	action_set_owner.get_owned_list(&current);
-	for (const RID &E : current) {
-		ActionSet *action_set = action_set_owner.get_or_null(E);
+	for (const RID &action_set_rid : action_set_owner.get_owned_list()) {
+		ActionSet *action_set = action_set_owner.get_or_null(action_set_rid);
 		if (action_set && action_set->name == p_name) {
-			return E;
+			return action_set_rid;
 		}
 	}
 
@@ -3127,12 +3117,10 @@ void OpenXRAPI::action_set_free(RID p_action_set) {
 }
 
 RID OpenXRAPI::get_action_rid(XrAction p_action) {
-	List<RID> current;
-	action_owner.get_owned_list(&current);
-	for (const RID &E : current) {
-		Action *action = action_owner.get_or_null(E);
+	for (const RID &action_rid : action_owner.get_owned_list()) {
+		Action *action = action_owner.get_or_null(action_rid);
 		if (action && action->handle == p_action) {
-			return E;
+			return action_rid;
 		}
 	}
 
@@ -3140,12 +3128,10 @@ RID OpenXRAPI::get_action_rid(XrAction p_action) {
 }
 
 RID OpenXRAPI::find_action(const String &p_name, const RID &p_action_set) {
-	List<RID> current;
-	action_owner.get_owned_list(&current);
-	for (const RID &E : current) {
-		Action *action = action_owner.get_or_null(E);
+	for (const RID &action_rid : action_owner.get_owned_list()) {
+		Action *action = action_owner.get_or_null(action_rid);
 		if (action && action->name == p_name && (p_action_set.is_null() || action->action_set_rid == p_action_set)) {
-			return E;
+			return action_rid;
 		}
 	}
 
@@ -3257,12 +3243,10 @@ void OpenXRAPI::action_free(RID p_action) {
 }
 
 RID OpenXRAPI::get_interaction_profile_rid(XrPath p_path) {
-	List<RID> current;
-	interaction_profile_owner.get_owned_list(&current);
-	for (const RID &E : current) {
-		InteractionProfile *ip = interaction_profile_owner.get_or_null(E);
+	for (const RID &ip_rid : interaction_profile_owner.get_owned_list()) {
+		InteractionProfile *ip = interaction_profile_owner.get_or_null(ip_rid);
 		if (ip && ip->path == p_path) {
-			return E;
+			return ip_rid;
 		}
 	}
 

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -2670,16 +2670,15 @@ bool RendererCanvasCull::free(RID p_rid) {
 
 template <typename T>
 void RendererCanvasCull::_free_rids(T &p_owner, const char *p_type) {
-	List<RID> owned;
-	p_owner.get_owned_list(&owned);
+	LocalVector<RID> owned = p_owner.get_owned_list();
 	if (owned.size()) {
 		if (owned.size() == 1) {
 			WARN_PRINT(vformat("1 RID of type \"%s\" was leaked.", p_type));
 		} else {
 			WARN_PRINT(vformat("%d RIDs of type \"%s\" were leaked.", owned.size(), p_type));
 		}
-		for (const RID &E : owned) {
-			free(E);
+		for (const RID &rid : owned) {
+			free(rid);
 		}
 	}
 }

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1640,10 +1640,7 @@ void TextureStorage::texture_set_detect_roughness_callback(RID p_texture, RS::Te
 }
 
 void TextureStorage::texture_debug_usage(List<RS::TextureInfo> *r_info) {
-	List<RID> textures;
-	texture_owner.get_owned_list(&textures);
-
-	for (const RID &rid : textures) {
+	for (const RID &rid : texture_owner.get_owned_list()) {
 		Texture *t = texture_owner.get_or_null(rid);
 		if (!t) {
 			continue;

--- a/servers/rendering/storage/compositor_storage.cpp
+++ b/servers/rendering/storage/compositor_storage.cpp
@@ -57,9 +57,7 @@ void RendererCompositorStorage::compositor_effect_free(RID p_rid) {
 	ERR_FAIL_NULL(effect);
 
 	// Remove this RID from any compositor that uses it.
-	List<RID> compositor_rids;
-	compositor_owner.get_owned_list(&compositor_rids);
-	for (const RID &compositor_rid : compositor_rids) {
+	for (const RID &compositor_rid : compositor_owner.get_owned_list()) {
 		Compositor *compositor = compositor_owner.get_or_null(compositor_rid);
 		if (compositor) {
 			compositor->compositor_effects.erase(p_rid);


### PR DESCRIPTION
Make `get_owned_list` return a `LocalVector` instead of `List` and use return value instead of pointer argument.

This is mainly for code simplification (with performance improvement as extra benifits), user can call `get_owned_list` directly instead of explicitly create a container and pass it.

`NavigationServer3D::get_maps()` use this function and are bottlenecked by it so I made a [stress test](https://github.com/user-attachments/files/19512132/rid_owner.zip) which create 300000 maps and fetch them every frame.

Master:
![image](https://github.com/user-attachments/assets/4f1c0e6d-e9b5-454b-a107-c34af3ae6ee8)


This PR:
![image](https://github.com/user-attachments/assets/dd1b3bf7-fef2-41b9-84e4-700b0fc90091)

Performance improvement is huge, but I doubt if anyone will use it like this.