### PR TITLE
Remove old oversampling property from font importers.

### DIFF
--- a/doc/classes/ResourceImporterDynamicFont.xml
+++ b/doc/classes/ResourceImporterDynamicFont.xml
@@ -66,9 +66,6 @@
 		<member name="opentype_features" type="Dictionary" setter="" getter="" default="{}">
 			The OpenType features to enable, disable or set a value for this font. This can be used to enable optional features provided by the font, such as ligatures or alternative glyphs. The list of supported OpenType features varies on a per-font basis.
 		</member>
-		<member name="oversampling" type="float" setter="" getter="" default="0.0">
-			Deprecated. This property does nothing.
-		</member>
 		<member name="preload" type="Array" setter="" getter="" default="[]">
 			The glyph ranges to prerender. This can avoid stuttering during gameplay when new characters need to be rendered, especially if [member subpixel_positioning] is enabled. The downside of using preloading is that initial project load times will increase, as well as memory usage.
 		</member>

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -69,7 +69,7 @@ bool DynamicFontImportSettingsData::_get(const StringName &p_name, Variant &r_re
 void DynamicFontImportSettingsData::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (const List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
 		if (owner && owner->import_settings_data.is_valid()) {
-			if (owner->import_settings_data->get("multichannel_signed_distance_field") && (E->get().option.name == "size" || E->get().option.name == "outline_size" || E->get().option.name == "oversampling")) {
+			if (owner->import_settings_data->get("multichannel_signed_distance_field") && (E->get().option.name == "size" || E->get().option.name == "outline_size")) {
 				continue;
 			}
 			if (!owner->import_settings_data->get("multichannel_signed_distance_field") && (E->get().option.name == "msdf_pixel_range" || E->get().option.name == "msdf_size")) {
@@ -507,8 +507,6 @@ void DynamicFontImportSettingsDialog::_main_prop_changed(const String &p_edited_
 			_variations_validate();
 		} else if (p_edited_property == "keep_rounding_remainders") {
 			font_preview->set_keep_rounding_remainders(import_settings_data->get("keep_rounding_remainders"));
-		} else if (p_edited_property == "oversampling") {
-			font_preview->set_oversampling(import_settings_data->get("oversampling"));
 		}
 	}
 
@@ -983,7 +981,6 @@ void DynamicFontImportSettingsDialog::_re_import() {
 	main_settings["hinting"] = import_settings_data->get("hinting");
 	main_settings["subpixel_positioning"] = import_settings_data->get("subpixel_positioning");
 	main_settings["keep_rounding_remainders"] = import_settings_data->get("keep_rounding_remainders");
-	main_settings["oversampling"] = import_settings_data->get("oversampling");
 	main_settings["fallbacks"] = import_settings_data->get("fallbacks");
 	main_settings["compress"] = import_settings_data->get("compress");
 
@@ -1296,7 +1293,6 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 		}
 		font_preview->set_subpixel_positioning((TextServer::SubpixelPositioning)font_subpixel_positioning);
 		font_preview->set_keep_rounding_remainders(import_settings_data->get("keep_rounding_remainders"));
-		font_preview->set_oversampling(import_settings_data->get("oversampling"));
 	}
 	font_preview_label->add_theme_font_override(SceneStringName(font), font_preview);
 	font_preview_label->add_theme_font_size_override(SceneStringName(font_size), 200 * EDSCALE);
@@ -1330,7 +1326,6 @@ DynamicFontImportSettingsDialog::DynamicFontImportSettingsDialog() {
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal"), 1));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::INT, "subpixel_positioning", PROPERTY_HINT_ENUM, "Disabled,Auto,One Half of a Pixel,One Quarter of a Pixel,Auto (Except Pixel Fonts)"), 4));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "keep_rounding_remainders"), true));
-	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::FLOAT, "oversampling", PROPERTY_HINT_RANGE, "0,10,0.1"), 0.0));
 
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::NIL, "Metadata Overrides", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP), Variant()));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::DICTIONARY, "language_support"), Dictionary()));

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -75,9 +75,6 @@ bool ResourceImporterDynamicFont::get_option_visibility(const String &p_path, co
 	if (p_option == "antialiasing" && bool(p_options["multichannel_signed_distance_field"])) {
 		return false;
 	}
-	if (p_option == "oversampling" && bool(p_options["multichannel_signed_distance_field"])) {
-		return false;
-	}
 	if (p_option == "subpixel_positioning" && bool(p_options["multichannel_signed_distance_field"])) {
 		return false;
 	}
@@ -120,7 +117,6 @@ void ResourceImporterDynamicFont::get_import_options(const String &p_path, List<
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal"), 1));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "subpixel_positioning", PROPERTY_HINT_ENUM, "Disabled,Auto,One Half of a Pixel,One Quarter of a Pixel,Auto (Except Pixel Fonts)"), 4));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "keep_rounding_remainders"), true));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "oversampling", PROPERTY_HINT_RANGE, "0,10,0.1"), 0.0));
 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::NIL, "Fallbacks", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP), Variant()));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::ARRAY, "fallbacks", PROPERTY_HINT_ARRAY_TYPE, MAKE_RESOURCE_TYPE_HINT("Font")), Array()));
@@ -159,7 +155,6 @@ Error ResourceImporterDynamicFont::import(ResourceUID::ID p_source_id, const Str
 	int hinting = p_options["hinting"];
 	int subpixel_positioning = p_options["subpixel_positioning"];
 	bool keep_rounding_remainders = p_options["keep_rounding_remainders"];
-	real_t oversampling = p_options["oversampling"];
 	Array fallbacks = p_options["fallbacks"];
 
 	// Load base font data.
@@ -181,7 +176,6 @@ Error ResourceImporterDynamicFont::import(ResourceUID::ID p_source_id, const Str
 	font->set_modulate_color_glyphs(modulate_color_glyphs);
 	font->set_allow_system_fallback(allow_system_fallback);
 	font->set_hinting((TextServer::Hinting)hinting);
-	font->set_oversampling(oversampling);
 	font->set_fallbacks(fallbacks);
 
 	if (subpixel_positioning == 4 /* Auto (Except Pixel Fonts) */) {

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -117,7 +117,6 @@ Error ResourceImporterImageFont::import(ResourceUID::ID p_source_id, const Strin
 	font->set_modulate_color_glyphs(false);
 	font->set_allow_system_fallback(false);
 	font->set_hinting(TextServer::HINTING_NONE);
-	font->set_oversampling(1.0f);
 	font->set_fallbacks(fallbacks);
 	font->set_texture_image(0, Vector2i(chr_height, 0), 0, img);
 	font->set_fixed_size_scale_mode(smode);


### PR DESCRIPTION
Removes `oversampling` property from the font importers, which is no longer needed after https://github.com/godotengine/godot/pull/104872
