### PR TITLE
Fix miscellaneous oddities around the class reference (part 4)

### DIFF
--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -477,7 +477,15 @@
 		<method name="sort">
 			<return type="void" />
 			<description>
-				Sorts the dictionary in-place by key. This can be used to ensure dictionaries with the same contents produce equivalent results when getting the [method keys], getting the [method values], and converting to a string. This is also useful when wanting a JSON representation consistent with what is in memory, and useful for storing on a database that requires dictionaries to be sorted.
+				Sorts the dictionary in ascending order, by key. The final order is dependent on the "less than" ([code]&lt;[/code]) comparison between keys.
+				[codeblocks]
+				[gdscript]
+				var numbers = { "c": 2, "a": 0, "b": 1 }
+				numbers.sort()
+				print(numbers) # Prints { "a": 0, "b": 1, "c": 2 }
+				[/gdscript]
+				[/codeblocks]
+				This method ensures that the dictionary's entries are ordered consistently when [method keys] or [method values] are called, or when the dictionary needs to be converted to a string through [method @GlobalScope.str] or [method JSON.stringify].
 			</description>
 		</method>
 		<method name="values" qualifiers="const">

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -101,7 +101,7 @@
 			<return type="float" />
 			<description>
 				Returns the actual scale of the editor UI ([code]1.0[/code] being 100% scale). This can be used to adjust position and dimensions of the UI added by plugins.
-				[b]Note:[/b] This value is set via the [code]interface/editor/display_scale[/code] and [code]interface/editor/custom_display_scale[/code] editor settings. Editor must be restarted for changes to be properly applied.
+				[b]Note:[/b] This value is set via the [member EditorSettings.interface/editor/display_scale] and [member EditorSettings.interface/editor/custom_display_scale] settings. The editor must be restarted for changes to be properly applied.
 			</description>
 		</method>
 		<method name="get_editor_settings" qualifiers="const">

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -55,16 +55,16 @@
 			<return type="void" />
 			<param index="0" name="viewport_control" type="Control" />
 			<description>
-				Called by the engine when the 3D editor's viewport is updated. Use the [code]overlay[/code] [Control] for drawing. You can update the viewport manually by calling [method update_overlays].
+				Called by the engine when the 3D editor's viewport is updated. [param viewport_control] is an overlay on top of the viewport and it can be used for drawing. You can update the viewport manually by calling [method update_overlays].
 				[codeblocks]
 				[gdscript]
 				func _forward_3d_draw_over_viewport(overlay):
-				    # Draw a circle at cursor position.
+				    # Draw a circle at the cursor's position.
 				    overlay.draw_circle(overlay.get_local_mouse_position(), 64, Color.WHITE)
 
 				func _forward_3d_gui_input(camera, event):
 				    if event is InputEventMouseMotion:
-				        # Redraw viewport when cursor is moved.
+				        # Redraw the viewport when the cursor is moved.
 				        update_overlays()
 				        return EditorPlugin.AFTER_GUI_INPUT_STOP
 				    return EditorPlugin.AFTER_GUI_INPUT_PASS
@@ -72,7 +72,7 @@
 				[csharp]
 				public override void _Forward3DDrawOverViewport(Control viewportControl)
 				{
-				    // Draw a circle at cursor position.
+				    // Draw a circle at the cursor's position.
 				    viewportControl.DrawCircle(viewportControl.GetLocalMousePosition(), 64, Colors.White);
 				}
 
@@ -80,7 +80,7 @@
 				{
 				    if (@event is InputEventMouseMotion)
 				    {
-				        // Redraw viewport when cursor is moved.
+				        // Redraw the viewport when the cursor is moved.
 				        UpdateOverlays();
 				        return EditorPlugin.AfterGuiInput.Stop;
 				    }
@@ -139,16 +139,16 @@
 			<return type="void" />
 			<param index="0" name="viewport_control" type="Control" />
 			<description>
-				Called by the engine when the 2D editor's viewport is updated. Use the [code]overlay[/code] [Control] for drawing. You can update the viewport manually by calling [method update_overlays].
+				Called by the engine when the 2D editor's viewport is updated. [param viewport_control] is an overlay on top of the viewport and it can be used for drawing. You can update the viewport manually by calling [method update_overlays].
 				[codeblocks]
 				[gdscript]
 				func _forward_canvas_draw_over_viewport(overlay):
-				    # Draw a circle at cursor position.
+				    # Draw a circle at the cursor's position.
 				    overlay.draw_circle(overlay.get_local_mouse_position(), 64, Color.WHITE)
 
 				func _forward_canvas_gui_input(event):
 				    if event is InputEventMouseMotion:
-				        # Redraw viewport when cursor is moved.
+				        # Redraw the viewport when the cursor is moved.
 				        update_overlays()
 				        return true
 				    return false
@@ -156,7 +156,7 @@
 				[csharp]
 				public override void _ForwardCanvasDrawOverViewport(Control viewportControl)
 				{
-				    // Draw a circle at cursor position.
+				    // Draw a circle at the cursor's position.
 				    viewportControl.DrawCircle(viewportControl.GetLocalMousePosition(), 64, Colors.White);
 				}
 
@@ -164,7 +164,7 @@
 				{
 				    if (@event is InputEventMouseMotion)
 				    {
-				        // Redraw viewport when cursor is moved.
+				        // Redraw the viewport when the cursor is moved.
 				        UpdateOverlays();
 				        return true;
 				    }

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -847,7 +847,7 @@
 			Translations are provided by the community. If you spot a mistake, [url=$DOCS_URL/contributing/documentation/editor_and_docs_localization.html]contribute to editor translations on Weblate![/url]
 		</member>
 		<member name="interface/editor/editor_screen" type="int" setter="" getter="">
-			The preferred monitor to display the editor. If [b]Auto[/b], the editor will remember the last screen it was displayed on across restarts.
+			The preferred monitor to display the editor. If [b]Auto[/b], the editor will remember the last screen it was displayed on across multiple sessions.
 		</member>
 		<member name="interface/editor/expand_to_title" type="bool" setter="" getter="">
 			Expanding main editor window content to the title, if supported by [DisplayServer]. See [constant DisplayServer.WINDOW_FLAG_EXTEND_TO_TITLE].
@@ -1186,7 +1186,7 @@
 		</member>
 		<member name="run/window_placement/rect" type="int" setter="" getter="">
 			The window mode to use to display the project when starting the project from the editor.
-			[b]Note:[/b] Game embedding is not available for "Force Maximized" or "Force Fullscreen."
+			[b]Note:[/b] Game embedding is not available for [b]"Force Maximized"[/b] or [b]"Force Fullscreen"[/b].
 		</member>
 		<member name="run/window_placement/rect_custom_position" type="Vector2" setter="" getter="">
 			The custom position to use when starting the project from the editor (in pixels from the top-left corner). Only effective if [member run/window_placement/rect] is set to [b]Custom Position[/b].

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		This class can be used to permanently store data in the user device's file system and to read from it. This is useful for storing game save data or player configuration files.
-		Here's a sample on how to write and read from a file:
+		[b]Example:[/b] How to write and read from a file. The file named [code]"save_game.dat"[/code] will be stored in the user data folder, as specified in the [url=$DOCS_URL/tutorials/io/data_paths.html]Data paths[/url] documentation:
 		[codeblocks]
 		[gdscript]
 		func save_to_file(content):
@@ -32,10 +32,9 @@
 		}
 		[/csharp]
 		[/codeblocks]
-		In the example above, the file will be saved in the user data folder as specified in the [url=$DOCS_URL/tutorials/io/data_paths.html]Data paths[/url] documentation.
-		[FileAccess] will close when it's freed, which happens when it goes out of scope or when it gets assigned with [code]null[/code]. [method close] can be used to close it before then explicitly. In C# the reference must be disposed manually, which can be done with the [code]using[/code] statement or by calling the [code]Dispose[/code] method directly.
+		A [FileAccess] instance will close its file when the instance is freed. Since it inherits [RefCounted], this happens automatically when it is no longer in use. [method close] can be called to close it earlier. In C#, the reference must be disposed manually, which can be done with the [code]using[/code] statement or by calling the [code]Dispose[/code] method directly.
 		[b]Note:[/b] To access project resources once exported, it is recommended to use [ResourceLoader] instead of [FileAccess], as some files are converted to engine-specific formats and their original source files might not be present in the exported PCK package. If using [FileAccess], make sure the file is included in the export by changing its import mode to [b]Keep File (exported as is)[/b] in the Import dock, or, for files where this option is not available, change the non-resource export filter in the Export dialog to include the file's extension (e.g. [code]*.txt[/code]).
-		[b]Note:[/b] Files are automatically closed only if the process exits "normally" (such as by clicking the window manager's close button or pressing [b]Alt + F4[/b]). If you stop the project execution by pressing [b]F8[/b] while the project is running, the file won't be closed as the game process will be killed. You can work around this by calling [method flush] at regular intervals.
+		[b]Note:[/b] Files are automatically closed only if the process exits "normally" (such as by clicking the window manager's close button or pressing [kbd]Alt + F4[/kbd]). If you stop the project execution by pressing [kbd]F8[/kbd] while the project is running, the file won't be closed as the game process will be killed. You can work around this by calling [method flush] at regular intervals.
 	</description>
 	<tutorials>
 		<link title="File system">$DOCS_URL/tutorials/scripting/filesystem.html</link>

--- a/doc/classes/LookAtModifier3D.xml
+++ b/doc/classes/LookAtModifier3D.xml
@@ -19,7 +19,7 @@
 		<method name="is_interpolating" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns whether the time-based interpolation is running or not. If [code]true[/code], it is equivalent to [method get_interpolation_remaining] being [code]0[/code].
+				Returns [code]true[/code] if time-based interpolation is running. If [code]true[/code], it is equivalent to [method get_interpolation_remaining] returning [code]0.0[/code].
 				This is useful to determine whether a [LookAtModifier3D] can be removed safely.
 			</description>
 		</method>

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -132,7 +132,7 @@
 			<description>
 				Rotates the node so that the local forward axis (-Z, [constant Vector3.FORWARD]) points toward the [param target] position. This operation is calculated in global space (relative to the world).
 				The local up axis (+Y) points as close to the [param up] vector as possible while staying perpendicular to the local forward axis. The resulting transform is orthogonal, and the scale is preserved. Non-uniform scaling may not work correctly.
-				The [param target] position cannot be the same as the node's position, the [param up] vector cannot be [constant Vector3.ZERO]. Furthermore, the direction from the node's position to the [param target] position cannot be parallel to the [param up] vector, to avoid unintended rotation around the local Z axis.
+				The [param target] position cannot be the same as the node's position, the [param up] vector cannot be [constant Vector3.ZERO]. Furthermore, the direction from the node's position to the [param target] position cannot be parallel to the [param up] vector, to avoid an unintended rotation around the local Z axis.
 				If [param use_model_front] is [code]true[/code], the +Z axis (asset front) is treated as forward (implies +X is left) and points toward the [param target] position. By default, the -Z axis (camera forward) is treated as forward (implies +X is right).
 				[b]Note:[/b] This method fails if the node is not in the scene tree. If necessary, use [method look_at_from_position] instead.
 			</description>

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -205,7 +205,6 @@
 			<param index="0" name="iter" type="Array" />
 			<description>
 				Initializes the iterator. [param iter] stores the iteration state. Since GDScript does not support passing arguments by reference, a single-element array is used as a wrapper. Returns [code]true[/code] so long as the iterator has not reached the end.
-				Example:
 				[codeblock]
 				class MyRange:
 				    var _from

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1101,7 +1101,7 @@
 		</member>
 		<member name="filesystem/import/blender/enabled" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], Blender 3D scene files with the [code].blend[/code] extension will be imported by converting them to glTF 2.0.
-			This requires configuring a path to a Blender executable in the editor settings at [code]filesystem/import/blender/blender_path[/code]. Blender 3.0 or later is required.
+			This requires configuring a path to a Blender executable in the [member EditorSettings.filesystem/import/blender/blender_path] setting. Blender 3.0 or later is required.
 		</member>
 		<member name="filesystem/import/blender/enabled.android" type="bool" setter="" getter="" default="false">
 			Override for [member filesystem/import/blender/enabled] on Android where Blender can't easily be accessed from Godot.
@@ -3110,11 +3110,11 @@
 		</member>
 		<member name="rendering/rendering_device/fallback_to_opengl3" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], the forward renderer will fall back to OpenGL 3 if Direct3D 12, Metal, and Vulkan are not supported.
-			[b]Note:[/b] This setting is implemented only on Windows, Android, macOS, iOS, and Linux/X11.
+			[b]Note:[/b] This setting is implemented on Windows, Android, macOS, iOS, and Linux/X11.
 		</member>
 		<member name="rendering/rendering_device/fallback_to_vulkan" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], the forward renderer will fall back to Vulkan if Direct3D 12 (on Windows) or Metal (on macOS x86_64) are not supported. The fallback is always attempted regardless of this setting if Direct3D 12 (Windows) or Metal (macOS) driver support was disabled at compile time.
-			[b]Note:[/b] This setting is implemented only on Windows and macOS.
+			[b]Note:[/b] This setting is implemented on Windows and macOS.
 		</member>
 		<member name="rendering/rendering_device/pipeline_cache/enable" type="bool" setter="" getter="" default="true">
 			Enable the pipeline cache that is saved to disk if the graphics API supports it.

--- a/doc/classes/SpringBoneSimulator3D.xml
+++ b/doc/classes/SpringBoneSimulator3D.xml
@@ -19,7 +19,7 @@
 			<return type="bool" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns [code]true[/code] if the all child [SpringBoneCollision3D]s are contained in the collision list at [param index] in the settings.
+				Returns [code]true[/code] if all child [SpringBoneCollision3D]s are contained in the collision list at [param index] in the settings.
 			</description>
 		</method>
 		<method name="clear_collisions">
@@ -378,8 +378,8 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If sets [param enabled] to [code]true[/code], the all child [SpringBoneCollision3D]s are collided and [method set_exclude_collision_path] is enabled as an exclusion list at [param index] in the settings.
-				If sets [param enabled] to [code]false[/code], you need to manually register all valid collisions with [method set_collision_path].
+				If [param enabled] is [code]true[/code], all child [SpringBoneCollision3D]s are colliding and [method set_exclude_collision_path] is enabled as an exclusion list at [param index] in the settings.
+				If [param enabled] is [code]false[/code], you need to manually register all valid collisions with [method set_collision_path].
 			</description>
 		</method>
 		<method name="set_end_bone">

--- a/doc/classes/StreamPeer.xml
+++ b/doc/classes/StreamPeer.xml
@@ -69,7 +69,7 @@
 			<return type="Array" />
 			<param index="0" name="bytes" type="int" />
 			<description>
-				Returns a chunk data with the received bytes. The number of bytes to be received can be requested in the "bytes" argument. If not enough bytes are available, the function will return how many were actually received. This function returns two values, an [enum Error] code, and a data array.
+				Returns a chunk data with the received bytes. The number of bytes to be received can be requested in the [param bytes] argument. If not enough bytes are available, the function will return how many were actually received. This function returns two values: an [enum Error] code and a data array.
 			</description>
 		</method>
 		<method name="get_string">

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -727,7 +727,7 @@
 				GD.Print(n.ToString("e1")); // Prints -5.2e+008
 				[/csharp]
 				[/codeblocks]
-				[b]Note:[/b] In C#, this method is not implemented. To achieve similar results, see C#'s [url=https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings]Standard numeric format strings[/url]
+				[b]Note:[/b] In C#, this method is not implemented. To achieve similar results, see C#'s [url=https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings]Standard numeric format strings[/url].
 			</description>
 		</method>
 		<method name="num_uint64" qualifiers="static">

--- a/modules/gltf/doc_classes/EditorSceneFormatImporterBlend.xml
+++ b/modules/gltf/doc_classes/EditorSceneFormatImporterBlend.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Imports Blender scenes in the [code].blend[/code] file format through the glTF 2.0 3D import pipeline. This importer requires Blender to be installed by the user, so that it can be used to export the scene as glTF 2.0.
-		The location of the Blender binary is set via the [code]filesystem/import/blender/blender_path[/code] editor setting.
+		The location of the Blender binary is set via the [member EditorSettings.filesystem/import/blender/blender_path] setting.
 		This importer is only used if [member ProjectSettings.filesystem/import/blender/enabled] is enabled, otherwise [code].blend[/code] files present in the project folder are not imported.
 		Blend import requires Blender 3.0.
 		Internally, the EditorSceneFormatImporterBlend uses the Blender glTF "Use Original" mode to reference external textures.

--- a/modules/gltf/doc_classes/GLTFObjectModelProperty.xml
+++ b/modules/gltf/doc_classes/GLTFObjectModelProperty.xml
@@ -63,7 +63,7 @@
 			If set, this [Expression] will be used to convert the property value from the Godot property to the value expected by the glTF object model. This is useful when the glTF object model uses a different unit system, or when the data needs to be transformed in some way. If [code]null[/code], the value will be copied as-is.
 		</member>
 		<member name="json_pointers" type="PackedStringArray[]" setter="set_json_pointers" getter="get_json_pointers" default="[]">
-			The glTF object model JSON pointers used to identify the property in the glTF object model. In most cases, there will be only one item in this array, but niche cases may require multiple pointers. The items are themselves arrays which represent the JSON pointer split into its components.
+			The glTF object model JSON pointers used to identify the property in the glTF object model. In most cases, there will be only one item in this array, but specific cases may require multiple pointers. The items are themselves arrays which represent the JSON pointer split into its components.
 		</member>
 		<member name="node_paths" type="NodePath[]" setter="set_node_paths" getter="get_node_paths" default="[]">
 			An array of [NodePath]s that point to a property, or multiple properties, in the Godot scene tree. On import, this will either be set by [GLTFDocument], or by a [GLTFDocumentExtension] class. For simple cases, use [method append_path_to_property] to add properties to this array.

--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -34,7 +34,7 @@
 			<param index="1" name="godot_scene_node" type="Node" />
 			<param index="2" name="parent_node_index" type="int" />
 			<description>
-				Append the given [GLTFNode] to the state, and return its new index. This can be used to export one Godot node as multiple glTF nodes, or inject new glTF nodes at import time. On import, this must be called before [method GLTFDocumentExtension._generate_scene_node] finishes for the parent node. On export, this must be called before [method GLTFDocumentExtension._export_node] runs for the parent node.
+				Appends the given [GLTFNode] to the state, and returns its new index. This can be used to export one Godot node as multiple glTF nodes, or inject new glTF nodes at import time. On import, this must be called before [method GLTFDocumentExtension._generate_scene_node] finishes for the parent node. On export, this must be called before [method GLTFDocumentExtension._export_node] runs for the parent node.
 				The [param godot_scene_node] parameter is the Godot scene node that corresponds to this glTF node. This is highly recommended to be set to a valid node, but may be [code]null[/code] if there is no corresponding Godot scene node. One Godot scene node may be used for multiple glTF nodes, so if exporting multiple glTF nodes for one Godot scene node, use the same Godot scene node for each.
 				The [param parent_node_index] parameter is the index of the parent [GLTFNode] in the state. If [code]-1[/code], the node will be a root node, otherwise the new node will be added to the parent's list of children. The index will also be written to the [member GLTFNode.parent] property of the new node.
 			</description>

--- a/modules/openxr/doc_classes/OpenXRAnalogThresholdModifier.xml
+++ b/modules/openxr/doc_classes/OpenXRAnalogThresholdModifier.xml
@@ -14,13 +14,13 @@
 			Haptic pulse to emit when the user releases the input.
 		</member>
 		<member name="off_threshold" type="float" setter="set_off_threshold" getter="get_off_threshold" default="0.4">
-			When our input value falls below this, our output becomes false.
+			When our input value falls below this, our output becomes [code]false[/code].
 		</member>
 		<member name="on_haptic" type="OpenXRHapticBase" setter="set_on_haptic" getter="get_on_haptic">
 			Haptic pulse to emit when the user presses the input.
 		</member>
 		<member name="on_threshold" type="float" setter="set_on_threshold" getter="get_on_threshold" default="0.6">
-			When our input value is equal or larger than this value, our output becomes true. It stays true until it falls under the [member off_threshold] value.
+			When our input value is equal or larger than this value, our output becomes [code]true[/code]. It stays [code]true[/code] until it falls under the [member off_threshold] value.
 		</member>
 	</members>
 </class>

--- a/modules/openxr/doc_classes/OpenXRDpadBindingModifier.xml
+++ b/modules/openxr/doc_classes/OpenXRDpadBindingModifier.xml
@@ -21,8 +21,8 @@
 			Input path for this dpad binding modifier.
 		</member>
 		<member name="is_sticky" type="bool" setter="set_is_sticky" getter="get_is_sticky" default="false">
-			If [code]false[/code], when the joystick enters a new dpad zone this becomes true.
-			If [code]true[/code], when the joystick remains in active dpad zone, this remains true even if we overlap with another zone.
+			If [code]false[/code], when the joystick enters a new dpad zone this becomes [code]true[/code].
+			If [code]true[/code], when the joystick remains in active dpad zone, this remains [code]true[/code] even if we overlap with another zone.
 		</member>
 		<member name="off_haptic" type="OpenXRHapticBase" setter="set_off_haptic" getter="get_off_haptic">
 			Haptic pulse to emit when the user releases the input.
@@ -31,10 +31,10 @@
 			Haptic pulse to emit when the user presses the input.
 		</member>
 		<member name="threshold" type="float" setter="set_threshold" getter="get_threshold" default="0.6">
-			When our input value is equal or larger than this value, our dpad in that direction becomes true. It stays true until it falls under the [member threshold_released] value.
+			When our input value is equal or larger than this value, our dpad in that direction becomes [code]true[/code]. It stays [code]true[/code] until it falls under the [member threshold_released] value.
 		</member>
 		<member name="threshold_released" type="float" setter="set_threshold_released" getter="get_threshold_released" default="0.4">
-			When our input value falls below this, our output becomes false.
+			When our input value falls below this, our output becomes [code]false[/code].
 		</member>
 		<member name="wedge_angle" type="float" setter="set_wedge_angle" getter="get_wedge_angle" default="1.5708">
 			The angle of each wedge that identifies the 4 directions of the emulated dpad.


### PR DESCRIPTION
Continuation of https://github.com/godotengine/godot/pull/104333
I can't keep going with ever-so-slightly different names for these.

This PR addressed yet yet another huge chunk of class reference oddities I remembered to note down for later while localizing the class reference. Some of these are clear typos, some are inconsistencies, some are just awkward.

Of particular note:
- Modify **Dictionary**'s `sort()` substantially
	- For parity with **Array**'s corresponding method
	- ~Add an example and note which only makes sense if https://github.com/godotengine/godot/pull/105065 is merged first!~
	- Part of it could be summarized to _"sorting the dictionary is useful if you need a dictionary to be sorted"_. Yeah...
	- Please do not use `keys()` and `values()` methods as replacements for actual words. It's confusing and harder to localize
- Modify **LookAtModifier3D**'s `is_interpolating()` substantially
- Modify **FileAccess**'s leading description substantially
	- This was in the process of fixing `[b]` tags being used for *"Alt + F4"* instead of `[kbd]` tags
- Replace singular use of "niche" with a more common word
- Remove a barren *"Example:"* that [should not exist](https://github.com/godotengine/godot/pull/95749) and yet it does
- Fix more `true` and `false` with `[code]` tags ([guys, come on](https://github.com/godotengine/godot/pull/95762))
- Fix **EditorPlugin**'s `_forward_3d_draw_over_viewport` and `_forward_canvas_draw_over_viewport` not referencing their parameter properly
- Fix **StreamPeer**'s `get_partial_data` not referencing their parameter properly
- Fix more editor settings not being linked with a `[member]` tag