### PR TITLE
SCons: Integrate `everything` as a warning level

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -108,10 +108,14 @@ def redirect_emitter(target, source, env):
 
 def disable_warnings(self):
     # 'self' is the environment
-    if self.msvc and not using_clang(self):
-        self["WARNLEVEL"] = "/w"
-    else:
-        self["WARNLEVEL"] = "-w"
+    MSVC_SYNTAX = self.msvc and not using_clang(self)
+    PREFIXES = ("/W", "/w") if MSVC_SYNTAX else ("-W", "-w")
+    EXCLUDES = ("/w", "/wd4267") if MSVC_SYNTAX else ("-w")
+    self["WARNLEVEL"] = "/w" if MSVC_SYNTAX else "-w"
+    for identifier in ["CCFLAGS", "CXXFLAGS", "CFLAGS"]:
+        for item in self.Split(self[identifier]):
+            if item.startswith(PREFIXES) and item not in EXCLUDES:
+                self[identifier].remove(item)
 
 
 def force_optimization_on_debug(self):


### PR DESCRIPTION
- Supersedes #105023
- Depends on #104982

This was the main motivator behind the aforementioned PR: adding a `-Weverything` toggle. This is a **very strongly discouraged** option for the average user, as it warns of *literally everything* that is capable of being warned about. However, laying everything out like this has the benefit of exposing which areas we currently need to suppress in order to account for every single warning; that's something we can actually use to piecemeal whatever warnings we'd want to integrate into `extra`. As GCC lacks an `-Weverything` equivalent, that compiler will fall back to `extra` with a warning. MSVC and Clang both feature *tentative* support, but this isn't a new "baseline" in any capacity (eg: `extra` will remain the default for `dev_mode`); it's very much a niche option, and shall be treated as such.