### PR TITLE
Add a quick setting for update checking mode in the project manager

### DIFF
--- a/editor/engine_update_label.cpp
+++ b/editor/engine_update_label.cpp
@@ -250,12 +250,7 @@ void EngineUpdateLabel::_notification(int p_what) {
 			}
 
 			if (_can_check_updates()) {
-				if (!checked_update) {
-					_check_update();
-				} else {
-					// This will be wrong when user toggles online mode twice when update is available, but it's not worth handling.
-					_set_status(UpdateStatus::UP_TO_DATE);
-				}
+				_check_update();
 			} else {
 				_set_status(UpdateStatus::OFFLINE);
 			}

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -48,6 +48,7 @@ void QuickSettingsDialog::_fetch_setting_values() {
 	editor_themes.clear();
 	editor_scales.clear();
 	editor_network_modes.clear();
+	editor_check_for_updates.clear();
 	editor_directory_naming_conventions.clear();
 
 	{
@@ -65,6 +66,8 @@ void QuickSettingsDialog::_fetch_setting_values() {
 				editor_scales = pi.hint_string.split(",");
 			} else if (pi.name == "network/connection/network_mode") {
 				editor_network_modes = pi.hint_string.split(",");
+			} else if (pi.name == "network/connection/engine_version_update_mode") {
+				editor_check_for_updates = pi.hint_string.split(",");
 			} else if (pi.name == "project_manager/directory_naming_convention") {
 				editor_directory_naming_conventions = pi.hint_string.split(",");
 			}
@@ -130,6 +133,19 @@ void QuickSettingsDialog::_update_current_values() {
 		}
 	}
 
+	// Check for updates options.
+	{
+		const int current_check_for_updates_mode = EDITOR_GET("network/connection/engine_version_update_mode");
+
+		for (int i = 0; i < editor_check_for_updates.size(); i++) {
+			const String &update_mode_value = editor_check_for_updates[i];
+			if (current_check_for_updates_mode == i) {
+				check_for_updates_option_button->set_text(update_mode_value);
+				check_for_updates_option_button->select(i);
+			}
+		}
+	}
+
 	// Project directory naming options.
 	{
 		const int current_directory_naming = EDITOR_GET("project_manager/directory_naming_convention");
@@ -177,6 +193,10 @@ void QuickSettingsDialog::_scale_selected(int p_id) {
 
 void QuickSettingsDialog::_network_mode_selected(int p_id) {
 	_set_setting_value("network/connection/network_mode", p_id);
+}
+
+void QuickSettingsDialog::_check_for_updates_selected(int p_id) {
+	_set_setting_value("network/connection/engine_version_update_mode", p_id);
 }
 
 void QuickSettingsDialog::_directory_naming_convention_selected(int p_id) {
@@ -318,6 +338,20 @@ QuickSettingsDialog::QuickSettingsDialog() {
 			}
 
 			_add_setting_control(TTR("Network Mode"), network_mode_option_button);
+		}
+
+		// Update check options.
+		{
+			check_for_updates_option_button = memnew(OptionButton);
+			check_for_updates_option_button->set_fit_to_longest_item(false);
+			check_for_updates_option_button->connect(SceneStringName(item_selected), callable_mp(this, &QuickSettingsDialog::_check_for_updates_selected));
+
+			for (int i = 0; i < editor_check_for_updates.size(); i++) {
+				const String &check_for_updates_value = editor_check_for_updates[i];
+				check_for_updates_option_button->add_item(check_for_updates_value, i);
+			}
+
+			_add_setting_control(TTR("Check for Updates"), check_for_updates_option_button);
 		}
 
 		// Project directory naming options.

--- a/editor/project_manager/quick_settings_dialog.h
+++ b/editor/project_manager/quick_settings_dialog.h
@@ -48,6 +48,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	Vector<String> editor_themes;
 	Vector<String> editor_scales;
 	Vector<String> editor_network_modes;
+	Vector<String> editor_check_for_updates;
 	Vector<String> editor_directory_naming_conventions;
 
 	void _fetch_setting_values();
@@ -66,6 +67,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	OptionButton *theme_option_button = nullptr;
 	OptionButton *scale_option_button = nullptr;
 	OptionButton *network_mode_option_button = nullptr;
+	OptionButton *check_for_updates_option_button = nullptr;
 	OptionButton *directory_naming_convention_button = nullptr;
 
 	Label *custom_theme_label = nullptr;
@@ -76,6 +78,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	void _theme_selected(int p_id);
 	void _scale_selected(int p_id);
 	void _network_mode_selected(int p_id);
+	void _check_for_updates_selected(int p_id);
 	void _directory_naming_convention_selected(int p_id);
 	void _set_setting_value(const String &p_setting, const Variant &p_value, bool p_restart_required = false);
 


### PR DESCRIPTION
This allows toggling whether to check for updates directly from the project manager, as well as choosing which type of updates to check for.

Additionally, the update check will be performed again when switching between offline and online mode (if online mode was previously used). This allows forcing the check to be performed again in case you had no network connection when the project manager started.

- See https://github.com/godotengine/godot-proposals/issues/12194#issuecomment-2786857066.

## Preview

*I've locally changed the engine version to 4.4-stable for testing purposes.*

https://github.com/user-attachments/assets/6c2f7c91-bfe8-4ec1-9e63-9a569e057f84
