### PR TITLE
Improve get_cursor_shape() documentation

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -385,7 +385,7 @@
 			<return type="int" enum="Control.CursorShape" />
 			<param index="0" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Returns the mouse cursor shape the control displays on mouse hover. See [enum CursorShape].
+				Returns the mouse cursor shape for this control when hovered over [param position] in local coordinates. For most controls, this is the same as [member mouse_default_cursor_shape], but some built-in controls implement more complex logic. See [enum CursorShape].
 			</description>
 		</method>
 		<method name="get_end" qualifiers="const">


### PR DESCRIPTION
To hopefully spare some people the headache I had.

This method is overridden for some Godot controls, but there is no way to override it yourself. It does the same as getting the default cursor shape for controls that haven't overridden it.