### PR TITLE
Make navigation maps emit `map_changed` directly

### DIFF
--- a/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
@@ -293,13 +293,11 @@ COMMAND_2(map_set_active, RID, p_map, bool, p_active) {
 	if (p_active) {
 		if (!map_is_active(p_map)) {
 			active_maps.push_back(map);
-			active_maps_iteration_id.push_back(map->get_iteration_id());
 		}
 	} else {
 		int map_index = active_maps.find(map);
 		ERR_FAIL_COND(map_index < 0);
 		active_maps.remove_at(map_index);
-		active_maps_iteration_id.remove_at(map_index);
 	}
 }
 
@@ -1192,7 +1190,6 @@ COMMAND_1(free, RID, p_object) {
 		int map_index = active_maps.find(map);
 		if (map_index >= 0) {
 			active_maps.remove_at(map_index);
-			active_maps_iteration_id.remove_at(map_index);
 		}
 		map_owner.free(p_object);
 
@@ -1288,8 +1285,6 @@ void GodotNavigationServer2D::physics_process(double p_delta_time) {
 	int _new_pm_edge_free_count = 0;
 	int _new_pm_obstacle_count = 0;
 
-	// In c++ we can't be sure that this is performed in the main thread
-	// even with mutable functions.
 	MutexLock lock(operations_mutex);
 	for (uint32_t i(0); i < active_maps.size(); i++) {
 		active_maps[i]->sync();
@@ -1305,13 +1300,6 @@ void GodotNavigationServer2D::physics_process(double p_delta_time) {
 		_new_pm_edge_connection_count += active_maps[i]->get_pm_edge_connection_count();
 		_new_pm_edge_free_count += active_maps[i]->get_pm_edge_free_count();
 		_new_pm_obstacle_count += active_maps[i]->get_pm_obstacle_count();
-
-		// Emit a signal if a map changed.
-		const uint32_t new_map_iteration_id = active_maps[i]->get_iteration_id();
-		if (new_map_iteration_id != active_maps_iteration_id[i]) {
-			emit_signal(SNAME("map_changed"), active_maps[i]->get_self());
-			active_maps_iteration_id[i] = new_map_iteration_id;
-		}
 	}
 
 	pm_region_count = _new_pm_region_count;

--- a/modules/navigation_2d/2d/godot_navigation_server_2d.h
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.h
@@ -84,7 +84,6 @@ class GodotNavigationServer2D : public NavigationServer2D {
 
 	bool active = true;
 	LocalVector<NavMap2D *> active_maps;
-	LocalVector<uint32_t> active_maps_iteration_id;
 
 #ifdef CLIPPER2_ENABLED
 	NavMeshGenerator2D *navmesh_generator_2d = nullptr;

--- a/modules/navigation_2d/nav_map_2d.cpp
+++ b/modules/navigation_2d/nav_map_2d.cpp
@@ -40,6 +40,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/worker_thread_pool.h"
+#include "servers/navigation_server_2d.h"
 
 #include <Obstacle2d.h>
 
@@ -418,6 +419,8 @@ void NavMap2D::sync() {
 	}
 	if (iteration_ready) {
 		_sync_iteration();
+
+		NavigationServer2D::get_singleton()->emit_signal(SNAME("map_changed"), get_self());
 	}
 
 	map_settings_dirty = false;

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
@@ -120,13 +120,11 @@ COMMAND_2(map_set_active, RID, p_map, bool, p_active) {
 	if (p_active) {
 		if (!map_is_active(p_map)) {
 			active_maps.push_back(map);
-			active_maps_iteration_id.push_back(map->get_iteration_id());
 		}
 	} else {
 		int map_index = active_maps.find(map);
 		ERR_FAIL_COND(map_index < 0);
 		active_maps.remove_at(map_index);
-		active_maps_iteration_id.remove_at(map_index);
 	}
 }
 
@@ -1224,7 +1222,6 @@ COMMAND_1(free, RID, p_object) {
 		int map_index = active_maps.find(map);
 		if (map_index >= 0) {
 			active_maps.remove_at(map_index);
-			active_maps_iteration_id.remove_at(map_index);
 		}
 		map_owner.free(p_object);
 
@@ -1369,8 +1366,6 @@ void GodotNavigationServer3D::physics_process(double p_delta_time) {
 	int _new_pm_edge_free_count = 0;
 	int _new_pm_obstacle_count = 0;
 
-	// In c++ we can't be sure that this is performed in the main thread
-	// even with mutable functions.
 	MutexLock lock(operations_mutex);
 	for (uint32_t i(0); i < active_maps.size(); i++) {
 		active_maps[i]->sync();
@@ -1386,13 +1381,6 @@ void GodotNavigationServer3D::physics_process(double p_delta_time) {
 		_new_pm_edge_connection_count += active_maps[i]->get_pm_edge_connection_count();
 		_new_pm_edge_free_count += active_maps[i]->get_pm_edge_free_count();
 		_new_pm_obstacle_count += active_maps[i]->get_pm_obstacle_count();
-
-		// Emit a signal if a map changed.
-		const uint32_t new_map_iteration_id = active_maps[i]->get_iteration_id();
-		if (new_map_iteration_id != active_maps_iteration_id[i]) {
-			emit_signal(SNAME("map_changed"), active_maps[i]->get_self());
-			active_maps_iteration_id[i] = new_map_iteration_id;
-		}
 	}
 
 	pm_region_count = _new_pm_region_count;

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.h
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.h
@@ -79,7 +79,6 @@ class GodotNavigationServer3D : public NavigationServer3D {
 
 	bool active = true;
 	LocalVector<NavMap3D *> active_maps;
-	LocalVector<uint32_t> active_maps_iteration_id;
 
 	NavMeshGenerator3D *navmesh_generator_3d = nullptr;
 

--- a/modules/navigation_3d/nav_map_3d.cpp
+++ b/modules/navigation_3d/nav_map_3d.cpp
@@ -40,6 +40,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/worker_thread_pool.h"
+#include "servers/navigation_server_3d.h"
 
 #include <Obstacle2d.h>
 
@@ -474,6 +475,8 @@ void NavMap3D::sync() {
 	}
 	if (iteration_ready) {
 		_sync_iteration();
+
+		NavigationServer3D::get_singleton()->emit_signal(SNAME("map_changed"), get_self());
 	}
 
 	map_settings_dirty = false;


### PR DESCRIPTION
Makes navigation maps emit `map_changed` directly on their iteration sync.

There is no need to track all the active maps and their current iteration id in a separate `active_maps_iteration_id` LocalVector so it can be removed.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
