### PR TITLE
Fix NoiseTexture2D.get_image() returning null on first call

### DIFF
--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -387,5 +387,8 @@ RID NoiseTexture2D::get_rid() const {
 }
 
 Ref<Image> NoiseTexture2D::get_image() const {
+	if (image.is_null()) {
+		const_cast<NoiseTexture2D *>(this)->_update_texture();
+	}
 	return image;
 }

--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -82,6 +82,8 @@ void NoiseTexture2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_noise", "noise"), &NoiseTexture2D::set_noise);
 	ClassDB::bind_method(D_METHOD("get_noise"), &NoiseTexture2D::get_noise);
 
+	ClassDB::bind_method(D_METHOD("get_image"), &NoiseTexture2D::get_image);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "width", PROPERTY_HINT_RANGE, "1,2048,1,or_greater,suffix:px"), "set_width", "get_width");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "height", PROPERTY_HINT_RANGE, "1,2048,1,or_greater,suffix:px"), "set_height", "get_height");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "invert"), "set_invert", "get_invert");
@@ -388,7 +390,12 @@ RID NoiseTexture2D::get_rid() const {
 
 Ref<Image> NoiseTexture2D::get_image() const {
 	if (image.is_null()) {
-		const_cast<NoiseTexture2D *>(this)->_update_texture();
+		const_cast<NoiseTexture2D *>(this)->_generate_image_now(); // const_cast here is necessary since we are going to modify the image
 	}
 	return image;
+}
+
+void NoiseTexture2D::_generate_image_now() {
+	Ref<Image> new_image = _generate_texture();
+	_set_texture_image(new_image);
 }

--- a/modules/noise/noise_texture_2d.h
+++ b/modules/noise/noise_texture_2d.h
@@ -73,6 +73,8 @@ private:
 
 	Ref<Image> _modulate_with_gradient(Ref<Image> p_image, Ref<Gradient> p_gradient);
 
+	void _generate_image_now();
+
 protected:
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
@@ -117,7 +119,7 @@ public:
 	virtual RID get_rid() const override;
 	virtual bool has_alpha() const override { return false; }
 
-	virtual Ref<Image> get_image() const override;
+	Ref<Image> get_image() const override;
 
 	NoiseTexture2D();
 	virtual ~NoiseTexture2D();


### PR DESCRIPTION
Ensure the internal image is generated before the first get_image() call. This prevents get_image() from returning null in _ready() unless manually awaited.

Fixes godotengine/godot#105261