### PR TITLE
Allow `Sprite2D` being dragged to change their `region_rect`

### DIFF
--- a/editor/plugins/sprite_2d_editor_plugin.h
+++ b/editor/plugins/sprite_2d_editor_plugin.h
@@ -119,6 +119,11 @@ class Sprite2DEditorPlugin : public EditorPlugin {
 
 	Sprite2DEditor *sprite_editor = nullptr;
 
+	Label *dragging_mode_hint = nullptr;
+
+	void _editor_theme_changed();
+	void _update_dragging_mode_hint(bool p_region_enabled);
+
 public:
 	virtual String get_plugin_name() const override { return "Sprite2D"; }
 	bool has_main_screen() const override { return false; }

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -55,8 +55,10 @@ class Sprite2D : public Node2D {
 	int hframes = 1;
 
 	void _get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_clip_enabled) const;
+	Point2 _get_rect_offset(const Size2i &p_size) const;
 
 	void _texture_changed();
+	void _emit_region_rect_enabled();
 
 protected:
 	void _notification(int p_what);
@@ -73,6 +75,8 @@ public:
 	virtual void _edit_set_pivot(const Point2 &p_pivot) override;
 	virtual Point2 _edit_get_pivot() const override;
 	virtual bool _edit_use_pivot() const override;
+
+	virtual void _edit_set_rect(const Rect2 &p_rect) override;
 #endif // TOOLS_ENABLED
 
 #ifdef DEBUG_ENABLED
@@ -83,6 +87,7 @@ public:
 #endif // DEBUG_ENABLED
 
 	bool is_pixel_opaque(const Point2 &p_point) const;
+	bool is_editor_region_rect_draggable() const;
 
 	void set_texture(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_texture() const;


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/12192

Not sure if this should be synchronized for `AnimatedSprite2D`.

Video:
<video src="https://github.com/user-attachments/assets/3322a1da-d8bf-43b9-a94c-a5f2608e3693" controls="" height=400 width=600> </video>

Having received a feedback from arkology, I've swapped the behavior mentioned in the linked proposal

TODO list:
- [ ] ~~Support frames.~~ (This could be a bit harder to implement, so I leave this in another pr by me or by others)
- [x] Reserve the old behavior and add a text to hint the new dragging behavior.
- [ ] ~~Synchronize the effect for `AnimatedSprite2D`.~~ (This should not be implemented for `AnimatedSprite2D` as it doesn't have `region_enabled`. To keep animated sprite compatible with current behavior, it's better not to synchronize the feature)
- [x] Peer review.