### PR TITLE
Default mjpeg avi movie writer to 16 bit audio and add an editor option so it can still write 32 bit.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1085,6 +1085,9 @@
 		<member name="editor/import/use_multiple_threads" type="bool" setter="" getter="" default="true">
 			If [code]true[/code] importing of resources is run on multiple threads.
 		</member>
+		<member name="editor/movie_writer/audio_bit_depth" type="int" setter="" getter="" default="16">
+			Number of bits per audio sample written to the [code].avi[/code] file. Only 16 and 32-bit are supported.
+		</member>
 		<member name="editor/movie_writer/disable_vsync" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], requests V-Sync to be disabled when writing a movie (similar to setting [member display/window/vsync/vsync_mode] to [b]Disabled[/b]). This can speed up video writing if the hardware is fast enough to render, encode and save the video at a framerate higher than the monitor's refresh rate.
 			[b]Note:[/b] [member editor/movie_writer/disable_vsync] has no effect if the operating system or graphics driver forces V-Sync with no way for applications to disable it.

--- a/modules/jpg/movie_writer_mjpeg.cpp
+++ b/modules/jpg/movie_writer_mjpeg.cpp
@@ -133,7 +133,7 @@ Error MovieWriterMJPEG::write_begin(const Size2i &p_movie_size, uint32_t p_fps, 
 
 	// Audio //
 
-	const uint32_t bit_depth = 32;
+	const uint32_t bit_depth = audio_bit_depth;
 	uint32_t channels = 2;
 	switch (speaker_mode) {
 		case AudioServer::SPEAKER_MODE_STEREO:
@@ -207,7 +207,18 @@ Error MovieWriterMJPEG::write_frame(const Ref<Image> &p_image, const int32_t *p_
 
 	f->store_buffer((const uint8_t *)"01wb", 4); // Stream 1, Audio.
 	f->store_32(audio_block_size);
-	f->store_buffer((const uint8_t *)p_audio_data, audio_block_size);
+	if (audio_bit_depth == 16) {
+		// Convert from 32bit to 16bit.
+		Vector<int16_t> audio_buffer_16;
+		int num_samples = audio_block_size / 2;
+		audio_buffer_16.resize(num_samples);
+		for (int i = 0; i < num_samples; ++i) {
+			audio_buffer_16.write[i] = (int16_t)(p_audio_data[i] >> 16);
+		}
+		f->store_buffer((const uint8_t *)audio_buffer_16.ptr(), audio_block_size);
+	} else {
+		f->store_buffer((const uint8_t *)p_audio_data, audio_block_size);
+	}
 
 	frame_count++;
 
@@ -260,4 +271,5 @@ MovieWriterMJPEG::MovieWriterMJPEG() {
 	mix_rate = GLOBAL_GET("editor/movie_writer/mix_rate");
 	speaker_mode = AudioServer::SpeakerMode(int(GLOBAL_GET("editor/movie_writer/speaker_mode")));
 	quality = GLOBAL_GET("editor/movie_writer/video_quality");
+	audio_bit_depth = GLOBAL_GET("editor/movie_writer/audio_bit_depth");
 }

--- a/modules/jpg/movie_writer_mjpeg.h
+++ b/modules/jpg/movie_writer_mjpeg.h
@@ -37,6 +37,7 @@ class MovieWriterMJPEG : public MovieWriter {
 
 	uint32_t mix_rate = 48000;
 	AudioServer::SpeakerMode speaker_mode = AudioServer::SPEAKER_MODE_STEREO;
+	uint32_t audio_bit_depth = 16;
 	String base_path;
 	uint32_t frame_count = 0;
 	uint32_t fps = 0;

--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -157,6 +157,7 @@ void MovieWriter::_bind_methods() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/movie_writer/mix_rate", PROPERTY_HINT_RANGE, "8000,192000,1,suffix:Hz"), 48000);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/movie_writer/speaker_mode", PROPERTY_HINT_ENUM, "Stereo,3.1,5.1,7.1"), 0);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "editor/movie_writer/video_quality", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), 0.75);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/movie_writer/audio_bit_depth", PROPERTY_HINT_ENUM, "16:16,32:32"), 16);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "editor/movie_writer/ogv/audio_quality", PROPERTY_HINT_RANGE, "-0.1,1.0,0.01"), 0.5);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/movie_writer/ogv/encoding_speed", PROPERTY_HINT_ENUM, "Fastest (Lowest Efficiency):4,Fast (Low Efficiency):3,Slow (High Efficiency):2,Slowest (Highest Efficiency):1"), 4);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/movie_writer/ogv/keyframe_interval", PROPERTY_HINT_RANGE, "1,1024,1"), 64);


### PR DESCRIPTION
Lots of software doesn't support 32bit audio, so I made this change makes the movie maker output 16bit by default.  The bit depth can be changed in the editor settings.

Closes: https://github.com/godotengine/godot-proposals/issues/12131