### PR TITLE
Use a dialog when there are too many Resource Picker popup menu items

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1009,6 +1009,11 @@
 		<member name="interface/inspector/open_resources_in_current_inspector" type="bool" setter="" getter="">
 			If [code]true[/code], subresources can be edited in the current inspector view. If the resource type is defined in [member interface/inspector/resources_to_open_in_new_inspector] or if this setting is [code]false[/code], attempting to edit a subresource always opens a new inspector view.
 		</member>
+		<member name="interface/inspector/resource_picker_use_dialog_threshold" type="int" setter="" getter="">
+			If number of items on the resource picker's popup menu exceeds this value, a searchable dialog will be used instead.
+			- If set to [code]0[/code], the dialog will always be used.
+			- If set to [code]-1[/code], the popup menu will always be used.
+		</member>
 		<member name="interface/inspector/resources_to_open_in_new_inspector" type="PackedStringArray" setter="" getter="">
 			List of resources that should always be opened in a new inspector view, even if [member interface/inspector/open_resources_in_current_inspector] is [code]true[/code].
 		</member>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -108,6 +108,7 @@
 #include "editor/filesystem_dock.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_popup_menu_dialog.h"
 #include "editor/gui/editor_quick_open_dialog.h"
 #include "editor/gui/editor_run_bar.h"
 #include "editor/gui/editor_scene_tabs.h"
@@ -8253,6 +8254,9 @@ EditorNode::EditorNode() {
 
 	quick_open_dialog = memnew(EditorQuickOpenDialog);
 	gui_base->add_child(quick_open_dialog);
+
+	popup_menu_dialog = memnew(EditorPopupMenuDialog);
+	gui_base->add_child(popup_menu_dialog);
 
 	quick_open_color_palette = memnew(EditorQuickOpenDialog);
 	gui_base->add_child(quick_open_color_palette);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -89,6 +89,7 @@ class EditorSettingsDialog;
 class EditorTitleBar;
 class ExportTemplateManager;
 class EditorQuickOpenDialog;
+class EditorPopupMenuDialog;
 class FBXImporterManager;
 class FileSystemDock;
 class HistoryDock;
@@ -247,6 +248,7 @@ private:
 
 	EditorCommandPalette *command_palette = nullptr;
 	EditorQuickOpenDialog *quick_open_dialog = nullptr;
+	EditorPopupMenuDialog *popup_menu_dialog = nullptr;
 	EditorExport *editor_export = nullptr;
 	EditorLog *log = nullptr;
 	EditorNativeShaderSourceVisualizer *native_shader_source_visualizer = nullptr;
@@ -928,6 +930,7 @@ public:
 	Dictionary drag_files_and_dirs(const Vector<String> &p_paths, Control *p_from);
 
 	EditorQuickOpenDialog *get_quick_open_dialog() { return quick_open_dialog; }
+	EditorPopupMenuDialog *get_popup_menu_dialog() { return popup_menu_dialog; }
 
 	void add_tool_menu_item(const String &p_name, const Callable &p_callback);
 	void add_tool_submenu_item(const String &p_name, PopupMenu *p_submenu);

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -38,6 +38,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/filesystem_dock.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_popup_menu_dialog.h"
 #include "editor/gui/editor_quick_open_dialog.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
 #include "editor/plugins/script_editor_plugin.h"
@@ -125,7 +126,7 @@ void EditorResourcePicker::_update_resource_preview(const String &p_path, const 
 void EditorResourcePicker::_resource_selected() {
 	if (edited_resource.is_null()) {
 		edit_button->set_pressed(true);
-		_update_menu();
+		_update_menu(true);
 		return;
 	}
 
@@ -182,7 +183,7 @@ void EditorResourcePicker::_resource_saved(Object *p_resource) {
 	}
 }
 
-void EditorResourcePicker::_update_menu() {
+void EditorResourcePicker::_update_menu(bool p_allow_dialog) {
 	if (edit_menu && edit_menu->is_visible()) {
 		edit_button->set_pressed(false);
 		edit_menu->hide();
@@ -191,12 +192,21 @@ void EditorResourcePicker::_update_menu() {
 
 	_update_menu_items();
 
-	Rect2 gt = edit_button->get_screen_rect();
-	edit_menu->reset_size();
-	int ms = edit_menu->get_contents_minimum_size().width;
-	Vector2 popup_pos = gt.get_end() - Vector2(ms, 0);
-	edit_menu->set_position(popup_pos);
-	edit_menu->popup();
+	int dialog_threshold = EDITOR_GET("interface/inspector/resource_picker_use_dialog_threshold");
+	if (p_allow_dialog && dialog_threshold >= 0 && edit_menu->get_item_count() >= dialog_threshold) {
+		EditorNode::get_singleton()->get_popup_menu_dialog()->popup_dialog(edit_menu, TTR("Add Resource"), TTR("Search Resources..."));
+	} else {
+		Rect2 gt = edit_button->get_screen_rect();
+		edit_menu->reset_size();
+		int ms = edit_menu->get_contents_minimum_size().width;
+		Vector2 popup_pos = gt.get_end() - Vector2(ms, 0);
+		edit_menu->set_position(popup_pos);
+		edit_menu->popup();
+	}
+}
+
+void EditorResourcePicker::_update_menu_from_button() {
+	_update_menu(false);
 }
 
 void EditorResourcePicker::_update_menu_items() {
@@ -1131,7 +1141,7 @@ EditorResourcePicker::EditorResourcePicker(bool p_hide_assign_button_controls) {
 	edit_button->set_action_mode(BaseButton::ACTION_MODE_BUTTON_PRESS);
 	edit_button->set_accessibility_name(TTRC("Edit"));
 	add_child(edit_button);
-	edit_button->connect(SceneStringName(pressed), callable_mp(this, &EditorResourcePicker::_update_menu));
+	edit_button->connect(SceneStringName(pressed), callable_mp(this, &EditorResourcePicker::_update_menu_from_button));
 	edit_button->connect(SceneStringName(gui_input), callable_mp(this, &EditorResourcePicker::_button_input));
 
 	add_theme_constant_override("separation", 0);

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -92,7 +92,8 @@ class EditorResourcePicker : public HBoxContainer {
 
 	void _resource_saved(Object *p_resource);
 
-	void _update_menu();
+	void _update_menu(bool p_allow_dialog);
+	void _update_menu_from_button();
 	void _update_menu_items();
 	void _edit_menu_cbk(int p_which);
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -556,6 +556,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	open_in_new_inspector_defaults.push_back("MeshLibrary");
 	_initial_set("interface/inspector/resources_to_open_in_new_inspector", open_in_new_inspector_defaults);
 
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/inspector/resource_picker_use_dialog_threshold", 30, "-1,9999,1")
+
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/default_color_picker_mode", (int32_t)ColorPicker::MODE_RGB, "RGB,HSV,RAW,OKHSL")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/default_color_picker_shape", (int32_t)ColorPicker::SHAPE_OKHSL_CIRCLE, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle,OKHSL Circle")
 

--- a/editor/gui/editor_popup_menu_dialog.cpp
+++ b/editor/gui/editor_popup_menu_dialog.cpp
@@ -1,0 +1,256 @@
+/**************************************************************************/
+/*  editor_popup_menu_dialog.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_popup_menu_dialog.h"
+
+#include "core/string/fuzzy_search.h"
+#include "editor/editor_node.h"
+#include "editor/editor_settings.h"
+#include "editor/themes/editor_scale.h"
+#include "scene/gui/item_list.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/margin_container.h"
+
+EditorPopupMenuDialog::EditorPopupMenuDialog() {
+	VBoxContainer *vbc = memnew(VBoxContainer);
+	vbc->add_theme_constant_override("separation", 0);
+	add_child(vbc);
+
+	{
+		// Search bar
+		MarginContainer *mc = memnew(MarginContainer);
+		mc->add_theme_constant_override("margin_top", 6);
+		mc->add_theme_constant_override("margin_bottom", 6);
+		mc->add_theme_constant_override("margin_left", 1);
+		mc->add_theme_constant_override("margin_right", 1);
+		vbc->add_child(mc);
+
+		search_box = memnew(LineEdit);
+		search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		search_box->set_clear_button_enabled(true);
+		mc->add_child(search_box);
+	}
+
+	{
+		item_list = memnew(ItemList);
+		item_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		item_list->connect("item_activated", callable_mp(this, &EditorPopupMenuDialog::handle_item_activated));
+		vbc->add_child(item_list);
+	}
+
+	search_box->connect(SceneStringName(text_changed), callable_mp(this, &EditorPopupMenuDialog::_search_box_text_changed));
+	search_box->connect(SceneStringName(gui_input), callable_mp(this, &EditorPopupMenuDialog::handle_search_box_input));
+	register_text_enter(search_box);
+	get_ok_button()->hide();
+}
+
+void EditorPopupMenuDialog::popup_dialog(PopupMenu *p_popup_menu, const String &p_title, const String &p_search_placeholder) {
+	ERR_FAIL_COND(p_popup_menu->get_item_count() == 0);
+
+	popup_menu = p_popup_menu;
+
+	int item_count = p_popup_menu->get_item_count();
+	for (int i = 0; i < item_count; i++) {
+		String text = p_popup_menu->get_item_text(i);
+
+		if (p_popup_menu->is_item_separator(i)) {
+			continue;
+		}
+
+		PopupMenuItem item;
+		item.text = text;
+		item.icon = p_popup_menu->get_item_icon(i);
+		item.popup_menu_index = i;
+
+		items.push_back(item);
+	}
+
+	item_visible_status.resize(items.size());
+
+	_search_box_text_changed("");
+	get_ok_button()->set_disabled(true);
+
+	set_title(p_title);
+	search_box->set_placeholder(p_search_placeholder);
+
+	popup_centered_clamped(Size2(300, 650) * EDSCALE, 0.8f);
+	search_box->grab_focus();
+	item_list->get_v_scroll_bar()->set_value(0);
+}
+
+void EditorPopupMenuDialog::ok_pressed() {
+	PackedInt32Array selected_items = item_list->get_selected_items();
+	ERR_FAIL_COND(selected_items.size() != 1);
+
+	int absolute_index = item_list->get_item_metadata(selected_items[0]);
+	if (absolute_index >= 0 && absolute_index < items.size()) {
+		callable_mp(popup_menu, &PopupMenu::activate_item).call_deferred(items[absolute_index].popup_menu_index);
+	}
+
+	cleanup();
+	hide();
+}
+
+void EditorPopupMenuDialog::cancel_pressed() {
+	cleanup();
+}
+
+void EditorPopupMenuDialog::cleanup() {
+	items.clear();
+	item_visible_status.clear();
+
+	item_list->clear();
+	search_box->clear();
+}
+
+void EditorPopupMenuDialog::handle_search_box_input(const Ref<InputEvent> &p_ie) {
+	if (num_visible_results < 0) {
+		return;
+	}
+
+	Ref<InputEventKey> key_event = p_ie;
+	if (key_event.is_valid() && key_event->is_pressed()) {
+		bool move_selection = false;
+
+		switch (key_event->get_keycode()) {
+			case Key::UP:
+			case Key::DOWN:
+			case Key::PAGEUP:
+			case Key::PAGEDOWN: {
+				move_selection = true;
+			} break;
+			default:
+				break; // Let the event through so it will reach the search box.
+		}
+
+		if (move_selection) {
+			_move_selection_index(key_event->get_keycode());
+			search_box->accept_event();
+		}
+	}
+}
+
+void EditorPopupMenuDialog::_move_selection_index(Key p_key) {
+	// Don't move selection if there are no results.
+	if (num_visible_results <= 0) {
+		return;
+	}
+	const int max_index = num_visible_results - 1;
+
+	PackedInt32Array selected_items = item_list->get_selected_items();
+	if (selected_items.size() != 1) {
+		return;
+	}
+
+	int idx = selected_items[0];
+	if (p_key == Key::UP) {
+		idx = (idx == 0) ? max_index : (idx - 1);
+	} else if (p_key == Key::DOWN) {
+		idx = (idx == max_index) ? 0 : (idx + 1);
+	} else if (p_key == Key::PAGEUP) {
+		idx = (idx == 0) ? idx : MAX(idx - 10, 0);
+	} else if (p_key == Key::PAGEDOWN) {
+		idx = (idx == max_index) ? idx : MIN(idx + 10, max_index);
+	}
+
+	item_list->deselect_all();
+	item_list->select(idx);
+	item_list->ensure_current_is_visible();
+}
+
+void EditorPopupMenuDialog::handle_item_activated(int p_index) {
+	ok_pressed();
+}
+
+void EditorPopupMenuDialog::_search_box_text_changed(const String &p_query) {
+	int total_item_count = items.size();
+
+	if (p_query.is_empty()) {
+		num_visible_results = total_item_count;
+		item_visible_status.fill(true);
+	} else {
+		_update_fuzzy_search_results(p_query);
+	}
+
+	// The selected id is the item's index in EditorPopupMenuDialog::items, NOT the filtered ItemList.
+	int selected_id = -1;
+	Vector<int> selections = item_list->get_selected_items();
+	if (selections.size() == 1) {
+		selected_id = item_list->get_item_metadata(selections[0]);
+	}
+
+	item_list->set_item_count(num_visible_results);
+	item_list->deselect_all();
+
+	bool has_selected_item = false;
+	int item_index = 0;
+	for (int i = 0; i < total_item_count; i++) {
+		if (item_visible_status[i]) {
+			const PopupMenuItem &item = items.get(i);
+			item_list->set_item_text(item_index, item.text);
+			item_list->set_item_icon(item_index, item.icon);
+			item_list->set_item_metadata(item_index, i); // Use EditorPopupMenuDialog::items index as id.
+			if (selected_id == i) {
+				item_list->select(item_index);
+				has_selected_item = true;
+			}
+			item_index++;
+		}
+	}
+
+	// Select first item if none were selected.
+	if (num_visible_results > 0 && !has_selected_item) {
+		item_list->select(0);
+	}
+
+	get_ok_button()->set_disabled(num_visible_results == 0);
+}
+
+void EditorPopupMenuDialog::_update_fuzzy_search_results(const String &p_query) {
+	FuzzySearch fuzzy_search;
+	fuzzy_search.set_query(p_query);
+	fuzzy_search.max_results = items.size();
+	bool fuzzy_matching = EDITOR_GET("filesystem/quick_open_dialog/enable_fuzzy_matching");
+	int max_misses = EDITOR_GET("filesystem/quick_open_dialog/max_fuzzy_misses");
+	fuzzy_search.allow_subsequences = fuzzy_matching;
+	fuzzy_search.max_misses = fuzzy_matching ? max_misses : 0;
+
+	num_visible_results = 0;
+	item_visible_status.fill(false);
+
+	int count = items.size();
+	for (int i = 0; i < count; i++) {
+		FuzzySearchResult result;
+		if (fuzzy_search.search(items[i].text, result)) {
+			num_visible_results++;
+			item_visible_status.set(i, true);
+		}
+	}
+}

--- a/editor/gui/editor_popup_menu_dialog.h
+++ b/editor/gui/editor_popup_menu_dialog.h
@@ -1,0 +1,81 @@
+/**************************************************************************/
+/*  editor_popup_menu_dialog.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/os/keyboard.h"
+#include "core/string/fuzzy_search.h"
+#include "scene/gui/dialogs.h"
+
+class LineEdit;
+class ItemList;
+class PopupMenu;
+
+class EditorPopupMenuDialog : public AcceptDialog {
+	GDCLASS(EditorPopupMenuDialog, AcceptDialog);
+
+public:
+	void popup_dialog(PopupMenu *p_popup_menu, const String &p_title, const String &p_search_placeholder);
+
+	EditorPopupMenuDialog();
+
+	struct PopupMenuItem {
+		String text;
+		Ref<Texture2D> icon;
+		int popup_menu_index;
+	};
+
+protected:
+	virtual void cancel_pressed() override;
+	virtual void ok_pressed() override;
+
+private:
+	Vector<PopupMenuItem> items;
+	Vector<bool> item_visible_status;
+
+	Vector<FuzzySearchResult> search_results;
+
+	PopupMenu *popup_menu = nullptr;
+
+	LineEdit *search_box = nullptr;
+	ItemList *item_list = nullptr;
+
+	int popup_menu_offset = 0;
+	int num_visible_results = 0;
+
+	void cleanup();
+
+	void handle_search_box_input(const Ref<InputEvent> &p_ie);
+	void handle_item_activated(int p_index);
+
+	void _move_selection_index(Key p_key);
+	void _update_fuzzy_search_results(const String &p_query);
+	void _search_box_text_changed(const String &p_query);
+};


### PR DESCRIPTION
- *Production edit:
closes https://github.com/godotengine/godot-proposals/issues/43,
closes https://github.com/godotengine/godot-proposals/issues/3430,
closes https://github.com/godotengine/godot-proposals/issues/3333*

This PR adds an editor setting to set a threshold for the number of items that should appear in the popup menu for the Resource Picker. If the items exceed this value, it opens them as a searchable dialog instead:

## Vids and Pics

https://github.com/user-attachments/assets/ca7c1dab-6264-4d53-aa32-98ee27416cfa

> [!NOTE]  
> For demonstration purposes the threshold is set to `10` in this video, but by default is `30`. So normally the dialog wouldn't trigger for `Mesh`. Afaik only a `Resource` `@export` would exceed `30`.

<img src="https://github.com/user-attachments/assets/475b3342-e6a6-494d-ad88-9075b6e31f78" width="500" title="Image" />

## Details

* The threshold option can be set to `0` to always open the dialog, or `-1` to disable the dialog all together. 

* A popup menu is still used when the arrow button is clicked; I think it would be jarring if the button with a down-arrow didn't create a popup menu underneath it. So basically the dialog only appears when creating a new resource and clicking `<empty>`. 

* The dialog is implemented by scanning the contents of the provided `PopupMenu` and converting its entries into list items. While this may seem a little hacky, I thought it would be a good way to let this behavior become reusable in the future for any other dynamically sized `PopupMenu`s. It also means the behavior for generating the entries in the first place doesn't need to be duplicated.

## To Be Discussed

* Maybe the popup menu should also contain a button to open as a searchable dialog regardless of the size?

* The `ItemList` widget used in the dialog doesn't have any obvious "separator" equivalent to replicate the separators from the `PopupMenu`. If we want to keep the separators, I could make a specialized `ItemList`-lookalike Control similar to how the `Quick Open` does it and add them that way, but I wanted to get feedback first before I put that much work into it. Thanks for reading!