### PR TITLE
Change `DisplayServerMacOS` from `GDCLASS` to `GDSOFTCLASS`. Add `GDSOFTCLASS` to other display servers.

### DIFF
--- a/platform/ios/display_server_ios.h
+++ b/platform/ios/display_server_ios.h
@@ -56,7 +56,7 @@
 #import <QuartzCore/CAMetalLayer.h>
 
 class DisplayServerIOS : public DisplayServer {
-	// No need to register with GDCLASS, it's platform-specific and nothing is added.
+	GDSOFTCLASS(DisplayServerIOS, DisplayServer);
 
 	_THREAD_SAFE_CLASS_
 

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -67,7 +67,8 @@
 #undef CursorShape
 
 class DisplayServerWayland : public DisplayServer {
-	// No need to register with GDCLASS, it's platform-specific and nothing is added.
+	GDSOFTCLASS(DisplayServerWayland, DisplayServer);
+
 	struct WindowData {
 		WindowID id = INVALID_WINDOW_ID;
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -123,7 +123,7 @@ typedef struct _xrr_monitor_info {
 #undef CursorShape
 
 class DisplayServerX11 : public DisplayServer {
-	// No need to register with GDCLASS, it's platform-specific and nothing is added.
+	GDSOFTCLASS(DisplayServerX11, DisplayServer);
 
 	_THREAD_SAFE_CLASS_
 

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -64,7 +64,7 @@
 #undef CursorShape
 
 class DisplayServerMacOS : public DisplayServer {
-	GDCLASS(DisplayServerMacOS, DisplayServer); // Note: required for Object::cast_to.
+	GDSOFTCLASS(DisplayServerMacOS, DisplayServer);
 
 	_THREAD_SAFE_CLASS_
 

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -38,7 +38,7 @@
 #include <emscripten/html5.h>
 
 class DisplayServerWeb : public DisplayServer {
-	// No need to register with GDCLASS, it's platform-specific and nothing is added.
+	GDSOFTCLASS(DisplayServerWeb, DisplayServer);
 
 private:
 	struct JSTouchEvent {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -366,7 +366,7 @@ class DropTargetWindows;
 #endif
 
 class DisplayServerWindows : public DisplayServer {
-	// No need to register with GDCLASS, it's platform-specific and nothing is added.
+	GDSOFTCLASS(DisplayServerWindows, DisplayServer);
 
 	friend class DropTargetWindows;
 

--- a/servers/display_server_headless.h
+++ b/servers/display_server_headless.h
@@ -35,6 +35,8 @@
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
 class DisplayServerHeadless : public DisplayServer {
+	GDSOFTCLASS(DisplayServerHeadless, DisplayServer);
+
 private:
 	friend class DisplayServer;
 

--- a/tests/display_server_mock.h
+++ b/tests/display_server_mock.h
@@ -37,6 +37,8 @@
 // Specialized DisplayServer for unittests based on DisplayServerHeadless, that
 // additionally supports things like mouse enter/exit events and clipboard.
 class DisplayServerMock : public DisplayServerHeadless {
+	GDSOFTCLASS(DisplayServerMock, DisplayServerHeadless);
+
 private:
 	friend class DisplayServer;
 


### PR DESCRIPTION
`GDCLASS` was originally added for `cast_to` only. `DisplayServerAndroid` already has `GDSOFTCLASS`.