### PR TITLE
Fix regression causing jittery canvas transforms

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1772,7 +1772,7 @@ void Control::_size_changed() {
 			}
 		}
 
-		if (pos_changed && !size_changed) {
+		if (pos_changed && !approx_size_changed) {
 			_update_canvas_item_transform();
 		}
 


### PR DESCRIPTION
This PR https://github.com/godotengine/godot/pull/104451 introduced a tricky regression. Canvas item transforms could risk not being updated for multiple frames due to the conditional on the line in this commit. Before the "approx_pos|size_changed" fix, the transform would get updated incidentally either way. But now there's a gap where (pos_changed && !size_changed) may not be true for a few frames and there's nothing else left to trigger a transform update.

The fix is quite simple: remain trigger happy around position changes and make sure to update the item transform if position has changed at all, but now respect the `approx_size_changed`, as `size_changed` was often true due to minor floating point accumulation that the original PR was addressing in some ways.

Fixes https://github.com/godotengine/godot/issues/105483

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
