### PR TITLE
Fix issue with playing a custom scene from a UID

### DIFF
--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -259,7 +259,7 @@ void EditorRunBar::_run_scene(const String &p_scene_path, const Vector<String> &
 	String run_filename;
 	switch (current_mode) {
 		case RUN_CUSTOM: {
-			run_filename = p_scene_path;
+			run_filename = ResourceUID::ensure_path(p_scene_path);
 			run_custom_filename = run_filename;
 		} break;
 


### PR DESCRIPTION
This fixes an issue when using `EditorInterface.play_custom_scene` with a UID string. Currently, doing so will fall back to playing the project's "main" scene but this fix will now resolve the UID to it's actual scene path and play that.

Here's a [tiny_project](https://github.com/user-attachments/files/19705122/tiny_project.zip) that demonstrates the issue and the fix when working: To test, run the "Play Custom Scene" tool menu item.

| Current Godot incorrectly plays the main scene: | The fix now plays the correct scene: |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/0c518f4f-ea74-473e-832b-8daa2f7a7d76) | ![image](https://github.com/user-attachments/assets/a6f18054-585f-4fce-b2d0-402a5a0caa41) |





