### PR TITLE
Style: Declare inline macros as attributes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -52,8 +52,10 @@ AllowShortFunctionsOnASingleLine: Inline
 # AlwaysBreakAfterReturnType: None
 # AlwaysBreakBeforeMultilineStrings: false
 # AlwaysBreakTemplateDeclarations: MultiLine
-# AttributeMacros:
-#   - __capability
+AttributeMacros:
+  - _ALWAYS_INLINE_
+  - _FORCE_INLINE_
+  - _NO_INLINE_
 # BinPackArguments: true
 # BinPackParameters: true
 # BitFieldColonSpacing: Both

--- a/drivers/metal/metal_objects.h
+++ b/drivers/metal/metal_objects.h
@@ -945,8 +945,7 @@ namespace rid {
 
 // Converts an Objective-C object to a pointer, and incrementing the
 // reference count.
-_FORCE_INLINE_
-void *owned(id p_id) {
+_FORCE_INLINE_ void *owned(id p_id) {
 	return (__bridge_retained void *)p_id;
 }
 
@@ -962,14 +961,12 @@ MAKE_ID(MTLVertexDescriptor *, RDD::VertexFormatID)
 MAKE_ID(id<MTLCommandQueue>, RDD::CommandPoolID)
 
 // Converts a pointer to an Objective-C object without changing the reference count.
-_FORCE_INLINE_
-auto get(RDD::ID p_id) {
+_FORCE_INLINE_ auto get(RDD::ID p_id) {
 	return (p_id.id) ? (__bridge ::id)(void *)p_id.id : nil;
 }
 
 // Converts a pointer to an Objective-C object, and decrements the reference count.
-_FORCE_INLINE_
-auto release(RDD::ID p_id) {
+_FORCE_INLINE_ auto release(RDD::ID p_id) {
 	return (__bridge_transfer ::id)(void *)p_id.id;
 }
 

--- a/misc/utility/clang_format_glsl.yml
+++ b/misc/utility/clang_format_glsl.yml
@@ -9,6 +9,10 @@ AlignTrailingComments:
   OverEmptyLines: 0
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortFunctionsOnASingleLine: Inline
+AttributeMacros:
+  - _ALWAYS_INLINE_
+  - _FORCE_INLINE_
+  - _NO_INLINE_
 BreakConstructorInitializers: AfterColon
 ColumnLimit: 0
 ConstructorInitializerIndentWidth: 8

--- a/tests/python_build/fixtures/gles3/vertex_fragment.glsl
+++ b/tests/python_build/fixtures/gles3/vertex_fragment.glsl
@@ -3,7 +3,7 @@
 #[modes]
 
 mode_ninepatch = #define USE_NINEPATCH
-
+/* clang-format off */
 #[specializations]
 
 DISABLE_LIGHTING = false
@@ -12,13 +12,13 @@ DISABLE_LIGHTING = false
 
 precision highp float;
 precision highp int;
-
+/* clang-format on */
 layout(location = 0) in highp vec3 vertex;
 
 out highp vec4 position_interp;
 
 void main() {
-	position_interp = vec4(vertex.x,1,0,1);
+	position_interp = vec4(vertex.x, 1, 0, 1);
 }
 
 #[fragment]

--- a/tests/python_build/fixtures/glsl/compute.glsl
+++ b/tests/python_build/fixtures/glsl/compute.glsl
@@ -4,7 +4,6 @@
 
 #VERSION_DEFINES
 
-
 #include "_included.glsl"
 
 void main() {

--- a/tests/python_build/fixtures/glsl/vertex_fragment.glsl
+++ b/tests/python_build/fixtures/glsl/vertex_fragment.glsl
@@ -11,9 +11,8 @@ lines = "#define MODE_LINES";
 layout(location = 0) out vec3 uv_interp;
 
 void main() {
-
 #ifdef MODE_LINES
-	uv_interp = vec3(0,0,1);
+	uv_interp = vec3(0, 0, 1);
 #endif
 }
 
@@ -28,5 +27,5 @@ void main() {
 layout(location = 0) out vec4 dst_color;
 
 void main() {
-	dst_color = vec4(1,1,0,0);
+	dst_color = vec4(1, 1, 0, 0);
 }


### PR DESCRIPTION
`clang-format` allows us to specify which macros we are explicitly using as attributes, ensuring they're *not* parsed as identifiers. While intellisense has been largely successful at detecting this already, this change managed to find a single instance where this wasn't the case. The original item—`__capability`—was removed, as it has no use within the entire repo, thirdparty code included; if it ever gets used in the future, we can readd it explicitly then. Some shader files also appear to have been added but not synced with the later `clang-format` CLI checks, so that's been updated as well