### PR TITLE
Add convert indent on save filter option in editor settings

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1276,6 +1276,9 @@
 		<member name="text_editor/behavior/files/convert_indent_on_save" type="bool" setter="" getter="">
 			If [code]true[/code], converts indentation to match the script editor's indentation settings when saving a script. See also [member text_editor/behavior/indent/type].
 		</member>
+		<member name="text_editor/behavior/files/convert_indent_on_save_filter" type="String" setter="" getter="">
+			The comma-separated files to convert indentation when saving the file (e.g: *.gd, *.cs). If left empty, any file will have its indentation converted when it is saved.
+		</member>
 		<member name="text_editor/behavior/files/drop_preload_resources_as_uid" type="bool" setter="" getter="">
 			If [code]true[/code], when dropping a [Resource] file to script editor while [kbd]Ctrl[/kbd] is held, the resource will be preloaded with a UID. If [code]false[/code], the resource will be preloaded with a path.
 			When you hold [kbd]Ctrl+Shift[/kbd], the behavior is reversed.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -743,6 +743,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/files/autosave_interval_secs", 0);
 	_initial_set("text_editor/behavior/files/restore_scripts_on_load", true);
 	_initial_set("text_editor/behavior/files/convert_indent_on_save", true);
+	_initial_set("text_editor/behavior/files/convert_indent_on_save_filter", "");
 	_initial_set("text_editor/behavior/files/auto_reload_scripts_on_external_change", false);
 	_initial_set("text_editor/behavior/files/auto_reload_and_parse_scripts_on_save", true);
 	_initial_set("text_editor/behavior/files/open_dominant_script_on_scene_change", false, true);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -431,6 +431,7 @@ class ScriptEditor : public PanelContainer {
 	bool trim_trailing_whitespace_on_save;
 	bool trim_final_newlines_on_save;
 	bool convert_indent_on_save;
+	Vector<String> convert_indent_on_save_filter;
 	bool external_editor_active;
 
 	void _goto_script_line2(int p_line);
@@ -535,6 +536,9 @@ class ScriptEditor : public PanelContainer {
 
 	static void _open_script_request(const String &p_path);
 	void _close_builtin_scripts_from_scene(const String &p_scene);
+
+	Vector<String> _parse_convert_indent_on_save_filter(const String &filter_str);
+	bool _should_convert_indent_on_save(ScriptEditorBase *const se);
 
 	static ScriptEditor *script_editor;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #86092

### Summary

These changes add a "Convert Indent on Save Filter" option to the editor settings under Text Editor/Behavior/Files. This filter specifies which files have their indentation automatically converted on save (if the "Convert Indent on Save" option is enabled).

For example, putting `*.gd` under the filter option would mean any GDScript file would have their indentation automatically converted on save. Additionally, saving wouldn't modify the indentation of a file that doesn't match the pattern (like a JSON or text file).

### Backwards Compatibility

Some users could rely on the current behavior where all files have their indentation automatically converted. By default, the "Convert Indent on Save Filter" option is left empty and any file will be automatically converted on save. 

### Support for Multiple File Types

Since the user may want to automatically indent multiple file types, the "Convert Indent on Save Filter" option supports a comma-separated list. As an example, a user could specify `*.gd, *.cs, *.h, *.cpp` for the filter.