### PR TITLE
SCons: Integrate `WARNLEVEL` & `OPTIMIZELEVEL`

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -108,31 +108,19 @@ def redirect_emitter(target, source, env):
 def disable_warnings(self):
     # 'self' is the environment
     if self.msvc and not using_clang(self):
-        # We have to remove existing warning level defines before appending /w,
-        # otherwise we get: "warning D9025 : overriding '/W3' with '/w'"
-        WARN_FLAGS = ["/Wall", "/W4", "/W3", "/W2", "/W1", "/W0"]
-        self["CCFLAGS"] = [x for x in self["CCFLAGS"] if x not in WARN_FLAGS]
-        self["CFLAGS"] = [x for x in self["CFLAGS"] if x not in WARN_FLAGS]
-        self["CXXFLAGS"] = [x for x in self["CXXFLAGS"] if x not in WARN_FLAGS]
-        self.AppendUnique(CCFLAGS=["/w"])
+        self["WARNLEVEL"] = "/w"
     else:
-        self.AppendUnique(CCFLAGS=["-w"])
+        self["WARNLEVEL"] = "-w"
 
 
 def force_optimization_on_debug(self):
     # 'self' is the environment
     if self["target"] == "template_release":
         return
-
-    if self.msvc:
-        # We have to remove existing optimization level defines before appending /O2,
-        # otherwise we get: "warning D9025 : overriding '/0d' with '/02'"
-        self["CCFLAGS"] = [x for x in self["CCFLAGS"] if not x.startswith("/O")]
-        self["CFLAGS"] = [x for x in self["CFLAGS"] if not x.startswith("/O")]
-        self["CXXFLAGS"] = [x for x in self["CXXFLAGS"] if not x.startswith("/O")]
-        self.AppendUnique(CCFLAGS=["/O2"])
+    elif self.msvc:
+        self["OPTIMIZELEVEL"] = "/O2"
     else:
-        self.AppendUnique(CCFLAGS=["-O3"])
+        self["OPTIMIZELEVEL"] = "-O3"
 
 
 def add_module_version_string(self, s):


### PR DESCRIPTION
This might not be the most interesting/exciting PR in isolation, as it's more me delving into the potential benefits of more native SCons functionality. Specifically: the ability to pass a variable handle instead of the variable itself, meaning it can be changed after the fact without having to search-and-replace anything. This drastically simplifies the logic in calls to `disable_warnings` and `force_optimization_on_debug`, on top of ensuring that the flags variables will remain as `CLVar` on msvc. This also cleans up the setup process for warnings & optimization flags, with additional measures to make added flags use `AppendUnique` to further safeguard against redundancies.

The only other changes are minor tweaks to the changes from #104893, as I realized `CLVar` isn't necessary in this context & msvc cl should be passed `/external:anglebrackets`.