### PR TITLE
Make the position and the size of FileSystem controls more precise

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -107,7 +107,7 @@ bool FileSystemList::edit_selected() {
 	Rect2 popup_rect;
 	Vector2 ofs;
 
-	Vector2 icon_size = get_item_icon(s)->get_size();
+	Vector2 icon_size = get_fixed_icon_size() * get_icon_scale();
 
 	// Handles the different icon modes (TOP/LEFT).
 	switch (get_icon_mode()) {
@@ -120,12 +120,12 @@ bool FileSystemList::edit_selected() {
 				rect.position.x -= get_h_scroll_bar()->get_value();
 			}
 			ofs = Vector2(0, Math::floor((MAX(line_editor->get_minimum_size().height, rect.size.height) - rect.size.height) / 2));
-			popup_rect.position = get_screen_position() + rect.position - ofs;
+			popup_rect.position = rect.position - ofs;
 			popup_rect.size = rect.size;
 
 			// Adjust for icon position and size.
-			popup_rect.size.x -= icon_size.x;
-			popup_rect.position.x += icon_size.x;
+			popup_rect.size.x -= MAX(theme_cache.h_separation, 0) / 2 + icon_size.x;
+			popup_rect.position.x += MAX(theme_cache.h_separation, 0) / 2 + icon_size.x;
 			break;
 		case ItemList::ICON_MODE_TOP:
 			rect = get_item_rect(s, false);
@@ -135,14 +135,18 @@ bool FileSystemList::edit_selected() {
 			if (get_h_scroll_bar()->is_visible()) {
 				rect.position.x -= get_h_scroll_bar()->get_value();
 			}
-			popup_rect.position = get_screen_position() + rect.position;
+			popup_rect.position = rect.position;
 			popup_rect.size = rect.size;
 
 			// Adjust for icon position and size.
-			popup_rect.size.y -= icon_size.y;
-			popup_rect.position.y += icon_size.y;
+			popup_rect.size.y -= MAX(theme_cache.v_separation, 0) / 2 + theme_cache.icon_margin + icon_size.y;
+			popup_rect.position.y += MAX(theme_cache.v_separation, 0) / 2 + theme_cache.icon_margin + icon_size.y;
 			break;
 	}
+	if (is_layout_rtl()) {
+		popup_rect.position.x = get_size().width - popup_rect.position.x - popup_rect.size.x;
+	}
+	popup_rect.position += get_screen_position();
 
 	popup_editor->set_position(popup_rect.position);
 	popup_editor->set_size(popup_rect.size);

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -329,11 +329,14 @@ Rect2 ItemList::get_item_rect(int p_idx, bool p_expand) const {
 	ERR_FAIL_INDEX_V(p_idx, items.size(), Rect2());
 
 	Rect2 ret = items[p_idx].rect_cache;
-	ret.position += theme_cache.panel_style->get_offset();
-
 	if (p_expand && p_idx % current_columns == current_columns - 1) {
-		ret.size.width = get_size().width - ret.position.x;
+		int width = get_size().width - theme_cache.panel_style->get_minimum_size().width;
+		if (scroll_bar_v->is_visible()) {
+			width -= scroll_bar_v->get_combined_minimum_size().width;
+		}
+		ret.size.width = width - ret.position.x;
 	}
+	ret.position += theme_cache.panel_style->get_offset();
 	return ret;
 }
 
@@ -1524,9 +1527,7 @@ void ItemList::_notification(int p_what) {
 						icon_size = items[i].get_icon_size() * icon_scale;
 					}
 
-					Vector2 icon_ofs;
-
-					Point2 pos = items[i].rect_cache.position + icon_ofs + base_ofs;
+					Point2 pos = items[i].rect_cache.position + base_ofs;
 
 					if (icon_mode == ICON_MODE_TOP) {
 						pos.y += MAX(theme_cache.v_separation, 0) / 2;
@@ -1579,14 +1580,14 @@ void ItemList::_notification(int p_what) {
 						tag_icon_size = items[i].tag_icon->get_size();
 					}
 
-					Point2 draw_pos = items[i].rect_cache.position;
+					Point2 draw_pos = items[i].rect_cache.position + base_ofs;
 					draw_pos.x += MAX(theme_cache.h_separation, 0) / 2;
 					draw_pos.y += MAX(theme_cache.v_separation, 0) / 2;
 					if (rtl) {
 						draw_pos.x = size.width - draw_pos.x - tag_icon_size.x;
 					}
 
-					draw_texture_rect(items[i].tag_icon, Rect2(draw_pos + base_ofs, tag_icon_size));
+					draw_texture_rect(items[i].tag_icon, Rect2(draw_pos, tag_icon_size));
 				}
 
 				if (!items[i].text.is_empty()) {
@@ -1646,10 +1647,12 @@ void ItemList::_notification(int p_what) {
 							text_ofs.x += MAX(theme_cache.h_separation, 0) / 2;
 						}
 
+						real_t text_width_ofs = text_ofs.x;
+
 						text_ofs += base_ofs;
 						text_ofs += items[i].rect_cache.position;
 
-						float text_w = items[i].rect_cache.size.width - icon_size.x - MAX(theme_cache.h_separation, 0);
+						float text_w = items[i].rect_cache.size.width - text_width_ofs;
 						if (wraparound_items && items[i].rect_cache.size.width > width) {
 							text_w -= items[i].rect_cache.size.width - width;
 						}

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -143,6 +143,14 @@ private:
 
 	bool do_autoscroll_to_bottom = false;
 
+	void _scroll_changed(double);
+	void _shape_text(int p_idx);
+	void _mouse_exited();
+	void _shift_range_select(int p_from, int p_to);
+
+	String _atr(int p_idx, const String &p_text) const;
+
+protected:
 	struct ThemeCache {
 		int h_separation = 0;
 		int v_separation = 0;
@@ -171,14 +179,6 @@ private:
 		Color guide_color;
 	} theme_cache;
 
-	void _scroll_changed(double);
-	void _shape_text(int p_idx);
-	void _mouse_exited();
-	void _shift_range_select(int p_from, int p_to);
-
-	String _atr(int p_idx, const String &p_text) const;
-
-protected:
 	void _notification(int p_what);
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const { return property_helper.property_get_value(p_name, r_ret); }


### PR DESCRIPTION
Before: The rename LineEdit is too long.
![before1](https://github.com/user-attachments/assets/0acbf30a-8c23-44af-a9c6-25fd5a2dc60c)

After:
![after1](https://github.com/user-attachments/assets/2887b200-ca73-4e47-809b-6ad28ae55338)

Before: Text is out of hightlight backgroud.
![before2](https://github.com/user-attachments/assets/ba11a0ad-05d9-4951-9d23-88d03dbee299)

After:
![after2](https://github.com/user-attachments/assets/ba66c2a5-ff05-4642-949d-919a75f7f7a9)

Before: The rename LineEdit covers the icon.
![before3](https://github.com/user-attachments/assets/11131259-035b-44d8-83ac-6b08023f52f9)

After: 
![after3](https://github.com/user-attachments/assets/d240ef02-5bea-49e2-8f46-93b1d4597b5a)

Before: When right-to-left, The rename LineEdit and tag icons are offset.
![before4](https://github.com/user-attachments/assets/413f4a92-2783-47c8-b29d-54a682ba14ee)

After:
![after4](https://github.com/user-attachments/assets/ea88a584-62f8-4ff9-bce9-204b02f914c0)


