### PR TITLE
Smoke test: Log an error if `reserve()` is called with fewer elements than `size()`

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -260,7 +260,6 @@ int64_t AStar3D::get_point_capacity() const {
 
 void AStar3D::reserve_space(int64_t p_num_nodes) {
 	ERR_FAIL_COND_MSG(p_num_nodes <= 0, vformat("New capacity must be greater than 0, new was: %d.", p_num_nodes));
-	ERR_FAIL_COND_MSG((uint32_t)p_num_nodes < points.get_capacity(), vformat("New capacity must be greater than current capacity: %d, new was: %d.", points.get_capacity(), p_num_nodes));
 	points.reserve(p_num_nodes);
 }
 

--- a/core/string/string_buffer.h
+++ b/core/string/string_buffer.h
@@ -117,7 +117,8 @@ StringBuffer<SHORT_BUFFER_SIZE> &StringBuffer<SHORT_BUFFER_SIZE>::append(const c
 
 template <int SHORT_BUFFER_SIZE>
 StringBuffer<SHORT_BUFFER_SIZE> &StringBuffer<SHORT_BUFFER_SIZE>::reserve(int p_size) {
-	if (p_size < SHORT_BUFFER_SIZE || p_size < buffer.size() || !p_size) {
+	ERR_FAIL_COND_V_MSG(p_size < length(), *this, "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
+	if (p_size <= SHORT_BUFFER_SIZE || p_size <= buffer.size()) {
 		return *this;
 	}
 

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -414,11 +414,14 @@ public:
 	// Reserves space for a number of elements, useful to avoid many resizes and rehashes.
 	// If adding a known (possibly large) number of elements at once, must be larger than old capacity.
 	void reserve(uint32_t p_new_capacity) {
-		ERR_FAIL_COND_MSG(p_new_capacity < get_capacity(), "It is impossible to reserve less capacity than is currently available.");
+		ERR_FAIL_COND_MSG(p_new_capacity < size(), "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
 		if (elements == nullptr) {
 			capacity = MAX(4u, p_new_capacity);
 			capacity = next_power_of_2(capacity) - 1;
 			return; // Unallocated yet.
+		}
+		if (p_new_capacity <= get_capacity()) {
+			return;
 		}
 		_resize_and_rehash(p_new_capacity);
 	}
@@ -665,9 +668,7 @@ public:
 	}
 
 	AHashMap(const HashMap<TKey, TValue> &p_other) {
-		if (p_other.size() > get_capacity()) {
-			reserve(p_other.size());
-		}
+		reserve(p_other.size());
 		for (const KeyValue<TKey, TValue> &E : p_other) {
 			uint32_t hash = _hash(E.key);
 			_insert_element(E.key, E.value, hash);
@@ -686,9 +687,7 @@ public:
 
 	void operator=(const HashMap<TKey, TValue> &p_other) {
 		reset();
-		if (p_other.size() > get_capacity()) {
-			reserve(p_other.size());
-		}
+		reserve(p_other.size());
 		for (const KeyValue<TKey, TValue> &E : p_other) {
 			uint32_t hash = _hash(E.key);
 			_insert_element(E.key, E.value, hash);
@@ -705,9 +704,7 @@ public:
 	}
 
 	AHashMap(std::initializer_list<KeyValue<TKey, TValue>> p_init) {
-		if (p_init.size() > get_capacity()) {
-			reserve(p_init.size());
-		}
+		reserve(p_init.size());
 		for (const KeyValue<TKey, TValue> &E : p_init) {
 			insert(E.key, E.value);
 		}

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -432,6 +432,7 @@ public:
 	// Reserves space for a number of elements, useful to avoid many resizes and rehashes.
 	// If adding a known (possibly large) number of elements at once, must be larger than old capacity.
 	void reserve(uint32_t p_new_capacity) {
+		ERR_FAIL_COND_MSG(p_new_capacity < size(), "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
 		uint32_t new_index = capacity_index;
 
 		while (hash_table_size_primes[new_index] < p_new_capacity) {

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -294,6 +294,7 @@ public:
 	// Reserves space for a number of elements, useful to avoid many resizes and rehashes.
 	// If adding a known (possibly large) number of elements at once, must be larger than old capacity.
 	void reserve(uint32_t p_new_capacity) {
+		ERR_FAIL_COND_MSG(p_new_capacity < size(), "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
 		uint32_t new_index = capacity_index;
 
 		while (hash_table_size_primes[new_index] < p_new_capacity) {

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -144,6 +144,7 @@ public:
 	_FORCE_INLINE_ bool is_empty() const { return count == 0; }
 	_FORCE_INLINE_ U get_capacity() const { return capacity; }
 	void reserve(U p_size) {
+		ERR_FAIL_COND_MSG(p_size < size(), "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
 		if (p_size > capacity) {
 			if (tight) {
 				capacity = p_size;

--- a/core/templates/oa_hash_map.h
+++ b/core/templates/oa_hash_map.h
@@ -301,7 +301,10 @@ public:
 	 *  capacity.
 	 **/
 	void reserve(uint32_t p_new_capacity) {
-		ERR_FAIL_COND(p_new_capacity < capacity);
+		ERR_FAIL_COND_MSG(p_new_capacity < get_num_elements(), "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
+		if (p_new_capacity <= capacity) {
+			return;
+		}
 		_resize_and_rehash(p_new_capacity);
 	}
 


### PR DESCRIPTION
Follow-up to @AThousandShips' and my conversation at https://github.com/godotengine/godot/pull/103698#issuecomment-2721117519

Currently, some core collections (`OAHashMap`, `AStar2D`, `AStar3D`, and `AHashMap`) log an error if `new_capacity < old_capacity`.
At first glance, this makes sense because you want to catch bugs in `reserve()` calling behavior.
However, the logic is flawed, because the following will also print an error:
```c++
map.reserve(10);
map.reserve(11);
// Error: It is impossible to reserve less capacity than is currently available.
```

This is because `reserve` doesn't reserve exactly the number of requested elements (for almost all collections), but rather to the next largest power of 2. This fact is not exposed to the caller. This can be confusing, and leads to callers always having to run explicit checks to avoid error messages:

```c++
if (map.capacity() < needed_capacity) {
	map.reserve(needed_capacity)
}
```

There is a good alternative: Checking for `size() < capacity` instead. This should catch the same mistake that was intended with the current check, without being misleading or accidentally exposing reserve mechanics. I don't think there is a situation where calling `reserve` is realistically correct with a number smaller than the current size.

For example, this smoke test finds the following bug:
```c++
void add_elements(LocalVector<Vector3> r_points) {
	r_points.reserve(3);
	// Should have been r_points.reserve(r_points.size() + 3);
	r_points.push_back(Vector3(1, 2, 3));
	r_points.push_back(Vector3(1, 2, 3));
	r_points.push_back(Vector3(1, 2, 3));
}
```

The suggested smoke test is added to all collections that support `reserve()`.

- *Production edit: This closes https://github.com/godotengine/godot-proposals/discussions/12285.*
- Closes https://github.com/godotengine/godot/issues/102612