### PR TITLE
Optimize `ClassDB::get_inheriters_from_class`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1437,8 +1437,8 @@ PackedStringArray ClassDB::get_class_list() const {
 }
 
 PackedStringArray ClassDB::get_inheriters_from_class(const StringName &p_class) const {
-	List<StringName> classes;
-	::ClassDB::get_inheriters_from_class(p_class, &classes);
+	LocalVector<StringName> classes;
+	::ClassDB::get_inheriters_from_class(p_class, classes);
 
 	PackedStringArray ret;
 	ret.resize(classes.size());

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -281,12 +281,12 @@ void ClassDB::get_extension_class_list(const Ref<GDExtension> &p_extension, List
 }
 #endif
 
-void ClassDB::get_inheriters_from_class(const StringName &p_class, List<StringName> *p_classes) {
+void ClassDB::get_inheriters_from_class(const StringName &p_class, LocalVector<StringName> &p_classes) {
 	Locker::Lock lock(Locker::STATE_READ);
 
 	for (const KeyValue<StringName, ClassInfo> &E : classes) {
 		if (E.key != p_class && _is_parent_class(E.key, p_class)) {
-			p_classes->push_back(E.key);
+			p_classes.push_back(E.key);
 		}
 	}
 }

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -315,7 +315,7 @@ public:
 	static void get_extension_class_list(const Ref<GDExtension> &p_extension, List<StringName> *p_classes);
 	static ObjectGDExtension *get_placeholder_extension(const StringName &p_class);
 #endif
-	static void get_inheriters_from_class(const StringName &p_class, List<StringName> *p_classes);
+	static void get_inheriters_from_class(const StringName &p_class, LocalVector<StringName> &p_classes);
 	static void get_direct_inheriters_from_class(const StringName &p_class, List<StringName> *p_classes);
 	static StringName get_parent_class_nocheck(const StringName &p_class);
 	static bool get_inheritance_chain_nocheck(const StringName &p_class, Vector<StringName> &r_result);

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -974,8 +974,8 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	effect_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED); // Don't translate class names.
 	effect_options->connect("index_pressed", callable_mp(this, &EditorAudioBus::_effect_add));
 	add_child(effect_options);
-	List<StringName> effect_list;
-	ClassDB::get_inheriters_from_class("AudioEffect", &effect_list);
+	LocalVector<StringName> effect_list;
+	ClassDB::get_inheriters_from_class("AudioEffect", effect_list);
 	effect_list.sort_custom<StringName::AlphCompare>();
 	for (const StringName &E : effect_list) {
 		if (!ClassDB::can_instantiate(E) || ClassDB::is_virtual(E)) {

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -607,8 +607,8 @@ static void _add_allowed_type(const StringName &p_type, List<StringName> *p_vect
 			p_vector->push_back(p_type);
 		}
 
-		List<StringName> inheriters;
-		ClassDB::get_inheriters_from_class(p_type, &inheriters);
+		LocalVector<StringName> inheriters;
+		ClassDB::get_inheriters_from_class(p_type, inheriters);
 		for (const StringName &S : inheriters) {
 			_add_allowed_type(S, p_vector);
 		}

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1531,8 +1531,8 @@ ProjectExportDialog::ProjectExportDialog() {
 	resources_vb->add_child(server_strip_message);
 
 	{
-		List<StringName> resource_names;
-		ClassDB::get_inheriters_from_class("Resource", &resource_names);
+		LocalVector<StringName> resource_names;
+		ClassDB::get_inheriters_from_class("Resource", resource_names);
 
 		PackedStringArray strippable;
 		for (const StringName &resource_name : resource_names) {

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1839,7 +1839,7 @@ Variant SceneTreeEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from
 }
 
 bool SceneTreeEditor::_is_script_type(const StringName &p_type) const {
-	return (script_types->find(p_type));
+	return (script_types->has(p_type));
 }
 
 bool SceneTreeEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
@@ -2144,8 +2144,8 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	ask_before_revoke_checkbox->set_tooltip_text(TTR("This dialog can also be enabled/disabled in the Editor Settings: Docks > Scene Tree > Ask Before Revoking Unique Name."));
 	vb->add_child(ask_before_revoke_checkbox);
 
-	script_types = memnew(List<StringName>);
-	ClassDB::get_inheriters_from_class("Script", script_types);
+	script_types = memnew(LocalVector<StringName>);
+	ClassDB::get_inheriters_from_class("Script", *script_types);
 }
 
 SceneTreeEditor::~SceneTreeEditor() {

--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -212,7 +212,7 @@ class SceneTreeEditor : public Control {
 
 	Timer *update_timer = nullptr;
 
-	List<StringName> *script_types;
+	LocalVector<StringName> *script_types;
 	bool _is_script_type(const StringName &p_type) const;
 
 	Vector<StringName> valid_types;

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -76,8 +76,8 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 			animations_menu->clear();
 			animations_to_add.clear();
 
-			List<StringName> classes;
-			ClassDB::get_inheriters_from_class("AnimationRootNode", &classes);
+			LocalVector<StringName> classes;
+			ClassDB::get_inheriters_from_class("AnimationRootNode", classes);
 			classes.sort_custom<StringName::AlphCompare>();
 
 			menu->add_submenu_node_item(TTR("Add Animation"), animations_menu);

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -119,10 +119,10 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 			menu->clear(false);
 			animations_menu->clear();
 			animations_to_add.clear();
-			List<StringName> classes;
+			LocalVector<StringName> classes;
 			classes.sort_custom<StringName::AlphCompare>();
 
-			ClassDB::get_inheriters_from_class("AnimationRootNode", &classes);
+			ClassDB::get_inheriters_from_class("AnimationRootNode", classes);
 			menu->add_submenu_node_item(TTR("Add Animation"), animations_menu);
 
 			List<StringName> names;

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -631,8 +631,8 @@ void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 		}
 	}
 
-	List<StringName> classes;
-	ClassDB::get_inheriters_from_class("AnimationRootNode", &classes);
+	LocalVector<StringName> classes;
+	ClassDB::get_inheriters_from_class("AnimationRootNode", classes);
 	classes.sort_custom<StringName::AlphCompare>();
 
 	for (const StringName &class_name : classes) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -921,8 +921,8 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 		node.insert_text = node.display.quote(p_quote_style);
 		r_result.insert(node.display, node);
 
-		List<StringName> native_classes;
-		ClassDB::get_inheriters_from_class("Node", &native_classes);
+		LocalVector<StringName> native_classes;
+		ClassDB::get_inheriters_from_class("Node", native_classes);
 		for (const StringName &E : native_classes) {
 			if (!ClassDB::is_class_exposed(E)) {
 				continue;


### PR DESCRIPTION
This method is exposed to gdscript so I benchmark it. Result shows it is heavily bottlenecked by `List` construction/destruction, so I replace it with `LocalVector`.

Test Script:
```GDScript
extends Node2D

func _process(delta: float) -> void:
	for i in range(150):
		ClassDB.get_inheriters_from_class("Object")
```

Master:
FPS: 43~44
![master](https://github.com/user-attachments/assets/fc952186-822b-42f3-920d-1272be7b95ff)

This PR:
FPS: 92~93
![pr](https://github.com/user-attachments/assets/3444e5a8-8bbe-40e9-80d8-dfd56ac11632)
