### PR TITLE
Add note to `ShaderMaterial.set_shader_parameter` docs on mismatched value types

### DIFF
--- a/doc/classes/ShaderMaterial.xml
+++ b/doc/classes/ShaderMaterial.xml
@@ -26,6 +26,7 @@
 			<description>
 				Changes the value set for this material of a uniform in the shader.
 				[b]Note:[/b] [param param] is case-sensitive and must match the name of the uniform in the code exactly (not the capitalized name in the inspector).
+				[b]Note:[/b] No error will be thrown if the type of [param value] does not match, and your shader may exhibit undefined behavior. This includes setting a GDScript [int]/[float] (which are 64-bit) into a shader int/float (which are 32 bit). This may lead to unintended consequences in cases where a high range or precision is required.
 				[b]Note:[/b] Changes to the shader uniform will be effective on all instances using this [ShaderMaterial]. To prevent this, use per-instance uniforms with [method GeometryInstance3D.set_instance_shader_parameter] or duplicate the [ShaderMaterial] resource using [method Resource.duplicate]. Per-instance uniforms allow for better shader reuse and are therefore faster, so they should be preferred over duplicating the [ShaderMaterial] when possible.
 			</description>
 		</method>

--- a/doc/classes/ShaderMaterial.xml
+++ b/doc/classes/ShaderMaterial.xml
@@ -26,7 +26,7 @@
 			<description>
 				Changes the value set for this material of a uniform in the shader.
 				[b]Note:[/b] [param param] is case-sensitive and must match the name of the uniform in the code exactly (not the capitalized name in the inspector).
-				[b]Note:[/b] No error will be thrown if the type of [param value] does not match, and your shader may exhibit undefined behavior. This includes setting a GDScript [int]/[float] (which are 64-bit) into a shader int/float (which are 32 bit). This may lead to unintended consequences in cases where a high range or precision is required.
+				[b]Note:[/b] No error will be thrown if the type of [param value] does not match. The value will be casted to the expected type silently, which may result in the shader exhibiting undefined behavior. This includes setting a GDScript [int]/[float] (which are 64-bit) into a shader int/float (which are 32 bit). This may lead to unintended consequences in cases where a high range or precision is required.
 				[b]Note:[/b] Changes to the shader uniform will be effective on all instances using this [ShaderMaterial]. To prevent this, use per-instance uniforms with [method GeometryInstance3D.set_instance_shader_parameter] or duplicate the [ShaderMaterial] resource using [method Resource.duplicate]. Per-instance uniforms allow for better shader reuse and are therefore faster, so they should be preferred over duplicating the [ShaderMaterial] when possible.
 			</description>
 		</method>


### PR DESCRIPTION
Adapted the note from the [shading language uniforms docs](https://docs.godotengine.org/en/stable/tutorials/shaders/shader_reference/shading_language.html#setting-uniforms-from-code) in the `ShaderMaterial` class reference to warn about passing mismatched types to `set_shader_parameter`, following my findings in #104705.