### PR TITLE
Pre-allocate more resources when screen textures are detected in the Mobile renderer

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -910,6 +910,14 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 		global_pipeline_data_required.use_lightmaps = true;
 	}
 
+	if (global_surface_data.screen_texture_used || global_surface_data.depth_texture_used) {
+		if (rb_data.is_valid()) {
+			// Just called to create the framebuffer since we know we will need it later.
+			rb_data->get_color_fbs(RenderBufferDataForwardMobile::FB_CONFIG_RENDER_PASS);
+		}
+		global_pipeline_data_required.use_separate_post_pass = true;
+	}
+
 	_update_dirty_geometry_pipelines();
 
 	p_render_data->scene_data->emissive_exposure_normalization = -1.0;


### PR DESCRIPTION
Further improvements for https://github.com/godotengine/godot/issues/101554

I ran the MRP on an older Android device and detected the stutter still. https://github.com/godotengine/godot/pull/105175 helped a lot, but it missed a few things. Now on my Pixel 4 I have the slightest amount of stutter still and it comes from two things:
1. The tonemap shader's pipeline. I [experimented with pre-warming](https://github.com/clayjohn/godot/tree/rd-mobile-tonemap-warm) and it didn't help. There might be something trickier going on here. 
2. The first draw call after enabling refraction. I can't figure out what the reason is. I have confirmed it isn't pipeline compilation or texture allocation. Its possible it is a driver resource or something inside the RD, but I would need to do a more detailed investigation to know for sure.

This PR reduces the frame hitch from ~750 ms to ~50 ms on my Pixel 4. On newer devices, the difference is small enough to not be noticeable/measurable. 