### PR TITLE
Add unit test for WebSocketPeer default state

### DIFF
--- a/tests/core/test_websocket_peer.h
+++ b/tests/core/test_websocket_peer.h
@@ -1,3 +1,34 @@
+/**************************************************************************/
+/* test_websocket_peer.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+
 #include "modules/websocket/websocket_peer.h"
 #include "tests/test_macros.h"
 

--- a/tests/core/test_websocket_peer.h
+++ b/tests/core/test_websocket_peer.h
@@ -1,0 +1,25 @@
+/*
+.poll() behavior?
+.close() call and updated state?
+set_write_mode()
+get_connected_host()
+*/
+
+#include "modules/websocket/websocket_peer.h"
+#include "tests/test_macros.h"
+
+namespace TestWebSocketPeer {
+
+TEST_CASE("[WebSocketPeer] after creation state is closed") {
+	WebSocketPeer *peer = WebSocketPeer::create();
+	CHECK_MESSAGE(peer != nullptr, "WebSocketPeer::create() returned nullptr");
+
+	if (peer) {
+		CHECK(peer->get_ready_state() == WebSocketPeer::STATE_CLOSED);
+		memdelete(peer);
+	}
+
+}
+
+} // namespace TestWebSocketPeer
+

--- a/tests/core/test_websocket_peer.h
+++ b/tests/core/test_websocket_peer.h
@@ -1,10 +1,3 @@
-/*
-.poll() behavior?
-.close() call and updated state?
-set_write_mode()
-get_connected_host()
-*/
-
 #include "modules/websocket/websocket_peer.h"
 #include "tests/test_macros.h"
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -37,6 +37,7 @@
 #include "editor/editor_settings.h"
 #endif // TOOLS_ENABLED
 
+#include "tests/core/test_websocket_peer.h" // ++
 #include "tests/core/config/test_project_settings.h"
 #include "tests/core/input/test_input_event.h"
 #include "tests/core/input/test_input_event_key.h"

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -37,7 +37,7 @@
 #include "editor/editor_settings.h"
 #endif // TOOLS_ENABLED
 
-#include "tests/core/test_websocket_peer.h" // ++
+#include "tests/core/test_websocket_peer.h" 
 #include "tests/core/config/test_project_settings.h"
 #include "tests/core/input/test_input_event.h"
 #include "tests/core/input/test_input_event_key.h"


### PR DESCRIPTION
This adds a basic unit test for WebSocketPeer to verify its default ready state after creation.

Link to [#43440](https://github.com/godotengine/godot/issues/43440) 
