### PR TITLE
Add [br] to bbcode parsing for `rich_text_label`

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -5412,6 +5412,9 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 			push_language(lang);
 			pos = brk_end + 1;
 			tag_stack.push_front("lang");
+		} else if (tag == "br") {
+			add_text("\r");
+			pos = brk_end + 1;
 		} else if (tag == "p") {
 			push_paragraph(HORIZONTAL_ALIGNMENT_LEFT);
 			pos = brk_end + 1;


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/105520
``` cpp
else if (tag == "br") {
    add_text("\r");
    pos = brk_end + 1;
}
```

![image](https://github.com/user-attachments/assets/c14a8697-1af3-4f3a-832a-a4cef7424b3b)
