### PR TITLE
Add `EditorInterface::close_scene()`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -19,6 +19,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="close_scene">
+			<return type="int" enum="Error" />
+			<description>
+				Closes the currently active scene, discarding any pending changes in the process. Returns [constant OK] on success or [constant ERR_DOES_NOT_EXIST] if there is no scene to close.
+			</description>
+		</method>
 		<method name="edit_node">
 			<return type="void" />
 			<param index="0" name="node" type="Node" />

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -713,6 +713,10 @@ void EditorInterface::save_all_scenes() {
 	EditorNode::get_singleton()->save_all_scenes();
 }
 
+Error EditorInterface::close_scene() {
+	return EditorNode::get_singleton()->close_scene() ? OK : ERR_DOES_NOT_EXIST;
+}
+
 // Scene playback.
 
 void EditorInterface::play_main_scene() {
@@ -845,6 +849,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save_scene"), &EditorInterface::save_scene);
 	ClassDB::bind_method(D_METHOD("save_scene_as", "path", "with_preview"), &EditorInterface::save_scene_as, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("save_all_scenes"), &EditorInterface::save_all_scenes);
+	ClassDB::bind_method(D_METHOD("close_scene"), &EditorInterface::close_scene);
 
 	ClassDB::bind_method(D_METHOD("mark_scene_as_unsaved"), &EditorInterface::mark_scene_as_unsaved);
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -177,6 +177,7 @@ public:
 	void save_scene_as(const String &p_scene, bool p_with_preview = true);
 	void mark_scene_as_unsaved();
 	void save_all_scenes();
+	Error close_scene();
 
 	// Scene playback.
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4974,6 +4974,19 @@ bool EditorNode::_find_scene_in_use(Node *p_node, const String &p_path) const {
 	return false;
 }
 
+bool EditorNode::close_scene() {
+	int tab_index = editor_data.get_edited_scene();
+	if (tab_index == 0 && get_edited_scene() == nullptr && editor_data.get_scene_path(tab_index).is_empty()) {
+		return false;
+	}
+
+	tab_closing_idx = tab_index;
+	current_menu_option = SCENE_CLOSE;
+	_discard_changes();
+	changing_scene = false;
+	return true;
+}
+
 bool EditorNode::is_scene_in_use(const String &p_path) {
 	Node *es = get_edited_scene();
 	if (es) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -943,6 +943,8 @@ public:
 		}
 	}
 
+	bool close_scene();
+
 	bool is_scene_in_use(const String &p_path);
 
 	void save_editor_layout_delayed();


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot-proposals/issues/8806

Tested with creating 4 test scenes consisting only of Label nodes, then running following editor script with no scenes opened in the editor:

```gdscript
@tool
extends EditorScript

func _run():
	var scenes = [
		"res://test_1.tscn",
		"res://test_2.tscn",
		"res://test_3.tscn",
		"res://test_4.tscn",
	]

	for scene_path: String in scenes:
		print("Opening scene from ", scene_path)
		EditorInterface.open_scene_from_path(scene_path)
		var root := EditorInterface.get_edited_scene_root()
		(root as Label).text = scene_path + Time.get_datetime_string_from_system()
		EditorInterface.save_scene()
		print("Closing scene, result: ", EditorInterface.close_scene())

	print("Redundant scene close, result: ", EditorInterface.close_scene())
```

Output:

```
Opening scene from res://test_1.tscn
Closing scene, result: 0
Opening scene from res://test_2.tscn
Closing scene, result: 0
Opening scene from res://test_3.tscn
Closing scene, result: 0
Opening scene from res://test_4.tscn
Closing scene, result: 0
Redundant scene close, result: 33
```

The label texts were successfully updated.