### PR TITLE
Optimize Color HTML validation

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -368,22 +368,20 @@ Color Color::html(const String &p_rgba) {
 bool Color::html_is_valid(const String &p_color) {
 	String color = p_color;
 
-	if (color.length() == 0) {
+	if (color.is_empty()) {
 		return false;
 	}
-	if (color[0] == '#') {
-		color = color.substr(1);
-	}
 
-	// Check if the amount of hex digits is valid.
+	int current_pos = (color[0] == '#') ? 1 : 0;
 	int len = color.length();
-	if (!(len == 3 || len == 4 || len == 6 || len == 8)) {
+	int num_of_digits = len - current_pos;
+	if (!(num_of_digits == 3 || num_of_digits == 4 || num_of_digits == 6 || num_of_digits == 8)) {
 		return false;
 	}
 
 	// Check if each hex digit is valid.
-	for (int i = 0; i < len; i++) {
-		if (_parse_col4(color, i) == -1) {
+	for (int i = current_pos; i < len; i++) {
+		if (!is_hex_digit(p_color[i])) {
 			return false;
 		}
 	}


### PR DESCRIPTION
Restores #104874, but without rushing tests this time.

My benchmark makes comparisons between various cases and the performance of the empty string case, which should remove the overhead from logic that hasn't changed.

<details>
<summary>Benchmarking code</summary>

```gdscript
func _ready():
	await get_tree().create_timer(0.5).timeout
	
	var t := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("")
	var empty_t := Time.get_ticks_usec() - t
	
	print_rich("[b]--- Invalid colors ---[/b]")
	
	var t1 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("ab")
	print("2 digits: ", String.num((Time.get_ticks_usec() - empty_t - t1) / 1000.0, 1), "ms")
	
	var t2 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("#ab")
	print("2 digits with #: ", String.num((Time.get_ticks_usec() - empty_t - t2) / 1000.0, 1), "ms")
	
	var t3 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("1234567890")
	print("9 digits: ", String.num((Time.get_ticks_usec() - empty_t - t3) / 1000.0, 1), "ms")
	
	var t4 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("#1234567890")
	print("9 digits with #: ", String.num((Time.get_ticks_usec() - empty_t - t4) / 1000.0, 1), "ms")
	
	var t5 := Time.get_ticks_usec()
	var col := "lmofa".repeat(2000)
	for i in 1000000:
		var a := Color.html_is_valid(col)
	print("10000 digits: ", String.num((Time.get_ticks_usec() - empty_t - t5) / 1000.0, 1), "ms")
	
	var t6 := Time.get_ticks_usec()
	col = "#" + col
	for i in 1000000:
		var a := Color.html_is_valid(col)
	print("10000 digits with #: ", String.num((Time.get_ticks_usec() - empty_t - t6) / 1000.0, 1), "ms")
	
	var t7 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("1o345678")
	print("8 digits with bad 2nd: ", String.num((Time.get_ticks_usec() - empty_t - t7) / 1000.0, 1), "ms")
	
	var t8 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("1234567o")
	print("8 digits with bad 8th: ", String.num((Time.get_ticks_usec() - empty_t - t8) / 1000.0, 1), "ms")
	
	print_rich("[b]--- Valid colors ---[/b]")
	
	var t9 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("0aB")
	print("3 digits: ", String.num((Time.get_ticks_usec() - empty_t - t9) / 1000.0, 1), "ms")
	
	var t10 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("#0aB")
	print("3 digits with #: ", String.num((Time.get_ticks_usec() - empty_t - t10) / 1000.0, 1), "ms")
	
	var t11 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("0aB1")
	print("4 digits: ", String.num((Time.get_ticks_usec() - empty_t - t11) / 1000.0, 1), "ms")
	
	var t12 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("#0aB1")
	print("4 digits with #: ", String.num((Time.get_ticks_usec() - empty_t - t12) / 1000.0, 1), "ms")
	
	var t13 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("0aB1cD")
	print("6 digits: ", String.num((Time.get_ticks_usec() - empty_t - t13) / 1000.0, 1), "ms")
	
	var t14 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("#0aB1cD")
	print("6 digits with #: ", String.num((Time.get_ticks_usec() - empty_t - t14) / 1000.0, 1), "ms")
	
	var t15 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("0aB1cD2e")
	print("8 digits: ", String.num((Time.get_ticks_usec() - empty_t - t15) / 1000.0, 1), "ms")
	
	var t16 := Time.get_ticks_usec()
	for i in 1000000:
		var a := Color.html_is_valid("#0aB1cD2e")
	print("8 digits with #: ", String.num((Time.get_ticks_usec() - empty_t - t16) / 1000.0, 1), "ms")
```
</details>

### Results

These are the results for a million runs on a build that keeps the old method and a modified version of the above benchmark.

**--- Invalid colors ---**
2 digits: 74.1ms --> 74.0ms
2 digits with #: 465.1ms --> 75.0ms
9 digits: 70.1ms --> 70.7ms
9 digits with #: 464.8ms --> 71.7ms
10000 digits: 70.1ms --> 70.3ms
10000 digits with #: 2897.7ms --> 70.5ms
8 digits with bad 2nd: 122.5ms --> 99.9ms
8 digits with bad 8th: 302.3ms --> 100.1ms
**--- Valid colors ---**
3 digits: 155.4ms --> 101.4ms
3 digits with #: 563.3ms --> 102.7ms
4 digits: 183.1ms --> 101.7ms
4 digits with #: 590.2ms --> 101.4ms
6 digits: 247.3ms --> 100.1ms
6 digits with #: 666.9ms --> 99.6ms
8 digits: 308.0ms --> 100.1ms
8 digits with #: 738.7ms --> 128.6ms

As you can see, the speed of checks with hashtag are now identical to checks without it. And if the string has a valid number of digits, the checks that follow are much cheaper as they don't parse the number, but instead only check if it's hexadecimal.