### PR TITLE
Move `GD_IS_CLASS_ENABLED` and respective include from `class_db.h` to `object.h`, as this is where it's needed.

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -587,7 +587,3 @@ _FORCE_INLINE_ Vector<Error> errarray(P... p_args) {
 	}
 
 #define GDREGISTER_NATIVE_STRUCT(m_class, m_code) ClassDB::register_native_struct(#m_class, m_code, sizeof(m_class))
-
-#define GD_IS_CLASS_ENABLED(m_class) m_class::_class_is_enabled
-
-#include "core/disabled_classes.gen.h"

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/disabled_classes.gen.h"
 #include "core/extension/gdextension_interface.h"
 #include "core/object/message_queue.h"
 #include "core/object/object_id.h"
@@ -130,6 +131,9 @@ enum PropertyUsageFlags {
 	PROPERTY_USAGE_DEFAULT = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR,
 	PROPERTY_USAGE_NO_EDITOR = PROPERTY_USAGE_STORAGE,
 };
+
+// Respective values are defined by disabled_classes.gen.h
+#define GD_IS_CLASS_ENABLED(m_class) m_class::_class_is_enabled
 
 #define ADD_SIGNAL(m_signal) ::ClassDB::add_signal(get_class_static(), m_signal)
 #define ADD_PROPERTY(m_property, m_setter, m_getter) ::ClassDB::add_property(get_class_static(), m_property, _scs_create(m_setter), _scs_create(m_getter))


### PR DESCRIPTION
Small addendum to https://github.com/godotengine/godot/pull/105028.

If we're trying to move `Object` away from `ClassDB`, we should make sure that foregoing includes doesn't accidentally break disabled classes.
The include should have been in `object.h` from the start, as this is where it's used.