### PR TITLE
Return netmask in `IP.get_local_interfaces()`

### DIFF
--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -275,6 +275,7 @@ TypedArray<Dictionary> IP::_get_local_interfaces() const {
 		rc["name"] = c.name;
 		rc["friendly"] = c.name_friendly;
 		rc["index"] = c.index;
+		rc["netmask"] = String(c.netmask);
 
 		Array ips;
 		for (const IPAddress &F : c.ip_addresses) {

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -80,6 +80,7 @@ public:
 		String name;
 		String name_friendly;
 		String index;
+		IPAddress netmask;
 		List<IPAddress> ip_addresses;
 	};
 

--- a/doc/classes/IP.xml
+++ b/doc/classes/IP.xml
@@ -40,6 +40,7 @@
 				    "name": "eth0", # Interface name.
 				    "friendly": "Ethernet One", # A friendly name (might be empty).
 				    "addresses": ["192.168.1.101"], # An array of IP addresses associated to this interface.
+				    "netmask": "255.255.255.0", # The network mask address.
 				}
 				[/codeblock]
 			</description>

--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -141,6 +141,7 @@ void IPUnix::get_local_interfaces(HashMap<String, Interface_Info> *r_interfaces)
 			info.name = ifa->ifa_name;
 			info.name_friendly = ifa->ifa_name;
 			info.index = String::num_uint64(if_nametoindex(ifa->ifa_name));
+			info.netmask = _sockaddr2ip(ifa->ifa_netmask);
 			E = r_interfaces->insert(ifa->ifa_name, info);
 			ERR_CONTINUE(!E);
 		}

--- a/drivers/windows/ip_windows.cpp
+++ b/drivers/windows/ip_windows.cpp
@@ -138,6 +138,11 @@ void IPWindows::get_local_interfaces(HashMap<String, Interface_Info> *r_interfac
 				continue;
 			}
 			info.ip_addresses.push_front(_sockaddr2ip(address->Address.lpSockaddr));
+			if (family == AF_INET) {
+				ULONG netmask_bytes = 0;
+				ConvertLengthToIpv4Mask(address->OnLinkPrefixLength, &netmask_bytes);
+				info.netmask.set_ipv4(reinterpret_cast<uint8_t *>(&netmask_bytes));
+			}
 			address = address->Next;
 		}
 		adapter = adapter->Next;


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot-proposals/issues/2274

Adds `netmask` field to return value of `get_local_interfaces()`.

I've skipped adding bcast/default gateway since only netmask was agreed upon, quoting the [proposal comment](https://github.com/godotengine/godot-proposals/issues/2274#issuecomment-894417273):

> Adding the subnet mask was approved during the networking meeting (to match with the OS function). Gateway detection would probably require a different IP function and proposal.

I've used @Calinou's code for *nix part and added mine for Windows version.

---

Tested with:

```gdscript
@tool
extends Node2D

func _ready() -> void:
	var addresses := IP.get_local_interfaces()
	for addr in addresses:
		print(addr)
```

returns:

```
{ "name": "{F319B332-5EEE-11EC-8BFC-806E6F6E6963}", "friendly": "Loopback Pseudo-Interface 1", "index": "1", "netmask": "255.0.0.0", "addresses": ["0:0:0:0:0:0:0:1", "127.0.0.1"] }
{ "name": "{54B980CF-9546-4F35-8828-EF742F91CEEA}", "friendly": "Ethernet 2", "index": "9", "netmask": "255.255.0.0", "addresses": ["fe80:0:0:0:1644:f89d:7967:568d", "169.254.87.138"] }
{ "name": "{A484D53F-267C-49A1-A2EF-A796735F70C3}", "friendly": "Połączenie lokalne* 2", "index": "15", "netmask": "255.255.0.0", "addresses": ["fe80:0:0:0:9b91:bb3d:7867:9fe4", "169.254.13.99"] }
{ "name": "{48CE3956-1123-40CB-853B-0587454FDAA2}", "friendly": "Połączenie lokalne* 1", "index": "7", "netmask": "255.255.0.0", "addresses": ["fe80:0:0:0:3e7b:8538:454b:d47", "169.254.69.65"] }
{ "name": "{B7F0BF29-484D-4BF3-BAD9-39CB87FA6FD0}", "friendly": "Wi-Fi", "index": "18", "netmask": "255.255.0.0", "addresses": ["fe80:0:0:0:a909:504f:6fc8:887c", "169.254.253.72"] }
{ "name": "{8121B98D-8F82-4136-A738-D3C2E7F58FB1}", "friendly": "Ethernet", "index": "13", "netmask": "255.255.255.0", "addresses": ["fe80:0:0:0:f15f:82b9:7aae:8f48", "10.0.0.23"] }
```