### PR TITLE
Handle null values for object types, as seen in typed dictionaries

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -1360,7 +1360,14 @@ void EditorPropertyDictionary::update_property() {
 
 			Variant value;
 			object->get_by_property_name(slot.prop_name, value);
-			Variant::Type value_type = value.get_type();
+
+			Variant::Type value_type;
+
+			if (dict.is_typed_value() && slot.prop_key) {
+				value_type = value_subtype;
+			} else {
+				value_type = value.get_type();
+			}
 
 			// Check if the editor property needs to be updated.
 			bool value_as_id = Object::cast_to<EncodedObjectAsID>(value);


### PR DESCRIPTION
This fixes typed dictionaries not providing an editable property in the inspector for `null` values, as described in #104760.

To do this it adds a check in `EditorInspectorDefaultPlugin::get_editor_for_property` to see if the value for `p_hint` is `PROPERTY_HINT_RESOURCE_TYPE` or `PROPERTY_HINT_NODE_TYPE` when `p_type` is `Variant::NIL`. If it is, then the case instead returns the result for the function as if it was called with `Variant::OBJECT`. It was done this way to avoid changing `p_type` to not be const and to not introduce another variable, since I assumed almost all arguments being const was for performance reasons. Happy to introduce a second variable or make `p_type` not const if that is preferred.

Original experience (from issue):
![Image](https://github.com/user-attachments/assets/66705de8-33ef-4d9b-bfc4-aabf1f9aa308)

Resulting experience:

![Screenshot from 2025-03-29 17-56-47](https://github.com/user-attachments/assets/b4d402e4-7efa-42a7-9533-640fe739b733)

Fixes #104760
