### PR TITLE
Use Math::abs to avoid ambiguity with integer abs

### DIFF
--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -143,7 +143,7 @@ struct [[nodiscard]] Quaternion {
 		Vector3 n0 = p_v0.normalized();
 		Vector3 n1 = p_v1.normalized();
 		real_t d = n0.dot(n1);
-		if (abs(d) > ALMOST_ONE) {
+		if (Math::abs(d) > ALMOST_ONE) {
 			if (d >= 0) {
 				return; // Vectors are same.
 			}


### PR DESCRIPTION
For parity with https://github.com/godotengine/godot-cpp/pull/1767