### PR TITLE
Expose missing `String` encoding conversion functions

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -268,26 +268,12 @@ class [[nodiscard]] String {
 	static constexpr char32_t _null = 0;
 	static constexpr char32_t _replacement_char = 0xfffd;
 
-	// Known-length copy.
-	void copy_from_unchecked(const char32_t *p_char, int p_length);
-
 	// NULL-terminated c string copy - automatically parse the string to find the length.
 	void append_latin1(const char *p_cstr) {
 		append_latin1(Span(p_cstr, p_cstr ? strlen(p_cstr) : 0));
 	}
 	void append_utf32(const char32_t *p_cstr) {
 		append_utf32(Span(p_cstr, p_cstr ? strlen(p_cstr) : 0));
-	}
-
-	// wchar_t copy_from depends on the platform.
-	void append_wstring(const Span<wchar_t> &p_cstr) {
-#ifdef WINDOWS_ENABLED
-		// wchar_t is 16-bit, parse as UTF-16
-		append_utf16((const char16_t *)p_cstr.ptr(), p_cstr.size());
-#else
-		// wchar_t is 32-bit, copy directly
-		append_utf32((Span<char32_t> &)p_cstr);
-#endif
 	}
 	void append_wstring(const wchar_t *p_cstr) {
 #ifdef WINDOWS_ENABLED
@@ -562,10 +548,35 @@ public:
 	}
 	static String utf16(const Span<char16_t> &p_range) { return utf16(p_range.ptr(), p_range.size()); }
 
-	void append_utf32(const Span<char32_t> &p_cstr);
+	// wchar_t copy_from depends on the platform.
+	Error append_wstring(const Span<wchar_t> &p_cstr) {
+#ifdef WINDOWS_ENABLED
+		// wchar_t is 16-bit, parse as UTF-16
+		return append_utf16((const char16_t *)p_cstr.ptr(), p_cstr.size());
+#else
+		// wchar_t is 32-bit, copy directly
+		return append_utf32((Span<char32_t> &)p_cstr);
+#endif
+	}
+	static String wstring(const Span<wchar_t> &p_string) {
+		String string;
+		string.append_wstring(p_string);
+		return string;
+	}
+
+	Error append_utf32(const Span<char32_t> &p_cstr);
 	static String utf32(const Span<char32_t> &p_span) {
 		String string;
 		string.append_utf32(p_span);
+		return string;
+	}
+
+	// Like append_utf32, but does not check the string for string integrity (and is thus faster).
+	// Prefer this function for conversion from trusted utf32 strings.
+	void append_utf32_unchecked(const Span<char32_t> &p_span);
+	static String utf32_unchecked(const Span<char32_t> &p_string) {
+		String string;
+		string.append_utf32_unchecked(p_string);
 		return string;
 	}
 


### PR DESCRIPTION
This can be seen as sort of a follow-up of recent PRs going in the same direction: I'm completing the function ensemble for string conversions with named encodings. In particular:
- `append_utf32` gets an `Error` return type, allowing the caller to react to poorly encoded strings.
- `append_utf32_unchecked` is added (formerly `copy_from_unchecked`), for high performance conversion from trusted strings.
- `append_wstring` is added, for conversion from platform defined strings.

I want to soon begin eliminating implicit pointer-to-string conversions, so these functions will be needed :)

With `append_utf32_unchecked` available, `String::operator+=` can use that instead of the slow `append_utf32` function. It should be several times faster than before.