### PR TITLE
Use Span to reduce allocations in `HTTPClientTCP::poll`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4345,13 +4345,13 @@ String String::dedent() const {
 	return new_string;
 }
 
-String String::strip_edges(bool left, bool right) const {
-	int len = length();
-	int beg = 0, end = len;
+Span<char32_t> String::strip_edges_span(Span<char32_t> p_span, bool p_left, bool p_right) {
+	uint64_t beg = 0;
+	uint64_t end = p_span.size();
 
-	if (left) {
-		for (int i = 0; i < len; i++) {
-			if (operator[](i) <= 32) {
+	if (p_left) {
+		for (uint64_t i = 0; i < end; i++) {
+			if (p_span[i] <= 32) {
 				beg++;
 			} else {
 				break;
@@ -4359,9 +4359,9 @@ String String::strip_edges(bool left, bool right) const {
 		}
 	}
 
-	if (right) {
-		for (int i = len - 1; i >= 0; i--) {
-			if (operator[](i) <= 32) {
+	if (p_right && (end > 0)) {
+		for (uint64_t i = end - 1; i > beg; i--) {
+			if (p_span[i] <= 32) {
 				end--;
 			} else {
 				break;
@@ -4369,11 +4369,14 @@ String String::strip_edges(bool left, bool right) const {
 		}
 	}
 
-	if (beg == 0 && end == len) {
-		return *this;
-	}
+	return Span(p_span.ptr() + beg, static_cast<uint64_t>(end - beg));
+}
 
-	return substr(beg, end - beg);
+String String::strip_edges(bool left, bool right) const {
+	const char32_t *p = ptr();
+	Span<char32_t> sp = strip_edges_span(span(), left, right);
+
+	return substr(sp.begin() - p, sp.size());
 }
 
 String String::strip_escapes() const {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -293,6 +293,8 @@ public:
 	_FORCE_INLINE_ operator Span<char32_t>() const { return Span(ptr(), length()); }
 	_FORCE_INLINE_ Span<char32_t> span() const { return Span(ptr(), length()); }
 
+	static Span<char32_t> strip_edges_span(Span<char32_t> p_span, bool p_left, bool p_right);
+
 	void remove_at(int p_index) { _cowdata.remove_at(p_index); }
 
 	_FORCE_INLINE_ void clear() { resize(0); }


### PR DESCRIPTION
Spotted during [this PR](https://github.com/godotengine/godot/pull/104810).

Used span to avoid some substring allocations. Avoid find that could be done at compile time. Remove useless push_back, parse_utf8 does not have to be 0 terminated.

Extracted strip_edges logic into a static function, to be able to call it with span and strings (without the need to allocate a string).
The name may not be very good, but naming it strip_edges brought conflict with Variant, probably because the name is bound.
Maybe we should come up with a long term solution for this because I guess the need will arise with other functions (applying strings functions to span created from strings).