### PR TITLE
Update donation link to `fund.godotengine.org`

### DIFF
--- a/DONORS.md
+++ b/DONORS.md
@@ -5,7 +5,7 @@ contributors, as well as occasional paid contributors thanks to the financial
 support of generous donors.
 
 The ways to donate to the project, as well as details on how the funds are
-used, are described on [Godot's website](https://godotengine.org/donate).
+used, are described on [Godot's website](https://fund.godotengine.org).
 
 The following is a list of the current monthly donors, who will have their
 generous deed immortalized in the next stable release of Godot Engine.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3363,7 +3363,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			about->popup_centered(Size2(780, 500) * EDSCALE);
 		} break;
 		case HELP_SUPPORT_GODOT_DEVELOPMENT: {
-			OS::get_singleton()->shell_open("https://godotengine.org/donate");
+			OS::get_singleton()->shell_open("https://fund.godotengine.org");
 		} break;
 	}
 }

--- a/misc/dist/linux/org.godotengine.Godot.appdata.xml
+++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml
@@ -29,7 +29,7 @@
   <url type="bugtracker">https://github.com/godotengine/godot/issues</url>
   <url type="faq">https://docs.godotengine.org/en/latest/about/faq.html</url>
   <url type="help">https://docs.godotengine.org</url>
-  <url type="donation">https://godotengine.org/donate</url>
+  <url type="donation">https://fund.godotengine.org</url>
   <url type="translate">https://hosted.weblate.org/projects/godot-engine/godot</url>
   <developer_name>The Godot Engine Community</developer_name>
   <update_contact>akien_at_godotengine_dot_org</update_contact>


### PR DESCRIPTION
This points to the Development Fund page directly.
