### PR TITLE
Allow GDScript tests to enable static typing-related warnings and add tests for them

### DIFF
--- a/modules/gdscript/tests/gdscript_test_runner.h
+++ b/modules/gdscript/tests/gdscript_test_runner.h
@@ -66,6 +66,8 @@ public:
 		TOKENIZER_BUFFER,
 	};
 
+	bool use_static_typing_warnings = false;
+
 private:
 	struct ErrorHandlerData {
 		TestResult *result = nullptr;

--- a/modules/gdscript/tests/scripts/analyzer/warnings/inferred_declaration.static.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/inferred_declaration.static.gd
@@ -1,0 +1,6 @@
+func no_exec_test() -> void:
+    for i in 10:
+        print(i)
+
+func test() -> void:
+    pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/inferred_declaration.static.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/inferred_declaration.static.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+~~ WARNING at line 2: (INFERRED_DECLARATION) "for" iterator variable "i" has an implicitly inferred static type.

--- a/modules/gdscript/tests/scripts/analyzer/warnings/untyped_declaration.static.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/untyped_declaration.static.gd
@@ -1,0 +1,6 @@
+func no_exec_test():
+    var my_var = 42
+    print(my_var)
+
+func test():
+    pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/untyped_declaration.static.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/untyped_declaration.static.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+~~ WARNING at line 1: (UNTYPED_DECLARATION) Function "no_exec_test()" has no static return type.
+~~ WARNING at line 2: (UNTYPED_DECLARATION) Variable "my_var" has no static type.
+~~ WARNING at line 5: (UNTYPED_DECLARATION) Function "test()" has no static return type.


### PR DESCRIPTION
With this PR, a GDScript test can have `.static.` added to its name (for example, `my_test.static.gd`) in order to enable the `UNTYPED_DECLARATION` and `INFERRED_DECLARATION` warnings for it. This way, tests can be written which look at GDScript's static typing detection without cluttering the expected output files for other tests.

Tests for `UNTYPED_DECLARATION` and `INFERRED_DECLARATION` are also added to ensure those warnings (and the ability to enable them through `.static.` in the filename!) are working correctly.