### PR TITLE
Add external custom modules in vcxproj

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -990,6 +990,15 @@ def generate_vs_project(env, original_args, project_name="godot"):
         results += r
         return results
 
+    def glob_current_and_custom(pattern, dirs):
+        paths = ["."]
+        if env["custom_modules"]:
+            paths = paths + env["custom_modules"].split(",")
+        results = []
+        for p in paths:
+            results = results + glob_recursive_2(pattern, dirs, p)
+        return results
+
     def get_bool(args, option, default):
         from SCons.Variables.BoolVariable import _text2bool
 
@@ -1120,19 +1129,19 @@ def generate_vs_project(env, original_args, project_name="godot"):
     headers = []
     headers_dirs = []
     for ext in extensions["headers"]:
-        for file in glob_recursive_2("*" + ext, headers_dirs):
+        for file in glob_current_and_custom("*" + ext, headers_dirs):
             headers.append(str(file).replace("/", "\\"))
 
     sources = []
     sources_dirs = []
     for ext in extensions["sources"]:
-        for file in glob_recursive_2("*" + ext, sources_dirs):
+        for file in glob_current_and_custom("*" + ext, sources_dirs):
             sources.append(str(file).replace("/", "\\"))
 
     others = []
     others_dirs = []
     for ext in extensions["others"]:
-        for file in glob_recursive_2("*" + ext, others_dirs):
+        for file in glob_current_and_custom("*" + ext, others_dirs):
             others.append(str(file).replace("/", "\\"))
 
     skip_filters = False
@@ -1214,7 +1223,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
     set_sources = set(sources_active)
     set_others = set(others_active)
     for file in headers:
-        base_path = os.path.dirname(file).replace("\\", "_")
+        base_path = os.path.dirname(file).replace("\\", "_").replace(":", "")
         all_items.append(f'<ClInclude Include="{file}">')
         all_items.append(
             f"  <ExcludedFromBuild Condition=\"!$(ActiveProjectItemList_{base_path}.Contains(';{file};'))\">true</ExcludedFromBuild>"
@@ -1224,7 +1233,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
             activeItems.append(file)
 
     for file in sources:
-        base_path = os.path.dirname(file).replace("\\", "_")
+        base_path = os.path.dirname(file).replace("\\", "_").replace(":", "")
         all_items.append(f'<ClCompile Include="{file}">')
         all_items.append(
             f"  <ExcludedFromBuild Condition=\"!$(ActiveProjectItemList_{base_path}.Contains(';{file};'))\">true</ExcludedFromBuild>"
@@ -1234,7 +1243,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
             activeItems.append(file)
 
     for file in others:
-        base_path = os.path.dirname(file).replace("\\", "_")
+        base_path = os.path.dirname(file).replace("\\", "_").replace(":", "")
         all_items.append(f'<None Include="{file}">')
         all_items.append(
             f"  <ExcludedFromBuild Condition=\"!$(ActiveProjectItemList_{base_path}.Contains(';{file};'))\">true</ExcludedFromBuild>"
@@ -1253,7 +1262,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
         condition = "'$(GodotConfiguration)|$(GodotPlatform)'=='" + vsconf + "'"
         itemlist = {}
         for item in activeItems:
-            key = os.path.dirname(item).replace("\\", "_")
+            key = os.path.dirname(item).replace("\\", "_").replace(":", "")
             if key not in itemlist:
                 itemlist[key] = [item]
             else:


### PR DESCRIPTION
This adds external custom modules to vcxproj generation. Without this, the files are not added to the project and cannot be easily browsed and edited, although they will compile and link correctly.

Because external custom modules use full paths, I also had to strip the ":" character from the exclude patterns, which VS does not support.
I.e. for example without the additional fix you'd get:
<ExcludedFromBuild Condition="!$(ActiveProjectItemList_D:_code_modules_procedural.Contains(...
instead of
<ExcludedFromBuild Condition="!$(ActiveProjectItemList_D_code_modules_procedural.Contains(...