### PR TITLE
Fix wrong translation method in FileDialog

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1778,7 +1778,7 @@ FileDialog::FileDialog() {
 	show_filename_filter_button->set_theme_type_variation(SceneStringName(FlatButton));
 	show_filename_filter_button->set_toggle_mode(true);
 	show_filename_filter_button->set_pressed(false);
-	show_filename_filter_button->set_tooltip_text(RTR("Toggle the visibility of the filter for file names."));
+	show_filename_filter_button->set_tooltip_text(ETR("Toggle the visibility of the filter for file names."));
 	show_filename_filter_button->connect(SceneStringName(toggled), callable_mp(this, &FileDialog::set_show_filename_filter));
 	hbc->add_child(show_filename_filter_button);
 
@@ -1805,7 +1805,7 @@ FileDialog::FileDialog() {
 	tree->add_child(message);
 
 	filename_filter_box = memnew(HBoxContainer);
-	filename_filter_box->add_child(memnew(Label(RTR("Filter:"))));
+	filename_filter_box->add_child(memnew(Label(ETR("Filter:"))));
 	filename_filter = memnew(LineEdit);
 	filename_filter->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_FILE);
 	filename_filter->set_stretch_ratio(4);


### PR DESCRIPTION
Controls nodes should use ETR to mark strings as extractable.