### PR TITLE
Add button to open user directory in export dialog

### DIFF
--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -189,6 +189,11 @@ bool EditorRunNative::is_deploy_debug_remote_enabled() const {
 	return EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_deploy_remote_debug", true);
 }
 
+void EditorRunNative::open_user_directory() {
+	String user_dir = ProjectSettings::get_singleton()->get_user_data_dir();
+	OS::get_singleton()->shell_open(user_dir);
+}
+
 EditorRunNative::EditorRunNative() {
 	ED_SHORTCUT("remote_deploy/deploy_to_device_1", TTRC("Deploy to First Device in List"), KeyModifierMask::SHIFT | Key::F5);
 	ED_SHORTCUT_OVERRIDE("remote_deploy/deploy_to_device_1", "macos", KeyModifierMask::META | KeyModifierMask::SHIFT | Key::B);

--- a/editor/editor_run_native.h
+++ b/editor/editor_run_native.h
@@ -60,5 +60,7 @@ public:
 
 	bool is_deploy_debug_remote_enabled() const;
 
+	void open_user_directory();
+
 	EditorRunNative();
 };

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1470,6 +1470,12 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_path->set_save_mode();
 	export_path->connect("property_changed", callable_mp(this, &ProjectExportDialog::_export_path_changed));
 
+	// Add the "Open user:// Directory" button
+	Button *open_user_dir_button = memnew(Button);
+	open_user_dir_button->set_text(TTR("Open user:// Directory"));
+	open_user_dir_button->connect(SceneStringName(pressed), callable_mp(this, &ProjectExportDialog::_open_user_directory));
+	settings_vb->add_child(open_user_dir_button);
+
 	// Subsections.
 
 	sections = memnew(TabContainer);
@@ -1803,4 +1809,9 @@ ProjectExportDialog::ProjectExportDialog() {
 			default_filename = "UnnamedProject";
 		}
 	}
+}
+
+void ProjectExportDialog::_open_user_directory() {
+	String user_dir = ProjectSettings::get_singleton()->get_user_data_dir();
+	OS::get_singleton()->shell_open(user_dir);
 }


### PR DESCRIPTION
Add a button to open the `user://` directory in the export dialog.

* **editor/export/project_export.cpp**
  - Add a button labeled "Open user:// Directory" next to the export path field.
  - Implement the button's functionality to open the `user://` directory in the system's file explorer.
  - Add a method `_open_user_directory` to handle the button click event.

* **editor/editor_run_native.cpp**
  - Add a method `open_user_directory` to open the `user://` directory in the system's file explorer.

* **editor/editor_run_native.h**
  - Declare the new method `open_user_directory`.

