### PR TITLE
Add support for object pointer and ref types to TypedArray

### DIFF
--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -48,7 +48,7 @@ public:
 			TypedArray(Array(p_variant)) {
 	}
 	_FORCE_INLINE_ TypedArray(const Array &p_array) {
-		set_typed(Variant::OBJECT, T::get_class_static(), Variant());
+		set_typed(Variant::OBJECT, std::remove_pointer_t<T>::get_class_static(), Variant());
 		if (is_same_typed(p_array)) {
 			_ref(p_array);
 		} else {
@@ -58,7 +58,7 @@ public:
 	_FORCE_INLINE_ TypedArray(std::initializer_list<Variant> p_init) :
 			TypedArray(Array(p_init)) {}
 	_FORCE_INLINE_ TypedArray() {
-		set_typed(Variant::OBJECT, T::get_class_static(), Variant());
+		set_typed(Variant::OBJECT, std::remove_pointer_t<T>::get_class_static(), Variant());
 	}
 };
 
@@ -167,7 +167,7 @@ struct GetTypeInfo<TypedArray<T>> {
 	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_class_static());
+		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, std::remove_pointer_t<T>::get_class_static());
 	}
 };
 

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -662,4 +662,28 @@ TEST_CASE("[Array] Test rfind_custom") {
 	CHECK_EQ(index, 4);
 }
 
+TEST_CASE("[Array] Typed object pointer init") {
+	Object *a = memnew(Object);
+	Object *b = memnew(Object);
+	TypedArray<Object *> tarr = {
+		a,
+		b,
+	};
+	CHECK_EQ(tarr[0], Variant(a));
+	CHECK_EQ(tarr[1], Variant(b));
+	memdelete(a);
+	memdelete(b);
+}
+
+TEST_CASE("[Array] Typed refCounted init") {
+	Ref<RefCounted> a = memnew(RefCounted);
+	Ref<RefCounted> b = memnew(RefCounted);
+	TypedArray<Ref<RefCounted>> tarr = {
+		a,
+		b,
+	};
+	CHECK_EQ(tarr[0], Variant(a));
+	CHECK_EQ(tarr[1], Variant(b));
+}
+
 } // namespace TestArray


### PR DESCRIPTION
Adds support for object pointer sub types and adds a test for object pointer and ref sub types for TypedArray.
I think it makes sense to support this and will allow us to add methods to TypedArray that use the `T` typed that overload methods from the base Array class giving better type support.

Its also something that will help one of my projects when support is also added to `godot-cpp`.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/12261*