### PR TITLE
[3.x] Physics Interpolation - Reduce unnecessary `VisualServer` updates

### DIFF
--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -105,20 +105,20 @@ void VisualInstance::_notification(int p_what) {
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (_is_vi_visible()) {
 				if (!_is_using_identity_transform()) {
-					// Physics interpolated VIs don't need to send their transform immediately after setting,
-					// indeed it is counterproductive, because the interpolated transform will be sent
-					// to the VisualServer immediately prior to rendering.
-					if (!is_physics_interpolated_and_enabled()) {
-						VisualServer::get_singleton()->instance_set_transform(instance, get_global_transform());
-					} else {
-						// For instance when first adding to the tree, when the previous transform is
-						// unset, to prevent streaking from the origin.
-						if (_is_physics_interpolation_reset_requested() && is_inside_tree()) {
-							if (_is_vi_visible()) {
-								_notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
-							}
+					// Physics interpolation cases.
+					if (is_inside_tree() && get_tree()->is_physics_interpolation_enabled()) {
+						// Physics interpolated VIs don't need to send their transform immediately after setting,
+						// indeed it is counterproductive, because the interpolated transform will be sent
+						// to the VisualServer immediately prior to rendering.
+						if (is_physics_interpolated() && _is_physics_interpolation_reset_requested()) {
+							// For instance when first adding to the tree, when the previous transform is
+							// unset, to prevent streaking from the origin.
+							_notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
 							_set_physics_interpolation_reset_requested(false);
 						}
+					} else {
+						// Physics interpolation global off, always send.
+						VisualServer::get_singleton()->instance_set_transform(instance, get_global_transform());
 					}
 				}
 			}


### PR DESCRIPTION
With the new `SceneTreeFTI`, most xforms are updated to the server externally by the FTI system, so it is no longer necessary to update the server on each `NOTIFICATION_TRANSFORM_CHANGED`.

Each call to `VisualServer::get_singleton()->instance_set_transform()` incurs some expense, so it is sensible to reduce these when they are superfluous (as a later update will be made by `SceneTreeFTI` immediately prior to rendering).

## Notes
* I didn't put this in the main PR both to keep it clear and free from excessive optimization, and because I wanted to look at this in isolation. There is the potential for regressions here so we can easily revert or bisect a self contained PR.
* With the old FTI I had previously looked at preventing propagation into non-interpolated branches (#103331) but with the new technique this is probably no longer appropriate, not least because we need to set `DIRTY_GLOBAL_INTERPOLATED`.
* Most of these `NOTIFICATION_TRANSFORM_CHANGED` will be no-ops for `VisualInstances` in this situation (which isn't ideal), however we need to (for now) allow any derived classes the opportunity to respond to the notification. This can possibly be further optimized in the future.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
