### PR TITLE
Add `erase_unordered()` to LocalVector

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -103,6 +103,15 @@ public:
 		return false;
 	}
 
+	bool erase_unordered(const T &p_val) {
+		int64_t idx = find(p_val);
+		if (idx >= 0) {
+			remove_at_unordered(idx);
+			return true;
+		}
+		return false;
+	}
+
 	U erase_multiple_unordered(const T &p_val) {
 		U from = 0;
 		U occurrences = 0;

--- a/tests/core/templates/test_local_vector.h
+++ b/tests/core/templates/test_local_vector.h
@@ -178,6 +178,23 @@ TEST_CASE("[LocalVector] Remove Unordered.") {
 	CHECK(vector.size() == 0);
 }
 
+TEST_CASE("[LocalVector] Erase Unordered.") {
+	LocalVector<int> vector;
+	vector.push_back(1);
+	vector.push_back(3);
+	vector.push_back(0);
+	vector.push_back(2);
+	vector.push_back(4);
+
+	CHECK(vector.find(1) == 0);
+
+	vector.erase_unordered(1);
+
+	CHECK(vector.find(1) == -1);
+	CHECK(vector.size() == 4);
+	CHECK(vector[0] == 4);
+}
+
 TEST_CASE("[LocalVector] Erase.") {
 	LocalVector<int> vector;
 	vector.push_back(1);


### PR DESCRIPTION
Adds `erase_unordered()` to `LocalVector`.

More performant for a single value erase when order does not matter

This is in comparison to `erase()` that reorders and `erase_multiple_unordered()` that runs a while find() search. Both can be very slow on large arrays.

This is also included in the bigger PR https://github.com/godotengine/godot/pull/104269/ and was already merged for Godot 3 with https://github.com/godotengine/godot/pull/103685 but so far not for Godot 4.

Right now we have a few code duplicates around the engine that all do first a `find()` followed by a `remove_at_unordered()` manually to work around that issue (e.g. all the navigation map object arrays). Those can be updated when this gets merged.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
