### PR TITLE
[macOS] Use productCategory instead of vendorName for joypad name

### DIFF
--- a/drivers/apple/joypad_apple.mm
+++ b/drivers/apple/joypad_apple.mm
@@ -503,7 +503,13 @@ void JoypadApple::add_joypad(GCController *p_controller) {
 	}
 
 	// Tell Godot about our new controller.
-	Input::get_singleton()->joy_connection_changed(joy_id, true, String::utf8(p_controller.vendorName.UTF8String));
+	char const *device_name;
+	if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, *)) {
+		device_name = p_controller.productCategory.UTF8String;
+	} else {
+		device_name = p_controller.vendorName.UTF8String;
+	}
+	Input::get_singleton()->joy_connection_changed(joy_id, true, String::utf8(device_name));
 
 	// Assign our player index.
 	joypads.insert(joy_id, memnew(GameController(joy_id, p_controller)));


### PR DESCRIPTION
The current macos joypad implementation uses `vendorName` as the joy name.

The `vendorName` on macos is just the local device name of the controller. This name can also be changed by the user by simply changing the name of the device in the Bluetooth settings. `productCategory` on the other hand always returns a more fitting unchanging device name.

The current implementation causes inconsistencies with other platforms, where `get_joy_name` just provides the name of the controller according to the specifications. If I connect my Switch Pro Controller that I renamed to "My amazing controller" to my laptop, vendorName is "My amazing controller", so `get_joy_name` returns "My amazing controller" whereas e.g. on Windows it returns "Nintendo Switch Pro Controller". If `get_joy_name` retrieved `productCategory` instead the result would be "Switch Pro Controller", which would help properly identify which controller is actually connected to the computer.

[Relevant Apple Docs](https://developer.apple.com/documentation/gamecontroller/gcdevice)