### PR TITLE
Android: Replace the deprecated version macro

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -990,7 +990,7 @@ void EditorExportPlatformAndroid::_get_manifest_info(const Ref<EditorExportPrese
 
 	MetadataInfo editor_version_metadata = {
 		"org.godotengine.editor.version",
-		String(VERSION_FULL_CONFIG)
+		String(GODOT_VERSION_FULL_CONFIG)
 	};
 	r_metadata.append(editor_version_metadata);
 }


### PR DESCRIPTION
Fix compilation with `deprecated=no`, which is a regression introduced by #103173.