### PR TITLE
Fix typo in Window's `exclude_from_capture`

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -2180,9 +2180,9 @@
 			[b]Note:[/b] This flag is implemented only on Windows (11).
 		</constant>
 		<constant name="WINDOW_FLAG_EXCLUDE_FROM_CAPTURE" value="9" enum="WindowFlags">
-			Windows is excluded from screenshots taken by [method screen_get_image], [method screen_get_image_rect], and [method screen_get_pixel].
+			Window is excluded from screenshots taken by [method screen_get_image], [method screen_get_image_rect], and [method screen_get_pixel].
 			[b]Note:[/b] This flag is implemented on macOS and Windows.
-			[b]Note:[/b] Setting this flag will [b]NOT[/b] prevent other apps from capturing an image, it should not be used as a security measure.
+			[b]Note:[/b] Setting this flag will [b]NOT[/b] prevent other apps from capturing an image. It should not be used as a security measure.
 		</constant>
 		<constant name="WINDOW_FLAG_POPUP_WM_HINT" value="10" enum="WindowFlags">
 			Signals the window manager that this window is supposed to be an implementation-defined "popup" (usually a floating, borderless, untileable and immovable child window).

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -600,7 +600,9 @@
 			The screen the window is currently on.
 		</member>
 		<member name="exclude_from_capture" type="bool" setter="set_flag" getter="get_flag" default="false">
-			Windows is excluded from screenshots taken by [method DisplayServer.screen_get_image], [method DisplayServer.screen_get_image_rect], and [method DisplayServer.screen_get_pixel].
+			If [code]true[/code], the [Window] is excluded from screenshots taken by [method DisplayServer.screen_get_image], [method DisplayServer.screen_get_image_rect], and [method DisplayServer.screen_get_pixel].
+			[b]Note:[/b] This property is implemented on macOS and Windows.
+			[b]Note:[/b] Enabling this setting does [b]NOT[/b] prevent other apps from capturing an image. It should not be used as a security measure.
 		</member>
 		<member name="exclusive" type="bool" setter="set_exclusive" getter="is_exclusive" default="false">
 			If [code]true[/code], the [Window] will be in exclusive mode. Exclusive windows are always on top of their parent and will block all input going to the parent [Window].


### PR DESCRIPTION
What the title says. It also ports of over the additional notes from its corresponding **WINDOW_FLAG_EXCLUDE_FROM_CAPTURE** constant.

CC @bruvzg 