### PR TITLE
[TextServer] Make font atlas textures size configurable.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1617,6 +1617,8 @@ ProjectSettings::ProjectSettings() {
 
 	GLOBAL_DEF_BASIC("gui/common/snap_controls_to_pixels", true);
 	GLOBAL_DEF_BASIC("gui/fonts/dynamic_fonts/use_oversampling", true);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "gui/fonts/min_atlas_texture_size", PROPERTY_HINT_ENUM, U"256×256:8,512×512:9,1024×1024:10,2048×2048:11,4096×4096:12,8192×8192:13,16384×16384:14"), 8);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "gui/fonts/max_atlas_texture_size", PROPERTY_HINT_ENUM, U"256×256:8,512×512:9,1024×1024:10,2048×2048:11,4096×4096:12,8192×8192:13,16384×16384:14"), 11);
 
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/rendering_device/vsync/frame_queue_size", PROPERTY_HINT_RANGE, "2,3,1"), 2);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/rendering_device/vsync/swapchain_image_count", PROPERTY_HINT_RANGE, "2,4,1"), 3);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1161,6 +1161,12 @@
 		</member>
 		<member name="gui/fonts/dynamic_fonts/use_oversampling" type="bool" setter="" getter="" default="true">
 		</member>
+		<member name="gui/fonts/max_atlas_texture_size" type="int" setter="" getter="" default="11">
+			Maximum font atlas texture size, specified as a power of two. Default texture atlas size is [code]font_size * oversampling * 16[/code] clamped between [member gui/fonts/min_atlas_texture_size] and [member gui/fonts/max_atlas_texture_size]. Increasing texture atlas size will improve drawing performance for text with a large number of unique glyphs or large font sizes, but makes atlas updates slower. If you are increasing the atlas size, consider pre-rendering required glyphs in the advanced font import dialog, or using [method TextServer.font_render_range].
+		</member>
+		<member name="gui/fonts/min_atlas_texture_size" type="int" setter="" getter="" default="8">
+			Minimum font atlas texture size, specified as a power of two. Default texture atlas size is [code]font_size * oversampling * 16[/code] clamped between [member gui/fonts/min_atlas_texture_size] and [member gui/fonts/max_atlas_texture_size]. Increasing texture atlas size will improve drawing performance for text with a large number of unique glyphs or large font sizes, but makes atlas updates slower. If you are increasing the atlas size, consider pre-rendering required glyphs in the advanced font import dialog, or using [method TextServer.font_render_range].
+		</member>
 		<member name="gui/theme/custom" type="String" setter="" getter="" default="&quot;&quot;">
 			Path to a custom [Theme] resource file to use for the project ([code].theme[/code] or generic [code].tres[/code]/[code].res[/code] extension).
 		</member>

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -845,14 +845,10 @@ _FORCE_INLINE_ TextServerAdvanced::FontTexturePosition TextServerAdvanced::find_
 
 	if (ret.index == -1) {
 		// Could not find texture to fit, create one.
-		int texsize = MAX(p_data->size.x * p_data->oversampling * 8, 256);
-
+		int texsize = MAX(p_data->size.x * p_data->oversampling * 16, 1 << min_atlas_texture_size);
 		texsize = next_power_of_2(texsize);
-		if (p_msdf) {
-			texsize = MIN(texsize, 2048);
-		} else {
-			texsize = MIN(texsize, 1024);
-		}
+		texsize = MIN(texsize, 1 << max_atlas_texture_size);
+
 		if (mw > texsize) { // Special case, adapt to it?
 			texsize = next_power_of_2(mw);
 		}
@@ -7922,12 +7918,15 @@ bool TextServerAdvanced::_is_valid_letter(uint64_t p_unicode) const {
 
 void TextServerAdvanced::_update_settings() {
 	lcd_subpixel_layout.set((TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout"));
+	min_atlas_texture_size = GLOBAL_GET("gui/fonts/min_atlas_texture_size");
+	max_atlas_texture_size = GLOBAL_GET("gui/fonts/max_atlas_texture_size");
 }
 
 TextServerAdvanced::TextServerAdvanced() {
 	_insert_num_systems_lang();
 	_insert_feature_sets();
 	_bmp_create_font_funcs();
+	_update_settings();
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &TextServerAdvanced::_update_settings));
 }
 

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -574,6 +574,9 @@ class TextServerAdvanced : public TextServerExtension {
 	mutable RID_PtrOwner<FontAdvanced> font_owner;
 	mutable RID_PtrOwner<ShapedTextDataAdvanced> shaped_owner;
 
+	int min_atlas_texture_size = 8;
+	int max_atlas_texture_size = 11;
+
 	_FORCE_INLINE_ FontAdvanced *_get_font_data(const RID &p_font_rid) const {
 		RID rid = p_font_rid;
 		FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(rid);

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -267,15 +267,10 @@ _FORCE_INLINE_ TextServerFallback::FontTexturePosition TextServerFallback::find_
 
 	if (ret.index == -1) {
 		// Could not find texture to fit, create one.
-		int texsize = MAX(p_data->size.x * p_data->oversampling * 8, 256);
-
+		int texsize = MAX(p_data->size.x * p_data->oversampling * 16, 1 << min_atlas_texture_size);
 		texsize = next_power_of_2(texsize);
+		texsize = MIN(texsize, 1 << max_atlas_texture_size);
 
-		if (p_msdf) {
-			texsize = MIN(texsize, 2048);
-		} else {
-			texsize = MIN(texsize, 1024);
-		}
 		if (mw > texsize) { // Special case, adapt to it?
 			texsize = next_power_of_2(mw);
 		}
@@ -5055,10 +5050,13 @@ PackedInt32Array TextServerFallback::_string_get_word_breaks(const String &p_str
 
 void TextServerFallback::_update_settings() {
 	lcd_subpixel_layout.set((TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout"));
+	min_atlas_texture_size = GLOBAL_GET("gui/fonts/min_atlas_texture_size");
+	max_atlas_texture_size = GLOBAL_GET("gui/fonts/max_atlas_texture_size");
 }
 
 TextServerFallback::TextServerFallback() {
 	_insert_feature_sets();
+	_update_settings();
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &TextServerFallback::_update_settings));
 }
 

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -485,6 +485,9 @@ class TextServerFallback : public TextServerExtension {
 	mutable RID_PtrOwner<FontFallback> font_owner;
 	mutable RID_PtrOwner<ShapedTextDataFallback> shaped_owner;
 
+	int min_atlas_texture_size = 8;
+	int max_atlas_texture_size = 11;
+
 	_FORCE_INLINE_ FontFallback *_get_font_data(const RID &p_font_rid) const {
 		RID rid = p_font_rid;
 		FontFallbackLinkedVariation *fdv = font_var_owner.get_or_null(rid);


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/104537

It's not exactly a fix for this issue, but gives more control over font atlas size.