### PR TITLE
Fix issue where vsproj=yes vsproj_gen_only=no sometimes fails to build

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1274,7 +1274,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
 
         props_template = props_template.replace("%%OUTPUT%%", output)
 
-        proplist = [format_key_value(v) for v in list(env["CPPDEFINES"])]
+        proplist = [format_key_value(j) for j in list(env["CPPDEFINES"])]
         proplist += [format_key_value(j) for j in env.get("VSHINT_DEFINES", [])]
         props_template = props_template.replace("%%DEFINES%%", ";".join(proplist))
 
@@ -1283,9 +1283,9 @@ def generate_vs_project(env, original_args, project_name="godot"):
         proplist += [str(j) for j in get_default_include_paths(env)]
         props_template = props_template.replace("%%INCLUDES%%", ";".join(proplist))
 
-        proplist = env["CCFLAGS"]
-        proplist += [x for x in env["CXXFLAGS"] if not x.startswith("$")]
-        proplist += [str(j) for j in env.get("VSHINT_OPTIONS", [])]
+        proplist = [env.subst("$CCFLAGS")]
+        proplist += [env.subst("$CXXFLAGS")]
+        proplist += [env.subst("$VSHINT_OPTIONS")]
         props_template = props_template.replace("%%OPTIONS%%", " ".join(proplist))
 
         # Windows allows us to have spaces in paths, so we need


### PR DESCRIPTION
Assigning `env["CCFLAGS"]` directly to a variable causes any changes to that variable to also be done to the original env object. This means CCFLAGS would be modified during generation of the VS project with additional flags and other options set by platforms.

This would normally not be noticed when just generating the project, but when generating and building at the same time with a compiler that doesn't support VS-style flags, this flag leakage can cause unexpected build failures.

The change on line 1277 is just making the temp iteration variable naming consistent for all iterators.