### PR TITLE
CI: Remove "Free disk space on runner" job (REVERTED)

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -115,12 +115,6 @@ jobs:
         run: |
           sudo apt-get install libwayland-bin
 
-      - name: Free disk space on runner
-        run: |
-          echo "Disk usage before:" && df -h
-          sudo rm -rf /usr/local/lib/android
-          echo "Disk usage after:" && df -h
-
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore
         with:


### PR DESCRIPTION
With the improvements that've been made to the way that caches are saved, such that they can no longer approach the multiple GiB of space they once did, the step freeing disk space is no longer relevant. The amount of time it eats up is largely negligible, but if it ultimately serves no purpose anymore then it still warrants removal. To verify, of the current 1169 cached instances in our repo (feels like a lot?), the absolute max size one reached is 664.96 MiB, not even two-thirds of the way to one gibibyte.