### PR TITLE
Fix animation track subproperty hints

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4593,12 +4593,6 @@ PropertyInfo AnimationTrackEditor::_find_hint_for_track(int p_idx, NodePath &r_b
 		}
 	}
 
-	if (property_info_base.is_null()) {
-		WARN_PRINT(vformat("Could not determine track hint for '%s:%s' because its base property is null.",
-				String(path.get_concatenated_names()), String(path.get_concatenated_subnames())));
-		return PropertyInfo();
-	}
-
 	List<PropertyInfo> pinfo;
 	property_info_base.get_property_list(&pinfo);
 
@@ -4607,6 +4601,9 @@ PropertyInfo AnimationTrackEditor::_find_hint_for_track(int p_idx, NodePath &r_b
 			return E;
 		}
 	}
+
+	WARN_PRINT(vformat("Could not determine track hint for '%s:%s' because its base property is null.",
+			String(path.get_concatenated_names()), String(path.get_concatenated_subnames())));
 
 	return PropertyInfo();
 }

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4576,7 +4576,7 @@ PropertyInfo AnimationTrackEditor::_find_hint_for_track(int p_idx, NodePath &r_b
 
 	// Hack for the fact that bezier tracks leftover paths can reference
 	// the individual components for types like vectors.
-	if (property_info_base.is_null()) {
+	if (animation->track_get_type(p_idx) == Animation::TYPE_BEZIER && property_info_base.is_null()) {
 		if (res.is_valid()) {
 			property_info_base = res;
 		} else if (node) {


### PR DESCRIPTION
Simple AnimationPlayer-related fixes:
- Check the property list first before showing the "no track hint warning" introduced by #84129 so that it doesn't skip subproperties.
- Only apply fix introduced by #96789 to bezier track types, because this fix removes the subproperty from the path which is needed for bezier tracks but causes a bug for normal value track types with subproperties.

*Bugsquad edit:* Fixes #99115 Fixes #102130