### PR TITLE
Add an editor setting to toggle nomedia file creation

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1142,6 +1142,10 @@
 			If [code]true[/code], enable TLSv1.3 negotiation.
 			[b]Note:[/b] Only supported when using Mbed TLS 3.0 or later (Linux distribution packages may be compiled against older system Mbed TLS packages), otherwise the maximum supported TLS version is always TLSv1.2.
 		</member>
+		<member name="project_manager/auto_create_nomedia_file" type="bool" setter="" getter="">
+			If [code]true[/code], the editor automatically creates a [code].nomedia[/code] file in the project's root directory to prevent media files from appearing in Android's gallery or media library apps.
+			[b]Note:[/b] Only available in the Android editor.
+		</member>
 		<member name="project_manager/default_renderer" type="String" setter="" getter="">
 			The renderer type that will be checked off by default when creating a new project. Accepted strings are "forward_plus", "mobile" or "gl_compatibility".
 		</member>

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1069,15 +1069,17 @@ void EditorFileSystem::scan() {
 	if (first_scan) {
 		_first_scan_filesystem();
 #ifdef ANDROID_ENABLED
-		const String nomedia_file_path = ProjectSettings::get_singleton()->get_resource_path().path_join(".nomedia");
-		if (!FileAccess::exists(nomedia_file_path)) {
-			// Create a .nomedia file to hide assets from media apps on Android.
-			Ref<FileAccess> f = FileAccess::open(nomedia_file_path, FileAccess::WRITE);
-			if (f.is_null()) {
-				// .nomedia isn't so critical.
-				ERR_PRINT("Couldn't create .nomedia in project path.");
-			} else {
-				f->close();
+		if (EDITOR_GET("project_manager/auto_create_nomedia_file")) {
+			const String nomedia_file_path = ProjectSettings::get_singleton()->get_resource_path().path_join(".nomedia");
+			if (!FileAccess::exists(nomedia_file_path)) {
+				// Create a .nomedia file to hide assets from media apps on Android.
+				Ref<FileAccess> f = FileAccess::open(nomedia_file_path, FileAccess::WRITE);
+				if (f.is_null()) {
+					// .nomedia isn't so critical.
+					ERR_PRINT("Couldn't create .nomedia in project path.");
+				} else {
+					f->close();
+				}
 			}
 		}
 #endif

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1052,6 +1052,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	const String default_renderer = "forward_plus";
 #endif
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_ENUM, "project_manager/default_renderer", default_renderer, "forward_plus,mobile,gl_compatibility")
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "project_manager/auto_create_nomedia_file", true, "")
 
 #undef EDITOR_SETTING
 #undef EDITOR_SETTING_BASIC

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -726,14 +726,16 @@ void ProjectDialog::ok_pressed() {
 	hide();
 	if (mode == MODE_NEW || mode == MODE_IMPORT || mode == MODE_INSTALL) {
 #ifdef ANDROID_ENABLED
-		// Create a .nomedia file to hide assets from media apps on Android.
-		const String nomedia_file_path = path.path_join(".nomedia");
-		Ref<FileAccess> f2 = FileAccess::open(nomedia_file_path, FileAccess::WRITE);
-		if (f2.is_null()) {
-			// .nomedia isn't so critical.
-			ERR_PRINT("Couldn't create .nomedia in project path.");
-		} else {
-			f2->close();
+		if (EDITOR_GET("project_manager/auto_create_nomedia_file")) {
+			// Create a .nomedia file to hide assets from media apps on Android.
+			const String nomedia_file_path = path.path_join(".nomedia");
+			Ref<FileAccess> f2 = FileAccess::open(nomedia_file_path, FileAccess::WRITE);
+			if (f2.is_null()) {
+				// .nomedia isn't so critical.
+				ERR_PRINT("Couldn't create .nomedia in project path.");
+			} else {
+				f2->close();
+			}
 		}
 #endif
 		emit_signal(SNAME("project_created"), path, edit_check_box->is_pressed());


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/104970

This PR introduces an editor setting `project_manager/auto_create_nomedia_file` to toggle automatic `.nomedia` file creation. This is enabled by default.

Initially, I didn’t think an editor setting was necessary since it only affects a single file, but some users might prefer having full control over this behavior 🙂  See: https://github.com/godotengine/godot-proposals/issues/10364#issuecomment-2777873894