### PR TITLE
Apple: Add pthread implementation of `Thread` class

### DIFF
--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -119,6 +119,8 @@ private:
 public:
 	static void _set_platform_functions(const PlatformFunctions &p_functions);
 
+	_FORCE_INLINE_ static void yield() { std::this_thread::yield(); }
+
 	_FORCE_INLINE_ ID get_id() const { return id; }
 	// get the ID of the caller thread
 	_FORCE_INLINE_ static ID get_caller_id() {

--- a/drivers/apple/SCsub
+++ b/drivers/apple/SCsub
@@ -5,3 +5,4 @@ Import("env")
 
 # Driver source files
 env.add_source_files(env.drivers_sources, "*.mm")
+env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/apple/thread_apple.cpp
+++ b/drivers/apple/thread_apple.cpp
@@ -1,0 +1,129 @@
+/**************************************************************************/
+/*  thread_apple.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "thread_apple.h"
+
+#include "core/error/error_macros.h"
+#include "core/object/script_language.h"
+#include "core/string/ustring.h"
+
+SafeNumeric<uint64_t> Thread::id_counter(1); // The first value after .increment() is 2, hence by default the main thread ID should be 1.
+thread_local Thread::ID Thread::caller_id = Thread::id_counter.increment();
+
+struct ThreadData {
+	Thread::Callback callback;
+	void *userdata;
+	Thread::ID caller_id;
+};
+
+void *Thread::thread_callback(void *p_data) {
+	ThreadData *thread_data = static_cast<ThreadData *>(p_data);
+
+	// Set the caller ID for this thread
+	caller_id = thread_data->caller_id;
+
+	ScriptServer::thread_enter(); // Scripts may need to attach a stack.
+
+	// Call the actual callback
+	thread_data->callback(thread_data->userdata);
+
+	ScriptServer::thread_exit();
+
+	// Clean up
+	memdelete(thread_data);
+
+	return nullptr;
+}
+
+Error Thread::set_name(const String &p_name) {
+	int err = pthread_setname_np(p_name.utf8().get_data());
+	return err == 0 ? OK : ERR_INVALID_PARAMETER;
+}
+
+Thread::ID Thread::start(Thread::Callback p_callback, void *p_user, const Settings &p_settings) {
+	ERR_FAIL_COND_V_MSG(id != UNASSIGNED_ID, UNASSIGNED_ID, "A Thread object has been re-started without wait_to_finish() having been called on it.");
+	id = id_counter.increment();
+
+	ThreadData *thread_data = memnew(ThreadData);
+	thread_data->callback = p_callback;
+	thread_data->userdata = p_user;
+	thread_data->caller_id = id;
+
+	// Create the thread
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+
+	switch (p_settings.priority) {
+		case PRIORITY_LOW:
+			pthread_attr_set_qos_class_np(&attr, QOS_CLASS_UTILITY, 0);
+			break;
+		case PRIORITY_NORMAL:
+			pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INITIATED, 0);
+			break;
+		case PRIORITY_HIGH:
+			pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INTERACTIVE, 0);
+			break;
+	}
+
+	if (p_settings.stack_size > 0) {
+		pthread_attr_setstacksize(&attr, p_settings.stack_size);
+	}
+
+	// Create the thread
+	pthread_create(&pthread, &attr, thread_callback, thread_data);
+
+	// Clean up attributes
+	pthread_attr_destroy(&attr);
+
+	return id;
+}
+
+void Thread::wait_to_finish() {
+	ERR_FAIL_COND_MSG(id == UNASSIGNED_ID, "Attempt of waiting to finish on a thread that was never started.");
+	ERR_FAIL_COND_MSG(id == get_caller_id(), "Threads can't wait to finish on themselves, another thread must wait.");
+
+	int err = pthread_join(pthread, nullptr);
+	if (err != 0) {
+		ERR_FAIL_MSG("Thread::wait_to_finish() failed to join thread.");
+	}
+	pthread = pthread_t();
+	id = UNASSIGNED_ID;
+}
+
+Thread::~Thread() {
+	if (id != UNASSIGNED_ID) {
+#ifdef DEBUG_ENABLED
+		WARN_PRINT(
+				"A Thread object is being destroyed without its completion having been realized.\n"
+				"Please call wait_to_finish() on it to ensure correct cleanup.");
+#endif
+		pthread_detach(pthread);
+	}
+}

--- a/drivers/metal/metal_utils.h
+++ b/drivers/metal/metal_utils.h
@@ -32,6 +32,8 @@
 
 #import <os/log.h>
 
+#import <functional>
+
 #pragma mark - Boolean flags
 
 namespace flags {

--- a/platform/ios/platform_config.h
+++ b/platform/ios/platform_config.h
@@ -32,6 +32,8 @@
 
 #include <alloca.h>
 
+#define PLATFORM_THREAD_OVERRIDE
+
 #define PTHREAD_RENAME_SELF
 
 #define _weakify(var) __weak typeof(var) GDWeak_##var = var;

--- a/platform/ios/platform_thread.h
+++ b/platform/ios/platform_thread.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  thread_posix.cpp                                                      */
+/*  platform_thread.h                                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,56 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#if defined(UNIX_ENABLED)
+#pragma once
 
-#include "thread_posix.h"
-
-#include "core/os/thread.h"
-#include "core/string/ustring.h"
-
-#if defined(PLATFORM_THREAD_OVERRIDE) && defined(__APPLE__)
-void init_thread_posix() {
-}
-#else
-
-#ifdef PTHREAD_BSD_SET_NAME
-#include <pthread_np.h>
-#endif
-
-static Error set_name(const String &p_name) {
-#ifdef PTHREAD_NO_RENAME
-	return ERR_UNAVAILABLE;
-
-#else
-
-#ifdef PTHREAD_RENAME_SELF
-
-	// check if thread is the same as caller
-	int err = pthread_setname_np(p_name.utf8().get_data());
-
-#else
-
-	pthread_t running_thread = pthread_self();
-#ifdef PTHREAD_BSD_SET_NAME
-	pthread_set_name_np(running_thread, p_name.utf8().get_data());
-	int err = 0; // Open/FreeBSD ignore errors in this function
-#elif defined(PTHREAD_NETBSD_SET_NAME)
-	int err = pthread_setname_np(running_thread, "%s", const_cast<char *>(p_name.utf8().get_data()));
-#else
-	int err = pthread_setname_np(running_thread, p_name.utf8().get_data());
-#endif // PTHREAD_BSD_SET_NAME
-
-#endif // PTHREAD_RENAME_SELF
-
-	return err == 0 ? OK : ERR_INVALID_PARAMETER;
-
-#endif // PTHREAD_NO_RENAME
-}
-
-void init_thread_posix() {
-	Thread::_set_platform_functions({ .set_name = set_name });
-}
-
-#endif // PLATFORM_THREAD_OVERRIDE && __APPLE__
-
-#endif // UNIX_ENABLED
+#include "drivers/apple/thread_apple.h"

--- a/platform/macos/platform_config.h
+++ b/platform/macos/platform_config.h
@@ -32,6 +32,8 @@
 
 #include <alloca.h>
 
+#define PLATFORM_THREAD_OVERRIDE
+
 #define PTHREAD_RENAME_SELF
 
 #define _weakify(var) __weak typeof(var) GDWeak_##var = var;

--- a/platform/macos/platform_thread.h
+++ b/platform/macos/platform_thread.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  thread_posix.cpp                                                      */
+/*  platform_thread.h                                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,56 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#if defined(UNIX_ENABLED)
+#pragma once
 
-#include "thread_posix.h"
-
-#include "core/os/thread.h"
-#include "core/string/ustring.h"
-
-#if defined(PLATFORM_THREAD_OVERRIDE) && defined(__APPLE__)
-void init_thread_posix() {
-}
-#else
-
-#ifdef PTHREAD_BSD_SET_NAME
-#include <pthread_np.h>
-#endif
-
-static Error set_name(const String &p_name) {
-#ifdef PTHREAD_NO_RENAME
-	return ERR_UNAVAILABLE;
-
-#else
-
-#ifdef PTHREAD_RENAME_SELF
-
-	// check if thread is the same as caller
-	int err = pthread_setname_np(p_name.utf8().get_data());
-
-#else
-
-	pthread_t running_thread = pthread_self();
-#ifdef PTHREAD_BSD_SET_NAME
-	pthread_set_name_np(running_thread, p_name.utf8().get_data());
-	int err = 0; // Open/FreeBSD ignore errors in this function
-#elif defined(PTHREAD_NETBSD_SET_NAME)
-	int err = pthread_setname_np(running_thread, "%s", const_cast<char *>(p_name.utf8().get_data()));
-#else
-	int err = pthread_setname_np(running_thread, p_name.utf8().get_data());
-#endif // PTHREAD_BSD_SET_NAME
-
-#endif // PTHREAD_RENAME_SELF
-
-	return err == 0 ? OK : ERR_INVALID_PARAMETER;
-
-#endif // PTHREAD_NO_RENAME
-}
-
-void init_thread_posix() {
-	Thread::_set_platform_functions({ .set_name = set_name });
-}
-
-#endif // PLATFORM_THREAD_OVERRIDE && __APPLE__
-
-#endif // UNIX_ENABLED
+#include "drivers/apple/thread_apple.h"

--- a/tests/core/templates/test_rid.h
+++ b/tests/core/templates/test_rid.h
@@ -140,7 +140,7 @@ TEST_CASE("[RID_Owner] Thread safety") {
 			uint32_t target = (p_step / 2 + 1) * threads.size();
 			sync[buf_idx].fetch_add(1, std::memory_order_relaxed);
 			do {
-				std::this_thread::yield();
+				Thread::yield();
 			} while (sync[buf_idx].load(std::memory_order_relaxed) != target);
 		}
 


### PR DESCRIPTION
This allows Apple platforms to override the default stack size of a thread in the `WorkerThreadPool`, which is 512KiB by default.

This must be increased, as SPIRV-Cross, used by the Metal driver, can use deeply nested stacks. This is exacerbated when using a debug build, which has increased stack-size requirements. Without an option to override the stack size, we have observed stack overflows.

The stack size is for Apple platforms is explicitly set to 1 MiB. For `DEV_BUILD` the stack size is set to 2MiB, as debug builds have larger stack requirements.

> [!IMPORTANT]
>
> `test_rid.h` directly called `std::this_thread::yield()`, so I added a static `yield` function to `Thread`, that can be platform-specific.