### PR TITLE
Fix `EditorHelpBitTooltip` in single window mode.

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -4555,7 +4555,7 @@ void EditorHelpBitTooltip::popup_under_cursor() {
 	// When `FLAG_POPUP` is false, it prevents the editor from losing focus when displaying the tooltip.
 	// This way, clicks and double-clicks are still available outside the tooltip.
 	set_flag(Window::FLAG_POPUP, false);
-	set_flag(Window::FLAG_NO_FOCUS, true);
+	set_flag(Window::FLAG_NO_FOCUS, !is_embedded());
 	popup(r);
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105109

Uses the same logic as other popups.