### PR TITLE
Improve EditorAbout dialog auto-translation

### DIFF
--- a/editor/credits_roll.cpp
+++ b/editor/credits_roll.cpp
@@ -51,6 +51,7 @@ Label *CreditsRoll::_create_label(const String &p_with_text, LabelSize p_size) {
 	switch (p_size) {
 		case LabelSize::NORMAL: {
 			label->add_theme_font_size_override(SceneStringName(font_size), font_size_normal);
+			label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 		} break;
 
 		case LabelSize::HEADER: {
@@ -165,6 +166,7 @@ void CreditsRoll::roll_credits() {
 		_create_nothing();
 
 		project_manager = _create_label(TTR("Project Manager", "Job Title"), LabelSize::HEADER);
+		project_manager->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 		_create_label(_build_string(AUTHORS_PROJECT_MANAGERS));
 
 		_create_nothing();

--- a/editor/editor_about.h
+++ b/editor/editor_about.h
@@ -31,13 +31,13 @@
 #pragma once
 
 #include "scene/gui/dialogs.h"
-#include "scene/gui/item_list.h"
-#include "scene/gui/rich_text_label.h"
-#include "scene/gui/scroll_container.h"
-#include "scene/gui/texture_rect.h"
-#include "scene/gui/tree.h"
 
 class CreditsRoll;
+class ItemList;
+class Label;
+class RichTextLabel;
+class TextureRect;
+class Tree;
 
 /**
  * NOTE: Do not assume the EditorNode singleton to be available in this class' methods.
@@ -47,12 +47,19 @@ class EditorAbout : public AcceptDialog {
 	GDCLASS(EditorAbout, AcceptDialog);
 
 private:
-	void _license_tree_selected();
-	void _project_manager_clicked();
-	void _item_with_website_selected(int p_id, ItemList *p_il);
-	void _item_list_resized(ItemList *p_il);
-	ScrollContainer *_populate_list(const String &p_name, const List<String> &p_sections, const char *const *const p_src[], int p_single_column_flags = 0, bool p_allow_website = false, const String &p_easter_egg_section = String());
+	enum SectionFlags {
+		FLAG_SINGLE_COLUMN = 1 << 0,
+		FLAG_ALLOW_WEBSITE = 1 << 1,
+		FLAG_EASTER_EGG = 1 << 2,
+	};
 
+	void _license_tree_selected();
+	void _item_activated(int p_idx, ItemList *p_il);
+	void _item_list_resized(ItemList *p_il);
+	Label *_create_section(Control *p_parent, const String &p_name, const char *const *p_src, BitField<SectionFlags> p_flags = 0);
+
+	Label *_about_text_label = nullptr;
+	Label *_project_manager_label = nullptr;
 	Tree *_tpl_tree = nullptr;
 	RichTextLabel *license_text_label = nullptr;
 	RichTextLabel *_tpl_text = nullptr;


### PR DESCRIPTION
Part of https://github.com/godotengine/godot/issues/104574

Make strings in `EditorAbout` utilize auto-translation when possible. Other cases are handled in `NOTIFICATION_TRANSLATION_CHANGED`.