### PR TITLE
Add `THREADS_ENABLED` check before RID thread tests

### DIFF
--- a/tests/core/templates/test_rid.h
+++ b/tests/core/templates/test_rid.h
@@ -37,6 +37,7 @@
 
 #include "tests/test_macros.h"
 
+#ifdef THREADS_ENABLED
 #ifdef SANITIZERS_ENABLED
 #ifdef __has_feature
 #if __has_feature(thread_sanitizer)
@@ -45,7 +46,8 @@
 #elif defined(__SANITIZE_THREAD__)
 #define TSAN_ENABLED
 #endif
-#endif
+#endif // SANITIZERS_ENABLED
+#endif // THREADS_ENABLED
 
 #ifdef TSAN_ENABLED
 #include <sanitizer/tsan_interface.h>
@@ -113,6 +115,7 @@ TEST_CASE("[RID] 'get_local_index'") {
 	CHECK(RID::from_uint64(4'294'967'297).get_local_index() == 1);
 }
 
+#ifdef THREADS_ENABLED
 // This case would let sanitizers realize data races.
 // Additionally, on purely weakly ordered architectures, it would detect synchronization issues
 // if RID_Alloc failed to impose proper memory ordering and the test's threads are distributed
@@ -248,4 +251,6 @@ TEST_CASE("[RID_Owner] Thread safety") {
 		tester.test();
 	}
 }
+#endif // THREADS_ENABLED
+
 } // namespace TestRID


### PR DESCRIPTION
Without these checks, we cannot build the Editor for the single-threaded Web build.

The tests themselves don't use the Godot `Thread` class (which handles well single-threaded builds), but `std::thread`.