### PR TITLE
[.NET] Fix `string.PathJoin` to be consistent with core

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -1315,7 +1315,9 @@ namespace Godot
         /// <returns>The concatenated path with the given file name.</returns>
         public static string PathJoin(this string instance, string file)
         {
-            if (instance.Length > 0 && instance[instance.Length - 1] == '/')
+            if (instance.Length == 0)
+                return file;
+            if (instance[^1] == '/' || (file.Length > 0 && file[0] == '/'))
                 return instance + file;
             return instance + "/" + file;
         }


### PR DESCRIPTION
Be consistent with `String::path_join`.

Expected:
```gdscript
print("abc".path_join("")) # abc/
print("".path_join("def")) # def
print("abc/".path_join("def")) # abc/def
print("abc".path_join("/def")) # abc/def
print("abc".path_join("def")) # abc/def
```

C# at present:
```csharp
GD.Print("abc".PathJoin("")); // abc/
GD.Print("".PathJoin("def")); // /def
GD.Print("abc/".PathJoin("def")); // abc/def
GD.Print("abc".PathJoin("/def")); // abc//def
GD.Print("abc".PathJoin("def")); // abc/def
```
