### PR TITLE
Reduce memory footprint of virtual methods

### DIFF
--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -15,57 +15,63 @@ script_has_method = """ScriptInstance *_script_instance = ((Object *)(this))->ge
 		}"""
 
 proto = """#define GDVIRTUAL$VER($ALIAS $RET m_name $ARG)\\
-	StringName _gdvirtual_##$VARNAME##_sn = #m_name;\\
-	mutable bool _gdvirtual_##$VARNAME##_initialized = false;\\
-	mutable void *_gdvirtual_##$VARNAME = nullptr;\\
+    mutable void *_gdvirtual_##$VARNAME = nullptr;\\
 	_FORCE_INLINE_ bool _gdvirtual_##$VARNAME##_call($CALLARGS) $CONST {\\
+	    static const StringName _gdvirtual_##$VARNAME##_sn = _scs_create(#m_name, true);\\
 		$SCRIPTCALL\\
-		if (unlikely(_get_extension() && !_gdvirtual_##$VARNAME##_initialized)) {\\
-			MethodInfo mi = _gdvirtual_##$VARNAME##_get_method_info();\\
-			uint32_t hash = mi.get_compatibility_hash();\\
-			_gdvirtual_##$VARNAME = nullptr;\\
-			if (_get_extension()->get_virtual_call_data2 && _get_extension()->call_virtual_with_data) {\\
-				_gdvirtual_##$VARNAME = _get_extension()->get_virtual_call_data2(_get_extension()->class_userdata, &_gdvirtual_##$VARNAME##_sn, hash);\\
-			} else if (_get_extension()->get_virtual2) {\\
-				_gdvirtual_##$VARNAME = (void *)_get_extension()->get_virtual2(_get_extension()->class_userdata, &_gdvirtual_##$VARNAME##_sn, hash);\\
+        if (_get_extension()) {\\
+            if(unlikely(!_gdvirtual_##$VARNAME)) {\\
+				MethodInfo mi = _gdvirtual_##$VARNAME##_get_method_info();\\
+				uint32_t hash = mi.get_compatibility_hash();\\
+				if (_get_extension()->get_virtual_call_data2 && _get_extension()->call_virtual_with_data) {\\
+					_gdvirtual_##$VARNAME = _get_extension()->get_virtual_call_data2(_get_extension()->class_userdata, &_gdvirtual_##$VARNAME##_sn, hash);\\
+				} else if (_get_extension()->get_virtual2) {\\
+					_gdvirtual_##$VARNAME = (void *)_get_extension()->get_virtual2(_get_extension()->class_userdata, &_gdvirtual_##$VARNAME##_sn, hash);\\
+				}\\
+				_GDVIRTUAL_GET_DEPRECATED(_gdvirtual_##$VARNAME, _gdvirtual_##$VARNAME##_sn, $COMPAT)\\
+				_GDVIRTUAL_TRACK(_gdvirtual_##$VARNAME);\\
+				if (!_gdvirtual_##$VARNAME) {\\
+				    _gdvirtual_##$VARNAME= INVALID_GDVIRTUAL_PTR;\\
+				}\\
 			}\\
-			_GDVIRTUAL_GET_DEPRECATED(_gdvirtual_##$VARNAME, _gdvirtual_##$VARNAME##_sn, $COMPAT)\\
-			_GDVIRTUAL_TRACK(_gdvirtual_##$VARNAME, _gdvirtual_##$VARNAME##_initialized);\\
-			_gdvirtual_##$VARNAME##_initialized = true;\\
-		}\\
-		if (_gdvirtual_##$VARNAME) {\\
-			$CALLPTRARGS\\
-			$CALLPTRRETDEF\\
-			if (_get_extension()->call_virtual_with_data) {\\
-				_get_extension()->call_virtual_with_data(_get_extension_instance(), &_gdvirtual_##$VARNAME##_sn, _gdvirtual_##$VARNAME, $CALLPTRARGPASS, $CALLPTRRETPASS);\\
-				$CALLPTRRET\\
-			} else {\\
-				((GDExtensionClassCallVirtual)_gdvirtual_##$VARNAME)(_get_extension_instance(), $CALLPTRARGPASS, $CALLPTRRETPASS);\\
-				$CALLPTRRET\\
+			if (_gdvirtual_##$VARNAME != INVALID_GDVIRTUAL_PTR) {\\
+				$CALLPTRARGS\\
+				$CALLPTRRETDEF\\
+				if (_get_extension()->call_virtual_with_data) {\\
+					_get_extension()->call_virtual_with_data(_get_extension_instance(), &_gdvirtual_##$VARNAME##_sn, _gdvirtual_##$VARNAME, $CALLPTRARGPASS, $CALLPTRRETPASS);\\
+					$CALLPTRRET\\
+				} else {\\
+					((GDExtensionClassCallVirtual)_gdvirtual_##$VARNAME)(_get_extension_instance(), $CALLPTRARGPASS, $CALLPTRRETPASS);\\
+					$CALLPTRRET\\
+				}\\
+				return true;\\
 			}\\
-			return true;\\
 		}\\
 		$REQCHECK\\
 		$RVOID\\
 		return false;\\
 	}\\
 	_FORCE_INLINE_ bool _gdvirtual_##$VARNAME##_overridden() const {\\
+	    static const StringName _gdvirtual_##$VARNAME##_sn = _scs_create(#m_name, true);\\
 		$SCRIPTHASMETHOD\\
-		if (unlikely(_get_extension() && !_gdvirtual_##$VARNAME##_initialized)) {\\
-			MethodInfo mi = _gdvirtual_##$VARNAME##_get_method_info();\\
-			uint32_t hash = mi.get_compatibility_hash();\\
-			_gdvirtual_##$VARNAME = nullptr;\\
-			if (_get_extension()->get_virtual_call_data2 && _get_extension()->call_virtual_with_data) {\\
-				_gdvirtual_##$VARNAME = _get_extension()->get_virtual_call_data2(_get_extension()->class_userdata, &_gdvirtual_##$VARNAME##_sn, hash);\\
-			} else if (_get_extension()->get_virtual2) {\\
-				_gdvirtual_##$VARNAME = (void *)_get_extension()->get_virtual2(_get_extension()->class_userdata, &_gdvirtual_##$VARNAME##_sn, hash);\\
+        if (_get_extension()) {\\
+            if(unlikely(!_gdvirtual_##$VARNAME)) {\\
+				MethodInfo mi = _gdvirtual_##$VARNAME##_get_method_info();\\
+				uint32_t hash = mi.get_compatibility_hash();\\
+				if (_get_extension()->get_virtual_call_data2 && _get_extension()->call_virtual_with_data) {\\
+					_gdvirtual_##$VARNAME = _get_extension()->get_virtual_call_data2(_get_extension()->class_userdata, &_gdvirtual_##$VARNAME##_sn, hash);\\
+				} else if (_get_extension()->get_virtual2) {\\
+					_gdvirtual_##$VARNAME = (void *)_get_extension()->get_virtual2(_get_extension()->class_userdata, &_gdvirtual_##$VARNAME##_sn, hash);\\
+				}\\
+				_GDVIRTUAL_GET_DEPRECATED(_gdvirtual_##$VARNAME, _gdvirtual_##$VARNAME##_sn, $COMPAT)\\
+				_GDVIRTUAL_TRACK(_gdvirtual_##$VARNAME);\\
+				if (!_gdvirtual_##$VARNAME) {\\
+				    _gdvirtual_##$VARNAME= INVALID_GDVIRTUAL_PTR;\\
+				}\\
 			}\\
-			_GDVIRTUAL_GET_DEPRECATED(_gdvirtual_##$VARNAME, _gdvirtual_##$VARNAME##_sn, $COMPAT)\\
-			_GDVIRTUAL_TRACK(_gdvirtual_##$VARNAME, _gdvirtual_##$VARNAME##_initialized);\\
-			_gdvirtual_##$VARNAME##_initialized = true;\\
-		}\\
-		if (_gdvirtual_##$VARNAME) {\\
-			return true;\\
+			if (_gdvirtual_##$VARNAME != INVALID_GDVIRTUAL_PTR) {\\
+				return true;\\
+			}\\
 		}\\
 		return false;\\
 	}\\
@@ -102,7 +108,7 @@ def generate_version(argcount, const=False, returns=False, required=False, compa
     else:
         s = s.replace("$RET ", "")
         s = s.replace("\t\t$RVOID\\\n", "")
-        s = s.replace("\t\t\t$CALLPTRRETDEF\\\n", "")
+        s = s.replace("\t\t\t\t$CALLPTRRETDEF\\\n", "")
 
     if const:
         sproto += "C"
@@ -211,17 +217,19 @@ def run(target, source, env):
 
 #include "core/object/script_instance.h"
 
+inline int const INVALID_GDVIRTUAL_VARIABLE = 0;
+inline void* const INVALID_GDVIRTUAL_PTR = static_cast<void*>(const_cast<int*>(&INVALID_GDVIRTUAL_VARIABLE));
+
 #ifdef TOOLS_ENABLED
-#define _GDVIRTUAL_TRACK(m_virtual, m_initialized)\\
+#define _GDVIRTUAL_TRACK(m_virtual)\\
 	if (_get_extension()->reloadable) {\\
 		VirtualMethodTracker *tracker = memnew(VirtualMethodTracker);\\
 		tracker->method = (void **)&m_virtual;\\
-		tracker->initialized = &m_initialized;\\
 		tracker->next = virtual_method_list;\\
 		virtual_method_list = tracker;\\
 	}
 #else
-#define _GDVIRTUAL_TRACK(m_virtual, m_initialized)
+#define _GDVIRTUAL_TRACK(m_virtual)
 #endif
 
 #ifndef DISABLE_DEPRECATED

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2102,7 +2102,6 @@ void Object::clear_internal_extension() {
 	// Clear the virtual methods.
 	while (virtual_method_list) {
 		(*virtual_method_list->method) = nullptr;
-		(*virtual_method_list->initialized) = false;
 		virtual_method_list = virtual_method_list->next;
 	}
 }

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -764,7 +764,6 @@ protected:
 #ifdef TOOLS_ENABLED
 	struct VirtualMethodTracker {
 		void **method;
-		bool *initialized;
 		VirtualMethodTracker *next;
 	};
 


### PR DESCRIPTION
I noticed that for each virtual methods we were allocating 3 different non-static variables:
- A StringName for the name of the method.
- A void pointer for the GDExtension callback.
- A boolean to check if the callback was set.

Taking into account memory alignment, this is a cost of 24 bytes of memory per virtual method per instance, which adds up quickly.
For example, Node has 10 virtual methods, which means a cost 240 bytes per instance, even if you don't use any extension.

I removed the boolean and _replaced its associated use with a null pointer check_**( Edit: This approach was wrong. I changed it afterward, see next messages)**. The StringName is now static to avoid allocating one per instance as well.
This reduces the memory cost of a virtual method to 8 bytes per instance, reducing the total size by 160 bytes for Node, and 280 bytes for Control (picked those examples as they are the most common to use).

Node:
- master: 1072 Bytes
- PR: 912 Bytes

Control:
- master: 2560 Bytes
- PR: 2240 Bytes

Another example for a class that is mostly made of virtual methods:

PhysicsDirectBodyState3DExtension :
- master: 1520 Bytes
- PR: 784 Bytes
