### PR TITLE
Fix typo ovrsampling → oversampling

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -143,7 +143,7 @@ void CanvasItem::_redraw_callback() {
 		drawing = true;
 		Ref<TextServer> ts = TextServerManager::get_singleton()->get_primary_interface();
 		if (ts.is_valid()) {
-			ts->set_current_drawn_item_ovrsampling(get_viewport()->get_oversampling());
+			ts->set_current_drawn_item_oversampling(get_viewport()->get_oversampling());
 		}
 		current_item_drawn = this;
 		notification(NOTIFICATION_DRAW);
@@ -151,7 +151,7 @@ void CanvasItem::_redraw_callback() {
 		GDVIRTUAL_CALL(_draw);
 		current_item_drawn = nullptr;
 		if (ts.is_valid()) {
-			ts->set_current_drawn_item_ovrsampling(0.0);
+			ts->set_current_drawn_item_oversampling(0.0);
 		}
 		drawing = false;
 	}

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -605,7 +605,7 @@ public:
 
 	TypedArray<Vector3i> parse_structured_text(StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const;
 
-	virtual void set_current_drawn_item_ovrsampling(double p_vp_oversampling) { vp_oversampling = p_vp_oversampling; }
+	virtual void set_current_drawn_item_oversampling(double p_vp_oversampling) { vp_oversampling = p_vp_oversampling; }
 
 	virtual void cleanup() {}
 


### PR DESCRIPTION
...just a small typo I found while looking through https://github.com/godotengine/godot/pull/104872 :slightly_smiling_face: 