### PR TITLE
Add `--scene` command line argument

### DIFF
--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -146,6 +146,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 	}
 
 	if (!p_scene.is_empty()) {
+		args.push_back("--scene");
 		args.push_back(p_scene);
 	}
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -513,7 +513,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_copyright("(c) 2014-present Godot Engine contributors. (c) 2007-present Juan Linietsky, Ariel Manzur.");
 
 	print_help_title("Usage");
-	OS::get_singleton()->print("  %s \u001b[96m[options] [path to scene or \"project.godot\" file]\u001b[0m\n", p_binary);
+	OS::get_singleton()->print("  %s \u001b[96m[options] [path to \"project.godot\" file]\u001b[0m\n", p_binary);
 
 #if defined(TOOLS_ENABLED)
 	print_help_title("Option legend (this build = editor)");
@@ -554,6 +554,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--quit-after <int>", "Quit after the given number of iterations. Set to 0 to disable.\n");
 	print_help_option("-l, --language <locale>", "Use a specific locale (<locale> being a two-letter code).\n");
 	print_help_option("--path <directory>", "Path to a project (<directory> must contain a \"project.godot\" file).\n");
+	print_help_option("--scene <path>", "Path or UID of a scene in the project that should be started.\n");
 	print_help_option("-u, --upwards", "Scan folders upwards for project.godot file.\n");
 	print_help_option("--main-pack <file>", "Path to a pack (.pck) file to load.\n");
 #ifdef DISABLE_DEPRECATED
@@ -3846,7 +3847,14 @@ int Main::start() {
 		} else if (E->get() == "--install-android-build-template") {
 			install_android_build_template = true;
 #endif // TOOLS_ENABLED
-		} else if (E->get().length() && E->get()[0] != '-' && positional_arg.is_empty()) {
+		} else if (E->get() == "--scene") {
+			E = E->next();
+			if (E) {
+				game_path = E->get();
+			} else {
+				ERR_FAIL_V_MSG(EXIT_FAILURE, "Missing scene path, aborting.");
+			}
+		} else if (E->get().length() && E->get()[0] != '-' && positional_arg.is_empty() && game_path.is_empty()) {
 			positional_arg = E->get();
 
 			if (E->get().ends_with(".scn") ||


### PR DESCRIPTION
Currently Godot tries to use unrecognized launch argument as scene path. It used to be worse, but now it at least checks whether the argument is a path to scene file ([which doesn't work with UIDs](https://github.com/godotengine/godot/pull/105288) :P). Overall it's a rather poor idea that required some hacks to avoid confusing errors that it can cause.

This PR adds support for `--scene` argument, which expects a path to the scene. Since it doesn't need any validation, it will automatically work with UIDs or custom scene formats. I changed the code in EditorRun to use it, not sure if we specify scene in other places.

The old way of specifying scene is soft-deprecated. I removed it from help, but it's still supported. It's only considered if you don't use the new argument.