### PR TITLE
Fix importing compressed dds textures with non-power-of-two width or height

### DIFF
--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -140,7 +140,7 @@ static Ref<Image> _dds_load_layer(Ref<FileAccess> p_file, DDSFormat p_dds_format
 			WARN_PRINT(vformat("%s: DDS height '%d' is not divisible by %d. This is not allowed as per the DDS specification, attempting to load anyway.", p_file->get_path(), p_height, info.divisor));
 		}
 
-		uint32_t size = MAX(info.divisor, w) / info.divisor * MAX(info.divisor, h) / info.divisor * info.block_size;
+		uint32_t size = MAX(1u, (w + 3) / 4) * MAX(1u, (h + 3) / 4) * info.block_size;
 
 		if (p_flags & DDSD_LINEARSIZE) {
 			ERR_FAIL_COND_V_MSG(size != p_pitch, Ref<Resource>(), "DDS header flags specify that a linear size of the top-level image is present, but the specified size does not match the expected value.");
@@ -152,7 +152,7 @@ static Ref<Image> _dds_load_layer(Ref<FileAccess> p_file, DDSFormat p_dds_format
 			w = MAX(1u, w >> 1);
 			h = MAX(1u, h >> 1);
 
-			uint32_t bsize = MAX(info.divisor, w) / info.divisor * MAX(info.divisor, h) / info.divisor * info.block_size;
+			uint32_t bsize = MAX(1u, (w + 3) / 4) * MAX(1u, (h + 3) / 4) * info.block_size;
 			size += bsize;
 		}
 


### PR DESCRIPTION
Accodring to the [DDS documentation](
https://learn.microsoft.com/en-us/windows/win32/direct3ddds/dds-file-layout-for-textures) the size of each mipmap level for compressed formats (like DXT1–DXT5) should be calculated as:

    max(1, ( (width + 3) / 4 ) ) x max(1, ( (height + 3) / 4 ) ) x 8(DXT1) or 16(DXT2-5)

However, DDS loader was using a slightly different formula, which led to incorrect results for textures where width or height are not powers of two. This caused errors during texture import.

```
>cat test.txt | grep wrong
  WARNING: modules\dds\texture_loader_dds.cpp:145 -  wrong mipmap 0: 512 x 384 = 196608
  WARNING: modules\dds\texture_loader_dds.cpp:163 -  wrong mipmap 1: 256 x 192 = 49152
  WARNING: modules\dds\texture_loader_dds.cpp:163 -  wrong mipmap 2: 128 x 96 = 12288
  WARNING: modules\dds\texture_loader_dds.cpp:163 -  wrong mipmap 3: 64 x 48 = 3072
  WARNING: modules\dds\texture_loader_dds.cpp:163 -  wrong mipmap 4: 32 x 24 = 768
  WARNING: modules\dds\texture_loader_dds.cpp:163 -  wrong mipmap 5: 16 x 12 = 192
  WARNING: modules\dds\texture_loader_dds.cpp:163 -  wrong mipmap 6: 8 x 6 = 48               <----------- wrong
  WARNING: modules\dds\texture_loader_dds.cpp:163 -  wrong mipmap 7: 4 x 3 = 16
  WARNING: modules\dds\texture_loader_dds.cpp:163 -  wrong mipmap 8: 2 x 1 = 16
  WARNING: modules\dds\texture_loader_dds.cpp:163 -  wrong mipmap 9: 1 x 1 = 16

>cat test.txt | grep correct
  WARNING: modules\dds\texture_loader_dds.cpp:148 -  correct mipmap 0: 512 x 384 = 196608
  WARNING: modules\dds\texture_loader_dds.cpp:166 -  correct mipmap 1: 256 x 192 = 49152
  WARNING: modules\dds\texture_loader_dds.cpp:166 -  correct mipmap 2: 128 x 96 = 12288
  WARNING: modules\dds\texture_loader_dds.cpp:166 -  correct mipmap 3: 64 x 48 = 3072
  WARNING: modules\dds\texture_loader_dds.cpp:166 -  correct mipmap 4: 32 x 24 = 768
  WARNING: modules\dds\texture_loader_dds.cpp:166 -  correct mipmap 5: 16 x 12 = 192
  WARNING: modules\dds\texture_loader_dds.cpp:166 -  correct mipmap 6: 8 x 6 = 64               <----------- correct
  WARNING: modules\dds\texture_loader_dds.cpp:166 -  correct mipmap 7: 4 x 3 = 16
  WARNING: modules\dds\texture_loader_dds.cpp:166 -  correct mipmap 8: 2 x 1 = 16
  WARNING: modules\dds\texture_loader_dds.cpp:166 -  correct mipmap 9: 1 x 1 = 16
```

I updated the formula to match the spec and verified it against a set of DDS textures saved in various compressed formats supported by Godot.

Archive with test dds'ses in different formats:
[dds_mipmap_compressed_test.zip](https://github.com/user-attachments/files/19668901/dds_mipmap_compressed_test.zip)

Screenshots:
![image](https://github.com/user-attachments/assets/c40dd8d6-2fa3-4eb4-8118-7bf5508c7bf8)

