### PR TITLE
Fix GridMap move selection crashing on invalid MeshLibrary item

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -551,6 +551,9 @@ void GridMapEditor::_fill_selection() {
 
 void GridMapEditor::_clear_clipboard_data() {
 	for (const ClipboardItem &E : clipboard_items) {
+		if (E.instance.is_null()) {
+			continue;
+		}
 		RenderingServer::get_singleton()->free(E.instance);
 	}
 
@@ -561,6 +564,8 @@ void GridMapEditor::_set_clipboard_data() {
 	_clear_clipboard_data();
 
 	Ref<MeshLibrary> meshLibrary = node->get_mesh_library();
+
+	const RID scenario = get_tree()->get_root()->get_world_3d()->get_scenario();
 
 	for (int i = selection.begin.x; i <= selection.end.x; i++) {
 		for (int j = selection.begin.y; j <= selection.end.y; j++) {
@@ -577,7 +582,9 @@ void GridMapEditor::_set_clipboard_data() {
 				item.cell_item = itm;
 				item.grid_offset = Vector3(selected) - selection.begin;
 				item.orientation = node->get_cell_item_orientation(selected);
-				item.instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), get_tree()->get_root()->get_world_3d()->get_scenario());
+				if (mesh.is_valid()) {
+					item.instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), scenario);
+				}
 
 				clipboard_items.push_back(item);
 			}
@@ -606,6 +613,9 @@ void GridMapEditor::_update_paste_indicator() {
 	RenderingServer::get_singleton()->instance_set_transform(paste_instance, node->get_global_transform() * xf);
 
 	for (const ClipboardItem &item : clipboard_items) {
+		if (item.instance.is_null()) {
+			continue;
+		}
 		xf = Transform3D();
 		xf.origin = (paste_indicator.begin + (paste_indicator.current - paste_indicator.click) + center) * node->get_cell_size();
 		xf.basis = rot * xf.basis;


### PR DESCRIPTION
Fixes GridMap editor crashing when selected cells contain invalid MeshLibrary item and cells are moved with the GridMap editor clipboard tool.

Fixes https://github.com/godotengine/godot/issues/105542

As a bonus moves the rendering scenario quadruple-getter outside the triple-for-loop.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
