### PR TITLE
Capitalize text in SpinBox and EditorSpinSlider to parse with Expression

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -571,6 +571,7 @@ void EditorSpinSlider::_evaluate_input_text() {
 	String text = value_input->get_text().replace_char(',', '.');
 	text = text.replace_char(';', ',');
 	text = TS->parse_number(text);
+	text = text.to_upper();
 
 	Error err = expr->parse(text);
 	if (err != OK) {

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -144,6 +144,7 @@ void SpinBox::_text_submitted(const String &p_string) {
 	text = TS->parse_number(text);
 	// Ignore the prefix and suffix in the expression.
 	text = text.trim_prefix(prefix + " ").trim_suffix(" " + suffix);
+	text = text.to_upper();
 
 	Error err = expr->parse(text);
 


### PR DESCRIPTION
Alternative to #100395. For example, this allows typing `tau/4` instead of `TAU/4` in the editor. If we also re-enable infinity, this would also fix the problem where users need to type `INF` but it's displayed as `inf`, and typing `inf` doesn't work.