### PR TITLE
LSP: Don't serialize empty documentation

### DIFF
--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1077,8 +1077,12 @@ struct CompletionItem {
 			dict["insertText"] = insertText;
 		}
 		if (resolved) {
-			dict["detail"] = detail;
-			dict["documentation"] = documentation.to_json();
+			if (!detail.is_empty()) {
+				dict["detail"] = detail;
+			}
+			if (!documentation.value.is_empty()) {
+				dict["documentation"] = documentation.to_json();
+			}
 			dict["deprecated"] = deprecated;
 			dict["preselect"] = preselect;
 			if (!sortText.is_empty()) {


### PR DESCRIPTION
Related to https://github.com/godotengine/godot-vscode-plugin/issues/842

When we send empty strings as documentation VSCode will still show a window for documentation but it stays empty. Those properties are optional in LSP so we can omit them if we were not able to resolve meaningful content.

This still doesn't solve the fact that we should be able to resolve the documentation in the context of the issue. But there are suggestions for which we will never be able to find documentation (e.g. argument options).
