### PR TITLE
Handle the case where `waitpid` returns `errno` `EINTR`.

### DIFF
--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -71,6 +71,9 @@ class OS_Unix : public OS {
 	void _load_iconv();
 #endif
 
+	static int _wait_for_pid_completion(const pid_t p_pid, int *r_status, int p_options);
+	bool _check_pid_is_running(const pid_t p_pid, int *r_status) const;
+
 protected:
 	// UNIX only handles the core functions.
 	// inheriting platforms under unix (eg. X11) should handle the rest


### PR DESCRIPTION
Fixes #105097 

This case indicates that a debugger is attached, and `waitpid` should be called again.
Fix in reference to [this](https://stackoverflow.com/questions/21554195/why-waitpid-return-1-when-run-in-debugger) stackoverflow answer.
I'm not 100% sure this is the best way to handle it, but it seems to at least succeed in the debugger.