### PR TITLE
Add `compress_for_servers` build option for Web (and add `opts.get_arguments()`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,8 @@ platform/android/java/*/libs/
 
 # Web platform
 *.bc
+*.br
+*.gz
 platform/web/node_modules/
 
 # Misc

--- a/SConstruct
+++ b/SConstruct
@@ -156,6 +156,7 @@ if profile:
         customs.append(profile + ".py")
 
 opts = Variables(customs, ARGUMENTS)
+opts.__class__.get_arguments = methods.opts_get_arguments
 
 # Target build options
 opts.Add((["platform", "p"], "Target platform (%s)" % "|".join(platform_list), ""))
@@ -385,7 +386,7 @@ for key, value in flag_list.items():
         env[key] = value
 
 # Update the environment to take platform-specific options into account.
-opts.Update(env, {**ARGUMENTS, **env.Dictionary()})
+opts.Update(env, {**ARGUMENTS, **opts.get_arguments(env)})
 
 # Detect modules.
 modules_detected = OrderedDict()
@@ -444,7 +445,9 @@ for name, path in modules_detected.items():
 env.modules_detected = modules_detected
 
 # Update the environment again after all the module options are added.
-opts.Update(env, {**ARGUMENTS, **env.Dictionary()})
+opts.Update(env, {**ARGUMENTS, **opts.get_arguments(env)})
+
+# Generate --help
 Help(opts.GenerateHelpText(env))
 
 

--- a/methods.py
+++ b/methods.py
@@ -1642,3 +1642,15 @@ def get_default_include_paths(env):
         print_warning("Failed to find the include paths in the compiler output.")
         return []
     return [x.strip() for x in match[1].strip().splitlines()]
+
+
+def opts_get_arguments(self, env):
+    # First pull in the defaults, except any which are None.
+    values = {opt.key: opt.default for opt in self.options if opt.default is not None}
+
+    args = {}
+    for option in self.options:
+        if option.converter and option.key in values and option.key in env:
+            args[option.key] = str(env[option.key])
+
+    return args

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -9,7 +9,9 @@ from emscripten_helpers import (
     create_engine_file,
     create_template_zip,
     get_template_zip_path,
+    run_brotli_compression,
     run_closure_compiler,
+    run_gzip_compression,
 )
 from SCons.Util import WhereIs
 
@@ -34,7 +36,7 @@ def get_tools(env: "SConsEnvironment"):
 
 
 def get_opts():
-    from SCons.Variables import BoolVariable
+    from SCons.Variables import BoolVariable, ListVariable
 
     return [
         ("initial_memory", "Initial WASM memory (in MiB)", 32),
@@ -56,6 +58,13 @@ def get_opts():
             "proxy_to_pthread",
             "Use Emscripten PROXY_TO_PTHREAD option to run the main application code to a separate thread",
             False,
+        ),
+        ListVariable(
+            "compress_for_servers",
+            help="Compress ahead files for compatible servers to reduce download size. Compression can take some time",
+            default="none",
+            names=["gzip", "brotli"],
+            map={"gz": "gzip", "br": "brotli"},
         ),
     ]
 
@@ -303,3 +312,21 @@ def configure(env: "SConsEnvironment"):
     # This workaround creates a closure that prevents the garbage collector from freeing the WebGL context.
     # We also only use WebGL2, and changing context version is not widely supported anyway.
     env.Append(LINKFLAGS=["-sGL_WORKAROUND_SAFARI_GETCONTEXT_BUG=0"])
+
+    def generate_compress_emitter(suffix):
+        from SCons.Util import splitext
+
+        def emitter(target, source, env):
+            return [p.target_from_source("", f"{splitext(p.name)[1]}.{suffix}") for p in source], source
+
+        return emitter
+
+    if "gzip" in env["compress_for_servers"]:
+        gzip_action = env.Action(run_gzip_compression)
+        gzip_builder = env.Builder(action=gzip_action, emitter=generate_compress_emitter("gz"))
+        env.Append(BUILDERS={"CompressGZip": gzip_builder})
+
+    if "brotli" in env["compress_for_servers"]:
+        brotli_action = env.Action(run_brotli_compression)
+        brotli_builder = env.Builder(action=brotli_action, emitter=generate_compress_emitter("br"))
+        env.Append(BUILDERS={"CompressBrotli": brotli_builder})

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -1,9 +1,14 @@
 import json
 import os
+import subprocess
 
-from SCons.Util import WhereIs
+from SCons.Errors import UserError
+from SCons.Util import WhereIs, splitext
 
+from misc.utility.color import print_info, print_warning
 from platform_methods import get_build_version
+
+text_file_extensions = [".js", ".html"]
 
 
 def run_closure_compiler(target, source, env, for_signature):
@@ -33,22 +38,40 @@ def create_engine_file(env, target, source, externs, threads_enabled):
 def create_template_zip(env, js, wasm, side):
     binary_name = "godot.editor" if env.editor_build else "godot"
     zip_dir = env.Dir(env.GetTemplateZipPath())
-    in_files = [
-        js,
-        wasm,
-        "#platform/web/js/libs/audio.worklet.js",
-        "#platform/web/js/libs/audio.position.worklet.js",
-    ]
-    out_files = [
-        zip_dir.File(binary_name + ".js"),
-        zip_dir.File(binary_name + ".wasm"),
-        zip_dir.File(binary_name + ".audio.worklet.js"),
-        zip_dir.File(binary_name + ".audio.position.worklet.js"),
-    ]
+
+    in_files = []
+    out_files = []
+
+    def add_gzip_file(in_file, out_file):
+        file_gz = env.CompressGZip(in_file)
+        in_files.append(file_gz)
+        out_files.append(str(out_file) + ".gz")
+
+    def add_brotli_file(in_file, out_file):
+        file_br = env.CompressBrotli(in_file)
+        in_files.append(file_br)
+        out_files.append(str(out_file) + ".br")
+
+    def compress_file(in_file, out_file):
+        if "gzip" in env["compress_for_servers"]:
+            add_gzip_file(in_file, out_file)
+        if "brotli" in env["compress_for_servers"]:
+            add_brotli_file(in_file, out_file)
+
+    def add_to_template(in_file, zip_file):
+        out_file = zip_dir.File(zip_file)
+        in_files.append(in_file)
+        out_files.append(out_file)
+        compress_file(in_file, out_file)
+
+    add_to_template(js, binary_name + ".js")
+    add_to_template(wasm, binary_name + ".wasm")
+    add_to_template("#platform/web/js/libs/audio.worklet.js", binary_name + ".audio.worklet.js")
+    add_to_template("#platform/web/js/libs/audio.position.worklet.js", binary_name + ".audio.position.worklet.js")
+
     # Dynamic linking (extensions) specific.
     if env["dlink_enabled"]:
-        in_files.append(side)  # Side wasm (contains the actual Godot code).
-        out_files.append(zip_dir.File(binary_name + ".side.wasm"))
+        add_to_template(side, binary_name + "side.wasm")  # Side wasm (contains the actual Godot code).
 
     service_worker = "#misc/dist/html/service-worker.js"
     if env.editor_build:
@@ -74,33 +97,24 @@ def create_template_zip(env, js, wasm, side):
             "___GODOT_ENSURE_CROSSORIGIN_ISOLATION_HEADERS___": "true",
         }
         html = env.Substfile(target="#bin/godot${PROGSUFFIX}.html", source=html, SUBST_DICT=subst_dict)
-        in_files.append(html)
-        out_files.append(zip_dir.File(binary_name + ".html"))
+        add_to_template(html, binary_name + ".html")
         # And logo/favicon
-        in_files.append("#misc/dist/html/logo.svg")
-        out_files.append(zip_dir.File("logo.svg"))
-        in_files.append("#icon.png")
-        out_files.append(zip_dir.File("favicon.png"))
+        add_to_template("#misc/dist/html/logo.svg", "logo.svg")
+        add_to_template("#icon.png", "favicon.png")
         # PWA
         service_worker = env.Substfile(
             target="#bin/godot${PROGSUFFIX}.service.worker.js",
             source=service_worker,
             SUBST_DICT=subst_dict,
         )
-        in_files.append(service_worker)
-        out_files.append(zip_dir.File("service.worker.js"))
-        in_files.append("#misc/dist/html/manifest.json")
-        out_files.append(zip_dir.File("manifest.json"))
-        in_files.append("#misc/dist/html/offline.html")
-        out_files.append(zip_dir.File("offline.html"))
+        add_to_template(service_worker, "service.worker.js")
+        add_to_template("#misc/dist/html/manifest.json", "manifest.json")
+        add_to_template("#misc/dist/html/offline.html", "offline.html")
     else:
         # HTML
-        in_files.append("#misc/dist/html/full-size.html")
-        out_files.append(zip_dir.File(binary_name + ".html"))
-        in_files.append(service_worker)
-        out_files.append(zip_dir.File(binary_name + ".service.worker.js"))
-        in_files.append("#misc/dist/html/offline-export.html")
-        out_files.append(zip_dir.File("godot.offline.html"))
+        add_to_template("#misc/dist/html/full-size.html", binary_name + ".html")
+        add_to_template(service_worker, binary_name + ".service.worker.js")
+        add_to_template("#misc/dist/html/offline-export.html", "godot.offline.html")
 
     zip_files = env.NoCache(env.InstallAs(out_files, in_files))
     env.NoCache(
@@ -127,3 +141,59 @@ def add_js_pre(env, js_pre):
 
 def add_js_externs(env, externs):
     env.Append(JS_EXTERNS=env.File(externs))
+
+
+def run_gzip_compression(target, source, env):
+    try:
+        import gzip
+    except ImportError as exc:
+        msg = f"Cannot import 'gzip' module.\n{exc}"
+        raise UserError(msg) from exc
+
+    for t in target:
+        target_path = str(t)
+        source_path = splitext(target_path)[0]
+
+        if source_path in [str(p) for p in source]:
+            with gzip.open(target_path, "wb") as tf:
+                with open(source_path, "rb") as sf:
+                    print_info(f'[gzip] Reading "{source_path}"')
+                    source_bytes = sf.read()
+                    source_bytes_len = len(source_bytes)
+                    human_size = human_readable_size(source_bytes_len)
+                    print_info(f'[gzip] Compressing "{source_path}" ({human_size}) / Writing "{target_path}"')
+                    tf.write(source_bytes)
+
+
+def run_brotli_compression(target, source, env):
+    brotli_path = WhereIs("brotli")
+    if brotli_path is None:
+        raise UserError("[Brotli] Could not find `brotli` command line utility.")
+
+    for t in target:
+        target_path = str(t)
+        source_path = splitext(target_path)[0]
+
+        if source_path in [str(p) for p in source]:
+            absolute_source_path = env.File(source_path).get_abspath()
+            source_stat = os.stat(absolute_source_path)
+            one_megabyte = 1024 * 1024
+            is_bigger_than_one_megabyte = source_stat.st_size > one_megabyte
+            human_size = human_readable_size(source_stat.st_size)
+
+            print_info(f'[brotli] Compressing "{source_path}" ({human_size}) to "{target_path}" ')
+            if is_bigger_than_one_megabyte:
+                print_warning(
+                    f'[brotli] As "{source_path}" is more than 1MiB ({human_size}), it may take a while. Brotli is notoriously slow when compiling important files.'
+                )
+
+            brotli_cmd = [brotli_path, source_path, "-o", target_path, "--force"]
+            subprocess.run(brotli_cmd)
+
+
+def human_readable_size(size: float) -> str:
+    for unit in ("", "Ki", "Mi", "Gi"):
+        if abs(size) < 1024:
+            return f"{size:3.1f}{unit}B"
+        size = size / 1024
+    return f"{size}B"


### PR DESCRIPTION
> [!NOTE]
> This PR is the first of (maybe) two that intends to apply some optimizations underlined by @popcar2 in his great blog post on [How to Minify Godot's Build Size (93MB -> 6.4MB exe)](https://popcar.bearblog.dev/how-to-minify-godots-build-size/).

## `compress_for_servers` build option
This PR primarily adds the new `compress_for_servers` build option. See [Compression in HTTP (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Compression) for more information (tl;dr, it permits the server to send a compressed file instead of the raw file, for the receiver to decompress it seamlessly, saving bandwidth). It is configured as a `ListVariable`, which seem to be the first time it's used in the project. It accepts those values:
- `gzip` (alias `gz`): gzips web built files
- `brotli` (alias `br`): brotli compress built files
- `none` (default): no compression of built files
- `all`: will apply all compression formats to built files

`ListVariable` is interesting because it permits the use of multiple values as entry. `compress_for_servers=all` is the dynamic equivalent (handled by `ListVariable`) of `compress_for_servers=gzip,brotli`.

> [!NOTE]
> A new PR (or this one) needs to follow-up in order to add those server compressed files into the official build templates.

## `opts.get_arguments()`
Incidentally, in order to fix some issues with `SCons.Variables.ListVariable` against our current `opts.Update()` use in SConstruct, this PR also introduces `opts.get_arguments()` as a new `Variables` class method. It returns `opts` values as if they were entered by hand in the command line. Otherwise, the new `ListVariable` gets updated twice and the result isn't idempotent, and the `ListVariable` validator don't recognize it's own values. This change was made to prevent this.

This PR also cleans up (a lot) `create_template_zip()` in `platform/web/emscripten_helpers.py`. It simplifies adding files to `in_files` and `out_files`, no need anymore to track manually each file that are added to add their `zipfile` counterpart.