### PR TITLE
Remove 2^31 cap on RID allocations

### DIFF
--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -164,8 +164,7 @@ class RID_Alloc : public RID_AllocBase {
 		uint32_t free_chunk = free_index / elements_in_chunk;
 		uint32_t free_element = free_index % elements_in_chunk;
 
-		uint32_t validator = (uint32_t)(_gen_id() & 0x7FFFFFFF);
-		CRASH_COND_MSG(validator == 0x7FFFFFFF, "Overflow in RID validator");
+		uint32_t validator = 1 + (uint32_t)(_gen_id() % 0x7FFFFFFF);
 		uint64_t id = validator;
 		id <<= 32;
 		id |= free_index;
@@ -329,7 +328,7 @@ public:
 
 		uint32_t validator = uint32_t(id >> 32);
 
-		bool owned = (validator != 0x7FFFFFFF) && (chunks[idx_chunk][idx_element].validator & 0x7FFFFFFF) == validator;
+		bool owned = (chunks[idx_chunk][idx_element].validator & 0x7FFFFFFF) == validator;
 
 		if constexpr (THREAD_SAFE) {
 			mutex.unlock();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/89680
Fixes: https://github.com/godotengine/godot/issues/74728

## Background

RIDs are `uint64_t` handles comprised of two pieces of information:
1. `uint32_t` index into a chunked array of elements
2. `uint32_t` "validator"

Each element stores its underlying data component and a matching `uint32_t` validator. https://github.com/godotengine/godot/blob/2d3bdcac35ac22ee6c4d5d5edc88ba947d0659d5/core/templates/rid_owner.h#L103-L106

When we do operations with an RID, we use the index to lookup the "chunk" (which is improperly named as it is actually the element itself) and we compare the validator contained within the RID to the one stored in the "chunk". If they match, then we know that this RID belongs to this RID owner. This system allows us to comfortably use RIDs for many different systems, while still detecting if an RID belongs to a given RID owner. 

The validator comes from the `_gen_id()` function which returns a unique value for each allocation. Internally, it simply atomically increments an atomic `uint64_t`:

https://github.com/godotengine/godot/blob/2d3bdcac35ac22ee6c4d5d5edc88ba947d0659d5/core/templates/rid_owner.h#L93-L95

So every allocation gets a unique ID. However, the validator is a `uint32_t`, so to actually consume the id, we need to truncate it to 32 bits. Currently we do that by masking to `0x7FFFFFFF`
https://github.com/godotengine/godot/blob/2d3bdcac35ac22ee6c4d5d5edc88ba947d0659d5/core/templates/rid_owner.h#L167

Why `0x7FFFFFFF`? Its because we actually only use the first 31 bits for the validator id. The 32nd bit is reserved for indicating whether the RID has been initialized or not. Thus we have two special values anything with the 32nd bit (0x80000000) set means "uninitialized" (we use this for error checking for allocated, but uninitialized RIDs), and `0xFFFFFFFF` which means the chunk is unallocated and can be used by a new RID.

RIDs are created in two stages, first the RID is allocated, which means we acquire an index in the element pool and a validator bit. Then, we actually initialize the backing memory for the object. This split is beneficial for a multithreaded APIs (like rendering) where we want to reserve an RID and return immediately on the main thread, but where initialization needs to happen on a separate thread. This approach allows us to give the main thread a handle to the object before the object is initialized. 

### The Problem

The problem we have right now is that RIDs are limited once we reach `0x7FFFFFFF` total allocations (across all RID_Owners) we intentionally crash the engine:

https://github.com/godotengine/godot/blob/2d3bdcac35ac22ee6c4d5d5edc88ba947d0659d5/core/templates/rid_owner.h#L167-L168

As ATS points out in https://github.com/godotengine/godot/issues/89680 this makes most Godot games a ticking time bomb. Certain game types like bullet hells are especially at risk unless they manually pool objects. Ultimately, any game running long enough will exhaust the RID validators and crash. 

### History

This crash was introduced in https://github.com/godotengine/godot/pull/74759 to solve a different problem reported in https://github.com/godotengine/godot/issues/74728. 

In https://github.com/godotengine/godot/issues/74728 the OP reports a funny situation. Once enough RIDs are allocated `0x7FFFFFFF +1` the validator bit becomes `0` IF that happens when the first allocation for an RID owner is made, then the `ID` will be 0 as well. IF both the ID and validator are 0, then the RID itself will be 0. However, 0 is a special value for RIDs that corresponds to an invalid RID. Therefore, in this special case it is possible to allocate an invalid RID. Then, when the RID is initialized it will fail because `get_or_null()` returns a `nullptr` if the `RID == 0`.

https://github.com/godotengine/godot/blob/2d3bdcac35ac22ee6c4d5d5edc88ba947d0659d5/core/templates/rid_owner.h#L293-L295

https://github.com/godotengine/godot/blob/2d3bdcac35ac22ee6c4d5d5edc88ba947d0659d5/core/templates/rid_owner.h#L202-L205

Then finally, when you try to free the RID it will crash because the ID actually is valid and the validator matches the allocated chunk, but the memory was never initialized.

We solved this problem in https://github.com/godotengine/godot/pull/74759 by ensuring that the validator never wrapped back around to zero. Therefore, this situation would never arise, since you are guaranteed a non-zero RID by virtue of having a non-zero validator. 

Unfortunately, that solution created an arbitrary limit on the number of _validators_ that could be generated. Once we generate 2^31, we can no longer create any new RIDs and the engine has no choice but to crash. 

#### The Solution

Instead of crashing when the validator wraps around to zero, we can just avoid the problematic case by ensuring that the validator is always between `1` and `0x7FFFFFFF`. This avoids the problematic case while allowing the validators to increment beyond the limits of `2^31`. 

#### Discussion

We decided to crash in https://github.com/godotengine/godot/pull/74759 because no one that reviewed the PR was sure about whether it was okay to re-use validators. In other words, we thought that there might be a requirement that each validator is totally unique for the run of the program. Therefore we agreed on a solution that enforced that requirement. 

In hindsight and in discussion with @lawnjelly I realized that it is safe and intended for validators to not necessarily be unique. First consider the following:
1. `_get_id()` increments for all RID_Owners which means that, until you reach 2^31, each validator is unique across all RID_Owners
2. The validator is only checked once the index has been found inside the element list
3. For a collision to occur the RID index needs to point to a valid element _and_ that element needs to have the same validator as the validator in the RID. Which means the chances of collision are abysmally low. 

A collision can't occur within the first 2 billion allocations, after that, a collision can only occur with elements that have not been freed (if you reach 2 billion allocations, you must have been freeing most of them), _and_ if the RID is used with a different RID_Owner. In such a case the odds of a collision are exceedingly rare. If only the validator was being used, and assuming that no RIDs are freed, the odds would be 1 in 2 billion, but since the index and validator need to match, still assuming no RIDs are freed, that makes the odds 1 in 4e18. 

Looking through the history of that code, its also clear that the intended case was for the validator to wrap. 

The original code in 4f16397 used `uint32_t validator = (uint32_t)(_gen_id() % 0xFFFFFFFF);`. Then it was changed to wrap over `0x7FFFFFFF` in 8b19ffd. Seeing that `_get_id()` was always 64 bit, it would never have made sense to limit the validator to only 2^31 or 2^32 values. 

### Maintainer notes

Tagged for 4.5. This issue goes back as far as 4.1, but to date it seems like no one has actually hit the limit. So this is more of a theoretical problem. That being said, we should consider cherrypicking to 4.4 since https://github.com/godotengine/godot/pull/99257 introduced a paradigm that creates and frees UniformSet RIDs every frame. With this change, most Godot games would run into the limit if they ran for a week or so at 60 FPS.