### PR TITLE
Fix typos in `UDPServer::poll` documentation

### DIFF
--- a/doc/classes/UDPServer.xml
+++ b/doc/classes/UDPServer.xml
@@ -154,7 +154,7 @@
 		<method name="poll">
 			<return type="int" enum="Error" />
 			<description>
-				Call this method at regular intervals (e.g. inside [method Node._process]) to process new packets. And packet from known address/port pair will be delivered to the appropriate [PacketPeerUDP], any packet received from an unknown address/port pair will be added as a pending connection (see [method is_connection_available], [method take_connection]). The maximum number of pending connection is defined via [member max_pending_connections].
+				Call this method at regular intervals (e.g. inside [method Node._process]) to process new packets. Any packet from a known address/port pair will be delivered to the appropriate [PacketPeerUDP], while any packet received from an unknown address/port pair will be added as a pending connection (see [method is_connection_available] and [method take_connection]). The maximum number of pending connections is defined via [member max_pending_connections].
 			</description>
 		</method>
 		<method name="stop">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes typos in the `UDPServer::poll` documentation.

Closes godotengine/godot-docs#10801

Someone had opened a PR to fix this in the godot-docs repository (godotengine/godot-docs#10805), but they have deleted their account. 
