### PR TITLE
Add custom sort to center tab bar in the editor and project manager.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7723,6 +7723,7 @@ EditorNode::EditorNode() {
 	main_editor_button_hb->set_mouse_filter(Control::MOUSE_FILTER_STOP);
 	editor_main_screen->set_button_container(main_editor_button_hb);
 	title_bar->add_child(main_editor_button_hb);
+	title_bar->set_center_control(main_editor_button_hb);
 
 	// Options are added and handled by DebuggerEditorPlugin.
 	debug_menu = memnew(PopupMenu);

--- a/editor/gui/editor_title_bar.cpp
+++ b/editor/gui/editor_title_bar.cpp
@@ -80,6 +80,53 @@ void EditorTitleBar::gui_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
+void EditorTitleBar::set_center_control(Control *p_center_control) {
+	center_control = p_center_control;
+}
+
+Control *EditorTitleBar::get_center_control() const {
+	return center_control;
+}
+
+void EditorTitleBar::_notification(int p_what) {
+	if (!center_control || p_what != NOTIFICATION_SORT_CHILDREN) {
+		return;
+	}
+
+	Control *prev = nullptr;
+	Control *base = nullptr;
+	Control *next = nullptr;
+	for (int i = 0; i < get_child_count(); i++) {
+		Control *c = as_sortable_control(get_child(i));
+		if (!c) {
+			continue;
+		}
+		if (base) {
+			next = c;
+			break;
+		}
+		if (c != center_control) {
+			prev = c;
+			continue;
+		}
+		base = c;
+	}
+	if (base && prev && next) {
+		Size2i title_size = get_size();
+		Size2i c_size = base->get_combined_minimum_size();
+
+		int min_offset = prev->get_position().x + prev->get_combined_minimum_size().x;
+		int max_offset = next->get_position().x + next->get_size().x - next->get_combined_minimum_size().x - c_size.x;
+
+		int offset = (title_size.width - c_size.width) / 2;
+		offset = CLAMP(offset, min_offset, max_offset);
+
+		fit_child_in_rect(prev, Rect2i(prev->get_position().x, 0, offset - prev->get_position().x, title_size.height));
+		fit_child_in_rect(base, Rect2i(offset, 0, c_size.width, title_size.height));
+		fit_child_in_rect(next, Rect2i(offset + c_size.width, 0, next->get_position().x + next->get_size().x - (offset + c_size.width), title_size.height));
+	}
+}
+
 void EditorTitleBar::set_can_move_window(bool p_enabled) {
 	can_move = p_enabled;
 	set_process_input(can_move);

--- a/editor/gui/editor_title_bar.h
+++ b/editor/gui/editor_title_bar.h
@@ -39,12 +39,18 @@ class EditorTitleBar : public HBoxContainer {
 	Point2i click_pos;
 	bool moving = false;
 	bool can_move = false;
+	Control *center_control = nullptr;
 
 protected:
+	void _notification(int p_what);
+
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	static void _bind_methods() {}
 
 public:
+	void set_center_control(Control *p_center_control);
+	Control *get_center_control() const;
+
 	void set_can_move_window(bool p_enabled);
 	bool get_can_move_window() const;
 };

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1158,12 +1158,10 @@ void ProjectManager::_titlebar_resized() {
 	if (left_menu_spacer) {
 		int w = (root_container->is_layout_rtl()) ? margin.y : margin.x;
 		left_menu_spacer->set_custom_minimum_size(Size2(w, 0));
-		right_spacer->set_custom_minimum_size(Size2(w, 0));
 	}
 	if (right_menu_spacer) {
 		int w = (root_container->is_layout_rtl()) ? margin.x : margin.y;
 		right_menu_spacer->set_custom_minimum_size(Size2(w, 0));
-		left_spacer->set_custom_minimum_size(Size2(w, 0));
 	}
 	if (title_bar) {
 		title_bar->set_custom_minimum_size(Size2(0, margin.z - title_bar->get_global_position().y));
@@ -1309,6 +1307,7 @@ ProjectManager::ProjectManager() {
 		main_view_toggles->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		main_view_toggles->set_stretch_ratio(2.0);
 		title_bar->add_child(main_view_toggles);
+		title_bar->set_center_control(main_view_toggles);
 
 		if (can_expand) {
 			// Spacer to center main toggles.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105102

Mostly relevant for macOS, since on other platforms menu and editor buttons have almost same width and tab buttons are close to centered.

Fixes tabs centering (top - before, bottom - after):
<img width="3006" alt="Screenshot 2025-04-06 at 22 25 20" src="https://github.com/user-attachments/assets/1180add6-7ed8-4fb6-ace2-08ae5148832d" />

Also improves element fitting when window width is small:
<img width="1049" alt="Screenshot 2025-04-06 at 23 44 26" src="https://github.com/user-attachments/assets/b57b1208-3cde-40b3-bfc9-63643767683f" />