### PR TITLE
SCons: Don't attempt to resolve paths in emitter

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -96,9 +96,9 @@ def redirect_emitter(target, source, env):
 
     redirected_targets = []
     for item in target:
-        if base_folder in (path := Path(item.get_abspath()).resolve()).parents:
+        if base_folder in (path := Path(item.get_abspath())).parents:
             item = env.File(f"#bin/obj/{path.relative_to(base_folder)}")
-        elif (alt_base := Path(env.Dir(".").get_abspath()).resolve().parent) in path.parents:
+        elif (alt_base := Path(env.Dir(".").get_abspath()).parent) in path.parents:
             item = env.File(f"#bin/obj/external/{path.relative_to(alt_base)}")
         else:
             print_warning(f'Failed to redirect "{path}"')


### PR DESCRIPTION
(probably) Resolves https://github.com/godotengine/godot/pull/104851#issuecomment-2784929767 

This turned out to be a redundant step, as the path was already passed as absolute beforehand. Removing it keeps the path as absolute, without attempting symlink resolution.