### PR TITLE
Fix EditorNode3DGizmo::add_solid_box() GPU stalling

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -486,10 +486,10 @@ void EditorNode3DGizmo::add_handles(const Vector<Vector3> &p_handles, const Ref<
 void EditorNode3DGizmo::add_solid_box(const Ref<Material> &p_material, Vector3 p_size, Vector3 p_position, const Transform3D &p_xform) {
 	ERR_FAIL_NULL(spatial_node);
 
-	BoxMesh box_mesh;
-	box_mesh.set_size(p_size);
+	Array arrays;
+	arrays.resize(RS::ARRAY_MAX);
+	BoxMesh::create_mesh_array(arrays, p_size);
 
-	Array arrays = box_mesh.surface_get_arrays(0);
 	PackedVector3Array vertex = arrays[RS::ARRAY_VERTEX];
 	Vector3 *w = vertex.ptrw();
 
@@ -499,8 +499,9 @@ void EditorNode3DGizmo::add_solid_box(const Ref<Material> &p_material, Vector3 p
 
 	arrays[RS::ARRAY_VERTEX] = vertex;
 
-	Ref<ArrayMesh> m = memnew(ArrayMesh);
-	m->add_surface_from_arrays(box_mesh.surface_get_primitive_type(0), arrays);
+	Ref<ArrayMesh> m;
+	m.instantiate();
+	m->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, arrays);
 	add_mesh(m, p_material, p_xform);
 }
 


### PR DESCRIPTION
Fixes `EditorNode3DGizmo::add_solid_box()` stalling the GPU because it used a function that queries the mesh arrays from the GPU.

All the primitive meshes have static `create_mesh_array()` functions to create the mesh arrays on the CPU that should be used for such cases where only the primitive geometry arrays are needed but not the actual mesh resource.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
