### PR TITLE
[.NET] Add a preload hook to load .NET assemblies from the APK

### DIFF
--- a/modules/mono/thirdparty/mono_delegates.h
+++ b/modules/mono/thirdparty/mono_delegates.h
@@ -1,0 +1,38 @@
+// Adapted from monovm.h and assembly-functions.h to match coreclr_delegates.h.
+
+// https://github.com/dotnet/runtime/blob/27a7fe5c4bbe0762c231b2a46162e60ee04f3cde/src/mono/mono/mini/monovm.h
+// https://github.com/dotnet/runtime/blob/27a7fe5c4bbe0762c231b2a46162e60ee04f3cde/src/native/public/mono/metadata/details/assembly-functions.h
+
+#ifndef _MONO_DELEGATES_H_
+#define _MONO_DELEGATES_H_
+
+#include "mono_types.h"
+
+typedef MonoAssembly *(*MonoAssemblyPreLoadFunc)(
+		MonoAssemblyName *aname,
+		char **assemblies_path,
+		void* user_data);
+
+typedef void (*mono_install_assembly_preload_hook_fn)(
+		MonoAssemblyPreLoadFunc func,
+		void *user_data);
+
+typedef const char *(*mono_assembly_name_get_name_fn)(MonoAssemblyName *aname);
+
+typedef const char *(*mono_assembly_name_get_culture_fn)(MonoAssemblyName *aname);
+
+typedef MonoImage *(*mono_image_open_from_data_with_name_fn)(
+		char *data,
+		uint32_t data_len,
+		mono_bool need_copy,
+		/*out*/ MonoImageOpenStatus *status,
+		mono_bool refonly,
+		const char *name);
+
+typedef MonoAssembly *(*mono_assembly_load_from_full_fn)(
+		MonoImage *image,
+		const char *fname,
+		/*out*/ MonoImageOpenStatus *status,
+		mono_bool refonly);
+
+#endif // _MONO_DELEGATES_H_

--- a/modules/mono/thirdparty/mono_types.h
+++ b/modules/mono/thirdparty/mono_types.h
@@ -1,0 +1,26 @@
+// Adapted from mono-public-types.h and image-types.h.
+
+// https://github.com/dotnet/runtime/blob/27a7fe5c4bbe0762c231b2a46162e60ee04f3cde/src/native/public/mono/utils/details/mono-publib-types.h
+// https://github.com/dotnet/runtime/blob/27a7fe5c4bbe0762c231b2a46162e60ee04f3cde/src/native/public/mono/metadata/details/image-types.h
+
+#ifndef _MONO_TYPES_H_
+#define _MONO_TYPES_H_
+
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef int32_t mono_bool;
+
+typedef void MonoAssembly;
+typedef void MonoAssemblyName;
+typedef void MonoImage;
+
+typedef enum {
+	MONO_IMAGE_OK,
+	MONO_IMAGE_ERROR_ERRNO,
+	MONO_IMAGE_MISSING_ASSEMBLYREF,
+	MONO_IMAGE_IMAGE_INVALID,
+	MONO_IMAGE_NOT_SUPPORTED, ///< \since net7
+} MonoImageOpenStatus;
+
+#endif // _MONO_TYPES_H_


### PR DESCRIPTION
Avoids using assemblies extracted to a temporary directory in Android.

- Fixes https://github.com/godotengine/godot/issues/103915
- Fixes https://github.com/godotengine/godot/issues/104721
- Fixes https://github.com/godotengine/godot/issues/105142

---

| :robot: Android templates for testing |
|:-:|
| [Godot_v4.5-android-no-copy_mono_export_templates.tpz](https://github.com/raulsntos/godot/releases/download/android-nocopy/Godot_v4.5-android-no-copy_mono_export_templates.tpz) |
