### PR TITLE
Rename `_strlen_clipped` to `strnlen` (and use the system equivalent for `char *` inputs)

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -902,8 +902,9 @@ static void gdextension_string_new_with_wide_chars(GDExtensionUninitializedStrin
 }
 
 static void gdextension_string_new_with_latin1_chars_and_len(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size) {
+	const size_t string_length = p_contents ? (p_size < 0 ? strlen(p_contents) : strnlen(p_contents, p_size)) : 0;
 	String *dest = memnew_placement(r_dest, String);
-	dest->append_latin1(Span(p_contents, p_contents ? _strlen_clipped(p_contents, p_size) : 0));
+	dest->append_latin1(Span(p_contents, string_length));
 }
 
 static void gdextension_string_new_with_utf8_chars_and_len(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size) {
@@ -927,8 +928,9 @@ static GDExtensionInt gdextension_string_new_with_utf16_chars_and_len2(GDExtensi
 }
 
 static void gdextension_string_new_with_utf32_chars_and_len(GDExtensionUninitializedStringPtr r_dest, const char32_t *p_contents, GDExtensionInt p_char_count) {
+	const size_t string_length = p_contents ? (p_char_count < 0 ? strlen(p_contents) : strnlen(p_contents, p_char_count)) : 0;
 	String *string = memnew_placement(r_dest, String);
-	string->append_utf32(Span(p_contents, p_contents ? _strlen_clipped(p_contents, p_char_count) : 0));
+	string->append_utf32(Span(p_contents, string_length));
 }
 
 static void gdextension_string_new_with_wide_chars_and_len(GDExtensionUninitializedStringPtr r_dest, const wchar_t *p_contents, GDExtensionInt p_char_count) {
@@ -938,8 +940,9 @@ static void gdextension_string_new_with_wide_chars_and_len(GDExtensionUninitiali
 		dest->append_utf16((const char16_t *)p_contents, p_char_count);
 	} else {
 		// wchar_t is 32 bit (UTF-32).
+		const size_t string_length = p_contents ? (p_char_count < 0 ? strlen(p_contents) : strnlen((const char32_t *)p_contents, p_char_count)) : 0;
 		String *string = memnew_placement(r_dest, String);
-		string->append_utf32(Span((const char32_t *)p_contents, p_contents ? _strlen_clipped((const char32_t *)p_contents, p_char_count) : 0));
+		string->append_utf32(Span((const char32_t *)p_contents, string_length));
 	}
 }
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -66,39 +66,45 @@ constexpr size_t strlen(const char32_t *p_str) {
 }
 
 // strlen equivalent function for wchar_t * arguments; depends on the platform.
-constexpr size_t strlen(const wchar_t *str) {
+constexpr size_t strlen(const wchar_t *p_str) {
 	// Use static_cast twice because reinterpret_cast is not allowed in constexpr
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit
-	return strlen(static_cast<const char16_t *>(static_cast<const void *>(str)));
+	return strlen(static_cast<const char16_t *>(static_cast<const void *>(p_str)));
 #else
 	// wchar_t is 32-bit
-	return strlen(static_cast<const char32_t *>(static_cast<const void *>(str)));
+	return strlen(static_cast<const char32_t *>(static_cast<const void *>(p_str)));
 #endif
 }
 
-constexpr size_t _strlen_clipped(const char *p_str, int p_clip_to_len) {
-	if (p_clip_to_len < 0) {
-		return strlen(p_str);
-	}
-
-	int len = 0;
+// strnlen equivalent function for char16_t * arguments.
+constexpr size_t strnlen(const char16_t *p_str, size_t p_clip_to_len) {
+	size_t len = 0;
 	while (len < p_clip_to_len && *(p_str++) != 0) {
 		len++;
 	}
 	return len;
 }
 
-constexpr size_t _strlen_clipped(const char32_t *p_str, int p_clip_to_len) {
-	if (p_clip_to_len < 0) {
-		return strlen(p_str);
-	}
-
-	int len = 0;
+// strnlen equivalent function for char32_t * arguments.
+constexpr size_t strnlen(const char32_t *p_str, size_t p_clip_to_len) {
+	size_t len = 0;
 	while (len < p_clip_to_len && *(p_str++) != 0) {
 		len++;
 	}
 	return len;
+}
+
+// strnlen equivalent function for wchar_t * arguments; depends on the platform.
+constexpr size_t strnlen(const wchar_t *p_str, size_t p_clip_to_len) {
+	// Use static_cast twice because reinterpret_cast is not allowed in constexpr
+#ifdef WINDOWS_ENABLED
+	// wchar_t is 16-bit
+	return strnlen(static_cast<const char16_t *>(static_cast<const void *>(p_str)), p_clip_to_len);
+#else
+	// wchar_t is 32-bit
+	return strnlen(static_cast<const char32_t *>(static_cast<const void *>(p_str)), p_clip_to_len);
+#endif
 }
 
 template <typename L, typename R>


### PR DESCRIPTION
I only now realized that the functionality is equivalent to [`strnlen`](https://man7.org/linux/man-pages/man3/strnlen.3.html).
The only difference is that `_strlen_clipped` takes an `int`, while `strnlen` takes `size_t`. We'll just let callers use `strlen` if they choose to accept negative arguments (as gdextension currently does).

## Benchmark
Of course I had to test this. `strnlen` is about 10x faster than `_strlen_clipped` we had implemented before:
<details>
<summary>Code</summary>

This took a bit of tricker to prevent inlining (and bring in cache faults):

```c++
	static constexpr size_t N = 10000;
	Vector<char*> vector;
	for (int i = 0; i < 100000; ++i) {
		vector.append((char *)malloc(N));
		for (int j = 0; j < N; ++j) {
			vector.ptr()[i][j] = 2;
		}
		vector.ptr()[i][9000] = 0;
	}

	{
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int j = 0; j < 10; ++j) {
			for (uint64_t i = 0; i < vector.size(); i ++) {
				test1(vector.ptr()[i], N);
			}
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
	{
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int j = 0; j < 10; ++j) {
			for (uint64_t i = 0; i < vector.size(); i ++) {
				test2(vector.ptr()[i], N);
			}
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
```

And in a separate file:
```c++
__attribute__((noinline)) size_t test1(const char *ch, size_t size) {
	return strnlen(ch, size);
}

__attribute__((noinline)) size_t test2(const char *ch, size_t size) {
	return _strlen_clipped(ch, size);
}
```
</details>

This resulted in:
- `248ms` (new code)
- `2916ms` (current master)

The only beneficiary by this point is GDExtension code, because other `_strlen_clipped` callers have been eliminated already.