### PR TITLE
Add docs for _get_property_warning

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1834,6 +1834,13 @@ void Object::_bind_methods() {
 		BIND_OBJ_CORE_METHOD(mi);
 	}
 
+	{
+		MethodInfo mi("_get_property_warning");
+		mi.arguments.push_back(PropertyInfo(Variant::STRING_NAME, "property"));
+		mi.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
+		BIND_OBJ_CORE_METHOD(mi);
+	}
+
 	BIND_OBJ_CORE_METHOD(MethodInfo(Variant::NIL, "_validate_property", PropertyInfo(Variant::DICTIONARY, "property")));
 
 	BIND_OBJ_CORE_METHOD(MethodInfo(Variant::BOOL, "_property_can_revert", PropertyInfo(Variant::STRING_NAME, "property")));

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -703,6 +703,7 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_property) const { return false; }
 	void _get_property_list(List<PropertyInfo> *p_list) const {}
 	void _validate_property(PropertyInfo &p_property) const {}
+	void _get_property_warning(const StringName &p_name, String &r_property) const {}
 	bool _property_can_revert(const StringName &p_name) const { return false; }
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return false; }
 	void _notification(int p_notification) {}

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -186,6 +186,25 @@
 				[b]Note:[/b] If the object's script is not [annotation @GDScript.@tool], this method will not be called in the editor.
 			</description>
 		</method>
+		<method name="_get_property_warning" qualifiers="virtual">
+			<return type="Variant" />
+			<param index="0" name="property" type="StringName" />
+			<description>
+				Override this method to customize warning messages for properties in the inspector.
+				Should return the given [param property]'s warning to be displayed as warnings in the inspector if the script that overrides it is a [code]tool[/code] script.
+				Returning an empty string produces no warnings.
+				[codeblock]
+				@export var energy = 0
+
+				func _get_property_warning(property):
+				    if property == "energy" and energy &lt; 0:
+				        return "Energy must be 0 or greater."
+				    else:
+				        return ""
+				[/codeblock]
+				[b]Note:[/b] If the object's script is not [annotation @GDScript.@tool], this method will not be called in the editor.
+			</description>
+		</method>
 		<method name="_init" qualifiers="virtual">
 			<return type="void" />
 			<description>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -774,7 +774,8 @@ void EditorProperty::update_editor_property_status() {
 
 	bool new_warning = false;
 	if (object->has_method("_get_property_warning")) {
-		new_warning = !String(object->call("_get_property_warning", property)).is_empty();
+		const Variant custom_warning = object->call("_get_property_warning", property);
+		new_warning = (custom_warning.get_type() != Variant::NIL) && !String(custom_warning).is_empty();
 	}
 
 	Variant current = object->get(_get_revert_property());
@@ -1256,9 +1257,9 @@ Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
 	String prologue;
 
 	if (object->has_method("_get_property_warning")) {
-		const String custom_warning = object->call("_get_property_warning", property);
-		if (!custom_warning.is_empty()) {
-			prologue = "[b][color=" + get_theme_color(SNAME("warning_color")).to_html(false) + "]" + custom_warning + "[/color][/b]";
+		const Variant custom_warning = object->call("_get_property_warning", property);
+		if ((custom_warning.get_type() != Variant::NIL) && !String(custom_warning).is_empty()) {
+			prologue = "[b][color=" + get_theme_color(SNAME("warning_color")).to_html(false) + "]" + String(custom_warning) + "[/color][/b]";
 		}
 	}
 


### PR DESCRIPTION
Currently, property editors in the inspector reference a `_get_property_warning` method that can be overridden in the object. This method defines warnings for individual properties, but there is currently no documentation for this. The method currently works in the editor, the only thing this PR does is to document this function and to fix a bug where null return values would still print a warning error.

In the inspector currently:
https://github.com/godotengine/godot/blob/e5ccaa79e2a2d5551369bd6cc1f8ed654a791275/editor/editor_inspector.cpp#L775-L778

https://github.com/godotengine/godot/blob/e5ccaa79e2a2d5551369bd6cc1f8ed654a791275/editor/editor_inspector.cpp#L1258-L1263

These warnings were added in #74644 with the intention of being used in the export popups. They do have the associated issue of not updating the yellow label until it is redrawn if the warning comes from the value of a different property. That being said; this is not an issue if the warning comes from the property itself, so the bug is minor and not in the scope of this PR.