### PR TITLE
have `ShaderMaterial.set_shader_parameter()` implicitly cast between int and float

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -457,8 +457,16 @@ void ShaderMaterial::set_shader_parameter(const StringName &p_param, const Varia
 			// Never assigned, also update the remap cache.
 			remap_cache["shader_parameter/" + p_param.operator String()] = p_param;
 			param_cache.insert(p_param, p_value);
+			v = param_cache.getptr(p_param);
 		} else {
-			*v = p_value;
+			// Cast p_value between float and int to avoid minor annoyances.
+			if (v->get_type() == Variant::FLOAT && p_value.get_type() == Variant::INT) {
+				*v = float(p_value);
+			} else if (v->get_type() == Variant::INT && p_value.get_type() == Variant::FLOAT) {
+				*v = int32_t(p_value);
+			} else {
+				*v = p_value;
+			}
 		}
 
 		if (p_value.get_type() == Variant::OBJECT) {
@@ -473,7 +481,7 @@ void ShaderMaterial::set_shader_parameter(const StringName &p_param, const Varia
 				RS::get_singleton()->material_set_param(material_rid, p_param, tex_rid);
 			}
 		} else if (material_rid.is_valid()) {
-			RS::get_singleton()->material_set_param(material_rid, p_param, p_value);
+			RS::get_singleton()->material_set_param(material_rid, p_param, *v);
 		}
 	}
 }

--- a/tests/scene/test_shader_material.h
+++ b/tests/scene/test_shader_material.h
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  test_shader_material.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/resources/material.h"
+#include "tests/test_macros.h"
+
+namespace TestShaderMaterial {
+
+TEST_CASE("[ShaderMaterial] get/set") {
+	Ref<ShaderMaterial> shader_material = memnew(ShaderMaterial);
+
+	shader_material->set_shader_parameter("param", Variant(2));
+	CHECK(shader_material->get_shader_parameter("param") == Variant(2));
+}
+
+TEST_CASE("[ShaderMaterial] implicit int/float conversion") {
+	Ref<ShaderMaterial> shader_material = memnew(ShaderMaterial);
+
+	shader_material->set_shader_parameter("float", 2.4);
+	shader_material->set_shader_parameter("float", 2);
+	CHECK(shader_material->get_shader_parameter("float") == Variant(2.0));
+
+	shader_material->set_shader_parameter("int", 2);
+	shader_material->set_shader_parameter("int", 2.4);
+	CHECK(shader_material->get_shader_parameter("int") == Variant(2));
+}
+
+} // namespace TestShaderMaterial

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -135,6 +135,7 @@
 #include "tests/scene/test_parallax_2d.h"
 #include "tests/scene/test_path_2d.h"
 #include "tests/scene/test_path_follow_2d.h"
+#include "tests/scene/test_shader_material.h"
 #include "tests/scene/test_sprite_frames.h"
 #include "tests/scene/test_style_box_texture.h"
 #include "tests/scene/test_texture_progress_bar.h"


### PR DESCRIPTION
Addresses issue #104705.

`ShaderMaterial.set_shader_parameter()` now implicitly casts between int and float, similar to `Tween`. This avoids changing the underlying type of the shader parameter, which could lead to undefined behavior.