### PR TITLE
[Web] Cache feature support checks to reduce JS interop overhead

### DIFF
--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -152,10 +152,12 @@ bool OS_Web::_check_internal_feature_support(const String &p_feature) {
 	if (p_feature == "web") {
 		return true;
 	}
-	if (godot_js_os_has_feature(p_feature.utf8().get_data())) {
-		return true;
+	if (feature_support_cache.has(p_feature)) {
+		return feature_support_cache[p_feature];
 	}
-	return false;
+	bool supported = godot_js_os_has_feature(p_feature.utf8().get_data());
+	feature_support_cache[p_feature] = supported;
+	return supported;
 }
 
 String OS_Web::get_executable_path() const {

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -47,6 +47,8 @@ class OS_Web : public OS_Unix {
 
 	MIDIDriverWebMidi midi_driver;
 
+	HashMap<String, bool> feature_support_cache;
+
 	bool idb_is_syncing = false;
 	bool idb_available = false;
 	bool idb_needs_sync = false;


### PR DESCRIPTION
This PR adds a cache to `_check_internal_feature_support()` to avoid redundant JS calls.

While profiling my game, I noticed that each key input triggered ~228 calls to `godot_js_os_has_feature`, introducing significant overhead due to UTF-8 string conversions and JS interop.

This change reduces that to a single call per unique feature, improving performance with no behavior changes.