### PR TITLE
LSP: Rework management of client owned files

### DIFF
--- a/modules/SCsub
+++ b/modules/SCsub
@@ -52,6 +52,7 @@ for name, path in env.module_list.items():
 
 # Generate header to be included in `tests/test_main.cpp` to run module-specific tests.
 if env["tests"]:
+    env.Append(CPPDEFINES=["TESTS_ENABLED"])
     env.CommandNoCache("modules_tests.gen.h", test_headers, env.Run(modules_builders.modules_tests_builder))
 
 # libmodules.a with only register_module_types.

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -344,8 +344,9 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 					if (res.is_valid() && !res->get_path().is_empty()) {
 						value_text = "preload(\"" + res->get_path() + "\")";
 						if (symbol.documentation.is_empty()) {
-							if (HashMap<String, ExtendGDScriptParser *>::Iterator S = GDScriptLanguageProtocol::get_singleton()->get_workspace()->scripts.find(res->get_path())) {
-								symbol.documentation = S->value->class_symbol.documentation;
+							ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(res->get_path());
+							if (parser) {
+								symbol.documentation = parser->class_symbol.documentation;
 							}
 						}
 					} else {
@@ -1038,18 +1039,17 @@ Dictionary ExtendGDScriptParser::generate_api() const {
 	return api;
 }
 
-Error ExtendGDScriptParser::parse(const String &p_code, const String &p_path) {
+void ExtendGDScriptParser::parse(const String &p_code, const String &p_path) {
 	path = p_path;
 	lines = p_code.split("\n");
 
-	Error err = GDScriptParser::parse(p_code, p_path, false);
+	parse_result = GDScriptParser::parse(p_code, p_path, false);
 	GDScriptAnalyzer analyzer(this);
 
-	if (err == OK) {
-		err = analyzer.analyze();
+	if (parse_result == OK) {
+		parse_result = analyzer.analyze();
 	}
 	update_diagnostics();
 	update_symbols();
 	update_document_links(p_code);
-	return err;
 }

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -143,6 +143,7 @@ public:
 	_FORCE_INLINE_ const Vector<LSP::Diagnostic> &get_diagnostics() const { return diagnostics; }
 	_FORCE_INLINE_ const ClassMembers &get_members() const { return members; }
 	_FORCE_INLINE_ const HashMap<String, ClassMembers> &get_inner_classes() const { return inner_classes; }
+	Error parse_result;
 
 	Error get_left_function_call(const LSP::Position &p_position, LSP::Position &r_func_pos, int &r_arg_index) const;
 
@@ -166,5 +167,5 @@ public:
 	const Array &get_member_completions();
 	Dictionary generate_api() const;
 
-	Error parse(const String &p_code, const String &p_path);
+	void parse(const String &p_code, const String &p_path);
 };

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -36,6 +36,19 @@
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/settings/editor_settings.h"
+#include "modules/gdscript/language_server/godot_lsp.h"
+
+#define LSP_CLIENT_V(m_ret_val)                                    \
+	ERR_FAIL_COND_V(latest_client_id == LSP_NO_CLIENT, m_ret_val); \
+	ERR_FAIL_COND_V(!clients.has(latest_client_id), m_ret_val);    \
+	Ref<LSPeer> client = clients.get(latest_client_id);            \
+	ERR_FAIL_COND_V(!client.is_valid(), m_ret_val);
+
+#define LSP_CLIENT                                      \
+	ERR_FAIL_COND(latest_client_id == LSP_NO_CLIENT);   \
+	ERR_FAIL_COND(!clients.has(latest_client_id));      \
+	Ref<LSPeer> client = clients.get(latest_client_id); \
+	ERR_FAIL_COND(!client.is_valid());
 
 GDScriptLanguageProtocol *GDScriptLanguageProtocol::singleton = nullptr;
 
@@ -312,8 +325,7 @@ void GDScriptLanguageProtocol::notify_client(const String &p_method, const Varia
 	}
 #endif
 	if (p_client_id == -1) {
-		ERR_FAIL_COND_MSG(latest_client_id == -1,
-				"GDScript LSP: Can't notify client as none was connected.");
+		ERR_FAIL_COND_MSG(latest_client_id == LSP_NO_CLIENT, "GDScript LSP: Can't notify client as none was connected.");
 		p_client_id = latest_client_id;
 	}
 	ERR_FAIL_COND(!clients.has(p_client_id));
@@ -333,8 +345,7 @@ void GDScriptLanguageProtocol::request_client(const String &p_method, const Vari
 	}
 #endif
 	if (p_client_id == -1) {
-		ERR_FAIL_COND_MSG(latest_client_id == -1,
-				"GDScript LSP: Can't notify client as none was connected.");
+		ERR_FAIL_COND_MSG(latest_client_id == LSP_NO_CLIENT, "GDScript LSP: Can't notify client as none was connected.");
 		p_client_id = latest_client_id;
 	}
 	ERR_FAIL_COND(!clients.has(p_client_id));
@@ -354,6 +365,174 @@ bool GDScriptLanguageProtocol::is_smart_resolve_enabled() const {
 
 bool GDScriptLanguageProtocol::is_goto_native_symbols_enabled() const {
 	return bool(_EDITOR_GET("network/language_server/show_native_symbols_in_editor"));
+}
+
+ExtendGDScriptParser *GDScriptLanguageProtocol::LSPeer::parse_script(const String &p_path) {
+	remove_cached_parser(p_path);
+
+	String content;
+	const LSP::TextDocumentItem *document = managed_files.getptr(p_path);
+	if (document == nullptr) {
+		if (!p_path.has_extension("gd")) {
+			return nullptr;
+		}
+		Error err;
+		content = FileAccess::get_file_as_string(p_path, &err);
+		if (err != OK) {
+			return nullptr;
+		}
+	} else {
+		if (document->languageId != LSP::LanguageId::GDSCRIPT) {
+			return nullptr;
+		}
+		content = document->text;
+	}
+
+	ExtendGDScriptParser *parser = memnew(ExtendGDScriptParser);
+	parser->parse(content, p_path);
+
+	if (document != nullptr) {
+		parse_results[p_path] = parser;
+		GDScriptLanguageProtocol::get_singleton()->get_workspace()->publish_diagnostics(p_path);
+	} else {
+		stale_parsers[p_path] = parser;
+	}
+
+	return parser;
+}
+
+void GDScriptLanguageProtocol::LSPeer::remove_cached_parser(const String &p_path) {
+	HashMap<String, ExtendGDScriptParser *>::Iterator cached = parse_results.find(p_path);
+	if (cached) {
+		memdelete(cached->value);
+		parse_results.remove(cached);
+	}
+
+	HashMap<String, ExtendGDScriptParser *>::Iterator stale = stale_parsers.find(p_path);
+	if (stale) {
+		memdelete(stale->value);
+		stale_parsers.remove(stale);
+	}
+}
+
+ExtendGDScriptParser *GDScriptLanguageProtocol::get_parse_result(const String &p_path) {
+	LSP_CLIENT_V(nullptr);
+
+	ExtendGDScriptParser **cached_parser = client->parse_results.getptr(p_path);
+	if (cached_parser == nullptr) {
+		return client->parse_script(p_path);
+	}
+	return *cached_parser;
+}
+
+void GDScriptLanguageProtocol::lsp_did_open(const Dictionary &p_params) {
+	LSP_CLIENT;
+
+	LSP::TextDocumentItem document;
+	document.load(p_params["textDocument"]);
+
+	// We keep track of non GDScript files that the client owns, but we are not interested in the content.
+	if (document.languageId != LSP::LanguageId::GDSCRIPT) {
+		document.text = "";
+	}
+
+	String path = get_workspace()->get_file_path(document.uri);
+
+	/// An open notification must not be sent more than once without a corresponding close notification send before.
+	ERR_FAIL_COND_MSG(client->managed_files.has(path), "LSP: Client is opening already opened file.");
+
+	client->managed_files[path] = document;
+	client->parse_script(path);
+}
+
+void GDScriptLanguageProtocol::lsp_did_change(const Dictionary &p_params) {
+	LSP_CLIENT;
+
+	LSP::TextDocumentIdentifier identifier;
+	identifier.load(p_params["textDocument"]);
+
+	String path = get_workspace()->get_file_path(identifier.uri);
+	LSP::TextDocumentItem *document = client->managed_files.getptr(path);
+
+	/// Before a client can change a text document it must claim ownership of its content using the textDocument/didOpen notification.
+	ERR_FAIL_COND_MSG(document == nullptr, "LSP: Client is changing file without opening it.");
+
+	if (document->languageId != LSP::LanguageId::GDSCRIPT) {
+		return;
+	}
+
+	Array contentChanges = p_params["contentChanges"];
+
+	if (contentChanges.is_empty()) {
+		return;
+	}
+
+	// We only support TextDocumentSyncKind::Full. So only the last full text is relevant.
+	LSP::TextDocumentContentChangeEvent event;
+	event.load(contentChanges.back());
+	document->text = event.text;
+
+	client->parse_script(path);
+}
+
+void GDScriptLanguageProtocol::lsp_did_close(const Dictionary &p_params) {
+	LSP_CLIENT;
+
+	LSP::TextDocumentIdentifier identifier;
+	identifier.load(p_params["textDocument"]);
+
+	String path = get_workspace()->get_file_path(identifier.uri);
+	bool was_opened = client->managed_files.erase(path);
+
+	client->remove_cached_parser(path);
+
+	/// A close notification requires a previous open notification to be sent.
+	ERR_FAIL_COND_MSG(!was_opened, "LSP: Client is closing file without opening it.");
+}
+
+void GDScriptLanguageProtocol::resolve_related_symbols(const LSP::TextDocumentPositionParams &p_doc_pos, List<const LSP::DocumentSymbol *> &r_list) {
+	LSP_CLIENT;
+
+	String path = workspace->get_file_path(p_doc_pos.textDocument.uri);
+
+	const ExtendGDScriptParser *parser = get_parse_result(path);
+	if (!parser) {
+		return;
+	}
+
+	String symbol_identifier;
+	LSP::Range range;
+	symbol_identifier = parser->get_identifier_under_position(p_doc_pos.position, range);
+
+	for (const KeyValue<StringName, ClassMembers> &E : workspace->native_members) {
+		if (const LSP::DocumentSymbol *const *symbol = E.value.getptr(symbol_identifier)) {
+			r_list.push_back(*symbol);
+		}
+	}
+
+	for (const KeyValue<String, ExtendGDScriptParser *> &E : client->parse_results) {
+		const ExtendGDScriptParser *scr = E.value;
+		const ClassMembers &members = scr->get_members();
+		if (const LSP::DocumentSymbol *const *symbol = members.getptr(symbol_identifier)) {
+			r_list.push_back(*symbol);
+		}
+
+		for (const KeyValue<String, ClassMembers> &F : scr->get_inner_classes()) {
+			const ClassMembers *inner_class = &F.value;
+			if (const LSP::DocumentSymbol *const *symbol = inner_class->getptr(symbol_identifier)) {
+				r_list.push_back(*symbol);
+			}
+		}
+	}
+}
+
+GDScriptLanguageProtocol::LSPeer::~LSPeer() {
+	while (!parse_results.is_empty()) {
+		remove_cached_parser(parse_results.begin()->key);
+	}
+	while (!stale_parsers.is_empty()) {
+		remove_cached_parser(stale_parsers.begin()->key);
+	}
 }
 
 // clang-format off
@@ -392,8 +571,6 @@ GDScriptLanguageProtocol::GDScriptLanguageProtocol() {
 
 	SET_COMPLETION_METHOD(resolve);
 
-	SET_WORKSPACE_METHOD(didDeleteFiles);
-
 	set_method("initialize", callable_mp(this, &GDScriptLanguageProtocol::initialize));
 	set_method("initialized", callable_mp(this, &GDScriptLanguageProtocol::initialized));
 
@@ -403,3 +580,6 @@ GDScriptLanguageProtocol::GDScriptLanguageProtocol() {
 #undef SET_DOCUMENT_METHOD
 #undef SET_COMPLETION_METHOD
 #undef SET_WORKSPACE_METHOD
+
+#undef LSP_CLIENT
+#undef LSP_CLIENT_V

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -48,7 +48,6 @@ protected:
 
 private:
 	Array find_symbols(const LSP::TextDocumentPositionParams &p_location, List<const LSP::DocumentSymbol *> &r_list);
-	LSP::TextDocumentItem load_document_item(const Variant &p_param);
 	void notify_client_show_symbol(const LSP::DocumentSymbol *symbol);
 
 public:
@@ -59,7 +58,6 @@ public:
 	void didSave(const Variant &p_param);
 
 	void reload_script(Ref<GDScript> p_to_reload_script);
-	void sync_script_content(const String &p_path, const String &p_content);
 	void show_native_symbol_in_editor(const String &p_symbol_id);
 
 	Variant nativeSymbol(const Dictionary &p_params);

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "../gdscript_parser.h"
+#include "core/error/error_macros.h"
 #include "gdscript_extend_parser.h"
 #include "godot_lsp.h"
 
@@ -44,9 +44,20 @@ private:
 	void _get_owners(EditorFileSystemDirectory *efsd, String p_path, List<String> &owners);
 	Node *_get_owner_scene_node(String p_path);
 
+#ifndef DISABLE_DEPRECATED
+	void didDeleteFiles() {}
+	Error parse_script(const String &p_path, const String &p_content) {
+		WARN_DEPRECATED;
+		return Error::FAILED;
+	}
+	Error parse_local_script(const String &p_path) {
+		WARN_DEPRECATED;
+		return Error::FAILED;
+	}
+#endif // DISABLE_DEPRECATED
+
 protected:
 	static void _bind_methods();
-	void remove_cache_parser(const String &p_path);
 	bool initialized = false;
 	HashMap<StringName, LSP::DocumentSymbol> native_symbols;
 
@@ -60,9 +71,6 @@ protected:
 
 	void reload_all_workspace_scripts();
 
-	ExtendGDScriptParser *get_parse_successed_script(const String &p_path);
-	ExtendGDScriptParser *get_parse_result(const String &p_path);
-
 	void list_script_files(const String &p_root_dir, List<String> &r_files);
 
 	void apply_new_signal(Object *obj, String function, PackedStringArray args);
@@ -71,15 +79,10 @@ public:
 	String root;
 	String root_uri;
 
-	HashMap<String, ExtendGDScriptParser *> scripts;
-	HashMap<String, ExtendGDScriptParser *> parse_results;
 	HashMap<StringName, ClassMembers> native_members;
 
 public:
 	Error initialize();
-
-	Error parse_script(const String &p_path, const String &p_content);
-	Error parse_local_script(const String &p_path);
 
 	String get_file_path(const String &p_uri);
 	String get_file_uri(const String &p_path) const;
@@ -88,12 +91,11 @@ public:
 	void completion(const LSP::CompletionParams &p_params, List<ScriptLanguage::CodeCompletionOption> *r_options);
 
 	const LSP::DocumentSymbol *resolve_symbol(const LSP::TextDocumentPositionParams &p_doc_pos, const String &p_symbol_name = "", bool p_func_required = false);
-	void resolve_related_symbols(const LSP::TextDocumentPositionParams &p_doc_pos, List<const LSP::DocumentSymbol *> &r_list);
+
 	const LSP::DocumentSymbol *resolve_native_symbol(const LSP::NativeSymbolInspectParams &p_params);
 	void resolve_document_links(const String &p_uri, List<LSP::DocumentLink> &r_list);
 	Dictionary generate_script_api(const String &p_path);
 	Error resolve_signature(const LSP::TextDocumentPositionParams &p_doc_pos, LSP::SignatureHelp &r_signature);
-	void didDeleteFiles(const Dictionary &p_params);
 	Dictionary rename(const LSP::TextDocumentPositionParams &p_doc_pos, const String &new_name);
 	bool can_rename(const LSP::TextDocumentPositionParams &p_doc_pos, LSP::DocumentSymbol &r_symbol, LSP::Range &r_range);
 	Vector<LSP::Location> find_usages_in_file(const LSP::DocumentSymbol &p_symbol, const String &p_file_path);


### PR DESCRIPTION
Related to https://github.com/godotengine/godot-vscode-plugin/issues/842 (there is at least one other issue that makes the resolve not work).
Fixes https://github.com/GDQuest/zed-gdscript/issues/6

Supersedes partially https://github.com/godotengine/godot/pull/103186 (this PR includes saveguards for all methods except `willSaveWaitUntil` and `didSave` which might still do weird stuff when editing non gdscript files).

Our current approach for managing client owned content is as follows:
- when the client sends changes we parse them and cache them
- when we are interested in a file we look in the cache, if we don't have it we load it from disk

The catch: scripts with errors are cached differently, so if the client sends a change with parse errors it does not get cached correctly and subsequent requests (such as resolve) might reload the file from disk. Then the content that the server uses might not match with position information from the client which will result in early returns from the resolve endpoint.

This PR splits this solution up, by tracking client owned files separately from the parser cache (this is also relevant for https://github.com/godotengine/godot/pull/103186).

It also moves those caches to be per client, to prevent issues when multiple clients are connected.

Known issues:
- https://github.com/godotengine/godot-vscode-plugin/issues/844

TODO:
- [x] Handle compatibility
- [x] https://github.com/godotengine/godot/pull/104401 should be merged, since this PR relies on file paths to manage the index of client owned files.
- [x] https://github.com/godotengine/godot-vscode-plugin/issues/844 should be resolved, since the VSCode extension would likely break if the server enforces the protocol