### PR TITLE
Clarify that `Window.dpi_changed` signal is supported on Linux (Wayland)

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -2214,7 +2214,7 @@
 		</constant>
 		<constant name="WINDOW_EVENT_DPI_CHANGE" value="6" enum="WindowEvent">
 			Sent when the window is moved to the display with different DPI, or display DPI is changed.
-			[b]Note:[/b] This flag is implemented only on macOS.
+			[b]Note:[/b] This flag is implemented only on macOS and Linux (Wayland).
 		</constant>
 		<constant name="WINDOW_EVENT_TITLEBAR_CHANGE" value="7" enum="WindowEvent">
 			Sent when the window title bar decoration is changed (e.g. [constant WINDOW_FLAG_EXTEND_TO_TITLE] is set or window entered/exited full screen mode).

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -734,7 +734,7 @@
 		<signal name="dpi_changed">
 			<description>
 				Emitted when the [Window]'s DPI changes as a result of OS-level changes (e.g. moving the window from a Retina display to a lower resolution one).
-				[b]Note:[/b] Only implemented on macOS.
+				[b]Note:[/b] Only implemented on macOS and Linux (Wayland).
 			</description>
 		</signal>
 		<signal name="files_dropped">


### PR DESCRIPTION
See https://github.com/godotengine/godot/blob/4.4/platform/linuxbsd/wayland/wayland_thread.cpp#L3093