### PR TITLE
Add addons_updated signal to EditorPlugin.

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -781,6 +781,17 @@
 		</method>
 	</methods>
 	<signals>
+		<signal name="addons_updated">
+			<param index="0" name="addons" type="Dictionary[]" />
+			<description>
+				Emitted when addon information is changed or newly detected by the editor. The argument is an array of dictionaries detailing every folder relative to [code]res://addons[/code] that contains either a [code]plugin.cfg[/code] or some other non-hidden file.
+				The key-value pairs of each Dictionary are as follows:
+				- [b]&amp;"dir_name"[/b]: ([String]) The directory path relative to [code]res://addons/[/code]: [code]"my_plugin"[/code]
+				- [b]&amp;"config_path"[/b]: ([String]) The absolute path to the [code]plugin.cfg[/code] file: [code]"res://addons/my_plugin/plugin.cfg"[/code]. May be empty if an addon.
+				- [b]&amp;"script_path"[/b]: ([String]) The simplified absolute path to the plugin's specified [EditorPlugin] script: [code]"res://addons/my_plugin/plugin.gd"[/code]. May be empty if an addon.
+				- [b]&amp;"plugin"[/b]: ([EditorPlugin]) The plugin instance. Will be [code]null[/code] if the addon is not a plugin or the plugin is not enabled.
+			</description>
+		</signal>
 		<signal name="main_screen_changed">
 			<param index="0" name="screen_name" type="String" />
 			<description>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -673,6 +673,21 @@ bool EditorNode::_is_project_data_missing() {
 	return false;
 }
 
+void EditorNode::_on_editor_addons_updated(Array addons) const {
+	for (Dictionary addon : addons) {
+		String config_path = addon[SNAME("config_path")].operator String();
+		if (config_path.length() > 0) {
+			EditorPlugin *const *ep = addon_name_to_plugin.getptr(config_path);
+			if (ep) {
+				addon[SNAME("plugin")] = *ep;
+			}
+		}
+	}
+	for (const KeyValue<String, EditorPlugin *> &E : addon_name_to_plugin) {
+		E.value->emit_signal(SNAME("addons_updated"), addons);
+	}
+}
+
 void EditorNode::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -994,6 +1009,8 @@ void EditorNode::init_plugins() {
 	if (!pending_addons.is_empty()) {
 		EditorFileSystem::get_singleton()->connect("script_classes_updated", callable_mp(this, &EditorNode::_enable_pending_addons), CONNECT_ONE_SHOT);
 	}
+
+	EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(project_settings_editor, &ProjectSettingsEditor::update_plugins), CONNECT_ONE_SHOT | CONNECT_DEFERRED);
 }
 
 void EditorNode::_on_plugin_ready(Object *p_script, const String &p_activate_name) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -684,6 +684,7 @@ public:
 	// Public for use with callable_mp.
 	void init_plugins();
 	void _on_plugin_ready(Object *p_script, const String &p_activate_name);
+	void _on_editor_addons_updated(Array addons) const;
 
 	bool call_build();
 

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -674,6 +674,7 @@ void EditorPlugin::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("resource_saved", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource")));
 	ADD_SIGNAL(MethodInfo("scene_saved", PropertyInfo(Variant::STRING, "filepath")));
 	ADD_SIGNAL(MethodInfo("project_settings_changed"));
+	ADD_SIGNAL(MethodInfo("addons_updated", PropertyInfo(Variant::ARRAY, "addons", PROPERTY_HINT_ARRAY_TYPE, "Dictionary")));
 
 	BIND_ENUM_CONSTANT(CONTAINER_TOOLBAR);
 	BIND_ENUM_CONSTANT(CONTAINER_SPATIAL_EDITOR_MENU);

--- a/editor/plugins/editor_plugin_settings.h
+++ b/editor/plugins/editor_plugin_settings.h
@@ -34,6 +34,14 @@
 
 class TextureRect;
 class Tree;
+class EditorPlugin;
+
+struct EditorAddonInfo {
+	String dir_name;
+	String config_path;
+	bool has_public_file = false;
+	EditorPlugin *plugin = nullptr;
+};
 
 class EditorPluginSettings : public VBoxContainer {
 	GDCLASS(EditorPluginSettings, VBoxContainer);
@@ -62,10 +70,11 @@ class EditorPluginSettings : public VBoxContainer {
 	void _create_clicked();
 	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 
-	static Vector<String> _get_plugins(const String &p_dir);
+	static Vector<String> _get_plugins(const String &p_dir, Vector<EditorAddonInfo> &r_addons, bool &r_has_public_file);
 
 protected:
 	void _notification(int p_what);
+	static void _bind_methods();
 
 public:
 	void update_plugins();

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -770,6 +770,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	plugin_settings = memnew(EditorPluginSettings);
 	plugin_settings->set_name(TTR("Plugins"));
+	plugin_settings->connect("editor_addons_updated", callable_mp(EditorNode::get_singleton(), &EditorNode::_on_editor_addons_updated));
 	tab_container->add_child(plugin_settings);
 
 	timer = memnew(Timer);


### PR DESCRIPTION
Closes godotengine/godot-proposals#11323.

Rather than a virtual method, it's set up as an `addons_updated` signal to keep in line with the usage of past-tense naming conventions. Ended up using `dir_name`, `config_path`, `script_path`, and `plugin` as the Dictionary keys. Omitted `name` since most won't need it and can derive it from `config_path` by loading the `ConfigFile`. Also omitted `is_enabled` since the nullability of the `plugin` instance informs you of that anyway.

Edit: Here is a sample project I created to showcase the behavior.
[demo_addons-updated.zip](https://github.com/user-attachments/files/19819153/demo_addons-updated.zip)

When iterating over each addon dictionary and printing it, it produces the following results:
```
{ &"dir_name": "config_addon", &"config_path": "res://addons/config_addon/plugin.cfg", &"script_path": "", &"plugin": <Object#null> }
{ &"dir_name": "extra_icons", &"config_path": "", &"script_path": "", &"plugin": <Object#null> }
{ &"dir_name": "sub/nested_addon", &"config_path": "", &"script_path": "", &"plugin": <Object#null> }
{ &"dir_name": "sub/nested_plugin", &"config_path": "res://addons/sub/nested_plugin/plugin.cfg", &"script_path": "res://addons/sub/nested_plugin/nested_plugin.gd", &"plugin": <Object#null> }
{ &"dir_name": "test", &"config_path": "res://addons/test/plugin.cfg", &"script_path": "res://addons/test/plugin.gd", &"plugin": @EditorPlugin@21745:<EditorPlugin#2183940619311> }
{ &"dir_name": "test2", &"config_path": "res://addons/test2/plugin.cfg", &"script_path": "res://addons/test2/test_plugin_2.gd", &"plugin": <Object#null> }
```