### PR TITLE
LSP: Fix type bind, mark as experimental, deprecate direct LSP access

### DIFF
--- a/modules/gdscript/config.py
+++ b/modules/gdscript/config.py
@@ -11,7 +11,10 @@ def get_doc_classes():
     return [
         "@GDScript",
         "GDScript",
+        "GDScriptLanguageProtocol",
         "GDScriptSyntaxHighlighter",
+        "GDScriptTextDocument",
+        "GDScriptWorkspace",
     ]
 
 

--- a/modules/gdscript/doc_classes/GDScriptLanguageProtocol.xml
+++ b/modules/gdscript/doc_classes/GDScriptLanguageProtocol.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDScriptLanguageProtocol" inherits="JSONRPC" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		GDScript language server.
+	</brief_description>
+	<description>
+		Provides access to certain features that are implemented in the language server.
+		[b]Note:[/b] This class is not a language server client that can be used to access LSP functionality. It only provides access to a limited set of features that is implemented using the same technical foundation as the language server.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_text_document" deprecated="[GDScriptTextDocument] is deprecated.">
+			<return type="GDScriptTextDocument" />
+			<description>
+				Returns the language server's [GDScriptTextDocument] instance.
+			</description>
+		</method>
+		<method name="get_workspace">
+			<return type="GDScriptWorkspace" />
+			<description>
+				Returns the language server's [GDScriptWorkspace] instance.
+			</description>
+		</method>
+		<method name="initialize" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Dictionary" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="initialized" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="void" />
+			<param index="0" name="params" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="is_initialized" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the language server was initialized by a language server client, [code]false[/code] otherwise.
+			</description>
+		</method>
+		<method name="is_smart_resolve_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the language server is providing the smart resolve feature, [code]false[/code] otherwise. The feature can be configured through the editor settings.
+			</description>
+		</method>
+		<method name="notify_client" deprecated="Might result in unwanted side effects for connected clients.">
+			<return type="void" />
+			<param index="0" name="method" type="String" />
+			<param index="1" name="params" type="Variant" default="null" />
+			<param index="2" name="client_id" type="int" default="-1" />
+			<description>
+			</description>
+		</method>
+		<method name="on_client_connected" deprecated="Might result in unwanted side effects for connected clients.">
+			<return type="int" enum="Error" />
+			<description>
+			</description>
+		</method>
+		<method name="on_client_disconnected" deprecated="Might result in unwanted side effects for connected clients.">
+			<return type="void" />
+			<param index="0" name="client_id" type="int" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/gdscript/doc_classes/GDScriptTextDocument.xml
+++ b/modules/gdscript/doc_classes/GDScriptTextDocument.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDScriptTextDocument" inherits="RefCounted" deprecated="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Document related language server functionality.
+	</brief_description>
+	<description>
+		Provides language server functionality related to documents.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="codeLens" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Array" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="colorPresentation" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Array" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="completion" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Array" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="declaration" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Variant" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="definition" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Array" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="didChange" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="void" />
+			<param index="0" name="params" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="didClose" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="void" />
+			<param index="0" name="params" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="didOpen" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="void" />
+			<param index="0" name="params" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="didSave" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="void" />
+			<param index="0" name="params" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="documentLink" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Array" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="documentSymbol" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Array" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="foldingRange" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Array" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="hover" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Variant" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="nativeSymbol" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Variant" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="prepareRename" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Variant" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="references" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Array" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="rename" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Dictionary" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="resolve" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Dictionary" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="show_native_symbol_in_editor" deprecated="Use [method ScriptEditor.goto_help] instead.">
+			<return type="void" />
+			<param index="0" name="symbol_id" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="signatureHelp" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="Variant" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="willSaveWaitUntil" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="void" />
+			<param index="0" name="params" type="Variant" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/gdscript/doc_classes/GDScriptWorkspace.xml
+++ b/modules/gdscript/doc_classes/GDScriptWorkspace.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDScriptWorkspace" inherits="RefCounted" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Workspace related language server functionality.
+	</brief_description>
+	<description>
+		Provides language server functionality related to the workspace.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="apply_new_signal" deprecated="Might result in unwanted side effects for connected clients.">
+			<return type="void" />
+			<param index="0" name="obj" type="Object" />
+			<param index="1" name="function" type="String" />
+			<param index="2" name="args" type="PackedStringArray" />
+			<description>
+			</description>
+		</method>
+		<method name="didDeleteFiles" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
+			<return type="void" />
+			<param index="0" name="params" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="generate_script_api">
+			<return type="Dictionary" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Returns the interface of the script in a machine-readable format.
+			</description>
+		</method>
+		<method name="get_file_path">
+			<return type="String" />
+			<param index="0" name="uri" type="String" />
+			<description>
+				Converts a URI to a file path.
+			</description>
+		</method>
+		<method name="get_file_uri" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Converts a file path to a URI.
+			</description>
+		</method>
+		<method name="parse_local_script" deprecated="Might result in unwanted side effects for connected clients.">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="parse_script" deprecated="Might result in unwanted side effects for connected clients.">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="content" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="publish_diagnostics" deprecated="Might result in unwanted side effects for connected clients.">
+			<return type="void" />
+			<param index="0" name="path" type="String" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -174,15 +174,18 @@ String GDScriptLanguageProtocol::format_output(const String &p_text) {
 }
 
 void GDScriptLanguageProtocol::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_text_document"), &GDScriptLanguageProtocol::get_text_document);
+	ClassDB::bind_method(D_METHOD("get_workspace"), &GDScriptLanguageProtocol::get_workspace);
+	ClassDB::bind_method(D_METHOD("is_smart_resolve_enabled"), &GDScriptLanguageProtocol::is_smart_resolve_enabled);
+	ClassDB::bind_method(D_METHOD("is_initialized"), &GDScriptLanguageProtocol::is_initialized);
+
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("initialize", "params"), &GDScriptLanguageProtocol::initialize);
 	ClassDB::bind_method(D_METHOD("initialized", "params"), &GDScriptLanguageProtocol::initialized);
 	ClassDB::bind_method(D_METHOD("on_client_connected"), &GDScriptLanguageProtocol::on_client_connected);
-	ClassDB::bind_method(D_METHOD("on_client_disconnected"), &GDScriptLanguageProtocol::on_client_disconnected);
+	ClassDB::bind_method(D_METHOD("on_client_disconnected", "client_id"), &GDScriptLanguageProtocol::on_client_disconnected);
 	ClassDB::bind_method(D_METHOD("notify_client", "method", "params", "client_id"), &GDScriptLanguageProtocol::notify_client, DEFVAL(Variant()), DEFVAL(-1));
-	ClassDB::bind_method(D_METHOD("is_smart_resolve_enabled"), &GDScriptLanguageProtocol::is_smart_resolve_enabled);
-	ClassDB::bind_method(D_METHOD("get_text_document"), &GDScriptLanguageProtocol::get_text_document);
-	ClassDB::bind_method(D_METHOD("get_workspace"), &GDScriptLanguageProtocol::get_workspace);
-	ClassDB::bind_method(D_METHOD("is_initialized"), &GDScriptLanguageProtocol::is_initialized);
+#endif // !DISABLE_DEPRECATED
 }
 
 Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -62,7 +62,7 @@ void GDScriptLanguageServer::_notification(int p_what) {
 			}
 
 			if (started && !use_thread) {
-				protocol.poll(poll_limit_usec);
+				GDScriptLanguageProtocol::get_singleton()->poll(poll_limit_usec);
 			}
 		} break;
 
@@ -88,7 +88,7 @@ void GDScriptLanguageServer::thread_main(void *p_userdata) {
 	GDScriptLanguageServer *self = static_cast<GDScriptLanguageServer *>(p_userdata);
 	while (self->thread_running) {
 		// Poll 20 times per second
-		self->protocol.poll(self->poll_limit_usec);
+		GDScriptLanguageProtocol::get_singleton()->poll(self->poll_limit_usec);
 		OS::get_singleton()->delay_usec(50000);
 	}
 }
@@ -98,7 +98,7 @@ void GDScriptLanguageServer::start() {
 	port = (GDScriptLanguageServer::port_override > -1) ? GDScriptLanguageServer::port_override : (int)_EDITOR_GET("network/language_server/remote_port");
 	use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
 	poll_limit_usec = (int)_EDITOR_GET("network/language_server/poll_limit_usec");
-	if (protocol.start(port, IPAddress(host)) == OK) {
+	if (GDScriptLanguageProtocol::get_singleton()->start(port, IPAddress(host)) == OK) {
 		EditorNode::get_log()->add_message("--- GDScript language server started on port " + itos(port) + " ---", EditorLog::MSG_TYPE_EDITOR);
 		if (use_thread) {
 			thread_running = true;
@@ -115,7 +115,7 @@ void GDScriptLanguageServer::stop() {
 		thread_running = false;
 		thread.wait_to_finish();
 	}
-	protocol.stop();
+	GDScriptLanguageProtocol::get_singleton()->stop();
 	started = false;
 	EditorNode::get_log()->add_message("--- GDScript language server stopped ---", EditorLog::MSG_TYPE_EDITOR);
 }

--- a/modules/gdscript/language_server/gdscript_language_server.h
+++ b/modules/gdscript/language_server/gdscript_language_server.h
@@ -37,8 +37,6 @@
 class GDScriptLanguageServer : public EditorPlugin {
 	GDCLASS(GDScriptLanguageServer, EditorPlugin);
 
-	GDScriptLanguageProtocol protocol;
-
 	Thread thread;
 	bool thread_running = false;
 	// There is no notification when the editor is initialized. We need to poll till we attempted to start the server.

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -39,27 +39,30 @@
 #include "servers/display/display_server.h"
 
 void GDScriptTextDocument::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("didOpen"), &GDScriptTextDocument::didOpen);
-	ClassDB::bind_method(D_METHOD("didClose"), &GDScriptTextDocument::didClose);
-	ClassDB::bind_method(D_METHOD("didChange"), &GDScriptTextDocument::didChange);
-	ClassDB::bind_method(D_METHOD("willSaveWaitUntil"), &GDScriptTextDocument::willSaveWaitUntil);
-	ClassDB::bind_method(D_METHOD("didSave"), &GDScriptTextDocument::didSave);
-	ClassDB::bind_method(D_METHOD("nativeSymbol"), &GDScriptTextDocument::nativeSymbol);
-	ClassDB::bind_method(D_METHOD("documentSymbol"), &GDScriptTextDocument::documentSymbol);
-	ClassDB::bind_method(D_METHOD("completion"), &GDScriptTextDocument::completion);
-	ClassDB::bind_method(D_METHOD("resolve"), &GDScriptTextDocument::resolve);
-	ClassDB::bind_method(D_METHOD("rename"), &GDScriptTextDocument::rename);
-	ClassDB::bind_method(D_METHOD("prepareRename"), &GDScriptTextDocument::prepareRename);
-	ClassDB::bind_method(D_METHOD("references"), &GDScriptTextDocument::references);
-	ClassDB::bind_method(D_METHOD("foldingRange"), &GDScriptTextDocument::foldingRange);
-	ClassDB::bind_method(D_METHOD("codeLens"), &GDScriptTextDocument::codeLens);
-	ClassDB::bind_method(D_METHOD("documentLink"), &GDScriptTextDocument::documentLink);
-	ClassDB::bind_method(D_METHOD("colorPresentation"), &GDScriptTextDocument::colorPresentation);
-	ClassDB::bind_method(D_METHOD("hover"), &GDScriptTextDocument::hover);
-	ClassDB::bind_method(D_METHOD("definition"), &GDScriptTextDocument::definition);
-	ClassDB::bind_method(D_METHOD("declaration"), &GDScriptTextDocument::declaration);
-	ClassDB::bind_method(D_METHOD("signatureHelp"), &GDScriptTextDocument::signatureHelp);
-	ClassDB::bind_method(D_METHOD("show_native_symbol_in_editor"), &GDScriptTextDocument::show_native_symbol_in_editor);
+	ClassDB::bind_method(D_METHOD("show_native_symbol_in_editor", "symbol_id"), &GDScriptTextDocument::show_native_symbol_in_editor);
+
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("didOpen", "params"), &GDScriptTextDocument::didOpen);
+	ClassDB::bind_method(D_METHOD("didClose", "params"), &GDScriptTextDocument::didClose);
+	ClassDB::bind_method(D_METHOD("didChange", "params"), &GDScriptTextDocument::didChange);
+	ClassDB::bind_method(D_METHOD("willSaveWaitUntil", "params"), &GDScriptTextDocument::willSaveWaitUntil);
+	ClassDB::bind_method(D_METHOD("didSave", "params"), &GDScriptTextDocument::didSave);
+	ClassDB::bind_method(D_METHOD("nativeSymbol", "params"), &GDScriptTextDocument::nativeSymbol);
+	ClassDB::bind_method(D_METHOD("documentSymbol", "params"), &GDScriptTextDocument::documentSymbol);
+	ClassDB::bind_method(D_METHOD("completion", "params"), &GDScriptTextDocument::completion);
+	ClassDB::bind_method(D_METHOD("resolve", "params"), &GDScriptTextDocument::resolve);
+	ClassDB::bind_method(D_METHOD("rename", "params"), &GDScriptTextDocument::rename);
+	ClassDB::bind_method(D_METHOD("prepareRename", "params"), &GDScriptTextDocument::prepareRename);
+	ClassDB::bind_method(D_METHOD("references", "params"), &GDScriptTextDocument::references);
+	ClassDB::bind_method(D_METHOD("foldingRange", "params"), &GDScriptTextDocument::foldingRange);
+	ClassDB::bind_method(D_METHOD("codeLens", "params"), &GDScriptTextDocument::codeLens);
+	ClassDB::bind_method(D_METHOD("documentLink", "params"), &GDScriptTextDocument::documentLink);
+	ClassDB::bind_method(D_METHOD("colorPresentation", "params"), &GDScriptTextDocument::colorPresentation);
+	ClassDB::bind_method(D_METHOD("hover", "params"), &GDScriptTextDocument::hover);
+	ClassDB::bind_method(D_METHOD("definition", "params"), &GDScriptTextDocument::definition);
+	ClassDB::bind_method(D_METHOD("declaration", "params"), &GDScriptTextDocument::declaration);
+	ClassDB::bind_method(D_METHOD("signatureHelp", "params"), &GDScriptTextDocument::signatureHelp);
+#endif // !DISABLE_DEPRECATED
 }
 
 void GDScriptTextDocument::didOpen(const Variant &p_param) {

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -43,16 +43,16 @@
 #include "editor/settings/editor_settings.h"
 
 void GDScriptWorkspace::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("apply_new_signal"), &GDScriptWorkspace::apply_new_signal);
+	ClassDB::bind_method(D_METHOD("apply_new_signal", "obj", "function", "args"), &GDScriptWorkspace::apply_new_signal);
 	ClassDB::bind_method(D_METHOD("get_file_path", "uri"), &GDScriptWorkspace::get_file_path);
 	ClassDB::bind_method(D_METHOD("get_file_uri", "path"), &GDScriptWorkspace::get_file_uri);
-	ClassDB::bind_method(D_METHOD("publish_diagnostics", "path"), &GDScriptWorkspace::publish_diagnostics);
 	ClassDB::bind_method(D_METHOD("generate_script_api", "path"), &GDScriptWorkspace::generate_script_api);
 
 #ifndef DISABLE_DEPRECATED
-	ClassDB::bind_method(D_METHOD("didDeleteFiles"), &GDScriptWorkspace::didDeleteFiles);
+	ClassDB::bind_method(D_METHOD("didDeleteFiles", "params"), &GDScriptWorkspace::didDeleteFiles);
 	ClassDB::bind_method(D_METHOD("parse_script", "path", "content"), &GDScriptWorkspace::parse_script);
-	ClassDB::bind_method(D_METHOD("parse_local_script", "path"), &GDScriptWorkspace::parse_script);
+	ClassDB::bind_method(D_METHOD("parse_local_script", "path"), &GDScriptWorkspace::parse_local_script);
+	ClassDB::bind_method(D_METHOD("publish_diagnostics", "path"), &GDScriptWorkspace::publish_diagnostics);
 #endif
 }
 

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -41,7 +41,7 @@ class GDScriptWorkspace : public RefCounted {
 
 private:
 #ifndef DISABLE_DEPRECATED
-	void didDeleteFiles() {}
+	void didDeleteFiles(const Dictionary &p_params) {}
 	Error parse_script(const String &p_path, const String &p_content) {
 		WARN_DEPRECATED;
 		return Error::FAILED;

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -128,10 +128,9 @@ static void _editor_init() {
 #endif
 
 #ifndef GDSCRIPT_NO_LSP
-	register_lsp_types();
-	GDScriptLanguageServer *lsp_plugin = memnew(GDScriptLanguageServer);
-	EditorNode::get_singleton()->add_editor_plugin(lsp_plugin);
-	Engine::get_singleton()->add_singleton(Engine::Singleton("GDScriptLanguageProtocol", GDScriptLanguageProtocol::get_singleton()));
+	Engine::Singleton singleton("GDScriptLanguageProtocol", GDScriptLanguageProtocol::get_singleton());
+	singleton.editor_only = true;
+	Engine::get_singleton()->add_singleton(singleton);
 #endif // !GDSCRIPT_NO_LSP
 }
 
@@ -163,6 +162,11 @@ void initialize_gdscript_module(ModuleInitializationLevel p_level) {
 		EditorTranslationParser::get_singleton()->add_parser(gdscript_translation_parser_plugin, EditorTranslationParser::STANDARD);
 	} else if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
 		GDREGISTER_CLASS(GDScriptSyntaxHighlighter);
+#ifndef GDSCRIPT_NO_LSP
+		register_lsp_types();
+		memnew(GDScriptLanguageProtocol);
+		EditorPlugins::add_by_type<GDScriptLanguageServer>();
+#endif // !GDSCRIPT_NO_LSP
 	}
 #endif // TOOLS_ENABLED
 }
@@ -193,6 +197,9 @@ void uninitialize_gdscript_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
 		EditorTranslationParser::get_singleton()->remove_parser(gdscript_translation_parser_plugin, EditorTranslationParser::STANDARD);
 		gdscript_translation_parser_plugin.unref();
+#ifndef GDSCRIPT_NO_LSP
+		memdelete(GDScriptLanguageProtocol::get_singleton());
+#endif // GDSCRIPT_NO_LSP
 	}
 #endif // TOOLS_ENABLED
 }

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -101,6 +101,8 @@ GDScriptLanguageProtocol *initialize(const String &p_root) {
 	String absolute_root = dir->get_current_dir();
 	init_language(absolute_root);
 
+	// Recreate the singleton for each test, to ensure a clean state.
+	memdelete_notnull(GDScriptLanguageProtocol::get_singleton());
 	GDScriptLanguageProtocol *proto = memnew(GDScriptLanguageProtocol);
 	TestGDScriptLanguageProtocolInitializer::setup_client();
 
@@ -492,7 +494,6 @@ func f():
 			test_resolve_symbols(uri, all_test_data, all_test_data);
 		}
 
-		memdelete(proto);
 		memdelete(efs);
 		finish_language();
 	}
@@ -531,7 +532,6 @@ func f():
 			REQUIRE(cls.documentation.contains("t3"));
 		}
 
-		memdelete(proto);
 		memdelete(efs);
 		finish_language();
 	}


### PR DESCRIPTION
~Fixes (not anymore) https://github.com/godotengine/godot/issues/52162~
~Fixes (not anymore) https://github.com/godotengine/godot/issues/86132~

The LSP types were not added at the right time, so they were not picked up at some places e.g. by the doctools (internal documentation recognized them though).

This PR binds them at the correct time to get picked up by the doc tools. The classes are now marked as experimental, the amount of internals that is exposed makes implementation of new LSP features while keeping behavior of all those methods infeasible.

In addition this PR marks some methods as deprecated:
- Methods that have the primary purpose of interacting with connected clients: The LSP is not meant to be extendable and usage of those methods isn't possible in a meaningful way, since there is no way to actually obtain information about the connected clients
- Methods that directly implement an LSP endpoint: Those had to be exposed due to how JSONRPC functioned before #104890 . They are not save to access as public API though for two reasons:
    1. They expect to be communicating with an compliant LSP client, so users would have to ensure to follow the LSP lifecycle when using those, it's unlikely that they will.
    2. Some of those methods rely on context from the networking code (which peer is processed at the moment). When accessing those methods not through the networking code this context isn't set correctly, which could lead to incorrect behavior.
