### PR TITLE
Improve project modification from Project Manager

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -185,6 +185,7 @@ public:
 
 	Error load_custom(const String &p_path);
 	Error save_custom(const String &p_path = "", const CustomMap &p_custom = CustomMap(), const Vector<String> &p_custom_features = Vector<String>(), bool p_merge_with_current = true);
+	Error save_simple(const String &p_path); // Saves while avoiding unnecessary changes.
 	Error save();
 	void set_custom_property_info(const PropertyInfo &p_info);
 	const HashMap<StringName, PropertyInfo> &get_custom_property_info() const;

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -919,7 +919,7 @@ void ProjectManager::_apply_project_tags() {
 	} else {
 		tags.sort();
 		cfg->set("application/config/tags", tags);
-		Error err = cfg->save_custom(project_godot);
+		Error err = cfg->save_simple(project_godot);
 		memdelete(cfg);
 
 		if (err != OK) {

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -705,17 +705,15 @@ void ProjectDialog::ok_pressed() {
 	}
 
 	if (mode == MODE_RENAME || mode == MODE_INSTALL) {
-		// Load project.godot as ConfigFile to set the new name.
-		ConfigFile cfg;
-		String project_godot = path.path_join("project.godot");
-		Error err = cfg.load(project_godot);
-		if (err != OK) {
-			dialog_error->set_text(vformat(TTR("Couldn't load project at '%s' (error %d). It may be missing or corrupted."), project_godot, err));
+		const String project_godot = path.path_join("project.godot");
+		ProjectSettings *cfg = memnew(ProjectSettings(project_godot));
+		if (!cfg->is_project_loaded()) {
+			dialog_error->set_text(vformat(TTR("Couldn't load project at '%s'. It may be missing or corrupted."), project_godot));
 			dialog_error->popup_centered();
 			return;
 		}
-		cfg.set_value("application", "config/name", project_name->get_text().strip_edges());
-		err = cfg.save(project_godot);
+		cfg->set_setting("application/config/name", project_name->get_text().strip_edges());
+		Error err = cfg->save_simple(project_godot);
 		if (err != OK) {
 			dialog_error->set_text(vformat(TTR("Couldn't save project at '%s' (error %d)."), project_godot, err));
 			dialog_error->popup_centered();


### PR DESCRIPTION
Kind of follow-up to #75048

- Use ProjectSettings when renaming project
- Add `save_simple()` method to ProjectSettings
  - Saves the project while avoiding changes (e.g. previously when you changed project tags it would modify project's version)
  - May still modify `config_version`, but currently it only affects 3.x projects

EDIT:
Fixes #114584