### PR TITLE
Add warning for deprecated identifiers in GDScript

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -563,6 +563,9 @@
 			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when deprecated keywords are used.
 			[b]Note:[/b] There are currently no deprecated keywords, so this warning is never produced.
 		</member>
+		<member name="debug/gdscript/warnings/deprecated_usage" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when deprecated symbols are used. These include any deprecated class, enum, constant, signal, property, and method.
+		</member>
 		<member name="debug/gdscript/warnings/directory_rules" type="Dictionary" setter="" getter="" default="{ &quot;res://addons&quot;: 0 }">
 			The rules for including or excluding scripts when generating warnings, as a dictionary. Each rule is an entry consisting of a directory path (key) and a decision (value). When trying to generate a warning, the GDScript parser chooses the most specific rule, i.e. the most nested directory containing the script. If the decision is [b]Exclude[/b], warnings are not generated for this script. If the decision is [b]Include[/b] or the script doesn't satisfy any of the rules, the warning configuration specified in the Project Settings is applied.
 			It is recommended to include your own addons/libraries, either project-specific or actively being developed at the moment. Third-party or project-agnostic addons/libraries should be excluded, as they may be incompatible with the project's warning configuration.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -568,6 +568,9 @@
 			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when deprecated keywords are used.
 			[b]Note:[/b] There are currently no deprecated keywords, so this warning is never produced.
 		</member>
+		<member name="debug/gdscript/warnings/deprecated_usage" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when deprecated symbols are used. These include any deprecated class, enum, constant, signal, property, and method.
+		</member>
 		<member name="debug/gdscript/warnings/directory_rules" type="Dictionary" setter="" getter="" default="{ &quot;res://addons&quot;: 0 }">
 			The rules for including or excluding scripts when generating warnings, as a dictionary. Each rule is an entry consisting of a directory path (key) and a decision (value). When trying to generate a warning, the GDScript parser chooses the most specific rule, i.e. the most nested directory containing the script. If the decision is [b]Exclude[/b], warnings are not generated for this script. If the decision is [b]Include[/b] or the script doesn't satisfy any of the rules, the warning configuration specified in the Project Settings is applied.
 			It is recommended to include your own addons/libraries, either project-specific or actively being developed at the moment. Third-party or project-agnostic addons/libraries should be excluded, as they may be incompatible with the project's warning configuration.

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -46,6 +46,10 @@
 
 #include "modules/gdscript/gdscript_parser.h"
 
+#ifdef TOOLS_ENABLED
+#include "editor/doc/editor_help.h"
+#endif
+
 #if defined(TOOLS_ENABLED) && !defined(DISABLE_DEPRECATED)
 #define SUGGEST_GODOT4_RENAMES
 #include "editor/project_upgrade/renames_map_3_to_4.h"
@@ -2176,6 +2180,13 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 		type = specified_type;
 	}
 
+#ifdef TOOLS_ENABLED
+	String dep_message, dep_value_type, dep_value_name;
+	if (get_type_is_deprecated(type, &dep_message, &dep_value_type, &dep_value_name)) {
+		parser->push_warning(p_assignable, GDScriptWarning::DEPRECATED_USAGE, dep_value_type, dep_value_name, dep_message);
+	}
+#endif // TOOLS_ENABLED
+
 	if (p_assignable->initializer != nullptr) {
 		reduce_expression(p_assignable->initializer);
 
@@ -4128,6 +4139,13 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 	StringName name = p_identifier->name;
 
 	if (base.kind == GDScriptParser::DataType::ENUM) {
+#ifdef TOOLS_ENABLED
+		String message;
+		if (get_enum_value_is_deprecated(base, name, &message)) {
+			String full_value_name = vformat("%s.%s", base.enum_type, name);
+			parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "enum value", full_value_name, message);
+		}
+#endif // TOOLS_ENABLED
 		if (base.is_meta_type) {
 			if (base.enum_values.has(name)) {
 				p_identifier->type_constraint = type_from_metatype(base);
@@ -4273,6 +4291,11 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 					p_identifier->reduced_value = member.constant->initializer->reduced_value;
 					p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CONSTANT;
 					p_identifier->constant_source = member.constant;
+#ifdef TOOLS_ENABLED
+					if (member.constant->doc_data.is_deprecated) {
+						parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "constant", name, member.constant->doc_data.deprecated_message);
+					}
+#endif // TOOLS_ENABLED
 					return;
 				}
 
@@ -4281,6 +4304,11 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 					p_identifier->is_constant = true;
 					p_identifier->reduced_value = member.enum_value.value;
 					p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CONSTANT;
+#ifdef TOOLS_ENABLED
+					if (member.enum_value.doc_data.is_deprecated) {
+						parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "enum value", name, member.enum_value.doc_data.deprecated_message);
+					}
+#endif // TOOLS_ENABLED
 					return;
 				}
 
@@ -4289,6 +4317,11 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 					p_identifier->is_constant = true;
 					p_identifier->reduced_value = member.m_enum->dictionary;
 					p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CONSTANT;
+#ifdef TOOLS_ENABLED
+					if (member.m_enum->doc_data.is_deprecated) {
+						parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "enum", name, member.m_enum->doc_data.deprecated_message);
+					}
+#endif // TOOLS_ENABLED
 					return;
 				}
 
@@ -4298,6 +4331,11 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 						p_identifier->source = member.variable->is_static ? GDScriptParser::IdentifierNode::STATIC_VARIABLE : GDScriptParser::IdentifierNode::MEMBER_VARIABLE;
 						p_identifier->variable_source = member.variable;
 						member.variable->usages += 1;
+#ifdef TOOLS_ENABLED
+						if (member.variable->doc_data.is_deprecated) {
+							parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "property or variable", name, member.variable->doc_data.deprecated_message);
+						}
+#endif // TOOLS_ENABLED
 						return;
 					}
 				} break;
@@ -4308,6 +4346,12 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 						p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_SIGNAL;
 						p_identifier->signal_source = member.signal;
 						member.signal->usages += 1;
+
+#ifdef TOOLS_ENABLED
+						if (member.signal->doc_data.is_deprecated) {
+							parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "signal", name, member.signal->doc_data.deprecated_message);
+						}
+#endif // TOOLS_ENABLED
 						return;
 					}
 				} break;
@@ -4325,6 +4369,11 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 				case GDScriptParser::ClassNode::Member::CLASS: {
 					reduce_identifier_from_base_set_class(p_identifier, member.get_datatype());
 					p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CLASS;
+#ifdef TOOLS_ENABLED
+					if (script_class->get_member(name).m_class->doc_data.is_deprecated) {
+						parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "class", name, script_class->get_member(name).m_class->doc_data.deprecated_message);
+					}
+#endif // TOOLS_ENABLED
 					return;
 				}
 
@@ -4414,6 +4463,12 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 				p_identifier->type_constraint = type_from_property(getter->get_return_info(), false, !has_setter);
 				p_identifier->source = GDScriptParser::IdentifierNode::INHERITED_VARIABLE;
 			}
+#ifdef TOOLS_ENABLED
+			String message;
+			if (get_native_property_is_deprecated(native, name, &message)) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "property", name, message);
+			}
+#endif // TOOLS_ENABLED
 			return;
 		}
 		if (ClassDB::get_method_info(native, name, &method_info)) {
@@ -4426,11 +4481,23 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 			// Signal is a type too.
 			p_identifier->type_constraint = make_signal_type(method_info);
 			p_identifier->source = GDScriptParser::IdentifierNode::INHERITED_VARIABLE;
+#ifdef TOOLS_ENABLED
+			String message;
+			if (get_native_signal_is_deprecated(native, name, &message)) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "signal", name, message);
+			}
+#endif // TOOLS_ENABLED
 			return;
 		}
 		if (ClassDB::has_enum(native, name)) {
 			p_identifier->type_constraint = make_native_enum_type(name, native);
 			p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CONSTANT;
+#ifdef TOOLS_ENABLED
+			String message;
+			if (get_native_enum_is_deprecated(native, name, &message)) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "enum", name, message);
+			}
+#endif // TOOLS_ENABLED
 			return;
 		}
 		bool valid = false;
@@ -4440,6 +4507,13 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 			p_identifier->is_constant = true;
 			p_identifier->reduced_value = int_constant;
 			p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CONSTANT;
+
+#ifdef TOOLS_ENABLED
+			String message;
+			if (get_native_constant_is_deprecated(native, name, &message)) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "constant", name, message);
+			}
+#endif // TOOLS_ENABLED
 
 			// Check whether this constant, which exists, belongs to an enum
 			StringName enum_name = ClassDB::get_integer_constant_enum(native, name);
@@ -4496,6 +4570,12 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 			// TODO: Constant should have a value on the node itself.
 			p_identifier->reduced_value = p_identifier->constant_source->initializer->reduced_value;
 			found_source = true;
+
+#ifdef TOOLS_ENABLED
+			if (p_identifier->constant_source->doc_data.is_deprecated) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "constant", p_identifier->name, p_identifier->constant_source->doc_data.deprecated_message);
+			}
+#endif
 			break;
 		case GDScriptParser::IdentifierNode::MEMBER_SIGNAL:
 			p_identifier->signal_source->usages++;
@@ -4517,6 +4597,11 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 				parser->push_warning(p_identifier, GDScriptWarning::UNASSIGNED_VARIABLE, p_identifier->name);
 			}
 #endif // DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
+			if (p_identifier->variable_source->doc_data.is_deprecated) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "property or variable", p_identifier->name, p_identifier->variable_source->doc_data.deprecated_message);
+			}
+#endif // TOOLS_ENABLED
 			break;
 		case GDScriptParser::IdentifierNode::LOCAL_ITERATOR:
 			p_identifier->type_constraint = p_identifier->bind_source->type_constraint;
@@ -4637,6 +4722,12 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 	}
 
 	if (class_exists(name)) {
+#ifdef TOOLS_ENABLED
+		String message;
+		if (get_class_is_deprecated(name, &message)) {
+			parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "class", name, message);
+		}
+#endif // TOOLS_ENABLED
 		p_identifier->source = GDScriptParser::IdentifierNode::NATIVE_CLASS;
 		p_identifier->type_constraint = make_native_meta_type(name);
 		return;
@@ -4644,6 +4735,12 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 
 	if (ScriptServer::is_global_class(name)) {
 		p_identifier->type_constraint = make_global_class_meta_type(name, p_identifier);
+#ifdef TOOLS_ENABLED
+		String message;
+		if (get_class_is_deprecated(name, &message)) {
+			parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "class", name, message);
+		}
+#endif // TOOLS_ENABLED
 		return;
 	}
 
@@ -4684,6 +4781,12 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 					}
 				}
 			}
+#ifdef TOOLS_ENABLED
+			String message;
+			if (get_class_is_deprecated(name, &message)) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "class", name, message);
+			}
+#endif // TOOLS_ENABLED
 			result.is_constant = true;
 			p_identifier->type_constraint = result;
 			return;
@@ -4701,6 +4804,13 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 		}
 		p_identifier->is_constant = true;
 		p_identifier->reduced_value = value;
+
+#ifdef TOOLS_ENABLED
+		String message;
+		if (get_native_constant_is_deprecated("@GlobalScope", name, &message)) {
+			parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "constant", name, message);
+		}
+#endif // TOOLS_ENABLED
 		return;
 	}
 
@@ -6068,6 +6178,12 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::Node *p_source, bo
 		r_return_type.is_meta_type = false;
 		r_return_type.is_coroutine = found_function->is_coroutine;
 
+#ifdef TOOLS_ENABLED
+		// For user-defined methods.
+		if (found_function->doc_data.is_deprecated) {
+			parser->push_warning(p_source, GDScriptWarning::DEPRECATED_USAGE, "function", found_function->identifier->name, found_function->doc_data.deprecated_message);
+		}
+#endif // TOOLS_ENABLED
 		return true;
 	}
 
@@ -6112,6 +6228,12 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::Node *p_source, bo
 			*r_native_class = native_method->get_instance_class();
 		}
 #endif // DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
+		String message;
+		if (get_native_function_is_deprecated(base_native, function_name, &message)) {
+			parser->push_warning(p_source, GDScriptWarning::DEPRECATED_USAGE, "function", function_name, message);
+		}
+#endif // TOOLS_ENABLED
 		return valid;
 	}
 
@@ -6719,6 +6841,336 @@ Error GDScriptAnalyzer::resolve_dependencies() {
 
 	return parser->errors.is_empty() ? OK : ERR_PARSE_ERROR;
 }
+
+// HACK: Deprecation info is stored in the documentation data, which is only accessible
+// through editor classes. So, to determine whether symbols are deprecated, we have to
+// access those editor classes.
+// Ideally, the GDScript module should be completely independent of the editor, but until
+// documentation management is moved from the editor to the GDScript module (if that ever
+// happens), in order to support deprecation status detection, we have to do this.
+#ifdef TOOLS_ENABLED
+/// @brief Returns info about the deprecation status of the given data type according to
+/// the documentation.
+/// @note This method performs more computation than `GDScriptParser::get_class_is_deprecated()`.
+/// You may want to use that method instead, if you have the class name as a string and know
+/// it will be in the DocTools class list.
+/// @param p_type The data type to check the deprecation status of.
+/// @param r_message If the data type is deprecated, this will be filled with the deprecation
+/// message. It may describe the current preferred alternative to using this data type.
+/// @param r_value_type If the data type is deprecated, this will be filled with the
+/// "kind" of data type being checked, such as "class" or "enum". This allows the warning
+/// message to accurately state the data type kind it is warning about.
+/// @param r_value_name If the data type is deprecated, this will be filled with the
+/// user-readable name of the data type being checked, so that the warning message
+/// can include it in its description.
+/// @return Whether or not the provided data type is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_type_is_deprecated(const GDScriptParser::DataType &p_type, String *r_message, String *r_value_type, String *r_type_name) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+
+	// If DocTools are not available, then we can't get info about deprecation status,
+	// so we will just say nothing is deprecated.
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (r_type_name) {
+		*r_type_name = p_type.native_type;
+	}
+
+	// No builtins are deprecated.
+	if (p_type.kind == GDScriptParser::DataType::Kind::BUILTIN) {
+		return false;
+	}
+
+	// Methods where we consult the class_list have different ways of getting the key.
+	StringName class_name;
+	if (p_type.kind == GDScriptParser::DataType::Kind::NATIVE) {
+		class_name = p_type.native_type;
+	} else if (p_type.kind == GDScriptParser::DataType::Kind::SCRIPT) {
+		class_name = p_type.script_type->get_doc_class_name();
+	}
+
+	if (!class_name.is_empty() && class_list.has(class_name)) {
+		DocData::ClassDoc dd = class_list[class_name];
+
+		if (r_value_type) {
+			*r_value_type = "class";
+		}
+		if (r_message) {
+			*r_message = dd.deprecated_message;
+		}
+
+		return dd.is_deprecated;
+	}
+
+	// For classes, we can get the deprecation data straight from their
+	// linked doc_data.
+	if (p_type.kind == GDScriptParser::DataType::Kind::CLASS) {
+		if (r_value_type) {
+			*r_value_type = "class";
+		}
+		if (r_message) {
+			*r_message = p_type.class_type->doc_data.deprecated_message;
+		}
+
+		if (r_type_name) {
+			if (p_type.class_type && p_type.class_type->identifier) {
+				*r_type_name = p_type.class_type->identifier->name;
+			} else {
+				*r_type_name = "";
+			}
+		}
+		return p_type.class_type->doc_data.is_deprecated;
+	}
+
+	// For enums, we have to do a bit of work to get their data...
+	if (p_type.kind == GDScriptParser::DataType::Kind::ENUM) {
+		if (r_value_type) {
+			*r_value_type = "enum";
+		}
+		StringName enum_type = p_type.enum_type; // Something like MyEnum.
+		GDScriptParser::ClassNode *class_type = p_type.class_type;
+		class_name = "@GlobalScope";
+		if (class_type && class_type->identifier) {
+			class_name = class_type->identifier->name;
+		}
+
+		if (class_list.has(class_name)) {
+			DocData::ClassDoc class_doc = class_list[class_name];
+			if (class_doc.enums.has(enum_type)) {
+				if (r_message) {
+					*r_message = class_doc.enums[enum_type].deprecated_message;
+				}
+				return class_doc.enums[enum_type].is_deprecated;
+			}
+		}
+	}
+
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of the given enum value according to the
+/// documentation.
+/// @note This method is for checking a single value within an enum, not the enum type as a whole.
+/// If you want to check an entire enum's type, use `GDScriptAnalyzer::get_native_enum_is_deprecated()`.
+/// @param p_base_type The base enum type to check the deprecation status of.
+/// @param p_value_name The name of the individual value within the enum type provided by `p_base_type`
+/// to check the deprecation status of.
+/// @param r_message If the enum value is deprecated, this will be filled with the
+/// deprecation message provided in the documentation.
+/// @return Whether or not the provided enum value is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_enum_value_is_deprecated(const GDScriptParser::DataType &p_base_type, const StringName &p_value_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+
+	// If DocTools are not available, then we can't get info about deprecation status,
+	// so we will just say nothing is deprecated.
+	if (!doc_tools) {
+		return false;
+	}
+
+	StringName class_name;
+
+	// TODO: Is this a proper way of detecting it's from a native class?
+	// e.g., "AnimationPlayer.AnimationProcessCallback"
+	// User-defined enums also seem to have a "native_type" so we can't
+	// detect actual native classes solely based on whether or not that
+	// string is defined.
+	if (p_base_type.native_type && !p_base_type.class_type) {
+		class_name = String(p_base_type.native_type).get_slicec('.', 0);
+	}
+
+	else if (p_base_type.class_type && p_base_type.class_type->identifier && p_base_type.class_type->identifier->name) {
+		class_name = p_base_type.class_type->identifier->name;
+		// It's an inner class, so we need to get the outer class's name
+		// as well to construct its full name as found in the doc data.
+		if (p_base_type.class_type->outer != nullptr && p_base_type.class_type->outer->identifier != nullptr) {
+			class_name = String(p_base_type.class_type->outer->identifier->name) + "." + class_name;
+		}
+	}
+
+	if (doc_tools->class_list.has(class_name)) {
+		for (const DocData::ConstantDoc &doc : doc_tools->class_list[class_name].constants) {
+			if (doc.enumeration == p_base_type.enum_type && doc.name == p_value_name) {
+				if (doc.is_deprecated) {
+					if (r_message) {
+						*r_message = doc.deprecated_message;
+					}
+					return true;
+				}
+				break;
+			}
+		}
+	}
+
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of a given native class property according
+/// to the documentation.
+/// @param p_native_class The name of the native class to which the property belongs.
+/// @param p_property_name The name of the property to check the deprecation status of.
+/// @param r_message If the property is deprecated, this will be filled with the deprecation
+/// message provided in the documentation.
+/// @return Whether or not the provided property is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_native_property_is_deprecated(const StringName &p_native_class, const StringName &p_property_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (class_list.has(p_native_class)) {
+		for (const DocData::PropertyDoc &doc : class_list[p_native_class].properties) {
+			if (doc.name == p_property_name) {
+				if (r_message) {
+					*r_message = doc.deprecated_message;
+				}
+				return doc.is_deprecated;
+			}
+		}
+	}
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of a given native function/method according to the
+/// documentation.
+/// @param p_native_class The name of the native class to which the function/method belongs.
+/// @param p_function_name The name of the function/method to check the deprecation status of.
+/// @param r_message If the function/method is deprecated, this will be filled with the deprecation
+/// message provided in the documentation.
+/// @return Whether or not the provided function/method is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_native_function_is_deprecated(const StringName &p_native_class, const StringName &p_function_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (class_list.has(p_native_class)) {
+		for (const DocData::MethodDoc &doc : class_list[p_native_class].methods) {
+			if (doc.name == p_function_name) {
+				if (r_message) {
+					*r_message = doc.deprecated_message;
+				}
+				return doc.is_deprecated;
+			}
+		}
+	}
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of a given native signal according to the
+/// documentation.
+/// @param p_native_class The name of the native class to which the signal belongs.
+/// @param p_signal_name The name of the signal to check the deprecation status of.
+/// @param r_message If the signal is deprecated, this will be filled with the deprecation
+/// message provided in the documentation.
+/// @return Whether or not the provided signal is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_native_signal_is_deprecated(const StringName &p_native_class, const StringName &p_signal_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (class_list.has(p_native_class)) {
+		for (const DocData::MethodDoc &doc : class_list[p_native_class].signals) {
+			if (doc.name == p_signal_name) {
+				if (r_message) {
+					*r_message = doc.deprecated_message;
+				}
+				return doc.is_deprecated;
+			}
+		}
+	}
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of a given native enum according to the
+/// documentation.
+/// @note This method is for checking an entire enum, not a single value within an enum.
+/// If you want to check a single value within an enum, use `GDScriptAnalyzer::get_enum_value_is_deprecated()`.
+/// @param p_native_class The name of the native class to which the enum belongs.
+/// @param p_enum_name The name of the enum to check the deprecation status of.
+/// @param r_message If the enum is deprecated, this will be filled with the deprecation
+/// message provided in the documentation.
+/// @return Whether or not the provided enum is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_native_enum_is_deprecated(const StringName &p_native_class, const StringName &p_enum_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (class_list.has(p_native_class) && class_list[p_native_class].enums.has(p_enum_name)) {
+		DocData::EnumDoc doc = class_list[p_native_class].enums[p_enum_name];
+		if (doc.is_deprecated) {
+			if (r_message) {
+				*r_message = doc.deprecated_message;
+			}
+			return true;
+		}
+	}
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of a given native constant according
+/// to the documentation.
+/// @param p_native_class The name of the native class to which the constant belongs.
+/// @param p_constant_name The name of the constant to check the deprecation status of.
+/// @param r_message If the constant is deprecated, this will be filled with the deprecation
+/// message provided in the documentation.
+/// @return Whether or not the provided constant is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_native_constant_is_deprecated(const StringName &p_native_class, const StringName &p_constant_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (class_list.has(p_native_class)) {
+		for (const DocData::ConstantDoc &doc : class_list[p_native_class].constants) {
+			if (doc.name == p_constant_name) {
+				if (r_message) {
+					*r_message = doc.deprecated_message;
+				}
+				return doc.is_deprecated;
+			}
+		}
+	}
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of a native class according to the
+/// documentation, given its name as a string.
+/// @param p_class_name The name of the native class to check the deprecation status of.
+/// @param r_message If the class is deprecated, this will be filled with the deprecation
+/// method provided in the documentation.
+/// @return Whether or not the provided class is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_class_is_deprecated(const StringName &p_class_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (class_list.has(p_class_name)) {
+		if (r_message) {
+			*r_message = class_list[p_class_name].deprecated_message;
+		}
+		return class_list[p_class_name].is_deprecated;
+	}
+	return false;
+}
+#endif // TOOLS_ENABLED
 
 Error GDScriptAnalyzer::analyze() {
 	parser->errors.clear();

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -46,6 +46,10 @@
 
 #include "modules/gdscript/gdscript_parser.h"
 
+#ifdef TOOLS_ENABLED
+#include "editor/doc/editor_help.h"
+#endif
+
 #if defined(TOOLS_ENABLED) && !defined(DISABLE_DEPRECATED)
 #define SUGGEST_GODOT4_RENAMES
 #include "editor/project_upgrade/renames_map_3_to_4.h"
@@ -2164,6 +2168,13 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 		type = specified_type;
 	}
 
+#ifdef TOOLS_ENABLED
+	String dep_message, dep_value_type, dep_value_name;
+	if (get_type_is_deprecated(type, &dep_message, &dep_value_type, &dep_value_name)) {
+		parser->push_warning(p_assignable, GDScriptWarning::DEPRECATED_USAGE, dep_value_type, dep_value_name, dep_message);
+	}
+#endif // TOOLS_ENABLED
+
 	if (p_assignable->initializer != nullptr) {
 		reduce_expression(p_assignable->initializer);
 
@@ -4111,6 +4122,13 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 	StringName name = p_identifier->name;
 
 	if (base.kind == GDScriptParser::DataType::ENUM) {
+#ifdef TOOLS_ENABLED
+		String message;
+		if (get_enum_value_is_deprecated(base, name, &message)) {
+			String full_value_name = vformat("%s.%s", base.enum_type, name);
+			parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "enum value", full_value_name, message);
+		}
+#endif // TOOLS_ENABLED
 		if (base.is_meta_type) {
 			if (base.enum_values.has(name)) {
 				p_identifier->type_constraint = type_from_metatype(base);
@@ -4256,6 +4274,11 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 					p_identifier->reduced_value = member.constant->initializer->reduced_value;
 					p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CONSTANT;
 					p_identifier->constant_source = member.constant;
+#ifdef TOOLS_ENABLED
+					if (member.constant->doc_data.is_deprecated) {
+						parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "constant", name, member.constant->doc_data.deprecated_message);
+					}
+#endif // TOOLS_ENABLED
 					return;
 				}
 
@@ -4264,6 +4287,11 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 					p_identifier->is_constant = true;
 					p_identifier->reduced_value = member.enum_value.value;
 					p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CONSTANT;
+#ifdef TOOLS_ENABLED
+					if (member.enum_value.doc_data.is_deprecated) {
+						parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "enum value", name, member.enum_value.doc_data.deprecated_message);
+					}
+#endif // TOOLS_ENABLED
 					return;
 				}
 
@@ -4272,6 +4300,11 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 					p_identifier->is_constant = true;
 					p_identifier->reduced_value = member.m_enum->dictionary;
 					p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CONSTANT;
+#ifdef TOOLS_ENABLED
+					if (member.m_enum->doc_data.is_deprecated) {
+						parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "enum", name, member.m_enum->doc_data.deprecated_message);
+					}
+#endif // TOOLS_ENABLED
 					return;
 				}
 
@@ -4281,6 +4314,11 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 						p_identifier->source = member.variable->is_static ? GDScriptParser::IdentifierNode::STATIC_VARIABLE : GDScriptParser::IdentifierNode::MEMBER_VARIABLE;
 						p_identifier->variable_source = member.variable;
 						member.variable->usages += 1;
+#ifdef TOOLS_ENABLED
+						if (member.variable->doc_data.is_deprecated) {
+							parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "property or variable", name, member.variable->doc_data.deprecated_message);
+						}
+#endif // TOOLS_ENABLED
 						return;
 					}
 				} break;
@@ -4291,6 +4329,12 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 						p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_SIGNAL;
 						p_identifier->signal_source = member.signal;
 						member.signal->usages += 1;
+
+#ifdef TOOLS_ENABLED
+						if (member.signal->doc_data.is_deprecated) {
+							parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "signal", name, member.signal->doc_data.deprecated_message);
+						}
+#endif // TOOLS_ENABLED
 						return;
 					}
 				} break;
@@ -4308,6 +4352,11 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 				case GDScriptParser::ClassNode::Member::CLASS: {
 					reduce_identifier_from_base_set_class(p_identifier, member.get_datatype());
 					p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CLASS;
+#ifdef TOOLS_ENABLED
+					if (script_class->get_member(name).m_class->doc_data.is_deprecated) {
+						parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "class", name, script_class->get_member(name).m_class->doc_data.deprecated_message);
+					}
+#endif // TOOLS_ENABLED
 					return;
 				}
 
@@ -4399,6 +4448,12 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 				p_identifier->type_constraint = ptype;
 				p_identifier->source = GDScriptParser::IdentifierNode::INHERITED_VARIABLE;
 			}
+#ifdef TOOLS_ENABLED
+			String message;
+			if (get_native_property_is_deprecated(native, name, &message)) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "property", name, message);
+			}
+#endif // TOOLS_ENABLED
 			return;
 		}
 		if (ClassDB::get_method_info(native, name, &method_info)) {
@@ -4411,11 +4466,23 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 			// Signal is a type too.
 			p_identifier->type_constraint = make_signal_type(method_info);
 			p_identifier->source = GDScriptParser::IdentifierNode::INHERITED_VARIABLE;
+#ifdef TOOLS_ENABLED
+			String message;
+			if (get_native_signal_is_deprecated(native, name, &message)) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "signal", name, message);
+			}
+#endif // TOOLS_ENABLED
 			return;
 		}
 		if (ClassDB::has_enum(native, name)) {
 			p_identifier->type_constraint = make_native_enum_type(name, native);
 			p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CONSTANT;
+#ifdef TOOLS_ENABLED
+			String message;
+			if (get_native_enum_is_deprecated(native, name, &message)) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "enum", name, message);
+			}
+#endif // TOOLS_ENABLED
 			return;
 		}
 		bool valid = false;
@@ -4425,6 +4492,13 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 			p_identifier->is_constant = true;
 			p_identifier->reduced_value = int_constant;
 			p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CONSTANT;
+
+#ifdef TOOLS_ENABLED
+			String message;
+			if (get_native_constant_is_deprecated(native, name, &message)) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "constant", name, message);
+			}
+#endif // TOOLS_ENABLED
 
 			// Check whether this constant, which exists, belongs to an enum
 			StringName enum_name = ClassDB::get_integer_constant_enum(native, name);
@@ -4480,6 +4554,12 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 			// TODO: Constant should have a value on the node itself.
 			p_identifier->reduced_value = p_identifier->constant_source->initializer->reduced_value;
 			found_source = true;
+
+#ifdef TOOLS_ENABLED
+			if (p_identifier->constant_source->doc_data.is_deprecated) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "constant", p_identifier->name, p_identifier->constant_source->doc_data.deprecated_message);
+			}
+#endif
 			break;
 		case GDScriptParser::IdentifierNode::MEMBER_SIGNAL:
 			p_identifier->signal_source->usages++;
@@ -4501,6 +4581,11 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 				parser->push_warning(p_identifier, GDScriptWarning::UNASSIGNED_VARIABLE, p_identifier->name);
 			}
 #endif // DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
+			if (p_identifier->variable_source->doc_data.is_deprecated) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "property or variable", p_identifier->name, p_identifier->variable_source->doc_data.deprecated_message);
+			}
+#endif // TOOLS_ENABLED
 			break;
 		case GDScriptParser::IdentifierNode::LOCAL_ITERATOR:
 			p_identifier->type_constraint = p_identifier->bind_source->type_constraint;
@@ -4621,6 +4706,12 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 	}
 
 	if (class_exists(name)) {
+#ifdef TOOLS_ENABLED
+		String message;
+		if (get_class_is_deprecated(name, &message)) {
+			parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "class", name, message);
+		}
+#endif // TOOLS_ENABLED
 		p_identifier->source = GDScriptParser::IdentifierNode::NATIVE_CLASS;
 		p_identifier->type_constraint = make_native_meta_type(name);
 		return;
@@ -4628,6 +4719,12 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 
 	if (ScriptServer::is_global_class(name)) {
 		p_identifier->type_constraint = make_global_class_meta_type(name, p_identifier);
+#ifdef TOOLS_ENABLED
+		String message;
+		if (get_class_is_deprecated(name, &message)) {
+			parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "class", name, message);
+		}
+#endif // TOOLS_ENABLED
 		return;
 	}
 
@@ -4668,6 +4765,12 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 					}
 				}
 			}
+#ifdef TOOLS_ENABLED
+			String message;
+			if (get_class_is_deprecated(name, &message)) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "class", name, message);
+			}
+#endif // TOOLS_ENABLED
 			result.is_constant = true;
 			p_identifier->type_constraint = result;
 			return;
@@ -4685,6 +4788,13 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 		}
 		p_identifier->is_constant = true;
 		p_identifier->reduced_value = value;
+
+#ifdef TOOLS_ENABLED
+		String message;
+		if (get_native_constant_is_deprecated("@GlobalScope", name, &message)) {
+			parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_USAGE, "constant", name, message);
+		}
+#endif // TOOLS_ENABLED
 		return;
 	}
 
@@ -6049,6 +6159,12 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::Node *p_source, bo
 		r_return_type.is_meta_type = false;
 		r_return_type.is_coroutine = found_function->is_coroutine;
 
+#ifdef TOOLS_ENABLED
+		// For user-defined methods.
+		if (found_function->doc_data.is_deprecated) {
+			parser->push_warning(p_source, GDScriptWarning::DEPRECATED_USAGE, "function", found_function->identifier->name, found_function->doc_data.deprecated_message);
+		}
+#endif // TOOLS_ENABLED
 		return true;
 	}
 
@@ -6093,6 +6209,12 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::Node *p_source, bo
 			*r_native_class = native_method->get_instance_class();
 		}
 #endif // DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
+		String message;
+		if (get_native_function_is_deprecated(base_native, function_name, &message)) {
+			parser->push_warning(p_source, GDScriptWarning::DEPRECATED_USAGE, "function", function_name, message);
+		}
+#endif // TOOLS_ENABLED
 		return valid;
 	}
 
@@ -6700,6 +6822,336 @@ Error GDScriptAnalyzer::resolve_dependencies() {
 
 	return parser->errors.is_empty() ? OK : ERR_PARSE_ERROR;
 }
+
+// HACK: Deprecation info is stored in the documentation data, which is only accessible
+// through editor classes. So, to determine whether symbols are deprecated, we have to
+// access those editor classes.
+// Ideally, the GDScript module should be completely independent of the editor, but until
+// documentation management is moved from the editor to the GDScript module (if that ever
+// happens), in order to support deprecation status detection, we have to do this.
+#ifdef TOOLS_ENABLED
+/// @brief Returns info about the deprecation status of the given data type according to
+/// the documentation.
+/// @note This method performs more computation than `GDScriptParser::get_class_is_deprecated()`.
+/// You may want to use that method instead, if you have the class name as a string and know
+/// it will be in the DocTools class list.
+/// @param p_type The data type to check the deprecation status of.
+/// @param r_message If the data type is deprecated, this will be filled with the deprecation
+/// message. It may describe the current preferred alternative to using this data type.
+/// @param r_value_type If the data type is deprecated, this will be filled with the
+/// "kind" of data type being checked, such as "class" or "enum". This allows the warning
+/// message to accurately state the data type kind it is warning about.
+/// @param r_value_name If the data type is deprecated, this will be filled with the
+/// user-readable name of the data type being checked, so that the warning message
+/// can include it in its description.
+/// @return Whether or not the provided data type is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_type_is_deprecated(const GDScriptParser::DataType &p_type, String *r_message, String *r_value_type, String *r_type_name) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+
+	// If DocTools are not available, then we can't get info about deprecation status,
+	// so we will just say nothing is deprecated.
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (r_type_name) {
+		*r_type_name = p_type.native_type;
+	}
+
+	// No builtins are deprecated.
+	if (p_type.kind == GDScriptParser::DataType::Kind::BUILTIN) {
+		return false;
+	}
+
+	// Methods where we consult the class_list have different ways of getting the key.
+	StringName class_name;
+	if (p_type.kind == GDScriptParser::DataType::Kind::NATIVE) {
+		class_name = p_type.native_type;
+	} else if (p_type.kind == GDScriptParser::DataType::Kind::SCRIPT) {
+		class_name = p_type.script_type->get_doc_class_name();
+	}
+
+	if (!class_name.is_empty() && class_list.has(class_name)) {
+		DocData::ClassDoc dd = class_list[class_name];
+
+		if (r_value_type) {
+			*r_value_type = "class";
+		}
+		if (r_message) {
+			*r_message = dd.deprecated_message;
+		}
+
+		return dd.is_deprecated;
+	}
+
+	// For classes, we can get the deprecation data straight from their
+	// linked doc_data.
+	if (p_type.kind == GDScriptParser::DataType::Kind::CLASS) {
+		if (r_value_type) {
+			*r_value_type = "class";
+		}
+		if (r_message) {
+			*r_message = p_type.class_type->doc_data.deprecated_message;
+		}
+
+		if (r_type_name) {
+			if (p_type.class_type && p_type.class_type->identifier) {
+				*r_type_name = p_type.class_type->identifier->name;
+			} else {
+				*r_type_name = "";
+			}
+		}
+		return p_type.class_type->doc_data.is_deprecated;
+	}
+
+	// For enums, we have to do a bit of work to get their data...
+	if (p_type.kind == GDScriptParser::DataType::Kind::ENUM) {
+		if (r_value_type) {
+			*r_value_type = "enum";
+		}
+		StringName enum_type = p_type.enum_type; // Something like MyEnum.
+		GDScriptParser::ClassNode *class_type = p_type.class_type;
+		class_name = "@GlobalScope";
+		if (class_type && class_type->identifier) {
+			class_name = class_type->identifier->name;
+		}
+
+		if (class_list.has(class_name)) {
+			DocData::ClassDoc class_doc = class_list[class_name];
+			if (class_doc.enums.has(enum_type)) {
+				if (r_message) {
+					*r_message = class_doc.enums[enum_type].deprecated_message;
+				}
+				return class_doc.enums[enum_type].is_deprecated;
+			}
+		}
+	}
+
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of the given enum value according to the
+/// documentation.
+/// @note This method is for checking a single value within an enum, not the enum type as a whole.
+/// If you want to check an entire enum's type, use `GDScriptAnalyzer::get_native_enum_is_deprecated()`.
+/// @param p_base_type The base enum type to check the deprecation status of.
+/// @param p_value_name The name of the individual value within the enum type provided by `p_base_type`
+/// to check the deprecation status of.
+/// @param r_message If the enum value is deprecated, this will be filled with the
+/// deprecation message provided in the documentation.
+/// @return Whether or not the provided enum value is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_enum_value_is_deprecated(const GDScriptParser::DataType &p_base_type, const StringName &p_value_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+
+	// If DocTools are not available, then we can't get info about deprecation status,
+	// so we will just say nothing is deprecated.
+	if (!doc_tools) {
+		return false;
+	}
+
+	StringName class_name;
+
+	// TODO: Is this a proper way of detecting it's from a native class?
+	// e.g., "AnimationPlayer.AnimationProcessCallback"
+	// User-defined enums also seem to have a "native_type" so we can't
+	// detect actual native classes solely based on whether or not that
+	// string is defined.
+	if (p_base_type.native_type && !p_base_type.class_type) {
+		class_name = String(p_base_type.native_type).get_slicec('.', 0);
+	}
+
+	else if (p_base_type.class_type && p_base_type.class_type->identifier && p_base_type.class_type->identifier->name) {
+		class_name = p_base_type.class_type->identifier->name;
+		// It's an inner class, so we need to get the outer class's name
+		// as well to construct its full name as found in the doc data.
+		if (p_base_type.class_type->outer != nullptr && p_base_type.class_type->outer->identifier != nullptr) {
+			class_name = String(p_base_type.class_type->outer->identifier->name) + "." + class_name;
+		}
+	}
+
+	if (doc_tools->class_list.has(class_name)) {
+		for (const DocData::ConstantDoc &doc : doc_tools->class_list[class_name].constants) {
+			if (doc.enumeration == p_base_type.enum_type && doc.name == p_value_name) {
+				if (doc.is_deprecated) {
+					if (r_message) {
+						*r_message = doc.deprecated_message;
+					}
+					return true;
+				}
+				break;
+			}
+		}
+	}
+
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of a given native class property according
+/// to the documentation.
+/// @param p_native_class The name of the native class to which the property belongs.
+/// @param p_property_name The name of the property to check the deprecation status of.
+/// @param r_message If the property is deprecated, this will be filled with the deprecation
+/// message provided in the documentation.
+/// @return Whether or not the provided property is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_native_property_is_deprecated(const StringName &p_native_class, const StringName &p_property_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (class_list.has(p_native_class)) {
+		for (const DocData::PropertyDoc &doc : class_list[p_native_class].properties) {
+			if (doc.name == p_property_name) {
+				if (r_message) {
+					*r_message = doc.deprecated_message;
+				}
+				return doc.is_deprecated;
+			}
+		}
+	}
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of a given native function/method according to the
+/// documentation.
+/// @param p_native_class The name of the native class to which the function/method belongs.
+/// @param p_function_name The name of the function/method to check the deprecation status of.
+/// @param r_message If the function/method is deprecated, this will be filled with the deprecation
+/// message provided in the documentation.
+/// @return Whether or not the provided function/method is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_native_function_is_deprecated(const StringName &p_native_class, const StringName &p_function_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (class_list.has(p_native_class)) {
+		for (const DocData::MethodDoc &doc : class_list[p_native_class].methods) {
+			if (doc.name == p_function_name) {
+				if (r_message) {
+					*r_message = doc.deprecated_message;
+				}
+				return doc.is_deprecated;
+			}
+		}
+	}
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of a given native signal according to the
+/// documentation.
+/// @param p_native_class The name of the native class to which the signal belongs.
+/// @param p_signal_name The name of the signal to check the deprecation status of.
+/// @param r_message If the signal is deprecated, this will be filled with the deprecation
+/// message provided in the documentation.
+/// @return Whether or not the provided signal is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_native_signal_is_deprecated(const StringName &p_native_class, const StringName &p_signal_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (class_list.has(p_native_class)) {
+		for (const DocData::MethodDoc &doc : class_list[p_native_class].signals) {
+			if (doc.name == p_signal_name) {
+				if (r_message) {
+					*r_message = doc.deprecated_message;
+				}
+				return doc.is_deprecated;
+			}
+		}
+	}
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of a given native enum according to the
+/// documentation.
+/// @note This method is for checking an entire enum, not a single value within an enum.
+/// If you want to check a single value within an enum, use `GDScriptAnalyzer::get_enum_value_is_deprecated()`.
+/// @param p_native_class The name of the native class to which the enum belongs.
+/// @param p_enum_name The name of the enum to check the deprecation status of.
+/// @param r_message If the enum is deprecated, this will be filled with the deprecation
+/// message provided in the documentation.
+/// @return Whether or not the provided enum is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_native_enum_is_deprecated(const StringName &p_native_class, const StringName &p_enum_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (class_list.has(p_native_class) && class_list[p_native_class].enums.has(p_enum_name)) {
+		DocData::EnumDoc doc = class_list[p_native_class].enums[p_enum_name];
+		if (doc.is_deprecated) {
+			if (r_message) {
+				*r_message = doc.deprecated_message;
+			}
+			return true;
+		}
+	}
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of a given native constant according
+/// to the documentation.
+/// @param p_native_class The name of the native class to which the constant belongs.
+/// @param p_constant_name The name of the constant to check the deprecation status of.
+/// @param r_message If the constant is deprecated, this will be filled with the deprecation
+/// message provided in the documentation.
+/// @return Whether or not the provided constant is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_native_constant_is_deprecated(const StringName &p_native_class, const StringName &p_constant_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (class_list.has(p_native_class)) {
+		for (const DocData::ConstantDoc &doc : class_list[p_native_class].constants) {
+			if (doc.name == p_constant_name) {
+				if (r_message) {
+					*r_message = doc.deprecated_message;
+				}
+				return doc.is_deprecated;
+			}
+		}
+	}
+	return false;
+}
+
+/// @brief Returns info about the deprecation status of a native class according to the
+/// documentation, given its name as a string.
+/// @param p_class_name The name of the native class to check the deprecation status of.
+/// @param r_message If the class is deprecated, this will be filled with the deprecation
+/// method provided in the documentation.
+/// @return Whether or not the provided class is marked as deprecated in the documentation.
+bool GDScriptAnalyzer::get_class_is_deprecated(const StringName &p_class_name, String *r_message) {
+	DocTools *doc_tools = EditorHelp::get_doc_data();
+	if (!doc_tools) {
+		return false;
+	}
+
+	HashMap<String, DocData::ClassDoc> &class_list = doc_tools->class_list;
+
+	if (class_list.has(p_class_name)) {
+		if (r_message) {
+			*r_message = class_list[p_class_name].deprecated_message;
+		}
+		return class_list[p_class_name].is_deprecated;
+	}
+	return false;
+}
+#endif // TOOLS_ENABLED
 
 Error GDScriptAnalyzer::analyze() {
 	parser->errors.clear();

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -177,5 +177,19 @@ public:
 	static GDScriptParser::DataType type_from_metatype(const GDScriptParser::DataType &p_meta_type);
 	static bool class_exists(const StringName &p_class);
 
+	// Methods for checking deprecation status of various GDScript symbols.
+	// Because deprecation information comes from the documentation, which is
+	// only accessible through editor classes, we have to lock it behind TOOLS_ENABLED.
+#ifdef TOOLS_ENABLED
+	static bool get_type_is_deprecated(const GDScriptParser::DataType &p_type, String *r_message = nullptr, String *r_value_type = nullptr, String *r_value_name = nullptr);
+	static bool get_enum_value_is_deprecated(const GDScriptParser::DataType &p_base_type, const StringName &p_value_name, String *r_message = nullptr);
+	static bool get_native_property_is_deprecated(const StringName &p_native_class, const StringName &p_property_name, String *r_message = nullptr);
+	static bool get_native_function_is_deprecated(const StringName &p_native_class, const StringName &p_function_name, String *r_message = nullptr);
+	static bool get_native_signal_is_deprecated(const StringName &p_native_class, const StringName &p_signal_name, String *r_message = nullptr);
+	static bool get_native_enum_is_deprecated(const StringName &p_native_class, const StringName &p_enum_name, String *r_message = nullptr);
+	static bool get_native_constant_is_deprecated(const StringName &p_native_class, const StringName &p_constant_name, String *r_message = nullptr);
+	static bool get_class_is_deprecated(const StringName &p_class_name, String *r_message = nullptr);
+#endif // TOOLS_ENABLED
+
 	GDScriptAnalyzer(GDScriptParser *p_parser);
 };

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -175,5 +175,19 @@ public:
 	static GDScriptParser::DataType type_from_metatype(const GDScriptParser::DataType &p_meta_type);
 	static bool class_exists(const StringName &p_class);
 
+	// Methods for checking deprecation status of various GDScript symbols.
+	// Because deprecation information comes from the documentation, which is
+	// only accessible through editor classes, we have to lock it behind TOOLS_ENABLED.
+#ifdef TOOLS_ENABLED
+	static bool get_type_is_deprecated(const GDScriptParser::DataType &p_type, String *r_message = nullptr, String *r_value_type = nullptr, String *r_value_name = nullptr);
+	static bool get_enum_value_is_deprecated(const GDScriptParser::DataType &p_base_type, const StringName &p_value_name, String *r_message = nullptr);
+	static bool get_native_property_is_deprecated(const StringName &p_native_class, const StringName &p_property_name, String *r_message = nullptr);
+	static bool get_native_function_is_deprecated(const StringName &p_native_class, const StringName &p_function_name, String *r_message = nullptr);
+	static bool get_native_signal_is_deprecated(const StringName &p_native_class, const StringName &p_signal_name, String *r_message = nullptr);
+	static bool get_native_enum_is_deprecated(const StringName &p_native_class, const StringName &p_enum_name, String *r_message = nullptr);
+	static bool get_native_constant_is_deprecated(const StringName &p_native_class, const StringName &p_constant_name, String *r_message = nullptr);
+	static bool get_class_is_deprecated(const StringName &p_class_name, String *r_message = nullptr);
+#endif // TOOLS_ENABLED
+
 	GDScriptAnalyzer(GDScriptParser *p_parser);
 };

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -33,6 +33,8 @@
 #include "core/object/property_info.h"
 #include "core/variant/variant.h"
 
+#include "modules/regex/regex.h"
+
 #ifdef DEBUG_ENABLED
 
 String GDScriptWarning::get_message() const {
@@ -171,6 +173,72 @@ String GDScriptWarning::get_message() const {
 			return vformat(R"*(The default value uses "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
 		case ONREADY_WITH_EXPORT:
 			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
+		case DEPRECATED_USAGE: {
+			CHECK_SYMBOLS(3);
+			String symbol_type = symbols[0];
+			String name;
+			if (symbols[1].length() > 0) {
+				name = vformat(R"( "%s")", symbols[1]);
+			}
+
+			String deprecated_message = symbols[2];
+			if (deprecated_message.length() > 0) {
+				// These documentation tags contain information inside, which needs to be preserved
+				// when we strip the BBCode.
+				RegEx special_tag_re(R"(\[(?:annotation|constant|enum|member|method|constructor|operator|signal|theme_item|param) (.*?)\])");
+				TypedArray<RegExMatch> matches = special_tag_re.search_all(deprecated_message);
+				for (int i = matches.size() - 1; i >= 0; i--) {
+					RegExMatch *m = Object::cast_to<RegExMatch>(matches[i]);
+					if (!m) {
+						continue;
+					}
+					PackedStringArray strings = m->get_strings();
+					if (strings.size() < 2) {
+						continue;
+					}
+					String bbcode_ver = strings[0];
+					String stripped_ver = strings[1];
+					deprecated_message = deprecated_message.replace(bbcode_ver, stripped_ver);
+				}
+
+				// Completely remove other tags (except for class ones - for those
+				// we want to keep the inner content but remove the brackets).
+				RegEx other_tag_re(R"(\[(.*?)\])");
+				matches = other_tag_re.search_all(deprecated_message);
+				for (int i = matches.size() - 1; i >= 0; i--) {
+					RegExMatch *m = Object::cast_to<RegExMatch>(matches[i]);
+					if (!m) {
+						continue;
+					}
+					PackedStringArray strings = m->get_strings();
+					if (strings.size() < 1) {
+						continue;
+					}
+					String bbcode_ver = strings[0];
+					String tag_body = strings[1];
+
+					// All closing tags can be removed.
+					// Additionally, known BBCode opening tags can be removed.
+					if (tag_body.begins_with("/") || tag_body == "br" || tag_body == "lb" || tag_body == "rb" || tag_body == "b" ||
+							tag_body == "i" || tag_body == "u" || tag_body == "s" || tag_body.begins_with("color=") ||
+							tag_body.begins_with("font=") || tag_body == "img" || tag_body.begins_with("img ") ||
+							tag_body == "url" || tag_body.begins_with("url=") || tag_body == "center" ||
+							tag_body == "kbd" || tag_body == "code" || tag_body.begins_with("code ") || tag_body == "codeblock") {
+						deprecated_message = deprecated_message.replace(bbcode_ver, "");
+					} else {
+						// The tag isn't a known BBCode tag, so it must be a class?
+						// While we could check against EditorHelp::get_doc_data()
+						// to verify this, that would mean bringing in EditorHelp
+						// as a dependency and wrapping things in TOOLS_ENABLED checks.
+						deprecated_message = deprecated_message.replace(bbcode_ver, tag_body);
+					}
+				}
+
+				return vformat(R"(The %s%s is deprecated: "%s")", symbol_type, name, deprecated_message);
+			} else {
+				return vformat(R"(The %s%s is deprecated. See its documentation for more information and alternatives.)", symbol_type, name);
+			}
+		}
 #ifndef DISABLE_DEPRECATED
 		// Never produced. These warnings migrated from 3.x by mistake.
 		case PROPERTY_USED_AS_FUNCTION: // There is already an error.
@@ -249,6 +317,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		PNAME("NATIVE_METHOD_OVERRIDE"),
 		PNAME("GET_NODE_DEFAULT_WITHOUT_ONREADY"),
 		PNAME("ONREADY_WITH_EXPORT"),
+		PNAME("DEPRECATED_USAGE"),
 #ifndef DISABLE_DEPRECATED
 		"PROPERTY_USED_AS_FUNCTION",
 		"CONSTANT_USED_AS_FUNCTION",

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -31,6 +31,7 @@
 #include "gdscript_warning.h"
 
 #include "core/object/property_info.h"
+#include "core/string/regex.h"
 #include "core/variant/variant.h"
 
 #ifdef DEBUG_ENABLED
@@ -173,6 +174,72 @@ String GDScriptWarning::get_message() const {
 			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
 		case ONREADY_WITH_CAST:
 			return vformat(R"("as" will silently return "null" if the type of "%s" is wrong. Prefer assigning the node directly to an explicitly typed variable to get an error in such cases.)", symbols[0]);
+		case DEPRECATED_USAGE: {
+			CHECK_SYMBOLS(3);
+			String symbol_type = symbols[0];
+			String name;
+			if (symbols[1].length() > 0) {
+				name = vformat(R"( "%s")", symbols[1]);
+			}
+
+			String deprecated_message = symbols[2];
+			if (deprecated_message.length() > 0) {
+				// These documentation tags contain information inside, which needs to be preserved
+				// when we strip the BBCode.
+				RegEx special_tag_re(R"(\[(?:annotation|constant|enum|member|method|constructor|operator|signal|theme_item|param) (.*?)\])");
+				TypedArray<RegExMatch> matches = special_tag_re.search_all(deprecated_message);
+				for (int i = matches.size() - 1; i >= 0; i--) {
+					RegExMatch *m = Object::cast_to<RegExMatch>(matches[i]);
+					if (!m) {
+						continue;
+					}
+					PackedStringArray strings = m->get_strings();
+					if (strings.size() < 2) {
+						continue;
+					}
+					String bbcode_ver = strings[0];
+					String stripped_ver = strings[1];
+					deprecated_message = deprecated_message.replace(bbcode_ver, stripped_ver);
+				}
+
+				// Completely remove other tags (except for class ones - for those
+				// we want to keep the inner content but remove the brackets).
+				RegEx other_tag_re(R"(\[(.*?)\])");
+				matches = other_tag_re.search_all(deprecated_message);
+				for (int i = matches.size() - 1; i >= 0; i--) {
+					RegExMatch *m = Object::cast_to<RegExMatch>(matches[i]);
+					if (!m) {
+						continue;
+					}
+					PackedStringArray strings = m->get_strings();
+					if (strings.size() < 1) {
+						continue;
+					}
+					String bbcode_ver = strings[0];
+					String tag_body = strings[1];
+
+					// All closing tags can be removed.
+					// Additionally, known BBCode opening tags can be removed.
+					if (tag_body.begins_with("/") || tag_body == "br" || tag_body == "lb" || tag_body == "rb" || tag_body == "b" ||
+							tag_body == "i" || tag_body == "u" || tag_body == "s" || tag_body.begins_with("color=") ||
+							tag_body.begins_with("font=") || tag_body == "img" || tag_body.begins_with("img ") ||
+							tag_body == "url" || tag_body.begins_with("url=") || tag_body == "center" ||
+							tag_body == "kbd" || tag_body == "code" || tag_body.begins_with("code ") || tag_body == "codeblock") {
+						deprecated_message = deprecated_message.replace(bbcode_ver, "");
+					} else {
+						// The tag isn't a known BBCode tag, so it must be a class?
+						// While we could check against EditorHelp::get_doc_data()
+						// to verify this, that would mean bringing in EditorHelp
+						// as a dependency and wrapping things in TOOLS_ENABLED checks.
+						deprecated_message = deprecated_message.replace(bbcode_ver, tag_body);
+					}
+				}
+
+				return vformat(R"(The %s%s is deprecated: "%s")", symbol_type, name, deprecated_message);
+			} else {
+				return vformat(R"(The %s%s is deprecated. See its documentation for more information and alternatives.)", symbol_type, name);
+			}
+		}
 #ifndef DISABLE_DEPRECATED
 		// Never produced. These warnings migrated from 3.x by mistake.
 		case PROPERTY_USED_AS_FUNCTION: // There is already an error.
@@ -252,6 +319,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		PNAME("GET_NODE_DEFAULT_WITHOUT_ONREADY"),
 		PNAME("ONREADY_WITH_EXPORT"),
 		PNAME("ONREADY_WITH_CAST"),
+		PNAME("DEPRECATED_USAGE"),
 #ifndef DISABLE_DEPRECATED
 		"PROPERTY_USED_AS_FUNCTION",
 		"CONSTANT_USED_AS_FUNCTION",

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -92,6 +92,7 @@ public:
 		NATIVE_METHOD_OVERRIDE, // The script method overrides a native one, this may not work as intended.
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
 		ONREADY_WITH_EXPORT, // The `@onready` annotation will set the value after `@export` which is likely not intended.
+		DEPRECATED_USAGE, // A symbol being used is marked as deprecated in the documentation.
 #ifndef DISABLE_DEPRECATED
 		PROPERTY_USED_AS_FUNCTION, // Function not found, but there's a property with the same name.
 		CONSTANT_USED_AS_FUNCTION, // Function not found, but there's a constant with the same name.
@@ -151,6 +152,7 @@ public:
 		ERROR, // NATIVE_METHOD_OVERRIDE // May not work as expected.
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.
 		ERROR, // ONREADY_WITH_EXPORT // May not work as expected.
+		WARN, // DEPRECATED_USAGE
 #ifndef DISABLE_DEPRECATED
 		WARN, // PROPERTY_USED_AS_FUNCTION
 		WARN, // CONSTANT_USED_AS_FUNCTION

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -93,6 +93,7 @@ public:
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
 		ONREADY_WITH_EXPORT, // The `@onready` annotation will set the value after `@export` which is likely not intended.
 		ONREADY_WITH_CAST, // The cast will silently assign `null` if the node has a wrong type. This is likely not intended.
+		DEPRECATED_USAGE, // A symbol being used is marked as deprecated in the documentation.
 #ifndef DISABLE_DEPRECATED
 		PROPERTY_USED_AS_FUNCTION, // Function not found, but there's a property with the same name.
 		CONSTANT_USED_AS_FUNCTION, // Function not found, but there's a constant with the same name.
@@ -153,6 +154,7 @@ public:
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.
 		ERROR, // ONREADY_WITH_EXPORT // May not work as expected.
 		WARN, // ONREADY_WITH_CAST
+		WARN, // DEPRECATED_USAGE
 #ifndef DISABLE_DEPRECATED
 		WARN, // PROPERTY_USED_AS_FUNCTION
 		WARN, // CONSTANT_USED_AS_FUNCTION

--- a/modules/gdscript/tests/scripts/analyzer/warnings/deprecated_usage.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/deprecated_usage.gd
@@ -1,0 +1,169 @@
+@warning_ignore_start("standalone_expression")
+@warning_ignore_start("unused_signal")
+@warning_ignore_start("unused_variable")
+@warning_ignore_start("unused_local_constant")
+
+## This is a deprecated property.
+## @deprecated
+var deprecated_property: float = 1.0
+
+## This is a non-deprecated property.
+var normal_property: int = 3
+
+## This is a deprecated property with a getter and setter.
+## @deprecated
+var deprecated_property_2: float = 2.0:
+    get:
+        return sqrt(5)
+    set(value):
+        deprecated_property_2 = value
+
+## This is a deprecated enum.
+## @deprecated
+enum DeprecatedEnum { ONE, TWO, THREE }
+
+## This is a deprecated constant.
+## @deprecated
+const DEPRECATED_CONST = "hello"
+
+const TWO = 9
+
+# NOT WORKING
+enum NamedEnum {
+    ONE,
+    ## This is a deprecated constant in an enum.
+    ## @deprecated
+    TWO
+}
+
+enum {
+    ANONYMOUS_ONE,
+    ## This one is deprecated
+    ## @deprecated
+    ANONYMOUS_TWO
+}
+
+## This is an inner deprecated class.
+## @deprecated
+class InnerDeprecatedClass:
+    ## @deprecated
+    enum InnerDeprecatedEnum { ONE, TWO }
+
+class InnerClass:
+    enum  {
+        ## @deprecated
+        ONE,
+        TWO
+    }
+
+    ## @deprecated
+    const INNER_DEPRECATED_CONST = 3
+
+    ## @deprecated
+    enum InnerDeprecatedEnum { ONE, TWO }
+
+    enum InnerDeprecatedEnum2 {
+        ## @deprecated
+        DEPRECATED_ONE,
+        NON_DEPRECATED_ONE
+    }
+
+    ## @deprecated
+    var inner_deprecated_property = 3
+
+    ## @deprecated
+    signal inner_deprecated_signal
+
+    ## @deprecated
+    func inner_dep_function():
+        pass
+
+## This is a deprecated signal.
+## @deprecated
+signal deprecated_signal
+
+func test():
+    # User-defined method marked as deprecated
+    deprecated_function()
+    InnerClass.new().inner_dep_function()
+
+    # Native method marked as deprecated
+    # NOTE: This causes issues with the test runner, so it will be commented
+    # out for now.
+    # AnimationPlayer.new().get_method_call_mode()
+
+    # Inner class of a file marked as deprecated
+    var i3: InnerDeprecatedClass
+    var i4 = InnerDeprecatedClass.new()
+
+    # Native class
+    var native_class: VisualShaderNodeComment
+    var native_class_2 = VisualShaderNodeComment.new()
+
+    # User-defined constant marked as deprecated
+    print(DEPRECATED_CONST)
+    print(InnerClass.INNER_DEPRECATED_CONST)
+
+    # User-defined local constant marked as deprecated
+    ## @deprecated
+    const DEPRECATED_LOCAL_CONST = 3
+    print(DEPRECATED_LOCAL_CONST)
+
+    # User-defined named enum marked as deprecated
+    var dep_enum: DeprecatedEnum
+    var dep_enum_2 = DeprecatedEnum.ONE
+    var inner_dep_enum: InnerClass.InnerDeprecatedEnum
+    var inner_dep_enum_2 = InnerClass.InnerDeprecatedEnum.ONE
+
+    # Individual value in a user-defined anonymous enum marked as deprecated
+    var dep_enum_value_anon = ANONYMOUS_TWO
+    var dep_enum_value_anon_2 = InnerClass.ONE
+
+    # Individual value in a user-defined named enum marked as deprecated
+    var dep_enum_value_named = NamedEnum.TWO
+    var dep_enum_value_named_2 = InnerClass.InnerDeprecatedEnum2.DEPRECATED_ONE
+
+    # Individual value in an enum from a native class marked as deprecated
+    var dep_native_enum_value = AnimationPlayer.ANIMATION_PROCESS_PHYSICS
+    var dep_native_enum_value_2 = AnimationPlayer.AnimationProcessCallback.ANIMATION_PROCESS_PHYSICS
+
+    # Constant in GlobalScope
+    var global_const = PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE
+
+    # Local variable marked as deprecated
+    ## @deprecated
+    var dep_local = 3
+    print(dep_local)
+
+    # User-defined property marked as deprecated
+    print(deprecated_property)
+    print(deprecated_property_2)
+    print(InnerClass.new().inner_deprecated_property)
+
+    # Native property marked as deprecated
+    print(AStarGrid2D.new().size)
+
+    # User-defined signal marked as deprecated
+    deprecated_signal.connect(hello)
+    InnerClass.new().inner_deprecated_signal.connect(hello)
+
+    # Native signal marked as deprecated
+    Resource.new().setup_local_to_scene_requested.connect(hello)
+
+
+## This is a deprecated function.
+## @deprecated
+func deprecated_function():
+    print("I'm deprecated")
+
+
+## This is a non-deprecated function.
+func non_deprecated_function():
+    print("I'm not deprecated")
+
+## @deprecated
+func example():
+    pass
+
+func hello():
+    pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/deprecated_usage.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/deprecated_usage.out
@@ -1,0 +1,31 @@
+GDTEST_OK
+~~ WARNING at line 19: (DEPRECATED_USAGE) The property or variable "deprecated_property_2" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 87: (DEPRECATED_USAGE) The function "deprecated_function" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 88: (DEPRECATED_USAGE) The function "inner_dep_function" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 97: (DEPRECATED_USAGE) The class "InnerDeprecatedClass" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 104: (DEPRECATED_USAGE) The constant "DEPRECATED_CONST" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 105: (DEPRECATED_USAGE) The constant "INNER_DEPRECATED_CONST" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 110: (DEPRECATED_USAGE) The constant "DEPRECATED_LOCAL_CONST" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 114: (DEPRECATED_USAGE) The enum "DeprecatedEnum" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 115: (DEPRECATED_USAGE) The enum "InnerDeprecatedEnum" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 116: (DEPRECATED_USAGE) The enum "InnerDeprecatedEnum" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 119: (DEPRECATED_USAGE) The enum value "ANONYMOUS_TWO" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 120: (DEPRECATED_USAGE) The enum value "ONE" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 136: (DEPRECATED_USAGE) The property or variable "dep_local" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 139: (DEPRECATED_USAGE) The property or variable "deprecated_property" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 140: (DEPRECATED_USAGE) The property or variable "deprecated_property_2" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 141: (DEPRECATED_USAGE) The property or variable "inner_deprecated_property" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 147: (DEPRECATED_USAGE) The signal "deprecated_signal" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 147: (RETURN_VALUE_DISCARDED) The function "connect()" returns a value that will be discarded if not used.
+~~ WARNING at line 148: (DEPRECATED_USAGE) The signal "inner_deprecated_signal" is deprecated. See its documentation for more information and alternatives.
+~~ WARNING at line 148: (RETURN_VALUE_DISCARDED) The function "connect()" returns a value that will be discarded if not used.
+~~ WARNING at line 151: (RETURN_VALUE_DISCARDED) The function "connect()" returns a value that will be discarded if not used.
+I'm deprecated
+hello
+3
+3
+3
+1.0
+2.23606797749979
+3
+(0, 0)


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12105 .

This PR adds a new warning, `DEPRECATED_IDENTIFIER`, to GDScript. As the name suggests, it activates when a line contains an identifier that has been marked as deprecated in the documentation.

![CleanShot 2025-04-02 at 21 55 01@2x](https://github.com/user-attachments/assets/de4aa390-98c5-493d-b23a-1e262e0ee0ca)

## Tested cases
- [x] User-defined method call
- [x] User-defined method call in inner class
- [x] Native method call
- [x] Main class of file as type annotation
- [x] Main class of file for constructors, static methods, etc
- [x] Inner class as type annotation
- [x] Inner class for constructors, static methods, etc
- [x] Native class as type annotation
- [x] Native class for constructors, static methods, etc
- [x] Autoload with global name as type annotation
- [x] Autoload with global name for constructors, methods, etc
- [x] User-defined class constant
- [x] User-defined class constant in inner class
- [x] User-defined local constant
- [x] User-defined named enum
- [x] User-defined named enum in inner class
- [x] Individual value in user-defined anonymous enum
- [x] Individual value in user-defined anonymous enum in inner class
- [x] Individual value in user-defined named enum
- [x] Individual value in user-defined named enum in inner class
- [x] Individual value in native enum
- [x] Constant in global scope
- [x] Local variable
- [x] User-defined property
- [x] User-defined property in inner class
- [x] Native property
- [x] User-defined signal
- [x] User-defined signal in inner class
- [x] Native signal

## To Do
- [x] Get all the cases working!
- [x] Make the message more professional
- [x] Add context to the message (for example, instead of "identifier" say "variable", "method", etc)
- [x] Clean up some code that goes against Godot's code style (I think I used an `auto` or two)
- [x] Re-run tests to generate new warning output
  - [x] Add tests to detect use of deprecated identifiers?