### PR TITLE
Add support for disabling gamepad inputs in the Input class

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -203,6 +203,8 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("parse_input_event", "event"), &Input::parse_input_event);
 	ClassDB::bind_method(D_METHOD("set_use_accumulated_input", "enable"), &Input::set_use_accumulated_input);
 	ClassDB::bind_method(D_METHOD("is_using_accumulated_input"), &Input::is_using_accumulated_input);
+	ClassDB::bind_method(D_METHOD("set_joypad_enabled", "enable"), &Input::set_joypad_enabled);
+	ClassDB::bind_method(D_METHOD("is_joypad_enabled"), &Input::is_joypad_enabled);
 	ClassDB::bind_method(D_METHOD("flush_buffered_events"), &Input::flush_buffered_events);
 	ClassDB::bind_method(D_METHOD("set_emulate_mouse_from_touch", "enable"), &Input::set_emulate_mouse_from_touch);
 	ClassDB::bind_method(D_METHOD("is_emulating_mouse_from_touch"), &Input::is_emulating_mouse_from_touch);
@@ -211,6 +213,7 @@ void Input::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_mode"), "set_mouse_mode", "get_mouse_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_accumulated_input"), "set_use_accumulated_input", "is_using_accumulated_input");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "joypad_enabled"), "set_joypad_enabled", "is_joypad_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emulate_mouse_from_touch"), "set_emulate_mouse_from_touch", "is_emulating_mouse_from_touch");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emulate_touch_from_mouse"), "set_emulate_touch_from_mouse", "is_emulating_touch_from_mouse");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_joypad_on_unfocused_application"), "set_ignore_joypad_on_unfocused_application", "is_ignoring_joypad_on_unfocused_application");
@@ -384,7 +387,7 @@ bool Input::is_mouse_button_pressed(MouseButton p_button) const {
 }
 
 bool Input::_should_ignore_joypad_events() const {
-	return ignore_joypad_on_unfocused_application && !application_focused && !embedder_focused;
+	return !joypad_enabled || (ignore_joypad_on_unfocused_application && !application_focused && !embedder_focused);
 }
 
 static JoyAxis _combine_device(JoyAxis p_value, int p_device) {
@@ -398,7 +401,7 @@ static JoyButton _combine_device(JoyButton p_value, int p_device) {
 bool Input::is_joy_button_pressed(int p_device, JoyButton p_button) const {
 	_THREAD_SAFE_METHOD_
 
-	if (disable_input) {
+	if (disable_input || !joypad_enabled) {
 		return false;
 	}
 
@@ -605,7 +608,7 @@ Vector2 Input::get_vector(const StringName &p_negative_x, const StringName &p_po
 float Input::get_joy_axis(int p_device, JoyAxis p_axis) const {
 	_THREAD_SAFE_METHOD_
 
-	if (disable_input) {
+	if (disable_input || !joypad_enabled) {
 		return 0;
 	}
 
@@ -619,10 +622,16 @@ float Input::get_joy_axis(int p_device, JoyAxis p_axis) const {
 
 String Input::get_joy_name(int p_idx) {
 	_THREAD_SAFE_METHOD_
+	if (!joypad_enabled) {
+		return "";
+	}
 	return joy_names[p_idx].name;
 }
 
 Vector2 Input::get_joy_vibration_strength(int p_device) {
+	if (!joypad_enabled) {
+		return Vector2();
+	}
 	if (joy_vibration.has(p_device)) {
 		return Vector2(joy_vibration[p_device].weak_magnitude, joy_vibration[p_device].strong_magnitude);
 	} else {
@@ -639,6 +648,9 @@ uint64_t Input::get_joy_vibration_timestamp(int p_device) {
 }
 
 float Input::get_joy_vibration_duration(int p_device) {
+	if (!joypad_enabled) {
+		return 0.0f;
+	}
 	if (joy_vibration.has(p_device)) {
 		return joy_vibration[p_device].duration;
 	} else {
@@ -648,6 +660,9 @@ float Input::get_joy_vibration_duration(int p_device) {
 
 float Input::get_joy_vibration_remaining_duration(int p_device) {
 	_THREAD_SAFE_METHOD_
+	if (!joypad_enabled) {
+		return 0.0f;
+	}
 	const Joypad *joypad = joy_names.getptr(p_device);
 	if (joypad == nullptr || !joypad->has_vibration) {
 		return 0.f;
@@ -1209,6 +1224,9 @@ Vector3 Input::get_joy_gyroscope(int p_device) const {
 
 void Input::set_joy_motion_sensors_enabled(int p_device, bool p_enable) {
 	_THREAD_SAFE_METHOD_
+	if (!joypad_enabled) {
+		return;
+	}
 	Joypad *joypad = joy_names.getptr(p_device);
 	if (joypad == nullptr || joypad->features == nullptr) {
 		return;
@@ -1234,6 +1252,9 @@ bool Input::has_joy_motion_sensors(int p_device) const {
 
 float Input::get_joy_motion_sensors_rate(int p_device) const {
 	_THREAD_SAFE_METHOD_
+	if (!joypad_enabled) {
+		return 0.0f;
+	}
 	const MotionInfo *motion = joy_motion.getptr(p_device);
 	if (motion == nullptr) {
 		return 0.0f;
@@ -1289,6 +1310,9 @@ void Input::clear_joy_motion_sensors_calibration(int p_device) {
 
 Dictionary Input::get_joy_motion_sensors_calibration(int p_device) const {
 	_THREAD_SAFE_METHOD_
+	if (!joypad_enabled) {
+		return Dictionary();
+	}
 	const MotionInfo *motion = joy_motion.getptr(p_device);
 	if (motion == nullptr) {
 		return Dictionary();
@@ -1309,6 +1333,9 @@ Dictionary Input::get_joy_motion_sensors_calibration(int p_device) const {
 
 void Input::set_joy_motion_sensors_calibration(int p_device, const Dictionary &p_calibration_info) {
 	_THREAD_SAFE_METHOD_
+	if (!joypad_enabled) {
+		return;
+	}
 	MotionInfo *motion = joy_motion.getptr(p_device);
 	if (motion == nullptr) {
 		return;
@@ -1371,6 +1398,9 @@ void Input::start_joy_vibration(int p_device, float p_weak_magnitude, float p_st
 
 void Input::stop_joy_vibration(int p_device) {
 	_THREAD_SAFE_METHOD_
+	if (!joypad_enabled) {
+		return;
+	}
 	VibrationInfo vibration;
 	vibration.weak_magnitude = 0;
 	vibration.strong_magnitude = 0;
@@ -1659,6 +1689,17 @@ bool Input::is_using_accumulated_input() {
 	return use_accumulated_input;
 }
 
+void Input::set_joypad_enabled(bool p_enable) {
+	joypad_enabled = p_enable;
+	if (!joypad_enabled) {
+		release_pressed_events();
+	}
+}
+
+bool Input::is_joypad_enabled() {
+	return joypad_enabled;
+}
+
 void Input::release_pressed_events() {
 	// Don't release the events if the application (or the window it's embedded in) is still focused.
 	if (application_focused || embedder_focused) {
@@ -1670,7 +1711,7 @@ void Input::release_pressed_events() {
 	keys_pressed.clear();
 	physical_keys_pressed.clear();
 	key_label_pressed.clear();
-	if (ignore_joypad_on_unfocused_application) {
+	if (!joypad_enabled || ignore_joypad_on_unfocused_application) {
 		joy_buttons_pressed.clear();
 		_joy_axis.clear();
 
@@ -2359,11 +2400,17 @@ bool Input::is_joy_known(int p_device) {
 
 String Input::get_joy_guid(int p_device) const {
 	ERR_FAIL_COND_V(!joy_names.has(p_device), "");
+	if (!joypad_enabled) {
+		return "";
+	}
 	return joy_names[p_device].uid;
 }
 
 Dictionary Input::get_joy_info(int p_device) const {
 	ERR_FAIL_COND_V(!joy_names.has(p_device), Dictionary());
+	if (!joypad_enabled) {
+		return Dictionary();
+	}
 	return joy_names[p_device].info;
 }
 
@@ -2455,6 +2502,7 @@ Input::Input() {
 	gravity_enabled = GLOBAL_DEF_RST_BASIC("input_devices/sensors/enable_gravity", false);
 	gyroscope_enabled = GLOBAL_DEF_RST_BASIC("input_devices/sensors/enable_gyroscope", false);
 	magnetometer_enabled = GLOBAL_DEF_RST_BASIC("input_devices/sensors/enable_magnetometer", false);
+	joypad_enabled = GLOBAL_DEF_BASIC("input_devices/joypads/joypad_enabled", true);
 	ignore_joypad_on_unfocused_application = GLOBAL_DEF_RST_BASIC("input_devices/joypads/ignore_joypad_on_unfocused_application", false);
 }
 

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1691,27 +1691,22 @@ bool Input::is_using_accumulated_input() {
 
 void Input::set_joypad_enabled(bool p_enable) {
 	joypad_enabled = p_enable;
-	if (!joypad_enabled) {
+	if (_should_ignore_joypad_events()) {
 		release_pressed_events();
 	}
 }
 
-bool Input::is_joypad_enabled() {
+bool Input::is_joypad_enabled() const {
 	return joypad_enabled;
 }
 
 void Input::release_pressed_events() {
-	// Don't release the events if the application (or the window it's embedded in) is still focused.
-	if (application_focused || embedder_focused) {
-		return;
-	}
-
 	flush_buffered_events(); // this is needed to release actions strengths
 
 	keys_pressed.clear();
 	physical_keys_pressed.clear();
 	key_label_pressed.clear();
-	if (!joypad_enabled || ignore_joypad_on_unfocused_application) {
+	if (_should_ignore_joypad_events()) {
 		joy_buttons_pressed.clear();
 		_joy_axis.clear();
 

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -203,8 +203,10 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("parse_input_event", "event"), &Input::parse_input_event);
 	ClassDB::bind_method(D_METHOD("set_use_accumulated_input", "enable"), &Input::set_use_accumulated_input);
 	ClassDB::bind_method(D_METHOD("is_using_accumulated_input"), &Input::is_using_accumulated_input);
-	ClassDB::bind_method(D_METHOD("set_joypad_enabled", "enable"), &Input::set_joypad_enabled);
-	ClassDB::bind_method(D_METHOD("is_joypad_enabled"), &Input::is_joypad_enabled);
+	ClassDB::bind_method(D_METHOD("set_joypads_enabled", "enable"), &Input::set_joypads_enabled);
+	ClassDB::bind_method(D_METHOD("set_joypad_device_enabled", "device", "enable"), &Input::set_joypad_device_enabled);
+	ClassDB::bind_method(D_METHOD("are_joypads_enabled"), &Input::are_joypads_enabled);
+	ClassDB::bind_method(D_METHOD("is_joypad_enabled", "device"), &Input::is_joypad_enabled);
 	ClassDB::bind_method(D_METHOD("flush_buffered_events"), &Input::flush_buffered_events);
 	ClassDB::bind_method(D_METHOD("set_emulate_mouse_from_touch", "enable"), &Input::set_emulate_mouse_from_touch);
 	ClassDB::bind_method(D_METHOD("is_emulating_mouse_from_touch"), &Input::is_emulating_mouse_from_touch);
@@ -213,7 +215,7 @@ void Input::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_mode"), "set_mouse_mode", "get_mouse_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_accumulated_input"), "set_use_accumulated_input", "is_using_accumulated_input");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "joypad_enabled"), "set_joypad_enabled", "is_joypad_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "joypads_enabled"), "set_joypads_enabled", "are_joypads_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emulate_mouse_from_touch"), "set_emulate_mouse_from_touch", "is_emulating_mouse_from_touch");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emulate_touch_from_mouse"), "set_emulate_touch_from_mouse", "is_emulating_touch_from_mouse");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_joypad_on_unfocused_application"), "set_ignore_joypad_on_unfocused_application", "is_ignoring_joypad_on_unfocused_application");
@@ -386,8 +388,8 @@ bool Input::is_mouse_button_pressed(MouseButton p_button) const {
 	return mouse_button_mask.has_flag(mouse_button_to_mask(p_button));
 }
 
-bool Input::_should_ignore_joypad_events() const {
-	return !joypad_enabled || (ignore_joypad_on_unfocused_application && !application_focused && !embedder_focused);
+bool Input::_should_ignore_joypad_events(int p_device) const {
+	return !joypads_enabled || is_joypad_enabled(p_device) || (ignore_joypad_on_unfocused_application && !application_focused && !embedder_focused);
 }
 
 static JoyAxis _combine_device(JoyAxis p_value, int p_device) {
@@ -401,7 +403,7 @@ static JoyButton _combine_device(JoyButton p_value, int p_device) {
 bool Input::is_joy_button_pressed(int p_device, JoyButton p_button) const {
 	_THREAD_SAFE_METHOD_
 
-	if (disable_input || !joypad_enabled) {
+	if (disable_input || !joypads_enabled) {
 		return false;
 	}
 
@@ -608,7 +610,7 @@ Vector2 Input::get_vector(const StringName &p_negative_x, const StringName &p_po
 float Input::get_joy_axis(int p_device, JoyAxis p_axis) const {
 	_THREAD_SAFE_METHOD_
 
-	if (disable_input || !joypad_enabled) {
+	if (disable_input || !joypads_enabled) {
 		return 0;
 	}
 
@@ -622,14 +624,14 @@ float Input::get_joy_axis(int p_device, JoyAxis p_axis) const {
 
 String Input::get_joy_name(int p_idx) {
 	_THREAD_SAFE_METHOD_
-	if (!joypad_enabled) {
+	if (!joypads_enabled) {
 		return "";
 	}
 	return joy_names[p_idx].name;
 }
 
 Vector2 Input::get_joy_vibration_strength(int p_device) {
-	if (!joypad_enabled) {
+	if (!joypads_enabled) {
 		return Vector2();
 	}
 	if (joy_vibration.has(p_device)) {
@@ -648,7 +650,7 @@ uint64_t Input::get_joy_vibration_timestamp(int p_device) {
 }
 
 float Input::get_joy_vibration_duration(int p_device) {
-	if (!joypad_enabled) {
+	if (!joypads_enabled) {
 		return 0.0f;
 	}
 	if (joy_vibration.has(p_device)) {
@@ -660,7 +662,7 @@ float Input::get_joy_vibration_duration(int p_device) {
 
 float Input::get_joy_vibration_remaining_duration(int p_device) {
 	_THREAD_SAFE_METHOD_
-	if (!joypad_enabled) {
+	if (!joypads_enabled) {
 		return 0.0f;
 	}
 	const Joypad *joypad = joy_names.getptr(p_device);
@@ -1144,7 +1146,7 @@ void Input::set_joy_features(int p_device, JoypadFeatures *p_features) {
 void Input::set_joy_light(int p_device, const Color &p_color) {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events()) {
+	if (_should_ignore_joypad_events(p_device)) {
 		return;
 	}
 
@@ -1164,7 +1166,7 @@ bool Input::has_joy_light(int p_device) const {
 Vector3 Input::get_joy_accelerometer(int p_device) const {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events()) {
+	if (_should_ignore_joypad_events(p_device)) {
 		return Vector3();
 	}
 
@@ -1187,7 +1189,7 @@ Vector3 Input::get_joy_accelerometer(int p_device) const {
 Vector3 Input::get_joy_gravity(int p_device) const {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events()) {
+	if (_should_ignore_joypad_events(p_device)) {
 		return Vector3();
 	}
 
@@ -1206,7 +1208,7 @@ Vector3 Input::get_joy_gravity(int p_device) const {
 Vector3 Input::get_joy_gyroscope(int p_device) const {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events()) {
+	if (_should_ignore_joypad_events(p_device)) {
 		return Vector3();
 	}
 
@@ -1224,7 +1226,7 @@ Vector3 Input::get_joy_gyroscope(int p_device) const {
 
 void Input::set_joy_motion_sensors_enabled(int p_device, bool p_enable) {
 	_THREAD_SAFE_METHOD_
-	if (!joypad_enabled) {
+	if (!joypads_enabled) {
 		return;
 	}
 	Joypad *joypad = joy_names.getptr(p_device);
@@ -1252,7 +1254,7 @@ bool Input::has_joy_motion_sensors(int p_device) const {
 
 float Input::get_joy_motion_sensors_rate(int p_device) const {
 	_THREAD_SAFE_METHOD_
-	if (!joypad_enabled) {
+	if (!joypads_enabled) {
 		return 0.0f;
 	}
 	const MotionInfo *motion = joy_motion.getptr(p_device);
@@ -1310,7 +1312,7 @@ void Input::clear_joy_motion_sensors_calibration(int p_device) {
 
 Dictionary Input::get_joy_motion_sensors_calibration(int p_device) const {
 	_THREAD_SAFE_METHOD_
-	if (!joypad_enabled) {
+	if (!joypads_enabled) {
 		return Dictionary();
 	}
 	const MotionInfo *motion = joy_motion.getptr(p_device);
@@ -1333,7 +1335,7 @@ Dictionary Input::get_joy_motion_sensors_calibration(int p_device) const {
 
 void Input::set_joy_motion_sensors_calibration(int p_device, const Dictionary &p_calibration_info) {
 	_THREAD_SAFE_METHOD_
-	if (!joypad_enabled) {
+	if (!joypads_enabled) {
 		return;
 	}
 	MotionInfo *motion = joy_motion.getptr(p_device);
@@ -1381,7 +1383,7 @@ void Input::set_joy_motion_sensors_rate(int p_device, float p_rate) {
 void Input::start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration) {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events()) {
+	if (_should_ignore_joypad_events(p_device)) {
 		return;
 	}
 
@@ -1398,7 +1400,7 @@ void Input::start_joy_vibration(int p_device, float p_weak_magnitude, float p_st
 
 void Input::stop_joy_vibration(int p_device) {
 	_THREAD_SAFE_METHOD_
-	if (!joypad_enabled) {
+	if (!joypads_enabled) {
 		return;
 	}
 	VibrationInfo vibration;
@@ -1689,18 +1691,40 @@ bool Input::is_using_accumulated_input() {
 	return use_accumulated_input;
 }
 
-void Input::set_joypad_enabled(bool p_enable) {
-	joypad_enabled = p_enable;
+void Input::set_joypads_enabled(bool p_enable) {
+	joypads_enabled = p_enable;
 	if (_should_ignore_joypad_events()) {
-		release_pressed_events();
+		release_pressed_events(true);
 	}
 }
 
-bool Input::is_joypad_enabled() const {
-	return joypad_enabled;
+void Input::set_joypad_device_enabled(int p_device, bool p_enable) {
+	if (p_enable) {
+		joypads_enabled_state.erase(p_device);
+	} else {
+		joypads_enabled_state.append(p_device);
+	}
+	if (_should_ignore_joypad_events()) {
+		release_pressed_events(true);
+	}
 }
 
-void Input::release_pressed_events() {
+bool Input::are_joypads_enabled() const {
+	return joypads_enabled;
+}
+
+bool Input::is_joypad_enabled(int p_device) const {
+	if (p_device < 0)
+		return true;
+	return joypads_enabled_state.has(p_device);
+}
+
+void Input::release_pressed_events(bool p_force_released) {
+	// Don't release the events if the application (or the window it's embedded in) is still focused.
+	if (!p_force_released && (application_focused || embedder_focused)) {
+		return;
+	}
+
 	flush_buffered_events(); // this is needed to release actions strengths
 
 	keys_pressed.clear();
@@ -1753,7 +1777,7 @@ void Input::set_event_dispatch_function(EventDispatchFunc p_function) {
 void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 	_THREAD_SAFE_METHOD_;
 
-	if (_should_ignore_joypad_events()) {
+	if (_should_ignore_joypad_events(p_device)) {
 		return;
 	}
 
@@ -1785,7 +1809,7 @@ void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 	_THREAD_SAFE_METHOD_;
 
-	if (_should_ignore_joypad_events()) {
+	if (_should_ignore_joypad_events(p_device)) {
 		return;
 	}
 
@@ -1859,7 +1883,7 @@ void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 void Input::joy_hat(int p_device, BitField<HatMask> p_val) {
 	_THREAD_SAFE_METHOD_;
 
-	if (_should_ignore_joypad_events()) {
+	if (_should_ignore_joypad_events(p_device)) {
 		return;
 	}
 
@@ -1906,7 +1930,7 @@ void Input::joy_hat(int p_device, BitField<HatMask> p_val) {
 void Input::joy_motion_sensors(int p_device, const Vector3 &p_accelerometer, const Vector3 &p_gyroscope) {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events()) {
+	if (_should_ignore_joypad_events(p_device)) {
 		return;
 	}
 
@@ -1927,7 +1951,7 @@ void Input::joy_motion_sensors(int p_device, const Vector3 &p_accelerometer, con
 void Input::joy_touchpad(int p_device, int p_touchpad, int p_finger, const Vector2 &p_position, float p_pressure, bool p_pressed) {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events()) {
+	if (_should_ignore_joypad_events(p_device)) {
 		return;
 	}
 
@@ -2395,7 +2419,7 @@ bool Input::is_joy_known(int p_device) {
 
 String Input::get_joy_guid(int p_device) const {
 	ERR_FAIL_COND_V(!joy_names.has(p_device), "");
-	if (!joypad_enabled) {
+	if (!joypads_enabled) {
 		return "";
 	}
 	return joy_names[p_device].uid;
@@ -2403,7 +2427,7 @@ String Input::get_joy_guid(int p_device) const {
 
 Dictionary Input::get_joy_info(int p_device) const {
 	ERR_FAIL_COND_V(!joy_names.has(p_device), Dictionary());
-	if (!joypad_enabled) {
+	if (!joypads_enabled) {
 		return Dictionary();
 	}
 	return joy_names[p_device].info;
@@ -2497,7 +2521,7 @@ Input::Input() {
 	gravity_enabled = GLOBAL_DEF_RST_BASIC("input_devices/sensors/enable_gravity", false);
 	gyroscope_enabled = GLOBAL_DEF_RST_BASIC("input_devices/sensors/enable_gyroscope", false);
 	magnetometer_enabled = GLOBAL_DEF_RST_BASIC("input_devices/sensors/enable_magnetometer", false);
-	joypad_enabled = GLOBAL_DEF_BASIC("input_devices/joypads/joypad_enabled", true);
+	joypads_enabled = GLOBAL_DEF_BASIC("input_devices/joypads/joypad_enabled", true);
 	ignore_joypad_on_unfocused_application = GLOBAL_DEF_RST_BASIC("input_devices/joypads/ignore_joypad_on_unfocused_application", false);
 }
 

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1692,7 +1692,7 @@ bool Input::is_using_accumulated_input() {
 void Input::set_joypad_enabled(bool p_enable) {
 	joypad_enabled = p_enable;
 	if (_should_ignore_joypad_events()) {
-		release_pressed_events();
+		release_pressed_events(true);
 	}
 }
 
@@ -1700,7 +1700,12 @@ bool Input::is_joypad_enabled() const {
 	return joypad_enabled;
 }
 
-void Input::release_pressed_events() {
+void Input::release_pressed_events(bool p_force_released) {
+	// Don't release the events if the application (or the window it's embedded in) is still focused.
+	if (!p_force_released && (application_focused || embedder_focused)) {
+		return;
+	}
+
 	flush_buffered_events(); // this is needed to release actions strengths
 
 	keys_pressed.clear();

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -203,10 +203,8 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("parse_input_event", "event"), &Input::parse_input_event);
 	ClassDB::bind_method(D_METHOD("set_use_accumulated_input", "enable"), &Input::set_use_accumulated_input);
 	ClassDB::bind_method(D_METHOD("is_using_accumulated_input"), &Input::is_using_accumulated_input);
-	ClassDB::bind_method(D_METHOD("set_joypads_enabled", "enable"), &Input::set_joypads_enabled);
-	ClassDB::bind_method(D_METHOD("set_joypad_device_enabled", "device", "enable"), &Input::set_joypad_device_enabled);
-	ClassDB::bind_method(D_METHOD("are_joypads_enabled"), &Input::are_joypads_enabled);
-	ClassDB::bind_method(D_METHOD("is_joypad_enabled", "device"), &Input::is_joypad_enabled);
+	ClassDB::bind_method(D_METHOD("set_joypad_enabled", "enable"), &Input::set_joypad_enabled);
+	ClassDB::bind_method(D_METHOD("is_joypad_enabled"), &Input::is_joypad_enabled);
 	ClassDB::bind_method(D_METHOD("flush_buffered_events"), &Input::flush_buffered_events);
 	ClassDB::bind_method(D_METHOD("set_emulate_mouse_from_touch", "enable"), &Input::set_emulate_mouse_from_touch);
 	ClassDB::bind_method(D_METHOD("is_emulating_mouse_from_touch"), &Input::is_emulating_mouse_from_touch);
@@ -215,7 +213,7 @@ void Input::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_mode"), "set_mouse_mode", "get_mouse_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_accumulated_input"), "set_use_accumulated_input", "is_using_accumulated_input");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "joypads_enabled"), "set_joypads_enabled", "are_joypads_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "joypad_enabled"), "set_joypad_enabled", "is_joypad_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emulate_mouse_from_touch"), "set_emulate_mouse_from_touch", "is_emulating_mouse_from_touch");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emulate_touch_from_mouse"), "set_emulate_touch_from_mouse", "is_emulating_touch_from_mouse");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_joypad_on_unfocused_application"), "set_ignore_joypad_on_unfocused_application", "is_ignoring_joypad_on_unfocused_application");
@@ -388,8 +386,8 @@ bool Input::is_mouse_button_pressed(MouseButton p_button) const {
 	return mouse_button_mask.has_flag(mouse_button_to_mask(p_button));
 }
 
-bool Input::_should_ignore_joypad_events(int p_device) const {
-	return !joypads_enabled || is_joypad_enabled(p_device) || (ignore_joypad_on_unfocused_application && !application_focused && !embedder_focused);
+bool Input::_should_ignore_joypad_events() const {
+	return !joypad_enabled || (ignore_joypad_on_unfocused_application && !application_focused && !embedder_focused);
 }
 
 static JoyAxis _combine_device(JoyAxis p_value, int p_device) {
@@ -403,7 +401,7 @@ static JoyButton _combine_device(JoyButton p_value, int p_device) {
 bool Input::is_joy_button_pressed(int p_device, JoyButton p_button) const {
 	_THREAD_SAFE_METHOD_
 
-	if (disable_input || !joypads_enabled) {
+	if (disable_input || !joypad_enabled) {
 		return false;
 	}
 
@@ -610,7 +608,7 @@ Vector2 Input::get_vector(const StringName &p_negative_x, const StringName &p_po
 float Input::get_joy_axis(int p_device, JoyAxis p_axis) const {
 	_THREAD_SAFE_METHOD_
 
-	if (disable_input || !joypads_enabled) {
+	if (disable_input || !joypad_enabled) {
 		return 0;
 	}
 
@@ -624,14 +622,14 @@ float Input::get_joy_axis(int p_device, JoyAxis p_axis) const {
 
 String Input::get_joy_name(int p_idx) {
 	_THREAD_SAFE_METHOD_
-	if (!joypads_enabled) {
+	if (!joypad_enabled) {
 		return "";
 	}
 	return joy_names[p_idx].name;
 }
 
 Vector2 Input::get_joy_vibration_strength(int p_device) {
-	if (!joypads_enabled) {
+	if (!joypad_enabled) {
 		return Vector2();
 	}
 	if (joy_vibration.has(p_device)) {
@@ -650,7 +648,7 @@ uint64_t Input::get_joy_vibration_timestamp(int p_device) {
 }
 
 float Input::get_joy_vibration_duration(int p_device) {
-	if (!joypads_enabled) {
+	if (!joypad_enabled) {
 		return 0.0f;
 	}
 	if (joy_vibration.has(p_device)) {
@@ -662,7 +660,7 @@ float Input::get_joy_vibration_duration(int p_device) {
 
 float Input::get_joy_vibration_remaining_duration(int p_device) {
 	_THREAD_SAFE_METHOD_
-	if (!joypads_enabled) {
+	if (!joypad_enabled) {
 		return 0.0f;
 	}
 	const Joypad *joypad = joy_names.getptr(p_device);
@@ -1146,7 +1144,7 @@ void Input::set_joy_features(int p_device, JoypadFeatures *p_features) {
 void Input::set_joy_light(int p_device, const Color &p_color) {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events(p_device)) {
+	if (_should_ignore_joypad_events()) {
 		return;
 	}
 
@@ -1166,7 +1164,7 @@ bool Input::has_joy_light(int p_device) const {
 Vector3 Input::get_joy_accelerometer(int p_device) const {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events(p_device)) {
+	if (_should_ignore_joypad_events()) {
 		return Vector3();
 	}
 
@@ -1189,7 +1187,7 @@ Vector3 Input::get_joy_accelerometer(int p_device) const {
 Vector3 Input::get_joy_gravity(int p_device) const {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events(p_device)) {
+	if (_should_ignore_joypad_events()) {
 		return Vector3();
 	}
 
@@ -1208,7 +1206,7 @@ Vector3 Input::get_joy_gravity(int p_device) const {
 Vector3 Input::get_joy_gyroscope(int p_device) const {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events(p_device)) {
+	if (_should_ignore_joypad_events()) {
 		return Vector3();
 	}
 
@@ -1226,7 +1224,7 @@ Vector3 Input::get_joy_gyroscope(int p_device) const {
 
 void Input::set_joy_motion_sensors_enabled(int p_device, bool p_enable) {
 	_THREAD_SAFE_METHOD_
-	if (!joypads_enabled) {
+	if (!joypad_enabled) {
 		return;
 	}
 	Joypad *joypad = joy_names.getptr(p_device);
@@ -1254,7 +1252,7 @@ bool Input::has_joy_motion_sensors(int p_device) const {
 
 float Input::get_joy_motion_sensors_rate(int p_device) const {
 	_THREAD_SAFE_METHOD_
-	if (!joypads_enabled) {
+	if (!joypad_enabled) {
 		return 0.0f;
 	}
 	const MotionInfo *motion = joy_motion.getptr(p_device);
@@ -1312,7 +1310,7 @@ void Input::clear_joy_motion_sensors_calibration(int p_device) {
 
 Dictionary Input::get_joy_motion_sensors_calibration(int p_device) const {
 	_THREAD_SAFE_METHOD_
-	if (!joypads_enabled) {
+	if (!joypad_enabled) {
 		return Dictionary();
 	}
 	const MotionInfo *motion = joy_motion.getptr(p_device);
@@ -1335,7 +1333,7 @@ Dictionary Input::get_joy_motion_sensors_calibration(int p_device) const {
 
 void Input::set_joy_motion_sensors_calibration(int p_device, const Dictionary &p_calibration_info) {
 	_THREAD_SAFE_METHOD_
-	if (!joypads_enabled) {
+	if (!joypad_enabled) {
 		return;
 	}
 	MotionInfo *motion = joy_motion.getptr(p_device);
@@ -1383,7 +1381,7 @@ void Input::set_joy_motion_sensors_rate(int p_device, float p_rate) {
 void Input::start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration) {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events(p_device)) {
+	if (_should_ignore_joypad_events()) {
 		return;
 	}
 
@@ -1400,7 +1398,7 @@ void Input::start_joy_vibration(int p_device, float p_weak_magnitude, float p_st
 
 void Input::stop_joy_vibration(int p_device) {
 	_THREAD_SAFE_METHOD_
-	if (!joypads_enabled) {
+	if (!joypad_enabled) {
 		return;
 	}
 	VibrationInfo vibration;
@@ -1691,40 +1689,18 @@ bool Input::is_using_accumulated_input() {
 	return use_accumulated_input;
 }
 
-void Input::set_joypads_enabled(bool p_enable) {
-	joypads_enabled = p_enable;
+void Input::set_joypad_enabled(bool p_enable) {
+	joypad_enabled = p_enable;
 	if (_should_ignore_joypad_events()) {
-		release_pressed_events(true);
+		release_pressed_events();
 	}
 }
 
-void Input::set_joypad_device_enabled(int p_device, bool p_enable) {
-	if (p_enable) {
-		joypads_enabled_state.erase(p_device);
-	} else {
-		joypads_enabled_state.append(p_device);
-	}
-	if (_should_ignore_joypad_events()) {
-		release_pressed_events(true);
-	}
+bool Input::is_joypad_enabled() const {
+	return joypad_enabled;
 }
 
-bool Input::are_joypads_enabled() const {
-	return joypads_enabled;
-}
-
-bool Input::is_joypad_enabled(int p_device) const {
-	if (p_device < 0)
-		return true;
-	return joypads_enabled_state.has(p_device);
-}
-
-void Input::release_pressed_events(bool p_force_released) {
-	// Don't release the events if the application (or the window it's embedded in) is still focused.
-	if (!p_force_released && (application_focused || embedder_focused)) {
-		return;
-	}
-
+void Input::release_pressed_events() {
 	flush_buffered_events(); // this is needed to release actions strengths
 
 	keys_pressed.clear();
@@ -1777,7 +1753,7 @@ void Input::set_event_dispatch_function(EventDispatchFunc p_function) {
 void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 	_THREAD_SAFE_METHOD_;
 
-	if (_should_ignore_joypad_events(p_device)) {
+	if (_should_ignore_joypad_events()) {
 		return;
 	}
 
@@ -1809,7 +1785,7 @@ void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 	_THREAD_SAFE_METHOD_;
 
-	if (_should_ignore_joypad_events(p_device)) {
+	if (_should_ignore_joypad_events()) {
 		return;
 	}
 
@@ -1883,7 +1859,7 @@ void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 void Input::joy_hat(int p_device, BitField<HatMask> p_val) {
 	_THREAD_SAFE_METHOD_;
 
-	if (_should_ignore_joypad_events(p_device)) {
+	if (_should_ignore_joypad_events()) {
 		return;
 	}
 
@@ -1930,7 +1906,7 @@ void Input::joy_hat(int p_device, BitField<HatMask> p_val) {
 void Input::joy_motion_sensors(int p_device, const Vector3 &p_accelerometer, const Vector3 &p_gyroscope) {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events(p_device)) {
+	if (_should_ignore_joypad_events()) {
 		return;
 	}
 
@@ -1951,7 +1927,7 @@ void Input::joy_motion_sensors(int p_device, const Vector3 &p_accelerometer, con
 void Input::joy_touchpad(int p_device, int p_touchpad, int p_finger, const Vector2 &p_position, float p_pressure, bool p_pressed) {
 	_THREAD_SAFE_METHOD_
 
-	if (_should_ignore_joypad_events(p_device)) {
+	if (_should_ignore_joypad_events()) {
 		return;
 	}
 
@@ -2419,7 +2395,7 @@ bool Input::is_joy_known(int p_device) {
 
 String Input::get_joy_guid(int p_device) const {
 	ERR_FAIL_COND_V(!joy_names.has(p_device), "");
-	if (!joypads_enabled) {
+	if (!joypad_enabled) {
 		return "";
 	}
 	return joy_names[p_device].uid;
@@ -2427,7 +2403,7 @@ String Input::get_joy_guid(int p_device) const {
 
 Dictionary Input::get_joy_info(int p_device) const {
 	ERR_FAIL_COND_V(!joy_names.has(p_device), Dictionary());
-	if (!joypads_enabled) {
+	if (!joypad_enabled) {
 		return Dictionary();
 	}
 	return joy_names[p_device].info;
@@ -2521,7 +2497,7 @@ Input::Input() {
 	gravity_enabled = GLOBAL_DEF_RST_BASIC("input_devices/sensors/enable_gravity", false);
 	gyroscope_enabled = GLOBAL_DEF_RST_BASIC("input_devices/sensors/enable_gyroscope", false);
 	magnetometer_enabled = GLOBAL_DEF_RST_BASIC("input_devices/sensors/enable_magnetometer", false);
-	joypads_enabled = GLOBAL_DEF_BASIC("input_devices/joypads/joypad_enabled", true);
+	joypad_enabled = GLOBAL_DEF_BASIC("input_devices/joypads/joypad_enabled", true);
 	ignore_joypad_on_unfocused_application = GLOBAL_DEF_RST_BASIC("input_devices/joypads/ignore_joypad_on_unfocused_application", false);
 }
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -165,6 +165,7 @@ private:
 	bool emulate_mouse_from_touch = false;
 	bool agile_input_event_flushing = false;
 	bool use_accumulated_input = true;
+	bool joypad_enabled = true;
 
 	int mouse_from_touch_index = -1;
 
@@ -498,6 +499,8 @@ public:
 	void set_agile_input_event_flushing(bool p_enable);
 	void set_use_accumulated_input(bool p_enable);
 	bool is_using_accumulated_input();
+	void set_joypad_enabled(bool p_enable);
+	bool is_joypad_enabled();
 
 	void release_pressed_events();
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -500,7 +500,7 @@ public:
 	void set_use_accumulated_input(bool p_enable);
 	bool is_using_accumulated_input();
 	void set_joypad_enabled(bool p_enable);
-	bool is_joypad_enabled();
+	bool is_joypad_enabled() const;
 
 	void release_pressed_events();
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -165,7 +165,9 @@ private:
 	bool emulate_mouse_from_touch = false;
 	bool agile_input_event_flushing = false;
 	bool use_accumulated_input = true;
-	bool joypad_enabled = true;
+	bool joypads_enabled = true;
+
+	TypedArray<int> joypads_enabled_state;
 
 	int mouse_from_touch_index = -1;
 
@@ -342,7 +344,7 @@ private:
 
 	EventDispatchFunc event_dispatch_function = nullptr;
 
-	bool _should_ignore_joypad_events() const;
+	bool _should_ignore_joypad_events(int p_device = -1) const;
 
 #ifndef DISABLE_DEPRECATED
 	void _vibrate_handheld_bind_compat_91143(int p_duration_ms = 500);
@@ -499,10 +501,12 @@ public:
 	void set_agile_input_event_flushing(bool p_enable);
 	void set_use_accumulated_input(bool p_enable);
 	bool is_using_accumulated_input();
-	void set_joypad_enabled(bool p_enable);
-	bool is_joypad_enabled() const;
+	void set_joypads_enabled(bool p_enable);
+	void set_joypad_device_enabled(int p_device, bool p_enable);
+	bool are_joypads_enabled() const;
+	bool is_joypad_enabled(int p_device) const;
 
-	void release_pressed_events();
+	void release_pressed_events(bool p_force_released = false);
 
 	void set_event_dispatch_function(EventDispatchFunc p_function);
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -502,7 +502,7 @@ public:
 	void set_joypad_enabled(bool p_enable);
 	bool is_joypad_enabled() const;
 
-	void release_pressed_events();
+	void release_pressed_events(bool p_force_released = false);
 
 	void set_event_dispatch_function(EventDispatchFunc p_function);
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -165,9 +165,7 @@ private:
 	bool emulate_mouse_from_touch = false;
 	bool agile_input_event_flushing = false;
 	bool use_accumulated_input = true;
-	bool joypads_enabled = true;
-
-	TypedArray<int> joypads_enabled_state;
+	bool joypad_enabled = true;
 
 	int mouse_from_touch_index = -1;
 
@@ -344,7 +342,7 @@ private:
 
 	EventDispatchFunc event_dispatch_function = nullptr;
 
-	bool _should_ignore_joypad_events(int p_device = -1) const;
+	bool _should_ignore_joypad_events() const;
 
 #ifndef DISABLE_DEPRECATED
 	void _vibrate_handheld_bind_compat_91143(int p_duration_ms = 500);
@@ -501,12 +499,10 @@ public:
 	void set_agile_input_event_flushing(bool p_enable);
 	void set_use_accumulated_input(bool p_enable);
 	bool is_using_accumulated_input();
-	void set_joypads_enabled(bool p_enable);
-	void set_joypad_device_enabled(int p_device, bool p_enable);
-	bool are_joypads_enabled() const;
-	bool is_joypad_enabled(int p_device) const;
+	void set_joypad_enabled(bool p_enable);
+	bool is_joypad_enabled() const;
 
-	void release_pressed_events(bool p_force_released = false);
+	void release_pressed_events();
 
 	void set_event_dispatch_function(EventDispatchFunc p_function);
 

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -879,6 +879,11 @@
 		<member name="ignore_joypad_on_unfocused_application" type="bool" setter="set_ignore_joypad_on_unfocused_application" getter="is_ignoring_joypad_on_unfocused_application">
 			If [code]true[/code], joypad input (including motion sensors) and LED light changes will be ignored and joypad vibration will be stopped when the application is not focused.
 		</member>
+		<member name="joypad_enabled" type="bool" setter="set_joypad_enabled" getter="is_joypad_enabled">
+			If [code]true[/code], enables joypad input events and allows the use of joypad-related functions such as [method Input.is_joy_button_pressed], [method Input.get_joy_axis], [method Input.start_joy_vibration], and [method Input.stop_joy_vibration].
+			See also [member ProjectSettings.input_devices/joypads/joypad_enabled].
+			[b]Note:[/b] Regardless of this property, Godot always detects how many joypads are connected (see [method get_connected_joypads]).
+		</member>
 		<member name="mouse_mode" type="int" setter="set_mouse_mode" getter="get_mouse_mode" enum="Input.MouseMode">
 			Controls the mouse mode.
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1678,6 +1678,13 @@
 		<member name="input_devices/joypads/ignore_joypad_on_unfocused_application" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], joypad input (including motion sensors) and LED light changes will be ignored and joypad vibration will be stopped when the application is not focused.
 		</member>
+		<member name="input_devices/joypads/joypad_enabled" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], enables joypad input events and allows the use of joypad-related functions such as [method Input.is_joy_button_pressed], [method Input.get_joy_axis], [method Input.start_joy_vibration], and [method Input.stop_joy_vibration].
+			This also affects [method Input.is_action_just_pressed], [method Input.is_action_just_released], and [method Input.is_action_pressed].
+			To control this at runtime, use [member Input.joypad_enabled].
+			[b]Note:[/b] Regardless of this property, Godot always detects how many joypads are connected (see [method Input.get_connected_joypads]).
+			[b]Note:[/b] You can also disable the joypad by using the [code]--disable-joypad[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url].
+		</member>
 		<member name="input_devices/pen_tablet/driver" type="String" setter="" getter="">
 			Specifies the tablet driver to use. If left empty, the default driver will be used.
 			[b]Note:[/b] The driver in use can be overridden at runtime via the [code]--tablet-driver[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url].

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1543,6 +1543,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			}
 		} else if (arg == "--single-threaded-scene") {
 			single_threaded_scene = true;
+		} else if (arg == "--disable-joypad") {
+			GLOBAL_DEF_BASIC("input_devices/joypads/joypad_enabled", false);
 		} else if (arg == "--build-solutions") { // Build the scripting solution such C#
 
 			auto_build_solutions = true;


### PR DESCRIPTION
Fixes: godotengine/godot-proposals/issues/12259

https://github.com/user-attachments/assets/7bd2cbcf-f487-496d-805b-8b0101d69046

- *Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/8391 and supersedes https://github.com/godotengine/godot/pull/84848
