### PR TITLE
Add `optimize_wasm` build option for Web

### DIFF
--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -118,7 +118,15 @@ js_wrapped = env.NoCache(
     env.Textfile("#bin/godot", [env.File(f) for f in wrap_list], TEXTFILESUFFIX="${PROGSUFFIX}.wrapped.js")
 )
 
+main_wasm = build[1]
+side_wasm = build[2] if len(build) > 2 else None
+
+if env["optimize_wasm"]:
+    main_wasm = env.OptimizeWASM(main_wasm)
+    if side_wasm is not None:
+        side_wasm = env.OptimizeWASM(side_wasm)
+
 # 0 - unwrapped js file (use wrapped one instead)
 # 1 - wasm file
 # 2 - wasm side (when dlink is enabled).
-env.CreateTemplateZip(js_wrapped, build[1], build[2] if len(build) > 2 else None)
+env.CreateTemplateZip(js_wrapped, main_wasm, side_wasm)


### PR DESCRIPTION
> [!NOTE]
> This PR is the second of two (maybe more to come?) that intends to apply some optimizations underlined by @popcar2 in his great blog post on [How to Minify Godot's Build Size (93MB -> 6.4MB exe)](https://popcar.bearblog.dev/how-to-minify-godots-build-size/).

> [!WARNING]
> *Heads-up release management team:* This is an independent PR from #105371, but I would prefer the latter being merged first as there will be conflicts.

This PR adds the `optimize_wasm` build option for the Web platform. This will permit people to optimize the built wasm files from the Godot build script, without having to manually do it. It requires though the `wasm-opt` command line utility from [the binaryen project](https://github.com/WebAssembly/binaryen).

Hopefully, this will enable smaller engine downloads for players on the Web.