### PR TITLE
Emit `changed` when `exp_edit` changes

### DIFF
--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -73,7 +73,7 @@
 	<signals>
 		<signal name="changed">
 			<description>
-				Emitted when [member min_value], [member max_value], [member page], or [member step] change.
+				Emitted when [member min_value], [member max_value], [member page], [member step], or [member exp_edit] change.
 			</description>
 		</signal>
 		<signal name="value_changed">

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -400,6 +400,7 @@ void Range::set_exp_ratio(bool p_enable) {
 
 	shared->exp_ratio = p_enable;
 
+	shared->emit_changed("exp_edit");
 	update_configuration_warnings();
 }
 


### PR DESCRIPTION
Toggling `exp_edit` will affect Range's `ratio`. The `changed` wasn't emitted on that event, which caused some controls to not update properly.


https://github.com/user-attachments/assets/7dce6d98-c0b5-45a2-b1c4-bb3088f27e4c

https://github.com/user-attachments/assets/aabfdb83-4f66-44c5-8965-1d23780fbf13

