### PR TITLE
[3.x] Use the in-built casting instead of `dynamic_cast` on all platforms

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -262,6 +262,16 @@ public:                                                             \
                                                                     \
 private:
 
+// This is a barebones version of GDCLASS,
+// only intended for simple classes deriving from Object
+// so that they can support the `Object::cast_to()` method.
+#define GDSOFTCLASS(m_class, m_inherits)                                                                                                \
+public:                                                                                                                                 \
+	typedef m_class self_type;                                                                                                          \
+	virtual bool is_class_ptr(void *p_ptr) const { return (p_ptr == get_class_ptr_static()) ? true : m_inherits::is_class_ptr(p_ptr); } \
+                                                                                                                                        \
+private:
+
 #define GDCLASS(m_class, m_inherits)                                                                                                    \
 private:                                                                                                                                \
 	void operator=(const m_class &p_rval) {}                                                                                            \
@@ -609,30 +619,26 @@ public:
 
 	template <class T>
 	static T *cast_to(Object *p_object) {
-#ifndef NO_SAFE_CAST
-		return dynamic_cast<T *>(p_object);
-#else
+		static_assert(std::is_base_of<Object, T>::value, "T must be derived from Object");
+		static_assert(std::is_same<std::decay_t<T>, typename T::self_type>::value, "T must use GDCLASS or GDSOFTCLASS");
 		if (!p_object)
 			return NULL;
 		if (p_object->is_class_ptr(T::get_class_ptr_static()))
 			return static_cast<T *>(p_object);
 		else
 			return NULL;
-#endif
 	}
 
 	template <class T>
 	static const T *cast_to(const Object *p_object) {
-#ifndef NO_SAFE_CAST
-		return dynamic_cast<const T *>(p_object);
-#else
+		static_assert(std::is_base_of<Object, T>::value, "T must be derived from Object");
+		static_assert(std::is_same<std::decay_t<T>, typename T::self_type>::value, "T must use GDCLASS or GDSOFTCLASS");
 		if (!p_object)
 			return NULL;
 		if (p_object->is_class_ptr(T::get_class_ptr_static()))
 			return static_cast<const T *>(p_object);
 		else
 			return NULL;
-#endif
 	}
 
 	enum {

--- a/modules/camera/camera_osx.mm
+++ b/modules/camera/camera_osx.mm
@@ -200,6 +200,8 @@
 // CameraFeedOSX - Subclass for camera feeds in OSX
 
 class CameraFeedOSX : public CameraFeed {
+	GDSOFTCLASS(CameraFeedOSX, CameraFeed);
+
 private:
 	AVCaptureDevice *device;
 	MyCaptureSession *capture_session;

--- a/modules/mbedtls/crypto_mbedtls.h
+++ b/modules/mbedtls/crypto_mbedtls.h
@@ -41,6 +41,8 @@
 class CryptoMbedTLS;
 class SSLContextMbedTLS;
 class CryptoKeyMbedTLS : public CryptoKey {
+	GDSOFTCLASS(CryptoKeyMbedTLS, CryptoKey);
+
 private:
 	mbedtls_pk_context pkey;
 	int locks = 0;
@@ -73,6 +75,8 @@ public:
 };
 
 class X509CertificateMbedTLS : public X509Certificate {
+	GDSOFTCLASS(X509CertificateMbedTLS, X509Certificate);
+
 private:
 	mbedtls_x509_crt cert;
 	int locks;

--- a/modules/websocket/websocket_macros.h
+++ b/modules/websocket/websocket_macros.h
@@ -63,6 +63,7 @@ protected:
 	CNAME *(*CNAME::_create)() = NULL;
 
 #define GDCIIMPL(IMPNAME, CNAME)                                      \
+	GDSOFTCLASS(IMPNAME, CNAME)                                       \
 public:                                                               \
 	static CNAME *_create() { return memnew(IMPNAME); }               \
 	static void make_default() { CNAME::_create = IMPNAME::_create; } \

--- a/platform/osx/export/codesign.h
+++ b/platform/osx/export/codesign.h
@@ -125,6 +125,8 @@ public:
 /*************************************************************************/
 
 class CodeSignBlob : public Reference {
+	GDSOFTCLASS(CodeSignBlob, Reference);
+
 public:
 	virtual PoolByteArray get_hash_sha1() const = 0;
 	virtual PoolByteArray get_hash_sha256() const = 0;


### PR DESCRIPTION
The in-built casting appears significantly faster than `dynamic_cast`.

## Notes
* In #103708 @Ivorforce noticed that a DIY cast through our Object hierarchy was much faster than using `dynamic_cast`.
* It turns out that 3.x already has an analogous method available, and it is already used on web and Android (where `NO_SAFE_CAST` is defined).
* There doesn't seem a compelling reason to not use the faster method on all platforms (as with 4.x).
* This significantly speeds up the `SceneTreeFTI` for 3D physics interpolation (by 2 or 3x), which is one of the heavier users of runtime scene tree traversal.

## Discussion
I've not added the same backup for non-GDCLASS objects, I don't think we have this problem on 3.x (well it already compiles without it on web and Android). Indeed, we probably *can't* easily support `dynamic_cast` on `NO_SAFE_CAST` platforms anyway.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
