### PR TITLE
Add `volume_db` to the wav importer

### DIFF
--- a/doc/classes/ResourceImporterWAV.xml
+++ b/doc/classes/ResourceImporterWAV.xml
@@ -38,6 +38,10 @@
 		<member name="edit/trim" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], automatically trim the beginning and end of the audio if it's lower than -50 dB after normalization (see [member edit/normalize]). This prevents having files with silence at the beginning or end, which increases their size unnecessarily and adds latency to the moment they are played back. A fade-in/fade-out period of 500 samples is also used during trimming to avoid audible pops.
 		</member>
+		<member name="edit/volume_db" type="float" setter="" getter="" default="0.0">
+			Adjusts the audio's volume by this many decibels. Applied after normalization.
+			[b]Note:[/b] Clipping may occur with positive values. A warning will be shown if this happens.
+		</member>
 		<member name="force/8_bit" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], forces the imported audio to use 8-bit quantization if the source file is 16-bit or higher.
 			Enabling this is generally not recommended, as 8-bit quantization decreases audio quality significantly. If you need smaller file sizes, consider using Ogg Vorbis or MP3 audio instead.

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -80,6 +80,7 @@ void ResourceImporterWAV::get_import_options(const String &p_path, List<ImportOp
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "force/max_rate_hz", PROPERTY_HINT_RANGE, "11025,192000,1,exp"), 44100));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "edit/trim"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "edit/normalize"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "edit/volume_db", PROPERTY_HINT_RANGE, "-24,24,0.001,or_greater,or_less,exp"), 0.0));
 	// Keep the `edit/loop_mode` enum in sync with AudioStreamWAV::LoopMode (note: +1 offset due to "Detect From WAV").
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "edit/loop_mode", PROPERTY_HINT_ENUM, "Detect From WAV,Disabled,Forward,Ping-Pong,Backward", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "edit/loop_begin"), 0));

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -947,6 +947,20 @@ Ref<AudioStreamWAV> AudioStreamWAV::load_from_buffer(const Vector<uint8_t> &p_st
 		}
 	}
 
+	float volume_db = p_options["edit/volume_db"];
+	if (volume_db != 0.0f) {
+		float volume_linear = Math::db_to_linear(volume_db);
+		float max = 0.0f;
+		for (int i = 0; i < data.size(); i++) {
+			data.write[i] *= volume_linear;
+			max = MAX(max, abs(data[i]));
+			data.write[i] = CLAMP(data[i], -1.0f, 1.0f);
+		}
+		if (max > 1.0f) {
+			WARN_PRINT(vformat("%f decibels of clipping occurred when importing WAV. Consider lowering \"Volume dB\" on the WAV import panel.", Math::linear_to_db(max)));
+		}
+	}
+
 	bool trim = p_options["edit/trim"];
 
 	if (trim && (loop_mode == AudioStreamWAV::LOOP_DISABLED) && format_channels > 0) {


### PR DESCRIPTION
This adds a `volume_db` setting to the wav importer. Works similarly to normalization where the change is baked into the imported data. Produces a warning if the audio clips when importing.