### PR TITLE
Fix caching of objects' class name pointer in `Object` instances.

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -249,9 +249,9 @@ void Object::cancel_free() {
 }
 
 void Object::_initialize() {
-	_class_name_ptr = _get_class_namev(); // Set the direct pointer, which is much faster to obtain, but can only happen after _initialize.
+	// Cache the class name in the object for quick reference.
+	_class_name_ptr = _get_class_namev();
 	_initialize_classv();
-	_class_name_ptr = nullptr; // May have been called from a constructor.
 }
 
 void Object::_postinitialize() {
@@ -1590,7 +1590,7 @@ void Object::initialize_class() {
 	if (initialized) {
 		return;
 	}
-	_add_class_to_classdb(get_class_static(), get_parent_class_static());
+	_add_class_to_classdb(get_class_static(), StringName());
 	_bind_methods();
 	_bind_compatibility_methods();
 	initialized = true;
@@ -1968,6 +1968,20 @@ uint32_t Object::get_edited_version() const {
 	return _edited_version;
 }
 #endif
+
+const StringName &Object::get_class_name() const {
+	if (_extension) {
+		// Can't put inside the unlikely as constructor can run it.
+		return _extension->class_name;
+	}
+
+	if (unlikely(!_class_name_ptr)) {
+		// While class is initializing / deinitializing, constructors and destructors
+		// need access to the proper class at the proper stage.
+		return *_get_class_namev();
+	}
+	return *_class_name_ptr;
+}
 
 StringName Object::get_class_name_for_extension(const GDExtension *p_library) const {
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
`Object` instances have a field called `_class_name_ptr` intended to cache accesses of their class names.
This field has been broken for a while now: It is temporarily set during `_initialize` and then reset to `null` again. This substantially decreased efficiency of the `get_class_name` function.

In actuality, `_initialize` is called only from `postinitialize_handler`, and the corresponding `ClassDB::creator`. It is never called from a constructor. For this reason, resetting the pointer was not needed.
I also made it not inline, which decreases the binary size by ~0.5mb. Since surrounding logic is more complex, this will likely not have detrimental performance impact.

With the `_class_name_ptr` guaranteed to be set (after construction anyway), `get_class` can just use it to return its string buffer instead of allocating a new one. This will substantially speed up calls of this function. In addition, a virtual function can be removed from `Object` and `GDCLASS`.

Finally, I took the opportunity to remove `get_parent_class_static`, in favour of a `supertype` declaration. This allows deduplication of the corresponding logic.

## Benchmark

I measured an unsubstantial 1% improvement in editor launch time (within measurement error):
```
 ❯ hyperfine -m25 -iw1 "bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit" "bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit"
Benchmark 1: bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      3.136 s ±  0.135 s    [User: 2.477 s, System: 0.351 s]
  Range (min … max):    2.958 s …  3.432 s    25 runs

Benchmark 2: bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      3.115 s ±  0.134 s    [User: 2.473 s, System: 0.347 s]
  Range (min … max):    2.952 s …  3.432 s    25 runs

Summary
  bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit ran
    1.01 ± 0.06 times faster than bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit
```