### PR TITLE
Change `get_class_static` to return `StringName`.

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1345,7 +1345,7 @@ static Error _encode_container_type(const ContainerType &p_type, uint8_t *&buf, 
 				_encode_string(EncodedObjectAsID::get_class_static(), buf, r_len);
 			}
 		} else if (p_type.class_name != StringName()) {
-			_encode_string(p_full_objects ? p_type.class_name.operator String() : EncodedObjectAsID::get_class_static(), buf, r_len);
+			_encode_string(p_full_objects ? p_type.class_name : EncodedObjectAsID::get_class_static(), buf, r_len);
 		} else {
 			// No need to check `p_full_objects` since `class_name` should be non-empty for `builtin_type == Variant::OBJECT`.
 			if (buf) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -419,14 +419,14 @@ private:                                                                        
 public:                                                                                                                                     \
 	static constexpr bool _class_is_enabled = !bool(GD_IS_DEFINED(ClassDB_Disable_##m_class)) && m_inherits::_class_is_enabled;             \
 	virtual const StringName *_get_class_namev() const override {                                                                           \
+		return &get_class_static();                                                                                                         \
+	}                                                                                                                                       \
+	static const StringName &get_class_static() {                                                                                           \
 		static StringName _class_name_static;                                                                                               \
 		if (unlikely(!_class_name_static)) {                                                                                                \
 			StringName::assign_static_unique_class_name(&_class_name_static, #m_class);                                                     \
 		}                                                                                                                                   \
-		return &_class_name_static;                                                                                                         \
-	}                                                                                                                                       \
-	static _FORCE_INLINE_ String get_class_static() {                                                                                       \
-		return String(#m_class);                                                                                                            \
+		return _class_name_static;                                                                                                          \
 	}                                                                                                                                       \
 	virtual bool is_class(const String &p_class) const override {                                                                           \
 		if (_get_extension() && _get_extension()->is_class(p_class)) {                                                                      \
@@ -739,11 +739,7 @@ protected:
 	Variant _call_deferred_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
 	virtual const StringName *_get_class_namev() const {
-		static StringName _class_name_static;
-		if (unlikely(!_class_name_static)) {
-			StringName::assign_static_unique_class_name(&_class_name_static, "Object");
-		}
-		return &_class_name_static;
+		return &get_class_static();
 	}
 
 	TypedArray<StringName> _get_meta_list_bind() const;
@@ -811,7 +807,13 @@ public:
 	};
 
 	/* TYPE API */
-	static String get_class_static() { return "Object"; }
+	static const StringName &get_class_static() {
+		static StringName _class_name_static;
+		if (unlikely(!_class_name_static)) {
+			StringName::assign_static_unique_class_name(&_class_name_static, "Object");
+		}
+		return _class_name_static;
+	}
 
 	_FORCE_INLINE_ String get_class() const { return get_class_name(); }
 

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -105,7 +105,7 @@ void GDScriptDocGen::_doctype_from_gdtype(const GDType &p_gdtype, String &r_type
 			return;
 		case GDType::SCRIPT:
 			if (p_gdtype.is_meta_type) {
-				r_type = p_gdtype.script_type.is_valid() ? p_gdtype.script_type->get_class() : Script::get_class_static();
+				r_type = p_gdtype.script_type.is_valid() ? p_gdtype.script_type->get_class_name() : Script::get_class_static();
 				return;
 			}
 			if (p_gdtype.script_type.is_valid()) {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -129,7 +129,7 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 			if (p_handle_metatype && p_datatype.is_meta_type) {
 				result.kind = GDScriptDataType::NATIVE;
 				result.builtin_type = Variant::OBJECT;
-				result.native_type = p_datatype.script_type.is_valid() ? p_datatype.script_type->get_class() : Script::get_class_static();
+				result.native_type = p_datatype.script_type.is_valid() ? p_datatype.script_type->get_class_name() : Script::get_class_static();
 				break;
 			}
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4357,7 +4357,7 @@ static StringName _find_narrowest_native_or_global_class(const GDScriptParser::D
 			}
 
 			if (p_type.is_meta_type) {
-				return script.is_valid() ? script->get_class() : Script::get_class_static();
+				return script.is_valid() ? script->get_class_name() : Script::get_class_static();
 			}
 			if (script.is_null()) {
 				return p_type.native_type;
@@ -5257,7 +5257,7 @@ PropertyInfo GDScriptParser::DataType::to_property_info(const String &p_name) co
 		case SCRIPT:
 			result.type = Variant::OBJECT;
 			if (is_meta_type) {
-				result.class_name = script_type.is_valid() ? script_type->get_class() : Script::get_class_static();
+				result.class_name = script_type.is_valid() ? script_type->get_class_name() : Script::get_class_static();
 			} else if (script_type.is_valid() && script_type->get_global_name() != StringName()) {
 				result.class_name = script_type->get_global_name();
 			} else {


### PR DESCRIPTION
Follow-up of #105099.

`get_class_static` currently returns a newly allocated `String`. Instead, I propose to make it return `StringName`, using the same mechanic previously used for `_get_class_namev`.
Most callers use it as `StringName` anyway, making it a better match.

This substantially improves performance of `get_class_static` callers:
- Those that use it as `String` no longer need to allocate a new string; instead they can use a `CoW` copy of the `StringName`'s buffer.
- Those that expect `StringName` no longer need to allocate `String`, and no longer need to search for the `StringName` in the `StringName` table.

This PR also seems to reduce the binary size by a whopping 4mb (2%) for me. This is possibly because `get_class_static` was using `_FORCE_INLINE_` before, although i'm still surprised it had that much of a size impact.

## Benchmark

`get_class_static` did not appear in profiles earlier, so I don't expect any measurable changes. Just to be sure, I benchmarked. It was an unsubstantial 1% improvement (within expected error):

```
 ❯ hyperfine -m25 -iw1 "bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit" "bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit"
Benchmark 1: bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      3.469 s ±  0.142 s    [User: 2.466 s, System: 0.335 s]
  Range (min … max):    3.213 s …  3.753 s    25 runs

Benchmark 2: bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      3.427 s ±  0.114 s    [User: 2.449 s, System: 0.332 s]
  Range (min … max):    3.232 s …  3.592 s    25 runs

Summary
  bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit ran
    1.01 ± 0.05 times faster than bin/godot.macos.editor.arm64.master --path /Users/lukas/dev/godot/empty-game --editor --quit
```