### PR TITLE
Increase chunk limit for known problematic `RID_Owners`.

### DIFF
--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -60,7 +60,7 @@ class GodotPhysicsServer2D : public PhysicsServer2D {
 	mutable RID_PtrOwner<GodotShape2D, true> shape_owner;
 	mutable RID_PtrOwner<GodotSpace2D, true> space_owner;
 	mutable RID_PtrOwner<GodotArea2D, true> area_owner;
-	mutable RID_PtrOwner<GodotBody2D, true> body_owner;
+	mutable RID_PtrOwner<GodotBody2D, true> body_owner{ 65536, 1048576 };
 	mutable RID_PtrOwner<GodotJoint2D, true> joint_owner;
 
 	static GodotPhysicsServer2D *godot_singleton;

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -58,7 +58,7 @@ class GodotPhysicsServer3D : public PhysicsServer3D {
 	mutable RID_PtrOwner<GodotShape3D, true> shape_owner;
 	mutable RID_PtrOwner<GodotSpace3D, true> space_owner;
 	mutable RID_PtrOwner<GodotArea3D, true> area_owner;
-	mutable RID_PtrOwner<GodotBody3D, true> body_owner;
+	mutable RID_PtrOwner<GodotBody3D, true> body_owner{ 65536, 1048576 };
 	mutable RID_PtrOwner<GodotSoftBody3D, true> soft_body_owner;
 	mutable RID_PtrOwner<GodotJoint3D, true> joint_owner;
 

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -48,7 +48,7 @@ class JoltPhysicsServer3D final : public PhysicsServer3D {
 
 	mutable RID_PtrOwner<JoltSpace3D, true> space_owner;
 	mutable RID_PtrOwner<JoltArea3D, true> area_owner;
-	mutable RID_PtrOwner<JoltBody3D, true> body_owner;
+	mutable RID_PtrOwner<JoltBody3D, true> body_owner{ 65536, 1048576 };
 	mutable RID_PtrOwner<JoltSoftBody3D, true> soft_body_owner;
 	mutable RID_PtrOwner<JoltShape3D, true> shape_owner;
 	mutable RID_PtrOwner<JoltJoint3D, true> joint_owner;

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -184,7 +184,7 @@ public:
 	};
 
 	mutable RID_Owner<Canvas, true> canvas_owner;
-	RID_Owner<Item, true> canvas_item_owner;
+	RID_Owner<Item, true> canvas_item_owner{ 65536, 4194304 };
 	RID_Owner<RendererCanvasRender::Light, true> canvas_light_owner;
 
 	template <typename T>

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1031,7 +1031,7 @@ public:
 
 	uint32_t thread_cull_threshold = 200;
 
-	mutable RID_Owner<Instance, true> instance_owner;
+	mutable RID_Owner<Instance, true> instance_owner{ 65536, 4194304 };
 
 	uint32_t geometry_instance_pair_mask = 0; // used in traditional forward, unnecessary on clustered
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/104176
Fixes: https://github.com/godotengine/godot/issues/103420
Fixes: https://github.com/godotengine/godot/issues/99162
Fixes: https://github.com/godotengine/godot/issues/103650
Also reported here: https://www.reddit.com/r/godot/comments/1k0sz07/godot_crashes_after_262k_objects/

Supersedes: https://github.com/godotengine/godot/pull/99307

Currently all RID_Owners have a limit of 2^18 allocations ever since https://github.com/godotengine/godot/pull/97465. This was chosen as a reasonably high limit, but the actual limit is configurable per RID_Owner in case some need to be higher. 

In order to make thread safe RID owners lock-free for fetching, we needed to have a fixed chunk list. Therefore, we need to pick a limit at init time and stick with it. The actual chunks can be allocated dynamically (chunks are 65536 bytes by default, but this size can also be configured).

I think it is clear that the default is too small for some of these common types. For CanvasItems it is easy to hit the limit because tilemaps allocate a canvasitem per tile. I think us maintainers are all a little surprised that people are hitting these limits as having so many instances seems like it would be too much for the engine to handle. The good news is that apparently the engine is way more capable than we give it credit for. 

### Possible solutions

We have 3 possible solutions:
1. Increase the element limit to a new fixed limit (what this PR does)
2. Allow increasing the element limit (what https://github.com/godotengine/godot/pull/99307 does)
3. Remove the limit entirely by using non-thread safe RID Owners

My preference is to start with this PR (for 4.4 and 4.5) and then investigate option 3 for 4.5. As Randomshaper pointed out https://github.com/godotengine/godot/pull/99307#issuecomment-2482153851 #99307 is not granular enough, it increases the default for all RID_Owners which wastes a lot of memory. However, the alternative, to have one setting per RID_Owner would be too granular and would be both confusing and difficult to manage for users. 

Further, I suspect that CanvasItem and Instance can both use non-thread safe RID_Owners which would remove the limit entirely. 

However, **this issue needs to be fixed for 4.4** and I am not confident enough to switch to non-thread safe versions. So lets go ahead with this PR for now to unblock users, then evaluate a more drastic solution for later dev releases.

### Implementation details

As mentioned, increasing the element cap uses more memory. Thankfully RIDs are allocated in chunks, so we don't need to reserve space for all possible RIDs. However, we do need to allocate some minimal data for chunk tracking.

This PR increases the baseline memory usage for each RID owner as follows:
canvas_item_owner: 20 kb -> 328 kb
Instance_owner: 20kb -> 384 kb
body_owner: 0.125 kb -> 2 kb each

The rationale for only increasing the limit for body_owners to 2^20 instead of 2^22 was simply because it is unlikely for every single node in the game to have a corresponding physics body. Physics heavy games can have a lot (which is why we need to increase the limit), but the basic types will always have more. 

To be clear, these are still arbitrary thresholds. The values were chosen to not increase RAM usage by a noticeable amount while still fixing all the MRPs from the reported issues. We can further fine tune the exact limits as we get more reports. 
