### PR TITLE
Update `GDScriptLanguage::globals` when a `GDExtension` is loaded in exported builds

### DIFF
--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -60,10 +60,8 @@ GDExtensionManager::LoadStatus GDExtensionManager::_load_extension_internal(cons
 }
 
 void GDExtensionManager::_finish_load_extension(const Ref<GDExtension> &p_extension) {
-#ifdef TOOLS_ENABLED
 	// Signals that a new extension is loaded so GDScript can register new class names.
 	emit_signal("extension_loaded", p_extension);
-#endif
 
 	if (startup_callback_called) {
 		// Extension is loading after the startup callback has already been called,
@@ -75,10 +73,8 @@ void GDExtensionManager::_finish_load_extension(const Ref<GDExtension> &p_extens
 }
 
 GDExtensionManager::LoadStatus GDExtensionManager::_unload_extension_internal(const Ref<GDExtension> &p_extension) {
-#ifdef TOOLS_ENABLED
 	// Signals that a new extension is unloading so GDScript can unregister class names.
 	emit_signal("extension_unloading", p_extension);
-#endif
 
 	if (!shutdown_callback_called) {
 		// Extension is unloading before the shutdown callback has been called,

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -282,6 +282,7 @@ void ClassDB::get_extensions_class_list(LocalVector<StringName> &p_classes) {
 	SortArray<StringName> sorter;
 	sorter.sort(&p_classes[original_size], p_classes.size() - original_size);
 }
+#endif
 
 void ClassDB::get_extension_class_list(const Ref<GDExtension> &p_extension, List<StringName> *p_classes) {
 	Locker::Lock lock(Locker::STATE_READ);
@@ -298,7 +299,6 @@ void ClassDB::get_extension_class_list(const Ref<GDExtension> &p_extension, List
 
 	p_classes->sort_custom<StringName::AlphCompare>();
 }
-#endif
 
 void ClassDB::get_inheriters_from_class(const StringName &p_class, LocalVector<StringName> &p_classes) {
 	Locker::Lock lock(Locker::STATE_READ);

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -332,7 +332,9 @@ public:
 	static void get_class_list(LocalVector<StringName> &p_classes);
 #ifdef TOOLS_ENABLED
 	static void get_extensions_class_list(LocalVector<StringName> &p_classes);
+#endif
 	static void get_extension_class_list(const Ref<GDExtension> &p_extension, List<StringName> *p_classes);
+#ifdef TOOLS_ENABLED
 	static ObjectGDExtension *get_placeholder_extension(const StringName &p_class);
 #endif
 	static const GDType *get_gdtype(const StringName &p_class);

--- a/doc/classes/GDExtensionManager.xml
+++ b/doc/classes/GDExtensionManager.xml
@@ -68,19 +68,18 @@
 			<param index="0" name="extension" type="GDExtension" />
 			<description>
 				Emitted after the editor has finished loading a new extension.
-				[b]Note:[/b] This signal is only emitted in editor builds.
 			</description>
 		</signal>
 		<signal name="extension_unloading">
 			<param index="0" name="extension" type="GDExtension" />
 			<description>
 				Emitted before the editor starts unloading an extension.
-				[b]Note:[/b] This signal is only emitted in editor builds.
 			</description>
 		</signal>
 		<signal name="extensions_reloaded">
 			<description>
 				Emitted after the editor has finished reloading one or more extensions.
+				[b]Note:[/b] This signal is only emitted in editor builds.
 			</description>
 		</signal>
 	</signals>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -54,8 +54,8 @@
 #include "scene/resources/packed_scene.h"
 #include "scene/scene_string_names.h"
 
-#ifdef TOOLS_ENABLED
 #include "core/extension/gdextension_manager.h"
+#ifdef TOOLS_ENABLED
 #include "editor/file_system/editor_paths.h"
 #endif
 
@@ -2290,12 +2290,8 @@ void GDScriptLanguage::init() {
 		_add_global(E.name, E.ptr);
 	}
 
-#ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
-		GDExtensionManager::get_singleton()->connect("extension_loaded", callable_mp(this, &GDScriptLanguage::_extension_loaded));
-		GDExtensionManager::get_singleton()->connect("extension_unloading", callable_mp(this, &GDScriptLanguage::_extension_unloading));
-	}
-#endif // TOOLS_ENABLED
+	GDExtensionManager::get_singleton()->connect("extension_loaded", callable_mp(this, &GDScriptLanguage::_extension_loaded));
+	GDExtensionManager::get_singleton()->connect("extension_unloading", callable_mp(this, &GDScriptLanguage::_extension_unloading));
 
 #ifdef DEBUG_ENABLED
 	GDScriptParser::update_project_settings();
@@ -2309,7 +2305,6 @@ void GDScriptLanguage::init() {
 #endif // TESTS_ENABLED
 }
 
-#ifdef TOOLS_ENABLED
 void GDScriptLanguage::_extension_loaded(const Ref<GDExtension> &p_extension) {
 	List<StringName> class_list;
 	ClassDB::get_extension_class_list(p_extension, &class_list);
@@ -2329,7 +2324,6 @@ void GDScriptLanguage::_extension_unloading(const Ref<GDExtension> &p_extension)
 		_remove_global(n);
 	}
 }
-#endif
 
 String GDScriptLanguage::get_type() const {
 	return "GDScript";
@@ -2344,6 +2338,10 @@ void GDScriptLanguage::finish() {
 		return;
 	}
 	finishing = true;
+
+	// To prevent spam in unit tests.
+	GDExtensionManager::get_singleton()->disconnect("extension_loaded", callable_mp(this, &GDScriptLanguage::_extension_loaded));
+	GDExtensionManager::get_singleton()->disconnect("extension_unloading", callable_mp(this, &GDScriptLanguage::_extension_unloading));
 
 	// Clear the cache before parsing the script_list
 	GDScriptCache::clear();

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -474,10 +474,8 @@ class GDScriptLanguage : public ScriptLanguage {
 
 	HashMap<String, ObjectID> orphan_subclasses;
 
-#ifdef TOOLS_ENABLED
 	void _extension_loaded(const Ref<GDExtension> &p_extension);
 	void _extension_unloading(const Ref<GDExtension> &p_extension);
-#endif
 
 public:
 	bool debug_break(const String &p_error, bool p_allow_continue = true);


### PR DESCRIPTION
Fix [104056](https://github.com/godotengine/godot/issues/104056)

The root cause of the issue is that the `GDScriptLanguage::globals` is not updated when a new `GDExtension` is loaded in an exported game. This leads to a GDScript compilation failure when the types defined by the `GDExtension` are used explicitly in `.gd` scripts loaded from a pck file (such as a mod).

The logic to handle this already exists (added in [93972](https://github.com/godotengine/godot/pull/93972)) but is currently enabled only on editor builds. My proposed fix is to remove that constraint so it also applies to exported builds. I haven’t noticed any side effects, but I’m not very familiar with this part of the engine, so let me know if this isn’t the right approach.