### PR TITLE
[3.x] Physics Interpolation - Fix non-interpolated resting xforms

### DIFF
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -179,8 +179,11 @@ void Spatial::_notification(int p_what) {
 
 			notification(NOTIFICATION_ENTER_WORLD);
 
-			if (is_physics_interpolated_and_enabled()) {
-				// Always reset FTI when entering tree.
+			if (is_inside_tree() && get_tree()->is_physics_interpolation_enabled()) {
+				// Always reset FTI when entering tree
+				// and update the servers,
+				// both for interpolated and non-interpolated nodes,
+				// to ensure the server xforms are up to date.
 				fti_pump_xform();
 
 				// No need to interpolate as we are doing a reset.
@@ -278,7 +281,7 @@ void Spatial::_notification(int p_what) {
 
 		case NOTIFICATION_PAUSED: {
 			if (is_physics_interpolated_and_enabled()) {
-				data.local_transform_prev = data.local_transform;
+				data.local_transform_prev = get_transform();
 			}
 		} break;
 
@@ -310,11 +313,7 @@ void Spatial::set_global_rotation(const Vector3 &p_euler_rad) {
 }
 
 void Spatial::fti_pump_xform() {
-	if (data.dirty & DIRTY_LOCAL) {
-		_update_local_transform();
-	}
-
-	data.local_transform_prev = data.local_transform;
+	data.local_transform_prev = get_transform();
 }
 
 void Spatial::fti_notify_node_changed(bool p_transform_changed) {
@@ -1119,6 +1118,7 @@ Spatial::Spatial() :
 	data.fti_on_tick_xform_list = false;
 	data.fti_on_tick_property_list = false;
 	data.fti_global_xform_interp_set = false;
+	data.fti_frame_xform_force_update = false;
 
 	data.merging_mode = MERGING_MODE_INHERIT;
 

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -128,6 +128,7 @@ private:
 		bool fti_on_tick_xform_list : 1;
 		bool fti_on_tick_property_list : 1;
 		bool fti_global_xform_interp_set : 1;
+		bool fti_frame_xform_force_update : 1;
 
 		bool merging_allowed : 1;
 


### PR DESCRIPTION
Ensure servers are updated for non-interpolated Spatials, during the `SceneTreeFTI` traversal update.
Ensure properties and xforms are given a final server update in the final resting positions after removal from tick lists. Fixes dirty local xform bug.
Fixes dirty global xform bug.

As discussed with @rburing yesterday this fixes a number of last minute bugs I noticed in the new system.

## Regression in non-interpolated objects
I noticed in WroughtFlesh that on the loading scene, some non-interpolated objects weren't in their correct positions. #104854 was leaving it to `SceneTreeFTI` to be in charge of updating non-interpolated object xforms, but one small snag, these were being ignored completely by `SceneTreeFTI`.

Now these nodes have a flag set which activates their processing during `_update_dirty_spatials()`.

This should ensure they get one and (hopefully) only one update to the server, keeping things as efficient as possible. An alternative would have been to revert #104854 but I think this arrangement should be the most optimal solution for reducing server updates to bare minimum.

## Ensure servers are updated when removing xforms and properties from their tick lists
This was a slight oversight, as it wasn't necessary with the old server based approach. Now we scene side FTI, we can't just pump the data on the nodes when removing from tick lists, we have to _ensure_ the server is also updated.

For properties, we can update them immediately on removal from the tick list.

For xforms, for the best results, we not only need to update the spatial itself with the final resting xform, we want to ensure all the children are also updated with the final resting xform. We do this by adding another flag to the spatial, `fti_frame_xform_force_update`, which forces the scene tree traversal to do one last update of any node we choose. This flag is cleared on each traversal, but allows us a way of using the existing mechanisms to ensure the entire branch is updated to the resting xforms.

## Ensure `local_transform` is up to date during interpolation
I noticed on `3D platformer` on low tick rate that animated rotating coins were not interpolating as they should. It turned out that the `set_rotate()` call makes the local dirty, this means the `local_transform` can be stale at the time of interpolation.

The solution was rather simple, replace all the references to `local_transform` with `get_transform()` wrapper function, which ensures that any dirty data is updated.

The coins now interpolate correctly.

## Ensure `global_transform` is up to date during interpolation
Noticed bone attachment wasn't working in WroughtFlesh. Worked out again it was due to a dirty transform, this time global, so now this is updated when dirty when traversing the scene tree in `SceneTreeFTI`.

## Notes
* I'll add these fixes to the 4.x PR.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
