### PR TITLE
Image: Fix typo at `_set_color_at_ofs` with `FORMAT_RGB565`

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3331,7 +3331,7 @@ void Image::_set_color_at_ofs(uint8_t *ptr, uint32_t ofs, const Color &p_color) 
 			uint16_t rgba = 0;
 
 			rgba = uint16_t(CLAMP(p_color.r * 31.0, 0, 31));
-			rgba |= uint16_t(CLAMP(p_color.g * 63.0, 0, 33)) << 5;
+			rgba |= uint16_t(CLAMP(p_color.g * 63.0, 0, 63)) << 5;
 			rgba |= uint16_t(CLAMP(p_color.b * 31.0, 0, 31)) << 11;
 
 			((uint16_t *)ptr)[ofs] = rgba;


### PR DESCRIPTION
An excerpt from #103635 that doesn't break compatibility.
The function would incorrectly clamp the green channel to 33 instead of 63 (2^6 - 1) due to a typo, which resulted in the green channel being less saturated than expected.