### PR TITLE
Bind `Noise` virtual methods

### DIFF
--- a/modules/noise/doc_classes/Noise.xml
+++ b/modules/noise/doc_classes/Noise.xml
@@ -11,6 +11,76 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_get_image" qualifiers="virtual const">
+			<return type="Image" />
+			<param index="0" name="width" type="int" />
+			<param index="1" name="height" type="int" />
+			<param index="2" name="invert" type="bool" />
+			<param index="3" name="in_3d_space" type="bool" />
+			<param index="4" name="normalize" type="bool" />
+			<description>
+				Overrides [method get_image], used by [NoiseTexture2D]. If not overridden, a default implementation is provided using [method get_noise_2d] or [method get_noise_3d].
+			</description>
+		</method>
+		<method name="_get_image_3d" qualifiers="virtual const">
+			<return type="Image[]" />
+			<param index="0" name="width" type="int" />
+			<param index="1" name="height" type="int" />
+			<param index="2" name="depth" type="int" />
+			<param index="3" name="invert" type="bool" />
+			<param index="4" name="normalize" type="bool" />
+			<description>
+				Overrides [method get_image_3d], used by [NoiseTexture3D]. If not overridden, a default implementation is provided using [method get_noise_3d].
+			</description>
+		</method>
+		<method name="_get_noise_1d" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="x" type="float" />
+			<description>
+				Overrides [method get_noise_1d]. Currently this is not used by the engine.
+			</description>
+		</method>
+		<method name="_get_noise_2d" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="x" type="float" />
+			<param index="1" name="y" type="float" />
+			<description>
+				Overrides [method get_noise_2d], used by [method get_image] if it is not overridden and the generation does not occur in 3D space.
+			</description>
+		</method>
+		<method name="_get_noise_3d" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="x" type="float" />
+			<param index="1" name="y" type="float" />
+			<param index="2" name="z" type="float" />
+			<description>
+				Overrides [method get_noise_3d], used by [method get_image_3d] and [method get_image] if these are not overridden and the generation occurs in 3D space.
+			</description>
+		</method>
+		<method name="_get_seamless_image" qualifiers="virtual const">
+			<return type="Image" />
+			<param index="0" name="width" type="int" />
+			<param index="1" name="height" type="int" />
+			<param index="2" name="invert" type="bool" />
+			<param index="3" name="in_3d_space" type="bool" />
+			<param index="4" name="skirt" type="float" />
+			<param index="5" name="normalize" type="bool" />
+			<description>
+				Overrides [method get_seamless_image]. If not overridden, a default implementation is provided using [method get_image].
+			</description>
+		</method>
+		<method name="_get_seamless_image_3d" qualifiers="virtual const">
+			<return type="Image[]" />
+			<param index="0" name="width" type="int" />
+			<param index="1" name="height" type="int" />
+			<param index="2" name="depth" type="int" />
+			<param index="3" name="invert" type="bool" />
+			<param index="4" name="skirt" type="float" />
+			<param index="5" name="normalize" type="bool" />
+			<description>
+				Overrides [method get_seamless_image_3d]. If not overridden, a default implementation is provided using [method get_image_3d].
+			</description>
+		</method>
 		<method name="get_image" qualifiers="const">
 			<return type="Image" />
 			<param index="0" name="width" type="int" />

--- a/modules/noise/fastnoise_lite.cpp
+++ b/modules/noise/fastnoise_lite.cpp
@@ -299,7 +299,7 @@ real_t FastNoiseLite::get_domain_warp_fractal_gain() const {
 
 // Noise interface functions.
 
-real_t FastNoiseLite::get_noise_1d(real_t p_x) const {
+real_t FastNoiseLite::get_noise_1d(real_t p_x, Error *err) const {
 	p_x += offset.x;
 	if (domain_warp_enabled) {
 		// Needed since DomainWarp expects a reference.
@@ -309,11 +309,7 @@ real_t FastNoiseLite::get_noise_1d(real_t p_x) const {
 	return get_noise_2d(p_x, 0.0);
 }
 
-real_t FastNoiseLite::get_noise_2dv(Vector2 p_v) const {
-	return get_noise_2d(p_v.x, p_v.y);
-}
-
-real_t FastNoiseLite::get_noise_2d(real_t p_x, real_t p_y) const {
+real_t FastNoiseLite::get_noise_2d(real_t p_x, real_t p_y, Error *err) const {
 	p_x += offset.x;
 	p_y += offset.y;
 	if (domain_warp_enabled) {
@@ -322,11 +318,7 @@ real_t FastNoiseLite::get_noise_2d(real_t p_x, real_t p_y) const {
 	return _noise.GetNoise(p_x, p_y);
 }
 
-real_t FastNoiseLite::get_noise_3dv(Vector3 p_v) const {
-	return get_noise_3d(p_v.x, p_v.y, p_v.z);
-}
-
-real_t FastNoiseLite::get_noise_3d(real_t p_x, real_t p_y, real_t p_z) const {
+real_t FastNoiseLite::get_noise_3d(real_t p_x, real_t p_y, real_t p_z, Error *err) const {
 	p_x += offset.x;
 	p_y += offset.y;
 	p_z += offset.z;
@@ -334,10 +326,6 @@ real_t FastNoiseLite::get_noise_3d(real_t p_x, real_t p_y, real_t p_z) const {
 		_domain_warp_noise.DomainWarp(p_x, p_y, p_z);
 	}
 	return _noise.GetNoise(p_x, p_y, p_z);
-}
-
-void FastNoiseLite::_changed() {
-	emit_changed();
 }
 
 void FastNoiseLite::_bind_methods() {
@@ -411,8 +399,6 @@ void FastNoiseLite::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_domain_warp_fractal_gain", "domain_warp_gain"), &FastNoiseLite::set_domain_warp_fractal_gain);
 	ClassDB::bind_method(D_METHOD("get_domain_warp_fractal_gain"), &FastNoiseLite::get_domain_warp_fractal_gain);
-
-	ClassDB::bind_method(D_METHOD("_changed"), &FastNoiseLite::_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "noise_type", PROPERTY_HINT_ENUM, "Simplex,Simplex Smooth,Cellular,Perlin,Value Cubic,Value"), "set_noise_type", "get_noise_type");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "seed"), "set_seed", "get_seed");

--- a/modules/noise/fastnoise_lite.h
+++ b/modules/noise/fastnoise_lite.h
@@ -202,15 +202,9 @@ public:
 	real_t get_domain_warp_fractal_gain() const;
 
 	// Interface methods.
-	real_t get_noise_1d(real_t p_x) const override;
-
-	real_t get_noise_2dv(Vector2 p_v) const override;
-	real_t get_noise_2d(real_t p_x, real_t p_y) const override;
-
-	real_t get_noise_3dv(Vector3 p_v) const override;
-	real_t get_noise_3d(real_t p_x, real_t p_y, real_t p_z) const override;
-
-	void _changed();
+	real_t get_noise_1d(real_t p_x, Error *err = nullptr) const override;
+	real_t get_noise_2d(real_t p_x, real_t p_y, Error *err = nullptr) const override;
+	real_t get_noise_3d(real_t p_x, real_t p_y, real_t p_z, Error *err = nullptr) const override;
 };
 
 VARIANT_ENUM_CAST(FastNoiseLite::NoiseType);

--- a/modules/noise/noise.h
+++ b/modules/noise/noise.h
@@ -275,19 +275,31 @@ class Noise : public Resource {
 	}
 
 protected:
+	GDVIRTUAL1RC(real_t, _get_noise_1d, real_t)
+	GDVIRTUAL2RC(real_t, _get_noise_2d, real_t, real_t)
+	GDVIRTUAL3RC(real_t, _get_noise_3d, real_t, real_t, real_t)
+	GDVIRTUAL5RC(Ref<Image>, _get_image, int, int, bool, bool, bool)
+	GDVIRTUAL5RC(TypedArray<Ref<Image>>, _get_image_3d, int, int, int, bool, bool)
+	GDVIRTUAL6RC(Ref<Image>, _get_seamless_image, int, int, bool, bool, real_t, bool)
+	GDVIRTUAL6RC(TypedArray<Ref<Image>>, _get_seamless_image_3d, int, int, int, bool, real_t, bool)
+
 	static void _bind_methods();
 
 public:
 	// Virtual destructor so we can delete any Noise derived object when referenced as a Noise*.
 	virtual ~Noise() {}
 
-	virtual real_t get_noise_1d(real_t p_x) const = 0;
+	virtual real_t get_noise_1d(real_t p_x, Error *err = nullptr) const;
 
-	virtual real_t get_noise_2dv(Vector2 p_v) const = 0;
-	virtual real_t get_noise_2d(real_t p_x, real_t p_y) const = 0;
+	virtual real_t get_noise_2dv(Vector2 p_v) const;
+	virtual real_t get_noise_2d(real_t p_x, real_t p_y, Error *err = nullptr) const;
 
-	virtual real_t get_noise_3dv(Vector3 p_v) const = 0;
-	virtual real_t get_noise_3d(real_t p_x, real_t p_y, real_t p_z) const = 0;
+	virtual real_t get_noise_3dv(Vector3 p_v) const;
+	virtual real_t get_noise_3d(real_t p_x, real_t p_y, real_t p_z, Error *err = nullptr) const;
+
+	real_t _get_noise_1d(real_t p_x) const;
+	real_t _get_noise_2d(real_t p_x, real_t p_y) const;
+	real_t _get_noise_3d(real_t p_x, real_t p_y, real_t p_z) const;
 
 	Vector<Ref<Image>> _get_image(int p_width, int p_height, int p_depth, bool p_invert = false, bool p_in_3d_space = false, bool p_normalize = true) const;
 	virtual Ref<Image> get_image(int p_width, int p_height, bool p_invert = false, bool p_in_3d_space = false, bool p_normalize = true) const;

--- a/modules/noise/noise_texture_3d.cpp
+++ b/modules/noise/noise_texture_3d.cpp
@@ -144,28 +144,20 @@ TypedArray<Image> NoiseTexture3D::_generate_texture() {
 
 	ERR_FAIL_COND_V_MSG((int64_t)width * height * depth > Image::MAX_PIXELS, TypedArray<Image>(), "The NoiseTexture3D is too big, consider lowering its width, height, or depth.");
 
-	Vector<Ref<Image>> images;
+	TypedArray<Ref<Image>> images;
 
 	if (seamless) {
-		images = ref_noise->_get_seamless_image(width, height, depth, invert, true, seamless_blend_skirt, normalize);
+		images = ref_noise->get_seamless_image_3d(width, height, depth, invert, seamless_blend_skirt, normalize);
 	} else {
-		images = ref_noise->_get_image(width, height, depth, invert, true, normalize);
+		images = ref_noise->get_image_3d(width, height, depth, invert, normalize);
 	}
 
 	if (color_ramp.is_valid()) {
 		for (int i = 0; i < images.size(); i++) {
-			images.write[i] = _modulate_with_gradient(images[i], color_ramp);
+			images[i] = _modulate_with_gradient(images[i], color_ramp);
 		}
 	}
-
-	TypedArray<Image> new_data;
-	new_data.resize(images.size());
-
-	for (int i = 0; i < new_data.size(); i++) {
-		new_data[i] = images[i];
-	}
-
-	return new_data;
+	return images;
 }
 
 Ref<Image> NoiseTexture3D::_modulate_with_gradient(Ref<Image> p_image, Ref<Gradient> p_gradient) {

--- a/modules/noise/register_types.cpp
+++ b/modules/noise/register_types.cpp
@@ -47,7 +47,7 @@ void initialize_noise_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		GDREGISTER_CLASS(NoiseTexture3D);
 		GDREGISTER_CLASS(NoiseTexture2D);
-		GDREGISTER_ABSTRACT_CLASS(Noise);
+		GDREGISTER_VIRTUAL_CLASS(Noise);
 		GDREGISTER_CLASS(FastNoiseLite);
 		ClassDB::add_compatibility_class("NoiseTexture", "NoiseTexture2D");
 	}


### PR DESCRIPTION
The current Noise class cannot be inherited. This allows scripts to inherit from Noise to create custom implementations