### PR TITLE
Fix crash in `Node::add_sibling` due to missing checks

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1722,12 +1722,19 @@ void Node::add_child(RequiredParam<Node> rp_child, bool p_force_readable_name, I
 
 void Node::add_sibling(RequiredParam<Node> rp_sibling, bool p_force_readable_name) {
 	ERR_FAIL_COND_MSG(data.tree && !Thread::is_main_thread(), "Adding a sibling to a node inside the SceneTree is only allowed from the main thread. Use call_deferred(\"add_sibling\",node).");
+	ERR_THREAD_GUARD
 	EXTRACT_PARAM_OR_FAIL(p_sibling, rp_sibling);
 	ERR_FAIL_COND_MSG(p_sibling == this, vformat("Can't add sibling '%s' to itself.", p_sibling->get_name())); // adding to itself!
+	ERR_FAIL_COND_MSG(p_sibling->data.parent, vformat("Can't add sibling '%s' to '%s', already has a parent '%s'.", p_sibling->get_name(), get_name(), p_sibling->data.parent->get_name()));
 	ERR_FAIL_NULL(data.parent);
+	ERR_FAIL_COND_MSG(p_sibling == data.parent, vformat("Can't add sibling '%s' to '%s', the sibling '%s' is the parent of '%s'.", p_sibling->get_name(), get_name(), p_sibling->get_name(), get_name()));
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_MSG(p_sibling->is_ancestor_of(data.parent), vformat("Can't add sibling '%s' to '%s' as it would result in a cyclic dependency since the sibling '%s' is already a parent of '%s'.", p_sibling->get_name(), get_name(), p_sibling->get_name(), get_name())); // Slow check so inside DEBUG_ENABLED
+#endif
 	ERR_FAIL_COND_MSG(data.parent->data.blocked > 0, "Parent node is busy setting up children, `add_sibling()` failed. Consider using `add_sibling.call_deferred(sibling)` instead.");
 
-	data.parent->add_child(p_sibling, p_force_readable_name, data.internal_mode);
+	data.parent->_validate_child_name(p_sibling, p_force_readable_name);
+	data.parent->_add_child_nocheck(p_sibling, p_sibling->data.name, data.internal_mode);
 	data.parent->_update_children_cache();
 	data.parent->_move_child(p_sibling, get_index() + 1);
 }


### PR DESCRIPTION
### Crash cause

When calling `Node::add_sibling`, if the sibling already has a parent it can cause the game to crash. The internal call to `add_child` fails but `add_sibling` continues its execution. A crash then happens as it's not under the right parent and `get_index() + 1` might be out of range.
Also note that when not crashing, it still has some unexpected behaviour. In case the sibling has already a parent, it just moves the sibling to another index under its parent.

**MRE:**
[mre-node-add-sibling-crash.zip](https://github.com/user-attachments/files/19813622/mre-node-add-sibling-crash.zip)

### This PR

I added all the required checks directly in the `add_sibling` function and call the private methods directly to avoid unnecessary checks.

Added checks:
- Thread guard
- Sibling already has a parent
- Sibling is the parent of node
- Sibling is an ancestor of node (if `DEBUG_ENABLED` only cause it's slow, see discussion https://github.com/godotengine/godot/pull/48998)

The crash is fixed in the MRE with the following error:
```
E 0:00:00:316   future_child_2.gd:8 @ add_sibling_crash(): Can't add sibling 'FutureChild2' to 'Child1', already has a parent 'Root'.
  <C++ Error>   Condition "p_sibling->data.parent" is true.
  <C++ Source>  scene/main/node.cpp:1845 @ add_sibling()
  <Stack Trace> future_child_2.gd:8 @ add_sibling_crash()
```

Additional notes:
- I haven't copied the owner inconsistency warning from `add_child`, not sure if this is really relevant (even in `add_child`)