### PR TITLE
[.NET] Fix extraction of C# default property values when negative

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptPropertyDefVal.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptPropertyDefVal.generated.cs
@@ -22,7 +22,7 @@ partial class ExportedFields
         values.Add(PropertyName.@_fieldInt16, global::Godot.Variant.From<short>(___fieldInt16_default_value));
         int ___fieldInt32_default_value = 10;
         values.Add(PropertyName.@_fieldInt32, global::Godot.Variant.From<int>(___fieldInt32_default_value));
-        long ___fieldInt64_default_value = 10;
+        long ___fieldInt64_default_value = -10_000;
         values.Add(PropertyName.@_fieldInt64, global::Godot.Variant.From<long>(___fieldInt64_default_value));
         byte ___fieldByte_default_value = 10;
         values.Add(PropertyName.@_fieldByte, global::Godot.Variant.From<byte>(___fieldByte_default_value));

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptPropertyDefVal.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptPropertyDefVal.generated.cs
@@ -36,7 +36,7 @@ partial class ExportedProperties
         values.Add(PropertyName.@PropertyInt16, global::Godot.Variant.From<short>(__PropertyInt16_default_value));
         int __PropertyInt32_default_value = 10;
         values.Add(PropertyName.@PropertyInt32, global::Godot.Variant.From<int>(__PropertyInt32_default_value));
-        long __PropertyInt64_default_value = 10;
+        long __PropertyInt64_default_value = -10_000;
         values.Add(PropertyName.@PropertyInt64, global::Godot.Variant.From<long>(__PropertyInt64_default_value));
         byte __PropertyByte_default_value = 10;
         values.Add(PropertyName.@PropertyByte, global::Godot.Variant.From<byte>(__PropertyByte_default_value));

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedFields.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedFields.cs
@@ -9,7 +9,7 @@ public partial class ExportedFields : GodotObject
     [Export] private SByte _fieldSByte = 10;
     [Export] private Int16 _fieldInt16 = 10;
     [Export] private Int32 _fieldInt32 = 10;
-    [Export] private Int64 _fieldInt64 = 10;
+    [Export] private Int64 _fieldInt64 = -10_000;
     [Export] private Byte _fieldByte = 10;
     [Export] private UInt16 _fieldUInt16 = 10;
     [Export] private UInt32 _fieldUInt32 = 10;

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedProperties.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedProperties.cs
@@ -97,7 +97,7 @@ public partial class ExportedProperties : GodotObject
     [Export] private SByte PropertySByte { get; set; } = 10;
     [Export] private Int16 PropertyInt16 { get; set; } = 10;
     [Export] private Int32 PropertyInt32 { get; set; } = 10;
-    [Export] private Int64 PropertyInt64 { get; set; } = 10;
+    [Export] private Int64 PropertyInt64 { get; set; } = -10_000;
     [Export] private Byte PropertyByte { get; set; } = 10;
     [Export] private UInt16 PropertyUInt16 { get; set; } = 10;
     [Export] private UInt32 PropertyUInt32 { get; set; } = 10;

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
@@ -430,6 +430,13 @@ namespace Godot.SourceGenerators
                 return true;
             }
 
+            // Handle negative literals (e.g., `-10`)
+            if (expression is PrefixUnaryExpressionSyntax { Operand: LiteralExpressionSyntax } &&
+                expression.Kind() == SyntaxKind.UnaryMinusExpression)
+            {
+                return true;
+            }
+
             // Handle identifiers (e.g., variable names)
             if (expression is IdentifierNameSyntax identifier)
             {


### PR DESCRIPTION
Fixes #105348. This was an obvious overlook. I changed some test values so we cover negative literals. 

Cheers.