### PR TITLE
Implement proper LSP file rename/delete (moves/deletes .uid/.import files)

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -371,6 +371,8 @@ GDScriptLanguageProtocol::GDScriptLanguageProtocol() {
 	SET_COMPLETION_METHOD(resolve);
 
 	SET_WORKSPACE_METHOD(didDeleteFiles);
+	SET_WORKSPACE_METHOD(willDeleteFiles);
+	SET_WORKSPACE_METHOD(willRenameFiles);
 
 	set_method("initialize", callable_mp(this, &GDScriptLanguageProtocol::initialize));
 	set_method("initialized", callable_mp(this, &GDScriptLanguageProtocol::initialized));

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -116,6 +116,64 @@ void GDScriptWorkspace::didDeleteFiles(const Dictionary &p_params) {
 	}
 }
 
+Dictionary GDScriptWorkspace::willDeleteFiles(const Dictionary &p_params) {
+	LSP::WorkspaceEdit out_workspace_edit;
+
+	Array files = p_params["files"];
+	for (int i = 0; i < files.size(); ++i) {
+		Dictionary file = files[i];
+		String uri = file["uri"];
+		String path = get_file_path(uri);
+
+		if (path.ends_with(".gd")) {
+			// Editor should delete .uid file
+			LSP::DeleteFile delete_file;
+			delete_file.uri = get_file_uri(path + ".uid");
+			delete_file.options.ignoreIfNotExists = true;
+			out_workspace_edit.add_document_change(&delete_file);
+		} else {
+			// Editor should delete .import file
+			LSP::DeleteFile delete_file;
+			delete_file.uri = get_file_uri(path + ".import");
+			delete_file.options.ignoreIfNotExists = true;
+			out_workspace_edit.add_document_change(&delete_file);
+		}
+	}
+
+	return out_workspace_edit.to_json();
+}
+
+Dictionary GDScriptWorkspace::willRenameFiles(const Dictionary &p_params) {
+	LSP::WorkspaceEdit out_workspace_edit;
+
+	Array files = p_params["files"];
+	for (int i = 0; i < files.size(); ++i) {
+		Dictionary file = files[i];
+		String old_uri = file["oldUri"];
+		String old_path = get_file_path(old_uri);
+		String new_uri = file["newUri"];
+		String new_path = get_file_path(new_uri);
+
+		if (old_path.ends_with(".gd") && FileAccess::exists(old_path + ".uid")) {
+			// Editor should rename .uid file
+			LSP::RenameFile rename_file;
+			rename_file.oldUri = get_file_uri(old_path + ".uid");
+			rename_file.newUri = get_file_uri(new_path + ".uid");
+			rename_file.options.ignoreIfExists = true;
+			out_workspace_edit.add_document_change(&rename_file);
+		} else if (FileAccess::exists(old_path + ".import")) {
+			// Editor should rename .import file
+			LSP::RenameFile rename_file;
+			rename_file.oldUri = get_file_uri(old_path + ".import");
+			rename_file.newUri = get_file_uri(new_path + ".import");
+			rename_file.options.ignoreIfExists = true;
+			out_workspace_edit.add_document_change(&rename_file);
+		}
+	}
+
+	return out_workspace_edit.to_json();
+}
+
 void GDScriptWorkspace::remove_cache_parser(const String &p_path) {
 	HashMap<String, ExtendGDScriptParser *>::Iterator parser = parse_results.find(p_path);
 	HashMap<String, ExtendGDScriptParser *>::Iterator scr = scripts.find(p_path);
@@ -430,7 +488,6 @@ Error GDScriptWorkspace::parse_script(const String &p_path, const String &p_cont
 		remove_cache_parser(p_path);
 		parse_results[p_path] = parser;
 		scripts[p_path] = parser;
-
 	} else {
 		if (last_parser && last_script && last_parser->value != last_script->value) {
 			memdelete(last_parser->value);

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "../gdscript_parser.h"
 #include "gdscript_extend_parser.h"
 #include "godot_lsp.h"
 
@@ -91,6 +90,8 @@ public:
 	Dictionary generate_script_api(const String &p_path);
 	Error resolve_signature(const LSP::TextDocumentPositionParams &p_doc_pos, LSP::SignatureHelp &r_signature);
 	void didDeleteFiles(const Dictionary &p_params);
+	Dictionary willDeleteFiles(const Dictionary &p_params);
+	Dictionary willRenameFiles(const Dictionary &p_params);
 	Dictionary rename(const LSP::TextDocumentPositionParams &p_doc_pos, const String &new_name);
 	bool can_rename(const LSP::TextDocumentPositionParams &p_doc_pos, LSP::DocumentSymbol &r_symbol, LSP::Range &r_range);
 	Vector<LSP::Location> find_usages_in_file(const LSP::DocumentSymbol &p_symbol, const String &p_file_path);

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -291,6 +291,181 @@ struct TextEdit {
 	 * empty string.
 	 */
 	String newText;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["range"] = range.to_json();
+		dict["newText"] = newText;
+		return dict;
+	}
+};
+
+struct DocumentChange {
+	virtual Dictionary to_json() const = 0;
+	virtual ~DocumentChange() = default;
+};
+/**
+ * Options to create a file.
+ */
+struct CreateFileOptions {
+	/**
+	 * Overwrite existing file. Overwrite wins over `ignoreIfExists`
+	 */
+	bool overwrite = false;
+	/**
+	 * Ignore if exists.
+	 */
+	bool ignoreIfExists = false;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["overwrite"] = overwrite;
+		dict["ignoreIfExists"] = ignoreIfExists;
+		return dict;
+	}
+};
+/**
+ * Create file operation
+ */
+struct CreateFile : public DocumentChange {
+	/**
+	 * The resource to create.
+	 */
+	String uri;
+	/**
+	 * Additional options.
+	 */
+	CreateFileOptions options;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["kind"] = "create";
+		dict["uri"] = uri;
+		dict["options"] = options.to_json();
+		return dict;
+	}
+};
+
+/**
+ * Rename file options.
+ */
+struct RenameFileOptions {
+	/**
+	 * Overwrite target if existing. Overwrite wins over `ignoreIfExists`.
+	 */
+	bool overwrite = false;
+	/**
+	 * Ignores if target exists.
+	 */
+	bool ignoreIfExists = false;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["overwrite"] = overwrite;
+		dict["ignoreIfExists"] = ignoreIfExists;
+		return dict;
+	}
+};
+
+/**
+ * Rename file operation.
+ */
+struct RenameFile : public DocumentChange {
+	/**
+	 * The old (existing) location.
+	 */
+	String oldUri;
+	/**
+	 * The new location.
+	 */
+	String newUri;
+	/**
+	 * Rename options.
+	 */
+	RenameFileOptions options;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["kind"] = "rename";
+		dict["oldUri"] = oldUri;
+		dict["newUri"] = newUri;
+		dict["options"] = options.to_json();
+		return dict;
+	}
+};
+
+/**
+ * Delete file options.
+ */
+struct DeleteFileOptions {
+	/**
+	 * Delete the content recursively if a folder is denoted.
+	 */
+	bool recursive = false;
+	/**
+	 * Ignore the operation if the file doesn't exist.
+	 */
+	bool ignoreIfNotExists = false;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["recursive"] = recursive;
+		dict["ignoreIfNotExists"] = ignoreIfNotExists;
+		return dict;
+	}
+};
+
+/**
+ * Delete file operation.
+ */
+struct DeleteFile : public DocumentChange {
+	/**
+	 * The file to delete.
+	 */
+	String uri;
+	/**
+	 * Delete options.
+	 */
+	DeleteFileOptions options;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["kind"] = "delete";
+		dict["uri"] = uri;
+		dict["options"] = options.to_json();
+		return dict;
+	}
+};
+
+/**
+ * Describes textual changes on a single text document. The text document is
+ * referred to as a OptionalVersionedTextDocumentIdentifier to allow clients to
+ * check the text document version before an edit is applied. A TextDocumentEdit
+ * describes all changes on a version Si and after they are applied move the
+ * document to version Si+1. So the creator of a TextDocumentEdit doesn’t need
+ * to sort the array of edits or do any kind of ordering. However the edits must
+ * be non overlapping.
+ */
+struct TextDocumentEdit : public DocumentChange {
+	/**
+	 * The text document to change.
+	 */
+	TextDocumentIdentifier textDocument;
+	/**
+	 * The edits to be applied.
+	 */
+	Vector<TextEdit> edits;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+		dict["textDocument"] = textDocument.to_json();
+		Array out_edits;
+		for (int i = 0; i < edits.size(); i++) {
+			out_edits[i] = edits[i].to_json();
+		}
+		dict["edits"] = out_edits;
+		return dict;
+	}
 };
 
 /**
@@ -301,6 +476,22 @@ struct WorkspaceEdit {
 	 * Holds changes to existing resources.
 	 */
 	HashMap<String, Vector<TextEdit>> changes;
+	/**
+	 * Depending on the client capability
+	 * `workspace.workspaceEdit.resourceOperations` document changes are either
+	 * an array of `TextDocumentEdit`s to express changes to n different text
+	 * documents where each text document edit addresses a specific version of
+	 * a text document. Or it can contain above `TextDocumentEdit`s mixed with
+	 * create, rename and delete file / folder operations.
+	 *
+	 * Whether a client supports versioned document edits is expressed via
+	 * `workspace.workspaceEdit.documentChanges` client capability.
+	 *
+	 * If a client neither supports `documentChanges` nor
+	 * `workspace.workspaceEdit.resourceOperations` then only plain `TextEdit`s
+	 * using the `changes` property are supported.
+	 */
+	Vector<Dictionary> documentChanges;
 
 	_FORCE_INLINE_ void add_edit(const String &uri, const TextEdit &edit) {
 		if (changes.has(uri)) {
@@ -310,25 +501,6 @@ struct WorkspaceEdit {
 			edits.push_back(edit);
 			changes[uri] = edits;
 		}
-	}
-
-	_FORCE_INLINE_ Dictionary to_json() const {
-		Dictionary dict;
-
-		Dictionary out_changes;
-		for (const KeyValue<String, Vector<TextEdit>> &E : changes) {
-			Array edits;
-			for (int i = 0; i < E.value.size(); ++i) {
-				Dictionary text_edit;
-				text_edit["range"] = E.value[i].range.to_json();
-				text_edit["newText"] = E.value[i].newText;
-				edits.push_back(text_edit);
-			}
-			out_changes[E.key] = edits;
-		}
-		dict["changes"] = out_changes;
-
-		return dict;
 	}
 
 	_FORCE_INLINE_ void add_change(const String &uri, const int &line, const int &start_character, const int &end_character, const String &new_text) {
@@ -346,6 +518,39 @@ struct WorkspaceEdit {
 			edit_list.push_back(new_edit);
 			changes.insert(uri, edit_list);
 		}
+	}
+
+	_FORCE_INLINE_ void add_document_change(const DocumentChange *document_change) {
+		documentChanges.push_back(document_change->to_json());
+	}
+
+	_FORCE_INLINE_ Dictionary to_json() const {
+		Dictionary dict;
+
+		Dictionary out_changes;
+		for (const KeyValue<String, Vector<TextEdit>> &E : changes) {
+			Array edits;
+			for (int i = 0; i < E.value.size(); ++i) {
+				Dictionary text_edit;
+				text_edit["range"] = E.value[i].range.to_json();
+				text_edit["newText"] = E.value[i].newText;
+				edits.push_back(text_edit);
+			}
+			out_changes[E.key] = edits;
+		}
+		if (out_changes.size()) {
+			dict["changes"] = out_changes;
+		}
+
+		Array out_document_changes;
+		for (int i = 0; i < documentChanges.size(); i++) {
+			out_document_changes.push_back(documentChanges[i]);
+		}
+		if (out_document_changes.size()) {
+			dict["documentChanges"] = out_document_changes;
+		}
+
+		return dict;
 	}
 };
 
@@ -1593,7 +1798,7 @@ struct FileOperationPattern {
 	/**
 	 * The glob pattern to match.
 	 */
-	String glob = "**/*.gd";
+	String glob;
 
 	/**
 	 * Whether to match `file`s or `folder`s with this pattern.
@@ -1640,8 +1845,12 @@ struct FileOperationRegistrationOptions {
 	 */
 	Vector<FileOperationFilter> filters;
 
-	FileOperationRegistrationOptions() {
-		filters.push_back(FileOperationFilter());
+	FileOperationRegistrationOptions(String glob) {
+		FileOperationPattern pattern;
+		pattern.glob = glob;
+		FileOperationFilter filter;
+		filter.pattern = pattern;
+		filters.push_back(filter);
 	}
 
 	Dictionary to_json() const {
@@ -1662,13 +1871,23 @@ struct FileOperationRegistrationOptions {
  */
 struct FileOperations {
 	/**
+	 * The server is interested in receiving willDeleteFiles file notifications.
+	 */
+	FileOperationRegistrationOptions willDelete = FileOperationRegistrationOptions("*");
+	/**
+	 * The server is interested in receiving willRenameFiles file notifications.
+	 */
+	FileOperationRegistrationOptions willRename = FileOperationRegistrationOptions("*");
+	/**
 	 * The server is interested in receiving didDeleteFiles file notifications.
 	 */
-	FileOperationRegistrationOptions didDelete;
+	FileOperationRegistrationOptions didDelete = FileOperationRegistrationOptions("*/*gd");
 
 	Dictionary to_json() const {
 		Dictionary dict;
 
+		dict["willDelete"] = willDelete.to_json();
+		dict["willRename"] = willRename.to_json();
 		dict["didDelete"] = didDelete.to_json();
 
 		return dict;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105515


Implement `willRenameFiles`, which provides to the LSP client a command to rename the matching `.uid` (for `.gd` files) or `.import` (for other files), if they exist.

Implement `willDeleteFiles`, which provides to the LSP client a command to delete the matching `.uid` (for `.gd` files) or `.import` (for other files), if they exist.

Tested working within Neovim with LSP.


