### PR TITLE
LSP: Don't advertise support for workspace symbols

### DIFF
--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1752,7 +1752,7 @@ struct ServerCapabilities {
 	/**
 	 * The server provides workspace symbol support.
 	 */
-	bool workspaceSymbolProvider = true;
+	bool workspaceSymbolProvider = false;
 
 	/**
 	 * The server supports workspace folder.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-vscode-plugin/issues/697
Fixes https://github.com/godotengine/godot-vscode-plugin/issues/701
Fixes maybe https://github.com/godotengine/godot-vscode-plugin/issues/751

We don't implement workspace symbol support, but told clients we did. No wonder they try to use it.