### PR TITLE
Add GDSOFTCLASS to FileAccess and DirAccess derived classes

### DIFF
--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -34,6 +34,7 @@
 #include "core/io/file_access.h"
 
 class FileAccessCompressed : public FileAccess {
+	GDSOFTCLASS(FileAccessCompressed, FileAccess);
 	Compression::Mode cmode = Compression::MODE_ZSTD;
 	bool writing = false;
 	uint64_t write_pos = 0;

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -36,6 +36,8 @@
 #define ENCRYPTED_HEADER_MAGIC 0x43454447
 
 class FileAccessEncrypted : public FileAccess {
+	GDSOFTCLASS(FileAccessEncrypted, FileAccess);
+
 public:
 	enum Mode : int32_t {
 		MODE_READ,

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -33,6 +33,7 @@
 #include "core/io/file_access.h"
 
 class FileAccessMemory : public FileAccess {
+	GDSOFTCLASS(FileAccessMemory, FileAccess);
 	uint8_t *data = nullptr;
 	uint64_t length = 0;
 	mutable uint64_t pos = 0;

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -157,6 +157,7 @@ public:
 };
 
 class FileAccessPack : public FileAccess {
+	GDSOFTCLASS(FileAccessPack, FileAccess);
 	PackedData::PackedFile pf;
 
 	mutable uint64_t pos;
@@ -241,6 +242,7 @@ bool PackedData::has_directory(const String &p_path) {
 }
 
 class DirAccessPack : public DirAccess {
+	GDSOFTCLASS(DirAccessPack, DirAccess);
 	PackedData::PackedDir *current;
 
 	List<String> list_dirs;

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -73,6 +73,7 @@ public:
 };
 
 class FileAccessZip : public FileAccess {
+	GDSOFTCLASS(FileAccessZip, FileAccess);
 	unzFile zfile = nullptr;
 	unz_file_info64 file_info;
 

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -40,6 +40,7 @@
 #include <unistd.h>
 
 class DirAccessUnix : public DirAccess {
+	GDSOFTCLASS(DirAccessUnix, DirAccess);
 	DIR *dir_stream = nullptr;
 
 	bool _cisdir = false;

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -38,6 +38,7 @@
 #if defined(UNIX_ENABLED)
 
 class FileAccessUnix : public FileAccess {
+	GDSOFTCLASS(FileAccessUnix, FileAccess);
 	FILE *f = nullptr;
 	int flags = 0;
 	void check_errors(bool p_write = false) const;

--- a/drivers/unix/file_access_unix_pipe.h
+++ b/drivers/unix/file_access_unix_pipe.h
@@ -38,6 +38,7 @@
 #if defined(UNIX_ENABLED)
 
 class FileAccessUnixPipe : public FileAccess {
+	GDSOFTCLASS(FileAccessUnixPipe, FileAccess);
 	bool unlink_on_close = false;
 
 	int fd[2] = { -1, -1 };

--- a/drivers/windows/dir_access_windows.h
+++ b/drivers/windows/dir_access_windows.h
@@ -37,6 +37,7 @@
 struct DirAccessWindowsPrivate;
 
 class DirAccessWindows : public DirAccess {
+	GDSOFTCLASS(DirAccessWindows, DirAccess);
 	enum {
 		MAX_DRIVES = 26
 	};

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -38,6 +38,7 @@
 #include <stdio.h>
 
 class FileAccessWindows : public FileAccess {
+	GDSOFTCLASS(FileAccessWindows, FileAccess);
 	FILE *f = nullptr;
 	int flags = 0;
 	void check_errors(bool p_write = false) const;

--- a/drivers/windows/file_access_windows_pipe.h
+++ b/drivers/windows/file_access_windows_pipe.h
@@ -37,7 +37,9 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+
 class FileAccessWindowsPipe : public FileAccess {
+	GDSOFTCLASS(FileAccessWindowsPipe, FileAccess);
 	HANDLE fd[2] = { nullptr, nullptr };
 
 	mutable Error last_error = OK;

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -42,6 +42,7 @@
 /// The implementation use jni in order to comply with Android filesystem
 /// access restriction.
 class DirAccessJAndroid : public DirAccessUnix {
+	GDSOFTCLASS(DirAccessJAndroid, DirAccessUnix);
 	static jobject dir_access_handler;
 	static jclass cls;
 

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -38,6 +38,7 @@
 #include <stdio.h>
 
 class FileAccessAndroid : public FileAccess {
+	GDSOFTCLASS(FileAccessAndroid, FileAccess);
 	static AAssetManager *asset_manager;
 	static jobject j_asset_manager;
 

--- a/platform/android/file_access_filesystem_jandroid.h
+++ b/platform/android/file_access_filesystem_jandroid.h
@@ -35,6 +35,7 @@
 #include "core/io/file_access.h"
 
 class FileAccessFilesystemJAndroid : public FileAccess {
+	GDSOFTCLASS(FileAccessFilesystemJAndroid, FileAccess);
 	static jobject file_access_handler;
 	static jclass cls;
 

--- a/platform/macos/dir_access_macos.h
+++ b/platform/macos/dir_access_macos.h
@@ -41,6 +41,8 @@
 #include <unistd.h>
 
 class DirAccessMacOS : public DirAccessUnix {
+	GDSOFTCLASS(DirAccessMacOS, DirAccessUnix);
+
 protected:
 	virtual String fix_unicode_name(const char *p_name) const override;
 


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/104844

The previous PR made it impossible to dynamically cast FileAccess and DirAccess pointers for most of the derived classes because they didn't have either the GDCLASS or GDSOFTCLASS macros. I have corrected this.