### PR TITLE
Fix differences between PhysicsDirectSpaceState2D/3D docs

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -33,14 +33,14 @@
 			<return type="Dictionary" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters2D" />
 			<description>
-				Checks the intersections of a shape, given through a [PhysicsShapeQueryParameters2D] object, against the space. If it collides with more than one shape, the nearest one is selected. If the shape did not intersect anything, then an empty dictionary is returned instead.
-				[b]Note:[/b] This method does not take into account the [code]motion[/code] property of the object. The returned object is a dictionary containing the following fields:
+				Checks the intersections of a shape, given through a [PhysicsShapeQueryParameters2D] object, against the space. If it collides with more than one shape, the nearest one is selected. The returned object is a dictionary containing the following fields:
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]linear_velocity[/code]: The colliding object's velocity [Vector2]. If the object is an [Area2D], the result is [code](0, 0)[/code].
 				[code]normal[/code]: The collision normal of the query shape at the intersection point, pointing away from the intersecting object.
 				[code]point[/code]: The intersection point.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
+				If the shape did not intersect anything, then an empty dictionary is returned instead.
 			</description>
 		</method>
 		<method name="intersect_point">

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -15,7 +15,7 @@
 			<return type="PackedFloat32Array" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters3D" />
 			<description>
-				Checks how far a [Shape3D] can move without colliding. All the parameters for the query, including the shape, are supplied through a [PhysicsShapeQueryParameters3D] object.
+				Checks how far a [Shape3D] can move without colliding. All the parameters for the query, including the shape and the motion, are supplied through a [PhysicsShapeQueryParameters3D] object.
 				Returns an array with the safe and unsafe proportions (between 0 and 1) of the motion. The safe proportion is the maximum fraction of the motion that can be made without a collision. The unsafe proportion is the minimum fraction of the distance that must be moved for a collision. If no collision is detected a result of [code][1.0, 1.0][/code] will be returned.
 				[b]Note:[/b] Any [Shape3D]s that the shape is already colliding with e.g. inside of, will be ignored. Use [method collide_shape] to determine the [Shape3D]s that the shape is already colliding with.
 			</description>


### PR DESCRIPTION
Similar to https://github.com/godotengine/godot/pull/105048 and https://github.com/godotengine/godot/pull/104354

This PR addresses differences between the documentation of **PhysicsDirectSpaceState2D** and **PhysicsDirectSpaceState3D** (within reason).

This comes with the goal not only making the two consistent, but also reducing the overall amount of strings to localize.