### PR TITLE
TextureEditorPlugin: Add borders to 3D and Layered editors

### DIFF
--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -83,9 +83,8 @@ void Texture3DEditor::_notification(int p_what) {
 
 		case NOTIFICATION_DRAW: {
 			Ref<Texture2D> checkerboard = get_editor_theme_icon(SNAME("Checkerboard"));
-			Size2 size = get_size();
-
-			draw_texture_rect(checkerboard, Rect2(Point2(), size), true);
+			draw_texture_rect(checkerboard, texture_rect->get_rect(), true);
+			_draw_outline();
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -93,6 +92,7 @@ void Texture3DEditor::_notification(int p_what) {
 				Ref<Font> metadata_label_font = get_theme_font(SNAME("expression"), EditorStringName(EditorFonts));
 				info->add_theme_font_override(SceneStringName(font), metadata_label_font);
 			}
+			theme_cache.outline_color = get_theme_color(SNAME("extra_border_color_1"), EditorStringName(Editor));
 		} break;
 	}
 }
@@ -118,6 +118,12 @@ void Texture3DEditor::_update_material(bool p_texture_changed) {
 	}
 
 	material->set_shader_parameter("u_channel_factors", channel_selector->get_selected_channel_factors());
+}
+
+void Texture3DEditor::_draw_outline() {
+	const float outline_width = Math::round(EDSCALE);
+	const Rect2 outline_rect = texture_rect->get_rect().grow(outline_width * 0.5);
+	draw_rect(outline_rect, theme_cache.outline_color, false, outline_width);
 }
 
 void Texture3DEditor::_make_shaders() {
@@ -149,7 +155,7 @@ void Texture3DEditor::_texture_rect_update_area() {
 	int ofs_x = (size.width - tex_width) / 2;
 	int ofs_y = (size.height - tex_height) / 2;
 
-	texture_rect->set_position(Vector2(ofs_x, ofs_y));
+	texture_rect->set_position(Vector2(ofs_x, ofs_y - Math::round(EDSCALE)));
 	texture_rect->set_size(Vector2(tex_width, tex_height));
 }
 

--- a/editor/plugins/texture_3d_editor_plugin.h
+++ b/editor/plugins/texture_3d_editor_plugin.h
@@ -41,6 +41,10 @@ class ColorChannelSelector;
 class Texture3DEditor : public Control {
 	GDCLASS(Texture3DEditor, Control);
 
+	struct ThemeCache {
+		Color outline_color;
+	} theme_cache;
+
 	SpinBox *layer = nullptr;
 	Label *info = nullptr;
 	Ref<Texture3D> texture;
@@ -53,6 +57,8 @@ class Texture3DEditor : public Control {
 	ColorChannelSelector *channel_selector = nullptr;
 
 	bool setting = false;
+
+	void _draw_outline();
 
 	void _make_shaders();
 

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -96,7 +96,7 @@ void TexturePreview::_notification(int p_what) {
 
 			bg_rect->set_color(get_theme_color(SNAME("dark_color_2"), EditorStringName(Editor)));
 			checkerboard->set_texture(get_editor_theme_icon(SNAME("Checkerboard")));
-			cached_outline_color = get_theme_color(SNAME("extra_border_color_1"), EditorStringName(Editor));
+			theme_cache.outline_color = get_theme_color(SNAME("extra_border_color_1"), EditorStringName(Editor));
 		} break;
 	}
 }
@@ -104,7 +104,7 @@ void TexturePreview::_notification(int p_what) {
 void TexturePreview::_draw_outline() {
 	const float outline_width = Math::round(EDSCALE);
 	const Rect2 outline_rect = Rect2(Vector2(), outline_overlay->get_size()).grow(outline_width * 0.5);
-	outline_overlay->draw_rect(outline_rect, cached_outline_color, false, outline_width);
+	outline_overlay->draw_rect(outline_rect, theme_cache.outline_color, false, outline_width);
 }
 
 void TexturePreview::_update_texture_display_ratio() {

--- a/editor/plugins/texture_editor_plugin.h
+++ b/editor/plugins/texture_editor_plugin.h
@@ -45,6 +45,10 @@ class TexturePreview : public MarginContainer {
 	GDCLASS(TexturePreview, MarginContainer);
 
 private:
+	struct ThemeCache {
+		Color outline_color;
+	} theme_cache;
+
 	TextureRect *texture_display = nullptr;
 
 	MarginContainer *margin_container = nullptr;
@@ -56,8 +60,6 @@ private:
 	Ref<ShaderMaterial> material;
 
 	ColorChannelSelector *channel_selector = nullptr;
-
-	Color cached_outline_color;
 
 	void _draw_outline();
 	void _update_metadata_label_text();

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -239,9 +239,8 @@ void TextureLayeredEditor::_notification(int p_what) {
 
 		case NOTIFICATION_DRAW: {
 			Ref<Texture2D> checkerboard = get_editor_theme_icon(SNAME("Checkerboard"));
-			Size2 size = get_size();
-
-			draw_texture_rect(checkerboard, Rect2(Point2(), size), true);
+			draw_texture_rect(checkerboard, texture_rect->get_rect(), true);
+			_draw_outline();
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -249,6 +248,7 @@ void TextureLayeredEditor::_notification(int p_what) {
 				Ref<Font> metadata_label_font = get_theme_font(SNAME("expression"), EditorStringName(EditorFonts));
 				info->add_theme_font_override(SceneStringName(font), metadata_label_font);
 			}
+			theme_cache.outline_color = get_theme_color(SNAME("extra_border_color_1"), EditorStringName(Editor));
 		} break;
 	}
 }
@@ -296,6 +296,12 @@ void TextureLayeredEditor::on_selected_channels_changed() {
 	_update_material(false);
 }
 
+void TextureLayeredEditor::_draw_outline() {
+	const float outline_width = Math::round(EDSCALE);
+	const Rect2 outline_rect = texture_rect->get_rect().grow(outline_width * 0.5);
+	draw_rect(outline_rect, theme_cache.outline_color, false, outline_width);
+}
+
 void TextureLayeredEditor::_make_shaders() {
 	shaders[0].instantiate();
 	shaders[0]->set_code(array_2d_shader);
@@ -333,7 +339,7 @@ void TextureLayeredEditor::_texture_rect_update_area() {
 	int ofs_x = (size.width - tex_width) / 2;
 	int ofs_y = (size.height - tex_height) / 2;
 
-	texture_rect->set_position(Vector2(ofs_x, ofs_y));
+	texture_rect->set_position(Vector2(ofs_x, ofs_y - Math::round(EDSCALE)));
 	texture_rect->set_size(Vector2(tex_width, tex_height));
 }
 

--- a/editor/plugins/texture_layered_editor_plugin.h
+++ b/editor/plugins/texture_layered_editor_plugin.h
@@ -41,6 +41,10 @@ class ColorChannelSelector;
 class TextureLayeredEditor : public Control {
 	GDCLASS(TextureLayeredEditor, Control);
 
+	struct ThemeCache {
+		Color outline_color;
+	} theme_cache;
+
 	SpinBox *layer = nullptr;
 	Label *info = nullptr;
 	Ref<TextureLayered> texture;
@@ -55,6 +59,8 @@ class TextureLayeredEditor : public Control {
 	bool setting = false;
 
 	ColorChannelSelector *channel_selector = nullptr;
+
+	void _draw_outline();
 
 	void _make_shaders();
 	void _update_material(bool p_texture_changed);


### PR DESCRIPTION
Makes the 3d and Layered docks look similar to the 2D ones.

Comparison:
| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/e1d9db6a-1ce6-4e4d-8cc9-626826aa9629) | ![after](https://github.com/user-attachments/assets/f89e5bea-8351-4e9a-a1e8-5b1e5815c441) |

