### PR TITLE
Use non-recursive mutex for `StringName`, improving performance

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2226,6 +2226,16 @@ void Object::detach_from_objectdb() {
 	}
 }
 
+void Object::assign_class_name_static(const Span<char> &p_name, StringName &r_target) {
+	static BinaryMutex _mutex;
+	MutexLock lock(_mutex);
+	if (r_target) {
+		// Already assigned while we were waiting for the mutex.
+		return;
+	}
+	r_target = StringName(p_name.ptr(), true);
+}
+
 Object::~Object() {
 	if (script_instance) {
 		memdelete(script_instance);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -425,7 +425,7 @@ public:                                                                         
 	static const StringName &get_class_static() {                                                                                           \
 		static StringName _class_name_static;                                                                                               \
 		if (unlikely(!_class_name_static)) {                                                                                                \
-			StringName::assign_static_unique_class_name(&_class_name_static, #m_class);                                                     \
+			assign_class_name_static(#m_class, _class_name_static);                                                                         \
 		}                                                                                                                                   \
 		return _class_name_static;                                                                                                          \
 	}                                                                                                                                       \
@@ -811,10 +811,12 @@ public:
 	};
 
 	/* TYPE API */
+	static void assign_class_name_static(const Span<char> &p_name, StringName &r_target);
+
 	static const StringName &get_class_static() {
 		static StringName _class_name_static;
 		if (unlikely(!_class_name_static)) {
-			StringName::assign_static_unique_class_name(&_class_name_static, "Object");
+			assign_class_name_static("Object", _class_name_static);
 		}
 		return _class_name_static;
 	}

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -39,7 +39,7 @@ struct StringName::Table {
 	constexpr static uint32_t TABLE_MASK = TABLE_LEN - 1;
 
 	static inline _Data *table[TABLE_LEN];
-	static inline Mutex mutex;
+	static inline BinaryMutex mutex;
 	static inline PagedAllocator<_Data> allocator;
 };
 
@@ -205,13 +205,6 @@ StringName::StringName(const StringName &p_name) {
 
 	if (p_name._data && p_name._data->refcount.ref()) {
 		_data = p_name._data;
-	}
-}
-
-void StringName::assign_static_unique_class_name(StringName *ptr, const char *p_name) {
-	MutexLock lock(Table::mutex);
-	if (*ptr == StringName()) {
-		*ptr = StringName(p_name, true);
 	}
 }
 

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -178,8 +178,6 @@ public:
 	StringName(const String &p_name, bool p_static = false);
 	StringName() {}
 
-	static void assign_static_unique_class_name(StringName *ptr, const char *p_name);
-
 #ifdef SIZE_EXTRA
 	_NO_INLINE_
 #else


### PR DESCRIPTION
~Requires https://github.com/godotengine/godot/pull/105166 (mostly for code conflict convenience).~

This PR changes `StringName` to use a non-recursive mutex.
Non-recursive mutexes are faster, so `StringName` creation is accelerated with this PR.

Notably, the mutex is not the main bottleneck in `StringName` creation right now (cache misses are). But after the improvements from my other PR https://github.com/godotengine/godot/pull/104372, the mutex lock could be pretty substantial (10-20%).

## Discussion

There was only one use requiring recursivity: `assign_static_unique_class_name`. This used the `StringName` mutex to avoid potential access conflicts of different threads trying to assign the static class name at the same time.
There is no need to use the `StringName` mutex for this, so I moved the functionality to `Object` instead (which is the only place it's used).

## Benchmark

I made an out-of-project benchmark for this, because I was interested in the raw performance difference. On my system (macOS arm64), non-recursive mutexes can apparently be 35% faster than recursive ones:
```c++
    std::mutex binary_mutex;
    std::recursive_mutex recursive_mutex;

    {
        auto t0 = std::chrono::high_resolution_clock::now();
        for (int i = 0; i < 100000000; i ++) {
            // Test
            std::unique_lock lock(binary_mutex);
        }
        auto t1 = std::chrono::high_resolution_clock::now();
        std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
    }
    {
        auto t0 = std::chrono::high_resolution_clock::now();
        for (int i = 0; i < 100000000; i ++) {
            // Test
            std::unique_lock lock(recursive_mutex);
        }
        auto t1 = std::chrono::high_resolution_clock::now();
        std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
    }
```

This printed:
```
1435ms (binary mutex)
2175ms (recursive mutex)
```