### PR TITLE
Fix editing custom data for tilesets

### DIFF
--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -6952,6 +6952,16 @@ bool TileData::_get(const StringName &p_name, Variant &r_ret) const {
 			}
 		}
 #endif // NAVIGATION_2D_DISABLED
+		else if (components.size() == 1 && components[0].begins_with("custom_data_") && components[0].trim_prefix("custom_data_").is_valid_int()) {
+			// Custom data layers.
+			int layer_index = components[0].trim_prefix("custom_data_").to_int();
+			ERR_FAIL_COND_V(layer_index < 0, false);
+			if (layer_index >= custom_data.size()) {
+				return false;
+			}
+			r_ret = get_custom_data_by_layer_id(layer_index);
+			return true;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105022

Looks like an "else if" was accidentally left out in https://github.com/godotengine/godot/pull/104811