### PR TITLE
Add thread safety to Object signals

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -608,7 +608,8 @@ private:
 		HashMap<Callable, Slot, HashableHasher<Callable>> slot_map;
 		bool removable = false;
 	};
-
+	friend struct _ObjectSignalLock;
+	mutable Mutex *signal_mutex = nullptr;
 	HashMap<StringName, SignalData> signal_map;
 	List<Connection> connections;
 #ifdef DEBUG_ENABLED
@@ -755,6 +756,8 @@ protected:
 	static void _get_property_list_from_classdb(const StringName &p_class, List<PropertyInfo> *p_list, bool p_no_inheritance, const Object *p_validator);
 
 	bool _disconnect(const StringName &p_signal, const Callable &p_callable, bool p_force = false);
+
+	virtual bool _uses_signal_mutex() const;
 
 #ifdef TOOLS_ENABLED
 	struct VirtualMethodTracker {

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -521,6 +521,7 @@
 				A signal can only be connected once to the same [Callable]. If the signal is already connected, this method returns [constant ERR_INVALID_PARAMETER] and generates an error, unless the signal is connected with [constant CONNECT_REFERENCE_COUNTED]. To prevent this, use [method is_connected] first to check for existing connections.
 				[b]Note:[/b] If the [param callable]'s object is freed, the connection will be lost.
 				[b]Note:[/b] In GDScript, it is generally recommended to connect signals with [method Signal.connect] instead.
+				[b]Note:[/b] This operation (and all other signal related operations) is thread-safe.
 			</description>
 		</method>
 		<method name="disconnect">

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -387,6 +387,8 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 
 protected:
+	virtual bool _uses_signal_mutex() const override { return false; } // Node uses thread guards instead.
+
 	virtual void input(const Ref<InputEvent> &p_event);
 	virtual void shortcut_input(const Ref<InputEvent> &p_key_event);
 	virtual void unhandled_input(const Ref<InputEvent> &p_event);


### PR DESCRIPTION
* It turns out the majority of this work was done already by AThousandShips as part of #89451. This allows to do lock-less emitting of signals.
* This means, that only the signal map needs to be protected, making the task simple and without risk of deadlocks, or affecting performance.
* Objects can choose to not protect signals for performance (as example Node uses thread guards for protection instead, so these signals are not thread safe).
* Keep in mind Node uses its own thread guards, and will not be using this mutex, so it will not affect performance of scene code (The majority of the signal users).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
