### PR TITLE
Move NavigationServer navmesh sync from `main()` to `process()`

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4602,13 +4602,6 @@ bool Main::iteration() {
 	XRServer::get_singleton()->_process();
 #endif // XR_DISABLED
 
-#ifndef NAVIGATION_2D_DISABLED
-	NavigationServer2D::get_singleton()->sync();
-#endif // NAVIGATION_2D_DISABLED
-#ifndef NAVIGATION_3D_DISABLED
-	NavigationServer3D::get_singleton()->sync();
-#endif // NAVIGATION_3D_DISABLED
-
 	for (int iters = 0; iters < advance.physics_steps; ++iters) {
 		if (Input::get_singleton()->is_agile_input_event_flushing()) {
 			Input::get_singleton()->flush_buffered_events();

--- a/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
@@ -1262,6 +1262,8 @@ void GodotNavigationServer2D::process(double p_delta_time) {
 	// Will run reliably every rendered frame independent of the physics tick rate.
 	// Use for things that (only) need to update once per main loop iteration and rendered frame or is visible to the user.
 	// E.g. (final) sync of objects for this main loop iteration, updating rendered debug visuals, updating debug statistics, ...
+
+	sync();
 }
 
 void GodotNavigationServer2D::physics_process(double p_delta_time) {

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
@@ -1343,6 +1343,8 @@ void GodotNavigationServer3D::process(double p_delta_time) {
 	// Will run reliably every rendered frame independent of the physics tick rate.
 	// Use for things that (only) need to update once per main loop iteration and rendered frame or is visible to the user.
 	// E.g. (final) sync of objects for this main loop iteration, updating rendered debug visuals, updating debug statistics, ...
+
+	sync();
 }
 
 void GodotNavigationServer3D::physics_process(double p_delta_time) {


### PR DESCRIPTION
Moves NavigationServer navmesh sync from main() to process().

Before the dedicated NavigationServer `sync()` function was used to sync the thread baked navmeshes with the main loop.

It was done in the main loop before the physics step loop because the sync inside the physics process was too unreliable with its inconsistent loop timing.

With the server now having its dedicated `process()` function we do not really need to call the sync() function outside in the main loop and can just merge the two together cleaning main up a little again.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
