### PR TITLE
Add `{c,cpp}_compiler_launcher` options

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -296,6 +296,9 @@ opts.Add("asflags", "Custom flags for the assembler")
 opts.Add("arflags", "Custom flags for the archive tool")
 opts.Add("rcflags", "Custom flags for Windows resource compiler")
 
+opts.Add("c_compiler_launcher", "C compiler launcher (e.g. `ccache`)")
+opts.Add("cpp_compiler_launcher", "C++ compiler launcher (e.g. `ccache`)")
+
 # Update the environment to have all above options defined
 # in following code (especially platform and custom_modules).
 opts.Update(env)
@@ -1121,6 +1124,13 @@ for key in (emitters := env.StaticObject.builder.emitter):
     emitters[key] = ListEmitter([methods.redirect_emitter] + env.Flatten(emitters[key]))
 for key in (emitters := env.SharedObject.builder.emitter):
     emitters[key] = ListEmitter([methods.redirect_emitter] + env.Flatten(emitters[key]))
+
+# Prepend compiler launchers
+if "c_compiler_launcher" in env:
+    env["CC"] = " ".join([env["c_compiler_launcher"], env["CC"]])
+
+if "cpp_compiler_launcher" in env:
+    env["CXX"] = " ".join([env["cpp_compiler_launcher"], env["CXX"]])
 
 # Build subdirs, the build order is dependent on link order.
 Export("env")


### PR DESCRIPTION
This PR adds `{c,cpp}_compiler_launcher` options to enable the use of tools like `ccache` with Godot.

```bash
# Needs `ccache` to be preinstalled and in the path
scons c_compiler_launcher=ccache cpp_compiler_launcher=ccache
```

This command essentially prefixes `ccache` to every {`CC`,`CXX`} call.

See [`CMAKE_LANG_COMPILER_LAUNCHER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_LAUNCHER.html#variable:CMAKE_%3CLANG%3E_COMPILER_LAUNCHER) for the inspiration.