### PR TITLE
[4.3] Improve editor 2D/3D main screen auto-switching logic

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -642,6 +642,8 @@ private:
 
 	Dictionary _get_main_scene_state();
 	void _set_main_scene_state(Dictionary p_state, Node *p_for_scene);
+	bool _can_auto_switch_main_screens() const;
+	int _get_plugin_index(EditorPlugin *p_editor) const;
 
 	int _get_current_main_editor();
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1777,15 +1777,6 @@ void ScriptEditor::_notification(int p_what) {
 	}
 }
 
-bool ScriptEditor::can_take_away_focus() const {
-	ScriptEditorBase *current = _get_current_editor();
-	if (current) {
-		return current->can_lose_focus_on_node_selection();
-	} else {
-		return true;
-	}
-}
-
 void ScriptEditor::_close_builtin_scripts_from_scene(const String &p_scene) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -186,7 +186,6 @@ public:
 	virtual void add_callback(const String &p_function, const PackedStringArray &p_args) = 0;
 	virtual void update_settings() = 0;
 	virtual void set_debugger_active(bool p_active) = 0;
-	virtual bool can_lose_focus_on_node_selection() { return true; }
 	virtual void update_toggle_scripts_button() {}
 
 	virtual bool show_members_overview() = 0;
@@ -565,8 +564,6 @@ public:
 
 	void trigger_live_script_reload(const String &p_script_path);
 	void trigger_live_script_reload_all();
-
-	bool can_take_away_focus() const;
 
 	VSplitContainer *get_left_list_split() { return list_split; }
 

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -141,7 +141,6 @@ public:
 	virtual void tag_saved_version() override;
 	virtual void update_settings() override;
 	virtual bool show_members_overview() override;
-	virtual bool can_lose_focus_on_node_selection() override { return true; }
 	virtual void set_debugger_active(bool p_active) override;
 	virtual void set_tooltip_request_func(const Callable &p_toolip_callback) override;
 	virtual void add_callback(const String &p_function, const PackedStringArray &p_args) override;


### PR DESCRIPTION
This PR backports #104010 and the `"editor_index"` part of #96389 to Godot 4.3.

Why? For the moment, I have [my modules/extensions](https://github.com/orgs/godot-dimensions/repositories) targeting both Godot 4.3 and 4.4. There are a few minor engine changes that can improve the experience there, so I figure it makes sense to backport. Also would be nice to have #104097 and #104113 backported to fix Projection/Vector4(i), but those are bigger and should be cherry-picked the usual way.