### PR TITLE
Fix minimize button not being disabled on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2331,10 +2331,10 @@ void DisplayServerWindows::_get_window_style(bool p_main_window, bool p_initiali
 			r_style |= WS_MAXIMIZE;
 		}
 		if (!p_fullscreen) {
-			r_style |= WS_SYSMENU | WS_MINIMIZEBOX;
+			r_style |= WS_SYSMENU;
 
 			if (p_resizable) {
-				r_style |= WS_MAXIMIZEBOX;
+				r_style |= WS_MAXIMIZEBOX | WS_MINIMIZEBOX;
 			}
 		}
 	} else {
@@ -2348,9 +2348,9 @@ void DisplayServerWindows::_get_window_style(bool p_main_window, bool p_initiali
 			}
 		} else {
 			if (p_minimized) {
-				r_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MINIMIZE;
+				r_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZE;
 			} else {
-				r_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
+				r_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU;
 			}
 		}
 	}


### PR DESCRIPTION
`unresizable` flag is supposed to hide window's minimize button. I don't know how it's on other systems, but it doesn't do it on Windows.

Before fix:
![image](https://github.com/user-attachments/assets/6dab1dac-4093-4a5b-80eb-fc868e4f3de5)

After fix:
![image](https://github.com/user-attachments/assets/e338cc89-6447-4927-9673-c001600c0104)

btw this is how most dialogs should look. They shouldn't have minimize and maximize buttons.