### PR TITLE
Fix EditorInspector tooltip disappearing in special cases

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -4485,7 +4485,7 @@ void EditorHelpBitTooltip::_notification(int p_what) {
 						queue_free();
 					}
 				} else if (!Input::get_singleton()->get_last_mouse_velocity().is_zero_approx()) {
-					if (!_is_mouse_inside_tooltip && OS::get_singleton()->get_ticks_msec() - _enter_tree_time > 250) {
+					if (!_is_mouse_inside_tooltip && OS::get_singleton()->get_ticks_msec() - _enter_tree_time > 350) {
 						_start_timer();
 					}
 				}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/104672
Fixes https://github.com/godotengine/godot/issues/105572

_**EditorInspector**_ tooltips seems to be affected by waccom drivers after https://github.com/godotengine/godot/pull/95044
This makes ProjectSettings, EditorSettings and Inspector tooltips disappear very fast even if you don't move the mouse.
Having a waccom driver installed seems to be enough for this to happen, as I have this issue without a pen tablet connected.

Disabling the internal process of the tooltip's EditorHelpBitTooltip solves this issue.
Everything is still working fine on windows. But some testing in other OS's would be appreciated.

Problem:

https://github.com/user-attachments/assets/f94f5ad1-2ee7-4212-b9a0-6f9757c8015d


Fixed:


https://github.com/user-attachments/assets/6ade3a4a-0a2e-44b7-8cab-d049f0a922b7


PS: Feel free to close this PR if someone more knowledgeable knows how to fix this issue in a better way.