### PR TITLE
Add `profiler_path` option to `SCons` builds, with support for `tracy` and `perfetto`.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -202,6 +202,14 @@ opts.Add(BoolVariable("use_volk", "Use the volk library to load the Vulkan loade
 opts.Add(BoolVariable("accesskit", "Use AccessKit C SDK", True))
 opts.Add(("accesskit_sdk_path", "Path to the AccessKit C SDK", ""))
 opts.Add(BoolVariable("sdl", "Enable the SDL3 input driver", True))
+opts.Add(("profiler_path", "Path to the Profiler framework. Only tracy and perfetto are supported at the moment.", ""))
+opts.Add(
+    BoolVariable(
+        "profiler_sample_callstack",
+        "Profile random samples application-wide using a callstack based sampler.",
+        False,
+    )
+)
 
 # Advanced options
 opts.Add(

--- a/core/SCsub
+++ b/core/SCsub
@@ -217,6 +217,7 @@ env.CommandNoCache(
 )
 
 # Chain load SCsubs
+SConscript("profiling/SCsub")
 SConscript("os/SCsub")
 SConscript("math/SCsub")
 SConscript("crypto/SCsub")

--- a/core/profiling/SCsub
+++ b/core/profiling/SCsub
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+import pathlib
+from typing import Tuple
+
+import profiling_builders
+
+Import("env")
+
+env.add_source_files(env.core_sources, "*.cpp")
+
+
+def get_profiler_and_path_from_path(path: pathlib.Path) -> Tuple[str, pathlib.Path]:
+    if not path.is_dir():
+        print("profiler_path must be empty or point to a directory.")
+        Exit(255)
+
+    if (path / "sdk" / "perfetto.cc").is_file():
+        # perfetto root directory.
+        return "perfetto", path / "sdk"
+    if (path / "perfetto.cc").is_file():
+        # perfetto sdk directory.
+        return "perfetto", path
+
+    if (path / "public" / "TracyClient.cpp").is_file():
+        # tracy root directory
+        return "tracy", path / "public"
+    if (path / "TracyClient.cpp").is_file():
+        # tracy public directory
+        return "tracy", path
+
+    print("Unrecognized profiler_path option. Please set a path to either tracy or perfetto.")
+    Exit(255)
+
+
+env["profiler"] = None
+if env["profiler_path"]:
+    profiler_name, profiler_path = get_profiler_and_path_from_path(pathlib.Path(env["profiler_path"]))
+    env["profiler"] = profiler_name
+
+    if profiler_name == "tracy":
+        env.Prepend(CPPPATH=[str(profiler_path.absolute())])
+
+        env_tracy = env.Clone()
+        env_tracy.Append(CPPDEFINES=["TRACY_ENABLE"])
+        if env["profiler_sample_callstack"]:
+            if env["platform"] not in ("windows", "linux", "android"):
+                # Reference the feature matrix in the tracy documentation.
+                print("Tracy does not support call stack sampling on this platform. Aborting.")
+                Exit(255)
+
+            # 62 is the maximum supported callstack depth reported by the tracy docs.
+            env_tracy.Append(CPPDEFINES=[("TRACY_CALLSTACK", 62)])
+        env_tracy.disable_warnings()
+        env_tracy.add_source_files(env.core_sources, str((profiler_path / "TracyClient.cpp").absolute()))
+    elif profiler_name == "perfetto":
+        env.Prepend(CPPPATH=[str(profiler_path.absolute())])
+
+        env_perfetto = env.Clone()
+        if env["profiler_sample_callstack"]:
+            print("Perfetto does not support call stack sampling. Aborting.")
+            Exit(255)
+        env_perfetto.disable_warnings()
+        env_perfetto.Prepend(CPPPATH=[str(profiler_path.absolute())])
+        env_perfetto.add_source_files(env.core_sources, str((profiler_path / "perfetto.cc").absolute()))
+
+
+env.CommandNoCache("profiling.gen.h", [env.Value(env["profiler"])], env.Run(profiling_builders.profiler_gen_builder))

--- a/core/profiling/profiling.cpp
+++ b/core/profiling/profiling.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  main_ios.mm                                                           */
+/*  profiling.cpp                                                         */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,51 +28,18 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#import "os_ios.h"
+#include "profiling.h"
 
-#include "core/profiling/profiling.h"
-#import "drivers/apple_embedded/godot_app_delegate.h"
-#import "drivers/apple_embedded/main_utilities.h"
-#include "main/main.h"
+#ifdef GODOT_USE_PERFETTO
+PERFETTO_TRACK_EVENT_STATIC_STORAGE();
 
-#import <UIKit/UIKit.h>
-#include <cstdio>
+void godot_init_profiler() {
+	perfetto::TracingInitArgs args;
 
-static OS_IOS *os = nullptr;
+	args.backends |= perfetto::kSystemBackend;
 
-int apple_embedded_main(int argc, char **argv) {
-#if defined(VULKAN_ENABLED)
-	//MoltenVK - enable full component swizzling support
-	setenv("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1", 1);
+	perfetto::Tracing::Initialize(args);
+	perfetto::TrackEvent::Register();
+}
+
 #endif
-
-	change_to_launch_dir(argv);
-
-	os = new OS_IOS();
-
-	// We must override main when testing is enabled
-	TEST_MAIN_OVERRIDE
-
-	char *fargv[64];
-	argc = process_args(argc, argv, fargv);
-
-	godot_init_profiler();
-
-	Error err = Main::setup(fargv[0], argc - 1, &fargv[1], false);
-
-	if (err != OK) {
-		if (err == ERR_HELP) { // Returned by --help and --version, so success.
-			return EXIT_SUCCESS;
-		}
-		return EXIT_FAILURE;
-	}
-
-	os->initialize_modules();
-
-	return os->get_exit_code();
-}
-
-void apple_embedded_finish() {
-	Main::cleanup();
-	delete os;
-}

--- a/core/profiling/profiling.cpp
+++ b/core/profiling/profiling.cpp
@@ -30,7 +30,13 @@
 
 #include "profiling.h"
 
-#ifdef GODOT_USE_PERFETTO
+#if defined(GODOT_USE_TRACY)
+void godot_init_profiler() {
+	// Send our first event to tracy; otherwise it doesn't start collecting data.
+	// FrameMark is kind of fitting because it communicates "this is where we started tracing".
+	FrameMark;
+}
+#elif defined(GODOT_USE_PERFETTO)
 PERFETTO_TRACK_EVENT_STATIC_STORAGE();
 
 void godot_init_profiler() {
@@ -41,5 +47,8 @@ void godot_init_profiler() {
 	perfetto::Tracing::Initialize(args);
 	perfetto::TrackEvent::Register();
 }
-
+#else
+void godot_init_profiler() {
+	// Stub
+}
 #endif

--- a/core/profiling/profiling.h
+++ b/core/profiling/profiling.h
@@ -1,0 +1,106 @@
+/**************************************************************************/
+/*  profiling.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/typedefs.h"
+#include "profiling.gen.h"
+
+#if defined(GODOT_USE_TRACY)
+// Use the tracy profiler.
+
+#define TRACY_ENABLE
+#include <tracy/Tracy.hpp>
+
+#ifndef TRACY_CALLSTACK
+#define TRACY_CALLSTACK 0
+#endif
+
+// Define tracing macros.
+#define GodotProfileFrameMark FrameMark
+#define GodotProfileZone(m_zone_name) ZoneScopedN(m_zone_name)
+#define GodotProfileZoneGroupedFirst(m_group_name, m_zone_name) ZoneNamedN(__godot_tracy_zone_##m_group_name, m_zone_name, true)
+#define GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name) __godot_tracy_zone_##m_group_name.~ScopedZone();
+#define GodotProfileZoneGrouped(m_group_name, m_zone_name)                                                                                                       \
+	GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name);                                                                                                  \
+	static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location, TracyLine){ m_zone_name, TracyFunction, TracyFile, (uint32_t)TracyLine, 0 }; \
+	new (&__godot_tracy_zone_##m_group_name) tracy::ScopedZone(&TracyConcat(__tracy_source_location, TracyLine), TRACY_CALLSTACK, true)
+
+static void godot_init_profiler() {
+	// Send our first event to tracy; otherwise it doesn't start collecting data.
+	// FrameMark is kind of fitting because it communicates "this is where we started tracing".
+	FrameMark;
+}
+
+#elif defined(GODOT_USE_PERFETTO)
+// Use the perfetto profiler.
+
+#include <perfetto.h>
+
+PERFETTO_DEFINE_CATEGORIES(
+		perfetto::Category("godot")
+				.SetDescription("All Godot Events"), );
+
+// See PERFETTO_INTERNAL_SCOPED_EVENT_FINALIZER
+struct PerfettoGroupedEventEnder {
+	_FORCE_INLINE_ void _end_now() {
+		TRACE_EVENT_END("godot");
+	}
+
+	_FORCE_INLINE_ ~PerfettoGroupedEventEnder() {
+		_end_now();
+	}
+};
+
+#define GodotProfileFrameMark // TODO
+#define GodotProfileZone(m_zone_name) TRACE_EVENT("godot", m_zone_name);
+#define GodotProfileZoneGroupedFirst(m_group_name, m_zone_name) \
+	TRACE_EVENT_BEGIN("godot", m_zone_name);                    \
+	PerfettoGroupedEventEnder __godot_perfetto_zone_##m_group_name
+#define GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name) __godot_perfetto_zone_##m_group_name.~PerfettoGroupedEventEnder()
+#define GodotProfileZoneGrouped(m_group_name, m_zone_name) \
+	__godot_perfetto_zone_##m_group_name._end_now();       \
+	TRACE_EVENT_BEGIN("godot", m_zone_name);
+
+void godot_init_profiler();
+
+#else
+// No profiling; all macros are stubs.
+
+static void godot_init_profiler() {
+}
+
+#define GodotProfileFrameMark
+#define GodotProfileZone(m_zone_name)
+#define GodotProfileZoneGroupedFirst(m_group_name, m_zone_name)
+#define GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name)
+#define GodotProfileZoneGrouped(m_group_name, m_zone_name)
+
+#endif

--- a/core/profiling/profiling.h
+++ b/core/profiling/profiling.h
@@ -53,11 +53,7 @@
 	static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location, TracyLine){ m_zone_name, TracyFunction, TracyFile, (uint32_t)TracyLine, 0 }; \
 	new (&__godot_tracy_zone_##m_group_name) tracy::ScopedZone(&TracyConcat(__tracy_source_location, TracyLine), TRACY_CALLSTACK, true)
 
-static void godot_init_profiler() {
-	// Send our first event to tracy; otherwise it doesn't start collecting data.
-	// FrameMark is kind of fitting because it communicates "this is where we started tracing".
-	FrameMark;
-}
+void godot_init_profiler();
 
 #elif defined(GODOT_USE_PERFETTO)
 // Use the perfetto profiler.
@@ -94,8 +90,7 @@ void godot_init_profiler();
 #else
 // No profiling; all macros are stubs.
 
-static void godot_init_profiler() {
-}
+void godot_init_profiler();
 
 #define GodotProfileFrameMark
 #define GodotProfileZone(m_zone_name)

--- a/core/profiling/profiling_builders.py
+++ b/core/profiling/profiling_builders.py
@@ -1,0 +1,13 @@
+"""Functions used to generate source files during build time"""
+
+import methods
+
+
+def profiler_gen_builder(target, source, env):
+    with methods.generated_wrapper(str(target[0])) as file:
+        if env["profiler"] == "tracy":
+            file.write("#define GODOT_USE_TRACY\n")
+            if env["profiler_sample_callstack"]:
+                file.write("#define TRACY_CALLSTACK 62\n")
+        if env["profiler"] == "perfetto":
+            file.write("#define GODOT_USE_PERFETTO\n")

--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -41,6 +41,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/os/main_loop.h"
+#include "core/profiling/profiling.h"
 #import "drivers/apple/os_log_logger.h"
 #include "main/main.h"
 
@@ -204,6 +205,9 @@ bool OS_AppleEmbedded::iterate() {
 	if (!main_loop) {
 		return true;
 	}
+
+	GodotProfileFrameMark;
+	GodotProfileZone("OS_AppleEmbedded::iterate");
 
 	if (DisplayServer::get_singleton()) {
 		DisplayServer::get_singleton()->process_events();

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -49,6 +49,7 @@
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/os/main_loop.h"
+#include "core/profiling/profiling.h"
 #include "main/main.h"
 #include "servers/rendering/rendering_server.h"
 
@@ -151,6 +152,8 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setVirtualKeyboardHei
 }
 
 JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *env, jclass clazz, jobject p_godot_instance, jobject p_asset_manager, jobject p_godot_io, jobject p_net_utils, jobject p_directory_access_handler, jobject p_file_access_handler, jboolean p_use_apk_expansion) {
+	godot_init_profiler();
+
 	JavaVM *jvm;
 	env->GetJavaVM(&jvm);
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -42,6 +42,7 @@
 #include "core/extension/gdextension_manager.h"
 #include "core/io/xml_parser.h"
 #include "core/os/main_loop.h"
+#include "core/profiling/profiling.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
 #ifdef TOOLS_ENABLED
@@ -356,6 +357,8 @@ void OS_Android::main_loop_begin() {
 }
 
 bool OS_Android::main_loop_iterate(bool *r_should_swap_buffers) {
+	GodotProfileFrameMark;
+	GodotProfileZone("OS_Android::main_loop_iterate");
 	if (!main_loop) {
 		return false;
 	}

--- a/platform/linuxbsd/godot_linuxbsd.cpp
+++ b/platform/linuxbsd/godot_linuxbsd.cpp
@@ -30,6 +30,7 @@
 
 #include "os_linuxbsd.h"
 
+#include "core/profiling/profiling.h"
 #include "main/main.h"
 
 #include <unistd.h>
@@ -92,6 +93,8 @@ int main(int argc, char *argv[]) {
 	struct rlimit stack_lim = { 0x1E00000, 0x1E00000 };
 	setrlimit(RLIMIT_STACK, &stack_lim);
 #endif
+
+	godot_init_profiler();
 
 	OS_LinuxBSD os;
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -37,6 +37,7 @@
 #ifdef SDL_ENABLED
 #include "drivers/sdl/joypad_sdl.h"
 #endif
+#include "core/profiling/profiling.h"
 #include "main/main.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
@@ -970,6 +971,8 @@ String OS_LinuxBSD::get_system_dir(SystemDir p_dir, bool p_shared_storage) const
 }
 
 void OS_LinuxBSD::run() {
+	GodotProfileFrameMark;
+	GodotProfileZone("OS_LinuxBSD::run");
 	if (!main_loop) {
 		return;
 	}

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -34,6 +34,7 @@
 #import "godot_window.h"
 #import "key_mapping_macos.h"
 
+#include "core/profiling/profiling.h"
 #include "main/main.h"
 
 @implementation GodotContentLayerDelegate
@@ -56,6 +57,9 @@
 - (void)displayLayer:(CALayer *)layer {
 	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
 	if (OS::get_singleton()->get_main_loop() && ds->get_is_resizing() && need_redraw) {
+		GodotProfileFrameMark;
+		GodotProfileZone("[GodotContentLayerDelegate displayLayer]");
+
 		Main::force_redraw();
 		if (!Main::is_iterating()) { // Avoid cyclic loop.
 			Main::iteration();

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -32,6 +32,7 @@
 
 #import "godot_application.h"
 
+#include "core/profiling/profiling.h"
 #include "main/main.h"
 
 #if defined(SANITIZERS_ENABLED)
@@ -39,6 +40,8 @@
 #endif
 
 int main(int argc, char **argv) {
+	godot_init_profiler();
+
 #if defined(VULKAN_ENABLED)
 	setenv("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1", 1); // MoltenVK - enable full component swizzling support.
 	setenv("MVK_CONFIG_SWAPCHAIN_MIN_MAG_FILTER_USE_NEAREST", "0", 1); // MoltenVK - use linear surface scaling. TODO: remove when full DPI scaling is implemented.

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -1106,6 +1106,9 @@ void OS_MacOS_NSApp::start_main() {
 				pre_wait_observer = CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, kCFRunLoopBeforeWaiting, true, 0, ^(CFRunLoopObserverRef observer, CFRunLoopActivity activity) {
 					@autoreleasepool {
 						@try {
+							GodotProfileFrameMark;
+							GodotProfileZone("macOS main loop");
+
 							if (ds_mac) {
 								ds_mac->_process_events(false);
 							} else if (ds) {
@@ -1279,6 +1282,9 @@ void OS_MacOS_Embedded::run() {
 		while (true) {
 			@autoreleasepool {
 				@try {
+					GodotProfileFrameMark;
+					GodotProfileZone("macOS embedded main loop");
+
 					ds->process_events();
 
 #ifdef SDL_ENABLED

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -41,6 +41,7 @@
 #include "core/crypto/crypto_core.h"
 #include "core/io/file_access.h"
 #include "core/os/main_loop.h"
+#include "core/profiling/profiling.h"
 #include "core/version_generated.gen.h"
 #include "drivers/apple/os_log_logger.h"
 #include "main/main.h"
@@ -1080,6 +1081,8 @@ static void handle_interrupt(int sig) {
 }
 
 void OS_MacOS_NSApp::start_main() {
+	godot_init_profiler();
+
 	Error err;
 	@autoreleasepool {
 		err = Main::setup(execpath, argc, argv);

--- a/platform/visionos/main_visionos.mm
+++ b/platform/visionos/main_visionos.mm
@@ -30,6 +30,7 @@
 
 #import "os_visionos.h"
 
+#include "core/profiling/profiling.h"
 #import "drivers/apple_embedded/godot_app_delegate.h"
 #import "drivers/apple_embedded/main_utilities.h"
 #include "main/main.h"
@@ -49,6 +50,8 @@ int apple_embedded_main(int argc, char **argv) {
 
 	char *fargv[64];
 	argc = process_args(argc, argv, fargv);
+
+	godot_init_profiler();
 
 	Error err = Main::setup(fargv[0], argc - 1, &fargv[1], false);
 

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -40,6 +40,7 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/io/file_access.h"
 #include "core/os/main_loop.h"
+#include "core/profiling/profiling.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
 #include "main/main.h"
@@ -79,6 +80,8 @@ void OS_Web::fs_sync_callback() {
 }
 
 bool OS_Web::main_loop_iterate() {
+	GodotProfileFrameMark;
+	GodotProfileZone("OS_Web::main_loop_iterate");
 	if (is_userfs_persistent() && idb_needs_sync && !idb_is_syncing) {
 		idb_is_syncing = true;
 		idb_needs_sync = false;

--- a/platform/web/web_main.cpp
+++ b/platform/web/web_main.cpp
@@ -35,6 +35,7 @@
 #include "core/config/engine.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/profiling/profiling.h"
 #include "main/main.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h" // SceneTree only forward declares it.
@@ -126,6 +127,8 @@ void print_web_header() {
 
 /// When calling main, it is assumed FS is setup and synced.
 extern EMSCRIPTEN_KEEPALIVE int godot_web_main(int argc, char *argv[]) {
+	godot_init_profiler();
+
 	os = new OS_Web();
 
 #ifdef TOOLS_ENABLED

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -30,6 +30,7 @@
 
 #include "os_windows.h"
 
+#include "core/profiling/profiling.h"
 #include "main/main.h"
 
 #include <clocale>
@@ -66,6 +67,8 @@ char *wc_to_utf8(const wchar_t *wc) {
 }
 
 int widechar_main(int argc, wchar_t **argv) {
+	godot_init_profiler();
+
 	OS_Windows os(nullptr);
 
 	setlocale(LC_CTYPE, "");

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -39,6 +39,7 @@
 #include "core/debugger/script_debugger.h"
 #include "core/io/marshalls.h"
 #include "core/os/main_loop.h"
+#include "core/profiling/profiling.h"
 #include "core/version_generated.gen.h"
 #include "drivers/windows/dir_access_windows.h"
 #include "drivers/windows/file_access_windows.h"
@@ -2329,6 +2330,8 @@ void OS_Windows::run() {
 	main_loop->initialize();
 
 	while (true) {
+		GodotProfileFrameMark;
+		GodotProfileZone("OS_Windows::run");
 		DisplayServer::get_singleton()->process_events(); // get rid of pending events
 		if (Main::iteration()) {
 			break;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -37,6 +37,7 @@
 #include "core/object/message_queue.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/os/os.h"
+#include "core/profiling/profiling.h"
 #include "node.h"
 #include "scene/animation/tween.h"
 #include "scene/debugger/scene_debugger.h"
@@ -572,6 +573,7 @@ void SceneTree::set_group(const StringName &p_group, const String &p_name, const
 }
 
 void SceneTree::initialize() {
+	GodotProfileZone("SceneTree::initialize");
 	ERR_FAIL_NULL(root);
 	MainLoop::initialize();
 	root->_set_tree(this);

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/math/transform_interpolator.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/profiling/profiling.h"
 #include "renderer_canvas_cull.h"
 #include "renderer_scene_cull.h"
 #include "rendering_server_globals.h"
@@ -733,6 +734,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 }
 
 void RendererViewport::draw_viewports(bool p_swap_buffers) {
+	GodotProfileZoneGroupedFirst(_profile_zone, "prepare viewports");
 	timestamp_vp_map.clear();
 
 #ifndef XR_DISABLED
@@ -750,6 +752,7 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 	}
 
 	if (sorted_active_viewports_dirty) {
+		GodotProfileZoneGrouped(_profile_zone, "_sort_active_viewports");
 		sorted_active_viewports = _sort_active_viewports();
 		sorted_active_viewports_dirty = false;
 	}
@@ -758,11 +761,12 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 	//draw viewports
 	RENDER_TIMESTAMP("> Render Viewports");
 
+	GodotProfileZoneGrouped(_profile_zone, "render viewports");
+
 	//determine what is visible
 	draw_viewports_pass++;
 
 	for (int i = sorted_active_viewports.size() - 1; i >= 0; i--) { //to compute parent dependency, must go in reverse draw order
-
 		Viewport *vp = sorted_active_viewports[i];
 
 		if (vp->update_mode == RS::VIEWPORT_UPDATE_DISABLED) {
@@ -821,6 +825,9 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 	int draw_calls_used = 0;
 
 	for (int i = 0; i < sorted_active_viewports.size(); i++) {
+		// TODO Somehow print the index
+		GodotProfileZone("render viewport");
+
 		Viewport *vp = sorted_active_viewports[i];
 
 		if (vp->last_pass != draw_viewports_pass) {
@@ -925,6 +932,7 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 		vertices_drawn += vp->render_info.info[RS::VIEWPORT_RENDER_INFO_TYPE_CANVAS][RS::VIEWPORT_RENDER_INFO_PRIMITIVES_IN_FRAME];
 		draw_calls_used += vp->render_info.info[RS::VIEWPORT_RENDER_INFO_TYPE_CANVAS][RS::VIEWPORT_RENDER_INFO_DRAW_CALLS_IN_FRAME];
 	}
+
 	RSG::scene->set_debug_draw_mode(RS::VIEWPORT_DEBUG_DRAW_DISABLED);
 
 	total_objects_drawn = objects_drawn;
@@ -933,6 +941,7 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 
 	RENDER_TIMESTAMP("< Render Viewports");
 
+	GodotProfileZoneGrouped(_profile_zone, "rasterizer->blit_render_targets_to_screen");
 	if (p_swap_buffers && !blit_to_screen_list.is_empty()) {
 		for (const KeyValue<int, Vector<BlitToScreen>> &E : blit_to_screen_list) {
 			RSG::rasterizer->blit_render_targets_to_screen(E.key, E.value.ptr(), E.value.size());

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -31,6 +31,7 @@
 #include "rendering_server_default.h"
 
 #include "core/os/os.h"
+#include "core/profiling/profiling.h"
 #include "renderer_canvas_cull.h"
 #include "renderer_scene_cull.h"
 #include "rendering_server_globals.h"
@@ -66,6 +67,7 @@ void RenderingServerDefault::request_frame_drawn_callback(const Callable &p_call
 }
 
 void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
+	GodotProfileZoneGroupedFirst(_profile_zone, "rasterizer->begin_frame");
 	RSG::rasterizer->begin_frame(frame_step);
 
 	TIMESTAMP_BEGIN()
@@ -75,6 +77,7 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 	RENDER_TIMESTAMP("Prepare Render Frame");
 
 #ifndef XR_DISABLED
+	GodotProfileZoneGrouped(_profile_zone, "xr_server->pre_render");
 	XRServer *xr_server = XRServer::get_singleton();
 	if (xr_server != nullptr) {
 		// Let XR server know we're about to render a frame.
@@ -82,30 +85,41 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 	}
 #endif // XR_DISABLED
 
+	GodotProfileZoneGrouped(_profile_zone, "scene->update");
 	RSG::scene->update(); //update scenes stuff before updating instances
+	GodotProfileZoneGrouped(_profile_zone, "canvas->update");
 	RSG::canvas->update();
 
 	frame_setup_time = double(OS::get_singleton()->get_ticks_usec() - time_usec) / 1000.0;
 
+	GodotProfileZoneGrouped(_profile_zone, "particles_storage->update_particles");
 	RSG::particles_storage->update_particles(); //need to be done after instances are updated (colliders and particle transforms), and colliders are rendered
 
+	GodotProfileZoneGrouped(_profile_zone, "scene->render_probes");
 	RSG::scene->render_probes();
 
+	GodotProfileZoneGrouped(_profile_zone, "viewport->draw_viewports");
 	RSG::viewport->draw_viewports(p_swap_buffers);
+
+	GodotProfileZoneGrouped(_profile_zone, "canvas_render->update");
 	RSG::canvas_render->update();
 
+	GodotProfileZoneGrouped(_profile_zone, "rasterizer->end_frame");
 	RSG::rasterizer->end_frame(p_swap_buffers);
 
 #ifndef XR_DISABLED
 	if (xr_server != nullptr) {
+		GodotProfileZone("xr_server->end_frame");
 		// let our XR server know we're done so we can get our frame timing
 		xr_server->end_frame();
 	}
 #endif // XR_DISABLED
 
+	GodotProfileZoneGrouped(_profile_zone, "update_visibility_notifiers");
 	RSG::canvas->update_visibility_notifiers();
 	RSG::scene->update_visibility_notifiers();
 
+	GodotProfileZoneGrouped(_profile_zone, "post_draw_steps");
 	if (create_thread) {
 		callable_mp(this, &RenderingServerDefault::_run_post_draw_steps).call_deferred();
 	} else {
@@ -113,6 +127,7 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 	}
 
 	if (RSG::utilities->get_captured_timestamps_count()) {
+		GodotProfileZoneGrouped(_profile_zone, "frame_profile");
 		Vector<FrameProfileArea> new_profile;
 		if (RSG::utilities->capturing_timestamps) {
 			new_profile.resize(RSG::utilities->get_captured_timestamps_count());
@@ -143,6 +158,7 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 	frame_profile_frame = RSG::utilities->get_captured_timestamps_frame();
 
 	if (print_gpu_profile) {
+		GodotProfileZoneGrouped(_profile_zone, "gpu_profile");
 		if (print_frame_profile_ticks_from == 0) {
 			print_frame_profile_ticks_from = OS::get_singleton()->get_ticks_usec();
 		}
@@ -185,6 +201,7 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 		}
 	}
 
+	GodotProfileZoneGrouped(_profile_zone, "memory_info");
 	RSG::utilities->update_memory_info();
 }
 


### PR DESCRIPTION
This is a minimal implementation to support the [tracy profiler](https://github.com/wolfpld/tracy/releases/tag/v0.11.1) and the [perfetto profiler](https://perfetto.dev).

<img width="1512" alt="SCR-20250331-qkvh" src="https://github.com/user-attachments/assets/faf8ebd2-3ad3-44e2-9d77-91373e6e6a59" />

<img width="1510" alt="SCR-20250331-trct" src="https://github.com/user-attachments/assets/3abf5055-79f5-4350-b461-8dd369d8192d" />


- Related to https://github.com/godotengine/godot-proposals/issues/5346

If this is accepted, future PRs could expand the granularity of frame tracking to include the various servers, steps etc.
Future PRs could also add support for other profilers (e.g. Perfetto).

## Why?

Tracy is a popular profiler for games and other "real time" software. "Profiling" means tracking performance over time, to try to figure out the cause of lag spikes, low frame rates, high RAM use, and others. The ultimate goal of course being to eliminate those problems.

It is already possible to profile Godot games. For one, Godot has a small [profiler built-in](https://docs.godotengine.org/en/stable/tutorials/scripting/debug/the_profiler.html). However, it's lacking features for serious profiling tasks, especially to profile c++ code.

There are [guides](https://docs.godotengine.org/en/stable/contributing/development/debugging/using_cpp_profilers.html) to use external C++ profilers on the docs as well. These are capable of a lot, but there are features offered by tracy that are not supported by other profilers - for example per-frame profiling, which requires injection of a high precision callback to be worthwhile.

Here are the supported features per platform, stolen from the current [tracy manual](https://github.com/wolfpld/tracy/releases/download/v0.11.1/tracy.pdf):
<img width="866" alt="SCR-20250402-bhxh" src="https://github.com/user-attachments/assets/abf06f5c-988c-4878-b25f-0732db105813" />

## Alternatives

I am not familiar with any profilers except `Instruments` (including `tracy`). This PR is a first step to get familiar with them.
The idea is to establish a framework that allows injection of any useful intrusive profilers. For example, `Perfetto` may be integratable too, if desired by someone.

It is currently also possible to integrate tracy support with the [Godot Tracy Module](https://github.com/AndreaCatania/godot_tracy) (cc @AndreaCatania). This is a great effort, and I've referenced this for my implementation.
The reason I'm still proposing to integrate this into the engine itself is that intrusive changes to the codebase are required to support frame tracking, which is arguably the most useful feature of tracy. It would be nice for the engine to 'just' support this.

## Implementation notes

This is the first module I am working with / proposing. Chances are the approach is suboptimal. Please suggest improvements! :)

In particular, my idea was that you could include `profiling.h` and use generic macros to mark things to profile, regardless of the actual profiler used (in assumption that others work similar to `tracy` in this regard).

## License
Tracy uses the [`BSD` license](https://github.com/wolfpld/tracy/blob/master/LICENSE), which is compatible with ours (thanks @AThousandShips and @Calinou!)