### PR TITLE
Core: Decouple `GDCLASS` from `ClassDB`

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -840,7 +840,7 @@ use_script:
 	return scr.is_valid() && scr->is_valid() && scr->is_abstract();
 }
 
-void ClassDB::_add_class2(const StringName &p_class, const StringName &p_inherits) {
+void ClassDB::_add_class(const StringName &p_class, const StringName &p_inherits) {
 	Locker::Lock lock(Locker::STATE_WRITE);
 
 	const StringName &name = p_class;

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -78,6 +78,8 @@ MethodDefinition D_METHOD(const char *p_name, const VarArgs... p_args) {
 #endif
 
 class ClassDB {
+	friend class Object;
+
 public:
 	enum APIType {
 		API_CORE,
@@ -193,7 +195,7 @@ public:
 	static APIType current_api;
 	static HashMap<APIType, uint32_t> api_hashes_cache;
 
-	static void _add_class2(const StringName &p_class, const StringName &p_inherits);
+	static void _add_class(const StringName &p_class, const StringName &p_inherits);
 
 	static HashMap<StringName, HashMap<StringName, Variant>> default_values;
 	static HashSet<StringName> default_values_cached;
@@ -221,12 +223,6 @@ private:
 	static bool _can_instantiate(ClassInfo *p_class_info, bool p_exposed_only = true);
 
 public:
-	// DO NOT USE THIS!!!!!! NEEDS TO BE PUBLIC BUT DO NOT USE NO MATTER WHAT!!!
-	template <typename T>
-	static void _add_class() {
-		_add_class2(T::get_class_static(), T::get_parent_class_static());
-	}
-
 	template <typename T>
 	static void register_class(bool p_virtual = false) {
 		Locker::Lock lock(Locker::STATE_WRITE);

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1590,7 +1590,7 @@ void Object::initialize_class() {
 	if (initialized) {
 		return;
 	}
-	ClassDB::_add_class<Object>();
+	_add_class_to_classdb(get_class_static(), get_parent_class_static());
 	_bind_methods();
 	_bind_compatibility_methods();
 	initialized = true;
@@ -1664,6 +1664,14 @@ void Object::_clear_internal_resource_paths(const Variant &p_var) {
 		default: {
 		}
 	}
+}
+
+void Object::_add_class_to_classdb(const StringName &p_class, const StringName &p_inherits) {
+	ClassDB::_add_class(p_class, p_inherits);
+}
+
+void Object::_get_property_list_from_classdb(const StringName &p_class, List<PropertyInfo> *p_list, bool p_no_inheritance, const Object *p_validator) {
+	ClassDB::get_property_list(p_class, p_list, p_no_inheritance, p_validator);
 }
 
 #ifdef TOOLS_ENABLED

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -454,7 +454,7 @@ public:                                                                         
 			return;                                                                                                                         \
 		}                                                                                                                                   \
 		m_inherits::initialize_class();                                                                                                     \
-		::ClassDB::_add_class<m_class>();                                                                                                   \
+		_add_class_to_classdb(get_class_static(), get_parent_class_static());                                                               \
 		if (m_class::_get_bind_methods() != m_inherits::_get_bind_methods()) {                                                              \
 			_bind_methods();                                                                                                                \
 		}                                                                                                                                   \
@@ -499,7 +499,7 @@ protected:                                                                      
 			m_inherits::_get_property_listv(p_list, p_reversed);                                                                            \
 		}                                                                                                                                   \
 		p_list->push_back(PropertyInfo(Variant::NIL, get_class_static(), PROPERTY_HINT_NONE, get_class_static(), PROPERTY_USAGE_CATEGORY)); \
-		::ClassDB::get_property_list(#m_class, p_list, true, this);                                                                         \
+		_get_property_list_from_classdb(#m_class, p_list, true, this);                                                                      \
 		if (m_class::_get_get_property_list() != m_inherits::_get_get_property_list()) {                                                    \
 			_get_property_list(p_list);                                                                                                     \
 		}                                                                                                                                   \
@@ -758,6 +758,9 @@ protected:
 
 	friend class ClassDB;
 	friend class PlaceholderExtensionInstance;
+
+	static void _add_class_to_classdb(const StringName &p_class, const StringName &p_inherits);
+	static void _get_property_list_from_classdb(const StringName &p_class, List<PropertyInfo> *p_list, bool p_no_inheritance, const Object *p_validator);
 
 	bool _disconnect(const StringName &p_signal, const Callable &p_callable, bool p_force = false);
 


### PR DESCRIPTION
After bringing up my interest in decoupling `GDCLASS` from `ClassDB` in [this proposal](https://github.com/godotengine/godot-proposals/issues/12155#issuecomment-2779512035), I got curious and checked just how easily that could be integrated as-is. Turns out… Surprisingly easy! It's not a full decoupling of `ClassDB` from `Object`, which is the real endgoal, but decoupling just `GDCLASS` is enough to make `core/object/class_db.h` no longer a 100% required include for all `Object` subclass headers.