### PR TITLE
[3.x] FTI - Fix 3D auto-resets

### DIFF
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -191,7 +191,15 @@ void Spatial::_notification(int p_what) {
 
 				// Make sure servers are up to date.
 				fti_update_servers_xform();
+
+				// As well as a reset based on the transform when adding, the user may change
+				// the transform during the first tick / frame, and we want to reset automatically
+				// at the end of the frame / tick (unless the user manually called `reset_physics_interpolation()`).
+				if (is_physics_interpolated()) {
+					get_tree()->get_scene_tree_fti().spatial_request_reset(this);
+				}
 			}
+
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			if (is_inside_tree()) {

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -103,24 +103,10 @@ void VisualInstance::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			if (_is_vi_visible()) {
-				if (!_is_using_identity_transform()) {
-					// Physics interpolation cases.
-					if (is_inside_tree() && get_tree()->is_physics_interpolation_enabled()) {
-						// Physics interpolated VIs don't need to send their transform immediately after setting,
-						// indeed it is counterproductive, because the interpolated transform will be sent
-						// to the VisualServer immediately prior to rendering.
-						if (is_physics_interpolated() && _is_physics_interpolation_reset_requested()) {
-							// For instance when first adding to the tree, when the previous transform is
-							// unset, to prevent streaking from the origin.
-							_notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
-							_set_physics_interpolation_reset_requested(false);
-						}
-					} else {
-						// Physics interpolation global off, always send.
-						VisualServer::get_singleton()->instance_set_transform(instance, get_global_transform());
-					}
-				}
+			// ToDo : Can we turn off notify transform for physics interpolated cases?
+			if (_is_vi_visible() && !(is_inside_tree() && get_tree()->is_physics_interpolation_enabled()) && !_is_using_identity_transform()) {
+				// Physics interpolation global off, always send.
+				VisualServer::get_singleton()->instance_set_transform(instance, get_global_transform());
 			}
 		} break;
 		case NOTIFICATION_EXIT_WORLD: {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -101,12 +101,6 @@ void Node::_notification(int p_notification) {
 			get_tree()->node_count++;
 			orphan_node_count--;
 
-			// Allow physics interpolated nodes to automatically reset when added to the tree
-			// (this is to save the user doing this manually each time).
-			if (get_tree()->is_physics_interpolation_enabled()) {
-				_set_physics_interpolation_reset_requested(true);
-			}
-
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			ERR_FAIL_COND(!get_viewport());

--- a/scene/main/scene_tree_fti.h
+++ b/scene/main/scene_tree_fti.h
@@ -48,6 +48,7 @@ public:
 	bool is_enabled() const { return false; }
 
 	void spatial_notify_changed(Spatial &r_spatial, bool p_transform_changed) {}
+	void spatial_request_reset(Spatial *p_spatial) {}
 	void spatial_notify_delete(Spatial *p_spatial) {}
 };
 #else
@@ -73,6 +74,8 @@ class SceneTreeFTI {
 
 		LocalVector<Spatial *> frame_property_list;
 
+		LocalVector<Spatial *> request_reset_list;
+
 		uint32_t mirror = 0;
 
 		bool enabled = false;
@@ -87,6 +90,8 @@ class SceneTreeFTI {
 	} data;
 
 	void _update_dirty_spatials(Node *p_node, uint32_t p_current_frame, float p_interpolation_fraction, bool p_active, const Transform *p_parent_global_xform = nullptr, int p_depth = 0);
+	void _update_request_resets();
+
 	void _reset_flags(Node *p_node);
 	void _spatial_notify_set_xform(Spatial &r_spatial);
 	void _spatial_notify_set_property(Spatial &r_spatial);
@@ -104,6 +109,7 @@ public:
 		}
 	}
 
+	void spatial_request_reset(Spatial *p_spatial);
 	void spatial_notify_delete(Spatial *p_spatial);
 
 	// Calculate interpolated xforms, send to visual server.


### PR DESCRIPTION
* Ensure `NOTIFICATION_RESET_PHYSICS_INTERPOLATION` is sent to derived classes
* Add deferred auto-resets for all `Spatials` on entering the tree

## Notes
* @Calinou noticed in #104269 that some of the auto-resets weren't working correctly (for the bullets)
* These weren't working because the root nodes of the bullet scene was a `KinematicBody` / `CharacterBody3D` which isn't derived from `VisualInstance`
* After some testing I discovered a number of auto-reset situations weren't working correctly for `SceneTreeFTI` so took the opportunity to rewrite them to work more sensibly with the new system.
* Now `Spatials` entering the scene tree add themselves to a list in the `SceneTreeFTI`, and all items on that list are reset prior to the tick and frame update. This ensures that all `Spatials` (not just `VisualInstances`) are reset, and only reset once on their first tick / frame on entering the tree.
* The exception is `Spatials` that have `reset_physics_interpolation()` called on them manually during the first tick / frame. This allows users to _prime_ instances for moving starts, when desired.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
