### PR TITLE
[macOS] Add support for DualShock touchpad button

### DIFF
--- a/drivers/apple/joypad_apple.mm
+++ b/drivers/apple/joypad_apple.mm
@@ -391,6 +391,10 @@ GameController::GameController(int p_joy_id, GCController *p_controller) :
 				xboxGamepad.paddleButton3.pressedChangedHandler = BUTTON(JoyButton::PADDLE3);
 				xboxGamepad.paddleButton4.pressedChangedHandler = BUTTON(JoyButton::PADDLE4);
 			}
+			if ([gamepad isKindOfClass:[GCDualShockGamepad class]]) {
+				GCDualShockGamepad *dualShockGamepad = (GCDualShockGamepad *)gamepad;
+				dualShockGamepad.touchpadButton.pressedChangedHandler = BUTTON(JoyButton::TOUCHPAD);
+			}
 		}
 
 		if (@available(macOS 12, iOS 15.0, tvOS 15.0, *)) {


### PR DESCRIPTION
Up until now the DualShock touchpad button (PS4, PS5) was not supported on macOS. This PR adds that functionality