### PR TITLE
Always use `String` as `StringName` backing internally.

### DIFF
--- a/core/core_string_names.h
+++ b/core/core_string_names.h
@@ -44,45 +44,45 @@ public:
 
 	_FORCE_INLINE_ static CoreStringNames *get_singleton() { return singleton; }
 
-	const StringName free_ = StaticCString::create("free"); // free would conflict with C++ keyword.
-	const StringName changed = StaticCString::create("changed");
-	const StringName script = StaticCString::create("script");
-	const StringName script_changed = StaticCString::create("script_changed");
-	const StringName _iter_init = StaticCString::create("_iter_init");
-	const StringName _iter_next = StaticCString::create("_iter_next");
-	const StringName _iter_get = StaticCString::create("_iter_get");
-	const StringName get_rid = StaticCString::create("get_rid");
-	const StringName _to_string = StaticCString::create("_to_string");
-	const StringName _custom_features = StaticCString::create("_custom_features");
+	const StringName free_ = "free"; // free would conflict with C++ keyword.
+	const StringName changed = "changed";
+	const StringName script = "script";
+	const StringName script_changed = "script_changed";
+	const StringName _iter_init = "_iter_init";
+	const StringName _iter_next = "_iter_next";
+	const StringName _iter_get = "_iter_get";
+	const StringName get_rid = "get_rid";
+	const StringName _to_string = "_to_string";
+	const StringName _custom_features = "_custom_features";
 
-	const StringName x = StaticCString::create("x");
-	const StringName y = StaticCString::create("y");
-	const StringName z = StaticCString::create("z");
-	const StringName w = StaticCString::create("w");
-	const StringName r = StaticCString::create("r");
-	const StringName g = StaticCString::create("g");
-	const StringName b = StaticCString::create("b");
-	const StringName a = StaticCString::create("a");
-	const StringName position = StaticCString::create("position");
-	const StringName size = StaticCString::create("size");
-	const StringName end = StaticCString::create("end");
-	const StringName basis = StaticCString::create("basis");
-	const StringName origin = StaticCString::create("origin");
-	const StringName normal = StaticCString::create("normal");
-	const StringName d = StaticCString::create("d");
-	const StringName h = StaticCString::create("h");
-	const StringName s = StaticCString::create("s");
-	const StringName v = StaticCString::create("v");
-	const StringName r8 = StaticCString::create("r8");
-	const StringName g8 = StaticCString::create("g8");
-	const StringName b8 = StaticCString::create("b8");
-	const StringName a8 = StaticCString::create("a8");
+	const StringName x = "x";
+	const StringName y = "y";
+	const StringName z = "z";
+	const StringName w = "w";
+	const StringName r = "r";
+	const StringName g = "g";
+	const StringName b = "b";
+	const StringName a = "a";
+	const StringName position = "position";
+	const StringName size = "size";
+	const StringName end = "end";
+	const StringName basis = "basis";
+	const StringName origin = "origin";
+	const StringName normal = "normal";
+	const StringName d = "d";
+	const StringName h = "h";
+	const StringName s = "s";
+	const StringName v = "v";
+	const StringName r8 = "r8";
+	const StringName g8 = "g8";
+	const StringName b8 = "b8";
+	const StringName a8 = "a8";
 
-	const StringName call = StaticCString::create("call");
-	const StringName call_deferred = StaticCString::create("call_deferred");
-	const StringName bind = StaticCString::create("bind");
-	const StringName notification = StaticCString::create("notification");
-	const StringName property_list_changed = StaticCString::create("property_list_changed");
+	const StringName call = "call";
+	const StringName call_deferred = "call_deferred";
+	const StringName bind = "bind";
+	const StringName notification = "notification";
+	const StringName property_list_changed = "property_list_changed";
 };
 
 #define CoreStringName(m_name) CoreStringNames::get_singleton()->m_name

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -39,10 +39,10 @@
 
 MethodDefinition D_METHODP(const char *p_name, const char *const **p_args, uint32_t p_argcount) {
 	MethodDefinition md;
-	md.name = StaticCString::create(p_name);
+	md.name = StringName(p_name);
 	md.args.resize(p_argcount);
 	for (uint32_t i = 0; i < p_argcount; i++) {
-		md.args.write[i] = StaticCString::create(*p_args[i]);
+		md.args.write[i] = StringName(*p_args[i]);
 	}
 	return md;
 }
@@ -1932,7 +1932,7 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, bool p_
 	StringName mdname = method_name.name;
 #else
 MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, bool p_compatibility, const char *method_name, const Variant **p_defs, int p_defcount) {
-	StringName mdname = StaticCString::create(method_name);
+	StringName mdname = StringName(method_name);
 #endif
 
 	Locker::Lock lock(Locker::STATE_WRITE);

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -17,7 +17,7 @@ script_has_method = """ScriptInstance *_script_instance = ((Object *)(this))->ge
 proto = """#define GDVIRTUAL$VER($ALIAS $RET m_name $ARG)\\
 	mutable void *_gdvirtual_##$VARNAME = nullptr;\\
 	_FORCE_INLINE_ bool _gdvirtual_##$VARNAME##_call($CALLARGS) $CONST {\\
-		static const StringName _gdvirtual_##$VARNAME##_sn = _scs_create(#m_name, true);\\
+		static const StringName _gdvirtual_##$VARNAME##_sn = StringName(#m_name, true);\\
 		$SCRIPTCALL\\
 		if (_get_extension()) {\\
 			if (unlikely(!_gdvirtual_##$VARNAME)) {\\
@@ -53,7 +53,7 @@ proto = """#define GDVIRTUAL$VER($ALIAS $RET m_name $ARG)\\
 		return false;\\
 	}\\
 	_FORCE_INLINE_ bool _gdvirtual_##$VARNAME##_overridden() const {\\
-		static const StringName _gdvirtual_##$VARNAME##_sn = _scs_create(#m_name, true);\\
+		static const StringName _gdvirtual_##$VARNAME##_sn = StringName(#m_name, true);\\
 		$SCRIPTHASMETHOD\\
 		if (_get_extension()) {\\
 			if (unlikely(!_gdvirtual_##$VARNAME)) {\\

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -137,8 +137,8 @@ enum PropertyUsageFlags {
 #define GD_IS_CLASS_ENABLED(m_class) m_class::_class_is_enabled
 
 #define ADD_SIGNAL(m_signal) ::ClassDB::add_signal(get_class_static(), m_signal)
-#define ADD_PROPERTY(m_property, m_setter, m_getter) ::ClassDB::add_property(get_class_static(), m_property, _scs_create(m_setter), _scs_create(m_getter))
-#define ADD_PROPERTYI(m_property, m_setter, m_getter, m_index) ::ClassDB::add_property(get_class_static(), m_property, _scs_create(m_setter), _scs_create(m_getter), m_index)
+#define ADD_PROPERTY(m_property, m_setter, m_getter) ::ClassDB::add_property(get_class_static(), m_property, StringName(m_setter), StringName(m_getter))
+#define ADD_PROPERTYI(m_property, m_setter, m_getter, m_index) ::ClassDB::add_property(get_class_static(), m_property, StringName(m_setter), StringName(m_getter), m_index)
 #define ADD_PROPERTY_DEFAULT(m_property, m_default) ::ClassDB::set_property_default_value(get_class_static(), m_property, m_default)
 #define ADD_GROUP(m_name, m_prefix) ::ClassDB::add_property_group(get_class_static(), m_name, m_prefix)
 #define ADD_GROUP_INDENT(m_name, m_prefix, m_depth) ::ClassDB::add_property_group(get_class_static(), m_name, m_prefix, m_depth)
@@ -146,8 +146,8 @@ enum PropertyUsageFlags {
 #define ADD_SUBGROUP_INDENT(m_name, m_prefix, m_depth) ::ClassDB::add_property_subgroup(get_class_static(), m_name, m_prefix, m_depth)
 #define ADD_LINKED_PROPERTY(m_property, m_linked_property) ::ClassDB::add_linked_property(get_class_static(), m_property, m_linked_property)
 
-#define ADD_ARRAY_COUNT(m_label, m_count_property, m_count_property_setter, m_count_property_getter, m_prefix) ClassDB::add_property_array_count(get_class_static(), m_label, m_count_property, _scs_create(m_count_property_setter), _scs_create(m_count_property_getter), m_prefix)
-#define ADD_ARRAY_COUNT_WITH_USAGE_FLAGS(m_label, m_count_property, m_count_property_setter, m_count_property_getter, m_prefix, m_property_usage_flags) ClassDB::add_property_array_count(get_class_static(), m_label, m_count_property, _scs_create(m_count_property_setter), _scs_create(m_count_property_getter), m_prefix, m_property_usage_flags)
+#define ADD_ARRAY_COUNT(m_label, m_count_property, m_count_property_setter, m_count_property_getter, m_prefix) ClassDB::add_property_array_count(get_class_static(), m_label, m_count_property, StringName(m_count_property_setter), StringName(m_count_property_getter), m_prefix)
+#define ADD_ARRAY_COUNT_WITH_USAGE_FLAGS(m_label, m_count_property, m_count_property_setter, m_count_property_getter, m_prefix, m_property_usage_flags) ClassDB::add_property_array_count(get_class_static(), m_label, m_count_property, StringName(m_count_property_setter), StringName(m_count_property_getter), m_prefix, m_property_usage_flags)
 #define ADD_ARRAY(m_array_path, m_prefix) ClassDB::add_property_array(get_class_static(), m_array_path, m_prefix)
 
 // Helper macro to use with PROPERTY_HINT_ARRAY_TYPE for arrays of specific resources:

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -33,18 +33,8 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 
-StaticCString StaticCString::create(const char *p_ptr) {
-	StaticCString scs;
-	scs.ptr = p_ptr;
-	return scs;
-}
-
 bool StringName::_Data::operator==(const String &p_name) const {
-	if (cname) {
-		return p_name == cname;
-	} else {
-		return name == p_name;
-	}
+	return name == p_name;
 }
 
 bool StringName::_Data::operator!=(const String &p_name) const {
@@ -52,19 +42,11 @@ bool StringName::_Data::operator!=(const String &p_name) const {
 }
 
 bool StringName::_Data::operator==(const char *p_name) const {
-	if (cname) {
-		return strcmp(cname, p_name) == 0;
-	} else {
-		return name == p_name;
-	}
+	return name == p_name;
 }
 
 bool StringName::_Data::operator!=(const char *p_name) const {
 	return !operator==(p_name);
-}
-
-StringName _scs_create(const char *p_chr, bool p_static) {
-	return (p_chr[0] ? StringName(StaticCString::create(p_chr), p_static) : StringName());
 }
 
 void StringName::setup() {
@@ -115,9 +97,7 @@ void StringName::cleanup() {
 				lost_strings++;
 
 				if (OS::get_singleton()->is_stdout_verbose()) {
-					String dname = String(d->cname ? d->cname : d->name);
-
-					print_line(vformat("Orphan StringName: %s (static: %d, total: %d)", dname, d->static_count.get(), d->refcount.get()));
+					print_line(vformat("Orphan StringName: %s (static: %d, total: %d)", d->name, d->static_count.get(), d->refcount.get()));
 				}
 			}
 
@@ -138,11 +118,7 @@ void StringName::unref() {
 		MutexLock lock(mutex);
 
 		if (CoreGlobals::leak_reporting_enabled && _data->static_count.get() > 0) {
-			if (_data->cname) {
-				ERR_PRINT("BUG: Unreferenced static string to 0: " + String(_data->cname));
-			} else {
-				ERR_PRINT("BUG: Unreferenced static string to 0: " + String(_data->name));
-			}
+			ERR_PRINT("BUG: Unreferenced static string to 0: " + _data->name);
 		}
 		if (_data->prev) {
 			_data->prev->next = _data->next;
@@ -193,12 +169,7 @@ bool StringName::operator!=(const char *p_name) const {
 
 char32_t StringName::operator[](int p_index) const {
 	if (_data) {
-		if (_data->cname) {
-			CRASH_BAD_INDEX(p_index, static_cast<long>(strlen(_data->cname)));
-			return _data->cname[p_index];
-		} else {
-			return _data->name[p_index];
-		}
+		return _data->name[p_index];
 	}
 
 	CRASH_BAD_INDEX(p_index, 0);
@@ -207,11 +178,7 @@ char32_t StringName::operator[](int p_index) const {
 
 int StringName::length() const {
 	if (_data) {
-		if (_data->cname) {
-			return strlen(_data->cname);
-		} else {
-			return _data->name.length();
-		}
+		return _data->name.length();
 	}
 
 	return 0;
@@ -219,11 +186,7 @@ int StringName::length() const {
 
 bool StringName::is_empty() const {
 	if (_data) {
-		if (_data->cname) {
-			return _data->cname[0] == 0;
-		} else {
-			return _data->name.is_empty();
-		}
+		return _data->name.is_empty();
 	}
 
 	return true;
@@ -302,66 +265,9 @@ StringName::StringName(const char *p_name, bool p_static) {
 	_data->static_count.set(p_static ? 1 : 0);
 	_data->hash = hash;
 	_data->idx = idx;
-	_data->cname = nullptr;
 	_data->next = _table[idx];
 	_data->prev = nullptr;
 
-#ifdef DEBUG_ENABLED
-	if (unlikely(debug_stringname)) {
-		// Keep in memory, force static.
-		_data->refcount.ref();
-		_data->static_count.increment();
-	}
-#endif
-	if (_table[idx]) {
-		_table[idx]->prev = _data;
-	}
-	_table[idx] = _data;
-}
-
-StringName::StringName(const StaticCString &p_static_string, bool p_static) {
-	_data = nullptr;
-
-	ERR_FAIL_COND(!configured);
-
-	ERR_FAIL_COND(!p_static_string.ptr || !p_static_string.ptr[0]);
-
-	const uint32_t hash = String::hash(p_static_string.ptr);
-	const uint32_t idx = hash & STRING_TABLE_MASK;
-
-	MutexLock lock(mutex);
-	_data = _table[idx];
-
-	while (_data) {
-		// compare hash first
-		if (_data->hash == hash && _data->operator==(p_static_string.ptr)) {
-			break;
-		}
-		_data = _data->next;
-	}
-
-	if (_data && _data->refcount.ref()) {
-		// exists
-		if (p_static) {
-			_data->static_count.increment();
-		}
-#ifdef DEBUG_ENABLED
-		if (unlikely(debug_stringname)) {
-			_data->debug_references++;
-		}
-#endif
-		return;
-	}
-
-	_data = memnew(_Data);
-
-	_data->refcount.init();
-	_data->static_count.set(p_static ? 1 : 0);
-	_data->hash = hash;
-	_data->idx = idx;
-	_data->cname = p_static_string.ptr;
-	_data->next = _table[idx];
-	_data->prev = nullptr;
 #ifdef DEBUG_ENABLED
 	if (unlikely(debug_stringname)) {
 		// Keep in memory, force static.
@@ -416,7 +322,6 @@ StringName::StringName(const String &p_name, bool p_static) {
 	_data->static_count.set(p_static ? 1 : 0);
 	_data->hash = hash;
 	_data->idx = idx;
-	_data->cname = nullptr;
 	_data->next = _table[idx];
 	_data->prev = nullptr;
 #ifdef DEBUG_ENABLED

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -38,11 +38,6 @@
 
 class Main;
 
-struct StaticCString {
-	const char *ptr;
-	static StaticCString create(const char *p_ptr);
-};
-
 class StringName {
 	enum {
 		STRING_TABLE_BITS = 16,
@@ -53,12 +48,11 @@ class StringName {
 	struct _Data {
 		SafeRefCount refcount;
 		SafeNumeric<uint32_t> static_count;
-		const char *cname = nullptr;
 		String name;
 #ifdef DEBUG_ENABLED
 		uint32_t debug_references = 0;
 #endif
-		String get_name() const { return cname ? String(cname) : name; }
+		const String &get_name() const { return name; }
 		bool operator==(const String &p_name) const;
 		bool operator!=(const String &p_name) const;
 		bool operator==(const char *p_name) const;
@@ -97,13 +91,14 @@ class StringName {
 	StringName(_Data *p_data) { _data = p_data; }
 
 public:
-	explicit operator bool() const { return _data && (_data->cname || !_data->name.is_empty()); }
+	explicit operator bool() const { return _data && !_data->name.is_empty(); }
 
 	bool operator==(const String &p_name) const;
 	bool operator==(const char *p_name) const;
 	bool operator!=(const String &p_name) const;
 	bool operator!=(const char *p_name) const;
 
+	const char32_t *get_data() const { return _data ? _data->name.ptr() : U""; }
 	char32_t operator[](int p_index) const;
 	int length() const;
 	bool is_empty() const;
@@ -112,11 +107,7 @@ public:
 		if (!_data) {
 			return false;
 		}
-		if (_data->cname != nullptr) {
-			return (char32_t)_data->cname[0] == (char32_t)UNIQUE_NODE_PREFIX[0];
-		} else {
-			return (char32_t)_data->name[0] == (char32_t)UNIQUE_NODE_PREFIX[0];
-		}
+		return (char32_t)_data->name[0] == (char32_t)UNIQUE_NODE_PREFIX[0];
 	}
 	_FORCE_INLINE_ bool operator<(const StringName &p_name) const {
 		return _data < p_name._data;
@@ -151,11 +142,7 @@ public:
 
 	_FORCE_INLINE_ operator String() const {
 		if (_data) {
-			if (_data->cname) {
-				return String(_data->cname);
-			} else {
-				return _data->name;
-			}
+			return _data->name;
 		}
 
 		return String();
@@ -171,40 +158,13 @@ public:
 			return compare(l, r);
 		}
 		_FORCE_INLINE_ static bool compare(const StringName &l, const StringName &r) {
-			const char *l_cname = l._data ? l._data->cname : "";
-			const char *r_cname = r._data ? r._data->cname : "";
-
-			if (l_cname) {
-				if (r_cname) {
-					return str_compare(l_cname, r_cname) < 0;
-				} else {
-					return str_compare(l_cname, r._data->name.ptr()) < 0;
-				}
-			} else {
-				if (r_cname) {
-					return str_compare(l._data->name.ptr(), r_cname) < 0;
-				} else {
-					return str_compare(l._data->name.ptr(), r._data->name.ptr()) < 0;
-				}
-			}
+			return str_compare(l.get_data(), r.get_data()) < 0;
 		}
 		_FORCE_INLINE_ static bool compare(const String &l, const StringName &r) {
-			const char *r_cname = r._data ? r._data->cname : "";
-
-			if (r_cname) {
-				return str_compare(l.get_data(), r_cname) < 0;
-			} else {
-				return str_compare(l.get_data(), r._data->name.ptr()) < 0;
-			}
+			return str_compare(l.get_data(), r.get_data()) < 0;
 		}
 		_FORCE_INLINE_ static bool compare(const StringName &l, const String &r) {
-			const char *l_cname = l._data ? l._data->cname : "";
-
-			if (l_cname) {
-				return str_compare(l_cname, r.get_data()) < 0;
-			} else {
-				return str_compare(l._data->name.ptr(), r.get_data()) < 0;
-			}
+			return str_compare(l.get_data(), r.get_data()) < 0;
 		}
 		_FORCE_INLINE_ static bool compare(const String &l, const String &r) {
 			return str_compare(l.get_data(), r.get_data()) < 0;
@@ -229,7 +189,6 @@ public:
 		p_name._data = nullptr;
 	}
 	StringName(const String &p_name, bool p_static = false);
-	StringName(const StaticCString &p_static_string, bool p_static = false);
 	StringName() {}
 
 	static void assign_static_unique_class_name(StringName *ptr, const char *p_name);
@@ -259,8 +218,6 @@ bool operator!=(const String &p_name, const StringName &p_string_name);
 bool operator==(const char *p_name, const StringName &p_string_name);
 bool operator!=(const char *p_name, const StringName &p_string_name);
 
-StringName _scs_create(const char *p_chr, bool p_static = false);
-
 /*
  * The SNAME macro is used to speed up StringName creation, as it allows caching it after the first usage in a very efficient way.
  * It should NOT be used everywhere, but instead in places where high performance is required and the creation of a StringName
@@ -273,4 +230,4 @@ StringName _scs_create(const char *p_chr, bool p_static = false);
  * Use in places that can be called hundreds of times per frame (or more) is recommended, but this situation is very rare. If in doubt, do not use.
  */
 
-#define SNAME(m_arg) ([]() -> const StringName & { static StringName sname = _scs_create(m_arg, true); return sname; })()
+#define SNAME(m_arg) ([]() -> const StringName & { static StringName sname = StringName(m_arg, true); return sname; })()

--- a/editor/editor_string_names.h
+++ b/editor/editor_string_names.h
@@ -44,10 +44,10 @@ public:
 
 	_FORCE_INLINE_ static EditorStringNames *get_singleton() { return singleton; }
 
-	const StringName Editor = StaticCString::create("Editor");
-	const StringName EditorFonts = StaticCString::create("EditorFonts");
-	const StringName EditorIcons = StaticCString::create("EditorIcons");
-	const StringName EditorStyles = StaticCString::create("EditorStyles");
+	const StringName Editor = StringName("Editor");
+	const StringName EditorFonts = StringName("EditorFonts");
+	const StringName EditorIcons = StringName("EditorIcons");
+	const StringName EditorStyles = StringName("EditorStyles");
 };
 
 #define EditorStringName(m_name) EditorStringNames::get_singleton()->m_name

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2251,13 +2251,13 @@ void GDScriptLanguage::init() {
 	//populate global constants
 	int gcc = CoreConstants::get_global_constant_count();
 	for (int i = 0; i < gcc; i++) {
-		_add_global(StaticCString::create(CoreConstants::get_global_constant_name(i)), CoreConstants::get_global_constant_value(i));
+		_add_global(StringName(CoreConstants::get_global_constant_name(i)), CoreConstants::get_global_constant_value(i));
 	}
 
-	_add_global(StaticCString::create("PI"), Math::PI);
-	_add_global(StaticCString::create("TAU"), Math::TAU);
-	_add_global(StaticCString::create("INF"), Math::INF);
-	_add_global(StaticCString::create("NAN"), Math::NaN);
+	_add_global(StringName("PI"), Math::PI);
+	_add_global(StringName("TAU"), Math::TAU);
+	_add_global(StringName("INF"), Math::INF);
+	_add_global(StringName("NAN"), Math::NaN);
 
 	//populate native classes
 
@@ -2930,16 +2930,16 @@ thread_local GDScriptLanguage::CallStack GDScriptLanguage::_call_stack;
 GDScriptLanguage::GDScriptLanguage() {
 	ERR_FAIL_COND(singleton);
 	singleton = this;
-	strings._init = StaticCString::create("_init");
-	strings._static_init = StaticCString::create("_static_init");
-	strings._notification = StaticCString::create("_notification");
-	strings._set = StaticCString::create("_set");
-	strings._get = StaticCString::create("_get");
-	strings._get_property_list = StaticCString::create("_get_property_list");
-	strings._validate_property = StaticCString::create("_validate_property");
-	strings._property_can_revert = StaticCString::create("_property_can_revert");
-	strings._property_get_revert = StaticCString::create("_property_get_revert");
-	strings._script_source = StaticCString::create("script/source");
+	strings._init = StringName("_init");
+	strings._static_init = StringName("_static_init");
+	strings._notification = StringName("_notification");
+	strings._set = StringName("_set");
+	strings._get = StringName("_get");
+	strings._get_property_list = StringName("_get_property_list");
+	strings._validate_property = StringName("_validate_property");
+	strings._property_can_revert = StringName("_property_can_revert");
+	strings._property_get_revert = StringName("_property_get_revert");
+	strings._script_source = StringName("script/source");
 	_debug_parse_err_line = -1;
 	_debug_parse_err_file = "";
 

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -132,7 +132,7 @@ void finish_language() {
 StringName GDScriptTestRunner::test_function_name;
 
 GDScriptTestRunner::GDScriptTestRunner(const String &p_source_dir, bool p_init_language, bool p_print_filenames, bool p_use_binary_tokens) {
-	test_function_name = StaticCString::create("test");
+	test_function_name = StringName("test");
 	do_init_languages = p_init_language;
 	print_filenames = p_print_filenames;
 	binary_tokens = p_use_binary_tokens;

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -668,41 +668,41 @@ class BindingsGenerator {
 	void _initialize_compat_singletons();
 
 	struct NameCache {
-		StringName type_void = StaticCString::create("void");
-		StringName type_Variant = StaticCString::create("Variant");
-		StringName type_VarArg = StaticCString::create("VarArg");
-		StringName type_Object = StaticCString::create("Object");
-		StringName type_RefCounted = StaticCString::create("RefCounted");
-		StringName type_RID = StaticCString::create("RID");
-		StringName type_Callable = StaticCString::create("Callable");
-		StringName type_Signal = StaticCString::create("Signal");
-		StringName type_String = StaticCString::create("String");
-		StringName type_StringName = StaticCString::create("StringName");
-		StringName type_NodePath = StaticCString::create("NodePath");
-		StringName type_Array_generic = StaticCString::create("Array_@generic");
-		StringName type_Dictionary_generic = StaticCString::create("Dictionary_@generic");
-		StringName type_at_GlobalScope = StaticCString::create("@GlobalScope");
-		StringName enum_Error = StaticCString::create("Error");
+		StringName type_void = "void";
+		StringName type_Variant = "Variant";
+		StringName type_VarArg = "VarArg";
+		StringName type_Object = "Object";
+		StringName type_RefCounted = "RefCounted";
+		StringName type_RID = "RID";
+		StringName type_Callable = "Callable";
+		StringName type_Signal = "Signal";
+		StringName type_String = "String";
+		StringName type_StringName = "StringName";
+		StringName type_NodePath = "NodePath";
+		StringName type_Array_generic = "Array_@generic";
+		StringName type_Dictionary_generic = "Dictionary_@generic";
+		StringName type_at_GlobalScope = "@GlobalScope";
+		StringName enum_Error = "Error";
 
-		StringName type_sbyte = StaticCString::create("sbyte");
-		StringName type_short = StaticCString::create("short");
-		StringName type_int = StaticCString::create("int");
-		StringName type_byte = StaticCString::create("byte");
-		StringName type_ushort = StaticCString::create("ushort");
-		StringName type_uint = StaticCString::create("uint");
-		StringName type_long = StaticCString::create("long");
-		StringName type_ulong = StaticCString::create("ulong");
+		StringName type_sbyte = "sbyte";
+		StringName type_short = "short";
+		StringName type_int = "int";
+		StringName type_byte = "byte";
+		StringName type_ushort = "ushort";
+		StringName type_uint = "uint";
+		StringName type_long = "long";
+		StringName type_ulong = "ulong";
 
-		StringName type_bool = StaticCString::create("bool");
-		StringName type_float = StaticCString::create("float");
-		StringName type_double = StaticCString::create("double");
+		StringName type_bool = "bool";
+		StringName type_float = "float";
+		StringName type_double = "double";
 
-		StringName type_Vector2 = StaticCString::create("Vector2");
-		StringName type_Rect2 = StaticCString::create("Rect2");
-		StringName type_Vector3 = StaticCString::create("Vector3");
-		StringName type_Vector3i = StaticCString::create("Vector3i");
-		StringName type_Vector4 = StaticCString::create("Vector4");
-		StringName type_Vector4i = StaticCString::create("Vector4i");
+		StringName type_Vector2 = "Vector2";
+		StringName type_Rect2 = "Rect2";
+		StringName type_Vector3 = "Vector3";
+		StringName type_Vector3i = "Vector3i";
+		StringName type_Vector4 = "Vector4";
+		StringName type_Vector4i = "Vector4i";
 
 		// Object not included as it must be checked for all derived classes
 		static constexpr int nullable_types_count = 19;
@@ -713,21 +713,21 @@ class BindingsGenerator {
 
 			type_Array_generic,
 			type_Dictionary_generic,
-			StaticCString::create(_STR(Array)),
-			StaticCString::create(_STR(Dictionary)),
-			StaticCString::create(_STR(Callable)),
-			StaticCString::create(_STR(Signal)),
+			StringName(_STR(Array)),
+			StringName(_STR(Dictionary)),
+			StringName(_STR(Callable)),
+			StringName(_STR(Signal)),
 
-			StaticCString::create(_STR(PackedByteArray)),
-			StaticCString::create(_STR(PackedInt32Array)),
-			StaticCString::create(_STR(PackedInt64Array)),
-			StaticCString::create(_STR(PackedFloat32Array)),
-			StaticCString::create(_STR(PackedFloat64Array)),
-			StaticCString::create(_STR(PackedStringArray)),
-			StaticCString::create(_STR(PackedVector2Array)),
-			StaticCString::create(_STR(PackedVector3Array)),
-			StaticCString::create(_STR(PackedColorArray)),
-			StaticCString::create(_STR(PackedVector4Array)),
+			StringName(_STR(PackedByteArray)),
+			StringName(_STR(PackedInt32Array)),
+			StringName(_STR(PackedInt64Array)),
+			StringName(_STR(PackedFloat32Array)),
+			StringName(_STR(PackedFloat64Array)),
+			StringName(_STR(PackedStringArray)),
+			StringName(_STR(PackedVector2Array)),
+			StringName(_STR(PackedVector3Array)),
+			StringName(_STR(PackedColorArray)),
+			StringName(_STR(PackedVector4Array)),
 		};
 
 		bool is_nullable_type(const StringName &p_type) const {

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -565,7 +565,7 @@ void VoxelGI::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("bake", "from_node", "create_visual_debug"), &VoxelGI::bake, DEFVAL(Variant()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("debug_bake"), &VoxelGI::_debug_bake);
-	ClassDB::set_method_flags(get_class_static(), _scs_create("debug_bake"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
+	ClassDB::set_method_flags(get_class_static(), StringName("debug_bake"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "subdiv", PROPERTY_HINT_ENUM, "64,128,256,512"), "set_subdiv", "get_subdiv");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size", PROPERTY_HINT_NONE, "suffix:m"), "set_size", "get_size");

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -159,7 +159,7 @@ void Material::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_render_priority"), &Material::get_render_priority);
 
 	ClassDB::bind_method(D_METHOD("inspect_native_shader_code"), &Material::inspect_native_shader_code);
-	ClassDB::set_method_flags(get_class_static(), _scs_create("inspect_native_shader_code"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
+	ClassDB::set_method_flags(get_class_static(), StringName("inspect_native_shader_code"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 
 	ClassDB::bind_method(D_METHOD("create_placeholder"), &Material::create_placeholder);
 

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -2305,9 +2305,9 @@ void ArrayMesh::_bind_methods() {
 #endif // PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("create_outline", "margin"), &ArrayMesh::create_outline);
 	ClassDB::bind_method(D_METHOD("regen_normal_maps"), &ArrayMesh::regen_normal_maps);
-	ClassDB::set_method_flags(get_class_static(), _scs_create("regen_normal_maps"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
+	ClassDB::set_method_flags(get_class_static(), StringName("regen_normal_maps"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 	ClassDB::bind_method(D_METHOD("lightmap_unwrap", "transform", "texel_size"), &ArrayMesh::lightmap_unwrap);
-	ClassDB::set_method_flags(get_class_static(), _scs_create("lightmap_unwrap"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
+	ClassDB::set_method_flags(get_class_static(), StringName("lightmap_unwrap"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 	ClassDB::bind_method(D_METHOD("generate_triangle_mesh"), &ArrayMesh::generate_triangle_mesh);
 
 	ClassDB::bind_method(D_METHOD("set_custom_aabb", "aabb"), &ArrayMesh::set_custom_aabb);

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -277,7 +277,7 @@ void Shader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_shader_uniform_list", "get_groups"), &Shader::_get_shader_uniform_list, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("inspect_native_shader_code"), &Shader::inspect_native_shader_code);
-	ClassDB::set_method_flags(get_class_static(), _scs_create("inspect_native_shader_code"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
+	ClassDB::set_method_flags(get_class_static(), StringName("inspect_native_shader_code"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_code", "get_code");
 

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -45,116 +45,116 @@ public:
 
 	_FORCE_INLINE_ static SceneStringNames *get_singleton() { return singleton; }
 
-	const StringName resized = StaticCString::create("resized");
-	const StringName draw = StaticCString::create("draw");
-	const StringName hidden = StaticCString::create("hidden");
-	const StringName visibility_changed = StaticCString::create("visibility_changed");
+	const StringName resized = "resized";
+	const StringName draw = "draw";
+	const StringName hidden = "hidden";
+	const StringName visibility_changed = "visibility_changed";
 
-	const StringName input_event = StaticCString::create("input_event");
-	const StringName gui_input = StaticCString::create("gui_input");
-	const StringName window_input = StaticCString::create("window_input");
+	const StringName input_event = "input_event";
+	const StringName gui_input = "gui_input";
+	const StringName window_input = "window_input";
 
-	const StringName tree_entered = StaticCString::create("tree_entered");
-	const StringName tree_exiting = StaticCString::create("tree_exiting");
-	const StringName tree_exited = StaticCString::create("tree_exited");
-	const StringName ready = StaticCString::create("ready");
-	const StringName _ready = StaticCString::create("_ready");
+	const StringName tree_entered = "tree_entered";
+	const StringName tree_exiting = "tree_exiting";
+	const StringName tree_exited = "tree_exited";
+	const StringName ready = "ready";
+	const StringName _ready = "_ready";
 
-	const StringName item_rect_changed = StaticCString::create("item_rect_changed");
-	const StringName size_flags_changed = StaticCString::create("size_flags_changed");
-	const StringName minimum_size_changed = StaticCString::create("minimum_size_changed");
-	const StringName sleeping_state_changed = StaticCString::create("sleeping_state_changed");
-	const StringName node_configuration_warning_changed = StaticCString::create("node_configuration_warning_changed");
-	const StringName update = StaticCString::create("update");
-	const StringName updated = StaticCString::create("updated");
+	const StringName item_rect_changed = "item_rect_changed";
+	const StringName size_flags_changed = "size_flags_changed";
+	const StringName minimum_size_changed = "minimum_size_changed";
+	const StringName sleeping_state_changed = "sleeping_state_changed";
+	const StringName node_configuration_warning_changed = "node_configuration_warning_changed";
+	const StringName update = "update";
+	const StringName updated = "updated";
 
-	const StringName line_separation = StaticCString::create("line_separation");
-	const StringName font = StaticCString::create("font");
-	const StringName font_size = StaticCString::create("font_size");
-	const StringName font_color = StaticCString::create("font_color");
+	const StringName line_separation = "line_separation";
+	const StringName font = "font";
+	const StringName font_size = "font_size";
+	const StringName font_color = "font_color";
 
-	const StringName mouse_entered = StaticCString::create("mouse_entered");
-	const StringName mouse_exited = StaticCString::create("mouse_exited");
-	const StringName mouse_shape_entered = StaticCString::create("mouse_shape_entered");
-	const StringName mouse_shape_exited = StaticCString::create("mouse_shape_exited");
-	const StringName focus_entered = StaticCString::create("focus_entered");
-	const StringName focus_exited = StaticCString::create("focus_exited");
+	const StringName mouse_entered = "mouse_entered";
+	const StringName mouse_exited = "mouse_exited";
+	const StringName mouse_shape_entered = "mouse_shape_entered";
+	const StringName mouse_shape_exited = "mouse_shape_exited";
+	const StringName focus_entered = "focus_entered";
+	const StringName focus_exited = "focus_exited";
 
-	const StringName pre_sort_children = StaticCString::create("pre_sort_children");
-	const StringName sort_children = StaticCString::create("sort_children");
+	const StringName pre_sort_children = "pre_sort_children";
+	const StringName sort_children = "sort_children";
 
-	const StringName finished = StaticCString::create("finished");
-	const StringName animation_finished = StaticCString::create("animation_finished");
-	const StringName animation_changed = StaticCString::create("animation_changed");
-	const StringName animation_started = StaticCString::create("animation_started");
-	const StringName RESET = StaticCString::create("RESET");
+	const StringName finished = "finished";
+	const StringName animation_finished = "animation_finished";
+	const StringName animation_changed = "animation_changed";
+	const StringName animation_started = "animation_started";
+	const StringName RESET = "RESET";
 
-	const StringName pose_updated = StaticCString::create("pose_updated");
-	const StringName skeleton_updated = StaticCString::create("skeleton_updated");
-	const StringName bone_enabled_changed = StaticCString::create("bone_enabled_changed");
-	const StringName show_rest_only_changed = StaticCString::create("show_rest_only_changed");
+	const StringName pose_updated = "pose_updated";
+	const StringName skeleton_updated = "skeleton_updated";
+	const StringName bone_enabled_changed = "bone_enabled_changed";
+	const StringName show_rest_only_changed = "show_rest_only_changed";
 
-	const StringName body_shape_entered = StaticCString::create("body_shape_entered");
-	const StringName body_entered = StaticCString::create("body_entered");
-	const StringName body_shape_exited = StaticCString::create("body_shape_exited");
-	const StringName body_exited = StaticCString::create("body_exited");
+	const StringName body_shape_entered = "body_shape_entered";
+	const StringName body_entered = "body_entered";
+	const StringName body_shape_exited = "body_shape_exited";
+	const StringName body_exited = "body_exited";
 
-	const StringName area_shape_entered = StaticCString::create("area_shape_entered");
-	const StringName area_shape_exited = StaticCString::create("area_shape_exited");
+	const StringName area_shape_entered = "area_shape_entered";
+	const StringName area_shape_exited = "area_shape_exited";
 
-	const StringName screen_entered = StaticCString::create("screen_entered");
-	const StringName screen_exited = StaticCString::create("screen_exited");
+	const StringName screen_entered = "screen_entered";
+	const StringName screen_exited = "screen_exited";
 
-	const StringName _spatial_editor_group = StaticCString::create("_spatial_editor_group");
-	const StringName _request_gizmo = StaticCString::create("_request_gizmo");
+	const StringName _spatial_editor_group = "_spatial_editor_group";
+	const StringName _request_gizmo = "_request_gizmo";
 
-	const StringName offset = StaticCString::create("offset");
-	const StringName rotation_mode = StaticCString::create("rotation_mode");
-	const StringName rotate = StaticCString::create("rotate");
-	const StringName h_offset = StaticCString::create("h_offset");
-	const StringName v_offset = StaticCString::create("v_offset");
+	const StringName offset = "offset";
+	const StringName rotation_mode = "rotation_mode";
+	const StringName rotate = "rotate";
+	const StringName h_offset = "h_offset";
+	const StringName v_offset = "v_offset";
 
-	const StringName area_entered = StaticCString::create("area_entered");
-	const StringName area_exited = StaticCString::create("area_exited");
+	const StringName area_entered = "area_entered";
+	const StringName area_exited = "area_exited";
 
-	const StringName frame_changed = StaticCString::create("frame_changed");
-	const StringName texture_changed = StaticCString::create("texture_changed");
+	const StringName frame_changed = "frame_changed";
+	const StringName texture_changed = "texture_changed";
 
-	const StringName autoplay = StaticCString::create("autoplay");
-	const StringName blend_times = StaticCString::create("blend_times");
-	const StringName speed = StaticCString::create("speed");
+	const StringName autoplay = "autoplay";
+	const StringName blend_times = "blend_times";
+	const StringName speed = "speed";
 
 	const NodePath path_pp = NodePath("..");
 
-	const StringName default_ = StaticCString::create("default"); // default would conflict with C++ keyword.
-	const StringName output = StaticCString::create("output");
+	const StringName default_ = "default"; // default would conflict with C++ keyword.
+	const StringName output = "output";
 
-	const StringName Master = StaticCString::create("Master"); // Audio bus name.
+	const StringName Master = "Master"; // Audio bus name.
 
-	const StringName theme_changed = StaticCString::create("theme_changed");
-	const StringName shader = StaticCString::create("shader");
-	const StringName shader_overrides_group = StaticCString::create("_shader_overrides_group_");
-	const StringName shader_overrides_group_active = StaticCString::create("_shader_overrides_group_active_");
+	const StringName theme_changed = "theme_changed";
+	const StringName shader = "shader";
+	const StringName shader_overrides_group = "_shader_overrides_group_";
+	const StringName shader_overrides_group_active = "_shader_overrides_group_active_";
 
-	const StringName _custom_type_script = StaticCString::create("_custom_type_script");
+	const StringName _custom_type_script = "_custom_type_script";
 
-	const StringName pressed = StaticCString::create("pressed");
-	const StringName id_pressed = StaticCString::create("id_pressed");
-	const StringName toggled = StaticCString::create("toggled");
-	const StringName hover = StaticCString::create("hover");
+	const StringName pressed = "pressed";
+	const StringName id_pressed = "id_pressed";
+	const StringName toggled = "toggled";
+	const StringName hover = "hover";
 
-	const StringName panel = StaticCString::create("panel");
-	const StringName item_selected = StaticCString::create("item_selected");
-	const StringName confirmed = StaticCString::create("confirmed");
+	const StringName panel = "panel";
+	const StringName item_selected = "item_selected";
+	const StringName confirmed = "confirmed";
 
-	const StringName text_changed = StaticCString::create("text_changed");
-	const StringName text_submitted = StaticCString::create("text_submitted");
-	const StringName value_changed = StaticCString::create("value_changed");
+	const StringName text_changed = "text_changed";
+	const StringName text_submitted = "text_submitted";
+	const StringName value_changed = "value_changed";
 
-	const StringName Start = StaticCString::create("Start");
-	const StringName End = StaticCString::create("End");
+	const StringName Start = "Start";
+	const StringName End = "End";
 
-	const StringName FlatButton = StaticCString::create("FlatButton");
+	const StringName FlatButton = "FlatButton";
 };
 
 #define SceneStringName(m_name) SceneStringNames::get_singleton()->m_name

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -124,21 +124,21 @@ struct ExposedClass {
 };
 
 struct NamesCache {
-	StringName variant_type = StaticCString::create("Variant");
-	StringName object_class = StaticCString::create("Object");
-	StringName ref_counted_class = StaticCString::create("RefCounted");
-	StringName string_type = StaticCString::create("String");
-	StringName string_name_type = StaticCString::create("StringName");
-	StringName node_path_type = StaticCString::create("NodePath");
-	StringName bool_type = StaticCString::create("bool");
-	StringName int_type = StaticCString::create("int");
-	StringName float_type = StaticCString::create("float");
-	StringName void_type = StaticCString::create("void");
-	StringName vararg_stub_type = StaticCString::create("@VarArg@");
-	StringName vector2_type = StaticCString::create("Vector2");
-	StringName rect2_type = StaticCString::create("Rect2");
-	StringName vector3_type = StaticCString::create("Vector3");
-	StringName vector4_type = StaticCString::create("Vector4");
+	StringName variant_type = StringName("Variant");
+	StringName object_class = StringName("Object");
+	StringName ref_counted_class = StringName("RefCounted");
+	StringName string_type = StringName("String");
+	StringName string_name_type = StringName("StringName");
+	StringName node_path_type = StringName("NodePath");
+	StringName bool_type = StringName("bool");
+	StringName int_type = StringName("int");
+	StringName float_type = StringName("float");
+	StringName void_type = StringName("void");
+	StringName vararg_stub_type = StringName("@VarArg@");
+	StringName vector2_type = StringName("Vector2");
+	StringName rect2_type = StringName("Rect2");
+	StringName vector3_type = StringName("Vector3");
+	StringName vector4_type = StringName("Vector4");
 
 	// Object not included as it must be checked for all derived classes
 	static constexpr int nullable_types_count = 18;
@@ -147,21 +147,21 @@ struct NamesCache {
 		string_name_type,
 		node_path_type,
 
-		StaticCString::create(_STR(Array)),
-		StaticCString::create(_STR(Dictionary)),
-		StaticCString::create(_STR(Callable)),
-		StaticCString::create(_STR(Signal)),
+		StringName(_STR(Array)),
+		StringName(_STR(Dictionary)),
+		StringName(_STR(Callable)),
+		StringName(_STR(Signal)),
 
-		StaticCString::create(_STR(PackedByteArray)),
-		StaticCString::create(_STR(PackedInt32Array)),
-		StaticCString::create(_STR(PackedInt64rray)),
-		StaticCString::create(_STR(PackedFloat32Array)),
-		StaticCString::create(_STR(PackedFloat64Array)),
-		StaticCString::create(_STR(PackedStringArray)),
-		StaticCString::create(_STR(PackedVector2Array)),
-		StaticCString::create(_STR(PackedVector3Array)),
-		StaticCString::create(_STR(PackedColorArray)),
-		StaticCString::create(_STR(PackedVector4Array)),
+		StringName(_STR(PackedByteArray)),
+		StringName(_STR(PackedInt32Array)),
+		StringName(_STR(PackedInt64rray)),
+		StringName(_STR(PackedFloat32Array)),
+		StringName(_STR(PackedFloat64Array)),
+		StringName(_STR(PackedStringArray)),
+		StringName(_STR(PackedVector2Array)),
+		StringName(_STR(PackedVector3Array)),
+		StringName(_STR(PackedColorArray)),
+		StringName(_STR(PackedVector4Array)),
 	};
 
 	bool is_nullable_type(const StringName &p_type) const {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11517.

## Benchmark

I benchmarked the launch of Godot of `master` vs this PR. There was a ~2% improvement (which is still within fluctuations, so no guarantees):
```
 ❯ hyperfine -m25 -iw1 "bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit" "bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit"
Benchmark 1: bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      3.407 s ±  0.184 s    [User: 2.486 s, System: 0.359 s]
  Range (min … max):    3.062 s …  3.845 s    25 runs

Benchmark 2: bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      3.343 s ±  0.186 s    [User: 2.470 s, System: 0.352 s]
  Range (min … max):    3.066 s …  3.688 s    25 runs

Summary
  bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit ran
    1.02 ± 0.08 times faster than bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit
```

## Allocation Tracking

I tracked persistent allocations during a normal editor run (`/Users/lukas/dev/godot/godot/bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor`), measured during the idle peak after launch, using Apple Instruments.
- `1092408576b` / `1.02Gib` on master
- `1095411792b`  / `1.02Gib` on this pr

So, the difference seems to be around `3mb` / `0.27%` (additional cost in this PR vs `master`) in the editor.

## Binary size
The binary size shrinks by 300kb (0.16%), at least for me.

## Verdict

I don't think the RAM saved is worth the costs of having a split `StringName` backing.
It's simpler, and more predicable, to know that any `StringName` can convert to `String` instantly and without cost.

Additionally, operations like `size()` can be better inlined, making other operations generally faster. This is desirable especially because `StringName` is supposed to be fast, and it can be detrimental if some operations are considerably _slower_ than `String`.

This fact is exploitable to make additional RAM and performance savings, especially for well-known strings. For example, it could be tested whether `StringName` referencing could be faster than `String` allocations (working towards interning). This would not be possible if `StringName` does not guarantee a `String` backing.