### PR TITLE
Add inspector support for typed property hint formats

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2849,6 +2849,7 @@
 		<constant name="PROPERTY_HINT_TYPE_STRING" value="23" enum="PropertyHint">
 			If a property is [String], hints that the property represents a particular type (class). This allows to select a type from the create dialog. The property will store the selected type as a string.
 			If a property is [Array], hints the editor how to show elements. The [code]hint_string[/code] must encode nested types using [code]":"[/code] and [code]"/"[/code].
+			If a property is [Dictionary], hints the editor how to show elements. The [code]hint_string[/code] is the same as [Array], with a [code]";"[/code] separating the key and value.
 			[codeblocks]
 			[gdscript]
 			# Array of elem_type.
@@ -2923,10 +2924,12 @@
 			Hints that an [int] property is a pointer. Used by GDExtension.
 		</constant>
 		<constant name="PROPERTY_HINT_ARRAY_TYPE" value="31" enum="PropertyHint">
-			Hints that a property is an [Array] with the stored type specified in the hint string.
+			Hints that a property is an [Array] with the stored type specified in the hint string. The hint string contains the type of the array (e.g. [code]"String"[/code]).
+			Use the hint string format from [constant PROPERTY_HINT_TYPE_STRING] for more control over the stored type.
 		</constant>
 		<constant name="PROPERTY_HINT_DICTIONARY_TYPE" value="38" enum="PropertyHint">
 			Hints that a property is a [Dictionary] with the stored types specified in the hint string. The hint string contains the key and value types separated by a semicolon (e.g. [code]"int;String"[/code]).
+			Use the hint string format from [constant PROPERTY_HINT_TYPE_STRING] for more control over the stored types.
 		</constant>
 		<constant name="PROPERTY_HINT_LOCALE_ID" value="32" enum="PropertyHint">
 			Hints that a string property is a locale code. Editing it will show a locale dialog for picking language and country.

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -865,6 +865,14 @@ void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint
 
 			subtype_hint_string = p_hint_string.substr(hint_subtype_separator + 1);
 			subtype = Variant::Type(subtype_string.to_int());
+		} else {
+			subtype = Variant::get_type_by_name(p_hint_string);
+
+			if (subtype == Variant::VARIANT_MAX) {
+				subtype = Variant::OBJECT;
+				subtype_hint = PROPERTY_HINT_RESOURCE_TYPE;
+				subtype_hint_string = p_hint_string;
+			}
 		}
 	}
 }
@@ -1155,12 +1163,21 @@ void EditorPropertyDictionary::setup(PropertyHint p_hint, const String &p_hint_s
 
 			key_subtype_hint_string = key.substr(hint_key_subtype_separator + 1);
 			key_subtype = Variant::Type(key_subtype_string.to_int());
+		} else {
+			key_subtype = Variant::get_type_by_name(key);
 
-			Variant new_key = object->get_new_item_key();
-			VariantInternal::initialize(&new_key, key_subtype);
-			object->set_new_item_key(new_key);
+			if (key_subtype == Variant::VARIANT_MAX) {
+				key_subtype = Variant::OBJECT;
+				key_subtype_hint = PROPERTY_HINT_RESOURCE_TYPE;
+				key_subtype_hint_string = key;
+			}
 		}
+
+		Variant new_key = object->get_new_item_key();
+		VariantInternal::initialize(&new_key, key_subtype);
+		object->set_new_item_key(new_key);
 	}
+
 	if (types.size() > 1 && !types[1].is_empty()) {
 		String value = types[1];
 		int hint_value_subtype_separator = value.find_char(':');
@@ -1174,11 +1191,19 @@ void EditorPropertyDictionary::setup(PropertyHint p_hint, const String &p_hint_s
 
 			value_subtype_hint_string = value.substr(hint_value_subtype_separator + 1);
 			value_subtype = Variant::Type(value_subtype_string.to_int());
+		} else {
+			value_subtype = Variant::get_type_by_name(value);
 
-			Variant new_value = object->get_new_item_value();
-			VariantInternal::initialize(&new_value, value_subtype);
-			object->set_new_item_value(new_value);
+			if (value_subtype == Variant::VARIANT_MAX) {
+				value_subtype = Variant::OBJECT;
+				value_subtype_hint = PROPERTY_HINT_RESOURCE_TYPE;
+				value_subtype_hint_string = value;
+			}
 		}
+
+		Variant new_value = object->get_new_item_value();
+		VariantInternal::initialize(&new_value, value_subtype);
+		object->set_new_item_value(new_value);
 	}
 }
 


### PR DESCRIPTION
Currently, the editor supports two methods of typing dictionaries and arrays, with the `PROPERTY_HINT_ARRAY_TYPE` hint (and the dictionary alternative), and the `PROPERTY_HINT_TYPE_STRING`. These type hints have different formats, and so need to be handled separately. That being said, the inspector currently does not accept the `PROPERTY_HINT_ARRAY_TYPE` and `PROPERTY_HINT_DICTIONARY_TYPE` formats, and so does not understand the associated type hints. This leads to nodes such as the GraphEdit's type_names property not having the proper inspector editor when creating a key/value pair (instead being the general object one).

For reference; `PROPERTY_HINT_TYPE_STRING` is of the format `"%s:%s/%s" % [Variant::Type type, PropertyHint hint, String hint_string]`, while `PROPERTY_HINT_ARRAY_TYPE` is the human-readable class name like `"Texture2D"`.

| Before; the add key and value are not typed: | After |
| - | - |
| <img width="335" alt="Before" src="https://github.com/user-attachments/assets/ad1b1a7c-71cf-4650-a3cf-217bd0bc1c32" /> | <img width="334" alt="Screenshot 2025-04-14 at 10 21 24 AM" src="https://github.com/user-attachments/assets/462dd742-092f-4a32-9d09-804dbf658134" /> |


This PR allows the inspector to receive this format, as well as adding the relevant documentation to the PROPERTY_HINT_TYPE_STRING and PROPERTY_HINT_ARRAY_TYPE constants.

See also: #100926 
A bit outdated but also: https://github.com/godotengine/godot/pull/78656/files#r1736538595
