### PR TITLE
Add reveal button to EditorPropertyText for secret text

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -165,6 +165,14 @@ void EditorPropertyText::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_theme();
+
+			if (is_secret) {
+				if (show_secret->is_pressed()) {
+					show_secret->set_button_icon(get_editor_theme_icon(SNAME("GuiVisibilityVisible")));
+				} else {
+					show_secret->set_button_icon(get_editor_theme_icon(SNAME("GuiVisibilityHidden")));
+				}
+			}
 		} break;
 	}
 }
@@ -219,6 +227,19 @@ void EditorPropertyText::_text_changed(const String &p_string) {
 	}
 }
 
+void EditorPropertyText::_show_secret_toggled(bool p_toggled) {
+	text->set_secret(!p_toggled);
+	if (p_toggled) {
+		text->set_tooltip_text(get_tooltip_string(text->get_text()));
+		show_secret->set_button_icon(get_editor_theme_icon(SNAME("GuiVisibilityVisible")));
+		show_secret->set_tooltip_text(TTRC("Hide secret text."));
+	} else {
+		text->set_tooltip_text("");
+		show_secret->set_button_icon(get_editor_theme_icon(SNAME("GuiVisibilityHidden")));
+		show_secret->set_tooltip_text(TTRC("Show secret text."));
+	}
+}
+
 void EditorPropertyText::update_property() {
 	String s = get_edited_property_value();
 	updating = true;
@@ -248,7 +269,22 @@ void EditorPropertyText::set_string_name(bool p_enabled) {
 }
 
 void EditorPropertyText::set_secret(bool p_enabled) {
+	is_secret = p_enabled;
+	if (p_enabled) {
+		show_secret = memnew(Button);
+		show_secret->set_toggle_mode(true);
+		show_secret->set_tooltip_text(TTRC("Show secret text."));
+		text->get_parent()->add_child(show_secret);
+		add_focusable(show_secret);
+		show_secret->connect(SceneStringName(toggled), callable_mp(this, &EditorPropertyText::_show_secret_toggled));
+	} else {
+		text->set_tooltip_text(get_tooltip_string(text->get_text()));
+	}
 	text->set_secret(p_enabled);
+	if (show_secret != nullptr) {
+		show_secret->set_visible(p_enabled);
+		show_secret->set_pressed_no_signal(false);
+	}
 }
 
 void EditorPropertyText::set_placeholder(const String &p_string) {

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -94,10 +94,13 @@ public:
 class EditorPropertyText : public EditorProperty {
 	GDCLASS(EditorPropertyText, EditorProperty);
 	LineEdit *text = nullptr;
+	Button *show_secret = nullptr;
 
 	bool monospaced = false;
 	bool updating = false;
 	bool string_name = false;
+	bool is_secret = false;
+	void _show_secret_toggled(bool p_toggled);
 	void _text_changed(const String &p_string);
 	void _text_submitted(const String &p_string);
 	void _update_theme();


### PR DESCRIPTION
This pull request introduces a new button to the editor text property for properties marked as secrets. The button allows users to toggle between showing and hiding the secret text.  
The tooltip is displayed only when the text is revealed to minimize the risk of accidentally exposing sensitive information.  Previously, this was the only way to show the plain text, but is no longer necessary.

![image](https://github.com/user-attachments/assets/1707513e-a75b-4ce1-af2e-df69f1504810)
![image](https://github.com/user-attachments/assets/d08cc0db-ff1f-40d9-9a41-84535364ea76)