### PR TITLE
Convert `while`-`pop_front` loops to iterator loops

### DIFF
--- a/core/debugger/debugger_marshalls.cpp
+++ b/core/debugger/debugger_marshalls.cpp
@@ -94,7 +94,7 @@ bool DebuggerMarshalls::ScriptStackVariable::deserialize(const Array &p_arr) {
 	return true;
 }
 
-Array DebuggerMarshalls::OutputError::serialize() {
+Array DebuggerMarshalls::OutputError::serialize() const {
 	unsigned int size = callstack.size();
 	Array arr = {
 		hr,

--- a/core/debugger/debugger_marshalls.h
+++ b/core/debugger/debugger_marshalls.h
@@ -65,7 +65,7 @@ struct DebuggerMarshalls {
 		bool warning = false;
 		Vector<ScriptLanguage::StackInfo> callstack;
 
-		Array serialize();
+		Array serialize() const;
 		bool deserialize(const Array &p_arr);
 	};
 

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -237,11 +237,10 @@ void RemoteDebugger::flush_output() {
 		output_strings.clear();
 	}
 
-	while (errors.size()) {
-		ErrorMessage oe = errors.front()->get();
+	for (const ErrorMessage &oe : errors) {
 		_put_msg("error", oe.serialize());
-		errors.pop_front();
 	}
+	errors.clear();
 
 	// Update limits
 	uint64_t ticks = OS::get_singleton()->get_ticks_usec() / 1000;

--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -60,7 +60,7 @@ private:
 		MessageType type;
 	};
 	List<OutputString> output_strings;
-	List<ErrorMessage> errors;
+	LocalVector<ErrorMessage> errors;
 
 	int n_messages_dropped = 0;
 	int max_errors_per_second = 0;

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -236,7 +236,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 		Vector3 v = p_points[f.points_over[next]];
 
 		//find lit faces and lit edges
-		List<List<Face>::Element *> lit_faces; //lit face is a death sentence
+		LocalVector<List<Face>::Element *> lit_faces; //lit face is a death sentence
 
 		HashMap<Edge, FaceConnect, Edge> lit_edges; //create this on the flight, should not be that bad for performance and simplifies code a lot
 
@@ -314,10 +314,10 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 
 		//erase lit faces
 
-		while (lit_faces.size()) {
-			faces.erase(lit_faces.front()->get());
-			lit_faces.pop_front();
+		for (List<Face>::Element *lf : lit_faces) {
+			faces.erase(lf);
 		}
+		lit_faces.clear();
 
 		//put faces that contain no points on the front
 

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -779,7 +779,7 @@ void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, c
 	}
 
 	properties = p_properties;
-	List<StringName> to_remove;
+	LocalVector<StringName> to_remove;
 
 	for (KeyValue<StringName, Variant> &E : values) {
 		if (!new_values.has(E.key)) {
@@ -795,10 +795,10 @@ void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, c
 		}
 	}
 
-	while (to_remove.size()) {
-		values.erase(to_remove.front()->get());
-		to_remove.pop_front();
+	for (const StringName &key : to_remove) {
+		values.erase(key);
 	}
+	to_remove.clear();
 
 	if (owner && owner->get_script_instance() == this) {
 		owner->notify_property_list_changed();

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -1261,7 +1261,7 @@ Error DocTools::erase_classes(const String &p_dir) {
 		return err;
 	}
 
-	List<String> to_erase;
+	LocalVector<String> to_erase;
 
 	da->list_dir_begin();
 	String path;
@@ -1274,9 +1274,8 @@ Error DocTools::erase_classes(const String &p_dir) {
 	}
 	da->list_dir_end();
 
-	while (to_erase.size()) {
-		da->remove(to_erase.front()->get());
-		to_erase.pop_front();
+	for (const String &file : to_erase) {
+		da->remove(file);
 	}
 
 	return OK;

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -948,7 +948,7 @@ void EditorAssetLibrary::_update_image_queue() {
 	const int max_images = 6;
 	int current_images = 0;
 
-	List<int> to_delete;
+	LocalVector<int> to_delete;
 	for (KeyValue<int, ImageQueue> &E : image_queue) {
 		if (!E.value.active && current_images < max_images) {
 			String cache_filename_base = EditorPaths::get_singleton()->get_cache_dir().path_join("assetimage_" + E.value.image_url.md5_text());
@@ -973,10 +973,9 @@ void EditorAssetLibrary::_update_image_queue() {
 		}
 	}
 
-	while (to_delete.size()) {
-		image_queue[to_delete.front()->get()].request->queue_free();
-		image_queue.erase(to_delete.front()->get());
-		to_delete.pop_front();
+	for (const int key : to_delete) {
+		image_queue[key].request->queue_free();
+		image_queue.erase(key);
 	}
 }
 

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -33,7 +33,6 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
-#include "core/string/string_name.h"
 #include "scene/2d/audio_stream_player_2d.h"
 #include "scene/animation/animation_player.h"
 #include "scene/audio/audio_stream_player.h"
@@ -168,7 +167,7 @@ void AnimationMixer::_animation_set_cache_update() {
 	}
 
 	// Check removed.
-	List<StringName> to_erase;
+	LocalVector<StringName> to_erase;
 	for (const KeyValue<StringName, AnimationData> &E : animation_set) {
 		if (E.value.last_update != animation_set_update_pass) {
 			// Was not updated, must be erased.
@@ -177,10 +176,10 @@ void AnimationMixer::_animation_set_cache_update() {
 		}
 	}
 
-	while (to_erase.size()) {
-		animation_set.erase(to_erase.front()->get());
-		to_erase.pop_front();
+	for (const StringName &key : to_erase) {
+		animation_set.erase(key);
 	}
+	to_erase.clear();
 
 	if (clear_cache_needed) {
 		// If something was modified or removed, caches need to be cleared.

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -895,7 +895,7 @@ void AnimationPlayer::_animation_removed(const StringName &p_name, const StringN
 	_animation_set_cache_update();
 
 	// Erase blends if needed
-	List<BlendKey> to_erase;
+	LocalVector<BlendKey> to_erase;
 	for (const KeyValue<BlendKey, double> &E : blend_times) {
 		BlendKey bk = E.key;
 		if (bk.from == name || bk.to == name) {
@@ -903,9 +903,8 @@ void AnimationPlayer::_animation_removed(const StringName &p_name, const StringN
 		}
 	}
 
-	while (to_erase.size()) {
-		blend_times.erase(to_erase.front()->get());
-		to_erase.pop_front();
+	for (const BlendKey &bk : to_erase) {
+		blend_times.erase(bk);
 	}
 }
 
@@ -913,7 +912,7 @@ void AnimationPlayer::_rename_animation(const StringName &p_from_name, const Str
 	AnimationMixer::_rename_animation(p_from_name, p_to_name);
 
 	// Rename autoplay or blends if needed.
-	List<BlendKey> to_erase;
+	LocalVector<BlendKey> to_erase;
 	HashMap<BlendKey, double, BlendKey> to_insert;
 	for (const KeyValue<BlendKey, double> &E : blend_times) {
 		BlendKey bk = E.key;
@@ -934,10 +933,10 @@ void AnimationPlayer::_rename_animation(const StringName &p_from_name, const Str
 		}
 	}
 
-	while (to_erase.size()) {
-		blend_times.erase(to_erase.front()->get());
-		to_erase.pop_front();
+	for (const BlendKey &bk : to_erase) {
+		blend_times.erase(bk);
 	}
+	to_erase.clear();
 
 	while (to_insert.size()) {
 		blend_times[to_insert.begin()->key] = to_insert.begin()->value;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4074,8 +4074,8 @@ void Viewport::_camera_2d_set(Camera2D *p_camera_2d) {
 
 #ifndef PHYSICS_2D_DISABLED
 void Viewport::_cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paused_only, uint64_t p_frame_reference) {
-	List<ObjectID> to_erase;
-	List<ObjectID> to_mouse_exit;
+	LocalVector<ObjectID> to_erase;
+	LocalVector<ObjectID> to_mouse_exit;
 
 	for (const KeyValue<ObjectID, uint64_t> &E : physics_2d_mouseover) {
 		if (!p_clean_all_frames && E.value == p_frame_reference) {
@@ -4095,14 +4095,14 @@ void Viewport::_cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paus
 		to_erase.push_back(E.key);
 	}
 
-	while (to_erase.size()) {
-		physics_2d_mouseover.erase(to_erase.front()->get());
-		to_erase.pop_front();
+	for (const ObjectID &key : to_erase) {
+		physics_2d_mouseover.erase(key);
 	}
+	to_erase.clear();
 
 	// Per-shape.
-	List<Pair<ObjectID, int>> shapes_to_erase;
-	List<Pair<ObjectID, int>> shapes_to_mouse_exit;
+	LocalVector<Pair<ObjectID, int>> shapes_to_erase;
+	LocalVector<Pair<ObjectID, int>> shapes_to_mouse_exit;
 
 	for (KeyValue<Pair<ObjectID, int>, uint64_t> &E : physics_2d_shape_mouseover) {
 		if (!p_clean_all_frames && E.value == p_frame_reference) {
@@ -4122,24 +4122,20 @@ void Viewport::_cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paus
 		shapes_to_erase.push_back(E.key);
 	}
 
-	while (shapes_to_erase.size()) {
-		physics_2d_shape_mouseover.erase(shapes_to_erase.front()->get());
-		shapes_to_erase.pop_front();
+	for (const Pair<ObjectID, int> &key : shapes_to_erase) {
+		physics_2d_shape_mouseover.erase(key);
 	}
 
-	while (to_mouse_exit.size()) {
-		Object *o = ObjectDB::get_instance(to_mouse_exit.front()->get());
+	for (const ObjectID &key : to_mouse_exit) {
+		Object *o = ObjectDB::get_instance(key);
 		CollisionObject2D *co = Object::cast_to<CollisionObject2D>(o);
 		co->_mouse_exit();
-		to_mouse_exit.pop_front();
 	}
 
-	while (shapes_to_mouse_exit.size()) {
-		Pair<ObjectID, int> e = shapes_to_mouse_exit.front()->get();
-		Object *o = ObjectDB::get_instance(e.first);
+	for (const Pair<ObjectID, int> &key : shapes_to_mouse_exit) {
+		Object *o = ObjectDB::get_instance(key.first);
 		CollisionObject2D *co = Object::cast_to<CollisionObject2D>(o);
-		co->_mouse_shape_exit(e.second);
-		shapes_to_mouse_exit.pop_front();
+		co->_mouse_shape_exit(key.second);
 	}
 }
 #endif // PHYSICS_2D_DISABLED

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -3714,68 +3714,63 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 				if (p_value.is_array()) {
 					Array p = p_value;
 					Vector2i last_coord;
-					while (p.size() > 0) {
-						if (p[0].get_type() == Variant::VECTOR2) {
-							last_coord = p[0];
-						} else if (p[0].get_type() == Variant::INT) {
-							ctd->autotile_bitmask_flags.insert(last_coord, p[0]);
+					for (const Variant &elem : p) {
+						if (elem.get_type() == Variant::VECTOR2) {
+							last_coord = elem;
+						} else if (elem.get_type() == Variant::INT) {
+							ctd->autotile_bitmask_flags.insert(last_coord, elem);
 						}
-						p.pop_front();
 					}
 				}
 			} else if (what == "occluder_map") {
 				Array p = p_value;
 				Vector2 last_coord;
-				while (p.size() > 0) {
-					if (p[0].get_type() == Variant::VECTOR2) {
-						last_coord = p[0];
-					} else if (p[0].get_type() == Variant::OBJECT) {
-						ctd->autotile_occluder_map.insert(last_coord, p[0]);
+				for (const Variant &elem : p) {
+					if (elem.get_type() == Variant::VECTOR2) {
+						last_coord = elem;
+					} else if (elem.get_type() == Variant::OBJECT) {
+						ctd->autotile_occluder_map.insert(last_coord, elem);
 					}
-					p.pop_front();
 				}
 			} else if (what == "navpoly_map") {
 				Array p = p_value;
 				Vector2 last_coord;
-				while (p.size() > 0) {
-					if (p[0].get_type() == Variant::VECTOR2) {
-						last_coord = p[0];
-					} else if (p[0].get_type() == Variant::OBJECT) {
+				for (const Variant &elem : p) {
+					if (elem.get_type() == Variant::VECTOR2) {
+						last_coord = elem;
+					} else if (elem.get_type() == Variant::OBJECT) {
 #ifndef NAVIGATION_2D_DISABLED
-						ctd->autotile_navpoly_map.insert(last_coord, p[0]);
+						ctd->autotile_navpoly_map.insert(last_coord, elem);
 #endif // NAVIGATION_2D_DISABLED
 					}
-					p.pop_front();
 				}
 			} else if (what == "priority_map") {
 				Array p = p_value;
 				Vector3 val;
 				Vector2 v;
 				int priority;
-				while (p.size() > 0) {
-					val = p[0];
+				for (const Variant &elem : p) {
+					val = elem;
 					if (val.z > 1) {
 						v.x = val.x;
 						v.y = val.y;
 						priority = (int)val.z;
 						ctd->autotile_priority_map.insert(v, priority);
 					}
-					p.pop_front();
 				}
 			} else if (what == "z_index_map") {
 				Array p = p_value;
 				Vector3 val;
 				Vector2 v;
 				int z_index;
-				while (p.size() > 0) {
-					val = p[0];
+				for (const Variant &elem : p) {
+					val = elem;
 					if (val.z != 0) {
 						v.x = val.x;
 						v.y = val.y;
 						z_index = (int)val.z;
 						ctd->autotile_z_index_map.insert(v, z_index);
 					}
-					p.pop_front();
 				}
 			}
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -126,7 +126,7 @@ Ref<Resource> SceneState::get_remap_resource(const Ref<Resource> &p_resource, Ha
 
 Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	// Nodes where instantiation failed (because something is missing.)
-	List<Node *> stray_instances;
+	LocalVector<Node *> stray_instances;
 
 #define NODE_FROM_ID(p_name, p_id)                      \
 	Node *p_name;                                       \
@@ -614,10 +614,10 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	//Node *s = ret_nodes[0];
 
 	//remove nodes that could not be added, likely as a result that
-	while (stray_instances.size()) {
-		memdelete(stray_instances.front()->get());
-		stray_instances.pop_front();
+	for (Node *node : stray_instances) {
+		memdelete(node);
 	}
+	stray_instances.clear();
 
 	for (int i = 0; i < editable_instances.size(); i++) {
 		Node *ei = ret_nodes[0]->get_node_or_null(editable_instances[i]);

--- a/servers/rendering/storage/utilities.h
+++ b/servers/rendering/storage/utilities.h
@@ -81,10 +81,9 @@ public:
 	}
 
 	void update_end() { //call after updating dependencies
-		List<Pair<Dependency *, DependencyTracker *>> to_clean_up;
+		LocalVector<Pair<Dependency *, DependencyTracker *>> to_clean_up;
 
-		for (Dependency *E : dependencies) {
-			Dependency *dep = E;
+		for (Dependency *dep : dependencies) {
 			HashMap<DependencyTracker *, uint32_t>::Iterator F = dep->instances.find(this);
 			ERR_CONTINUE(!F);
 			if (F->value != instance_version) {
@@ -95,16 +94,14 @@ public:
 			}
 		}
 
-		while (to_clean_up.size()) {
-			to_clean_up.front()->get().first->instances.erase(to_clean_up.front()->get().second);
-			dependencies.erase(to_clean_up.front()->get().first);
-			to_clean_up.pop_front();
+		for (const Pair<Dependency *, DependencyTracker *> &pair : to_clean_up) {
+			pair.first->instances.erase(pair.second);
+			dependencies.erase(pair.first);
 		}
 	}
 
 	void clear() { // clear all dependencies
-		for (Dependency *E : dependencies) {
-			Dependency *dep = E;
+		for (Dependency *dep : dependencies) {
 			dep->instances.erase(this);
 		}
 		dependencies.clear();


### PR DESCRIPTION
Cleanup loops which are linear scan but use `while`.

Semantically, this change provides greater optimization potential because we can now batch free elements. However, this benefit can only be realized after switching the container to `Vector`/`LocalVector`, as `List` always removes elements one by one.

Some loops are at the bottom of their scope and the container destruct right after the loop, I omit `clear()` for them.
