### PR TITLE
[3.x] Physics Interpolation - Fix `disable_scale` bug in 3D

### DIFF
--- a/scene/main/scene_tree_fti.cpp
+++ b/scene/main/scene_tree_fti.cpp
@@ -352,6 +352,12 @@ void SceneTreeFTI::_update_dirty_spatials(Node *p_node, uint32_t p_current_frame
 			s->data.global_transform_interpolated = local_interp;
 		}
 
+		// Watch for this, disable_scale can cause incredibly confusing bugs
+		// and must be checked for when calculating global xforms.
+		if (s->data.disable_scale) {
+			s->data.global_transform_interpolated.basis.orthonormalize();
+		}
+
 		// Upload to VisualServer the interpolated global xform.
 		s->fti_update_servers_xform();
 


### PR DESCRIPTION
Thanks to @Calinou 's beady eyes he noticed a regression in #104269 affecting a particular light in the 4.x version of TPS demo.

3 hours of debugging and head scratching later, I realized that `get_global_transform()` had a feature I'd never noticed before, `disable_scale`. If this is set, it orthonormalizes the global basis.

As `SceneTreeFTI` is manually re-creating interpolated global xforms, it also should respect the `disable_scale` feature, which is used on `Lights` and some other nodes.

## Notes
* Haven't yet seen bugs due to this in the wild on 3.x, but good to close this. 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
