### PR TITLE
Add bswap methods to the `PackedByteArray` bindings.

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -694,6 +694,57 @@ struct _VariantCall {
 		return s;
 	}
 
+	static void func_PackedByteArray_bswap16(PackedByteArray *p_instance, int64_t p_offset, int64_t p_count) {
+		size_t sz = p_instance->size();
+		if (sz == 0 || p_count == 0) {
+			return;
+		}
+		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(sz) - 2);
+		if (p_count < 0) {
+			p_count = floor((sz - p_offset) / 2);
+		}
+		ERR_FAIL_COND(p_count > floor((sz - p_offset) / 2));
+
+		uint16_t *w = (uint16_t *)(p_instance->ptrw() + p_offset);
+		for (int64_t i = 0; i < p_count; i++) {
+			w[i] = BSWAP16(w[i]);
+		}
+	}
+
+	static void func_PackedByteArray_bswap32(PackedByteArray *p_instance, int64_t p_offset, int64_t p_count) {
+		size_t sz = p_instance->size();
+		if (sz == 0 || p_count == 0) {
+			return;
+		}
+		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(sz) - 4);
+		if (p_count < 0) {
+			p_count = floor((sz - p_offset) / 4);
+		}
+		ERR_FAIL_COND(p_count > floor((sz - p_offset) / 4));
+
+		uint32_t *w = (uint32_t *)(p_instance->ptrw() + p_offset);
+		for (int64_t i = 0; i < p_count; i++) {
+			w[i] = BSWAP32(w[i]);
+		}
+	}
+
+	static void func_PackedByteArray_bswap64(PackedByteArray *p_instance, int64_t p_offset, int64_t p_count) {
+		size_t sz = p_instance->size();
+		if (sz == 0 || p_count == 0) {
+			return;
+		}
+		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(sz) - 8);
+		if (p_count < 0) {
+			p_count = floor((sz - p_offset) / 8);
+		}
+		ERR_FAIL_COND(p_count > floor((sz - p_offset) / 8));
+
+		uint64_t *w = (uint64_t *)(p_instance->ptrw() + p_offset);
+		for (int64_t i = 0; i < p_count; i++) {
+			w[i] = BSWAP64(w[i]);
+		}
+	}
+
 	static String func_PackedByteArray_get_string_from_utf8(PackedByteArray *p_instance) {
 		String s;
 		if (p_instance->size() > 0) {
@@ -2492,6 +2543,10 @@ static void _register_variant_builtin_methods_array() {
 	bind_function(PackedByteArray, to_int64_array, _VariantCall::func_PackedByteArray_decode_s64_array, sarray(), varray());
 	bind_function(PackedByteArray, to_float32_array, _VariantCall::func_PackedByteArray_decode_float_array, sarray(), varray());
 	bind_function(PackedByteArray, to_float64_array, _VariantCall::func_PackedByteArray_decode_double_array, sarray(), varray());
+
+	bind_functionnc(PackedByteArray, bswap16, _VariantCall::func_PackedByteArray_bswap16, sarray("offset", "count"), varray(0, -1));
+	bind_functionnc(PackedByteArray, bswap32, _VariantCall::func_PackedByteArray_bswap32, sarray("offset", "count"), varray(0, -1));
+	bind_functionnc(PackedByteArray, bswap64, _VariantCall::func_PackedByteArray_bswap64, sarray("offset", "count"), varray(0, -1));
 
 	bind_functionnc(PackedByteArray, encode_u8, _VariantCall::func_PackedByteArray_encode_u8, sarray("byte_offset", "value"), varray());
 	bind_functionnc(PackedByteArray, encode_s8, _VariantCall::func_PackedByteArray_encode_s8, sarray("byte_offset", "value"), varray());

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -56,6 +56,30 @@
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
+		<method name="bswap16">
+			<return type="void" />
+			<param index="0" name="offset" type="int" default="0" />
+			<param index="1" name="count" type="int" default="-1" />
+			<description>
+				Swaps the byte order of [param count] 16-bit segments of the array starting at [param offset]. Swap is done in-place. If [param count] is less than zero, all segments to the end of array are processed, if processed data size is not a multiple of 2, the byte after the last processed 16-bit segment is not modified.
+			</description>
+		</method>
+		<method name="bswap32">
+			<return type="void" />
+			<param index="0" name="offset" type="int" default="0" />
+			<param index="1" name="count" type="int" default="-1" />
+			<description>
+				Swaps the byte order of [param count] 32-bit segments of the array starting at [param offset]. Swap is done in-place. If [param count] is less than zero, all segments to the end of array are processed, if processed data size is not a multiple of 4, bytes after the last processed 32-bit segment are not modified.
+			</description>
+		</method>
+		<method name="bswap64">
+			<return type="void" />
+			<param index="0" name="offset" type="int" default="0" />
+			<param index="1" name="count" type="int" default="-1" />
+			<description>
+				Swaps the byte order of [param count] 64-bit segments of the array starting at [param offset]. Swap is done in-place. If [param count] is less than zero, all segments to the end of array are processed, if processed data size is not a multiple of 8, bytes after the last processed 64-bit segment are not modified.
+			</description>
+		</method>
 		<method name="clear">
 			<return type="void" />
 			<description>


### PR DESCRIPTION
Partially addresses https://github.com/godotengine/godot-proposals/issues/9586, without introducing intrusive changes to the `Packed*Array`s.

This can be done with a script, but swapping large amount of data with a script is much slower. Irrelevant for C++, since it's trivial to do without extra methods, so added only as Variant methods.

```gdscript
	var a0 : PackedByteArray = [00, 11, 22, 33, 44, 55, 66, 77, 88, 11, 22, 33, 44, 55, 66, 77, 88, 99]
	var a1 = a0.duplicate()
	a1.bswap16(1)
	var a2 = a0.duplicate()
	a2.bswap32(1)
	var a3 = a0.duplicate()
	a3.bswap64(1)
	print(a0) # [0, 11, 22, 33, 44, 55, 66, 77, 88, 11, 22, 33, 44, 55, 66, 77, 88, 99]
	print(a1) # [0, 22, 11, 44, 33, 66, 55, 88, 77, 22, 11, 44, 33, 66, 55, 88, 77, 99]
	print(a2) # [0, 44, 33, 22, 11, 88, 77, 66, 55, 44, 33, 22, 11, 88, 77, 66, 55, 99]
	print(a3) # [0, 88, 77, 66, 55, 44, 33, 22, 11, 88, 77, 66, 55, 44, 33, 22, 11, 99]
```
