### PR TITLE
Add `PhysicsDirectSpaceState3D.intersect_ray_no_alloc`

### DIFF
--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -241,6 +241,44 @@ Ref<PhysicsRayQueryParameters3D> PhysicsRayQueryParameters3D::create(Vector3 p_f
 	return params;
 }
 
+Vector3 PhysicsRayQueryResult3D::get_position() const {
+	return result.position;
+}
+
+Vector3 PhysicsRayQueryResult3D::get_normal() const {
+	return result.normal;
+}
+
+RID PhysicsRayQueryResult3D::get_rid() const {
+	return result.rid;
+}
+
+ObjectID PhysicsRayQueryResult3D::get_collider_id() const {
+	return result.collider_id;
+}
+
+Object *PhysicsRayQueryResult3D::get_collider() const {
+	return result.collider;
+}
+
+int PhysicsRayQueryResult3D::get_shape() const {
+	return result.shape;
+}
+
+int PhysicsRayQueryResult3D::get_face_index() const {
+	return result.face_index;
+}
+
+void PhysicsRayQueryResult3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_position"), &PhysicsRayQueryResult3D::get_position);
+	ClassDB::bind_method(D_METHOD("get_normal"), &PhysicsRayQueryResult3D::get_normal);
+	ClassDB::bind_method(D_METHOD("get_rid"), &PhysicsRayQueryResult3D::get_rid);
+	ClassDB::bind_method(D_METHOD("get_collider_id"), &PhysicsRayQueryResult3D::get_collider_id);
+	ClassDB::bind_method(D_METHOD("get_collider"), &PhysicsRayQueryResult3D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_shape"), &PhysicsRayQueryResult3D::get_shape);
+	ClassDB::bind_method(D_METHOD("get_face_index"), &PhysicsRayQueryResult3D::get_face_index);
+}
+
 void PhysicsPointQueryParameters3D::set_exclude(const TypedArray<RID> &p_exclude) {
 	parameters.exclude.clear();
 	for (int i = 0; i < p_exclude.size(); i++) {
@@ -376,6 +414,17 @@ Dictionary PhysicsDirectSpaceState3D::_intersect_ray(const Ref<PhysicsRayQueryPa
 	return d;
 }
 
+bool PhysicsDirectSpaceState3D::_intersect_ray_no_alloc(const Ref<PhysicsRayQueryParameters3D> &p_ray_query, const Ref<PhysicsRayQueryResult3D> &p_result) {
+	ERR_FAIL_COND_V(p_ray_query.is_null(), false);
+
+	RayResult *result_ptr = nullptr;
+	if (p_result.is_valid()) {
+		result_ptr = p_result->get_result_ptr();
+	}
+
+	return intersect_ray(p_ray_query->get_parameters(), *result_ptr);
+}
+
 TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(const Ref<PhysicsPointQueryParameters3D> &p_point_query, int p_max_results) {
 	ERR_FAIL_COND_V(p_point_query.is_null(), TypedArray<Dictionary>());
 
@@ -481,6 +530,7 @@ PhysicsDirectSpaceState3D::PhysicsDirectSpaceState3D() {
 void PhysicsDirectSpaceState3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("intersect_point", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_point, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("intersect_ray", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray);
+	ClassDB::bind_method(D_METHOD("intersect_ray_no_alloc", "parameters", "result"), &PhysicsDirectSpaceState3D::_intersect_ray_no_alloc);
 	ClassDB::bind_method(D_METHOD("intersect_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("cast_motion", "parameters"), &PhysicsDirectSpaceState3D::_cast_motion);
 	ClassDB::bind_method(D_METHOD("collide_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_collide_shape, DEFVAL(32));

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -115,6 +115,7 @@ public:
 };
 
 class PhysicsRayQueryParameters3D;
+class PhysicsRayQueryResult3D;
 class PhysicsPointQueryParameters3D;
 class PhysicsShapeQueryParameters3D;
 
@@ -123,6 +124,7 @@ class PhysicsDirectSpaceState3D : public Object {
 
 private:
 	Dictionary _intersect_ray(const Ref<PhysicsRayQueryParameters3D> &p_ray_query);
+	bool _intersect_ray_no_alloc(const Ref<PhysicsRayQueryParameters3D> &p_ray_query, const Ref<PhysicsRayQueryResult3D> &r_result);
 	TypedArray<Dictionary> _intersect_point(const Ref<PhysicsPointQueryParameters3D> &p_point_query, int p_max_results = 32);
 	TypedArray<Dictionary> _intersect_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32);
 	Vector<real_t> _cast_motion(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query);
@@ -850,6 +852,26 @@ public:
 
 	void set_exclude(const TypedArray<RID> &p_exclude);
 	TypedArray<RID> get_exclude() const;
+};
+
+class PhysicsRayQueryResult3D : public RefCounted {
+	GDCLASS(PhysicsRayQueryResult3D, RefCounted);
+
+	PhysicsDirectSpaceState3D::RayResult result;
+
+protected:
+	static void _bind_methods();
+
+public:
+	PhysicsDirectSpaceState3D::RayResult *get_result_ptr() { return &result; }
+
+	Vector3 get_position() const;
+	Vector3 get_normal() const;
+	RID get_rid() const;
+	ObjectID get_collider_id() const;
+	Object *get_collider() const;
+	int get_shape() const;
+	int get_face_index() const;
 };
 
 class PhysicsPointQueryParameters3D : public RefCounted {

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -318,6 +318,7 @@ void register_server_types() {
 	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectBodyState3D);
 	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectSpaceState3D);
 	GDREGISTER_CLASS(PhysicsRayQueryParameters3D);
+	GDREGISTER_CLASS(PhysicsRayQueryResult3D);
 	GDREGISTER_CLASS(PhysicsPointQueryParameters3D);
 	GDREGISTER_CLASS(PhysicsShapeQueryParameters3D);
 	GDREGISTER_CLASS(PhysicsTestMotionParameters3D);


### PR DESCRIPTION
Adds a "no alloc" variant of `PhysicsDirectSpaceState3D.IntersectRay` method. Takes a user-allocated result object as a parameter and stores the result there (original method creates a new `Dictionary` on every call).

This is primarily useful for C# scripts because of GC, but the function will also be available in GDScript - I'm not sure if it makes sense there, but I don't know if there's a way to not expose it to GDScript.

There's been some talks about providing zero allocation C# API here: https://github.com/godotengine/godot-proposals/issues/7842, but I do not know of any concrete plans or decisions made on how to approach this, so I implemented it in a way that makes sense to me.