### PR TITLE
Fix missing `gdb.printing` import for the pretty print script

### DIFF
--- a/misc/utility/godot_gdb_pretty_print.py
+++ b/misc/utility/godot_gdb_pretty_print.py
@@ -25,6 +25,7 @@ From there you can figure out how to print it nicely.
 import re
 
 import gdb  # type: ignore
+import gdb.printing  # type: ignore
 
 
 # Printer for Godot StringName variables.


### PR DESCRIPTION
Without it, the script may not actually work on some systems (and by some I mean mine).