### PR TITLE
Validate custom directory when running from editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5702,11 +5702,6 @@ bool EditorNode::ensure_main_scene(bool p_from_native) {
 		return false;
 	}
 
-	if (!EditorNode::validate_custom_directory()) {
-		current_menu_option = -1;
-		return false;
-	}
-
 	return true;
 }
 

--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -218,6 +218,10 @@ void EditorRunBar::_run_scene(const String &p_scene_path, const Vector<String> &
 		return;
 	}
 
+	if (!EditorNode::get_singleton()->validate_custom_directory()) {
+		return;
+	}
+
 	_reset_play_buttons();
 
 	String write_movie_file;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes https://github.com/godotengine/godot/issues/103367

@KoBeWi  Found out edge cases when using F6 to start project, the validate_custom_directory won't be triggered

https://github.com/godotengine/godot/pull/103796#issuecomment-2781036564