### PR TITLE
Editor: Add some gizmo handles for `MeshInstance3D`

### DIFF
--- a/editor/scene/3d/gizmos/gizmo_3d_helper.h
+++ b/editor/scene/3d/gizmos/gizmo_3d_helper.h
@@ -42,7 +42,8 @@ class Gizmo3DHelper : public RefCounted {
 	Transform3D initial_transform;
 
 private:
-	void _cylinder_or_capsule_set_handle(const Vector3 p_segment[2], int p_id, real_t &r_height, real_t &r_radius, Vector3 &r_cylinder_position, bool p_is_capsule);
+	void _cylinder_or_capsule_or_cone_frustum_set_handle(const Vector3 p_segment[2], int p_id, real_t &r_height, real_t &r_radius_top, real_t &r_radius_bottom, Vector3 &r_position, bool p_is_capsule, bool p_is_frustum);
+	String _cylinder_or_capsule_or_cone_frustum_get_handle_name(int p_id) const;
 
 public:
 	/**
@@ -51,6 +52,7 @@ public:
 	 * Depending on the type of gizmo that will be used, different formats for the `p_initial_value` are required:
 	 * Box: The size of the box as `Vector3`
 	 * Cylinder or Capsule: A `Vector2` of the form `Vector2(radius, height)`
+	 * Cone frustum: A `Vector3` of the form `Vector3(radius_top, radius_bottom, height)`
 	 */
 	void initialize_handle_action(const Variant &p_initial_value, const Transform3D &p_initial_transform);
 	void get_segment(Camera3D *p_camera, const Point2 &p_point, Vector3 *r_segment);
@@ -65,20 +67,31 @@ public:
 	// Cylinder
 
 	Vector<Vector3> cylinder_get_handles(real_t p_height, real_t p_radius);
-	String cylinder_get_handle_name(int p_id) const;
+	_FORCE_INLINE_ String cylinder_get_handle_name(int p_id) { return _cylinder_or_capsule_or_cone_frustum_get_handle_name(p_id); }
 	_FORCE_INLINE_ void cylinder_set_handle(const Vector3 p_segment[2], int p_id, real_t &r_height, real_t &r_radius, Vector3 &r_cylinder_position) {
-		_cylinder_or_capsule_set_handle(p_segment, p_id, r_height, r_radius, r_cylinder_position, false);
+		real_t radius_bottom;
+		_cylinder_or_capsule_or_cone_frustum_set_handle(p_segment, p_id, r_height, r_radius, radius_bottom, r_cylinder_position, false, false);
 	}
 	void cylinder_commit_handle(int p_id, const String &p_radius_action_name, const String &p_height_action_name, bool p_cancel, Object *p_position_object, Object *p_height_object = nullptr, Object *p_radius_object = nullptr, const StringName &p_position_property = "global_position", const StringName &p_height_property = "height", const StringName &p_radius_property = "radius");
 
 	// Capsule
 
 	_FORCE_INLINE_ Vector<Vector3> capsule_get_handles(real_t p_height, real_t p_radius) { return cylinder_get_handles(p_height, p_radius); }
-	_FORCE_INLINE_ String capsule_get_handle_name(int p_id) { return cylinder_get_handle_name(p_id); }
+	_FORCE_INLINE_ String capsule_get_handle_name(int p_id) { return _cylinder_or_capsule_or_cone_frustum_get_handle_name(p_id); }
 	_FORCE_INLINE_ void capsule_set_handle(const Vector3 p_segment[2], int p_id, real_t &r_height, real_t &r_radius, Vector3 &r_capsule_position) {
-		_cylinder_or_capsule_set_handle(p_segment, p_id, r_height, r_radius, r_capsule_position, true);
+		real_t radius_bottom;
+		_cylinder_or_capsule_or_cone_frustum_set_handle(p_segment, p_id, r_height, r_radius, radius_bottom, r_capsule_position, true, false);
 	}
 	_FORCE_INLINE_ void capsule_commit_handle(int p_id, const String &p_radius_action_name, const String &p_height_action_name, bool p_cancel, Object *p_position_object, Object *p_height_object = nullptr, Object *p_radius_object = nullptr, const StringName &p_position_property = "global_position", const StringName &p_height_property = "height", const StringName &p_radius_property = "radius") {
 		cylinder_commit_handle(p_id, p_radius_action_name, p_height_action_name, p_cancel, p_position_object, p_height_object, p_radius_object, p_position_property, p_height_property, p_radius_property);
 	}
+
+	// Cone frustum
+
+	Vector<Vector3> cone_frustum_get_handles(real_t p_height, real_t p_radius_top, real_t p_radius_bottom);
+	_FORCE_INLINE_ String cone_frustum_get_handle_name(int p_id) { return _cylinder_or_capsule_or_cone_frustum_get_handle_name(p_id); }
+	_FORCE_INLINE_ void cone_frustum_set_handle(const Vector3 p_segment[2], int p_id, real_t &r_height, real_t &r_radius_top, real_t &r_radius_bottom, Vector3 &r_frustum_position) {
+		_cylinder_or_capsule_or_cone_frustum_set_handle(p_segment, p_id, r_height, r_radius_top, r_radius_bottom, r_frustum_position, false, true);
+	}
+	void cone_frustum_commit_handle(int p_id, const String &p_radius_action_name, const String &p_height_action_name, bool p_cancel, Object *p_position_object, Object *p_height_object = nullptr, Object *p_radius_top_object = nullptr, Object *p_radius_bottom_object = nullptr, const StringName &p_position_property = "global_position", const StringName &p_height_property = "height", const StringName &p_radius_top_property = "top_radius", const StringName &p_radius_bottom_property = "bottom_radius");
 };

--- a/editor/scene/3d/gizmos/mesh_instance_3d_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/mesh_instance_3d_gizmo_plugin.h
@@ -30,10 +30,13 @@
 
 #pragma once
 
+#include "editor/scene/3d/gizmos/gizmo_3d_helper.h"
 #include "editor/scene/3d/node_3d_editor_gizmos.h"
 
 class MeshInstance3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(MeshInstance3DGizmoPlugin, EditorNode3DGizmoPlugin);
+
+	Ref<Gizmo3DHelper> helper;
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
@@ -41,4 +44,15 @@ public:
 	int get_priority() const override;
 	bool can_be_hidden() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
+
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const override;
+	void begin_handle_action(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, Camera3D *p_camera, const Point2 &p_point) override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel = false) override;
+
+	MeshInstance3DGizmoPlugin() {
+		helper.instantiate();
+		create_handle_material("handles");
+	}
 };


### PR DESCRIPTION
Adds gizmos handles for boxes, cylinders and capsules to `MeshInstance3D`:

https://github.com/user-attachments/assets/9d02c9b4-4124-421a-9a30-9ed31e3198d4

Since cylinder meshes have a split radius for top and bottom this PR adds a new handle behavior to `GizmoHelper3D` called cone frustum. I was considering adding handles for top and bottom radius as well, but I didn't find a good way to handle overlap with the height handles when dragging them very small, so this behavior only features one handle to move the middle point as seen in the video.

