### PR TITLE
Expose `Viewport::is_camera_3d_override_enabled` method to GDScript

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -199,6 +199,12 @@
 				Sets the drag data human-readable description.
 			</description>
 		</method>
+		<method name="is_camera_3d_override_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the user activated a camera override mode at the Game tab.
+			</description>
+		</method>
 		<method name="is_input_handled" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -5077,6 +5077,7 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_audio_listener_3d"), &Viewport::get_audio_listener_3d);
 	ClassDB::bind_method(D_METHOD("get_camera_3d"), &Viewport::get_camera_3d);
+	ClassDB::bind_method(D_METHOD("is_camera_3d_override_enabled"), &Viewport::is_camera_3d_override_enabled);
 	ClassDB::bind_method(D_METHOD("set_as_audio_listener_3d", "enable"), &Viewport::set_as_audio_listener_3d);
 	ClassDB::bind_method(D_METHOD("is_audio_listener_3d"), &Viewport::is_audio_listener_3d);
 


### PR DESCRIPTION
To properly close a proposal: https://github.com/godotengine/godot-proposals/issues/11616.