### PR TITLE
Improve default OK text in AcceptDialog

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -151,7 +151,6 @@
 		<member name="mode_overrides_title" type="bool" setter="set_mode_overrides_title" getter="is_mode_overriding_title" default="true">
 			If [code]true[/code], changing the [member file_mode] property will set the window title accordingly (e.g. setting [member file_mode] to [constant FILE_MODE_OPEN_FILE] will change the window title to "Open a File").
 		</member>
-		<member name="ok_button_text" type="String" setter="set_ok_button_text" getter="get_ok_button_text" overrides="AcceptDialog" default="&quot;Save&quot;" />
 		<member name="option_count" type="int" setter="set_option_count" getter="get_option_count" default="0">
 			The number of additional [OptionButton]s and [CheckBox]es in the dialog.
 		</member>

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -223,9 +223,10 @@ EditorPropertyText::EditorPropertyText() {
 	add_child(hb);
 
 	text = memnew(LineEdit);
+	text->set_h_size_flags(SIZE_EXPAND_FILL);
+	text->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED); // Prevents translating placeholder.
 	hb->add_child(text);
 	add_focusable(text);
-	text->set_h_size_flags(SIZE_EXPAND_FILL);
 	text->connect(SceneStringName(text_changed), callable_mp(this, &EditorPropertyText::_text_changed));
 	text->connect(SceneStringName(text_submitted), callable_mp(this, &EditorPropertyText::_text_submitted));
 }

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -261,7 +261,7 @@ void AcceptDialog::_update_child_rects() {
 
 void AcceptDialog::_update_ok_text() {
 	String prev_text = ok_button->get_text();
-	String new_text = internal_ok_text;
+	String new_text = default_ok_text;
 
 	if (!ok_text.is_empty()) {
 		new_text = ok_text;
@@ -315,9 +315,13 @@ Size2 AcceptDialog::_get_contents_minimum_size() const {
 	return content_minsize;
 }
 
-void AcceptDialog::set_internal_ok_text(const String &p_text) {
-	internal_ok_text = p_text;
+void AcceptDialog::set_default_ok_text(const String &p_text) {
+	if (default_ok_text == p_text) {
+		return;
+	}
+	default_ok_text = p_text;
 	_update_ok_text();
+	notify_property_list_changed();
 }
 
 void AcceptDialog::_custom_action(const String &p_action) {
@@ -441,7 +445,13 @@ void AcceptDialog::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, AcceptDialog, buttons_min_height);
 }
 
-bool AcceptDialog::swap_cancel_ok = false;
+void AcceptDialog::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "ok_button_text") {
+		p_property.hint = PROPERTY_HINT_PLACEHOLDER_TEXT;
+		p_property.hint_string = default_ok_text;
+	}
+}
+
 void AcceptDialog::set_swap_cancel_ok(bool p_swap) {
 	swap_cancel_ok = p_swap;
 }
@@ -472,7 +482,7 @@ AcceptDialog::AcceptDialog() {
 
 	buttons_hbox->add_spacer();
 	ok_button = memnew(Button);
-	set_internal_ok_text(ETR("OK"));
+	set_default_ok_text(ETR("OK"));
 	buttons_hbox->add_child(ok_button);
 	buttons_hbox->add_spacer();
 

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -52,7 +52,7 @@ class AcceptDialog : public Window {
 
 	bool popped_up = false;
 	String ok_text;
-	String internal_ok_text;
+	String default_ok_text;
 
 	bool hide_on_ok = true;
 	bool close_on_escape = true;
@@ -69,7 +69,7 @@ class AcceptDialog : public Window {
 	void _update_child_rects();
 	void _update_ok_text();
 
-	static bool swap_cancel_ok;
+	inline static bool swap_cancel_ok = false;
 
 	void _parent_focused();
 
@@ -80,12 +80,13 @@ protected:
 
 	void _notification(int p_what);
 	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
 
 	virtual void ok_pressed() {}
 	virtual void cancel_pressed() {}
 	virtual void custom_action(const String &) {}
 
-	void set_internal_ok_text(const String &p_text);
+	void set_default_ok_text(const String &p_text);
 
 	// Not private since used by derived classes signal.
 	void _text_submitted(const String &p_text);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -596,16 +596,16 @@ void FileDialog::deselect_all() {
 	switch (mode) {
 		case FILE_MODE_OPEN_FILE:
 		case FILE_MODE_OPEN_FILES:
-			set_internal_ok_text(ETR("Open"));
+			set_default_ok_text(ETR("Open"));
 			break;
 		case FILE_MODE_OPEN_DIR:
-			set_internal_ok_text(ETR("Select Current Folder"));
+			set_default_ok_text(ETR("Select Current Folder"));
 			break;
 		case FILE_MODE_OPEN_ANY:
-			set_ok_button_text(ETR("Open"));
+			set_default_ok_text(ETR("Open"));
 			break;
 		case FILE_MODE_SAVE_FILE:
-			set_ok_button_text(ETR("Save"));
+			set_default_ok_text(ETR("Save"));
 			break;
 	}
 }
@@ -629,14 +629,14 @@ void FileDialog::_file_list_selected(int p_item) {
 	if (!d["dir"]) {
 		filename_edit->set_text(d["name"]);
 		if (mode == FILE_MODE_SAVE_FILE) {
-			set_internal_ok_text(ETR("Save"));
+			set_default_ok_text(ETR("Save"));
 		} else {
-			set_internal_ok_text(ETR("Open"));
+			set_default_ok_text(ETR("Open"));
 		}
 	} else if (mode == FILE_MODE_OPEN_DIR || mode == FILE_MODE_OPEN_ANY || !dir_access->file_exists(filename_edit->get_text())) {
 		filename_edit->set_text("");
 		if (mode == FILE_MODE_OPEN_DIR || mode == FILE_MODE_OPEN_ANY) {
-			set_internal_ok_text(ETR("Select This Folder"));
+			set_default_ok_text(ETR("Select This Folder"));
 		}
 	}
 
@@ -1138,35 +1138,35 @@ void FileDialog::set_file_mode(FileMode p_mode) {
 	mode = p_mode;
 	switch (mode) {
 		case FILE_MODE_OPEN_FILE:
-			set_internal_ok_text(ETR("Open"));
+			set_default_ok_text(ETR("Open"));
 			if (mode_overrides_title) {
 				set_title(ETR("Open a File"));
 			}
 			make_dir_button->hide();
 			break;
 		case FILE_MODE_OPEN_FILES:
-			set_internal_ok_text(ETR("Open"));
+			set_default_ok_text(ETR("Open"));
 			if (mode_overrides_title) {
 				set_title(ETR("Open File(s)"));
 			}
 			make_dir_button->hide();
 			break;
 		case FILE_MODE_OPEN_DIR:
-			set_internal_ok_text(ETR("Select Current Folder"));
+			set_default_ok_text(ETR("Select Current Folder"));
 			if (mode_overrides_title) {
 				set_title(ETR("Open a Directory"));
 			}
 			make_dir_button->show();
 			break;
 		case FILE_MODE_OPEN_ANY:
-			set_internal_ok_text(ETR("Open"));
+			set_default_ok_text(ETR("Open"));
 			if (mode_overrides_title) {
 				set_title(ETR("Open a File or Directory"));
 			}
 			make_dir_button->show();
 			break;
 		case FILE_MODE_SAVE_FILE:
-			set_internal_ok_text(ETR("Save"));
+			set_default_ok_text(ETR("Save"));
 			if (mode_overrides_title) {
 				set_title(ETR("Save a File"));
 			}
@@ -1644,7 +1644,7 @@ FileDialog::FileDialog() {
 	set_title(ETR("Save a File"));
 	set_hide_on_ok(false);
 	set_size(Size2(640, 360));
-	set_internal_ok_text(ETR("Save")); // Default mode text.
+	set_default_ok_text(ETR("Save")); // Default mode text.
 
 	show_hidden_files = default_show_hidden_files;
 	dir_access = DirAccess::create(DirAccess::ACCESS_RESOURCES);


### PR DESCRIPTION
Follow-up to #81178
Fixes #106406

- Fixed some missed OK texts in FileDialog.
- Renamed the `internal_ok_text` to `default_ok_text`, to better match its purpose.
- Added placeholder that displays default OK text.

https://github.com/user-attachments/assets/000316ad-86e9-4643-aafc-98905fd455c6

I noticed that `title` property has the same problem as `ok_button_text`, but it's in Window and fixing it is going to be a bit more complex :/