### PR TITLE
Add a safety check for `CowData::_unref()`, for when something tries to add elements during destruction.

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -282,6 +282,12 @@ void CowData<T>::_unref() {
 
 	// Free memory.
 	Memory::free_static((uint8_t *)prev_ptr - DATA_OFFSET, false);
+
+#ifdef DEBUG_ENABLED
+	// If any destructors access us through pointers, it is a bug.
+	// We can't really test for that, but we can at least check no items have been added.
+	ERR_FAIL_COND_MSG(_ptr != nullptr, "Internal bug, please report: CowData was modified during destruction.");
+#endif
 }
 
 template <typename T>


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/issues/101830

I don't think it will trigger on master, because iirc I saw a _read_ access, not _write_ access. But the sanity check would at least catch major breaches of contract. 