### PR TITLE
Fix `is_pixel_opaque` bound checks.

### DIFF
--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -269,8 +269,8 @@ bool CompressedTexture2D::is_pixel_opaque(int p_x, int p_y) const {
 		int x = p_x * aw / w;
 		int y = p_y * ah / h;
 
-		x = CLAMP(x, 0, aw);
-		y = CLAMP(y, 0, ah);
+		x = CLAMP(x, 0, aw - 1);
+		y = CLAMP(y, 0, ah - 1);
 
 		return alpha_cache->get_bit(x, y);
 	}

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -197,8 +197,8 @@ bool ImageTexture::is_pixel_opaque(int p_x, int p_y) const {
 		int x = p_x * aw / w;
 		int y = p_y * ah / h;
 
-		x = CLAMP(x, 0, aw);
-		y = CLAMP(y, 0, ah);
+		x = CLAMP(x, 0, aw - 1);
+		y = CLAMP(y, 0, ah - 1);
 
 		return alpha_cache->get_bit(x, y);
 	}

--- a/scene/resources/portable_compressed_texture.cpp
+++ b/scene/resources/portable_compressed_texture.cpp
@@ -313,8 +313,8 @@ bool PortableCompressedTexture2D::is_pixel_opaque(int p_x, int p_y) const {
 		int x = p_x * aw / size.width;
 		int y = p_y * ah / size.height;
 
-		x = CLAMP(x, 0, aw);
-		y = CLAMP(y, 0, ah);
+		x = CLAMP(x, 0, aw - 1);
+		y = CLAMP(y, 0, ah - 1);
 
 		return alpha_cache->get_bit(x, y);
 	}


### PR DESCRIPTION
This method is no exposed, internal calls use correct ranges, and `get_bit` do bound check it again, so this not critical.