### PR TITLE
Add desktop notifications for MacOS

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -628,6 +628,17 @@ String OS::get_unique_id() const {
 	return ::OS::get_singleton()->get_unique_id();
 }
 
+Error OS::send_notification(const String &p_title, const String &p_message, const Callable &p_callback, const Variant &p_icon, int p_duration, const Dictionary &p_datetime_to_send) {
+	Ref<Image> icon;
+	if (p_icon.get_type() == Variant::OBJECT) {
+		Object *obj = p_icon.get_validated_object();
+		if (obj) {
+			icon = Ref(cast_to<Image>(obj));
+		}
+	}
+	return ::OS::get_singleton()->send_notification(p_title, p_message, p_callback, icon, p_duration, p_datetime_to_send);
+}
+
 OS *OS::singleton = nullptr;
 
 void OS::_bind_methods() {
@@ -733,6 +744,8 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("request_permissions"), &OS::request_permissions);
 	ClassDB::bind_method(D_METHOD("get_granted_permissions"), &OS::get_granted_permissions);
 	ClassDB::bind_method(D_METHOD("revoke_granted_permissions"), &OS::revoke_granted_permissions);
+
+	ClassDB::bind_method(D_METHOD("send_notification", "title", "message", "callback", "icon", "duration", "datetime_to_send"), &OS::send_notification, DEFVAL(Callable()), DEFVAL(Variant()), DEFVAL(-1), DEFVAL(Dictionary()));
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "low_processor_usage_mode"), "set_low_processor_usage_mode", "is_in_low_processor_usage_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "low_processor_usage_mode_sleep_usec"), "set_low_processor_usage_mode_sleep_usec", "get_low_processor_usage_mode_sleep_usec");

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -158,6 +158,8 @@ public:
 	virtual void open_midi_inputs();
 	virtual void close_midi_inputs();
 
+	Error send_notification(const String &p_title, const String &p_message, const Callable &p_callback = Callable(), const Variant &p_icon = Variant(), int p_duration = -1, const Dictionary &p_datetime_to_send = Dictionary());
+
 	void set_low_processor_usage_mode(bool p_enabled);
 	bool is_in_low_processor_usage_mode() const;
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/config/engine.h"
+#include "core/io/image.h"
 #include "core/io/logger.h"
 #include "core/io/remote_filesystem_client.h"
 #include "core/os/time_enums.h"
@@ -311,6 +312,8 @@ public:
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const;
 
 	virtual Error move_to_trash(const String &p_path) { return FAILED; }
+
+	virtual Error send_notification(const String &p_title, const String &p_message, const Callable &p_callback = Callable(), const Ref<Image> &p_icon = Ref<Image>(), int p_duration = -1, const Dictionary &p_datetime_to_send = Dictionary()) { return FAILED; }
 
 	void create_lock_file();
 	void remove_lock_file();

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -773,6 +773,65 @@
 				On macOS (sandboxed applications only), this function clears list of user selected folders accessible to the application.
 			</description>
 		</method>
+		<method name="send_notification">
+			<return type="int" enum="Error" />
+			<param index="0" name="title" type="String" />
+			<param index="1" name="message" type="String" />
+			<param index="2" name="callback" type="Callable" default="Callable()" />
+			<param index="3" name="icon" type="Variant" default="null" />
+			<param index="4" name="duration" type="int" default="-1" />
+			<param index="5" name="datetime_to_send" type="Dictionary" default="{}" />
+			<description>
+				Sends a desktop notification to the user with the given title and message.
+
+				The notification behavior and appearance varies depending on the platform, with some platforms potentially ignoring certain parameters:
+				- [param title]: The title of the notification.
+				- [param message]: The main body text of the notification.
+				- [param callback]: Callable to be called when the user interacts with the notification (e.g., clicks on it). Note that not all platforms support this feature.
+				- [param icon]: A custom icon to display with the notification. Pass an Image object or null to use the default application icon.
+				- [param duration]: How long the notification should remain visible in seconds. If set to -1 (default), the system default duration will be used. If set to 0, the notification will remain until manually dismissed (not supported on all platforms).
+				- [param datetime_to_send]: A Dictionary that specifies when to schedule the notification. If empty (default), the notification is sent immediately. The Dictionary can be in one of these formats:
+				  - Full datetime: Must include keys "year", "month", "day", "hour", "minute", and "second".
+				  - Unix timestamp: A single key "unix_time" with a Unix timestamp value.
+				  - Relative time: A single key "relative_seconds" specifying seconds from now when the notification should be sent.
+
+				[b]Note:[/b] This method is currently only implemented on macOS.
+
+				[b]Note:[/b] On macOS, this implementation uses the UserNotifications framework (UNUserNotificationCenter) on macOS 10.14+ and falls back to NSUserNotification on older versions. On macOS 10.14+, notifications are automatically grouped together when multiple notifications are sent. When running in headless mode or with --script, the notification will be printed to the console instead.
+
+				[b]Note:[/b] The [param duration] parameter is not supported on macOS, the notification duration is controlled by the system's accessibility settings.
+
+				[b]Example:[/b] Sending an immediate notification:
+				[codeblocks]
+				[gdscript]
+				func _on_operation_completed() -&gt; void:
+				    OS.send_notification("Operation Completed", "Your task has finished processing.")
+				[/gdscript]
+				[csharp]
+				private void OnOperationCompleted()
+				{
+				    OS.SendNotification("Operation Completed", "Your task has finished processing.");
+				}
+				[/csharp]
+				[/codeblocks]
+
+				[b]Example:[/b] Scheduling a notification for 10 minutes from now:
+				[codeblocks]
+				[gdscript]
+				func schedule_reminder() -&gt; void:
+				    var datetime = {"relative_seconds": 600}  # 10 minutes
+				    OS.send_notification("Reminder", "Your potion is ready!", Callable(), null, -1, datetime)
+				[/gdscript]
+				[csharp]
+				private void ScheduleReminder()
+				{
+				    var datetime = new Godot.Collections.Dictionary { {"relative_seconds", 600} };  // 10 minutes
+				    OS.SendNotification("Reminder", "Your potion is ready!", new Callable(), null, -1, datetime);
+				}
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="set_environment" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="variable" type="String" />

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -231,6 +231,8 @@ def configure(env: "SConsEnvironment"):
             "Security",
             "-framework",
             "UniformTypeIdentifiers",
+            "-framework",
+            "UserNotifications",
         ]
     )
     env.Append(LIBS=["pthread", "z"])

--- a/platform/macos/godot_application_delegate.h
+++ b/platform/macos/godot_application_delegate.h
@@ -34,8 +34,9 @@
 
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
 
-@interface GodotApplicationDelegate : NSObject <NSUserInterfaceItemSearching, NSApplicationDelegate> {
+@interface GodotApplicationDelegate : NSObject <NSUserInterfaceItemSearching, NSApplicationDelegate, UNUserNotificationCenterDelegate> {
 	bool high_contrast;
 	bool reduce_motion;
 	bool reduce_transparency;
@@ -51,4 +52,7 @@
 - (bool)getReduceMotion;
 - (bool)getReduceTransparency;
 - (bool)getVoiceOver;
+
+// For notification callbacks
+@property(nonatomic, strong) NSMutableDictionary *notificationCallbacks;
 @end

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -33,11 +33,17 @@
 #include "crash_handler_macos.h"
 
 #include "core/input/input.h"
+#include "core/io/image.h"
 #import "drivers/apple/joypad_apple.h"
 #import "drivers/coreaudio/audio_driver_coreaudio.h"
 #import "drivers/coremidi/midi_driver_coremidi.h"
 #include "drivers/unix/os_unix.h"
 #include "servers/audio_server.h"
+#import <UserNotifications/UserNotifications.h>
+
+@interface GodotNotificationDelegate : NSObject <UNUserNotificationCenterDelegate>
+@property(nonatomic, strong) NSMutableDictionary *callbacks;
+@end
 
 class OS_MacOS : public OS_Unix {
 	const char *execpath = nullptr;
@@ -68,6 +74,7 @@ class OS_MacOS : public OS_Unix {
 	CGFloat _weight_to_ct(int p_weight) const;
 	CGFloat _stretch_to_ct(int p_stretch) const;
 	String _get_default_fontname(const String &p_font_name) const;
+	double _calculate_notification_delay(const Dictionary &p_datetime_dict);
 
 	static _FORCE_INLINE_ String get_framework_executable(const String &p_path);
 	static void pre_wait_observer_cb(CFRunLoopObserverRef p_observer, CFRunLoopActivity p_activiy, void *p_context);
@@ -140,6 +147,8 @@ public:
 
 	virtual String get_system_ca_certificates() override;
 	virtual OS::PreferredTextureFormat get_preferred_texture_format() const override;
+
+	virtual Error send_notification(const String &p_title, const String &p_message, const Callable &p_callback = Callable(), const Ref<Image> &p_icon = Ref<Image>(), int p_duration = -1, const Dictionary &p_datetime_to_send = Dictionary()) override;
 
 	void run(); // Runs macOS native event loop.
 	void start_main(); // Initializes and runs Godot main loop.


### PR DESCRIPTION
# Desktop Notifications for macOS

## Summary
Partial implementation for https://github.com/godotengine/godot-proposals/issues/1338. Adds support for desktop notifications on macOS, allowing games and applications to send native system notifications even when the application is not in focus. Also supports scheduling them for future delivery.

## Changes
- Added `OS::send_notification()` method, that can be implemented in any system, with the following signature:
  ```gdscript
  Error send_notification(String title, String message, Callable callback = Callable(), Variant icon = null, int duration = -1, Dictionary datetime_to_send = {})
  ```
- Include MacOS implementation, which includes the following functionalities:
    - Custom Icons
    - Callbacks
    - Scheduling notifications
- Uses `UNUserNotificationCenter` on macOS 10.14+ and falls back to `NSUserNotification` on older versions
- Supports scheduling notifications for future delivery using the following datetime formats:
  - Full datetime: Dictionary with keys "year", "month", "day", "hour", "minute", "second"
  - Unix timestamp: Dictionary with key "unix_time"
  - Relative time: Dictionary with key "relative_seconds"
- Defensively handles edge cases like script mode, headless mode, and invalid app contexts
- Added documentation with examples
- Notifications work for Headless mode, but not for script mode (in which case, notification will be logged, and a warning will be shown).

## Current Limitations
- Notifications will only work when the application is properly exported/bundled (this is a macOS system limitation).
  - If the app is not bundled, notification will at least be logged along with a warning.
- Notifications will only show if application is out of focus.
- The duration parameter is not supported on macOS, as notification duration is controlled by the system's accessibility settings.

## Testing
1. Compile with `scons dev_build=yes generate_bundle=yes`. It will need to be bundled for notifications to work.
2. Download [these scripts](https://gist.github.com/Dowsley/ce2df692c1aa0f6a4a671f49c721bcf0)
3. Run one of the test scripts from the project: `./bin/godot_macos_editor_dev.app/Contents/MacOS/Godot --path /PATH/TO/PROJECT -s test_basic_notification.gd`
    - Each of the 4 scripts is made to test a specific functionality.
    - When you run the script, it will open a window. Since notifications only appear when app is out of focus, they have 2-3 seconds timers for you to click out of the new window to make it lose focus. Otherwise no notification will be shown.
5. If notification does not work even after following steps correctly, you need to go to System Settings > Notifications > GodotTest (or whatever the name of your bundle) > Enable Notifications

### Evidence/Live testing:
#### 1. Basic Notification
https://github.com/user-attachments/assets/74ff7d81-cb6e-4e27-8014-147ff79f7a6b

#### 2. Icons
https://github.com/user-attachments/assets/21fadcf1-344d-400e-9daf-528c7b086ea5

#### 3. Callbacks
https://github.com/user-attachments/assets/e2564bea-193a-433f-8194-4c8c2390508b

#### 4. Scheduling (minor correction: it was 10 seconds from the time it was sent, not 15)
https://github.com/user-attachments/assets/94176e20-9358-4b81-812e-a2748197c04e

#### 5. Any of the tests above, but executed in an unbundled project
![image](https://github.com/user-attachments/assets/33d5f0f5-76f9-4347-b94b-6e593744e270)

Also, while you're recording, notifications wont show in MacOS by default. Make sure to change this setting when recording to show me any possible bug.

## What can improve right now
- Did not have an opportunity to test feature on older MacOS versions. Would love some help.

## Future Work
- Investigate a possible implementation for duration.
- Implementation for other platforms, of course.
