### PR TITLE
Remove no longer needed link polygons from NavMapBuilder

### DIFF
--- a/modules/navigation_2d/2d/nav_map_iteration_2d.h
+++ b/modules/navigation_2d/2d/nav_map_iteration_2d.h
@@ -57,7 +57,6 @@ struct NavMapIterationBuild2D {
 	NavMapIteration2D *map_iteration = nullptr;
 
 	int navmesh_polygon_count = 0;
-	int link_polygon_count = 0;
 
 	void reset() {
 		performance_data.reset();
@@ -68,7 +67,6 @@ struct NavMapIterationBuild2D {
 		free_edge_count = 0;
 
 		navmesh_polygon_count = 0;
-		link_polygon_count = 0;
 	}
 };
 
@@ -76,13 +74,10 @@ struct NavMapIteration2D {
 	mutable SafeNumeric<uint32_t> users;
 	RWLock rwlock;
 
-	LocalVector<nav_2d::Polygon> link_polygons;
-
 	LocalVector<NavRegionIteration2D> region_iterations;
 	LocalVector<NavLinkIteration2D> link_iterations;
 
 	int navmesh_polygon_count = 0;
-	int link_polygon_count = 0;
 
 	// The edge connections that the map builds on top with the edge connection margin.
 	HashMap<uint32_t, LocalVector<nav_2d::Edge::Connection>> external_region_connections;

--- a/modules/navigation_2d/nav_link_2d.cpp
+++ b/modules/navigation_2d/nav_link_2d.cpp
@@ -177,4 +177,6 @@ void NavLink2D::get_iteration_update(NavLinkIteration2D &r_iteration) {
 	r_iteration.start_position = get_start_position();
 	r_iteration.end_position = get_end_position();
 	r_iteration.bidirectional = is_bidirectional();
+
+	r_iteration.navmesh_polygons.clear();
 }

--- a/modules/navigation_3d/3d/nav_map_builder_3d.cpp
+++ b/modules/navigation_3d/3d/nav_map_builder_3d.cpp
@@ -269,16 +269,13 @@ void NavMapBuilder3D::_build_step_navlink_connections(NavMapIterationBuild3D &r_
 
 	real_t link_connection_radius = r_build.link_connection_radius;
 
-	LocalVector<Polygon> &link_polygons = map_iteration->link_polygons;
 	LocalVector<NavLinkIteration3D> &links = map_iteration->link_iterations;
 	int polygon_count = r_build.polygon_count;
 
 	real_t link_connection_radius_sqr = link_connection_radius * link_connection_radius;
-	uint32_t link_poly_idx = 0;
-	link_polygons.resize(links.size());
 
 	// Search for polygons within range of a nav link.
-	for (const NavLinkIteration3D &link : links) {
+	for (NavLinkIteration3D &link : links) {
 		if (!link.get_enabled()) {
 			continue;
 		}
@@ -335,7 +332,9 @@ void NavMapBuilder3D::_build_step_navlink_connections(NavMapIterationBuild3D &r_
 
 		// If we have both a start and end point, then create a synthetic polygon to route through.
 		if (closest_start_polygon && closest_end_polygon) {
-			Polygon &new_polygon = link_polygons[link_poly_idx++];
+			link.navmesh_polygons.clear();
+			link.navmesh_polygons.resize(1);
+			Polygon &new_polygon = link.navmesh_polygons[0];
 			new_polygon.id = polygon_count++;
 			new_polygon.owner = &link;
 
@@ -384,22 +383,21 @@ void NavMapBuilder3D::_build_step_navlink_connections(NavMapIterationBuild3D &r_
 			}
 		}
 	}
+
+	r_build.polygon_count = polygon_count;
 }
 
 void NavMapBuilder3D::_build_update_map_iteration(NavMapIterationBuild3D &r_build) {
 	NavMapIteration3D *map_iteration = r_build.map_iteration;
 
-	LocalVector<Polygon> &link_polygons = map_iteration->link_polygons;
-
 	map_iteration->navmesh_polygon_count = r_build.polygon_count;
-	map_iteration->link_polygon_count = link_polygons.size();
 
 	map_iteration->path_query_slots_mutex.lock();
 	for (NavMeshQueries3D::PathQuerySlot &p_path_query_slot : map_iteration->path_query_slots) {
 		p_path_query_slot.traversable_polys.clear();
 		p_path_query_slot.traversable_polys.reserve(map_iteration->navmesh_polygon_count * 0.25);
 		p_path_query_slot.path_corridor.clear();
-		p_path_query_slot.path_corridor.resize(map_iteration->navmesh_polygon_count + map_iteration->link_polygon_count);
+		p_path_query_slot.path_corridor.resize(map_iteration->navmesh_polygon_count);
 	}
 	map_iteration->path_query_slots_mutex.unlock();
 }

--- a/modules/navigation_3d/3d/nav_map_iteration_3d.h
+++ b/modules/navigation_3d/3d/nav_map_iteration_3d.h
@@ -57,7 +57,6 @@ struct NavMapIterationBuild3D {
 	NavMapIteration3D *map_iteration = nullptr;
 
 	int navmesh_polygon_count = 0;
-	int link_polygon_count = 0;
 
 	void reset() {
 		performance_data.reset();
@@ -68,7 +67,6 @@ struct NavMapIterationBuild3D {
 		free_edge_count = 0;
 
 		navmesh_polygon_count = 0;
-		link_polygon_count = 0;
 	}
 };
 
@@ -77,13 +75,11 @@ struct NavMapIteration3D {
 	RWLock rwlock;
 
 	Vector3 map_up;
-	LocalVector<Nav3D::Polygon> link_polygons;
 
 	LocalVector<NavRegionIteration3D> region_iterations;
 	LocalVector<NavLinkIteration3D> link_iterations;
 
 	int navmesh_polygon_count = 0;
-	int link_polygon_count = 0;
 
 	// The edge connections that the map builds on top with the edge connection margin.
 	HashMap<uint32_t, LocalVector<Nav3D::Edge::Connection>> external_region_connections;

--- a/modules/navigation_3d/nav_link_3d.cpp
+++ b/modules/navigation_3d/nav_link_3d.cpp
@@ -177,4 +177,6 @@ void NavLink3D::get_iteration_update(NavLinkIteration3D &r_iteration) {
 	r_iteration.start_position = get_start_position();
 	r_iteration.end_position = get_end_position();
 	r_iteration.bidirectional = is_bidirectional();
+
+	r_iteration.navmesh_polygons.clear();
 }


### PR DESCRIPTION
Removes no longer needed link polygons from NavMapBuilder.

We changed the NavBaseIteration to have the `navmesh_polygons` so both link and regions have them. Having the thin navlink polygons not owned by the link iteration also gave some update troubles when testing something else so this needs to be changed anyway.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
