### PR TITLE
Safeguard against freed exported nodes

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -2934,22 +2934,21 @@ void EditorPropertyNodePath::_text_submitted(const String &p_text) {
 }
 
 const NodePath EditorPropertyNodePath::_get_node_path() const {
-	const Node *base_node = const_cast<EditorPropertyNodePath *>(this)->get_base_node();
-
 	Variant val = get_edited_property_value();
-	Node *n = Object::cast_to<Node>(val);
-	if (n) {
-		if (!n->is_inside_tree()) {
-			return NodePath();
-		}
+	if (val.get_type() == Variant::NODE_PATH) {
+		return val;
+	}
+
+	const Node *base_node = const_cast<EditorPropertyNodePath *>(this)->get_base_node();
+	const Node *n = Object::cast_to<Node>(val.get_validated_object());
+	if (n && n->is_inside_tree()) {
 		if (base_node) {
 			return base_node->get_path_to(n);
 		} else {
 			return get_tree()->get_edited_scene_root()->get_path_to(n);
 		}
-	} else {
-		return val;
 	}
+	return NodePath();
 }
 
 bool EditorPropertyNodePath::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {


### PR DESCRIPTION
Fixes #104579

The property wrongly shows revert arrow, but at least it won't crash.