### PR TITLE
Fix visual shader editor popups not using editor scale.

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -3315,7 +3315,7 @@ void VisualShaderEditor::_edit_port_default_input(Object *p_button, int p_node, 
 			popup_pref_size.width = 180;
 			break;
 	}
-	property_editor_popup->set_min_size(popup_pref_size);
+	property_editor_popup->set_min_size(popup_pref_size * EDSCALE);
 
 	property_editor->set_object_and_property(edited_property_holder.ptr(), "edited_property");
 	property_editor->update_property();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105185

<img width="284" alt="Screenshot 2025-04-10 at 10 18 17" src="https://github.com/user-attachments/assets/324be6b1-530a-4929-b9b5-2f37996bf2fd" />
