### PR TITLE
Add microphone access to `Input`

### DIFF
--- a/core/input/input.h
+++ b/core/input/input.h
@@ -103,6 +103,7 @@ private:
 	int64_t mouse_window = 0;
 	bool legacy_just_pressed_behavior = false;
 	bool disable_input = false;
+	unsigned int microphone_buffer_ofs = 0;
 
 	struct ActionState {
 		uint64_t pressed_physics_frame = UINT64_MAX;
@@ -393,6 +394,11 @@ public:
 
 	void set_disable_input(bool p_disable);
 	bool is_input_disabled() const;
+
+	Error start_microphone();
+	Error stop_microphone();
+	int get_microphone_frames_available();
+	PackedVector2Array get_microphone_buffer(int p_frames);
 
 	Input();
 	~Input();

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -183,6 +183,22 @@
 				[b]Note:[/b] For Android, [member ProjectSettings.input_devices/sensors/enable_magnetometer] must be enabled.
 			</description>
 		</method>
+		<method name="get_microphone_buffer">
+			<return type="PackedVector2Array" />
+			<param index="0" name="frames" type="int" />
+			<description>
+				Gets the next [param frames] audio samples from the internal microphone ring buffer.
+				The buffer is filled at the rate of [method AudioServer.get_input_mix_rate] frames per second after [method start_microphone] has been called.
+				Returns a [PackedVector2Array] containing exactly [param frames] audio samples if available, or an empty [PackedVector2Array] if insufficient data was available.
+				The samples are signed floating-point PCM between [code]-1[/code] and [code]1[/code]. You will have to scale them if you want to use them as 8 or 16-bit integer samples. ([code]v = 0x7fff * samples[0].x[/code])
+			</description>
+		</method>
+		<method name="get_microphone_frames_available">
+			<return type="int" />
+			<description>
+				Returns the number of frames available to read using [method get_microphone_buffer].
+			</description>
+		</method>
 		<method name="get_mouse_button_mask" qualifiers="const">
 			<return type="int" enum="MouseButtonMask" is_bitfield="true" />
 			<description>
@@ -395,11 +411,24 @@
 				[b]Note:[/b] For macOS, vibration is only supported in macOS 11 and later.
 			</description>
 		</method>
+		<method name="start_microphone">
+			<return type="int" enum="Error" />
+			<description>
+				Starts the input microphone.  Call [method get_microphone_buffer] to retrieve the values.
+				Returns [code]ERR_ALREADY_IN_USE[/code] if already running.
+			</description>
+		</method>
 		<method name="stop_joy_vibration">
 			<return type="void" />
 			<param index="0" name="device" type="int" />
 			<description>
 				Stops the vibration of the joypad started with [method start_joy_vibration].
+			</description>
+		</method>
+		<method name="stop_microphone">
+			<return type="int" enum="Error" />
+			<description>
+				Stops the input microphone.
 			</description>
 		</method>
 		<method name="vibrate_handheld">

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -762,6 +762,9 @@ void AudioDriverPulseAudio::finish_input_device() {
 }
 
 Error AudioDriverPulseAudio::input_start() {
+	if (pa_rec_str) {
+		return ERR_ALREADY_IN_USE;
+	}
 	lock();
 	Error err = init_input_device();
 	unlock();

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -1004,6 +1004,10 @@ void AudioDriverWASAPI::finish() {
 }
 
 Error AudioDriverWASAPI::input_start() {
+	if (audio_input.active.is_set()) {
+		return ERR_ALREADY_IN_USE;
+	}
+
 	Error err = init_input_device();
 	if (err != OK) {
 		ERR_PRINT("WASAPI: init_input_device error");
@@ -1023,11 +1027,9 @@ Error AudioDriverWASAPI::input_stop() {
 	if (audio_input.active.is_set()) {
 		audio_input.audio_client->Stop();
 		audio_input.active.clear();
-
-		return OK;
 	}
 
-	return FAILED;
+	return OK;
 }
 
 PackedStringArray AudioDriverWASAPI::get_input_device_list() {

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -190,12 +190,16 @@ void AudioDriverWeb::finish() {
 }
 
 Error AudioDriverWeb::input_start() {
+	if (input_started) {
+		return ERR_ALREADY_IN_USE;
+	}
 	lock();
 	input_buffer_init(buffer_length);
 	unlock();
 	if (godot_audio_input_start()) {
 		return FAILED;
 	}
+	input_started = true;
 	return OK;
 }
 
@@ -204,6 +208,7 @@ Error AudioDriverWeb::input_stop() {
 	lock();
 	input_buffer.clear();
 	unlock();
+	input_started = false;
 	return OK;
 }
 

--- a/platform/web/audio_driver_web.h
+++ b/platform/web/audio_driver_web.h
@@ -54,6 +54,7 @@ private:
 	int buffer_length = 0;
 	int mix_rate = 0;
 	int channel_count = 0;
+	bool input_started = false;
 
 	WASM_EXPORT static void _state_change_callback(int p_state);
 	WASM_EXPORT static void _latency_update_callback(float p_latency);

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -396,7 +396,7 @@ bool AudioStreamMicrophone::is_monophonic() const {
 int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 	AudioDriver::get_singleton()->lock();
 
-	Vector<int32_t> buf = AudioDriver::get_singleton()->get_input_buffer();
+	Vector<int32_t> &buf = AudioDriver::get_singleton()->get_input_buffer();
 	unsigned int input_size = AudioDriver::get_singleton()->get_input_size();
 	int mix_rate = AudioDriver::get_singleton()->get_input_mix_rate();
 	unsigned int playback_delay = MIN(((50 * mix_rate) / 1000) * 2, buf.size() >> 1);

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -109,6 +109,7 @@ void AudioDriver::input_buffer_write(int32_t sample) {
 			input_size++;
 		}
 	} else {
+		// This case could only happen if two threads were calling this function without any locking.
 		WARN_PRINT("input_buffer_write: Invalid input_position=" + itos(input_position) + " input_buffer.size()=" + itos(input_buffer.size()));
 	}
 }

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -122,7 +122,7 @@ public:
 	SpeakerMode get_speaker_mode_by_total_channels(int p_channels) const;
 	int get_total_channels_by_speaker_mode(SpeakerMode) const;
 
-	Vector<int32_t> get_input_buffer() { return input_buffer; }
+	Vector<int32_t> &get_input_buffer() { return input_buffer; }
 	unsigned int get_input_position() { return input_position; }
 	unsigned int get_input_size() { return input_size; }
 


### PR DESCRIPTION
This PR is an alternative to https://github.com/godotengine/godot/pull/100508 that answers https://github.com/godotengine/godot-proposals/issues/11347 

We add the following four functions to the `Input` singleton to manage and access the microphone data stream independently of the Audio System.

```C
Error start_microphone()
Error stop_microphone()
int get_microphone_frames_available()
PackedVector2Array get_microphone_buffer(int p_frames)
```

The current means of accessing the microphone data involves chaining the following units together in a sequence:

> `AudioStreamPlayer [ AudioStreamMicrophone ]`
> -> `AudioBus [ AudioCaptureEffect ]`
> -> `AudioOutput`

The `AudioCaptureEffect` in the middle intercepts the audio data as it flows from the source stream to the output stream copies it into a buffer.

This structure is problematic because it is locking two real-time serial devices (microphone and speakers) into the same chain so that any systematic drift between them no matter how insignificant will eventually overwhelm any buffer.

Issues that this may have caused are https://github.com/godotengine/godot/issues/80173 https://github.com/godotengine/godot/issues/95120  https://github.com/godotengine/godot/issues/86428 . The problem is most consistent on Android where the microphone will either enter an endless loop or shut down after several minutes of use.

Additional changes are made to the platform implementations of `AudioDriver.input_start()` to make them safe to call multiple times, which can happen if there is more than one `AudioStreamMicrophone` present in the project.

The full test of these functions are in the `godot-demo-projects/audio/mic_input` project of https://github.com/godotengine/godot-demo-projects/pull/1172 . This demo includes an option to push the samples straight into an `AudioStreamGenerator` to simulate a loop-back.  The observed delay is about the same (1/3 seconds) as the original case of using an `AudioStreamMicrophone` as input.

The code that extracts the buffer is as follows:

```GDScript
var recording_buffer = [ ]
var audio_sample_size = 882   # 20ms at 44.1kHz
func _process(delta : float) -> void:
    while Input.get_microphone_frames_available() >= audio_sample_size:
        var audio_samples : PackedVector2Array = Input.get_microphone_buffer(audio_sample_size)
        if audio_samples:
            recording_buffer.append(audio_samples)
```

I have tested it on Windows, Android and Linux and it is perfectly designed to work with https://github.com/goatchurchprime/two-voip-godot-4