### PR TITLE
JSONRPC: Fix notification return behavior

### DIFF
--- a/modules/jsonrpc/tests/test_jsonrpc.cpp
+++ b/modules/jsonrpc/tests/test_jsonrpc.cpp
@@ -79,4 +79,10 @@ void test_process_action_bad_method(const Dictionary &p_in) {
 	check_error_no_method(out_dict);
 }
 
+void test_no_response(const Variant &p_in) {
+	TestClassJSONRPC json_rpc = TestClassJSONRPC();
+	const Variant &res = json_rpc.process_action(p_in, true);
+	CHECK(res.get_type() == Variant::NIL);
+}
+
 } // namespace TestJSONRPC

--- a/modules/jsonrpc/tests/test_jsonrpc.h
+++ b/modules/jsonrpc/tests/test_jsonrpc.h
@@ -46,6 +46,7 @@ TEST_CASE("[JSONRPC] process_action invalid") {
 	check_invalid(json_rpc.process_action(1234));
 	check_invalid(json_rpc.process_action(false));
 	check_invalid(json_rpc.process_action(3.14159));
+	check_invalid(json_rpc.process_action(Array()));
 }
 
 void check_invalid_string(const String &p_str);
@@ -57,6 +58,7 @@ TEST_CASE("[JSONRPC] process_string invalid") {
 	check_invalid_string(json_rpc.process_string("1234"));
 	check_invalid_string(json_rpc.process_string("false"));
 	check_invalid_string(json_rpc.process_string("3.14159"));
+	check_invalid_string(json_rpc.process_string("[]"));
 }
 
 class TestClassJSONRPC : public JSONRPC {
@@ -125,9 +127,73 @@ void test_process_action_bad_method(const Dictionary &p_in);
 
 TEST_CASE("[JSONRPC] process_action bad method") {
 	Dictionary in_dict;
+	in_dict["id"] = 1;
 	in_dict["method"] = "nothing";
 
 	test_process_action_bad_method(in_dict);
+}
+
+void test_no_response(const Variant &p_in);
+
+TEST_CASE("[JSONRPC] process_action notification") {
+	Dictionary in_dict = Dictionary();
+	in_dict["method"] = "something";
+	in_dict["params"] = "yes";
+
+	test_no_response(in_dict);
+}
+
+TEST_CASE("[JSONRPC] process_action notification bad method") {
+	Dictionary in_dict;
+	in_dict["method"] = "nothing";
+
+	test_no_response(in_dict);
+}
+
+TEST_CASE("[JSONRPC] process_action notification batch") {
+	Array in;
+	Dictionary in_1;
+	in_1["method"] = "something";
+	in_1["params"] = "more";
+	in.push_back(in_1);
+	Dictionary in_2;
+	in_2["method"] = "something";
+	in_2["params"] = "yes";
+	in.push_back(in_2);
+
+	test_no_response(in);
+}
+
+TEST_CASE("[JSONRPC] mixed batch") {
+	Array in;
+	Dictionary in_1;
+	in_1["method"] = "something";
+	in_1["id"] = 1;
+	in_1["params"] = "more";
+	in.push_back(in_1);
+	Dictionary in_2;
+	in_2["method"] = "something";
+	in_2["id"] = 2;
+	in_2["params"] = "yes";
+	in.push_back(in_2);
+	Dictionary in_3;
+	in_3["method"] = "something";
+	in_3["params"] = "yes";
+	in.push_back(in_3);
+
+	Array expected;
+	Dictionary expected_1;
+	expected_1["jsonrpc"] = "2.0";
+	expected_1["id"] = 1;
+	expected_1["result"] = "more, please";
+	expected.push_back(expected_1);
+	Dictionary expected_2;
+	expected_2["jsonrpc"] = "2.0";
+	expected_2["id"] = 2;
+	expected_2["result"] = "yes, please";
+	expected.push_back(expected_2);
+
+	test_process_action(in, expected, true);
 }
 
 } // namespace TestJSONRPC


### PR DESCRIPTION
Fixes some misalignment's with the JSONRPC spec (didn't open a new issue for them just check the new test cases).

This allows us to remove a hack from #42070 which introduced LSP code in JSONRPC. Since all LSP methods starting with `$/` are notifications there never should have been a response to them in the first place, regardless of errors.
