### PR TITLE
Add quick access to Movie Maker output path in editor bar

### DIFF
--- a/editor/gui/editor_filepath_select.cpp
+++ b/editor/gui/editor_filepath_select.cpp
@@ -1,0 +1,69 @@
+/**************************************************************************/
+/*  editor_filepath_select.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_filepath_select.h"
+
+void EditorFilepathSelect::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED:
+			browse_button->set_button_icon(get_editor_theme_icon(SNAME("FileBrowse")));
+			break;
+	}
+}
+void EditorFilepathSelect::_path_pressed() {
+	if (!dialog) {
+		dialog = memnew(EditorFileDialog);
+		dialog->connect("file_selected", callable_mp(this, &EditorFilepathSelect::_dialog_path_selected));
+		add_child(dialog);
+	}
+
+	String full_path = edit->get_text();
+	dialog->clear_filters();
+
+	dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
+	dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
+	dialog->popup_file_dialog();
+}
+
+void EditorFilepathSelect::_dialog_path_selected(const String &p_path) {
+	edit->set_text(p_path);
+}
+
+EditorFilepathSelect::EditorFilepathSelect() {
+	edit = memnew(LineEdit);
+	edit->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_FILE);
+	add_child(edit);
+	edit->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	browse_button = memnew(Button);
+	add_child(browse_button);
+	browse_button->set_clip_text(true);
+	browse_button->connect(SceneStringName(pressed), callable_mp(this, &EditorFilepathSelect::_path_pressed));
+}

--- a/editor/gui/editor_filepath_select.cpp
+++ b/editor/gui/editor_filepath_select.cpp
@@ -38,14 +38,7 @@ void EditorFilepathSelect::_notification(int p_what) {
 	}
 }
 void EditorFilepathSelect::_path_pressed() {
-	if (!dialog) {
-		dialog = memnew(EditorFileDialog);
-		dialog->connect("file_selected", callable_mp(this, &EditorFilepathSelect::_dialog_path_selected));
-		add_child(dialog);
-	}
-
 	String full_path = edit->get_text();
-	dialog->clear_filters();
 
 	dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
@@ -70,4 +63,8 @@ EditorFilepathSelect::EditorFilepathSelect() {
 	add_child(browse_button);
 	browse_button->set_clip_text(true);
 	browse_button->connect(SceneStringName(pressed), callable_mp(this, &EditorFilepathSelect::_path_pressed));
+
+	dialog = memnew(EditorFileDialog);
+	dialog->connect("file_selected", callable_mp(this, &EditorFilepathSelect::_dialog_path_selected));
+	add_child(dialog);
 }

--- a/editor/gui/editor_filepath_select.cpp
+++ b/editor/gui/editor_filepath_select.cpp
@@ -54,6 +54,10 @@ void EditorFilepathSelect::_path_pressed() {
 
 void EditorFilepathSelect::_dialog_path_selected(const String &p_path) {
 	edit->set_text(p_path);
+
+	// TODO: Make a different signal, instead of manually emitting the LineEdit's
+	// signal?
+	edit->emit_signal("text_submitted", p_path);
 }
 
 EditorFilepathSelect::EditorFilepathSelect() {

--- a/editor/gui/editor_filepath_select.h
+++ b/editor/gui/editor_filepath_select.h
@@ -49,5 +49,6 @@ class EditorFilepathSelect : public HBoxContainer {
 
 public:
 	LineEdit *get_edit() { return edit; }
+	EditorFileDialog *get_dialog() { return dialog; }
 	EditorFilepathSelect();
 };

--- a/editor/gui/editor_filepath_select.h
+++ b/editor/gui/editor_filepath_select.h
@@ -1,0 +1,53 @@
+/**************************************************************************/
+/*  editor_filepath_select.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/gui/editor_file_dialog.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/line_edit.h"
+
+class EditorFilepathSelect : public HBoxContainer {
+	GDCLASS(EditorFilepathSelect, HBoxContainer);
+
+	LineEdit *edit = nullptr;
+	Button *browse_button = nullptr;
+	EditorFileDialog *dialog = nullptr;
+
+	void _notification(int p_what);
+
+	void _path_pressed();
+	void _dialog_path_selected(const String &p_path);
+
+public:
+	LineEdit *get_edit() { return edit; }
+	EditorFilepathSelect();
+};

--- a/editor/gui/editor_quick_movie_maker_config.cpp
+++ b/editor/gui/editor_quick_movie_maker_config.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "editor/project_settings_editor.h"
 #include "editor/themes/editor_scale.h"
 
 void EditorQuickMovieMakerConfig::_close_requested() {
@@ -89,6 +90,12 @@ void EditorQuickMovieMakerConfig::_notification(int p_what) {
 	}
 }
 
+void EditorQuickMovieMakerConfig::_open_settings_pressed() {
+	set_visible(false);
+	ProjectSettingsEditor::get_singleton()->popup_project_settings(true);
+	ProjectSettingsEditor::get_singleton()->set_general_page("editor/movie_writer");
+}
+
 EditorQuickMovieMakerConfig::EditorQuickMovieMakerConfig() {
 	set_transient(true);
 
@@ -116,4 +123,9 @@ EditorQuickMovieMakerConfig::EditorQuickMovieMakerConfig() {
 			filepath_select->get_dialog()->add_filter(e);
 		}
 	}
+
+	open_settings_button = memnew(Button);
+	parts_container->add_child(open_settings_button);
+	open_settings_button->set_text("Open Project Settings...");
+	open_settings_button->connect("pressed", callable_mp(this, &EditorQuickMovieMakerConfig::_open_settings_pressed));
 }

--- a/editor/gui/editor_quick_movie_maker_config.cpp
+++ b/editor/gui/editor_quick_movie_maker_config.cpp
@@ -1,0 +1,119 @@
+/**************************************************************************/
+/*  editor_quick_movie_maker_config.cpp                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_quick_movie_maker_config.h"
+
+#include "core/config/project_settings.h"
+#include "editor/editor_undo_redo_manager.h"
+#include "editor/themes/editor_scale.h"
+
+void EditorQuickMovieMakerConfig::_close_requested() {
+	if (movie_path_was_changed) {
+		_update_movie_file_path(filepath_select->get_edit()->get_text());
+	}
+}
+
+void EditorQuickMovieMakerConfig::_path_edit_focus_exited() {
+	if (movie_path_was_changed) {
+		_update_movie_file_path(filepath_select->get_edit()->get_text());
+	}
+}
+
+void EditorQuickMovieMakerConfig::_path_edit_text_submitted(const String &p_new_text) {
+	_update_movie_file_path(p_new_text);
+}
+
+void EditorQuickMovieMakerConfig::_path_edit_text_changed(const String &p_new_text) {
+	movie_path_was_changed = true;
+}
+
+void EditorQuickMovieMakerConfig::_update_movie_file_path(const String &p_new_text) {
+	// Immediately save the project settings value.
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Set movie_file"));
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "editor/movie_writer/movie_file", p_new_text);
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "editor/movie_writer/movie_file", GLOBAL_GET("editor/movie_writer/movie_file"));
+	undo_redo->add_undo_property(filepath_select->get_edit(), "text", GLOBAL_GET("editor/movie_writer/movie_file"));
+	undo_redo->commit_action();
+}
+
+void EditorQuickMovieMakerConfig::_visibility_changed() {
+	if (is_visible()) {
+		// Populate the field with the current Movie Maker path.
+		Variant current_path_variant = ProjectSettings::get_singleton()->get("editor/movie_writer/movie_file");
+		String current_path = current_path_variant;
+		filepath_select->get_edit()->set_text(current_path);
+
+		// Set to true when the LineEdit contents are changed;
+		// tells Godot to actually change the property string.
+		movie_path_was_changed = false;
+	}
+}
+
+void EditorQuickMovieMakerConfig::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_POSTINITIALIZE:
+			connect("visibility_changed", callable_mp(this, &EditorQuickMovieMakerConfig::_visibility_changed));
+			connect("close_requested", callable_mp(this, &EditorQuickMovieMakerConfig::_close_requested));
+			break;
+		case NOTIFICATION_THEME_CHANGED:
+			set_min_size(Size2i(600.0, 0.0) * EDSCALE);
+			break;
+	}
+}
+
+EditorQuickMovieMakerConfig::EditorQuickMovieMakerConfig() {
+	set_transient(true);
+
+	parts_container = memnew(VBoxContainer);
+	add_child(parts_container);
+
+	path_container = memnew(VBoxContainer);
+	parts_container->add_child(path_container);
+
+	path_label = memnew(Label);
+	path_container->add_child(path_label);
+	path_label->set_text("Movie output path");
+
+	// NOTE: Use EditorPropertyPath as reference.
+	filepath_select = memnew(EditorFilepathSelect);
+	parts_container->add_child(filepath_select);
+	filepath_select->get_edit()->connect("text_submitted", callable_mp(this, &EditorQuickMovieMakerConfig::_path_edit_text_submitted));
+	filepath_select->get_edit()->connect("text_changed", callable_mp(this, &EditorQuickMovieMakerConfig::_path_edit_text_changed));
+
+	String extensions_string = ProjectSettings::get_singleton()->get_custom_property_info().get(StringName("editor/movie_writer/movie_file")).hint_string;
+	Vector<String> extensions = extensions_string.split(",");
+	for (int i = 0; i < extensions.size(); i++) {
+		String e = extensions[i].strip_edges();
+		if (!e.is_empty()) {
+			filepath_select->get_dialog()->add_filter(e);
+		}
+	}
+}

--- a/editor/gui/editor_quick_movie_maker_config.h
+++ b/editor/gui/editor_quick_movie_maker_config.h
@@ -51,7 +51,6 @@ class EditorQuickMovieMakerConfig : public PopupPanel {
 	void _notification(int p_what);
 	void _open_settings_pressed();
 
-public:
 	void _close_requested();
 	void _path_edit_focus_exited();
 	void _path_edit_text_submitted(const String &p_new_text);
@@ -59,5 +58,6 @@ public:
 	void _visibility_changed();
 	void _update_movie_file_path(const String &p_new_text);
 
+public:
 	EditorQuickMovieMakerConfig();
 };

--- a/editor/gui/editor_quick_movie_maker_config.h
+++ b/editor/gui/editor_quick_movie_maker_config.h
@@ -33,6 +33,7 @@
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_filepath_select.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
 #include "scene/gui/label.h"
 #include "scene/gui/popup.h"
 
@@ -44,9 +45,11 @@ class EditorQuickMovieMakerConfig : public PopupPanel {
 	Label *path_label = nullptr;
 	VBoxContainer *path_container = nullptr;
 	EditorFilepathSelect *filepath_select = nullptr;
+	Button *open_settings_button = nullptr;
 	bool movie_path_was_changed = false;
 
 	void _notification(int p_what);
+	void _open_settings_pressed();
 
 public:
 	void _close_requested();

--- a/editor/gui/editor_quick_movie_maker_config.h
+++ b/editor/gui/editor_quick_movie_maker_config.h
@@ -1,0 +1,60 @@
+/**************************************************************************/
+/*  editor_quick_movie_maker_config.h                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_filepath_select.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/label.h"
+#include "scene/gui/popup.h"
+
+class EditorQuickMovieMakerConfig : public PopupPanel {
+	GDCLASS(EditorQuickMovieMakerConfig, PopupPanel);
+
+	VBoxContainer *parts_container = nullptr;
+
+	Label *path_label = nullptr;
+	VBoxContainer *path_container = nullptr;
+	EditorFilepathSelect *filepath_select = nullptr;
+	bool movie_path_was_changed = false;
+
+	void _notification(int p_what);
+
+public:
+	void _close_requested();
+	void _path_edit_focus_exited();
+	void _path_edit_text_submitted(const String &p_new_text);
+	void _path_edit_text_changed(const String &p_new_text);
+	void _visibility_changed();
+	void _update_movie_file_path(const String &p_new_text);
+
+	EditorQuickMovieMakerConfig();
+};

--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -183,11 +183,8 @@ void EditorRunBar::_movie_dropdown_toggled(bool p_enabled) {
 		Variant current_path_variant = ProjectSettings::get_singleton()->get("editor/movie_writer/movie_file");
 		String current_path = current_path_variant;
 		movie_filepath_select->get_edit()->set_text(current_path);
-
-		print_line("Show Movie Maker settings dropdown");
 		movie_popup->show();
 	} else {
-		print_line("Hide Movie Maker settings dropdown");
 		movie_popup->hide();
 	}
 }
@@ -744,5 +741,13 @@ EditorRunBar::EditorRunBar() {
 	movie_popup_parts_container->add_child(movie_filepath_select);
 	movie_filepath_select->get_edit()->connect("text_submitted", callable_mp(this, &EditorRunBar::_movie_popup_path_edit_text_submitted));
 
+	String extensions_string = ProjectSettings::get_singleton()->get_custom_property_info().get(StringName("editor/movie_writer/movie_file")).hint_string;
+	Vector<String> extensions = extensions_string.split(",");
+	for (int i = 0; i < extensions.size(); i++) {
+		String e = extensions[i].strip_edges();
+		if (!e.is_empty()) {
+			movie_filepath_select->get_dialog()->add_filter(e);
+		}
+	}
 	movie_popup->hide();
 }

--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -182,7 +182,7 @@ void EditorRunBar::_movie_dropdown_toggled(bool p_enabled) {
 		// Populate the field with the current Movie Maker path.
 		Variant current_path_variant = ProjectSettings::get_singleton()->get("editor/movie_writer/movie_file");
 		String current_path = current_path_variant;
-		movie_popup_path_edit->set_text(current_path);
+		movie_filepath_select->get_edit()->set_text(current_path);
 
 		print_line("Show Movie Maker settings dropdown");
 		movie_popup->show();
@@ -209,7 +209,7 @@ void EditorRunBar::_movie_popup_path_edit_text_submitted(const String &p_new_tex
 	undo_redo->create_action(TTR("Set movie_file"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "editor/movie_writer/movie_file", p_new_text);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "editor/movie_writer/movie_file", GLOBAL_GET("editor/movie_writer/movie_file"));
-	undo_redo->add_undo_property(movie_popup_path_edit, "text", GLOBAL_GET("editor/movie_writer/movie_file"));
+	undo_redo->add_undo_property(movie_filepath_select->get_edit(), "text", GLOBAL_GET("editor/movie_writer/movie_file"));
 	undo_redo->commit_action();
 }
 
@@ -739,12 +739,10 @@ EditorRunBar::EditorRunBar() {
 	movie_popup_path_container->add_child(movie_popup_path_label);
 	movie_popup_path_label->set_text("Output path");
 
-	// TODO: look at EditorPropertyPath
-	movie_popup_path_edit = memnew(LineEdit);
-	movie_popup_path_edit->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_FILE);
-	movie_popup_path_container->add_child(movie_popup_path_edit);
-	movie_popup_path_edit->connect("text_submitted", callable_mp(this, &EditorRunBar::_movie_popup_path_edit_text_submitted));
-	movie_popup_path_edit->connect(SceneStringName(focus_exited), callable_mp(this, &EditorRunBar::_movie_popup_path_edit_focus_exited));
+	// NOTE: Use EditorPropertyPath as reference.
+	movie_filepath_select = memnew(EditorFilepathSelect);
+	movie_popup_parts_container->add_child(movie_filepath_select);
+	movie_filepath_select->get_edit()->connect("text_submitted", callable_mp(this, &EditorRunBar::_movie_popup_path_edit_text_submitted));
 
 	movie_popup->hide();
 }

--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -222,7 +222,6 @@ void EditorRunBar::_update_movie_file_path(const String &p_new_text) {
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "editor/movie_writer/movie_file", GLOBAL_GET("editor/movie_writer/movie_file"));
 	undo_redo->add_undo_property(movie_filepath_select->get_edit(), "text", GLOBAL_GET("editor/movie_writer/movie_file"));
 	undo_redo->commit_action();
-	// TODO: Update LineEdit when undo or redo is done
 }
 
 Vector<String> EditorRunBar::_get_xr_mode_play_args(int p_xr_mode_id) {
@@ -749,7 +748,7 @@ EditorRunBar::EditorRunBar() {
 
 	movie_popup_path_label = memnew(Label);
 	movie_popup_path_container->add_child(movie_popup_path_label);
-	movie_popup_path_label->set_text("Output path");
+	movie_popup_path_label->set_text("Movie output path");
 
 	// NOTE: Use EditorPropertyPath as reference.
 	movie_filepath_select = memnew(EditorFilepathSelect);
@@ -765,5 +764,6 @@ EditorRunBar::EditorRunBar() {
 			movie_filepath_select->get_dialog()->add_filter(e);
 		}
 	}
+
 	movie_popup->hide();
 }

--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -696,6 +696,7 @@ EditorRunBar::EditorRunBar() {
 	movie_dropdown_button->set_pressed(false);
 	movie_dropdown_button->set_focus_mode(Control::FOCUS_NONE);
 
+	// TODO: Toggle dropdown button off whenever config panel is made invisible.
 	movie_dropdown_button->connect(SceneStringName(toggled), callable_mp(this, &EditorRunBar::_movie_dropdown_toggled));
 
 	movie_popup = memnew(EditorQuickMovieMakerConfig);

--- a/editor/gui/editor_run_bar.h
+++ b/editor/gui/editor_run_bar.h
@@ -32,6 +32,7 @@
 
 #include "editor/editor_run.h"
 #include "editor/export/editor_export.h"
+#include "editor/gui/editor_filepath_select.h"
 #include "scene/gui/margin_container.h"
 
 class Button;
@@ -83,8 +84,8 @@ class EditorRunBar : public MarginContainer {
 	VBoxContainer *movie_popup_parts_container = nullptr;
 
 	Label *movie_popup_path_label = nullptr;
-	LineEdit *movie_popup_path_edit = nullptr;
 	VBoxContainer *movie_popup_path_container = nullptr;
+	EditorFilepathSelect *movie_filepath_select = nullptr;
 
 	RunMode current_mode = RunMode::STOPPED;
 	String run_custom_filename;

--- a/editor/gui/editor_run_bar.h
+++ b/editor/gui/editor_run_bar.h
@@ -96,6 +96,8 @@ class EditorRunBar : public MarginContainer {
 	void _write_movie_toggled(bool p_enabled);
 	void _movie_dropdown_toggled(bool p_enabled);
 	void _movie_popup_close_requested();
+	void _movie_popup_path_edit_focus_exited();
+	void _movie_popup_path_edit_text_submitted(const String &p_new_text);
 	void _quick_run_selected(const String &p_file_path, int p_id = -1);
 
 	void _play_current_pressed(int p_id = -1);

--- a/editor/gui/editor_run_bar.h
+++ b/editor/gui/editor_run_bar.h
@@ -33,6 +33,7 @@
 #include "editor/editor_run.h"
 #include "editor/export/editor_export.h"
 #include "editor/gui/editor_filepath_select.h"
+#include "editor/gui/editor_quick_movie_maker_config.h"
 #include "scene/gui/margin_container.h"
 
 class Button;
@@ -80,13 +81,7 @@ class EditorRunBar : public MarginContainer {
 	Button *write_movie_button = nullptr;
 	Button *movie_dropdown_button = nullptr;
 
-	PopupPanel *movie_popup = nullptr;
-	VBoxContainer *movie_popup_parts_container = nullptr;
-
-	Label *movie_popup_path_label = nullptr;
-	VBoxContainer *movie_popup_path_container = nullptr;
-	EditorFilepathSelect *movie_filepath_select = nullptr;
-	bool movie_path_was_changed = false;
+	EditorQuickMovieMakerConfig *movie_popup = nullptr;
 
 	RunMode current_mode = RunMode::STOPPED;
 	String run_custom_filename;
@@ -98,10 +93,6 @@ class EditorRunBar : public MarginContainer {
 	void _write_movie_toggled(bool p_enabled);
 	void _movie_dropdown_toggled(bool p_enabled);
 	void _movie_popup_close_requested();
-	void _movie_popup_path_edit_focus_exited();
-	void _movie_popup_path_edit_text_submitted(const String &p_new_text);
-	void _movie_popup_path_edit_text_changed(const String &p_new_text);
-	void _update_movie_file_path(const String &p_new_text);
 	void _quick_run_selected(const String &p_file_path, int p_id = -1);
 
 	void _play_current_pressed(int p_id = -1);

--- a/editor/gui/editor_run_bar.h
+++ b/editor/gui/editor_run_bar.h
@@ -86,6 +86,7 @@ class EditorRunBar : public MarginContainer {
 	Label *movie_popup_path_label = nullptr;
 	VBoxContainer *movie_popup_path_container = nullptr;
 	EditorFilepathSelect *movie_filepath_select = nullptr;
+	bool movie_path_was_changed = false;
 
 	RunMode current_mode = RunMode::STOPPED;
 	String run_custom_filename;
@@ -99,6 +100,8 @@ class EditorRunBar : public MarginContainer {
 	void _movie_popup_close_requested();
 	void _movie_popup_path_edit_focus_exited();
 	void _movie_popup_path_edit_text_submitted(const String &p_new_text);
+	void _movie_popup_path_edit_text_changed(const String &p_new_text);
+	void _update_movie_file_path(const String &p_new_text);
 	void _quick_run_selected(const String &p_file_path, int p_id = -1);
 
 	void _play_current_pressed(int p_id = -1);

--- a/editor/gui/editor_run_bar.h
+++ b/editor/gui/editor_run_bar.h
@@ -36,7 +36,9 @@
 
 class Button;
 class EditorRunNative;
+class LineEdit;
 class PanelContainer;
+class PopupPanel;
 class HBoxContainer;
 class AcceptDialog;
 
@@ -72,8 +74,17 @@ class EditorRunBar : public MarginContainer {
 	EditorRun editor_run;
 	EditorRunNative *run_native = nullptr;
 
+	HBoxContainer *movie_hbox = nullptr;
 	PanelContainer *write_movie_panel = nullptr;
 	Button *write_movie_button = nullptr;
+	Button *movie_dropdown_button = nullptr;
+
+	PopupPanel *movie_popup = nullptr;
+	VBoxContainer *movie_popup_parts_container = nullptr;
+
+	Label *movie_popup_path_label = nullptr;
+	LineEdit *movie_popup_path_edit = nullptr;
+	VBoxContainer *movie_popup_path_container = nullptr;
 
 	RunMode current_mode = RunMode::STOPPED;
 	String run_custom_filename;
@@ -83,6 +94,8 @@ class EditorRunBar : public MarginContainer {
 	void _update_play_buttons();
 
 	void _write_movie_toggled(bool p_enabled);
+	void _movie_dropdown_toggled(bool p_enabled);
+	void _movie_popup_close_requested();
 	void _quick_run_selected(const String &p_file_path, int p_id = -1);
 
 	void _play_current_pressed(int p_id = -1);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11541 .

This PR adds a button to the editor's run bar next to the Movie Maker button. Clicking the button opens a popup window where the Movie Maker output path can be changed.

https://github.com/user-attachments/assets/d691c983-b1a4-4745-a270-282db0f7cff7

To help accomplish this, it also includes a new class, `EditorFilepathSelect`, which consists of a `LineEdit` and a `Button`. Clicking the `Button` opens a file dialog, and choosing a file from the dialog populates the `LineEdit` with its path.

## To Do
- [x] Update the project setting when focus leaves the `LineEdit`
- [ ] Include a checkbox for setting the current scene's movie path instead of the global project path(?)
- [x] Set the `EditorFilepathSelect`'s accepted file types

It isn't necessary for this PR specifically, and would probably increase the amount of time it takes by a lot, so unless it is very desired I won't try to add additional settings to `EditorFilepathSelect` until perhaps a future PR.