### PR TITLE
Add null check for SpriteFramesEditor's SpriteFrames

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1294,6 +1294,10 @@ void SpriteFramesEditor::_animation_speed_resized() {
 }
 
 void SpriteFramesEditor::_animation_speed_changed(double p_value) {
+	if (frames.is_null()) {
+		return;
+	}
+
 	if (updating) {
 		return;
 	}
@@ -1374,6 +1378,10 @@ void SpriteFramesEditor::_frame_list_item_selected(int p_index, bool p_selected)
 }
 
 void SpriteFramesEditor::_frame_duration_changed(double p_value) {
+	if (frames.is_null()) {
+		return;
+	}
+
 	if (updating) {
 		return;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #104822

Adding missing null checks for `frames` seems to be more in-line with existing code, (see also: AnimationTrackEditor's `animation.ptr()` null checks) so this is the solution I ended up with.