### PR TITLE
[macOS] Fix missing frame_changed signal to CameraFeed

### DIFF
--- a/modules/camera/camera_android.cpp
+++ b/modules/camera/camera_android.cpp
@@ -368,8 +368,6 @@ void CameraFeedAndroid::onImage(void *context, AImageReader *p_reader) {
 
 	// Release image
 	AImage_delete(image);
-
-	feed->emit_signal(SNAME("frame_changed"));
 }
 
 void CameraFeedAndroid::onSessionReady(void *context, ACameraCaptureSession *session) {

--- a/modules/camera/camera_feed_linux.cpp
+++ b/modules/camera/camera_feed_linux.cpp
@@ -204,8 +204,6 @@ void CameraFeedLinux::_read_frame() {
 	if (ioctl(file_descriptor, VIDIOC_QBUF, &buffer) == -1) {
 		print_error(vformat("ioctl(VIDIOC_QBUF) error: %d.", errno));
 	}
-
-	emit_signal(SNAME("frame_changed"));
 }
 
 void CameraFeedLinux::_stop_capturing() {

--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -196,12 +196,13 @@ void CameraFeed::set_rgb_image(const Ref<Image> &p_rgb_img) {
 			RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_rgb_img);
 			RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_RGBA_IMAGE], new_texture);
 
-			emit_signal(SNAME("format_changed"));
+			emit_signal(format_changed_signal_name);
 		} else {
 			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_RGBA_IMAGE], p_rgb_img);
 		}
 
 		datatype = CameraFeed::FEED_RGB;
+		emit_signal(frame_changed_signal_name);
 	}
 }
 
@@ -219,12 +220,13 @@ void CameraFeed::set_ycbcr_image(const Ref<Image> &p_ycbcr_img) {
 			RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_ycbcr_img);
 			RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_RGBA_IMAGE], new_texture);
 
-			emit_signal(SNAME("format_changed"));
+			emit_signal(format_changed_signal_name);
 		} else {
 			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_RGBA_IMAGE], p_ycbcr_img);
 		}
 
 		datatype = CameraFeed::FEED_YCBCR;
+		emit_signal(frame_changed_signal_name);
 	}
 }
 
@@ -252,13 +254,14 @@ void CameraFeed::set_ycbcr_images(const Ref<Image> &p_y_img, const Ref<Image> &p
 				RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_CBCR_IMAGE], new_texture);
 			}
 
-			emit_signal(SNAME("format_changed"));
+			emit_signal(format_changed_signal_name);
 		} else {
 			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_Y_IMAGE], p_y_img);
 			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_CBCR_IMAGE], p_cbcr_img);
 		}
 
 		datatype = CameraFeed::FEED_YCBCR_SEP;
+		emit_signal(frame_changed_signal_name);
 	}
 }
 
@@ -273,6 +276,7 @@ void CameraFeed::set_external(int p_width, int p_height) {
 	}
 
 	datatype = CameraFeed::FEED_EXTERNAL;
+	emit_signal(frame_changed_signal_name);
 }
 
 bool CameraFeed::activate_feed() {

--- a/servers/camera/camera_feed.h
+++ b/servers/camera/camera_feed.h
@@ -59,6 +59,8 @@ public:
 
 private:
 	int id; // unique id for this, for internal use in case feeds are removed
+	const StringName format_changed_signal_name = "format_changed";
+	const StringName frame_changed_signal_name = "frame_changed";
 
 protected:
 	struct FeedFormat {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
fixed #104808
I will add the missing emit of the frame_changed signal in the CameraFeed class on macOS.

- *Production edit: Related to https://github.com/godot-sdk-integrations/godot-ios-plugins/pull/78.*