### PR TITLE
Update OS.request_permission (and related) descriptions to reflect reality. 

### DIFF
--- a/doc/classes/MainLoop.xml
+++ b/doc/classes/MainLoop.xml
@@ -96,7 +96,7 @@
 			<param index="0" name="permission" type="String" />
 			<param index="1" name="granted" type="bool" />
 			<description>
-				Emitted when a user responds to a permission request.
+				Emitted when a user responds to a permission request. In the case of multiple requests under Android, eg. via [method OS.request_permissions], the signals emit only once the OS is satisfied user-dialogue is complete; one signal per requested permission come that time.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -751,19 +751,19 @@
 			<return type="bool" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Requests permission from the OS for the given [param name]. Returns [code]true[/code] if the permission has already been granted. See also [signal MainLoop.on_request_permissions_result].
+				Requests a [i]dangerous[/i] permission (matching the given [param name]) from the OS. Returns [code]true[/code] unless [param name] is a valid [i]dangerous[/i] permission which has not already been granted. Otherwise dispatches the appropriate request to Android and returns [code]false[/code]. See also [signal MainLoop.on_request_permissions_result].
 				The [param name] must be the full permission name. For example:
 				- [code]OS.request_permission("android.permission.READ_EXTERNAL_STORAGE")[/code]
 				- [code]OS.request_permission("android.permission.POST_NOTIFICATIONS")[/code]
-				[b]Note:[/b] Permission must be checked during export.
 				[b]Note:[/b] This method is only implemented on Android.
+				[b]Note:[/b] In use, it is a requirement that said permission be ticked during export time; to insert it into AndroidManifest, and prevent the OS / [signal MainLoop.on_request_permissions_result] from reporting immediately back upon request that the permission was user-denied.
+				[b]Note:[/b] Under current implementations, single-permission requests such as this are simply discarded if the OS' permissions dialog is already open, awaiting user input. Care should be taken in handing 'focus' over between app, OS, and back; potentially even pausing the scene-tree where appropriate.
 			</description>
 		</method>
 		<method name="request_permissions">
 			<return type="bool" />
 			<description>
-				Requests [i]dangerous[/i] permissions from the OS. Returns [code]true[/code] if permissions have already been granted. See also [signal MainLoop.on_request_permissions_result].
-				[b]Note:[/b] Permissions must be checked during export.
+				Requests [i]dangerous[/i] permissions from the OS; as per the AndroidManifest (ie, those ticked during export). Returns [code]true[/code] if all permissions have already been granted. Otherwise dispatches the appropriate request(s) to Android and returns [code]false[/code]. See also [signal MainLoop.on_request_permissions_result].
 				[b]Note:[/b] This method is only implemented on Android. Normal permissions are automatically granted at install time in Android applications.
 			</description>
 		</method>


### PR DESCRIPTION
From a peek through the code, probably just some Legacy goop from the ever-evolving challenges Android likes to throw us. :-D

Contrary to what its previous description claimed, functionally, request_permission returns true not just when the permission has been granted. Pass it some junk, a 'normal' permission (even one without an entry in AndroidManifest!), or a typo, and - as request_permission is in essence actually a "!dispatched to Android" method - it also returns true! Quite misleading.

... fine for the plural method, request_permission**s**, because there's no room for bad parameters to get passed in there. Though this, in turn, suggests the original note about checking 'exports' for that method could use some elaboration for what that does; now offered.

Finally, it was originally unclear when, exactly, the on_request_permissions_result signal / signals might fire where the plural method initiated the requests; per permission, or all at once? It's <sorta> all at once - phew! - but with the caveat discovered, however, that any singular request_permission made whilst the OS dialogue is open is apparently just cast aside... even though our method returns the false value suggesting it was dispatched. :-/ Popped a warning on the request_permission description not to do something daft like that, then.