### PR TITLE
Fix BBCode print with nested `[`.

### DIFF
--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -257,7 +257,8 @@ void __print_line_rich(const String &p_string) {
 		} else if (tag == "/fgcolor") {
 			output += "\u001b[39;49m";
 		} else {
-			output += vformat("[%s]", tag);
+			output += "[";
+			pos = brk_pos + 1;
 		}
 	}
 	output += "\u001b[0m"; // Reset.


### PR DESCRIPTION
Before:
<img width="348" alt="Screenshot 2025-04-10 at 19 55 21" src="https://github.com/user-attachments/assets/9bb7a36c-7a74-4505-993d-cf49164714cf" />


After:
<img width="260" alt="Screenshot 2025-04-10 at 19 13 51" src="https://github.com/user-attachments/assets/bb023129-5452-4feb-9660-a068efa92c98" />
