### PR TITLE
SCons: Only set GCC `-Wvirtual-inheritance` for C++ and `warnings=extra`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -862,12 +862,7 @@ else:  # GCC, Clang
     common_warnings = []
 
     if methods.using_gcc(env):
-        common_warnings += [
-            "-Wshadow",
-            "-Wno-misleading-indentation",
-            # For optimized Object::cast_to / object.inherits_from()
-            "-Wvirtual-inheritance",
-        ]
+        common_warnings += ["-Wshadow", "-Wno-misleading-indentation"]
         if cc_version_major < 11:
             # Regression in GCC 9/10, spams so much in our variadic templates
             # that we need to outright disable it.
@@ -895,7 +890,7 @@ else:  # GCC, Clang
                     "-Wstringop-overflow=4",
                 ]
             )
-            env.Append(CXXFLAGS=["-Wplacement-new=1"])
+            env.Append(CXXFLAGS=["-Wplacement-new=1", "-Wvirtual-inheritance"])
             # Need to fix a warning with AudioServer lambdas before enabling.
             # if cc_version_major != 9:  # GCC 9 had a regression (GH-36325).
             #    env.Append(CXXFLAGS=["-Wnoexcept"])


### PR DESCRIPTION
Follow-up to #103708.
This would be used for C code too and raise
```
cc1: warning: command-line option '-Wvirtual-inheritance' is valid for C++/ObjC++ but not for C
```

@Zylann also reported having issues with thirdparty headers using virtual inheritance raising this warning, so I think it makes sense to only use it in our `extra` level (checked on CI and enabled by `dev_mode`) and not for `moderate`/`all` (default).