### PR TITLE
Gui: Fix invalid menu bar hover

### DIFF
--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -423,8 +423,11 @@ void MenuBar::_draw_menu_item(int p_index) {
 	bool pressed = (active_menu == p_index);
 	bool rtl = is_layout_rtl();
 
-	if (has_focus() && focused_menu == -1 && p_index == 0) {
-		hovered = true;
+	// When close the active_menu, the hovered menu should be the one that was active.
+	if (has_focus() && active_menu == -1 && focused_menu == -1) {
+		if (p_index == selected_menu) {
+			hovered = true;
+		}
 	}
 
 	if (menu_cache[p_index].hidden) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes #105365

Cause: 
When close the active_menu, and the focused_menu will be -1, then it sets the first button to hovered

Fix: 
I assume the the change is aiming to set hovered to the menu bar button at the mouse position when closing the active_menu

Without this fix, If you try select / deselect the menu bar button(except the first button (Menu))
When deselect the button, the hovering is gone.