### PR TITLE
Automatically activate camera monitoring when using `CameraTexture`

### DIFF
--- a/scene/resources/camera_texture.cpp
+++ b/scene/resources/camera_texture.cpp
@@ -142,7 +142,12 @@ bool CameraTexture::get_camera_active() const {
 	}
 }
 
-CameraTexture::CameraTexture() {}
+CameraTexture::CameraTexture() {
+	// Note: When any CameraTexture is created, we need to automatically activate monitoring
+	//       of camera feeds. This may incur a small lag spike, so it may be preferable to
+	//       enable it manually before creating the camera texture.
+	CameraServer::get_singleton()->set_monitoring_feeds(true);
+}
 
 CameraTexture::~CameraTexture() {
 	if (_texture.is_valid()) {

--- a/servers/camera_server.cpp
+++ b/servers/camera_server.cpp
@@ -42,6 +42,7 @@ void CameraServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_monitoring_feeds", "is_monitoring_feeds"), &CameraServer::set_monitoring_feeds);
 	ClassDB::bind_method(D_METHOD("is_monitoring_feeds"), &CameraServer::is_monitoring_feeds);
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "monitoring_feeds"), "set_monitoring_feeds", "is_monitoring_feeds");
+	ADD_PROPERTY_DEFAULT("monitoring_feeds", false);
 
 	ClassDB::bind_method(D_METHOD("get_feed", "index"), &CameraServer::get_feed);
 	ClassDB::bind_method(D_METHOD("get_feed_count"), &CameraServer::get_feed_count);


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/104232
Fixes https://github.com/godotengine/godot/pull/104232#issuecomment-2768484533

My recent PR https://github.com/godotengine/godot/pull/104232 deactivated the `CameraServer` by default, to speed up editor launch times, since most projects do not need to monitor the cameras.

Unfortunately, since the editor itself needs to monitor cameras when using `CameraTexture`, `CameraTexture` has been broken since then.
We expect of applications to start monitoring the camera consciously, so no resources are wasted. But I'm not sure if there is any boilerplate in place in Godot to make this easy for things like `CameraTexture`, which is used in a completely modular way, and may silently be created through serialization, GUI and from code.

So for the editor, I'm proposing to start `CameraServer` monitoring automatically when using the first `CameraTexture`. This will incur a small hiccup, although it's not super noticeable.
The hack is employed only in editor builds, so the need to run `CameraServer.get_singleton().is_monitoring = true` will be inconsistent between editor and release binaries of games. This is not great, but I cannot think of a better alternative to fix the problem at the moment.