### PR TITLE
Prepare NavigationServer for `process()` and `physics_process()` split

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4648,10 +4648,10 @@ bool Main::iteration() {
 		uint64_t navigation_begin = OS::get_singleton()->get_ticks_usec();
 
 #ifndef NAVIGATION_2D_DISABLED
-		NavigationServer2D::get_singleton()->process(physics_step * time_scale);
+		NavigationServer2D::get_singleton()->physics_process(physics_step * time_scale);
 #endif // NAVIGATION_2D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
-		NavigationServer3D::get_singleton()->process(physics_step * time_scale);
+		NavigationServer3D::get_singleton()->physics_process(physics_step * time_scale);
 #endif // NAVIGATION_3D_DISABLED
 
 		navigation_process_ticks = MAX(navigation_process_ticks, OS::get_singleton()->get_ticks_usec() - navigation_begin); // keep the largest one for reference
@@ -4690,6 +4690,13 @@ bool Main::iteration() {
 		exit = true;
 	}
 	message_queue->flush();
+
+#ifndef NAVIGATION_2D_DISABLED
+	NavigationServer2D::get_singleton()->process(process_step * time_scale);
+#endif // NAVIGATION_2D_DISABLED
+#ifndef NAVIGATION_3D_DISABLED
+	NavigationServer3D::get_singleton()->process(process_step * time_scale);
+#endif // NAVIGATION_3D_DISABLED
 
 	RenderingServer::get_singleton()->sync(); //sync if still drawing from previous frames.
 

--- a/modules/navigation_2d/2d/godot_navigation_server_2d.h
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.h
@@ -320,7 +320,9 @@ public:
 	virtual void set_active(bool p_active) override;
 
 	void flush_queries();
-	virtual void process(real_t p_delta_time) override;
+
+	virtual void process(double p_delta_time) override;
+	virtual void physics_process(double p_delta_time) override;
 	virtual void init() override;
 	virtual void sync() override;
 	virtual void finish() override;

--- a/modules/navigation_2d/nav_map_2d.cpp
+++ b/modules/navigation_2d/nav_map_2d.cpp
@@ -532,10 +532,8 @@ void NavMap2D::compute_single_avoidance_step(uint32_t p_index, NavAgent2D **p_ag
 	(*(p_agent + p_index))->update();
 }
 
-void NavMap2D::step(real_t p_deltatime) {
-	deltatime = p_deltatime;
-
-	rvo_simulation.setTimeStep(float(deltatime));
+void NavMap2D::step(double p_delta_time) {
+	rvo_simulation.setTimeStep(float(p_delta_time));
 
 	if (active_avoidance_agents.size() > 0) {
 		if (use_threads && avoidance_use_multiple_threads) {

--- a/modules/navigation_2d/nav_map_2d.h
+++ b/modules/navigation_2d/nav_map_2d.h
@@ -91,9 +91,6 @@ class NavMap2D : public NavRid2D {
 	/// Are rvo obstacles modified?
 	bool obstacles_dirty = true;
 
-	/// Physics delta time.
-	real_t deltatime = 0.0;
-
 	/// Change the id each time the map is updated.
 	uint32_t iteration_id = 0;
 
@@ -203,7 +200,7 @@ public:
 	Vector2 get_random_point(uint32_t p_navigation_layers, bool p_uniformly) const;
 
 	void sync();
-	void step(real_t p_deltatime);
+	void step(double p_delta_time);
 	void dispatch_callbacks();
 
 	// Performance Monitor

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
@@ -1306,8 +1306,6 @@ void GodotNavigationServer3D::set_active(bool p_active) {
 }
 
 void GodotNavigationServer3D::flush_queries() {
-	// In c++ we can't be sure that this is performed in the main thread
-	// even with mutable functions.
 	MutexLock lock(commands_mutex);
 	MutexLock lock2(operations_mutex);
 
@@ -1340,7 +1338,21 @@ void GodotNavigationServer3D::sync() {
 	}
 }
 
-void GodotNavigationServer3D::process(real_t p_delta_time) {
+void GodotNavigationServer3D::process(double p_delta_time) {
+	// Called for each main loop iteration AFTER node and user script process() and BEFORE RenderingServer sync.
+	// Will run reliably every rendered frame independent of the physics tick rate.
+	// Use for things that (only) need to update once per main loop iteration and rendered frame or is visible to the user.
+	// E.g. (final) sync of objects for this main loop iteration, updating rendered debug visuals, updating debug statistics, ...
+}
+
+void GodotNavigationServer3D::physics_process(double p_delta_time) {
+	// Called for each physics process step AFTER node and user script physics_process() and BEFORE PhysicsServer sync.
+	// Will NOT run reliably every rendered frame. If there is no physics step this function will not run.
+	// Use for physics or step depending calculations and updates where the result affects the next step calculation.
+	// E.g. anything physics sync related, avoidance simulations, physics space state queries, ...
+	// If physics process needs to play catchup this function will be called multiple times per frame so it should not hold
+	// costly updates that are not important outside the stepped calculations to avoid causing a physics performance death spiral.
+
 	flush_queries();
 
 	if (!active) {

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.h
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.h
@@ -280,7 +280,9 @@ public:
 	virtual void set_active(bool p_active) override;
 
 	void flush_queries();
-	virtual void process(real_t p_delta_time) override;
+
+	virtual void process(double p_delta_time) override;
+	virtual void physics_process(double p_delta_time) override;
 	virtual void init() override;
 	virtual void sync() override;
 	virtual void finish() override;

--- a/modules/navigation_3d/nav_map_3d.cpp
+++ b/modules/navigation_3d/nav_map_3d.cpp
@@ -614,11 +614,9 @@ void NavMap3D::compute_single_avoidance_step_3d(uint32_t index, NavAgent3D **age
 	(*(agent + index))->update();
 }
 
-void NavMap3D::step(real_t p_deltatime) {
-	deltatime = p_deltatime;
-
-	rvo_simulation_2d.setTimeStep(float(deltatime));
-	rvo_simulation_3d.setTimeStep(float(deltatime));
+void NavMap3D::step(double p_delta_time) {
+	rvo_simulation_2d.setTimeStep(float(p_delta_time));
+	rvo_simulation_3d.setTimeStep(float(p_delta_time));
 
 	if (active_2d_avoidance_agents.size() > 0) {
 		if (use_threads && avoidance_use_multiple_threads) {

--- a/modules/navigation_3d/nav_map_3d.h
+++ b/modules/navigation_3d/nav_map_3d.h
@@ -99,9 +99,6 @@ class NavMap3D : public NavRid3D {
 	/// Are rvo obstacles modified?
 	bool obstacles_dirty = true;
 
-	/// Physics delta time
-	real_t deltatime = 0.0;
-
 	/// Change the id each time the map is updated.
 	uint32_t iteration_id = 0;
 
@@ -221,7 +218,7 @@ public:
 	Vector3 get_random_point(uint32_t p_navigation_layers, bool p_uniformly) const;
 
 	void sync();
-	void step(real_t p_deltatime);
+	void step(double p_delta_time);
 	void dispatch_callbacks();
 
 	// Performance Monitor

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -308,7 +308,8 @@ public:
 	/// The result of this process is needed by the physics server,
 	/// so this must be called in the main thread.
 	/// Note: This function is not thread safe.
-	virtual void process(real_t delta_time) = 0;
+	virtual void process(double p_delta_time) = 0;
+	virtual void physics_process(double p_delta_time) = 0;
 	virtual void init() = 0;
 	virtual void sync() = 0;
 	virtual void finish() = 0;

--- a/servers/navigation_server_2d_dummy.h
+++ b/servers/navigation_server_2d_dummy.h
@@ -163,8 +163,8 @@ public:
 	void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result, const Callable &p_callback = Callable()) override {}
 
 	void set_active(bool p_active) override {}
-
-	void process(real_t delta_time) override {}
+	void process(double p_delta_time) override {}
+	void physics_process(double p_delta_time) override {}
 	void init() override {}
 	void sync() override {}
 	void finish() override {}

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -346,7 +346,8 @@ public:
 	/// The result of this process is needed by the physics server,
 	/// so this must be called in the main thread.
 	/// Note: This function is not thread safe.
-	virtual void process(real_t delta_time) = 0;
+	virtual void process(double p_delta_time) = 0;
+	virtual void physics_process(double p_delta_time) = 0;
 	virtual void init() = 0;
 	virtual void sync() = 0;
 	virtual void finish() = 0;

--- a/servers/navigation_server_3d_dummy.h
+++ b/servers/navigation_server_3d_dummy.h
@@ -196,7 +196,8 @@ public:
 
 	void free(RID p_object) override {}
 	void set_active(bool p_active) override {}
-	void process(real_t delta_time) override {}
+	void process(double p_delta_time) override {}
+	void physics_process(double p_delta_time) override {}
 	void init() override {}
 	void sync() override {}
 	void finish() override {}

--- a/tests/servers/test_navigation_server_2d.h
+++ b/tests/servers/test_navigation_server_2d.h
@@ -120,7 +120,7 @@ TEST_SUITE("[Navigation2D]") {
 		SUBCASE("Setters/getters should work") {
 			bool initial_avoidance_enabled = navigation_server->agent_get_avoidance_enabled(agent);
 			navigation_server->agent_set_avoidance_enabled(agent, !initial_avoidance_enabled);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 			CHECK_EQ(navigation_server->agent_get_avoidance_enabled(agent), !initial_avoidance_enabled);
 			// TODO: Add remaining setters/getters once the missing getters are added.
@@ -131,11 +131,11 @@ TEST_SUITE("[Navigation2D]") {
 			CHECK(map.is_valid());
 			navigation_server->map_set_active(map, true);
 			navigation_server->agent_set_map(agent, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_AGENT_COUNT), 1);
 			navigation_server->agent_set_map(agent, RID());
 			navigation_server->free(map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_AGENT_COUNT), 0);
 		}
 
@@ -184,7 +184,7 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->map_set_link_connection_radius(map, 0.77);
 			bool initial_use_edge_connections = navigation_server->map_get_use_edge_connections(map);
 			navigation_server->map_set_use_edge_connections(map, !initial_use_edge_connections);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 			CHECK_EQ(navigation_server->map_get_cell_size(map), doctest::Approx(0.55));
 			CHECK_EQ(navigation_server->map_get_edge_connection_margin(map), doctest::Approx(0.66));
@@ -194,11 +194,11 @@ TEST_SUITE("[Navigation2D]") {
 
 		SUBCASE("'ProcessInfo' should report map iff active") {
 			navigation_server->map_set_active(map, true);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK(navigation_server->map_is_active(map));
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_ACTIVE_MAPS), 1);
 			navigation_server->map_set_active(map, false);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_ACTIVE_MAPS), 0);
 		}
 
@@ -206,10 +206,10 @@ TEST_SUITE("[Navigation2D]") {
 			RID agent = navigation_server->agent_create();
 			CHECK(agent.is_valid());
 			navigation_server->agent_set_map(agent, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_agents(map).size(), 1);
 			navigation_server->free(agent);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_agents(map).size(), 0);
 		}
 
@@ -217,10 +217,10 @@ TEST_SUITE("[Navigation2D]") {
 			RID link = navigation_server->link_create();
 			CHECK(link.is_valid());
 			navigation_server->link_set_map(link, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_links(map).size(), 1);
 			navigation_server->free(link);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_links(map).size(), 0);
 		}
 
@@ -228,10 +228,10 @@ TEST_SUITE("[Navigation2D]") {
 			RID obstacle = navigation_server->obstacle_create();
 			CHECK(obstacle.is_valid());
 			navigation_server->obstacle_set_map(obstacle, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_obstacles(map).size(), 1);
 			navigation_server->free(obstacle);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_obstacles(map).size(), 0);
 		}
 
@@ -239,16 +239,16 @@ TEST_SUITE("[Navigation2D]") {
 			RID region = navigation_server->region_create();
 			CHECK(region.is_valid());
 			navigation_server->region_set_map(region, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_regions(map).size(), 1);
 			navigation_server->free(region);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_regions(map).size(), 0);
 		}
 
 		SUBCASE("Queries against empty map should return empty or invalid values") {
 			navigation_server->map_set_active(map, true);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 			ERR_PRINT_OFF;
 			CHECK_EQ(navigation_server->map_get_closest_point(map, Vector2(7, 7)), Vector2());
@@ -271,11 +271,11 @@ TEST_SUITE("[Navigation2D]") {
 			ERR_PRINT_ON;
 
 			navigation_server->map_set_active(map, false);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		}
 
 		navigation_server->free(map);
-		navigation_server->process(0.0); // Give server some cycles to actually remove map.
+		navigation_server->physics_process(0.0); // Give server some cycles to actually remove map.
 		CHECK_EQ(navigation_server->get_maps().size(), 0);
 	}
 
@@ -298,7 +298,7 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->link_set_owner_id(link, ObjectID((int64_t)7));
 			navigation_server->link_set_start_position(link, Vector2(8, 8));
 			navigation_server->link_set_travel_cost(link, 0.66);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 			CHECK_EQ(navigation_server->link_is_bidirectional(link), !initial_bidirectional);
 			CHECK_EQ(navigation_server->link_get_end_position(link), Vector2(7, 7));
@@ -314,11 +314,11 @@ TEST_SUITE("[Navigation2D]") {
 			CHECK(map.is_valid());
 			navigation_server->map_set_active(map, true);
 			navigation_server->link_set_map(link, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_LINK_COUNT), 1);
 			navigation_server->link_set_map(link, RID());
 			navigation_server->free(map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_LINK_COUNT), 0);
 		}
 
@@ -353,7 +353,7 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->region_set_owner_id(region, ObjectID((int64_t)7));
 			navigation_server->region_set_travel_cost(region, 0.66);
 			navigation_server->region_set_use_edge_connections(region, !initial_use_edge_connections);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 			CHECK_EQ(navigation_server->region_get_enter_cost(region), doctest::Approx(0.55));
 			CHECK_EQ(navigation_server->region_get_navigation_layers(region), 5);
@@ -367,11 +367,11 @@ TEST_SUITE("[Navigation2D]") {
 			CHECK(map.is_valid());
 			navigation_server->map_set_active(map, true);
 			navigation_server->region_set_map(region, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_REGION_COUNT), 1);
 			navigation_server->region_set_map(region, RID());
 			navigation_server->free(map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_REGION_COUNT), 0);
 		}
 
@@ -400,7 +400,7 @@ TEST_SUITE("[Navigation2D]") {
 		CallableMock agent_avoidance_callback_mock;
 		navigation_server->agent_set_avoidance_callback(agent, callable_mp(&agent_avoidance_callback_mock, &CallableMock::function1));
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 0);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 1);
 		CHECK_NE(agent_avoidance_callback_mock.function1_latest_arg0, Vector3(0, 0, 0));
 
@@ -436,7 +436,7 @@ TEST_SUITE("[Navigation2D]") {
 
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 0);
 		CHECK_EQ(agent_2_avoidance_callback_mock.function1_calls, 0);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 1);
 		CHECK_EQ(agent_2_avoidance_callback_mock.function1_calls, 1);
 		Vector3 agent_1_safe_velocity = agent_1_avoidance_callback_mock.function1_latest_arg0;
@@ -474,7 +474,7 @@ TEST_SUITE("[Navigation2D]") {
 		navigation_server->obstacle_set_radius(obstacle_1, 1);
 
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 0);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 1);
 		Vector3 agent_1_safe_velocity = agent_1_avoidance_callback_mock.function1_latest_arg0;
 		CHECK_MESSAGE(agent_1_safe_velocity.x > 0, "Agent 1 should move a bit along desired velocity (+X).");
@@ -483,7 +483,7 @@ TEST_SUITE("[Navigation2D]") {
 		navigation_server->free(obstacle_1);
 		navigation_server->free(agent_1);
 		navigation_server->free(map);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
 	TEST_CASE("[NavigationServer2D] Server should make agents avoid static obstacles when avoidance enabled") {
@@ -525,7 +525,7 @@ TEST_SUITE("[Navigation2D]") {
 
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 0);
 		CHECK_EQ(agent_2_avoidance_callback_mock.function1_calls, 0);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 1);
 		CHECK_EQ(agent_2_avoidance_callback_mock.function1_calls, 1);
 		Vector3 agent_1_safe_velocity = agent_1_avoidance_callback_mock.function1_latest_arg0;
@@ -539,7 +539,7 @@ TEST_SUITE("[Navigation2D]") {
 		navigation_server->free(agent_2);
 		navigation_server->free(agent_1);
 		navigation_server->free(map);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
 	TEST_CASE("[NavigationServer2D][SceneTree] Server should be able to parse geometry") {
@@ -614,7 +614,7 @@ TEST_SUITE("[Navigation2D]") {
 		navigation_server->map_set_use_async_iterations(map, false);
 		navigation_server->region_set_map(region, map);
 		navigation_server->region_set_navigation_polygon(region, navigation_polygon);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 		CHECK_EQ(navigation_polygon->get_polygon_count(), 0);
 		CHECK_EQ(navigation_polygon->get_vertices().size(), 0);
@@ -633,7 +633,7 @@ TEST_SUITE("[Navigation2D]") {
 		SUBCASE("Map should emit signal and take newly baked navigation mesh into account") {
 			SIGNAL_WATCH(navigation_server, "map_changed");
 			SIGNAL_CHECK_FALSE("map_changed");
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			SIGNAL_CHECK("map_changed", build_array(build_array(map)));
 			SIGNAL_UNWATCH(navigation_server, "map_changed");
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector2(0, 0)), Vector2(0, 0));
@@ -641,7 +641,7 @@ TEST_SUITE("[Navigation2D]") {
 
 		navigation_server->free(region);
 		navigation_server->free(map);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 		memdelete(polygon);
 		memdelete(node_2d);
@@ -671,7 +671,7 @@ TEST_SUITE("[Navigation2D]") {
 		navigation_server->map_set_use_async_iterations(map, false);
 		navigation_server->region_set_map(region, map);
 		navigation_server->region_set_navigation_polygon(region, navigation_polygon);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 		SUBCASE("Simple queries should return non-default values") {
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector2(0.0, 0.0)), Vector2(0, 0));
@@ -746,7 +746,7 @@ TEST_SUITE("[Navigation2D]") {
 
 		navigation_server->free(region);
 		navigation_server->free(map);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
 	TEST_CASE("[NavigationServer2D] Server should simplify path properly") {

--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -91,7 +91,7 @@ TEST_SUITE("[Navigation3D]") {
 		SUBCASE("Setters/getters should work") {
 			bool initial_use_3d_avoidance = navigation_server->agent_get_use_3d_avoidance(agent);
 			navigation_server->agent_set_use_3d_avoidance(agent, !initial_use_3d_avoidance);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 			CHECK_EQ(navigation_server->agent_get_use_3d_avoidance(agent), !initial_use_3d_avoidance);
 			// TODO: Add remaining setters/getters once the missing getters are added.
@@ -102,11 +102,11 @@ TEST_SUITE("[Navigation3D]") {
 			CHECK(map.is_valid());
 			navigation_server->map_set_active(map, true);
 			navigation_server->agent_set_map(agent, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_AGENT_COUNT), 1);
 			navigation_server->agent_set_map(agent, RID());
 			navigation_server->free(map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_AGENT_COUNT), 0);
 		}
 
@@ -157,7 +157,7 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->map_set_up(map, Vector3(1, 0, 0));
 			bool initial_use_edge_connections = navigation_server->map_get_use_edge_connections(map);
 			navigation_server->map_set_use_edge_connections(map, !initial_use_edge_connections);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 			CHECK_EQ(navigation_server->map_get_cell_size(map), doctest::Approx(0.55));
 			CHECK_EQ(navigation_server->map_get_edge_connection_margin(map), doctest::Approx(0.66));
@@ -168,11 +168,11 @@ TEST_SUITE("[Navigation3D]") {
 
 		SUBCASE("'ProcessInfo' should report map iff active") {
 			navigation_server->map_set_active(map, true);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK(navigation_server->map_is_active(map));
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_ACTIVE_MAPS), 1);
 			navigation_server->map_set_active(map, false);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_ACTIVE_MAPS), 0);
 		}
 
@@ -180,10 +180,10 @@ TEST_SUITE("[Navigation3D]") {
 			RID agent = navigation_server->agent_create();
 			CHECK(agent.is_valid());
 			navigation_server->agent_set_map(agent, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_agents(map).size(), 1);
 			navigation_server->free(agent);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_agents(map).size(), 0);
 		}
 
@@ -191,10 +191,10 @@ TEST_SUITE("[Navigation3D]") {
 			RID link = navigation_server->link_create();
 			CHECK(link.is_valid());
 			navigation_server->link_set_map(link, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_links(map).size(), 1);
 			navigation_server->free(link);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_links(map).size(), 0);
 		}
 
@@ -202,10 +202,10 @@ TEST_SUITE("[Navigation3D]") {
 			RID obstacle = navigation_server->obstacle_create();
 			CHECK(obstacle.is_valid());
 			navigation_server->obstacle_set_map(obstacle, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_obstacles(map).size(), 1);
 			navigation_server->free(obstacle);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_obstacles(map).size(), 0);
 		}
 
@@ -213,16 +213,16 @@ TEST_SUITE("[Navigation3D]") {
 			RID region = navigation_server->region_create();
 			CHECK(region.is_valid());
 			navigation_server->region_set_map(region, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_regions(map).size(), 1);
 			navigation_server->free(region);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_regions(map).size(), 0);
 		}
 
 		SUBCASE("Queries against empty map should return empty or invalid values") {
 			navigation_server->map_set_active(map, true);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 			ERR_PRINT_OFF;
 			CHECK_EQ(navigation_server->map_get_closest_point(map, Vector3(7, 7, 7)), Vector3());
@@ -246,11 +246,11 @@ TEST_SUITE("[Navigation3D]") {
 			ERR_PRINT_ON;
 
 			navigation_server->map_set_active(map, false);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		}
 
 		navigation_server->free(map);
-		navigation_server->process(0.0); // Give server some cycles to actually remove map.
+		navigation_server->physics_process(0.0); // Give server some cycles to actually remove map.
 		CHECK_EQ(navigation_server->get_maps().size(), 0);
 	}
 
@@ -273,7 +273,7 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->link_set_owner_id(link, ObjectID((int64_t)7));
 			navigation_server->link_set_start_position(link, Vector3(8, 8, 8));
 			navigation_server->link_set_travel_cost(link, 0.66);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 			CHECK_EQ(navigation_server->link_is_bidirectional(link), !initial_bidirectional);
 			CHECK_EQ(navigation_server->link_get_end_position(link), Vector3(7, 7, 7));
@@ -289,11 +289,11 @@ TEST_SUITE("[Navigation3D]") {
 			CHECK(map.is_valid());
 			navigation_server->map_set_active(map, true);
 			navigation_server->link_set_map(link, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_LINK_COUNT), 1);
 			navigation_server->link_set_map(link, RID());
 			navigation_server->free(map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_LINK_COUNT), 0);
 		}
 
@@ -328,7 +328,7 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->region_set_owner_id(region, ObjectID((int64_t)7));
 			navigation_server->region_set_travel_cost(region, 0.66);
 			navigation_server->region_set_use_edge_connections(region, !initial_use_edge_connections);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 			CHECK_EQ(navigation_server->region_get_enter_cost(region), doctest::Approx(0.55));
 			CHECK_EQ(navigation_server->region_get_navigation_layers(region), 5);
@@ -342,11 +342,11 @@ TEST_SUITE("[Navigation3D]") {
 			CHECK(map.is_valid());
 			navigation_server->map_set_active(map, true);
 			navigation_server->region_set_map(region, map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_REGION_COUNT), 1);
 			navigation_server->region_set_map(region, RID());
 			navigation_server->free(map);
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_REGION_COUNT), 0);
 		}
 
@@ -375,7 +375,7 @@ TEST_SUITE("[Navigation3D]") {
 		CallableMock agent_avoidance_callback_mock;
 		navigation_server->agent_set_avoidance_callback(agent, callable_mp(&agent_avoidance_callback_mock, &CallableMock::function1));
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 0);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 1);
 		CHECK_NE(agent_avoidance_callback_mock.function1_latest_arg0, Vector3(0, 0, 0));
 
@@ -411,7 +411,7 @@ TEST_SUITE("[Navigation3D]") {
 
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 0);
 		CHECK_EQ(agent_2_avoidance_callback_mock.function1_calls, 0);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 1);
 		CHECK_EQ(agent_2_avoidance_callback_mock.function1_calls, 1);
 		Vector3 agent_1_safe_velocity = agent_1_avoidance_callback_mock.function1_latest_arg0;
@@ -449,7 +449,7 @@ TEST_SUITE("[Navigation3D]") {
 		navigation_server->obstacle_set_radius(obstacle_1, 1);
 
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 0);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 1);
 		Vector3 agent_1_safe_velocity = agent_1_avoidance_callback_mock.function1_latest_arg0;
 		CHECK_MESSAGE(agent_1_safe_velocity.x > 0, "Agent 1 should move a bit along desired velocity (+X).");
@@ -458,7 +458,7 @@ TEST_SUITE("[Navigation3D]") {
 		navigation_server->free(obstacle_1);
 		navigation_server->free(agent_1);
 		navigation_server->free(map);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
 	TEST_CASE("[NavigationServer3D] Server should make agents avoid static obstacles when avoidance enabled") {
@@ -508,7 +508,7 @@ TEST_SUITE("[Navigation3D]") {
 
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 0);
 		CHECK_EQ(agent_2_avoidance_callback_mock.function1_calls, 0);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 1);
 		CHECK_EQ(agent_2_avoidance_callback_mock.function1_calls, 1);
 		Vector3 agent_1_safe_velocity = agent_1_avoidance_callback_mock.function1_latest_arg0;
@@ -522,7 +522,7 @@ TEST_SUITE("[Navigation3D]") {
 		navigation_server->free(agent_2);
 		navigation_server->free(agent_1);
 		navigation_server->free(map);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
 #ifndef DISABLE_DEPRECATED
@@ -548,7 +548,7 @@ TEST_SUITE("[Navigation3D]") {
 		navigation_server->map_set_active(map, true);
 		navigation_server->region_set_map(region, map);
 		navigation_server->region_set_navigation_mesh(region, navigation_mesh);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 		CHECK_EQ(navigation_mesh->get_polygon_count(), 0);
 		CHECK_EQ(navigation_mesh->get_vertices().size(), 0);
@@ -564,7 +564,7 @@ TEST_SUITE("[Navigation3D]") {
 		SUBCASE("Map should emit signal and take newly baked navigation mesh into account") {
 			SIGNAL_WATCH(navigation_server, "map_changed");
 			SIGNAL_CHECK_FALSE("map_changed");
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			SIGNAL_CHECK("map_changed", build_array(build_array(map)));
 			SIGNAL_UNWATCH(navigation_server, "map_changed");
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector3(0, 0, 0)), Vector3(0, 0, 0));
@@ -572,7 +572,7 @@ TEST_SUITE("[Navigation3D]") {
 
 		navigation_server->free(region);
 		navigation_server->free(map);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		memdelete(mesh_instance);
 		memdelete(node_3d);
 	}
@@ -644,7 +644,7 @@ TEST_SUITE("[Navigation3D]") {
 		navigation_server->map_set_active(map, true);
 		navigation_server->region_set_map(region, map);
 		navigation_server->region_set_navigation_mesh(region, navigation_mesh);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 		CHECK_EQ(navigation_mesh->get_polygon_count(), 0);
 		CHECK_EQ(navigation_mesh->get_vertices().size(), 0);
@@ -660,7 +660,7 @@ TEST_SUITE("[Navigation3D]") {
 		SUBCASE("Map should emit signal and take newly baked navigation mesh into account") {
 			SIGNAL_WATCH(navigation_server, "map_changed");
 			SIGNAL_CHECK_FALSE("map_changed");
-			navigation_server->process(0.0); // Give server some cycles to commit.
+			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			SIGNAL_CHECK("map_changed", build_array(build_array(map)));
 			SIGNAL_UNWATCH(navigation_server, "map_changed");
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector3(0, 0, 0)), Vector3(0, 0, 0));
@@ -668,7 +668,7 @@ TEST_SUITE("[Navigation3D]") {
 
 		navigation_server->free(region);
 		navigation_server->free(map);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		memdelete(mesh_instance);
 		memdelete(node_3d);
 	}
@@ -693,7 +693,7 @@ TEST_SUITE("[Navigation3D]") {
 		navigation_server->map_set_use_async_iterations(map, false);
 		navigation_server->region_set_map(region, map);
 		navigation_server->region_set_navigation_mesh(region, navigation_mesh);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 		SUBCASE("Simple queries should return non-default values") {
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector3(0, 0, 0)), Vector3(0, 0, 0));
@@ -807,7 +807,7 @@ TEST_SUITE("[Navigation3D]") {
 
 		navigation_server->free(region);
 		navigation_server->free(map);
-		navigation_server->process(0.0); // Give server some cycles to commit.
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
 	// FIXME: The race condition mentioned below is actually a problem and fails on CI (GH-90613).


### PR DESCRIPTION
Prepares the NavigationServer API for a split of its functionality between frame `process()` and stepped `physics_process()`.

Right now the NavigationServer syncs everything with each physic process step.

Only the RVO avoidance is a stepped process that actually requires physics process steps. This current dependency on physics causes a number of issues for all kinds of other things.

Main motivation and reasoning to split physics process and process:
- Lots of delay and unexpected sync behavior for users when running with physics process for stuff that has zero dependency or relation with physics or a stepped process.
E.g. navigation map, navmesh syncs, path queries, ... they all have nothing to do with physics or a stepped process. The common user expectation is that they should always update as soon as possible and performance feasible instead of waiting x-frames until physics decides to finally do something.
Some users with a low physics tick in their project need to await the sync in their scripts a random x-times until even a NavigationServer update finally happens. Explaining that physics mess to new users over and over is frustrating.
- Lots of opportunities to trigger a performance physics death spiral due the costly updates of the NavigationServer in situations where physics already is trying to play step catchup.
Most updates of the NavigationServer have no benefit for being done more than once in a loop per main iteration frame. It is all wasted performance when run in a physics iteration loop that does between 0 to 8 steps per frame.
- In case of rendering debug with the server the rendered visuals all stutter and are unresponsive when the server only has physics process for its update available. So we need the frame process available through the server api anyway soon™.

I didn't want to cramp all the server changes into the same PR so the newer process() function is only a stub function in this PR for now. I have a few development branches that alread work with this split and git makes a rebase mess everytime for me so it would be good to have that change in already.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
