### PR TITLE
Search custom types when filtering on type in the SceneTree dock

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1107,6 +1107,33 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 	return p_parent->is_visible();
 }
 
+bool SceneTreeEditor::_node_matches_class_term(const Node *p_item_node, const String &p_term) {
+	if (p_term.is_empty()) {
+		// Defend against https://github.com/godotengine/godot/issues/82473
+		return true;
+	}
+	Ref<Script> item_script = p_item_node->get_script();
+	while (item_script.is_valid()) {
+		String global_name = item_script->get_global_name();
+		if (global_name.to_lower().contains(p_term)) {
+			return true;
+		}
+		item_script = item_script->get_base_script();
+	}
+
+	String type = p_item_node->get_class();
+	// Every Node is a Node, duh!
+	while (type != "Node") {
+		if (type.to_lower().contains(p_term)) {
+			return true;
+		}
+
+		type = ClassDB::get_parent_class(type);
+	}
+
+	return false;
+}
+
 bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, const PackedStringArray &p_terms) {
 	if (p_terms.is_empty()) {
 		return true;
@@ -1122,18 +1149,8 @@ bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, const PackedStri
 
 			if (parameter == "type" || parameter == "t") {
 				// Filter by Type.
-				String type = get_node(p_item->get_metadata(0))->get_class();
-				bool term_in_inherited_class = false;
-				// Every Node is a Node, duh!
-				while (type != "Node") {
-					if (type.to_lower().contains(argument)) {
-						term_in_inherited_class = true;
-						break;
-					}
-
-					type = ClassDB::get_parent_class(type);
-				}
-				if (!term_in_inherited_class) {
+				Node *item_node = get_node(p_item->get_metadata(0));
+				if (!_node_matches_class_term(item_node, argument)) {
 					return false;
 				}
 			} else if (parameter == "group" || parameter == "g") {

--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -146,6 +146,7 @@ class SceneTreeEditor : public Control {
 
 	void _test_update_tree();
 	bool _update_filter(TreeItem *p_parent = nullptr, bool p_scroll_to_selected = false);
+	bool _node_matches_class_term(const Node *p_item_node, const String &p_term);
 	bool _item_matches_all_terms(TreeItem *p_item, const PackedStringArray &p_terms);
 	void _tree_changed();
 	void _tree_process_mode_changed();


### PR DESCRIPTION
Fixes #105049.

When searching the SceneTree dock with the `t:TypeName` filter, we were only filtering by class, not class_name. This adds a walk up the class_name chain, as well. 

This was also impacted by #82473: when you typed `t:` with no argument no nodes would display. I'm defending against that as long as I'm in here since fixing contains would be a larger, compat breaking change, but I may well take a crack at that next.