### PR TITLE
PackedByteArray: Direct big-endian encoding/decoding

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -872,11 +872,23 @@ struct _VariantCall {
 		const uint8_t *r = p_instance->ptr();
 		return decode_uint16(&r[p_offset]);
 	}
+	static int64_t func_PackedByteArray_decode_u16_be(PackedByteArray *p_instance, int64_t p_offset) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 2), 0);
+		const uint8_t *r = p_instance->ptr();
+		return decode_uint16_be(&r[p_offset]);
+	}
 	static int64_t func_PackedByteArray_decode_s16(PackedByteArray *p_instance, int64_t p_offset) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 2), 0);
 		const uint8_t *r = p_instance->ptr();
 		return (int16_t)decode_uint16(&r[p_offset]);
+	}
+	static int64_t func_PackedByteArray_decode_s16_be(PackedByteArray *p_instance, int64_t p_offset) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 2), 0);
+		const uint8_t *r = p_instance->ptr();
+		return (int16_t)decode_uint16_be(&r[p_offset]);
 	}
 	static int64_t func_PackedByteArray_decode_u32(PackedByteArray *p_instance, int64_t p_offset) {
 		uint64_t size = p_instance->size();
@@ -884,11 +896,23 @@ struct _VariantCall {
 		const uint8_t *r = p_instance->ptr();
 		return decode_uint32(&r[p_offset]);
 	}
+	static int64_t func_PackedByteArray_decode_u32_be(PackedByteArray *p_instance, int64_t p_offset) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 4), 0);
+		const uint8_t *r = p_instance->ptr();
+		return decode_uint32_be(&r[p_offset]);
+	}
 	static int64_t func_PackedByteArray_decode_s32(PackedByteArray *p_instance, int64_t p_offset) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 4), 0);
 		const uint8_t *r = p_instance->ptr();
 		return (int32_t)decode_uint32(&r[p_offset]);
+	}
+	static int64_t func_PackedByteArray_decode_s32_be(PackedByteArray *p_instance, int64_t p_offset) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 4), 0);
+		const uint8_t *r = p_instance->ptr();
+		return (int32_t)decode_uint32_be(&r[p_offset]);
 	}
 	static int64_t func_PackedByteArray_decode_u64(PackedByteArray *p_instance, int64_t p_offset) {
 		uint64_t size = p_instance->size();
@@ -896,17 +920,35 @@ struct _VariantCall {
 		const uint8_t *r = p_instance->ptr();
 		return (int64_t)decode_uint64(&r[p_offset]);
 	}
+	static int64_t func_PackedByteArray_decode_u64_be(PackedByteArray *p_instance, int64_t p_offset) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 8), 0);
+		const uint8_t *r = p_instance->ptr();
+		return (int64_t)decode_uint64_be(&r[p_offset]);
+	}
 	static int64_t func_PackedByteArray_decode_s64(PackedByteArray *p_instance, int64_t p_offset) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 8), 0);
 		const uint8_t *r = p_instance->ptr();
 		return (int64_t)decode_uint64(&r[p_offset]);
 	}
+	static int64_t func_PackedByteArray_decode_s64_be(PackedByteArray *p_instance, int64_t p_offset) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 8), 0);
+		const uint8_t *r = p_instance->ptr();
+		return (int64_t)decode_uint64_be(&r[p_offset]);
+	}
 	static double func_PackedByteArray_decode_half(PackedByteArray *p_instance, int64_t p_offset) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 2), 0);
 		const uint8_t *r = p_instance->ptr();
 		return Math::half_to_float(decode_uint16(&r[p_offset]));
+	}
+	static double func_PackedByteArray_decode_half_be(PackedByteArray *p_instance, int64_t p_offset) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 2), 0);
+		const uint8_t *r = p_instance->ptr();
+		return Math::half_to_float(decode_uint16_be(&r[p_offset]));
 	}
 	static double func_PackedByteArray_decode_float(PackedByteArray *p_instance, int64_t p_offset) {
 		uint64_t size = p_instance->size();
@@ -915,11 +957,23 @@ struct _VariantCall {
 		return decode_float(&r[p_offset]);
 	}
 
+	static double func_PackedByteArray_decode_float_be(PackedByteArray *p_instance, int64_t p_offset) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 4), 0);
+		const uint8_t *r = p_instance->ptr();
+		return decode_float_be(&r[p_offset]);
+	}
 	static double func_PackedByteArray_decode_double(PackedByteArray *p_instance, int64_t p_offset) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 8), 0);
 		const uint8_t *r = p_instance->ptr();
 		return decode_double(&r[p_offset]);
+	}
+	static double func_PackedByteArray_decode_double_be(PackedByteArray *p_instance, int64_t p_offset) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND_V(p_offset < 0 || p_offset > (int64_t(size) - 8), 0);
+		const uint8_t *r = p_instance->ptr();
+		return decode_double_be(&r[p_offset]);
 	}
 
 	static bool func_PackedByteArray_has_encoded_var(PackedByteArray *p_instance, int64_t p_offset, bool p_allow_objects) {
@@ -1031,6 +1085,12 @@ struct _VariantCall {
 		uint8_t *w = p_instance->ptrw();
 		encode_uint16((uint16_t)p_value, &w[p_offset]);
 	}
+	static void func_PackedByteArray_encode_u16_be(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 2);
+		uint8_t *w = p_instance->ptrw();
+		encode_uint16_be((uint16_t)p_value, &w[p_offset]);
+	}
 	static void func_PackedByteArray_encode_s16(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 2);
@@ -1038,11 +1098,23 @@ struct _VariantCall {
 		encode_uint16((int16_t)p_value, &w[p_offset]);
 	}
 
+	static void func_PackedByteArray_encode_s16_be(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 2);
+		uint8_t *w = p_instance->ptrw();
+		encode_uint16_be((int16_t)p_value, &w[p_offset]);
+	}
 	static void func_PackedByteArray_encode_u32(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 4);
 		uint8_t *w = p_instance->ptrw();
 		encode_uint32((uint32_t)p_value, &w[p_offset]);
+	}
+	static void func_PackedByteArray_encode_u32_be(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 4);
+		uint8_t *w = p_instance->ptrw();
+		encode_uint32_be((uint32_t)p_value, &w[p_offset]);
 	}
 	static void func_PackedByteArray_encode_s32(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
 		uint64_t size = p_instance->size();
@@ -1051,11 +1123,23 @@ struct _VariantCall {
 		encode_uint32((int32_t)p_value, &w[p_offset]);
 	}
 
+	static void func_PackedByteArray_encode_s32_be(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 4);
+		uint8_t *w = p_instance->ptrw();
+		encode_uint32_be((int32_t)p_value, &w[p_offset]);
+	}
 	static void func_PackedByteArray_encode_u64(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 8);
 		uint8_t *w = p_instance->ptrw();
 		encode_uint64((uint64_t)p_value, &w[p_offset]);
+	}
+	static void func_PackedByteArray_encode_u64_be(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 8);
+		uint8_t *w = p_instance->ptrw();
+		encode_uint64_be((uint64_t)p_value, &w[p_offset]);
 	}
 	static void func_PackedByteArray_encode_s64(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
 		uint64_t size = p_instance->size();
@@ -1064,11 +1148,23 @@ struct _VariantCall {
 		encode_uint64((int64_t)p_value, &w[p_offset]);
 	}
 
+	static void func_PackedByteArray_encode_s64_be(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 8);
+		uint8_t *w = p_instance->ptrw();
+		encode_uint64_be((int64_t)p_value, &w[p_offset]);
+	}
 	static void func_PackedByteArray_encode_half(PackedByteArray *p_instance, int64_t p_offset, double p_value) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 2);
 		uint8_t *w = p_instance->ptrw();
 		encode_uint16(Math::make_half_float(p_value), &w[p_offset]);
+	}
+	static void func_PackedByteArray_encode_half_be(PackedByteArray *p_instance, int64_t p_offset, double p_value) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 2);
+		uint8_t *w = p_instance->ptrw();
+		encode_uint16_be(Math::make_half_float(p_value), &w[p_offset]);
 	}
 	static void func_PackedByteArray_encode_float(PackedByteArray *p_instance, int64_t p_offset, double p_value) {
 		uint64_t size = p_instance->size();
@@ -1076,11 +1172,23 @@ struct _VariantCall {
 		uint8_t *w = p_instance->ptrw();
 		encode_float(p_value, &w[p_offset]);
 	}
+	static void func_PackedByteArray_encode_float_be(PackedByteArray *p_instance, int64_t p_offset, double p_value) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 4);
+		uint8_t *w = p_instance->ptrw();
+		encode_float_be(p_value, &w[p_offset]);
+	}
 	static void func_PackedByteArray_encode_double(PackedByteArray *p_instance, int64_t p_offset, double p_value) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 8);
 		uint8_t *w = p_instance->ptrw();
 		encode_double(p_value, &w[p_offset]);
+	}
+	static void func_PackedByteArray_encode_double_be(PackedByteArray *p_instance, int64_t p_offset, double p_value) {
+		uint64_t size = p_instance->size();
+		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 8);
+		uint8_t *w = p_instance->ptrw();
+		encode_double_be(p_value, &w[p_offset]);
 	}
 	static int64_t func_PackedByteArray_encode_var(PackedByteArray *p_instance, int64_t p_offset, const Variant &p_value, bool p_allow_objects) {
 		uint64_t size = p_instance->size();
@@ -2539,7 +2647,16 @@ static void _register_variant_builtin_methods_array() {
 	bind_function(PackedByteArray, decode_half, _VariantCall::func_PackedByteArray_decode_half, sarray("byte_offset"), varray());
 	bind_function(PackedByteArray, decode_float, _VariantCall::func_PackedByteArray_decode_float, sarray("byte_offset"), varray());
 	bind_function(PackedByteArray, decode_double, _VariantCall::func_PackedByteArray_decode_double, sarray("byte_offset"), varray());
+	bind_function(PackedByteArray, decode_u16_be, _VariantCall::func_PackedByteArray_decode_u16_be, sarray("byte_offset"), varray());
+	bind_function(PackedByteArray, decode_s16_be, _VariantCall::func_PackedByteArray_decode_s16_be, sarray("byte_offset"), varray());
+	bind_function(PackedByteArray, decode_u32_be, _VariantCall::func_PackedByteArray_decode_u32_be, sarray("byte_offset"), varray());
+	bind_function(PackedByteArray, decode_s32_be, _VariantCall::func_PackedByteArray_decode_s32_be, sarray("byte_offset"), varray());
+	bind_function(PackedByteArray, decode_u64_be, _VariantCall::func_PackedByteArray_decode_u64_be, sarray("byte_offset"), varray());
+	bind_function(PackedByteArray, decode_s64_be, _VariantCall::func_PackedByteArray_decode_s64_be, sarray("byte_offset"), varray());
+	bind_function(PackedByteArray, decode_half_be, _VariantCall::func_PackedByteArray_decode_half_be, sarray("byte_offset"), varray());
+	bind_function(PackedByteArray, decode_float_be, _VariantCall::func_PackedByteArray_decode_float_be, sarray("byte_offset"), varray());
 	bind_function(PackedByteArray, has_encoded_var, _VariantCall::func_PackedByteArray_has_encoded_var, sarray("byte_offset", "allow_objects"), varray(false));
+	bind_function(PackedByteArray, decode_double_be, _VariantCall::func_PackedByteArray_decode_double_be, sarray("byte_offset"), varray());
 	bind_function(PackedByteArray, decode_var, _VariantCall::func_PackedByteArray_decode_var, sarray("byte_offset", "allow_objects"), varray(false));
 	bind_function(PackedByteArray, decode_var_size, _VariantCall::func_PackedByteArray_decode_var_size, sarray("byte_offset", "allow_objects"), varray(false));
 
@@ -2561,8 +2678,17 @@ static void _register_variant_builtin_methods_array() {
 	bind_functionnc(PackedByteArray, encode_u64, _VariantCall::func_PackedByteArray_encode_u64, sarray("byte_offset", "value"), varray());
 	bind_functionnc(PackedByteArray, encode_s64, _VariantCall::func_PackedByteArray_encode_s64, sarray("byte_offset", "value"), varray());
 	bind_functionnc(PackedByteArray, encode_half, _VariantCall::func_PackedByteArray_encode_half, sarray("byte_offset", "value"), varray());
-	bind_functionnc(PackedByteArray, encode_float, _VariantCall::func_PackedByteArray_encode_float, sarray("byte_offset", "value"), varray());
 	bind_functionnc(PackedByteArray, encode_double, _VariantCall::func_PackedByteArray_encode_double, sarray("byte_offset", "value"), varray());
+	bind_functionnc(PackedByteArray, encode_u16_be, _VariantCall::func_PackedByteArray_encode_u16_be, sarray("byte_offset", "value"), varray());
+	bind_functionnc(PackedByteArray, encode_s16_be, _VariantCall::func_PackedByteArray_encode_s16_be, sarray("byte_offset", "value"), varray());
+	bind_functionnc(PackedByteArray, encode_u32_be, _VariantCall::func_PackedByteArray_encode_u32_be, sarray("byte_offset", "value"), varray());
+	bind_functionnc(PackedByteArray, encode_s32_be, _VariantCall::func_PackedByteArray_encode_s32_be, sarray("byte_offset", "value"), varray());
+	bind_functionnc(PackedByteArray, encode_u64_be, _VariantCall::func_PackedByteArray_encode_u64_be, sarray("byte_offset", "value"), varray());
+	bind_functionnc(PackedByteArray, encode_s64_be, _VariantCall::func_PackedByteArray_encode_s64_be, sarray("byte_offset", "value"), varray());
+	bind_functionnc(PackedByteArray, encode_half_be, _VariantCall::func_PackedByteArray_encode_half_be, sarray("byte_offset", "value"), varray());
+	bind_functionnc(PackedByteArray, encode_float, _VariantCall::func_PackedByteArray_encode_float, sarray("byte_offset", "value"), varray());
+	bind_functionnc(PackedByteArray, encode_float_be, _VariantCall::func_PackedByteArray_encode_float_be, sarray("byte_offset", "value"), varray());
+	bind_functionnc(PackedByteArray, encode_double_be, _VariantCall::func_PackedByteArray_encode_double_be, sarray("byte_offset", "value"), varray());
 	bind_functionnc(PackedByteArray, encode_var, _VariantCall::func_PackedByteArray_encode_var, sarray("byte_offset", "value", "allow_objects"), varray(false));
 
 	/* Int32 Array */

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -107,6 +107,13 @@
 				Decodes a 64-bit floating-point number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0.0[/code] if a valid number can't be decoded.
 			</description>
 		</method>
+		<method name="decode_double_be" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="byte_offset" type="int" />
+			<description>
+				Decodes a 64-bit floating-point number from the bytes starting at [param byte_offset] in [b]big-endian order[/b]. Fails if the byte count is insufficient. Returns [code]0.0[/code] if a valid number can't be decoded.
+			</description>
+		</method>
 		<method name="decode_float" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="byte_offset" type="int" />
@@ -114,11 +121,25 @@
 				Decodes a 32-bit floating-point number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0.0[/code] if a valid number can't be decoded.
 			</description>
 		</method>
+		<method name="decode_float_be" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="byte_offset" type="int" />
+			<description>
+				Decodes a 32-bit floating-point number from the bytes starting at [param byte_offset] in [b]big-endian order[/b]. Fails if the byte count is insufficient. Returns [code]0.0[/code] if a valid number can't be decoded.
+			</description>
+		</method>
 		<method name="decode_half" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="byte_offset" type="int" />
 			<description>
 				Decodes a 16-bit floating-point number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0.0[/code] if a valid number can't be decoded.
+			</description>
+		</method>
+		<method name="decode_half_be" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="byte_offset" type="int" />
+			<description>
+				Decodes a 16-bit floating-point number from the bytes starting at [param byte_offset] in [b]big-endian order[/b]. Fails if the byte count is insufficient. Returns [code]0.0[/code] if a valid number can't be decoded.
 			</description>
 		</method>
 		<method name="decode_s8" qualifiers="const">
@@ -135,6 +156,13 @@
 				Decodes a 16-bit signed integer number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
 			</description>
 		</method>
+		<method name="decode_s16_be" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="byte_offset" type="int" />
+			<description>
+				Decodes a 16-bit signed integer number from the bytes starting at [param byte_offset] in [b]big-endian order[/b]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
+			</description>
+		</method>
 		<method name="decode_s32" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="byte_offset" type="int" />
@@ -142,11 +170,25 @@
 				Decodes a 32-bit signed integer number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
 			</description>
 		</method>
+		<method name="decode_s32_be" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="byte_offset" type="int" />
+			<description>
+				Decodes a 32-bit signed integer number from the bytes starting at [param byte_offset] in [b]big-endian order[/b]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
+			</description>
+		</method>
 		<method name="decode_s64" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="byte_offset" type="int" />
 			<description>
 				Decodes a 64-bit signed integer number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
+			</description>
+		</method>
+		<method name="decode_s64_be" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="byte_offset" type="int" />
+			<description>
+				Decodes a 64-bit signed integer number from the bytes starting at [param byte_offset] in [b]big-endian order[/b]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
 			</description>
 		</method>
 		<method name="decode_u8" qualifiers="const">
@@ -163,6 +205,13 @@
 				Decodes a 16-bit unsigned integer number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
 			</description>
 		</method>
+		<method name="decode_u16_be" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="byte_offset" type="int" />
+			<description>
+				Decodes a 16-bit unsigned integer number from the bytes starting at [param byte_offset] in [b]big-endian order[/b]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
+			</description>
+		</method>
 		<method name="decode_u32" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="byte_offset" type="int" />
@@ -170,11 +219,25 @@
 				Decodes a 32-bit unsigned integer number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
 			</description>
 		</method>
+		<method name="decode_u32_be" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="byte_offset" type="int" />
+			<description>
+				Decodes a 32-bit unsigned integer number from the bytes starting at [param byte_offset] in [b]big-endian order[/b]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
+			</description>
+		</method>
 		<method name="decode_u64" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="byte_offset" type="int" />
 			<description>
 				Decodes a 64-bit unsigned integer number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
+			</description>
+		</method>
+		<method name="decode_u64_be" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="byte_offset" type="int" />
+			<description>
+				Decodes a 64-bit unsigned integer number from the bytes starting at [param byte_offset] in [b]big-endian order[/b]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
 			</description>
 		</method>
 		<method name="decode_var" qualifiers="const">
@@ -227,6 +290,14 @@
 				Encodes a 64-bit floating-point number as bytes at the index of [param byte_offset] bytes. The array must have at least 8 bytes of allocated space, starting at the offset.
 			</description>
 		</method>
+		<method name="encode_double_be">
+			<return type="void" />
+			<param index="0" name="byte_offset" type="int" />
+			<param index="1" name="value" type="float" />
+			<description>
+				Encodes a 64-bit floating-point number as bytes at the index of [param byte_offset] bytes in [b]big-endian order[/b]. The array must have at least 8 bytes of allocated space, starting at the offset.
+			</description>
+		</method>
 		<method name="encode_float">
 			<return type="void" />
 			<param index="0" name="byte_offset" type="int" />
@@ -235,12 +306,28 @@
 				Encodes a 32-bit floating-point number as bytes at the index of [param byte_offset] bytes. The array must have at least 4 bytes of space, starting at the offset.
 			</description>
 		</method>
+		<method name="encode_float_be">
+			<return type="void" />
+			<param index="0" name="byte_offset" type="int" />
+			<param index="1" name="value" type="float" />
+			<description>
+				Encodes a 32-bit floating-point number as bytes at the index of [param byte_offset] bytes in [b]big-endian order[/b]. The array must have at least 4 bytes of allocated space, starting at the offset.
+			</description>
+		</method>
 		<method name="encode_half">
 			<return type="void" />
 			<param index="0" name="byte_offset" type="int" />
 			<param index="1" name="value" type="float" />
 			<description>
 				Encodes a 16-bit floating-point number as bytes at the index of [param byte_offset] bytes. The array must have at least 2 bytes of space, starting at the offset.
+			</description>
+		</method>
+		<method name="encode_half_be">
+			<return type="void" />
+			<param index="0" name="byte_offset" type="int" />
+			<param index="1" name="value" type="float" />
+			<description>
+				Encodes a 16-bit floating-point number as bytes at the index of [param byte_offset] bytes in [b]big-endian order[/b]. The array must have at least 2 bytes of space, starting at the offset.
 			</description>
 		</method>
 		<method name="encode_s8">
@@ -259,6 +346,14 @@
 				Encodes a 16-bit signed integer number as bytes at the index of [param byte_offset] bytes. The array must have at least 2 bytes of space, starting at the offset.
 			</description>
 		</method>
+		<method name="encode_s16_be">
+			<return type="void" />
+			<param index="0" name="byte_offset" type="int" />
+			<param index="1" name="value" type="int" />
+			<description>
+				Encodes a 16-bit signed integer number as bytes at the index of [param byte_offset] bytes. The array must have at least 2 bytes of space, starting at the offset.
+			</description>
+		</method>
 		<method name="encode_s32">
 			<return type="void" />
 			<param index="0" name="byte_offset" type="int" />
@@ -267,12 +362,28 @@
 				Encodes a 32-bit signed integer number as bytes at the index of [param byte_offset] bytes. The array must have at least 4 bytes of space, starting at the offset.
 			</description>
 		</method>
+		<method name="encode_s32_be">
+			<return type="void" />
+			<param index="0" name="byte_offset" type="int" />
+			<param index="1" name="value" type="int" />
+			<description>
+				Encodes a 32-bit signed integer number as bytes at the index of [param byte_offset] bytes in [b]big-endian order[/b]. The array must have at least 4 bytes of space, starting at the offset.
+			</description>
+		</method>
 		<method name="encode_s64">
 			<return type="void" />
 			<param index="0" name="byte_offset" type="int" />
 			<param index="1" name="value" type="int" />
 			<description>
 				Encodes a 64-bit signed integer number as bytes at the index of [param byte_offset] bytes. The array must have at least 8 bytes of space, starting at the offset.
+			</description>
+		</method>
+		<method name="encode_s64_be">
+			<return type="void" />
+			<param index="0" name="byte_offset" type="int" />
+			<param index="1" name="value" type="int" />
+			<description>
+				Encodes a 64-bit signed integer number as bytes at the index of [param byte_offset] bytes in [b]big-endian order[/b]. The array must have at least 8 bytes of space, starting at the offset.
 			</description>
 		</method>
 		<method name="encode_u8">
@@ -291,6 +402,14 @@
 				Encodes a 16-bit unsigned integer number as bytes at the index of [param byte_offset] bytes. The array must have at least 2 bytes of space, starting at the offset.
 			</description>
 		</method>
+		<method name="encode_u16_be">
+			<return type="void" />
+			<param index="0" name="byte_offset" type="int" />
+			<param index="1" name="value" type="int" />
+			<description>
+				Encodes a 16-bit unsigned integer number as bytes at the index of [param byte_offset] bytes in [b]big-endian order[/b]. The array must have at least 2 bytes of space, starting at the offset.
+			</description>
+		</method>
 		<method name="encode_u32">
 			<return type="void" />
 			<param index="0" name="byte_offset" type="int" />
@@ -299,12 +418,28 @@
 				Encodes a 32-bit unsigned integer number as bytes at the index of [param byte_offset] bytes. The array must have at least 4 bytes of space, starting at the offset.
 			</description>
 		</method>
+		<method name="encode_u32_be">
+			<return type="void" />
+			<param index="0" name="byte_offset" type="int" />
+			<param index="1" name="value" type="int" />
+			<description>
+				Encodes a 32-bit unsigned integer number as bytes at the index of [param byte_offset] bytes in [b]big-endian order[/b]. The array must have at least 4 bytes of space, starting at the offset.
+			</description>
+		</method>
 		<method name="encode_u64">
 			<return type="void" />
 			<param index="0" name="byte_offset" type="int" />
 			<param index="1" name="value" type="int" />
 			<description>
 				Encodes a 64-bit unsigned integer number as bytes at the index of [param byte_offset] bytes. The array must have at least 8 bytes of space, starting at the offset.
+			</description>
+		</method>
+		<method name="encode_u64_be">
+			<return type="void" />
+			<param index="0" name="byte_offset" type="int" />
+			<param index="1" name="value" type="int" />
+			<description>
+				Encodes a 64-bit unsigned integer number as bytes at the index of [param byte_offset] bytes in [b]big-endian order[/b]. The array must have at least 8 bytes of space, starting at the offset.
 			</description>
 		</method>
 		<method name="encode_var">

--- a/tests/core/io/test_marshalls.h
+++ b/tests/core/io/test_marshalls.h
@@ -39,26 +39,43 @@ namespace TestMarshalls {
 TEST_CASE("[Marshalls] Unsigned 16 bit integer encoding") {
 	uint8_t arr[2];
 
+	// Little-endian
 	unsigned int actual_size = encode_uint16(0x1234, arr);
 	CHECK(actual_size == sizeof(uint16_t));
 	CHECK_MESSAGE(arr[0] == 0x34, "First encoded byte value should be equal to low order byte value.");
 	CHECK_MESSAGE(arr[1] == 0x12, "Last encoded byte value should be equal to high order byte value.");
+
+	// Big-endian
+	actual_size = encode_uint16_be(0x1234, arr);
+	CHECK(actual_size == sizeof(uint16_t));
+	CHECK_MESSAGE(arr[0] == 0x12, "(Big-endian) First encoded byte value should be equal to high order byte value.");
+	CHECK_MESSAGE(arr[1] == 0x34, "(Big-endian) Last encoded byte value should be equal to low order byte value.");
 }
 
 TEST_CASE("[Marshalls] Unsigned 32 bit integer encoding") {
 	uint8_t arr[4];
 
+	// Little-endian
 	unsigned int actual_size = encode_uint32(0x12345678, arr);
 	CHECK(actual_size == sizeof(uint32_t));
 	CHECK_MESSAGE(arr[0] == 0x78, "First encoded byte value should be equal to low order byte value.");
 	CHECK(arr[1] == 0x56);
 	CHECK(arr[2] == 0x34);
 	CHECK_MESSAGE(arr[3] == 0x12, "Last encoded byte value should be equal to high order byte value.");
+
+	// Big-endian
+	actual_size = encode_uint32_be(0x12345678, arr);
+	CHECK(actual_size == sizeof(uint32_t));
+	CHECK_MESSAGE(arr[0] == 0x12, "(Big-endian) First encoded byte value should be equal to high order byte value.");
+	CHECK(arr[1] == 0x34);
+	CHECK(arr[2] == 0x56);
+	CHECK_MESSAGE(arr[3] == 0x78, "(Big-endian) Last encoded byte value should be equal to low order byte value.");
 }
 
 TEST_CASE("[Marshalls] Unsigned 64 bit integer encoding") {
 	uint8_t arr[8];
 
+	// Little-endian
 	unsigned int actual_size = encode_uint64(0x0f123456789abcdef, arr);
 	CHECK(actual_size == sizeof(uint64_t));
 	CHECK_MESSAGE(arr[0] == 0xef, "First encoded byte value should be equal to low order byte value.");
@@ -69,24 +86,48 @@ TEST_CASE("[Marshalls] Unsigned 64 bit integer encoding") {
 	CHECK(arr[5] == 0x45);
 	CHECK(arr[6] == 0x23);
 	CHECK_MESSAGE(arr[7] == 0xf1, "Last encoded byte value should be equal to high order byte value.");
+
+	// Big-endian
+	actual_size = encode_uint64_be(0x0f123456789abcdef, arr);
+	CHECK(actual_size == sizeof(uint64_t));
+	CHECK_MESSAGE(arr[0] == 0xf1, "(Big-endian) First encoded byte value should be equal to high order byte value.");
+	CHECK(arr[1] == 0x23);
+	CHECK(arr[2] == 0x45);
+	CHECK(arr[3] == 0x67);
+	CHECK(arr[4] == 0x89);
+	CHECK(arr[5] == 0xab);
+	CHECK(arr[6] == 0xcd);
+	CHECK_MESSAGE(arr[7] == 0xef, "(Big-endian) Last encoded byte value should be equal to low order byte value.");
 }
 
 TEST_CASE("[Marshalls] Unsigned 16 bit integer decoding") {
+	// Little-endian
 	uint8_t arr[] = { 0x34, 0x12 };
-
 	CHECK(decode_uint16(arr) == 0x1234);
+
+	// Big-endian
+	uint8_t arr_be[] = { 0x12, 0x34 };
+	CHECK(decode_uint16_be(arr_be) == 0x1234);
 }
 
 TEST_CASE("[Marshalls] Unsigned 32 bit integer decoding") {
+	// Little-endian
 	uint8_t arr[] = { 0x78, 0x56, 0x34, 0x12 };
-
 	CHECK(decode_uint32(arr) == 0x12345678);
+
+	// Big-endian
+	uint8_t arr_be[] = { 0x12, 0x34, 0x56, 0x78 };
+	CHECK(decode_uint32_be(arr_be) == 0x12345678);
 }
 
 TEST_CASE("[Marshalls] Unsigned 64 bit integer decoding") {
+	// Little-endian
 	uint8_t arr[] = { 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0xf1 };
-
 	CHECK(decode_uint64(arr) == 0x0f123456789abcdef);
+
+	// Big-endian
+	uint8_t arr_be[] = { 0xf1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
+	CHECK(decode_uint64_be(arr_be) == 0x0f123456789abcdef);
 }
 
 TEST_CASE("[Marshalls] Floating point half precision encoding") {
@@ -97,10 +138,18 @@ TEST_CASE("[Marshalls] Floating point half precision encoding") {
 	// sign exponent (5 bits)    fraction (10 bits)
 	//  0        01101               0101010101
 	// Hexadecimal: 0x3555
+
+	// Little-endian
 	unsigned int actual_size = encode_half(0.33325195f, arr);
 	CHECK(actual_size == sizeof(uint16_t));
 	CHECK(arr[0] == 0x55);
 	CHECK(arr[1] == 0x35);
+
+	// Big-endian
+	unsigned int actual_size_be = encode_half_be(0.33325195f, arr);
+	CHECK(actual_size_be == sizeof(uint16_t));
+	CHECK(arr[0] == 0x35);
+	CHECK(arr[1] == 0x55);
 }
 
 TEST_CASE("[Marshalls] Floating point single precision encoding") {
@@ -111,12 +160,22 @@ TEST_CASE("[Marshalls] Floating point single precision encoding") {
 	// sign exponent (8 bits)    fraction (23 bits)
 	//  0       01111100      01000000000000000000000
 	// Hexadecimal: 0x3E200000
+
+	// Little-endian
 	unsigned int actual_size = encode_float(0.15625f, arr);
 	CHECK(actual_size == sizeof(uint32_t));
 	CHECK(arr[0] == 0x00);
 	CHECK(arr[1] == 0x00);
 	CHECK(arr[2] == 0x20);
 	CHECK(arr[3] == 0x3e);
+
+	// Big-endian
+	actual_size = encode_float_be(0.15625f, arr);
+	CHECK(actual_size == sizeof(uint32_t));
+	CHECK(arr[0] == 0x3e);
+	CHECK(arr[1] == 0x20);
+	CHECK(arr[2] == 0x00);
+	CHECK(arr[3] == 0x00);
 }
 
 TEST_CASE("[Marshalls] Floating point double precision encoding") {
@@ -127,6 +186,8 @@ TEST_CASE("[Marshalls] Floating point double precision encoding") {
 	// sign exponent (11 bits)                  fraction (52 bits)
 	//  0      01111111101     0101010101010101010101010101010101010101010101010101
 	// Hexadecimal: 0x3FD5555555555555
+
+	// Little-endian
 	unsigned int actual_size = encode_double(0.33333333333333333, arr);
 	CHECK(actual_size == sizeof(uint64_t));
 	CHECK(arr[0] == 0x55);
@@ -137,27 +198,48 @@ TEST_CASE("[Marshalls] Floating point double precision encoding") {
 	CHECK(arr[5] == 0x55);
 	CHECK(arr[6] == 0xd5);
 	CHECK(arr[7] == 0x3f);
+
+	// Big-endian
+	actual_size = encode_double_be(0.33333333333333333, arr);
+	CHECK(actual_size == sizeof(uint64_t));
+	CHECK(arr[0] == 0x3f);
+	CHECK(arr[1] == 0xd5);
+	CHECK(arr[2] == 0x55);
+	CHECK(arr[3] == 0x55);
+	CHECK(arr[4] == 0x55);
+	CHECK(arr[5] == 0x55);
+	CHECK(arr[6] == 0x55);
+	CHECK(arr[7] == 0x55);
 }
 
 TEST_CASE("[Marshalls] Floating point half precision decoding") {
+	// Little-endian
 	uint8_t arr[] = { 0x55, 0x35 };
-
-	// See floating point half precision encoding test case for details behind expected values.
 	CHECK(decode_half(arr) == 0.33325195f);
+
+	// Big-endian
+	uint8_t arr_be[] = { 0x35, 0x55 };
+	CHECK(decode_half_be(arr_be) == 0.33325195f);
 }
 
 TEST_CASE("[Marshalls] Floating point single precision decoding") {
+	// Little-endian
 	uint8_t arr[] = { 0x00, 0x00, 0x20, 0x3e };
-
-	// See floating point encoding test case for details behind expected values
 	CHECK(decode_float(arr) == 0.15625f);
+
+	// Big-endian
+	uint8_t arr_be[] = { 0x3e, 0x20, 0x00, 0x00 };
+	CHECK(decode_float_be(arr_be) == 0.15625f);
 }
 
 TEST_CASE("[Marshalls] Floating point double precision decoding") {
+	// Little-endian
 	uint8_t arr[] = { 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0xd5, 0x3f };
-
-	// See floating point encoding test case for details behind expected values
 	CHECK(decode_double(arr) == 0.33333333333333333);
+
+	// Big-endian
+	uint8_t arr_be[] = { 0x3f, 0xd5, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55 };
+	CHECK(decode_double_be(arr_be) == 0.33333333333333333);
 }
 
 TEST_CASE("[Marshalls] C string encoding") {


### PR DESCRIPTION
Added an alternate method for all encoding/decoding functions above u8 in order to read/write in big endian. Also slightly cleaned up a bit of the encoding/decoding logic.
- This aims to help read & write BE binary without having to manually implement those functions in GDScript. Existing implementations are unaffected as this is another method entirely.

___

- *Production edit: Related to https://github.com/godotengine/godot/pull/105178
and https://github.com/godotengine/godot-docs/issues/10848.*