### PR TITLE
Clarify `RigidBody2D.linear_velocity` documentation

### DIFF
--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -208,7 +208,7 @@
 			Defines how [member linear_damp] is applied. See [enum DampMode] for possible values.
 		</member>
 		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector2(0, 0)">
-			The body's linear velocity in pixels per second. Can be used sporadically, but [b]don't set this every frame[/b], because physics may run in another thread and runs at a different granularity. Use [method _integrate_forces] as your process loop for precise control of the body state.
+			The body's linear velocity in pixels per second. Setting it every frame may cause unpredictable behavior, as physics can run in a separate thread with different timing granularity. For precise control over the body’s state, use [method _integrate_forces] in your process loop.
 		</member>
 		<member name="lock_rotation" type="bool" setter="set_lock_rotation_enabled" getter="is_lock_rotation_enabled" default="false">
 			If [code]true[/code], the body cannot rotate. Gravity and forces only apply linear movement.


### PR DESCRIPTION
Clarified `RigidBody2D.linear_velocity` description to be more consistent with the class-level note.

The original description reads:

> The body's linear velocity in pixels per second. Can be used sporadically, but don't set this every frame, because physics may run in another thread and runs at a different granularity. Use _integrate_forces() as your process loop for precise control of the body state.

I suggest updating it to:

> The body's linear velocity in pixels per second. Setting it every frame can cause unpredictable behavior, as physics may run in another thread with different granularity. For precise control of the body state, use _integrate_forces() as your process loop.

I believe this change ensures the method description is consistent with the class note, which reads:

> Note: Changing the 2D transform or linear_velocity of a RigidBody2D very often may lead to some unpredictable behaviors. If you need to directly affect the body, prefer _integrate_forces() as it allows you to directly access the physics state.