### PR TITLE
Use validated key in `Dictionary::has`

### DIFF
--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -218,7 +218,7 @@ bool Dictionary::is_empty() const {
 bool Dictionary::has(const Variant &p_key) const {
 	Variant key = p_key;
 	ERR_FAIL_COND_V(!_p->typed_key.validate(key, "use 'has'"), false);
-	return _p->variant_map.has(p_key);
+	return _p->variant_map.has(key);
 }
 
 bool Dictionary::has_all(const Array &p_keys) const {


### PR DESCRIPTION
Updated `Dictionary::has` to use validated key when checking `variant_map`, to handle cases when passed in key is converted to `Dictionary`'s key type.

Fixes #105204

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
