### PR TITLE
Remove error print in the Animation getter.

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -464,7 +464,9 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 	String prop_name = p_name;
 
 	if (p_name == SNAME("_compression")) {
-		ERR_FAIL_COND_V(!compression.enabled, false);
+		if (!compression.enabled) {
+			return false;
+		}
 		Dictionary comp;
 		comp["fps"] = compression.fps;
 		Array bounds;


### PR DESCRIPTION
Since introduction of typed Dictionaries (was the same for Arrays before it), resource loader always attempt to `get` value, before setting it, so this condition will always be true when loading and should not spam unnecessary error messages.

Fixes https://github.com/godotengine/godot/issues/105158