### PR TITLE
Optimize `Array` `min`/`max` methods

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -801,47 +801,45 @@ Variant Array::pop_at(int p_pos) {
 }
 
 Variant Array::min() const {
-	Variant minval;
-	for (int i = 0; i < size(); i++) {
-		if (i == 0) {
-			minval = get(i);
-		} else {
-			bool valid;
-			Variant ret;
-			Variant test = get(i);
-			Variant::evaluate(Variant::OP_LESS, test, minval, ret, valid);
-			if (!valid) {
-				return Variant(); //not a valid comparison
-			}
-			if (bool(ret)) {
-				//is less
-				minval = test;
-			}
+	int array_size = size();
+	if (array_size == 0) {
+		return Variant();
+	}
+
+	int min_index = 0;
+	Variant is_less;
+	for (int i = 1; i < array_size; i++) {
+		bool valid;
+		Variant::evaluate(Variant::OP_LESS, _p->array[i], _p->array[min_index], is_less, valid);
+		if (!valid) {
+			return Variant(); //not a valid comparison
+		}
+		if (bool(is_less)) {
+			min_index = i;
 		}
 	}
-	return minval;
+	return _p->array[min_index];
 }
 
 Variant Array::max() const {
-	Variant maxval;
-	for (int i = 0; i < size(); i++) {
-		if (i == 0) {
-			maxval = get(i);
-		} else {
-			bool valid;
-			Variant ret;
-			Variant test = get(i);
-			Variant::evaluate(Variant::OP_GREATER, test, maxval, ret, valid);
-			if (!valid) {
-				return Variant(); //not a valid comparison
-			}
-			if (bool(ret)) {
-				//is greater
-				maxval = test;
-			}
+	int array_size = size();
+	if (array_size == 0) {
+		return Variant();
+	}
+
+	int max_index = 0;
+	Variant is_greater;
+	for (int i = 1; i < array_size; i++) {
+		bool valid;
+		Variant::evaluate(Variant::OP_GREATER, _p->array[i], _p->array[max_index], is_greater, valid);
+		if (!valid) {
+			return Variant(); //not a valid comparison
+		}
+		if (bool(is_greater)) {
+			max_index = i;
 		}
 	}
-	return maxval;
+	return _p->array[max_index];
 }
 
 const void *Array::id() const {


### PR DESCRIPTION
Updated `Array::min` and `Array::max` to not copy Variants for comparison, and store index instead of copying each time new min/max is found.

Makes min/max around 30% faster for ints, and around 80% faster for strings, compared with gdscript below:

```gdscript
func _ready() -> void:
	test_min(range(100), 100000, "min int")
	test_min(range(100).map(str), 100000, "min str")
	test_max(range(100), 100000, "max int")
	test_max(range(100).map(str), 100000, "max str")

func test_min(p_array : Array, p_times : int, p_name : String):
	var start := Time.get_ticks_msec()
	for i in p_times:
		p_array.min()
	var end := Time.get_ticks_msec()
	print("%s: %dms" % [p_name, end - start])
	
func test_max(p_array : Array, p_times : int, p_name : String):
	var start := Time.get_ticks_msec()
	for i in p_times:
		p_array.max()
	var end := Time.get_ticks_msec()
	print("%s: %dms" % [p_name, end - start])
```

old
```
min int: 230ms
min str: 396ms
max int: 231ms
max str: 428ms
```

new
```
min int: 169ms
min str: 228ms
max int: 171ms
max str: 228ms
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
