### PR TITLE
Android Editor: Auto create `nomedia` file to hide project files in media apps

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1068,6 +1068,19 @@ void EditorFileSystem::scan() {
 	// to be loaded to continue the scan and reimportations.
 	if (first_scan) {
 		_first_scan_filesystem();
+#ifdef ANDROID_ENABLED
+		const String nomedia_file_path = ProjectSettings::get_singleton()->get_resource_path().path_join(".nomedia");
+		if (!FileAccess::exists(nomedia_file_path)) {
+			// Create a .nomedia file to hide assets from media apps on Android.
+			Ref<FileAccess> f = FileAccess::open(nomedia_file_path, FileAccess::WRITE);
+			if (f.is_null()) {
+				// .nomedia isn't so critical.
+				ERR_PRINT("Couldn't create .nomedia in project path.");
+			} else {
+				f->close();
+			}
+		}
+#endif
 	}
 
 	_update_extensions();

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -725,6 +725,17 @@ void ProjectDialog::ok_pressed() {
 
 	hide();
 	if (mode == MODE_NEW || mode == MODE_IMPORT || mode == MODE_INSTALL) {
+#ifdef ANDROID_ENABLED
+		// Create a .nomedia file to hide assets from media apps on Android.
+		const String nomedia_file_path = path.path_join(".nomedia");
+		Ref<FileAccess> f2 = FileAccess::open(nomedia_file_path, FileAccess::WRITE);
+		if (f2.is_null()) {
+			// .nomedia isn't so critical.
+			ERR_PRINT("Couldn't create .nomedia in project path.");
+		} else {
+			f2->close();
+		}
+#endif
 		emit_signal(SNAME("project_created"), path, edit_check_box->is_pressed());
 	} else if (mode == MODE_RENAME) {
 		emit_signal(SNAME("projects_updated"));


### PR DESCRIPTION
This PR makes sure project media files don’t show up in Android’s gallery/media apps by automatically handling `nomedia` files:
- Creates a `nomedia` file when a project is created, imported, or installed.
- Checks for `nomedia` file during the first filesystem scan and creates one if missing.

Closes https://github.com/godotengine/godot-proposals/issues/10364