### PR TITLE
Audio: Change playback position type from float to double

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -35,6 +35,26 @@
 				Generates an [AudioBusLayout] using the available buses and effects.
 			</description>
 		</method>
+		<method name="get_absolute_time" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the absolute time in seconds of the [AudioServer] timeline based on the number of audio frames mixed. Used to schedule sounds to be played in the future with higher accuracy.
+				[b]Note:[/b] This value only updates each time an audio chunk is mixed and should not be relied on as an accurate "current" time of the [AudioServer].
+				[b]Example:[/b] Schedule two sounds to be played at the same time ~1 second in the future:
+				[codeblocks]
+				[gdscript]
+				var future_time = AudioServer.get_absolute_time() + 1
+				player1.play_scheduled(future_time)
+				player2.play_scheduled(future_time)
+				[/gdscript]
+				[csharp]
+				double futureTime = AudioServer.GetAbsoluteTime() + 1;
+				player1.PlayScheduled(futureTime);
+				player2.PlayScheduled(futureTime);
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="get_bus_channels" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="bus_idx" type="int" />

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -44,6 +44,18 @@
 				Plays a sound from the beginning, or the given [param from_position] in seconds.
 			</description>
 		</method>
+		<method name="play_scheduled">
+			<return type="void" />
+			<param index="0" name="absolute_time" type="float" />
+			<param index="1" name="from_position" type="float" default="0.0" />
+			<description>
+				Schedules a sound to be played at [param absolute_time] on the [AudioServer] timeline. Use in conjunction with [method AudioServer.get_absolute_time]. The sound starts from the given [param from_position] in seconds.
+				[b]Note:[/b] Sounds scheduled to play earlier than [method AudioServer.get_absolute_time] will be played immediately.
+				[b]Note:[/b] By default, scheduled sounds will stop the currently playing sound on this player. Consider changing [member max_polyphony] to prevent this.
+				[b]Note:[/b] [member pitch_scale] does not affect the scheduling time.
+				[b]Note:[/b] On the Web platform, [member playback_type] must be set to [constant AudioServer.PLAYBACK_TYPE_STREAM] for [method play_scheduled] to work.
+			</description>
+		</method>
 		<method name="seek">
 			<return type="void" />
 			<param index="0" name="to_position" type="float" />

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -38,6 +38,18 @@
 				Queues the audio to play on the next physics frame, from the given position [param from_position], in seconds.
 			</description>
 		</method>
+		<method name="play_scheduled">
+			<return type="void" />
+			<param index="0" name="absolute_time" type="float" />
+			<param index="1" name="from_position" type="float" default="0.0" />
+			<description>
+				Schedules a sound to be played at [param absolute_time] on the [AudioServer] timeline. Use in conjunction with [method AudioServer.get_absolute_time]. The sound starts from the given [param from_position] in seconds.
+				[b]Note:[/b] Sounds scheduled to play earlier than [method AudioServer.get_absolute_time] will be played immediately.
+				[b]Note:[/b] By default, scheduled sounds will stop the currently playing sound on this player. Consider changing [member max_polyphony] to prevent this.
+				[b]Note:[/b] [member pitch_scale] does not affect the scheduling time.
+				[b]Note:[/b] On the Web platform, [member playback_type] must be set to [constant AudioServer.PLAYBACK_TYPE_STREAM] for [method play_scheduled] to work.
+			</description>
+		</method>
 		<method name="seek">
 			<return type="void" />
 			<param index="0" name="to_position" type="float" />

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -38,6 +38,18 @@
 				Queues the audio to play on the next physics frame, from the given position [param from_position], in seconds.
 			</description>
 		</method>
+		<method name="play_scheduled">
+			<return type="void" />
+			<param index="0" name="absolute_time" type="float" />
+			<param index="1" name="from_position" type="float" default="0.0" />
+			<description>
+				Schedules a sound to be played at [param absolute_time] on the [AudioServer] timeline. Use in conjunction with [method AudioServer.get_absolute_time]. The sound starts from the given [param from_position] in seconds.
+				[b]Note:[/b] Sounds scheduled to play earlier than [method AudioServer.get_absolute_time] will be played immediately.
+				[b]Note:[/b] By default, scheduled sounds will stop the currently playing sound on this player. Consider changing [member max_polyphony] to prevent this.
+				[b]Note:[/b] [member pitch_scale] does not affect the scheduling time.
+				[b]Note:[/b] On the Web platform, [member playback_type] must be set to [constant AudioServer.PLAYBACK_TYPE_STREAM] for [method play_scheduled] to work.
+			</description>
+		</method>
 		<method name="seek">
 			<return type="void" />
 			<param index="0" name="to_position" type="float" />

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -82,3 +82,18 @@ Validate extension JSON: Error: Field 'classes/TextServerExtension/methods/_shap
 Validate extension JSON: Error: Field 'classes/TextServerExtension/methods/_shaped_text_draw_outline/arguments': size changed value in new API, from 7 to 8.
 
 Optional "oversmpling" argument added. Compatibility methods registered.
+
+
+GH-105545
+---------
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer/methods/get_playback_position/return_value': meta changed value in new API, from "float" to "double".
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer/methods/play/arguments/0': meta changed value in new API, from "float" to "double".
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer/methods/seek/arguments/0': meta changed value in new API, from "float" to "double".
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer2D/methods/get_playback_position/return_value': meta changed value in new API, from "float" to "double".
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer2D/methods/play/arguments/0': meta changed value in new API, from "float" to "double".
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer2D/methods/seek/arguments/0': meta changed value in new API, from "float" to "double".
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer3D/methods/get_playback_position/return_value': meta changed value in new API, from "float" to "double".
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer3D/methods/play/arguments/0': meta changed value in new API, from "float" to "double".
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer3D/methods/seek/arguments/0': meta changed value in new API, from "float" to "double".
+
+Playback position return/param type changed from float to double for higher precision. Compatibility methods registered.

--- a/scene/2d/audio_stream_player_2d.compat.inc
+++ b/scene/2d/audio_stream_player_2d.compat.inc
@@ -34,8 +34,23 @@ bool AudioStreamPlayer2D::_is_autoplay_enabled_bind_compat_86907() {
 	return is_autoplay_enabled();
 }
 
+void AudioStreamPlayer2D::_play_bind_compat_105545(float p_from_pos) {
+	play(p_from_pos);
+}
+
+void AudioStreamPlayer2D::_seek_bind_compat_105545(float p_seconds) {
+	seek(p_seconds);
+}
+
+float AudioStreamPlayer2D::_get_playback_position_bind_compat_105545() {
+	return get_playback_position();
+}
+
 void AudioStreamPlayer2D::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("is_autoplay_enabled"), &AudioStreamPlayer2D::_is_autoplay_enabled_bind_compat_86907);
+	ClassDB::bind_compatibility_method(D_METHOD("play", "from_position"), &AudioStreamPlayer2D::_play_bind_compat_105545, DEFVAL(0.0));
+	ClassDB::bind_compatibility_method(D_METHOD("seek", "to_position"), &AudioStreamPlayer2D::_seek_bind_compat_105545);
+	ClassDB::bind_compatibility_method(D_METHOD("get_playback_position"), &AudioStreamPlayer2D::_get_playback_position_bind_compat_105545);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -253,7 +253,7 @@ void AudioStreamPlayer2D::_play_internal(double p_from_pos) {
 	}
 }
 
-void AudioStreamPlayer2D::play(float p_from_pos) {
+void AudioStreamPlayer2D::play(double p_from_pos) {
 	internal->scheduled_time = 0;
 	_play_internal(p_from_pos);
 }
@@ -263,7 +263,7 @@ void AudioStreamPlayer2D::play_scheduled(double p_abs_time, double p_from_pos) {
 	_play_internal(p_from_pos);
 }
 
-void AudioStreamPlayer2D::seek(float p_seconds) {
+void AudioStreamPlayer2D::seek(double p_seconds) {
 	internal->seek(p_seconds);
 }
 
@@ -279,7 +279,7 @@ bool AudioStreamPlayer2D::is_playing() const {
 	return internal->is_playing();
 }
 
-float AudioStreamPlayer2D::get_playback_position() {
+double AudioStreamPlayer2D::get_playback_position() {
 	if (setplay.get() >= 0) {
 		return setplay.get(); // play() has been called this frame, but no playback exists just yet.
 	}

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -72,6 +72,8 @@ private:
 	StringName _get_actual_bus();
 	void _update_panning();
 
+	void _play_internal(double p_from_pos = 0.0);
+
 	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer2D *>(self)->force_update_panning = true; }
 
 	uint32_t area_mask = 1;
@@ -110,6 +112,7 @@ public:
 	float get_pitch_scale() const;
 
 	void play(float p_from_pos = 0.0);
+	void play_scheduled(double p_abs_time, double p_from_pos = 0.0);
 	void seek(float p_seconds);
 	void stop();
 	bool is_playing() const;

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -95,6 +95,9 @@ protected:
 
 #ifndef DISABLE_DEPRECATED
 	bool _is_autoplay_enabled_bind_compat_86907();
+	void _play_bind_compat_105545(float p_from_pos = 0.0);
+	void _seek_bind_compat_105545(float p_seconds);
+	float _get_playback_position_bind_compat_105545();
 	static void _bind_compatibility_methods();
 #endif // DISABLE_DEPRECATED
 
@@ -111,12 +114,12 @@ public:
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;
 
-	void play(float p_from_pos = 0.0);
+	void play(double p_from_pos = 0.0);
 	void play_scheduled(double p_abs_time, double p_from_pos = 0.0);
-	void seek(float p_seconds);
+	void seek(double p_seconds);
 	void stop();
 	bool is_playing() const;
-	float get_playback_position();
+	double get_playback_position();
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;

--- a/scene/3d/audio_stream_player_3d.compat.inc
+++ b/scene/3d/audio_stream_player_3d.compat.inc
@@ -34,8 +34,23 @@ bool AudioStreamPlayer3D::_is_autoplay_enabled_bind_compat_86907() {
 	return is_autoplay_enabled();
 }
 
+void AudioStreamPlayer3D::_play_bind_compat_105545(float p_from_pos) {
+	play(p_from_pos);
+}
+
+void AudioStreamPlayer3D::_seek_bind_compat_105545(float p_seconds) {
+	seek(p_seconds);
+}
+
+float AudioStreamPlayer3D::_get_playback_position_bind_compat_105545() {
+	return get_playback_position();
+}
+
 void AudioStreamPlayer3D::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("is_autoplay_enabled"), &AudioStreamPlayer3D::_is_autoplay_enabled_bind_compat_86907);
+	ClassDB::bind_compatibility_method(D_METHOD("play", "from_position"), &AudioStreamPlayer3D::_play_bind_compat_105545, DEFVAL(0.0));
+	ClassDB::bind_compatibility_method(D_METHOD("seek", "to_position"), &AudioStreamPlayer3D::_seek_bind_compat_105545);
+	ClassDB::bind_compatibility_method(D_METHOD("get_playback_position"), &AudioStreamPlayer3D::_get_playback_position_bind_compat_105545);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -289,7 +289,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 				internal->active.set();
 				HashMap<StringName, Vector<AudioFrame>> bus_map;
 				bus_map[_get_actual_bus()] = volume_vector;
-				AudioServer::get_singleton()->start_playback_stream(setplayback, bus_map, setplay.get(), actual_pitch_scale, linear_attenuation, attenuation_filter_cutoff_hz);
+				AudioServer::get_singleton()->start_playback_stream(setplayback, bus_map, setplay.get(), internal->scheduled_time, actual_pitch_scale, linear_attenuation, attenuation_filter_cutoff_hz);
 				setplayback.unref();
 				setplay.set(-1);
 			}
@@ -591,7 +591,7 @@ float AudioStreamPlayer3D::get_pitch_scale() const {
 	return internal->pitch_scale;
 }
 
-void AudioStreamPlayer3D::play(float p_from_pos) {
+void AudioStreamPlayer3D::_play_internal(double p_from_pos) {
 	Ref<AudioStreamPlayback> stream_playback = internal->play_basic();
 	if (stream_playback.is_null()) {
 		return;
@@ -601,12 +601,26 @@ void AudioStreamPlayer3D::play(float p_from_pos) {
 
 	// Sample handling.
 	if (stream_playback->get_is_sample() && stream_playback->get_sample_playback().is_valid()) {
+		if (internal->scheduled_time > 0) {
+			WARN_PRINT_ED("play_scheduled() does not support samples. Playing immediately.");
+		}
+
 		Ref<AudioSamplePlayback> sample_playback = stream_playback->get_sample_playback();
 		sample_playback->offset = p_from_pos;
 		sample_playback->bus = _get_actual_bus();
 
 		AudioServer::get_singleton()->start_sample_playback(sample_playback);
 	}
+}
+
+void AudioStreamPlayer3D::play(float p_from_pos) {
+	internal->scheduled_time = 0;
+	_play_internal(p_from_pos);
+}
+
+void AudioStreamPlayer3D::play_scheduled(double p_abs_time, double p_from_pos) {
+	internal->scheduled_time = p_abs_time;
+	_play_internal(p_from_pos);
 }
 
 void AudioStreamPlayer3D::seek(float p_seconds) {
@@ -822,6 +836,7 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer3D::get_pitch_scale);
 
 	ClassDB::bind_method(D_METHOD("play", "from_position"), &AudioStreamPlayer3D::play, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("play_scheduled", "absolute_time", "from_position"), &AudioStreamPlayer3D::play_scheduled, DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("seek", "to_position"), &AudioStreamPlayer3D::seek);
 	ClassDB::bind_method(D_METHOD("stop"), &AudioStreamPlayer3D::stop);
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -613,7 +613,7 @@ void AudioStreamPlayer3D::_play_internal(double p_from_pos) {
 	}
 }
 
-void AudioStreamPlayer3D::play(float p_from_pos) {
+void AudioStreamPlayer3D::play(double p_from_pos) {
 	internal->scheduled_time = 0;
 	_play_internal(p_from_pos);
 }
@@ -623,7 +623,7 @@ void AudioStreamPlayer3D::play_scheduled(double p_abs_time, double p_from_pos) {
 	_play_internal(p_from_pos);
 }
 
-void AudioStreamPlayer3D::seek(float p_seconds) {
+void AudioStreamPlayer3D::seek(double p_seconds) {
 	internal->seek(p_seconds);
 }
 
@@ -639,7 +639,7 @@ bool AudioStreamPlayer3D::is_playing() const {
 	return internal->is_playing();
 }
 
-float AudioStreamPlayer3D::get_playback_position() {
+double AudioStreamPlayer3D::get_playback_position() {
 	if (setplay.get() >= 0) {
 		return setplay.get(); // play() has been called this frame, but no playback exists just yet.
 	}

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -97,6 +97,8 @@ private:
 #endif // PHYSICS_3D_DISABLED
 	Vector<AudioFrame> _update_panning();
 
+	void _play_internal(double p_from_pos = 0.0);
+
 	uint32_t area_mask = 1;
 
 	AudioServer::PlaybackType playback_type = AudioServer::PlaybackType::PLAYBACK_TYPE_DEFAULT;
@@ -155,6 +157,7 @@ public:
 	float get_pitch_scale() const;
 
 	void play(float p_from_pos = 0.0);
+	void play_scheduled(double p_abs_time, double p_from_pos = 0.0);
 	void seek(float p_seconds);
 	void stop();
 	bool is_playing() const;

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -134,6 +134,9 @@ protected:
 
 #ifndef DISABLE_DEPRECATED
 	bool _is_autoplay_enabled_bind_compat_86907();
+	void _play_bind_compat_105545(float p_from_pos = 0.0);
+	void _seek_bind_compat_105545(float p_seconds);
+	float _get_playback_position_bind_compat_105545();
 	static void _bind_compatibility_methods();
 #endif // DISABLE_DEPRECATED
 
@@ -156,12 +159,12 @@ public:
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;
 
-	void play(float p_from_pos = 0.0);
+	void play(double p_from_pos = 0.0);
 	void play_scheduled(double p_abs_time, double p_from_pos = 0.0);
-	void seek(float p_seconds);
+	void seek(double p_seconds);
 	void stop();
 	bool is_playing() const;
-	float get_playback_position();
+	double get_playback_position();
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;

--- a/scene/audio/audio_stream_player.compat.inc
+++ b/scene/audio/audio_stream_player.compat.inc
@@ -34,8 +34,23 @@ bool AudioStreamPlayer::_is_autoplay_enabled_bind_compat_86907() {
 	return is_autoplay_enabled();
 }
 
+void AudioStreamPlayer::_play_bind_compat_105545(float p_from_pos) {
+	play(p_from_pos);
+}
+
+void AudioStreamPlayer::_seek_bind_compat_105545(float p_seconds) {
+	seek(p_seconds);
+}
+
+float AudioStreamPlayer::_get_playback_position_bind_compat_105545() {
+	return get_playback_position();
+}
+
 void AudioStreamPlayer::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("is_autoplay_enabled"), &AudioStreamPlayer::_is_autoplay_enabled_bind_compat_86907);
+	ClassDB::bind_compatibility_method(D_METHOD("play", "from_position"), &AudioStreamPlayer::_play_bind_compat_105545, DEFVAL(0.0));
+	ClassDB::bind_compatibility_method(D_METHOD("seek", "to_position"), &AudioStreamPlayer::_seek_bind_compat_105545);
+	ClassDB::bind_compatibility_method(D_METHOD("get_playback_position"), &AudioStreamPlayer::_get_playback_position_bind_compat_105545);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -103,16 +103,20 @@ int AudioStreamPlayer::get_max_polyphony() const {
 	return internal->max_polyphony;
 }
 
-void AudioStreamPlayer::play(float p_from_pos) {
+void AudioStreamPlayer::_play_internal(double p_from_pos) {
 	Ref<AudioStreamPlayback> stream_playback = internal->play_basic();
 	if (stream_playback.is_null()) {
 		return;
 	}
-	AudioServer::get_singleton()->start_playback_stream(stream_playback, internal->bus, _get_volume_vector(), p_from_pos, internal->pitch_scale);
+	AudioServer::get_singleton()->start_playback_stream(stream_playback, internal->bus, _get_volume_vector(), p_from_pos, internal->scheduled_time, internal->pitch_scale);
 	internal->ensure_playback_limit();
 
 	// Sample handling.
 	if (stream_playback->get_is_sample() && stream_playback->get_sample_playback().is_valid()) {
+		if (internal->scheduled_time > 0) {
+			WARN_PRINT_ED("play_scheduled() does not support samples. Playing immediately.");
+		}
+
 		Ref<AudioSamplePlayback> sample_playback = stream_playback->get_sample_playback();
 		sample_playback->offset = p_from_pos;
 		sample_playback->volume_vector = _get_volume_vector();
@@ -120,6 +124,16 @@ void AudioStreamPlayer::play(float p_from_pos) {
 
 		AudioServer::get_singleton()->start_sample_playback(sample_playback);
 	}
+}
+
+void AudioStreamPlayer::play(float p_from_pos) {
+	internal->scheduled_time = 0;
+	_play_internal(p_from_pos);
+}
+
+void AudioStreamPlayer::play_scheduled(double p_abs_time, double p_from_pos) {
+	internal->scheduled_time = p_abs_time;
+	_play_internal(p_from_pos);
 }
 
 void AudioStreamPlayer::seek(float p_seconds) {
@@ -248,6 +262,7 @@ void AudioStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer::get_pitch_scale);
 
 	ClassDB::bind_method(D_METHOD("play", "from_position"), &AudioStreamPlayer::play, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("play_scheduled", "absolute_time", "from_position"), &AudioStreamPlayer::play_scheduled, DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("seek", "to_position"), &AudioStreamPlayer::seek);
 	ClassDB::bind_method(D_METHOD("stop"), &AudioStreamPlayer::stop);
 

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -126,7 +126,7 @@ void AudioStreamPlayer::_play_internal(double p_from_pos) {
 	}
 }
 
-void AudioStreamPlayer::play(float p_from_pos) {
+void AudioStreamPlayer::play(double p_from_pos) {
 	internal->scheduled_time = 0;
 	_play_internal(p_from_pos);
 }
@@ -136,7 +136,7 @@ void AudioStreamPlayer::play_scheduled(double p_abs_time, double p_from_pos) {
 	_play_internal(p_from_pos);
 }
 
-void AudioStreamPlayer::seek(float p_seconds) {
+void AudioStreamPlayer::seek(double p_seconds) {
 	internal->seek(p_seconds);
 }
 
@@ -148,7 +148,7 @@ bool AudioStreamPlayer::is_playing() const {
 	return internal->is_playing();
 }
 
-float AudioStreamPlayer::get_playback_position() {
+double AudioStreamPlayer::get_playback_position() {
 	return internal->get_playback_position();
 }
 

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -58,6 +58,8 @@ private:
 
 	Vector<AudioFrame> _get_volume_vector();
 
+	void _play_internal(double p_from_pos = 0.0);
+
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
@@ -89,6 +91,7 @@ public:
 	int get_max_polyphony() const;
 
 	void play(float p_from_pos = 0.0);
+	void play_scheduled(double p_abs_time, double p_from_pos = 0.0);
 	void seek(float p_seconds);
 	void stop();
 	bool is_playing() const;

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -71,6 +71,9 @@ protected:
 
 #ifndef DISABLE_DEPRECATED
 	bool _is_autoplay_enabled_bind_compat_86907();
+	void _play_bind_compat_105545(float p_from_pos = 0.0);
+	void _seek_bind_compat_105545(float p_seconds);
+	float _get_playback_position_bind_compat_105545();
 	static void _bind_compatibility_methods();
 #endif // DISABLE_DEPRECATED
 
@@ -90,12 +93,12 @@ public:
 	void set_max_polyphony(int p_max_polyphony);
 	int get_max_polyphony() const;
 
-	void play(float p_from_pos = 0.0);
+	void play(double p_from_pos = 0.0);
 	void play_scheduled(double p_abs_time, double p_from_pos = 0.0);
-	void seek(float p_seconds);
+	void seek(double p_seconds);
 	void stop();
 	bool is_playing() const;
-	float get_playback_position();
+	double get_playback_position();
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;

--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -260,7 +260,7 @@ void AudioStreamPlayerInternal::set_stream(Ref<AudioStream> p_stream) {
 	node->notify_property_list_changed();
 }
 
-void AudioStreamPlayerInternal::seek(float p_seconds) {
+void AudioStreamPlayerInternal::seek(double p_seconds) {
 	if (is_playing()) {
 		stop_callable.call();
 		play_callable.call(p_seconds);
@@ -286,7 +286,7 @@ bool AudioStreamPlayerInternal::is_playing() const {
 	return false;
 }
 
-float AudioStreamPlayerInternal::get_playback_position() {
+double AudioStreamPlayerInternal::get_playback_position() {
 	// Return the playback position of the most recently started playback stream.
 	if (!stream_playbacks.is_empty()) {
 		return AudioServer::get_singleton()->get_playback_position(stream_playbacks[stream_playbacks.size() - 1]);

--- a/scene/audio/audio_stream_player_internal.h
+++ b/scene/audio/audio_stream_player_internal.h
@@ -76,6 +76,7 @@ public:
 	bool autoplay = false;
 	StringName bus;
 	int max_polyphony = 1;
+	double scheduled_time = 0;
 
 	void process();
 	void ensure_playback_limit();
@@ -93,10 +94,10 @@ public:
 	StringName get_bus() const;
 
 	Ref<AudioStreamPlayback> play_basic();
-	void seek(float p_seconds);
+	void seek(double p_seconds);
 	void stop_basic();
 	bool is_playing() const;
-	float get_playback_position();
+	double get_playback_position();
 
 	void set_playing(bool p_enable);
 	bool is_active() const;

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -404,8 +404,22 @@ void AudioServer::_mix_step() {
 			buf[i] = playback->lookahead[i];
 		}
 
-		// Mix the audio stream.
-		unsigned int mixed_frames = playback->stream_playback->mix(&buf[LOOKAHEAD_BUFFER_SIZE], playback->pitch_scale.get(), buffer_size);
+		unsigned int mixed_frames = 0;
+
+		// For audio scheduled to start later, fill the buffer with silence frames.
+		uint64_t scheduled_start_frame = playback->scheduled_start_frame.get();
+		if (scheduled_start_frame > mix_frames) {
+			unsigned int silence_frames = (unsigned int)MIN(scheduled_start_frame - mix_frames, buffer_size);
+			for (unsigned int i = 0; i < silence_frames; i++) {
+				buf[LOOKAHEAD_BUFFER_SIZE + i] = AudioFrame(0, 0);
+			}
+			mixed_frames += silence_frames;
+		}
+
+		// Then mix the actual audio stream with the remaining space.
+		if (mixed_frames < buffer_size) {
+			mixed_frames += playback->stream_playback->mix(&buf[LOOKAHEAD_BUFFER_SIZE + mixed_frames], playback->pitch_scale.get(), buffer_size - mixed_frames);
+		}
 
 		if (tag_used_audio_streams && playback->stream_playback->is_playing()) {
 			playback->stream_playback->tag_used_streams();
@@ -1224,21 +1238,21 @@ float AudioServer::get_playback_speed_scale() const {
 	return playback_speed_scale;
 }
 
-void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time, float p_pitch_scale) {
+void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, double p_from_pos, double p_scheduled_start_time, float p_pitch_scale) {
 	ERR_FAIL_COND(p_playback.is_null());
 
 	HashMap<StringName, Vector<AudioFrame>> map;
 	map[p_bus] = p_volume_db_vector;
 
-	start_playback_stream(p_playback, map, p_start_time, p_pitch_scale);
+	start_playback_stream(p_playback, map, p_from_pos, p_scheduled_start_time, p_pitch_scale);
 }
 
-void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, float p_start_time, float p_pitch_scale, float p_highshelf_gain, float p_attenuation_cutoff_hz) {
+void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, double p_from_pos, double p_scheduled_start_time, float p_pitch_scale, float p_highshelf_gain, float p_attenuation_cutoff_hz) {
 	ERR_FAIL_COND(p_playback.is_null());
 
 	AudioStreamPlaybackListNode *playback_node = new AudioStreamPlaybackListNode();
 	playback_node->stream_playback = p_playback;
-	playback_node->stream_playback->start(p_start_time);
+	playback_node->stream_playback->start(p_from_pos);
 
 	AudioStreamPlaybackBusDetails *new_bus_details = new AudioStreamPlaybackBusDetails();
 	int idx = 0;
@@ -1262,6 +1276,14 @@ void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, con
 	playback_node->pitch_scale.set(p_pitch_scale);
 	playback_node->highshelf_gain.set(p_highshelf_gain);
 	playback_node->attenuation_filter_cutoff_hz.set(p_attenuation_cutoff_hz);
+
+	uint64_t scheduled_start_frame = uint64_t(p_scheduled_start_time * get_mix_rate());
+	if (scheduled_start_frame > 0 && scheduled_start_frame < mix_frames) {
+		WARN_PRINT_ED(vformat("Sound (%s) was scheduled for absolute time %.4f, which has already passed. Playing immediately.",
+				p_playback->get_instance_id(),
+				p_scheduled_start_time));
+	}
+	playback_node->scheduled_start_frame.set(scheduled_start_frame);
 
 	memset(playback_node->prev_bus_details->volume, 0, sizeof(playback_node->prev_bus_details->volume));
 
@@ -1447,7 +1469,7 @@ bool AudioServer::is_playback_active(Ref<AudioStreamPlayback> p_playback) {
 	return playback_node->state.load() == AudioStreamPlaybackListNode::PLAYING;
 }
 
-float AudioServer::get_playback_position(Ref<AudioStreamPlayback> p_playback) {
+double AudioServer::get_playback_position(Ref<AudioStreamPlayback> p_playback) {
 	ERR_FAIL_COND_V(p_playback.is_null(), 0);
 
 	// Samples.
@@ -1685,6 +1707,10 @@ double AudioServer::get_time_to_next_mix() const {
 
 double AudioServer::get_time_since_last_mix() const {
 	return AudioDriver::get_singleton()->get_time_since_last_mix();
+}
+
+double AudioServer::get_absolute_time() const {
+	return mix_frames / (double)get_mix_rate();
 }
 
 AudioServer *AudioServer::singleton = nullptr;
@@ -2012,6 +2038,7 @@ void AudioServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_time_to_next_mix"), &AudioServer::get_time_to_next_mix);
 	ClassDB::bind_method(D_METHOD("get_time_since_last_mix"), &AudioServer::get_time_since_last_mix);
+	ClassDB::bind_method(D_METHOD("get_absolute_time"), &AudioServer::get_absolute_time);
 	ClassDB::bind_method(D_METHOD("get_output_latency"), &AudioServer::get_output_latency);
 
 	ClassDB::bind_method(D_METHOD("get_input_device_list"), &AudioServer::get_input_device_list);

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -294,6 +294,7 @@ private:
 		SafeNumeric<float> pitch_scale;
 		SafeNumeric<float> highshelf_gain;
 		SafeNumeric<float> attenuation_filter_cutoff_hz; // This isn't used unless highshelf_gain is nonzero.
+		SafeNumeric<uint64_t> scheduled_start_frame;
 		AudioFilterSW::Processor filter_process[8];
 		// Updating this ref after the list node is created breaks consistency guarantees, don't do it!
 		Ref<AudioStreamPlayback> stream_playback;
@@ -428,9 +429,9 @@ public:
 	float get_playback_speed_scale() const;
 
 	// Convenience method.
-	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time = 0, float p_pitch_scale = 1);
+	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, double p_from_pos = 0, double p_scheduled_start_time = 0, float p_pitch_scale = 1);
 	// Expose all parameters.
-	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, float p_start_time = 0, float p_pitch_scale = 1, float p_highshelf_gain = 0, float p_attenuation_cutoff_hz = 0);
+	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, double p_from_pos = 0, double p_scheduled_start_time = 0, float p_pitch_scale = 1, float p_highshelf_gain = 0, float p_attenuation_cutoff_hz = 0);
 	void stop_playback_stream(Ref<AudioStreamPlayback> p_playback);
 
 	void set_playback_bus_exclusive(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volumes);
@@ -441,7 +442,7 @@ public:
 	void set_playback_highshelf_params(Ref<AudioStreamPlayback> p_playback, float p_gain, float p_attenuation_cutoff_hz);
 
 	bool is_playback_active(Ref<AudioStreamPlayback> p_playback);
-	float get_playback_position(Ref<AudioStreamPlayback> p_playback);
+	double get_playback_position(Ref<AudioStreamPlayback> p_playback);
 	bool is_playback_paused(Ref<AudioStreamPlayback> p_playback);
 
 	uint64_t get_mix_count() const;
@@ -472,6 +473,7 @@ public:
 	virtual double get_output_latency() const;
 	virtual double get_time_to_next_mix() const;
 	virtual double get_time_since_last_mix() const;
+	virtual double get_absolute_time() const;
 
 	void add_listener_changed_callback(AudioCallback p_callback, void *p_userdata);
 	void remove_listener_changed_callback(AudioCallback p_callback, void *p_userdata);


### PR DESCRIPTION
Two reasons to change this:
* At a default mix rate of 44100, the playback position in seconds can experience rounding errors with a 32-bit type if the value is high enough. 44100 requires 15 free bits in the mantissa to be within 1/2 an audio frame, so the cutoff is 512 seconds before rounding issues occur (512=2^9, and 9+15 > 23 mantissa bits in 32-bit float).
* Internally, AudioStreamPlayback and AudioStream use a 64-bit type for playback position.

See this discussion: https://github.com/godotengine/godot/pull/105510#discussion_r2049745296

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
