### PR TITLE
[CodeEdit] Fix folding for comments mixed with code region tags.

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1645,12 +1645,12 @@ bool CodeEdit::can_fold_line(int p_line) const {
 		if (delimiter_end_line == p_line) {
 			/* Check we are the start of the block. */
 			if (p_line - 1 >= 0) {
-				if ((in_string != -1 && is_in_string(p_line - 1) != -1) || (in_comment != -1 && is_in_comment(p_line - 1) != -1)) {
+				if ((in_string != -1 && is_in_string(p_line - 1) != -1) || (in_comment != -1 && is_in_comment(p_line - 1) != -1 && !is_line_code_region_start(p_line - 1) && !is_line_code_region_end(p_line - 1))) {
 					return false;
 				}
 			}
 			/* Check it continues for at least one line. */
-			return ((in_string != -1 && is_in_string(p_line + 1) != -1) || (in_comment != -1 && is_in_comment(p_line + 1) != -1));
+			return ((in_string != -1 && is_in_string(p_line + 1) != -1) || (in_comment != -1 && is_in_comment(p_line + 1) != -1 && !is_line_code_region_start(p_line + 1) && !is_line_code_region_end(p_line + 1)));
 		}
 		return ((in_string != -1 && is_in_string(delimiter_end_line) != -1) || (in_comment != -1 && is_in_comment(delimiter_end_line) != -1));
 	}
@@ -1703,6 +1703,10 @@ void CodeEdit::fold_line(int p_line) {
 			if (end_line == p_line) {
 				for (int i = p_line + 1; i <= line_count; i++) {
 					if ((in_string != -1 && is_in_string(i) == -1) || (in_comment != -1 && is_in_comment(i) == -1)) {
+						break;
+					}
+					if (in_comment != -1 && (is_line_code_region_start(i) || is_line_code_region_end(i))) {
+						// A code region tag should split a comment block, ending it early.
 						break;
 					}
 					end_line = i;


### PR DESCRIPTION
Fixes #102382.

## Changes

The changes are all in `scene/gui/code_edit.cpp` and consist of three parts:

Part 1: `can_fold_line` doesn't return false anymore for any line in a comment block if the previous line is a code region tag (which would previously have been considered a part of that comment block, hence the comment line right below wouldn't have counted as an eligible comment block start line, so it'd have returned false).

Part 2: Part 1 fixes the problem a little too well: It causes even single line comment blocks to be foldable if there's a code region tag on the next line. That's why the `p + 1` checks are also checking for code region tags now.

Part 3: `fold_line` now treats code region tags as end delimiters for comment blocks, making sure that folding comments doesn't fold code region tags. <strike>Downside: Folding comments is roughly 2.5x slower now (on my Ryzen 5800X3D folding a comment block of 2500 lines takes about 1ms (with fix) vs. 0.38 ms (without fix)).</strike> The attached project contains a benchmark you can run.

Note: Thanks to kitbdev's input the performance problem doesn't apply anymore, and the PR now properly supports multiline comments (e.g. `/* */`-style comments).


## Tests

In the comment folding tests, I'm using `get_visible_line_count_in_range` instead of `is_line_folded` to check that the comment block isn't just folded, but folded properly. The second call checks if the region tag is still visible.

## Benchmark for `fold_line`

[fold_line_benchmark_for_issue_102382.zip](https://github.com/user-attachments/files/19600694/fold_line_benchmark_for_issue_102382.zip)
This also contains a file `manual_test.gd` which has various comment/region tag constellations for manual testing.