### PR TITLE
Allow moving meshes without motion vectors

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2046,6 +2046,13 @@
 				Sets whether an instance is drawn or not. Equivalent to [member Node3D.visible].
 			</description>
 		</method>
+		<method name="instance_teleport">
+			<return type="void" />
+			<param index="0" name="instance" type="RID" />
+			<description>
+				Resets motion vectors and other interpolated values. Use this [i]after[/i] teleporting a mesh from one position to another to avoid ghosting artifacts.
+			</description>
+		</method>
 		<method name="instances_cull_aabb" qualifiers="const">
 			<return type="PackedInt64Array" />
 			<param index="0" name="aabb" type="AABB" />

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -110,6 +110,7 @@ void VisualInstance3D::_notification(int p_what) {
 				if (!_is_using_identity_transform()) {
 					RenderingServer::get_singleton()->instance_set_transform(instance, get_global_transform());
 				}
+				RenderingServer::get_singleton()->instance_teleport(instance);
 
 				RenderingServer::get_singleton()->instance_reset_physics_interpolation(instance);
 			}

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -49,6 +49,7 @@ public:
 		virtual void set_surface_materials(const Vector<RID> &p_materials) override {}
 		virtual void set_mesh_instance(RID p_mesh_instance) override {}
 		virtual void set_transform(const Transform3D &p_transform, const AABB &p_aabb, const AABB &p_transformed_aabb) override {}
+		virtual void reset_motion_vectors() override {}
 		virtual void set_pivot_data(float p_sorting_offset, bool p_use_aabb_center) override {}
 		virtual void set_lod_bias(float p_lod_bias) override {}
 		virtual void set_layer_mask(uint32_t p_layer_mask) override {}

--- a/servers/rendering/renderer_geometry_instance.cpp
+++ b/servers/rendering/renderer_geometry_instance.cpp
@@ -134,6 +134,9 @@ void RenderGeometryInstanceBase::set_cast_double_sided_shadows(bool p_enable) {
 	_mark_dirty();
 }
 
+void RenderGeometryInstanceBase::reset_motion_vectors() {
+}
+
 Transform3D RenderGeometryInstanceBase::get_transform() {
 	return transform;
 }

--- a/servers/rendering/renderer_geometry_instance.h
+++ b/servers/rendering/renderer_geometry_instance.h
@@ -61,6 +61,8 @@ public:
 	virtual void set_instance_shader_uniforms_offset(int32_t p_offset) = 0;
 	virtual void set_cast_double_sided_shadows(bool p_enable) = 0;
 
+	virtual void reset_motion_vectors() = 0;
+
 	virtual Transform3D get_transform() = 0;
 	virtual AABB get_aabb() = 0;
 
@@ -144,6 +146,8 @@ public:
 	virtual void set_use_dynamic_gi(bool p_enable) override;
 	virtual void set_instance_shader_uniforms_offset(int32_t p_offset) override;
 	virtual void set_cast_double_sided_shadows(bool p_enable) override;
+
+	virtual void reset_motion_vectors() override;
 
 	virtual Transform3D get_transform() override;
 	virtual AABB get_aabb() override;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -544,7 +544,11 @@ private:
 
 		//used during setup
 		uint64_t prev_transform_change_frame = 0xFFFFFFFF;
-		bool prev_transform_dirty = true;
+		enum TransformStatus {
+			NONE,
+			MOVED,
+			TELEPORTED,
+		} transform_status = TransformStatus::MOVED;
 		Transform3D prev_transform;
 		RID voxel_gi_instances[MAX_VOXEL_GI_INSTANCESS_PER_INSTANCE];
 		GeometryInstanceSurfaceDataCache *surface_caches = nullptr;
@@ -556,6 +560,7 @@ private:
 		virtual void _mark_dirty() override;
 
 		virtual void set_transform(const Transform3D &p_transform, const AABB &p_aabb, const AABB &p_transformed_aabb) override;
+		virtual void reset_motion_vectors() override;
 		virtual void set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) override;
 		virtual void set_lightmap_capture(const Color *p_sh9) override;
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -412,6 +412,7 @@ public:
 		// This will either be the interpolated transform (when using fixed timestep interpolation)
 		// or the ONLY transform (when not using FTI).
 		Transform3D transform;
+		bool teleported = false;
 
 		// For interpolation we store the current transform (this physics tick)
 		// and the transform in the previous tick.
@@ -1053,6 +1054,8 @@ public:
 	virtual void instance_set_surface_override_material(RID p_instance, int p_surface, RID p_material);
 	virtual void instance_set_visible(RID p_instance, bool p_visible);
 	virtual void instance_geometry_set_transparency(RID p_instance, float p_transparency);
+
+	virtual void instance_teleport(RID p_instance);
 
 	virtual void instance_set_custom_aabb(RID p_instance, AABB p_aabb);
 

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -90,6 +90,8 @@ public:
 	virtual void instance_set_visible(RID p_instance, bool p_visible) = 0;
 	virtual void instance_geometry_set_transparency(RID p_instance, float p_transparency) = 0;
 
+	virtual void instance_teleport(RID p_instance) = 0;
+
 	virtual void instance_set_custom_aabb(RID p_instance, AABB p_aabb) = 0;
 
 	virtual void instance_attach_skeleton(RID p_instance, RID p_skeleton) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -887,6 +887,8 @@ public:
 	FUNC3(instance_set_surface_override_material, RID, int, RID)
 	FUNC2(instance_set_visible, RID, bool)
 
+	FUNC1(instance_teleport, RID)
+
 	FUNC2(instance_set_custom_aabb, RID, AABB)
 
 	FUNC2(instance_attach_skeleton, RID, RID)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3172,6 +3172,8 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("instance_set_visible", "instance", "visible"), &RenderingServer::instance_set_visible);
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_transparency", "instance", "transparency"), &RenderingServer::instance_geometry_set_transparency);
 
+	ClassDB::bind_method(D_METHOD("instance_teleport", "instance"), &RenderingServer::instance_teleport);
+
 	ClassDB::bind_method(D_METHOD("instance_set_custom_aabb", "instance", "aabb"), &RenderingServer::instance_set_custom_aabb);
 
 	ClassDB::bind_method(D_METHOD("instance_attach_skeleton", "instance", "skeleton"), &RenderingServer::instance_attach_skeleton);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1434,6 +1434,8 @@ public:
 	virtual void instance_set_surface_override_material(RID p_instance, int p_surface, RID p_material) = 0;
 	virtual void instance_set_visible(RID p_instance, bool p_visible) = 0;
 
+	virtual void instance_teleport(RID p_instance) = 0;
+
 	virtual void instance_set_custom_aabb(RID p_instance, AABB aabb) = 0;
 
 	virtual void instance_attach_skeleton(RID p_instance, RID p_skeleton) = 0;


### PR DESCRIPTION
This PR makes it possible to translate meshes without writing their movement to the movement buffer.

Right now, this PR integrates with the physics_interpolation feature to handle the propagation of "teleports" through the scene. To teleport something, the user simply has to update the transform and then call `reset_physics_interpolation`.

Alternatively the user can use the optional "teleport" parameter when calling manually calling the RenderingServer's bound transform method.

<details>
<summary>Video Example</summary>

https://github.com/user-attachments/assets/524b334b-c0e2-4a33-83e5-deaf6180d807
</details>


- Supersedes #77523
- Fixes https://github.com/TokisanGames/Terrain3D/issues/302