### PR TITLE
Fix gizmos from 3D editor plugins not applying changes to locked nodes

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -5216,7 +5216,7 @@ void Node3DEditorViewport::apply_transform(Vector3 p_motion, double p_snap) {
 			continue;
 		}
 
-		if (sp->has_meta("_edit_lock_")) {
+		if (sp->has_meta("_edit_lock_") && !spatial_editor->is_gizmo_visible()) {
 			continue;
 		}
 


### PR DESCRIPTION
A good example of this bug happening is when enabling the "Edit Mode" in a locked `Skeleton3D` node. The gizmo to manipulate bones will appear, but you won't be able to change the bone's transform.