### PR TITLE
AudioStreamPlayers can now send audio to multiple buses

### DIFF
--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -70,6 +70,8 @@ private:
 	bool _is_active() const;
 
 	StringName _get_actual_bus();
+	HashMap<StringName, Vector<AudioFrame>> _get_bus_vectors();
+	
 	void _update_panning();
 
 	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer2D *>(self)->force_update_panning = true; }
@@ -117,6 +119,13 @@ public:
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;
+	
+	void remove_bus_route(const StringName &p_bus);
+	float get_bus_volume_linear(const StringName &p_bus);
+	float get_bus_volume_db(const StringName &p_bus);
+	void set_bus_volume_linear(const StringName &p_bus, float p_volume_linear);	
+	void set_bus_volume_db(const StringName &p_bus, float p_volume_db);		
+	Dictionary get_buses_as_dictionary();
 
 	void set_autoplay(bool p_enable);
 	bool is_autoplay_enabled() const;

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -91,6 +91,8 @@ private:
 	void _set_playing(bool p_enable);
 	bool _is_active() const;
 	StringName _get_actual_bus();
+	HashMap<StringName, Vector<AudioFrame>> _get_bus_vectors(Vector<AudioFrame> output_volume_vector);	
+
 #ifndef PHYSICS_3D_DISABLED
 	Area3D *_get_overriding_area();
 #endif // PHYSICS_3D_DISABLED
@@ -161,6 +163,13 @@ public:
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;
+
+	void remove_bus_route(const StringName &p_bus);
+	float get_bus_volume_linear(const StringName &p_bus);
+	float get_bus_volume_db(const StringName &p_bus);
+	void set_bus_volume_linear(const StringName &p_bus, float p_volume_linear);	
+	void set_bus_volume_db(const StringName &p_bus, float p_volume_db);		
+	Dictionary get_buses_as_dictionary();
 
 	void set_max_polyphony(int p_max_polyphony);
 	int get_max_polyphony() const;

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -57,6 +57,7 @@ private:
 	bool _is_active() const;
 
 	Vector<AudioFrame> _get_volume_vector();
+	HashMap<StringName, Vector<AudioFrame>> _get_bus_vectors();
 
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
@@ -78,6 +79,13 @@ public:
 
 	void set_volume_db(float p_volume);
 	float get_volume_db() const;
+	
+	void remove_bus_route(const StringName &p_bus);
+	float get_bus_volume_linear(const StringName &p_bus);
+	float get_bus_volume_db(const StringName &p_bus);
+	void set_bus_volume_linear(const StringName &p_bus, float p_volume_linear);	
+	void set_bus_volume_db(const StringName &p_bus, float p_volume_db);	
+	Dictionary get_buses_as_dictionary();
 
 	void set_volume_linear(float p_volume);
 	float get_volume_linear() const;

--- a/scene/audio/audio_stream_player_internal.h
+++ b/scene/audio/audio_stream_player_internal.h
@@ -65,6 +65,10 @@ private:
 		return (AudioServer::get_singleton()->get_default_playback_type() == AudioServer::PlaybackType::PLAYBACK_TYPE_SAMPLE && get_playback_type() == AudioServer::PlaybackType::PLAYBACK_TYPE_DEFAULT) || get_playback_type() == AudioServer::PlaybackType::PLAYBACK_TYPE_SAMPLE;
 	}
 
+protected:
+	HashMap<StringName, float> bus_volumes;
+	Vector<StringName> active_buses;
+
 public:
 	Vector<Ref<AudioStreamPlayback>> stream_playbacks;
 	Ref<AudioStream> stream;
@@ -72,11 +76,17 @@ public:
 	SafeFlag active;
 
 	float pitch_scale = 1.0;
-	float volume_db = 0.0;
+	float volume_db = 0.0;	
 	bool autoplay = false;
-	StringName bus;
+	StringName bus;	// DEPRECATING...
 	int max_polyphony = 1;
-
+			
+	void remove_bus_route(const StringName &p_bus);
+	void set_bus_volume(const StringName &p_bus, float p_volume);
+	float get_bus_volume(const StringName &p_bus);
+	HashMap<StringName, float> get_bus_volumes();
+	Dictionary get_buses_as_dictionary();
+	HashMap<StringName, Vector<AudioFrame>> get_bus_vectors(Vector<AudioFrame> volume_vector);
 	void process();
 	void ensure_playback_limit();
 


### PR DESCRIPTION
AudioStreamPlayers can now send audio to multiple buses. Exposed functions to gdscript for set_bus_volume(bus_name, volume) and get_bus_volume(bus_name) and get buses as dictionary for AudioStreamPlayer,  AudioStreamPlayer2D, and AudioStreamPlayer3D
