### PR TITLE
Add GridMap octant related queries and tests

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -97,6 +97,20 @@
 				This function returns always the map set on the GridMap node and not the map on the NavigationServer. If the map is changed directly with the NavigationServer API the GridMap node will not be aware of the map change.
 			</description>
 		</method>
+		<method name="get_octant_coords_from_cell_coords" qualifiers="const">
+			<return type="Vector3i" />
+			<param index="0" name="cell_coords" type="Vector3i" />
+			<description>
+				Returns the [Vector3i] octant coordinates of the octant that the cell at [param cell_coords] belongs to.
+			</description>
+		</method>
+		<method name="get_octants_in_bounds" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="bounds" type="AABB" />
+			<description>
+				Returns an array of [Vector3i] octant coordinates that are inside the given [param bounds], including octants that have no cells in use.
+			</description>
+		</method>
 		<method name="get_orthogonal_index_from_basis" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="basis" type="Basis" />
@@ -115,6 +129,41 @@
 			<param index="0" name="item" type="int" />
 			<description>
 				Returns an array of all cells with the given item index specified in [param item].
+			</description>
+		</method>
+		<method name="get_used_cells_in_octant" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="octant_coords" type="Vector3i" />
+			<description>
+				Returns an array of [Vector3i]s with the cell coordinates of non-empty cells inside the octant at [param octant_coords].
+			</description>
+		</method>
+		<method name="get_used_cells_in_octant_by_item" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="octant_coords" type="Vector3i" />
+			<param index="1" name="item" type="int" />
+			<description>
+				Returns an array of [Vector3i]s with the cell coordinates of cells inside the octant at [param octant_coords] that use the specified cell [param item].
+			</description>
+		</method>
+		<method name="get_used_octants" qualifiers="const">
+			<return type="Vector3i[]" />
+			<description>
+				Returns an array of [Vector3i]s with the octant coordinates of the non-empty octants in the grid map.
+			</description>
+		</method>
+		<method name="get_used_octants_by_item" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="item" type="int" />
+			<description>
+				Returns an array of [Vector3i]s with the octant coordinates of the octants that use the specified [param item] in the grid map.
+			</description>
+		</method>
+		<method name="get_used_octants_in_bounds" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="bounds" type="AABB" />
+			<description>
+				Returns an array of [Vector3i]s with the octant coordinates of non-empty octants that are inside the local [param bounds].
 			</description>
 		</method>
 		<method name="local_to_map" qualifiers="const">

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -303,6 +303,21 @@ public:
 	TypedArray<Vector3i> get_used_cells() const;
 	TypedArray<Vector3i> get_used_cells_by_item(int p_item) const;
 
+	TypedArray<Vector3i> get_used_octants() const;
+	TypedArray<Vector3i> get_used_octants_by_item(int p_item) const;
+
+	TypedArray<Vector3i> get_used_cells_in_octant(const Vector3i &p_octant_coords) const;
+	TypedArray<Vector3i> get_used_cells_in_octant_by_item(const Vector3i &p_octant_coords, int p_item) const;
+
+	// Fastpath functions for native modules that do not use Variant / TypedArray.
+	LocalVector<IndexKey> get_index_keys_in_bounds(const AABB &p_bounds, bool p_used_only = true) const;
+	LocalVector<OctantKey> get_octant_keys_in_bounds(const AABB &p_bounds, bool p_used_only = true) const;
+
+	TypedArray<Vector3i> get_octants_in_bounds(const AABB &p_bounds) const;
+	TypedArray<Vector3i> get_used_octants_in_bounds(const AABB &p_bounds) const;
+
+	Vector3i get_octant_coords_from_cell_coords(const Vector3i &p_cell_coords) const;
+
 	Array get_meshes() const;
 
 	void clear_baked_meshes();

--- a/modules/gridmap/tests/test_grid_map.h
+++ b/modules/gridmap/tests/test_grid_map.h
@@ -1,0 +1,121 @@
+/**************************************************************************/
+/*  test_grid_map.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "../grid_map.h"
+
+#include "tests/test_macros.h"
+
+namespace TestGridMap {
+
+TEST_CASE("[SceneTree][GridMap] Heh Heh, Godotsphir!!") {
+	SUBCASE("[SceneTree][GridMap] Make GridMap live the Godotsphir-life correctly") {
+		Ref<MeshLibrary> mesh_library;
+		mesh_library.instantiate();
+
+		int item1 = 0;
+		int item2 = 1;
+
+		{
+			Vector<int> item_list = mesh_library->get_item_list();
+			CHECK(item_list.size() == 0);
+		}
+
+		mesh_library->create_item(item1);
+		mesh_library->create_item(item2);
+
+		int last_unused_item_id = mesh_library->get_last_unused_item_id();
+		CHECK(last_unused_item_id == 2);
+
+		mesh_library->set_item_name(item1, "Item1");
+		mesh_library->set_item_name(item2, "Item2");
+
+		Ref<BoxMesh> box_mesh;
+		box_mesh.instantiate();
+		box_mesh->set_size(Vector3(1.0, 1.0, 1.0));
+
+		mesh_library->set_item_mesh(item1, box_mesh);
+		mesh_library->set_item_mesh(item2, box_mesh);
+
+		{
+			Vector<int> item_list = mesh_library->get_item_list();
+			CHECK(item_list.size() == 2);
+			CHECK(item_list[0] == item1);
+			CHECK(item_list[1] == item2);
+		}
+
+		GridMap *grid_map = memnew(GridMap);
+		grid_map->set_mesh_library(mesh_library);
+
+		SceneTree::get_singleton()->get_root()->add_child(grid_map);
+
+		grid_map->set_octant_size(8);
+		grid_map->set_cell_size(Vector3(1.0, 1.0, 1.0));
+
+		grid_map->set_cell_item(Vector3i(0, 0, 0), -1);
+
+		CHECK(grid_map->get_used_cells().size() == 0);
+		CHECK(grid_map->get_used_octants().size() == 0);
+
+		grid_map->set_cell_item(Vector3i(0, 0, 0), item1);
+		grid_map->set_cell_item(Vector3i(7, 7, 7), item2);
+
+		CHECK(grid_map->get_used_cells().size() == 2);
+		CHECK(grid_map->get_used_octants().size() == 1);
+		CHECK(grid_map->get_used_octants()[0] == Vector3i(0, 0, 0));
+
+		grid_map->set_cell_item(Vector3i(8, 8, 8), item2);
+
+		CHECK(grid_map->get_used_cells().size() == 3);
+		CHECK(grid_map->get_used_octants().size() == 2);
+		CHECK(grid_map->get_used_octants()[0] == Vector3i(0, 0, 0));
+		CHECK(grid_map->get_used_octants()[1] == Vector3i(1, 1, 1));
+
+		AABB bounds;
+		bounds.position = Vector3(0.0, 0.0, 0.0);
+		bounds.size = Vector3(8.0, 8.0, 8.0);
+
+		CHECK(grid_map->get_octants_in_bounds(bounds).size() == 1);
+		CHECK(grid_map->get_used_octants_in_bounds(bounds).size() == 1);
+		CHECK(grid_map->get_octants_in_bounds(bounds)[0] == Vector3i(0, 0, 0));
+
+		// Edge margin is -CMP_EPSILON.
+		bounds.size = Vector3(8.001, 8.001, 8.001);
+		CHECK(grid_map->get_octants_in_bounds(bounds).size() == 8);
+		CHECK(grid_map->get_used_octants_in_bounds(bounds).size() == 2);
+
+		SceneTree::get_singleton()->get_root()->remove_child(grid_map);
+
+		memdelete(grid_map);
+	}
+}
+
+} // namespace TestGridMap


### PR DESCRIPTION
Adds GridMap octant queries.

Requires https://github.com/godotengine/godot/pull/105329 to be merged first.

Adds octant query functions as a performance alternative to the existing cell functions.

E.g. when only a few cells for some specific octants are needed, e.g. inside some AABB bounds, and not all the cells of the entire GridMap which creates potentially a slow array with thousands of entries.

`TypedArray[Vector3i] get_used_octants()`
Returns the octant coordinates as Vector3i of all octants that have at least 1 cell in use.

`TypedArray[Vector3i] get_used_octants_by_item( p_item: int)`
Returns the used octant coordinates of all octants that have at least 1 cell with the specific cell item in use.

`TypedArray[Vector3i] get_used_cells_in_octant(p_octant_coords: Vector3i)`
Returns the used cell coordinates of all the cells inside the specific octant coordinate.

`TypedArray[Vector3i] get_used_cells_in_octant_by_item(p_octant_coords: Vector3i, p_item: int)`
Returns the used cell coordinates of all the cells inside the specific octant coordinate that have the specific cell item in use.

`TypedArray[Vector3i] get_used_octants_in_bounds(p_bounds: AABB)`
Returns the used octant coordinates of all octants that have at least 1 cell used with the specific local bounds.

`Vector3i get_octant_coords_from_cell_coords(p_cell_coords: Vector3i)`
Script helper to convert cell coordinate to octant coordinate for the octant related query functions.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
