### PR TITLE
Remove postMessage limit on audio position worklet

### DIFF
--- a/platform/web/js/libs/audio.position.worklet.js
+++ b/platform/web/js/libs/audio.position.worklet.js
@@ -28,12 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-const POST_THRESHOLD_S = 0.1;
-
 class GodotPositionReportingProcessor extends AudioWorkletProcessor {
 	constructor(...args) {
 		super(...args);
-		this.lastPostTime = currentTime;
 		this.position = 0;
 		this.ended = false;
 
@@ -53,13 +50,8 @@ class GodotPositionReportingProcessor extends AudioWorkletProcessor {
 			const input = inputs[0];
 			if (input.length > 0) {
 				this.position += input[0].length;
+				this.port.postMessage({ type: 'position', data: this.position });
 			}
-		}
-
-		// Posting messages is expensive. Let's limit the number of posts.
-		if (currentTime - this.lastPostTime > POST_THRESHOLD_S) {
-			this.lastPostTime = currentTime;
-			this.port.postMessage({ type: 'position', data: this.position });
 		}
 
 		return true;


### PR DESCRIPTION
This limit was added with the following comment:

```
// Posting messages is expensive. Let's limit the number of posts.
```

I ran some Chrome profiling on my [test project](https://pizzalovers007.itch.io/music-sync-test-no-limit?secret=nCvfiwA0VtUyvV1vdrtRcOSRMk), and on my machine (Ryzen 9 5900X, GTX 1080) the [`onmessage` callback](https://github.com/godotengine/godot/blob/4.4/platform/web/js/libs/library_godot_audio.js#L642) took 3-5 microseconds to run. Even with CPU throttling at 20x, it only took 0.2ms.

The audio JS library on no-thread Web builds posts messages with chunks of sound data, and `audio.worklet.js` also posts messages on every process. Limiting the position message posts doesn't seem to be necessary here.

Fixes #105397.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
