### PR TITLE
Rename GraphEdit connection getter methods

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -208,7 +208,7 @@
 				Returns the points which would make up a connection between [param from_node] and [param to_node].
 			</description>
 		</method>
-		<method name="get_connection_list_from_node" qualifiers="const">
+		<method name="get_connections_by_node" qualifiers="const">
 			<return type="Dictionary[]" />
 			<param index="0" name="node" type="StringName" />
 			<description>
@@ -328,7 +328,7 @@
 		<member name="connection_lines_thickness" type="float" setter="set_connection_lines_thickness" getter="get_connection_lines_thickness" default="4.0">
 			The thickness of the lines between the nodes.
 		</member>
-		<member name="connections" type="Dictionary[]" setter="set_connections" getter="get_connection_list" default="[]">
+		<member name="connections" type="Dictionary[]" setter="set_connections" getter="get_connections" default="[]">
 			The connections between [GraphNode]s.
 			A connection is represented as a [Dictionary] in the form of:
 			[codeblock]

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -82,3 +82,9 @@ Validate extension JSON: Error: Field 'classes/TextServerExtension/methods/_shap
 Validate extension JSON: Error: Field 'classes/TextServerExtension/methods/_shaped_text_draw_outline/arguments': size changed value in new API, from 7 to 8.
 
 Optional "oversmpling" argument added. Compatibility methods registered.
+
+GH-105443
+---------
+Validate extension JSON: Error: Field 'classes/GraphEdit/properties/connections': getter changed value in new API, from "get_connection_list" to &"get_connections".
+
+Renamed getter. Compatibility methods registered.

--- a/scene/gui/graph_edit.compat.inc
+++ b/scene/gui/graph_edit.compat.inc
@@ -51,6 +51,8 @@ void GraphEdit::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("set_arrange_nodes_button_hidden", "enable"), &GraphEdit::_set_arrange_nodes_button_hidden_bind_compat_81582);
 	ClassDB::bind_compatibility_method(D_METHOD("get_connection_line", "from_node", "to_node"), &GraphEdit::_get_connection_line_bind_compat_86158);
 	ClassDB::bind_compatibility_method(D_METHOD("connect_node", "from_node", "from_port", "to_node", "to_port"), &GraphEdit::_connect_node_bind_compat_97449);
+	ClassDB::bind_compatibility_method(D_METHOD("get_connection_list"), &GraphEdit::_get_connections);
+	ClassDB::bind_compatibility_method(D_METHOD("get_connection_list_from_node", "node"), &GraphEdit::_get_connections_by_node);
 }
 
 #endif

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2508,7 +2508,7 @@ void GraphEdit::set_connections(const TypedArray<Dictionary> &p_connections) {
 	}
 }
 
-TypedArray<Dictionary> GraphEdit::_get_connection_list() const {
+TypedArray<Dictionary> GraphEdit::_get_connections() const {
 	Vector<Ref<Connection>> conns = get_connections();
 
 	TypedArray<Dictionary> arr;
@@ -2553,7 +2553,7 @@ TypedArray<Dictionary> GraphEdit::_get_connections_intersecting_with_rect(const 
 	return arr;
 }
 
-TypedArray<Dictionary> GraphEdit::_get_connection_list_from_node(const StringName &p_node) const {
+TypedArray<Dictionary> GraphEdit::_get_connections_by_node(const StringName &p_node) const {
 	ERR_FAIL_COND_V(!connection_map.has(p_node), TypedArray<Dictionary>());
 
 	List<Ref<GraphEdit::Connection>> connections_from_node = connection_map.get(p_node);
@@ -2928,10 +2928,10 @@ void GraphEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("disconnect_node", "from_node", "from_port", "to_node", "to_port"), &GraphEdit::disconnect_node);
 	ClassDB::bind_method(D_METHOD("set_connection_activity", "from_node", "from_port", "to_node", "to_port", "amount"), &GraphEdit::set_connection_activity);
 	ClassDB::bind_method(D_METHOD("set_connections", "connections"), &GraphEdit::set_connections);
-	ClassDB::bind_method(D_METHOD("get_connection_list"), &GraphEdit::_get_connection_list);
+	ClassDB::bind_method(D_METHOD("get_connections"), &GraphEdit::_get_connections);
 	ClassDB::bind_method(D_METHOD("get_connection_count", "from_node", "from_port"), &GraphEdit::get_connection_count);
 	ClassDB::bind_method(D_METHOD("get_closest_connection_at_point", "point", "max_distance"), &GraphEdit::_get_closest_connection_at_point, DEFVAL(4.0));
-	ClassDB::bind_method(D_METHOD("get_connection_list_from_node", "node"), &GraphEdit::_get_connection_list_from_node);
+	ClassDB::bind_method(D_METHOD("get_connections_by_node", "node"), &GraphEdit::_get_connections_by_node);
 	ClassDB::bind_method(D_METHOD("get_connections_intersecting_with_rect", "rect"), &GraphEdit::_get_connections_intersecting_with_rect);
 	ClassDB::bind_method(D_METHOD("clear_connections"), &GraphEdit::clear_connections);
 	ClassDB::bind_method(D_METHOD("force_connection_drag_end"), &GraphEdit::force_connection_drag_end);
@@ -3046,7 +3046,7 @@ void GraphEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "connection_lines_curvature"), "set_connection_lines_curvature", "get_connection_lines_curvature");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "connection_lines_thickness", PROPERTY_HINT_RANGE, "0,100,0.1,suffix:px"), "set_connection_lines_thickness", "get_connection_lines_thickness");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "connection_lines_antialiased"), "set_connection_lines_antialiased", "is_connection_lines_antialiased");
-	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "connections", PROPERTY_HINT_ARRAY_TYPE, vformat("%s/%s:%s", Variant::DICTIONARY, PROPERTY_HINT_NONE, String())), "set_connections", "get_connection_list");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "connections", PROPERTY_HINT_ARRAY_TYPE, vformat("%s/%s:%s", Variant::DICTIONARY, PROPERTY_HINT_NONE, String())), "set_connections", "get_connections");
 
 	ADD_GROUP("Zoom", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "zoom"), "set_zoom", "get_zoom");

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -346,10 +346,10 @@ private:
 	bool is_in_port_hotzone(const Vector2 &p_pos, const Vector2 &p_mouse_pos, const Vector2i &p_port_size, bool p_left);
 
 	void set_connections(const TypedArray<Dictionary> &p_connections);
-	TypedArray<Dictionary> _get_connection_list() const;
+	TypedArray<Dictionary> _get_connections() const;
 	Dictionary _get_closest_connection_at_point(const Vector2 &p_point, float p_max_distance = 4.0) const;
 	TypedArray<Dictionary> _get_connections_intersecting_with_rect(const Rect2 &p_rect) const;
-	TypedArray<Dictionary> _get_connection_list_from_node(const StringName &p_node) const;
+	TypedArray<Dictionary> _get_connections_by_node(const StringName &p_node) const;
 
 	Rect2 _compute_shrinked_frame_rect(const GraphFrame *p_frame);
 	void _set_drag_frame_attached_nodes(GraphFrame *p_frame, bool p_drag);


### PR DESCRIPTION
The new method `_get_connection_list_from_node` is named with the keyword `from`. `GraphEdit` already uses the keyword `from` to distinguish whether a connection is `from` or `to` a node or port, so this keyword incorrectly implies that the method returns a list of all connections `from` a given node (instead of returning all connections on the node, regardless of direction).

Additionally, `_get_connection_list` and `_get_connection_list_from_node` refer to the list of connections as `connection_list`, which is inconsistent with other methods such as `_get_connections_intersecting_with_rect`, `set_connections`, `clear_connections`, and `get_connections_description` that simply use `connections`.

This change resolves both linguistic issues by renaming `_get_connection_list` to `_get_connections` and `_get_connection_list_from_node` to `_get_connections_by_node`.

Renaming `_get_connection_list` breaks compatibility with Godot 4.4