### PR TITLE
Fix `Array::insert`

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -318,8 +318,6 @@ Error Array::insert(int p_pos, const Variant &p_value) {
 		p_pos = _p->array.size() + p_pos;
 	}
 
-	ERR_FAIL_INDEX_V_MSG(p_pos, _p->array.size(), ERR_INVALID_PARAMETER, vformat("The calculated index %d is out of bounds (the array has %d elements). Leaving the array untouched.", p_pos, _p->array.size()));
-
 	return _p->array.insert(p_pos, std::move(value));
 }
 
@@ -494,8 +492,6 @@ void Array::remove_at(int p_pos) {
 		// Relative offset from the end.
 		p_pos = _p->array.size() + p_pos;
 	}
-
-	ERR_FAIL_INDEX_MSG(p_pos, _p->array.size(), vformat("The calculated index %d is out of bounds (the array has %d elements). Leaving the array untouched.", p_pos, _p->array.size()));
 
 	_p->array.remove_at(p_pos);
 }

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -126,12 +126,14 @@ TEST_CASE("[Array] resize(), insert(), and erase()") {
 	CHECK(int(arr[0]) == 2);
 	arr.erase(2);
 	CHECK(int(arr[0]) == 1);
-
-	// Negative index on insert.
-	CHECK(arr.size() == 3);
+	arr.resize(0);
+	CHECK(arr.size() == 0);
+	arr.insert(0, 8);
+	CHECK(arr.size() == 1);
+	arr.insert(1, 16);
+	CHECK(int(arr[1]) == 16);
 	arr.insert(-1, 3);
-	CHECK(int(arr[2]) == 3);
-	CHECK(arr.size() == 4);
+	CHECK(int(arr[1]) == 3);
 }
 
 TEST_CASE("[Array] front() and back()") {


### PR DESCRIPTION
A bounds-check in `Array::insert` was using the old array size, preventing insertions at the array's size.
There exists a check in `CowData::insert` that uses the correct method of checking the new array size, so the redundant and incorrect check in `Array::insert` was removed.

To avoid this regression happening again, tests were added which insert values at the array size.

The commit that added the check also added a similarly redundant check to `Array::remove_at` which was also removed in this commit.
