### PR TITLE
Make `MissingNode`/`MissingResource` non-virtual and hide from dialogs

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -176,7 +176,7 @@ void register_core_types() {
 	GDREGISTER_VIRTUAL_CLASS(ScriptExtension);
 	GDREGISTER_VIRTUAL_CLASS(ScriptLanguageExtension);
 
-	GDREGISTER_VIRTUAL_CLASS(MissingResource);
+	GDREGISTER_CLASS(MissingResource);
 	GDREGISTER_CLASS(Image);
 
 	GDREGISTER_CLASS(Shortcut);

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -856,6 +856,8 @@ CreateDialog::CreateDialog() {
 
 	type_blacklist.insert("PluginScript"); // PluginScript must be initialized before use, which is not possible here.
 	type_blacklist.insert("ScriptCreateDialog"); // This is an exposed editor Node that doesn't have an Editor prefix.
+	type_blacklist.insert("MissingNode");
+	type_blacklist.insert("MissingResource");
 
 	HSplitContainer *hsc = memnew(HSplitContainer);
 	add_child(hsc);

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -653,6 +653,18 @@ String EditorResourcePicker::_get_resource_type(const Ref<Resource> &p_resource)
 	return res_type;
 }
 
+static bool _should_hide_type(const StringName &p_type) {
+	if (ClassDB::is_virtual(p_type)) {
+		return true;
+	}
+
+	if (p_type == SNAME("MissingResource")) {
+		return true;
+	}
+
+	return false;
+}
+
 static void _add_allowed_type(const StringName &p_type, List<StringName> *p_vector) {
 	if (p_vector->find(p_type)) {
 		// Already added.
@@ -660,9 +672,9 @@ static void _add_allowed_type(const StringName &p_type, List<StringName> *p_vect
 	}
 
 	if (ClassDB::class_exists(p_type)) {
-		// Engine class,
+		// Engine class.
 
-		if (!ClassDB::is_virtual(p_type)) {
+		if (!_should_hide_type(p_type)) {
 			p_vector->push_back(p_type);
 		}
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -411,7 +411,7 @@ void register_scene_types() {
 	OS::get_singleton()->yield(); // may take time to init
 
 	GDREGISTER_CLASS(Node);
-	GDREGISTER_VIRTUAL_CLASS(MissingNode);
+	GDREGISTER_CLASS(MissingNode);
 	GDREGISTER_ABSTRACT_CLASS(InstancePlaceholder);
 
 	GDREGISTER_ABSTRACT_CLASS(CanvasItem);


### PR DESCRIPTION
It looks like `ClassDB::class_get_default_property_value` only works for properties defined in the specified class. When implementing the upgrading tool for C# we replace Nodes and Resources with `MissingNode` and `MissingResource`, and saving them adds a lot of unwanted noise.

This PR tries to avoid that noise by looking at their base type `Node` and `Resource` instead but it's more like a hack than a proper solution. Alternatively, we could modify `ClassDB::class_get_default_property_value` to iterate the class hierarchy instead, but I don't know what consequences a change like that could have throughout the engine.
