### PR TITLE
Add a Culling Mode property to GeometryInstance3D

### DIFF
--- a/doc/classes/GeometryInstance3D.xml
+++ b/doc/classes/GeometryInstance3D.xml
@@ -33,6 +33,10 @@
 		<member name="cast_shadow" type="int" setter="set_cast_shadows_setting" getter="get_cast_shadows_setting" enum="GeometryInstance3D.ShadowCastingSetting" default="1">
 			The selected shadow casting flag. See [enum ShadowCastingSetting] for possible values.
 		</member>
+		<member name="culling_mode" type="int" setter="set_culling_mode" getter="get_culling_mode" enum="GeometryInstance3D.CullingMode" default="0">
+			The frustum/occlusion culling mode to use for this instance. See [enum CullingMode] for possible values.
+			[b]Note:[/b] Not to be confused with backface culling on materials (see [member BaseMaterial3D.cull_mode] instead).
+		</member>
 		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)">
 			Overrides the bounding box of this node with a custom one. This can be used to avoid the expensive [AABB] recalculation that happens when a skeleton is used with a [MeshInstance3D] or to have precise control over the [MeshInstance3D]'s bounding box. To use the default AABB, set value to an [AABB] with all fields set to [code]0.0[/code]. To avoid frustum culling, set [member custom_aabb] to a very large AABB that covers your entire game world such as [code]AABB(-10000, -10000, -10000, 20000, 20000, 20000)[/code]. To disable all forms of culling (including occlusion culling), call [method RenderingServer.instance_set_ignore_culling] on the [GeometryInstance3D]'s [RID].
 		</member>
@@ -50,7 +54,7 @@
 			The global illumination mode to use for the whole geometry. To avoid inconsistent results, use a mode that matches the purpose of the mesh during gameplay (static/dynamic).
 			[b]Note:[/b] Lights' bake mode will also affect the global illumination rendering. See [member Light3D.light_bake_mode].
 		</member>
-		<member name="ignore_occlusion_culling" type="bool" setter="set_ignore_occlusion_culling" getter="is_ignoring_occlusion_culling" default="false">
+		<member name="ignore_occlusion_culling" type="bool" setter="set_ignore_occlusion_culling" getter="is_ignoring_occlusion_culling" deprecated="Use [member culling_mode] instead.">
 			If [code]true[/code], disables occlusion culling for this instance. Useful for gizmos that must be rendered even when occlusion culling is in use.
 			[b]Note:[/b] [member ignore_occlusion_culling] does not affect frustum culling (which is what happens when an object is not visible given the camera's angle). To avoid frustum culling, set [member custom_aabb] to a very large AABB that covers your entire game world such as [code]AABB(-10000, -10000, -10000, 20000, 20000, 20000)[/code].
 		</member>
@@ -114,6 +118,15 @@
 		</constant>
 		<constant name="GI_MODE_DYNAMIC" value="2" enum="GIMode">
 			Dynamic global illumination mode. Use for dynamic objects that contribute to global illumination. This GI mode is only effective when using [VoxelGI], but it has a higher performance impact than [constant GI_MODE_STATIC]. When using other GI methods, this will act the same as [constant GI_MODE_DISABLED]. When using [LightmapGI], the object will receive indirect lighting using lightmap probes instead of using the baked lightmap texture.
+		</constant>
+		<constant name="CULLING_MODE_NORMAL" value="0" enum="CullingMode">
+			Perform frustum and occlusion culling. This mode should be used in most cases, as it avoids rendering the object if it isn't visible, which improves performance. Note that occlusion culling requires [member ProjectSettings.rendering/occlusion_culling/use_occlusion_culling] to be enabled.
+		</constant>
+		<constant name="CULLING_MODE_IGNORE_OCCLUSION_CULLING" value="1" enum="CullingMode">
+			Perform frustum culling only. With large amounts of instances, this can slightly improve performance in situations where you know the object will never be culled by another object. This is because culling has a CPU cost (especially occlusion culling).
+		</constant>
+		<constant name="CULLING_MODE_IGNORE_OCCLUSION_AND_FRUSTUM_CULLING" value="2" enum="CullingMode">
+			Don't perform any kind of culling (neither frustum nor occlusion). With large amounts of instances, this can slightly improve performance in situations where you know the object will never be culled by another object and will always be in the view frustum. This is because culling has a CPU cost (especially occlusion culling). This can also be used to force the object to render regardless of its position, which can be useful to precompile shaders in a loading screen.
 		</constant>
 		<constant name="LIGHTMAP_SCALE_1X" value="0" enum="LightmapScale" deprecated="Use [member gi_lightmap_texel_scale] instead.">
 			The standard texel density for lightmapping with [LightmapGI].

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -508,14 +508,48 @@ GeometryInstance3D::GIMode GeometryInstance3D::get_gi_mode() const {
 	return gi_mode;
 }
 
+void GeometryInstance3D::set_culling_mode(CullingMode p_mode) {
+	if (p_mode == culling_mode) {
+		return;
+	}
+
+	culling_mode = p_mode;
+
+	switch (p_mode) {
+		case CULLING_MODE_NORMAL: {
+			RS::get_singleton()->instance_geometry_set_flag(get_instance(), RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, false);
+			RS::get_singleton()->instance_set_ignore_culling(get_instance(), false);
+		} break;
+		case CULLING_MODE_IGNORE_OCCLUSION_CULLING: {
+			RS::get_singleton()->instance_geometry_set_flag(get_instance(), RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+			RS::get_singleton()->instance_set_ignore_culling(get_instance(), false);
+		} break;
+		case CULLING_MODE_IGNORE_OCCLUSION_AND_FRUSTUM_CULLING: {
+			RS::get_singleton()->instance_geometry_set_flag(get_instance(), RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+			RS::get_singleton()->instance_set_ignore_culling(get_instance(), true);
+		} break;
+		case CULLING_MODE_MAX:
+			break; // Internal value, skip.
+	}
+}
+
+GeometryInstance3D::CullingMode GeometryInstance3D::get_culling_mode() const {
+	return culling_mode;
+}
+
+#ifndef DISABLE_DEPRECATED
 void GeometryInstance3D::set_ignore_occlusion_culling(bool p_enabled) {
-	ignore_occlusion_culling = p_enabled;
-	RS::get_singleton()->instance_geometry_set_flag(get_instance(), RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, ignore_occlusion_culling);
+	if (p_enabled) {
+		set_culling_mode(CULLING_MODE_IGNORE_OCCLUSION_CULLING);
+	} else {
+		set_culling_mode(CULLING_MODE_NORMAL);
+	}
 }
 
 bool GeometryInstance3D::is_ignoring_occlusion_culling() {
-	return ignore_occlusion_culling;
+	return culling_mode >= CULLING_MODE_IGNORE_OCCLUSION_CULLING;
 }
+#endif // DISABLE_DEPRECATED
 
 Ref<TriangleMesh> GeometryInstance3D::generate_triangle_mesh() const {
 	return Ref<TriangleMesh>();
@@ -601,8 +635,13 @@ void GeometryInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_gi_mode", "mode"), &GeometryInstance3D::set_gi_mode);
 	ClassDB::bind_method(D_METHOD("get_gi_mode"), &GeometryInstance3D::get_gi_mode);
 
+	ClassDB::bind_method(D_METHOD("set_culling_mode", "mode"), &GeometryInstance3D::set_culling_mode);
+	ClassDB::bind_method(D_METHOD("get_culling_mode"), &GeometryInstance3D::get_culling_mode);
+
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_ignore_occlusion_culling", "ignore_culling"), &GeometryInstance3D::set_ignore_occlusion_culling);
 	ClassDB::bind_method(D_METHOD("is_ignoring_occlusion_culling"), &GeometryInstance3D::is_ignoring_occlusion_culling);
+#endif // DISABLE_DEPRECATED
 
 	ClassDB::bind_method(D_METHOD("set_custom_aabb", "aabb"), &GeometryInstance3D::set_custom_aabb);
 	ClassDB::bind_method(D_METHOD("get_custom_aabb"), &GeometryInstance3D::get_custom_aabb);
@@ -617,7 +656,10 @@ void GeometryInstance3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "extra_cull_margin", PROPERTY_HINT_RANGE, "0,16384,0.01,suffix:m"), "set_extra_cull_margin", "get_extra_cull_margin");
 	ADD_PROPERTY(PropertyInfo(Variant::AABB, "custom_aabb", PROPERTY_HINT_NONE, "suffix:m"), "set_custom_aabb", "get_custom_aabb");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lod_bias", PROPERTY_HINT_RANGE, "0.001,128,0.001"), "set_lod_bias", "get_lod_bias");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_occlusion_culling"), "set_ignore_occlusion_culling", "is_ignoring_occlusion_culling");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "culling_mode", PROPERTY_HINT_ENUM, "Normal,Ignore Occlusion Culling,Ignore Occlusion and Frustum Culling"), "set_culling_mode", "get_culling_mode");
+#ifndef DISABLE_DEPRECATED
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_occlusion_culling", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_ignore_occlusion_culling", "is_ignoring_occlusion_culling");
+#endif // DISABLE_DEPRECATED
 
 	ADD_GROUP("Global Illumination", "gi_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "gi_mode", PROPERTY_HINT_ENUM, "Disabled,Static,Dynamic"), "set_gi_mode", "get_gi_mode");
@@ -641,6 +683,10 @@ void GeometryInstance3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(GI_MODE_DISABLED);
 	BIND_ENUM_CONSTANT(GI_MODE_STATIC);
 	BIND_ENUM_CONSTANT(GI_MODE_DYNAMIC);
+
+	BIND_ENUM_CONSTANT(CULLING_MODE_NORMAL);
+	BIND_ENUM_CONSTANT(CULLING_MODE_IGNORE_OCCLUSION_CULLING);
+	BIND_ENUM_CONSTANT(CULLING_MODE_IGNORE_OCCLUSION_AND_FRUSTUM_CULLING);
 
 	BIND_ENUM_CONSTANT(LIGHTMAP_SCALE_1X);
 	BIND_ENUM_CONSTANT(LIGHTMAP_SCALE_2X);

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -99,6 +99,13 @@ public:
 		GI_MODE_DYNAMIC
 	};
 
+	enum CullingMode {
+		CULLING_MODE_NORMAL,
+		CULLING_MODE_IGNORE_OCCLUSION_CULLING,
+		CULLING_MODE_IGNORE_OCCLUSION_AND_FRUSTUM_CULLING,
+		CULLING_MODE_MAX,
+	};
+
 	enum LightmapScale {
 		LIGHTMAP_SCALE_1X,
 		LIGHTMAP_SCALE_2X,
@@ -135,7 +142,10 @@ private:
 	AABB custom_aabb;
 	float lightmap_texel_scale = 1.0f;
 	GIMode gi_mode = GI_MODE_STATIC;
+	CullingMode culling_mode = CULLING_MODE_NORMAL;
+#ifndef DISABLE_DEPRECATED
 	bool ignore_occlusion_culling = false;
+#endif // DISABLE_DEPRECATED
 
 	const StringName *_instance_uniform_get_remap(const StringName &p_name) const;
 
@@ -198,8 +208,13 @@ public:
 	void set_custom_aabb(AABB p_aabb);
 	AABB get_custom_aabb() const;
 
+	void set_culling_mode(CullingMode p_mode);
+	CullingMode get_culling_mode() const;
+
+#ifndef DISABLE_DEPRECATED
 	void set_ignore_occlusion_culling(bool p_enabled);
 	bool is_ignoring_occlusion_culling();
+#endif // DISABLE_DEPRECATED
 
 	virtual Ref<TriangleMesh> generate_triangle_mesh() const;
 
@@ -210,5 +225,6 @@ public:
 
 VARIANT_ENUM_CAST(GeometryInstance3D::ShadowCastingSetting);
 VARIANT_ENUM_CAST(GeometryInstance3D::GIMode);
+VARIANT_ENUM_CAST(GeometryInstance3D::CullingMode);
 VARIANT_ENUM_CAST(GeometryInstance3D::LightmapScale);
 VARIANT_ENUM_CAST(GeometryInstance3D::VisibilityRangeFadeMode);


### PR DESCRIPTION
This new enum property allows disabling both frustum and occlusion culling, which can be useful for shader precompilation purposes, especially on Compatibility where other techniques are not available. Using this property, you no longer have to specifically position your 3D node to be in front of the camera: it can be located anywhere in the scene and precompilation will work, as long as it's visible in the scene tree.

Ignore Occlusion Culling is automatically migrated and still works to keep compatibility with existing projects, but it's now deprecated.

- See https://github.com/godotengine/godot-proposals/issues/12119#issuecomment-2767393805.

## Preview

https://github.com/user-attachments/assets/f8500552-acf0-48f3-abd5-06466a8b73a4

