### PR TITLE
Remove unused `get_inheritance_list_static` from `GDCLASS`.

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -432,10 +432,6 @@ public:                                                                         
 	static _FORCE_INLINE_ String get_parent_class_static() {                                                                                \
 		return m_inherits::get_class_static();                                                                                              \
 	}                                                                                                                                       \
-	static void get_inheritance_list_static(List<String> *p_inheritance_list) {                                                             \
-		m_inherits::get_inheritance_list_static(p_inheritance_list);                                                                        \
-		p_inheritance_list->push_back(String(#m_class));                                                                                    \
-	}                                                                                                                                       \
 	virtual bool is_class(const String &p_class) const override {                                                                           \
 		if (_get_extension() && _get_extension()->is_class(p_class)) {                                                                      \
 			return true;                                                                                                                    \
@@ -817,8 +813,6 @@ public:
 	};
 
 	/* TYPE API */
-	static void get_inheritance_list_static(List<String> *p_inheritance_list) { p_inheritance_list->push_back("Object"); }
-
 	static String get_class_static() { return "Object"; }
 	static String get_parent_class_static() { return String(); }
 

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -143,15 +143,6 @@ TEST_CASE("[Object] Core getters") {
 	CHECK_MESSAGE(
 			object.get_save_class() == "Object",
 			"The returned save class should match the expected value.");
-
-	List<String> inheritance_list;
-	object.get_inheritance_list_static(&inheritance_list);
-	CHECK_MESSAGE(
-			inheritance_list.size() == 1,
-			"The inheritance list should consist of Object only");
-	CHECK_MESSAGE(
-			inheritance_list.front()->get() == "Object",
-			"The inheritance list should consist of Object only");
 }
 
 TEST_CASE("[Object] Metadata") {


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/104921

I missed this in my first go over the macro.
This function is also unused, besides a unit test for it.

Calling it would work, but the current recommended way to do it right now is through the `ClassDB` API (`get_inheritance_chain_nocheck`).
I may challenge this in the future, but for now it's better to have one standard than to have one and a half.