### PR TITLE
Implement `SVGTexture` auto-scalable with font oversampling.

### DIFF
--- a/doc/classes/SVGTexture.xml
+++ b/doc/classes/SVGTexture.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SVGTexture" inherits="Texture2D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A scalable [Texture2D] based on an SVG image.
+	</brief_description>
+	<description>
+		A scalable [Texture2D] based on an SVG image. [SVGTexture]s are automatically rescaled to match font oversampling.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="create_from_string" qualifiers="static">
+			<return type="SVGTexture" />
+			<param index="0" name="source" type="String" />
+			<param index="1" name="scale" type="float" default="1.0" />
+			<param index="2" name="saturation" type="float" default="1.0" />
+			<param index="3" name="color_map" type="Dictionary" default="{}" />
+			<description>
+				Creates a new [SVGTexture] and initializes it by allocating and setting the SVG data from string.
+			</description>
+		</method>
+		<method name="set_size_override">
+			<return type="void" />
+			<param index="0" name="size" type="Vector2i" />
+			<description>
+				Resizes the texture to the specified dimensions.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="base_scale" type="float" setter="set_base_scale" getter="get_base_scale" default="1.0">
+			SVG texture scale.
+		</member>
+		<member name="color_map" type="Dictionary" setter="set_color_map" getter="get_color_map" default="{}">
+			If sets, remaps SVG texture colors according to [Color]-[Color] map.
+		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
+		<member name="saturation" type="float" setter="set_saturation" getter="get_saturation" default="1.0">
+			Overrides texture saturation.
+		</member>
+		<member name="source" type="String" setter="set_source" getter="get_source" default="&quot;&quot;">
+			SVG source code.
+		</member>
+	</members>
+</class>

--- a/doc/classes/SVGTexture.xml
+++ b/doc/classes/SVGTexture.xml
@@ -4,7 +4,7 @@
 		A scalable [Texture2D] based on an SVG image.
 	</brief_description>
 	<description>
-		A scalable [Texture2D] based on an SVG image. [SVGTexture]s are automatically rescaled to match font oversampling.
+		A scalable [Texture2D] based on an SVG image. [SVGTexture]s are automatically re-rasterized to match font oversampling.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -29,10 +29,10 @@
 	</methods>
 	<members>
 		<member name="base_scale" type="float" setter="set_base_scale" getter="get_base_scale" default="1.0">
-			SVG texture scale.
+			SVG texture scale. [code]1.0[/code] is the original SVG size. Higher values result in a larger image.
 		</member>
 		<member name="color_map" type="Dictionary" setter="set_color_map" getter="get_color_map" default="{}">
-			If sets, remaps SVG texture colors according to [Color]-[Color] map.
+			If set, remaps SVG texture colors according to [Color]-[Color] map.
 		</member>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="saturation" type="float" setter="set_saturation" getter="get_saturation" default="1.0">

--- a/editor/icons/SVGTexture.svg
+++ b/editor/icons/SVGTexture.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="M2 1a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1Zm1 2h10v8H3Z"/><path fill="#8da5f3" stroke="#8da5f3" stroke-linejoin="round" stroke-width=".75" d="M10.24 9.24H5.76V4.76h4.48L8 7Z"/></svg>

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -44,6 +44,7 @@
 #include "scene/resources/style_box_flat.h"
 #include "scene/resources/style_box_line.h"
 #include "scene/resources/style_box_texture.h"
+#include "scene/resources/svg_texture.h"
 #include "scene/resources/texture.h"
 
 // Theme configuration.
@@ -1724,7 +1725,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 			p_theme->set_constant("port_h_offset", "GraphNode", 1);
 			p_theme->set_constant("separation", "GraphNode", 1 * EDSCALE);
 
-			Ref<ImageTexture> port_icon = p_theme->get_icon(SNAME("GuiGraphNodePort"), EditorStringName(EditorIcons));
+			Ref<SVGTexture> port_icon = p_theme->get_icon(SNAME("GuiGraphNodePort"), EditorStringName(EditorIcons));
 			// The true size is 24x24 This is necessary for sharp port icons at high zoom levels in GraphEdit (up to ~200%).
 			port_icon->set_size_override(Size2(12, 12));
 			p_theme->set_icon("port", "GraphNode", port_icon);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -44,6 +44,7 @@
 #include "scene/main/canvas_layer.h"
 #include "scene/main/window.h"
 #include "scene/resources/mesh.h"
+#include "scene/resources/svg_texture.h"
 #include "scene/resources/text_line.h"
 #include "scene/resources/world_2d.h"
 #include "servers/audio_server.h"
@@ -1085,6 +1086,9 @@ bool Viewport::_set_size(const Size2i &p_size, const Size2 &p_size_2d_override, 
 	if (new_font_oversampling != font_oversampling) {
 		TS->reference_oversampling_level(new_font_oversampling);
 		TS->unreference_oversampling_level(font_oversampling);
+
+		SVGTexture::reference_scaling_level(new_font_oversampling);
+		SVGTexture::unreference_scaling_level(font_oversampling);
 	}
 
 	size = new_size;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -148,6 +148,7 @@
 #include "scene/resources/style_box_line.h"
 #include "scene/resources/style_box_texture.h"
 #include "scene/resources/surface_tool.h"
+#include "scene/resources/svg_texture.h"
 #include "scene/resources/syntax_highlighter.h"
 #include "scene/resources/text_line.h"
 #include "scene/resources/text_paragraph.h"
@@ -935,6 +936,7 @@ void register_scene_types() {
 #ifndef _3D_DISABLED
 	GDREGISTER_CLASS(AudioStreamPlayer3D);
 	GDREGISTER_VIRTUAL_CLASS(PrimitiveMesh);
+	GDREGISTER_CLASS(SVGTexture);
 	GDREGISTER_CLASS(BoxMesh);
 	GDREGISTER_CLASS(CapsuleMesh);
 	GDREGISTER_CLASS(CylinderMesh);

--- a/scene/resources/svg_texture.cpp
+++ b/scene/resources/svg_texture.cpp
@@ -1,0 +1,380 @@
+/**************************************************************************/
+/*  svg_texture.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "svg_texture.h"
+
+#include "core/io/image_loader.h"
+#include "scene/main/canvas_item.h"
+#include "scene/main/viewport.h"
+#include "scene/resources/bit_map.h"
+#include "scene/resources/placeholder_textures.h"
+
+#include "modules/modules_enabled.gen.h" // For svg.
+#ifdef MODULE_SVG_ENABLED
+#include "modules/svg/image_loader_svg.h"
+#endif
+
+Mutex SVGTexture::mutex;
+HashMap<double, SVGTexture::ScalingLevel> SVGTexture::scaling_levels;
+
+void SVGTexture::reference_scaling_level(double p_scale) {
+	if (Math::is_equal_approx(p_scale, 1.0)) {
+		return;
+	}
+
+	MutexLock lock(mutex);
+	ScalingLevel *sl = scaling_levels.getptr(p_scale);
+	if (sl) {
+		sl->refcount++;
+	} else {
+		ScalingLevel new_sl;
+		scaling_levels.insert(p_scale, new_sl);
+	}
+}
+
+void SVGTexture::unreference_scaling_level(double p_scale) {
+	if (Math::is_equal_approx(p_scale, 1.0)) {
+		return;
+	}
+
+	MutexLock lock(mutex);
+	ScalingLevel *sl = scaling_levels.getptr(p_scale);
+	if (sl) {
+		sl->refcount--;
+		if (sl->refcount == 0) {
+			for (SVGTexture *tx : sl->textures) {
+				tx->_remove_scale(p_scale);
+			}
+			sl->textures.clear();
+			scaling_levels.erase(p_scale);
+		}
+	}
+}
+
+Ref<SVGTexture> SVGTexture::create_from_string(const String &p_source, float p_scale, float p_saturation, const Dictionary &p_color_map) {
+	Ref<SVGTexture> svg_texture;
+	svg_texture.instantiate();
+	svg_texture->set_source(p_source);
+	svg_texture->set_base_scale(p_scale);
+	svg_texture->set_saturation(p_saturation);
+	svg_texture->set_color_map(p_color_map);
+	return svg_texture;
+}
+
+void SVGTexture::set_source(const String &p_source) {
+	if (source == p_source) {
+		return;
+	}
+	source = p_source;
+	_update_texture();
+}
+
+String SVGTexture::get_source() const {
+	return source;
+}
+
+void SVGTexture::set_base_scale(float p_scale) {
+	if (base_scale == p_scale) {
+		return;
+	}
+	ERR_FAIL_COND(p_scale <= 0.0);
+
+	base_scale = p_scale;
+	_update_texture();
+}
+
+float SVGTexture::get_base_scale() const {
+	return base_scale;
+}
+
+void SVGTexture::set_saturation(float p_saturation) {
+	if (saturation == p_saturation) {
+		return;
+	}
+
+	saturation = p_saturation;
+	_update_texture();
+}
+
+float SVGTexture::get_saturation() const {
+	return saturation;
+}
+
+void SVGTexture::set_color_map(const Dictionary &p_color_map) {
+	if (color_map == p_color_map) {
+		return;
+	}
+	color_map = p_color_map;
+	cmap.clear();
+	for (const Variant *E = color_map.next(); E; E = color_map.next(E)) {
+		cmap[*E] = color_map[*E];
+	}
+	_update_texture();
+}
+
+Dictionary SVGTexture::get_color_map() const {
+	return color_map;
+}
+
+void SVGTexture::_remove_scale(double p_scale) {
+	if (Math::is_equal_approx(p_scale, 1.0)) {
+		return;
+	}
+
+	RID *rid = texture_cache.getptr(p_scale);
+	if (rid) {
+		if (rid->is_valid()) {
+			RenderingServer::get_singleton()->free(*rid);
+		}
+		texture_cache.erase(p_scale);
+	}
+}
+
+RID SVGTexture::_ensure_scale(double p_scale) const {
+	if (Math::is_equal_approx(p_scale, 1.0)) {
+		if (!base_texture.is_valid()) {
+			base_texture = _load_at_scale(p_scale, true);
+		}
+		return base_texture;
+	}
+	RID *rid = texture_cache.getptr(p_scale);
+	if (rid) {
+		return *rid;
+	}
+
+	MutexLock lock(mutex);
+	ScalingLevel *sl = scaling_levels.getptr(p_scale);
+	ERR_FAIL_NULL_V_MSG(sl, RID(), "Invalid scaling level");
+	sl->textures.insert(const_cast<SVGTexture *>(this));
+
+	RID new_rid = _load_at_scale(p_scale, false);
+	texture_cache[p_scale] = new_rid;
+	return new_rid;
+}
+
+RID SVGTexture::_load_at_scale(double p_scale, bool p_set_size) const {
+	Ref<Image> img = memnew(Image);
+#ifdef MODULE_SVG_ENABLED
+	const bool upsample = !Math::is_equal_approx(Math::round(p_scale * base_scale), p_scale * base_scale);
+
+	Error err = ImageLoaderSVG::create_image_from_string(img, source, p_scale * base_scale, upsample, cmap);
+	ERR_FAIL_COND_V_MSG(err != OK, RID(), "Failed generating icon, unsupported or invalid SVG data in default theme.");
+#else
+	img = Image::create_empty(Math::round(16 * p_scale * base_scale), Math::round(16 * p_scale * base_scale), false, Image::FORMAT_RGBA8);
+#endif
+	if (saturation != 1.0) {
+		img->adjust_bcs(1.0, 1.0, saturation);
+	}
+
+	if (p_set_size) {
+		size.x = img->get_width();
+		base_size.x = img->get_width();
+		if (size_override.x != 0) {
+			size.x = size_override.x;
+		}
+		size.y = img->get_height();
+		base_size.y = img->get_height();
+		if (size_override.y != 0) {
+			size.y = size_override.y;
+		}
+	}
+
+	RID rid = RenderingServer::get_singleton()->texture_2d_create(img);
+	RenderingServer::get_singleton()->texture_set_size_override(rid, size.x, size.y);
+	return rid;
+}
+
+void SVGTexture::_clear() {
+	for (KeyValue<double, RID> &tx : texture_cache) {
+		if (tx.value.is_valid()) {
+			RenderingServer::get_singleton()->free(tx.value);
+		}
+	}
+	texture_cache.clear();
+	if (base_texture.is_valid()) {
+		RenderingServer::get_singleton()->free(base_texture);
+	}
+	base_texture = RID();
+	alpha_cache.unref();
+}
+
+void SVGTexture::_update_texture() {
+	_clear();
+	_ensure_scale(1.0);
+
+	emit_changed();
+}
+
+Ref<Image> SVGTexture::get_image() const {
+	RID rid = _ensure_scale(1.0);
+	if (rid.is_valid()) {
+		return RenderingServer::get_singleton()->texture_2d_get(rid);
+	} else {
+		return Ref<Image>();
+	}
+}
+
+int SVGTexture::get_width() const {
+	return size.x;
+}
+
+int SVGTexture::get_height() const {
+	return size.y;
+}
+
+RID SVGTexture::get_rid() const {
+	return _ensure_scale(1.0);
+}
+
+bool SVGTexture::has_alpha() const {
+	return true;
+}
+
+void SVGTexture::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate, bool p_transpose) const {
+	double scale = 1.0;
+	CanvasItem *ci = CanvasItem::get_current_item_drawn();
+	if (ci) {
+		Viewport *vp = ci->get_viewport();
+		if (vp) {
+			scale = vp->get_oversampling();
+		}
+	}
+	RID rid = _ensure_scale(scale);
+
+	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, Rect2(p_pos, size), rid, false, p_modulate, p_transpose);
+}
+
+void SVGTexture::draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose) const {
+	double scale = 1.0;
+	CanvasItem *ci = CanvasItem::get_current_item_drawn();
+	if (ci) {
+		Viewport *vp = ci->get_viewport();
+		if (vp) {
+			scale = vp->get_oversampling();
+		}
+	}
+	RID rid = _ensure_scale(scale);
+
+	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, p_rect, rid, p_tile, p_modulate, p_transpose);
+}
+
+void SVGTexture::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) const {
+	double scale = 1.0;
+	CanvasItem *ci = CanvasItem::get_current_item_drawn();
+	if (ci) {
+		Viewport *vp = ci->get_viewport();
+		if (vp) {
+			scale = vp->get_oversampling();
+		}
+	}
+	RID rid = _ensure_scale(scale);
+
+	RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, p_rect, rid, p_src_rect, p_modulate, p_transpose, p_clip_uv);
+}
+
+bool SVGTexture::is_pixel_opaque(int p_x, int p_y) const {
+	if (!alpha_cache.is_valid()) {
+		Ref<Image> img = get_image();
+		if (img.is_valid()) {
+			alpha_cache.instantiate();
+			alpha_cache->create_from_image_alpha(img);
+		}
+	}
+
+	if (alpha_cache.is_valid()) {
+		int aw = int(alpha_cache->get_size().width);
+		int ah = int(alpha_cache->get_size().height);
+		if (aw == 0 || ah == 0) {
+			return true;
+		}
+
+		int x = p_x * aw / size.x;
+		int y = p_y * ah / size.y;
+
+		x = CLAMP(x, 0, aw);
+		y = CLAMP(y, 0, ah);
+
+		return alpha_cache->get_bit(x, y);
+	}
+
+	return true;
+}
+
+void SVGTexture::set_size_override(const Size2i &p_size) {
+	if (size_override == p_size) {
+		return;
+	}
+	size_override = p_size;
+	size = base_size;
+	if (size_override.x != 0) {
+		size.x = size_override.x;
+	}
+	if (size_override.y != 0) {
+		size.y = size_override.y;
+	}
+	for (KeyValue<double, RID> &tx : texture_cache) {
+		if (tx.value.is_valid()) {
+			RenderingServer::get_singleton()->texture_set_size_override(tx.value, size.x, size.y);
+		}
+	}
+	if (base_texture.is_valid()) {
+		RenderingServer::get_singleton()->texture_set_size_override(base_texture, size.x, size.y);
+	}
+
+	emit_changed();
+}
+
+void SVGTexture::_bind_methods() {
+	ClassDB::bind_static_method("SVGTexture", D_METHOD("create_from_string", "source", "scale", "saturation", "color_map"), &SVGTexture::create_from_string, DEFVAL(1.0), DEFVAL(1.0), DEFVAL(Dictionary()));
+
+	ClassDB::bind_method(D_METHOD("set_source", "source"), &SVGTexture::set_source);
+	ClassDB::bind_method(D_METHOD("get_source"), &SVGTexture::get_source);
+	ClassDB::bind_method(D_METHOD("set_base_scale", "base_scale"), &SVGTexture::set_base_scale);
+	ClassDB::bind_method(D_METHOD("get_base_scale"), &SVGTexture::get_base_scale);
+	ClassDB::bind_method(D_METHOD("set_saturation", "saturation"), &SVGTexture::set_saturation);
+	ClassDB::bind_method(D_METHOD("get_saturation"), &SVGTexture::get_saturation);
+	ClassDB::bind_method(D_METHOD("set_color_map", "color_map"), &SVGTexture::set_color_map);
+	ClassDB::bind_method(D_METHOD("get_color_map"), &SVGTexture::get_color_map);
+	ClassDB::bind_method(D_METHOD("set_size_override", "size"), &SVGTexture::set_size_override);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source", PROPERTY_HINT_MULTILINE_TEXT), "set_source", "get_source");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "base_scale", PROPERTY_HINT_RANGE, "0.01,10.0,0.01"), "set_base_scale", "get_base_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "saturation", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_saturation", "get_saturation");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "color_map"), "set_color_map", "get_color_map");
+}
+
+SVGTexture::~SVGTexture() {
+	_clear();
+
+	MutexLock lock(mutex);
+	for (KeyValue<double, ScalingLevel> &sl : scaling_levels) {
+		sl.value.textures.erase(this);
+	}
+}

--- a/scene/resources/svg_texture.cpp
+++ b/scene/resources/svg_texture.cpp
@@ -159,7 +159,7 @@ void SVGTexture::_remove_scale(double p_scale) {
 
 RID SVGTexture::_ensure_scale(double p_scale) const {
 	if (Math::is_equal_approx(p_scale, 1.0)) {
-		if (!base_texture.is_valid()) {
+		if (base_texture.is_null()) {
 			base_texture = _load_at_scale(p_scale, true);
 		}
 		return base_texture;
@@ -180,7 +180,8 @@ RID SVGTexture::_ensure_scale(double p_scale) const {
 }
 
 RID SVGTexture::_load_at_scale(double p_scale, bool p_set_size) const {
-	Ref<Image> img = memnew(Image);
+	Ref<Image> img;
+	img.instantiate();
 #ifdef MODULE_SVG_ENABLED
 	const bool upsample = !Math::is_equal_approx(Math::round(p_scale * base_scale), p_scale * base_scale);
 
@@ -300,7 +301,7 @@ void SVGTexture::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const 
 }
 
 bool SVGTexture::is_pixel_opaque(int p_x, int p_y) const {
-	if (!alpha_cache.is_valid()) {
+	if (alpha_cache.is_null()) {
 		Ref<Image> img = get_image();
 		if (img.is_valid()) {
 			alpha_cache.instantiate();
@@ -318,8 +319,8 @@ bool SVGTexture::is_pixel_opaque(int p_x, int p_y) const {
 		int x = p_x * aw / size.x;
 		int y = p_y * ah / size.y;
 
-		x = CLAMP(x, 0, aw);
-		y = CLAMP(y, 0, ah);
+		x = CLAMP(x, 0, aw - 1);
+		y = CLAMP(y, 0, ah - 1);
 
 		return alpha_cache->get_bit(x, y);
 	}

--- a/scene/resources/svg_texture.h
+++ b/scene/resources/svg_texture.h
@@ -1,0 +1,104 @@
+/**************************************************************************/
+/*  svg_texture.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/templates/lru.h"
+#include "scene/resources/texture.h"
+
+class BitMap;
+
+class SVGTexture : public Texture2D {
+	GDCLASS(SVGTexture, Texture2D);
+
+	String source;
+	float base_scale = 1.0;
+	float saturation = 1.0;
+	Dictionary color_map;
+	Size2 size_override;
+
+	struct ScalingLevel {
+		HashSet<SVGTexture *> textures;
+		int32_t refcount = 1;
+	};
+	static Mutex mutex;
+	static HashMap<double, ScalingLevel> scaling_levels;
+
+	mutable RID base_texture;
+	mutable HashMap<double, RID> texture_cache;
+	mutable Ref<BitMap> alpha_cache;
+	mutable HashMap<Color, Color> cmap;
+	mutable Size2 base_size;
+	mutable Size2 size;
+
+	void _remove_scale(double p_scale);
+	RID _ensure_scale(double p_scale) const;
+	RID _load_at_scale(double p_scale, bool p_set_size) const;
+	void _update_texture();
+	void _clear();
+
+protected:
+	static void _bind_methods();
+
+public:
+	static Ref<SVGTexture> create_from_string(const String &p_source, float p_scale = 1.0, float p_saturation = 1.0, const Dictionary &p_color_map = Dictionary());
+
+	void set_source(const String &p_source);
+	String get_source() const;
+
+	void set_base_scale(float p_scale);
+	float get_base_scale() const;
+
+	void set_color_map(const Dictionary &p_color_map);
+	Dictionary get_color_map() const;
+
+	void set_saturation(float p_saturation);
+	float get_saturation() const;
+
+	Ref<Image> get_image() const override;
+
+	int get_width() const override;
+	int get_height() const override;
+
+	virtual RID get_rid() const override;
+
+	bool has_alpha() const override;
+	virtual void draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;
+	virtual void draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;
+	virtual void draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = true) const override;
+
+	void set_size_override(const Size2i &p_size);
+	bool is_pixel_opaque(int p_x, int p_y) const override;
+
+	static void reference_scaling_level(double p_scale);
+	static void unreference_scaling_level(double p_scale);
+
+	~SVGTexture();
+};

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -38,15 +38,11 @@
 #include "scene/resources/image_texture.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/resources/style_box_line.h"
+#include "scene/resources/svg_texture.h"
 #include "scene/resources/theme.h"
 #include "scene/scene_string_names.h"
 #include "scene/theme/theme_db.h"
 #include "servers/text_server.h"
-
-#include "modules/modules_enabled.gen.h" // For svg.
-#ifdef MODULE_SVG_ENABLED
-#include "modules/svg/image_loader_svg.h"
-#endif
 
 static const int default_font_size = 16;
 
@@ -80,26 +76,8 @@ static Ref<StyleBoxFlat> sb_expand(Ref<StyleBoxFlat> p_sbox, float p_left, float
 }
 
 // See also `editor_generate_icon()` in `editor/themes/editor_icons.cpp`.
-static Ref<ImageTexture> generate_icon(int p_index) {
-	Ref<Image> img = memnew(Image);
-
-#ifdef MODULE_SVG_ENABLED
-	// Upsample icon generation only if the scale isn't an integer multiplier.
-	// Generating upsampled icons is slower, and the benefit is hardly visible
-	// with integer scales.
-	const bool upsample = !Math::is_equal_approx(Math::round(scale), scale);
-
-	Error err = ImageLoaderSVG::create_image_from_string(img, default_theme_icons_sources[p_index], scale, upsample, HashMap<Color, Color>());
-	ERR_FAIL_COND_V_MSG(err != OK, Ref<ImageTexture>(), "Failed generating icon, unsupported or invalid SVG data in default theme.");
-
-	img->fix_alpha_edges();
-#else
-	// If the SVG module is disabled, we can't really display the UI well, but at least we won't crash.
-	// 16 pixels is used as it's the most common base size for Godot icons.
-	img = Image::create_empty(Math::round(16 * scale), Math::round(16 * scale), false, Image::FORMAT_RGBA8);
-#endif
-
-	return ImageTexture::create_from_image(img);
+static Ref<SVGTexture> generate_icon(int p_index) {
+	return SVGTexture::create_from_string(default_theme_icons_sources[p_index], scale);
 }
 
 static Ref<StyleBox> make_empty_stylebox(float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1) {


### PR DESCRIPTION
~Depends on https://github.com/godotengine/godot/pull/104872, required for automatic DPI scaling.~

Partial port of https://github.com/godotengine/godot/pull/86022 to the new global oversampling model.

- Implement `SVGTexture` that is automatically re-rasterized to match font oversampling factor.
- Use it for editor icons and default theme elements to auto-scale UI with oversampling

https://github.com/user-attachments/assets/46b0eacf-160d-4bbb-94f3-7d90677a6dc4
