### PR TITLE
Delete `VariantGetInternalPtr` and `VariantImplicitConvert`, replace with `VariantInternalAccessor`

### DIFF
--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -531,27 +531,27 @@ void call_with_ptr_args_static_method(void (*p_method)(P...), const void **p_arg
 
 template <typename T, typename... P>
 void call_with_validated_variant_args(Variant *base, void (T::*p_method)(P...), const Variant **p_args) {
-	call_with_validated_variant_args_helper<T, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
+	call_with_validated_variant_args_helper<T, P...>(&VariantInternalAccessor<T>::get(base), p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
 template <typename T, typename R, typename... P>
 void call_with_validated_variant_args_ret(Variant *base, R (T::*p_method)(P...), const Variant **p_args, Variant *r_ret) {
-	call_with_validated_variant_args_ret_helper<T, R, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
+	call_with_validated_variant_args_ret_helper<T, R, P...>(&VariantInternalAccessor<T>::get(base), p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
 template <typename T, typename R, typename... P>
 void call_with_validated_variant_args_retc(Variant *base, R (T::*p_method)(P...) const, const Variant **p_args, Variant *r_ret) {
-	call_with_validated_variant_args_retc_helper<T, R, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
+	call_with_validated_variant_args_retc_helper<T, R, P...>(&VariantInternalAccessor<T>::get(base), p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
 template <typename T, typename... P>
 void call_with_validated_variant_args_static(Variant *base, void (*p_method)(T *, P...), const Variant **p_args) {
-	call_with_validated_variant_args_static_helper<T, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
+	call_with_validated_variant_args_static_helper<T, P...>(&VariantInternalAccessor<T>::get(base), p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
 template <typename T, typename R, typename... P>
 void call_with_validated_variant_args_static_retc(Variant *base, R (*p_method)(T *, P...), const Variant **p_args, Variant *r_ret) {
-	call_with_validated_variant_args_static_retc_helper<T, R, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
+	call_with_validated_variant_args_static_retc_helper<T, R, P...>(&VariantInternalAccessor<T>::get(base), p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
 template <typename... P>

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -174,11 +174,11 @@ private:
 	friend struct _VariantCall;
 	friend class VariantInternal;
 	template <typename>
-	friend struct _VariantGetInternalPtrLocal;
+	friend struct _VariantInternalAccessorLocal;
 	template <typename>
-	friend struct _VariantGetInternalPtrElsewhere;
+	friend struct _VariantInternalAccessorElsewhere;
 	template <typename>
-	friend struct _VariantGetInternalPtrPackedArrayRef;
+	friend struct _VariantInternalAccessorPackedArrayRef;
 	// Variant takes 24 bytes when real_t is float, and 40 bytes if double.
 	// It only allocates extra memory for AABB/Transform2D (24, 48 if double),
 	// Basis/Transform3D (48, 96 if double), Projection (64, 128 if double),

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -173,6 +173,12 @@ private:
 
 	friend struct _VariantCall;
 	friend class VariantInternal;
+	template <typename>
+	friend struct _VariantGetInternalPtrLocal;
+	template <typename>
+	friend struct _VariantGetInternalPtrElsewhere;
+	template <typename>
+	friend struct _VariantGetInternalPtrPackedArrayRef;
 	// Variant takes 24 bytes when real_t is float, and 40 bytes if double.
 	// It only allocates extra memory for AABB/Transform2D (24, 48 if double),
 	// Basis/Transform3D (48, 96 if double), Projection (64, 128 if double),

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -54,58 +54,58 @@ static _FORCE_INLINE_ void vc_static_method_call(void (*method)(P...), const Var
 
 template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_method_call(R (T::*method)(P...), Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
-	call_with_variant_args_ret_dv(VariantGetInternalPtr<T>::get_ptr(base), method, p_args, p_argcount, r_ret, r_error, p_defvals);
+	call_with_variant_args_ret_dv(&VariantInternalAccessor<T>::get(base), method, p_args, p_argcount, r_ret, r_error, p_defvals);
 }
 
 template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_method_call(R (T::*method)(P...) const, Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
-	call_with_variant_args_retc_dv(VariantGetInternalPtr<T>::get_ptr(base), method, p_args, p_argcount, r_ret, r_error, p_defvals);
+	call_with_variant_args_retc_dv(&VariantInternalAccessor<T>::get(base), method, p_args, p_argcount, r_ret, r_error, p_defvals);
 }
 
 template <typename T, typename... P>
 static _FORCE_INLINE_ void vc_method_call(void (T::*method)(P...), Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	VariantInternal::clear(&r_ret);
-	call_with_variant_args_dv(VariantGetInternalPtr<T>::get_ptr(base), method, p_args, p_argcount, r_error, p_defvals);
+	call_with_variant_args_dv(&VariantInternalAccessor<T>::get(base), method, p_args, p_argcount, r_error, p_defvals);
 }
 
 template <typename T, typename... P>
 static _FORCE_INLINE_ void vc_method_call(void (T::*method)(P...) const, Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	VariantInternal::clear(&r_ret);
-	call_with_variant_argsc_dv(VariantGetInternalPtr<T>::get_ptr(base), method, p_args, p_argcount, r_error, p_defvals);
+	call_with_variant_argsc_dv(&VariantInternalAccessor<T>::get(base), method, p_args, p_argcount, r_error, p_defvals);
 }
 
 template <typename From, typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_method_call(R (T::*method)(P...), Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
-	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
+	T converted(static_cast<T>(VariantInternalAccessor<From>::get(base)));
 	call_with_variant_args_ret_dv(&converted, method, p_args, p_argcount, r_ret, r_error, p_defvals);
 }
 
 template <typename From, typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_method_call(R (T::*method)(P...) const, Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
-	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
+	T converted(static_cast<T>(VariantInternalAccessor<From>::get(base)));
 	call_with_variant_args_retc_dv(&converted, method, p_args, p_argcount, r_ret, r_error, p_defvals);
 }
 
 template <typename From, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_method_call(void (T::*method)(P...), Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
-	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
+	T converted(static_cast<T>(VariantInternalAccessor<From>::get(base)));
 	call_with_variant_args_dv(&converted, method, p_args, p_argcount, r_error, p_defvals);
 }
 
 template <typename From, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_method_call(void (T::*method)(P...) const, Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
-	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
+	T converted(static_cast<T>(VariantInternalAccessor<From>::get(base)));
 	call_with_variant_argsc_dv(&converted, method, p_args, p_argcount, r_error, p_defvals);
 }
 
 template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_method_call_static(R (*method)(T *, P...), Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
-	call_with_variant_args_retc_static_helper_dv(VariantGetInternalPtr<T>::get_ptr(base), method, p_args, p_argcount, r_ret, p_defvals, r_error);
+	call_with_variant_args_retc_static_helper_dv(&VariantInternalAccessor<T>::get(base), method, p_args, p_argcount, r_ret, p_defvals, r_error);
 }
 
 template <typename T, typename... P>
 static _FORCE_INLINE_ void vc_method_call_static(void (*method)(T *, P...), Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
-	call_with_variant_args_static_helper_dv(VariantGetInternalPtr<T>::get_ptr(base), method, p_args, p_argcount, p_defvals, r_error);
+	call_with_variant_args_static_helper_dv(&VariantInternalAccessor<T>::get(base), method, p_args, p_argcount, p_defvals, r_error);
 }
 
 template <typename R, typename T, typename... P>
@@ -129,24 +129,24 @@ static _FORCE_INLINE_ void vc_validated_call(void (T::*method)(P...) const, Vari
 
 template <typename From, typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_validated_call(R (T::*method)(P...), Variant *base, const Variant **p_args, Variant *r_ret) {
-	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
+	T converted(static_cast<T>(VariantInternalAccessor<From>::get(base)));
 	call_with_validated_variant_args_ret_helper<T, R, P...>(&converted, method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
 template <typename From, typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_validated_call(R (T::*method)(P...) const, Variant *base, const Variant **p_args, Variant *r_ret) {
-	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
+	T converted(static_cast<T>(VariantInternalAccessor<From>::get(base)));
 	call_with_validated_variant_args_retc_helper<T, R, P...>(&converted, method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 template <typename From, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_validated_call(void (T::*method)(P...), Variant *base, const Variant **p_args, Variant *r_ret) {
-	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
+	T converted(static_cast<T>(VariantInternalAccessor<From>::get(base)));
 	call_with_validated_variant_args_helper<T, P...>(&converted, method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
 template <typename From, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_validated_call(void (T::*method)(P...) const, Variant *base, const Variant **p_args, Variant *r_ret) {
-	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
+	T converted(static_cast<T>(VariantInternalAccessor<From>::get(base)));
 	call_with_validated_variant_argsc_helper<T, P...>(&converted, method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
@@ -1168,17 +1168,17 @@ struct _VariantCall {
 	}
 
 	static void func_Callable_call(Variant *v, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
-		Callable *callable = VariantGetInternalPtr<Callable>::get_ptr(v);
+		Callable *callable = &VariantInternalAccessor<Callable>::get(v);
 		callable->callp(p_args, p_argcount, r_ret, r_error);
 	}
 
 	static void func_Callable_call_deferred(Variant *v, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
-		Callable *callable = VariantGetInternalPtr<Callable>::get_ptr(v);
+		Callable *callable = &VariantInternalAccessor<Callable>::get(v);
 		callable->call_deferredp(p_args, p_argcount);
 	}
 
 	static void func_Callable_rpc(Variant *v, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
-		Callable *callable = VariantGetInternalPtr<Callable>::get_ptr(v);
+		Callable *callable = &VariantInternalAccessor<Callable>::get(v);
 		callable->rpcp(0, p_args, p_argcount, r_error);
 	}
 
@@ -1191,13 +1191,13 @@ struct _VariantCall {
 			r_error.argument = 0;
 			r_error.expected = Variant::INT;
 		} else {
-			Callable *callable = VariantGetInternalPtr<Callable>::get_ptr(v);
+			Callable *callable = &VariantInternalAccessor<Callable>::get(v);
 			callable->rpcp(*p_args[0], &p_args[1], p_argcount - 1, r_error);
 		}
 	}
 
 	static void func_Callable_bind(Variant *v, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
-		Callable *callable = VariantGetInternalPtr<Callable>::get_ptr(v);
+		Callable *callable = &VariantInternalAccessor<Callable>::get(v);
 		r_ret = callable->bindp(p_args, p_argcount);
 	}
 
@@ -1206,7 +1206,7 @@ struct _VariantCall {
 	}
 
 	static void func_Signal_emit(Variant *v, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
-		Signal *signal = VariantGetInternalPtr<Signal>::get_ptr(v);
+		Signal *signal = &VariantInternalAccessor<Signal>::get(v);
 		signal->emit(p_args, p_argcount);
 	}
 

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -125,8 +125,8 @@ void Variant::_register_variant_constructors() {
 
 	add_constructor<VariantConstructNoArgs<Transform2D>>(sarray());
 	add_constructor<VariantConstructor<Transform2D, Transform2D>>(sarray("from"));
-	add_constructor<VariantConstructor<Transform2D, float, Vector2>>(sarray("rotation", "position"));
-	add_constructor<VariantConstructor<Transform2D, float, Size2, float, Vector2>>(sarray("rotation", "scale", "skew", "position"));
+	add_constructor<VariantConstructor<Transform2D, double, Vector2>>(sarray("rotation", "position"));
+	add_constructor<VariantConstructor<Transform2D, double, Size2, double, Vector2>>(sarray("rotation", "scale", "skew", "position"));
 	add_constructor<VariantConstructor<Transform2D, Vector2, Vector2, Vector2>>(sarray("x_axis", "y_axis", "origin"));
 
 	add_constructor<VariantConstructNoArgs<Plane>>(sarray());

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -113,7 +113,7 @@ class VariantConstructor {
 
 	template <size_t... Is>
 	static _FORCE_INLINE_ void validated_construct_helper(T &base, const Variant **p_args, IndexSequence<Is...>) {
-		base = T((*VariantGetInternalPtr<P>::get_ptr(p_args[Is]))...);
+		base = T((VariantInternalAccessor<P>::get(p_args[Is]))...);
 	}
 
 	template <size_t... Is>
@@ -125,12 +125,12 @@ public:
 	static void construct(Variant &r_ret, const Variant **p_args, Callable::CallError &r_error) {
 		r_error.error = Callable::CallError::CALL_OK;
 		VariantTypeChanger<T>::change(&r_ret);
-		construct_helper(*VariantGetInternalPtr<T>::get_ptr(&r_ret), p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
+		construct_helper(VariantInternalAccessor<T>::get(&r_ret), p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
 	}
 
 	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {
 		VariantTypeChanger<T>::change(r_ret);
-		validated_construct_helper(*VariantGetInternalPtr<T>::get_ptr(r_ret), p_args, BuildIndexSequence<sizeof...(P)>{});
+		validated_construct_helper(VariantInternalAccessor<T>::get(r_ret), p_args, BuildIndexSequence<sizeof...(P)>{});
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		ptr_construct_helper(base, p_args, BuildIndexSequence<sizeof...(P)>{});
@@ -249,7 +249,7 @@ public:
 
 	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {
 		VariantTypeChanger<T>::change(r_ret);
-		const String &src_str = *VariantGetInternalPtr<String>::get_ptr(p_args[0]);
+		const String &src_str = VariantInternalAccessor<String>::get(p_args[0]);
 		T ret = Variant();
 		if (r_ret->get_type() == Variant::Type::INT) {
 			ret = src_str.to_int();
@@ -302,9 +302,9 @@ public:
 		}
 
 		if (p_args[1]->get_type() == Variant::STRING_NAME) {
-			method = *VariantGetInternalPtr<StringName>::get_ptr(p_args[1]);
+			method = VariantInternalAccessor<StringName>::get(p_args[1]);
 		} else if (p_args[1]->get_type() == Variant::STRING) {
-			method = *VariantGetInternalPtr<String>::get_ptr(p_args[1]);
+			method = VariantInternalAccessor<String>::get(p_args[1]);
 		} else {
 			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 			r_error.argument = 1;
@@ -313,12 +313,12 @@ public:
 		}
 
 		VariantTypeChanger<Callable>::change(&r_ret);
-		*VariantGetInternalPtr<Callable>::get_ptr(&r_ret) = Callable(object_id, method);
+		VariantInternalAccessor<Callable>::get(&r_ret) = Callable(object_id, method);
 	}
 
 	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {
 		VariantTypeChanger<Callable>::change(r_ret);
-		*VariantGetInternalPtr<Callable>::get_ptr(r_ret) = Callable(VariantInternal::get_object_id(p_args[0]), *VariantGetInternalPtr<StringName>::get_ptr(p_args[1]));
+		VariantInternalAccessor<Callable>::get(r_ret) = Callable(VariantInternal::get_object_id(p_args[0]), VariantInternalAccessor<StringName>::get(p_args[1]));
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		PtrConstruct<Callable>::construct(Callable(PtrToArg<Object *>::convert(p_args[0]), PtrToArg<StringName>::convert(p_args[1])), base);
@@ -359,9 +359,9 @@ public:
 		}
 
 		if (p_args[1]->get_type() == Variant::STRING_NAME) {
-			method = *VariantGetInternalPtr<StringName>::get_ptr(p_args[1]);
+			method = VariantInternalAccessor<StringName>::get(p_args[1]);
 		} else if (p_args[1]->get_type() == Variant::STRING) {
-			method = *VariantGetInternalPtr<String>::get_ptr(p_args[1]);
+			method = VariantInternalAccessor<String>::get(p_args[1]);
 		} else {
 			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 			r_error.argument = 1;
@@ -370,12 +370,12 @@ public:
 		}
 
 		VariantTypeChanger<Signal>::change(&r_ret);
-		*VariantGetInternalPtr<Signal>::get_ptr(&r_ret) = Signal(object_id, method);
+		VariantInternalAccessor<Signal>::get(&r_ret) = Signal(object_id, method);
 	}
 
 	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {
 		VariantTypeChanger<Signal>::change(r_ret);
-		*VariantGetInternalPtr<Signal>::get_ptr(r_ret) = Signal(VariantInternal::get_object_id(p_args[0]), *VariantGetInternalPtr<StringName>::get_ptr(p_args[1]));
+		VariantInternalAccessor<Signal>::get(r_ret) = Signal(VariantInternal::get_object_id(p_args[0]), VariantInternalAccessor<StringName>::get(p_args[1]));
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		PtrConstruct<Signal>::construct(Signal(PtrToArg<Object *>::convert(p_args[0]), PtrToArg<StringName>::convert(p_args[1])), base);
@@ -436,20 +436,20 @@ public:
 			return;
 		}
 
-		const Dictionary &base_dict = *VariantGetInternalPtr<Dictionary>::get_ptr(p_args[0]);
+		const Dictionary &base_dict = VariantInternalAccessor<Dictionary>::get(p_args[0]);
 		const uint32_t key_type = p_args[1]->operator uint32_t();
-		const StringName &key_class_name = *VariantGetInternalPtr<StringName>::get_ptr(p_args[2]);
+		const StringName &key_class_name = VariantInternalAccessor<StringName>::get(p_args[2]);
 		const uint32_t value_type = p_args[4]->operator uint32_t();
-		const StringName &value_class_name = *VariantGetInternalPtr<StringName>::get_ptr(p_args[5]);
+		const StringName &value_class_name = VariantInternalAccessor<StringName>::get(p_args[5]);
 		r_ret = Dictionary(base_dict, key_type, key_class_name, *p_args[3], value_type, value_class_name, *p_args[6]);
 	}
 
 	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {
-		const Dictionary &base_dict = *VariantGetInternalPtr<Dictionary>::get_ptr(p_args[0]);
+		const Dictionary &base_dict = VariantInternalAccessor<Dictionary>::get(p_args[0]);
 		const uint32_t key_type = p_args[1]->operator uint32_t();
-		const StringName &key_class_name = *VariantGetInternalPtr<StringName>::get_ptr(p_args[2]);
+		const StringName &key_class_name = VariantInternalAccessor<StringName>::get(p_args[2]);
 		const uint32_t value_type = p_args[4]->operator uint32_t();
-		const StringName &value_class_name = *VariantGetInternalPtr<StringName>::get_ptr(p_args[5]);
+		const StringName &value_class_name = VariantInternalAccessor<StringName>::get(p_args[5]);
 		*r_ret = Dictionary(base_dict, key_type, key_class_name, *p_args[3], value_type, value_class_name, *p_args[6]);
 	}
 
@@ -528,15 +528,15 @@ public:
 			return;
 		}
 
-		const Array &base_arr = *VariantGetInternalPtr<Array>::get_ptr(p_args[0]);
+		const Array &base_arr = VariantInternalAccessor<Array>::get(p_args[0]);
 		const uint32_t type = p_args[1]->operator uint32_t();
 		r_ret = Array(base_arr, type, *p_args[2], *p_args[3]);
 	}
 
 	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {
-		const Array &base_arr = *VariantGetInternalPtr<Array>::get_ptr(p_args[0]);
+		const Array &base_arr = VariantInternalAccessor<Array>::get(p_args[0]);
 		const uint32_t type = p_args[1]->operator uint32_t();
-		const StringName &class_name = *VariantGetInternalPtr<StringName>::get_ptr(p_args[2]);
+		const StringName &class_name = VariantInternalAccessor<StringName>::get(p_args[2]);
 		*r_ret = Array(base_arr, type, class_name, *p_args[3]);
 	}
 
@@ -591,8 +591,8 @@ public:
 		}
 
 		r_ret = Array();
-		Array &dst_arr = *VariantGetInternalPtr<Array>::get_ptr(&r_ret);
-		const T &src_arr = *VariantGetInternalPtr<T>::get_ptr(p_args[0]);
+		Array &dst_arr = VariantInternalAccessor<Array>::get(&r_ret);
+		const T &src_arr = VariantInternalAccessor<T>::get(p_args[0]);
 
 		int size = src_arr.size();
 		dst_arr.resize(size);
@@ -603,8 +603,8 @@ public:
 
 	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {
 		*r_ret = Array();
-		Array &dst_arr = *VariantGetInternalPtr<Array>::get_ptr(r_ret);
-		const T &src_arr = *VariantGetInternalPtr<T>::get_ptr(p_args[0]);
+		Array &dst_arr = VariantInternalAccessor<Array>::get(r_ret);
+		const T &src_arr = VariantInternalAccessor<T>::get(p_args[0]);
 
 		int size = src_arr.size();
 		dst_arr.resize(size);
@@ -650,8 +650,8 @@ public:
 		}
 
 		VariantTypeChanger<T>::change(&r_ret);
-		const Array &src_arr = *VariantGetInternalPtr<Array>::get_ptr(p_args[0]);
-		T &dst_arr = *VariantGetInternalPtr<T>::get_ptr(&r_ret);
+		const Array &src_arr = VariantInternalAccessor<Array>::get(p_args[0]);
+		T &dst_arr = VariantInternalAccessor<T>::get(&r_ret);
 
 		int size = src_arr.size();
 		dst_arr.resize(size);
@@ -662,8 +662,8 @@ public:
 
 	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {
 		VariantTypeChanger<T>::change(r_ret);
-		const Array &src_arr = *VariantGetInternalPtr<Array>::get_ptr(p_args[0]);
-		T &dst_arr = *VariantGetInternalPtr<T>::get_ptr(r_ret);
+		const Array &src_arr = VariantInternalAccessor<Array>::get(p_args[0]);
+		T &dst_arr = VariantInternalAccessor<T>::get(r_ret);
 
 		int size = src_arr.size();
 		dst_arr.resize(size);

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -534,221 +534,36 @@ public:
 	}
 };
 
-/// Types that can be stored in Variant.
-template <typename T, typename = void>
-struct VariantGetInternalPtr;
-
-template <typename T>
-struct VariantGetInternalPtr<T, std::enable_if_t<!std::is_same_v<T, GetSimpleTypeT<T>>>> : VariantGetInternalPtr<GetSimpleTypeT<T>> {};
-
-template <typename T>
-struct _VariantGetInternalPtrLocal {
-	using type = T;
-	static constexpr bool is_local = true;
-	static _FORCE_INLINE_ T *get_ptr(Variant *v) { return reinterpret_cast<T *>(v->_data._mem); }
-	static _FORCE_INLINE_ const T *get_ptr(const Variant *v) { return reinterpret_cast<const T *>(v->_data._mem); }
-};
-
-template <typename T>
-struct _VariantGetInternalPtrElsewhere {
-	using type = T;
-	static constexpr bool is_local = false;
-	static _FORCE_INLINE_ T *get_ptr(Variant *v) { return reinterpret_cast<T *>(v->_data._ptr); }
-	static _FORCE_INLINE_ const T *get_ptr(const Variant *v) { return reinterpret_cast<const T *>(v->_data._ptr); }
-};
-
-template <typename T>
-struct _VariantGetInternalPtrPackedArrayRef {
-	using type = Vector<T>;
-	static constexpr bool is_local = false;
-	static _FORCE_INLINE_ Vector<T> *get_ptr(Variant *v) { return &static_cast<Variant::PackedArrayRef<T> *>(v->_data.packed_array)->array; }
-	static _FORCE_INLINE_ const Vector<T> *get_ptr(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<T> *>(v->_data.packed_array)->array; }
-};
-
-template <>
-struct VariantGetInternalPtr<bool> : _VariantGetInternalPtrLocal<bool> {};
-
-template <>
-struct VariantGetInternalPtr<int64_t> : _VariantGetInternalPtrLocal<int64_t> {};
-
-template <>
-struct VariantGetInternalPtr<double> : _VariantGetInternalPtrLocal<double> {};
-
-template <>
-struct VariantGetInternalPtr<String> : _VariantGetInternalPtrLocal<String> {};
-
-template <>
-struct VariantGetInternalPtr<Vector2> : _VariantGetInternalPtrLocal<Vector2> {};
-
-template <>
-struct VariantGetInternalPtr<Vector2i> : _VariantGetInternalPtrLocal<Vector2i> {};
-
-template <>
-struct VariantGetInternalPtr<Rect2> : _VariantGetInternalPtrLocal<Rect2> {};
-
-template <>
-struct VariantGetInternalPtr<Rect2i> : _VariantGetInternalPtrLocal<Rect2i> {};
-
-template <>
-struct VariantGetInternalPtr<Vector3> : _VariantGetInternalPtrLocal<Vector3> {};
-
-template <>
-struct VariantGetInternalPtr<Vector3i> : _VariantGetInternalPtrLocal<Vector3i> {};
-
-template <>
-struct VariantGetInternalPtr<Vector4> : _VariantGetInternalPtrLocal<Vector4> {};
-
-template <>
-struct VariantGetInternalPtr<Vector4i> : _VariantGetInternalPtrLocal<Vector4i> {};
-
-template <>
-struct VariantGetInternalPtr<Transform2D> : _VariantGetInternalPtrElsewhere<Transform2D> {};
-
-template <>
-struct VariantGetInternalPtr<Transform3D> : _VariantGetInternalPtrElsewhere<Transform3D> {};
-
-template <>
-struct VariantGetInternalPtr<Projection> : _VariantGetInternalPtrElsewhere<Projection> {};
-
-template <>
-struct VariantGetInternalPtr<Plane> : _VariantGetInternalPtrLocal<Plane> {};
-
-template <>
-struct VariantGetInternalPtr<Quaternion> : _VariantGetInternalPtrLocal<Quaternion> {};
-
-template <>
-struct VariantGetInternalPtr<::AABB> : _VariantGetInternalPtrElsewhere<::AABB> {};
-
-template <>
-struct VariantGetInternalPtr<Basis> : _VariantGetInternalPtrElsewhere<Basis> {};
-
-template <>
-struct VariantGetInternalPtr<Color> : _VariantGetInternalPtrLocal<Color> {};
-
-template <>
-struct VariantGetInternalPtr<StringName> : _VariantGetInternalPtrLocal<StringName> {};
-
-template <>
-struct VariantGetInternalPtr<NodePath> : _VariantGetInternalPtrLocal<NodePath> {};
-
-template <>
-struct VariantGetInternalPtr<::RID> : _VariantGetInternalPtrLocal<::RID> {};
-
-// template <>
-// struct VariantGetInternalPtr<Variant::ObjData> : _VariantGetInternalPtrLocal<Variant::ObjData> {};
-
-template <>
-struct VariantGetInternalPtr<Callable> : _VariantGetInternalPtrLocal<Callable> {};
-
-template <>
-struct VariantGetInternalPtr<Signal> : _VariantGetInternalPtrLocal<Signal> {};
-
-template <>
-struct VariantGetInternalPtr<Dictionary> : _VariantGetInternalPtrLocal<Dictionary> {};
-
-template <>
-struct VariantGetInternalPtr<Array> : _VariantGetInternalPtrLocal<Array> {};
-
-template <>
-struct VariantGetInternalPtr<PackedByteArray> : _VariantGetInternalPtrPackedArrayRef<uint8_t> {};
-
-template <>
-struct VariantGetInternalPtr<PackedInt32Array> : _VariantGetInternalPtrPackedArrayRef<int32_t> {};
-
-template <>
-struct VariantGetInternalPtr<PackedInt64Array> : _VariantGetInternalPtrPackedArrayRef<int64_t> {};
-
-template <>
-struct VariantGetInternalPtr<PackedFloat32Array> : _VariantGetInternalPtrPackedArrayRef<float> {};
-
-template <>
-struct VariantGetInternalPtr<PackedFloat64Array> : _VariantGetInternalPtrPackedArrayRef<double> {};
-
-template <>
-struct VariantGetInternalPtr<PackedStringArray> : _VariantGetInternalPtrPackedArrayRef<String> {};
-
-template <>
-struct VariantGetInternalPtr<PackedVector2Array> : _VariantGetInternalPtrPackedArrayRef<Vector2> {};
-
-template <>
-struct VariantGetInternalPtr<PackedVector3Array> : _VariantGetInternalPtrPackedArrayRef<Vector3> {};
-
-template <>
-struct VariantGetInternalPtr<PackedColorArray> : _VariantGetInternalPtrPackedArrayRef<Color> {};
-
-template <>
-struct VariantGetInternalPtr<PackedVector4Array> : _VariantGetInternalPtrPackedArrayRef<Vector4> {};
-
-template <typename T, typename = std::void_t<>>
-struct IsVariantType : std::false_type {};
-
-template <typename T>
-struct IsVariantType<T, std::void_t<typename VariantGetInternalPtr<T>::type>> : std::true_type {};
-
-template <typename T>
-constexpr bool IsVariantTypeT = IsVariantType<T>::value;
-
-/// Types that can be implicitly converted to and from Variant,
-///  using another type to store the actual value.
-template <typename T, typename = void>
-struct VariantImplicitConvert;
-
-template <typename T, typename S>
-struct _VariantImplicitConvertCast {
-	using EncodeT = S;
-	static _FORCE_INLINE_ T read(const Variant &p_variant) {
-		return T(*VariantGetInternalPtr<S>::get_ptr(&p_variant));
-	}
-	static _FORCE_INLINE_ T read(Variant &p_variant) {
-		return T(*VariantGetInternalPtr<S>::get_ptr(&p_variant));
-	}
-	static _FORCE_INLINE_ void write(T p_val, Variant &p_variant) {
-		*VariantGetInternalPtr<S>::get_ptr(&p_variant) = S(std::move(p_val));
-	}
-};
-
-// Integer types.
-template <typename T>
-struct VariantImplicitConvert<T, std::enable_if_t<std::is_integral_v<T> && !std::is_same_v<T, bool> && !std::is_same_v<T, int64_t>>> : _VariantImplicitConvertCast<T, int64_t> {};
-template <typename T>
-struct VariantImplicitConvert<T, std::enable_if_t<std::is_enum_v<T>>> : _VariantImplicitConvertCast<T, int64_t> {};
-template <typename T>
-struct VariantImplicitConvert<BitField<T>, std::enable_if_t<std::is_enum_v<T>>> : _VariantImplicitConvertCast<BitField<T>, int64_t> {};
-
-template <>
-struct VariantImplicitConvert<ObjectID> : _VariantImplicitConvertCast<ObjectID, int64_t> {};
-
-// Float types.
-template <>
-struct VariantImplicitConvert<float> : _VariantImplicitConvertCast<float, double> {};
-
-template <typename T, typename = std::void_t<>>
-struct IsVariantImplicitConversionType : std::false_type {};
-
-template <typename T>
-struct IsVariantImplicitConversionType<T, std::void_t<typename VariantImplicitConvert<T>::EncodeT>> : std::true_type {};
-
-template <typename T>
-constexpr bool IsVariantImplicitConversionTypeT = IsVariantImplicitConversionType<T>::value;
-
 template <typename T, typename = void>
 struct VariantInternalAccessor;
 
 template <typename T>
-struct VariantInternalAccessor<T, std::enable_if_t<IsVariantTypeT<T>>> {
-	static _FORCE_INLINE_ T &get(Variant *v) { return *VariantGetInternalPtr<T>::get_ptr(v); }
-	static _FORCE_INLINE_ const T &get(const Variant *v) { return *VariantGetInternalPtr<T>::get_ptr(v); }
-	static _FORCE_INLINE_ void set(Variant *v, T p_value) { *VariantGetInternalPtr<T>::get_ptr(v) = std::move(p_value); }
-};
-
-template <typename T>
-struct VariantInternalAccessor<T, std::enable_if_t<IsVariantImplicitConversionTypeT<T>>> {
-	static _FORCE_INLINE_ T get(const Variant *v) { return VariantImplicitConvert<T>::read(*v); }
-	static _FORCE_INLINE_ void set(Variant *v, T p_value) { VariantImplicitConvert<T>::write(std::move(p_value), *v); }
-};
-
-template <typename T>
 struct VariantInternalAccessor<T, std::enable_if_t<!std::is_same_v<T, GetSimpleTypeT<T>>>> : VariantInternalAccessor<GetSimpleTypeT<T>> {};
+
+template <typename T>
+struct _VariantInternalAccessorLocal {
+	using declared_when_native_type = void;
+	static constexpr bool is_local = true;
+	static _FORCE_INLINE_ T &get(Variant *v) { return *reinterpret_cast<T *>(v->_data._mem); }
+	static _FORCE_INLINE_ const T &get(const Variant *v) { return *reinterpret_cast<const T *>(v->_data._mem); }
+	static _FORCE_INLINE_ void set(Variant *v, T p_value) { *reinterpret_cast<T *>(v->_data._mem) = std::move(p_value); }
+};
+
+template <typename T>
+struct _VariantInternalAccessorElsewhere {
+	using declared_when_native_type = void;
+	static _FORCE_INLINE_ T &get(Variant *v) { return *reinterpret_cast<T *>(v->_data._ptr); }
+	static _FORCE_INLINE_ const T &get(const Variant *v) { return *reinterpret_cast<const T *>(v->_data._ptr); }
+	static _FORCE_INLINE_ void set(Variant *v, T p_value) { *reinterpret_cast<T *>(v->_data._ptr) = std::move(p_value); }
+};
+
+template <typename T>
+struct _VariantInternalAccessorPackedArrayRef {
+	using declared_when_native_type = void;
+	static _FORCE_INLINE_ Vector<T> &get(Variant *v) { return static_cast<Variant::PackedArrayRef<T> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ const Vector<T> &get(const Variant *v) { return static_cast<const Variant::PackedArrayRef<T> *>(v->_data.packed_array)->array; }
+	static _FORCE_INLINE_ void set(Variant *v, Vector<T> p_value) { static_cast<Variant::PackedArrayRef<T> *>(v->_data.packed_array)->array = std::move(p_value); }
+};
 
 template <typename T>
 struct VariantInternalAccessor<T *> {
@@ -802,15 +617,163 @@ struct VariantInternalAccessor<Vector<Variant>> {
 	}
 };
 
+template <>
+struct VariantInternalAccessor<bool> : _VariantInternalAccessorLocal<bool> {};
+
+template <>
+struct VariantInternalAccessor<int64_t> : _VariantInternalAccessorLocal<int64_t> {};
+
+template <>
+struct VariantInternalAccessor<double> : _VariantInternalAccessorLocal<double> {};
+
+template <>
+struct VariantInternalAccessor<String> : _VariantInternalAccessorLocal<String> {};
+
+template <>
+struct VariantInternalAccessor<Vector2> : _VariantInternalAccessorLocal<Vector2> {};
+
+template <>
+struct VariantInternalAccessor<Vector2i> : _VariantInternalAccessorLocal<Vector2i> {};
+
+template <>
+struct VariantInternalAccessor<Rect2> : _VariantInternalAccessorLocal<Rect2> {};
+
+template <>
+struct VariantInternalAccessor<Rect2i> : _VariantInternalAccessorLocal<Rect2i> {};
+
+template <>
+struct VariantInternalAccessor<Vector3> : _VariantInternalAccessorLocal<Vector3> {};
+
+template <>
+struct VariantInternalAccessor<Vector3i> : _VariantInternalAccessorLocal<Vector3i> {};
+
+template <>
+struct VariantInternalAccessor<Vector4> : _VariantInternalAccessorLocal<Vector4> {};
+
+template <>
+struct VariantInternalAccessor<Vector4i> : _VariantInternalAccessorLocal<Vector4i> {};
+
+template <>
+struct VariantInternalAccessor<Transform2D> : _VariantInternalAccessorElsewhere<Transform2D> {};
+
+template <>
+struct VariantInternalAccessor<Transform3D> : _VariantInternalAccessorElsewhere<Transform3D> {};
+
+template <>
+struct VariantInternalAccessor<Projection> : _VariantInternalAccessorElsewhere<Projection> {};
+
+template <>
+struct VariantInternalAccessor<Plane> : _VariantInternalAccessorLocal<Plane> {};
+
+template <>
+struct VariantInternalAccessor<Quaternion> : _VariantInternalAccessorLocal<Quaternion> {};
+
+template <>
+struct VariantInternalAccessor<::AABB> : _VariantInternalAccessorElsewhere<::AABB> {};
+
+template <>
+struct VariantInternalAccessor<Basis> : _VariantInternalAccessorElsewhere<Basis> {};
+
+template <>
+struct VariantInternalAccessor<Color> : _VariantInternalAccessorLocal<Color> {};
+
+template <>
+struct VariantInternalAccessor<StringName> : _VariantInternalAccessorLocal<StringName> {};
+
+template <>
+struct VariantInternalAccessor<NodePath> : _VariantInternalAccessorLocal<NodePath> {};
+
+template <>
+struct VariantInternalAccessor<::RID> : _VariantInternalAccessorLocal<::RID> {};
+
+// template <>
+// struct VariantInternalAccessor<Variant::ObjData> : _VariantInternalAccessorLocal<Variant::ObjData> {};
+
+template <>
+struct VariantInternalAccessor<Callable> : _VariantInternalAccessorLocal<Callable> {};
+
+template <>
+struct VariantInternalAccessor<Signal> : _VariantInternalAccessorLocal<Signal> {};
+
+template <>
+struct VariantInternalAccessor<Dictionary> : _VariantInternalAccessorLocal<Dictionary> {};
+
+template <>
+struct VariantInternalAccessor<Array> : _VariantInternalAccessorLocal<Array> {};
+
+template <>
+struct VariantInternalAccessor<PackedByteArray> : _VariantInternalAccessorPackedArrayRef<uint8_t> {};
+
+template <>
+struct VariantInternalAccessor<PackedInt32Array> : _VariantInternalAccessorPackedArrayRef<int32_t> {};
+
+template <>
+struct VariantInternalAccessor<PackedInt64Array> : _VariantInternalAccessorPackedArrayRef<int64_t> {};
+
+template <>
+struct VariantInternalAccessor<PackedFloat32Array> : _VariantInternalAccessorPackedArrayRef<float> {};
+
+template <>
+struct VariantInternalAccessor<PackedFloat64Array> : _VariantInternalAccessorPackedArrayRef<double> {};
+
+template <>
+struct VariantInternalAccessor<PackedStringArray> : _VariantInternalAccessorPackedArrayRef<String> {};
+
+template <>
+struct VariantInternalAccessor<PackedVector2Array> : _VariantInternalAccessorPackedArrayRef<Vector2> {};
+
+template <>
+struct VariantInternalAccessor<PackedVector3Array> : _VariantInternalAccessorPackedArrayRef<Vector3> {};
+
+template <>
+struct VariantInternalAccessor<PackedColorArray> : _VariantInternalAccessorPackedArrayRef<Color> {};
+
+template <>
+struct VariantInternalAccessor<PackedVector4Array> : _VariantInternalAccessorPackedArrayRef<Vector4> {};
+
+template <typename T, typename = std::void_t<>>
+struct IsVariantType : std::false_type {};
+
+template <typename T>
+struct IsVariantType<T, std::void_t<typename VariantInternalAccessor<T>::declared_when_native_type>> : std::true_type {};
+
+template <typename T>
+constexpr bool IsVariantTypeT = IsVariantType<T>::value;
+
+template <typename T, typename S>
+struct _VariantInternalAccessorConvert {
+	static _FORCE_INLINE_ T get(const Variant *v) {
+		return T(VariantInternalAccessor<S>::get(v));
+	}
+	static _FORCE_INLINE_ void set(Variant *v, const T p_value) {
+		VariantInternalAccessor<S>::get(v) = S(std::move(p_value));
+	}
+};
+
+// Integer types.
+template <typename T>
+struct VariantInternalAccessor<T, std::enable_if_t<std::is_integral_v<T> && !std::is_same_v<T, bool> && !std::is_same_v<T, int64_t>>> : _VariantInternalAccessorConvert<T, int64_t> {};
+template <typename T>
+struct VariantInternalAccessor<T, std::enable_if_t<std::is_enum_v<T>>> : _VariantInternalAccessorConvert<T, int64_t> {};
+template <typename T>
+struct VariantInternalAccessor<BitField<T>, std::enable_if_t<std::is_enum_v<T>>> : _VariantInternalAccessorConvert<BitField<T>, int64_t> {};
+
+template <>
+struct VariantInternalAccessor<ObjectID> : _VariantInternalAccessorConvert<ObjectID, int64_t> {};
+
+// Float types.
+template <>
+struct VariantInternalAccessor<float> : _VariantInternalAccessorConvert<float, double> {};
+
 template <typename T, typename = void>
 struct VariantInitializer {
 	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<T>(v); }
 };
 
 template <typename T>
-struct VariantInitializer<T, std::enable_if_t<VariantGetInternalPtr<T>::is_local>> {
+struct VariantInitializer<T, std::enable_if_t<VariantInternalAccessor<T>::is_local>> {
 	static _FORCE_INLINE_ void init(Variant *v) {
-		memnew_placement(VariantGetInternalPtr<T>::get_ptr(v), T);
+		memnew_placement(&VariantInternalAccessor<T>::get(v), T);
 		VariantInternal::set_type(*v, GetTypeInfo<T>::VARIANT_TYPE);
 	}
 };
@@ -902,7 +865,7 @@ struct VariantDefaultInitializer;
 template <typename T>
 struct VariantDefaultInitializer<T, std::enable_if_t<IsVariantTypeT<T>>> {
 	static _FORCE_INLINE_ void init(Variant *v) {
-		*VariantGetInternalPtr<T>::get_ptr(v) = T();
+		VariantInternalAccessor<T>::get(v) = T();
 	}
 };
 

--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -51,13 +51,13 @@ template <>
 class OperatorEvaluatorMul<Vector2, Vector2i, double> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector2i &a = *VariantGetInternalPtr<Vector2i>::get_ptr(&p_left);
-		const double &b = *VariantGetInternalPtr<double>::get_ptr(&p_right);
+		const Vector2i &a = VariantInternalAccessor<Vector2i>::get(&p_left);
+		const double &b = VariantInternalAccessor<double>::get(&p_right);
 		*r_ret = Vector2(a.x, a.y) * b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<Vector2>::get_ptr(r_ret) = Vector2(VariantGetInternalPtr<Vector2i>::get_ptr(left)->x, VariantGetInternalPtr<Vector2i>::get_ptr(left)->y) * *VariantGetInternalPtr<double>::get_ptr(right);
+		VariantInternalAccessor<Vector2>::get(r_ret) = Vector2(VariantInternalAccessor<Vector2i>::get(left).x, VariantInternalAccessor<Vector2i>::get(left).y) * VariantInternalAccessor<double>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector2>::encode(Vector2(PtrToArg<Vector2i>::convert(left).x, PtrToArg<Vector2i>::convert(left).y) * PtrToArg<double>::convert(right), r_ret);
@@ -69,13 +69,13 @@ template <>
 class OperatorEvaluatorMul<Vector2, double, Vector2i> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector2i &a = *VariantGetInternalPtr<Vector2i>::get_ptr(&p_right);
-		const double &b = *VariantGetInternalPtr<double>::get_ptr(&p_left);
+		const Vector2i &a = VariantInternalAccessor<Vector2i>::get(&p_right);
+		const double &b = VariantInternalAccessor<double>::get(&p_left);
 		*r_ret = Vector2(a.x, a.y) * b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<Vector2>::get_ptr(r_ret) = Vector2(VariantGetInternalPtr<Vector2i>::get_ptr(right)->x, VariantGetInternalPtr<Vector2i>::get_ptr(right)->y) * *VariantGetInternalPtr<double>::get_ptr(left);
+		VariantInternalAccessor<Vector2>::get(r_ret) = Vector2(VariantInternalAccessor<Vector2i>::get(right).x, VariantInternalAccessor<Vector2i>::get(right).y) * VariantInternalAccessor<double>::get(left);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector2>::encode(Vector2(PtrToArg<Vector2i>::convert(right).x, PtrToArg<Vector2i>::convert(right).y) * PtrToArg<double>::convert(left), r_ret);
@@ -87,8 +87,8 @@ template <>
 class OperatorEvaluatorDivNZ<Vector2, Vector2i, double> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector2i &a = *VariantGetInternalPtr<Vector2i>::get_ptr(&p_left);
-		const double &b = *VariantGetInternalPtr<double>::get_ptr(&p_right);
+		const Vector2i &a = VariantInternalAccessor<Vector2i>::get(&p_left);
+		const double &b = VariantInternalAccessor<double>::get(&p_right);
 		if (unlikely(b == 0)) {
 			r_valid = false;
 			*r_ret = "Division by zero error";
@@ -98,7 +98,7 @@ public:
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<Vector2>::get_ptr(r_ret) = Vector2(VariantGetInternalPtr<Vector2i>::get_ptr(left)->x, VariantGetInternalPtr<Vector2i>::get_ptr(left)->y) / *VariantGetInternalPtr<double>::get_ptr(right);
+		VariantInternalAccessor<Vector2>::get(r_ret) = Vector2(VariantInternalAccessor<Vector2i>::get(left).x, VariantInternalAccessor<Vector2i>::get(left).y) / VariantInternalAccessor<double>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector2>::encode(Vector2(PtrToArg<Vector2i>::convert(left).x, PtrToArg<Vector2i>::convert(left).y) / PtrToArg<double>::convert(right), r_ret);
@@ -110,13 +110,13 @@ template <>
 class OperatorEvaluatorMul<Vector3, Vector3i, double> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector3i &a = *VariantGetInternalPtr<Vector3i>::get_ptr(&p_left);
-		const double &b = *VariantGetInternalPtr<double>::get_ptr(&p_right);
+		const Vector3i &a = VariantInternalAccessor<Vector3i>::get(&p_left);
+		const double &b = VariantInternalAccessor<double>::get(&p_right);
 		*r_ret = Vector3(a.x, a.y, a.z) * b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<Vector3>::get_ptr(r_ret) = Vector3(VariantGetInternalPtr<Vector3i>::get_ptr(left)->x, VariantGetInternalPtr<Vector3i>::get_ptr(left)->y, VariantGetInternalPtr<Vector3i>::get_ptr(left)->z) * *VariantGetInternalPtr<double>::get_ptr(right);
+		VariantInternalAccessor<Vector3>::get(r_ret) = Vector3(VariantInternalAccessor<Vector3i>::get(left).x, VariantInternalAccessor<Vector3i>::get(left).y, VariantInternalAccessor<Vector3i>::get(left).z) * VariantInternalAccessor<double>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector3>::encode(Vector3(PtrToArg<Vector3i>::convert(left).x, PtrToArg<Vector3i>::convert(left).y, PtrToArg<Vector3i>::convert(left).z) * PtrToArg<double>::convert(right), r_ret);
@@ -128,13 +128,13 @@ template <>
 class OperatorEvaluatorMul<Vector3, double, Vector3i> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector3i &a = *VariantGetInternalPtr<Vector3i>::get_ptr(&p_right);
-		const double &b = *VariantGetInternalPtr<double>::get_ptr(&p_left);
+		const Vector3i &a = VariantInternalAccessor<Vector3i>::get(&p_right);
+		const double &b = VariantInternalAccessor<double>::get(&p_left);
 		*r_ret = Vector3(a.x, a.y, a.z) * b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<Vector3>::get_ptr(r_ret) = Vector3(VariantGetInternalPtr<Vector3i>::get_ptr(right)->x, VariantGetInternalPtr<Vector3i>::get_ptr(right)->y, VariantGetInternalPtr<Vector3i>::get_ptr(right)->z) * *VariantGetInternalPtr<double>::get_ptr(left);
+		VariantInternalAccessor<Vector3>::get(r_ret) = Vector3(VariantInternalAccessor<Vector3i>::get(right).x, VariantInternalAccessor<Vector3i>::get(right).y, VariantInternalAccessor<Vector3i>::get(right).z) * VariantInternalAccessor<double>::get(left);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector3>::encode(Vector3(PtrToArg<Vector3i>::convert(right).x, PtrToArg<Vector3i>::convert(right).y, PtrToArg<Vector3i>::convert(right).z) * PtrToArg<double>::convert(left), r_ret);
@@ -146,8 +146,8 @@ template <>
 class OperatorEvaluatorDivNZ<Vector3, Vector3i, double> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector3i &a = *VariantGetInternalPtr<Vector3i>::get_ptr(&p_left);
-		const double &b = *VariantGetInternalPtr<double>::get_ptr(&p_right);
+		const Vector3i &a = VariantInternalAccessor<Vector3i>::get(&p_left);
+		const double &b = VariantInternalAccessor<double>::get(&p_right);
 		if (unlikely(b == 0)) {
 			r_valid = false;
 			*r_ret = "Division by zero error";
@@ -157,7 +157,7 @@ public:
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<Vector3>::get_ptr(r_ret) = Vector3(VariantGetInternalPtr<Vector3i>::get_ptr(left)->x, VariantGetInternalPtr<Vector3i>::get_ptr(left)->y, VariantGetInternalPtr<Vector3i>::get_ptr(left)->z) / *VariantGetInternalPtr<double>::get_ptr(right);
+		VariantInternalAccessor<Vector3>::get(r_ret) = Vector3(VariantInternalAccessor<Vector3i>::get(left).x, VariantInternalAccessor<Vector3i>::get(left).y, VariantInternalAccessor<Vector3i>::get(left).z) / VariantInternalAccessor<double>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector3>::encode(Vector3(PtrToArg<Vector3i>::convert(left).x, PtrToArg<Vector3i>::convert(left).y, PtrToArg<Vector3i>::convert(left).z) / PtrToArg<double>::convert(right), r_ret);
@@ -171,13 +171,13 @@ template <>
 class OperatorEvaluatorMul<Vector4, Vector4i, double> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector4i &a = *VariantGetInternalPtr<Vector4i>::get_ptr(&p_left);
-		const double &b = *VariantGetInternalPtr<double>::get_ptr(&p_right);
+		const Vector4i &a = VariantInternalAccessor<Vector4i>::get(&p_left);
+		const double &b = VariantInternalAccessor<double>::get(&p_right);
 		*r_ret = Vector4(a.x, a.y, a.z, a.w) * b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<Vector4>::get_ptr(r_ret) = Vector4(VariantGetInternalPtr<Vector4i>::get_ptr(left)->x, VariantGetInternalPtr<Vector4i>::get_ptr(left)->y, VariantGetInternalPtr<Vector4i>::get_ptr(left)->z, VariantGetInternalPtr<Vector4i>::get_ptr(left)->w) * *VariantGetInternalPtr<double>::get_ptr(right);
+		VariantInternalAccessor<Vector4>::get(r_ret) = Vector4(VariantInternalAccessor<Vector4i>::get(left).x, VariantInternalAccessor<Vector4i>::get(left).y, VariantInternalAccessor<Vector4i>::get(left).z, VariantInternalAccessor<Vector4i>::get(left).w) * VariantInternalAccessor<double>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector4>::encode(Vector4(PtrToArg<Vector4i>::convert(left).x, PtrToArg<Vector4i>::convert(left).y, PtrToArg<Vector4i>::convert(left).z, PtrToArg<Vector4i>::convert(left).w) * PtrToArg<double>::convert(right), r_ret);
@@ -189,13 +189,13 @@ template <>
 class OperatorEvaluatorMul<Vector4, double, Vector4i> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector4i &a = *VariantGetInternalPtr<Vector4i>::get_ptr(&p_right);
-		const double &b = *VariantGetInternalPtr<double>::get_ptr(&p_left);
+		const Vector4i &a = VariantInternalAccessor<Vector4i>::get(&p_right);
+		const double &b = VariantInternalAccessor<double>::get(&p_left);
 		*r_ret = Vector4(a.x, a.y, a.z, a.w) * b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<Vector4>::get_ptr(r_ret) = Vector4(VariantGetInternalPtr<Vector4i>::get_ptr(right)->x, VariantGetInternalPtr<Vector4i>::get_ptr(right)->y, VariantGetInternalPtr<Vector4i>::get_ptr(right)->z, VariantGetInternalPtr<Vector4i>::get_ptr(right)->w) * *VariantGetInternalPtr<double>::get_ptr(left);
+		VariantInternalAccessor<Vector4>::get(r_ret) = Vector4(VariantInternalAccessor<Vector4i>::get(right).x, VariantInternalAccessor<Vector4i>::get(right).y, VariantInternalAccessor<Vector4i>::get(right).z, VariantInternalAccessor<Vector4i>::get(right).w) * VariantInternalAccessor<double>::get(left);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector4>::encode(Vector4(PtrToArg<Vector4i>::convert(right).x, PtrToArg<Vector4i>::convert(right).y, PtrToArg<Vector4i>::convert(right).z, PtrToArg<Vector4i>::convert(right).w) * PtrToArg<double>::convert(left), r_ret);
@@ -207,8 +207,8 @@ template <>
 class OperatorEvaluatorDivNZ<Vector4, Vector4i, double> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector4i &a = *VariantGetInternalPtr<Vector4i>::get_ptr(&p_left);
-		const double &b = *VariantGetInternalPtr<double>::get_ptr(&p_right);
+		const Vector4i &a = VariantInternalAccessor<Vector4i>::get(&p_left);
+		const double &b = VariantInternalAccessor<double>::get(&p_right);
 		if (unlikely(b == 0)) {
 			r_valid = false;
 			*r_ret = "Division by zero error";
@@ -219,7 +219,7 @@ public:
 	}
 
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<Vector4>::get_ptr(r_ret) = Vector4(VariantGetInternalPtr<Vector4i>::get_ptr(left)->x, VariantGetInternalPtr<Vector4i>::get_ptr(left)->y, VariantGetInternalPtr<Vector4i>::get_ptr(left)->z, VariantGetInternalPtr<Vector4i>::get_ptr(left)->w) / *VariantGetInternalPtr<double>::get_ptr(right);
+		VariantInternalAccessor<Vector4>::get(r_ret) = Vector4(VariantInternalAccessor<Vector4i>::get(left).x, VariantInternalAccessor<Vector4i>::get(left).y, VariantInternalAccessor<Vector4i>::get(left).z, VariantInternalAccessor<Vector4i>::get(left).w) / VariantInternalAccessor<double>::get(right);
 	}
 
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
@@ -1166,7 +1166,7 @@ bool Variant::in(const Variant &p_index, bool *r_valid) const {
 	}
 	if (valid) {
 		ERR_FAIL_COND_V(ret.type != BOOL, false);
-		return *VariantGetInternalPtr<bool>::get_ptr(&ret);
+		return VariantInternalAccessor<bool>::get(&ret);
 	} else {
 		return false;
 	}

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -39,13 +39,13 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorAdd {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a + b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) + *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left) + VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) + PtrToArg<B>::convert(right), r_ret);
@@ -57,13 +57,13 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorSub {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a - b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) - *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left) - VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) - PtrToArg<B>::convert(right), r_ret);
@@ -75,13 +75,13 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorMul {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a * b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) * *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left) * VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) * PtrToArg<B>::convert(right), r_ret);
@@ -93,13 +93,13 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorPow {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = R(Math::pow((double)a, (double)b));
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = R(Math::pow((double)*VariantGetInternalPtr<A>::get_ptr(left), (double)*VariantGetInternalPtr<B>::get_ptr(right)));
+		VariantInternalAccessor<R>::get(r_ret) = R(Math::pow((double)VariantInternalAccessor<A>::get(left), (double)VariantInternalAccessor<B>::get(right)));
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(R(Math::pow((double)PtrToArg<A>::convert(left), (double)PtrToArg<B>::convert(right))), r_ret);
@@ -111,13 +111,13 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorXForm {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a.xform(b);
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = VariantGetInternalPtr<A>::get_ptr(left)->xform(*VariantGetInternalPtr<B>::get_ptr(right));
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left).xform(VariantInternalAccessor<B>::get(right));
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left).xform(PtrToArg<B>::convert(right)), r_ret);
@@ -129,13 +129,13 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorXFormInv {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = b.xform_inv(a);
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = VariantGetInternalPtr<B>::get_ptr(right)->xform_inv(*VariantGetInternalPtr<A>::get_ptr(left));
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<B>::get(right).xform_inv(VariantInternalAccessor<A>::get(left));
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<B>::convert(right).xform_inv(PtrToArg<A>::convert(left)), r_ret);
@@ -147,13 +147,13 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorDiv {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a / b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) / *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left) / VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) / PtrToArg<B>::convert(right), r_ret);
@@ -165,8 +165,8 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorDivNZ {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		if (b == 0) {
 			r_valid = false;
 			*r_ret = "Division by zero error";
@@ -176,7 +176,7 @@ public:
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) / *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left) / VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) / PtrToArg<B>::convert(right), r_ret);
@@ -188,8 +188,8 @@ template <>
 class OperatorEvaluatorDivNZ<Vector2i, Vector2i, Vector2i> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector2i &a = *VariantGetInternalPtr<Vector2i>::get_ptr(&p_left);
-		const Vector2i &b = *VariantGetInternalPtr<Vector2i>::get_ptr(&p_right);
+		const Vector2i &a = VariantInternalAccessor<Vector2i>::get(&p_left);
+		const Vector2i &b = VariantInternalAccessor<Vector2i>::get(&p_right);
 		if (unlikely(b.x == 0 || b.y == 0)) {
 			r_valid = false;
 			*r_ret = "Division by zero error";
@@ -200,7 +200,7 @@ public:
 	}
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<Vector2i>::change(r_ret);
-		*VariantGetInternalPtr<Vector2i>::get_ptr(r_ret) = *VariantGetInternalPtr<Vector2i>::get_ptr(left) / *VariantGetInternalPtr<Vector2i>::get_ptr(right);
+		VariantInternalAccessor<Vector2i>::get(r_ret) = VariantInternalAccessor<Vector2i>::get(left) / VariantInternalAccessor<Vector2i>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector2i>::encode(PtrToArg<Vector2i>::convert(left) / PtrToArg<Vector2i>::convert(right), r_ret);
@@ -212,8 +212,8 @@ template <>
 class OperatorEvaluatorDivNZ<Vector3i, Vector3i, Vector3i> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector3i &a = *VariantGetInternalPtr<Vector3i>::get_ptr(&p_left);
-		const Vector3i &b = *VariantGetInternalPtr<Vector3i>::get_ptr(&p_right);
+		const Vector3i &a = VariantInternalAccessor<Vector3i>::get(&p_left);
+		const Vector3i &b = VariantInternalAccessor<Vector3i>::get(&p_right);
 		if (unlikely(b.x == 0 || b.y == 0 || b.z == 0)) {
 			r_valid = false;
 			*r_ret = "Division by zero error";
@@ -224,7 +224,7 @@ public:
 	}
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<Vector3i>::change(r_ret);
-		*VariantGetInternalPtr<Vector3i>::get_ptr(r_ret) = *VariantGetInternalPtr<Vector3i>::get_ptr(left) / *VariantGetInternalPtr<Vector3i>::get_ptr(right);
+		VariantInternalAccessor<Vector3i>::get(r_ret) = VariantInternalAccessor<Vector3i>::get(left) / VariantInternalAccessor<Vector3i>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector3i>::encode(PtrToArg<Vector3i>::convert(left) / PtrToArg<Vector3i>::convert(right), r_ret);
@@ -236,8 +236,8 @@ template <>
 class OperatorEvaluatorDivNZ<Vector4i, Vector4i, Vector4i> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector4i &a = *VariantGetInternalPtr<Vector4i>::get_ptr(&p_left);
-		const Vector4i &b = *VariantGetInternalPtr<Vector4i>::get_ptr(&p_right);
+		const Vector4i &a = VariantInternalAccessor<Vector4i>::get(&p_left);
+		const Vector4i &b = VariantInternalAccessor<Vector4i>::get(&p_right);
 		if (unlikely(b.x == 0 || b.y == 0 || b.z == 0 || b.w == 0)) {
 			r_valid = false;
 			*r_ret = "Division by zero error";
@@ -248,7 +248,7 @@ public:
 	}
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<Vector4i>::change(r_ret);
-		*VariantGetInternalPtr<Vector4i>::get_ptr(r_ret) = *VariantGetInternalPtr<Vector4i>::get_ptr(left) / *VariantGetInternalPtr<Vector4i>::get_ptr(right);
+		VariantInternalAccessor<Vector4i>::get(r_ret) = VariantInternalAccessor<Vector4i>::get(left) / VariantInternalAccessor<Vector4i>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector4i>::encode(PtrToArg<Vector4i>::convert(left) / PtrToArg<Vector4i>::convert(right), r_ret);
@@ -260,13 +260,13 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorMod {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a % b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) % *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left) % VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) % PtrToArg<B>::convert(right), r_ret);
@@ -278,8 +278,8 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorModNZ {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		if (b == 0) {
 			r_valid = false;
 			*r_ret = "Modulo by zero error";
@@ -289,7 +289,7 @@ public:
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) % *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left) % VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) % PtrToArg<B>::convert(right), r_ret);
@@ -301,8 +301,8 @@ template <>
 class OperatorEvaluatorModNZ<Vector2i, Vector2i, Vector2i> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector2i &a = *VariantGetInternalPtr<Vector2i>::get_ptr(&p_left);
-		const Vector2i &b = *VariantGetInternalPtr<Vector2i>::get_ptr(&p_right);
+		const Vector2i &a = VariantInternalAccessor<Vector2i>::get(&p_left);
+		const Vector2i &b = VariantInternalAccessor<Vector2i>::get(&p_right);
 		if (unlikely(b.x == 0 || b.y == 0)) {
 			r_valid = false;
 			*r_ret = "Modulo by zero error";
@@ -313,7 +313,7 @@ public:
 	}
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<Vector2i>::change(r_ret);
-		*VariantGetInternalPtr<Vector2i>::get_ptr(r_ret) = *VariantGetInternalPtr<Vector2i>::get_ptr(left) % *VariantGetInternalPtr<Vector2i>::get_ptr(right);
+		VariantInternalAccessor<Vector2i>::get(r_ret) = VariantInternalAccessor<Vector2i>::get(left) % VariantInternalAccessor<Vector2i>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector2i>::encode(PtrToArg<Vector2i>::convert(left) % PtrToArg<Vector2i>::convert(right), r_ret);
@@ -325,8 +325,8 @@ template <>
 class OperatorEvaluatorModNZ<Vector3i, Vector3i, Vector3i> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector3i &a = *VariantGetInternalPtr<Vector3i>::get_ptr(&p_left);
-		const Vector3i &b = *VariantGetInternalPtr<Vector3i>::get_ptr(&p_right);
+		const Vector3i &a = VariantInternalAccessor<Vector3i>::get(&p_left);
+		const Vector3i &b = VariantInternalAccessor<Vector3i>::get(&p_right);
 		if (unlikely(b.x == 0 || b.y == 0 || b.z == 0)) {
 			r_valid = false;
 			*r_ret = "Modulo by zero error";
@@ -337,7 +337,7 @@ public:
 	}
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<Vector3i>::change(r_ret);
-		*VariantGetInternalPtr<Vector3i>::get_ptr(r_ret) = *VariantGetInternalPtr<Vector3i>::get_ptr(left) % *VariantGetInternalPtr<Vector3i>::get_ptr(right);
+		VariantInternalAccessor<Vector3i>::get(r_ret) = VariantInternalAccessor<Vector3i>::get(left) % VariantInternalAccessor<Vector3i>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector3i>::encode(PtrToArg<Vector3i>::convert(left) % PtrToArg<Vector3i>::convert(right), r_ret);
@@ -349,8 +349,8 @@ template <>
 class OperatorEvaluatorModNZ<Vector4i, Vector4i, Vector4i> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector4i &a = *VariantGetInternalPtr<Vector4i>::get_ptr(&p_left);
-		const Vector4i &b = *VariantGetInternalPtr<Vector4i>::get_ptr(&p_right);
+		const Vector4i &a = VariantInternalAccessor<Vector4i>::get(&p_left);
+		const Vector4i &b = VariantInternalAccessor<Vector4i>::get(&p_right);
 		if (unlikely(b.x == 0 || b.y == 0 || b.z == 0 || b.w == 0)) {
 			r_valid = false;
 			*r_ret = "Modulo by zero error";
@@ -361,7 +361,7 @@ public:
 	}
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<Vector4i>::change(r_ret);
-		*VariantGetInternalPtr<Vector4i>::get_ptr(r_ret) = *VariantGetInternalPtr<Vector4i>::get_ptr(left) % *VariantGetInternalPtr<Vector4i>::get_ptr(right);
+		VariantInternalAccessor<Vector4i>::get(r_ret) = VariantInternalAccessor<Vector4i>::get(left) % VariantInternalAccessor<Vector4i>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<Vector4i>::encode(PtrToArg<Vector4i>::convert(left) % PtrToArg<Vector4i>::convert(right), r_ret);
@@ -373,12 +373,12 @@ template <typename R, typename A>
 class OperatorEvaluatorNeg {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
 		*r_ret = -a;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = -*VariantGetInternalPtr<A>::get_ptr(left);
+		VariantInternalAccessor<R>::get(r_ret) = -VariantInternalAccessor<A>::get(left);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(-PtrToArg<A>::convert(left), r_ret);
@@ -390,12 +390,12 @@ template <typename R, typename A>
 class OperatorEvaluatorPos {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
 		*r_ret = a;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left);
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left), r_ret);
@@ -407,8 +407,8 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorShiftLeft {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 
 #if defined(DEBUG_ENABLED)
 		if (b < 0 || a < 0) {
@@ -421,7 +421,7 @@ public:
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) << *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left) << VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) << PtrToArg<B>::convert(right), r_ret);
@@ -433,8 +433,8 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorShiftRight {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 
 #if defined(DEBUG_ENABLED)
 		if (b < 0 || a < 0) {
@@ -447,7 +447,7 @@ public:
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) >> *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left) >> VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) >> PtrToArg<B>::convert(right), r_ret);
@@ -459,13 +459,13 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorBitOr {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a | b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) | *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left) | VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) | PtrToArg<B>::convert(right), r_ret);
@@ -477,13 +477,13 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorBitAnd {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a & b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) & *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left) & VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) & PtrToArg<B>::convert(right), r_ret);
@@ -495,13 +495,13 @@ template <typename R, typename A, typename B>
 class OperatorEvaluatorBitXor {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a ^ b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) ^ *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(left) ^ VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) ^ PtrToArg<B>::convert(right), r_ret);
@@ -513,12 +513,12 @@ template <typename R, typename A>
 class OperatorEvaluatorBitNeg {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
 		*r_ret = ~a;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<R>::get_ptr(r_ret) = ~*VariantGetInternalPtr<A>::get_ptr(left);
+		VariantInternalAccessor<R>::get(r_ret) = ~VariantInternalAccessor<A>::get(left);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(~PtrToArg<A>::convert(left), r_ret);
@@ -530,13 +530,13 @@ template <typename A, typename B>
 class OperatorEvaluatorEqual {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a == b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) == *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<bool>::get(r_ret) = VariantInternalAccessor<A>::get(left) == VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) == PtrToArg<B>::convert(right), r_ret);
@@ -555,7 +555,7 @@ public:
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		const Object *a = left->get_validated_object();
 		const Object *b = right->get_validated_object();
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = a == b;
+		VariantInternalAccessor<bool>::get(r_ret) = a == b;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Object *>::convert(left) == PtrToArg<Object *>::convert(right), r_ret);
@@ -572,7 +572,7 @@ public:
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		const Object *a = left->get_validated_object();
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = a == nullptr;
+		VariantInternalAccessor<bool>::get(r_ret) = a == nullptr;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Object *>::convert(left) == nullptr, r_ret);
@@ -589,7 +589,7 @@ public:
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		const Object *b = right->get_validated_object();
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = nullptr == b;
+		VariantInternalAccessor<bool>::get(r_ret) = nullptr == b;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(nullptr == PtrToArg<Object *>::convert(right), r_ret);
@@ -601,13 +601,13 @@ template <typename A, typename B>
 class OperatorEvaluatorNotEqual {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a != b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) != *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<bool>::get(r_ret) = VariantInternalAccessor<A>::get(left) != VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) != PtrToArg<B>::convert(right), r_ret);
@@ -626,7 +626,7 @@ public:
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		Object *a = left->get_validated_object();
 		Object *b = right->get_validated_object();
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = a != b;
+		VariantInternalAccessor<bool>::get(r_ret) = a != b;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Object *>::convert(left) != PtrToArg<Object *>::convert(right), r_ret);
@@ -643,7 +643,7 @@ public:
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		Object *a = left->get_validated_object();
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = a != nullptr;
+		VariantInternalAccessor<bool>::get(r_ret) = a != nullptr;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Object *>::convert(left) != nullptr, r_ret);
@@ -660,7 +660,7 @@ public:
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		Object *b = right->get_validated_object();
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = nullptr != b;
+		VariantInternalAccessor<bool>::get(r_ret) = nullptr != b;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(nullptr != PtrToArg<Object *>::convert(right), r_ret);
@@ -672,13 +672,13 @@ template <typename A, typename B>
 class OperatorEvaluatorLess {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a < b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) < *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<bool>::get(r_ret) = VariantInternalAccessor<A>::get(left) < VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) < PtrToArg<B>::convert(right), r_ret);
@@ -690,13 +690,13 @@ template <typename A, typename B>
 class OperatorEvaluatorLessEqual {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a <= b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) <= *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<bool>::get(r_ret) = VariantInternalAccessor<A>::get(left) <= VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) <= PtrToArg<B>::convert(right), r_ret);
@@ -708,13 +708,13 @@ template <typename A, typename B>
 class OperatorEvaluatorGreater {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a > b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) > *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<bool>::get(r_ret) = VariantInternalAccessor<A>::get(left) > VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) > PtrToArg<B>::convert(right), r_ret);
@@ -726,13 +726,13 @@ template <typename A, typename B>
 class OperatorEvaluatorGreaterEqual {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a >= b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) >= *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<bool>::get(r_ret) = VariantInternalAccessor<A>::get(left) >= VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) >= PtrToArg<B>::convert(right), r_ret);
@@ -744,13 +744,13 @@ template <typename A, typename B>
 class OperatorEvaluatorAnd {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a && b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) && *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<bool>::get(r_ret) = VariantInternalAccessor<A>::get(left) && VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) && PtrToArg<B>::convert(right), r_ret);
@@ -762,13 +762,13 @@ template <typename A, typename B>
 class OperatorEvaluatorOr {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = a || b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) || *VariantGetInternalPtr<B>::get_ptr(right);
+		VariantInternalAccessor<bool>::get(r_ret) = VariantInternalAccessor<A>::get(left) || VariantInternalAccessor<B>::get(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) || PtrToArg<B>::convert(right), r_ret);
@@ -784,13 +784,13 @@ public:
 		return ((a) || (b)) && !((a) && (b));
 	}
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 		*r_ret = xor_op(a, b);
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = xor_op(*VariantGetInternalPtr<A>::get_ptr(left), *VariantGetInternalPtr<B>::get_ptr(right));
+		VariantInternalAccessor<bool>::get(r_ret) = xor_op(VariantInternalAccessor<A>::get(left), VariantInternalAccessor<B>::get(right));
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(xor_op(PtrToArg<A>::convert(left), PtrToArg<B>::convert(right)), r_ret);
@@ -802,12 +802,12 @@ template <typename A>
 class OperatorEvaluatorNot {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
 		*r_ret = a == A();
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) == A();
+		VariantInternalAccessor<bool>::get(r_ret) = VariantInternalAccessor<A>::get(left) == A();
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) == A(), r_ret);
@@ -836,8 +836,8 @@ public:
 		}
 	}
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Array &array_a = *VariantGetInternalPtr<Array>::get_ptr(&p_left);
-		const Array &array_b = *VariantGetInternalPtr<Array>::get_ptr(&p_right);
+		const Array &array_a = VariantInternalAccessor<Array>::get(&p_left);
+		const Array &array_b = VariantInternalAccessor<Array>::get(&p_right);
 		Array sum;
 		_add_arrays(sum, array_a, array_b);
 		*r_ret = sum;
@@ -845,7 +845,7 @@ public:
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		*r_ret = Array();
-		_add_arrays(*VariantGetInternalPtr<Array>::get_ptr(r_ret), *VariantGetInternalPtr<Array>::get_ptr(left), *VariantGetInternalPtr<Array>::get_ptr(right));
+		_add_arrays(VariantInternalAccessor<Array>::get(r_ret), VariantInternalAccessor<Array>::get(left), VariantInternalAccessor<Array>::get(right));
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		Array ret;
@@ -859,16 +859,16 @@ template <typename T>
 class OperatorEvaluatorAppendArray {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Vector<T> &array_a = *VariantGetInternalPtr<Vector<T>>::get_ptr(&p_left);
-		const Vector<T> &array_b = *VariantGetInternalPtr<Vector<T>>::get_ptr(&p_right);
+		const Vector<T> &array_a = VariantInternalAccessor<Vector<T>>::get(&p_left);
+		const Vector<T> &array_b = VariantInternalAccessor<Vector<T>>::get(&p_right);
 		Vector<T> sum = array_a;
 		sum.append_array(array_b);
 		*r_ret = sum;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<Vector<T>>::get_ptr(r_ret) = *VariantGetInternalPtr<Vector<T>>::get_ptr(left);
-		VariantGetInternalPtr<Vector<T>>::get_ptr(r_ret)->append_array(*VariantGetInternalPtr<Vector<T>>::get_ptr(right));
+		VariantInternalAccessor<Vector<T>>::get(r_ret) = VariantInternalAccessor<Vector<T>>::get(left);
+		VariantInternalAccessor<Vector<T>>::get(r_ret).append_array(VariantInternalAccessor<Vector<T>>::get(right));
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		Vector<T> sum = PtrToArg<Vector<T>>::convert(left);
@@ -882,15 +882,15 @@ template <typename Left, typename Right>
 class OperatorEvaluatorStringConcat {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const String a(*VariantGetInternalPtr<Left>::get_ptr(&p_left));
-		const String b(*VariantGetInternalPtr<Right>::get_ptr(&p_right));
+		const String a(VariantInternalAccessor<Left>::get(&p_left));
+		const String b(VariantInternalAccessor<Right>::get(&p_right));
 		*r_ret = a + b;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		const String a(*VariantGetInternalPtr<Left>::get_ptr(left));
-		const String b(*VariantGetInternalPtr<Right>::get_ptr(right));
-		*VariantGetInternalPtr<String>::get_ptr(r_ret) = a + b;
+		const String a(VariantInternalAccessor<Left>::get(left));
+		const String b(VariantInternalAccessor<Right>::get(right));
+		VariantInternalAccessor<String>::get(r_ret) = a + b;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		const String a(PtrToArg<Left>::convert(left));
@@ -915,16 +915,16 @@ public:
 		return a;
 	}
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		*r_ret = do_mod(*VariantGetInternalPtr<S>::get_ptr(&p_left), &r_valid);
+		*r_ret = do_mod(VariantInternalAccessor<S>::get(&p_left), &r_valid);
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		bool valid = true;
-		String result = do_mod(*VariantGetInternalPtr<S>::get_ptr(left), &valid);
+		String result = do_mod(VariantInternalAccessor<S>::get(left), &valid);
 		if (unlikely(!valid)) {
-			*VariantGetInternalPtr<String>::get_ptr(r_ret) = *VariantGetInternalPtr<S>::get_ptr(left);
+			VariantInternalAccessor<String>::get(r_ret) = VariantInternalAccessor<S>::get(left);
 			ERR_FAIL_MSG(vformat("String formatting error: %s.", result));
 		}
-		*VariantGetInternalPtr<String>::get_ptr(r_ret) = result;
+		VariantInternalAccessor<String>::get(r_ret) = result;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<String>::encode(do_mod(PtrToArg<S>::convert(left), nullptr), r_ret);
@@ -943,16 +943,16 @@ public:
 		return a;
 	}
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		*r_ret = do_mod(*VariantGetInternalPtr<S>::get_ptr(&p_left), *VariantGetInternalPtr<Array>::get_ptr(&p_right), &r_valid);
+		*r_ret = do_mod(VariantInternalAccessor<S>::get(&p_left), VariantInternalAccessor<Array>::get(&p_right), &r_valid);
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		bool valid = true;
-		String result = do_mod(*VariantGetInternalPtr<S>::get_ptr(left), *VariantGetInternalPtr<Array>::get_ptr(right), &valid);
+		String result = do_mod(VariantInternalAccessor<S>::get(left), VariantInternalAccessor<Array>::get(right), &valid);
 		if (unlikely(!valid)) {
-			*VariantGetInternalPtr<String>::get_ptr(r_ret) = *VariantGetInternalPtr<S>::get_ptr(left);
+			VariantInternalAccessor<String>::get(r_ret) = VariantInternalAccessor<S>::get(left);
 			ERR_FAIL_MSG(vformat("String formatting error: %s.", result));
 		}
-		*VariantGetInternalPtr<String>::get_ptr(r_ret) = result;
+		VariantInternalAccessor<String>::get(r_ret) = result;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<String>::encode(do_mod(PtrToArg<S>::convert(left), PtrToArg<Array>::convert(right), nullptr), r_ret);
@@ -973,16 +973,16 @@ public:
 		return a;
 	}
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		*r_ret = do_mod(*VariantGetInternalPtr<S>::get_ptr(&p_left), p_right.get_validated_object(), &r_valid);
+		*r_ret = do_mod(VariantInternalAccessor<S>::get(&p_left), p_right.get_validated_object(), &r_valid);
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		bool valid = true;
-		String result = do_mod(*VariantGetInternalPtr<S>::get_ptr(left), right->get_validated_object(), &valid);
+		String result = do_mod(VariantInternalAccessor<S>::get(left), right->get_validated_object(), &valid);
 		if (unlikely(!valid)) {
-			*VariantGetInternalPtr<String>::get_ptr(r_ret) = *VariantGetInternalPtr<S>::get_ptr(left);
+			VariantInternalAccessor<String>::get(r_ret) = VariantInternalAccessor<S>::get(left);
 			ERR_FAIL_MSG(vformat("String formatting error: %s.", result));
 		}
-		*VariantGetInternalPtr<String>::get_ptr(r_ret) = result;
+		VariantInternalAccessor<String>::get(r_ret) = result;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<String>::encode(do_mod(PtrToArg<S>::convert(left), PtrToArg<Object *>::convert(right), nullptr), r_ret);
@@ -1002,16 +1002,16 @@ public:
 		return a;
 	}
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		*r_ret = do_mod(*VariantGetInternalPtr<S>::get_ptr(&p_left), *VariantGetInternalPtr<T>::get_ptr(&p_right), &r_valid);
+		*r_ret = do_mod(VariantInternalAccessor<S>::get(&p_left), VariantInternalAccessor<T>::get(&p_right), &r_valid);
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		bool valid = true;
-		String result = do_mod(*VariantGetInternalPtr<S>::get_ptr(left), *VariantGetInternalPtr<T>::get_ptr(right), &valid);
+		String result = do_mod(VariantInternalAccessor<S>::get(left), VariantInternalAccessor<T>::get(right), &valid);
 		if (unlikely(!valid)) {
-			*VariantGetInternalPtr<String>::get_ptr(r_ret) = *VariantGetInternalPtr<S>::get_ptr(left);
+			VariantInternalAccessor<String>::get(r_ret) = VariantInternalAccessor<S>::get(left);
 			ERR_FAIL_MSG(vformat("String formatting error: %s.", result));
 		}
-		*VariantGetInternalPtr<String>::get_ptr(r_ret) = result;
+		VariantInternalAccessor<String>::get(r_ret) = result;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<String>::encode(do_mod(PtrToArg<S>::convert(left), PtrToArg<T>::convert(right), nullptr), r_ret);
@@ -1027,7 +1027,7 @@ public:
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = true;
+		VariantInternalAccessor<bool>::get(r_ret) = true;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(true, r_ret);
@@ -1043,7 +1043,7 @@ public:
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = false;
+		VariantInternalAccessor<bool>::get(r_ret) = false;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(false, r_ret);
@@ -1070,15 +1070,15 @@ _FORCE_INLINE_ static bool _operate_get_nil(const Variant *p_ptr) {
 }
 
 _FORCE_INLINE_ static bool _operate_get_bool(const Variant *p_ptr) {
-	return *VariantGetInternalPtr<bool>::get_ptr(p_ptr);
+	return VariantInternalAccessor<bool>::get(p_ptr);
 }
 
 _FORCE_INLINE_ static bool _operate_get_int(const Variant *p_ptr) {
-	return *VariantGetInternalPtr<int64_t>::get_ptr(p_ptr) != 0;
+	return VariantInternalAccessor<int64_t>::get(p_ptr) != 0;
 }
 
 _FORCE_INLINE_ static bool _operate_get_float(const Variant *p_ptr) {
-	return *VariantGetInternalPtr<double>::get_ptr(p_ptr) != 0.0;
+	return VariantInternalAccessor<double>::get(p_ptr) != 0.0;
 }
 
 _FORCE_INLINE_ static bool _operate_get_object(const Variant *p_ptr) {
@@ -1105,25 +1105,25 @@ _FORCE_INLINE_ static bool _operate_get_ptr_object(const void *p_ptr) {
 	return PtrToArg<Object *>::convert(p_ptr) != nullptr;
 }
 
-#define OP_EVALUATOR(m_class_name, m_left, m_right, m_op)                                                                    \
-	class m_class_name {                                                                                                     \
-	public:                                                                                                                  \
-		static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {                 \
-			*r_ret = m_op(_operate_get_##m_left(&p_left), _operate_get_##m_right(&p_right));                                 \
-			r_valid = true;                                                                                                  \
-		}                                                                                                                    \
-                                                                                                                             \
-		static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {                   \
-			*VariantGetInternalPtr<bool>::get_ptr(r_ret) = m_op(_operate_get_##m_left(left), _operate_get_##m_right(right)); \
-		}                                                                                                                    \
-                                                                                                                             \
-		static void ptr_evaluate(const void *left, const void *right, void *r_ret) {                                         \
-			PtrToArg<bool>::encode(m_op(_operate_get_ptr_##m_left(left), _operate_get_ptr_##m_right(right)), r_ret);         \
-		}                                                                                                                    \
-                                                                                                                             \
-		static Variant::Type get_return_type() {                                                                             \
-			return Variant::BOOL;                                                                                            \
-		}                                                                                                                    \
+#define OP_EVALUATOR(m_class_name, m_left, m_right, m_op)                                                                 \
+	class m_class_name {                                                                                                  \
+	public:                                                                                                               \
+		static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {              \
+			*r_ret = m_op(_operate_get_##m_left(&p_left), _operate_get_##m_right(&p_right));                              \
+			r_valid = true;                                                                                               \
+		}                                                                                                                 \
+                                                                                                                          \
+		static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {                \
+			VariantInternalAccessor<bool>::get(r_ret) = m_op(_operate_get_##m_left(left), _operate_get_##m_right(right)); \
+		}                                                                                                                 \
+                                                                                                                          \
+		static void ptr_evaluate(const void *left, const void *right, void *r_ret) {                                      \
+			PtrToArg<bool>::encode(m_op(_operate_get_ptr_##m_left(left), _operate_get_ptr_##m_right(right)), r_ret);      \
+		}                                                                                                                 \
+                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                          \
+			return Variant::BOOL;                                                                                         \
+		}                                                                                                                 \
 	};
 
 // OR
@@ -1264,11 +1264,11 @@ OP_EVALUATOR(OperatorEvaluatorObjectXObjectXor, object, object, _operate_xor)
 class OperatorEvaluatorNotBool {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		*r_ret = !*VariantGetInternalPtr<bool>::get_ptr(&p_left);
+		*r_ret = !VariantInternalAccessor<bool>::get(&p_left);
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = !*VariantGetInternalPtr<bool>::get_ptr(left);
+		VariantInternalAccessor<bool>::get(r_ret) = !VariantInternalAccessor<bool>::get(left);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(!PtrToArg<bool>::convert(left), r_ret);
@@ -1279,11 +1279,11 @@ public:
 class OperatorEvaluatorNotInt {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		*r_ret = !*VariantGetInternalPtr<int64_t>::get_ptr(&p_left);
+		*r_ret = !VariantInternalAccessor<int64_t>::get(&p_left);
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = !*VariantGetInternalPtr<int64_t>::get_ptr(left);
+		VariantInternalAccessor<bool>::get(r_ret) = !VariantInternalAccessor<int64_t>::get(left);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(!PtrToArg<int64_t>::convert(left), r_ret);
@@ -1294,11 +1294,11 @@ public:
 class OperatorEvaluatorNotFloat {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		*r_ret = !*VariantGetInternalPtr<double>::get_ptr(&p_left);
+		*r_ret = !VariantInternalAccessor<double>::get(&p_left);
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = !*VariantGetInternalPtr<double>::get_ptr(left);
+		VariantInternalAccessor<bool>::get(r_ret) = !VariantInternalAccessor<double>::get(left);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(!PtrToArg<double>::convert(left), r_ret);
@@ -1313,7 +1313,7 @@ public:
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = left->get_validated_object() == nullptr;
+		VariantInternalAccessor<bool>::get(r_ret) = left->get_validated_object() == nullptr;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Object *>::convert(left) == nullptr, r_ret);
@@ -1330,16 +1330,16 @@ template <typename Left>
 class OperatorEvaluatorInStringFind<Left, String> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Left &str_a = *VariantGetInternalPtr<Left>::get_ptr(&p_left);
-		const String &str_b = *VariantGetInternalPtr<String>::get_ptr(&p_right);
+		const Left &str_a = VariantInternalAccessor<Left>::get(&p_left);
+		const String &str_b = VariantInternalAccessor<String>::get(&p_right);
 
 		*r_ret = str_b.find(str_a) != -1;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		const Left &str_a = *VariantGetInternalPtr<Left>::get_ptr(left);
-		const String &str_b = *VariantGetInternalPtr<String>::get_ptr(right);
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = str_b.find(str_a) != -1;
+		const Left &str_a = VariantInternalAccessor<Left>::get(left);
+		const String &str_b = VariantInternalAccessor<String>::get(right);
+		VariantInternalAccessor<bool>::get(r_ret) = str_b.find(str_a) != -1;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<String>::convert(right).find(PtrToArg<Left>::convert(left)) != -1, r_ret);
@@ -1351,16 +1351,16 @@ template <typename Left>
 class OperatorEvaluatorInStringFind<Left, StringName> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Left &str_a = *VariantGetInternalPtr<Left>::get_ptr(&p_left);
-		const String str_b = VariantGetInternalPtr<StringName>::get_ptr(&p_right)->operator String();
+		const Left &str_a = VariantInternalAccessor<Left>::get(&p_left);
+		const String str_b = VariantInternalAccessor<StringName>::get(&p_right).operator String();
 
 		*r_ret = str_b.find(str_a) != -1;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		const Left &str_a = *VariantGetInternalPtr<Left>::get_ptr(left);
-		const String str_b = VariantGetInternalPtr<StringName>::get_ptr(right)->operator String();
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = str_b.find(str_a) != -1;
+		const Left &str_a = VariantInternalAccessor<Left>::get(left);
+		const String str_b = VariantInternalAccessor<StringName>::get(right).operator String();
+		VariantInternalAccessor<bool>::get(r_ret) = str_b.find(str_a) != -1;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<StringName>::convert(right).operator String().find(PtrToArg<Left>::convert(left)) != -1, r_ret);
@@ -1372,16 +1372,16 @@ template <typename A, typename B>
 class OperatorEvaluatorInArrayFind {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
+		const B &b = VariantInternalAccessor<B>::get(&p_right);
 
 		*r_ret = b.find(a) != -1;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(left);
-		const B &b = *VariantGetInternalPtr<B>::get_ptr(right);
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = b.find(a) != -1;
+		const A &a = VariantInternalAccessor<A>::get(left);
+		const B &b = VariantInternalAccessor<B>::get(right);
+		VariantInternalAccessor<bool>::get(r_ret) = b.find(a) != -1;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<B>::convert(right).find(PtrToArg<A>::convert(left)) != -1, r_ret);
@@ -1392,13 +1392,13 @@ public:
 class OperatorEvaluatorInArrayFindNil {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Array &b = *VariantGetInternalPtr<Array>::get_ptr(&p_right);
+		const Array &b = VariantInternalAccessor<Array>::get(&p_right);
 		*r_ret = b.find(Variant()) != -1;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		const Array &b = *VariantGetInternalPtr<Array>::get_ptr(right);
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = b.find(Variant()) != -1;
+		const Array &b = VariantInternalAccessor<Array>::get(right);
+		VariantInternalAccessor<bool>::get(r_ret) = b.find(Variant()) != -1;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Array>::convert(right).find(Variant()) != -1, r_ret);
@@ -1409,13 +1409,13 @@ public:
 class OperatorEvaluatorInArrayFindObject {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Array &b = *VariantGetInternalPtr<Array>::get_ptr(&p_right);
+		const Array &b = VariantInternalAccessor<Array>::get(&p_right);
 		*r_ret = b.find(p_left) != -1;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		const Array &b = *VariantGetInternalPtr<Array>::get_ptr(right);
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = b.find(*left) != -1;
+		const Array &b = VariantInternalAccessor<Array>::get(right);
+		VariantInternalAccessor<bool>::get(r_ret) = b.find(*left) != -1;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Array>::convert(right).find(PtrToArg<Object *>::convert(left)) != -1, r_ret);
@@ -1427,16 +1427,16 @@ template <typename A>
 class OperatorEvaluatorInDictionaryHas {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Dictionary &b = *VariantGetInternalPtr<Dictionary>::get_ptr(&p_right);
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
+		const Dictionary &b = VariantInternalAccessor<Dictionary>::get(&p_right);
+		const A &a = VariantInternalAccessor<A>::get(&p_left);
 
 		*r_ret = b.has(a);
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		const Dictionary &b = *VariantGetInternalPtr<Dictionary>::get_ptr(right);
-		const A &a = *VariantGetInternalPtr<A>::get_ptr(left);
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = b.has(a);
+		const Dictionary &b = VariantInternalAccessor<Dictionary>::get(right);
+		const A &a = VariantInternalAccessor<A>::get(left);
+		VariantInternalAccessor<bool>::get(r_ret) = b.has(a);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Dictionary>::convert(right).has(PtrToArg<A>::convert(left)), r_ret);
@@ -1447,14 +1447,14 @@ public:
 class OperatorEvaluatorInDictionaryHasNil {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Dictionary &b = *VariantGetInternalPtr<Dictionary>::get_ptr(&p_right);
+		const Dictionary &b = VariantInternalAccessor<Dictionary>::get(&p_right);
 
 		*r_ret = b.has(Variant());
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		const Dictionary &b = *VariantGetInternalPtr<Dictionary>::get_ptr(right);
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = b.has(Variant());
+		const Dictionary &b = VariantInternalAccessor<Dictionary>::get(right);
+		VariantInternalAccessor<bool>::get(r_ret) = b.has(Variant());
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Dictionary>::convert(right).has(Variant()), r_ret);
@@ -1465,14 +1465,14 @@ public:
 class OperatorEvaluatorInDictionaryHasObject {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
-		const Dictionary &b = *VariantGetInternalPtr<Dictionary>::get_ptr(&p_right);
+		const Dictionary &b = VariantInternalAccessor<Dictionary>::get(&p_right);
 
 		*r_ret = b.has(p_left);
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		const Dictionary &b = *VariantGetInternalPtr<Dictionary>::get_ptr(right);
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = b.has(*left);
+		const Dictionary &b = VariantInternalAccessor<Dictionary>::get(right);
+		VariantInternalAccessor<bool>::get(r_ret) = b.has(*left);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Dictionary>::convert(right).has(PtrToArg<Object *>::convert(left)), r_ret);
@@ -1490,7 +1490,7 @@ public:
 			return;
 		}
 
-		const String &a = *VariantGetInternalPtr<String>::get_ptr(&p_left);
+		const String &a = VariantInternalAccessor<String>::get(&p_left);
 
 		bool exist;
 		b->get(a, &exist);
@@ -1500,14 +1500,14 @@ public:
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		Object *l = right->get_validated_object();
 		if (unlikely(!l)) {
-			*VariantGetInternalPtr<bool>::get_ptr(r_ret) = false;
+			VariantInternalAccessor<bool>::get(r_ret) = false;
 			ERR_FAIL_MSG("Invalid base object for 'in'.");
 		}
-		const String &a = *VariantGetInternalPtr<String>::get_ptr(left);
+		const String &a = VariantInternalAccessor<String>::get(left);
 
 		bool valid;
 		l->get(a, &valid);
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = valid;
+		VariantInternalAccessor<bool>::get(r_ret) = valid;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		bool valid;
@@ -1527,7 +1527,7 @@ public:
 			return;
 		}
 
-		const StringName &a = *VariantGetInternalPtr<StringName>::get_ptr(&p_left);
+		const StringName &a = VariantInternalAccessor<StringName>::get(&p_left);
 
 		bool exist;
 		b->get(a, &exist);
@@ -1537,14 +1537,14 @@ public:
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		Object *l = right->get_validated_object();
 		if (unlikely(!l)) {
-			*VariantGetInternalPtr<bool>::get_ptr(r_ret) = false;
+			VariantInternalAccessor<bool>::get(r_ret) = false;
 			ERR_FAIL_MSG("Invalid base object for 'in'.");
 		}
-		const StringName &a = *VariantGetInternalPtr<StringName>::get_ptr(left);
+		const StringName &a = VariantInternalAccessor<StringName>::get(left);
 
 		bool valid;
 		l->get(a, &valid);
-		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = valid;
+		VariantInternalAccessor<bool>::get(r_ret) = valid;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		bool valid;

--- a/core/variant/variant_setget.h
+++ b/core/variant/variant_setget.h
@@ -38,244 +38,244 @@
 
 /**** NAMED SETTERS AND GETTERS ****/
 
-#define SETGET_STRUCT(m_base_type, m_member_type, m_member)                                                                          \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                                \
-		static void get(const Variant *base, Variant *member) {                                                                      \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                                        \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member;    \
-		}                                                                                                                            \
-		static inline void validated_get(const Variant *base, Variant *member) {                                                     \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member;    \
-		}                                                                                                                            \
-		static void ptr_get(const void *base, void *member) {                                                                        \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_member, member);                                  \
-		}                                                                                                                            \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                          \
-			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) {                                                     \
-				VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member = *VariantGetInternalPtr<m_member_type>::get_ptr(value); \
-				valid = true;                                                                                                        \
-			} else {                                                                                                                 \
-				valid = false;                                                                                                       \
-			}                                                                                                                        \
-		}                                                                                                                            \
-		static inline void validated_set(Variant *base, const Variant *value) {                                                      \
-			VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member = *VariantGetInternalPtr<m_member_type>::get_ptr(value);     \
-		}                                                                                                                            \
-		static void ptr_set(void *base, const void *member) {                                                                        \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                                    \
-			b.m_member = PtrToArg<m_member_type>::convert(member);                                                                   \
-			PtrToArg<m_base_type>::encode(b, base);                                                                                  \
-		}                                                                                                                            \
-		static Variant::Type get_type() {                                                                                            \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                         \
-		}                                                                                                                            \
+#define SETGET_STRUCT(m_base_type, m_member_type, m_member)                                                                    \
+	struct VariantSetGet_##m_base_type##_##m_member {                                                                          \
+		static void get(const Variant *base, Variant *member) {                                                                \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                                  \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_member;    \
+		}                                                                                                                      \
+		static inline void validated_get(const Variant *base, Variant *member) {                                               \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_member;    \
+		}                                                                                                                      \
+		static void ptr_get(const void *base, void *member) {                                                                  \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_member, member);                            \
+		}                                                                                                                      \
+		static void set(Variant *base, const Variant *value, bool &valid) {                                                    \
+			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) {                                               \
+				VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<m_member_type>::get(value); \
+				valid = true;                                                                                                  \
+			} else {                                                                                                           \
+				valid = false;                                                                                                 \
+			}                                                                                                                  \
+		}                                                                                                                      \
+		static inline void validated_set(Variant *base, const Variant *value) {                                                \
+			VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<m_member_type>::get(value);     \
+		}                                                                                                                      \
+		static void ptr_set(void *base, const void *member) {                                                                  \
+			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                              \
+			b.m_member = PtrToArg<m_member_type>::convert(member);                                                             \
+			PtrToArg<m_base_type>::encode(b, base);                                                                            \
+		}                                                                                                                      \
+		static Variant::Type get_type() {                                                                                      \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                   \
+		}                                                                                                                      \
 	};
 
-#define SETGET_NUMBER_STRUCT(m_base_type, m_member_type, m_member)                                                                \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                             \
-		static void get(const Variant *base, Variant *member) {                                                                   \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                                     \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member; \
-		}                                                                                                                         \
-		static inline void validated_get(const Variant *base, Variant *member) {                                                  \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member; \
-		}                                                                                                                         \
-		static void ptr_get(const void *base, void *member) {                                                                     \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_member, member);                               \
-		}                                                                                                                         \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                       \
-			if (value->get_type() == Variant::FLOAT) {                                                                            \
-				VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member = *VariantGetInternalPtr<double>::get_ptr(value);     \
-				valid = true;                                                                                                     \
-			} else if (value->get_type() == Variant::INT) {                                                                       \
-				VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member = *VariantGetInternalPtr<int64_t>::get_ptr(value);    \
-				valid = true;                                                                                                     \
-			} else {                                                                                                              \
-				valid = false;                                                                                                    \
-			}                                                                                                                     \
-		}                                                                                                                         \
-		static inline void validated_set(Variant *base, const Variant *value) {                                                   \
-			VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member = *VariantGetInternalPtr<m_member_type>::get_ptr(value);  \
-		}                                                                                                                         \
-		static void ptr_set(void *base, const void *member) {                                                                     \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                                 \
-			b.m_member = PtrToArg<m_member_type>::convert(member);                                                                \
-			PtrToArg<m_base_type>::encode(b, base);                                                                               \
-		}                                                                                                                         \
-		static Variant::Type get_type() {                                                                                         \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                      \
-		}                                                                                                                         \
+#define SETGET_NUMBER_STRUCT(m_base_type, m_member_type, m_member)                                                          \
+	struct VariantSetGet_##m_base_type##_##m_member {                                                                       \
+		static void get(const Variant *base, Variant *member) {                                                             \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                               \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_member; \
+		}                                                                                                                   \
+		static inline void validated_get(const Variant *base, Variant *member) {                                            \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_member; \
+		}                                                                                                                   \
+		static void ptr_get(const void *base, void *member) {                                                               \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_member, member);                         \
+		}                                                                                                                   \
+		static void set(Variant *base, const Variant *value, bool &valid) {                                                 \
+			if (value->get_type() == Variant::FLOAT) {                                                                      \
+				VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<double>::get(value);     \
+				valid = true;                                                                                               \
+			} else if (value->get_type() == Variant::INT) {                                                                 \
+				VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<int64_t>::get(value);    \
+				valid = true;                                                                                               \
+			} else {                                                                                                        \
+				valid = false;                                                                                              \
+			}                                                                                                               \
+		}                                                                                                                   \
+		static inline void validated_set(Variant *base, const Variant *value) {                                             \
+			VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<m_member_type>::get(value);  \
+		}                                                                                                                   \
+		static void ptr_set(void *base, const void *member) {                                                               \
+			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                           \
+			b.m_member = PtrToArg<m_member_type>::convert(member);                                                          \
+			PtrToArg<m_base_type>::encode(b, base);                                                                         \
+		}                                                                                                                   \
+		static Variant::Type get_type() {                                                                                   \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                \
+		}                                                                                                                   \
 	};
 
-#define SETGET_STRUCT_CUSTOM(m_base_type, m_member_type, m_member, m_custom)                                                         \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                                \
-		static void get(const Variant *base, Variant *member) {                                                                      \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                                        \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom;    \
-		}                                                                                                                            \
-		static inline void validated_get(const Variant *base, Variant *member) {                                                     \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom;    \
-		}                                                                                                                            \
-		static void ptr_get(const void *base, void *member) {                                                                        \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_custom, member);                                  \
-		}                                                                                                                            \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                          \
-			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) {                                                     \
-				VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom = *VariantGetInternalPtr<m_member_type>::get_ptr(value); \
-				valid = true;                                                                                                        \
-			} else {                                                                                                                 \
-				valid = false;                                                                                                       \
-			}                                                                                                                        \
-		}                                                                                                                            \
-		static inline void validated_set(Variant *base, const Variant *value) {                                                      \
-			VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom = *VariantGetInternalPtr<m_member_type>::get_ptr(value);     \
-		}                                                                                                                            \
-		static void ptr_set(void *base, const void *member) {                                                                        \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                                    \
-			b.m_custom = PtrToArg<m_member_type>::convert(member);                                                                   \
-			PtrToArg<m_base_type>::encode(b, base);                                                                                  \
-		}                                                                                                                            \
-		static Variant::Type get_type() {                                                                                            \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                         \
-		}                                                                                                                            \
+#define SETGET_STRUCT_CUSTOM(m_base_type, m_member_type, m_member, m_custom)                                                   \
+	struct VariantSetGet_##m_base_type##_##m_member {                                                                          \
+		static void get(const Variant *base, Variant *member) {                                                                \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                                  \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_custom;    \
+		}                                                                                                                      \
+		static inline void validated_get(const Variant *base, Variant *member) {                                               \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_custom;    \
+		}                                                                                                                      \
+		static void ptr_get(const void *base, void *member) {                                                                  \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_custom, member);                            \
+		}                                                                                                                      \
+		static void set(Variant *base, const Variant *value, bool &valid) {                                                    \
+			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) {                                               \
+				VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<m_member_type>::get(value); \
+				valid = true;                                                                                                  \
+			} else {                                                                                                           \
+				valid = false;                                                                                                 \
+			}                                                                                                                  \
+		}                                                                                                                      \
+		static inline void validated_set(Variant *base, const Variant *value) {                                                \
+			VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<m_member_type>::get(value);     \
+		}                                                                                                                      \
+		static void ptr_set(void *base, const void *member) {                                                                  \
+			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                              \
+			b.m_custom = PtrToArg<m_member_type>::convert(member);                                                             \
+			PtrToArg<m_base_type>::encode(b, base);                                                                            \
+		}                                                                                                                      \
+		static Variant::Type get_type() {                                                                                      \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                   \
+		}                                                                                                                      \
 	};
 
-#define SETGET_NUMBER_STRUCT_CUSTOM(m_base_type, m_member_type, m_member, m_custom)                                               \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                             \
-		static void get(const Variant *base, Variant *member) {                                                                   \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                                     \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom; \
-		}                                                                                                                         \
-		static inline void validated_get(const Variant *base, Variant *member) {                                                  \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom; \
-		}                                                                                                                         \
-		static void ptr_get(const void *base, void *member) {                                                                     \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_custom, member);                               \
-		}                                                                                                                         \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                       \
-			if (value->get_type() == Variant::FLOAT) {                                                                            \
-				VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom = *VariantGetInternalPtr<double>::get_ptr(value);     \
-				valid = true;                                                                                                     \
-			} else if (value->get_type() == Variant::INT) {                                                                       \
-				VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom = *VariantGetInternalPtr<int64_t>::get_ptr(value);    \
-				valid = true;                                                                                                     \
-			} else {                                                                                                              \
-				valid = false;                                                                                                    \
-			}                                                                                                                     \
-		}                                                                                                                         \
-		static inline void validated_set(Variant *base, const Variant *value) {                                                   \
-			VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom = *VariantGetInternalPtr<m_member_type>::get_ptr(value);  \
-		}                                                                                                                         \
-		static void ptr_set(void *base, const void *member) {                                                                     \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                                 \
-			b.m_custom = PtrToArg<m_member_type>::convert(member);                                                                \
-			PtrToArg<m_base_type>::encode(b, base);                                                                               \
-		}                                                                                                                         \
-		static Variant::Type get_type() {                                                                                         \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                      \
-		}                                                                                                                         \
+#define SETGET_NUMBER_STRUCT_CUSTOM(m_base_type, m_member_type, m_member, m_custom)                                         \
+	struct VariantSetGet_##m_base_type##_##m_member {                                                                       \
+		static void get(const Variant *base, Variant *member) {                                                             \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                               \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_custom; \
+		}                                                                                                                   \
+		static inline void validated_get(const Variant *base, Variant *member) {                                            \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_custom; \
+		}                                                                                                                   \
+		static void ptr_get(const void *base, void *member) {                                                               \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_custom, member);                         \
+		}                                                                                                                   \
+		static void set(Variant *base, const Variant *value, bool &valid) {                                                 \
+			if (value->get_type() == Variant::FLOAT) {                                                                      \
+				VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<double>::get(value);     \
+				valid = true;                                                                                               \
+			} else if (value->get_type() == Variant::INT) {                                                                 \
+				VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<int64_t>::get(value);    \
+				valid = true;                                                                                               \
+			} else {                                                                                                        \
+				valid = false;                                                                                              \
+			}                                                                                                               \
+		}                                                                                                                   \
+		static inline void validated_set(Variant *base, const Variant *value) {                                             \
+			VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<m_member_type>::get(value);  \
+		}                                                                                                                   \
+		static void ptr_set(void *base, const void *member) {                                                               \
+			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                           \
+			b.m_custom = PtrToArg<m_member_type>::convert(member);                                                          \
+			PtrToArg<m_base_type>::encode(b, base);                                                                         \
+		}                                                                                                                   \
+		static Variant::Type get_type() {                                                                                   \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                \
+		}                                                                                                                   \
 	};
 
-#define SETGET_STRUCT_FUNC(m_base_type, m_member_type, m_member, m_setter, m_getter)                                                \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                               \
-		static void get(const Variant *base, Variant *member) {                                                                     \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                                       \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(); \
-		}                                                                                                                           \
-		static inline void validated_get(const Variant *base, Variant *member) {                                                    \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(); \
-		}                                                                                                                           \
-		static void ptr_get(const void *base, void *member) {                                                                       \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_getter(), member);                               \
-		}                                                                                                                           \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                         \
-			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) {                                                    \
-				VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_setter(*VariantGetInternalPtr<m_member_type>::get_ptr(value)); \
-				valid = true;                                                                                                       \
-			} else {                                                                                                                \
-				valid = false;                                                                                                      \
-			}                                                                                                                       \
-		}                                                                                                                           \
-		static inline void validated_set(Variant *base, const Variant *value) {                                                     \
-			VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_setter(*VariantGetInternalPtr<m_member_type>::get_ptr(value));     \
-		}                                                                                                                           \
-		static void ptr_set(void *base, const void *member) {                                                                       \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                                   \
-			b.m_setter(PtrToArg<m_member_type>::convert(member));                                                                   \
-			PtrToArg<m_base_type>::encode(b, base);                                                                                 \
-		}                                                                                                                           \
-		static Variant::Type get_type() {                                                                                           \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                        \
-		}                                                                                                                           \
+#define SETGET_STRUCT_FUNC(m_base_type, m_member_type, m_member, m_setter, m_getter)                                          \
+	struct VariantSetGet_##m_base_type##_##m_member {                                                                         \
+		static void get(const Variant *base, Variant *member) {                                                               \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                                 \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(); \
+		}                                                                                                                     \
+		static inline void validated_get(const Variant *base, Variant *member) {                                              \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(); \
+		}                                                                                                                     \
+		static void ptr_get(const void *base, void *member) {                                                                 \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_getter(), member);                         \
+		}                                                                                                                     \
+		static void set(Variant *base, const Variant *value, bool &valid) {                                                   \
+			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) {                                              \
+				VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<m_member_type>::get(value)); \
+				valid = true;                                                                                                 \
+			} else {                                                                                                          \
+				valid = false;                                                                                                \
+			}                                                                                                                 \
+		}                                                                                                                     \
+		static inline void validated_set(Variant *base, const Variant *value) {                                               \
+			VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<m_member_type>::get(value));     \
+		}                                                                                                                     \
+		static void ptr_set(void *base, const void *member) {                                                                 \
+			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                             \
+			b.m_setter(PtrToArg<m_member_type>::convert(member));                                                             \
+			PtrToArg<m_base_type>::encode(b, base);                                                                           \
+		}                                                                                                                     \
+		static Variant::Type get_type() {                                                                                     \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                  \
+		}                                                                                                                     \
 	};
 
-#define SETGET_NUMBER_STRUCT_FUNC(m_base_type, m_member_type, m_member, m_setter, m_getter)                                         \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                               \
-		static void get(const Variant *base, Variant *member) {                                                                     \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                                       \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(); \
-		}                                                                                                                           \
-		static inline void validated_get(const Variant *base, Variant *member) {                                                    \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(); \
-		}                                                                                                                           \
-		static void ptr_get(const void *base, void *member) {                                                                       \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_getter(), member);                               \
-		}                                                                                                                           \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                         \
-			if (value->get_type() == Variant::FLOAT) {                                                                              \
-				VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_setter(*VariantGetInternalPtr<double>::get_ptr(value));        \
-				valid = true;                                                                                                       \
-			} else if (value->get_type() == Variant::INT) {                                                                         \
-				VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_setter(*VariantGetInternalPtr<int64_t>::get_ptr(value));       \
-				valid = true;                                                                                                       \
-			} else {                                                                                                                \
-				valid = false;                                                                                                      \
-			}                                                                                                                       \
-		}                                                                                                                           \
-		static inline void validated_set(Variant *base, const Variant *value) {                                                     \
-			VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_setter(*VariantGetInternalPtr<m_member_type>::get_ptr(value));     \
-		}                                                                                                                           \
-		static void ptr_set(void *base, const void *member) {                                                                       \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                                   \
-			b.m_setter(PtrToArg<m_member_type>::convert(member));                                                                   \
-			PtrToArg<m_base_type>::encode(b, base);                                                                                 \
-		}                                                                                                                           \
-		static Variant::Type get_type() {                                                                                           \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                        \
-		}                                                                                                                           \
+#define SETGET_NUMBER_STRUCT_FUNC(m_base_type, m_member_type, m_member, m_setter, m_getter)                                   \
+	struct VariantSetGet_##m_base_type##_##m_member {                                                                         \
+		static void get(const Variant *base, Variant *member) {                                                               \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                                 \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(); \
+		}                                                                                                                     \
+		static inline void validated_get(const Variant *base, Variant *member) {                                              \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(); \
+		}                                                                                                                     \
+		static void ptr_get(const void *base, void *member) {                                                                 \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_getter(), member);                         \
+		}                                                                                                                     \
+		static void set(Variant *base, const Variant *value, bool &valid) {                                                   \
+			if (value->get_type() == Variant::FLOAT) {                                                                        \
+				VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<double>::get(value));        \
+				valid = true;                                                                                                 \
+			} else if (value->get_type() == Variant::INT) {                                                                   \
+				VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<int64_t>::get(value));       \
+				valid = true;                                                                                                 \
+			} else {                                                                                                          \
+				valid = false;                                                                                                \
+			}                                                                                                                 \
+		}                                                                                                                     \
+		static inline void validated_set(Variant *base, const Variant *value) {                                               \
+			VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<m_member_type>::get(value));     \
+		}                                                                                                                     \
+		static void ptr_set(void *base, const void *member) {                                                                 \
+			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                             \
+			b.m_setter(PtrToArg<m_member_type>::convert(member));                                                             \
+			PtrToArg<m_base_type>::encode(b, base);                                                                           \
+		}                                                                                                                     \
+		static Variant::Type get_type() {                                                                                     \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                  \
+		}                                                                                                                     \
 	};
 
-#define SETGET_STRUCT_FUNC_INDEX(m_base_type, m_member_type, m_member, m_setter, m_getter, m_index)                                          \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                                        \
-		static void get(const Variant *base, Variant *member) {                                                                              \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                                                \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(m_index);   \
-		}                                                                                                                                    \
-		static inline void validated_get(const Variant *base, Variant *member) {                                                             \
-			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(m_index);   \
-		}                                                                                                                                    \
-		static void ptr_get(const void *base, void *member) {                                                                                \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_getter(m_index), member);                                 \
-		}                                                                                                                                    \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                                  \
-			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) {                                                             \
-				VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_setter(m_index, *VariantGetInternalPtr<m_member_type>::get_ptr(value)); \
-				valid = true;                                                                                                                \
-			} else {                                                                                                                         \
-				valid = false;                                                                                                               \
-			}                                                                                                                                \
-		}                                                                                                                                    \
-		static inline void validated_set(Variant *base, const Variant *value) {                                                              \
-			VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_setter(m_index, *VariantGetInternalPtr<m_member_type>::get_ptr(value));     \
-		}                                                                                                                                    \
-		static void ptr_set(void *base, const void *member) {                                                                                \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                                            \
-			b.m_setter(m_index, PtrToArg<m_member_type>::convert(member));                                                                   \
-			PtrToArg<m_base_type>::encode(b, base);                                                                                          \
-		}                                                                                                                                    \
-		static Variant::Type get_type() {                                                                                                    \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                                 \
-		}                                                                                                                                    \
+#define SETGET_STRUCT_FUNC_INDEX(m_base_type, m_member_type, m_member, m_setter, m_getter, m_index)                                    \
+	struct VariantSetGet_##m_base_type##_##m_member {                                                                                  \
+		static void get(const Variant *base, Variant *member) {                                                                        \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                                          \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(m_index);   \
+		}                                                                                                                              \
+		static inline void validated_get(const Variant *base, Variant *member) {                                                       \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(m_index);   \
+		}                                                                                                                              \
+		static void ptr_get(const void *base, void *member) {                                                                          \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_getter(m_index), member);                           \
+		}                                                                                                                              \
+		static void set(Variant *base, const Variant *value, bool &valid) {                                                            \
+			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) {                                                       \
+				VariantInternalAccessor<m_base_type>::get(base).m_setter(m_index, VariantInternalAccessor<m_member_type>::get(value)); \
+				valid = true;                                                                                                          \
+			} else {                                                                                                                   \
+				valid = false;                                                                                                         \
+			}                                                                                                                          \
+		}                                                                                                                              \
+		static inline void validated_set(Variant *base, const Variant *value) {                                                        \
+			VariantInternalAccessor<m_base_type>::get(base).m_setter(m_index, VariantInternalAccessor<m_member_type>::get(value));     \
+		}                                                                                                                              \
+		static void ptr_set(void *base, const void *member) {                                                                          \
+			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                                      \
+			b.m_setter(m_index, PtrToArg<m_member_type>::convert(member));                                                             \
+			PtrToArg<m_base_type>::encode(b, base);                                                                                    \
+		}                                                                                                                              \
+		static Variant::Type get_type() {                                                                                              \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                           \
+		}                                                                                                                              \
 	};
 
 SETGET_NUMBER_STRUCT(Vector2, double, x)

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -4726,8 +4726,8 @@ Variant ShaderLanguage::get_default_datatype_value(DataType p_type, int p_array_
 				}
 				value = Variant(array);
 			} else {
-				VariantInitializer<float>::init(&value);
-				VariantDefaultInitializer<float>::init(&value);
+				VariantInitializer<double>::init(&value);
+				VariantDefaultInitializer<double>::init(&value);
 			}
 			break;
 		case ShaderLanguage::TYPE_VEC2:


### PR DESCRIPTION
Includes / supersedes #105246.
I recommend looking briefly at the above PR, but merging this one (without merging the above first), because it ultimately creates the better end picture.

## Explanation
`VariantGetInternalPtr`, `VariantImplicitConvert` (introduced temporarily in #105246) and `VariantInternalAccessor` do pretty much the same thing: They allow users to get values and assign values when working with `Variant`, when the underlying type is known to match.

Having 3 types for the same task is not a great idea, because code will diverge. In this PR, I am deduplicating functionality by deleting `VariantGetInternalPtr` and `VariantImplicitConvert`, and merely using `VariantInternalAccessor` in all cases.
Doing this allows us to confidently maintain `VariantInternalAccessor` going forwards, instead of having to maintain a convoluted mess of different ways to do the same thing.

The PR is big and scary, but almost all of the changes are pretty safe search-and-replace.

## Notes
Through search-and-replace, some `VariantInternalAccessor` uses ended up using the following style:
```c++
VariantInternalAccessor<A>::get(variant) = b;
// Instead of 
VariantInternalAccessor<A>::set(variant, b);
```

This looks a bit weird, but it's not detrimental to performance, using a reference to assign to the value. This can get cleaned up if it's confusing in the future.