### PR TITLE
Optimize `is_class` by using static types instead of strings.

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -2191,7 +2191,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 #ifdef REAL_T_IS_DOUBLE
 		format_flags |= FORMAT_FLAG_REAL_T_IS_DOUBLE;
 #endif
-		if (!p_resource->is_class("PackedScene")) {
+		if (!p_resource->is_class_by_name("PackedScene")) {
 			Ref<Script> s = p_resource->get_script();
 			if (s.is_valid()) {
 				script_class = s->get_global_name();

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1461,7 +1461,7 @@ bool ResourceLoader::add_custom_resource_format_loader(const String &script_path
 
 	Ref<Resource> res = ResourceLoader::load(script_path);
 	ERR_FAIL_COND_V(res.is_null(), false);
-	ERR_FAIL_COND_V(!res->is_class("Script"), false);
+	ERR_FAIL_COND_V(!res->is_class<Script>(), false);
 
 	Ref<Script> s = res;
 	StringName ibt = s->get_instance_base_type();

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -233,7 +233,7 @@ bool ResourceSaver::add_custom_resource_format_saver(const String &script_path) 
 
 	Ref<Resource> res = ResourceLoader::load(script_path);
 	ERR_FAIL_COND_V(res.is_null(), false);
-	ERR_FAIL_COND_V(!res->is_class("Script"), false);
+	ERR_FAIL_COND_V(!res->is_class<Script>(), false);
 
 	Ref<Script> s = res;
 	StringName ibt = s->get_instance_base_type();

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -548,7 +548,7 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 
 	_get_property_listv(p_list, p_reversed);
 
-	if (!is_class("Script")) { // can still be set, but this is for user-friendliness
+	if (!is_class<Script>()) { // can still be set, but this is for user-friendliness
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NEVER_DUPLICATE));
 	}
 
@@ -1707,7 +1707,7 @@ void Object::notify_property_list_changed() {
 
 void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_class"), &Object::get_class);
-	ClassDB::bind_method(D_METHOD("is_class", "class"), &Object::is_class);
+	ClassDB::bind_method(D_METHOD("is_class", "class"), &Object::is_class_by_name);
 	ClassDB::bind_method(D_METHOD("set", "property", "value"), &Object::_set_bind);
 	ClassDB::bind_method(D_METHOD("get", "property"), &Object::_get_bind);
 	ClassDB::bind_method(D_METHOD("set_indexed", "property_path", "value"), &Object::_set_indexed_bind);
@@ -2411,10 +2411,10 @@ void ObjectDB::cleanup() {
 					Object *obj = object_slots[i].object;
 
 					String extra_info;
-					if (obj->is_class("Node")) {
+					if (obj->is_class_by_name("Node")) {
 						extra_info = " - Node path: " + String(node_get_path->call(obj, nullptr, 0, call_error));
 					}
-					if (obj->is_class("Resource")) {
+					if (obj->is_class_by_name("Resource")) {
 						extra_info = " - Resource path: " + String(resource_get_path->call(obj, nullptr, 0, call_error));
 					}
 

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -829,7 +829,7 @@ void PlaceHolderScriptInstance::property_set_fallback(const StringName &p_name, 
 		if (!found) {
 			PropertyHint hint = PROPERTY_HINT_NONE;
 			const Object *obj = p_value.get_validated_object();
-			if (obj && obj->is_class("Node")) {
+			if (obj && obj->is_class_by_name("Node")) {
 				hint = PROPERTY_HINT_NODE_TYPE;
 			}
 			properties.push_back(PropertyInfo(p_value.get_type(), p_name, hint, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_SCRIPT_VARIABLE));

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -94,7 +94,7 @@ Error Callable::rpcp(int p_id, const Variant **p_arguments, int p_argcount, Call
 	} else if (!is_custom()) {
 		Object *obj = ObjectDB::get_instance(ObjectID(object));
 #ifdef DEBUG_ENABLED
-		if (!obj || !obj->is_class("Node")) {
+		if (!obj || !obj->is_class_by_name("Node")) {
 			r_call_error.error = CallError::CALL_ERROR_INSTANCE_IS_NULL;
 			r_call_error.argument = 0;
 			r_call_error.expected = 0;

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -73,7 +73,7 @@ Vector<uint8_t> ResourceSaverPNG::save_image_to_buffer(const Ref<Image> &p_img) 
 }
 
 bool ResourceSaverPNG::recognize(const Ref<Resource> &p_resource) const {
-	return (p_resource.is_valid() && p_resource->is_class("ImageTexture"));
+	return (p_resource.is_valid() && p_resource->is_class<ImageTexture>());
 }
 
 void ResourceSaverPNG::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5263,12 +5263,12 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 	ERR_FAIL_NULL(node);
 	NodePath path_to = root->get_path_to(node, true);
 
-	if (adding_track_type == Animation::TYPE_BLEND_SHAPE && !node->is_class("MeshInstance3D")) {
+	if (adding_track_type == Animation::TYPE_BLEND_SHAPE && !node->is_class<MeshInstance3D>()) {
 		EditorNode::get_singleton()->show_warning(TTR("Blend Shape tracks only apply to MeshInstance3D nodes."));
 		return;
 	}
 
-	if ((adding_track_type == Animation::TYPE_POSITION_3D || adding_track_type == Animation::TYPE_ROTATION_3D || adding_track_type == Animation::TYPE_SCALE_3D) && !node->is_class("Node3D")) {
+	if ((adding_track_type == Animation::TYPE_POSITION_3D || adding_track_type == Animation::TYPE_ROTATION_3D || adding_track_type == Animation::TYPE_SCALE_3D) && !node->is_class<Node3D>()) {
 		EditorNode::get_singleton()->show_warning(TTR("Position/Rotation/Scale 3D tracks only apply to 3D-based nodes."));
 		return;
 	}
@@ -5313,7 +5313,7 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 			prop_selector->select_property_from_instance(node);
 		} break;
 		case Animation::TYPE_AUDIO: {
-			if (!node->is_class("AudioStreamPlayer") && !node->is_class("AudioStreamPlayer2D") && !node->is_class("AudioStreamPlayer3D")) {
+			if (!node->is_class_by_name("AudioStreamPlayer") && !node->is_class_by_name("AudioStreamPlayer2D") && !node->is_class_by_name("AudioStreamPlayer3D")) {
 				EditorNode::get_singleton()->show_warning(TTR("Audio tracks can only point to nodes of type:\n-AudioStreamPlayer\n-AudioStreamPlayer2D\n-AudioStreamPlayer3D"));
 				return;
 			}
@@ -5327,7 +5327,7 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 
 		} break;
 		case Animation::TYPE_ANIMATION: {
-			if (!node->is_class("AnimationPlayer")) {
+			if (!node->is_class<AnimationPlayer>()) {
 				EditorNode::get_singleton()->show_warning(TTR("Animation tracks can only point to AnimationPlayer nodes."));
 				return;
 			}

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -1324,26 +1324,26 @@ void AnimationTrackEditTypeAnimation::set_node(Object *p_object) {
 
 /////////
 AnimationTrackEdit *AnimationTrackEditDefaultPlugin::create_value_track_edit(Object *p_object, Variant::Type p_type, const String &p_property, PropertyHint p_hint, const String &p_hint_string, int p_usage) {
-	if (p_property == "playing" && (p_object->is_class("AudioStreamPlayer") || p_object->is_class("AudioStreamPlayer2D") || p_object->is_class("AudioStreamPlayer3D"))) {
+	if (p_property == "playing" && (p_object->is_class_by_name("AudioStreamPlayer") || p_object->is_class_by_name("AudioStreamPlayer2D") || p_object->is_class_by_name("AudioStreamPlayer3D"))) {
 		AnimationTrackEditAudio *audio = memnew(AnimationTrackEditAudio);
 		audio->set_node(p_object);
 		return audio;
 	}
 
-	if (p_property == "frame" && (p_object->is_class("Sprite2D") || p_object->is_class("Sprite3D") || p_object->is_class("AnimatedSprite2D") || p_object->is_class("AnimatedSprite3D"))) {
+	if (p_property == "frame" && (p_object->is_class<Sprite2D>() || p_object->is_class<Sprite3D>() || p_object->is_class<AnimatedSprite2D>() || p_object->is_class<AnimatedSprite3D>())) {
 		AnimationTrackEditSpriteFrame *sprite = memnew(AnimationTrackEditSpriteFrame);
 		sprite->set_node(p_object);
 		return sprite;
 	}
 
-	if (p_property == "frame_coords" && (p_object->is_class("Sprite2D") || p_object->is_class("Sprite3D"))) {
+	if (p_property == "frame_coords" && (p_object->is_class<Sprite2D>() || p_object->is_class<Sprite3D>())) {
 		AnimationTrackEditSpriteFrame *sprite = memnew(AnimationTrackEditSpriteFrame);
 		sprite->set_as_coords();
 		sprite->set_node(p_object);
 		return sprite;
 	}
 
-	if (p_property == "current_animation" && (p_object->is_class("AnimationPlayer"))) {
+	if (p_property == "current_animation" && (p_object->is_class<AnimationPlayer>())) {
 		AnimationTrackEditSubAnim *player = memnew(AnimationTrackEditSubAnim);
 		player->set_node(p_object);
 		return player;

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -981,7 +981,7 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 			emit_signal(SNAME("property_keyed"), property, use_keying_next());
 
 			if (use_keying_next()) {
-				if (property == "frame_coords" && (object->is_class("Sprite2D") || object->is_class("Sprite3D"))) {
+				if (property == "frame_coords" && (object->is_class_by_name("Sprite2D") || object->is_class_by_name("Sprite3D"))) {
 					Vector2i new_coords = object->get(property);
 					new_coords.x++;
 					if (new_coords.x >= int64_t(object->get("hframes"))) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1541,7 +1541,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 
 	List<String> preferred;
 	for (const String &E : extensions) {
-		if (p_resource->is_class("Script") && (E == "tres" || E == "res")) {
+		if (p_resource->is_class<Script>() && (E == "tres" || E == "res")) {
 			// This serves no purpose and confused people.
 			continue;
 		}
@@ -1779,13 +1779,13 @@ void EditorNode::_save_edited_subresources(Node *scene, HashMap<Ref<Resource>, b
 }
 
 void EditorNode::_find_node_types(Node *p_node, int &count_2d, int &count_3d) {
-	if (p_node->is_class("Viewport") || (p_node != editor_data.get_edited_scene_root() && p_node->get_owner() != editor_data.get_edited_scene_root())) {
+	if (p_node->is_class<Viewport>() || (p_node != editor_data.get_edited_scene_root() && p_node->get_owner() != editor_data.get_edited_scene_root())) {
 		return;
 	}
 
-	if (p_node->is_class("CanvasItem")) {
+	if (p_node->is_class<CanvasItem>()) {
 		count_2d++;
-	} else if (p_node->is_class("Node3D")) {
+	} else if (p_node->is_class<Node3D>()) {
 		count_3d++;
 	}
 
@@ -2658,13 +2658,13 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 	}
 
 	// Update the use folding setting and state.
-	bool disable_folding = bool(EDITOR_GET("interface/inspector/disable_folding")) || current_obj->is_class("EditorDebuggerRemoteObjects");
+	bool disable_folding = bool(EDITOR_GET("interface/inspector/disable_folding")) || current_obj->is_class<EditorDebuggerRemoteObjects>();
 	if (InspectorDock::get_inspector_singleton()->is_using_folding() == disable_folding) {
 		InspectorDock::get_inspector_singleton()->set_use_folding(!disable_folding, false);
 	}
 
-	bool is_resource = current_obj->is_class("Resource");
-	bool is_node = current_obj->is_class("Node");
+	bool is_resource = current_obj->is_class<Resource>();
+	bool is_node = current_obj->is_class<Node>();
 	bool stay_in_script_editor_on_node_selected = bool(EDITOR_GET("text_editor/behavior/navigation/stay_in_script_editor_on_node_selected"));
 	bool skip_main_plugin = false;
 
@@ -2739,7 +2739,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 		Node *selected_node = nullptr;
 
 		Vector<Node *> multi_nodes;
-		if (current_obj->is_class("MultiNodeEdit")) {
+		if (current_obj->is_class<MultiNodeEdit>()) {
 			Node *scene = get_edited_scene();
 			if (scene) {
 				MultiNodeEdit *multi_node_edit = Object::cast_to<MultiNodeEdit>(current_obj);
@@ -2760,7 +2760,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 			}
 		}
 
-		if (!current_obj->is_class("EditorDebuggerRemoteObjects")) {
+		if (!current_obj->is_class<EditorDebuggerRemoteObjects>()) {
 			EditorDebuggerNode::get_singleton()->clear_remote_tree_selection();
 		}
 
@@ -2776,7 +2776,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 			editable_info,
 			info_is_warning);
 
-	Object *editor_owner = (is_node || current_obj->is_class("MultiNodeEdit")) ? (Object *)SceneTreeDock::get_singleton() : is_resource ? (Object *)InspectorDock::get_inspector_singleton()
+	Object *editor_owner = (is_node || current_obj->is_class<MultiNodeEdit>()) ? (Object *)SceneTreeDock::get_singleton() : is_resource ? (Object *)InspectorDock::get_inspector_singleton()
 																																		: (Object *)this;
 
 	// Take care of the main editor plugin.
@@ -5088,7 +5088,7 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 		return get_class_icon(class_name, p_fallback);
 	}
 
-	if (scr.is_null() && p_object->is_class("Script")) {
+	if (scr.is_null() && p_object->is_class<Script>()) {
 		scr = p_object;
 	}
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2851,7 +2851,7 @@ bool EditorPropertyNodePath::is_drop_valid(const Dictionary &p_drag_data) const 
 	}
 
 	for (const StringName &E : valid_types) {
-		if (dropped_node->is_class(E) ||
+		if (dropped_node->is_class_by_name(E) ||
 				EditorNode::get_singleton()->is_object_of_custom_type(dropped_node, E)) {
 			return true;
 		} else {

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -158,7 +158,7 @@ void EditorResourcePicker::_file_selected(const String &p_path) {
 		for (int i = 0; i < base_type.get_slice_count(","); i++) {
 			String base = base_type.get_slicec(',', i);
 
-			any_type_matches = is_global_class ? EditorNode::get_editor_data().script_class_is_parent(res_type, base) : loaded_resource->is_class(base);
+			any_type_matches = is_global_class ? EditorNode::get_editor_data().script_class_is_parent(res_type, base) : loaded_resource->is_class_by_name(base);
 
 			if (any_type_matches) {
 				break;

--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -147,7 +147,7 @@ void EditorObjectSelector::update_path() {
 				if (name.is_empty()) {
 					name = r->get_class();
 				}
-			} else if (obj->is_class("EditorDebuggerRemoteObjects")) {
+			} else if (obj->is_class_by_name("EditorDebuggerRemoteObjects")) {
 				name = obj->call("get_title");
 			} else if (Object::cast_to<Node>(obj)) {
 				name = Object::cast_to<Node>(obj)->get_name();

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -133,7 +133,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		undo_redo->add_undo_method(this, "emit_signal", "node_changed");
 		undo_redo->commit_action();
 	} else if (p_id == BUTTON_PIN) {
-		if (n->is_class("AnimationMixer")) {
+		if (n->is_class<AnimationMixer>()) {
 			AnimationPlayerEditor::get_singleton()->unpin();
 			_update_tree();
 		}
@@ -141,7 +141,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 	} else if (p_id == BUTTON_GROUP) {
 		undo_redo->create_action(TTR("Ungroup Children"));
 
-		if (n->is_class("CanvasItem") || n->is_class("Node3D")) {
+		if (n->is_class<CanvasItem>() || n->is_class<Node3D>()) {
 			undo_redo->add_do_method(n, "remove_meta", "_edit_group_");
 			undo_redo->add_undo_method(n, "set_meta", "_edit_group_", true);
 			undo_redo->add_do_method(this, "_update_tree");
@@ -346,7 +346,7 @@ void SceneTreeEditor::_update_node_subtree(Node *p_node, TreeItem *p_parent, boo
 	if (valid_types.size()) {
 		bool valid = false;
 		for (const StringName &E : valid_types) {
-			if (p_node->is_class(E) ||
+			if (p_node->is_class_by_name(E) ||
 					EditorNode::get_singleton()->is_object_of_custom_type(p_node, E)) {
 				valid = true;
 				break;
@@ -606,7 +606,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 			_update_visibility_color(p_node, p_item);
 		}
 
-		if (p_node->is_class("AnimationMixer")) {
+		if (p_node->is_class<AnimationMixer>()) {
 			bool is_pinned = AnimationPlayerEditor::get_singleton()->get_editing_node() == p_node && AnimationPlayerEditor::get_singleton()->is_pinned();
 
 			if (is_pinned) {
@@ -707,7 +707,7 @@ void SceneTreeEditor::_node_visibility_changed(Node *p_node) {
 
 	if (p_node->has_method("is_visible")) {
 		node_visible = p_node->call("is_visible");
-		if (p_node->is_class("CanvasItem") || p_node->is_class("CanvasLayer") || p_node->is_class("Window")) {
+		if (p_node->is_class<CanvasItem>() || p_node->is_class_by_name("CanvasLayer") || p_node->is_class<Window>()) {
 			CanvasItemEditor::get_singleton()->get_viewport_control()->queue_redraw();
 		}
 	}
@@ -985,7 +985,7 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 		if (!valid_types.is_empty()) {
 			selectable = false;
 			for (const StringName &E : valid_types) {
-				if (n->is_class(E) ||
+				if (n->is_class_by_name(E) ||
 						EditorNode::get_singleton()->is_object_of_custom_type(n, E)) {
 					selectable = true;
 					break;

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -353,7 +353,7 @@ void InspectorDock::_prepare_history() {
 			}
 		} else if (Object::cast_to<Node>(obj)) {
 			text = Object::cast_to<Node>(obj)->get_name();
-		} else if (obj->is_class("EditorDebuggerRemoteObjects")) {
+		} else if (obj->is_class<EditorDebuggerRemoteObjects>()) {
 			text = obj->call("get_title");
 		} else {
 			text = obj->get_class();
@@ -551,9 +551,9 @@ void InspectorDock::update(Object *p_object) {
 	current = p_object;
 
 	const bool is_object = p_object != nullptr;
-	const bool is_resource = is_object && p_object->is_class("Resource");
-	const bool is_text_file = is_object && p_object->is_class("TextFile");
-	const bool is_node = is_object && p_object->is_class("Node");
+	const bool is_resource = is_object && p_object->is_class<Resource>();
+	const bool is_text_file = is_object && p_object->is_class<TextFile>();
+	const bool is_node = is_object && p_object->is_class<Node>();
 
 	object_menu->set_disabled(!is_object || is_text_file);
 	search->set_editable(is_object && !is_text_file);

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -765,7 +765,7 @@ void AbstractPolygon2DEditorPlugin::edit(Object *p_object) {
 }
 
 bool AbstractPolygon2DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class(klass);
+	return p_object->is_class_by_name(klass);
 }
 
 void AbstractPolygon2DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1921,7 +1921,7 @@ AnimationMixer *AnimationPlayerEditor::fetch_mixer_for_library() const {
 		return nullptr;
 	}
 	// Does AnimationTree have AnimationPlayer?
-	if (original_node->is_class("AnimationTree")) {
+	if (original_node->is_class<AnimationTree>()) {
 		AnimationTree *src_tree = Object::cast_to<AnimationTree>(original_node);
 		Node *src_player = src_tree->get_node_or_null(src_tree->get_animation_player());
 		if (src_player) {
@@ -2322,7 +2322,7 @@ void AnimationPlayerEditorPlugin::edit(Object *p_object) {
 
 	AnimationMixer *src_node = Object::cast_to<AnimationMixer>(p_object);
 	bool is_dummy = false;
-	if (!p_object->is_class("AnimationPlayer")) {
+	if (!p_object->is_class<AnimationPlayer>()) {
 		// If it needs dummy AnimationPlayer, assign original AnimationMixer to LibraryEditor.
 		_update_dummy_player(src_node);
 
@@ -2392,7 +2392,7 @@ void AnimationPlayerEditorPlugin::_update_dummy_player(AnimationMixer *p_mixer) 
 }
 
 bool AnimationPlayerEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("AnimationPlayer") || p_object->is_class("AnimationTree") || p_object->is_class("AnimationMixer");
+	return p_object->is_class<AnimationPlayer>() || p_object->is_class<AnimationTree>() || p_object->is_class<AnimationMixer>();
 }
 
 void AnimationPlayerEditorPlugin::make_visible(bool p_visible) {
@@ -2434,7 +2434,7 @@ AnimationTrackKeyEditEditorPlugin::AnimationTrackKeyEditEditorPlugin() {
 }
 
 bool AnimationTrackKeyEditEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("AnimationTrackKeyEdit");
+	return p_object->is_class<AnimationTrackKeyEdit>();
 }
 
 bool EditorInspectorPluginAnimationMarkerKeyEdit::can_handle(Object *p_object) {
@@ -2455,5 +2455,5 @@ AnimationMarkerKeyEditEditorPlugin::AnimationMarkerKeyEditEditorPlugin() {
 }
 
 bool AnimationMarkerKeyEditEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("AnimationMarkerKeyEdit");
+	return p_object->is_class<AnimationMarkerKeyEdit>();
 }

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -964,7 +964,7 @@ void AnimationNodeStateMachineEditor::_clip_dst_line_to_rect(const Vector2 &p_fr
 
 Ref<StyleBox> AnimationNodeStateMachineEditor::_adjust_stylebox_opacity(Ref<StyleBox> p_style, float p_opacity) {
 	Ref<StyleBox> style = p_style->duplicate();
-	if (style->is_class("StyleBoxFlat")) {
+	if (style->is_class<StyleBoxFlat>()) {
 		Ref<StyleBoxFlat> flat_style = style;
 		Color bg_color = flat_style->get_bg_color();
 		Color border_color = flat_style->get_border_color();

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -282,7 +282,7 @@ void AnimationTreeEditorPlugin::edit(Object *p_object) {
 }
 
 bool AnimationTreeEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("AnimationTree");
+	return p_object->is_class<AnimationTree>();
 }
 
 void AnimationTreeEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/camera_2d_editor_plugin.cpp
+++ b/editor/plugins/camera_2d_editor_plugin.cpp
@@ -137,7 +137,7 @@ void Camera2DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Camera2DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("Camera2D");
+	return p_object->is_class<Camera2D>();
 }
 
 void Camera2DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/camera_3d_editor_plugin.cpp
+++ b/editor/plugins/camera_3d_editor_plugin.cpp
@@ -112,7 +112,7 @@ void Camera3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Camera3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("Camera3D");
+	return p_object->is_class<Camera3D>();
 }
 
 void Camera3DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5746,7 +5746,7 @@ void CanvasItemEditorPlugin::edit(Object *p_object) {
 }
 
 bool CanvasItemEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("CanvasItem");
+	return p_object->is_class<CanvasItem>();
 }
 
 void CanvasItemEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -651,7 +651,7 @@ void CollisionShape2DEditorPlugin::edit(Object *p_obj) {
 }
 
 bool CollisionShape2DEditorPlugin::handles(Object *p_obj) const {
-	return p_obj->is_class("CollisionShape2D");
+	return p_obj->is_class<CollisionShape2D>();
 }
 
 void CollisionShape2DEditorPlugin::make_visible(bool visible) {

--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -915,7 +915,7 @@ void FontPreview::_notification(int p_what) {
 					} else {
 						name = vformat("%s (%s)", prev_font->get_font_name(), prev_font->get_font_style_name());
 					}
-					if (prev_font->is_class("FontVariation")) {
+					if (prev_font->is_class<FontVariation>()) {
 						// TRANSLATORS: This refers to variable font config, appended to the font name.
 						name += " - " + TTR("Variation");
 					}

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -64,7 +64,7 @@ void GPUParticlesCollisionSDF3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool GPUParticlesCollisionSDF3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("GPUParticlesCollisionSDF3D");
+	return p_object->is_class<GPUParticlesCollisionSDF3D>();
 }
 
 void GPUParticlesCollisionSDF3DEditorPlugin::_notification(int p_what) {

--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -139,7 +139,7 @@ void LightmapGIEditorPlugin::edit(Object *p_object) {
 }
 
 bool LightmapGIEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("LightmapGI");
+	return p_object->is_class<LightmapGI>();
 }
 
 void LightmapGIEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -309,7 +309,7 @@ void MeshLibraryEditorPlugin::edit(Object *p_node) {
 }
 
 bool MeshLibraryEditorPlugin::handles(Object *p_node) const {
-	return p_node->is_class("MeshLibrary");
+	return p_node->is_class<MeshLibrary>();
 }
 
 void MeshLibraryEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -370,7 +370,7 @@ void MultiMeshEditorPlugin::edit(Object *p_object) {
 }
 
 bool MultiMeshEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("MultiMeshInstance3D");
+	return p_object->is_class<MultiMeshInstance3D>();
 }
 
 void MultiMeshEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1106,7 +1106,7 @@ void Node3DEditorViewport::_select_region() {
 		}
 
 		// Replace the node by the group if grouped
-		if (node->is_class("Node3D")) {
+		if (node->is_class<Node3D>()) {
 			Node3D *sel = Object::cast_to<Node3D>(node);
 			while (node && node != EditorNode::get_singleton()->get_edited_scene()->get_parent()) {
 				Node3D *selected_tmp = Object::cast_to<Node3D>(node);
@@ -4400,7 +4400,7 @@ void _insert_rid_recursive(Node *node, HashSet<RID> &rids) {
 
 	if (co) {
 		rids.insert(co->get_rid());
-	} else if (node->is_class("CSGShape3D")) { // HACK: We should avoid referencing module logic.
+	} else if (node->is_class_by_name("CSGShape3D")) { // HACK: We should avoid referencing module logic.
 		rids.insert(node->call("_get_root_collision_instance"));
 	}
 
@@ -9729,7 +9729,7 @@ void Node3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Node3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("Node3D");
+	return p_object->is_class<Node3D>();
 }
 
 Dictionary Node3DEditorPlugin::get_state() const {

--- a/editor/plugins/occluder_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/occluder_instance_3d_editor_plugin.cpp
@@ -87,7 +87,7 @@ void OccluderInstance3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool OccluderInstance3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("OccluderInstance3D");
+	return p_object->is_class<OccluderInstance3D>();
 }
 
 void OccluderInstance3DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -105,7 +105,7 @@ void ParticlesEditorPlugin::edit(Object *p_object) {
 }
 
 bool ParticlesEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class(handled_type);
+	return p_object->is_class_by_name(handled_type);
 }
 
 void ParticlesEditorPlugin::make_visible(bool p_visible) {
@@ -644,7 +644,7 @@ void Particles3DEditorPlugin::_node_selected(const NodePath &p_path) {
 		return;
 	}
 
-	if (!sel->is_class("Node3D")) {
+	if (!sel->is_class<Node3D>()) {
 		EditorNode::get_singleton()->show_warning(vformat(TTR("\"%s\" doesn't inherit from Node3D."), sel->get_name()));
 		return;
 	}

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -796,7 +796,7 @@ void Path2DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Path2DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("Path2D");
+	return p_object->is_class<Path2D>();
 }
 
 void Path2DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -751,7 +751,7 @@ void Path3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Path3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("Path3D");
+	return p_object->is_class<Path3D>();
 }
 
 void Path3DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/physical_bone_3d_editor_plugin.h
+++ b/editor/plugins/physical_bone_3d_editor_plugin.h
@@ -65,7 +65,7 @@ class PhysicalBone3DEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "PhysicalBone3D"; }
-	virtual bool handles(Object *p_object) const override { return p_object->is_class("PhysicalBone3D"); }
+	virtual bool handles(Object *p_object) const override { return p_object->is_class_by_name("PhysicalBone3D"); }
 	virtual void make_visible(bool p_visible) override;
 	virtual void edit(Object *p_node) override;
 };

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -401,7 +401,7 @@ void ResourcePreloaderEditorPlugin::edit(Object *p_object) {
 }
 
 bool ResourcePreloaderEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("ResourcePreloader");
+	return p_object->is_class<ResourcePreloader>();
 }
 
 void ResourcePreloaderEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -226,7 +226,7 @@ bool EditorInspectorRootMotionPlugin::can_handle(Object *p_object) {
 }
 
 bool EditorInspectorRootMotionPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
-	if (p_path == "root_motion_track" && p_object->is_class("AnimationMixer") && p_type == Variant::NODE_PATH) {
+	if (p_path == "root_motion_track" && p_object->is_class<AnimationMixer>() && p_type == Variant::NODE_PATH) {
 		EditorPropertyRootMotion *editor = memnew(EditorPropertyRootMotion);
 		add_property_editor(p_path, editor);
 		return true;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4571,7 +4571,7 @@ bool ScriptEditorPlugin::handles(Object *p_object) const {
 		return true;
 	}
 
-	return p_object->is_class("Script");
+	return p_object->is_class<Script>();
 }
 
 void ScriptEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -114,7 +114,7 @@ void Skeleton2DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Skeleton2DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("Skeleton2D");
+	return p_object->is_class<Skeleton2D>();
 }
 
 void Skeleton2DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -1424,7 +1424,7 @@ EditorPlugin::AfterGUIInput Skeleton3DEditorPlugin::forward_3d_gui_input(Camera3
 }
 
 bool Skeleton3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("Skeleton3D");
+	return p_object->is_class<Skeleton3D>();
 }
 
 void Skeleton3DEditor::_bone_enabled_changed(const int p_bone_id) {

--- a/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
@@ -62,7 +62,7 @@ void SkeletonIK3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool SkeletonIK3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("SkeletonIK3D");
+	return p_object->is_class<SkeletonIK3D>();
 }
 
 void SkeletonIK3DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -665,7 +665,7 @@ void Sprite2DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Sprite2DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("Sprite2D");
+	return p_object->is_class<Sprite2D>();
 }
 
 void Sprite2DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -1003,7 +1003,7 @@ void TileSourceInspectorPlugin::_confirm_change_id() {
 }
 
 bool TileSourceInspectorPlugin::can_handle(Object *p_object) {
-	return p_object->is_class("TileSetAtlasSourceProxyObject") || p_object->is_class("TileSetScenesCollectionProxyObject");
+	return p_object->is_class_by_name("TileSetAtlasSourceProxyObject") || p_object->is_class_by_name("TileSetScenesCollectionProxyObject");
 }
 
 bool TileSourceInspectorPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2121,7 +2121,7 @@ void VisualShaderEditor::_update_nodes() {
 				String script_path = ScriptServer::get_global_class_path(E);
 				Ref<Resource> res = ResourceLoader::load(script_path);
 				ERR_CONTINUE(res.is_null());
-				ERR_CONTINUE(!res->is_class("Script"));
+				ERR_CONTINUE(!res->is_class<Script>());
 				Ref<Script> scr = Ref<Script>(res);
 
 				Ref<VisualShaderNodeCustom> ref;
@@ -7960,19 +7960,19 @@ public:
 Control *VisualShaderNodePluginDefault::create_editor(const Ref<Resource> &p_parent_resource, const Ref<VisualShaderNode> &p_node) {
 	Ref<VisualShader> p_shader = Ref<VisualShader>(p_parent_resource.ptr());
 
-	if (p_shader.is_valid() && (p_node->is_class("VisualShaderNodeVaryingGetter") || p_node->is_class("VisualShaderNodeVaryingSetter"))) {
+	if (p_shader.is_valid() && (p_node->is_class<VisualShaderNodeVaryingGetter>() || p_node->is_class<VisualShaderNodeVaryingSetter>())) {
 		VisualShaderNodePluginVaryingEditor *editor = memnew(VisualShaderNodePluginVaryingEditor);
 		editor->setup(vseditor, p_node, p_shader->get_shader_type());
 		return editor;
 	}
 
-	if (p_node->is_class("VisualShaderNodeParameterRef")) {
+	if (p_node->is_class<VisualShaderNodeParameterRef>()) {
 		VisualShaderNodePluginParameterRefEditor *editor = memnew(VisualShaderNodePluginParameterRefEditor);
 		editor->setup(vseditor, p_node);
 		return editor;
 	}
 
-	if (p_node->is_class("VisualShaderNodeInput")) {
+	if (p_node->is_class<VisualShaderNodeInput>()) {
 		VisualShaderNodePluginInputEditor *editor = memnew(VisualShaderNodePluginInputEditor);
 		editor->setup(vseditor, p_node);
 		return editor;
@@ -8150,7 +8150,7 @@ bool EditorInspectorVisualShaderModePlugin::can_handle(Object *p_object) {
 }
 
 bool EditorInspectorVisualShaderModePlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
-	if (p_path == "mode" && p_object->is_class("VisualShader") && p_type == Variant::INT) {
+	if (p_path == "mode" && p_object->is_class<VisualShader>() && p_type == Variant::INT) {
 		EditorPropertyVisualShaderMode *mode_editor = memnew(EditorPropertyVisualShaderMode);
 		Vector<String> options = p_hint_text.split(",");
 		mode_editor->setup(options);

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -90,7 +90,7 @@ void VoxelGIEditorPlugin::edit(Object *p_object) {
 }
 
 bool VoxelGIEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("VoxelGI");
+	return p_object->is_class<VoxelGI>();
 }
 
 void VoxelGIEditorPlugin::_notification(int p_what) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3278,7 +3278,7 @@ bool SceneTreeDock::_check_node_recursive(Variant &r_variant, Node *p_node, Node
 	switch (r_variant.get_type()) {
 		case Variant::OBJECT: {
 			if (p_node == r_variant) {
-				if (p_by_node->is_class(type_hint) || EditorNode::get_singleton()->is_object_of_custom_type(p_by_node, type_hint)) {
+				if (p_by_node->is_class_by_name(type_hint) || EditorNode::get_singleton()->is_object_of_custom_type(p_by_node, type_hint)) {
 					r_variant = p_by_node;
 				} else {
 					r_variant = memnew(Object);
@@ -4066,7 +4066,7 @@ void SceneTreeDock::_focus_node() {
 	Node *node = scene_tree->get_selected();
 	ERR_FAIL_NULL(node);
 
-	if (node->is_class("CanvasItem")) {
+	if (node->is_class<CanvasItem>()) {
 		CanvasItemEditorPlugin *editor = Object::cast_to<CanvasItemEditorPlugin>(editor_data->get_editor_by_name("2D"));
 		editor->get_canvas_item_editor()->focus_selection();
 	} else {

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -70,7 +70,7 @@ static String _get_var_type(const Variant *p_var) {
 				basestr = "null instance";
 			}
 		} else {
-			if (bobj->is_class_ptr(GDScriptNativeClass::get_class_ptr_static())) {
+			if (bobj->is_class<GDScriptNativeClass>()) {
 				basestr = Object::cast_to<GDScriptNativeClass>(bobj)->get_name();
 			} else {
 				basestr = bobj->get_class();
@@ -1908,7 +1908,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						bool was_freed = false;
 						Object *obj = ret->get_validated_object_with_check(was_freed);
 
-						if (obj && obj->is_class_ptr(GDScriptFunctionState::get_class_ptr_static())) {
+						if (obj && obj->is_class<GDScriptFunctionState>()) {
 							err_text = R"(Trying to call an async function without "await".)";
 							OPCODE_BREAK;
 						}
@@ -2510,7 +2510,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 						// Is this even possible to be null at this point?
 						if (obj) {
-							if (obj->is_class_ptr(GDScriptFunctionState::get_class_ptr_static())) {
+							if (obj->is_class<GDScriptFunctionState>()) {
 								result = Signal(obj, "completed");
 							}
 						}

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1798,7 +1798,7 @@ void GridMapEditorPlugin::edit(Object *p_object) {
 }
 
 bool GridMapEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("GridMap");
+	return p_object->is_class<GridMap>();
 }
 
 void GridMapEditorPlugin::make_visible(bool p_visible) {

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
@@ -164,7 +164,7 @@ void MultiplayerEditorPlugin::edit(Object *p_object) {
 }
 
 bool MultiplayerEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("MultiplayerSynchronizer");
+	return p_object->is_class<MultiplayerSynchronizer>();
 }
 
 void MultiplayerEditorPlugin::make_visible(bool p_visible) {

--- a/modules/navigation_3d/editor/navigation_mesh_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_mesh_editor_plugin.cpp
@@ -152,7 +152,7 @@ void NavigationMeshEditorPlugin::edit(Object *p_object) {
 }
 
 bool NavigationMeshEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("NavigationRegion3D");
+	return p_object->is_class<NavigationRegion3D>();
 }
 
 void NavigationMeshEditorPlugin::make_visible(bool p_visible) {

--- a/modules/webp/resource_saver_webp.cpp
+++ b/modules/webp/resource_saver_webp.cpp
@@ -76,7 +76,7 @@ Vector<uint8_t> ResourceSaverWebP::save_image_to_buffer(const Ref<Image> &p_img,
 }
 
 bool ResourceSaverWebP::recognize(const Ref<Resource> &p_resource) const {
-	return (p_resource.is_valid() && p_resource->is_class("ImageTexture"));
+	return (p_resource.is_valid() && p_resource->is_class<ImageTexture>());
 }
 
 void ResourceSaverWebP::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -130,13 +130,13 @@ Error WSLPeer::accept_stream(Ref<StreamPeer> p_stream) {
 
 	_clear();
 
-	if (p_stream->is_class_ptr(StreamPeerTCP::get_class_ptr_static())) {
+	if (p_stream->is_class<StreamPeerTCP>()) {
 		tcp = p_stream;
 		connection = p_stream;
 		use_tls = false;
-	} else if (p_stream->is_class_ptr(StreamPeerTLS::get_class_ptr_static())) {
+	} else if (p_stream->is_class<StreamPeerTLS>()) {
 		Ref<StreamPeer> base_stream = static_cast<Ref<StreamPeerTLS>>(p_stream)->get_stream();
-		ERR_FAIL_COND_V(base_stream.is_null() || !base_stream->is_class_ptr(StreamPeerTCP::get_class_ptr_static()), ERR_INVALID_PARAMETER);
+		ERR_FAIL_COND_V(base_stream.is_null() || !base_stream->is_class<StreamPeerTCP>(), ERR_INVALID_PARAMETER);
 		tcp = static_cast<Ref<StreamPeerTCP>>(base_stream);
 		connection = p_stream;
 		use_tls = true;

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -148,13 +148,13 @@ void GPUParticles2D::set_process_material(const Ref<Material> &p_material) {
 		return;
 	}
 
-	if (process_material.is_valid() && process_material->is_class("ParticleProcessMaterial")) {
+	if (process_material.is_valid() && process_material->is_class<ParticleProcessMaterial>()) {
 		process_material->disconnect("emission_shape_changed", callable_mp((CanvasItem *)this, &GPUParticles2D::queue_redraw));
 	}
 
 	process_material = p_material;
 
-	if (process_material.is_valid() && process_material->is_class("ParticleProcessMaterial")) {
+	if (process_material.is_valid() && process_material->is_class<ParticleProcessMaterial>()) {
 		process_material->connect("emission_shape_changed", callable_mp((CanvasItem *)this, &GPUParticles2D::queue_redraw));
 	}
 

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -397,13 +397,13 @@ void PointLight2D::set_texture(const Ref<Texture2D> &p_texture) {
 	if (texture.is_valid()) {
 #ifdef DEBUG_ENABLED
 		if (
-				p_texture->is_class("AnimatedTexture") ||
-				p_texture->is_class("AtlasTexture") ||
-				p_texture->is_class("CameraTexture") ||
-				p_texture->is_class("CanvasTexture") ||
-				p_texture->is_class("MeshTexture") ||
-				p_texture->is_class("Texture2DRD") ||
-				p_texture->is_class("ViewportTexture")) {
+				p_texture->is_class_by_name("AnimatedTexture") ||
+				p_texture->is_class_by_name("AtlasTexture") ||
+				p_texture->is_class_by_name("CameraTexture") ||
+				p_texture->is_class_by_name("CanvasTexture") ||
+				p_texture->is_class_by_name("MeshTexture") ||
+				p_texture->is_class_by_name("Texture2DRD") ||
+				p_texture->is_class_by_name("ViewportTexture")) {
 			WARN_PRINT(vformat("%s cannot be used as a PointLight2D texture (%s). As a workaround, assign the value returned by %s's `get_image()` instead.", p_texture->get_class(), get_path(), p_texture->get_class()));
 		}
 #endif

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -47,13 +47,13 @@ void Decal::set_texture(DecalTexture p_type, const Ref<Texture2D> &p_texture) {
 
 #ifdef DEBUG_ENABLED
 	if (p_texture.is_valid() &&
-			(p_texture->is_class("AnimatedTexture") ||
-					p_texture->is_class("AtlasTexture") ||
-					p_texture->is_class("CameraTexture") ||
-					p_texture->is_class("CanvasTexture") ||
-					p_texture->is_class("MeshTexture") ||
-					p_texture->is_class("Texture2DRD") ||
-					p_texture->is_class("ViewportTexture"))) {
+			(p_texture->is_class_by_name("AnimatedTexture") ||
+					p_texture->is_class_by_name("AtlasTexture") ||
+					p_texture->is_class_by_name("CameraTexture") ||
+					p_texture->is_class_by_name("CanvasTexture") ||
+					p_texture->is_class_by_name("MeshTexture") ||
+					p_texture->is_class_by_name("Texture2DRD") ||
+					p_texture->is_class_by_name("ViewportTexture"))) {
 		WARN_PRINT(vformat("%s cannot be used as a Decal texture (%s). As a workaround, assign the value returned by %s's `get_image()` instead.", p_texture->get_class(), get_path(), p_texture->get_class()));
 	}
 #endif

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -203,13 +203,13 @@ void Light3D::set_projector(const Ref<Texture2D> &p_texture) {
 
 #ifdef DEBUG_ENABLED
 	if (p_texture.is_valid() &&
-			(p_texture->is_class("AnimatedTexture") ||
-					p_texture->is_class("AtlasTexture") ||
-					p_texture->is_class("CameraTexture") ||
-					p_texture->is_class("CanvasTexture") ||
-					p_texture->is_class("MeshTexture") ||
-					p_texture->is_class("Texture2DRD") ||
-					p_texture->is_class("ViewportTexture"))) {
+			(p_texture->is_class_by_name("AnimatedTexture") ||
+					p_texture->is_class_by_name("AtlasTexture") ||
+					p_texture->is_class_by_name("CameraTexture") ||
+					p_texture->is_class_by_name("CanvasTexture") ||
+					p_texture->is_class_by_name("MeshTexture") ||
+					p_texture->is_class_by_name("Texture2DRD") ||
+					p_texture->is_class_by_name("ViewportTexture"))) {
 		WARN_PRINT(vformat("%s cannot be used as a Light3D projector texture (%s). As a workaround, assign the value returned by %s's `get_image()` instead.", p_texture->get_class(), get_path(), p_texture->get_class()));
 	}
 #endif

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -669,7 +669,7 @@ void SceneDebuggerObject::deserialize(const Array &p_arr) {
 			if (var.is_zero()) {
 				var = Ref<Resource>();
 			} else if (var.get_type() == Variant::OBJECT) {
-				if (((Object *)var)->is_class("EncodedObjectAsID")) {
+				if (((Object *)var)->is_class<EncodedObjectAsID>()) {
 					var = Object::cast_to<EncodedObjectAsID>(var)->get_object_id();
 					pinfo.type = var.get_type();
 					pinfo.hint = PROPERTY_HINT_OBJECT_ID;
@@ -824,9 +824,9 @@ void LiveEditor::_node_set_func(int p_id, const StringName &p_prop, const Varian
 		Variant orig_tf;
 
 		if (keep_transform) {
-			if (n2->is_class("Node3D")) {
+			if (n2->is_class<Node3D>()) {
 				orig_tf = n2->call("get_transform");
-			} else if (n2->is_class("CanvasItem")) {
+			} else if (n2->is_class<CanvasItem>()) {
 				orig_tf = n2->call("_edit_get_state");
 			}
 		}
@@ -834,12 +834,12 @@ void LiveEditor::_node_set_func(int p_id, const StringName &p_prop, const Varian
 		n2->set(p_prop, p_value);
 
 		if (keep_transform) {
-			if (n2->is_class("Node3D")) {
+			if (n2->is_class<Node3D>()) {
 				Variant new_tf = n2->call("get_transform");
 				if (new_tf != orig_tf) {
 					n2->call("set_transform", orig_tf);
 				}
-			} else if (n2->is_class("CanvasItem")) {
+			} else if (n2->is_class<CanvasItem>()) {
 				Variant new_tf = n2->call("_edit_get_state");
 				if (new_tf != orig_tf) {
 					n2->call("_edit_set_state", orig_tf);
@@ -895,9 +895,9 @@ void LiveEditor::_node_call_func(int p_id, const StringName &p_method, const Var
 		Variant orig_tf;
 
 		if (keep_transform) {
-			if (n2->is_class("Node3D")) {
+			if (n2->is_class<Node3D>()) {
 				orig_tf = n2->call("get_transform");
-			} else if (n2->is_class("CanvasItem")) {
+			} else if (n2->is_class<CanvasItem>()) {
 				orig_tf = n2->call("_edit_get_state");
 			}
 		}
@@ -906,12 +906,12 @@ void LiveEditor::_node_call_func(int p_id, const StringName &p_method, const Var
 		n2->callp(p_method, p_args, p_argcount, ce);
 
 		if (keep_transform) {
-			if (n2->is_class("Node3D")) {
+			if (n2->is_class<Node3D>()) {
 				Variant new_tf = n2->call("get_transform");
 				if (new_tf != orig_tf) {
 					n2->call("set_transform", orig_tf);
 				}
-			} else if (n2->is_class("CanvasItem")) {
+			} else if (n2->is_class<CanvasItem>()) {
 				Variant new_tf = n2->call("_edit_get_state");
 				if (new_tf != orig_tf) {
 					n2->call("_edit_set_state", orig_tf);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1925,7 +1925,7 @@ TypedArray<Node> Node::find_children(const String &p_pattern, const String &p_ty
 		}
 
 		if (p_pattern.is_empty() || cptr[i]->data.name.operator String().match(p_pattern)) {
-			if (p_type.is_empty() || cptr[i]->is_class(p_type)) {
+			if (p_type.is_empty() || cptr[i]->is_class_by_name(p_type)) {
 				ret.append(cptr[i]);
 			} else if (cptr[i]->get_script_instance()) {
 				Ref<Script> scr = cptr[i]->get_script_instance()->get_script();

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -355,7 +355,7 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 					// Check if the Object class (hint string) changed, for example Texture2D sampler to Texture3D.
 					// Allow inheritance, Texture2D type sampler should also accept CompressedTexture2D.
 					Object *cached_obj = cached;
-					if (!cached_obj->is_class(pi.hint_string)) {
+					if (!cached_obj->is_class_by_name(pi.hint_string)) {
 						is_uniform_type_compatible = false;
 					}
 				}

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1442,7 +1442,7 @@ void VisualShader::set_mode(Mode p_mode) {
 				keep = false;
 			} else {
 				Ref<VisualShaderNode> from_node = graph[i].nodes[from].node;
-				if (from_node->is_class("VisualShaderNodeOutput") || from_node->is_class("VisualShaderNodeInput")) {
+				if (from_node->is_class<VisualShaderNodeOutput>() || from_node->is_class<VisualShaderNodeInput>()) {
 					keep = false;
 				}
 			}
@@ -1451,7 +1451,7 @@ void VisualShader::set_mode(Mode p_mode) {
 				keep = false;
 			} else {
 				Ref<VisualShaderNode> to_node = graph[i].nodes[to].node;
-				if (to_node->is_class("VisualShaderNodeOutput") || to_node->is_class("VisualShaderNodeInput")) {
+				if (to_node->is_class<VisualShaderNodeOutput>() || to_node->is_class<VisualShaderNodeInput>()) {
 					keep = false;
 				}
 			}

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -129,7 +129,7 @@ TEST_CASE("[Object] Core getters") {
 	Object object;
 
 	CHECK_MESSAGE(
-			object.is_class("Object"),
+			object.is_class<Object>(),
 			"is_class() should return the expected value.");
 	CHECK_MESSAGE(
 			object.get_class() == "Object",

--- a/tests/scene/test_gltf_document.h
+++ b/tests/scene/test_gltf_document.h
@@ -201,13 +201,13 @@ TEST_CASE("[SceneTree][GLTFDocument] Load cube.gltf") {
 	Node *node = gltf_document->generate_scene(gltf_state);
 
 	// Check the loaded scene.
-	CHECK(node->is_class("Node3D"));
+	CHECK(node->is_class<Node3D>());
 	CHECK(node->get_name() == "cube");
 
-	CHECK(node->get_child(0)->is_class("MeshInstance3D"));
+	CHECK(node->get_child(0)->is_class<MeshInstance3D>());
 	CHECK(node->get_child(0)->get_name() == "Cube");
 
-	CHECK(node->get_child(1)->is_class("AnimationPlayer"));
+	CHECK(node->get_child(1)->is_class<AnimationPlayer>());
 	CHECK(node->get_child(1)->get_name() == "AnimationPlayer");
 
 	test_gltf_save(node);
@@ -229,13 +229,13 @@ TEST_CASE("[SceneTree][GLTFDocument] Load suzanne.glb") {
 	Node *node = gltf_document->generate_scene(gltf_state);
 
 	// Check the loaded scene.
-	CHECK(node->is_class("Node3D"));
+	CHECK(node->is_class<Node3D>());
 	CHECK(node->get_name() == "suzanne");
 
-	CHECK(node->get_child(0)->is_class("MeshInstance3D"));
+	CHECK(node->get_child(0)->is_class<MeshInstance3D>());
 	CHECK(node->get_child(0)->get_name() == "Suzanne");
 
-	CHECK(node->get_child(1)->is_class("Camera3D"));
+	CHECK(node->get_child(1)->is_class<Camera3D>());
 	CHECK(node->get_child(1)->get_name() == "Camera");
 
 	test_gltf_save(node);


### PR DESCRIPTION
`is_class` is used to ask `Object` subtypes if they derive from a certain class.
It currently uses `String` parameters, which is wasteful because the string often needs to be allocate, and because it needs to do a lot of string comparisons.

We already have a much faster way of determining subtypes: `is_class_ptr`. It is annoying to use though, so I created a safe wrapper function from my implementation in https://github.com/godotengine/godot/pull/103708.
The new function is named `is_class` to encourage developers to use it.
The old function is renamed `is_class_by_name` to discourage developers to use it unless needed.

Changing callers of the function could be automated (search `is_class\("(\w+)")`, replace with `is_class<$1>()`).
~50 of the ~150 uses started erroring because of unknown types. I replaced those manually back to `is_class_by_name`, to avoid new includes. Future implementers may choose to add an include to change `is_class_by_name` usage to `is_class`.

## Benchmark
I determined that `is_class` can be 35x faster than `is_class_by_name` (formerly `is_class`):
```c++
	Node3D *node = memnew(Node3D);

	{
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < 50000000; i++) {
			// Test
			node->is_class<Node2D>();
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
	{
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < 50000000; i++) {
			// Test
			node->is_class_by_name("Node2D");
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
```

The test probably unrealistically favours `is_class_by_name` because memory is in cache during the test, so the practical difference may be even better.

## Notes on compatibility
This breaks compatibility to existing modules, which will have to choose either the new `is_class` or the old `is_class_by_name` manually. This will be a static failure, so no risks are involved.
It does not break binary compatibility.