### PR TITLE
Fix 'LinkError' when GDExtension enables exceptions

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -260,6 +260,8 @@ def configure(env: "SConsEnvironment"):
         env.Append(LINKFLAGS=["-sSIDE_MODULE=2"])
         env.Append(CCFLAGS=["-fvisibility=hidden"])
         env.Append(LINKFLAGS=["-fvisibility=hidden"])
+        env.Append(CCFLAGS=["-fwasm-exceptions"])
+        env.Append(LINKFLAGS=["-fwasm-exceptions"])
         env.extra_suffix = ".dlink" + env.extra_suffix
 
     env.Append(LINKFLAGS=["-sWASM_BIGINT"])


### PR DESCRIPTION
Add `-fwasm-exceptions` options when compiling for the web with gdextension enabled, which allows gdextension enable exceptions.

* *Bugsquad edit, fixes: #104835*