### PR TITLE
OpenXR: Request the `XR_KHR_loader_init` extension

### DIFF
--- a/modules/openxr/extensions/platform/openxr_android_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_android_extension.cpp
@@ -58,7 +58,9 @@ OpenXRAndroidExtension::OpenXRAndroidExtension() {
 HashMap<String, bool *> OpenXRAndroidExtension::get_requested_extensions() {
 	HashMap<String, bool *> request_extensions;
 
-	request_extensions[XR_KHR_LOADER_INIT_ANDROID_EXTENSION_NAME] = &loader_init_extension_available;
+	// XR_KHR_LOADER_INIT_EXTENSION_NAME is a dependency of XR_KHR_LOADER_INIT_ANDROID_EXTENSION_NAME
+	request_extensions[XR_KHR_LOADER_INIT_EXTENSION_NAME] = &loader_init_extension_available;
+	request_extensions[XR_KHR_LOADER_INIT_ANDROID_EXTENSION_NAME] = &loader_init_android_extension_available;
 	request_extensions[XR_KHR_ANDROID_CREATE_INSTANCE_EXTENSION_NAME] = &create_instance_extension_available;
 
 	return request_extensions;
@@ -69,7 +71,7 @@ void OpenXRAndroidExtension::on_before_instance_created() {
 		// XR_KHR_loader_init not supported on this platform
 		return;
 	}
-	loader_init_extension_available = true;
+	loader_init_android_extension_available = true;
 
 	XrLoaderInitInfoAndroidKHR loader_init_info_android = {
 		.type = XR_TYPE_LOADER_INIT_INFO_ANDROID_KHR,
@@ -87,7 +89,7 @@ static XrInstanceCreateInfoAndroidKHR instance_create_info;
 
 void *OpenXRAndroidExtension::set_instance_create_info_and_get_next_pointer(void *p_next_pointer) {
 	if (!create_instance_extension_available) {
-		if (!loader_init_extension_available) {
+		if (!loader_init_android_extension_available) {
 			WARN_PRINT("No Android extensions available, couldn't pass JVM and Activity to OpenXR");
 		}
 		return nullptr;

--- a/modules/openxr/extensions/platform/openxr_android_extension.h
+++ b/modules/openxr/extensions/platform/openxr_android_extension.h
@@ -53,6 +53,7 @@ private:
 	JavaVM *vm;
 	jobject activity_object;
 	bool loader_init_extension_available = false;
+	bool loader_init_android_extension_available = false;
 	bool create_instance_extension_available = false;
 
 	// Initialize the loader


### PR DESCRIPTION
The [XR_KHR_loader_init_android](https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_KHR_loader_init_android) extension that we use, depends on the `XR_KHR_loader_init` extension which we weren't previously enabling. While most OpenXR runtimes don't seem to care, this is technically incorrect per the spec:

![Selection_319](https://github.com/user-attachments/assets/47c6e996-93bb-4829-9c42-fb01bbfffc04)

This PR enables the `XR_KHR_loader_init` extension as we should to correctly conform to the OpenXR spec.