### PR TITLE
Deprecate NavigationServer `map_force_update()`

### DIFF
--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -457,7 +457,7 @@
 				Create a new map.
 			</description>
 		</method>
-		<method name="map_force_update">
+		<method name="map_force_update" deprecated="This method is no longer supported, as it is incompatible with asynchronous updates. It can only be used in a single-threaded context, at your own risk.">
 			<return type="void" />
 			<param index="0" name="map" type="RID" />
 			<description>

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -496,7 +496,7 @@
 				Create a new map.
 			</description>
 		</method>
-		<method name="map_force_update">
+		<method name="map_force_update" deprecated="This method is no longer supported, as it is incompatible with asynchronous updates. It can only be used in a single-threaded context, at your own risk.">
 			<return type="void" />
 			<param index="0" name="map" type="RID" />
 			<description>


### PR DESCRIPTION
Deprecates `map_force_update()` function as it is incompatible with async updates.

Resolves (https://github.com/godotengine/godot/issues/104671)

To be clear, not removing that function anytime soon, likely not before Godot 5 because some projects clearly make use of it, but it cant be updated going forward and shouldnt be used.

That function does not work outside of a full single-threaded context (and even single-thread it had problems).

When maps, regions, navmeshes and more all update async on their own a user cant force a map update and get the result that the user would expect. And then add threads to the mix and even more does not work anymore.

There is no way to keep this function alive going forward. It does not help, users need to craft code that is robust enough that it can work with the normal (a)sync flow, e.g. connect to the update signals, or poll the iteration id, ... or just be patient and wait and let the map do its thing.

We may need to add more API functions to check for updates and update the documentation to make this process easier.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
