### PR TITLE
Update NavigationServer statistics on frame process instead of physics process

### DIFF
--- a/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
@@ -1277,6 +1277,38 @@ void GodotNavigationServer2D::process(double p_delta_time) {
 	// E.g. (final) sync of objects for this main loop iteration, updating rendered debug visuals, updating debug statistics, ...
 
 	sync();
+
+	int _new_pm_region_count = 0;
+	int _new_pm_agent_count = 0;
+	int _new_pm_link_count = 0;
+	int _new_pm_polygon_count = 0;
+	int _new_pm_edge_count = 0;
+	int _new_pm_edge_merge_count = 0;
+	int _new_pm_edge_connection_count = 0;
+	int _new_pm_edge_free_count = 0;
+	int _new_pm_obstacle_count = 0;
+
+	for (NavMap2D *map : active_maps) {
+		_new_pm_region_count += map->get_pm_region_count();
+		_new_pm_agent_count += map->get_pm_agent_count();
+		_new_pm_link_count += map->get_pm_link_count();
+		_new_pm_polygon_count += map->get_pm_polygon_count();
+		_new_pm_edge_count += map->get_pm_edge_count();
+		_new_pm_edge_merge_count += map->get_pm_edge_merge_count();
+		_new_pm_edge_connection_count += map->get_pm_edge_connection_count();
+		_new_pm_edge_free_count += map->get_pm_edge_free_count();
+		_new_pm_obstacle_count += map->get_pm_obstacle_count();
+	}
+
+	pm_region_count = _new_pm_region_count;
+	pm_agent_count = _new_pm_agent_count;
+	pm_link_count = _new_pm_link_count;
+	pm_polygon_count = _new_pm_polygon_count;
+	pm_edge_count = _new_pm_edge_count;
+	pm_edge_merge_count = _new_pm_edge_merge_count;
+	pm_edge_connection_count = _new_pm_edge_connection_count;
+	pm_edge_free_count = _new_pm_edge_free_count;
+	pm_obstacle_count = _new_pm_obstacle_count;
 }
 
 void GodotNavigationServer2D::physics_process(double p_delta_time) {
@@ -1293,42 +1325,12 @@ void GodotNavigationServer2D::physics_process(double p_delta_time) {
 		return;
 	}
 
-	int _new_pm_region_count = 0;
-	int _new_pm_agent_count = 0;
-	int _new_pm_link_count = 0;
-	int _new_pm_polygon_count = 0;
-	int _new_pm_edge_count = 0;
-	int _new_pm_edge_merge_count = 0;
-	int _new_pm_edge_connection_count = 0;
-	int _new_pm_edge_free_count = 0;
-	int _new_pm_obstacle_count = 0;
-
 	MutexLock lock(operations_mutex);
 	for (uint32_t i(0); i < active_maps.size(); i++) {
 		active_maps[i]->sync();
 		active_maps[i]->step(p_delta_time);
 		active_maps[i]->dispatch_callbacks();
-
-		_new_pm_region_count += active_maps[i]->get_pm_region_count();
-		_new_pm_agent_count += active_maps[i]->get_pm_agent_count();
-		_new_pm_link_count += active_maps[i]->get_pm_link_count();
-		_new_pm_polygon_count += active_maps[i]->get_pm_polygon_count();
-		_new_pm_edge_count += active_maps[i]->get_pm_edge_count();
-		_new_pm_edge_merge_count += active_maps[i]->get_pm_edge_merge_count();
-		_new_pm_edge_connection_count += active_maps[i]->get_pm_edge_connection_count();
-		_new_pm_edge_free_count += active_maps[i]->get_pm_edge_free_count();
-		_new_pm_obstacle_count += active_maps[i]->get_pm_obstacle_count();
 	}
-
-	pm_region_count = _new_pm_region_count;
-	pm_agent_count = _new_pm_agent_count;
-	pm_link_count = _new_pm_link_count;
-	pm_polygon_count = _new_pm_polygon_count;
-	pm_edge_count = _new_pm_edge_count;
-	pm_edge_merge_count = _new_pm_edge_merge_count;
-	pm_edge_connection_count = _new_pm_edge_connection_count;
-	pm_edge_free_count = _new_pm_edge_free_count;
-	pm_obstacle_count = _new_pm_obstacle_count;
 }
 
 void GodotNavigationServer2D::set_active(bool p_active) {

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
@@ -1370,6 +1370,38 @@ void GodotNavigationServer3D::process(double p_delta_time) {
 	// E.g. (final) sync of objects for this main loop iteration, updating rendered debug visuals, updating debug statistics, ...
 
 	sync();
+
+	int _new_pm_region_count = 0;
+	int _new_pm_agent_count = 0;
+	int _new_pm_link_count = 0;
+	int _new_pm_polygon_count = 0;
+	int _new_pm_edge_count = 0;
+	int _new_pm_edge_merge_count = 0;
+	int _new_pm_edge_connection_count = 0;
+	int _new_pm_edge_free_count = 0;
+	int _new_pm_obstacle_count = 0;
+
+	for (NavMap3D *map : active_maps) {
+		_new_pm_region_count += map->get_pm_region_count();
+		_new_pm_agent_count += map->get_pm_agent_count();
+		_new_pm_link_count += map->get_pm_link_count();
+		_new_pm_polygon_count += map->get_pm_polygon_count();
+		_new_pm_edge_count += map->get_pm_edge_count();
+		_new_pm_edge_merge_count += map->get_pm_edge_merge_count();
+		_new_pm_edge_connection_count += map->get_pm_edge_connection_count();
+		_new_pm_edge_free_count += map->get_pm_edge_free_count();
+		_new_pm_obstacle_count += map->get_pm_obstacle_count();
+	}
+
+	pm_region_count = _new_pm_region_count;
+	pm_agent_count = _new_pm_agent_count;
+	pm_link_count = _new_pm_link_count;
+	pm_polygon_count = _new_pm_polygon_count;
+	pm_edge_count = _new_pm_edge_count;
+	pm_edge_merge_count = _new_pm_edge_merge_count;
+	pm_edge_connection_count = _new_pm_edge_connection_count;
+	pm_edge_free_count = _new_pm_edge_free_count;
+	pm_obstacle_count = _new_pm_obstacle_count;
 }
 
 void GodotNavigationServer3D::physics_process(double p_delta_time) {
@@ -1386,42 +1418,12 @@ void GodotNavigationServer3D::physics_process(double p_delta_time) {
 		return;
 	}
 
-	int _new_pm_region_count = 0;
-	int _new_pm_agent_count = 0;
-	int _new_pm_link_count = 0;
-	int _new_pm_polygon_count = 0;
-	int _new_pm_edge_count = 0;
-	int _new_pm_edge_merge_count = 0;
-	int _new_pm_edge_connection_count = 0;
-	int _new_pm_edge_free_count = 0;
-	int _new_pm_obstacle_count = 0;
-
 	MutexLock lock(operations_mutex);
 	for (uint32_t i(0); i < active_maps.size(); i++) {
 		active_maps[i]->sync();
 		active_maps[i]->step(p_delta_time);
 		active_maps[i]->dispatch_callbacks();
-
-		_new_pm_region_count += active_maps[i]->get_pm_region_count();
-		_new_pm_agent_count += active_maps[i]->get_pm_agent_count();
-		_new_pm_link_count += active_maps[i]->get_pm_link_count();
-		_new_pm_polygon_count += active_maps[i]->get_pm_polygon_count();
-		_new_pm_edge_count += active_maps[i]->get_pm_edge_count();
-		_new_pm_edge_merge_count += active_maps[i]->get_pm_edge_merge_count();
-		_new_pm_edge_connection_count += active_maps[i]->get_pm_edge_connection_count();
-		_new_pm_edge_free_count += active_maps[i]->get_pm_edge_free_count();
-		_new_pm_obstacle_count += active_maps[i]->get_pm_obstacle_count();
 	}
-
-	pm_region_count = _new_pm_region_count;
-	pm_agent_count = _new_pm_agent_count;
-	pm_link_count = _new_pm_link_count;
-	pm_polygon_count = _new_pm_polygon_count;
-	pm_edge_count = _new_pm_edge_count;
-	pm_edge_merge_count = _new_pm_edge_merge_count;
-	pm_edge_connection_count = _new_pm_edge_connection_count;
-	pm_edge_free_count = _new_pm_edge_free_count;
-	pm_obstacle_count = _new_pm_obstacle_count;
 }
 
 void GodotNavigationServer3D::init() {

--- a/tests/servers/test_navigation_server_2d.h
+++ b/tests/servers/test_navigation_server_2d.h
@@ -85,6 +85,7 @@ TEST_SUITE("[Navigation2D]") {
 		CHECK_EQ(navigation_server->get_maps().size(), 0);
 
 		SUBCASE("'ProcessInfo' should report all counters empty as well") {
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_ACTIVE_MAPS), 0);
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_REGION_COUNT), 0);
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_AGENT_COUNT), 0);
@@ -104,6 +105,7 @@ TEST_SUITE("[Navigation2D]") {
 		CHECK(agent.is_valid());
 
 		SUBCASE("'ProcessInfo' should not report dangling agent") {
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_AGENT_COUNT), 0);
 		}
 
@@ -122,10 +124,12 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->map_set_active(map, true);
 			navigation_server->agent_set_map(agent, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_AGENT_COUNT), 1);
 			navigation_server->agent_set_map(agent, RID());
 			navigation_server->free(map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_AGENT_COUNT), 0);
 		}
 
@@ -165,6 +169,7 @@ TEST_SUITE("[Navigation2D]") {
 		CHECK_EQ(navigation_server->get_maps().size(), 1);
 
 		SUBCASE("'ProcessInfo' should not report inactive map") {
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_ACTIVE_MAPS), 0);
 		}
 
@@ -186,9 +191,11 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->map_set_active(map, true);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK(navigation_server->map_is_active(map));
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_ACTIVE_MAPS), 1);
 			navigation_server->map_set_active(map, false);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_ACTIVE_MAPS), 0);
 		}
 
@@ -276,6 +283,7 @@ TEST_SUITE("[Navigation2D]") {
 		CHECK(link.is_valid());
 
 		SUBCASE("'ProcessInfo' should not report dangling link") {
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_LINK_COUNT), 0);
 		}
 
@@ -305,10 +313,12 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->map_set_active(map, true);
 			navigation_server->link_set_map(link, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_LINK_COUNT), 1);
 			navigation_server->link_set_map(link, RID());
 			navigation_server->free(map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_LINK_COUNT), 0);
 		}
 
@@ -333,6 +343,7 @@ TEST_SUITE("[Navigation2D]") {
 		CHECK(region.is_valid());
 
 		SUBCASE("'ProcessInfo' should not report dangling region") {
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_REGION_COUNT), 0);
 		}
 
@@ -358,10 +369,12 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->map_set_active(map, true);
 			navigation_server->region_set_map(region, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_REGION_COUNT), 1);
 			navigation_server->region_set_map(region, RID());
 			navigation_server->free(map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_REGION_COUNT), 0);
 		}
 

--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -75,6 +75,7 @@ TEST_SUITE("[Navigation3D]") {
 		CHECK(agent.is_valid());
 
 		SUBCASE("'ProcessInfo' should not report dangling agent") {
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_AGENT_COUNT), 0);
 		}
 
@@ -93,10 +94,12 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->map_set_active(map, true);
 			navigation_server->agent_set_map(agent, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_AGENT_COUNT), 1);
 			navigation_server->agent_set_map(agent, RID());
 			navigation_server->free(map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_AGENT_COUNT), 0);
 		}
 
@@ -137,6 +140,7 @@ TEST_SUITE("[Navigation3D]") {
 		CHECK_EQ(navigation_server->get_maps().size(), 1);
 
 		SUBCASE("'ProcessInfo' should not report inactive map") {
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_ACTIVE_MAPS), 0);
 		}
 
@@ -160,9 +164,11 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->map_set_active(map, true);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK(navigation_server->map_is_active(map));
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_ACTIVE_MAPS), 1);
 			navigation_server->map_set_active(map, false);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_ACTIVE_MAPS), 0);
 		}
 
@@ -251,6 +257,7 @@ TEST_SUITE("[Navigation3D]") {
 		CHECK(link.is_valid());
 
 		SUBCASE("'ProcessInfo' should not report dangling link") {
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_LINK_COUNT), 0);
 		}
 
@@ -280,10 +287,12 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->map_set_active(map, true);
 			navigation_server->link_set_map(link, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_LINK_COUNT), 1);
 			navigation_server->link_set_map(link, RID());
 			navigation_server->free(map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_LINK_COUNT), 0);
 		}
 
@@ -308,6 +317,7 @@ TEST_SUITE("[Navigation3D]") {
 		CHECK(region.is_valid());
 
 		SUBCASE("'ProcessInfo' should not report dangling region") {
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_REGION_COUNT), 0);
 		}
 
@@ -333,10 +343,12 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->map_set_active(map, true);
 			navigation_server->region_set_map(region, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_REGION_COUNT), 1);
 			navigation_server->region_set_map(region, RID());
 			navigation_server->free(map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
+			navigation_server->process(0.0); // Force stats update.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_REGION_COUNT), 0);
 		}
 


### PR DESCRIPTION
Updates NavigationServer statistics on frame process instead of physics process.

The diff looks bigger than the actual change is. This just moves the stat update block from the physics_process() function to the newer process() function that runs with the actual frame rate.

In case of multiple physics steps in the same frame only the final result will be rendered. In case of no physics step in a frame the stats are not accurate. Either way updating a stats display on a physics step is suboptimal.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
