### PR TITLE
Move `THREADS_ENABLED` check after common imports

### DIFF
--- a/core/os/semaphore.h
+++ b/core/os/semaphore.h
@@ -30,9 +30,10 @@
 
 #pragma once
 
+#include "core/typedefs.h"
+
 #ifdef THREADS_ENABLED
 
-#include "core/typedefs.h"
 #ifdef DEBUG_ENABLED
 #include "core/error/error_macros.h"
 #endif


### PR DESCRIPTION
Makes single-threaded editor actually build.

Otherwise, it complains at line 139 that `uint32_t` isn't defined.

It's actually my mistake, when I implemented `THREADS_ENABLED`, I was a little bit too eager on the big `#ifdef`.