### PR TITLE
Fix GDExtension `Object/Node::to_string` to check `is_valid` before returning the result

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -978,7 +978,9 @@ String Object::to_string() {
 		String ret;
 		GDExtensionBool is_valid;
 		_extension->to_string(_extension_instance, &is_valid, &ret);
-		return ret;
+		if (is_valid) {
+			return ret;
+		}
 	}
 	return "<" + get_class() + "#" + itos(get_instance_id()) + ">";
 }

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2864,7 +2864,9 @@ String Node::to_string() {
 		String ret;
 		GDExtensionBool is_valid;
 		_get_extension()->to_string(_get_extension_instance(), &is_valid, &ret);
-		return ret;
+		if (is_valid) {
+			return ret;
+		}
 	}
 	return (get_name() ? String(get_name()) + ":" : "") + Object::to_string();
 }


### PR DESCRIPTION
At best, this results in an empty string, at worst, the result is never initialized when is_valid is false.