### PR TITLE
SCons: Add `CPPEXTPATH` for external includes (reverted)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -15,6 +15,7 @@ from types import ModuleType
 
 from SCons import __version__ as scons_raw_version
 from SCons.Builder import ListEmitter
+from SCons.Util import CLVar
 
 # Explicitly resolve the helper modules, this is done to avoid clash with
 # modules of the same name that might be randomly added (e.g. someone adding
@@ -443,9 +444,18 @@ for tool in custom_tools:
     env.Tool(tool)
 
 
-# add default include paths
-
+# Add default include paths.
 env.Prepend(CPPPATH=["#"])
+
+# Allow marking includes as external/system to avoid raising warnings.
+env["_CCCOMCOM"] += " $_CPPEXTINCFLAGS"
+env["CPPEXTPATH"] = CLVar("")
+if env.scons_version < (4, 2):
+    env["_CPPEXTINCFLAGS"] = "${_concat(EXTINCPREFIX, CPPEXTPATH, EXTINCSUFFIX, __env__, RDirs, TARGET, SOURCE)}"
+else:
+    env["_CPPEXTINCFLAGS"] = (
+        "${_concat(EXTINCPREFIX, CPPEXTPATH, EXTINCSUFFIX, __env__, RDirs, TARGET, SOURCE, affect_signature=False)}"
+    )
 
 # configure ENV for platform
 env.platform_exporters = platform_exporters
@@ -909,6 +919,17 @@ else:  # GCC, Clang
 
     if env["werror"]:
         env.Append(CCFLAGS=["-Werror"])
+
+# Configure external includes.
+if env.msvc:
+    if cc_version_major < 16 or (cc_version_major == 16 and cc_version_minor < 10):
+        env.AppendUnique(CCFLAGS=["/experimental:external"])
+    env.AppendUnique(CCFLAGS=["/external:W0"])
+    env["EXTINCPREFIX"] = "/external:I"
+    env["EXTINCSUFFIX"] = ""
+else:
+    env["EXTINCPREFIX"] = "-isystem "
+    env["EXTINCSUFFIX"] = ""
 
 if hasattr(detect, "get_program_suffix"):
     suffix = "." + detect.get_program_suffix()

--- a/core/SCsub
+++ b/core/SCsub
@@ -51,8 +51,8 @@ if env["brotli"] and env["builtin_brotli"]:
     ]
     thirdparty_brotli_sources = [thirdparty_brotli_dir + file for file in thirdparty_brotli_sources]
 
-    env_thirdparty.Prepend(CPPPATH=[thirdparty_brotli_dir + "include"])
-    env.Prepend(CPPPATH=[thirdparty_brotli_dir + "include"])
+    env_thirdparty.Prepend(CPPEXTPATH=[thirdparty_brotli_dir + "include"])
+    env.Prepend(CPPEXTPATH=[thirdparty_brotli_dir + "include"])
 
     if env.get("use_ubsan") or env.get("use_asan") or env.get("use_tsan") or env.get("use_lsan") or env.get("use_msan"):
         env_thirdparty.Append(CPPDEFINES=["BROTLI_BUILD_PORTABLE"])
@@ -69,8 +69,8 @@ if env["builtin_clipper2"]:
     ]
     thirdparty_clipper_sources = [thirdparty_clipper_dir + file for file in thirdparty_clipper_sources]
 
-    env_thirdparty.Prepend(CPPPATH=[thirdparty_clipper_dir + "include"])
-    env.Prepend(CPPPATH=[thirdparty_clipper_dir + "include"])
+    env_thirdparty.Prepend(CPPEXTPATH=[thirdparty_clipper_dir + "include"])
+    env.Prepend(CPPEXTPATH=[thirdparty_clipper_dir + "include"])
 
     env_thirdparty.Append(CPPDEFINES=["CLIPPER2_ENABLED"])
     env.Append(CPPDEFINES=["CLIPPER2_ENABLED"])
@@ -94,9 +94,9 @@ if env["builtin_zlib"]:
     ]
     thirdparty_zlib_sources = [thirdparty_zlib_dir + file for file in thirdparty_zlib_sources]
 
-    env_thirdparty.Prepend(CPPPATH=[thirdparty_zlib_dir])
+    env_thirdparty.Prepend(CPPEXTPATH=[thirdparty_zlib_dir])
     # Needs to be available in main env too
-    env.Prepend(CPPPATH=[thirdparty_zlib_dir])
+    env.Prepend(CPPEXTPATH=[thirdparty_zlib_dir])
     if env.dev_build:
         env_thirdparty.Append(CPPDEFINES=["ZLIB_DEBUG"])
         # Affects headers so it should also be defined for Godot code
@@ -148,9 +148,9 @@ if env["builtin_zstd"]:
         thirdparty_zstd_sources.append("decompress/huf_decompress_amd64.S")
     thirdparty_zstd_sources = [thirdparty_zstd_dir + file for file in thirdparty_zstd_sources]
 
-    env_thirdparty.Prepend(CPPPATH=[thirdparty_zstd_dir, thirdparty_zstd_dir + "common"])
+    env_thirdparty.Prepend(CPPEXTPATH=[thirdparty_zstd_dir, thirdparty_zstd_dir + "common"])
     env_thirdparty.Append(CPPDEFINES=["ZSTD_STATIC_LINKING_ONLY"])
-    env.Prepend(CPPPATH=thirdparty_zstd_dir)
+    env.Prepend(CPPEXTPATH=thirdparty_zstd_dir)
     # Also needed in main env includes will trigger warnings
     env.Append(CPPDEFINES=["ZSTD_STATIC_LINKING_ONLY"])
 

--- a/core/crypto/SCsub
+++ b/core/crypto/SCsub
@@ -13,7 +13,7 @@ if is_builtin or not has_module:
     # Use our headers for builtin or if the module is not going to be compiled.
     # We decided not to depend on system mbedtls just for these few files that can
     # be easily extracted.
-    env_crypto.Prepend(CPPPATH=["#thirdparty/mbedtls/include"])
+    env_crypto.Prepend(CPPEXTPATH=["#thirdparty/mbedtls/include"])
 
 # MbedTLS core functions (for CryptoCore).
 # If the mbedtls module is compiled we don't need to add the .c files with our

--- a/drivers/backtrace/SCsub
+++ b/drivers/backtrace/SCsub
@@ -26,7 +26,7 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_backtrace.Prepend(CPPPATH=[thirdparty_dir])
+env_backtrace.Prepend(CPPEXTPATH=[thirdparty_dir])
 
 env_thirdparty = env_backtrace.Clone()
 env_thirdparty.disable_warnings()

--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -15,15 +15,15 @@ thirdparty_obj = []
 
 # DirectX Headers (must take precedence over Windows SDK's).
 
-env.Prepend(CPPPATH=["#thirdparty/directx_headers/include/directx"])
-env_d3d12_rdd.Prepend(CPPPATH=["#thirdparty/directx_headers/include/directx"])
-env_d3d12_rdd.Prepend(CPPPATH=["#thirdparty/directx_headers/include/dxguids"])
+env.Prepend(CPPEXTPATH=["#thirdparty/directx_headers/include/directx"])
+env_d3d12_rdd.Prepend(CPPEXTPATH=["#thirdparty/directx_headers/include/directx"])
+env_d3d12_rdd.Prepend(CPPEXTPATH=["#thirdparty/directx_headers/include/dxguids"])
 
 
 # Direct3D 12 Memory Allocator.
 
-env.Append(CPPPATH=["#thirdparty/d3d12ma"])
-env_d3d12_rdd.Append(CPPPATH=["#thirdparty/d3d12ma"])
+env.Append(CPPEXTPATH=["#thirdparty/d3d12ma"])
+env_d3d12_rdd.Append(CPPEXTPATH=["#thirdparty/d3d12ma"])
 
 
 # Agility SDK.
@@ -38,7 +38,7 @@ if env["agility_sdk_path"] != "" and os.path.exists(env["agility_sdk_path"]):
 
 if env["use_pix"]:
     env_d3d12_rdd.Append(CPPDEFINES=["PIX_ENABLED"])
-    env_d3d12_rdd.Append(CPPPATH=[env["pix_path"] + "/Include"])
+    env_d3d12_rdd.Append(CPPEXTPATH=[env["pix_path"] + "/Include"])
 
 
 # Mesa (SPIR-V to DXIL functionality).
@@ -147,7 +147,7 @@ else:
         env.Append(CCFLAGS=["-Wno-unknown-pragmas"])
 
 # This is needed since rendering_device_d3d12.cpp needs to include some Mesa internals.
-env_d3d12_rdd.Prepend(CPPPATH=mesa_private_inc_paths)
+env_d3d12_rdd.Prepend(CPPEXTPATH=mesa_private_inc_paths)
 # For the same reason as above, the defines must be the same as in the 3rd-party code itself.
 env_d3d12_rdd.Append(CPPDEFINES=extra_defines)
 

--- a/drivers/d3d12/d3d12ma.cpp
+++ b/drivers/d3d12/d3d12ma.cpp
@@ -30,35 +30,4 @@
 
 #include "rendering_context_driver_d3d12.h"
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wswitch"
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#pragma GCC diagnostic ignored "-Wduplicated-branches"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wsign-compare"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#pragma GCC diagnostic ignored "-Wunused-function"
-#pragma GCC diagnostic ignored "-Wnonnull-compare"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#pragma clang diagnostic ignored "-Wstring-plus-int"
-#pragma clang diagnostic ignored "-Wswitch"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#pragma clang diagnostic ignored "-Wtautological-undefined-compare"
-#pragma clang diagnostic ignored "-Wunused-variable"
-#pragma clang diagnostic ignored "-Wunused-but-set-variable"
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-
-#if defined(_MSC_VER)
-#pragma warning(disable : 4189 4505)
-#endif
-
-#include "thirdparty/d3d12ma/D3D12MemAlloc.cpp"
+#include <D3D12MemAlloc.cpp>

--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -37,27 +37,7 @@
 #include "core/version.h"
 #include "servers/rendering/rendering_device.h"
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wswitch"
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#pragma clang diagnostic ignored "-Wstring-plus-int"
-#pragma clang diagnostic ignored "-Wswitch"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#endif
-
-#include "dxcapi.h"
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+#include <dxcapi.h>
 
 #if !defined(_MSC_VER)
 #include <guiddef.h>

--- a/drivers/d3d12/rendering_context_driver_d3d12.h
+++ b/drivers/d3d12/rendering_context_driver_d3d12.h
@@ -37,22 +37,6 @@
 #include "servers/display_server.h"
 #include "servers/rendering/rendering_context_driver.h"
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wswitch"
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#pragma clang diagnostic ignored "-Wstring-plus-int"
-#pragma clang diagnostic ignored "-Wswitch"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-
 #if defined(AS)
 #undef AS
 #endif
@@ -71,16 +55,10 @@
 #include <dcomp.h>
 #endif
 
-#include "d3dx12.h"
+#include <d3dx12.h>
 #include <dxgi1_6.h>
 
 #include <wrl/client.h>
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(__clang__)
-#pragma clang diagnostic pop
-#endif
 
 using Microsoft::WRL::ComPtr;
 

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -39,43 +39,12 @@
 #include "dxil_hash.h"
 #include "rendering_context_driver_d3d12.h"
 
-// No point in fighting warnings in Mesa.
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4200) // "nonstandard extension used: zero-sized array in struct/union".
-#pragma warning(disable : 4806) // "'&': unsafe operation: no value of type 'bool' promoted to type 'uint32_t' can equal the given constant".
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wswitch"
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#pragma clang diagnostic ignored "-Wstring-plus-int"
-#pragma clang diagnostic ignored "-Wswitch"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#endif
-
-#include "nir_spirv.h"
-#include "nir_to_dxil.h"
-#include "spirv_to_dxil.h"
+#include <nir_spirv.h>
+#include <nir_to_dxil.h>
+#include <spirv_to_dxil.h>
 extern "C" {
-#include "dxil_spirv_nir.h"
+#include <dxil_spirv_nir.h>
 }
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(__clang__)
-#pragma clang diagnostic pop
-#endif
-
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 
 #if !defined(_MSC_VER)
 #include <guiddef.h>

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -40,38 +40,16 @@
 #define __REQUIRED_RPCNDR_H_VERSION__ 475
 #endif
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wswitch"
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#pragma clang diagnostic ignored "-Wstring-plus-int"
-#pragma clang diagnostic ignored "-Wswitch"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-
-#include "d3dx12.h"
+#include <d3dx12.h>
 #include <dxgi1_6.h>
 #define D3D12MA_D3D12_HEADERS_ALREADY_INCLUDED
-#include "D3D12MemAlloc.h"
+#include <D3D12MemAlloc.h>
 
 #include <wrl/client.h>
 
 #if defined(_MSC_VER) && defined(MemoryBarrier)
 // Annoying define from winnt.h. Reintroduced by some of the headers above.
 #undef MemoryBarrier
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(__clang__)
-#pragma clang diagnostic pop
 #endif
 
 using Microsoft::WRL::ComPtr;

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -13,12 +13,7 @@ if env["platform"] in ["macos", "windows", "linuxbsd"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    # Treat glad headers as system headers to avoid raising warnings. Not supported on MSVC.
-    if not env.msvc:
-        env.Append(CPPFLAGS=["-isystem", Dir(thirdparty_dir).path])
-    else:
-        env.Prepend(CPPPATH=[thirdparty_dir])
-
+    env.Prepend(CPPEXTPATH=[thirdparty_dir])
     env.Append(CPPDEFINES=["GLAD_ENABLED"])
     env.Append(CPPDEFINES=["EGL_ENABLED"])
 

--- a/drivers/metal/SCsub
+++ b/drivers/metal/SCsub
@@ -22,7 +22,7 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_metal.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "/include"])
+env_metal.Prepend(CPPEXTPATH=[thirdparty_dir, thirdparty_dir + "/include"])
 
 # Must enable exceptions for SPIRV-Cross; otherwise, it will abort the process on errors.
 if "-fno-exceptions" in env_metal["CXXFLAGS"]:

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -30,9 +30,9 @@ if env["builtin_libpng"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_png.Prepend(CPPPATH=[thirdparty_dir])
+    env_png.Prepend(CPPEXTPATH=[thirdparty_dir])
     # Needed for drivers includes and in platform/web.
-    env.Prepend(CPPPATH=[thirdparty_dir])
+    env.Prepend(CPPEXTPATH=[thirdparty_dir])
 
     env_thirdparty = env_png.Clone()
     env_thirdparty.disable_warnings()

--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -8,11 +8,11 @@ thirdparty_dir = "#thirdparty/vulkan"
 thirdparty_volk_dir = "#thirdparty/volk"
 
 # Use bundled Vulkan headers
-env.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "/include"])
+env.Prepend(CPPEXTPATH=[thirdparty_dir, thirdparty_dir + "/include"])
 
 if env["use_volk"]:
     env.AppendUnique(CPPDEFINES=["USE_VOLK"])
-    env.Prepend(CPPPATH=[thirdparty_volk_dir])
+    env.Prepend(CPPEXTPATH=[thirdparty_volk_dir])
 
 if env["platform"] == "android":
     env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_ANDROID_KHR"])

--- a/modules/astcenc/SCsub
+++ b/modules/astcenc/SCsub
@@ -37,7 +37,7 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_astcenc.Prepend(CPPPATH=[thirdparty_dir])
+env_astcenc.Prepend(CPPEXTPATH=[thirdparty_dir])
 
 env_thirdparty = env_astcenc.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/basis_universal/SCsub
+++ b/modules/basis_universal/SCsub
@@ -42,18 +42,14 @@ if basisu_encoder:
 
 transcoder_sources = [thirdparty_dir + "transcoder/basisu_transcoder.cpp"]
 
-# Treat Basis headers as system headers to avoid raising warnings. Not supported on MSVC.
-if not env.msvc:
-    env_basisu.Append(CPPFLAGS=["-isystem", Dir(thirdparty_dir).path])
-else:
-    env_basisu.Prepend(CPPPATH=[thirdparty_dir])
+env_basisu.Prepend(CPPEXTPATH=[thirdparty_dir])
 
 if basisu_encoder:
-    env_basisu.Prepend(CPPPATH=["#thirdparty/jpeg-compressor"])
-    env_basisu.Prepend(CPPPATH=["#thirdparty/tinyexr"])
+    env_basisu.Prepend(CPPEXTPATH=["#thirdparty/jpeg-compressor"])
+    env_basisu.Prepend(CPPEXTPATH=["#thirdparty/tinyexr"])
 
 if env["builtin_zstd"]:
-    env_basisu.Prepend(CPPPATH=["#thirdparty/zstd"])
+    env_basisu.Prepend(CPPEXTPATH=["#thirdparty/zstd"])
 
 env_thirdparty = env_basisu.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/csg/SCsub
+++ b/modules/csg/SCsub
@@ -31,7 +31,7 @@ thirdparty_sources = [
 ]
 
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
-env_csg.Prepend(CPPPATH=[thirdparty_dir + "include"])
+env_csg.Prepend(CPPEXTPATH=[thirdparty_dir + "include"])
 env_thirdparty = env_csg.Clone()
 env_thirdparty.disable_warnings()
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)

--- a/modules/cvtt/SCsub
+++ b/modules/cvtt/SCsub
@@ -26,7 +26,7 @@ thirdparty_sources = [
 
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_cvtt.Prepend(CPPPATH=[thirdparty_dir])
+env_cvtt.Prepend(CPPEXTPATH=[thirdparty_dir])
 
 env_thirdparty = env_cvtt.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -24,7 +24,7 @@ if env["builtin_enet"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_enet.Prepend(CPPPATH=[thirdparty_dir])
+    env_enet.Prepend(CPPEXTPATH=[thirdparty_dir])
     env_enet.Append(CPPDEFINES=["GODOT_ENET"])
 
     env_thirdparty = env_enet.Clone()

--- a/modules/etcpak/SCsub
+++ b/modules/etcpak/SCsub
@@ -20,7 +20,7 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_etcpak.Prepend(CPPPATH=[thirdparty_dir])
+env_etcpak.Prepend(CPPEXTPATH=[thirdparty_dir])
 
 env_thirdparty = env_etcpak.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/fbx/SCsub
+++ b/modules/fbx/SCsub
@@ -13,7 +13,7 @@ thirdparty_obj = []
 thirdparty_dir = "#thirdparty/ufbx/"
 thirdparty_sources = [thirdparty_dir + "ufbx.c"]
 
-env_fbx.Prepend(CPPPATH=[thirdparty_dir])
+env_fbx.Prepend(CPPEXTPATH=[thirdparty_dir])
 
 env_thirdparty = env_fbx.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -62,15 +62,15 @@ if env["builtin_freetype"]:
     if env["brotli"]:
         env_freetype.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
 
-    env_freetype.Prepend(CPPPATH=[thirdparty_dir + "/include"])
+    env_freetype.Prepend(CPPEXTPATH=[thirdparty_dir + "/include"])
     # Also needed in main env for scene/
-    env.Prepend(CPPPATH=[thirdparty_dir + "/include"])
+    env.Prepend(CPPEXTPATH=[thirdparty_dir + "/include"])
 
     env_freetype.Append(CPPDEFINES=["FT2_BUILD_LIBRARY", "FT_CONFIG_OPTION_USE_PNG", "FT_CONFIG_OPTION_SYSTEM_ZLIB"])
 
     # Also requires libpng headers
     if env["builtin_libpng"]:
-        env_freetype.Prepend(CPPPATH=["#thirdparty/libpng"])
+        env_freetype.Prepend(CPPEXTPATH=["#thirdparty/libpng"])
 
     sfnt = thirdparty_dir + "src/sfnt/sfnt.c"
     # Must be done after all CPPDEFINES are being set so we can copy them.

--- a/modules/glslang/SCsub
+++ b/modules/glslang/SCsub
@@ -62,13 +62,9 @@ if env["builtin_glslang"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    # Treat glslang headers as system headers to avoid raising warnings. Not supported on MSVC.
     # Include `#thirdparty` to workaround mismatch between location of `SPIRV` in library source
     # and in installed public headers.
-    if not env.msvc:
-        env_glslang.Append(CPPFLAGS=["-isystem", Dir(thirdparty_dir).path, "-isystem", Dir("#thirdparty").path])
-    else:
-        env_glslang.Prepend(CPPPATH=[thirdparty_dir, "#thirdparty"])
+    env_glslang.Prepend(CPPEXTPATH=[thirdparty_dir, "#thirdparty"])
 
     env_glslang.Append(CPPDEFINES=["ENABLE_OPT=0"])
 

--- a/modules/jolt_physics/SCsub
+++ b/modules/jolt_physics/SCsub
@@ -144,7 +144,7 @@ thirdparty_sources = [
 
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_jolt.Prepend(CPPPATH=[thirdparty_dir])
+env_jolt.Prepend(CPPEXTPATH=[thirdparty_dir])
 
 if env.dev_build:
     env_jolt.Append(CPPDEFINES=["JPH_ENABLE_ASSERTS"])

--- a/modules/jpg/SCsub
+++ b/modules/jpg/SCsub
@@ -18,7 +18,7 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_jpg.Prepend(CPPPATH=[thirdparty_dir])
+env_jpg.Prepend(CPPEXTPATH=[thirdparty_dir])
 
 env_thirdparty = env_jpg.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/ktx/SCsub
+++ b/modules/ktx/SCsub
@@ -33,18 +33,18 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_ktx.Prepend(CPPPATH=[thirdparty_dir + "include"])
-env_ktx.Prepend(CPPPATH=[thirdparty_dir + "utils"])
-env_ktx.Prepend(CPPPATH=[thirdparty_dir + "lib"])
-env_ktx.Prepend(CPPPATH=[thirdparty_dir + "other_include"])
+env_ktx.Prepend(CPPEXTPATH=[thirdparty_dir + "include"])
+env_ktx.Prepend(CPPEXTPATH=[thirdparty_dir + "utils"])
+env_ktx.Prepend(CPPEXTPATH=[thirdparty_dir + "lib"])
+env_ktx.Prepend(CPPEXTPATH=[thirdparty_dir + "other_include"])
 
-env_ktx.Prepend(CPPPATH=["#thirdparty/basis_universal"])
+env_ktx.Prepend(CPPEXTPATH=["#thirdparty/basis_universal"])
 if env.editor_build:
     # We already build miniz in the basis_universal module (editor only).
     env_ktx.Append(CPPDEFINES=["MINIZ_HEADER_FILE_ONLY"])
 
 if env["vulkan"]:
-    env_ktx.Prepend(CPPPATH=["#thirdparty/vulkan/include"])
+    env_ktx.Prepend(CPPEXTPATH=["#thirdparty/vulkan/include"])
 else:
     # Falls back on bundled `vkformat_enum.h`.
     env_ktx.Append(CPPDEFINES=["LIBKTX"])

--- a/modules/mbedtls/SCsub
+++ b/modules/mbedtls/SCsub
@@ -120,7 +120,7 @@ if env["builtin_mbedtls"]:
     thirdparty_dir = "#thirdparty/mbedtls/library/"
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_mbed_tls.Prepend(CPPPATH=["#thirdparty/mbedtls/include/"])
+    env_mbed_tls.Prepend(CPPEXTPATH=["#thirdparty/mbedtls/include/"])
     config_path = "thirdparty/mbedtls/include/godot_module_mbedtls_config.h"
     config_path = f"<{config_path}>" if env_mbed_tls["ninja"] and env_mbed_tls.msvc else f'\\"{config_path}\\"'
     env_mbed_tls.Append(CPPDEFINES=[("MBEDTLS_CONFIG_FILE", config_path)])

--- a/modules/minimp3/SCsub
+++ b/modules/minimp3/SCsub
@@ -8,11 +8,7 @@ env_minimp3 = env_modules.Clone()
 
 thirdparty_dir = "#thirdparty/minimp3/"
 
-# Treat minimp3 headers as system headers to avoid raising warnings. Not supported on MSVC.
-if not env.msvc:
-    env_minimp3.Append(CPPFLAGS=["-isystem", Dir(thirdparty_dir).path])
-else:
-    env_minimp3.Prepend(CPPPATH=[thirdparty_dir])
+env_minimp3.Prepend(CPPEXTPATH=[thirdparty_dir])
 
 if not env["minimp3_extra_formats"]:
     env_minimp3.Append(CPPDEFINES=["MINIMP3_ONLY_MP3"])

--- a/modules/msdfgen/SCsub
+++ b/modules/msdfgen/SCsub
@@ -42,7 +42,7 @@ if env["builtin_msdfgen"]:
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
     env_msdfgen.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
-    env_msdfgen.Prepend(CPPPATH=["#thirdparty/freetype/include", "#thirdparty/msdfgen", "#thirdparty/nanosvg"])
+    env_msdfgen.Prepend(CPPEXTPATH=["#thirdparty/freetype/include", "#thirdparty/msdfgen", "#thirdparty/nanosvg"])
 
     lib = env_msdfgen.add_library("msdfgen_builtin", thirdparty_sources)
     thirdparty_obj += lib

--- a/modules/navigation_2d/SCsub
+++ b/modules/navigation_2d/SCsub
@@ -21,7 +21,7 @@ if env["builtin_rvo2_2d"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_navigation_2d.Prepend(CPPPATH=[thirdparty_dir])
+    env_navigation_2d.Prepend(CPPEXTPATH=[thirdparty_dir])
 
     env_thirdparty = env_navigation_2d.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/navigation_3d/SCsub
+++ b/modules/navigation_3d/SCsub
@@ -29,7 +29,7 @@ if env["builtin_recastnavigation"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_navigation_3d.Prepend(CPPPATH=[thirdparty_dir + "Include"])
+    env_navigation_3d.Prepend(CPPEXTPATH=[thirdparty_dir + "Include"])
 
     env_thirdparty = env_navigation_3d.Clone()
     env_thirdparty.disable_warnings()
@@ -46,7 +46,7 @@ if env["builtin_rvo2_2d"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_navigation_3d.Prepend(CPPPATH=[thirdparty_dir])
+    env_navigation_3d.Prepend(CPPEXTPATH=[thirdparty_dir])
 
     # Don't build rvo_2d if 2D navigation is enabled.
     if not navigation_2d_enabled:
@@ -64,7 +64,7 @@ if env["builtin_rvo2_3d"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_navigation_3d.Prepend(CPPPATH=[thirdparty_dir])
+    env_navigation_3d.Prepend(CPPEXTPATH=[thirdparty_dir])
 
     env_thirdparty = env_navigation_3d.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/noise/SCsub
+++ b/modules/noise/SCsub
@@ -7,7 +7,7 @@ Import("env_modules")
 env_noise = env_modules.Clone()
 
 thirdparty_dir = "#thirdparty/noise/"
-env_noise.Prepend(CPPPATH=[thirdparty_dir])
+env_noise.Prepend(CPPEXTPATH=[thirdparty_dir])
 
 # Godot source files
 

--- a/modules/ogg/SCsub
+++ b/modules/ogg/SCsub
@@ -18,7 +18,7 @@ if env["builtin_libogg"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_ogg.Prepend(CPPPATH=[thirdparty_dir])
+    env_ogg.Prepend(CPPEXTPATH=[thirdparty_dir])
 
     env_thirdparty = env_ogg.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -49,7 +49,7 @@ if env["builtin_openxr"]:
     thirdparty_dir = "#thirdparty/openxr"
 
     env_openxr.Prepend(
-        CPPPATH=[
+        CPPEXTPATH=[
             thirdparty_dir,
             thirdparty_dir + "/include",
             thirdparty_dir + "/src",
@@ -65,7 +65,7 @@ if env["builtin_openxr"]:
     if env["disable_exceptions"]:
         env_thirdparty.AppendUnique(CPPDEFINES=["XRLOADER_DISABLE_EXCEPTION_HANDLING", ("JSON_USE_EXCEPTION", 0)])
 
-    env_thirdparty.Append(CPPPATH=[thirdparty_dir + "/src/loader"])
+    env_thirdparty.Append(CPPEXTPATH=[thirdparty_dir + "/src/loader"])
 
     # add in external jsoncpp dependency
     thirdparty_jsoncpp_dir = thirdparty_dir + "/src/external/jsoncpp/src/lib_json/"

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -62,7 +62,7 @@ if env["builtin_embree"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in embree_src]
 
-    env_raycast.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "include"])
+    env_raycast.Prepend(CPPEXTPATH=[thirdparty_dir, thirdparty_dir + "include"])
     env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_SSE2", "EMBREE_LOWEST_ISA", "TASKING_INTERNAL"])
     env_raycast.AppendUnique(CPPDEFINES=["NDEBUG"])  # No assert() even in debug builds.
 

--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -53,7 +53,7 @@ if env["builtin_pcre2"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_regex.Prepend(CPPPATH=[thirdparty_dir])
+    env_regex.Prepend(CPPEXTPATH=[thirdparty_dir])
     env_regex.Append(CPPDEFINES=thirdparty_flags)
 
     def pcre2_builtin(width):

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -65,7 +65,7 @@ if env["module_webp_enabled"]:
 
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_svg.Prepend(CPPPATH=[thirdparty_dir + "inc"])
+env_svg.Prepend(CPPEXTPATH=[thirdparty_dir + "inc"])
 
 # Enable ThorVG static object linking.
 env_svg.Append(CPPDEFINES=["TVG_STATIC"])
@@ -75,7 +75,7 @@ env_svg.Append(CPPDEFINES=["THORVG_FILE_IO_SUPPORT"])
 env_thirdparty = env_svg.Clone()
 env_thirdparty.disable_warnings()
 env_thirdparty.Prepend(
-    CPPPATH=[
+    CPPEXTPATH=[
         thirdparty_dir + "src/common",
         thirdparty_dir + "src/loaders/svg",
         thirdparty_dir + "src/renderer",
@@ -86,11 +86,11 @@ env_thirdparty.Prepend(
     ]
 )
 if env["builtin_libpng"]:
-    env_thirdparty.Prepend(CPPPATH=["#thirdparty/libpng"])
+    env_thirdparty.Prepend(CPPEXTPATH=["#thirdparty/libpng"])
 if env["module_webp_enabled"]:
-    env_thirdparty.Prepend(CPPPATH=[thirdparty_dir + "src/loaders/external_webp"])
+    env_thirdparty.Prepend(CPPEXTPATH=[thirdparty_dir + "src/loaders/external_webp"])
     if env["builtin_libwebp"]:
-        env_thirdparty.Prepend(CPPPATH=["#thirdparty/libwebp/src"])
+        env_thirdparty.Prepend(CPPEXTPATH=["#thirdparty/libwebp/src"])
 
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 env.modules_sources += thirdparty_obj

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -35,7 +35,7 @@ msdfgen_enabled = "msdfgen" in env.module_list
 
 if "svg" in env.module_list:
     env_text_server_adv.Prepend(
-        CPPPATH=[
+        CPPEXTPATH=[
             "#thirdparty/thorvg/inc",
             "#thirdparty/thorvg/src/common",
             "#thirdparty/thorvg/src/renderer",
@@ -135,11 +135,11 @@ if env["builtin_harfbuzz"]:
             ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_harfbuzz.Prepend(CPPPATH=["#thirdparty/harfbuzz/src"])
+    env_harfbuzz.Prepend(CPPEXTPATH=["#thirdparty/harfbuzz/src"])
 
     env_harfbuzz.Append(CCFLAGS=["-DHAVE_ICU"])
     if env["builtin_icu4c"]:
-        env_harfbuzz.Prepend(CPPPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
+        env_harfbuzz.Prepend(CPPEXTPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
         env_harfbuzz.Append(
             CCFLAGS=[
                 "-DU_STATIC_IMPLEMENTATION",
@@ -162,15 +162,15 @@ if env["builtin_harfbuzz"]:
                 ]
             )
         if env["builtin_freetype"]:
-            env_harfbuzz.Prepend(CPPPATH=["#thirdparty/freetype/include"])
+            env_harfbuzz.Prepend(CPPEXTPATH=["#thirdparty/freetype/include"])
         if env["builtin_graphite"] and env["graphite"]:
-            env_harfbuzz.Prepend(CPPPATH=["#thirdparty/graphite/include"])
+            env_harfbuzz.Prepend(CPPEXTPATH=["#thirdparty/graphite/include"])
             env_harfbuzz.Append(CCFLAGS=["-DGRAPHITE2_STATIC"])
 
     if env["platform"] in ["android", "linuxbsd", "web"]:
         env_harfbuzz.Append(CCFLAGS=["-DHAVE_PTHREAD"])
 
-    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/harfbuzz/src"])
+    env_text_server_adv.Prepend(CPPEXTPATH=["#thirdparty/harfbuzz/src"])
 
     lib = env_harfbuzz.add_library("harfbuzz_builtin", thirdparty_sources)
     thirdparty_obj += lib
@@ -233,7 +233,7 @@ if env["builtin_graphite"] and freetype_enabled and env["graphite"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_graphite.Prepend(CPPPATH=["#thirdparty/graphite/src", "#thirdparty/graphite/include"])
+    env_graphite.Prepend(CPPEXTPATH=["#thirdparty/graphite/src", "#thirdparty/graphite/include"])
     env_graphite.Append(
         CCFLAGS=[
             "-DGRAPHITE2_STATIC",
@@ -473,15 +473,10 @@ if env["builtin_icu4c"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    if env.editor_build:
-        env_icu.CommandNoCache(
-            "#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/icudt_godot.dat", env.Run(make_icu_data)
-        )
-        env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/"])
-    else:
+    if not env.editor_build:
         thirdparty_sources += ["icu_data/icudata_stub.cpp"]
 
-    env_icu.Prepend(CPPPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
+    env_icu.Prepend(CPPEXTPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
     env_icu.Append(
         CXXFLAGS=[
             "-DU_STATIC_IMPLEMENTATION",
@@ -510,10 +505,17 @@ if env["builtin_icu4c"]:
     if env.editor_build:
         env_text_server_adv.Append(CXXFLAGS=["-DICU_STATIC_DATA"])
 
-    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
+    env_text_server_adv.Prepend(CPPEXTPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
 
     lib = env_icu.add_library("icu_builtin", thirdparty_sources)
     thirdparty_obj += lib
+
+    if env.editor_build:
+        icudata = env_icu.CommandNoCache(
+            "#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/icudt_godot.dat", env.Run(make_icu_data)
+        )
+        env_text_server_adv.Prepend(CPPEXTPATH=["#thirdparty/icu4c/"])
+        env_icu.Depends(lib, icudata)
 
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack
@@ -534,19 +536,15 @@ if env["builtin_icu4c"]:
 module_obj = []
 
 if env["builtin_msdfgen"] and msdfgen_enabled:
-    # Treat msdfgen headers as system headers to avoid raising warnings. Not supported on MSVC.
     env_text_server_adv.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
-    if not env.msvc:
-        env_text_server_adv.Append(CPPFLAGS=["-isystem", Dir("#thirdparty/msdfgen").path])
-    else:
-        env_text_server_adv.Prepend(CPPPATH=["#thirdparty/msdfgen"])
+    env_text_server_adv.Prepend(CPPEXTPATH=["#thirdparty/msdfgen"])
 
 if env["builtin_freetype"] and freetype_enabled:
     env_text_server_adv.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
-    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/freetype/include"])
+    env_text_server_adv.Prepend(CPPEXTPATH=["#thirdparty/freetype/include"])
 
 if env["builtin_graphite"] and freetype_enabled and env["graphite"]:
-    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/graphite/include"])
+    env_text_server_adv.Prepend(CPPEXTPATH=["#thirdparty/graphite/include"])
 
 env_text_server_adv.add_source_files(module_obj, "*.cpp")
 env.modules_sources += module_obj

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -60,23 +60,17 @@ using namespace godot;
 // Built-in ICU data.
 
 #ifdef ICU_STATIC_DATA
-#include "icudata.gen.h"
+#include <icudata.gen.h>
 #endif
 
 // Thirdparty headers.
 
 #ifdef MODULE_MSDFGEN_ENABLED
-#ifdef _MSC_VER
-#pragma warning(disable : 4458)
-#endif
 #include <core/EdgeHolder.h>
 #include <core/ShapeDistanceFinder.h>
 #include <core/contour-combiners.h>
 #include <core/edge-selectors.h>
 #include <msdfgen.h>
-#ifdef _MSC_VER
-#pragma warning(default : 4458)
-#endif
 #endif
 
 #ifdef MODULE_SVG_ENABLED

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -94,11 +94,6 @@ using namespace godot;
 
 // Thirdparty headers.
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
-#endif
-
 #include <unicode/ubidi.h>
 #include <unicode/ubrk.h>
 #include <unicode/uchar.h>
@@ -111,10 +106,6 @@ using namespace godot;
 #include <unicode/uspoof.h>
 #include <unicode/ustring.h>
 #include <unicode/utypes.h>
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 #ifdef MODULE_FREETYPE_ENABLED
 #include <ft2build.h>

--- a/modules/text_server_fb/SCsub
+++ b/modules/text_server_fb/SCsub
@@ -11,21 +11,17 @@ env_text_server_fb = env_modules.Clone()
 
 if "svg" in env.module_list:
     env_text_server_fb.Prepend(
-        CPPPATH=["#thirdparty/thorvg/inc", "#thirdparty/thorvg/src/common", "#thirdparty/thorvg/src/renderer"]
+        CPPEXTPATH=["#thirdparty/thorvg/inc", "#thirdparty/thorvg/src/common", "#thirdparty/thorvg/src/renderer"]
     )
     # Enable ThorVG static object linking.
     env_text_server_fb.Append(CPPDEFINES=["TVG_STATIC"])
 
 if env["builtin_msdfgen"] and msdfgen_enabled:
-    # Treat msdfgen headers as system headers to avoid raising warnings. Not supported on MSVC.
     env_text_server_fb.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
-    if not env.msvc:
-        env_text_server_fb.Append(CPPFLAGS=["-isystem", Dir("#thirdparty/msdfgen").path])
-    else:
-        env_text_server_fb.Prepend(CPPPATH=["#thirdparty/msdfgen"])
+    env_text_server_fb.Prepend(CPPEXTPATH=["#thirdparty/msdfgen"])
 
 if env["builtin_freetype"] and freetype_enabled:
     env_text_server_fb.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
-    env_text_server_fb.Prepend(CPPPATH=["#thirdparty/freetype/include"])
+    env_text_server_fb.Prepend(CPPEXTPATH=["#thirdparty/freetype/include"])
 
 env_text_server_fb.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -61,17 +61,11 @@ using namespace godot;
 // Thirdparty headers.
 
 #ifdef MODULE_MSDFGEN_ENABLED
-#ifdef _MSC_VER
-#pragma warning(disable : 4458)
-#endif
 #include <core/EdgeHolder.h>
 #include <core/ShapeDistanceFinder.h>
 #include <core/contour-combiners.h>
 #include <core/edge-selectors.h>
 #include <msdfgen.h>
-#ifdef _MSC_VER
-#pragma warning(default : 4458)
-#endif
 #endif
 
 #ifdef MODULE_FREETYPE_ENABLED

--- a/modules/theora/SCsub
+++ b/modules/theora/SCsub
@@ -79,13 +79,13 @@ if env["builtin_libtheora"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_theora.Prepend(CPPPATH=[thirdparty_dir])
+    env_theora.Prepend(CPPEXTPATH=[thirdparty_dir])
 
     # also requires libogg and libvorbis
     if env["builtin_libogg"]:
-        env_theora.Prepend(CPPPATH=["#thirdparty/libogg"])
+        env_theora.Prepend(CPPEXTPATH=["#thirdparty/libogg"])
     if env["builtin_libvorbis"]:
-        env_theora.Prepend(CPPPATH=["#thirdparty/libvorbis"])
+        env_theora.Prepend(CPPEXTPATH=["#thirdparty/libvorbis"])
 
     env_thirdparty = env_theora.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/tinyexr/SCsub
+++ b/modules/tinyexr/SCsub
@@ -17,7 +17,7 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_tinyexr.Prepend(CPPPATH=[thirdparty_dir])
+env_tinyexr.Prepend(CPPEXTPATH=[thirdparty_dir])
 
 # Enable threaded loading with C++11.
 env_tinyexr.Append(CPPDEFINES=["TINYEXR_USE_THREAD"])

--- a/modules/upnp/SCsub
+++ b/modules/upnp/SCsub
@@ -29,13 +29,13 @@ if env["builtin_miniupnpc"] and env["platform"] != "web":
     ]
     thirdparty_sources = [thirdparty_dir + "src/" + file for file in thirdparty_sources]
 
-    env_upnp.Prepend(CPPPATH=[thirdparty_dir + "include"])
+    env_upnp.Prepend(CPPEXTPATH=[thirdparty_dir + "include"])
     env_upnp.Append(CPPDEFINES=["MINIUPNP_STATICLIB"])
     if env["platform"] != "windows":
         env_upnp.Append(CPPDEFINES=["MINIUPNPC_SET_SOCKET_TIMEOUT"])
 
     env_thirdparty = env_upnp.Clone()
-    env_thirdparty.Prepend(CPPPATH=[thirdparty_dir + "include/miniupnpc"])
+    env_thirdparty.Prepend(CPPEXTPATH=[thirdparty_dir + "include/miniupnpc"])
     env_thirdparty.disable_warnings()
     env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
     env.modules_sources += thirdparty_obj

--- a/modules/vhacd/SCsub
+++ b/modules/vhacd/SCsub
@@ -27,7 +27,7 @@ thirdparty_sources = [
 
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_vhacd.Prepend(CPPPATH=[thirdparty_dir + "inc"])
+env_vhacd.Prepend(CPPEXTPATH=[thirdparty_dir + "inc"])
 
 env_thirdparty = env_vhacd.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/vorbis/SCsub
+++ b/modules/vorbis/SCsub
@@ -42,11 +42,11 @@ if env["builtin_libvorbis"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_vorbis.Prepend(CPPPATH=[thirdparty_dir])
+    env_vorbis.Prepend(CPPEXTPATH=[thirdparty_dir])
 
     # also requires libogg
     if env["builtin_libogg"]:
-        env_vorbis.Prepend(CPPPATH=["#thirdparty/libogg"])
+        env_vorbis.Prepend(CPPEXTPATH=["#thirdparty/libogg"])
 
     env_thirdparty = env_vorbis.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/webp/SCsub
+++ b/modules/webp/SCsub
@@ -139,7 +139,7 @@ if env["builtin_libwebp"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_webp.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "src/"])
+    env_webp.Prepend(CPPEXTPATH=[thirdparty_dir, thirdparty_dir + "src/"])
 
     env_thirdparty = env_webp.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -23,7 +23,7 @@ elif env["builtin_wslay"]:
     ]
     thirdparty_sources = [thirdparty_dir + s for s in thirdparty_sources]
 
-    env_ws.Prepend(CPPPATH=[thirdparty_dir])
+    env_ws.Prepend(CPPEXTPATH=[thirdparty_dir])
     env_ws.Append(CPPDEFINES=["HAVE_CONFIG_H"])
 
     if env["platform"] == "windows":

--- a/modules/xatlas_unwrap/SCsub
+++ b/modules/xatlas_unwrap/SCsub
@@ -17,7 +17,7 @@ if env["builtin_xatlas"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_xatlas_unwrap.Prepend(CPPPATH=[thirdparty_dir])
+    env_xatlas_unwrap.Prepend(CPPEXTPATH=[thirdparty_dir])
 
     env_thirdparty = env_xatlas_unwrap.Clone()
     env_thirdparty.disable_warnings()

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -164,7 +164,7 @@ def configure(env: "SConsEnvironment"):
                 "$IOS_SDK_PATH/System/Library/Frameworks/QuartzCore.framework/Headers",
             ]
         )
-        env.Prepend(CPPPATH=["#thirdparty/spirv-cross"])
+        env.Prepend(CPPEXTPATH=["#thirdparty/spirv-cross"])
 
     if env["vulkan"] and env["ios_simulator"]:
         print_warning("iOS simulator does not support the Vulkan rendering driver")

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -293,7 +293,7 @@ def configure(env: "SConsEnvironment"):
 
     if not env["builtin_recastnavigation"]:
         # No pkgconfig file so far, hardcode default paths.
-        env.Prepend(CPPPATH=["/usr/include/recastnavigation"])
+        env.Prepend(CPPEXTPATH=["/usr/include/recastnavigation"])
         env.Append(LIBS=["Recast"])
 
     if not env["builtin_embree"] and env["arch"] in ["x86_64", "arm64"]:
@@ -394,7 +394,7 @@ def configure(env: "SConsEnvironment"):
 
     env.Prepend(CPPPATH=["#platform/linuxbsd"])
     if env["use_sowrap"]:
-        env.Prepend(CPPPATH=["#thirdparty/linuxbsd_headers"])
+        env.Prepend(CPPEXTPATH=["#thirdparty/linuxbsd_headers"])
 
     env.Append(
         CPPDEFINES=[
@@ -456,9 +456,9 @@ def configure(env: "SConsEnvironment"):
                 sys.exit(255)
             env.ParseConfig("pkg-config wayland-egl --cflags --libs")
         else:
-            env.Prepend(CPPPATH=["#thirdparty/linuxbsd_headers/wayland/"])
+            env.Prepend(CPPEXTPATH=["#thirdparty/linuxbsd_headers/wayland/"])
             if env["libdecor"]:
-                env.Prepend(CPPPATH=["#thirdparty/linuxbsd_headers/libdecor-0/"])
+                env.Prepend(CPPEXTPATH=["#thirdparty/linuxbsd_headers/libdecor-0/"])
 
         if env["libdecor"]:
             env.Append(CPPDEFINES=["LIBDECOR_ENABLED"])

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -231,7 +231,7 @@ def configure(env: "SConsEnvironment"):
             env.Append(LINKFLAGS=["-lANGLE.macos." + env["arch"]])
             env.Append(LINKFLAGS=["-lEGL.macos." + env["arch"]])
             env.Append(LINKFLAGS=["-lGLES.macos." + env["arch"]])
-        env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+        env.Prepend(CPPEXTPATH=["#thirdparty/angle/include"])
 
     env.Append(LINKFLAGS=["-rpath", "@executable_path/../Frameworks", "-rpath", "@executable_path"])
 
@@ -246,7 +246,7 @@ def configure(env: "SConsEnvironment"):
         extra_frameworks.add("Metal")
         extra_frameworks.add("MetalKit")
         extra_frameworks.add("MetalFX")
-        env.Prepend(CPPPATH=["#thirdparty/spirv-cross"])
+        env.Prepend(CPPEXTPATH=["#thirdparty/spirv-cross"])
 
     if env["vulkan"]:
         env.AppendUnique(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -461,7 +461,7 @@ def configure_msvc(env: "SConsEnvironment"):
                 "libGLES.windows." + env["arch"] + prebuilt_lib_extra_suffix,
             ]
             LIBS += ["dxgi", "d3d9", "d3d11"]
-        env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+        env.Prepend(CPPEXTPATH=["#thirdparty/angle/include"])
 
     if env["target"] in ["editor", "template_debug"]:
         LIBS += ["psapi", "dbghelp"]
@@ -808,7 +808,7 @@ def configure_mingw(env: "SConsEnvironment"):
                 ]
             )
             env.Append(LIBS=["dxgi", "d3d9", "d3d11"])
-        env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+        env.Prepend(CPPEXTPATH=["#thirdparty/angle/include"])
 
     env.Append(CPPDEFINES=["MINGW_ENABLED", ("MINGW_HAS_SECURE_API", 1)])
 

--- a/servers/rendering/renderer_rd/effects/SCsub
+++ b/servers/rendering/renderer_rd/effects/SCsub
@@ -13,7 +13,7 @@ thirdparty_dir = "#thirdparty/amd-fsr2/"
 thirdparty_sources = ["ffx_assert.cpp", "ffx_fsr2.cpp"]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_effects.Prepend(CPPPATH=[thirdparty_dir])
+env_effects.Prepend(CPPEXTPATH=[thirdparty_dir])
 
 # This flag doesn't actually control anything GCC specific in FSR2. It determines
 # if symbols should be exported, which is not required for Godot.


### PR DESCRIPTION
- Supersedes #101196

A reimagining of the above PR. Instead of adding a dedicated method for external includes, this instead opts to add an entirely new SCons variable to append pathing to. This keeps the existing logic almost completely unchanged, with only generic renames being needed most of the time. Much like the previous PR, this removes the need for the warning wrappers around external includes, so those have been removed as necessary.