### PR TITLE
[3.x, RTL] Track external changes in the custom fonts set by BBCode / `push_font`.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1848,7 +1848,15 @@ void RichTextLabel::push_font(const Ref<Font> &p_font) {
 	ItemFont *item = memnew(ItemFont);
 
 	item->font = p_font;
+	item->owner = get_instance_id();
+	item->font->connect("changed", this, "_invalidate_fonts", Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
+
 	_add_item(item, true);
+}
+
+void RichTextLabel::_invalidate_fonts() {
+	main->first_invalid_line = 0; //invalidate ALL
+	update();
 }
 
 void RichTextLabel::push_normal() {
@@ -2926,6 +2934,8 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_effects", "effects"), &RichTextLabel::set_effects);
 	ClassDB::bind_method(D_METHOD("get_effects"), &RichTextLabel::get_effects);
 	ClassDB::bind_method(D_METHOD("install_effect", "effect"), &RichTextLabel::install_effect);
+
+	ClassDB::bind_method(D_METHOD("_invalidate_fonts"), &RichTextLabel::_invalidate_fonts);
 
 	ADD_GROUP("BBCode", "bbcode_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bbcode_enabled"), "set_use_bbcode", "is_using_bbcode");

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -164,7 +164,17 @@ private:
 
 	struct ItemFont : public Item {
 		Ref<Font> font;
+		ObjectID owner;
+
 		ItemFont() { type = ITEM_FONT; }
+		~ItemFont() {
+			if (font.is_valid()) {
+				RichTextLabel *owner_rtl = ObjectDB::get_instance<RichTextLabel>(owner);
+				if (owner_rtl) {
+					font->disconnect("changed", owner_rtl, "_invalidate_fonts");
+				}
+			}
+		}
 	};
 
 	struct ItemColor : public Item {
@@ -347,6 +357,8 @@ private:
 
 	void _add_item(Item *p_item, bool p_enter = false, bool p_ensure_newline = false);
 	void _remove_item(Item *p_item, const int p_line, const int p_subitem_line);
+
+	void _invalidate_fonts();
 
 	struct ProcessState {
 		int line_width;


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/105259 for 3.x
