### PR TITLE
Display PortableCompressedTexture's format in inspector preview

### DIFF
--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -124,6 +124,11 @@ static Image::Format get_texture_2d_format(const Ref<Texture2D> &p_texture) {
 		return compressed_texture->get_format();
 	}
 
+	const Ref<PortableCompressedTexture2D> portable_compressed_texture = p_texture;
+	if (portable_compressed_texture.is_valid()) {
+		return portable_compressed_texture->get_format();
+	}
+
 	// AtlasTexture?
 
 	// Unknown


### PR DESCRIPTION
Before:
![屏幕截图_20250403_183324](https://github.com/user-attachments/assets/8ad45649-a230-48d1-bc62-fadd63572d67)
After:
![屏幕截图_20250403_184054](https://github.com/user-attachments/assets/1ecdc136-7941-4278-8b96-a8efa19f002c)