### PR TITLE
Add GridMap Octant visual debug

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -96,6 +96,13 @@
 				This function returns always the map set on the GridMap node and not the map on the NavigationServer. If the map is changed directly with the NavigationServer API the GridMap node will not be aware of the map change.
 			</description>
 		</method>
+		<method name="get_octant_coords_from_cell_coords" qualifiers="const">
+			<return type="Vector3i" />
+			<param index="0" name="cell_coords" type="Vector3i" />
+			<description>
+				Returns the [Vector3i] octant coordinates of the [param cell_coords].
+			</description>
+		</method>
 		<method name="get_orthogonal_index_from_basis" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="basis" type="Basis" />
@@ -114,6 +121,41 @@
 			<param index="0" name="item" type="int" />
 			<description>
 				Returns an array of all cells with the given item index specified in [param item].
+			</description>
+		</method>
+		<method name="get_used_cells_in_octant" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="octant_coords" type="Vector3i" />
+			<description>
+				Returns an array of [Vector3i] with the non-empty cell coordinates inside the octant at [param octant_coords].
+			</description>
+		</method>
+		<method name="get_used_cells_in_octant_by_item" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="octant_coords" type="Vector3i" />
+			<param index="1" name="item" type="int" />
+			<description>
+				Returns an array of [Vector3i] with the non-empty cell coordinates inside the octant at [param octant_coords]. that use the specified cell [param item].
+			</description>
+		</method>
+		<method name="get_used_octants" qualifiers="const">
+			<return type="Vector3i[]" />
+			<description>
+				Returns an array of [Vector3i] with the non-empty octant coordinates in the grid map.
+			</description>
+		</method>
+		<method name="get_used_octants_by_item" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="item" type="int" />
+			<description>
+				Returns an array of [Vector3i] with the non-empty octant coordinates that use the specified [param item] in the grid map.
+			</description>
+		</method>
+		<method name="get_used_octants_in_bounds" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="bounds" type="AABB" />
+			<description>
+				Returns an array of [Vector3i] with the non-empty octant coordinates that are inside the local [param bounds].
 			</description>
 		</method>
 		<method name="local_to_map" qualifiers="const">
@@ -213,6 +255,18 @@
 		</member>
 		<member name="collision_priority" type="float" setter="set_collision_priority" getter="get_collision_priority" default="1.0">
 			The priority used to solve colliding when occurring penetration. The higher the priority is, the lower the penetration into the object will be. This can for example be used to prevent the player from breaking through the boundaries of a level.
+		</member>
+		<member name="debug_custom_color_octants" type="Color" setter="debug_set_custom_color_octants" getter="debug_get_custom_color_octants" default="Color(1, 1, 1, 1)">
+			The custom [Color] used for rendering octant debug visuals when [member debug_use_custom] is enabled.
+		</member>
+		<member name="debug_enabled" type="bool" setter="debug_set_enabled" getter="debug_get_enabled" default="false">
+			If [code]true[/code] shows debug visuals for this node.
+		</member>
+		<member name="debug_show_octants" type="bool" setter="debug_set_show_octants" getter="debug_get_show_octants" default="true">
+			If [code]true[/code] and [member debug_enabled] is enabled, shows debug visuals for octants.
+		</member>
+		<member name="debug_use_custom" type="bool" setter="debug_set_use_custom" getter="debug_get_use_custom" default="false">
+			If [code]true[/code], the debug related custom options for this node override the default debug options.
 		</member>
 		<member name="mesh_library" type="MeshLibrary" setter="set_mesh_library" getter="get_mesh_library">
 			The assigned [MeshLibrary].

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -152,6 +152,9 @@ class GridMap : public Node3D {
 		OctantKey() {}
 	};
 
+	OctantKey get_octant_key_from_index_key(const IndexKey &p_index_key) const;
+	OctantKey get_octant_key_from_cell_coords(const Vector3i &p_cell_coords) const;
+
 #ifndef PHYSICS_3D_DISABLED
 	uint32_t collision_layer = 1;
 	uint32_t collision_mask = 1;
@@ -224,6 +227,45 @@ class GridMap : public Node3D {
 	};
 
 	Vector<BakedMesh> baked_meshes;
+
+	bool debug_dirty = true;
+	bool debug_enabled = false;
+	bool debug_show_octants = true;
+	bool debug_use_custom = false;
+
+	Color debug_default_color_octants = Color(1.0, 1.0, 1.0, 1.0);
+	Color debug_custom_color_octants = Color(1.0, 1.0, 1.0, 1.0);
+
+	Ref<StandardMaterial3D> debug_default_octant_line_material;
+	Ref<StandardMaterial3D> debug_custom_octant_line_material;
+
+	void _debug_update();
+	void _debug_update_octants();
+	void _debug_clear();
+	void _debug_clear_octants();
+
+	RID debug_octant_line_mesh_rid;
+
+	struct OctantDebug {
+		RID debug_line_mesh_rid;
+		RID debug_line_instance_rid;
+	};
+	HashMap<OctantKey, OctantDebug *, OctantKey> debug_octant_map;
+
+	Array build_octant_line_mesh_arrays() const;
+
+public:
+	void debug_set_enabled(bool p_enable);
+	bool debug_get_enabled() const;
+
+	void debug_set_show_octants(bool p_enable);
+	bool debug_get_show_octants() const;
+
+	void debug_set_use_custom(bool p_enable);
+	bool debug_get_use_custom() const;
+
+	void debug_set_custom_color_octants(const Color &p_color);
+	Color debug_get_custom_color_octants() const;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -300,6 +342,15 @@ public:
 
 	TypedArray<Vector3i> get_used_cells() const;
 	TypedArray<Vector3i> get_used_cells_by_item(int p_item) const;
+
+	TypedArray<Vector3i> get_used_octants() const;
+	TypedArray<Vector3i> get_used_octants_by_item(int p_item) const;
+
+	TypedArray<Vector3i> get_used_cells_in_octant(const Vector3i &p_octant_coords) const;
+	TypedArray<Vector3i> get_used_cells_in_octant_by_item(const Vector3i &p_octant_coords, int p_item) const;
+
+	TypedArray<Vector3i> get_used_octants_in_bounds(const AABB &p_bounds) const;
+	Vector3i get_octant_coords_from_cell_coords(const Vector3i &p_cell_coords) const;
 
 	Array get_meshes() const;
 


### PR DESCRIPTION
Adds GridMap Octant visual debug.

Requires https://github.com/godotengine/godot/pull/105329 and https://github.com/godotengine/godot/pull/105332 to be merged first (in that order).

![gridmap_octant_debug_options](https://github.com/user-attachments/assets/c5ba6574-b23d-485d-90ed-98920427c05c)

![gridmap_octant_debug](https://github.com/user-attachments/assets/928509d8-23f6-4fc5-b3bd-a9bca57eea8d)


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
