### PR TITLE
Fix translation of various undo action names

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -1159,7 +1159,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 					if (I.key == REMOVE_ICON) {
 						if (!read_only) {
 							EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-							undo_redo->create_action("Remove Bezier Track", UndoRedo::MERGE_DISABLE, animation.ptr());
+							undo_redo->create_action(TTR("Remove Bezier Track"), UndoRedo::MERGE_DISABLE, animation.ptr());
 
 							undo_redo->add_do_method(this, "_update_locked_tracks_after", track);
 							undo_redo->add_do_method(this, "_update_hidden_tracks_after", track);

--- a/editor/plugins/gizmos/gpu_particles_collision_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/gpu_particles_collision_3d_gizmo_plugin.cpp
@@ -143,7 +143,7 @@ void GPUParticlesCollision3DGizmoPlugin::commit_handle(const EditorNode3DGizmo *
 	}
 
 	if (Object::cast_to<GPUParticlesCollisionBox3D>(sn) || Object::cast_to<GPUParticlesAttractorBox3D>(sn) || Object::cast_to<GPUParticlesAttractorVectorField3D>(sn) || Object::cast_to<GPUParticlesCollisionSDF3D>(sn) || Object::cast_to<GPUParticlesCollisionHeightField3D>(sn)) {
-		helper->box_commit_handle("Change Box Shape Size", p_cancel, sn);
+		helper->box_commit_handle(TTR("Change Box Shape Size"), p_cancel, sn);
 	}
 }
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5081,7 +5081,7 @@ void Node3DEditorViewport::commit_transform() {
 		TTRC("Scale"),
 	};
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(_transform_name[_edit.mode]);
+	undo_redo->create_action(TTRGET(_transform_name[_edit.mode]));
 
 	const List<Node *> &selection = editor_selection->get_top_selected_node_list();
 

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -65,7 +65,7 @@ void ParticlesEditorPlugin::_notification(int p_what) {
 			PopupMenu *popup = menu->get_popup();
 			popup->add_shortcut(ED_SHORTCUT("particles/restart_emission", TTRC("Restart Emission"), KeyModifierMask::CTRL | Key::R), MENU_RESTART);
 			_add_menu_options(popup);
-			popup->add_item(conversion_option_name, MENU_OPTION_CONVERT);
+			popup->add_item(TTRGET(conversion_option_name), MENU_OPTION_CONVERT);
 		} break;
 	}
 }
@@ -89,7 +89,7 @@ void ParticlesEditorPlugin::_menu_callback(int p_idx) {
 			Node *converted_node = _convert_particles();
 
 			EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-			ur->create_action(conversion_option_name, UndoRedo::MERGE_DISABLE, edited_node);
+			ur->create_action(TTRGET(conversion_option_name), UndoRedo::MERGE_DISABLE, edited_node);
 			SceneTreeDock::get_singleton()->replace_node(edited_node, converted_node);
 			ur->commit_action(false);
 		} break;
@@ -493,7 +493,7 @@ void GPUParticles2DEditorPlugin::_generate_emission_mask() {
 
 GPUParticles2DEditorPlugin::GPUParticles2DEditorPlugin() {
 	handled_type = TTRC("GPUParticles2D");
-	conversion_option_name = TTR("Convert to CPUParticles2D");
+	conversion_option_name = TTRC("Convert to CPUParticles2D");
 
 	generate_visibility_rect = memnew(ConfirmationDialog);
 	generate_visibility_rect->set_title(TTR("Generate Visibility Rect"));
@@ -591,7 +591,7 @@ void CPUParticles2DEditorPlugin::_generate_emission_mask() {
 
 CPUParticles2DEditorPlugin::CPUParticles2DEditorPlugin() {
 	handled_type = TTRC("CPUParticles2D");
-	conversion_option_name = TTR("Convert to GPUParticles2D");
+	conversion_option_name = TTRC("Convert to GPUParticles2D");
 }
 
 // 3D /////////////////////////////////////////////
@@ -966,7 +966,7 @@ void GPUParticles3DEditorPlugin::_generate_emission_points() {
 
 GPUParticles3DEditorPlugin::GPUParticles3DEditorPlugin() {
 	handled_type = TTRC("GPUParticles3D");
-	conversion_option_name = TTR("Convert to CPUParticles3D");
+	conversion_option_name = TTRC("Convert to CPUParticles3D");
 }
 
 Node *CPUParticles3DEditorPlugin::_convert_particles() {
@@ -1011,5 +1011,5 @@ void CPUParticles3DEditorPlugin::_generate_emission_points() {
 
 CPUParticles3DEditorPlugin::CPUParticles3DEditorPlugin() {
 	handled_type = TTRC("CPUParticles3D");
-	conversion_option_name = TTR("Convert to GPUParticles3D");
+	conversion_option_name = TTRC("Convert to GPUParticles3D");
 }


### PR DESCRIPTION
About the change to `Convert to {CPU,GPU}Particles2D`: These names were translated in the constructor, which is not ideal since we're moving towards changing the language dynamically. So changed to use `TTRC` + `TTRGET` instead.