### PR TITLE
Add copyright attribution metadata to icon.svg

### DIFF
--- a/icon.svg
+++ b/icon.svg
@@ -1,1 +1,43 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024"><g fill="#fff"><path d="M105 673v33q407 354 814 0v-33z"/><path fill="#478cbf" d="m105 673 152 14q12 1 15 14l4 67 132 10 8-61q2-11 15-15h162q13 4 15 15l8 61 132-10 4-67q3-13 15-14l152-14V427q30-39 56-81-35-59-83-108-43 20-82 47-40-37-88-64 7-51 8-102-59-28-123-42-26 43-46 89-49-7-98 0-20-46-46-89-64 14-123 42 1 51 8 102-48 27-88 64-39-27-82-47-48 49-83 108 26 42 56 81zm0 33v39c0 276 813 276 814 0v-39l-134 12-5 69q-2 10-14 13l-162 11q-12 0-16-11l-10-65H446l-10 65q-4 11-16 11l-162-11q-12-3-14-13l-5-69z"/><path d="M483 600c0 34 58 34 58 0v-86c0-34-58-34-58 0z"/><circle cx="725" cy="526" r="90"/><circle cx="299" cy="526" r="90"/></g><g fill="#414042"><circle cx="307" cy="532" r="60"/><circle cx="717" cy="532" r="60"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" width="1024" height="1024">
+    <g fill="#fff">
+        <path d="m105 673v33q407 354 814 0v-33z"/>
+        <path fill="#478cbf" d="m105 673 152 14q12 1 15 14l4 67 132 10 8-61q2-11 15-15h162q13 4 15 15l8 61 132-10 4-67q3-13 15-14l152-14V427q30-39 56-81-35-59-83-108-43 20-82 47-40-37-88-64 7-51 8-102-59-28-123-42-26 43-46 89-49-7-98 0-20-46-46-89-64 14-123 42 1 51 8 102-48 27-88 64-39-27-82-47-48 49-83 108 26 42 56 81zm0 33v39c0 276 813 276 814 0v-39l-134 12-5 69q-2 10-14 13l-162 11q-12 0-16-11l-10-65H446l-10 65q-4 11-16 11l-162-11q-12-3-14-13l-5-69z"/>
+        <path d="m483 600c0 34 58 34 58 0v-86c0-34-58-34-58 0z"/>
+        <circle cx="725" cy="526" r="90"/>
+        <circle cx="299" cy="526" r="90"/>
+    </g>
+    <g fill="#414042">
+        <circle cx="307" cy="532" r="60"/>
+        <circle cx="717" cy="532" r="60"/>
+    </g>
+    <metadata>
+        <rdf:RDF>
+            <cc:Work>
+                <dc:creator>
+                    <cc:Agent>
+                        <dc:title>
+                            Andrea Calabró
+                        </dc:title>
+                    </cc:Agent>
+                </dc:creator>
+                <dc:title>
+                    Godot Engine logo
+                </dc:title>
+                <dc:source>
+                    https://godotengine.org
+                </dc:source>
+                <cc:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
+                <dc:date>
+                    2017
+                </dc:date>
+            </cc:Work>
+            <cc:License rdf:about="http://creativecommons.org/licenses/by/4.0/">
+                <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+                <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+                <cc:requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+                <cc:requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+                <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+            </cc:License>
+        </rdf:RDF>
+    </metadata>
+</svg>


### PR DESCRIPTION
See also: https://github.com/godotengine/godot/pull/61955#issuecomment-1986723262

# TODO

- [as bruvzg mentioned](https://github.com/godotengine/godot/pull/105358#issuecomment-2800062346), this PR should actually change `editor/icons/DefaultProjectIcon.svg`, not `icon.svg`.
- I am not sure if `<dc:date>2017</dc:date>` is correct or if `Copyright (c) 2017` should be used somewhere.
- Fix potential CI/CD bug (see below)

---

**Edit:** Was a comment (`<!-- -->`), but now it is SVG metadata.

SVG metadata resources:

- https://svgo.dev/docs/plugins/removeMetadata/
- https://www.w3.org/TR/SVGTiny12/metadata.html#metadataElementExample
- https://opensource.creativecommons.org/ccrel/

## CI/CD: Possible SVGO bug

- [svg/svgo#431](/svg/svgo/issues/431)
- [svg/svgo#1609](/svg/svgo/issues/1609)

SVGO strips the metadata unless both these overrides are present. However, this incorrectly also whitelists editor metadata like `xmlns:inkscape`.

```diff
diff --git a/misc/utility/svgo.config.mjs b/misc/utility/svgo.config.mjs
index 3849103e2b..10ba9063d5 100644
--- a/misc/utility/svgo.config.mjs
+++ b/misc/utility/svgo.config.mjs
@@ -12,6 +12,8 @@ export default {
                                overrides: {
                                        removeHiddenElems: false,
                                        convertPathData: false,
+                                       removeEditorsNSData: false,
+                                       removeMetadata: false,
                                },
                        },
                },
```

A possible workaround is using `scour` or another optimizer.

`scour --no-line-breaks icon.svg > _icon.svg && mv _icon.svg icon.svg`

In the meantime, I enabled pretty print so the diff is easier to view.

`svgo icon.svg --config misc/utility/svgo.config.mjs --pretty`