### PR TITLE
ufbx: Update to 0.18.0

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -974,7 +974,7 @@ Patches:
 ## ufbx
 
 - Upstream: https://github.com/ufbx/ufbx
-- Version: 0.17.1 (6ca5309972f03625e6990f3084ff4c1cc55a09b6, 2025)
+- Version: 0.18.0 (729ab835444f5f229e5f7cff332692ce6c00415d, 2025)
 - License: MIT
 
 Files extracted from upstream source:


### PR DESCRIPTION
https://github.com/ufbx/ufbx/releases/tag/v0.18.0

**Changes from version 0.17.1 to version 0.18.0:**

- Animation curve extrapolation
- Support for new `TCDefinition` time codes
- Better support for user defined properties
- Added support for OpenUSD materials exported from 3ds Max
- Added warning/error when loading unsupported FBX versions (<3000 or >7700)
- Fixed strict warnings when compiling in C
