### PR TITLE
Implement importer resolution scale to reduce texture quality without affecting size

### DIFF
--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -151,6 +151,10 @@
 			- In 2D, a [CanvasItemMaterial] will need to be created and configured to use the [constant CanvasItemMaterial.BLEND_MODE_PREMULT_ALPHA] blend mode on [CanvasItem]s that use this texture. In custom [code]@canvas_item[/code] shaders, [code]render_mode blend_premul_alpha;[/code] should be used.
 			- In 3D, a [BaseMaterial3D] will need to be created and configured to use the [constant BaseMaterial3D.BLEND_MODE_PREMULT_ALPHA] blend mode on materials that use this texture. In custom [code]spatial[/code] shaders, [code]render_mode blend_premul_alpha;[/code] should be used.
 		</member>
+		<member name="process/resolution_scale" type="float" setter="" getter="" default="1.0">
+			Scales the texture resolution without affecting the size-related properties of the [Texture2D] that are used rendering and scripting. Lower values significantly reduce image disk size and VRAM usage and reduce image quality because of downscaling.
+			[b]Note:[/b] This will cause [method RenderingServer.texture_2d_get] to return a downscaled image, and affect the performance of [method Texture2D.get_image] because it returns an image upscaled to the original size.
+		</member>
 		<member name="process/size_limit" type="int" setter="" getter="" default="0">
 			If set to a value greater than [code]0[/code], the size of the texture is limited on import to a value smaller than or equal to the value specified here. For non-square textures, the size limit affects the longer dimension, with the shorter dimension scaled to preserve aspect ratio. Resizing is performed using cubic interpolation.
 			This can be used to reduce memory usage without affecting the source images, or avoid issues with textures not displaying on mobile/web platforms (as these usually can't display textures larger than 4096×4096).

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -86,7 +86,7 @@ protected:
 	static ResourceImporterTexture *singleton;
 	static const char *compression_formats[];
 
-	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
+	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel, float p_resolution_scale);
 	void _save_editor_meta(const Dictionary &p_metadata, const String &p_to_path);
 	Dictionary _load_editor_meta(const String &p_to_path) const;
 

--- a/editor/scene/texture/texture_editor_plugin.cpp
+++ b/editor/scene/texture/texture_editor_plugin.cpp
@@ -148,7 +148,7 @@ static int get_texture_mipmaps_count(const Ref<Texture2D> &p_texture) {
 			image = atlas->get_image();
 		}
 	} else {
-		image = p_texture->get_image();
+		image = RS::get_singleton()->texture_2d_get(p_texture->get_rid());
 	}
 
 	if (image.is_valid()) {
@@ -165,7 +165,9 @@ void TexturePreview::_update_metadata_label_text() {
 
 	const String format_name = format != Image::FORMAT_MAX ? Image::get_format_name(format) : texture->get_class();
 
-	const Vector2i resolution = texture->get_size();
+	const Ref<Image> img = RS::get_singleton()->texture_2d_get(texture->get_rid());
+	ERR_FAIL_COND(img.is_null());
+	const Vector2i resolution = img->get_size();
 	const int mipmaps = get_texture_mipmaps_count(texture);
 
 	if (format != Image::FORMAT_MAX) {
@@ -184,24 +186,15 @@ void TexturePreview::_update_metadata_label_text() {
 		}
 		memory *= mipmaps_multiplier;
 
-		if (mipmaps >= 1) {
-			metadata_label->set_text(
-					vformat(String::utf8("%d×%d %s\n") + TTR("%s Mipmaps") + "\n" + TTR("Memory: %s"),
-							texture->get_width(),
-							texture->get_height(),
-							format_name,
-							mipmaps,
-							String::humanize_size(memory)));
-		} else {
-			// "No Mipmaps" is easier to distinguish than "0 Mipmaps",
-			// especially since 0, 6, and 8 look quite close with the default code font.
-			metadata_label->set_text(
-					vformat(String::utf8("%d×%d %s\n") + TTR("No Mipmaps") + "\n" + TTR("Memory: %s"),
-							texture->get_width(),
-							texture->get_height(),
-							format_name,
-							String::humanize_size(memory)));
-		}
+		String texture_size_str = texture->get_size() != resolution ? vformat(String::utf8("(%d×%d)"), texture->get_width(), texture->get_height()) : "";
+		String mipmaps_str = mipmaps >= 1 ? vformat("%d Mipmaps", mipmaps) : "No Mipmaps";
+		metadata_label->set_text(
+				vformat(String::utf8("%d×%d %s %s\n") + TTR(mipmaps_str) + "\n" + TTR("Memory: %s"),
+						resolution.width,
+						resolution.height,
+						format_name,
+						texture_size_str,
+						String::humanize_size(memory)));
 	} else {
 		metadata_label->set_text(
 				vformat(String::utf8("%d×%d %s"),

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -238,7 +238,17 @@ bool CompressedTexture2D::has_alpha() const {
 
 Ref<Image> CompressedTexture2D::get_image() const {
 	if (texture.is_valid()) {
-		return RS::get_singleton()->texture_2d_get(texture);
+		Ref<Image> img = RS::get_singleton()->texture_2d_get(texture);
+		if (img->get_width() != w && img->get_height() != h) {
+			if (Engine::get_singleton()->is_editor_hint()) {
+				img = img->duplicate();
+			}
+			if (img->is_compressed()) {
+				img->decompress();
+			}
+			img->resize(w, h);
+		}
+		return img;
 	} else {
 		return Ref<Image>();
 	}


### PR DESCRIPTION
- Implements the texture import part of https://github.com/godotengine/godot-proposals/issues/10034

This PR only has minimal changes in`ResourceImporterTexture`, it resizes the image data before saving ctex and storing the origin texture size as brefore.
But it works, `CompressedTexture2D` still loads the scaled texture properly by `RS::get_singleton()->texture_set_size_override()`, though more testing may be required.
![屏幕截图_20250408_143710](https://github.com/user-attachments/assets/b4f6e824-cebc-481f-8434-3780450b47d4)