### PR TITLE
[.Net] Avoid array allocation when signal have 0 arg

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
@@ -48,12 +48,19 @@ namespace Godot
 
                 awaiter._completed = true;
 
-                Variant[] signalArgs = new Variant[argCount];
+                if (argCount > 0)
+                {
+                    Variant[] signalArgs = new Variant[argCount];
 
-                for (int i = 0; i < argCount; i++)
-                    signalArgs[i] = Variant.CreateCopyingBorrowed(*args[i]);
+                    for (int i = 0; i < argCount; i++)
+                        signalArgs[i] = Variant.CreateCopyingBorrowed(*args[i]);
 
-                awaiter._result = signalArgs;
+                    awaiter._result = signalArgs;
+                }
+                else
+                {
+                    awaiter._result = [];
+                }
 
                 awaiter._continuation?.Invoke();
             }


### PR DESCRIPTION
Before this PR, `SignalAwaiter` always allocates an array based on the Signal's argument count, even if the count number is zero.  
This PR avoids the empty array allocation each completion call by directing empty array acquisition from `new Variant[0]` to  `Array.Empty<Variant>` (aka `[]`, the global empty Variant array),
