### PR TITLE
thorvg: Update to 0.15.12

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -943,7 +943,7 @@ Patches:
 ## thorvg
 
 - Upstream: https://github.com/thorvg/thorvg
-- Version: 0.15.11 (61360cf6db0a05a8dd2ebdcc44d4cbbc315692ec, 2025)
+- Version: 0.15.12 (91bd6f35b94e92abfc1a320632e66cd124943524, 2025)
 - License: MIT
 
 Files extracted from upstream source:
@@ -954,6 +954,7 @@ Files extracted from upstream source:
 Patches:
 
 - `0001-revert-tvglines-bezier-precision.patch` (GH-96658)
+- `0002-png-explicit-variable-scope.patch` (GH-105093)
 
 
 ## tinyexr

--- a/thirdparty/thorvg/inc/config.h
+++ b/thirdparty/thorvg/inc/config.h
@@ -15,5 +15,5 @@
 // For internal debugging:
 //#define THORVG_LOG_ENABLED
 
-#define THORVG_VERSION_STRING "0.15.11"
+#define THORVG_VERSION_STRING "0.15.12"
 #endif

--- a/thirdparty/thorvg/patches/0002-png-explicit-variable-scope.patch
+++ b/thirdparty/thorvg/patches/0002-png-explicit-variable-scope.patch
@@ -1,0 +1,13 @@
+diff --git a/thirdparty/thorvg/src/loaders/external_png/tvgPngLoader.cpp b/thirdparty/thorvg/src/loaders/external_png/tvgPngLoader.cpp
+index 71bf25a62b..c362403125 100644
+--- a/thirdparty/thorvg/src/loaders/external_png/tvgPngLoader.cpp
++++ b/thirdparty/thorvg/src/loaders/external_png/tvgPngLoader.cpp
+@@ -88,7 +88,7 @@ bool PngLoader::read()
+ 
+     if (w == 0 || h == 0) return false;
+ 
+-    if (cs == ColorSpace::ARGB8888 || cs == ColorSpace::ARGB8888S) {
++    if (ImageLoader::cs == ColorSpace::ARGB8888 || ImageLoader::cs == ColorSpace::ARGB8888S) {
+         image->format = PNG_FORMAT_BGRA;
+         surface.cs = ColorSpace::ARGB8888S;
+     } else {

--- a/thirdparty/thorvg/src/loaders/external_png/tvgPngLoader.cpp
+++ b/thirdparty/thorvg/src/loaders/external_png/tvgPngLoader.cpp
@@ -88,7 +88,7 @@ bool PngLoader::read()
 
     if (w == 0 || h == 0) return false;
 
-    if (cs == ColorSpace::ARGB8888 || cs == ColorSpace::ARGB8888S) {
+    if (ImageLoader::cs == ColorSpace::ARGB8888 || ImageLoader::cs == ColorSpace::ARGB8888S) {
         image->format = PNG_FORMAT_BGRA;
         surface.cs = ColorSpace::ARGB8888S;
     } else {

--- a/thirdparty/thorvg/src/loaders/external_webp/tvgWebpLoader.cpp
+++ b/thirdparty/thorvg/src/loaders/external_webp/tvgWebpLoader.cpp
@@ -56,7 +56,7 @@ WebpLoader::WebpLoader() : ImageLoader(FileType::Webp)
 
 WebpLoader::~WebpLoader()
 {
-    this->done();
+    done();
 
     if (freeData) free(data);
     data = nullptr;

--- a/thirdparty/thorvg/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/thirdparty/thorvg/src/loaders/jpg/tvgJpgLoader.cpp
@@ -63,6 +63,7 @@ JpgLoader::JpgLoader() : ImageLoader(FileType::Jpg)
 
 JpgLoader::~JpgLoader()
 {
+    done();
     clear();
     free(surface.buf8);
 }

--- a/thirdparty/thorvg/src/loaders/svg/tvgSvgLoader.cpp
+++ b/thirdparty/thorvg/src/loaders/svg/tvgSvgLoader.cpp
@@ -405,6 +405,27 @@ static char* _idFromUrl(const char* url)
 }
 
 
+static size_t _srcFromUrl(const char* url, char*& src)
+{
+    src = (char*)strchr(url, '(');
+    auto close = strchr(url, ')');
+    if (!src || !close || src >= close) return 0;
+
+    src = strchr(src, '\'');
+    if (!src || src >= close) return 0;
+    ++src;
+
+    close = strchr(src, '\'');
+    if (!close || close == src) return 0;
+    --close;
+
+    while (src < close && *src == ' ') ++src;
+    while (src < close && *close == ' ') --close;
+
+    return close - src + 1;
+}
+
+
 static unsigned char _parseColor(const char* value, char** end)
 {
     float r;
@@ -2005,6 +2026,42 @@ static SvgNode* _createImageNode(SvgLoaderData* loader, SvgNode* parent, const c
 }
 
 
+static char* _unquote(const char* str)
+{
+    auto len = str ? strlen(str) : 0;
+    if (len >= 2 && str[0] == '\'' && str[len - 1] == '\'') return strDuplicate(str + 1, len - 2);
+    return strdup(str);
+}
+
+
+static bool _attrParseFontFace(void* data, const char* key, const char* value)
+{
+    if (!key || !value) return false;
+
+    key = _skipSpace(key, nullptr);
+    value = _skipSpace(value, nullptr);
+
+    auto loader = (SvgLoaderData*)data;
+    auto& font = loader->fonts.last();
+
+    if (!strcmp(key, "font-family")) {
+        if (font.name) free(font.name);
+        font.name = _unquote(value);
+    } else if (!strcmp(key, "src")) {
+        font.srcLen = _srcFromUrl(value, font.src);
+    }
+
+    return true;
+}
+
+
+static void _createFontFace(SvgLoaderData* loader, const char* buf, unsigned bufLength, parseAttributes func)
+{
+    loader->fonts.push(FontFace());
+    func(buf, bufLength, _attrParseFontFace, loader);
+}
+
+
 static SvgNode* _getDefsNode(SvgNode* node)
 {
     if (!node) return nullptr;
@@ -3455,6 +3512,8 @@ static void _svgLoaderParserXmlCssStyle(SvgLoaderData* loader, const char* conte
             TVGLOG("SVG", "Unsupported elements used in the internal CSS style sheets [Elements: %s]", tag);
         } else if (!strcmp(tag, "all")) {
             if ((node = _createCssStyleNode(loader, loader->cssStyle, attrs, attrsLength, simpleXmlParseW3CAttribute))) node->id = _copyId(name);
+        } else if (!strcmp(tag, "@font-face")) { //css at-rule specifying font
+            _createFontFace(loader, attrs, attrsLength, simpleXmlParseW3CAttribute);
         } else if (!isIgnoreUnsupportedLogElements(tag)) {
             TVGLOG("SVG", "Unsupported elements used in the internal CSS style sheets [Elements: %s]", tag);
         }
@@ -3829,7 +3888,7 @@ SvgLoader::SvgLoader() : ImageLoader(FileType::Svg)
 
 SvgLoader::~SvgLoader()
 {
-    this->done();
+    done();
     clear();
 }
 

--- a/thirdparty/thorvg/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/thirdparty/thorvg/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -555,6 +555,14 @@ struct SvgNodeIdPair
     char *id;
 };
 
+struct FontFace
+{
+    char* name = nullptr;
+    char* src = nullptr;
+    size_t srcLen = 0;
+    char* decoded = nullptr;
+};
+
 enum class OpenedTagType : uint8_t
 {
     Other = 0,
@@ -574,6 +582,7 @@ struct SvgLoaderData
     Array<SvgNodeIdPair> cloneNodes;
     Array<SvgNodeIdPair> nodesToStyle;
     Array<char*> images;        //embedded images
+    Array<FontFace> fonts;
     int level = 0;
     bool result = false;
     OpenedTagType openedTag = OpenedTagType::Other;

--- a/thirdparty/thorvg/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/thirdparty/thorvg/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -573,8 +573,6 @@ static unique_ptr<Picture> _imageBuildHelper(SvgLoaderData& loaderData, SvgNode*
     if (!node->node.image.href || !strlen(node->node.image.href)) return nullptr;
     auto picture = Picture::gen();
 
-    TaskScheduler::async(false);    //force to load a picture on the same thread
-
     const char* href = node->node.image.href;
     if (!strncmp(href, "data:", sizeof("data:") - 1)) {
         href += sizeof("data:") - 1;
@@ -586,14 +584,12 @@ static unique_ptr<Picture> _imageBuildHelper(SvgLoaderData& loaderData, SvgNode*
             auto size = b64Decode(href, strlen(href), &decoded);
             if (picture->load(decoded, size, mimetype, false) != Result::Success) {
                 free(decoded);
-                TaskScheduler::async(true);
                 return nullptr;
             }
         } else {
             auto size = svgUtilURLDecode(href, &decoded);
             if (picture->load(decoded, size, mimetype, false) != Result::Success) {
                 free(decoded);
-                TaskScheduler::async(true);
                 return nullptr;
             }
         }
@@ -605,7 +601,6 @@ static unique_ptr<Picture> _imageBuildHelper(SvgLoaderData& loaderData, SvgNode*
         const char *dot = strrchr(href, '.');
         if (dot && !strcmp(dot, ".svg")) {
             TVGLOG("SVG", "Embedded svg file is disabled.");
-            TaskScheduler::async(true);
             return nullptr;
         }
         string imagePath = href;
@@ -614,12 +609,9 @@ static unique_ptr<Picture> _imageBuildHelper(SvgLoaderData& loaderData, SvgNode*
             imagePath = svgPath.substr(0, (last == string::npos ? 0 : last + 1)) + imagePath;
         }
         if (picture->load(imagePath) != Result::Success) {
-            TaskScheduler::async(true);
             return nullptr;
         }
     }
-
-    TaskScheduler::async(true);
 
     float w, h;
     Matrix m = {1, 0, 0, 0, 1, 0, 0, 0, 1};
@@ -900,6 +892,41 @@ static void _updateInvalidViewSize(const Scene* scene, Box& vBox, float& w, floa
     if (!validHeight) h *= vBox.h;
 }
 
+
+static void _loadFonts(Array<FontFace>& fonts)
+{
+    if (fonts.empty()) return;
+
+    static constexpr struct {
+        const char* prefix;
+        size_t len;
+    } prefixes[] = {
+        {"data:font/ttf;base64,", sizeof("data:font/ttf;base64,") - 1},
+        {"data:application/font-ttf;base64,", sizeof("data:application/font-ttf;base64,") - 1}
+    };
+
+    for (uint32_t i = 0; i < fonts.count; ++i) {
+        auto p = &fonts[i];
+        if (!p->name) continue;
+
+        size_t shift = 0;
+        for (const auto& prefix : prefixes) {
+            if (p->srcLen > prefix.len && !memcmp(p->src, prefix.prefix, prefix.len)) {
+                shift = prefix.len;
+                break;
+            }
+        }
+        if (shift == 0) {
+            TVGLOG("SVG", "The embedded font \"%s\" data not loaded properly.", p->name);
+            continue;
+        }
+
+        auto size = b64Decode(p->src + shift, p->srcLen - shift, &p->decoded);
+
+        if (Text::load(p->name, p->decoded, size) != Result::Success) TVGERR("SVG", "Error while loading the ttf font named \"%s\".", p->name);
+    }
+}
+
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
@@ -909,6 +936,8 @@ Scene* svgSceneBuild(SvgLoaderData& loaderData, Box vBox, float w, float h, Aspe
     //TODO: aspect ratio is valid only if viewBox was set
 
     if (!loaderData.doc || (loaderData.doc->type != SvgNodeType::Doc)) return nullptr;
+
+    _loadFonts(loaderData.fonts);
 
     auto docNode = _sceneBuildHelper(loaderData, loaderData.doc, vBox, svgPath, false, 0);
 

--- a/thirdparty/thorvg/src/loaders/svg/tvgXmlParser.cpp
+++ b/thirdparty/thorvg/src/loaders/svg/tvgXmlParser.cpp
@@ -483,6 +483,14 @@ bool simpleXmlParseW3CAttribute(const char* buf, unsigned bufLength, simpleXMLAt
     do {
         char* sep = (char*)strchr(buf, ':');
         next = (char*)strchr(buf, ';');
+
+        if (auto src = strstr(buf, "src")) {//src tag from css font-face contains extra semicolon
+            if (src < sep) {
+                if (next + 1 < end) next = (char*)strchr(next + 1, ';');
+                else return true;
+            }
+        }
+
         if (sep >= end) {
             next = nullptr;
             sep = nullptr;

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwMath.cpp
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwMath.cpp
@@ -314,10 +314,10 @@ bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, S
     }
 
     if (fastTrack) {
-        renderRegion.min.x = static_cast<SwCoord>(nearbyint(xMin / 64.0f));
-        renderRegion.max.x = static_cast<SwCoord>(nearbyint(xMax / 64.0f));
-        renderRegion.min.y = static_cast<SwCoord>(nearbyint(yMin / 64.0f));
-        renderRegion.max.y = static_cast<SwCoord>(nearbyint(yMax / 64.0f));
+        renderRegion.min.x = static_cast<SwCoord>(round(xMin / 64.0f));
+        renderRegion.max.x = static_cast<SwCoord>(round(xMax / 64.0f));
+        renderRegion.min.y = static_cast<SwCoord>(round(yMin / 64.0f));
+        renderRegion.max.y = static_cast<SwCoord>(round(yMax / 64.0f));
     } else {
         renderRegion.min.x = xMin >> 6;
         renderRegion.max.x = (xMax + 63) >> 6;

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwShape.cpp
@@ -102,7 +102,6 @@ static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix& trans
 {
     Line cur = {dash.ptCur, *to};
     auto len = cur.length();
-
     if (tvg::zero(len)) {
         _outlineMoveTo(*dash.outline, &dash.ptCur, transform);
     //draw the current line fully
@@ -117,7 +116,7 @@ static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix& trans
         }
     //draw the current line partially
     } else {
-        while (len - dash.curLen > 0.0001f) {
+        while (len - dash.curLen > DASH_PATTERN_THRESHOLD) {
             Line left, right;
             if (dash.curLen > 0) {
                 len -= dash.curLen;
@@ -178,7 +177,7 @@ static void _dashCubicTo(SwDashStroke& dash, const Point* ctrl1, const Point* ct
         }
     //draw the current line partially
     } else {
-        while ((len - dash.curLen) > 0.0001f) {
+        while ((len - dash.curLen) > DASH_PATTERN_THRESHOLD) {
             Bezier left, right;
             if (dash.curLen > 0) {
                 len -= dash.curLen;

--- a/thirdparty/thorvg/src/renderer/tvgLoadModule.h
+++ b/thirdparty/thorvg/src/renderer/tvgLoadModule.h
@@ -23,6 +23,8 @@
 #ifndef _TVG_LOAD_MODULE_H_
 #define _TVG_LOAD_MODULE_H_
 
+#include <atomic>
+#include "tvgCommon.h"
 #include "tvgRender.h"
 #include "tvgInlist.h"
 
@@ -38,7 +40,7 @@ struct LoadModule
     };
 
     FileType type;                                  //current loader file type
-    uint16_t sharing = 0;                           //reference count
+    atomic<uint16_t> sharing{};                     //reference count
     bool readied = false;                           //read done already.
     bool pathcache = false;                         //cached by path
 
@@ -77,7 +79,7 @@ struct LoadModule
 
 struct ImageLoader : LoadModule
 {
-    static ColorSpace cs;                           //desired value
+    static atomic<ColorSpace> cs;                   //desired value
 
     float w = 0, h = 0;                             //default image size
     RenderSurface surface;
@@ -95,14 +97,21 @@ struct ImageLoader : LoadModule
 };
 
 
+struct FontMetrics
+{
+    //TODO: add necessary metrics
+    float minw;
+};
+
+
 struct FontLoader : LoadModule
 {
-    float scale = 1.0f;
-
     FontLoader(FileType type) : LoadModule(type) {}
 
-    virtual bool request(Shape* shape, char* text) = 0;
-    virtual bool transform(Paint* paint, float fontSize, bool italic) = 0;
+    using LoadModule::read;
+
+    virtual bool read(Shape* shape, char* text, FontMetrics& out) = 0;
+    virtual float transform(Paint* paint, FontMetrics& mertrics, float fontSize, bool italic) = 0;
 };
 
 #endif //_TVG_LOAD_MODULE_H_

--- a/thirdparty/thorvg/src/renderer/tvgRender.h
+++ b/thirdparty/thorvg/src/renderer/tvgRender.h
@@ -35,6 +35,8 @@ namespace tvg
 using RenderData = void*;
 using pixel_t = uint32_t;
 
+#define DASH_PATTERN_THRESHOLD 0.001f
+
 enum RenderUpdateFlag : uint8_t {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, GradientStroke = 64, Blend = 128, All = 255};
 enum CompositionFlag : uint8_t {Invalid = 0, Opacity = 1, Blending = 2, Masking = 4, PostProcessing = 8};  //Composition Purpose
 

--- a/thirdparty/thorvg/src/renderer/tvgTaskScheduler.cpp
+++ b/thirdparty/thorvg/src/renderer/tvgTaskScheduler.cpp
@@ -40,8 +40,6 @@ static TaskSchedulerImpl* inst = nullptr;
 
 #ifdef THORVG_THREAD_SUPPORT
 
-static thread_local bool _async = true;
-
 struct TaskQueue {
     Inlist<Task>             taskDeque;
     mutex                    mtx;
@@ -157,7 +155,7 @@ struct TaskSchedulerImpl
     void request(Task* task)
     {
         //Async
-        if (threads.count > 0 && _async) {
+        if (threads.count > 0) {
             task->prepare();
             auto i = idx++;
             for (uint32_t n = 0; n < threads.count; ++n) {
@@ -177,8 +175,6 @@ struct TaskSchedulerImpl
 };
 
 #else //THORVG_THREAD_SUPPORT
-
-static bool _async = true;
 
 struct TaskSchedulerImpl
 {
@@ -219,11 +215,4 @@ uint32_t TaskScheduler::threads()
 {
     if (inst) return inst->threadCnt();
     return 0;
-}
-
-
-void TaskScheduler::async(bool on)
-{
-    //toggle async tasking for each thread on/off
-    _async = on;
 }

--- a/thirdparty/thorvg/src/renderer/tvgTaskScheduler.h
+++ b/thirdparty/thorvg/src/renderer/tvgTaskScheduler.h
@@ -103,7 +103,6 @@ struct TaskScheduler
     static void init(uint32_t threads);
     static void term();
     static void request(Task* task);
-    static void async(bool on);
 };
 
 }  //namespace

--- a/thirdparty/thorvg/update-thorvg.sh
+++ b/thirdparty/thorvg/update-thorvg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-VERSION=0.15.11
+VERSION=0.15.12
 # Uncomment and set a git hash to use specific commit instead of tag.
 #GIT_COMMIT=
 


### PR DESCRIPTION
https://github.com/thorvg/thorvg/releases/tag/v0.15.12
<details open>
<summary>Changes</summary>

- [Renderer] Improved thread safety during font loading.
- [Renderer] Fixed a crash caused by extremely small stroke dash sizes.
- [SwEngine] Resolved a crash due to out-of-bounds image access.
- [GlEngine] Corrected the Luma Masking equation.
- [Lottie] Added support for wiggle effect.
- [Lottie] Improved the safety and compatibility.
- [Ttf] Improved thread safety.
- [Svg] Added support for embedded fonts.
</details>

---

Added a new patch; see https://github.com/thorvg/thorvg/pull/3394.
