### PR TITLE
[Web] Avoid extra copy when encoding string in WebSocket `_onmessage`

### DIFF
--- a/modules/websocket/library_godot_websocket.js
+++ b/modules/websocket/library_godot_websocket.js
@@ -58,8 +58,7 @@ const GodotWebSocket = {
 				return;
 			} else if (typeof event.data === 'string') {
 				is_string = 1;
-				const enc = new TextEncoder('utf-8');
-				buffer = new Uint8Array(enc.encode(event.data));
+				buffer = new TextEncoder('utf-8').encode(event.data);
 			} else {
 				GodotRuntime.error('Unknown message type');
 				return;


### PR DESCRIPTION
This PR avoids an extra copy when handling string messages in the WebSocket `_onmessage` handler.
[`TextEncoder.encode()` ](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encode)already returns a `Uint8Array`