### PR TITLE
Fix EditorSpinSlider Grabber Scaling

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -435,10 +435,8 @@ void EditorSpinSlider::_draw_spin_slider() {
 					grabber->set_texture(grabber_tex);
 				}
 
-				Vector2 scale = get_global_transform_with_canvas().get_scale();
-				grabber->set_scale(scale);
 				grabber->reset_size();
-				grabber->set_position((grabber_rect.get_center() - grabber->get_size() * 0.5) * scale);
+				grabber->set_position(grabber_rect.get_center() - grabber->get_size() * 0.5);
 
 				if (mousewheel_over_grabber) {
 					Input::get_singleton()->warp_mouse(grabber->get_position() + grabber_rect.size);


### PR DESCRIPTION
Fixes #105010.

The scaling was applied previously because the grabber had `set_as_top_level(true)`, and so needed to be scaled separately to the EditorSpinSlider. As #97946 changed this behavior, the incorrect scaling behavior resurfaced. This PR removes the manual scaling, because the grabber is now scaled alongside the rest of the node.