### PR TITLE
Support custom features in project settings dialog

### DIFF
--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -49,7 +49,14 @@ class FileSystemDock;
 class ProjectSettingsEditor : public AcceptDialog {
 	GDCLASS(ProjectSettingsEditor, AcceptDialog);
 
-	static ProjectSettingsEditor *singleton;
+	inline static ProjectSettingsEditor *singleton = nullptr;
+
+	enum {
+		FEATURE_ALL,
+		FEATURE_CUSTOM,
+		FEATURE_FIRST,
+	};
+
 	ProjectSettings *ps = nullptr;
 	Timer *timer = nullptr;
 


### PR DESCRIPTION
Allows adding overrides for custom features.

https://github.com/user-attachments/assets/3e4a3b83-a2ca-41f8-8c00-36a761d7d0fb

Previously there was no way to do that. The option would change to `(All)` and disable Add button.
I added a new feature menu option called Custom, which adds `.custom` to your setting and automatically selects it. Also typing a non-standard feature in the setting will automatically select that option.