### PR TITLE
Add missing "/" to "center" tag in `__print_line_rich()`

### DIFF
--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -148,7 +148,7 @@ void __print_line_rich(const String &p_string) {
 			output += "";
 		} else if (tag == "center") {
 			output += "\n\t\t\t";
-		} else if (tag == "center") {
+		} else if (tag == "/center") {
 			output += "";
 		} else if (tag == "right") {
 			output += "\n\t\t\t\t\t\t";


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes a typo in `__print_line_rich()`, which has no impact on the output since that particular case adds nothing to the string.