### PR TITLE
Remove `auto` misuse cases.

### DIFF
--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -268,7 +268,7 @@ void CameraFeed::set_external(int p_width, int p_height) {
 		base_width = p_width;
 		base_height = p_height;
 
-		auto new_texture = RenderingServer::get_singleton()->texture_external_create(p_width, p_height, 0);
+		RID new_texture = RenderingServer::get_singleton()->texture_external_create(p_width, p_height, 0);
 		RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_YCBCR_IMAGE], new_texture);
 	}
 

--- a/tests/core/templates/test_a_hash_map.h
+++ b/tests/core/templates/test_a_hash_map.h
@@ -207,7 +207,7 @@ TEST_CASE("[AHashMap] Insert, iterate and remove many elements") {
 
 	//insert order should have been kept
 	int idx = 0;
-	for (auto &K : map) {
+	for (const KeyValue<int, int> &K : map) {
 		CHECK(idx == K.key);
 		CHECK(idx == K.value);
 		CHECK(map.has(idx));


### PR DESCRIPTION
We probably should update guidelines to reflect real state of the codebase: https://docs.godotengine.org/en/stable/contributing/development/cpp_usage_guidelines.html#auto-keyword

These two cases are exactly what should not be done, but we have plenty of legit uses of it:
- C++ templates / macros (not using it will require duplication of template and reduce readability).
- C++ lambdas / Obj-C blocks (type is obvious from function/block definition, and spelling it out will reduce readability).