### PR TITLE
Allow building the editor with 3D disabled, or without 3D Physics/Navigation.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1071,12 +1071,9 @@ sys.modules.pop("detect")
 if env.editor_build:
     unsupported_opts = []
     for disable_opt in [
-        "disable_3d",
         "disable_advanced_gui",
         "disable_physics_2d",
-        "disable_physics_3d",
         "disable_navigation_2d",
-        "disable_navigation_3d",
     ]:
         if env[disable_opt]:
             unsupported_opts.append(disable_opt)

--- a/SConstruct
+++ b/SConstruct
@@ -1065,12 +1065,9 @@ if env.editor_build:
     unsupported_opts = []
     for disable_opt in [
         "disable_2d",
-        "disable_3d",
         "disable_advanced_gui",
         "disable_physics_2d",
-        "disable_physics_3d",
         "disable_navigation_2d",
-        "disable_navigation_3d",
     ]:
         if env[disable_opt]:
             unsupported_opts.append(disable_opt)

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -42,7 +42,9 @@
 #include "editor/inspector/editor_properties.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#ifndef _3D_DISABLED
 #include "scene/3d/skeleton_3d.h"
+#endif // _3D_DISABLED
 #include "scene/gui/check_box.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/line_edit.h"
@@ -927,6 +929,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 		if (path.get_subname_count()) {
 			String concat = path.get_concatenated_subnames();
 
+#ifndef _3D_DISABLED
 			Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(node);
 			if (skeleton && skeleton->find_bone(concat) != -1) {
 				//path in skeleton
@@ -967,6 +970,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 
 			} else {
 				//just a property
+#endif // _3D_DISABLED
 				ti = filters->create_item(ti);
 				ti->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
 				ti->set_text(0, concat);
@@ -974,7 +978,9 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 				ti->set_selectable(0, true);
 				ti->set_checked(0, anode->is_path_filtered(path));
 				ti->set_metadata(0, path);
+#ifndef _3D_DISABLED
 			}
+#endif // _3D_DISABLED
 		} else {
 			if (ti) {
 				//just a node, not a property track

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -42,7 +42,9 @@
 #include "editor/inspector/editor_properties.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#ifndef _3D_DISABLED
 #include "scene/3d/skeleton_3d.h"
+#endif // _3D_DISABLED
 #include "scene/gui/check_box.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/line_edit.h"
@@ -928,6 +930,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 		if (path.get_subname_count()) {
 			String concat = path.get_concatenated_subnames();
 
+#ifndef _3D_DISABLED
 			Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(node);
 			if (skeleton && skeleton->find_bone(concat) != -1) {
 				//path in skeleton
@@ -968,6 +971,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 
 			} else {
 				//just a property
+#endif // _3D_DISABLED
 				ti = filters->create_item(ti);
 				ti->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
 				ti->set_text(0, concat);
@@ -975,7 +979,9 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 				ti->set_selectable(0, true);
 				ti->set_checked(0, anode->is_path_filtered(path));
 				ti->set_metadata(0, path);
+#ifndef _3D_DISABLED
 			}
+#endif // _3D_DISABLED
 		} else {
 			if (ti) {
 				//just a node, not a property track

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -44,7 +44,6 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_validation_panel.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h" // For onion skinning.
 #include "editor/scene/canvas_item_editor_plugin.h" // For onion skinning.
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
@@ -53,11 +52,14 @@
 #include "scene/animation/animation_tree.h"
 #include "scene/gui/separator.h"
 #include "scene/main/scene_tree.h"
-#include "scene/main/window.h"
 #include "scene/resources/animation.h"
 #include "scene/resources/image_texture.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
+
+#ifndef _3D_DISABLED
+#include "editor/scene/3d/node_3d_editor_plugin.h" // For onion skinning.
+#endif
 
 ///////////////////////////////////
 
@@ -1795,6 +1797,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_prolog() {
 		_allocate_onion_layers();
 	}
 
+#ifndef _3D_DISABLED
 	// Hide superfluous elements that would make the overlay unnecessary cluttered.
 	if (Node3DEditor::get_singleton()->is_visible()) {
 		// 3D
@@ -1819,6 +1822,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_prolog() {
 		Node3DEditor::get_singleton()->set_state(new_state);
 	} else {
 		// CanvasItemEditor.
+#endif // _3D_DISABLED
 		onion.temp.canvas_edit_state = CanvasItemEditor::get_singleton()->get_state();
 		Dictionary new_state = onion.temp.canvas_edit_state.duplicate();
 		new_state["show_origin"] = false;
@@ -1832,7 +1836,9 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_prolog() {
 		new_state["show_transformation_gizmos"] = onion.include_gizmos ? new_state["gizmos"] : Variant(false);
 		// TODO: Save/restore only affected entries.
 		CanvasItemEditor::get_singleton()->set_state(new_state);
+#ifndef _3D_DISABLED
 	}
+#endif // _3D_DISABLED
 
 	// Tweak the root viewport to ensure it's rendered before our target.
 	RID root_vp = get_tree()->get_root()->get_viewport_rid();
@@ -1942,14 +1948,18 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_epilog() {
 	player->seek_internal(onion.temp.anim_player_position, true, true, false);
 	player->restore(onion.temp.anim_values_backup);
 
+#ifndef _3D_DISABLED
 	// Restore state of main editors.
 	if (Node3DEditor::get_singleton()->is_visible()) {
 		// 3D
 		Node3DEditor::get_singleton()->set_state(onion.temp.spatial_edit_state);
 	} else { // CanvasItemEditor
 		// 2D
+#endif // _3D_DISABLED
 		CanvasItemEditor::get_singleton()->set_state(onion.temp.canvas_edit_state);
+#ifndef _3D_DISABLED
 	}
+#endif // _3D_DISABLED
 
 	// Update viewports with skin layers overlaid for the actual engine loop render.
 	onion.can_overlay = true;
@@ -2349,7 +2359,9 @@ AnimationPlayerEditor::~AnimationPlayerEditor() {
 void AnimationPlayerEditorPlugin::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
+#ifndef _3D_DISABLED
 			Node3DEditor::get_singleton()->connect(SNAME("transform_key_request"), callable_mp(this, &AnimationPlayerEditorPlugin::_transform_key_request));
+#endif // _3D_DISABLED
 			InspectorDock::get_inspector_singleton()->connect(SNAME("property_keyed"), callable_mp(this, &AnimationPlayerEditorPlugin::_property_keyed));
 			anim_editor->get_track_editor()->connect(SNAME("keying_changed"), callable_mp(this, &AnimationPlayerEditorPlugin::_update_keying));
 			InspectorDock::get_inspector_singleton()->connect(SNAME("edited_object_changed"), callable_mp(anim_editor->get_track_editor(), &AnimationTrackEditor::update_keying));
@@ -2367,6 +2379,7 @@ void AnimationPlayerEditorPlugin::_property_keyed(const String &p_keyed, const V
 	te->insert_value_key(p_keyed, p_advance);
 }
 
+#ifndef _3D_DISABLED
 void AnimationPlayerEditorPlugin::_transform_key_request(Object *sp, const String &p_sub, const Transform3D &p_key) {
 	if (!anim_editor->get_track_editor()->has_keying()) {
 		return;
@@ -2379,6 +2392,7 @@ void AnimationPlayerEditorPlugin::_transform_key_request(Object *sp, const Strin
 	anim_editor->get_track_editor()->insert_transform_key(s, p_sub, Animation::TYPE_ROTATION_3D, p_key.basis.get_rotation_quaternion());
 	anim_editor->get_track_editor()->insert_transform_key(s, p_sub, Animation::TYPE_SCALE_3D, p_key.basis.get_scale());
 }
+#endif // _3D_DISABLED
 
 void AnimationPlayerEditorPlugin::_update_keying() {
 	InspectorDock::get_inspector_singleton()->set_keying(anim_editor->get_track_editor()->has_keying());

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -44,7 +44,6 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_validation_panel.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h" // For onion skinning.
 #include "editor/scene/canvas_item_editor_plugin.h" // For onion skinning.
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
@@ -53,11 +52,14 @@
 #include "scene/animation/animation_tree.h"
 #include "scene/gui/separator.h"
 #include "scene/main/scene_tree.h"
-#include "scene/main/window.h"
 #include "scene/resources/animation.h"
 #include "scene/resources/image_texture.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
+
+#ifndef _3D_DISABLED
+#include "editor/scene/3d/node_3d_editor_plugin.h" // For onion skinning.
+#endif
 
 ///////////////////////////////////
 
@@ -1793,6 +1795,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_prolog() {
 		_allocate_onion_layers();
 	}
 
+#ifndef _3D_DISABLED
 	// Hide superfluous elements that would make the overlay unnecessary cluttered.
 	if (Node3DEditor::get_singleton()->is_visible()) {
 		// 3D
@@ -1817,6 +1820,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_prolog() {
 		Node3DEditor::get_singleton()->set_state(new_state);
 	} else {
 		// CanvasItemEditor.
+#endif // _3D_DISABLED
 		onion.temp.canvas_edit_state = CanvasItemEditor::get_singleton()->get_state();
 		Dictionary new_state = onion.temp.canvas_edit_state.duplicate();
 		new_state["show_origin"] = false;
@@ -1830,7 +1834,9 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_prolog() {
 		new_state["show_transformation_gizmos"] = onion.include_gizmos ? new_state["gizmos"] : Variant(false);
 		// TODO: Save/restore only affected entries.
 		CanvasItemEditor::get_singleton()->set_state(new_state);
+#ifndef _3D_DISABLED
 	}
+#endif // _3D_DISABLED
 
 	// Tweak the root viewport to ensure it's rendered before our target.
 	RID root_vp = get_tree()->get_root()->get_viewport_rid();
@@ -1940,14 +1946,18 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_epilog() {
 	player->seek_internal(onion.temp.anim_player_position, true, true, false);
 	player->restore(onion.temp.anim_values_backup);
 
+#ifndef _3D_DISABLED
 	// Restore state of main editors.
 	if (Node3DEditor::get_singleton()->is_visible()) {
 		// 3D
 		Node3DEditor::get_singleton()->set_state(onion.temp.spatial_edit_state);
 	} else { // CanvasItemEditor
 		// 2D
+#endif // _3D_DISABLED
 		CanvasItemEditor::get_singleton()->set_state(onion.temp.canvas_edit_state);
+#ifndef _3D_DISABLED
 	}
+#endif // _3D_DISABLED
 
 	// Update viewports with skin layers overlaid for the actual engine loop render.
 	onion.can_overlay = true;
@@ -2353,7 +2363,9 @@ AnimationPlayerEditor::~AnimationPlayerEditor() {
 void AnimationPlayerEditorPlugin::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
+#ifndef _3D_DISABLED
 			Node3DEditor::get_singleton()->connect(SNAME("transform_3d_key_request"), callable_mp(this, &AnimationPlayerEditorPlugin::_transform_3d_key_request));
+#endif // _3D_DISABLED
 			InspectorDock::get_inspector_singleton()->connect(SNAME("property_keyed"), callable_mp(this, &AnimationPlayerEditorPlugin::_property_keyed));
 			anim_editor->get_track_editor()->connect(SNAME("keying_changed"), callable_mp(this, &AnimationPlayerEditorPlugin::_update_keying));
 			InspectorDock::get_inspector_singleton()->connect(SNAME("edited_object_changed"), callable_mp(anim_editor->get_track_editor(), &AnimationTrackEditor::update_keying));
@@ -2371,6 +2383,7 @@ void AnimationPlayerEditorPlugin::_property_keyed(const String &p_keyed, const V
 	te->insert_value_key(p_keyed, p_advance);
 }
 
+#ifndef _3D_DISABLED
 void AnimationPlayerEditorPlugin::_transform_3d_key_request(Object *sp, const String &p_sub, const Transform3D &p_key) {
 	if (!anim_editor->get_track_editor()->has_keying()) {
 		return;
@@ -2383,6 +2396,7 @@ void AnimationPlayerEditorPlugin::_transform_3d_key_request(Object *sp, const St
 	anim_editor->get_track_editor()->insert_transform_3d_key(s, p_sub, Animation::TYPE_ROTATION_3D, p_key.basis.get_rotation_quaternion());
 	anim_editor->get_track_editor()->insert_transform_3d_key(s, p_sub, Animation::TYPE_SCALE_3D, p_key.basis.get_scale());
 }
+#endif // _3D_DISABLED
 
 void AnimationPlayerEditorPlugin::_update_keying() {
 	InspectorDock::get_inspector_singleton()->set_keying(anim_editor->get_track_editor()->has_keying());

--- a/editor/animation/animation_player_editor_plugin.h
+++ b/editor/animation/animation_player_editor_plugin.h
@@ -296,7 +296,9 @@ protected:
 	void _notification(int p_what);
 
 	void _property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance);
+#ifndef _3D_DISABLED
 	void _transform_key_request(Object *sp, const String &p_sub, const Transform3D &p_key);
+#endif // _3D_DISABLED
 	void _update_keying();
 
 public:
@@ -310,7 +312,9 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	virtual void forward_canvas_force_draw_over_viewport(Control *p_overlay) override { anim_editor->forward_force_draw_over_viewport(p_overlay); }
+#ifndef _3D_DISABLED
 	virtual void forward_3d_force_draw_over_viewport(Control *p_overlay) override { anim_editor->forward_force_draw_over_viewport(p_overlay); }
+#endif // _3D_DISABLED
 
 	AnimationPlayerEditorPlugin();
 	~AnimationPlayerEditorPlugin();

--- a/editor/animation/animation_player_editor_plugin.h
+++ b/editor/animation/animation_player_editor_plugin.h
@@ -296,7 +296,9 @@ protected:
 	void _notification(int p_what);
 
 	void _property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance);
+#ifndef _3D_DISABLED
 	void _transform_3d_key_request(Object *sp, const String &p_sub, const Transform3D &p_key);
+#endif // _3D_DISABLED
 	void _update_keying();
 
 public:
@@ -310,7 +312,9 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	virtual void forward_canvas_force_draw_over_viewport(Control *p_overlay) override { anim_editor->forward_force_draw_over_viewport(p_overlay); }
+#ifndef _3D_DISABLED
 	virtual void forward_3d_force_draw_over_viewport(Control *p_overlay) override { anim_editor->forward_force_draw_over_viewport(p_overlay); }
+#endif // _3D_DISABLED
 
 	AnimationPlayerEditorPlugin();
 	~AnimationPlayerEditorPlugin();

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -51,7 +51,9 @@
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#ifndef _3D_DISABLED
 #include "scene/3d/mesh_instance_3d.h"
+#endif // _3D_DISABLED
 #include "scene/animation/animation_player.h"
 #include "scene/animation/tween.h"
 #include "scene/gui/check_box.h"
@@ -4551,7 +4553,7 @@ void AnimationTrackEditor::_insert_track(bool p_reset_wanted, bool p_create_bezi
 		_edit_menu_pressed(EDIT_GOTO_NEXT_STEP_TIMELINE_ONLY);
 	}
 }
-
+#ifndef _3D_DISABLED
 void AnimationTrackEditor::insert_transform_key(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type, const Variant &p_value) {
 	if (read_only) {
 		popup_read_only_dialog();
@@ -4621,6 +4623,7 @@ bool AnimationTrackEditor::has_track(Node3D *p_node, const String &p_sub, const 
 	}
 	return false;
 }
+#endif // _3D_DISABLED
 
 void AnimationTrackEditor::_insert_animation_key(NodePath p_path, const Variant &p_value) {
 	if (read_only) {
@@ -6054,6 +6057,7 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 	// id.value is filled in each case handled below.
 
 	switch (animation->track_get_type(p_track)) {
+#ifndef _3D_DISABLED
 		case Animation::TYPE_POSITION_3D: {
 			Node3D *base = Object::cast_to<Node3D>(node);
 
@@ -6094,6 +6098,7 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 
 			id.value = base->get_blend_shape_value(base->find_blend_shape_by_name(id.path.get_subname(0)));
 		} break;
+#endif // _3D_DISABLED
 		case Animation::TYPE_VALUE: {
 			NodePath bp;
 			_find_hint_for_track(p_track, bp, &id.value);

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -51,7 +51,9 @@
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#ifndef _3D_DISABLED
 #include "scene/3d/mesh_instance_3d.h"
+#endif // _3D_DISABLED
 #include "scene/animation/animation_player.h"
 #include "scene/animation/tween.h"
 #include "scene/gui/check_box.h"
@@ -4533,7 +4535,7 @@ void AnimationTrackEditor::_insert_track(bool p_reset_wanted, bool p_create_bezi
 		_edit_menu_pressed(EDIT_GOTO_NEXT_STEP_TIMELINE_ONLY);
 	}
 }
-
+#ifndef _3D_DISABLED
 void AnimationTrackEditor::insert_transform_3d_key(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type, const Variant &p_value) {
 	if (read_only) {
 		popup_read_only_dialog();
@@ -4603,6 +4605,7 @@ bool AnimationTrackEditor::has_transform_3d_track(Node3D *p_node, const String &
 	}
 	return false;
 }
+#endif // _3D_DISABLED
 
 void AnimationTrackEditor::_insert_animation_key(NodePath p_path, const Variant &p_value) {
 	if (read_only) {
@@ -6036,6 +6039,7 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 	// id.value is filled in each case handled below.
 
 	switch (animation->track_get_type(p_track)) {
+#ifndef _3D_DISABLED
 		case Animation::TYPE_POSITION_3D: {
 			Node3D *base = Object::cast_to<Node3D>(node);
 
@@ -6076,6 +6080,7 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 
 			id.value = base->get_blend_shape_value(base->find_blend_shape_by_name(id.path.get_subname(0)));
 		} break;
+#endif // _3D_DISABLED
 		case Animation::TYPE_VALUE: {
 			NodePath bp;
 			_find_hint_for_track(p_track, bp, &id.value);

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -34,7 +34,9 @@
 #include "editor/editor_data.h"
 #include "editor/inspector/editor_properties.h"
 #include "editor/inspector/property_selector.h"
+#ifndef _3D_DISABLED
 #include "scene/3d/node_3d.h"
+#endif // _3D_DISABLED
 #include "scene/gui/control.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/scroll_bar.h"
@@ -972,8 +974,10 @@ public:
 	void set_anim_pos(float p_pos);
 	void insert_node_value_key(Node *p_node, const String &p_property, bool p_only_if_exists = false, bool p_advance = false);
 	void insert_value_key(const String &p_property, bool p_advance);
+#ifndef _3D_DISABLED
 	void insert_transform_key(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type, const Variant &p_value);
 	bool has_track(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type);
+#endif // _3D_DISABLED
 	void make_insert_queue();
 	void commit_insert_queue();
 

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -34,7 +34,9 @@
 #include "editor/editor_data.h"
 #include "editor/inspector/editor_properties.h"
 #include "editor/inspector/property_selector.h"
+#ifndef _3D_DISABLED
 #include "scene/3d/node_3d.h"
+#endif // _3D_DISABLED
 #include "scene/gui/control.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/scroll_bar.h"
@@ -976,8 +978,10 @@ public:
 	void set_anim_pos(float p_pos);
 	void insert_node_value_key(Node *p_node, const String &p_property, bool p_only_if_exists = false, bool p_advance = false);
 	void insert_value_key(const String &p_property, bool p_advance);
+#ifndef _3D_DISABLED
 	void insert_transform_3d_key(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type, const Variant &p_value);
 	bool has_transform_3d_track(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type);
+#endif // _3D_DISABLED
 	void make_insert_queue();
 	void commit_insert_queue();
 

--- a/editor/animation/animation_track_editor_plugins.cpp
+++ b/editor/animation/animation_track_editor_plugins.cpp
@@ -39,10 +39,13 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/2d/animated_sprite_2d.h"
 #include "scene/2d/sprite_2d.h"
-#include "scene/3d/sprite_3d.h"
 #include "scene/animation/animation_player.h"
 #include "servers/audio/audio_stream.h"
 #include "servers/rendering/rendering_server.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/sprite_3d.h"
+#endif // _3D_DISABLED
 
 /// BOOL ///
 int AnimationTrackEditBool::get_key_height() const {
@@ -383,7 +386,11 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 
 	Size2 size;
 
+#ifndef _3D_DISABLED
 	if (Object::cast_to<Sprite2D>(object) || Object::cast_to<Sprite3D>(object)) {
+#else
+	if (Object::cast_to<Sprite2D>(object)) {
+#endif // _3D_DISABLED
 		Ref<Texture2D> texture = object->call("get_texture");
 		if (texture.is_null()) {
 			return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
@@ -404,7 +411,11 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 		if (vframes > 1) {
 			size.y /= vframes;
 		}
+#ifndef _3D_DISABLED
 	} else if (Object::cast_to<AnimatedSprite2D>(object) || Object::cast_to<AnimatedSprite3D>(object)) {
+#else
+	} else if (Object::cast_to<AnimatedSprite2D>(object)) {
+#endif // _3D_DISABLED
 		Ref<SpriteFrames> sf = object->call("get_sprite_frames");
 		if (sf.is_null()) {
 			return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
@@ -468,7 +479,11 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 	Ref<Texture2D> texture;
 	Rect2 region;
 
+#ifndef _3D_DISABLED
 	if (Object::cast_to<Sprite2D>(object) || Object::cast_to<Sprite3D>(object)) {
+#else
+	if (Object::cast_to<Sprite2D>(object)) {
+#endif // _3D_DISABLED
 		texture = object->call("get_texture");
 		if (texture.is_null()) {
 			AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
@@ -503,7 +518,11 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 		region.position.x += region.size.x * coords.x;
 		region.position.y += region.size.y * coords.y;
 
+#ifndef _3D_DISABLED
 	} else if (Object::cast_to<AnimatedSprite2D>(object) || Object::cast_to<AnimatedSprite3D>(object)) {
+#else
+	} else if (Object::cast_to<AnimatedSprite2D>(object)) {
+#endif // _3D_DISABLED
 		Ref<SpriteFrames> sf = object->call("get_sprite_frames");
 		if (sf.is_null()) {
 			AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);

--- a/editor/animation/animation_track_editor_plugins.cpp
+++ b/editor/animation/animation_track_editor_plugins.cpp
@@ -39,10 +39,13 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/2d/animated_sprite_2d.h"
 #include "scene/2d/sprite_2d.h"
-#include "scene/3d/sprite_3d.h"
 #include "scene/animation/animation_player.h"
 #include "scene/resources/audio/audio_stream.h"
 #include "servers/rendering/rendering_server.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/sprite_3d.h"
+#endif // _3D_DISABLED
 
 /// BOOL ///
 int AnimationTrackEditBool::get_key_height() const {
@@ -383,7 +386,11 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 
 	Size2 size;
 
+#ifndef _3D_DISABLED
 	if (Object::cast_to<Sprite2D>(object) || Object::cast_to<Sprite3D>(object)) {
+#else
+	if (Object::cast_to<Sprite2D>(object)) {
+#endif // _3D_DISABLED
 		Ref<Texture2D> texture = object->call("get_texture");
 		if (texture.is_null()) {
 			return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
@@ -404,7 +411,11 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 		if (vframes > 1) {
 			size.y /= vframes;
 		}
+#ifndef _3D_DISABLED
 	} else if (Object::cast_to<AnimatedSprite2D>(object) || Object::cast_to<AnimatedSprite3D>(object)) {
+#else
+	} else if (Object::cast_to<AnimatedSprite2D>(object)) {
+#endif // _3D_DISABLED
 		Ref<SpriteFrames> sf = object->call("get_sprite_frames");
 		if (sf.is_null()) {
 			return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
@@ -468,7 +479,11 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 	Ref<Texture2D> texture;
 	Rect2 region;
 
+#ifndef _3D_DISABLED
 	if (Object::cast_to<Sprite2D>(object) || Object::cast_to<Sprite3D>(object)) {
+#else
+	if (Object::cast_to<Sprite2D>(object)) {
+#endif // _3D_DISABLED
 		texture = object->call("get_texture");
 		if (texture.is_null()) {
 			AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
@@ -503,7 +518,11 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 		region.position.x += region.size.x * coords.x;
 		region.position.y += region.size.y * coords.y;
 
+#ifndef _3D_DISABLED
 	} else if (Object::cast_to<AnimatedSprite2D>(object) || Object::cast_to<AnimatedSprite3D>(object)) {
+#else
+	} else if (Object::cast_to<AnimatedSprite2D>(object)) {
+#endif // _3D_DISABLED
 		Ref<SpriteFrames> sf = object->call("get_sprite_frames");
 		if (sf.is_null()) {
 			AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -54,12 +54,10 @@
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_toaster.h"
 #include "editor/inspector/editor_property_name_processor.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "main/performance.h"
-#include "scene/3d/camera_3d.h"
 #include "scene/debugger/scene_debugger_object.h"
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
@@ -73,6 +71,11 @@
 #include "scene/gui/tree.h"
 #include "servers/debugger/servers_debugger.h"
 #include "servers/display/display_server.h"
+
+#ifndef _3D_DISABLED
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "scene/3d/camera_3d.h"
+#endif // _3D_DISABLED
 
 using CameraOverride = EditorDebuggerNode::CameraOverride;
 
@@ -1172,6 +1175,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 						_put_msg("scene:transform_camera_2d", msg);
 					}
 
+#ifndef _3D_DISABLED
 					// Node3D Editor
 					{
 						Node3DEditorViewport *viewport = Node3DEditor::get_singleton()->get_last_used_viewport();
@@ -1189,6 +1193,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 						msg.push_back(cam->get_far());
 						_put_msg("scene:transform_camera_3d", msg);
 					}
+#endif // _3D_DISABLED
 				}
 
 				if (is_breaked() && can_request_idle_draw) {

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -54,13 +54,10 @@
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_toaster.h"
 #include "editor/inspector/editor_property_name_processor.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h"
-#include "editor/scene/3d/node_3d_editor_viewport.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "main/performance.h"
-#include "scene/3d/camera_3d.h"
 #include "scene/debugger/scene_debugger_object.h"
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
@@ -74,6 +71,11 @@
 #include "scene/gui/tree.h"
 #include "servers/debugger/servers_debugger.h"
 #include "servers/display/display_server.h"
+
+#ifndef _3D_DISABLED
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "scene/3d/camera_3d.h"
+#endif // _3D_DISABLED
 
 using CameraOverride = EditorDebuggerNode::CameraOverride;
 
@@ -1176,6 +1178,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 						_put_msg("scene:transform_camera_2d", msg);
 					}
 
+#ifndef _3D_DISABLED
 					// Node3D Editor
 					{
 						Node3DEditorViewport *viewport = Node3DEditor::get_singleton()->get_last_used_viewport();
@@ -1193,6 +1196,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 						msg.push_back(cam->get_far());
 						_put_msg("scene:transform_camera_3d", msg);
 					}
+#endif // _3D_DISABLED
 				}
 
 				if (is_breaked() && can_request_idle_draw) {

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -53,7 +53,6 @@
 #include "editor/gui/create_dialog.h"
 #include "editor/gui/directory_create_dialog.h"
 #include "editor/gui/editor_dir_dialog.h"
-#include "editor/import/3d/scene_import_settings.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "editor/inspector/editor_resource_preview.h"
 #include "editor/inspector/editor_resource_tooltip_plugins.h"
@@ -74,6 +73,10 @@
 #include "scene/gui/progress_bar.h"
 #include "scene/resources/packed_scene.h"
 #include "servers/display/display_server.h"
+
+#ifndef _3D_DISABLED
+#include "editor/import/3d/scene_import_settings.h"
+#endif // _3D_DISABLED
 
 Control *FileSystemTree::make_custom_tooltip(const String &p_text) const {
 	TreeItem *item = get_item_at_position(get_local_mouse_position());
@@ -1327,6 +1330,7 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 
 		String resource_type = ResourceLoader::get_resource_type(fpath);
 		if (resource_type == "PackedScene" || resource_type == "AnimationLibrary") {
+#ifndef _3D_DISABLED
 			bool is_imported = false;
 			{
 				List<String> importer_exts;
@@ -1343,8 +1347,11 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 			if (is_imported) {
 				SceneImportSettingsDialog::get_singleton()->open_settings(p_path, resource_type);
 			} else {
+#endif // _3D_DISABLED
 				EditorNode::get_singleton()->load_scene_or_resource(fpath);
+#ifndef _3D_DISABLED
 			}
+#endif // _3D_DISABLED
 		} else if (ResourceLoader::is_imported(fpath)) {
 			// If the importer has advanced settings, show them.
 			int order;

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -53,7 +53,6 @@
 #include "editor/gui/create_dialog.h"
 #include "editor/gui/directory_create_dialog.h"
 #include "editor/gui/editor_dir_dialog.h"
-#include "editor/import/3d/scene_import_settings.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "editor/inspector/editor_resource_preview.h"
 #include "editor/inspector/editor_resource_tooltip_plugins.h"
@@ -77,6 +76,10 @@
 #include "scene/main/timer.h"
 #include "scene/resources/packed_scene.h"
 #include "servers/display/display_server.h"
+
+#ifndef _3D_DISABLED
+#include "editor/import/3d/scene_import_settings.h"
+#endif // _3D_DISABLED
 
 Control *FileSystemTree::make_custom_tooltip(const String &p_text) const {
 	TreeItem *item = get_item_at_position(get_local_mouse_position());
@@ -1346,6 +1349,7 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 
 		String resource_type = ResourceLoader::get_resource_type(fpath);
 		if (resource_type == "PackedScene" || resource_type == "AnimationLibrary") {
+#ifndef _3D_DISABLED
 			bool is_imported = false;
 			{
 				List<String> importer_exts;
@@ -1362,8 +1366,11 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 			if (is_imported) {
 				SceneImportSettingsDialog::get_singleton()->open_settings(p_path, resource_type);
 			} else {
+#endif // _3D_DISABLED
 				EditorNode::get_singleton()->load_scene_or_resource(fpath);
+#ifndef _3D_DISABLED
 			}
+#endif // _3D_DISABLED
 		} else if (ResourceLoader::is_imported(fpath)) {
 			// If the importer has advanced settings, show them.
 			int order;

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -53,7 +53,6 @@
 #include "editor/gui/editor_quick_open_dialog.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "editor/inspector/multi_node_edit.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/scene/rename_dialog.h"
 #include "editor/scene/reparent_dialog.h"
@@ -73,6 +72,10 @@
 #include "scene/property_utils.h"
 #include "scene/resources/packed_scene.h"
 #include "servers/display/display_server.h"
+
+#ifndef _3D_DISABLED
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#endif // _3D_DISABLED
 
 void SceneTreeDock::_nodes_drag_begin() {
 	pending_click_select = nullptr;
@@ -396,8 +399,10 @@ void SceneTreeDock::_perform_create_audio_stream_players(const Vector<String> &p
 	if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
 		if (Object::cast_to<Node2D>(p_parent)) {
 			node_type = "AudioStreamPlayer2D";
+#ifndef _3D_DISABLED
 		} else if (Object::cast_to<Node3D>(p_parent)) {
 			node_type = "AudioStreamPlayer3D";
+#endif // _3D_DISABLED
 		}
 	}
 
@@ -486,6 +491,7 @@ void SceneTreeDock::_replace_with_branch_scene(const String &p_file, Node *p_bas
 		copy_2d->set_scale(base_2d->get_scale());
 	}
 
+#ifndef _3D_DISABLED
 	Node3D *copy_3d = Object::cast_to<Node3D>(instantiated_scene);
 	Node3D *base_3d = Object::cast_to<Node3D>(p_base);
 	if (copy_3d && base_3d) {
@@ -493,6 +499,7 @@ void SceneTreeDock::_replace_with_branch_scene(const String &p_file, Node *p_bas
 		copy_3d->set_rotation(base_3d->get_rotation());
 		copy_3d->set_scale(base_3d->get_scale());
 	}
+#endif // _3D_DISABLED
 
 	// Ensure that local signals are still connected.
 	List<MethodInfo> signal_list;
@@ -656,7 +663,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				if (preferred_types.is_empty()) {
 					preferred_types.push_back("Control");
 					preferred_types.push_back("Node2D");
+#ifndef _3D_DISABLED
 					preferred_types.push_back("Node3D");
+#endif // _3D_DISABLED
 				}
 
 				for (int i = 0; i < preferred_types.size(); i++) {
@@ -1599,7 +1608,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 						new_node = memnew(Node2D);
 						break;
 					case TOOL_CREATE_3D_SCENE:
+#ifndef _3D_DISABLED
 						new_node = memnew(Node3D);
+#endif // _3D_DISABLED
 						break;
 					case TOOL_CREATE_USER_INTERFACE: {
 						Control *node = memnew(Control);
@@ -1688,9 +1699,11 @@ void SceneTreeDock::_notification(int p_what) {
 				scene_tree->connect("node_changed", callable_mp((CanvasItem *)canvas_item_plugin->get_canvas_item_editor()->get_viewport_control(), &CanvasItem::queue_redraw));
 			}
 
+#ifndef _3D_DISABLED
 			Node3DEditorPlugin *spatial_editor_plugin = Object::cast_to<Node3DEditorPlugin>(editor_data->get_editor_by_name("3D"));
 			spatial_editor_plugin->get_spatial_editor()->connect("item_lock_status_changed", callable_mp(scene_tree, &SceneTreeEditor::_update_tree).bind(false));
 			spatial_editor_plugin->get_spatial_editor()->connect("item_group_status_changed", callable_mp(scene_tree, &SceneTreeEditor::_update_tree).bind(false));
+#endif // _3D_DISABLED
 
 			filter->set_clear_button_enabled(true);
 
@@ -1733,11 +1746,13 @@ void SceneTreeDock::_notification(int p_what) {
 			button_2d->set_button_icon(get_editor_theme_icon(SNAME("Node2D")));
 			button_2d->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(TOOL_CREATE_2D_SCENE, false));
 
+#ifndef _3D_DISABLED
 			button_3d = memnew(Button);
 			beginner_node_shortcuts->add_child(button_3d);
 			button_3d->set_text(TTR("3D Scene"));
 			button_3d->set_button_icon(get_editor_theme_icon(SNAME("Node3D")));
 			button_3d->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(TOOL_CREATE_3D_SCENE, false));
+#endif // _3D_DISABLED
 
 			button_ui = memnew(Button);
 			beginner_node_shortcuts->add_child(button_ui);
@@ -1800,9 +1815,11 @@ void SceneTreeDock::_notification(int p_what) {
 			if (button_2d) {
 				button_2d->set_button_icon(get_editor_theme_icon(SNAME("Node2D")));
 			}
+#ifndef _3D_DISABLED
 			if (button_3d) {
 				button_3d->set_button_icon(get_editor_theme_icon(SNAME("Node3D")));
 			}
+#endif // _3D_DISABLED
 			if (button_ui) {
 				button_ui->set_button_icon(get_editor_theme_icon(SNAME("Control")));
 			}
@@ -2577,9 +2594,11 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 			if (Object::cast_to<Node2D>(node)) {
 				undo_redo->add_do_method(node, "set_global_transform", Object::cast_to<Node2D>(node)->get_global_transform());
 			}
+#ifndef _3D_DISABLED
 			if (Object::cast_to<Node3D>(node)) {
 				undo_redo->add_do_method(node, "set_global_transform", Object::cast_to<Node3D>(node)->get_global_transform());
 			}
+#endif // _3D_DISABLED
 			if (Object::cast_to<Control>(node)) {
 				undo_redo->add_do_method(node, "set_global_position", Object::cast_to<Control>(node)->get_global_position());
 			}
@@ -2622,9 +2641,11 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 			if (Object::cast_to<Node2D>(node)) {
 				undo_redo->add_undo_method(node, "set_transform", Object::cast_to<Node2D>(node)->get_transform());
 			}
+#ifndef _3D_DISABLED
 			if (Object::cast_to<Node3D>(node)) {
 				undo_redo->add_undo_method(node, "set_transform", Object::cast_to<Node3D>(node)->get_transform());
 			}
+#endif // _3D_DISABLED
 			if (!reparented_to_container && Object::cast_to<Control>(node)) {
 				undo_redo->add_undo_method(node, "set_position", Object::cast_to<Control>(node)->get_position());
 			}
@@ -2776,15 +2797,19 @@ void SceneTreeDock::_reparent_nodes_to_paths_with_transform_and_name(Node *p_roo
 		node->get_owned_by(p_owner, &owned);
 		node->reparent(parent_node);
 		node->set_name(p_names[i]);
+#ifndef _3D_DISABLED
 		Node3D *node_3d = Object::cast_to<Node3D>(node);
 		if (node_3d) {
 			node_3d->set_transform(p_transforms[i]);
 		} else {
+#endif // _3D_DISABLED
 			Node2D *node_2d = Object::cast_to<Node2D>(node);
 			if (node_2d) {
 				node_2d->set_transform(p_transforms[i]);
 			}
+#ifndef _3D_DISABLED
 		}
+#endif // _3D_DISABLED
 
 		for (Node *F : owned) {
 			F->set_owner(p_owner);
@@ -2826,17 +2851,21 @@ void SceneTreeDock::_toggle_editable_children(Node *p_node) {
 				owned_nodes_array.push_back(owned_node);
 				paths_array.push_back(p_node->get_path_to(owned_node->get_parent()));
 				name_array.push_back(owned_node->get_name());
+#ifndef _3D_DISABLED
 				Node3D *node_3d = Object::cast_to<Node3D>(owned_node);
 				if (node_3d) {
 					transform_array.push_back(node_3d->get_transform());
 				} else {
+#endif // _3D_DISABLED
 					Node2D *node_2d = Object::cast_to<Node2D>(owned_node);
 					if (node_2d) {
 						transform_array.push_back(node_2d->get_transform());
 					} else {
 						transform_array.push_back(Variant());
 					}
+#ifndef _3D_DISABLED
 				}
+#endif // _3D_DISABLED
 			}
 		}
 
@@ -2846,8 +2875,10 @@ void SceneTreeDock::_toggle_editable_children(Node *p_node) {
 		}
 	}
 
+#ifndef _3D_DISABLED
 	undo_redo->add_undo_method(Node3DEditor::get_singleton(), "update_all_gizmos", p_node);
 	undo_redo->add_do_method(Node3DEditor::get_singleton(), "update_all_gizmos", p_node);
+#endif // _3D_DISABLED
 
 	undo_redo->add_undo_method(scene_tree, "update_tree");
 	undo_redo->add_do_method(scene_tree, "update_tree");
@@ -3196,7 +3227,8 @@ void SceneTreeDock::_create() {
 		}
 
 		if (center_parent) {
-			// Find parent type and only average positions of relevant nodes.
+// Find parent type and only average positions of relevant nodes.
+#ifndef _3D_DISABLED
 			Node3D *parent_node_3d = Object::cast_to<Node3D>(last_created);
 			if (parent_node_3d) {
 				Vector3 position;
@@ -3213,6 +3245,7 @@ void SceneTreeDock::_create() {
 					parent_node_3d->set_global_position(position / node_count);
 				}
 			}
+#endif // _3D_DISABLED
 
 			Node2D *parent_node_2d = Object::cast_to<Node2D>(last_created);
 			if (parent_node_2d) {
@@ -3524,6 +3557,7 @@ void SceneTreeDock::_new_scene_from(const String &p_file) {
 				copy_2d->set_scale(Size2(1, 1));
 			}
 		}
+#ifndef _3D_DISABLED
 		Node3D *copy_3d = Object::cast_to<Node3D>(copy);
 		if (copy_3d != nullptr) {
 			if (reset_position) {
@@ -3536,6 +3570,7 @@ void SceneTreeDock::_new_scene_from(const String &p_file) {
 				copy_3d->set_scale(Vector3(1, 1, 1));
 			}
 		}
+#endif // _3D_DISABLED
 
 		Ref<PackedScene> sdata = memnew(PackedScene);
 		Error err = sdata->pack(copy);
@@ -4262,8 +4297,10 @@ void SceneTreeDock::_focus_node() {
 		CanvasItemEditorPlugin *editor = Object::cast_to<CanvasItemEditorPlugin>(editor_data->get_editor_by_name("2D"));
 		editor->get_canvas_item_editor()->focus_selection();
 	} else {
+#ifndef _3D_DISABLED
 		Node3DEditorPlugin *editor = Object::cast_to<Node3DEditorPlugin>(editor_data->get_editor_by_name("3D"));
 		editor->get_spatial_editor()->get_editor_viewport(0)->focus_selection();
+#endif // _3D_DISABLED
 	}
 }
 
@@ -4720,15 +4757,19 @@ void SceneTreeDock::_feature_profile_changed() {
 	if (profile.is_valid()) {
 		profile_allow_editing = !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_SCENE_TREE);
 		profile_allow_script_editing = !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_SCRIPT);
+#ifndef _3D_DISABLED
 		bool profile_allow_3d = !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D);
 
 		button_3d->set_visible(profile_allow_3d);
+#endif // _3D_DISABLED
 		button_add->set_visible(profile_allow_editing);
 		button_instance->set_visible(profile_allow_editing);
 		scene_tree->set_can_rename(profile_allow_editing);
 
 	} else {
+#ifndef _3D_DISABLED
 		button_3d->set_visible(true);
+#endif // _3D_DISABLED
 		button_add->set_visible(true);
 		button_instance->set_visible(true);
 		scene_tree->set_can_rename(true);

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -53,8 +53,6 @@
 #include "editor/gui/editor_quick_open_dialog.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "editor/inspector/multi_node_edit.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h"
-#include "editor/scene/3d/node_3d_editor_viewport.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/scene/rename_dialog.h"
 #include "editor/scene/reparent_dialog.h"
@@ -76,6 +74,10 @@
 #include "scene/resources/packed_scene.h"
 #include "scene/resources/style_box_flat.h"
 #include "servers/display/display_server.h"
+
+#ifndef _3D_DISABLED
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#endif // _3D_DISABLED
 
 void SceneTreeDock::_nodes_drag_begin() {
 	pending_click_select = nullptr;
@@ -436,8 +438,10 @@ void SceneTreeDock::_perform_create_audio_stream_players(const Vector<String> &p
 	if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
 		if (Object::cast_to<Node2D>(p_parent)) {
 			node_type = "AudioStreamPlayer2D";
+#ifndef _3D_DISABLED
 		} else if (Object::cast_to<Node3D>(p_parent)) {
 			node_type = "AudioStreamPlayer3D";
+#endif // _3D_DISABLED
 		}
 	}
 
@@ -526,6 +530,7 @@ void SceneTreeDock::_replace_with_branch_scene(const String &p_file, Node *p_bas
 		copy_2d->set_scale(base_2d->get_scale());
 	}
 
+#ifndef _3D_DISABLED
 	Node3D *copy_3d = Object::cast_to<Node3D>(instantiated_scene);
 	Node3D *base_3d = Object::cast_to<Node3D>(p_base);
 	if (copy_3d && base_3d) {
@@ -533,6 +538,7 @@ void SceneTreeDock::_replace_with_branch_scene(const String &p_file, Node *p_bas
 		copy_3d->set_rotation(base_3d->get_rotation());
 		copy_3d->set_scale(base_3d->get_scale());
 	}
+#endif // _3D_DISABLED
 
 	// Ensure that local signals are still connected.
 	List<MethodInfo> signal_list;
@@ -690,7 +696,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				if (preferred_types.is_empty()) {
 					preferred_types.push_back("Control");
 					preferred_types.push_back("Node2D");
+#ifndef _3D_DISABLED
 					preferred_types.push_back("Node3D");
+#endif // _3D_DISABLED
 				}
 
 				for (int i = 0; i < preferred_types.size(); i++) {
@@ -1638,7 +1646,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 						new_node = memnew(Node2D);
 						break;
 					case TOOL_CREATE_3D_SCENE:
+#ifndef _3D_DISABLED
 						new_node = memnew(Node3D);
+#endif // _3D_DISABLED
 						break;
 					case TOOL_CREATE_USER_INTERFACE: {
 						Control *node = memnew(Control);
@@ -1727,9 +1737,11 @@ void SceneTreeDock::_notification(int p_what) {
 				scene_tree->connect("node_changed", callable_mp((CanvasItem *)canvas_item_plugin->get_canvas_item_editor()->get_viewport_control(), &CanvasItem::queue_redraw));
 			}
 
+#ifndef _3D_DISABLED
 			Node3DEditorPlugin *spatial_editor_plugin = Object::cast_to<Node3DEditorPlugin>(editor_data->get_editor_by_name("3D"));
 			spatial_editor_plugin->get_spatial_editor()->connect("item_lock_status_changed", callable_mp(scene_tree, &SceneTreeEditor::_update_tree).bind(false));
 			spatial_editor_plugin->get_spatial_editor()->connect("item_group_status_changed", callable_mp(scene_tree, &SceneTreeEditor::_update_tree).bind(false));
+#endif // _3D_DISABLED
 
 			filter->set_clear_button_enabled(true);
 
@@ -1772,11 +1784,13 @@ void SceneTreeDock::_notification(int p_what) {
 			button_2d->set_button_icon(get_editor_theme_icon(SNAME("Node2D")));
 			button_2d->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(TOOL_CREATE_2D_SCENE, false));
 
+#ifndef _3D_DISABLED
 			button_3d = memnew(Button);
 			beginner_node_shortcuts->add_child(button_3d);
 			button_3d->set_text(TTRC("3D Scene"));
 			button_3d->set_button_icon(get_editor_theme_icon(SNAME("Node3D")));
 			button_3d->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(TOOL_CREATE_3D_SCENE, false));
+#endif // _3D_DISABLED
 
 			button_ui = memnew(Button);
 			beginner_node_shortcuts->add_child(button_ui);
@@ -1840,9 +1854,11 @@ void SceneTreeDock::_notification(int p_what) {
 			if (button_2d) {
 				button_2d->set_button_icon(get_editor_theme_icon(SNAME("Node2D")));
 			}
+#ifndef _3D_DISABLED
 			if (button_3d) {
 				button_3d->set_button_icon(get_editor_theme_icon(SNAME("Node3D")));
 			}
+#endif // _3D_DISABLED
 			if (button_ui) {
 				button_ui->set_button_icon(get_editor_theme_icon(SNAME("Control")));
 			}
@@ -2652,9 +2668,11 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 			if (Object::cast_to<Node2D>(node)) {
 				undo_redo->add_do_method(node, "set_global_transform", Object::cast_to<Node2D>(node)->get_global_transform());
 			}
+#ifndef _3D_DISABLED
 			if (Object::cast_to<Node3D>(node)) {
 				undo_redo->add_do_method(node, "set_global_transform", Object::cast_to<Node3D>(node)->get_global_transform());
 			}
+#endif // _3D_DISABLED
 			if (Object::cast_to<Control>(node)) {
 				undo_redo->add_do_method(node, "set_global_position", Object::cast_to<Control>(node)->get_global_position());
 			}
@@ -2697,9 +2715,11 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 			if (Object::cast_to<Node2D>(node)) {
 				undo_redo->add_undo_method(node, "set_transform", Object::cast_to<Node2D>(node)->get_transform());
 			}
+#ifndef _3D_DISABLED
 			if (Object::cast_to<Node3D>(node)) {
 				undo_redo->add_undo_method(node, "set_transform", Object::cast_to<Node3D>(node)->get_transform());
 			}
+#endif // _3D_DISABLED
 			if (!reparented_to_container && Object::cast_to<Control>(node)) {
 				undo_redo->add_undo_method(node, "set_position", Object::cast_to<Control>(node)->get_position());
 			}
@@ -2851,15 +2871,19 @@ void SceneTreeDock::_reparent_nodes_to_paths_with_transform_and_name(Node *p_roo
 		node->get_owned_by(p_owner, &owned);
 		node->reparent(parent_node);
 		node->set_name(p_names[i]);
+#ifndef _3D_DISABLED
 		Node3D *node_3d = Object::cast_to<Node3D>(node);
 		if (node_3d) {
 			node_3d->set_transform(p_transforms[i]);
 		} else {
+#endif // _3D_DISABLED
 			Node2D *node_2d = Object::cast_to<Node2D>(node);
 			if (node_2d) {
 				node_2d->set_transform(p_transforms[i]);
 			}
+#ifndef _3D_DISABLED
 		}
+#endif // _3D_DISABLED
 
 		for (Node *F : owned) {
 			F->set_owner(p_owner);
@@ -2901,17 +2925,21 @@ void SceneTreeDock::_toggle_editable_children(Node *p_node) {
 				owned_nodes_array.push_back(owned_node);
 				paths_array.push_back(p_node->get_path_to(owned_node->get_parent()));
 				name_array.push_back(owned_node->get_name());
+#ifndef _3D_DISABLED
 				Node3D *node_3d = Object::cast_to<Node3D>(owned_node);
 				if (node_3d) {
 					transform_array.push_back(node_3d->get_transform());
 				} else {
+#endif // _3D_DISABLED
 					Node2D *node_2d = Object::cast_to<Node2D>(owned_node);
 					if (node_2d) {
 						transform_array.push_back(node_2d->get_transform());
 					} else {
 						transform_array.push_back(Variant());
 					}
+#ifndef _3D_DISABLED
 				}
+#endif // _3D_DISABLED
 			}
 		}
 
@@ -2921,8 +2949,10 @@ void SceneTreeDock::_toggle_editable_children(Node *p_node) {
 		}
 	}
 
+#ifndef _3D_DISABLED
 	undo_redo->add_undo_method(Node3DEditor::get_singleton(), "update_all_gizmos", p_node);
 	undo_redo->add_do_method(Node3DEditor::get_singleton(), "update_all_gizmos", p_node);
+#endif // _3D_DISABLED
 
 	undo_redo->add_undo_method(scene_tree, "update_tree");
 	undo_redo->add_do_method(scene_tree, "update_tree");
@@ -3280,6 +3310,7 @@ void SceneTreeDock::_create() {
 
 		if (center_parent) {
 			// Find parent type and only average positions of relevant nodes.
+#ifndef _3D_DISABLED
 			Node3D *parent_node_3d = Object::cast_to<Node3D>(last_created);
 			if (parent_node_3d) {
 				Vector3 position;
@@ -3296,6 +3327,7 @@ void SceneTreeDock::_create() {
 					parent_node_3d->set_global_position(position / node_count);
 				}
 			}
+#endif // _3D_DISABLED
 
 			Node2D *parent_node_2d = Object::cast_to<Node2D>(last_created);
 			if (parent_node_2d) {
@@ -3627,6 +3659,7 @@ void SceneTreeDock::_new_scene_from(const String &p_file) {
 				copy_2d->set_scale(Size2(1, 1));
 			}
 		}
+#ifndef _3D_DISABLED
 		Node3D *copy_3d = Object::cast_to<Node3D>(copy);
 		if (copy_3d != nullptr) {
 			if (reset_position) {
@@ -3639,6 +3672,7 @@ void SceneTreeDock::_new_scene_from(const String &p_file) {
 				copy_3d->set_scale(Vector3(1, 1, 1));
 			}
 		}
+#endif // _3D_DISABLED
 
 		Ref<PackedScene> sdata = memnew(PackedScene);
 		Error err = sdata->pack(copy);
@@ -4375,8 +4409,10 @@ void SceneTreeDock::_focus_node() {
 		CanvasItemEditorPlugin *editor = Object::cast_to<CanvasItemEditorPlugin>(editor_data->get_editor_by_name("2D"));
 		editor->get_canvas_item_editor()->focus_selection();
 	} else {
+#ifndef _3D_DISABLED
 		Node3DEditorPlugin *editor = Object::cast_to<Node3DEditorPlugin>(editor_data->get_editor_by_name("3D"));
 		editor->get_spatial_editor()->get_editor_viewport(0)->focus_selection();
+#endif // _3D_DISABLED
 	}
 }
 
@@ -4658,14 +4694,22 @@ void SceneTreeDock::paste_node_as_replacement() {
 
 		const bool is_missing_node_selected = Object::cast_to<MissingNode>(selected) != nullptr;
 		const CanvasItem *selected_canvas_item = Object::cast_to<CanvasItem>(selected);
+#ifndef _3D_DISABLED
 		const Node3D *selected_node_3d = Object::cast_to<Node3D>(selected);
+#endif // _3D_DISABLED
 		Transform2D selected_transform_2d;
+#ifndef _3D_DISABLED
 		Transform3D selected_transform_3d;
 		if (selected_canvas_item) {
 			selected_transform_2d = selected_canvas_item->get_transform();
 		} else if (selected_node_3d) {
 			selected_transform_3d = selected_node_3d->get_transform();
 		}
+#else
+		if (selected_canvas_item) {
+			selected_transform_2d = selected_canvas_item->get_transform();
+		}
+#endif // _3D_DISABLED
 
 		if (selected_canvas_item) {
 			Node2D *new_node_2d = Object::cast_to<Node2D>(new_node);
@@ -4677,11 +4721,13 @@ void SceneTreeDock::paste_node_as_replacement() {
 				new_control->set_rotation(selected_transform_2d.get_rotation());
 				new_control->set_scale(selected_transform_2d.get_scale());
 			}
+#ifndef _3D_DISABLED
 		} else if (selected_node_3d) {
 			Node3D *new_node_3d = Object::cast_to<Node3D>(new_node);
 			if (new_node_3d) {
 				new_node_3d->set_transform(selected_transform_3d);
 			}
+#endif // _3D_DISABLED
 		}
 
 		for (Node *child : new_node->iterate_children()) {
@@ -4847,15 +4893,19 @@ void SceneTreeDock::_feature_profile_changed() {
 	if (profile.is_valid()) {
 		profile_allow_editing = !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_SCENE_TREE);
 		profile_allow_script_editing = !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_SCRIPT);
+#ifndef _3D_DISABLED
 		bool profile_allow_3d = !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D);
 
 		button_3d->set_visible(profile_allow_3d);
+#endif // _3D_DISABLED
 		button_add->set_visible(profile_allow_editing);
 		button_instance->set_visible(profile_allow_editing);
 		scene_tree->set_can_rename(profile_allow_editing);
 
 	} else {
+#ifndef _3D_DISABLED
 		button_3d->set_visible(true);
+#endif // _3D_DISABLED
 		button_add->set_visible(true);
 		button_instance->set_visible(true);
 		scene_tree->set_can_rename(true);

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -123,7 +123,9 @@ class SceneTreeDock : public EditorDock {
 	VBoxContainer *favorite_node_shortcuts = nullptr;
 
 	Button *button_2d = nullptr;
+#ifndef _3D_DISABLED
 	Button *button_3d = nullptr;
+#endif // _3D_DISABLED
 	Button *button_ui = nullptr;
 	Button *button_custom = nullptr;
 	Button *button_clipboard = nullptr;

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -126,7 +126,9 @@ class SceneTreeDock : public EditorDock {
 	VBoxContainer *favorite_node_shortcuts = nullptr;
 
 	Button *button_2d = nullptr;
+#ifndef _3D_DISABLED
 	Button *button_3d = nullptr;
+#endif // _3D_DISABLED
 	Button *button_ui = nullptr;
 	Button *button_custom = nullptr;
 	Button *button_clipboard = nullptr;

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -49,7 +49,6 @@
 #include "editor/inspector/editor_resource_preview.h"
 #include "editor/inspector/property_selector.h"
 #include "editor/run/editor_run_bar.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/scene/editor_scene_tabs.h"
 #include "editor/scene/scene_tree_editor.h"
 #include "editor/settings/editor_command_palette.h"
@@ -57,8 +56,6 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "main/main.h"
-#include "scene/3d/light_3d.h"
-#include "scene/3d/mesh_instance_3d.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/control.h"
 #include "scene/main/window.h"
@@ -67,6 +64,12 @@
 #include "scene/resources/theme.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
+
+#ifndef _3D_DISABLED
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "scene/3d/light_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
+#endif // _3D_DISABLED
 
 EditorInterface *EditorInterface::singleton = nullptr;
 
@@ -111,6 +114,7 @@ EditorUndoRedoManager *EditorInterface::get_editor_undo_redo() const {
 	return EditorUndoRedoManager::get_singleton();
 }
 
+#ifndef _3D_DISABLED
 AABB EditorInterface::_calculate_aabb_for_scene(Node *p_node, AABB &p_scene_aabb) {
 	MeshInstance3D *mesh_node = Object::cast_to<MeshInstance3D>(p_node);
 	if (mesh_node && mesh_node->get_mesh().is_valid()) {
@@ -370,6 +374,7 @@ void EditorInterface::make_scene_preview(const String &p_path, Node *p_scene, in
 	EditorResourcePreview::get_singleton()->check_for_invalidation(p_path);
 	EditorFileSystem::get_singleton()->emit_signal(SNAME("filesystem_changed"));
 }
+#endif // _3D_DISABLED
 
 void EditorInterface::add_root_node(Node *p_node) {
 	if (EditorNode::get_singleton()->get_edited_scene()) {
@@ -423,10 +428,12 @@ SubViewport *EditorInterface::get_editor_viewport_2d() const {
 	return EditorNode::get_singleton()->get_scene_root();
 }
 
+#ifndef _3D_DISABLED
 SubViewport *EditorInterface::get_editor_viewport_3d(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, static_cast<int>(Node3DEditor::VIEWPORTS_COUNT), nullptr);
 	return Node3DEditor::get_singleton()->get_editor_viewport(p_idx)->get_viewport_node();
 }
+#endif // _3D_DISABLED
 
 void EditorInterface::set_main_screen_editor(const String &p_name) {
 	EditorNode::get_singleton()->get_editor_main_screen()->select_by_name(p_name);
@@ -452,6 +459,7 @@ String EditorInterface::get_editor_language() const {
 	return EditorSettings::get_singleton()->get_language();
 }
 
+#ifndef _3D_DISABLED
 bool EditorInterface::is_node_3d_snap_enabled() const {
 	return Node3DEditor::get_singleton()->is_snap_enabled();
 }
@@ -467,6 +475,7 @@ real_t EditorInterface::get_node_3d_rotate_snap() const {
 real_t EditorInterface::get_node_3d_scale_snap() const {
 	return Node3DEditor::get_singleton()->get_scale_snap();
 }
+#endif // _3D_DISABLED
 
 void EditorInterface::popup_dialog(Window *p_dialog, const Rect2i &p_screen_rect) {
 	p_dialog->popup_exclusive(EditorNode::get_singleton(), p_screen_rect);
@@ -830,10 +839,12 @@ void EditorInterface::get_argument_options(const StringName &p_function, int p_i
 			for (String E : { "\"2D\"", "\"3D\"", "\"Script\"", "\"Game\"", "\"AssetLib\"" }) {
 				r_options->push_back(E);
 			}
+#ifndef _3D_DISABLED
 		} else if (pf == "get_editor_viewport_3d") {
 			for (uint32_t i = 0; i < Node3DEditor::VIEWPORTS_COUNT; i++) {
 				r_options->push_back(String::num_int64(i));
 			}
+#endif // _3D_DISABLED
 		}
 	}
 	Object::get_argument_options(p_function, p_idx, r_options);
@@ -855,7 +866,9 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_toaster"), &EditorInterface::get_editor_toaster);
 	ClassDB::bind_method(D_METHOD("get_editor_undo_redo"), &EditorInterface::get_editor_undo_redo);
 
+#ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
+#endif // _3D_DISABLED
 
 	ClassDB::bind_method(D_METHOD("set_plugin_enabled", "plugin", "enabled"), &EditorInterface::set_plugin_enabled);
 	ClassDB::bind_method(D_METHOD("is_plugin_enabled", "plugin"), &EditorInterface::is_plugin_enabled);
@@ -867,7 +880,9 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_main_screen"), &EditorInterface::get_editor_main_screen);
 	ClassDB::bind_method(D_METHOD("get_script_editor"), &EditorInterface::get_script_editor);
 	ClassDB::bind_method(D_METHOD("get_editor_viewport_2d"), &EditorInterface::get_editor_viewport_2d);
+#ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_editor_viewport_3d", "idx"), &EditorInterface::get_editor_viewport_3d, DEFVAL(0));
+#endif // _3D_DISABLED
 
 	ClassDB::bind_method(D_METHOD("set_main_screen_editor", "name"), &EditorInterface::set_main_screen_editor);
 	ClassDB::bind_method(D_METHOD("set_distraction_free_mode", "enter"), &EditorInterface::set_distraction_free_mode);
@@ -877,10 +892,12 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_scale"), &EditorInterface::get_editor_scale);
 	ClassDB::bind_method(D_METHOD("get_editor_language"), &EditorInterface::get_editor_language);
 
+#ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("is_node_3d_snap_enabled"), &EditorInterface::is_node_3d_snap_enabled);
 	ClassDB::bind_method(D_METHOD("get_node_3d_translate_snap"), &EditorInterface::get_node_3d_translate_snap);
 	ClassDB::bind_method(D_METHOD("get_node_3d_rotate_snap"), &EditorInterface::get_node_3d_rotate_snap);
 	ClassDB::bind_method(D_METHOD("get_node_3d_scale_snap"), &EditorInterface::get_node_3d_scale_snap);
+#endif // _3D_DISABLED
 
 	ClassDB::bind_method(D_METHOD("popup_dialog", "dialog", "rect"), &EditorInterface::popup_dialog, DEFVAL(Rect2i()));
 	ClassDB::bind_method(D_METHOD("popup_dialog_centered", "dialog", "minsize"), &EditorInterface::popup_dialog_centered, DEFVAL(Size2i()));

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -51,8 +51,6 @@
 #include "editor/inspector/property_selector.h"
 #include "editor/run/editor_run_bar.h"
 #include "editor/scene/2d/scene_paint_2d_editor_plugin.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h"
-#include "editor/scene/3d/node_3d_editor_viewport.h"
 #include "editor/scene/editor_scene_tabs.h"
 #include "editor/scene/scene_tree_editor.h"
 #include "editor/settings/editor_command_palette.h"
@@ -60,8 +58,6 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "main/main.h"
-#include "scene/3d/light_3d.h"
-#include "scene/3d/visual_instance_3d.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/control.h"
 #include "scene/main/window.h"
@@ -70,6 +66,12 @@
 #include "scene/resources/theme.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
+
+#ifndef _3D_DISABLED
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "scene/3d/light_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
+#endif // _3D_DISABLED
 
 EditorInterface *EditorInterface::singleton = nullptr;
 
@@ -122,6 +124,7 @@ ScenePaint2DEditor *EditorInterface::get_scene_paint_2d() const {
 	return ScenePaint2DEditor::get_singleton();
 }
 
+#ifndef _3D_DISABLED
 AABB EditorInterface::_calculate_aabb_for_scene(Node *p_node, AABB &p_scene_aabb) {
 	GeometryInstance3D *geom_node = Object::cast_to<GeometryInstance3D>(p_node);
 	if (geom_node != nullptr) {
@@ -381,6 +384,7 @@ void EditorInterface::make_scene_preview(const String &p_path, Node *p_scene, in
 	EditorResourcePreview::get_singleton()->check_for_invalidation(p_path);
 	EditorFileSystem::get_singleton()->filesystem_changed();
 }
+#endif // _3D_DISABLED
 
 void EditorInterface::add_root_node(Node *p_node) {
 	if (EditorNode::get_singleton()->get_edited_scene()) {
@@ -436,10 +440,12 @@ SubViewport *EditorInterface::get_editor_viewport_2d() const {
 	return EditorNode::get_singleton()->get_scene_root();
 }
 
+#ifndef _3D_DISABLED
 SubViewport *EditorInterface::get_editor_viewport_3d(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, static_cast<int>(Node3DEditor::VIEWPORTS_COUNT), nullptr);
 	return Node3DEditor::get_singleton()->get_editor_viewport(p_idx)->get_viewport_node();
 }
+#endif // _3D_DISABLED
 
 #ifndef DISABLE_DEPRECATED
 void EditorInterface::set_main_screen_editor(const String &p_name) {
@@ -473,6 +479,7 @@ String EditorInterface::get_editor_language() const {
 	return EditorSettings::get_singleton()->get_language();
 }
 
+#ifndef _3D_DISABLED
 bool EditorInterface::is_node_3d_snap_enabled() const {
 	return Node3DEditor::get_singleton()->is_snap_enabled();
 }
@@ -488,6 +495,7 @@ real_t EditorInterface::get_node_3d_rotate_snap() const {
 real_t EditorInterface::get_node_3d_scale_snap() const {
 	return Node3DEditor::get_singleton()->get_scale_snap();
 }
+#endif // _3D_DISABLED
 
 void EditorInterface::popup_dialog(Window *p_dialog, const Rect2i &p_screen_rect) {
 	p_dialog->popup_exclusive(EditorNode::get_singleton(), p_screen_rect);
@@ -854,11 +862,13 @@ void EditorInterface::get_argument_options(const StringName &p_function, int p_i
 			}
 		}
 #endif
+#ifndef _3D_DISABLED
 		if (pf == "get_editor_viewport_3d") {
 			for (uint32_t i = 0; i < Node3DEditor::VIEWPORTS_COUNT; i++) {
 				r_options->push_back(String::num_int64(i));
 			}
 		}
+#endif // _3D_DISABLED
 	}
 	Object::get_argument_options(p_function, p_idx, r_options);
 }
@@ -881,7 +891,9 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_undo_redo"), &EditorInterface::get_editor_undo_redo);
 	ClassDB::bind_method(D_METHOD("get_scene_paint_2d"), &EditorInterface::get_scene_paint_2d);
 
+#ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
+#endif // _3D_DISABLED
 
 	ClassDB::bind_method(D_METHOD("set_plugin_enabled", "plugin", "enabled"), &EditorInterface::set_plugin_enabled);
 	ClassDB::bind_method(D_METHOD("is_plugin_enabled", "plugin"), &EditorInterface::is_plugin_enabled);
@@ -892,7 +904,9 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_base_control"), &EditorInterface::get_base_control);
 	ClassDB::bind_method(D_METHOD("get_script_editor"), &EditorInterface::get_script_editor);
 	ClassDB::bind_method(D_METHOD("get_editor_viewport_2d"), &EditorInterface::get_editor_viewport_2d);
+#ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_editor_viewport_3d", "idx"), &EditorInterface::get_editor_viewport_3d, DEFVAL(0));
+#endif // _3D_DISABLED
 
 #ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("get_editor_main_screen"), &EditorInterface::get_editor_main_screen);
@@ -906,10 +920,12 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_scale"), &EditorInterface::get_editor_scale);
 	ClassDB::bind_method(D_METHOD("get_editor_language"), &EditorInterface::get_editor_language);
 
+#ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("is_node_3d_snap_enabled"), &EditorInterface::is_node_3d_snap_enabled);
 	ClassDB::bind_method(D_METHOD("get_node_3d_translate_snap"), &EditorInterface::get_node_3d_translate_snap);
 	ClassDB::bind_method(D_METHOD("get_node_3d_rotate_snap"), &EditorInterface::get_node_3d_rotate_snap);
 	ClassDB::bind_method(D_METHOD("get_node_3d_scale_snap"), &EditorInterface::get_node_3d_scale_snap);
+#endif // _3D_DISABLED
 
 	ClassDB::bind_method(D_METHOD("popup_dialog", "dialog", "rect"), &EditorInterface::popup_dialog, DEFVAL(Rect2i()));
 	ClassDB::bind_method(D_METHOD("popup_dialog_centered", "dialog", "minsize"), &EditorInterface::popup_dialog_centered, DEFVAL(Size2i()));

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -79,8 +79,10 @@ class EditorInterface : public Object {
 
 	// Editor tools.
 
+#ifndef _3D_DISABLED
 	TypedArray<Texture2D> _make_mesh_previews(const TypedArray<Mesh> &p_meshes, int p_preview_size);
 	AABB _calculate_aabb_for_scene(Node *p_node, AABB &p_scene_aabb);
+#endif // _3D_DISABLED
 
 protected:
 	static void _bind_methods();
@@ -108,9 +110,6 @@ public:
 	EditorToaster *get_editor_toaster() const;
 	EditorUndoRedoManager *get_editor_undo_redo() const;
 
-	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);
-	void make_scene_preview(const String &p_path, Node *p_scene, int p_preview_size);
-
 	void set_plugin_enabled(const String &p_plugin, bool p_enabled);
 	bool is_plugin_enabled(const String &p_plugin) const;
 
@@ -122,7 +121,6 @@ public:
 	VBoxContainer *get_editor_main_screen() const;
 	ScriptEditor *get_script_editor() const;
 	SubViewport *get_editor_viewport_2d() const;
-	SubViewport *get_editor_viewport_3d(int p_idx = 0) const;
 
 	void set_main_screen_editor(const String &p_name);
 	void set_distraction_free_mode(bool p_enter);
@@ -132,10 +130,16 @@ public:
 	float get_editor_scale() const;
 	String get_editor_language() const;
 
+#ifndef _3D_DISABLED
+	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);
+	void make_scene_preview(const String &p_path, Node *p_scene, int p_preview_size);
+	SubViewport *get_editor_viewport_3d(int p_idx = 0) const;
+
 	bool is_node_3d_snap_enabled() const;
 	real_t get_node_3d_translate_snap() const;
 	real_t get_node_3d_rotate_snap() const;
 	real_t get_node_3d_scale_snap() const;
+#endif // _3D_DISABLED
 
 	void popup_dialog(Window *p_dialog, const Rect2i &p_screen_rect = Rect2i());
 	void popup_dialog_centered(Window *p_dialog, const Size2i &p_minsize = Size2i());

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -81,8 +81,10 @@ class EditorInterface : public Object {
 
 	// Editor tools.
 
+#ifndef _3D_DISABLED
 	TypedArray<Texture2D> _make_mesh_previews(const TypedArray<Mesh> &p_meshes, int p_preview_size);
 	AABB _calculate_aabb_for_scene(Node *p_node, AABB &p_scene_aabb);
+#endif // _3D_DISABLED
 
 protected:
 	static void _bind_methods();
@@ -112,9 +114,6 @@ public:
 	EditorUndoRedoManager *get_editor_undo_redo() const;
 	ScenePaint2DEditor *get_scene_paint_2d() const;
 
-	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);
-	void make_scene_preview(const String &p_path, Node *p_scene, int p_preview_size);
-
 	void set_plugin_enabled(const String &p_plugin, bool p_enabled);
 	bool is_plugin_enabled(const String &p_plugin) const;
 
@@ -128,7 +127,6 @@ public:
 #endif
 	ScriptEditor *get_script_editor() const;
 	SubViewport *get_editor_viewport_2d() const;
-	SubViewport *get_editor_viewport_3d(int p_idx = 0) const;
 
 #ifndef DISABLE_DEPRECATED
 	void set_main_screen_editor(const String &p_name);
@@ -141,10 +139,16 @@ public:
 	float get_editor_scale() const;
 	String get_editor_language() const;
 
+#ifndef _3D_DISABLED
+	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);
+	void make_scene_preview(const String &p_path, Node *p_scene, int p_preview_size);
+	SubViewport *get_editor_viewport_3d(int p_idx = 0) const;
+
 	bool is_node_3d_snap_enabled() const;
 	real_t get_node_3d_translate_snap() const;
 	real_t get_node_3d_rotate_snap() const;
 	real_t get_node_3d_scale_snap() const;
+#endif // _3D_DISABLED
 
 	void popup_dialog(Window *p_dialog, const Rect2i &p_screen_rect = Rect2i());
 	void popup_dialog_centered(Window *p_dialog, const Size2i &p_minsize = Size2i());

--- a/editor/editor_main_screen.cpp
+++ b/editor/editor_main_screen.cpp
@@ -43,11 +43,18 @@ void EditorMainScreen::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
 			set_accessibility_region(true);
+#ifndef _3D_DISABLED
 			if (EDITOR_3D < buttons.size() && buttons[EDITOR_3D]->is_visible()) {
 				// If the 3D editor is enabled, use this as the default.
 				select(EDITOR_3D);
 				return;
 			}
+#else
+			if (buttons[EDITOR_2D]->is_visible()) {
+				select(EDITOR_2D);
+				return;
+			}
+#endif // _3D_DISABLED
 
 			// Switch to the first main screen plugin that is enabled. Usually this is
 			// 2D, but may be subsequent ones if 2D is disabled in the feature profile.

--- a/editor/editor_main_screen.cpp
+++ b/editor/editor_main_screen.cpp
@@ -35,7 +35,9 @@
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_node.h"
 #include "editor/plugins/editor_plugin.h"
+#ifndef _3D_DISABLED
 #include "editor/scene/3d/node_3d_editor_plugin.h"
+#endif // _3D_DISABLED
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
@@ -102,10 +104,12 @@ void EditorMainScreen::_notification(int p_what) {
 
 			for (int i = 0; i < get_tab_count(); i++) {
 				EditorDock *dock = get_dock(i);
+#ifndef _3D_DISABLED
 				if (dock == Node3DEditor::get_singleton()) {
 					dock->make_visible();
 					break;
 				}
+#endif // _3D_DISABLED
 			}
 		} break;
 	}

--- a/editor/editor_main_screen.h
+++ b/editor/editor_main_screen.h
@@ -44,7 +44,9 @@ class EditorMainScreen : public PanelContainer {
 public:
 	enum EditorTable {
 		EDITOR_2D = 0,
+#ifndef _3D_DISABLED
 		EDITOR_3D,
+#endif // _3D_DISABLED
 		EDITOR_SCRIPT,
 		EDITOR_GAME,
 		EDITOR_ASSETLIB,

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -88,10 +88,6 @@
 #include "editor/gui/editor_toaster.h"
 #include "editor/gui/progress_dialog.h"
 #include "editor/gui/window_wrapper.h"
-#include "editor/import/3d/editor_import_collada.h"
-#include "editor/import/3d/resource_importer_obj.h"
-#include "editor/import/3d/resource_importer_scene.h"
-#include "editor/import/3d/scene_import_settings.h"
 #include "editor/import/audio_stream_import_settings.h"
 #include "editor/import/dynamic_font_import_settings.h"
 #include "editor/import/fbx_importer_manager.h"
@@ -123,10 +119,6 @@
 #include "editor/run/editor_run.h"
 #include "editor/run/editor_run_bar.h"
 #include "editor/run/game_view_plugin.h"
-#include "editor/scene/3d/material_3d_conversion_plugins.h"
-#include "editor/scene/3d/mesh_library_editor_plugin.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h"
-#include "editor/scene/3d/root_motion_editor_plugin.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/scene/editor_scene_tabs.h"
 #include "editor/scene/material_editor_plugin.h"
@@ -151,7 +143,6 @@
 #include "editor/version_control/version_control_editor_plugin.h"
 #include "main/main.h"
 #include "scene/2d/node_2d.h"
-#include "scene/3d/bone_attachment_3d.h"
 #include "scene/animation/animation_tree.h"
 #include "scene/gui/color_picker.h"
 #include "scene/gui/dialogs.h"
@@ -176,8 +167,10 @@
 #include "servers/audio/audio_server.h"
 #include "servers/display/display_server.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
-#include "servers/navigation_3d/navigation_server_3d.h"
 #include "servers/rendering/rendering_server.h"
+#ifndef NAVIGATION_3D_DISABLED
+#include "servers/navigation_3d/navigation_server_3d.h"
+#endif // NAVIGATION_3D_DISABLED
 
 #ifdef VULKAN_ENABLED
 #include "editor/shader/shader_baker/shader_baker_export_plugin_platform_vulkan.h"
@@ -204,6 +197,18 @@
 #endif // ANDROID_ENABLED
 
 #include "modules/modules_enabled.gen.h" // For gdscript, mono.
+
+#ifndef _3D_DISABLED
+#include "editor/import/3d/editor_import_collada.h"
+#include "editor/import/3d/resource_importer_obj.h"
+#include "editor/import/3d/resource_importer_scene.h"
+#include "editor/import/3d/scene_import_settings.h"
+#include "editor/scene/3d/material_3d_conversion_plugins.h"
+#include "editor/scene/3d/mesh_library_editor_plugin.h"
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "editor/scene/3d/root_motion_editor_plugin.h"
+#include "scene/3d/bone_attachment_3d.h"
+#endif // _3D_DISABLED
 
 #include <cstdlib>
 
@@ -414,8 +419,10 @@ void EditorNode::shortcut_input(const Ref<InputEvent> &p_event) {
 			FileSystemDock::get_singleton()->focus_on_filter();
 		} else if (ED_IS_SHORTCUT("editor/editor_2d", p_event)) {
 			editor_main_screen->select(EditorMainScreen::EDITOR_2D);
+#ifndef _3D_DISABLED
 		} else if (ED_IS_SHORTCUT("editor/editor_3d", p_event)) {
 			editor_main_screen->select(EditorMainScreen::EDITOR_3D);
+#endif // _3D_DISABLED
 		} else if (ED_IS_SHORTCUT("editor/editor_script", p_event)) {
 			editor_main_screen->select(EditorMainScreen::EDITOR_SCRIPT);
 		} else if (ED_IS_SHORTCUT("editor/editor_game", p_event)) {
@@ -441,10 +448,14 @@ void EditorNode::shortcut_input(const Ref<InputEvent> &p_event) {
 				Node *node_with_visibility;
 				node_with_visibility = Object::cast_to<CanvasItem>(E);
 				if (!node_with_visibility || !node_with_visibility->is_inside_tree()) {
+#ifndef _3D_DISABLED
 					node_with_visibility = Object::cast_to<Node3D>(E);
 					if (!node_with_visibility || !node_with_visibility->is_inside_tree()) {
+#endif // _3D_DISABLED
 						continue;
+#ifndef _3D_DISABLED
 					}
+#endif // _3D_DISABLED
 				}
 
 				undo_redo->add_do_method(node_with_visibility, "set_visible", !node_with_visibility->get("visible"));
@@ -607,6 +618,7 @@ void EditorNode::_update_from_settings() {
 	NavigationServer2D::get_singleton()->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/2d/enable_edge_lines"));
 	NavigationServer2D::get_singleton()->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/2d/enable_geometry_face_random_color"));
 
+#ifndef NAVIGATION_3D_DISABLED
 	NavigationServer3D::get_singleton()->set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/3d/edge_connection_color"));
 	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_edge_color"));
 	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_face_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_face_color"));
@@ -617,6 +629,7 @@ void EditorNode::_update_from_settings() {
 	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines"));
 	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines_xray(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines_xray"));
 	NavigationServer3D::get_singleton()->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/3d/enable_geometry_face_random_color"));
+#endif // NAVIGATION_3D_DISABLED
 #endif // DEBUG_ENABLED
 }
 
@@ -936,7 +949,9 @@ void EditorNode::_notification(int p_what) {
 			_update_theme(true);
 
 			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(int(EDITOR_GET("interface/editor/timers/low_processor_mode_sleep_usec")));
+#ifndef _3D_DISABLED
 			get_tree()->get_root()->set_as_audio_listener_3d(false);
+#endif // _3D_DISABLED
 			get_tree()->get_root()->set_as_audio_listener_2d(false);
 			get_tree()->get_root()->set_snap_2d_transforms_to_pixel(false);
 			get_tree()->get_root()->set_snap_2d_vertices_to_pixel(false);
@@ -1004,9 +1019,10 @@ void EditorNode::_notification(int p_what) {
 			}
 			default_layout->set_value("docks", "dock_9", String(",").join(bottom_docks));
 
+#ifndef _3D_DISABLED
 			RenderingServer::get_singleton()->viewport_set_disable_2d(get_scene_root()->get_viewport_rid(), true);
+#endif // _3D_DISABLED
 			RenderingServer::get_singleton()->viewport_set_environment_mode(get_viewport()->get_viewport_rid(), RSE::VIEWPORT_ENVIRONMENT_DISABLED);
-			DisplayServer::get_singleton()->screen_set_keep_on(EDITOR_GET("interface/editor/display/keep_screen_on"));
 
 			feature_profile_manager->notify_changed();
 
@@ -2246,8 +2262,10 @@ void EditorNode::_find_node_types(Node *p_node, int &count_2d, int &count_3d) {
 
 	if (p_node->is_class("CanvasItem")) {
 		count_2d++;
+#ifndef _3D_DISABLED
 	} else if (p_node->is_class("Node3D")) {
 		count_3d++;
+#endif // _3D_DISABLED
 	}
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
@@ -2281,6 +2299,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			if (viewport_texture->get_width() > 0 && viewport_texture->get_height() > 0) {
 				img = viewport_texture->get_image();
 			}
+#ifndef _3D_DISABLED
 		} else {
 			// The 3D editor may be disabled as a feature, but scenes can still be opened.
 			// This check prevents the preview from regenerating in case those scenes are then saved.
@@ -2289,6 +2308,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			if (profile.is_null() || !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D)) {
 				img = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_image();
 			}
+#endif // _3D_DISABLED
 		}
 
 		if (img.is_valid() && img->get_width() > 0 && img->get_height() > 0) {
@@ -2484,7 +2504,9 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	scene->propagate_notification(NOTIFICATION_EDITOR_PRE_SAVE);
 
 	editor_data.apply_changes_in_editors();
+#ifndef _3D_DISABLED
 	save_default_environment();
+#endif // _3D_DISABLED
 	List<Pair<AnimationMixer *, Ref<AnimatedValuesBackup>>> anim_backups;
 	_reset_animation_mixers(scene, &anim_backups);
 	_save_editor_states(p_file, idx);
@@ -2632,7 +2654,9 @@ void EditorNode::_save_all_scenes() {
 			_save_scene(scene_path, i);
 		}
 	}
+#ifndef _3D_DISABLED
 	save_default_environment();
+#endif // _3D_DISABLED
 
 	if (!scenes_to_save_as.is_empty()) {
 		_proceed_save_asing_scene_tabs();
@@ -2728,7 +2752,9 @@ void EditorNode::_dialog_action(String p_file) {
 					return;
 				}
 
+#ifndef _3D_DISABLED
 				save_default_environment();
+#endif // _3D_DISABLED
 				_save_scene_with_preview(p_file, scene_idx);
 				_add_to_recent_scenes(p_file);
 				save_editor_layout_delayed();
@@ -2752,7 +2778,9 @@ void EditorNode::_dialog_action(String p_file) {
 
 		case SAVE_AND_RUN: {
 			if (file->get_file_mode() == EditorFileDialog::FILE_MODE_SAVE_FILE) {
+#ifndef _3D_DISABLED
 				save_default_environment();
+#endif // _3D_DISABLED
 				_save_scene_with_preview(p_file);
 				project_run_bar->play_custom_scene(p_file);
 			}
@@ -2763,12 +2791,15 @@ void EditorNode::_dialog_action(String p_file) {
 			ProjectSettings::get_singleton()->save();
 
 			if (file->get_file_mode() == EditorFileDialog::FILE_MODE_SAVE_FILE) {
+#ifndef _3D_DISABLED
 				save_default_environment();
+#endif // _3D_DISABLED
 				_save_scene_with_preview(p_file);
 				project_run_bar->play_main_scene((bool)pick_main_scene->get_meta("from_native", false));
 			}
 		} break;
 
+#ifndef _3D_DISABLED
 		case FILE_EXPORT_MESH_LIBRARY: {
 			const Dictionary &fd_options = file_export_lib->get_selected_options();
 			bool merge_with_existing_library = fd_options.get(TTR("Merge With Existing"), true);
@@ -2800,6 +2831,7 @@ void EditorNode::_dialog_action(String p_file) {
 			}
 
 		} break;
+#endif // _3D_DISABLED
 
 		case PROJECT_PACK_AS_ZIP: {
 			ProjectZIPPacker::pack_project_zip(p_file);
@@ -3036,6 +3068,7 @@ void EditorNode::push_item_no_inspector(Object *p_object) {
 	_edit_current(false, true);
 }
 
+#ifndef _3D_DISABLED
 void EditorNode::save_default_environment() {
 	Ref<Environment> fallback = get_tree()->get_root()->get_world_3d()->get_fallback_environment();
 
@@ -3045,6 +3078,7 @@ void EditorNode::save_default_environment() {
 		save_resource_in_path(fallback, fallback->get_path());
 	}
 }
+#endif // _3D_DISABLED
 
 void EditorNode::hide_unused_editors(const Object *p_editing_owner) {
 	if (p_editing_owner) {
@@ -4114,6 +4148,7 @@ void EditorNode::_tool_menu_option(int p_idx) {
 }
 
 void EditorNode::_export_as_menu_option(int p_idx) {
+#ifndef _3D_DISABLED
 	if (p_idx == 0) { // MeshLibrary
 		current_menu_option = FILE_EXPORT_MESH_LIBRARY;
 
@@ -4133,6 +4168,7 @@ void EditorNode::_export_as_menu_option(int p_idx) {
 		file_export_lib->set_title(TTR("Export Mesh Library"));
 		file_export_lib->popup_file_dialog();
 	} else { // Custom menu options added by plugins
+#endif // _3D_DISABLED
 		if (export_as_menu->get_item_submenu(p_idx).is_empty()) { // If not a submenu
 			Callable callback = export_as_menu->get_item_metadata(p_idx);
 			Callable::CallError ce;
@@ -4144,7 +4180,9 @@ void EditorNode::_export_as_menu_option(int p_idx) {
 				ERR_PRINT("Error calling function from export_as menu: " + err);
 			}
 		}
+#ifndef _3D_DISABLED
 	}
+#endif // _3D_DISABLED
 }
 
 int EditorNode::_next_unsaved_scene(bool p_valid_filename, int p_start) {
@@ -5218,10 +5256,12 @@ void EditorNode::get_preload_scene_modification_table(
 				if (node_2d) {
 					new_additive_node_entry.transform_2d = node_2d->get_transform();
 				}
+#ifndef _3D_DISABLED
 				Node3D *node_3d = Object::cast_to<Node3D>(p_node);
 				if (node_3d) {
 					new_additive_node_entry.transform_3d = node_3d->get_transform();
 				}
+#endif // _3D_DISABLED
 
 				p_instance_modifications.addition_list.push_back(new_additive_node_entry);
 			}
@@ -7087,6 +7127,7 @@ void EditorNode::_file_access_close_error_notify_impl(const String &p_str) {
 // tree so that editor scripts which create transient nodes will have the opportunity
 // to recreate them.
 void EditorNode::_notify_nodes_scene_reimported(Node *p_node, Array p_reimported_nodes) {
+#ifndef _3D_DISABLED
 	Skeleton3D *skel_3d = Object::cast_to<Skeleton3D>(p_node);
 	if (skel_3d) {
 		skel_3d->reset_bone_poses();
@@ -7096,6 +7137,7 @@ void EditorNode::_notify_nodes_scene_reimported(Node *p_node, Array p_reimported
 			attachment->notify_rebind_required();
 		}
 	}
+#endif // _3D_DISABLED
 
 	if (p_node->has_method("_nodes_scene_reimported")) {
 		p_node->call("_nodes_scene_reimported", p_reimported_nodes);
@@ -7535,10 +7577,12 @@ void EditorNode::reload_instances_with_path_in_edited_scenes() {
 						node_2d->set_transform(additive_node_entry.transform_2d);
 					}
 
+#ifndef _3D_DISABLED
 					Node3D *node_3d = Object::cast_to<Node3D>(additive_node_entry.node);
 					if (node_3d) {
 						node_3d->set_transform(additive_node_entry.transform_3d);
 					}
+#endif // _3D_DISABLED
 				}
 			}
 
@@ -7850,7 +7894,9 @@ void EditorNode::_feature_profile_changed() {
 		editor_dock_manager->set_dock_enabled(ImportDock::get_singleton(), !fs_dock_disabled && !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_IMPORT_DOCK));
 		editor_dock_manager->set_dock_enabled(history_dock, !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_HISTORY_DOCK));
 
+#ifndef _3D_DISABLED
 		editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_3D, !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D));
+#endif // _3D_DISABLED
 		editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_SCRIPT, !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_SCRIPT));
 		if (!Engine::get_singleton()->is_recovery_mode_hint()) {
 			editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_GAME, !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_GAME));
@@ -7864,7 +7910,9 @@ void EditorNode::_feature_profile_changed() {
 		editor_dock_manager->set_dock_enabled(GroupsDock::get_singleton(), true);
 		editor_dock_manager->set_dock_enabled(FileSystemDock::get_singleton(), true);
 		editor_dock_manager->set_dock_enabled(history_dock, true);
+#ifndef _3D_DISABLED
 		editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_3D, true);
+#endif // _3D_DISABLED
 		editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_SCRIPT, true);
 		if (!Engine::get_singleton()->is_recovery_mode_hint()) {
 			editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_GAME, true);
@@ -8019,7 +8067,9 @@ void EditorNode::_build_file_menu() {
 
 	if (!export_as_menu) {
 		export_as_menu = memnew(PopupMenu);
+#ifndef _3D_DISABLED
 		export_as_menu->add_shortcut(ED_GET_SHORTCUT("editor/export_as_mesh_library"), FILE_EXPORT_MESH_LIBRARY);
+#endif // _3D_DISABLED
 		export_as_menu->connect("index_pressed", callable_mp(this, &EditorNode::_export_as_menu_option));
 	}
 	file_menu->add_submenu_node_item(TTRC("Export As..."), export_as_menu, SCENE_EXPORT_AS);
@@ -8361,12 +8411,14 @@ EditorNode::EditorNode() {
 
 		AudioServer::get_singleton()->set_enable_tagging_used_audio_streams(true);
 
+#ifndef NAVIGATION_3D_DISABLED
 		// No navigation by default if in editor.
 		if (NavigationServer3D::get_singleton()->get_debug_enabled()) {
 			NavigationServer3D::get_singleton()->set_active(true);
 		} else {
 			NavigationServer3D::get_singleton()->set_active(false);
 		}
+#endif // NAVIGATION_3D_DISABLED
 
 		// No physics by default if in editor.
 #ifndef PHYSICS_3D_DISABLED
@@ -8554,14 +8606,17 @@ EditorNode::EditorNode() {
 		import_wav.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(import_wav);
 
+#ifndef _3D_DISABLED
 		Ref<ResourceImporterOBJ> import_obj;
 		import_obj.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(import_obj);
+#endif // _3D_DISABLED
 
 		Ref<ResourceImporterShaderFile> import_shader_file;
 		import_shader_file.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(import_shader_file);
 
+#ifndef _3D_DISABLED
 		Ref<ResourceImporterScene> import_model_as_scene;
 		import_model_as_scene.instantiate("PackedScene");
 		ResourceFormatImporter::get_singleton()->add_importer(import_model_as_scene);
@@ -8588,7 +8643,12 @@ EditorNode::EditorNode() {
 			Ref<EditorSceneFormatImporterESCN> import_escn;
 			import_escn.instantiate();
 			ResourceImporterScene::add_scene_importer(import_escn);
+
+			Ref<EditorInspectorRootMotionPlugin> rmp;
+			rmp.instantiate();
+			EditorInspector::add_inspector_plugin(rmp);
 		}
+#endif // _3D_DISABLED
 
 		Ref<ResourceImporterBitMap> import_bitmap;
 		import_bitmap.instantiate();
@@ -8599,10 +8659,6 @@ EditorNode::EditorNode() {
 		Ref<EditorInspectorDefaultPlugin> eidp;
 		eidp.instantiate();
 		EditorInspector::add_inspector_plugin(eidp);
-
-		Ref<EditorInspectorRootMotionPlugin> rmp;
-		rmp.instantiate();
-		EditorInspector::add_inspector_plugin(rmp);
 
 		Ref<EditorInspectorParticleProcessMaterialPlugin> ppm;
 		ppm.instantiate();
@@ -8858,7 +8914,9 @@ EditorNode::EditorNode() {
 	scene_root->set_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
 	scene_root->set_translation_domain(StringName());
 	scene_root->set_embedding_subwindows(true);
+#ifndef _3D_DISABLED
 	scene_root->set_disable_3d(true);
+#endif // _3D_DISABLED
 	scene_root->set_disable_input(true);
 	scene_root->set_as_audio_listener_2d(true);
 
@@ -8884,8 +8942,10 @@ EditorNode::EditorNode() {
 	project_settings_editor = memnew(ProjectSettingsEditor(&editor_data));
 	gui_base->add_child(project_settings_editor);
 
+#ifndef _3D_DISABLED
 	scene_import_settings = memnew(SceneImportSettingsDialog);
 	gui_base->add_child(scene_import_settings);
+#endif // _3D_DISABLED
 
 	audio_stream_import_settings = memnew(AudioStreamImportSettingsDialog);
 	gui_base->add_child(audio_stream_import_settings);
@@ -8939,7 +8999,9 @@ EditorNode::EditorNode() {
 	ED_SHORTCUT_AND_COMMAND("editor/quick_open_scene", TTRC("Quick Open Scene..."), KeyModifierMask::CMD_OR_CTRL + KeyModifierMask::SHIFT + Key::O);
 	ED_SHORTCUT_AND_COMMAND("editor/quick_open_script", TTRC("Quick Open Script..."), KeyModifierMask::CMD_OR_CTRL + KeyModifierMask::ALT + Key::O);
 
+#ifndef _3D_DISABLED
 	ED_SHORTCUT("editor/export_as_mesh_library", TTRC("MeshLibrary..."));
+#endif // _3D_DISABLED
 
 	ED_SHORTCUT_AND_COMMAND("editor/reload_saved_scene", TTRC("Reload Saved Scene"));
 	ED_SHORTCUT_AND_COMMAND("editor/close_scene", TTRC("Close Scene"), KeyModifierMask::CMD_OR_CTRL + KeyModifierMask::SHIFT + Key::W);
@@ -9379,7 +9441,9 @@ EditorNode::EditorNode() {
 	gui_base->add_child(project_data_missing);
 
 	add_editor_plugin(memnew(CanvasItemEditorPlugin));
+#ifndef _3D_DISABLED
 	add_editor_plugin(memnew(Node3DEditorPlugin));
+#endif // _3D_DISABLED
 	add_editor_plugin(memnew(ScriptEditorPlugin));
 
 	if (!Engine::get_singleton()->is_recovery_mode_hint()) {
@@ -9433,6 +9497,7 @@ EditorNode::EditorNode() {
 	resource_preview->add_preview_generator(Ref<EditorGradientPreviewPlugin>(memnew(EditorGradientPreviewPlugin)));
 
 	{
+#ifndef _3D_DISABLED
 		Ref<StandardMaterial3DConversionPlugin> spatial_mat_convert;
 		spatial_mat_convert.instantiate();
 		resource_conversion_plugins.push_back(spatial_mat_convert);
@@ -9440,6 +9505,7 @@ EditorNode::EditorNode() {
 		Ref<ORMMaterial3DConversionPlugin> orm_mat_convert;
 		orm_mat_convert.instantiate();
 		resource_conversion_plugins.push_back(orm_mat_convert);
+#endif // _3D_DISABLED
 
 		Ref<CanvasItemMaterialConversionPlugin> canvas_item_mat_convert;
 		canvas_item_mat_convert.instantiate();
@@ -9453,6 +9519,7 @@ EditorNode::EditorNode() {
 		particles_mat_convert.instantiate();
 		resource_conversion_plugins.push_back(particles_mat_convert);
 
+#ifndef _3D_DISABLED
 		Ref<ProceduralSkyMaterialConversionPlugin> procedural_sky_mat_convert;
 		procedural_sky_mat_convert.instantiate();
 		resource_conversion_plugins.push_back(procedural_sky_mat_convert);
@@ -9468,6 +9535,7 @@ EditorNode::EditorNode() {
 		Ref<FogMaterialConversionPlugin> fog_mat_convert;
 		fog_mat_convert.instantiate();
 		resource_conversion_plugins.push_back(fog_mat_convert);
+#endif // _3D_DISABLED
 	}
 
 	update_spinner_step_msec = OS::get_singleton()->get_ticks_msec();
@@ -9590,8 +9658,10 @@ EditorNode::EditorNode() {
 	ResourceSaver::set_save_callback(_resource_saved);
 	ResourceLoader::set_load_callback(_resource_loaded);
 
+#ifndef _3D_DISABLED
 	// Apply setting presets in case the editor_settings file is missing values.
 	EditorSettingsDialog::update_navigation_preset();
+#endif // _3D_DISABLED
 
 	screenshot_timer = memnew(Timer);
 	screenshot_timer->set_one_shot(true);
@@ -9623,7 +9693,9 @@ EditorNode::EditorNode() {
 EditorNode::~EditorNode() {
 	EditorInspector::cleanup_plugins();
 	EditorTranslationParser::get_singleton()->clean_parsers();
+#ifndef _3D_DISABLED
 	ResourceImporterScene::clean_up_importer_plugins();
+#endif // _3D_DISABLED
 	EditorContextMenuPluginManager::cleanup();
 
 	remove_print_handler(&print_handler);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -90,10 +90,12 @@
 #include "editor/gui/editor_toaster.h"
 #include "editor/gui/progress_dialog.h"
 #include "editor/gui/window_wrapper.h"
+#ifndef _3D_DISABLED
 #include "editor/import/3d/editor_import_collada.h"
 #include "editor/import/3d/resource_importer_obj.h"
 #include "editor/import/3d/resource_importer_scene.h"
 #include "editor/import/3d/scene_import_settings.h"
+#endif // _3D_DISABLED
 #include "editor/import/audio_stream_import_settings.h"
 #include "editor/import/dynamic_font_import_settings.h"
 #include "editor/import/fbx_importer_manager.h"
@@ -126,11 +128,13 @@
 #include "editor/run/editor_run.h"
 #include "editor/run/editor_run_bar.h"
 #include "editor/run/game_view_plugin.h"
+#ifndef _3D_DISABLED
 #include "editor/scene/3d/material_3d_conversion_plugins.h"
 #include "editor/scene/3d/mesh_library_editor_plugin.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/scene/3d/node_3d_editor_viewport.h"
 #include "editor/scene/3d/root_motion_editor_plugin.h"
+#endif // _3D_DISABLED
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/scene/editor_scene_tabs.h"
 #include "editor/scene/material_editor_plugin.h"
@@ -156,7 +160,9 @@
 #include "editor/version_control/version_control_editor_plugin.h"
 #include "main/main.h"
 #include "scene/2d/node_2d.h"
+#ifndef _3D_DISABLED
 #include "scene/3d/bone_attachment_3d.h"
+#endif // _3D_DISABLED
 #include "scene/animation/animation_tree.h"
 #include "scene/gui/color_picker.h"
 #include "scene/gui/control.h"
@@ -173,7 +179,9 @@
 #include "scene/main/timer.h"
 #include "scene/main/window.h"
 #include "scene/property_utils.h"
+#ifndef _3D_DISABLED
 #include "scene/resources/3d/mesh_library.h"
+#endif // _3D_DISABLED
 #include "scene/resources/dpi_texture.h"
 #include "scene/resources/image_texture.h"
 #include "scene/resources/packed_scene.h"
@@ -184,8 +192,12 @@
 #include "servers/display/display_server.h"
 #include "servers/display/display_server_enums.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
+#ifndef NAVIGATION_3D_DISABLED
 #include "servers/navigation_3d/navigation_server_3d.h"
+#endif // NAVIGATION_3D_DISABLED
+#ifndef PHYSICS_3D_DISABLED
 #include "servers/physics_3d/physics_server_3d_manager.h"
+#endif // PHYSICS_3D_DISABLED
 #include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server.h"
 
@@ -448,10 +460,14 @@ void EditorNode::shortcut_input(const Ref<InputEvent> &p_event) {
 				Node *node_with_visibility;
 				node_with_visibility = Object::cast_to<CanvasItem>(E);
 				if (!node_with_visibility || !node_with_visibility->is_inside_tree()) {
+#ifndef _3D_DISABLED
 					node_with_visibility = Object::cast_to<Node3D>(E);
 					if (!node_with_visibility || !node_with_visibility->is_inside_tree()) {
+#endif // _3D_DISABLED
 						continue;
+#ifndef _3D_DISABLED
 					}
+#endif // _3D_DISABLED
 				}
 
 				undo_redo->add_do_method(node_with_visibility, "set_visible", !node_with_visibility->get("visible"));
@@ -615,6 +631,7 @@ void EditorNode::_update_from_settings() {
 	NavigationServer2D::get_singleton()->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/2d/enable_edge_lines"));
 	NavigationServer2D::get_singleton()->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/2d/enable_geometry_face_random_color"));
 
+#ifndef NAVIGATION_3D_DISABLED
 	NavigationServer3D::get_singleton()->set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/3d/edge_connection_color"));
 	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_edge_color"));
 	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_face_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_face_color"));
@@ -625,6 +642,7 @@ void EditorNode::_update_from_settings() {
 	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines"));
 	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines_xray(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines_xray"));
 	NavigationServer3D::get_singleton()->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/3d/enable_geometry_face_random_color"));
+#endif // NAVIGATION_3D_DISABLED
 #endif // DEBUG_ENABLED
 }
 
@@ -985,7 +1003,9 @@ void EditorNode::_notification(int p_what) {
 			_update_theme(true);
 
 			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(int(EDITOR_GET("interface/editor/timers/low_processor_mode_sleep_usec")));
+#ifndef _3D_DISABLED
 			get_tree()->get_root()->set_as_audio_listener_3d(false);
+#endif // _3D_DISABLED
 			get_tree()->get_root()->set_as_audio_listener_2d(false);
 			get_tree()->get_root()->set_snap_2d_transforms_to_pixel(false);
 			get_tree()->get_root()->set_snap_2d_vertices_to_pixel(false);
@@ -1050,7 +1070,9 @@ void EditorNode::_notification(int p_what) {
 			}
 			default_layout->set_value("docks", "dock_9", String(",").join(bottom_docks));
 
+#ifndef _3D_DISABLED
 			RenderingServer::get_singleton()->viewport_set_disable_2d(get_scene_root()->get_viewport_rid(), true);
+#endif // _3D_DISABLED
 			RenderingServer::get_singleton()->viewport_set_environment_mode(get_viewport()->get_viewport_rid(), RSE::VIEWPORT_ENVIRONMENT_DISABLED);
 			DisplayServer::get_singleton()->screen_set_keep_on(EDITOR_GET("interface/editor/display/keep_screen_on"));
 
@@ -2289,8 +2311,10 @@ void EditorNode::_find_node_types(Node *p_node, int &count_2d, int &count_3d) {
 
 	if (p_node->is_class("CanvasItem")) {
 		count_2d++;
+#ifndef _3D_DISABLED
 	} else if (p_node->is_class("Node3D")) {
 		count_3d++;
+#endif // _3D_DISABLED
 	}
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
@@ -2324,6 +2348,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			if (viewport_texture->get_width() > 0 && viewport_texture->get_height() > 0) {
 				img = viewport_texture->get_image();
 			}
+#ifndef _3D_DISABLED
 		} else {
 			// The 3D editor may be disabled as a feature, but scenes can still be opened.
 			// This check prevents the preview from regenerating in case those scenes are then saved.
@@ -2332,6 +2357,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			if (profile.is_null() || !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D)) {
 				img = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_image();
 			}
+#endif // _3D_DISABLED
 		}
 
 		if (img.is_valid() && img->get_width() > 0 && img->get_height() > 0) {
@@ -2527,7 +2553,9 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	scene->propagate_notification(NOTIFICATION_EDITOR_PRE_SAVE);
 
 	editor_data.apply_changes_in_editors();
+#ifndef _3D_DISABLED
 	save_default_environment();
+#endif // _3D_DISABLED
 	List<Pair<AnimationMixer *, Ref<AnimatedValuesBackup>>> anim_backups;
 	_reset_animation_mixers(scene, &anim_backups);
 	_save_editor_states(p_file, idx);
@@ -2675,7 +2703,9 @@ void EditorNode::_save_all_scenes() {
 			_save_scene(scene_path, i);
 		}
 	}
+#ifndef _3D_DISABLED
 	save_default_environment();
+#endif // _3D_DISABLED
 
 	if (!scenes_to_save_as.is_empty()) {
 		_proceed_save_asing_scene_tabs();
@@ -2771,7 +2801,9 @@ void EditorNode::_dialog_action(String p_file) {
 					return;
 				}
 
+#ifndef _3D_DISABLED
 				save_default_environment();
+#endif // _3D_DISABLED
 				_save_scene_with_preview(p_file, scene_idx);
 				_add_to_recent_scenes(p_file);
 				save_editor_layout_delayed();
@@ -2795,7 +2827,9 @@ void EditorNode::_dialog_action(String p_file) {
 
 		case SAVE_AND_RUN: {
 			if (file->get_file_mode() == EditorFileDialog::FILE_MODE_SAVE_FILE) {
+#ifndef _3D_DISABLED
 				save_default_environment();
+#endif // _3D_DISABLED
 				_save_scene_with_preview(p_file);
 				project_run_bar->play_custom_scene(p_file);
 			}
@@ -2806,12 +2840,15 @@ void EditorNode::_dialog_action(String p_file) {
 			ProjectSettings::get_singleton()->save();
 
 			if (file->get_file_mode() == EditorFileDialog::FILE_MODE_SAVE_FILE) {
+#ifndef _3D_DISABLED
 				save_default_environment();
+#endif // _3D_DISABLED
 				_save_scene_with_preview(p_file);
 				project_run_bar->play_main_scene((bool)pick_main_scene->get_meta("from_native", false));
 			}
 		} break;
 
+#ifndef _3D_DISABLED
 		case FILE_EXPORT_MESH_LIBRARY: {
 			const Dictionary &fd_options = file_export_lib->get_selected_options();
 			bool merge_with_existing_library = fd_options.get(TTR("Merge With Existing"), true);
@@ -2843,6 +2880,7 @@ void EditorNode::_dialog_action(String p_file) {
 			}
 
 		} break;
+#endif // _3D_DISABLED
 
 		case PROJECT_PACK_AS_ZIP: {
 			ProjectZIPPacker::pack_project_zip(p_file);
@@ -3087,6 +3125,7 @@ void EditorNode::push_item_no_inspector(Object *p_object) {
 	_edit_current(false, true);
 }
 
+#ifndef _3D_DISABLED
 void EditorNode::save_default_environment() {
 	Ref<Environment> fallback = get_tree()->get_root()->get_world_3d()->get_fallback_environment();
 
@@ -3096,6 +3135,7 @@ void EditorNode::save_default_environment() {
 		save_resource_in_path(fallback, fallback->get_path());
 	}
 }
+#endif // _3D_DISABLED
 
 void EditorNode::hide_unused_editors(const Object *p_editing_owner) {
 	if (p_editing_owner) {
@@ -4188,6 +4228,7 @@ void EditorNode::_tool_menu_option(int p_idx) {
 }
 
 void EditorNode::_export_as_menu_option(int p_idx) {
+#ifndef _3D_DISABLED
 	if (p_idx == 0) { // MeshLibrary
 		current_menu_option = FILE_EXPORT_MESH_LIBRARY;
 
@@ -4207,6 +4248,7 @@ void EditorNode::_export_as_menu_option(int p_idx) {
 		file_export_lib->set_title(TTR("Export Mesh Library"));
 		file_export_lib->popup_file_dialog();
 	} else { // Custom menu options added by plugins
+#endif // _3D_DISABLED
 		if (export_as_menu->get_item_submenu(p_idx).is_empty()) { // If not a submenu
 			Callable callback = export_as_menu->get_item_metadata(p_idx);
 			Callable::CallError ce;
@@ -4218,7 +4260,9 @@ void EditorNode::_export_as_menu_option(int p_idx) {
 				ERR_PRINT("Error calling function from export_as menu: " + err);
 			}
 		}
+#ifndef _3D_DISABLED
 	}
+#endif // _3D_DISABLED
 }
 
 int EditorNode::_next_unsaved_scene(bool p_valid_filename, int p_start) {
@@ -5314,10 +5358,12 @@ void EditorNode::get_preload_scene_modification_table(
 				if (canvas_item) {
 					new_additive_node_entry.transform_2d = canvas_item->get_transform();
 				}
+#ifndef _3D_DISABLED
 				Node3D *node_3d = Object::cast_to<Node3D>(p_node);
 				if (node_3d) {
 					new_additive_node_entry.transform_3d = node_3d->get_transform();
 				}
+#endif // _3D_DISABLED
 
 				p_instance_modifications.addition_list.push_back(new_additive_node_entry);
 			}
@@ -7191,6 +7237,7 @@ void EditorNode::_file_access_close_error_notify_impl(const String &p_str) {
 // tree so that editor scripts which create transient nodes will have the opportunity
 // to recreate them.
 void EditorNode::_notify_nodes_scene_reimported(Node *p_node, Array p_reimported_nodes) {
+#ifndef _3D_DISABLED
 	Skeleton3D *skel_3d = Object::cast_to<Skeleton3D>(p_node);
 	if (skel_3d) {
 		skel_3d->reset_bone_poses();
@@ -7200,6 +7247,7 @@ void EditorNode::_notify_nodes_scene_reimported(Node *p_node, Array p_reimported
 			attachment->notify_rebind_required();
 		}
 	}
+#endif // _3D_DISABLED
 
 	p_node->call(SNAME("_nodes_scene_reimported"), p_reimported_nodes);
 
@@ -7628,10 +7676,12 @@ void EditorNode::reload_instances_with_path_in_edited_scenes() {
 						node_2d->set_transform(additive_node_entry.transform_2d);
 					}
 
+#ifndef _3D_DISABLED
 					Node3D *node_3d = Object::cast_to<Node3D>(additive_node_entry.node);
 					if (node_3d) {
 						node_3d->set_transform(additive_node_entry.transform_3d);
 					}
+#endif // _3D_DISABLED
 				}
 			}
 
@@ -7943,7 +7993,9 @@ void EditorNode::_feature_profile_changed() {
 		editor_dock_manager->set_dock_enabled(ImportDock::get_singleton(), !fs_dock_disabled && !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_IMPORT_DOCK));
 		editor_dock_manager->set_dock_enabled(history_dock, !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_HISTORY_DOCK));
 
+#ifndef _3D_DISABLED
 		editor_dock_manager->set_dock_enabled(Node3DEditor::get_singleton(), !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D));
+#endif // _3D_DISABLED
 		editor_dock_manager->set_dock_enabled(ScriptEditor::get_singleton(), !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_SCRIPT));
 		if (!Engine::get_singleton()->is_recovery_mode_hint()) {
 			editor_dock_manager->set_dock_enabled(GameView::get_dock(), !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_GAME));
@@ -7957,7 +8009,9 @@ void EditorNode::_feature_profile_changed() {
 		editor_dock_manager->set_dock_enabled(GroupsDock::get_singleton(), true);
 		editor_dock_manager->set_dock_enabled(FileSystemDock::get_singleton(), true);
 		editor_dock_manager->set_dock_enabled(history_dock, true);
+#ifndef _3D_DISABLED
 		editor_dock_manager->set_dock_enabled(Node3DEditor::get_singleton(), true);
+#endif // _3D_DISABLED
 		editor_dock_manager->set_dock_enabled(ScriptEditor::get_singleton(), true);
 		if (!Engine::get_singleton()->is_recovery_mode_hint() && GameView::get_dock()) {
 			editor_dock_manager->set_dock_enabled(GameView::get_dock(), true);
@@ -8112,7 +8166,9 @@ void EditorNode::_build_file_menu(bool p_dark_mode) {
 
 	if (!export_as_menu) {
 		export_as_menu = memnew(PopupMenu);
+#ifndef _3D_DISABLED
 		export_as_menu->add_shortcut(ED_GET_SHORTCUT("editor/export_as_mesh_library"), FILE_EXPORT_MESH_LIBRARY);
+#endif // _3D_DISABLED
 		export_as_menu->connect("index_pressed", callable_mp(this, &EditorNode::_export_as_menu_option));
 	}
 	file_menu->add_submenu_node_item(TTRC("Export As..."), export_as_menu, SCENE_EXPORT_AS);
@@ -8437,7 +8493,9 @@ HashMap<String, Variant> EditorNode::get_initial_settings() {
 	settings["display/window/stretch/mode"] = "canvas_items";
 	settings["gui/common/auto_focus_strategy"] = Control::AutoFocusStrategy::STRATEGY_BALLOON;
 	settings["input_devices/joypads/ignore_joypad_on_unfocused_application"] = true;
+#ifndef PHYSICS_3D_DISABLED
 	settings["physics/3d/physics_engine"] = PhysicsServer3DManager::JOLT_PHYSICS_NAME;
+#endif // PHYSICS_3D_DISABLED
 	settings["rendering/rendering_device/driver.windows"] = "d3d12";
 	settings["rendering/lights_and_shadows/multi_bounce_occlusion/enabled"] = true;
 	return settings;
@@ -8458,12 +8516,14 @@ EditorNode::EditorNode() {
 
 		AudioServer::get_singleton()->set_enable_tagging_used_audio_streams(true);
 
+#ifndef NAVIGATION_3D_DISABLED
 		// No navigation by default if in editor.
 		if (NavigationServer3D::get_singleton()->get_debug_enabled()) {
 			NavigationServer3D::get_singleton()->set_active(true);
 		} else {
 			NavigationServer3D::get_singleton()->set_active(false);
 		}
+#endif // NAVIGATION_3D_DISABLED
 
 		// No physics by default if in editor.
 #ifndef PHYSICS_3D_DISABLED
@@ -8664,6 +8724,7 @@ EditorNode::EditorNode() {
 		import_shader_file.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(import_shader_file);
 
+#ifndef _3D_DISABLED
 		Ref<ResourceImporterOBJ> import_obj;
 		import_obj.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(import_obj);
@@ -8695,6 +8756,7 @@ EditorNode::EditorNode() {
 			import_escn.instantiate();
 			ResourceImporterScene::add_scene_importer(import_escn);
 		}
+#endif // _3D_DISABLED
 
 		Ref<ResourceImporterBitMap> import_bitmap;
 		import_bitmap.instantiate();
@@ -8706,9 +8768,11 @@ EditorNode::EditorNode() {
 		eidp.instantiate();
 		EditorInspector::add_inspector_plugin(eidp);
 
+#ifndef _3D_DISABLED
 		Ref<EditorInspectorRootMotionPlugin> rmp;
 		rmp.instantiate();
 		EditorInspector::add_inspector_plugin(rmp);
+#endif // _3D_DISABLED
 
 		Ref<EditorInspectorParticleProcessMaterialPlugin> ppm;
 		ppm.instantiate();
@@ -8999,7 +9063,9 @@ EditorNode::EditorNode() {
 	scene_root->set_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
 	scene_root->set_translation_domain(StringName());
 	scene_root->set_embedding_subwindows(true);
+#ifndef _3D_DISABLED
 	scene_root->set_disable_3d(true);
+#endif // _3D_DISABLED
 	scene_root->set_disable_input(true);
 	scene_root->set_as_audio_listener_2d(true);
 
@@ -9020,8 +9086,10 @@ EditorNode::EditorNode() {
 	project_settings_editor = memnew(ProjectSettingsEditor(&editor_data));
 	gui_base->add_child(project_settings_editor);
 
+#ifndef _3D_DISABLED
 	scene_import_settings = memnew(SceneImportSettingsDialog);
 	gui_base->add_child(scene_import_settings);
+#endif // _3D_DISABLED
 
 	audio_stream_import_settings = memnew(AudioStreamImportSettingsDialog);
 	gui_base->add_child(audio_stream_import_settings);
@@ -9088,7 +9156,9 @@ EditorNode::EditorNode() {
 	ED_SHORTCUT_AND_COMMAND("editor/quick_open_scene", TTRC("Quick Open Scene..."), KeyModifierMask::CMD_OR_CTRL + KeyModifierMask::SHIFT + Key::O);
 	ED_SHORTCUT_AND_COMMAND("editor/quick_open_script", TTRC("Quick Open Script..."), KeyModifierMask::CMD_OR_CTRL + KeyModifierMask::ALT + Key::O);
 
+#ifndef _3D_DISABLED
 	ED_SHORTCUT("editor/export_as_mesh_library", TTRC("MeshLibrary..."));
+#endif // _3D_DISABLED
 
 	ED_SHORTCUT_AND_COMMAND("editor/reload_saved_scene", TTRC("Reload Saved Scene"));
 	ED_SHORTCUT_AND_COMMAND("editor/close_scene", TTRC("Close Scene"), KeyModifierMask::CMD_OR_CTRL + KeyModifierMask::SHIFT + Key::W);
@@ -9486,7 +9556,9 @@ EditorNode::EditorNode() {
 	gui_base->add_child(project_data_missing);
 
 	add_editor_plugin(memnew(CanvasItemEditorPlugin));
+#ifndef _3D_DISABLED
 	add_editor_plugin(memnew(Node3DEditorPlugin));
+#endif // _3D_DISABLED
 	add_editor_plugin(memnew(ScriptEditorPlugin));
 
 	if (!Engine::get_singleton()->is_recovery_mode_hint()) {
@@ -9552,6 +9624,7 @@ EditorNode::EditorNode() {
 		particles_mat_convert.instantiate();
 		resource_conversion_plugins.push_back(particles_mat_convert);
 
+#ifndef _3D_DISABLED
 		Ref<StandardMaterial3DConversionPlugin> spatial_mat_convert;
 		spatial_mat_convert.instantiate();
 		resource_conversion_plugins.push_back(spatial_mat_convert);
@@ -9575,6 +9648,7 @@ EditorNode::EditorNode() {
 		Ref<FogMaterialConversionPlugin> fog_mat_convert;
 		fog_mat_convert.instantiate();
 		resource_conversion_plugins.push_back(fog_mat_convert);
+#endif // _3D_DISABLED
 	}
 
 	update_spinner_step_msec = OS::get_singleton()->get_ticks_msec();
@@ -9701,7 +9775,9 @@ EditorNode::EditorNode() {
 	ResourceLoader::set_load_callback(_resource_loaded);
 
 	// Apply setting presets in case the editor_settings file is missing values.
+#ifndef _3D_DISABLED
 	EditorSettingsDialog::update_3d_navigation_preset();
+#endif // _3D_DISABLED
 
 	screenshot_timer = memnew(Timer);
 	screenshot_timer->set_one_shot(true);
@@ -9754,7 +9830,6 @@ EditorNode::EditorNode() {
 	}
 	{
 		const String _2d_key = CanvasItemEditor::get_singleton()->get_effective_layout_key();
-		const String _3d_key = Node3DEditor::get_singleton()->get_effective_layout_key();
 		const String script_key = ScriptEditor::get_singleton()->get_effective_layout_key();
 		String game_key;
 		if (GameView::get_dock()) {
@@ -9764,7 +9839,12 @@ EditorNode::EditorNode() {
 		if (AssetLibraryEditorPlugin::get_library()) {
 			asset_lib_key = AssetLibraryEditorPlugin::get_library()->get_effective_layout_key();
 		}
+#ifndef _3D_DISABLED
+		const String _3d_key = Node3DEditor::get_singleton()->get_effective_layout_key();
 		default_layout->set_value(docks_section, DockTabContainer::get_config_key(EditorDock::DOCK_SLOT_MAIN_SCREEN), vformat("%s,%s,%s,%s,%s", _2d_key, _3d_key, script_key, game_key, asset_lib_key));
+#else
+		default_layout->set_value(docks_section, DockTabContainer::get_config_key(EditorDock::DOCK_SLOT_MAIN_SCREEN), vformat("%s,%s,%s,%s", _2d_key, script_key, game_key, asset_lib_key));
+#endif // _3D_DISABLED
 	}
 
 	int hsplits[] = { 0, dock_hsize, -dock_hsize, 0 };
@@ -9793,7 +9873,9 @@ EditorNode::EditorNode() {
 EditorNode::~EditorNode() {
 	EditorInspector::cleanup_plugins();
 	EditorTranslationParser::get_singleton()->clean_parsers();
+#ifndef _3D_DISABLED
 	ResourceImporterScene::clean_up_importer_plugins();
+#endif // _3D_DISABLED
 	EditorContextMenuPluginManager::cleanup();
 
 	remove_print_handler(&print_handler);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -162,7 +162,9 @@ public:
 		SCENE_CLOSE_ALL,
 		SCENE_QUIT,
 
+#ifndef _3D_DISABLED
 		FILE_EXPORT_MESH_LIBRARY,
+#endif // _3D_DISABLED
 
 		// Project menu.
 		PROJECT_OPEN_SETTINGS,
@@ -990,7 +992,9 @@ public:
 	bool is_scene_in_use(const String &p_path);
 
 	void save_editor_layout_delayed();
+#ifndef _3D_DISABLED
 	void save_default_environment();
+#endif // _3D_DISABLED
 
 	void open_export_template_manager();
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -167,7 +167,9 @@ public:
 		SCENE_CLOSE_ALL,
 		SCENE_QUIT,
 
+#ifndef _3D_DISABLED
 		FILE_EXPORT_MESH_LIBRARY,
+#endif // _3D_DISABLED
 
 		// Project menu.
 		PROJECT_OPEN_SETTINGS,
@@ -1008,7 +1010,9 @@ public:
 	bool is_scene_in_use(const String &p_path);
 
 	void save_editor_layout_delayed();
+#ifndef _3D_DISABLED
 	void save_default_environment();
+#endif // _3D_DISABLED
 
 	void open_export_template_manager();
 

--- a/editor/export/shader_baker/shader_baker_export_plugin.cpp
+++ b/editor/export/shader_baker/shader_baker_export_plugin.cpp
@@ -36,11 +36,14 @@
 #include "core/string/string_builder.h"
 #include "core/version.h"
 #include "editor/editor_node.h"
-#include "scene/3d/label_3d.h"
-#include "scene/3d/sprite_3d.h"
+#include "scene/resources/material.h"
 #include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
 #include "servers/rendering/rendering_shader_container.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/label_3d.h"
+#include "scene/3d/sprite_3d.h"
 
 // Ensure that AlphaCut is the same between the two classes so we can share the code to detect transparency.
 static_assert(ENUM_MEMBERS_EQUAL(SpriteBase3D::ALPHA_CUT_DISABLED, Label3D::ALPHA_CUT_DISABLED));
@@ -48,6 +51,7 @@ static_assert(ENUM_MEMBERS_EQUAL(SpriteBase3D::ALPHA_CUT_DISCARD, Label3D::ALPHA
 static_assert(ENUM_MEMBERS_EQUAL(SpriteBase3D::ALPHA_CUT_OPAQUE_PREPASS, Label3D::ALPHA_CUT_OPAQUE_PREPASS));
 static_assert(ENUM_MEMBERS_EQUAL(SpriteBase3D::ALPHA_CUT_HASH, Label3D::ALPHA_CUT_HASH));
 static_assert(ENUM_MEMBERS_EQUAL(SpriteBase3D::ALPHA_CUT_MAX, Label3D::ALPHA_CUT_MAX));
+#endif // _3D_DISABLED
 
 String ShaderBakerExportPlugin::get_name() const {
 	return "ShaderBaker";
@@ -296,6 +300,7 @@ Ref<Resource> ShaderBakerExportPlugin::_customize_resource(const Ref<Resource> &
 }
 
 Node *ShaderBakerExportPlugin::_customize_scene(Node *p_root, const String &p_path) {
+#ifndef _3D_DISABLED
 	LocalVector<Node *> nodes_to_visit;
 	nodes_to_visit.push_back(p_root);
 	while (!nodes_to_visit.is_empty()) {
@@ -362,6 +367,7 @@ Node *ShaderBakerExportPlugin::_customize_scene(Node *p_root, const String &p_pa
 			nodes_to_visit.push_back(node->get_child(i));
 		}
 	}
+#endif // _3D_DISABLED
 
 	return nullptr;
 }

--- a/editor/export/shader_baker_export_plugin.cpp
+++ b/editor/export/shader_baker_export_plugin.cpp
@@ -36,11 +36,14 @@
 #include "core/string/string_builder.h"
 #include "core/version.h"
 #include "editor/editor_node.h"
-#include "scene/3d/label_3d.h"
-#include "scene/3d/sprite_3d.h"
+#include "scene/resources/material.h"
 #include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
 #include "servers/rendering/rendering_shader_container.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/label_3d.h"
+#include "scene/3d/sprite_3d.h"
 
 // Ensure that AlphaCut is the same between the two classes so we can share the code to detect transparency.
 static_assert(ENUM_MEMBERS_EQUAL(SpriteBase3D::ALPHA_CUT_DISABLED, Label3D::ALPHA_CUT_DISABLED));
@@ -48,6 +51,7 @@ static_assert(ENUM_MEMBERS_EQUAL(SpriteBase3D::ALPHA_CUT_DISCARD, Label3D::ALPHA
 static_assert(ENUM_MEMBERS_EQUAL(SpriteBase3D::ALPHA_CUT_OPAQUE_PREPASS, Label3D::ALPHA_CUT_OPAQUE_PREPASS));
 static_assert(ENUM_MEMBERS_EQUAL(SpriteBase3D::ALPHA_CUT_HASH, Label3D::ALPHA_CUT_HASH));
 static_assert(ENUM_MEMBERS_EQUAL(SpriteBase3D::ALPHA_CUT_MAX, Label3D::ALPHA_CUT_MAX));
+#endif // _3D_DISABLED
 
 String ShaderBakerExportPlugin::get_name() const {
 	return "ShaderBaker";
@@ -296,6 +300,7 @@ Ref<Resource> ShaderBakerExportPlugin::_customize_resource(const Ref<Resource> &
 }
 
 Node *ShaderBakerExportPlugin::_customize_scene(Node *p_root, const String &p_path) {
+#ifndef _3D_DISABLED
 	LocalVector<Node *> nodes_to_visit;
 	nodes_to_visit.push_back(p_root);
 	while (!nodes_to_visit.is_empty()) {
@@ -362,6 +367,7 @@ Node *ShaderBakerExportPlugin::_customize_scene(Node *p_root, const String &p_pa
 			nodes_to_visit.push_back(node->get_child(i));
 		}
 	}
+#endif // _3D_DISABLED
 
 	return nullptr;
 }

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -42,24 +42,30 @@
 #include "editor/settings/editor_settings.h"
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
-#include "scene/3d/navigation/navigation_region_3d.h"
 #include "scene/3d/occluder_instance_3d.h"
-#include "scene/3d/physics/area_3d.h"
-#include "scene/3d/physics/collision_shape_3d.h"
-#include "scene/3d/physics/static_body_3d.h"
-#include "scene/3d/physics/vehicle_body_3d.h"
 #include "scene/animation/animation_player.h"
-#include "scene/resources/3d/box_shape_3d.h"
 #include "scene/resources/3d/importer_mesh.h"
 #include "scene/resources/3d/mesh_library.h"
-#include "scene/resources/3d/separation_ray_shape_3d.h"
-#include "scene/resources/3d/sphere_shape_3d.h"
-#include "scene/resources/3d/world_boundary_shape_3d.h"
 #include "scene/resources/animation.h"
 #include "scene/resources/bone_map.h"
 #include "scene/resources/packed_scene.h"
 #include "scene/resources/physics_material.h"
 #include "scene/resources/resource_format_text.h"
+
+#ifndef NAVIGATION_3D_DISABLED
+#include "scene/3d/navigation/navigation_region_3d.h"
+#endif // NAVIGATION_3D_DISABLED
+
+#ifndef PHYSICS_3D_DISABLED
+#include "scene/3d/physics/area_3d.h"
+#include "scene/3d/physics/collision_shape_3d.h"
+#include "scene/3d/physics/static_body_3d.h"
+#include "scene/3d/physics/vehicle_body_3d.h"
+#include "scene/resources/3d/box_shape_3d.h"
+#include "scene/resources/3d/separation_ray_shape_3d.h"
+#include "scene/resources/3d/sphere_shape_3d.h"
+#include "scene/resources/3d/world_boundary_shape_3d.h"
+#endif // PHYSICS_3D_DISABLED
 
 void EditorSceneFormatImporter::get_extensions(List<String> *r_extensions) const {
 	Vector<String> arr;
@@ -470,6 +476,7 @@ static String _fixstr(const String &p_what, const String &p_str) {
 	return what;
 }
 
+#ifndef PHYSICS_3D_DISABLED
 static void _pre_gen_shape_list(Ref<ImporterMesh> &mesh, Vector<Ref<Shape3D>> &r_shape_list, bool p_convex) {
 	ERR_FAIL_COND_MSG(mesh.is_null(), "Cannot generate shape list with null mesh value.");
 	if (!p_convex) {
@@ -485,6 +492,7 @@ static void _pre_gen_shape_list(Ref<ImporterMesh> &mesh, Vector<Ref<Shape3D>> &r
 		}
 	}
 }
+#endif // PHYSICS_3D_DISABLED
 
 struct ScalableNodeCollection {
 	HashSet<Node3D *> node_3ds;
@@ -809,6 +817,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 			ERR_FAIL_V_MSG(nullptr, vformat("Skipped node `%s` because its name is empty after removing the suffix.", name));
 		}
 
+#ifndef PHYSICS_3D_DISABLED
 		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
 		if (mi) {
 			Ref<ImporterMesh> mesh = mi->get_mesh();
@@ -942,7 +951,9 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 				_add_shapes(col, shapes);
 			}
 		}
+#endif // PHYSICS_3D_DISABLED
 
+#ifndef NAVIGATION_3D_DISABLED
 	} else if (_teststr(name, "navmesh") && Object::cast_to<ImporterMeshInstance3D>(p_node)) {
 		if (isroot) {
 			return p_node;
@@ -963,6 +974,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 		p_node->set_owner(nullptr);
 		memdelete(p_node);
 		p_node = nmi;
+#endif // NAVIGATION_3D_DISABLED
 	} else if (_teststr(name, "occ") || _teststr(name, "occonly")) {
 		if (isroot) {
 			return p_node;
@@ -989,6 +1001,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 				}
 			}
 		}
+#ifndef PHYSICS_3D_DISABLED
 	} else if (_teststr(name, "vehicle")) {
 		if (isroot) {
 			return p_node;
@@ -1062,6 +1075,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 				_add_shapes(col, shapes);
 			}
 		}
+#endif // PHYSICS_3D_DISABLED
 	}
 
 	if (p_node) {
@@ -1677,6 +1691,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 				r_scanned_meshes.insert(m);
 			}
 
+#ifndef PHYSICS_3D_DISABLED
 			if (node_settings.has("generate/physics")) {
 				int mesh_physics_mode = MeshPhysicsMode::MESH_PHYSICS_DISABLED;
 
@@ -1795,9 +1810,11 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 					}
 				}
 			}
+#endif // PHYSICS_3D_DISABLED
 		}
 	}
 
+#ifndef NAVIGATION_3D_DISABLED
 	//navmesh (node may have changed type above)
 	if (Object::cast_to<ImporterMeshInstance3D>(p_node)) {
 		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
@@ -1829,6 +1846,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 			}
 		}
 	}
+#endif // NAVIGATION_3D_DISABLED
 
 	if (Object::cast_to<ImporterMeshInstance3D>(p_node)) {
 		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
@@ -2893,6 +2911,7 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 	return p_node;
 }
 
+#ifndef PHYSICS_3D_DISABLED
 void ResourceImporterScene::_add_shapes(Node *p_node, const Vector<Ref<Shape3D>> &p_shapes) {
 	for (const Ref<Shape3D> &E : p_shapes) {
 		CollisionShape3D *cshape = memnew(CollisionShape3D);
@@ -2902,6 +2921,7 @@ void ResourceImporterScene::_add_shapes(Node *p_node, const Vector<Ref<Shape3D>>
 		cshape->set_owner(p_node->get_owner());
 	}
 }
+#endif // PHYSICS_3D_DISABLED
 
 void ResourceImporterScene::_copy_meta(Object *p_src_object, Object *p_dst_object) {
 	List<StringName> meta_list;

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -42,24 +42,30 @@
 #include "editor/settings/editor_settings.h"
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
-#include "scene/3d/navigation/navigation_region_3d.h"
 #include "scene/3d/occluder_instance_3d.h"
-#include "scene/3d/physics/area_3d.h"
-#include "scene/3d/physics/collision_shape_3d.h"
-#include "scene/3d/physics/static_body_3d.h"
-#include "scene/3d/physics/vehicle_body_3d.h"
 #include "scene/animation/animation_player.h"
-#include "scene/resources/3d/box_shape_3d.h"
 #include "scene/resources/3d/importer_mesh.h"
 #include "scene/resources/3d/mesh_library.h"
-#include "scene/resources/3d/separation_ray_shape_3d.h"
-#include "scene/resources/3d/sphere_shape_3d.h"
-#include "scene/resources/3d/world_boundary_shape_3d.h"
 #include "scene/resources/animation.h"
 #include "scene/resources/bone_map.h"
 #include "scene/resources/packed_scene.h"
 #include "scene/resources/physics_material.h"
 #include "scene/resources/resource_format_text.h"
+
+#ifndef NAVIGATION_3D_DISABLED
+#include "scene/3d/navigation/navigation_region_3d.h"
+#endif // NAVIGATION_3D_DISABLED
+
+#ifndef PHYSICS_3D_DISABLED
+#include "scene/3d/physics/area_3d.h"
+#include "scene/3d/physics/collision_shape_3d.h"
+#include "scene/3d/physics/static_body_3d.h"
+#include "scene/3d/physics/vehicle_body_3d.h"
+#include "scene/resources/3d/box_shape_3d.h"
+#include "scene/resources/3d/separation_ray_shape_3d.h"
+#include "scene/resources/3d/sphere_shape_3d.h"
+#include "scene/resources/3d/world_boundary_shape_3d.h"
+#endif // PHYSICS_3D_DISABLED
 
 void EditorSceneFormatImporter::get_extensions(List<String> *r_extensions) const {
 	Vector<String> arr;
@@ -470,6 +476,7 @@ static String _fixstr(const String &p_what, const String &p_str) {
 	return what;
 }
 
+#ifndef PHYSICS_3D_DISABLED
 static void _pre_gen_shape_list(Ref<ImporterMesh> &mesh, Vector<Ref<Shape3D>> &r_shape_list, bool p_convex) {
 	ERR_FAIL_COND_MSG(mesh.is_null(), "Cannot generate shape list with null mesh value.");
 	if (!p_convex) {
@@ -485,6 +492,7 @@ static void _pre_gen_shape_list(Ref<ImporterMesh> &mesh, Vector<Ref<Shape3D>> &r
 		}
 	}
 }
+#endif // PHYSICS_3D_DISABLED
 
 struct ScalableNodeCollection {
 	HashSet<Node3D *> node_3ds;
@@ -855,6 +863,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 			ERR_FAIL_V_MSG(nullptr, vformat("Skipped node `%s` because its name is empty after removing the suffix.", name));
 		}
 
+#ifndef PHYSICS_3D_DISABLED
 		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
 		if (mi) {
 			Ref<ImporterMesh> mesh = mi->get_mesh();
@@ -990,6 +999,57 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 				_add_shapes(col, shapes);
 			}
 		}
+#endif // PHYSICS_3D_DISABLED
+
+#ifndef NAVIGATION_3D_DISABLED
+	} else if (_teststr(name, "navmesh") && Object::cast_to<ImporterMeshInstance3D>(p_node)) {
+		if (isroot) {
+			return p_node;
+		}
+
+		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
+
+		Ref<ImporterMesh> mesh = mi->get_mesh();
+		ERR_FAIL_COND_V(mesh.is_null(), nullptr);
+		NavigationRegion3D *nmi = memnew(NavigationRegion3D);
+
+		nmi->set_name(_fixstr(name, "navmesh"));
+		Ref<NavigationMesh> nmesh = mesh->create_navigation_mesh();
+		nmi->set_navigation_mesh(nmesh);
+		Object::cast_to<Node3D>(nmi)->set_transform(mi->get_transform());
+		_copy_meta(p_node, nmi);
+		p_node->replace_by(nmi);
+		p_node->set_owner(nullptr);
+		memdelete(p_node);
+		p_node = nmi;
+#endif // NAVIGATION_3D_DISABLED
+	} else if (_teststr(name, "occ") || _teststr(name, "occonly")) {
+		if (isroot) {
+			return p_node;
+		}
+		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
+		if (mi) {
+			Ref<ImporterMesh> mesh = mi->get_mesh();
+
+			if (mesh.is_valid()) {
+				if (r_occluder_arrays) {
+					OccluderInstance3D::bake_single_node(mi, 0.0f, r_occluder_arrays->first, r_occluder_arrays->second);
+				}
+				if (_teststr(name, "occ")) {
+					String fixed_name = _fixstr(name, "occ");
+					if (!fixed_name.is_empty()) {
+						if (mi->get_parent() && !mi->get_parent()->has_node(fixed_name)) {
+							mi->set_name(fixed_name);
+						}
+					}
+				} else {
+					p_node->set_owner(nullptr);
+					memdelete(p_node);
+					p_node = nullptr;
+				}
+			}
+		}
+#ifndef PHYSICS_3D_DISABLED
 	} else if (_teststr(name, "vehicle")) {
 		if (isroot) {
 			return p_node;
@@ -1063,6 +1123,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 				_add_shapes(col, shapes);
 			}
 		}
+#endif // PHYSICS_3D_DISABLED
 	}
 
 	if (p_node) {
@@ -1714,6 +1775,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 				r_scanned_meshes.insert(m);
 			}
 
+#ifndef PHYSICS_3D_DISABLED
 			if (node_settings.has("generate/physics")) {
 				int mesh_physics_mode = MeshPhysicsMode::MESH_PHYSICS_DISABLED;
 
@@ -1832,9 +1894,11 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 					}
 				}
 			}
+#endif // PHYSICS_3D_DISABLED
 		}
 	}
 
+#ifndef NAVIGATION_3D_DISABLED
 	//navmesh (node may have changed type above)
 	if (Object::cast_to<ImporterMeshInstance3D>(p_node)) {
 		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
@@ -1866,6 +1930,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 			}
 		}
 	}
+#endif // NAVIGATION_3D_DISABLED
 
 	if (Object::cast_to<ImporterMeshInstance3D>(p_node)) {
 		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
@@ -2947,6 +3012,7 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 	return p_node;
 }
 
+#ifndef PHYSICS_3D_DISABLED
 void ResourceImporterScene::_add_shapes(Node *p_node, const Vector<Ref<Shape3D>> &p_shapes) {
 	for (const Ref<Shape3D> &E : p_shapes) {
 		CollisionShape3D *cshape = memnew(CollisionShape3D);
@@ -2956,6 +3022,7 @@ void ResourceImporterScene::_add_shapes(Node *p_node, const Vector<Ref<Shape3D>>
 		cshape->set_owner(p_node->get_owner());
 	}
 }
+#endif // PHYSICS_3D_DISABLED
 
 void ResourceImporterScene::_copy_meta(Object *p_src_object, Object *p_dst_object) {
 	List<StringName> meta_list;

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -34,13 +34,18 @@
 #include "core/io/resource_importer.h"
 #include "core/variant/dictionary.h"
 #include "scene/3d/importer_mesh_instance_3d.h"
+#include "scene/resources/3d/importer_mesh.h"
+#include "scene/resources/animation.h"
+#include "scene/resources/mesh.h"
+
+#ifndef PHYSICS_3D_DISABLED
 #include "scene/resources/3d/box_shape_3d.h"
 #include "scene/resources/3d/capsule_shape_3d.h"
 #include "scene/resources/3d/cylinder_shape_3d.h"
-#include "scene/resources/3d/importer_mesh.h"
 #include "scene/resources/3d/sphere_shape_3d.h"
-#include "scene/resources/animation.h"
-#include "scene/resources/mesh.h"
+#else
+using Shape3D = RefCounted;
+#endif // PHYSICS_3D_DISABLED
 
 class AnimationPlayer;
 class ImporterMesh;
@@ -212,7 +217,9 @@ class ResourceImporterScene : public ResourceImporter {
 	Array _get_skinned_pose_transforms(ImporterMeshInstance3D *p_src_mesh_node);
 	void _replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner);
 	Node *_generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<Vector<uint8_t>> &r_lightmap_caches);
+#ifndef PHYSICS_3D_DISABLED
 	void _add_shapes(Node *p_node, const Vector<Ref<Shape3D>> &p_shapes);
+#endif // PHYSICS_3D_DISABLED
 	void _copy_meta(Object *p_src_object, Object *p_dst_object);
 	Node *_replace_node_with_type_and_script(Node *p_node, String p_node_type, Ref<Script> p_script);
 
@@ -302,11 +309,13 @@ public:
 
 	ResourceImporterScene(const String &p_scene_import_type = "PackedScene");
 
+#ifndef PHYSICS_3D_DISABLED
 	template <typename M>
 	static Vector<Ref<Shape3D>> get_collision_shapes(const Ref<ImporterMesh> &p_mesh, const M &p_options, float p_applied_root_scale);
 
 	template <typename M>
 	static Transform3D get_collision_shapes_transform(const M &p_options);
+#endif // PHYSICS_3D_DISABLED
 };
 
 class EditorSceneFormatImporterESCN : public EditorSceneFormatImporter {
@@ -317,6 +326,7 @@ public:
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr) override;
 };
 
+#ifndef PHYSICS_3D_DISABLED
 template <typename M>
 Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<ImporterMesh> &p_mesh, const M &p_options, float p_applied_root_scale) {
 	ERR_FAIL_COND_V(p_mesh.is_null(), Vector<Ref<Shape3D>>());
@@ -516,3 +526,4 @@ Transform3D ResourceImporterScene::get_collision_shapes_transform(const M &p_opt
 	}
 	return transform;
 }
+#endif // PHYSICS_3D_DISABLED

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -76,10 +76,12 @@ class SceneImportSettingsData : public Object {
 
 			current[p_name] = p_value;
 
+#ifndef PHYSICS_3D_DISABLED
 			// SceneImportSettings must decide if a new collider should be generated or not.
 			if (category == ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE) {
 				SceneImportSettingsDialog::get_singleton()->request_generate_collider();
 			}
+#endif // PHYSICS_3D_DISABLED
 
 			Ref<ResourceImporterScene> resource_importer_scene = SceneImportSettingsDialog::get_singleton()->get_resource_importer_scene();
 			if (category == ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MAX) {
@@ -576,6 +578,7 @@ void SceneImportSettingsDialog::_update_view_gizmos() {
 		open_settings(base_path);
 		return;
 	}
+#ifndef PHYSICS_3D_DISABLED
 	for (const KeyValue<String, NodeData> &e : node_map) {
 		// Skip import nodes that aren't MeshInstance3D.
 		const MeshInstance3D *mesh_node = Object::cast_to<MeshInstance3D>(e.value.node);
@@ -667,6 +670,7 @@ void SceneImportSettingsDialog::_update_view_gizmos() {
 	}
 
 	generate_collider = false;
+#endif // PHYSICS_3D_DISABLED
 }
 
 void SceneImportSettingsDialog::_update_camera() {
@@ -727,9 +731,11 @@ void SceneImportSettingsDialog::_load_default_subresource_settings(HashMap<Strin
 	}
 }
 
+#ifndef PHYSICS_3D_DISABLED
 void SceneImportSettingsDialog::request_generate_collider() {
 	generate_collider = true;
 }
+#endif // PHYSICS_3D_DISABLED
 
 void SceneImportSettingsDialog::update_view() {
 	update_view_timer->start();

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -235,7 +235,9 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 
 	void _load_default_subresource_settings(HashMap<StringName, Variant> &settings, const String &p_type, const String &p_import_id, ResourceImporterScene::InternalImportCategory p_category);
 
+#ifndef PHYSICS_3D_DISABLED
 	bool generate_collider = false;
+#endif // PHYSICS_3D_DISABLED
 
 	Timer *update_view_timer = nullptr;
 
@@ -245,7 +247,9 @@ protected:
 
 public:
 	const Ref<ResourceImporterScene> &get_resource_importer_scene() const { return _resource_importer_scene; }
+#ifndef PHYSICS_3D_DISABLED
 	void request_generate_collider();
+#endif // PHYSICS_3D_DISABLED
 	void update_view();
 	void open_settings(const String &p_path, const String &p_scene_import_type = "PackedScene");
 	static SceneImportSettingsDialog *get_singleton();

--- a/editor/import/SCsub
+++ b/editor/import/SCsub
@@ -4,4 +4,5 @@ from misc.utility.scons_hints import *
 Import("env")
 
 env.add_source_files(env.editor_sources, "*.cpp")
-env.add_source_files(env.editor_sources, "3d/*.cpp")
+if not env["disable_3d"]:
+    env.add_source_files(env.editor_sources, "3d/*.cpp")

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -55,8 +55,6 @@
 #include "editor/settings/project_settings_editor.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/2d/gpu_particles_2d.h"
-#include "scene/3d/fog_volume.h"
-#include "scene/3d/gpu_particles_3d.h"
 #include "scene/gui/color_picker.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/text_edit.h"
@@ -64,9 +62,14 @@
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/font.h"
+#include "servers/display/display_server.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/fog_volume.h"
+#include "scene/3d/gpu_particles_3d.h"
 #include "scene/resources/mesh.h"
 #include "scene/resources/sky.h"
-#include "servers/display/display_server.h"
+#endif // _3D_DISABLED
 
 #include "modules/modules_enabled.gen.h"
 
@@ -3543,16 +3546,22 @@ void EditorPropertyResource::_update_preferred_shader() {
 		const StringName &ed_property = parent_property->get_edited_property();
 
 		// Set preferred shader based on edited parent type.
+#ifndef _3D_DISABLED
 		if ((Object::cast_to<GPUParticles2D>(ed_object) || Object::cast_to<GPUParticles3D>(ed_object)) && ed_property == SNAME("process_material")) {
+#else
+		if (Object::cast_to<GPUParticles2D>(ed_object) && ed_property == SNAME("process_material")) {
+#endif // _3D_DISABLED
 			shader_picker->set_preferred_mode(Shader::MODE_PARTICLES);
-		} else if (Object::cast_to<FogVolume>(ed_object)) {
-			shader_picker->set_preferred_mode(Shader::MODE_FOG);
 		} else if (Object::cast_to<CanvasItem>(ed_object)) {
 			shader_picker->set_preferred_mode(Shader::MODE_CANVAS_ITEM);
+#ifndef _3D_DISABLED
+		} else if (Object::cast_to<FogVolume>(ed_object)) {
+			shader_picker->set_preferred_mode(Shader::MODE_FOG);
 		} else if (Object::cast_to<Node3D>(ed_object) || Object::cast_to<Mesh>(ed_object)) {
 			shader_picker->set_preferred_mode(Shader::MODE_SPATIAL);
 		} else if (Object::cast_to<Sky>(ed_object)) {
 			shader_picker->set_preferred_mode(Shader::MODE_SKY);
+#endif // _3D_DISABLED
 		}
 	}
 }

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -56,8 +56,6 @@
 #include "editor/settings/project_settings_editor.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/2d/gpu_particles_2d.h"
-#include "scene/3d/fog_volume.h"
-#include "scene/3d/gpu_particles_3d.h"
 #include "scene/gui/color_picker.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/text_edit.h"
@@ -65,8 +63,14 @@
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/font.h"
+#include "servers/display/display_server.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/fog_volume.h"
+#include "scene/3d/gpu_particles_3d.h"
 #include "scene/resources/mesh.h"
 #include "scene/resources/sky.h"
+#endif // _3D_DISABLED
 #include "servers/audio/audio_server.h"
 #include "servers/display/display_server.h"
 
@@ -3599,16 +3603,22 @@ void EditorPropertyResource::_update_preferred_shader() {
 		const StringName &ed_property = parent_property->get_edited_property();
 
 		// Set preferred shader based on edited parent type.
+#ifndef _3D_DISABLED
 		if ((Object::cast_to<GPUParticles2D>(ed_object) || Object::cast_to<GPUParticles3D>(ed_object)) && ed_property == SNAME("process_material")) {
+#else
+		if (Object::cast_to<GPUParticles2D>(ed_object) && ed_property == SNAME("process_material")) {
+#endif // _3D_DISABLED
 			shader_picker->set_preferred_mode(Shader::MODE_PARTICLES);
 		} else if (Object::cast_to<CanvasItem>(ed_object)) {
 			shader_picker->set_preferred_mode(Shader::MODE_CANVAS_ITEM);
+#ifndef _3D_DISABLED
 		} else if (Object::cast_to<FogVolume>(ed_object)) {
 			shader_picker->set_preferred_mode(Shader::MODE_FOG);
 		} else if (Object::cast_to<Node3D>(ed_object) || Object::cast_to<Mesh>(ed_object)) {
 			shader_picker->set_preferred_mode(Shader::MODE_SPATIAL);
 		} else if (Object::cast_to<Sky>(ed_object)) {
 			shader_picker->set_preferred_mode(Shader::MODE_SKY);
+#endif // _3D_DISABLED
 		}
 	}
 }

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -35,6 +35,7 @@
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/object/script_language.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -52,11 +52,14 @@
 #include "scene/gui/button.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/property_utils.h"
-#include "scene/resources/3d/sky_material.h"
 #include "scene/resources/gradient_texture.h"
 #include "scene/resources/image_texture.h"
 #include "servers/audio/audio_server.h"
 #include "servers/rendering/rendering_server.h"
+
+#ifndef _3D_DISABLED
+#include "scene/resources/3d/sky_material.h"
+#endif // _3D_DISABLED
 
 static bool _has_sub_resources(const Ref<Resource> &p_res) {
 	List<PropertyInfo> property_list;
@@ -869,8 +872,10 @@ void EditorResourcePicker::_ensure_allowed_types() const {
 		const String base = allowed_types[i].strip_edges();
 		if (base == "BaseMaterial3D") {
 			allowed_types_with_convert.insert("Texture2D");
+#ifndef _3D_DISABLED
 		} else if (base == "PanoramaSkyMaterial") {
 			allowed_types_with_convert.insert("Texture2D");
+#endif // _3D_DISABLED
 		} else if (ClassDB::is_parent_class("ShaderMaterial", base)) {
 			allowed_types_with_convert.insert("Shader");
 		} else if (ClassDB::is_parent_class("ImageTexture", base)) {
@@ -1012,6 +1017,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 					break;
 				}
 
+#ifndef _3D_DISABLED
 				if (at == "PanoramaSkyMaterial" && Ref<Texture2D>(dropped_resource).is_valid()) {
 					Ref<PanoramaSkyMaterial> mat = edited_resource;
 					if (mat.is_null()) {
@@ -1021,6 +1027,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 					dropped_resource = mat;
 					break;
 				}
+#endif // _3D_DISABLED
 
 				if (at == "ShaderMaterial" && Ref<Shader>(dropped_resource).is_valid()) {
 					Ref<ShaderMaterial> mat = edited_resource;

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -48,18 +48,20 @@
 #include "editor/file_system/editor_file_system.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_title_bar.h"
-#include "editor/import/3d/resource_importer_scene.h"
 #include "editor/import/editor_import_plugin.h"
 #include "editor/inspector/editor_inspector.h"
 #include "editor/plugins/editor_plugin_list.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/project_settings_editor.h"
 #include "editor/translations/editor_translation_parser.h"
-#include "scene/3d/camera_3d.h"
 #include "scene/gui/popup_menu.h"
+#ifndef _3D_DISABLED
+#include "editor/import/3d/resource_importer_scene.h"
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "scene/3d/camera_3d.h"
+#endif // _3D_DISABLED
 
 void EditorPlugin::add_custom_type(const String &p_type, const String &p_base, const Ref<Script> &p_script, const Ref<Texture2D> &p_icon) {
 	EditorNode::get_editor_data().add_custom_type(p_type, p_base, p_script, p_icon);
@@ -141,6 +143,7 @@ void EditorPlugin::add_control_to_container(CustomControlContainer p_location, C
 			EditorNode::get_title_bar()->add_child(p_control);
 		} break;
 
+#ifndef _3D_DISABLED
 		case CONTAINER_SPATIAL_EDITOR_MENU: {
 			Node3DEditor::get_singleton()->add_control_to_menu_panel(p_control);
 
@@ -155,6 +158,7 @@ void EditorPlugin::add_control_to_container(CustomControlContainer p_location, C
 			Node3DEditor::get_singleton()->get_shader_split()->add_child(p_control);
 
 		} break;
+#endif // _3D_DISABLED
 		case CONTAINER_CANVAS_EDITOR_MENU: {
 			CanvasItemEditor::get_singleton()->add_control_to_menu_panel(p_control);
 
@@ -182,6 +186,9 @@ void EditorPlugin::add_control_to_container(CustomControlContainer p_location, C
 			ProjectSettingsEditor::get_singleton()->get_tabs()->add_child(p_control);
 
 		} break;
+
+		default: {
+		} break;
 	}
 }
 
@@ -193,6 +200,7 @@ void EditorPlugin::remove_control_from_container(CustomControlContainer p_locati
 			EditorNode::get_title_bar()->remove_child(p_control);
 		} break;
 
+#ifndef _3D_DISABLED
 		case CONTAINER_SPATIAL_EDITOR_MENU: {
 			Node3DEditor::get_singleton()->remove_control_from_menu_panel(p_control);
 
@@ -207,6 +215,8 @@ void EditorPlugin::remove_control_from_container(CustomControlContainer p_locati
 			Node3DEditor::get_singleton()->get_shader_split()->remove_child(p_control);
 
 		} break;
+#endif // _3D_DISABLED
+
 		case CONTAINER_CANVAS_EDITOR_MENU: {
 			CanvasItemEditor::get_singleton()->remove_control_from_menu_panel(p_control);
 
@@ -229,6 +239,9 @@ void EditorPlugin::remove_control_from_container(CustomControlContainer p_locati
 		case CONTAINER_PROJECT_SETTING_TAB_RIGHT: {
 			ProjectSettingsEditor::get_singleton()->get_tabs()->remove_child(p_control);
 
+		} break;
+
+		default: {
 		} break;
 	}
 }
@@ -301,6 +314,7 @@ void EditorPlugin::forward_canvas_force_draw_over_viewport(Control *p_overlay) {
 
 // Updates the overlays of the 2D viewport or, if in 3D mode, of every 3D viewport.
 int EditorPlugin::update_overlays() const {
+#ifndef _3D_DISABLED
 	if (Node3DEditor::get_singleton()->is_visible()) {
 		int count = 0;
 		for (uint32_t i = 0; i < Node3DEditor::VIEWPORTS_COUNT; i++) {
@@ -312,12 +326,17 @@ int EditorPlugin::update_overlays() const {
 		}
 		return count;
 	} else {
+#endif // _3D_DISABLED
+
 		// This will update the normal viewport itself as well
 		CanvasItemEditor::get_singleton()->get_viewport_control()->queue_redraw();
 		return 1;
+#ifndef _3D_DISABLED
 	}
+#endif // _3D_DISABLED
 }
 
+#ifndef _3D_DISABLED
 EditorPlugin::AfterGUIInput EditorPlugin::forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) {
 	int success = EditorPlugin::AFTER_GUI_INPUT_PASS;
 	GDVIRTUAL_CALL(_forward_3d_gui_input, p_camera, p_event, success);
@@ -331,6 +350,7 @@ void EditorPlugin::forward_3d_draw_over_viewport(Control *p_overlay) {
 void EditorPlugin::forward_3d_force_draw_over_viewport(Control *p_overlay) {
 	GDVIRTUAL_CALL(_forward_3d_force_draw_over_viewport, p_overlay);
 }
+#endif // _3D_DISABLED
 
 String EditorPlugin::get_plugin_name() const {
 	String name;
@@ -476,6 +496,7 @@ void EditorPlugin::remove_export_platform(const Ref<EditorExportPlatform> &p_pla
 	EditorExport::get_singleton()->remove_export_platform(p_platform);
 }
 
+#ifndef _3D_DISABLED
 void EditorPlugin::add_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin) {
 	ERR_FAIL_COND(p_gizmo_plugin.is_null());
 	Node3DEditor::get_singleton()->add_gizmo_plugin(p_gizmo_plugin);
@@ -485,6 +506,7 @@ void EditorPlugin::remove_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin
 	ERR_FAIL_COND(p_gizmo_plugin.is_null());
 	Node3DEditor::get_singleton()->remove_gizmo_plugin(p_gizmo_plugin);
 }
+#endif // _3D_DISABLED
 
 void EditorPlugin::add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin) {
 	ERR_FAIL_COND(p_plugin.is_null());
@@ -496,6 +518,7 @@ void EditorPlugin::remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_p
 	EditorInspector::remove_inspector_plugin(p_plugin);
 }
 
+#ifndef _3D_DISABLED
 void EditorPlugin::add_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer, bool p_first_priority) {
 	ERR_FAIL_COND(p_importer.is_null());
 	ResourceImporterScene::add_scene_importer(p_importer, p_first_priority);
@@ -513,6 +536,7 @@ void EditorPlugin::add_scene_post_import_plugin(const Ref<EditorScenePostImportP
 void EditorPlugin::remove_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin) {
 	ResourceImporterScene::remove_post_importer_plugin(p_plugin);
 }
+#endif // _3D_DISABLED
 
 void EditorPlugin::add_context_menu_plugin(EditorContextMenuPlugin::ContextMenuSlot p_slot, const Ref<EditorContextMenuPlugin> &p_plugin) {
 	EditorContextMenuPluginManager::get_singleton()->add_plugin(p_slot, p_plugin);
@@ -657,16 +681,18 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_translation_parser_plugin", "parser"), &EditorPlugin::remove_translation_parser_plugin);
 	ClassDB::bind_method(D_METHOD("add_import_plugin", "importer", "first_priority"), &EditorPlugin::add_import_plugin, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_import_plugin", "importer"), &EditorPlugin::remove_import_plugin);
+#ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("add_scene_format_importer_plugin", "scene_format_importer", "first_priority"), &EditorPlugin::add_scene_format_importer_plugin, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_scene_format_importer_plugin", "scene_format_importer"), &EditorPlugin::remove_scene_format_importer_plugin);
 	ClassDB::bind_method(D_METHOD("add_scene_post_import_plugin", "scene_import_plugin", "first_priority"), &EditorPlugin::add_scene_post_import_plugin, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_scene_post_import_plugin", "scene_import_plugin"), &EditorPlugin::remove_scene_post_import_plugin);
+	ClassDB::bind_method(D_METHOD("add_node_3d_gizmo_plugin", "plugin"), &EditorPlugin::add_node_3d_gizmo_plugin);
+	ClassDB::bind_method(D_METHOD("remove_node_3d_gizmo_plugin", "plugin"), &EditorPlugin::remove_node_3d_gizmo_plugin);
+#endif // _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("add_export_plugin", "plugin"), &EditorPlugin::add_export_plugin);
 	ClassDB::bind_method(D_METHOD("remove_export_plugin", "plugin"), &EditorPlugin::remove_export_plugin);
 	ClassDB::bind_method(D_METHOD("add_export_platform", "platform"), &EditorPlugin::add_export_platform);
 	ClassDB::bind_method(D_METHOD("remove_export_platform", "platform"), &EditorPlugin::remove_export_platform);
-	ClassDB::bind_method(D_METHOD("add_node_3d_gizmo_plugin", "plugin"), &EditorPlugin::add_node_3d_gizmo_plugin);
-	ClassDB::bind_method(D_METHOD("remove_node_3d_gizmo_plugin", "plugin"), &EditorPlugin::remove_node_3d_gizmo_plugin);
 	ClassDB::bind_method(D_METHOD("add_inspector_plugin", "plugin"), &EditorPlugin::add_inspector_plugin);
 	ClassDB::bind_method(D_METHOD("remove_inspector_plugin", "plugin"), &EditorPlugin::remove_inspector_plugin);
 	ClassDB::bind_method(D_METHOD("add_resource_conversion_plugin", "plugin"), &EditorPlugin::add_resource_conversion_plugin);
@@ -685,9 +711,11 @@ void EditorPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_forward_canvas_gui_input, "event");
 	GDVIRTUAL_BIND(_forward_canvas_draw_over_viewport, "viewport_control");
 	GDVIRTUAL_BIND(_forward_canvas_force_draw_over_viewport, "viewport_control");
+#ifndef _3D_DISABLED
 	GDVIRTUAL_BIND(_forward_3d_gui_input, "viewport_camera", "event");
 	GDVIRTUAL_BIND(_forward_3d_draw_over_viewport, "viewport_control");
 	GDVIRTUAL_BIND(_forward_3d_force_draw_over_viewport, "viewport_control");
+#endif // _3D_DISABLED
 	GDVIRTUAL_BIND(_get_plugin_name);
 	GDVIRTUAL_BIND(_get_plugin_icon);
 	GDVIRTUAL_BIND(_has_main_screen);

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -49,19 +49,20 @@
 #include "editor/file_system/editor_file_system.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_title_bar.h"
-#include "editor/import/3d/resource_importer_scene.h"
 #include "editor/import/editor_import_plugin.h"
 #include "editor/inspector/editor_inspector.h"
 #include "editor/plugins/editor_plugin_list.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h"
-#include "editor/scene/3d/node_3d_editor_viewport.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/project_settings_editor.h"
 #include "editor/translations/editor_translation_parser.h"
-#include "scene/3d/camera_3d.h"
 #include "scene/gui/popup_menu.h"
+#ifndef _3D_DISABLED
+#include "editor/import/3d/resource_importer_scene.h"
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "scene/3d/camera_3d.h"
+#endif // _3D_DISABLED
 
 void EditorPlugin::add_custom_type(const String &p_type, const String &p_base, const Ref<Script> &p_script, const Ref<Texture2D> &p_icon) {
 	EditorNode::get_editor_data().add_custom_type(p_type, p_base, p_script, p_icon);
@@ -147,6 +148,7 @@ void EditorPlugin::add_control_to_container(CustomControlContainer p_location, C
 			EditorNode::get_title_bar()->add_child(p_control);
 		} break;
 
+#ifndef _3D_DISABLED
 		case CONTAINER_SPATIAL_EDITOR_MENU: {
 			Node3DEditor::get_singleton()->add_control_to_menu_panel(p_control);
 
@@ -161,6 +163,7 @@ void EditorPlugin::add_control_to_container(CustomControlContainer p_location, C
 			Node3DEditor::get_singleton()->get_shader_split()->add_child(p_control);
 
 		} break;
+#endif // _3D_DISABLED
 		case CONTAINER_CANVAS_EDITOR_MENU: {
 			CanvasItemEditor::get_singleton()->add_control_to_menu_panel(p_control);
 
@@ -188,6 +191,9 @@ void EditorPlugin::add_control_to_container(CustomControlContainer p_location, C
 			ProjectSettingsEditor::get_singleton()->get_tabs()->add_child(p_control);
 
 		} break;
+
+		default: {
+		} break;
 	}
 }
 
@@ -199,6 +205,7 @@ void EditorPlugin::remove_control_from_container(CustomControlContainer p_locati
 			EditorNode::get_title_bar()->remove_child(p_control);
 		} break;
 
+#ifndef _3D_DISABLED
 		case CONTAINER_SPATIAL_EDITOR_MENU: {
 			Node3DEditor::get_singleton()->remove_control_from_menu_panel(p_control);
 
@@ -213,6 +220,8 @@ void EditorPlugin::remove_control_from_container(CustomControlContainer p_locati
 			Node3DEditor::get_singleton()->get_shader_split()->remove_child(p_control);
 
 		} break;
+#endif // _3D_DISABLED
+
 		case CONTAINER_CANVAS_EDITOR_MENU: {
 			CanvasItemEditor::get_singleton()->remove_control_from_menu_panel(p_control);
 
@@ -235,6 +244,9 @@ void EditorPlugin::remove_control_from_container(CustomControlContainer p_locati
 		case CONTAINER_PROJECT_SETTING_TAB_RIGHT: {
 			ProjectSettingsEditor::get_singleton()->get_tabs()->remove_child(p_control);
 
+		} break;
+
+		default: {
 		} break;
 	}
 }
@@ -307,6 +319,7 @@ void EditorPlugin::forward_canvas_force_draw_over_viewport(Control *p_overlay) {
 
 // Updates the overlays of the 2D viewport or, if in 3D mode, of every 3D viewport.
 int EditorPlugin::update_overlays() const {
+#ifndef _3D_DISABLED
 	if (Node3DEditor::get_singleton()->is_visible()) {
 		int count = 0;
 		for (uint32_t i = 0; i < Node3DEditor::VIEWPORTS_COUNT; i++) {
@@ -318,12 +331,17 @@ int EditorPlugin::update_overlays() const {
 		}
 		return count;
 	} else {
+#endif // _3D_DISABLED
+
 		// This will update the normal viewport itself as well
 		CanvasItemEditor::get_singleton()->get_viewport_control()->queue_redraw();
 		return 1;
+#ifndef _3D_DISABLED
 	}
+#endif // _3D_DISABLED
 }
 
+#ifndef _3D_DISABLED
 EditorPlugin::AfterGUIInput EditorPlugin::forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) {
 	int success = EditorPlugin::AFTER_GUI_INPUT_PASS;
 	GDVIRTUAL_CALL(_forward_3d_gui_input, p_camera, p_event, success);
@@ -337,6 +355,7 @@ void EditorPlugin::forward_3d_draw_over_viewport(Control *p_overlay) {
 void EditorPlugin::forward_3d_force_draw_over_viewport(Control *p_overlay) {
 	GDVIRTUAL_CALL(_forward_3d_force_draw_over_viewport, p_overlay);
 }
+#endif // _3D_DISABLED
 
 String EditorPlugin::get_plugin_name() const {
 	String name;
@@ -482,6 +501,7 @@ void EditorPlugin::remove_export_platform(const Ref<EditorExportPlatform> &p_pla
 	EditorExport::get_singleton()->remove_export_platform(p_platform);
 }
 
+#ifndef _3D_DISABLED
 void EditorPlugin::add_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin) {
 	ERR_FAIL_COND(p_gizmo_plugin.is_null());
 	Node3DEditor::get_singleton()->add_gizmo_plugin(p_gizmo_plugin);
@@ -509,6 +529,7 @@ void EditorPlugin::add_scene_post_import_plugin(const Ref<EditorScenePostImportP
 void EditorPlugin::remove_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin) {
 	ResourceImporterScene::remove_post_importer_plugin(p_plugin);
 }
+#endif // _3D_DISABLED
 
 void EditorPlugin::add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin) {
 	ERR_FAIL_COND(p_plugin.is_null());
@@ -682,12 +703,14 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_context_menu_plugin", "slot", "plugin"), &EditorPlugin::add_context_menu_plugin);
 	ClassDB::bind_method(D_METHOD("remove_context_menu_plugin", "plugin"), &EditorPlugin::remove_context_menu_plugin);
 
+#ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("add_node_3d_gizmo_plugin", "plugin"), &EditorPlugin::add_node_3d_gizmo_plugin);
 	ClassDB::bind_method(D_METHOD("remove_node_3d_gizmo_plugin", "plugin"), &EditorPlugin::remove_node_3d_gizmo_plugin);
 	ClassDB::bind_method(D_METHOD("add_scene_format_importer_plugin", "scene_format_importer", "first_priority"), &EditorPlugin::add_scene_format_importer_plugin, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_scene_format_importer_plugin", "scene_format_importer"), &EditorPlugin::remove_scene_format_importer_plugin);
 	ClassDB::bind_method(D_METHOD("add_scene_post_import_plugin", "scene_import_plugin", "first_priority"), &EditorPlugin::add_scene_post_import_plugin, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_scene_post_import_plugin", "scene_import_plugin"), &EditorPlugin::remove_scene_post_import_plugin);
+#endif // _3D_DISABLED
 
 	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorPlugin::get_editor_interface);
 	ClassDB::bind_method(D_METHOD("get_script_create_dialog"), &EditorPlugin::get_script_create_dialog);
@@ -698,9 +721,11 @@ void EditorPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_forward_canvas_gui_input, "event");
 	GDVIRTUAL_BIND(_forward_canvas_draw_over_viewport, "viewport_control");
 	GDVIRTUAL_BIND(_forward_canvas_force_draw_over_viewport, "viewport_control");
+#ifndef _3D_DISABLED
 	GDVIRTUAL_BIND(_forward_3d_gui_input, "viewport_camera", "event");
 	GDVIRTUAL_BIND(_forward_3d_draw_over_viewport, "viewport_control");
 	GDVIRTUAL_BIND(_forward_3d_force_draw_over_viewport, "viewport_control");
+#endif // _3D_DISABLED
 	GDVIRTUAL_BIND(_get_plugin_name);
 	GDVIRTUAL_BIND(_get_plugin_icon);
 	GDVIRTUAL_BIND(_has_main_screen);

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -32,11 +32,15 @@
 
 #include "core/io/config_file.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
-#include "scene/3d/camera_3d.h"
 #include "scene/gui/control.h"
 #include "scene/main/node.h"
 
+#ifndef _3D_DISABLED
+#include "scene/3d/camera_3d.h"
+
 class Node3D;
+#endif // _3D_DISABLED
+
 class Button;
 class PopupMenu;
 class EditorDebuggerPlugin;
@@ -122,9 +126,11 @@ protected:
 	GDVIRTUAL1R(bool, _forward_canvas_gui_input, Ref<InputEvent>)
 	GDVIRTUAL1(_forward_canvas_draw_over_viewport, Control *)
 	GDVIRTUAL1(_forward_canvas_force_draw_over_viewport, Control *)
+#ifndef _3D_DISABLED
 	GDVIRTUAL2R(int, _forward_3d_gui_input, Camera3D *, Ref<InputEvent>)
 	GDVIRTUAL1(_forward_3d_draw_over_viewport, Control *)
 	GDVIRTUAL1(_forward_3d_force_draw_over_viewport, Control *)
+#endif // _3D_DISABLED
 	GDVIRTUAL0RC(String, _get_plugin_name)
 	GDVIRTUAL0RC(Ref<Texture2D>, _get_plugin_icon)
 	GDVIRTUAL0RC(bool, _has_main_screen)
@@ -189,9 +195,11 @@ public:
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay);
 	virtual void forward_canvas_force_draw_over_viewport(Control *p_overlay);
 
+#ifndef _3D_DISABLED
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event);
 	virtual void forward_3d_draw_over_viewport(Control *p_overlay);
 	virtual void forward_3d_force_draw_over_viewport(Control *p_overlay);
+#endif // _3D_DISABLED
 
 	virtual String get_plugin_name() const;
 	virtual const Ref<Texture2D> get_plugin_icon() const;
@@ -242,17 +250,19 @@ public:
 	void add_export_platform(const Ref<EditorExportPlatform> &p_platform);
 	void remove_export_platform(const Ref<EditorExportPlatform> &p_platform);
 
-	void add_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
-	void remove_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
-
 	void add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
 	void remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
+
+#ifndef _3D_DISABLED
+	void add_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
+	void remove_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
 
 	void add_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer, bool p_first_priority = false);
 	void remove_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer);
 
 	void add_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_importer, bool p_first_priority = false);
 	void remove_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_importer);
+#endif // _3D_DISABLED
 
 	void add_autoload_singleton(const String &p_name, const String &p_path);
 	void remove_autoload_singleton(const String &p_name);

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -32,11 +32,15 @@
 
 #include "core/io/config_file.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
-#include "scene/3d/camera_3d.h"
 #include "scene/gui/control.h"
 #include "scene/main/node.h"
 
+#ifndef _3D_DISABLED
+#include "scene/3d/camera_3d.h"
+
 class Node3D;
+#endif // _3D_DISABLED
+
 class Button;
 class PopupMenu;
 class EditorDebuggerPlugin;
@@ -122,9 +126,11 @@ protected:
 	GDVIRTUAL1R(bool, _forward_canvas_gui_input, Ref<InputEvent>)
 	GDVIRTUAL1(_forward_canvas_draw_over_viewport, Control *)
 	GDVIRTUAL1(_forward_canvas_force_draw_over_viewport, Control *)
+#ifndef _3D_DISABLED
 	GDVIRTUAL2R(int, _forward_3d_gui_input, Camera3D *, Ref<InputEvent>)
 	GDVIRTUAL1(_forward_3d_draw_over_viewport, Control *)
 	GDVIRTUAL1(_forward_3d_force_draw_over_viewport, Control *)
+#endif // _3D_DISABLED
 	GDVIRTUAL0RC(String, _get_plugin_name)
 	GDVIRTUAL0RC(Ref<Texture2D>, _get_plugin_icon)
 	GDVIRTUAL0RC(bool, _has_main_screen)
@@ -189,9 +195,11 @@ public:
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay);
 	virtual void forward_canvas_force_draw_over_viewport(Control *p_overlay);
 
+#ifndef _3D_DISABLED
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event);
 	virtual void forward_3d_draw_over_viewport(Control *p_overlay);
 	virtual void forward_3d_force_draw_over_viewport(Control *p_overlay);
+#endif // _3D_DISABLED
 
 	virtual String get_plugin_name() const;
 	virtual const Ref<Texture2D> get_plugin_icon() const;
@@ -242,6 +250,7 @@ public:
 	void add_export_platform(const Ref<EditorExportPlatform> &p_platform);
 	void remove_export_platform(const Ref<EditorExportPlatform> &p_platform);
 
+#ifndef _3D_DISABLED
 	void add_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
 	void remove_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
 
@@ -250,6 +259,7 @@ public:
 
 	void add_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_importer, bool p_first_priority = false);
 	void remove_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_importer);
+#endif // _3D_DISABLED
 
 	void add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
 	void remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);

--- a/editor/plugins/editor_plugin_list.cpp
+++ b/editor/plugins/editor_plugin_list.cpp
@@ -42,6 +42,19 @@ bool EditorPluginList::forward_gui_input(const Ref<InputEvent> &p_event) const {
 	return discard;
 }
 
+void EditorPluginList::forward_canvas_draw_over_viewport(Control *p_overlay) const {
+	for (EditorPlugin *plugin : plugins_list) {
+		plugin->forward_canvas_draw_over_viewport(p_overlay);
+	}
+}
+
+void EditorPluginList::forward_canvas_force_draw_over_viewport(Control *p_overlay) const {
+	for (EditorPlugin *plugin : plugins_list) {
+		plugin->forward_canvas_force_draw_over_viewport(p_overlay);
+	}
+}
+
+#ifndef _3D_DISABLED
 EditorPlugin::AfterGUIInput EditorPluginList::forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event, bool p_serve_when_force_input_enabled) const {
 	EditorPlugin::AfterGUIInput after = EditorPlugin::AFTER_GUI_INPUT_PASS;
 
@@ -62,18 +75,6 @@ EditorPlugin::AfterGUIInput EditorPluginList::forward_3d_gui_input(Camera3D *p_c
 	return after;
 }
 
-void EditorPluginList::forward_canvas_draw_over_viewport(Control *p_overlay) const {
-	for (EditorPlugin *plugin : plugins_list) {
-		plugin->forward_canvas_draw_over_viewport(p_overlay);
-	}
-}
-
-void EditorPluginList::forward_canvas_force_draw_over_viewport(Control *p_overlay) const {
-	for (EditorPlugin *plugin : plugins_list) {
-		plugin->forward_canvas_force_draw_over_viewport(p_overlay);
-	}
-}
-
 void EditorPluginList::forward_3d_draw_over_viewport(Control *p_overlay) const {
 	for (EditorPlugin *plugin : plugins_list) {
 		plugin->forward_3d_draw_over_viewport(p_overlay);
@@ -85,6 +86,7 @@ void EditorPluginList::forward_3d_force_draw_over_viewport(Control *p_overlay) c
 		plugin->forward_3d_force_draw_over_viewport(p_overlay);
 	}
 }
+#endif // _3D_DISABLED
 
 void EditorPluginList::add_plugin(EditorPlugin *p_plugin) {
 	ERR_FAIL_COND(plugins_list.has(p_plugin));

--- a/editor/plugins/editor_plugin_list.h
+++ b/editor/plugins/editor_plugin_list.h
@@ -42,9 +42,11 @@ public:
 	bool forward_gui_input(const Ref<InputEvent> &p_event) const;
 	void forward_canvas_draw_over_viewport(Control *p_overlay) const;
 	void forward_canvas_force_draw_over_viewport(Control *p_overlay) const;
+#ifndef _3D_DISABLED
 	EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event, bool p_serve_when_force_input_enabled) const;
 	void forward_3d_draw_over_viewport(Control *p_overlay) const;
 	void forward_3d_force_draw_over_viewport(Control *p_overlay) const;
+#endif // _3D_DISABLED
 
 	void add_plugin(EditorPlugin *p_plugin);
 	void remove_plugin(EditorPlugin *p_plugin);

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1326,8 +1326,13 @@ ProjectManager::ProjectManager() {
 	singleton = this;
 
 	// Turn off some servers we aren't going to be using in the Project Manager.
+
+#ifndef NAVIGATION_3D_DISABLED
 	NavigationServer3D::get_singleton()->set_active(false);
+#endif // NAVIGATION_3D_DISABLED
+#ifndef PHYSICS_3D_DISABLED
 	PhysicsServer3D::get_singleton()->set_active(false);
+#endif // PHYSICS_3D_DISABLED
 	PhysicsServer2D::get_singleton()->set_active(false);
 
 	// Initialize settings.

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1368,8 +1368,13 @@ ProjectManager::ProjectManager() {
 	singleton = this;
 
 	// Turn off some servers we aren't going to be using in the Project Manager.
+
+#ifndef NAVIGATION_3D_DISABLED
 	NavigationServer3D::get_singleton()->set_active(false);
+#endif // NAVIGATION_3D_DISABLED
+#ifndef PHYSICS_3D_DISABLED
 	PhysicsServer3D::get_singleton()->set_active(false);
+#endif // PHYSICS_3D_DISABLED
 	PhysicsServer2D::get_singleton()->set_active(false);
 
 	// Initialize settings.

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -57,8 +57,6 @@
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_spin_slider.h"
 #include "editor/gui/editor_toaster.h"
-#include "editor/import/3d/resource_importer_obj.h"
-#include "editor/import/3d/resource_importer_scene.h"
 #include "editor/import/editor_import_plugin.h"
 #include "editor/import/resource_importer_bitmask.h"
 #include "editor/import/resource_importer_bmfont.h"
@@ -92,22 +90,6 @@
 #include "editor/scene/2d/skeleton_2d_editor_plugin.h"
 #include "editor/scene/2d/sprite_2d_editor_plugin.h"
 #include "editor/scene/2d/tiles/tiles_editor_plugin.h"
-#include "editor/scene/3d/bone_map_editor_plugin.h"
-#include "editor/scene/3d/camera_3d_editor_plugin.h"
-#include "editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.h"
-#include "editor/scene/3d/lightmap_gi_editor_plugin.h"
-#include "editor/scene/3d/mesh_editor_plugin.h"
-#include "editor/scene/3d/mesh_instance_3d_editor_plugin.h"
-#include "editor/scene/3d/mesh_library_editor_plugin.h"
-#include "editor/scene/3d/multimesh_editor_plugin.h"
-#include "editor/scene/3d/node_3d_editor_gizmos.h"
-#include "editor/scene/3d/occluder_instance_3d_editor_plugin.h"
-#include "editor/scene/3d/particles_3d_editor_plugin.h"
-#include "editor/scene/3d/path_3d_editor_plugin.h"
-#include "editor/scene/3d/physics/physical_bone_3d_editor_plugin.h"
-#include "editor/scene/3d/polygon_3d_editor_plugin.h"
-#include "editor/scene/3d/skeleton_3d_editor_plugin.h"
-#include "editor/scene/3d/voxel_gi_editor_plugin.h"
 #include "editor/scene/curve_editor_plugin.h"
 #include "editor/scene/gradient_editor_plugin.h"
 #include "editor/scene/gui/control_editor_plugin.h"
@@ -141,8 +123,33 @@
 
 #ifndef DISABLE_DEPRECATED
 #include "editor/scene/2d/parallax_background_editor_plugin.h"
+#endif
+
+#ifndef _3D_DISABLED
+#include "editor/import/3d/resource_importer_obj.h"
+#include "editor/import/3d/resource_importer_scene.h"
+#include "editor/scene/3d/bone_map_editor_plugin.h"
+#include "editor/scene/3d/camera_3d_editor_plugin.h"
+#include "editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.h"
+#include "editor/scene/3d/lightmap_gi_editor_plugin.h"
+#include "editor/scene/3d/mesh_editor_plugin.h"
+#include "editor/scene/3d/mesh_instance_3d_editor_plugin.h"
+#include "editor/scene/3d/mesh_library_editor_plugin.h"
+#include "editor/scene/3d/multimesh_editor_plugin.h"
+#include "editor/scene/3d/node_3d_editor_gizmos.h"
+#include "editor/scene/3d/occluder_instance_3d_editor_plugin.h"
+#include "editor/scene/3d/particles_3d_editor_plugin.h"
+#include "editor/scene/3d/path_3d_editor_plugin.h"
+#include "editor/scene/3d/polygon_3d_editor_plugin.h"
+#include "editor/scene/3d/skeleton_3d_editor_plugin.h"
+#include "editor/scene/3d/voxel_gi_editor_plugin.h"
+#ifndef PHYSICS_3D_DISABLED
+#include "editor/scene/3d/physics/physical_bone_3d_editor_plugin.h"
+#endif // PHYSICS_3D_DISABLED
+#ifndef DISABLE_DEPRECATED
 #include "editor/scene/3d/skeleton_ik_3d_editor_plugin.h"
 #endif
+#endif // _3D_DISABLED
 
 void register_editor_types() {
 	OS::get_singleton()->benchmark_begin_measure("Editor", "Register Types");
@@ -162,8 +169,10 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorFileDialog);
 	GDREGISTER_VIRTUAL_CLASS(EditorSettings);
 	GDREGISTER_ABSTRACT_CLASS(EditorToaster);
+#ifndef _3D_DISABLED
 	GDREGISTER_CLASS(EditorNode3DGizmo);
 	GDREGISTER_CLASS(EditorNode3DGizmoPlugin);
+#endif // _3D_DISABLED
 	GDREGISTER_ABSTRACT_CLASS(EditorResourcePreview);
 	GDREGISTER_CLASS(EditorResourcePreviewGenerator);
 	GDREGISTER_CLASS(EditorResourceTooltipPlugin);
@@ -184,8 +193,10 @@ void register_editor_types() {
 	register_exporter_types();
 
 	GDREGISTER_CLASS(EditorResourceConversionPlugin);
+#ifndef _3D_DISABLED
 	GDREGISTER_CLASS(EditorSceneFormatImporter);
 	GDREGISTER_CLASS(EditorScenePostImportPlugin);
+#endif // _3D_DISABLED
 	GDREGISTER_CLASS(EditorInspector);
 	GDREGISTER_CLASS(EditorInspectorPlugin);
 	GDREGISTER_CLASS(EditorProperty);
@@ -200,7 +211,9 @@ void register_editor_types() {
 	GDREGISTER_ABSTRACT_CLASS(FileSystemDock);
 	GDREGISTER_VIRTUAL_CLASS(EditorFileSystemImportFormatSupportQuery);
 
+#ifndef _3D_DISABLED
 	GDREGISTER_CLASS(EditorScenePostImport);
+#endif // _3D_DISABLED
 	GDREGISTER_VIRTUAL_CLASS(EditorCommandPalette);
 	GDREGISTER_CLASS(EditorDebuggerPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorDebuggerSession);
@@ -214,8 +227,10 @@ void register_editor_types() {
 	GDREGISTER_CLASS(ResourceImporterImageFont);
 	GDREGISTER_CLASS(ResourceImporterSVG);
 	GDREGISTER_CLASS(ResourceImporterLayeredTexture);
+#ifndef _3D_DISABLED
 	GDREGISTER_CLASS(ResourceImporterOBJ);
 	GDREGISTER_CLASS(ResourceImporterScene);
+#endif // _3D_DISABLED
 	GDREGISTER_CLASS(ResourceImporterShaderFile);
 	GDREGISTER_CLASS(ResourceImporterTexture);
 	GDREGISTER_CLASS(ResourceImporterTextureAtlas);
@@ -226,37 +241,25 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<AudioStreamEditorPlugin>();
 	EditorPlugins::add_by_type<AudioStreamRandomizerEditorPlugin>();
 	EditorPlugins::add_by_type<BitMapEditorPlugin>();
-	EditorPlugins::add_by_type<BoneMapEditorPlugin>();
-	EditorPlugins::add_by_type<Camera3DEditorPlugin>();
 	EditorPlugins::add_by_type<ControlEditorPlugin>();
-	EditorPlugins::add_by_type<CPUParticles3DEditorPlugin>();
 	EditorPlugins::add_by_type<CurveEditorPlugin>();
 	if (!Engine::get_singleton()->is_recovery_mode_hint()) {
 		EditorPlugins::add_by_type<DebugAdapterServer>();
 	}
 	EditorPlugins::add_by_type<EditorScriptPlugin>();
 	EditorPlugins::add_by_type<FontEditorPlugin>();
-	EditorPlugins::add_by_type<GPUParticles3DEditorPlugin>();
-	EditorPlugins::add_by_type<GPUParticlesCollisionSDF3DEditorPlugin>();
 	EditorPlugins::add_by_type<GradientEditorPlugin>();
 	EditorPlugins::add_by_type<GradientTexture2DEditorPlugin>();
 	EditorPlugins::add_by_type<InputEventEditorPlugin>();
-	EditorPlugins::add_by_type<LightmapGIEditorPlugin>();
 	EditorPlugins::add_by_type<MarginContainerEditorPlugin>();
 	EditorPlugins::add_by_type<MaterialEditorPlugin>();
-	EditorPlugins::add_by_type<MeshEditorPlugin>();
-	EditorPlugins::add_by_type<MeshInstance3DEditorPlugin>();
-	EditorPlugins::add_by_type<MeshLibraryEditorPlugin>();
-	EditorPlugins::add_by_type<MultiMeshEditorPlugin>();
-	EditorPlugins::add_by_type<OccluderInstance3DEditorPlugin>();
 	EditorPlugins::add_by_type<PackedSceneEditorPlugin>();
-	EditorPlugins::add_by_type<Path3DEditorPlugin>();
+#ifndef PHYSICS_3D_DISABLED
 	EditorPlugins::add_by_type<PhysicalBone3DEditorPlugin>();
-	EditorPlugins::add_by_type<Polygon3DEditorPlugin>();
+#endif // PHYSICS_3D_DISABLED
 	EditorPlugins::add_by_type<ResourcePreloaderEditorPlugin>();
 	EditorPlugins::add_by_type<ShaderEditorPlugin>();
 	EditorPlugins::add_by_type<ShaderFileEditorPlugin>();
-	EditorPlugins::add_by_type<Skeleton3DEditorPlugin>();
 	EditorPlugins::add_by_type<SpriteFramesEditorPlugin>();
 	EditorPlugins::add_by_type<StyleBoxEditorPlugin>();
 	EditorPlugins::add_by_type<SubViewportPreviewEditorPlugin>();
@@ -267,10 +270,26 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<ThemeEditorPlugin>();
 	EditorPlugins::add_by_type<ToolButtonEditorPlugin>();
 	EditorPlugins::add_by_type<VirtualJoystickEditorPlugin>();
+#ifndef _3D_DISABLED
+	EditorPlugins::add_by_type<BoneMapEditorPlugin>();
+	EditorPlugins::add_by_type<Camera3DEditorPlugin>();
+	EditorPlugins::add_by_type<CPUParticles3DEditorPlugin>();
+	EditorPlugins::add_by_type<GPUParticles3DEditorPlugin>();
+	EditorPlugins::add_by_type<GPUParticlesCollisionSDF3DEditorPlugin>();
+	EditorPlugins::add_by_type<LightmapGIEditorPlugin>();
+	EditorPlugins::add_by_type<MeshEditorPlugin>();
+	EditorPlugins::add_by_type<MeshInstance3DEditorPlugin>();
+	EditorPlugins::add_by_type<MeshLibraryEditorPlugin>();
+	EditorPlugins::add_by_type<MultiMeshEditorPlugin>();
+	EditorPlugins::add_by_type<OccluderInstance3DEditorPlugin>();
+	EditorPlugins::add_by_type<Path3DEditorPlugin>();
+	EditorPlugins::add_by_type<Polygon3DEditorPlugin>();
+	EditorPlugins::add_by_type<Skeleton3DEditorPlugin>();
 	EditorPlugins::add_by_type<VoxelGIEditorPlugin>();
 #ifndef DISABLE_DEPRECATED
 	EditorPlugins::add_by_type<SkeletonIK3DEditorPlugin>();
 #endif
+#endif // _3D_DISABLED
 
 	// 2D
 	EditorPlugins::add_by_type<Camera2DEditorPlugin>();

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -56,8 +56,6 @@
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_spin_slider.h"
 #include "editor/gui/editor_toaster.h"
-#include "editor/import/3d/resource_importer_obj.h"
-#include "editor/import/3d/resource_importer_scene.h"
 #include "editor/import/editor_import_plugin.h"
 #include "editor/import/resource_importer_bitmask.h"
 #include "editor/import/resource_importer_bmfont.h"
@@ -91,22 +89,6 @@
 #include "editor/scene/2d/scene_paint_2d_editor_plugin.h"
 #include "editor/scene/2d/skeleton_2d_editor_plugin.h"
 #include "editor/scene/2d/sprite_2d_editor_plugin.h"
-#include "editor/scene/3d/bone_map_editor_plugin.h"
-#include "editor/scene/3d/camera_3d_editor_plugin.h"
-#include "editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.h"
-#include "editor/scene/3d/lightmap_gi_editor_plugin.h"
-#include "editor/scene/3d/mesh_editor_plugin.h"
-#include "editor/scene/3d/mesh_instance_3d_editor_plugin.h"
-#include "editor/scene/3d/mesh_library_editor_plugin.h"
-#include "editor/scene/3d/multimesh_editor_plugin.h"
-#include "editor/scene/3d/node_3d_editor_gizmos.h"
-#include "editor/scene/3d/occluder_instance_3d_editor_plugin.h"
-#include "editor/scene/3d/particles_3d_editor_plugin.h"
-#include "editor/scene/3d/path_3d_editor_plugin.h"
-#include "editor/scene/3d/physics/physical_bone_3d_editor_plugin.h"
-#include "editor/scene/3d/polygon_3d_editor_plugin.h"
-#include "editor/scene/3d/skeleton_3d_editor_plugin.h"
-#include "editor/scene/3d/voxel_gi_editor_plugin.h"
 #include "editor/scene/curve_editor_plugin.h"
 #include "editor/scene/gradient_editor_plugin.h"
 #include "editor/scene/gui/control_editor_plugin.h"
@@ -140,8 +122,33 @@
 
 #ifndef DISABLE_DEPRECATED
 #include "editor/scene/2d/parallax_background_editor_plugin.h"
+#endif // DISABLE_DEPRECATED
+
+#ifndef _3D_DISABLED
+#include "editor/import/3d/resource_importer_obj.h"
+#include "editor/import/3d/resource_importer_scene.h"
+#include "editor/scene/3d/bone_map_editor_plugin.h"
+#include "editor/scene/3d/camera_3d_editor_plugin.h"
+#include "editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.h"
+#include "editor/scene/3d/lightmap_gi_editor_plugin.h"
+#include "editor/scene/3d/mesh_editor_plugin.h"
+#include "editor/scene/3d/mesh_instance_3d_editor_plugin.h"
+#include "editor/scene/3d/mesh_library_editor_plugin.h"
+#include "editor/scene/3d/multimesh_editor_plugin.h"
+#include "editor/scene/3d/node_3d_editor_gizmos.h"
+#include "editor/scene/3d/occluder_instance_3d_editor_plugin.h"
+#include "editor/scene/3d/particles_3d_editor_plugin.h"
+#include "editor/scene/3d/path_3d_editor_plugin.h"
+#include "editor/scene/3d/polygon_3d_editor_plugin.h"
+#include "editor/scene/3d/skeleton_3d_editor_plugin.h"
+#include "editor/scene/3d/voxel_gi_editor_plugin.h"
+#ifndef PHYSICS_3D_DISABLED
+#include "editor/scene/3d/physics/physical_bone_3d_editor_plugin.h"
+#endif // PHYSICS_3D_DISABLED
+#ifndef DISABLE_DEPRECATED
 #include "editor/scene/3d/skeleton_ik_3d_editor_plugin.h"
 #endif
+#endif // _3D_DISABLED
 
 void register_editor_types() {
 	OS::get_singleton()->benchmark_begin_measure("Editor", "Register Types");
@@ -162,6 +169,10 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorFileDialog);
 	GDREGISTER_VIRTUAL_CLASS(EditorSettings);
 	GDREGISTER_ABSTRACT_CLASS(EditorToaster);
+#ifndef _3D_DISABLED
+	GDREGISTER_CLASS(EditorNode3DGizmo);
+	GDREGISTER_CLASS(EditorNode3DGizmoPlugin);
+#endif // _3D_DISABLED
 	GDREGISTER_ABSTRACT_CLASS(EditorResourcePreview);
 	GDREGISTER_CLASS(EditorResourcePreviewGenerator);
 	GDREGISTER_CLASS(EditorResourceTooltipPlugin);
@@ -182,6 +193,10 @@ void register_editor_types() {
 	register_exporter_types();
 
 	GDREGISTER_CLASS(EditorResourceConversionPlugin);
+#ifndef _3D_DISABLED
+	GDREGISTER_CLASS(EditorSceneFormatImporter);
+	GDREGISTER_CLASS(EditorScenePostImportPlugin);
+#endif // _3D_DISABLED
 	GDREGISTER_CLASS(EditorInspector);
 	GDREGISTER_CLASS(EditorInspectorPlugin);
 	GDREGISTER_CLASS(EditorProperty);
@@ -196,16 +211,12 @@ void register_editor_types() {
 	GDREGISTER_ABSTRACT_CLASS(FileSystemDock);
 	GDREGISTER_VIRTUAL_CLASS(EditorFileSystemImportFormatSupportQuery);
 
+#ifndef _3D_DISABLED
+	GDREGISTER_CLASS(EditorScenePostImport);
+#endif // _3D_DISABLED
 	GDREGISTER_VIRTUAL_CLASS(EditorCommandPalette);
 	GDREGISTER_CLASS(EditorDebuggerPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorDebuggerSession);
-
-	// 3D editor foundational classes.
-	GDREGISTER_CLASS(EditorNode3DGizmo);
-	GDREGISTER_CLASS(EditorNode3DGizmoPlugin);
-	GDREGISTER_CLASS(EditorSceneFormatImporter);
-	GDREGISTER_CLASS(EditorScenePostImportPlugin);
-	GDREGISTER_CLASS(EditorScenePostImport);
 
 	// Required to document import options in the class reference.
 	GDREGISTER_CLASS(ResourceImporterBitMap);
@@ -216,8 +227,10 @@ void register_editor_types() {
 	GDREGISTER_CLASS(ResourceImporterImageFont);
 	GDREGISTER_CLASS(ResourceImporterSVG);
 	GDREGISTER_CLASS(ResourceImporterLayeredTexture);
+#ifndef _3D_DISABLED
 	GDREGISTER_CLASS(ResourceImporterOBJ);
 	GDREGISTER_CLASS(ResourceImporterScene);
+#endif // _3D_DISABLED
 	GDREGISTER_CLASS(ResourceImporterShaderFile);
 	GDREGISTER_CLASS(ResourceImporterTexture);
 	GDREGISTER_CLASS(ResourceImporterTextureAtlas);
@@ -241,6 +254,9 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<MarginContainerEditorPlugin>();
 	EditorPlugins::add_by_type<MaterialEditorPlugin>();
 	EditorPlugins::add_by_type<PackedSceneEditorPlugin>();
+#ifndef PHYSICS_3D_DISABLED
+	EditorPlugins::add_by_type<PhysicalBone3DEditorPlugin>();
+#endif // PHYSICS_3D_DISABLED
 	EditorPlugins::add_by_type<ResourcePreloaderEditorPlugin>();
 	EditorPlugins::add_by_type<ShaderEditorPlugin>();
 	EditorPlugins::add_by_type<ShaderFileEditorPlugin>();
@@ -254,6 +270,26 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<ThemeEditorPlugin>();
 	EditorPlugins::add_by_type<ToolButtonEditorPlugin>();
 	EditorPlugins::add_by_type<VirtualJoystickEditorPlugin>();
+#ifndef _3D_DISABLED
+	EditorPlugins::add_by_type<BoneMapEditorPlugin>();
+	EditorPlugins::add_by_type<Camera3DEditorPlugin>();
+	EditorPlugins::add_by_type<CPUParticles3DEditorPlugin>();
+	EditorPlugins::add_by_type<GPUParticles3DEditorPlugin>();
+	EditorPlugins::add_by_type<GPUParticlesCollisionSDF3DEditorPlugin>();
+	EditorPlugins::add_by_type<LightmapGIEditorPlugin>();
+	EditorPlugins::add_by_type<MeshEditorPlugin>();
+	EditorPlugins::add_by_type<MeshInstance3DEditorPlugin>();
+	EditorPlugins::add_by_type<MeshLibraryEditorPlugin>();
+	EditorPlugins::add_by_type<MultiMeshEditorPlugin>();
+	EditorPlugins::add_by_type<OccluderInstance3DEditorPlugin>();
+	EditorPlugins::add_by_type<Path3DEditorPlugin>();
+	EditorPlugins::add_by_type<Polygon3DEditorPlugin>();
+	EditorPlugins::add_by_type<Skeleton3DEditorPlugin>();
+	EditorPlugins::add_by_type<VoxelGIEditorPlugin>();
+#ifndef DISABLE_DEPRECATED
+	EditorPlugins::add_by_type<SkeletonIK3DEditorPlugin>();
+#endif
+#endif // _3D_DISABLED
 
 	// Node2D-based editor plugins.
 	EditorPlugins::add_by_type<Camera2DEditorPlugin>();
@@ -272,28 +308,6 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<CollisionShape2DEditorPlugin>();
 #ifndef DISABLE_DEPRECATED
 	EditorPlugins::add_by_type<ParallaxBackgroundEditorPlugin>();
-#endif
-
-	// 3D editor plugins.
-	EditorPlugins::add_by_type<BoneMapEditorPlugin>();
-	EditorPlugins::add_by_type<Camera3DEditorPlugin>();
-	EditorPlugins::add_by_type<CPUParticles3DEditorPlugin>();
-	EditorPlugins::add_by_type<GPUParticles3DEditorPlugin>();
-	EditorPlugins::add_by_type<GPUParticlesCollisionSDF3DEditorPlugin>();
-	EditorPlugins::add_by_type<LightmapGIEditorPlugin>();
-	EditorPlugins::add_by_type<MeshEditorPlugin>();
-	EditorPlugins::add_by_type<MeshInstance3DEditorPlugin>();
-	EditorPlugins::add_by_type<MeshLibraryEditorPlugin>();
-	EditorPlugins::add_by_type<OccluderInstance3DEditorPlugin>();
-	EditorPlugins::add_by_type<MultiMeshEditorPlugin>();
-	EditorPlugins::add_by_type<Path3DEditorPlugin>();
-	EditorPlugins::add_by_type<Polygon3DEditorPlugin>();
-	EditorPlugins::add_by_type<Skeleton3DEditorPlugin>();
-	EditorPlugins::add_by_type<VoxelGIEditorPlugin>();
-	// 3D physics editor plugins.
-	EditorPlugins::add_by_type<PhysicalBone3DEditorPlugin>();
-#ifndef DISABLE_DEPRECATED
-	EditorPlugins::add_by_type<SkeletonIK3DEditorPlugin>();
 #endif
 
 	// For correct doc generation.

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -425,7 +425,9 @@ void EditorRunBar::play_current_scene(bool p_reload, const Vector<String> &p_pla
 
 	String last_current_scene = run_current_filename; // This is necessary to have a copy of the string.
 
+#ifndef _3D_DISABLED
 	EditorNode::get_singleton()->save_default_environment();
+#endif // _3D_DISABLED
 	stop_playing();
 
 	current_mode = RunMode::RUN_CURRENT;

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -436,7 +436,9 @@ void EditorRunBar::play_current_scene(bool p_reload, const Vector<String> &p_pla
 
 	String last_current_scene = run_current_filename; // This is necessary to have a copy of the string.
 
+#ifndef _3D_DISABLED
 	EditorNode::get_singleton()->save_default_environment();
+#endif // _3D_DISABLED
 	stop_playing();
 
 	current_mode = RunMode::RUN_CURRENT;

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -330,6 +330,7 @@ void GameViewDebugger::reset_camera_2d_position() {
 	}
 }
 
+#ifndef _3D_DISABLED
 void GameViewDebugger::reset_camera_3d_position() {
 	for (Ref<EditorDebuggerSession> &I : sessions) {
 		if (I->is_active()) {
@@ -337,6 +338,7 @@ void GameViewDebugger::reset_camera_3d_position() {
 		}
 	}
 }
+#endif // _3D_DISABLED
 
 void GameViewDebugger::setup_session(int p_session_id) {
 	Ref<EditorDebuggerSession> session = get_session(p_session_id);
@@ -656,7 +658,9 @@ void GameView::_update_debugger_buttons() {
 
 	bool disable_camera_reset = empty || !camera_override_button->is_pressed() || !menu->is_item_checked(menu->get_item_index(CAMERA_MODE_INGAME));
 	menu->set_item_disabled(CAMERA_RESET_2D, disable_camera_reset);
+#ifndef _3D_DISABLED
 	menu->set_item_disabled(CAMERA_RESET_3D, disable_camera_reset);
+#endif // _3D_DISABLED
 
 	if (empty) {
 		suspend_button->set_pressed(false);
@@ -1085,7 +1089,11 @@ void GameView::_camera_override_button_toggled(bool p_pressed) {
 
 void GameView::_camera_override_menu_id_pressed(int p_id) {
 	PopupMenu *menu = camera_override_menu->get_popup();
+#ifndef _3D_DISABLED
 	if (p_id != CAMERA_RESET_2D && p_id != CAMERA_RESET_3D) {
+#else
+	if (p_id != CAMERA_RESET_2D) {
+#endif // _3D_DISABLED
 		for (int i = 0; i < menu->get_item_count(); i++) {
 			menu->set_item_checked(i, false);
 		}
@@ -1095,9 +1103,11 @@ void GameView::_camera_override_menu_id_pressed(int p_id) {
 		case CAMERA_RESET_2D: {
 			debugger->reset_camera_2d_position();
 		} break;
+#ifndef _3D_DISABLED
 		case CAMERA_RESET_3D: {
 			debugger->reset_camera_3d_position();
 		} break;
+#endif // _3D_DISABLED
 		case CAMERA_MODE_INGAME: {
 			debugger->set_camera_manipulate_mode(EditorDebuggerNode::OVERRIDE_INGAME);
 			menu->set_item_checked(menu->get_item_index(p_id), true);
@@ -1135,7 +1145,9 @@ void GameView::_notification(int p_what) {
 
 			node_type_button[RuntimeNodeSelect::NODE_TYPE_NONE]->set_button_icon(get_editor_theme_icon(SNAME("InputEventJoypadMotion")));
 			node_type_button[RuntimeNodeSelect::NODE_TYPE_2D]->set_button_icon(get_editor_theme_icon(SNAME("2DNodes")));
+#ifndef _3D_DISABLED
 			node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_button_icon(get_editor_theme_icon(SNAME("Node3D")));
+#endif // _3D_DISABLED
 
 			select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_button_icon(get_editor_theme_icon(SNAME("ToolSelect")));
 			select_mode_button[RuntimeNodeSelect::SELECT_MODE_LIST]->set_button_icon(get_editor_theme_icon(SNAME("ListSelect")));
@@ -1423,11 +1435,13 @@ void GameView::_feature_profile_changed() {
 
 	is_feature_enabled = is_profile_null || !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_GAME);
 
+#ifndef _3D_DISABLED
 	bool is_3d_enabled = is_profile_null || !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D);
 	if (!is_3d_enabled && node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->is_pressed()) {
 		_node_type_pressed(RuntimeNodeSelect::NODE_TYPE_NONE);
 	}
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_visible(is_3d_enabled);
+#endif // _3D_DISABLED
 }
 
 GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embedded_process, WindowWrapper *p_wrapper) {
@@ -1506,6 +1520,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_2D]->connect(SceneStringName(pressed), callable_mp(this, &GameView::_node_type_pressed).bind(RuntimeNodeSelect::NODE_TYPE_2D));
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_2D]->set_tooltip_text(TTRC("Disable game input and allow to select Node2Ds, Controls, and manipulate the 2D camera."));
 
+#ifndef _3D_DISABLED
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D] = memnew(Button);
 	input_hb->add_child(node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]);
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_text(TTRC("3D"));
@@ -1513,6 +1528,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_theme_type_variation("FlatButtonNoIconTint");
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->connect(SceneStringName(pressed), callable_mp(this, &GameView::_node_type_pressed).bind(RuntimeNodeSelect::NODE_TYPE_3D));
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_tooltip_text(TTRC("Disable game input and allow to select Node3Ds and manipulate the 3D camera."));
+#endif // _3D_DISABLED
 
 	input_hb->add_child(memnew(VSeparator));
 
@@ -1525,7 +1541,11 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_pressed(true);
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_theme_type_variation(SceneStringName(FlatButton));
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->connect(SceneStringName(pressed), callable_mp(this, &GameView::_select_mode_pressed).bind(RuntimeNodeSelect::SELECT_MODE_SINGLE));
+#ifndef _3D_DISABLED
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_shortcut(ED_GET_SHORTCUT("spatial_editor/tool_select"));
+#else
+	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_shortcut(ED_GET_SHORTCUT("canvas_item_editor/select_mode"));
+#endif // _3D_DISABLED
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_shortcut_context(this);
 
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_LIST] = memnew(Button);
@@ -1601,7 +1621,9 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	menu = camera_override_menu->get_popup();
 	menu->connect(SceneStringName(id_pressed), callable_mp(this, &GameView::_camera_override_menu_id_pressed));
 	menu->add_item(TTRC("Reset 2D Camera"), CAMERA_RESET_2D);
+#ifndef _3D_DISABLED
 	menu->add_item(TTRC("Reset 3D Camera"), CAMERA_RESET_3D);
+#endif // _3D_DISABLED
 	menu->add_separator();
 	menu->add_radio_check_item(TTRC("Manipulate In-Game"), CAMERA_MODE_INGAME);
 	menu->set_item_checked(menu->get_item_index(CAMERA_MODE_INGAME), true);

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -337,6 +337,7 @@ void GameViewDebugger::reset_camera_2d_position() {
 	}
 }
 
+#ifndef _3D_DISABLED
 void GameViewDebugger::reset_camera_3d_position() {
 	for (Ref<EditorDebuggerSession> &I : sessions) {
 		if (I->is_active()) {
@@ -344,6 +345,7 @@ void GameViewDebugger::reset_camera_3d_position() {
 		}
 	}
 }
+#endif // _3D_DISABLED
 
 void GameViewDebugger::setup_session(int p_session_id) {
 	Ref<EditorDebuggerSession> session = get_session(p_session_id);
@@ -659,7 +661,9 @@ void GameView::_update_debugger_buttons() {
 
 	bool disable_camera_reset = empty || !camera_override_button->is_pressed() || !menu->is_item_checked(menu->get_item_index(CAMERA_MODE_INGAME));
 	menu->set_item_disabled(CAMERA_RESET_2D, disable_camera_reset);
+#ifndef _3D_DISABLED
 	menu->set_item_disabled(CAMERA_RESET_3D, disable_camera_reset);
+#endif // _3D_DISABLED
 
 	if (empty) {
 		suspend_button->set_pressed(false);
@@ -1131,7 +1135,11 @@ void GameView::_camera_override_button_toggled(bool p_pressed) {
 
 void GameView::_camera_override_menu_id_pressed(int p_id) {
 	PopupMenu *menu = camera_override_menu->get_popup();
+#ifndef _3D_DISABLED
 	if (p_id != CAMERA_RESET_2D && p_id != CAMERA_RESET_3D) {
+#else
+	if (p_id != CAMERA_RESET_2D) {
+#endif // _3D_DISABLED
 		for (int i = 0; i < menu->get_item_count(); i++) {
 			menu->set_item_checked(i, false);
 		}
@@ -1141,9 +1149,11 @@ void GameView::_camera_override_menu_id_pressed(int p_id) {
 		case CAMERA_RESET_2D: {
 			debugger->reset_camera_2d_position();
 		} break;
+#ifndef _3D_DISABLED
 		case CAMERA_RESET_3D: {
 			debugger->reset_camera_3d_position();
 		} break;
+#endif // _3D_DISABLED
 		case CAMERA_MODE_INGAME: {
 			debugger->set_camera_manipulate_mode(EditorDebuggerNode::OVERRIDE_INGAME);
 			menu->set_item_checked(menu->get_item_index(p_id), true);
@@ -1180,7 +1190,9 @@ void GameView::_notification(int p_what) {
 
 			node_type_button[RuntimeNodeSelect::NODE_TYPE_NONE]->set_button_icon(get_editor_theme_icon(SNAME("InputEventJoypadMotion")));
 			node_type_button[RuntimeNodeSelect::NODE_TYPE_2D]->set_button_icon(get_editor_theme_icon(SNAME("2DNodes")));
+#ifndef _3D_DISABLED
 			node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_button_icon(get_editor_theme_icon(SNAME("Node3D")));
+#endif // _3D_DISABLED
 
 			select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_button_icon(get_editor_theme_icon(SNAME("ToolSelect")));
 			select_mode_button[RuntimeNodeSelect::SELECT_MODE_LIST]->set_button_icon(get_editor_theme_icon(SNAME("ListSelect")));
@@ -1470,11 +1482,13 @@ void GameView::_feature_profile_changed() {
 
 	is_feature_enabled = is_profile_null || !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_GAME);
 
+#ifndef _3D_DISABLED
 	bool is_3d_enabled = is_profile_null || !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D);
 	if (!is_3d_enabled && node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->is_pressed()) {
 		_node_type_pressed(RuntimeNodeSelect::NODE_TYPE_NONE);
 	}
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_visible(is_3d_enabled);
+#endif // _3D_DISABLED
 }
 
 GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embedded_process, WindowWrapper *p_wrapper) {
@@ -1555,6 +1569,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_2D]->connect(SceneStringName(pressed), callable_mp(this, &GameView::_node_type_pressed).bind(RuntimeNodeSelect::NODE_TYPE_2D));
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_2D]->set_tooltip_text(TTRC("Disable game input to allow selecting Node2Ds and Controls, as well as manipulate the 2D camera."));
 
+#ifndef _3D_DISABLED
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D] = memnew(Button);
 	input_hb->add_child(node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]);
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_text(TTRC("3D"));
@@ -1562,6 +1577,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_theme_type_variation("FlatButtonNoIconTint");
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->connect(SceneStringName(pressed), callable_mp(this, &GameView::_node_type_pressed).bind(RuntimeNodeSelect::NODE_TYPE_3D));
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_tooltip_text(TTRC("Disable game input to allow selecting Node3Ds and manipulating the 3D camera."));
+#endif // _3D_DISABLED
 
 	main_menu_fc->add_child(memnew(VSeparator));
 
@@ -1573,7 +1589,11 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_pressed(true);
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_theme_type_variation(SceneStringName(FlatButton));
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->connect(SceneStringName(pressed), callable_mp(this, &GameView::_select_mode_pressed).bind(RuntimeNodeSelect::SELECT_MODE_SINGLE));
+#ifndef _3D_DISABLED
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_shortcut(ED_GET_SHORTCUT("spatial_editor/tool_select"));
+#else
+	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_shortcut(ED_GET_SHORTCUT("canvas_item_editor/select_mode"));
+#endif // _3D_DISABLED
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_shortcut_context(this);
 
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_LIST] = memnew(Button);
@@ -1630,7 +1650,9 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	menu = camera_override_menu->get_popup();
 	menu->connect(SceneStringName(id_pressed), callable_mp(this, &GameView::_camera_override_menu_id_pressed));
 	menu->add_item(TTRC("Reset 2D Camera"), CAMERA_RESET_2D);
+#ifndef _3D_DISABLED
 	menu->add_item(TTRC("Reset 3D Camera"), CAMERA_RESET_3D);
+#endif // _3D_DISABLED
 	menu->add_separator();
 	menu->add_radio_check_item(TTRC("Manipulate In-Game"), CAMERA_MODE_INGAME);
 	menu->set_item_checked(menu->get_item_index(CAMERA_MODE_INGAME), true);

--- a/editor/run/game_view_plugin.h
+++ b/editor/run/game_view_plugin.h
@@ -109,7 +109,9 @@ public:
 	void report_window_focused(bool p_focused);
 
 	void reset_camera_2d_position();
+#ifndef _3D_DISABLED
 	void reset_camera_3d_position();
+#endif // _3D_DISABLED
 
 	virtual void setup_session(int p_session_id) override;
 
@@ -121,7 +123,9 @@ class GameView : public VBoxContainer {
 
 	enum {
 		CAMERA_RESET_2D,
+#ifndef _3D_DISABLED
 		CAMERA_RESET_3D,
+#endif // _3D_DISABLED
 		CAMERA_MODE_INGAME,
 		CAMERA_MODE_EDITORS,
 		SELECTION_AVOID_LOCKED,

--- a/editor/run/game_view_plugin.h
+++ b/editor/run/game_view_plugin.h
@@ -110,7 +110,9 @@ public:
 	void report_window_focused(bool p_focused);
 
 	void reset_camera_2d_position();
+#ifndef _3D_DISABLED
 	void reset_camera_3d_position();
+#endif // _3D_DISABLED
 
 	virtual void setup_session(int p_session_id) override;
 
@@ -122,7 +124,9 @@ class GameView : public VBoxContainer {
 
 	enum {
 		CAMERA_RESET_2D,
+#ifndef _3D_DISABLED
 		CAMERA_RESET_3D,
+#endif // _3D_DISABLED
 		CAMERA_MODE_INGAME,
 		CAMERA_MODE_EDITORS,
 		SELECTION_HIDE,

--- a/editor/scene/3d/SCsub
+++ b/editor/scene/3d/SCsub
@@ -6,4 +6,5 @@ Import("env")
 env.add_source_files(env.editor_sources, "*.cpp")
 
 SConscript("gizmos/SCsub")
-SConscript("physics/SCsub")
+if not env["disable_physics_3d"]:
+    SConscript("physics/SCsub")

--- a/editor/scene/3d/gizmos/SCsub
+++ b/editor/scene/3d/gizmos/SCsub
@@ -5,4 +5,5 @@ Import("env")
 
 env.add_source_files(env.editor_sources, "*.cpp")
 
-SConscript("physics/SCsub")
+if not env["disable_physics_3d"]:
+    SConscript("physics/SCsub")

--- a/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
@@ -38,9 +38,14 @@
 #include "editor/inspector/multi_node_edit.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/themes/editor_scale.h"
+#ifndef NAVIGATION_3D_DISABLED
 #include "scene/3d/navigation/navigation_region_3d.h"
+#endif // NAVIGATION_3D_DISABLED
+#ifndef PHYSICS_3D_DISABLED
 #include "scene/3d/physics/collision_shape_3d.h"
 #include "scene/3d/physics/static_body_3d.h"
+#include "scene/gui/option_button.h"
+#endif // PHYSICS_3D_DISABLED
 #include "scene/gui/aspect_ratio_container.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/dialogs.h"
@@ -66,6 +71,7 @@ void MeshInstance3DEditor::edit(MeshInstance3D *p_mesh) {
 	node = p_mesh;
 }
 
+#ifndef PHYSICS_3D_DISABLED
 Vector<Ref<Shape3D>> MeshInstance3DEditor::create_shape_from_mesh(Ref<Mesh> p_mesh, int p_option, bool p_verbose) {
 	Vector<Ref<Shape3D>> shapes;
 	switch (p_option) {
@@ -424,6 +430,7 @@ void MeshInstance3DEditor::_create_collision_shape() {
 
 	ur->commit_action();
 }
+#endif // PHYSICS_3D_DISABLED
 
 void MeshInstance3DEditor::_menu_option(int p_option) {
 	Ref<Mesh> mesh = node->get_mesh();
@@ -434,13 +441,17 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 	}
 
 	switch (p_option) {
+#ifndef PHYSICS_3D_DISABLED
 		case MENU_OPTION_CREATE_COLLISION_SHAPE: {
 			shape_dialog->popup_centered();
 		} break;
+#endif // PHYSICS_3D_DISABLED
 
+#ifndef NAVIGATION_3D_DISABLED
 		case MENU_OPTION_CREATE_NAVMESH: {
 			navigation_mesh_dialog->popup_centered(Vector2(200, 90));
 		} break;
+#endif // NAVIGATION_3D_DISABLED
 
 		case MENU_OPTION_CREATE_OUTLINE_MESH: {
 			outline_dialog->popup_centered(Vector2(200, 90));
@@ -706,6 +717,7 @@ void MeshInstance3DEditor::_debug_uv_draw() {
 			Math::round(EDSCALE) / debug_uv->get_size().x);
 }
 
+#ifndef NAVIGATION_3D_DISABLED
 void MeshInstance3DEditor::_create_navigation_mesh() {
 	Ref<Mesh> mesh = node->get_mesh();
 	if (mesh.is_null()) {
@@ -735,6 +747,7 @@ void MeshInstance3DEditor::_create_navigation_mesh() {
 	ur->add_undo_method(node, "remove_child", nmi);
 	ur->commit_action();
 }
+#endif // NAVIGATION_3D_DISABLED
 
 void MeshInstance3DEditor::_create_outline_mesh() {
 	Ref<Mesh> mesh = node->get_mesh();
@@ -802,8 +815,12 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	options->set_theme_type_variation("FlatMenuButtonNoIconTint");
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(options);
 
+#ifndef PHYSICS_3D_DISABLED
 	options->get_popup()->add_item(TTR("Create Collision Shape..."), MENU_OPTION_CREATE_COLLISION_SHAPE);
+#endif
+#ifndef NAVIGATION_3D_DISABLED
 	options->get_popup()->add_item(TTR("Create Navigation Mesh"), MENU_OPTION_CREATE_NAVMESH);
+#endif
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Create Outline Mesh..."), MENU_OPTION_CREATE_OUTLINE_MESH);
 	options->get_popup()->set_item_tooltip(options->get_popup()->get_item_count() - 1, TTR("Creates a static outline mesh. The outline mesh will have its normals flipped automatically.\nThis can be used instead of the StandardMaterial Grow property when using that property isn't possible."));
@@ -834,6 +851,7 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	add_child(outline_dialog);
 	outline_dialog->connect(SceneStringName(confirmed), callable_mp(this, &MeshInstance3DEditor::_create_outline_mesh));
 
+#ifndef PHYSICS_3D_DISABLED
 	shape_dialog = memnew(ConfirmationDialog);
 	shape_dialog->set_title(TTR("Create Collision Shape"));
 	shape_dialog->set_ok_button_text(TTR("Create"));
@@ -901,6 +919,7 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 
 	add_child(shape_dialog);
 	shape_dialog->connect(SceneStringName(confirmed), callable_mp(this, &MeshInstance3DEditor::_create_collision_shape));
+#endif // PHYSICS_3D_DISABLED
 
 	err_dialog = memnew(AcceptDialog);
 	add_child(err_dialog);
@@ -917,6 +936,7 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	debug_uv->connect(SceneStringName(draw), callable_mp(this, &MeshInstance3DEditor::_debug_uv_draw));
 	debug_uv_arc->add_child(debug_uv);
 
+#ifndef NAVIGATION_3D_DISABLED
 	navigation_mesh_dialog = memnew(ConfirmationDialog);
 	navigation_mesh_dialog->set_title(TTR("Create NavigationMesh"));
 	navigation_mesh_dialog->set_ok_button_text(TTR("Create"));
@@ -931,6 +951,7 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 
 	add_child(navigation_mesh_dialog);
 	navigation_mesh_dialog->connect(SceneStringName(confirmed), callable_mp(this, &MeshInstance3DEditor::_create_navigation_mesh));
+#endif // NAVIGATION_3D_DISABLED
 }
 
 void MeshInstance3DEditorPlugin::edit(Object *p_object) {

--- a/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
@@ -38,9 +38,14 @@
 #include "editor/inspector/multi_node_edit.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/themes/editor_scale.h"
+#ifndef NAVIGATION_3D_DISABLED
 #include "scene/3d/navigation/navigation_region_3d.h"
+#endif // NAVIGATION_3D_DISABLED
+#ifndef PHYSICS_3D_DISABLED
 #include "scene/3d/physics/collision_shape_3d.h"
 #include "scene/3d/physics/static_body_3d.h"
+#include "scene/gui/option_button.h"
+#endif // PHYSICS_3D_DISABLED
 #include "scene/gui/aspect_ratio_container.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/dialogs.h"
@@ -66,6 +71,7 @@ void MeshInstance3DEditor::edit(MeshInstance3D *p_mesh) {
 	node = p_mesh;
 }
 
+#ifndef PHYSICS_3D_DISABLED
 Vector<Ref<Shape3D>> MeshInstance3DEditor::create_shape_from_mesh(Ref<Mesh> p_mesh, int p_option, bool p_verbose) {
 	Vector<Ref<Shape3D>> shapes;
 	switch (p_option) {
@@ -424,6 +430,7 @@ void MeshInstance3DEditor::_create_collision_shape() {
 
 	ur->commit_action();
 }
+#endif // PHYSICS_3D_DISABLED
 
 void MeshInstance3DEditor::_menu_option(int p_option) {
 	Ref<Mesh> mesh = node->get_mesh();
@@ -434,13 +441,17 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 	}
 
 	switch (p_option) {
+#ifndef PHYSICS_3D_DISABLED
 		case MENU_OPTION_CREATE_COLLISION_SHAPE: {
 			shape_dialog->popup_centered();
 		} break;
+#endif // PHYSICS_3D_DISABLED
 
+#ifndef NAVIGATION_3D_DISABLED
 		case MENU_OPTION_CREATE_NAVMESH: {
 			navigation_mesh_dialog->popup_centered(Vector2(200, 90));
 		} break;
+#endif // NAVIGATION_3D_DISABLED
 
 		case MENU_OPTION_CREATE_OUTLINE_MESH: {
 			outline_dialog->popup_centered(Vector2(200, 90));
@@ -706,6 +717,7 @@ void MeshInstance3DEditor::_debug_uv_draw() {
 			Math::round(EDSCALE) / debug_uv->get_size().x);
 }
 
+#ifndef NAVIGATION_3D_DISABLED
 void MeshInstance3DEditor::_create_navigation_mesh() {
 	Ref<Mesh> mesh = node->get_mesh();
 	if (mesh.is_null()) {
@@ -735,6 +747,7 @@ void MeshInstance3DEditor::_create_navigation_mesh() {
 	ur->add_undo_method(node, "remove_child", nmi);
 	ur->commit_action();
 }
+#endif // NAVIGATION_3D_DISABLED
 
 void MeshInstance3DEditor::_create_outline_mesh() {
 	Ref<Mesh> mesh = node->get_mesh();
@@ -802,8 +815,12 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	options->set_theme_type_variation("FlatMenuButtonNoIconTint");
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(options);
 
+#ifndef PHYSICS_3D_DISABLED
 	options->get_popup()->add_item(TTR("Create Collision Shape..."), MENU_OPTION_CREATE_COLLISION_SHAPE);
+#endif
+#ifndef NAVIGATION_3D_DISABLED
 	options->get_popup()->add_item(TTR("Create Navigation Mesh"), MENU_OPTION_CREATE_NAVMESH);
+#endif
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Create Outline Mesh..."), MENU_OPTION_CREATE_OUTLINE_MESH);
 	options->get_popup()->set_item_tooltip(options->get_popup()->get_item_count() - 1, TTR("Creates a static outline mesh. The outline mesh will have its normals flipped automatically.\nThis can be used instead of the StandardMaterial Grow property when using that property isn't possible."));
@@ -834,6 +851,7 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	add_child(outline_dialog);
 	outline_dialog->connect(SceneStringName(confirmed), callable_mp(this, &MeshInstance3DEditor::_create_outline_mesh));
 
+#ifndef PHYSICS_3D_DISABLED
 	shape_dialog = memnew(ConfirmationDialog);
 	shape_dialog->set_title(TTR("Create Collision Shape"));
 	shape_dialog->set_ok_button_text(TTR("Create"));
@@ -901,6 +919,7 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 
 	add_child(shape_dialog);
 	shape_dialog->connect(SceneStringName(confirmed), callable_mp(this, &MeshInstance3DEditor::_create_collision_shape));
+#endif // PHYSICS_3D_DISABLED
 
 	err_dialog = memnew(AcceptDialog);
 	err_dialog->set_flag(Window::FLAG_RESIZE_DISABLED, true);
@@ -918,6 +937,7 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	debug_uv->connect(SceneStringName(draw), callable_mp(this, &MeshInstance3DEditor::_debug_uv_draw));
 	debug_uv_arc->add_child(debug_uv);
 
+#ifndef NAVIGATION_3D_DISABLED
 	navigation_mesh_dialog = memnew(ConfirmationDialog);
 	navigation_mesh_dialog->set_title(TTR("Create NavigationMesh"));
 	navigation_mesh_dialog->set_ok_button_text(TTR("Create"));
@@ -932,6 +952,7 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 
 	add_child(navigation_mesh_dialog);
 	navigation_mesh_dialog->connect(SceneStringName(confirmed), callable_mp(this, &MeshInstance3DEditor::_create_navigation_mesh));
+#endif // NAVIGATION_3D_DISABLED
 }
 
 void MeshInstance3DEditorPlugin::edit(Object *p_object) {

--- a/editor/scene/3d/mesh_instance_3d_editor_plugin.h
+++ b/editor/scene/3d/mesh_instance_3d_editor_plugin.h
@@ -32,20 +32,24 @@
 
 #include "editor/plugins/editor_plugin.h"
 #include "scene/3d/mesh_instance_3d.h"
-#include "scene/gui/option_button.h"
 
 class AcceptDialog;
 class AspectRatioContainer;
 class ConfirmationDialog;
 class MenuButton;
+class OptionButton;
 class SpinBox;
 
 class MeshInstance3DEditor : public Control {
 	GDCLASS(MeshInstance3DEditor, Control);
 
 	enum Menu {
+#ifndef PHYSICS_3D_DISABLED
 		MENU_OPTION_CREATE_COLLISION_SHAPE,
+#endif
+#ifndef NAVIGATION_3D_DISABLED
 		MENU_OPTION_CREATE_NAVMESH,
+#endif
 		MENU_OPTION_CREATE_OUTLINE_MESH,
 		MENU_OPTION_CREATE_DEBUG_TANGENTS,
 		MENU_OPTION_CREATE_UV2,
@@ -53,6 +57,7 @@ class MeshInstance3DEditor : public Control {
 		MENU_OPTION_DEBUG_UV2,
 	};
 
+#ifndef PHYSICS_3D_DISABLED
 	enum ShapePlacement {
 		SHAPE_PLACEMENT_SIBLING,
 		SHAPE_PLACEMENT_STATIC_BODY_CHILD,
@@ -76,6 +81,7 @@ class MeshInstance3DEditor : public Control {
 		SHAPE_AXIS_Z,
 		SHAPE_AXIS_LONGEST,
 	};
+#endif // PHYSICS_3D_DISABLED
 
 	MeshInstance3D *node = nullptr;
 
@@ -84,12 +90,14 @@ class MeshInstance3DEditor : public Control {
 	ConfirmationDialog *outline_dialog = nullptr;
 	SpinBox *outline_size = nullptr;
 
+#ifndef PHYSICS_3D_DISABLED
 	ConfirmationDialog *shape_dialog = nullptr;
 	OptionButton *shape_type = nullptr;
 	OptionButton *shape_placement = nullptr;
 	Label *shape_axis_label = nullptr;
 	OptionButton *shape_axis = nullptr;
 	Transform3D shape_offset_transform;
+#endif // PHYSICS_3D_DISABLED
 
 	AcceptDialog *err_dialog = nullptr;
 
@@ -98,15 +106,23 @@ class MeshInstance3DEditor : public Control {
 	Control *debug_uv = nullptr;
 	Vector<Vector2> uv_lines;
 
+#ifndef NAVIGATION_3D_DISABLED
 	ConfirmationDialog *navigation_mesh_dialog = nullptr;
+#endif // NAVIGATION_3D_DISABLED
 
+#ifndef PHYSICS_3D_DISABLED
 	void _shape_dialog_about_to_popup();
 	void _shape_type_selected(int p_option);
 	void _create_collision_shape();
 	Vector<Ref<Shape3D>> create_shape_from_mesh(Ref<Mesh> p_mesh, int p_option, bool p_verbose);
+#endif // PHYSICS_3D_DISABLED
+
 	void _menu_option(int p_option);
 	void _create_outline_mesh();
+
+#ifndef NAVIGATION_3D_DISABLED
 	void _create_navigation_mesh();
+#endif // NAVIGATION_3D_DISABLED
 
 	void _create_uv_lines(int p_layer);
 	friend class MeshInstance3DEditorPlugin;

--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -46,8 +46,6 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/3d/mesh_instance_3d.h"
-#include "scene/3d/navigation/navigation_region_3d.h"
-#include "scene/3d/physics/static_body_3d.h"
 #include "scene/gui/button.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/menu_button.h"
@@ -56,6 +54,13 @@
 #include "scene/main/timer.h"
 #include "scene/resources/3d/mesh_library.h"
 #include "scene/resources/packed_scene.h"
+
+#ifndef NAVIGATION_3D_DISABLED
+#include "scene/3d/navigation/navigation_region_3d.h"
+#endif // NAVIGATION_3D_DISABLED
+#ifndef PHYSICS_3D_DISABLED
+#include "scene/3d/physics/static_body_3d.h"
+#endif // PHYSICS_3D_DISABLED
 
 bool MeshLibraryEditor::MeshLibraryItem::_set(const StringName &p_name, const Variant &p_value) {
 	ERR_FAIL_COND_V(mesh_library.is_null(), false);
@@ -561,6 +566,7 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 	}
 	p_library->set_item_mesh_transform(item_id, item_mesh_transform);
 
+#ifndef PHYSICS_3D_DISABLED
 	Vector<MeshLibrary::ShapeData> collisions;
 	for (int i = 0; i < mesh_instance_node->get_child_count(); i++) {
 		StaticBody3D *static_body_node = Object::cast_to<StaticBody3D>(mesh_instance_node->get_child(i));
@@ -591,7 +597,9 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 		}
 	}
 	p_library->set_item_shapes(item_id, collisions);
+#endif // PHYSICS_3D_DISABLED
 
+#ifndef NAVIGATION_3D_DISABLED
 	for (int i = 0; i < mesh_instance_node->get_child_count(); i++) {
 		NavigationRegion3D *navigation_region_node = Object::cast_to<NavigationRegion3D>(mesh_instance_node->get_child(i));
 		if (!navigation_region_node) {
@@ -605,6 +613,7 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 			break;
 		}
 	}
+#endif // NAVIGATION_3D_DISABLED
 }
 
 void MeshLibraryEditor::_icon_size_changed(float p_value) {

--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -47,8 +47,6 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/3d/mesh_instance_3d.h"
-#include "scene/3d/navigation/navigation_region_3d.h"
-#include "scene/3d/physics/static_body_3d.h"
 #include "scene/gui/button.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/menu_button.h"
@@ -57,6 +55,13 @@
 #include "scene/main/timer.h"
 #include "scene/resources/3d/mesh_library.h"
 #include "scene/resources/packed_scene.h"
+
+#ifndef NAVIGATION_3D_DISABLED
+#include "scene/3d/navigation/navigation_region_3d.h"
+#endif // NAVIGATION_3D_DISABLED
+#ifndef PHYSICS_3D_DISABLED
+#include "scene/3d/physics/static_body_3d.h"
+#endif // PHYSICS_3D_DISABLED
 
 bool MeshLibraryEditor::MeshLibraryItem::_set(const StringName &p_name, const Variant &p_value) {
 	ERR_FAIL_COND_V(mesh_library.is_null(), false);
@@ -578,6 +583,7 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 	}
 	p_library->set_item_mesh_transform(item_id, item_mesh_transform);
 
+#ifndef PHYSICS_3D_DISABLED
 	Vector<MeshLibrary::ShapeData> collisions;
 	for (int i = 0; i < mesh_instance_node->get_child_count(); i++) {
 		StaticBody3D *static_body_node = Object::cast_to<StaticBody3D>(mesh_instance_node->get_child(i));
@@ -608,7 +614,9 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 		}
 	}
 	p_library->set_item_shapes(item_id, collisions);
+#endif // PHYSICS_3D_DISABLED
 
+#ifndef NAVIGATION_3D_DISABLED
 	for (int i = 0; i < mesh_instance_node->get_child_count(); i++) {
 		NavigationRegion3D *navigation_region_node = Object::cast_to<NavigationRegion3D>(mesh_instance_node->get_child(i));
 		if (!navigation_region_node) {
@@ -622,6 +630,7 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 			break;
 		}
 	}
+#endif // NAVIGATION_3D_DISABLED
 }
 
 void MeshLibraryEditor::_icon_size_changed(float p_value) {

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -70,16 +70,6 @@
 #include "editor/scene/3d/gizmos/mesh_instance_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/occluder_instance_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/particles_3d_emission_shape_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/collision_object_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/collision_polygon_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/physics_bone_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/ray_cast_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/shape_cast_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/soft_body_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/spring_arm_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/vehicle_body_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/reflection_probe_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/spring_bone_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/sprite_base_3d_gizmo_plugin.h"
@@ -95,8 +85,6 @@
 #include "scene/3d/decal.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
-#include "scene/3d/physics/collision_shape_3d.h"
-#include "scene/3d/physics/physics_body_3d.h"
 #include "scene/3d/sprite_3d.h"
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/3d/world_environment.h"
@@ -113,6 +101,21 @@
 #include "scene/resources/sky.h"
 #include "scene/resources/surface_tool.h"
 #include "servers/rendering/rendering_server.h"
+
+#ifndef PHYSICS_3D_DISABLED
+#include "editor/scene/3d/gizmos/physics/collision_object_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/collision_polygon_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/physics_bone_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/ray_cast_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/shape_cast_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/soft_body_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/spring_arm_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/vehicle_body_3d_gizmo_plugin.h"
+#include "scene/3d/physics/collision_shape_3d.h"
+#include "scene/3d/physics/physics_body_3d.h"
+#endif // PHYSICS_3D_DISABLED
 
 constexpr real_t GIZMO_ARROW_SIZE = 0.35;
 constexpr real_t GIZMO_RING_HALF_WIDTH = 0.1;
@@ -861,9 +864,11 @@ static bool _node_is_snap_source(Node *p_node, bool p_use_collision) {
 	if (!p_use_collision) {
 		return Object::cast_to<GeometryInstance3D>(p_node);
 	}
+#ifndef PHYSICS_3D_DISABLED
 	if (Object::cast_to<CollisionShape3D>(p_node)) {
 		return true;
 	}
+#endif // PHYSICS_3D_DISABLED
 	Node3D *n3d = Object::cast_to<Node3D>(p_node);
 	if (!n3d) {
 		return false;
@@ -5374,6 +5379,7 @@ void Node3DEditorViewport::assign_pending_data_pointers(Node3D *p_preview_node, 
 }
 
 void _insert_rid_recursive(Node *node, HashSet<RID> &rids) {
+#ifndef PHYSICS_3D_DISABLED
 	CollisionObject3D *co = Object::cast_to<CollisionObject3D>(node);
 
 	if (co) {
@@ -5381,6 +5387,7 @@ void _insert_rid_recursive(Node *node, HashSet<RID> &rids) {
 	} else if (node->is_class("CSGShape3D")) { // HACK: We should avoid referencing module logic.
 		rids.insert(node->call("_get_root_collision_instance"));
 	}
+#endif // PHYSICS_3D_DISABLED
 
 	for (int i = 0; i < node->get_child_count(); i++) {
 		Node *child = node->get_child(i);
@@ -5395,7 +5402,9 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos, Node3D
 	Vector3 world_ray = get_ray(p_pos);
 	Vector3 world_pos = get_ray_pos(p_pos);
 
+#ifndef PHYSICS_3D_DISABLED
 	PhysicsDirectSpaceState3D *ss = get_tree()->get_root()->get_world_3d()->get_direct_space_state();
+#endif // PHYSICS_3D_DISABLED
 
 	HashSet<RID> rids;
 
@@ -5411,6 +5420,7 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos, Node3D
 		}
 	}
 
+#ifndef PHYSICS_3D_DISABLED
 	PhysicsDirectSpaceState3D::RayParameters ray_params;
 	ray_params.exclude = rids;
 	ray_params.from = world_pos;
@@ -5443,6 +5453,7 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos, Node3D
 
 		return result_offset;
 	}
+#endif // PHYSICS_3D_DISABLED
 
 	const bool is_orthogonal = camera->get_projection() == Camera3D::PROJECTION_ORTHOGONAL;
 
@@ -9342,6 +9353,7 @@ HashSet<T *> _get_child_nodes(Node *parent_node) {
 	return nodes;
 }
 
+#ifndef PHYSICS_3D_DISABLED
 HashSet<RID> _get_physics_bodies_rid(Node *node) {
 	HashSet<RID> rids = HashSet<RID>();
 	PhysicsBody3D *pb = Node::cast_to<PhysicsBody3D>(node);
@@ -9355,11 +9367,13 @@ HashSet<RID> _get_physics_bodies_rid(Node *node) {
 
 	return rids;
 }
+#endif // PHYSICS_3D_DISABLED
 
 void Node3DEditor::snap_selected_nodes_to_floor() {
 	do_snap_selected_nodes_to_floor = true;
 }
 
+#ifndef PHYSICS_3D_DISABLED
 void Node3DEditor::_snap_selected_nodes_to_floor() {
 	const List<Node *> &selection = editor_selection->get_top_selected_node_list();
 	Dictionary snap_data;
@@ -9491,6 +9505,7 @@ void Node3DEditor::_snap_selected_nodes_to_floor() {
 		}
 	}
 }
+#endif // PHYSICS_3D_DISABLED
 
 void Node3DEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
@@ -9698,12 +9713,14 @@ void Node3DEditor::_notification(int p_what) {
 			_update_vertex_snap_tooltips();
 		} break;
 
+#ifndef PHYSICS_3D_DISABLED
 		case NOTIFICATION_PHYSICS_PROCESS: {
 			if (do_snap_selected_nodes_to_floor) {
 				_snap_selected_nodes_to_floor();
 				do_snap_selected_nodes_to_floor = false;
 			}
 		}
+#endif // PHYSICS_3D_DISABLED
 	}
 }
 
@@ -10035,17 +10052,10 @@ void Node3DEditor::_register_all_gizmos() {
 	add_gizmo_plugin(Ref<AudioListener3DGizmoPlugin>(memnew(AudioListener3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<MeshInstance3DGizmoPlugin>(memnew(MeshInstance3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<OccluderInstance3DGizmoPlugin>(memnew(OccluderInstance3DGizmoPlugin)));
-	add_gizmo_plugin(Ref<SoftBody3DGizmoPlugin>(memnew(SoftBody3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<SpriteBase3DGizmoPlugin>(memnew(SpriteBase3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<Label3DGizmoPlugin>(memnew(Label3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<GeometryInstance3DGizmoPlugin>(memnew(GeometryInstance3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<Marker3DGizmoPlugin>(memnew(Marker3DGizmoPlugin)));
-	add_gizmo_plugin(Ref<RayCast3DGizmoPlugin>(memnew(RayCast3DGizmoPlugin)));
-	add_gizmo_plugin(Ref<ShapeCast3DGizmoPlugin>(memnew(ShapeCast3DGizmoPlugin)));
-	add_gizmo_plugin(Ref<SpringArm3DGizmoPlugin>(memnew(SpringArm3DGizmoPlugin)));
-	add_gizmo_plugin(Ref<SpringBoneCollision3DGizmoPlugin>(memnew(SpringBoneCollision3DGizmoPlugin)));
-	add_gizmo_plugin(Ref<SpringBoneSimulator3DGizmoPlugin>(memnew(SpringBoneSimulator3DGizmoPlugin)));
-	add_gizmo_plugin(Ref<VehicleWheel3DGizmoPlugin>(memnew(VehicleWheel3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<VisibleOnScreenNotifier3DGizmoPlugin>(memnew(VisibleOnScreenNotifier3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<GPUParticles3DGizmoPlugin>(memnew(GPUParticles3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<GPUParticlesCollision3DGizmoPlugin>(memnew(GPUParticlesCollision3DGizmoPlugin)));
@@ -10056,14 +10066,23 @@ void Node3DEditor::_register_all_gizmos() {
 	add_gizmo_plugin(Ref<VoxelGIGizmoPlugin>(memnew(VoxelGIGizmoPlugin)));
 	add_gizmo_plugin(Ref<LightmapGIGizmoPlugin>(memnew(LightmapGIGizmoPlugin)));
 	add_gizmo_plugin(Ref<LightmapProbeGizmoPlugin>(memnew(LightmapProbeGizmoPlugin)));
+	add_gizmo_plugin(Ref<FogVolumeGizmoPlugin>(memnew(FogVolumeGizmoPlugin)));
+#ifndef PHYSICS_3D_DISABLED
+	add_gizmo_plugin(Ref<SoftBody3DGizmoPlugin>(memnew(SoftBody3DGizmoPlugin)));
+	add_gizmo_plugin(Ref<RayCast3DGizmoPlugin>(memnew(RayCast3DGizmoPlugin)));
+	add_gizmo_plugin(Ref<ShapeCast3DGizmoPlugin>(memnew(ShapeCast3DGizmoPlugin)));
+	add_gizmo_plugin(Ref<SpringArm3DGizmoPlugin>(memnew(SpringArm3DGizmoPlugin)));
+	add_gizmo_plugin(Ref<SpringBoneCollision3DGizmoPlugin>(memnew(SpringBoneCollision3DGizmoPlugin)));
+	add_gizmo_plugin(Ref<SpringBoneSimulator3DGizmoPlugin>(memnew(SpringBoneSimulator3DGizmoPlugin)));
+	add_gizmo_plugin(Ref<VehicleWheel3DGizmoPlugin>(memnew(VehicleWheel3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<CollisionObject3DGizmoPlugin>(memnew(CollisionObject3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<CollisionShape3DGizmoPlugin>(memnew(CollisionShape3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<CollisionPolygon3DGizmoPlugin>(memnew(CollisionPolygon3DGizmoPlugin)));
-	add_gizmo_plugin(Ref<Joint3DGizmoPlugin>(memnew(Joint3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<PhysicalBone3DGizmoPlugin>(memnew(PhysicalBone3DGizmoPlugin)));
-	add_gizmo_plugin(Ref<FogVolumeGizmoPlugin>(memnew(FogVolumeGizmoPlugin)));
 	add_gizmo_plugin(Ref<TwoBoneIK3DGizmoPlugin>(memnew(TwoBoneIK3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<ChainIK3DGizmoPlugin>(memnew(ChainIK3DGizmoPlugin)));
+	add_gizmo_plugin(Ref<Joint3DGizmoPlugin>(memnew(Joint3DGizmoPlugin)));
+#endif // PHYSICS_3D_DISABLED
 }
 
 void Node3DEditor::_bind_methods() {

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -67,16 +67,6 @@
 #include "editor/scene/3d/gizmos/mesh_instance_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/occluder_instance_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/particles_3d_emission_shape_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/collision_object_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/collision_polygon_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/physics_bone_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/ray_cast_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/shape_cast_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/soft_body_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/spring_arm_3d_gizmo_plugin.h"
-#include "editor/scene/3d/gizmos/physics/vehicle_body_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/reflection_probe_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/spring_bone_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/sprite_base_3d_gizmo_plugin.h"
@@ -90,8 +80,9 @@
 #include "editor/translations/editor_translation_preview_menu.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/light_3d.h"
-#include "scene/3d/physics/collision_shape_3d.h"
-#include "scene/3d/physics/physics_body_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/sprite_3d.h"
+#include "scene/3d/visual_instance_3d.h"
 #include "scene/3d/world_environment.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
@@ -117,7 +108,7192 @@
 #include "modules/texture_streaming/texture_streaming.h"
 #endif
 
+#ifndef PHYSICS_3D_DISABLED
+#include "editor/scene/3d/gizmos/physics/collision_object_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/collision_polygon_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/physics_bone_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/ray_cast_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/shape_cast_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/soft_body_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/spring_arm_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/vehicle_body_3d_gizmo_plugin.h"
+#include "scene/3d/physics/collision_shape_3d.h"
+#include "scene/3d/physics/physics_body_3d.h"
+#endif // PHYSICS_3D_DISABLED
+
 using namespace Node3DEditorConstants;
+
+void ViewportNavigationControl::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			if (viewport != nullptr) {
+				_draw();
+				_update_navigation();
+			}
+		} break;
+
+		case NOTIFICATION_MOUSE_ENTER: {
+			hovered = true;
+			queue_redraw();
+		} break;
+
+		case NOTIFICATION_MOUSE_EXIT: {
+			hovered = false;
+			queue_redraw();
+		} break;
+	}
+}
+
+void ViewportNavigationControl::_draw() {
+	if (nav_mode == View3DController::NAV_MODE_NONE) {
+		return;
+	}
+
+	Vector2 center = get_size() / 2.0;
+	float radius = get_size().x / 2.0;
+
+	const bool focused = focused_index != -1;
+	draw_circle(center, radius, Color(0.5, 0.5, 0.5, focused || hovered ? 0.35 : 0.15));
+
+	const Color c = focused ? Color(0.9, 0.9, 0.9, 0.9) : Color(0.5, 0.5, 0.5, 0.25);
+
+	Vector2 circle_pos = focused ? center.move_toward(focused_pos, radius) : center;
+
+	draw_circle(circle_pos, AXIS_CIRCLE_RADIUS, c);
+	draw_circle(circle_pos, AXIS_CIRCLE_RADIUS * 0.8, c.darkened(0.4));
+}
+
+void ViewportNavigationControl::_process_click(int p_index, Vector2 p_position, bool p_pressed) {
+	hovered = false;
+	queue_redraw();
+
+	if (focused_index != -1 && focused_index != p_index) {
+		return;
+	}
+	if (p_pressed) {
+		if (p_position.distance_to(get_size() / 2.0) < get_size().x / 2.0) {
+			focused_pos = p_position;
+			focused_index = p_index;
+			queue_redraw();
+		}
+	} else {
+		focused_index = -1;
+		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
+			Input::get_singleton()->warp_mouse(focused_mouse_start);
+		}
+	}
+}
+
+void ViewportNavigationControl::_process_drag(int p_index, Vector2 p_position, Vector2 p_relative_position) {
+	if (focused_index == p_index) {
+		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_VISIBLE) {
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
+			focused_mouse_start = p_position;
+		}
+		focused_pos += p_relative_position;
+		queue_redraw();
+	}
+}
+
+void ViewportNavigationControl::gui_input(const Ref<InputEvent> &p_event) {
+	// Mouse events
+	const Ref<InputEventMouseButton> mouse_button = p_event;
+	if (mouse_button.is_valid() && mouse_button->get_button_index() == MouseButton::LEFT) {
+		_process_click(100, mouse_button->get_position(), mouse_button->is_pressed());
+	}
+
+	const Ref<InputEventMouseMotion> mouse_motion = p_event;
+	if (mouse_motion.is_valid()) {
+		_process_drag(100, mouse_motion->get_global_position(), viewport->view_3d_controller->get_warped_mouse_motion(mouse_motion, viewport->surface->get_global_rect()));
+	}
+
+	// Touch events
+	const Ref<InputEventScreenTouch> screen_touch = p_event;
+	if (screen_touch.is_valid()) {
+		_process_click(screen_touch->get_index(), screen_touch->get_position(), screen_touch->is_pressed());
+	}
+
+	const Ref<InputEventScreenDrag> screen_drag = p_event;
+	if (screen_drag.is_valid()) {
+		_process_drag(screen_drag->get_index(), screen_drag->get_position(), screen_drag->get_relative());
+	}
+}
+
+void ViewportNavigationControl::_update_navigation() {
+	if (focused_index == -1) {
+		return;
+	}
+
+	Vector2 delta = focused_pos - (get_size() / 2.0);
+	Vector2 delta_normalized = delta.normalized();
+	switch (nav_mode) {
+		case View3DController::NAV_MODE_MOVE: {
+			real_t speed_multiplier = MIN(delta.length() / (get_size().x * 100.0), 3.0);
+			real_t speed = viewport->view_3d_controller->get_freelook_speed() * speed_multiplier;
+
+			Vector3 forward;
+			if (viewport->view_3d_controller->get_freelook_scheme() == View3DController::FreelookScheme::FREELOOK_FULLY_AXIS_LOCKED) {
+				// Forward/backward keys will always go straight forward/backward, never moving on the Y axis.
+				forward = Vector3(0, 0, delta_normalized.y).rotated(Vector3(0, 1, 0), viewport->camera->get_rotation().y);
+			} else {
+				// Forward/backward keys will be relative to the camera pitch.
+				forward = viewport->camera->get_transform().basis.xform(Vector3(0, 0, delta_normalized.y));
+			}
+
+			const Vector3 right = viewport->camera->get_transform().basis.xform(Vector3(delta_normalized.x, 0, 0));
+
+			const Vector3 direction = forward + right;
+			const Vector3 motion = direction * speed;
+			viewport->view_3d_controller->cursor.pos += motion;
+			viewport->view_3d_controller->cursor.eye_pos += motion;
+		} break;
+
+		case View3DController::NAV_MODE_LOOK: {
+			real_t speed_multiplier = MIN(delta.length() / (get_size().x * 2.5), 3.0);
+			real_t speed = viewport->view_3d_controller->get_freelook_speed() * speed_multiplier;
+			viewport->view_3d_controller->cursor_look(nullptr, delta_normalized * speed);
+		} break;
+
+		case View3DController::NAV_MODE_PAN: {
+			real_t speed_multiplier = MIN(delta.length() / (get_size().x), 3.0);
+			real_t speed = viewport->view_3d_controller->get_freelook_speed() * speed_multiplier;
+			viewport->view_3d_controller->cursor_pan(nullptr, -delta_normalized * speed);
+		} break;
+		case View3DController::NAV_MODE_ZOOM: {
+			real_t speed_multiplier = MIN(delta.length() / (get_size().x), 3.0);
+			real_t speed = viewport->view_3d_controller->get_freelook_speed() * speed_multiplier;
+			viewport->view_3d_controller->cursor_zoom(nullptr, delta_normalized * speed);
+		} break;
+		case View3DController::NAV_MODE_ORBIT: {
+			real_t speed_multiplier = MIN(delta.length() / (get_size().x), 3.0);
+			real_t speed = viewport->view_3d_controller->get_freelook_speed() * speed_multiplier;
+			viewport->view_3d_controller->cursor_orbit(nullptr, delta_normalized * speed);
+		} break;
+		case View3DController::NAV_MODE_NONE: {
+		} break;
+	}
+}
+
+void ViewportNavigationControl::set_navigation_mode(View3DController::NavigationMode p_nav_mode) {
+	nav_mode = p_nav_mode;
+}
+
+void ViewportNavigationControl::set_viewport(Node3DEditorViewport *p_viewport) {
+	viewport = p_viewport;
+}
+
+void ViewportRotationControl::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			axis_menu_options.clear();
+			axis_menu_options.push_back(Node3DEditorViewport::VIEW_RIGHT);
+			axis_menu_options.push_back(Node3DEditorViewport::VIEW_TOP);
+			axis_menu_options.push_back(Node3DEditorViewport::VIEW_FRONT);
+			axis_menu_options.push_back(Node3DEditorViewport::VIEW_LEFT);
+			axis_menu_options.push_back(Node3DEditorViewport::VIEW_BOTTOM);
+			axis_menu_options.push_back(Node3DEditorViewport::VIEW_REAR);
+
+			axis_colors.clear();
+			axis_colors.push_back(get_theme_color(SNAME("axis_x_color"), EditorStringName(Editor)));
+			axis_colors.push_back(get_theme_color(SNAME("axis_y_color"), EditorStringName(Editor)));
+			axis_colors.push_back(get_theme_color(SNAME("axis_z_color"), EditorStringName(Editor)));
+			queue_redraw();
+		} break;
+
+		case NOTIFICATION_DRAW: {
+			if (viewport != nullptr) {
+				_draw();
+			}
+		} break;
+
+		case NOTIFICATION_MOUSE_EXIT: {
+			focused_axis = -2;
+			queue_redraw();
+		} break;
+
+		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
+			gizmo_activated = false;
+		} break;
+	}
+}
+
+void ViewportRotationControl::_draw() {
+	const Vector2 center = get_size() / 2.0;
+	const real_t radius = get_size().x / 2.0;
+
+	if (focused_axis > -2 || orbiting_index != -1) {
+		draw_circle(center, radius, Color(0.5, 0.5, 0.5, 0.25), true, -1.0, true);
+	}
+
+	Vector<Axis2D> axis_to_draw;
+	_get_sorted_axis(axis_to_draw);
+	for (int i = 0; i < axis_to_draw.size(); ++i) {
+		_draw_axis(axis_to_draw[i]);
+	}
+}
+
+void ViewportRotationControl::_draw_axis(const Axis2D &p_axis) {
+	const bool focused = focused_axis == p_axis.axis;
+	const bool positive = p_axis.is_positive;
+	const int direction = p_axis.axis % 3;
+
+	const Color axis_color = axis_colors[direction];
+	const double min_alpha = 0.35;
+	const double alpha = focused ? 1.0 : Math::remap((p_axis.z_axis + 1.0) / 2.0, 0, 0.5, min_alpha, 1.0);
+	const Color c = focused ? Color(axis_color.lightened(0.25), 1.0) : Color(axis_color, alpha);
+
+	// Highlight positive axis text when hovered.
+	const Color c_positive_axis = focused ? Color(1.0, 1.0, 1.0, alpha) : Color(0.0, 0.0, 0.0, alpha * 0.6);
+
+	// Highlight negative axis text when hovered, but hide when not focused.
+	const Color c_negative_axis = focused ? Color(1.0, 1.0, 1.0, alpha) : Color(axis_color, 0);
+
+	if (positive) {
+		// Draw axis lines for the positive axes.
+		const Vector2 center = get_size() / 2.0;
+		const Vector2 diff = p_axis.screen_point - center;
+		const float line_length = MAX(diff.length() - AXIS_CIRCLE_RADIUS - 0.5 * EDSCALE, 0);
+
+		draw_line(center + diff.limit_length(0.5 * EDSCALE), center + diff.limit_length(line_length), c, 1.5 * EDSCALE, true);
+
+		draw_circle(p_axis.screen_point, AXIS_CIRCLE_RADIUS, c, true, -1.0, true);
+
+		// Draw the axis letter for the positive axes.
+		const String axis_name = direction == 0 ? "X" : (direction == 1 ? "Y" : "Z");
+		const Ref<Font> &font = get_theme_font(SNAME("rotation_control"), EditorStringName(EditorFonts));
+		const int font_size = get_theme_font_size(SNAME("rotation_control_size"), EditorStringName(EditorFonts));
+		const Size2 char_size = font->get_char_size(axis_name[0], font_size);
+		const Vector2 char_offset = Vector2(-char_size.width / 2.0, char_size.height * 0.25);
+		draw_char(font, p_axis.screen_point + char_offset, axis_name, font_size, c_positive_axis);
+	} else {
+		// Draw an outline around the negative axes.
+		draw_circle(p_axis.screen_point, AXIS_CIRCLE_RADIUS, c, true, -1.0, true);
+		draw_circle(p_axis.screen_point, AXIS_CIRCLE_RADIUS * 0.8, c.darkened(0.4), true, -1.0, true);
+
+		// Draw the text for the negative axes.
+		const String axis_name = direction == 0 ? "-X" : (direction == 1 ? "-Y" : "-Z");
+		const Ref<Font> &font = get_theme_font(SNAME("rotation_control"), EditorStringName(EditorFonts));
+		const int font_size = get_theme_font_size(SNAME("rotation_control_size"), EditorStringName(EditorFonts));
+		const Size2 string_size = font->get_string_size(axis_name, HORIZONTAL_ALIGNMENT_LEFT, -1.0f, font_size);
+		const float font_ascent = font->get_ascent(font_size);
+		const float font_descent = font->get_descent(font_size);
+		const float string_height = font_ascent + font_descent;
+		const Vector2 offset(-string_size.width / 2.0, string_height * 0.25);
+		draw_string(font, p_axis.screen_point + offset, axis_name, HORIZONTAL_ALIGNMENT_LEFT, -1.0f, font_size, c_negative_axis);
+	}
+}
+
+void ViewportRotationControl::_get_sorted_axis(Vector<Axis2D> &r_axis) {
+	const Vector2 center = get_size() / 2.0;
+	const real_t radius = get_size().x / 2.0 - AXIS_CIRCLE_RADIUS - 2.0 * EDSCALE;
+	const Basis camera_basis = viewport->view_3d_controller->to_camera_transform().get_basis().inverse();
+
+	for (int i = 0; i < 3; ++i) {
+		Vector3 axis_3d = camera_basis.get_column(i);
+		Vector2 axis_vector = Vector2(axis_3d.x, -axis_3d.y) * radius;
+
+		if (Math::abs(axis_3d.z) < 1.0) {
+			Axis2D pos_axis;
+			pos_axis.axis = i;
+			pos_axis.screen_point = center + axis_vector;
+			pos_axis.z_axis = axis_3d.z;
+			pos_axis.is_positive = true;
+			r_axis.push_back(pos_axis);
+
+			Axis2D neg_axis;
+			neg_axis.axis = i + 3;
+			neg_axis.screen_point = center - axis_vector;
+			neg_axis.z_axis = -axis_3d.z;
+			neg_axis.is_positive = false;
+			r_axis.push_back(neg_axis);
+		} else {
+			// Special case when the camera is aligned with one axis.
+			Axis2D axis;
+			axis.axis = i + (axis_3d.z <= 0 ? 0 : 3);
+			axis.screen_point = center;
+			axis.z_axis = 1.0;
+			// Invert display style to fix aligned axis rendering.
+			axis.is_positive = (axis_3d.z > 0);
+			r_axis.push_back(axis);
+		}
+	}
+
+	r_axis.sort_custom<Axis2DCompare>();
+}
+
+void ViewportRotationControl::_process_click(int p_index, Vector2 p_position, bool p_pressed) {
+	if (orbiting_index != -1 && orbiting_index != p_index) {
+		return;
+	}
+	if (p_pressed) {
+		if (p_position.distance_to(get_size() / 2.0) < get_size().x / 2.0) {
+			orbiting_index = p_index;
+		}
+	} else {
+		if (focused_axis > -1 && gizmo_activated) {
+			viewport->_menu_option(axis_menu_options[focused_axis]);
+			_update_focus();
+		}
+		orbiting_index = -1;
+		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
+			Input::get_singleton()->warp_mouse(orbiting_mouse_start);
+		}
+	}
+}
+
+void ViewportRotationControl::_process_drag(Ref<InputEventWithModifiers> p_event, int p_index, Vector2 p_position, Vector2 p_relative_position) {
+	Point2 mouse_pos = get_local_mouse_position();
+	const bool movement_threshold_passed = original_mouse_pos.distance_to(mouse_pos) > 4 * EDSCALE;
+	if (orbiting_index == p_index && gizmo_activated && movement_threshold_passed) {
+		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_VISIBLE) {
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
+			orbiting_mouse_start = p_position;
+			saved_cursor = viewport->view_3d_controller->cursor;
+		}
+		viewport->view_3d_controller->cursor_orbit(p_event, p_relative_position);
+		focused_axis = -1;
+	} else {
+		_update_focus();
+	}
+}
+
+void ViewportRotationControl::gui_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	// Key events
+	const Ref<InputEventKey> k = p_event;
+
+	if (k.is_valid() && k->is_action_pressed(SNAME("ui_cancel"), false, true)) {
+		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
+			Input::get_singleton()->warp_mouse(orbiting_mouse_start);
+			viewport->view_3d_controller->cursor = saved_cursor;
+			gizmo_activated = false;
+		}
+	}
+
+	// Mouse events
+	const Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid()) {
+		if (mb->get_button_index() == MouseButton::LEFT) {
+			_process_click(100, mb->get_position(), mb->is_pressed());
+			if (mb->is_pressed()) {
+				gizmo_activated = true;
+				original_mouse_pos = get_local_mouse_position();
+				grab_focus();
+			}
+		} else if (mb->get_button_index() == MouseButton::RIGHT) {
+			if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
+				Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
+				Input::get_singleton()->warp_mouse(orbiting_mouse_start);
+				viewport->view_3d_controller->cursor = saved_cursor;
+				gizmo_activated = false;
+			}
+		}
+	}
+
+	const Ref<InputEventMouseMotion> mm = p_event;
+	if (mm.is_valid()) {
+		_process_drag(mm, 100, mm->get_global_position(), viewport->view_3d_controller->get_warped_mouse_motion(mm, viewport->surface->get_global_rect()));
+	}
+
+	// Touch events
+	const Ref<InputEventScreenTouch> screen_touch = p_event;
+	if (screen_touch.is_valid()) {
+		_process_click(screen_touch->get_index(), screen_touch->get_position(), screen_touch->is_pressed());
+	}
+
+	const Ref<InputEventScreenDrag> screen_drag = p_event;
+	if (screen_drag.is_valid()) {
+		_process_drag(nullptr, screen_drag->get_index(), screen_drag->get_position(), screen_drag->get_relative());
+	}
+}
+
+void ViewportRotationControl::_update_focus() {
+	int original_focus = focused_axis;
+	focused_axis = -2;
+	Vector2 mouse_pos = get_local_mouse_position();
+
+	if (mouse_pos.distance_to(get_size() / 2.0) < get_size().x / 2.0) {
+		focused_axis = -1;
+	}
+
+	Vector<Axis2D> axes;
+	_get_sorted_axis(axes);
+
+	for (int i = 0; i < axes.size(); i++) {
+		const Axis2D &axis = axes[i];
+		if (mouse_pos.distance_to(axis.screen_point) < AXIS_CIRCLE_RADIUS) {
+			focused_axis = axis.axis;
+		}
+	}
+
+	if (focused_axis != original_focus) {
+		queue_redraw();
+	}
+}
+
+void ViewportRotationControl::set_viewport(Node3DEditorViewport *p_viewport) {
+	viewport = p_viewport;
+}
+
+void Node3DEditorViewport::_view_settings_confirmed(real_t p_interp_delta) {
+	// Set FOV override multiplier back to the default, so that the FOV
+	// setting specified in the View menu is correctly applied.
+	view_3d_controller->cursor.fov_scale = 1.0;
+
+	view_3d_controller->update_camera(p_interp_delta);
+}
+
+void Node3DEditorViewport::_update_navigation_controls_visibility() {
+	bool show_viewport_rotation_gizmo = EDITOR_GET("editors/3d/navigation/show_viewport_rotation_gizmo") && (!previewing_cinema && !previewing_camera);
+	rotation_control->set_visible(show_viewport_rotation_gizmo);
+
+	bool show_viewport_navigation_gizmo = EDITOR_GET("editors/3d/navigation/show_viewport_navigation_gizmo") && (!previewing_cinema && !previewing_camera);
+	position_control->set_visible(show_viewport_navigation_gizmo);
+	look_control->set_visible(show_viewport_navigation_gizmo);
+}
+
+bool Node3DEditorViewport::_is_rotation_arc_visible() const {
+	return _edit.mode == TRANSFORM_ROTATE && !Math::is_zero_approx(_edit.accumulated_rotation_angle) && _edit.gizmo_initiated;
+}
+
+int Node3DEditorViewport::get_selected_count() const {
+	const HashMap<ObjectID, Object *> &selection = editor_selection->get_selection();
+
+	int count = 0;
+
+	for (const KeyValue<ObjectID, Object *> &E : selection) {
+		Node3D *sp = ObjectDB::get_instance<Node3D>(E.key);
+		if (!sp) {
+			continue;
+		}
+
+		Node3DEditorSelectedItem *se = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(sp);
+		if (!se) {
+			continue;
+		}
+
+		count++;
+	}
+
+	return count;
+}
+
+void Node3DEditorViewport::cancel_transform() {
+	const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+
+	for (Node *E : selection) {
+		Node3D *sp = Object::cast_to<Node3D>(E);
+		if (!sp) {
+			continue;
+		}
+
+		Node3DEditorSelectedItem *se = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(sp);
+		if (!se) {
+			continue;
+		}
+
+		if (se && se->gizmo.is_valid()) {
+			Vector<int> ids;
+			Vector<Transform3D> restore;
+
+			for (const KeyValue<int, Transform3D> &GE : se->subgizmos) {
+				ids.push_back(GE.key);
+				restore.push_back(GE.value);
+			}
+
+			se->gizmo->commit_subgizmos(ids, restore, true);
+		}
+
+		sp->set_global_transform(se->original);
+	}
+
+	for (const KeyValue<Node3D *, Transform3D> &pair : _edit.children_original_globals) {
+		pair.key->set_global_transform(pair.value);
+	}
+
+	collision_reposition = false;
+	finish_transform();
+	set_message(TTRC("Transform Aborted."), 3);
+}
+
+void Node3DEditorViewport::_update_shrink() {
+	const float scaling_3d_scale = GLOBAL_GET("rendering/scaling_3d/scale");
+	const float shrink_factor = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_HALF_RESOLUTION)) ? 0.5 : 1.0;
+	viewport->set_scaling_3d_scale(MAX(0.25, scaling_3d_scale * shrink_factor));
+}
+
+float Node3DEditorViewport::get_znear() const {
+	return CLAMP(spatial_editor->get_znear(), MIN_Z, MAX_Z);
+}
+
+float Node3DEditorViewport::get_zfar() const {
+	return CLAMP(spatial_editor->get_zfar(), MIN_Z, MAX_Z);
+}
+
+float Node3DEditorViewport::get_fov() const {
+	return CLAMP(spatial_editor->get_fov() * view_3d_controller->cursor.fov_scale, MIN_FOV, MAX_FOV);
+}
+
+Transform3D Node3DEditorViewport::_get_camera_transform() const {
+	return camera->get_global_transform();
+}
+
+Vector3 Node3DEditorViewport::_get_camera_position() const {
+	return _get_camera_transform().origin;
+}
+
+Point2 Node3DEditorViewport::point_to_screen(const Vector3 &p_point) {
+	return camera->unproject_position(p_point);
+}
+
+Vector3 Node3DEditorViewport::get_ray_pos(const Vector2 &p_pos) const {
+	return camera->project_ray_origin(p_pos);
+}
+
+Vector3 Node3DEditorViewport::_get_camera_normal() const {
+	return -_get_camera_transform().basis.get_column(2);
+}
+
+Vector3 Node3DEditorViewport::get_ray(const Vector2 &p_pos) const {
+	return camera->project_ray_normal(p_pos);
+}
+
+void Node3DEditorViewport::_clear_selected() {
+	if (previewing) {
+		return;
+	}
+
+	_edit.gizmo = Ref<EditorNode3DGizmo>();
+	_edit.gizmo_handle = -1;
+	_edit.gizmo_handle_secondary = false;
+	_edit.gizmo_initial_value = Variant();
+
+	Node3D *selected = spatial_editor->get_single_selected_node();
+	Node3DEditorSelectedItem *se = selected ? editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(selected) : nullptr;
+
+	if (se && se->gizmo.is_valid()) {
+		se->subgizmos.clear();
+		se->gizmo->redraw();
+		se->gizmo.unref();
+		spatial_editor->update_transform_gizmo();
+	} else {
+		editor_selection->clear();
+		Node3DEditor::get_singleton()->edit(nullptr);
+	}
+}
+
+void Node3DEditorViewport::_select_clicked(bool p_allow_locked) {
+	if (previewing) {
+		clicked = ObjectID();
+		return;
+	}
+
+	Node *node = ObjectDB::get_instance<Node3D>(clicked);
+	Node3D *selected = Object::cast_to<Node3D>(node);
+	clicked = ObjectID();
+
+	if (!selected) {
+		return;
+	}
+
+	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
+
+	// Prevent selection of nodes not owned by the edited scene.
+	while (node && node != edited_scene->get_parent()) {
+		Node *node_owner = node->get_owner();
+		if (node_owner == edited_scene || node == edited_scene || (node_owner != nullptr && edited_scene->is_editable_instance(node_owner))) {
+			break;
+		}
+		node = node->get_parent();
+		selected = Object::cast_to<Node3D>(node);
+	}
+
+	if (!p_allow_locked) {
+		// Replace the node by the group if grouped
+		while (node && node != edited_scene->get_parent()) {
+			Node3D *selected_tmp = Object::cast_to<Node3D>(node);
+			if (selected_tmp && node->has_meta("_edit_group_")) {
+				selected = selected_tmp;
+			}
+			node = node->get_parent();
+		}
+	}
+
+	if (p_allow_locked || (selected != nullptr && !_is_node_locked(selected))) {
+		if (clicked_wants_append) {
+			const List<Node *> &top_node_list = editor_selection->get_top_selected_node_list();
+			const Node *active_node = top_node_list.is_empty() ? nullptr : top_node_list.back()->get();
+			if (editor_selection->is_selected(selected)) {
+				editor_selection->remove_node(selected);
+				if (selected != active_node) {
+					editor_selection->add_node(selected);
+				}
+			} else {
+				editor_selection->add_node(selected);
+			}
+		} else {
+			if (!editor_selection->is_selected(selected)) {
+				editor_selection->clear();
+				editor_selection->add_node(selected);
+				EditorNode::get_singleton()->edit_node(selected);
+			}
+		}
+
+		const List<Node *> &top_node_list = editor_selection->get_top_selected_node_list();
+		if (top_node_list.size() == 1) {
+			EditorNode::get_singleton()->edit_node(top_node_list.front()->get());
+		}
+	}
+}
+
+ObjectID Node3DEditorViewport::_select_ray(const Point2 &p_pos) const {
+	Vector3 ray = get_ray(p_pos);
+	Vector3 pos = get_ray_pos(p_pos);
+	Vector2 shrinked_pos = p_pos;
+
+	if (viewport->get_debug_draw() == Viewport::DEBUG_DRAW_SDFGI_PROBES) {
+		RS::get_singleton()->sdfgi_set_debug_probe_select(pos, ray);
+	}
+
+	HashSet<Ref<EditorNode3DGizmo>> found_gizmos;
+
+	Node *edited_scene = get_tree()->get_edited_scene_root();
+	ObjectID closest;
+	Node *item = nullptr;
+	float closest_dist = 1e20;
+
+	Vector<Node3D *> nodes_with_gizmos = Node3DEditor::get_singleton()->gizmo_bvh_ray_query(pos, pos + ray * camera->get_far());
+
+	for (Node3D *spat : nodes_with_gizmos) {
+		if (!spat || _is_node_locked(spat)) {
+			continue;
+		}
+
+		Vector<Ref<Node3DGizmo>> gizmos = spat->get_gizmos();
+
+		for (int j = 0; j < gizmos.size(); j++) {
+			Ref<EditorNode3DGizmo> seg = gizmos[j];
+
+			if (seg.is_null() || found_gizmos.has(seg)) {
+				continue;
+			}
+
+			found_gizmos.insert(seg);
+			Vector3 point;
+			Vector3 normal;
+
+			bool inters = seg->intersect_ray(camera, shrinked_pos, point, normal);
+
+			if (!inters) {
+				continue;
+			}
+
+			const real_t dist = pos.distance_to(point);
+
+			if (dist < 0) {
+				continue;
+			}
+
+			if (dist < closest_dist) {
+				item = Object::cast_to<Node>(spat);
+				if (item != edited_scene) {
+					item = edited_scene->get_deepest_editable_node(item);
+				}
+
+				closest = item->get_instance_id();
+				closest_dist = dist;
+			}
+		}
+	}
+
+	if (!item) {
+		return ObjectID();
+	}
+
+	return closest;
+}
+
+float Node3DEditorViewport::_min_screen_dist_to_aabb(const AABB &p_aabb, const Transform3D &p_transform, const Point2 &p_cursor) const {
+	Vector3 first_corner = p_transform.xform(p_aabb.get_endpoint(0));
+	if (camera->is_position_behind(first_corner)) {
+		return 0.0f;
+	}
+	Point2 screen_min = camera->unproject_position(first_corner);
+	Point2 screen_max = screen_min;
+
+	for (int i = 1; i < 8; i++) {
+		Vector3 world_corner = p_transform.xform(p_aabb.get_endpoint(i));
+		if (camera->is_position_behind(world_corner)) {
+			return 0.0f;
+		}
+		Point2 s = camera->unproject_position(world_corner);
+		screen_min = screen_min.min(s);
+		screen_max = screen_max.max(s);
+	}
+
+	float dx = MAX(screen_min.x - p_cursor.x, MAX(0.0f, p_cursor.x - screen_max.x));
+	float dy = MAX(screen_min.y - p_cursor.y, MAX(0.0f, p_cursor.y - screen_max.y));
+	return Math::sqrt(dx * dx + dy * dy);
+}
+
+static bool _node_is_snap_source(Node *p_node, bool p_use_collision) {
+	if (!p_use_collision) {
+		return Object::cast_to<GeometryInstance3D>(p_node);
+	}
+#ifndef PHYSICS_3D_DISABLED
+	if (Object::cast_to<CollisionShape3D>(p_node)) {
+		return true;
+	}
+#endif // PHYSICS_3D_DISABLED
+	Node3D *n3d = Object::cast_to<Node3D>(p_node);
+	if (!n3d) {
+		return false;
+	}
+	for (const Ref<Node3DGizmo> &g : n3d->get_gizmos()) {
+		Ref<EditorNode3DGizmo> seg = g;
+		if (seg.is_valid() && seg->get_collision_meshes_are_snap_source()) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool _node_has_snap_target(Node *p_node, bool p_use_collision) {
+	if (_node_is_snap_source(p_node, p_use_collision)) {
+		return true;
+	}
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		if (_node_has_snap_target(p_node->get_child(i), p_use_collision)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool Node3DEditorViewport::_find_closest_vertex_on_node(const Point2 &p_screen_pos, Node3D *p_node, float &r_closest_screen_dist, Vector3 &r_vertex_world) const {
+	bool found = false;
+	bool use_collision = Node3DEditor::get_singleton()->is_vertex_snap_use_collision();
+	bool walk_collision_segments = use_collision && Object::cast_to<CollisionShape3D>(p_node);
+
+	Transform3D gt = p_node->get_global_transform();
+	Vector<Ref<Node3DGizmo>> gizmos = p_node->get_gizmos();
+
+	for (int i = 0; i < gizmos.size(); i++) {
+		Ref<EditorNode3DGizmo> seg = gizmos[i];
+		if (seg.is_null()) {
+			continue;
+		}
+
+		if (walk_collision_segments) {
+			const Vector<Vector3> &segments = seg->get_collision_segments();
+			for (int si = 0; si < segments.size(); si++) {
+				Vector3 world_v = gt.xform(segments[si]);
+				if (camera->is_position_behind(world_v)) {
+					continue;
+				}
+				Vector2 screen_v = camera->unproject_position(world_v);
+				float dist = screen_v.distance_to(p_screen_pos);
+				if (dist < r_closest_screen_dist) {
+					r_closest_screen_dist = dist;
+					r_vertex_world = world_v;
+					found = true;
+				}
+			}
+		}
+
+		if (!use_collision || seg->get_collision_meshes_are_snap_source()) {
+			const LocalVector<Ref<TriangleMesh>> &meshes = seg->get_collision_meshes();
+			for (const Ref<TriangleMesh> &tm : meshes) {
+				if (tm.is_null() || !tm->is_valid()) {
+					continue;
+				}
+
+				const Vector<TriangleMesh::BVH> &bvh = tm->get_bvh();
+				const Vector<TriangleMesh::Triangle> &triangles = tm->get_triangles();
+				const Vector<Vector3> &vertices = tm->get_vertices();
+
+				if (bvh.is_empty()) {
+					continue;
+				}
+
+				// Traverse the TriangleMesh BVH, pruning branches whose screen-space
+				// AABB is farther than the current best.
+				LocalVector<int> stack;
+				stack.push_back(bvh.size() - 1);
+
+				while (!stack.is_empty()) {
+					int node_idx = stack[stack.size() - 1];
+					stack.resize(stack.size() - 1);
+
+					const TriangleMesh::BVH &b = bvh[node_idx];
+
+					if (_min_screen_dist_to_aabb(b.aabb, gt, p_screen_pos) >= r_closest_screen_dist) {
+						continue;
+					}
+
+					if (b.face_index >= 0) {
+						const TriangleMesh::Triangle &tri = triangles[b.face_index];
+						for (int vi = 0; vi < 3; vi++) {
+							Vector3 world_v = gt.xform(vertices[tri.indices[vi]]);
+							if (camera->is_position_behind(world_v)) {
+								continue;
+							}
+							Vector2 screen_v = camera->unproject_position(world_v);
+							float dist = screen_v.distance_to(p_screen_pos);
+							if (dist < r_closest_screen_dist) {
+								r_closest_screen_dist = dist;
+								r_vertex_world = world_v;
+								found = true;
+							}
+						}
+					} else {
+						stack.push_back(b.left);
+						stack.push_back(b.right);
+					}
+				}
+			}
+		}
+	}
+
+	return found;
+}
+
+bool Node3DEditorViewport::_find_closest_vertex_in_scene(const Point2 &p_screen_pos, float p_threshold, Vector3 &r_vertex_world, const HashMap<ObjectID, Vector3> *p_exclude) {
+	float closest_screen_dist = p_threshold;
+	bool found = false;
+
+	Point2 min_pos(p_screen_pos.x - p_threshold, p_screen_pos.y - p_threshold);
+	Point2 max_pos(p_screen_pos.x + p_threshold, p_screen_pos.y + p_threshold);
+	Vector<Node3D *> nodes_with_gizmos = Node3DEditor::get_singleton()->gizmo_bvh_frustum_query(_build_screen_frustum(min_pos, max_pos));
+
+	bool use_collision = Node3DEditor::get_singleton()->is_vertex_snap_use_collision();
+
+	for (Node3D *spat : nodes_with_gizmos) {
+		if (!spat) {
+			continue;
+		}
+
+		if (!_node_is_snap_source(spat, use_collision)) {
+			continue;
+		}
+
+		if (p_exclude) {
+			bool should_skip = false;
+			Node *current = spat;
+			while (current) {
+				if (p_exclude->has(current->get_instance_id())) {
+					should_skip = true;
+					break;
+				}
+				current = current->get_parent();
+			}
+			if (should_skip) {
+				continue;
+			}
+		}
+
+		if (_find_closest_vertex_on_node(p_screen_pos, spat, closest_screen_dist, r_vertex_world)) {
+			found = true;
+		}
+	}
+
+	return found;
+}
+
+void Node3DEditorViewport::_vertex_snap_commit() {
+	for (const KeyValue<ObjectID, Vector3> &E : vertex_snap_original_positions) {
+		Node3D *node = ObjectDB::get_instance<Node3D>(E.key);
+		if (node) {
+			vertex_snap_source += node->get_global_position() - E.value;
+			break;
+		}
+	}
+
+	HashMap<ObjectID, Vector3> original_positions;
+	for (const KeyValue<ObjectID, Vector3> &E : vertex_snap_original_positions) {
+		original_positions[E.key] = E.value;
+	}
+	vertex_snap_dragging = false;
+	vertex_snap_has_target = false;
+	vertex_snap_original_positions.clear();
+	if (!vertex_snap_mode) {
+		vertex_snap_has_source = false;
+		set_message("");
+	}
+	surface->queue_redraw();
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Vertex Snap"));
+	for (const KeyValue<ObjectID, Vector3> &E : original_positions) {
+		Node3D *node = ObjectDB::get_instance<Node3D>(E.key);
+		if (node) {
+			undo_redo->add_do_method(node, "set_global_position", node->get_global_position());
+			undo_redo->add_undo_method(node, "set_global_position", E.value);
+		}
+	}
+	undo_redo->commit_action(false);
+	_reset_follow_mode_count();
+}
+
+void Node3DEditorViewport::_vertex_snap_cancel() {
+	vertex_snap_mode = false;
+	vertex_snap_keycode = Key::NONE;
+	vertex_snap_dragging = false;
+	vertex_snap_has_source = false;
+	vertex_snap_has_target = false;
+
+	for (const KeyValue<ObjectID, Vector3> &E : vertex_snap_original_positions) {
+		Node3D *node = ObjectDB::get_instance<Node3D>(E.key);
+		if (node) {
+			node->set_global_position(E.value);
+		}
+	}
+	vertex_snap_original_positions.clear();
+	set_message(TTR("Vertex Snap Canceled."), 3);
+	surface->queue_redraw();
+}
+
+bool Node3DEditorViewport::_is_vertex_occluded(const Vector3 &p_world_pos, const Vector2 &p_screen_pos) const {
+	Vector3 ray_pos = get_ray_pos(p_screen_pos);
+	float vertex_dist = ray_pos.distance_to(p_world_pos);
+	Vector<Node3D *> hits = Node3DEditor::get_singleton()->gizmo_bvh_ray_query(ray_pos, ray_pos + get_ray(p_screen_pos) * camera->get_far());
+	for (Node3D *spat : hits) {
+		if (!spat) {
+			continue;
+		}
+		Vector<Ref<Node3DGizmo>> gizmos = spat->get_gizmos();
+		for (int i = 0; i < gizmos.size(); i++) {
+			Ref<EditorNode3DGizmo> seg = gizmos[i];
+			if (seg.is_null()) {
+				continue;
+			}
+			Vector3 point, normal;
+			if (seg->intersect_ray(camera, p_screen_pos, point, normal)) {
+				if (ray_pos.distance_to(point) < vertex_dist - 0.01f) {
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
+void Node3DEditorViewport::_vertex_snap_update_source(const Point2 &p_screen_pos) {
+	const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+	if (selection.is_empty()) {
+		vertex_snap_has_source = false;
+		return;
+	}
+
+	float threshold = VERTEX_SNAP_THRESHOLD * EDSCALE;
+	Vector3 vw;
+	bool found = false;
+
+	if (spatial_editor->is_vertex_snap_origin_mode()) {
+		found = _find_closest_vertex_in_scene(p_screen_pos, threshold, vw);
+	} else {
+		bool use_collision = spatial_editor->is_vertex_snap_use_collision();
+		bool selection_has_snap_target = false;
+		for (Node *E : selection) {
+			Node3D *sp = Object::cast_to<Node3D>(E);
+			if (!sp) {
+				continue;
+			}
+
+			LocalVector<Node3D *> descendants;
+			descendants.push_back(sp);
+			while (!descendants.is_empty()) {
+				Node3D *node = descendants[descendants.size() - 1];
+				descendants.resize(descendants.size() - 1);
+				if (_node_is_snap_source(node, use_collision)) {
+					selection_has_snap_target = true;
+					if (_find_closest_vertex_on_node(p_screen_pos, node, threshold, vw)) {
+						found = true;
+					}
+				}
+				for (int i = 0; i < node->get_child_count(); i++) {
+					Node3D *child = Object::cast_to<Node3D>(node->get_child(i));
+					if (child) {
+						descendants.push_back(child);
+					}
+				}
+			}
+		}
+
+		if (!found && !selection_has_snap_target) {
+			found = _find_closest_vertex_in_scene(p_screen_pos, threshold, vw);
+		}
+	}
+
+	if (found) {
+		vertex_snap_source = vw;
+		vertex_snap_has_source = true;
+	} else {
+		vertex_snap_has_source = false;
+	}
+}
+
+void Node3DEditorViewport::_find_items_at_pos(const Point2 &p_pos, Vector<_RayResult> &r_results, bool p_include_locked_nodes) {
+	Vector3 ray = get_ray(p_pos);
+	Vector3 pos = get_ray_pos(p_pos);
+
+	Vector<Node3D *> nodes_with_gizmos = Node3DEditor::get_singleton()->gizmo_bvh_ray_query(pos, pos + ray * camera->get_far());
+
+	HashSet<Node3D *> found_nodes;
+
+	for (Node3D *spat : nodes_with_gizmos) {
+		if (!spat) {
+			continue;
+		}
+
+		if (found_nodes.has(spat)) {
+			continue;
+		}
+
+		if (!p_include_locked_nodes && _is_node_locked(spat)) {
+			continue;
+		}
+
+		Vector<Ref<Node3DGizmo>> gizmos = spat->get_gizmos();
+		for (int j = 0; j < gizmos.size(); j++) {
+			Ref<EditorNode3DGizmo> seg = gizmos[j];
+
+			if (seg.is_null()) {
+				continue;
+			}
+
+			Vector3 point;
+			Vector3 normal;
+
+			bool inters = seg->intersect_ray(camera, p_pos, point, normal);
+
+			if (!inters) {
+				continue;
+			}
+
+			const real_t dist = pos.distance_to(point);
+
+			if (dist < 0) {
+				continue;
+			}
+
+			found_nodes.insert(spat);
+
+			_RayResult res;
+			res.item = spat;
+			res.depth = dist;
+			r_results.push_back(res);
+			break;
+		}
+	}
+
+	r_results.sort();
+}
+
+Vector3 Node3DEditorViewport::_get_screen_to_space(const Vector3 &p_vector3) {
+	Projection cm;
+	if (view_3d_controller->is_orthogonal()) {
+		cm.set_orthogonal(camera->get_size(), get_size().aspect(), get_znear() + p_vector3.z, get_zfar());
+	} else {
+		cm.set_perspective(get_fov(), get_size().aspect(), get_znear() + p_vector3.z, get_zfar());
+	}
+	Vector2 screen_he = cm.get_viewport_half_extents();
+
+	Transform3D camera_transform;
+	camera_transform.translate_local(view_3d_controller->cursor.pos);
+	camera_transform.basis.rotate(Vector3(1, 0, 0), -view_3d_controller->cursor.x_rot);
+	camera_transform.basis.rotate(Vector3(0, 1, 0), -view_3d_controller->cursor.y_rot);
+	camera_transform.translate_local(0, 0, view_3d_controller->cursor.distance);
+
+	return camera_transform.xform(Vector3(((p_vector3.x / get_size().width) * 2.0 - 1.0) * screen_he.x, ((1.0 - (p_vector3.y / get_size().height)) * 2.0 - 1.0) * screen_he.y, -(get_znear() + p_vector3.z)));
+}
+
+Vector<Plane> Node3DEditorViewport::_build_screen_frustum(const Point2 &p_min, const Point2 &p_max) {
+	const real_t z_offset = MAX(0.0, 5.0 - get_znear());
+	Vector3 box[4] = {
+		Vector3(p_min.x, p_min.y, z_offset),
+		Vector3(p_max.x, p_min.y, z_offset),
+		Vector3(p_max.x, p_max.y, z_offset),
+		Vector3(p_min.x, p_max.y, z_offset),
+	};
+
+	Vector<Plane> frustum;
+	Vector3 cam_pos = _get_camera_position();
+	for (int i = 0; i < 4; i++) {
+		Vector3 a = _get_screen_to_space(box[i]);
+		Vector3 b = _get_screen_to_space(box[(i + 1) % 4]);
+		if (view_3d_controller->is_orthogonal()) {
+			frustum.push_back(Plane((a - b).normalized(), a));
+		} else {
+			frustum.push_back(Plane(a, b, cam_pos));
+		}
+	}
+	Plane near_plane = Plane(-_get_camera_normal(), cam_pos);
+	near_plane.d -= get_znear();
+	frustum.push_back(near_plane);
+	Plane far_plane = -near_plane;
+	far_plane.d += get_zfar();
+	frustum.push_back(far_plane);
+	return frustum;
+}
+
+void Node3DEditorViewport::_select_region() {
+	View3DController::Cursor cursor = view_3d_controller->cursor;
+
+	if (cursor.region_begin == cursor.region_end) {
+		if (!clicked_wants_append) {
+			_clear_selected();
+		}
+		return;
+	}
+
+	Point2 region_min = cursor.region_begin.min(cursor.region_end);
+	Point2 region_max = cursor.region_begin.max(cursor.region_end);
+	Vector<Plane> frustum = _build_screen_frustum(region_min, region_max);
+
+	if (spatial_editor->get_single_selected_node()) {
+		Node3D *single_selected = spatial_editor->get_single_selected_node();
+		Node3DEditorSelectedItem *se = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(single_selected);
+
+		if (se) {
+			Ref<EditorNode3DGizmo> old_gizmo;
+			if (!clicked_wants_append) {
+				se->subgizmos.clear();
+				old_gizmo = se->gizmo;
+				se->gizmo.unref();
+			}
+
+			bool found_subgizmos = false;
+			Vector<Ref<Node3DGizmo>> gizmos = single_selected->get_gizmos();
+			for (int j = 0; j < gizmos.size(); j++) {
+				Ref<EditorNode3DGizmo> seg = gizmos[j];
+				if (seg.is_null()) {
+					continue;
+				}
+
+				if (se->gizmo.is_valid() && se->gizmo != seg) {
+					continue;
+				}
+
+				Vector<int> subgizmos = seg->subgizmos_intersect_frustum(camera, frustum);
+				if (!subgizmos.is_empty()) {
+					se->gizmo = seg;
+					for (int i = 0; i < subgizmos.size(); i++) {
+						int subgizmo_id = subgizmos[i];
+						if (!se->subgizmos.has(subgizmo_id)) {
+							se->subgizmos.insert(subgizmo_id, se->gizmo->get_subgizmo_transform(subgizmo_id));
+						}
+					}
+					found_subgizmos = true;
+					break;
+				}
+			}
+
+			if (!clicked_wants_append || found_subgizmos) {
+				if (se->gizmo.is_valid()) {
+					se->gizmo->redraw();
+				}
+
+				if (old_gizmo != se->gizmo && old_gizmo.is_valid()) {
+					old_gizmo->redraw();
+				}
+
+				spatial_editor->update_transform_gizmo();
+			}
+
+			if (found_subgizmos) {
+				return;
+			}
+		}
+	}
+
+	if (!clicked_wants_append) {
+		_clear_selected();
+	}
+
+	Vector<Node3D *> nodes_with_gizmos = Node3DEditor::get_singleton()->gizmo_bvh_frustum_query(frustum);
+	HashSet<Node3D *> found_nodes;
+	Vector<Node *> selected;
+
+	Node *edited_scene = get_tree()->get_edited_scene_root();
+	if (edited_scene == nullptr) {
+		return;
+	}
+
+	for (Node3D *sp : nodes_with_gizmos) {
+		if (!sp || _is_node_locked(sp)) {
+			continue;
+		}
+
+		if (found_nodes.has(sp)) {
+			continue;
+		}
+		found_nodes.insert(sp);
+
+		Node *node = Object::cast_to<Node>(sp);
+
+		// Selection requires that the node is the edited scene or its descendant, and has an owner.
+		if (node != edited_scene) {
+			if (!node->get_owner() || !edited_scene->is_ancestor_of(node)) {
+				continue;
+			}
+			node = edited_scene->get_deepest_editable_node(node);
+			while (node != edited_scene) {
+				Node *node_owner = node->get_owner();
+				if (node_owner == edited_scene || (node_owner != nullptr && edited_scene->is_editable_instance(node_owner))) {
+					break;
+				}
+				node = node->get_parent();
+			}
+		}
+
+		// Replace the node by the group if grouped
+		if (node->is_class("Node3D")) {
+			Node3D *sel = Object::cast_to<Node3D>(node);
+			while (node && node != EditorNode::get_singleton()->get_edited_scene()->get_parent()) {
+				Node3D *selected_tmp = Object::cast_to<Node3D>(node);
+				if (selected_tmp && node->has_meta("_edit_group_")) {
+					sel = selected_tmp;
+				}
+				node = node->get_parent();
+			}
+			node = sel;
+		}
+
+		if (_is_node_locked(node)) {
+			continue;
+		}
+
+		Vector<Ref<Node3DGizmo>> gizmos = sp->get_gizmos();
+		for (int j = 0; j < gizmos.size(); j++) {
+			Ref<EditorNode3DGizmo> seg = gizmos[j];
+			if (seg.is_null()) {
+				continue;
+			}
+
+			if (seg->intersect_frustum(camera, frustum)) {
+				selected.push_back(node);
+			}
+		}
+	}
+
+	for (int i = 0; i < selected.size(); i++) {
+		if (!editor_selection->is_selected(selected[i])) {
+			editor_selection->add_node(selected[i]);
+		}
+	}
+
+	const List<Node *> &top_node_list = editor_selection->get_top_selected_node_list();
+	if (top_node_list.size() == 1) {
+		EditorNode::get_singleton()->edit_node(top_node_list.front()->get());
+	}
+}
+
+void Node3DEditorViewport::_view_state_changed() {
+	if (view_3d_controller->get_orthogonal_mode() == View3DController::ORTHOGONAL_AUTO) {
+		_menu_option(VIEW_ORTHOGONAL);
+		view_3d_controller->force_auto_orthogonal();
+	} else if (view_3d_controller->get_orthogonal_mode() == View3DController::ORTHOGONAL_DISABLED) {
+		_menu_option(VIEW_PERSPECTIVE);
+	}
+	_update_name();
+}
+
+void Node3DEditorViewport::_update_name() {
+	view_display_menu->set_text(view_3d_controller->get_view_type_name());
+	view_display_menu->reset_size();
+}
+
+void Node3DEditorViewport::_compute_edit(const Point2 &p_point) {
+	_edit.original_local = spatial_editor->are_local_coords_enabled();
+	_edit.click_ray = get_ray(p_point);
+	_edit.click_ray_pos = get_ray_pos(p_point);
+	_edit.plane = TRANSFORM_VIEW;
+	spatial_editor->update_transform_gizmo();
+	_edit.center = spatial_editor->get_gizmo_transform().origin;
+
+	Node3D *selected = spatial_editor->get_single_selected_node();
+	Node3DEditorSelectedItem *se = selected ? editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(selected) : nullptr;
+
+	if (se && se->gizmo.is_valid()) {
+		for (const KeyValue<int, Transform3D> &E : se->subgizmos) {
+			int subgizmo_id = E.key;
+			se->subgizmos[subgizmo_id] = se->gizmo->get_subgizmo_transform(subgizmo_id);
+		}
+		se->original_local = selected->get_transform();
+		se->original = selected->get_global_transform();
+	} else {
+		const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+
+		for (Node *E : selection) {
+			Node3D *sp = Object::cast_to<Node3D>(E);
+			if (!sp) {
+				continue;
+			}
+
+			Node3DEditorSelectedItem *sel_item = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(sp);
+
+			if (!sel_item) {
+				continue;
+			}
+
+			sel_item->original_local = sel_item->sp->get_local_gizmo_transform();
+			sel_item->original = sel_item->sp->get_global_gizmo_transform();
+		}
+	}
+
+	if (spatial_editor->is_preserve_children_transform_enabled() && _edit.children_original_globals.is_empty()) {
+		const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+		for (Node *E : selection) {
+			Node3D *sp = Object::cast_to<Node3D>(E);
+			if (!sp) {
+				continue;
+			}
+
+			int child_count = sp->get_child_count();
+			for (int i = 0; i < child_count; i++) {
+				Node3D *child = Object::cast_to<Node3D>(sp->get_child(i));
+				if (child) {
+					_edit.children_original_globals[child] = child->get_global_transform();
+				}
+			}
+		}
+	}
+}
+
+static Key _get_key_modifier_setting(const String &p_property) {
+	switch (EDITOR_GET(p_property).operator int()) {
+		case 0:
+			return Key::NONE;
+		case 1:
+			return Key::SHIFT;
+		case 2:
+			return Key::ALT;
+		case 3:
+			return Key::META;
+		case 4:
+			return Key::CTRL;
+	}
+	return Key::NONE;
+}
+
+static Key _get_key_modifier(Ref<InputEventWithModifiers> e) {
+	if (e->is_shift_pressed()) {
+		return Key::SHIFT;
+	}
+	if (e->is_alt_pressed()) {
+		return Key::ALT;
+	}
+	if (e->is_ctrl_pressed()) {
+		return Key::CTRL;
+	}
+	if (e->is_meta_pressed()) {
+		return Key::META;
+	}
+	return Key::NONE;
+}
+
+bool Node3DEditorViewport::_transform_gizmo_select(const Vector2 &p_screenpos, bool p_highlight_only) {
+	if (!spatial_editor->is_gizmo_visible()) {
+		return false;
+	}
+	if (get_selected_count() == 0) {
+		if (p_highlight_only) {
+			spatial_editor->select_gizmo_highlight_axis(-1);
+		}
+		return false;
+	}
+
+	Vector3 ray_pos = get_ray_pos(p_screenpos);
+	Vector3 ray = get_ray(p_screenpos);
+
+	Transform3D gt = spatial_editor->get_gizmo_transform();
+
+	if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE) {
+		int col_axis = -1;
+		real_t col_d = 1e20;
+
+		for (int i = 0; i < 3; i++) {
+			const Vector3 grabber_pos = gt.origin + gt.basis.get_column(i).normalized() * gizmo_scale * (GIZMO_ARROW_OFFSET + (GIZMO_ARROW_SIZE * 0.5));
+			const real_t grabber_radius = gizmo_scale * GIZMO_ARROW_SIZE;
+
+			Vector3 r;
+
+			if (Geometry3D::segment_intersects_sphere(ray_pos, ray_pos + ray * MAX_Z, grabber_pos, grabber_radius, &r)) {
+				const real_t d = r.distance_to(ray_pos);
+				if (d < col_d) {
+					col_d = d;
+					col_axis = i;
+				}
+			}
+		}
+
+		bool is_plane_translate = false;
+		// plane select
+		if (col_axis == -1) {
+			col_d = 1e20;
+
+			for (int i = 0; i < 3; i++) {
+				Vector3 ivec2 = gt.basis.get_column((i + 1) % 3).normalized();
+				Vector3 ivec3 = gt.basis.get_column((i + 2) % 3).normalized();
+
+				// Allow some tolerance to make the plane easier to click,
+				// even if the click is actually slightly outside the plane.
+				const Vector3 grabber_pos = gt.origin + (ivec2 + ivec3) * gizmo_scale * (GIZMO_PLANE_SIZE + GIZMO_PLANE_DST * 0.6667);
+
+				Vector3 r;
+				Plane plane(gt.basis.get_column(i).normalized(), gt.origin);
+
+				if (plane.intersects_ray(ray_pos, ray, &r)) {
+					const real_t dist = r.distance_to(grabber_pos);
+					// Allow some tolerance to make the plane easier to click,
+					// even if the click is actually slightly outside the plane.
+					if (dist < (gizmo_scale * GIZMO_PLANE_SIZE * 1.5)) {
+						const real_t d = ray_pos.distance_to(r);
+						if (d < col_d) {
+							col_d = d;
+							col_axis = i;
+
+							is_plane_translate = true;
+						}
+					}
+				}
+			}
+		}
+
+		if (col_axis != -1) {
+			if (p_highlight_only) {
+				spatial_editor->select_gizmo_highlight_axis(col_axis + (is_plane_translate ? 6 : 0));
+
+			} else {
+				//handle plane translate
+				_edit.mode = TRANSFORM_TRANSLATE;
+				_compute_edit(p_screenpos);
+				_edit.plane = TransformPlane(TRANSFORM_X_AXIS + col_axis + (is_plane_translate ? 3 : 0));
+			}
+			return true;
+		}
+	}
+
+	if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE) {
+		int col_axis = -1;
+		bool view_rotation_selected = false;
+		bool trackball_selected = false;
+
+		Vector3 hit_position;
+		Vector3 hit_normal;
+		real_t ray_length = gt.origin.distance_to(ray_pos) + (GIZMO_CIRCLE_SIZE * gizmo_scale) * 4.0f;
+		if (Geometry3D::segment_intersects_sphere(ray_pos, ray_pos + ray * ray_length, gt.origin, gizmo_scale * (GIZMO_CIRCLE_SIZE), &hit_position, &hit_normal)) {
+			if (hit_normal.dot(_get_camera_normal()) < 0.05) {
+				hit_position = gt.xform_inv(hit_position).abs();
+				int min_axis = hit_position.min_axis_index();
+				if (hit_position[min_axis] < gizmo_scale * GIZMO_RING_HALF_WIDTH) {
+					col_axis = min_axis;
+				}
+			}
+		}
+
+		if (col_axis == -1) {
+			float col_d = 1e20;
+
+			for (int i = 0; i < 3; i++) {
+				Plane plane(gt.basis.get_column(i).normalized(), gt.origin);
+				Vector3 r;
+				if (!plane.intersects_ray(ray_pos, ray, &r)) {
+					continue;
+				}
+
+				const real_t dist = r.distance_to(gt.origin);
+				const Vector3 r_dir = (r - gt.origin).normalized();
+
+				if (_get_camera_normal().dot(r_dir) <= 0.005) {
+					if (dist > gizmo_scale * (GIZMO_CIRCLE_SIZE - GIZMO_RING_HALF_WIDTH) && dist < gizmo_scale * (GIZMO_CIRCLE_SIZE + GIZMO_RING_HALF_WIDTH)) {
+						const real_t d = ray_pos.distance_to(r);
+						if (d < col_d) {
+							col_d = d;
+							col_axis = i;
+						}
+					}
+				}
+			}
+		}
+
+		if (col_axis == -1) {
+			Vector3 ray_to_center = gt.origin - ray_pos;
+			real_t ray_length_to_center = ray_to_center.dot(ray);
+			Vector3 closest_point_on_ray = ray_pos + ray * ray_length_to_center;
+			real_t distance_ray_to_center = closest_point_on_ray.distance_to(gt.origin);
+
+			real_t view_rotation_radius = gizmo_scale * spatial_editor->gizmo_view_rotation_scale;
+			real_t circumference_tolerance = gizmo_scale * GIZMO_RING_HALF_WIDTH;
+
+			if (Math::abs(distance_ray_to_center - view_rotation_radius) < circumference_tolerance &&
+					ray_length_to_center > 0) {
+				view_rotation_selected = true;
+			} else if (spatial_editor->is_trackball_enabled() && distance_ray_to_center < gizmo_scale * (GIZMO_CIRCLE_SIZE - GIZMO_RING_HALF_WIDTH) && ray_length_to_center > 0) {
+				trackball_selected = true;
+			}
+		}
+
+		if (view_rotation_selected) {
+			if (p_highlight_only) {
+				spatial_editor->select_gizmo_highlight_axis(GIZMO_HIGHLIGHT_AXIS_VIEW_ROTATION);
+			} else {
+				_edit.mode = TRANSFORM_ROTATE;
+				_compute_edit(p_screenpos);
+				_edit.plane = TRANSFORM_VIEW;
+				_edit.accumulated_rotation_angle = 0.0;
+				_edit.rotation_angle = 0.0;
+				_edit.rotation_axis = _get_camera_normal();
+				_edit.view_axis_local = spatial_editor->get_gizmo_transform().basis.xform_inv(_get_camera_normal()).normalized();
+				_edit.gizmo_initiated = true;
+			}
+			return true;
+		} else if (trackball_selected) {
+			if (p_highlight_only) {
+				spatial_editor->select_gizmo_highlight_axis(GIZMO_HIGHLIGHT_AXIS_TRACKBALL);
+			} else {
+				_edit.mode = TRANSFORM_ROTATE;
+				_compute_edit(p_screenpos);
+				_edit.plane = TRANSFORM_VIEW;
+				_edit.is_trackball = true;
+				_edit.show_rotation_line = false;
+				_edit.accumulated_rotation_angle = 0.0;
+				_edit.rotation_angle = 0.0;
+				_edit.rotation_axis = _get_camera_normal();
+				_edit.gizmo_initiated = true;
+				spatial_editor->select_gizmo_highlight_axis(-1);
+			}
+			return true;
+		} else if (col_axis != -1) {
+			if (p_highlight_only) {
+				spatial_editor->select_gizmo_highlight_axis(col_axis + 3);
+			} else {
+				//handle axis-specific rotate
+				_edit.mode = TRANSFORM_ROTATE;
+				_compute_edit(p_screenpos);
+				_edit.plane = TransformPlane(TRANSFORM_X_AXIS + col_axis);
+				_edit.accumulated_rotation_angle = 0.0;
+				_edit.rotation_angle = 0.0;
+				_edit.rotation_axis = gt.basis.get_column(col_axis).normalized();
+				_edit.gizmo_initiated = true;
+			}
+			return true;
+		}
+	}
+
+	if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE) {
+		int col_axis = -1;
+		float col_d = 1e20;
+
+		for (int i = 0; i < 3; i++) {
+			const Vector3 grabber_pos = gt.origin + gt.basis.get_column(i).normalized() * gizmo_scale * GIZMO_SCALE_OFFSET;
+			const real_t grabber_radius = gizmo_scale * GIZMO_ARROW_SIZE;
+
+			Vector3 r;
+
+			if (Geometry3D::segment_intersects_sphere(ray_pos, ray_pos + ray * MAX_Z, grabber_pos, grabber_radius, &r)) {
+				const real_t d = r.distance_to(ray_pos);
+				if (d < col_d) {
+					col_d = d;
+					col_axis = i;
+				}
+			}
+		}
+
+		bool is_plane_scale = false;
+		// plane select
+		if (col_axis == -1) {
+			col_d = 1e20;
+
+			for (int i = 0; i < 3; i++) {
+				const Vector3 ivec2 = gt.basis.get_column((i + 1) % 3).normalized();
+				const Vector3 ivec3 = gt.basis.get_column((i + 2) % 3).normalized();
+
+				// Allow some tolerance to make the plane easier to click,
+				// even if the click is actually slightly outside the plane.
+				const Vector3 grabber_pos = gt.origin + (ivec2 + ivec3) * gizmo_scale * (GIZMO_PLANE_SIZE + GIZMO_PLANE_DST * 0.6667);
+
+				Vector3 r;
+				Plane plane(gt.basis.get_column(i).normalized(), gt.origin);
+
+				if (plane.intersects_ray(ray_pos, ray, &r)) {
+					const real_t dist = r.distance_to(grabber_pos);
+					// Allow some tolerance to make the plane easier to click,
+					// even if the click is actually slightly outside the plane.
+					if (dist < (gizmo_scale * GIZMO_PLANE_SIZE * 1.5)) {
+						const real_t d = ray_pos.distance_to(r);
+						if (d < col_d) {
+							col_d = d;
+							col_axis = i;
+
+							is_plane_scale = true;
+						}
+					}
+				}
+			}
+		}
+
+		if (col_axis != -1) {
+			if (p_highlight_only) {
+				spatial_editor->select_gizmo_highlight_axis(col_axis + (is_plane_scale ? 12 : 9));
+
+			} else {
+				//handle scale
+				_edit.mode = TRANSFORM_SCALE;
+				_compute_edit(p_screenpos);
+				_edit.plane = TransformPlane(TRANSFORM_X_AXIS + col_axis + (is_plane_scale ? 3 : 0));
+			}
+			return true;
+		}
+	}
+
+	if (p_highlight_only) {
+		spatial_editor->select_gizmo_highlight_axis(-1);
+	}
+
+	return false;
+}
+
+void Node3DEditorViewport::_transform_gizmo_apply(Node3D *p_node, const Transform3D &p_transform, bool p_local) {
+	if (p_transform.basis.determinant() == 0) {
+		return;
+	}
+
+	bool preserve_children = spatial_editor->is_preserve_children_transform_enabled();
+
+	Vector<Transform3D> children_global_transforms;
+	Vector<Node3D *> node3d_children;
+
+	if (preserve_children) {
+		int child_count = p_node->get_child_count();
+		for (int i = 0; i < child_count; i++) {
+			Node3D *child = Object::cast_to<Node3D>(p_node->get_child(i));
+			if (child) {
+				children_global_transforms.push_back(child->get_global_transform());
+				node3d_children.push_back(child);
+			}
+		}
+	}
+
+	if (p_local) {
+		p_node->set_transform(p_transform);
+	} else {
+		p_node->set_global_transform(p_transform);
+	}
+
+	if (preserve_children) {
+		for (int i = 0; i < node3d_children.size(); i++) {
+			node3d_children[i]->set_global_transform(children_global_transforms[i]);
+		}
+	}
+}
+
+Transform3D Node3DEditorViewport::_compute_transform(TransformMode p_mode, const Transform3D &p_original, const Transform3D &p_original_local, Vector3 p_motion, double p_extra, bool p_local, bool p_orthogonal, bool p_view_axis) {
+	switch (p_mode) {
+		case TRANSFORM_SCALE: {
+			if (spatial_editor->is_snap_enabled()) {
+				p_motion.snapf(p_extra);
+			}
+			Transform3D s;
+			if (p_local) {
+				s.basis = p_original_local.basis.scaled_local(p_motion + Vector3(1, 1, 1));
+				s.origin = p_original_local.origin;
+			} else {
+				s.basis.scale(p_motion + Vector3(1, 1, 1));
+				Transform3D base = Transform3D(Basis(), _edit.center);
+				s = base * (s * (base.inverse() * p_original));
+
+				// Recalculate orthogonalized scale without moving origin.
+				if (p_orthogonal) {
+					s.basis = p_original.basis.scaled_orthogonal(p_motion + Vector3(1, 1, 1));
+				}
+			}
+
+			return s;
+		}
+		case TRANSFORM_TRANSLATE: {
+			if (spatial_editor->is_snap_enabled()) {
+				p_motion.snapf(p_extra);
+			}
+
+			if (p_local) {
+				return p_original_local.translated_local(p_motion);
+			}
+
+			return p_original.translated(p_motion);
+		}
+		case TRANSFORM_ROTATE: {
+			Transform3D r;
+
+			Basis parent_global_basis = p_original.basis * p_original_local.basis.inverse();
+
+			Vector3 axis;
+			if (p_local && !p_view_axis) {
+				axis = p_original_local.basis.xform(p_motion);
+			} else {
+				axis = parent_global_basis.xform_inv(p_motion);
+			}
+
+			if (p_local) {
+				r.basis = Basis(axis.normalized(), p_extra) * p_original_local.basis;
+				r.origin = p_original_local.origin;
+			} else {
+				r.basis = parent_global_basis * Basis(axis.normalized(), p_extra) * p_original_local.basis;
+				r.origin = Basis(p_motion, p_extra).xform(p_original.origin - _edit.center) + _edit.center;
+			}
+
+			return r;
+		}
+		default: {
+			ERR_FAIL_V_MSG(Transform3D(), "Invalid mode in '_compute_transform'");
+		}
+	}
+}
+
+void Node3DEditorViewport::_reset_transform(TransformType p_type) {
+	List<Node *> selection = editor_selection->get_full_selected_node_list();
+	if (selection.is_empty()) {
+		return;
+	}
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Reset Transform"));
+	for (Node *node : selection) {
+		Node3D *sp = Object::cast_to<Node3D>(node);
+		if (!sp) {
+			continue;
+		}
+
+		switch (p_type) {
+			case TransformType::POSITION:
+				undo_redo->add_undo_method(sp, "set_position", sp->get_position());
+				undo_redo->add_do_method(sp, "set_position", Vector3());
+				break;
+			case TransformType::ROTATION:
+				undo_redo->add_undo_method(sp, "set_rotation", sp->get_rotation());
+				undo_redo->add_do_method(sp, "set_rotation", Vector3());
+				break;
+			case TransformType::SCALE:
+				undo_redo->add_undo_method(sp, "set_scale", sp->get_scale());
+				undo_redo->add_do_method(sp, "set_scale", Vector3(1, 1, 1));
+				break;
+		}
+	}
+	undo_redo->commit_action();
+}
+
+void Node3DEditorViewport::_surface_mouse_enter() {
+	if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
+		return;
+	}
+
+	if (!surface->has_focus() && (!get_viewport()->gui_get_focus_owner() || !get_viewport()->gui_get_focus_owner()->is_text_field())) {
+		surface->grab_focus();
+	}
+}
+
+void Node3DEditorViewport::_surface_mouse_exit() {
+	_remove_preview_node();
+	_reset_preview_material();
+	_remove_preview_material();
+}
+
+void Node3DEditorViewport::_surface_focus_enter() {
+	view_display_menu->set_disable_shortcuts(false);
+}
+
+void Node3DEditorViewport::_surface_focus_exit() {
+	view_display_menu->set_disable_shortcuts(true);
+}
+
+bool Node3DEditorViewport::_is_node_locked(const Node *p_node) const {
+	return p_node->get_meta("_edit_lock_", false);
+}
+
+void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
+	Vector<_RayResult> potential_selection_results;
+	_find_items_at_pos(b->get_position(), potential_selection_results, b->is_alt_pressed());
+
+	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
+
+	// Filter to a list of nodes which include either the edited scene or nodes directly owned by the edited scene.
+	// If a node has an invalid owner, recursively check their parents until a valid node is found.
+	for (int i = 0; i < potential_selection_results.size(); i++) {
+		Node3D *node = potential_selection_results[i].item;
+		while (true) {
+			if (node == nullptr || node == edited_scene->get_parent()) {
+				break;
+			} else {
+				Node *node_owner = node->get_owner();
+				if (node == edited_scene || node_owner == edited_scene || (node_owner != nullptr && edited_scene->is_editable_instance(node_owner))) {
+					if (!selection_results.has(node)) {
+						selection_results.append(node);
+					}
+					break;
+				}
+			}
+			node = Object::cast_to<Node3D>(node->get_parent());
+		}
+	}
+
+	clicked_wants_append = b->is_shift_pressed();
+
+	if (selection_results.size() == 1) {
+		clicked = selection_results[0]->get_instance_id();
+		selection_results.clear();
+
+		if (clicked.is_valid()) {
+			_select_clicked(b->is_alt_pressed());
+		}
+	} else if (!selection_results.is_empty()) {
+		NodePath root_path = get_tree()->get_edited_scene_root()->get_path();
+		StringName root_name = root_path.get_name(root_path.get_name_count() - 1);
+		int icon_max_width = EditorNode::get_singleton()->get_editor_theme()->get_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+
+		for (int i = 0; i < selection_results.size(); i++) {
+			Node3D *spat = selection_results[i];
+
+			Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(spat);
+
+			String node_path = "/" + root_name + "/" + String(root_path.rel_path_to(spat->get_path()));
+
+			int locked = 0;
+			if (_is_node_locked(spat)) {
+				locked = 1;
+			} else {
+				Node *ed_scene = EditorNode::get_singleton()->get_edited_scene();
+				Node *node = spat;
+
+				while (node && node != ed_scene->get_parent()) {
+					Node3D *selected_tmp = Object::cast_to<Node3D>(node);
+					if (selected_tmp && node->has_meta("_edit_group_")) {
+						locked = 2;
+					}
+					node = node->get_parent();
+				}
+			}
+
+			String suffix;
+			if (locked == 1) {
+				suffix = " (" + TTR("Locked") + ")";
+			} else if (locked == 2) {
+				suffix = " (" + TTR("Grouped") + ")";
+			}
+			selection_menu->add_item((String)spat->get_name() + suffix);
+			selection_menu->set_item_icon(i, icon);
+			selection_menu->set_item_icon_max_width(i, icon_max_width);
+			selection_menu->set_item_metadata(i, node_path);
+			selection_menu->set_item_tooltip(i, String(spat->get_name()) + "\nType: " + spat->get_class() + "\nPath: " + node_path);
+		}
+
+		selection_results_menu = selection_results;
+		selection_menu->set_position(get_screen_position() + b->get_position());
+		selection_menu->reset_size();
+		selection_menu->popup();
+	}
+}
+
+// Helper function to redirect mouse events to the active freelook viewport
+static bool _redirect_freelook_input(const Ref<InputEvent> &p_event, Node3DEditorViewport *p_exclude_viewport = nullptr) {
+	if (Input::get_singleton()->get_mouse_mode() != Input::MouseMode::MOUSE_MODE_CAPTURED) {
+		return false;
+	}
+
+	Node3DEditor *editor = Node3DEditor::get_singleton();
+	if (!editor->get_freelook_viewport()) {
+		return false;
+	}
+
+	Node3DEditorViewport *freelook_vp = editor->get_freelook_viewport();
+	if (freelook_vp == p_exclude_viewport) {
+		return false;
+	}
+
+	Ref<InputEventMouse> mouse_event = p_event;
+	if (!mouse_event.is_valid()) {
+		return false;
+	}
+
+	Control *target_surface = freelook_vp->get_surface();
+
+	target_surface->emit_signal(SceneStringName(gui_input), p_event);
+	return true;
+}
+
+// This is only active during instant transforms,
+// to capture and wrap mouse events outside the control.
+void Node3DEditorViewport::input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(!_edit.instant);
+	Ref<InputEventMouseMotion> m = p_event;
+
+	if (m.is_valid()) {
+		_edit.mouse_pos += view_3d_controller->get_warped_mouse_motion(p_event, surface->get_global_rect());
+		update_transform(_get_key_modifier(m) == Key::SHIFT);
+	}
+}
+
+void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
+	const Ref<InputEventKey> k = p_event;
+
+	if (k.is_valid() && k->is_pressed() && EDITOR_GET("editors/3d/navigation/emulate_numpad")) {
+		const Key code = k->get_physical_keycode();
+		if (code >= Key::KEY_0 && code <= Key::KEY_9) {
+			k->set_keycode(code - Key::KEY_0 + Key::KP_0);
+		}
+	}
+
+	if (get_viewport()->gui_get_drag_data()) {
+		// Disable all input actions during drag-and-drop.
+		return;
+	}
+
+	if (k.is_valid()) {
+		Ref<InputEventKey> k_no_shift = k->duplicate();
+		k_no_shift->set_shift_pressed(false);
+		if (!vertex_snap_mode && !vertex_snap_dragging && k->is_pressed() && _edit.mode == TRANSFORM_NONE && ED_IS_SHORTCUT("spatial_editor/vertex_snap", k_no_shift)) {
+			vertex_snap_mode = true;
+			vertex_snap_keycode = k->get_physical_keycode() != Key::NONE ? k->get_physical_keycode() : k->get_keycode();
+			_disable_follow_mode();
+			set_message(TTR("Vertex Snap"));
+			_vertex_snap_update_source(_edit.mouse_pos);
+			surface->queue_redraw();
+		} else if (vertex_snap_mode && !k->is_pressed() && k->get_physical_keycode() == vertex_snap_keycode) {
+			vertex_snap_mode = false;
+			vertex_snap_keycode = Key::NONE;
+			if (!vertex_snap_dragging) {
+				vertex_snap_has_source = false;
+				vertex_snap_has_target = false;
+				set_message("");
+				surface->queue_redraw();
+			}
+		} else if ((vertex_snap_mode || vertex_snap_dragging) && k->is_pressed() && k->get_keycode() == Key::ESCAPE) {
+			if (vertex_snap_dragging) {
+				_vertex_snap_cancel();
+			} else {
+				vertex_snap_has_source = false;
+				surface->queue_redraw();
+			}
+			vertex_snap_mode = false;
+			vertex_snap_keycode = Key::NONE;
+			set_message("");
+			return;
+		}
+	}
+
+	if (_redirect_freelook_input(p_event, this)) {
+		return;
+	}
+
+	{
+		Ref<InputEventMouseButton> vb = p_event;
+		if ((vertex_snap_mode || vertex_snap_dragging) && vb.is_valid()) {
+			if (vb->get_button_index() == MouseButton::RIGHT && vb->is_pressed() && vertex_snap_dragging) {
+				_vertex_snap_cancel();
+				return;
+			}
+			if (vb->get_button_index() == MouseButton::LEFT) {
+				if (vb->is_pressed()) {
+					const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+					bool use_origin_snap = spatial_editor->is_vertex_snap_origin_mode();
+
+					Node3D *selected = spatial_editor->get_single_selected_node();
+					Node3DEditorSelectedItem *se = selected ? editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(selected) : nullptr;
+					bool has_subgizmos = se && se->gizmo.is_valid() && !se->subgizmos.is_empty();
+
+					if (!use_origin_snap) {
+						bool has_snap_target = false;
+						for (Node *E : selection) {
+							if (_node_has_snap_target(E, spatial_editor->is_vertex_snap_use_collision())) {
+								has_snap_target = true;
+								break;
+							}
+						}
+						if (!has_snap_target) {
+							use_origin_snap = true;
+						}
+					}
+
+					if (use_origin_snap || !vertex_snap_has_source) {
+						_vertex_snap_update_source(vb->get_position());
+					}
+
+					if (vertex_snap_has_source && !selection.is_empty()) {
+						vertex_snap_original_positions.clear();
+						for (Node *E : selection) {
+							Node3D *sp = Object::cast_to<Node3D>(E);
+							if (sp) {
+								vertex_snap_original_positions[sp->get_instance_id()] = sp->get_global_position();
+							}
+						}
+
+						if (!use_origin_snap) {
+							vertex_snap_dragging = true;
+							Vector3 cam_normal = camera->get_global_transform().basis.get_column(2);
+							vertex_snap_drag_plane = Plane(cam_normal, vertex_snap_source);
+						} else {
+							if (has_subgizmos) {
+								Transform3D gi = selected->get_global_transform().affine_inverse();
+								Vector3 local_target = gi.xform(vertex_snap_source);
+
+								Vector<int> ids;
+								Vector<Transform3D> restores;
+								for (const KeyValue<int, Transform3D> &GE : se->subgizmos) {
+									Transform3D original_xform = se->gizmo->get_subgizmo_transform(GE.key);
+									ids.push_back(GE.key);
+									restores.push_back(original_xform);
+
+									Transform3D snapped_xform = original_xform;
+									snapped_xform.origin = local_target;
+									se->gizmo->set_subgizmo_transform(GE.key, snapped_xform);
+								}
+								se->gizmo->commit_subgizmos(ids, restores, false);
+							} else {
+								EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+								undo_redo->create_action(TTR("Vertex Snap"));
+								for (const KeyValue<ObjectID, Vector3> &E2 : vertex_snap_original_positions) {
+									Node3D *node = ObjectDB::get_instance<Node3D>(E2.key);
+									if (node) {
+										node->set_global_position(vertex_snap_source);
+										undo_redo->add_do_method(node, "set_global_position", vertex_snap_source);
+										undo_redo->add_undo_method(node, "set_global_position", E2.value);
+									}
+								}
+								undo_redo->commit_action(false);
+							}
+							vertex_snap_original_positions.clear();
+							spatial_editor->update_transform_gizmo();
+							_reset_follow_mode_count();
+						}
+						surface->queue_redraw();
+					}
+				} else {
+					if (vertex_snap_dragging) {
+						_vertex_snap_commit();
+					}
+				}
+				return;
+			}
+		}
+	}
+
+	EditorPlugin::AfterGUIInput after = EditorPlugin::AFTER_GUI_INPUT_PASS;
+	{
+		EditorNode *en = EditorNode::get_singleton();
+
+		switch (en->get_editor_plugins_force_input_forwarding()->forward_3d_gui_input(camera, p_event, true)) {
+			case EditorPlugin::AFTER_GUI_INPUT_PASS: {
+				// Continue processing.
+			} break;
+
+			case EditorPlugin::AFTER_GUI_INPUT_STOP: {
+				return; // Stop processing.
+			} break;
+
+			case EditorPlugin::AFTER_GUI_INPUT_CUSTOM: {
+				after = EditorPlugin::AFTER_GUI_INPUT_CUSTOM;
+			} break;
+		}
+
+		switch (en->get_editor_plugins_over()->forward_3d_gui_input(camera, p_event, false)) {
+			case EditorPlugin::AFTER_GUI_INPUT_PASS: {
+				// Continue processing.
+			} break;
+
+			case EditorPlugin::AFTER_GUI_INPUT_STOP: {
+				return; // Stop processing.
+			} break;
+
+			case EditorPlugin::AFTER_GUI_INPUT_CUSTOM: {
+				after = EditorPlugin::AFTER_GUI_INPUT_CUSTOM;
+			} break;
+		}
+	}
+
+	// Several parts of the 3D navigation are handled here.
+	bool was_navigating = view_3d_controller->is_navigating();
+	view_3d_controller->gui_input(p_event, surface->get_global_rect());
+	if (was_navigating && !view_3d_controller->is_navigating()) {
+		return;
+	}
+
+	Ref<InputEventMouseButton> b = p_event;
+
+	if (b.is_valid()) {
+		emit_signal(SNAME("clicked"));
+
+		View3DController::NavigationMouseButton orbit_mouse_preference = (View3DController::NavigationMouseButton)EDITOR_GET("editors/3d/navigation/orbit_mouse_button").operator int();
+		View3DController::NavigationMouseButton pan_mouse_preference = (View3DController::NavigationMouseButton)EDITOR_GET("editors/3d/navigation/pan_mouse_button").operator int();
+		View3DController::NavigationMouseButton zoom_mouse_preference = (View3DController::NavigationMouseButton)EDITOR_GET("editors/3d/navigation/zoom_mouse_button").operator int();
+
+		switch (b->get_button_index()) {
+			case MouseButton::RIGHT: {
+				if (b->is_pressed()) {
+					if (_edit.gizmo.is_valid()) {
+						// Restore.
+						_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, true);
+						_edit.gizmo = Ref<EditorNode3DGizmo>();
+						set_message("");
+					}
+
+					if (_edit.mode == TRANSFORM_NONE) {
+						if (orbit_mouse_preference == View3DController::NAV_MOUSE_BUTTON_RIGHT && _is_nav_modifier_pressed("spatial_editor/viewport_orbit_modifier_1") && _is_nav_modifier_pressed("spatial_editor/viewport_orbit_modifier_2")) {
+							break;
+						} else if (pan_mouse_preference == View3DController::NAV_MOUSE_BUTTON_RIGHT && _is_nav_modifier_pressed("spatial_editor/viewport_pan_modifier_1") && _is_nav_modifier_pressed("spatial_editor/viewport_pan_modifier_2")) {
+							break;
+						} else if (zoom_mouse_preference == View3DController::NAV_MOUSE_BUTTON_RIGHT && _is_nav_modifier_pressed("spatial_editor/viewport_zoom_modifier_1") && _is_nav_modifier_pressed("spatial_editor/viewport_zoom_modifier_2")) {
+							break;
+						}
+					}
+
+					if (b->is_alt_pressed()) {
+						_list_select(b);
+						return;
+					}
+
+					if (_edit.mode != TRANSFORM_NONE) {
+						cancel_transform();
+						break;
+					}
+
+					const Key mod = _get_key_modifier(b);
+					if (!view_3d_controller->is_orthogonal() && !(previewing && !pilot_preview_enabled)) {
+						if (mod == _get_key_modifier_setting("editors/3d/freelook/freelook_activation_modifier")) {
+							view_3d_controller->set_freelook_enabled(true);
+						}
+					}
+				} else {
+					view_3d_controller->set_freelook_enabled(false);
+				}
+
+				if (view_3d_controller->is_freelook_enabled() && !surface->has_focus()) {
+					// Focus usually doesn't trigger on right-click, but in case of freelook it should,
+					// otherwise using keyboard navigation would misbehave
+					surface->grab_focus();
+				}
+
+			} break;
+			case MouseButton::MIDDLE: {
+				if (b->is_pressed() && _edit.mode != TRANSFORM_NONE) {
+					if (orbit_mouse_preference == View3DController::NAV_MOUSE_BUTTON_MIDDLE && _is_nav_modifier_pressed("spatial_editor/viewport_orbit_modifier_1") && _is_nav_modifier_pressed("spatial_editor/viewport_orbit_modifier_2")) {
+						break;
+					} else if (pan_mouse_preference == View3DController::NAV_MOUSE_BUTTON_MIDDLE && _is_nav_modifier_pressed("spatial_editor/viewport_pan_modifier_1") && _is_nav_modifier_pressed("spatial_editor/viewport_pan_modifier_2")) {
+						break;
+					} else if (zoom_mouse_preference == View3DController::NAV_MOUSE_BUTTON_MIDDLE && _is_nav_modifier_pressed("spatial_editor/viewport_zoom_modifier_1") && _is_nav_modifier_pressed("spatial_editor/viewport_zoom_modifier_2")) {
+						break;
+					}
+
+					switch (_edit.plane) {
+						case TRANSFORM_VIEW: {
+							_edit.plane = TRANSFORM_X_AXIS;
+							set_message(TTR("X-Axis Transform."), 2);
+							view_3d_controller->set_view_type(View3DController::VIEW_TYPE_USER);
+						} break;
+						case TRANSFORM_X_AXIS: {
+							_edit.plane = TRANSFORM_Y_AXIS;
+							set_message(TTR("Y-Axis Transform."), 2);
+
+						} break;
+						case TRANSFORM_Y_AXIS: {
+							_edit.plane = TRANSFORM_Z_AXIS;
+							set_message(TTR("Z-Axis Transform."), 2);
+
+						} break;
+						case TRANSFORM_Z_AXIS: {
+							_edit.plane = TRANSFORM_VIEW;
+							// TRANSLATORS: This refers to the transform of the view plane.
+							set_message(TTR("View Plane Transform."), 2);
+
+						} break;
+						case TRANSFORM_YZ:
+						case TRANSFORM_XZ:
+						case TRANSFORM_XY: {
+						} break;
+					}
+				}
+			} break;
+			case MouseButton::LEFT: {
+				if (b->is_pressed()) {
+					clicked_wants_append = b->is_shift_pressed();
+
+					if (_edit.mode != TRANSFORM_NONE && (_edit.instant || collision_reposition)) {
+						commit_transform();
+						break; // just commit the edit, stop processing the event so we don't deselect the object
+					}
+					if (orbit_mouse_preference == View3DController::NAV_MOUSE_BUTTON_LEFT && _is_nav_modifier_pressed("spatial_editor/viewport_orbit_modifier_1") && _is_nav_modifier_pressed("spatial_editor/viewport_orbit_modifier_2")) {
+						break;
+					} else if (pan_mouse_preference == View3DController::NAV_MOUSE_BUTTON_LEFT && _is_nav_modifier_pressed("spatial_editor/viewport_pan_modifier_1") && _is_nav_modifier_pressed("spatial_editor/viewport_pan_modifier_2")) {
+						break;
+					} else if (zoom_mouse_preference == View3DController::NAV_MOUSE_BUTTON_LEFT && _is_nav_modifier_pressed("spatial_editor/viewport_zoom_modifier_1") && _is_nav_modifier_pressed("spatial_editor/viewport_zoom_modifier_2")) {
+						break;
+					}
+
+					if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_RULER) {
+						EditorNode::get_singleton()->get_scene_root()->add_child(ruler);
+						collision_reposition = true;
+						break;
+					}
+
+					if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_LIST_SELECT) {
+						_list_select(b);
+						break;
+					}
+
+					_edit.mouse_pos = b->get_position();
+					_edit.original_mouse_pos = b->get_position();
+					_edit.mode = TRANSFORM_NONE;
+					_edit.original = spatial_editor->get_gizmo_transform(); // To prevent to break when flipping with scale.
+
+					bool can_select_gizmos = spatial_editor->get_single_selected_node();
+
+					{
+						int idx = view_display_menu->get_popup()->get_item_index(VIEW_GIZMOS);
+						int idx2 = view_display_menu->get_popup()->get_item_index(VIEW_TRANSFORM_GIZMO);
+						can_select_gizmos = can_select_gizmos && view_display_menu->get_popup()->is_item_checked(idx);
+						transform_gizmo_visible = view_display_menu->get_popup()->is_item_checked(idx2);
+					}
+
+					// Gizmo handles
+					if (can_select_gizmos) {
+						Vector<Ref<Node3DGizmo>> gizmos = spatial_editor->get_single_selected_node()->get_gizmos();
+
+						bool intersected_handle = false;
+						for (int i = 0; i < gizmos.size(); i++) {
+							Ref<EditorNode3DGizmo> seg = gizmos[i];
+
+							if (seg.is_null()) {
+								continue;
+							}
+
+							int gizmo_handle = -1;
+							bool gizmo_secondary = false;
+							seg->handles_intersect_ray(camera, _edit.mouse_pos, b->is_shift_pressed(), gizmo_handle, gizmo_secondary);
+							if (gizmo_handle != -1) {
+								_edit.gizmo = seg;
+								seg->begin_handle_action(gizmo_handle, gizmo_secondary);
+								_edit.gizmo_handle = gizmo_handle;
+								_edit.gizmo_handle_secondary = gizmo_secondary;
+								_edit.gizmo_initial_value = seg->get_handle_value(gizmo_handle, gizmo_secondary);
+								intersected_handle = true;
+								break;
+							}
+						}
+
+						if (intersected_handle) {
+							break;
+						}
+					}
+
+					// Transform gizmo
+					if (transform_gizmo_visible && _transform_gizmo_select(_edit.mouse_pos)) {
+						break;
+					}
+
+					// Subgizmos
+					if (can_select_gizmos) {
+						Node3DEditorSelectedItem *se = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(spatial_editor->get_single_selected_node());
+						Vector<Ref<Node3DGizmo>> gizmos = spatial_editor->get_single_selected_node()->get_gizmos();
+
+						bool intersected_subgizmo = false;
+						for (int i = 0; i < gizmos.size(); i++) {
+							Ref<EditorNode3DGizmo> seg = gizmos[i];
+
+							if (seg.is_null()) {
+								continue;
+							}
+
+							int subgizmo_id = seg->subgizmos_intersect_ray(camera, _edit.mouse_pos);
+							if (subgizmo_id != -1) {
+								ERR_CONTINUE(!se);
+								if (b->is_shift_pressed()) {
+									if (se->subgizmos.has(subgizmo_id)) {
+										se->subgizmos.erase(subgizmo_id);
+									} else {
+										se->subgizmos.insert(subgizmo_id, seg->get_subgizmo_transform(subgizmo_id));
+									}
+								} else {
+									se->subgizmos.clear();
+									se->subgizmos.insert(subgizmo_id, seg->get_subgizmo_transform(subgizmo_id));
+								}
+
+								if (se->subgizmos.is_empty()) {
+									se->gizmo = Ref<EditorNode3DGizmo>();
+								} else {
+									se->gizmo = seg;
+								}
+
+								seg->redraw();
+								spatial_editor->update_transform_gizmo();
+								_reset_follow_mode_count();
+								intersected_subgizmo = true;
+								break;
+							}
+						}
+
+						if (intersected_subgizmo) {
+							break;
+						}
+					}
+
+					clicked = ObjectID();
+
+					bool node_selected = get_selected_count() > 0;
+
+					if (after != EditorPlugin::AFTER_GUI_INPUT_CUSTOM) {
+						// Single item selection.
+						clicked = _select_ray(b->get_position());
+
+						if (clicked.is_valid() && !editor_selection->is_selected(ObjectDB::get_instance<Node>(clicked))) {
+							if (!node_selected || (!b->is_alt_pressed() && !(spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM && b->is_command_or_control_pressed()))) {
+								selection_in_progress = true;
+								break;
+							}
+						}
+
+						if (clicked.is_null()) {
+							if (node_selected) {
+								TransformMode mode = TRANSFORM_NONE;
+
+								if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM) {
+									if (b->is_command_or_control_pressed()) {
+										mode = TRANSFORM_ROTATE;
+									} else if (b->is_alt_pressed()) {
+										mode = TRANSFORM_TRANSLATE;
+									}
+								} else if (b->is_alt_pressed()) {
+									switch (spatial_editor->get_tool_mode()) {
+										case Node3DEditor::TOOL_MODE_ROTATE:
+											mode = TRANSFORM_ROTATE;
+											break;
+										case Node3DEditor::TOOL_MODE_MOVE:
+											mode = TRANSFORM_TRANSLATE;
+											break;
+										case Node3DEditor::TOOL_MODE_SCALE:
+											mode = TRANSFORM_SCALE;
+											break;
+										default:
+											break;
+									}
+								}
+
+								if (mode != TRANSFORM_NONE) {
+									begin_transform(mode, false);
+									break;
+								}
+							}
+
+							if (!previewing) {
+								// Default to region select.
+								view_3d_controller->cursor.region_select = true;
+								view_3d_controller->cursor.region_begin = b->get_position();
+								view_3d_controller->cursor.region_end = b->get_position();
+							}
+							break;
+						}
+					}
+
+					if (clicked.is_valid() && !clicked_wants_append) {
+						bool is_clicked_node_selected = editor_selection->is_selected(ObjectDB::get_instance<Node>(clicked));
+						TransformMode mode = TRANSFORM_NONE;
+
+						switch (spatial_editor->get_tool_mode()) {
+							case Node3DEditor::TOOL_MODE_TRANSFORM:
+								if (b->is_command_or_control_pressed() && node_selected) {
+									mode = TRANSFORM_ROTATE;
+								} else if (b->is_alt_pressed() && node_selected) {
+									mode = TRANSFORM_TRANSLATE;
+								} else if (is_clicked_node_selected) {
+									mode = TRANSFORM_TRANSLATE;
+								}
+								break;
+							case Node3DEditor::TOOL_MODE_ROTATE:
+								if (is_clicked_node_selected || (b->is_alt_pressed() && node_selected)) {
+									mode = TRANSFORM_ROTATE;
+								}
+								break;
+							case Node3DEditor::TOOL_MODE_MOVE:
+								if (is_clicked_node_selected || (b->is_alt_pressed() && node_selected)) {
+									mode = TRANSFORM_TRANSLATE;
+								}
+								break;
+							case Node3DEditor::TOOL_MODE_SCALE:
+								if (is_clicked_node_selected || (b->is_alt_pressed() && node_selected)) {
+									mode = TRANSFORM_SCALE;
+								}
+								break;
+							default:
+								break;
+						}
+
+						if (mode != TRANSFORM_NONE) {
+							begin_transform(mode, false);
+							break;
+						}
+					}
+
+					surface->queue_redraw();
+				} else {
+					if (ruler->is_inside_tree()) {
+						EditorNode::get_singleton()->get_scene_root()->remove_child(ruler);
+						ruler_start_point->set_visible(false);
+						ruler_end_point->set_visible(false);
+						ruler_label->set_visible(false);
+						ruler_label_x->set_visible(false);
+						ruler_label_y->set_visible(false);
+						ruler_label_z->set_visible(false);
+						collision_reposition = false;
+						break;
+					}
+
+					if (_edit.gizmo.is_valid()) {
+						// Certain gizmo plugins should be able to commit handles without dragging them.
+						if (_edit.original_mouse_pos != _edit.mouse_pos || _edit.gizmo->get_plugin()->can_commit_handle_on_click()) {
+							_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, false);
+						}
+						Node3D *selected_node = spatial_editor->get_single_selected_node();
+						if (selected_node) {
+							selected_node->update_gizmos();
+						}
+						_edit.gizmo = Ref<EditorNode3DGizmo>();
+						set_message("");
+						break;
+					}
+
+					if (after != EditorPlugin::AFTER_GUI_INPUT_CUSTOM) {
+						selection_in_progress = false;
+
+						if (clicked.is_valid() && _edit.mode == TRANSFORM_NONE) {
+							_select_clicked(false);
+						} else if (view_3d_controller->cursor.region_select) {
+							_select_region();
+							surface->queue_redraw();
+						}
+
+						movement_threshold_passed = false;
+						view_3d_controller->cursor.region_select = false;
+					}
+
+					if (!_edit.instant && _edit.mode != TRANSFORM_NONE) {
+						Node3D *selected = spatial_editor->get_single_selected_node();
+						Node3DEditorSelectedItem *se = selected ? editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(selected) : nullptr;
+
+						if (se && se->gizmo.is_valid()) {
+							Vector<int> ids;
+							Vector<Transform3D> restore;
+
+							for (const KeyValue<int, Transform3D> &GE : se->subgizmos) {
+								ids.push_back(GE.key);
+								restore.push_back(GE.value);
+							}
+
+							se->gizmo->commit_subgizmos(ids, restore, false);
+						} else {
+							if (_edit.original_mouse_pos != _edit.mouse_pos) {
+								commit_transform();
+							}
+						}
+						_edit.mode = TRANSFORM_NONE;
+						set_message("");
+						spatial_editor->update_transform_gizmo();
+					}
+				}
+
+			} break;
+			default:
+				break;
+		}
+	}
+
+	Ref<InputEventMouseMotion> m = p_event;
+
+	// Instant transforms process mouse motion in input() to handle wrapping.
+	if (m.is_valid() && !_edit.instant) {
+		_edit.mouse_pos = m->get_position();
+
+		if (vertex_snap_mode || vertex_snap_dragging) {
+			if (!vertex_snap_dragging) {
+				_vertex_snap_update_source(m->get_position());
+			} else {
+				const float vertex_snap_threshold = VERTEX_SNAP_THRESHOLD * EDSCALE;
+				bool has_displacement = false;
+				Vector3 displacement;
+
+				Vector3 target;
+				if (_find_closest_vertex_in_scene(m->get_position(), vertex_snap_threshold, target, &vertex_snap_original_positions)) {
+					vertex_snap_target = target;
+					vertex_snap_has_target = true;
+					displacement = target - vertex_snap_source;
+					has_displacement = true;
+					set_message(TTR("Vertex Snap (Snapped)"));
+				} else {
+					vertex_snap_has_target = false;
+					Vector3 ray_pos = get_ray_pos(m->get_position());
+					Vector3 ray_dir = get_ray(m->get_position());
+					Vector3 intersection;
+					if (vertex_snap_drag_plane.intersects_ray(ray_pos, ray_dir, &intersection)) {
+						displacement = intersection - vertex_snap_source;
+						has_displacement = true;
+					}
+					set_message(TTR("Vertex Snap"));
+				}
+
+				if (has_displacement) {
+					for (const KeyValue<ObjectID, Vector3> &E : vertex_snap_original_positions) {
+						Node3D *node = ObjectDB::get_instance<Node3D>(E.key);
+						if (node) {
+							node->set_global_position(E.value + displacement);
+						}
+					}
+				}
+			}
+			surface->queue_redraw();
+			return;
+		}
+
+		if (!view_3d_controller->is_freelook_enabled() && spatial_editor->get_single_selected_node()) {
+			Vector<Ref<Node3DGizmo>> gizmos = spatial_editor->get_single_selected_node()->get_gizmos();
+
+			Ref<EditorNode3DGizmo> found_gizmo;
+			int found_handle = -1;
+			bool found_handle_secondary = false;
+
+			for (int i = 0; i < gizmos.size(); i++) {
+				Ref<EditorNode3DGizmo> seg = gizmos[i];
+				if (seg.is_null()) {
+					continue;
+				}
+
+				seg->handles_intersect_ray(camera, _edit.mouse_pos, false, found_handle, found_handle_secondary);
+
+				if (found_handle != -1) {
+					found_gizmo = seg;
+					break;
+				}
+			}
+
+			if (found_gizmo.is_valid()) {
+				spatial_editor->select_gizmo_highlight_axis(-1);
+			}
+
+			bool current_hover_handle_secondary = false;
+			int current_hover_handle = spatial_editor->get_current_hover_gizmo_handle(current_hover_handle_secondary);
+			if (found_gizmo != spatial_editor->get_current_hover_gizmo() || found_handle != current_hover_handle || found_handle_secondary != current_hover_handle_secondary) {
+				spatial_editor->set_current_hover_gizmo(found_gizmo);
+				spatial_editor->set_current_hover_gizmo_handle(found_handle, found_handle_secondary);
+				spatial_editor->get_single_selected_node()->update_gizmos();
+			}
+		}
+
+		if (!view_3d_controller->is_freelook_enabled() && transform_gizmo_visible && spatial_editor->get_current_hover_gizmo().is_null() && !m->get_button_mask().has_flag(MouseButtonMask::LEFT) && _edit.gizmo.is_null()) {
+			_transform_gizmo_select(_edit.mouse_pos, true);
+		}
+
+		if (_edit.gizmo.is_valid()) {
+			_edit.gizmo->set_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, camera, m->get_position());
+			Variant v = _edit.gizmo->get_handle_value(_edit.gizmo_handle, _edit.gizmo_handle_secondary);
+			String n = _edit.gizmo->get_handle_name(_edit.gizmo_handle, _edit.gizmo_handle_secondary);
+			set_message(n + ": " + String(v));
+
+		} else if (m->get_button_mask().has_flag(MouseButtonMask::LEFT)) {
+			movement_threshold_passed = _edit.original_mouse_pos.distance_to(_edit.mouse_pos) > 8 * EDSCALE;
+
+			if ((selection_in_progress || clicked_wants_append || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT) && movement_threshold_passed && clicked.is_valid() && !previewing) {
+				view_3d_controller->cursor.region_select = true;
+				view_3d_controller->cursor.region_begin = _edit.original_mouse_pos;
+				clicked = ObjectID();
+			}
+
+			if (view_3d_controller->cursor.region_select) {
+				view_3d_controller->cursor.region_end = m->get_position();
+				surface->queue_redraw();
+				return;
+			}
+
+			if (clicked.is_valid() && movement_threshold_passed && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE)) {
+				bool is_select_mode = (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM);
+				bool is_clicked_selected = editor_selection->is_selected(ObjectDB::get_instance<Node>(clicked));
+
+				if (_edit.mode == TRANSFORM_NONE && (is_select_mode || is_clicked_selected)) {
+					_compute_edit(_edit.original_mouse_pos);
+					clicked = ObjectID();
+					_edit.mode = TRANSFORM_TRANSLATE;
+				}
+			}
+
+			if (_edit.mode == TRANSFORM_NONE || _edit.numeric_input != 0 || _edit.numeric_next_decimal != 0) {
+				return;
+			}
+
+			if (!selection_in_progress) {
+				update_transform(_get_key_modifier(m) == Key::SHIFT);
+			}
+		}
+	}
+
+	if (k.is_valid()) {
+		if (!k->is_pressed()) {
+			return;
+		}
+
+		if (_edit.instant) {
+			// In a Blender-style transform, numbers set the magnitude of the transform.
+			// E.g. pressing g4.5x means "translate 4.5 units along the X axis".
+			bool processed = true;
+			Key keycode = k->get_keycode();
+			Key physical_keycode = k->get_physical_keycode();
+
+			// Use physical keycode for main keyboard numbers (for non-QWERTY layouts like AZERTY)
+			// but regular keycode for numpad numbers.
+			if ((physical_keycode >= Key::KEY_0 && physical_keycode <= Key::KEY_9) || (keycode >= Key::KP_0 && keycode <= Key::KP_9)) {
+				uint32_t value;
+				if (physical_keycode >= Key::KEY_0 && physical_keycode <= Key::KEY_9) {
+					value = uint32_t(physical_keycode - Key::KEY_0);
+				} else {
+					value = uint32_t(keycode - Key::KP_0);
+				}
+
+				if (_edit.numeric_next_decimal < 0) {
+					_edit.numeric_input = _edit.numeric_input + value * Math::pow(10.0, _edit.numeric_next_decimal--);
+				} else {
+					_edit.numeric_input = _edit.numeric_input * 10 + value;
+				}
+				update_transform_numeric();
+			} else if (keycode == Key::MINUS || keycode == Key::KP_SUBTRACT) {
+				_edit.numeric_negate = !_edit.numeric_negate;
+				update_transform_numeric();
+			} else if (keycode == Key::PERIOD || physical_keycode == Key::KP_PERIOD) {
+				// Use physical keycode for KP_PERIOD to ensure numpad period works consistently
+				// across different keyboard layouts (like nordic keyboards).
+				if (_edit.numeric_next_decimal == 0) {
+					_edit.numeric_next_decimal = -1;
+				}
+			} else if (keycode == Key::ENTER || keycode == Key::KP_ENTER || keycode == Key::SPACE) {
+				commit_transform();
+			} else {
+				processed = false;
+			}
+
+			if (processed) {
+				// Ignore mouse inputs once we receive a numeric input.
+				set_process_input(false);
+				accept_event();
+				return;
+			}
+		}
+
+		Ref<InputEvent> event_mod = p_event;
+		if (EDITOR_GET("editors/3d/navigation/emulate_numpad")) {
+			const Key code = k->get_physical_keycode();
+			if (code >= Key::KEY_0 && code <= Key::KEY_9) {
+				event_mod = p_event->duplicate();
+				Ref<InputEventKey> k_mod = event_mod;
+				k_mod->set_keycode(code - Key::KEY_0 + Key::KP_0);
+			}
+		}
+
+		if (_edit.mode == TRANSFORM_NONE) {
+			if (_edit.gizmo.is_null() && view_3d_controller->is_freelook_enabled() && k->get_keycode() == Key::ESCAPE) {
+				view_3d_controller->set_freelook_enabled(false);
+				return;
+			}
+
+			if (_edit.gizmo.is_valid() && (k->get_keycode() == Key::ESCAPE || k->get_keycode() == Key::BACKSPACE)) {
+				// Restore.
+				_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, true);
+				_edit.gizmo = Ref<EditorNode3DGizmo>();
+				set_message("");
+			}
+			if (k->get_keycode() == Key::ESCAPE && !view_3d_controller->cursor.region_select && !k->is_echo()) {
+				_clear_selected();
+				return;
+			}
+		} else {
+			// We're actively transforming, handle keys specially
+			TransformPlane new_plane = TRANSFORM_VIEW;
+			if (ED_IS_SHORTCUT("spatial_editor/lock_transform_x", event_mod)) {
+				new_plane = TRANSFORM_X_AXIS;
+			} else if (ED_IS_SHORTCUT("spatial_editor/lock_transform_y", event_mod)) {
+				new_plane = TRANSFORM_Y_AXIS;
+			} else if (ED_IS_SHORTCUT("spatial_editor/lock_transform_z", event_mod)) {
+				new_plane = TRANSFORM_Z_AXIS;
+			} else if (_edit.mode != TRANSFORM_ROTATE) { // rotating on a plane doesn't make sense
+				if (ED_IS_SHORTCUT("spatial_editor/lock_transform_yz", event_mod)) {
+					new_plane = TRANSFORM_YZ;
+				} else if (ED_IS_SHORTCUT("spatial_editor/lock_transform_xz", event_mod)) {
+					new_plane = TRANSFORM_XZ;
+				} else if (ED_IS_SHORTCUT("spatial_editor/lock_transform_xy", event_mod)) {
+					new_plane = TRANSFORM_XY;
+				}
+			}
+
+			if (new_plane != TRANSFORM_VIEW) {
+				if (new_plane != _edit.plane) {
+					// lock me once and get a global constraint
+					_edit.plane = new_plane;
+					spatial_editor->set_local_coords_enabled(false);
+				} else if (!spatial_editor->are_local_coords_enabled()) {
+					// lock me twice and get a local constraint
+					spatial_editor->set_local_coords_enabled(true);
+				} else {
+					// lock me thrice and we're back where we started
+					_edit.plane = TRANSFORM_VIEW;
+					spatial_editor->set_local_coords_enabled(false);
+				}
+				if (_edit.numeric_input != 0 || _edit.numeric_next_decimal != 0) {
+					update_transform_numeric();
+				} else {
+					update_transform(Input::get_singleton()->is_key_pressed(Key::SHIFT));
+				}
+				accept_event();
+				return;
+			}
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/bottom_view", event_mod)) {
+			_menu_option(VIEW_BOTTOM);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/top_view", event_mod)) {
+			_menu_option(VIEW_TOP);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/rear_view", event_mod)) {
+			_menu_option(VIEW_REAR);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/front_view", event_mod)) {
+			_menu_option(VIEW_FRONT);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/left_view", event_mod)) {
+			_menu_option(VIEW_LEFT);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/right_view", event_mod)) {
+			_menu_option(VIEW_RIGHT);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/orbit_view_down", event_mod)) {
+			// Clamp rotation to roughly -90..90 degrees so the user can't look upside-down and end up disoriented.
+			view_3d_controller->cursor.x_rot = CLAMP(view_3d_controller->cursor.x_rot - Math::PI / 12.0, -1.57, 1.57);
+			view_3d_controller->cursor.unsnapped_x_rot = view_3d_controller->cursor.x_rot;
+			view_3d_controller->set_view_type(View3DController::VIEW_TYPE_USER);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/orbit_view_up", event_mod)) {
+			// Clamp rotation to roughly -90..90 degrees so the user can't look upside-down and end up disoriented.
+			view_3d_controller->cursor.x_rot = CLAMP(view_3d_controller->cursor.x_rot + Math::PI / 12.0, -1.57, 1.57);
+			view_3d_controller->cursor.unsnapped_x_rot = view_3d_controller->cursor.x_rot;
+			view_3d_controller->set_view_type(View3DController::VIEW_TYPE_USER);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/orbit_view_right", event_mod)) {
+			view_3d_controller->cursor.y_rot -= Math::PI / 12.0;
+			view_3d_controller->cursor.unsnapped_y_rot = view_3d_controller->cursor.y_rot;
+			view_3d_controller->set_view_type(View3DController::VIEW_TYPE_USER);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/orbit_view_left", event_mod)) {
+			view_3d_controller->cursor.y_rot += Math::PI / 12.0;
+			view_3d_controller->cursor.unsnapped_y_rot = view_3d_controller->cursor.y_rot;
+			view_3d_controller->set_view_type(View3DController::VIEW_TYPE_USER);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/orbit_view_180", event_mod)) {
+			view_3d_controller->cursor.y_rot += Math::PI;
+			view_3d_controller->cursor.unsnapped_y_rot = view_3d_controller->cursor.y_rot;
+			view_3d_controller->set_view_type(View3DController::VIEW_TYPE_USER);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/focus_origin", event_mod)) {
+			_menu_option(VIEW_CENTER_TO_ORIGIN);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/focus_selection", event_mod)) {
+			_menu_option(VIEW_CENTER_TO_SELECTION);
+			times_focused_consecutively += 1;
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/align_transform_with_view", event_mod)) {
+			_menu_option(VIEW_ALIGN_TRANSFORM_WITH_VIEW);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/align_rotation_with_view", event_mod)) {
+			_menu_option(VIEW_ALIGN_ROTATION_WITH_VIEW);
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/insert_anim_key", event_mod)) {
+			if (!get_selected_count() || _edit.mode != TRANSFORM_NONE) {
+				return;
+			}
+
+			if (!AnimationPlayerEditor::get_singleton()->get_track_editor()->has_keying()) {
+				set_message(TTR("Keying is disabled (no key inserted)."));
+				return;
+			}
+
+			const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+
+			for (Node *E : selection) {
+				Node3D *sp = Object::cast_to<Node3D>(E);
+				if (!sp) {
+					continue;
+				}
+
+				spatial_editor->emit_signal(SNAME("transform_3d_key_request"), sp, "", sp->get_transform());
+			}
+
+			set_message(TTR("Animation Key Inserted."));
+		}
+		if (ED_IS_SHORTCUT("spatial_editor/cancel_transform", event_mod) && _edit.mode != TRANSFORM_NONE) {
+			cancel_transform();
+		}
+		if (!view_3d_controller->is_freelook_enabled() && !k->is_echo()) {
+			if (ED_IS_SHORTCUT("spatial_editor/reset_transform_position", event_mod)) {
+				_reset_transform(TransformType::POSITION);
+			}
+			if (ED_IS_SHORTCUT("spatial_editor/reset_transform_rotation", event_mod)) {
+				_reset_transform(TransformType::ROTATION);
+			}
+			if (ED_IS_SHORTCUT("spatial_editor/reset_transform_scale", event_mod)) {
+				_reset_transform(TransformType::SCALE);
+			}
+			if (ED_IS_SHORTCUT("spatial_editor/instant_translate", event_mod) && (_edit.mode != TRANSFORM_TRANSLATE || collision_reposition)) {
+				if (_edit.mode == TRANSFORM_NONE) {
+					begin_transform(TRANSFORM_TRANSLATE, true);
+				} else if (_edit.instant || collision_reposition) {
+					commit_transform();
+					begin_transform(TRANSFORM_TRANSLATE, true);
+				}
+			}
+			if (ED_IS_SHORTCUT("spatial_editor/instant_rotate", event_mod)) {
+				if (_edit.mode == TRANSFORM_ROTATE && _edit.instant) {
+					_edit.is_trackball = !_edit.is_trackball;
+					_edit.show_rotation_line = !_edit.is_trackball;
+					_edit.plane = TRANSFORM_VIEW;
+					_edit.original_mouse_pos = _edit.mouse_pos;
+					if (_edit.is_trackball) {
+						set_message(TTR("Trackball Rotation"));
+					} else {
+						_edit.initial_click_vector = Vector3();
+						_edit.previous_rotation_vector = Vector3();
+						_edit.accumulated_rotation_angle = 0.0;
+						_edit.rotation_angle = 0.0;
+						set_message(vformat(TTR("Rotating %s degrees."), String::num(0, 0)));
+					}
+					surface->queue_redraw();
+				} else if (_edit.mode != TRANSFORM_ROTATE) {
+					if (_edit.mode == TRANSFORM_NONE) {
+						begin_transform(TRANSFORM_ROTATE, true);
+					} else if (_edit.instant || collision_reposition) {
+						commit_transform();
+						begin_transform(TRANSFORM_ROTATE, true);
+					}
+				}
+			}
+			if (ED_IS_SHORTCUT("spatial_editor/instant_scale", event_mod) && _edit.mode != TRANSFORM_SCALE) {
+				if (_edit.mode == TRANSFORM_NONE) {
+					begin_transform(TRANSFORM_SCALE, true);
+				} else if (_edit.instant || collision_reposition) {
+					commit_transform();
+					begin_transform(TRANSFORM_SCALE, true);
+				}
+			}
+			if (ED_IS_SHORTCUT("spatial_editor/collision_reposition", event_mod) && editor_selection->get_top_selected_node_list().size() == 1 && !collision_reposition) {
+				if (_edit.mode == TRANSFORM_NONE || _edit.instant) {
+					if (_edit.mode == TRANSFORM_NONE) {
+						_compute_edit(_edit.mouse_pos);
+					} else {
+						commit_transform();
+						_compute_edit(_edit.mouse_pos);
+					}
+					_edit.mode = TRANSFORM_TRANSLATE;
+					collision_reposition = true;
+				}
+			}
+		}
+
+		// Freelook doesn't work in orthogonal mode or when previewing without pilot mode.
+		if (!view_3d_controller->is_orthogonal() && !(previewing && !pilot_preview_enabled) && ED_IS_SHORTCUT("spatial_editor/freelook_toggle", event_mod)) {
+			view_3d_controller->set_freelook_enabled(!view_3d_controller->is_freelook_enabled());
+		} else if (k->get_keycode() == Key::ESCAPE) {
+			view_3d_controller->set_freelook_enabled(false);
+		}
+
+		if (k->get_keycode() == Key::SPACE) {
+			if (!k->is_pressed()) {
+				emit_signal(SNAME("toggle_maximize_view"), this);
+			}
+		}
+	}
+
+	// Freelook uses most of the useful shortcuts, like save, so its OK
+	// to consider freelook active as end of the line for future events.
+	if (view_3d_controller->is_freelook_enabled()) {
+		accept_event();
+	}
+}
+
+void Node3DEditorViewport::_cursor_interpolated() {
+	last_camera_transform = view_3d_controller->interp_to_camera_transform();
+
+	if (previewing_camera && previewing && pilot_preview_enabled) {
+		previewing->set_global_transform(last_camera_transform);
+	} else if (!previewing_camera) {
+		camera->set_global_transform(last_camera_transform);
+	}
+
+	if (view_3d_controller->is_orthogonal()) {
+		float half_fov = Math::deg_to_rad(get_fov()) / 2.0;
+		float height = 2.0 * view_3d_controller->cursor.distance * Math::tan(half_fov);
+		camera->set_orthogonal(height, get_znear(), get_zfar());
+	} else {
+		camera->set_perspective(get_fov(), get_znear(), get_zfar());
+	}
+
+	view_3d_controller->set_z_near(get_znear());
+	view_3d_controller->set_z_far(get_zfar());
+
+	update_transform_gizmo_view();
+	rotation_control->queue_redraw();
+	position_control->queue_redraw();
+	look_control->queue_redraw();
+	surface->queue_redraw();
+	spatial_editor->update_grid();
+}
+
+void Node3DEditorViewport::_cursor_distance_scaled() {
+	zoom_indicator_delay = ZOOM_FREELOOK_INDICATOR_DELAY_S;
+	surface->queue_redraw();
+}
+
+void Node3DEditorViewport::_freelook_changed() {
+	spatial_editor->set_freelook_viewport(view_3d_controller->is_freelook_enabled() ? this : nullptr);
+}
+
+void Node3DEditorViewport::_freelook_speed_scaled() {
+	zoom_indicator_delay = ZOOM_FREELOOK_INDICATOR_DELAY_S;
+	surface->queue_redraw();
+}
+
+bool Node3DEditorViewport::_is_nav_modifier_pressed(const String &p_name) {
+	return _is_shortcut_empty(p_name) || Input::get_singleton()->is_action_pressed(p_name);
+}
+
+bool Node3DEditorViewport::_is_shortcut_empty(const String &p_name) {
+	Ref<Shortcut> check_shortcut = ED_GET_SHORTCUT(p_name);
+
+	ERR_FAIL_COND_V_MSG(check_shortcut.is_null(), true, "The Shortcut was null, possible name mismatch.");
+
+	return check_shortcut->get_events().is_empty();
+}
+
+void Node3DEditorViewport::set_message(const String &p_message, float p_time) {
+	message = p_message;
+	message_time = p_time;
+}
+
+void Node3DEditorPlugin::edited_scene_changed() {
+	for (uint32_t i = 0; i < Node3DEditor::VIEWPORTS_COUNT; i++) {
+		Node3DEditorViewport *viewport = Node3DEditor::get_singleton()->get_editor_viewport(i);
+		if (viewport->is_visible()) {
+			viewport->notification(Control::NOTIFICATION_VISIBILITY_CHANGED);
+		}
+	}
+}
+
+void Node3DEditorViewport::_project_settings_changed() {
+	// Update shadow atlas if changed.
+	int shadowmap_size = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_size");
+	bool shadowmap_16_bits = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_16_bits");
+	int atlas_q0 = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_0_subdiv");
+	int atlas_q1 = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_1_subdiv");
+	int atlas_q2 = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_2_subdiv");
+	int atlas_q3 = GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_3_subdiv");
+
+	viewport->set_positional_shadow_atlas_size(shadowmap_size);
+	viewport->set_positional_shadow_atlas_16_bits(shadowmap_16_bits);
+	viewport->set_positional_shadow_atlas_quadrant_subdiv(0, Viewport::PositionalShadowAtlasQuadrantSubdiv(atlas_q0));
+	viewport->set_positional_shadow_atlas_quadrant_subdiv(1, Viewport::PositionalShadowAtlasQuadrantSubdiv(atlas_q1));
+	viewport->set_positional_shadow_atlas_quadrant_subdiv(2, Viewport::PositionalShadowAtlasQuadrantSubdiv(atlas_q2));
+	viewport->set_positional_shadow_atlas_quadrant_subdiv(3, Viewport::PositionalShadowAtlasQuadrantSubdiv(atlas_q3));
+
+	// Update MSAA, screen-space AA and debanding if changed
+
+	const int msaa_mode = GLOBAL_GET("rendering/anti_aliasing/quality/msaa_3d");
+	viewport->set_msaa_3d(Viewport::MSAA(msaa_mode));
+	const int ssaa_mode = GLOBAL_GET("rendering/anti_aliasing/quality/screen_space_aa");
+	viewport->set_screen_space_aa(Viewport::ScreenSpaceAA(ssaa_mode));
+	const bool use_taa = GLOBAL_GET("rendering/anti_aliasing/quality/use_taa");
+	viewport->set_use_taa(use_taa);
+
+	const bool transparent_background = GLOBAL_GET("rendering/viewport/transparent_background");
+	viewport->set_transparent_background(transparent_background);
+
+	const bool use_debanding = GLOBAL_GET("rendering/anti_aliasing/quality/use_debanding");
+	viewport->set_use_debanding(use_debanding);
+
+	const bool use_occlusion_culling = GLOBAL_GET("rendering/occlusion_culling/use_occlusion_culling");
+	viewport->set_use_occlusion_culling(use_occlusion_culling);
+
+	const float mesh_lod_threshold = GLOBAL_GET("rendering/mesh_lod/lod_change/threshold_pixels");
+	viewport->set_mesh_lod_threshold(mesh_lod_threshold);
+
+	const Viewport::Scaling3DMode scaling_3d_mode = Viewport::Scaling3DMode(int(GLOBAL_GET("rendering/scaling_3d/mode")));
+	viewport->set_scaling_3d_mode(scaling_3d_mode);
+
+	_update_shrink();
+
+	const float fsr_sharpness = GLOBAL_GET("rendering/scaling_3d/fsr_sharpness");
+	viewport->set_fsr_sharpness(fsr_sharpness);
+
+	const float texture_mipmap_bias = GLOBAL_GET("rendering/textures/default_filters/texture_mipmap_bias");
+	viewport->set_texture_mipmap_bias(texture_mipmap_bias);
+
+	const Viewport::AnisotropicFiltering anisotropic_filtering_level = Viewport::AnisotropicFiltering(int(GLOBAL_GET("rendering/textures/default_filters/anisotropic_filtering_level")));
+	viewport->set_anisotropic_filtering_level(anisotropic_filtering_level);
+}
+
+static void override_label_colors(Control *p_control) {
+	p_control->begin_bulk_theme_override();
+	p_control->add_theme_color_override(SceneStringName(font_color), p_control->get_theme_color(SNAME("font_dark_background_color"), EditorStringName(Editor)));
+	p_control->add_theme_color_override("font_hover_color", p_control->get_theme_color(SNAME("font_dark_background_hover_color"), EditorStringName(Editor)));
+	p_control->add_theme_color_override("font_focus_color", p_control->get_theme_color(SNAME("font_dark_background_focus_color"), EditorStringName(Editor)));
+	p_control->add_theme_color_override("font_pressed_color", p_control->get_theme_color(SNAME("font_dark_background_pressed_color"), EditorStringName(Editor)));
+	p_control->add_theme_color_override("font_hover_pressed_color", p_control->get_theme_color(SNAME("font_dark_background_hover_pressed_color"), EditorStringName(Editor)));
+	p_control->end_bulk_theme_override();
+}
+
+static void override_button_stylebox(Button *p_button, const Ref<StyleBox> p_stylebox) {
+	p_button->begin_bulk_theme_override();
+	p_button->add_theme_style_override(CoreStringName(normal), p_stylebox);
+	p_button->add_theme_style_override("normal_mirrored", p_stylebox);
+	p_button->add_theme_style_override(SceneStringName(hover), p_stylebox);
+	p_button->add_theme_style_override("hover_mirrored", p_stylebox);
+	p_button->add_theme_style_override("hover_pressed", p_stylebox);
+	p_button->add_theme_style_override("hover_pressed_mirrored", p_stylebox);
+	p_button->add_theme_style_override(SceneStringName(pressed), p_stylebox);
+	p_button->add_theme_style_override("pressed_mirrored", p_stylebox);
+	p_button->add_theme_style_override("focus", p_stylebox);
+	p_button->add_theme_style_override("focus_mirrored", p_stylebox);
+	p_button->add_theme_style_override("disabled", p_stylebox);
+	p_button->add_theme_style_override("disabled_mirrored", p_stylebox);
+	p_button->end_bulk_theme_override();
+}
+
+void Node3DEditorViewport::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			_update_name();
+			_update_centered_labels();
+			message_time = MIN(message_time, 0.001); // Make it disappear.
+
+			const int item_count = display_submenu->get_item_count();
+			for (int i = 0; i < item_count; i++) {
+				const Array item_data = display_submenu->get_item_metadata(i);
+				if (item_data.is_empty()) {
+					continue;
+				}
+
+				SupportedRenderingMethods rendering_methods = item_data[0];
+				String base_tooltip = item_data[1];
+
+				bool disabled = false;
+				String disabled_tooltip;
+				switch (rendering_methods) {
+					case SupportedRenderingMethods::ALL:
+						break;
+					case SupportedRenderingMethods::FORWARD_PLUS_MOBILE:
+						disabled = OS::get_singleton()->get_current_rendering_method() == "gl_compatibility";
+						disabled_tooltip = TTR("This debug draw mode is only supported when using the Forward+ or Mobile renderer.");
+						break;
+					case SupportedRenderingMethods::FORWARD_PLUS:
+						disabled = OS::get_singleton()->get_current_rendering_method() == "gl_compatibility" || OS::get_singleton()->get_current_rendering_method() == "mobile";
+						disabled_tooltip = TTR("This debug draw mode is only supported when using the Forward+ renderer.");
+						break;
+				}
+
+				display_submenu->set_item_disabled(i, disabled);
+				String tooltip = TTR(base_tooltip);
+				if (disabled) {
+					if (tooltip.is_empty()) {
+						tooltip = disabled_tooltip;
+					} else {
+						tooltip += "\n\n" + disabled_tooltip;
+					}
+				}
+				display_submenu->set_item_tooltip(i, tooltip);
+			}
+		} break;
+
+		case NOTIFICATION_READY: {
+			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Node3DEditorViewport::_project_settings_changed));
+			_update_navigation_controls_visibility();
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			bool vp_visible = is_visible_in_tree();
+
+			set_process(vp_visible);
+			set_physics_process(vp_visible);
+
+			if (vp_visible) {
+				view_3d_controller->set_orthogonal(view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_ORTHOGONAL)));
+				view_3d_controller->update_camera();
+				_update_name();
+			} else {
+				view_3d_controller->set_freelook_enabled(false);
+			}
+			callable_mp(this, &Node3DEditorViewport::update_transform_gizmo_view).call_deferred();
+		} break;
+
+		case NOTIFICATION_RESIZED: {
+			callable_mp(this, &Node3DEditorViewport::update_transform_gizmo_view).call_deferred();
+		} break;
+
+		case NOTIFICATION_PROCESS: {
+			if (ruler->is_inside_tree()) {
+				Vector3 start_pos = ruler_start_point->get_global_position();
+				Vector3 end_pos = ruler_end_point->get_global_position();
+
+				geometry->clear_surfaces();
+				geometry->surface_begin(Mesh::PRIMITIVE_LINES);
+
+				Vector3 center = (start_pos + end_pos) / 2;
+				Vector3 camera_dir = (camera->get_transform().origin - center).normalized();
+				real_t offset_distance = 0.01;
+
+				geometry->surface_add_vertex(start_pos + camera_dir * offset_distance);
+				geometry->surface_add_vertex(end_pos + camera_dir * offset_distance);
+				geometry->surface_end();
+
+				geometry_xray->clear_surfaces();
+				geometry_xray->surface_begin(Mesh::PRIMITIVE_LINES);
+				geometry_xray->surface_add_vertex(start_pos);
+				geometry_xray->surface_add_vertex(end_pos);
+				geometry_xray->surface_end();
+
+				float distance = start_pos.distance_to(end_pos);
+				if (distance < 0.001) {
+					distance = 0.0;
+				}
+				ruler_label->set_text(TranslationServer::get_singleton()->format_number(vformat("%.3f m", distance), _get_locale()));
+
+				Vector2 screen_position = camera->unproject_position(center) - (ruler_label->get_custom_minimum_size() / 2);
+				ruler_label->set_position(screen_position);
+
+				bool show_components = Input::get_singleton()->is_key_pressed(Key::SHIFT);
+
+				if (show_components) {
+					Ref<ImmediateMesh> triangle_mesh = ruler_triangle_lines->get_mesh();
+					Ref<ImmediateMesh> triangle_mesh_xray = ruler_triangle_lines_xray->get_mesh();
+
+					if (triangle_mesh.is_valid() && triangle_mesh_xray.is_valid()) {
+						Vector3 delta = end_pos - start_pos;
+						delta = delta.abs();
+						const real_t threshold = 0.001;
+						if (delta.x < threshold) {
+							delta.x = 0.0;
+						}
+						if (delta.y < threshold) {
+							delta.y = 0.0;
+						}
+						if (delta.z < threshold) {
+							delta.z = 0.0;
+						}
+
+						Vector3 corner_point;
+						Color first_line_color;
+						Color second_line_color;
+
+						Color axis_x_color = get_theme_color(SNAME("axis_x_color"), EditorStringName(Editor));
+						Color axis_y_color = get_theme_color(SNAME("axis_y_color"), EditorStringName(Editor));
+						Color axis_z_color = get_theme_color(SNAME("axis_z_color"), EditorStringName(Editor));
+
+						if (delta.x > 0.0 && delta.y > 0.0 && delta.z == 0.0) {
+							// XY plane
+							corner_point = Vector3(end_pos.x, start_pos.y, start_pos.z);
+							first_line_color = axis_x_color;
+							second_line_color = axis_y_color;
+						} else if (delta.x > 0.0 && delta.z > 0.0 && delta.y == 0.0) {
+							// XZ plane
+							corner_point = Vector3(end_pos.x, start_pos.y, start_pos.z);
+							first_line_color = axis_x_color;
+							second_line_color = axis_z_color;
+						} else if (delta.y > 0.0 && delta.z > 0.0 && delta.x == 0.0) {
+							// YZ plane
+							corner_point = Vector3(start_pos.x, start_pos.y, end_pos.z);
+							first_line_color = axis_z_color;
+							second_line_color = axis_y_color;
+						} else if (delta.x > 0.0 && delta.y > 0.0 && delta.z > 0.0) {
+							// All three axes
+							corner_point = Vector3(end_pos.x, start_pos.y, start_pos.z);
+							first_line_color = axis_x_color;
+							second_line_color = axis_y_color;
+						} else {
+							corner_point = end_pos;
+							first_line_color = axis_x_color;
+							second_line_color = axis_x_color;
+						}
+
+						triangle_mesh->clear_surfaces();
+						triangle_mesh->surface_begin(Mesh::PRIMITIVE_LINES);
+
+						Vector3 triangle_camera_dir = (camera->get_transform().origin - center).normalized();
+						real_t triangle_offset_distance = 0.01;
+
+						triangle_mesh->surface_set_color(first_line_color);
+						triangle_mesh->surface_add_vertex(start_pos + triangle_camera_dir * triangle_offset_distance);
+						triangle_mesh->surface_set_color(first_line_color);
+						triangle_mesh->surface_add_vertex(corner_point + triangle_camera_dir * triangle_offset_distance);
+						triangle_mesh->surface_set_color(second_line_color);
+						triangle_mesh->surface_add_vertex(corner_point + triangle_camera_dir * triangle_offset_distance);
+						triangle_mesh->surface_set_color(second_line_color);
+						triangle_mesh->surface_add_vertex(end_pos + triangle_camera_dir * triangle_offset_distance);
+
+						triangle_mesh->surface_end();
+
+						Color first_line_color_xray = first_line_color;
+						Color second_line_color_xray = second_line_color;
+						first_line_color_xray.a = 0.15;
+						second_line_color_xray.a = 0.15;
+
+						triangle_mesh_xray->clear_surfaces();
+						triangle_mesh_xray->surface_begin(Mesh::PRIMITIVE_LINES);
+
+						triangle_mesh_xray->surface_set_color(first_line_color_xray);
+						triangle_mesh_xray->surface_add_vertex(start_pos);
+						triangle_mesh_xray->surface_set_color(first_line_color_xray);
+						triangle_mesh_xray->surface_add_vertex(corner_point);
+						triangle_mesh_xray->surface_set_color(second_line_color_xray);
+						triangle_mesh_xray->surface_add_vertex(corner_point);
+						triangle_mesh_xray->surface_set_color(second_line_color_xray);
+						triangle_mesh_xray->surface_add_vertex(end_pos);
+
+						triangle_mesh_xray->surface_end();
+					}
+				} else {
+					Ref<ImmediateMesh> triangle_mesh = ruler_triangle_lines->get_mesh();
+					Ref<ImmediateMesh> triangle_mesh_xray = ruler_triangle_lines_xray->get_mesh();
+
+					if (triangle_mesh.is_valid()) {
+						triangle_mesh->clear_surfaces();
+					}
+					if (triangle_mesh_xray.is_valid()) {
+						triangle_mesh_xray->clear_surfaces();
+					}
+				}
+
+				if (show_components) {
+					Vector3 delta = end_pos - start_pos;
+					delta = delta.abs();
+					const real_t threshold = 0.001;
+					if (delta.x < threshold) {
+						delta.x = 0.0;
+					}
+					if (delta.y < threshold) {
+						delta.y = 0.0;
+					}
+					if (delta.z < threshold) {
+						delta.z = 0.0;
+					}
+
+					int active_axes = 0;
+					if (delta.x > 0.0) {
+						active_axes++;
+					}
+					if (delta.y > 0.0) {
+						active_axes++;
+					}
+					if (delta.z > 0.0) {
+						active_axes++;
+					}
+
+					String x_text = delta.x > 0.0 ? TranslationServer::get_singleton()->format_number(vformat("X: %.3f m", delta.x), _get_locale()) : "";
+					String y_text = delta.y > 0.0 ? TranslationServer::get_singleton()->format_number(vformat("Y: %.3f m", delta.y), _get_locale()) : "";
+					String z_text = delta.z > 0.0 ? TranslationServer::get_singleton()->format_number(vformat("Z: %.3f m", delta.z), _get_locale()) : "";
+
+					Color axis_x_color = get_theme_color(SNAME("axis_x_color"), EditorStringName(Editor));
+					Color axis_y_color = get_theme_color(SNAME("axis_y_color"), EditorStringName(Editor));
+					Color axis_z_color = get_theme_color(SNAME("axis_z_color"), EditorStringName(Editor));
+
+					Vector3 corner_point;
+
+					if (active_axes >= 2) {
+						if (delta.z == 0.0) {
+							// XY plane
+							corner_point = Vector3(end_pos.x, start_pos.y, start_pos.z);
+
+							ruler_label_x->add_theme_color_override(SceneStringName(font_color), axis_x_color);
+							ruler_label_x->set_text(x_text);
+							ruler_label_x->set_visible(true);
+							Vector2 x_pos = camera->unproject_position((start_pos + corner_point) / 2) - (ruler_label_x->get_custom_minimum_size() / 2);
+							ruler_label_x->set_position(x_pos);
+
+							ruler_label_y->add_theme_color_override(SceneStringName(font_color), axis_y_color);
+							ruler_label_y->set_text(y_text);
+							ruler_label_y->set_visible(true);
+							Vector2 y_pos = camera->unproject_position((corner_point + end_pos) / 2) - (ruler_label_y->get_custom_minimum_size() / 2);
+							ruler_label_y->set_position(y_pos);
+
+							ruler_label_z->set_visible(false);
+						} else if (delta.y == 0.0) {
+							// XZ plane
+							corner_point = Vector3(end_pos.x, start_pos.y, start_pos.z);
+
+							ruler_label_x->add_theme_color_override(SceneStringName(font_color), axis_x_color);
+							ruler_label_x->set_text(x_text);
+							ruler_label_x->set_visible(true);
+							Vector2 x_pos = camera->unproject_position((start_pos + corner_point) / 2) - (ruler_label_x->get_custom_minimum_size() / 2);
+							ruler_label_x->set_position(x_pos);
+
+							ruler_label_y->add_theme_color_override(SceneStringName(font_color), axis_z_color);
+							ruler_label_y->set_text(z_text);
+							ruler_label_y->set_visible(true);
+							Vector2 z_pos = camera->unproject_position((corner_point + end_pos) / 2) - (ruler_label_y->get_custom_minimum_size() / 2);
+							ruler_label_y->set_position(z_pos);
+
+							ruler_label_z->set_visible(false);
+						} else if (delta.x == 0.0) {
+							// YZ plane
+							corner_point = Vector3(start_pos.x, start_pos.y, end_pos.z);
+
+							ruler_label_x->add_theme_color_override(SceneStringName(font_color), axis_z_color);
+							ruler_label_x->set_text(z_text);
+							ruler_label_x->set_visible(true);
+							Vector2 z_pos = camera->unproject_position((start_pos + corner_point) / 2) - (ruler_label_x->get_custom_minimum_size() / 2);
+							ruler_label_x->set_position(z_pos);
+
+							ruler_label_y->add_theme_color_override(SceneStringName(font_color), axis_y_color);
+							ruler_label_y->set_text(y_text);
+							ruler_label_y->set_visible(true);
+							Vector2 y_pos = camera->unproject_position((corner_point + end_pos) / 2) - (ruler_label_y->get_custom_minimum_size() / 2);
+							ruler_label_y->set_position(y_pos);
+
+							ruler_label_z->set_visible(false);
+						} else {
+							// All three axes
+							corner_point = Vector3(end_pos.x, start_pos.y, start_pos.z);
+
+							ruler_label_x->add_theme_color_override(SceneStringName(font_color), axis_x_color);
+							ruler_label_x->set_text(x_text);
+							ruler_label_x->set_visible(true);
+							Vector2 x_pos = camera->unproject_position((start_pos + corner_point) / 2) - (ruler_label_x->get_custom_minimum_size() / 2);
+							ruler_label_x->set_position(x_pos);
+
+							ruler_label_y->add_theme_color_override(SceneStringName(font_color), axis_y_color);
+							ruler_label_y->set_text(y_text);
+							ruler_label_y->set_visible(true);
+							Vector2 y_pos = camera->unproject_position((corner_point + end_pos) / 2) - (ruler_label_y->get_custom_minimum_size() / 2);
+							ruler_label_y->set_position(y_pos);
+
+							ruler_label_z->add_theme_color_override(SceneStringName(font_color), axis_z_color);
+							ruler_label_z->set_text(z_text);
+							ruler_label_z->set_visible(true);
+							Vector2 z_pos = camera->unproject_position(center + Vector3(0, 0, -0.5)) - (ruler_label_z->get_custom_minimum_size() / 2);
+							ruler_label_z->set_position(z_pos);
+						}
+					} else if (active_axes == 1) {
+						corner_point = end_pos;
+
+						if (delta.x > 0.0) {
+							ruler_label_x->add_theme_color_override(SceneStringName(font_color), axis_x_color);
+							ruler_label_x->set_text(x_text);
+							ruler_label_x->set_visible(true);
+							Vector2 pos = camera->unproject_position(center) - (ruler_label_x->get_custom_minimum_size() / 2);
+							ruler_label_x->set_position(pos);
+							ruler_label_y->set_visible(false);
+							ruler_label_z->set_visible(false);
+						} else if (delta.y > 0.0) {
+							ruler_label_x->add_theme_color_override(SceneStringName(font_color), axis_y_color);
+							ruler_label_x->set_text(y_text);
+							ruler_label_x->set_visible(true);
+							Vector2 pos = camera->unproject_position(center) - (ruler_label_x->get_custom_minimum_size() / 2);
+							ruler_label_x->set_position(pos);
+							ruler_label_y->set_visible(false);
+							ruler_label_z->set_visible(false);
+						} else {
+							ruler_label_x->add_theme_color_override(SceneStringName(font_color), axis_z_color);
+							ruler_label_x->set_text(z_text);
+							ruler_label_x->set_visible(true);
+							Vector2 pos = camera->unproject_position(center) - (ruler_label_x->get_custom_minimum_size() / 2);
+							ruler_label_x->set_position(pos);
+							ruler_label_y->set_visible(false);
+							ruler_label_z->set_visible(false);
+						}
+					} else {
+						ruler_label_x->set_visible(false);
+						ruler_label_y->set_visible(false);
+						ruler_label_z->set_visible(false);
+					}
+
+				} else {
+					ruler_label_x->set_visible(false);
+					ruler_label_y->set_visible(false);
+					ruler_label_z->set_visible(false);
+				}
+			}
+
+			real_t delta = get_process_delta_time();
+
+			if (zoom_indicator_delay > 0) {
+				zoom_indicator_delay -= delta;
+				if (zoom_indicator_delay <= 0) {
+					surface->queue_redraw();
+					zoom_limit_label->hide();
+				}
+			}
+
+			if (view_3d_controller->is_freelook_enabled()) {
+				view_3d_controller->update_freelook(delta);
+				_disable_follow_mode();
+			}
+
+			if (focused_node_id.is_valid() && get_selected_count() > 0 && times_focused_consecutively >= 2 && times_focused_consecutively % 2 == 0) {
+				Node *focused_node = ObjectDB::get_instance<Node>(focused_node_id);
+				if (focused_node) {
+					follow_mode->set_text(vformat(TTR("Following %s"), focused_node->get_name()));
+					follow_mode->set_button_icon(get_editor_theme_icon(focused_node->get_class()));
+					follow_mode->show();
+					focus_selection();
+				} else {
+					_disable_follow_mode();
+				}
+			} else {
+				follow_mode->hide();
+			}
+
+			Node *scene_root = SceneTreeDock::get_singleton()->get_editor_data()->get_edited_scene_root();
+			if (previewing_cinema && scene_root != nullptr) {
+				Camera3D *cam = scene_root->get_viewport()->get_camera_3d();
+				if (cam != nullptr && cam != previewing) {
+					//then switch the viewport's camera to the scene's viewport camera
+					if (previewing != nullptr) {
+						previewing->disconnect(SceneStringName(tree_exited), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
+						previewing->disconnect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
+					}
+					previewing = cam;
+					previewing->connect(SceneStringName(tree_exited), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
+					previewing->connect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
+					RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), cam->get_camera());
+					surface->queue_redraw();
+				}
+			}
+
+			if (_camera_moved_externally()) {
+				// If camera moved after this plugin last set it, presumably a tool script has moved it, accept the new camera transform as the cursor position.
+				_apply_camera_transform_to_cursor();
+				view_3d_controller->update_camera();
+			} else {
+				view_3d_controller->update_camera(delta);
+			}
+
+			const HashMap<ObjectID, Object *> &selection = editor_selection->get_selection();
+
+			bool changed = false;
+			bool exist = false;
+
+			for (const KeyValue<ObjectID, Object *> &E : selection) {
+				Node3D *sp = ObjectDB::get_instance<Node3D>(E.key);
+				if (!sp) {
+					continue;
+				}
+
+				Node3DEditorSelectedItem *se = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(sp);
+				if (!se) {
+					continue;
+				}
+
+				Transform3D t = sp->get_global_gizmo_transform();
+				if (!t.is_finite()) {
+					continue;
+				}
+				AABB new_aabb = _calculate_spatial_bounds(sp);
+
+				exist = true;
+				if (se->last_xform == t && se->aabb == new_aabb && !se->last_xform_dirty) {
+					continue;
+				}
+				changed = true;
+				se->last_xform_dirty = false;
+				se->last_xform = t;
+
+				se->aabb = new_aabb;
+
+				Transform3D t_offset = t;
+
+				// apply AABB scaling before item's global transform
+				{
+					const Vector3 offset(0.005, 0.005, 0.005);
+					Basis aabb_s;
+					aabb_s.scale(se->aabb.size + offset);
+					t.translate_local(se->aabb.position - offset / 2);
+					t.basis = t.basis * aabb_s;
+				}
+				{
+					const Vector3 offset(0.01, 0.01, 0.01);
+					Basis aabb_s;
+					aabb_s.scale(se->aabb.size + offset);
+					t_offset.translate_local(se->aabb.position - offset / 2);
+					t_offset.basis = t_offset.basis * aabb_s;
+				}
+
+				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance, t);
+				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_offset, t_offset);
+				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_xray, t);
+				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_xray_offset, t_offset);
+			}
+
+			if (changed || (spatial_editor->is_gizmo_visible() && !exist)) {
+				spatial_editor->update_transform_gizmo();
+			}
+
+			if (message_time > 0) {
+				if (message != last_message) {
+					surface->queue_redraw();
+					last_message = message;
+				}
+
+				message_time -= get_process_delta_time();
+				if (message_time < 0) {
+					surface->queue_redraw();
+				}
+			}
+
+			bool show_info = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_INFORMATION));
+			if (show_info != info_panel->is_visible()) {
+				info_panel->set_visible(show_info);
+			}
+
+			Camera3D *current_camera;
+
+			if (previewing) {
+				current_camera = previewing;
+			} else {
+				current_camera = camera;
+			}
+
+			if (show_info) {
+				const String viewport_size = vformat(U"%d × %d", viewport->get_size().x * viewport->get_scaling_3d_scale(), viewport->get_size().y * viewport->get_scaling_3d_scale());
+				String text;
+				text += vformat(TTR("X: %s"), rtos(current_camera->get_position().x).pad_decimals(1)) + "\n";
+				text += vformat(TTR("Y: %s"), rtos(current_camera->get_position().y).pad_decimals(1)) + "\n";
+				text += vformat(TTR("Z: %s"), rtos(current_camera->get_position().z).pad_decimals(1)) + "\n";
+				text += "\n";
+				text += vformat(
+						TTR("Size: %s (%.1fMP)") + "\n",
+						viewport_size,
+						viewport->get_size().x * viewport->get_size().y * Math::pow(viewport->get_scaling_3d_scale(), 2) * 0.000001);
+
+				text += "\n";
+				text += vformat(TTR("Objects: %d"), viewport->get_render_info(Viewport::RENDER_INFO_TYPE_VISIBLE, Viewport::RENDER_INFO_OBJECTS_IN_FRAME)) + "\n";
+				text += vformat(TTR("Primitives: %d"), viewport->get_render_info(Viewport::RENDER_INFO_TYPE_VISIBLE, Viewport::RENDER_INFO_PRIMITIVES_IN_FRAME)) + "\n";
+				text += vformat(TTR("Draw Calls: %d"), viewport->get_render_info(Viewport::RENDER_INFO_TYPE_VISIBLE, Viewport::RENDER_INFO_DRAW_CALLS_IN_FRAME));
+
+				info_label->set_text(text);
+			}
+
+			// FPS Counter.
+			bool show_fps = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_FRAME_TIME));
+
+			if (show_fps != frame_time_panel->is_visible()) {
+				frame_time_panel->set_visible(show_fps);
+				RS::get_singleton()->viewport_set_measure_render_time(viewport->get_viewport_rid(), show_fps);
+				for (int i = 0; i < FRAME_TIME_HISTORY; i++) {
+					// Initialize to 120 FPS, so that the initial estimation until we get enough data is always reasonable.
+					cpu_time_history[i] = 8.333333;
+					gpu_time_history[i] = 8.333333;
+				}
+				cpu_time_history_index = 0;
+				gpu_time_history_index = 0;
+			}
+			if (show_fps) {
+				cpu_time_history[cpu_time_history_index] = RS::get_singleton()->viewport_get_measured_render_time_cpu(viewport->get_viewport_rid());
+				cpu_time_history_index = (cpu_time_history_index + 1) % FRAME_TIME_HISTORY;
+				double cpu_time = 0.0;
+				for (int i = 0; i < FRAME_TIME_HISTORY; i++) {
+					cpu_time += cpu_time_history[i];
+				}
+				cpu_time /= FRAME_TIME_HISTORY;
+				// Prevent unrealistically low values.
+				cpu_time = MAX(0.01, cpu_time);
+
+				gpu_time_history[gpu_time_history_index] = RS::get_singleton()->viewport_get_measured_render_time_gpu(viewport->get_viewport_rid());
+				gpu_time_history_index = (gpu_time_history_index + 1) % FRAME_TIME_HISTORY;
+				double gpu_time = 0.0;
+				for (int i = 0; i < FRAME_TIME_HISTORY; i++) {
+					gpu_time += gpu_time_history[i];
+				}
+				gpu_time /= FRAME_TIME_HISTORY;
+				// Prevent division by zero for the FPS counter (and unrealistically low values).
+				// This limits the reported FPS to 100000.
+				gpu_time = MAX(0.01, gpu_time);
+
+				// Color labels depending on performance level ("good" = green, "OK" = yellow, "bad" = red).
+				// Middle point is at 15 ms.
+				cpu_time_label->set_text(vformat(TTR("CPU Time: %s ms"), rtos(cpu_time).pad_decimals(2)));
+				cpu_time_label->add_theme_color_override(
+						SceneStringName(font_color),
+						frame_time_gradient->get_color_at_offset(
+								Math::remap(cpu_time, 0, 30, 0, 1)));
+
+				gpu_time_label->set_text(vformat(TTR("GPU Time: %s ms"), rtos(gpu_time).pad_decimals(2)));
+				// Middle point is at 15 ms.
+				gpu_time_label->add_theme_color_override(
+						SceneStringName(font_color),
+						frame_time_gradient->get_color_at_offset(
+								Math::remap(gpu_time, 0, 30, 0, 1)));
+
+				const double fps = 1000.0 / gpu_time;
+				fps_label->set_text(vformat(TTR("FPS: %d"), fps));
+				// Middle point is at 60 FPS.
+				fps_label->add_theme_color_override(
+						SceneStringName(font_color),
+						frame_time_gradient->get_color_at_offset(
+								Math::remap(fps, 110, 10, 0, 1)));
+			}
+		} break;
+
+		case NOTIFICATION_PHYSICS_PROCESS: {
+			if (collision_reposition) {
+				Node3D *selected_node = nullptr;
+
+				if (ruler->is_inside_tree()) {
+					if (ruler_start_point->is_visible()) {
+						selected_node = ruler_end_point;
+					} else {
+						selected_node = ruler_start_point;
+					}
+				} else {
+					const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+					if (selection.size() == 1) {
+						selected_node = Object::cast_to<Node3D>(selection.front()->get());
+					}
+				}
+
+				if (selected_node) {
+					if (!ruler->is_inside_tree()) {
+						double snap = EDITOR_GET("interface/inspector/default_float_step");
+						int snap_step_decimals = Math::range_step_decimals(snap);
+						set_message(vformat(TTR("Translating: %s"), vformat("%.*v", snap_step_decimals, selected_node->get_global_position())));
+					}
+
+					selected_node->set_global_position(spatial_editor->snap_point(_get_instance_position(_edit.mouse_pos, selected_node)));
+
+					if (ruler->is_inside_tree() && !ruler_start_point->is_visible()) {
+						ruler_end_point->set_global_position(ruler_start_point->get_global_position());
+						ruler_start_point->set_visible(true);
+						ruler_end_point->set_visible(true);
+						ruler_label->set_visible(true);
+						ruler_label_x->set_visible(false);
+						ruler_label_y->set_visible(false);
+						ruler_label_z->set_visible(false);
+					}
+				}
+			}
+
+			if (!update_preview_node) {
+				return;
+			}
+			if (preview_node->is_inside_tree()) {
+				preview_node_pos = spatial_editor->snap_point(_get_instance_position(preview_node_viewport_pos, preview_node));
+				double snap = EDITOR_GET("interface/inspector/default_float_step");
+				int snap_step_decimals = Math::range_step_decimals(snap);
+				set_message(vformat(TTR("Instantiating: %s"), vformat("%.*v", snap_step_decimals, preview_node_pos)));
+				Transform3D preview_gl_transform = Transform3D(Basis(), preview_node_pos);
+				preview_node->set_global_transform(preview_gl_transform);
+				if (!preview_node->is_visible()) {
+					preview_node->show();
+				}
+			}
+			update_preview_node = false;
+		} break;
+
+		case NOTIFICATION_APPLICATION_FOCUS_OUT:
+		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
+			view_3d_controller->set_freelook_enabled(false);
+			view_3d_controller->cursor.region_select = false;
+			surface->queue_redraw();
+
+			// Commit the drag if the window is focused out.
+			if (_edit.mode != TRANSFORM_NONE) {
+				commit_transform();
+				return;
+			}
+
+			if (_edit.gizmo.is_valid()) {
+				// Certain gizmo plugins should be able to commit handles without dragging them.
+				if (_edit.original_mouse_pos != _edit.mouse_pos || _edit.gizmo->get_plugin()->can_commit_handle_on_click()) {
+					_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, false);
+				}
+
+				spatial_editor->get_single_selected_node()->update_gizmos();
+				_edit.gizmo = Ref<EditorNode3DGizmo>();
+				set_message("");
+			}
+		} break;
+
+		case NOTIFICATION_ENTER_TREE: {
+			surface->connect(SceneStringName(draw), callable_mp(this, &Node3DEditorViewport::_draw));
+			surface->connect(SceneStringName(gui_input), callable_mp(this, &Node3DEditorViewport::_sinput));
+			surface->connect(SceneStringName(mouse_entered), callable_mp(this, &Node3DEditorViewport::_surface_mouse_enter));
+			surface->connect(SceneStringName(mouse_exited), callable_mp(this, &Node3DEditorViewport::_surface_mouse_exit));
+			surface->connect(SceneStringName(focus_entered), callable_mp(this, &Node3DEditorViewport::_surface_focus_enter));
+			surface->connect(SceneStringName(focus_exited), callable_mp(this, &Node3DEditorViewport::_surface_focus_exit));
+
+			_init_gizmo_instance(index);
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			_finish_gizmo_instances();
+		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			_update_centered_labels();
+
+			view_display_menu->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHlDarkBackground")));
+			preview_camera->set_button_icon(get_editor_theme_icon(SNAME("Camera3DDarkBackground")));
+			pilot_camera->set_button_icon(get_editor_theme_icon(SNAME("3D")));
+			Control *gui_base = EditorNode::get_singleton()->get_gui_base();
+
+			const Ref<StyleBox> &information_3d_stylebox = gui_base->get_theme_stylebox(SNAME("Information3dViewport"), EditorStringName(EditorStyles));
+
+			override_button_stylebox(view_display_menu, information_3d_stylebox);
+			override_label_colors(view_display_menu);
+			override_button_stylebox(translation_preview_button, information_3d_stylebox);
+			override_label_colors(translation_preview_button);
+			override_button_stylebox(follow_mode, information_3d_stylebox);
+			override_label_colors(follow_mode);
+			override_button_stylebox(preview_camera, information_3d_stylebox);
+			override_label_colors(preview_camera);
+
+			frame_time_gradient->set_color(0, get_theme_color(SNAME("success_color_dark_background"), EditorStringName(Editor)));
+			frame_time_gradient->set_color(1, get_theme_color(SNAME("warning_color_dark_background"), EditorStringName(Editor)));
+			frame_time_gradient->set_color(2, get_theme_color(SNAME("error_color_dark_background"), EditorStringName(Editor)));
+
+			override_button_stylebox(pilot_camera, information_3d_stylebox);
+			override_label_colors(pilot_camera);
+
+			info_panel->add_theme_style_override(SceneStringName(panel), information_3d_stylebox);
+			override_label_colors(info_label);
+			tooltip_panel->add_theme_style_override(CoreStringName(normal), information_3d_stylebox);
+
+			frame_time_panel->add_theme_style_override(SceneStringName(panel), information_3d_stylebox);
+			// Set a minimum width to prevent the width from changing all the time
+			// when numbers vary rapidly. This minimum width is set based on a
+			// GPU time of 999.99 ms in the current editor language.
+			const float min_width = get_theme_font(SNAME("main"), EditorStringName(EditorFonts))->get_string_size(vformat(TTR("GPU Time: %s ms"), 999.99)).x;
+			frame_time_panel->set_custom_minimum_size(Size2(min_width, 0) * EDSCALE);
+			frame_time_vbox->add_theme_constant_override("separation", Math::round(-1 * EDSCALE));
+
+			cinema_label->add_theme_style_override(CoreStringName(normal), information_3d_stylebox);
+			locked_label->add_theme_style_override(CoreStringName(normal), information_3d_stylebox);
+
+			ruler_label->add_theme_color_override(SceneStringName(font_color), Color(1.0, 0.9, 0.0, 1.0));
+			ruler_label->add_theme_color_override("font_outline_color", Color(0.0, 0.0, 0.0, 1.0));
+			ruler_label->add_theme_constant_override("outline_size", 4 * EDSCALE);
+			ruler_label->add_theme_font_size_override(SceneStringName(font_size), 15 * EDSCALE);
+			ruler_label->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("bold"), EditorStringName(EditorFonts)));
+
+			ruler_label_x->add_theme_color_override("font_outline_color", Color(0.0, 0.0, 0.0, 1.0));
+			ruler_label_x->add_theme_constant_override("outline_size", 4 * EDSCALE);
+			ruler_label_x->add_theme_font_size_override(SceneStringName(font_size), 15 * EDSCALE);
+			ruler_label_x->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("bold"), EditorStringName(EditorFonts)));
+
+			ruler_label_y->add_theme_color_override("font_outline_color", Color(0.0, 0.0, 0.0, 1.0));
+			ruler_label_y->add_theme_constant_override("outline_size", 4 * EDSCALE);
+			ruler_label_y->add_theme_font_size_override(SceneStringName(font_size), 15 * EDSCALE);
+			ruler_label_y->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("bold"), EditorStringName(EditorFonts)));
+
+			ruler_label_z->add_theme_color_override("font_outline_color", Color(0.0, 0.0, 0.0, 1.0));
+			ruler_label_z->add_theme_constant_override("outline_size", 4 * EDSCALE);
+			ruler_label_z->add_theme_font_size_override(SceneStringName(font_size), 15 * EDSCALE);
+			ruler_label_z->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("bold"), EditorStringName(EditorFonts)));
+		} break;
+
+		case NOTIFICATION_DRAG_END: {
+			// Clear preview material when dropped outside applicable object.
+			if (spatial_editor->get_preview_material().is_valid() && !is_drag_successful()) {
+				_reset_preview_material();
+				_remove_preview_material();
+			} else {
+				_remove_preview_node();
+			}
+		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			_update_view_3d_controller();
+
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/3d")) {
+				_update_navigation_controls_visibility();
+			}
+		} break;
+	}
+}
+
+void Node3DEditorViewport::_update_view_3d_controller(bool p_update_all) {
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_FOV_DECREASE, ED_GET_SHORTCUT("spatial_editor/decrease_fov"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_FOV_INCREASE, ED_GET_SHORTCUT("spatial_editor/increase_fov"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_FOV_RESET, ED_GET_SHORTCUT("spatial_editor/reset_fov"));
+
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_PAN_MOD_1, ED_GET_SHORTCUT("spatial_editor/viewport_pan_modifier_1"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_PAN_MOD_2, ED_GET_SHORTCUT("spatial_editor/viewport_pan_modifier_2"));
+
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_ORBIT_MOD_1, ED_GET_SHORTCUT("spatial_editor/viewport_orbit_modifier_1"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_ORBIT_MOD_2, ED_GET_SHORTCUT("spatial_editor/viewport_orbit_modifier_2"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_ORBIT_SNAP_MOD_1, ED_GET_SHORTCUT("spatial_editor/viewport_orbit_snap_modifier_1"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_ORBIT_SNAP_MOD_2, ED_GET_SHORTCUT("spatial_editor/viewport_orbit_snap_modifier_2"));
+
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_FREELOOK_FORWARD, ED_GET_SHORTCUT("spatial_editor/freelook_forward"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_FREELOOK_BACKWARDS, ED_GET_SHORTCUT("spatial_editor/freelook_backwards"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_FREELOOK_LEFT, ED_GET_SHORTCUT("spatial_editor/freelook_left"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_FREELOOK_RIGHT, ED_GET_SHORTCUT("spatial_editor/freelook_right"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_FREELOOK_UP, ED_GET_SHORTCUT("spatial_editor/freelook_up"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_FREELOOK_DOWN, ED_GET_SHORTCUT("spatial_editor/freelook_down"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_FREELOOK_SPEED_MOD, ED_GET_SHORTCUT("spatial_editor/freelook_speed_modifier"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_FREELOOK_SLOW_MOD, ED_GET_SHORTCUT("spatial_editor/freelook_slow_modifier"));
+
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_ZOOM_MOD_1, ED_GET_SHORTCUT("spatial_editor/viewport_zoom_modifier_1"));
+	view_3d_controller->set_shortcut(View3DController::SHORTCUT_ZOOM_MOD_2, ED_GET_SHORTCUT("spatial_editor/viewport_zoom_modifier_2"));
+
+	if (p_update_all || EditorSettings::get_singleton()->check_changed_settings_in_group("editors/3d")) {
+		view_3d_controller->set_pan_mouse_button((View3DController::NavigationMouseButton)EDITOR_GET("editors/3d/navigation/pan_mouse_button").operator int());
+
+		view_3d_controller->set_orbit_sensitivity(EDITOR_GET("editors/3d/navigation_feel/orbit_sensitivity"));
+		view_3d_controller->set_orbit_inertia(EDITOR_GET("editors/3d/navigation_feel/orbit_inertia"));
+		view_3d_controller->set_orbit_mouse_button((View3DController::NavigationMouseButton)EDITOR_GET("editors/3d/navigation/orbit_mouse_button").operator int());
+
+		view_3d_controller->set_zoom_style((View3DController::ZoomStyle)EDITOR_GET("editors/3d/navigation/zoom_style").operator int());
+		view_3d_controller->set_zoom_inertia(EDITOR_GET("editors/3d/navigation_feel/zoom_inertia"));
+		view_3d_controller->set_zoom_mouse_button((View3DController::NavigationMouseButton)EDITOR_GET("editors/3d/navigation/zoom_mouse_button").operator int());
+
+		view_3d_controller->set_freelook_scheme((View3DController::FreelookScheme)EDITOR_GET("editors/3d/freelook/freelook_navigation_scheme").operator int());
+		view_3d_controller->set_freelook_base_speed(EDITOR_GET("editors/3d/freelook/freelook_base_speed"));
+		view_3d_controller->set_freelook_sensitivity(EDITOR_GET("editors/3d/freelook/freelook_sensitivity"));
+		view_3d_controller->set_freelook_inertia(EDITOR_GET("editors/3d/freelook/freelook_inertia"));
+		view_3d_controller->set_freelook_speed_zoom_link(EDITOR_GET("editors/3d/freelook/freelook_speed_zoom_link"));
+		view_3d_controller->set_freelook_invert_y_axis(EDITOR_GET("editors/3d/freelook/freelook_invert_y_axis"));
+
+		view_3d_controller->set_translation_sensitivity(EDITOR_GET("editors/3d/navigation_feel/translation_sensitivity"));
+		view_3d_controller->set_translation_inertia(EDITOR_GET("editors/3d/navigation_feel/translation_inertia"));
+
+		view_3d_controller->set_angle_snap_threshold(EDITOR_GET("editors/3d/navigation_feel/angle_snap_threshold"));
+
+		view_3d_controller->set_emulate_3_button_mouse(EDITOR_GET("editors/3d/navigation/emulate_3_button_mouse"));
+		view_3d_controller->set_emulate_numpad(EDITOR_GET("editors/3d/navigation/emulate_numpad"));
+
+		view_3d_controller->set_invert_x_axis(EDITOR_GET("editors/3d/navigation/invert_x_axis"));
+		view_3d_controller->set_invert_y_axis(EDITOR_GET("editors/3d/navigation/invert_y_axis"));
+
+		view_3d_controller->set_warped_mouse_panning((View3DController::NavigationMouseButton)EDITOR_GET("editors/3d/navigation/warped_mouse_panning").operator int());
+	}
+}
+
+static void draw_indicator_bar(Control &p_surface, real_t p_fill, const Ref<Texture2D> p_icon, const Ref<Font> p_font, int p_font_size, const String &p_text, const Color &p_color) {
+	// Adjust bar size from control height
+	const Vector2 surface_size = p_surface.get_size();
+	const real_t h = surface_size.y / 2.0;
+	const real_t y = (surface_size.y - h) / 2.0;
+
+	const Rect2 r(10 * EDSCALE, y, 6 * EDSCALE, h);
+	const real_t sy = r.size.y * p_fill;
+
+	// Note: because this bar appears over the viewport, it has to stay readable for any background color
+	// Draw both neutral dark and bright colors to account this
+	p_surface.draw_rect(r, p_color * Color(1, 1, 1, 0.2));
+	p_surface.draw_rect(Rect2(r.position.x, r.position.y + r.size.y - sy, r.size.x, sy), p_color * Color(1, 1, 1, 0.6));
+	p_surface.draw_rect(r.grow(1), Color(0, 0, 0, 0.7), false, Math::round(EDSCALE));
+
+	const Vector2 icon_size = p_icon->get_size();
+	const Vector2 icon_pos = Vector2(r.position.x - (icon_size.x - r.size.x) / 2, r.position.y + r.size.y + 2 * EDSCALE);
+	p_surface.draw_texture(p_icon, icon_pos, p_color);
+
+	// Draw text below the bar (for speed/zoom information).
+	p_surface.draw_string_outline(p_font, Vector2(icon_pos.x, icon_pos.y + icon_size.y + 16 * EDSCALE), p_text, HORIZONTAL_ALIGNMENT_LEFT, -1.f, p_font_size, Math::round(4 * EDSCALE), Color(0, 0, 0));
+	p_surface.draw_string(p_font, Vector2(icon_pos.x, icon_pos.y + icon_size.y + 16 * EDSCALE), p_text, HORIZONTAL_ALIGNMENT_LEFT, -1.f, p_font_size, p_color);
+}
+
+void Node3DEditorViewport::_draw() {
+	EditorNode::get_singleton()->get_editor_plugins_over()->forward_3d_draw_over_viewport(surface);
+	EditorNode::get_singleton()->get_editor_plugins_force_over()->forward_3d_force_draw_over_viewport(surface);
+
+	if (surface->has_focus() || rotation_control->has_focus()) {
+		Size2 size = surface->get_size();
+		Rect2 r = Rect2(Point2(), size);
+		get_theme_stylebox(SNAME("FocusViewport"), EditorStringName(EditorStyles))->draw(surface->get_canvas_item(), r);
+	}
+
+	View3DController::Cursor cursor = view_3d_controller->cursor;
+
+	if (cursor.region_select && movement_threshold_passed) {
+		const Rect2 selection_rect = Rect2(cursor.region_begin, cursor.region_end - cursor.region_begin);
+
+		surface->draw_rect(
+				selection_rect,
+				get_theme_color(SNAME("box_selection_fill_color"), EditorStringName(Editor)));
+
+		surface->draw_rect(
+				selection_rect,
+				get_theme_color(SNAME("box_selection_stroke_color"), EditorStringName(Editor)),
+				false,
+				Math::round(EDSCALE));
+	}
+
+	RID ci = surface->get_canvas_item();
+
+	if (message_time > 0) {
+		Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
+		int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
+		Point2 msgpos = Point2(10 * EDSCALE, get_size().y - 14 * EDSCALE);
+		font->draw_string(ci, msgpos + Point2(1, 1), message, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color(0, 0, 0, 0.8));
+		font->draw_string(ci, msgpos + Point2(-1, -1), message, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color(0, 0, 0, 0.8));
+		font->draw_string(ci, msgpos, message, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color(1, 1, 1, 1));
+	}
+
+	if ((vertex_snap_mode || vertex_snap_dragging) && vertex_snap_has_source) {
+		const float circle_radius = 6.0f * EDSCALE;
+		const float outline_width = 2.0f * EDSCALE;
+		const float occluded_alpha = 0.30f;
+
+		Vector3 source_display = vertex_snap_source;
+		if (vertex_snap_dragging) {
+			for (const KeyValue<ObjectID, Vector3> &E : vertex_snap_original_positions) {
+				Node3D *node = ObjectDB::get_instance<Node3D>(E.key);
+				if (node) {
+					source_display = vertex_snap_source + (node->get_global_position() - E.value);
+					break;
+				}
+			}
+		}
+
+		if (!camera->is_position_behind(source_display)) {
+			Vector2 screen_pos = camera->unproject_position(source_display);
+			bool occluded = _is_vertex_occluded(source_display, screen_pos);
+			float alpha = occluded ? occluded_alpha : 1.0f;
+			surface->draw_circle(screen_pos, circle_radius + outline_width, Color(0, 0, 0, 0.6 * alpha), true, -1.0, true);
+			surface->draw_circle(screen_pos, circle_radius, Color(1, 1, 0, alpha), true, -1.0, true);
+		}
+
+		if (vertex_snap_dragging && vertex_snap_has_target && !camera->is_position_behind(vertex_snap_target)) {
+			Vector2 screen_pos = camera->unproject_position(vertex_snap_target);
+			bool occluded = _is_vertex_occluded(vertex_snap_target, screen_pos);
+			float alpha = occluded ? occluded_alpha : 1.0f;
+			surface->draw_circle(screen_pos, circle_radius + outline_width, Color(0, 0, 0, 0.6 * alpha), true, -1.0, true);
+			surface->draw_circle(screen_pos, circle_radius, Color(0, 1, 0, alpha), true, -1.0, true);
+		}
+	}
+
+	if (_edit.mode == TRANSFORM_ROTATE) {
+		Point2 center = point_to_screen(_edit.center);
+
+		Color handle_color;
+		switch (_edit.plane) {
+			case TRANSFORM_VIEW:
+				handle_color = get_theme_color(SNAME("axis_view_plane_color"), EditorStringName(Editor));
+				break;
+			case TRANSFORM_X_AXIS:
+				handle_color = get_theme_color(SNAME("axis_x_color"), EditorStringName(Editor));
+				break;
+			case TRANSFORM_Y_AXIS:
+				handle_color = get_theme_color(SNAME("axis_y_color"), EditorStringName(Editor));
+				break;
+			case TRANSFORM_Z_AXIS:
+				handle_color = get_theme_color(SNAME("axis_z_color"), EditorStringName(Editor));
+				break;
+			default:
+				handle_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+				break;
+		}
+
+		if (!_edit.is_trackball && _is_rotation_arc_visible() && !_edit.initial_click_vector.is_zero_approx()) {
+			Vector3 up = _edit.rotation_axis;
+			Vector3 right = _edit.initial_click_vector;
+
+			right = right - up * up.dot(right);
+			right.normalize();
+			Vector3 forward = up.cross(right);
+
+			real_t rotation_radius = (_edit.plane == TRANSFORM_VIEW) ? spatial_editor->gizmo_view_rotation_scale : GIZMO_CIRCLE_SIZE;
+
+			const int circle_segments = 64;
+			Vector<Point2> circle_points;
+			for (int i = 0; i <= circle_segments; i++) {
+				float angle = (float(i) / float(circle_segments)) * Math::TAU;
+				Vector3 point_3d = _edit.center + gizmo_scale * rotation_radius * (right * Math::cos(angle) + forward * Math::sin(angle));
+				Point2 point_2d = point_to_screen(point_3d);
+				circle_points.push_back(point_2d);
+			}
+
+			Color circle_color = handle_color.from_hsv(handle_color.get_h(), handle_color.get_s() * 0.6, 1.0, 0.8);
+			Vector<Color> circle_colors;
+			circle_colors.resize(circle_points.size());
+			circle_colors.fill(circle_color);
+			RenderingServer::get_singleton()->canvas_item_add_polyline(ci, circle_points, circle_colors, Math::round(2 * EDSCALE), true);
+
+			const int segments = 64;
+			float display_angle = _edit.rotation_angle;
+
+			float abs_angle = Math::abs(display_angle);
+			if (abs_angle > Math::TAU) {
+				float remainder = Math::fmod((double)abs_angle, Math::TAU);
+				remainder = remainder < 0.01 ? Math::TAU : remainder;
+				display_angle = SIGN(display_angle) * remainder;
+				abs_angle = remainder;
+			}
+
+			int num_segments = MAX(8, int(abs_angle / (Math::TAU / segments) * segments));
+			num_segments = MIN(num_segments, segments);
+
+			Color fill_color = Color(1.0, 1.0, 1.0, 0.2);
+
+			bool is_counterclockwise = display_angle > 0;
+			float start_angle = is_counterclockwise ? 0.0f : display_angle;
+			float end_angle = is_counterclockwise ? display_angle : 0.0f;
+
+			for (int i = 0; i < num_segments; i++) {
+				float t1 = float(i) / float(num_segments);
+				float t2 = float(i + 1) / float(num_segments);
+				float angle1 = Math::lerp(start_angle, end_angle, t1);
+				float angle2 = Math::lerp(start_angle, end_angle, t2);
+
+				Vector3 point1_3d = _edit.center + gizmo_scale * rotation_radius * (right * Math::cos(angle1) + forward * Math::sin(angle1));
+				Vector3 point2_3d = _edit.center + gizmo_scale * rotation_radius * (right * Math::cos(angle2) + forward * Math::sin(angle2));
+
+				Point2 point1_2d = point_to_screen(point1_3d);
+				Point2 point2_2d = point_to_screen(point2_3d);
+
+				Vector<Point2> triangle_points;
+				triangle_points.push_back(center);
+				triangle_points.push_back(point1_2d);
+				triangle_points.push_back(point2_2d);
+
+				Vector<Color> triangle_colors;
+				triangle_colors.push_back(fill_color);
+				triangle_colors.push_back(fill_color);
+				triangle_colors.push_back(fill_color);
+
+				RenderingServer::get_singleton()->canvas_item_add_polygon(ci, triangle_points, triangle_colors);
+			}
+
+			Color edge_color = handle_color.from_hsv(handle_color.get_h(), handle_color.get_s() * 0.8, 1.0, 0.7);
+
+			Vector3 start_point_3d = _edit.center + gizmo_scale * rotation_radius * right;
+			Point2 start_point_2d = point_to_screen(start_point_3d);
+			RenderingServer::get_singleton()->canvas_item_add_line(
+					ci,
+					center,
+					start_point_2d,
+					edge_color,
+					Math::round(2 * EDSCALE),
+					true);
+
+			Vector3 end_point_3d = _edit.center + gizmo_scale * rotation_radius * (right * Math::cos(display_angle) + forward * Math::sin(display_angle));
+			Point2 end_point_2d = point_to_screen(end_point_3d);
+			RenderingServer::get_singleton()->canvas_item_add_line(
+					ci,
+					center,
+					end_point_2d,
+					edge_color,
+					Math::round(2 * EDSCALE),
+					true);
+		}
+
+		if (_edit.show_rotation_line) {
+			handle_color = handle_color.from_hsv(handle_color.get_h(), handle_color.get_s() * 0.25, 1.0, handle_color.a);
+			RenderingServer::get_singleton()->canvas_item_add_line(
+					ci,
+					_edit.mouse_pos,
+					center,
+					handle_color,
+					Math::round(2 * EDSCALE));
+		}
+	}
+	if (previewing) {
+		Size2 ss = Size2(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height"));
+		float aspect = ss.aspect();
+		Size2 s = get_size();
+
+		Rect2 draw_rect;
+
+		switch (previewing->get_keep_aspect_mode()) {
+			case Camera3D::KEEP_WIDTH: {
+				draw_rect.size = Size2(s.width, s.width / aspect);
+				draw_rect.position.x = 0;
+				draw_rect.position.y = (s.height - draw_rect.size.y) * 0.5;
+
+			} break;
+			case Camera3D::KEEP_HEIGHT: {
+				draw_rect.size = Size2(s.height * aspect, s.height);
+				draw_rect.position.y = 0;
+				draw_rect.position.x = (s.width - draw_rect.size.x) * 0.5;
+
+			} break;
+		}
+
+		draw_rect = Rect2(Vector2(), s).intersection(draw_rect);
+
+		surface->draw_rect(draw_rect, Color(0.6, 0.6, 0.1, 0.5), false, Math::round(2 * EDSCALE));
+
+	} else {
+		if (zoom_indicator_delay > 0.0) {
+			if (view_3d_controller->is_freelook_enabled()) {
+				// Show speed.
+
+				real_t min_speed = MAX(camera->get_near() * 4, View3DControllerConsts::ZOOM_FREELOOK_MIN);
+				real_t max_speed = MIN(camera->get_far() / 4, View3DControllerConsts::ZOOM_FREELOOK_MAX);
+				real_t scale_length = (max_speed - min_speed);
+
+				if (!Math::is_zero_approx(scale_length)) {
+					float freelook_speed = view_3d_controller->get_freelook_speed();
+					real_t logscale_t = 1.0 - Math::log1p(freelook_speed - min_speed) / Math::log1p(scale_length);
+
+					// Display the freelook speed to help the user get a better sense of scale.
+					const int precision = freelook_speed < 1.0 ? 2 : 1;
+					draw_indicator_bar(
+							*surface,
+							1.0 - logscale_t,
+							get_editor_theme_icon(SNAME("ViewportSpeed")),
+							get_theme_font("bold", EditorStringName(EditorFonts)),
+							get_theme_font_size(SceneStringName(font_size), SNAME("Label")),
+							vformat("%s m/s", String::num(freelook_speed).pad_decimals(precision)),
+							Color(1.0, 0.95, 0.7));
+				}
+			} else {
+				// Show zoom
+				zoom_limit_label->set_visible(zoom_failed_attempts_count > 15);
+
+				real_t min_distance = MAX(camera->get_near() * 4, View3DControllerConsts::ZOOM_FREELOOK_MIN);
+				real_t max_distance = MIN(camera->get_far() / 4, View3DControllerConsts::ZOOM_FREELOOK_MAX);
+				real_t scale_length = (max_distance - min_distance);
+
+				if (!Math::is_zero_approx(scale_length)) {
+					real_t logscale_t = 1.0 - Math::log1p(cursor.distance - min_distance) / Math::log1p(scale_length);
+
+					// Display the zoom center distance to help the user get a better sense of scale.
+					const int precision = cursor.distance < 1.0 ? 2 : 1;
+					draw_indicator_bar(
+							*surface,
+							logscale_t,
+							get_editor_theme_icon(SNAME("ViewportZoom")),
+							get_theme_font("bold", EditorStringName(EditorFonts)),
+							get_theme_font_size(SceneStringName(font_size), SNAME("Label")),
+							vformat("%s m", String::num(cursor.distance).pad_decimals(precision)),
+							Color(0.7, 0.95, 1.0));
+				}
+			}
+		}
+	}
+}
+
+bool Node3DEditorViewport::_camera_moved_externally() {
+	if (previewing_camera && previewing) {
+		if (pilot_preview_enabled) {
+			Transform3D t = previewing->get_global_transform();
+			return !t.is_equal_approx(last_camera_transform);
+		}
+		return false;
+	}
+	Transform3D t = camera->get_global_transform();
+	return !t.is_equal_approx(last_camera_transform);
+}
+
+void Node3DEditorViewport::_apply_camera_transform_to_cursor() {
+	if (previewing_camera && previewing) {
+		if (pilot_preview_enabled) {
+			_sync_cursor_from_transform(previewing->get_global_transform());
+		}
+		return;
+	}
+	_sync_cursor_from_transform(camera->get_camera_transform());
+}
+
+void Node3DEditorViewport::_menu_option(int p_option) {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	switch (p_option) {
+		case VIEW_TOP: {
+			view_3d_controller->cursor.y_rot = 0;
+			view_3d_controller->cursor.x_rot = Math::PI / 2.0;
+			view_3d_controller->cursor.unsnapped_y_rot = view_3d_controller->cursor.y_rot;
+			view_3d_controller->cursor.unsnapped_x_rot = view_3d_controller->cursor.x_rot;
+			set_message(TTR("Top View."), 2);
+			view_3d_controller->set_view_type(View3DController::VIEW_TYPE_TOP);
+
+		} break;
+		case VIEW_BOTTOM: {
+			view_3d_controller->cursor.y_rot = 0;
+			view_3d_controller->cursor.x_rot = -Math::PI / 2.0;
+			view_3d_controller->cursor.unsnapped_y_rot = view_3d_controller->cursor.y_rot;
+			view_3d_controller->cursor.unsnapped_x_rot = view_3d_controller->cursor.x_rot;
+			set_message(TTR("Bottom View."), 2);
+			view_3d_controller->set_view_type(View3DController::VIEW_TYPE_BOTTOM);
+
+		} break;
+		case VIEW_LEFT: {
+			view_3d_controller->cursor.x_rot = 0;
+			view_3d_controller->cursor.y_rot = Math::PI / 2.0;
+			view_3d_controller->cursor.unsnapped_x_rot = view_3d_controller->cursor.x_rot;
+			view_3d_controller->cursor.unsnapped_y_rot = view_3d_controller->cursor.y_rot;
+			set_message(TTR("Left View."), 2);
+			view_3d_controller->set_view_type(View3DController::VIEW_TYPE_LEFT);
+
+		} break;
+		case VIEW_RIGHT: {
+			view_3d_controller->cursor.x_rot = 0;
+			view_3d_controller->cursor.y_rot = -Math::PI / 2.0;
+			view_3d_controller->cursor.unsnapped_x_rot = view_3d_controller->cursor.x_rot;
+			view_3d_controller->cursor.unsnapped_y_rot = view_3d_controller->cursor.y_rot;
+			set_message(TTR("Right View."), 2);
+			view_3d_controller->set_view_type(View3DController::VIEW_TYPE_RIGHT);
+
+		} break;
+		case VIEW_FRONT: {
+			view_3d_controller->cursor.x_rot = 0;
+			view_3d_controller->cursor.y_rot = 0;
+			view_3d_controller->cursor.unsnapped_x_rot = view_3d_controller->cursor.x_rot;
+			view_3d_controller->cursor.unsnapped_y_rot = view_3d_controller->cursor.y_rot;
+			set_message(TTR("Front View."), 2);
+			view_3d_controller->set_view_type(View3DController::VIEW_TYPE_FRONT);
+
+		} break;
+		case VIEW_REAR: {
+			view_3d_controller->cursor.x_rot = 0;
+			view_3d_controller->cursor.y_rot = Math::PI;
+			view_3d_controller->cursor.unsnapped_x_rot = view_3d_controller->cursor.x_rot;
+			view_3d_controller->cursor.unsnapped_y_rot = view_3d_controller->cursor.y_rot;
+			set_message(TTR("Rear View."), 2);
+			view_3d_controller->set_view_type(View3DController::VIEW_TYPE_REAR);
+
+		} break;
+		case VIEW_CENTER_TO_ORIGIN: {
+			view_3d_controller->cursor.pos = Vector3(0, 0, 0);
+			_disable_follow_mode();
+
+		} break;
+		case VIEW_CENTER_TO_SELECTION: {
+			focus_selection();
+
+		} break;
+		case VIEW_ALIGN_TRANSFORM_WITH_VIEW: {
+			if (!get_selected_count()) {
+				break;
+			}
+
+			Transform3D camera_transform = camera->get_global_transform();
+
+			const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+
+			undo_redo->create_action(TTR("Align Transform with View"));
+			for (Node *E : selection) {
+				Node3D *sp = Object::cast_to<Node3D>(E);
+				if (!sp) {
+					continue;
+				}
+
+				Node3DEditorSelectedItem *se = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(sp);
+				if (!se) {
+					continue;
+				}
+
+				Transform3D xform = camera_transform;
+				if (view_3d_controller->is_orthogonal()) {
+					Vector3 offset = camera_transform.basis.xform(Vector3(0, 0, view_3d_controller->cursor.distance));
+					xform.origin = view_3d_controller->cursor.pos + offset;
+				} else {
+					xform.scale_basis(sp->get_scale());
+				}
+
+				if (Object::cast_to<Decal>(E)) {
+					// Adjust rotation to match Decal's default orientation.
+					// This makes the decal "look" in the same direction as the camera,
+					// rather than pointing down relative to the camera orientation.
+					xform.basis.rotate_local(Vector3(1, 0, 0), Math::TAU * 0.25);
+				}
+
+				Node3D *parent = sp->get_parent_node_3d();
+				Transform3D local_xform = parent ? parent->get_global_transform().affine_inverse() * xform : xform;
+				undo_redo->add_do_method(sp, "set_transform", local_xform);
+				undo_redo->add_undo_method(sp, "set_transform", sp->get_local_gizmo_transform());
+			}
+			undo_redo->commit_action();
+
+		} break;
+		case VIEW_ALIGN_ROTATION_WITH_VIEW: {
+			if (!get_selected_count()) {
+				break;
+			}
+
+			Transform3D camera_transform = camera->get_global_transform();
+
+			const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+
+			undo_redo->create_action(TTR("Align Rotation with View"));
+			for (Node *E : selection) {
+				Node3D *sp = Object::cast_to<Node3D>(E);
+				if (!sp) {
+					continue;
+				}
+
+				Node3DEditorSelectedItem *se = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(sp);
+				if (!se) {
+					continue;
+				}
+
+				Basis basis = camera_transform.basis;
+
+				if (Object::cast_to<Decal>(E)) {
+					// Adjust rotation to match Decal's default orientation.
+					// This makes the decal "look" in the same direction as the camera,
+					// rather than pointing down relative to the camera orientation.
+					basis.rotate_local(Vector3(1, 0, 0), Math::TAU * 0.25);
+				}
+
+				undo_redo->add_do_method(sp, "set_rotation", basis.get_euler_normalized());
+				undo_redo->add_undo_method(sp, "set_rotation", sp->get_rotation());
+			}
+			undo_redo->commit_action();
+
+		} break;
+		case VIEW_ENVIRONMENT: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_ENVIRONMENT);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			current = !current;
+			if (current) {
+				camera->set_environment(Ref<Resource>());
+			} else {
+				camera->set_environment(Node3DEditor::get_singleton()->get_viewport_environment());
+			}
+
+			view_display_menu->get_popup()->set_item_checked(idx, current);
+
+		} break;
+		case VIEW_PERSPECTIVE: {
+			view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_PERSPECTIVE), true);
+			view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_ORTHOGONAL), false);
+			view_3d_controller->set_orthogonal(false);
+			callable_mp(this, &Node3DEditorViewport::update_transform_gizmo_view).call_deferred();
+			view_3d_controller->update_camera();
+			_update_name();
+
+		} break;
+		case VIEW_ORTHOGONAL: {
+			view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_PERSPECTIVE), false);
+			view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_ORTHOGONAL), true);
+			view_3d_controller->set_orthogonal(true);
+			callable_mp(this, &Node3DEditorViewport::update_transform_gizmo_view).call_deferred();
+			view_3d_controller->update_camera();
+			_update_name();
+		} break;
+		case VIEW_SWITCH_PERSPECTIVE_ORTHOGONAL: {
+			_menu_option(view_3d_controller->is_orthogonal() ? VIEW_PERSPECTIVE : VIEW_ORTHOGONAL);
+
+		} break;
+		case VIEW_AUTO_ORTHOGONAL: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_AUTO_ORTHOGONAL);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			current = !current;
+			view_display_menu->get_popup()->set_item_checked(idx, current);
+			view_3d_controller->set_auto_orthogonal_allowed(current);
+			_update_name();
+		} break;
+		case VIEW_LOCK_ROTATION: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_LOCK_ROTATION);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			_set_lock_view_rotation(!current);
+
+		} break;
+		case VIEW_AUDIO_LISTENER: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_AUDIO_LISTENER);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			current = !current;
+			viewport->set_as_audio_listener_3d(current);
+			view_display_menu->get_popup()->set_item_checked(idx, current);
+
+		} break;
+		case VIEW_AUDIO_DOPPLER: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_AUDIO_DOPPLER);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			current = !current;
+			camera->set_doppler_tracking(current ? Camera3D::DOPPLER_TRACKING_IDLE_STEP : Camera3D::DOPPLER_TRACKING_DISABLED);
+			view_display_menu->get_popup()->set_item_checked(idx, current);
+
+		} break;
+		case VIEW_CINEMATIC_PREVIEW: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_CINEMATIC_PREVIEW);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			current = !current;
+			view_display_menu->get_popup()->set_item_checked(idx, current);
+			_toggle_cinema_preview(current);
+
+			cinema_label->set_visible(current);
+			_update_centered_labels();
+			surface->queue_redraw();
+
+			if (current) {
+				preview_camera->hide();
+			} else {
+				if (previewing != nullptr) {
+					preview_camera->show();
+				}
+			}
+		} break;
+		case VIEW_GIZMOS: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_GIZMOS);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			current = !current;
+			uint32_t layers = camera->get_cull_mask();
+			layers &= ~(1 << GIZMO_EDIT_LAYER);
+			if (current) {
+				layers |= (1 << GIZMO_EDIT_LAYER);
+			}
+			camera->set_cull_mask(layers);
+			view_display_menu->get_popup()->set_item_checked(idx, current);
+
+		} break;
+		case VIEW_TRANSFORM_GIZMO: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_TRANSFORM_GIZMO);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			current = !current;
+			transform_gizmo_visible = current;
+
+			spatial_editor->update_transform_gizmo();
+			view_display_menu->get_popup()->set_item_checked(idx, current);
+		} break;
+		case VIEW_HALF_RESOLUTION: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_HALF_RESOLUTION);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			view_display_menu->get_popup()->set_item_checked(idx, !current);
+			_update_shrink();
+		} break;
+		case VIEW_INFORMATION: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_INFORMATION);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			view_display_menu->get_popup()->set_item_checked(idx, !current);
+
+		} break;
+		case VIEW_FRAME_TIME: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_FRAME_TIME);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			view_display_menu->get_popup()->set_item_checked(idx, !current);
+		} break;
+		case VIEW_GRID: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_GRID);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			current = !current;
+			uint32_t layers = camera->get_cull_mask();
+			layers &= ~(1 << GIZMO_GRID_LAYER);
+			if (current) {
+				layers |= (1 << GIZMO_GRID_LAYER);
+			}
+			camera->set_cull_mask(layers);
+			view_display_menu->get_popup()->set_item_checked(idx, current);
+		} break;
+		case VIEW_DISPLAY_NORMAL:
+		case VIEW_DISPLAY_WIREFRAME:
+		case VIEW_DISPLAY_OVERDRAW:
+		case VIEW_DISPLAY_UNSHADED:
+		case VIEW_DISPLAY_LIGHTING:
+		case VIEW_DISPLAY_NORMAL_BUFFER:
+		case VIEW_DISPLAY_DEBUG_SHADOW_ATLAS:
+		case VIEW_DISPLAY_DEBUG_DIRECTIONAL_SHADOW_ATLAS:
+		case VIEW_DISPLAY_DEBUG_VOXEL_GI_ALBEDO:
+		case VIEW_DISPLAY_DEBUG_VOXEL_GI_LIGHTING:
+		case VIEW_DISPLAY_DEBUG_VOXEL_GI_EMISSION:
+		case VIEW_DISPLAY_DEBUG_SCENE_LUMINANCE:
+		case VIEW_DISPLAY_DEBUG_SSAO:
+		case VIEW_DISPLAY_DEBUG_SSIL:
+		case VIEW_DISPLAY_DEBUG_PSSM_SPLITS:
+		case VIEW_DISPLAY_DEBUG_DECAL_ATLAS:
+		case VIEW_DISPLAY_DEBUG_AREA_LIGHT_ATLAS:
+		case VIEW_DISPLAY_DEBUG_SDFGI:
+		case VIEW_DISPLAY_DEBUG_SDFGI_PROBES:
+		case VIEW_DISPLAY_DEBUG_GI_BUFFER:
+		case VIEW_DISPLAY_DEBUG_DISABLE_LOD:
+		case VIEW_DISPLAY_DEBUG_CLUSTER_OMNI_LIGHTS:
+		case VIEW_DISPLAY_DEBUG_CLUSTER_SPOT_LIGHTS:
+		case VIEW_DISPLAY_DEBUG_CLUSTER_AREA_LIGHTS:
+		case VIEW_DISPLAY_DEBUG_CLUSTER_DECALS:
+		case VIEW_DISPLAY_DEBUG_CLUSTER_REFLECTION_PROBES:
+		case VIEW_DISPLAY_DEBUG_OCCLUDERS:
+		case VIEW_DISPLAY_MOTION_VECTORS:
+		case VIEW_DISPLAY_INTERNAL_BUFFER: {
+			static const int display_options[] = {
+				VIEW_DISPLAY_NORMAL,
+				VIEW_DISPLAY_WIREFRAME,
+				VIEW_DISPLAY_OVERDRAW,
+				VIEW_DISPLAY_UNSHADED,
+				VIEW_DISPLAY_LIGHTING,
+				VIEW_DISPLAY_NORMAL_BUFFER,
+				VIEW_DISPLAY_DEBUG_SHADOW_ATLAS,
+				VIEW_DISPLAY_DEBUG_DIRECTIONAL_SHADOW_ATLAS,
+				VIEW_DISPLAY_DEBUG_VOXEL_GI_ALBEDO,
+				VIEW_DISPLAY_DEBUG_VOXEL_GI_LIGHTING,
+				VIEW_DISPLAY_DEBUG_VOXEL_GI_EMISSION,
+				VIEW_DISPLAY_DEBUG_SCENE_LUMINANCE,
+				VIEW_DISPLAY_DEBUG_SSAO,
+				VIEW_DISPLAY_DEBUG_SSIL,
+				VIEW_DISPLAY_DEBUG_GI_BUFFER,
+				VIEW_DISPLAY_DEBUG_DISABLE_LOD,
+				VIEW_DISPLAY_DEBUG_PSSM_SPLITS,
+				VIEW_DISPLAY_DEBUG_DECAL_ATLAS,
+				VIEW_DISPLAY_DEBUG_AREA_LIGHT_ATLAS,
+				VIEW_DISPLAY_DEBUG_SDFGI,
+				VIEW_DISPLAY_DEBUG_SDFGI_PROBES,
+				VIEW_DISPLAY_DEBUG_CLUSTER_OMNI_LIGHTS,
+				VIEW_DISPLAY_DEBUG_CLUSTER_SPOT_LIGHTS,
+				VIEW_DISPLAY_DEBUG_CLUSTER_AREA_LIGHTS,
+				VIEW_DISPLAY_DEBUG_CLUSTER_DECALS,
+				VIEW_DISPLAY_DEBUG_CLUSTER_REFLECTION_PROBES,
+				VIEW_DISPLAY_DEBUG_OCCLUDERS,
+				VIEW_DISPLAY_MOTION_VECTORS,
+				VIEW_DISPLAY_INTERNAL_BUFFER,
+				VIEW_MAX
+			};
+			static const Viewport::DebugDraw debug_draw_modes[] = {
+				Viewport::DEBUG_DRAW_DISABLED,
+				Viewport::DEBUG_DRAW_WIREFRAME,
+				Viewport::DEBUG_DRAW_OVERDRAW,
+				Viewport::DEBUG_DRAW_UNSHADED,
+				Viewport::DEBUG_DRAW_LIGHTING,
+				Viewport::DEBUG_DRAW_NORMAL_BUFFER,
+				Viewport::DEBUG_DRAW_SHADOW_ATLAS,
+				Viewport::DEBUG_DRAW_DIRECTIONAL_SHADOW_ATLAS,
+				Viewport::DEBUG_DRAW_VOXEL_GI_ALBEDO,
+				Viewport::DEBUG_DRAW_VOXEL_GI_LIGHTING,
+				Viewport::DEBUG_DRAW_VOXEL_GI_EMISSION,
+				Viewport::DEBUG_DRAW_SCENE_LUMINANCE,
+				Viewport::DEBUG_DRAW_SSAO,
+				Viewport::DEBUG_DRAW_SSIL,
+				Viewport::DEBUG_DRAW_GI_BUFFER,
+				Viewport::DEBUG_DRAW_DISABLE_LOD,
+				Viewport::DEBUG_DRAW_PSSM_SPLITS,
+				Viewport::DEBUG_DRAW_DECAL_ATLAS,
+				Viewport::DEBUG_DRAW_AREA_LIGHT_ATLAS,
+				Viewport::DEBUG_DRAW_SDFGI,
+				Viewport::DEBUG_DRAW_SDFGI_PROBES,
+				Viewport::DEBUG_DRAW_CLUSTER_OMNI_LIGHTS,
+				Viewport::DEBUG_DRAW_CLUSTER_SPOT_LIGHTS,
+				Viewport::DEBUG_DRAW_CLUSTER_AREA_LIGHTS,
+				Viewport::DEBUG_DRAW_CLUSTER_DECALS,
+				Viewport::DEBUG_DRAW_CLUSTER_REFLECTION_PROBES,
+				Viewport::DEBUG_DRAW_OCCLUDERS,
+				Viewport::DEBUG_DRAW_MOTION_VECTORS,
+				Viewport::DEBUG_DRAW_INTERNAL_BUFFER,
+			};
+
+			for (int idx = 0; display_options[idx] != VIEW_MAX; idx++) {
+				int id = display_options[idx];
+				int item_idx = view_display_menu->get_popup()->get_item_index(id);
+				if (item_idx != -1) {
+					view_display_menu->get_popup()->set_item_checked(item_idx, id == p_option);
+				}
+				item_idx = display_submenu->get_item_index(id);
+				if (item_idx != -1) {
+					display_submenu->set_item_checked(item_idx, id == p_option);
+				}
+
+				if (id == p_option) {
+					viewport->set_debug_draw(debug_draw_modes[idx]);
+				}
+			}
+		} break;
+	}
+}
+
+void Node3DEditorViewport::_preview_exited_scene() {
+	preview_camera->disconnect(SceneStringName(toggled), callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+	preview_camera->set_pressed(false);
+	_toggle_camera_preview(false);
+	preview_camera->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+	view_display_menu->show();
+}
+
+void Node3DEditorViewport::_preview_camera_property_changed() {
+	if (previewing) {
+		surface->queue_redraw();
+	}
+}
+
+void Node3DEditorViewport::_sync_cursor_from_transform(const Transform3D &p_transform) {
+	const Basis basis = p_transform.basis;
+
+	view_3d_controller->cursor.eye_pos = p_transform.origin;
+	view_3d_controller->cursor.x_rot = -basis.get_euler().x;
+	view_3d_controller->cursor.y_rot = -basis.get_euler().y;
+	view_3d_controller->cursor.unsnapped_x_rot = view_3d_controller->cursor.x_rot;
+	view_3d_controller->cursor.unsnapped_y_rot = view_3d_controller->cursor.y_rot;
+
+	real_t distance = view_3d_controller->cursor.distance;
+	if (view_3d_controller->is_orthogonal()) {
+		distance = (get_zfar() - get_znear()) / 2.0;
+	}
+	view_3d_controller->cursor.pos = p_transform.origin - basis.get_column(2) * distance;
+}
+
+void Node3DEditorViewport::_update_centered_labels() {
+	if (cinema_label->is_visible()) {
+		cinema_label->reset_size();
+		float cinema_half_width = cinema_label->get_size().width / 2.0f;
+		cinema_label->set_anchor_and_offset(SIDE_LEFT, 0.5f, -cinema_half_width);
+	}
+
+	if (locked_label->is_visible()) {
+		locked_label->reset_size();
+		float locked_half_width = locked_label->get_size().width / 2.0f;
+		locked_label->set_anchor_and_offset(SIDE_LEFT, 0.5f, -locked_half_width);
+	}
+}
+
+void Node3DEditorViewport::_init_gizmo_instance(int p_idx) {
+	uint32_t layer = 1 << (GIZMO_BASE_LAYER + p_idx);
+
+	for (int i = 0; i < 3; i++) {
+		move_gizmo_instance[i] = RS::get_singleton()->instance_create();
+		RS::get_singleton()->instance_set_base(move_gizmo_instance[i], spatial_editor->get_move_gizmo(i)->get_rid());
+		RS::get_singleton()->instance_set_scenario(move_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
+		RS::get_singleton()->instance_set_visible(move_gizmo_instance[i], false);
+		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(move_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
+		RS::get_singleton()->instance_set_layer_mask(move_gizmo_instance[i], layer);
+		RS::get_singleton()->instance_geometry_set_flag(move_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		RS::get_singleton()->instance_geometry_set_flag(move_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+
+		move_plane_gizmo_instance[i] = RS::get_singleton()->instance_create();
+		RS::get_singleton()->instance_set_base(move_plane_gizmo_instance[i], spatial_editor->get_move_plane_gizmo(i)->get_rid());
+		RS::get_singleton()->instance_set_scenario(move_plane_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
+		RS::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], false);
+		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(move_plane_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
+		RS::get_singleton()->instance_set_layer_mask(move_plane_gizmo_instance[i], layer);
+		RS::get_singleton()->instance_geometry_set_flag(move_plane_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		RS::get_singleton()->instance_geometry_set_flag(move_plane_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+
+		scale_gizmo_instance[i] = RS::get_singleton()->instance_create();
+		RS::get_singleton()->instance_set_base(scale_gizmo_instance[i], spatial_editor->get_scale_gizmo(i)->get_rid());
+		RS::get_singleton()->instance_set_scenario(scale_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
+		RS::get_singleton()->instance_set_visible(scale_gizmo_instance[i], false);
+		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(scale_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
+		RS::get_singleton()->instance_set_layer_mask(scale_gizmo_instance[i], layer);
+		RS::get_singleton()->instance_geometry_set_flag(scale_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		RS::get_singleton()->instance_geometry_set_flag(scale_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+
+		scale_plane_gizmo_instance[i] = RS::get_singleton()->instance_create();
+		RS::get_singleton()->instance_set_base(scale_plane_gizmo_instance[i], spatial_editor->get_scale_plane_gizmo(i)->get_rid());
+		RS::get_singleton()->instance_set_scenario(scale_plane_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
+		RS::get_singleton()->instance_set_visible(scale_plane_gizmo_instance[i], false);
+		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(scale_plane_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
+		RS::get_singleton()->instance_set_layer_mask(scale_plane_gizmo_instance[i], layer);
+		RS::get_singleton()->instance_geometry_set_flag(scale_plane_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		RS::get_singleton()->instance_geometry_set_flag(scale_plane_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+
+		axis_gizmo_instance[i] = RS::get_singleton()->instance_create();
+	}
+
+	for (int i = 0; i < 3; i++) {
+		RS::get_singleton()->instance_set_base(axis_gizmo_instance[i], spatial_editor->get_axis_gizmo(i)->get_rid());
+		RS::get_singleton()->instance_set_scenario(axis_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
+		RS::get_singleton()->instance_set_visible(axis_gizmo_instance[i], true);
+		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(axis_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
+		RS::get_singleton()->instance_set_layer_mask(axis_gizmo_instance[i], layer);
+		RS::get_singleton()->instance_geometry_set_flag(axis_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		RS::get_singleton()->instance_geometry_set_flag(axis_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+	}
+
+	for (int i = 0; i < 4; i++) {
+		rotate_gizmo_instance[i] = RS::get_singleton()->instance_create();
+		RS::get_singleton()->instance_set_base(rotate_gizmo_instance[i], spatial_editor->get_rotate_gizmo(i)->get_rid());
+		RS::get_singleton()->instance_set_scenario(rotate_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
+		RS::get_singleton()->instance_set_visible(rotate_gizmo_instance[i], false);
+		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(rotate_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
+		RS::get_singleton()->instance_set_layer_mask(rotate_gizmo_instance[i], layer);
+		RS::get_singleton()->instance_geometry_set_flag(rotate_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		RS::get_singleton()->instance_geometry_set_flag(rotate_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+	}
+
+	// Create trackball sphere instance
+	trackball_sphere_instance = RS::get_singleton()->instance_create();
+	RS::get_singleton()->instance_set_base(trackball_sphere_instance, spatial_editor->get_trackball_sphere_gizmo()->get_rid());
+	RS::get_singleton()->instance_set_scenario(trackball_sphere_instance, get_tree()->get_root()->get_world_3d()->get_scenario());
+	RS::get_singleton()->instance_set_visible(trackball_sphere_instance, false);
+	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(trackball_sphere_instance, RSE::SHADOW_CASTING_SETTING_OFF);
+	RS::get_singleton()->instance_set_layer_mask(trackball_sphere_instance, layer);
+	RS::get_singleton()->instance_geometry_set_flag(trackball_sphere_instance, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+	RS::get_singleton()->instance_geometry_set_flag(trackball_sphere_instance, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+}
+
+void Node3DEditorViewport::_finish_gizmo_instances() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	for (int i = 0; i < 3; i++) {
+		RS::get_singleton()->free_rid(move_gizmo_instance[i]);
+		RS::get_singleton()->free_rid(move_plane_gizmo_instance[i]);
+		RS::get_singleton()->free_rid(rotate_gizmo_instance[i]);
+		RS::get_singleton()->free_rid(scale_gizmo_instance[i]);
+		RS::get_singleton()->free_rid(scale_plane_gizmo_instance[i]);
+		RS::get_singleton()->free_rid(axis_gizmo_instance[i]);
+	}
+	// Rotation white outline
+	RS::get_singleton()->free_rid(rotate_gizmo_instance[3]);
+
+	RS::get_singleton()->free_rid(trackball_sphere_instance);
+}
+
+void Node3DEditorViewport::_disable_follow_mode() {
+	// Exit follow mode by resetting the number of times the follow shortcut was used consecutively.
+	times_focused_consecutively = 0;
+}
+
+void Node3DEditorViewport::_reset_follow_mode_count() {
+	bool is_in_follow_mode = times_focused_consecutively >= 2 && times_focused_consecutively % 2 == 0;
+	if (!is_in_follow_mode) {
+		times_focused_consecutively = 0;
+	}
+}
+
+void Node3DEditorViewport::_toggle_camera_preview(bool p_activate) {
+	ERR_FAIL_COND(p_activate && !preview);
+	ERR_FAIL_COND(!p_activate && !previewing);
+
+	emit_signal(SNAME("clicked"));
+	previewing_camera = p_activate;
+	_update_navigation_controls_visibility();
+
+	if (!p_activate) {
+		previewing->disconnect(SceneStringName(tree_exiting), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
+		previewing->disconnect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
+		previewing = nullptr;
+		RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), camera->get_camera()); //restore
+		if (!preview) {
+			preview_camera->hide();
+		}
+		pilot_camera->hide();
+		pilot_preview_enabled = false;
+		pilot_camera->set_pressed(false);
+
+		_apply_camera_transform_to_cursor();
+		view_3d_controller->update_camera(0);
+		last_camera_transform = camera->get_global_transform();
+
+		surface->queue_redraw();
+
+	} else {
+		previewing = preview;
+		previewing->connect(SceneStringName(tree_exiting), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
+		previewing->connect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
+		RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), preview->get_camera()); //replace
+
+		_sync_cursor_from_transform(preview->get_global_transform());
+		view_3d_controller->update_camera(0);
+
+		pilot_camera->show();
+
+		if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
+			pilot_camera->set_pressed(true);
+		}
+
+		surface->queue_redraw();
+	}
+}
+
+void Node3DEditorViewport::_toggle_pilot_preview(bool p_activate) {
+	pilot_preview_enabled = p_activate;
+	if (p_activate && previewing) {
+		_sync_cursor_from_transform(previewing->get_global_transform());
+		view_3d_controller->update_camera(0);
+	}
+}
+
+void Node3DEditorViewport::_toggle_cinema_preview(bool p_activate) {
+	previewing_cinema = p_activate;
+	_update_navigation_controls_visibility();
+
+	if (!previewing_cinema) {
+		if (previewing != nullptr) {
+			previewing->disconnect(SceneStringName(tree_exited), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
+			previewing->disconnect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
+		}
+
+		previewing = nullptr;
+		RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), camera->get_camera()); //restore
+		preview_camera->set_pressed(false);
+		if (!preview) {
+			preview_camera->hide();
+		} else {
+			preview_camera->show();
+		}
+		view_display_menu->show();
+		surface->queue_redraw();
+	}
+}
+
+void Node3DEditorViewport::_selection_result_pressed(int p_result) {
+	if (selection_results_menu.size() <= p_result) {
+		return;
+	}
+
+	clicked = selection_results_menu[p_result]->get_instance_id();
+
+	if (clicked.is_valid()) {
+		_select_clicked(true);
+	}
+
+	selection_results_menu.clear();
+}
+
+void Node3DEditorViewport::_selection_menu_hide() {
+	selection_results.clear();
+	selection_menu->clear();
+	selection_menu->reset_size();
+}
+
+void Node3DEditorViewport::set_can_preview(Camera3D *p_preview) {
+	preview = p_preview;
+
+	if (!preview_camera->is_pressed() && !previewing_cinema) {
+		preview_camera->set_visible(p_preview);
+	}
+}
+
+void Node3DEditorViewport::switch_preview_camera(Camera3D *p_new_camera) {
+	if (!previewing_camera || !previewing || !p_new_camera || p_new_camera == previewing) {
+		return;
+	}
+
+	previewing->disconnect(SceneStringName(tree_exiting), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
+	previewing->disconnect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
+
+	previewing = p_new_camera;
+	previewing->connect(SceneStringName(tree_exiting), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
+	previewing->connect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
+	RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), p_new_camera->get_camera());
+
+	_sync_cursor_from_transform(p_new_camera->get_global_transform());
+	view_3d_controller->update_camera(0);
+
+	surface->queue_redraw();
+}
+
+void Node3DEditorViewport::update_transform_gizmo_view() {
+	if (!is_visible_in_tree()) {
+		return;
+	}
+
+	Transform3D xform = spatial_editor->get_gizmo_transform();
+
+	Transform3D camera_xform = camera->get_transform();
+
+	if (xform.origin.is_equal_approx(camera_xform.origin)) {
+		for (int i = 0; i < 3; i++) {
+			RenderingServer::get_singleton()->instance_set_visible(move_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(scale_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(scale_plane_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(axis_gizmo_instance[i], false);
+		}
+		RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[3], false);
+		return;
+	}
+
+	const Vector3 camz = -camera_xform.get_basis().get_column(2).normalized();
+	const Vector3 camy = -camera_xform.get_basis().get_column(1).normalized();
+	const Plane p = Plane(camz, camera_xform.origin);
+	const real_t gizmo_d = MAX(Math::abs(p.distance_to(xform.origin)), CMP_EPSILON);
+	const real_t d0 = camera->unproject_position(camera_xform.origin + camz * gizmo_d).y;
+	const real_t d1 = camera->unproject_position(camera_xform.origin + camz * gizmo_d + camy).y;
+	const real_t dd = MAX(Math::abs(d0 - d1), CMP_EPSILON);
+
+	const real_t gizmo_size = EDITOR_GET("editors/3d/manipulator_gizmo_size");
+	// At low viewport heights, multiply the gizmo scale based on the viewport height.
+	// This prevents the gizmo from growing very large and going outside the viewport.
+	const int viewport_base_height = 400 * MAX(1, EDSCALE);
+	gizmo_scale =
+			(gizmo_size / Math::abs(dd)) * MAX(1, EDSCALE) *
+			MIN(viewport_base_height, subviewport_container->get_size().height) / viewport_base_height;
+	Vector3 scale = Vector3(1, 1, 1) * gizmo_scale;
+
+	// If the determinant is zero, we should disable the gizmo from being rendered,
+	// this prevents supplying bad values to the renderer and then having to filter it out again.
+	if (xform.basis.determinant() == 0) {
+		for (int i = 0; i < 3; i++) {
+			RenderingServer::get_singleton()->instance_set_visible(move_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(scale_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(scale_plane_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(axis_gizmo_instance[i], false);
+		}
+		RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[3], false);
+		return;
+	}
+
+	bool local_coords = spatial_editor->are_local_coords_enabled();
+	bool arc_visible = _is_rotation_arc_visible();
+	int show_gizmo_flags = EDITOR_GET("editors/3d/show_gizmo_during_rotation");
+
+	bool keep_gizmo_visible = arc_visible && ((local_coords && (show_gizmo_flags & Node3DEditor::TRANSFORM_MODE_LOCAL)) || (!local_coords && (show_gizmo_flags & Node3DEditor::TRANSFORM_MODE_GLOBAL)));
+	bool hide_gizmo_during_rotation = arc_visible && !keep_gizmo_visible;
+	bool hide_gizmo_during_trackball = (_edit.mode == TRANSFORM_ROTATE && _edit.is_trackball);
+
+	int arc_replaces_ring = -1;
+	if (keep_gizmo_visible) {
+		switch (_edit.plane) {
+			case TRANSFORM_X_AXIS:
+				arc_replaces_ring = 0;
+				break;
+			case TRANSFORM_Y_AXIS:
+				arc_replaces_ring = 1;
+				break;
+			case TRANSFORM_Z_AXIS:
+				arc_replaces_ring = 2;
+				break;
+			case TRANSFORM_VIEW:
+				arc_replaces_ring = 3;
+				break;
+			default:
+				break;
+		}
+	}
+
+	bool show_gizmo = spatial_editor->is_gizmo_visible() && !_edit.instant && transform_gizmo_visible && !collision_reposition && !hide_gizmo_during_rotation && !hide_gizmo_during_trackball;
+	bool show_rotate_gizmo = show_gizmo && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE);
+
+	for (int i = 0; i < 3; i++) {
+		Transform3D axis_angle;
+		if (xform.basis.get_column(i).normalized().dot(xform.basis.get_column((i + 1) % 3).normalized()) < 1.0) {
+			axis_angle = axis_angle.looking_at(xform.basis.get_column(i).normalized(), xform.basis.get_column((i + 1) % 3).normalized());
+		}
+		axis_angle.basis.scale(scale);
+		axis_angle.origin = xform.origin;
+		RenderingServer::get_singleton()->instance_set_transform(move_gizmo_instance[i], axis_angle);
+		RenderingServer::get_singleton()->instance_set_visible(move_gizmo_instance[i], show_gizmo && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE));
+		RenderingServer::get_singleton()->instance_set_transform(move_plane_gizmo_instance[i], axis_angle);
+		RenderingServer::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], show_gizmo && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE));
+		RenderingServer::get_singleton()->instance_set_transform(rotate_gizmo_instance[i], axis_angle);
+		RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[i], show_rotate_gizmo && i != arc_replaces_ring);
+		RenderingServer::get_singleton()->instance_set_transform(scale_gizmo_instance[i], axis_angle);
+		RenderingServer::get_singleton()->instance_set_visible(scale_gizmo_instance[i], show_gizmo && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE));
+		RenderingServer::get_singleton()->instance_set_transform(scale_plane_gizmo_instance[i], axis_angle);
+		RenderingServer::get_singleton()->instance_set_visible(scale_plane_gizmo_instance[i], show_gizmo && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE));
+		RenderingServer::get_singleton()->instance_set_transform(axis_gizmo_instance[i], xform);
+	}
+
+	Transform3D view_rotation_xform = xform;
+	view_rotation_xform.orthonormalize();
+
+	bool can_show_trackball = spatial_editor->is_gizmo_visible() && !_edit.instant && transform_gizmo_visible && !collision_reposition && !hide_gizmo_during_rotation;
+	bool show_trackball_sphere = can_show_trackball && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE) && !hide_gizmo_during_trackball;
+	Transform3D trackball_xform = view_rotation_xform;
+	trackball_xform.basis.scale(scale);
+	RenderingServer::get_singleton()->instance_set_transform(trackball_sphere_instance, trackball_xform);
+	RenderingServer::get_singleton()->instance_set_visible(trackball_sphere_instance, show_trackball_sphere);
+
+	bool shrink_view_ring = arc_replaces_ring >= 0 && arc_replaces_ring < 3;
+	Vector3 view_ring_scale = shrink_view_ring ? scale : scale * (spatial_editor->gizmo_view_rotation_scale / GIZMO_CIRCLE_SIZE);
+	view_rotation_xform.basis.scale(view_ring_scale);
+	RenderingServer::get_singleton()->instance_set_transform(rotate_gizmo_instance[3], view_rotation_xform);
+	RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[3], show_rotate_gizmo && arc_replaces_ring != 3);
+
+	bool show_axes = spatial_editor->is_gizmo_visible() && _edit.mode != TRANSFORM_NONE && !hide_gizmo_during_trackball;
+	RenderingServer *rs = RenderingServer::get_singleton();
+	rs->instance_set_visible(axis_gizmo_instance[0], show_axes && (_edit.plane == TRANSFORM_X_AXIS || _edit.plane == TRANSFORM_XY || _edit.plane == TRANSFORM_XZ));
+	rs->instance_set_visible(axis_gizmo_instance[1], show_axes && (_edit.plane == TRANSFORM_Y_AXIS || _edit.plane == TRANSFORM_XY || _edit.plane == TRANSFORM_YZ));
+	rs->instance_set_visible(axis_gizmo_instance[2], show_axes && (_edit.plane == TRANSFORM_Z_AXIS || _edit.plane == TRANSFORM_XZ || _edit.plane == TRANSFORM_YZ));
+}
+
+void Node3DEditorViewport::update_transform_gizmo_highlight() {
+	if (!is_visible_in_tree() || !Rect2(Vector2(), surface->get_size()).has_point(surface->get_local_mouse_position())) {
+		return;
+	}
+	_transform_gizmo_select(surface->get_local_mouse_position(), true);
+}
+
+void Node3DEditorViewport::set_state(const Dictionary &p_state) {
+	if (p_state.has("position")) {
+		view_3d_controller->cursor.pos = p_state["position"];
+	}
+	if (p_state.has("x_rotation")) {
+		view_3d_controller->cursor.x_rot = p_state["x_rotation"];
+		view_3d_controller->cursor.unsnapped_x_rot = view_3d_controller->cursor.x_rot;
+	}
+	if (p_state.has("y_rotation")) {
+		view_3d_controller->cursor.y_rot = p_state["y_rotation"];
+		view_3d_controller->cursor.unsnapped_y_rot = view_3d_controller->cursor.y_rot;
+	}
+	if (p_state.has("distance")) {
+		view_3d_controller->cursor.distance = p_state["distance"];
+	}
+	if (p_state.has("orthogonal")) {
+		bool orth = p_state["orthogonal"];
+		_menu_option(orth ? VIEW_ORTHOGONAL : VIEW_PERSPECTIVE);
+	}
+	if (p_state.has("view_type")) {
+		view_3d_controller->set_view_type(View3DController::ViewType(p_state["view_type"].operator int()));
+	}
+	if (p_state.has("auto_orthogonal_enabled")) {
+		bool enabled = p_state["auto_orthogonal_enabled"];
+		view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_AUTO_ORTHOGONAL), enabled);
+		view_3d_controller->set_auto_orthogonal_allowed(enabled);
+	}
+	if (p_state.has("auto_orthogonal")) {
+		if (p_state["auto_orthogonal"]) {
+			view_3d_controller->force_auto_orthogonal();
+			_update_name();
+		}
+	}
+	if (p_state.has("display_mode")) {
+		int display = p_state["display_mode"];
+
+		int idx = view_display_menu->get_popup()->get_item_index(display);
+		if (idx != -1 && !view_display_menu->get_popup()->is_item_checked(idx)) {
+			_menu_option(display);
+		} else {
+			idx = display_submenu->get_item_index(display);
+			if (idx != -1 && !display_submenu->is_item_checked(idx)) {
+				_menu_option(display);
+			}
+		}
+	}
+	if (p_state.has("lock_rotation")) {
+		_set_lock_view_rotation(p_state["lock_rotation"]);
+	}
+	if (p_state.has("use_environment")) {
+		bool env = p_state["use_environment"];
+
+		if (env != camera->get_environment().is_valid()) {
+			_menu_option(VIEW_ENVIRONMENT);
+		}
+	}
+	if (p_state.has("listener")) {
+		bool listener = p_state["listener"];
+
+		int idx = view_display_menu->get_popup()->get_item_index(VIEW_AUDIO_LISTENER);
+		viewport->set_as_audio_listener_3d(listener);
+		view_display_menu->get_popup()->set_item_checked(idx, listener);
+	}
+	if (p_state.has("doppler")) {
+		bool doppler = p_state["doppler"];
+
+		int idx = view_display_menu->get_popup()->get_item_index(VIEW_AUDIO_DOPPLER);
+		camera->set_doppler_tracking(doppler ? Camera3D::DOPPLER_TRACKING_IDLE_STEP : Camera3D::DOPPLER_TRACKING_DISABLED);
+		view_display_menu->get_popup()->set_item_checked(idx, doppler);
+	}
+	if (p_state.has("gizmos")) {
+		bool gizmos = p_state["gizmos"];
+
+		int idx = view_display_menu->get_popup()->get_item_index(VIEW_GIZMOS);
+		if (view_display_menu->get_popup()->is_item_checked(idx) != gizmos) {
+			_menu_option(VIEW_GIZMOS);
+		}
+	}
+	if (p_state.has("transform_gizmo")) {
+		bool transform_gizmo = p_state["transform_gizmo"];
+
+		int idx = view_display_menu->get_popup()->get_item_index(VIEW_TRANSFORM_GIZMO);
+		if (view_display_menu->get_popup()->is_item_checked(idx) != transform_gizmo) {
+			_menu_option(VIEW_TRANSFORM_GIZMO);
+		}
+	}
+	if (p_state.has("grid")) {
+		bool grid = p_state["grid"];
+
+		int idx = view_display_menu->get_popup()->get_item_index(VIEW_GRID);
+		if (view_display_menu->get_popup()->is_item_checked(idx) != grid) {
+			_menu_option(VIEW_GRID);
+		}
+	}
+	if (p_state.has("information")) {
+		bool information = p_state["information"];
+
+		int idx = view_display_menu->get_popup()->get_item_index(VIEW_INFORMATION);
+		if (view_display_menu->get_popup()->is_item_checked(idx) != information) {
+			_menu_option(VIEW_INFORMATION);
+		}
+	}
+	if (p_state.has("frame_time")) {
+		bool fps = p_state["frame_time"];
+
+		int idx = view_display_menu->get_popup()->get_item_index(VIEW_FRAME_TIME);
+		if (view_display_menu->get_popup()->is_item_checked(idx) != fps) {
+			_menu_option(VIEW_FRAME_TIME);
+		}
+	}
+	if (p_state.has("half_res")) {
+		bool half_res = p_state["half_res"];
+
+		int idx = view_display_menu->get_popup()->get_item_index(VIEW_HALF_RESOLUTION);
+		view_display_menu->get_popup()->set_item_checked(idx, half_res);
+		_update_shrink();
+	}
+	if (p_state.has("cinematic_preview")) {
+		previewing_cinema = p_state["cinematic_preview"];
+
+		int idx = view_display_menu->get_popup()->get_item_index(VIEW_CINEMATIC_PREVIEW);
+		view_display_menu->get_popup()->set_item_checked(idx, previewing_cinema);
+
+		cinema_label->set_visible(previewing_cinema);
+		if (previewing_cinema) {
+			_update_centered_labels();
+			surface->queue_redraw();
+		}
+	}
+
+	if (preview_camera->is_connected(SceneStringName(toggled), callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview))) {
+		preview_camera->disconnect(SceneStringName(toggled), callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+	}
+	if (p_state.has("previewing")) {
+		Node *pv = EditorNode::get_singleton()->get_edited_scene()->get_node(p_state["previewing"]);
+		if (Object::cast_to<Camera3D>(pv)) {
+			previewing = Object::cast_to<Camera3D>(pv);
+			previewing->connect(SceneStringName(tree_exiting), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
+			previewing->connect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
+			RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), previewing->get_camera()); //replace
+			surface->queue_redraw();
+			previewing_camera = true;
+			_update_navigation_controls_visibility();
+			preview_camera->set_pressed(true);
+			preview_camera->show();
+			pilot_camera->show();
+
+			camera->set_global_transform(view_3d_controller->to_camera_transform());
+
+			_sync_cursor_from_transform(previewing->get_global_transform());
+			view_3d_controller->update_camera(0);
+		}
+	}
+	preview_camera->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+}
+
+Dictionary Node3DEditorViewport::get_state() const {
+	Dictionary d;
+	d["position"] = view_3d_controller->cursor.pos;
+	d["x_rotation"] = view_3d_controller->cursor.x_rot;
+	d["y_rotation"] = view_3d_controller->cursor.y_rot;
+	d["distance"] = view_3d_controller->cursor.distance;
+	d["use_environment"] = camera->get_environment().is_valid();
+	d["orthogonal"] = camera->get_projection() == Camera3D::PROJECTION_ORTHOGONAL;
+	d["view_type"] = view_3d_controller->get_view_type();
+	d["auto_orthogonal"] = view_3d_controller->get_orthogonal_mode() == View3DController::ORTHOGONAL_AUTO;
+	d["auto_orthogonal_enabled"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_AUTO_ORTHOGONAL));
+
+	// Find selected display mode.
+	int display_mode = VIEW_DISPLAY_NORMAL;
+	for (int i = VIEW_DISPLAY_NORMAL; i < VIEW_DISPLAY_ADVANCED; i++) {
+		if (view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(i))) {
+			display_mode = i;
+			break;
+		}
+	}
+	for (int i = VIEW_DISPLAY_ADVANCED + 1; i < VIEW_DISPLAY_MAX; i++) {
+		if (display_submenu->is_item_checked(display_submenu->get_item_index(i))) {
+			display_mode = i;
+			break;
+		}
+	}
+	d["display_mode"] = display_mode;
+
+	d["listener"] = viewport->is_audio_listener_3d();
+	d["doppler"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_AUDIO_DOPPLER));
+	d["gizmos"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_GIZMOS));
+	d["transform_gizmo"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_TRANSFORM_GIZMO));
+	d["grid"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_GRID));
+	d["information"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_INFORMATION));
+	d["frame_time"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_FRAME_TIME));
+	d["half_res"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_HALF_RESOLUTION));
+	d["cinematic_preview"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_CINEMATIC_PREVIEW));
+	if (previewing) {
+		d["previewing"] = EditorNode::get_singleton()->get_edited_scene()->get_path_to(previewing);
+	}
+	d["lock_rotation"] = view_3d_controller->is_locking_rotation();
+
+	return d;
+}
+
+void Node3DEditorViewport::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("toggle_maximize_view", PropertyInfo(Variant::OBJECT, "viewport")));
+	ADD_SIGNAL(MethodInfo("clicked"));
+}
+
+void Node3DEditorViewport::reset() {
+	view_3d_controller->set_orthogonal(false);
+	view_3d_controller->set_view_type(View3DController::VIEW_TYPE_USER);
+	message_time = 0;
+	message = "";
+	last_message = "";
+
+	view_3d_controller->cursor = View3DController::Cursor();
+}
+
+void Node3DEditorViewport::focus_selection() {
+	Vector3 center;
+	int count = 0;
+
+	const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+	focused_node_id = ObjectID();
+	if (!selection.is_empty()) {
+		focused_node_id = selection.front()->get()->get_instance_id();
+	}
+
+	for (Node *node : selection) {
+		Node3D *node_3d = Object::cast_to<Node3D>(node);
+		if (!node_3d) {
+			continue;
+		}
+
+		Node3DEditorSelectedItem *se = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(node_3d);
+		if (!se) {
+			continue;
+		}
+
+		if (se->gizmo.is_valid()) {
+			for (const KeyValue<int, Transform3D> &GE : se->subgizmos) {
+				const Vector3 pos = node_3d->get_global_gizmo_transform().xform(se->gizmo->get_subgizmo_transform(GE.key).origin);
+				if (pos.is_finite()) {
+					center += pos;
+					count++;
+				}
+			}
+		} else {
+			const Vector3 pos = node_3d->get_global_gizmo_transform().origin;
+			if (pos.is_finite()) {
+				center += pos;
+				count++;
+			}
+		}
+	}
+
+	if (count > 1) {
+		center /= count;
+	}
+
+	view_3d_controller->cursor.pos = center;
+}
+
+void Node3DEditorViewport::assign_pending_data_pointers(Node3D *p_preview_node, AABB *p_preview_bounds, AcceptDialog *p_accept) {
+	preview_node = p_preview_node;
+	preview_bounds = p_preview_bounds;
+	accept = p_accept;
+}
+
+void _insert_rid_recursive(Node *node, HashSet<RID> &rids) {
+#ifndef PHYSICS_3D_DISABLED
+	CollisionObject3D *co = Object::cast_to<CollisionObject3D>(node);
+
+	if (co) {
+		rids.insert(co->get_rid());
+	} else if (node->is_class("CSGShape3D")) { // HACK: We should avoid referencing module logic.
+		rids.insert(node->call("_get_root_collision_instance"));
+	}
+#endif // PHYSICS_3D_DISABLED
+
+	for (int i = 0; i < node->get_child_count(); i++) {
+		Node *child = node->get_child(i);
+		_insert_rid_recursive(child, rids);
+	}
+}
+
+Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos, Node3D *p_node) const {
+	const float MAX_DISTANCE = 50.0;
+	const float FALLBACK_DISTANCE = 5.0;
+
+	Vector3 world_ray = get_ray(p_pos);
+	Vector3 world_pos = get_ray_pos(p_pos);
+
+#ifndef PHYSICS_3D_DISABLED
+	PhysicsDirectSpaceState3D *ss = get_tree()->get_root()->get_world_3d()->get_direct_space_state();
+#endif // PHYSICS_3D_DISABLED
+
+	HashSet<RID> rids;
+
+	if (preview_node && preview_node->get_child_count() > 0) {
+		_insert_rid_recursive(preview_node, rids);
+	} else if (!preview_node->is_inside_tree() && !ruler->is_inside_tree()) {
+		const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+
+		Node3D *first_selected_node = Object::cast_to<Node3D>(selection.front()->get());
+
+		if (first_selected_node) {
+			_insert_rid_recursive(first_selected_node, rids);
+		}
+	}
+
+#ifndef PHYSICS_3D_DISABLED
+	PhysicsDirectSpaceState3D::RayParameters ray_params;
+	ray_params.exclude = rids;
+	ray_params.from = world_pos;
+	ray_params.to = world_pos + world_ray * camera->get_far();
+
+	PhysicsDirectSpaceState3D::RayResult result;
+	if (ss->intersect_ray(ray_params, result) && (preview_node->get_child_count() > 0 || !preview_node->is_inside_tree())) {
+		// Calculate an offset for the `p_node` such that the its bounding box is on top of and touching the contact surface's plane.
+
+		// Use the Gram-Schmidt process to get an orthonormal Basis aligned with the surface normal.
+		const Vector3 bb_basis_x = result.normal;
+		Vector3 bb_basis_y = Vector3(0, 1, 0);
+		bb_basis_y = bb_basis_y - bb_basis_y.project(bb_basis_x);
+		if (bb_basis_y.is_zero_approx()) {
+			bb_basis_y = Vector3(0, 0, 1);
+			bb_basis_y = bb_basis_y - bb_basis_y.project(bb_basis_x);
+		}
+		bb_basis_y = bb_basis_y.normalized();
+		const Vector3 bb_basis_z = bb_basis_x.cross(bb_basis_y);
+		const Basis bb_basis = Basis(bb_basis_x, bb_basis_y, bb_basis_z);
+
+		// This normal-aligned Basis allows us to create an AABB that can fit on the surface plane as snugly as possible.
+		const Transform3D bb_transform = Transform3D(bb_basis, p_node->get_global_transform().origin);
+		const AABB p_node_bb = _calculate_spatial_bounds(p_node, true, &bb_transform);
+		// The x-axis's alignment with the surface normal also makes it trivial to get the distance from `p_node`'s origin at (0, 0, 0) to the correct AABB face.
+		const float offset_distance = -p_node_bb.position.x;
+
+		// `result_offset` is in global space.
+		const Vector3 result_offset = result.position + result.normal * offset_distance;
+
+		return result_offset;
+	}
+#endif // PHYSICS_3D_DISABLED
+
+	const bool is_orthogonal = camera->get_projection() == Camera3D::PROJECTION_ORTHOGONAL;
+
+	// The XZ plane.
+	Vector3 intersection;
+	Plane plane(Vector3(0, 1, 0));
+	if (plane.intersects_ray(world_pos, world_ray, &intersection)) {
+		if (is_orthogonal || world_pos.distance_to(intersection) <= MAX_DISTANCE) {
+			return intersection;
+		}
+	}
+
+	// Plane facing the camera using fallback distance.
+	if (is_orthogonal) {
+		plane = Plane(world_ray, view_3d_controller->cursor.pos - world_ray * (view_3d_controller->cursor.distance - FALLBACK_DISTANCE));
+	} else {
+		plane = Plane(world_ray, world_pos + world_ray * FALLBACK_DISTANCE);
+	}
+	if (plane.intersects_ray(world_pos, world_ray, &intersection)) {
+		return intersection;
+	}
+
+	// Not likely, but just in case...
+	return world_pos + world_ray * FALLBACK_DISTANCE;
+}
+
+AABB Node3DEditorViewport::_calculate_spatial_bounds(const Node3D *p_parent, bool p_omit_top_level, const Transform3D *p_bounds_orientation) {
+	if (!p_parent) {
+		return AABB(Vector3(-0.2, -0.2, -0.2), Vector3(0.4, 0.4, 0.4));
+	}
+	const Transform3D parent_transform = p_parent->get_global_transform();
+	if (!parent_transform.is_finite()) {
+		return AABB();
+	}
+	AABB bounds;
+
+	Transform3D bounds_orientation;
+	Transform3D xform_to_top_level_parent_space;
+	if (p_bounds_orientation) {
+		bounds_orientation = *p_bounds_orientation;
+		xform_to_top_level_parent_space = bounds_orientation.affine_inverse() * parent_transform;
+	} else {
+		bounds_orientation = parent_transform;
+	}
+
+	const VisualInstance3D *visual_instance = Object::cast_to<VisualInstance3D>(p_parent);
+	if (visual_instance) {
+		bounds = visual_instance->get_aabb();
+	} else {
+		bounds = AABB();
+	}
+	bounds = xform_to_top_level_parent_space.xform(bounds);
+
+	for (int i = 0; i < p_parent->get_child_count(); i++) {
+		const Node3D *child = Object::cast_to<Node3D>(p_parent->get_child(i));
+		if (child && !(p_omit_top_level && child->is_set_as_top_level())) {
+			const AABB child_bounds = _calculate_spatial_bounds(child, p_omit_top_level, &bounds_orientation);
+			bounds.merge_with(child_bounds);
+		}
+	}
+
+	return bounds;
+}
+
+Node *Node3DEditorViewport::_sanitize_preview_node(Node *p_node) const {
+	Node3D *node_3d = Object::cast_to<Node3D>(p_node);
+	if (node_3d == nullptr) {
+		Node3D *replacement_node = memnew(Node3D);
+		replacement_node->set_name(p_node->get_name());
+		p_node->replace_by(replacement_node);
+		memdelete(p_node);
+		p_node = replacement_node;
+	} else {
+		VisualInstance3D *visual_instance = Object::cast_to<VisualInstance3D>(node_3d);
+		if (visual_instance == nullptr) {
+			Node3D *replacement_node = memnew(Node3D);
+			replacement_node->set_name(node_3d->get_name());
+			replacement_node->set_visible(node_3d->is_visible());
+			replacement_node->set_transform(node_3d->get_transform());
+			replacement_node->set_rotation_edit_mode(node_3d->get_rotation_edit_mode());
+			replacement_node->set_rotation_order(node_3d->get_rotation_order());
+			replacement_node->set_as_top_level(node_3d->is_set_as_top_level());
+			p_node->replace_by(replacement_node);
+			memdelete(p_node);
+			p_node = replacement_node;
+		}
+	}
+
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		_sanitize_preview_node(p_node->get_child(i));
+	}
+
+	return p_node;
+}
+
+void Node3DEditorViewport::_create_preview_node(const Vector<String> &files) const {
+	bool add_preview = false;
+	for (const String &path : files) {
+		Ref<Resource> res = ResourceLoader::load(path);
+		ERR_CONTINUE(res.is_null());
+
+		Ref<PackedScene> scene = res;
+		if (scene.is_valid()) {
+			Node *instance = scene->instantiate();
+			if (instance) {
+				instance = _sanitize_preview_node(instance);
+				preview_node->add_child(instance);
+				Node3D *node_3d = Object::cast_to<Node3D>(instance);
+				if (node_3d) {
+					node_3d->set_as_top_level(false);
+				}
+			}
+			add_preview = true;
+		}
+
+		Ref<Mesh> mesh = res;
+		if (mesh.is_valid()) {
+			MeshInstance3D *mesh_instance = memnew(MeshInstance3D);
+			mesh_instance->set_mesh(mesh);
+			preview_node->add_child(mesh_instance);
+			add_preview = true;
+		}
+
+		Ref<AudioStream> audio = res;
+		if (audio.is_valid()) {
+			Sprite3D *sprite = memnew(Sprite3D);
+			sprite->set_texture(get_editor_theme_icon(SNAME("Gizmo3DSamplePlayer")));
+			sprite->set_billboard_mode(StandardMaterial3D::BILLBOARD_ENABLED);
+			sprite->set_pixel_size(0.005);
+			preview_node->add_child(sprite);
+			add_preview = true;
+		}
+	}
+	if (add_preview) {
+		EditorNode::get_singleton()->get_scene_root()->add_child(preview_node);
+		*preview_bounds = _calculate_spatial_bounds(preview_node);
+	}
+}
+
+void Node3DEditorViewport::_remove_preview_node() {
+	tooltip_panel->hide();
+
+	set_message("");
+	if (preview_node->get_parent()) {
+		for (int i = preview_node->get_child_count() - 1; i >= 0; i--) {
+			Node *node = preview_node->get_child(i);
+			node->queue_free();
+			preview_node->remove_child(node);
+		}
+		EditorNode::get_singleton()->get_scene_root()->remove_child(preview_node);
+	}
+}
+
+bool Node3DEditorViewport::_apply_preview_material(ObjectID p_target, const Point2 &p_point) const {
+	_reset_preview_material();
+
+	if (p_target.is_null()) {
+		return false;
+	}
+
+	spatial_editor->set_preview_material_target(p_target);
+
+	Object *target_inst = ObjectDB::get_instance(p_target);
+
+	bool is_ctrl = Input::get_singleton()->is_key_pressed(Key::CTRL);
+
+	MeshInstance3D *mesh_instance = Object::cast_to<MeshInstance3D>(target_inst);
+	if (is_ctrl && mesh_instance) {
+		Ref<Mesh> mesh = mesh_instance->get_mesh();
+		int surface_count = mesh->get_surface_count();
+
+		Vector3 world_ray = get_ray(p_point);
+		Vector3 world_pos = get_ray_pos(p_point);
+
+		int closest_surface = -1;
+		float closest_dist = 1e20;
+
+		Transform3D gt = mesh_instance->get_global_transform();
+
+		Transform3D ai = gt.affine_inverse();
+		Vector3 xform_ray = ai.basis.xform(world_ray).normalized();
+		Vector3 xform_pos = ai.xform(world_pos);
+
+		for (int surface_idx = 0; surface_idx < surface_count; surface_idx++) {
+			Ref<TriangleMesh> surface_mesh = mesh->generate_surface_triangle_mesh(surface_idx);
+
+			Vector3 rpos, rnorm;
+			if (surface_mesh->intersect_ray(xform_pos, xform_ray, rpos, rnorm)) {
+				Vector3 hitpos = gt.xform(rpos);
+
+				const real_t dist = world_pos.distance_to(hitpos);
+
+				if (dist < 0) {
+					continue;
+				}
+
+				if (dist < closest_dist) {
+					closest_surface = surface_idx;
+					closest_dist = dist;
+				}
+			}
+		}
+
+		if (closest_surface == -1) {
+			return false;
+		}
+
+		spatial_editor->set_preview_material_surface(closest_surface);
+		spatial_editor->set_preview_reset_material(mesh_instance->get_surface_override_material(closest_surface));
+		mesh_instance->set_surface_override_material(closest_surface, spatial_editor->get_preview_material());
+
+		return true;
+	}
+
+	GeometryInstance3D *geometry_instance = Object::cast_to<GeometryInstance3D>(target_inst);
+	if (geometry_instance) {
+		spatial_editor->set_preview_material_surface(-1);
+		spatial_editor->set_preview_reset_material(geometry_instance->get_material_override());
+		geometry_instance->set_material_override(spatial_editor->get_preview_material());
+		return true;
+	}
+
+	return false;
+}
+
+void Node3DEditorViewport::_reset_preview_material() const {
+	ObjectID last_target = spatial_editor->get_preview_material_target();
+	if (last_target.is_null()) {
+		return;
+	}
+	Object *last_target_inst = ObjectDB::get_instance(last_target);
+
+	MeshInstance3D *mesh_instance = Object::cast_to<MeshInstance3D>(last_target_inst);
+	GeometryInstance3D *geometry_instance = Object::cast_to<GeometryInstance3D>(last_target_inst);
+	if (mesh_instance && spatial_editor->get_preview_material_surface() != -1) {
+		mesh_instance->set_surface_override_material(spatial_editor->get_preview_material_surface(), spatial_editor->get_preview_reset_material());
+	} else if (geometry_instance) {
+		geometry_instance->set_material_override(spatial_editor->get_preview_reset_material());
+	}
+}
+
+void Node3DEditorViewport::_remove_preview_material() {
+	tooltip_panel->hide();
+
+	spatial_editor->set_preview_material(Ref<Material>());
+	spatial_editor->set_preview_reset_material(Ref<Material>());
+	spatial_editor->set_preview_material_target(ObjectID());
+	spatial_editor->set_preview_material_surface(-1);
+}
+
+bool Node3DEditorViewport::_cyclical_dependency_exists(const String &p_target_scene_path, Node *p_desired_node) const {
+	if (p_desired_node->get_scene_file_path() == p_target_scene_path) {
+		return true;
+	}
+
+	int childCount = p_desired_node->get_child_count();
+	for (int i = 0; i < childCount; i++) {
+		Node *child = p_desired_node->get_child(i);
+		if (_cyclical_dependency_exists(p_target_scene_path, child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool Node3DEditorViewport::_create_instance(Node *p_parent, const String &p_path, const Point2 &p_point) {
+	Ref<Resource> res = ResourceLoader::load(p_path);
+	ERR_FAIL_COND_V(res.is_null(), false);
+
+	Ref<PackedScene> scene = res;
+	Ref<Mesh> mesh = res;
+
+	Node *instantiated_scene = nullptr;
+
+	if (mesh.is_valid() || scene.is_valid()) {
+		if (mesh.is_valid()) {
+			MeshInstance3D *mesh_instance = memnew(MeshInstance3D);
+			mesh_instance->set_mesh(mesh);
+
+			// Adjust casing according to project setting. The file name is expected to be in snake_case, but will work for others.
+			const String &node_name = Node::adjust_name_casing(p_path.get_file().get_basename());
+			if (!node_name.is_empty()) {
+				mesh_instance->set_name(node_name);
+			}
+
+			instantiated_scene = mesh_instance;
+		} else {
+			if (scene.is_null()) { // invalid scene
+				return false;
+			} else {
+				instantiated_scene = scene->instantiate(PackedScene::GEN_EDIT_STATE_INSTANCE);
+			}
+		}
+	}
+
+	if (instantiated_scene == nullptr) {
+		return false;
+	}
+
+	if (!EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path().is_empty()) { // Cyclic instantiation.
+		if (_cyclical_dependency_exists(EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path(), instantiated_scene)) {
+			memdelete(instantiated_scene);
+			return false;
+		}
+	}
+
+	if (scene.is_valid()) {
+		instantiated_scene->set_scene_file_path(ProjectSettings::get_singleton()->localize_path(p_path));
+	}
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->add_do_method(p_parent, "add_child", instantiated_scene, true);
+	undo_redo->add_do_method(instantiated_scene, "set_owner", EditorNode::get_singleton()->get_edited_scene());
+	undo_redo->add_do_reference(instantiated_scene);
+	undo_redo->add_undo_method(p_parent, "remove_child", instantiated_scene);
+	undo_redo->add_do_method(editor_selection, "add_node", instantiated_scene);
+
+	String new_name = p_parent->validate_child_name(instantiated_scene);
+	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
+	undo_redo->add_do_method(ed, "live_debug_instantiate_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent), p_path, new_name);
+	undo_redo->add_undo_method(ed, "live_debug_remove_node", NodePath(String(EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent)) + "/" + new_name));
+
+	Node3D *node3d = Object::cast_to<Node3D>(instantiated_scene);
+	if (node3d) {
+		Transform3D parent_tf;
+		Node3D *parent_node3d = Object::cast_to<Node3D>(p_parent);
+		if (parent_node3d) {
+			parent_tf = parent_node3d->get_global_gizmo_transform();
+		}
+
+		Transform3D new_tf = node3d->get_transform();
+		if (node3d->is_set_as_top_level()) {
+			new_tf.origin += preview_node_pos;
+		} else {
+			new_tf.origin = parent_tf.affine_inverse().xform(preview_node_pos + node3d->get_position());
+			new_tf.basis = parent_tf.affine_inverse().basis * new_tf.basis;
+		}
+
+		undo_redo->add_do_method(instantiated_scene, "set_transform", new_tf);
+	}
+
+	return true;
+}
+
+bool Node3DEditorViewport::_create_audio_node(Node *p_parent, const String &p_path, const Point2 &p_point) {
+	Ref<AudioStream> audio = ResourceLoader::load(p_path);
+	ERR_FAIL_COND_V(audio.is_null(), false);
+
+	AudioStreamPlayer3D *audio_player = memnew(AudioStreamPlayer3D);
+	audio_player->set_stream(audio);
+
+	// Adjust casing according to project setting. The file name is expected to be in snake_case, but will work for others.
+	const String &node_name = Node::adjust_name_casing(p_path.get_file().get_basename());
+	if (!node_name.is_empty()) {
+		audio_player->set_name(node_name);
+	}
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->add_do_method(p_parent, "add_child", audio_player, true);
+	undo_redo->add_do_method(audio_player, "set_owner", EditorNode::get_singleton()->get_edited_scene());
+	undo_redo->add_do_reference(audio_player);
+	undo_redo->add_undo_method(p_parent, "remove_child", audio_player);
+	undo_redo->add_do_method(editor_selection, "add_node", audio_player);
+
+	const String new_name = p_parent->validate_child_name(audio_player);
+	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
+	undo_redo->add_do_method(ed, "live_debug_create_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent), audio_player->get_class(), new_name);
+	undo_redo->add_undo_method(ed, "live_debug_remove_node", NodePath(String(EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent)) + "/" + new_name));
+
+	Transform3D parent_tf;
+	Node3D *parent_node3d = Object::cast_to<Node3D>(p_parent);
+	if (parent_node3d) {
+		parent_tf = parent_node3d->get_global_gizmo_transform();
+	}
+
+	Transform3D new_tf = audio_player->get_transform();
+	new_tf.origin = parent_tf.affine_inverse().xform(preview_node_pos + audio_player->get_position());
+	new_tf.basis = parent_tf.affine_inverse().basis * new_tf.basis;
+
+	undo_redo->add_do_method(audio_player, "set_transform", new_tf);
+
+	return true;
+}
+
+void Node3DEditorViewport::_perform_drop_data() {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	if (spatial_editor->get_preview_material_target().is_valid()) {
+		GeometryInstance3D *geometry_instance = ObjectDB::get_instance<GeometryInstance3D>(spatial_editor->get_preview_material_target());
+		MeshInstance3D *mesh_instance = ObjectDB::get_instance<MeshInstance3D>(spatial_editor->get_preview_material_target());
+		if (mesh_instance && spatial_editor->get_preview_material_surface() != -1) {
+			undo_redo->create_action(vformat(TTR("Set Surface %d Override Material"), spatial_editor->get_preview_material_surface()));
+			undo_redo->add_do_method(geometry_instance, "set_surface_override_material", spatial_editor->get_preview_material_surface(), spatial_editor->get_preview_material());
+			undo_redo->add_undo_method(geometry_instance, "set_surface_override_material", spatial_editor->get_preview_material_surface(), spatial_editor->get_preview_reset_material());
+			undo_redo->commit_action();
+		} else if (geometry_instance) {
+			undo_redo->create_action(TTR("Set Material Override"));
+			undo_redo->add_do_method(geometry_instance, "set_material_override", spatial_editor->get_preview_material());
+			undo_redo->add_undo_method(geometry_instance, "set_material_override", spatial_editor->get_preview_reset_material());
+			undo_redo->commit_action();
+		}
+
+		_remove_preview_material();
+		return;
+	}
+
+	_remove_preview_node();
+
+	PackedStringArray error_files;
+
+	undo_redo->create_action(TTR("Create Node"), UndoRedo::MERGE_DISABLE, target_node);
+	undo_redo->add_do_method(editor_selection, "clear");
+
+	for (int i = 0; i < selected_files.size(); i++) {
+		String path = selected_files[i];
+		Ref<Resource> res = ResourceLoader::load(path);
+		if (res.is_null()) {
+			continue;
+		}
+
+		Ref<PackedScene> scene = res;
+		Ref<Mesh> mesh = res;
+		if (mesh.is_valid() || scene.is_valid()) {
+			if (!_create_instance(target_node, path, drop_pos)) {
+				error_files.push_back(path.get_file());
+			}
+		}
+
+		Ref<AudioStream> audio = res;
+		if (audio.is_valid()) {
+			if (!_create_audio_node(target_node, path, drop_pos)) {
+				error_files.push_back(path.get_file());
+			}
+		}
+	}
+
+	undo_redo->commit_action();
+
+	if (error_files.size() > 0) {
+		accept->set_text(vformat(TTR("Error instantiating scene from %s."), String(", ").join(error_files)));
+		accept->popup_centered();
+	}
+}
+
+void Node3DEditorViewport::_show_tooltip(const String &p_title, const String &p_description) const {
+	tooltip_panel->set_text(
+			vformat("[font_size=%s][b][color=%s]%s[/color][/b][/font_size]\n%s",
+					get_theme_default_font_size() + 2,
+					get_theme_color(SNAME("accent_color"), EditorStringName(Editor)).to_html(false),
+					p_title, p_description));
+	tooltip_panel->show();
+}
+
+bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
+	if (previewing) {
+		return false;
+	}
+
+	if (p_point == Vector2(Math::INF, Math::INF)) {
+		tooltip_panel->hide();
+		return false;
+	}
+	preview_node_viewport_pos = p_point;
+
+	Dictionary d = p_data;
+	if (!d.has("type") || String(d["type"]) != "files") {
+		tooltip_panel->hide();
+		return false;
+	}
+	Vector<String> files = d["files"];
+
+	// If we already have a preview material or preview node,
+	// We just need to update them.
+	if (spatial_editor->get_preview_material().is_valid()) {
+		ObjectID new_preview_material_target = _select_ray(p_point);
+		return _apply_preview_material(new_preview_material_target, p_point);
+	}
+
+	if (preview_node->is_inside_tree()) {
+		preview_node_viewport_pos = p_point;
+		update_preview_node = true;
+		return true;
+	}
+
+	// If we don't already have a preview material or preview node,
+	// it means that this is the first time we are visiting this function.
+	// In that case, we need to check that the file(s) are droppable.
+	bool is_cyclical_dep = false;
+	String error_file;
+
+	enum {
+		SCENE = 1 << 0,
+		TEXTURE = 1 << 1,
+		AUDIO = 1 << 2,
+		MESH = 1 << 3,
+		MATERIAL = 1 << 4,
+	};
+	int instantiate_type = 0;
+
+	// Track whether a type other than PackedScene is valid to stop checking them and only
+	// continue to check if the rest of the scenes are valid (don't have cyclic dependencies).
+	bool is_other_valid = false;
+	// Check if at least one of the dragged files is a mesh, material, texture, or scene.
+	for (int i = 0; i < files.size(); i++) {
+		const String &res_type = ResourceLoader::get_resource_type(files[i]);
+		bool is_scene = ClassDB::is_parent_class(res_type, "PackedScene");
+		bool is_mesh = ClassDB::is_parent_class(res_type, "Mesh");
+		bool is_material = ClassDB::is_parent_class(res_type, "Material");
+		bool is_texture = ClassDB::is_parent_class(res_type, "Texture");
+		bool is_audio = ClassDB::is_parent_class(res_type, "AudioStream");
+
+		if (is_mesh || is_scene || is_material || is_texture || is_audio) {
+			Ref<Resource> res = ResourceLoader::load(files[i]);
+			if (res.is_null()) {
+				continue;
+			}
+			Ref<PackedScene> scn = res;
+			Ref<Mesh> mesh = res;
+			Ref<Material> mat = res;
+			Ref<Texture2D> tex = res;
+			Ref<AudioStream> audio = res;
+			if (scn.is_valid()) {
+				Node *instantiated_scene = scn->instantiate(PackedScene::GEN_EDIT_STATE_INSTANCE);
+				if (!instantiated_scene) {
+					continue;
+				}
+				Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
+				if (edited_scene && !edited_scene->get_scene_file_path().is_empty() && _cyclical_dependency_exists(edited_scene->get_scene_file_path(), instantiated_scene)) {
+					memdelete(instantiated_scene);
+					is_cyclical_dep = true;
+					error_file = files[i].get_file();
+					break;
+				}
+				memdelete(instantiated_scene);
+				instantiate_type |= SCENE;
+			} else if (!is_other_valid && mat.is_valid()) {
+				Ref<BaseMaterial3D> base_mat = res;
+				Ref<ShaderMaterial> shader_mat = res;
+
+				if (base_mat.is_null() && shader_mat.is_null()) {
+					continue;
+				}
+
+				spatial_editor->set_preview_material(mat);
+				is_other_valid = true;
+				instantiate_type |= MATERIAL;
+				continue;
+			} else if (!is_other_valid && mesh.is_valid()) {
+				// Let the mesh pass.
+				is_other_valid = true;
+				instantiate_type |= MESH;
+			} else if (!is_other_valid && tex.is_valid()) {
+				Ref<StandardMaterial3D> new_mat;
+				new_mat.instantiate();
+				new_mat->set_texture(BaseMaterial3D::TEXTURE_ALBEDO, tex);
+
+				spatial_editor->set_preview_material(new_mat);
+				is_other_valid = true;
+				instantiate_type |= TEXTURE;
+				continue;
+			} else if (!is_other_valid && audio.is_valid()) {
+				is_other_valid = true;
+				instantiate_type |= AUDIO;
+			} else {
+				continue;
+			}
+		}
+	}
+
+	String title = TTRN("Can't drop the file...", "Can't drop the files...", files.size());
+	if (is_cyclical_dep) {
+		_show_tooltip(title, vformat(TTR("Circular dependency found at %s."), error_file));
+		return false;
+	}
+
+	if (instantiate_type == 0) {
+		_show_tooltip(title, TTR("File format is not supported."));
+		return false;
+	}
+
+	// Only droppable file(s), on first frame, will make it to this point.
+	// Hence it is a good place to create the previews and tooltips.
+	_create_preview_node(files);
+	preview_node->hide();
+
+	String desc = "[ul]" +
+			TTRN("[b]Default:[/b] Add as sibling of selected node (except when root is selected).",
+					"[b]Default:[/b] Add as siblings of selected node (except when root is selected).",
+					files.size()) +
+			"\n" +
+			TTRN("[b]Hold Shift:[/b] Add as child of selected node.",
+					"[b]Hold Shift:[/b] Add as children of selected node.",
+					files.size()) +
+			"\n" +
+			TTRN("[b]Hold Alt:[/b] Add as child of root node.",
+					"[b]Hold Alt:[/b] Add as children of root node.",
+					files.size());
+
+	if (files.size() > 1) {
+		title = TTR("Dropping multiple files...");
+	} else if (instantiate_type & SCENE) {
+		title = TTR("Dropping a Scene file...");
+	} else if (instantiate_type & MESH) {
+		title = TTR("Dropping a Mesh file...");
+	} else if (instantiate_type & AUDIO) {
+		title = TTR("Dropping an Audio file...");
+	} else if (instantiate_type & MATERIAL || instantiate_type & TEXTURE) {
+		title = TTR("Dropping a Material...");
+		desc = "[ul]";
+		desc += vformat(TTR("[b]Default:[/b] Place in Geometry's Material Override slot.") +
+						"\n" + TTR("[b]Hold %s:[/b] Place in Mesh's Surface Material Override slot."),
+				keycode_get_string((Key)KeyModifierMask::CMD_OR_CTRL));
+	}
+	desc += "[/ul]";
+
+	_show_tooltip(title, desc);
+
+	return true;
+}
+
+void Node3DEditorViewport::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
+	if (!can_drop_data_fw(p_point, p_data, p_from)) {
+		return;
+	}
+
+	bool is_shift = Input::get_singleton()->is_key_pressed(Key::SHIFT);
+	bool is_alt = Input::get_singleton()->is_key_pressed(Key::ALT);
+
+	selected_files.clear();
+	Dictionary d = p_data;
+	if (d.has("type") && String(d["type"]) == "files") {
+		selected_files = d["files"];
+	}
+
+	const List<Node *> &selected_nodes = EditorNode::get_singleton()->get_editor_selection()->get_top_selected_node_list();
+	Node *root_node = EditorNode::get_singleton()->get_edited_scene();
+	if (selected_nodes.size() > 0) {
+		Node *selected_node = selected_nodes.front()->get();
+		if (is_alt) {
+			target_node = root_node;
+		} else if (is_shift) {
+			target_node = selected_node;
+		} else { // Default behavior.
+			target_node = (selected_node != root_node) ? selected_node->get_parent() : root_node;
+		}
+	} else {
+		if (root_node) {
+			target_node = root_node;
+		} else {
+			// Create a root node so we can add child nodes to it.
+			SceneTreeDock::get_singleton()->add_root_node(memnew(Node3D));
+			target_node = get_tree()->get_edited_scene_root();
+		}
+	}
+
+	drop_pos = p_point;
+
+	_perform_drop_data();
+}
+
+void Node3DEditorViewport::begin_transform(TransformMode p_mode, bool instant) {
+	if (previewing) {
+		return;
+	}
+
+	if (get_selected_count() > 0) {
+		_edit.children_original_globals.clear();
+
+		_edit.mode = p_mode;
+		_compute_edit(_edit.mouse_pos);
+		_edit.instant = instant;
+		_edit.initial_click_vector = Vector3();
+		_edit.previous_rotation_vector = Vector3();
+		_edit.accumulated_rotation_angle = 0.0;
+		_edit.rotation_angle = 0.0;
+		_edit.gizmo_initiated = false;
+		switch (p_mode) {
+			case TRANSFORM_ROTATE:
+				_edit.show_rotation_line = true;
+				set_message(vformat(TTR("Rotating %s degrees."), String::num(0, 0)));
+				break;
+			case TRANSFORM_TRANSLATE:
+				set_message(vformat(TTR("Translating: %s"), vformat("%.0v", Vector3())));
+				break;
+			case TRANSFORM_SCALE:
+				set_message(vformat(TTR("Scaling: %s"), vformat("%.0v", Vector3())));
+				break;
+			default:
+				break;
+		}
+		update_transform_gizmo_view();
+		set_process_input(instant);
+		surface->queue_redraw();
+	}
+}
+
+// Apply the current transform operation.
+void Node3DEditorViewport::commit_transform() {
+	ERR_FAIL_COND(_edit.mode == TRANSFORM_NONE);
+	static const char *_transform_name[4] = {
+		TTRC("None"),
+		TTRC("Rotate"),
+		// TRANSLATORS: This refers to the movement that changes the position of an object.
+		TTRC("Translate"),
+		TTRC("Scale"),
+	};
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(_transform_name[_edit.mode]);
+
+	const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+
+	for (Node *E : selection) {
+		Node3D *sp = Object::cast_to<Node3D>(E);
+		if (!sp) {
+			continue;
+		}
+
+		Node3DEditorSelectedItem *se = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(sp);
+		if (!se) {
+			continue;
+		}
+
+		undo_redo->add_do_method(sp, "set_transform", sp->get_local_gizmo_transform());
+		undo_redo->add_undo_method(sp, "set_transform", se->original_local);
+	}
+
+	if (!_edit.children_original_globals.is_empty()) {
+		for (const KeyValue<Node3D *, Transform3D> &pair : _edit.children_original_globals) {
+			Node3D *child = pair.key;
+			Transform3D original_global = pair.value;
+			Transform3D current_global = child->get_global_transform();
+
+			undo_redo->add_do_method(child, "set_global_transform", current_global);
+			undo_redo->add_undo_method(child, "set_global_transform", original_global);
+		}
+	}
+
+	undo_redo->commit_action();
+
+	collision_reposition = false;
+	finish_transform();
+	_reset_follow_mode_count();
+	set_message("");
+}
+
+void Node3DEditorViewport::apply_transform(Vector3 p_motion, double p_snap) {
+	// View-plane translate/scale always uses global coords; rotation and axis operations respect local/global preference.
+	bool local_coords = spatial_editor->are_local_coords_enabled() &&
+			!(_edit.plane == TRANSFORM_VIEW && _edit.mode != TRANSFORM_ROTATE);
+
+	bool is_global_view_plane = (_edit.plane == TRANSFORM_VIEW) &&
+			((_edit.mode != TRANSFORM_ROTATE) || !spatial_editor->are_local_coords_enabled());
+
+	const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+	for (Node *E : selection) {
+		Node3D *sp = Object::cast_to<Node3D>(E);
+		if (!sp) {
+			continue;
+		}
+
+		Node3DEditorSelectedItem *se = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(sp);
+		if (!se) {
+			continue;
+		}
+
+		if (sp->has_meta("_edit_lock_") && !spatial_editor->is_gizmo_visible()) {
+			continue;
+		}
+
+		if (se->gizmo.is_valid()) {
+			for (KeyValue<int, Transform3D> &GE : se->subgizmos) {
+				Transform3D xform = GE.value;
+				Transform3D new_xform = _compute_transform(_edit.mode, se->original * xform, xform, p_motion, p_snap, local_coords, _edit.plane != TRANSFORM_VIEW, is_global_view_plane); // Force orthogonal with subgizmo.
+				if (!local_coords) {
+					new_xform = se->original.affine_inverse() * new_xform;
+				}
+				se->gizmo->set_subgizmo_transform(GE.key, new_xform);
+			}
+		} else {
+			Transform3D new_xform = _compute_transform(_edit.mode, se->original, se->original_local, p_motion, p_snap, local_coords, sp->get_rotation_edit_mode() != Node3D::ROTATION_EDIT_MODE_BASIS && _edit.plane != TRANSFORM_VIEW, is_global_view_plane);
+			_transform_gizmo_apply(se->sp, new_xform, local_coords);
+		}
+	}
+
+	spatial_editor->update_transform_gizmo();
+	surface->queue_redraw();
+}
+
+// Update the current transform operation in response to an input.
+void Node3DEditorViewport::update_transform(bool p_shift) {
+	Vector3 ray_pos = get_ray_pos(_edit.mouse_pos);
+	Vector3 ray = get_ray(_edit.mouse_pos);
+	double snap = EDITOR_GET("interface/inspector/default_float_step");
+	int snap_step_decimals = Math::range_step_decimals(snap);
+
+	// View-plane translate/scale always uses global coords; rotation and axis operations respect local/global preference.
+	bool local_coords = spatial_editor->are_local_coords_enabled() &&
+			!(_edit.plane == TRANSFORM_VIEW && _edit.mode != TRANSFORM_ROTATE);
+
+	switch (_edit.mode) {
+		case TRANSFORM_SCALE: {
+			Vector3 motion_mask;
+			Plane plane;
+			bool plane_mv = false;
+
+			switch (_edit.plane) {
+				case TRANSFORM_VIEW:
+					motion_mask = Vector3(0, 0, 0);
+					plane = Plane(_get_camera_normal(), _edit.center);
+					break;
+				case TRANSFORM_X_AXIS:
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(0).normalized();
+					plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
+					break;
+				case TRANSFORM_Y_AXIS:
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(1).normalized();
+					plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
+					break;
+				case TRANSFORM_Z_AXIS:
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(2).normalized();
+					plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
+					break;
+				case TRANSFORM_YZ:
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(2).normalized() + spatial_editor->get_gizmo_transform().basis.get_column(1).normalized();
+					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_column(0).normalized(), _edit.center);
+					plane_mv = true;
+					break;
+				case TRANSFORM_XZ:
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(2).normalized() + spatial_editor->get_gizmo_transform().basis.get_column(0).normalized();
+					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_column(1).normalized(), _edit.center);
+					plane_mv = true;
+					break;
+				case TRANSFORM_XY:
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(0).normalized() + spatial_editor->get_gizmo_transform().basis.get_column(1).normalized();
+					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_column(2).normalized(), _edit.center);
+					plane_mv = true;
+					break;
+			}
+
+			Vector3 intersection;
+			if (!plane.intersects_ray(ray_pos, ray, &intersection)) {
+				break;
+			}
+
+			Vector3 click;
+			if (!plane.intersects_ray(_edit.click_ray_pos, _edit.click_ray, &click)) {
+				break;
+			}
+
+			Vector3 motion = intersection - click;
+			if (_edit.plane != TRANSFORM_VIEW) {
+				if (!plane_mv) {
+					motion = motion_mask.dot(motion) * motion_mask;
+
+				} else {
+					// Alternative planar scaling mode
+					if (p_shift) {
+						motion = motion_mask.dot(motion) * motion_mask;
+					}
+				}
+
+			} else {
+				const real_t center_click_dist = click.distance_to(_edit.center);
+				const real_t center_inters_dist = intersection.distance_to(_edit.center);
+				if (center_click_dist == 0) {
+					break;
+				}
+
+				const real_t scale = center_inters_dist - center_click_dist;
+				motion = Vector3(scale, scale, scale);
+			}
+
+			motion /= click.distance_to(_edit.center);
+
+			if (spatial_editor->is_snap_enabled()) {
+				snap = spatial_editor->get_scale_snap() / 100;
+			}
+			Vector3 motion_snapped = motion;
+			motion_snapped.snapf(snap);
+			// This might not be necessary anymore after issue #288 is solved (in 4.0?).
+			// TRANSLATORS: Refers to changing the scale of a node in the 3D editor.
+			set_message(vformat(TTR("Scaling: %s"), vformat("%.*v", snap_step_decimals, motion_snapped)));
+			if (local_coords) {
+				// TODO: needed?
+				motion = _edit.original.basis.inverse().xform(motion);
+			}
+
+			apply_transform(motion, snap);
+		} break;
+
+		case TRANSFORM_TRANSLATE: {
+			Vector3 motion_mask;
+			Plane plane;
+			bool plane_mv = false;
+
+			switch (_edit.plane) {
+				case TRANSFORM_VIEW:
+					plane = Plane(_get_camera_normal(), _edit.center);
+					break;
+				case TRANSFORM_X_AXIS:
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(0).normalized();
+					plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
+					break;
+				case TRANSFORM_Y_AXIS:
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(1).normalized();
+					plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
+					break;
+				case TRANSFORM_Z_AXIS:
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(2).normalized();
+					plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
+					break;
+				case TRANSFORM_YZ:
+					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_column(0).normalized(), _edit.center);
+					plane_mv = true;
+					break;
+				case TRANSFORM_XZ:
+					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_column(1).normalized(), _edit.center);
+					plane_mv = true;
+					break;
+				case TRANSFORM_XY:
+					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_column(2).normalized(), _edit.center);
+					plane_mv = true;
+					break;
+			}
+
+			Vector3 intersection;
+			if (!plane.intersects_ray(ray_pos, ray, &intersection)) {
+				break;
+			}
+
+			Vector3 click;
+			if (!plane.intersects_ray(_edit.click_ray_pos, _edit.click_ray, &click)) {
+				break;
+			}
+
+			Vector3 motion = intersection - click;
+			if (_edit.plane != TRANSFORM_VIEW) {
+				if (!plane_mv) {
+					motion = motion_mask.dot(motion) * motion_mask;
+				}
+			}
+
+			if (spatial_editor->is_snap_enabled()) {
+				snap = spatial_editor->get_translate_snap();
+			}
+			Vector3 motion_snapped = motion;
+			motion_snapped.snapf(snap);
+			// TRANSLATORS: Refers to changing the position of a node in the 3D editor.
+			set_message(vformat(TTR("Translating: %s"), vformat("%.*v", snap_step_decimals, motion_snapped)));
+			if (local_coords) {
+				motion = spatial_editor->get_gizmo_transform().basis.inverse().xform(motion);
+			}
+
+			apply_transform(motion, snap);
+		} break;
+
+		case TRANSFORM_ROTATE: {
+			Plane plane;
+			if (camera->get_projection() == Camera3D::PROJECTION_PERSPECTIVE) {
+				Vector3 cam_to_obj = _edit.center - _get_camera_position();
+				if (!cam_to_obj.is_zero_approx()) {
+					plane = Plane(cam_to_obj.normalized(), _edit.center);
+				} else {
+					plane = Plane(_get_camera_normal(), _edit.center);
+				}
+			} else {
+				plane = Plane(_get_camera_normal(), _edit.center);
+			}
+
+			if (_edit.is_trackball) {
+				Vector2 motion_delta = _edit.mouse_pos - _edit.original_mouse_pos;
+				real_t sensitivity = TRACKBALL_SENSITIVITY * EDSCALE;
+				Vector2 rotation_input = motion_delta * sensitivity;
+
+				Transform3D cam_transform = view_3d_controller->to_camera_transform();
+				Vector3 cam_right = cam_transform.basis.get_column(0).normalized();
+				Vector3 cam_up = cam_transform.basis.get_column(1).normalized();
+				Vector3 rotation_axis = cam_up * rotation_input.x + cam_right * rotation_input.y;
+
+				real_t rotation_angle = rotation_axis.length();
+				if (rotation_angle > 0.0f) {
+					rotation_axis /= rotation_angle;
+
+					if (spatial_editor->is_snap_enabled()) {
+						double snap_step = spatial_editor->get_rotate_snap();
+						double angle_deg = Math::rad_to_deg(rotation_angle);
+						angle_deg = Math::snapped(angle_deg, snap_step);
+						rotation_angle = Math::deg_to_rad(angle_deg);
+					}
+
+					double angle_deg = Math::rad_to_deg(rotation_angle);
+					set_message(vformat(TTR("Rotating %s degrees."), String::num(angle_deg, 2)));
+
+					apply_transform(rotation_axis, rotation_angle);
+				}
+				break;
+			}
+
+			Vector3 local_axis;
+			Vector3 global_axis;
+			switch (_edit.plane) {
+				case TRANSFORM_VIEW:
+					local_axis = _edit.view_axis_local;
+					global_axis = _get_camera_normal();
+					break;
+				case TRANSFORM_X_AXIS:
+					local_axis = Vector3(1, 0, 0);
+					break;
+				case TRANSFORM_Y_AXIS:
+					local_axis = Vector3(0, 1, 0);
+					break;
+				case TRANSFORM_Z_AXIS:
+					local_axis = Vector3(0, 0, 1);
+					break;
+				case TRANSFORM_YZ:
+				case TRANSFORM_XZ:
+				case TRANSFORM_XY:
+					break;
+			}
+
+			if (_edit.plane != TRANSFORM_VIEW) {
+				global_axis = spatial_editor->get_gizmo_transform().basis.xform(local_axis).normalized();
+			}
+
+			Vector3 intersection;
+			if (!plane.intersects_ray(ray_pos, ray, &intersection)) {
+				break;
+			}
+
+			Vector3 click;
+			if (!plane.intersects_ray(_edit.click_ray_pos, _edit.click_ray, &click)) {
+				break;
+			}
+
+			Vector3 current_rotation_vector = (intersection - _edit.center).normalized();
+
+			if (_edit.initial_click_vector == Vector3()) {
+				Plane rotation_plane(global_axis, _edit.center);
+				Vector3 click_on_rotation_plane;
+				if (rotation_plane.intersects_ray(_edit.click_ray_pos, _edit.click_ray, &click_on_rotation_plane)) {
+					_edit.initial_click_vector = (click_on_rotation_plane - _edit.center).normalized();
+				} else {
+					_edit.initial_click_vector = (click - _edit.center).normalized();
+				}
+				_edit.previous_rotation_vector = current_rotation_vector;
+				_edit.accumulated_rotation_angle = 0.0;
+				_edit.rotation_angle = 0.0;
+			}
+
+			static const float orthogonal_threshold = Math::cos(Math::deg_to_rad(85.0f));
+			bool axis_is_orthogonal = Math::abs(plane.normal.dot(global_axis)) < orthogonal_threshold;
+
+			if (_edit.previous_rotation_vector != Vector3()) {
+				double delta_angle = _edit.previous_rotation_vector.signed_angle_to(current_rotation_vector, global_axis);
+				_edit.accumulated_rotation_angle += delta_angle;
+			}
+			_edit.previous_rotation_vector = current_rotation_vector;
+
+			if (spatial_editor->is_snap_enabled()) {
+				snap = spatial_editor->get_rotate_snap();
+				snap_step_decimals = Math::range_step_decimals(snap);
+			}
+
+			if (axis_is_orthogonal) {
+				_edit.show_rotation_line = false;
+				Vector3 projection_axis = plane.normal.cross(global_axis);
+				Vector3 delta = intersection - click;
+				float projection = delta.dot(projection_axis);
+				double orth_angle = (projection * (Math::PI / 2.0f)) / (gizmo_scale * GIZMO_CIRCLE_SIZE);
+				_edit.rotation_angle = spatial_editor->is_snap_enabled()
+						? Math::deg_to_rad(Math::snapped(Math::rad_to_deg(orth_angle), snap))
+						: orth_angle;
+			} else {
+				_edit.show_rotation_line = true;
+				_edit.rotation_angle = spatial_editor->is_snap_enabled()
+						? Math::deg_to_rad(Math::snapped(Math::rad_to_deg(_edit.accumulated_rotation_angle), snap))
+						: _edit.accumulated_rotation_angle;
+			}
+			set_message(vformat(TTR("Rotating %s degrees."), String::num(Math::rad_to_deg(_edit.rotation_angle), snap_step_decimals)));
+
+			Vector3 compute_axis = local_coords ? local_axis : global_axis;
+			apply_transform(compute_axis, _edit.rotation_angle);
+		} break;
+		default: {
+		}
+	}
+}
+
+void Node3DEditorViewport::update_transform_numeric() {
+	Vector3 motion;
+	switch (_edit.plane) {
+		case TRANSFORM_VIEW: {
+			switch (_edit.mode) {
+				case TRANSFORM_TRANSLATE:
+					motion = Vector3(1, 0, 0);
+					break;
+				case TRANSFORM_ROTATE:
+					motion = _edit.view_axis_local;
+					break;
+				case TRANSFORM_SCALE:
+					motion = Vector3(1, 1, 1);
+					break;
+				case TRANSFORM_NONE:
+					ERR_FAIL_MSG("_edit.mode cannot be TRANSFORM_NONE in update_transform_numeric.");
+			}
+			break;
+		}
+		case TRANSFORM_X_AXIS:
+			motion = Vector3(1, 0, 0);
+			break;
+		case TRANSFORM_Y_AXIS:
+			motion = Vector3(0, 1, 0);
+			break;
+		case TRANSFORM_Z_AXIS:
+			motion = Vector3(0, 0, 1);
+			break;
+		case TRANSFORM_XY:
+			motion = Vector3(1, 1, 0);
+			break;
+		case TRANSFORM_XZ:
+			motion = Vector3(1, 0, 1);
+			break;
+		case TRANSFORM_YZ:
+			motion = Vector3(0, 1, 1);
+			break;
+	}
+
+	double value = _edit.numeric_input * (_edit.numeric_negate ? -1 : 1);
+	double extra = 0.0;
+	switch (_edit.mode) {
+		case TRANSFORM_TRANSLATE:
+			motion *= value;
+			set_message(vformat(TTR("Translating %s."), motion));
+			break;
+		case TRANSFORM_ROTATE:
+			extra = Math::deg_to_rad(value);
+			set_message(vformat(TTR("Rotating %f degrees."), value));
+			break;
+		case TRANSFORM_SCALE:
+			// To halve the size of an object in Blender, you scale it by 0.5.
+			// Doing the same in Godot is considered scaling it by -0.5.
+			motion *= (value - 1.0);
+			set_message(vformat(TTR("Scaling %s."), motion));
+			break;
+		case TRANSFORM_NONE:
+			ERR_FAIL_MSG("_edit.mode cannot be TRANSFORM_NONE in update_transform_numeric.");
+	}
+
+	apply_transform(motion, extra);
+}
+
+// Perform cleanup after a transform operation is committed or canceled.
+void Node3DEditorViewport::finish_transform() {
+	_edit.mode = TRANSFORM_NONE;
+	_edit.instant = false;
+	_edit.numeric_input = 0;
+	_edit.numeric_next_decimal = 0;
+	_edit.numeric_negate = false;
+	_edit.is_trackball = false;
+	_edit.initial_click_vector = Vector3();
+	_edit.previous_rotation_vector = Vector3();
+	_edit.accumulated_rotation_angle = 0.0;
+	_edit.rotation_angle = 0.0;
+	_edit.gizmo_initiated = false;
+	_edit.children_original_globals.clear();
+	spatial_editor->set_local_coords_enabled(_edit.original_local);
+	spatial_editor->update_transform_gizmo();
+	surface->queue_redraw();
+	set_process_input(false);
+	clicked = ObjectID();
+}
+
+// Register a shortcut and also add it as an input action with the same events.
+void Node3DEditorViewport::register_shortcut_action(const String &p_path, const String &p_name, Key p_keycode, bool p_physical) {
+	Ref<Shortcut> sc = ED_SHORTCUT(p_path, p_name, p_keycode, p_physical);
+	shortcut_changed_callback(sc, p_path);
+	// Connect to the change event on the shortcut so the input binding can be updated.
+	sc->connect_changed(callable_mp(this, &Node3DEditorViewport::shortcut_changed_callback).bind(sc, p_path));
+}
+
+// Update the action in the InputMap to the provided shortcut events.
+void Node3DEditorViewport::shortcut_changed_callback(const Ref<Shortcut> p_shortcut, const String &p_shortcut_path) {
+	InputMap *im = InputMap::get_singleton();
+	if (im->has_action(p_shortcut_path)) {
+		im->action_erase_events(p_shortcut_path);
+	} else {
+		im->add_action(p_shortcut_path);
+	}
+
+	for (int i = 0; i < p_shortcut->get_events().size(); i++) {
+		im->action_add_event(p_shortcut_path, p_shortcut->get_events()[i]);
+	}
+
+	if (view_3d_controller.is_valid()) {
+		_update_view_3d_controller();
+	}
+}
+
+void Node3DEditorViewport::_set_lock_view_rotation(bool p_lock_rotation) {
+	view_3d_controller->set_lock_rotation(p_lock_rotation);
+	int idx = view_display_menu->get_popup()->get_item_index(VIEW_LOCK_ROTATION);
+	view_display_menu->get_popup()->set_item_checked(idx, p_lock_rotation);
+	if (p_lock_rotation) {
+		locked_label->show();
+	} else {
+		locked_label->hide();
+	}
+}
+
+void Node3DEditorViewport::_add_advanced_debug_draw_mode_item(PopupMenu *p_popup, const String &p_name, int p_value, SupportedRenderingMethods p_rendering_methods, const String &p_tooltip) {
+	display_submenu->add_radio_check_item(p_name, p_value);
+	Array item_data = { p_rendering_methods, p_tooltip };
+	display_submenu->set_item_metadata(-1, item_data); // Tooltip is assigned in NOTIFICATION_TRANSLATION_CHANGED.
+}
+
+void Node3DEditorViewport::_load_viewport_inputs() {
+	// Registering with Key::NONE intentionally creates an empty Array.
+	register_shortcut_action("spatial_editor/viewport_orbit_modifier_1", TTRC("Viewport Orbit Modifier 1"), Key::NONE);
+	register_shortcut_action("spatial_editor/viewport_orbit_modifier_2", TTRC("Viewport Orbit Modifier 2"), Key::NONE);
+	register_shortcut_action("spatial_editor/viewport_orbit_snap_modifier_1", TTRC("Viewport Orbit Snap Modifier 1"), Key::ALT);
+	register_shortcut_action("spatial_editor/viewport_orbit_snap_modifier_2", TTRC("Viewport Orbit Snap Modifier 2"), Key::NONE);
+	register_shortcut_action("spatial_editor/viewport_pan_modifier_1", TTRC("Viewport Pan Modifier 1"), Key::SHIFT);
+	register_shortcut_action("spatial_editor/viewport_pan_modifier_2", TTRC("Viewport Pan Modifier 2"), Key::NONE);
+	register_shortcut_action("spatial_editor/viewport_zoom_modifier_1", TTRC("Viewport Zoom Modifier 1"), Key::CTRL);
+	register_shortcut_action("spatial_editor/viewport_zoom_modifier_2", TTRC("Viewport Zoom Modifier 2"), Key::NONE);
+
+	register_shortcut_action("spatial_editor/freelook_left", TTRC("Freelook Left"), Key::A, true);
+	register_shortcut_action("spatial_editor/freelook_right", TTRC("Freelook Right"), Key::D, true);
+	register_shortcut_action("spatial_editor/freelook_forward", TTRC("Freelook Forward"), Key::W, true);
+	register_shortcut_action("spatial_editor/freelook_backwards", TTRC("Freelook Backwards"), Key::S, true);
+	register_shortcut_action("spatial_editor/freelook_up", TTRC("Freelook Up"), Key::E, true);
+	register_shortcut_action("spatial_editor/freelook_down", TTRC("Freelook Down"), Key::Q, true);
+	register_shortcut_action("spatial_editor/freelook_speed_modifier", TTRC("Freelook Speed Modifier"), Key::SHIFT);
+	register_shortcut_action("spatial_editor/freelook_slow_modifier", TTRC("Freelook Slow Modifier"), Key::ALT);
+}
+
+Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p_index) {
+	cpu_time_history_index = 0;
+	gpu_time_history_index = 0;
+
+	_edit.mode = TRANSFORM_NONE;
+	_edit.plane = TRANSFORM_VIEW;
+	_edit.show_rotation_line = true;
+	_edit.instant = false;
+	_edit.gizmo_handle = -1;
+	_edit.gizmo_handle_secondary = false;
+
+	index = p_index;
+	editor_selection = EditorNode::get_singleton()->get_editor_selection();
+	editor_selection->connect("selection_changed", callable_mp(this, &Node3DEditorViewport::_reset_follow_mode_count));
+
+	message_time = 0;
+	zoom_indicator_delay = 0.0;
+
+	spatial_editor = p_spatial_editor;
+	SubViewportContainer *c = memnew(SubViewportContainer);
+	subviewport_container = c;
+	c->set_stretch(true);
+	add_child(c);
+	c->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	viewport = memnew(SubViewport);
+	viewport->set_disable_input(true);
+
+	c->add_child(viewport);
+	surface = memnew(Control);
+	SET_DRAG_FORWARDING_CD(surface, Node3DEditorViewport);
+	add_child(surface);
+	surface->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	surface->set_clip_contents(true);
+	camera = memnew(Camera3D);
+	camera->set_disable_gizmos(true);
+	camera->set_cull_mask(((1 << 20) - 1) | (1 << (GIZMO_BASE_LAYER + p_index)) | (1 << GIZMO_EDIT_LAYER) | (1 << GIZMO_GRID_LAYER) | (1 << MISC_TOOL_LAYER));
+	viewport->add_child(camera);
+	camera->make_current();
+	surface->set_focus_mode(FOCUS_ALL);
+
+	VBoxContainer *vbox = memnew(VBoxContainer);
+	surface->add_child(vbox);
+	vbox->set_offset(SIDE_LEFT, 10 * EDSCALE);
+	vbox->set_offset(SIDE_TOP, 10 * EDSCALE);
+
+	HBoxContainer *hbox = memnew(HBoxContainer);
+	vbox->add_child(hbox);
+
+	view_display_menu = memnew(MenuButton);
+	view_display_menu->set_flat(false);
+	view_display_menu->set_h_size_flags(0);
+	view_display_menu->set_shortcut_context(this);
+	view_display_menu->set_accessibility_name(TTRC("View"));
+	view_display_menu->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	view_display_menu->get_popup()->set_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
+	hbox->add_child(view_display_menu);
+
+	view_display_menu->get_popup()->set_hide_on_checkable_item_selection(false);
+
+	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/top_view"), VIEW_TOP);
+	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/bottom_view"), VIEW_BOTTOM);
+	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/left_view"), VIEW_LEFT);
+	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/right_view"), VIEW_RIGHT);
+	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/front_view"), VIEW_FRONT);
+	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/rear_view"), VIEW_REAR);
+	view_display_menu->get_popup()->add_separator();
+	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/switch_perspective_orthogonal"), VIEW_SWITCH_PERSPECTIVE_ORTHOGONAL);
+	view_display_menu->get_popup()->add_radio_check_item(TTRC("Perspective"), VIEW_PERSPECTIVE);
+	view_display_menu->get_popup()->add_radio_check_item(TTRC("Orthogonal"), VIEW_ORTHOGONAL);
+	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_PERSPECTIVE), true);
+	view_display_menu->get_popup()->add_check_item(TTRC("Auto Orthogonal Enabled"), VIEW_AUTO_ORTHOGONAL);
+	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_AUTO_ORTHOGONAL), true);
+	view_display_menu->get_popup()->add_separator();
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_lock_rotation", TTRC("Lock View Rotation")), VIEW_LOCK_ROTATION);
+	view_display_menu->get_popup()->add_separator();
+	// TRANSLATORS: "Normal" as in "normal life", not "normal vector".
+	view_display_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_normal", TTRC("Display Normal")), VIEW_DISPLAY_NORMAL);
+	view_display_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_wireframe", TTRC("Display Wireframe")), VIEW_DISPLAY_WIREFRAME);
+	view_display_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_overdraw", TTRC("Display Overdraw")), VIEW_DISPLAY_OVERDRAW);
+	view_display_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_lighting", TTRC("Display Lighting")), VIEW_DISPLAY_LIGHTING);
+	view_display_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_unshaded", TTRC("Display Unshaded")), VIEW_DISPLAY_UNSHADED);
+	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_DISPLAY_NORMAL), true);
+
+	display_submenu = memnew(PopupMenu);
+	display_submenu->set_hide_on_checkable_item_selection(false);
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Directional Shadow Splits"), VIEW_DISPLAY_DEBUG_PSSM_SPLITS, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
+			TTRC("Displays directional shadow splits in different colors to make adjusting split thresholds easier. \nRed: 1st split (closest to the camera), Green: 2nd split, Blue: 3rd split, Yellow: 4th split (furthest from the camera)"));
+	display_submenu->add_separator();
+	// TRANSLATORS: "Normal" as in "normal vector", not "normal life".
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Normal Buffer"), VIEW_DISPLAY_NORMAL_BUFFER, SupportedRenderingMethods::FORWARD_PLUS);
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Shadow Atlas"), VIEW_DISPLAY_DEBUG_SHADOW_ATLAS, SupportedRenderingMethods::ALL,
+			TTRC("Displays the shadow atlas used for positional (omni/spot) shadow mapping.\nRequires a visible OmniLight3D or SpotLight3D node with shadows enabled to have a visible effect."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Directional Shadow Map"), VIEW_DISPLAY_DEBUG_DIRECTIONAL_SHADOW_ATLAS, SupportedRenderingMethods::ALL,
+			TTRC("Displays the shadow map used for directional shadow mapping.\nRequires a visible DirectionalLight3D node with shadows enabled to have a visible effect."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Decal Atlas"), VIEW_DISPLAY_DEBUG_DECAL_ATLAS, SupportedRenderingMethods::FORWARD_PLUS_MOBILE);
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("AreaLight3D Atlas"), VIEW_DISPLAY_DEBUG_AREA_LIGHT_ATLAS, SupportedRenderingMethods::FORWARD_PLUS_MOBILE);
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("VoxelGI Lighting"), VIEW_DISPLAY_DEBUG_VOXEL_GI_LIGHTING, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Requires a visible VoxelGI node that has been baked to have a visible effect."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("VoxelGI Albedo"), VIEW_DISPLAY_DEBUG_VOXEL_GI_ALBEDO, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Requires a visible VoxelGI node that has been baked to have a visible effect."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("VoxelGI Emission"), VIEW_DISPLAY_DEBUG_VOXEL_GI_EMISSION, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Requires a visible VoxelGI node that has been baked to have a visible effect."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SDFGI Cascades"), VIEW_DISPLAY_DEBUG_SDFGI, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Requires SDFGI to be enabled in Environment to have a visible effect."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SDFGI Probes"), VIEW_DISPLAY_DEBUG_SDFGI_PROBES, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Left-click a SDFGI probe to display its occlusion information (white = not occluded, red = fully occluded).\nRequires SDFGI to be enabled in Environment to have a visible effect."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Scene Luminance"), VIEW_DISPLAY_DEBUG_SCENE_LUMINANCE, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
+			TTRC("Displays the scene luminance computed from the 3D buffer. This is used for Auto Exposure calculation.\nRequires Auto Exposure to be enabled in CameraAttributes to have a visible effect."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SSAO"), VIEW_DISPLAY_DEBUG_SSAO, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Displays the screen-space ambient occlusion buffer. Requires SSAO to be enabled in Environment to have a visible effect."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SSIL"), VIEW_DISPLAY_DEBUG_SSIL, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Displays the screen-space indirect lighting buffer. Requires SSIL to be enabled in Environment to have a visible effect."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("VoxelGI/SDFGI Buffer"), VIEW_DISPLAY_DEBUG_GI_BUFFER, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Requires SDFGI or VoxelGI to be enabled to have a visible effect."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Disable Mesh LOD"), VIEW_DISPLAY_DEBUG_DISABLE_LOD, SupportedRenderingMethods::ALL,
+			TTRC("Renders all meshes with their highest level of detail regardless of their distance from the camera."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("OmniLight3D Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_OMNI_LIGHTS, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Highlights tiles of pixels that are affected by at least one OmniLight3D."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SpotLight3D Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_SPOT_LIGHTS, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Highlights tiles of pixels that are affected by at least one SpotLight3D."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("AreaLight3D Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_AREA_LIGHTS, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Highlights tiles of pixels that are affected by at least one AreaLight3D."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Decal Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_DECALS, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Highlights tiles of pixels that are affected by at least one Decal."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("ReflectionProbe Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_REFLECTION_PROBES, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Highlights tiles of pixels that are affected by at least one ReflectionProbe."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Occlusion Culling Buffer"), VIEW_DISPLAY_DEBUG_OCCLUDERS, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
+			TTRC("Represents occluders with black pixels. Requires occlusion culling to be enabled to have a visible effect."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Motion Vectors"), VIEW_DISPLAY_MOTION_VECTORS, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Represents motion vectors with colored lines in the direction of motion. Gray dots represent areas with no per-pixel motion."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Internal Buffer"), VIEW_DISPLAY_INTERNAL_BUFFER, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
+			TTRC("Shows the scene rendered in linear colorspace before any tonemapping or post-processing."));
+	view_display_menu->get_popup()->add_submenu_node_item(TTRC("Display Advanced..."), display_submenu, VIEW_DISPLAY_ADVANCED);
+
+	view_display_menu->get_popup()->add_separator();
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_environment", TTRC("View Environment")), VIEW_ENVIRONMENT);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_gizmos", TTRC("View Gizmos")), VIEW_GIZMOS);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_transform_gizmo", TTRC("View Transform Gizmo")), VIEW_TRANSFORM_GIZMO);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_grid_lines", TTRC("View Grid")), VIEW_GRID);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_information", TTRC("View Information")), VIEW_INFORMATION);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_fps", TTRC("View Frame Time")), VIEW_FRAME_TIME);
+	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_ENVIRONMENT), true);
+	view_display_menu->get_popup()->add_separator();
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_half_resolution", TTRC("Half Resolution")), VIEW_HALF_RESOLUTION);
+	view_display_menu->get_popup()->add_separator();
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_audio_listener", TTRC("Audio Listener")), VIEW_AUDIO_LISTENER);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_audio_doppler", TTRC("Enable Doppler")), VIEW_AUDIO_DOPPLER);
+	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_GIZMOS), true);
+	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_TRANSFORM_GIZMO), true);
+	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_GRID), true);
+
+	view_display_menu->get_popup()->add_separator();
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_cinematic_preview", TTRC("Cinematic Preview")), VIEW_CINEMATIC_PREVIEW);
+
+	view_display_menu->get_popup()->add_separator();
+	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_origin"), VIEW_CENTER_TO_ORIGIN);
+	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_selection"), VIEW_CENTER_TO_SELECTION);
+	view_display_menu->get_popup()->set_item_tooltip(-1, TTR("Press Focus Selection twice to start following the selection as it moves. Press it yet another time to stop following the selection."));
+	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_transform_with_view"), VIEW_ALIGN_TRANSFORM_WITH_VIEW);
+	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_rotation_with_view"), VIEW_ALIGN_ROTATION_WITH_VIEW);
+	view_display_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &Node3DEditorViewport::_menu_option));
+	display_submenu->connect(SceneStringName(id_pressed), callable_mp(this, &Node3DEditorViewport::_menu_option));
+	view_display_menu->set_disable_shortcuts(true);
+
+	_load_viewport_inputs();
+	InputMap::get_singleton()->connect("project_settings_loaded", callable_mp(this, &Node3DEditorViewport::_load_viewport_inputs));
+
+	ED_SHORTCUT("spatial_editor/lock_transform_x", TTRC("Lock Transformation to X axis"), Key::X);
+	ED_SHORTCUT("spatial_editor/lock_transform_y", TTRC("Lock Transformation to Y axis"), Key::Y);
+	ED_SHORTCUT("spatial_editor/lock_transform_z", TTRC("Lock Transformation to Z axis"), Key::Z);
+	ED_SHORTCUT("spatial_editor/lock_transform_yz", TTRC("Lock Transformation to YZ plane"), KeyModifierMask::SHIFT | Key::X);
+	ED_SHORTCUT("spatial_editor/lock_transform_xz", TTRC("Lock Transformation to XZ plane"), KeyModifierMask::SHIFT | Key::Y);
+	ED_SHORTCUT("spatial_editor/lock_transform_xy", TTRC("Lock Transformation to XY plane"), KeyModifierMask::SHIFT | Key::Z);
+	ED_SHORTCUT("spatial_editor/cancel_transform", TTRC("Cancel Transformation"), Key::ESCAPE);
+	ED_SHORTCUT("spatial_editor/instant_translate", TTRC("Begin Translate Transformation"));
+	ED_SHORTCUT("spatial_editor/instant_rotate", TTRC("Begin Rotate Transformation"));
+	ED_SHORTCUT("spatial_editor/instant_scale", TTRC("Begin Scale Transformation"));
+	ED_SHORTCUT("spatial_editor/collision_reposition", TTRC("Reposition Using Collisions"), KeyModifierMask::SHIFT | Key::G);
+	ED_SHORTCUT("spatial_editor/reset_transform_position", TTRC("Reset Position"), KeyModifierMask::ALT + Key::W);
+	ED_SHORTCUT("spatial_editor/reset_transform_rotation", TTRC("Reset Rotation"), KeyModifierMask::ALT + Key::E);
+	ED_SHORTCUT("spatial_editor/reset_transform_scale", TTRC("Reset Scale"), KeyModifierMask::ALT + Key::R);
+
+	translation_preview_button = memnew(EditorTranslationPreviewButton);
+	hbox->add_child(translation_preview_button);
+
+	follow_mode = memnew(Button);
+	follow_mode->set_tooltip_text(TTR("Click to stop following this node as it moves."));
+	follow_mode->hide();
+	vbox->add_child(follow_mode);
+	follow_mode->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditorViewport::_disable_follow_mode));
+
+	preview_camera = memnew(CheckBox);
+	preview_camera->set_text(TTRC("Preview"));
+	preview_camera->set_tooltip_text(TTRC("Preview through the selected camera.\nHold Shift while clicking to also enable Pilot mode."));
+	// Using Control even on macOS to avoid conflict with Quick Open shortcut.
+	preview_camera->set_shortcut(ED_SHORTCUT("spatial_editor/toggle_camera_preview", TTRC("Toggle Camera Preview"), KeyModifierMask::CTRL | Key::P));
+	vbox->add_child(preview_camera);
+	preview_camera->set_h_size_flags(0);
+	preview_camera->set_theme_type_variation("CheckBoxNoIconTint");
+	preview_camera->hide();
+	preview_camera->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+
+	pilot_camera = memnew(CheckBox);
+	pilot_camera->set_text(TTRC("Pilot"));
+	pilot_camera->set_tooltip_text(TTRC("Enable pilot mode for the preview camera.\nAllows WASD movement and mouse look when in preview mode."));
+	pilot_camera->set_shortcut(ED_SHORTCUT("spatial_editor/toggle_pilot_preview", TTRC("Toggle Pilot Mode in Preview")));
+	vbox->add_child(pilot_camera);
+	pilot_camera->set_h_size_flags(0);
+	pilot_camera->set_theme_type_variation("CheckBoxNoIconTint");
+	pilot_camera->hide();
+	pilot_camera->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditorViewport::_toggle_pilot_preview));
+	previewing = nullptr;
+	gizmo_scale = 1.0;
+
+	preview_node = nullptr;
+
+	bottom_center_vbox = memnew(VBoxContainer);
+	bottom_center_vbox->set_anchors_preset(LayoutPreset::PRESET_CENTER);
+	bottom_center_vbox->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -20 * EDSCALE);
+	bottom_center_vbox->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -10 * EDSCALE);
+	bottom_center_vbox->set_h_grow_direction(GROW_DIRECTION_BOTH);
+	bottom_center_vbox->set_v_grow_direction(GROW_DIRECTION_BEGIN);
+	surface->add_child(bottom_center_vbox);
+
+	info_panel = memnew(PanelContainer);
+	info_panel->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -90 * EDSCALE);
+	info_panel->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -90 * EDSCALE);
+	info_panel->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, -10 * EDSCALE);
+	info_panel->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -10 * EDSCALE);
+	info_panel->set_h_grow_direction(GROW_DIRECTION_BEGIN);
+	info_panel->set_v_grow_direction(GROW_DIRECTION_BEGIN);
+	info_panel->set_mouse_filter(MOUSE_FILTER_IGNORE);
+	surface->add_child(info_panel);
+	info_panel->hide();
+
+	info_label = memnew(Label);
+	info_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+	info_panel->add_child(info_label);
+
+	cinema_label = memnew(Label);
+	cinema_label->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, 10 * EDSCALE);
+	cinema_label->set_h_grow_direction(GROW_DIRECTION_END);
+	cinema_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	cinema_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	surface->add_child(cinema_label);
+	cinema_label->set_text(TTRC("Cinematic Preview"));
+	cinema_label->hide();
+	previewing_cinema = false;
+
+	locked_label = memnew(Label);
+	locked_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	locked_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	locked_label->set_h_size_flags(SIZE_SHRINK_CENTER);
+	bottom_center_vbox->add_child(locked_label);
+	locked_label->set_text(TTRC("View Rotation Locked"));
+	locked_label->hide();
+
+	zoom_limit_label = memnew(Label);
+	zoom_limit_label->set_text(TTRC(U"To zoom further, change the camera's clipping planes (View → Settings...)"));
+	zoom_limit_label->set_name("ZoomLimitMessageLabel");
+	zoom_limit_label->add_theme_color_override(SceneStringName(font_color), Color(1, 1, 1, 1));
+	zoom_limit_label->hide();
+	bottom_center_vbox->add_child(zoom_limit_label);
+
+	tooltip_panel = memnew(RichTextLabel);
+	vbox->add_child(tooltip_panel);
+	tooltip_panel->hide();
+	tooltip_panel->set_h_grow_direction(GROW_DIRECTION_BEGIN);
+	tooltip_panel->set_v_grow_direction(GROW_DIRECTION_BEGIN);
+	tooltip_panel->set_mouse_filter(MOUSE_FILTER_IGNORE);
+	tooltip_panel->set_focus_mode(FOCUS_ACCESSIBILITY);
+	tooltip_panel->set_use_bbcode(true);
+	tooltip_panel->set_fit_content(true);
+	tooltip_panel->set_scroll_active(false);
+	tooltip_panel->set_tab_size(1);
+	tooltip_panel->set_autowrap_mode(TextServer::AUTOWRAP_OFF);
+	tooltip_panel->set_anchors_and_offsets_preset(LayoutPreset::PRESET_TOP_LEFT);
+	tooltip_panel->add_theme_color_override(SceneStringName(font_color), Color(0.8f, 0.8f, 0.8f, 1));
+	tooltip_panel->add_theme_constant_override("paragraph_separation", 5);
+
+	frame_time_gradient = memnew(Gradient);
+	// The color is set when the theme changes.
+	frame_time_gradient->add_point(0.5, Color());
+
+	top_right_vbox = memnew(VBoxContainer);
+	top_right_vbox->add_theme_constant_override("separation", 10.0 * EDSCALE);
+	top_right_vbox->set_anchors_and_offsets_preset(PRESET_TOP_RIGHT, PRESET_MODE_MINSIZE, 10.0 * EDSCALE);
+	top_right_vbox->set_h_grow_direction(GROW_DIRECTION_BEGIN);
+
+	const int navigation_control_size = 150;
+
+	position_control = memnew(ViewportNavigationControl);
+	position_control->set_navigation_mode(View3DController::NAV_MODE_MOVE);
+	position_control->set_custom_minimum_size(Size2(navigation_control_size, navigation_control_size) * EDSCALE);
+	position_control->set_h_size_flags(SIZE_SHRINK_END);
+	position_control->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, 0);
+	position_control->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -navigation_control_size * EDSCALE);
+	position_control->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_BEGIN, navigation_control_size * EDSCALE);
+	position_control->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, 0);
+	position_control->set_viewport(this);
+	surface->add_child(position_control);
+
+	look_control = memnew(ViewportNavigationControl);
+	look_control->set_navigation_mode(View3DController::NAV_MODE_LOOK);
+	look_control->set_custom_minimum_size(Size2(navigation_control_size, navigation_control_size) * EDSCALE);
+	look_control->set_h_size_flags(SIZE_SHRINK_END);
+	look_control->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -navigation_control_size * EDSCALE);
+	look_control->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -navigation_control_size * EDSCALE);
+	look_control->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, 0);
+	look_control->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, 0);
+	look_control->set_viewport(this);
+	surface->add_child(look_control);
+
+	rotation_control = memnew(ViewportRotationControl);
+	rotation_control->set_custom_minimum_size(Size2(80, 80) * EDSCALE);
+	rotation_control->set_h_size_flags(SIZE_SHRINK_END);
+	rotation_control->set_viewport(this);
+	rotation_control->set_focus_mode(FOCUS_CLICK);
+	top_right_vbox->add_child(rotation_control);
+
+	frame_time_panel = memnew(PanelContainer);
+	frame_time_panel->set_mouse_filter(MOUSE_FILTER_IGNORE);
+	top_right_vbox->add_child(frame_time_panel);
+	frame_time_panel->hide();
+
+	frame_time_vbox = memnew(VBoxContainer);
+	frame_time_panel->add_child(frame_time_vbox);
+
+	// Individual Labels are used to allow coloring each label with its own color.
+	cpu_time_label = memnew(Label);
+	frame_time_vbox->add_child(cpu_time_label);
+
+	gpu_time_label = memnew(Label);
+	frame_time_vbox->add_child(gpu_time_label);
+
+	fps_label = memnew(Label);
+	frame_time_vbox->add_child(fps_label);
+
+	surface->add_child(top_right_vbox);
+
+	accept = nullptr;
+
+	selection_menu = memnew(PopupMenu);
+	add_child(selection_menu);
+	selection_menu->set_min_size(Size2(100, 0) * EDSCALE);
+	selection_menu->connect(SceneStringName(id_pressed), callable_mp(this, &Node3DEditorViewport::_selection_result_pressed));
+	selection_menu->connect("popup_hide", callable_mp(this, &Node3DEditorViewport::_selection_menu_hide));
+
+	if (p_index == 0) {
+		view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_AUDIO_LISTENER), true);
+		viewport->set_as_audio_listener_3d(true);
+	}
+
+	ruler = memnew(Node);
+
+	ruler_start_point = memnew(Node3D);
+	ruler_start_point->set_visible(false);
+
+	ruler_end_point = memnew(Node3D);
+	ruler_end_point->set_visible(false);
+
+	ruler_material.instantiate();
+	ruler_material->set_albedo(Color(1.0, 0.9, 0.0, 1.0));
+	ruler_material->set_flag(BaseMaterial3D::FLAG_DISABLE_FOG, true);
+	ruler_material->set_shading_mode(BaseMaterial3D::SHADING_MODE_UNSHADED);
+	ruler_material->set_depth_draw_mode(BaseMaterial3D::DEPTH_DRAW_DISABLED);
+
+	ruler_material_xray.instantiate();
+	ruler_material_xray->set_albedo(Color(1.0, 0.9, 0.0, 0.15));
+	ruler_material_xray->set_flag(BaseMaterial3D::FLAG_DISABLE_FOG, true);
+	ruler_material_xray->set_shading_mode(BaseMaterial3D::SHADING_MODE_UNSHADED);
+	ruler_material_xray->set_flag(BaseMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+	ruler_material_xray->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA);
+	ruler_material_xray->set_render_priority(BaseMaterial3D::RENDER_PRIORITY_MAX);
+
+	geometry.instantiate();
+
+	geometry_xray.instantiate();
+
+	ruler_line = memnew(MeshInstance3D);
+	ruler_line->set_mesh(geometry);
+	ruler_line->set_material_override(ruler_material);
+
+	ruler_line_xray = memnew(MeshInstance3D);
+	ruler_line_xray->set_mesh(geometry_xray);
+	ruler_line_xray->set_material_override(ruler_material_xray);
+
+	ruler_triangle_material.instantiate();
+	ruler_triangle_material->set_albedo(Color(1.0, 1.0, 1.0, 1.0));
+	ruler_triangle_material->set_flag(BaseMaterial3D::FLAG_DISABLE_FOG, true);
+	ruler_triangle_material->set_shading_mode(BaseMaterial3D::SHADING_MODE_UNSHADED);
+	ruler_triangle_material->set_depth_draw_mode(BaseMaterial3D::DEPTH_DRAW_DISABLED);
+	ruler_triangle_material->set_flag(BaseMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
+
+	ruler_triangle_material_xray.instantiate();
+	ruler_triangle_material_xray->set_albedo(Color(1.0, 1.0, 1.0, 0.15));
+	ruler_triangle_material_xray->set_flag(BaseMaterial3D::FLAG_DISABLE_FOG, true);
+	ruler_triangle_material_xray->set_shading_mode(BaseMaterial3D::SHADING_MODE_UNSHADED);
+	ruler_triangle_material_xray->set_flag(BaseMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+	ruler_triangle_material_xray->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA);
+	ruler_triangle_material_xray->set_render_priority(BaseMaterial3D::RENDER_PRIORITY_MAX);
+	ruler_triangle_material_xray->set_flag(BaseMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
+
+	ruler_triangle_lines = memnew(MeshInstance3D);
+	Ref<ImmediateMesh> triangle_mesh;
+	triangle_mesh.instantiate();
+	ruler_triangle_lines->set_mesh(triangle_mesh);
+	ruler_triangle_lines->set_material_override(ruler_triangle_material);
+
+	ruler_triangle_lines_xray = memnew(MeshInstance3D);
+	Ref<ImmediateMesh> triangle_mesh_xray;
+	triangle_mesh_xray.instantiate();
+	ruler_triangle_lines_xray->set_mesh(triangle_mesh_xray);
+	ruler_triangle_lines_xray->set_material_override(ruler_triangle_material_xray);
+
+	ruler_label = memnew(Label);
+	ruler_label->set_visible(false);
+
+	ruler_label_x = memnew(Label);
+	ruler_label_x->set_visible(false);
+
+	ruler_label_y = memnew(Label);
+	ruler_label_y->set_visible(false);
+
+	ruler_label_z = memnew(Label);
+	ruler_label_z->set_visible(false);
+
+	ruler->add_child(ruler_start_point);
+	ruler->add_child(ruler_end_point);
+	ruler->add_child(ruler_line);
+	ruler->add_child(ruler_line_xray);
+	ruler->add_child(ruler_triangle_lines);
+	ruler->add_child(ruler_triangle_lines_xray);
+
+	viewport->add_child(ruler_label);
+	viewport->add_child(ruler_label_x);
+	viewport->add_child(ruler_label_y);
+	viewport->add_child(ruler_label_z);
+
+	view_3d_controller.instantiate();
+	view_3d_controller->connect("view_state_changed", callable_mp(this, &Node3DEditorViewport::_view_state_changed));
+	view_3d_controller->connect("fov_scaled", callable_mp((CanvasItem *)surface, &CanvasItem::queue_redraw));
+	view_3d_controller->connect("freelook_changed", callable_mp(this, &Node3DEditorViewport::_freelook_changed));
+	view_3d_controller->connect("freelook_speed_scaled", callable_mp(this, &Node3DEditorViewport::_freelook_speed_scaled));
+	view_3d_controller->connect("cursor_panned", callable_mp(this, &Node3DEditorViewport::_disable_follow_mode));
+	view_3d_controller->connect("cursor_interpolated", callable_mp(this, &Node3DEditorViewport::_cursor_interpolated));
+	view_3d_controller->connect("cursor_distance_scaled", callable_mp(this, &Node3DEditorViewport::_cursor_distance_scaled));
+	_update_view_3d_controller(true);
+
+	_update_name();
+
+	EditorNode::get_singleton()->register_hdr_viewport(viewport);
+}
+
+Node3DEditorViewport::~Node3DEditorViewport() {
+	memdelete(ruler);
+}
+
+//////////////////////////////////////////////////////////////
+
+void Node3DEditorViewportContainer::_update_split_drag_margin() {
+	if (view != VIEW_USE_4_VIEWPORTS && view != VIEW_USE_3_VIEWPORTS) {
+		return;
+	}
+	// Also for 3 viewports view since the first split container is used to remember the offset.
+	first_split->set_split_offset(second_split->get_split_offset());
+
+	if (view == VIEW_USE_4_VIEWPORTS) {
+		// Extend to cover the first split on top.
+		second_split->set_drag_area_margin_begin(second_split->get_size().y - get_size().y);
+	}
+}
+
+void Node3DEditorViewportContainer::_notification(int p_what) {
+	switch (p_what) {
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			if (!EditorSettings::get_singleton()->check_changed_settings_in_group("interface/touchscreen")) {
+				return;
+			}
+			[[fallthrough]];
+		}
+		case NOTIFICATION_READY: {
+			bool touch_optimizations = EDITOR_GET("interface/touchscreen/enable_touch_optimizations");
+			main_split->set_touch_dragger_enabled(touch_optimizations);
+			first_split->set_touch_dragger_enabled(touch_optimizations);
+			second_split->set_touch_dragger_enabled(touch_optimizations);
+		} break;
+	}
+}
+
+void Node3DEditorViewportContainer::set_view(View p_view) {
+	view = p_view;
+
+	Node3DEditorViewport *viewports[4];
+	for (uint32_t i = 0; i < 4; i++) {
+		viewports[i] = Node3DEditor::get_singleton()->get_editor_viewport(i);
+		ERR_FAIL_NULL(viewports[i]);
+	}
+
+	const bool previous_main_vertical = !first_split->is_vertical();
+	const float horizontal_offset = previous_main_vertical ? first_split->get_split_offset() : main_split->get_split_offset();
+	const float vertical_offset = previous_main_vertical ? main_split->get_split_offset() : first_split->get_split_offset();
+
+	first_split->set_dragging_enabled(true);
+	second_split->set_drag_area_margin_begin(0);
+	viewports[0]->show();
+
+	switch (view) {
+		case VIEW_USE_1_VIEWPORT: {
+			for (int i = 1; i < 4; i++) {
+				viewports[i]->hide();
+			}
+			second_split->hide();
+		} break;
+		case VIEW_USE_2_VIEWPORTS:
+		case VIEW_USE_2_VIEWPORTS_ALT: {
+			viewports[1]->show();
+			viewports[2]->hide();
+			viewports[3]->hide();
+			second_split->hide();
+			const bool is_vertical = view == VIEW_USE_2_VIEWPORTS;
+			if (first_split->is_vertical() != is_vertical) {
+				first_split->set_vertical(is_vertical);
+				first_split->set_split_offset(is_vertical ? vertical_offset : horizontal_offset);
+				main_split->set_split_offset(is_vertical ? horizontal_offset : vertical_offset); // Store the other offset here for later.
+			}
+		} break;
+		case VIEW_USE_3_VIEWPORTS:
+		case VIEW_USE_3_VIEWPORTS_ALT: {
+			// Default mode has two on bottom (second_split). Alt mode has two on the left (first_split).
+			const bool main_vertical = view == VIEW_USE_3_VIEWPORTS;
+			viewports[1]->set_visible(!main_vertical);
+			viewports[2]->show();
+			viewports[3]->set_visible(main_vertical);
+			second_split->show();
+			main_split->set_vertical(main_vertical);
+			main_split->set_split_offset(main_vertical ? vertical_offset : horizontal_offset);
+			first_split->set_vertical(!main_vertical);
+			first_split->set_split_offset(main_vertical ? horizontal_offset : vertical_offset);
+			second_split->set_split_offset(main_vertical ? horizontal_offset : vertical_offset);
+		} break;
+		case VIEW_USE_4_VIEWPORTS: {
+			for (int i = 1; i < 4; i++) {
+				viewports[i]->show();
+			}
+			second_split->show();
+			main_split->set_vertical(true);
+			main_split->set_split_offset(vertical_offset);
+			first_split->set_vertical(false);
+			first_split->set_split_offset(horizontal_offset);
+			second_split->set_split_offset(horizontal_offset);
+
+			first_split->set_dragging_enabled(false);
+			_update_split_drag_margin();
+		} break;
+	}
+}
+
+Node3DEditorViewportContainer::View Node3DEditorViewportContainer::get_view() {
+	return view;
+}
+
+void Node3DEditorViewportContainer::add_viewport(Node3DEditorViewport *p_viewport, int p_index) {
+	if (p_index <= 1) {
+		first_split->add_child(p_viewport);
+	} else {
+		second_split->add_child(p_viewport);
+		if (p_index == 3) {
+			// Connect to the second split's child to update the drag margin immediately whenever the split offset changes.
+			p_viewport->connect(SceneStringName(resized), callable_mp(this, &Node3DEditorViewportContainer::_update_split_drag_margin));
+		}
+	}
+}
+
+Dictionary Node3DEditorViewportContainer::get_split_state() const {
+	Dictionary state;
+	state["main"] = Math::round(main_split->get_split_offset() / EDSCALE);
+	state["first"] = Math::round(first_split->get_split_offset() / EDSCALE);
+	state["second"] = Math::round(second_split->get_split_offset() / EDSCALE);
+	return state;
+}
+
+void Node3DEditorViewportContainer::set_split_state(const Dictionary &p_state) {
+	if (p_state.has("main")) {
+		main_split->set_split_offset(int(p_state["main"]) * EDSCALE);
+	}
+	if (p_state.has("first")) {
+		first_split->set_split_offset(int(p_state["first"]) * EDSCALE);
+	}
+	if (p_state.has("second")) {
+		second_split->set_split_offset(int(p_state["second"]) * EDSCALE);
+	}
+}
+
+Node3DEditorViewportContainer::Node3DEditorViewportContainer() {
+	set_clip_contents(true);
+
+	main_split = memnew(SplitContainer);
+	main_split->set_drag_nested_intersections(true);
+
+	first_split = memnew(SplitContainer);
+	first_split->set_h_size_flags(SIZE_EXPAND_FILL);
+	first_split->set_v_size_flags(SIZE_EXPAND_FILL);
+	first_split->set_drag_nested_intersections(true);
+
+	second_split = memnew(SplitContainer);
+	second_split->set_h_size_flags(SIZE_EXPAND_FILL);
+	second_split->set_v_size_flags(SIZE_EXPAND_FILL);
+	second_split->set_drag_nested_intersections(true);
+
+	main_split->add_child(first_split);
+	main_split->add_child(second_split);
+	add_child(main_split);
+}
 
 ///////////////////////////////////////////////////////////////////
 
@@ -2151,6 +9327,7 @@ HashSet<T *> _get_child_nodes(Node *parent_node) {
 	return nodes;
 }
 
+#ifndef PHYSICS_3D_DISABLED
 HashSet<RID> _get_physics_bodies_rid(Node *node) {
 	HashSet<RID> rids = HashSet<RID>();
 	PhysicsBody3D *pb = Node::cast_to<PhysicsBody3D>(node);
@@ -2164,11 +9341,13 @@ HashSet<RID> _get_physics_bodies_rid(Node *node) {
 
 	return rids;
 }
+#endif // PHYSICS_3D_DISABLED
 
 void Node3DEditor::snap_selected_nodes_to_floor() {
 	do_snap_selected_nodes_to_floor = true;
 }
 
+#ifndef PHYSICS_3D_DISABLED
 void Node3DEditor::_snap_selected_nodes_to_floor() {
 	const List<Node *> &selection = editor_selection->get_top_selected_node_list();
 	Dictionary snap_data;
@@ -2300,6 +9479,7 @@ void Node3DEditor::_snap_selected_nodes_to_floor() {
 		}
 	}
 }
+#endif // PHYSICS_3D_DISABLED
 
 void Node3DEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
@@ -2686,12 +9866,14 @@ void Node3DEditor::_notification(int p_what) {
 			_update_vertex_snap_tooltips();
 		} break;
 
+#ifndef PHYSICS_3D_DISABLED
 		case NOTIFICATION_PHYSICS_PROCESS: {
 			if (do_snap_selected_nodes_to_floor) {
 				_snap_selected_nodes_to_floor();
 				do_snap_selected_nodes_to_floor = false;
 			}
 		}
+#endif // PHYSICS_3D_DISABLED
 	}
 }
 
@@ -3048,9 +10230,9 @@ void Node3DEditor::_register_all_gizmos() {
 	add_gizmo_plugin(Ref<LightmapGIGizmoPlugin>(memnew(LightmapGIGizmoPlugin)));
 	add_gizmo_plugin(Ref<LightmapProbeGizmoPlugin>(memnew(LightmapProbeGizmoPlugin)));
 	add_gizmo_plugin(Ref<FogVolumeGizmoPlugin>(memnew(FogVolumeGizmoPlugin)));
+#ifndef PHYSICS_3D_DISABLED
 	add_gizmo_plugin(Ref<TwoBoneIK3DGizmoPlugin>(memnew(TwoBoneIK3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<ChainIK3DGizmoPlugin>(memnew(ChainIK3DGizmoPlugin)));
-	// Physics gizmo plugins.
 	add_gizmo_plugin(Ref<CollisionObject3DGizmoPlugin>(memnew(CollisionObject3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<CollisionShape3DGizmoPlugin>(memnew(CollisionShape3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<CollisionPolygon3DGizmoPlugin>(memnew(CollisionPolygon3DGizmoPlugin)));
@@ -3061,6 +10243,7 @@ void Node3DEditor::_register_all_gizmos() {
 	add_gizmo_plugin(Ref<PhysicalBone3DGizmoPlugin>(memnew(PhysicalBone3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<VehicleWheel3DGizmoPlugin>(memnew(VehicleWheel3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<RayCast3DGizmoPlugin>(memnew(RayCast3DGizmoPlugin)));
+#endif // PHYSICS_3D_DISABLED
 }
 
 void Node3DEditor::_bind_methods() {

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -835,8 +835,10 @@ private:
 	void _selection_changed();
 	void _refresh_menu_icons();
 
+#ifndef PHYSICS_3D_DISABLED
 	bool do_snap_selected_nodes_to_floor = false;
 	void _snap_selected_nodes_to_floor();
+#endif // PHYSICS_3D_DISABLED
 
 	// Preview Sun and Environment
 

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -310,8 +310,10 @@ private:
 	void _selection_changed();
 	void _refresh_menu_icons();
 
+#ifndef PHYSICS_3D_DISABLED
 	bool do_snap_selected_nodes_to_floor = false;
 	void _snap_selected_nodes_to_floor();
+#endif // PHYSICS_3D_DISABLED
 
 	// Preview Sun and Environment
 

--- a/editor/scene/3d/root_motion_editor_plugin.cpp
+++ b/editor/scene/3d/root_motion_editor_plugin.cpp
@@ -33,11 +33,14 @@
 #include "core/object/callable_mp.h"
 #include "editor/editor_node.h"
 #include "editor/themes/editor_scale.h"
-#include "scene/3d/skeleton_3d.h"
 #include "scene/animation/animation_mixer.h"
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/tree.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/skeleton_3d.h"
+#endif // _3D_DISABLED
 
 void EditorPropertyRootMotion::_confirmed() {
 	TreeItem *ti = filters->get_selected();
@@ -122,6 +125,7 @@ void EditorPropertyRootMotion::_node_assign() {
 			continue; //no node, can't edit
 		}
 
+#ifndef _3D_DISABLED
 		Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(node);
 		if (skeleton) {
 			HashMap<int, TreeItem *> items;
@@ -151,6 +155,7 @@ void EditorPropertyRootMotion::_node_assign() {
 				joint_item->set_collapsed(true);
 			}
 		}
+#endif // _3D_DISABLED
 	}
 
 	filters->ensure_cursor_is_visible();

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -44,15 +44,18 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/3d/mesh_instance_3d.h"
-#include "scene/3d/physics/collision_shape_3d.h"
-#include "scene/3d/physics/physical_bone_3d.h"
-#include "scene/3d/physics/physical_bone_simulator_3d.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/main/scene_tree.h"
-#include "scene/resources/3d/capsule_shape_3d.h"
 #include "scene/resources/skeleton_profile.h"
 #include "scene/resources/surface_tool.h"
+
+#ifndef PHYSICS_3D_DISABLED
+#include "scene/3d/physics/collision_shape_3d.h"
+#include "scene/3d/physics/physical_bone_3d.h"
+#include "scene/3d/physics/physical_bone_simulator_3d.h"
+#include "scene/resources/3d/capsule_shape_3d.h"
+#endif // PHYSICS_3D_DISABLED
 
 void BonePropertiesEditor::create_editors() {
 	section = memnew(EditorInspectorSection);
@@ -418,10 +421,12 @@ void Skeleton3DEditor::_on_click_skeleton_option(int p_skeleton_option) {
 			pose_to_rest(false);
 			break;
 		}
+#ifndef PHYSICS_3D_DISABLED
 		case SKELETON_OPTION_CREATE_PHYSICAL_SKELETON: {
 			create_physical_skeleton();
 			break;
 		}
+#endif // PHYSICS_3D_DISABLED
 		case SKELETON_OPTION_EXPORT_SKELETON_PROFILE: {
 			export_skeleton_profile();
 			break;
@@ -554,6 +559,7 @@ void Skeleton3DEditor::pose_to_rest(const bool p_all_bones) {
 	ur->commit_action();
 }
 
+#ifndef PHYSICS_3D_DISABLED
 void Skeleton3DEditor::create_physical_skeleton() {
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	ERR_FAIL_NULL(get_tree());
@@ -658,6 +664,7 @@ PhysicalBone3D *Skeleton3DEditor::create_physical_bone(int bone_id, int bone_chi
 	physical_bone->set_joint_offset(joint_transform);
 	return physical_bone;
 }
+#endif // PHYSICS_3D_DISABLED
 
 void Skeleton3DEditor::export_skeleton_profile() {
 	if (!skeleton->get_bone_count()) {
@@ -1085,7 +1092,9 @@ void Skeleton3DEditor::create_editors() {
 	p->add_shortcut(ED_SHORTCUT("skeleton_3d_editor/reset_selected_poses", TTRC("Reset Selected Poses")), SKELETON_OPTION_RESET_SELECTED_POSES);
 	p->add_shortcut(ED_SHORTCUT("skeleton_3d_editor/all_poses_to_rests", TTRC("Apply All Poses to Rests")), SKELETON_OPTION_ALL_POSES_TO_RESTS);
 	p->add_shortcut(ED_SHORTCUT("skeleton_3d_editor/selected_poses_to_rests", TTRC("Apply Selected Poses to Rests")), SKELETON_OPTION_SELECTED_POSES_TO_RESTS);
+#ifndef PHYSICS_3D_DISABLED
 	p->add_item(TTR("Create Physical Skeleton"), SKELETON_OPTION_CREATE_PHYSICAL_SKELETON);
+#endif // PHYSICS_3D_DISABLED
 	p->add_item(TTR("Export Skeleton Profile"), SKELETON_OPTION_EXPORT_SKELETON_PROFILE);
 
 	p->connect(SceneStringName(id_pressed), callable_mp(this, &Skeleton3DEditor::_on_click_skeleton_option));

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -44,15 +44,18 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/3d/mesh_instance_3d.h"
-#include "scene/3d/physics/collision_shape_3d.h"
-#include "scene/3d/physics/physical_bone_3d.h"
-#include "scene/3d/physics/physical_bone_simulator_3d.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/main/scene_tree.h"
-#include "scene/resources/3d/capsule_shape_3d.h"
 #include "scene/resources/skeleton_profile.h"
 #include "scene/resources/surface_tool.h"
+
+#ifndef PHYSICS_3D_DISABLED
+#include "scene/3d/physics/collision_shape_3d.h"
+#include "scene/3d/physics/physical_bone_3d.h"
+#include "scene/3d/physics/physical_bone_simulator_3d.h"
+#include "scene/resources/3d/capsule_shape_3d.h"
+#endif // PHYSICS_3D_DISABLED
 
 void BonePropertiesEditor::create_editors() {
 	section = memnew(EditorInspectorSection);
@@ -445,9 +448,11 @@ void Skeleton3DEditor::_on_click_skeleton_option(int p_skeleton_option) {
 		case SKELETON_OPTION_SELECTED_POSES_TO_RESTS: {
 			pose_to_rest(false);
 		} break;
+#ifndef PHYSICS_3D_DISABLED
 		case SKELETON_OPTION_CREATE_PHYSICAL_SKELETON: {
 			create_physical_skeleton();
 		} break;
+#endif // PHYSICS_3D_DISABLED
 		case SKELETON_OPTION_EXPORT_SKELETON_PROFILE: {
 			export_skeleton_profile();
 		} break;
@@ -583,6 +588,7 @@ void Skeleton3DEditor::pose_to_rest(const bool p_all_bones) {
 	ur->commit_action();
 }
 
+#ifndef PHYSICS_3D_DISABLED
 void Skeleton3DEditor::create_physical_skeleton() {
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	ERR_FAIL_NULL(get_tree());
@@ -687,6 +693,7 @@ PhysicalBone3D *Skeleton3DEditor::create_physical_bone(int bone_id, int bone_chi
 	physical_bone->set_joint_offset(joint_transform);
 	return physical_bone;
 }
+#endif // PHYSICS_3D_DISABLED
 
 void Skeleton3DEditor::export_skeleton_profile() {
 	if (!skeleton->get_bone_count()) {
@@ -1133,7 +1140,9 @@ void Skeleton3DEditor::create_editors() {
 	p->add_shortcut(ED_SHORTCUT("skeleton_3d_editor/reset_selected_poses_and_skin_scales", TTRC("Reset Selected Poses & Skin Scales")), SKELETON_OPTION_RESET_SELECTED_POSES_AND_SKIN_SCALES);
 	p->add_shortcut(ED_SHORTCUT("skeleton_3d_editor/all_poses_to_rests", TTRC("Apply All Poses to Rests")), SKELETON_OPTION_ALL_POSES_TO_RESTS);
 	p->add_shortcut(ED_SHORTCUT("skeleton_3d_editor/selected_poses_to_rests", TTRC("Apply Selected Poses to Rests")), SKELETON_OPTION_SELECTED_POSES_TO_RESTS);
+#ifndef PHYSICS_3D_DISABLED
 	p->add_item(TTR("Create Physical Skeleton"), SKELETON_OPTION_CREATE_PHYSICAL_SKELETON);
+#endif // PHYSICS_3D_DISABLED
 	p->add_item(TTR("Export Skeleton Profile"), SKELETON_OPTION_EXPORT_SKELETON_PROFILE);
 
 	p->connect(SceneStringName(id_pressed), callable_mp(this, &Skeleton3DEditor::_on_click_skeleton_option));

--- a/editor/scene/3d/skeleton_3d_editor_plugin.h
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.h
@@ -43,7 +43,9 @@
 class EditorInspectorPluginSkeleton;
 class EditorPropertyVector3;
 class Joint;
+#ifndef PHYSICS_3D_DISABLED
 class PhysicalBone3D;
+#endif // PHYSICS_3D_DISABLED
 class Skeleton3DEditorPlugin;
 class Button;
 class Tree;
@@ -116,12 +118,16 @@ class Skeleton3DEditor : public VBoxContainer {
 		SKELETON_OPTION_RESET_SELECTED_POSES,
 		SKELETON_OPTION_ALL_POSES_TO_RESTS,
 		SKELETON_OPTION_SELECTED_POSES_TO_RESTS,
+#ifndef PHYSICS_3D_DISABLED
 		SKELETON_OPTION_CREATE_PHYSICAL_SKELETON,
+#endif
 		SKELETON_OPTION_EXPORT_SKELETON_PROFILE,
 	};
 
 	struct BoneInfo {
+#ifndef PHYSICS_3D_DISABLED
 		PhysicalBone3D *physical_bone = nullptr;
+#endif // PHYSICS_3D_DISABLED
 		Transform3D relative_rest; // Relative to skeleton node.
 	};
 
@@ -183,8 +189,10 @@ class Skeleton3DEditor : public VBoxContainer {
 	void _insert_keys(const bool p_all_bones);
 	void insert_keys(const bool p_all_bones, const bool p_enable_modifier);
 
+#ifndef PHYSICS_3D_DISABLED
 	void create_physical_skeleton();
 	PhysicalBone3D *create_physical_bone(int bone_id, int bone_child_id, const Vector<BoneInfo> &bones_infos);
+#endif // PHYSICS_3D_DISABLED
 
 	void export_skeleton_profile();
 

--- a/editor/scene/3d/skeleton_3d_editor_plugin.h
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.h
@@ -43,7 +43,9 @@
 class EditorInspectorPluginSkeleton;
 class EditorPropertyVector3;
 class Joint;
+#ifndef PHYSICS_3D_DISABLED
 class PhysicalBone3D;
+#endif // PHYSICS_3D_DISABLED
 class Skeleton3DEditorPlugin;
 class Button;
 class Tree;
@@ -119,12 +121,16 @@ class Skeleton3DEditor : public VBoxContainer {
 		SKELETON_OPTION_RESET_SELECTED_POSES_AND_SKIN_SCALES,
 		SKELETON_OPTION_ALL_POSES_TO_RESTS,
 		SKELETON_OPTION_SELECTED_POSES_TO_RESTS,
+#ifndef PHYSICS_3D_DISABLED
 		SKELETON_OPTION_CREATE_PHYSICAL_SKELETON,
+#endif
 		SKELETON_OPTION_EXPORT_SKELETON_PROFILE,
 	};
 
 	struct BoneInfo {
+#ifndef PHYSICS_3D_DISABLED
 		PhysicalBone3D *physical_bone = nullptr;
+#endif // PHYSICS_3D_DISABLED
 		Transform3D relative_rest; // Relative to skeleton node.
 	};
 
@@ -186,8 +192,10 @@ class Skeleton3DEditor : public VBoxContainer {
 	void _insert_keys(const bool p_all_bones);
 	void insert_keys(const bool p_all_bones, const bool p_enable_modifier);
 
+#ifndef PHYSICS_3D_DISABLED
 	void create_physical_skeleton();
 	PhysicalBone3D *create_physical_bone(int bone_id, int bone_child_id, const Vector<BoneInfo> &bones_infos);
+#endif // PHYSICS_3D_DISABLED
 
 	void export_skeleton_profile();
 

--- a/editor/scene/SCsub
+++ b/editor/scene/SCsub
@@ -6,6 +6,7 @@ Import("env")
 env.add_source_files(env.editor_sources, "*.cpp")
 
 SConscript("2d/SCsub")
-SConscript("3d/SCsub")
+if not env["disable_3d"]:
+    SConscript("3d/SCsub")
 SConscript("gui/SCsub")
 SConscript("texture/SCsub")

--- a/editor/scene/gradient_editor_plugin.cpp
+++ b/editor/scene/gradient_editor_plugin.cpp
@@ -38,7 +38,6 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_spin_slider.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
@@ -47,6 +46,10 @@
 #include "scene/gui/popup.h"
 #include "scene/gui/separator.h"
 #include "scene/resources/gradient_texture.h"
+
+#ifndef _3D_DISABLED
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#endif // _3D_DISABLED
 
 int GradientEdit::_get_point_at(int p_xpos) const {
 	int result = -1;

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -30,29 +30,30 @@
 
 #include "material_editor_plugin.h"
 
-#include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
 #include "editor/editor_node.h"
-#include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
-#include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
-#include "scene/gui/button.h"
 #include "scene/gui/color_rect.h"
-#include "scene/gui/label.h"
 #include "scene/gui/subviewport_container.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/blit_material.h"
 #include "scene/resources/canvas_item_material.h"
 #include "scene/resources/particle_process_material.h"
-#include "scene/resources/sky.h"
 #include "servers/rendering/rendering_server.h"
 
-// 3D.
+#ifndef _3D_DISABLED
+#include "core/config/project_settings.h"
+#include "editor/editor_string_names.h"
+#include "editor/settings/editor_settings.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
+#include "scene/gui/button.h"
+#include "scene/gui/label.h"
+#include "scene/resources/sky.h"
+#endif // _3D_DISABLED
 
 Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_from, bool p_copy_params) {
 	ERR_FAIL_COND_V(p_from.is_null(), Ref<ShaderMaterial>());
@@ -83,6 +84,7 @@ Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_
 	return smat;
 }
 
+#ifndef _3D_DISABLED
 void MaterialEditor::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
@@ -101,22 +103,26 @@ void MaterialEditor::gui_input(const Ref<InputEvent> &p_event) {
 		_store_rotation_metadata();
 	}
 }
+#endif // _3D_DISABLED
 
 void MaterialEditor::_update_theme_item_cache() {
 	Control::_update_theme_item_cache();
 
+#ifndef _3D_DISABLED
 	theme_cache.light_1_icon = get_editor_theme_icon(SNAME("MaterialPreviewLight1"));
 	theme_cache.light_2_icon = get_editor_theme_icon(SNAME("MaterialPreviewLight2"));
 
 	theme_cache.sphere_icon = get_editor_theme_icon(SNAME("MaterialPreviewSphere"));
 	theme_cache.box_icon = get_editor_theme_icon(SNAME("MaterialPreviewCube"));
 	theme_cache.quad_icon = get_editor_theme_icon(SNAME("MaterialPreviewQuad"));
+#endif // _3D_DISABLED
 
 	theme_cache.checkerboard = get_editor_theme_icon(SNAME("Checkerboard"));
 }
 
 void MaterialEditor::_notification(int p_what) {
 	switch (p_what) {
+#ifndef _3D_DISABLED
 		case NOTIFICATION_THEME_CHANGED: {
 			light_1_switch->set_button_icon(theme_cache.light_1_icon);
 			light_2_switch->set_button_icon(theme_cache.light_2_icon);
@@ -127,16 +133,22 @@ void MaterialEditor::_notification(int p_what) {
 
 			error_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 		} break;
+#endif // _3D_DISABLED
 
 		case NOTIFICATION_DRAW: {
+#ifndef _3D_DISABLED
 			if (!is_unsupported_shader_mode) {
+#endif // _3D_DISABLED
 				Size2 size = get_size();
 				draw_texture_rect(theme_cache.checkerboard, Rect2(Point2(), size), true);
+#ifndef _3D_DISABLED
 			}
+#endif // _3D_DISABLED
 		} break;
 	}
 }
 
+#ifndef _3D_DISABLED
 void MaterialEditor::_set_rotation(real_t p_x_degrees, real_t p_y_degrees) {
 	rot.x = Math::deg_to_rad(p_x_degrees);
 	rot.y = Math::deg_to_rad(p_y_degrees);
@@ -233,6 +245,20 @@ void MaterialEditor::_on_quad_switch_pressed() {
 	_store_rotation_metadata();
 	EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_mesh", "quad");
 }
+#else
+void MaterialEditor::edit(Ref<Material> p_material) {
+	material = p_material;
+	if (material.is_null()) {
+		hide();
+		return;
+	}
+
+	if (p_material->get_shader_mode() == Shader::MODE_CANVAS_ITEM) {
+		layout_2d->show();
+		rect_instance->set_material(material);
+	}
+}
+#endif // _3D_DISABLED
 
 MaterialEditor::MaterialEditor() {
 	set_custom_minimum_size(Size2(1, 150) * EDSCALE);
@@ -260,6 +286,7 @@ MaterialEditor::MaterialEditor() {
 
 	layout_2d->set_visible(false);
 
+#ifndef _3D_DISABLED
 	layout_error = memnew(VBoxContainer);
 	layout_error->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 	layout_error->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
@@ -402,6 +429,7 @@ MaterialEditor::MaterialEditor() {
 	_set_rotation(stored_rot.x, stored_rot.y);
 
 	EditorNode::get_singleton()->register_hdr_viewport(viewport);
+#endif // _3D_DISABLED
 	EditorNode::get_singleton()->register_hdr_viewport(viewport_2d);
 }
 
@@ -424,7 +452,11 @@ void EditorInspectorPluginMaterial::parse_begin(Object *p_object) {
 	Ref<Material> m(material);
 
 	MaterialEditor *editor = memnew(MaterialEditor);
+#ifndef _3D_DISABLED
 	editor->edit(m, env);
+#else
+	editor->edit(m);
+#endif // _3D_DISABLED
 	add_custom_control(editor);
 }
 
@@ -464,12 +496,14 @@ void EditorInspectorPluginMaterial::_undo_redo_inspector_callback(Object *p_undo
 }
 
 EditorInspectorPluginMaterial::EditorInspectorPluginMaterial() {
+#ifndef _3D_DISABLED
 	env.instantiate();
 	Ref<Sky> sky = memnew(Sky());
 	env->set_sky(sky);
 	env->set_background(Environment::BG_COLOR);
 	env->set_ambient_source(Environment::AMBIENT_SOURCE_SKY);
 	env->set_reflection_source(Environment::REFLECTION_SOURCE_SKY);
+#endif // _3D_DISABLED
 
 	EditorNode::get_editor_data().add_undo_redo_inspector_hook_callback(callable_mp(this, &EditorInspectorPluginMaterial::_undo_redo_inspector_callback));
 }

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -30,29 +30,30 @@
 
 #include "material_editor_plugin.h"
 
-#include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
 #include "editor/editor_node.h"
-#include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
-#include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
-#include "scene/gui/button.h"
 #include "scene/gui/color_rect.h"
-#include "scene/gui/label.h"
 #include "scene/gui/subviewport_container.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/blit_material.h"
 #include "scene/resources/canvas_item_material.h"
 #include "scene/resources/particle_process_material.h"
-#include "scene/resources/sky.h"
 #include "servers/rendering/rendering_server.h"
 
-// 3D.
+#ifndef _3D_DISABLED
+#include "core/config/project_settings.h"
+#include "editor/editor_string_names.h"
+#include "editor/settings/editor_settings.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
+#include "scene/gui/button.h"
+#include "scene/gui/label.h"
+#include "scene/resources/sky.h"
+#endif // _3D_DISABLED
 
 Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_from, bool p_copy_params) {
 	ERR_FAIL_COND_V(p_from.is_null(), Ref<ShaderMaterial>());
@@ -83,6 +84,7 @@ Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_
 	return smat;
 }
 
+#ifndef _3D_DISABLED
 void MaterialEditor::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
@@ -101,31 +103,37 @@ void MaterialEditor::gui_input(const Ref<InputEvent> &p_event) {
 		_store_rotation_metadata();
 	}
 }
+#endif // _3D_DISABLED
 
 void MaterialEditor::set_autohide_buttons(bool p_autohide) {
 	autohide_buttons = p_autohide;
+#ifndef _3D_DISABLED
 	if (autohide_buttons) {
 		layout_3d->hide();
 	} else {
 		layout_3d->show();
 	}
+#endif // _3D_DISABLED
 }
 
 void MaterialEditor::_update_theme_item_cache() {
 	Control::_update_theme_item_cache();
 
+#ifndef _3D_DISABLED
 	theme_cache.light_1_icon = get_editor_theme_icon(SNAME("MaterialPreviewLight1"));
 	theme_cache.light_2_icon = get_editor_theme_icon(SNAME("MaterialPreviewLight2"));
 
 	theme_cache.sphere_icon = get_editor_theme_icon(SNAME("MaterialPreviewSphere"));
 	theme_cache.box_icon = get_editor_theme_icon(SNAME("MaterialPreviewCube"));
 	theme_cache.quad_icon = get_editor_theme_icon(SNAME("MaterialPreviewQuad"));
+#endif // _3D_DISABLED
 
 	theme_cache.checkerboard = get_editor_theme_icon(SNAME("Checkerboard"));
 }
 
 void MaterialEditor::_notification(int p_what) {
 	switch (p_what) {
+#ifndef _3D_DISABLED
 		case NOTIFICATION_THEME_CHANGED: {
 			light_1_switch->set_button_icon(theme_cache.light_1_icon);
 			light_2_switch->set_button_icon(theme_cache.light_2_icon);
@@ -136,32 +144,42 @@ void MaterialEditor::_notification(int p_what) {
 
 			error_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 		} break;
+#endif // _3D_DISABLED
 
 		case NOTIFICATION_DRAW: {
+#ifndef _3D_DISABLED
 			if (!is_unsupported_shader_mode) {
+#endif // _3D_DISABLED
 				Size2 size = get_size();
 				draw_rect(Rect2(Point2(), size), Color(0, 0, 0, 1)); // Since checkerboard texture is transluscent, draw opaque black behind it.
 				draw_texture_rect(theme_cache.checkerboard, Rect2(Point2(), size), true);
+#ifndef _3D_DISABLED
 			}
+#endif // _3D_DISABLED
 		} break;
 
 		case NOTIFICATION_MOUSE_ENTER: {
 			if (autohide_buttons) {
 				Shader::Mode mode = material.is_valid() ? material->get_shader_mode() : Shader::MODE_MAX;
+#ifndef _3D_DISABLED
 				if (mode == Shader::MODE_SPATIAL) {
 					layout_3d->show();
 				}
+#endif // _3D_DISABLED
 			}
 		} break;
 
 		case NOTIFICATION_MOUSE_EXIT: {
 			if (autohide_buttons) {
+#ifndef _3D_DISABLED
 				layout_3d->hide();
+#endif // _3D_DISABLED
 			}
 		} break;
 	}
 }
 
+#ifndef _3D_DISABLED
 void MaterialEditor::_set_rotation(real_t p_x_degrees, real_t p_y_degrees) {
 	rot.x = Math::deg_to_rad(p_x_degrees);
 	rot.y = Math::deg_to_rad(p_y_degrees);
@@ -260,6 +278,20 @@ void MaterialEditor::_on_quad_switch_pressed() {
 	_store_rotation_metadata();
 	EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_mesh", "quad");
 }
+#else
+void MaterialEditor::edit(Ref<Material> p_material) {
+	material = p_material;
+	if (material.is_null()) {
+		hide();
+		return;
+	}
+
+	if (p_material->get_shader_mode() == Shader::MODE_CANVAS_ITEM) {
+		layout_2d->show();
+		rect_instance->set_material(material);
+	}
+}
+#endif // _3D_DISABLED
 
 MaterialEditor::MaterialEditor() {
 	set_custom_minimum_size(Size2(1, 100) * EDSCALE);
@@ -288,6 +320,7 @@ MaterialEditor::MaterialEditor() {
 
 	layout_2d->set_visible(false);
 
+#ifndef _3D_DISABLED
 	layout_error = memnew(VBoxContainer);
 	layout_error->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 	layout_error->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
@@ -444,6 +477,7 @@ MaterialEditor::MaterialEditor() {
 	_set_rotation(stored_rot.x, stored_rot.y);
 
 	EditorNode::get_singleton()->register_hdr_viewport(viewport);
+#endif // _3D_DISABLED
 	EditorNode::get_singleton()->register_hdr_viewport(viewport_2d);
 }
 
@@ -466,7 +500,11 @@ void EditorInspectorPluginMaterial::parse_begin(Object *p_object) {
 	Ref<Material> m(material);
 
 	MaterialEditor *editor = memnew(MaterialEditor);
+#ifndef _3D_DISABLED
 	editor->edit(m, env);
+#else
+	editor->edit(m);
+#endif // _3D_DISABLED
 	add_custom_control(editor);
 }
 
@@ -506,12 +544,14 @@ void EditorInspectorPluginMaterial::_undo_redo_inspector_callback(Object *p_undo
 }
 
 EditorInspectorPluginMaterial::EditorInspectorPluginMaterial() {
+#ifndef _3D_DISABLED
 	env.instantiate();
 	Ref<Sky> sky = memnew(Sky());
 	env->set_sky(sky);
 	env->set_background(Environment::BG_COLOR);
 	env->set_ambient_source(Environment::AMBIENT_SOURCE_SKY);
 	env->set_reflection_source(Environment::REFLECTION_SOURCE_SKY);
+#endif // _3D_DISABLED
 
 	EditorNode::get_editor_data().add_undo_redo_inspector_hook_callback(callable_mp(this, &EditorInspectorPluginMaterial::_undo_redo_inspector_callback));
 }

--- a/editor/scene/material_editor_plugin.h
+++ b/editor/scene/material_editor_plugin.h
@@ -33,14 +33,18 @@
 #include "editor/inspector/editor_inspector.h"
 #include "editor/plugins/editor_plugin.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
-#include "scene/resources/3d/primitive_meshes.h"
 #include "scene/resources/material.h"
 
+#ifndef _3D_DISABLED
+#include "scene/resources/3d/primitive_meshes.h"
+
 class Camera3D;
-class ColorRect;
 class DirectionalLight3D;
-class HBoxContainer;
 class MeshInstance3D;
+#endif // _3D_DISABLED
+
+class ColorRect;
+class HBoxContainer;
 class SubViewport;
 class SubViewportContainer;
 class Button;
@@ -58,11 +62,13 @@ class MaterialEditor : public Control {
 	bool is_unsupported_shader_mode = false;
 
 	struct ThemeCache {
+#ifndef _3D_DISABLED
 		Ref<Texture2D> light_1_icon;
 		Ref<Texture2D> light_2_icon;
 		Ref<Texture2D> sphere_icon;
 		Ref<Texture2D> box_icon;
 		Ref<Texture2D> quad_icon;
+#endif // _3D_DISABLED
 		Ref<Texture2D> checkerboard;
 	} theme_cache;
 
@@ -72,6 +78,7 @@ class MaterialEditor : public Control {
 	HBoxContainer *layout_2d = nullptr;
 	ColorRect *rect_instance = nullptr;
 
+#ifndef _3D_DISABLED
 	// 3D spatial materials.
 	Vector2 rot;
 	Node3D *rotation = nullptr;
@@ -102,21 +109,30 @@ class MaterialEditor : public Control {
 	void _set_rotation(real_t p_x_degrees, real_t p_y_degrees);
 	void _store_rotation_metadata();
 	void _update_rotation();
+#endif // _3D_DISABLED
 
 protected:
 	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
+#ifndef _3D_DISABLED
 	void gui_input(const Ref<InputEvent> &p_event) override;
+#endif // _3D_DISABLED
 
 public:
 	static Ref<ShaderMaterial> make_shader_material(const Ref<Material> &p_from, bool p_copy_params = true);
+#ifndef _3D_DISABLED
 	void edit(Ref<Material> p_material, const Ref<Environment> &p_env);
+#else
+	void edit(Ref<Material> p_material);
+#endif // _3D_DISABLED
 	MaterialEditor();
 };
 
 class EditorInspectorPluginMaterial : public EditorInspectorPlugin {
 	GDCLASS(EditorInspectorPluginMaterial, EditorInspectorPlugin);
+#ifndef _3D_DISABLED
 	Ref<Environment> env;
+#endif // _3D_DISABLED
 
 public:
 	virtual bool can_handle(Object *p_object) override;

--- a/editor/scene/material_editor_plugin.h
+++ b/editor/scene/material_editor_plugin.h
@@ -33,15 +33,19 @@
 #include "editor/inspector/editor_inspector.h"
 #include "editor/plugins/editor_plugin.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
-#include "scene/resources/3d/primitive_meshes.h"
-#include "scene/resources/environment.h"
 #include "scene/resources/material.h"
 
+#ifndef _3D_DISABLED
+#include "scene/resources/3d/primitive_meshes.h"
+#include "scene/resources/environment.h"
+
 class Camera3D;
-class ColorRect;
 class DirectionalLight3D;
-class HBoxContainer;
 class MeshInstance3D;
+#endif // _3D_DISABLED
+
+class ColorRect;
+class HBoxContainer;
 class SubViewport;
 class SubViewportContainer;
 class Button;
@@ -60,11 +64,13 @@ class MaterialEditor : public Control {
 	bool autohide_buttons = false;
 
 	struct ThemeCache {
+#ifndef _3D_DISABLED
 		Ref<Texture2D> light_1_icon;
 		Ref<Texture2D> light_2_icon;
 		Ref<Texture2D> sphere_icon;
 		Ref<Texture2D> box_icon;
 		Ref<Texture2D> quad_icon;
+#endif // _3D_DISABLED
 		Ref<Texture2D> checkerboard;
 	} theme_cache;
 
@@ -74,6 +80,7 @@ class MaterialEditor : public Control {
 	HBoxContainer *layout_2d = nullptr;
 	ColorRect *rect_instance = nullptr;
 
+#ifndef _3D_DISABLED
 	// 3D spatial materials.
 	Vector2 rot;
 	Node3D *rotation = nullptr;
@@ -104,23 +111,32 @@ class MaterialEditor : public Control {
 	void _set_rotation(real_t p_x_degrees, real_t p_y_degrees);
 	void _store_rotation_metadata();
 	void _update_rotation();
+#endif // _3D_DISABLED
 
 protected:
 	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
+#ifndef _3D_DISABLED
 	void gui_input(const Ref<InputEvent> &p_event) override;
+#endif // _3D_DISABLED
 
 public:
 	void set_autohide_buttons(bool p_autohide);
 
 	static Ref<ShaderMaterial> make_shader_material(const Ref<Material> &p_from, bool p_copy_params = true);
+#ifndef _3D_DISABLED
 	void edit(Ref<Material> p_material, const Ref<Environment> &p_env);
+#else
+	void edit(Ref<Material> p_material);
+#endif // _3D_DISABLED
 	MaterialEditor();
 };
 
 class EditorInspectorPluginMaterial : public EditorInspectorPlugin {
 	GDCLASS(EditorInspectorPluginMaterial, EditorInspectorPlugin);
+#ifndef _3D_DISABLED
 	Ref<Environment> env;
+#endif // _3D_DISABLED
 
 public:
 	virtual bool can_handle(Object *p_object) override;

--- a/editor/scene/particles_editor_plugin.cpp
+++ b/editor/scene/particles_editor_plugin.cpp
@@ -43,8 +43,10 @@ void ParticlesEditorPlugin::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			if (handled_type.ends_with("2D")) {
 				add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, toolbar);
+#ifndef _3D_DISABLED
 			} else if (handled_type.ends_with("3D")) {
 				add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, toolbar);
+#endif // _3D_DISABLED
 			} else {
 				DEV_ASSERT(false);
 			}

--- a/editor/scene/scene_create_dialog.cpp
+++ b/editor/scene/scene_create_dialog.cpp
@@ -37,10 +37,8 @@
 #include "editor/editor_string_names.h"
 #include "editor/gui/create_dialog.h"
 #include "editor/gui/editor_validation_panel.h"
-#include "editor/settings/editor_feature_profile.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/2d/node_2d.h"
-#include "scene/3d/node_3d.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/grid_container.h"
@@ -48,12 +46,19 @@
 #include "scene/gui/option_button.h"
 #include "scene/resources/packed_scene.h"
 
+#ifndef _3D_DISABLED
+#include "editor/settings/editor_feature_profile.h"
+#include "scene/3d/node_3d.h"
+#endif // _3D_DISABLED
+
 void SceneCreateDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			select_node_button->set_button_icon(get_editor_theme_icon(SNAME("ClassList")));
 			node_type_2d->set_button_icon(get_editor_theme_icon(SNAME("Node2D")));
+#ifndef _3D_DISABLED
 			node_type_3d->set_button_icon(get_editor_theme_icon(SNAME("Node3D")));
+#endif // _3D_DISABLED
 			node_type_gui->set_button_icon(get_editor_theme_icon(SNAME("Control")));
 			node_type_other->add_theme_icon_override(SNAME("icon"), get_editor_theme_icon(SNAME("Node")));
 		} break;
@@ -71,11 +76,13 @@ void SceneCreateDialog::config(const String &p_dir, const String &p_scene_name) 
 	callable_mp((Control *)scene_name_edit, &Control::grab_focus).call_deferred(false);
 	validation_panel->update();
 
+#ifndef _3D_DISABLED
 	Ref<EditorFeatureProfile> profile = EditorFeatureProfileManager::get_singleton()->get_current_profile();
 	node_type_3d->set_visible(profile.is_null() || !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D));
 	if (!node_type_3d->is_visible() && node_type_3d->is_pressed()) {
 		node_type_2d->set_pressed(true);
 	}
+#endif // _3D_DISABLED
 }
 
 void SceneCreateDialog::accept_create() {
@@ -172,9 +179,11 @@ Node *SceneCreateDialog::create_scene_root() {
 		case ROOT_2D_SCENE:
 			root = memnew(Node2D);
 			break;
+#ifndef _3D_DISABLED
 		case ROOT_3D_SCENE:
 			root = memnew(Node3D);
 			break;
+#endif // _3D_DISABLED
 		case ROOT_USER_INTERFACE: {
 			Control *gui_ctl = memnew(Control);
 			// Making the root control full rect by default is more useful for resizable UIs.
@@ -223,12 +232,14 @@ SceneCreateDialog::SceneCreateDialog() {
 		node_type_2d->set_meta(type_meta, ROOT_2D_SCENE);
 		node_type_2d->set_pressed(true);
 
+#ifndef _3D_DISABLED
 		node_type_3d = memnew(CheckBox);
 		vb->add_child(node_type_3d);
 		node_type_3d->set_text(TTR("3D Scene"));
 		node_type_3d->set_theme_type_variation("CheckBoxNoIconTint");
 		node_type_3d->set_button_group(node_type_group);
 		node_type_3d->set_meta(type_meta, ROOT_3D_SCENE);
+#endif // _3D_DISABLED
 
 		node_type_gui = memnew(CheckBox);
 		vb->add_child(node_type_gui);

--- a/editor/scene/scene_create_dialog.h
+++ b/editor/scene/scene_create_dialog.h
@@ -54,7 +54,9 @@ class SceneCreateDialog : public ConfirmationDialog {
 public:
 	enum RootType {
 		ROOT_2D_SCENE,
+#ifndef _3D_DISABLED
 		ROOT_3D_SCENE,
+#endif // _3D_DISABLED
 		ROOT_USER_INTERFACE,
 		ROOT_OTHER,
 	};
@@ -66,7 +68,9 @@ private:
 
 	Ref<ButtonGroup> node_type_group;
 	CheckBox *node_type_2d = nullptr;
+#ifndef _3D_DISABLED
 	CheckBox *node_type_3d = nullptr;
+#endif // _3D_DISABLED
 	CheckBox *node_type_gui = nullptr;
 	CheckBox *node_type_other = nullptr;
 

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -76,12 +76,14 @@ PackedStringArray SceneTreeEditor::_get_node_configuration_warnings(Node *p_node
 				warnings.append(TTR("The root node of a scene is recommended to not be transformed, since instances of the scene will usually override this. Reset the transform and reload the scene to remove this warning."));
 			}
 		}
+#ifndef _3D_DISABLED
 		Node3D *node_3d = Object::cast_to<Node3D>(p_node);
 		if (node_3d) {
 			if (!node_3d->get_position().is_zero_approx()) {
 				warnings.append(TTR("The root node of a scene is recommended to not be transformed, since instances of the scene will usually override this. Reset the transform and reload the scene to remove this warning."));
 			}
 		}
+#endif // _3D_DISABLED
 	}
 	return warnings;
 }

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -78,12 +78,14 @@ PackedStringArray SceneTreeEditor::_get_node_configuration_warnings(Node *p_node
 				warnings.append(TTR("The root node of a scene is recommended to not be transformed, since instances of the scene will usually override this. Reset the transform and reload the scene to remove this warning."));
 			}
 		}
+#ifndef _3D_DISABLED
 		Node3D *node_3d = Object::cast_to<Node3D>(p_node);
 		if (node_3d) {
 			if (!node_3d->get_position().is_zero_approx()) {
 				warnings.append(TTR("The root node of a scene is recommended to not be transformed, since instances of the scene will usually override this. Reset the transform and reload the scene to remove this warning."));
 			}
 		}
+#endif // _3D_DISABLED
 	}
 	return warnings;
 }
@@ -237,6 +239,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		if (Object::cast_to<CanvasItem>(n)) {
 			undo_redo->add_do_method(CanvasItemEditor::get_singleton(), "emit_signal", "item_lock_status_changed");
 			undo_redo->add_undo_method(CanvasItemEditor::get_singleton(), "emit_signal", "item_lock_status_changed");
+#ifndef _3D_DISABLED
 		} else if (Object::cast_to<Node3D>(n)) {
 			Node3DEditor *node_3d_editor = Node3DEditor::get_singleton();
 			undo_redo->add_do_method(node_3d_editor, "emit_signal", "item_lock_status_changed");
@@ -245,6 +248,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 			undo_redo->add_undo_method(node_3d_editor, "_refresh_menu_icons");
 			undo_redo->add_do_method(node_3d_editor, "update_transform_gizmo");
 			undo_redo->add_undo_method(node_3d_editor, "update_transform_gizmo");
+#endif // _3D_DISABLED
 		}
 		undo_redo->commit_action();
 	} else if (p_id == BUTTON_PIN) {

--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -48,7 +48,6 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/2d/animated_sprite_2d.h"
-#include "scene/3d/sprite_3d.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/flow_container.h"
 #include "scene/gui/margin_container.h"
@@ -58,6 +57,10 @@
 #include "scene/gui/split_container.h"
 #include "scene/main/scene_tree.h"
 #include "scene/resources/atlas_texture.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/sprite_3d.h"
+#endif // _3D_DISABLED
 
 static void _draw_shadowed_line(Control *p_control, const Point2 &p_from, const Size2 &p_size, const Size2 &p_shadow_offset, Color p_color, Color p_shadow_color) {
 	p_control->draw_line(p_from, p_from + p_size, p_color);
@@ -1152,12 +1155,14 @@ static void _find_anim_sprites(Node *p_node, List<Node *> *r_nodes, Ref<SpriteFr
 		}
 	}
 
+#ifndef _3D_DISABLED
 	{
 		AnimatedSprite3D *as = Object::cast_to<AnimatedSprite3D>(p_node);
 		if (as && as->get_sprite_frames() == p_sfames) {
 			r_nodes->push_back(p_node);
 		}
 	}
+#endif // _3D_DISABLED
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		_find_anim_sprites(p_node->get_child(i), r_nodes, p_sfames);
@@ -2043,8 +2048,12 @@ void SpriteFramesEditor::_fetch_sprite_node() {
 
 	bool show_node_edit = false;
 	AnimatedSprite2D *as2d = Object::cast_to<AnimatedSprite2D>(selected);
+#ifndef _3D_DISABLED
 	AnimatedSprite3D *as3d = Object::cast_to<AnimatedSprite3D>(selected);
 	if (as2d || as3d) {
+#else
+	if (as2d) {
+#endif // _3D_DISABLED
 		if (frames != selected->call("get_sprite_frames")) {
 			_remove_sprite_node();
 		} else {
@@ -2792,12 +2801,16 @@ void SpriteFramesEditorPlugin::edit(Object *p_object) {
 	if (animated_sprite) {
 		s = animated_sprite->get_sprite_frames();
 	} else {
+#ifndef _3D_DISABLED
 		AnimatedSprite3D *animated_sprite_3d = Object::cast_to<AnimatedSprite3D>(p_object);
 		if (animated_sprite_3d) {
 			s = animated_sprite_3d->get_sprite_frames();
 		} else {
+#endif // _3D_DISABLED
 			s = p_object;
+#ifndef _3D_DISABLED
 		}
+#endif // _3D_DISABLED
 	}
 
 	frames_editor->edit(s);
@@ -2808,10 +2821,12 @@ bool SpriteFramesEditorPlugin::handles(Object *p_object) const {
 	if (animated_sprite_2d && *animated_sprite_2d->get_sprite_frames()) {
 		return true;
 	}
+#ifndef _3D_DISABLED
 	AnimatedSprite3D *animated_sprite_3d = Object::cast_to<AnimatedSprite3D>(p_object);
 	if (animated_sprite_3d && *animated_sprite_3d->get_sprite_frames()) {
 		return true;
 	}
+#endif // _3D_DISABLED
 	SpriteFrames *frames = Object::cast_to<SpriteFrames>(p_object);
 	if (frames && (frames_editor->get_sprite_frames().is_null() || frames_editor->get_sprite_frames() == frames)) {
 		return true;

--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -48,7 +48,6 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/2d/animated_sprite_2d.h"
-#include "scene/3d/sprite_3d.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/flow_container.h"
 #include "scene/gui/margin_container.h"
@@ -58,6 +57,10 @@
 #include "scene/gui/split_container.h"
 #include "scene/main/scene_tree.h"
 #include "scene/resources/atlas_texture.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/sprite_3d.h"
+#endif // _3D_DISABLED
 
 static void _draw_shadowed_line(Control *p_control, const Point2 &p_from, const Size2 &p_size, const Size2 &p_shadow_offset, Color p_color, Color p_shadow_color) {
 	p_control->draw_line(p_from, p_from + p_size, p_color);
@@ -1152,12 +1155,14 @@ static void _find_anim_sprites(Node *p_node, List<Node *> *r_nodes, Ref<SpriteFr
 		}
 	}
 
+#ifndef _3D_DISABLED
 	{
 		AnimatedSprite3D *as = Object::cast_to<AnimatedSprite3D>(p_node);
 		if (as && as->get_sprite_frames() == p_sfames) {
 			r_nodes->push_back(p_node);
 		}
 	}
+#endif // _3D_DISABLED
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		_find_anim_sprites(p_node->get_child(i), r_nodes, p_sfames);
@@ -2043,7 +2048,13 @@ void SpriteFramesEditor::_fetch_sprite_node() {
 	}
 
 	bool show_node_edit = false;
-	if (selected && selected->has_method("get_sprite_frames")) {
+	AnimatedSprite2D *as2d = Object::cast_to<AnimatedSprite2D>(selected);
+#ifndef _3D_DISABLED
+	AnimatedSprite3D *as3d = Object::cast_to<AnimatedSprite3D>(selected);
+	if (as2d || as3d) {
+#else
+	if (as2d) {
+#endif // _3D_DISABLED
 		if (frames != selected->call("get_sprite_frames")) {
 			_remove_sprite_node();
 		} else {
@@ -2793,12 +2804,16 @@ void SpriteFramesEditorPlugin::edit(Object *p_object) {
 	if (animated_sprite) {
 		s = animated_sprite->get_sprite_frames();
 	} else {
+#ifndef _3D_DISABLED
 		AnimatedSprite3D *animated_sprite_3d = Object::cast_to<AnimatedSprite3D>(p_object);
 		if (animated_sprite_3d) {
 			s = animated_sprite_3d->get_sprite_frames();
 		} else {
+#endif // _3D_DISABLED
 			s = p_object;
+#ifndef _3D_DISABLED
 		}
+#endif // _3D_DISABLED
 	}
 
 	frames_editor->edit(s);
@@ -2809,10 +2824,12 @@ bool SpriteFramesEditorPlugin::handles(Object *p_object) const {
 	if (animated_sprite_2d && *animated_sprite_2d->get_sprite_frames()) {
 		return true;
 	}
+#ifndef _3D_DISABLED
 	AnimatedSprite3D *animated_sprite_3d = Object::cast_to<AnimatedSprite3D>(p_object);
 	if (animated_sprite_3d && *animated_sprite_3d->get_sprite_frames()) {
 		return true;
 	}
+#endif // _3D_DISABLED
 	SpriteFrames *frames = Object::cast_to<SpriteFrames>(p_object);
 	if (frames && (frames_editor->get_sprite_frames().is_null() || frames_editor->get_sprite_frames() == frames)) {
 		return true;

--- a/editor/scene/texture/texture_region_editor_plugin.cpp
+++ b/editor/scene/texture/texture_region_editor_plugin.cpp
@@ -40,7 +40,6 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/2d/sprite_2d.h"
-#include "scene/3d/sprite_3d.h"
 #include "scene/gui/nine_patch_rect.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
@@ -51,6 +50,10 @@
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/style_box_texture.h"
 #include "servers/rendering/rendering_server.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/sprite_3d.h"
+#endif // _3D_DISABLED
 
 Transform2D TextureRegionEditor::_get_offset_transform() const {
 	Transform2D mtx;
@@ -386,9 +389,11 @@ void TextureRegionEditor::_commit_drag() {
 		if (node_sprite_2d) {
 			undo_redo->add_do_method(node_sprite_2d, "set_region_rect", node_sprite_2d->get_region_rect());
 			undo_redo->add_undo_method(node_sprite_2d, "set_region_rect", rect_prev);
+#ifndef _3D_DISABLED
 		} else if (node_sprite_3d) {
 			undo_redo->add_do_method(node_sprite_3d, "set_region_rect", node_sprite_3d->get_region_rect());
 			undo_redo->add_undo_method(node_sprite_3d, "set_region_rect", rect_prev);
+#endif // _3D_DISABLED
 		} else if (node_ninepatch) {
 			undo_redo->add_do_method(node_ninepatch, "set_region_rect", node_ninepatch->get_region_rect());
 			undo_redo->add_undo_method(node_ninepatch, "set_region_rect", rect_prev);
@@ -464,8 +469,10 @@ void TextureRegionEditor::_texture_overlay_input(const Ref<InputEvent> &p_input)
 									Rect2 r;
 									if (node_sprite_2d) {
 										r = node_sprite_2d->get_region_rect();
+#ifndef _3D_DISABLED
 									} else if (node_sprite_3d) {
 										r = node_sprite_3d->get_region_rect();
+#endif // _3D_DISABLED
 									} else if (node_ninepatch) {
 										r = node_ninepatch->get_region_rect();
 									} else if (res_stylebox.is_valid()) {
@@ -481,9 +488,11 @@ void TextureRegionEditor::_texture_overlay_input(const Ref<InputEvent> &p_input)
 								if (node_sprite_2d) {
 									undo_redo->add_do_method(node_sprite_2d, "set_region_rect", rect);
 									undo_redo->add_undo_method(node_sprite_2d, "set_region_rect", node_sprite_2d->get_region_rect());
+#ifndef _3D_DISABLED
 								} else if (node_sprite_3d) {
 									undo_redo->add_do_method(node_sprite_3d, "set_region_rect", rect);
 									undo_redo->add_undo_method(node_sprite_3d, "set_region_rect", node_sprite_3d->get_region_rect());
+#endif // _3D_DISABLED
 								} else if (node_ninepatch) {
 									undo_redo->add_do_method(node_ninepatch, "set_region_rect", rect);
 									undo_redo->add_undo_method(node_ninepatch, "set_region_rect", node_ninepatch->get_region_rect());
@@ -814,8 +823,10 @@ void TextureRegionEditor::_zoom_out() {
 void TextureRegionEditor::_apply_rect(const Rect2 &p_rect) {
 	if (node_sprite_2d) {
 		node_sprite_2d->set_region_rect(p_rect);
+#ifndef _3D_DISABLED
 	} else if (node_sprite_3d) {
 		node_sprite_3d->set_region_rect(p_rect);
+#endif // _3D_DISABLED
 	} else if (node_ninepatch) {
 		node_ninepatch->set_region_rect(p_rect);
 	} else if (res_stylebox.is_valid()) {
@@ -951,7 +962,11 @@ void TextureRegionEditor::_notification(int p_what) {
 }
 
 void TextureRegionEditor::_node_removed(Node *p_node) {
+#ifndef _3D_DISABLED
 	if (p_node == node_sprite_2d || p_node == node_sprite_3d || p_node == node_ninepatch) {
+#else
+	if (p_node == node_sprite_2d || p_node == node_ninepatch) {
+#endif // _3D_DISABLED
 		_clear_edited_object();
 		hide();
 	}
@@ -962,10 +977,12 @@ void TextureRegionEditor::_clear_edited_object() {
 		node_sprite_2d->disconnect(SceneStringName(texture_changed), callable_mp(this, &TextureRegionEditor::_texture_changed));
 		node_sprite_2d->disconnect(SceneStringName(item_rect_changed), callable_mp(this, &TextureRegionEditor::_edit_region));
 	}
+#ifndef _3D_DISABLED
 	if (node_sprite_3d) {
 		node_sprite_3d->disconnect(SceneStringName(texture_changed), callable_mp(this, &TextureRegionEditor::_texture_changed));
 		node_sprite_3d->disconnect(SceneStringName(item_rect_changed), callable_mp(this, &TextureRegionEditor::_edit_region));
 	}
+#endif // _3D_DISABLED
 	if (node_ninepatch) {
 		node_ninepatch->disconnect(SceneStringName(texture_changed), callable_mp(this, &TextureRegionEditor::_texture_changed));
 		node_ninepatch->disconnect(SceneStringName(item_rect_changed), callable_mp(this, &TextureRegionEditor::_edit_region));
@@ -980,7 +997,9 @@ void TextureRegionEditor::_clear_edited_object() {
 	}
 
 	node_sprite_2d = nullptr;
+#ifndef _3D_DISABLED
 	node_sprite_3d = nullptr;
+#endif // _3D_DISABLED
 	node_ninepatch = nullptr;
 	res_stylebox = Ref<StyleBoxTexture>();
 	res_atlas_texture = Ref<AtlasTexture>();
@@ -991,7 +1010,9 @@ void TextureRegionEditor::edit(Object *p_obj) {
 
 	if (p_obj) {
 		node_sprite_2d = Object::cast_to<Sprite2D>(p_obj);
+#ifndef _3D_DISABLED
 		node_sprite_3d = Object::cast_to<Sprite3D>(p_obj);
+#endif // _3D_DISABLED
 		node_ninepatch = Object::cast_to<NinePatchRect>(p_obj);
 
 		bool is_resource = false;
@@ -1024,9 +1045,11 @@ Ref<Texture2D> TextureRegionEditor::_get_edited_object_texture() const {
 	if (node_sprite_2d) {
 		return node_sprite_2d->get_texture();
 	}
+#ifndef _3D_DISABLED
 	if (node_sprite_3d) {
 		return node_sprite_3d->get_texture();
 	}
+#endif // _3D_DISABLED
 	if (node_ninepatch) {
 		return node_ninepatch->get_texture();
 	}
@@ -1045,8 +1068,10 @@ Rect2 TextureRegionEditor::_get_edited_object_region() const {
 
 	if (node_sprite_2d) {
 		region = node_sprite_2d->get_region_rect();
+#ifndef _3D_DISABLED
 	} else if (node_sprite_3d) {
 		region = node_sprite_3d->get_region_rect();
+#endif // _3D_DISABLED
 	} else if (node_ninepatch) {
 		region = node_ninepatch->get_region_rect();
 	} else if (res_stylebox.is_valid()) {
@@ -1085,6 +1110,7 @@ void TextureRegionEditor::_edit_region() {
 	CanvasItem::TextureFilter filter = CanvasItem::TEXTURE_FILTER_NEAREST_WITH_MIPMAPS;
 	if (node_sprite_2d) {
 		filter = node_sprite_2d->get_texture_filter_in_tree();
+#ifndef _3D_DISABLED
 	} else if (node_sprite_3d) {
 		StandardMaterial3D::TextureFilter filter_3d = node_sprite_3d->get_texture_filter();
 
@@ -1112,6 +1138,7 @@ void TextureRegionEditor::_edit_region() {
 				filter = CanvasItem::TEXTURE_FILTER_PARENT_NODE;
 				break;
 		}
+#endif // _3D_DISABLED
 	} else if (node_ninepatch) {
 		filter = node_ninepatch->get_texture_filter_in_tree();
 	}
@@ -1378,7 +1405,11 @@ TextureRegionEditor::TextureRegionEditor() {
 ////////////////////////
 
 bool EditorInspectorPluginTextureRegion::can_handle(Object *p_object) {
+#ifndef _3D_DISABLED
 	return Object::cast_to<Sprite2D>(p_object) || Object::cast_to<Sprite3D>(p_object) || Object::cast_to<NinePatchRect>(p_object) || Object::cast_to<StyleBoxTexture>(p_object) || Object::cast_to<AtlasTexture>(p_object);
+#else
+	return Object::cast_to<Sprite2D>(p_object) || Object::cast_to<NinePatchRect>(p_object) || Object::cast_to<StyleBoxTexture>(p_object) || Object::cast_to<AtlasTexture>(p_object);
+#endif // _3D_DISABLED
 }
 
 void EditorInspectorPluginTextureRegion::_region_edit(Object *p_object) {
@@ -1387,7 +1418,11 @@ void EditorInspectorPluginTextureRegion::_region_edit(Object *p_object) {
 
 bool EditorInspectorPluginTextureRegion::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
 	if ((p_type == Variant::RECT2 || p_type == Variant::RECT2I)) {
+#ifndef _3D_DISABLED
 		if (((Object::cast_to<Sprite2D>(p_object) || Object::cast_to<Sprite3D>(p_object) || Object::cast_to<NinePatchRect>(p_object) || Object::cast_to<StyleBoxTexture>(p_object)) && p_path == "region_rect") || (Object::cast_to<AtlasTexture>(p_object) && p_path == "region")) {
+#else
+		if (((Object::cast_to<Sprite2D>(p_object) || Object::cast_to<NinePatchRect>(p_object) || Object::cast_to<StyleBoxTexture>(p_object)) && p_path == "region_rect") || (Object::cast_to<AtlasTexture>(p_object) && p_path == "region")) {
+#endif // _3D_DISABLED
 			EditorInspectorActionButton *button = memnew(EditorInspectorActionButton(TTRC("Edit Region"), SNAME("RegionEdit")));
 			button->connect(SceneStringName(pressed), callable_mp(this, &EditorInspectorPluginTextureRegion::_region_edit).bind(p_object));
 			add_property_editor(p_path, button, true);

--- a/editor/scene/texture/texture_region_editor_plugin.cpp
+++ b/editor/scene/texture/texture_region_editor_plugin.cpp
@@ -40,7 +40,6 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/2d/sprite_2d.h"
-#include "scene/3d/sprite_3d.h"
 #include "scene/gui/nine_patch_rect.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
@@ -51,6 +50,10 @@
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/style_box_texture.h"
 #include "servers/rendering/rendering_server.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/sprite_3d.h"
+#endif // _3D_DISABLED
 
 Transform2D TextureRegionEditor::_get_offset_transform() const {
 	Transform2D mtx;
@@ -383,7 +386,15 @@ void TextureRegionEditor::_commit_drag() {
 		edited_margin = -1;
 	} else {
 		undo_redo->create_action(TTR("Set Region Rect"));
-		if (node_ninepatch) {
+		if (node_sprite_2d) {
+			undo_redo->add_do_method(node_sprite_2d, "set_region_rect", node_sprite_2d->get_region_rect());
+			undo_redo->add_undo_method(node_sprite_2d, "set_region_rect", rect_prev);
+#ifndef _3D_DISABLED
+		} else if (node_sprite_3d) {
+			undo_redo->add_do_method(node_sprite_3d, "set_region_rect", node_sprite_3d->get_region_rect());
+			undo_redo->add_undo_method(node_sprite_3d, "set_region_rect", rect_prev);
+#endif // _3D_DISABLED
+		} else if (node_ninepatch) {
 			undo_redo->add_do_method(node_ninepatch, "set_region_rect", node_ninepatch->get_region_rect());
 			undo_redo->add_undo_method(node_ninepatch, "set_region_rect", rect_prev);
 		} else if (res_stylebox.is_valid()) {
@@ -392,12 +403,6 @@ void TextureRegionEditor::_commit_drag() {
 		} else if (res_atlas_texture.is_valid()) {
 			undo_redo->add_do_method(res_atlas_texture.ptr(), "set_region", res_atlas_texture->get_region());
 			undo_redo->add_undo_method(res_atlas_texture.ptr(), "set_region", rect_prev);
-		} else if (node_sprite_2d) {
-			undo_redo->add_do_method(node_sprite_2d, "set_region_rect", node_sprite_2d->get_region_rect());
-			undo_redo->add_undo_method(node_sprite_2d, "set_region_rect", rect_prev);
-		} else if (node_sprite_3d) {
-			undo_redo->add_do_method(node_sprite_3d, "set_region_rect", node_sprite_3d->get_region_rect());
-			undo_redo->add_undo_method(node_sprite_3d, "set_region_rect", rect_prev);
 		}
 		drag_index = -1;
 	}
@@ -461,13 +466,34 @@ void TextureRegionEditor::_texture_overlay_input(const Ref<InputEvent> &p_input)
 							if (E.has_point(point)) {
 								rect = E;
 								if (Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL) && !(Input::get_singleton()->is_key_pressed(Key(Key::SHIFT | Key::ALT)))) {
-									Rect2 r = _get_edited_object_region();
+									Rect2 r;
+									if (node_sprite_2d) {
+										r = node_sprite_2d->get_region_rect();
+#ifndef _3D_DISABLED
+									} else if (node_sprite_3d) {
+										r = node_sprite_3d->get_region_rect();
+#endif // _3D_DISABLED
+									} else if (node_ninepatch) {
+										r = node_ninepatch->get_region_rect();
+									} else if (res_stylebox.is_valid()) {
+										r = res_stylebox->get_region_rect();
+									} else if (res_atlas_texture.is_valid()) {
+										r = res_atlas_texture->get_region();
+									}
 									rect.expand_to(r.position);
 									rect.expand_to(r.get_end());
 								}
 
 								undo_redo->create_action(TTR("Set Region Rect"));
-								if (node_ninepatch) {
+								if (node_sprite_2d) {
+									undo_redo->add_do_method(node_sprite_2d, "set_region_rect", rect);
+									undo_redo->add_undo_method(node_sprite_2d, "set_region_rect", node_sprite_2d->get_region_rect());
+#ifndef _3D_DISABLED
+								} else if (node_sprite_3d) {
+									undo_redo->add_do_method(node_sprite_3d, "set_region_rect", rect);
+									undo_redo->add_undo_method(node_sprite_3d, "set_region_rect", node_sprite_3d->get_region_rect());
+#endif // _3D_DISABLED
+								} else if (node_ninepatch) {
 									undo_redo->add_do_method(node_ninepatch, "set_region_rect", rect);
 									undo_redo->add_undo_method(node_ninepatch, "set_region_rect", node_ninepatch->get_region_rect());
 								} else if (res_stylebox.is_valid()) {
@@ -476,12 +502,6 @@ void TextureRegionEditor::_texture_overlay_input(const Ref<InputEvent> &p_input)
 								} else if (res_atlas_texture.is_valid()) {
 									undo_redo->add_do_method(res_atlas_texture.ptr(), "set_region", rect);
 									undo_redo->add_undo_method(res_atlas_texture.ptr(), "set_region", res_atlas_texture->get_region());
-								} else if (node_sprite_2d) {
-									undo_redo->add_do_method(node_sprite_2d, "set_region_rect", rect);
-									undo_redo->add_undo_method(node_sprite_2d, "set_region_rect", node_sprite_2d->get_region_rect());
-								} else if (node_sprite_3d) {
-									undo_redo->add_do_method(node_sprite_3d, "set_region_rect", rect);
-									undo_redo->add_undo_method(node_sprite_3d, "set_region_rect", node_sprite_3d->get_region_rect());
 								}
 
 								undo_redo->add_do_method(this, "_update_rect");
@@ -803,8 +823,10 @@ void TextureRegionEditor::_zoom_out() {
 void TextureRegionEditor::_apply_rect(const Rect2 &p_rect) {
 	if (node_sprite_2d) {
 		node_sprite_2d->set_region_rect(p_rect);
+#ifndef _3D_DISABLED
 	} else if (node_sprite_3d) {
 		node_sprite_3d->set_region_rect(p_rect);
+#endif // _3D_DISABLED
 	} else if (node_ninepatch) {
 		node_ninepatch->set_region_rect(p_rect);
 	} else if (res_stylebox.is_valid()) {
@@ -940,7 +962,11 @@ void TextureRegionEditor::_notification(int p_what) {
 }
 
 void TextureRegionEditor::_node_removed(Node *p_node) {
+#ifndef _3D_DISABLED
 	if (p_node == node_sprite_2d || p_node == node_sprite_3d || p_node == node_ninepatch) {
+#else
+	if (p_node == node_sprite_2d || p_node == node_ninepatch) {
+#endif // _3D_DISABLED
 		_clear_edited_object();
 		hide();
 	}
@@ -951,10 +977,12 @@ void TextureRegionEditor::_clear_edited_object() {
 		node_sprite_2d->disconnect(SceneStringName(texture_changed), callable_mp(this, &TextureRegionEditor::_texture_changed));
 		node_sprite_2d->disconnect(SceneStringName(item_rect_changed), callable_mp(this, &TextureRegionEditor::_edit_region));
 	}
+#ifndef _3D_DISABLED
 	if (node_sprite_3d) {
 		node_sprite_3d->disconnect(SceneStringName(texture_changed), callable_mp(this, &TextureRegionEditor::_texture_changed));
 		node_sprite_3d->disconnect(SceneStringName(item_rect_changed), callable_mp(this, &TextureRegionEditor::_edit_region));
 	}
+#endif // _3D_DISABLED
 	if (node_ninepatch) {
 		node_ninepatch->disconnect(SceneStringName(texture_changed), callable_mp(this, &TextureRegionEditor::_texture_changed));
 		node_ninepatch->disconnect(SceneStringName(item_rect_changed), callable_mp(this, &TextureRegionEditor::_edit_region));
@@ -969,7 +997,9 @@ void TextureRegionEditor::_clear_edited_object() {
 	}
 
 	node_sprite_2d = nullptr;
+#ifndef _3D_DISABLED
 	node_sprite_3d = nullptr;
+#endif // _3D_DISABLED
 	node_ninepatch = nullptr;
 	res_stylebox = Ref<StyleBoxTexture>();
 	res_atlas_texture = Ref<AtlasTexture>();
@@ -980,7 +1010,9 @@ void TextureRegionEditor::edit(Object *p_obj) {
 
 	if (p_obj) {
 		node_sprite_2d = Object::cast_to<Sprite2D>(p_obj);
+#ifndef _3D_DISABLED
 		node_sprite_3d = Object::cast_to<Sprite3D>(p_obj);
+#endif // _3D_DISABLED
 		node_ninepatch = Object::cast_to<NinePatchRect>(p_obj);
 
 		bool is_resource = false;
@@ -1013,9 +1045,11 @@ Ref<Texture2D> TextureRegionEditor::_get_edited_object_texture() const {
 	if (node_sprite_2d) {
 		return node_sprite_2d->get_texture();
 	}
+#ifndef _3D_DISABLED
 	if (node_sprite_3d) {
 		return node_sprite_3d->get_texture();
 	}
+#endif // _3D_DISABLED
 	if (node_ninepatch) {
 		return node_ninepatch->get_texture();
 	}
@@ -1032,16 +1066,18 @@ Ref<Texture2D> TextureRegionEditor::_get_edited_object_texture() const {
 Rect2 TextureRegionEditor::_get_edited_object_region() const {
 	Rect2 region;
 
-	if (node_ninepatch) {
+	if (node_sprite_2d) {
+		region = node_sprite_2d->get_region_rect();
+#ifndef _3D_DISABLED
+	} else if (node_sprite_3d) {
+		region = node_sprite_3d->get_region_rect();
+#endif // _3D_DISABLED
+	} else if (node_ninepatch) {
 		region = node_ninepatch->get_region_rect();
 	} else if (res_stylebox.is_valid()) {
 		region = res_stylebox->get_region_rect();
 	} else if (res_atlas_texture.is_valid()) {
 		region = res_atlas_texture->get_region();
-	} else if (node_sprite_2d) {
-		region = node_sprite_2d->get_region_rect();
-	} else if (node_sprite_3d) {
-		region = node_sprite_3d->get_region_rect();
 	}
 
 	const Ref<Texture2D> object_texture = _get_edited_object_texture();
@@ -1072,10 +1108,9 @@ void TextureRegionEditor::_edit_region() {
 	}
 
 	CanvasItem::TextureFilter filter = CanvasItem::TEXTURE_FILTER_NEAREST_WITH_MIPMAPS;
-	if (node_ninepatch) {
-		filter = node_ninepatch->get_texture_filter_in_tree();
-	} else if (node_sprite_2d) {
+	if (node_sprite_2d) {
 		filter = node_sprite_2d->get_texture_filter_in_tree();
+#ifndef _3D_DISABLED
 	} else if (node_sprite_3d) {
 		StandardMaterial3D::TextureFilter filter_3d = node_sprite_3d->get_texture_filter();
 
@@ -1103,6 +1138,9 @@ void TextureRegionEditor::_edit_region() {
 				filter = CanvasItem::TEXTURE_FILTER_PARENT_NODE;
 				break;
 		}
+#endif // _3D_DISABLED
+	} else if (node_ninepatch) {
+		filter = node_ninepatch->get_texture_filter_in_tree();
 	}
 
 	// occurs when get_texture_filter_in_tree reaches the scene root
@@ -1367,7 +1405,11 @@ TextureRegionEditor::TextureRegionEditor() {
 ////////////////////////
 
 bool EditorInspectorPluginTextureRegion::can_handle(Object *p_object) {
+#ifndef _3D_DISABLED
 	return Object::cast_to<Sprite2D>(p_object) || Object::cast_to<Sprite3D>(p_object) || Object::cast_to<NinePatchRect>(p_object) || Object::cast_to<StyleBoxTexture>(p_object) || Object::cast_to<AtlasTexture>(p_object);
+#else
+	return Object::cast_to<Sprite2D>(p_object) || Object::cast_to<NinePatchRect>(p_object) || Object::cast_to<StyleBoxTexture>(p_object) || Object::cast_to<AtlasTexture>(p_object);
+#endif // _3D_DISABLED
 }
 
 void EditorInspectorPluginTextureRegion::_region_edit(Object *p_object) {
@@ -1376,7 +1418,11 @@ void EditorInspectorPluginTextureRegion::_region_edit(Object *p_object) {
 
 bool EditorInspectorPluginTextureRegion::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
 	if ((p_type == Variant::RECT2 || p_type == Variant::RECT2I)) {
+#ifndef _3D_DISABLED
 		if (((Object::cast_to<Sprite2D>(p_object) || Object::cast_to<Sprite3D>(p_object) || Object::cast_to<NinePatchRect>(p_object) || Object::cast_to<StyleBoxTexture>(p_object)) && p_path == "region_rect") || (Object::cast_to<AtlasTexture>(p_object) && p_path == "region")) {
+#else
+		if (((Object::cast_to<Sprite2D>(p_object) || Object::cast_to<NinePatchRect>(p_object) || Object::cast_to<StyleBoxTexture>(p_object)) && p_path == "region_rect") || (Object::cast_to<AtlasTexture>(p_object) && p_path == "region")) {
+#endif // _3D_DISABLED
 			EditorInspectorActionButton *button = memnew(EditorInspectorActionButton(TTRC("Edit Region"), SNAME("RegionEdit")));
 			button->connect(SceneStringName(pressed), callable_mp(this, &EditorInspectorPluginTextureRegion::_region_edit).bind(p_object));
 			add_property_editor(p_path, button, true);

--- a/editor/settings/editor_feature_profile.cpp
+++ b/editor/settings/editor_feature_profile.cpp
@@ -45,7 +45,9 @@
 #include "scene/gui/separator.h"
 
 const char *EditorFeatureProfile::feature_names[FEATURE_MAX] = {
+#ifndef _3D_DISABLED
 	TTRC("3D Editor"),
+#endif // _3D_DISABLED
 	TTRC("Script Editor"),
 	TTRC("Asset Store"),
 	TTRC("Scene Tree Editing"),
@@ -61,7 +63,9 @@ const char *EditorFeatureProfile::feature_names[FEATURE_MAX] = {
 };
 
 const char *EditorFeatureProfile::feature_descriptions[FEATURE_MAX] = {
+#ifndef _3D_DISABLED
 	TTRC("Allows to view and edit 3D scenes."),
+#endif // _3D_DISABLED
 	TTRC("Allows to edit scripts using the integrated script editor."),
 	TTRC("Provides built-in access to the Asset Store."),
 	TTRC("Allows editing the node hierarchy in the Scene dock."),
@@ -77,7 +81,9 @@ const char *EditorFeatureProfile::feature_descriptions[FEATURE_MAX] = {
 };
 
 const char *EditorFeatureProfile::feature_identifiers[FEATURE_MAX] = {
+#ifndef _3D_DISABLED
 	"3d",
+#endif // _3D_DISABLED
 	"script",
 	"asset_lib",
 	"scene_tree",
@@ -318,7 +324,9 @@ void EditorFeatureProfile::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save_to_file", "path"), &EditorFeatureProfile::save_to_file);
 	ClassDB::bind_method(D_METHOD("load_from_file", "path"), &EditorFeatureProfile::load_from_file);
 
+#ifndef _3D_DISABLED
 	BIND_ENUM_CONSTANT(FEATURE_3D);
+#endif // _3D_DISABLED
 	BIND_ENUM_CONSTANT(FEATURE_SCRIPT);
 	BIND_ENUM_CONSTANT(FEATURE_ASSET_LIB);
 	BIND_ENUM_CONSTANT(FEATURE_SCENE_TREE);

--- a/editor/settings/editor_feature_profile.h
+++ b/editor/settings/editor_feature_profile.h
@@ -44,7 +44,9 @@ class EditorFeatureProfile : public RefCounted {
 
 public:
 	enum Feature {
+#ifndef _3D_DISABLED
 		FEATURE_3D,
+#endif // _3D_DISABLED
 		FEATURE_SCRIPT,
 		FEATURE_ASSET_LIB,
 		FEATURE_SCENE_TREE,

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -885,6 +885,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	/* Editors */
 
+#ifndef _3D_DISABLED
 	// GridMap
 	// GridMapEditor
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/grid_map/pick_distance", 5000.0, "1,8192,0.1,or_greater");
@@ -990,6 +991,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/manipulator_gizmo_opacity", 0.9, "0,1,0.01");
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_FLAGS, "editors/3d/show_gizmo_during_rotation", 2, "Global,Local");
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/view_plane_rotation_gizmo_scale", 1.14, "1.0,2.0,0.01,or_greater");
+#endif // _3D_DISABLED
 
 	// 2D
 	_initial_set("editors/2d/grid_color", Color(1.0, 1.0, 1.0, 0.07), true);

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -913,6 +913,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	/* Editors */
 
+#ifndef _3D_DISABLED
 	// GridMap
 	// GridMapEditor
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/grid_map/pick_distance", 5000.0, "1,8192,0.1,or_greater");
@@ -1022,6 +1023,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/manipulator_gizmo_opacity", 0.9, "0,1,0.01");
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_FLAGS, "editors/3d/show_gizmo_during_rotation", 2, "Global,Local");
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/view_plane_rotation_gizmo_scale", 1.14, "1.0,2.0,0.01,or_greater");
+#endif // _3D_DISABLED
 
 	// 2D
 	_initial_set("editors/2d/grid_color", Color(1.0, 1.0, 1.0, 0.07), true);

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -43,19 +43,23 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/inspector/editor_property_name_processor.h"
 #include "editor/inspector/editor_sectioned_inspector.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/settings/editor_event_search_bar.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/settings/event_listener_line_edit.h"
 #include "editor/settings/input_event_configuration_dialog.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
-#include "scene/debugger/view_3d_controller.h"
 #include "scene/gui/check_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
+#include "scene/main/timer.h"
+
+#ifndef _3D_DISABLED
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "scene/debugger/view_3d_controller.h"
+#endif // _3D_DISABLED
 
 void EditorSettingsDialog::ok_pressed() {
 	if (!EditorSettings::get_singleton()) {
@@ -86,14 +90,17 @@ void EditorSettingsDialog::_settings_property_edited() {
 		EditorSettings::get_singleton()->set_manually("text_editor/theme/color_theme", "Custom");
 	} else if (full_name.begins_with("editors/visual_editors/connection_colors") || full_name.begins_with("editors/visual_editors/category_colors")) {
 		EditorSettings::get_singleton()->set_manually("editors/visual_editors/color_theme", "Custom");
+#ifndef _3D_DISABLED
 	} else if (full_name == "editors/3d/navigation/orbit_mouse_button" || full_name == "editors/3d/navigation/pan_mouse_button" || full_name == "editors/3d/navigation/zoom_mouse_button" || full_name == "editors/3d/navigation/emulate_3_button_mouse") {
 		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/navigation_scheme", (int)View3DController::NAV_SCHEME_CUSTOM);
 	} else if (full_name == "editors/3d/navigation/navigation_scheme") {
 		update_navigation_preset();
 		_update_shortcuts();
+#endif // _3D_DISABLED
 	}
 }
 
+#ifndef _3D_DISABLED
 void EditorSettingsDialog::update_navigation_preset() {
 	View3DController::NavigationScheme nav_scheme = (View3DController::NavigationScheme)EDITOR_GET("editors/3d/navigation/navigation_scheme").operator int();
 	View3DController::NavigationMouseButton set_orbit_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
@@ -183,6 +190,7 @@ void EditorSettingsDialog::update_navigation_preset() {
 		_set_shortcut_input("spatial_editor/viewport_orbit_snap_modifier_2", orbit_snap_mod_key_2);
 	}
 }
+#endif // _3D_DISABLED
 
 void EditorSettingsDialog::_set_shortcut_input(const String &p_name, Ref<InputEventKey> &p_event) {
 	Array sc_events;
@@ -217,7 +225,9 @@ void EditorSettingsDialog::popup_edit_settings() {
 
 	EditorSettings::get_singleton()->update_text_editor_themes_list(); // Make sure we have an up to date list of themes.
 
+#ifndef _3D_DISABLED
 	_update_dynamic_property_hints();
+#endif // _3D_DISABLED
 
 	inspector->edit(EditorSettings::get_singleton());
 	inspector->get_inspector()->update_tree();
@@ -295,11 +305,13 @@ void EditorSettingsDialog::_notification(int p_what) {
 				_update_shortcuts();
 			}
 
+#ifndef _3D_DISABLED
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/3d/navigation")) {
 				// Shortcuts may have changed, so dynamic hint values must update.
 				_update_dynamic_property_hints();
 				inspector->get_inspector()->update_tree();
 			}
+#endif // _3D_DISABLED
 
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/localization/localize_settings")) {
 				inspector->update_category_list();
@@ -429,12 +441,14 @@ void EditorSettingsDialog::_update_shortcut_events(const String &p_path, const A
 		undo_redo->commit_action();
 	}
 
+#ifndef _3D_DISABLED
 	bool path_is_orbit_mod = p_path == "spatial_editor/viewport_orbit_modifier_1" || p_path == "spatial_editor/viewport_orbit_modifier_2";
 	bool path_is_pan_mod = p_path == "spatial_editor/viewport_pan_modifier_1" || p_path == "spatial_editor/viewport_pan_modifier_2";
 	bool path_is_zoom_mod = p_path == "spatial_editor/viewport_zoom_modifier_1" || p_path == "spatial_editor/viewport_zoom_modifier_2";
 	if (path_is_orbit_mod || path_is_pan_mod || path_is_zoom_mod) {
 		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/navigation_scheme", (int)View3DController::NAV_SCHEME_CUSTOM);
 	}
+#endif // _3D_DISABLED
 }
 
 Array EditorSettingsDialog::_event_list_to_array_helper(const List<Ref<InputEvent>> &p_events) {
@@ -878,11 +892,14 @@ void EditorSettingsDialog::drop_data_fw(const Point2 &p_point, const Variant &p_
 void EditorSettingsDialog::_tabs_tab_changed(int p_tab) {
 	_focus_current_search_box();
 
+#ifndef _3D_DISABLED
 	// When tab has switched, shortcuts may have changed.
 	_update_dynamic_property_hints();
+#endif // _3D_DISABLED
 	inspector->get_inspector()->update_tree();
 }
 
+#ifndef _3D_DISABLED
 void EditorSettingsDialog::_update_dynamic_property_hints() {
 	// Calling add_property_hint overrides the existing hint.
 	EditorSettings *settings = EditorSettings::get_singleton();
@@ -890,6 +907,7 @@ void EditorSettingsDialog::_update_dynamic_property_hints() {
 	settings->add_property_hint(_create_mouse_shortcut_property_info("editors/3d/navigation/pan_mouse_button", "spatial_editor/viewport_pan_modifier_1", "spatial_editor/viewport_pan_modifier_2"));
 	settings->add_property_hint(_create_mouse_shortcut_property_info("editors/3d/navigation/zoom_mouse_button", "spatial_editor/viewport_zoom_modifier_1", "spatial_editor/viewport_zoom_modifier_2"));
 }
+#endif // _3D_DISABLED
 
 PropertyInfo EditorSettingsDialog::_create_mouse_shortcut_property_info(const String &p_property_name, const String &p_shortcut_1_name, const String &p_shortcut_2_name) {
 	String hint_string;

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -43,7 +43,6 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/inspector/editor_property_name_processor.h"
 #include "editor/inspector/editor_sectioned_inspector.h"
-#include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/settings/editor_event_search_bar.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/settings/event_listener_line_edit.h"
@@ -51,13 +50,17 @@
 #include "editor/settings/project_settings_editor.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
-#include "scene/debugger/view_3d_controller.h"
 #include "scene/gui/check_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
 #include "scene/main/timer.h"
+
+#ifndef _3D_DISABLED
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "scene/debugger/view_3d_controller.h"
+#endif // _3D_DISABLED
 
 void EditorSettingsDialog::ok_pressed() {
 	if (!EditorSettings::get_singleton()) {
@@ -88,17 +91,20 @@ void EditorSettingsDialog::_settings_property_edited() {
 		EditorSettings::get_singleton()->set_manually("text_editor/theme/color_theme", "Custom");
 	} else if (full_name.begins_with("editors/visual_editors/connection_colors") || full_name.begins_with("editors/visual_editors/category_colors")) {
 		EditorSettings::get_singleton()->set_manually("editors/visual_editors/color_theme", "Custom");
+#ifndef _3D_DISABLED
 	} else if (full_name == "editors/3d/navigation/orbit_mouse_button" || full_name == "editors/3d/navigation/pan_mouse_button" || full_name == "editors/3d/navigation/zoom_mouse_button" || full_name == "editors/3d/navigation/emulate_3_button_mouse") {
 		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/navigation_scheme", (int)View3DController::NAV_SCHEME_CUSTOM);
 	} else if (full_name == "editors/3d/navigation/navigation_scheme") {
 		update_3d_navigation_preset();
 		_update_shortcuts();
+#endif // _3D_DISABLED
 	} else if (full_name == "interface/editor/appearance/custom_display_scale") {
 		// The "Custom" display scale is index 7 in the setting's enum hint.
 		EditorSettings::get_singleton()->set_manually("interface/editor/appearance/display_scale", 7);
 	}
 }
 
+#ifndef _3D_DISABLED
 void EditorSettingsDialog::update_3d_navigation_preset() {
 	View3DController::NavigationScheme nav_scheme = (View3DController::NavigationScheme)EDITOR_GET("editors/3d/navigation/navigation_scheme").operator int();
 	View3DController::NavigationMouseButton set_orbit_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
@@ -188,6 +194,7 @@ void EditorSettingsDialog::update_3d_navigation_preset() {
 		_set_shortcut_input("spatial_editor/viewport_orbit_snap_modifier_2", orbit_snap_mod_key_2);
 	}
 }
+#endif // _3D_DISABLED
 
 void EditorSettingsDialog::_set_shortcut_input(const String &p_name, Ref<InputEventKey> &p_event) {
 	Array sc_events;
@@ -222,7 +229,9 @@ void EditorSettingsDialog::popup_edit_settings() {
 
 	EditorSettings::get_singleton()->update_text_editor_themes_list(); // Make sure we have an up to date list of themes.
 
+#ifndef _3D_DISABLED
 	_update_dynamic_property_hints();
+#endif // _3D_DISABLED
 
 	inspector->edit(EditorSettings::get_singleton());
 	inspector->get_inspector()->update_tree();
@@ -330,11 +339,13 @@ void EditorSettingsDialog::_notification(int p_what) {
 				_update_shortcuts();
 			}
 
+#ifndef _3D_DISABLED
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/3d/navigation")) {
 				// Shortcuts may have changed, so dynamic hint values must update.
 				_update_dynamic_property_hints();
 				inspector->get_inspector()->update_tree();
 			}
+#endif // _3D_DISABLED
 
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/localization/localize_settings")) {
 				inspector->update_category_list();
@@ -464,12 +475,14 @@ void EditorSettingsDialog::_update_shortcut_events(const String &p_path, const A
 		undo_redo->commit_action();
 	}
 
+#ifndef _3D_DISABLED
 	bool path_is_orbit_mod = p_path == "spatial_editor/viewport_orbit_modifier_1" || p_path == "spatial_editor/viewport_orbit_modifier_2";
 	bool path_is_pan_mod = p_path == "spatial_editor/viewport_pan_modifier_1" || p_path == "spatial_editor/viewport_pan_modifier_2";
 	bool path_is_zoom_mod = p_path == "spatial_editor/viewport_zoom_modifier_1" || p_path == "spatial_editor/viewport_zoom_modifier_2";
 	if (path_is_orbit_mod || path_is_pan_mod || path_is_zoom_mod) {
 		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/navigation_scheme", (int)View3DController::NAV_SCHEME_CUSTOM);
 	}
+#endif // _3D_DISABLED
 }
 
 Array EditorSettingsDialog::_event_list_to_array_helper(const List<Ref<InputEvent>> &p_events) {
@@ -913,11 +926,14 @@ void EditorSettingsDialog::drop_data_fw(const Point2 &p_point, const Variant &p_
 void EditorSettingsDialog::_tabs_tab_changed(int p_tab) {
 	_focus_current_search_box();
 
+#ifndef _3D_DISABLED
 	// When tab has switched, shortcuts may have changed.
 	_update_dynamic_property_hints();
+#endif // _3D_DISABLED
 	inspector->get_inspector()->update_tree();
 }
 
+#ifndef _3D_DISABLED
 void EditorSettingsDialog::_update_dynamic_property_hints() {
 	// Calling add_property_hint overrides the existing hint.
 	EditorSettings *settings = EditorSettings::get_singleton();
@@ -925,6 +941,7 @@ void EditorSettingsDialog::_update_dynamic_property_hints() {
 	settings->add_property_hint(_create_mouse_shortcut_property_info("editors/3d/navigation/pan_mouse_button", "spatial_editor/viewport_pan_modifier_1", "spatial_editor/viewport_pan_modifier_2"));
 	settings->add_property_hint(_create_mouse_shortcut_property_info("editors/3d/navigation/zoom_mouse_button", "spatial_editor/viewport_zoom_modifier_1", "spatial_editor/viewport_zoom_modifier_2"));
 }
+#endif // _3D_DISABLED
 
 PropertyInfo EditorSettingsDialog::_create_mouse_shortcut_property_info(const String &p_property_name, const String &p_shortcut_1_name, const String &p_shortcut_2_name) {
 	String hint_string;

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -103,7 +103,10 @@ class EditorSettingsDialog : public AcceptDialog {
 
 	void _advanced_toggled(bool p_button_pressed);
 
+#ifndef _3D_DISABLED
 	void _update_dynamic_property_hints();
+#endif // _3D_DISABLED
+
 	PropertyInfo _create_mouse_shortcut_property_info(const String &p_property_name, const String &p_shortcut_1_name, const String &p_shortcut_2_name);
 	String _get_shortcut_button_string(const String &p_shortcut_name);
 
@@ -130,7 +133,9 @@ protected:
 
 public:
 	void popup_edit_settings();
+#ifndef _3D_DISABLED
 	static void update_navigation_preset();
+#endif // _3D_DISABLED
 	void set_current_section(const String &p_section);
 	void set_advanced_mode_enabled(bool p_enabled);
 

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -105,7 +105,10 @@ class EditorSettingsDialog : public AcceptDialog {
 
 	void _advanced_toggled(bool p_button_pressed);
 
+#ifndef _3D_DISABLED
 	void _update_dynamic_property_hints();
+#endif // _3D_DISABLED
+
 	PropertyInfo _create_mouse_shortcut_property_info(const String &p_property_name, const String &p_shortcut_1_name, const String &p_shortcut_2_name);
 	String _get_shortcut_button_string(const String &p_shortcut_name);
 
@@ -135,7 +138,9 @@ protected:
 
 public:
 	void popup_edit_settings();
+#ifndef _3D_DISABLED
 	static void update_3d_navigation_preset();
+#endif // _3D_DISABLED
 	void set_current_section(const String &p_section);
 	void set_advanced_mode_enabled(bool p_enabled);
 	static EditorSettingsDialog *get_singleton() { return singleton; }

--- a/editor/shader/shader_text_editor.cpp
+++ b/editor/shader/shader_text_editor.cpp
@@ -43,14 +43,18 @@
 #include "editor/script/syntax_highlighters.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#ifndef _3D_DISABLED
 #include "scene/3d/mesh_instance_3d.h"
+#endif // _3D_DISABLED
 #include "scene/gui/panel_container.h"
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/resources/shader.h"
+#ifndef _3D_DISABLED
 #include "scene/resources/sky.h"
+#endif // _3D_DISABLED
 #include "scene/resources/style_box_flat.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
@@ -208,12 +212,14 @@ HashMap<String, String> TextShaderPreview::builtin_canvas_types = {
 };
 
 TextShaderPreview::TextShaderPreview() {
+#ifndef _3D_DISABLED
 	env.instantiate();
 	Ref<Sky> sky = memnew(Sky);
 	env->set_sky(sky);
 	env->set_background(Environment::BG_COLOR);
 	env->set_ambient_source(Environment::AMBIENT_SOURCE_SKY);
 	env->set_reflection_source(Environment::REFLECTION_SOURCE_SKY);
+#endif // _3D_DISABLED
 
 	shader_material.instantiate();
 
@@ -566,7 +572,11 @@ void TextShaderPreview::_reset_shader_parameters(Ref<ShaderMaterial> &p_target) 
 }
 
 void TextShaderPreview::_show_error(const String &p_error) {
+#ifndef _3D_DISABLED
 	surface->edit(Ref<Material>(), env);
+#else
+	surface->edit(Ref<Material>());
+#endif // _3D_DISABLED
 	error_label->set_text(p_error);
 	surface_container->hide();
 	error_container->show();
@@ -596,6 +606,7 @@ Ref<ShaderMaterial> TextShaderPreview::_get_source_material() const {
 		return Ref<ShaderMaterial>();
 	}
 
+#ifndef _3D_DISABLED
 	const GeometryInstance3D *gi = Object::cast_to<GeometryInstance3D>(object);
 	if (gi) {
 		const Ref<ShaderMaterial> material_overlay = gi->get_material_overlay();
@@ -623,6 +634,7 @@ Ref<ShaderMaterial> TextShaderPreview::_get_source_material() const {
 			}
 		}
 	}
+#endif // _3D_DISABLED
 
 	return Ref<ShaderMaterial>();
 }
@@ -725,7 +737,11 @@ void TextShaderPreview::set_shader_code(const String &p_code, int p_line, bool p
 
 	error_container->hide();
 	surface_container->show();
+#ifndef _3D_DISABLED
 	surface->edit(shader_material.ptr(), env);
+#else
+	surface->edit(shader_material.ptr());
+#endif // _3D_DISABLED
 	surface->show(); // Edit may have called hide() earlier on failed compilation.
 }
 

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -45,13 +45,16 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
-#include "scene/3d/mesh_instance_3d.h"
 #include "scene/gui/split_container.h"
-#include "scene/resources/sky.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
 #include "servers/rendering/shader_preprocessor.h"
 #include "servers/rendering/shader_types.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/resources/sky.h"
+#endif // _3D_DISABLED
 
 #include "modules/regex/regex.h"
 
@@ -230,12 +233,14 @@ TextShaderPreview::TextShaderPreview() {
 	surface_container->set_custom_minimum_size(Size2(150, 150) * EDSCALE);
 	add_child(surface_container);
 
+#ifndef _3D_DISABLED
 	env.instantiate();
 	Ref<Sky> sky = memnew(Sky);
 	env->set_sky(sky);
 	env->set_background(Environment::BG_COLOR);
 	env->set_ambient_source(Environment::AMBIENT_SOURCE_SKY);
 	env->set_reflection_source(Environment::REFLECTION_SOURCE_SKY);
+#endif // _3D_DISABLED
 
 	surface = memnew(MaterialEditor);
 	surface_container->add_child(surface);
@@ -488,7 +493,11 @@ void TextShaderPreview::_reset_shader_parameters(Ref<ShaderMaterial> &p_target) 
 }
 
 void TextShaderPreview::_show_error(const String &p_error) {
+#ifndef _3D_DISABLED
 	surface->edit(Ref<Material>(), env);
+#else
+	surface->edit(Ref<Material>());
+#endif // _3D_DISABLED
 	error_label->set_text(p_error);
 	error_label->show();
 }
@@ -517,6 +526,7 @@ Ref<ShaderMaterial> TextShaderPreview::_get_source_material() const {
 		return Ref<ShaderMaterial>();
 	}
 
+#ifndef _3D_DISABLED
 	const GeometryInstance3D *gi = Object::cast_to<GeometryInstance3D>(object);
 	if (gi) {
 		const Ref<ShaderMaterial> material_overlay = gi->get_material_overlay();
@@ -544,6 +554,7 @@ Ref<ShaderMaterial> TextShaderPreview::_get_source_material() const {
 			}
 		}
 	}
+#endif // _3D_DISABLED
 
 	return Ref<ShaderMaterial>();
 }
@@ -638,7 +649,11 @@ void TextShaderPreview::set_shader_code(const String &p_code, int p_line, bool p
 
 	surface->show();
 	error_label->hide();
+#ifndef _3D_DISABLED
 	surface->edit(shader_material.ptr(), env);
+#else
+	surface->edit(shader_material.ptr());
+#endif // _3D_DISABLED
 }
 
 /*** SHADER SCRIPT EDITOR ****/

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -81,7 +81,9 @@ void CSGShapeEditor::_menu_option(int p_option) {
 			_create_baked_mesh_instance();
 		} break;
 		case MENU_OPTION_BAKE_COLLISION_SHAPE: {
+#ifndef PHYSICS_3D_DISABLED
 			_create_baked_collision_shape();
+#endif // PHYSICS_3D_DISABLED
 		} break;
 	}
 }
@@ -119,6 +121,7 @@ void CSGShapeEditor::_create_baked_mesh_instance() {
 	ur->commit_action();
 }
 
+#ifndef PHYSICS_3D_DISABLED
 void CSGShapeEditor::_create_baked_collision_shape() {
 	if (node == get_tree()->get_edited_scene_root()) {
 		err_dialog->set_text(TTR("Can not add a baked collision shape as sibling for the scene root.\nMove the CSG root node below a parent node."));
@@ -151,6 +154,7 @@ void CSGShapeEditor::_create_baked_collision_shape() {
 
 	ur->commit_action();
 }
+#endif // PHYSICS_3D_DISABLED
 
 CSGShapeEditor::CSGShapeEditor() {
 	options = memnew(MenuButton);
@@ -162,7 +166,9 @@ CSGShapeEditor::CSGShapeEditor() {
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(options);
 
 	options->get_popup()->add_item(TTR("Bake Mesh Instance"), MENU_OPTION_BAKE_MESH_INSTANCE);
+#ifndef PHYSICS_3D_DISABLED
 	options->get_popup()->add_item(TTR("Bake Collision Shape"), MENU_OPTION_BAKE_COLLISION_SHAPE);
+#endif // PHYSICS_3D_DISABLED
 
 	options->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &CSGShapeEditor::_menu_option));
 

--- a/modules/csg/editor/csg_gizmos.h
+++ b/modules/csg/editor/csg_gizmos.h
@@ -76,7 +76,9 @@ class CSGShapeEditor : public Control {
 	void _menu_option(int p_option);
 
 	void _create_baked_mesh_instance();
+#ifndef PHYSICS_3D_DISABLED
 	void _create_baked_collision_shape();
+#endif // PHYSICS_3D_DISABLED
 
 protected:
 	void _node_removed(Node *p_node);

--- a/modules/lightmapper_rd/config.py
+++ b/modules/lightmapper_rd/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return env.editor_build
+    return not env["disable_3d"] and env.editor_build
 
 
 def configure(env):

--- a/modules/lightmapper_rd/config.py
+++ b/modules/lightmapper_rd/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return env.editor_build and env["rendering_device"]
+    return not env["disable_3d"] and env.editor_build and env["rendering_device"]
 
 
 def configure(env):

--- a/modules/raycast/register_types.cpp
+++ b/modules/raycast/register_types.cpp
@@ -41,7 +41,7 @@ void initialize_raycast_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) && !defined(_3D_DISABLED)
 	LightmapRaycasterEmbree::make_default_raycaster();
 	StaticRaycasterEmbree::make_default_raycaster();
 #endif

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -2124,7 +2124,11 @@ void VisualShaderEditor::_clear_preview_param() {
 }
 
 void VisualShaderEditor::_update_preview_parameter_list() {
+#ifndef _3D_DISABLED
 	material_editor->edit(preview_material.ptr(), env);
+#else
+	material_editor->edit(preview_material.ptr());
+#endif // _3D_DISABLED
 
 	List<PropertyInfo> properties;
 	RenderingServer::get_singleton()->get_shader_parameter_list(visual_shader->get_rid(), &properties);
@@ -6858,12 +6862,14 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	// Initialize material editor.
 	{
+#ifndef _3D_DISABLED
 		env.instantiate();
 		Ref<Sky> sky = memnew(Sky());
 		env->set_sky(sky);
 		env->set_background(Environment::BG_COLOR);
 		env->set_ambient_source(Environment::AMBIENT_SOURCE_SKY);
 		env->set_reflection_source(Environment::REFLECTION_SOURCE_SKY);
+#endif // _3D_DISABLED
 
 		preview_material.instantiate();
 		preview_material->connect(CoreStringName(property_list_changed), callable_mp(this, &VisualShaderEditor::_update_preview_parameter_list));

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -2745,7 +2745,11 @@ void VisualShaderEditor::_clear_preview_param() {
 }
 
 void VisualShaderEditor::_update_preview_parameter_list() {
-	material_editor->edit(preview_material.ptr(), preview_environment);
+#ifndef _3D_DISABLED
+	material_editor->edit(preview_material.ptr(), env);
+#else
+	material_editor->edit(preview_material.ptr());
+#endif // _3D_DISABLED
 
 	List<PropertyInfo> properties;
 	RenderingServer::get_singleton()->get_shader_parameter_list(visual_shader->get_rid(), &properties);
@@ -7763,12 +7767,14 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	// Initialize material editor.
 	{
-		preview_environment.instantiate();
+#ifndef _3D_DISABLED
+		env.instantiate();
 		Ref<Sky> sky = memnew(Sky());
-		preview_environment->set_sky(sky);
-		preview_environment->set_background(Environment::BG_COLOR);
-		preview_environment->set_ambient_source(Environment::AMBIENT_SOURCE_SKY);
-		preview_environment->set_reflection_source(Environment::REFLECTION_SOURCE_SKY);
+		env->set_sky(sky);
+		env->set_background(Environment::BG_COLOR);
+		env->set_ambient_source(Environment::AMBIENT_SOURCE_SKY);
+		env->set_reflection_source(Environment::REFLECTION_SOURCE_SKY);
+#endif // _3D_DISABLED
 
 		preview_material.instantiate();
 		preview_material->connect(CoreStringName(property_list_changed), callable_mp(this, &VisualShaderEditor::_update_preview_parameter_list));

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.h
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.h
@@ -212,7 +212,9 @@ class VisualShaderEditor : public ShaderEditor {
 	MaterialEditor *material_editor = nullptr;
 	Ref<VisualShader> visual_shader;
 	Ref<ShaderMaterial> preview_material;
+#ifndef _3D_DISABLED
 	Ref<Environment> env;
+#endif // _3D_DISABLED
 	String param_filter_name;
 	EditorProperty *current_prop = nullptr;
 	VBoxContainer *shader_preview_vbox = nullptr;

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.h
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.h
@@ -266,7 +266,9 @@ class VisualShaderEditor : public ScriptEditorBase {
 	Ref<VisualShaderGroup> visual_shader_group; // Could be null.
 
 	Ref<ShaderMaterial> preview_material;
-	Ref<Environment> preview_environment;
+#ifndef _3D_DISABLED
+	Ref<Environment> env;
+#endif // _3D_DISABLED
 
 	Ref<ConfigFile> vs_editor_cache; // Keeps the graph offsets and zoom levels for each VisualShader that has been edited.
 

--- a/modules/xatlas_unwrap/config.py
+++ b/modules/xatlas_unwrap/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return env.editor_build
+    return not env["disable_3d"] and env.editor_build
 
 
 def configure(env):

--- a/platform/android/editor/game_menu_utils_jni.cpp
+++ b/platform/android/editor/game_menu_utils_jni.cpp
@@ -121,7 +121,9 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_res
 #ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
+#ifndef _3D_DISABLED
 		game_view_plugin->get_debugger()->reset_camera_3d_position();
+#endif // _3D_DISABLED
 	}
 #endif
 }

--- a/platform/android/editor/game_menu_utils_jni.cpp
+++ b/platform/android/editor/game_menu_utils_jni.cpp
@@ -139,7 +139,9 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_res
 #ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
+#ifndef _3D_DISABLED
 		game_view_plugin->get_debugger()->reset_camera_3d_position();
+#endif // _3D_DISABLED
 	}
 #endif
 }

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -677,6 +677,7 @@ void register_scene_types() {
 	GDREGISTER_VIRTUAL_CLASS(SkeletonModifier3D);
 	GDREGISTER_CLASS(ModifierBoneTarget3D);
 	GDREGISTER_CLASS(RetargetModifier3D);
+#ifndef PHYSICS_3D_DISABLED
 	GDREGISTER_VIRTUAL_CLASS(JointLimitation3D);
 	GDREGISTER_CLASS(JointLimitationCone3D);
 	GDREGISTER_CLASS(SpringBoneSimulator3D);
@@ -685,6 +686,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(SpringBoneCollisionCapsule3D);
 	GDREGISTER_CLASS(SpringBoneCollisionPlane3D);
 	GDREGISTER_VIRTUAL_CLASS(BoneConstraint3D);
+#endif // PHYSICS_3D_DISABLED
 	GDREGISTER_CLASS(CopyTransformModifier3D);
 	GDREGISTER_CLASS(ConvertTransformModifier3D);
 	GDREGISTER_CLASS(AimModifier3D);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -696,6 +696,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(RootMotionView);
 	GDREGISTER_VIRTUAL_CLASS(SkeletonModifier3D);
 	GDREGISTER_CLASS(RetargetModifier3D);
+#ifndef PHYSICS_3D_DISABLED
 	GDREGISTER_VIRTUAL_CLASS(JointLimitation3D);
 	GDREGISTER_CLASS(JointLimitationCone3D);
 	GDREGISTER_CLASS(SpringBoneSimulator3D);
@@ -704,6 +705,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(SpringBoneCollisionCapsule3D);
 	GDREGISTER_CLASS(SpringBoneCollisionPlane3D);
 	GDREGISTER_VIRTUAL_CLASS(BoneConstraint3D);
+#endif // PHYSICS_3D_DISABLED
 	GDREGISTER_CLASS(CopyTransformModifier3D);
 	GDREGISTER_CLASS(ConvertTransformModifier3D);
 	GDREGISTER_CLASS(AimModifier3D);

--- a/scene/resources/3d/world_3d.cpp
+++ b/scene/resources/3d/world_3d.cpp
@@ -49,8 +49,8 @@ void World3D::_remove_camera(Camera3D *p_camera) {
 	cameras.erase(p_camera);
 }
 
-RID World3D::get_space() const {
 #ifndef PHYSICS_3D_DISABLED
+RID World3D::get_space() const {
 	if (space.is_null()) {
 		space = PhysicsServer3D::get_singleton()->space_create();
 		PhysicsServer3D::get_singleton()->space_set_active(space, true);
@@ -59,9 +59,9 @@ RID World3D::get_space() const {
 		PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_LINEAR_DAMP, GLOBAL_GET("physics/3d/default_linear_damp"));
 		PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP, GLOBAL_GET("physics/3d/default_angular_damp"));
 	}
-#endif // PHYSICS_3D_DISABLED
 	return space;
 }
+#endif // PHYSICS_3D_DISABLED
 
 #ifndef NAVIGATION_3D_DISABLED
 RID World3D::get_navigation_map() const {
@@ -155,7 +155,10 @@ PhysicsDirectSpaceState3D *World3D::get_direct_space_state() {
 #endif // PHYSICS_3D_DISABLED
 
 void World3D::_bind_methods() {
+#ifndef PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_space"), &World3D::get_space);
+	ClassDB::bind_method(D_METHOD("get_direct_space_state"), &World3D::get_direct_space_state);
+#endif // PHYSICS_3D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_navigation_map"), &World3D::get_navigation_map);
 #endif // NAVIGATION_3D_DISABLED
@@ -166,20 +169,17 @@ void World3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_fallback_environment"), &World3D::get_fallback_environment);
 	ClassDB::bind_method(D_METHOD("set_camera_attributes", "attributes"), &World3D::set_camera_attributes);
 	ClassDB::bind_method(D_METHOD("get_camera_attributes"), &World3D::get_camera_attributes);
-#ifndef PHYSICS_3D_DISABLED
-	ClassDB::bind_method(D_METHOD("get_direct_space_state"), &World3D::get_direct_space_state);
-#endif // PHYSICS_3D_DISABLED
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "environment", PROPERTY_HINT_RESOURCE_TYPE, Environment::get_class_static()), "set_environment", "get_environment");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "fallback_environment", PROPERTY_HINT_RESOURCE_TYPE, Environment::get_class_static()), "set_fallback_environment", "get_fallback_environment");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "camera_attributes", PROPERTY_HINT_RESOURCE_TYPE, "CameraAttributesPractical,CameraAttributesPhysical"), "set_camera_attributes", "get_camera_attributes");
+	ADD_PROPERTY(PropertyInfo(Variant::RID, "scenario", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_scenario");
+#ifndef PHYSICS_3D_DISABLED
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_space");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "direct_space_state", PROPERTY_HINT_RESOURCE_TYPE, PhysicsDirectSpaceState3D::get_class_static(), PROPERTY_USAGE_NONE), "", "get_direct_space_state");
+#endif // PHYSICS_3D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "navigation_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_navigation_map");
 #endif // NAVIGATION_3D_DISABLED
-	ADD_PROPERTY(PropertyInfo(Variant::RID, "scenario", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_scenario");
-#ifndef PHYSICS_3D_DISABLED
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "direct_space_state", PROPERTY_HINT_RESOURCE_TYPE, PhysicsDirectSpaceState3D::get_class_static(), PROPERTY_USAGE_NONE), "", "get_direct_space_state");
-#endif // PHYSICS_3D_DISABLED
 }
 
 World3D::World3D() {

--- a/scene/resources/3d/world_3d.cpp
+++ b/scene/resources/3d/world_3d.cpp
@@ -53,8 +53,8 @@ void World3D::_remove_camera(Camera3D *p_camera) {
 	cameras.erase(p_camera);
 }
 
-RID World3D::get_space() const {
 #ifndef PHYSICS_3D_DISABLED
+RID World3D::get_space() const {
 	if (space.is_null()) {
 		space = PhysicsServer3D::get_singleton()->space_create();
 		PhysicsServer3D::get_singleton()->space_set_active(space, true);
@@ -63,9 +63,9 @@ RID World3D::get_space() const {
 		PhysicsServer3D::get_singleton()->area_set_param(space, PS3DE::AREA_PARAM_LINEAR_DAMP, GLOBAL_GET("physics/3d/default_linear_damp"));
 		PhysicsServer3D::get_singleton()->area_set_param(space, PS3DE::AREA_PARAM_ANGULAR_DAMP, GLOBAL_GET("physics/3d/default_angular_damp"));
 	}
-#endif // PHYSICS_3D_DISABLED
 	return space;
 }
+#endif // PHYSICS_3D_DISABLED
 
 #ifndef NAVIGATION_3D_DISABLED
 RID World3D::get_navigation_map() const {
@@ -159,7 +159,10 @@ PhysicsDirectSpaceState3D *World3D::get_direct_space_state() {
 #endif // PHYSICS_3D_DISABLED
 
 void World3D::_bind_methods() {
+#ifndef PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_space"), &World3D::get_space);
+	ClassDB::bind_method(D_METHOD("get_direct_space_state"), &World3D::get_direct_space_state);
+#endif // PHYSICS_3D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_navigation_map"), &World3D::get_navigation_map);
 #endif // NAVIGATION_3D_DISABLED
@@ -170,20 +173,17 @@ void World3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_fallback_environment"), &World3D::get_fallback_environment);
 	ClassDB::bind_method(D_METHOD("set_camera_attributes", "attributes"), &World3D::set_camera_attributes);
 	ClassDB::bind_method(D_METHOD("get_camera_attributes"), &World3D::get_camera_attributes);
-#ifndef PHYSICS_3D_DISABLED
-	ClassDB::bind_method(D_METHOD("get_direct_space_state"), &World3D::get_direct_space_state);
-#endif // PHYSICS_3D_DISABLED
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "environment", PROPERTY_HINT_RESOURCE_TYPE, Environment::get_class_static()), "set_environment", "get_environment");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "fallback_environment", PROPERTY_HINT_RESOURCE_TYPE, Environment::get_class_static()), "set_fallback_environment", "get_fallback_environment");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "camera_attributes", PROPERTY_HINT_RESOURCE_TYPE, "CameraAttributesPractical,CameraAttributesPhysical"), "set_camera_attributes", "get_camera_attributes");
+	ADD_PROPERTY(PropertyInfo(Variant::RID, "scenario", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_scenario");
+#ifndef PHYSICS_3D_DISABLED
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_space");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "direct_space_state", PROPERTY_HINT_RESOURCE_TYPE, PhysicsDirectSpaceState3D::get_class_static(), PROPERTY_USAGE_NONE), "", "get_direct_space_state");
+#endif // PHYSICS_3D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "navigation_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_navigation_map");
 #endif // NAVIGATION_3D_DISABLED
-	ADD_PROPERTY(PropertyInfo(Variant::RID, "scenario", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_scenario");
-#ifndef PHYSICS_3D_DISABLED
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "direct_space_state", PROPERTY_HINT_RESOURCE_TYPE, PhysicsDirectSpaceState3D::get_class_static(), PROPERTY_USAGE_NONE), "", "get_direct_space_state");
-#endif // PHYSICS_3D_DISABLED
 }
 
 World3D::World3D() {

--- a/scene/resources/3d/world_3d.h
+++ b/scene/resources/3d/world_3d.h
@@ -48,7 +48,9 @@ class World3D : public Resource {
 
 private:
 	RID scenario;
+#ifndef PHYSICS_3D_DISABLED
 	mutable RID space;
+#endif // PHYSICS_3D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
 	mutable RID navigation_map;
 #endif // NAVIGATION_3D_DISABLED
@@ -69,7 +71,9 @@ protected:
 	void _remove_camera(Camera3D *p_camera);
 
 public:
+#ifndef PHYSICS_3D_DISABLED
 	RID get_space() const;
+#endif // PHYSICS_3D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
 	RID get_navigation_map() const;
 #endif // NAVIGATION_3D_DISABLED


### PR DESCRIPTION
Allows building the editor using `disable_navigation_3d=yes`, `disable_physics_3d=yes` or `disable_3d=yes`.

* Discussion: https://github.com/godotengine/godot-proposals/discussions/12305

I just have submitted my answers for Godot Community poll, noticing that the majority of Godot users focus on 2D games and GUI applications, but yet only 6% are recompiling the engine so I do agree that the cost is more the benefits, but it worth to be updated for those who needs it and until many users be familiar with building 2D templates.

Size Comparison: https://github.com/mounirtohami/godot/actions/runs/16565434882
<img width="500" height="388" alt="image" src="https://github.com/user-attachments/assets/98b66f49-1125-4288-a091-6b529baf6d3e" />

