### PR TITLE
Fix exported Node/Resource variables resetting when extending script in the SceneTreeDock

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -646,10 +646,40 @@ void InspectorDock::apply_script_properties(Object *p_object) {
 		return;
 	}
 
+	List<PropertyInfo> properties;
+	si->get_property_list(&properties);
+
 	for (const Pair<StringName, Variant> &E : stored_properties) {
 		Variant current_prop;
 		if (si->get(E.first, current_prop) && current_prop.get_type() == E.second.get_type()) {
 			si->set(E.first, E.second);
+		} else if (E.second.get_type() == Variant::OBJECT) {
+			for (const PropertyInfo &pi : properties) {
+				if (E.first != pi.name) {
+					continue;
+				}
+
+				if (pi.type != Variant::OBJECT) {
+					break;
+				}
+
+				Object *p_property_object = E.second;
+
+				if (p_property_object->is_class(pi.hint_string)) {
+					si->set(E.first, E.second);
+					break;
+				}
+
+				Ref<Script> base_script = p_property_object->get_script();
+				while (base_script.is_valid()) {
+					if (base_script->get_global_name() == pi.hint_string) {
+						si->set(E.first, E.second);
+						break;
+					}
+					base_script = base_script->get_base_script();
+				}
+				break;
+			}
 		}
 	}
 	stored_properties.clear();


### PR DESCRIPTION
When a script is extended that has an `@export`ed `Node` or `Resource` derived variable, the value of that variable is lost. This happens because `GDScript::member_default_values_cache` receives `Variant::NIL` values for these variables (presumably, C# also would suffer this bug for similar reasons, but I don't use C# and this solution is language agnostic).

This PR adds an extra check after the initial check between the default value's type and the type of the value to be copied has failed. If the value to be copied is of type `Variant::OBJECT`, then we look for this property's name in `ScriptInstance::get_property_list` and check that the type of the the value to be copied extends or is the type specified by the export variable.

Since `Object::is_class` doesn't work with `class_name` types, we need to also check the inheritance manually if that check fails.