### PR TITLE
Implement EditorTextureImportPlugin to extend texture importer

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -544,12 +544,12 @@
 				If [param first_priority] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
 			</description>
 		</method>
-		<method name="add_texture_import_plugin">
+		<method name="add_texture_post_import_plugin">
 			<return type="void" />
-			<param index="0" name="importer" type="EditorTextureImportPlugin" />
+			<param index="0" name="importer" type="EditorTexturePostImportPlugin" />
 			<param index="1" name="first_priority" type="bool" default="false" />
 			<description>
-				Add a [EditorTextureImportPlugin]. These plugins allow customizing the import process of [CompressedTexture2D].
+				Add a [EditorTexturePostImportPlugin]. These plugins allow customizing the import process of [CompressedTexture2D].
 				If [param first_priority] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
 			</description>
 		</method>
@@ -741,11 +741,11 @@
 				Remove the [EditorScenePostImportPlugin], added with [method add_scene_post_import_plugin].
 			</description>
 		</method>
-		<method name="remove_texture_import_plugin">
+		<method name="remove_texture_post_import_plugin">
 			<return type="void" />
-			<param index="0" name="importer" type="EditorTextureImportPlugin" />
+			<param index="0" name="importer" type="EditorTexturePostImportPlugin" />
 			<description>
-				Remove the [EditorTextureImportPlugin], added with [method add_texture_import_plugin].
+				Remove the [EditorTexturePostImportPlugin], added with [method add_texture_post_import_plugin].
 			</description>
 		</method>
 		<method name="remove_tool_menu_item">

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -544,6 +544,15 @@
 				If [param first_priority] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
 			</description>
 		</method>
+		<method name="add_texture_import_plugin">
+			<return type="void" />
+			<param index="0" name="importer" type="EditorTextureImportPlugin" />
+			<param index="1" name="first_priority" type="bool" default="false" />
+			<description>
+				Add a [EditorTextureImportPlugin]. These plugins allow customizing the import process of [CompressedTexture2D].
+				If [param first_priority] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
+			</description>
+		</method>
 		<method name="add_tool_menu_item">
 			<return type="void" />
 			<param index="0" name="name" type="String" />
@@ -730,6 +739,13 @@
 			<param index="0" name="scene_import_plugin" type="EditorScenePostImportPlugin" />
 			<description>
 				Remove the [EditorScenePostImportPlugin], added with [method add_scene_post_import_plugin].
+			</description>
+		</method>
+		<method name="remove_texture_import_plugin">
+			<return type="void" />
+			<param index="0" name="importer" type="EditorTextureImportPlugin" />
+			<description>
+				Remove the [EditorTextureImportPlugin], added with [method add_texture_import_plugin].
 			</description>
 		</method>
 		<method name="remove_tool_menu_item">

--- a/doc/classes/EditorTextureImportPlugin.xml
+++ b/doc/classes/EditorTextureImportPlugin.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorTextureImportPlugin" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Plugin to control and modify the process of importing a [CompressedTexture2D].
+	</brief_description>
+	<description>
+		This plugin type exists to extend [ResourceImporterTexture] and modify the process of importing [CompressedTexture2D], allowing to load custom file format, add import options, and change the image when processing.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_get_import_options" qualifiers="virtual const">
+			<return type="void" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="preset_index" type="int" />
+			<description>
+				Override to add import options. These will appear in the Texture2D import dock on the editor. Add options via [method add_import_option] and [method add_import_option_advanced].
+			</description>
+		</method>
+		<method name="_get_option_visibility" qualifiers="virtual const">
+			<return type="Variant" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="option" type="String" />
+			<description>
+				Override to change the visibility of import option. Should return [code]true[/code] to show the given option, [code]false[/code] to hide the given option, or [code]null[/code] to ignore.
+			</description>
+		</method>
+		<method name="_get_recognized_extensions" qualifiers="virtual const">
+			<return type="PackedStringArray" />
+			<description>
+				Gets the file extensions that will be added to the recognized extensions list of texture importer.
+			</description>
+		</method>
+		<method name="_load_image" qualifiers="virtual const">
+			<return type="Image" />
+			<param index="0" name="source_file" type="String" />
+			<description>
+				Override to add import options. These will appear in the Texture2D import dock on the editor. Add options via [method add_import_option] and [method add_import_option_advanced].
+			</description>
+		</method>
+		<method name="_post_process" qualifiers="virtual const">
+			<return type="Image" />
+			<param index="0" name="image" type="Image" />
+			<description>
+				Post process the image. This function is called after the image has been processed, such as fix alpha border, apply size limit. See also [ResourceImporterTexture].
+			</description>
+		</method>
+		<method name="_pre_process" qualifiers="virtual const">
+			<return type="Image" />
+			<param index="0" name="image" type="Image" />
+			<description>
+				Pre Process the image. This function is called right after the image loader loaded the image and no changes have been made.
+			</description>
+		</method>
+		<method name="add_import_option">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="value" type="Variant" />
+			<description>
+				Add a specific import option (name and default value only). This function can only be called from [method _get_import_options].
+			</description>
+		</method>
+		<method name="add_import_option_advanced">
+			<return type="void" />
+			<param index="0" name="type" type="int" enum="Variant.Type" />
+			<param index="1" name="name" type="String" />
+			<param index="2" name="default_value" type="Variant" />
+			<param index="3" name="hint" type="int" enum="PropertyHint" default="0" />
+			<param index="4" name="hint_string" type="String" default="&quot;&quot;" />
+			<param index="5" name="usage_flags" type="int" default="6" />
+			<description>
+				Add a specific import option. This function can only be called from [method _get_import_options].
+			</description>
+		</method>
+		<method name="get_option_value" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Query the value of an option. This function can only be called from [method _get_option_visibility], [method _load_image], [method _pre_process] and [method _post_process].
+			</description>
+		</method>
+	</methods>
+	<constants>
+		<constant name="PRESET_DETECT" value="0" enum="Preset">
+			The 2D/3D (Auto-Detect) preset of texture importer. Can be accessed in [method _get_import_options].
+		</constant>
+		<constant name="PRESET_2D" value="1" enum="Preset">
+			The 2D preset of texture importer. Can be accessed in [method _get_import_options].
+		</constant>
+		<constant name="PRESET_3D" value="2" enum="Preset">
+			The 3D preset of texture importer. Can be accessed in [method _get_import_options].
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/EditorTexturePostImportPlugin.xml
+++ b/doc/classes/EditorTexturePostImportPlugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="EditorTextureImportPlugin" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="EditorTexturePostImportPlugin" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Plugin to control and modify the process of importing a [CompressedTexture2D].
 	</brief_description>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8381,6 +8381,7 @@ EditorNode::~EditorNode() {
 	EditorInspector::cleanup_plugins();
 	EditorTranslationParser::get_singleton()->clean_parsers();
 	ResourceImporterScene::clean_up_importer_plugins();
+	ResourceImporterTexture::clean_up_importer_plugins();
 	EditorContextMenuPluginManager::cleanup();
 
 	remove_print_handler(&print_handler);

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -41,23 +41,23 @@
 #include "editor/themes/editor_theme_manager.h"
 #include "scene/resources/compressed_texture.h"
 
-Variant EditorTextureImportPlugin::get_option_value(const StringName &p_name) const {
+Variant EditorTexturePostImportPlugin::get_option_value(const StringName &p_name) const {
 	ERR_FAIL_COND_V_MSG(current_options == nullptr, Variant(), "get_option_value() called from a function where option values are not available.");
 	ERR_FAIL_COND_V_MSG(!current_options->has(p_name), Variant(), "get_option_value() called with unexisting option argument: " + String(p_name));
 	return (*current_options)[p_name];
 }
 
-void EditorTextureImportPlugin::add_import_option(const String &p_name, const Variant &p_default_value) {
+void EditorTexturePostImportPlugin::add_import_option(const String &p_name, const Variant &p_default_value) {
 	ERR_FAIL_NULL_MSG(current_option_list, "add_import_option() can only be called from get_import_options().");
 	add_import_option_advanced(p_default_value.get_type(), p_name, p_default_value);
 }
 
-void EditorTextureImportPlugin::add_import_option_advanced(Variant::Type p_type, const String &p_name, const Variant &p_default_value, PropertyHint p_hint, const String &p_hint_string, int p_usage_flags) {
+void EditorTexturePostImportPlugin::add_import_option_advanced(Variant::Type p_type, const String &p_name, const Variant &p_default_value, PropertyHint p_hint, const String &p_hint_string, int p_usage_flags) {
 	ERR_FAIL_NULL_MSG(current_option_list, "add_import_option_advanced() can only be called from get_import_options().");
 	current_option_list->push_back(ResourceImporter::ImportOption(PropertyInfo(p_type, p_name, p_hint, p_hint_string, p_usage_flags), p_default_value));
 }
 
-void EditorTextureImportPlugin::get_recognized_extensions(List<String> *p_extensions) const {
+void EditorTexturePostImportPlugin::get_recognized_extensions(List<String> *p_extensions) const {
 	Vector<String> extensions;
 	GDVIRTUAL_CALL(_get_recognized_extensions, extensions);
 	for (int i = 0; i < extensions.size(); i++) {
@@ -65,13 +65,13 @@ void EditorTextureImportPlugin::get_recognized_extensions(List<String> *p_extens
 	}
 }
 
-void EditorTextureImportPlugin::get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options, Preset p_preset) const {
+void EditorTexturePostImportPlugin::get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options, Preset p_preset) const {
 	current_option_list = r_options;
 	GDVIRTUAL_CALL(_get_import_options, p_path, p_preset);
 	current_option_list = nullptr;
 }
 
-Variant EditorTextureImportPlugin::get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
+Variant EditorTexturePostImportPlugin::get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
 	current_options = &p_options;
 	Variant ret;
 	GDVIRTUAL_CALL(_get_option_visibility, p_path, p_option, ret);
@@ -79,7 +79,7 @@ Variant EditorTextureImportPlugin::get_option_visibility(const String &p_path, c
 	return ret;
 }
 
-Ref<Image> EditorTextureImportPlugin::load_image(const String &p_source_file, bool *r_use_custom_loader, const HashMap<StringName, Variant> &p_options) const {
+Ref<Image> EditorTexturePostImportPlugin::load_image(const String &p_source_file, bool *r_use_custom_loader, const HashMap<StringName, Variant> &p_options) const {
 	Ref<Image> image;
 	current_options = &p_options;
 	bool use_custom_loader = GDVIRTUAL_CALL(_load_image, p_source_file, image);
@@ -90,7 +90,7 @@ Ref<Image> EditorTextureImportPlugin::load_image(const String &p_source_file, bo
 	return image;
 }
 
-Ref<Image> EditorTextureImportPlugin::pre_process(Ref<Image> p_image, const HashMap<StringName, Variant> &p_options) const {
+Ref<Image> EditorTexturePostImportPlugin::pre_process(Ref<Image> p_image, const HashMap<StringName, Variant> &p_options) const {
 	Ref<Image> image = p_image;
 	current_options = &p_options;
 	GDVIRTUAL_CALL(_pre_process, p_image, image);
@@ -98,7 +98,7 @@ Ref<Image> EditorTextureImportPlugin::pre_process(Ref<Image> p_image, const Hash
 	return image;
 }
 
-Ref<Image> EditorTextureImportPlugin::post_process(Ref<Image> p_image, const HashMap<StringName, Variant> &p_options) const {
+Ref<Image> EditorTexturePostImportPlugin::post_process(Ref<Image> p_image, const HashMap<StringName, Variant> &p_options) const {
 	Ref<Image> image = p_image;
 	current_options = &p_options;
 	GDVIRTUAL_CALL(_post_process, p_image, image);
@@ -106,10 +106,10 @@ Ref<Image> EditorTextureImportPlugin::post_process(Ref<Image> p_image, const Has
 	return image;
 }
 
-void EditorTextureImportPlugin::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_option_value", "name"), &EditorTextureImportPlugin::get_option_value);
-	ClassDB::bind_method(D_METHOD("add_import_option", "name", "value"), &EditorTextureImportPlugin::add_import_option);
-	ClassDB::bind_method(D_METHOD("add_import_option_advanced", "type", "name", "default_value", "hint", "hint_string", "usage_flags"), &EditorTextureImportPlugin::add_import_option_advanced, DEFVAL(PROPERTY_HINT_NONE), DEFVAL(""), DEFVAL(PROPERTY_USAGE_DEFAULT));
+void EditorTexturePostImportPlugin::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_option_value", "name"), &EditorTexturePostImportPlugin::get_option_value);
+	ClassDB::bind_method(D_METHOD("add_import_option", "name", "value"), &EditorTexturePostImportPlugin::add_import_option);
+	ClassDB::bind_method(D_METHOD("add_import_option_advanced", "type", "name", "default_value", "hint", "hint_string", "usage_flags"), &EditorTexturePostImportPlugin::add_import_option_advanced, DEFVAL(PROPERTY_HINT_NONE), DEFVAL(""), DEFVAL(PROPERTY_USAGE_DEFAULT));
 
 	BIND_ENUM_CONSTANT(PRESET_DETECT);
 	BIND_ENUM_CONSTANT(PRESET_2D);
@@ -254,7 +254,7 @@ String ResourceImporterTexture::get_visible_name() const {
 
 void ResourceImporterTexture::get_recognized_extensions(List<String> *p_extensions) const {
 	ImageLoader::get_recognized_extensions(p_extensions);
-	for (const Ref<EditorTextureImportPlugin> &plugin : texture_import_plugins) {
+	for (const Ref<EditorTexturePostImportPlugin> &plugin : texture_import_plugins) {
 		plugin->get_recognized_extensions(p_extensions);
 	}
 }
@@ -296,7 +296,7 @@ bool ResourceImporterTexture::get_option_visibility(const String &p_path, const 
 		return p_options["mipmaps/generate"];
 	}
 
-	for (const Ref<EditorTextureImportPlugin> &plugin : texture_import_plugins) {
+	for (const Ref<EditorTexturePostImportPlugin> &plugin : texture_import_plugins) {
 		Variant ret = plugin->get_option_visibility(p_path, p_option, p_options);
 		if (ret.get_type() == Variant::BOOL && !ret) {
 			return false;
@@ -351,7 +351,7 @@ void ResourceImporterTexture::get_import_options(const String &p_path, List<Impo
 		r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "editor/convert_colors_with_editor_theme"), false));
 	}
 
-	for (const Ref<EditorTextureImportPlugin> &plugin : texture_import_plugins) {
+	for (const Ref<EditorTexturePostImportPlugin> &plugin : texture_import_plugins) {
 		plugin->get_import_options(p_path, r_options);
 	}
 }
@@ -436,7 +436,7 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 	}
 }
 
-void ResourceImporterTexture::add_texture_import_plugin(Ref<EditorTextureImportPlugin> p_plugin, bool p_first_priority) {
+void ResourceImporterTexture::add_post_import_plugin(Ref<EditorTexturePostImportPlugin> p_plugin, bool p_first_priority) {
 	ERR_FAIL_COND(p_plugin.is_null());
 	if (p_first_priority) {
 		texture_import_plugins.insert(0, p_plugin);
@@ -445,7 +445,7 @@ void ResourceImporterTexture::add_texture_import_plugin(Ref<EditorTextureImportP
 	}
 }
 
-void ResourceImporterTexture::remove_texture_import_plugin(Ref<EditorTextureImportPlugin> p_importer) {
+void ResourceImporterTexture::remove_post_import_plugin(Ref<EditorTexturePostImportPlugin> p_importer) {
 	texture_import_plugins.erase(p_importer);
 }
 
@@ -677,7 +677,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 	Error err = OK;
 	bool use_custom_loader = false;
 
-	for (const Ref<EditorTextureImportPlugin> &plugin : texture_import_plugins) {
+	for (const Ref<EditorTexturePostImportPlugin> &plugin : texture_import_plugins) {
 		image = plugin->load_image(p_source_file, &use_custom_loader, p_options);
 	}
 	ERR_FAIL_COND_V_MSG(image.is_null(), ERR_INVALID_DATA, "The returned image of _load_image() is null.");
@@ -687,7 +687,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 		ERR_FAIL_COND_V(err != OK, err);
 	}
 
-	for (const Ref<EditorTextureImportPlugin> &plugin : texture_import_plugins) {
+	for (const Ref<EditorTexturePostImportPlugin> &plugin : texture_import_plugins) {
 		image = plugin->pre_process(image, p_options);
 	}
 	ERR_FAIL_COND_V_MSG(image.is_null(), ERR_INVALID_DATA, "The returned image of _pre_process() is null.");
@@ -765,7 +765,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 		}
 	}
 
-	for (const Ref<EditorTextureImportPlugin> &plugin : texture_import_plugins) {
+	for (const Ref<EditorTexturePostImportPlugin> &plugin : texture_import_plugins) {
 		image = plugin->post_process(image, p_options);
 	}
 	ERR_FAIL_COND_V_MSG(image.is_null(), ERR_INVALID_DATA, "The returned image of _post_process() is null.");
@@ -971,7 +971,7 @@ bool ResourceImporterTexture::are_import_settings_valid(const String &p_path, co
 }
 
 ResourceImporterTexture *ResourceImporterTexture::singleton = nullptr;
-Vector<Ref<EditorTextureImportPlugin>> ResourceImporterTexture::texture_import_plugins;
+Vector<Ref<EditorTexturePostImportPlugin>> ResourceImporterTexture::texture_import_plugins;
 
 ResourceImporterTexture::ResourceImporterTexture(bool p_singleton) {
 	// This should only be set through the EditorNode.

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -41,6 +41,90 @@
 #include "editor/themes/editor_theme_manager.h"
 #include "scene/resources/compressed_texture.h"
 
+Variant EditorTextureImportPlugin::get_option_value(const StringName &p_name) const {
+	ERR_FAIL_COND_V_MSG(current_options == nullptr, Variant(), "get_option_value() called from a function where option values are not available.");
+	ERR_FAIL_COND_V_MSG(!current_options->has(p_name), Variant(), "get_option_value() called with unexisting option argument: " + String(p_name));
+	return (*current_options)[p_name];
+}
+
+void EditorTextureImportPlugin::add_import_option(const String &p_name, const Variant &p_default_value) {
+	ERR_FAIL_NULL_MSG(current_option_list, "add_import_option() can only be called from get_import_options().");
+	add_import_option_advanced(p_default_value.get_type(), p_name, p_default_value);
+}
+
+void EditorTextureImportPlugin::add_import_option_advanced(Variant::Type p_type, const String &p_name, const Variant &p_default_value, PropertyHint p_hint, const String &p_hint_string, int p_usage_flags) {
+	ERR_FAIL_NULL_MSG(current_option_list, "add_import_option_advanced() can only be called from get_import_options().");
+	current_option_list->push_back(ResourceImporter::ImportOption(PropertyInfo(p_type, p_name, p_hint, p_hint_string, p_usage_flags), p_default_value));
+}
+
+void EditorTextureImportPlugin::get_recognized_extensions(List<String> *p_extensions) const {
+	Vector<String> extensions;
+	GDVIRTUAL_CALL(_get_recognized_extensions, extensions);
+	for (int i = 0; i < extensions.size(); i++) {
+		p_extensions->push_back(extensions[i]);
+	}
+}
+
+void EditorTextureImportPlugin::get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options, Preset p_preset) const {
+	current_option_list = r_options;
+	GDVIRTUAL_CALL(_get_import_options, p_path, p_preset);
+	current_option_list = nullptr;
+}
+
+Variant EditorTextureImportPlugin::get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
+	current_options = &p_options;
+	Variant ret;
+	GDVIRTUAL_CALL(_get_option_visibility, p_path, p_option, ret);
+	current_options = nullptr;
+	return ret;
+}
+
+Ref<Image> EditorTextureImportPlugin::load_image(const String &p_source_file, bool *r_use_custom_loader, const HashMap<StringName, Variant> &p_options) const {
+	Ref<Image> image;
+	current_options = &p_options;
+	bool use_custom_loader = GDVIRTUAL_CALL(_load_image, p_source_file, image);
+	current_options = nullptr;
+	if (r_use_custom_loader) {
+		*r_use_custom_loader = use_custom_loader;
+	}
+	return image;
+}
+
+Ref<Image> EditorTextureImportPlugin::pre_process(Ref<Image> p_image, const HashMap<StringName, Variant> &p_options) const {
+	Ref<Image> image = p_image;
+	current_options = &p_options;
+	GDVIRTUAL_CALL(_pre_process, p_image, image);
+	current_options = nullptr;
+	return image;
+}
+
+Ref<Image> EditorTextureImportPlugin::post_process(Ref<Image> p_image, const HashMap<StringName, Variant> &p_options) const {
+	Ref<Image> image = p_image;
+	current_options = &p_options;
+	GDVIRTUAL_CALL(_post_process, p_image, image);
+	current_options = nullptr;
+	return image;
+}
+
+void EditorTextureImportPlugin::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_option_value", "name"), &EditorTextureImportPlugin::get_option_value);
+	ClassDB::bind_method(D_METHOD("add_import_option", "name", "value"), &EditorTextureImportPlugin::add_import_option);
+	ClassDB::bind_method(D_METHOD("add_import_option_advanced", "type", "name", "default_value", "hint", "hint_string", "usage_flags"), &EditorTextureImportPlugin::add_import_option_advanced, DEFVAL(PROPERTY_HINT_NONE), DEFVAL(""), DEFVAL(PROPERTY_USAGE_DEFAULT));
+
+	BIND_ENUM_CONSTANT(PRESET_DETECT);
+	BIND_ENUM_CONSTANT(PRESET_2D);
+	BIND_ENUM_CONSTANT(PRESET_3D);
+
+	GDVIRTUAL_BIND(_get_recognized_extensions);
+	GDVIRTUAL_BIND(_get_import_options, "path", "preset_index");
+	GDVIRTUAL_BIND(_get_option_visibility, "path", "option");
+	GDVIRTUAL_BIND(_load_image, "source_file");
+	GDVIRTUAL_BIND(_pre_process, "image");
+	GDVIRTUAL_BIND(_post_process, "image");
+}
+
+///////////////////////////////////////////////////////
+
 void ResourceImporterTexture::_texture_reimport_roughness(const Ref<CompressedTexture2D> &p_tex, const String &p_normal_path, RS::TextureDetectRoughnessChannel p_channel) {
 	ERR_FAIL_COND(p_tex.is_null());
 
@@ -170,6 +254,9 @@ String ResourceImporterTexture::get_visible_name() const {
 
 void ResourceImporterTexture::get_recognized_extensions(List<String> *p_extensions) const {
 	ImageLoader::get_recognized_extensions(p_extensions);
+	for (const Ref<EditorTextureImportPlugin> &plugin : texture_import_plugins) {
+		plugin->get_recognized_extensions(p_extensions);
+	}
 }
 
 String ResourceImporterTexture::get_save_extension() const {
@@ -207,6 +294,13 @@ bool ResourceImporterTexture::get_option_visibility(const String &p_path, const 
 
 	} else if (p_option == "mipmaps/limit") {
 		return p_options["mipmaps/generate"];
+	}
+
+	for (const Ref<EditorTextureImportPlugin> &plugin : texture_import_plugins) {
+		Variant ret = plugin->get_option_visibility(p_path, p_option, p_options);
+		if (ret.get_type() == Variant::BOOL && !ret) {
+			return false;
+		}
 	}
 
 	return true;
@@ -255,6 +349,10 @@ void ResourceImporterTexture::get_import_options(const String &p_path, List<Impo
 		// Editor use only, applies to SVG.
 		r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "editor/scale_with_editor_scale"), false));
 		r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "editor/convert_colors_with_editor_theme"), false));
+	}
+
+	for (const Ref<EditorTextureImportPlugin> &plugin : texture_import_plugins) {
+		plugin->get_import_options(p_path, r_options);
 	}
 }
 
@@ -336,6 +434,23 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 			f->store_buffer(data.ptr(), data_size);
 		} break;
 	}
+}
+
+void ResourceImporterTexture::add_texture_import_plugin(Ref<EditorTextureImportPlugin> p_plugin, bool p_first_priority) {
+	ERR_FAIL_COND(p_plugin.is_null());
+	if (p_first_priority) {
+		texture_import_plugins.insert(0, p_plugin);
+	} else {
+		texture_import_plugins.push_back(p_plugin);
+	}
+}
+
+void ResourceImporterTexture::remove_texture_import_plugin(Ref<EditorTextureImportPlugin> p_importer) {
+	texture_import_plugins.erase(p_importer);
+}
+
+void ResourceImporterTexture::clean_up_importer_plugins() {
+	texture_import_plugins.clear();
 }
 
 void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_roughness, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel) {
@@ -559,10 +674,24 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 	// Load the main image.
 	Ref<Image> image;
 	image.instantiate();
-	Error err = ImageLoader::load_image(p_source_file, image, nullptr, loader_flags, scale);
-	if (err != OK) {
-		return err;
+	Error err = OK;
+	bool use_custom_loader = false;
+
+	for (const Ref<EditorTextureImportPlugin> &plugin : texture_import_plugins) {
+		image = plugin->load_image(p_source_file, &use_custom_loader, p_options);
 	}
+	ERR_FAIL_COND_V_MSG(image.is_null(), ERR_INVALID_DATA, "The returned image of _load_image() is null.");
+
+	if (!use_custom_loader) {
+		err = ImageLoader::load_image(p_source_file, image, nullptr, loader_flags, scale);
+		ERR_FAIL_COND_V(err != OK, err);
+	}
+
+	for (const Ref<EditorTextureImportPlugin> &plugin : texture_import_plugins) {
+		image = plugin->pre_process(image, p_options);
+	}
+	ERR_FAIL_COND_V_MSG(image.is_null(), ERR_INVALID_DATA, "The returned image of _pre_process() is null.");
+
 	images_imported.push_back(image);
 
 	// Load the editor-only image.
@@ -635,6 +764,11 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 			_clamp_hdr_exposure(target_image);
 		}
 	}
+
+	for (const Ref<EditorTextureImportPlugin> &plugin : texture_import_plugins) {
+		image = plugin->post_process(image, p_options);
+	}
+	ERR_FAIL_COND_V_MSG(image.is_null(), ERR_INVALID_DATA, "The returned image of _post_process() is null.");
 
 	bool detect_3d = int(p_options["detect_3d/compress_to"]) > 0;
 	bool detect_roughness = roughness == 0;
@@ -837,6 +971,7 @@ bool ResourceImporterTexture::are_import_settings_valid(const String &p_path, co
 }
 
 ResourceImporterTexture *ResourceImporterTexture::singleton = nullptr;
+Vector<Ref<EditorTextureImportPlugin>> ResourceImporterTexture::texture_import_plugins;
 
 ResourceImporterTexture::ResourceImporterTexture(bool p_singleton) {
 	// This should only be set through the EditorNode.

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -37,8 +37,8 @@
 
 class CompressedTexture2D;
 
-class EditorTextureImportPlugin : public RefCounted {
-	GDCLASS(EditorTextureImportPlugin, RefCounted);
+class EditorTexturePostImportPlugin : public RefCounted {
+	GDCLASS(EditorTexturePostImportPlugin, RefCounted);
 
 public:
 	enum Preset {
@@ -74,12 +74,12 @@ public:
 	virtual Ref<Image> pre_process(Ref<Image> p_image, const HashMap<StringName, Variant> &p_options) const;
 	virtual Ref<Image> post_process(Ref<Image> p_image, const HashMap<StringName, Variant> &p_options) const;
 };
-VARIANT_ENUM_CAST(EditorTextureImportPlugin::Preset);
+VARIANT_ENUM_CAST(EditorTexturePostImportPlugin::Preset);
 
 class ResourceImporterTexture : public ResourceImporter {
 	GDCLASS(ResourceImporterTexture, ResourceImporter);
 
-	static Vector<Ref<EditorTextureImportPlugin>> texture_import_plugins;
+	static Vector<Ref<EditorTexturePostImportPlugin>> texture_import_plugins;
 
 public:
 	enum CompressMode {
@@ -125,8 +125,8 @@ public:
 
 	static ResourceImporterTexture *get_singleton() { return singleton; }
 
-	static void add_texture_import_plugin(Ref<EditorTextureImportPlugin> p_plugin, bool p_first_priority = false);
-	static void remove_texture_import_plugin(Ref<EditorTextureImportPlugin> p_plugin);
+	static void add_post_import_plugin(Ref<EditorTexturePostImportPlugin> p_plugin, bool p_first_priority = false);
+	static void remove_post_import_plugin(Ref<EditorTexturePostImportPlugin> p_plugin);
 	static void clean_up_importer_plugins();
 
 	virtual String get_importer_name() const override;

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -429,12 +429,12 @@ void EditorPlugin::remove_import_plugin(const Ref<EditorImportPlugin> &p_importe
 	}
 }
 
-void EditorPlugin::add_texture_import_plugin(const Ref<EditorTextureImportPlugin> &p_importer, bool p_first_priority) {
-	ResourceImporterTexture::get_singleton()->add_texture_import_plugin(p_importer, p_first_priority);
+void EditorPlugin::add_texture_post_import_plugin(const Ref<EditorTexturePostImportPlugin> &p_importer, bool p_first_priority) {
+	ResourceImporterTexture::get_singleton()->add_post_import_plugin(p_importer, p_first_priority);
 }
 
-void EditorPlugin::remove_texture_import_plugin(const Ref<EditorTextureImportPlugin> &p_importer) {
-	ResourceImporterTexture::get_singleton()->remove_texture_import_plugin(p_importer);
+void EditorPlugin::remove_texture_post_import_plugin(const Ref<EditorTexturePostImportPlugin> &p_importer) {
+	ResourceImporterTexture::get_singleton()->remove_post_import_plugin(p_importer);
 }
 
 void EditorPlugin::add_export_plugin(const Ref<EditorExportPlugin> &p_exporter) {
@@ -626,8 +626,8 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_translation_parser_plugin", "parser"), &EditorPlugin::remove_translation_parser_plugin);
 	ClassDB::bind_method(D_METHOD("add_import_plugin", "importer", "first_priority"), &EditorPlugin::add_import_plugin, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_import_plugin", "importer"), &EditorPlugin::remove_import_plugin);
-	ClassDB::bind_method(D_METHOD("add_texture_import_plugin", "importer", "first_priority"), &EditorPlugin::add_texture_import_plugin, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("remove_texture_import_plugin", "importer"), &EditorPlugin::remove_texture_import_plugin);
+	ClassDB::bind_method(D_METHOD("add_texture_post_import_plugin", "importer", "first_priority"), &EditorPlugin::add_texture_post_import_plugin, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("remove_texture_post_import_plugin", "importer"), &EditorPlugin::remove_texture_post_import_plugin);
 	ClassDB::bind_method(D_METHOD("add_scene_format_importer_plugin", "scene_format_importer", "first_priority"), &EditorPlugin::add_scene_format_importer_plugin, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_scene_format_importer_plugin", "scene_format_importer"), &EditorPlugin::remove_scene_format_importer_plugin);
 	ClassDB::bind_method(D_METHOD("add_scene_post_import_plugin", "scene_import_plugin", "first_priority"), &EditorPlugin::add_scene_post_import_plugin, DEFVAL(false));

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -429,6 +429,14 @@ void EditorPlugin::remove_import_plugin(const Ref<EditorImportPlugin> &p_importe
 	}
 }
 
+void EditorPlugin::add_texture_import_plugin(const Ref<EditorTextureImportPlugin> &p_importer, bool p_first_priority) {
+	ResourceImporterTexture::get_singleton()->add_texture_import_plugin(p_importer, p_first_priority);
+}
+
+void EditorPlugin::remove_texture_import_plugin(const Ref<EditorTextureImportPlugin> &p_importer) {
+	ResourceImporterTexture::get_singleton()->remove_texture_import_plugin(p_importer);
+}
+
 void EditorPlugin::add_export_plugin(const Ref<EditorExportPlugin> &p_exporter) {
 	ERR_FAIL_COND(p_exporter.is_null());
 	EditorExport::get_singleton()->add_export_plugin(p_exporter);
@@ -618,6 +626,8 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_translation_parser_plugin", "parser"), &EditorPlugin::remove_translation_parser_plugin);
 	ClassDB::bind_method(D_METHOD("add_import_plugin", "importer", "first_priority"), &EditorPlugin::add_import_plugin, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_import_plugin", "importer"), &EditorPlugin::remove_import_plugin);
+	ClassDB::bind_method(D_METHOD("add_texture_import_plugin", "importer", "first_priority"), &EditorPlugin::add_texture_import_plugin, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("remove_texture_import_plugin", "importer"), &EditorPlugin::remove_texture_import_plugin);
 	ClassDB::bind_method(D_METHOD("add_scene_format_importer_plugin", "scene_format_importer", "first_priority"), &EditorPlugin::add_scene_format_importer_plugin, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_scene_format_importer_plugin", "scene_format_importer"), &EditorPlugin::remove_scene_format_importer_plugin);
 	ClassDB::bind_method(D_METHOD("add_scene_post_import_plugin", "scene_import_plugin", "first_priority"), &EditorPlugin::add_scene_post_import_plugin, DEFVAL(false));

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -223,8 +223,8 @@ public:
 	void add_import_plugin(const Ref<EditorImportPlugin> &p_importer, bool p_first_priority = false);
 	void remove_import_plugin(const Ref<EditorImportPlugin> &p_importer);
 
-	void add_texture_import_plugin(const Ref<EditorTextureImportPlugin> &p_importer, bool p_first_priority = false);
-	void remove_texture_import_plugin(const Ref<EditorTextureImportPlugin> &p_importer);
+	void add_texture_post_import_plugin(const Ref<EditorTexturePostImportPlugin> &p_importer, bool p_first_priority = false);
+	void remove_texture_post_import_plugin(const Ref<EditorTexturePostImportPlugin> &p_importer);
 
 	void add_export_plugin(const Ref<EditorExportPlugin> &p_exporter);
 	void remove_export_plugin(const Ref<EditorExportPlugin> &p_exporter);

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/config_file.h"
+#include "editor/import/resource_importer_texture.h"
 #include "editor/plugins/editor_context_menu_plugin.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/gui/control.h"
@@ -221,6 +222,9 @@ public:
 
 	void add_import_plugin(const Ref<EditorImportPlugin> &p_importer, bool p_first_priority = false);
 	void remove_import_plugin(const Ref<EditorImportPlugin> &p_importer);
+
+	void add_texture_import_plugin(const Ref<EditorTextureImportPlugin> &p_importer, bool p_first_priority = false);
+	void remove_texture_import_plugin(const Ref<EditorTextureImportPlugin> &p_importer);
 
 	void add_export_plugin(const Ref<EditorExportPlugin> &p_exporter);
 	void remove_export_plugin(const Ref<EditorExportPlugin> &p_exporter);

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -205,7 +205,7 @@ void register_editor_types() {
 	GDREGISTER_CLASS(ResourceImporterTextureAtlas);
 	GDREGISTER_CLASS(ResourceImporterWAV);
 
-	GDREGISTER_CLASS(EditorTextureImportPlugin);
+	GDREGISTER_CLASS(EditorTexturePostImportPlugin);
 
 	// This list is alphabetized, and plugins that depend on Node2D are in their own section below.
 	EditorPlugins::add_by_type<AnimationTreeEditorPlugin>();

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -205,6 +205,8 @@ void register_editor_types() {
 	GDREGISTER_CLASS(ResourceImporterTextureAtlas);
 	GDREGISTER_CLASS(ResourceImporterWAV);
 
+	GDREGISTER_CLASS(EditorTextureImportPlugin);
+
 	// This list is alphabetized, and plugins that depend on Node2D are in their own section below.
 	EditorPlugins::add_by_type<AnimationTreeEditorPlugin>();
 	EditorPlugins::add_by_type<AudioStreamEditorPlugin>();


### PR DESCRIPTION
Partially implements https://github.com/godotengine/godot-proposals/issues/1943
This PR intends to address the situation that many proposals need  options to customize texture importer:
- https://github.com/godotengine/godot-proposals/issues/11243
- https://github.com/godotengine/godot-proposals/issues/11997
- https://github.com/godotengine/godot-proposals/issues/9618
- https://github.com/godotengine/godot-proposals/issues/5247

Related PRs:
- https://github.com/godotengine/godot/pull/81803
- https://github.com/godotengine/godot/pull/91284
- https://github.com/godotengine/godot/pull/99676
- https://github.com/godotengine/godot/pull/88669
- https://github.com/godotengine/godot/pull/100226
- https://github.com/godotengine/godot/pull/91580

`EditorTextureImportPlugin` can be used to extend `ResourceImporterTexture` and modify the process of importing `CompressedTexture2D`, allowing to load custom file format, add importer options, and change the image when processing.

The design mainly refers to the `EditorScenePostImportPlugin`.

Example:
```gdscript
@tool
extends EditorTextureImportPlugin

func _load_image(source_file: String) -> Image:
    var image := Image.load_from_file(source_file)
    return image
    
func _get_import_options(path: String, preset_index: int) -> void:
    add_import_option("process/resize", Vector2i(0, 0))
    add_import_option("process/trim_alpha", false)
    add_import_option("process/invert_color", false)

func _pre_process(image: Image) -> Image:
    var resize: Vector2i = get_option_value("process/resize")
    var trim_alpha: bool = get_option_value("process/trim_alpha")
    var invert_color: bool = get_option_value("process/invert_color")

    if resize.x > 0 and resize.y > 0:
        image.resize(resize.x, resize.y, Image.INTERPOLATE_CUBIC)
    
    if trim_alpha:
        var rect := image.get_used_rect();
        var img := image.get_region(rect);
        image.set_data(rect.size.x, rect.size.y, image.has_mipmaps(), image.get_format(), img.get_data());

    if invert_color:
        for i in range(image.get_width()):
            for j in range(image.get_height()):
                var color := image.get_pixel(i, j);
                var inverted := Color(1 - color.r, 1 - color.g, 1 - color.b, color.a);
                image.set_pixel(i, j, inverted);
            
    return image

```