### PR TITLE
Android Editor: Add new actions and enhancements to `TouchActionsPanel`

### DIFF
--- a/editor/gui/touch_actions_panel.h
+++ b/editor/gui/touch_actions_panel.h
@@ -45,6 +45,9 @@ private:
 	Button *delete_button = nullptr;
 	Button *undo_button = nullptr;
 	Button *redo_button = nullptr;
+	Button *cut_button = nullptr;
+	Button *copy_button = nullptr;
+	Button *paste_button = nullptr;
 
 	TextureRect *drag_handle = nullptr;
 	Button *layout_toggle_button = nullptr;
@@ -54,7 +57,18 @@ private:
 	bool dragging = false;
 	Vector2 drag_offset;
 
+	enum Modifier {
+		MODIFIER_CTRL,
+		MODIFIER_SHIFT,
+		MODIFIER_ALT
+	};
+
+	bool ctrl_btn_pressed = false;
+	bool shift_btn_pressed = false;
+	bool alt_btn_pressed = false;
+
 	void _notification(int p_what);
+	virtual void input(const Ref<InputEvent> &event) override;
 
 	void _simulate_editor_shortcut(const String &p_shortcut_name);
 	void _simulate_key_press(Key p_keycode);
@@ -62,6 +76,9 @@ private:
 	void _switch_layout();
 	void _lock_panel_toggled(bool p_pressed);
 	Button *_add_new_action_button(const String &p_shortcut, const String &p_name, Key p_keycode = Key::NONE);
+
+	void _add_new_modifier_button(Modifier p_modifier);
+	void _on_modifier_button_toggled(bool p_pressed, int p_modifier);
 
 	void _hardware_keyboard_connected(bool p_connected);
 


### PR DESCRIPTION
This PR continues the work from #100339 with the following updates:

- The panel’s layout and position are now saved and restored across projects and editor restarts.
- Toggle buttons for `Ctrl`, `Shift`, and `Alt` keys have been added to support actions that require holding down these keys, such as Ctrl for multi-selection.
- Additional action buttons have been introduced: Cut, Copy, and Paste. 
- Some UI polish.