### PR TITLE
Add an actual name for Ogg Vorbis importer visible name.

### DIFF
--- a/modules/vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/vorbis/resource_importer_ogg_vorbis.cpp
@@ -45,7 +45,7 @@ String ResourceImporterOggVorbis::get_importer_name() const {
 }
 
 String ResourceImporterOggVorbis::get_visible_name() const {
-	return "oggvorbisstr";
+	return "Ogg Vorbis";
 }
 
 void ResourceImporterOggVorbis::get_recognized_extensions(List<String> *p_extensions) const {


### PR DESCRIPTION
### WAV Importer:
- Importer name: wav
- Visible name: Microsoft WAV
- Save extension: .sample

### MP3 Importer:
- Importer name: mp3
- Visible name: MP3
- Save extension: .mp3str

But for Ogg Vorbis, all 3 are oggvorbisstr?
![image](https://github.com/user-attachments/assets/f8bc71b3-3dc9-46e6-a730-d46301071499)

I believe this was an oversight, so I made this PR to modify the visible name to "Ogg Vorbis":
![image](https://github.com/user-attachments/assets/2104aeb6-3d67-4061-98c7-7a62d123b8b7)

I considered modifying the importer name too, but that would cause a compatibility break.