### PR TITLE
Move notification handler logic from `GDCLASS` to `GDCLASS_RECEIVE_NOTIFICATIONS`, making receiving notifications explicit.

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -119,6 +119,7 @@ protected:
 	// through EditorFileSystem::_update_script_documentation when updated directly on disk.
 	virtual bool editor_can_reload_from_file() override { return false; }
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	friend class PlaceHolderScriptInstance;

--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -114,6 +114,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -204,6 +204,7 @@ class AnimationBezierTrackEdit : public Control {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static float get_bezier_key_value(Array p_bezier_key_array);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -242,6 +242,7 @@ class AnimationTimelineEdit : public Range {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	int get_name_limit() const;
@@ -366,6 +367,7 @@ class AnimationMarkerEdit : public Control {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
@@ -489,6 +491,7 @@ class AnimationTrackEdit : public Control {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
@@ -560,6 +563,7 @@ class AnimationTrackEditGroup : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
@@ -865,6 +869,7 @@ class AnimationTrackEditor : public VBoxContainer {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	// Public for use with callable_mp.

--- a/editor/audio_stream_preview.h
+++ b/editor/audio_stream_preview.h
@@ -94,6 +94,7 @@ class AudioStreamPreviewGenerator : public Node {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -55,6 +55,7 @@ class GotoLinePopup : public PopupPanel {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void _input_from_window(const Ref<InputEvent> &p_event) override;
 
 public:
@@ -122,6 +123,7 @@ class FindReplaceBar : public HBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void _update_flags(bool p_direction_backwards);
 
@@ -232,6 +234,7 @@ protected:
 	void _text_changed();
 	void _line_col_changed();
 	void _notification(int);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	bool is_warnings_panel_opened = false;

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -159,6 +159,7 @@ private:
 protected:
 	virtual void _post_popup() override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -261,6 +262,7 @@ class ConnectionsDock : public VBoxContainer {
 protected:
 	void _connect_pressed();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -104,6 +104,7 @@ class CreateDialog : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	void _save_and_update_favorite_list();

--- a/editor/debugger/debug_adapter/debug_adapter_server.h
+++ b/editor/debugger/debug_adapter/debug_adapter_server.h
@@ -46,6 +46,7 @@ class DebugAdapterServer : public EditorPlugin {
 
 private:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static int port_override;

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -78,6 +78,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -162,6 +162,7 @@ protected:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -82,6 +82,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	enum Button {

--- a/editor/debugger/editor_expression_evaluator.h
+++ b/editor/debugger/editor_expression_evaluator.h
@@ -64,6 +64,7 @@ protected:
 	ScriptEditorDebugger *editor_debugger = nullptr;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void on_start();

--- a/editor/debugger/editor_performance_profiler.h
+++ b/editor/debugger/editor_performance_profiler.h
@@ -79,6 +79,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void reset();

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -169,6 +169,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/debugger/editor_visual_profiler.h
+++ b/editor/debugger/editor_visual_profiler.h
@@ -135,6 +135,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -283,6 +283,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/editor_about.h
+++ b/editor/editor_about.h
@@ -58,6 +58,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	EditorAbout();

--- a/editor/editor_asset_installer.h
+++ b/editor/editor_asset_installer.h
@@ -95,6 +95,7 @@ class EditorAssetInstaller : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void open_asset(const String &p_path, bool p_autoskip_toplevel = false);

--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -126,6 +126,7 @@ class EditorAudioBus : public PanelContainer {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void update_bus();
@@ -145,6 +146,7 @@ class EditorAudioBusDrop : public Control {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 };
 
 class EditorAudioBuses : public VBoxContainer {
@@ -196,6 +198,7 @@ class EditorAudioBuses : public VBoxContainer {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void open_layout(const String &p_path);
@@ -258,6 +261,7 @@ private:
 
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _draw_audio_notches();
 };
 

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -100,6 +100,7 @@ class EditorAutoloadSettings : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/editor_build_profile.h
+++ b/editor/editor_build_profile.h
@@ -177,6 +177,7 @@ class EditorBuildProfileManager : public AcceptDialog {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	Ref<EditorBuildProfile> get_current_profile();

--- a/editor/editor_command_palette.h
+++ b/editor/editor_command_palette.h
@@ -88,6 +88,7 @@ class EditorCommandPalette : public ConfirmationDialog {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void open_popup();

--- a/editor/editor_dock_manager.h
+++ b/editor/editor_dock_manager.h
@@ -197,6 +197,7 @@ class DockContextPopup : public PopupPanel {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void select_current_dock_in_dock_slot(int p_dock_slot);

--- a/editor/editor_feature_profile.h
+++ b/editor/editor_feature_profile.h
@@ -174,6 +174,7 @@ class EditorFeatureProfileManager : public AcceptDialog {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	Ref<EditorFeatureProfile> get_current_profile();

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -380,6 +380,7 @@ class EditorFileSystem : public Node {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -66,6 +66,7 @@ class FindBar : public HBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	bool _search(bool p_search_previous = false);
 
@@ -223,6 +224,7 @@ protected:
 	virtual void _update_theme_item_cache() override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -346,6 +348,7 @@ class EditorHelpBit : public VBoxContainer {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void parse_symbol(const String &p_symbol, const String &p_prologue = String());
@@ -375,6 +378,7 @@ class EditorHelpBitTooltip : public PopupPanel {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static Control *show_tooltip(Control *p_target, const String &p_symbol, const String &p_prologue = String(), bool p_use_class_prefix = false);

--- a/editor/editor_help_search.h
+++ b/editor/editor_help_search.h
@@ -93,6 +93,7 @@ class EditorHelpSearch : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -146,6 +146,7 @@ protected:
 	bool has_borders = false;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	virtual void _set_read_only(bool p_read_only);
 
@@ -312,6 +313,7 @@ class EditorInspectorCategory : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
@@ -346,6 +348,7 @@ protected:
 	VBoxContainer *vbox = nullptr;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
@@ -464,6 +467,7 @@ class EditorInspectorArray : public EditorInspectorSection {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -494,6 +498,7 @@ class EditorPaginator : public HBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -637,6 +642,7 @@ class EditorInspector : public ScrollContainer {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static void add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -176,6 +176,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void add_message(const String &p_msg, MessageType p_type = MSG_TYPE_STD);

--- a/editor/editor_main_screen.h
+++ b/editor/editor_main_screen.h
@@ -63,6 +63,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_button_container(HBoxContainer *p_button_hb);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -679,6 +679,7 @@ protected:
 
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	// Public for use with callable_mp.

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -90,6 +90,7 @@ class EditorPropertyMultilineText : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;
@@ -124,6 +125,7 @@ class EditorPropertyTextEnum : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void setup(const Vector<String> &p_options, bool p_string_name = false, bool p_loose_mode = false);
@@ -152,6 +154,7 @@ class EditorPropertyPath : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void setup(const Vector<String> &p_extensions, bool p_folder, bool p_global);
@@ -172,6 +175,7 @@ class EditorPropertyLocale : public EditorProperty {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void setup(const String &p_hit_string);
@@ -273,6 +277,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -318,6 +323,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void _set_read_only(bool p_read_only) override;
 
 public:
@@ -424,6 +430,7 @@ class EditorPropertyEasing : public EditorProperty {
 	void _spin_focus_exited();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
@@ -442,6 +449,7 @@ class EditorPropertyRect2 : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;
@@ -457,6 +465,7 @@ class EditorPropertyRect2i : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;
@@ -472,6 +481,7 @@ class EditorPropertyPlane : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;
@@ -504,6 +514,7 @@ class EditorPropertyQuaternion : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;
@@ -519,6 +530,7 @@ class EditorPropertyAABB : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;
@@ -534,6 +546,7 @@ class EditorPropertyTransform2D : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;
@@ -549,6 +562,7 @@ class EditorPropertyBasis : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;
@@ -564,6 +578,7 @@ class EditorPropertyTransform3D : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;
@@ -580,6 +595,7 @@ class EditorPropertyProjection : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;
@@ -603,6 +619,7 @@ class EditorPropertyColor : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;
@@ -650,6 +667,7 @@ class EditorPropertyNodePath : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;
@@ -693,6 +711,7 @@ class EditorPropertyResource : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -147,6 +147,7 @@ protected:
 	bool dropping = false;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual void _add_element();
 	virtual void _length_changed(double p_page);
@@ -259,6 +260,7 @@ class EditorPropertyDictionary : public EditorProperty {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void setup(PropertyHint p_hint, const String &p_hint_string = "");
@@ -296,6 +298,7 @@ class EditorPropertyLocalizableString : public EditorProperty {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;

--- a/editor/editor_properties_vector.h
+++ b/editor/editor_properties_vector.h
@@ -58,6 +58,7 @@ class EditorPropertyVectorN : public EditorProperty {
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -119,6 +119,7 @@ protected:
 	Button *get_assign_button() { return assign_button; }
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void set_assign_button_min_size(const Size2i &p_size);
 
@@ -207,6 +208,7 @@ class EditorAudioStreamPicker : public EditorResourcePicker {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	EditorAudioStreamPicker();

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -121,6 +121,7 @@ class EditorResourcePreview : public Node {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/editor_run_native.h
+++ b/editor/editor_run_native.h
@@ -53,6 +53,7 @@ class EditorRunNative : public HBoxContainer {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	Error start_run_native(int p_id);

--- a/editor/editor_settings_dialog.h
+++ b/editor/editor_settings_dialog.h
@@ -86,6 +86,7 @@ class EditorSettingsDialog : public AcceptDialog {
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _update_icons();
 
 	void _event_config_confirmed();

--- a/editor/engine_update_label.h
+++ b/editor/engine_update_label.h
@@ -91,6 +91,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	virtual void pressed() override;

--- a/editor/event_listener_line_edit.h
+++ b/editor/event_listener_line_edit.h
@@ -57,6 +57,7 @@ class EventListenerLineEdit : public LineEdit {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/export/editor_export.h
+++ b/editor/export/editor_export.h
@@ -58,6 +58,7 @@ protected:
 	void emit_presets_runnable_changed();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/export/export_template_manager.h
+++ b/editor/export/export_template_manager.h
@@ -119,6 +119,7 @@ class ExportTemplateManager : public AcceptDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static String get_android_build_directory(const Ref<EditorExportPreset> &p_preset);

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -60,6 +60,7 @@ class ProjectExportTextureFormatError : public HBoxContainer {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void show_for_texture_format(const String &p_friendly_name, const String &p_setting_identifier);
@@ -208,6 +209,7 @@ class ProjectExportDialog : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/fbx_importer_manager.h
+++ b/editor/fbx_importer_manager.h
@@ -56,6 +56,7 @@ class FBXImporterManager : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static FBXImporterManager *get_singleton() { return singleton; }

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -367,6 +367,7 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/find_in_files.h
+++ b/editor/find_in_files.h
@@ -60,6 +60,7 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 
@@ -118,6 +119,7 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void _visibility_changed();
 	void custom_action(const String &p_action) override;
@@ -174,6 +176,7 @@ protected:
 	static void _bind_methods();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 private:
 	void _on_button_clicked(TreeItem *p_item, int p_column, int p_id, int p_mouse_button_index);

--- a/editor/group_settings_editor.h
+++ b/editor/group_settings_editor.h
@@ -86,6 +86,7 @@ class GroupSettingsEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/groups_editor.h
+++ b/editor/groups_editor.h
@@ -124,6 +124,7 @@ class GroupsEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -74,6 +74,7 @@ class EditorBottomPanel : public PanelContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const;

--- a/editor/gui/editor_dir_dialog.h
+++ b/editor/gui/editor_dir_dialog.h
@@ -64,6 +64,7 @@ class EditorDirDialog : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -293,6 +293,7 @@ protected:
 	virtual void _update_theme_item_cache() override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	bool _set(const StringName &p_name, const Variant &p_value) { return property_helper.property_set_value(p_name, p_value); }
 	bool _get(const StringName &p_name, Variant &r_ret) const { return property_helper.property_get_value(p_name, r_ret); }
 	void _get_property_list(List<PropertyInfo> *p_list) const { property_helper.get_property_list(p_list); }

--- a/editor/gui/editor_object_selector.h
+++ b/editor/gui/editor_object_selector.h
@@ -57,6 +57,7 @@ class EditorObjectSelector : public Button {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual Size2 get_minimum_size() const override;

--- a/editor/gui/editor_quick_open_dialog.h
+++ b/editor/gui/editor_quick_open_dialog.h
@@ -78,6 +78,7 @@ public:
 
 protected:
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 };
 
 class QuickOpenResultContainer : public VBoxContainer {
@@ -104,6 +105,7 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 private:
 	static constexpr int MAX_HISTORY_SIZE = 20;
@@ -207,6 +209,7 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 private:
 	HBoxContainer *hbc = nullptr;
@@ -232,6 +235,7 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 private:
 	QuickOpenResultListItem *list_item = nullptr;

--- a/editor/gui/editor_run_bar.h
+++ b/editor/gui/editor_run_bar.h
@@ -98,6 +98,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/gui/editor_scene_tabs.h
+++ b/editor/gui/editor_scene_tabs.h
@@ -90,6 +90,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void unhandled_key_input(const Ref<InputEvent> &p_event) override;
 	static void _bind_methods();
 

--- a/editor/gui/editor_spin_slider.h
+++ b/editor/gui/editor_spin_slider.h
@@ -94,6 +94,7 @@ class EditorSpinSlider : public Range {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	static void _bind_methods();
 	void _grabber_mouse_entered();

--- a/editor/gui/editor_toaster.h
+++ b/editor/gui/editor_toaster.h
@@ -109,6 +109,7 @@ protected:
 	static EditorToaster *singleton;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static EditorToaster *get_singleton();

--- a/editor/gui/editor_validation_panel.h
+++ b/editor/gui/editor_validation_panel.h
@@ -71,6 +71,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void add_line(int p_id, const String &p_valid_message = "");

--- a/editor/gui/editor_version_button.h
+++ b/editor/gui/editor_version_button.h
@@ -50,6 +50,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual void pressed() override;
 

--- a/editor/gui/editor_zoom_widget.h
+++ b/editor/gui/editor_zoom_widget.h
@@ -50,6 +50,7 @@ class EditorZoomWidget : public HBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -159,6 +159,7 @@ class SceneTreeEditor : public Control {
 
 	TreeItem *_find(TreeItem *p_node, const NodePath &p_path);
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _selected_changed();
 	void _deselect_items();
 
@@ -280,6 +281,7 @@ class SceneTreeDialog : public ConfirmationDialog {
 protected:
 	void _update_valid_type_icons();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/gui/touch_actions_panel.h
+++ b/editor/gui/touch_actions_panel.h
@@ -55,6 +55,7 @@ private:
 	Vector2 drag_offset;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void _simulate_editor_shortcut(const String &p_shortcut_name);
 	void _simulate_key_press(Key p_keycode);

--- a/editor/history_dock.h
+++ b/editor/history_dock.h
@@ -59,6 +59,7 @@ class HistoryDock : public VBoxContainer {
 
 protected:
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -239,6 +239,7 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 protected:
 	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	bool is_editing_animation() const { return editing_animation; }

--- a/editor/import/audio_stream_import_settings.h
+++ b/editor/import/audio_stream_import_settings.h
@@ -88,6 +88,7 @@ class AudioStreamImportSettingsDialog : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _preview_changed(ObjectID p_which);
 	void _preview_zoom_in();
 	void _preview_zoom_out();

--- a/editor/import/dynamic_font_import_settings.h
+++ b/editor/import/dynamic_font_import_settings.h
@@ -164,6 +164,7 @@ class DynamicFontImportSettingsDialog : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void open_settings(const String &p_path);

--- a/editor/import_defaults_editor.h
+++ b/editor/import_defaults_editor.h
@@ -56,6 +56,7 @@ class ImportDefaultsEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void clear();

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -96,6 +96,7 @@ public:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_edit_path(const String &p_path);

--- a/editor/input_event_configuration_dialog.h
+++ b/editor/input_event_configuration_dialog.h
@@ -120,6 +120,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	// Pass an existing event to configure it. Alternatively, pass no event to start with a blank configuration.

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -145,6 +145,7 @@ public:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void go_back();

--- a/editor/localization_editor.h
+++ b/editor/localization_editor.h
@@ -88,6 +88,7 @@ class LocalizationEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/node_dock.h
+++ b/editor/node_dock.h
@@ -59,6 +59,7 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -107,6 +107,7 @@ protected:
 	void _wip_cancel();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _node_removed(Node *p_node);
 
 	void remove_point(const Vertex &p_vertex);

--- a/editor/plugins/animation_blend_space_1d_editor.h
+++ b/editor/plugins/animation_blend_space_1d_editor.h
@@ -127,6 +127,7 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/animation_blend_space_2d_editor.h
+++ b/editor/plugins/animation_blend_space_2d_editor.h
@@ -138,6 +138,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/animation_blend_tree_editor_plugin.h
+++ b/editor/plugins/animation_blend_tree_editor_plugin.h
@@ -152,6 +152,7 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -207,4 +208,5 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 };

--- a/editor/plugins/animation_library_editor.h
+++ b/editor/plugins/animation_library_editor.h
@@ -117,6 +117,7 @@ class AnimationLibraryEditor : public AcceptDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _update_editor(Object *p_mixer);
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	static void _bind_methods();

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -246,6 +246,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _node_removed(Node *p_node);
 	static void _bind_methods();
 
@@ -290,6 +291,7 @@ class AnimationPlayerEditorPlugin : public EditorPlugin {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void _property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance);
 	void _transform_key_request(Object *sp, const String &p_sub, const Transform3D &p_key);

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -294,6 +294,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/animation_tree_editor_plugin.h
+++ b/editor/plugins/animation_tree_editor_plugin.h
@@ -70,6 +70,7 @@ class AnimationTreeEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _node_removed(Node *p_node);
 
 	static AnimationTreeEditor *singleton;

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -71,6 +71,7 @@ class EditorAssetLibraryItem : public PanelContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -115,6 +116,7 @@ class EditorAssetLibraryItemDescription : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -160,6 +162,7 @@ class EditorAssetLibraryItemDownload : public MarginContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -322,6 +325,7 @@ class EditorAssetLibrary : public PanelContainer {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 public:

--- a/editor/plugins/audio_stream_editor_plugin.h
+++ b/editor/plugins/audio_stream_editor_plugin.h
@@ -57,6 +57,7 @@ class AudioStreamEditor : public ColorRect {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _preview_changed(ObjectID p_which);
 	void _play();
 	void _stop();

--- a/editor/plugins/bit_map_editor_plugin.h
+++ b/editor/plugins/bit_map_editor_plugin.h
@@ -52,6 +52,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void setup(const Ref<BitMap> &p_bitmap);

--- a/editor/plugins/bone_map_editor_plugin.h
+++ b/editor/plugins/bone_map_editor_plugin.h
@@ -65,6 +65,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	StringName get_profile_bone_name() const;
@@ -91,6 +92,7 @@ class BoneMapperItem : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	virtual void _value_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing);
 	virtual void create_editor();
@@ -114,6 +116,7 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _confirm();
 
 private:
@@ -175,6 +178,7 @@ class BoneMapper : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	virtual void _value_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing);
 	virtual void _profile_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing);
@@ -200,6 +204,7 @@ class BoneMapEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	BoneMapEditor(Ref<BoneMap> &p_bone_map);

--- a/editor/plugins/camera_2d_editor_plugin.h
+++ b/editor/plugins/camera_2d_editor_plugin.h
@@ -55,6 +55,7 @@ class Camera2DEditor : public Control {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void edit(Camera2D *p_camera);

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -526,6 +526,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 
@@ -598,6 +599,7 @@ class CanvasItemEditorPlugin : public EditorPlugin {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual String get_plugin_name() const override { return TTRC("2D"); }
@@ -653,6 +655,7 @@ class CanvasItemEditorViewport : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;

--- a/editor/plugins/cast_2d_editor_plugin.h
+++ b/editor/plugins/cast_2d_editor_plugin.h
@@ -47,6 +47,7 @@ class Cast2DEditor : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _node_removed(Node *p_node);
 
 public:

--- a/editor/plugins/collision_shape_2d_editor_plugin.h
+++ b/editor/plugins/collision_shape_2d_editor_plugin.h
@@ -85,6 +85,7 @@ class CollisionShape2DEditor : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _node_removed(Node *p_node);
 
 public:

--- a/editor/plugins/color_channel_selector.h
+++ b/editor/plugins/color_channel_selector.h
@@ -49,6 +49,7 @@ public:
 
 private:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void on_channel_button_toggled(bool p_unused_pressed);
 	void create_button(unsigned int p_channel_index, const String &p_text, Control *p_parent);

--- a/editor/plugins/control_editor_plugin.h
+++ b/editor/plugins/control_editor_plugin.h
@@ -69,6 +69,7 @@ class ControlPositioningWarning : public MarginContainer {
 
 protected:
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_control(Control *p_node);
@@ -149,6 +150,7 @@ class ControlEditorPopupButton : public Button {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual Size2 get_minimum_size() const override;
@@ -179,6 +181,7 @@ class AnchorPresetPicker : public ControlEditorPresetPicker {
 
 protected:
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -197,6 +200,7 @@ class SizeFlagPresetPicker : public ControlEditorPresetPicker {
 
 protected:
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -233,6 +237,7 @@ class ControlEditorToolbar : public HBoxContainer {
 
 protected:
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static ControlEditorToolbar *singleton;
 

--- a/editor/plugins/curve_editor_plugin.h
+++ b/editor/plugins/curve_editor_plugin.h
@@ -71,6 +71,7 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 private:
@@ -165,6 +166,7 @@ class CurveEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static const int DEFAULT_SNAP;

--- a/editor/plugins/debugger_editor_plugin.h
+++ b/editor/plugins/debugger_editor_plugin.h
@@ -63,6 +63,7 @@ private:
 
 	void _update_debug_options();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _menu_option(int p_option);
 
 public:

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -104,6 +104,7 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 	EditorUndoRedoManager *get_undo_redo();

--- a/editor/plugins/editor_plugin_settings.h
+++ b/editor/plugins/editor_plugin_settings.h
@@ -66,6 +66,7 @@ class EditorPluginSettings : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void update_plugins();

--- a/editor/plugins/embedded_process.h
+++ b/editor/plugins/embedded_process.h
@@ -72,6 +72,7 @@ class EmbeddedProcess : public Control {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void embed_process(OS::ProcessID p_pid);

--- a/editor/plugins/font_config_plugin.h
+++ b/editor/plugins/font_config_plugin.h
@@ -97,6 +97,7 @@ class EditorPropertyFontMetaOverride : public EditorProperty {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods() {}
 
 	void _edit_pressed();
@@ -181,6 +182,7 @@ class EditorPropertyOTFeatures : public EditorProperty {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods() {}
 
 	void _edit_pressed();
@@ -214,6 +216,7 @@ class FontPreview : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	Ref<Font> prev_font;

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -204,6 +204,7 @@ class GameView : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_state(const Dictionary &p_state);
@@ -236,6 +237,7 @@ class GameViewPlugin : public EditorPlugin {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual String get_plugin_name() const override { return TTRC("Game"); }

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
@@ -58,6 +58,7 @@ class GPUParticlesCollisionSDF3DEditorPlugin : public EditorPlugin {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual String get_plugin_name() const override { return "GPUParticlesCollisionSDF3D"; }

--- a/editor/plugins/gradient_editor_plugin.h
+++ b/editor/plugins/gradient_editor_plugin.h
@@ -81,6 +81,7 @@ class GradientEdit : public Control {
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -117,6 +118,7 @@ class GradientEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static const int DEFAULT_SNAP;

--- a/editor/plugins/gradient_texture_2d_editor_plugin.h
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.h
@@ -70,6 +70,7 @@ class GradientTexture2DEdit : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_texture(Ref<GradientTexture2D> &p_texture);
@@ -95,6 +96,7 @@ class GradientTexture2DEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static const int DEFAULT_SNAP;

--- a/editor/plugins/input_event_editor_plugin.h
+++ b/editor/plugins/input_event_editor_plugin.h
@@ -50,6 +50,7 @@ class InputEventConfigContainer : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_event(const Ref<InputEvent> &p_event);

--- a/editor/plugins/material_editor_plugin.h
+++ b/editor/plugins/material_editor_plugin.h
@@ -103,6 +103,7 @@ class MaterialEditor : public Control {
 protected:
 	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void gui_input(const Ref<InputEvent> &p_event) override;
 	void _set_rotation(real_t p_x_degrees, real_t p_y_degrees);
 	void _store_rotation_metadata();

--- a/editor/plugins/mesh_editor_plugin.h
+++ b/editor/plugins/mesh_editor_plugin.h
@@ -72,6 +72,7 @@ class MeshEditor : public SubViewportContainer {
 protected:
 	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:

--- a/editor/plugins/mesh_instance_3d_editor_plugin.h
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.h
@@ -100,6 +100,7 @@ protected:
 	void _node_removed(Node *p_node);
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void edit(MeshInstance3D *p_mesh);

--- a/editor/plugins/navigation_link_2d_editor_plugin.h
+++ b/editor/plugins/navigation_link_2d_editor_plugin.h
@@ -49,6 +49,7 @@ class NavigationLink2DEditor : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _node_removed(Node *p_node);
 
 public:

--- a/editor/plugins/navigation_obstacle_3d_editor_plugin.h
+++ b/editor/plugins/navigation_obstacle_3d_editor_plugin.h
@@ -107,6 +107,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _node_removed(Node *p_node);
 
 public:

--- a/editor/plugins/navigation_polygon_editor_plugin.h
+++ b/editor/plugins/navigation_polygon_editor_plugin.h
@@ -66,6 +66,7 @@ class NavigationPolygonEditor : public AbstractPolygon2DEditor {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual Node2D *_get_node() const override;
 	virtual void _set_node(Node *p_polygon) override;

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -90,6 +90,7 @@ class ViewportRotationControl : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _draw();
 	void _draw_axis(const Axis2D &p_axis);
@@ -535,6 +536,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -620,6 +622,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_view(View p_view);
@@ -929,6 +932,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	//void _gui_input(InputEvent p_event);
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
@@ -1077,6 +1081,7 @@ class ViewportNavigationControl : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _draw();
 	void _process_click(int p_index, Vector2 p_position, bool p_pressed);

--- a/editor/plugins/packed_scene_editor_plugin.h
+++ b/editor/plugins/packed_scene_editor_plugin.h
@@ -44,6 +44,7 @@ class PackedSceneEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	PackedSceneEditor(Ref<PackedScene> &p_packed_scene);

--- a/editor/plugins/parallax_background_editor_plugin.h
+++ b/editor/plugins/parallax_background_editor_plugin.h
@@ -52,6 +52,7 @@ class ParallaxBackgroundEditorPlugin : public EditorPlugin {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual String get_plugin_name() const override { return "ParallaxBackground"; }

--- a/editor/plugins/particle_process_material_editor_plugin.h
+++ b/editor/plugins/particle_process_material_editor_plugin.h
@@ -118,6 +118,7 @@ class ParticleProcessMaterialMinMaxPropertyEditor : public EditorProperty {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void setup(float p_min, float p_max, float p_step, bool p_allow_less, bool p_allow_greater, bool p_degrees);

--- a/editor/plugins/particles_editor_plugin.h
+++ b/editor/plugins/particles_editor_plugin.h
@@ -62,6 +62,7 @@ protected:
 	Node *edited_node = nullptr;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	bool need_show_lifetime_dialog(SpinBox *p_seconds);
 	virtual void _menu_callback(int p_idx);
@@ -109,6 +110,7 @@ protected:
 	void _get_base_emission_mask(PackedVector2Array &r_valid_positions, PackedVector2Array &r_valid_normals, PackedByteArray &r_valid_colors, Vector2i &r_image_size);
 	virtual void _generate_emission_mask() = 0;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _selection_changed();
 
 public:

--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -114,6 +114,7 @@ class Path2DEditor : public HBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _node_removed(Node *p_node);
 	static void _bind_methods();
 

--- a/editor/plugins/plugin_config_dialog.h
+++ b/editor/plugins/plugin_config_dialog.h
@@ -75,6 +75,7 @@ class PluginConfigDialog : public ConfirmationDialog {
 
 protected:
 	virtual void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -181,6 +181,7 @@ protected:
 	virtual void _commit_action() override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	Vector2 snap_point(Vector2 p_target) const;

--- a/editor/plugins/polygon_3d_editor_plugin.h
+++ b/editor/plugins/polygon_3d_editor_plugin.h
@@ -85,6 +85,7 @@ class Polygon3DEditor : public HBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _node_removed(Node *p_node);
 	static void _bind_methods();
 

--- a/editor/plugins/resource_preloader_editor_plugin.h
+++ b/editor/plugins/resource_preloader_editor_plugin.h
@@ -72,6 +72,7 @@ class ResourcePreloaderEditor : public PanelContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 

--- a/editor/plugins/root_motion_editor_plugin.h
+++ b/editor/plugins/root_motion_editor_plugin.h
@@ -52,6 +52,7 @@ class EditorPropertyRootMotion : public EditorProperty {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void update_property() override;

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -156,6 +156,7 @@ class ScriptEditorQuickOpen : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -540,6 +541,7 @@ class ScriptEditor : public PanelContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -619,6 +621,7 @@ class ScriptEditorPlugin : public EditorPlugin {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual String get_plugin_name() const override { return TTRC("Script"); }

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -186,6 +186,7 @@ protected:
 	void _warning_clicked(const Variant &p_line);
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	HashMap<String, Ref<EditorSyntaxHighlighter>> highlighters;
 	void _change_syntax_highlighter(int p_idx);

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -127,6 +127,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual String get_plugin_name() const override { return "Shader"; }

--- a/editor/plugins/shader_file_editor_plugin.h
+++ b/editor/plugins/shader_file_editor_plugin.h
@@ -57,6 +57,7 @@ class ShaderFileEditor : public PanelContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static ShaderFileEditor *singleton;

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -92,6 +92,7 @@ class BonePropertiesEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	BonePropertiesEditor(Skeleton3D *p_skeleton);
@@ -216,6 +217,7 @@ class Skeleton3DEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _node_removed(Node *p_node);
 
 public:

--- a/editor/plugins/sprite_2d_editor_plugin.h
+++ b/editor/plugins/sprite_2d_editor_plugin.h
@@ -107,6 +107,7 @@ class Sprite2DEditor : public Control {
 protected:
 	void _node_removed(Node *p_node);
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -277,6 +277,7 @@ class SpriteFramesEditor : public HSplitContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _node_removed(Node *p_node);
 	static void _bind_methods();
 

--- a/editor/plugins/style_box_editor_plugin.h
+++ b/editor/plugins/style_box_editor_plugin.h
@@ -50,6 +50,7 @@ class StyleBoxPreview : public TextureRect {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void edit(const Ref<StyleBox> &p_stylebox);

--- a/editor/plugins/text_shader_editor.h
+++ b/editor/plugins/text_shader_editor.h
@@ -77,6 +77,7 @@ class ShaderTextEditor : public CodeTextEditor {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	virtual void _load_theme_settings() override;
 
@@ -180,6 +181,7 @@ class TextShaderEditor : public ShaderEditor {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	void _make_context_menu(bool p_selection, Vector2 p_position);
 	void _text_edit_gui_input(const Ref<InputEvent> &p_ev);

--- a/editor/plugins/texture_3d_editor_plugin.h
+++ b/editor/plugins/texture_3d_editor_plugin.h
@@ -74,6 +74,7 @@ class Texture3DEditor : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void edit(Ref<Texture3D> p_texture);

--- a/editor/plugins/texture_editor_plugin.h
+++ b/editor/plugins/texture_editor_plugin.h
@@ -64,6 +64,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _update_texture_display_ratio();
 
 	void on_selected_channels_changed();

--- a/editor/plugins/texture_layered_editor_plugin.h
+++ b/editor/plugins/texture_layered_editor_plugin.h
@@ -76,6 +76,7 @@ class TextureLayeredEditor : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -140,6 +140,7 @@ class TextureRegionEditor : public AcceptDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	static void _bind_methods();
 

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -172,6 +172,7 @@ class ThemeItemImportTree : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -276,6 +277,7 @@ class ThemeItemEditorDialog : public AcceptDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -312,6 +314,7 @@ class ThemeTypeDialog : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -413,6 +416,7 @@ class ThemeTypeEditor : public MarginContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -457,6 +461,7 @@ class ThemeEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void edit(const Ref<Theme> &p_theme);

--- a/editor/plugins/theme_editor_preview.h
+++ b/editor/plugins/theme_editor_preview.h
@@ -78,6 +78,7 @@ protected:
 	void add_preview_overlay(Control *p_overlay);
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -93,6 +94,7 @@ class DefaultThemeEditorPreview : public ThemeEditorPreview {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	DefaultThemeEditorPreview();
@@ -109,6 +111,7 @@ class SceneThemeEditorPreview : public ThemeEditorPreview {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/tiles/atlas_merging_dialog.h
+++ b/editor/plugins/tiles/atlas_merging_dialog.h
@@ -76,6 +76,7 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void update_tile_set(Ref<TileSet> p_tile_set);

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -122,6 +122,7 @@ protected:
 	virtual void _update_theme_item_cache() override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/tiles/tile_data_editors.h
+++ b/editor/plugins/tiles/tile_data_editors.h
@@ -171,6 +171,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -228,6 +229,7 @@ protected:
 	String property;
 	Variant::Type property_type;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual Variant _get_painted_value();
 	virtual void _set_painted_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile);
@@ -292,6 +294,7 @@ protected:
 	virtual void _tile_set_changed() override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected = false) override;
@@ -325,6 +328,7 @@ protected:
 	virtual void _tile_set_changed() override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected = false) override;
@@ -371,6 +375,7 @@ protected:
 	virtual void _tile_set_changed() override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual Control *get_toolbar() override { return toolbar; }
@@ -406,6 +411,7 @@ protected:
 	virtual void _tile_set_changed() override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected = false) override;

--- a/editor/plugins/tiles/tile_map_layer_editor.h
+++ b/editor/plugins/tiles/tile_map_layer_editor.h
@@ -405,6 +405,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _draw_shape(Control *p_control, Rect2 p_region, TileSet::TileShape p_shape, TileSet::TileOffsetAxis p_offset_axis, Color p_color);
 
 public:

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -291,6 +291,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	// -- input events --

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -112,6 +112,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	_FORCE_INLINE_ static TileSetEditor *get_singleton() { return singleton; }

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
@@ -136,6 +136,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/tiles/tiles_editor_plugin.h
+++ b/editor/plugins/tiles/tiles_editor_plugin.h
@@ -128,6 +128,7 @@ class TileMapEditorPlugin : public EditorPlugin {
 
 protected:
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void edit(Object *p_object) override;

--- a/editor/plugins/version_control_editor_plugin.h
+++ b/editor/plugins/version_control_editor_plugin.h
@@ -136,6 +136,7 @@ private:
 	List<EditorVCSInterface::DiffFile> diff_content;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _initialize_vcs();
 	void _set_vcs_ui_state(bool p_enabled);
 	void _set_credentials();

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -7618,6 +7618,7 @@ public:
 			} break;
 		}
 	}
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void _item_selected(int p_item) {
 		editor->call_deferred(SNAME("_input_select_item"), input, get_item_metadata(p_item));
@@ -7673,6 +7674,7 @@ public:
 			connect(SceneStringName(item_selected), callable_mp(this, &VisualShaderNodePluginVaryingEditor::_item_selected));
 		}
 	}
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void _item_selected(int p_item) {
 		editor->call_deferred(SNAME("_varying_select_item"), varying, get_item_metadata(p_item));
@@ -7757,6 +7759,7 @@ public:
 			} break;
 		}
 	}
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void _item_selected(int p_item) {
 		editor->call_deferred(SNAME("_parameter_ref_select_item"), parameter_ref, get_item_metadata(p_item));

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -84,6 +84,7 @@ class VSRerouteNode : public VSGraphNode {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual void draw_port(int p_slot_index, Point2i p_pos, bool p_left, const Color &p_color) override;
 
@@ -635,6 +636,7 @@ class VisualShaderEditor : public ShaderEditor {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -702,6 +704,7 @@ class VisualShaderNodePortPreview : public Control {
 	void _shader_changed(); //must regen
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual Size2 get_minimum_size() const override;

--- a/editor/plugins/voxel_gi_editor_plugin.h
+++ b/editor/plugins/voxel_gi_editor_plugin.h
@@ -57,6 +57,7 @@ class VoxelGIEditorPlugin : public EditorPlugin {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual String get_plugin_name() const override { return "VoxelGI"; }

--- a/editor/progress_dialog.h
+++ b/editor/progress_dialog.h
@@ -93,6 +93,7 @@ class ProgressDialog : public CenterContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static ProgressDialog *get_singleton() { return singleton; }

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -246,6 +246,7 @@ class ProjectManager : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static ProjectManager *get_singleton() { return singleton; }

--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -136,6 +136,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_mode(Mode p_mode);

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -66,6 +66,7 @@ class ProjectListItemControl : public HBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -229,6 +230,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/project_manager/project_tag.h
+++ b/editor/project_manager/project_tag.h
@@ -44,6 +44,7 @@ class ProjectTag : public HBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void connect_button_to(const Callable &p_callable);

--- a/editor/project_manager/quick_settings_dialog.h
+++ b/editor/project_manager/quick_settings_dialog.h
@@ -86,6 +86,7 @@ class QuickSettingsDialog : public AcceptDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -119,6 +119,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/property_selector.h
+++ b/editor/property_selector.h
@@ -67,6 +67,7 @@ class PropertySelector : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/reparent_dialog.h
+++ b/editor/reparent_dialog.h
@@ -46,6 +46,7 @@ class ReparentDialog : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/scene_create_dialog.h
+++ b/editor/scene_create_dialog.h
@@ -87,6 +87,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void config(const String &p_dir);

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -306,6 +306,7 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -118,6 +118,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/shader_create_dialog.h
+++ b/editor/shader_create_dialog.h
@@ -101,6 +101,7 @@ class ShaderCreateDialog : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/editor/shader_globals_editor.h
+++ b/editor/shader_globals_editor.h
@@ -57,6 +57,7 @@ class ShaderGlobalsEditor : public VBoxContainer {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	LineEdit *get_name_box() const;

--- a/editor/window_wrapper.h
+++ b/editor/window_wrapper.h
@@ -62,6 +62,7 @@ class WindowWrapper : public MarginContainer {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
@@ -111,6 +112,7 @@ protected:
 	static void _bind_methods();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	ScreenSelect();

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -125,6 +125,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual CSGBrush *_build_brush() = 0;
 	void _make_dirty(bool p_parent_removing = false);
 	PackedStringArray get_configuration_warnings() const override;
@@ -433,6 +434,7 @@ protected:
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_polygon(const Vector<Vector2> &p_polygon);

--- a/modules/csg/editor/csg_gizmos.h
+++ b/modules/csg/editor/csg_gizmos.h
@@ -82,6 +82,7 @@ protected:
 	void _node_removed(Node *p_node);
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void edit(CSGShape3D *p_csg_shape);

--- a/modules/gdscript/language_server/gdscript_language_server.h
+++ b/modules/gdscript/language_server/gdscript_language_server.h
@@ -50,6 +50,7 @@ class GDScriptLanguageServer : public EditorPlugin {
 
 private:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static int port_override;

--- a/modules/gltf/editor/editor_import_blend_runner.h
+++ b/modules/gltf/editor/editor_import_blend_runner.h
@@ -44,6 +44,7 @@ class EditorImportBlendRunner : public Node {
 	void _resources_reimported(const PackedStringArray &p_files);
 	void _kill_blender();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	bool _extract_error_message_xml(const Vector<uint8_t> &p_response_data, String &r_error_message);
 
 protected:

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -256,6 +256,7 @@ class GridMapEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -274,6 +275,7 @@ class GridMapEditorPlugin : public EditorPlugin {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -231,6 +231,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _update_visibility();
 	static void _bind_methods();
 

--- a/modules/interactive_music/editor/audio_stream_interactive_editor_plugin.h
+++ b/modules/interactive_music/editor/audio_stream_interactive_editor_plugin.h
@@ -73,6 +73,7 @@ class AudioStreamInteractiveTransitionEditor : public AcceptDialog {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/modules/multiplayer/editor/editor_network_profiler.h
+++ b/modules/multiplayer/editor/editor_network_profiler.h
@@ -100,6 +100,7 @@ protected:
 	virtual void _update_theme_item_cache() override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.h
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.h
@@ -69,6 +69,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual void edit(Object *p_object) override;

--- a/modules/multiplayer/editor/replication_editor.h
+++ b/modules/multiplayer/editor/replication_editor.h
@@ -94,6 +94,7 @@ protected:
 	static void _bind_methods();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void edit(MultiplayerSynchronizer *p_object);

--- a/modules/multiplayer/multiplayer_spawner.h
+++ b/modules/multiplayer/multiplayer_spawner.h
@@ -80,6 +80,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 #ifdef TOOLS_ENABLED
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/modules/multiplayer/multiplayer_synchronizer.h
+++ b/modules/multiplayer/multiplayer_synchronizer.h
@@ -76,6 +76,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static Error get_state(const List<NodePath> &p_properties, Object *p_obj, Vector<Variant> &r_variant, Vector<const Variant *> &r_variant_ptrs);

--- a/modules/navigation_3d/editor/navigation_mesh_editor_plugin.h
+++ b/modules/navigation_3d/editor/navigation_mesh_editor_plugin.h
@@ -58,6 +58,7 @@ class NavigationMeshEditor : public Control {
 protected:
 	void _node_removed(Node *p_node);
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void edit(NavigationRegion3D *p_nav_region);

--- a/modules/noise/editor/noise_editor_plugin.cpp
+++ b/modules/noise/editor/noise_editor_plugin.cpp
@@ -100,6 +100,7 @@ private:
 			} break;
 		}
 	}
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void update_preview() {
 		if (MIN(_preview_texture_size.width, _preview_texture_size.height) > 0) {

--- a/modules/openxr/editor/openxr_action_editor.h
+++ b/modules/openxr/editor/openxr_action_editor.h
@@ -60,6 +60,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	// used for undo/redo
 	void _do_set_name(const String p_new_text);

--- a/modules/openxr/editor/openxr_action_map_editor.h
+++ b/modules/openxr/editor/openxr_action_map_editor.h
@@ -93,6 +93,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void _clear_action_map();
 

--- a/modules/openxr/editor/openxr_action_set_editor.h
+++ b/modules/openxr/editor/openxr_action_set_editor.h
@@ -77,6 +77,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	// used for undo/redo
 	void _do_set_name(const String p_new_text);

--- a/modules/openxr/editor/openxr_binding_modifier_editor.h
+++ b/modules/openxr/editor/openxr_binding_modifier_editor.h
@@ -98,6 +98,7 @@ protected:
 
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void _on_remove_binding_modifier();
 

--- a/modules/openxr/editor/openxr_binding_modifiers_dialog.h
+++ b/modules/openxr/editor/openxr_binding_modifiers_dialog.h
@@ -66,6 +66,7 @@ protected:
 
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	// used for undo/redo
 	void _do_add_binding_modifier_editor(OpenXRBindingModifierEditor *p_binding_modifier_editor);

--- a/modules/openxr/editor/openxr_interaction_profile_editor.h
+++ b/modules/openxr/editor/openxr_interaction_profile_editor.h
@@ -60,6 +60,7 @@ protected:
 
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	const OpenXRInteractionProfileMetadata::InteractionProfile *profile_def = nullptr;
 

--- a/modules/openxr/editor/openxr_select_action_dialog.h
+++ b/modules/openxr/editor/openxr_select_action_dialog.h
@@ -55,6 +55,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void _on_select_action(const String p_action);

--- a/modules/openxr/editor/openxr_select_interaction_profile_dialog.h
+++ b/modules/openxr/editor/openxr_select_interaction_profile_dialog.h
@@ -49,6 +49,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void _on_select_interaction_profile(const String p_interaction_profile);

--- a/modules/openxr/editor/openxr_select_runtime.h
+++ b/modules/openxr/editor/openxr_select_runtime.h
@@ -40,6 +40,7 @@ public:
 
 protected:
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 private:
 	void _update_items();

--- a/modules/openxr/scene/openxr_composition_layer.h
+++ b/modules/openxr/scene/openxr_composition_layer.h
@@ -112,6 +112,7 @@ protected:
 	static void _bind_methods();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _get_property_list(List<PropertyInfo> *p_property_list) const;
 	bool _get(const StringName &p_property, Variant &r_value) const;
 	bool _set(const StringName &p_property, const Variant &p_value);

--- a/modules/openxr/scene/openxr_composition_layer_cylinder.h
+++ b/modules/openxr/scene/openxr_composition_layer_cylinder.h
@@ -59,6 +59,7 @@ protected:
 	static void _bind_methods();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void update_transform();
 

--- a/modules/openxr/scene/openxr_composition_layer_equirect.h
+++ b/modules/openxr/scene/openxr_composition_layer_equirect.h
@@ -61,6 +61,7 @@ protected:
 	static void _bind_methods();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void update_transform();
 

--- a/modules/openxr/scene/openxr_composition_layer_quad.h
+++ b/modules/openxr/scene/openxr_composition_layer_quad.h
@@ -54,6 +54,7 @@ protected:
 	static void _bind_methods();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void update_transform();
 

--- a/modules/openxr/scene/openxr_hand.h
+++ b/modules/openxr/scene/openxr_hand.h
@@ -111,6 +111,7 @@ public:
 	BoneUpdate get_bone_update() const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 };
 
 VARIANT_ENUM_CAST(OpenXRHand::Hands)

--- a/modules/openxr/scene/openxr_visibility_mask.h
+++ b/modules/openxr/scene/openxr_visibility_mask.h
@@ -39,6 +39,7 @@ protected:
 	static void _bind_methods();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	void _on_openxr_session_begun();
 	void _on_openxr_session_stopping();

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -193,6 +193,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	typedef Error (*EditorExportSaveFunction)(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -154,6 +154,7 @@ protected:
 	virtual String get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	virtual String get_name() const override { return "iOS"; }

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -68,6 +68,7 @@ protected:
 #endif // DISABLE_DEPRECATED
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:

--- a/scene/2d/audio_listener_2d.h
+++ b/scene/2d/audio_listener_2d.h
@@ -45,6 +45,7 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -85,6 +85,7 @@ private:
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -121,6 +121,7 @@ protected:
 	virtual Transform2D get_camera_transform();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
 

--- a/scene/2d/canvas_modulate.h
+++ b/scene/2d/canvas_modulate.h
@@ -47,6 +47,7 @@ class CanvasModulate : public Node2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -215,6 +215,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 #ifdef TOOLS_ENABLED
 	void _draw_emission_gizmo();
 #endif

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -100,6 +100,7 @@ protected:
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 #ifdef TOOLS_ENABLED
 	void _draw_emission_gizmo();
 #endif

--- a/scene/2d/light_2d.h
+++ b/scene/2d/light_2d.h
@@ -78,6 +78,7 @@ private:
 protected:
 	_FORCE_INLINE_ RID _get_light() const { return canvas_light; }
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
 

--- a/scene/2d/light_occluder_2d.h
+++ b/scene/2d/light_occluder_2d.h
@@ -88,6 +88,7 @@ class LightOccluder2D : public Node2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/2d/line_2d.h
+++ b/scene/2d/line_2d.h
@@ -116,6 +116,7 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _draw();
 
 	static void _bind_methods();

--- a/scene/2d/marker_2d.h
+++ b/scene/2d/marker_2d.h
@@ -41,6 +41,7 @@ class Marker2D : public Node2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/2d/mesh_instance_2d.h
+++ b/scene/2d/mesh_instance_2d.h
@@ -44,6 +44,7 @@ class MeshInstance2D : public Node2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/2d/multimesh_instance_2d.h
+++ b/scene/2d/multimesh_instance_2d.h
@@ -45,6 +45,7 @@ class MultiMeshInstance2D : public Node2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/2d/navigation/navigation_agent_2d.h
+++ b/scene/2d/navigation/navigation_agent_2d.h
@@ -107,6 +107,7 @@ class NavigationAgent2D : public Node {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/scene/2d/navigation/navigation_link_2d.h
+++ b/scene/2d/navigation/navigation_link_2d.h
@@ -54,6 +54,7 @@ class NavigationLink2D : public Node2D {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/scene/2d/navigation/navigation_obstacle_2d.h
+++ b/scene/2d/navigation/navigation_obstacle_2d.h
@@ -73,6 +73,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	NavigationObstacle2D();

--- a/scene/2d/navigation/navigation_region_2d.h
+++ b/scene/2d/navigation/navigation_region_2d.h
@@ -68,6 +68,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -52,6 +52,7 @@ class Node2D : public CanvasItem {
 
 protected:
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/2d/parallax_2d.h
+++ b/scene/2d/parallax_2d.h
@@ -60,6 +60,7 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	void _camera_moved(const Transform2D &p_transform, const Point2 &p_screen_offset, const Point2 &p_adj_screen_offset);
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/2d/parallax_background.h
+++ b/scene/2d/parallax_background.h
@@ -52,6 +52,7 @@ protected:
 	void _camera_moved(const Transform2D &p_transform, const Point2 &p_screen_offset, const Point2 &p_adj_screen_offset);
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/2d/parallax_layer.h
+++ b/scene/2d/parallax_layer.h
@@ -44,6 +44,7 @@ class ParallaxLayer : public Node2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -44,6 +44,7 @@ class Path2D : public Node2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -79,6 +80,7 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/2d/physics/animatable_body_2d.h
+++ b/scene/2d/physics/animatable_body_2d.h
@@ -45,6 +45,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/2d/physics/character_body_2d.h
+++ b/scene/2d/physics/character_body_2d.h
@@ -161,6 +161,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
 };

--- a/scene/2d/physics/collision_object_2d.h
+++ b/scene/2d/physics/collision_object_2d.h
@@ -92,6 +92,7 @@ protected:
 	CollisionObject2D(RID p_rid, bool p_area);
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	void _update_pickable();

--- a/scene/2d/physics/collision_polygon_2d.h
+++ b/scene/2d/physics/collision_polygon_2d.h
@@ -61,6 +61,7 @@ protected:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/2d/physics/collision_shape_2d.h
+++ b/scene/2d/physics/collision_shape_2d.h
@@ -55,6 +55,7 @@ class CollisionShape2D : public Node2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 #ifdef DEBUG_ENABLED
 	bool _property_can_revert(const StringName &p_name) const;

--- a/scene/2d/physics/joints/damped_spring_joint_2d.h
+++ b/scene/2d/physics/joints/damped_spring_joint_2d.h
@@ -44,6 +44,7 @@ class DampedSpringJoint2D : public Joint2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void _configure_joint(RID p_joint, PhysicsBody2D *body_a, PhysicsBody2D *body_b) override;
 	static void _bind_methods();
 

--- a/scene/2d/physics/joints/groove_joint_2d.h
+++ b/scene/2d/physics/joints/groove_joint_2d.h
@@ -42,6 +42,7 @@ class GrooveJoint2D : public Joint2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void _configure_joint(RID p_joint, PhysicsBody2D *body_a, PhysicsBody2D *body_b) override;
 	static void _bind_methods();
 

--- a/scene/2d/physics/joints/joint_2d.h
+++ b/scene/2d/physics/joints/joint_2d.h
@@ -54,6 +54,7 @@ protected:
 	void _update_joint(bool p_only_free = false);
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void _configure_joint(RID p_joint, PhysicsBody2D *body_a, PhysicsBody2D *body_b) = 0;
 
 	static void _bind_methods();

--- a/scene/2d/physics/joints/pin_joint_2d.h
+++ b/scene/2d/physics/joints/pin_joint_2d.h
@@ -46,6 +46,7 @@ class PinJoint2D : public Joint2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void _configure_joint(RID p_joint, PhysicsBody2D *body_a, PhysicsBody2D *body_b) override;
 	static void _bind_methods();
 

--- a/scene/2d/physics/physical_bone_2d.h
+++ b/scene/2d/physics/physical_bone_2d.h
@@ -40,6 +40,7 @@ class PhysicalBone2D : public RigidBody2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 private:

--- a/scene/2d/physics/ray_cast_2d.h
+++ b/scene/2d/physics/ray_cast_2d.h
@@ -59,6 +59,7 @@ class RayCast2D : public Node2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _update_raycast_state();
 	static void _bind_methods();
 

--- a/scene/2d/physics/rigid_body_2d.h
+++ b/scene/2d/physics/rigid_body_2d.h
@@ -137,6 +137,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	void _validate_property(PropertyInfo &p_property) const;

--- a/scene/2d/physics/shape_cast_2d.h
+++ b/scene/2d/physics/shape_cast_2d.h
@@ -63,6 +63,7 @@ class ShapeCast2D : public Node2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _update_shapecast_state();
 	static void _bind_methods();
 

--- a/scene/2d/physics/touch_screen_button.h
+++ b/scene/2d/physics/touch_screen_button.h
@@ -69,6 +69,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -78,6 +78,7 @@ class Polygon2D : public Node2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
 

--- a/scene/2d/remote_transform_2d.h
+++ b/scene/2d/remote_transform_2d.h
@@ -50,6 +50,7 @@ class RemoteTransform2D : public Node2D {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_remote_node(const NodePath &p_remote_node);

--- a/scene/2d/skeleton_2d.h
+++ b/scene/2d/skeleton_2d.h
@@ -63,6 +63,7 @@ class Bone2D : public Node2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	bool _set(const StringName &p_path, const Variant &p_value);
 	bool _get(const StringName &p_path, Variant &r_ret) const;
@@ -152,6 +153,7 @@ protected:
 	///////////////////////////////////////////////////////
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	bool _set(const StringName &p_path, const Variant &p_value);
 	bool _get(const StringName &p_path, Variant &r_ret) const;

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -60,6 +60,7 @@ class Sprite2D : public Node2D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -99,6 +99,7 @@ protected:
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return property_helper.property_get_revert(p_name, r_property); }
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -494,6 +494,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;

--- a/scene/2d/visible_on_screen_notifier_2d.h
+++ b/scene/2d/visible_on_screen_notifier_2d.h
@@ -51,6 +51,7 @@ protected:
 	virtual void _screen_exit() {}
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -99,6 +100,7 @@ protected:
 	NodePath enable_node_path = NodePath("..");
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	void _update_enable_mode(bool p_enable);

--- a/scene/3d/audio_listener_3d.h
+++ b/scene/3d/audio_listener_3d.h
@@ -52,6 +52,7 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -123,6 +123,7 @@ private:
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -60,6 +60,7 @@ protected:
 	bool _set(const StringName &p_path, const Variant &p_value);
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 #ifndef DISABLE_DEPRECATED

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -137,6 +137,7 @@ protected:
 	void _update_camera_mode();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -207,6 +207,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -106,6 +106,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/3d/gpu_particles_collision_3d.h
+++ b/scene/3d/gpu_particles_collision_3d.h
@@ -233,6 +233,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -152,6 +152,7 @@ protected:
 	GDVIRTUAL2RC(TypedArray<Vector3i>, _structured_text_parser, Array, String)
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 

--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -96,6 +96,7 @@ protected:
 
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 
 	Light3D(RenderingServer::LightType p_type);

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -278,6 +278,7 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_light_data(const Ref<LightmapGIData> &p_data);

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -64,6 +64,7 @@ protected:
 	bool surface_index_0 = false;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	bool _property_can_revert(const StringName &p_name) const;

--- a/scene/3d/multimesh_instance_3d.h
+++ b/scene/3d/multimesh_instance_3d.h
@@ -49,6 +49,7 @@ protected:
 	virtual void _physics_interpolated_changed() override;
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_multimesh(const Ref<MultiMesh> &p_multimesh);

--- a/scene/3d/navigation/navigation_agent_3d.h
+++ b/scene/3d/navigation/navigation_agent_3d.h
@@ -115,6 +115,7 @@ class NavigationAgent3D : public Node {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/3d/navigation/navigation_link_3d.h
+++ b/scene/3d/navigation/navigation_link_3d.h
@@ -57,6 +57,7 @@ class NavigationLink3D : public Node3D {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/scene/3d/navigation/navigation_obstacle_3d.h
+++ b/scene/3d/navigation/navigation_obstacle_3d.h
@@ -79,6 +79,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	NavigationObstacle3D();

--- a/scene/3d/navigation/navigation_region_3d.h
+++ b/scene/3d/navigation/navigation_region_3d.h
@@ -67,6 +67,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -169,6 +169,7 @@ protected:
 	void _disable_client_physics_interpolation();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	void _validate_property(PropertyInfo &p_property) const;

--- a/scene/3d/occluder_instance_3d.h
+++ b/scene/3d/occluder_instance_3d.h
@@ -49,6 +49,7 @@ protected:
 	virtual void _update_arrays(PackedVector3Array &r_vertices, PackedInt32Array &r_indices) = 0;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	PackedVector3Array get_vertices() const;

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -51,6 +51,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 
@@ -100,6 +101,7 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 

--- a/scene/3d/physics/animatable_body_3d.h
+++ b/scene/3d/physics/animatable_body_3d.h
@@ -48,6 +48,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/3d/physics/area_3d.h
+++ b/scene/3d/physics/area_3d.h
@@ -144,6 +144,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
 

--- a/scene/3d/physics/character_body_3d.h
+++ b/scene/3d/physics/character_body_3d.h
@@ -178,6 +178,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
 };

--- a/scene/3d/physics/collision_object_3d.h
+++ b/scene/3d/physics/collision_object_3d.h
@@ -104,6 +104,7 @@ protected:
 	}
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	void _on_transform_changed();

--- a/scene/3d/physics/collision_polygon_3d.h
+++ b/scene/3d/physics/collision_polygon_3d.h
@@ -60,6 +60,7 @@ protected:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 #ifdef DEBUG_ENABLED

--- a/scene/3d/physics/collision_shape_3d.h
+++ b/scene/3d/physics/collision_shape_3d.h
@@ -61,6 +61,7 @@ protected:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 #ifdef DEBUG_ENABLED

--- a/scene/3d/physics/joints/joint_3d.h
+++ b/scene/3d/physics/joints/joint_3d.h
@@ -54,6 +54,7 @@ protected:
 	void _update_joint(bool p_only_free = false);
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual void _configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsBody3D *body_b) = 0;
 

--- a/scene/3d/physics/physical_bone_3d.h
+++ b/scene/3d/physics/physical_bone_3d.h
@@ -199,6 +199,7 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	GDVIRTUAL1(_integrate_forces, PhysicsDirectBodyState3D *)
 	static void _body_state_changed_callback(void *p_instance, PhysicsDirectBodyState3D *p_state);
 	void _body_state_changed(PhysicsDirectBodyState3D *p_state);

--- a/scene/3d/physics/ray_cast_3d.h
+++ b/scene/3d/physics/ray_cast_3d.h
@@ -75,6 +75,7 @@ class RayCast3D : public Node3D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _update_raycast_state();
 	static void _bind_methods();
 

--- a/scene/3d/physics/rigid_body_3d.h
+++ b/scene/3d/physics/rigid_body_3d.h
@@ -131,6 +131,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	void _validate_property(PropertyInfo &p_property) const;

--- a/scene/3d/physics/shape_cast_3d.h
+++ b/scene/3d/physics/shape_cast_3d.h
@@ -77,6 +77,7 @@ class ShapeCast3D : public Node3D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _update_shapecast_state();
 	void _shape_changed();
 	static void _bind_methods();

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -122,6 +122,7 @@ protected:
 	bool _get_property_pinned_points(int p_item, const String &p_what, Variant &r_ret) const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/3d/physics/spring_arm_3d.h
+++ b/scene/3d/physics/spring_arm_3d.h
@@ -45,6 +45,7 @@ class SpringArm3D : public Node3D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/3d/physics/vehicle_body_3d.h
+++ b/scene/3d/physics/vehicle_body_3d.h
@@ -94,6 +94,7 @@ class VehicleWheel3D : public Node3D {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/3d/remote_transform_3d.h
+++ b/scene/3d/remote_transform_3d.h
@@ -50,6 +50,7 @@ class RemoteTransform3D : public Node3D {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_remote_node(const NodePath &p_remote_node);

--- a/scene/3d/retarget_modifier_3d.h
+++ b/scene/3d/retarget_modifier_3d.h
@@ -90,6 +90,7 @@ protected:
 
 	static void _bind_methods();
 	virtual void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void move_child_notify(Node *p_child) override;

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -208,6 +208,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	TypedArray<StringName> _get_bone_meta_list_bind(int p_bone) const;
 	static void _bind_methods();
 

--- a/scene/3d/skeleton_ik_3d.h
+++ b/scene/3d/skeleton_ik_3d.h
@@ -143,6 +143,7 @@ protected:
 
 	static void _bind_methods();
 	virtual void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual void _process_modification() override;
 

--- a/scene/3d/skeleton_modifier_3d.h
+++ b/scene/3d/skeleton_modifier_3d.h
@@ -64,6 +64,7 @@ protected:
 
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	virtual void _set_active(bool p_active);

--- a/scene/3d/spring_bone_simulator_3d.h
+++ b/scene/3d/spring_bone_simulator_3d.h
@@ -149,6 +149,7 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -100,6 +100,7 @@ private:
 protected:
 	Color _get_color_accum();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	virtual void _draw() = 0;
 	void draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect, Rect2 p_src_rect);
@@ -251,6 +252,7 @@ protected:
 	virtual void _draw() override;
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:

--- a/scene/3d/visible_on_screen_notifier_3d.h
+++ b/scene/3d/visible_on_screen_notifier_3d.h
@@ -47,6 +47,7 @@ protected:
 	virtual void _screen_exit() {}
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -77,6 +78,7 @@ protected:
 	NodePath enable_node_path = NodePath("..");
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	void _update_enable_mode(bool p_enable);

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -48,6 +48,7 @@ protected:
 	void set_instance_use_identity_transform(bool p_enable);
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
 

--- a/scene/3d/world_environment.h
+++ b/scene/3d/world_environment.h
@@ -48,6 +48,7 @@ class WorldEnvironment : public Node {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/3d/xr/xr_body_modifier_3d.h
+++ b/scene/3d/xr/xr_body_modifier_3d.h
@@ -66,6 +66,7 @@ public:
 	BoneUpdate get_bone_update() const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 protected:
 	static void _bind_methods();

--- a/scene/3d/xr/xr_face_modifier_3d.h
+++ b/scene/3d/xr/xr_face_modifier_3d.h
@@ -67,4 +67,5 @@ public:
 	NodePath get_target() const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 };

--- a/scene/3d/xr/xr_hand_modifier_3d.h
+++ b/scene/3d/xr/xr_hand_modifier_3d.h
@@ -57,6 +57,7 @@ public:
 	PackedStringArray get_configuration_warnings() const override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 protected:
 	static void _bind_methods();

--- a/scene/3d/xr/xr_nodes.h
+++ b/scene/3d/xr/xr_nodes.h
@@ -54,6 +54,7 @@ protected:
 	void _removed_tracker(const StringName &p_tracker_name, int p_tracker_type);
 	void _pose_changed(const Ref<XRPose> &p_pose);
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	PackedStringArray get_configuration_warnings() const override;
@@ -99,6 +100,7 @@ protected:
 
 	void _update_visibility();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void _validate_property(PropertyInfo &p_property) const;
@@ -200,6 +202,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	virtual void _physics_interpolated_changed() override;
 

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -345,6 +345,7 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void _validate_property(PropertyInfo &p_property) const;
 
 #ifdef TOOLS_ENABLED

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -144,6 +144,7 @@ protected:
 	virtual void _validate_property(PropertyInfo &p_property) const override;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -318,6 +318,7 @@ private:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	virtual void _validate_property(PropertyInfo &p_property) const override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods();
 

--- a/scene/animation/root_motion_view.h
+++ b/scene/animation/root_motion_view.h
@@ -51,6 +51,7 @@ public:
 
 private:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -61,6 +61,7 @@ private:
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/scene/gui/aspect_ratio_container.h
+++ b/scene/gui/aspect_ratio_container.h
@@ -37,6 +37,7 @@ class AspectRatioContainer : public Container {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	virtual Size2 get_minimum_size() const override;
 

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -84,6 +84,7 @@ protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	bool _was_pressed_by_mouse() const;
 

--- a/scene/gui/box_container.h
+++ b/scene/gui/box_container.h
@@ -56,6 +56,7 @@ protected:
 	bool is_fixed = false;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -117,6 +117,7 @@ protected:
 	Ref<StyleBox> _get_current_stylebox() const;
 	Size2 _get_largest_stylebox_size() const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/center_container.h
+++ b/scene/gui/center_container.h
@@ -39,6 +39,7 @@ class CenterContainer : public Container {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/check_box.h
+++ b/scene/gui/check_box.h
@@ -58,6 +58,7 @@ protected:
 	Size2 get_minimum_size() const override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	bool is_radio();

--- a/scene/gui/check_button.h
+++ b/scene/gui/check_button.h
@@ -58,6 +58,7 @@ protected:
 	virtual Size2 get_minimum_size() const override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -313,6 +313,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -65,6 +65,7 @@ class ColorPresetButton : public BaseButton {
 
 protected:
 	void _notification(int);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -345,6 +346,7 @@ protected:
 	virtual void _update_theme_item_cache() override;
 
 	void _notification(int);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -458,6 +460,7 @@ class ColorPickerButton : public Button {
 
 protected:
 	void _notification(int);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/color_rect.h
+++ b/scene/gui/color_rect.h
@@ -39,6 +39,7 @@ class ColorRect : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -57,6 +57,7 @@ protected:
 	GDVIRTUAL0RC(Vector<int>, _get_allowed_size_flags_vertical)
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -369,6 +369,7 @@ protected:
 	// Base object overrides.
 
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	// Exposed virtual methods.

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -79,6 +79,7 @@ protected:
 	virtual void _post_popup() override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	virtual void ok_pressed() {}

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -218,6 +218,7 @@ private:
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	bool _set(const StringName &p_name, const Variant &p_value) { return property_helper.property_set_value(p_name, p_value); }
 	bool _get(const StringName &p_name, Variant &r_ret) const { return property_helper.property_get_value(p_name, r_ret); }
 	void _get_property_list(List<PropertyInfo> *p_list) const { property_helper.get_property_list(p_list); }

--- a/scene/gui/flow_container.h
+++ b/scene/gui/flow_container.h
@@ -70,6 +70,7 @@ protected:
 	bool is_fixed = false;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -375,6 +375,7 @@ protected:
 	virtual void remove_child_notify(Node *p_child) override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 #ifndef DISABLE_DEPRECATED
 	static void _bind_compatibility_methods();

--- a/scene/gui/graph_element.h
+++ b/scene/gui/graph_element.h
@@ -59,6 +59,7 @@ protected:
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_ev) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	virtual void _resort();

--- a/scene/gui/graph_frame.h
+++ b/scene/gui/graph_frame.h
@@ -71,6 +71,7 @@ protected:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	void _validate_property(PropertyInfo &p_property) const;

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -100,6 +100,7 @@ class GraphNode : public GraphElement {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	virtual void _resort() override;

--- a/scene/gui/grid_container.h
+++ b/scene/gui/grid_container.h
@@ -44,6 +44,7 @@ class GridContainer : public Container {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -173,6 +173,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const { return property_helper.property_get_value(p_name, r_ret); }
 	void _get_property_list(List<PropertyInfo> *p_list) const { property_helper.get_property_list(p_list); }

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -115,6 +115,7 @@ protected:
 	int get_layout_data(Vector2 &r_offset, int &r_last_line, int &r_line_spacing) const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -258,6 +258,7 @@ protected:
 	virtual void _update_theme_item_cache() override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -80,6 +80,7 @@ protected:
 	virtual Size2 get_minimum_size() const override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/margin_container.h
+++ b/scene/gui/margin_container.h
@@ -44,6 +44,7 @@ class MarginContainer : public Container {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/menu_bar.h
+++ b/scene/gui/menu_bar.h
@@ -142,6 +142,7 @@ protected:
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void move_child_notify(Node *p_child) override;
 	virtual void remove_child_notify(Node *p_child) override;

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -49,6 +49,7 @@ class MenuButton : public Button {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const { property_helper.get_property_list(p_list); }

--- a/scene/gui/nine_patch_rect.h
+++ b/scene/gui/nine_patch_rect.h
@@ -54,6 +54,7 @@ public:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual Size2 get_minimum_size() const override;
 	static void _bind_methods();
 

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -82,6 +82,7 @@ protected:
 	virtual String _get_translated_text(const String &p_text) const override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const { return property_helper.property_get_value(p_name, r_ret); }
 	void _get_property_list(List<PropertyInfo> *p_list) const { property_helper.get_property_list(p_list); }

--- a/scene/gui/panel.h
+++ b/scene/gui/panel.h
@@ -41,6 +41,7 @@ class Panel : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/panel_container.h
+++ b/scene/gui/panel_container.h
@@ -41,6 +41,7 @@ class PanelContainer : public Container {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -61,6 +61,7 @@ protected:
 	virtual void _input_from_window(const Ref<InputEvent> &p_event) override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
@@ -95,6 +96,7 @@ protected:
 	void _update_child_rects() const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	virtual Size2 _get_contents_minimum_size() const override;

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -226,6 +226,7 @@ protected:
 	virtual void _input_from_window(const Ref<InputEvent> &p_event) override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const { return property_helper.property_get_value(p_name, r_ret); }
 	void _get_property_list(List<PropertyInfo> *p_list) const { property_helper.get_property_list(p_list); }

--- a/scene/gui/progress_bar.h
+++ b/scene/gui/progress_bar.h
@@ -52,6 +52,7 @@ class ProgressBar : public Range {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();

--- a/scene/gui/reference_rect.h
+++ b/scene/gui/reference_rect.h
@@ -41,6 +41,7 @@ class ReferenceRect : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -129,6 +129,7 @@ protected:
 	virtual void _update_theme_item_cache() override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -107,6 +107,7 @@ class ScrollBar : public Range {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -93,6 +93,7 @@ protected:
 	void _reposition_children();
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	bool _updating_scrollbars = false;

--- a/scene/gui/separator.h
+++ b/scene/gui/separator.h
@@ -43,6 +43,7 @@ protected:
 	Orientation orientation = Orientation::HORIZONTAL;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -72,6 +72,7 @@ protected:
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -142,6 +142,7 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -39,6 +39,7 @@ class SplitContainerDragger : public Control {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 private:
@@ -97,6 +98,7 @@ protected:
 	bool is_fixed = false;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -46,6 +46,7 @@ class SubViewportContainer : public Container {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	virtual void add_child_notify(Node *p_child) override;

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -180,6 +180,7 @@ protected:
 	bool _property_can_revert(const StringName &p_name) const { return property_helper.property_can_revert(p_name); }
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return property_helper.property_get_revert(p_name, r_property); }
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	Variant get_drag_data(const Point2 &p_point) override;

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -123,6 +123,7 @@ protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void move_child_notify(Node *p_child) override;
 	virtual void remove_child_notify(Node *p_child) override;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -659,6 +659,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/gui/texture_button.h
+++ b/scene/gui/texture_button.h
@@ -70,6 +70,7 @@ protected:
 	virtual Size2 get_minimum_size() const override;
 	virtual bool has_point(const Point2 &p_point) const override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/texture_progress_bar.h
+++ b/scene/gui/texture_progress_bar.h
@@ -42,6 +42,7 @@ class TextureProgressBar : public Range {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:

--- a/scene/gui/texture_rect.h
+++ b/scene/gui/texture_rect.h
@@ -66,6 +66,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	virtual Size2 get_minimum_size() const override;
 	static void _bind_methods();
 #ifndef DISABLE_DEPRECATED

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -718,6 +718,7 @@ protected:
 	virtual void _update_theme_item_cache() override;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -79,6 +79,7 @@ class VideoStreamPlayer : public Control {
 protected:
 	static void _bind_methods();
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -172,6 +172,7 @@ protected:
 	void set_canvas_item_use_identity_transform(bool p_enable);
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -62,6 +62,7 @@ class CanvasLayer : public Node {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
 

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -121,6 +121,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -339,6 +339,7 @@ protected:
 	void _unblock() { data.blocked--; }
 
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual void _physics_interpolated_changed();
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -272,6 +272,7 @@ private:
 
 protected:
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/main/shader_globals_override.h
+++ b/scene/main/shader_globals_override.h
@@ -54,6 +54,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/main/status_indicator.h
+++ b/scene/main/status_indicator.h
@@ -44,6 +44,7 @@ class StatusIndicator : public Node {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	void _callback(MouseButton p_index, const Point2i &p_pos);

--- a/scene/main/timer.h
+++ b/scene/main/timer.h
@@ -46,6 +46,7 @@ class Timer : public Node {
 
 protected:
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -500,6 +500,7 @@ protected:
 	bool _is_size_allocated() const;
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 #if !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
 	void _process_picking();
 #endif // !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
@@ -860,6 +861,7 @@ protected:
 	static void _bind_methods();
 	virtual DisplayServer::WindowID get_window_id() const override;
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	void set_size(const Size2i &p_size);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -252,6 +252,7 @@ protected:
 	virtual void _input_from_window(const Ref<InputEvent> &p_event) {}
 
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -684,6 +684,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:
@@ -813,6 +814,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 	void _notification(int p_notification);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -624,6 +624,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	virtual void _create_mesh_array(Array &p_arr) const override;
 

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -471,6 +471,7 @@ protected:
 	void _notification(int p_what) {
 		order_superclass = ++order_global;
 	}
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	static inline int order_global = 0;
@@ -484,6 +485,7 @@ protected:
 	void _notification(int p_what) {
 		order_subclass = ++order_global;
 	}
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	int order_subclass = -1;

--- a/tests/scene/test_node.h
+++ b/tests/scene/test_node.h
@@ -62,6 +62,7 @@ protected:
 			} break;
 		}
 	}
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 	static void _bind_methods() {
 		ClassDB::bind_method(D_METHOD("set_exported_node", "node"), &TestNode::set_exported_node);

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -82,6 +82,7 @@ protected:
 			} break;
 		}
 	}
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	bool mouse_over = false;
@@ -135,6 +136,7 @@ protected:
 			} break;
 		}
 	}
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	Variant drag_data;

--- a/tests/scene/test_window.h
+++ b/tests/scene/test_window.h
@@ -52,6 +52,7 @@ protected:
 			} break;
 		}
 	}
+	GDCLASS_RECEIVE_NOTIFICATIONS(_notification);
 
 public:
 	bool mouse_over = false;


### PR DESCRIPTION
Notifications are currently 'subscribed to' by declaring the magical `_notification` function.
To accomodate this, every `GDCLASS` overrides `_notification_forwardv` and `_notification_backwardv`, which is wasteful and somewhat confusing.

Instead, I propose to make subscribing to notifications explicit, by declaring `GDCLASS_RECEIVE_NOTIFICATIONS`. 
I don't think it will have noticeable performance impact (although it may be slightly favorable due to code caches). Similar changes could be applied to other "magic" functions, like `_bind_methods`.

In turn, it's a breaking change for modules, and a harsh one at that: I don't think it will be possible to statically fail to notify updaters they have to change code (or at least, I didn't find any way to).

Currently, I'm thinking to keep this idea for 5.x since there's no tangible benefit to it now, and it's a little annoying for updaters. That's why I'm making it a draft.
But I'd like to hear other people's opinion :)

## Implementation side note
Almost all code updates are a single search replace:
```
void _notification\(int p_what\)\;
void _notification(int p_what);\n\tGDCLASS_RECEIVE_NOTIFICATIONS(_notification);
```