### PR TITLE
Make shader editor menu position consistent with script editor

### DIFF
--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -84,9 +84,10 @@ class ShaderEditorPlugin : public EditorPlugin {
 		CONTEXT_VALID_ITEM,
 	};
 
-	HSplitContainer *main_split = nullptr;
-	VBoxContainer *left_panel = nullptr;
+	VBoxContainer *main_container = nullptr;
+	HSplitContainer *files_split = nullptr;
 	HBoxContainer *menu_hb = nullptr;
+	Control *menu_spacer = nullptr;
 
 	ItemList *shader_list = nullptr;
 	TabContainer *shader_tabs = nullptr;

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -1210,7 +1210,6 @@ TextShaderEditor::TextShaderEditor() {
 	bookmarks_menu->connect("index_pressed", callable_mp(this, &TextShaderEditor::_bookmark_item_pressed));
 
 	add_child(main_container);
-	main_container->add_child(hbc);
 	hbc->add_child(edit_menu);
 	hbc->add_child(search_menu);
 	hbc->add_child(goto_menu);


### PR DESCRIPTION
Currently, the shader editor has two modes, where the `file` menu button starts above the file list, then migrates to above the text editor when a file is selected, increasing the size of the file list vbox. This PR pulls the menu bars from the text editor above both the file list and the editor in order to be more consistent with the GDScript editor.

This PR also renames the properties `left_panel` -> `main_container` and `main_split` -> `files_split` to reflect this change in organization.

Iteration on #100287

Before:
<img width="961" alt="Screenshot 2025-04-09 at 3 04 18 AM" src="https://github.com/user-attachments/assets/1b685113-28c1-436c-8135-03e686886dd4" />

After:
<img width="960" alt="Screenshot 2025-04-09 at 3 02 26 AM" src="https://github.com/user-attachments/assets/facf30f8-7917-4762-afdd-99dba95762bd" />
