### PR TITLE
Fix missing tooltips on "Advanced Import Settings for Scene" window

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1891,6 +1891,9 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	inspector = memnew(EditorInspector);
 	inspector->set_custom_minimum_size(Size2(300 * EDSCALE, 0));
 	inspector->connect(SNAME("property_edited"), callable_mp(this, &SceneImportSettingsDialog::_inspector_property_edited));
+	// Display the same tooltips as in the Import dock.
+	inspector->set_object_class(ResourceImporterScene::get_class_static());
+	inspector->set_use_doc_hints(true);
 
 	property_split->add_child(inspector);
 


### PR DESCRIPTION
Resolves #83484

This commit fixes a regression since 4.2 where settings in the inspector panel on the right part of the "Advanced Import Settings for Scene" window does not contain the same tooltips as its Import Dock counterpart (which were retrieved from the XML class reference).

Before (4.4.1.stable) :
![image](https://github.com/user-attachments/assets/781d7467-ca1b-4124-a8ac-852cb23bd012)

After:
![image](https://github.com/user-attachments/assets/35441124-8271-4991-a376-df2e74e04f6b)

The fix are borrowed from the Import Dock code (`editor\import_dock.cpp`) that has the same tooltips.

Note: I don't think hard coding "ResourceImporterScene" as the object class is the best idea, perhaps those who knows the source better could help? Though i think it's safe for this case?

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
