### PR TITLE
Allow inserting at end of array again

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -318,7 +318,7 @@ Error Array::insert(int p_pos, const Variant &p_value) {
 		p_pos = _p->array.size() + p_pos;
 	}
 
-	ERR_FAIL_INDEX_V_MSG(p_pos, _p->array.size(), ERR_INVALID_PARAMETER, vformat("The calculated index %d is out of bounds (the array has %d elements). Leaving the array untouched.", p_pos, _p->array.size()));
+	ERR_FAIL_INDEX_V_MSG(p_pos, _p->array.size() + 1, ERR_INVALID_PARAMETER, vformat("The calculated index %d is out of bounds (the array has %d elements). Leaving the array untouched.", p_pos, _p->array.size()));
 
 	return _p->array.insert(p_pos, std::move(value));
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Inserting at end of array (at array.size()) used to work but recently would throw an error instead. Making it work again.
