### PR TITLE
Fix typo in the description of RandomNumberGenerator.state

### DIFF
--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -103,7 +103,7 @@
 			print(rng.randf()) # Prints the same value as previously.
 			[/codeblock]
 			[b]Note:[/b] Do not set state to arbitrary values, since the random number generator requires the state to have certain qualities to behave properly. It should only be set to values that came from the state property itself. To initialize the random number generator with arbitrary input, use [member seed] instead.
-			[b]Note:[/b] The default value of this property is pseudo-random, and changes when calling [method randomize]. The [code]0[/code] value documented here is a placeholder, and not the actual default seed.
+			[b]Note:[/b] The default value of this property is pseudo-random, and changes when calling [method randomize]. The [code]0[/code] value documented here is a placeholder, and not the actual default state.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
The second note of this doc mentions that "the value documented here is [...] not the actual default seed". I have corrected this to say that it's not the default "state" instead, since it has no reason to ever match the seed.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
