### PR TITLE
Add `Engine Version Update Mode` button to Project Manager `Quick Settings`

### DIFF
--- a/editor/engine_update_label.cpp
+++ b/editor/engine_update_label.cpp
@@ -250,12 +250,7 @@ void EngineUpdateLabel::_notification(int p_what) {
 			}
 
 			if (_can_check_updates()) {
-				if (!checked_update) {
-					_check_update();
-				} else {
-					// This will be wrong when user toggles online mode twice when update is available, but it's not worth handling.
-					_set_status(UpdateStatus::UP_TO_DATE);
-				}
+				_check_update();
 			} else {
 				_set_status(UpdateStatus::OFFLINE);
 			}

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -48,6 +48,7 @@ void QuickSettingsDialog::_fetch_setting_values() {
 	editor_themes.clear();
 	editor_scales.clear();
 	editor_network_modes.clear();
+	editor_engine_version_update_modes.clear();
 	editor_directory_naming_conventions.clear();
 
 	{
@@ -65,6 +66,8 @@ void QuickSettingsDialog::_fetch_setting_values() {
 				editor_scales = pi.hint_string.split(",");
 			} else if (pi.name == "network/connection/network_mode") {
 				editor_network_modes = pi.hint_string.split(",");
+			} else if (pi.name == "network/connection/engine_version_update_mode") {
+				editor_engine_version_update_modes = pi.hint_string.split(",");
 			} else if (pi.name == "project_manager/directory_naming_convention") {
 				editor_directory_naming_conventions = pi.hint_string.split(",");
 			}
@@ -130,6 +133,22 @@ void QuickSettingsDialog::_update_current_values() {
 		}
 	}
 
+	// Engine version update mode options.
+	{
+		const int current_update_mode = EDITOR_GET("network/connection/engine_version_update_mode");
+
+		for (int i = 0; i < editor_engine_version_update_modes.size(); i++) {
+			const String &engine_version_update_mode_value = editor_engine_version_update_modes[i];
+			if (current_update_mode == i) {
+				engine_version_update_mode_button->set_text(engine_version_update_mode_value);
+				engine_version_update_mode_button->select(i);
+
+				// Disables Engine Version Update Mode selection if Network mode is set to Offline.
+				engine_version_update_mode_button->set_disabled(!EDITOR_GET("network/connection/network_mode"));
+			}
+		}
+	}
+
 	// Project directory naming options.
 	{
 		const int current_directory_naming = EDITOR_GET("project_manager/directory_naming_convention");
@@ -177,6 +196,13 @@ void QuickSettingsDialog::_scale_selected(int p_id) {
 
 void QuickSettingsDialog::_network_mode_selected(int p_id) {
 	_set_setting_value("network/connection/network_mode", p_id);
+
+	// Disables Engine Version Update Mode selection if Network mode is set to Offline.
+	engine_version_update_mode_button->set_disabled(!p_id);
+}
+
+void QuickSettingsDialog::_engine_version_update_mode_selected(int p_id) {
+	_set_setting_value("network/connection/engine_version_update_mode", p_id);
 }
 
 void QuickSettingsDialog::_directory_naming_convention_selected(int p_id) {
@@ -318,6 +344,20 @@ QuickSettingsDialog::QuickSettingsDialog() {
 			}
 
 			_add_setting_control(TTR("Network Mode"), network_mode_option_button);
+		}
+
+		// Engine version update mode options.
+		{
+			engine_version_update_mode_button = memnew(OptionButton);
+			engine_version_update_mode_button->set_fit_to_longest_item(false);
+			engine_version_update_mode_button->connect(SceneStringName(item_selected), callable_mp(this, &QuickSettingsDialog::_engine_version_update_mode_selected));
+
+			for (int i = 0; i < editor_engine_version_update_modes.size(); i++) {
+				const String &engine_version_update_mode_value = editor_engine_version_update_modes[i];
+				engine_version_update_mode_button->add_item(engine_version_update_mode_value, i);
+			}
+
+			_add_setting_control(TTR("Engine Version Update Mode"), engine_version_update_mode_button);
 		}
 
 		// Project directory naming options.

--- a/editor/project_manager/quick_settings_dialog.h
+++ b/editor/project_manager/quick_settings_dialog.h
@@ -48,6 +48,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	Vector<String> editor_themes;
 	Vector<String> editor_scales;
 	Vector<String> editor_network_modes;
+	Vector<String> editor_engine_version_update_modes;
 	Vector<String> editor_directory_naming_conventions;
 
 	void _fetch_setting_values();
@@ -66,6 +67,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	OptionButton *theme_option_button = nullptr;
 	OptionButton *scale_option_button = nullptr;
 	OptionButton *network_mode_option_button = nullptr;
+	OptionButton *engine_version_update_mode_button = nullptr;
 	OptionButton *directory_naming_convention_button = nullptr;
 
 	Label *custom_theme_label = nullptr;
@@ -76,6 +78,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	void _theme_selected(int p_id);
 	void _scale_selected(int p_id);
 	void _network_mode_selected(int p_id);
+	void _engine_version_update_mode_selected(int p_id);
 	void _directory_naming_convention_selected(int p_id);
 	void _set_setting_value(const String &p_setting, const Variant &p_value, bool p_restart_required = false);
 


### PR DESCRIPTION
Adds the `Engine Version Update Mode` button from Editor Settings to the `Quick Settings` menu in the Project Manager based on discussion in https://github.com/godotengine/godot-proposals/issues/12194.

> [!NOTE]
>I added functionality to disable the button (_only in Quick Settings_) if Network Mode is set to `Offline`, this can be removed if wanted.
---
https://github.com/user-attachments/assets/778b19b3-9f19-4d12-903e-fda3ae6cfb1b
