### PR TITLE
Replace NavigationServer2D `Point` struct with `Vector2`

### DIFF
--- a/modules/navigation_2d/2d/nav_mesh_queries_2d.cpp
+++ b/modules/navigation_2d/2d/nav_mesh_queries_2d.cpp
@@ -90,8 +90,8 @@ Vector2 NavMeshQueries2D::polygons_get_random_point(const LocalVector<Polygon> &
 		real_t accumulated_polygon_area = 0;
 		RBMap<real_t, uint32_t> polygon_area_map;
 
-		for (uint32_t rpp_index = 2; rpp_index < rr_polygon.points.size(); rpp_index++) {
-			real_t triangle_area = Triangle2(rr_polygon.points[0].pos, rr_polygon.points[rpp_index - 1].pos, rr_polygon.points[rpp_index].pos).get_area();
+		for (uint32_t rpp_index = 2; rpp_index < rr_polygon.vertices.size(); rpp_index++) {
+			real_t triangle_area = Triangle2(rr_polygon.vertices[0], rr_polygon.vertices[rpp_index - 1], rr_polygon.vertices[rpp_index]).get_area();
 
 			if (triangle_area == 0.0) {
 				continue;
@@ -109,9 +109,9 @@ Vector2 NavMeshQueries2D::polygons_get_random_point(const LocalVector<Polygon> &
 		RBMap<real_t, uint32_t>::Iterator polygon_E = polygon_area_map.find_closest(polygon_area_map_pos);
 		ERR_FAIL_COND_V(!polygon_E, Vector2());
 		uint32_t rrp_face_index = polygon_E->value;
-		ERR_FAIL_UNSIGNED_INDEX_V(rrp_face_index, rr_polygon.points.size(), Vector2());
+		ERR_FAIL_UNSIGNED_INDEX_V(rrp_face_index, rr_polygon.vertices.size(), Vector2());
 
-		const Triangle2 triangle(rr_polygon.points[0].pos, rr_polygon.points[rrp_face_index - 1].pos, rr_polygon.points[rrp_face_index].pos);
+		const Triangle2 triangle(rr_polygon.vertices[0], rr_polygon.vertices[rrp_face_index - 1], rr_polygon.vertices[rrp_face_index]);
 
 		Vector2 triangle_random_position = triangle.get_random_point_inside();
 		return triangle_random_position;
@@ -121,9 +121,9 @@ Vector2 NavMeshQueries2D::polygons_get_random_point(const LocalVector<Polygon> &
 
 		const Polygon &rr_polygon = region_polygons[rrp_polygon_index];
 
-		uint32_t rrp_face_index = Math::random(int(2), rr_polygon.points.size() - 1);
+		uint32_t rrp_face_index = Math::random(int(2), rr_polygon.vertices.size() - 1);
 
-		const Triangle2 triangle(rr_polygon.points[0].pos, rr_polygon.points[rrp_face_index - 1].pos, rr_polygon.points[rrp_face_index].pos);
+		const Triangle2 triangle(rr_polygon.vertices[0], rr_polygon.vertices[rrp_face_index - 1], rr_polygon.vertices[rrp_face_index]);
 
 		Vector2 triangle_random_position = triangle.get_random_point_inside();
 		return triangle_random_position;
@@ -256,8 +256,8 @@ void NavMeshQueries2D::_query_task_find_start_end_positions(NavMeshPathQueryTask
 			}
 
 			// For each triangle check the distance between the origin/destination.
-			for (uint32_t point_id = 2; point_id < p.points.size(); point_id++) {
-				const Triangle2 triangle(p.points[0].pos, p.points[point_id - 1].pos, p.points[point_id].pos);
+			for (uint32_t point_id = 2; point_id < p.vertices.size(); point_id++) {
+				const Triangle2 triangle(p.vertices[0], p.vertices[point_id - 1], p.vertices[point_id]);
 
 				Vector2 point = triangle.get_closest_point_to(p_query_task.start_position);
 				real_t distance_to_point = point.distance_to(p_query_task.start_position);
@@ -371,8 +371,8 @@ void NavMeshQueries2D::_query_task_build_path_corridor(NavMeshPathQueryTask2D &p
 			// Set as end point the furthest reachable point.
 			end_poly = reachable_end;
 			real_t end_d = FLT_MAX;
-			for (uint32_t point_id = 2; point_id < end_poly->points.size(); point_id++) {
-				Triangle2 t(end_poly->points[0].pos, end_poly->points[point_id - 1].pos, end_poly->points[point_id].pos);
+			for (uint32_t point_id = 2; point_id < end_poly->vertices.size(); point_id++) {
+				Triangle2 t(end_poly->vertices[0], end_poly->vertices[point_id - 1], end_poly->vertices[point_id]);
 				Vector2 spoint = t.get_closest_point_to(p_target_position);
 				real_t dpoint = spoint.distance_squared_to(p_target_position);
 				if (dpoint < end_d) {
@@ -383,8 +383,8 @@ void NavMeshQueries2D::_query_task_build_path_corridor(NavMeshPathQueryTask2D &p
 
 			// Search all faces of start polygon as well.
 			bool closest_point_on_start_poly = false;
-			for (uint32_t point_id = 2; point_id < begin_poly->points.size(); point_id++) {
-				Triangle2 t(begin_poly->points[0].pos, begin_poly->points[point_id - 1].pos, begin_poly->points[point_id].pos);
+			for (uint32_t point_id = 2; point_id < begin_poly->vertices.size(); point_id++) {
+				Triangle2 t(begin_poly->vertices[0], begin_poly->vertices[point_id - 1], begin_poly->vertices[point_id]);
 				Vector2 spoint = t.get_closest_point_to(p_target_position);
 				real_t dpoint = spoint.distance_squared_to(p_target_position);
 				if (dpoint < end_d) {
@@ -442,8 +442,8 @@ void NavMeshQueries2D::_query_task_build_path_corridor(NavMeshPathQueryTask2D &p
 	if (!found_route) {
 		real_t end_d = FLT_MAX;
 		// Search all faces of the start polygon for the closest point to our target position.
-		for (uint32_t point_id = 2; point_id < begin_poly->points.size(); point_id++) {
-			Triangle2 t(begin_poly->points[0].pos, begin_poly->points[point_id - 1].pos, begin_poly->points[point_id].pos);
+		for (uint32_t point_id = 2; point_id < begin_poly->vertices.size(); point_id++) {
+			Triangle2 t(begin_poly->vertices[0], begin_poly->vertices[point_id - 1], begin_poly->vertices[point_id]);
 			Vector2 spoint = t.get_closest_point_to(p_target_position);
 			real_t dpoint = spoint.distance_squared_to(p_target_position);
 			if (dpoint < end_d) {
@@ -682,8 +682,8 @@ void NavMeshQueries2D::_query_task_post_process_edgecentered(NavMeshPathQueryTas
 	while (np_id != -1 && navigation_polys[np_id].back_navigation_poly_id != -1) {
 		if (navigation_polys[np_id].back_navigation_edge != -1) {
 			int prev = navigation_polys[np_id].back_navigation_edge;
-			int prev_n = (navigation_polys[np_id].back_navigation_edge + 1) % navigation_polys[np_id].poly->points.size();
-			Vector2 point = (navigation_polys[np_id].poly->points[prev].pos + navigation_polys[np_id].poly->points[prev_n].pos) * 0.5;
+			int prev_n = (navigation_polys[np_id].back_navigation_edge + 1) % navigation_polys[np_id].poly->vertices.size();
+			Vector2 point = (navigation_polys[np_id].poly->vertices[prev] + navigation_polys[np_id].poly->vertices[prev_n]) * 0.5;
 
 			_query_task_push_back_point_with_metadata(p_query_task, point, navigation_polys[np_id].poly);
 		} else {
@@ -736,13 +736,13 @@ ClosestPointQueryResult NavMeshQueries2D::map_iteration_get_closest_point_info(c
 	const LocalVector<NavRegionIteration2D> &regions = p_map_iteration.region_iterations;
 	for (const NavRegionIteration2D &region : regions) {
 		for (const Polygon &polygon : region.get_navmesh_polygons()) {
-			real_t cross = (polygon.points[1].pos - polygon.points[0].pos).cross(polygon.points[2].pos - polygon.points[0].pos);
+			real_t cross = (polygon.vertices[1] - polygon.vertices[0]).cross(polygon.vertices[2] - polygon.vertices[0]);
 			Vector2 closest_on_polygon;
 			real_t closest = FLT_MAX;
 			bool inside = true;
-			Vector2 previous = polygon.points[polygon.points.size() - 1].pos;
-			for (uint32_t point_id = 0; point_id < polygon.points.size(); ++point_id) {
-				Vector2 edge = polygon.points[point_id].pos - previous;
+			Vector2 previous = polygon.vertices[polygon.vertices.size() - 1];
+			for (uint32_t point_id = 0; point_id < polygon.vertices.size(); ++point_id) {
+				Vector2 edge = polygon.vertices[point_id] - previous;
 				Vector2 to_point = p_point - previous;
 				real_t edge_to_point_cross = edge.cross(to_point);
 				bool clockwise = (edge_to_point_cross * cross) > 0;
@@ -753,9 +753,9 @@ ClosestPointQueryResult NavMeshQueries2D::map_iteration_get_closest_point_info(c
 					real_t edge_square = edge.length_squared();
 
 					if (point_projected_on_edge > edge_square) {
-						real_t distance = polygon.points[point_id].pos.distance_squared_to(p_point);
+						real_t distance = polygon.vertices[point_id].distance_squared_to(p_point);
 						if (distance < closest) {
-							closest_on_polygon = polygon.points[point_id].pos;
+							closest_on_polygon = polygon.vertices[point_id];
 							closest = distance;
 						}
 					} else if (point_projected_on_edge < 0.0) {
@@ -771,7 +771,7 @@ ClosestPointQueryResult NavMeshQueries2D::map_iteration_get_closest_point_info(c
 						break;
 					}
 				}
-				previous = polygon.points[point_id].pos;
+				previous = polygon.vertices[point_id];
 			}
 
 			if (inside) {
@@ -868,13 +868,13 @@ ClosestPointQueryResult NavMeshQueries2D::polygons_get_closest_point_info(const 
 	// TODO: Check for further 2D improvements.
 
 	for (const Polygon &polygon : p_polygons) {
-		real_t cross = (polygon.points[1].pos - polygon.points[0].pos).cross(polygon.points[2].pos - polygon.points[0].pos);
+		real_t cross = (polygon.vertices[1] - polygon.vertices[0]).cross(polygon.vertices[2] - polygon.vertices[0]);
 		Vector2 closest_on_polygon;
 		real_t closest = FLT_MAX;
 		bool inside = true;
-		Vector2 previous = polygon.points[polygon.points.size() - 1].pos;
-		for (uint32_t point_id = 0; point_id < polygon.points.size(); ++point_id) {
-			Vector2 edge = polygon.points[point_id].pos - previous;
+		Vector2 previous = polygon.vertices[polygon.vertices.size() - 1];
+		for (uint32_t point_id = 0; point_id < polygon.vertices.size(); ++point_id) {
+			Vector2 edge = polygon.vertices[point_id] - previous;
 			Vector2 to_point = p_point - previous;
 			real_t edge_to_point_cross = edge.cross(to_point);
 			bool clockwise = (edge_to_point_cross * cross) > 0;
@@ -885,9 +885,9 @@ ClosestPointQueryResult NavMeshQueries2D::polygons_get_closest_point_info(const 
 				real_t edge_square = edge.length_squared();
 
 				if (point_projected_on_edge > edge_square) {
-					real_t distance = polygon.points[point_id].pos.distance_squared_to(p_point);
+					real_t distance = polygon.vertices[point_id].distance_squared_to(p_point);
 					if (distance < closest) {
-						closest_on_polygon = polygon.points[point_id].pos;
+						closest_on_polygon = polygon.vertices[point_id];
 						closest = distance;
 					}
 				} else if (point_projected_on_edge < 0.0) {
@@ -903,7 +903,7 @@ ClosestPointQueryResult NavMeshQueries2D::polygons_get_closest_point_info(const 
 					break;
 				}
 			}
-			previous = polygon.points[point_id].pos;
+			previous = polygon.vertices[point_id];
 		}
 
 		if (inside) {

--- a/modules/navigation_2d/nav_region_2d.cpp
+++ b/modules/navigation_2d/nav_region_2d.cpp
@@ -229,7 +229,7 @@ void NavRegion2D::update_polygons() {
 		const int *indices = navigation_mesh_polygon.ptr();
 		bool valid(true);
 
-		polygon.points.resize(navigation_mesh_polygon_size);
+		polygon.vertices.resize(navigation_mesh_polygon_size);
 		polygon.edges.resize(navigation_mesh_polygon_size);
 
 		real_t _new_polygon_surface_area = 0.0;
@@ -254,8 +254,7 @@ void NavRegion2D::update_polygons() {
 			}
 
 			Vector2 point_position = transform.xform(vertices_r[idx]);
-			polygon.points[j].pos = point_position;
-			polygon.points[j].key = NavMapBuilder2D::get_point_key(point_position, map->get_merge_rasterizer_cell_size());
+			polygon.vertices[j] = point_position;
 
 			if (first_vertex) {
 				first_vertex = false;

--- a/modules/navigation_2d/nav_utils_2d.h
+++ b/modules/navigation_2d/nav_utils_2d.h
@@ -71,11 +71,6 @@ struct EdgeKey {
 	}
 };
 
-struct Point {
-	Vector2 pos;
-	PointKey key;
-};
-
 struct Edge {
 	/// The gateway in the edge, as, in some case, the whole edge might not be navigable.
 	struct Connection {
@@ -103,8 +98,7 @@ struct Polygon {
 	/// Navigation region or link that contains this polygon.
 	const NavBaseIteration2D *owner = nullptr;
 
-	/// The points of this `Polygon`
-	LocalVector<Point> points;
+	LocalVector<Vector2> vertices;
 
 	/// The edges of this `Polygon`
 	LocalVector<Edge> edges;


### PR DESCRIPTION
Replaces NavigationServer2D `Point` struct with `Vector2` and renames points to vertices.

2D version of https://github.com/godotengine/godot/pull/105253

Makes code simpler and more readable. Also renames the points to vertices as vertices have a clear meaning in context of navmesh geometry while points are just something.

We have no real need to keep the (edge)key of the Point struct as it can be constructed on demand. It is only needed at the edge merge step when the map is build, never after, so a waste to keep it around forever. That reduces the Point to just the `pos` which is the global position on the navigation map, aka a simple Vector2 can do that better.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
