### PR TITLE
Fix crash in release build with llvm-mingw.

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -405,7 +405,7 @@ def configure_msvc(env: "SConsEnvironment"):
 
     if env["accesskit"]:
         if int(env["target_win_version"], 16) < 0x0602:
-            print_info("AcceeKit enabled, targeted Windows version changed to Windows 8 (0x602).")
+            print_info("AccessKit enabled, targeted Windows version changed to Windows 8 (0x602).")
             env["target_win_version"] = "0x0602"  # Accessibility API require Windows 8+
 
     env.AppendUnique(
@@ -771,7 +771,7 @@ def configure_mingw(env: "SConsEnvironment"):
 
     if env["accesskit"]:
         if int(env["target_win_version"], 16) < 0x0602:
-            print_info("AcceeKit enabled, targeted Windows version changed to Windows 8 (0x602).")
+            print_info("AccessKit enabled, targeted Windows version changed to Windows 8 (0x602).")
             env["target_win_version"] = "0x0602"  # Accessibility API require Windows 8+
 
     if not env["use_llvm"]:

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2790,7 +2790,7 @@ int DisplayServerWindows::accessibility_should_increase_contrast() const {
 }
 
 int DisplayServerWindows::accessibility_should_reduce_animation() const {
-	bool anim_enabled = false;
+	BOOL anim_enabled = false; // Note: this should be BOOL (WinAPI), not bool (C++), since SystemParametersInfoA expect variable with specific size.
 	if (!SystemParametersInfoA(SPI_GETCLIENTAREAANIMATION, 0, &anim_enabled, 0)) {
 		return -1;
 	}
@@ -2798,7 +2798,7 @@ int DisplayServerWindows::accessibility_should_reduce_animation() const {
 }
 
 int DisplayServerWindows::accessibility_should_reduce_transparency() const {
-	bool tr_enabled = false;
+	BOOL tr_enabled = false; // Note: this should be BOOL (WinAPI), not bool (C++), since SystemParametersInfoA expect variable with specific size.
 	if (!SystemParametersInfoA(SPI_GETDISABLEOVERLAPPEDCONTENT, 0, &tr_enabled, 0)) {
 		return -1;
 	}
@@ -2806,7 +2806,7 @@ int DisplayServerWindows::accessibility_should_reduce_transparency() const {
 }
 
 int DisplayServerWindows::accessibility_screen_reader_active() const {
-	bool sr_enabled = false;
+	BOOL sr_enabled = false; // Note: this should be BOOL (WinAPI), not bool (C++), since SystemParametersInfoA expect variable with specific size.
 	if (SystemParametersInfoA(SPI_GETSCREENREADER, 0, &sr_enabled, 0) && sr_enabled) {
 		return true;
 	}
@@ -7208,6 +7208,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 
 	windows[MAIN_WINDOW_ID].initialized = true;
 
+#ifdef ACCESSKIT_ENABLED
 	if (accessibility_screen_reader_active()) {
 		_THREAD_SAFE_LOCK_
 		uint64_t time_wait = OS::get_singleton()->get_ticks_msec();
@@ -7225,6 +7226,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 		}
 		_THREAD_SAFE_UNLOCK_
 	}
+#endif
 
 #if defined(RD_ENABLED)
 	if (rendering_context) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105423

Whatever clang is using as `bool` is not the same as `BOOL` and result in stack corruption. Also fixes typo in the `detect.py`.