### PR TITLE
Fix issue with improper notifications in propagate function

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -680,19 +680,17 @@ void Node::set_process_mode(ProcessMode p_mode) {
 void Node::_propagate_pause_notification(bool p_enable) {
 	bool prev_can_process = _can_process(!p_enable);
 	bool next_can_process = _can_process(p_enable);
-
 	bool process_mode_pausible = !prev_can_process && next_can_process;
 	bool process_mode_when_paused = prev_can_process && !next_can_process;
-	bool process_mode_always = prev_can_process && next_can_process;
 
-	bool should_send_notification = process_mode_always || process_mode_pausible || process_mode_when_paused;
+	bool should_send_notification = process_mode_pausible || process_mode_when_paused;
 
-	if(should_send_notification)
-	{
-		if(get_tree()->is_paused())
-			notification(NOTIFICATION_PAUSED); 
-		else
+	if (should_send_notification) {
+		if (p_enable) {
+			notification(NOTIFICATION_PAUSED);
+		} else {
 			notification(NOTIFICATION_UNPAUSED);
+		}
 	}
 
 	data.blocked++;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -682,10 +682,10 @@ void Node::_propagate_pause_notification(bool p_enable) {
 	bool next_can_process = _can_process(p_enable);
 
 	bool process_mode_pausible = !prev_can_process && next_can_process;
-	bool process_mode_when_pauded = prev_can_process && !next_can_process;
+	bool process_mode_when_paused = prev_can_process && !next_can_process;
 	bool process_mode_always = prev_can_process && next_can_process;
 
-	bool should_send_notification = process_mode_always || process_mode_pausible || process_mode_when_pauded;
+	bool should_send_notification = process_mode_always || process_mode_pausible || process_mode_when_paused;
 
 	if(should_send_notification)
 	{

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -681,10 +681,18 @@ void Node::_propagate_pause_notification(bool p_enable) {
 	bool prev_can_process = _can_process(!p_enable);
 	bool next_can_process = _can_process(p_enable);
 
-	if (prev_can_process && !next_can_process) {
-		notification(NOTIFICATION_PAUSED);
-	} else if (!prev_can_process && next_can_process) {
-		notification(NOTIFICATION_UNPAUSED);
+	bool process_mode_pausible = !prev_can_process && next_can_process;
+	bool process_mode_when_pauded = prev_can_process && !next_can_process;
+	bool process_mode_always = prev_can_process && next_can_process;
+
+	bool should_send_notification = process_mode_always || process_mode_pausible || process_mode_when_pauded;
+
+	if(should_send_notification)
+	{
+		if(get_tree()->is_paused())
+			notification(NOTIFICATION_PAUSED); 
+		else
+			notification(NOTIFICATION_UNPAUSED);
 	}
 
 	data.blocked++;


### PR DESCRIPTION
Fixes: #83160 

The issue was two-fold. First: NOTIFICATION_PAUSED and NOTIFICATION_UNPAUSED were not being sent if Process Mode was set to Always, see #104778, secondly and directly related in the logic, the wrong notification was being sent when Process Mode was set to when paused.

For Clarity: Now when Process Mode is Always, When_Paused, or Pausable, if when we pause the correct value of NOTIFICATION_PAUSED (14) is sent, when unpausing NOTIFICATION_UNPAUSED (15) is sent.

This PR corrects the logic and ensures that the proper notification is being sent, and is sent in all process modes it should be, (so not in disabled). 

Tested by running the mrp from #104778 

EDIT: Per comments, reworked so notifications are only being sent when Process Mode is either When_Paused or Pausable and ensured that they are both being sent the correct notification each time now by testing the p_enable to determine which message to send rather than checking the prev_can_process and next_can_process variables.
