### PR TITLE
[3.x] Physics Interpolation - Fix `CPUParticles` to work with `SceneTreeFTI`

### DIFF
--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -639,7 +639,7 @@ void CPUParticles::_particles_process(float p_delta) {
 	Transform emission_xform;
 	Basis velocity_xform;
 	if (!local_coords) {
-		emission_xform = get_global_transform();
+		emission_xform = get_global_transform_interpolated();
 		velocity_xform = emission_xform.basis;
 	}
 
@@ -1207,6 +1207,9 @@ void CPUParticles::_refresh_interpolation_state() {
 		return;
 	}
 	bool interpolated = is_physics_interpolated_and_enabled();
+
+	// New SceneTreeFTI force CPUParticles to always update on the frame.
+	interpolated = false;
 
 	if (_interpolated == interpolated) {
 		return;


### PR DESCRIPTION
Fixes behaviour of `CPUParticles` to behave similarly to `Particles` when using physics interpolation.

## Notes
* #103685 while being generally amazing had the unfortunate side effect of breaking `CPUParticles` somewhat
* `CPUParticles` contained a lot of specific code to workaround problems caused by the previous server side physics interpolation, these no longer should work in the same way
* On balance `CPUParticles` is better off using a paradigm of per frame processing, while following an interpolated target (as in #80931 which does this for 2D). The results are far superior.
* This PR hardcodes it to use per frame processing when physics interpolation is on, while following the interpolated target for emission using `get_global_transform_interpolated()` (which is far more effective now that FTI is done client side)

## Discussion
In the interests of brevity, this PR currently only changes 2 lines to get the behaviour required. There is therefore quite a lot of unused code now in `CPUParticles`, but that might make more sense to remove in a follow up, as it makes this PR easier to review. (Related, the equivalent change in 4.x has less to remove, because `CPUParticles` physics interpolation has not yet been forward ported).

`CPUParticles` now works perfectly in global and local mode (with physics interpolation on for the branch, with `physics_interpolation_mode` set to OFF and an interpolated parent it judders as expected, but users shouldn't normally be using this).
`GPUParticles` works perfectly in global and local mode (in both `physics_interpolation_mode` settings for the branch.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
