### PR TITLE
Replace GridMap legacy use of `List` with `LocalVector`

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -813,8 +813,8 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 					for (const SetItem &si : set_items) {
 						undo_redo->add_do_method(node, "set_cell_item", si.position, si.new_value, si.new_orientation);
 					}
-					for (List<SetItem>::Element *E = set_items.back(); E; E = E->prev()) {
-						const SetItem &si = E->get();
+					for (uint32_t i = set_items.size(); i > 0; i--) {
+						const SetItem &si = set_items[i - 1];
 						undo_redo->add_undo_method(node, "set_cell_item", si.position, si.old_value, si.old_orientation);
 					}
 
@@ -1379,6 +1379,8 @@ GridMapEditor::GridMapEditor() {
 	HBoxContainer *mode_buttons = memnew(HBoxContainer);
 	toolbar->add_child(mode_buttons);
 	mode_buttons_group.instantiate();
+
+	viewport_shortcut_buttons.reserve(12);
 
 	transform_mode_button = memnew(Button);
 	transform_mode_button->set_theme_type_variation(SceneStringName(FlatButton));

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -74,7 +74,7 @@ class GridMapEditor : public VBoxContainer {
 	double accumulated_floor_delta = 0.0;
 
 	HBoxContainer *toolbar = nullptr;
-	List<BaseButton *> viewport_shortcut_buttons;
+	TightLocalVector<BaseButton *> viewport_shortcut_buttons;
 	Ref<ButtonGroup> mode_buttons_group;
 	// mode
 	Button *transform_mode_button = nullptr;
@@ -110,7 +110,7 @@ class GridMapEditor : public VBoxContainer {
 		int old_orientation = 0;
 	};
 
-	List<SetItem> set_items;
+	LocalVector<SetItem> set_items;
 
 	GridMap *node = nullptr;
 	Ref<MeshLibrary> mesh_library = nullptr;
@@ -139,7 +139,7 @@ class GridMapEditor : public VBoxContainer {
 		RID instance;
 	};
 
-	List<ClipboardItem> clipboard_items;
+	LocalVector<ClipboardItem> clipboard_items;
 
 	Color default_color;
 	Color erase_color;

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/marshalls.h"
 #include "core/math/convex_hull.h"
+#include "core/templates/a_hash_map.h"
 #include "scene/resources/3d/box_shape_3d.h"
 #include "scene/resources/3d/capsule_shape_3d.h"
 #include "scene/resources/3d/concave_polygon_shape_3d.h"
@@ -619,7 +620,11 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 	 * and set said multimesh bounding box to one containing all cells which have this item
 	 */
 
-	HashMap<int, List<Pair<Transform3D, IndexKey>>> multimesh_items;
+	struct MultiMeshItemPlacement {
+		Transform3D transform;
+		IndexKey index_key;
+	};
+	AHashMap<int, LocalVector<MultiMeshItemPlacement>> item_id_to_multimesh_item_placements;
 
 	for (const IndexKey &E : g.cells) {
 		ERR_CONTINUE(!cell_map.has(E));
@@ -639,14 +644,14 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
 		if (baked_meshes.is_empty()) {
 			if (mesh_library->get_item_mesh(c.item).is_valid()) {
-				if (!multimesh_items.has(c.item)) {
-					multimesh_items[c.item] = List<Pair<Transform3D, IndexKey>>();
+				if (!item_id_to_multimesh_item_placements.has(c.item)) {
+					item_id_to_multimesh_item_placements[c.item] = LocalVector<MultiMeshItemPlacement>();
 				}
 
-				Pair<Transform3D, IndexKey> p;
-				p.first = xform * mesh_library->get_item_mesh_transform(c.item);
-				p.second = E;
-				multimesh_items[c.item].push_back(p);
+				MultiMeshItemPlacement p;
+				p.transform = xform * mesh_library->get_item_mesh_transform(c.item);
+				p.index_key = E;
+				item_id_to_multimesh_item_placements[c.item].push_back(p);
 			}
 		}
 
@@ -717,7 +722,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 
 	//update multimeshes, only if not baked
 	if (baked_meshes.is_empty()) {
-		for (const KeyValue<int, List<Pair<Transform3D, IndexKey>>> &E : multimesh_items) {
+		for (const KeyValue<int, LocalVector<MultiMeshItemPlacement>> &E : item_id_to_multimesh_item_placements) {
 			Octant::MultimeshInstance mmi;
 
 			RID mm = RS::get_singleton()->multimesh_create();
@@ -725,14 +730,15 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 			RS::get_singleton()->multimesh_set_mesh(mm, mesh_library->get_item_mesh(E.key)->get_rid());
 
 			int idx = 0;
-			for (const Pair<Transform3D, IndexKey> &F : E.value) {
-				RS::get_singleton()->multimesh_instance_set_transform(mm, idx, F.first);
+			const LocalVector<MultiMeshItemPlacement> &mm_item_placements = E.value;
+			for (const MultiMeshItemPlacement &mm_item_placement : mm_item_placements) {
+				RS::get_singleton()->multimesh_instance_set_transform(mm, idx, mm_item_placement.transform);
 #ifdef TOOLS_ENABLED
 
 				Octant::MultimeshInstance::Item it;
 				it.index = idx;
-				it.transform = F.first;
-				it.key = F.second;
+				it.transform = mm_item_placement.transform;
+				it.key = mm_item_placement.index_key;
 				mmi.items.push_back(it);
 #endif
 
@@ -1089,17 +1095,19 @@ void GridMap::_update_octants_callback() {
 		return;
 	}
 
-	List<OctantKey> to_delete;
+	LocalVector<OctantKey> to_delete;
+	to_delete.reserve(octant_map.size());
 	for (const KeyValue<OctantKey, Octant *> &E : octant_map) {
 		if (_octant_update(E.key)) {
 			to_delete.push_back(E.key);
 		}
 	}
 
-	while (to_delete.front()) {
-		memdelete(octant_map[to_delete.front()->get()]);
-		octant_map.erase(to_delete.front()->get());
-		to_delete.pop_front();
+	while (!to_delete.is_empty()) {
+		const OctantKey &octantkey = to_delete[0];
+		memdelete(octant_map[octantkey]);
+		octant_map.erase(octantkey);
+		to_delete.remove_at_unordered(0);
 	}
 
 	_update_visibility();


### PR DESCRIPTION
Replaces GridMap legacy use of `List` with `LocalVector`.

Same for the old item id to multimesh item placement code (yeah that was what all that unreadable `<int, List<Pair<Transform3D, IndexKey>>` meant).

There is no real use for a `List` here, this is just legacy code that was never updated.

Uses a `TightLocalVector` for the editor viewport shortcut buttons as it does not change in size and the size is known from the start.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
