### PR TITLE
Add an option to disable capturing for a given control.

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1004,6 +1004,10 @@
 			If [code]true[/code], automatically converts code line numbers, list indices, [SpinBox] and [ProgressBar] values from the Western Arabic (0..9) to the numeral systems used in current locale.
 			[b]Note:[/b] Numbers within the text are not automatically converted, it can be done manually, using [method TextServer.format_number].
 		</member>
+		<member name="mouse_capture" type="bool" setter="set_mouse_capture" getter="get_mouse_capture" default="true">
+			If [code]false[/code], prevents the control and all of its children from receiving mouse input. This, unlike [member mouse_filter], affects capturing (outer-most to inner-most) instead of bubbling (inner-most to outer-most).
+			This is practically similar to making the control invisible, except only affecting mouse input.
+		</member>
 		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" enum="Control.CursorShape" default="0">
 			The default cursor shape for this control. Useful for Godot plugins and applications or games that use the system's mouse cursors.
 			[b]Note:[/b] On Linux, shapes may vary depending on the cursor theme of the system.

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1898,6 +1898,18 @@ Control::RecursiveBehavior Control::get_mouse_recursive_behavior() const {
 	return data.mouse_recursive_behavior;
 }
 
+void Control::set_mouse_capture(bool p_state) {
+	ERR_MAIN_THREAD_GUARD;
+
+	data.mouse_capture = p_state;
+}
+
+bool Control::get_mouse_capture() const {
+	ERR_READ_THREAD_GUARD_V(true)
+
+	return data.mouse_capture;
+}
+
 void Control::set_force_pass_scroll_events(bool p_force_pass_scroll_events) {
 	ERR_MAIN_THREAD_GUARD;
 	data.force_pass_scroll_events = p_force_pass_scroll_events;
@@ -3775,6 +3787,9 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mouse_recursive_behavior", "mouse_recursive_behavior"), &Control::set_mouse_recursive_behavior);
 	ClassDB::bind_method(D_METHOD("get_mouse_recursive_behavior"), &Control::get_mouse_recursive_behavior);
 
+	ClassDB::bind_method(D_METHOD("set_mouse_capture", "mouse_capture"), &Control::set_mouse_capture);
+	ClassDB::bind_method(D_METHOD("get_mouse_capture"), &Control::get_mouse_capture);
+
 	ClassDB::bind_method(D_METHOD("set_force_pass_scroll_events", "force_pass_scroll_events"), &Control::set_force_pass_scroll_events);
 	ClassDB::bind_method(D_METHOD("is_force_pass_scroll_events"), &Control::is_force_pass_scroll_events);
 
@@ -3875,6 +3890,9 @@ void Control::_bind_methods() {
 	ADD_GROUP("Mouse", "mouse_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_filter", PROPERTY_HINT_ENUM, "Stop,Pass (Propagate Up),Ignore"), "set_mouse_filter", "get_mouse_filter");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_recursive_behavior", PROPERTY_HINT_ENUM, "Inherited,Disabled,Enabled"), "set_mouse_recursive_behavior", "get_mouse_recursive_behavior");
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mouse_capture"), "set_mouse_capture", "get_mouse_capture");
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mouse_force_pass_scroll_events"), "set_force_pass_scroll_events", "is_force_pass_scroll_events");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_default_cursor_shape", PROPERTY_HINT_ENUM, "Arrow,I-Beam,Pointing Hand,Cross,Wait,Busy,Drag,Can Drop,Forbidden,Vertical Resize,Horizontal Resize,Secondary Diagonal Resize,Main Diagonal Resize,Move,Vertical Split,Horizontal Split,Help"), "set_default_cursor_shape", "get_default_cursor_shape");
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -228,6 +228,9 @@ private:
 		MouseFilter mouse_filter = MOUSE_FILTER_STOP;
 		RecursiveBehavior parent_mouse_recursive_behavior = RECURSIVE_BEHAVIOR_INHERITED;
 		RecursiveBehavior mouse_recursive_behavior = RECURSIVE_BEHAVIOR_INHERITED;
+
+		bool mouse_capture = true;
+
 		bool force_pass_scroll_events = true;
 
 		bool clip_contents = false;
@@ -538,6 +541,9 @@ public:
 
 	void set_mouse_recursive_behavior(RecursiveBehavior p_recursive_mouse_behavior);
 	RecursiveBehavior get_mouse_recursive_behavior() const;
+
+	void set_mouse_capture(bool p_state);
+	bool get_mouse_capture() const;
 
 	void set_force_pass_scroll_events(bool p_force_pass_scroll_events);
 	bool is_force_pass_scroll_events() const;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1749,6 +1749,12 @@ Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_
 
 	Control *c = Object::cast_to<Control>(p_node);
 
+	// stop the capture on controls that don't allow it.
+	// this makes it as if this control never even existed/wasn't visible
+	if (c && !c->get_mouse_capture()) {
+		return nullptr;
+	}
+
 	if (!c || !c->is_clipping_contents() || c->has_point(matrix.affine_inverse().xform(p_global))) {
 		for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
 			CanvasItem *ci = Object::cast_to<CanvasItem>(p_node->get_child(i));

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -266,6 +266,15 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 			CHECK(root->gui_find_control(on_b) == node_a);
 		}
 
+		SUBCASE("[VIEWPORT][GuiFindControl] Nodes with mouse capturing disabled are not considered as results.") {
+			// Non-Root Control
+			node_d->set_mouse_capture(false);
+			CHECK(root->gui_find_control(on_d) == node_b);
+			// Root Control
+			node_b->set_mouse_capture(false);
+			CHECK(root->gui_find_control(on_b) == node_a);
+		}
+
 		SUBCASE("[VIEWPORT][GuiFindControl] Root Control with CanvasItem as parent is affected by parent's transform.") {
 			node_b->remove_child(node_c);
 			node_c->set_position(Point2i(50, 50));


### PR DESCRIPTION
This acts as a complement to mouse_filter, allowing the user to stop a control and its children from ever being used for bubbling. Disabling capturing is functionally similar to hiding a control, albeit with no effect on appearance.

In a roundabout way, this implements the functionality of the version of `MOUSE_FILTER_IGNORE` discussed here: https://github.com/godotengine/godot-proposals/issues/3613

I might be confusing terminology with this. 'Capture' might not be the right term.