### PR TITLE
macOS: Allow users to select Continuity Camera

### DIFF
--- a/modules/camera/camera_macos.mm
+++ b/modules/camera/camera_macos.mm
@@ -309,17 +309,21 @@ MyDeviceNotifications *device_notifications = nil;
 // CameraMacOS - Subclass for our camera server on macOS
 
 void CameraMacOS::update_feeds() {
-#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
-	AVCaptureDeviceDiscoverySession *session;
-#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
-	// Avoid deprecated warning if the minimum SDK is 14.0.
-	session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternal, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
-#else
-	session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+	NSArray<AVCaptureDevice *> *devices = nullptr;
+#if defined(__x86_64__)
+	if (@available(macOS 10.15, *)) {
 #endif
-	NSArray<AVCaptureDevice *> *devices = session.devices;
-#else
-	NSArray<AVCaptureDevice *> *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+		AVCaptureDeviceDiscoverySession *session;
+		if (@available(macOS 14.0, *)) {
+			session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternal, AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeContinuityCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+		} else {
+			session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+		}
+		devices = session.devices;
+#if defined(__x86_64__)
+	} else {
+		devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+	}
 #endif
 
 	// remove devices that are gone..


### PR DESCRIPTION
fixed https://github.com/godotengine/godot-proposals/issues/12125
Added Continuity Camera to the device discovery session to provide users with more camera options. Users on macOS 13+ can now select their Continuity Camera device within the application.
https://support.apple.com/en-us/102546
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
