### PR TITLE
Add `keep_decal_opacity` property to allow decals to modify surface alpha

### DIFF
--- a/doc/classes/Decal.xml
+++ b/doc/classes/Decal.xml
@@ -7,7 +7,7 @@
 		[Decal]s are used to project a texture onto a [Mesh] in the scene. Use Decals to add detail to a scene without affecting the underlying [Mesh]. They are often used to add weathering to building, add dirt or mud to the ground, or add variety to props. Decals can be moved at any time, making them suitable for things like blob shadows or laser sight dots.
 		They are made of an [AABB] and a group of [Texture2D]s specifying [Color], normal, ORM (ambient occlusion, roughness, metallic), and emission. Decals are projected within their [AABB] so altering the orientation of the Decal affects the direction in which they are projected. By default, Decals are projected down (i.e. from positive Y to negative Y).
 		The [Texture2D]s associated with the Decal are automatically stored in a texture atlas which is used for drawing the decals so all decals can be drawn at once. Godot uses clustered decals, meaning they are stored in cluster data and drawn when the mesh is drawn, they are not drawn as a post-processing effect after.
-		[b]Note:[/b] Decals cannot affect an underlying material's transparency, regardless of its transparency mode (alpha blend, alpha scissor, alpha hash, opaque pre-pass). This means translucent or transparent areas of a material will remain translucent or transparent even if an opaque decal is applied on them.
+		[b]Note:[/b] Decals can modify an underlying material's transparency based on their own alpha. If a decal's alpha is greater than the surface alpha at a given pixel, the decal's alpha will be used, allowing decals to make surfaces more opaque. This can be toggled using the [member keep_decal_opacity] property.
 		[b]Note:[/b] Decals are only supported in the Forward+ and Mobile rendering methods, not Compatibility. When using the Mobile rendering method, only 8 decals can be displayed on each mesh resource. Attempting to display more than 8 decals on a single mesh resource will result in decals flickering in and out as the camera moves.
 		[b]Note:[/b] When using the Mobile rendering method, decals will only correctly affect meshes whose visibility AABB intersects with the decal's AABB. If using a shader to deform the mesh in a way that makes it go outside its AABB, [member GeometryInstance3D.extra_cull_margin] must be increased on the mesh. Otherwise, the decal may not be visible on the mesh.
 	</description>
@@ -76,6 +76,9 @@
 		</member>
 		<member name="emission_energy" type="float" setter="set_emission_energy" getter="get_emission_energy" default="1.0">
 			Energy multiplier for the emission texture. This will make the decal emit light at a higher or lower intensity, independently of the albedo color. See also [member modulate].
+		</member>
+		<member name="keep_decal_opacity" type="bool" setter="set_keep_decal_opacity" getter="is_keep_decal_opacity_enabled" default="false">
+			If [code]true[/code], the alpha from the decal's [member texture_albedo] will override the surface's alpha for any pixel where the decal's alpha is greater. This ensures that the resulting pixels are at least as opaque as the decal, never less.
 		</member>
 		<member name="lower_fade" type="float" setter="set_lower_fade" getter="get_lower_fade" default="0.3">
 			Sets the curve over which the decal will fade as the surface gets further from the center of the [AABB]. Only positive values are valid (negative values will be clamped to [code]0.0[/code]). See also [member upper_fade].

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1183,6 +1183,14 @@
 				Sets the upper fade ([param above]) and lower fade ([param below]) in the decal specified by the [param decal] RID. Equivalent to [member Decal.upper_fade] and [member Decal.lower_fade].
 			</description>
 		</method>
+		<method name="decal_set_keep_decal_opacity">
+			<return type="void" />
+			<param index="0" name="decal" type="RID" />
+			<param index="1" name="keep_decal_opacity" type="bool" />
+			<description>
+				If [code]true[/code], the alpha from the decal's texture will override the surface's alpha for any pixel where the decal's alpha is greater. This ensures that the resulting pixels are at least as opaque as the decal, never less.
+			</description>
+		</method>
 		<method name="decal_set_modulate">
 			<return type="void" />
 			<param index="0" name="decal" type="RID" />

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2253,6 +2253,9 @@ void TextureStorage::decal_set_fade(RID p_decal, float p_above, float p_below) {
 void TextureStorage::decal_set_normal_fade(RID p_decal, float p_fade) {
 }
 
+void TextureStorage::decal_set_keep_decal_opacity(RID p_decal, bool p_override) {
+}
+
 AABB TextureStorage::decal_get_aabb(RID p_decal) const {
 	return AABB();
 }

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -622,6 +622,7 @@ public:
 	virtual void decal_set_distance_fade(RID p_decal, bool p_enabled, float p_begin, float p_length) override;
 	virtual void decal_set_fade(RID p_decal, float p_above, float p_below) override;
 	virtual void decal_set_normal_fade(RID p_decal, float p_fade) override;
+	virtual void decal_set_keep_decal_opacity(RID p_decal, bool p_override) override;
 
 	virtual AABB decal_get_aabb(RID p_decal) const override;
 	virtual uint32_t decal_get_cull_mask(RID p_decal) const override { return 0; }

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -112,6 +112,15 @@ real_t Decal::get_normal_fade() const {
 	return normal_fade;
 }
 
+void Decal::set_keep_decal_opacity(bool p_override) {
+	keep_decal_opacity = p_override;
+	RS::get_singleton()->decal_set_keep_decal_opacity(decal, keep_decal_opacity);
+}
+
+bool Decal::is_keep_decal_opacity_enabled() const {
+	return keep_decal_opacity;
+}
+
 void Decal::set_modulate(Color p_modulate) {
 	modulate = p_modulate;
 	RS::get_singleton()->decal_set_modulate(decal, p_modulate);
@@ -220,6 +229,9 @@ void Decal::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_normal_fade", "fade"), &Decal::set_normal_fade);
 	ClassDB::bind_method(D_METHOD("get_normal_fade"), &Decal::get_normal_fade);
 
+	ClassDB::bind_method(D_METHOD("set_keep_decal_opacity", "keep_decal_opacity"), &Decal::set_keep_decal_opacity);
+	ClassDB::bind_method(D_METHOD("is_keep_decal_opacity_enabled"), &Decal::is_keep_decal_opacity_enabled);
+
 	ClassDB::bind_method(D_METHOD("set_enable_distance_fade", "enable"), &Decal::set_enable_distance_fade);
 	ClassDB::bind_method(D_METHOD("is_distance_fade_enabled"), &Decal::is_distance_fade_enabled);
 
@@ -249,6 +261,7 @@ void Decal::_bind_methods() {
 	// A Normal Fade of 1.0 causes the decal to be invisible even if fully perpendicular to a surface.
 	// Due to this, limit Normal Fade to 0.999.
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "normal_fade", PROPERTY_HINT_RANGE, "0,0.999,0.001"), "set_normal_fade", "get_normal_fade");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_decal_opacity"), "set_keep_decal_opacity", "is_keep_decal_opacity_enabled");
 
 	ADD_GROUP("Vertical Fade", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "upper_fade", PROPERTY_HINT_EXP_EASING, "attenuation"), "set_upper_fade", "get_upper_fade");

--- a/scene/3d/decal.h
+++ b/scene/3d/decal.h
@@ -53,6 +53,7 @@ private:
 	Color modulate = Color(1, 1, 1, 1);
 	uint32_t cull_mask = (1 << 20) - 1;
 	real_t normal_fade = 0.0;
+	bool keep_decal_opacity = false;
 	real_t upper_fade = 0.3;
 	real_t lower_fade = 0.3;
 	bool distance_fade_enabled = false;
@@ -92,7 +93,10 @@ public:
 	real_t get_lower_fade() const;
 
 	void set_normal_fade(real_t p_fade);
-	real_t get_normal_fade() const;
+	real_t get_normal_fade() const; ////////
+
+	void set_keep_decal_opacity(bool p_override);
+	bool is_keep_decal_opacity_enabled() const;
 
 	void set_enable_distance_fade(bool p_enable);
 	bool is_distance_fade_enabled() const;

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -145,6 +145,7 @@ public:
 	virtual void decal_set_distance_fade(RID p_decal, bool p_enabled, float p_begin, float p_length) override {}
 	virtual void decal_set_fade(RID p_decal, float p_above, float p_below) override {}
 	virtual void decal_set_normal_fade(RID p_decal, float p_fade) override {}
+	virtual void decal_set_keep_decal_opacity(RID p_decal, bool p_override) override {}
 
 	virtual AABB decal_get_aabb(RID p_decal) const override { return AABB(); }
 	virtual uint32_t decal_get_cull_mask(RID p_decal) const override { return 0; }

--- a/servers/rendering/renderer_rd/shaders/decal_data_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/decal_data_inc.glsl
@@ -14,4 +14,5 @@ struct DecalData {
 	mat3x4 normal_xform;
 	vec3 normal;
 	float normal_fade;
+	uint keep_decal_opacity;
 };

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1598,6 +1598,9 @@ void fragment_shader(in SceneData scene_data) {
 						decal_albedo = textureLod(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].albedo_rect.zw + decals.data[decal_index].albedo_rect.xy, 0.0);
 					}
 					decal_albedo *= decals.data[decal_index].modulate;
+					if (decals.data[decal_index].keep_decal_opacity == 1u) {
+						alpha = max(alpha, decal_albedo.a);
+					}
 					decal_albedo.a *= fade;
 					albedo = mix(albedo, decal_albedo.rgb, decal_albedo.a * decals.data[decal_index].albedo_mix);
 

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1508,6 +1508,9 @@ void main() {
 				decal_albedo = textureLod(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].albedo_rect.zw + decals.data[decal_index].albedo_rect.xy, 0.0);
 			}
 			decal_albedo *= decals.data[decal_index].modulate;
+			if (decals.data[decal_index].keep_decal_opacity == 1u) {
+				alpha = max(alpha, decal_albedo.a);
+			}
 			decal_albedo.a *= fade;
 			albedo = hvec3(mix(vec3(albedo), decal_albedo.rgb, decal_albedo.a * decals.data[decal_index].albedo_mix));
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -2999,6 +2999,12 @@ void TextureStorage::decal_set_normal_fade(RID p_decal, float p_fade) {
 	decal->normal_fade = p_fade;
 }
 
+void TextureStorage::decal_set_keep_decal_opacity(RID p_decal, bool p_override) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->keep_decal_opacity = p_override;
+}
+
 void TextureStorage::decal_atlas_mark_dirty_on_texture(RID p_texture) {
 	if (decal_atlas.textures.has(p_texture)) {
 		//belongs to decal atlas..
@@ -3406,6 +3412,8 @@ void TextureStorage::update_decal_buffer(const PagedArray<RID> &p_decals, const 
 		dd.normal[1] = normal.y;
 		dd.normal[2] = normal.z;
 		dd.normal_fade = decal->normal_fade;
+
+		dd.keep_decal_opacity = static_cast<uint32_t>(decal->keep_decal_opacity);
 
 		RID albedo_tex = decal->textures[RS::DECAL_TEXTURE_ALBEDO];
 		RID emission_tex = decal->textures[RS::DECAL_TEXTURE_EMISSION];

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -298,6 +298,7 @@ private:
 		float distance_fade_begin = 40.0;
 		float distance_fade_length = 10.0;
 		float normal_fade = 0.0;
+		bool keep_decal_opacity = false;
 
 		Dependency dependency;
 	};
@@ -334,6 +335,12 @@ private:
 		float normal_xform[12];
 		float normal[3];
 		float normal_fade;
+		uint32_t keep_decal_opacity;
+
+		// Added padding to maintain correct buffer alignment for UBO.
+		uint32_t pad0;
+		uint32_t pad1;
+		uint32_t pad2;
 	};
 
 	struct DecalInstanceSort {
@@ -628,6 +635,7 @@ public:
 	virtual void decal_set_distance_fade(RID p_decal, bool p_enabled, float p_begin, float p_length) override;
 	virtual void decal_set_fade(RID p_decal, float p_above, float p_below) override;
 	virtual void decal_set_normal_fade(RID p_decal, float p_fade) override;
+	virtual void decal_set_keep_decal_opacity(RID p_decal, bool p_override) override;
 
 	void decal_atlas_mark_dirty_on_texture(RID p_texture);
 	void decal_atlas_remove_texture(RID p_texture);
@@ -678,6 +686,11 @@ public:
 	_FORCE_INLINE_ float decal_get_normal_fade(RID p_decal) {
 		const Decal *decal = decal_owner.get_or_null(p_decal);
 		return decal->normal_fade;
+	}
+
+	_FORCE_INLINE_ bool decal_is_keep_decal_opacity_enabled(RID p_decal) {
+		const Decal *decal = decal_owner.get_or_null(p_decal);
+		return decal->keep_decal_opacity;
 	}
 
 	_FORCE_INLINE_ bool decal_is_distance_fade_enabled(RID p_decal) {

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2688,6 +2688,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("decal_set_distance_fade", "decal", "enabled", "begin", "length"), &RenderingServer::decal_set_distance_fade);
 	ClassDB::bind_method(D_METHOD("decal_set_fade", "decal", "above", "below"), &RenderingServer::decal_set_fade);
 	ClassDB::bind_method(D_METHOD("decal_set_normal_fade", "decal", "fade"), &RenderingServer::decal_set_normal_fade);
+	ClassDB::bind_method(D_METHOD("decal_set_keep_decal_opacity", "decal", "keep_decal_opacity"), &RenderingServer::decal_set_keep_decal_opacity);
 
 	ClassDB::bind_method(D_METHOD("decals_set_filter", "filter"), &RenderingServer::decals_set_filter);
 

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -696,6 +696,7 @@ public:
 	virtual void decal_set_distance_fade(RID p_decal, bool p_enabled, float p_begin, float p_length) = 0;
 	virtual void decal_set_fade(RID p_decal, float p_above, float p_below) = 0;
 	virtual void decal_set_normal_fade(RID p_decal, float p_fade) = 0;
+	virtual void decal_set_keep_decal_opacity(RID p_decal, bool p_override) = 0;
 
 	enum DecalFilter {
 		DECAL_FILTER_NEAREST,

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -535,6 +535,7 @@ public:
 	FUNC4(decal_set_distance_fade, RID, bool, float, float)
 	FUNC3(decal_set_fade, RID, float, float)
 	FUNC2(decal_set_normal_fade, RID, float)
+	FUNC2(decal_set_keep_decal_opacity, RID, bool)
 
 	/* BAKED LIGHT API */
 

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -122,6 +122,7 @@ public:
 	virtual void decal_set_distance_fade(RID p_decal, bool p_enabled, float p_begin, float p_length) = 0;
 	virtual void decal_set_fade(RID p_decal, float p_above, float p_below) = 0;
 	virtual void decal_set_normal_fade(RID p_decal, float p_fade) = 0;
+	virtual void decal_set_keep_decal_opacity(RID p_decal, bool p_override = false) = 0;
 
 	virtual AABB decal_get_aabb(RID p_decal) const = 0;
 	virtual uint32_t decal_get_cull_mask(RID p_decal) const = 0;


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot-proposals/issues/12245

```glsl
if (decals.data[decal_index].keep_decal_opacity== 1u) {
    alpha = max(alpha, decal_albedo.a);
}
```

Before:
![image](https://github.com/user-attachments/assets/516dc2ed-a7f6-4ace-bdba-b896ddb373af)

After:
![image](https://github.com/user-attachments/assets/c1c717a7-8f1a-46d4-8673-ef5e4ffef6e5)
![image](https://github.com/user-attachments/assets/5738d656-e177-4888-ba75-5d04c0b38c23)

