### PR TITLE
Allow theming audio buses

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -140,11 +140,11 @@ void EditorAudioBus::_notification(int p_what) {
 
 		case NOTIFICATION_DRAW: {
 			if (is_master) {
-				draw_style_box(get_theme_stylebox(SNAME("disabled"), SNAME("Button")), Rect2(Vector2(), get_size()));
+				draw_style_box(get_theme_stylebox(SNAME("master"), SNAME("EditorAudioBus")), Rect2(Vector2(), get_size()));
 			} else if (has_focus()) {
-				draw_style_box(get_theme_stylebox(SNAME("focus"), SNAME("Button")), Rect2(Vector2(), get_size()));
+				draw_style_box(get_theme_stylebox(SNAME("focus"), SNAME("EditorAudioBus")), Rect2(Vector2(), get_size()));
 			} else {
-				draw_style_box(get_theme_stylebox(SNAME("BottomPanel"), EditorStringName(EditorStyles)), Rect2(Vector2(), get_size()));
+				draw_style_box(get_theme_stylebox(SNAME("normal"), SNAME("EditorAudioBus")), Rect2(Vector2(), get_size()));
 			}
 
 			if (get_index() != 0 && hovering_drop) {

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1972,6 +1972,11 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		icon_hover_color.a = 1.0;
 		p_theme->set_color("icon_hover_color", "BottomPanelButton", icon_hover_color);
 		p_theme->set_color("icon_hover_pressed_color", "BottomPanelButton", icon_hover_color);
+
+		// Audio bus.
+		p_theme->set_stylebox("normal", "EditorAudioBus", style_bottom_panel);
+		p_theme->set_stylebox("master", "EditorAudioBus", p_config.button_style_disabled);
+		p_theme->set_stylebox("focus", "EditorAudioBus", p_config.button_style_focus);
 	}
 
 	// Editor GUI widgets.


### PR DESCRIPTION
Exposes styleboxes for EditorAudioBus backgrounds instead of using Button and BottomPanel ones.

Needed when drawing buses on top of a transparent ScrollContainer because it's impossible to make them not blend with the bottom panel otherwise:

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/3a352cad-eadb-464d-b0ba-33a760ab3a78) | ![after](https://github.com/user-attachments/assets/a95ffe84-dab3-4285-ad49-e8b879099b10) |

Doesn't affect the default theme