### PR TITLE
Web: Support creating and loading gziped pck and wasm files.

### DIFF
--- a/platform/web/doc_classes/EditorExportPlatformWeb.xml
+++ b/platform/web/doc_classes/EditorExportPlatformWeb.xml
@@ -37,6 +37,9 @@
 		<member name="html/focus_canvas_on_start" type="bool" setter="" getter="">
 			If [code]true[/code], the canvas will be focused as soon as the application is loaded, if the browser window is already in focus.
 		</member>
+		<member name="html/force_gzip" type="bool" setter="" getter="">
+			If [code]true[/code], the project pack and wasm files will be gzip compressed and loaded in a way that bypasses server side compression.
+		</member>
 		<member name="html/head_include" type="String" setter="" getter="">
 			Additional HTML tags to include inside the [code]&lt;head&gt;[/code], such as [code]&lt;meta&gt;[/code] tags.
 			[b]Note:[/b] You do not need to add a [code]&lt;title&gt;[/code] tag, as it is automatically included based on the project's name.

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -128,7 +128,7 @@ void EditorExportPlatformWeb::_replace_strings(const HashMap<String, String> &p_
 	}
 }
 
-void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, BitField<EditorExportPlatform::DebugFlags> p_flags, const Vector<SharedObject> p_shared_objects, const Dictionary &p_file_sizes) {
+void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, BitField<EditorExportPlatform::DebugFlags> p_flags, const Vector<SharedObject> p_shared_objects, const Dictionary &p_file_sizes, bool p_force_gzip) {
 	// Engine.js config
 	Dictionary config;
 	Array libs;
@@ -151,6 +151,10 @@ void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<Edito
 
 	config["godotPoolSize"] = p_preset->get("threads/godot_pool_size");
 	config["emscriptenPoolSize"] = p_preset->get("threads/emscripten_pool_size");
+
+	if (p_force_gzip) {
+		config["gzip"] = true;
+	}
 
 	String head_include;
 	if (p_preset->get("html/export_icon")) {
@@ -376,6 +380,7 @@ void EditorExportPlatformWeb::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "html/head_include", PROPERTY_HINT_MULTILINE_TEXT), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "html/canvas_resize_policy", PROPERTY_HINT_ENUM, "None,Project,Adaptive"), 2));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "html/focus_canvas_on_start"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "html/force_gzip"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "html/experimental_virtual_keyboard"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "progressive_web_app/enabled"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "progressive_web_app/ensure_cross_origin_isolation_headers"), true));
@@ -489,6 +494,7 @@ Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_p
 	const String custom_release = p_preset->get("custom_template/release");
 	const String custom_html = p_preset->get("html/custom_html_shell");
 	const bool export_icon = p_preset->get("html/export_icon");
+	const bool force_gzip = p_preset->get("html/force_gzip");
 	const bool pwa = p_preset->get("progressive_web_app/enabled");
 
 	const String base_dir = p_path.get_base_dir();
@@ -546,11 +552,35 @@ Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_p
 	Dictionary file_sizes;
 	Ref<FileAccess> f = FileAccess::open(pck_path, FileAccess::READ);
 	if (f.is_valid()) {
-		file_sizes[pck_path.get_file()] = (uint64_t)f->get_length();
+		file_sizes[pck_path.get_file() + (force_gzip ? ".gzip" : "")] = (uint64_t)f->get_length();
+
+		if (force_gzip) {
+			PackedByteArray data = f->get_buffer(f->get_length());
+			PackedByteArray result;
+			result.resize(data.size());
+			int sz = Compression::compress(result.ptrw(), data.ptr(), data.size(), Compression::MODE_GZIP);
+			result.resize(sz);
+			Ref<FileAccess> to = FileAccess::open(pck_path + ".gzip", FileAccess::WRITE);
+			to->store_buffer(result);
+			f.unref();
+			DirAccess::remove_file_or_error(pck_path);
+		}
 	}
 	f = FileAccess::open(base_path + ".wasm", FileAccess::READ);
 	if (f.is_valid()) {
-		file_sizes[base_name + ".wasm"] = (uint64_t)f->get_length();
+		file_sizes[base_name + ".wasm" + (force_gzip ? ".gzip" : "")] = (uint64_t)f->get_length();
+
+		if (force_gzip) {
+			PackedByteArray data = f->get_buffer(f->get_length());
+			PackedByteArray result;
+			result.resize(data.size());
+			int sz = Compression::compress(result.ptrw(), data.ptr(), data.size(), Compression::MODE_GZIP);
+			result.resize(sz);
+			Ref<FileAccess> to = FileAccess::open(base_path + ".wasm.gzip", FileAccess::WRITE);
+			to->store_buffer(result);
+			f.unref();
+			DirAccess::remove_file_or_error(base_path + ".wasm");
+		}
 	}
 
 	// Read the HTML shell file (custom or from template).
@@ -566,7 +596,7 @@ Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_p
 	f.unref(); // close file.
 
 	// Generate HTML file with replaced strings.
-	_fix_html(html, p_preset, base_name, p_debug, p_flags, shared_objects, file_sizes);
+	_fix_html(html, p_preset, base_name, p_debug, p_flags, shared_objects, file_sizes, force_gzip);
 	Error err = _write_or_error(html.ptr(), html.size(), p_path);
 	if (err != OK) {
 		// Message is supplied by the subroutine method.

--- a/platform/web/export/export_plugin.h
+++ b/platform/web/export/export_plugin.h
@@ -105,7 +105,7 @@ class EditorExportPlatformWeb : public EditorExportPlatform {
 
 	Error _extract_template(const String &p_template, const String &p_dir, const String &p_name, bool pwa);
 	void _replace_strings(const HashMap<String, String> &p_replaces, Vector<uint8_t> &r_template);
-	void _fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, BitField<EditorExportPlatform::DebugFlags> p_flags, const Vector<SharedObject> p_shared_objects, const Dictionary &p_file_sizes);
+	void _fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, BitField<EditorExportPlatform::DebugFlags> p_flags, const Vector<SharedObject> p_shared_objects, const Dictionary &p_file_sizes, bool p_force_gzip);
 	Error _add_manifest_icon(const Ref<EditorExportPreset> &p_preset, const String &p_path, const String &p_icon, int p_size, Array &r_arr);
 	Error _build_pwa(const Ref<EditorExportPreset> &p_preset, const String p_path, const Vector<SharedObject> &p_shared_objects);
 	Error _write_or_error(const uint8_t *p_content, int p_len, String p_path);

--- a/platform/web/js/engine/config.js
+++ b/platform/web/js/engine/config.js
@@ -143,6 +143,12 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		 * @type {number}
 		 */
 		godotPoolSize: 4,
+		/*
+		 * Fetch pack and engine gzip from the server.
+		 * @memberof EngineConfig
+		 * @type {boolean}
+		 */
+		gzip: false,
 		/**
 		 * A callback function for handling Godot's ``OS.execute`` calls.
 		 *
@@ -271,6 +277,7 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		this.fileSizes = parse('fileSizes', this.fileSizes);
 		this.emscriptenPoolSize = parse('emscriptenPoolSize', this.emscriptenPoolSize);
 		this.godotPoolSize = parse('godotPoolSize', this.godotPoolSize);
+		this.gzip = parse('gzip', this.gzip);
 		this.args = parse('args', this.args);
 		this.onExecute = parse('onExecute', this.onExecute);
 		this.onExit = parse('onExit', this.onExit);

--- a/platform/web/js/engine/engine.js
+++ b/platform/web/js/engine/engine.js
@@ -36,14 +36,15 @@ const Engine = (function () {
 	 *
 	 * @param {string} basePath Base path of the engine to load.
 	 * @param {number=} [size=0] The file size if known.
+	 * @param {boolean=} [gzip=false] Request gzipped version
 	 * @returns {Promise} A Promise that resolves once the engine is loaded.
 	 *
 	 * @function Engine.load
 	 */
-	Engine.load = function (basePath, size) {
+	Engine.load = function (basePath, size, gzip) {
 		if (loadPromise == null) {
 			loadPath = basePath;
-			loadPromise = preloader.loadPromise(`${loadPath}.wasm`, size, true);
+			loadPromise = preloader.loadPromise(`${loadPath}.wasm${gzip ? '.gzip' : ''}`, size, true);
 			requestAnimationFrame(preloader.animateProgress);
 		}
 		return loadPromise;
@@ -83,7 +84,7 @@ const Engine = (function () {
 						initPromise = Promise.reject(new Error('A base path must be provided when calling `init` and the engine is not loaded.'));
 						return initPromise;
 					}
-					Engine.load(basePath, this.config.fileSizes[`${basePath}.wasm`]);
+					Engine.load(basePath, this.config.fileSizes[`${basePath}.wasm${this.config.gzip ? '.gzip' : ''}`], this.config.gzip);
 				}
 				const me = this;
 				function doInit(promise) {
@@ -197,7 +198,7 @@ const Engine = (function () {
 				this.config.update(override);
 				// Add main-pack argument.
 				const exe = this.config.executable;
-				const pack = this.config.mainPack || `${exe}.pck`;
+				const pack = this.config.mainPack || `${exe}.pck${this.config.gzip ? '.gzip' : ''}`;
 				this.config.args = ['--main-pack', pack].concat(this.config.args);
 				// Start and init with execName as loadPath if not inited.
 				const me = this;

--- a/platform/web/js/engine/preloader.js
+++ b/platform/web/js/engine/preloader.js
@@ -16,7 +16,14 @@ const Preloader = /** @constructor */ function () { // eslint-disable-line no-un
 				return Promise.resolve();
 			});
 		}
-		const reader = response.body.getReader();
+		let reader;
+		if (response.url.endsWith('.gzip')) {
+			const ds = new DecompressionStream('gzip');
+			reader = ds.readable.getReader();
+			response.body.pipeThrough(ds);
+		} else {
+			reader = response.body.getReader();
+		}
 		return new Response(new ReadableStream({
 			start: function (controller) {
 				onloadprogress(reader, controller).then(function () {


### PR DESCRIPTION
- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/12208.*

Pervious attempts and tutorial at this have either pulled in some other javascript library, or only worked on the pack file.  This is a new approach that uses [DecompressionStream ](https://caniuse.com/mdn-api_decompressionstream) to efficiently and transparently decompress incoming gziped files.