### PR TITLE
Small refactoring in PopupMenu.

### DIFF
--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -144,11 +144,13 @@ class PopupMenu : public Popup {
 	void _activate_submenu(int p_over, bool p_by_keyboard = false);
 	void _submenu_timeout();
 
+	int _focus_previous_selectable();
+	int _focus_next_selectable();
+
 	uint64_t popup_time_msec = 0;
 	bool hide_on_item_selection = true;
 	bool hide_on_checkable_item_selection = true;
 	bool hide_on_multistate_item_selection = false;
-	Vector2 moved;
 
 	HashMap<Ref<Shortcut>, int> shortcut_refcount;
 


### PR DESCRIPTION
Extract functions for selecting next/previous items.
Rework repetition into existing loop, when hiding menus in PopupMenu::activate_item.

Remove:
- Some unnecessary Vector::write calls for const access.
- Misleading/unused 'id' local variable.
- Unused member variable, 'moved'.
- A PopupMenu to PopupMenu cast.

Refactor only, no behaviour changes/fixes.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
