### PR TITLE
Skip adding autocompleted method's params if parenthesis after incomplete name is already present

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3555,26 +3555,28 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 				if (method_hint.contains_char(':')) {
 					method_hint = method_hint.get_slicec(':', 0);
 				}
-				method_hint += "(";
+				if (!completion_context.has_param_parenthesis) {
+					method_hint += "(";
 
-				for (int64_t i = 0; i < mi.arguments.size(); ++i) {
-					if (i > 0) {
-						method_hint += ", ";
+					for (int64_t i = 0; i < mi.arguments.size(); ++i) {
+						if (i > 0) {
+							method_hint += ", ";
+						}
+						String arg = mi.arguments[i].name;
+						if (arg.contains_char(':')) {
+							arg = arg.substr(0, arg.find_char(':'));
+						}
+						method_hint += arg;
+						if (use_type_hint) {
+							method_hint += ": " + _get_visual_datatype(mi.arguments[i], true, class_name);
+						}
 					}
-					String arg = mi.arguments[i].name;
-					if (arg.contains_char(':')) {
-						arg = arg.substr(0, arg.find_char(':'));
-					}
-					method_hint += arg;
+					method_hint += ")";
 					if (use_type_hint) {
-						method_hint += ": " + _get_visual_datatype(mi.arguments[i], true, class_name);
+						method_hint += " -> " + _get_visual_datatype(mi.return_val, false, class_name);
 					}
+					method_hint += ":";
 				}
-				method_hint += ")";
-				if (use_type_hint) {
-					method_hint += " -> " + _get_visual_datatype(mi.return_val, false, class_name);
-				}
-				method_hint += ":";
 
 				ScriptLanguage::CodeCompletionOption option(method_hint, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 				options.insert(option.display, option);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1323,6 +1323,7 @@ public:
 		int current_line = -1;
 		int current_argument = -1;
 		Variant::Type builtin_type = Variant::VARIANT_MAX;
+		bool has_param_parenthesis = false;
 		Node *node = nullptr;
 		Object *base = nullptr;
 		GDScriptParser *parser = nullptr;
@@ -1476,8 +1477,10 @@ private:
 	// Setting p_force to false will prevent the completion context from being update if a context was already set before.
 	// This should only be done when we push context before we consumed any tokens for the corresponding structure.
 	// See parse_precedence for an example.
-	void make_completion_context(CompletionType p_type, Node *p_node, int p_argument = -1, bool p_force = true);
-	void make_completion_context(CompletionType p_type, Variant::Type p_builtin_type, bool p_force = true);
+	bool make_completion_context(CompletionType p_type, Node *p_node, bool p_force = true);
+	void make_completion_context_argument(CompletionType p_type, Node *p_node, int p_argument, bool p_force = true);
+	void make_completion_context_bultin_type(CompletionType p_type, Variant::Type p_builtin_type, bool p_force = true);
+	bool make_completion_context_virtual_method(CompletionType p_type, Node *p_node, bool p_has_param_parenthesis, bool p_force = true);
 	// In some cases it might become necessary to alter the completion context after parsing a subexpression.
 	// For example to not override COMPLETE_CALL_ARGUMENTS with COMPLETION_NONE from string literals.
 	void override_completion_context(const Node *p_for_node, CompletionType p_type, Node *p_node, int p_argument = -1);


### PR DESCRIPTION
Fixes #21813 
Fixes https://github.com/godotengine/godot-proposals/issues/9731

The solution isn't fool-proof since it won't work if there are spaces between end of autocompleted modifier and opening parenthesis, but should be good enough.

### Tests while renaming methods

Before/after pressing enter:
![obraz](https://github.com/user-attachments/assets/1edf9f46-d1f0-4189-8873-21142e1166d9)
![obraz](https://github.com/user-attachments/assets/d1785431-8875-49b2-a1d7-46b3f13e3c3a)

Ditto, ragression check
![obraz](https://github.com/user-attachments/assets/a090cbc6-c520-4db2-b486-44a764f8d11d)
![obraz](https://github.com/user-attachments/assets/05cf42c3-3f05-44b4-a7bb-43df44a4383c)
