### PR TITLE
Optimize HTML color validation

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -368,22 +368,21 @@ Color Color::html(const String &p_rgba) {
 bool Color::html_is_valid(const String &p_color) {
 	String color = p_color;
 
-	if (color.length() == 0) {
+	if (color.is_empty()) {
 		return false;
 	}
-	if (color[0] == '#') {
-		color = color.substr(1);
-	}
 
-	// Check if the amount of hex digits is valid.
+	int current_pos = (color[0] == '#') ? 1 : 0;
 	int len = color.length();
-	if (!(len == 3 || len == 4 || len == 6 || len == 8)) {
+	int num_of_digits = len - current_pos;
+	if (!(num_of_digits == 3 || num_of_digits == 4 || num_of_digits == 6 || num_of_digits == 8)) {
 		return false;
 	}
 
 	// Check if each hex digit is valid.
-	for (int i = 0; i < len; i++) {
-		if (_parse_col4(color, i) == -1) {
+	for (int i = current_pos; i < num_of_digits; i++) {
+		char c = p_color[current_pos];
+		if (!(c >= '0' && c <= '9') && !(c >= 'a' && c <= 'f') && !(c >= 'A' && c <= 'F')) {
 			return false;
 		}
 	}


### PR DESCRIPTION
I was surprised to see this bottlenecking my app, so I checked Godot's source code and sure enough, it's quite unoptimized.

Below are some GDScript benchmarks of the current master, dev build, 100k runs - I timed various strings against the empty string case.

**--- Invalid colors ---**
2 digits: 0.4ms
2 digits with #: 37.8ms
9 digits: 0.5ms
9 digits with #: 37.5ms
8 digits, bad char on pos 2: 5.9ms
8 digits with #, bad char on pos 2: 50.3ms
8 digits, bad char on pos 8: 24.3ms
8 digits with #, bad char on pos 8: 64.7ms
10000 digits: 0.9ms
10000 digits with #: 288ms

**--- Valid colors ---**
3 digits: 2.4ms
3 digits with #: 42ms
4 digits: 11.6ms
4 digits with #: 52.7ms
6 digits: 17.4ms
6 digits with #: 57.5ms
8 digits: 23.8ms
8 digits with #: 63.6ms

-----

With this PR, all of them took 0.2-0.5ms.