### PR TITLE
Add singleton check before adding webxr interface

### DIFF
--- a/modules/webxr/register_types.cpp
+++ b/modules/webxr/register_types.cpp
@@ -45,8 +45,10 @@ void initialize_webxr_module(ModuleInitializationLevel p_level) {
 	GDREGISTER_ABSTRACT_CLASS(WebXRInterface);
 
 #ifdef WEB_ENABLED
-	webxr.instantiate();
-	XRServer::get_singleton()->add_interface(webxr);
+	if (XRServer::get_singleton()) {
+		webxr.instantiate();
+		XRServer::get_singleton()->add_interface(webxr);
+	}
 #endif
 }
 


### PR DESCRIPTION
When trying to run `--test` single threaded on Web, I stumbled upon this weird issue.

![image](https://github.com/user-attachments/assets/99355111-f659-4bd1-85e4-da13d674ae5e)

It seems that when running `--test` without threads on the Web, a race condition happens and the `XRServer` singleton isn't available the first time `initialize_webxr_module()` is called.

This PR adds a simple null check.