### PR TITLE
Use `FrozenDictionary` for `NamedColors`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Frozen;
 
 namespace Godot
 {
@@ -9,7 +10,7 @@ namespace Godot
     public static class Colors
     {
         // Color names and values are derived from core/math/color_names.inc
-        internal static readonly Dictionary<string, Color> NamedColors = new Dictionary<string, Color> {
+        internal static readonly FrozenDictionary<string, Color> NamedColors = new Dictionary<string, Color> {
             { "ALICEBLUE", Colors.AliceBlue },
             { "ANTIQUEWHITE", Colors.AntiqueWhite },
             { "AQUA", Colors.Aqua },
@@ -156,7 +157,7 @@ namespace Godot
             { "WHITESMOKE", Colors.WhiteSmoke },
             { "YELLOW", Colors.Yellow },
             { "YELLOWGREEN", Colors.YellowGreen },
-        };
+        }.ToFrozenDictionary();
 
 #pragma warning disable CS1591 // Disable warning: "Missing XML comment for publicly visible type or member"
         public static Color AliceBlue => new Color(0xF0F8FFFF);


### PR DESCRIPTION
Uses a [FrozenDictionary](https://learn.microsoft.com/en-us/dotnet/api/system.collections.frozen.frozendictionary-2) which was added in .NET 8.0 for performance and to make it read-only.

## Benchmark:

| Method              | Mean     | Error     | StdDev    |
|-------------------- |---------:|----------:|----------:|
| DictionaryGet       | 8.880 ns | 0.0444 ns | 0.0415 ns |
| FrozenDictionaryGet | 6.923 ns | 0.0337 ns | 0.0299 ns |

[frozen dictionary benchmark.zip](https://github.com/user-attachments/files/19623047/frozen.dictionary.benchmark.zip)