### PR TITLE
Fix time display in MovieWriter window title and console output

### DIFF
--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -184,10 +184,12 @@ void MovieWriter::set_extensions_hint() {
 
 void MovieWriter::add_frame() {
 	const int movie_time_seconds = Engine::get_singleton()->get_frames_drawn() / fps;
-	const String movie_time = vformat("%s:%s:%s",
-			String::num(movie_time_seconds / 3600).pad_zeros(2),
-			String::num((movie_time_seconds % 3600) / 60).pad_zeros(2),
-			String::num(movie_time_seconds % 60).pad_zeros(2));
+	const int frame_remainder = Engine::get_singleton()->get_frames_drawn() % fps;
+	const String movie_time = vformat("%s:%s:%s:%s",
+			String::num(movie_time_seconds / 3600, 0).pad_zeros(2),
+			String::num((movie_time_seconds % 3600) / 60, 0).pad_zeros(2),
+			String::num(movie_time_seconds % 60, 0).pad_zeros(2),
+			String::num(frame_remainder, 0).pad_zeros(2));
 
 #ifdef DEBUG_ENABLED
 	DisplayServer::get_singleton()->window_set_title(vformat("MovieWriter: Frame %d (time: %s) - %s (DEBUG)", Engine::get_singleton()->get_frames_drawn(), movie_time, project_name));
@@ -216,7 +218,7 @@ void MovieWriter::end() {
 	write_end();
 
 	// Print a report with various statistics.
-	print_line("----------------");
+	print_line("--------------------------------------------------------------------------------");
 	String movie_path = Engine::get_singleton()->get_write_movie_path();
 	if (movie_path.is_relative_path()) {
 		// Print absolute path to make finding the file easier,
@@ -226,19 +228,21 @@ void MovieWriter::end() {
 	print_line(vformat("Done recording movie at path: %s", movie_path));
 
 	const int movie_time_seconds = Engine::get_singleton()->get_frames_drawn() / fps;
-	const String movie_time = vformat("%s:%s:%s",
-			String::num(movie_time_seconds / 3600).pad_zeros(2),
-			String::num((movie_time_seconds % 3600) / 60).pad_zeros(2),
-			String::num(movie_time_seconds % 60).pad_zeros(2));
+	const int frame_remainder = Engine::get_singleton()->get_frames_drawn() % fps;
+	const String movie_time = vformat("%s:%s:%s:%s",
+			String::num(movie_time_seconds / 3600, 0).pad_zeros(2),
+			String::num((movie_time_seconds % 3600) / 60, 0).pad_zeros(2),
+			String::num(movie_time_seconds % 60, 0).pad_zeros(2),
+			String::num(frame_remainder, 0).pad_zeros(2));
 
 	const int real_time_seconds = Time::get_singleton()->get_ticks_msec() / 1000;
 	const String real_time = vformat("%s:%s:%s",
-			String::num(real_time_seconds / 3600).pad_zeros(2),
-			String::num((real_time_seconds % 3600) / 60).pad_zeros(2),
-			String::num(real_time_seconds % 60).pad_zeros(2));
+			String::num(real_time_seconds / 3600, 0).pad_zeros(2),
+			String::num((real_time_seconds % 3600) / 60, 0).pad_zeros(2),
+			String::num(real_time_seconds % 60, 0).pad_zeros(2));
 
-	print_line(vformat("%d frames at %d FPS (movie length: %s), recorded in %s (%d%% of real-time speed).", Engine::get_singleton()->get_frames_drawn(), fps, movie_time, real_time, (float(movie_time_seconds) / real_time_seconds) * 100));
+	print_line(vformat("%d frames at %d FPS (movie length: %s), recorded in %s (%d%% of real-time speed).", Engine::get_singleton()->get_frames_drawn(), fps, movie_time, real_time, (float(MAX(1, movie_time_seconds)) / MAX(1, real_time_seconds)) * 100));
 	print_line(vformat("CPU time: %.2f seconds (average: %.2f ms/frame)", cpu_time / 1000, cpu_time / Engine::get_singleton()->get_frames_drawn()));
 	print_line(vformat("GPU time: %.2f seconds (average: %.2f ms/frame)", gpu_time / 1000, gpu_time / Engine::get_singleton()->get_frames_drawn()));
-	print_line("----------------");
+	print_line("--------------------------------------------------------------------------------");
 }


### PR DESCRIPTION
Following the [change to `String::num()`](https://github.com/godotengine/godot/pull/47502), decimals were added even when numbers were being rounded to whole integers beforehand. Additionally, the frame remainder is displayed as a timecode to the window title and console output.

This also fixes a floating-point division by zero that occurred when the movie was recorded in less than 1 second of real time.

## Preview

### Before

![Screenshot_20250331_203211](https://github.com/user-attachments/assets/61406411-eb02-4493-aca9-1fb6473e4755)

```
----------------
Done recording movie at path: /tmp/out.avi
5 frames at 60 FPS (movie length: 00.0:00.0:00.0), recorded in 00.0:00.0:00.0 (--9223372036854775808% of real-time speed).
CPU time: 0.00 seconds (average: 0.37 ms/frame)
GPU time: 0.00 seconds (average: 0.00 ms/frame)
----------------
```

### After

![Screenshot_20250331_203337](https://github.com/user-attachments/assets/8692d622-ccb1-4514-b935-0f39fa0b108c)

```
--------------------------------------------------------------------------------
Done recording movie at path: /tmp/out.avi
5 frames at 60 FPS (movie length: 00:00:00:05), recorded in 00:00:00 (100% of real-time speed).
CPU time: 0.00 seconds (average: 0.35 ms/frame)
GPU time: 0.00 seconds (average: 0.00 ms/frame)
--------------------------------------------------------------------------------
```
