### PR TITLE
Fix RendererRD crash on start on Intel Macs.

### DIFF
--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -722,12 +722,6 @@ SkyRD::SkyRD() {
 	roughness_layers = GLOBAL_GET("rendering/reflections/sky_reflections/roughness_layers");
 	sky_ggx_samples_quality = GLOBAL_GET("rendering/reflections/sky_reflections/ggx_samples");
 	sky_use_cubemap_array = GLOBAL_GET("rendering/reflections/sky_reflections/texture_array_reflections");
-#if defined(MACOS_ENABLED) && defined(__x86_64__)
-	if (OS::get_singleton()->get_current_rendering_driver_name() == "vulkan" && RenderingServer::get_singleton()->get_video_adapter_name().contains("Intel")) {
-		// Disable texture array reflections on macOS on Intel GPUs due to driver bugs.
-		sky_use_cubemap_array = false;
-	}
-#endif
 }
 
 void SkyRD::init() {
@@ -952,6 +946,15 @@ void sky() {
 void SkyRD::set_texture_format(RD::DataFormat p_texture_format) {
 	texture_format = p_texture_format;
 }
+
+#if defined(MACOS_ENABLED) && defined(__x86_64__)
+void SkyRD::check_cubemap_array() {
+	if (OS::get_singleton()->get_current_rendering_driver_name() == "vulkan" && RenderingServer::get_singleton()->get_video_adapter_name().contains("Intel")) {
+		// Disable texture array reflections on macOS on Intel GPUs due to driver bugs.
+		sky_use_cubemap_array = false;
+	}
+}
+#endif
 
 SkyRD::~SkyRD() {
 	// cleanup anything created in init...

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -280,6 +280,9 @@ public:
 
 	uint32_t sky_ggx_samples_quality;
 	bool sky_use_cubemap_array;
+#if defined(MACOS_ENABLED) && defined(__x86_64__)
+	void check_cubemap_array();
+#endif
 	Sky *dirty_sky_list = nullptr;
 	mutable RID_Owner<Sky, true> sky_owner;
 	int roughness_layers;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -158,6 +158,11 @@ void RendererCompositorRD::initialize() {
 
 		blit.sampler = RD::get_singleton()->sampler_create(RD::SamplerState());
 	}
+#if defined(MACOS_ENABLED) && defined(__x86_64__)
+	if (scene) {
+		scene->get_sky()->check_cubemap_array();
+	}
+#endif
 }
 
 uint64_t RendererCompositorRD::frame = 1;


### PR DESCRIPTION
Regression from https://github.com/godotengine/godot/pull/103306, check was done before `RSG::utilities` init (required for `get_video_adapter_name`).

Fixes https://github.com/godotengine/godot/issues/105422

Note: marked as "cherrypick 4.4" since #103306 is.