### PR TITLE
Suppress unused paramater warning conflicting with if constexpr

### DIFF
--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -200,6 +200,8 @@ template <bool p_ensure_zero = false, typename T>
 _FORCE_INLINE_ void memnew_arr_placement(T *p_start, size_t p_num) {
 	if constexpr (std::is_trivially_constructible_v<T> && !p_ensure_zero) {
 		// Don't need to do anything :)
+		(void)p_start;
+		(void)p_num;
 	} else if constexpr (is_zero_constructible_v<T>) {
 		// Can optimize with memset.
 		memset(static_cast<void *>(p_start), 0, p_num * sizeof(T));


### PR DESCRIPTION
The version of g++ that github actions currently uses seems to see a parameter as unused if the only use is in `if constexpr` branch that are unused for a particular invocation.

```
./core/os/memory.h:200:45: error: parameter 'p_start' set but not used [-Werror=unused-but-set-parameter]
  200 | _FORCE_INLINE_ void memnew_arr_placement(T *p_start, size_t p_num) {
      |                                          ~~~^~~~~~~
```