### PR TITLE
JSONRPC: Require manual method registration

### DIFF
--- a/doc/classes/JSONRPC.xml
+++ b/doc/classes/JSONRPC.xml
@@ -69,11 +69,14 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_scope">
+		<method name="set_method">
 			<return type="void" />
-			<param index="0" name="scope" type="String" />
-			<param index="1" name="target" type="Object" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="callback" type="Callable" />
 			<description>
+				Registers a callback for the given method name.
+				- [param name] The name that clients can use to access the callback.
+				- [param callback] The callback which will handle the specific method.
 			</description>
 		</method>
 	</methods>

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -24,3 +24,10 @@ Validate extension JSON: Error: Field 'classes/OpenXRAPIExtension/methods/regist
 Validate extension JSON: Error: Field 'classes/OpenXRAPIExtension/methods/unregister_projection_views_extension/arguments/0': type changed value in new API, from "OpenXRExtensionWrapperExtension" to "OpenXRExtensionWrapper".
 
 Switched from `OpenXRExtensionWrapperExtension` to parent `OpenXRExtensionWrapper`. Compatibility methods registered.
+
+
+GH-104890
+---------
+Validate extension JSON: API was removed: classes/JSONRPC/methods/set_scope
+
+Replaced `set_scope` with `set_method`. Compatibility method registered for binary compatibility. Manual upgrade required by users to retain functionality.

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -334,13 +334,50 @@ bool GDScriptLanguageProtocol::is_goto_native_symbols_enabled() const {
 	return bool(_EDITOR_GET("network/language_server/show_native_symbols_in_editor"));
 }
 
+// clang-format off
+#define SET_DOCUMENT_METHOD(m_method) set_method(_STR(textDocument/m_method), callable_mp(text_document.ptr(), &GDScriptTextDocument::m_method))
+#define SET_COMPLETION_METHOD(m_method) set_method(_STR(completionItem/m_method), callable_mp(text_document.ptr(), &GDScriptTextDocument::m_method))
+#define SET_WORKSPACE_METHOD(m_method) set_method(_STR(workspace/m_method), callable_mp(workspace.ptr(), &GDScriptWorkspace::m_method))
+// clang-format on
+
 GDScriptLanguageProtocol::GDScriptLanguageProtocol() {
 	server.instantiate();
 	singleton = this;
 	workspace.instantiate();
 	text_document.instantiate();
-	set_scope("textDocument", text_document.ptr());
-	set_scope("completionItem", text_document.ptr());
-	set_scope("workspace", workspace.ptr());
+
+	SET_DOCUMENT_METHOD(didOpen);
+	SET_DOCUMENT_METHOD(didClose);
+	SET_DOCUMENT_METHOD(didChange);
+	SET_DOCUMENT_METHOD(willSaveWaitUntil);
+	SET_DOCUMENT_METHOD(didSave);
+
+	SET_DOCUMENT_METHOD(documentSymbol);
+	SET_DOCUMENT_METHOD(completion);
+	SET_DOCUMENT_METHOD(rename);
+	SET_DOCUMENT_METHOD(prepareRename);
+	SET_DOCUMENT_METHOD(references);
+	SET_DOCUMENT_METHOD(foldingRange);
+	SET_DOCUMENT_METHOD(codeLens);
+	SET_DOCUMENT_METHOD(documentLink);
+	SET_DOCUMENT_METHOD(colorPresentation);
+	SET_DOCUMENT_METHOD(hover);
+	SET_DOCUMENT_METHOD(definition);
+	SET_DOCUMENT_METHOD(declaration);
+	SET_DOCUMENT_METHOD(signatureHelp);
+
+	SET_DOCUMENT_METHOD(nativeSymbol); // Custom method.
+
+	SET_COMPLETION_METHOD(resolve);
+
+	SET_WORKSPACE_METHOD(didDeleteFiles);
+
+	set_method("initialize", callable_mp(this, &GDScriptLanguageProtocol::initialize));
+	set_method("initialized", callable_mp(this, &GDScriptLanguageProtocol::initialized));
+
 	workspace->root = ProjectSettings::get_singleton()->get_resource_path();
 }
+
+#undef SET_DOCUMENT_METHOD
+#undef SET_COMPLETION_METHOD
+#undef SET_WORKSPACE_METHOD

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -44,6 +44,14 @@ protected:
 
 	Ref<FileAccess> file_checker;
 
+	Array native_member_completions;
+
+private:
+	Array find_symbols(const LSP::TextDocumentPositionParams &p_location, List<const LSP::DocumentSymbol *> &r_list);
+	LSP::TextDocumentItem load_document_item(const Variant &p_param);
+	void notify_client_show_symbol(const LSP::DocumentSymbol *symbol);
+
+public:
 	void didOpen(const Variant &p_param);
 	void didClose(const Variant &p_param);
 	void didChange(const Variant &p_param);
@@ -54,14 +62,6 @@ protected:
 	void sync_script_content(const String &p_path, const String &p_content);
 	void show_native_symbol_in_editor(const String &p_symbol_id);
 
-	Array native_member_completions;
-
-private:
-	Array find_symbols(const LSP::TextDocumentPositionParams &p_location, List<const LSP::DocumentSymbol *> &r_list);
-	LSP::TextDocumentItem load_document_item(const Variant &p_param);
-	void notify_client_show_symbol(const LSP::DocumentSymbol *symbol);
-
-public:
 	Variant nativeSymbol(const Dictionary &p_params);
 	Array documentSymbol(const Dictionary &p_params);
 	Array completion(const Dictionary &p_params);

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -45,7 +45,7 @@
 
 void GDScriptWorkspace::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("apply_new_signal"), &GDScriptWorkspace::apply_new_signal);
-	ClassDB::bind_method(D_METHOD("didDeleteFiles"), &GDScriptWorkspace::did_delete_files);
+	ClassDB::bind_method(D_METHOD("didDeleteFiles"), &GDScriptWorkspace::didDeleteFiles);
 	ClassDB::bind_method(D_METHOD("parse_script", "path", "content"), &GDScriptWorkspace::parse_script);
 	ClassDB::bind_method(D_METHOD("parse_local_script", "path"), &GDScriptWorkspace::parse_local_script);
 	ClassDB::bind_method(D_METHOD("get_file_path", "uri"), &GDScriptWorkspace::get_file_path);
@@ -106,7 +106,7 @@ void GDScriptWorkspace::apply_new_signal(Object *obj, String function, PackedStr
 	GDScriptLanguageProtocol::get_singleton()->request_client("workspace/applyEdit", params.to_json());
 }
 
-void GDScriptWorkspace::did_delete_files(const Dictionary &p_params) {
+void GDScriptWorkspace::didDeleteFiles(const Dictionary &p_params) {
 	Array files = p_params["files"];
 	for (int i = 0; i < files.size(); ++i) {
 		Dictionary file = files[i];

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -90,7 +90,7 @@ public:
 	void resolve_document_links(const String &p_uri, List<LSP::DocumentLink> &r_list);
 	Dictionary generate_script_api(const String &p_path);
 	Error resolve_signature(const LSP::TextDocumentPositionParams &p_doc_pos, LSP::SignatureHelp &r_signature);
-	void did_delete_files(const Dictionary &p_params);
+	void didDeleteFiles(const Dictionary &p_params);
 	Dictionary rename(const LSP::TextDocumentPositionParams &p_doc_pos, const String &new_name);
 	bool can_rename(const LSP::TextDocumentPositionParams &p_doc_pos, LSP::DocumentSymbol &r_symbol, LSP::Range &r_range);
 	Vector<LSP::Location> find_usages_in_file(const LSP::DocumentSymbol &p_symbol, const String &p_file_path);

--- a/modules/jsonrpc/jsonrpc.compat.inc
+++ b/modules/jsonrpc/jsonrpc.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  jsonrpc.h                                                             */
+/*  jsonrpc.compat.inc                                                    */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,45 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
-
-#include "core/object/class_db.h"
-#include "core/variant/variant.h"
-
-class JSONRPC : public Object {
-	GDCLASS(JSONRPC, Object)
-
-	HashMap<String, Callable> methods;
-
-protected:
-	static void _bind_methods();
-
 #ifndef DISABLE_DEPRECATED
-	void _set_scope_bind_compat_104890(const String &p_scope, Object *p_obj);
-	static void _bind_compatibility_methods();
+
+void JSONRPC::_set_scope_bind_compat_104890(const String &p_scope, Object *p_obj) {
+	ERR_PRINT("JSONRPC::set_scope is not supported anymore. Upgrade to JSONRPC::set_method.");
+}
+
+void JSONRPC::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_scope", "scope", "target"), &JSONRPC::_set_scope_bind_compat_104890);
+}
+
 #endif
-
-public:
-	JSONRPC();
-	~JSONRPC();
-
-	enum ErrorCode {
-		PARSE_ERROR = -32700,
-		INVALID_REQUEST = -32600,
-		METHOD_NOT_FOUND = -32601,
-		INVALID_PARAMS = -32602,
-		INTERNAL_ERROR = -32603,
-	};
-
-	Dictionary make_response_error(int p_code, const String &p_message, const Variant &p_id = Variant()) const;
-	Dictionary make_response(const Variant &p_value, const Variant &p_id);
-	Dictionary make_notification(const String &p_method, const Variant &p_params);
-	Dictionary make_request(const String &p_method, const Variant &p_params, const Variant &p_id);
-
-	Variant process_action(const Variant &p_action, bool p_process_arr_elements = false);
-	String process_string(const String &p_input);
-
-	void set_method(const String &p_name, const Callable &p_callback);
-};
-
-VARIANT_ENUM_CAST(JSONRPC::ErrorCode);

--- a/modules/jsonrpc/tests/test_jsonrpc.cpp
+++ b/modules/jsonrpc/tests/test_jsonrpc.cpp
@@ -57,10 +57,6 @@ String TestClassJSONRPC::something(const String &p_in) {
 	return p_in + ", please";
 }
 
-void TestClassJSONRPC::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("something", "in"), &TestClassJSONRPC::something);
-}
-
 void test_process_action(const Variant &p_in, const Variant &p_expected, bool p_process_array_elements) {
 	TestClassJSONRPC json_rpc = TestClassJSONRPC();
 	const Variant &observed = json_rpc.process_action(p_in, p_process_array_elements);

--- a/modules/jsonrpc/tests/test_jsonrpc.h
+++ b/modules/jsonrpc/tests/test_jsonrpc.h
@@ -60,20 +60,17 @@ TEST_CASE("[JSONRPC] process_string invalid") {
 }
 
 class TestClassJSONRPC : public JSONRPC {
-	GDCLASS(TestClassJSONRPC, JSONRPC)
-
 public:
-	String something(const String &p_in);
+	TestClassJSONRPC() {
+		set_method("something", callable_mp(this, &TestClassJSONRPC::something));
+	}
 
-protected:
-	static void _bind_methods();
+	String something(const String &p_in);
 };
 
 void test_process_action(const Variant &p_in, const Variant &p_expected, bool p_process_array_elements = false);
 
 TEST_CASE("[JSONRPC] process_action Dictionary") {
-	ClassDB::register_class<TestClassJSONRPC>();
-
 	Dictionary in_dict = Dictionary();
 	in_dict["method"] = "something";
 	in_dict["id"] = "ID";


### PR DESCRIPTION
Removes the scope system from JSONRPC to separate better between LSP and JSONRPC. Instead methods are directly registered with the new `set_method`, which allows to use certain methods that were not supported previously due to not being valid identifiers.
