### PR TITLE
Fix `get_collision_exceptions` spamming errors after body is freed

### DIFF
--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -149,6 +149,10 @@ TypedArray<PhysicsBody2D> PhysicsBody2D::get_collision_exceptions() {
 	Array ret;
 	for (const RID &body : exceptions) {
 		ObjectID instance_id = PhysicsServer2D::get_singleton()->body_get_object_instance_id(body);
+		if (instance_id.is_null()) {
+			PhysicsServer2D::get_singleton()->body_remove_collision_exception(get_rid(), body);
+			continue;
+		}
 		Object *obj = ObjectDB::get_instance(instance_id);
 		PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(obj);
 		ret.append(physics_body);

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -62,6 +62,10 @@ TypedArray<PhysicsBody3D> PhysicsBody3D::get_collision_exceptions() {
 	Array ret;
 	for (const RID &body : exceptions) {
 		ObjectID instance_id = PhysicsServer3D::get_singleton()->body_get_object_instance_id(body);
+		if (instance_id.is_null()) {
+			PhysicsServer3D::get_singleton()->body_remove_collision_exception(get_rid(), body);
+			continue;
+		}
 		Object *obj = ObjectDB::get_instance(instance_id);
 		PhysicsBody3D *physics_body = Object::cast_to<PhysicsBody3D>(obj);
 		ret.append(physics_body);


### PR DESCRIPTION
Fixes #53520

A single error will still be produced at https://github.com/godotengine/godot/blob/master/modules/godot_physics_2d/godot_physics_server_2d.cpp#L690 but at least it stops infinite errors from happening. It also prevents the null object from showing up in the array returned to gdscript land.