### PR TITLE
Remove unused `get_valid_parents_static` functions from `GDCLASS`.

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -258,12 +258,6 @@ void Object::_postinitialize() {
 	notification(NOTIFICATION_POSTINITIALIZE);
 }
 
-void Object::get_valid_parents_static(List<String> *p_parents) {
-}
-
-void Object::_get_valid_parents_static(List<String> *p_parents) {
-}
-
 void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid) {
 #ifdef TOOLS_ENABLED
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -442,13 +442,6 @@ public:                                                                         
 		}                                                                                                                                   \
 		return (p_class == (#m_class)) ? true : m_inherits::is_class(p_class);                                                              \
 	}                                                                                                                                       \
-	static void get_valid_parents_static(List<String> *p_parents) {                                                                         \
-		if (m_class::_get_valid_parents_static != m_inherits::_get_valid_parents_static) {                                                  \
-			m_class::_get_valid_parents_static(p_parents);                                                                                  \
-		}                                                                                                                                   \
-                                                                                                                                            \
-		m_inherits::get_valid_parents_static(p_parents);                                                                                    \
-	}                                                                                                                                       \
                                                                                                                                             \
 protected:                                                                                                                                  \
 	_FORCE_INLINE_ static void (*_get_bind_methods())() {                                                                                   \
@@ -749,8 +742,6 @@ protected:
 	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) {
 		return &Object::_notification;
 	}
-	static void get_valid_parents_static(List<String> *p_parents);
-	static void _get_valid_parents_static(List<String> *p_parents);
 
 	Variant _call_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 	Variant _call_deferred_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);


### PR DESCRIPTION
My next code cleanup victim is apparently `GDCLASS`. I found a function that isn't in use, and has apparently existed since Godot was made open source.
Calling the function would always return empty lists, and it isn't used anywhere, so we should remove it.