### PR TITLE
SCons: Re-enable GCC warning `-Wnoexcept`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -898,17 +898,15 @@ else:  # GCC, Clang
             env.AppendUnique(
                 CCFLAGS=[
                     "-Walloc-zero",
+                    "-Wattribute-alias=2",
                     "-Wduplicated-branches",
                     "-Wduplicated-cond",
                     "-Wstringop-overflow=4",
                 ]
             )
             env.AppendUnique(CXXFLAGS=["-Wplacement-new=1", "-Wvirtual-inheritance"])
-            # Need to fix a warning with AudioServer lambdas before enabling.
-            # if cc_version_major != 9:  # GCC 9 had a regression (GH-36325).
-            #    env.Append(CXXFLAGS=["-Wnoexcept"])
-            if cc_version_major >= 9:
-                env.AppendUnique(CCFLAGS=["-Wattribute-alias=2"])
+            if cc_version_major > 9:  # Regression in GCC 9 (see GH-36325).
+                env.AppendUnique(CXXFLAGS=["-Wnoexcept"])
             if cc_version_major >= 11:  # Broke on MethodBind templates before GCC 11.
                 env.AppendUnique(CCFLAGS=["-Wlogical-op"])
         elif methods.using_clang(env) or methods.using_emcc(env):

--- a/core/templates/safe_list.h
+++ b/core/templates/safe_list.h
@@ -56,7 +56,7 @@ class SafeList {
 		// to the previous list item in time that was also logically deleted.
 		std::atomic<SafeListNode *> graveyard_next = nullptr;
 
-		std::function<void(T)> deletion_fn = [](T t) { return; };
+		std::function<void(T)> deletion_fn = [](T t) noexcept { return; };
 
 		T val;
 	};
@@ -147,7 +147,7 @@ public:
 
 	void erase(T p_value) {
 		Iterator tmp = find(p_value);
-		erase(tmp, [](T t) { return; });
+		erase(tmp, [](T t) noexcept { return; });
 	}
 
 	void erase(Iterator &p_iterator, std::function<void(T)> p_deletion_fn) {

--- a/modules/jolt_physics/spaces/jolt_body_accessor_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_body_accessor_3d.cpp
@@ -99,9 +99,9 @@ const JPH::BodyID *JoltBodyAccessor3D::get_ids() const {
 
 	return std::visit(
 			VariantVisitors{
-					[](const JPH::BodyID &p_id) { return &p_id; },
-					[](const JPH::BodyIDVector &p_vector) { return p_vector.data(); },
-					[](const BodyIDSpan &p_span) { return p_span.ptr; } },
+					[](const JPH::BodyID &p_id) noexcept { return &p_id; },
+					[](const JPH::BodyIDVector &p_vector) noexcept { return p_vector.data(); },
+					[](const BodyIDSpan &p_span) noexcept { return p_span.ptr; } },
 			ids);
 }
 
@@ -110,9 +110,9 @@ int JoltBodyAccessor3D::get_count() const {
 
 	return std::visit(
 			VariantVisitors{
-					[](const JPH::BodyID &p_id) { return 1; },
-					[](const JPH::BodyIDVector &p_vector) { return (int)p_vector.size(); },
-					[](const BodyIDSpan &p_span) { return p_span.count; } },
+					[](const JPH::BodyID &p_id) noexcept { return 1; },
+					[](const JPH::BodyIDVector &p_vector) noexcept { return (int)p_vector.size(); },
+					[](const BodyIDSpan &p_span) noexcept { return p_span.count; } },
 			ids);
 }
 

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1612,7 +1612,7 @@ void AudioServer::update() {
 	listener_changed_callback_list.maybe_cleanup();
 	playback_list.maybe_cleanup();
 	for (AudioStreamPlaybackBusDetails *bus_details : bus_details_graveyard_frame_old) {
-		bus_details_graveyard_frame_old.erase(bus_details, [](AudioStreamPlaybackBusDetails *d) { delete d; });
+		bus_details_graveyard_frame_old.erase(bus_details, [](AudioStreamPlaybackBusDetails *d) noexcept { delete d; });
 	}
 	for (AudioStreamPlaybackBusDetails *bus_details : bus_details_graveyard) {
 		bus_details_graveyard_frame_old.insert(bus_details);
@@ -1699,7 +1699,7 @@ void AudioServer::add_update_callback(AudioCallback p_callback, void *p_userdata
 void AudioServer::remove_update_callback(AudioCallback p_callback, void *p_userdata) {
 	for (CallbackItem *ci : update_callback_list) {
 		if (ci->callback == p_callback && ci->userdata == p_userdata) {
-			update_callback_list.erase(ci, [](CallbackItem *c) { delete c; });
+			update_callback_list.erase(ci, [](CallbackItem *c) noexcept { delete c; });
 		}
 	}
 }
@@ -1714,7 +1714,7 @@ void AudioServer::add_mix_callback(AudioCallback p_callback, void *p_userdata) {
 void AudioServer::remove_mix_callback(AudioCallback p_callback, void *p_userdata) {
 	for (CallbackItem *ci : mix_callback_list) {
 		if (ci->callback == p_callback && ci->userdata == p_userdata) {
-			mix_callback_list.erase(ci, [](CallbackItem *c) { delete c; });
+			mix_callback_list.erase(ci, [](CallbackItem *c) noexcept { delete c; });
 		}
 	}
 }
@@ -1729,7 +1729,7 @@ void AudioServer::add_listener_changed_callback(AudioCallback p_callback, void *
 void AudioServer::remove_listener_changed_callback(AudioCallback p_callback, void *p_userdata) {
 	for (CallbackItem *ci : listener_changed_callback_list) {
 		if (ci->callback == p_callback && ci->userdata == p_userdata) {
-			listener_changed_callback_list.erase(ci, [](CallbackItem *c) { delete c; });
+			listener_changed_callback_list.erase(ci, [](CallbackItem *c) noexcept { delete c; });
 		}
 	}
 }


### PR DESCRIPTION
Reimplements `-Wnoexcept` into the GCC `extra` warnings batch. However, I'm not certain if this is something we *want* added back as a warning, despite how easily it was reintegrated. What this seems to do is add additional checks for `noexcept` scenarios, but we've long since explicitly disabled exceptions across the repo, so it feels a bit redundant. I'm not opposed to adding `noexcept` to the relevant functions, but that's obviously WELL outside the scope of this PR.

The only other change was moving `-Wattribute-alias=2` to the main GCC `CCFLAGS`, as its conditional would always evaluate to "true".