### PR TITLE
Fix incorrect title bar sorting in RTL layout.

### DIFF
--- a/editor/gui/editor_title_bar.cpp
+++ b/editor/gui/editor_title_bar.cpp
@@ -96,7 +96,23 @@ void EditorTitleBar::_notification(int p_what) {
 	Control *prev = nullptr;
 	Control *base = nullptr;
 	Control *next = nullptr;
-	for (int i = 0; i < get_child_count(); i++) {
+
+	bool rtl = is_layout_rtl();
+
+	int start;
+	int end;
+	int delta;
+	if (rtl) {
+		start = get_child_count() - 1;
+		end = -1;
+		delta = -1;
+	} else {
+		start = 0;
+		end = get_child_count();
+		delta = +1;
+	}
+
+	for (int i = start; i != end; i += delta) {
 		Control *c = as_sortable_control(get_child(i));
 		if (!c) {
 			continue;


### PR DESCRIPTION
Adds layout direction check missed in https://github.com/godotengine/godot/pull/105106

Before:
<img width="1155" alt="Screenshot 2025-04-17 at 09 33 51" src="https://github.com/user-attachments/assets/52a9b798-c824-4945-98c2-e93c8af8f3bb" />

After:
<img width="1155" alt="Screenshot 2025-04-17 at 09 32 15" src="https://github.com/user-attachments/assets/024e7cda-d4da-4955-968c-62e502aff641" />
