### PR TITLE
Fix Sublime text external editor Exec Flags setting

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1168,7 +1168,7 @@ String EditorSettings::_guess_exec_args_for_extenal_editor(const String &p_path)
 	if (editor.begins_with("rider")) {
 		new_exec_flags = "{project} --line {line} {file}";
 	} else if (editor == "subl" || editor == "sublime text" || editor == "sublime_text") {
-		new_exec_flags = "{project} {file}:{line}:{column}";
+		new_exec_flags = "{project} {file}:{line}:{col}";
 	} else if (editor == "vim" || editor == "gvim") {
 		new_exec_flags = "\"+call cursor({line}, {col})\" {file}";
 	} else if (editor == "emacs") {


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/98846.
- Companion PR to https://github.com/godotengine/godot-docs/pull/10869.

The placeholder must be `{col}`, not `{column}`.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/31#discussioncomment-12819013.
