### PR TITLE
Use `LocalVector` on `GDScriptInstance::members`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1551,7 +1551,7 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 				callp(member->setter, &args, 1, err);
 				return err.error == Callable::CallError::CALL_OK;
 			} else {
-				members.write[member->index] = value;
+				members[member->index] = value;
 				return true;
 			}
 		}
@@ -1997,21 +1997,19 @@ const Variant GDScriptInstance::get_rpc_config() const {
 void GDScriptInstance::reload_members() {
 #ifdef DEBUG_ENABLED
 
-	Vector<Variant> new_members;
+	LocalVector<Variant> new_members;
 	new_members.resize(script->member_indices.size());
 
 	//pass the values to the new indices
 	for (KeyValue<StringName, GDScript::MemberInfo> &E : script->member_indices) {
 		if (member_indices_cache.has(E.key)) {
 			Variant value = members[member_indices_cache[E.key]];
-			new_members.write[E.value.index] = value;
+			new_members[E.value.index] = value;
 		}
 	}
 
-	members.resize(new_members.size()); //resize
-
 	//apply
-	members = new_members;
+	members = std::move(new_members);
 
 	//pass the values to the new indices
 	member_indices_cache.clear();

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -362,7 +362,7 @@ class GDScriptInstance : public ScriptInstance {
 #ifdef DEBUG_ENABLED
 	HashMap<StringName, int> member_indices_cache; //used only for hot script reloading
 #endif
-	Vector<Variant> members;
+	LocalVector<Variant> members;
 
 	SelfList<GDScriptFunctionState>::List pending_func_states;
 

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -324,7 +324,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 
 		for (KeyValue<StringName, GDScript::MemberInfo> &E : gd_ref->member_indices) {
 			if (d.has(E.key)) {
-				inst->members.write[E.value.index] = d[E.key];
+				inst->members[E.value.index] = d[E.key];
 			}
 		}
 	}

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -739,7 +739,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #endif
 
 	bool awaited = false;
-	Variant *variant_addresses[ADDR_TYPE_MAX] = { stack, _constants_ptr, p_instance ? p_instance->members.ptrw() : nullptr };
+	Variant *variant_addresses[ADDR_TYPE_MAX] = { stack, _constants_ptr, p_instance ? p_instance->members.ptr() : nullptr };
 
 #ifdef DEBUG_ENABLED
 	OPCODE_WHILE(ip < _code_size) {


### PR DESCRIPTION
Modifies `GDScriptInstance::members` to use a `LocalVector` instead of `Vector`. This should be slightly faster and go easier on memory due to the lack of CoW.

## Benchmarks

> Updated as of December 3, 2025

Project used for benchmarking: [bunnymark_custom.zip](https://github.com/user-attachments/files/23910537/bunnymark_custom.zip) (modify the line in `_ready()` that adds bunnies as intended).

It should start and immediately spawn the desired amount of bunnies. After 30 seconds, prints the FPS amount of the last 15 seconds (the first 15 are discarded as an anti-fluctuation measure) and exits.

The command was something like `for i in {1..3}; do gamemoderun ./before.x86_64 --no-header && gamemoderun ./after.x86_64 --no-header; done > bunny_count.txt` on a machine with almost zero programs running in the background. More than one run is necessary due to GDScript being too unstable and sensible to fluctuations.

Unlike some previous benchmarks, I opted to keep the numbers as low as possible to keep closer to more common cases. There is virtually no difference if the amount is lower than this.

### 500 bunnies
| `master` | PR |
|-|-|
| 2514 | 2511
| 2531 | 2547
| 2537 | 2549

Average increase of 0.31%

### 1000 bunnies
| `master` | PR |
|-|-|
| 1677 | 1682
| 1668 | 1683
| 1670 | 1673

Average increase of 0.45%

### 5000 bunnies
| `master` | PR |
|-|-|
| 360 | 371
| 364 | 361
| 361 | 367

Average increase of 1.29%

## Other considerations

On a very high amount of instances (probably near 50k bunnies), the improvement would certainly reach around 10%, it's just that it's nowhere near a common use case.

While the improvement numbers aren't that high, template release production builds on Linux had a decrease of 8 KiB. When running both before and after cases and looking at a system monitor, most of the times the after one will use a few KBs less memory.