### PR TITLE
Rename editor setting `Engine Version Update Mode` to `Check for Updates` 

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1117,7 +1117,7 @@
 			Specify the multiplier to apply to the scale for the editor gizmo handles to improve usability on touchscreen devices.
 			[b]Note:[/b] Defaults to [code]1[/code] on non-touchscreen devices.
 		</member>
-		<member name="network/connection/engine_version_update_mode" type="int" setter="" getter="">
+		<member name="network/connection/check_for_updates" type="int" setter="" getter="">
 			Specifies how the engine should check for updates.
 			- [b]Disable Update Checks[/b] will block the engine from checking updates (see also [member network/connection/network_mode]).
 			- [b]Check Newest Preview[/b] (default for preview versions) will check for the newest available development snapshot.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -473,7 +473,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 		if (String(GODOT_VERSION_STATUS) == String("stable")) {
 			default_update_mode = EngineUpdateLabel::UpdateMode::NEWEST_STABLE;
 		}
-		EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "network/connection/engine_version_update_mode", int(default_update_mode), "Disable Update Checks,Check Newest Preview,Check Newest Stable,Check Newest Patch"); // Uses EngineUpdateLabel::UpdateMode.
+		EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "network/connection/check_for_updates", int(default_update_mode), "Disable Update Checks,Check Newest Preview,Check Newest Stable,Check Newest Patch"); // Uses EngineUpdateLabel::UpdateMode.
 	}
 
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/use_embedded_menu", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING)

--- a/editor/engine_update_label.cpp
+++ b/editor/engine_update_label.cpp
@@ -37,7 +37,7 @@
 
 bool EngineUpdateLabel::_can_check_updates() const {
 	return int(EDITOR_GET("network/connection/network_mode")) == EditorSettings::NETWORK_ONLINE &&
-			UpdateMode(int(EDITOR_GET("network/connection/engine_version_update_mode"))) != UpdateMode::DISABLED;
+			UpdateMode(int(EDITOR_GET("network/connection/check_for_updates"))) != UpdateMode::DISABLED;
 }
 
 void EngineUpdateLabel::_check_update() {
@@ -78,7 +78,7 @@ void EngineUpdateLabel::_http_request_completed(int p_result, int p_response_cod
 		version_array = result;
 	}
 
-	UpdateMode update_mode = UpdateMode(int(EDITOR_GET("network/connection/engine_version_update_mode")));
+	UpdateMode update_mode = UpdateMode(int(EDITOR_GET("network/connection/check_for_updates")));
 	bool stable_only = update_mode == UpdateMode::NEWEST_STABLE || update_mode == UpdateMode::NEWEST_PATCH;
 
 	const Dictionary current_version_info = Engine::get_singleton()->get_version_info();

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -48,7 +48,7 @@ void QuickSettingsDialog::_fetch_setting_values() {
 	editor_themes.clear();
 	editor_scales.clear();
 	editor_network_modes.clear();
-	editor_engine_version_update_modes.clear();
+	editor_check_for_updates.clear();
 	editor_directory_naming_conventions.clear();
 
 	{
@@ -66,8 +66,8 @@ void QuickSettingsDialog::_fetch_setting_values() {
 				editor_scales = pi.hint_string.split(",");
 			} else if (pi.name == "network/connection/network_mode") {
 				editor_network_modes = pi.hint_string.split(",");
-			} else if (pi.name == "network/connection/engine_version_update_mode") {
-				editor_engine_version_update_modes = pi.hint_string.split(",");
+			} else if (pi.name == "network/connection/check_for_updates") {
+				editor_check_for_updates = pi.hint_string.split(",");
 			} else if (pi.name == "project_manager/directory_naming_convention") {
 				editor_directory_naming_conventions = pi.hint_string.split(",");
 			}
@@ -133,18 +133,18 @@ void QuickSettingsDialog::_update_current_values() {
 		}
 	}
 
-	// Engine version update mode options.
+	// Check for updates options.
 	{
-		const int current_update_mode = EDITOR_GET("network/connection/engine_version_update_mode");
+		const int current_update_mode = EDITOR_GET("network/connection/check_for_updates");
 
-		for (int i = 0; i < editor_engine_version_update_modes.size(); i++) {
-			const String &engine_version_update_mode_value = editor_engine_version_update_modes[i];
+		for (int i = 0; i < editor_check_for_updates.size(); i++) {
+			const String &check_for_update_value = editor_check_for_updates[i];
 			if (current_update_mode == i) {
-				engine_version_update_mode_button->set_text(engine_version_update_mode_value);
-				engine_version_update_mode_button->select(i);
+				check_for_update_button->set_text(check_for_update_value);
+				check_for_update_button->select(i);
 
-				// Disables Engine Version Update Mode selection if Network mode is set to Offline.
-				engine_version_update_mode_button->set_disabled(!EDITOR_GET("network/connection/network_mode"));
+				// Disables Check for Updates selection if Network mode is set to Offline.
+				check_for_update_button->set_disabled(!EDITOR_GET("network/connection/network_mode"));
 			}
 		}
 	}
@@ -197,12 +197,12 @@ void QuickSettingsDialog::_scale_selected(int p_id) {
 void QuickSettingsDialog::_network_mode_selected(int p_id) {
 	_set_setting_value("network/connection/network_mode", p_id);
 
-	// Disables Engine Version Update Mode selection if Network mode is set to Offline.
-	engine_version_update_mode_button->set_disabled(!p_id);
+	// Disables Check for Updates selection if Network mode is set to Offline.
+	check_for_update_button->set_disabled(!p_id);
 }
 
-void QuickSettingsDialog::_engine_version_update_mode_selected(int p_id) {
-	_set_setting_value("network/connection/engine_version_update_mode", p_id);
+void QuickSettingsDialog::_check_for_update_selected(int p_id) {
+	_set_setting_value("network/connection/check_for_updates", p_id);
 }
 
 void QuickSettingsDialog::_directory_naming_convention_selected(int p_id) {
@@ -346,18 +346,18 @@ QuickSettingsDialog::QuickSettingsDialog() {
 			_add_setting_control(TTRC("Network Mode"), network_mode_option_button);
 		}
 
-		// Engine version update mode options.
+		// Check for updates options.
 		{
-			engine_version_update_mode_button = memnew(OptionButton);
-			engine_version_update_mode_button->set_fit_to_longest_item(false);
-			engine_version_update_mode_button->connect(SceneStringName(item_selected), callable_mp(this, &QuickSettingsDialog::_engine_version_update_mode_selected));
+			check_for_update_button = memnew(OptionButton);
+			check_for_update_button->set_fit_to_longest_item(false);
+			check_for_update_button->connect(SceneStringName(item_selected), callable_mp(this, &QuickSettingsDialog::_check_for_update_selected));
 
-			for (int i = 0; i < editor_engine_version_update_modes.size(); i++) {
-				const String &engine_version_update_mode_value = editor_engine_version_update_modes[i];
-				engine_version_update_mode_button->add_item(engine_version_update_mode_value, i);
+			for (int i = 0; i < editor_check_for_updates.size(); i++) {
+				const String &check_for_update_value = editor_check_for_updates[i];
+				check_for_update_button->add_item(check_for_update_value, i);
 			}
 
-			_add_setting_control(TTRC("Engine Version Update Mode"), engine_version_update_mode_button);
+			_add_setting_control(TTRC("Check for Updates"), check_for_update_button);
 		}
 
 		// Project directory naming options.

--- a/editor/project_manager/quick_settings_dialog.h
+++ b/editor/project_manager/quick_settings_dialog.h
@@ -48,7 +48,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	Vector<String> editor_themes;
 	Vector<String> editor_scales;
 	Vector<String> editor_network_modes;
-	Vector<String> editor_engine_version_update_modes;
+	Vector<String> editor_check_for_updates;
 	Vector<String> editor_directory_naming_conventions;
 
 	void _fetch_setting_values();
@@ -67,7 +67,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	OptionButton *theme_option_button = nullptr;
 	OptionButton *scale_option_button = nullptr;
 	OptionButton *network_mode_option_button = nullptr;
-	OptionButton *engine_version_update_mode_button = nullptr;
+	OptionButton *check_for_update_button = nullptr;
 	OptionButton *directory_naming_convention_button = nullptr;
 
 	Label *custom_theme_label = nullptr;
@@ -78,7 +78,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	void _theme_selected(int p_id);
 	void _scale_selected(int p_id);
 	void _network_mode_selected(int p_id);
-	void _engine_version_update_mode_selected(int p_id);
+	void _check_for_update_selected(int p_id);
 	void _directory_naming_convention_selected(int p_id);
 	void _set_setting_value(const String &p_setting, const Variant &p_value, bool p_restart_required = false);
 


### PR DESCRIPTION
Renames editor/quick setting `Engine Version Update Mode` to `Check for Updates` based on discussion in https://github.com/godotengine/godot/pull/105162 and https://github.com/godotengine/godot/pull/105169.

![image](https://github.com/user-attachments/assets/7c610801-22ed-44f7-bad5-ccca01b8ffa7)
