### PR TITLE
Add maven publishing configuration for Godot tools

### DIFF
--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -79,7 +79,7 @@ def templateExcludedBuildTask() {
     // We exclude these gradle tasks so we can run the scons command manually.
     def excludedTasks = []
     if (excludeSconsBuildTasks()) {
-        logger.lifecycle("Excluding Android studio build tasks")
+        logger.info("Excluding Android studio build tasks")
         for (String flavor : supportedFlavors) {
             String[] supportedBuildTypes = supportedFlavorsBuildTypes[flavor]
             for (String buildType : supportedBuildTypes) {
@@ -206,7 +206,7 @@ def generateBuildTasks(String flavor = "template", String edition = "standard", 
                 }
             }
         } else {
-            logger.lifecycle("No native shared libs for target $target. Skipping build.")
+            logger.info("No native shared libs for target $target. Skipping build.")
         }
     }
 

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 ext {
     PUBLISH_ARTIFACT_ID = 'godot'
+    TOOLS_PUBLISH_ARTIFACT_ID = 'godot-tools'
 }
 
 apply from: "../scripts/publish-module.gradle"
@@ -182,6 +183,10 @@ android {
 
     publishing {
         singleVariant("templateRelease") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+        singleVariant("editorRelease") {
             withSourcesJar()
             withJavadocJar()
         }

--- a/platform/android/java/scripts/publish-module.gradle
+++ b/platform/android/java/scripts/publish-module.gradle
@@ -19,7 +19,55 @@ afterEvaluate {
                 // Mostly self-explanatory metadata
                 pom {
                     name = PUBLISH_ARTIFACT_ID
-                    description = 'Godot Engine Android Library'
+                    description = 'Godot Engine Android Library - Template Build'
+                    url = 'https://godotengine.org/'
+                    licenses {
+                        license {
+                            name = 'MIT License'
+                            url = 'https://github.com/godotengine/godot/blob/master/LICENSE.txt'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'm4gr3d'
+                            name = 'Fredia Huya-Kouadio'
+                            email = 'fhuyakou@gmail.com'
+                        }
+                        developer {
+                            id = 'reduz'
+                            name = 'Juan Linietsky'
+                            email = 'reduzio@gmail.com'
+                        }
+                        developer {
+                            id = 'akien-mga'
+                            name = 'Rémi Verschelde'
+                            email = 'rverschelde@gmail.com'
+                        }
+                        // Add all other devs here...
+                    }
+
+                    // Version control info - if you're using GitHub, follow the
+                    // format as seen here
+                    scm {
+                        connection = 'scm:git:github.com/godotengine/godot.git'
+                        developerConnection = 'scm:git:ssh://github.com/godotengine/godot.git'
+                        url = 'https://github.com/godotengine/godot/tree/master'
+                    }
+                }
+            }
+            toolsRelease(MavenPublication) {
+                from components.editorRelease
+
+                // The coordinates of the library, being set from variables that
+                // we'll set up later
+                groupId ossrhGroupId
+                artifactId TOOLS_PUBLISH_ARTIFACT_ID
+                version PUBLISH_VERSION
+
+                // Mostly self-explanatory metadata
+                pom {
+                    name = TOOLS_PUBLISH_ARTIFACT_ID
+                    description = 'Godot Engine Tools Android Library - Editor Build'
                     url = 'https://godotengine.org/'
                     licenses {
                         license {


### PR DESCRIPTION
The Godot Android library on MavenCentral is a `template` build; this updated configuration adds a new 'Godot Tools' publishing artifact, allowing developers access to the `editor` build of the Godot Android library.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
