### PR TITLE
Fix newly created scripts being misclassified as built-in

### DIFF
--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -138,12 +138,12 @@ Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path,
 			}
 #endif
 
-			if (p_flags & FLAG_CHANGE_PATH) {
-				p_resource->set_path(old_path);
-			}
-
 			if (save_callback && path.begins_with("res://")) {
 				save_callback(p_resource, path);
+			}
+
+			if (p_flags & FLAG_CHANGE_PATH) {
+				p_resource->set_path(old_path, true);
 			}
 
 			return OK;


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot/issues/105163