### PR TITLE
CI: Bump various pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ exclude: |
 
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v19.1.3
+    rev: v20.1.0
     hooks:
       - id: clang-format
         files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|inc|java)$
@@ -29,12 +29,12 @@ repos:
         files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|inc|java|glsl)$
         args: [--fix, --quiet, --use-color]
         types_or: [text]
-        additional_dependencies: [clang-tidy==19.1.0]
+        additional_dependencies: [clang-tidy==20.1.0]
         require_serial: true
         stages: [manual] # Not automatically triggered, invoked via `pre-commit run --hook-stage manual clang-tidy`
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.10
+    rev: v0.11.4
     hooks:
       - id: ruff
         args: [--fix]
@@ -52,7 +52,7 @@ repos:
         types_or: [text]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies: [tomli]

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -283,43 +283,43 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 #define REAL_MEMBER_OFFSET(type, member) \
 	{                                    \
 		type,                            \
-				member,                  \
-				"float",                 \
-				sizeof(float),           \
-				"float",                 \
-				sizeof(float),           \
-				"double",                \
-				sizeof(double),          \
-				"double",                \
-				sizeof(double),          \
+		member,                          \
+		"float",                         \
+		sizeof(float),                   \
+		"float",                         \
+		sizeof(float),                   \
+		"double",                        \
+		sizeof(double),                  \
+		"double",                        \
+		sizeof(double),                  \
 	}
 
 #define INT32_MEMBER_OFFSET(type, member) \
 	{                                     \
 		type,                             \
-				member,                   \
-				"int32",                  \
-				sizeof(int32_t),          \
-				"int32",                  \
-				sizeof(int32_t),          \
-				"int32",                  \
-				sizeof(int32_t),          \
-				"int32",                  \
-				sizeof(int32_t),          \
+		member,                           \
+		"int32",                          \
+		sizeof(int32_t),                  \
+		"int32",                          \
+		sizeof(int32_t),                  \
+		"int32",                          \
+		sizeof(int32_t),                  \
+		"int32",                          \
+		sizeof(int32_t),                  \
 	}
 
 #define INT32_BASED_BUILTIN_MEMBER_OFFSET(type, member, member_type, member_elems) \
 	{                                                                              \
 		type,                                                                      \
-				member,                                                            \
-				member_type,                                                       \
-				sizeof(int32_t) * member_elems,                                    \
-				member_type,                                                       \
-				sizeof(int32_t) * member_elems,                                    \
-				member_type,                                                       \
-				sizeof(int32_t) * member_elems,                                    \
-				member_type,                                                       \
-				sizeof(int32_t) * member_elems,                                    \
+		member,                                                                    \
+		member_type,                                                               \
+		sizeof(int32_t) * member_elems,                                            \
+		member_type,                                                               \
+		sizeof(int32_t) * member_elems,                                            \
+		member_type,                                                               \
+		sizeof(int32_t) * member_elems,                                            \
+		member_type,                                                               \
+		sizeof(int32_t) * member_elems,                                            \
 	}
 
 #define REAL_BASED_BUILTIN_MEMBER_OFFSET(type, member, member_type, member_elems) \

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -950,7 +950,7 @@ void FileAccess::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_float"), &FileAccess::get_float);
 	ClassDB::bind_method(D_METHOD("get_double"), &FileAccess::get_double);
 	ClassDB::bind_method(D_METHOD("get_real"), &FileAccess::get_real);
-	ClassDB::bind_method(D_METHOD("get_buffer", "length"), (Vector<uint8_t>(FileAccess::*)(int64_t) const) & FileAccess::get_buffer);
+	ClassDB::bind_method(D_METHOD("get_buffer", "length"), (Vector<uint8_t> (FileAccess::*)(int64_t) const) & FileAccess::get_buffer);
 	ClassDB::bind_method(D_METHOD("get_line"), &FileAccess::get_line);
 	ClassDB::bind_method(D_METHOD("get_csv_line", "delim"), &FileAccess::get_csv_line, DEFVAL(","));
 	ClassDB::bind_method(D_METHOD("get_as_text", "skip_cr"), &FileAccess::get_as_text, DEFVAL(false));
@@ -969,7 +969,7 @@ void FileAccess::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("store_float", "value"), &FileAccess::store_float);
 	ClassDB::bind_method(D_METHOD("store_double", "value"), &FileAccess::store_double);
 	ClassDB::bind_method(D_METHOD("store_real", "value"), &FileAccess::store_real);
-	ClassDB::bind_method(D_METHOD("store_buffer", "buffer"), (bool(FileAccess::*)(const Vector<uint8_t> &)) & FileAccess::store_buffer);
+	ClassDB::bind_method(D_METHOD("store_buffer", "buffer"), (bool (FileAccess::*)(const Vector<uint8_t> &))&FileAccess::store_buffer);
 	ClassDB::bind_method(D_METHOD("store_line", "line"), &FileAccess::store_line);
 	ClassDB::bind_method(D_METHOD("store_csv_line", "values", "delim"), &FileAccess::store_csv_line, DEFVAL(","));
 	ClassDB::bind_method(D_METHOD("store_string", "string"), &FileAccess::store_string);

--- a/core/object/callable_method_pointer.h
+++ b/core/object/callable_method_pointer.h
@@ -81,8 +81,7 @@ class CallableCustomMethodPointer : public CallableCustomMethodPointerBase {
 	struct Data {
 		T *instance;
 		uint64_t object_id;
-		R(T::*method)
-		(P...);
+		R (T::*method)(P...);
 	} data;
 
 public:
@@ -151,8 +150,7 @@ class CallableCustomMethodPointerC : public CallableCustomMethodPointerBase {
 	struct Data {
 		T *instance;
 		uint64_t object_id;
-		R(T::*method)
-		(P...) const;
+		R (T::*method)(P...) const;
 	} data;
 
 public:
@@ -225,8 +223,7 @@ Callable create_custom_callable_function_pointer(T *p_instance,
 template <typename R, typename... P>
 class CallableCustomStaticMethodPointer : public CallableCustomMethodPointerBase {
 	struct Data {
-		R(*method)
-		(P...);
+		R (*method)(P...);
 	} data;
 
 public:

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -142,8 +142,7 @@ public:
 template <typename Derived, typename T, typename R, bool should_returns>
 class MethodBindVarArgBase : public MethodBind {
 protected:
-	R(T::*method)
-	(const Variant **, int, Callable::CallError &);
+	R (T::*method)(const Variant **, int, Callable::CallError &);
 	MethodInfo method_info;
 
 public:
@@ -473,8 +472,7 @@ template <typename T, typename R, typename... P>
 template <typename R, typename... P>
 #endif
 class MethodBindTR : public MethodBind {
-	R(MB_T::*method)
-	(P...);
+	R (MB_T::*method)(P...);
 
 protected:
 	virtual Variant::Type _gen_argument_type(int p_arg) const override {
@@ -569,8 +567,7 @@ template <typename T, typename R, typename... P>
 template <typename R, typename... P>
 #endif
 class MethodBindTRC : public MethodBind {
-	R(MB_T::*method)
-	(P...) const;
+	R (MB_T::*method)(P...) const;
 
 protected:
 	virtual Variant::Type _gen_argument_type(int p_arg) const override {
@@ -721,8 +718,7 @@ MethodBind *create_static_method_bind(void (*p_method)(P...)) {
 
 template <typename R, typename... P>
 class MethodBindTRS : public MethodBind {
-	R(*function)
-	(P...);
+	R (*function)(P...);
 
 protected:
 	virtual Variant::Type _gen_argument_type(int p_arg) const override {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -473,7 +473,7 @@ protected:                                                                      
 		initialize_class();                                                                                                                 \
 	}                                                                                                                                       \
 	_FORCE_INLINE_ bool (Object::*_get_get() const)(const StringName &p_name, Variant &) const {                                            \
-		return (bool(Object::*)(const StringName &, Variant &) const) & m_class::_get;                                                      \
+		return (bool (Object::*)(const StringName &, Variant &) const) & m_class::_get;                                                     \
 	}                                                                                                                                       \
 	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override {                                                           \
 		if (m_class::_get_get() != m_inherits::_get_get()) {                                                                                \
@@ -484,7 +484,7 @@ protected:                                                                      
 		return m_inherits::_getv(p_name, r_ret);                                                                                            \
 	}                                                                                                                                       \
 	_FORCE_INLINE_ bool (Object::*_get_set() const)(const StringName &p_name, const Variant &p_property) {                                  \
-		return (bool(Object::*)(const StringName &, const Variant &)) & m_class::_set;                                                      \
+		return (bool (Object::*)(const StringName &, const Variant &)) & m_class::_set;                                                     \
 	}                                                                                                                                       \
 	virtual bool _setv(const StringName &p_name, const Variant &p_property) override {                                                      \
 		if (m_inherits::_setv(p_name, p_property)) {                                                                                        \
@@ -496,7 +496,7 @@ protected:                                                                      
 		return false;                                                                                                                       \
 	}                                                                                                                                       \
 	_FORCE_INLINE_ void (Object::*_get_get_property_list() const)(List<PropertyInfo> * p_list) const {                                      \
-		return (void(Object::*)(List<PropertyInfo> *) const) & m_class::_get_property_list;                                                 \
+		return (void (Object::*)(List<PropertyInfo> *) const) & m_class::_get_property_list;                                                \
 	}                                                                                                                                       \
 	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const override {                                          \
 		if (!p_reversed) {                                                                                                                  \
@@ -512,7 +512,7 @@ protected:                                                                      
 		}                                                                                                                                   \
 	}                                                                                                                                       \
 	_FORCE_INLINE_ void (Object::*_get_validate_property() const)(PropertyInfo & p_property) const {                                        \
-		return (void(Object::*)(PropertyInfo &) const) & m_class::_validate_property;                                                       \
+		return (void (Object::*)(PropertyInfo &) const) & m_class::_validate_property;                                                      \
 	}                                                                                                                                       \
 	virtual void _validate_propertyv(PropertyInfo &p_property) const override {                                                             \
 		m_inherits::_validate_propertyv(p_property);                                                                                        \
@@ -521,7 +521,7 @@ protected:                                                                      
 		}                                                                                                                                   \
 	}                                                                                                                                       \
 	_FORCE_INLINE_ bool (Object::*_get_property_can_revert() const)(const StringName &p_name) const {                                       \
-		return (bool(Object::*)(const StringName &) const) & m_class::_property_can_revert;                                                 \
+		return (bool (Object::*)(const StringName &) const) & m_class::_property_can_revert;                                                \
 	}                                                                                                                                       \
 	virtual bool _property_can_revertv(const StringName &p_name) const override {                                                           \
 		if (m_class::_get_property_can_revert() != m_inherits::_get_property_can_revert()) {                                                \
@@ -532,7 +532,7 @@ protected:                                                                      
 		return m_inherits::_property_can_revertv(p_name);                                                                                   \
 	}                                                                                                                                       \
 	_FORCE_INLINE_ bool (Object::*_get_property_get_revert() const)(const StringName &p_name, Variant &) const {                            \
-		return (bool(Object::*)(const StringName &, Variant &) const) & m_class::_property_get_revert;                                      \
+		return (bool (Object::*)(const StringName &, Variant &) const) & m_class::_property_get_revert;                                     \
 	}                                                                                                                                       \
 	virtual bool _property_get_revertv(const StringName &p_name, Variant &r_ret) const override {                                           \
 		if (m_class::_get_property_get_revert() != m_inherits::_get_property_get_revert()) {                                                \
@@ -543,7 +543,7 @@ protected:                                                                      
 		return m_inherits::_property_get_revertv(p_name, r_ret);                                                                            \
 	}                                                                                                                                       \
 	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) {                                                                         \
-		return (void(Object::*)(int)) & m_class::_notification;                                                                             \
+		return (void (Object::*)(int)) & m_class::_notification;                                                                            \
 	}                                                                                                                                       \
 	virtual void _notification_forwardv(int p_notification) override {                                                                      \
 		m_inherits::_notification_forwardv(p_notification);                                                                                 \

--- a/core/templates/span.h
+++ b/core/templates/span.h
@@ -44,11 +44,10 @@ class Span {
 
 public:
 	static constexpr bool is_string = std::disjunction_v<
-		std::is_same<T, char>,
-		std::is_same<T, char16_t>,
-		std::is_same<T, char32_t>,
-		std::is_same<T, wchar_t>
-	>;
+			std::is_same<T, char>,
+			std::is_same<T, char16_t>,
+			std::is_same<T, char32_t>,
+			std::is_same<T, wchar_t>>;
 
 	_FORCE_INLINE_ constexpr Span() = default;
 	_FORCE_INLINE_ constexpr Span(const T *p_ptr, uint64_t p_len) :

--- a/modules/bcdec/image_decompress_bcdec.cpp
+++ b/modules/bcdec/image_decompress_bcdec.cpp
@@ -48,14 +48,14 @@ static void decompress_image(BCdecFormat format, const void *src, void *dst, con
 	const uint8_t *src_blocks = reinterpret_cast<const uint8_t *>(src);
 	uint8_t *dec_blocks = reinterpret_cast<uint8_t *>(dst);
 
-#define DECOMPRESS_LOOP(func, block_size, color_bytesize, color_components)            \
-	for (uint64_t y = 0; y < height; y += 4) {                                         \
-		for (uint64_t x = 0; x < width; x += 4) {                                      \
-			func(&src_blocks[src_pos], &dec_blocks[dst_pos], width *color_components); \
-			src_pos += block_size;                                                     \
-			dst_pos += 4 * color_bytesize;                                             \
-		}                                                                              \
-		dst_pos += 3 * width * color_bytesize;                                         \
+#define DECOMPRESS_LOOP(func, block_size, color_bytesize, color_components)             \
+	for (uint64_t y = 0; y < height; y += 4) {                                          \
+		for (uint64_t x = 0; x < width; x += 4) {                                       \
+			func(&src_blocks[src_pos], &dec_blocks[dst_pos], width * color_components); \
+			src_pos += block_size;                                                      \
+			dst_pos += 4 * color_bytesize;                                              \
+		}                                                                               \
+		dst_pos += 3 * width * color_bytesize;                                          \
 	}
 
 #define DECOMPRESS_LOOP_SAFE(func, block_size, color_bytesize, color_components, output)                                                              \

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -613,12 +613,12 @@ void GDScriptParser::parse_program() {
 	current_class = head;
 	bool can_have_class_or_extends = true;
 
-#define PUSH_PENDING_ANNOTATIONS_TO_HEAD                  \
-	if (!annotation_stack.is_empty()) {                   \
-		for (AnnotationNode * annot : annotation_stack) { \
-			head->annotations.push_back(annot);           \
-		}                                                 \
-		annotation_stack.clear();                         \
+#define PUSH_PENDING_ANNOTATIONS_TO_HEAD                 \
+	if (!annotation_stack.is_empty()) {                  \
+		for (AnnotationNode *annot : annotation_stack) { \
+			head->annotations.push_back(annot);          \
+		}                                                \
+		annotation_stack.clear();                        \
 	}
 
 	while (!check(GDScriptTokenizer::Token::TK_EOF)) {

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -3246,7 +3246,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			ip += 5;                                                                                                       \
 		} else {                                                                                                           \
 			int jumpto = _code_ptr[ip + 4];                                                                                \
-			GD_ERR_BREAK(jumpto<0 || jumpto> _code_size);                                                                  \
+			GD_ERR_BREAK(jumpto < 0 || jumpto > _code_size);                                                               \
 			ip = jumpto;                                                                                                   \
 		}                                                                                                                  \
 	}                                                                                                                      \
@@ -3576,7 +3576,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		(*idx)++;                                                                                   \
 		if (*idx >= array->size()) {                                                                \
 			int jumpto = _code_ptr[ip + 4];                                                         \
-			GD_ERR_BREAK(jumpto<0 || jumpto> _code_size);                                           \
+			GD_ERR_BREAK(jumpto < 0 || jumpto > _code_size);                                        \
 			ip = jumpto;                                                                            \
 		} else {                                                                                    \
 			GET_VARIANT_PTR(iterator, 2);                                                           \

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -128,14 +128,14 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	// Nodes where instantiation failed (because something is missing.)
 	List<Node *> stray_instances;
 
-#define NODE_FROM_ID(p_name, p_id)                      \
-	Node *p_name;                                       \
-	if (p_id & FLAG_ID_IS_PATH) {                       \
-		NodePath np = node_paths[p_id & FLAG_MASK];     \
-		p_name = ret_nodes[0]->get_node_or_null(np);    \
-	} else {                                            \
-		ERR_FAIL_INDEX_V(p_id &FLAG_MASK, nc, nullptr); \
-		p_name = ret_nodes[p_id & FLAG_MASK];           \
+#define NODE_FROM_ID(p_name, p_id)                       \
+	Node *p_name;                                        \
+	if (p_id & FLAG_ID_IS_PATH) {                        \
+		NodePath np = node_paths[p_id & FLAG_MASK];      \
+		p_name = ret_nodes[0]->get_node_or_null(np);     \
+	} else {                                             \
+		ERR_FAIL_INDEX_V(p_id & FLAG_MASK, nc, nullptr); \
+		p_name = ret_nodes[p_id & FLAG_MASK];            \
 	}
 
 	int nc = nodes.size();

--- a/servers/rendering/renderer_rd/shaders/effects/ssao.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ssao.glsl
@@ -195,9 +195,9 @@ void SSAO_tap_inner(const int p_quality_level, inout float r_obscurance_sum, ino
 	float weight = 1.0;
 
 	if (p_quality_level >= SSAO_HALOING_REDUCTION_ENABLE_AT_QUALITY_PRESET) {
-		float reduct = max(0, -hit_delta.z);
-		reduct = clamp(reduct * params.neg_inv_radius + 2.0, 0.0, 1.0);
-		weight = SSAO_HALOING_REDUCTION_AMOUNT * reduct + (1.0 - SSAO_HALOING_REDUCTION_AMOUNT);
+		float reduce = max(0, -hit_delta.z);
+		reduce = clamp(reduce * params.neg_inv_radius + 2.0, 0.0, 1.0);
+		weight = SSAO_HALOING_REDUCTION_AMOUNT * reduce + (1.0 - SSAO_HALOING_REDUCTION_AMOUNT);
 	}
 	weight *= p_weight_mod;
 	r_obscurance_sum += obscurance * weight;

--- a/servers/rendering/renderer_rd/shaders/effects/ssil.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ssil.glsl
@@ -195,9 +195,9 @@ void SSIL_tap_inner(const int p_quality_level, inout vec3 r_color_sum, inout flo
 	float weight = 1.0;
 
 	if (p_quality_level >= SSIL_HALOING_REDUCTION_ENABLE_AT_QUALITY_PRESET) {
-		float reduct = max(0, -hit_delta.z);
-		reduct = clamp(reduct * params.neg_inv_radius + 2.0, 0.0, 1.0);
-		weight = SSIL_HALOING_REDUCTION_AMOUNT * reduct + (1.0 - SSIL_HALOING_REDUCTION_AMOUNT);
+		float reduce = max(0, -hit_delta.z);
+		reduce = clamp(reduce * params.neg_inv_radius + 2.0, 0.0, 1.0);
+		weight = SSIL_HALOING_REDUCTION_AMOUNT * reduce + (1.0 - SSIL_HALOING_REDUCTION_AMOUNT);
 	}
 
 	// Translate sampling_uv to last screen's coordinates


### PR DESCRIPTION
Bumps the following pre-commit hooks to their most recent version:
- clang-format (`19.1.3`→`20.1.0`)
- clang-tidy (`19.1.0`→`20.1.0`)
- ruff (`0.9.10`→`0.11.2`)
- codespell (`2.3.0`→`2.4.1`)

Does NOT upgrade mypy, as we want to retain 3.8 as the minimum Python version. A full pass was performed to catch & resolve any issues found from the updates.