### PR TITLE
Add Physics query parameters RID include filters for Point, Ray and Shape queries

### DIFF
--- a/doc/classes/PhysicsPointQueryParameters2D.xml
+++ b/doc/classes/PhysicsPointQueryParameters2D.xml
@@ -26,6 +26,10 @@
 			The list of object [RID]s that will be excluded from collisions. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node.
 			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then assign it to the property again.
 		</member>
+		<member name="include" type="RID[]" setter="set_include" getter="get_include" default="[]">
+			The list of object [RID]s that will be included by the query. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node. If left empty all objects are included. If an object ends up being both included and excluded at the same time it will be excluded.
+			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then assign it to the property again.
+		</member>
 		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
 			The position being queried for, in global coordinates.
 		</member>

--- a/doc/classes/PhysicsPointQueryParameters3D.xml
+++ b/doc/classes/PhysicsPointQueryParameters3D.xml
@@ -22,6 +22,10 @@
 			The list of object [RID]s that will be excluded from collisions. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
 			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then assign it to the property again.
 		</member>
+		<member name="include" type="RID[]" setter="set_include" getter="get_include" default="[]">
+			The list of object [RID]s that will be included by the query. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node. If left empty all objects are included. If an object ends up being both included and excluded at the same time it will be excluded.
+			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then assign it to the property again.
+		</member>
 		<member name="position" type="Vector3" setter="set_position" getter="get_position" default="Vector3(0, 0, 0)">
 			The position being queried for, in global coordinates.
 		</member>

--- a/doc/classes/PhysicsRayQueryParameters2D.xml
+++ b/doc/classes/PhysicsRayQueryParameters2D.xml
@@ -44,6 +44,10 @@
 		<member name="hit_from_inside" type="bool" setter="set_hit_from_inside" getter="is_hit_from_inside_enabled" default="false">
 			If [code]true[/code], the query will detect a hit when starting inside shapes. In this case the collision normal will be [code]Vector2(0, 0)[/code]. Does not affect concave polygon shapes.
 		</member>
+		<member name="include" type="RID[]" setter="set_include" getter="get_include" default="[]">
+			The list of object [RID]s that will be included by the query. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node. If left empty all objects are included. If an object ends up being both included and excluded at the same time it will be excluded.
+			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then assign it to the property again.
+		</member>
 		<member name="to" type="Vector2" setter="set_to" getter="get_to" default="Vector2(0, 0)">
 			The ending point of the ray being queried for, in global coordinates.
 		</member>

--- a/doc/classes/PhysicsRayQueryParameters3D.xml
+++ b/doc/classes/PhysicsRayQueryParameters3D.xml
@@ -47,6 +47,10 @@
 		<member name="hit_from_inside" type="bool" setter="set_hit_from_inside" getter="is_hit_from_inside_enabled" default="false">
 			If [code]true[/code], the query will detect a hit when starting inside shapes. In this case the collision normal will be [code]Vector3(0, 0, 0)[/code]. Does not affect concave polygon shapes or heightmap shapes.
 		</member>
+		<member name="include" type="RID[]" setter="set_include" getter="get_include" default="[]">
+			The list of object [RID]s that will be included by the query. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node. If left empty all objects are included. If an object ends up being both included and excluded at the same time it will be excluded.
+			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then assign it to the property again.
+		</member>
 		<member name="to" type="Vector3" setter="set_to" getter="get_to" default="Vector3(0, 0, 0)">
 			The ending point of the ray being queried for, in global coordinates.
 		</member>

--- a/doc/classes/PhysicsShapeQueryParameters2D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters2D.xml
@@ -22,6 +22,10 @@
 			The list of object [RID]s that will be excluded from collisions. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node.
 			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then assign it to the property again.
 		</member>
+		<member name="include" type="RID[]" setter="set_include" getter="get_include" default="[]">
+			The list of object [RID]s that will be included by the query. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node. If left empty all objects are included. If an object ends up being both included and excluded at the same time it will be excluded.
+			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then assign it to the property again.
+		</member>
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.0">
 			The collision margin for the shape.
 		</member>

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -22,6 +22,10 @@
 			The list of object [RID]s that will be excluded from collisions. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
 			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then assign it to the property again.
 		</member>
+		<member name="include" type="RID[]" setter="set_include" getter="get_include" default="[]">
+			The list of object [RID]s that will be included by the query. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node. If left empty all objects are included. If an object ends up being both included and excluded at the same time it will be excluded.
+			[b]Note:[/b] The returned array is copied and any changes to it will not update the original property value. To update the value you need to modify the returned array, and then assign it to the property again.
+		</member>
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.0">
 			The collision margin for the shape.
 		</member>

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -69,12 +69,18 @@ int GodotPhysicsDirectSpaceState2D::intersect_point(const PointParameters &p_par
 
 	int cc = 0;
 
+	const bool include_filter_enabled = !p_parameters.include.is_empty();
+
 	for (int i = 0; i < amount; i++) {
 		if (!_can_collide_with(space->intersection_query_results[i], p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas)) {
 			continue;
 		}
 
 		if (p_parameters.exclude.has(space->intersection_query_results[i]->get_self())) {
+			continue;
+		}
+
+		if (include_filter_enabled && !p_parameters.include.has(space->intersection_query_results[i]->get_self())) {
 			continue;
 		}
 
@@ -134,12 +140,18 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parame
 	const GodotCollisionObject2D *res_obj = nullptr;
 	real_t min_d = 1e10;
 
+	const bool include_filter_enabled = !p_parameters.include.is_empty();
+
 	for (int i = 0; i < amount; i++) {
 		if (!_can_collide_with(space->intersection_query_results[i], p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas)) {
 			continue;
 		}
 
 		if (p_parameters.exclude.has(space->intersection_query_results[i]->get_self())) {
+			continue;
+		}
+
+		if (include_filter_enabled && !p_parameters.include.has(space->intersection_query_results[i]->get_self())) {
 			continue;
 		}
 
@@ -221,6 +233,8 @@ int GodotPhysicsDirectSpaceState2D::intersect_shape(const ShapeParameters &p_par
 
 	int cc = 0;
 
+	const bool include_filter_enabled = !p_parameters.include.is_empty();
+
 	for (int i = 0; i < amount; i++) {
 		if (cc >= p_result_max) {
 			break;
@@ -231,6 +245,10 @@ int GodotPhysicsDirectSpaceState2D::intersect_shape(const ShapeParameters &p_par
 		}
 
 		if (p_parameters.exclude.has(space->intersection_query_results[i]->get_self())) {
+			continue;
+		}
+
+		if (include_filter_enabled && !p_parameters.include.has(space->intersection_query_results[i]->get_self())) {
 			continue;
 		}
 
@@ -267,6 +285,8 @@ bool GodotPhysicsDirectSpaceState2D::cast_motion(const ShapeParameters &p_parame
 	real_t best_safe = 1;
 	real_t best_unsafe = 1;
 
+	const bool include_filter_enabled = !p_parameters.include.is_empty();
+
 	for (int i = 0; i < amount; i++) {
 		if (!_can_collide_with(space->intersection_query_results[i], p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas)) {
 			continue;
@@ -274,6 +294,10 @@ bool GodotPhysicsDirectSpaceState2D::cast_motion(const ShapeParameters &p_parame
 
 		if (p_parameters.exclude.has(space->intersection_query_results[i]->get_self())) {
 			continue; //ignore excluded
+		}
+
+		if (include_filter_enabled && !p_parameters.include.has(space->intersection_query_results[i]->get_self())) {
+			continue;
 		}
 
 		const GodotCollisionObject2D *col_obj = space->intersection_query_results[i];

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -65,6 +65,8 @@ int GodotPhysicsDirectSpaceState3D::intersect_point(const PointParameters &p_par
 	int amount = space->broadphase->cull_point(p_parameters.position, space->intersection_query_results, GodotSpace3D::INTERSECTION_QUERY_MAX, space->intersection_query_subindex_results);
 	int cc = 0;
 
+	const bool include_filter_enabled = !p_parameters.include.is_empty();
+
 	//Transform3D ai = p_xform.affine_inverse();
 
 	for (int i = 0; i < amount; i++) {
@@ -79,6 +81,10 @@ int GodotPhysicsDirectSpaceState3D::intersect_point(const PointParameters &p_par
 		//area can't be picked by ray (default)
 
 		if (p_parameters.exclude.has(space->intersection_query_results[i]->get_self())) {
+			continue;
+		}
+
+		if (include_filter_enabled && !p_parameters.include.has(space->intersection_query_results[i]->get_self())) {
 			continue;
 		}
 
@@ -127,6 +133,8 @@ bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parame
 	const GodotCollisionObject3D *res_obj = nullptr;
 	real_t min_d = 1e10;
 
+	const bool include_filter_enabled = !p_parameters.include.is_empty();
+
 	for (int i = 0; i < amount; i++) {
 		if (!_can_collide_with(space->intersection_query_results[i], p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas)) {
 			continue;
@@ -137,6 +145,10 @@ bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parame
 		}
 
 		if (p_parameters.exclude.has(space->intersection_query_results[i]->get_self())) {
+			continue;
+		}
+
+		if (include_filter_enabled && !p_parameters.include.has(space->intersection_query_results[i]->get_self())) {
 			continue;
 		}
 
@@ -221,6 +233,7 @@ int GodotPhysicsDirectSpaceState3D::intersect_shape(const ShapeParameters &p_par
 
 	int cc = 0;
 
+	const bool include_filter_enabled = !p_parameters.include.is_empty();
 	//Transform3D ai = p_xform.affine_inverse();
 
 	for (int i = 0; i < amount; i++) {
@@ -235,6 +248,10 @@ int GodotPhysicsDirectSpaceState3D::intersect_shape(const ShapeParameters &p_par
 		//area can't be picked by ray (default)
 
 		if (p_parameters.exclude.has(space->intersection_query_results[i]->get_self())) {
+			continue;
+		}
+
+		if (include_filter_enabled && !p_parameters.include.has(space->intersection_query_results[i]->get_self())) {
 			continue;
 		}
 
@@ -286,6 +303,8 @@ bool GodotPhysicsDirectSpaceState3D::cast_motion(const ShapeParameters &p_parame
 
 	Vector3 closest_A, closest_B;
 
+	const bool include_filter_enabled = !p_parameters.include.is_empty();
+
 	for (int i = 0; i < amount; i++) {
 		if (!_can_collide_with(space->intersection_query_results[i], p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas)) {
 			continue;
@@ -293,6 +312,10 @@ bool GodotPhysicsDirectSpaceState3D::cast_motion(const ShapeParameters &p_parame
 
 		if (p_parameters.exclude.has(space->intersection_query_results[i]->get_self())) {
 			continue; //ignore excluded
+		}
+
+		if (include_filter_enabled && !p_parameters.include.has(space->intersection_query_results[i]->get_self())) {
+			continue;
 		}
 
 		const GodotCollisionObject3D *col_obj = space->intersection_query_results[i];

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -176,6 +176,23 @@ TypedArray<RID> PhysicsRayQueryParameters2D::get_exclude() const {
 	return ret;
 }
 
+void PhysicsRayQueryParameters2D::set_include(const TypedArray<RID> &p_include) {
+	parameters.include.clear();
+	for (int i = 0; i < p_include.size(); i++) {
+		parameters.include.insert(p_include[i]);
+	}
+}
+
+TypedArray<RID> PhysicsRayQueryParameters2D::get_include() const {
+	TypedArray<RID> ret;
+	ret.resize(parameters.include.size());
+	int idx = 0;
+	for (const RID &E : parameters.include) {
+		ret[idx++] = E;
+	}
+	return ret;
+}
+
 void PhysicsRayQueryParameters2D::_bind_methods() {
 	ClassDB::bind_static_method("PhysicsRayQueryParameters2D", D_METHOD("create", "from", "to", "collision_mask", "exclude"), &PhysicsRayQueryParameters2D::create, DEFVAL(UINT32_MAX), DEFVAL(TypedArray<RID>()));
 
@@ -191,6 +208,9 @@ void PhysicsRayQueryParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_exclude", "exclude"), &PhysicsRayQueryParameters2D::set_exclude);
 	ClassDB::bind_method(D_METHOD("get_exclude"), &PhysicsRayQueryParameters2D::get_exclude);
 
+	ClassDB::bind_method(D_METHOD("set_include", "include"), &PhysicsRayQueryParameters2D::set_include);
+	ClassDB::bind_method(D_METHOD("get_include"), &PhysicsRayQueryParameters2D::get_include);
+
 	ClassDB::bind_method(D_METHOD("set_collide_with_bodies", "enable"), &PhysicsRayQueryParameters2D::set_collide_with_bodies);
 	ClassDB::bind_method(D_METHOD("is_collide_with_bodies_enabled"), &PhysicsRayQueryParameters2D::is_collide_with_bodies_enabled);
 
@@ -204,6 +224,7 @@ void PhysicsRayQueryParameters2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "to"), "set_to", "get_to");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_exclude", "get_exclude");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "include", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_include", "get_include");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies"), "set_collide_with_bodies", "is_collide_with_bodies_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas"), "set_collide_with_areas", "is_collide_with_areas_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hit_from_inside"), "set_hit_from_inside", "is_hit_from_inside_enabled");
@@ -228,6 +249,23 @@ TypedArray<RID> PhysicsPointQueryParameters2D::get_exclude() const {
 	return ret;
 }
 
+void PhysicsPointQueryParameters2D::set_include(const TypedArray<RID> &p_include) {
+	parameters.include.clear();
+	for (int i = 0; i < p_include.size(); i++) {
+		parameters.include.insert(p_include[i]);
+	}
+}
+
+TypedArray<RID> PhysicsPointQueryParameters2D::get_include() const {
+	TypedArray<RID> ret;
+	ret.resize(parameters.include.size());
+	int idx = 0;
+	for (const RID &E : parameters.include) {
+		ret[idx++] = E;
+	}
+	return ret;
+}
+
 void PhysicsPointQueryParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_position", "position"), &PhysicsPointQueryParameters2D::set_position);
 	ClassDB::bind_method(D_METHOD("get_position"), &PhysicsPointQueryParameters2D::get_position);
@@ -241,6 +279,9 @@ void PhysicsPointQueryParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_exclude", "exclude"), &PhysicsPointQueryParameters2D::set_exclude);
 	ClassDB::bind_method(D_METHOD("get_exclude"), &PhysicsPointQueryParameters2D::get_exclude);
 
+	ClassDB::bind_method(D_METHOD("set_include", "include"), &PhysicsPointQueryParameters2D::set_include);
+	ClassDB::bind_method(D_METHOD("get_include"), &PhysicsPointQueryParameters2D::get_include);
+
 	ClassDB::bind_method(D_METHOD("set_collide_with_bodies", "enable"), &PhysicsPointQueryParameters2D::set_collide_with_bodies);
 	ClassDB::bind_method(D_METHOD("is_collide_with_bodies_enabled"), &PhysicsPointQueryParameters2D::is_collide_with_bodies_enabled);
 
@@ -251,6 +292,7 @@ void PhysicsPointQueryParameters2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "canvas_instance_id", PROPERTY_HINT_OBJECT_ID), "set_canvas_instance_id", "get_canvas_instance_id");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_exclude", "get_exclude");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "include", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_include", "get_include");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies"), "set_collide_with_bodies", "is_collide_with_bodies_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas"), "set_collide_with_areas", "is_collide_with_areas_enabled");
 }
@@ -287,6 +329,23 @@ TypedArray<RID> PhysicsShapeQueryParameters2D::get_exclude() const {
 	return ret;
 }
 
+void PhysicsShapeQueryParameters2D::set_include(const TypedArray<RID> &p_include) {
+	parameters.include.clear();
+	for (int i = 0; i < p_include.size(); i++) {
+		parameters.include.insert(p_include[i]);
+	}
+}
+
+TypedArray<RID> PhysicsShapeQueryParameters2D::get_include() const {
+	TypedArray<RID> ret;
+	ret.resize(parameters.include.size());
+	int idx = 0;
+	for (const RID &E : parameters.include) {
+		ret[idx++] = E;
+	}
+	return ret;
+}
+
 void PhysicsShapeQueryParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &PhysicsShapeQueryParameters2D::set_shape);
 	ClassDB::bind_method(D_METHOD("get_shape"), &PhysicsShapeQueryParameters2D::get_shape);
@@ -309,6 +368,9 @@ void PhysicsShapeQueryParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_exclude", "exclude"), &PhysicsShapeQueryParameters2D::set_exclude);
 	ClassDB::bind_method(D_METHOD("get_exclude"), &PhysicsShapeQueryParameters2D::get_exclude);
 
+	ClassDB::bind_method(D_METHOD("set_include", "include"), &PhysicsShapeQueryParameters2D::set_include);
+	ClassDB::bind_method(D_METHOD("get_include"), &PhysicsShapeQueryParameters2D::get_include);
+
 	ClassDB::bind_method(D_METHOD("set_collide_with_bodies", "enable"), &PhysicsShapeQueryParameters2D::set_collide_with_bodies);
 	ClassDB::bind_method(D_METHOD("is_collide_with_bodies_enabled"), &PhysicsShapeQueryParameters2D::is_collide_with_bodies_enabled);
 
@@ -317,6 +379,7 @@ void PhysicsShapeQueryParameters2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_exclude", "get_exclude");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "include", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_include", "get_include");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_margin", "get_margin");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "motion"), "set_motion", "get_motion");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D"), "set_shape", "get_shape");

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -133,6 +133,7 @@ public:
 		Vector2 from;
 		Vector2 to;
 		HashSet<RID> exclude;
+		HashSet<RID> include;
 		uint32_t collision_mask = UINT32_MAX;
 
 		bool collide_with_bodies = true;
@@ -163,6 +164,7 @@ public:
 		Vector2 position;
 		ObjectID canvas_instance_id;
 		HashSet<RID> exclude;
+		HashSet<RID> include;
 		uint32_t collision_mask = UINT32_MAX;
 
 		bool collide_with_bodies = true;
@@ -179,6 +181,7 @@ public:
 		Vector2 motion;
 		real_t margin = 0.0;
 		HashSet<RID> exclude;
+		HashSet<RID> include;
 		uint32_t collision_mask = UINT32_MAX;
 
 		bool collide_with_bodies = true;
@@ -646,6 +649,9 @@ public:
 
 	void set_exclude(const TypedArray<RID> &p_exclude);
 	TypedArray<RID> get_exclude() const;
+
+	void set_include(const TypedArray<RID> &p_include);
+	TypedArray<RID> get_include() const;
 };
 
 class PhysicsPointQueryParameters2D : public RefCounted {
@@ -676,6 +682,9 @@ public:
 
 	void set_exclude(const TypedArray<RID> &p_exclude);
 	TypedArray<RID> get_exclude() const;
+
+	void set_include(const TypedArray<RID> &p_include);
+	TypedArray<RID> get_include() const;
 };
 
 class PhysicsShapeQueryParameters2D : public RefCounted {
@@ -717,6 +726,9 @@ public:
 
 	void set_exclude(const TypedArray<RID> &p_exclude);
 	TypedArray<RID> get_exclude() const;
+
+	void set_include(const TypedArray<RID> &p_include);
+	TypedArray<RID> get_include() const;
 };
 
 class PhysicsTestMotionParameters2D : public RefCounted {

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -192,6 +192,23 @@ TypedArray<RID> PhysicsRayQueryParameters3D::get_exclude() const {
 	return ret;
 }
 
+void PhysicsRayQueryParameters3D::set_include(const TypedArray<RID> &p_include) {
+	parameters.include.clear();
+	for (int i = 0; i < p_include.size(); i++) {
+		parameters.include.insert(p_include[i]);
+	}
+}
+
+TypedArray<RID> PhysicsRayQueryParameters3D::get_include() const {
+	TypedArray<RID> ret;
+	ret.resize(parameters.include.size());
+	int idx = 0;
+	for (const RID &E : parameters.include) {
+		ret[idx++] = E;
+	}
+	return ret;
+}
+
 void PhysicsRayQueryParameters3D::_bind_methods() {
 	ClassDB::bind_static_method("PhysicsRayQueryParameters3D", D_METHOD("create", "from", "to", "collision_mask", "exclude"), &PhysicsRayQueryParameters3D::create, DEFVAL(UINT32_MAX), DEFVAL(TypedArray<RID>()));
 
@@ -206,6 +223,9 @@ void PhysicsRayQueryParameters3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_exclude", "exclude"), &PhysicsRayQueryParameters3D::set_exclude);
 	ClassDB::bind_method(D_METHOD("get_exclude"), &PhysicsRayQueryParameters3D::get_exclude);
+
+	ClassDB::bind_method(D_METHOD("set_include", "include"), &PhysicsRayQueryParameters3D::set_include);
+	ClassDB::bind_method(D_METHOD("get_include"), &PhysicsRayQueryParameters3D::get_include);
 
 	ClassDB::bind_method(D_METHOD("set_collide_with_bodies", "enable"), &PhysicsRayQueryParameters3D::set_collide_with_bodies);
 	ClassDB::bind_method(D_METHOD("is_collide_with_bodies_enabled"), &PhysicsRayQueryParameters3D::is_collide_with_bodies_enabled);
@@ -223,6 +243,7 @@ void PhysicsRayQueryParameters3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "to"), "set_to", "get_to");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_exclude", "get_exclude");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "include", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_include", "get_include");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies"), "set_collide_with_bodies", "is_collide_with_bodies_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas"), "set_collide_with_areas", "is_collide_with_areas_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hit_from_inside"), "set_hit_from_inside", "is_hit_from_inside_enabled");
@@ -258,6 +279,23 @@ TypedArray<RID> PhysicsPointQueryParameters3D::get_exclude() const {
 	return ret;
 }
 
+void PhysicsPointQueryParameters3D::set_include(const TypedArray<RID> &p_include) {
+	parameters.include.clear();
+	for (int i = 0; i < p_include.size(); i++) {
+		parameters.include.insert(p_include[i]);
+	}
+}
+
+TypedArray<RID> PhysicsPointQueryParameters3D::get_include() const {
+	TypedArray<RID> ret;
+	ret.resize(parameters.include.size());
+	int idx = 0;
+	for (const RID &E : parameters.include) {
+		ret[idx++] = E;
+	}
+	return ret;
+}
+
 void PhysicsPointQueryParameters3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_position", "position"), &PhysicsPointQueryParameters3D::set_position);
 	ClassDB::bind_method(D_METHOD("get_position"), &PhysicsPointQueryParameters3D::get_position);
@@ -268,6 +306,9 @@ void PhysicsPointQueryParameters3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_exclude", "exclude"), &PhysicsPointQueryParameters3D::set_exclude);
 	ClassDB::bind_method(D_METHOD("get_exclude"), &PhysicsPointQueryParameters3D::get_exclude);
 
+	ClassDB::bind_method(D_METHOD("set_include", "include"), &PhysicsPointQueryParameters3D::set_include);
+	ClassDB::bind_method(D_METHOD("get_include"), &PhysicsPointQueryParameters3D::get_include);
+
 	ClassDB::bind_method(D_METHOD("set_collide_with_bodies", "enable"), &PhysicsPointQueryParameters3D::set_collide_with_bodies);
 	ClassDB::bind_method(D_METHOD("is_collide_with_bodies_enabled"), &PhysicsPointQueryParameters3D::is_collide_with_bodies_enabled);
 
@@ -277,6 +318,7 @@ void PhysicsPointQueryParameters3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "position"), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_exclude", "get_exclude");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "include", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_include", "get_include");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies"), "set_collide_with_bodies", "is_collide_with_bodies_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas"), "set_collide_with_areas", "is_collide_with_areas_enabled");
 }
@@ -313,6 +355,23 @@ TypedArray<RID> PhysicsShapeQueryParameters3D::get_exclude() const {
 	return ret;
 }
 
+void PhysicsShapeQueryParameters3D::set_include(const TypedArray<RID> &p_include) {
+	parameters.include.clear();
+	for (int i = 0; i < p_include.size(); i++) {
+		parameters.include.insert(p_include[i]);
+	}
+}
+
+TypedArray<RID> PhysicsShapeQueryParameters3D::get_include() const {
+	TypedArray<RID> ret;
+	ret.resize(parameters.include.size());
+	int idx = 0;
+	for (const RID &E : parameters.include) {
+		ret[idx++] = E;
+	}
+	return ret;
+}
+
 void PhysicsShapeQueryParameters3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &PhysicsShapeQueryParameters3D::set_shape);
 	ClassDB::bind_method(D_METHOD("get_shape"), &PhysicsShapeQueryParameters3D::get_shape);
@@ -335,6 +394,9 @@ void PhysicsShapeQueryParameters3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_exclude", "exclude"), &PhysicsShapeQueryParameters3D::set_exclude);
 	ClassDB::bind_method(D_METHOD("get_exclude"), &PhysicsShapeQueryParameters3D::get_exclude);
 
+	ClassDB::bind_method(D_METHOD("set_include", "include"), &PhysicsShapeQueryParameters3D::set_include);
+	ClassDB::bind_method(D_METHOD("get_include"), &PhysicsShapeQueryParameters3D::get_include);
+
 	ClassDB::bind_method(D_METHOD("set_collide_with_bodies", "enable"), &PhysicsShapeQueryParameters3D::set_collide_with_bodies);
 	ClassDB::bind_method(D_METHOD("is_collide_with_bodies_enabled"), &PhysicsShapeQueryParameters3D::is_collide_with_bodies_enabled);
 
@@ -343,6 +405,7 @@ void PhysicsShapeQueryParameters3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_exclude", "get_exclude");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "include", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_include", "get_include");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_margin", "get_margin");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "motion"), "set_motion", "get_motion");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape3D"), "set_shape", "get_shape");

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -137,6 +137,7 @@ public:
 		Vector3 from;
 		Vector3 to;
 		HashSet<RID> exclude;
+		HashSet<RID> include;
 		uint32_t collision_mask = UINT32_MAX;
 
 		bool collide_with_bodies = true;
@@ -170,6 +171,7 @@ public:
 	struct PointParameters {
 		Vector3 position;
 		HashSet<RID> exclude;
+		HashSet<RID> include;
 		uint32_t collision_mask = UINT32_MAX;
 
 		bool collide_with_bodies = true;
@@ -184,6 +186,7 @@ public:
 		Vector3 motion;
 		real_t margin = 0.0;
 		HashSet<RID> exclude;
+		HashSet<RID> include;
 		uint32_t collision_mask = UINT32_MAX;
 
 		bool collide_with_bodies = true;
@@ -850,6 +853,9 @@ public:
 
 	void set_exclude(const TypedArray<RID> &p_exclude);
 	TypedArray<RID> get_exclude() const;
+
+	void set_include(const TypedArray<RID> &p_include);
+	TypedArray<RID> get_include() const;
 };
 
 class PhysicsPointQueryParameters3D : public RefCounted {
@@ -877,6 +883,9 @@ public:
 
 	void set_exclude(const TypedArray<RID> &p_exclude);
 	TypedArray<RID> get_exclude() const;
+
+	void set_include(const TypedArray<RID> &p_include);
+	TypedArray<RID> get_include() const;
 };
 
 class PhysicsShapeQueryParameters3D : public RefCounted {
@@ -918,6 +927,9 @@ public:
 
 	void set_exclude(const TypedArray<RID> &p_exclude);
 	TypedArray<RID> get_exclude() const;
+
+	void set_include(const TypedArray<RID> &p_include);
+	TypedArray<RID> get_include() const;
 };
 
 class PhysicsTestMotionParameters3D : public RefCounted {


### PR DESCRIPTION
Adds Physics query parameters RID `include` filters for `Point`, `Ray` and `Shape` queries.

Same as the existing parameter `exclude` filter but reverse.
If left empty all objects are included as before.
If at least one RID is included all other RIDs are ignored in the query.
If an object RID ends up being both in the `include` and `exclude` list at the same time it will be excluded.

Left out the motion tests on purpose as they dont share the same pattern as the ray, point and shape tests.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
