### PR TITLE
[3.x] Change ARVR Nodes default interpolation to off

### DIFF
--- a/doc/classes/ARVRAnchor.xml
+++ b/doc/classes/ARVRAnchor.xml
@@ -46,6 +46,7 @@
 		<member name="anchor_id" type="int" setter="set_anchor_id" getter="get_anchor_id" default="1">
 			The anchor's ID. You can set this before the anchor itself exists. The first anchor gets an ID of [code]1[/code], the second an ID of [code]2[/code], etc. When anchors get removed, the engine can then assign the corresponding ID to new anchors. The most common situation where anchors "disappear" is when the AR server identifies that two anchors represent different parts of the same plane and merges them.
 		</member>
+		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="1" />
 	</members>
 	<signals>
 		<signal name="mesh_updated">

--- a/doc/classes/ARVRCamera.xml
+++ b/doc/classes/ARVRCamera.xml
@@ -12,6 +12,9 @@
 	</tutorials>
 	<methods>
 	</methods>
+	<members>
+		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="1" />
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/ARVRController.xml
+++ b/doc/classes/ARVRController.xml
@@ -64,6 +64,7 @@
 			For any other controller that the [ARVRServer] detects, we continue with controller ID 3.
 			When a controller is turned off, its slot is freed. This ensures controllers will keep the same ID even when controllers with lower IDs are turned off.
 		</member>
+		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="1" />
 		<member name="rumble" type="float" setter="set_rumble" getter="get_rumble" default="0.0">
 			The degree to which the controller vibrates. Ranges from [code]0.0[/code] to [code]1.0[/code]. If changed, updates [member ARVRPositionalTracker.rumble] accordingly.
 			This is a useful property to animate if you want the controller to vibrate for a limited duration.

--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -69,6 +69,13 @@ String ARVRCamera::get_configuration_warning() const {
 		warning += TTR("ARVRCamera must have an ARVROrigin node as its parent.");
 	};
 
+	if (is_physics_interpolated()) {
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("ARVRCamera should have physics_interpolation_mode set to OFF in order to avoid jitter.");
+	}
+
 	return warning;
 };
 
@@ -172,8 +179,8 @@ Vector<Plane> ARVRCamera::get_frustum() const {
 	return cm.get_projection_planes(get_camera_transform());
 };
 
-ARVRCamera::ARVRCamera(){
-	// nothing to do here yet for now..
+ARVRCamera::ARVRCamera() {
+	set_physics_interpolation_mode(Node::PHYSICS_INTERPOLATION_MODE_OFF);
 };
 
 ARVRCamera::~ARVRCamera(){
@@ -390,6 +397,13 @@ String ARVRController::get_configuration_warning() const {
 		warning += TTR("The controller ID must not be 0 or this controller won't be bound to an actual controller.");
 	};
 
+	if (is_physics_interpolated()) {
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("ARVRController should have physics_interpolation_mode set to OFF in order to avoid jitter.");
+	}
+
 	return warning;
 };
 
@@ -397,6 +411,8 @@ ARVRController::ARVRController() {
 	controller_id = 1;
 	is_active = true;
 	button_states = 0;
+
+	set_physics_interpolation_mode(Node::PHYSICS_INTERPOLATION_MODE_OFF);
 };
 
 ARVRController::~ARVRController(){
@@ -524,6 +540,13 @@ String ARVRAnchor::get_configuration_warning() const {
 		warning += TTR("The anchor ID must not be 0 or this anchor won't be bound to an actual anchor.");
 	};
 
+	if (is_physics_interpolated()) {
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("ARVRAnchor should have physics_interpolation_mode set to OFF in order to avoid jitter.");
+	}
+
 	return warning;
 };
 
@@ -543,6 +566,8 @@ Ref<Mesh> ARVRAnchor::get_mesh() const {
 ARVRAnchor::ARVRAnchor() {
 	anchor_id = 1;
 	is_active = true;
+
+	set_physics_interpolation_mode(Node::PHYSICS_INTERPOLATION_MODE_OFF);
 };
 
 ARVRAnchor::~ARVRAnchor(){


### PR DESCRIPTION
Follow up for https://github.com/godotengine/godot/pull/103685
Addresses the second issue mentioned here: https://github.com/godotengine/godot/pull/103685#issuecomment-2718336903

ARVR Nodes get their transform updated on `NOTIFICATION_INTERNAL_PROCESS` , this causes some issues if interpolation is enabled, this PR fixes:
- `ARVRCamera`, `ARVRController` and  `ARVRAnchor` jitter when interpolation is enabled in project settings.
- Fixes the warning `Interpolated Camera triggered from outside physics process`.
Thanks to https://github.com/godotengine/godot/pull/103685 we can now have mixed interpolation modes on the scene without issues, so interpolation on ARVR Nodes should be disabled by default.

`ARVROrigin` isn't affected by this because its transform isn't updated on `NOTIFICATION_INTERNAL_PROCESS`.

Here is an comparison running at 10 physics FPS:

Before

https://github.com/user-attachments/assets/c72a63b3-2838-4ed7-a5d1-f81371ecca88

After

https://github.com/user-attachments/assets/a0b9c775-7ad8-4af4-90fd-6bee86d1d991

It's a bit hard to notice without a VR headset.

The alternative would be to change the transform on `NOTIFICATION_INTERNAL_PHYSICS_PROCESS` if interpolation is enabled on the nodes, it would also fix the issue but it would introduce pretty severe input lag for the tracking. 
In my opinion these nodes just shouldn't be interpolated at all, users will want the latest tracking data available on any situation.