### PR TITLE
Expose `object.get_class_name()`. Deprecate `object.get_class()`

### DIFF
--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -275,7 +275,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 			script_debugger->set_lines_left(-1);
 
 			MainLoop *main_loop = OS::get_singleton()->get_main_loop();
-			if (main_loop->get_class() == "SceneTree") {
+			if (main_loop->get_class_name() == "SceneTree") {
 				main_loop->call("quit");
 			}
 			break;

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -1282,7 +1282,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 			if (s.class_name != StringName()) {
 				d["type"] = String(s.class_name);
 			} else {
-				d["type"] = String(s.ptr->get_class());
+				d["type"] = String(s.ptr->get_class_name());
 			}
 			singletons.push_back(d);
 		}

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -766,7 +766,7 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 				return Variant();
 			}
 
-			ERR_FAIL_COND_V(!ClassDB::can_instantiate(obj->get_class()), Variant());
+			ERR_FAIL_COND_V(!ClassDB::can_instantiate(obj->get_class_name()), Variant());
 
 			List<PropertyInfo> prop_list;
 			obj->get_property_list(&prop_list);
@@ -794,7 +794,7 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			}
 
 			Dictionary ret;
-			ret[TYPE] = obj->get_class();
+			ret[TYPE] = obj->get_class_name();
 			ret[PROPS] = props;
 			return ret;
 		} break;

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1747,9 +1747,9 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 					r_len += 4;
 
 				} else {
-					ERR_FAIL_COND_V(!ClassDB::can_instantiate(obj->get_class()), ERR_INVALID_PARAMETER);
+					ERR_FAIL_COND_V(!ClassDB::can_instantiate(obj->get_class_name()), ERR_INVALID_PARAMETER);
 
-					_encode_string(obj->get_class(), buf, r_len);
+					_encode_string(obj->get_class_name(), buf, r_len);
 
 					List<PropertyInfo> props;
 					obj->get_property_list(&props);

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -220,7 +220,7 @@ void Resource::reset_state() {
 
 Error Resource::copy_from(const Ref<Resource> &p_resource) {
 	ERR_FAIL_COND_V(p_resource.is_null(), ERR_INVALID_PARAMETER);
-	if (get_class() != p_resource->get_class()) {
+	if (get_class_name() != p_resource->get_class_name()) {
 		return ERR_INVALID_PARAMETER;
 	}
 
@@ -253,7 +253,7 @@ void Resource::reload_from_file() {
 		return;
 	}
 
-	Ref<Resource> s = ResourceLoader::load(ResourceLoader::path_remap(path), get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
+	Ref<Resource> s = ResourceLoader::load(ResourceLoader::path_remap(path), get_class_name(), ResourceFormatLoader::CACHE_MODE_IGNORE);
 
 	if (s.is_null()) {
 		return;
@@ -315,7 +315,7 @@ Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, HashMap<Ref
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
 
-	Ref<Resource> r = Object::cast_to<Resource>(ClassDB::instantiate(get_class()));
+	Ref<Resource> r = Object::cast_to<Resource>(ClassDB::instantiate(get_class_name()));
 	ERR_FAIL_COND_V(r.is_null(), Ref<Resource>());
 
 	r->local_scene = p_for_scene;
@@ -391,7 +391,7 @@ Ref<Resource> Resource::duplicate(bool p_subresources) const {
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
 
-	Ref<Resource> r = static_cast<Resource *>(ClassDB::instantiate(get_class()));
+	Ref<Resource> r = static_cast<Resource *>(ClassDB::instantiate(get_class_name()));
 	ERR_FAIL_COND_V(r.is_null(), Ref<Resource>());
 
 	for (const PropertyInfo &E : plist) {
@@ -628,7 +628,7 @@ void ResourceCache::clear() {
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			ERR_PRINT(vformat("%d resources still in use at exit.", resources.size()));
 			for (const KeyValue<String, Resource *> &E : resources) {
-				print_line(vformat("Resource still in use: %s (%s)", E.key, E.value->get_class()));
+				print_line(vformat("Resource still in use: %s (%s)", E.key, E.value->get_class_name()));
 			}
 		} else {
 			ERR_PRINT(vformat("%d resources still in use at exit (run with --verbose for details).", resources.size()));

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -757,7 +757,7 @@ Error ResourceLoaderBinary::load() {
 			if (cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE && ResourceCache::has(path)) {
 				//use the existing one
 				Ref<Resource> cached = ResourceCache::get_ref(path);
-				if (cached->get_class() == t) {
+				if (cached->get_class_name() == t) {
 					cached->reset_state();
 					res = cached;
 				}
@@ -782,7 +782,7 @@ Error ResourceLoaderBinary::load() {
 
 				r = Object::cast_to<Resource>(obj);
 				if (!r) {
-					String obj_class = obj->get_class();
+					String obj_class = obj->get_class_name();
 					error = ERR_FILE_CORRUPT;
 					memdelete(obj); //bye
 					ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, vformat("'%s': Resource type in resource field not a resource, type is: %s.", local_path, obj_class));
@@ -2121,7 +2121,7 @@ static String _resource_get_class(Ref<Resource> p_resource) {
 	if (missing_resource.is_valid()) {
 		return missing_resource->get_original_class();
 	} else {
-		return p_resource->get_class();
+		return p_resource->get_class_name();
 	}
 }
 
@@ -2253,7 +2253,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 						}
 					}
 
-					Variant default_value = ClassDB::class_get_default_property_value(E->get_class(), F.name);
+					Variant default_value = ClassDB::class_get_default_property_value(E->get_class_name(), F.name);
 
 					if (default_value.get_type() != Variant::NIL && bool(Variant::evaluate(Variant::OP_EQUAL, p.value, default_value))) {
 						continue;

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -931,7 +931,7 @@ bool ResourceLoader::_ensure_load_progress() {
 }
 
 void ResourceLoader::resource_changed_connect(Resource *p_source, const Callable &p_callable, uint32_t p_flags) {
-	print_lt(vformat("%d\t%ud:%s\t" FUNCTION_STR "\t%d", Thread::get_caller_id(), p_source->get_instance_id(), p_source->get_class(), p_callable.get_object_id()));
+	print_lt(vformat("%d\t%ud:%s\t" FUNCTION_STR "\t%d", Thread::get_caller_id(), p_source->get_instance_id(), p_source->get_class_name(), p_callable.get_object_id()));
 
 	MutexLock lock(thread_load_mutex);
 
@@ -949,7 +949,7 @@ void ResourceLoader::resource_changed_connect(Resource *p_source, const Callable
 }
 
 void ResourceLoader::resource_changed_disconnect(Resource *p_source, const Callable &p_callable) {
-	print_lt(vformat("%d\t%ud:%s\t" FUNCTION_STR "t%d", Thread::get_caller_id(), p_source->get_instance_id(), p_source->get_class(), p_callable.get_object_id()));
+	print_lt(vformat("%d\t%ud:%s\t" FUNCTION_STR "t%d", Thread::get_caller_id(), p_source->get_instance_id(), p_source->get_class_name(), p_callable.get_object_id()));
 
 	MutexLock lock(thread_load_mutex);
 
@@ -963,7 +963,7 @@ void ResourceLoader::resource_changed_disconnect(Resource *p_source, const Calla
 }
 
 void ResourceLoader::resource_changed_emit(Resource *p_source) {
-	print_lt(vformat("%d\t%ud:%s\t" FUNCTION_STR, Thread::get_caller_id(), p_source->get_instance_id(), p_source->get_class()));
+	print_lt(vformat("%d\t%ud:%s\t" FUNCTION_STR, Thread::get_caller_id(), p_source->get_instance_id(), p_source->get_class_name()));
 
 	MutexLock lock(thread_load_mutex);
 

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -2247,7 +2247,7 @@ Variant ClassDB::class_get_default_property_value(const StringName &p_class, con
 	if (var.get_type() == Variant::OBJECT) {
 		Object *obj = var.get_validated_object();
 		if (obj) {
-			WARN_PRINT(vformat("Instantiated %s used as default value for %s's \"%s\" property.", obj->get_class(), p_class, p_property));
+			WARN_PRINT(vformat("Instantiated %s used as default value for %s's \"%s\" property.", obj->get_class_name(), p_class, p_property));
 		}
 	}
 #endif

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -124,7 +124,7 @@ def generate_version(argcount, const=False, returns=False, required=False, compa
         method_flags += " | METHOD_FLAG_VIRTUAL_REQUIRED"
         s = s.replace(
             "$REQCHECK",
-            'ERR_PRINT_ONCE("Required virtual method " + get_class() + "::" + #m_name + " must be overridden before calling.");',
+            'ERR_PRINT_ONCE("Required virtual method " + get_class_name() + "::" + #m_name + " must be overridden before calling.");',
         )
     else:
         s = s.replace("\t\t$REQCHECK\\\n", "")

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -143,7 +143,7 @@ Error CallQueue::push_set(ObjectID p_id, const StringName &p_prop, const Variant
 		if (pages_used == max_pages) {
 			String type;
 			if (ObjectDB::get_instance(p_id)) {
-				type = ObjectDB::get_instance(p_id)->get_class();
+				type = ObjectDB::get_instance(p_id)->get_class_name();
 			}
 			fprintf(stderr, "Failed set: %s: %s target ID: %s. Message queue out of memory. %s\n", type.utf8().get_data(), String(p_prop).utf8().get_data(), itos(p_id).utf8().get_data(), error_text.utf8().get_data());
 			statistics();

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -960,7 +960,7 @@ String Object::to_string() {
 		_extension->to_string(_extension_instance, &is_valid, &ret);
 		return ret;
 	}
-	return "<" + get_class() + "#" + itos(get_instance_id()) + ">";
+	return "<" + get_class_name() + "#" + itos(get_instance_id()) + ">";
 }
 
 void Object::set_script_and_instance(const Variant &p_script, ScriptInstance *p_instance) {
@@ -1451,7 +1451,7 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 #endif
 		}
 
-		ERR_FAIL_COND_V_MSG(!signal_is_valid, ERR_INVALID_PARAMETER, vformat("In Object of type '%s': Attempt to connect nonexistent signal '%s' to callable '%s'.", String(get_class()), p_signal, p_callable));
+		ERR_FAIL_COND_V_MSG(!signal_is_valid, ERR_INVALID_PARAMETER, vformat("In Object of type '%s': Attempt to connect nonexistent signal '%s' to callable '%s'.", String(get_class_name()), p_signal, p_callable));
 
 		signal_map[p_signal] = SignalData();
 		s = &signal_map[p_signal];
@@ -1708,7 +1708,7 @@ void Object::notify_property_list_changed() {
 }
 
 void Object::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_class"), &Object::get_class);
+	ClassDB::bind_method(D_METHOD("get_class_name"), &Object::get_class_name);
 	ClassDB::bind_method(D_METHOD("is_class", "class"), &Object::is_class);
 	ClassDB::bind_method(D_METHOD("set", "property", "value"), &Object::_set_bind);
 	ClassDB::bind_method(D_METHOD("get", "property"), &Object::_get_bind);
@@ -1867,6 +1867,16 @@ void Object::_bind_methods() {
 	BIND_ENUM_CONSTANT(CONNECT_PERSIST);
 	BIND_ENUM_CONSTANT(CONNECT_ONE_SHOT);
 	BIND_ENUM_CONSTANT(CONNECT_REFERENCE_COUNTED);
+
+#ifndef DISABLE_DEPRECATED
+	GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations")
+	GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations")
+	GODOT_MSVC_WARNING_PUSH_AND_IGNORE(4996)
+	ClassDB::bind_method(D_METHOD("get_class"), &Object::get_class);
+	GODOT_MSVC_WARNING_POP
+	GODOT_CLANG_WARNING_POP
+	GODOT_GCC_WARNING_POP
+#endif
 }
 
 void Object::set_deferred(const StringName &p_property, const Variant &p_value) {
@@ -2435,7 +2445,7 @@ void ObjectDB::cleanup() {
 
 					uint64_t id = uint64_t(i) | (uint64_t(object_slots[i].validator) << OBJECTDB_SLOT_MAX_COUNT_BITS) | (object_slots[i].is_ref_counted ? OBJECTDB_REFERENCE_BIT : 0);
 					DEV_ASSERT(id == (uint64_t)obj->get_instance_id()); // We could just use the id from the object, but this check may help catching memory corruption catastrophes.
-					print_line("Leaked instance: " + String(obj->get_class()) + ":" + uitos(id) + extra_info);
+					print_line("Leaked instance: " + String(obj->get_class_name()) + ":" + uitos(id) + extra_info);
 
 					count--;
 				}

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -815,9 +815,11 @@ public:
 		return _class_name_static;
 	}
 
-	_FORCE_INLINE_ String get_class() const { return get_class_name(); }
+#ifndef DISABLE_DEPRECATED
+	[[deprecated]] _FORCE_INLINE_ String get_class() const { return get_class_name(); }
+#endif
 
-	virtual String get_save_class() const { return get_class(); } //class stored when saving
+	virtual String get_save_class() const { return get_class_name(); } //class stored when saving
 
 	virtual bool is_class(const String &p_class) const {
 		if (_extension && _extension->is_class(p_class)) {

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -181,7 +181,7 @@ void Script::reload_from_file() {
 #ifdef TOOLS_ENABLED
 	// Replicates how the ScriptEditor reloads script resources, which generally handles it.
 	// However, when scripts are to be reloaded but aren't open in the internal editor, we go through here instead.
-	const Ref<Script> rel = ResourceLoader::load(ResourceLoader::path_remap(get_path()), get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
+	const Ref<Script> rel = ResourceLoader::load(ResourceLoader::path_remap(get_path()), get_class_name(), ResourceFormatLoader::CACHE_MODE_IGNORE);
 	if (rel.is_null()) {
 		return;
 	}

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -359,7 +359,7 @@ Callable::operator String() const {
 
 		Object *base = get_object();
 		if (base) {
-			String class_name = base->get_class();
+			String class_name = base->get_class_name();
 			Ref<Script> script = base->get_script();
 			if (script.is_valid()) {
 				if (!script->get_global_name().is_empty()) {
@@ -519,7 +519,7 @@ bool Signal::operator<(const Signal &p_signal) const {
 Signal::operator String() const {
 	Object *base = get_object();
 	if (base) {
-		String class_name = base->get_class();
+		String class_name = base->get_class_name();
 		Ref<Script> script = base->get_script();
 		if (script.is_valid() && script->get_path().is_resource_file()) {
 			class_name += "(" + script->get_path().get_file() + ")";

--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -131,7 +131,7 @@ struct ContainerTypeValidate {
 
 		StringName obj_class = object->get_class_name();
 		if (obj_class != class_name) {
-			ERR_FAIL_COND_V_MSG(!ClassDB::is_parent_class(object->get_class_name(), class_name), false, vformat("Attempted to %s an object of type '%s' into a %s, which does not inherit from '%s'.", String(p_operation), object->get_class(), where, String(class_name)));
+			ERR_FAIL_COND_V_MSG(!ClassDB::is_parent_class(object->get_class_name(), class_name), false, vformat("Attempted to %s an object of type '%s' into a %s, which does not inherit from '%s'.", String(p_operation), object->get_class_name(), where, String(class_name)));
 		}
 
 		if (script.is_null()) {

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3516,7 +3516,7 @@ String Variant::get_call_error_text(Object *p_base, const StringName &p_method, 
 
 	String base_text;
 	if (p_base) {
-		base_text = p_base->get_class();
+		base_text = p_base->get_class_name();
 		Ref<Resource> script = p_base->get_script();
 		if (script.is_valid() && script->get_path().is_resource_file()) {
 			base_text += "(" + script->get_path().get_file() + ")";

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -2156,7 +2156,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 
 			//store as generic object
 
-			p_store_string_func(p_store_string_ud, "Object(" + obj->get_class() + ",");
+			p_store_string_func(p_store_string_ud, "Object(" + obj->get_class_name() + ",");
 
 			List<PropertyInfo> props;
 			obj->get_property_list(&props);

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -699,10 +699,17 @@
 				[b]Note:[/b] In C#, [param property] must be in snake_case when referring to built-in Godot properties. Prefer using the names exposed in the [code]PropertyName[/code] class to avoid allocating a new [StringName] on each call.
 			</description>
 		</method>
-		<method name="get_class" qualifiers="const">
+		<method name="get_class" qualifiers="const" deprecated="Use get_class_name instead.">
 			<return type="String" />
 			<description>
 				Returns the object's built-in class name, as a [String]. See also [method is_class].
+				[b]Note:[/b] This method ignores [code]class_name[/code] declarations. If this object's script has defined a [code]class_name[/code], the base, built-in class name is returned instead.
+			</description>
+		</method>
+		<method name="get_class_name" qualifiers="const">
+			<return type="StringName" />
+			<description>
+				Returns the object's built-in class name, as a [StringName]. See also [method is_class].
 				[b]Note:[/b] This method ignores [code]class_name[/code] declarations. If this object's script has defined a [code]class_name[/code], the base, built-in class name is returned instead.
 			</description>
 		</method>

--- a/doc/classes/Variant.xml
+++ b/doc/classes/Variant.xml
@@ -40,7 +40,7 @@
 		        print("foo is an integer")
 		    TYPE_OBJECT:
 		        # Note that Objects are their own special category.
-		        # To get the name of the underlying Object type, you need the `get_class()` method.
+		        # To get the name of the underlying Object type, you need the `get_class_name()` method.
 		        print("foo is a(n) %s" % foo.get_class()) # inject the class name into a formatted string.
 		        # Note that this does not get the script's `class_name` global identifier.
 		        # If the `class_name` is needed, use `foo.get_script().get_global_name()` instead.

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -583,7 +583,7 @@ void AnimationTrackKeyEdit::_get_property_list(List<PropertyInfo> *p_list) const
 					Ref<Resource> res = v;
 					if (res.is_valid()) {
 						val_hint = PROPERTY_HINT_RESOURCE_TYPE;
-						val_hint_string = res->get_class();
+						val_hint_string = res->get_class_name();
 					}
 				}
 
@@ -1193,7 +1193,7 @@ void AnimationMultiTrackKeyEdit::_get_property_list(List<PropertyInfo> *p_list) 
 							Ref<Resource> res = v;
 							if (res.is_valid()) {
 								val_hint = PROPERTY_HINT_RESOURCE_TYPE;
-								val_hint_string = res->get_class();
+								val_hint_string = res->get_class_name();
 							}
 						}
 
@@ -2922,7 +2922,7 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 						} else if (!stream->get_name().is_empty()) {
 							stream_name = stream->get_name();
 						} else {
-							stream_name = stream->get_class();
+							stream_name = stream->get_class_name();
 						}
 					}
 
@@ -3054,7 +3054,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 						if (nd) {
 							StringName prop = npath.get_concatenated_subnames();
 							PropertyInfo prop_info;
-							ClassDB::get_property_info(nd->get_class(), prop, &prop_info);
+							ClassDB::get_property_info(nd->get_class_name(), prop, &prop_info);
 #ifdef DISABLE_DEPRECATED
 							bool is_angle = prop_info.type == Variant::FLOAT && prop_info.hint_string.contains("radians_as_degrees");
 #else
@@ -6445,7 +6445,7 @@ bool AnimationTrackEditor::_is_track_compatible(int p_target_track_idx, Variant:
 							if (nd) {
 								StringName prop = npath.get_concatenated_subnames();
 								PropertyInfo prop_info;
-								path_valid = ClassDB::get_property_info(nd->get_class(), prop, &prop_info);
+								path_valid = ClassDB::get_property_info(nd->get_class_name(), prop, &prop_info);
 								property_type = prop_info.type;
 							}
 						}
@@ -6555,8 +6555,8 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 				String text;
 				Ref<Texture2D> icon = get_editor_theme_icon(SNAME("Node"));
 				if (node) {
-					if (has_theme_icon(node->get_class(), EditorStringName(EditorIcons))) {
-						icon = get_editor_theme_icon(node->get_class());
+					if (has_theme_icon(node->get_class_name(), EditorStringName(EditorIcons))) {
+						icon = get_editor_theme_icon(node->get_class_name());
 					}
 
 					text = node->get_name();

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -966,7 +966,7 @@ void ConnectionsDock::_make_or_edit_connection() {
 	bool add_script_function_request = false;
 	Ref<Script> scr = target->get_script();
 
-	if (scr.is_valid() && !ClassDB::has_method(target->get_class(), cd.method)) {
+	if (scr.is_valid() && !ClassDB::has_method(target->get_class_name(), cd.method)) {
 		// Check in target's own script.
 		int line = scr->get_language()->find_function(cd.method, scr->get_source_code());
 		if (line != -1) {
@@ -1448,7 +1448,7 @@ void ConnectionsDock::update_tree() {
 	TreeItem *root = tree->create_item();
 	DocTools *doc_data = EditorHelp::get_doc_data();
 	EditorData &editor_data = EditorNode::get_editor_data();
-	StringName native_base = selected_node->get_class();
+	StringName native_base = selected_node->get_class_name();
 	Ref<Script> script_base = selected_node->get_script();
 
 	while (native_base != StringName()) {

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -983,7 +983,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 				continue;
 			}
 			pd.name = s.name;
-			pd.type = s.ptr->get_class();
+			pd.type = s.ptr->get_class_name();
 			while (String(ClassDB::get_parent_class(pd.type)) != "Object") {
 				pd.type = ClassDB::get_parent_class(pd.type);
 			}

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -818,7 +818,7 @@ String EditorData::get_scene_type(int p_idx) const {
 	if (!edited_scene[p_idx].root) {
 		return "";
 	}
-	return edited_scene[p_idx].root->get_class();
+	return edited_scene[p_idx].root->get_class_name();
 }
 
 void EditorData::move_edited_scene_to_index(int p_idx) {

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -3292,7 +3292,7 @@ void EditorHelp::popup_search() {
 	find_bar->popup_search();
 }
 
-String EditorHelp::get_class() {
+String EditorHelp::get_class_name() {
 	return edited_class;
 }
 

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -257,7 +257,7 @@ public:
 	void popup_search();
 	void search_again(bool p_search_previous = false);
 
-	String get_class();
+	String get_class_name();
 
 	void set_focused() { class_desc->grab_focus(); }
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3264,7 +3264,7 @@ bool EditorInspector::_is_property_disabled_by_feature_profile(const StringName 
 		return false;
 	}
 
-	StringName class_name = object->get_class();
+	StringName class_name = object->get_class_name();
 
 	while (class_name != StringName()) {
 		if (profile->is_class_property_disabled(class_name, p_property)) {
@@ -3872,7 +3872,7 @@ void EditorInspector::update_tree() {
 
 			// Small hack for theme_overrides. They are listed under Control, but come from another class.
 			if (classname == "Control" && p.name.begins_with("theme_override_")) {
-				classname = get_edited_object()->get_class();
+				classname = get_edited_object()->get_class_name();
 			}
 
 			// Search for the doc path in the cache.
@@ -5164,7 +5164,7 @@ void EditorInspector::_show_add_meta_dialog() {
 	StringName dialog_title;
 	Node *node = Object::cast_to<Node>(object);
 	// If object is derived from Node use node name, if derived from Resource use classname.
-	dialog_title = node ? node->get_name() : StringName(object->get_class());
+	dialog_title = node ? node->get_name() : StringName(object->get_class_name());
 
 	List<StringName> existing_meta_keys;
 	object->get_meta_list(&existing_meta_keys);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1560,7 +1560,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 			file->set_current_file(p_resource->get_path().get_file());
 		} else {
 			if (!preferred.is_empty()) {
-				String resource_name_snake_case = p_resource->get_class().to_snake_case();
+				String resource_name_snake_case = String(p_resource->get_class_name()).to_snake_case();
 				file->set_current_file("new_" + resource_name_snake_case + "." + preferred.front()->get().to_lower());
 			} else {
 				file->set_current_file(String());
@@ -1575,7 +1575,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 			}
 		}
 	} else if (!preferred.is_empty()) {
-		const String resource_name_snake_case = p_resource->get_class().to_snake_case();
+		const String resource_name_snake_case = String(p_resource->get_class_name()).to_snake_case();
 		const String existing = "new_" + resource_name_snake_case + "." + preferred.front()->get().to_lower();
 		file->set_current_path(existing);
 	}
@@ -2424,7 +2424,7 @@ void EditorNode::edit_item(Object *p_object, Object *p_editing_owner) {
 	ERR_FAIL_NULL(p_editing_owner);
 
 	// Editing for this type of object may be disabled by user's feature profile.
-	if (!p_object || _is_class_editor_disabled_by_feature_profile(p_object->get_class())) {
+	if (!p_object || _is_class_editor_disabled_by_feature_profile(p_object->get_class_name())) {
 		// Nothing to edit, clean up the owner context and return.
 		hide_unused_editors(p_editing_owner);
 		return;
@@ -4454,7 +4454,7 @@ void EditorNode::update_node_from_node_modification_entry(Node *p_node, Modifica
 			Connection conn = E;
 
 			bool valid = p_node->has_method(conn.callable.get_method()) || Ref<Script>(p_node->get_script()).is_null() || Ref<Script>(p_node->get_script())->has_method(conn.callable.get_method());
-			ERR_CONTINUE_MSG(!valid, vformat("Attempt to connect signal '%s.%s' to nonexistent method '%s.%s'.", conn.signal.get_object()->get_class(), conn.signal.get_name(), conn.callable.get_object()->get_class(), conn.callable.get_method()));
+			ERR_CONTINUE_MSG(!valid, vformat("Attempt to connect signal '%s.%s' to nonexistent method '%s.%s'.", conn.signal.get_object()->get_class_name(), conn.signal.get_name(), conn.callable.get_object()->get_class_name(), conn.callable.get_method()));
 
 			// Get the object which the signal is connected from.
 			Object *source_object = conn.signal.get_object();
@@ -5088,7 +5088,7 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 	if (Object::cast_to<MultiNodeEdit>(p_object)) {
 		return get_class_icon(Object::cast_to<MultiNodeEdit>(p_object)->get_edited_class_name(), p_fallback);
 	} else {
-		return _get_class_or_script_icon(p_object->get_class(), scr.is_valid() ? scr->get_path() : String(), p_fallback);
+		return _get_class_or_script_icon(p_object->get_class_name(), scr.is_valid() ? scr->get_path() : String(), p_fallback);
 	}
 }
 
@@ -6024,7 +6024,7 @@ Dictionary EditorNode::drag_resource(const Ref<Resource> &p_res, Control *p_from
 	} else if (!p_res->get_name().is_empty()) {
 		label->set_text(p_res->get_name());
 	} else {
-		label->set_text(p_res->get_class());
+		label->set_text(p_res->get_class_name());
 	}
 
 	drag_control->add_child(label);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3167,7 +3167,7 @@ void EditorPropertyResource::_resource_changed(const Ref<Resource> &p_resource) 
 	if (get_edited_object() && s.is_valid() && get_edited_property() == CoreStringName(script)) {
 		is_script = true;
 		InspectorDock::get_singleton()->store_script_properties(get_edited_object());
-		s->call("set_instance_base_type", get_edited_object()->get_class());
+		s->call("set_instance_base_type", get_edited_object()->get_class_name());
 	}
 
 	// Prevent the creation of invalid ViewportTextures when possible.

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -606,7 +606,7 @@ bool EditorPropertyArray::_is_drop_valid(const Dictionary &p_drag_data) const {
 			return false;
 		}
 
-		String res_type = res->get_class();
+		String res_type = res->get_class_name();
 		StringName script_class;
 		if (res->get_script()) {
 			script_class = EditorNode::get_singleton()->get_object_custom_type_name(res->get_script());

--- a/editor/editor_properties_vector.cpp
+++ b/editor/editor_properties_vector.cpp
@@ -115,7 +115,7 @@ void EditorPropertyVectorN::_store_link(bool p_linked) {
 	if (!get_edited_object()) {
 		return;
 	}
-	const String key = vformat("%s:%s", get_edited_object()->get_class(), get_edited_property());
+	const String key = vformat("%s:%s", get_edited_object()->get_class_name(), get_edited_property());
 	EditorSettings::get_singleton()->set_project_metadata("linked_properties", key, p_linked);
 }
 
@@ -131,7 +131,7 @@ void EditorPropertyVectorN::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			if (linked->is_visible()) {
 				if (get_edited_object()) {
-					const String key = vformat("%s:%s", get_edited_object()->get_class(), get_edited_property());
+					const String key = vformat("%s:%s", get_edited_object()->get_class_name(), get_edited_property());
 					linked->set_pressed_no_signal(EditorSettings::get_singleton()->get_project_metadata("linked_properties", key, true));
 					_update_ratio();
 				}

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -84,7 +84,7 @@ void EditorResourcePicker::_update_resource() {
 			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(edited_resource, this, "_update_resource_preview", edited_resource->get_instance_id());
 		}
 	} else if (edited_resource.is_valid()) {
-		assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + edited_resource->get_class());
+		assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + edited_resource->get_class_name());
 	}
 
 	assign_button->set_disabled(!editable && edited_resource.is_null());
@@ -144,7 +144,7 @@ void EditorResourcePicker::_file_selected(const String &p_path) {
 	if (!base_type.is_empty()) {
 		bool any_type_matches = false;
 
-		String res_type = loaded_resource->get_class();
+		String res_type = loaded_resource->get_class_name();
 		Ref<Script> res_script = loaded_resource->get_script();
 		bool is_global_class = false;
 		if (res_script.is_valid()) {
@@ -580,7 +580,7 @@ String EditorResourcePicker::_get_resource_type(const Ref<Resource> &p_resource)
 	if (p_resource.is_null()) {
 		return String();
 	}
-	String res_type = p_resource->get_class();
+	String res_type = p_resource->get_class_name();
 
 	Ref<Script> res_script = p_resource->get_script();
 	if (res_script.is_null()) {
@@ -911,8 +911,8 @@ void EditorResourcePicker::set_base_type(const String &p_base_type) {
 			is_custom = _is_type_valid(custom_class, allowed_types);
 		}
 
-		if (!is_custom && !_is_type_valid(edited_resource->get_class(), allowed_types)) {
-			String class_str = (custom_class == StringName() ? edited_resource->get_class() : vformat("%s (%s)", custom_class, edited_resource->get_class()));
+		if (!is_custom && !_is_type_valid(edited_resource->get_class_name(), allowed_types)) {
+			String class_str = (custom_class == StringName() ? String(edited_resource->get_class_name()) : vformat("%s (%s)", custom_class, edited_resource->get_class_name()));
 			WARN_PRINT(vformat("Value mismatch between the new base type of this EditorResourcePicker, '%s', and the type of the value it already has, '%s'.", base_type, class_str));
 		}
 	}
@@ -957,8 +957,8 @@ void EditorResourcePicker::set_edited_resource(Ref<Resource> p_resource) {
 			is_custom = _is_type_valid(custom_class, allowed_types);
 		}
 
-		if (!is_custom && !_is_type_valid(p_resource->get_class(), allowed_types)) {
-			String class_str = (custom_class == StringName() ? p_resource->get_class() : vformat("%s (%s)", custom_class, p_resource->get_class()));
+		if (!is_custom && !_is_type_valid(p_resource->get_class_name(), allowed_types)) {
+			String class_str = (custom_class == StringName() ? String(p_resource->get_class_name()) : vformat("%s (%s)", custom_class, p_resource->get_class_name()));
 			ERR_FAIL_MSG(vformat("Failed to set a resource of the type '%s' because this EditorResourcePicker only accepts '%s' and its derivatives.", class_str, base_type));
 		}
 	}
@@ -1028,9 +1028,9 @@ void EditorResourcePicker::_gather_resources_to_duplicate(const Ref<Resource> p_
 	}
 
 	if (res_name.is_empty()) {
-		p_item->set_text(0, p_resource->get_class());
+		p_item->set_text(0, p_resource->get_class_name());
 	} else {
-		p_item->set_text(0, vformat("%s (%s)", p_resource->get_class(), res_name));
+		p_item->set_text(0, vformat("%s (%s)", p_resource->get_class_name(), res_name));
 	}
 
 	p_item->set_icon(0, EditorNode::get_singleton()->get_object_icon(p_resource.ptr()));
@@ -1044,7 +1044,7 @@ void EditorResourcePicker::_gather_resources_to_duplicate(const Ref<Resource> p_
 	}
 
 	static Vector<String> unique_exceptions = { "Image", "Shader", "Mesh", "FontFile" };
-	if (!unique_exceptions.has(p_resource->get_class())) {
+	if (!unique_exceptions.has(p_resource->get_class_name())) {
 		// Automatically select resource, unless it's something that shouldn't be duplicated.
 		p_item->set_checked(0, true);
 	}
@@ -1380,7 +1380,7 @@ void EditorAudioStreamPicker::_preview_draw() {
 	} else if (audio_stream->get_path().is_resource_file()) {
 		text = audio_stream->get_path().get_file();
 	} else {
-		text = audio_stream->get_class().replace_first("AudioStream", "");
+		text = String(audio_stream->get_class_name()).replace_first("AudioStream", "");
 	}
 
 	stream_preview_rect->draw_texture(icon, Point2i(EDSCALE * 4, rect.position.y + (rect.size.height - icon->get_height()) / 2), icon_modulate);

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -169,7 +169,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 	uint64_t started_at = OS::get_singleton()->get_ticks_usec();
 
 	if (p_item.resource.is_valid()) {
-		type = p_item.resource->get_class();
+		type = p_item.resource->get_class_name();
 	} else {
 		type = ResourceLoader::get_resource_type(p_item.path);
 	}

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -191,7 +191,7 @@ void SectionedInspector::edit(Object *p_object) {
 
 	ObjectID id = p_object->get_instance_id();
 
-	inspector->set_object_class(p_object->get_class());
+	inspector->set_object_class(p_object->get_class_name());
 
 	if (obj != id) {
 		obj = id;

--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -145,7 +145,7 @@ void EditorObjectSelector::update_path() {
 				}
 
 				if (name.is_empty()) {
-					name = r->get_class();
+					name = r->get_class_name();
 				}
 			} else if (obj->is_class("EditorDebuggerRemoteObjects")) {
 				name = obj->call("get_title");
@@ -154,11 +154,11 @@ void EditorObjectSelector::update_path() {
 			} else if (Object::cast_to<Resource>(obj) && !Object::cast_to<Resource>(obj)->get_name().is_empty()) {
 				name = Object::cast_to<Resource>(obj)->get_name();
 			} else {
-				name = obj->get_class();
+				name = obj->get_class_name();
 			}
 
 			current_object_label->set_text(name);
-			set_tooltip_text(obj->get_class());
+			set_tooltip_text(obj->get_class_name());
 		}
 	}
 }

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -678,7 +678,7 @@ void SceneTreeEditor::_update_node_tooltip(Node *p_node, TreeItem *p_item) {
 	}
 
 	StringName custom_type = EditorNode::get_singleton()->get_object_custom_type_name(p_node);
-	tooltip += "\n" + TTR("Type:") + " " + (custom_type != StringName() ? String(custom_type) : p_node->get_class());
+	tooltip += "\n" + TTR("Type:") + " " + (custom_type != StringName() ? custom_type : p_node->get_class_name());
 
 	if (!p_node->get_editor_description().is_empty()) {
 		const PackedInt32Array boundaries = TS->string_get_word_breaks(p_node->get_editor_description(), "", 80);
@@ -1122,7 +1122,7 @@ bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, const PackedStri
 
 			if (parameter == "type" || parameter == "t") {
 				// Filter by Type.
-				String type = get_node(p_item->get_metadata(0))->get_class();
+				String type = get_node(p_item->get_metadata(0))->get_class_name();
 				bool term_in_inherited_class = false;
 				// Every Node is a Node, duh!
 				while (type != "Node") {
@@ -1517,9 +1517,9 @@ void SceneTreeEditor::rename_node(Node *p_node, const String &p_name, TreeItem *
 	if (new_name.is_empty()) {
 		// If name is still empty, fallback to class name.
 		if (GLOBAL_GET("editor/naming/node_name_casing").operator int() != NAME_CASING_PASCAL_CASE) {
-			new_name = Node::adjust_name_casing(p_node->get_class());
+			new_name = Node::adjust_name_casing(p_node->get_class_name());
 		} else {
-			new_name = p_node->get_class();
+			new_name = p_node->get_class_name();
 		}
 	}
 

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -383,7 +383,7 @@ void SceneImportSettingsDialog::_fill_scene(Node *p_node, TreeItem *p_parent_ite
 		p_node = mesh_node;
 	}
 
-	String type = p_node->get_class();
+	String type = p_node->get_class_name();
 
 	if (!has_theme_icon(type, EditorStringName(EditorIcons))) {
 		type = "Node3D";

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -101,7 +101,7 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case OBJECT_REQUEST_HELP: {
 			if (current) {
 				EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
-				emit_signal(SNAME("request_help"), current->get_class());
+				emit_signal(SNAME("request_help"), current->get_class_name());
 			}
 		} break;
 
@@ -349,14 +349,14 @@ void InspectorDock::_prepare_history() {
 			} else if (!r->get_name().is_empty()) {
 				text = r->get_name();
 			} else {
-				text = r->get_class();
+				text = r->get_class_name();
 			}
 		} else if (Object::cast_to<Node>(obj)) {
 			text = Object::cast_to<Node>(obj)->get_name();
 		} else if (obj->is_class("EditorDebuggerRemoteObjects")) {
 			text = obj->call("get_title");
 		} else {
-			text = obj->get_class();
+			text = obj->get_class_name();
 		}
 
 		if (i == editor_history->get_history_pos() && current) {

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -325,11 +325,11 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 	} else if (p_idx == MENU_LOAD_FILE_CONFIRM) {
 		anode = file_loaded;
 		file_loaded.unref();
-		base_name = anode->get_class();
+		base_name = anode->get_class_name();
 	} else if (p_idx == MENU_PASTE) {
 		anode = EditorSettings::get_singleton()->get_resource_clipboard();
 		ERR_FAIL_COND(anode.is_null());
-		base_name = anode->get_class();
+		base_name = anode->get_class_name();
 	} else if (!add_options[p_idx].type.is_empty()) {
 		AnimationNode *an = Object::cast_to<AnimationNode>(ClassDB::instantiate(add_options[p_idx].type));
 		ERR_FAIL_NULL(an);

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -752,7 +752,7 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 	}
 
 	if (base_name.is_empty()) {
-		base_name = node->get_class().replace_first("AnimationNode", "");
+		base_name = String(node->get_class_name()).replace_first("AnimationNode", "");
 	}
 
 	int base = 1;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2456,7 +2456,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 					selection_menu->set_item_icon(i, icon);
 					selection_menu->set_item_icon_max_width(i, icon_max_width);
 					selection_menu->set_item_metadata(i, node_path);
-					selection_menu->set_item_tooltip(i, String(item->get_name()) + "\nType: " + item->get_class() + "\nPath: " + node_path);
+					selection_menu->set_item_tooltip(i, String(item->get_name()) + "\nType: " + item->get_class_name() + "\nPath: " + node_path);
 				}
 
 				selection_results_menu = selection_results;
@@ -5960,7 +5960,7 @@ void CanvasItemEditorViewport::_create_texture_node(Node *p_parent, Node *p_chil
 	if (p_parent) {
 		String new_name = p_parent->validate_child_name(p_child);
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-		undo_redo->add_do_method(ed, "live_debug_create_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent), p_child->get_class(), new_name);
+		undo_redo->add_do_method(ed, "live_debug_create_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent), p_child->get_class_name(), new_name);
 		undo_redo->add_undo_method(ed, "live_debug_remove_node", NodePath(String(EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent)) + "/" + new_name));
 	}
 
@@ -6030,7 +6030,7 @@ void CanvasItemEditorViewport::_create_audio_node(Node *p_parent, const String &
 	if (p_parent) {
 		String new_name = p_parent->validate_child_name(child);
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-		undo_redo->add_do_method(ed, "live_debug_create_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent), child->get_class(), new_name);
+		undo_redo->add_do_method(ed, "live_debug_create_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent), child->get_class_name(), new_name);
 		undo_redo->add_undo_method(ed, "live_debug_remove_node", NodePath(String(EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent)) + "/" + new_name));
 	}
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1658,7 +1658,7 @@ void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 			selection_menu->add_item((String)spat->get_name() + suffix);
 			selection_menu->set_item_icon(i, icon);
 			selection_menu->set_item_metadata(i, node_path);
-			selection_menu->set_item_tooltip(i, String(spat->get_name()) + "\nType: " + spat->get_class() + "\nPath: " + node_path);
+			selection_menu->set_item_tooltip(i, String(spat->get_name()) + "\nType: " + spat->get_class_name() + "\nPath: " + node_path);
 		}
 
 		selection_results_menu = selection_results;
@@ -4830,7 +4830,7 @@ bool Node3DEditorViewport::_create_audio_node(Node *p_parent, const String &p_pa
 
 	const String new_name = p_parent->validate_child_name(audio_player);
 	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-	undo_redo->add_do_method(ed, "live_debug_create_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent), audio_player->get_class(), new_name);
+	undo_redo->add_do_method(ed, "live_debug_create_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent), audio_player->get_class_name(), new_name);
 	undo_redo->add_undo_method(ed, "live_debug_remove_node", NodePath(String(EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent)) + "/" + new_name));
 
 	Transform3D parent_tf;

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -155,7 +155,7 @@ void ResourcePreloaderEditor::_paste_pressed() {
 		name = r->get_path().get_file();
 	}
 	if (name.is_empty()) {
-		name = r->get_class();
+		name = r->get_class_name();
 	}
 
 	String basename = name;
@@ -201,7 +201,7 @@ void ResourcePreloaderEditor::_update_library() {
 
 		ERR_CONTINUE(r.is_null());
 
-		String type = r->get_class();
+		String type = r->get_class_name();
 		ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(type, "Object"));
 		ti->set_tooltip_text(0, TTR("Instance:") + " " + r->get_path() + "\n" + TTR("Type:") + " " + type);
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -774,7 +774,7 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 		Object::cast_to<ScriptEditorBase>(c)->validate();
 	}
 	if (Object::cast_to<EditorHelp>(c)) {
-		script_name_label->set_text(Object::cast_to<EditorHelp>(c)->get_class());
+		script_name_label->set_text(Object::cast_to<EditorHelp>(c)->get_class_name());
 		script_icon->set_texture(get_editor_theme_icon(SNAME("Help")));
 		if (is_visible_in_tree()) {
 			Object::cast_to<EditorHelp>(c)->set_focused();
@@ -1417,11 +1417,11 @@ void ScriptEditor::_menu_option(int p_option) {
 			EditorHelp *eh = Object::cast_to<EditorHelp>(tab);
 			bool native_class_doc = false;
 			if (eh) {
-				const HashMap<String, DocData::ClassDoc>::ConstIterator E = EditorHelp::get_doc_data()->class_list.find(eh->get_class());
+				const HashMap<String, DocData::ClassDoc>::ConstIterator E = EditorHelp::get_doc_data()->class_list.find(eh->get_class_name());
 				native_class_doc = E && !E->value.is_script_doc;
 			}
 			if (native_class_doc) {
-				String name = eh->get_class().to_lower();
+				String name = eh->get_class_name().to_lower();
 				String doc_url = vformat(GODOT_VERSION_DOCS_URL "/classes/class_%s.html", name);
 				OS::get_singleton()->shell_open(doc_url);
 			} else {
@@ -1550,7 +1550,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				if (!scr->is_tool()) {
 					is_runnable = false;
 
-					if (scr->get_class() == "GDScript") {
+					if (scr->get_class_name() == "GDScript") {
 						EditorToaster::get_singleton()->popup_str(TTR("Cannot run the script because it's not a tool script (add the @tool annotation at the top)."), EditorToaster::SEVERITY_WARNING);
 					} else {
 						EditorToaster::get_singleton()->popup_str(TTR("Cannot run the script because it's not a tool script."), EditorToaster::SEVERITY_WARNING);
@@ -2165,11 +2165,11 @@ void ScriptEditor::_update_online_doc() {
 	EditorHelp *eh = Object::cast_to<EditorHelp>(current);
 	bool native_class_doc = false;
 	if (eh) {
-		const HashMap<String, DocData::ClassDoc>::ConstIterator E = EditorHelp::get_doc_data()->class_list.find(eh->get_class());
+		const HashMap<String, DocData::ClassDoc>::ConstIterator E = EditorHelp::get_doc_data()->class_list.find(eh->get_class_name());
 		native_class_doc = E && !E->value.is_script_doc;
 	}
 	if (native_class_doc) {
-		String name = eh->get_class();
+		String name = eh->get_class_name();
 		String tooltip = vformat(TTR("Open '%s' in Godot online documentation."), name);
 		site_search->set_text(TTR("Open in Online Docs"));
 		site_search->set_tooltip_text(tooltip);
@@ -2286,8 +2286,8 @@ void ScriptEditor::_update_script_names() {
 		}
 
 		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_tab_control(i));
-		if (eh && !eh->get_class().is_empty()) {
-			String name = eh->get_class().unquote();
+		if (eh && !eh->get_class_name().is_empty()) {
+			String name = eh->get_class_name().unquote();
 			Ref<Texture2D> icon = get_editor_theme_icon(SNAME("Help"));
 			String tooltip = vformat(TTR("%s Class Reference"), name);
 
@@ -2857,7 +2857,7 @@ void ScriptEditor::_reload_scripts(bool p_refresh_only) {
 
 			Ref<Script> scr = edited_res;
 			if (scr.is_valid()) {
-				Ref<Script> rel_scr = ResourceLoader::load(scr->get_path(), scr->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
+				Ref<Script> rel_scr = ResourceLoader::load(scr->get_path(), scr->get_class_name(), ResourceFormatLoader::CACHE_MODE_IGNORE);
 				ERR_CONTINUE(rel_scr.is_null());
 				scr->set_source_code(rel_scr->get_source_code());
 				scr->reload(true);
@@ -2867,7 +2867,7 @@ void ScriptEditor::_reload_scripts(bool p_refresh_only) {
 
 			Ref<JSON> json = edited_res;
 			if (json.is_valid()) {
-				Ref<JSON> rel_json = ResourceLoader::load(json->get_path(), json->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
+				Ref<JSON> rel_json = ResourceLoader::load(json->get_path(), json->get_class_name(), ResourceFormatLoader::CACHE_MODE_IGNORE);
 				ERR_CONTINUE(rel_json.is_null());
 				json->parse(rel_json->get_parsed_text(), true);
 			}
@@ -3163,7 +3163,7 @@ Variant ScriptEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 	}
 	EditorHelp *eh = Object::cast_to<EditorHelp>(cur_node);
 	if (eh) {
-		preview_name = eh->get_class();
+		preview_name = eh->get_class_name();
 		preview_icon = get_editor_theme_icon(SNAME("Help"));
 	}
 
@@ -3648,7 +3648,7 @@ void ScriptEditor::get_window_layout(Ref<ConfigFile> p_layout) {
 		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_tab_control(i));
 
 		if (eh) {
-			helps.push_back(eh->get_class());
+			helps.push_back(eh->get_class_name());
 		}
 	}
 
@@ -3671,7 +3671,7 @@ void ScriptEditor::_help_class_open(const String &p_class) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_tab_control(i));
 
-		if (eh && eh->get_class() == p_class) {
+		if (eh && eh->get_class_name() == p_class) {
 			_go_to_tab(i);
 			_update_script_names();
 			return;
@@ -3706,7 +3706,7 @@ void ScriptEditor::_help_class_goto(const String &p_desc) {
 	_go_to_tab(tab_container->get_tab_count() - 1);
 	eh->go_to_help(p_desc);
 	eh->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
-	_add_recent_script(eh->get_class());
+	_add_recent_script(eh->get_class_name());
 	_sort_list_on_update = true;
 	_update_script_names();
 	_save_layout();
@@ -3716,7 +3716,7 @@ bool ScriptEditor::_help_tab_goto(const String &p_name, const String &p_desc) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_tab_control(i));
 
-		if (eh && eh->get_class() == p_name) {
+		if (eh && eh->get_class_name() == p_name) {
 			_go_to_tab(i);
 			eh->go_to_help(p_desc);
 			_update_script_names();
@@ -3731,7 +3731,7 @@ void ScriptEditor::update_doc(const String &p_name) {
 
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_tab_control(i));
-		if (eh && eh->get_class() == p_name) {
+		if (eh && eh->get_class_name() == p_name) {
 			eh->update_doc();
 			return;
 		}

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -515,15 +515,15 @@ String ScriptTextEditor::get_name() {
 
 Ref<Texture2D> ScriptTextEditor::get_theme_icon() {
 	if (get_parent_control()) {
-		String icon_name = script->get_class();
+		String icon_name = script->get_class_name();
 		if (script->is_built_in()) {
 			icon_name += "Internal";
 		}
 
 		if (get_parent_control()->has_theme_icon(icon_name, EditorStringName(EditorIcons))) {
 			return get_parent_control()->get_editor_theme_icon(icon_name);
-		} else if (get_parent_control()->has_theme_icon(script->get_class(), EditorStringName(EditorIcons))) {
-			return get_parent_control()->get_editor_theme_icon(script->get_class());
+		} else if (get_parent_control()->has_theme_icon(script->get_class_name(), EditorStringName(EditorIcons))) {
+			return get_parent_control()->get_editor_theme_icon(script->get_class_name());
 		}
 	}
 
@@ -873,7 +873,7 @@ void ScriptEditor::_update_modified_scripts_for_external_editor(Ref<Script> p_fo
 		uint64_t date = FileAccess::get_modified_time(scr->get_path());
 
 		if (last_date != date) {
-			Ref<Script> rel_scr = ResourceLoader::load(scr->get_path(), scr->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
+			Ref<Script> rel_scr = ResourceLoader::load(scr->get_path(), scr->get_class_name(), ResourceFormatLoader::CACHE_MODE_IGNORE);
 			ERR_CONTINUE(rel_scr.is_null());
 			scr->set_source_code(rel_scr->get_source_code());
 			scr->set_last_modified_time(rel_scr->get_last_modified_time());
@@ -1935,7 +1935,7 @@ static String _get_dropped_resource_line(const Ref<Resource> &p_resource, bool p
 			path = ResourceUID::get_singleton()->id_to_text(id);
 		}
 	}
-	const bool is_script = ClassDB::is_parent_class(p_resource->get_class(), "Script");
+	const bool is_script = ClassDB::is_parent_class(p_resource->get_class_name(), "Script");
 
 	if (!p_create_field) {
 		return vformat("preload(%s)", _quote_drop_data(path));

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -89,7 +89,7 @@ void ShaderEditorPlugin::_update_shader_list() {
 			text += "(*)";
 		}
 
-		String _class = shader->get_class();
+		String _class = shader->get_class_name();
 		if (!shader_list->has_theme_icon(_class, EditorStringName(EditorIcons))) {
 			_class = "TextFile";
 		}

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -869,7 +869,7 @@ void TextShaderEditor::_check_for_external_edit() {
 }
 
 void TextShaderEditor::_reload_shader_from_disk() {
-	Ref<Shader> rel_shader = ResourceLoader::load(shader->get_path(), shader->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
+	Ref<Shader> rel_shader = ResourceLoader::load(shader->get_path(), shader->get_class_name(), ResourceFormatLoader::CACHE_MODE_IGNORE);
 	ERR_FAIL_COND(rel_shader.is_null());
 
 	code_editor->set_block_shader_changed(true);
@@ -880,7 +880,7 @@ void TextShaderEditor::_reload_shader_from_disk() {
 }
 
 void TextShaderEditor::_reload_shader_include_from_disk() {
-	Ref<ShaderInclude> rel_shader_include = ResourceLoader::load(shader_inc->get_path(), shader_inc->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
+	Ref<ShaderInclude> rel_shader_include = ResourceLoader::load(shader_inc->get_path(), shader_inc->get_class_name(), ResourceFormatLoader::CACHE_MODE_IGNORE);
 	ERR_FAIL_COND(rel_shader_include.is_null());
 
 	code_editor->set_block_shader_changed(true);

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -164,7 +164,7 @@ void TexturePreview::_update_metadata_label_text() {
 
 	const Image::Format format = get_texture_2d_format(texture.ptr());
 
-	const String format_name = format != Image::FORMAT_MAX ? Image::get_format_name(format) : texture->get_class();
+	const String format_name = format != Image::FORMAT_MAX ? Image::get_format_name(format) : String(texture->get_class_name());
 
 	const Vector2i resolution = texture->get_size();
 	const int mipmaps = get_texture_mipmaps_count(texture);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3308,7 +3308,7 @@ void ThemeTypeEditor::_update_stylebox_from_leading() {
 			continue;
 		}
 
-		if (sb->get_class() == leading_stylebox.stylebox->get_class()) {
+		if (sb->get_class_name() == leading_stylebox.stylebox->get_class_name()) {
 			styleboxes.push_back(sb);
 		}
 	}

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -349,7 +349,7 @@ void PropertySelector::_item_selected() {
 	} else if (!base_type.is_empty()) {
 		class_type = base_type;
 	} else if (instance) {
-		class_type = instance->get_class();
+		class_type = instance->get_class_name();
 	}
 
 	String text;
@@ -562,7 +562,7 @@ void PropertySelector::select_method_from_basic_type(Variant::Type p_type, const
 }
 
 void PropertySelector::select_method_from_instance(Object *p_instance, const String &p_current) {
-	base_type = p_instance->get_class();
+	base_type = p_instance->get_class_name();
 	selected = p_current;
 	type = Variant::NIL;
 	script = ObjectID();

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -446,7 +446,7 @@ String RenameDialog::_substitute(const String &subject, const Node *node, int co
 
 	if (node) {
 		result = result.replace("${NAME}", node->get_name());
-		result = result.replace("${TYPE}", node->get_class());
+		result = result.replace("${TYPE}", node->get_class_name());
 	}
 
 	int current = EditorNode::get_editor_data().get_edited_scene();

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -426,7 +426,7 @@ void SceneTreeDock::_perform_create_audio_stream_players(const Vector<String> &p
 
 		String new_name = p_parent->validate_child_name(node);
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-		undo_redo->add_do_method(ed, "live_debug_create_node", edited_scene->get_path_to(p_parent), node->get_class(), new_name);
+		undo_redo->add_do_method(ed, "live_debug_create_node", edited_scene->get_path_to(p_parent), node->get_class_name(), new_name);
 		undo_redo->add_undo_method(ed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(p_parent)).path_join(new_name)));
 	}
 
@@ -744,7 +744,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			if (selected) {
-				create_dialog->popup_create(false, true, selected->get_class(), selected->get_name());
+				create_dialog->popup_create(false, true, selected->get_class_name(), selected->get_name());
 			}
 		} break;
 		case TOOL_EXTEND_SCRIPT: {
@@ -1233,7 +1233,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 					class_name = script_base->get_global_name();
 				}
 				if (class_name.is_empty()) {
-					class_name = node->get_class();
+					class_name = node->get_class_name();
 				}
 
 				ScriptEditor::get_singleton()->goto_help("class_name:" + class_name);
@@ -2923,7 +2923,7 @@ Node *SceneTreeDock::_do_create(Node *p_parent) {
 		undo_redo->add_undo_method(p_parent, "remove_child", child);
 
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-		undo_redo->add_do_method(ed, "live_debug_create_node", edited_scene->get_path_to(p_parent), child->get_class(), new_name);
+		undo_redo->add_do_method(ed, "live_debug_create_node", edited_scene->get_path_to(p_parent), child->get_class_name(), new_name);
 		undo_redo->add_undo_method(ed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(p_parent)).path_join(new_name)));
 
 	} else {
@@ -3153,7 +3153,7 @@ void SceneTreeDock::_replace_node(Node *p_node, Node *p_by_node, bool p_keep_pro
 		}
 
 		if (!default_oldnode) {
-			default_oldnode = Object::cast_to<Node>(ClassDB::instantiate(oldnode->get_class()));
+			default_oldnode = Object::cast_to<Node>(ClassDB::instantiate(oldnode->get_class_name()));
 		}
 
 		List<PropertyInfo> pinfo;
@@ -3288,7 +3288,7 @@ bool SceneTreeDock::_check_node_recursive(Variant &r_variant, Node *p_node, Node
 					r_variant = p_by_node;
 				} else {
 					r_variant = memnew(Object);
-					r_warn_message = vformat("The node's new type is incompatible with an exported variable (expected %s, but type is %s).", type_hint, p_by_node->get_class());
+					r_warn_message = vformat("The node's new type is incompatible with an exported variable (expected %s, but type is %s).", type_hint, p_by_node->get_class_name());
 				}
 				return true;
 			}
@@ -3635,7 +3635,7 @@ void SceneTreeDock::_script_dropped(const String &p_file, NodePath p_to) {
 		undo_redo->add_undo_method(n, "remove_child", new_node);
 
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-		undo_redo->add_do_method(ed, "live_debug_create_node", edited_scene->get_path_to(n), new_node->get_class(), new_node->get_name());
+		undo_redo->add_do_method(ed, "live_debug_create_node", edited_scene->get_path_to(n), new_node->get_class_name(), new_node->get_name());
 		undo_redo->add_undo_method(ed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(n)).path_join(new_node->get_name())));
 		undo_redo->commit_action();
 	} else {
@@ -4116,12 +4116,12 @@ void SceneTreeDock::attach_script_to_selected(bool p_extend) {
 		}
 	}
 
-	String inherits = selected->get_class();
+	String inherits = selected->get_class_name();
 
 	if (p_extend && existing.is_valid()) {
 		for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 			ScriptLanguage *l = ScriptServer::get_language(i);
-			if (l->get_type() == existing->get_class()) {
+			if (l->get_type() == existing->get_class_name()) {
 				String name = l->get_global_class_name(existing->get_path());
 				if (ScriptServer::is_global_class(name) && EDITOR_GET("interface/editors/derive_script_globals_by_name").operator bool()) {
 					inherits = name;
@@ -4528,7 +4528,7 @@ void SceneTreeDock::_list_all_subresources(PopupMenu *p_menu) {
 
 	for (const Pair<Ref<Resource>, Node *> &pair : all_resources) {
 		if (!unique_resources.has(pair.first)) {
-			resources_by_type[pair.first->get_class()].push_back(pair);
+			resources_by_type[pair.first->get_class_name()].push_back(pair);
 		}
 		unique_resources[pair.first]++;
 	}

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -415,9 +415,9 @@ ScriptInstance *GDScript::instance_create(Object *p_this) {
 	if (top->native.is_valid()) {
 		if (!ClassDB::is_parent_class(p_this->get_class_name(), top->native->get_name())) {
 			if (EngineDebugger::is_active()) {
-				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), 1, "Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be assigned to an object of type: '" + p_this->get_class() + "'");
+				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), 1, "Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be assigned to an object of type: '" + p_this->get_class_name() + "'");
 			}
-			ERR_FAIL_V_MSG(nullptr, "Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be assigned to an object of type '" + p_this->get_class() + "'" + ".");
+			ERR_FAIL_V_MSG(nullptr, "Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be assigned to an object of type '" + p_this->get_class_name() + "'" + ".");
 		}
 	}
 

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -56,7 +56,7 @@ static String _get_variant_string(const Variant &p_variant) {
 				if (script) {
 					txt = "script(" + GDScript::debug_get_script_name(script) + ")";
 				} else {
-					txt = "object(" + obj->get_class();
+					txt = "object(" + obj->get_class_name();
 					if (obj->get_script_instance()) {
 						txt += ", " + GDScript::debug_get_script_name(obj->get_script_instance()->get_script());
 					}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -4253,7 +4253,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 								r_result.class_name = Object::cast_to<GDScriptNativeClass>(obj)->get_name();
 							} else {
 								r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
-								r_result.class_name = obj->get_class();
+								r_result.class_name = obj->get_class_name();
 							}
 							return OK;
 						}

--- a/modules/gdscript/gdscript_rpc_callable.cpp
+++ b/modules/gdscript/gdscript_rpc_callable.cpp
@@ -47,7 +47,7 @@ uint32_t GDScriptRPCCallable::hash() const {
 }
 
 String GDScriptRPCCallable::get_as_text() const {
-	String class_name = object->get_class();
+	String class_name = object->get_class_name();
 	Ref<Script> script = object->get_script();
 	if (script.is_valid()) {
 		if (!script->get_global_name().is_empty()) {

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -73,7 +73,7 @@ static String _get_var_type(const Variant *p_var) {
 			if (bobj->is_class_ptr(GDScriptNativeClass::get_class_ptr_static())) {
 				basestr = Object::cast_to<GDScriptNativeClass>(bobj)->get_name();
 			} else {
-				basestr = bobj->get_class();
+				basestr = bobj->get_class_name();
 				if (bobj->get_script_instance()) {
 					basestr += " (" + GDScript::debug_get_script_name(bobj->get_script_instance()->get_script()) + ")";
 				}

--- a/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_warnings.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_warnings.gd
@@ -148,7 +148,7 @@ func test_unsafe_void_return() -> void:
 	return variant_func().f()
 
 @warning_ignore("native_method_override")
-func get_class():
+func get_class_name():
 	pass
 
 # We don't want to execute it because of errors, just analyze.

--- a/modules/gdscript/tests/scripts/runtime/features/export_group_no_name_conflict_with_properties.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/export_group_no_name_conflict_with_properties.gd
@@ -8,7 +8,7 @@
 
 func test():
 	var resource := Resource.new()
-	prints("Not shadowed:", resource.get_class())
+	prints("Not shadowed:", resource.get_class_name())
 
 	for property in get_property_list():
 		if str(property.name).begins_with("test_"):

--- a/modules/gdscript/tests/scripts/runtime/features/for_loop_iterator_specified_types.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/for_loop_iterator_specified_types.gd
@@ -37,7 +37,7 @@ func test():
 	var d2 := { RefCounted.new(): 1, Resource.new(): 2, ConfigFile.new(): 3 }
 	for k: RefCounted in d2:
 		var key := k
-		prints(k.get_class(), key.get_class())
+		prints(k.get_class_name(), key.get_class_name())
 
 	print("Test implicitly typed dictionary literal.")
 	for k: StringName in { x = 123, y = 456, z = 789 }:

--- a/modules/gdscript/tests/scripts/runtime/features/metatypes.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/metatypes.gd
@@ -14,7 +14,7 @@ func check_gdscript_native_class(value: Variant) -> void:
 	print(var_to_str(value).get_slice(",", 0).trim_prefix("Object("))
 
 func check_gdscript(value: GDScript) -> void:
-	print(value.get_class())
+	print(value.get_class_name())
 
 func check_enum(value: Dictionary) -> void:
 	print(value)

--- a/modules/gdscript/tests/scripts/runtime/features/object_constructor.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/object_constructor.gd
@@ -2,5 +2,5 @@
 
 func test():
 	var object := Object.new() # Not `Object()`.
-	print(object.get_class())
+	print(object.get_class_name())
 	object.free()

--- a/modules/gdscript/tests/scripts/runtime/features/type_casting.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/type_casting.gd
@@ -1,7 +1,7 @@
 func print_value(value: Variant) -> void:
 	if value is Object:
 		@warning_ignore("unsafe_method_access")
-		print("<%s>" % value.get_class())
+		print("<%s>" % value.get_class_name())
 	else:
 		print(var_to_str(value))
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1140,7 +1140,7 @@ bool CSharpLanguage::setup_csharp_script_binding(CSharpScriptBinding &r_script_b
 
 	bool parent_is_object_class = ClassDB::is_parent_class(p_object->get_class_name(), type_name);
 	ERR_FAIL_COND_V_MSG(!parent_is_object_class, false,
-			"Type inherits from native type '" + type_name + "', so it can't be instantiated in object of type: '" + p_object->get_class() + "'.");
+			"Type inherits from native type '" + type_name + "', so it can't be instantiated in object of type: '" + p_object->get_class_name() + "'.");
 
 #ifdef DEBUG_ENABLED
 	CRASH_COND(!r_script_binding.gchandle.is_released());
@@ -2448,9 +2448,9 @@ ScriptInstance *CSharpScript::instance_create(Object *p_this) {
 		if (EngineDebugger::is_active()) {
 			CSharpLanguage::get_singleton()->debug_break_parse(get_path(), 0,
 					"Script inherits from native type '" + String(native_name) +
-							"', so it can't be assigned to an object of type: '" + p_this->get_class() + "'");
+							"', so it can't be assigned to an object of type: '" + p_this->get_class_name() + "'");
 		}
-		ERR_FAIL_V_MSG(nullptr, "Script inherits from native type '" + String(native_name) + "', so it can't be assigned to an object of type: '" + p_this->get_class() + "'.");
+		ERR_FAIL_V_MSG(nullptr, "Script inherits from native type '" + String(native_name) + "', so it can't be assigned to an object of type: '" + p_this->get_class_name() + "'.");
 	}
 
 	Callable::CallError unchecked_error;

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -197,7 +197,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 			Node *base = _try_find_owner_node_in_tree(script);
 			if (base && Object::cast_to<Control>(base)) {
 				List<StringName> sn;
-				ThemeDB::get_singleton()->get_default_theme()->get_color_list(base->get_class(), &sn);
+				ThemeDB::get_singleton()->get_default_theme()->get_color_list(base->get_class_name(), &sn);
 
 				for (const StringName &E : sn) {
 					suggestions.push_back(quoted(E));
@@ -209,7 +209,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 			Node *base = _try_find_owner_node_in_tree(script);
 			if (base && Object::cast_to<Control>(base)) {
 				List<StringName> sn;
-				ThemeDB::get_singleton()->get_default_theme()->get_constant_list(base->get_class(), &sn);
+				ThemeDB::get_singleton()->get_default_theme()->get_constant_list(base->get_class_name(), &sn);
 
 				for (const StringName &E : sn) {
 					suggestions.push_back(quoted(E));
@@ -221,7 +221,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 			Node *base = _try_find_owner_node_in_tree(script);
 			if (base && Object::cast_to<Control>(base)) {
 				List<StringName> sn;
-				ThemeDB::get_singleton()->get_default_theme()->get_font_list(base->get_class(), &sn);
+				ThemeDB::get_singleton()->get_default_theme()->get_font_list(base->get_class_name(), &sn);
 
 				for (const StringName &E : sn) {
 					suggestions.push_back(quoted(E));
@@ -233,7 +233,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 			Node *base = _try_find_owner_node_in_tree(script);
 			if (base && Object::cast_to<Control>(base)) {
 				List<StringName> sn;
-				ThemeDB::get_singleton()->get_default_theme()->get_font_size_list(base->get_class(), &sn);
+				ThemeDB::get_singleton()->get_default_theme()->get_font_size_list(base->get_class_name(), &sn);
 
 				for (const StringName &E : sn) {
 					suggestions.push_back(quoted(E));
@@ -245,7 +245,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 			Node *base = _try_find_owner_node_in_tree(script);
 			if (base && Object::cast_to<Control>(base)) {
 				List<StringName> sn;
-				ThemeDB::get_singleton()->get_default_theme()->get_stylebox_list(base->get_class(), &sn);
+				ThemeDB::get_singleton()->get_default_theme()->get_stylebox_list(base->get_class_name(), &sn);
 
 				for (const StringName &E : sn) {
 					suggestions.push_back(quoted(E));

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -273,7 +273,7 @@ GCHandleIntPtr godotsharp_internal_unmanaged_instance_binding_create_managed(Obj
 
 	bool parent_is_object_class = ClassDB::is_parent_class(p_unmanaged->get_class_name(), script_binding.type_name);
 	ERR_FAIL_COND_V_MSG(!parent_is_object_class, { nullptr },
-			"Type inherits from native type '" + script_binding.type_name + "', so it can't be instantiated in object of type: '" + p_unmanaged->get_class() + "'.");
+			"Type inherits from native type '" + script_binding.type_name + "', so it can't be instantiated in object of type: '" + p_unmanaged->get_class_name() + "'.");
 
 	GCHandleIntPtr strong_gchandle =
 			GDMonoCache::managed_callbacks.ScriptManagerBridge_CreateManagedForGodotObjectBinding(
@@ -349,7 +349,7 @@ void godotsharp_array_filter_godot_objects_by_native(StringName *p_native_name, 
 	memnew_placement(r_output, Array);
 
 	for (int i = 0; i < p_input->size(); ++i) {
-		if (ClassDB::is_parent_class(((Object *)(*p_input)[i])->get_class(), *p_native_name)) {
+		if (ClassDB::is_parent_class(((Object *)(*p_input)[i])->get_class_name(), *p_native_name)) {
 			r_output->push_back(p_input[i]);
 		}
 	}
@@ -1507,7 +1507,7 @@ void godotsharp_object_to_string(Object *p_ptr, godot_string *r_str) {
 #endif
 	// Can't call 'Object::to_string()' here, as that can end up calling 'ToString' again resulting in an endless circular loop.
 	memnew_placement(r_str,
-			String("<" + p_ptr->get_class() + "#" + itos(p_ptr->get_instance_id()) + ">"));
+			String("<" + p_ptr->get_class_name() + "#" + itos(p_ptr->get_instance_id()) + ">"));
 }
 
 #ifdef __cplusplus

--- a/modules/mono/signal_awaiter_utils.cpp
+++ b/modules/mono/signal_awaiter_utils.cpp
@@ -67,7 +67,7 @@ uint32_t SignalAwaiterCallable::hash() const {
 String SignalAwaiterCallable::get_as_text() const {
 	Object *base = ObjectDB::get_instance(target_id);
 	if (base) {
-		String class_name = base->get_class();
+		String class_name = base->get_class_name();
 		Ref<Script> script = base->get_script();
 		if (script.is_valid() && script->get_path().is_resource_file()) {
 			class_name += "(" + script->get_path().get_file() + ")";
@@ -152,7 +152,7 @@ uint32_t EventSignalCallable::hash() const {
 }
 
 String EventSignalCallable::get_as_text() const {
-	String class_name = owner->get_class();
+	String class_name = owner->get_class_name();
 	Ref<Script> script = owner->get_script();
 	if (script.is_valid() && script->get_path().is_resource_file()) {
 		class_name += "(" + script->get_path().get_file() + ")";

--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -519,10 +519,10 @@ void ReplicationEditor::edit(MultiplayerSynchronizer *p_sync) {
 }
 
 Ref<Texture2D> ReplicationEditor::_get_class_icon(const Node *p_node) {
-	if (!p_node || !has_theme_icon(p_node->get_class(), EditorStringName(EditorIcons))) {
+	if (!p_node || !has_theme_icon(p_node->get_class_name(), EditorStringName(EditorIcons))) {
 		return get_theme_icon(SNAME("ImportFail"), EditorStringName(EditorIcons));
 	}
-	return get_theme_icon(p_node->get_class(), EditorStringName(EditorIcons));
+	return get_theme_icon(p_node->get_class_name(), EditorStringName(EditorIcons));
 }
 
 static bool can_sync(const Variant &p_var) {

--- a/modules/multiplayer/multiplayer_debugger.cpp
+++ b/modules/multiplayer/multiplayer_debugger.cpp
@@ -70,11 +70,11 @@ Error MultiplayerDebugger::_capture(void *p_user, const String &p_msg, const Arr
 			ERR_CONTINUE(!obj);
 			if (Object::cast_to<SceneReplicationConfig>(obj)) {
 				out.push_back(id);
-				out.push_back(obj->get_class());
+				out.push_back(obj->get_class_name());
 				out.push_back(((SceneReplicationConfig *)obj)->get_path());
 			} else if (Object::cast_to<Node>(obj)) {
 				out.push_back(id);
-				out.push_back(obj->get_class());
+				out.push_back(obj->get_class_name());
 				out.push_back(String(((Node *)obj)->get_path()));
 			} else {
 				ERR_FAIL_V(FAILED);

--- a/modules/openxr/editor/openxr_binding_modifier_editor.cpp
+++ b/modules/openxr/editor/openxr_binding_modifier_editor.cpp
@@ -284,7 +284,7 @@ void OpenXRBindingModifierEditor::setup(Ref<OpenXRActionMap> p_action_map, Ref<O
 	if (p_binding_modifier.is_valid()) {
 		binding_modifier_title->set_text(p_binding_modifier->get_description());
 
-		editor_inspector->set_object_class(p_binding_modifier->get_class());
+		editor_inspector->set_object_class(p_binding_modifier->get_class_name());
 		editor_inspector->edit(p_binding_modifier.ptr());
 	}
 }

--- a/modules/openxr/editor/openxr_binding_modifiers_dialog.cpp
+++ b/modules/openxr/editor/openxr_binding_modifiers_dialog.cpp
@@ -56,7 +56,7 @@ void OpenXRBindingModifiersDialog::_notification(int p_what) {
 OpenXRBindingModifierEditor *OpenXRBindingModifiersDialog::_add_binding_modifier_editor(Ref<OpenXRBindingModifier> p_binding_modifier) {
 	ERR_FAIL_COND_V(p_binding_modifier.is_null(), nullptr);
 
-	String class_name = p_binding_modifier->get_class();
+	String class_name = p_binding_modifier->get_class_name();
 	ERR_FAIL_COND_V(class_name.is_empty(), nullptr);
 	String editor_class = OpenXRActionMapEditor::get_binding_modifier_editor_class(class_name);
 	ERR_FAIL_COND_V(editor_class.is_empty(), nullptr);

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -404,7 +404,7 @@ void PointLight2D::set_texture(const Ref<Texture2D> &p_texture) {
 				p_texture->is_class("MeshTexture") ||
 				p_texture->is_class("Texture2DRD") ||
 				p_texture->is_class("ViewportTexture")) {
-			WARN_PRINT(vformat("%s cannot be used as a PointLight2D texture (%s). As a workaround, assign the value returned by %s's `get_image()` instead.", p_texture->get_class(), get_path(), p_texture->get_class()));
+			WARN_PRINT(vformat("%s cannot be used as a PointLight2D texture (%s). As a workaround, assign the value returned by %s's `get_image()` instead.", p_texture->get_class_name(), get_path(), p_texture->get_class_name()));
 		}
 #endif
 

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -54,7 +54,7 @@ void Decal::set_texture(DecalTexture p_type, const Ref<Texture2D> &p_texture) {
 					p_texture->is_class("MeshTexture") ||
 					p_texture->is_class("Texture2DRD") ||
 					p_texture->is_class("ViewportTexture"))) {
-		WARN_PRINT(vformat("%s cannot be used as a Decal texture (%s). As a workaround, assign the value returned by %s's `get_image()` instead.", p_texture->get_class(), get_path(), p_texture->get_class()));
+		WARN_PRINT(vformat("%s cannot be used as a Decal texture (%s). As a workaround, assign the value returned by %s's `get_image()` instead.", p_texture->get_class_name(), get_path(), p_texture->get_class_name()));
 	}
 #endif
 

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -210,7 +210,7 @@ void Light3D::set_projector(const Ref<Texture2D> &p_texture) {
 					p_texture->is_class("MeshTexture") ||
 					p_texture->is_class("Texture2DRD") ||
 					p_texture->is_class("ViewportTexture"))) {
-		WARN_PRINT(vformat("%s cannot be used as a Light3D projector texture (%s). As a workaround, assign the value returned by %s's `get_image()` instead.", p_texture->get_class(), get_path(), p_texture->get_class()));
+		WARN_PRINT(vformat("%s cannot be used as a Light3D projector texture (%s). As a workaround, assign the value returned by %s's `get_image()` instead.", p_texture->get_class_name(), get_path(), p_texture->get_class_name()));
 	}
 #endif
 

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -508,7 +508,7 @@ SceneDebuggerObject::SceneDebuggerObject(ObjectID p_id) {
 	}
 
 	id = p_id;
-	class_name = obj->get_class();
+	class_name = obj->get_class_name();
 
 	if (ScriptInstance *si = obj->get_script_instance()) {
 		// Read script instance constants and variables
@@ -729,7 +729,7 @@ SceneDebuggerTree::SceneDebuggerTree(Node *p_root) {
 				}
 			}
 		}
-		nodes.push_back(RemoteNode(count, n->get_name(), class_name.is_empty() ? n->get_class() : class_name, n->get_instance_id(), n->get_scene_file_path(), view_flags));
+		nodes.push_back(RemoteNode(count, n->get_name(), class_name.is_empty() ? String(n->get_class_name()) : class_name, n->get_instance_id(), n->get_scene_file_path(), view_flags));
 	}
 }
 

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -309,7 +309,7 @@ BoxContainer::AlignmentMode BoxContainer::get_alignment() const {
 }
 
 void BoxContainer::set_vertical(bool p_vertical) {
-	ERR_FAIL_COND_MSG(is_fixed, "Can't change orientation of " + get_class() + ".");
+	ERR_FAIL_COND_MSG(is_fixed, "Can't change orientation of " + get_class_name() + ".");
 	vertical = p_vertical;
 	update_minimum_size();
 	_resort();

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -208,7 +208,7 @@ void Container::_notification(int p_what) {
 PackedStringArray Container::get_configuration_warnings() const {
 	PackedStringArray warnings = Control::get_configuration_warnings();
 
-	if (get_class() == "Container" && get_script().is_null()) {
+	if (get_class_name() == "Container" && get_script().is_null()) {
 		warnings.push_back(RTR("Container by itself serves no purpose unless a script configures its children placement behavior.\nIf you don't intend to add a script, use a plain Control node instead."));
 	}
 

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -369,7 +369,7 @@ FlowContainer::LastWrapAlignmentMode FlowContainer::get_last_wrap_alignment() co
 }
 
 void FlowContainer::set_vertical(bool p_vertical) {
-	ERR_FAIL_COND_MSG(is_fixed, "Can't change orientation of " + get_class() + ".");
+	ERR_FAIL_COND_MSG(is_fixed, "Can't change orientation of " + get_class_name() + ".");
 	vertical = p_vertical;
 	update_minimum_size();
 	_resort();

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -405,7 +405,7 @@ bool SplitContainer::is_collapsed() const {
 }
 
 void SplitContainer::set_vertical(bool p_vertical) {
-	ERR_FAIL_COND_MSG(is_fixed, "Can't change orientation of " + get_class() + ".");
+	ERR_FAIL_COND_MSG(is_fixed, "Can't change orientation of " + get_class_name() + ".");
 	vertical = p_vertical;
 	update_minimum_size();
 	_resort();

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1608,7 +1608,7 @@ String Node::get_description() const {
 	} else {
 		description = get_name();
 		if (description.is_empty()) {
-			description = get_class();
+			description = get_class_name();
 		}
 	}
 	return description;
@@ -1727,7 +1727,7 @@ void Node::_generate_serial_child_name(const Node *p_child, StringName &name) co
 	if (name == StringName()) {
 		// No name and a new name is needed, create one.
 
-		name = p_child->get_class();
+		name = p_child->get_class_name();
 	}
 
 	const Node *const *existing = data.children.getptr(name);
@@ -2944,7 +2944,7 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 		instantiated = true;
 
 	} else {
-		Object *obj = ClassDB::instantiate(get_class());
+		Object *obj = ClassDB::instantiate(get_class_name());
 		ERR_FAIL_NULL_V(obj, nullptr);
 		node = Object::cast_to<Node>(obj);
 		if (!node) {
@@ -3366,7 +3366,7 @@ void Node::_replace_connections_target(Node *p_new_target) {
 		if (c.flags & CONNECT_PERSIST) {
 			c.signal.get_object()->disconnect(c.signal.get_name(), Callable(this, c.callable.get_method()));
 			bool valid = p_new_target->has_method(c.callable.get_method()) || Ref<Script>(p_new_target->get_script()).is_null() || Ref<Script>(p_new_target->get_script())->has_method(c.callable.get_method());
-			ERR_CONTINUE_MSG(!valid, vformat("Attempt to connect signal '%s.%s' to nonexistent method '%s.%s'.", c.signal.get_object()->get_class(), c.signal.get_name(), c.callable.get_object()->get_class(), c.callable.get_method()));
+			ERR_CONTINUE_MSG(!valid, vformat("Attempt to connect signal '%s.%s' to nonexistent method '%s.%s'.", c.signal.get_object()->get_class_name(), c.signal.get_name(), c.callable.get_object()->get_class_name(), c.callable.get_method()));
 			c.signal.get_object()->connect(c.signal.get_name(), Callable(p_new_target, c.callable.get_method()), c.flags);
 		}
 	}
@@ -3502,7 +3502,7 @@ static void _print_orphan_nodes_routine(Object *p_obj) {
 
 	List<String> info_strings;
 	info_strings.push_back(path);
-	info_strings.push_back(n->get_class());
+	info_strings.push_back(n->get_class_name());
 
 	_print_orphan_nodes_map[p_obj->get_instance_id()] = info_strings;
 }

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1872,7 +1872,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 #ifdef DEBUG_ENABLED
 			if (EngineDebugger::get_singleton()) {
-				Array arr = { gui.mouse_focus->get_path(), gui.mouse_focus->get_class() };
+				Array arr = { gui.mouse_focus->get_path(), gui.mouse_focus->get_class_name() };
 				EngineDebugger::get_singleton()->send_message("scene:click_ctrl", arr);
 			}
 #endif

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -84,7 +84,7 @@ Ref<Resource> SceneState::get_remap_resource(const Ref<Resource> &p_resource, Ha
 	HashMap<Ref<Resource>, Ref<Resource>>::Iterator R = remap_cache.find(p_resource);
 	if (R) {
 		remap_resource = R->value;
-	} else if (p_fallback.is_valid() && p_fallback->is_local_to_scene() && p_fallback->get_class() == p_resource->get_class()) {
+	} else if (p_fallback.is_valid() && p_fallback->is_local_to_scene() && p_fallback->get_class_name() == p_resource->get_class_name()) {
 		// Simply copy the data from the source resource to update the fallback resource that was previously set.
 
 		p_fallback->reset_state(); // May want to reset state.
@@ -979,7 +979,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 			// It's a missing node (type non existent on load).
 			nd.type = _nm_get_string(missing_node->get_original_class(), name_map);
 		} else {
-			nd.type = _nm_get_string(p_node->get_class(), name_map);
+			nd.type = _nm_get_string(p_node->get_class_name(), name_map);
 		}
 	} else {
 		// this node is part of an instantiated process, so do not save the type.
@@ -2150,7 +2150,7 @@ void PackedScene::reload_from_file() {
 		return;
 	}
 
-	Ref<PackedScene> s = ResourceLoader::load(ResourceLoader::path_remap(path), get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
+	Ref<PackedScene> s = ResourceLoader::load(ResourceLoader::path_remap(path), get_class_name(), ResourceFormatLoader::CACHE_MODE_IGNORE);
 	if (s.is_null()) {
 		return;
 	}

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -521,7 +521,7 @@ Error ResourceLoaderText::load() {
 		if (cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE && ResourceCache::has(path)) {
 			//reuse existing
 			Ref<Resource> cache = ResourceCache::get_ref(path);
-			if (cache.is_valid() && cache->get_class() == type) {
+			if (cache.is_valid() && cache->get_class_name() == type) {
 				res = cache;
 				res->reset_state();
 				do_assign = true;
@@ -678,7 +678,7 @@ Error ResourceLoaderText::load() {
 		resource = ResourceLoader::get_resource_ref_override(local_path);
 		if (resource.is_null()) {
 			Ref<Resource> cache = ResourceCache::get_ref(local_path);
-			if (cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE && cache.is_valid() && cache->get_class() == res_type) {
+			if (cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE && cache.is_valid() && cache->get_class_name() == res_type) {
 				cache->reset_state();
 				resource = cache;
 			}
@@ -1700,7 +1700,7 @@ static String _resource_get_class(Ref<Resource> p_resource) {
 	if (missing_resource.is_valid()) {
 		return missing_resource->get_original_class();
 	} else {
-		return p_resource->get_class();
+		return p_resource->get_class_name();
 	}
 }
 
@@ -1935,7 +1935,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 					}
 				}
 
-				Variant default_value = ClassDB::class_get_default_property_value(res->get_class(), name);
+				Variant default_value = ClassDB::class_get_default_property_value(res->get_class_name(), name);
 
 				if (default_value.get_type() != Variant::NIL && bool(Variant::evaluate(Variant::OP_EQUAL, value, default_value))) {
 					continue;

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -360,7 +360,7 @@ void ThemeDB::update_class_instance_items(Node *p_instance) {
 
 	// Use the hierarchy to initialize all inherited theme caches. Setters carry the necessary
 	// context and will set the values appropriately.
-	StringName class_name = p_instance->get_class();
+	StringName class_name = p_instance->get_class_name();
 	while (class_name != StringName()) {
 		HashMap<StringName, HashMap<StringName, ThemeItemBind>>::Iterator E = theme_item_binds.find(class_name);
 		if (E) {

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -132,7 +132,7 @@ TEST_CASE("[Object] Core getters") {
 			object.is_class("Object"),
 			"is_class() should return the expected value.");
 	CHECK_MESSAGE(
-			object.get_class() == "Object",
+			object.get_class_name() == "Object",
 			"The returned class should match the expected value.");
 	CHECK_MESSAGE(
 			object.get_class_name() == "Object",

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -295,7 +295,7 @@ public:
 
 	void watch_signal(Object *p_object, const String &p_signal) {
 		MethodInfo method_info;
-		ClassDB::get_signal(p_object->get_class(), p_signal, &method_info);
+		ClassDB::get_signal(p_object->get_class_name(), p_signal, &method_info);
 		switch (method_info.arguments.size()) {
 			case 0: {
 				p_object->connect(p_signal, callable_mp(this, &SignalWatcher::_signal_callback_zero).bind(p_signal));
@@ -317,7 +317,7 @@ public:
 
 	void unwatch_signal(Object *p_object, const String &p_signal) {
 		MethodInfo method_info;
-		ClassDB::get_signal(p_object->get_class(), p_signal, &method_info);
+		ClassDB::get_signal(p_object->get_class_name(), p_signal, &method_info);
 		switch (method_info.arguments.size()) {
 			case 0: {
 				p_object->disconnect(p_signal, callable_mp(this, &SignalWatcher::_signal_callback_zero));


### PR DESCRIPTION
`get_class` is a method that returns the class name of an `Object` as `String`. It simply calls another (not exposed) function called `get_class_name` which does the same but returns the name as `StringName`. This discards information,  makes things unnecessarily slow for callers needing a `StringName`, and essentially duplicates the function.

In an attempt to de-duplicate functionality, I exposed `get_class_name` and removed `get_class`. It would have been possible to change the return type of `get_class`, but I prefer the name `get_class_name` because it's returning the name, not a higher order class type.

The rest of the changes in this PR are pretty trivial; it's basically a big old search and replace changing instances of `get_class` to `get_class_name`.

@Repiteo I've got a special question to you: It seems I'm the first person to attempt to use `[[deprecated]]` in the repository. I'm using your new macros, which are great, but it still ended up somewhat verbose. Got any suggestions?

Edit: Turned to draft because the semantics of the new function should probably be discussed before exposing, see comments below.