### PR TITLE
Core: Integrate warning suppression macro helpers

### DIFF
--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -105,18 +105,16 @@ Error PacketPeerUDP::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 		return ERR_UNAVAILABLE;
 	}
 
-/* Bogus GCC warning here:
- * In member function 'int RingBuffer<T>::read(T*, int, bool) [with T = unsigned char]',
- *     inlined from 'virtual Error PacketPeerUDP::get_packet(const uint8_t**, int&)' at core/io/packet_peer_udp.cpp:112:9,
- *     inlined from 'virtual Error PacketPeerUDP::get_packet(const uint8_t**, int&)' at core/io/packet_peer_udp.cpp:99:7:
- * Error: ./core/ring_buffer.h:68:46: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
- *   68 |                                 p_buf[dst++] = read[pos + i];
- *      |                                 ~~~~~~~~~~~~~^~~~~~~
- */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wstringop-overflow=0"
-#endif
+	/* Bogus GCC warning here:
+	 * In member function 'int RingBuffer<T>::read(T*, int, bool) [with T = unsigned char]',
+	 *     inlined from 'virtual Error PacketPeerUDP::get_packet(const uint8_t**, int&)' at core/io/packet_peer_udp.cpp:112:9,
+	 *     inlined from 'virtual Error PacketPeerUDP::get_packet(const uint8_t**, int&)' at core/io/packet_peer_udp.cpp:99:7:
+	 * Error: ./core/ring_buffer.h:68:46: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
+	 *   68 |                                 p_buf[dst++] = read[pos + i];
+	 *      |                                 ~~~~~~~~~~~~~^~~~~~~
+	 */
+	GODOT_GCC_WARNING_PUSH
+	GODOT_GCC_PRAGMA(GCC diagnostic warning "-Wstringop-overflow=0") // Can't "ignore" this for some reason.
 
 	uint32_t size = 0;
 	uint8_t ipv6[16] = {};
@@ -129,9 +127,7 @@ Error PacketPeerUDP::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 	*r_buffer = packet_buffer;
 	r_buffer_size = size;
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+	GODOT_GCC_WARNING_POP
 
 	return OK;
 }

--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -167,11 +167,7 @@ public:
 		return p_segment_a + n * d; // Inside.
 	}
 
-// Disable False Positives in MSVC compiler; we correctly check for 0 here to prevent a division by 0.
-// See: https://github.com/godotengine/godot/pull/44274
-#ifdef _MSC_VER
-#pragma warning(disable : 4723)
-#endif
+	GODOT_MSVC_WARNING_PUSH_AND_IGNORE(4723) // Potential divide by 0. False positive (see: GH-44274).
 
 	static bool line_intersects_line(const Vector2 &p_from_a, const Vector2 &p_dir_a, const Vector2 &p_from_b, const Vector2 &p_dir_b, Vector2 &r_result) {
 		// See http://paulbourke.net/geometry/pointlineplane/
@@ -187,10 +183,7 @@ public:
 		return true;
 	}
 
-// Re-enable division by 0 warning
-#ifdef _MSC_VER
-#pragma warning(default : 4723)
-#endif
+	GODOT_MSVC_WARNING_POP
 
 	static bool segment_intersects_segment(const Vector2 &p_from_a, const Vector2 &p_to_a, const Vector2 &p_from_b, const Vector2 &p_to_b, Vector2 *r_result) {
 		Vector2 B = p_to_a - p_from_a;

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -257,11 +257,8 @@ class MethodBindVarArgTR : public MethodBindVarArgBase<MethodBindVarArgTR<T, R>,
 	friend class MethodBindVarArgBase<MethodBindVarArgTR<T, R>, T, R, true>;
 
 public:
-#if defined(SANITIZERS_ENABLED) && defined(__GNUC__) && !defined(__clang__)
-	// Workaround GH-66343 raised only with UBSAN, seems to be a false positive.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
+	GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wmaybe-uninitialized") // Workaround GH-66343 raised only with UBSAN, seems to be a false positive.
+
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 #ifdef TOOLS_ENABLED
 		ERR_FAIL_COND_V_MSG(p_object && p_object->is_extension_placeholder() && p_object->get_class_name() == MethodBind::get_instance_class(), Variant(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
@@ -269,9 +266,7 @@ public:
 		return (static_cast<T *>(p_object)->*MethodBindVarArgBase<MethodBindVarArgTR<T, R>, T, R, true>::method)(p_args, p_arg_count, r_error);
 	}
 
-#if defined(SANITIZERS_ENABLED) && defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+	GODOT_GCC_WARNING_POP
 
 	MethodBindVarArgTR(
 			R (T::*p_method)(const Variant **, int, Callable::CallError &),

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -711,11 +711,7 @@ public:
 
 	GDExtensionScriptInstanceDataPtr instance = nullptr;
 
-// There should not be warnings on explicit casts.
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wignored-qualifiers"
-#endif
+	GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wignored-qualifiers") // There should not be warnings on explicit casts.
 
 	virtual bool set(const StringName &p_name, const Variant &p_value) override {
 		if (native_info->set_func) {
@@ -963,7 +959,5 @@ public:
 #endif // DISABLE_DEPRECATED
 	}
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+	GODOT_GCC_WARNING_POP
 };

--- a/core/os/safe_binary_mutex.h
+++ b/core/os/safe_binary_mutex.h
@@ -36,10 +36,7 @@
 
 #ifdef THREADS_ENABLED
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundefined-var-template"
-#endif
+GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wundefined-var-template")
 
 // A very special kind of mutex, used in scenarios where these
 // requirements hold at the same time:
@@ -119,9 +116,7 @@ public:
 	// TODO: Implement a `try_temp_relock` if needed (will also need a dummy method below).
 };
 
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+GODOT_CLANG_WARNING_POP
 
 #else // No threads.
 

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -92,14 +92,9 @@ public:
 	};
 
 #if defined(__cpp_lib_hardware_interference_size) && !defined(ANDROID_ENABLED) // This would be OK with NDK >= 26.
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Winterference-size"
-#endif
+	GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Winterference-size")
 	static constexpr size_t CACHE_LINE_BYTES = std::hardware_destructive_interference_size;
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+	GODOT_GCC_WARNING_POP
 #else
 	// At a negligible memory cost, we use a conservatively high value.
 	static constexpr size_t CACHE_LINE_BYTES = 128;

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -49,11 +49,7 @@ class VMap;
 
 static_assert(std::is_trivially_destructible_v<std::atomic<uint64_t>>);
 
-// Silence a false positive warning (see GH-52119).
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wplacement-new"
-#endif
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wplacement-new") // Silence a false positive warning (see GH-52119).
 
 template <typename T>
 class CowData {
@@ -460,9 +456,7 @@ CowData<T>::CowData(std::initializer_list<T> p_init) {
 	}
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+GODOT_GCC_WARNING_POP
 
 // Zero-constructing CowData initializes _ptr to nullptr (and thus empty).
 template <typename T>

--- a/core/templates/lru.h
+++ b/core/templates/lru.h
@@ -33,18 +33,6 @@
 #include "hash_map.h"
 #include "list.h"
 
-#if defined(__GNUC__) && !defined(__clang__)
-#define ADDRESS_DIAGNOSTIC_WARNING_DISABLE \
-	_Pragma("GCC diagnostic push");        \
-	_Pragma("GCC diagnostic ignored \"-Waddress\"");
-
-#define ADDRESS_DIAGNOSTIC_POP \
-	_Pragma("GCC diagnostic pop");
-#else
-#define ADDRESS_DIAGNOSTIC_WARNING_DISABLE
-#define ADDRESS_DIAGNOSTIC_POP
-#endif
-
 template <typename TKey, typename TData, typename Hasher = HashMapHasherDefault, typename Comparator = HashMapComparatorDefault<TKey>, void (*BeforeEvict)(TKey &, TData &) = nullptr>
 class LRUCache {
 public:
@@ -72,11 +60,11 @@ public:
 		Element n = _list.push_front(Pair(p_key, p_value));
 
 		if (e) {
-			ADDRESS_DIAGNOSTIC_WARNING_DISABLE;
+			GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Waddress")
 			if constexpr (BeforeEvict != nullptr) {
 				BeforeEvict((*e)->get().key, (*e)->get().data);
 			}
-			ADDRESS_DIAGNOSTIC_POP;
+			GODOT_GCC_WARNING_POP
 			_list.erase(*e);
 			_map.erase(p_key);
 		}
@@ -84,11 +72,11 @@ public:
 
 		while (_map.size() > capacity) {
 			Element d = _list.back();
-			ADDRESS_DIAGNOSTIC_WARNING_DISABLE
+			GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Waddress")
 			if constexpr (BeforeEvict != nullptr) {
 				BeforeEvict(d->get().key, d->get().data);
 			}
-			ADDRESS_DIAGNOSTIC_POP
+			GODOT_GCC_WARNING_POP
 			_map.erase(d->get().key);
 			_list.pop_back();
 		}
@@ -141,11 +129,11 @@ public:
 			capacity = p_capacity;
 			while (_map.size() > capacity) {
 				Element d = _list.back();
-				ADDRESS_DIAGNOSTIC_WARNING_DISABLE;
+				GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Waddress")
 				if constexpr (BeforeEvict != nullptr) {
 					BeforeEvict(d->get().key, d->get().data);
 				}
-				ADDRESS_DIAGNOSTIC_POP;
+				GODOT_GCC_WARNING_POP
 				_map.erase(d->get().key);
 				_list.pop_back();
 			}
@@ -160,6 +148,3 @@ public:
 		capacity = p_capacity;
 	}
 };
-
-#undef ADDRESS_DIAGNOSTIC_WARNING_DISABLE
-#undef ADDRESS_DIAGNOSTIC_POP

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -344,3 +344,46 @@ struct is_zero_constructible<const volatile T> : is_zero_constructible<T> {};
 
 template <typename T>
 inline constexpr bool is_zero_constructible_v = is_zero_constructible<T>::value;
+
+// Warning suppression helper macros.
+#if defined(__clang__)
+#define GODOT_CLANG_PRAGMA(m_content) _Pragma(#m_content)
+#define GODOT_CLANG_WARNING_PUSH GODOT_CLANG_PRAGMA(clang diagnostic push)
+#define GODOT_CLANG_WARNING_IGNORE(m_warning) GODOT_CLANG_PRAGMA(clang diagnostic ignored m_warning)
+#define GODOT_CLANG_WARNING_POP GODOT_CLANG_PRAGMA(clang diagnostic pop)
+#define GODOT_CLANG_WARNING_PUSH_AND_IGNORE(m_warning) GODOT_CLANG_WARNING_PUSH GODOT_CLANG_WARNING_IGNORE(m_warning)
+#else
+#define GODOT_CLANG_PRAGMA(m_content)
+#define GODOT_CLANG_WARNING_PUSH
+#define GODOT_CLANG_WARNING_IGNORE(m_warning)
+#define GODOT_CLANG_WARNING_POP
+#define GODOT_CLANG_WARNING_PUSH_AND_IGNORE(m_warning)
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+#define GODOT_GCC_PRAGMA(m_content) _Pragma(#m_content)
+#define GODOT_GCC_WARNING_PUSH GODOT_GCC_PRAGMA(GCC diagnostic push)
+#define GODOT_GCC_WARNING_IGNORE(m_warning) GODOT_GCC_PRAGMA(GCC diagnostic ignored m_warning)
+#define GODOT_GCC_WARNING_POP GODOT_GCC_PRAGMA(GCC diagnostic pop)
+#define GODOT_GCC_WARNING_PUSH_AND_IGNORE(m_warning) GODOT_GCC_WARNING_PUSH GODOT_GCC_WARNING_IGNORE(m_warning)
+#else
+#define GODOT_GCC_PRAGMA(m_content)
+#define GODOT_GCC_WARNING_PUSH
+#define GODOT_GCC_WARNING_IGNORE(m_warning)
+#define GODOT_GCC_WARNING_POP
+#define GODOT_GCC_WARNING_PUSH_AND_IGNORE(m_warning)
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#define GODOT_MSVC_PRAGMA(m_command) __pragma(m_command)
+#define GODOT_MSVC_WARNING_PUSH GODOT_MSVC_PRAGMA(warning(push))
+#define GODOT_MSVC_WARNING_IGNORE(m_warning) GODOT_MSVC_PRAGMA(warning(disable : m_warning))
+#define GODOT_MSVC_WARNING_POP GODOT_MSVC_PRAGMA(warning(pop))
+#define GODOT_MSVC_WARNING_PUSH_AND_IGNORE(m_warning) GODOT_MSVC_WARNING_PUSH GODOT_MSVC_WARNING_IGNORE(m_warning)
+#else
+#define GODOT_MSVC_PRAGMA(m_command)
+#define GODOT_MSVC_WARNING_PUSH
+#define GODOT_MSVC_WARNING_IGNORE(m_warning)
+#define GODOT_MSVC_WARNING_POP
+#define GODOT_MSVC_WARNING_PUSH_AND_IGNORE(m_warning)
+#endif

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -689,10 +689,7 @@ void call_with_validated_object_instance_args_static_retc(T *base, R (*p_method)
 
 // GCC raises "parameter 'p_args' set but not used" when P = {},
 // it's not clever enough to treat other P values as making this branch valid.
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-but-set-parameter"
-#endif
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wunused-but-set-parameter")
 
 template <typename Q>
 void call_get_argument_type_helper(int p_arg, int &index, Variant::Type &type) {
@@ -1033,6 +1030,4 @@ void call_with_variant_args_static_dv(void (*p_method)(P...), const Variant **p_
 	call_with_variant_args_static(p_method, args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+GODOT_GCC_WARNING_POP

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -1336,14 +1336,9 @@ RDD::TextureID RenderingDeviceDriverD3D12::texture_create(const TextureFormat &p
 	}
 	tex_info->states_ptr = &tex_info->owner_info.states;
 	tex_info->format = p_format.format;
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#endif
+	GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wstrict-aliasing")
 	tex_info->desc = *(CD3DX12_RESOURCE_DESC *)&resource_desc;
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+	GODOT_GCC_WARNING_POP
 	tex_info->base_layer = 0;
 	tex_info->layers = resource_desc.ArraySize();
 	tex_info->base_mip = 0;

--- a/drivers/metal/pixel_formats.h
+++ b/drivers/metal/pixel_formats.h
@@ -50,8 +50,9 @@
 /* permissions and limitations under the License.                         */
 /**************************************************************************/
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#include "core/typedefs.h"
+
+GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations")
 
 #import "inflection_map.h"
 #import "metal_device_properties.h"
@@ -407,4 +408,4 @@ protected:
 	TightLocalVector<MTLFormatDesc> _mtl_vertex_format_descs;
 };
 
-#pragma clang diagnostic pop
+GODOT_CLANG_WARNING_POP

--- a/drivers/metal/pixel_formats.mm
+++ b/drivers/metal/pixel_formats.mm
@@ -450,8 +450,7 @@ void PixelFormats::initDataFormatCapabilities() {
 
 	addDataFormatDesc(X8_D24_UNORM_PACK32, Invalid, Depth24Unorm_Stencil8, Invalid, Invalid, 1, 1, 4, DepthStencil);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
+	GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
 
 	addDataFormatDesc(BC1_RGB_UNORM_BLOCK, BC1_RGBA, Invalid, Invalid, Invalid, 4, 4, 8, Compressed);
 	addDataFormatDesc(BC1_RGB_SRGB_BLOCK, BC1_RGBA_sRGB, Invalid, Invalid, Invalid, 4, 4, 8, Compressed);
@@ -476,7 +475,7 @@ void PixelFormats::initDataFormatCapabilities() {
 	addDataFormatDesc(BC7_UNORM_BLOCK, BC7_RGBAUnorm, Invalid, Invalid, Invalid, 4, 4, 16, Compressed);
 	addDataFormatDesc(BC7_SRGB_BLOCK, BC7_RGBAUnorm_sRGB, Invalid, Invalid, Invalid, 4, 4, 16, Compressed);
 
-#pragma clang diagnostic pop
+	GODOT_CLANG_WARNING_POP
 
 	addDataFormatDesc(ETC2_R8G8B8_UNORM_BLOCK, ETC2_RGB8, Invalid, Invalid, Invalid, 4, 4, 8, Compressed);
 	addDataFormatDesc(ETC2_R8G8B8_SRGB_BLOCK, ETC2_RGB8_sRGB, Invalid, Invalid, Invalid, 4, 4, 8, Compressed);
@@ -729,8 +728,7 @@ void PixelFormats::initMTLPixelFormatCapabilities() {
 	addMTLPixelFormatDescSRGB(ASTC_12x12_sRGB, ASTC_12x12, RF, ASTC_12x12_LDR);
 	addMTLPixelFormatDesc(ASTC_12x12_HDR, ASTC_12x12, RF);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
+	GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
 
 	addMTLPixelFormatDesc(BC1_RGBA, BC1_RGBA, RF);
 	addMTLPixelFormatDescSRGB(BC1_RGBA_sRGB, BC1_RGBA, RF, BC1_RGBA);
@@ -747,7 +745,7 @@ void PixelFormats::initMTLPixelFormatCapabilities() {
 	addMTLPixelFormatDesc(BC7_RGBAUnorm, BC7_RGBA, RF);
 	addMTLPixelFormatDescSRGB(BC7_RGBAUnorm_sRGB, BC7_RGBA, RF, BC7_RGBAUnorm);
 
-#pragma clang diagnostic pop
+	GODOT_CLANG_WARNING_POP
 
 	// YUV pixel formats
 	addMTLPixelFormatDesc(GBGR422, None, RF);
@@ -968,8 +966,7 @@ void PixelFormats::modifyMTLFormatCapabilities(const MetalFeatures &p_feat) {
 	setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_12x10_HDR, None);
 	setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_12x12_HDR, None);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
+	GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
 
 	bool noBC = !p_feat.supportsBCTextureCompression;
 	setMTLPixFmtCapsIf(noBC, BC1_RGBA, None);
@@ -987,7 +984,7 @@ void PixelFormats::modifyMTLFormatCapabilities(const MetalFeatures &p_feat) {
 	setMTLPixFmtCapsIf(noBC, BC7_RGBAUnorm, None);
 	setMTLPixFmtCapsIf(noBC, BC7_RGBAUnorm_sRGB, None);
 
-#pragma clang diagnostic pop
+	GODOT_CLANG_WARNING_POP
 
 	setMTLPixFmtCapsIf(iosOnly2, BGRA10_XR, None);
 	setMTLPixFmtCapsIf(iosOnly2, BGRA10_XR_sRGB, None);

--- a/drivers/unix/net_socket_unix.cpp
+++ b/drivers/unix/net_socket_unix.cpp
@@ -135,10 +135,7 @@ NetSocketUnix::~NetSocketUnix() {
 
 // Silence a warning reported in GH-27594.
 // EAGAIN and EWOULDBLOCK have the same value on most platforms, but it's not guaranteed.
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wlogical-op"
-#endif
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wlogical-op")
 
 NetSocketUnix::NetError NetSocketUnix::_get_socket_error() const {
 	if (errno == EISCONN) {
@@ -163,9 +160,7 @@ NetSocketUnix::NetError NetSocketUnix::_get_socket_error() const {
 	return ERR_NET_OTHER;
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+GODOT_GCC_WARNING_POP
 
 bool NetSocketUnix::_can_use_ip(const IPAddress &p_ip, const bool p_for_bind) const {
 	if (p_for_bind && !(p_ip.is_valid() || p_ip.is_wildcard())) {

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -126,11 +126,7 @@ static bool default_input_device_changed = false;
 static int output_reinit_countdown = 0;
 static int input_reinit_countdown = 0;
 
-// Silence warning due to a COM API weirdness (GH-35194).
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#endif
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor") // Silence warning due to a COM API weirdness (GH-35194).
 
 class CMMNotificationClient : public IMMNotificationClient {
 	LONG _cRef = 1;
@@ -196,9 +192,7 @@ public:
 	}
 };
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+GODOT_GCC_WARNING_POP
 
 static CMMNotificationClient notif_client;
 

--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -76,11 +76,10 @@ DisplayServerIOS::DisplayServerIOS(const String &p_rendering_driver, WindowMode 
 		RenderingContextDriverVulkanIOS::WindowPlatformData vulkan;
 #endif
 #ifdef METAL_ENABLED
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
+		GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
 		// Eliminate "RenderingContextDriverMetal is only available on iOS 14.0 or newer".
 		RenderingContextDriverMetal::WindowPlatformData metal;
-#pragma clang diagnostic pop
+		GODOT_CLANG_WARNING_POP
 #endif
 	} wpd;
 

--- a/platform/ios/godot_view.mm
+++ b/platform/ios/godot_view.mm
@@ -82,10 +82,9 @@ static const float earth_gravity = 9.80665;
 		layer = [GodotMetalLayer layer];
 #endif
 	} else if ([driverName isEqualToString:@"opengl3"]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations" // OpenGL is deprecated in iOS 12.0
+		GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations") // OpenGL is deprecated in iOS 12.0.
 		layer = [GodotOpenGLLayer layer];
-#pragma clang diagnostic pop
+		GODOT_CLANG_WARNING_POP
 	} else {
 		return nil;
 	}

--- a/platform/macos/gl_manager_macos_legacy.h
+++ b/platform/macos/gl_manager_macos_legacy.h
@@ -40,8 +40,7 @@
 #import <ApplicationServices/ApplicationServices.h>
 #import <CoreVideo/CoreVideo.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations" // OpenGL is deprecated in macOS 10.14
+GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations") // OpenGL is deprecated in macOS 10.14.
 
 typedef CGLError (*CGLEnablePtr)(CGLContextObj ctx, CGLContextEnable pname);
 typedef CGLError (*CGLSetParameterPtr)(CGLContextObj ctx, CGLContextParameter pname, const GLint *params);
@@ -89,6 +88,6 @@ public:
 	~GLManagerLegacy_MacOS();
 };
 
-#pragma clang diagnostic push
+GODOT_CLANG_WARNING_PUSH
 
 #endif // MACOS_ENABLED && GLES3_ENABLED

--- a/platform/macos/gl_manager_macos_legacy.mm
+++ b/platform/macos/gl_manager_macos_legacy.mm
@@ -36,8 +36,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations" // OpenGL is deprecated in macOS 10.14
+GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations") // OpenGL is deprecated in macOS 10.14.
 
 Error GLManagerLegacy_MacOS::create_context(GLWindow &win) {
 	NSOpenGLPixelFormatAttribute attributes[] = {
@@ -204,6 +203,6 @@ GLManagerLegacy_MacOS::~GLManagerLegacy_MacOS() {
 	release_current();
 }
 
-#pragma clang diagnostic pop
+GODOT_CLANG_WARNING_POP
 
 #endif // MACOS_ENABLED && GLES3_ENABLED

--- a/platform/macos/godot_content_view.h
+++ b/platform/macos/godot_content_view.h
@@ -54,8 +54,7 @@
 
 @end
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations" // OpenGL is deprecated in macOS 10.14
+GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations") // OpenGL is deprecated in macOS 10.14.
 
 @interface GodotContentView : RootView <NSTextInputClient> {
 	DisplayServer::WindowID window_id;
@@ -78,4 +77,4 @@
 
 @end
 
-#pragma clang diagnostic pop
+GODOT_CLANG_WARNING_POP

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -322,11 +322,7 @@ Error DisplayServerWindows::file_dialog_with_options_show(const String &p_title,
 	return _file_dialog_with_options_show(p_title, p_current_directory, p_root, p_filename, p_show_hidden, p_mode, p_filters, p_options, p_callback, true, p_window_id);
 }
 
-// Silence warning due to a COM API weirdness.
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#endif
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor") // Silence warning due to a COM API weirdness.
 
 class FileDialogEventHandler : public IFileDialogEvents, public IFileDialogControlEvents {
 	LONG ref_count = 1;
@@ -445,9 +441,7 @@ public:
 	virtual ~FileDialogEventHandler() {}
 };
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+GODOT_GCC_WARNING_POP
 
 LRESULT CALLBACK WndProcFileDialog(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 	DisplayServerWindows *ds_win = static_cast<DisplayServerWindows *>(DisplayServer::get_singleton());

--- a/platform/windows/drop_target_windows.h
+++ b/platform/windows/drop_target_windows.h
@@ -34,11 +34,7 @@
 
 #include <shlobj.h>
 
-// Silence warning due to a COM API weirdness.
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#endif
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor") // Silence warning due to a COM API weirdness.
 
 // https://learn.microsoft.com/en-us/windows/win32/api/ole2/nf-ole2-dodragdrop#remarks
 class DropTargetWindows : public IDropTarget {
@@ -69,6 +65,4 @@ public:
 	HRESULT STDMETHODCALLTYPE Drop(IDataObject *pDataObj, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
 };
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+GODOT_GCC_WARNING_POP

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1654,10 +1654,7 @@ Vector<String> OS_Windows::get_system_fonts() const {
 	return ret;
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#endif
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor") // Silence warning due to a COM API weirdness.
 
 class FallbackTextAnalysisSource : public IDWriteTextAnalysisSource {
 	LONG _cRef = 1;
@@ -1741,9 +1738,7 @@ public:
 	virtual ~FallbackTextAnalysisSource() {}
 };
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+GODOT_GCC_WARNING_POP
 
 String OS_Windows::_get_default_fontname(const String &p_font_name) const {
 	String font_name = p_font_name;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -1370,11 +1370,10 @@ bool DisplayServer::is_rendering_device_supported() {
 #endif
 #ifdef METAL_ENABLED
 	if (rcd == nullptr) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
+		GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
 		// Eliminate "RenderingContextDriverMetal is only available on iOS 14.0 or newer".
 		rcd = memnew(RenderingContextDriverMetal);
-#pragma clang diagnostic pop
+		GODOT_CLANG_WARNING_POP
 	}
 #endif
 
@@ -1453,11 +1452,10 @@ bool DisplayServer::can_create_rendering_device() {
 #endif
 #ifdef METAL_ENABLED
 	if (rcd == nullptr) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
+		GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
 		// Eliminate "RenderingContextDriverMetal is only available on iOS 14.0 or newer".
 		rcd = memnew(RenderingContextDriverMetal);
-#pragma clang diagnostic pop
+		GODOT_CLANG_WARNING_POP
 	}
 #endif
 

--- a/servers/rendering/renderer_rd/effects/metal_fx.mm
+++ b/servers/rendering/renderer_rd/effects/metal_fx.mm
@@ -51,8 +51,7 @@ MFXSpatialEffect::~MFXSpatialEffect() {
 }
 
 void MFXSpatialEffect::callback(RDD *p_driver, RDD::CommandBufferID p_command_buffer, CallbackArgs *p_userdata) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
+	GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
 
 	MDCommandBuffer *obj = (MDCommandBuffer *)(p_command_buffer.id);
 	obj->end();
@@ -73,7 +72,7 @@ void MFXSpatialEffect::callback(RDD *p_driver, RDD::CommandBufferID p_command_bu
 
 	CallbackArgs::free(&p_userdata);
 
-#pragma clang diagnostic pop
+	GODOT_CLANG_WARNING_POP
 }
 
 void MFXSpatialEffect::ensure_context(Ref<RenderSceneBuffersRD> p_render_buffers) {
@@ -99,8 +98,7 @@ void MFXSpatialEffect::process(Ref<RenderSceneBuffersRD> p_render_buffers, RID p
 MFXSpatialContext *MFXSpatialEffect::create_context(CreateParams p_params) const {
 	DEV_ASSERT(RD::get_singleton()->has_feature(RD::SUPPORTS_METALFX_SPATIAL));
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
+	GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
 
 	RenderingDeviceDriverMetal *rdd = (RenderingDeviceDriverMetal *)RD::get_singleton()->get_device_driver();
 	PixelFormats &pf = rdd->get_pixel_formats();
@@ -120,7 +118,7 @@ MFXSpatialContext *MFXSpatialEffect::create_context(CreateParams p_params) const
 	MFXSpatialContext *context = memnew(MFXSpatialContext);
 	context->scaler = scaler;
 
-#pragma clang diagnostic pop
+	GODOT_CLANG_WARNING_POP
 
 	return context;
 }
@@ -135,8 +133,7 @@ MFXTemporalEffect::~MFXTemporalEffect() {}
 MFXTemporalContext *MFXTemporalEffect::create_context(CreateParams p_params) const {
 	DEV_ASSERT(RD::get_singleton()->has_feature(RD::SUPPORTS_METALFX_TEMPORAL));
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
+	GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
 
 	RenderingDeviceDriverMetal *rdd = (RenderingDeviceDriverMetal *)RD::get_singleton()->get_device_driver();
 	PixelFormats &pf = rdd->get_pixel_formats();
@@ -164,7 +161,7 @@ MFXTemporalContext *MFXTemporalEffect::create_context(CreateParams p_params) con
 	scaler.motionVectorScaleY = p_params.motion_vector_scale.y;
 	scaler.depthReversed = true; // Godot uses reverse Z per https://github.com/godotengine/godot/pull/88328
 
-#pragma clang diagnostic pop
+	GODOT_CLANG_WARNING_POP
 
 	return context;
 }
@@ -189,8 +186,7 @@ void MFXTemporalEffect::process(RendererRD::MFXTemporalContext *p_ctx, RendererR
 }
 
 void MFXTemporalEffect::callback(RDD *p_driver, RDD::CommandBufferID p_command_buffer, CallbackArgs *p_userdata) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
+	GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
 
 	MDCommandBuffer *obj = (MDCommandBuffer *)(p_command_buffer.id);
 	obj->end();
@@ -221,5 +217,5 @@ void MFXTemporalEffect::callback(RDD *p_driver, RDD::CommandBufferID p_command_b
 
 	CallbackArgs::free(&p_userdata);
 
-#pragma clang diagnostic pop
+	GODOT_CLANG_WARNING_POP
 }


### PR DESCRIPTION
While looking into potential PRs for tackling ignored errors in a more methodical manner, I've realized just how invasive a lot of these suppression fields really are. Inspired by similar wrappers from some of our thirdparty libraries, this PR integrates new macros to streamline and consolidate the warning suppression process.

Before:
```cpp
#if defined(__GNUC__) && !defined(__clang__)
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wsome-warning"
#endif
...
#if defined(__GNUC__) && !defined(__clang__)
#pragma GCC diagnostic pop
#endif
```
After:
```cpp
GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wsome-warning")
...
GODOT_GCC_WARNING_POP
```

The name is a bit verbose, but that's the intent; this isn't something we want misused. To ensure no clashes, and to abide by the standard forbidding leading underscores, `GODOT` was chosen as the prefix for all of these macros. The next section is the compiler, in this case one of `GCC`, `CLANG`, or `MSVC`. Following that is the primary action, which has two instances: `PRAGMA` and `WARNING`. `WARNING` has subcategories for the common suppression calls: `PUSH`, `IGNORE`, and `POP`. There's one hybrid subcategory, `PUSH_AND_IGNORE`, for the instances with only a single warning to allow for one-liners.