### PR TITLE
Organize ifdefs for disabling navigation, physics, and XR

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -977,8 +977,8 @@ if env.editor_build:
 
 if env["disable_3d"]:
     env.Append(CPPDEFINES=["_3D_DISABLED"])
-    env["disable_physics_3d"] = True
     env["disable_navigation_3d"] = True
+    env["disable_physics_3d"] = True
     env["disable_xr"] = True
 if env["disable_advanced_gui"]:
     env.Append(CPPDEFINES=["ADVANCED_GUI_DISABLED"])

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -82,23 +82,26 @@
 #include "servers/navigation_server_2d.h"
 #include "servers/navigation_server_2d_dummy.h"
 #endif // NAVIGATION_2D_DISABLED
+
 #ifndef PHYSICS_2D_DISABLED
 #include "servers/physics_server_2d.h"
 #include "servers/physics_server_2d_dummy.h"
 #endif // PHYSICS_2D_DISABLED
 
 // 3D
-#ifndef PHYSICS_3D_DISABLED
-#include "servers/physics_server_3d.h"
-#include "servers/physics_server_3d_dummy.h"
-#endif // PHYSICS_3D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
 #include "servers/navigation_server_3d.h"
 #include "servers/navigation_server_3d_dummy.h"
 #endif // NAVIGATION_3D_DISABLED
-#ifndef _3D_DISABLED
+
+#ifndef PHYSICS_3D_DISABLED
+#include "servers/physics_server_3d.h"
+#include "servers/physics_server_3d_dummy.h"
+#endif // PHYSICS_3D_DISABLED
+
+#ifndef XR_DISABLED
 #include "servers/xr_server.h"
-#endif // _3D_DISABLED
+#endif // XR_DISABLED
 
 #ifdef TESTS_ENABLED
 #include "tests/test_main.h"

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -51,9 +51,9 @@
 #include "main/main.h"
 #include "servers/rendering_server.h"
 
-#ifndef _3D_DISABLED
+#ifndef XR_DISABLED
 #include "servers/xr_server.h"
-#endif // _3D_DISABLED
+#endif // XR_DISABLED
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_settings.h"

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1687,6 +1687,7 @@ void CanvasItem::set_clip_children_mode(ClipChildrenMode p_clip_mode) {
 
 	RS::get_singleton()->canvas_item_set_canvas_group_mode(get_canvas_item(), RS::CanvasGroupMode(clip_children_mode));
 }
+
 CanvasItem::ClipChildrenMode CanvasItem::get_clip_children_mode() const {
 	ERR_READ_THREAD_GUARD_V(CLIP_CHILDREN_DISABLED);
 	return clip_children_mode;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -35,13 +35,14 @@
 #include "core/io/resource_loader.h"
 #include "core/templates/local_vector.h"
 #include "scene/2d/node_2d.h"
-#ifndef _3D_DISABLED
-#include "scene/3d/node_3d.h"
-#endif // _3D_DISABLED
 #include "scene/gui/control.h"
 #include "scene/main/instance_placeholder.h"
 #include "scene/main/missing_node.h"
 #include "scene/property_utils.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/node_3d.h"
+#endif // _3D_DISABLED
 
 #define PACKED_SCENE_VERSION 3
 

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -42,20 +42,6 @@ RID World2D::get_canvas() const {
 	return canvas;
 }
 
-#ifndef PHYSICS_2D_DISABLED
-RID World2D::get_space() const {
-	if (space.is_null()) {
-		space = PhysicsServer2D::get_singleton()->space_create();
-		PhysicsServer2D::get_singleton()->space_set_active(space, true);
-		PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY, GLOBAL_GET("physics/2d/default_gravity"));
-		PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY_VECTOR, GLOBAL_GET("physics/2d/default_gravity_vector"));
-		PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_LINEAR_DAMP, GLOBAL_GET("physics/2d/default_linear_damp"));
-		PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_ANGULAR_DAMP, GLOBAL_GET("physics/2d/default_angular_damp"));
-	}
-	return space;
-}
-#endif // PHYSICS_2D_DISABLED
-
 #ifndef NAVIGATION_2D_DISABLED
 RID World2D::get_navigation_map() const {
 	if (navigation_map.is_null()) {
@@ -71,6 +57,18 @@ RID World2D::get_navigation_map() const {
 #endif // NAVIGATION_2D_DISABLED
 
 #ifndef PHYSICS_2D_DISABLED
+RID World2D::get_space() const {
+	if (space.is_null()) {
+		space = PhysicsServer2D::get_singleton()->space_create();
+		PhysicsServer2D::get_singleton()->space_set_active(space, true);
+		PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY, GLOBAL_GET("physics/2d/default_gravity"));
+		PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY_VECTOR, GLOBAL_GET("physics/2d/default_gravity_vector"));
+		PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_LINEAR_DAMP, GLOBAL_GET("physics/2d/default_linear_damp"));
+		PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_ANGULAR_DAMP, GLOBAL_GET("physics/2d/default_angular_damp"));
+	}
+	return space;
+}
+
 PhysicsDirectSpaceState2D *World2D::get_direct_space_state() {
 	return PhysicsServer2D::get_singleton()->space_get_direct_state(get_space());
 }
@@ -78,19 +76,16 @@ PhysicsDirectSpaceState2D *World2D::get_direct_space_state() {
 
 void World2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_canvas"), &World2D::get_canvas);
+	ADD_PROPERTY(PropertyInfo(Variant::RID, "canvas", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_canvas");
+
 #ifndef NAVIGATION_2D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_navigation_map"), &World2D::get_navigation_map);
+	ADD_PROPERTY(PropertyInfo(Variant::RID, "navigation_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_navigation_map");
 #endif // NAVIGATION_2D_DISABLED
+
 #ifndef PHYSICS_2D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_space"), &World2D::get_space);
 	ClassDB::bind_method(D_METHOD("get_direct_space_state"), &World2D::get_direct_space_state);
-#endif // PHYSICS_2D_DISABLED
-
-	ADD_PROPERTY(PropertyInfo(Variant::RID, "canvas", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_canvas");
-#ifndef NAVIGATION_2D_DISABLED
-	ADD_PROPERTY(PropertyInfo(Variant::RID, "navigation_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_navigation_map");
-#endif // NAVIGATION_2D_DISABLED
-#ifndef PHYSICS_2D_DISABLED
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_space");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "direct_space_state", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsDirectSpaceState2D", PROPERTY_USAGE_NONE), "", "get_direct_space_state");
 #endif // PHYSICS_2D_DISABLED
@@ -110,22 +105,19 @@ World2D::World2D() {
 
 World2D::~World2D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-#ifndef PHYSICS_2D_DISABLED
-	ERR_FAIL_NULL(PhysicsServer2D::get_singleton());
-#endif // PHYSICS_2D_DISABLED
+	RenderingServer::get_singleton()->free(canvas);
+
 #ifndef NAVIGATION_2D_DISABLED
 	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
-#endif // NAVIGATION_2D_DISABLED
-
-	RenderingServer::get_singleton()->free(canvas);
-#ifndef PHYSICS_2D_DISABLED
-	if (space.is_valid()) {
-		PhysicsServer2D::get_singleton()->free(space);
-	}
-#endif // PHYSICS_2D_DISABLED
-#ifndef NAVIGATION_2D_DISABLED
 	if (navigation_map.is_valid()) {
 		NavigationServer2D::get_singleton()->free(navigation_map);
 	}
 #endif // NAVIGATION_2D_DISABLED
+
+#ifndef PHYSICS_2D_DISABLED
+	ERR_FAIL_NULL(PhysicsServer2D::get_singleton());
+	if (space.is_valid()) {
+		PhysicsServer2D::get_singleton()->free(space);
+	}
+#endif // PHYSICS_2D_DISABLED
 }

--- a/scene/resources/world_2d.h
+++ b/scene/resources/world_2d.h
@@ -44,10 +44,12 @@ class World2D : public Resource {
 	GDCLASS(World2D, Resource);
 
 	RID canvas;
-	mutable RID space;
 #ifndef NAVIGATION_2D_DISABLED
 	mutable RID navigation_map;
 #endif // NAVIGATION_2D_DISABLED
+#ifndef PHYSICS_2D_DISABLED
+	mutable RID space;
+#endif // PHYSICS_2D_DISABLED
 
 	HashSet<Viewport *> viewports;
 

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -258,6 +258,12 @@ void register_server_types() {
 
 	ServersDebugger::initialize();
 
+#ifndef NAVIGATION_2D_DISABLED
+	GDREGISTER_ABSTRACT_CLASS(NavigationServer2D);
+	GDREGISTER_CLASS(NavigationPathQueryParameters2D);
+	GDREGISTER_CLASS(NavigationPathQueryResult2D);
+#endif // NAVIGATION_2D_DISABLED
+
 #ifndef PHYSICS_2D_DISABLED
 	// Physics 2D
 	GDREGISTER_CLASS(PhysicsServer2DManager);
@@ -286,11 +292,11 @@ void register_server_types() {
 	PhysicsServer2DManager::get_singleton()->register_server("Dummy", callable_mp_static(_create_dummy_physics_server_2d));
 #endif // PHYSICS_2D_DISABLED
 
-#ifndef NAVIGATION_2D_DISABLED
-	GDREGISTER_ABSTRACT_CLASS(NavigationServer2D);
-	GDREGISTER_CLASS(NavigationPathQueryParameters2D);
-	GDREGISTER_CLASS(NavigationPathQueryResult2D);
-#endif // NAVIGATION_2D_DISABLED
+#ifndef NAVIGATION_3D_DISABLED
+	GDREGISTER_ABSTRACT_CLASS(NavigationServer3D);
+	GDREGISTER_CLASS(NavigationPathQueryParameters3D);
+	GDREGISTER_CLASS(NavigationPathQueryResult3D);
+#endif // NAVIGATION_3D_DISABLED
 
 #ifndef PHYSICS_3D_DISABLED
 	// Physics 3D
@@ -336,12 +342,6 @@ void register_server_types() {
 	GDREGISTER_ABSTRACT_CLASS(XRTracker);
 #endif // XR_DISABLED
 
-#ifndef NAVIGATION_3D_DISABLED
-	GDREGISTER_ABSTRACT_CLASS(NavigationServer3D);
-	GDREGISTER_CLASS(NavigationPathQueryParameters3D);
-	GDREGISTER_CLASS(NavigationPathQueryResult3D);
-#endif // NAVIGATION_3D_DISABLED
-
 	writer_mjpeg = memnew(MovieWriterMJPEG);
 	MovieWriter::add_writer(writer_mjpeg);
 
@@ -369,14 +369,13 @@ void register_server_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("CameraServer", CameraServer::get_singleton(), "CameraServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("DisplayServer", DisplayServer::get_singleton(), "DisplayServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NativeMenu", NativeMenu::get_singleton(), "NativeMenu"));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("RenderingServer", RenderingServer::get_singleton(), "RenderingServer"));
 #ifndef NAVIGATION_2D_DISABLED
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer2D", NavigationServer2D::get_singleton(), "NavigationServer2D"));
 #endif // NAVIGATION_2D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer3D", NavigationServer3D::get_singleton(), "NavigationServer3D"));
 #endif // NAVIGATION_3D_DISABLED
-	Engine::get_singleton()->add_singleton(Engine::Singleton("RenderingServer", RenderingServer::get_singleton(), "RenderingServer"));
-
 #ifndef PHYSICS_2D_DISABLED
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer2D", PhysicsServer2D::get_singleton(), "PhysicsServer2D"));
 #endif // PHYSICS_2D_DISABLED

--- a/servers/rendering/renderer_compositor.cpp
+++ b/servers/rendering/renderer_compositor.cpp
@@ -31,7 +31,10 @@
 #include "renderer_compositor.h"
 
 #include "core/config/project_settings.h"
+
+#ifndef XR_DISABLED
 #include "servers/xr_server.h"
+#endif // XR_DISABLED
 
 RendererCompositor *RendererCompositor::singleton = nullptr;
 

--- a/servers/rendering/renderer_rd/effects/vrs.cpp
+++ b/servers/rendering/renderer_rd/effects/vrs.cpp
@@ -33,9 +33,9 @@
 #include "../storage_rd/texture_storage.h"
 #include "../uniform_set_cache_rd.h"
 
-#ifndef _3D_DISABLED
+#ifndef XR_DISABLED
 #include "servers/xr_server.h"
-#endif // _3D_DISABLED
+#endif // XR_DISABLED
 
 using namespace RendererRD;
 


### PR DESCRIPTION
This PR has a few misc changes to the order of includes, and in some cases the order of executed code (such as `Engine::get_singleton()->add_singleton`), which should not change behavior in any meaningful way (if it does, that's a bug). This is a minor cleanup on top of some recent refactors.

This PR:
- Organizes related code to avoid having more `#ifdef` and `#ifndef` directives than necessary, such as in World2D.
- Tries to make the order of these new directives consistent. The order shouldn't matter, so alphabetical: **n**avigation, then **p**hysics, then **x**r, and that also seems to be the dominant order already present in master.
    - Note: If the order does matter somewhere, we should add a comment to explicitly note that.
- Fixes a few cases where `_3D_DISABLED` was used in place of `XR_DISABLED`.