### PR TITLE
Fix incorrect mipmap size calculation for uncompressed DDS textures

### DIFF
--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -165,8 +165,8 @@ static Ref<Image> _dds_load_layer(Ref<FileAccess> p_file, DDSFormat p_dds_format
 		uint32_t size = p_width * p_height * info.block_size;
 
 		for (uint32_t i = 1; i < p_mipmaps; i++) {
-			w = (w + 1) >> 1;
-			h = (h + 1) >> 1;
+			w = MAX(1u, w >> 1);
+			h = MAX(1u, h >> 1);
 			size += w * h * info.block_size;
 		}
 


### PR DESCRIPTION
Previously, the DDS texture loader incorrectly calculated mipmap dimensions for uncompressed textures when the original dimensions were non-power-of-two.

For example, given a 120×120 texture, the expected mipmap chain should be:
    mipmap=0, size=120×120
    mipmap=1, size=60×60
    mipmap=2, size=30×30
    mipmap=3, size=15×15
    mipmap=4, size=7×7
    mipmap=5, size=3×3
    mipmap=6, size=1×1

But the loader was producing:
    mipmap=0, size=120×120
    mipmap=1, size=60×60
    mipmap=2, size=30×30
    mipmap=3, size=15×15
    mipmap=4, size=8×8
    mipmap=5, size=4×4
    mipmap=6, size=2×2

This commit corrects the logic to properly compute width and height independently at each mip level.

The change corresponds to [how the official Microsoft dds loader works](https://github.com/microsoft/DirectXTex/blob/main/DDSTextureLoader/DDSTextureLoader11.cpp#L1082)  / (MIT license).


Here are two textures for testing.
[dds_mipmap_test.zip](https://github.com/user-attachments/files/19668019/dds_mipmap_test.zip)


Fixes #105136. I also added a bit deeper explanation [in comments of the issue](https://github.com/godotengine/godot/issues/105136#issuecomment-2789786371).
