### PR TITLE
[Web] Add the equivalent of `-Werror` for `wasm-ld`

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -130,6 +130,10 @@ def configure(env: "SConsEnvironment"):
     ## Copy env variables.
     env["ENV"] = os.environ
 
+    # This makes `wasm-ld` treat all warnings as errors.
+    if env["werror"]:
+        env.Append(LINKFLAGS=["-Wl,--fatal-warnings"])
+
     # LTO
 
     if env["lto"] == "auto":  # Enable LTO for production.


### PR DESCRIPTION
This PR adds the linker flag `-Wl,--fatal-warnings`, which is the equivalent of `-Werror`. It will treat all warnings as errors. This will make sure that we don't build templates with `warning: function signature mismatch` (see https://github.com/godotengine/godot/issues/104497#issuecomment-2790451350), which ultimately cause issues like #104497. (seemingly caused by ThinLTO)

See https://lld.llvm.org/WebAssembly.html#function-signatures for more info about the tediousness of WASM and function signatures.