### PR TITLE
Convert `PtrToArg` macros to regular C++ structs.

### DIFF
--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -35,113 +35,215 @@
 #include "core/typedefs.h"
 #include "core/variant/variant.h"
 
+namespace Internal {
+
+template <typename T>
+struct PtrToArgDirect {
+	_FORCE_INLINE_ static const T &convert(const void *p_ptr) {
+		return *reinterpret_cast<const T *>(p_ptr);
+	}
+	typedef T EncodeT;
+	_FORCE_INLINE_ static void encode(T p_val, void *p_ptr) {
+		*((T *)p_ptr) = p_val;
+	}
+};
+
+template <typename T, typename S>
+struct PtrToArgConvert {
+	_FORCE_INLINE_ static T convert(const void *p_ptr) {
+		return static_cast<T>(*reinterpret_cast<const S *>(p_ptr));
+	}
+	typedef S EncodeT;
+	_FORCE_INLINE_ static void encode(T p_val, void *p_ptr) {
+		*((S *)p_ptr) = static_cast<S>(p_val);
+	}
+};
+
+template <typename T>
+struct PtrToArgByReference {
+	_FORCE_INLINE_ static const T &convert(const void *p_ptr) {
+		return *reinterpret_cast<const T *>(p_ptr);
+	}
+	typedef T EncodeT;
+	_FORCE_INLINE_ static void encode(const T &p_val, void *p_ptr) {
+		*((T *)p_ptr) = p_val;
+	}
+};
+
+template <typename T, typename TAlt>
+struct PtrToArgVectorConvert {
+	_FORCE_INLINE_ static Vector<TAlt> convert(const void *p_ptr) {
+		const Vector<T> *dvs = reinterpret_cast<const Vector<T> *>(p_ptr);
+		Vector<TAlt> ret;
+		int len = dvs->size();
+		ret.resize(len);
+		{
+			const T *r = dvs->ptr();
+			for (int i = 0; i < len; i++) {
+				ret.write[i] = r[i];
+			}
+		}
+		return ret;
+	}
+	// No EncodeT because direct pointer conversion not possible.
+	_FORCE_INLINE_ static void encode(const Vector<TAlt> &p_vec, void *p_ptr) {
+		Vector<T> *dv = reinterpret_cast<Vector<T> *>(p_ptr);
+		int len = p_vec.size();
+		dv->resize(len);
+		{
+			T *w = dv->ptrw();
+			for (int i = 0; i < len; i++) {
+				w[i] = p_vec[i];
+			}
+		}
+	}
+};
+
+template <typename T>
+struct PtrToArgVectorFromArray {
+	_FORCE_INLINE_ static Vector<T> convert(const void *p_ptr) {
+		const Array *arr = reinterpret_cast<const Array *>(p_ptr);
+		Vector<T> ret;
+		int len = arr->size();
+		ret.resize(len);
+		for (int i = 0; i < len; i++) {
+			ret.write[i] = (*arr)[i];
+		}
+		return ret;
+	}
+	// No EncodeT because direct pointer conversion not possible.
+	_FORCE_INLINE_ static void encode(const Vector<T> &p_vec, void *p_ptr) {
+		Array *arr = reinterpret_cast<Array *>(p_ptr);
+		int len = p_vec.size();
+		arr->resize(len);
+		for (int i = 0; i < len; i++) {
+			(*arr)[i] = p_vec[i];
+		}
+	}
+};
+
+template <typename T>
+struct PtrToArgStringConvertByReference {
+	_FORCE_INLINE_ static T convert(const void *p_ptr) {
+		T s = *reinterpret_cast<const String *>(p_ptr);
+		return s;
+	}
+	// No EncodeT because direct pointer conversion not possible.
+	_FORCE_INLINE_ static void encode(const T &p_vec, void *p_ptr) {
+		String *arr = reinterpret_cast<String *>(p_ptr);
+		*arr = p_vec;
+	}
+};
+
+} //namespace Internal
+
 template <typename T, typename = void>
 struct PtrToArg;
 
 template <typename T>
 struct PtrToArg<T, std::enable_if_t<!std::is_same_v<T, GetSimpleTypeT<T>>>> : PtrToArg<GetSimpleTypeT<T>> {};
 
-#define MAKE_PTRARG(m_type)                                              \
-	template <>                                                          \
-	struct PtrToArg<m_type> {                                            \
-		_FORCE_INLINE_ static const m_type &convert(const void *p_ptr) { \
-			return *reinterpret_cast<const m_type *>(p_ptr);             \
-		}                                                                \
-		typedef m_type EncodeT;                                          \
-		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) {   \
-			*((m_type *)p_ptr) = p_val;                                  \
-		}                                                                \
-	};
-
-#define MAKE_PTRARGCONV(m_type, m_conv)                                           \
-	template <>                                                                   \
-	struct PtrToArg<m_type> {                                                     \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {                 \
-			return static_cast<m_type>(*reinterpret_cast<const m_conv *>(p_ptr)); \
-		}                                                                         \
-		typedef m_conv EncodeT;                                                   \
-		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) {            \
-			*((m_conv *)p_ptr) = static_cast<m_conv>(p_val);                      \
-		}                                                                         \
-	};
-
-#define MAKE_PTRARG_BY_REFERENCE(m_type)                                      \
-	template <>                                                               \
-	struct PtrToArg<m_type> {                                                 \
-		_FORCE_INLINE_ static const m_type &convert(const void *p_ptr) {      \
-			return *reinterpret_cast<const m_type *>(p_ptr);                  \
-		}                                                                     \
-		typedef m_type EncodeT;                                               \
-		_FORCE_INLINE_ static void encode(const m_type &p_val, void *p_ptr) { \
-			*((m_type *)p_ptr) = p_val;                                       \
-		}                                                                     \
-	};
-
-#define MAKE_PTRARGCONV_CONDITIONAL(m_type, m_conv, m_conditional)                \
-	template <typename T>                                                         \
-	struct PtrToArg<m_type, std::enable_if_t<m_conditional>> {                    \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {                 \
-			return static_cast<m_type>(*reinterpret_cast<const m_conv *>(p_ptr)); \
-		}                                                                         \
-		typedef m_conv EncodeT;                                                   \
-		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) {            \
-			*((m_conv *)p_ptr) = static_cast<m_conv>(p_val);                      \
-		}                                                                         \
-	};
-
-MAKE_PTRARGCONV(bool, uint8_t);
+template <>
+struct PtrToArg<bool> : Internal::PtrToArgConvert<bool, uint8_t> {};
 // Integer types.
-MAKE_PTRARGCONV(uint8_t, int64_t);
-MAKE_PTRARGCONV(int8_t, int64_t);
-MAKE_PTRARGCONV(uint16_t, int64_t);
-MAKE_PTRARGCONV(int16_t, int64_t);
-MAKE_PTRARGCONV(uint32_t, int64_t);
-MAKE_PTRARGCONV(int32_t, int64_t);
-MAKE_PTRARG(int64_t);
-MAKE_PTRARG(uint64_t);
+template <>
+struct PtrToArg<uint8_t> : Internal::PtrToArgConvert<uint8_t, int64_t> {};
+template <>
+struct PtrToArg<int8_t> : Internal::PtrToArgConvert<int8_t, int64_t> {};
+template <>
+struct PtrToArg<uint16_t> : Internal::PtrToArgConvert<uint16_t, int64_t> {};
+template <>
+struct PtrToArg<int16_t> : Internal::PtrToArgConvert<int16_t, int64_t> {};
+template <>
+struct PtrToArg<uint32_t> : Internal::PtrToArgConvert<uint32_t, int64_t> {};
+template <>
+struct PtrToArg<int32_t> : Internal::PtrToArgConvert<int32_t, int64_t> {};
+template <>
+struct PtrToArg<int64_t> : Internal::PtrToArgDirect<int64_t> {};
+template <>
+struct PtrToArg<uint64_t> : Internal::PtrToArgDirect<uint64_t> {};
 // Float types
-MAKE_PTRARGCONV(float, double);
-MAKE_PTRARG(double);
+template <>
+struct PtrToArg<float> : Internal::PtrToArgConvert<float, double> {};
+template <>
+struct PtrToArg<double> : Internal::PtrToArgDirect<double> {};
 
-MAKE_PTRARG(String);
-MAKE_PTRARG(Vector2);
-MAKE_PTRARG(Vector2i);
-MAKE_PTRARG(Rect2);
-MAKE_PTRARG(Rect2i);
-MAKE_PTRARG_BY_REFERENCE(Vector3);
-MAKE_PTRARG_BY_REFERENCE(Vector3i);
-MAKE_PTRARG_BY_REFERENCE(Vector4);
-MAKE_PTRARG_BY_REFERENCE(Vector4i);
-MAKE_PTRARG(Transform2D);
-MAKE_PTRARG(Projection);
-MAKE_PTRARG_BY_REFERENCE(Plane);
-MAKE_PTRARG(Quaternion);
-MAKE_PTRARG_BY_REFERENCE(AABB);
-MAKE_PTRARG_BY_REFERENCE(Basis);
-MAKE_PTRARG_BY_REFERENCE(Transform3D);
-MAKE_PTRARG_BY_REFERENCE(Color);
-MAKE_PTRARG(StringName);
-MAKE_PTRARG(NodePath);
-MAKE_PTRARG(RID);
+template <>
+struct PtrToArg<String> : Internal::PtrToArgDirect<String> {};
+template <>
+struct PtrToArg<Vector2> : Internal::PtrToArgDirect<Vector2> {};
+template <>
+struct PtrToArg<Vector2i> : Internal::PtrToArgDirect<Vector2i> {};
+template <>
+struct PtrToArg<Rect2> : Internal::PtrToArgDirect<Rect2> {};
+template <>
+struct PtrToArg<Rect2i> : Internal::PtrToArgDirect<Rect2i> {};
+template <>
+struct PtrToArg<Vector3> : Internal::PtrToArgByReference<Vector3> {};
+template <>
+struct PtrToArg<Vector3i> : Internal::PtrToArgByReference<Vector3i> {};
+template <>
+struct PtrToArg<Vector4> : Internal::PtrToArgByReference<Vector4> {};
+template <>
+struct PtrToArg<Vector4i> : Internal::PtrToArgByReference<Vector4i> {};
+template <>
+struct PtrToArg<Transform2D> : Internal::PtrToArgDirect<Transform2D> {};
+template <>
+struct PtrToArg<Projection> : Internal::PtrToArgDirect<Projection> {};
+template <>
+struct PtrToArg<Plane> : Internal::PtrToArgByReference<Plane> {};
+template <>
+struct PtrToArg<Quaternion> : Internal::PtrToArgDirect<Quaternion> {};
+template <>
+struct PtrToArg<AABB> : Internal::PtrToArgByReference<AABB> {};
+template <>
+struct PtrToArg<Basis> : Internal::PtrToArgByReference<Basis> {};
+template <>
+struct PtrToArg<Transform3D> : Internal::PtrToArgByReference<Transform3D> {};
+template <>
+struct PtrToArg<Color> : Internal::PtrToArgByReference<Color> {};
+template <>
+struct PtrToArg<StringName> : Internal::PtrToArgDirect<StringName> {};
+template <>
+struct PtrToArg<NodePath> : Internal::PtrToArgDirect<NodePath> {};
+template <>
+struct PtrToArg<RID> : Internal::PtrToArgDirect<RID> {};
 // Object doesn't need this.
-MAKE_PTRARG(Callable);
-MAKE_PTRARG(Signal);
-MAKE_PTRARG(Dictionary);
-MAKE_PTRARG(Array);
-MAKE_PTRARG(PackedByteArray);
-MAKE_PTRARG(PackedInt32Array);
-MAKE_PTRARG(PackedInt64Array);
-MAKE_PTRARG(PackedFloat32Array);
-MAKE_PTRARG(PackedFloat64Array);
-MAKE_PTRARG(PackedStringArray);
-MAKE_PTRARG(PackedVector2Array);
-MAKE_PTRARG(PackedVector3Array);
-MAKE_PTRARG(PackedColorArray);
-MAKE_PTRARG(PackedVector4Array);
-MAKE_PTRARG_BY_REFERENCE(Variant);
+template <>
+struct PtrToArg<Callable> : Internal::PtrToArgDirect<Callable> {};
+template <>
+struct PtrToArg<Signal> : Internal::PtrToArgDirect<Signal> {};
+template <>
+struct PtrToArg<Dictionary> : Internal::PtrToArgDirect<Dictionary> {};
+template <>
+struct PtrToArg<Array> : Internal::PtrToArgDirect<Array> {};
+template <>
+struct PtrToArg<PackedByteArray> : Internal::PtrToArgDirect<PackedByteArray> {};
+template <>
+struct PtrToArg<PackedInt32Array> : Internal::PtrToArgDirect<PackedInt32Array> {};
+template <>
+struct PtrToArg<PackedInt64Array> : Internal::PtrToArgDirect<PackedInt64Array> {};
+template <>
+struct PtrToArg<PackedFloat32Array> : Internal::PtrToArgDirect<PackedFloat32Array> {};
+template <>
+struct PtrToArg<PackedFloat64Array> : Internal::PtrToArgDirect<PackedFloat64Array> {};
+template <>
+struct PtrToArg<PackedStringArray> : Internal::PtrToArgDirect<PackedStringArray> {};
+template <>
+struct PtrToArg<PackedVector2Array> : Internal::PtrToArgDirect<PackedVector2Array> {};
+template <>
+struct PtrToArg<PackedVector3Array> : Internal::PtrToArgDirect<PackedVector3Array> {};
+template <>
+struct PtrToArg<PackedColorArray> : Internal::PtrToArgDirect<PackedColorArray> {};
+template <>
+struct PtrToArg<PackedVector4Array> : Internal::PtrToArgDirect<PackedVector4Array> {};
+template <>
+struct PtrToArg<Variant> : Internal::PtrToArgByReference<Variant> {};
 
-MAKE_PTRARGCONV_CONDITIONAL(T, int64_t, std::is_enum_v<T>);
-MAKE_PTRARGCONV_CONDITIONAL(BitField<T>, int64_t, std::is_enum_v<T>);
+template <typename T>
+struct PtrToArg<T, std::enable_if_t<std::is_enum_v<T>>> : Internal::PtrToArgConvert<T, int64_t> {};
+template <typename T>
+struct PtrToArg<BitField<T>, std::enable_if_t<std::is_enum_v<T>>> : Internal::PtrToArgConvert<BitField<T>, int64_t> {};
 
 // This is for Object.
 
@@ -182,147 +284,23 @@ struct PtrToArg<ObjectID> {
 
 // This is for the special cases used by Variant.
 
-// No EncodeT because direct pointer conversion not possible.
-#define MAKE_VECARG(m_type)                                                              \
-	template <>                                                                          \
-	struct PtrToArg<Vector<m_type>> {                                                    \
-		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {                \
-			const Vector<m_type> *dvs = reinterpret_cast<const Vector<m_type> *>(p_ptr); \
-			Vector<m_type> ret;                                                          \
-			int len = dvs->size();                                                       \
-			ret.resize(len);                                                             \
-			{                                                                            \
-				const m_type *r = dvs->ptr();                                            \
-				for (int i = 0; i < len; i++) {                                          \
-					ret.write[i] = r[i];                                                 \
-				}                                                                        \
-			}                                                                            \
-			return ret;                                                                  \
-		}                                                                                \
-		_FORCE_INLINE_ static void encode(const Vector<m_type> &p_vec, void *p_ptr) {    \
-			Vector<m_type> *dv = reinterpret_cast<Vector<m_type> *>(p_ptr);              \
-			int len = p_vec.size();                                                      \
-			dv->resize(len);                                                             \
-			{                                                                            \
-				m_type *w = dv->ptrw();                                                  \
-				for (int i = 0; i < len; i++) {                                          \
-					w[i] = p_vec[i];                                                     \
-				}                                                                        \
-			}                                                                            \
-		}                                                                                \
-	};
-
-// No EncodeT because direct pointer conversion not possible.
-#define MAKE_VECARG_ALT(m_type, m_type_alt)                                               \
-	template <>                                                                           \
-	struct PtrToArg<Vector<m_type_alt>> {                                                 \
-		_FORCE_INLINE_ static Vector<m_type_alt> convert(const void *p_ptr) {             \
-			const Vector<m_type> *dvs = reinterpret_cast<const Vector<m_type> *>(p_ptr);  \
-			Vector<m_type_alt> ret;                                                       \
-			int len = dvs->size();                                                        \
-			ret.resize(len);                                                              \
-			{                                                                             \
-				const m_type *r = dvs->ptr();                                             \
-				for (int i = 0; i < len; i++) {                                           \
-					ret.write[i] = r[i];                                                  \
-				}                                                                         \
-			}                                                                             \
-			return ret;                                                                   \
-		}                                                                                 \
-		_FORCE_INLINE_ static void encode(const Vector<m_type_alt> &p_vec, void *p_ptr) { \
-			Vector<m_type> *dv = reinterpret_cast<Vector<m_type> *>(p_ptr);               \
-			int len = p_vec.size();                                                       \
-			dv->resize(len);                                                              \
-			{                                                                             \
-				m_type *w = dv->ptrw();                                                   \
-				for (int i = 0; i < len; i++) {                                           \
-					w[i] = p_vec[i];                                                      \
-				}                                                                         \
-			}                                                                             \
-		}                                                                                 \
-	};
-
-MAKE_VECARG_ALT(String, StringName);
+template <>
+struct PtrToArg<Vector<StringName>> : Internal::PtrToArgVectorConvert<String, StringName> {};
 
 // For stuff that gets converted to Array vectors.
 
-// No EncodeT because direct pointer conversion not possible.
-#define MAKE_VECARR(m_type)                                                           \
-	template <>                                                                       \
-	struct PtrToArg<Vector<m_type>> {                                                 \
-		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {             \
-			const Array *arr = reinterpret_cast<const Array *>(p_ptr);                \
-			Vector<m_type> ret;                                                       \
-			int len = arr->size();                                                    \
-			ret.resize(len);                                                          \
-			for (int i = 0; i < len; i++) {                                           \
-				ret.write[i] = (*arr)[i];                                             \
-			}                                                                         \
-			return ret;                                                               \
-		}                                                                             \
-		_FORCE_INLINE_ static void encode(const Vector<m_type> &p_vec, void *p_ptr) { \
-			Array *arr = reinterpret_cast<Array *>(p_ptr);                            \
-			int len = p_vec.size();                                                   \
-			arr->resize(len);                                                         \
-			for (int i = 0; i < len; i++) {                                           \
-				(*arr)[i] = p_vec[i];                                                 \
-			}                                                                         \
-		}                                                                             \
-	};
-
-MAKE_VECARR(Variant);
-MAKE_VECARR(RID);
-MAKE_VECARR(Plane);
-
-// No EncodeT because direct pointer conversion not possible.
-#define MAKE_DVECARR(m_type)                                                          \
-	template <>                                                                       \
-	struct PtrToArg<Vector<m_type>> {                                                 \
-		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {             \
-			const Array *arr = reinterpret_cast<const Array *>(p_ptr);                \
-			Vector<m_type> ret;                                                       \
-			int len = arr->size();                                                    \
-			ret.resize(len);                                                          \
-			{                                                                         \
-				m_type *w = ret.ptrw();                                               \
-				for (int i = 0; i < len; i++) {                                       \
-					w[i] = (*arr)[i];                                                 \
-				}                                                                     \
-			}                                                                         \
-			return ret;                                                               \
-		}                                                                             \
-		_FORCE_INLINE_ static void encode(const Vector<m_type> &p_vec, void *p_ptr) { \
-			Array *arr = reinterpret_cast<Array *>(p_ptr);                            \
-			int len = p_vec.size();                                                   \
-			arr->resize(len);                                                         \
-			{                                                                         \
-				const m_type *r = p_vec.ptr();                                        \
-				for (int i = 0; i < len; i++) {                                       \
-					(*arr)[i] = r[i];                                                 \
-				}                                                                     \
-			}                                                                         \
-		}                                                                             \
-	};
+template <>
+struct PtrToArg<Vector<Variant>> : Internal::PtrToArgVectorFromArray<Variant> {};
+template <>
+struct PtrToArg<Vector<RID>> : Internal::PtrToArgVectorFromArray<RID> {};
+template <>
+struct PtrToArg<Vector<Plane>> : Internal::PtrToArgVectorFromArray<Plane> {};
 
 // Special case for IPAddress.
 
-// No EncodeT because direct pointer conversion not possible.
-#define MAKE_STRINGCONV_BY_REFERENCE(m_type)                                  \
-	template <>                                                               \
-	struct PtrToArg<m_type> {                                                 \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {             \
-			m_type s = *reinterpret_cast<const String *>(p_ptr);              \
-			return s;                                                         \
-		}                                                                     \
-		_FORCE_INLINE_ static void encode(const m_type &p_vec, void *p_ptr) { \
-			String *arr = reinterpret_cast<String *>(p_ptr);                  \
-			*arr = p_vec;                                                     \
-		}                                                                     \
-	};
+template <>
+struct PtrToArg<IPAddress> : Internal::PtrToArgStringConvertByReference<IPAddress> {};
 
-MAKE_STRINGCONV_BY_REFERENCE(IPAddress);
-
-// No EncodeT because direct pointer conversion not possible.
 template <>
 struct PtrToArg<Vector<Face3>> {
 	_FORCE_INLINE_ static Vector<Face3> convert(const void *p_ptr) {
@@ -341,6 +319,7 @@ struct PtrToArg<Vector<Face3>> {
 		}
 		return ret;
 	}
+	// No EncodeT because direct pointer conversion not possible.
 	_FORCE_INLINE_ static void encode(const Vector<Face3> &p_vec, void *p_ptr) {
 		Vector<Vector3> *arr = reinterpret_cast<Vector<Vector3> *>(p_ptr);
 		int len = p_vec.size();


### PR DESCRIPTION
I'd like to reduce the number of both macro and template magic throughout Godot. Some of it is pretty convoluted and can be simplified.

As a first step, macros should be converted to regular C++ structs as much as possible. 
C style macros are difficult to edit, because they are (until called) not 'regular' code. For example, IDEs struggle to syntax highlight them, or give insights. Therefore, they are undesirable.

For this PR, I simply copy-pasted macro code to named structs. Then, I replaced the macro contents to simply instantiate the requested type with a specialization. Finally, I used my IDE to replace the macros with their contents, to avoid any mistakes with type arguments if I was manually converting.

As a second step, some of these can probably be simplified with C++ template magic in the future. But that's out of scope for this PR.
