### PR TITLE
Fix selected particles memory access violation in `Particles2DEditorPlugin`

### DIFF
--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -298,6 +298,10 @@ void Particles2DEditorPlugin::_selection_changed() {
 	}
 
 	for (Node *particles : selected_particles) {
+		if (!particles->is_inside_tree()) {
+			continue;
+		}
+
 		if (GPUParticles2D *gpu_particles = Object::cast_to<GPUParticles2D>(particles)) {
 			gpu_particles->set_show_gizmos(false);
 		} else if (CPUParticles2D *cpu_particles = Object::cast_to<CPUParticles2D>(particles)) {


### PR DESCRIPTION
Fixes #104994 

This Issue happens because `selected_particles`'s Pointers point to Nodes of a scene that was removed (due to closing the scene in editor). So the Cast call causes a Sigsegv.
I think this is fine since `selected_particles` is cleared anyways, so the Pointers to the removed Nodes are taken care of.