### PR TITLE
Fix `exp_edit` description

### DIFF
--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -45,7 +45,7 @@
 			If [code]true[/code], [member value] may be less than [member min_value].
 		</member>
 		<member name="exp_edit" type="bool" setter="set_exp_ratio" getter="is_ratio_exp" default="false">
-			If [code]true[/code], and [member min_value] is greater than 0, [member value] will be represented exponentially rather than linearly.
+			If [code]true[/code], and [member min_value] is greater or equal to [code]0[/code], [member value] will be represented exponentially rather than linearly.
 		</member>
 		<member name="max_value" type="float" setter="set_max" getter="get_max" default="100.0">
 			Maximum value. Range is clamped if [member value] is greater than [member max_value].

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -33,8 +33,8 @@
 PackedStringArray Range::get_configuration_warnings() const {
 	PackedStringArray warnings = Control::get_configuration_warnings();
 
-	if (shared->exp_ratio && shared->min <= 0) {
-		warnings.push_back(RTR("If \"Exp Edit\" is enabled, \"Min Value\" must be greater than 0."));
+	if (shared->exp_ratio && shared->min < 0) {
+		warnings.push_back(RTR("If \"Exp Edit\" is enabled, \"Min Value\" must be greater or equal to 0."));
 	}
 
 	return warnings;


### PR DESCRIPTION
`exp_edit` wrongly states that the min value can't be 0, while actually there is a special case that handles it.
Configuration warnings repeated this mistake.