### PR TITLE
Make 3D editor gizmo handles scale their interactable size based on editor scale

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -38,7 +38,7 @@
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "scene/resources/3d/primitive_meshes.h"
 
-#define HANDLE_HALF_SIZE 9.5
+#define HANDLE_HALF_SIZE 9.5 * MAX(1.0, EDSCALE)
 
 bool EditorNode3DGizmo::is_editable() const {
 	ERR_FAIL_NULL_V(spatial_node, false);


### PR DESCRIPTION
Previously, the gizmo handles were drawn at a larger size, but their interactable size stayed the same. For instance, this meant at 200% editor scale, you couldn't select them by clicking their outline, even though you could at 100% editor scale.

Behavior at editor scales below 100% is not affected to avoid impacting usability.

- See https://github.com/godotengine/godot/issues/90843.

cc @passivestar