### PR TITLE
Normalize description of `ResourceLoader.list_directory()`

### DIFF
--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -81,8 +81,8 @@
 			<description>
 				Lists a directory, returning all resources and subdirectories contained within. The resource files have the original file names as visible in the editor before exporting. The directories have [code]"/"[/code] appended.
 				[codeblock]
-				print(ResourceLoader.list_directory("res://assets/enemies/slime"))
 				# Prints ["extra_data/", "model.gltf", "model.tscn", "model_slime.png"]
+				print(ResourceLoader.list_directory("res://assets/enemies/slime"))
 				[/codeblock]
 				[b]Note:[/b] The order of files and directories returned by this method is not deterministic, and can vary between operating systems.
 				[b]Note:[/b] To normally traverse the filesystem, see [DirAccess].


### PR DESCRIPTION
Follow up of #104006, thanks to Mickeon for noticing this oversight of mine.

This is irregular when compared to other descriptions in the docs using `# Prints` on a separate line:
```gdscript
print(ResourceLoader.list_directory("res://assets/enemies/slime"))
# Prints ["extra_data/", "model.gltf", "model.tscn", "model_slime.png"]
```
So it was normalized to this:
```gdscript
# Prints ["extra_data/", "model.gltf", "model.tscn", "model_slime.png"]
print(ResourceLoader.list_directory("res://assets/enemies/slime"))
```
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
