### PR TITLE
Fix compiling with `disable_xr=yes` when 3d enabled

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -184,9 +184,9 @@ static PhysicsServer2D *physics_server_2d = nullptr;
 static PhysicsServer3DManager *physics_server_3d_manager = nullptr;
 static PhysicsServer3D *physics_server_3d = nullptr;
 #endif // PHYSICS_3D_DISABLED
-#ifndef _3D_DISABLED
+#ifndef XR_DISABLED
 static XRServer *xr_server = nullptr;
-#endif // _3D_DISABLED
+#endif // XR_DISABLED
 // We error out if setup2() doesn't turn this true
 static bool _start_success = false;
 
@@ -4919,11 +4919,11 @@ void Main::cleanup(bool p_force) {
 
 	EngineDebugger::deinitialize();
 
-#ifndef _3D_DISABLED
+#ifndef XR_DISABLED
 	if (xr_server) {
 		memdelete(xr_server);
 	}
-#endif // _3D_DISABLED
+#endif // XR_DISABLED
 
 	if (audio_server) {
 		audio_server->finish();


### PR DESCRIPTION
Replace the legacy `_3D_DISABLED` with `XR_DISABLED` in `main.cpp`.