### PR TITLE
[Web] Clean-up service worker and add `?no-cache`

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -382,6 +382,11 @@ window.addEventListener('load', () => {
 					});
 				});
 			});
+			navigator.serviceWorker.ready.then((registration) => {
+				window.addEventListener('pagehide', () => {
+					registration.active.postMessage('pagehide');
+				});
+			});
 		} catch (e) {
 			console.error('Error while registering service worker:', e);
 		}

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -164,7 +164,7 @@ const engine = new Engine(GODOT_CONFIG);
 		threads: GODOT_THREADS_ENABLED,
 	});
 
-	if (missing.length !== 0) {
+	if (missing.length > 0) {
 		if (GODOT_CONFIG['serviceWorker'] && GODOT_CONFIG['ensureCrossOriginIsolationHeaders'] && 'serviceWorker' in navigator) {
 			let serviceWorkerRegistrationPromise;
 			try {
@@ -210,6 +210,14 @@ const engine = new Engine(GODOT_CONFIG);
 		}).then(() => {
 			setStatusMode('hidden');
 		}, displayFailureNotice);
+
+		if (GODOT_CONFIG['serviceWorker'] && 'serviceWorker' in navigator) {
+			navigator.serviceWorker.ready.then((registration) => {
+				window.addEventListener('pagehide', () => {
+					registration.active.postMessage('pagehide');
+				});
+			});
+		}
 	}
 }());
 		</script>


### PR DESCRIPTION
## Service worker cleanup
As it says, it's a global cleanup of the service worker in order to remove nested promises `.then()` and `.catch()` to use the (easier to read) `async`/`await` syntax. It was quite due.

## `?no-cache`
This introduces a way for developers to disable temporarily the use of cache from a service worker. Really nice when trying to debug something and you want to make sure that the service worker doesn't serve cache.

Simply add the `no-cache` search parameter in the URL of the navigated page (usually the one displayed in the browser address bar). It will ignore cache for every downloaded file of the session (until a reload or a page close, [see `pagehide`](https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event)).

Though, if you use `no-cache=no` (or any negative), it will ignore `no-cache`.

_Edit: As @roughbits01 suggested in the [Godot Developers Chat](https://chat.godotengine.org/channel/web?msg=PtWYvQkquBJjahPg2), it will REALLY help on mobile devices, as they don't have the tools enabled to properly remove a service worker without using a connected computer to debug._ 