### PR TITLE
[3.x] Make changes for simplified ObjectDB::get_instance() casting

### DIFF
--- a/core/error_macros.cpp
+++ b/core/error_macros.cpp
@@ -153,7 +153,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 				String node_name;
 				if (p_id != 0) {
 					if (ObjectDB::get_instance(p_id)) {
-						Node *node = Object::cast_to<Node>(ObjectDB::get_instance(p_id));
+						Node *node = ObjectDB::get_instance<Node>(p_id);
 						if (node && node->is_inside_tree()) {
 							node_name = "\"" + String(node->get_path()) + "\"";
 						} else {

--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -910,7 +910,7 @@ void MultiplayerAPI::_init_node_profile(ObjectID p_node) {
 	}
 	profiler_frame_data.insert(p_node, ProfilingInfo());
 	profiler_frame_data[p_node].node = p_node;
-	profiler_frame_data[p_node].node_path = Object::cast_to<Node>(ObjectDB::get_instance(p_node))->get_path();
+	profiler_frame_data[p_node].node_path = ObjectDB::get_instance<Node>(p_node)->get_path();
 	profiler_frame_data[p_node].incoming_rpc = 0;
 	profiler_frame_data[p_node].incoming_rset = 0;
 	profiler_frame_data[p_node].outgoing_rpc = 0;

--- a/editor/array_property_edit.cpp
+++ b/editor/array_property_edit.cpp
@@ -275,7 +275,7 @@ void ArrayPropertyEdit::edit(Object *p_obj, const StringName &p_prop, const Stri
 }
 
 Node *ArrayPropertyEdit::get_node() {
-	return Object::cast_to<Node>(ObjectDB::get_instance(obj));
+	return ObjectDB::get_instance<Node>(obj);
 }
 
 bool ArrayPropertyEdit::_dont_undo_redo() {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -663,7 +663,7 @@ void CanvasItemEditor::_get_bones_at_pos(const Point2 &p_pos, Vector<_SelectResu
 	Point2 screen_pos = transform.xform(p_pos);
 
 	for (Map<BoneKey, BoneList>::Element *E = bone_list.front(); E; E = E->next()) {
-		Node2D *from_node = Object::cast_to<Node2D>(ObjectDB::get_instance(E->key().from));
+		Node2D *from_node = ObjectDB::get_instance<Node2D>(E->key().from);
 
 		Vector<Vector2> bone_shape;
 		if (!_get_bone_shape(&bone_shape, nullptr, E)) {
@@ -698,8 +698,8 @@ bool CanvasItemEditor::_get_bone_shape(Vector<Vector2> *shape, Vector<Vector2> *
 	int bone_width = EditorSettings::get_singleton()->get("editors/2d/bone_width");
 	int bone_outline_width = EditorSettings::get_singleton()->get("editors/2d/bone_outline_size");
 
-	Node2D *from_node = Object::cast_to<Node2D>(ObjectDB::get_instance(bone->key().from));
-	Node2D *to_node = Object::cast_to<Node2D>(ObjectDB::get_instance(bone->key().to));
+	Node2D *from_node = ObjectDB::get_instance<Node2D>(bone->key().from);
+	Node2D *to_node = ObjectDB::get_instance<Node2D>(bone->key().to);
 
 	if (!from_node) {
 		return false;
@@ -3766,7 +3766,7 @@ void CanvasItemEditor::_draw_bones() {
 				continue;
 			}
 
-			Node2D *from_node = Object::cast_to<Node2D>(ObjectDB::get_instance(E->key().from));
+			Node2D *from_node = ObjectDB::get_instance<Node2D>(E->key().from);
 			if (!from_node->is_visible_in_tree()) {
 				continue;
 			}
@@ -4377,7 +4377,7 @@ void CanvasItemEditor::_update_bone_list() {
 			continue;
 		}
 
-		Node *node = Object::cast_to<Node>(ObjectDB::get_instance(E->key().from));
+		Node *node = ObjectDB::get_instance<Node>(E->key().from);
 		if (!node || !node->is_inside_tree() || (node != get_tree()->get_edited_scene_root() && !get_tree()->get_edited_scene_root()->is_a_parent_of(node))) {
 			bone_to_erase.push_back(E);
 			continue;
@@ -5242,7 +5242,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			undo_redo->create_action(TTR("Paste Pose"));
 			for (List<PoseClipboard>::Element *E = pose_clipboard.front(); E; E = E->next()) {
-				Node2D *n2d = Object::cast_to<Node2D>(ObjectDB::get_instance(E->get().id));
+				Node2D *n2d = ObjectDB::get_instance<Node2D>(E->get().id);
 				if (!n2d) {
 					continue;
 				}

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -637,7 +637,7 @@ void SpatialEditorViewport::_select_clicked(bool p_append, bool p_single, bool p
 		return;
 	}
 
-	Node *node = Object::cast_to<Node>(ObjectDB::get_instance(clicked));
+	Node *node = ObjectDB::get_instance<Node>(clicked);
 	Spatial *selected = Object::cast_to<Spatial>(node);
 	if (!selected) {
 		return;
@@ -697,7 +697,7 @@ ObjectID SpatialEditorViewport::_select_ray(const Point2 &p_pos, bool p_append, 
 	int selected_handle = -1;
 
 	for (int i = 0; i < instances.size(); i++) {
-		Spatial *spat = Object::cast_to<Spatial>(ObjectDB::get_instance(instances[i]));
+		Spatial *spat = ObjectDB::get_instance<Spatial>(instances[i]);
 
 		if (!spat) {
 			continue;
@@ -761,7 +761,7 @@ void SpatialEditorViewport::_find_items_at_pos(const Point2 &p_pos, bool &r_incl
 	r_includes_current = false;
 
 	for (int i = 0; i < instances.size(); i++) {
-		Spatial *spat = Object::cast_to<Spatial>(ObjectDB::get_instance(instances[i]));
+		Spatial *spat = ObjectDB::get_instance<Spatial>(instances[i]);
 
 		if (!spat) {
 			continue;
@@ -884,7 +884,7 @@ void SpatialEditorViewport::_select_region() {
 	Node *edited_scene = get_tree()->get_edited_scene_root();
 
 	for (int i = 0; i < instances.size(); i++) {
-		Spatial *sp = Object::cast_to<Spatial>(ObjectDB::get_instance(instances[i]));
+		Spatial *sp = ObjectDB::get_instance<Spatial>(instances[i]);
 		if (!sp || _is_node_locked(sp)) {
 			continue;
 		}
@@ -1592,7 +1592,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					}
 
 					if (clicked && gizmo_handle >= 0) {
-						Spatial *spa = Object::cast_to<Spatial>(ObjectDB::get_instance(clicked));
+						Spatial *spa = ObjectDB::get_instance<Spatial>(clicked);
 						if (spa) {
 							Ref<EditorSpatialGizmo> seg = spa->get_gizmo();
 							if (seg.is_valid()) {

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1319,7 +1319,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 				if (inspect_edited_object_timeout < 0) {
 					inspect_edited_object_timeout = EditorSettings::get_singleton()->get("debugger/remote_inspect_refresh_interval");
 					if (inspected_object_id) {
-						if (ScriptEditorDebuggerInspectedObject *obj = Object::cast_to<ScriptEditorDebuggerInspectedObject>(ObjectDB::get_instance(editor->get_editor_history()->get_current()))) {
+						if (ScriptEditorDebuggerInspectedObject *obj = ObjectDB::get_instance<ScriptEditorDebuggerInspectedObject>(editor->get_editor_history()->get_current())) {
 							if (obj->remote_object_id == inspected_object_id) {
 								//take the chance and re-inspect selected object
 								Array msg;

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1510,7 +1510,7 @@ real_t KinematicCollision2D::get_angle(const Vector2 &p_up_direction) const {
 }
 
 Object *KinematicCollision2D::get_local_shape() const {
-	PhysicsBody2D *owner = Object::cast_to<PhysicsBody2D>(ObjectDB::get_instance(owner_id));
+	PhysicsBody2D *owner = ObjectDB::get_instance<PhysicsBody2D>(owner_id);
 	if (!owner) {
 		return nullptr;
 	}

--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -52,7 +52,7 @@ void RemoteTransform2D::_update_remote() {
 		return;
 	}
 
-	Node2D *n = Object::cast_to<Node2D>(ObjectDB::get_instance(cache));
+	Node2D *n = ObjectDB::get_instance<Node2D>(cache);
 	if (!n) {
 		return;
 	}

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1547,7 +1547,7 @@ real_t KinematicCollision::get_angle(const Vector3 &p_up_direction) const {
 }
 
 Object *KinematicCollision::get_local_shape() const {
-	PhysicsBody *owner = Object::cast_to<PhysicsBody>(ObjectDB::get_instance(owner_id));
+	PhysicsBody *owner = ObjectDB::get_instance<PhysicsBody>(owner_id);
 	if (!owner) {
 		return nullptr;
 	}

--- a/scene/3d/remote_transform.cpp
+++ b/scene/3d/remote_transform.cpp
@@ -51,7 +51,7 @@ void RemoteTransform::_update_remote() {
 		return;
 	}
 
-	Spatial *n = Object::cast_to<Spatial>(ObjectDB::get_instance(cache));
+	Spatial *n = ObjectDB::get_instance<Spatial>(cache);
 	if (!n) {
 		return;
 	}

--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -152,7 +152,7 @@ void RoomManager::_preview_camera_update() {
 	RID scenario = world->get_scenario();
 
 	if (_godot_preview_camera_ID != (ObjectID)-1) {
-		Camera *cam = Object::cast_to<Camera>(ObjectDB::get_instance(_godot_preview_camera_ID));
+		Camera *cam = ObjectDB::get_instance<Camera>(_godot_preview_camera_ID);
 		if (!cam) {
 			_godot_preview_camera_ID = (ObjectID)-1;
 		} else {

--- a/scene/animation/scene_tree_tween.cpp
+++ b/scene/animation/scene_tree_tween.cpp
@@ -349,7 +349,7 @@ bool SceneTreeTween::can_process(bool p_tree_paused) const {
 
 Node *SceneTreeTween::get_bound_node() const {
 	if (is_bound) {
-		return Object::cast_to<Node>(ObjectDB::get_instance(bound_node));
+		return ObjectDB::get_instance<Node>(bound_node);
 	} else {
 		return nullptr;
 	}

--- a/scene/debugger/script_debugger_remote.cpp
+++ b/scene/debugger/script_debugger_remote.cpp
@@ -118,7 +118,7 @@ void ScriptDebuggerRemote::_put_variable(const String &p_name, const Variant &p_
 }
 
 void ScriptDebuggerRemote::_save_node(ObjectID id, const String &p_path) {
-	Node *node = Object::cast_to<Node>(ObjectDB::get_instance(id));
+	Node *node = ObjectDB::get_instance<Node>(id);
 	ERR_FAIL_COND(!node);
 
 	Ref<PackedScene> ps = memnew(PackedScene);

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -1006,7 +1006,7 @@ void TabContainer::set_popup(Node *p_popup) {
 
 Popup *TabContainer::get_popup() const {
 	if (popup_obj_id) {
-		Popup *popup = Object::cast_to<Popup>(ObjectDB::get_instance(popup_obj_id));
+		Popup *popup = ObjectDB::get_instance<Popup>(popup_obj_id);
 		if (popup) {
 			return popup;
 		} else {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -621,7 +621,7 @@ void Viewport::_process_picking(bool p_ignore_paused) {
 		bool captured = false;
 
 		if (physics_object_capture != 0) {
-			CollisionObject *co = Object::cast_to<CollisionObject>(ObjectDB::get_instance(physics_object_capture));
+			CollisionObject *co = ObjectDB::get_instance<CollisionObject>(physics_object_capture);
 			if (co && camera) {
 				_collision_object_input_event(co, camera, ev, Vector3(), Vector3(), 0);
 				captured = true;
@@ -671,14 +671,14 @@ void Viewport::_process_picking(bool p_ignore_paused) {
 
 					if (is_mouse && new_collider != physics_object_over) {
 						if (physics_object_over) {
-							CollisionObject *co = Object::cast_to<CollisionObject>(ObjectDB::get_instance(physics_object_over));
+							CollisionObject *co = ObjectDB::get_instance<CollisionObject>(physics_object_over);
 							if (co) {
 								co->_mouse_exit();
 							}
 						}
 
 						if (new_collider) {
-							CollisionObject *co = Object::cast_to<CollisionObject>(ObjectDB::get_instance(new_collider));
+							CollisionObject *co = ObjectDB::get_instance<CollisionObject>(new_collider);
 							if (co) {
 								co->_mouse_enter();
 							}
@@ -2337,7 +2337,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			}
 		} else {
 			ObjectID control_id = gui.touch_focus[touch_index];
-			Control *over = Object::cast_to<Control>(ObjectDB::get_instance(control_id));
+			Control *over = ObjectDB::get_instance<Control>(control_id);
 			if (over && over->can_process()) {
 				touch_event = touch_event->xformed_by(Transform2D()); //make a copy
 				if (over == gui.last_mouse_focus) {
@@ -2384,7 +2384,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 	if (drag_event.is_valid()) {
 		const int drag_event_index = drag_event->get_index();
 		ObjectID control_id = gui.touch_focus[drag_event_index];
-		Control *over = Object::cast_to<Control>(ObjectDB::get_instance(control_id));
+		Control *over = ObjectDB::get_instance<Control>(control_id);
 		if (!over) {
 			over = _gui_find_control(drag_event->get_position());
 		}
@@ -2624,7 +2624,7 @@ Control *Viewport::_gui_get_drag_preview() {
 	if (!gui.drag_preview_id) {
 		return nullptr;
 	} else {
-		Control *drag_preview = Object::cast_to<Control>(ObjectDB::get_instance(gui.drag_preview_id));
+		Control *drag_preview = ObjectDB::get_instance<Control>(gui.drag_preview_id);
 		if (!drag_preview) {
 			ERR_PRINT("Don't free the control set as drag preview.");
 			gui.drag_preview_id = 0;
@@ -2787,7 +2787,7 @@ void Viewport::_drop_physics_mouseover(bool p_paused_only) {
 
 #ifndef _3D_DISABLED
 	if (physics_object_over) {
-		CollisionObject *co = Object::cast_to<CollisionObject>(ObjectDB::get_instance(physics_object_over));
+		CollisionObject *co = ObjectDB::get_instance<CollisionObject>(physics_object_over);
 		if (co) {
 			if (!co->is_inside_tree()) {
 				physics_object_over = physics_object_capture = 0;


### PR DESCRIPTION
This PR implements the use of the syntactic sugar from #100603 .

Related to #100602 in master.

## Notes
* This is very simple, converting the long form to the short form, there should be no change in functionality.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
