### PR TITLE
[3.x] Physics Interpolation - Add `InterpolatedProperty`

### DIFF
--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -552,10 +552,14 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #endif
 
 #ifdef DEV_ENABLED
-#define DEV_CHECK_ONCE(m_cond)                                                   \
-	if (unlikely(!(m_cond))) {                                                   \
-		ERR_PRINT_ONCE("DEV_CHECK_ONCE failed  \"" _STR(m_cond) "\" is false."); \
-	} else                                                                       \
+#define DEV_CHECK_ONCE(m_cond)                                                                                           \
+	if (true) {                                                                                                          \
+		static bool first_print = true;                                                                                  \
+		if (first_print && unlikely(!(m_cond))) {                                                                        \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "DEV_CHECK_ONCE failed  \"" _STR(m_cond) "\" is false."); \
+			first_print = false;                                                                                         \
+		}                                                                                                                \
+	} else                                                                                                               \
 		((void)0)
 #else
 #define DEV_CHECK_ONCE(m_cond)

--- a/core/interpolated_property.cpp
+++ b/core/interpolated_property.cpp
@@ -1,0 +1,46 @@
+/**************************************************************************/
+/*  interpolated_property.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "interpolated_property.h"
+
+#include "core/math/math_defs.h"
+#include "core/math/vector2.h"
+
+namespace InterpolatedPropertyFuncs {
+
+float lerp(float p_a, float p_b, float p_fraction) {
+	return Math::lerp(p_a, p_b, p_fraction);
+}
+
+Vector2 lerp(const Vector2 &p_a, const Vector2 &p_b, float p_fraction) {
+	return p_a.linear_interpolate(p_b, p_fraction);
+}
+
+} //namespace InterpolatedPropertyFuncs

--- a/core/interpolated_property.h
+++ b/core/interpolated_property.h
@@ -1,0 +1,109 @@
+/**************************************************************************/
+/*  interpolated_property.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef INTERPOLATED_PROPERTY_H
+#define INTERPOLATED_PROPERTY_H
+
+struct Vector2;
+
+namespace InterpolatedPropertyFuncs {
+float lerp(float p_a, float p_b, float p_fraction);
+Vector2 lerp(const Vector2 &p_a, const Vector2 &p_b, float p_fraction);
+} //namespace InterpolatedPropertyFuncs
+
+// This class is intended to reduce the boiler plate involved to
+// support custom properties to be physics interpolated.
+
+template <class T>
+class InterpolatedProperty {
+	// Only needs interpolating / updating the servers when
+	// curr and prev are different.
+	bool _needs_interpolating = false;
+	T _interpolated;
+	T curr;
+	T prev;
+
+public:
+	// FTI depends on the constant flow between current values
+	// (on the current tick) and stored previous values (on the previous tick).
+	// These should be updated both on each tick, and also on resets.
+	void pump() {
+		prev = curr;
+		_needs_interpolating = false;
+	}
+	void reset() { pump(); }
+
+	void set_interpolated_value(const T &p_val) {
+		_interpolated = p_val;
+	}
+	const T &interpolated() const { return _interpolated; }
+	bool needs_interpolating() const { return _needs_interpolating; }
+
+	bool interpolate(float p_interpolation_fraction) {
+		if (_needs_interpolating) {
+			_interpolated = InterpolatedPropertyFuncs::lerp(prev, curr, p_interpolation_fraction);
+			return true;
+		}
+		return false;
+	}
+
+	operator T() const {
+		return curr;
+	}
+
+	bool operator==(const T &p_o) const {
+		return p_o == curr;
+	}
+
+	bool operator!=(const T &p_o) const {
+		return p_o != curr;
+	}
+
+	InterpolatedProperty &operator=(T p_val) {
+		curr = p_val;
+		_interpolated = p_val;
+		_needs_interpolating = true;
+		return *this;
+	}
+	InterpolatedProperty(T p_val) {
+		curr = p_val;
+		_interpolated = p_val;
+		pump();
+	}
+	InterpolatedProperty() {
+		// Ensure either the constructor is run,
+		// or the memory is zeroed if using a fundamental type.
+		_interpolated = T{};
+		curr = T{};
+		prev = T{};
+	}
+};
+
+#endif // INTERPOLATED_PROPERTY_H

--- a/scene/3d/camera.h
+++ b/scene/3d/camera.h
@@ -31,6 +31,7 @@
 #ifndef CAMERA_H
 #define CAMERA_H
 
+#include "core/interpolated_property.h"
 #include "scene/3d/spatial.h"
 #include "scene/3d/spatial_velocity_tracker.h"
 #include "scene/main/viewport.h"
@@ -66,10 +67,12 @@ private:
 
 	Projection mode;
 
-	float fov;
-	float size;
-	Vector2 frustum_offset;
-	float near, far;
+	InterpolatedProperty<float> fov;
+	InterpolatedProperty<float> near;
+	InterpolatedProperty<float> far;
+
+	InterpolatedProperty<float> size;
+	InterpolatedProperty<Vector2> frustum_offset;
 	float v_offset;
 	float h_offset;
 	KeepAspect keep_aspect;
@@ -109,7 +112,10 @@ protected:
 	void _update_camera();
 	virtual void _request_camera_update();
 	void _update_camera_mode();
-	virtual void fti_update_servers();
+
+	virtual void fti_pump_property();
+	virtual void fti_update_servers_property();
+	virtual void fti_update_servers_xform();
 
 	void _notification(int p_what);
 	virtual void _validate_property(PropertyInfo &p_property) const;
@@ -230,9 +236,9 @@ private:
 
 protected:
 	virtual Transform _get_adjusted_camera_transform(const Transform &p_xform) const;
-	virtual void fti_pump();
+	virtual void fti_pump_xform();
+	virtual void fti_update_servers_xform();
 	virtual void _physics_interpolated_changed();
-	virtual void fti_update_servers();
 	///////////////////////////////////////////////////////
 
 	void _notification(int p_what);

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -123,8 +123,10 @@ private:
 		bool disable_scale : 1;
 
 		// Scene tree interpolation
-		bool fti_on_frame_list : 1;
-		bool fti_on_tick_list : 1;
+		bool fti_on_frame_xform_list : 1;
+		bool fti_on_frame_property_list : 1;
+		bool fti_on_tick_xform_list : 1;
+		bool fti_on_tick_property_list : 1;
 		bool fti_global_xform_interp_set : 1;
 
 		bool merging_allowed : 1;
@@ -166,18 +168,23 @@ protected:
 	// Calling this announces to the FTI system that a node has been moved,
 	// or requires an update in terms of interpolation
 	// (e.g. changing Camera zoom even if position hasn't changed).
-	void fti_notify_node_changed();
+	void fti_notify_node_changed(bool p_transform_changed = true);
 
 	// Opportunity after FTI to update the servers
 	// with global_transform_interpolated,
 	// and any custom interpolated data in derived classes.
 	// Make sure to call the parent class fti_update_servers(),
 	// so all data is updated to the servers.
-	virtual void fti_update_servers() {}
+	virtual void fti_update_servers_xform() {}
+	virtual void fti_update_servers_property() {}
 
 	// Pump the FTI data, also gives a chance for inherited classes
 	// to pump custom data, but they *must* call the base class here too.
-	virtual void fti_pump();
+	// This is the opportunity for classes to move current values for
+	// transforms and properties to stored previous values,
+	// and this should take place both on ticks, and during resets.
+	virtual void fti_pump_xform();
+	virtual void fti_pump_property() {}
 
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -82,7 +82,7 @@ void VisualInstance::set_instance_use_identity_transform(bool p_enable) {
 	}
 }
 
-void VisualInstance::fti_update_servers() {
+void VisualInstance::fti_update_servers_xform() {
 	if (!_is_using_identity_transform()) {
 		VisualServer::get_singleton()->instance_set_transform(get_instance(), _get_cached_global_transform_interpolated());
 	}

--- a/scene/3d/visual_instance.h
+++ b/scene/3d/visual_instance.h
@@ -52,7 +52,7 @@ protected:
 	void _update_visibility();
 	virtual void _refresh_portal_mode();
 	void set_instance_use_identity_transform(bool p_enable);
-	virtual void fti_update_servers();
+	virtual void fti_update_servers_xform();
 
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
Adds framework for `InterpolatedProperties`.
Adds interpolated properties to `Camera`.

Interpolates:
* Perspective (fov, near, far)
* Orthogonal (size, near, far)
* Frustum (size, frustum_offset, near, far)

Implements https://github.com/godotengine/godot-proposals/issues/9964 .

## Notes
* The move from server to scene side FTI makes this far easier.
* `Camera` provides a good test case for adding some custom interpolated properties.
* We could do all of it manually, but it makes some sense to create a helper template to reduce boiler plate.
* The `InterpolatedProperty` emulates the underlying type (for when FTI is off), but has some extra functionality available.
* Standardizes the use of `fti_pump()` for more reset functionality in `Spatial` derived classes.
* Automatically responds to `reset_physics_interpolation()` user calls.

## Discussion
While implementing this I made some minor adjustments to `SceneTreeFTI` to better support properties.

Properties aren't inherited and concatenated like scene tree xforms, so it turned out these are more efficient to handle separately.

* They only need to be updated once per frame (at the end) instead of two passes.
* They can maintain their own frame update list, instead of checking each node in the `SceneTree`, as often only a few nodes will need properties interpolating.
* Nodes when notifying changes now indicate via a bool whether the changes are to the transform, or to properties. In most cases transforms are already handled by the `Spatial` base class, so in most custom cases in the future contributors will be notifying custom property changes.

### `fti_pump` and `fti_update_servers`
One slightly controversial change it that `fti_pump()` and `fti_update_servers` is now separated into two versions - for xforms and for properties.

As far as I can see this is the most efficient way of handling it, even if it may look slightly more confusing in say the `Camera` class, where we have to update servers for _both_ xform and properties.

An alternative would be to send e.g. a `bool` with the two routines, however there is more opportunity to "shoot yourself in the foot" with that approach, particularly regarding calling the parent class routines.

In practice, most classes that custom interpolate will only be updating properties, and will rely on `Spatial` for xforms, so will only have to implement `fti_pump_property()` and `fti_update_servers_property()` - `Camera` is to some extent an anomaly and a worst case situation, so good to handle first.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
