### PR TITLE
Mention `error_string` in `Error` documentation

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2620,6 +2620,7 @@
 			if error:
 			    printerr("Still failing!")
 			[/codeblock]
+			See [method error_string] to convert error codes to human-readable strings.
 			[b]Note:[/b] Many functions do not return an error code, but will print error messages to standard output.
 		</constant>
 		<constant name="FAILED" value="1" enum="Error">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Closes godotengine/godot-docs#10777

Adds a mention to `error_string` in the `Error` documentation.