### PR TITLE
Fix OpenXR Action Map GUI not scaling according to Editor Scale

### DIFF
--- a/modules/openxr/editor/openxr_action_editor.cpp
+++ b/modules/openxr/editor/openxr_action_editor.cpp
@@ -31,6 +31,7 @@
 #include "openxr_action_editor.h"
 
 #include "editor/editor_string_names.h"
+#include "editor/themes/editor_scale.h"
 
 void OpenXRActionEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_do_set_name", "name"), &OpenXRActionEditor::_do_set_name);
@@ -134,14 +135,14 @@ OpenXRActionEditor::OpenXRActionEditor(Ref<OpenXRAction> p_action) {
 	action_name = memnew(LineEdit);
 	action_name->set_text(action->get_name());
 	action_name->set_tooltip_text(TTR("Internal name of the action. Some XR runtimes don't allow spaces or special characters."));
-	action_name->set_custom_minimum_size(Size2(150.0, 0.0));
+	action_name->set_custom_minimum_size(Size2(150.0 * EDSCALE, 0.0));
 	action_name->connect(SceneStringName(text_changed), callable_mp(this, &OpenXRActionEditor::_on_action_name_changed));
 	add_child(action_name);
 
 	action_localized_name = memnew(LineEdit);
 	action_localized_name->set_text(action->get_localized_name());
 	action_localized_name->set_tooltip_text(TTR("Human-readable name of the action. This can be displayed to end users."));
-	action_localized_name->set_custom_minimum_size(Size2(150.0, 0.0));
+	action_localized_name->set_custom_minimum_size(Size2(150.0 * EDSCALE, 0.0));
 	action_localized_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	action_localized_name->connect(SceneStringName(text_changed), callable_mp(this, &OpenXRActionEditor::_on_action_localized_name_changed));
 	add_child(action_localized_name);
@@ -154,7 +155,7 @@ OpenXRActionEditor::OpenXRActionEditor(Ref<OpenXRAction> p_action) {
 	action_type_button->add_item("Pose", OpenXRAction::OPENXR_ACTION_POSE);
 	action_type_button->add_item("Haptic", OpenXRAction::OPENXR_ACTION_HAPTIC);
 	action_type_button->select(int(action->get_action_type()));
-	action_type_button->set_custom_minimum_size(Size2(100.0, 0.0));
+	action_type_button->set_custom_minimum_size(Size2(100.0 * EDSCALE, 0.0));
 	action_type_button->connect(SceneStringName(item_selected), callable_mp(this, &OpenXRActionEditor::_on_item_selected));
 	add_child(action_type_button);
 

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -34,6 +34,7 @@
 #include "editor/editor_node.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/themes/editor_scale.h"
 
 HashMap<String, String> OpenXRActionMapEditor::interaction_profile_editors;
 HashMap<String, String> OpenXRActionMapEditor::binding_modifier_editors;
@@ -431,7 +432,7 @@ String OpenXRActionMapEditor::get_binding_modifier_editor_class(const String &p_
 
 OpenXRActionMapEditor::OpenXRActionMapEditor() {
 	undo_redo = EditorUndoRedoManager::get_singleton();
-	set_custom_minimum_size(Size2(0.0, 300.0));
+	set_custom_minimum_size(Size2(0.0, 300.0 * EDSCALE));
 
 	top_hb = memnew(HBoxContainer);
 	add_child(top_hb);

--- a/modules/openxr/editor/openxr_action_set_editor.cpp
+++ b/modules/openxr/editor/openxr_action_set_editor.cpp
@@ -31,6 +31,7 @@
 #include "openxr_action_set_editor.h"
 
 #include "editor/editor_string_names.h"
+#include "editor/themes/editor_scale.h"
 #include "openxr_action_editor.h"
 
 void OpenXRActionSetEditor::_bind_methods() {
@@ -244,14 +245,14 @@ OpenXRActionSetEditor::OpenXRActionSetEditor(Ref<OpenXRActionMap> p_action_map, 
 	action_set_name = memnew(LineEdit);
 	action_set_name->set_text(action_set->get_name());
 	action_set_name->set_tooltip_text(TTR("Internal name of the action. Some XR runtimes don't allow spaces or special characters."));
-	action_set_name->set_custom_minimum_size(Size2(150.0, 0.0));
+	action_set_name->set_custom_minimum_size(Size2(150.0 * EDSCALE, 0.0));
 	action_set_name->connect(SceneStringName(text_changed), callable_mp(this, &OpenXRActionSetEditor::_on_action_set_name_changed));
 	action_set_hb->add_child(action_set_name);
 
 	action_set_localized_name = memnew(LineEdit);
 	action_set_localized_name->set_text(action_set->get_localized_name());
 	action_set_localized_name->set_tooltip_text(TTR("Human-readable name of the action set. This can be displayed to end users."));
-	action_set_localized_name->set_custom_minimum_size(Size2(150.0, 0.0));
+	action_set_localized_name->set_custom_minimum_size(Size2(150.0 * EDSCALE, 0.0));
 	action_set_localized_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	action_set_localized_name->connect(SceneStringName(text_changed), callable_mp(this, &OpenXRActionSetEditor::_on_action_set_localized_name_changed));
 	action_set_hb->add_child(action_set_localized_name);
@@ -259,7 +260,7 @@ OpenXRActionSetEditor::OpenXRActionSetEditor(Ref<OpenXRActionMap> p_action_map, 
 	action_set_priority = memnew(TextEdit);
 	action_set_priority->set_text(itos(action_set->get_priority()));
 	action_set_priority->set_tooltip_text(TTR("Priority of the action set. If multiple action sets bind to the same input, the action set with the highest priority will be updated."));
-	action_set_priority->set_custom_minimum_size(Size2(50.0, 0.0));
+	action_set_priority->set_custom_minimum_size(Size2(50.0 * EDSCALE, 0.0));
 	action_set_priority->connect(SceneStringName(text_changed), callable_mp(this, &OpenXRActionSetEditor::_on_action_set_priority_changed));
 	action_set_hb->add_child(action_set_priority);
 

--- a/modules/openxr/editor/openxr_binding_modifiers_dialog.cpp
+++ b/modules/openxr/editor/openxr_binding_modifiers_dialog.cpp
@@ -32,6 +32,8 @@
 #include "../action_map/openxr_interaction_profile_metadata.h"
 #include "openxr_action_map_editor.h"
 
+#include "editor/themes/editor_scale.h"
+
 void OpenXRBindingModifiersDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_do_add_binding_modifier_editor", "binding_modifier_editor"), &OpenXRBindingModifiersDialog::_do_add_binding_modifier_editor);
 	ClassDB::bind_method(D_METHOD("_do_remove_binding_modifier_editor", "binding_modifier_editor"), &OpenXRBindingModifiersDialog::_do_remove_binding_modifier_editor);
@@ -191,7 +193,7 @@ OpenXRBindingModifiersDialog::OpenXRBindingModifiersDialog() {
 	set_transient(true);
 
 	binding_modifier_sc = memnew(ScrollContainer);
-	binding_modifier_sc->set_custom_minimum_size(Size2(350.0, 0.0));
+	binding_modifier_sc->set_custom_minimum_size(Size2(350.0 * EDSCALE, 0.0));
 	binding_modifier_sc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	binding_modifier_sc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	binding_modifier_sc->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);

--- a/modules/openxr/editor/openxr_select_action_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_action_dialog.cpp
@@ -30,6 +30,8 @@
 
 #include "openxr_select_action_dialog.h"
 
+#include "editor/themes/editor_scale.h"
+
 void OpenXRSelectActionDialog::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("action_selected", PropertyInfo(Variant::STRING, "action")));
 }
@@ -124,7 +126,7 @@ OpenXRSelectActionDialog::OpenXRSelectActionDialog(Ref<OpenXRActionMap> p_action
 	set_title(TTR("Select an action"));
 
 	scroll = memnew(ScrollContainer);
-	scroll->set_custom_minimum_size(Size2(600.0, 400.0));
+	scroll->set_custom_minimum_size(Size2(600.0 * EDSCALE, 400.0 * EDSCALE));
 	add_child(scroll);
 
 	main_vb = memnew(VBoxContainer);

--- a/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
@@ -33,6 +33,8 @@
 #include "../action_map/openxr_interaction_profile_metadata.h"
 #include "../openxr_api.h"
 
+#include "editor/themes/editor_scale.h"
+
 void OpenXRSelectInteractionProfileDialog::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("interaction_profile_selected", PropertyInfo(Variant::STRING, "interaction_profile")));
 }
@@ -116,7 +118,7 @@ OpenXRSelectInteractionProfileDialog::OpenXRSelectInteractionProfileDialog() {
 	set_title(TTR("Select an interaction profile"));
 
 	scroll = memnew(ScrollContainer);
-	scroll->set_custom_minimum_size(Size2(600.0, 400.0));
+	scroll->set_custom_minimum_size(Size2(600.0 * EDSCALE, 400.0 * EDSCALE));
 	add_child(scroll);
 
 	main_vb = memnew(VBoxContainer);


### PR DESCRIPTION
Currently, the minimum size of GUI items in the OpenXR module is constant. This means for devices with differing editor scales (`Godot -> Editor Settings -> Interface -> Editor -> Display Scale`) the GUI can be too small or too big, as the total number of pixels does not scale, but elements like the font do. This PR brings the OpenXR module in alignment with many of the other editor GUI elements by scaling the size of GUI elements according to the current `editor scale`.

Godot 4.4 (with 2x scale), note the cut-off text:
<img width="920" alt="Before the PR (2x scale)" src="https://github.com/user-attachments/assets/eb9a2864-b778-4cbd-9849-667185a427d4" />

This PR (with 2x scale):
<img width="926" alt="After the PR (2x scale)" src="https://github.com/user-attachments/assets/ef545396-9ff8-4d21-81d2-d8d3c17ef315" />