### PR TITLE
Remove debug focus rect draws from MenuBar and GraphNode.

### DIFF
--- a/doc/classes/MenuBar.xml
+++ b/doc/classes/MenuBar.xml
@@ -100,7 +100,7 @@
 		<member name="flat" type="bool" setter="set_flat" getter="is_flat" default="false">
 			Flat [MenuBar] don't display item decoration.
 		</member>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="3" />
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 		</member>

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -639,10 +639,6 @@ void GraphNode::_notification(int p_what) {
 			// Draw body (slots area) stylebox.
 			draw_style_box(sb_to_draw_panel, body_rect);
 
-			if (has_focus()) {
-				draw_style_box(theme_cache.panel_focus, body_rect);
-			}
-
 			// Draw title bar stylebox above.
 			draw_style_box(sb_to_draw_titlebar, titlebar_rect);
 

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -423,10 +423,6 @@ void MenuBar::_draw_menu_item(int p_index) {
 	bool pressed = (active_menu == p_index);
 	bool rtl = is_layout_rtl();
 
-	if (has_focus() && focused_menu == -1 && p_index == 0) {
-		hovered = true;
-	}
-
 	if (menu_cache[p_index].hidden) {
 		return;
 	}
@@ -969,7 +965,7 @@ String MenuBar::get_tooltip(const Point2 &p_pos) const {
 }
 
 MenuBar::MenuBar() {
-	set_focus_mode(FOCUS_ALL);
+	set_focus_mode(FOCUS_ACCESSIBILITY);
 	set_process_shortcut_input(true);
 }
 


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/105197, unnecessary focus rect draws I missed.

Fixes https://github.com/godotengine/godot/issues/105365