### PR TITLE
Replace `append_utfx` with direct `String::utfx`

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -774,8 +774,7 @@ Error ProjectSettings::_load_settings_binary(const String &p_path) {
 		cs.resize(slen + 1);
 		cs[slen] = 0;
 		f->get_buffer((uint8_t *)cs.ptr(), slen);
-		String key;
-		key.append_utf8(cs.ptr(), slen);
+		String key = String::utf8(cs.ptr(), slen);
 
 		uint32_t vlen = f->get_32();
 		Vector<uint8_t> d;

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1052,16 +1052,12 @@ static void gdextension_string_name_new_with_latin1_chars(GDExtensionUninitializ
 }
 
 static void gdextension_string_name_new_with_utf8_chars(GDExtensionUninitializedStringNamePtr r_dest, const char *p_contents) {
-	String tmp;
-	tmp.append_utf8(p_contents);
-
+	String tmp = String::utf8(p_contents);
 	memnew_placement(r_dest, StringName(tmp));
 }
 
 static void gdextension_string_name_new_with_utf8_chars_and_len(GDExtensionUninitializedStringNamePtr r_dest, const char *p_contents, GDExtensionInt p_size) {
-	String tmp;
-	tmp.append_utf8(p_contents, p_size);
-
+	String tmp = String::utf8(p_contents, p_size);
 	memnew_placement(r_dest, StringName(tmp));
 }
 

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -744,9 +744,7 @@ String FileAccess::get_pascal_string() {
 	get_buffer((uint8_t *)cs.ptr(), sl);
 	cs[sl] = 0;
 
-	String ret;
-	ret.append_utf8(cs.ptr(), sl);
-	return ret;
+	return String::utf8(cs.ptr(), sl);
 }
 
 bool FileAccess::store_line(const String &p_line) {

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -306,9 +306,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 		f->get_buffer((uint8_t *)cs.ptr(), sl);
 		cs[sl] = 0;
 
-		String path;
-		path.append_utf8(cs.ptr(), sl);
-
+		String path = String::utf8(cs.ptr(), sl);
 		uint64_t ofs = f->get_64();
 		uint64_t size = f->get_64();
 		uint8_t md5[16];

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -483,8 +483,7 @@ Error HTTPClientTCP::poll() {
 						(rs >= 4 && response_str[rs - 4] == '\r' && response_str[rs - 3] == '\n' && response_str[rs - 2] == '\r' && response_str[rs - 1] == '\n')) {
 					// End of response, parse.
 					response_str.push_back(0);
-					String response;
-					response.append_utf8((const char *)response_str.ptr(), response_str.size());
+					String response = String::utf8((const char *)response_str.ptr(), response_str.size());
 					Vector<String> responses = response.split("\n");
 					body_size = -1;
 					chunked = false;

--- a/core/io/plist.cpp
+++ b/core/io/plist.cpp
@@ -647,10 +647,8 @@ bool PList::load_file(const String &p_filename) {
 		Vector<uint8_t> array = FileAccess::get_file_as_bytes(p_filename, &err);
 		ERR_FAIL_COND_V(err != OK, false);
 
-		String ret;
-		ret.append_utf8((const char *)array.ptr(), array.size());
 		String err_str;
-		bool ok = load_string(ret, err_str);
+		bool ok = load_string(String::utf8((const char *)array.ptr(), array.size()), err_str);
 		ERR_FAIL_COND_V_MSG(!ok, false, "PList: " + err_str);
 
 		return true;

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -162,9 +162,7 @@ StringName ResourceLoaderBinary::_get_string() {
 			return StringName();
 		}
 		f->get_buffer((uint8_t *)&str_buf[0], len);
-		String s;
-		s.append_utf8(&str_buf[0], len);
-		return s;
+		return String::utf8(&str_buf[0], len);
 	}
 
 	return string_map[id];
@@ -918,9 +916,7 @@ static String get_ustring(Ref<FileAccess> f) {
 	Vector<char> str_buf;
 	str_buf.resize(len);
 	f->get_buffer((uint8_t *)&str_buf[0], len);
-	String s;
-	s.append_utf8(&str_buf[0], len);
-	return s;
+	return String::utf8(&str_buf[0], len);
 }
 
 String ResourceLoaderBinary::get_unicode_string() {
@@ -932,9 +928,7 @@ String ResourceLoaderBinary::get_unicode_string() {
 		return String();
 	}
 	f->get_buffer((uint8_t *)&str_buf[0], len);
-	String s;
-	s.append_utf8(&str_buf[0], len);
-	return s;
+	return String::utf8(&str_buf[0], len);
 }
 
 void ResourceLoaderBinary::get_classes_used(Ref<FileAccess> p_f, HashSet<StringName> *p_classes) {

--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -383,9 +383,7 @@ String StreamPeer::get_utf8_string(int p_bytes) {
 	err = get_data(buf.ptrw(), p_bytes);
 	ERR_FAIL_COND_V(err != OK, String());
 
-	String ret;
-	ret.append_utf8((const char *)buf.ptr(), buf.size());
-	return ret;
+	return String::utf8((const char *)buf.ptr(), buf.size());
 }
 
 Variant StreamPeer::get_var(bool p_allow_objects) {

--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -76,8 +76,7 @@ void *zipio_open(voidpf opaque, const char *p_fname, int mode) {
 	Ref<FileAccess> *fa = reinterpret_cast<Ref<FileAccess> *>(opaque);
 	ERR_FAIL_NULL_V(fa, nullptr);
 
-	String fname;
-	fname.append_utf8(p_fname);
+	String fname = String::utf8(p_fname);
 
 	int file_access_mode = 0;
 	if (mode & ZLIB_FILEFUNC_MODE_READ) {

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -253,17 +253,12 @@ StringName OptimizedTranslation::get_message(const StringName &p_src_text, const
 	}
 
 	if (bucket.elem[idx].comp_size == bucket.elem[idx].uncomp_size) {
-		String rstr;
-		rstr.append_utf8(&sptr[bucket.elem[idx].str_offset], bucket.elem[idx].uncomp_size);
-
-		return rstr;
+		return String::utf8(&sptr[bucket.elem[idx].str_offset], bucket.elem[idx].uncomp_size);
 	} else {
 		CharString uncomp;
 		uncomp.resize(bucket.elem[idx].uncomp_size + 1);
 		smaz_decompress(&sptr[bucket.elem[idx].str_offset], bucket.elem[idx].comp_size, uncomp.ptrw(), bucket.elem[idx].uncomp_size);
-		String rstr;
-		rstr.append_utf8(uncomp.get_data());
-		return rstr;
+		return String::utf8(uncomp.get_data());
 	}
 }
 
@@ -283,15 +278,13 @@ Vector<String> OptimizedTranslation::get_translated_message_list() const {
 			const Bucket &bucket = *(const Bucket *)&btptr[p];
 			for (int j = 0; j < bucket.size; j++) {
 				if (bucket.elem[j].comp_size == bucket.elem[j].uncomp_size) {
-					String rstr;
-					rstr.append_utf8(&sptr[bucket.elem[j].str_offset], bucket.elem[j].uncomp_size);
+					String rstr = String::utf8(&sptr[bucket.elem[j].str_offset], bucket.elem[j].uncomp_size);
 					msgs.push_back(rstr);
 				} else {
 					CharString uncomp;
 					uncomp.resize(bucket.elem[j].uncomp_size + 1);
 					smaz_decompress(&sptr[bucket.elem[j].str_offset], bucket.elem[j].comp_size, uncomp.ptrw(), bucket.elem[j].uncomp_size);
-					String rstr;
-					rstr.append_utf8(uncomp.get_data());
+					String rstr = String::utf8(uncomp.get_data());
 					msgs.push_back(rstr);
 				}
 			}

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1127,9 +1127,8 @@ String OS_Unix::get_executable_path() const {
 		WARN_PRINT("Couldn't get executable path from sysctl");
 		return OS::get_executable_path();
 	}
-	String b;
-	b.append_utf8(buf);
-	return b;
+
+	return String::utf8(buf);
 #elif defined(__APPLE__)
 	char temp_path[1];
 	uint32_t buff_size = 1;

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -66,8 +66,7 @@ Error DAPeer::handle_data() {
 			// End of headers
 			if (l > 3 && r[l] == '\n' && r[l - 1] == '\r' && r[l - 2] == '\n' && r[l - 3] == '\r') {
 				r[l - 3] = '\0'; // Null terminate to read string
-				String header;
-				header.append_utf8(r);
+				String header = String::utf8(r);
 				content_length = header.substr(16).to_int();
 				has_header = true;
 				req_pos = 0;
@@ -93,8 +92,7 @@ Error DAPeer::handle_data() {
 		}
 
 		// Parse data
-		String msg;
-		msg.append_utf8((const char *)req_buf, req_pos);
+		String msg = String::utf8((const char *)req_buf, req_pos);
 
 		// Apply a timestamp if it there's none yet
 		if (!timestamp) {

--- a/editor/engine_update_label.cpp
+++ b/editor/engine_update_label.cpp
@@ -61,9 +61,8 @@ void EngineUpdateLabel::_http_request_completed(int p_result, int p_response_cod
 
 	Array version_array;
 	{
-		String s;
 		const uint8_t *r = p_body.ptr();
-		s.append_utf8((const char *)r, p_body.size());
+		String s = String::utf8((const char *)r, p_body.size());
 
 		Variant result = JSON::parse_string(s);
 		if (result == Variant()) {

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -286,11 +286,7 @@ void ExportTemplateManager::_refresh_mirrors_completed(int p_status, int p_code,
 		return;
 	}
 
-	String response_json;
-	{
-		const uint8_t *r = p_data.ptr();
-		response_json.append_utf8((const char *)r, p_data.size());
-	}
+	String response_json = String::utf8((const char *)p_data.ptr(), p_data.size());
 
 	JSON json;
 	Error err = json.parse(response_json);
@@ -469,8 +465,7 @@ bool ExportTemplateManager::_install_file_selected(const String &p_file, bool p_
 			ERR_BREAK_MSG(ret < 0, vformat("An error occurred while attempting to read from file: %s. This file will not be used.", file));
 			unzCloseCurrentFile(pkg);
 
-			String data_str;
-			data_str.append_utf8((const char *)uncomp_data.ptr(), uncomp_data.size());
+			String data_str = String::utf8((const char *)uncomp_data.ptr(), uncomp_data.size());
 			data_str = data_str.strip_edges();
 
 			// Version number should be of the form major.minor[.patch].status[.module_config]

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1214,14 +1214,7 @@ void EditorAssetLibrary::_api_request(const String &p_request, RequestType p_req
 }
 
 void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const PackedStringArray &headers, const PackedByteArray &p_data) {
-	String str;
-
-	{
-		int datalen = p_data.size();
-		const uint8_t *r = p_data.ptr();
-		str.append_utf8((const char *)r, datalen);
-	}
-
+	String str = String::utf8((const char *)p_data.ptr(), (int)p_data.size());
 	bool error_abort = true;
 
 	switch (p_status) {

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -60,8 +60,7 @@ Error GDScriptLanguageProtocol::LSPeer::handle_data() {
 			// End of headers
 			if (l > 3 && r[l] == '\n' && r[l - 1] == '\r' && r[l - 2] == '\n' && r[l - 3] == '\r') {
 				r[l - 3] = '\0'; // Null terminate to read string
-				String header;
-				header.append_utf8(r);
+				String header = String::utf8(r);
 				content_length = header.substr(16).to_int();
 				has_header = true;
 				req_pos = 0;
@@ -87,8 +86,7 @@ Error GDScriptLanguageProtocol::LSPeer::handle_data() {
 		}
 
 		// Parse data
-		String msg;
-		msg.append_utf8((const char *)req_buf, req_pos);
+		String msg = String::utf8((const char *)req_buf, req_pos);
 
 		// Reset to read again
 		req_pos = 0;

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -101,8 +101,7 @@ protected:
 			return;
 		}
 
-		String source;
-		source.append_utf8(reinterpret_cast<const char *>(file.ptr()), file.size());
+		String source = String::utf8(reinterpret_cast<const char *>(file.ptr()), file.size());
 		GDScriptTokenizerBuffer::CompressMode compress_mode = script_mode == EditorExportPreset::MODE_SCRIPT_BINARY_TOKENS_COMPRESSED ? GDScriptTokenizerBuffer::COMPRESS_ZSTD : GDScriptTokenizerBuffer::COMPRESS_NONE;
 		file = GDScriptTokenizerBuffer::parse_code_string(source, compress_mode);
 		if (file.is_empty()) {

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -309,8 +309,7 @@ void test(TestType p_type) {
 	fa->get_buffer(buf.ptrw(), flen);
 	buf.write[flen] = 0;
 
-	String code;
-	code.append_utf8((const char *)&buf[0]);
+	String code = String::utf8((const char *)&buf[0]);
 
 	Vector<String> lines;
 	int last = 0;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -299,8 +299,7 @@ Error GLTFDocument::_parse_json(const String &p_path, Ref<GLTFState> p_state) {
 	Vector<uint8_t> array;
 	array.resize(file->get_length());
 	file->get_buffer(array.ptrw(), array.size());
-	String text;
-	text.append_utf8((const char *)array.ptr(), array.size());
+	String text = String::utf8((const char *)array.ptr(), array.size());
 
 	JSON json;
 	err = json.parse(text);
@@ -330,8 +329,7 @@ Error GLTFDocument::_parse_glb(Ref<FileAccess> p_file, Ref<GLTFState> p_state) {
 	uint32_t len = p_file->get_buffer(json_data.ptrw(), chunk_length);
 	ERR_FAIL_COND_V(len != chunk_length, ERR_FILE_CORRUPT);
 
-	String text;
-	text.append_utf8((const char *)json_data.ptr(), json_data.size());
+	String text = String::utf8((const char *)json_data.ptr(), json_data.size());
 
 	JSON json;
 	Error err = json.parse(text);

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -92,8 +92,7 @@ String cwd() {
 		return ".";
 	}
 
-	String result;
-	result.append_utf16(buffer.ptr());
+	String result = String::utf16((buffer.ptr());
 	if (result.is_empty()) {
 		return ".";
 	}
@@ -145,8 +144,7 @@ String realpath(const String &p_path) {
 
 	::CloseHandle(hFile);
 
-	String result;
-	result.append_utf16(buffer.ptr());
+	String result = String::utf16(buffer.ptr());
 	if (result.is_empty()) {
 		return p_path;
 	}

--- a/modules/multiplayer/scene_cache_interface.cpp
+++ b/modules/multiplayer/scene_cache_interface.cpp
@@ -100,8 +100,7 @@ void SceneCacheInterface::process_simplify_path(int p_from, const uint8_t *p_pac
 	ERR_FAIL_NULL(root_node);
 	int ofs = 1;
 
-	String methods_md5;
-	methods_md5.append_utf8((const char *)(p_packet + ofs), 32);
+	String methods_md5 = String::utf8((const char *)(p_packet + ofs), 32);
 	ofs += 33;
 
 	int id = decode_uint32(&p_packet[ofs]);
@@ -109,8 +108,7 @@ void SceneCacheInterface::process_simplify_path(int p_from, const uint8_t *p_pac
 
 	ERR_FAIL_COND_MSG(peers_info[p_from].recv_nodes.has(id), vformat("Duplicate remote cache ID %d for peer %d", id, p_from));
 
-	String paths;
-	paths.append_utf8((const char *)(p_packet + ofs), p_packet_len - ofs);
+	String paths = String::utf8((const char *)(p_packet + ofs), p_packet_len - ofs);
 
 	const NodePath path = paths;
 

--- a/modules/multiplayer/scene_rpc_interface.cpp
+++ b/modules/multiplayer/scene_rpc_interface.cpp
@@ -135,8 +135,7 @@ Node *SceneRPCInterface::_process_get_node(int p_from, const uint8_t *p_packet, 
 
 		ERR_FAIL_COND_V_MSG(ofs >= p_packet_len, nullptr, "Invalid packet received. Size smaller than declared.");
 
-		String paths;
-		paths.append_utf8((const char *)&p_packet[ofs], p_packet_len - ofs);
+		String paths = String::utf8((const char *)&p_packet[ofs], p_packet_len - ofs);
 
 		NodePath np = paths;
 

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1676,9 +1676,7 @@ String EditorExportPlatformAndroid::_parse_string(const uint8_t *p_bytes, bool p
 			str8.write[i] = p_bytes[offset + i];
 		}
 		str8.write[len] = 0;
-		String str;
-		str.append_utf8((const char *)str8.ptr(), len);
-		return str;
+		return String::utf8((const char *)str8.ptr(), len);
 	} else {
 		String str;
 		for (uint32_t i = 0; i < len; i++) {

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -450,9 +450,8 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 	bool valid_rel_specifier = !provisioning_profile_specifier_rel.is_empty();
 	rel_manual |= valid_rel_specifier;
 
-	String str;
+	String str = String::utf8((const char *)pfile.ptr(), pfile.size());
 	String strnew;
-	str.append_utf8((const char *)pfile.ptr(), pfile.size());
 	Vector<String> lines = str.split("\n");
 	for (int i = 0; i < lines.size(); i++) {
 		if (lines[i].contains("$binary")) {

--- a/platform/ios/keyboard_input_view.mm
+++ b/platform/ios/keyboard_input_view.mm
@@ -122,8 +122,7 @@
 }
 
 - (void)enterText:(NSString *)substring {
-	String characters;
-	characters.append_utf8([substring UTF8String]);
+	String characters = String::utf8([substring UTF8String]);
 
 	for (int i = 0; i < characters.size(); i++) {
 		int character = characters[i];

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -4140,10 +4140,7 @@ String WaylandThread::keyboard_get_layout_name(int p_index) const {
 	SeatState *ss = wl_seat_get_seat_state(wl_seat_current);
 
 	if (ss && ss->xkb_keymap) {
-		String ret;
-		ret.append_utf8(xkb_keymap_layout_get_name(ss->xkb_keymap, p_index));
-
-		return ret;
+		return String::utf8(xkb_keymap_layout_get_name(ss->xkb_keymap, p_index));
 	}
 
 	return "";

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -111,8 +111,7 @@ struct Hints {
 static String get_atom_name(Display *p_disp, Atom p_atom) {
 	char *name = XGetAtomName(p_disp, p_atom);
 	ERR_FAIL_NULL_V_MSG(name, String(), "Atom is invalid.");
-	String ret;
-	ret.append_utf8(name);
+	String ret = String::utf8(name);
 	XFree(name);
 	return ret;
 }
@@ -3684,8 +3683,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 				keycode -= 'a' - 'A';
 			}
 
-			String tmp;
-			tmp.append_utf8(utf8string, utf8bytes);
+			String tmp = String::utf8(utf8string, utf8bytes);
 			for (int i = 0; i < tmp.length(); i++) {
 				Ref<InputEventKey> k;
 				k.instantiate();
@@ -3765,8 +3763,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 				char str_xkb[256] = {};
 				int str_xkb_size = xkb_compose_state_get_utf8(wd.xkb_state, str_xkb, 255);
 
-				String tmp;
-				tmp.append_utf8(str_xkb, str_xkb_size);
+				String tmp = String::utf8(str_xkb, str_xkb_size);
 				for (int i = 0; i < tmp.length(); i++) {
 					Ref<InputEventKey> k;
 					k.instantiate();

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -736,9 +736,8 @@ void EditorExportPlatformMacOS::_make_icon(const Ref<EditorExportPreset> &p_pres
 }
 
 void EditorExportPlatformMacOS::_fix_privacy_manifest(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist) {
-	String str;
+	String str = String::utf8((const char *)plist.ptr(), plist.size());
 	String strnew;
-	str.append_utf8((const char *)plist.ptr(), plist.size());
 	Vector<String> lines = str.split("\n");
 	for (int i = 0; i < lines.size(); i++) {
 		if (lines[i].find("$priv_collection") != -1) {
@@ -815,9 +814,8 @@ void EditorExportPlatformMacOS::_fix_privacy_manifest(const Ref<EditorExportPres
 }
 
 void EditorExportPlatformMacOS::_fix_plist(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist, const String &p_binary) {
-	String str;
+	String str = String::utf8((const char *)plist.ptr(), plist.size());
 	String strnew;
-	str.append_utf8((const char *)plist.ptr(), plist.size());
 	Vector<String> lines = str.split("\n");
 	for (int i = 0; i < lines.size(); i++) {
 		if (lines[i].contains("$binary")) {

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -270,8 +270,7 @@
 	text.resize([characters length] + 1);
 	[characters getCharacters:(unichar *)text.ptrw() range:NSMakeRange(0, [characters length])];
 
-	String u32text;
-	u32text.append_utf16(text.ptr(), text.length());
+	String u32text = String::utf16(text.ptr(), text.length());
 
 	for (int i = 0; i < u32text.length(); i++) {
 		const char32_t codepoint = u32text[i];
@@ -652,8 +651,7 @@
 			text.resize([characters length] + 1);
 			[characters getCharacters:(unichar *)text.ptrw() range:NSMakeRange(0, [characters length])];
 
-			String u32text;
-			u32text.append_utf16(text.ptr(), text.length());
+			String u32text = String::utf16(text.ptr(), text.length());
 
 			DisplayServerMacOS::KeyEvent ke;
 			ke.window_id = window_id;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -110,8 +110,7 @@ Vector<String> OS_MacOS::get_granted_permissions() const {
 			BOOL isStale = NO;
 			NSURL *url = [NSURL URLByResolvingBookmarkData:bookmark options:NSURLBookmarkResolutionWithSecurityScope relativeToURL:nil bookmarkDataIsStale:&isStale error:&error];
 			if (!error && !isStale) {
-				String url_string;
-				url_string.append_utf8([[url path] UTF8String]);
+				String url_string = String::utf8([[url path] UTF8String]);
 				ret.push_back(url_string);
 			}
 		}
@@ -651,10 +650,7 @@ String OS_MacOS::get_executable_path() const {
 	if (ret <= 0) {
 		return OS::get_executable_path();
 	} else {
-		String path;
-		path.append_utf8(pathbuf);
-
-		return path;
+		return String::utf8(pathbuf);
 	}
 }
 
@@ -724,8 +720,7 @@ Error OS_MacOS::create_instance(const List<String> &p_arguments, ProcessID *r_ch
 	// If executable is bundled, always execute editor instances as an app bundle to ensure app window is registered and activated correctly.
 	NSString *nsappname = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];
 	if (nsappname != nil) {
-		String path;
-		path.append_utf8([[[NSBundle mainBundle] bundlePath] UTF8String]);
+		String path = String::utf8([[[NSBundle mainBundle] bundlePath] UTF8String]);
 		return create_process(path, p_arguments, r_child_id, false);
 	} else {
 		return create_process(get_executable_path(), p_arguments, r_child_id, false);


### PR DESCRIPTION
Just some follow up on @Ivorforce [PR](https://github.com/godotengine/godot/pull/104556).
Replacing most` String tmp; tmp.append_utfX` calls with one liner` String::utfX` call.

Might even help the compiler with guaranteed RVO instead of will probably NRVO in some occasions.