### PR TITLE
[.NET] Expose PropertyUsageFlags on ExportAttribute to match @export_custom()

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -592,11 +592,11 @@ namespace Godot.SourceGenerators
                     hintString: hintString, PropertyUsageFlags.ScriptVariable, exported: false);
             }
 
+            var constructorArguments = exportAttr.ConstructorArguments;
+
             if (!TryGetMemberExportHint(typeCache, memberType, exportAttr, memberVariantType,
                     isTypeArgument: false, out var hint, out hintString))
             {
-                var constructorArguments = exportAttr.ConstructorArguments;
-
                 if (constructorArguments.Length > 0)
                 {
                     var hintValue = exportAttr.ConstructorArguments[0].Value;
@@ -618,7 +618,21 @@ namespace Godot.SourceGenerators
                 }
             }
 
-            var propUsage = PropertyUsageFlags.Default | PropertyUsageFlags.ScriptVariable;
+            var propUsage = PropertyUsageFlags.Default;
+
+            if (constructorArguments.Length > 2)
+            {
+                var usageValue = exportAttr.ConstructorArguments[2].Value;
+
+                propUsage = usageValue switch
+                {
+                    null => PropertyUsageFlags.Default,
+                    int intValue => (PropertyUsageFlags)intValue,
+                    _ => (PropertyUsageFlags)(long)usageValue
+                };
+            }
+
+            propUsage |= PropertyUsageFlags.ScriptVariable;
 
             if (memberVariantType == VariantType.Nil)
                 propUsage |= PropertyUsageFlags.NilIsVariant;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
@@ -19,14 +19,23 @@ namespace Godot
         public string HintString { get; }
 
         /// <summary>
+        /// Optional usage flags that determine how the property should be handled by the editor.<br/>
+        /// Note: Regardless of the usage value, the <see cref="PropertyUsageFlags.ScriptVariable"/> flag is always added,
+        /// as with any explicitly declared script variable.
+        /// </summary>
+        public PropertyUsageFlags Usage { get; }
+
+        /// <summary>
         /// Constructs a new ExportAttribute Instance.
         /// </summary>
         /// <param name="hint">The hint for the exported property.</param>
         /// <param name="hintString">A string that may contain additional metadata for the hint.</param>
-        public ExportAttribute(PropertyHint hint = PropertyHint.None, string hintString = "")
+        /// <param name="usage">The usage flags for the exported property.</param>
+        public ExportAttribute(PropertyHint hint = PropertyHint.None, string hintString = "", PropertyUsageFlags usage = PropertyUsageFlags.Default)
         {
             Hint = hint;
             HintString = hintString;
+            Usage = usage;
         }
     }
 }


### PR DESCRIPTION
This adds the `PropertyUsageFlags` value to the `[Export]` attribute in C#. It now matches GDScript's `@export_custom(usage: ...)` attribute, allowing the usage flags to be set much easier. Previously this was only possible with  `_ValidateProperty(...)` in C#, which is very cumbersome.

Example:
```csharp
[Export(usage: PropertyUsageFlags.NoEditor)]
private bool _hiddenVariable;
```

edit: updated the pr to fix some issues I noticed
