### PR TITLE
Fix cases where `_get` returned true erroneously

### DIFF
--- a/modules/openxr/scene/openxr_composition_layer.cpp
+++ b/modules/openxr/scene/openxr_composition_layer.cpp
@@ -662,9 +662,10 @@ void OpenXRCompositionLayer::_get_property_list(List<PropertyInfo> *p_property_l
 bool OpenXRCompositionLayer::_get(const StringName &p_property, Variant &r_value) const {
 	if (extension_property_values.has(p_property)) {
 		r_value = extension_property_values[p_property];
+		return true;
 	}
 
-	return true;
+	return false;
 }
 
 bool OpenXRCompositionLayer::_set(const StringName &p_property, const Variant &p_value) {

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -56,21 +56,25 @@ void BoneAttachment3D::_validate_property(PropertyInfo &p_property) const {
 bool BoneAttachment3D::_set(const StringName &p_path, const Variant &p_value) {
 	if (p_path == SNAME("use_external_skeleton")) {
 		set_use_external_skeleton(p_value);
+		return true;
 	} else if (p_path == SNAME("external_skeleton")) {
 		set_external_skeleton(p_value);
+		return true;
 	}
 
-	return true;
+	return false;
 }
 
 bool BoneAttachment3D::_get(const StringName &p_path, Variant &r_ret) const {
 	if (p_path == SNAME("use_external_skeleton")) {
 		r_ret = get_use_external_skeleton();
+		return true;
 	} else if (p_path == SNAME("external_skeleton")) {
 		r_ret = get_external_skeleton();
+		return true;
 	}
 
-	return true;
+	return false;
 }
 
 void BoneAttachment3D::_get_property_list(List<PropertyInfo> *p_list) const {

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
@@ -67,7 +67,8 @@ bool SkeletonModification2DPhysicalBones::_get(const StringName &p_path, Variant
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
 		if (path.begins_with("fetch_bones")) {
-			return true; // Do nothing!
+			// Do nothing!
+			return false;
 		}
 	}
 #endif //TOOLS_ENABLED

--- a/scene/resources/skeleton_profile.cpp
+++ b/scene/resources/skeleton_profile.cpp
@@ -41,10 +41,10 @@ bool SkeletonProfile::_set(const StringName &p_path, const Variant &p_value) {
 
 		if (what == "group_name") {
 			set_group_name(which, p_value);
+			return true;
 		} else if (what == "texture") {
 			set_texture(which, p_value);
-		} else {
-			return false;
+			return true;
 		}
 	}
 
@@ -55,25 +55,31 @@ bool SkeletonProfile::_set(const StringName &p_path, const Variant &p_value) {
 
 		if (what == "bone_name") {
 			set_bone_name(which, p_value);
+			return true;
 		} else if (what == "bone_parent") {
 			set_bone_parent(which, p_value);
+			return true;
 		} else if (what == "tail_direction") {
 			set_tail_direction(which, static_cast<TailDirection>((int)p_value));
+			return true;
 		} else if (what == "bone_tail") {
 			set_bone_tail(which, p_value);
+			return true;
 		} else if (what == "reference_pose") {
 			set_reference_pose(which, p_value);
+			return true;
 		} else if (what == "handle_offset") {
 			set_handle_offset(which, p_value);
+			return true;
 		} else if (what == "group") {
 			set_group(which, p_value);
+			return true;
 		} else if (what == "require") {
 			set_required(which, p_value);
-		} else {
-			return false;
+			return true;
 		}
 	}
-	return true;
+	return false;
 }
 
 bool SkeletonProfile::_get(const StringName &p_path, Variant &r_ret) const {
@@ -86,39 +92,44 @@ bool SkeletonProfile::_get(const StringName &p_path, Variant &r_ret) const {
 
 		if (what == "group_name") {
 			r_ret = get_group_name(which);
+			return true;
 		} else if (what == "texture") {
 			r_ret = get_texture(which);
-		} else {
-			return false;
+			return true;
 		}
-	}
-
-	if (path.begins_with("bones/")) {
+	} else if (path.begins_with("bones/")) {
 		int which = path.get_slicec('/', 1).to_int();
 		String what = path.get_slicec('/', 2);
 		ERR_FAIL_INDEX_V(which, bones.size(), false);
 
 		if (what == "bone_name") {
 			r_ret = get_bone_name(which);
+			return true;
 		} else if (what == "bone_parent") {
 			r_ret = get_bone_parent(which);
+			return true;
 		} else if (what == "tail_direction") {
 			r_ret = get_tail_direction(which);
+			return true;
 		} else if (what == "bone_tail") {
 			r_ret = get_bone_tail(which);
+			return true;
 		} else if (what == "reference_pose") {
 			r_ret = get_reference_pose(which);
+			return true;
 		} else if (what == "handle_offset") {
 			r_ret = get_handle_offset(which);
+			return true;
 		} else if (what == "group") {
 			r_ret = get_group(which);
+			return true;
 		} else if (what == "require") {
 			r_ret = is_required(which);
-		} else {
-			return false;
+			return true;
 		}
 	}
-	return true;
+
+	return false;
 }
 
 void SkeletonProfile::_validate_property(PropertyInfo &p_property) const {


### PR DESCRIPTION
If you for example create a `BoneAttachment3D` and query `"albasldasbla" in bone_attachment` it would always return true.
This is because its `_get` always reported that a property exists.

I went through all classes that override `_get` and fixed this problem everywhere I could find.
The same still has to be done for `_set` in the future (I only updated those `_set`'s on classes that had erroneous `_get`'s)!

Ideally, this could be automatically detected and reported in debug builds, by checking whether the second parameter was modified when true is returned. But that is outside of the scope of this PR.