### PR TITLE
Change "GDExtension example in C++" links to accommodate the new docs file structure.

### DIFF
--- a/doc/classes/GDExtension.xml
+++ b/doc/classes/GDExtension.xml
@@ -9,7 +9,7 @@
 	</description>
 	<tutorials>
 		<link title="GDExtension overview">$DOCS_URL/tutorials/scripting/gdextension/what_is_gdextension.html</link>
-		<link title="GDExtension example in C++">$DOCS_URL/tutorials/scripting/gdextension/gdextension_cpp_example.html</link>
+		<link title="GDExtension example in C++">$DOCS_URL/tutorials/scripting/cpp/gdextension_cpp_example.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_minimum_library_initialization_level" qualifiers="const">

--- a/doc/classes/GDExtensionManager.xml
+++ b/doc/classes/GDExtensionManager.xml
@@ -9,7 +9,7 @@
 	</description>
 	<tutorials>
 		<link title="GDExtension overview">$DOCS_URL/tutorials/scripting/gdextension/what_is_gdextension.html</link>
-		<link title="GDExtension example in C++">$DOCS_URL/tutorials/scripting/gdextension/gdextension_cpp_example.html</link>
+		<link title="GDExtension example in C++">$DOCS_URL/tutorials/scripting/cpp/gdextension_cpp_example.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_extension">


### PR DESCRIPTION
Depends on https://github.com/godotengine/godot-docs/pull/10631/.
Staying as draft until then.

The C++ documentation is moving around a bit, to detangle it from general GDExtension info. There are two hard links referring to the old file structure; as soon as the above PR is merged, the main repo should follow along.