### PR TITLE
Clean and group NavigationServer headers

### DIFF
--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -47,7 +47,6 @@ struct NavMeshGeometryParser2D {
 	Callable callback;
 };
 
-// This server exposes the `NavigationServer3D` features in the 2D world.
 class NavigationServer2D : public Object {
 	GDCLASS(NavigationServer2D, Object);
 
@@ -57,42 +56,29 @@ protected:
 	static void _bind_methods();
 
 public:
-	/// Thread safe, can be used across many threads.
 	static NavigationServer2D *get_singleton();
 
 	virtual TypedArray<RID> get_maps() const = 0;
 
-	/// Create a new map.
+	/* MAP API */
+
 	virtual RID map_create() = 0;
 
-	/// Set map active.
 	virtual void map_set_active(RID p_map, bool p_active) = 0;
-
-	/// Returns true if the map is active.
 	virtual bool map_is_active(RID p_map) const = 0;
 
-	/// Set the map cell size used to weld the navigation mesh polygons.
 	virtual void map_set_cell_size(RID p_map, real_t p_cell_size) = 0;
-
-	/// Returns the map cell size.
 	virtual real_t map_get_cell_size(RID p_map) const = 0;
 
 	virtual void map_set_use_edge_connections(RID p_map, bool p_enabled) = 0;
 	virtual bool map_get_use_edge_connections(RID p_map) const = 0;
 
-	/// Set the map edge connection margin used to weld the compatible region edges.
 	virtual void map_set_edge_connection_margin(RID p_map, real_t p_connection_margin) = 0;
-
-	/// Returns the edge connection margin of this map.
 	virtual real_t map_get_edge_connection_margin(RID p_map) const = 0;
 
-	/// Set the map link connection radius used to attach links to the nav mesh.
 	virtual void map_set_link_connection_radius(RID p_map, real_t p_connection_radius) = 0;
-
-	/// Returns the link connection radius of this map.
 	virtual real_t map_get_link_connection_radius(RID p_map) const = 0;
 
-	/// Returns the navigation path to reach the destination from the origin.
 	virtual Vector<Vector2> map_get_path(RID p_map, Vector2 p_origin, Vector2 p_destination, bool p_optimize, uint32_t p_navigation_layers = 1) = 0;
 
 	virtual Vector2 map_get_closest_point(RID p_map, const Vector2 &p_point) const = 0;
@@ -111,7 +97,8 @@ public:
 
 	virtual Vector2 map_get_random_point(RID p_map, uint32_t p_navigation_layers, bool p_uniformly) const = 0;
 
-	/// Creates a new region.
+	/* REGION API */
+
 	virtual RID region_create() = 0;
 	virtual uint32_t region_get_iteration_id(RID p_region) const = 0;
 
@@ -121,36 +108,28 @@ public:
 	virtual void region_set_use_edge_connections(RID p_region, bool p_enabled) = 0;
 	virtual bool region_get_use_edge_connections(RID p_region) const = 0;
 
-	/// Set the enter_cost of a region
 	virtual void region_set_enter_cost(RID p_region, real_t p_enter_cost) = 0;
 	virtual real_t region_get_enter_cost(RID p_region) const = 0;
 
-	/// Set the travel_cost of a region
 	virtual void region_set_travel_cost(RID p_region, real_t p_travel_cost) = 0;
 	virtual real_t region_get_travel_cost(RID p_region) const = 0;
 
-	/// Set the node which manages this region.
 	virtual void region_set_owner_id(RID p_region, ObjectID p_owner_id) = 0;
 	virtual ObjectID region_get_owner_id(RID p_region) const = 0;
 
 	virtual bool region_owns_point(RID p_region, const Vector2 &p_point) const = 0;
 
-	/// Set the map of this region.
 	virtual void region_set_map(RID p_region, RID p_map) = 0;
 	virtual RID region_get_map(RID p_region) const = 0;
 
-	/// Set the region's layers
 	virtual void region_set_navigation_layers(RID p_region, uint32_t p_navigation_layers) = 0;
 	virtual uint32_t region_get_navigation_layers(RID p_region) const = 0;
 
-	/// Set the global transformation of this region.
 	virtual void region_set_transform(RID p_region, Transform2D p_transform) = 0;
 	virtual Transform2D region_get_transform(RID p_region) const = 0;
 
-	/// Set the navigation poly of this region.
 	virtual void region_set_navigation_polygon(RID p_region, Ref<NavigationPolygon> p_navigation_polygon) = 0;
 
-	/// Get a list of a region's connection to other regions.
 	virtual int region_get_connections_count(RID p_region) const = 0;
 	virtual Vector2 region_get_connection_pathway_start(RID p_region, int p_connection_id) const = 0;
 	virtual Vector2 region_get_connection_pathway_end(RID p_region, int p_connection_id) const = 0;
@@ -159,48 +138,41 @@ public:
 	virtual Vector2 region_get_random_point(RID p_region, uint32_t p_navigation_layers, bool p_uniformly) const = 0;
 	virtual Rect2 region_get_bounds(RID p_region) const = 0;
 
-	/// Creates a new link between positions in the nav map.
+	/* LINK API */
+
 	virtual RID link_create() = 0;
 
-	/// Set the map of this link.
 	virtual void link_set_map(RID p_link, RID p_map) = 0;
 	virtual RID link_get_map(RID p_link) const = 0;
 
 	virtual void link_set_enabled(RID p_link, bool p_enabled) = 0;
 	virtual bool link_get_enabled(RID p_link) const = 0;
 
-	/// Set whether this link travels in both directions.
 	virtual void link_set_bidirectional(RID p_link, bool p_bidirectional) = 0;
 	virtual bool link_is_bidirectional(RID p_link) const = 0;
 
-	/// Set the link's layers.
 	virtual void link_set_navigation_layers(RID p_link, uint32_t p_navigation_layers) = 0;
 	virtual uint32_t link_get_navigation_layers(RID p_link) const = 0;
 
-	/// Set the start position of the link.
 	virtual void link_set_start_position(RID p_link, Vector2 p_position) = 0;
 	virtual Vector2 link_get_start_position(RID p_link) const = 0;
 
-	/// Set the end position of the link.
 	virtual void link_set_end_position(RID p_link, Vector2 p_position) = 0;
 	virtual Vector2 link_get_end_position(RID p_link) const = 0;
 
-	/// Set the enter cost of the link.
 	virtual void link_set_enter_cost(RID p_link, real_t p_enter_cost) = 0;
 	virtual real_t link_get_enter_cost(RID p_link) const = 0;
 
-	/// Set the travel cost of the link.
 	virtual void link_set_travel_cost(RID p_link, real_t p_travel_cost) = 0;
 	virtual real_t link_get_travel_cost(RID p_link) const = 0;
 
-	/// Set the node which manages this link.
 	virtual void link_set_owner_id(RID p_link, ObjectID p_owner_id) = 0;
 	virtual ObjectID link_get_owner_id(RID p_link) const = 0;
 
-	/// Creates the agent.
+	/* AGENT API */
+
 	virtual RID agent_create() = 0;
 
-	/// Put the agent in the map.
 	virtual void agent_set_map(RID p_agent, RID p_map) = 0;
 	virtual RID agent_get_map(RID p_agent) const = 0;
 
@@ -210,64 +182,33 @@ public:
 	virtual void agent_set_avoidance_enabled(RID p_agent, bool p_enabled) = 0;
 	virtual bool agent_get_avoidance_enabled(RID p_agent) const = 0;
 
-	/// The maximum distance (center point to
-	/// center point) to other agents this agent
-	/// takes into account in the navigation. The
-	/// larger this number, the longer the running
-	/// time of the simulation. If the number is too
-	/// low, the simulation will not be safe.
-	/// Must be non-negative.
 	virtual void agent_set_neighbor_distance(RID p_agent, real_t p_distance) = 0;
 	virtual real_t agent_get_neighbor_distance(RID p_agent) const = 0;
 
-	/// The maximum number of other agents this
-	/// agent takes into account in the navigation.
-	/// The larger this number, the longer the
-	/// running time of the simulation. If the
-	/// number is too low, the simulation will not
-	/// be safe.
 	virtual void agent_set_max_neighbors(RID p_agent, int p_count) = 0;
 	virtual int agent_get_max_neighbors(RID p_agent) const = 0;
 
-	/// The minimal amount of time for which this
-	/// agent's velocities that are computed by the
-	/// simulation are safe with respect to other
-	/// agents. The larger this number, the sooner
-	/// this agent will respond to the presence of
-	/// other agents, but the less freedom this
-	/// agent has in choosing its velocities.
-	/// Must be positive.
 	virtual void agent_set_time_horizon_agents(RID p_agent, real_t p_time_horizon) = 0;
 	virtual real_t agent_get_time_horizon_agents(RID p_agent) const = 0;
 	virtual void agent_set_time_horizon_obstacles(RID p_agent, real_t p_time_horizon) = 0;
 	virtual real_t agent_get_time_horizon_obstacles(RID p_agent) const = 0;
 
-	/// The radius of this agent.
-	/// Must be non-negative.
 	virtual void agent_set_radius(RID p_agent, real_t p_radius) = 0;
 	virtual real_t agent_get_radius(RID p_agent) const = 0;
 
-	/// The maximum speed of this agent.
-	/// Must be non-negative.
 	virtual void agent_set_max_speed(RID p_agent, real_t p_max_speed) = 0;
 	virtual real_t agent_get_max_speed(RID p_agent) const = 0;
 
-	/// forces and agent velocity change in the avoidance simulation, adds simulation instability if done recklessly
 	virtual void agent_set_velocity_forced(RID p_agent, Vector2 p_velocity) = 0;
 
-	/// The wanted velocity for the agent as a "suggestion" to the avoidance simulation.
-	/// The simulation will try to fulfill this velocity wish if possible but may change the velocity depending on other agent's and obstacles'.
 	virtual void agent_set_velocity(RID p_agent, Vector2 p_velocity) = 0;
 	virtual Vector2 agent_get_velocity(RID p_agent) const = 0;
 
-	/// Position of the agent in world space.
 	virtual void agent_set_position(RID p_agent, Vector2 p_position) = 0;
 	virtual Vector2 agent_get_position(RID p_agent) const = 0;
 
-	/// Returns true if the map got changed the previous frame.
 	virtual bool agent_is_map_changed(RID p_agent) const = 0;
 
-	/// Callback called at the end of the RVO process
 	virtual void agent_set_avoidance_callback(RID p_agent, Callable p_callback) = 0;
 	virtual bool agent_has_avoidance_callback(RID p_agent) const = 0;
 
@@ -280,7 +221,8 @@ public:
 	virtual void agent_set_avoidance_priority(RID p_agent, real_t p_priority) = 0;
 	virtual real_t agent_get_avoidance_priority(RID p_agent) const = 0;
 
-	/// Creates the obstacle.
+	/* OBSTACLE API */
+
 	virtual RID obstacle_create() = 0;
 	virtual void obstacle_set_avoidance_enabled(RID p_obstacle, bool p_enabled) = 0;
 	virtual bool obstacle_get_avoidance_enabled(RID p_obstacle) const = 0;
@@ -299,24 +241,11 @@ public:
 	virtual void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) = 0;
 	virtual uint32_t obstacle_get_avoidance_layers(RID p_obstacle) const = 0;
 
-	/// Returns a customized navigation path using a query parameters object
+	/* QUERY API */
+
 	virtual void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result, const Callable &p_callback = Callable()) = 0;
 
-	/// Control activation of this server.
-	virtual void set_active(bool p_active) = 0;
-
-	/// Process the collision avoidance agents.
-	/// The result of this process is needed by the physics server,
-	/// so this must be called in the main thread.
-	/// Note: This function is not thread safe.
-	virtual void process(double p_delta_time) = 0;
-	virtual void physics_process(double p_delta_time) = 0;
-	virtual void init() = 0;
-	virtual void sync() = 0;
-	virtual void finish() = 0;
-
-	/// Destroy the `RID`
-	virtual void free(RID p_object) = 0;
+	/* NAVMESH BAKE API */
 
 	virtual void parse_source_geometry_data(const Ref<NavigationPolygon> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData2D> &p_source_geometry_data, Node *p_root_node, const Callable &p_callback = Callable()) = 0;
 	virtual void bake_from_source_geometry_data(const Ref<NavigationPolygon> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData2D> &p_source_geometry_data, const Callable &p_callback = Callable()) = 0;
@@ -334,8 +263,20 @@ public:
 
 	virtual Vector<Vector2> simplify_path(const Vector<Vector2> &p_path, real_t p_epsilon) = 0;
 
+	/* SERVER API */
+
+	virtual void set_active(bool p_active) = 0;
+	virtual void process(double p_delta_time) = 0;
+	virtual void physics_process(double p_delta_time) = 0;
+	virtual void init() = 0;
+	virtual void sync() = 0;
+	virtual void finish() = 0;
+	virtual void free(RID p_object) = 0;
+
 	NavigationServer2D();
 	~NavigationServer2D() override;
+
+	/* DEBUG API */
 
 	enum ProcessInfo {
 		INFO_ACTIVE_MAPS,

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -43,13 +43,6 @@ struct NavMeshGeometryParser3D {
 	Callable callback;
 };
 
-/// This server uses the concept of internal mutability.
-/// All the constant functions can be called in multithread because internally
-/// the server takes care to schedule the functions access.
-///
-/// Note: All the `set` functions are commands executed during the `sync` phase,
-/// don't expect that a change is immediately propagated.
-
 class NavigationServer3D : public Object {
 	GDCLASS(NavigationServer3D, Object);
 
@@ -59,30 +52,21 @@ protected:
 	static void _bind_methods();
 
 public:
-	/// Thread safe, can be used across many threads.
 	static NavigationServer3D *get_singleton();
 
 	virtual TypedArray<RID> get_maps() const = 0;
 
-	/// Create a new map.
+	/* MAP API */
+
 	virtual RID map_create() = 0;
 
-	/// Set map active.
 	virtual void map_set_active(RID p_map, bool p_active) = 0;
-
-	/// Returns true if the map is active.
 	virtual bool map_is_active(RID p_map) const = 0;
 
-	/// Set the map UP direction.
 	virtual void map_set_up(RID p_map, Vector3 p_up) = 0;
-
-	/// Returns the map UP direction.
 	virtual Vector3 map_get_up(RID p_map) const = 0;
 
-	/// Set the map cell size used to weld the navigation mesh polygons.
 	virtual void map_set_cell_size(RID p_map, real_t p_cell_size) = 0;
-
-	/// Returns the map cell size.
 	virtual real_t map_get_cell_size(RID p_map) const = 0;
 
 	virtual void map_set_cell_height(RID p_map, real_t p_height) = 0;
@@ -94,19 +78,12 @@ public:
 	virtual void map_set_use_edge_connections(RID p_map, bool p_enabled) = 0;
 	virtual bool map_get_use_edge_connections(RID p_map) const = 0;
 
-	/// Set the map edge connection margin used to weld the compatible region edges.
 	virtual void map_set_edge_connection_margin(RID p_map, real_t p_connection_margin) = 0;
-
-	/// Returns the edge connection margin of this map.
 	virtual real_t map_get_edge_connection_margin(RID p_map) const = 0;
 
-	/// Set the map link connection radius used to attach links to the nav mesh.
 	virtual void map_set_link_connection_radius(RID p_map, real_t p_connection_radius) = 0;
-
-	/// Returns the link connection radius of this map.
 	virtual real_t map_get_link_connection_radius(RID p_map) const = 0;
 
-	/// Returns the navigation path to reach the destination from the origin.
 	virtual Vector<Vector3> map_get_path(RID p_map, Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_navigation_layers = 1) = 0;
 
 	virtual Vector3 map_get_closest_point_to_segment(RID p_map, const Vector3 &p_from, const Vector3 &p_to, const bool p_use_collision = false) const = 0;
@@ -127,7 +104,8 @@ public:
 
 	virtual Vector3 map_get_random_point(RID p_map, uint32_t p_navigation_layers, bool p_uniformly) const = 0;
 
-	/// Creates a new region.
+	/* REGION API */
+
 	virtual RID region_create() = 0;
 	virtual uint32_t region_get_iteration_id(RID p_region) const = 0;
 
@@ -137,41 +115,32 @@ public:
 	virtual void region_set_use_edge_connections(RID p_region, bool p_enabled) = 0;
 	virtual bool region_get_use_edge_connections(RID p_region) const = 0;
 
-	/// Set the enter_cost of a region
 	virtual void region_set_enter_cost(RID p_region, real_t p_enter_cost) = 0;
 	virtual real_t region_get_enter_cost(RID p_region) const = 0;
 
-	/// Set the travel_cost of a region
 	virtual void region_set_travel_cost(RID p_region, real_t p_travel_cost) = 0;
 	virtual real_t region_get_travel_cost(RID p_region) const = 0;
 
-	/// Set the node which manages this region.
 	virtual void region_set_owner_id(RID p_region, ObjectID p_owner_id) = 0;
 	virtual ObjectID region_get_owner_id(RID p_region) const = 0;
 
 	virtual bool region_owns_point(RID p_region, const Vector3 &p_point) const = 0;
 
-	/// Set the map of this region.
 	virtual void region_set_map(RID p_region, RID p_map) = 0;
 	virtual RID region_get_map(RID p_region) const = 0;
 
-	/// Set the region's layers
 	virtual void region_set_navigation_layers(RID p_region, uint32_t p_navigation_layers) = 0;
 	virtual uint32_t region_get_navigation_layers(RID p_region) const = 0;
 
-	/// Set the global transformation of this region.
 	virtual void region_set_transform(RID p_region, Transform3D p_transform) = 0;
 	virtual Transform3D region_get_transform(RID p_region) const = 0;
 
-	/// Set the navigation mesh of this region.
 	virtual void region_set_navigation_mesh(RID p_region, Ref<NavigationMesh> p_navigation_mesh) = 0;
 
 #ifndef DISABLE_DEPRECATED
-	/// Bake the navigation mesh.
 	virtual void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) = 0;
 #endif // DISABLE_DEPRECATED
 
-	/// Get a list of a region's connection to other regions.
 	virtual int region_get_connections_count(RID p_region) const = 0;
 	virtual Vector3 region_get_connection_pathway_start(RID p_region, int p_connection_id) const = 0;
 	virtual Vector3 region_get_connection_pathway_end(RID p_region, int p_connection_id) const = 0;
@@ -183,48 +152,41 @@ public:
 
 	virtual AABB region_get_bounds(RID p_region) const = 0;
 
-	/// Creates a new link between positions in the nav map.
+	/* LINK API */
+
 	virtual RID link_create() = 0;
 
-	/// Set the map of this link.
 	virtual void link_set_map(RID p_link, RID p_map) = 0;
 	virtual RID link_get_map(RID p_link) const = 0;
 
 	virtual void link_set_enabled(RID p_link, bool p_enabled) = 0;
 	virtual bool link_get_enabled(RID p_link) const = 0;
 
-	/// Set whether this link travels in both directions.
 	virtual void link_set_bidirectional(RID p_link, bool p_bidirectional) = 0;
 	virtual bool link_is_bidirectional(RID p_link) const = 0;
 
-	/// Set the link's layers.
 	virtual void link_set_navigation_layers(RID p_link, uint32_t p_navigation_layers) = 0;
 	virtual uint32_t link_get_navigation_layers(RID p_link) const = 0;
 
-	/// Set the start position of the link.
 	virtual void link_set_start_position(RID p_link, Vector3 p_position) = 0;
 	virtual Vector3 link_get_start_position(RID p_link) const = 0;
 
-	/// Set the end position of the link.
 	virtual void link_set_end_position(RID p_link, Vector3 p_position) = 0;
 	virtual Vector3 link_get_end_position(RID p_link) const = 0;
 
-	/// Set the enter cost of the link.
 	virtual void link_set_enter_cost(RID p_link, real_t p_enter_cost) = 0;
 	virtual real_t link_get_enter_cost(RID p_link) const = 0;
 
-	/// Set the travel cost of the link.
 	virtual void link_set_travel_cost(RID p_link, real_t p_travel_cost) = 0;
 	virtual real_t link_get_travel_cost(RID p_link) const = 0;
 
-	/// Set the node which manages this link.
 	virtual void link_set_owner_id(RID p_link, ObjectID p_owner_id) = 0;
 	virtual ObjectID link_get_owner_id(RID p_link) const = 0;
 
-	/// Creates the agent.
+	/* AGENT API */
+
 	virtual RID agent_create() = 0;
 
-	/// Put the agent in the map.
 	virtual void agent_set_map(RID p_agent, RID p_map) = 0;
 	virtual RID agent_get_map(RID p_agent) const = 0;
 
@@ -237,66 +199,37 @@ public:
 	virtual void agent_set_use_3d_avoidance(RID p_agent, bool p_enabled) = 0;
 	virtual bool agent_get_use_3d_avoidance(RID p_agent) const = 0;
 
-	/// The maximum distance (center point to
-	/// center point) to other agents this agent
-	/// takes into account in the navigation. The
-	/// larger this number, the longer the running
-	/// time of the simulation. If the number is too
-	/// low, the simulation will not be safe.
-	/// Must be non-negative.
 	virtual void agent_set_neighbor_distance(RID p_agent, real_t p_distance) = 0;
 	virtual real_t agent_get_neighbor_distance(RID p_agent) const = 0;
 
-	/// The maximum number of other agents this
-	/// agent takes into account in the navigation.
-	/// The larger this number, the longer the
-	/// running time of the simulation. If the
-	/// number is too low, the simulation will not
-	/// be safe.
 	virtual void agent_set_max_neighbors(RID p_agent, int p_count) = 0;
 	virtual int agent_get_max_neighbors(RID p_agent) const = 0;
 
-	// Sets the minimum amount of time in seconds that an agent's
-	// must be able to stay on the calculated velocity while still avoiding collisions with agent's
-	// if this value is set to high an agent will often fall back to using a very low velocity just to be safe
 	virtual void agent_set_time_horizon_agents(RID p_agent, real_t p_time_horizon) = 0;
 	virtual real_t agent_get_time_horizon_agents(RID p_agent) const = 0;
 
-	/// Sets the minimum amount of time in seconds that an agent's
-	// must be able to stay on the calculated velocity while still avoiding collisions with obstacle's
-	// if this value is set to high an agent will often fall back to using a very low velocity just to be safe
 	virtual void agent_set_time_horizon_obstacles(RID p_agent, real_t p_time_horizon) = 0;
 	virtual real_t agent_get_time_horizon_obstacles(RID p_agent) const = 0;
 
-	/// The radius of this agent.
-	/// Must be non-negative.
 	virtual void agent_set_radius(RID p_agent, real_t p_radius) = 0;
 	virtual real_t agent_get_radius(RID p_agent) const = 0;
 
 	virtual void agent_set_height(RID p_agent, real_t p_height) = 0;
 	virtual real_t agent_get_height(RID p_agent) const = 0;
 
-	/// The maximum speed of this agent.
-	/// Must be non-negative.
 	virtual void agent_set_max_speed(RID p_agent, real_t p_max_speed) = 0;
 	virtual real_t agent_get_max_speed(RID p_agent) const = 0;
 
-	/// forces and agent velocity change in the avoidance simulation, adds simulation instability if done recklessly
 	virtual void agent_set_velocity_forced(RID p_agent, Vector3 p_velocity) = 0;
 
-	/// The wanted velocity for the agent as a "suggestion" to the avoidance simulation.
-	/// The simulation will try to fulfill this velocity wish if possible but may change the velocity depending on other agent's and obstacles'.
 	virtual void agent_set_velocity(RID p_agent, Vector3 p_velocity) = 0;
 	virtual Vector3 agent_get_velocity(RID p_agent) const = 0;
 
-	/// Position of the agent in world space.
 	virtual void agent_set_position(RID p_agent, Vector3 p_position) = 0;
 	virtual Vector3 agent_get_position(RID p_agent) const = 0;
 
-	/// Returns true if the map got changed the previous frame.
 	virtual bool agent_is_map_changed(RID p_agent) const = 0;
 
-	/// Callback called at the end of the RVO process
 	virtual void agent_set_avoidance_callback(RID p_agent, Callable p_callback) = 0;
 	virtual bool agent_has_avoidance_callback(RID p_agent) const = 0;
 
@@ -309,7 +242,8 @@ public:
 	virtual void agent_set_avoidance_priority(RID p_agent, real_t p_priority) = 0;
 	virtual real_t agent_get_avoidance_priority(RID p_agent) const = 0;
 
-	/// Creates the obstacle.
+	/* OBSTACLE API */
+
 	virtual RID obstacle_create() = 0;
 
 	virtual void obstacle_set_map(RID p_obstacle, RID p_map) = 0;
@@ -337,24 +271,11 @@ public:
 	virtual void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) = 0;
 	virtual uint32_t obstacle_get_avoidance_layers(RID p_obstacle) const = 0;
 
-	/// Destroy the `RID`
-	virtual void free(RID p_object) = 0;
+	/* QUERY API */
 
-	/// Control activation of this server.
-	virtual void set_active(bool p_active) = 0;
-
-	/// Process the collision avoidance agents.
-	/// The result of this process is needed by the physics server,
-	/// so this must be called in the main thread.
-	/// Note: This function is not thread safe.
-	virtual void process(double p_delta_time) = 0;
-	virtual void physics_process(double p_delta_time) = 0;
-	virtual void init() = 0;
-	virtual void sync() = 0;
-	virtual void finish() = 0;
-
-	/// Returns a customized navigation path using a query parameters object
 	virtual void query_path(const Ref<NavigationPathQueryParameters3D> &p_query_parameters, Ref<NavigationPathQueryResult3D> p_query_result, const Callable &p_callback = Callable()) = 0;
+
+	/* NAVMESH BAKE API */
 
 #ifndef _3D_DISABLED
 	virtual void parse_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, Node *p_root_node, const Callable &p_callback = Callable()) = 0;
@@ -374,8 +295,20 @@ public:
 
 	virtual Vector<Vector3> simplify_path(const Vector<Vector3> &p_path, real_t p_epsilon) = 0;
 
+	/* SERVER API */
+
+	virtual void set_active(bool p_active) = 0;
+	virtual void process(double p_delta_time) = 0;
+	virtual void physics_process(double p_delta_time) = 0;
+	virtual void init() = 0;
+	virtual void sync() = 0;
+	virtual void finish() = 0;
+	virtual void free(RID p_object) = 0;
+
 	NavigationServer3D();
 	~NavigationServer3D() override;
+
+	/* DEBUG API */
 
 	enum ProcessInfo {
 		INFO_ACTIVE_MAPS,


### PR DESCRIPTION
Cleans NavigationServer headers from (unhelpful) comments and groups functions.

- Most of the comments are of no value except noise as they just reword what the function name already says.
- Not just a few of the comments are ambiguous or technically wrong to begin with. I dont care to correct them with a block of text that needs to be maintained extra as all this information already exists in the actual documentation. The server api source code is the wrong place for lengthy api explainations that we have an actual documentation for.
- Some comments are highly specific to a specific backend implementation detail. That backend can change or be replaced, which already happened making these kind of comments outdated. Again, the server api source code is the wrong place to document such things.
- No Godot server has kept the same level of noisy legacy comments as the NavigationServer, not even the more or less unmaintained AudioServer. Time to spring clean.

The majority of those comments were not really helpful even when added originality, e.g. just repeating what the function name already says more or less explicitly. For some of the function it did make sense as back in the day they had cryptic function names full of abbreviations, or there was no documentation for the systems and functions at all (Godot 4 at that point had near zero user documentation for it). By now these comments are just line break noise and should go.

Groups a few of the functions so they are not all over the place so it is easier in the future to add new functions to those groups.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
