### PR TITLE
Core: Use `Math` namespace for constants

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -4331,10 +4331,10 @@ Dictionary Image::compute_image_metrics(const Ref<Image> p_compared_image, bool 
 	// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 	Dictionary result;
-	result["max"] = INFINITY;
-	result["mean"] = INFINITY;
-	result["mean_squared"] = INFINITY;
-	result["root_mean_squared"] = INFINITY;
+	result["max"] = Math::INF;
+	result["mean"] = Math::INF;
+	result["mean_squared"] = Math::INF;
+	result["root_mean_squared"] = Math::INF;
 	result["peak_snr"] = 0.0f;
 
 	ERR_FAIL_COND_V(p_compared_image.is_null(), result);

--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -48,7 +48,7 @@ static real_t heuristic_manhattan(const Vector2i &p_from, const Vector2i &p_to) 
 static real_t heuristic_octile(const Vector2i &p_from, const Vector2i &p_to) {
 	real_t dx = (real_t)Math::abs(p_to.x - p_from.x);
 	real_t dy = (real_t)Math::abs(p_to.y - p_from.y);
-	real_t F = Math_SQRT2 - 1;
+	real_t F = Math::SQRT2 - 1;
 	return (dx < dy) ? F * dx + dy : F * dy + dx;
 }
 

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -186,7 +186,7 @@ Basis Basis::diagonalize() {
 		// Compute the rotation angle
 		real_t angle;
 		if (Math::is_equal_approx(rows[j][j], rows[i][i])) {
-			angle = Math_PI / 4;
+			angle = Math::PI / 4;
 		} else {
 			angle = 0.5f * Math::atan(2 * rows[i][j] / (rows[j][j] - rows[i][i]));
 		}
@@ -486,12 +486,12 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 					}
 				} else {
 					euler.x = Math::atan2(rows[2][1], rows[1][1]);
-					euler.y = -Math_PI / 2.0f;
+					euler.y = -Math::PI / 2.0f;
 					euler.z = 0.0f;
 				}
 			} else {
 				euler.x = Math::atan2(rows[2][1], rows[1][1]);
-				euler.y = Math_PI / 2.0f;
+				euler.y = Math::PI / 2.0f;
 				euler.z = 0.0f;
 			}
 			return euler;
@@ -515,13 +515,13 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 					// It's -1
 					euler.x = -Math::atan2(rows[1][2], rows[2][2]);
 					euler.y = 0.0f;
-					euler.z = Math_PI / 2.0f;
+					euler.z = Math::PI / 2.0f;
 				}
 			} else {
 				// It's 1
 				euler.x = -Math::atan2(rows[1][2], rows[2][2]);
 				euler.y = 0.0f;
-				euler.z = -Math_PI / 2.0f;
+				euler.z = -Math::PI / 2.0f;
 			}
 			return euler;
 		}
@@ -551,12 +551,12 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 						euler.z = atan2(rows[1][0], rows[1][1]);
 					}
 				} else { // m12 == -1
-					euler.x = Math_PI * 0.5f;
+					euler.x = Math::PI * 0.5f;
 					euler.y = atan2(rows[0][1], rows[0][0]);
 					euler.z = 0;
 				}
 			} else { // m12 == 1
-				euler.x = -Math_PI * 0.5f;
+				euler.x = -Math::PI * 0.5f;
 				euler.y = -atan2(rows[0][1], rows[0][0]);
 				euler.z = 0;
 			}
@@ -582,13 +582,13 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 					// It's -1
 					euler.x = Math::atan2(rows[2][1], rows[2][2]);
 					euler.y = 0.0f;
-					euler.z = -Math_PI / 2.0f;
+					euler.z = -Math::PI / 2.0f;
 				}
 			} else {
 				// It's 1
 				euler.x = Math::atan2(rows[2][1], rows[2][2]);
 				euler.y = 0.0f;
-				euler.z = Math_PI / 2.0f;
+				euler.z = Math::PI / 2.0f;
 			}
 			return euler;
 		} break;
@@ -608,13 +608,13 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 					euler.z = Math::atan2(-rows[0][1], rows[1][1]);
 				} else {
 					// It's -1
-					euler.x = -Math_PI / 2.0f;
+					euler.x = -Math::PI / 2.0f;
 					euler.y = Math::atan2(rows[0][2], rows[0][0]);
 					euler.z = 0;
 				}
 			} else {
 				// It's 1
-				euler.x = Math_PI / 2.0f;
+				euler.x = Math::PI / 2.0f;
 				euler.y = Math::atan2(rows[0][2], rows[0][0]);
 				euler.z = 0;
 			}
@@ -637,13 +637,13 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 				} else {
 					// It's -1
 					euler.x = 0;
-					euler.y = Math_PI / 2.0f;
+					euler.y = Math::PI / 2.0f;
 					euler.z = -Math::atan2(rows[0][1], rows[1][1]);
 				}
 			} else {
 				// It's 1
 				euler.x = 0;
-				euler.y = -Math_PI / 2.0f;
+				euler.y = -Math::PI / 2.0f;
 				euler.z = -Math::atan2(rows[0][1], rows[1][1]);
 			}
 			return euler;
@@ -778,8 +778,8 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 		if ((xx > yy) && (xx > zz)) { // rows[0][0] is the largest diagonal term.
 			if (xx < CMP_EPSILON) {
 				x = 0;
-				y = Math_SQRT12;
-				z = Math_SQRT12;
+				y = Math::SQRT12;
+				z = Math::SQRT12;
 			} else {
 				x = Math::sqrt(xx);
 				y = xy / x;
@@ -787,9 +787,9 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 			}
 		} else if (yy > zz) { // rows[1][1] is the largest diagonal term.
 			if (yy < CMP_EPSILON) {
-				x = Math_SQRT12;
+				x = Math::SQRT12;
 				y = 0;
-				z = Math_SQRT12;
+				z = Math::SQRT12;
 			} else {
 				y = Math::sqrt(yy);
 				x = xy / y;
@@ -797,8 +797,8 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 			}
 		} else { // rows[2][2] is the largest diagonal term so base result on this.
 			if (zz < CMP_EPSILON) {
-				x = Math_SQRT12;
-				y = Math_SQRT12;
+				x = Math::SQRT12;
+				y = Math::SQRT12;
 				z = 0;
 			} else {
 				z = Math::sqrt(zz);
@@ -807,7 +807,7 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 			}
 		}
 		r_axis = Vector3(x, y, z);
-		r_angle = Math_PI;
+		r_angle = Math::PI;
 		return;
 	}
 	// As we have reached here there are no singularities so we can handle normally.

--- a/core/math/dynamic_bvh.cpp
+++ b/core/math/dynamic_bvh.cpp
@@ -181,7 +181,7 @@ DynamicBVH::Volume DynamicBVH::_bounds(Node **leaves, int p_count) {
 
 void DynamicBVH::_bottom_up(Node **leaves, int p_count) {
 	while (p_count > 1) {
-		real_t minsize = INFINITY;
+		real_t minsize = Math::INF;
 		int minidx[2] = { -1, -1 };
 		for (int i = 0; i < p_count; ++i) {
 			for (int j = i + 1; j < p_count; ++j) {

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -454,16 +454,16 @@ Error Expression::_get_token(Token &r_token) {
 						r_token.value = false;
 					} else if (id == "PI") {
 						r_token.type = TK_CONSTANT;
-						r_token.value = Math_PI;
+						r_token.value = Math::PI;
 					} else if (id == "TAU") {
 						r_token.type = TK_CONSTANT;
-						r_token.value = Math_TAU;
+						r_token.value = Math::TAU;
 					} else if (id == "INF") {
 						r_token.type = TK_CONSTANT;
-						r_token.value = INFINITY;
+						r_token.value = Math::INF;
 					} else if (id == "NAN") {
 						r_token.type = TK_CONSTANT;
-						r_token.value = NAN;
+						r_token.value = Math::NaN;
 					} else if (id == "not") {
 						r_token.type = TK_OP_NOT;
 					} else if (id == "or") {

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -744,7 +744,7 @@ Vector<Plane> Geometry3D::build_cylinder_planes(real_t p_radius, real_t p_height
 
 	Vector<Plane> planes;
 
-	const double sides_step = Math_TAU / p_sides;
+	const double sides_step = Math::TAU / p_sides;
 	for (int i = 0; i < p_sides; i++) {
 		Vector3 normal;
 		normal[(p_axis + 1) % 3] = Math::cos(i * sides_step);
@@ -775,7 +775,7 @@ Vector<Plane> Geometry3D::build_sphere_planes(real_t p_radius, int p_lats, int p
 	axis_neg[(p_axis + 2) % 3] = 1.0;
 	axis_neg[p_axis] = -1.0;
 
-	const double lon_step = Math_TAU / p_lons;
+	const double lon_step = Math::TAU / p_lons;
 	for (int i = 0; i < p_lons; i++) {
 		Vector3 normal;
 		normal[(p_axis + 1) % 3] = Math::cos(i * lon_step);
@@ -806,7 +806,7 @@ Vector<Plane> Geometry3D::build_capsule_planes(real_t p_radius, real_t p_height,
 	axis_neg[(p_axis + 2) % 3] = 1.0;
 	axis_neg[p_axis] = -1.0;
 
-	const double sides_step = Math_TAU / p_sides;
+	const double sides_step = Math::TAU / p_sides;
 	for (int i = 0; i < p_sides; i++) {
 		Vector3 normal;
 		normal[(p_axis + 1) % 3] = Math::cos(i * sides_step);
@@ -862,7 +862,6 @@ Vector<Vector3> Geometry3D::compute_convex_mesh_points(const Plane *p_planes, in
 }
 
 #define square(m_s) ((m_s) * (m_s))
-#define INF 1e20
 
 /* dt of 1d function using squared distance */
 static void edt(float *f, int stride, int n) {
@@ -872,8 +871,8 @@ static void edt(float *f, int stride, int n) {
 
 	int k = 0;
 	v[0] = 0;
-	z[0] = -INF;
-	z[1] = +INF;
+	z[0] = -Math::INF;
+	z[1] = +Math::INF;
 	for (int q = 1; q <= n - 1; q++) {
 		float s = ((f[q * stride] + square(q)) - (f[v[k] * stride] + square(v[k]))) / (2 * q - 2 * v[k]);
 		while (s <= z[k]) {
@@ -884,7 +883,7 @@ static void edt(float *f, int stride, int n) {
 		v[k] = q;
 
 		z[k] = s;
-		z[k + 1] = +INF;
+		z[k + 1] = +Math::INF;
 	}
 
 	k = 0;
@@ -909,7 +908,7 @@ Vector<uint32_t> Geometry3D::generate_edf(const Vector<bool> &p_voxels, const Ve
 
 	float *work_memory = memnew_arr(float, float_count);
 	for (uint32_t i = 0; i < float_count; i++) {
-		work_memory[i] = INF;
+		work_memory[i] = Math::INF;
 	}
 
 	uint32_t y_mult = p_size.x;

--- a/core/math/math_defs.h
+++ b/core/math/math_defs.h
@@ -30,18 +30,28 @@
 
 #pragma once
 
+#include "core/typedefs.h"
+
+#include <limits>
+
+namespace Math {
+inline constexpr double SQRT2 = 1.4142135623730950488016887242;
+inline constexpr double SQRT3 = 1.7320508075688772935274463415059;
+inline constexpr double SQRT12 = 0.7071067811865475244008443621048490;
+inline constexpr double SQRT13 = 0.57735026918962576450914878050196;
+inline constexpr double LN2 = 0.6931471805599453094172321215;
+inline constexpr double TAU = 6.2831853071795864769252867666;
+inline constexpr double PI = 3.1415926535897932384626433833;
+inline constexpr double E = 2.7182818284590452353602874714;
+inline constexpr double INF = std::numeric_limits<double>::infinity();
+inline constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
+} // namespace Math
+
 #define CMP_EPSILON 0.00001
 #define CMP_EPSILON2 (CMP_EPSILON * CMP_EPSILON)
 
 #define CMP_NORMALIZE_TOLERANCE 0.000001
 #define CMP_POINT_IN_PLANE_EPSILON 0.00001
-
-#define Math_SQRT12 0.7071067811865475244008443621048490
-#define Math_SQRT2 1.4142135623730950488016887242
-#define Math_LN2 0.6931471805599453094172321215
-#define Math_TAU 6.2831853071795864769252867666
-#define Math_PI 3.1415926535897932384626433833
-#define Math_E 2.7182818284590452353602874714
 
 #ifdef DEBUG_ENABLED
 #define MATH_CHECKS

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -75,10 +75,10 @@ _ALWAYS_INLINE_ float sinc(float p_x) {
 }
 
 _ALWAYS_INLINE_ double sincn(double p_x) {
-	return sinc(Math_PI * p_x);
+	return sinc(PI * p_x);
 }
 _ALWAYS_INLINE_ float sincn(float p_x) {
-	return sinc((float)Math_PI * p_x);
+	return sinc((float)PI * p_x);
 }
 
 _ALWAYS_INLINE_ double cosh(double p_x) {
@@ -97,18 +97,18 @@ _ALWAYS_INLINE_ float tanh(float p_x) {
 
 // Always does clamping so always safe to use.
 _ALWAYS_INLINE_ double asin(double p_x) {
-	return p_x < -1 ? (-Math_PI / 2) : (p_x > 1 ? (Math_PI / 2) : ::asin(p_x));
+	return p_x < -1 ? (-PI / 2) : (p_x > 1 ? (PI / 2) : ::asin(p_x));
 }
 _ALWAYS_INLINE_ float asin(float p_x) {
-	return p_x < -1 ? (-Math_PI / 2) : (p_x > 1 ? (Math_PI / 2) : ::asinf(p_x));
+	return p_x < -1 ? (-(float)PI / 2) : (p_x > 1 ? ((float)PI / 2) : ::asinf(p_x));
 }
 
 // Always does clamping so always safe to use.
 _ALWAYS_INLINE_ double acos(double p_x) {
-	return p_x < -1 ? Math_PI : (p_x > 1 ? 0 : ::acos(p_x));
+	return p_x < -1 ? PI : (p_x > 1 ? 0 : ::acos(p_x));
 }
 _ALWAYS_INLINE_ float acos(float p_x) {
-	return p_x < -1 ? Math_PI : (p_x > 1 ? 0 : ::acosf(p_x));
+	return p_x < -1 ? (float)PI : (p_x > 1 ? 0 : ::acosf(p_x));
 }
 
 _ALWAYS_INLINE_ double atan(double p_x) {
@@ -142,10 +142,10 @@ _ALWAYS_INLINE_ float acosh(float p_x) {
 
 // Always does clamping so always safe to use.
 _ALWAYS_INLINE_ double atanh(double p_x) {
-	return p_x <= -1 ? -INFINITY : (p_x >= 1 ? INFINITY : ::atanh(p_x));
+	return p_x <= -1 ? -INF : (p_x >= 1 ? INF : ::atanh(p_x));
 }
 _ALWAYS_INLINE_ float atanh(float p_x) {
-	return p_x <= -1 ? -INFINITY : (p_x >= 1 ? INFINITY : ::atanhf(p_x));
+	return p_x <= -1 ? (float)-INF : (p_x >= 1 ? (float)INF : ::atanhf(p_x));
 }
 
 _ALWAYS_INLINE_ double sqrt(double p_x) {
@@ -383,17 +383,17 @@ _ALWAYS_INLINE_ int64_t posmod(int64_t p_x, int64_t p_y) {
 }
 
 _ALWAYS_INLINE_ double deg_to_rad(double p_y) {
-	return p_y * (Math_PI / 180.0);
+	return p_y * (PI / 180.0);
 }
 _ALWAYS_INLINE_ float deg_to_rad(float p_y) {
-	return p_y * (float)(Math_PI / 180.0);
+	return p_y * ((float)PI / 180.0f);
 }
 
 _ALWAYS_INLINE_ double rad_to_deg(double p_y) {
-	return p_y * (180.0 / Math_PI);
+	return p_y * (180.0 / PI);
 }
 _ALWAYS_INLINE_ float rad_to_deg(float p_y) {
-	return p_y * (float)(180.0 / Math_PI);
+	return p_y * (180.0f / (float)PI);
 }
 
 _ALWAYS_INLINE_ double lerp(double p_from, double p_to, double p_weight) {
@@ -419,31 +419,31 @@ _ALWAYS_INLINE_ float cubic_interpolate(float p_from, float p_to, float p_pre, f
 }
 
 _ALWAYS_INLINE_ double cubic_interpolate_angle(double p_from, double p_to, double p_pre, double p_post, double p_weight) {
-	double from_rot = fmod(p_from, Math_TAU);
+	double from_rot = fmod(p_from, TAU);
 
-	double pre_diff = fmod(p_pre - from_rot, Math_TAU);
-	double pre_rot = from_rot + fmod(2.0 * pre_diff, Math_TAU) - pre_diff;
+	double pre_diff = fmod(p_pre - from_rot, TAU);
+	double pre_rot = from_rot + fmod(2.0 * pre_diff, TAU) - pre_diff;
 
-	double to_diff = fmod(p_to - from_rot, Math_TAU);
-	double to_rot = from_rot + fmod(2.0 * to_diff, Math_TAU) - to_diff;
+	double to_diff = fmod(p_to - from_rot, TAU);
+	double to_rot = from_rot + fmod(2.0 * to_diff, TAU) - to_diff;
 
-	double post_diff = fmod(p_post - to_rot, Math_TAU);
-	double post_rot = to_rot + fmod(2.0 * post_diff, Math_TAU) - post_diff;
+	double post_diff = fmod(p_post - to_rot, TAU);
+	double post_rot = to_rot + fmod(2.0 * post_diff, TAU) - post_diff;
 
 	return cubic_interpolate(from_rot, to_rot, pre_rot, post_rot, p_weight);
 }
 
 _ALWAYS_INLINE_ float cubic_interpolate_angle(float p_from, float p_to, float p_pre, float p_post, float p_weight) {
-	float from_rot = fmod(p_from, (float)Math_TAU);
+	float from_rot = fmod(p_from, (float)TAU);
 
-	float pre_diff = fmod(p_pre - from_rot, (float)Math_TAU);
-	float pre_rot = from_rot + fmod(2.0f * pre_diff, (float)Math_TAU) - pre_diff;
+	float pre_diff = fmod(p_pre - from_rot, (float)TAU);
+	float pre_rot = from_rot + fmod(2.0f * pre_diff, (float)TAU) - pre_diff;
 
-	float to_diff = fmod(p_to - from_rot, (float)Math_TAU);
-	float to_rot = from_rot + fmod(2.0f * to_diff, (float)Math_TAU) - to_diff;
+	float to_diff = fmod(p_to - from_rot, (float)TAU);
+	float to_rot = from_rot + fmod(2.0f * to_diff, (float)TAU) - to_diff;
 
-	float post_diff = fmod(p_post - to_rot, (float)Math_TAU);
-	float post_rot = to_rot + fmod(2.0f * post_diff, (float)Math_TAU) - post_diff;
+	float post_diff = fmod(p_post - to_rot, (float)TAU);
+	float post_rot = to_rot + fmod(2.0f * post_diff, (float)TAU) - post_diff;
 
 	return cubic_interpolate(from_rot, to_rot, pre_rot, post_rot, p_weight);
 }
@@ -473,31 +473,31 @@ _ALWAYS_INLINE_ float cubic_interpolate_in_time(float p_from, float p_to, float 
 
 _ALWAYS_INLINE_ double cubic_interpolate_angle_in_time(double p_from, double p_to, double p_pre, double p_post, double p_weight,
 		double p_to_t, double p_pre_t, double p_post_t) {
-	double from_rot = fmod(p_from, Math_TAU);
+	double from_rot = fmod(p_from, TAU);
 
-	double pre_diff = fmod(p_pre - from_rot, Math_TAU);
-	double pre_rot = from_rot + fmod(2.0 * pre_diff, Math_TAU) - pre_diff;
+	double pre_diff = fmod(p_pre - from_rot, TAU);
+	double pre_rot = from_rot + fmod(2.0 * pre_diff, TAU) - pre_diff;
 
-	double to_diff = fmod(p_to - from_rot, Math_TAU);
-	double to_rot = from_rot + fmod(2.0 * to_diff, Math_TAU) - to_diff;
+	double to_diff = fmod(p_to - from_rot, TAU);
+	double to_rot = from_rot + fmod(2.0 * to_diff, TAU) - to_diff;
 
-	double post_diff = fmod(p_post - to_rot, Math_TAU);
-	double post_rot = to_rot + fmod(2.0 * post_diff, Math_TAU) - post_diff;
+	double post_diff = fmod(p_post - to_rot, TAU);
+	double post_rot = to_rot + fmod(2.0 * post_diff, TAU) - post_diff;
 
 	return cubic_interpolate_in_time(from_rot, to_rot, pre_rot, post_rot, p_weight, p_to_t, p_pre_t, p_post_t);
 }
 _ALWAYS_INLINE_ float cubic_interpolate_angle_in_time(float p_from, float p_to, float p_pre, float p_post, float p_weight,
 		float p_to_t, float p_pre_t, float p_post_t) {
-	float from_rot = fmod(p_from, (float)Math_TAU);
+	float from_rot = fmod(p_from, (float)TAU);
 
-	float pre_diff = fmod(p_pre - from_rot, (float)Math_TAU);
-	float pre_rot = from_rot + fmod(2.0f * pre_diff, (float)Math_TAU) - pre_diff;
+	float pre_diff = fmod(p_pre - from_rot, (float)TAU);
+	float pre_rot = from_rot + fmod(2.0f * pre_diff, (float)TAU) - pre_diff;
 
-	float to_diff = fmod(p_to - from_rot, (float)Math_TAU);
-	float to_rot = from_rot + fmod(2.0f * to_diff, (float)Math_TAU) - to_diff;
+	float to_diff = fmod(p_to - from_rot, (float)TAU);
+	float to_rot = from_rot + fmod(2.0f * to_diff, (float)TAU) - to_diff;
 
-	float post_diff = fmod(p_post - to_rot, (float)Math_TAU);
-	float post_rot = to_rot + fmod(2.0f * post_diff, (float)Math_TAU) - post_diff;
+	float post_diff = fmod(p_post - to_rot, (float)TAU);
+	float post_rot = to_rot + fmod(2.0f * post_diff, (float)TAU) - post_diff;
 
 	return cubic_interpolate_in_time(from_rot, to_rot, pre_rot, post_rot, p_weight, p_to_t, p_pre_t, p_post_t);
 }
@@ -543,12 +543,12 @@ _ALWAYS_INLINE_ float bezier_derivative(float p_start, float p_control_1, float 
 }
 
 _ALWAYS_INLINE_ double angle_difference(double p_from, double p_to) {
-	double difference = fmod(p_to - p_from, Math_TAU);
-	return fmod(2.0 * difference, Math_TAU) - difference;
+	double difference = fmod(p_to - p_from, TAU);
+	return fmod(2.0 * difference, TAU) - difference;
 }
 _ALWAYS_INLINE_ float angle_difference(float p_from, float p_to) {
-	float difference = fmod(p_to - p_from, (float)Math_TAU);
-	return fmod(2.0f * difference, (float)Math_TAU) - difference;
+	float difference = fmod(p_to - p_from, (float)TAU);
+	return fmod(2.0f * difference, (float)TAU) - difference;
 }
 
 _ALWAYS_INLINE_ double lerp_angle(double p_from, double p_to, double p_weight) {
@@ -662,13 +662,13 @@ _ALWAYS_INLINE_ double rotate_toward(double p_from, double p_to, double p_delta)
 	double difference = angle_difference(p_from, p_to);
 	double abs_difference = abs(difference);
 	// When `p_delta < 0` move no further than to PI radians away from `p_to` (as PI is the max possible angle distance).
-	return p_from + CLAMP(p_delta, abs_difference - Math_PI, abs_difference) * (difference >= 0.0 ? 1.0 : -1.0);
+	return p_from + CLAMP(p_delta, abs_difference - PI, abs_difference) * (difference >= 0.0 ? 1.0 : -1.0);
 }
 _ALWAYS_INLINE_ float rotate_toward(float p_from, float p_to, float p_delta) {
 	float difference = angle_difference(p_from, p_to);
 	float abs_difference = abs(difference);
 	// When `p_delta < 0` move no further than to PI radians away from `p_to` (as PI is the max possible angle distance).
-	return p_from + CLAMP(p_delta, abs_difference - (float)Math_PI, abs_difference) * (difference >= 0.0f ? 1.0f : -1.0f);
+	return p_from + CLAMP(p_delta, abs_difference - (float)PI, abs_difference) * (difference >= 0.0f ? 1.0f : -1.0f);
 }
 
 _ALWAYS_INLINE_ double linear_to_db(double p_linear) {

--- a/core/math/random_pcg.h
+++ b/core/math/random_pcg.h
@@ -134,14 +134,14 @@ public:
 		if (temp < CMP_EPSILON) {
 			temp += CMP_EPSILON; // To prevent generating of INF value in log function, resulting to return NaN value from this function.
 		}
-		return p_mean + p_deviation * (cos(Math_TAU * randd()) * sqrt(-2.0 * log(temp))); // Box-Muller transform.
+		return p_mean + p_deviation * (cos(Math::TAU * randd()) * sqrt(-2.0 * log(temp))); // Box-Muller transform.
 	}
 	_FORCE_INLINE_ float randfn(float p_mean, float p_deviation) {
 		float temp = randf();
 		if (temp < CMP_EPSILON) {
 			temp += CMP_EPSILON; // To prevent generating of INF value in log function, resulting to return NaN value from this function.
 		}
-		return p_mean + p_deviation * (cos((float)Math_TAU * randf()) * sqrt(-2.0 * log(temp))); // Box-Muller transform.
+		return p_mean + p_deviation * (cos((float)Math::TAU * randf()) * sqrt(-2.0 * log(temp))); // Box-Muller transform.
 	}
 
 	double random(double p_from, double p_to);

--- a/core/math/static_raycaster.h
+++ b/core/math/static_raycaster.h
@@ -51,7 +51,7 @@ public:
 		_FORCE_INLINE_ Ray(const Vector3 &p_org,
 				const Vector3 &p_dir,
 				float p_tnear = 0.0f,
-				float p_tfar = INFINITY) :
+				float p_tfar = Math::INF) :
 				org(p_org),
 				tnear(p_tnear),
 				dir(p_dir),

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -71,12 +71,12 @@ void Transform2D::rotate(real_t p_angle) {
 
 real_t Transform2D::get_skew() const {
 	real_t det = determinant();
-	return Math::acos(columns[0].normalized().dot(SIGN(det) * columns[1].normalized())) - (real_t)Math_PI * 0.5f;
+	return Math::acos(columns[0].normalized().dot(SIGN(det) * columns[1].normalized())) - (real_t)Math::PI * 0.5f;
 }
 
 void Transform2D::set_skew(real_t p_angle) {
 	real_t det = determinant();
-	columns[1] = SIGN(det) * columns[0].rotated(((real_t)Math_PI * 0.5f + p_angle)).normalized() * columns[1].length();
+	columns[1] = SIGN(det) * columns[0].rotated(((real_t)Math::PI * 0.5f + p_angle)).normalized() * columns[1].length();
 }
 
 real_t Transform2D::get_rotation() const {

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -149,7 +149,7 @@ static _FORCE_INLINE_ uint32_t hash_murmur3_one_float(float p_in, uint32_t p_see
 	if (p_in == 0.0f) {
 		u.f = 0.0;
 	} else if (Math::is_nan(p_in)) {
-		u.f = NAN;
+		u.f = Math::NaN;
 	} else {
 		u.f = p_in;
 	}
@@ -172,7 +172,7 @@ static _FORCE_INLINE_ uint32_t hash_murmur3_one_double(double p_in, uint32_t p_s
 	if (p_in == 0.0f) {
 		u.d = 0.0;
 	} else if (Math::is_nan(p_in)) {
-		u.d = NAN;
+		u.d = Math::NaN;
 	} else {
 		u.d = p_in;
 	}
@@ -260,7 +260,7 @@ static _FORCE_INLINE_ uint32_t hash_djb2_one_float(double p_in, uint32_t p_prev 
 	if (p_in == 0.0f) {
 		u.d = 0.0;
 	} else if (Math::is_nan(p_in)) {
-		u.d = NAN;
+		u.d = Math::NaN;
 	} else {
 		u.d = p_in;
 	}
@@ -289,7 +289,7 @@ static _FORCE_INLINE_ uint64_t hash_djb2_one_float_64(double p_in, uint64_t p_pr
 	if (p_in == 0.0f) {
 		u.d = 0.0;
 	} else if (Math::is_nan(p_in)) {
-		u.d = NAN;
+		u.d = Math::NaN;
 	} else {
 		u.d = p_in;
 	}

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2740,7 +2740,7 @@ static void _register_variant_builtin_constants() {
 
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ZERO", Vector3(0, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ONE", Vector3(1, 1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "INF", Vector3(INFINITY, INFINITY, INFINITY));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "INF", Vector3(Math::INF, Math::INF, Math::INF));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "LEFT", Vector3(-1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "RIGHT", Vector3(1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "UP", Vector3(0, 1, 0));
@@ -2762,7 +2762,7 @@ static void _register_variant_builtin_constants() {
 
 	_VariantCall::add_variant_constant(Variant::VECTOR4, "ZERO", Vector4(0, 0, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR4, "ONE", Vector4(1, 1, 1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR4, "INF", Vector4(INFINITY, INFINITY, INFINITY, INFINITY));
+	_VariantCall::add_variant_constant(Variant::VECTOR4, "INF", Vector4(Math::INF, Math::INF, Math::INF, Math::INF));
 
 	_VariantCall::add_enum_constant(Variant::VECTOR3I, "Axis", "AXIS_X", Vector3i::AXIS_X);
 	_VariantCall::add_enum_constant(Variant::VECTOR3I, "Axis", "AXIS_Y", Vector3i::AXIS_Y);
@@ -2797,7 +2797,7 @@ static void _register_variant_builtin_constants() {
 
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "ZERO", Vector2(0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "ONE", Vector2(1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "INF", Vector2(INFINITY, INFINITY));
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "INF", Vector2(Math::INF, Math::INF));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "LEFT", Vector2(-1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "RIGHT", Vector2(1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "UP", Vector2(0, -1));

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -147,12 +147,12 @@ const char *VariantParser::tk_name[TK_MAX] = {
 
 static double stor_fix(const String &p_str) {
 	if (p_str == "inf") {
-		return INFINITY;
+		return Math::INF;
 	} else if (p_str == "-inf" || p_str == "inf_neg") {
 		// inf_neg kept for compatibility.
-		return -INFINITY;
+		return -Math::INF;
 	} else if (p_str == "nan") {
-		return NAN;
+		return Math::NaN;
 	}
 	return -1;
 }
@@ -698,12 +698,12 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 		} else if (id == "null" || id == "nil") {
 			value = Variant();
 		} else if (id == "inf") {
-			value = INFINITY;
+			value = Math::INF;
 		} else if (id == "-inf" || id == "inf_neg") {
 			// inf_neg kept for compatibility.
-			value = -INFINITY;
+			value = -Math::INF;
 		} else if (id == "nan") {
-			value = NAN;
+			value = Math::NaN;
 		} else if (id == "Vector2") {
 			Vector<real_t> args;
 			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);

--- a/drivers/gles3/effects/cubemap_filter.cpp
+++ b/drivers/gles3/effects/cubemap_filter.cpp
@@ -91,7 +91,7 @@ CubemapFilter::~CubemapFilter() {
 
 Vector3 importance_sample_GGX(Vector2 xi, float roughness4) {
 	// Compute distribution direction
-	float phi = 2.0 * Math_PI * xi.x;
+	float phi = 2.0 * Math::PI * xi.x;
 	float cos_theta = sqrt((1.0 - xi.y) / (1.0 + (roughness4 - 1.0) * xi.y));
 	float sin_theta = sqrt(1.0 - cos_theta * cos_theta);
 
@@ -107,7 +107,7 @@ Vector3 importance_sample_GGX(Vector2 xi, float roughness4) {
 float distribution_GGX(float NdotH, float roughness4) {
 	float NdotH2 = NdotH * NdotH;
 	float denom = (NdotH2 * (roughness4 - 1.0) + 1.0);
-	denom = Math_PI * denom * denom;
+	denom = Math::PI * denom * denom;
 
 	return roughness4 / denom;
 }
@@ -157,7 +157,7 @@ void CubemapFilter::filter_radiance(GLuint p_source_cubemap, GLuint p_dest_cubem
 		float roughness4 = roughness * roughness;
 		roughness4 *= roughness4;
 
-		float solid_angle_texel = 4.0 * Math_PI / float(6 * size * size);
+		float solid_angle_texel = 4.0 * Math::PI / float(6 * size * size);
 
 		LocalVector<float> sample_directions;
 		sample_directions.resize(4 * sample_count);

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1692,7 +1692,7 @@ void RasterizerCanvasGLES3::light_update_shadow(RID p_rid, int p_shadow_index, c
 	}
 
 	// Precomputed:
-	// Vector3 cam_target = Basis::from_euler(Vector3(0, 0, Math_TAU * ((i + 3) / 4.0))).xform(Vector3(0, 1, 0));
+	// Vector3 cam_target = Basis::from_euler(Vector3(0, 0, Math::TAU * ((i + 3) / 4.0))).xform(Vector3(0, 1, 0));
 	// projection = projection * Projection(Transform3D().looking_at(cam_targets[i], Vector3(0, 0, -1)).affine_inverse());
 	const Projection projections[4] = {
 		projection * Projection(Vector4(0, 0, -1, 0), Vector4(1, 0, 0, 0), Vector4(0, -1, 0, 0), Vector4(0, 0, 0, 1)),

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1672,7 +1672,7 @@ void RasterizerSceneGLES3::_setup_lights(const RenderDataGLES3 *p_render_data, b
 				if (is_using_physical_light_units()) {
 					light_data.energy *= light_storage->light_get_param(base, RS::LIGHT_PARAM_INTENSITY);
 				} else {
-					light_data.energy *= Math_PI;
+					light_data.energy *= Math::PI;
 				}
 
 				if (p_render_data->camera_attributes.is_valid()) {
@@ -1862,14 +1862,14 @@ void RasterizerSceneGLES3::_setup_lights(const RenderDataGLES3 *p_render_data, b
 
 			// Convert from Luminous Power to Luminous Intensity
 			if (type == RS::LIGHT_OMNI) {
-				energy *= 1.0 / (Math_PI * 4.0);
+				energy *= 1.0 / (Math::PI * 4.0);
 			} else {
 				// Spot Lights are not physically accurate, Luminous Intensity should change in relation to the cone angle.
 				// We make this assumption to keep them easy to control.
-				energy *= 1.0 / Math_PI;
+				energy *= 1.0 / Math::PI;
 			}
 		} else {
-			energy *= Math_PI;
+			energy *= Math::PI;
 		}
 
 		if (p_render_data->camera_attributes.is_valid()) {

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1143,9 +1143,9 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["CANVAS_MATRIX"] = "canvas_transform";
 		actions.renames["SCREEN_MATRIX"] = "screen_transform";
 		actions.renames["TIME"] = "time";
-		actions.renames["PI"] = _MKSTR(Math_PI);
-		actions.renames["TAU"] = _MKSTR(Math_TAU);
-		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["PI"] = _MKSTR(Math::PI);
+		actions.renames["TAU"] = _MKSTR(Math::TAU);
+		actions.renames["E"] = _MKSTR(Math::E);
 		actions.renames["AT_LIGHT_PASS"] = "false";
 		actions.renames["INSTANCE_CUSTOM"] = "instance_custom";
 
@@ -1238,9 +1238,9 @@ MaterialStorage::MaterialStorage() {
 
 		actions.renames["TIME"] = "scene_data.time";
 		actions.renames["EXPOSURE"] = "(1.0 / scene_data.emissive_exposure_normalization)";
-		actions.renames["PI"] = _MKSTR(Math_PI);
-		actions.renames["TAU"] = _MKSTR(Math_TAU);
-		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["PI"] = _MKSTR(Math::PI);
+		actions.renames["TAU"] = _MKSTR(Math::TAU);
+		actions.renames["E"] = _MKSTR(Math::E);
 		actions.renames["OUTPUT_IS_SRGB"] = "SHADER_IS_SRGB";
 		actions.renames["CLIP_SPACE_FAR"] = "SHADER_SPACE_FAR";
 		actions.renames["VIEWPORT_SIZE"] = "scene_data.viewport_size";
@@ -1406,9 +1406,9 @@ MaterialStorage::MaterialStorage() {
 		}
 		actions.renames["TRANSFORM"] = "xform";
 		actions.renames["TIME"] = "time";
-		actions.renames["PI"] = _MKSTR(Math_PI);
-		actions.renames["TAU"] = _MKSTR(Math_TAU);
-		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["PI"] = _MKSTR(Math::PI);
+		actions.renames["TAU"] = _MKSTR(Math::TAU);
+		actions.renames["E"] = _MKSTR(Math::E);
 		actions.renames["LIFETIME"] = "lifetime";
 		actions.renames["DELTA"] = "local_delta";
 		actions.renames["NUMBER"] = "particle_number";
@@ -1463,9 +1463,9 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["SCREEN_UV"] = "uv";
 		actions.renames["TIME"] = "time";
 		actions.renames["FRAGCOORD"] = "gl_FragCoord";
-		actions.renames["PI"] = _MKSTR(Math_PI);
-		actions.renames["TAU"] = _MKSTR(Math_TAU);
-		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["PI"] = _MKSTR(Math::PI);
+		actions.renames["TAU"] = _MKSTR(Math::TAU);
+		actions.renames["E"] = _MKSTR(Math::E);
 		actions.renames["HALF_RES_COLOR"] = "half_res_color";
 		actions.renames["QUARTER_RES_COLOR"] = "quarter_res_color";
 		actions.renames["RADIANCE"] = "radiance";

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -285,7 +285,7 @@ bool ActionMapEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 	TreeItem *source = Object::cast_to<TreeItem>(ObjectDB::get_instance(d["source"].operator ObjectID()));
 	TreeItem *selected = action_tree->get_selected();
 
-	TreeItem *item = (p_point == Vector2(INFINITY, INFINITY)) ? selected : action_tree->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? selected : action_tree->get_item_at_position(p_point);
 	if (!selected || !item || item == source) {
 		return false;
 	}
@@ -309,12 +309,12 @@ void ActionMapEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 	}
 
 	TreeItem *selected = action_tree->get_selected();
-	TreeItem *target = (p_point == Vector2(INFINITY, INFINITY)) ? selected : action_tree->get_item_at_position(p_point);
+	TreeItem *target = (p_point == Vector2(Math::INF, Math::INF)) ? selected : action_tree->get_item_at_position(p_point);
 	if (!target) {
 		return;
 	}
 
-	bool drop_above = ((p_point == Vector2(INFINITY, INFINITY)) ? action_tree->get_drop_section_at_position(action_tree->get_item_rect(target).position) : action_tree->get_drop_section_at_position(p_point)) == -1;
+	bool drop_above = ((p_point == Vector2(Math::INF, Math::INF)) ? action_tree->get_drop_section_at_position(action_tree->get_item_rect(target).position) : action_tree->get_drop_section_at_position(p_point)) == -1;
 
 	Dictionary d = p_data;
 	if (d["input_type"] == "action") {

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -824,8 +824,8 @@ void AnimationBezierTrackEdit::set_filtered(bool p_filtered) {
 
 void AnimationBezierTrackEdit::auto_fit_vertically() {
 	int track_count = animation->get_track_count();
-	real_t minimum_value = INFINITY;
-	real_t maximum_value = -INFINITY;
+	real_t minimum_value = Math::INF;
+	real_t maximum_value = -Math::INF;
 
 	int nb_track_visible = 0;
 	for (int i = 0; i < track_count; ++i) {
@@ -1036,10 +1036,10 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				return;
 			}
 
-			real_t minimum_time = INFINITY;
-			real_t maximum_time = -INFINITY;
-			real_t minimum_value = INFINITY;
-			real_t maximum_value = -INFINITY;
+			real_t minimum_time = Math::INF;
+			real_t maximum_time = -Math::INF;
+			real_t minimum_value = Math::INF;
+			real_t maximum_value = -Math::INF;
 
 			for (const IntPair &E : focused_keys) {
 				IntPair key_pair = E;

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -6930,8 +6930,8 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 						if (is_using_angle) {
 							real_t a = from_v;
 							real_t b = to_v;
-							real_t to_diff = fmod(b - a, Math_TAU);
-							to_v = a + fmod(2.0 * to_diff, Math_TAU) - to_diff;
+							real_t to_diff = fmod(b - a, Math::TAU);
+							to_v = a + fmod(2.0 * to_diff, Math::TAU) - to_diff;
 						}
 						Variant delta_v = Animation::subtract_variant(to_v, from_v);
 						double duration = to_t - from_t;
@@ -8791,8 +8791,8 @@ PackedStringArray AnimationMarkerEdit::get_selected_section() const {
 		PackedStringArray arr;
 		arr.push_back(""); // Marker with smallest time.
 		arr.push_back(""); // Marker with largest time.
-		double min_time = INFINITY;
-		double max_time = -INFINITY;
+		double min_time = Math::INF;
+		double max_time = -Math::INF;
 		for (const StringName &marker_name : selection) {
 			double time = animation->get_marker_time(marker_name);
 			if (time < min_time) {

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -635,7 +635,7 @@ void CreateDialog::_favorite_activated() {
 }
 
 Variant CreateDialog::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
-	TreeItem *ti = (p_point == Vector2(INFINITY, INFINITY)) ? favorites->get_selected() : favorites->get_item_at_position(p_point);
+	TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? favorites->get_selected() : favorites->get_item_at_position(p_point);
 	if (ti) {
 		Dictionary d;
 		d["type"] = "create_favorite_drag";
@@ -667,13 +667,13 @@ bool CreateDialog::can_drop_data_fw(const Point2 &p_point, const Variant &p_data
 void CreateDialog::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
 	Dictionary d = p_data;
 
-	TreeItem *ti = (p_point == Vector2(INFINITY, INFINITY)) ? favorites->get_selected() : favorites->get_item_at_position(p_point);
+	TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? favorites->get_selected() : favorites->get_item_at_position(p_point);
 	if (!ti) {
 		return;
 	}
 
 	String drop_at = ti->get_text(0);
-	int ds = (p_point == Vector2(INFINITY, INFINITY)) ? favorites->get_drop_section_at_position(favorites->get_item_rect(ti).position) : favorites->get_drop_section_at_position(p_point);
+	int ds = (p_point == Vector2(Math::INF, Math::INF)) ? favorites->get_drop_section_at_position(favorites->get_item_rect(ti).position) : favorites->get_drop_section_at_position(p_point);
 
 	int drop_idx = favorite_list.find(drop_at);
 	if (drop_idx < 0) {

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -636,7 +636,7 @@ Variant EditorAudioBus::get_drag_data(const Point2 &p_point) {
 	p->set_modulate(Color(1, 1, 1, 0.7));
 	p->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("focus"), SNAME("Button")));
 	p->set_size(get_size());
-	p->set_position((p_point == Vector2(INFINITY, INFINITY)) ? Vector2() : -p_point);
+	p->set_position((p_point == Vector2(Math::INF, Math::INF)) ? Vector2() : -p_point);
 	set_drag_preview(c);
 	Dictionary d;
 	d["type"] = "move_audio_bus";
@@ -669,7 +669,7 @@ void EditorAudioBus::drop_data(const Point2 &p_point, const Variant &p_data) {
 }
 
 Variant EditorAudioBus::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
-	TreeItem *item = (p_point == Vector2(INFINITY, INFINITY)) ? effects->get_selected() : effects->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? effects->get_selected() : effects->get_item_at_position(p_point);
 	if (!item) {
 		return Variant();
 	}
@@ -698,7 +698,7 @@ bool EditorAudioBus::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 		return false;
 	}
 
-	TreeItem *item = (p_point == Vector2(INFINITY, INFINITY)) ? effects->get_selected() : effects->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? effects->get_selected() : effects->get_item_at_position(p_point);
 	if (!item) {
 		return false;
 	}
@@ -711,11 +711,11 @@ bool EditorAudioBus::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 void EditorAudioBus::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
 	Dictionary d = p_data;
 
-	TreeItem *item = (p_point == Vector2(INFINITY, INFINITY)) ? effects->get_selected() : effects->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? effects->get_selected() : effects->get_item_at_position(p_point);
 	if (!item) {
 		return;
 	}
-	int pos = (p_point == Vector2(INFINITY, INFINITY)) ? effects->get_drop_section_at_position(effects->get_item_rect(item).position) : effects->get_drop_section_at_position(p_point);
+	int pos = (p_point == Vector2(Math::INF, Math::INF)) ? effects->get_drop_section_at_position(effects->get_item_rect(item).position) : effects->get_drop_section_at_position(p_point);
 	Variant md = item->get_metadata(0);
 
 	int paste_at;

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -659,13 +659,13 @@ bool EditorAutoloadSettings::can_drop_data_fw(const Point2 &p_point, const Varia
 	}
 
 	if (drop_data.has("type")) {
-		TreeItem *ti = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+		TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
 
 		if (!ti) {
 			return false;
 		}
 
-		int section = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
+		int section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
 
 		return section >= -1;
 	}
@@ -674,13 +674,13 @@ bool EditorAutoloadSettings::can_drop_data_fw(const Point2 &p_point, const Varia
 }
 
 void EditorAutoloadSettings::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_control) {
-	TreeItem *ti = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+	TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
 
 	if (!ti) {
 		return;
 	}
 
-	int section = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
+	int section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
 
 	if (section < -1) {
 		return;

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2783,7 +2783,7 @@ void EditorInspectorArray::drop_data_fw(const Point2 &p_point, const Variant &p_
 	Dictionary dict = p_data;
 
 	int to_drop = dict["index"];
-	int drop_position = (p_point == Vector2(INFINITY, INFINITY)) ? selected : _drop_position();
+	int drop_position = (p_point == Vector2(Math::INF, Math::INF)) ? selected : _drop_position();
 	if (drop_position < 0) {
 		return;
 	}
@@ -2801,7 +2801,7 @@ bool EditorInspectorArray::can_drop_data_fw(const Point2 &p_point, const Variant
 		return false;
 	}
 	Dictionary dict = p_data;
-	int drop_position = (p_point == Vector2(INFINITY, INFINITY)) ? selected : _drop_position();
+	int drop_position = (p_point == Vector2(Math::INF, Math::INF)) ? selected : _drop_position();
 	if (!dict.has("type") || dict["type"] != "property_array_element" || String(dict["property_array_prefix"]) != array_element_prefix || drop_position < 0) {
 		return false;
 	}

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -186,8 +186,8 @@ Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh
 		Vector3 ofs = aabb.get_center();
 		aabb.position -= ofs;
 		Transform3D xform;
-		xform.basis = Basis().rotated(Vector3(0, 1, 0), -Math_PI / 6);
-		xform.basis = Basis().rotated(Vector3(1, 0, 0), Math_PI / 6) * xform.basis;
+		xform.basis = Basis().rotated(Vector3(0, 1, 0), -Math::PI / 6);
+		xform.basis = Basis().rotated(Vector3(1, 0, 0), Math::PI / 6) * xform.basis;
 		AABB rot_aabb = xform.xform(aabb);
 		float m = MAX(rot_aabb.size.x, rot_aabb.size.y) * 0.5;
 		if (m == 0) {
@@ -282,8 +282,8 @@ void EditorInterface::make_scene_preview(const String &p_path, Node *p_scene, in
 	Vector3 center = scene_aabb.get_center();
 	float camera_size = scene_aabb.get_longest_axis_size();
 
-	const float cam_rot_x = -Math_PI / 4;
-	const float cam_rot_y = -Math_PI / 4;
+	const float cam_rot_x = -Math::PI / 4;
+	const float cam_rot_y = -Math::PI / 4;
 
 	camera->set_orthogonal(camera_size * 2.0, 0.0001, camera_size * 2.0);
 
@@ -295,8 +295,8 @@ void EditorInterface::make_scene_preview(const String &p_path, Node *p_scene, in
 	camera->set_transform(xf);
 
 	Transform3D xform;
-	xform.basis = Basis().rotated(Vector3(0, 1, 0), -Math_PI / 6);
-	xform.basis = Basis().rotated(Vector3(1, 0, 0), Math_PI / 6) * xform.basis;
+	xform.basis = Basis().rotated(Vector3(0, 1, 0), -Math::PI / 6);
+	xform.basis = Basis().rotated(Vector3(1, 0, 0), Math::PI / 6) * xform.basis;
 
 	light->set_transform(xform * Transform3D().looking_at(Vector3(-2, -1, -1), Vector3(0, 1, 0)));
 	light2->set_transform(xform * Transform3D().looking_at(Vector3(+1, -1, -2), Vector3(0, 1, 0)));

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -759,7 +759,7 @@ Variant EditorSettingsDialog::get_drag_data_fw(const Point2 &p_point, Control *p
 
 bool EditorSettingsDialog::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
 	TreeItem *selected = shortcuts->get_selected();
-	TreeItem *item = (p_point == Vector2(INFINITY, INFINITY)) ? shortcuts->get_selected() : shortcuts->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? shortcuts->get_selected() : shortcuts->get_item_at_position(p_point);
 	if (!selected || !item || item == selected || (String)item->get_meta("type", "") != "event") {
 		return false;
 	}
@@ -778,7 +778,7 @@ void EditorSettingsDialog::drop_data_fw(const Point2 &p_point, const Variant &p_
 	}
 
 	TreeItem *selected = shortcuts->get_selected();
-	TreeItem *target = (p_point == Vector2(INFINITY, INFINITY)) ? shortcuts->get_selected() : shortcuts->get_item_at_position(p_point);
+	TreeItem *target = (p_point == Vector2(Math::INF, Math::INF)) ? shortcuts->get_selected() : shortcuts->get_item_at_position(p_point);
 
 	if (!target) {
 		return;

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -321,7 +321,7 @@ bool EditorUndoRedoManager::redo() {
 	}
 
 	int selected_history = INVALID_HISTORY;
-	double global_timestamp = INFINITY;
+	double global_timestamp = Math::INF;
 
 	// Pick the history with lowest last action timestamp (either global or current scene).
 	{

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -746,7 +746,7 @@ void ProjectExportDialog::_delete_preset_confirm() {
 Variant ProjectExportDialog::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 	if (p_from == presets) {
 		int pos = -1;
-		if (p_point == Vector2(INFINITY, INFINITY)) {
+		if (p_point == Vector2(Math::INF, Math::INF)) {
 			if (presets->is_anything_selected()) {
 				pos = presets->get_selected_items()[0];
 			}
@@ -773,7 +773,7 @@ Variant ProjectExportDialog::get_drag_data_fw(const Point2 &p_point, Control *p_
 			return d;
 		}
 	} else if (p_from == patches) {
-		TreeItem *item = (p_point == Vector2(INFINITY, INFINITY)) ? patches->get_selected() : patches->get_item_at_position(p_point);
+		TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? patches->get_selected() : patches->get_item_at_position(p_point);
 
 		if (item) {
 			int item_metadata = item->get_metadata(0);
@@ -800,7 +800,7 @@ bool ProjectExportDialog::can_drop_data_fw(const Point2 &p_point, const Variant 
 
 		int pos = -1;
 		bool end = true;
-		if (p_point == Vector2(INFINITY, INFINITY)) {
+		if (p_point == Vector2(Math::INF, Math::INF)) {
 			if (presets->is_anything_selected()) {
 				pos = presets->get_selected_items()[0];
 			}
@@ -818,7 +818,7 @@ bool ProjectExportDialog::can_drop_data_fw(const Point2 &p_point, const Variant 
 			return false;
 		}
 
-		TreeItem *item = (p_point == Vector2(INFINITY, INFINITY)) ? patches->get_selected() : patches->get_item_at_position(p_point);
+		TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? patches->get_selected() : patches->get_item_at_position(p_point);
 		if (!item) {
 			return false;
 		}
@@ -838,7 +838,7 @@ void ProjectExportDialog::drop_data_fw(const Point2 &p_point, const Variant &p_d
 
 		int pos = -1;
 		bool end = true;
-		if (p_point == Vector2(INFINITY, INFINITY)) {
+		if (p_point == Vector2(Math::INF, Math::INF)) {
 			if (presets->is_anything_selected()) {
 				pos = presets->get_selected_items()[0];
 			}
@@ -875,7 +875,7 @@ void ProjectExportDialog::drop_data_fw(const Point2 &p_point, const Variant &p_d
 		Dictionary d = p_data;
 		int from_pos = d["patch"];
 
-		TreeItem *item = (p_point == Vector2(INFINITY, INFINITY)) ? patches->get_selected() : patches->get_item_at_position(p_point);
+		TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? patches->get_selected() : patches->get_item_at_position(p_point);
 		if (!item) {
 			return;
 		}
@@ -883,7 +883,7 @@ void ProjectExportDialog::drop_data_fw(const Point2 &p_point, const Variant &p_d
 		int to_pos = item->get_metadata(0);
 
 		int pos = -1;
-		if (p_point == Vector2(INFINITY, INFINITY)) {
+		if (p_point == Vector2(Math::INF, Math::INF)) {
 			pos = patches->get_drop_section_at_position(patches->get_item_rect(item).position);
 		} else {
 			pos = patches->get_drop_section_at_position(p_point);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2855,12 +2855,12 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 		}
 
 		// Moving favorite around.
-		TreeItem *ti = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+		TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
 		if (!ti) {
 			return false;
 		}
 
-		int drop_section = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
+		int drop_section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
 		if (ti == favorites_item) {
 			return (drop_section == 1); // The parent, first fav.
 		}
@@ -2933,11 +2933,11 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 			return;
 		}
 		// Moving favorite around.
-		TreeItem *ti = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+		TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
 		if (!ti) {
 			return;
 		}
-		int drop_section = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
+		int drop_section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
 
 		int drop_position;
 		Vector<String> drag_files = drag_data["files"];
@@ -3057,7 +3057,7 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 
 	// In the file list.
 	if (p_from == files) {
-		int pos = (p_point == Vector2(INFINITY, INFINITY)) ? -1 : files->get_item_at_position(p_point, true);
+		int pos = (p_point == Vector2(Math::INF, Math::INF)) ? -1 : files->get_item_at_position(p_point, true);
 		if (pos == -1) {
 			target = get_current_directory();
 			return;
@@ -3070,8 +3070,8 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 
 	// In the tree.
 	if (p_from == tree) {
-		TreeItem *ti = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_selected() : tree->get_item_at_position(p_point);
-		int section = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
+		TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+		int section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
 		if (ti) {
 			// Check the favorites first.
 			if (ti == tree->get_root()->get_first_child() && section >= 0) {

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1864,12 +1864,12 @@ bool SceneTreeEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 		return false;
 	}
 
-	TreeItem *item = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
 	if (!item) {
 		return false;
 	}
 
-	int section = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_drop_section_at_position(tree->get_item_rect(item).position) : tree->get_drop_section_at_position(p_point);
+	int section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(item).position) : tree->get_drop_section_at_position(p_point);
 	if (section < -1 || (section == -1 && !item->get_parent())) {
 		return false;
 	}
@@ -1953,11 +1953,11 @@ void SceneTreeEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 		return;
 	}
 
-	TreeItem *item = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
 	if (!item) {
 		return;
 	}
-	int section = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_drop_section_at_position(tree->get_item_rect(item).position) : tree->get_drop_section_at_position(p_point);
+	int section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(item).position) : tree->get_drop_section_at_position(p_point);
 	if (section < -1) {
 		return;
 	}

--- a/editor/import/3d/collada.cpp
+++ b/editor/import/3d/collada.cpp
@@ -1372,7 +1372,7 @@ Collada::Node *Collada::_parse_visual_instance_camera(XMLParser &p_parser) {
 	cam->camera = _uri_to_id(p_parser.get_named_attribute_value_safe("url"));
 
 	if (state.up_axis == Vector3::AXIS_Z) { //collada weirdness
-		cam->post_transform.basis.rotate(Vector3(1, 0, 0), -Math_PI * 0.5);
+		cam->post_transform.basis.rotate(Vector3(1, 0, 0), -Math::PI * 0.5);
 	}
 
 	if (p_parser.is_empty()) { //nothing else to parse...
@@ -1393,7 +1393,7 @@ Collada::Node *Collada::_parse_visual_instance_light(XMLParser &p_parser) {
 	cam->light = _uri_to_id(p_parser.get_named_attribute_value_safe("url"));
 
 	if (state.up_axis == Vector3::AXIS_Z) { //collada weirdness
-		cam->post_transform.basis.rotate(Vector3(1, 0, 0), -Math_PI * 0.5);
+		cam->post_transform.basis.rotate(Vector3(1, 0, 0), -Math::PI * 0.5);
 	}
 
 	if (p_parser.is_empty()) { //nothing else to parse...

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -826,7 +826,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 				SeparationRayShape3D *rayShape = memnew(SeparationRayShape3D);
 				rayShape->set_length(1);
 				colshape->set_shape(rayShape);
-				Object::cast_to<Node3D>(sb)->rotate_x(Math_PI / 2);
+				Object::cast_to<Node3D>(sb)->rotate_x(Math::PI / 2);
 			} else if (empty_draw_type == "IMAGE") {
 				WorldBoundaryShape3D *world_boundary_shape = memnew(WorldBoundaryShape3D);
 				colshape->set_shape(world_boundary_shape);

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -512,7 +512,7 @@ Transform3D ResourceImporterScene::get_collision_shapes_transform(const M &p_opt
 		}
 
 		if (p_options.has(SNAME("primitive/rotation"))) {
-			transform.basis = Basis::from_euler(p_options[SNAME("primitive/rotation")].operator Vector3() * (Math_PI / 180.0));
+			transform.basis = Basis::from_euler(p_options[SNAME("primitive/rotation")].operator Vector3() * (Math::PI / 180.0));
 		}
 	}
 	return transform;

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -744,8 +744,8 @@ void SceneImportSettingsDialog::open_settings(const String &p_path, const String
 	selected_id = "";
 	selected_type = "";
 
-	cam_rot_x = -Math_PI / 4;
-	cam_rot_y = -Math_PI / 4;
+	cam_rot_x = -Math::PI / 4;
+	cam_rot_y = -Math::PI / 4;
 	cam_zoom = 1;
 
 	{
@@ -1204,7 +1204,7 @@ void SceneImportSettingsDialog::_viewport_input(const Ref<InputEvent> &p_input) 
 	if (mm.is_valid() && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
 		(*rot_x) -= mm->get_relative().y * 0.01 * EDSCALE;
 		(*rot_y) -= mm->get_relative().x * 0.01 * EDSCALE;
-		(*rot_x) = CLAMP((*rot_x), -Math_PI / 2, Math_PI / 2);
+		(*rot_x) = CLAMP((*rot_x), -Math::PI / 2, Math::PI / 2);
 		_update_camera();
 	}
 	if (mm.is_valid() && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CURSOR_SHAPE)) {

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -128,8 +128,8 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 		TreeItem *mesh_node = nullptr;
 		TreeItem *material_node = nullptr;
 
-		float cam_rot_x = -Math_PI / 4;
-		float cam_rot_y = -Math_PI / 4;
+		float cam_rot_x = -Math::PI / 4;
+		float cam_rot_y = -Math::PI / 4;
 		float cam_zoom = 1;
 
 		HashMap<StringName, Variant> settings;
@@ -143,8 +143,8 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 		TreeItem *scene_node = nullptr;
 		TreeItem *mesh_node = nullptr;
 
-		float cam_rot_x = -Math_PI / 4;
-		float cam_rot_y = -Math_PI / 4;
+		float cam_rot_x = -Math::PI / 4;
+		float cam_rot_y = -Math::PI / 4;
 		float cam_zoom = 1;
 		HashMap<StringName, Variant> settings;
 	};

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2864,14 +2864,14 @@ Control::CursorShape CanvasItemEditor::get_cursor_shape(const Point2 &p_pos) con
 
 	List<CanvasItem *> selection = _get_edited_canvas_items();
 	if (selection.size() == 1) {
-		const double angle = Math::fposmod((double)selection.front()->get()->get_global_transform_with_canvas().get_rotation(), Math_PI);
-		if (angle > Math_PI * 7.0 / 8.0) {
+		const double angle = Math::fposmod((double)selection.front()->get()->get_global_transform_with_canvas().get_rotation(), Math::PI);
+		if (angle > Math::PI * 7.0 / 8.0) {
 			rotation_array_index = 0;
-		} else if (angle > Math_PI * 5.0 / 8.0) {
+		} else if (angle > Math::PI * 5.0 / 8.0) {
 			rotation_array_index = 1;
-		} else if (angle > Math_PI * 3.0 / 8.0) {
+		} else if (angle > Math::PI * 3.0 / 8.0) {
 			rotation_array_index = 2;
-		} else if (angle > Math_PI * 1.0 / 8.0) {
+		} else if (angle > Math::PI * 1.0 / 8.0) {
 			rotation_array_index = 3;
 		} else {
 			rotation_array_index = 0;
@@ -3103,7 +3103,7 @@ void CanvasItemEditor::_draw_rulers() {
 			viewport->draw_line(Point2(0, position.y), Point2(RULER_WIDTH, position.y), graduation_color, Math::round(EDSCALE));
 			real_t val = (ruler_transform * major_subdivide * minor_subdivide).xform(Point2(0, i)).y;
 
-			Transform2D text_xform = Transform2D(-Math_PI / 2.0, Point2(font->get_ascent(font_size) + Math::round(EDSCALE), position.y - 2));
+			Transform2D text_xform = Transform2D(-Math::PI / 2.0, Point2(font->get_ascent(font_size) + Math::round(EDSCALE), position.y - 2));
 			viewport->draw_set_transform_matrix(viewport->get_transform() * text_xform);
 			viewport->draw_string(font, Point2(), TS->format_number(vformat(((int)val == val) ? "%d" : "%.1f", val)), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, font_color);
 			viewport->draw_set_transform_matrix(viewport->get_transform());
@@ -3210,7 +3210,7 @@ void CanvasItemEditor::_draw_ruler_tool() {
 		Vector2 length_vector = (begin - end).abs() / zoom;
 
 		const real_t horizontal_angle_rad = length_vector.angle();
-		const real_t vertical_angle_rad = Math_PI / 2.0 - horizontal_angle_rad;
+		const real_t vertical_angle_rad = Math::PI / 2.0 - horizontal_angle_rad;
 
 		Ref<Font> font = get_theme_font(SNAME("bold"), EditorStringName(EditorFonts));
 		int font_size = 1.3 * get_theme_font_size(SNAME("bold_size"), EditorStringName(EditorFonts));
@@ -3246,15 +3246,15 @@ void CanvasItemEditor::_draw_ruler_tool() {
 			const Vector2 end_to_begin = (end - begin);
 
 			real_t arc_1_start_angle = end_to_begin.x < 0
-					? (end_to_begin.y < 0 ? 3.0 * Math_PI / 2.0 - vertical_angle_rad : Math_PI / 2.0)
-					: (end_to_begin.y < 0 ? 3.0 * Math_PI / 2.0 : Math_PI / 2.0 - vertical_angle_rad);
+					? (end_to_begin.y < 0 ? 3.0 * Math::PI / 2.0 - vertical_angle_rad : Math::PI / 2.0)
+					: (end_to_begin.y < 0 ? 3.0 * Math::PI / 2.0 : Math::PI / 2.0 - vertical_angle_rad);
 			real_t arc_1_end_angle = arc_1_start_angle + vertical_angle_rad;
 			// Constrain arc to triangle height & max size.
 			real_t arc_1_radius = MIN(MIN(arc_radius_max_length_percent * ruler_length, Math::abs(end_to_begin.y)), arc_max_radius);
 
 			real_t arc_2_start_angle = end_to_begin.x < 0
 					? (end_to_begin.y < 0 ? 0.0 : -horizontal_angle_rad)
-					: (end_to_begin.y < 0 ? Math_PI - horizontal_angle_rad : Math_PI);
+					: (end_to_begin.y < 0 ? Math::PI - horizontal_angle_rad : Math::PI);
 			real_t arc_2_end_angle = arc_2_start_angle + horizontal_angle_rad;
 			// Constrain arc to triangle width & max size.
 			real_t arc_2_radius = MIN(MIN(arc_radius_max_length_percent * ruler_length, Math::abs(end_to_begin.x)), arc_max_radius);
@@ -3275,8 +3275,8 @@ void CanvasItemEditor::_draw_ruler_tool() {
 		viewport->draw_string(font, text_pos, TS->format_number(vformat("%.1f px", length_vector.length())), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, font_color);
 
 		if (draw_secondary_lines) {
-			const int horizontal_angle = round(180 * horizontal_angle_rad / Math_PI);
-			const int vertical_angle = round(180 * vertical_angle_rad / Math_PI);
+			const int horizontal_angle = round(180 * horizontal_angle_rad / Math::PI);
+			const int vertical_angle = round(180 * vertical_angle_rad / Math::PI);
 
 			Point2 text_pos2 = text_pos;
 			text_pos2.x = begin.x < text_pos.x ? MIN(text_pos.x - text_width, begin.x - text_width / 2) : MAX(text_pos.x + text_width, begin.x - text_width / 2);
@@ -3655,7 +3655,7 @@ void CanvasItemEditor::_draw_selection() {
 					int next = (i + 1) % 4;
 
 					Vector2 ofs = ((endpoints[i] - endpoints[prev]).normalized() + ((endpoints[i] - endpoints[next]).normalized())).normalized();
-					ofs *= Math_SQRT2 * (select_handle->get_size().width / 2);
+					ofs *= Math::SQRT2 * (select_handle->get_size().width / 2);
 
 					select_handle->draw(vp_ci, (endpoints[i] + ofs - (select_handle->get_size() / 2)).floor());
 
@@ -4257,8 +4257,8 @@ void CanvasItemEditor::_selection_changed() {
 	}
 	selected_from_canvas = false;
 
-	if (temp_pivot != Vector2(INFINITY, INFINITY)) {
-		temp_pivot = Vector2(INFINITY, INFINITY);
+	if (temp_pivot != Vector2(Math::INF, Math::INF)) {
+		temp_pivot = Vector2(Math::INF, Math::INF);
 		viewport->queue_redraw();
 	}
 }
@@ -6175,7 +6175,7 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 }
 
 bool CanvasItemEditorViewport::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
-	if (p_point == Vector2(INFINITY, INFINITY)) {
+	if (p_point == Vector2(Math::INF, Math::INF)) {
 		return false;
 	}
 	Dictionary d = p_data;
@@ -6309,7 +6309,7 @@ bool CanvasItemEditorViewport::_is_any_texture_selected() const {
 }
 
 void CanvasItemEditorViewport::drop_data(const Point2 &p_point, const Variant &p_data) {
-	if (p_point == Vector2(INFINITY, INFINITY)) {
+	if (p_point == Vector2(Math::INF, Math::INF)) {
 		return;
 	}
 	bool is_shift = Input::get_singleton()->is_key_pressed(Key::SHIFT);

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -252,7 +252,7 @@ private:
 	bool key_scale = false;
 
 	bool pan_pressed = false;
-	Vector2 temp_pivot = Vector2(INFINITY, INFINITY);
+	Vector2 temp_pivot = Vector2(Math::INF, Math::INF);
 
 	bool ruler_tool_active = false;
 	Point2 ruler_tool_origin;

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -393,22 +393,22 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 
 	int lats = 32;
 	int lons = 32;
-	const double lat_step = Math_TAU / lats;
-	const double lon_step = Math_TAU / lons;
+	const double lat_step = Math::TAU / lats;
+	const double lon_step = Math::TAU / lons;
 	real_t radius = 1.0;
 
 	Vector<Vector3> vertices;
 	Vector<Vector3> normals;
 	Vector<Vector2> uvs;
 	Vector<real_t> tangents;
-	Basis tt = Basis(Vector3(0, 1, 0), Math_PI * 0.5);
+	Basis tt = Basis(Vector3(0, 1, 0), Math::PI * 0.5);
 
 	for (int i = 1; i <= lats; i++) {
-		double lat0 = lat_step * (i - 1) - Math_TAU / 4;
+		double lat0 = lat_step * (i - 1) - Math::TAU / 4;
 		double z0 = Math::sin(lat0);
 		double zr0 = Math::cos(lat0);
 
-		double lat1 = lat_step * i - Math_TAU / 4;
+		double lat1 = lat_step * i - Math::TAU / 4;
 		double z1 = Math::sin(lat1);
 		double zr1 = Math::cos(lat1);
 
@@ -433,7 +433,7 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 	vertices.push_back(v[m_idx] * radius);                                                     \
 	{                                                                                          \
 		Vector2 uv(Math::atan2(v[m_idx].x, v[m_idx].z), Math::atan2(-v[m_idx].y, v[m_idx].z)); \
-		uv /= Math_PI;                                                                         \
+		uv /= Math::PI;                                                                        \
 		uv *= 4.0;                                                                             \
 		uv = uv * 0.5 + Vector2(0.5, 0.5);                                                     \
 		uvs.push_back(uv);                                                                     \
@@ -736,8 +736,8 @@ Ref<Texture2D> EditorMeshPreviewPlugin::generate(const Ref<Resource> &p_from, co
 	Vector3 ofs = aabb.get_center();
 	aabb.position -= ofs;
 	Transform3D xform;
-	xform.basis = Basis().rotated(Vector3(0, 1, 0), -Math_PI * 0.125);
-	xform.basis = Basis().rotated(Vector3(1, 0, 0), Math_PI * 0.125) * xform.basis;
+	xform.basis = Basis().rotated(Vector3(0, 1, 0), -Math::PI * 0.125);
+	xform.basis = Basis().rotated(Vector3(1, 0, 0), Math::PI * 0.125) * xform.basis;
 	AABB rot_aabb = xform.xform(aabb);
 	real_t m = MAX(rot_aabb.size.x, rot_aabb.size.y) * 0.5;
 	if (m == 0) {

--- a/editor/plugins/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
@@ -176,8 +176,8 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			// Number of points in an octant. So there will be 8 * points_in_octant points in total.
 			// This corresponds to the smoothness of the circle.
 			const uint32_t points_in_octant = 15;
-			const real_t octant_angle = Math_PI / 4;
-			const real_t inc = (Math_PI / (4 * points_in_octant));
+			const real_t octant_angle = Math::PI / 4;
+			const real_t inc = (Math::PI / (4 * points_in_octant));
 			const real_t radius_squared = radius * radius;
 			real_t r = 0;
 
@@ -239,8 +239,8 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			const float radius = Math::sin(ha);
 
 			const uint32_t points_in_octant = 7;
-			const real_t octant_angle = Math_PI / 4;
-			const real_t inc = (Math_PI / (4 * points_in_octant));
+			const real_t octant_angle = Math::PI / 4;
+			const real_t inc = (Math::PI / (4 * points_in_octant));
 			const real_t radius_squared = radius * radius;
 			real_t r = 0;
 

--- a/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
@@ -271,8 +271,8 @@ float Camera3DGizmoPlugin::_find_closest_angle_to_half_pi_arc(const Vector3 &p_f
 	Vector3 min_p;
 
 	for (int i = 0; i < arc_test_points; i++) {
-		float a = i * Math_PI * 0.5 / arc_test_points;
-		float an = (i + 1) * Math_PI * 0.5 / arc_test_points;
+		float a = i * Math::PI * 0.5 / arc_test_points;
+		float an = (i + 1) * Math::PI * 0.5 / arc_test_points;
 		Vector3 p = Vector3(Math::cos(a), 0, -Math::sin(a)) * p_arc_radius;
 		Vector3 n = Vector3(Math::cos(an), 0, -Math::sin(an)) * p_arc_radius;
 
@@ -287,6 +287,6 @@ float Camera3DGizmoPlugin::_find_closest_angle_to_half_pi_arc(const Vector3 &p_f
 	}
 
 	//min_p = p_arc_xform.affine_inverse().xform(min_p);
-	float a = (Math_PI * 0.5) - Vector2(min_p.x, -min_p.z).angle();
+	float a = (Math::PI * 0.5) - Vector2(min_p.x, -min_p.z).angle();
 	return Math::rad_to_deg(a);
 }

--- a/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
@@ -359,7 +359,7 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		// Number of points in an octant. So there will be 8 * points_in_octant * 2 points in total for one circle.
 		// This Corresponds to the smoothness of the circle.
 		const uint32_t points_in_octant = 16;
-		const real_t inc = (Math_PI / (4 * points_in_octant));
+		const real_t inc = (Math::PI / (4 * points_in_octant));
 		const real_t radius_squared = radius * radius;
 		real_t r = 0;
 
@@ -429,8 +429,8 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		// Number of points in an octant. So there will be 8 * points_in_octant points in total.
 		// This corresponds to the smoothness of the circle.
 		const uint32_t points_in_octant = 16;
-		const real_t octant_angle = Math_PI / 4;
-		const real_t inc = (Math_PI / (4 * points_in_octant));
+		const real_t octant_angle = Math::PI / 4;
+		const real_t inc = (Math::PI / (4 * points_in_octant));
 		const real_t radius_squared = radius * radius;
 		real_t r = 0;
 
@@ -539,7 +539,7 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		// Number of points in an octant. So there will be 8 * points_in_octant * 2 points in total for one circle.
 		// This corresponds to the smoothness of the circle.
 		const uint32_t points_in_octant = 16;
-		const real_t inc = (Math_PI / (4 * points_in_octant));
+		const real_t inc = (Math::PI / (4 * points_in_octant));
 		const real_t radius_squared = radius * radius;
 		real_t r = 0;
 

--- a/editor/plugins/gizmos/gpu_particles_collision_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/gpu_particles_collision_3d_gizmo_plugin.cpp
@@ -200,8 +200,8 @@ void GPUParticlesCollision3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		// Number of points in an octant. So there will be 8 * points_in_octant points in total.
 		// This corresponds to the smoothness of the circle.
 		const uint32_t points_in_octant = 16;
-		const real_t octant_angle = Math_PI / 4;
-		const real_t inc = (Math_PI / (4 * points_in_octant));
+		const real_t octant_angle = Math::PI / 4;
+		const real_t inc = (Math::PI / (4 * points_in_octant));
 		const real_t radius_squared = radius * radius;
 		real_t r = 0;
 

--- a/editor/plugins/gizmos/joint_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/joint_3d_gizmo_plugin.cpp
@@ -179,8 +179,8 @@ void JointGizmosDrawer::draw_circle(Vector3::Axis p_axis, real_t p_radius, const
 
 	} else {
 		if (p_limit_lower > p_limit_upper) {
-			p_limit_lower = -Math_PI;
-			p_limit_upper = Math_PI;
+			p_limit_lower = -Math::PI;
+			p_limit_upper = Math::PI;
 		}
 
 		const int points = 32;

--- a/editor/plugins/gizmos/light_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/light_3d_gizmo_plugin.cpp
@@ -179,7 +179,7 @@ void Light3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 			for (int i = 0; i < arrow_sides; i++) {
 				for (int j = 0; j < arrow_points; j++) {
-					Basis ma(Vector3(0, 0, 1), Math_PI * i / arrow_sides);
+					Basis ma(Vector3(0, 0, 1), Math::PI * i / arrow_sides);
 
 					Vector3 v1 = arrow[j] - Vector3(0, 0, arrow_length);
 					Vector3 v2 = arrow[(j + 1) % arrow_points] - Vector3(0, 0, arrow_length);
@@ -295,8 +295,8 @@ float Light3DGizmoPlugin::_find_closest_angle_to_half_pi_arc(const Vector3 &p_fr
 	Vector3 min_p;
 
 	for (int i = 0; i < arc_test_points; i++) {
-		float a = i * Math_PI * 0.5 / arc_test_points;
-		float an = (i + 1) * Math_PI * 0.5 / arc_test_points;
+		float a = i * Math::PI * 0.5 / arc_test_points;
+		float an = (i + 1) * Math::PI * 0.5 / arc_test_points;
 		Vector3 p = Vector3(Math::cos(a), 0, -Math::sin(a)) * p_arc_radius;
 		Vector3 n = Vector3(Math::cos(an), 0, -Math::sin(an)) * p_arc_radius;
 
@@ -311,6 +311,6 @@ float Light3DGizmoPlugin::_find_closest_angle_to_half_pi_arc(const Vector3 &p_fr
 	}
 
 	//min_p = p_arc_xform.affine_inverse().xform(min_p);
-	float a = (Math_PI * 0.5) - Vector2(min_p.x, -min_p.z).angle();
+	float a = (Math::PI * 0.5) - Vector2(min_p.x, -min_p.z).angle();
 	return Math::rad_to_deg(a);
 }

--- a/editor/plugins/gizmos/lightmap_gi_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/lightmap_gi_gizmo_plugin.cpp
@@ -123,8 +123,8 @@ void LightmapGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	int stack_count = 8;
 	int sector_count = 16;
 
-	float sector_step = (Math_PI * 2.0) / sector_count;
-	float stack_step = Math_PI / stack_count;
+	float sector_step = (Math::PI * 2.0) / sector_count;
+	float stack_step = Math::PI / stack_count;
 
 	Vector<Vector3> vertices;
 	Vector<Color> colors;
@@ -141,7 +141,7 @@ void LightmapGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		}
 
 		for (int i = 0; i <= stack_count; ++i) {
-			float stack_angle = Math_PI / 2 - i * stack_step; // starting from pi/2 to -pi/2
+			float stack_angle = Math::PI / 2 - i * stack_step; // starting from pi/2 to -pi/2
 			float xy = radius * Math::cos(stack_angle); // r * cos(u)
 			float z = radius * Math::sin(stack_angle); // r * sin(u)
 

--- a/editor/plugins/gizmos/lightmap_probe_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/lightmap_probe_gizmo_plugin.cpp
@@ -66,14 +66,14 @@ void LightmapProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	int stack_count = 8;
 	int sector_count = 16;
 
-	float sector_step = (Math_PI * 2.0) / sector_count;
-	float stack_step = Math_PI / stack_count;
+	float sector_step = (Math::PI * 2.0) / sector_count;
+	float stack_step = Math::PI / stack_count;
 
 	Vector<Vector3> vertices;
 	float radius = 0.2;
 
 	for (int i = 0; i <= stack_count; ++i) {
-		float stack_angle = Math_PI / 2 - i * stack_step; // starting from pi/2 to -pi/2
+		float stack_angle = Math::PI / 2 - i * stack_step; // starting from pi/2 to -pi/2
 		float xy = radius * Math::cos(stack_angle); // r * cos(u)
 		float z = radius * Math::sin(stack_angle); // r * sin(u)
 

--- a/editor/plugins/gizmos/navigation_link_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/navigation_link_3d_gizmo_plugin.cpp
@@ -73,7 +73,7 @@ void NavigationLink3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	// Number of points in an octant. So there will be 8 * points_in_octant points in total.
 	// Correspond to the smoothness of the circle.
 	const uint32_t points_in_octant = 8;
-	real_t inc = (Math_PI / (4 * points_in_octant));
+	real_t inc = (Math::PI / (4 * points_in_octant));
 
 	Vector<Vector3> lines;
 	// points_in_octant * 8 * 2 per circle * 2 circles. 2 for the start-end. 4 for the arrow, and another 4 if bidirectionnal.

--- a/editor/plugins/gizmos/spring_bone_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/spring_bone_3d_gizmo_plugin.cpp
@@ -171,7 +171,7 @@ void SpringBoneSimulator3DGizmoPlugin::draw_sphere(Ref<SurfaceTool> &p_surface_t
 	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
 	static const Vector3 VECTOR3_FORWARD = Vector3(0, 0, 1);
 	static const int STEP = 16;
-	static const float SPPI = Math_TAU / (float)STEP;
+	static const float SPPI = Math::TAU / (float)STEP;
 
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
@@ -302,7 +302,7 @@ void SpringBoneCollision3DGizmoPlugin::draw_sphere(Ref<SurfaceTool> &p_surface_t
 	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
 	static const Vector3 VECTOR3_FORWARD = Vector3(0, 0, 1);
 	static const int STEP = 16;
-	static const float SPPI = Math_TAU / (float)STEP;
+	static const float SPPI = Math::TAU / (float)STEP;
 
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
@@ -330,8 +330,8 @@ void SpringBoneCollision3DGizmoPlugin::draw_capsule(Ref<SurfaceTool> &p_surface_
 	static const Vector3 VECTOR3_FORWARD = Vector3(0, 0, 1);
 	static const int STEP = 16;
 	static const int HALF_STEP = 8;
-	static const float SPPI = Math_TAU / (float)STEP;
-	static const float HALF_PI = Math_PI * 0.5;
+	static const float SPPI = Math::TAU / (float)STEP;
+	static const float HALF_PI = Math::PI * 0.5;
 
 	Vector3 top = VECTOR3_UP * (p_height * 0.5 - p_radius);
 	Vector3 bottom = -top;
@@ -376,7 +376,7 @@ void SpringBoneCollision3DGizmoPlugin::draw_capsule(Ref<SurfaceTool> &p_surface_
 
 void SpringBoneCollision3DGizmoPlugin::draw_plane(Ref<SurfaceTool> &p_surface_tool, const Color &p_color) {
 	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
-	static const float HALF_PI = Math_PI * 0.5;
+	static const float HALF_PI = Math::PI * 0.5;
 	static const float ARROW_LENGTH = 0.3;
 	static const float ARROW_HALF_WIDTH = 0.05;
 	static const float ARROW_TOP_HALF_WIDTH = 0.1;

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -62,7 +62,7 @@ void MaterialEditor::gui_input(const Ref<InputEvent> &p_event) {
 			const real_t limit = Math::deg_to_rad(80.0);
 			rot = rot.clampf(-limit, limit);
 		} else {
-			rot.x = CLAMP(rot.x, -Math_PI / 2, Math_PI / 2);
+			rot.x = CLAMP(rot.x, -Math::PI / 2, Math::PI / 2);
 		}
 		_update_rotation();
 		_store_rotation_metadata();

--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -43,7 +43,7 @@ void MeshEditor::gui_input(const Ref<InputEvent> &p_event) {
 		rot_x -= mm->get_relative().y * 0.01;
 		rot_y -= mm->get_relative().x * 0.01;
 
-		rot_x = CLAMP(rot_x, -Math_PI / 2, Math_PI / 2);
+		rot_x = CLAMP(rot_x, -Math::PI / 2, Math::PI / 2);
 		_update_rotation();
 	}
 }

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -174,10 +174,10 @@ void MultiMeshEditor::_populate() {
 
 	Transform3D axis_xform;
 	if (axis == Vector3::AXIS_Z) {
-		axis_xform.rotate(Vector3(1, 0, 0), -Math_PI * 0.5);
+		axis_xform.rotate(Vector3(1, 0, 0), -Math::PI * 0.5);
 	}
 	if (axis == Vector3::AXIS_X) {
-		axis_xform.rotate(Vector3(0, 0, 1), -Math_PI * 0.5);
+		axis_xform.rotate(Vector3(0, 0, 1), -Math::PI * 0.5);
 	}
 
 	for (int i = 0; i < instance_count; i++) {
@@ -203,9 +203,9 @@ void MultiMeshEditor::_populate() {
 
 		Basis post_xform;
 
-		post_xform.rotate(xform.basis.get_column(1), -Math::random(-_rotate_random, _rotate_random) * Math_PI);
-		post_xform.rotate(xform.basis.get_column(2), -Math::random(-_tilt_random, _tilt_random) * Math_PI);
-		post_xform.rotate(xform.basis.get_column(0), -Math::random(-_tilt_random, _tilt_random) * Math_PI);
+		post_xform.rotate(xform.basis.get_column(1), -Math::random(-_rotate_random, _rotate_random) * Math::PI);
+		post_xform.rotate(xform.basis.get_column(2), -Math::random(-_tilt_random, _tilt_random) * Math::PI);
+		post_xform.rotate(xform.basis.get_column(0), -Math::random(-_tilt_random, _tilt_random) * Math::PI);
 
 		xform.basis = post_xform * xform.basis;
 		//xform.basis.orthonormalize();

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2386,28 +2386,28 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		}
 		if (ED_IS_SHORTCUT("spatial_editor/orbit_view_down", p_event)) {
 			// Clamp rotation to roughly -90..90 degrees so the user can't look upside-down and end up disoriented.
-			cursor.x_rot = CLAMP(cursor.x_rot - Math_PI / 12.0, -1.57, 1.57);
+			cursor.x_rot = CLAMP(cursor.x_rot - Math::PI / 12.0, -1.57, 1.57);
 			view_type = VIEW_TYPE_USER;
 			_update_name();
 		}
 		if (ED_IS_SHORTCUT("spatial_editor/orbit_view_up", p_event)) {
 			// Clamp rotation to roughly -90..90 degrees so the user can't look upside-down and end up disoriented.
-			cursor.x_rot = CLAMP(cursor.x_rot + Math_PI / 12.0, -1.57, 1.57);
+			cursor.x_rot = CLAMP(cursor.x_rot + Math::PI / 12.0, -1.57, 1.57);
 			view_type = VIEW_TYPE_USER;
 			_update_name();
 		}
 		if (ED_IS_SHORTCUT("spatial_editor/orbit_view_right", p_event)) {
-			cursor.y_rot -= Math_PI / 12.0;
+			cursor.y_rot -= Math::PI / 12.0;
 			view_type = VIEW_TYPE_USER;
 			_update_name();
 		}
 		if (ED_IS_SHORTCUT("spatial_editor/orbit_view_left", p_event)) {
-			cursor.y_rot += Math_PI / 12.0;
+			cursor.y_rot += Math::PI / 12.0;
 			view_type = VIEW_TYPE_USER;
 			_update_name();
 		}
 		if (ED_IS_SHORTCUT("spatial_editor/orbit_view_180", p_event)) {
-			cursor.y_rot += Math_PI;
+			cursor.y_rot += Math::PI;
 			view_type = VIEW_TYPE_USER;
 			_update_name();
 		}
@@ -3502,7 +3502,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 	switch (p_option) {
 		case VIEW_TOP: {
 			cursor.y_rot = 0;
-			cursor.x_rot = Math_PI / 2.0;
+			cursor.x_rot = Math::PI / 2.0;
 			set_message(TTR("Top View."), 2);
 			view_type = VIEW_TYPE_TOP;
 			_set_auto_orthogonal();
@@ -3511,7 +3511,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 		} break;
 		case VIEW_BOTTOM: {
 			cursor.y_rot = 0;
-			cursor.x_rot = -Math_PI / 2.0;
+			cursor.x_rot = -Math::PI / 2.0;
 			set_message(TTR("Bottom View."), 2);
 			view_type = VIEW_TYPE_BOTTOM;
 			_set_auto_orthogonal();
@@ -3520,7 +3520,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 		} break;
 		case VIEW_LEFT: {
 			cursor.x_rot = 0;
-			cursor.y_rot = Math_PI / 2.0;
+			cursor.y_rot = Math::PI / 2.0;
 			set_message(TTR("Left View."), 2);
 			view_type = VIEW_TYPE_LEFT;
 			_set_auto_orthogonal();
@@ -3529,7 +3529,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 		} break;
 		case VIEW_RIGHT: {
 			cursor.x_rot = 0;
-			cursor.y_rot = -Math_PI / 2.0;
+			cursor.y_rot = -Math::PI / 2.0;
 			set_message(TTR("Right View."), 2);
 			view_type = VIEW_TYPE_RIGHT;
 			_set_auto_orthogonal();
@@ -3547,7 +3547,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 		} break;
 		case VIEW_REAR: {
 			cursor.x_rot = 0;
-			cursor.y_rot = Math_PI;
+			cursor.y_rot = Math::PI;
 			set_message(TTR("Rear View."), 2);
 			view_type = VIEW_TYPE_REAR;
 			_set_auto_orthogonal();
@@ -3596,7 +3596,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 					// Adjust rotation to match Decal's default orientation.
 					// This makes the decal "look" in the same direction as the camera,
 					// rather than pointing down relative to the camera orientation.
-					xform.basis.rotate_local(Vector3(1, 0, 0), Math_TAU * 0.25);
+					xform.basis.rotate_local(Vector3(1, 0, 0), Math::TAU * 0.25);
 				}
 
 				Node3D *parent = sp->get_parent_node_3d();
@@ -3634,7 +3634,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 					// Adjust rotation to match Decal's default orientation.
 					// This makes the decal "look" in the same direction as the camera,
 					// rather than pointing down relative to the camera orientation.
-					basis.rotate_local(Vector3(1, 0, 0), Math_TAU * 0.25);
+					basis.rotate_local(Vector3(1, 0, 0), Math::TAU * 0.25);
 				}
 
 				undo_redo->add_do_method(sp, "set_rotation", basis.get_euler_normalized());
@@ -4908,7 +4908,7 @@ void Node3DEditorViewport::_perform_drop_data() {
 }
 
 bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
-	if (p_point == Vector2(INFINITY, INFINITY)) {
+	if (p_point == Vector2(Math::INF, Math::INF)) {
 		return false;
 	}
 	preview_node_viewport_pos = p_point;
@@ -5373,7 +5373,7 @@ void Node3DEditorViewport::update_transform(bool p_shift) {
 				Vector3 projection_axis = plane.normal.cross(global_axis);
 				Vector3 delta = intersection - click;
 				float projection = delta.dot(projection_axis);
-				angle = (projection * (Math_PI / 2.0f)) / (gizmo_scale * GIZMO_CIRCLE_SIZE);
+				angle = (projection * (Math::PI / 2.0f)) / (gizmo_scale * GIZMO_CIRCLE_SIZE);
 			} else {
 				_edit.show_rotation_line = true;
 				Vector3 click_axis = (click - _edit.center).normalized();
@@ -7321,7 +7321,7 @@ void fragment() {
 
 				int arrow_sides = 16;
 
-				const real_t arrow_sides_step = Math_TAU / arrow_sides;
+				const real_t arrow_sides_step = Math::TAU / arrow_sides;
 				for (int k = 0; k < arrow_sides; k++) {
 					Basis ma(ivec, k * arrow_sides_step);
 					Basis mb(ivec, (k + 1) * arrow_sides_step);
@@ -7360,7 +7360,7 @@ void fragment() {
 					vec * GIZMO_PLANE_DST - ivec3 * GIZMO_PLANE_SIZE
 				};
 
-				Basis ma(ivec, Math_PI / 2);
+				Basis ma(ivec, Math::PI / 2);
 
 				Vector3 points[4] = {
 					ma.xform(plane[0]),
@@ -7400,14 +7400,14 @@ void fragment() {
 				int n = 128; // number of circle segments
 				int m = 3; // number of thickness segments
 
-				real_t step = Math_TAU / n;
+				real_t step = Math::TAU / n;
 				for (int j = 0; j < n; ++j) {
 					Basis basis = Basis(ivec, j * step);
 
 					Vector3 vertex = basis.xform(ivec2 * GIZMO_CIRCLE_SIZE);
 
 					for (int k = 0; k < m; ++k) {
-						Vector2 ofs = Vector2(Math::cos((Math_TAU * k) / m), Math::sin((Math_TAU * k) / m));
+						Vector2 ofs = Vector2(Math::cos((Math::TAU * k) / m), Math::sin((Math::TAU * k) / m));
 						Vector3 normal = ivec * ofs.x + ivec2 * ofs.y;
 
 						surftool->set_normal(basis.xform(normal));
@@ -7544,7 +7544,7 @@ void fragment() {
 
 				int arrow_sides = 4;
 
-				const real_t arrow_sides_step = Math_TAU / arrow_sides;
+				const real_t arrow_sides_step = Math::TAU / arrow_sides;
 				for (int k = 0; k < 4; k++) {
 					Basis ma(ivec, k * arrow_sides_step);
 					Basis mb(ivec, (k + 1) * arrow_sides_step);
@@ -7583,7 +7583,7 @@ void fragment() {
 					vec * GIZMO_PLANE_DST - ivec3 * GIZMO_PLANE_SIZE
 				};
 
-				Basis ma(ivec, Math_PI / 2);
+				Basis ma(ivec, Math::PI / 2);
 
 				Vector3 points[4] = {
 					ma.xform(plane[0]),
@@ -8912,7 +8912,7 @@ void Node3DEditor::_sun_direction_input(const Ref<InputEvent> &p_event) {
 	if (mm.is_valid() && mm->get_button_mask().has_flag(MouseButtonMask::LEFT)) {
 		sun_rotation.x += mm->get_relative().y * (0.02 * EDSCALE);
 		sun_rotation.y -= mm->get_relative().x * (0.02 * EDSCALE);
-		sun_rotation.x = CLAMP(sun_rotation.x, -Math_TAU / 4, Math_TAU / 4);
+		sun_rotation.x = CLAMP(sun_rotation.x, -Math::TAU / 4, Math::TAU / 4);
 
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 		undo_redo->create_action(TTR("Set Preview Sun Direction"), UndoRedo::MergeMode::MERGE_ENDS);

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -472,7 +472,7 @@ void Path3DGizmo::redraw() {
 
 					const int n = 36;
 					for (int i = 0; i <= n; i++) {
-						const float a = Math_TAU * i / n;
+						const float a = Math::TAU * i / n;
 						const Vector3 edge = sin(a) * side + cos(a) * up;
 						disk.append(pos + edge * disk_size);
 					}

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -253,7 +253,7 @@ void ResourcePreloaderEditor::edit(ResourcePreloader *p_preloader) {
 }
 
 Variant ResourcePreloaderEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
-	TreeItem *ti = (p_point == Vector2(INFINITY, INFINITY)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+	TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
 	if (!ti) {
 		return Variant();
 	}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3273,7 +3273,7 @@ void ScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 			int new_index = 0;
 			if (script_list->get_item_count() > 0) {
 				int pos = 0;
-				if (p_point == Vector2(INFINITY, INFINITY)) {
+				if (p_point == Vector2(Math::INF, Math::INF)) {
 					if (script_list->is_anything_selected()) {
 						pos = script_list->get_selected_items()[0];
 					}
@@ -3301,7 +3301,7 @@ void ScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 			int new_index = 0;
 			if (script_list->get_item_count() > 0) {
 				int pos = 0;
-				if (p_point == Vector2(INFINITY, INFINITY)) {
+				if (p_point == Vector2(Math::INF, Math::INF)) {
 					if (script_list->is_anything_selected()) {
 						pos = script_list->get_selected_items()[0];
 					}
@@ -3322,7 +3322,7 @@ void ScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 		int new_index = 0;
 		if (script_list->get_item_count() > 0) {
 			int pos = 0;
-			if (p_point == Vector2(INFINITY, INFINITY)) {
+			if (p_point == Vector2(Math::INF, Math::INF)) {
 				if (script_list->is_anything_selected()) {
 					pos = script_list->get_selected_items()[0];
 				}

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1958,7 +1958,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	Dictionary d = p_data;
 
 	CodeEdit *te = code_editor->get_text_editor();
-	Point2i pos = (p_point == Vector2(INFINITY, INFINITY)) ? Point2i(te->get_caret_line(0), te->get_caret_column(0)) : te->get_line_column_at_pos(p_point);
+	Point2i pos = (p_point == Vector2(Math::INF, Math::INF)) ? Point2i(te->get_caret_line(0), te->get_caret_column(0)) : te->get_line_column_at_pos(p_point);
 	int drop_at_line = pos.y;
 	int drop_at_column = pos.x;
 	int selection_index = te->get_selection_at_line_column(drop_at_line, drop_at_column);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -642,7 +642,7 @@ Variant ShaderEditorPlugin::get_drag_data_fw(const Point2 &p_point, Control *p_f
 	}
 
 	int idx = 0;
-	if (p_point == Vector2(INFINITY, INFINITY)) {
+	if (p_point == Vector2(Math::INF, Math::INF)) {
 		if (shader_list->is_anything_selected()) {
 			idx = shader_list->get_selected_items()[0];
 		}
@@ -726,7 +726,7 @@ void ShaderEditorPlugin::drop_data_fw(const Point2 &p_point, const Variant &p_da
 	if (String(d["type"]) == "shader_list_element") {
 		int idx = d["shader_list_element"];
 		int new_idx = 0;
-		if (p_point == Vector2(INFINITY, INFINITY)) {
+		if (p_point == Vector2(Math::INF, Math::INF)) {
 			if (shader_list->is_anything_selected()) {
 				new_idx = shader_list->get_selected_items()[0];
 			}

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -701,7 +701,7 @@ Variant Skeleton3DEditor::get_drag_data_fw(const Point2 &p_point, Control *p_fro
 }
 
 bool Skeleton3DEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
-	TreeItem *target = (p_point == Vector2(INFINITY, INFINITY)) ? joint_tree->get_selected() : joint_tree->get_item_at_position(p_point);
+	TreeItem *target = (p_point == Vector2(Math::INF, Math::INF)) ? joint_tree->get_selected() : joint_tree->get_item_at_position(p_point);
 	if (!target) {
 		return false;
 	}
@@ -729,7 +729,7 @@ void Skeleton3DEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 		return;
 	}
 
-	TreeItem *target = (p_point == Vector2(INFINITY, INFINITY)) ? joint_tree->get_selected() : joint_tree->get_item_at_position(p_point);
+	TreeItem *target = (p_point == Vector2(Math::INF, Math::INF)) ? joint_tree->get_selected() : joint_tree->get_item_at_position(p_point);
 	TreeItem *selected = Object::cast_to<TreeItem>(Dictionary(p_data)["node"]);
 
 	const BoneId target_boneidx = String(target->get_metadata(0)).get_slicec('/', 1).to_int();

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1662,7 +1662,7 @@ Variant SpriteFramesEditor::get_drag_data_fw(const Point2 &p_point, Control *p_f
 	}
 
 	int idx = -1;
-	if (p_point == Vector2(INFINITY, INFINITY)) {
+	if (p_point == Vector2(Math::INF, Math::INF)) {
 		if (frame_list->is_anything_selected()) {
 			idx = frame_list->get_selected_items()[0];
 		}
@@ -1744,7 +1744,7 @@ void SpriteFramesEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 	}
 
 	int at_pos = -1;
-	if (p_point == Vector2(INFINITY, INFINITY)) {
+	if (p_point == Vector2(Math::INF, Math::INF)) {
 		if (frame_list->is_anything_selected()) {
 			at_pos = frame_list->get_selected_items()[0];
 		}

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -171,7 +171,7 @@ void TextureRegionEditor::_texture_overlay_draw() {
 		int next = (i + 1) % 4;
 
 		Vector2 ofs = ((endpoints[i] - endpoints[prev]).normalized() + ((endpoints[i] - endpoints[next]).normalized())).normalized();
-		ofs *= Math_SQRT2 * (select_handle->get_size().width / 2);
+		ofs *= Math::SQRT2 * (select_handle->get_size().width / 2);
 
 		texture_overlay->draw_line(endpoints[i] - draw_ofs * draw_zoom, endpoints[next] - draw_ofs * draw_zoom, color, 2);
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -80,14 +80,14 @@ struct FloatConstantDef {
 };
 
 static FloatConstantDef float_constant_defs[] = {
-	{ "E", Math_E, TTRC("E constant (2.718282). Represents the base of the natural logarithm.") },
+	{ "E", Math::E, TTRC("E constant (2.718282). Represents the base of the natural logarithm.") },
 	{ "Epsilon", CMP_EPSILON, TTRC("Epsilon constant (0.00001). Smallest possible scalar number.") },
 	{ "Phi", 1.618034f, TTRC("Phi constant (1.618034). Golden ratio.") },
-	{ "Pi/4", Math_PI / 4, TTRC("Pi/4 constant (0.785398) or 45 degrees.") },
-	{ "Pi/2", Math_PI / 2, TTRC("Pi/2 constant (1.570796) or 90 degrees.") },
-	{ "Pi", Math_PI, TTRC("Pi constant (3.141593) or 180 degrees.") },
-	{ "Tau", Math_TAU, TTRC("Tau constant (6.283185) or 360 degrees.") },
-	{ "Sqrt2", Math_SQRT2, TTRC("Sqrt2 constant (1.414214). Square root of 2.") }
+	{ "Pi/4", Math::PI / 4, TTRC("Pi/4 constant (0.785398) or 45 degrees.") },
+	{ "Pi/2", Math::PI / 2, TTRC("Pi/2 constant (1.570796) or 90 degrees.") },
+	{ "Pi", Math::PI, TTRC("Pi constant (3.141593) or 180 degrees.") },
+	{ "Tau", Math::TAU, TTRC("Tau constant (6.283185) or 360 degrees.") },
+	{ "Sqrt2", Math::SQRT2, TTRC("Sqrt2 constant (1.414214). Square root of 2.") }
 };
 
 constexpr int MAX_FLOAT_CONST_DEFS = std::size(float_constant_defs);
@@ -6122,7 +6122,7 @@ void VisualShaderEditor::_connection_menu_id_pressed(int p_idx) {
 }
 
 Variant VisualShaderEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
-	if (p_point == Vector2(INFINITY, INFINITY)) {
+	if (p_point == Vector2(Math::INF, Math::INF)) {
 		return Variant();
 	}
 
@@ -6151,7 +6151,7 @@ Variant VisualShaderEditor::get_drag_data_fw(const Point2 &p_point, Control *p_f
 }
 
 bool VisualShaderEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
-	if (p_point == Vector2(INFINITY, INFINITY)) {
+	if (p_point == Vector2(Math::INF, Math::INF)) {
 		return false;
 	}
 
@@ -6170,7 +6170,7 @@ bool VisualShaderEditor::can_drop_data_fw(const Point2 &p_point, const Variant &
 }
 
 void VisualShaderEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
-	if (p_point == Vector2(INFINITY, INFINITY)) {
+	if (p_point == Vector2(Math::INF, Math::INF)) {
 		return;
 	}
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1348,14 +1348,14 @@ CSGBrush *CSGSphere3D::_build_brush() {
 
 		// We want to follow an order that's convenient for UVs.
 		// For latitude step we start at the top and move down like in an image.
-		const double latitude_step = -Math_PI / rings;
-		const double longitude_step = Math_TAU / radial_segments;
+		const double latitude_step = -Math::PI / rings;
+		const double longitude_step = Math::TAU / radial_segments;
 		int face = 0;
 		for (int i = 0; i < rings; i++) {
 			double cos0 = 0;
 			double sin0 = 1;
 			if (i > 0) {
-				double latitude0 = latitude_step * i + Math_TAU / 4;
+				double latitude0 = latitude_step * i + Math::TAU / 4;
 				cos0 = Math::cos(latitude0);
 				sin0 = Math::sin(latitude0);
 			}
@@ -1364,7 +1364,7 @@ CSGBrush *CSGSphere3D::_build_brush() {
 			double cos1 = 0;
 			double sin1 = -1;
 			if (i < rings - 1) {
-				double latitude1 = latitude_step * (i + 1) + Math_TAU / 4;
+				double latitude1 = latitude_step * (i + 1) + Math::TAU / 4;
 				cos1 = Math::cos(latitude1);
 				sin1 = Math::sin(latitude1);
 			}
@@ -1727,8 +1727,8 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 					inc_n = 0;
 				}
 
-				float ang = inc * Math_TAU;
-				float ang_n = inc_n * Math_TAU;
+				float ang = inc * Math::TAU;
+				float ang_n = inc_n * Math::TAU;
 
 				Vector3 face_base(Math::cos(ang), 0, Math::sin(ang));
 				Vector3 face_base_n(Math::cos(ang_n), 0, Math::sin(ang_n));
@@ -1970,8 +1970,8 @@ CSGBrush *CSGTorus3D::_build_brush() {
 					inci_n = 0;
 				}
 
-				float angi = inci * Math_TAU;
-				float angi_n = inci_n * Math_TAU;
+				float angi = inci * Math::TAU;
+				float angi_n = inci_n * Math::TAU;
 
 				Vector3 normali = Vector3(Math::cos(angi), 0, Math::sin(angi));
 				Vector3 normali_n = Vector3(Math::cos(angi_n), 0, Math::sin(angi_n));
@@ -1983,8 +1983,8 @@ CSGBrush *CSGTorus3D::_build_brush() {
 						incj_n = 0;
 					}
 
-					float angj = incj * Math_TAU;
-					float angj_n = incj_n * Math_TAU;
+					float angj = incj * Math::TAU;
+					float angj_n = incj_n * Math::TAU;
 
 					Vector2 normalj = Vector2(Math::cos(angj), Math::sin(angj)) * radius + Vector2(min_radius + radius, 0);
 					Vector2 normalj_n = Vector2(Math::cos(angj_n), Math::sin(angj_n)) * radius + Vector2(min_radius + radius, 0);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2254,10 +2254,10 @@ void GDScriptLanguage::init() {
 		_add_global(StaticCString::create(CoreConstants::get_global_constant_name(i)), CoreConstants::get_global_constant_value(i));
 	}
 
-	_add_global(StaticCString::create("PI"), Math_PI);
-	_add_global(StaticCString::create("TAU"), Math_TAU);
-	_add_global(StaticCString::create("INF"), INFINITY);
-	_add_global(StaticCString::create("NAN"), NAN);
+	_add_global(StaticCString::create("PI"), Math::PI);
+	_add_global(StaticCString::create("TAU"), Math::TAU);
+	_add_global(StaticCString::create("INF"), Math::INF);
+	_add_global(StaticCString::create("NAN"), Math::NaN);
 
 	//populate native classes
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -488,22 +488,22 @@ void GDScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) const
 void GDScriptLanguage::get_public_constants(List<Pair<String, Variant>> *p_constants) const {
 	Pair<String, Variant> pi;
 	pi.first = "PI";
-	pi.second = Math_PI;
+	pi.second = Math::PI;
 	p_constants->push_back(pi);
 
 	Pair<String, Variant> tau;
 	tau.first = "TAU";
-	tau.second = Math_TAU;
+	tau.second = Math::TAU;
 	p_constants->push_back(tau);
 
 	Pair<String, Variant> infinity;
 	infinity.first = "INF";
-	infinity.second = INFINITY;
+	infinity.second = Math::INF;
 	p_constants->push_back(infinity);
 
 	Pair<String, Variant> nan;
 	nan.first = "NAN";
-	nan.second = NAN;
+	nan.second = Math::NaN;
 	p_constants->push_back(nan);
 }
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2720,16 +2720,16 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_builtin_constant(Expressio
 
 	switch (op_type) {
 		case GDScriptTokenizer::Token::CONST_PI:
-			constant->value = Math_PI;
+			constant->value = Math::PI;
 			break;
 		case GDScriptTokenizer::Token::CONST_TAU:
-			constant->value = Math_TAU;
+			constant->value = Math::TAU;
 			break;
 		case GDScriptTokenizer::Token::CONST_INF:
-			constant->value = INFINITY;
+			constant->value = Math::INF;
 			break;
 		case GDScriptTokenizer::Token::CONST_NAN:
-			constant->value = NAN;
+			constant->value = Math::NaN;
 			break;
 		default:
 			return nullptr; // Unreachable.

--- a/modules/gltf/extensions/gltf_light.cpp
+++ b/modules/gltf/extensions/gltf_light.cpp
@@ -232,7 +232,7 @@ Dictionary GLTFLight::to_dictionary() const {
 	if (intensity != 1.0f) {
 		d["intensity"] = intensity;
 	}
-	if (light_type != "directional" && range != INFINITY) {
+	if (light_type != "directional" && range != Math::INF) {
 		d["range"] = range;
 	}
 	if (light_type == "spot") {

--- a/modules/gltf/extensions/gltf_light.h
+++ b/modules/gltf/extensions/gltf_light.h
@@ -48,9 +48,9 @@ private:
 	Color color = Color(1.0f, 1.0f, 1.0f);
 	float intensity = 1.0f;
 	String light_type;
-	float range = INFINITY;
+	float range = Math::INF;
 	float inner_cone_angle = 0.0f;
-	float outer_cone_angle = Math_TAU / 8.0f;
+	float outer_cone_angle = Math::TAU / 8.0f;
 	Dictionary additional_data;
 
 public:

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6973,7 +6973,7 @@ void GLTFDocument::_import_animation(Ref<GLTFState> p_state, AnimationPlayer *p_
 		animation->set_loop_mode(Animation::LOOP_LINEAR);
 	}
 
-	double anim_start = p_trimming ? INFINITY : 0.0;
+	double anim_start = p_trimming ? Math::INF : 0.0;
 	double anim_end = 0.0;
 
 	for (const KeyValue<int, GLTFAnimation::NodeTrack> &track_i : anim->get_node_tracks()) {
@@ -7660,7 +7660,7 @@ bool GLTFDocument::_convert_animation_node_track(Ref<GLTFState> p_state, GLTFAni
 						} else {
 							Vector3 rotation_euler = p_godot_animation->track_get_key_value(p_godot_anim_track_index, key_i);
 							if (node_prop == "rotation_degrees") {
-								rotation_euler *= Math_TAU / 360.0;
+								rotation_euler *= Math::TAU / 360.0;
 							}
 							rotation_quaternion = Quaternion::from_euler(rotation_euler);
 						}

--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -563,7 +563,7 @@ void GodotBody2D::integrate_forces(real_t p_step) {
 		linear_velocity = constant_linear_velocity + motion / p_step;
 
 		real_t rot = new_transform.get_rotation() - get_transform().get_rotation();
-		angular_velocity = constant_angular_velocity + remainder(rot, 2.0 * Math_PI) / p_step;
+		angular_velocity = constant_angular_velocity + remainder(rot, 2.0 * Math::PI) / p_step;
 
 		do_motion = true;
 

--- a/modules/godot_physics_2d/godot_body_pair_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_pair_2d.cpp
@@ -36,7 +36,7 @@
 #define ACCUMULATE_IMPULSES
 
 #define MIN_VELOCITY 0.001
-#define MAX_BIAS_ROTATION (Math_PI / 8)
+#define MAX_BIAS_ROTATION (Math::PI / 8)
 
 void GodotBodyPair2D::_add_contact(const Vector2 &p_point_A, const Vector2 &p_point_B, void *p_self) {
 	GodotBodyPair2D *self = static_cast<GodotBodyPair2D *>(p_self);

--- a/modules/godot_physics_3d/godot_body_pair_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_pair_3d.cpp
@@ -34,7 +34,7 @@
 #include "godot_space_3d.h"
 
 #define MIN_VELOCITY 0.0001
-#define MAX_BIAS_ROTATION (Math_PI / 8)
+#define MAX_BIAS_ROTATION (Math::PI / 8)
 
 void GodotBodyPair3D::_contact_added_callback(const Vector3 &p_point_A, int p_index_A, const Vector3 &p_point_B, int p_index_B, const Vector3 &normal, void *p_userdata) {
 	GodotBodyPair3D *pair = static_cast<GodotBodyPair3D *>(p_userdata);

--- a/modules/godot_physics_3d/godot_collision_solver_3d.cpp
+++ b/modules/godot_physics_3d/godot_collision_solver_3d.cpp
@@ -61,8 +61,8 @@ bool GodotCollisionSolver3D::solve_static_world_boundary(const GodotShape3D *p_s
 		// Use 3 equidistant points on the circle.
 		for (int i = 0; i < 3; ++i) {
 			Vector3 vertex_pos = circle_pos;
-			vertex_pos += circle_axis_1 * Math::cos(2.0 * Math_PI * i / 3.0);
-			vertex_pos += circle_axis_2 * Math::sin(2.0 * Math_PI * i / 3.0);
+			vertex_pos += circle_axis_1 * Math::cos(2.0 * Math::PI * i / 3.0);
+			vertex_pos += circle_axis_2 * Math::sin(2.0 * Math::PI * i / 3.0);
 			supports[i] = vertex_pos;
 		}
 	}
@@ -488,8 +488,8 @@ bool GodotCollisionSolver3D::solve_distance_world_boundary(const GodotShape3D *p
 		// Use 3 equidistant points on the circle.
 		for (int i = 0; i < 3; ++i) {
 			Vector3 vertex_pos = circle_pos;
-			vertex_pos += circle_axis_1 * Math::cos(2.0 * Math_PI * i / 3.0);
-			vertex_pos += circle_axis_2 * Math::sin(2.0 * Math_PI * i / 3.0);
+			vertex_pos += circle_axis_1 * Math::cos(2.0 * Math::PI * i / 3.0);
+			vertex_pos += circle_axis_2 * Math::sin(2.0 * Math::PI * i / 3.0);
 			supports[i] = vertex_pos;
 		}
 	}

--- a/modules/godot_physics_3d/godot_collision_solver_3d_sat.cpp
+++ b/modules/godot_physics_3d/godot_collision_solver_3d_sat.cpp
@@ -381,7 +381,7 @@ static void _generate_contacts_face_circle(const Vector3 *p_points_A, int p_poin
 	static const int circle_segments = 8;
 	Vector3 circle_points[circle_segments];
 
-	real_t angle_delta = 2.0 * Math_PI / circle_segments;
+	real_t angle_delta = 2.0 * Math::PI / circle_segments;
 
 	for (int i = 0; i < circle_segments; ++i) {
 		Vector3 point_pos = circle_B_pos;
@@ -511,8 +511,8 @@ static void _generate_contacts_circle_circle(const Vector3 *p_points_A, int p_po
 			// Circle A inside circle B.
 			for (int i = 0; i < 3; ++i) {
 				Vector3 circle_A_point = circle_A_pos;
-				circle_A_point += circle_A_line_1 * Math::cos(2.0 * Math_PI * i / 3.0);
-				circle_A_point += circle_A_line_2 * Math::sin(2.0 * Math_PI * i / 3.0);
+				circle_A_point += circle_A_line_1 * Math::cos(2.0 * Math::PI * i / 3.0);
+				circle_A_point += circle_A_line_2 * Math::sin(2.0 * Math::PI * i / 3.0);
 
 				contact_points[num_points] = circle_A_point;
 				++num_points;
@@ -521,8 +521,8 @@ static void _generate_contacts_circle_circle(const Vector3 *p_points_A, int p_po
 			// Circle B inside circle A.
 			for (int i = 0; i < 3; ++i) {
 				Vector3 circle_B_point = circle_B_pos;
-				circle_B_point += circle_B_line_1 * Math::cos(2.0 * Math_PI * i / 3.0);
-				circle_B_point += circle_B_line_2 * Math::sin(2.0 * Math_PI * i / 3.0);
+				circle_B_point += circle_B_line_1 * Math::cos(2.0 * Math::PI * i / 3.0);
+				circle_B_point += circle_B_line_2 * Math::sin(2.0 * Math::PI * i / 3.0);
 
 				Vector3 circle_A_point = circle_B_point - norm_proj;
 

--- a/modules/godot_physics_3d/godot_joint_3d.h
+++ b/modules/godot_physics_3d/godot_joint_3d.h
@@ -39,7 +39,7 @@ protected:
 	bool dynamic_B = false;
 
 	void plane_space(const Vector3 &n, Vector3 &p, Vector3 &q) {
-		if (Math::abs(n.z) > Math_SQRT12) {
+		if (Math::abs(n.z) > Math::SQRT12) {
 			// choose p in y-z plane
 			real_t a = n[1] * n[1] + n[2] * n[2];
 			real_t k = 1.0 / Math::sqrt(a);
@@ -57,7 +57,7 @@ protected:
 	}
 
 	_FORCE_INLINE_ real_t atan2fast(real_t y, real_t x) {
-		real_t coeff_1 = Math_PI / 4.0f;
+		real_t coeff_1 = Math::PI / 4.0f;
 		real_t coeff_2 = 3.0f * coeff_1;
 		real_t abs_y = Math::abs(y);
 		real_t angle;

--- a/modules/godot_physics_3d/godot_shape_3d.h
+++ b/modules/godot_physics_3d/godot_shape_3d.h
@@ -119,7 +119,7 @@ class GodotWorldBoundaryShape3D : public GodotShape3D {
 public:
 	Plane get_plane() const;
 
-	virtual real_t get_volume() const override { return INFINITY; }
+	virtual real_t get_volume() const override { return Math::INF; }
 	virtual PhysicsServer3D::ShapeType get_type() const override { return PhysicsServer3D::SHAPE_WORLD_BOUNDARY; }
 	virtual void project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const override;
 	virtual Vector3 get_support(const Vector3 &p_normal) const override;
@@ -172,7 +172,7 @@ class GodotSphereShape3D : public GodotShape3D {
 public:
 	real_t get_radius() const;
 
-	virtual real_t get_volume() const override { return 4.0 / 3.0 * Math_PI * radius * radius * radius; }
+	virtual real_t get_volume() const override { return 4.0 / 3.0 * Math::PI * radius * radius * radius; }
 
 	virtual PhysicsServer3D::ShapeType get_type() const override { return PhysicsServer3D::SHAPE_SPHERE; }
 
@@ -226,7 +226,7 @@ public:
 	_FORCE_INLINE_ real_t get_height() const { return height; }
 	_FORCE_INLINE_ real_t get_radius() const { return radius; }
 
-	virtual real_t get_volume() const override { return 4.0 / 3.0 * Math_PI * radius * radius * radius + (height - radius * 2.0) * Math_PI * radius * radius; }
+	virtual real_t get_volume() const override { return 4.0 / 3.0 * Math::PI * radius * radius * radius + (height - radius * 2.0) * Math::PI * radius * radius; }
 
 	virtual PhysicsServer3D::ShapeType get_type() const override { return PhysicsServer3D::SHAPE_CAPSULE; }
 
@@ -255,7 +255,7 @@ public:
 	_FORCE_INLINE_ real_t get_height() const { return height; }
 	_FORCE_INLINE_ real_t get_radius() const { return radius; }
 
-	virtual real_t get_volume() const override { return height * Math_PI * radius * radius; }
+	virtual real_t get_volume() const override { return height * Math::PI * radius * radius; }
 
 	virtual PhysicsServer3D::ShapeType get_type() const override { return PhysicsServer3D::SHAPE_CYLINDER; }
 

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -1245,7 +1245,7 @@ struct _SoftBodyIntersectSegmentInfo {
 	Vector3 dir;
 	Vector3 hit_position;
 	uint32_t hit_face_index = -1;
-	real_t hit_dist_sq = INFINITY;
+	real_t hit_dist_sq = Math::INF;
 
 	static bool process_hit(uint32_t p_face_index, void *p_userdata) {
 		_SoftBodyIntersectSegmentInfo &query_info = *(static_cast<_SoftBodyIntersectSegmentInfo *>(p_userdata));
@@ -1276,7 +1276,7 @@ bool GodotSoftBodyShape3D::intersect_segment(const Vector3 &p_begin, const Vecto
 
 	soft_body->query_ray(p_begin, p_end, _SoftBodyIntersectSegmentInfo::process_hit, &query_info);
 
-	if (query_info.hit_dist_sq != INFINITY) {
+	if (query_info.hit_dist_sq != Math::INF) {
 		r_result = query_info.hit_position;
 		r_normal = soft_body->get_face_normal(query_info.hit_face_index);
 		return true;

--- a/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.h
@@ -79,7 +79,7 @@ public:
 	real_t m_biasFactor = 0.3;
 	real_t m_relaxationFactor = 1.0;
 
-	real_t m_swingSpan1 = Math_TAU / 8.0;
+	real_t m_swingSpan1 = Math::TAU / 8.0;
 	real_t m_swingSpan2 = 0.0;
 	real_t m_twistSpan = 0.0;
 

--- a/modules/godot_physics_3d/joints/godot_hinge_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_hinge_joint_3d.h
@@ -75,8 +75,8 @@ class GodotHingeJoint3D : public GodotJoint3D {
 	real_t m_biasFactor = 0.3;
 	real_t m_relaxationFactor = 1.0;
 
-	real_t m_lowerLimit = Math_PI;
-	real_t m_upperLimit = -Math_PI;
+	real_t m_lowerLimit = Math::PI;
+	real_t m_upperLimit = -Math::PI;
 
 	real_t m_kHinge = 0.0;
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -98,14 +98,14 @@ void GridMapEditor::_menu_option(int p_option) {
 			Basis r;
 			if (input_action == INPUT_PASTE) {
 				r = node->get_basis_with_orthogonal_index(paste_indicator.orientation);
-				r.rotate(Vector3(0, 1, 0), -Math_PI / 2.0);
+				r.rotate(Vector3(0, 1, 0), -Math::PI / 2.0);
 				paste_indicator.orientation = node->get_orthogonal_index_from_basis(r);
 				_update_paste_indicator();
 				break;
 			}
 
 			r = node->get_basis_with_orthogonal_index(cursor_rot);
-			r.rotate(Vector3(0, 1, 0), -Math_PI / 2.0);
+			r.rotate(Vector3(0, 1, 0), -Math::PI / 2.0);
 			cursor_rot = node->get_orthogonal_index_from_basis(r);
 			_update_cursor_transform();
 		} break;
@@ -113,14 +113,14 @@ void GridMapEditor::_menu_option(int p_option) {
 			Basis r;
 			if (input_action == INPUT_PASTE) {
 				r = node->get_basis_with_orthogonal_index(paste_indicator.orientation);
-				r.rotate(Vector3(1, 0, 0), -Math_PI / 2.0);
+				r.rotate(Vector3(1, 0, 0), -Math::PI / 2.0);
 				paste_indicator.orientation = node->get_orthogonal_index_from_basis(r);
 				_update_paste_indicator();
 				break;
 			}
 
 			r = node->get_basis_with_orthogonal_index(cursor_rot);
-			r.rotate(Vector3(1, 0, 0), -Math_PI / 2.0);
+			r.rotate(Vector3(1, 0, 0), -Math::PI / 2.0);
 			cursor_rot = node->get_orthogonal_index_from_basis(r);
 			_update_cursor_transform();
 		} break;
@@ -128,14 +128,14 @@ void GridMapEditor::_menu_option(int p_option) {
 			Basis r;
 			if (input_action == INPUT_PASTE) {
 				r = node->get_basis_with_orthogonal_index(paste_indicator.orientation);
-				r.rotate(Vector3(0, 0, 1), -Math_PI / 2.0);
+				r.rotate(Vector3(0, 0, 1), -Math::PI / 2.0);
 				paste_indicator.orientation = node->get_orthogonal_index_from_basis(r);
 				_update_paste_indicator();
 				break;
 			}
 
 			r = node->get_basis_with_orthogonal_index(cursor_rot);
-			r.rotate(Vector3(0, 0, 1), -Math_PI / 2.0);
+			r.rotate(Vector3(0, 0, 1), -Math::PI / 2.0);
 			cursor_rot = node->get_orthogonal_index_from_basis(r);
 			_update_cursor_transform();
 		} break;
@@ -143,14 +143,14 @@ void GridMapEditor::_menu_option(int p_option) {
 			Basis r;
 			if (input_action == INPUT_PASTE) {
 				r = node->get_basis_with_orthogonal_index(paste_indicator.orientation);
-				r.rotate(Vector3(0, 1, 0), Math_PI / 2.0);
+				r.rotate(Vector3(0, 1, 0), Math::PI / 2.0);
 				paste_indicator.orientation = node->get_orthogonal_index_from_basis(r);
 				_update_paste_indicator();
 				break;
 			}
 
 			r = node->get_basis_with_orthogonal_index(cursor_rot);
-			r.rotate(Vector3(0, 1, 0), Math_PI / 2.0);
+			r.rotate(Vector3(0, 1, 0), Math::PI / 2.0);
 			cursor_rot = node->get_orthogonal_index_from_basis(r);
 			_update_cursor_transform();
 		} break;
@@ -158,14 +158,14 @@ void GridMapEditor::_menu_option(int p_option) {
 			Basis r;
 			if (input_action == INPUT_PASTE) {
 				r = node->get_basis_with_orthogonal_index(paste_indicator.orientation);
-				r.rotate(Vector3(1, 0, 0), Math_PI / 2.0);
+				r.rotate(Vector3(1, 0, 0), Math::PI / 2.0);
 				paste_indicator.orientation = node->get_orthogonal_index_from_basis(r);
 				_update_paste_indicator();
 				break;
 			}
 
 			r = node->get_basis_with_orthogonal_index(cursor_rot);
-			r.rotate(Vector3(1, 0, 0), Math_PI / 2.0);
+			r.rotate(Vector3(1, 0, 0), Math::PI / 2.0);
 			cursor_rot = node->get_orthogonal_index_from_basis(r);
 			_update_cursor_transform();
 		} break;
@@ -173,14 +173,14 @@ void GridMapEditor::_menu_option(int p_option) {
 			Basis r;
 			if (input_action == INPUT_PASTE) {
 				r = node->get_basis_with_orthogonal_index(paste_indicator.orientation);
-				r.rotate(Vector3(0, 0, 1), Math_PI / 2.0);
+				r.rotate(Vector3(0, 0, 1), Math::PI / 2.0);
 				paste_indicator.orientation = node->get_orthogonal_index_from_basis(r);
 				_update_paste_indicator();
 				break;
 			}
 
 			r = node->get_basis_with_orthogonal_index(cursor_rot);
-			r.rotate(Vector3(0, 0, 1), Math_PI / 2.0);
+			r.rotate(Vector3(0, 0, 1), Math::PI / 2.0);
 			cursor_rot = node->get_orthogonal_index_from_basis(r);
 			_update_cursor_transform();
 		} break;

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -111,7 +111,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(const JPH::Shape &p_jolt_s
 	};
 
 	// Figure out the number of steps we need in our binary search in order to achieve millimeter precision, within reason.
-	const int step_count = CLAMP(int(logf(1000.0f * motion_length) / (float)Math_LN2), 4, 16);
+	const int step_count = CLAMP(int(logf(1000.0f * motion_length) / (float)Math::LN2), 4, 16);
 
 	bool collided = false;
 

--- a/modules/jolt_physics/spaces/jolt_space_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_space_3d.cpp
@@ -57,7 +57,7 @@ constexpr double DEFAULT_CONTACT_MAX_SEPARATION = 0.05;
 constexpr double DEFAULT_CONTACT_MAX_ALLOWED_PENETRATION = 0.01;
 constexpr double DEFAULT_CONTACT_DEFAULT_BIAS = 0.8;
 constexpr double DEFAULT_SLEEP_THRESHOLD_LINEAR = 0.1;
-constexpr double DEFAULT_SLEEP_THRESHOLD_ANGULAR = 8.0 * Math_PI / 180;
+constexpr double DEFAULT_SLEEP_THRESHOLD_ANGULAR = 8.0 * Math::PI / 180;
 constexpr double DEFAULT_SOLVER_ITERATIONS = 8;
 
 } // namespace

--- a/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
@@ -253,7 +253,7 @@ void OpenXRHandTrackingExtension::on_process() {
 				// SKELETON_RIG_HUMANOID bone adjustment. This rotation performs:
 				// OpenXR Z+ -> Godot Humanoid Y-  (Back along the bone)
 				// OpenXR Y+ -> Godot Humanoid Z- (Out the back of the hand)
-				const Quaternion bone_adjustment(0.0, -Math_SQRT12, Math_SQRT12, 0.0);
+				const Quaternion bone_adjustment(0.0, -Math::SQRT12, Math::SQRT12, 0.0);
 
 				for (int joint = 0; joint < XR_HAND_JOINT_COUNT_EXT; joint++) {
 					const XrHandJointLocationEXT &location = hand_trackers[i].joint_locations[joint];

--- a/modules/openxr/scene/openxr_composition_layer_cylinder.cpp
+++ b/modules/openxr/scene/openxr_composition_layer_cylinder.cpp
@@ -77,7 +77,7 @@ Ref<Mesh> OpenXRCompositionLayerCylinder::_create_fallback_mesh() {
 	Vector<int> indices;
 
 	float delta_angle = central_angle / fallback_segments;
-	float start_angle = (-Math_PI / 2.0) - (central_angle / 2.0);
+	float start_angle = (-Math::PI / 2.0) - (central_angle / 2.0);
 
 	for (uint32_t i = 0; i < fallback_segments + 1; i++) {
 		float current_angle = start_angle + (delta_angle * i);
@@ -192,7 +192,7 @@ Vector2 OpenXRCompositionLayerCylinder::intersects_ray(const Vector3 &p_origin, 
 	Vector3 intersection = p_origin + p_direction * t;
 
 	Basis correction = cylinder_transform.basis.inverse();
-	correction.rotate(Vector3(0.0, 1.0, 0.0), -Math_PI / 2.0);
+	correction.rotate(Vector3(0.0, 1.0, 0.0), -Math::PI / 2.0);
 	Vector3 relative_point = correction.xform(intersection - cylinder_transform.origin);
 
 	Vector2 projected_point = Vector2(relative_point.x, relative_point.z);

--- a/modules/openxr/scene/openxr_composition_layer_cylinder.h
+++ b/modules/openxr/scene/openxr_composition_layer_cylinder.h
@@ -46,13 +46,13 @@ class OpenXRCompositionLayerCylinder : public OpenXRCompositionLayer {
 		{}, // subImage
 		{ { 0, 0, 0, 0 }, { 0, 0, 0 } }, // pose
 		1.0, // radius
-		Math_PI / 2.0, // centralAngle
+		Math::PI / 2.0, // centralAngle
 		1.0, // aspectRatio
 	};
 
 	float radius = 1.0;
 	float aspect_ratio = 1.0;
-	float central_angle = Math_PI / 2.0;
+	float central_angle = Math::PI / 2.0;
 	uint32_t fallback_segments = 10;
 
 protected:

--- a/modules/openxr/scene/openxr_composition_layer_equirect.cpp
+++ b/modules/openxr/scene/openxr_composition_layer_equirect.cpp
@@ -80,7 +80,7 @@ Ref<Mesh> OpenXRCompositionLayerEquirect::_create_fallback_mesh() {
 	float step_horizontal = central_horizontal_angle / fallback_segments;
 	float step_vertical = (upper_vertical_angle + lower_vertical_angle) / fallback_segments;
 
-	float start_horizontal_angle = Math_PI - (central_horizontal_angle / 2.0);
+	float start_horizontal_angle = Math::PI - (central_horizontal_angle / 2.0);
 
 	for (uint32_t i = 0; i < fallback_segments + 1; i++) {
 		for (uint32_t j = 0; j < fallback_segments + 1; j++) {
@@ -155,7 +155,7 @@ float OpenXRCompositionLayerEquirect::get_central_horizontal_angle() const {
 }
 
 void OpenXRCompositionLayerEquirect::set_upper_vertical_angle(float p_angle) {
-	ERR_FAIL_COND(p_angle <= 0 || p_angle > (Math_PI / 2.0));
+	ERR_FAIL_COND(p_angle <= 0 || p_angle > (Math::PI / 2.0));
 	upper_vertical_angle = p_angle;
 	composition_layer.upperVerticalAngle = p_angle;
 	update_fallback_mesh();
@@ -166,7 +166,7 @@ float OpenXRCompositionLayerEquirect::get_upper_vertical_angle() const {
 }
 
 void OpenXRCompositionLayerEquirect::set_lower_vertical_angle(float p_angle) {
-	ERR_FAIL_COND(p_angle <= 0 || p_angle > (Math_PI / 2.0));
+	ERR_FAIL_COND(p_angle <= 0 || p_angle > (Math::PI / 2.0));
 	lower_vertical_angle = p_angle;
 	composition_layer.lowerVerticalAngle = -p_angle;
 	update_fallback_mesh();
@@ -209,7 +209,7 @@ Vector2 OpenXRCompositionLayerEquirect::intersects_ray(const Vector3 &p_origin, 
 	Vector3 intersection = p_origin + p_direction * t;
 
 	Basis correction = equirect_transform.basis.inverse();
-	correction.rotate(Vector3(0.0, 1.0, 0.0), -Math_PI / 2.0);
+	correction.rotate(Vector3(0.0, 1.0, 0.0), -Math::PI / 2.0);
 	Vector3 relative_point = correction.xform(intersection - equirect_transform.origin);
 
 	float horizontal_intersection_angle = Math::atan2(relative_point.z, relative_point.x);
@@ -217,7 +217,7 @@ Vector2 OpenXRCompositionLayerEquirect::intersects_ray(const Vector3 &p_origin, 
 		return Vector2(-1.0, -1.0);
 	}
 
-	float vertical_intersection_angle = Math::acos(relative_point.y / radius) - (Math_PI / 2.0);
+	float vertical_intersection_angle = Math::acos(relative_point.y / radius) - (Math::PI / 2.0);
 	if (vertical_intersection_angle < 0) {
 		if (Math::abs(vertical_intersection_angle) > upper_vertical_angle) {
 			return Vector2(-1.0, -1.0);

--- a/modules/openxr/scene/openxr_composition_layer_equirect.h
+++ b/modules/openxr/scene/openxr_composition_layer_equirect.h
@@ -46,15 +46,15 @@ class OpenXRCompositionLayerEquirect : public OpenXRCompositionLayer {
 		{}, // subImage
 		{ { 0, 0, 0, 0 }, { 0, 0, 0 } }, // pose
 		1.0, // radius
-		Math_PI / 2.0, // centralHorizontalAngle
-		Math_PI / 4.0, // upperVerticalAngle
-		-Math_PI / 4.0, // lowerVerticalAngle
+		Math::PI / 2.0, // centralHorizontalAngle
+		Math::PI / 4.0, // upperVerticalAngle
+		-Math::PI / 4.0, // lowerVerticalAngle
 	};
 
 	float radius = 1.0;
-	float central_horizontal_angle = Math_PI / 2.0;
-	float upper_vertical_angle = Math_PI / 4.0;
-	float lower_vertical_angle = Math_PI / 4.0;
+	float central_horizontal_angle = Math::PI / 2.0;
+	float upper_vertical_angle = Math::PI / 4.0;
+	float lower_vertical_angle = Math::PI / 4.0;
 	uint32_t fallback_segments = 10;
 
 protected:

--- a/modules/openxr/scene/openxr_hand.cpp
+++ b/modules/openxr/scene/openxr_hand.cpp
@@ -311,7 +311,7 @@ void OpenXRHand::_update_skeleton() {
 		// SKELETON_RIG_HUMANOID bone adjustment. This rotation performs:
 		// OpenXR Z+ -> Godot Humanoid Y-  (Back along the bone)
 		// OpenXR Y+ -> Godot Humanoid Z- (Out the back of the hand)
-		Quaternion(0.0, -Math_SQRT12, Math_SQRT12, 0.0),
+		Quaternion(0.0, -Math::SQRT12, Math::SQRT12, 0.0),
 	};
 
 	// we cache our transforms so we can quickly calculate local transforms

--- a/platform/ios/godot_view.mm
+++ b/platform/ios/godot_view.mm
@@ -454,22 +454,22 @@ static const float earth_gravity = 9.80665;
 
 	switch (interfaceOrientation) {
 		case UIInterfaceOrientationLandscapeLeft: {
-			DisplayServerIOS::get_singleton()->update_gravity(Vector3(gravity.x, gravity.y, gravity.z).rotated(Vector3(0, 0, 1), -Math_PI * 0.5));
-			DisplayServerIOS::get_singleton()->update_accelerometer(Vector3(acceleration.x + gravity.x, acceleration.y + gravity.y, acceleration.z + gravity.z).rotated(Vector3(0, 0, 1), -Math_PI * 0.5));
-			DisplayServerIOS::get_singleton()->update_magnetometer(Vector3(magnetic.x, magnetic.y, magnetic.z).rotated(Vector3(0, 0, 1), -Math_PI * 0.5));
-			DisplayServerIOS::get_singleton()->update_gyroscope(Vector3(rotation.x, rotation.y, rotation.z).rotated(Vector3(0, 0, 1), -Math_PI * 0.5));
+			DisplayServerIOS::get_singleton()->update_gravity(Vector3(gravity.x, gravity.y, gravity.z).rotated(Vector3(0, 0, 1), -Math::PI * 0.5));
+			DisplayServerIOS::get_singleton()->update_accelerometer(Vector3(acceleration.x + gravity.x, acceleration.y + gravity.y, acceleration.z + gravity.z).rotated(Vector3(0, 0, 1), -Math::PI * 0.5));
+			DisplayServerIOS::get_singleton()->update_magnetometer(Vector3(magnetic.x, magnetic.y, magnetic.z).rotated(Vector3(0, 0, 1), -Math::PI * 0.5));
+			DisplayServerIOS::get_singleton()->update_gyroscope(Vector3(rotation.x, rotation.y, rotation.z).rotated(Vector3(0, 0, 1), -Math::PI * 0.5));
 		} break;
 		case UIInterfaceOrientationLandscapeRight: {
-			DisplayServerIOS::get_singleton()->update_gravity(Vector3(gravity.x, gravity.y, gravity.z).rotated(Vector3(0, 0, 1), Math_PI * 0.5));
-			DisplayServerIOS::get_singleton()->update_accelerometer(Vector3(acceleration.x + gravity.x, acceleration.y + gravity.y, acceleration.z + gravity.z).rotated(Vector3(0, 0, 1), Math_PI * 0.5));
-			DisplayServerIOS::get_singleton()->update_magnetometer(Vector3(magnetic.x, magnetic.y, magnetic.z).rotated(Vector3(0, 0, 1), Math_PI * 0.5));
-			DisplayServerIOS::get_singleton()->update_gyroscope(Vector3(rotation.x, rotation.y, rotation.z).rotated(Vector3(0, 0, 1), Math_PI * 0.5));
+			DisplayServerIOS::get_singleton()->update_gravity(Vector3(gravity.x, gravity.y, gravity.z).rotated(Vector3(0, 0, 1), Math::PI * 0.5));
+			DisplayServerIOS::get_singleton()->update_accelerometer(Vector3(acceleration.x + gravity.x, acceleration.y + gravity.y, acceleration.z + gravity.z).rotated(Vector3(0, 0, 1), Math::PI * 0.5));
+			DisplayServerIOS::get_singleton()->update_magnetometer(Vector3(magnetic.x, magnetic.y, magnetic.z).rotated(Vector3(0, 0, 1), Math::PI * 0.5));
+			DisplayServerIOS::get_singleton()->update_gyroscope(Vector3(rotation.x, rotation.y, rotation.z).rotated(Vector3(0, 0, 1), Math::PI * 0.5));
 		} break;
 		case UIInterfaceOrientationPortraitUpsideDown: {
-			DisplayServerIOS::get_singleton()->update_gravity(Vector3(gravity.x, gravity.y, gravity.z).rotated(Vector3(0, 0, 1), Math_PI));
-			DisplayServerIOS::get_singleton()->update_accelerometer(Vector3(acceleration.x + gravity.x, acceleration.y + gravity.y, acceleration.z + gravity.z).rotated(Vector3(0, 0, 1), Math_PI));
-			DisplayServerIOS::get_singleton()->update_magnetometer(Vector3(magnetic.x, magnetic.y, magnetic.z).rotated(Vector3(0, 0, 1), Math_PI));
-			DisplayServerIOS::get_singleton()->update_gyroscope(Vector3(rotation.x, rotation.y, rotation.z).rotated(Vector3(0, 0, 1), Math_PI));
+			DisplayServerIOS::get_singleton()->update_gravity(Vector3(gravity.x, gravity.y, gravity.z).rotated(Vector3(0, 0, 1), Math::PI));
+			DisplayServerIOS::get_singleton()->update_accelerometer(Vector3(acceleration.x + gravity.x, acceleration.y + gravity.y, acceleration.z + gravity.z).rotated(Vector3(0, 0, 1), Math::PI));
+			DisplayServerIOS::get_singleton()->update_magnetometer(Vector3(magnetic.x, magnetic.y, magnetic.z).rotated(Vector3(0, 0, 1), Math::PI));
+			DisplayServerIOS::get_singleton()->update_gyroscope(Vector3(rotation.x, rotation.y, rotation.z).rotated(Vector3(0, 0, 1), Math::PI));
 		} break;
 		default: { // assume portrait
 			DisplayServerIOS::get_singleton()->update_gravity(Vector3(gravity.x, gravity.y, gravity.z));

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -5008,8 +5008,8 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					windows[window_id].last_pressure_update = 0;
 
 					float pressure = float(packet.pkNormalPressure - windows[window_id].min_pressure) / float(windows[window_id].max_pressure - windows[window_id].min_pressure);
-					double azim = (packet.pkOrientation.orAzimuth / 10.0f) * (Math_PI / 180);
-					double alt = Math::tan((Math::abs(packet.pkOrientation.orAltitude / 10.0f)) * (Math_PI / 180));
+					double azim = (packet.pkOrientation.orAzimuth / 10.0f) * (Math::PI / 180);
+					double alt = Math::tan((Math::abs(packet.pkOrientation.orAltitude / 10.0f)) * (Math::PI / 180));
 					bool inverted = packet.pkStatus & TPS_INVERT;
 
 					Vector2 tilt = (windows[window_id].tilt_supported) ? Vector2(Math::atan(Math::sin(azim) / alt), Math::atan(Math::cos(azim) / alt)) : Vector2();

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -891,12 +891,12 @@ void CPUParticles2D::_particles_process(double p_delta) {
 					//do none
 				} break;
 				case EMISSION_SHAPE_SPHERE: {
-					real_t t = Math_TAU * rng->randf();
+					real_t t = Math::TAU * rng->randf();
 					real_t radius = emission_sphere_radius * rng->randf();
 					p.transform[2] = Vector2(Math::cos(t), Math::sin(t)) * radius;
 				} break;
 				case EMISSION_SHAPE_SPHERE_SURFACE: {
-					real_t s = rng->randf(), t = Math_TAU * rng->randf();
+					real_t s = rng->randf(), t = Math::TAU * rng->randf();
 					real_t radius = emission_sphere_radius * Math::sqrt(1.0 - s * s);
 					p.transform[2] = Vector2(Math::cos(t), Math::sin(t)) * radius;
 				} break;
@@ -1013,7 +1013,7 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			//orbit velocity
 			real_t orbit_amount = tex_orbit_velocity * Math::lerp(parameters_min[PARAM_ORBIT_VELOCITY], parameters_max[PARAM_ORBIT_VELOCITY], rand_from_seed(_seed));
 			if (orbit_amount != 0.0) {
-				real_t ang = orbit_amount * local_delta * Math_TAU;
+				real_t ang = orbit_amount * local_delta * Math::TAU;
 				// Not sure why the ParticleProcessMaterial code uses a clockwise rotation matrix,
 				// but we use -ang here to reproduce its behavior.
 				Transform2D rot = Transform2D(-ang, Vector2());
@@ -1067,7 +1067,7 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			tex_hue_variation = curve_parameters[PARAM_HUE_VARIATION]->sample(tv);
 		}
 
-		real_t hue_rot_angle = (tex_hue_variation)*Math_TAU * Math::lerp(parameters_min[PARAM_HUE_VARIATION], parameters_max[PARAM_HUE_VARIATION], p.hue_rot_rand);
+		real_t hue_rot_angle = (tex_hue_variation)*Math::TAU * Math::lerp(parameters_min[PARAM_HUE_VARIATION], parameters_max[PARAM_HUE_VARIATION], p.hue_rot_rand);
 		real_t hue_rot_c = Math::cos(hue_rot_angle);
 		real_t hue_rot_s = Math::sin(hue_rot_angle);
 

--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -144,7 +144,7 @@ void LineBuilder::build() {
 			} else if (texture_mode == Line2D::LINE_TEXTURE_STRETCH) {
 				uvx0 = width * width_factor / total_distance;
 			}
-			new_arc(pos0, pos_up0 - pos0, -Math_PI, color0, Rect2(0.f, 0.f, uvx0 * 2, 1.f));
+			new_arc(pos0, pos_up0 - pos0, -Math::PI, color0, Rect2(0.f, 0.f, uvx0 * 2, 1.f));
 			current_distance0 += modified_hw;
 			current_distance1 = current_distance0;
 		}
@@ -426,7 +426,7 @@ void LineBuilder::build() {
 			} else if (texture_mode == Line2D::LINE_TEXTURE_STRETCH) {
 				dist = width * width_factor / total_distance;
 			}
-			new_arc(pos1, pos_up1 - pos1, Math_PI, color, Rect2(uvx1 - 0.5f * dist, 0.f, dist, 1.f));
+			new_arc(pos1, pos_up1 - pos1, Math::PI, color, Rect2(uvx1 - 0.5f * dist, 0.f, dist, 1.f));
 		}
 	}
 }
@@ -509,7 +509,7 @@ void LineBuilder::strip_add_arc(Vector2 center, float angle_delta, Orientation o
 	Orientation opposite_orientation = orientation == UP ? DOWN : UP;
 	Vector2 vbegin = vertices[_last_index[opposite_orientation]] - center;
 	float radius = vbegin.length();
-	float angle_step = Math_PI / static_cast<float>(round_precision);
+	float angle_step = Math::PI / static_cast<float>(round_precision);
 	float steps = Math::abs(angle_delta) / angle_step;
 
 	if (angle_delta < 0.f) {
@@ -536,7 +536,7 @@ void LineBuilder::new_arc(Vector2 center, Vector2 vbegin, float angle_delta, Col
 	// with undistorted UVs from within a square section
 
 	float radius = vbegin.length();
-	float angle_step = Math_PI / static_cast<float>(round_precision);
+	float angle_step = Math::PI / static_cast<float>(round_precision);
 	float steps = Math::abs(angle_delta) / angle_step;
 
 	if (angle_delta < 0.f) {
@@ -546,7 +546,7 @@ void LineBuilder::new_arc(Vector2 center, Vector2 vbegin, float angle_delta, Col
 	float t = Vector2(1, 0).angle_to(vbegin);
 	float end_angle = t + angle_delta;
 	Vector2 rpos(0, 0);
-	float tt_begin = -Math_PI / 2.0f;
+	float tt_begin = -Math::PI / 2.0f;
 	float tt = tt_begin;
 
 	// Center vertice

--- a/scene/2d/navigation/navigation_link_2d.cpp
+++ b/scene/2d/navigation/navigation_link_2d.cpp
@@ -396,8 +396,8 @@ void NavigationLink2D::_update_debug_mesh() {
 	real_t radius = NavigationServer2D::get_singleton()->map_get_link_connection_radius(get_world_2d()->get_navigation_map());
 
 	draw_line(get_start_position(), get_end_position(), color);
-	draw_arc(get_start_position(), radius, 0, Math_TAU, 10, color);
-	draw_arc(get_end_position(), radius, 0, Math_TAU, 10, color);
+	draw_arc(get_start_position(), radius, 0, Math::TAU, 10, color);
+	draw_arc(get_end_position(), radius, 0, Math::TAU, 10, color);
 
 	const Vector2 link_segment = end_position - start_position;
 	const float arror_len = 5.0;

--- a/scene/2d/navigation/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation/navigation_obstacle_2d.cpp
@@ -382,7 +382,7 @@ void NavigationObstacle2D::navmesh_parse_source_geometry(const Ref<NavigationPol
 
 		obstruction_circle_vertices.resize(circle_points);
 		Vector2 *circle_vertices_ptrw = obstruction_circle_vertices.ptrw();
-		const real_t circle_point_step = Math_TAU / circle_points;
+		const real_t circle_point_step = Math::TAU / circle_points;
 
 		for (int i = 0; i < circle_points; i++) {
 			const float angle = i * circle_point_step;

--- a/scene/2d/navigation/navigation_region_2d.cpp
+++ b/scene/2d/navigation/navigation_region_2d.cpp
@@ -623,8 +623,8 @@ void NavigationRegion2D::_update_debug_edge_connections_mesh() {
 
 			// Draw a circle to illustrate the margins.
 			real_t angle = a.angle_to_point(b);
-			draw_arc(a, radius, angle + Math_PI / 2.0, angle - Math_PI / 2.0 + Math_TAU, 10, debug_edge_connection_color);
-			draw_arc(b, radius, angle - Math_PI / 2.0, angle + Math_PI / 2.0, 10, debug_edge_connection_color);
+			draw_arc(a, radius, angle + Math::PI / 2.0, angle - Math::PI / 2.0 + Math::TAU, 10, debug_edge_connection_color);
+			draw_arc(b, radius, angle - Math::PI / 2.0, angle + Math::PI / 2.0, 10, debug_edge_connection_color);
 		}
 	}
 }

--- a/scene/2d/physics/collision_polygon_2d.cpp
+++ b/scene/2d/physics/collision_polygon_2d.cpp
@@ -157,8 +157,8 @@ void CollisionPolygon2D::_notification(int p_what) {
 
 				Vector<Vector2> pts = {
 					line_to + Vector2(0, tsize),
-					line_to + Vector2(Math_SQRT12 * tsize, 0),
-					line_to + Vector2(-Math_SQRT12 * tsize, 0)
+					line_to + Vector2(Math::SQRT12 * tsize, 0),
+					line_to + Vector2(-Math::SQRT12 * tsize, 0)
 				};
 
 				Vector<Color> cols{ dcol, dcol, dcol };

--- a/scene/2d/physics/collision_shape_2d.cpp
+++ b/scene/2d/physics/collision_shape_2d.cpp
@@ -120,8 +120,8 @@ void CollisionShape2D::_notification(int p_what) {
 
 				Vector<Vector2> pts{
 					line_to + Vector2(0, tsize),
-					line_to + Vector2(Math_SQRT12 * tsize, 0),
-					line_to + Vector2(-Math_SQRT12 * tsize, 0)
+					line_to + Vector2(Math::SQRT12 * tsize, 0),
+					line_to + Vector2(-Math::SQRT12 * tsize, 0)
 				};
 
 				Vector<Color> cols{ draw_col, draw_col, draw_col };

--- a/scene/2d/physics/static_body_2d.cpp
+++ b/scene/2d/physics/static_body_2d.cpp
@@ -159,7 +159,7 @@ void StaticBody2D::navmesh_parse_source_geometry(const Ref<NavigationPolygon> &p
 				const real_t capsule_radius = capsule_shape->get_radius();
 
 				Vector<Vector2> shape_outline;
-				const real_t turn_step = Math_TAU / 12.0;
+				const real_t turn_step = Math::TAU / 12.0;
 				shape_outline.resize(14);
 				int shape_outline_inx = 0;
 				for (int i = 0; i < 12; i++) {
@@ -184,7 +184,7 @@ void StaticBody2D::navmesh_parse_source_geometry(const Ref<NavigationPolygon> &p
 				int circle_edge_count = 12;
 				shape_outline.resize(circle_edge_count);
 
-				const real_t turn_step = Math_TAU / real_t(circle_edge_count);
+				const real_t turn_step = Math::TAU / real_t(circle_edge_count);
 				for (int i = 0; i < circle_edge_count; i++) {
 					shape_outline.write[i] = static_body_xform.xform(Vector2(Math::cos(i * turn_step), Math::sin(i * turn_step)) * circle_radius);
 				}

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -329,7 +329,7 @@ bool Bone2D::_editor_get_bone_shape(Vector<Vector2> *p_shape, Vector<Vector2> *p
 		rel = Vector2(Math::cos(bone_angle), Math::sin(bone_angle)) * length * get_global_scale();
 	}
 
-	Vector2 relt = rel.rotated(Math_PI * 0.5).normalized() * bone_width;
+	Vector2 relt = rel.rotated(Math::PI * 0.5).normalized() * bone_width;
 	Vector2 reln = rel.normalized();
 	Vector2 reltn = relt.normalized();
 

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -886,14 +886,14 @@ void CPUParticles3D::_particles_process(double p_delta) {
 				} break;
 				case EMISSION_SHAPE_SPHERE: {
 					real_t s = 2.0 * rng->randf() - 1.0;
-					real_t t = Math_TAU * rng->randf();
+					real_t t = Math::TAU * rng->randf();
 					real_t x = rng->randf();
 					real_t radius = emission_sphere_radius * Math::sqrt(1.0 - s * s);
 					p.transform.origin = Vector3(0, 0, 0).lerp(Vector3(radius * Math::cos(t), radius * Math::sin(t), emission_sphere_radius * s), x);
 				} break;
 				case EMISSION_SHAPE_SPHERE_SURFACE: {
 					real_t s = 2.0 * rng->randf() - 1.0;
-					real_t t = Math_TAU * rng->randf();
+					real_t t = Math::TAU * rng->randf();
 					real_t radius = emission_sphere_radius * Math::sqrt(1.0 - s * s);
 					p.transform.origin = Vector3(radius * Math::cos(t), radius * Math::sin(t), emission_sphere_radius * s);
 				} break;
@@ -945,7 +945,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 					real_t y_pos = rng->randf();
 					real_t skew = MAX(MIN(radius_clamped, top_radius) / MAX(radius_clamped, top_radius), 0.5);
 					y_pos = radius_clamped < top_radius ? Math::pow(y_pos, skew) : 1.0 - Math::pow(y_pos, skew);
-					real_t ring_random_angle = rng->randf() * Math_TAU;
+					real_t ring_random_angle = rng->randf() * Math::TAU;
 					real_t ring_random_radius = Math::sqrt(rng->randf() * (radius_clamped * radius_clamped - emission_ring_inner_radius * emission_ring_inner_radius) + emission_ring_inner_radius * emission_ring_inner_radius);
 					ring_random_radius = Math::lerp(ring_random_radius, ring_random_radius * (top_radius / radius_clamped), y_pos);
 					Vector3 axis = emission_ring_axis == Vector3(0.0, 0.0, 0.0) ? Vector3(0.0, 0.0, 1.0) : emission_ring_axis.normalized();
@@ -1064,7 +1064,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 			if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 				real_t orbit_amount = tex_orbit_velocity * Math::lerp(parameters_min[PARAM_ORBIT_VELOCITY], parameters_max[PARAM_ORBIT_VELOCITY], rand_from_seed(alt_seed));
 				if (orbit_amount != 0.0) {
-					real_t ang = orbit_amount * local_delta * Math_TAU;
+					real_t ang = orbit_amount * local_delta * Math::TAU;
 					// Not sure why the ParticleProcessMaterial code uses a clockwise rotation matrix,
 					// but we use -ang here to reproduce its behavior.
 					Transform2D rot = Transform2D(-ang, Vector2());
@@ -1126,7 +1126,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 			tex_hue_variation = curve_parameters[PARAM_HUE_VARIATION]->sample(tv);
 		}
 
-		real_t hue_rot_angle = (tex_hue_variation)*Math_TAU * Math::lerp(parameters_min[PARAM_HUE_VARIATION], parameters_max[PARAM_HUE_VARIATION], p.hue_rot_rand);
+		real_t hue_rot_angle = (tex_hue_variation)*Math::TAU * Math::lerp(parameters_min[PARAM_HUE_VARIATION], parameters_max[PARAM_HUE_VARIATION], p.hue_rot_rand);
 		real_t hue_rot_c = Math::cos(hue_rot_angle);
 		real_t hue_rot_s = Math::sin(hue_rot_angle);
 

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -166,7 +166,7 @@ AABB Light3D::get_aabb() const {
 		real_t cone_slant_height = param[PARAM_RANGE];
 		real_t cone_angle_rad = Math::deg_to_rad(param[PARAM_SPOT_ANGLE]);
 
-		if (cone_angle_rad > Math_PI / 2.0) {
+		if (cone_angle_rad > Math::PI / 2.0) {
 			// Just return the AABB of an omni light if the spot angle is above 90 degrees.
 			return AABB(Vector3(-1, -1, -1) * cone_slant_height, Vector3(2, 2, 2) * cone_slant_height);
 		}

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1193,13 +1193,13 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 			} else if (Object::cast_to<OmniLight3D>(light)) {
 				OmniLight3D *l = Object::cast_to<OmniLight3D>(light);
 				if (use_physical_light_units) {
-					energy *= (1.0 / (Math_PI * 4.0));
+					energy *= (1.0 / (Math::PI * 4.0));
 				}
 				lightmapper->add_omni_light(light->get_name(), light->get_bake_mode() == Light3D::BAKE_STATIC, xf.origin, linear_color, energy, indirect_energy, l->get_param(Light3D::PARAM_RANGE), l->get_param(Light3D::PARAM_ATTENUATION), l->get_param(Light3D::PARAM_SIZE), l->get_param(Light3D::PARAM_SHADOW_BLUR));
 			} else if (Object::cast_to<SpotLight3D>(light)) {
 				SpotLight3D *l = Object::cast_to<SpotLight3D>(light);
 				if (use_physical_light_units) {
-					energy *= (1.0 / Math_PI);
+					energy *= (1.0 / Math::PI);
 				}
 				lightmapper->add_spot_light(light->get_name(), light->get_bake_mode() == Light3D::BAKE_STATIC, xf.origin, -xf.basis.get_column(Vector3::AXIS_Z).normalized(), linear_color, energy, indirect_energy, l->get_param(Light3D::PARAM_RANGE), l->get_param(Light3D::PARAM_ATTENUATION), l->get_param(Light3D::PARAM_SPOT_ANGLE), l->get_param(Light3D::PARAM_SPOT_ATTENUATION), l->get_param(Light3D::PARAM_SIZE), l->get_param(Light3D::PARAM_SHADOW_BLUR));
 			}

--- a/scene/3d/lightmapper.h
+++ b/scene/3d/lightmapper.h
@@ -63,7 +63,7 @@ public:
 		_FORCE_INLINE_ Ray(const Vector3 &p_org,
 				const Vector3 &p_dir,
 				float p_tnear = 0.0f,
-				float p_tfar = INFINITY) :
+				float p_tfar = Math::INF) :
 				org(p_org),
 				tnear(p_tnear),
 				dir(p_dir),

--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -554,13 +554,13 @@ void LookAtModifier3D::_process_modification(double p_delta) {
 		Vector3 prev_forward_vector_nrm = forward_vector.normalized();
 		Vector3 rest_forward_vector = get_vector_from_bone_axis(forward_axis);
 		if (symmetry_limitation) {
-			if ((is_not_max_influence || !Math::is_equal_approx(primary_limit_angle, (float)Math_TAU)) &&
+			if ((is_not_max_influence || !Math::is_equal_approx(primary_limit_angle, (float)Math::TAU)) &&
 					prev_forward_vector_nrm.dot(rest_forward_vector) < 0 &&
 					forward_vector_nrm.dot(rest_forward_vector) < 0) {
 				init_transition();
 			}
 		} else {
-			if ((is_not_max_influence || !Math::is_equal_approx(primary_positive_limit_angle + primary_negative_limit_angle, (float)Math_TAU)) &&
+			if ((is_not_max_influence || !Math::is_equal_approx(primary_positive_limit_angle + primary_negative_limit_angle, (float)Math::TAU)) &&
 					prev_forward_vector_nrm.dot(rest_forward_vector) < 0 &&
 					forward_vector_nrm.dot(rest_forward_vector) < 0) {
 				init_transition();
@@ -660,7 +660,7 @@ float LookAtModifier3D::remap_damped(float p_from, float p_to, float p_damp_thre
 		return sign * CLAMP(abs_value, p_from, p_to);
 	}
 
-	double limit = Math_PI;
+	double limit = Math::PI;
 	double inv_to = 1.0 / p_to;
 	double end_x = limit * inv_to;
 	double position = abs_value * inv_to;

--- a/scene/3d/look_at_modifier_3d.h
+++ b/scene/3d/look_at_modifier_3d.h
@@ -71,18 +71,18 @@ private:
 	bool use_angle_limitation = false;
 	bool symmetry_limitation = true;
 
-	float primary_limit_angle = Math_TAU;
+	float primary_limit_angle = Math::TAU;
 	float primary_damp_threshold = 1.0f;
-	float primary_positive_limit_angle = Math_PI;
+	float primary_positive_limit_angle = Math::PI;
 	float primary_positive_damp_threshold = 1.0f;
-	float primary_negative_limit_angle = Math_PI;
+	float primary_negative_limit_angle = Math::PI;
 	float primary_negative_damp_threshold = 1.0f;
 
-	float secondary_limit_angle = Math_TAU;
+	float secondary_limit_angle = Math::TAU;
 	float secondary_damp_threshold = 1.0f;
-	float secondary_positive_limit_angle = Math_PI;
+	float secondary_positive_limit_angle = Math::PI;
 	float secondary_positive_damp_threshold = 1.0f;
-	float secondary_negative_limit_angle = Math_PI;
+	float secondary_negative_limit_angle = Math::PI;
 	float secondary_negative_damp_threshold = 1.0f;
 
 	bool is_within_limitations = false;

--- a/scene/3d/navigation/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation/navigation_obstacle_3d.cpp
@@ -464,7 +464,7 @@ void NavigationObstacle3D::navmesh_parse_source_geometry(const Ref<NavigationMes
 
 		obstruction_circle_vertices.resize(circle_points);
 		Vector3 *circle_vertices_ptrw = obstruction_circle_vertices.ptrw();
-		const real_t circle_point_step = Math_TAU / circle_points;
+		const real_t circle_point_step = Math::TAU / circle_points;
 
 		for (int i = 0; i < circle_points; i++) {
 			const float angle = i * circle_point_step;
@@ -581,15 +581,15 @@ void NavigationObstacle3D::_update_fake_agent_radius_debug() {
 		float w;
 
 		v /= (rings + 1);
-		w = sin(Math_PI * v);
-		y = (radius)*cos(Math_PI * v);
+		w = sin(Math::PI * v);
+		y = (radius)*cos(Math::PI * v);
 
 		for (i = 0; i <= radial_segments; i++) {
 			float u = i;
 			u /= radial_segments;
 
-			x = sin(u * Math_TAU);
-			z = cos(u * Math_TAU);
+			x = sin(u * Math::TAU);
+			z = cos(u * Math::TAU);
 
 			Vector3 p = Vector3(x * radius * w, y, z * radius * w);
 			face_vertex_array.push_back(p);

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -321,13 +321,13 @@ void SphereOccluder3D::_update_arrays(PackedVector3Array &r_vertices, PackedInt3
 	int point = 0;
 	for (int j = 0; j <= (RINGS + 1); j++) {
 		float v = j / float(RINGS + 1);
-		float w = Math::sin(Math_PI * v);
-		float y = Math::cos(Math_PI * v);
+		float w = Math::sin(Math::PI * v);
+		float y = Math::cos(Math::PI * v);
 		for (int i = 0; i <= RADIAL_SEGMENTS; i++) {
 			float u = i / float(RADIAL_SEGMENTS);
 
-			float x = Math::cos(u * Math_TAU);
-			float z = Math::sin(u * Math_TAU);
+			float x = Math::cos(u * Math::TAU);
+			float z = Math::sin(u * Math::TAU);
 			vertex_ptr[vertex_i++] = Vector3(x * w, y, z * w) * radius;
 
 			if (i > 0 && j > 0) {

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -219,7 +219,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 					// Avoid to move forward on a wall if floor_block_on_wall is true.
 					// Applies only when the motion angle is under 90 degrees,
 					// in order to avoid blocking lateral motion along a wall.
-					if (motion_angle < .5 * Math_PI) {
+					if (motion_angle < .5 * Math::PI) {
 						apply_default_sliding = false;
 						if (p_was_on_floor && !vel_dir_facing_up) {
 							// Cancel the motion.

--- a/scene/3d/physics/joints/cone_twist_joint_3d.cpp
+++ b/scene/3d/physics/joints/cone_twist_joint_3d.cpp
@@ -87,8 +87,8 @@ void ConeTwistJoint3D::_configure_joint(RID p_joint, PhysicsBody3D *body_a, Phys
 }
 
 ConeTwistJoint3D::ConeTwistJoint3D() {
-	params[PARAM_SWING_SPAN] = Math_PI * 0.25;
-	params[PARAM_TWIST_SPAN] = Math_PI;
+	params[PARAM_SWING_SPAN] = Math::PI * 0.25;
+	params[PARAM_TWIST_SPAN] = Math::PI;
 	params[PARAM_BIAS] = 0.3;
 	params[PARAM_SOFTNESS] = 0.8;
 	params[PARAM_RELAXATION] = 1.0;

--- a/scene/3d/physics/joints/hinge_joint_3d.cpp
+++ b/scene/3d/physics/joints/hinge_joint_3d.cpp
@@ -122,8 +122,8 @@ void HingeJoint3D::_configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsB
 
 HingeJoint3D::HingeJoint3D() {
 	params[PARAM_BIAS] = 0.3;
-	params[PARAM_LIMIT_UPPER] = Math_PI * 0.5;
-	params[PARAM_LIMIT_LOWER] = -Math_PI * 0.5;
+	params[PARAM_LIMIT_UPPER] = Math::PI * 0.5;
+	params[PARAM_LIMIT_LOWER] = -Math::PI * 0.5;
 	params[PARAM_LIMIT_BIAS] = 0.3;
 	params[PARAM_LIMIT_SOFTNESS] = 0.9;
 	params[PARAM_LIMIT_RELAXATION] = 1.0;

--- a/scene/3d/physics/physical_bone_3d.h
+++ b/scene/3d/physics/physical_bone_3d.h
@@ -83,8 +83,8 @@ public:
 		virtual bool _get(const StringName &p_name, Variant &r_ret) const;
 		virtual void _get_property_list(List<PropertyInfo> *p_list) const;
 
-		real_t swing_span = Math_PI * 0.25;
-		real_t twist_span = Math_PI;
+		real_t swing_span = Math::PI * 0.25;
+		real_t twist_span = Math::PI;
 		real_t bias = 0.3;
 		real_t softness = 0.8;
 		real_t relaxation = 1.;
@@ -98,8 +98,8 @@ public:
 		virtual void _get_property_list(List<PropertyInfo> *p_list) const;
 
 		bool angular_limit_enabled = false;
-		real_t angular_limit_upper = Math_PI * 0.5;
-		real_t angular_limit_lower = -Math_PI * 0.5;
+		real_t angular_limit_upper = Math::PI * 0.5;
+		real_t angular_limit_lower = -Math::PI * 0.5;
 		real_t angular_limit_bias = 0.3;
 		real_t angular_limit_softness = 0.9;
 		real_t angular_limit_relaxation = 1.;

--- a/scene/3d/physics/ray_cast_3d.cpp
+++ b/scene/3d/physics/ray_cast_3d.cpp
@@ -413,7 +413,7 @@ void RayCast3D::_update_debug_shape_vertices() {
 		int vertices_strip_order[14] = { 4, 5, 0, 1, 2, 5, 6, 4, 7, 0, 3, 2, 7, 6 };
 		for (int v = 0; v < 14; v++) {
 			Vector3 vertex = vertices_strip_order[v] < 4 ? normal : normal / 3.0 + target_position;
-			debug_shape_vertices.push_back(vertex.rotated(dir, Math_PI * (0.5 * (vertices_strip_order[v] % 4) + 0.25)));
+			debug_shape_vertices.push_back(vertex.rotated(dir, Math::PI * (0.5 * (vertices_strip_order[v] % 4) + 0.25)));
 		}
 	}
 }

--- a/scene/3d/physics/vehicle_body_3d.cpp
+++ b/scene/3d/physics/vehicle_body_3d.cpp
@@ -879,7 +879,7 @@ void VehicleBody3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 		}
 
 		wheel.m_rotation += wheel.m_deltaRotation;
-		wheel.m_rpm = ((wheel.m_deltaRotation / step) * 60) / Math_TAU;
+		wheel.m_rpm = ((wheel.m_deltaRotation / step) * 60) / Math::TAU;
 
 		wheel.m_deltaRotation *= real_t(0.99); //damping of rotation when not in contact
 	}

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -816,7 +816,6 @@ Vector<int> Voxelizer::get_voxel_gi_level_cell_count() const {
 // https://prideout.net/blog/distance_fields/
 
 #define square(m_s) ((m_s) * (m_s))
-#define INF 1e20
 
 /* dt of 1d function using squared distance */
 static void edt(float *f, int stride, int n) {
@@ -826,8 +825,8 @@ static void edt(float *f, int stride, int n) {
 
 	int k = 0;
 	v[0] = 0;
-	z[0] = -INF;
-	z[1] = +INF;
+	z[0] = -Math::INF;
+	z[1] = +Math::INF;
 	for (int q = 1; q <= n - 1; q++) {
 		float s = ((f[q * stride] + square(q)) - (f[v[k] * stride] + square(v[k]))) / (2 * q - 2 * v[k]);
 		while (s <= z[k]) {
@@ -838,7 +837,7 @@ static void edt(float *f, int stride, int n) {
 		v[k] = q;
 
 		z[k] = s;
-		z[k + 1] = +INF;
+		z[k + 1] = +Math::INF;
 	}
 
 	k = 0;
@@ -862,7 +861,7 @@ Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, Bake
 	uint32_t float_count = octree_size.x * octree_size.y * octree_size.z;
 	float *work_memory = memnew_arr(float, float_count);
 	for (uint32_t i = 0; i < float_count; i++) {
-		work_memory[i] = INF;
+		work_memory[i] = Math::INF;
 	}
 
 	uint32_t y_mult = octree_size.x;
@@ -944,8 +943,6 @@ Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, Bake
 
 	return BAKE_RESULT_OK;
 }
-
-#undef INF
 
 void Voxelizer::_debug_mesh(int p_idx, int p_level, const AABB &p_aabb, Ref<MultiMesh> &p_multimesh, int &idx) {
 	if (p_level == cell_subdiv - 1) {

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1589,17 +1589,17 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 							float rot_a = t->value;
 							float rot_b = value;
 							float rot_init = t->init_value;
-							rot_a = Math::fposmod(rot_a, (float)Math_TAU);
-							rot_b = Math::fposmod(rot_b, (float)Math_TAU);
-							rot_init = Math::fposmod(rot_init, (float)Math_TAU);
-							if (rot_init < Math_PI) {
-								rot_a = rot_a > rot_init + Math_PI ? rot_a - Math_TAU : rot_a;
-								rot_b = rot_b > rot_init + Math_PI ? rot_b - Math_TAU : rot_b;
+							rot_a = Math::fposmod(rot_a, (float)Math::TAU);
+							rot_b = Math::fposmod(rot_b, (float)Math::TAU);
+							rot_init = Math::fposmod(rot_init, (float)Math::TAU);
+							if (rot_init < Math::PI) {
+								rot_a = rot_a > rot_init + Math::PI ? rot_a - Math::TAU : rot_a;
+								rot_b = rot_b > rot_init + Math::PI ? rot_b - Math::TAU : rot_b;
 							} else {
-								rot_a = rot_a < rot_init - Math_PI ? rot_a + Math_TAU : rot_a;
-								rot_b = rot_b < rot_init - Math_PI ? rot_b + Math_TAU : rot_b;
+								rot_a = rot_a < rot_init - Math::PI ? rot_a + Math::TAU : rot_a;
+								rot_b = rot_b < rot_init - Math::PI ? rot_b + Math::TAU : rot_b;
 							}
-							t->value = Math::fposmod(rot_a + (rot_b - rot_init) * (float)blend, (float)Math_TAU);
+							t->value = Math::fposmod(rot_a + (rot_b - rot_init) * (float)blend, (float)Math::TAU);
 						} else {
 							value = Animation::cast_to_blendwise(value);
 							if (t->init_value.is_array()) {

--- a/scene/animation/easing_equations.h
+++ b/scene/animation/easing_equations.h
@@ -62,15 +62,15 @@ static real_t in(real_t t, real_t b, real_t c, real_t d) {
 
 namespace Sine {
 static real_t in(real_t t, real_t b, real_t c, real_t d) {
-	return -c * cos(t / d * (Math_PI / 2)) + c + b;
+	return -c * cos(t / d * (Math::PI / 2)) + c + b;
 }
 
 static real_t out(real_t t, real_t b, real_t c, real_t d) {
-	return c * sin(t / d * (Math_PI / 2)) + b;
+	return c * sin(t / d * (Math::PI / 2)) + b;
 }
 
 static real_t in_out(real_t t, real_t b, real_t c, real_t d) {
-	return -c / 2 * (cos(Math_PI * t / d) - 1) + b;
+	return -c / 2 * (cos(Math::PI * t / d) - 1) + b;
 }
 
 static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
@@ -221,7 +221,7 @@ static real_t in(real_t t, real_t b, real_t c, real_t d) {
 	float a = c * pow(2, 10 * t);
 	float s = p / 4;
 
-	return -(a * sin((t * d - s) * (2 * Math_PI) / p)) + b;
+	return -(a * sin((t * d - s) * (2 * Math::PI) / p)) + b;
 }
 
 static real_t out(real_t t, real_t b, real_t c, real_t d) {
@@ -237,7 +237,7 @@ static real_t out(real_t t, real_t b, real_t c, real_t d) {
 	float p = d * 0.3f;
 	float s = p / 4;
 
-	return (c * pow(2, -10 * t) * sin((t * d - s) * (2 * Math_PI) / p) + c + b);
+	return (c * pow(2, -10 * t) * sin((t * d - s) * (2 * Math::PI) / p) + c + b);
 }
 
 static real_t in_out(real_t t, real_t b, real_t c, real_t d) {
@@ -256,12 +256,12 @@ static real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 	if (t < 1) {
 		t -= 1;
 		a *= pow(2, 10 * t);
-		return -0.5f * (a * sin((t * d - s) * (2 * Math_PI) / p)) + b;
+		return -0.5f * (a * sin((t * d - s) * (2 * Math::PI) / p)) + b;
 	}
 
 	t -= 1;
 	a *= pow(2, -10 * t);
-	return a * sin((t * d - s) * (2 * Math_PI) / p) * 0.5f + c + b;
+	return a * sin((t * d - s) * (2 * Math::PI) / p) * 0.5f + c + b;
 }
 
 static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
@@ -416,7 +416,7 @@ namespace Spring {
 static real_t out(real_t t, real_t b, real_t c, real_t d) {
 	t /= d;
 	real_t s = 1.0 - t;
-	t = (sin(t * Math_PI * (0.2 + 2.5 * t * t * t)) * pow(s, 2.2) + t) * (1.0 + (1.2 * s));
+	t = (sin(t * Math::PI * (0.2 + 2.5 * t * t * t)) * pow(s, 2.2) + t) * (1.0 + (1.2 * s));
 	return c * t + b;
 }
 

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -1623,7 +1623,7 @@ void RuntimeNodeSelect::_physics_frame() {
 
 	switch (selection_drag_state) {
 		case SELECTION_DRAG_END: {
-			selection_position = Point2(INFINITY, INFINITY);
+			selection_position = Point2(Math::INF, Math::INF);
 			selection_drag_state = SELECTION_DRAG_NONE;
 
 			if (selection_drag_area.get_area() > SELECTION_MIN_AREA) {
@@ -1679,11 +1679,11 @@ void RuntimeNodeSelect::_physics_frame() {
 	}
 
 	if (items.is_empty()) {
-		selection_position = Point2(INFINITY, INFINITY);
+		selection_position = Point2(Math::INF, Math::INF);
 		return;
 	}
 	if ((!list_shortcut_pressed && node_select_mode == SELECT_MODE_SINGLE) || items.size() == 1) {
-		selection_position = Point2(INFINITY, INFINITY);
+		selection_position = Point2(Math::INF, Math::INF);
 
 		Vector<Node *> node;
 		node.append(items[0].item);
@@ -1696,7 +1696,7 @@ void RuntimeNodeSelect::_physics_frame() {
 		_open_selection_list(items, selection_position);
 	}
 
-	selection_position = Point2(INFINITY, INFINITY);
+	selection_position = Point2(Math::INF, Math::INF);
 }
 
 void RuntimeNodeSelect::_send_ids(const Vector<Node *> &p_picked_nodes, bool p_invert_new_selections) {

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -215,7 +215,7 @@ private:
 
 	bool has_selection = false;
 	int max_selection = 1;
-	Point2 selection_position = Point2(INFINITY, INFINITY);
+	Point2 selection_position = Point2(Math::INF, Math::INF);
 	Rect2 selection_drag_area;
 	PopupMenu *selection_list = nullptr;
 	Color selection_area_fill;

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -164,8 +164,8 @@ void ColorPickerShape::draw_cursor(Control *p_control, const Vector2 &p_center, 
 void ColorPickerShape::draw_circle_cursor(Control *p_control, float p_hue) {
 	const Vector2 center = p_control->get_size() * 0.5;
 	const Vector2 cursor_pos(
-			center.x + (center.x * Math::cos(p_hue * Math_TAU) * color_picker->s),
-			center.y + (center.y * Math::sin(p_hue * Math_TAU) * color_picker->s));
+			center.x + (center.x * Math::cos(p_hue * Math::TAU) * color_picker->s),
+			center.y + (center.y * Math::sin(p_hue * Math::TAU) * color_picker->s));
 
 	draw_cursor(p_control, cursor_pos);
 }
@@ -407,7 +407,7 @@ void ColorPickerShapeWheel::_wheel_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 	const Vector2 uv_size = wheel_uv->get_size();
-	const Vector2 ring_radius = uv_size * Math_SQRT12 * WHEEL_RADIUS;
+	const Vector2 ring_radius = uv_size * Math::SQRT12 * WHEEL_RADIUS;
 	const Vector2 center = uv_size * 0.5;
 
 	if (is_click && !spinning) {
@@ -427,7 +427,7 @@ void ColorPickerShapeWheel::_wheel_input(const Ref<InputEvent> &p_event) {
 
 	if (spinning) {
 		real_t rad = center.angle_to_point(event_position);
-		color_picker->h = ((rad >= 0) ? rad : (Math_TAU + rad)) / Math_TAU;
+		color_picker->h = ((rad >= 0) ? rad : (Math::TAU + rad)) / Math::TAU;
 		apply_color();
 		return;
 	}
@@ -460,7 +460,7 @@ void ColorPickerShapeWheel::_wheel_draw() {
 
 void ColorPickerShapeWheel::_wheel_uv_draw() {
 	const Vector2 uv_size = wheel_uv->get_size();
-	const Vector2 ring_radius = uv_size * Math_SQRT12 * WHEEL_RADIUS;
+	const Vector2 ring_radius = uv_size * Math::SQRT12 * WHEEL_RADIUS;
 	const Vector2 center = uv_size * 0.5;
 
 	const Rect2 uv_rect(center - ring_radius, ring_radius * 2.0);
@@ -472,8 +472,8 @@ void ColorPickerShapeWheel::_wheel_uv_draw() {
 	float radius = WHEEL_RADIUS * 2.0;
 	radius += (1.0 - radius) * 0.5;
 	const Vector2 cursor_pos = center +
-			Vector2(center.x * Math::cos(color_picker->h * Math_TAU) * radius,
-					center.y * Math::sin(color_picker->h * Math_TAU) * radius);
+			Vector2(center.x * Math::cos(color_picker->h * Math::TAU) * radius,
+					center.y * Math::sin(color_picker->h * Math::TAU) * radius);
 	draw_cursor(wheel_uv, cursor_pos, false);
 }
 
@@ -539,7 +539,7 @@ void ColorPickerShapeCircle::update_circle_cursor(const Vector2 &p_color_change_
 		circle_keyboard_joypad_picker_cursor_position += p_color_change_vector;
 		real_t dist = p_center.distance_to(circle_keyboard_joypad_picker_cursor_position);
 		real_t rad = p_center.angle_to_point(circle_keyboard_joypad_picker_cursor_position);
-		color_picker->h = ((rad >= 0) ? rad : (Math_TAU + rad)) / Math_TAU;
+		color_picker->h = ((rad >= 0) ? rad : (Math::TAU + rad)) / Math::TAU;
 		color_picker->s = CLAMP(dist / p_center.x, 0, 1);
 	} else {
 		color_picker->h = get_h_on_circle_edge(p_color_change_vector);
@@ -608,7 +608,7 @@ void ColorPickerShapeVHSCircle::_circle_input(const Ref<InputEvent> &p_event) {
 	}
 
 	real_t rad = center.angle_to_point(event_position);
-	color_picker->h = ((rad >= 0) ? rad : (Math_TAU + rad)) / Math_TAU;
+	color_picker->h = ((rad >= 0) ? rad : (Math::TAU + rad)) / Math::TAU;
 	color_picker->s = CLAMP(dist / center.x, 0, 1);
 	color_picker->ok_hsl_h = color_picker->h;
 	color_picker->ok_hsl_s = color_picker->s;
@@ -668,7 +668,7 @@ void ColorPickerShapeVHSCircle::_value_slider_draw() {
 void ColorPickerShapeVHSCircle::_update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) {
 	if (circle_overlay->has_focus()) {
 		const Vector2 center = circle_overlay->get_size() / 2.0;
-		const Vector2 hue_offset = center * Vector2(Math::cos(color_picker->h * Math_TAU), Math::sin(color_picker->h * Math_TAU)) * color_picker->s;
+		const Vector2 hue_offset = center * Vector2(Math::cos(color_picker->h * Math::TAU), Math::sin(color_picker->h * Math::TAU)) * color_picker->s;
 		update_circle_cursor(p_color_change_vector, center, hue_offset);
 	} else if (value_slider->has_focus()) {
 		color_picker->v = CLAMP(color_picker->v - p_color_change_vector.y * echo_multiplier / 100.0, 0, 1);
@@ -693,7 +693,7 @@ void ColorPickerShapeOKHSLCircle::_circle_input(const Ref<InputEvent> &p_event) 
 	}
 
 	real_t rad = center.angle_to_point(event_position);
-	color_picker->h = ((rad >= 0) ? rad : (Math_TAU + rad)) / Math_TAU;
+	color_picker->h = ((rad >= 0) ? rad : (Math::TAU + rad)) / Math::TAU;
 	color_picker->s = CLAMP(dist / center.x, 0, 1);
 	color_picker->ok_hsl_h = color_picker->h;
 	color_picker->ok_hsl_s = color_picker->s;
@@ -761,7 +761,7 @@ void ColorPickerShapeOKHSLCircle::_value_slider_draw() {
 void ColorPickerShapeOKHSLCircle::_update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) {
 	if (circle_overlay->has_focus()) {
 		const Vector2 center = circle_overlay->get_size() / 2.0;
-		const Vector2 hue_offset = center * Vector2(Math::cos(color_picker->ok_hsl_h * Math_TAU), Math::sin(color_picker->ok_hsl_h * Math_TAU)) * color_picker->ok_hsl_s;
+		const Vector2 hue_offset = center * Vector2(Math::cos(color_picker->ok_hsl_h * Math::TAU), Math::sin(color_picker->ok_hsl_h * Math::TAU)) * color_picker->ok_hsl_s;
 		update_circle_cursor(p_color_change_vector, center, hue_offset);
 		color_picker->ok_hsl_h = color_picker->h;
 		color_picker->ok_hsl_s = color_picker->s;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2059,7 +2059,7 @@ void Control::accessibility_drag() {
 	Viewport *vp = get_viewport();
 
 	vp->_gui_force_drag_start();
-	Variant dnd_data = get_drag_data(Vector2(INFINITY, INFINITY));
+	Variant dnd_data = get_drag_data(Vector2(Math::INF, Math::INF));
 	if (dnd_data.get_type() != Variant::NIL) {
 		Window *w = Window::get_from_id(get_window()->get_window_id());
 		if (w) {
@@ -2077,7 +2077,7 @@ void Control::accessibility_drop() {
 	ERR_FAIL_COND(!is_inside_tree());
 	ERR_FAIL_COND(!get_viewport()->gui_is_dragging());
 
-	get_viewport()->gui_perform_drop_at(Vector2(INFINITY, INFINITY), this);
+	get_viewport()->gui_perform_drop_at(Vector2(Math::INF, Math::INF), this);
 
 	queue_accessibility_update();
 }
@@ -3603,7 +3603,7 @@ void Control::_notification(int p_notification) {
 			DisplayServer::get_singleton()->accessibility_update_add_action(ae, DisplayServer::AccessibilityAction::ACTION_HIDE_TOOLTIP, callable_mp(this, &Control::_accessibility_action_hide_tooltip));
 			DisplayServer::get_singleton()->accessibility_update_add_action(ae, DisplayServer::AccessibilityAction::ACTION_SCROLL_INTO_VIEW, callable_mp(this, &Control::_accessibility_action_scroll_into_view));
 			if (is_inside_tree() && get_viewport()->gui_is_dragging()) {
-				if (can_drop_data(Vector2(INFINITY, INFINITY), get_viewport()->gui_get_drag_data())) {
+				if (can_drop_data(Vector2(Math::INF, Math::INF), get_viewport()->gui_get_drag_data())) {
 					DisplayServer::get_singleton()->accessibility_update_set_extra_info(ae, vformat(RTR("%s can be dropped here. Use %s to drop, use %s to cancel."), get_viewport()->gui_get_drag_description(), InputMap::get_singleton()->get_action_description("ui_accessibility_drag_and_drop"), InputMap::get_singleton()->get_action_description("ui_cancel")));
 				} else {
 					DisplayServer::get_singleton()->accessibility_update_set_extra_info(ae, vformat(RTR("%s can not be dropped here. Use %s to cancel."), get_viewport()->gui_get_drag_description(), InputMap::get_singleton()->get_action_description("ui_cancel")));

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -976,7 +976,7 @@ void LineEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 	if (p_data.is_string() && is_editable()) {
 		apply_ime();
 
-		if (p_point != Vector2(INFINITY, INFINITY)) {
+		if (p_point != Vector2(Math::INF, Math::INF)) {
 			set_caret_at_pixel_pos(p_point.x);
 		}
 		int caret_column_tmp = caret_column;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1269,8 +1269,8 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 								uint64_t char_current_rand = item_shake->offset_random(glyphs[i].start);
 								uint64_t char_previous_rand = item_shake->offset_previous_random(glyphs[i].start);
 								uint64_t max_rand = 2147483647;
-								double current_offset = Math::remap(char_current_rand % max_rand, 0, max_rand, 0.0f, 2.f * (float)Math_PI);
-								double previous_offset = Math::remap(char_previous_rand % max_rand, 0, max_rand, 0.0f, 2.f * (float)Math_PI);
+								double current_offset = Math::remap(char_current_rand % max_rand, 0, max_rand, 0.0f, 2.f * (float)Math::PI);
+								double previous_offset = Math::remap(char_previous_rand % max_rand, 0, max_rand, 0.0f, 2.f * (float)Math::PI);
 								double n_time = (double)(item_shake->elapsed_time / (0.5f / item_shake->rate));
 								n_time = (n_time > 1.0) ? 1.0 : n_time;
 								item_shake->prev_off = Point2(Math::lerp(Math::sin(previous_offset), Math::sin(current_offset), n_time), Math::lerp(Math::cos(previous_offset), Math::cos(current_offset), n_time)) * (float)item_shake->strength / 10.0f;

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1390,7 +1390,7 @@ void TabBar::drop_data(const Point2 &p_point, const Variant &p_data) {
 }
 
 Variant TabBar::_handle_get_drag_data(const String &p_type, const Point2 &p_point) {
-	int tab_over = (p_point == Vector2(INFINITY, INFINITY)) ? current : get_tab_idx_at_point(p_point);
+	int tab_over = (p_point == Vector2(Math::INF, Math::INF)) ? current : get_tab_idx_at_point(p_point);
 	if (tab_over < 0) {
 		return Variant();
 	}
@@ -1455,7 +1455,7 @@ void TabBar::_handle_drop_data(const String &p_type, const Point2 &p_point, cons
 
 	if (String(d["type"]) == p_type) {
 		int tab_from_id = d["tab_index"];
-		int hover_now = (p_point == Vector2(INFINITY, INFINITY)) ? current : get_closest_tab_idx_to_point(p_point);
+		int hover_now = (p_point == Vector2(Math::INF, Math::INF)) ? current : get_closest_tab_idx_to_point(p_point);
 		NodePath from_path = d["from_path"];
 		NodePath to_path = get_path();
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3321,7 +3321,7 @@ bool TextEdit::can_drop_data(const Point2 &p_point, const Variant &p_data) const
 void TextEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 	Control::drop_data(p_point, p_data);
 
-	if (p_point == Vector2(INFINITY, INFINITY)) {
+	if (p_point == Vector2(Math::INF, Math::INF)) {
 		insert_text_at_caret(p_data);
 	} else if (p_data.is_string() && is_editable()) {
 		Point2i pos = get_line_column_at_pos(get_local_mouse_pos());

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -193,7 +193,7 @@ Point2 TextureProgressBar::unit_val_to_uv(float val) {
 	Point2 p = get_relative_center();
 
 	// Minimal version of Liang-Barsky clipping algorithm
-	float angle = (val * Math_TAU) - Math_PI * 0.5;
+	float angle = (val * Math::TAU) - Math::PI * 0.5;
 	Point2 dir = Vector2(Math::cos(angle), Math::sin(angle));
 	float t1 = 1.0;
 	float cp = 0.0;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -6232,7 +6232,7 @@ int Tree::get_button_id_at_position(const Point2 &p_pos) const {
 		return -1;
 	}
 
-	if (p_pos == Vector2(INFINITY, INFINITY)) {
+	if (p_pos == Vector2(Math::INF, Math::INF)) {
 		if (selected_item && selected_button >= 0) {
 			return selected_item->cells[selected_col].buttons[selected_button].id;
 		}

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -750,7 +750,7 @@ void CanvasItem::draw_arc(const Vector2 &p_center, real_t p_radius, real_t p_sta
 	Point2 *points_ptr = points.ptrw();
 
 	// Clamp angle difference to full circle so arc won't overlap itself.
-	const real_t delta_angle = CLAMP(p_end_angle - p_start_angle, -Math_TAU, Math_TAU);
+	const real_t delta_angle = CLAMP(p_end_angle - p_start_angle, -Math::TAU, Math::TAU);
 	for (int i = 0; i < p_point_count; i++) {
 		real_t theta = (i / (p_point_count - 1.0f)) * delta_angle + p_start_angle;
 		points_ptr[i] = p_center + Vector2(Math::cos(theta), Math::sin(theta)) * p_radius;
@@ -823,7 +823,7 @@ void CanvasItem::draw_circle(const Point2 &p_pos, real_t p_radius, const Color &
 		points.resize(circle_segments + 1);
 
 		Vector2 *points_ptr = points.ptrw();
-		const real_t circle_point_step = Math_TAU / circle_segments;
+		const real_t circle_point_step = Math::TAU / circle_segments;
 
 		for (int i = 0; i < circle_segments; i++) {
 			float angle = i * circle_point_step;

--- a/scene/resources/2d/capsule_shape_2d.cpp
+++ b/scene/resources/2d/capsule_shape_2d.cpp
@@ -36,7 +36,7 @@
 
 Vector<Vector2> CapsuleShape2D::_get_points() const {
 	Vector<Vector2> points;
-	const real_t turn_step = Math_TAU / 24.0;
+	const real_t turn_step = Math::TAU / 24.0;
 	for (int i = 0; i < 24; i++) {
 		Vector2 ofs = Vector2(0, (i > 6 && i <= 18) ? -height * 0.5 + radius : height * 0.5 - radius);
 

--- a/scene/resources/2d/circle_shape_2d.cpp
+++ b/scene/resources/2d/circle_shape_2d.cpp
@@ -77,7 +77,7 @@ void CircleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Vector2> points;
 	points.resize(24);
 
-	const real_t turn_step = Math_TAU / 24.0;
+	const real_t turn_step = Math::TAU / 24.0;
 	for (int i = 0; i < 24; i++) {
 		points.write[i] = Vector2(Math::cos(i * turn_step), Math::sin(i * turn_step)) * get_radius();
 	}

--- a/scene/resources/2d/separation_ray_shape_2d.cpp
+++ b/scene/resources/2d/separation_ray_shape_2d.cpp
@@ -74,7 +74,7 @@ Rect2 SeparationRayShape2D::get_rect() const {
 	Rect2 rect;
 	rect.position = Vector2();
 	rect.expand_to(Vector2(0, length));
-	rect = rect.grow(Math_SQRT12 * 4);
+	rect = rect.grow(Math::SQRT12 * 4);
 	return rect;
 }
 

--- a/scene/resources/2d/skeleton/skeleton_modification_2d.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d.cpp
@@ -81,15 +81,15 @@ bool SkeletonModification2D::get_enabled() {
 float SkeletonModification2D::clamp_angle(float p_angle, float p_min_bound, float p_max_bound, bool p_invert) {
 	// Map to the 0 to 360 range (in radians though) instead of the -180 to 180 range.
 	if (p_angle < 0) {
-		p_angle = Math_TAU + p_angle;
+		p_angle = Math::TAU + p_angle;
 	}
 
 	// Make min and max in the range of 0 to 360 (in radians), and make sure they are in the right order
 	if (p_min_bound < 0) {
-		p_min_bound = Math_TAU + p_min_bound;
+		p_min_bound = Math::TAU + p_min_bound;
 	}
 	if (p_max_bound < 0) {
-		p_max_bound = Math_TAU + p_max_bound;
+		p_max_bound = Math::TAU + p_max_bound;
 	}
 	if (p_min_bound > p_max_bound) {
 		SWAP(p_min_bound, p_max_bound);
@@ -130,10 +130,10 @@ void SkeletonModification2D::editor_draw_angle_constraints(Bone2D *p_operation_b
 	float arc_angle_min = p_min_bound;
 	float arc_angle_max = p_max_bound;
 	if (arc_angle_min < 0) {
-		arc_angle_min = (Math_PI * 2) + arc_angle_min;
+		arc_angle_min = (Math::PI * 2) + arc_angle_min;
 	}
 	if (arc_angle_max < 0) {
-		arc_angle_max = (Math_PI * 2) + arc_angle_max;
+		arc_angle_max = (Math::PI * 2) + arc_angle_max;
 	}
 	if (arc_angle_min > arc_angle_max) {
 		SWAP(arc_angle_min, arc_angle_max);
@@ -159,7 +159,7 @@ void SkeletonModification2D::editor_draw_angle_constraints(Bone2D *p_operation_b
 
 		if (p_constraint_inverted) {
 			stack->skeleton->draw_arc(Vector2(0, 0), p_operation_bone->get_length(),
-					arc_angle_min + (Math_PI * 2), arc_angle_max, 32, bone_ik_color, 1.0);
+					arc_angle_min + (Math::PI * 2), arc_angle_max, 32, bone_ik_color, 1.0);
 		} else {
 			stack->skeleton->draw_arc(Vector2(0, 0), p_operation_bone->get_length(),
 					arc_angle_min, arc_angle_max, 32, bone_ik_color, 1.0);
@@ -169,7 +169,7 @@ void SkeletonModification2D::editor_draw_angle_constraints(Bone2D *p_operation_b
 
 	} else {
 		stack->skeleton->draw_set_transform(stack->skeleton->to_local(p_operation_bone->get_global_position()));
-		stack->skeleton->draw_arc(Vector2(0, 0), p_operation_bone->get_length(), 0, Math_PI * 2, 32, bone_ik_color, 1.0);
+		stack->skeleton->draw_arc(Vector2(0, 0), p_operation_bone->get_length(), 0, Math::PI * 2, 32, bone_ik_color, 1.0);
 		stack->skeleton->draw_line(Vector2(0, 0), Vector2(1, 0) * p_operation_bone->get_length(), bone_ik_color, 1.0);
 	}
 }

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_ccdik.h
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_ccdik.h
@@ -49,7 +49,7 @@ private:
 
 		bool enable_constraint = false;
 		float constraint_angle_min = 0;
-		float constraint_angle_max = (2.0 * Math_PI);
+		float constraint_angle_max = (2.0 * Math::PI);
 		bool constraint_angle_invert = false;
 		bool constraint_in_localspace = true;
 

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_lookat.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_lookat.cpp
@@ -399,7 +399,7 @@ SkeletonModification2DLookAt::SkeletonModification2DLookAt() {
 	additional_rotation = 0;
 	enable_constraint = false;
 	constraint_angle_min = 0;
-	constraint_angle_max = Math_PI * 2;
+	constraint_angle_max = Math::PI * 2;
 	constraint_angle_invert = false;
 	enabled = true;
 

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_lookat.h
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_lookat.h
@@ -52,7 +52,7 @@ private:
 	float additional_rotation = 0;
 	bool enable_constraint = false;
 	float constraint_angle_min = 0;
-	float constraint_angle_max = (2.0 * Math_PI);
+	float constraint_angle_max = (2.0 * Math::PI);
 	bool constraint_angle_invert = false;
 	bool constraint_in_localspace = true;
 

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
@@ -178,7 +178,7 @@ void SkeletonModification2DTwoBoneIK::_execute(float p_delta) {
 			// We cannot solve for this angle! Do nothing to avoid setting the rotation (and scale) to NaN.
 		} else {
 			joint_one_bone->set_global_rotation(angle_atan - angle_0 - joint_one_bone->get_bone_angle());
-			joint_two_bone->set_rotation(-Math_PI - angle_1 - joint_two_bone->get_bone_angle() + joint_one_bone->get_bone_angle());
+			joint_two_bone->set_rotation(-Math::PI - angle_1 - joint_two_bone->get_bone_angle() + joint_one_bone->get_bone_angle());
 		}
 	} else {
 		joint_one_bone->set_global_rotation(angle_atan - joint_one_bone->get_bone_angle());
@@ -221,10 +221,10 @@ void SkeletonModification2DTwoBoneIK::_draw_editor_gizmo() {
 #endif // TOOLS_ENABLED
 
 	if (flip_bend_direction) {
-		float angle = -(Math_PI * 0.5) + operation_bone_one->get_bone_angle();
+		float angle = -(Math::PI * 0.5) + operation_bone_one->get_bone_angle();
 		stack->skeleton->draw_line(Vector2(0, 0), Vector2(Math::cos(angle), sin(angle)) * (operation_bone_one->get_length() * 0.5), bone_ik_color, 2.0);
 	} else {
-		float angle = (Math_PI * 0.5) + operation_bone_one->get_bone_angle();
+		float angle = (Math::PI * 0.5) + operation_bone_one->get_bone_angle();
 		stack->skeleton->draw_line(Vector2(0, 0), Vector2(Math::cos(angle), sin(angle)) * (operation_bone_one->get_length() * 0.5), bone_ik_color, 2.0);
 	}
 

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -389,7 +389,7 @@ void CapsuleMesh::_update_lightmap_size() {
 		Size2i _lightmap_size_hint;
 		float padding = get_uv2_padding();
 
-		float radial_length = radius * Math_PI * 0.5; // circumference of 90 degree bend
+		float radial_length = radius * Math::PI * 0.5; // circumference of 90 degree bend
 		float vertical_length = radial_length * 2 + (height - 2.0 * radius); // total vertical length
 
 		_lightmap_size_hint.x = MAX(1.0, 4.0 * radial_length / texel_size) + padding;
@@ -413,9 +413,9 @@ void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const floa
 	float twothirds = 2.0 / 3.0;
 
 	// Only used if we calculate UV2
-	float radial_width = 2.0 * radius * Math_PI;
+	float radial_width = 2.0 * radius * Math::PI;
 	float radial_h = radial_width / (radial_width + p_uv2_padding);
-	float radial_length = radius * Math_PI * 0.5; // circumference of 90 degree bend
+	float radial_length = radius * Math::PI * 0.5; // circumference of 90 degree bend
 	float vertical_length = radial_length * 2 + (height - 2.0 * radius) + p_uv2_padding; // total vertical length
 	float radial_v = radial_length / vertical_length; // v size of top and bottom section
 	float height_v = (height - 2.0 * radius) / vertical_length; // v size of height section
@@ -447,8 +447,8 @@ void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const floa
 			w = 1.0;
 			y = 0.0;
 		} else {
-			w = Math::sin(0.5 * Math_PI * v);
-			y = Math::cos(0.5 * Math_PI * v);
+			w = Math::sin(0.5 * Math::PI * v);
+			y = Math::cos(0.5 * Math::PI * v);
 		}
 
 		for (i = 0; i <= radial_segments; i++) {
@@ -459,8 +459,8 @@ void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const floa
 				x = 0.0;
 				z = 1.0;
 			} else {
-				x = -Math::sin(u * Math_TAU);
-				z = Math::cos(u * Math_TAU);
+				x = -Math::sin(u * Math::TAU);
+				z = Math::cos(u * Math::TAU);
 			}
 
 			Vector3 p = Vector3(x * w, y, -z * w);
@@ -506,8 +506,8 @@ void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const floa
 				x = 0.0;
 				z = 1.0;
 			} else {
-				x = -Math::sin(u * Math_TAU);
-				z = Math::cos(u * Math_TAU);
+				x = -Math::sin(u * Math::TAU);
+				z = Math::cos(u * Math::TAU);
 			}
 
 			Vector3 p = Vector3(x * radius, y, -z * radius);
@@ -546,8 +546,8 @@ void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const floa
 			w = 0.0;
 			y = -1.0;
 		} else {
-			w = Math::cos(0.5 * Math_PI * v);
-			y = -Math::sin(0.5 * Math_PI * v);
+			w = Math::cos(0.5 * Math::PI * v);
+			y = -Math::sin(0.5 * Math::PI * v);
 		}
 
 		for (i = 0; i <= radial_segments; i++) {
@@ -558,8 +558,8 @@ void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const floa
 				x = 0.0;
 				z = 1.0;
 			} else {
-				x = -Math::sin(u * Math_TAU);
-				z = Math::cos(u * Math_TAU);
+				x = -Math::sin(u * Math::TAU);
+				z = Math::cos(u * Math::TAU);
 			}
 
 			Vector3 p = Vector3(x * w, y, -z * w);
@@ -1028,8 +1028,8 @@ void CylinderMesh::_update_lightmap_size() {
 		Size2i _lightmap_size_hint;
 		float padding = get_uv2_padding();
 
-		float top_circumference = top_radius * Math_PI * 2.0;
-		float bottom_circumference = bottom_radius * Math_PI * 2.0;
+		float top_circumference = top_radius * Math::PI * 2.0;
+		float bottom_circumference = bottom_radius * Math::PI * 2.0;
 
 		float _width = MAX(top_circumference, bottom_circumference) / texel_size + padding;
 		_width = MAX(_width, (((top_radius + bottom_radius) / texel_size) + padding) * 2.0); // this is extremely unlikely to be larger, will only happen if padding is larger then our diameter.
@@ -1055,8 +1055,8 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 	float x, y, z, u, v, radius, radius_h;
 
 	// Only used if we calculate UV2
-	float top_circumference = top_radius * Math_PI * 2.0;
-	float bottom_circumference = bottom_radius * Math_PI * 2.0;
+	float top_circumference = top_radius * Math::PI * 2.0;
+	float bottom_circumference = bottom_radius * Math::PI * 2.0;
 	float vertical_length = height + MAX(2.0 * top_radius, 2.0 * bottom_radius) + (2.0 * p_uv2_padding);
 	float height_v = height / vertical_length;
 	float padding_v = p_uv2_padding / vertical_length;
@@ -1102,8 +1102,8 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 				x = 0.0;
 				z = 1.0;
 			} else {
-				x = Math::sin(u * Math_TAU);
-				z = Math::cos(u * Math_TAU);
+				x = Math::sin(u * Math::TAU);
+				z = Math::cos(u * Math::TAU);
 			}
 
 			Vector3 p = Vector3(x * radius, y, z * radius);
@@ -1159,8 +1159,8 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 				x = 0.0;
 				z = 1.0;
 			} else {
-				x = Math::sin(r * Math_TAU);
-				z = Math::cos(r * Math_TAU);
+				x = Math::sin(r * Math::TAU);
+				z = Math::cos(r * Math::TAU);
 			}
 
 			u = ((x + 1.0) * 0.25);
@@ -1206,8 +1206,8 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 				x = 0.0;
 				z = 1.0;
 			} else {
-				x = Math::sin(r * Math_TAU);
-				z = Math::cos(r * Math_TAU);
+				x = Math::sin(r * Math::TAU);
+				z = Math::cos(r * Math::TAU);
 			}
 
 			u = 0.5 + ((x + 1.0) * 0.25);
@@ -1921,9 +1921,9 @@ void SphereMesh::_update_lightmap_size() {
 		Size2i _lightmap_size_hint;
 		float padding = get_uv2_padding();
 
-		float _width = radius * Math_TAU;
+		float _width = radius * Math::TAU;
 		_lightmap_size_hint.x = MAX(1.0, (_width / texel_size) + padding);
-		float _height = (is_hemisphere ? 1.0 : 0.5) * height * Math_PI; // note, with hemisphere height is our radius, while with a full sphere it is the diameter..
+		float _height = (is_hemisphere ? 1.0 : 0.5) * height * Math::PI; // note, with hemisphere height is our radius, while with a full sphere it is the diameter..
 		_lightmap_size_hint.y = MAX(1.0, (_height / texel_size) + padding);
 
 		set_lightmap_size_hint(_lightmap_size_hint);
@@ -1944,11 +1944,11 @@ void SphereMesh::create_mesh_array(Array &p_arr, float radius, float height, int
 	float scale = height / radius * (is_hemisphere ? 1.0 : 0.5);
 
 	// Only used if we calculate UV2
-	float circumference = radius * Math_TAU;
+	float circumference = radius * Math::TAU;
 	float horizontal_length = circumference + p_uv2_padding;
 	float center_h = 0.5 * circumference / horizontal_length;
 
-	float height_v = scale * Math_PI / ((scale * Math_PI) + p_uv2_padding / radius);
+	float height_v = scale * Math::PI / ((scale * Math::PI) + p_uv2_padding / radius);
 
 	// set our bounding box
 
@@ -1977,8 +1977,8 @@ void SphereMesh::create_mesh_array(Array &p_arr, float radius, float height, int
 			w = 0.0;
 			y = -1.0;
 		} else {
-			w = Math::sin(Math_PI * v);
-			y = Math::cos(Math_PI * v);
+			w = Math::sin(Math::PI * v);
+			y = Math::cos(Math::PI * v);
 		}
 
 		for (i = 0; i <= radial_segments; i++) {
@@ -1989,8 +1989,8 @@ void SphereMesh::create_mesh_array(Array &p_arr, float radius, float height, int
 				x = 0.0;
 				z = 1.0;
 			} else {
-				x = Math::sin(u * Math_TAU);
-				z = Math::cos(u * Math_TAU);
+				x = Math::sin(u * Math::TAU);
+				z = Math::cos(u * Math::TAU);
 			}
 
 			if (is_hemisphere && y < 0.0) {
@@ -2141,9 +2141,9 @@ void TorusMesh::_update_lightmap_size() {
 
 		float radius = (max_radius - min_radius) * 0.5;
 
-		float _width = max_radius * Math_TAU;
+		float _width = max_radius * Math::TAU;
 		_lightmap_size_hint.x = MAX(1.0, (_width / texel_size) + padding);
-		float _height = radius * Math_TAU;
+		float _height = radius * Math::TAU;
 		_lightmap_size_hint.y = MAX(1.0, (_height / texel_size) + padding);
 
 		set_lightmap_size_hint(_lightmap_size_hint);
@@ -2181,23 +2181,23 @@ void TorusMesh::_create_mesh_array(Array &p_arr) const {
 	bool _add_uv2 = get_add_uv2();
 	float _uv2_padding = get_uv2_padding() * texel_size;
 
-	float horizontal_total = max_radius * Math_TAU + _uv2_padding;
-	float max_h = max_radius * Math_TAU / horizontal_total;
-	float delta_h = (max_radius - min_radius) * Math_TAU / horizontal_total;
+	float horizontal_total = max_radius * Math::TAU + _uv2_padding;
+	float max_h = max_radius * Math::TAU / horizontal_total;
+	float delta_h = (max_radius - min_radius) * Math::TAU / horizontal_total;
 
-	float height_v = radius * Math_TAU / (radius * Math_TAU + _uv2_padding);
+	float height_v = radius * Math::TAU / (radius * Math::TAU + _uv2_padding);
 
 	for (int i = 0; i <= rings; i++) {
 		int prevrow = (i - 1) * (ring_segments + 1);
 		int thisrow = i * (ring_segments + 1);
 		float inci = float(i) / rings;
-		float angi = inci * Math_TAU;
+		float angi = inci * Math::TAU;
 
 		Vector2 normali = (i == rings) ? Vector2(0.0, -1.0) : Vector2(-Math::sin(angi), -Math::cos(angi));
 
 		for (int j = 0; j <= ring_segments; j++) {
 			float incj = float(j) / ring_segments;
-			float angj = incj * Math_TAU;
+			float angj = incj * Math::TAU;
 
 			Vector2 normalj = (j == ring_segments) ? Vector2(-1.0, 0.0) : Vector2(-Math::cos(angj), Math::sin(angj));
 			Vector2 normalk = normalj * radius + Vector2(min_radius + radius, 0);
@@ -2486,8 +2486,8 @@ void TubeTrailMesh::_create_mesh_array(Array &p_arr) const {
 			float x = 0.0;
 			float z = 1.0;
 			if (i < radial_steps) {
-				x = Math::sin(u * Math_TAU);
-				z = Math::cos(u * Math_TAU);
+				x = Math::sin(u * Math::TAU);
+				z = Math::cos(u * Math::TAU);
 			}
 
 			Vector3 p = Vector3(x * r, y, z * r);
@@ -2559,8 +2559,8 @@ void TubeTrailMesh::_create_mesh_array(Array &p_arr) const {
 				float x = 0.0;
 				float z = 1.0;
 				if (i < radial_steps) {
-					x = Math::sin(r * Math_TAU);
-					z = Math::cos(r * Math_TAU);
+					x = Math::sin(r * Math::TAU);
+					z = Math::cos(r * Math::TAU);
 				}
 
 				float u = ((x + 1.0) * 0.25);
@@ -2628,8 +2628,8 @@ void TubeTrailMesh::_create_mesh_array(Array &p_arr) const {
 				float x = 0.0;
 				float z = 1.0;
 				if (i < radial_steps) {
-					x = Math::sin(r * Math_TAU);
-					z = Math::cos(r * Math_TAU);
+					x = Math::sin(r * Math::TAU);
+					z = Math::cos(r * Math::TAU);
 				}
 
 				float u = 0.5 + ((x + 1.0) * 0.25);
@@ -3248,8 +3248,8 @@ void TextMesh::_create_mesh_array(Array &p_arr) const {
 	Vector<Vector2> uvs;
 	Vector<int32_t> indices;
 
-	Vector2 min_p = Vector2(INFINITY, INFINITY);
-	Vector2 max_p = Vector2(-INFINITY, -INFINITY);
+	Vector2 min_p = Vector2(Math::INF, Math::INF);
+	Vector2 max_p = Vector2(-Math::INF, -Math::INF);
 
 	int32_t p_size = 0;
 	int32_t i_size = 0;

--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -581,8 +581,8 @@ private:
 		Vector<Vector2> triangles;
 		Vector<Vector<ContourPoint>> contours;
 		Vector<ContourInfo> contours_info;
-		Vector2 min_p = Vector2(INFINITY, INFINITY);
-		Vector2 max_p = Vector2(-INFINITY, -INFINITY);
+		Vector2 min_p = Vector2(Math::INF, Math::INF);
+		Vector2 max_p = Vector2(-Math::INF, -Math::INF);
 	};
 	mutable HashMap<GlyphMeshKey, GlyphMeshData, GlyphMeshKeyHasher> cache;
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2478,7 +2478,7 @@ Variant Animation::_interpolate_angle(const Variant &p_a, const Variant &p_b, re
 	if (vformat == ((1 << Variant::INT) | (1 << Variant::FLOAT)) || vformat == (1 << Variant::FLOAT)) {
 		real_t a = p_a;
 		real_t b = p_b;
-		return Math::fposmod((float)Math::lerp_angle(a, b, p_c), (float)Math_TAU);
+		return Math::fposmod((float)Math::lerp_angle(a, b, p_c), (float)Math::TAU);
 	}
 	return _interpolate(p_a, p_b, p_c);
 }
@@ -2515,7 +2515,7 @@ Variant Animation::_cubic_interpolate_angle_in_time(const Variant &p_pre_a, cons
 		real_t b = p_b;
 		real_t pa = p_pre_a;
 		real_t pb = p_post_b;
-		return Math::fposmod((float)Math::cubic_interpolate_angle_in_time(a, b, pa, pb, p_c, p_b_t, p_pre_a_t, p_post_b_t), (float)Math_TAU);
+		return Math::fposmod((float)Math::cubic_interpolate_angle_in_time(a, b, pa, pb, p_c, p_b_t, p_pre_a_t, p_post_b_t), (float)Math::TAU);
 	}
 	return _cubic_interpolate_in_time(p_pre_a, p_a, p_b, p_post_b, p_c, p_pre_a_t, p_b_t, p_post_b_t);
 }
@@ -4209,7 +4209,7 @@ bool Animation::_quaternion_track_optimize_key(const TKey<Quaternion> t0, const 
 	if (q0.get_axis().dot(q1.get_axis()) >= 1.0 - p_allowed_angular_error * 2.0) {
 		double a0 = Math::acos(t0.value.dot(t1.value));
 		double a1 = Math::acos(t1.value.dot(t2.value));
-		if (a0 + a1 >= Math_PI / 2) {
+		if (a0 + a1 >= Math::PI / 2) {
 			return false; // Rotation is more than 180 deg, keep key.
 		}
 		// Calc velocities.
@@ -4359,11 +4359,11 @@ void Animation::_value_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 				t1.value = vt->values[i + 1].value;
 				t2.value = vt->values[i + 2].value;
 				if (is_using_angle) {
-					float diff1 = fmod(t1.value - t0.value, Math_TAU);
-					t1.value = t0.value + fmod(2.0 * diff1, Math_TAU) - diff1;
-					float diff2 = fmod(t2.value - t1.value, Math_TAU);
-					t2.value = t1.value + fmod(2.0 * diff2, Math_TAU) - diff2;
-					if (abs(abs(diff1) + abs(diff2)) >= Math_PI) {
+					float diff1 = fmod(t1.value - t0.value, Math::TAU);
+					t1.value = t0.value + fmod(2.0 * diff1, Math::TAU) - diff1;
+					float diff2 = fmod(t2.value - t1.value, Math::TAU);
+					t2.value = t1.value + fmod(2.0 * diff2, Math::TAU) - diff2;
+					if (abs(abs(diff1) + abs(diff2)) >= Math::PI) {
 						break; // Rotation is more than 180 deg, keep key.
 					}
 				}
@@ -4423,8 +4423,8 @@ void Animation::_value_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 				float val_0 = vt->values[0].value;
 				float val_1 = vt->values[1].value;
 				if (is_using_angle) {
-					float diff1 = fmod(val_1 - val_0, Math_TAU);
-					val_1 = val_0 + fmod(2.0 * diff1, Math_TAU) - diff1;
+					float diff1 = fmod(val_1 - val_0, Math::TAU);
+					val_1 = val_0 + fmod(2.0 * diff1, Math::TAU) - diff1;
 				}
 				single_key = abs(val_0 - val_1) < p_allowed_precision_error;
 			} break;
@@ -4756,9 +4756,9 @@ Vector3i Animation::_compress_key(uint32_t p_track, const AABB &p_bounds, int32_
 			}
 			Vector3 axis = rot.get_axis();
 			float angle = rot.get_angle();
-			angle = Math::fposmod(double(angle), double(Math_PI * 2.0));
+			angle = Math::fposmod(double(angle), double(Math::PI * 2.0));
 			Vector2 oct = axis.octahedron_encode();
-			Vector3 rot_norm(oct.x, oct.y, angle / (Math_PI * 2.0)); // high resolution rotation in 0-1 angle.
+			Vector3 rot_norm(oct.x, oct.y, angle / (Math::PI * 2.0)); // high resolution rotation in 0-1 angle.
 
 			for (int j = 0; j < 3; j++) {
 				values[j] = CLAMP(int32_t(rot_norm[j] * 65535.0), 0, 65535);
@@ -5534,7 +5534,7 @@ int Animation::_get_compressed_key_count(uint32_t p_compressed_track) const {
 
 Quaternion Animation::_uncompress_quaternion(const Vector3i &p_value) const {
 	Vector3 axis = Vector3::octahedron_decode(Vector2(float(p_value.x) / 65535.0, float(p_value.y) / 65535.0));
-	float angle = (float(p_value.z) / 65535.0) * 2.0 * Math_PI;
+	float angle = (float(p_value.z) / 65535.0) * 2.0 * Math::PI;
 	return Quaternion(axis, angle);
 }
 Vector3 Animation::_uncompress_pos_scale(uint32_t p_compressed_track, const Vector3i &p_value) const {

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -335,7 +335,7 @@ private:
 	 * data for X / Blend Shape, Y and Z must be normalized first: unorm = float(data) / 65535.0
 	 * **Blend Shape**: (unorm * 2.0 - 1.0) * Compression::BLEND_SHAPE_RANGE
 	 * **Pos/Scale**: unorm_vec3 * bounds[track].size + bounds[track].position
-	 * **Rotation**: Quaternion(Vector3::octahedron_decode(unorm_vec3.xy),unorm_vec3.z * Math_PI * 2.0)
+	 * **Rotation**: Quaternion(Vector3::octahedron_decode(unorm_vec3.xy),unorm_vec3.z * Math::PI * 2.0)
 	 * **Frame**: page.time_offset + frame * (1.0/fps)
 	 */
 

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -345,7 +345,7 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 
 	// If the center is filled, we do not draw the border and directly use the inner ring as reference. Because all calls to this
 	// method either draw a ring or a filled rounded rectangle, but not both.
-	const real_t quarter_arc_rad = Math_PI / 2.0;
+	const real_t quarter_arc_rad = Math::PI / 2.0;
 	const Point2 style_rect_center = style_rect.get_center();
 
 	const int colors_size = colors.size();
@@ -364,7 +364,7 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 				idx_ofs *= 2;
 			}
 
-			const real_t pt_angle = (corner_idx + detail / (double)adapted_corner_detail) * quarter_arc_rad + Math_PI;
+			const real_t pt_angle = (corner_idx + detail / (double)adapted_corner_detail) * quarter_arc_rad + Math::PI;
 			const real_t angle_cosine = Math::cos(pt_angle);
 			const real_t angle_sine = Math::sin(pt_angle);
 

--- a/servers/audio/audio_filter_sw.cpp
+++ b/servers/audio/audio_filter_sw.cpp
@@ -60,7 +60,7 @@ void AudioFilterSW::prepare_coefficients(Coeffs *p_coeffs) {
 		final_cutoff = 1; //don't allow less than this
 	}
 
-	double omega = Math_TAU * final_cutoff / sampling_rate;
+	double omega = Math::TAU * final_cutoff / sampling_rate;
 
 	double sin_v = Math::sin(omega);
 	double cos_v = Math::cos(omega);
@@ -134,7 +134,7 @@ void AudioFilterSW::prepare_coefficients(Coeffs *p_coeffs) {
 			double hicutoff = resonance;
 			double centercutoff = (cutoff + resonance) / 2.0;
 			double bandwidth = (Math::log(centercutoff) - Math::log(hicutoff)) / Math::log((double)2);
-			omega = Math_TAU * centercutoff / sampling_rate;
+			omega = Math::TAU * centercutoff / sampling_rate;
 			alpha = Math::sin(omega) * Math::sinh(Math::log((double)2) / 2 * bandwidth * omega / Math::sin(omega));
 			a0 = 1 + alpha;
 
@@ -191,7 +191,7 @@ void AudioFilterSW::set_stages(int p_stages) {
 /* Fourier transform kernel to obtain response */
 
 float AudioFilterSW::get_response(float p_freq, Coeffs *p_coeffs) {
-	float freq = p_freq / sampling_rate * Math_TAU;
+	float freq = p_freq / sampling_rate * Math::TAU;
 
 	float cx = p_coeffs->b0, cy = 0.0;
 

--- a/servers/audio/effects/audio_effect_chorus.cpp
+++ b/servers/audio/effects/audio_effect_chorus.cpp
@@ -84,7 +84,7 @@ void AudioEffectChorusInstance::_process_chunk(const AudioFrame *p_src_frames, A
 		if (v.cutoff == 0) {
 			continue;
 		}
-		float auxlp = expf(-Math_TAU * v.cutoff / mix_rate);
+		float auxlp = expf(-Math::TAU * v.cutoff / mix_rate);
 		float c1 = 1.0 - auxlp;
 		float c2 = auxlp;
 		AudioFrame h = filter_h[vc];
@@ -104,7 +104,7 @@ void AudioEffectChorusInstance::_process_chunk(const AudioFrame *p_src_frames, A
 
 			float phase = (float)(local_cycles & AudioEffectChorus::CYCLES_MASK) / (float)(1 << AudioEffectChorus::CYCLES_FRAC);
 
-			float wave_delay = sinf(phase * Math_TAU) * max_depth_frames;
+			float wave_delay = sinf(phase * Math::TAU) * max_depth_frames;
 
 			int wave_delay_frames = lrint(floor(wave_delay));
 			float wave_delay_frac = wave_delay - (float)wave_delay_frames;

--- a/servers/audio/effects/audio_effect_delay.cpp
+++ b/servers/audio/effects/audio_effect_delay.cpp
@@ -73,7 +73,7 @@ void AudioEffectDelayInstance::_process_chunk(const AudioFrame *p_src_frames, Au
 	tap2_vol.right *= CLAMP(1.0 + base->tap_2_pan, 0, 1);
 
 	// feedback lowpass here
-	float lpf_c = expf(-Math_TAU * base->feedback_lowpass / mix_rate); // 0 .. 10khz
+	float lpf_c = expf(-Math::TAU * base->feedback_lowpass / mix_rate); // 0 .. 10khz
 	float lpf_ic = 1.0 - lpf_c;
 
 	const AudioFrame *src = p_src_frames;

--- a/servers/audio/effects/audio_effect_distortion.cpp
+++ b/servers/audio/effects/audio_effect_distortion.cpp
@@ -36,8 +36,8 @@ void AudioEffectDistortionInstance::process(const AudioFrame *p_src_frames, Audi
 	const float *src = (const float *)p_src_frames;
 	float *dst = (float *)p_dst_frames;
 
-	//float lpf_c=expf(-Math_TAU*keep_hf_hz.get()/(mix_rate*(float)OVERSAMPLE));
-	float lpf_c = expf(-Math_TAU * base->keep_hf_hz / (AudioServer::get_singleton()->get_mix_rate()));
+	//float lpf_c=expf(-Math::TAU*keep_hf_hz.get()/(mix_rate*(float)OVERSAMPLE));
+	float lpf_c = expf(-Math::TAU * base->keep_hf_hz / (AudioServer::get_singleton()->get_mix_rate()));
 	float lpf_ic = 1.0 - lpf_c;
 
 	float drive_f = base->drive;

--- a/servers/audio/effects/audio_effect_phaser.cpp
+++ b/servers/audio/effects/audio_effect_phaser.cpp
@@ -37,13 +37,13 @@ void AudioEffectPhaserInstance::process(const AudioFrame *p_src_frames, AudioFra
 	float dmin = base->range_min / (sampling_rate / 2.0);
 	float dmax = base->range_max / (sampling_rate / 2.0);
 
-	float increment = Math_TAU * (base->rate / sampling_rate);
+	float increment = Math::TAU * (base->rate / sampling_rate);
 
 	for (int i = 0; i < p_frame_count; i++) {
 		phase += increment;
 
-		while (phase >= Math_TAU) {
-			phase -= Math_TAU;
+		while (phase >= Math::TAU) {
+			phase -= Math::TAU;
 		}
 
 		float d = dmin + (dmax - dmin) * ((sin(phase) + 1.f) / 2.f);

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -92,7 +92,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 	fftFrameSize2 = fftFrameSize/2;
 	stepSize = fftFrameSize/osamp;
 	freqPerBin = sampleRate/(double)fftFrameSize;
-	expct = 2.*Math_PI*(double)stepSize/(double)fftFrameSize;
+	expct = 2.*Math::PI*(double)stepSize/(double)fftFrameSize;
 	inFifoLatency = fftFrameSize-stepSize;
 	if (gRover == 0) { gRover = inFifoLatency;
 }
@@ -112,7 +112,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 
 			/* do windowing and re,im interleave */
 			for (k = 0; k < fftFrameSize;k++) {
-				window = -.5*cos(2.*Math_PI*(double)k/(double)fftFrameSize)+.5;
+				window = -.5*cos(2.*Math::PI*(double)k/(double)fftFrameSize)+.5;
 				gFFTworksp[2*k] = gInFIFO[k] * window;
 				gFFTworksp[2*k+1] = 0.;
 			}
@@ -140,14 +140,14 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 				tmp -= (double)k*expct;
 
 				/* map delta phase into +/- Pi interval */
-				qpd = tmp/Math_PI;
+				qpd = tmp/Math::PI;
 				if (qpd >= 0) { qpd += qpd&1;
 				} else { qpd -= qpd&1;
 }
-				tmp -= Math_PI*(double)qpd;
+				tmp -= Math::PI*(double)qpd;
 
 				/* get deviation from bin frequency from the +/- Pi interval */
-				tmp = osamp*tmp/(2.*Math_PI);
+				tmp = osamp*tmp/(2.*Math::PI);
 
 				/* compute the k-th partials' true frequency */
 				tmp = (double)k*freqPerBin + tmp*freqPerBin;
@@ -184,7 +184,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 				tmp /= freqPerBin;
 
 				/* take osamp into account */
-				tmp = 2.*Math_PI*tmp/osamp;
+				tmp = 2.*Math::PI*tmp/osamp;
 
 				/* add the overlap phase advance back in */
 				tmp += (double)k*expct;
@@ -207,7 +207,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 
 			/* do windowing and add to output accumulator */
 			for(k=0; k < fftFrameSize; k++) {
-				window = -.5*cos(2.*Math_PI*(double)k/(double)fftFrameSize)+.5;
+				window = -.5*cos(2.*Math::PI*(double)k/(double)fftFrameSize)+.5;
 				gOutputAccum[k] += 2.*window*gFFTworksp[2*k]/(fftFrameSize2*osamp);
 			}
 			for (k = 0; k < stepSize; k++) { gOutFIFO[k] = gOutputAccum[k];
@@ -260,7 +260,7 @@ void SMBPitchShift::smbFft(float *fftBuffer, long fftFrameSize, long sign)
 		le2 = le>>1;
 		ur = 1.0;
 		ui = 0.0;
-		arg = Math_PI / (le2>>1);
+		arg = Math::PI / (le2>>1);
 		wr = cos(arg);
 		wi = sign*sin(arg);
 		for (j = 0; j < le2; j += 2) {

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -71,7 +71,7 @@ static void smbFft(float *fftBuffer, long fftFrameSize, long sign)
 		le2 = le >> 1;
 		ur = 1.0;
 		ui = 0.0;
-		arg = Math_PI / (le2 >> 1);
+		arg = Math::PI / (le2 >> 1);
 		wr = cos(arg);
 		wi = sign * sin(arg);
 		for (j = 0; j < le2; j += 2) {
@@ -110,7 +110,7 @@ void AudioEffectSpectrumAnalyzerInstance::process(const AudioFrame *p_src_frames
 	while (p_frame_count) {
 		int to_fill = fft_size * 2 - temporal_fft_pos;
 		to_fill = MIN(to_fill, p_frame_count);
-		const double to_fill_step = Math_TAU / (double)fft_size;
+		const double to_fill_step = Math::TAU / (double)fft_size;
 
 		float *fftw = temporal_fft.ptrw();
 		for (int i = 0; i < to_fill; i++) { //left and right buffers

--- a/servers/audio/effects/eq_filter.cpp
+++ b/servers/audio/effects/eq_filter.cpp
@@ -88,9 +88,9 @@ void EQ::recalculate_band_coefficients() {
 
 		double frq_l = round(frq / pow(2.0, octave_size / 2.0));
 
-		double side_gain2 = POW2(Math_SQRT12);
-		double th = Math_TAU * frq / mix_rate;
-		double th_l = Math_TAU * frq_l / mix_rate;
+		double side_gain2 = POW2(Math::SQRT12);
+		double th = Math::TAU * frq / mix_rate;
+		double th_l = Math::TAU * frq_l / mix_rate;
 
 		double c2a = side_gain2 * POW2(cos(th)) - 2.0 * side_gain2 * cos(th_l) * cos(th) + side_gain2 - POW2(sin(th_l));
 

--- a/servers/audio/effects/reverb_filter.cpp
+++ b/servers/audio/effects/reverb_filter.cpp
@@ -90,7 +90,7 @@ void Reverb::process(float *p_src, float *p_dst, int p_frames) {
 	}
 
 	if (params.hpf > 0) {
-		float hpaux = expf(-Math_TAU * params.hpf * 6000 / params.mix_rate);
+		float hpaux = expf(-Math::TAU * params.hpf * 6000 / params.mix_rate);
 		float hp_a1 = (1.0 + hpaux) / 2.0;
 		float hp_a2 = -(1.0 + hpaux) / 2.0;
 		float hp_b1 = hpaux;
@@ -292,7 +292,7 @@ void Reverb::update_parameters() {
 		float auxdmp = params.damp / 2.0 + 0.5; //only half the range (0.5 .. 1.0 is enough)
 		auxdmp *= auxdmp;
 
-		c.damp = expf(-Math_TAU * auxdmp * 10000 / params.mix_rate); // 0 .. 10khz
+		c.damp = expf(-Math::TAU * auxdmp * 10000 / params.mix_rate); // 0 .. 10khz
 	}
 }
 

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1440,7 +1440,7 @@ void RendererCanvasCull::canvas_item_add_circle(RID p_item, const Point2 &p_pos,
 		// Store circle center in the last point.
 		points_ptr[circle_segments + 1] = p_pos;
 
-		const real_t circle_point_step = Math_TAU / circle_segments;
+		const real_t circle_point_step = Math::TAU / circle_segments;
 
 		for (int i = 0; i < circle_segments + 1; i++) {
 			float angle = i * circle_point_step;
@@ -1484,7 +1484,7 @@ void RendererCanvasCull::canvas_item_add_circle(RID p_item, const Point2 &p_pos,
 		points.resize(2 * circle_segments + 2);
 		colors.resize(2 * circle_segments + 2);
 
-		const real_t circle_point_step = Math_TAU / circle_segments;
+		const real_t circle_point_step = Math::TAU / circle_segments;
 
 		Vector2 *points_ptr = points.ptrw();
 		Color *colors_ptr = colors.ptrw();

--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -81,7 +81,7 @@ SSEffects::SSEffects() {
 				int b = spmap[subPass];
 
 				float ca, sa;
-				float angle0 = (float(a) + float(b) / float(sub_pass_count)) * Math_PI * 0.5f;
+				float angle0 = (float(a) + float(b) / float(sub_pass_count)) * Math::PI * 0.5f;
 
 				ca = Math::cos(angle0);
 				sa = Math::sin(angle0);
@@ -706,7 +706,7 @@ void SSEffects::screen_space_indirect_lighting(Ref<RenderSceneBuffersRD> p_rende
 			}
 		}
 		radius_near_limit /= tan_half_fov_y;
-		ssil.gather_push_constant.intensity = p_settings.intensity * Math_PI;
+		ssil.gather_push_constant.intensity = p_settings.intensity * Math::PI;
 		ssil.gather_push_constant.fade_out_mul = -1.0 / (ssil_fadeout_to - ssil_fadeout_from);
 		ssil.gather_push_constant.fade_out_add = ssil_fadeout_from / (ssil_fadeout_to - ssil_fadeout_from) + 1.0;
 		ssil.gather_push_constant.inv_radius_near_limit = 1.0f / radius_near_limit;
@@ -788,7 +788,7 @@ void SSEffects::screen_space_indirect_lighting(Ref<RenderSceneBuffersRD> p_rende
 			RD::get_singleton()->draw_command_begin_label("Generate Importance Map");
 			ssil.importance_map_push_constant.half_screen_pixel_size[0] = 1.0 / p_ssil_buffers.buffer_width;
 			ssil.importance_map_push_constant.half_screen_pixel_size[1] = 1.0 / p_ssil_buffers.buffer_height;
-			ssil.importance_map_push_constant.intensity = p_settings.intensity * Math_PI;
+			ssil.importance_map_push_constant.intensity = p_settings.intensity * Math::PI;
 
 			//base pass
 			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, ssil.pipelines[SSIL_GATHER_BASE]);

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -205,9 +205,9 @@ void Fog::init_fog_shader(uint32_t p_max_directional_lights, int p_roughness_lay
 		ShaderCompiler::DefaultIdentifierActions actions;
 
 		actions.renames["TIME"] = "scene_params.time";
-		actions.renames["PI"] = _MKSTR(Math_PI);
-		actions.renames["TAU"] = _MKSTR(Math_TAU);
-		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["PI"] = _MKSTR(Math::PI);
+		actions.renames["TAU"] = _MKSTR(Math::TAU);
+		actions.renames["E"] = _MKSTR(Math::E);
 		actions.renames["WORLD_POSITION"] = "world.xyz";
 		actions.renames["OBJECT_POSITION"] = "params.position";
 		actions.renames["UVW"] = "uvw";

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -1674,7 +1674,7 @@ void GI::SDFGI::debug_probes(RID p_framebuffer, const uint32_t p_view_count, con
 	push_constant.band_power = 4;
 	push_constant.sections_in_band = ((band_points / 2) - 1);
 	push_constant.band_mask = band_points - 2;
-	push_constant.section_arc = Math_TAU / float(push_constant.sections_in_band);
+	push_constant.section_arc = Math::TAU / float(push_constant.sections_in_band);
 	push_constant.y_mult = y_mult;
 
 	uint32_t total_points = push_constant.sections_in_band * band_points;
@@ -1977,11 +1977,11 @@ void GI::SDFGI::pre_process_gi(const Transform3D &p_transform, RenderDataRD *p_r
 
 				// Convert from Luminous Power to Luminous Intensity
 				if (lights[idx].type == RS::LIGHT_OMNI) {
-					lights[idx].energy *= 1.0 / (Math_PI * 4.0);
+					lights[idx].energy *= 1.0 / (Math::PI * 4.0);
 				} else if (lights[idx].type == RS::LIGHT_SPOT) {
 					// Spot Lights are not physically accurate, Luminous Intensity should change in relation to the cone angle.
 					// We make this assumption to keep them easy to control.
-					lights[idx].energy *= 1.0 / Math_PI;
+					lights[idx].energy *= 1.0 / Math::PI;
 				}
 			}
 
@@ -2440,11 +2440,11 @@ void GI::SDFGI::render_static_lights(RenderDataRD *p_render_data, Ref<RenderScen
 
 					// Convert from Luminous Power to Luminous Intensity
 					if (lights[idx].type == RS::LIGHT_OMNI) {
-						lights[idx].energy *= 1.0 / (Math_PI * 4.0);
+						lights[idx].energy *= 1.0 / (Math::PI * 4.0);
 					} else if (lights[idx].type == RS::LIGHT_SPOT) {
 						// Spot Lights are not physically accurate, Luminous Intensity should change in relation to the cone angle.
 						// We make this assumption to keep them easy to control.
-						lights[idx].energy *= 1.0 / Math_PI;
+						lights[idx].energy *= 1.0 / Math::PI;
 					}
 				}
 
@@ -2906,11 +2906,11 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 
 					// Convert from Luminous Power to Luminous Intensity
 					if (l.type == RS::LIGHT_OMNI) {
-						l.energy *= 1.0 / (Math_PI * 4.0);
+						l.energy *= 1.0 / (Math::PI * 4.0);
 					} else if (l.type == RS::LIGHT_SPOT) {
 						// Spot Lights are not physically accurate, Luminous Intensity should change in relation to the cone angle.
 						// We make this assumption to keep them easy to control.
-						l.energy *= 1.0 / Math_PI;
+						l.energy *= 1.0 / Math::PI;
 					}
 				}
 

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -783,9 +783,9 @@ void SkyRD::init() {
 		actions.renames["SCREEN_UV"] = "uv";
 		actions.renames["FRAGCOORD"] = "gl_FragCoord";
 		actions.renames["TIME"] = "params.time";
-		actions.renames["PI"] = _MKSTR(Math_PI);
-		actions.renames["TAU"] = _MKSTR(Math_TAU);
-		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["PI"] = _MKSTR(Math::PI);
+		actions.renames["TAU"] = _MKSTR(Math::TAU);
+		actions.renames["E"] = _MKSTR(Math::E);
 		actions.renames["HALF_RES_COLOR"] = "half_res_color";
 		actions.renames["QUARTER_RES_COLOR"] = "quarter_res_color";
 		actions.renames["RADIANCE"] = "radiance";

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -618,9 +618,9 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 
 		actions.renames["TIME"] = "global_time";
 		actions.renames["EXPOSURE"] = "(1.0 / scene_data_block.data.emissive_exposure_normalization)";
-		actions.renames["PI"] = _MKSTR(Math_PI);
-		actions.renames["TAU"] = _MKSTR(Math_TAU);
-		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["PI"] = _MKSTR(Math::PI);
+		actions.renames["TAU"] = _MKSTR(Math::TAU);
+		actions.renames["E"] = _MKSTR(Math::E);
 		actions.renames["OUTPUT_IS_SRGB"] = "SHADER_IS_SRGB";
 		actions.renames["CLIP_SPACE_FAR"] = "SHADER_SPACE_FAR";
 		actions.renames["VIEWPORT_SIZE"] = "read_viewport_size";

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -552,9 +552,9 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 
 		actions.renames["TIME"] = "scene_data_block.data.time";
 		actions.renames["EXPOSURE"] = "(1.0 / scene_data_block.data.emissive_exposure_normalization)";
-		actions.renames["PI"] = _MKSTR(Math_PI);
-		actions.renames["TAU"] = _MKSTR(Math_TAU);
-		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["PI"] = _MKSTR(Math::PI);
+		actions.renames["TAU"] = _MKSTR(Math::TAU);
+		actions.renames["E"] = _MKSTR(Math::E);
 		actions.renames["OUTPUT_IS_SRGB"] = "SHADER_IS_SRGB";
 		actions.renames["CLIP_SPACE_FAR"] = "SHADER_SPACE_FAR";
 		actions.renames["VIEWPORT_SIZE"] = "read_viewport_size";

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1773,9 +1773,9 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 		actions.renames["CANVAS_MATRIX"] = "canvas_data.canvas_transform";
 		actions.renames["SCREEN_MATRIX"] = "canvas_data.screen_transform";
 		actions.renames["TIME"] = "canvas_data.time";
-		actions.renames["PI"] = _MKSTR(Math_PI);
-		actions.renames["TAU"] = _MKSTR(Math_TAU);
-		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["PI"] = _MKSTR(Math::PI);
+		actions.renames["TAU"] = _MKSTR(Math::TAU);
+		actions.renames["E"] = _MKSTR(Math::E);
 		actions.renames["AT_LIGHT_PASS"] = "false";
 		actions.renames["INSTANCE_CUSTOM"] = "instance_custom";
 

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -643,7 +643,7 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 				if (RendererSceneRenderRD::get_singleton()->is_using_physical_light_units()) {
 					light_data.energy *= light->param[RS::LIGHT_PARAM_INTENSITY];
 				} else {
-					light_data.energy *= Math_PI;
+					light_data.energy *= Math::PI;
 				}
 
 				if (p_render_data->camera_attributes.is_valid()) {
@@ -866,14 +866,14 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 
 			// Convert from Luminous Power to Luminous Intensity
 			if (type == RS::LIGHT_OMNI) {
-				energy *= 1.0 / (Math_PI * 4.0);
+				energy *= 1.0 / (Math::PI * 4.0);
 			} else {
 				// Spot Lights are not physically accurate, Luminous Intensity should change in relation to the cone angle.
 				// We make this assumption to keep them easy to control.
-				energy *= 1.0 / Math_PI;
+				energy *= 1.0 / Math::PI;
 			}
 		} else {
-			energy *= Math_PI;
+			energy *= Math::PI;
 		}
 
 		if (p_render_data->camera_attributes.is_valid()) {

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -80,9 +80,9 @@ ParticlesStorage::ParticlesStorage() {
 		}
 		actions.renames["TRANSFORM"] = "PARTICLE.xform";
 		actions.renames["TIME"] = "frame_history.data[0].time";
-		actions.renames["PI"] = _MKSTR(Math_PI);
-		actions.renames["TAU"] = _MKSTR(Math_TAU);
-		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["PI"] = _MKSTR(Math::PI);
+		actions.renames["TAU"] = _MKSTR(Math::TAU);
+		actions.renames["E"] = _MKSTR(Math::E);
 		actions.renames["LIFETIME"] = "params.lifetime";
 		actions.renames["DELTA"] = "local_delta";
 		actions.renames["NUMBER"] = "particle_number";

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -240,15 +240,15 @@ RID RenderingServer::_make_test_cube() {
 RID RenderingServer::make_sphere_mesh(int p_lats, int p_lons, real_t p_radius) {
 	Vector<Vector3> vertices;
 	Vector<Vector3> normals;
-	const double lat_step = Math_TAU / p_lats;
-	const double lon_step = Math_TAU / p_lons;
+	const double lat_step = Math::TAU / p_lats;
+	const double lon_step = Math::TAU / p_lons;
 
 	for (int i = 1; i <= p_lats; i++) {
-		double lat0 = lat_step * (i - 1) - Math_TAU / 4;
+		double lat0 = lat_step * (i - 1) - Math::TAU / 4;
 		double z0 = Math::sin(lat0);
 		double zr0 = Math::cos(lat0);
 
-		double lat1 = lat_step * i - Math_TAU / 4;
+		double lat1 = lat_step * i - Math::TAU / 4;
 		double z1 = Math::sin(lat1);
 		double zr1 = Math::cos(lat1);
 
@@ -327,9 +327,9 @@ void _get_axis_angle(const Vector3 &p_normal, const Vector4 &p_tangent, float &r
 	r_angle = float(angle);
 
 	if (d < 0.0) {
-		r_angle = CLAMP((1.0 - r_angle / Math_PI) * 0.5, 0.0, 0.49999);
+		r_angle = CLAMP((1.0 - r_angle / Math::PI) * 0.5, 0.0, 0.49999);
 	} else {
-		r_angle = CLAMP((r_angle / Math_PI) * 0.5 + 0.5, 0.500008, 1.0);
+		r_angle = CLAMP((r_angle / Math::PI) * 0.5 + 0.5, 0.500008, 1.0);
 	}
 }
 
@@ -337,7 +337,7 @@ void _get_axis_angle(const Vector3 &p_normal, const Vector4 &p_tangent, float &r
 // and p_angle includes the binormal direction.
 void _get_tbn_from_axis_angle(const Vector3 &p_axis, float p_angle, Vector3 &r_normal, Vector4 &r_tangent) {
 	float binormal_sign = p_angle > 0.5 ? 1.0 : -1.0;
-	float angle = Math::abs(p_angle * 2.0 - 1.0) * Math_PI;
+	float angle = Math::abs(p_angle * 2.0 - 1.0) * Math::PI;
 
 	Basis tbn = Basis(p_axis, angle);
 	Vector3 tan = tbn.rows[0];

--- a/tests/core/math/test_aabb.h
+++ b/tests/core/math/test_aabb.h
@@ -461,7 +461,7 @@ TEST_CASE("[AABB] Expanding") {
 
 TEST_CASE("[AABB] Finite number checks") {
 	constexpr Vector3 x(0, 1, 2);
-	const Vector3 infinite(NAN, NAN, NAN);
+	constexpr Vector3 infinite(Math::NaN, Math::NaN, Math::NaN);
 
 	CHECK_MESSAGE(
 			AABB(x, x).is_finite(),

--- a/tests/core/math/test_astar.h
+++ b/tests/core/math/test_astar.h
@@ -280,7 +280,7 @@ TEST_CASE("[Stress][AStar3D] Find paths") {
 		float d[N][N];
 		for (int u = 0; u < N; u++) {
 			for (int v = 0; v < N; v++) {
-				d[u][v] = (u == v || adj[u][v]) ? p[u].distance_to(p[v]) : INFINITY;
+				d[u][v] = (u == v || adj[u][v]) ? p[u].distance_to(p[v]) : Math::INF;
 			}
 		}
 		for (int w = 0; w < N; w++) {

--- a/tests/core/math/test_basis.h
+++ b/tests/core/math/test_basis.h
@@ -38,11 +38,11 @@
 namespace TestBasis {
 
 Vector3 deg_to_rad(const Vector3 &p_rotation) {
-	return p_rotation / 180.0 * Math_PI;
+	return p_rotation / 180.0 * Math::PI;
 }
 
 Vector3 rad2deg(const Vector3 &p_rotation) {
-	return p_rotation / Math_PI * 180.0;
+	return p_rotation / Math::PI * 180.0;
 }
 
 String get_rot_order_name(EulerOrder ro) {
@@ -218,7 +218,7 @@ TEST_CASE("[Stress][Basis] Euler conversions") {
 TEST_CASE("[Basis] Set axis angle") {
 	Vector3 axis;
 	real_t angle;
-	real_t pi = (real_t)Math_PI;
+	real_t pi = (real_t)Math::PI;
 
 	// Testing the singularity when the angle is 0°.
 	Basis identity(1, 0, 0, 0, 1, 0, 0, 0, 1);
@@ -270,7 +270,7 @@ TEST_CASE("[Basis] Set axis angle") {
 
 TEST_CASE("[Basis] Finite number checks") {
 	constexpr Vector3 x(0, 1, 2);
-	const Vector3 infinite(NAN, NAN, NAN);
+	constexpr Vector3 infinite(Math::NaN, Math::NaN, Math::NaN);
 
 	CHECK_MESSAGE(
 			Basis(x, x, x).is_finite(),
@@ -327,7 +327,7 @@ TEST_CASE("[Basis] Is conformal checks") {
 			"Basis with non-uniform scale should not be conformal.");
 
 	CHECK_FALSE_MESSAGE(
-			Basis(Vector3(Math_SQRT12, Math_SQRT12, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)).is_conformal(),
+			Basis(Vector3(Math::SQRT12, Math::SQRT12, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)).is_conformal(),
 			"Basis with the X axis skewed 45 degrees should not be conformal.");
 
 	CHECK_MESSAGE(
@@ -357,7 +357,7 @@ TEST_CASE("[Basis] Is orthogonal checks") {
 			"Basis with a flip, rotation, and uniform scale should be orthogonal.");
 
 	CHECK_FALSE_MESSAGE(
-			Basis(Vector3(Math_SQRT12, Math_SQRT12, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)).is_orthogonal(),
+			Basis(Vector3(Math::SQRT12, Math::SQRT12, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)).is_orthogonal(),
 			"Basis with the X axis skewed 45 degrees should not be orthogonal.");
 
 	CHECK_MESSAGE(
@@ -387,7 +387,7 @@ TEST_CASE("[Basis] Is orthonormal checks") {
 			"Basis with a flip, rotation, and uniform scale should not be orthonormal.");
 
 	CHECK_FALSE_MESSAGE(
-			Basis(Vector3(Math_SQRT12, Math_SQRT12, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)).is_orthonormal(),
+			Basis(Vector3(Math::SQRT12, Math::SQRT12, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)).is_orthonormal(),
 			"Basis with the X axis skewed 45 degrees should not be orthonormal.");
 
 	CHECK_FALSE_MESSAGE(
@@ -417,7 +417,7 @@ TEST_CASE("[Basis] Is rotation checks") {
 			"Basis with a squeeze should not be a rotation.");
 
 	CHECK_FALSE_MESSAGE(
-			Basis(Vector3(Math_SQRT12, Math_SQRT12, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)).is_rotation(),
+			Basis(Vector3(Math::SQRT12, Math::SQRT12, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)).is_rotation(),
 			"Basis with the X axis skewed 45 degrees should not be a rotation.");
 
 	CHECK_FALSE_MESSAGE(

--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -53,8 +53,8 @@ TEST_CASE("[Math] C++ macros") {
 	CHECK(SIGN(-5) == -1.0);
 	CHECK(SIGN(0) == 0.0);
 	CHECK(SIGN(5) == 1.0);
-	// Check that SIGN(NAN) returns 0.0.
-	CHECK(SIGN(NAN) == 0.0);
+	// Check that SIGN(Math::NaN) returns 0.0.
+	CHECK(SIGN(Math::NaN) == 0.0);
 }
 
 TEST_CASE("[Math] Power of two functions") {
@@ -189,7 +189,7 @@ TEST_CASE_TEMPLATE("[Math] asin/acos/atan", T, float, double) {
 	CHECK(Math::acos((T)0.5) == doctest::Approx((T)1.0471975512));
 	CHECK(Math::acos((T)1.0) == doctest::Approx((T)0.0));
 	CHECK(Math::acos((T)2.0) == doctest::Approx((T)0.0));
-	CHECK(Math::acos((T)-2.0) == doctest::Approx((T)Math_PI));
+	CHECK(Math::acos((T)-2.0) == doctest::Approx((T)Math::PI));
 
 	CHECK(Math::atan((T)-0.1) == doctest::Approx((T)-0.0996686525));
 	CHECK(Math::atan((T)0.1) == doctest::Approx((T)0.0996686525));
@@ -291,10 +291,10 @@ TEST_CASE_TEMPLATE("[Math] pow/log/log2/exp/sqrt", T, float, double) {
 
 TEST_CASE_TEMPLATE("[Math] is_nan/is_inf", T, float, double) {
 	CHECK(!Math::is_nan((T)0.0));
-	CHECK(Math::is_nan((T)NAN));
+	CHECK(Math::is_nan((T)Math::NaN));
 
 	CHECK(!Math::is_inf((T)0.0));
-	CHECK(Math::is_inf((T)INFINITY));
+	CHECK(Math::is_inf((T)Math::INF));
 }
 
 TEST_CASE_TEMPLATE("[Math] linear_to_db", T, float, double) {
@@ -387,15 +387,15 @@ TEST_CASE_TEMPLATE("[Math] remap", T, float, double) {
 
 TEST_CASE_TEMPLATE("[Math] angle_difference", T, float, double) {
 	// Loops around, should return 0.0.
-	CHECK(Math::angle_difference((T)0.0, (T)Math_TAU) == doctest::Approx((T)0.0));
-	CHECK(Math::angle_difference((T)Math_PI, (T)-Math_PI) == doctest::Approx((T)0.0));
-	CHECK(Math::angle_difference((T)0.0, (T)Math_TAU * (T)4.0) == doctest::Approx((T)0.0));
+	CHECK(Math::angle_difference((T)0.0, (T)Math::TAU) == doctest::Approx((T)0.0));
+	CHECK(Math::angle_difference((T)Math::PI, (T)-Math::PI) == doctest::Approx((T)0.0));
+	CHECK(Math::angle_difference((T)0.0, (T)Math::TAU * (T)4.0) == doctest::Approx((T)0.0));
 
 	// Rotation is clockwise, so it should return -PI.
-	CHECK(Math::angle_difference((T)0.0, (T)Math_PI) == doctest::Approx((T)-Math_PI));
-	CHECK(Math::angle_difference((T)0.0, (T)-Math_PI) == doctest::Approx((T)Math_PI));
-	CHECK(Math::angle_difference((T)Math_PI, (T)0.0) == doctest::Approx((T)Math_PI));
-	CHECK(Math::angle_difference((T)-Math_PI, (T)0.0) == doctest::Approx((T)-Math_PI));
+	CHECK(Math::angle_difference((T)0.0, (T)Math::PI) == doctest::Approx((T)-Math::PI));
+	CHECK(Math::angle_difference((T)0.0, (T)-Math::PI) == doctest::Approx((T)Math::PI));
+	CHECK(Math::angle_difference((T)Math::PI, (T)0.0) == doctest::Approx((T)Math::PI));
+	CHECK(Math::angle_difference((T)-Math::PI, (T)0.0) == doctest::Approx((T)-Math::PI));
 
 	CHECK(Math::angle_difference((T)0.0, (T)3.0) == doctest::Approx((T)3.0));
 	CHECK(Math::angle_difference((T)1.0, (T)-2.0) == doctest::Approx((T)-3.0));
@@ -406,23 +406,23 @@ TEST_CASE_TEMPLATE("[Math] angle_difference", T, float, double) {
 
 TEST_CASE_TEMPLATE("[Math] lerp_angle", T, float, double) {
 	// Counter-clockwise rotation.
-	CHECK(Math::lerp_angle((T)0.24 * Math_TAU, 0.75 * Math_TAU, 0.5) == doctest::Approx((T)-0.005 * Math_TAU));
+	CHECK(Math::lerp_angle((T)0.24 * Math::TAU, 0.75 * Math::TAU, 0.5) == doctest::Approx((T)-0.005 * Math::TAU));
 	// Counter-clockwise rotation.
-	CHECK(Math::lerp_angle((T)0.25 * Math_TAU, 0.75 * Math_TAU, 0.5) == doctest::Approx((T)0.0));
+	CHECK(Math::lerp_angle((T)0.25 * Math::TAU, 0.75 * Math::TAU, 0.5) == doctest::Approx((T)0.0));
 	// Clockwise rotation.
-	CHECK(Math::lerp_angle((T)0.26 * Math_TAU, 0.75 * Math_TAU, 0.5) == doctest::Approx((T)0.505 * Math_TAU));
+	CHECK(Math::lerp_angle((T)0.26 * Math::TAU, 0.75 * Math::TAU, 0.5) == doctest::Approx((T)0.505 * Math::TAU));
 
-	CHECK(Math::lerp_angle((T)-0.25 * Math_TAU, 1.25 * Math_TAU, 0.5) == doctest::Approx((T)-0.5 * Math_TAU));
-	CHECK(Math::lerp_angle((T)0.72 * Math_TAU, 1.44 * Math_TAU, 0.96) == doctest::Approx((T)0.4512 * Math_TAU));
-	CHECK(Math::lerp_angle((T)0.72 * Math_TAU, 1.44 * Math_TAU, 1.04) == doctest::Approx((T)0.4288 * Math_TAU));
+	CHECK(Math::lerp_angle((T)-0.25 * Math::TAU, 1.25 * Math::TAU, 0.5) == doctest::Approx((T)-0.5 * Math::TAU));
+	CHECK(Math::lerp_angle((T)0.72 * Math::TAU, 1.44 * Math::TAU, 0.96) == doctest::Approx((T)0.4512 * Math::TAU));
+	CHECK(Math::lerp_angle((T)0.72 * Math::TAU, 1.44 * Math::TAU, 1.04) == doctest::Approx((T)0.4288 * Math::TAU));
 
 	// Initial and final angles are effectively identical, so the value returned
 	// should always be the same regardless of the `weight` parameter.
-	CHECK(Math::lerp_angle((T)-4 * Math_TAU, 4 * Math_TAU, -1.0) == doctest::Approx((T)-4.0 * Math_TAU));
-	CHECK(Math::lerp_angle((T)-4 * Math_TAU, 4 * Math_TAU, 0.0) == doctest::Approx((T)-4.0 * Math_TAU));
-	CHECK(Math::lerp_angle((T)-4 * Math_TAU, 4 * Math_TAU, 0.5) == doctest::Approx((T)-4.0 * Math_TAU));
-	CHECK(Math::lerp_angle((T)-4 * Math_TAU, 4 * Math_TAU, 1.0) == doctest::Approx((T)-4.0 * Math_TAU));
-	CHECK(Math::lerp_angle((T)-4 * Math_TAU, 4 * Math_TAU, 500.0) == doctest::Approx((T)-4.0 * Math_TAU));
+	CHECK(Math::lerp_angle((T)-4 * Math::TAU, 4 * Math::TAU, -1.0) == doctest::Approx((T)-4.0 * Math::TAU));
+	CHECK(Math::lerp_angle((T)-4 * Math::TAU, 4 * Math::TAU, 0.0) == doctest::Approx((T)-4.0 * Math::TAU));
+	CHECK(Math::lerp_angle((T)-4 * Math::TAU, 4 * Math::TAU, 0.5) == doctest::Approx((T)-4.0 * Math::TAU));
+	CHECK(Math::lerp_angle((T)-4 * Math::TAU, 4 * Math::TAU, 1.0) == doctest::Approx((T)-4.0 * Math::TAU));
+	CHECK(Math::lerp_angle((T)-4 * Math::TAU, 4 * Math::TAU, 500.0) == doctest::Approx((T)-4.0 * Math::TAU));
 }
 
 TEST_CASE_TEMPLATE("[Math] move_toward", T, float, double) {
@@ -436,16 +436,16 @@ TEST_CASE_TEMPLATE("[Math] move_toward", T, float, double) {
 
 TEST_CASE_TEMPLATE("[Math] rotate_toward", T, float, double) {
 	// Rotate toward.
-	CHECK(Math::rotate_toward((T)0.0, (T)Math_PI * (T)0.75, (T)1.5) == doctest::Approx((T)1.5));
+	CHECK(Math::rotate_toward((T)0.0, (T)Math::PI * (T)0.75, (T)1.5) == doctest::Approx((T)1.5));
 	CHECK(Math::rotate_toward((T)-2.0, (T)1.0, (T)2.5) == doctest::Approx((T)0.5));
-	CHECK(Math::rotate_toward((T)-2.0, (T)Math_PI, (T)Math_PI) == doctest::Approx((T)-Math_PI));
-	CHECK(Math::rotate_toward((T)1.0, (T)Math_PI, (T)20.0) == doctest::Approx((T)Math_PI));
+	CHECK(Math::rotate_toward((T)-2.0, (T)Math::PI, (T)Math::PI) == doctest::Approx((T)-Math::PI));
+	CHECK(Math::rotate_toward((T)1.0, (T)Math::PI, (T)20.0) == doctest::Approx((T)Math::PI));
 
 	// Rotate away.
 	CHECK(Math::rotate_toward((T)0.0, (T)0.0, (T)-1.5) == doctest::Approx((T)-1.5));
-	CHECK(Math::rotate_toward((T)0.0, (T)0.0, (T)-Math_PI) == doctest::Approx((T)-Math_PI));
-	CHECK(Math::rotate_toward((T)3.0, (T)Math_PI, (T)-Math_PI) == doctest::Approx((T)0.0));
-	CHECK(Math::rotate_toward((T)2.0, (T)Math_PI, (T)-1.5) == doctest::Approx((T)0.5));
+	CHECK(Math::rotate_toward((T)0.0, (T)0.0, (T)-Math::PI) == doctest::Approx((T)-Math::PI));
+	CHECK(Math::rotate_toward((T)3.0, (T)Math::PI, (T)-Math::PI) == doctest::Approx((T)0.0));
+	CHECK(Math::rotate_toward((T)2.0, (T)Math::PI, (T)-1.5) == doctest::Approx((T)0.5));
 	CHECK(Math::rotate_toward((T)1.0, (T)2.0, (T)-0.5) == doctest::Approx((T)0.5));
 	CHECK(Math::rotate_toward((T)2.5, (T)2.0, (T)-0.5) == doctest::Approx((T)3.0));
 	CHECK(Math::rotate_toward((T)-1.0, (T)1.0, (T)-1.0) == doctest::Approx((T)-2.0));
@@ -585,10 +585,10 @@ TEST_CASE_TEMPLATE("[Math] pingpong", T, float, double) {
 }
 
 TEST_CASE_TEMPLATE("[Math] deg_to_rad/rad_to_deg", T, float, double) {
-	CHECK(Math::deg_to_rad((T)180.0) == doctest::Approx((T)Math_PI));
+	CHECK(Math::deg_to_rad((T)180.0) == doctest::Approx((T)Math::PI));
 	CHECK(Math::deg_to_rad((T)-27.0) == doctest::Approx((T)-0.471239));
 
-	CHECK(Math::rad_to_deg((T)Math_PI) == doctest::Approx((T)180.0));
+	CHECK(Math::rad_to_deg((T)Math::PI) == doctest::Approx((T)180.0));
 	CHECK(Math::rad_to_deg((T)-1.5) == doctest::Approx((T)-85.94366927));
 }
 
@@ -607,11 +607,11 @@ TEST_CASE_TEMPLATE("[Math] cubic_interpolate", T, float, double) {
 }
 
 TEST_CASE_TEMPLATE("[Math] cubic_interpolate_angle", T, float, double) {
-	CHECK(Math::cubic_interpolate_angle((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.0) == doctest::Approx((T)Math_PI * (1.0 / 6.0)));
-	CHECK(Math::cubic_interpolate_angle((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.25) == doctest::Approx((T)0.973566));
-	CHECK(Math::cubic_interpolate_angle((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.5) == doctest::Approx((T)Math_PI / 2.0));
-	CHECK(Math::cubic_interpolate_angle((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.75) == doctest::Approx((T)2.16803));
-	CHECK(Math::cubic_interpolate_angle((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)1.0) == doctest::Approx((T)Math_PI * (5.0 / 6.0)));
+	CHECK(Math::cubic_interpolate_angle((T)(Math::PI * (1.0 / 6.0)), (T)(Math::PI * (5.0 / 6.0)), (T)0.0, (T)Math::PI, (T)0.0) == doctest::Approx((T)Math::PI * (1.0 / 6.0)));
+	CHECK(Math::cubic_interpolate_angle((T)(Math::PI * (1.0 / 6.0)), (T)(Math::PI * (5.0 / 6.0)), (T)0.0, (T)Math::PI, (T)0.25) == doctest::Approx((T)0.973566));
+	CHECK(Math::cubic_interpolate_angle((T)(Math::PI * (1.0 / 6.0)), (T)(Math::PI * (5.0 / 6.0)), (T)0.0, (T)Math::PI, (T)0.5) == doctest::Approx((T)Math::PI / 2.0));
+	CHECK(Math::cubic_interpolate_angle((T)(Math::PI * (1.0 / 6.0)), (T)(Math::PI * (5.0 / 6.0)), (T)0.0, (T)Math::PI, (T)0.75) == doctest::Approx((T)2.16803));
+	CHECK(Math::cubic_interpolate_angle((T)(Math::PI * (1.0 / 6.0)), (T)(Math::PI * (5.0 / 6.0)), (T)0.0, (T)Math::PI, (T)1.0) == doctest::Approx((T)Math::PI * (5.0 / 6.0)));
 }
 
 TEST_CASE_TEMPLATE("[Math] cubic_interpolate_in_time", T, float, double) {
@@ -623,11 +623,11 @@ TEST_CASE_TEMPLATE("[Math] cubic_interpolate_in_time", T, float, double) {
 }
 
 TEST_CASE_TEMPLATE("[Math] cubic_interpolate_angle_in_time", T, float, double) {
-	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.0, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.0));
-	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.25, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.494964));
-	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.5, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)1.27627));
-	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.75, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)2.07394));
-	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)1.0, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)Math_PI * (5.0 / 6.0)));
+	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math::PI * (1.0 / 6.0)), (T)(Math::PI * (5.0 / 6.0)), (T)0.0, (T)Math::PI, (T)0.0, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.0));
+	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math::PI * (1.0 / 6.0)), (T)(Math::PI * (5.0 / 6.0)), (T)0.0, (T)Math::PI, (T)0.25, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.494964));
+	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math::PI * (1.0 / 6.0)), (T)(Math::PI * (5.0 / 6.0)), (T)0.0, (T)Math::PI, (T)0.5, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)1.27627));
+	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math::PI * (1.0 / 6.0)), (T)(Math::PI * (5.0 / 6.0)), (T)0.0, (T)Math::PI, (T)0.75, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)2.07394));
+	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math::PI * (1.0 / 6.0)), (T)(Math::PI * (5.0 / 6.0)), (T)0.0, (T)Math::PI, (T)1.0, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)Math::PI * (5.0 / 6.0)));
 }
 
 TEST_CASE_TEMPLATE("[Math] bezier_interpolate", T, float, double) {

--- a/tests/core/math/test_plane.h
+++ b/tests/core/math/test_plane.h
@@ -169,9 +169,9 @@ TEST_CASE("[Plane] Intersection") {
 
 TEST_CASE("[Plane] Finite number checks") {
 	constexpr Vector3 x(0, 1, 2);
-	const Vector3 infinite_vec(NAN, NAN, NAN);
+	constexpr Vector3 infinite_vec(Math::NaN, Math::NaN, Math::NaN);
 	constexpr real_t y = 0;
-	const real_t infinite_y = NAN;
+	constexpr real_t infinite_y = Math::NaN;
 
 	CHECK_MESSAGE(
 			Plane(x, y).is_finite(),

--- a/tests/core/math/test_quaternion.h
+++ b/tests/core/math/test_quaternion.h
@@ -411,21 +411,21 @@ TEST_CASE("[Stress][Quaternion] Many vector xforms") {
 	// For each trial, check that rotation by Quaternion yields same result as
 	// rotation by Basis.
 	constexpr int STEPS = 100; // Number of test steps in each dimension
-	constexpr double delta = 2.0 * Math_PI / STEPS; // Angle increment per step
+	constexpr double delta = 2.0 * Math::PI / STEPS; // Angle increment per step
 	constexpr double delta_vec = 20.0 / STEPS; // Vector increment per step
 	Vector3 vec_arb(1.0, 1.0, 1.0);
-	double x_angle = -Math_PI;
-	double y_angle = -Math_PI;
-	double z_angle = -Math_PI;
+	double x_angle = -Math::PI;
+	double y_angle = -Math::PI;
+	double z_angle = -Math::PI;
 	for (double i = 0; i < STEPS; ++i) {
 		vec_arb[0] = -10.0 + i * delta_vec;
-		x_angle = i * delta - Math_PI;
+		x_angle = i * delta - Math::PI;
 		for (double j = 0; j < STEPS; ++j) {
 			vec_arb[1] = -10.0 + j * delta_vec;
-			y_angle = j * delta - Math_PI;
+			y_angle = j * delta - Math::PI;
 			for (double k = 0; k < STEPS; ++k) {
 				vec_arb[2] = -10.0 + k * delta_vec;
-				z_angle = k * delta - Math_PI;
+				z_angle = k * delta - Math::PI;
 				Vector3 euler_yzx(x_angle, y_angle, z_angle);
 				test_quat_vec_rotate(euler_yzx, vec_arb);
 			}
@@ -434,7 +434,7 @@ TEST_CASE("[Stress][Quaternion] Many vector xforms") {
 }
 
 TEST_CASE("[Quaternion] Finite number checks") {
-	const real_t x = NAN;
+	constexpr real_t x = Math::NaN;
 
 	CHECK_MESSAGE(
 			Quaternion(0, 1, 2, 3).is_finite(),

--- a/tests/core/math/test_rect2.h
+++ b/tests/core/math/test_rect2.h
@@ -323,8 +323,8 @@ TEST_CASE("[Rect2] Merging") {
 }
 
 TEST_CASE("[Rect2] Finite number checks") {
-	const Vector2 x(0, 1);
-	const Vector2 infinite(NAN, NAN);
+	constexpr Vector2 x(0, 1);
+	constexpr Vector2 infinite(Math::NaN, Math::NaN);
 
 	CHECK_MESSAGE(
 			Rect2(x, x).is_finite(),

--- a/tests/core/math/test_transform_2d.h
+++ b/tests/core/math/test_transform_2d.h
@@ -56,7 +56,7 @@ TEST_CASE("[Transform2D] Copy constructor") {
 }
 
 TEST_CASE("[Transform2D] Constructor from angle and position") {
-	constexpr float ROTATION = Math_PI / 4;
+	constexpr float ROTATION = Math::PI / 4;
 	constexpr Vector2 TRANSLATION = Vector2(20, -20);
 
 	const Transform2D test = Transform2D(ROTATION, TRANSLATION);
@@ -65,9 +65,9 @@ TEST_CASE("[Transform2D] Constructor from angle and position") {
 }
 
 TEST_CASE("[Transform2D] Constructor from angle, scale, skew and position") {
-	constexpr float ROTATION = Math_PI / 2;
+	constexpr float ROTATION = Math::PI / 2;
 	constexpr Vector2 SCALE = Vector2(2, 0.5);
-	constexpr float SKEW = Math_PI / 4;
+	constexpr float SKEW = Math::PI / 4;
 	constexpr Vector2 TRANSLATION = Vector2(30, 0);
 
 	const Transform2D test = Transform2D(ROTATION, SCALE, SKEW, TRANSLATION);
@@ -182,7 +182,7 @@ TEST_CASE("[Transform2D] Interpolation") {
 
 TEST_CASE("[Transform2D] Finite number checks") {
 	constexpr Vector2 x = Vector2(0, 1);
-	const Vector2 infinite = Vector2(NAN, NAN);
+	constexpr Vector2 infinite = Vector2(Math::NaN, Math::NaN);
 
 	CHECK_MESSAGE(
 			Transform2D(x, x, x).is_finite(),
@@ -239,7 +239,7 @@ TEST_CASE("[Transform2D] Is conformal checks") {
 			"Transform2D with non-uniform scale should not be conformal.");
 
 	CHECK_FALSE_MESSAGE(
-			Transform2D(Vector2(Math_SQRT12, Math_SQRT12), Vector2(0, 1), Vector2()).is_conformal(),
+			Transform2D(Vector2(Math::SQRT12, Math::SQRT12), Vector2(0, 1), Vector2()).is_conformal(),
 			"Transform2D with the X axis skewed 45 degrees should not be conformal.");
 }
 

--- a/tests/core/math/test_transform_3d.h
+++ b/tests/core/math/test_transform_3d.h
@@ -86,9 +86,9 @@ TEST_CASE("[Transform3D] rotation") {
 
 TEST_CASE("[Transform3D] Finite number checks") {
 	constexpr Vector3 y(0, 1, 2);
-	const Vector3 infinite_vec(NAN, NAN, NAN);
+	constexpr Vector3 infinite_vec(Math::NaN, Math::NaN, Math::NaN);
 	constexpr Basis x(y, y, y);
-	const Basis infinite_basis(infinite_vec, infinite_vec, infinite_vec);
+	constexpr Basis infinite_basis(infinite_vec, infinite_vec, infinite_vec);
 
 	CHECK_MESSAGE(
 			Transform3D(x, y).is_finite(),
@@ -117,7 +117,7 @@ TEST_CASE("[Transform3D] Rotate around global origin") {
 	expected.basis[0] = Vector3(-1, 0, 0);
 	expected.basis[2] = Vector3(0, 0, -1);
 
-	const Transform3D rotated_transform = transform.rotated(Vector3(0, 1, 0), Math_PI);
+	const Transform3D rotated_transform = transform.rotated(Vector3(0, 1, 0), Math::PI);
 	CHECK_MESSAGE(rotated_transform.is_equal_approx(expected), "The rotated transform should have a new orientation and basis.");
 }
 
@@ -132,7 +132,7 @@ TEST_CASE("[Transform3D] Rotate in-place (local rotation)") {
 	expected.basis[0] = Vector3(-1, 0, 0);
 	expected.basis[2] = Vector3(0, 0, -1);
 
-	const Transform3D rotated_transform = Transform3D(transform.rotated_local(Vector3(0, 1, 0), Math_PI));
+	const Transform3D rotated_transform = Transform3D(transform.rotated_local(Vector3(0, 1, 0), Math::PI));
 	CHECK_MESSAGE(rotated_transform.is_equal_approx(expected), "The rotated transform should have a new orientation but still be based on the same origin.");
 }
 } // namespace TestTransform3D

--- a/tests/core/math/test_vector2.h
+++ b/tests/core/math/test_vector2.h
@@ -48,16 +48,16 @@ TEST_CASE("[Vector2] Angle methods") {
 	constexpr Vector2 vector_x = Vector2(1, 0);
 	constexpr Vector2 vector_y = Vector2(0, 1);
 	CHECK_MESSAGE(
-			vector_x.angle_to(vector_y) == doctest::Approx((real_t)Math_TAU / 4),
+			vector_x.angle_to(vector_y) == doctest::Approx((real_t)Math::TAU / 4),
 			"Vector2 angle_to should work as expected.");
 	CHECK_MESSAGE(
-			vector_y.angle_to(vector_x) == doctest::Approx((real_t)-Math_TAU / 4),
+			vector_y.angle_to(vector_x) == doctest::Approx((real_t)-Math::TAU / 4),
 			"Vector2 angle_to should work as expected.");
 	CHECK_MESSAGE(
-			vector_x.angle_to_point(vector_y) == doctest::Approx((real_t)Math_TAU * 3 / 8),
+			vector_x.angle_to_point(vector_y) == doctest::Approx((real_t)Math::TAU * 3 / 8),
 			"Vector2 angle_to_point should work as expected.");
 	CHECK_MESSAGE(
-			vector_y.angle_to_point(vector_x) == doctest::Approx((real_t)-Math_TAU / 8),
+			vector_y.angle_to_point(vector_x) == doctest::Approx((real_t)-Math::TAU / 8),
 			"Vector2 angle_to_point should work as expected.");
 }
 
@@ -94,7 +94,7 @@ TEST_CASE("[Vector2] Interpolation methods") {
 			vector1.normalized().slerp(vector2.normalized(), 1.0 / 3.0).is_equal_approx(Vector2(0.508990883827209473, 0.860771894454956055)),
 			"Vector2 slerp should work as expected.");
 	CHECK_MESSAGE(
-			Vector2(5, 0).slerp(Vector2(0, 5), 0.5).is_equal_approx(Vector2(5, 5) * Math_SQRT12),
+			Vector2(5, 0).slerp(Vector2(0, 5), 0.5).is_equal_approx(Vector2(5, 5) * Math::SQRT12),
 			"Vector2 slerp with non-normalized values should work as expected.");
 	CHECK_MESSAGE(
 			Vector2(1, 1).slerp(Vector2(2, 2), 0.5).is_equal_approx(Vector2(1.5, 1.5)),
@@ -135,7 +135,7 @@ TEST_CASE("[Vector2] Length methods") {
 			vector1.length_squared() == 200,
 			"Vector2 length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			vector1.length() == doctest::Approx(10 * (real_t)Math_SQRT2),
+			vector1.length() == doctest::Approx(10 * (real_t)Math::SQRT2),
 			"Vector2 length should work as expected.");
 	CHECK_MESSAGE(
 			vector2.length_squared() == 1300,
@@ -154,10 +154,10 @@ TEST_CASE("[Vector2] Length methods") {
 TEST_CASE("[Vector2] Limiting methods") {
 	constexpr Vector2 vector = Vector2(10, 10);
 	CHECK_MESSAGE(
-			vector.limit_length().is_equal_approx(Vector2(Math_SQRT12, Math_SQRT12)),
+			vector.limit_length().is_equal_approx(Vector2(Math::SQRT12, Math::SQRT12)),
 			"Vector2 limit_length should work as expected.");
 	CHECK_MESSAGE(
-			vector.limit_length(5).is_equal_approx(5 * Vector2(Math_SQRT12, Math_SQRT12)),
+			vector.limit_length(5).is_equal_approx(5 * Vector2(Math::SQRT12, Math::SQRT12)),
 			"Vector2 limit_length should work as expected.");
 
 	CHECK_MESSAGE(
@@ -179,7 +179,7 @@ TEST_CASE("[Vector2] Normalization methods") {
 			Vector2(1, 0).normalized() == Vector2(1, 0),
 			"Vector2 normalized should return the same vector for a normalized vector.");
 	CHECK_MESSAGE(
-			Vector2(1, 1).normalized().is_equal_approx(Vector2(Math_SQRT12, Math_SQRT12)),
+			Vector2(1, 1).normalized().is_equal_approx(Vector2(Math::SQRT12, Math::SQRT12)),
 			"Vector2 normalized should work as expected.");
 
 	Vector2 vector = Vector2(3.2, -5.4);
@@ -281,11 +281,11 @@ TEST_CASE("[Vector2] Operators") {
 			"Vector2 cast to String should work as expected.");
 #ifdef REAL_T_IS_DOUBLE
 	CHECK_MESSAGE(
-			((String)Vector2(Math_PI, Math_TAU)) == "(3.14159265358979, 6.28318530717959)",
+			((String)Vector2(Math::PI, Math::TAU)) == "(3.14159265358979, 6.28318530717959)",
 			"Vector2 cast to String should print the correct amount of digits for real_t = double.");
 #else
 	CHECK_MESSAGE(
-			((String)Vector2(Math_PI, Math_TAU)) == "(3.141593, 6.283185)",
+			((String)Vector2(Math::PI, Math::TAU)) == "(3.141593, 6.283185)",
 			"Vector2 cast to String should print the correct amount of digits for real_t = float.");
 #endif // REAL_T_IS_DOUBLE
 }
@@ -300,7 +300,7 @@ TEST_CASE("[Vector2] Other methods") {
 			vector.direction_to(Vector2()).is_equal_approx(-vector.normalized()),
 			"Vector2 direction_to should work as expected.");
 	CHECK_MESSAGE(
-			Vector2(1, 1).direction_to(Vector2(2, 2)).is_equal_approx(Vector2(Math_SQRT12, Math_SQRT12)),
+			Vector2(1, 1).direction_to(Vector2(2, 2)).is_equal_approx(Vector2(Math::SQRT12, Math::SQRT12)),
 			"Vector2 direction_to should work as expected.");
 
 	CHECK_MESSAGE(
@@ -317,16 +317,16 @@ TEST_CASE("[Vector2] Other methods") {
 			"Vector2 posmodv should work as expected.");
 
 	CHECK_MESSAGE(
-			vector.rotated(Math_TAU).is_equal_approx(Vector2(1.2, 3.4)),
+			vector.rotated(Math::TAU).is_equal_approx(Vector2(1.2, 3.4)),
 			"Vector2 rotated should work as expected.");
 	CHECK_MESSAGE(
-			vector.rotated(Math_TAU / 4).is_equal_approx(Vector2(-3.4, 1.2)),
+			vector.rotated(Math::TAU / 4).is_equal_approx(Vector2(-3.4, 1.2)),
 			"Vector2 rotated should work as expected.");
 	CHECK_MESSAGE(
-			vector.rotated(Math_TAU / 3).is_equal_approx(Vector2(-3.544486372867091398996, -0.660769515458673623883)),
+			vector.rotated(Math::TAU / 3).is_equal_approx(Vector2(-3.544486372867091398996, -0.660769515458673623883)),
 			"Vector2 rotated should work as expected.");
 	CHECK_MESSAGE(
-			vector.rotated(Math_TAU / 2).is_equal_approx(vector.rotated(Math_TAU / -2)),
+			vector.rotated(Math::TAU / 2).is_equal_approx(vector.rotated(Math::TAU / -2)),
 			"Vector2 rotated should work as expected.");
 
 	CHECK_MESSAGE(
@@ -472,7 +472,7 @@ TEST_CASE("[Vector2] Linear algebra methods") {
 }
 
 TEST_CASE("[Vector2] Finite number checks") {
-	const double infinite[] = { NAN, INFINITY, -INFINITY };
+	constexpr double infinite[] = { Math::NaN, Math::INF, -Math::INF };
 
 	CHECK_MESSAGE(
 			Vector2(0, 1).is_finite(),

--- a/tests/core/math/test_vector2i.h
+++ b/tests/core/math/test_vector2i.h
@@ -78,7 +78,7 @@ TEST_CASE("[Vector2i] Length methods") {
 			vector1.length_squared() == 200,
 			"Vector2i length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			vector1.length() == doctest::Approx(10 * Math_SQRT2),
+			vector1.length() == doctest::Approx(10 * Math::SQRT2),
 			"Vector2i length should work as expected.");
 	CHECK_MESSAGE(
 			vector2.length_squared() == 1300,

--- a/tests/core/math/test_vector3.h
+++ b/tests/core/math/test_vector3.h
@@ -33,9 +33,6 @@
 #include "core/math/vector3.h"
 #include "tests/test_macros.h"
 
-#define Math_SQRT13 0.57735026918962576450914878050196
-#define Math_SQRT3 1.7320508075688772935274463415059
-
 namespace TestVector3 {
 
 TEST_CASE("[Vector3] Constructor methods") {
@@ -51,26 +48,26 @@ TEST_CASE("[Vector3] Angle methods") {
 	constexpr Vector3 vector_y = Vector3(0, 1, 0);
 	constexpr Vector3 vector_yz = Vector3(0, 1, 1);
 	CHECK_MESSAGE(
-			vector_x.angle_to(vector_y) == doctest::Approx((real_t)Math_TAU / 4),
+			vector_x.angle_to(vector_y) == doctest::Approx((real_t)Math::TAU / 4),
 			"Vector3 angle_to should work as expected.");
 	CHECK_MESSAGE(
-			vector_x.angle_to(vector_yz) == doctest::Approx((real_t)Math_TAU / 4),
+			vector_x.angle_to(vector_yz) == doctest::Approx((real_t)Math::TAU / 4),
 			"Vector3 angle_to should work as expected.");
 	CHECK_MESSAGE(
-			vector_yz.angle_to(vector_x) == doctest::Approx((real_t)Math_TAU / 4),
+			vector_yz.angle_to(vector_x) == doctest::Approx((real_t)Math::TAU / 4),
 			"Vector3 angle_to should work as expected.");
 	CHECK_MESSAGE(
-			vector_y.angle_to(vector_yz) == doctest::Approx((real_t)Math_TAU / 8),
+			vector_y.angle_to(vector_yz) == doctest::Approx((real_t)Math::TAU / 8),
 			"Vector3 angle_to should work as expected.");
 
 	CHECK_MESSAGE(
-			vector_x.signed_angle_to(vector_y, vector_y) == doctest::Approx((real_t)Math_TAU / 4),
+			vector_x.signed_angle_to(vector_y, vector_y) == doctest::Approx((real_t)Math::TAU / 4),
 			"Vector3 signed_angle_to edge case should be positive.");
 	CHECK_MESSAGE(
-			vector_x.signed_angle_to(vector_yz, vector_y) == doctest::Approx((real_t)Math_TAU / -4),
+			vector_x.signed_angle_to(vector_yz, vector_y) == doctest::Approx((real_t)Math::TAU / -4),
 			"Vector3 signed_angle_to should work as expected.");
 	CHECK_MESSAGE(
-			vector_yz.signed_angle_to(vector_x, vector_y) == doctest::Approx((real_t)Math_TAU / 4),
+			vector_yz.signed_angle_to(vector_x, vector_y) == doctest::Approx((real_t)Math::TAU / 4),
 			"Vector3 signed_angle_to should work as expected.");
 }
 
@@ -152,7 +149,7 @@ TEST_CASE("[Vector3] Length methods") {
 			vector1.length_squared() == 300,
 			"Vector3 length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			vector1.length() == doctest::Approx(10 * (real_t)Math_SQRT3),
+			vector1.length() == doctest::Approx(10 * (real_t)Math::SQRT3),
 			"Vector3 length should work as expected.");
 	CHECK_MESSAGE(
 			vector2.length_squared() == 2900,
@@ -171,10 +168,10 @@ TEST_CASE("[Vector3] Length methods") {
 TEST_CASE("[Vector3] Limiting methods") {
 	constexpr Vector3 vector = Vector3(10, 10, 10);
 	CHECK_MESSAGE(
-			vector.limit_length().is_equal_approx(Vector3(Math_SQRT13, Math_SQRT13, Math_SQRT13)),
+			vector.limit_length().is_equal_approx(Vector3(Math::SQRT13, Math::SQRT13, Math::SQRT13)),
 			"Vector3 limit_length should work as expected.");
 	CHECK_MESSAGE(
-			vector.limit_length(5).is_equal_approx(5 * Vector3(Math_SQRT13, Math_SQRT13, Math_SQRT13)),
+			vector.limit_length(5).is_equal_approx(5 * Vector3(Math::SQRT13, Math::SQRT13, Math::SQRT13)),
 			"Vector3 limit_length should work as expected.");
 
 	CHECK_MESSAGE(
@@ -196,10 +193,10 @@ TEST_CASE("[Vector3] Normalization methods") {
 			Vector3(1, 0, 0).normalized() == Vector3(1, 0, 0),
 			"Vector3 normalized should return the same vector for a normalized vector.");
 	CHECK_MESSAGE(
-			Vector3(1, 1, 0).normalized().is_equal_approx(Vector3(Math_SQRT12, Math_SQRT12, 0)),
+			Vector3(1, 1, 0).normalized().is_equal_approx(Vector3(Math::SQRT12, Math::SQRT12, 0)),
 			"Vector3 normalized should work as expected.");
 	CHECK_MESSAGE(
-			Vector3(1, 1, 1).normalized().is_equal_approx(Vector3(Math_SQRT13, Math_SQRT13, Math_SQRT13)),
+			Vector3(1, 1, 1).normalized().is_equal_approx(Vector3(Math::SQRT13, Math::SQRT13, Math::SQRT13)),
 			"Vector3 normalized should work as expected.");
 
 	Vector3 vector = Vector3(3.2, -5.4, 6);
@@ -301,11 +298,11 @@ TEST_CASE("[Vector3] Operators") {
 			"Vector3 cast to String should work as expected.");
 #ifdef REAL_T_IS_DOUBLE
 	CHECK_MESSAGE(
-			((String)Vector3(Math_E, Math_SQRT2, Math_SQRT3)) == "(2.71828182845905, 1.4142135623731, 1.73205080756888)",
+			((String)Vector3(Math::E, Math::SQRT2, Math::SQRT3)) == "(2.71828182845905, 1.4142135623731, 1.73205080756888)",
 			"Vector3 cast to String should print the correct amount of digits for real_t = double.");
 #else
 	CHECK_MESSAGE(
-			((String)Vector3(Math_E, Math_SQRT2, Math_SQRT3)) == "(2.718282, 1.414214, 1.732051)",
+			((String)Vector3(Math::E, Math::SQRT2, Math::SQRT3)) == "(2.718282, 1.414214, 1.732051)",
 			"Vector3 cast to String should print the correct amount of digits for real_t = float.");
 #endif // REAL_T_IS_DOUBLE
 }
@@ -316,7 +313,7 @@ TEST_CASE("[Vector3] Other methods") {
 			vector.direction_to(Vector3()).is_equal_approx(-vector.normalized()),
 			"Vector3 direction_to should work as expected.");
 	CHECK_MESSAGE(
-			Vector3(1, 1, 1).direction_to(Vector3(2, 2, 2)).is_equal_approx(Vector3(Math_SQRT13, Math_SQRT13, Math_SQRT13)),
+			Vector3(1, 1, 1).direction_to(Vector3(2, 2, 2)).is_equal_approx(Vector3(Math::SQRT13, Math::SQRT13, Math::SQRT13)),
 			"Vector3 direction_to should work as expected.");
 	CHECK_MESSAGE(
 			vector.inverse().is_equal_approx(Vector3(1 / 1.2, 1 / 3.4, 1 / 5.6)),
@@ -335,16 +332,16 @@ TEST_CASE("[Vector3] Other methods") {
 			"Vector3 posmodv should work as expected.");
 
 	CHECK_MESSAGE(
-			vector.rotated(Vector3(0, 1, 0), Math_TAU).is_equal_approx(vector),
+			vector.rotated(Vector3(0, 1, 0), Math::TAU).is_equal_approx(vector),
 			"Vector3 rotated should work as expected.");
 	CHECK_MESSAGE(
-			vector.rotated(Vector3(0, 1, 0), Math_TAU / 4).is_equal_approx(Vector3(5.6, 3.4, -1.2)),
+			vector.rotated(Vector3(0, 1, 0), Math::TAU / 4).is_equal_approx(Vector3(5.6, 3.4, -1.2)),
 			"Vector3 rotated should work as expected.");
 	CHECK_MESSAGE(
-			vector.rotated(Vector3(1, 0, 0), Math_TAU / 3).is_equal_approx(Vector3(1.2, -6.54974226119285642, 0.1444863728670914)),
+			vector.rotated(Vector3(1, 0, 0), Math::TAU / 3).is_equal_approx(Vector3(1.2, -6.54974226119285642, 0.1444863728670914)),
 			"Vector3 rotated should work as expected.");
 	CHECK_MESSAGE(
-			vector.rotated(Vector3(0, 0, 1), Math_TAU / 2).is_equal_approx(vector.rotated(Vector3(0, 0, 1), Math_TAU / -2)),
+			vector.rotated(Vector3(0, 0, 1), Math::TAU / 2).is_equal_approx(vector.rotated(Vector3(0, 0, 1), Math::TAU / -2)),
 			"Vector3 rotated should work as expected.");
 
 	CHECK_MESSAGE(
@@ -490,7 +487,7 @@ TEST_CASE("[Vector3] Linear algebra methods") {
 }
 
 TEST_CASE("[Vector3] Finite number checks") {
-	const double infinite[] = { NAN, INFINITY, -INFINITY };
+	constexpr double infinite[] = { Math::NaN, Math::INF, -Math::INF };
 
 	CHECK_MESSAGE(
 			Vector3(0, 1, 2).is_finite(),

--- a/tests/core/math/test_vector3i.h
+++ b/tests/core/math/test_vector3i.h
@@ -33,8 +33,6 @@
 #include "core/math/vector3i.h"
 #include "tests/test_macros.h"
 
-#define Math_SQRT3 1.7320508075688772935274463415059
-
 namespace TestVector3i {
 
 TEST_CASE("[Vector3i] Constructor methods") {
@@ -83,7 +81,7 @@ TEST_CASE("[Vector3i] Length methods") {
 			vector1.length_squared() == 300,
 			"Vector3i length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			vector1.length() == doctest::Approx(10 * Math_SQRT3),
+			vector1.length() == doctest::Approx(10 * Math::SQRT3),
 			"Vector3i length should work as expected.");
 	CHECK_MESSAGE(
 			vector2.length_squared() == 2900,

--- a/tests/core/math/test_vector4.h
+++ b/tests/core/math/test_vector4.h
@@ -33,8 +33,6 @@
 #include "core/math/vector4.h"
 #include "tests/test_macros.h"
 
-#define Math_SQRT3 1.7320508075688772935274463415059
-
 namespace TestVector4 {
 
 TEST_CASE("[Vector4] Constructor methods") {
@@ -127,7 +125,7 @@ TEST_CASE("[Vector4] Normalization methods") {
 			Vector4(1, 0, 0, 0).normalized() == Vector4(1, 0, 0, 0),
 			"Vector4 normalized should return the same vector for a normalized vector.");
 	CHECK_MESSAGE(
-			Vector4(1, 1, 0, 0).normalized().is_equal_approx(Vector4(Math_SQRT12, Math_SQRT12, 0, 0)),
+			Vector4(1, 1, 0, 0).normalized().is_equal_approx(Vector4(Math::SQRT12, Math::SQRT12, 0, 0)),
 			"Vector4 normalized should work as expected.");
 	CHECK_MESSAGE(
 			Vector4(1, 1, 1, 1).normalized().is_equal_approx(Vector4(0.5, 0.5, 0.5, 0.5)),
@@ -216,11 +214,11 @@ TEST_CASE("[Vector4] Operators") {
 			"Vector4 cast to String should work as expected.");
 #ifdef REAL_T_IS_DOUBLE
 	CHECK_MESSAGE(
-			((String)Vector4(Math_E, Math_SQRT2, Math_SQRT3, Math_SQRT3)) == "(2.71828182845905, 1.4142135623731, 1.73205080756888, 1.73205080756888)",
+			((String)Vector4(Math::E, Math::SQRT2, Math::SQRT3, Math::SQRT3)) == "(2.71828182845905, 1.4142135623731, 1.73205080756888, 1.73205080756888)",
 			"Vector4 cast to String should print the correct amount of digits for real_t = double.");
 #else
 	CHECK_MESSAGE(
-			((String)Vector4(Math_E, Math_SQRT2, Math_SQRT3, Math_SQRT3)) == "(2.718282, 1.414214, 1.732051, 1.732051)",
+			((String)Vector4(Math::E, Math::SQRT2, Math::SQRT3, Math::SQRT3)) == "(2.718282, 1.414214, 1.732051, 1.732051)",
 			"Vector4 cast to String should print the correct amount of digits for real_t = float.");
 #endif // REAL_T_IS_DOUBLE
 }
@@ -323,7 +321,7 @@ TEST_CASE("[Vector4] Linear algebra methods") {
 }
 
 TEST_CASE("[Vector4] Finite number checks") {
-	const double infinite[] = { NAN, INFINITY, -INFINITY };
+	constexpr double infinite[] = { Math::NaN, Math::INF, -Math::INF };
 
 	CHECK_MESSAGE(
 			Vector4(0, 1, 2, 3).is_finite(),

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -579,12 +579,12 @@ TEST_CASE("[String] Number to string") {
 #ifdef REAL_T_IS_DOUBLE
 	CHECK_MESSAGE(String::num_real(real_t(123.456789)) == "123.456789", "Prints the appropriate amount of digits for real_t = double.");
 	CHECK_MESSAGE(String::num_real(real_t(-123.456789)) == "-123.456789", "Prints the appropriate amount of digits for real_t = double.");
-	CHECK_MESSAGE(String::num_real(real_t(Math_PI)) == "3.14159265358979", "Prints the appropriate amount of digits for real_t = double.");
+	CHECK_MESSAGE(String::num_real(real_t(Math::PI)) == "3.14159265358979", "Prints the appropriate amount of digits for real_t = double.");
 	CHECK_MESSAGE(String::num_real(real_t(3.1415f)) == "3.1414999961853", "Prints more digits of 32-bit float when real_t = double (ones that would be reliable for double) and no trailing zero.");
 #else
 	CHECK_MESSAGE(String::num_real(real_t(123.456789)) == "123.4568", "Prints the appropriate amount of digits for real_t = float.");
 	CHECK_MESSAGE(String::num_real(real_t(-123.456789)) == "-123.4568", "Prints the appropriate amount of digits for real_t = float.");
-	CHECK_MESSAGE(String::num_real(real_t(Math_PI)) == "3.141593", "Prints the appropriate amount of digits for real_t = float.");
+	CHECK_MESSAGE(String::num_real(real_t(Math::PI)) == "3.141593", "Prints the appropriate amount of digits for real_t = float.");
 	CHECK_MESSAGE(String::num_real(real_t(3.1415f)) == "3.1415", "Prints only reliable digits of 32-bit float when real_t = float.");
 #endif // REAL_T_IS_DOUBLE
 
@@ -690,15 +690,15 @@ TEST_CASE("[String] String to float") {
 	CHECK(String("-1e308").to_float() == -1e308);
 
 	// Exponent is so high that value is INFINITY/-INFINITY.
-	CHECK(String("1e309").to_float() == INFINITY);
-	CHECK(String("1e511").to_float() == INFINITY);
-	CHECK(String("-1e309").to_float() == -INFINITY);
-	CHECK(String("-1e511").to_float() == -INFINITY);
+	CHECK(String("1e309").to_float() == Math::INF);
+	CHECK(String("1e511").to_float() == Math::INF);
+	CHECK(String("-1e309").to_float() == -Math::INF);
+	CHECK(String("-1e511").to_float() == -Math::INF);
 
 	// Exponent is so high that a warning message is printed. Value is INFINITY/-INFINITY.
 	ERR_PRINT_OFF
-	CHECK(String("1e512").to_float() == INFINITY);
-	CHECK(String("-1e512").to_float() == -INFINITY);
+	CHECK(String("1e512").to_float() == Math::INF);
+	CHECK(String("-1e512").to_float() == -Math::INF);
 	ERR_PRINT_ON
 }
 
@@ -1003,7 +1003,7 @@ TEST_CASE("[String] sprintf") {
 	// Real (infinity) left-padded
 	format = "fish %11f frog";
 	args.clear();
-	args.push_back(INFINITY);
+	args.push_back(Math::INF);
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish         inf frog"));
@@ -1127,7 +1127,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector left-padded with inf/nan
 	format = "fish %11v frog";
 	args.clear();
-	args.push_back(Variant(Vector2(INFINITY, NAN)));
+	args.push_back(Variant(Vector2(Math::INF, Math::NaN)));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (        inf,         nan) frog"));

--- a/tests/scene/test_audio_stream_wav.h
+++ b/tests/scene/test_audio_stream_wav.h
@@ -46,7 +46,7 @@ constexpr int WAV_COUNT = WAV_RATE;
 
 float gen_wav(float frequency, float wav_rate, int wav_number) {
 	// formula for generating a sin wave with given frequency.
-	return Math::sin((Math_TAU * frequency / wav_rate) * wav_number);
+	return Math::sin((Math::TAU * frequency / wav_rate) * wav_number);
 }
 
 /* Generates a 440Hz sin wave in channel 0 (mono channel or left stereo channel)

--- a/tests/scene/test_camera_2d.h
+++ b/tests/scene/test_camera_2d.h
@@ -285,7 +285,7 @@ TEST_CASE("[SceneTree][Camera2D] Transforms") {
 	}
 
 	SUBCASE("Rotation") {
-		test_camera->set_rotation(Math_PI / 2);
+		test_camera->set_rotation(Math::PI / 2);
 		Transform2D xform = mock_viewport->get_canvas_transform();
 		Transform2D test_xform = Transform2D(Vector2(1, 0), Vector2(0, 1), Vector2(200, 100));
 		CHECK(xform.is_equal_approx(test_xform));
@@ -295,7 +295,7 @@ TEST_CASE("[SceneTree][Camera2D] Transforms") {
 		test_xform = Transform2D(Vector2(0, -1), Vector2(1, 0), Vector2(200, 100));
 		CHECK(xform.is_equal_approx(test_xform));
 
-		test_camera->set_rotation(-1 * Math_PI);
+		test_camera->set_rotation(-1 * Math::PI);
 		test_camera->force_update_scroll();
 		xform = mock_viewport->get_canvas_transform();
 		test_xform = Transform2D(Vector2(-1, 0), Vector2(0, -1), Vector2(200, 100));

--- a/tests/scene/test_camera_3d.h
+++ b/tests/scene/test_camera_3d.h
@@ -36,9 +36,6 @@
 
 #include "tests/test_macros.h"
 
-// Constants.
-#define SQRT3 (1.7320508f)
-
 TEST_CASE("[SceneTree][Camera3D] Getters and setters") {
 	Camera3D *test_camera = memnew(Camera3D);
 
@@ -246,13 +243,13 @@ TEST_CASE("[SceneTree][Camera3D] Project/Unproject position") {
 			CHECK(test_camera->project_position(Vector2(200, 100), 100.0f).is_equal_approx(Vector3(0, 0, -100.0f)));
 			CHECK(test_camera->project_position(Vector2(200, 100), test_camera->get_far()).is_equal_approx(Vector3(0, 0, -1.0f) * test_camera->get_far()));
 			// 3/4th way to Top left.
-			CHECK(test_camera->project_position(Vector2(100, 50), 0.5f).is_equal_approx(Vector3(-SQRT3 * 0.5f, SQRT3 * 0.25f, -0.5f)));
-			CHECK(test_camera->project_position(Vector2(100, 50), 1.0f).is_equal_approx(Vector3(-SQRT3, SQRT3 * 0.5f, -1.0f)));
-			CHECK(test_camera->project_position(Vector2(100, 50), test_camera->get_near()).is_equal_approx(Vector3(-SQRT3, SQRT3 * 0.5f, -1.0f) * test_camera->get_near()));
+			CHECK(test_camera->project_position(Vector2(100, 50), 0.5f).is_equal_approx(Vector3(-Math::SQRT3 * 0.5f, Math::SQRT3 * 0.25f, -0.5f)));
+			CHECK(test_camera->project_position(Vector2(100, 50), 1.0f).is_equal_approx(Vector3(-Math::SQRT3, Math::SQRT3 * 0.5f, -1.0f)));
+			CHECK(test_camera->project_position(Vector2(100, 50), test_camera->get_near()).is_equal_approx(Vector3(-Math::SQRT3, Math::SQRT3 * 0.5f, -1.0f) * test_camera->get_near()));
 			// 3/4th way to Bottom right.
-			CHECK(test_camera->project_position(Vector2(300, 150), 0.5f).is_equal_approx(Vector3(SQRT3 * 0.5f, -SQRT3 * 0.25f, -0.5f)));
-			CHECK(test_camera->project_position(Vector2(300, 150), 1.0f).is_equal_approx(Vector3(SQRT3, -SQRT3 * 0.5f, -1.0f)));
-			CHECK(test_camera->project_position(Vector2(300, 150), test_camera->get_far()).is_equal_approx(Vector3(SQRT3, -SQRT3 * 0.5f, -1.0f) * test_camera->get_far()));
+			CHECK(test_camera->project_position(Vector2(300, 150), 0.5f).is_equal_approx(Vector3(Math::SQRT3 * 0.5f, -Math::SQRT3 * 0.25f, -0.5f)));
+			CHECK(test_camera->project_position(Vector2(300, 150), 1.0f).is_equal_approx(Vector3(Math::SQRT3, -Math::SQRT3 * 0.5f, -1.0f)));
+			CHECK(test_camera->project_position(Vector2(300, 150), test_camera->get_far()).is_equal_approx(Vector3(Math::SQRT3, -Math::SQRT3 * 0.5f, -1.0f) * test_camera->get_far()));
 		}
 	}
 
@@ -274,11 +271,11 @@ TEST_CASE("[SceneTree][Camera3D] Project/Unproject position") {
 			CHECK(test_camera->unproject_position(Vector3(0, 0, -0.5f)).is_equal_approx(Vector2(200, 100)));
 			CHECK(test_camera->unproject_position(Vector3(0, 0, -100.0f)).is_equal_approx(Vector2(200, 100)));
 			// 3/4th way to Top left.
-			WARN(test_camera->unproject_position(Vector3(-SQRT3 * 0.5f, SQRT3 * 0.25f, -0.5f)).is_equal_approx(Vector2(100, 50)));
-			WARN(test_camera->unproject_position(Vector3(-SQRT3, SQRT3 * 0.5f, -1.0f)).is_equal_approx(Vector2(100, 50)));
+			WARN(test_camera->unproject_position(Vector3(-Math::SQRT3 * 0.5f, Math::SQRT3 * 0.25f, -0.5f)).is_equal_approx(Vector2(100, 50)));
+			WARN(test_camera->unproject_position(Vector3(-Math::SQRT3, Math::SQRT3 * 0.5f, -1.0f)).is_equal_approx(Vector2(100, 50)));
 			// 3/4th way to Bottom right.
-			CHECK(test_camera->unproject_position(Vector3(SQRT3 * 0.5f, -SQRT3 * 0.25f, -0.5f)).is_equal_approx(Vector2(300, 150)));
-			CHECK(test_camera->unproject_position(Vector3(SQRT3, -SQRT3 * 0.5f, -1.0f)).is_equal_approx(Vector2(300, 150)));
+			CHECK(test_camera->unproject_position(Vector3(Math::SQRT3 * 0.5f, -Math::SQRT3 * 0.25f, -0.5f)).is_equal_approx(Vector2(300, 150)));
+			CHECK(test_camera->unproject_position(Vector3(Math::SQRT3, -Math::SQRT3 * 0.5f, -1.0f)).is_equal_approx(Vector2(300, 150)));
 		}
 	}
 
@@ -336,9 +333,9 @@ TEST_CASE("[SceneTree][Camera3D] Project ray") {
 			// Center.
 			CHECK(test_camera->project_ray_normal(Vector2(200, 100)).is_equal_approx(Vector3(0, 0, -1)));
 			// Top left.
-			CHECK(test_camera->project_ray_normal(Vector2(0, 0)).is_equal_approx(Vector3(-SQRT3, SQRT3 / 2, -0.5f).normalized()));
+			CHECK(test_camera->project_ray_normal(Vector2(0, 0)).is_equal_approx(Vector3(-Math::SQRT3, Math::SQRT3 / 2, -0.5f).normalized()));
 			// Bottom right.
-			CHECK(test_camera->project_ray_normal(Vector2(400, 200)).is_equal_approx(Vector3(SQRT3, -SQRT3 / 2, -0.5f).normalized()));
+			CHECK(test_camera->project_ray_normal(Vector2(400, 200)).is_equal_approx(Vector3(Math::SQRT3, -Math::SQRT3 / 2, -0.5f).normalized()));
 		}
 	}
 
@@ -360,14 +357,12 @@ TEST_CASE("[SceneTree][Camera3D] Project ray") {
 			// Center.
 			CHECK(test_camera->project_local_ray_normal(Vector2(200, 100)).is_equal_approx(Vector3(0, 0, -1)));
 			// Top left.
-			CHECK(test_camera->project_local_ray_normal(Vector2(0, 0)).is_equal_approx(Vector3(-SQRT3, SQRT3 / 2, -0.5f).normalized()));
+			CHECK(test_camera->project_local_ray_normal(Vector2(0, 0)).is_equal_approx(Vector3(-Math::SQRT3, Math::SQRT3 / 2, -0.5f).normalized()));
 			// Bottom right.
-			CHECK(test_camera->project_local_ray_normal(Vector2(400, 200)).is_equal_approx(Vector3(SQRT3, -SQRT3 / 2, -0.5f).normalized()));
+			CHECK(test_camera->project_local_ray_normal(Vector2(400, 200)).is_equal_approx(Vector3(Math::SQRT3, -Math::SQRT3 / 2, -0.5f).normalized()));
 		}
 	}
 
 	memdelete(test_camera);
 	memdelete(mock_viewport);
 }
-
-#undef SQRT3

--- a/tests/scene/test_control.h
+++ b/tests/scene/test_control.h
@@ -52,9 +52,9 @@ TEST_CASE("[SceneTree][Control] Transforms") {
 		CHECK_EQ(test_node->get_global_transform(), Transform2D(0, Size2(4, 4), 0, Vector2(2, 2)));
 		test_node->set_scale(Vector2(1, 1));
 		test_node->set_rotation_degrees(90);
-		CHECK_EQ(test_node->get_global_transform(), Transform2D(Math_PI / 2, Vector2(2, 2)));
+		CHECK_EQ(test_node->get_global_transform(), Transform2D(Math::PI / 2, Vector2(2, 2)));
 		test_node->set_pivot_offset(Vector2(1, 0));
-		CHECK_EQ(test_node->get_global_transform(), Transform2D(Math_PI / 2, Vector2(3, 1)));
+		CHECK_EQ(test_node->get_global_transform(), Transform2D(Math::PI / 2, Vector2(3, 1)));
 
 		memdelete(test_child);
 		memdelete(test_node);

--- a/tests/scene/test_texture_progress_bar.h
+++ b/tests/scene/test_texture_progress_bar.h
@@ -63,22 +63,22 @@ TEST_CASE("[SceneTree][TextureProgressBar]") {
 		texture_progress_bar->set_radial_initial_angle(30.5);
 
 		ERR_PRINT_OFF;
-		texture_progress_bar->set_radial_initial_angle(INFINITY);
+		texture_progress_bar->set_radial_initial_angle(Math::INF);
 		ERR_PRINT_ON;
 		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)30.5));
 
 		ERR_PRINT_OFF;
-		texture_progress_bar->set_radial_initial_angle(-INFINITY);
+		texture_progress_bar->set_radial_initial_angle(-Math::INF);
 		ERR_PRINT_ON;
 		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)30.5));
 
 		ERR_PRINT_OFF;
-		texture_progress_bar->set_radial_initial_angle(NAN);
+		texture_progress_bar->set_radial_initial_angle(Math::NaN);
 		ERR_PRINT_ON;
 		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)30.5));
 
 		ERR_PRINT_OFF;
-		texture_progress_bar->set_radial_initial_angle(-NAN);
+		texture_progress_bar->set_radial_initial_angle(-Math::NaN);
 		ERR_PRINT_ON;
 		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)30.5));
 	}

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -1774,7 +1774,7 @@ TEST_CASE("[SceneTree][Viewport] Physics Picking 2D") {
 
 	SUBCASE("[Viewport][Picking2D] CollisionObject in CanvasLayer") {
 		CanvasLayer *node_c = memnew(CanvasLayer);
-		node_c->set_rotation(Math_PI);
+		node_c->set_rotation(Math::PI);
 		node_c->set_offset(Point2i(100, 100));
 		root->add_child(node_c);
 


### PR DESCRIPTION
- Supersedes #90499

Now that `Math` is a namespace, this reimplements the above additions of `Math_INF` and `Math_NAN` as `Math::INF` and `Math::NaN`[^1], as well as all the other `Math_` macros being ported to the namespace. By implementing these as namespaced `constexpr` variables instead of macros, we're able to both declutter the global namespace & resolve these expressions in compile-time contexts. This additionally adds `SQRT3` and `SQRT13` to the lineup, which already saw use in the repo but were originally defined across multiple files instead of pulling from a single source.

[^1]: Can't use `Math::NAN` because `NAN` is a macro that can be reasonably expected to always exist