### PR TITLE
Add functions to apply forces given a global position instead of an origin offset

### DIFF
--- a/doc/classes/PhysicsDirectBodyState2D.xml
+++ b/doc/classes/PhysicsDirectBodyState2D.xml
@@ -61,6 +61,15 @@
 				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
+		<method name="apply_force_at_position">
+			<return type="void" />
+			<param index="0" name="force" type="Vector2" />
+			<param index="1" name="global_position" type="Vector2" default="Vector2(0, 0)" />
+			<description>
+				Applies a positioned force to the body. A force is time dependent and meant to be applied every physics update.
+				[param global_position] is the position applied in global coordinates.
+			</description>
+		</method>
 		<method name="apply_impulse">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector2" />
@@ -69,6 +78,16 @@
 				Applies a positioned impulse to the body.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
 				[param position] is the offset from the body origin in global coordinates.
+			</description>
+		</method>
+		<method name="apply_impulse_at_position">
+			<return type="void" />
+			<param index="0" name="impulse" type="Vector2" />
+			<param index="1" name="global_position" type="Vector2" default="Vector2(0, 0)" />
+			<description>
+				Applies a positioned impulse to the body.
+				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
+				[param global_position] is the position applied in global coordinates.
 			</description>
 		</method>
 		<method name="apply_torque">

--- a/doc/classes/PhysicsDirectBodyState2DExtension.xml
+++ b/doc/classes/PhysicsDirectBodyState2DExtension.xml
@@ -54,12 +54,26 @@
 				Overridable version of [method PhysicsDirectBodyState2D.apply_force].
 			</description>
 		</method>
+		<method name="_apply_force_at_position" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="force" type="Vector2" />
+			<param index="1" name="global_position" type="Vector2" />
+			<description>
+			</description>
+		</method>
 		<method name="_apply_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector2" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.apply_impulse].
+			</description>
+		</method>
+		<method name="_apply_impulse_at_position" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="impulse" type="Vector2" />
+			<param index="1" name="position" type="Vector2" />
+			<description>
 			</description>
 		</method>
 		<method name="_apply_torque" qualifiers="virtual required">

--- a/doc/classes/PhysicsDirectBodyState3D.xml
+++ b/doc/classes/PhysicsDirectBodyState3D.xml
@@ -61,6 +61,16 @@
 				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
+		<method name="apply_force_at_position">
+			<return type="void" />
+			<param index="0" name="force" type="Vector3" />
+			<param index="1" name="global_position" type="Vector3" default="Vector3(0, 0, 0)" />
+			<description>
+				Applies a positioned force to the body. A force is time dependent and meant to be applied every physics update.
+				[param global_position] is the position the force is applied in global coordinates.
+				You can use this instead of [method apply_force] to not have to manually calculate the offset of the force position.
+			</description>
+		</method>
 		<method name="apply_impulse">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector3" />
@@ -69,6 +79,17 @@
 				Applies a positioned impulse to the body.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
 				[param position] is the offset from the body origin in global coordinates.
+			</description>
+		</method>
+		<method name="apply_impulse_at_position">
+			<return type="void" />
+			<param index="0" name="impulse" type="Vector3" />
+			<param index="1" name="global_position" type="Vector3" default="Vector3(0, 0, 0)" />
+			<description>
+				Applies a positioned impulse to the body.
+				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
+				[param global_position] is the position the force is applied in global coordinates.
+				You can use this instead of [method apply_impulse] to not have to manually calculate the offset of the force position.
 			</description>
 		</method>
 		<method name="apply_torque">

--- a/doc/classes/PhysicsDirectBodyState3DExtension.xml
+++ b/doc/classes/PhysicsDirectBodyState3DExtension.xml
@@ -48,10 +48,24 @@
 			<description>
 			</description>
 		</method>
+		<method name="_apply_force_at_position" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="force" type="Vector3" />
+			<param index="1" name="global_position" type="Vector3" />
+			<description>
+			</description>
+		</method>
 		<method name="_apply_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector3" />
 			<param index="1" name="position" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_apply_impulse_at_position" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="impulse" type="Vector3" />
+			<param index="1" name="global_position" type="Vector3" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -316,6 +316,16 @@
 				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
+		<method name="body_apply_force_at_position">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="force" type="Vector2" />
+			<param index="2" name="global_position" type="Vector2" default="Vector2(0, 0)" />
+			<description>
+				Applies a positioned force to the body at position. The force can affect rotation if [param global_position] is different from the body's center of mass. A force is time dependent and meant to be applied every physics update.
+				[param global_position] is the position applied in global coordinates.
+			</description>
+		</method>
 		<method name="body_apply_impulse">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
@@ -325,6 +335,17 @@
 				Applies a positioned impulse to the body. The impulse can affect rotation if [param position] is different from the body's center of mass.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
 				[param position] is the offset from the body origin in global coordinates.
+			</description>
+		</method>
+		<method name="body_apply_impulse_at_position">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="impulse" type="Vector2" />
+			<param index="2" name="global_position" type="Vector2" default="Vector2(0, 0)" />
+			<description>
+				Applies a positioned impulse to the body. The impulse can affect rotation if [param global_position] is different from the body's center of mass.
+				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
+				[param global_position] is the position applied in global coordinates.
 			</description>
 		</method>
 		<method name="body_apply_torque">

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -299,6 +299,14 @@
 				Overridable version of [method PhysicsServer2D.body_apply_force].
 			</description>
 		</method>
+		<method name="_body_apply_force_at_position" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="force" type="Vector2" />
+			<param index="2" name="global_position" type="Vector2" />
+			<description>
+			</description>
+		</method>
 		<method name="_body_apply_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
@@ -306,6 +314,14 @@
 			<param index="2" name="position" type="Vector2" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_apply_impulse].
+			</description>
+		</method>
+		<method name="_body_apply_impulse_at_position" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="impulse" type="Vector2" />
+			<param index="2" name="global_position" type="Vector2" />
+			<description>
 			</description>
 		</method>
 		<method name="_body_apply_torque" qualifiers="virtual required">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -306,6 +306,17 @@
 				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
+		<method name="body_apply_force_at_position">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="force" type="Vector3" />
+			<param index="2" name="global_position" type="Vector3" default="Vector3(0, 0, 0)" />
+			<description>
+				Applies a positioned force to the body at position. A force is time dependent and meant to be applied every physics update.
+				[param global_position] is the position the force is applied in global coordinates.
+				You can use this instead of [method body_apply_force] to not have to manually calculate the offset of the force position.
+			</description>
+		</method>
 		<method name="body_apply_impulse">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
@@ -315,6 +326,18 @@
 				Applies a positioned impulse to the body.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
 				[param position] is the offset from the body origin in global coordinates.
+			</description>
+		</method>
+		<method name="body_apply_impulse_at_position">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="impulse" type="Vector3" />
+			<param index="2" name="global_position" type="Vector3" default="Vector3(0, 0, 0)" />
+			<description>
+				Applies a positioned impulse to the body.
+				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
+				[param global_position] is the position the force is applied in global coordinates.
+				You can use this instead of [method body_apply_impulse] to not have to manually calculate the offset of the force position.
 			</description>
 		</method>
 		<method name="body_apply_torque">

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -249,11 +249,27 @@
 			<description>
 			</description>
 		</method>
+		<method name="_body_apply_force_at_position" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="force" type="Vector3" />
+			<param index="2" name="position" type="Vector3" />
+			<description>
+			</description>
+		</method>
 		<method name="_body_apply_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector3" />
 			<param index="2" name="position" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_apply_impulse_at_position" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="impulse" type="Vector3" />
+			<param index="2" name="global_position" type="Vector3" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -75,6 +75,15 @@
 				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
+		<method name="apply_force_at_position">
+			<return type="void" />
+			<param index="0" name="force" type="Vector2" />
+			<param index="1" name="global_position" type="Vector2" default="Vector2(0, 0)" />
+			<description>
+				Applies a positioned force to the body. A force is time dependent and meant to be applied every physics update.
+				[param global_position] is the position applied in global coordinates.
+			</description>
+		</method>
 		<method name="apply_impulse">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector2" />
@@ -83,6 +92,16 @@
 				Applies a positioned impulse to the body.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
 				[param position] is the offset from the body origin in global coordinates.
+			</description>
+		</method>
+		<method name="apply_impulse_at_position">
+			<return type="void" />
+			<param index="0" name="impulse" type="Vector2" />
+			<param index="1" name="global_position" type="Vector2" default="Vector2(0, 0)" />
+			<description>
+				Applies a positioned impulse to the body.
+				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
+				[param global_position] is the position applied in global coordinates.
 			</description>
 		</method>
 		<method name="apply_torque">

--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -75,6 +75,16 @@
 				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
+		<method name="apply_force_at_position">
+			<return type="void" />
+			<param index="0" name="force" type="Vector3" />
+			<param index="1" name="global_position" type="Vector3" default="Vector3(0, 0, 0)" />
+			<description>
+				Applies a positioned force to the body. A force is time dependent and meant to be applied every physics update.
+				[param global_position] is the position the force is applied in global coordinates.
+				You can use this instead of [method apply_force] to not have to manually calculate the offset of the force position.
+			</description>
+		</method>
 		<method name="apply_impulse">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector3" />
@@ -83,6 +93,17 @@
 				Applies a positioned impulse to the body.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
 				[param position] is the offset from the body origin in global coordinates.
+			</description>
+		</method>
+		<method name="apply_impulse_at_position">
+			<return type="void" />
+			<param index="0" name="impulse" type="Vector3" />
+			<param index="1" name="global_position" type="Vector3" default="Vector3(0, 0, 0)" />
+			<description>
+				Applies a positioned impulse to the body.
+				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
+				[param global_position] is the position the force is applied in global coordinates.
+				You can use this instead of [method apply_impulse] to not have to manually calculate the offset of the force position.
 			</description>
 		</method>
 		<method name="apply_torque">

--- a/modules/godot_physics_2d/godot_body_2d.h
+++ b/modules/godot_physics_2d/godot_body_2d.h
@@ -236,6 +236,11 @@ public:
 		angular_velocity += _inv_inertia * (p_position - center_of_mass).cross(p_impulse);
 	}
 
+	_FORCE_INLINE_ void apply_impulse_at_position(const Vector2 &p_impulse, const Vector2 &p_global_position = Vector2()) {
+		linear_velocity += p_impulse * _inv_mass;
+		angular_velocity += _inv_inertia * (p_global_position - center_of_mass - get_transform().get_origin()).cross(p_impulse);
+	}
+
 	_FORCE_INLINE_ void apply_torque_impulse(real_t p_torque) {
 		angular_velocity += _inv_inertia * p_torque;
 	}
@@ -258,6 +263,11 @@ public:
 	_FORCE_INLINE_ void apply_force(const Vector2 &p_force, const Vector2 &p_position = Vector2()) {
 		applied_force += p_force;
 		applied_torque += (p_position - center_of_mass).cross(p_force);
+	}
+
+	_FORCE_INLINE_ void apply_force_at_position(const Vector2 &p_force, const Vector2 &p_global_position = Vector2()) {
+		applied_force += p_force;
+		applied_torque += (p_global_position - center_of_mass - get_transform().get_origin()).cross(p_force);
 	}
 
 	_FORCE_INLINE_ void apply_torque(real_t p_torque) {

--- a/modules/godot_physics_2d/godot_body_direct_state_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_direct_state_2d.cpp
@@ -101,6 +101,11 @@ void GodotPhysicsDirectBodyState2D::apply_impulse(const Vector2 &p_impulse, cons
 	body->apply_impulse(p_impulse, p_position);
 }
 
+void GodotPhysicsDirectBodyState2D::apply_impulse_at_position(const Vector2 &p_impulse, const Vector2 &p_global_position) {
+	body->wakeup();
+	body->apply_impulse_at_position(p_impulse, p_global_position);
+}
+
 void GodotPhysicsDirectBodyState2D::apply_torque_impulse(real_t p_torque) {
 	body->wakeup();
 	body->apply_torque_impulse(p_torque);
@@ -114,6 +119,11 @@ void GodotPhysicsDirectBodyState2D::apply_central_force(const Vector2 &p_force) 
 void GodotPhysicsDirectBodyState2D::apply_force(const Vector2 &p_force, const Vector2 &p_position) {
 	body->wakeup();
 	body->apply_force(p_force, p_position);
+}
+
+void GodotPhysicsDirectBodyState2D::apply_force_at_position(const Vector2 &p_force, const Vector2 &p_global_position) {
+	body->wakeup();
+	body->apply_force_at_position(p_force, p_global_position);
 }
 
 void GodotPhysicsDirectBodyState2D::apply_torque(real_t p_torque) {

--- a/modules/godot_physics_2d/godot_body_direct_state_2d.h
+++ b/modules/godot_physics_2d/godot_body_direct_state_2d.h
@@ -62,10 +62,12 @@ public:
 
 	virtual void apply_central_impulse(const Vector2 &p_impulse) override;
 	virtual void apply_impulse(const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) override;
+	virtual void apply_impulse_at_position(const Vector2 &p_impulse, const Vector2 &p_global_position = Vector2()) override;
 	virtual void apply_torque_impulse(real_t p_torque) override;
 
 	virtual void apply_central_force(const Vector2 &p_force) override;
 	virtual void apply_force(const Vector2 &p_force, const Vector2 &p_position = Vector2()) override;
+	virtual void apply_force_at_position(const Vector2 &p_force, const Vector2 &p_global_position = Vector2()) override;
 	virtual void apply_torque(real_t p_torque) override;
 
 	virtual void add_constant_central_force(const Vector2 &p_force) override;

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -808,6 +808,16 @@ void GodotPhysicsServer2D::body_apply_impulse(RID p_body, const Vector2 &p_impul
 	body->wakeup();
 }
 
+void GodotPhysicsServer2D::body_apply_impulse_at_position(RID p_body, const Vector2 &p_impulse, const Vector2 &p_global_position) {
+	GodotBody2D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	_update_shapes();
+
+	body->apply_impulse_at_position(p_impulse, p_global_position);
+	body->wakeup();
+}
+
 void GodotPhysicsServer2D::body_apply_central_force(RID p_body, const Vector2 &p_force) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
@@ -821,6 +831,14 @@ void GodotPhysicsServer2D::body_apply_force(RID p_body, const Vector2 &p_force, 
 	ERR_FAIL_NULL(body);
 
 	body->apply_force(p_force, p_position);
+	body->wakeup();
+}
+
+void GodotPhysicsServer2D::body_apply_force_at_position(RID p_body, const Vector2 &p_force, const Vector2 &p_global_position) {
+	GodotBody2D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->apply_force_at_position(p_force, p_global_position);
 	body->wakeup();
 }
 

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -216,9 +216,11 @@ public:
 	virtual void body_apply_central_impulse(RID p_body, const Vector2 &p_impulse) override;
 	virtual void body_apply_torque_impulse(RID p_body, real_t p_torque) override;
 	virtual void body_apply_impulse(RID p_body, const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) override;
+	virtual void body_apply_impulse_at_position(RID p_body, const Vector2 &p_impulse, const Vector2 &p_global_position = Vector2()) override;
 
 	virtual void body_apply_central_force(RID p_body, const Vector2 &p_force) override;
 	virtual void body_apply_force(RID p_body, const Vector2 &p_force, const Vector2 &p_position = Vector2()) override;
+	virtual void body_apply_force_at_position(RID p_body, const Vector2 &p_force, const Vector2 &p_global_position = Vector2()) override;
 	virtual void body_apply_torque(RID p_body, real_t p_torque) override;
 
 	virtual void body_add_constant_central_force(RID p_body, const Vector2 &p_force) override;

--- a/modules/godot_physics_3d/godot_body_3d.h
+++ b/modules/godot_physics_3d/godot_body_3d.h
@@ -230,6 +230,11 @@ public:
 		angular_velocity += _inv_inertia_tensor.xform((p_position - center_of_mass).cross(p_impulse));
 	}
 
+	_FORCE_INLINE_ void apply_impulse_at_position(const Vector3 &p_impulse, const Vector3 &p_global_position = Vector3()) {
+		linear_velocity += p_impulse * _inv_mass;
+		angular_velocity += _inv_inertia_tensor.xform((p_global_position - center_of_mass - get_transform().origin).cross(p_impulse));
+	}
+
 	_FORCE_INLINE_ void apply_torque_impulse(const Vector3 &p_impulse) {
 		angular_velocity += _inv_inertia_tensor.xform(p_impulse);
 	}
@@ -256,6 +261,11 @@ public:
 	_FORCE_INLINE_ void apply_force(const Vector3 &p_force, const Vector3 &p_position = Vector3()) {
 		applied_force += p_force;
 		applied_torque += (p_position - center_of_mass).cross(p_force);
+	}
+
+	_FORCE_INLINE_ void apply_force_at_position(const Vector3 &p_force, const Vector3 &p_global_position = Vector3()) {
+		applied_force += p_force;
+		applied_torque += (p_global_position - center_of_mass - get_transform().origin).cross(p_force);
 	}
 
 	_FORCE_INLINE_ void apply_torque(const Vector3 &p_torque) {

--- a/modules/godot_physics_3d/godot_body_direct_state_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_direct_state_3d.cpp
@@ -109,6 +109,11 @@ void GodotPhysicsDirectBodyState3D::apply_impulse(const Vector3 &p_impulse, cons
 	body->apply_impulse(p_impulse, p_position);
 }
 
+void GodotPhysicsDirectBodyState3D::apply_impulse_at_position(const Vector3 &p_impulse, const Vector3 &p_global_position) {
+	body->wakeup();
+	body->apply_impulse_at_position(p_impulse, p_global_position);
+}
+
 void GodotPhysicsDirectBodyState3D::apply_torque_impulse(const Vector3 &p_impulse) {
 	body->wakeup();
 	body->apply_torque_impulse(p_impulse);
@@ -122,6 +127,11 @@ void GodotPhysicsDirectBodyState3D::apply_central_force(const Vector3 &p_force) 
 void GodotPhysicsDirectBodyState3D::apply_force(const Vector3 &p_force, const Vector3 &p_position) {
 	body->wakeup();
 	body->apply_force(p_force, p_position);
+}
+
+void GodotPhysicsDirectBodyState3D::apply_force_at_position(const Vector3 &p_force, const Vector3 &p_global_position) {
+	body->wakeup();
+	body->apply_force_at_position(p_force, p_global_position);
 }
 
 void GodotPhysicsDirectBodyState3D::apply_torque(const Vector3 &p_torque) {

--- a/modules/godot_physics_3d/godot_body_direct_state_3d.h
+++ b/modules/godot_physics_3d/godot_body_direct_state_3d.h
@@ -65,10 +65,12 @@ public:
 
 	virtual void apply_central_impulse(const Vector3 &p_impulse) override;
 	virtual void apply_impulse(const Vector3 &p_impulse, const Vector3 &p_position = Vector3()) override;
+	virtual void apply_impulse_at_position(const Vector3 &p_impulse, const Vector3 &p_global_position = Vector3()) override;
 	virtual void apply_torque_impulse(const Vector3 &p_impulse) override;
 
 	virtual void apply_central_force(const Vector3 &p_force) override;
 	virtual void apply_force(const Vector3 &p_force, const Vector3 &p_position = Vector3()) override;
+	virtual void apply_force_at_position(const Vector3 &p_force, const Vector3 &p_global_position = Vector3()) override;
 	virtual void apply_torque(const Vector3 &p_torque) override;
 
 	virtual void add_constant_central_force(const Vector3 &p_force) override;

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -711,6 +711,16 @@ void GodotPhysicsServer3D::body_apply_impulse(RID p_body, const Vector3 &p_impul
 	body->wakeup();
 }
 
+void GodotPhysicsServer3D::body_apply_impulse_at_position(RID p_body, const Vector3 &p_impulse, const Vector3 &p_global_position) {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	_update_shapes();
+
+	body->apply_impulse_at_position(p_impulse, p_global_position);
+	body->wakeup();
+}
+
 void GodotPhysicsServer3D::body_apply_torque_impulse(RID p_body, const Vector3 &p_impulse) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
@@ -734,6 +744,14 @@ void GodotPhysicsServer3D::body_apply_force(RID p_body, const Vector3 &p_force, 
 	ERR_FAIL_NULL(body);
 
 	body->apply_force(p_force, p_position);
+	body->wakeup();
+}
+
+void GodotPhysicsServer3D::body_apply_force_at_position(RID p_body, const Vector3 &p_force, const Vector3 &p_global_position) {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->apply_force_at_position(p_force, p_global_position);
 	body->wakeup();
 }
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -210,6 +210,7 @@ public:
 
 	virtual void body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) override;
 	virtual void body_apply_impulse(RID p_body, const Vector3 &p_impulse, const Vector3 &p_position = Vector3()) override;
+	virtual void body_apply_impulse_at_position(RID p_body, const Vector3 &p_impulse, const Vector3 &p_global_position = Vector3()) override;
 	virtual void body_apply_torque_impulse(RID p_body, const Vector3 &p_impulse) override;
 
 	virtual void soft_body_apply_point_impulse(RID p_body, int p_point_index, const Vector3 &p_impulse) override;
@@ -219,6 +220,7 @@ public:
 
 	virtual void body_apply_central_force(RID p_body, const Vector3 &p_force) override;
 	virtual void body_apply_force(RID p_body, const Vector3 &p_force, const Vector3 &p_position = Vector3()) override;
+	virtual void body_apply_force_at_position(RID p_body, const Vector3 &p_force, const Vector3 &p_global_position = Vector3()) override;
 	virtual void body_apply_torque(RID p_body, const Vector3 &p_torque) override;
 
 	virtual void body_add_constant_central_force(RID p_body, const Vector3 &p_force) override;

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -777,6 +777,13 @@ void JoltPhysicsServer3D::body_apply_impulse(RID p_body, const Vector3 &p_impuls
 	return body->apply_impulse(p_impulse, p_position);
 }
 
+void JoltPhysicsServer3D::body_apply_impulse_at_position(RID p_body, const Vector3 &p_impulse, const Vector3 &p_global_position) {
+	JoltBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	return body->apply_impulse_at_position(p_impulse, p_global_position);
+}
+
 void JoltPhysicsServer3D::body_apply_torque_impulse(RID p_body, const Vector3 &p_impulse) {
 	JoltBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
@@ -796,6 +803,13 @@ void JoltPhysicsServer3D::body_apply_force(RID p_body, const Vector3 &p_force, c
 	ERR_FAIL_NULL(body);
 
 	return body->apply_force(p_force, p_position);
+}
+
+void JoltPhysicsServer3D::body_apply_force_at_position(RID p_body, const Vector3 &p_force, const Vector3 &p_global_position) {
+	JoltBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	return body->apply_force_at_position(p_force, p_global_position);
 }
 
 void JoltPhysicsServer3D::body_apply_torque(RID p_body, const Vector3 &p_torque) {

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -255,10 +255,12 @@ public:
 
 	virtual void body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) override;
 	virtual void body_apply_impulse(RID p_body, const Vector3 &p_impulse, const Vector3 &p_position) override;
+	virtual void body_apply_impulse_at_position(RID p_body, const Vector3 &p_impulse, const Vector3 &p_global_position) override;
 	virtual void body_apply_torque_impulse(RID p_body, const Vector3 &p_impulse) override;
 
 	virtual void body_apply_central_force(RID p_body, const Vector3 &p_force) override;
 	virtual void body_apply_force(RID p_body, const Vector3 &p_force, const Vector3 &p_position) override;
+	virtual void body_apply_force_at_position(RID p_body, const Vector3 &p_force, const Vector3 &p_global_position) override;
 	virtual void body_apply_torque(RID p_body, const Vector3 &p_torque) override;
 
 	virtual void body_add_constant_central_force(RID p_body, const Vector3 &p_force) override;

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -898,6 +898,18 @@ void JoltBody3D::apply_force(const Vector3 &p_force, const Vector3 &p_position) 
 	_motion_changed();
 }
 
+void JoltBody3D::apply_force_at_position(const Vector3 &p_force, const Vector3 &p_global_position) {
+	ERR_FAIL_COND_MSG(!in_space(), vformat("Failed to apply force to '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
+
+	if (unlikely(!is_rigid()) || custom_integrator || p_force == Vector3()) {
+		return;
+	}
+
+	jolt_body->AddForce(to_jolt(p_force), JPH::RVec3(to_jolt(p_global_position)));
+
+	_motion_changed();
+}
+
 void JoltBody3D::apply_central_force(const Vector3 &p_force) {
 	ERR_FAIL_COND_MSG(!in_space(), vformat("Failed to apply central force to '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
 
@@ -918,6 +930,18 @@ void JoltBody3D::apply_impulse(const Vector3 &p_impulse, const Vector3 &p_positi
 	}
 
 	jolt_body->AddImpulse(to_jolt(p_impulse), jolt_body->GetPosition() + to_jolt(p_position));
+
+	_motion_changed();
+}
+
+void JoltBody3D::apply_impulse_at_position(const Vector3 &p_impulse, const Vector3 &p_global_position) {
+	ERR_FAIL_COND_MSG(!in_space(), vformat("Failed to apply impulse to '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
+
+	if (unlikely(!is_rigid()) || p_impulse == Vector3()) {
+		return;
+	}
+
+	jolt_body->AddImpulse(to_jolt(p_impulse), JPH::RVec3(to_jolt(p_global_position)));
 
 	_motion_changed();
 }

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -215,8 +215,10 @@ public:
 	void reset_mass_properties();
 
 	void apply_force(const Vector3 &p_force, const Vector3 &p_position);
+	void apply_force_at_position(const Vector3 &p_force, const Vector3 &p_global_position);
 	void apply_central_force(const Vector3 &p_force);
 	void apply_impulse(const Vector3 &p_impulse, const Vector3 &p_position);
+	void apply_impulse_at_position(const Vector3 &p_impulse, const Vector3 &p_global_position);
 
 	void apply_central_impulse(const Vector3 &p_impulse);
 	void apply_torque(const Vector3 &p_torque);

--- a/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.cpp
@@ -110,6 +110,10 @@ void JoltPhysicsDirectBodyState3D::apply_impulse(const Vector3 &p_impulse, const
 	return body->apply_impulse(p_impulse, p_position);
 }
 
+void JoltPhysicsDirectBodyState3D::apply_impulse_at_position(const Vector3 &p_impulse, const Vector3 &p_global_position) {
+	return body->apply_impulse_at_position(p_impulse, p_global_position);
+}
+
 void JoltPhysicsDirectBodyState3D::apply_torque_impulse(const Vector3 &p_impulse) {
 	return body->apply_torque_impulse(p_impulse);
 }
@@ -120,6 +124,10 @@ void JoltPhysicsDirectBodyState3D::apply_central_force(const Vector3 &p_force) {
 
 void JoltPhysicsDirectBodyState3D::apply_force(const Vector3 &p_force, const Vector3 &p_position) {
 	return body->apply_force(p_force, p_position);
+}
+
+void JoltPhysicsDirectBodyState3D::apply_force_at_position(const Vector3 &p_force, const Vector3 &p_global_position) {
+	return body->apply_force_at_position(p_force, p_global_position);
 }
 
 void JoltPhysicsDirectBodyState3D::apply_torque(const Vector3 &p_torque) {

--- a/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.h
+++ b/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.h
@@ -71,10 +71,12 @@ public:
 
 	virtual void apply_central_impulse(const Vector3 &p_impulse) override;
 	virtual void apply_impulse(const Vector3 &p_impulse, const Vector3 &p_position) override;
+	virtual void apply_impulse_at_position(const Vector3 &p_impulse, const Vector3 &p_global_position) override;
 	virtual void apply_torque_impulse(const Vector3 &p_impulse) override;
 
 	virtual void apply_central_force(const Vector3 &p_force) override;
 	virtual void apply_force(const Vector3 &p_force, const Vector3 &p_position) override;
+	virtual void apply_force_at_position(const Vector3 &p_force, const Vector3 &p_global_position) override;
 	virtual void apply_torque(const Vector3 &p_torque) override;
 
 	virtual void add_constant_central_force(const Vector3 &p_force) override;

--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -527,6 +527,10 @@ void RigidBody2D::apply_impulse(const Vector2 &p_impulse, const Vector2 &p_posit
 	PhysicsServer2D::get_singleton()->body_apply_impulse(get_rid(), p_impulse, p_position);
 }
 
+void RigidBody2D::apply_impulse_at_position(const Vector2 &p_impulse, const Vector2 &p_global_position) {
+	PhysicsServer2D::get_singleton()->body_apply_impulse_at_position(get_rid(), p_impulse, p_global_position);
+}
+
 void RigidBody2D::apply_torque_impulse(real_t p_torque) {
 	PhysicsServer2D::get_singleton()->body_apply_torque_impulse(get_rid(), p_torque);
 }
@@ -537,6 +541,10 @@ void RigidBody2D::apply_central_force(const Vector2 &p_force) {
 
 void RigidBody2D::apply_force(const Vector2 &p_force, const Vector2 &p_position) {
 	PhysicsServer2D::get_singleton()->body_apply_force(get_rid(), p_force, p_position);
+}
+
+void RigidBody2D::apply_force_at_position(const Vector2 &p_force, const Vector2 &p_global_position) {
+	PhysicsServer2D::get_singleton()->body_apply_force_at_position(get_rid(), p_force, p_global_position);
 }
 
 void RigidBody2D::apply_torque(real_t p_torque) {
@@ -712,10 +720,12 @@ void RigidBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_axis_velocity", "axis_velocity"), &RigidBody2D::set_axis_velocity);
 	ClassDB::bind_method(D_METHOD("apply_central_impulse", "impulse"), &RigidBody2D::apply_central_impulse, Vector2());
 	ClassDB::bind_method(D_METHOD("apply_impulse", "impulse", "position"), &RigidBody2D::apply_impulse, Vector2());
+	ClassDB::bind_method(D_METHOD("apply_impulse_at_position", "impulse", "global_position"), &RigidBody2D::apply_impulse_at_position, Vector2());
 	ClassDB::bind_method(D_METHOD("apply_torque_impulse", "torque"), &RigidBody2D::apply_torque_impulse);
 
 	ClassDB::bind_method(D_METHOD("apply_central_force", "force"), &RigidBody2D::apply_central_force);
 	ClassDB::bind_method(D_METHOD("apply_force", "force", "position"), &RigidBody2D::apply_force, Vector2());
+	ClassDB::bind_method(D_METHOD("apply_force_at_position", "force", "global_position"), &RigidBody2D::apply_force_at_position, Vector2());
 	ClassDB::bind_method(D_METHOD("apply_torque", "torque"), &RigidBody2D::apply_torque);
 
 	ClassDB::bind_method(D_METHOD("add_constant_central_force", "force"), &RigidBody2D::add_constant_central_force);

--- a/scene/2d/physics/rigid_body_2d.h
+++ b/scene/2d/physics/rigid_body_2d.h
@@ -217,10 +217,12 @@ public:
 
 	void apply_central_impulse(const Vector2 &p_impulse);
 	void apply_impulse(const Vector2 &p_impulse, const Vector2 &p_position = Vector2());
+	void apply_impulse_at_position(const Vector2 &p_impulse, const Vector2 &p_global_position = Vector2());
 	void apply_torque_impulse(real_t p_torque);
 
 	void apply_central_force(const Vector2 &p_force);
 	void apply_force(const Vector2 &p_force, const Vector2 &p_position = Vector2());
+	void apply_force_at_position(const Vector2 &p_force, const Vector2 &p_global_position = Vector2());
 	void apply_torque(real_t p_torque);
 
 	void add_constant_central_force(const Vector2 &p_force);

--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -552,6 +552,11 @@ void RigidBody3D::apply_impulse(const Vector3 &p_impulse, const Vector3 &p_posit
 	singleton->body_apply_impulse(get_rid(), p_impulse, p_position);
 }
 
+void RigidBody3D::apply_impulse_at_position(const Vector3 &p_impulse, const Vector3 &p_global_position) {
+	PhysicsServer3D *singleton = PhysicsServer3D::get_singleton();
+	singleton->body_apply_impulse_at_position(get_rid(), p_impulse, p_global_position);
+}
+
 void RigidBody3D::apply_torque_impulse(const Vector3 &p_impulse) {
 	PhysicsServer3D::get_singleton()->body_apply_torque_impulse(get_rid(), p_impulse);
 }
@@ -563,6 +568,11 @@ void RigidBody3D::apply_central_force(const Vector3 &p_force) {
 void RigidBody3D::apply_force(const Vector3 &p_force, const Vector3 &p_position) {
 	PhysicsServer3D *singleton = PhysicsServer3D::get_singleton();
 	singleton->body_apply_force(get_rid(), p_force, p_position);
+}
+
+void RigidBody3D::apply_force_at_position(const Vector3 &p_force, const Vector3 &p_global_position) {
+	PhysicsServer3D *singleton = PhysicsServer3D::get_singleton();
+	singleton->body_apply_force_at_position(get_rid(), p_force, p_global_position);
 }
 
 void RigidBody3D::apply_torque(const Vector3 &p_torque) {
@@ -735,10 +745,12 @@ void RigidBody3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("apply_central_impulse", "impulse"), &RigidBody3D::apply_central_impulse);
 	ClassDB::bind_method(D_METHOD("apply_impulse", "impulse", "position"), &RigidBody3D::apply_impulse, Vector3());
+	ClassDB::bind_method(D_METHOD("apply_impulse_at_position", "impulse", "global_position"), &RigidBody3D::apply_impulse_at_position, Vector3());
 	ClassDB::bind_method(D_METHOD("apply_torque_impulse", "impulse"), &RigidBody3D::apply_torque_impulse);
 
 	ClassDB::bind_method(D_METHOD("apply_central_force", "force"), &RigidBody3D::apply_central_force);
 	ClassDB::bind_method(D_METHOD("apply_force", "force", "position"), &RigidBody3D::apply_force, Vector3());
+	ClassDB::bind_method(D_METHOD("apply_force_at_position", "force", "global_position"), &RigidBody3D::apply_force_at_position, Vector3());
 	ClassDB::bind_method(D_METHOD("apply_torque", "torque"), &RigidBody3D::apply_torque);
 
 	ClassDB::bind_method(D_METHOD("add_constant_central_force", "force"), &RigidBody3D::add_constant_central_force);

--- a/scene/3d/physics/rigid_body_3d.h
+++ b/scene/3d/physics/rigid_body_3d.h
@@ -218,10 +218,12 @@ public:
 
 	void apply_central_impulse(const Vector3 &p_impulse);
 	void apply_impulse(const Vector3 &p_impulse, const Vector3 &p_position = Vector3());
+	void apply_impulse_at_position(const Vector3 &p_impulse, const Vector3 &p_global_position = Vector3());
 	void apply_torque_impulse(const Vector3 &p_impulse);
 
 	void apply_central_force(const Vector3 &p_force);
 	void apply_force(const Vector3 &p_force, const Vector3 &p_position = Vector3());
+	void apply_force_at_position(const Vector3 &p_force, const Vector3 &p_global_position = Vector3());
 	void apply_torque(const Vector3 &p_torque);
 
 	void add_constant_central_force(const Vector3 &p_force);

--- a/servers/physics_2d/direct_states/physics_direct_body_state_2d.cpp
+++ b/servers/physics_2d/direct_states/physics_direct_body_state_2d.cpp
@@ -89,9 +89,11 @@ void PhysicsDirectBodyState2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("apply_central_impulse", "impulse"), &PhysicsDirectBodyState2D::apply_central_impulse);
 	ClassDB::bind_method(D_METHOD("apply_torque_impulse", "impulse"), &PhysicsDirectBodyState2D::apply_torque_impulse);
 	ClassDB::bind_method(D_METHOD("apply_impulse", "impulse", "position"), &PhysicsDirectBodyState2D::apply_impulse, Vector2());
+	ClassDB::bind_method(D_METHOD("apply_impulse_at_position", "impulse", "global_position"), &PhysicsDirectBodyState2D::apply_impulse_at_position, Vector2());
 
 	ClassDB::bind_method(D_METHOD("apply_central_force", "force"), &PhysicsDirectBodyState2D::apply_central_force, Vector2());
 	ClassDB::bind_method(D_METHOD("apply_force", "force", "position"), &PhysicsDirectBodyState2D::apply_force, Vector2());
+	ClassDB::bind_method(D_METHOD("apply_force_at_position", "force", "global_position"), &PhysicsDirectBodyState2D::apply_force_at_position, Vector2());
 	ClassDB::bind_method(D_METHOD("apply_torque", "torque"), &PhysicsDirectBodyState2D::apply_torque);
 
 	ClassDB::bind_method(D_METHOD("add_constant_central_force", "force"), &PhysicsDirectBodyState2D::add_constant_central_force, Vector2());

--- a/servers/physics_2d/direct_states/physics_direct_body_state_2d.h
+++ b/servers/physics_2d/direct_states/physics_direct_body_state_2d.h
@@ -63,9 +63,11 @@ public:
 	virtual void apply_central_impulse(const Vector2 &p_impulse) = 0;
 	virtual void apply_torque_impulse(real_t p_torque) = 0;
 	virtual void apply_impulse(const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) = 0;
+	virtual void apply_impulse_at_position(const Vector2 &p_impulse, const Vector2 &p_global_position = Vector2()) = 0;
 
 	virtual void apply_central_force(const Vector2 &p_force) = 0;
 	virtual void apply_force(const Vector2 &p_force, const Vector2 &p_position = Vector2()) = 0;
+	virtual void apply_force_at_position(const Vector2 &p_force, const Vector2 &p_global_position = Vector2()) = 0;
 	virtual void apply_torque(real_t p_torque) = 0;
 
 	virtual void add_constant_central_force(const Vector2 &p_force) = 0;

--- a/servers/physics_2d/physics_server_2d.cpp
+++ b/servers/physics_2d/physics_server_2d.cpp
@@ -162,9 +162,11 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_apply_central_impulse", "body", "impulse"), &PhysicsServer2D::body_apply_central_impulse);
 	ClassDB::bind_method(D_METHOD("body_apply_torque_impulse", "body", "impulse"), &PhysicsServer2D::body_apply_torque_impulse);
 	ClassDB::bind_method(D_METHOD("body_apply_impulse", "body", "impulse", "position"), &PhysicsServer2D::body_apply_impulse, Vector2());
+	ClassDB::bind_method(D_METHOD("body_apply_impulse_at_position", "body", "impulse", "global_position"), &PhysicsServer2D::body_apply_impulse_at_position, Vector2());
 
 	ClassDB::bind_method(D_METHOD("body_apply_central_force", "body", "force"), &PhysicsServer2D::body_apply_central_force);
 	ClassDB::bind_method(D_METHOD("body_apply_force", "body", "force", "position"), &PhysicsServer2D::body_apply_force, Vector2());
+	ClassDB::bind_method(D_METHOD("body_apply_force_at_position", "body", "force", "global_position"), &PhysicsServer2D::body_apply_force_at_position, Vector2());
 	ClassDB::bind_method(D_METHOD("body_apply_torque", "body", "torque"), &PhysicsServer2D::body_apply_torque);
 
 	ClassDB::bind_method(D_METHOD("body_add_constant_central_force", "body", "force"), &PhysicsServer2D::body_add_constant_central_force);

--- a/servers/physics_2d/physics_server_2d.h
+++ b/servers/physics_2d/physics_server_2d.h
@@ -197,9 +197,11 @@ public:
 	virtual void body_apply_central_impulse(RID p_body, const Vector2 &p_impulse) = 0;
 	virtual void body_apply_torque_impulse(RID p_body, real_t p_torque) = 0;
 	virtual void body_apply_impulse(RID p_body, const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) = 0;
+	virtual void body_apply_impulse_at_position(RID p_body, const Vector2 &p_impulse, const Vector2 &p_global_position = Vector2()) = 0;
 
 	virtual void body_apply_central_force(RID p_body, const Vector2 &p_force) = 0;
 	virtual void body_apply_force(RID p_body, const Vector2 &p_force, const Vector2 &p_position = Vector2()) = 0;
+	virtual void body_apply_force_at_position(RID p_body, const Vector2 &p_force, const Vector2 &p_global_position = Vector2()) = 0;
 	virtual void body_apply_torque(RID p_body, real_t p_torque) = 0;
 
 	virtual void body_add_constant_central_force(RID p_body, const Vector2 &p_force) = 0;

--- a/servers/physics_2d/physics_server_2d_dummy.h
+++ b/servers/physics_2d/physics_server_2d_dummy.h
@@ -63,9 +63,11 @@ public:
 	virtual void apply_central_impulse(const Vector2 &p_impulse) override {}
 	virtual void apply_torque_impulse(real_t p_torque) override {}
 	virtual void apply_impulse(const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) override {}
+	virtual void apply_impulse_at_position(const Vector2 &p_impulse, const Vector2 &p_global_position = Vector2()) override {}
 
 	virtual void apply_central_force(const Vector2 &p_force) override {}
 	virtual void apply_force(const Vector2 &p_force, const Vector2 &p_position = Vector2()) override {}
+	virtual void apply_force_at_position(const Vector2 &p_force, const Vector2 &p_global_position = Vector2()) override {}
 	virtual void apply_torque(real_t p_torque) override {}
 
 	virtual void add_constant_central_force(const Vector2 &p_force) override {}
@@ -263,9 +265,11 @@ public:
 	virtual void body_apply_central_impulse(RID p_body, const Vector2 &p_impulse) override {}
 	virtual void body_apply_torque_impulse(RID p_body, real_t p_torque) override {}
 	virtual void body_apply_impulse(RID p_body, const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) override {}
+	virtual void body_apply_impulse_at_position(RID p_body, const Vector2 &p_impulse, const Vector2 &p_global_position = Vector2()) override {}
 
 	virtual void body_apply_central_force(RID p_body, const Vector2 &p_force) override {}
 	virtual void body_apply_force(RID p_body, const Vector2 &p_force, const Vector2 &p_position = Vector2()) override {}
+	virtual void body_apply_force_at_position(RID p_body, const Vector2 &p_force, const Vector2 &p_global_position = Vector2()) override {}
 	virtual void body_apply_torque(RID p_body, real_t p_torque) override {}
 
 	virtual void body_add_constant_central_force(RID p_body, const Vector2 &p_force) override {}

--- a/servers/physics_2d/physics_server_2d_extension.cpp
+++ b/servers/physics_2d/physics_server_2d_extension.cpp
@@ -75,10 +75,12 @@ void PhysicsDirectBodyState2DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_apply_central_impulse, "impulse");
 	GDVIRTUAL_BIND(_apply_impulse, "impulse", "position");
+	GDVIRTUAL_BIND(_apply_impulse_at_position, "impulse", "position");
 	GDVIRTUAL_BIND(_apply_torque_impulse, "impulse");
 
 	GDVIRTUAL_BIND(_apply_central_force, "force");
 	GDVIRTUAL_BIND(_apply_force, "force", "position");
+	GDVIRTUAL_BIND(_apply_force_at_position, "force", "global_position");
 	GDVIRTUAL_BIND(_apply_torque, "torque");
 
 	GDVIRTUAL_BIND(_add_constant_central_force, "force");
@@ -268,9 +270,11 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_body_apply_central_impulse, "body", "impulse");
 	GDVIRTUAL_BIND(_body_apply_torque_impulse, "body", "impulse");
 	GDVIRTUAL_BIND(_body_apply_impulse, "body", "impulse", "position");
+	GDVIRTUAL_BIND(_body_apply_impulse_at_position, "body", "impulse", "global_position");
 
 	GDVIRTUAL_BIND(_body_apply_central_force, "body", "force");
 	GDVIRTUAL_BIND(_body_apply_force, "body", "force", "position");
+	GDVIRTUAL_BIND(_body_apply_force_at_position, "body", "force", "global_position");
 	GDVIRTUAL_BIND(_body_apply_torque, "body", "torque");
 
 	GDVIRTUAL_BIND(_body_add_constant_central_force, "body", "force");

--- a/servers/physics_2d/physics_server_2d_extension.h
+++ b/servers/physics_2d/physics_server_2d_extension.h
@@ -68,9 +68,11 @@ public:
 	EXBIND1(apply_central_impulse, const Vector2 &)
 	EXBIND1(apply_torque_impulse, real_t)
 	EXBIND2(apply_impulse, const Vector2 &, const Vector2 &)
+	EXBIND2(apply_impulse_at_position, const Vector2 &, const Vector2 &)
 
 	EXBIND1(apply_central_force, const Vector2 &)
 	EXBIND2(apply_force, const Vector2 &, const Vector2 &)
+	EXBIND2(apply_force_at_position, const Vector2 &, const Vector2 &)
 	EXBIND1(apply_torque, real_t)
 
 	EXBIND1(add_constant_central_force, const Vector2 &)
@@ -343,9 +345,11 @@ public:
 	EXBIND2(body_apply_central_impulse, RID, const Vector2 &)
 	EXBIND2(body_apply_torque_impulse, RID, real_t)
 	EXBIND3(body_apply_impulse, RID, const Vector2 &, const Vector2 &)
+	EXBIND3(body_apply_impulse_at_position, RID, const Vector2 &, const Vector2 &)
 
 	EXBIND2(body_apply_central_force, RID, const Vector2 &)
 	EXBIND3(body_apply_force, RID, const Vector2 &, const Vector2 &)
+	EXBIND3(body_apply_force_at_position, RID, const Vector2 &, const Vector2 &)
 	EXBIND2(body_apply_torque, RID, real_t)
 
 	EXBIND2(body_add_constant_central_force, RID, const Vector2 &)

--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -225,9 +225,11 @@ public:
 	FUNC2(body_apply_central_impulse, RID, const Vector2 &);
 	FUNC2(body_apply_torque_impulse, RID, real_t);
 	FUNC3(body_apply_impulse, RID, const Vector2 &, const Vector2 &);
+	FUNC3(body_apply_impulse_at_position, RID, const Vector2 &, const Vector2 &);
 
 	FUNC2(body_apply_central_force, RID, const Vector2 &);
 	FUNC3(body_apply_force, RID, const Vector2 &, const Vector2 &);
+	FUNC3(body_apply_force_at_position, RID, const Vector2 &, const Vector2 &);
 	FUNC2(body_apply_torque, RID, real_t);
 
 	FUNC2(body_add_constant_central_force, RID, const Vector2 &);

--- a/servers/physics_3d/direct_states/physics_direct_body_state_3d.cpp
+++ b/servers/physics_3d/direct_states/physics_direct_body_state_3d.cpp
@@ -90,10 +90,12 @@ void PhysicsDirectBodyState3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("apply_central_impulse", "impulse"), &PhysicsDirectBodyState3D::apply_central_impulse, Vector3());
 	ClassDB::bind_method(D_METHOD("apply_impulse", "impulse", "position"), &PhysicsDirectBodyState3D::apply_impulse, Vector3());
+	ClassDB::bind_method(D_METHOD("apply_impulse_at_position", "impulse", "global_position"), &PhysicsDirectBodyState3D::apply_impulse_at_position, Vector3());
 	ClassDB::bind_method(D_METHOD("apply_torque_impulse", "impulse"), &PhysicsDirectBodyState3D::apply_torque_impulse);
 
 	ClassDB::bind_method(D_METHOD("apply_central_force", "force"), &PhysicsDirectBodyState3D::apply_central_force, Vector3());
 	ClassDB::bind_method(D_METHOD("apply_force", "force", "position"), &PhysicsDirectBodyState3D::apply_force, Vector3());
+	ClassDB::bind_method(D_METHOD("apply_force_at_position", "force", "global_position"), &PhysicsDirectBodyState3D::apply_force_at_position, Vector3());
 	ClassDB::bind_method(D_METHOD("apply_torque", "torque"), &PhysicsDirectBodyState3D::apply_torque);
 
 	ClassDB::bind_method(D_METHOD("add_constant_central_force", "force"), &PhysicsDirectBodyState3D::add_constant_central_force, Vector3());

--- a/servers/physics_3d/direct_states/physics_direct_body_state_3d.h
+++ b/servers/physics_3d/direct_states/physics_direct_body_state_3d.h
@@ -64,10 +64,12 @@ public:
 
 	virtual void apply_central_impulse(const Vector3 &p_impulse) = 0;
 	virtual void apply_impulse(const Vector3 &p_impulse, const Vector3 &p_position = Vector3()) = 0;
+	virtual void apply_impulse_at_position(const Vector3 &p_impulse, const Vector3 &p_global_position = Vector3()) = 0;
 	virtual void apply_torque_impulse(const Vector3 &p_impulse) = 0;
 
 	virtual void apply_central_force(const Vector3 &p_force) = 0;
 	virtual void apply_force(const Vector3 &p_force, const Vector3 &p_position = Vector3()) = 0;
+	virtual void apply_force_at_position(const Vector3 &p_force, const Vector3 &p_global_position = Vector3()) = 0;
 	virtual void apply_torque(const Vector3 &p_torque) = 0;
 
 	virtual void add_constant_central_force(const Vector3 &p_force) = 0;

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -188,10 +188,12 @@ void PhysicsServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("body_apply_central_impulse", "body", "impulse"), &PhysicsServer3D::body_apply_central_impulse);
 	ClassDB::bind_method(D_METHOD("body_apply_impulse", "body", "impulse", "position"), &PhysicsServer3D::body_apply_impulse, Vector3());
+	ClassDB::bind_method(D_METHOD("body_apply_impulse_at_position", "body", "impulse", "global_position"), &PhysicsServer3D::body_apply_impulse_at_position, Vector3());
 	ClassDB::bind_method(D_METHOD("body_apply_torque_impulse", "body", "impulse"), &PhysicsServer3D::body_apply_torque_impulse);
 
 	ClassDB::bind_method(D_METHOD("body_apply_central_force", "body", "force"), &PhysicsServer3D::body_apply_central_force);
 	ClassDB::bind_method(D_METHOD("body_apply_force", "body", "force", "position"), &PhysicsServer3D::body_apply_force, Vector3());
+	ClassDB::bind_method(D_METHOD("body_apply_force_at_position", "body", "force", "global_position"), &PhysicsServer3D::body_apply_force_at_position, Vector3());
 	ClassDB::bind_method(D_METHOD("body_apply_torque", "body", "torque"), &PhysicsServer3D::body_apply_torque);
 
 	ClassDB::bind_method(D_METHOD("body_add_constant_central_force", "body", "force"), &PhysicsServer3D::body_add_constant_central_force);

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -204,10 +204,12 @@ public:
 
 	virtual void body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) = 0;
 	virtual void body_apply_impulse(RID p_body, const Vector3 &p_impulse, const Vector3 &p_position = Vector3()) = 0;
+	virtual void body_apply_impulse_at_position(RID p_body, const Vector3 &p_impulse, const Vector3 &p_global_position = Vector3()) = 0;
 	virtual void body_apply_torque_impulse(RID p_body, const Vector3 &p_impulse) = 0;
 
 	virtual void body_apply_central_force(RID p_body, const Vector3 &p_force) = 0;
 	virtual void body_apply_force(RID p_body, const Vector3 &p_force, const Vector3 &p_position = Vector3()) = 0;
+	virtual void body_apply_force_at_position(RID p_body, const Vector3 &p_force, const Vector3 &p_global_position = Vector3()) = 0;
 	virtual void body_apply_torque(RID p_body, const Vector3 &p_torque) = 0;
 
 	virtual void body_add_constant_central_force(RID p_body, const Vector3 &p_force) = 0;

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -62,10 +62,12 @@ public:
 
 	virtual void apply_central_impulse(const Vector3 &p_impulse) override {}
 	virtual void apply_impulse(const Vector3 &p_impulse, const Vector3 &p_position = Vector3()) override {}
+	virtual void apply_impulse_at_position(const Vector3 &p_impulse, const Vector3 &p_global_position = Vector3()) override {}
 	virtual void apply_torque_impulse(const Vector3 &p_impulse) override {}
 
 	virtual void apply_central_force(const Vector3 &p_force) override {}
 	virtual void apply_force(const Vector3 &p_force, const Vector3 &p_position = Vector3()) override {}
+	virtual void apply_force_at_position(const Vector3 &p_force, const Vector3 &p_global_position = Vector3()) override {}
 	virtual void apply_torque(const Vector3 &p_torque) override {}
 
 	virtual void add_constant_central_force(const Vector3 &p_force) override {}
@@ -265,10 +267,12 @@ public:
 
 	virtual void body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) override {}
 	virtual void body_apply_impulse(RID p_body, const Vector3 &p_impulse, const Vector3 &p_position = Vector3()) override {}
+	virtual void body_apply_impulse_at_position(RID p_body, const Vector3 &p_impulse, const Vector3 &p_global_position = Vector3()) override {}
 	virtual void body_apply_torque_impulse(RID p_body, const Vector3 &p_impulse) override {}
 
 	virtual void body_apply_central_force(RID p_body, const Vector3 &p_force) override {}
 	virtual void body_apply_force(RID p_body, const Vector3 &p_force, const Vector3 &p_position = Vector3()) override {}
+	virtual void body_apply_force_at_position(RID p_body, const Vector3 &p_force, const Vector3 &p_global_position = Vector3()) override {}
 	virtual void body_apply_torque(RID p_body, const Vector3 &p_torque) override {}
 
 	virtual void body_add_constant_central_force(RID p_body, const Vector3 &p_force) override {}

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -79,10 +79,12 @@ void PhysicsDirectBodyState3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_apply_central_impulse, "impulse");
 	GDVIRTUAL_BIND(_apply_impulse, "impulse", "position");
+	GDVIRTUAL_BIND(_apply_impulse_at_position, "impulse", "global_position");
 	GDVIRTUAL_BIND(_apply_torque_impulse, "impulse");
 
 	GDVIRTUAL_BIND(_apply_central_force, "force");
 	GDVIRTUAL_BIND(_apply_force, "force", "position");
+	GDVIRTUAL_BIND(_apply_force_at_position, "force", "global_position");
 	GDVIRTUAL_BIND(_apply_torque, "torque");
 
 	GDVIRTUAL_BIND(_add_constant_central_force, "force");
@@ -268,10 +270,12 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_body_apply_central_impulse, "body", "impulse");
 	GDVIRTUAL_BIND(_body_apply_impulse, "body", "impulse", "position");
+	GDVIRTUAL_BIND(_body_apply_impulse_at_position, "body", "impulse", "global_position");
 	GDVIRTUAL_BIND(_body_apply_torque_impulse, "body", "impulse");
 
 	GDVIRTUAL_BIND(_body_apply_central_force, "body", "force");
 	GDVIRTUAL_BIND(_body_apply_force, "body", "force", "position");
+	GDVIRTUAL_BIND(_body_apply_force_at_position, "body", "force", "position");
 	GDVIRTUAL_BIND(_body_apply_torque, "body", "torque");
 
 	GDVIRTUAL_BIND(_body_add_constant_central_force, "body", "force");

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -69,10 +69,12 @@ public:
 
 	EXBIND1(apply_central_impulse, const Vector3 &)
 	EXBIND2(apply_impulse, const Vector3 &, const Vector3 &)
+	EXBIND2(apply_impulse_at_position, const Vector3 &, const Vector3 &)
 	EXBIND1(apply_torque_impulse, const Vector3 &)
 
 	EXBIND1(apply_central_force, const Vector3 &)
 	EXBIND2(apply_force, const Vector3 &, const Vector3 &)
+	EXBIND2(apply_force_at_position, const Vector3 &, const Vector3 &)
 	EXBIND1(apply_torque, const Vector3 &)
 
 	EXBIND1(add_constant_central_force, const Vector3 &)
@@ -339,10 +341,12 @@ public:
 
 	EXBIND2(body_apply_central_impulse, RID, const Vector3 &)
 	EXBIND3(body_apply_impulse, RID, const Vector3 &, const Vector3 &)
+	EXBIND3(body_apply_impulse_at_position, RID, const Vector3 &, const Vector3 &)
 	EXBIND2(body_apply_torque_impulse, RID, const Vector3 &)
 
 	EXBIND2(body_apply_central_force, RID, const Vector3 &)
 	EXBIND3(body_apply_force, RID, const Vector3 &, const Vector3 &)
+	EXBIND3(body_apply_force_at_position, RID, const Vector3 &, const Vector3 &)
 	EXBIND2(body_apply_torque, RID, const Vector3 &)
 
 	EXBIND2(body_add_constant_central_force, RID, const Vector3 &)

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -227,9 +227,11 @@ public:
 	FUNC2(body_apply_torque_impulse, RID, const Vector3 &);
 	FUNC2(body_apply_central_impulse, RID, const Vector3 &);
 	FUNC3(body_apply_impulse, RID, const Vector3 &, const Vector3 &);
+	FUNC3(body_apply_impulse_at_position, RID, const Vector3 &, const Vector3 &);
 
 	FUNC2(body_apply_central_force, RID, const Vector3 &);
 	FUNC3(body_apply_force, RID, const Vector3 &, const Vector3 &);
+	FUNC3(body_apply_force_at_position, RID, const Vector3 &, const Vector3 &);
 	FUNC2(body_apply_torque, RID, const Vector3 &);
 
 	FUNC3(soft_body_apply_point_impulse, RID, int, const Vector3 &);


### PR DESCRIPTION
# What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/12115

Adds physics methods for `apply_force_at_position(force, world_pos)` and `apply_impulse_at_position(force, world_pos)`.

Which uses a **global coordinate position** to say where the force is applied.
They represent a more common use-case where you want to apply a force to a global position.

For example, you can apply the force at a given node's position that is attached to the player's body without having to use subtract the rigidbodies global_position.
So _apply_force(force, (global_point - global_position) )_ == _apply_force_at_position(force, global_point)_

https://github.com/user-attachments/assets/3e2d2628-c6a8-4ac6-a94f-71996c0b7dfe

https://github.com/user-attachments/assets/2d0e2358-0023-4c79-b72b-fee2048c6d04


# Additional information

The **reason they are being added** is to not change/break the behavior of the already in use `apply_force` and `apply_impulse` which can take an optional global offset value for the position.
So this PR **will not break compatibility.**

Using them, it is now possible to apply forces at child objects position's without any hassle
```gdscript
apply_force_at_position(-%ForceLeft.global_basis.y * FORCE, %ForceLeft.global_position)
```
Previously, to get the same behavior you'd need to use
```gdscript
var body_offset := %ForceLeft.global_position - global_position
apply_force(-%ForceLeft.global_basis.y * FORCE, body_offset)
```
Which is **more confusing** and can lead to a lot of errors if you don't understand what a global offset means.

_(My first time using godot, years ago, I read it wrong and thought it was a local offset in the same sense as a local position, so the offset would be relative to the body's rotation. Made to lose two days thinking my math was wrong and redoing stuff)_

---
I've made a test MRP you can play around to check if everything is working as it should. 
From my simple tests, it seems to be okay.
[PR_MRP_physics_apply_at_position.zip](https://github.com/user-attachments/files/19560234/PR_MRP_physics_apply_at_position.zip)

Applying forces at the red cubes when pressing left/right and space 

https://github.com/user-attachments/assets/3477e1ab-c4dd-4bf1-9d5c-0951c4bbf45b

---
For reference, only Godot seems to use this global offset approach. 
With all other engines I've researched using global coordinates instead. 
This also include Jolt's own internals with AddForce(force, global_coordinate)

Edit: Force pushed changes, Jolt parameters now casts to JPH::RVec3 to not break tests.