### PR TITLE
Improve GridMap collider navmesh baking performance when using bake bounds

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -96,6 +96,13 @@
 				This function returns always the map set on the GridMap node and not the map on the NavigationServer. If the map is changed directly with the NavigationServer API the GridMap node will not be aware of the map change.
 			</description>
 		</method>
+		<method name="get_octant_coords_from_cell_coords" qualifiers="const">
+			<return type="Vector3i" />
+			<param index="0" name="cell_coords" type="Vector3i" />
+			<description>
+				Returns the [Vector3i] octant coordinates of the [param cell_coords].
+			</description>
+		</method>
 		<method name="get_orthogonal_index_from_basis" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="basis" type="Basis" />
@@ -114,6 +121,41 @@
 			<param index="0" name="item" type="int" />
 			<description>
 				Returns an array of all cells with the given item index specified in [param item].
+			</description>
+		</method>
+		<method name="get_used_cells_in_octant" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="octant_coords" type="Vector3i" />
+			<description>
+				Returns an array of [Vector3i] with the non-empty cell coordinates inside the octant at [param octant_coords].
+			</description>
+		</method>
+		<method name="get_used_cells_in_octant_by_item" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="octant_coords" type="Vector3i" />
+			<param index="1" name="item" type="int" />
+			<description>
+				Returns an array of [Vector3i] with the non-empty cell coordinates inside the octant at [param octant_coords]. that use the specified cell [param item].
+			</description>
+		</method>
+		<method name="get_used_octants" qualifiers="const">
+			<return type="Vector3i[]" />
+			<description>
+				Returns an array of [Vector3i] with the non-empty octant coordinates in the grid map.
+			</description>
+		</method>
+		<method name="get_used_octants_by_item" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="item" type="int" />
+			<description>
+				Returns an array of [Vector3i] with the non-empty octant coordinates that use the specified [param item] in the grid map.
+			</description>
+		</method>
+		<method name="get_used_octants_in_bounds" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="bounds" type="AABB" />
+			<description>
+				Returns an array of [Vector3i] with the non-empty octant coordinates that are inside the local [param bounds].
 			</description>
 		</method>
 		<method name="local_to_map" qualifiers="const">

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -152,6 +152,9 @@ class GridMap : public Node3D {
 		OctantKey() {}
 	};
 
+	OctantKey get_octant_key_from_index_key(const IndexKey &p_index_key) const;
+	OctantKey get_octant_key_from_cell_coords(const Vector3i &p_cell_coords) const;
+
 #ifndef PHYSICS_3D_DISABLED
 	uint32_t collision_layer = 1;
 	uint32_t collision_mask = 1;
@@ -300,6 +303,16 @@ public:
 
 	TypedArray<Vector3i> get_used_cells() const;
 	TypedArray<Vector3i> get_used_cells_by_item(int p_item) const;
+
+	TypedArray<Vector3i> get_used_octants() const;
+	TypedArray<Vector3i> get_used_octants_by_item(int p_item) const;
+
+	TypedArray<Vector3i> get_used_cells_in_octant(const Vector3i &p_octant_coords) const;
+	TypedArray<Vector3i> get_used_cells_in_octant_by_item(const Vector3i &p_octant_coords, int p_item) const;
+
+	TypedArray<Vector3i> get_used_octants_in_bounds(const AABB &p_bounds) const;
+	Vector3i get_octant_coords_from_cell_coords(const Vector3i &p_cell_coords) const;
+	RID get_physics_body_from_octant_coord(const Vector3i &p_octant_coords) const;
 
 	Array get_meshes() const;
 


### PR DESCRIPTION
Improves performance of GridMap navmesh baking by only querying relevant octants inside the bake bounds.

Requires https://github.com/godotengine/godot/pull/105329 and https://github.com/godotengine/godot/pull/105332 to be merged first.

This improves navmesh baking performance when baking GridMap cells with  **physics colliders** using the bake bounds, e.g. for chunk baking. Remember to set the NavigationMesh parse settings to only parse static colliders.

**DONT PARSE GRIDMAP VISUAL MESHES FOR NAVMESH BAKING** ... if you want performance at least.

If you still parse the GridMap visual meshes due to default bake settings your performance will remain horrible on larger GridMaps as for every visual mesh getter call the entire GPU gets stalled.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
