### PR TITLE
Expose `AnimationNode(StateMachine/BlendTree).get_node_list()`

### DIFF
--- a/doc/classes/AnimationNodeBlendTree.xml
+++ b/doc/classes/AnimationNodeBlendTree.xml
@@ -44,6 +44,12 @@
 				Returns the sub animation node with the specified [param name].
 			</description>
 		</method>
+		<method name="get_node_list" qualifiers="const">
+			<return type="StringName[]" />
+			<description>
+				Returns a list containing the names of all sub animation nodes in this blend tree.
+			</description>
+		</method>
 		<method name="get_node_position" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="name" type="StringName" />

--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -51,6 +51,12 @@
 				Returns the animation node with the given name.
 			</description>
 		</method>
+		<method name="get_node_list" qualifiers="const">
+			<return type="StringName[]" />
+			<description>
+				Returns a list containing the names of all animation nodes in this state machine.
+			</description>
+		</method>
 		<method name="get_node_name" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="node" type="AnimationNode" />

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -139,8 +139,7 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 
 	animations.clear();
 
-	List<StringName> nodes;
-	blend_tree->get_node_list(&nodes);
+	LocalVector<StringName> nodes = blend_tree->get_node_list();
 
 	for (const StringName &E : nodes) {
 		GraphNode *node = memnew(GraphNode);

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -448,8 +448,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		{
 			//snap
 			Vector2 cpos = state_machine->get_node_position(selected_node) + drag_ofs / EDSCALE;
-			List<StringName> nodes;
-			state_machine->get_node_list(&nodes);
+			LocalVector<StringName> nodes = state_machine->get_node_list();
 
 			float best_d_x = 1e20;
 			float best_d_y = 1e20;
@@ -661,8 +660,7 @@ void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<AnimationNodeStateMachine> p_nodesm, const StringName &p_name, const StringName &p_path) {
 	String prev_path;
 
-	List<StringName> nodes;
-	p_nodesm->get_node_list(&nodes);
+	LocalVector<StringName> nodes = p_nodesm->get_node_list();
 
 	PopupMenu *nodes_menu = memnew(PopupMenu);
 	nodes_menu->set_name(p_name);
@@ -961,8 +959,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	}
 	int sep = 3 * EDSCALE;
 
-	List<StringName> nodes;
-	state_machine->get_node_list(&nodes);
+	LocalVector<StringName> nodes = state_machine->get_node_list();
 
 	node_rects.clear();
 	Rect2 scroll_range;

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1667,10 +1667,24 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendTree::_process(const AnimationMixe
 	return _blend_node(output, "output", this, pi, FILTER_IGNORE, true, p_test_only, nullptr);
 }
 
-void AnimationNodeBlendTree::get_node_list(List<StringName> *r_list) {
+LocalVector<StringName> AnimationNodeBlendTree::get_node_list() const {
+	LocalVector<StringName> list;
+	list.reserve(nodes.size());
 	for (const KeyValue<StringName, Node> &E : nodes) {
-		r_list->push_back(E.key);
+		list.push_back(E.key);
 	}
+	list.sort_custom<StringName::AlphCompare>();
+	return list;
+}
+
+TypedArray<StringName> AnimationNodeBlendTree::get_node_list_as_typed_array() const {
+	TypedArray<StringName> typed_arr;
+	LocalVector<StringName> vec = get_node_list();
+	typed_arr.resize(vec.size());
+	for (uint32_t i = 0; i < vec.size(); i++) {
+		typed_arr[i] = vec[i];
+	}
+	return typed_arr;
 }
 
 void AnimationNodeBlendTree::set_graph_offset(const Vector2 &p_graph_offset) {
@@ -1827,6 +1841,7 @@ void AnimationNodeBlendTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_node", "name"), &AnimationNodeBlendTree::has_node);
 	ClassDB::bind_method(D_METHOD("connect_node", "input_node", "input_index", "output_node"), &AnimationNodeBlendTree::connect_node);
 	ClassDB::bind_method(D_METHOD("disconnect_node", "input_node", "input_index"), &AnimationNodeBlendTree::disconnect_node);
+	ClassDB::bind_method(D_METHOD("get_node_list"), &AnimationNodeBlendTree::get_node_list_as_typed_array);
 
 	ClassDB::bind_method(D_METHOD("set_node_position", "name", "position"), &AnimationNodeBlendTree::set_node_position);
 	ClassDB::bind_method(D_METHOD("get_node_position", "name"), &AnimationNodeBlendTree::get_node_position);

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -468,7 +468,8 @@ public:
 	virtual String get_caption() const override;
 	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
 
-	void get_node_list(List<StringName> *r_list);
+	LocalVector<StringName> get_node_list() const;
+	TypedArray<StringName> get_node_list_as_typed_array() const;
 
 	void set_graph_offset(const Vector2 &p_graph_offset);
 	Vector2 get_graph_offset() const;

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1427,16 +1427,24 @@ void AnimationNodeStateMachine::_rename_transitions(const StringName &p_name, co
 	updating_transitions = false;
 }
 
-void AnimationNodeStateMachine::get_node_list(List<StringName> *r_nodes) const {
-	List<StringName> nodes;
+LocalVector<StringName> AnimationNodeStateMachine::get_node_list() const {
+	LocalVector<StringName> nodes;
+	nodes.reserve(states.size());
 	for (const KeyValue<StringName, State> &E : states) {
 		nodes.push_back(E.key);
 	}
 	nodes.sort_custom<StringName::AlphCompare>();
+	return nodes;
+}
 
-	for (const StringName &E : nodes) {
-		r_nodes->push_back(E);
+TypedArray<StringName> AnimationNodeStateMachine::get_node_list_as_typed_array() const {
+	TypedArray<StringName> typed_arr;
+	LocalVector<StringName> vec = get_node_list();
+	typed_arr.resize(vec.size());
+	for (uint32_t i = 0; i < vec.size(); i++) {
+		typed_arr[i] = vec[i];
 	}
+	return typed_arr;
 }
 
 bool AnimationNodeStateMachine::has_transition(const StringName &p_from, const StringName &p_to) const {
@@ -1796,6 +1804,7 @@ void AnimationNodeStateMachine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("rename_node", "name", "new_name"), &AnimationNodeStateMachine::rename_node);
 	ClassDB::bind_method(D_METHOD("has_node", "name"), &AnimationNodeStateMachine::has_node);
 	ClassDB::bind_method(D_METHOD("get_node_name", "node"), &AnimationNodeStateMachine::get_node_name);
+	ClassDB::bind_method(D_METHOD("get_node_list"), &AnimationNodeStateMachine::get_node_list_as_typed_array);
 
 	ClassDB::bind_method(D_METHOD("set_node_position", "name", "position"), &AnimationNodeStateMachine::set_node_position);
 	ClassDB::bind_method(D_METHOD("get_node_position", "name"), &AnimationNodeStateMachine::get_node_position);

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -174,7 +174,8 @@ public:
 	void rename_node(const StringName &p_name, const StringName &p_new_name);
 	bool has_node(const StringName &p_name) const;
 	StringName get_node_name(const Ref<AnimationNode> &p_node) const;
-	void get_node_list(List<StringName> *r_nodes) const;
+	LocalVector<StringName> get_node_list() const;
+	TypedArray<StringName> get_node_list_as_typed_array() const;
 
 	void set_node_position(const StringName &p_name, const Vector2 &p_position);
 	Vector2 get_node_position(const StringName &p_name) const;


### PR DESCRIPTION
* Change `get_node_list()` to return `Vector<StringName>` instead of filling user-allocated `List<StringName>`.
* Expose `AnimationNodeStateMachine::get_node_list()` and `AnimationNodeBlendTree::get_node_list()`. This requires an intermediary function, that creates a `TypedArray`.

The first change is not really necessary, but it makes it a bit more consistent with how `VisualShader::get_node_list` works, which is a similar function I guess.

If you're wondering about a use case for this - I needed to retrieve names of all states, so I can internally assign an ID to each of them and then transfer that information between client and server. 