### PR TITLE
GLTF: Fix node path to skinned meshes for KHR_animation_pointer

### DIFF
--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -216,27 +216,65 @@ NodePath GLTFNode::get_scene_node_path(Ref<GLTFState> p_state, bool p_handle_ske
 	Vector<StringName> subpath;
 	Ref<GLTFNode> current_gltf_node = this;
 	const int gltf_node_count = p_state->nodes.size();
-	if (p_handle_skeletons && skeleton != -1) {
-		// Special case for skeleton nodes, skip all bones so that the path is to the Skeleton3D node.
-		// A path that would otherwise be `A/B/C/Bone1/Bone2/Bone3` becomes `A/B/C/Skeleton3D:Bone3`.
-		subpath.append(get_name());
-		// The generated Skeleton3D node will be named Skeleton3D, so add it to the path.
-		path.append("Skeleton3D");
-		do {
-			const int parent_index = current_gltf_node->get_parent();
-			ERR_FAIL_INDEX_V(parent_index, gltf_node_count, NodePath());
-			current_gltf_node = p_state->nodes[parent_index];
-		} while (current_gltf_node->skeleton != -1);
-	}
 	const bool is_godot_single_root = p_state->extensions_used.has("GODOT_single_root");
+	if (p_handle_skeletons) {
+		if (skin != -1) {
+			// Special case for skinned meshes, they become a child of a Skeleton3D node.
+			ERR_FAIL_INDEX_V(skin, p_state->skins.size(), NodePath());
+			Ref<GLTFSkin> gltf_skin = p_state->skins[skin];
+			ERR_FAIL_INDEX_V(gltf_skin->get_skeleton(), p_state->skeletons.size(), NodePath());
+			Ref<GLTFSkeleton> gltf_skeleton = p_state->skeletons[gltf_skin->get_skeleton()];
+			ERR_FAIL_COND_V(gltf_skeleton->get_roots().size() == 0, NodePath());
+			GLTFNodeIndex skeleton_root_index = gltf_skeleton->get_roots()[0];
+			ERR_FAIL_INDEX_V(skeleton_root_index, gltf_node_count, NodePath());
+			Ref<GLTFNode> skeleton_root_gltf_node = p_state->nodes[skeleton_root_index];
+			if (likely(skeleton_root_gltf_node->parent != -1)) {
+				Ref<GLTFNode> parent_gltf_node = p_state->nodes[skeleton_root_gltf_node->parent];
+				path = parent_gltf_node->get_scene_node_path(p_state).get_names();
+			}
+			if (likely(skeleton_root_gltf_node->parent != -1 || !is_godot_single_root)) {
+				path.append("Skeleton3D");
+			}
+			path.append(get_name());
+			return NodePath(path, subpath, false);
+		} else if (skeleton != -1) {
+			// Special case for skeleton nodes, skip all bones so that the path is to the Skeleton3D node.
+			// A path that would otherwise be `A/B/C/Bone1/Bone2/Bone3` becomes `A/B/C/Skeleton3D:Bone3`.
+			subpath.append(get_name());
+			do {
+				const int parent_index = current_gltf_node->get_parent();
+				if (parent_index == -1) {
+					// The skeleton has no parent glTF node, so it is a glTF root node, and/or the root Godot node.
+					if (!is_godot_single_root) {
+						path.append("Skeleton3D");
+					}
+					return NodePath(path, subpath, false);
+				}
+				ERR_FAIL_INDEX_V(parent_index, gltf_node_count, NodePath());
+				current_gltf_node = p_state->nodes[parent_index];
+			} while (current_gltf_node->skeleton != -1);
+			// The generated Skeleton3D node will be named Skeleton3D, so add it to the path.
+			path.append("Skeleton3D");
+		}
+	}
 	while (true) {
 		const int parent_index = current_gltf_node->get_parent();
 		if (is_godot_single_root && parent_index == -1) {
 			// For GODOT_single_root scenes, the root glTF node becomes the Godot scene root, so it
-			// should not be included in the path. Ex: A/B/C, A is single root, we want B/C only.
+			// should not be included in the path. Ex: `A/B/C`, A is single root, we want `B/C` only.
 			break;
 		}
 		path.insert(0, current_gltf_node->get_name());
+		if (p_handle_skeletons && current_gltf_node->skeleton != -1) {
+			// If a non-skeleton node is a child of a skeleton, it is attached to a bone attachment.
+			// Ex: `A/B/C/Bone1/Bone2/Bone3/D/E/F` should become `A/B/C/Skeleton3D/Bone3/D/E/F`.
+			// Calling `get_scene_node_path` gives us the `A/B/C/Skeleton3D` part, and we append `Bone3/D/E/F`.
+			NodePath skel_path = current_gltf_node->get_scene_node_path(p_state);
+			Vector<StringName> skel_names = skel_path.get_names();
+			skel_names.append_array(path);
+			path = skel_names;
+			return NodePath(skel_names, subpath, false);
+		}
 		if (!is_godot_single_root && parent_index == -1) {
 			break;
 		}

--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -217,27 +217,65 @@ NodePath GLTFNode::get_scene_node_path(Ref<GLTFState> p_state, bool p_handle_ske
 	Vector<StringName> subpath;
 	Ref<GLTFNode> current_gltf_node = this;
 	const int gltf_node_count = p_state->nodes.size();
-	if (p_handle_skeletons && skeleton != -1) {
-		// Special case for skeleton nodes, skip all bones so that the path is to the Skeleton3D node.
-		// A path that would otherwise be `A/B/C/Bone1/Bone2/Bone3` becomes `A/B/C/Skeleton3D:Bone3`.
-		subpath.append(get_name());
-		// The generated Skeleton3D node will be named Skeleton3D, so add it to the path.
-		path.append("Skeleton3D");
-		do {
-			const int parent_index = current_gltf_node->get_parent();
-			ERR_FAIL_INDEX_V(parent_index, gltf_node_count, NodePath());
-			current_gltf_node = p_state->nodes[parent_index];
-		} while (current_gltf_node->skeleton != -1);
-	}
 	const bool is_godot_single_root = p_state->extensions_used.has("GODOT_single_root");
+	if (p_handle_skeletons) {
+		if (skin != -1) {
+			// Special case for skinned meshes, they become a child of a Skeleton3D node.
+			ERR_FAIL_INDEX_V(skin, p_state->skins.size(), NodePath());
+			Ref<GLTFSkin> gltf_skin = p_state->skins[skin];
+			ERR_FAIL_INDEX_V(gltf_skin->get_skeleton(), p_state->skeletons.size(), NodePath());
+			Ref<GLTFSkeleton> gltf_skeleton = p_state->skeletons[gltf_skin->get_skeleton()];
+			ERR_FAIL_COND_V(gltf_skeleton->get_roots().size() == 0, NodePath());
+			GLTFNodeIndex skeleton_root_index = gltf_skeleton->get_roots()[0];
+			ERR_FAIL_INDEX_V(skeleton_root_index, gltf_node_count, NodePath());
+			Ref<GLTFNode> skeleton_root_gltf_node = p_state->nodes[skeleton_root_index];
+			if (likely(skeleton_root_gltf_node->parent != -1)) {
+				Ref<GLTFNode> parent_gltf_node = p_state->nodes[skeleton_root_gltf_node->parent];
+				path = parent_gltf_node->get_scene_node_path(p_state).get_names();
+			}
+			if (likely(skeleton_root_gltf_node->parent != -1 || !is_godot_single_root)) {
+				path.append("Skeleton3D");
+			}
+			path.append(get_name());
+			return NodePath(path, subpath, false);
+		} else if (skeleton != -1) {
+			// Special case for skeleton nodes, skip all bones so that the path is to the Skeleton3D node.
+			// A path that would otherwise be `A/B/C/Bone1/Bone2/Bone3` becomes `A/B/C/Skeleton3D:Bone3`.
+			subpath.append(get_name());
+			do {
+				const int parent_index = current_gltf_node->get_parent();
+				if (parent_index == -1) {
+					// The skeleton has no parent glTF node, so it is a glTF root node, and/or the root Godot node.
+					if (!is_godot_single_root) {
+						path.append("Skeleton3D");
+					}
+					return NodePath(path, subpath, false);
+				}
+				ERR_FAIL_INDEX_V(parent_index, gltf_node_count, NodePath());
+				current_gltf_node = p_state->nodes[parent_index];
+			} while (current_gltf_node->skeleton != -1);
+			// The generated Skeleton3D node will be named Skeleton3D, so add it to the path.
+			path.append("Skeleton3D");
+		}
+	}
 	while (true) {
 		const int parent_index = current_gltf_node->get_parent();
 		if (is_godot_single_root && parent_index == -1) {
 			// For GODOT_single_root scenes, the root glTF node becomes the Godot scene root, so it
-			// should not be included in the path. Ex: A/B/C, A is single root, we want B/C only.
+			// should not be included in the path. Ex: `A/B/C`, A is single root, we want `B/C` only.
 			break;
 		}
 		path.insert(0, current_gltf_node->get_name());
+		if (p_handle_skeletons && current_gltf_node->skeleton != -1) {
+			// If a non-skeleton node is a child of a skeleton, it is attached to a bone attachment.
+			// Ex: `A/B/C/Bone1/Bone2/Bone3/D/E/F` should become `A/B/C/Skeleton3D/Bone3/D/E/F`.
+			// Calling `get_scene_node_path` gives us the `A/B/C/Skeleton3D` part, and we append `Bone3/D/E/F`.
+			NodePath skel_path = current_gltf_node->get_scene_node_path(p_state);
+			Vector<StringName> skel_names = skel_path.get_names();
+			skel_names.append_array(path);
+			path = skel_names;
+			return NodePath(skel_names, subpath, false);
+		}
 		if (!is_godot_single_root && parent_index == -1) {
 			break;
 		}


### PR DESCRIPTION
This PR fixes issue #104728 by adding a new special case for the node path of skinned meshes. Note that this code runs before Godot nodes are generated, so that's why we can't just grab the node path of the generated Godot nodes.