### PR TITLE
Update ProgressBar description

### DIFF
--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -4,7 +4,7 @@
 		A control used for visual representation of a percentage.
 	</brief_description>
 	<description>
-		A control used for visual representation of a percentage. Shows fill percentage from right to left.
+		A control used for visual representation of a percentage. Shows the fill percentage in the center. Can also be used to show indeterminate progress. For more fill modes, use [TextureProgressBar] instead.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Updates the description for ProgressBar, since it was inaccurate before.
It can be filled from right to left, but it is begin to end (follows layout rtl mode) by default.
I added other details instead. Also mentioned TextureProgressBar since they are similar.