### PR TITLE
Deprecate GridMap built-in navmesh feature `bake_navigation` option

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -89,7 +89,7 @@
 				Returns an array of [Transform3D] and [Mesh] references corresponding to the non-empty cells in the grid. The transforms are specified in local space.
 			</description>
 		</method>
-		<method name="get_navigation_map" qualifiers="const">
+		<method name="get_navigation_map" qualifiers="const" deprecated="[GridMap]&apos;s built-in navigation mesh is no longer supported. Use the regular navigation system from [NavigationRegion3D] or [NavigationServer3D] instead.">
 			<return type="RID" />
 			<description>
 				Returns the [RID] of the navigation map this GridMap node uses for its cell baked navigation meshes.
@@ -172,7 +172,7 @@
 				Based on [param value], enables or disables the specified layer in the [member collision_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
-		<method name="set_navigation_map">
+		<method name="set_navigation_map" deprecated="[GridMap]&apos;s built-in navigation mesh is no longer supported. Use the regular navigation system from [NavigationRegion3D] or [NavigationServer3D] instead.">
 			<return type="void" />
 			<param index="0" name="navigation_map" type="RID" />
 			<description>
@@ -181,7 +181,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="bake_navigation" type="bool" setter="set_bake_navigation" getter="is_baking_navigation" default="false">
+		<member name="bake_navigation" type="bool" setter="set_bake_navigation" getter="is_baking_navigation" default="false" deprecated="[GridMap]&apos;s built-in navigation mesh is no longer supported. Use the regular navigation system from [NavigationRegion3D] or [NavigationServer3D] instead.">
 			If [code]true[/code], this GridMap creates a navigation region for each cell that uses a [member mesh_library] item with a navigation mesh. The created navigation region will use the navigation layers bitmask assigned to the [MeshLibrary]'s item.
 		</member>
 		<member name="cell_center_x" type="bool" setter="set_center_x" getter="get_center_x" default="true">

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -241,16 +241,21 @@ Array GridMap::get_collision_shapes() const {
 }
 #endif // PHYSICS_3D_DISABLED
 
+#if !defined(DISABLE_DEPRECATED)
 void GridMap::set_bake_navigation(bool p_bake_navigation) {
 	bake_navigation = p_bake_navigation;
 	_recreate_octant_data();
+	if (bake_navigation) {
+		WARN_DEPRECATED_MSG("GridMap 'bake_navigation' built-in navigation mesh is no longer supported. Use the regular navigation NavigationRegion3D / NavigationServer3D system instead.");
+	}
 }
 
 bool GridMap::is_baking_navigation() {
 	return bake_navigation;
 }
+#endif // !defined(DISABLE_DEPRECATED)
 
-#ifndef NAVIGATION_3D_DISABLED
+#if !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 void GridMap::set_navigation_map(RID p_navigation_map) {
 	map_override = p_navigation_map;
 	for (const KeyValue<OctantKey, Octant *> &E : octant_map) {
@@ -271,7 +276,7 @@ RID GridMap::get_navigation_map() const {
 	}
 	return RID();
 }
-#endif // NAVIGATION_3D_DISABLED
+#endif // !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 
 void GridMap::set_mesh_library(const Ref<MeshLibrary> &p_mesh_library) {
 	if (mesh_library.is_valid()) {
@@ -546,7 +551,7 @@ void GridMap::_octant_transform(const OctantKey &p_key) {
 	}
 #endif // PHYSICS_3D_DISABLED
 
-#ifndef NAVIGATION_3D_DISABLED
+#if !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 	// update transform for NavigationServer regions and navigation debugmesh instances
 	for (const KeyValue<IndexKey, Octant::NavigationCell> &E : g.navigation_cell_ids) {
 		if (bake_navigation) {
@@ -558,7 +563,7 @@ void GridMap::_octant_transform(const OctantKey &p_key) {
 			}
 		}
 	}
-#endif // NAVIGATION_3D_DISABLED
+#endif // !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 
 	for (int i = 0; i < g.multimesh_instances.size(); i++) {
 		RS::get_singleton()->instance_set_transform(g.multimesh_instances[i].instance, get_global_transform());
@@ -582,7 +587,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 	}
 #endif // PHYSICS_3D_DISABLED
 
-#ifndef NAVIGATION_3D_DISABLED
+#if !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 	//erase navigation
 	for (KeyValue<IndexKey, Octant::NavigationCell> &E : g.navigation_cell_ids) {
 		if (E.value.region.is_valid()) {
@@ -595,7 +600,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 		}
 	}
 	g.navigation_cell_ids.clear();
-#endif // NAVIGATION_3D_DISABLED
+#endif // !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 
 	//erase multimeshes
 
@@ -665,7 +670,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 		}
 #endif // PHYSICS_3D_DISABLED
 
-#ifndef NAVIGATION_3D_DISABLED
+#if !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 		// add the item's navigation_mesh at given xform to GridMap's Navigation ancestor
 		Ref<NavigationMesh> navigation_mesh = mesh_library->get_item_navigation_mesh(c.item);
 		if (navigation_mesh.is_valid()) {
@@ -706,14 +711,8 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 			}
 			g.navigation_cell_ids[E] = nm;
 		}
-#endif // NAVIGATION_3D_DISABLED
+#endif // !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 	}
-
-#if defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
-	if (bake_navigation) {
-		_update_octant_navigation_debug_edge_connections_mesh(p_key);
-	}
-#endif // defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
 
 	//update multimeshes, only if not baked
 	if (baked_meshes.is_empty()) {
@@ -817,7 +816,7 @@ void GridMap::_octant_enter_world(const OctantKey &p_key) {
 		RS::get_singleton()->instance_set_transform(g.multimesh_instances[i].instance, get_global_transform());
 	}
 
-#ifndef NAVIGATION_3D_DISABLED
+#if !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 	if (bake_navigation && mesh_library.is_valid()) {
 		for (KeyValue<IndexKey, Octant::NavigationCell> &F : g.navigation_cell_ids) {
 			if (cell_map.has(F.key) && F.value.region.is_valid() == false) {
@@ -838,21 +837,8 @@ void GridMap::_octant_enter_world(const OctantKey &p_key) {
 				}
 			}
 		}
-
-#ifdef DEBUG_ENABLED
-		if (bake_navigation) {
-			if (!g.navigation_debug_edge_connections_instance.is_valid()) {
-				g.navigation_debug_edge_connections_instance = RenderingServer::get_singleton()->instance_create();
-			}
-			if (g.navigation_debug_edge_connections_mesh.is_null()) {
-				g.navigation_debug_edge_connections_mesh.instantiate();
-			}
-
-			_update_octant_navigation_debug_edge_connections_mesh(p_key);
-		}
-#endif // DEBUG_ENABLED
 	}
-#endif // NAVIGATION_3D_DISABLED
+#endif // !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 }
 
 void GridMap::_octant_exit_world(const OctantKey &p_key) {
@@ -860,9 +846,9 @@ void GridMap::_octant_exit_world(const OctantKey &p_key) {
 #ifndef PHYSICS_3D_DISABLED
 	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
 #endif // PHYSICS_3D_DISABLED
-#ifndef NAVIGATION_3D_DISABLED
+#if !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
-#endif // NAVIGATION_3D_DISABLED
+#endif // !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 
 	ERR_FAIL_COND(!octant_map.has(p_key));
 	Octant &g = *octant_map[p_key];
@@ -880,7 +866,7 @@ void GridMap::_octant_exit_world(const OctantKey &p_key) {
 		RS::get_singleton()->instance_set_scenario(g.multimesh_instances[i].instance, RID());
 	}
 
-#ifndef NAVIGATION_3D_DISABLED
+#if !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 	for (KeyValue<IndexKey, Octant::NavigationCell> &F : g.navigation_cell_ids) {
 		if (F.value.region.is_valid()) {
 			NavigationServer3D::get_singleton()->free(F.value.region);
@@ -891,19 +877,7 @@ void GridMap::_octant_exit_world(const OctantKey &p_key) {
 			F.value.navigation_mesh_debug_instance = RID();
 		}
 	}
-#endif // NAVIGATION_3D_DISABLED
-
-#ifdef DEBUG_ENABLED
-	if (bake_navigation) {
-		if (g.navigation_debug_edge_connections_instance.is_valid()) {
-			RenderingServer::get_singleton()->free(g.navigation_debug_edge_connections_instance);
-			g.navigation_debug_edge_connections_instance = RID();
-		}
-		if (g.navigation_debug_edge_connections_mesh.is_valid()) {
-			g.navigation_debug_edge_connections_mesh.unref();
-		}
-	}
-#endif // DEBUG_ENABLED
+#endif // !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 }
 
 void GridMap::_octant_clean_up(const OctantKey &p_key) {
@@ -911,9 +885,9 @@ void GridMap::_octant_clean_up(const OctantKey &p_key) {
 #ifndef PHYSICS_3D_DISABLED
 	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
 #endif // PHYSICS_3D_DISABLED
-#ifndef NAVIGATION_3D_DISABLED
+#if !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
-#endif // NAVIGATION_3D_DISABLED
+#endif // !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 
 	ERR_FAIL_COND(!octant_map.has(p_key));
 	Octant &g = *octant_map[p_key];
@@ -929,7 +903,7 @@ void GridMap::_octant_clean_up(const OctantKey &p_key) {
 	PhysicsServer3D::get_singleton()->free(g.static_body);
 #endif // PHYSICS_3D_DISABLED
 
-#ifndef NAVIGATION_3D_DISABLED
+#if !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 	// Erase navigation
 	for (const KeyValue<IndexKey, Octant::NavigationCell> &E : g.navigation_cell_ids) {
 		if (E.value.region.is_valid()) {
@@ -940,19 +914,7 @@ void GridMap::_octant_clean_up(const OctantKey &p_key) {
 		}
 	}
 	g.navigation_cell_ids.clear();
-#endif // NAVIGATION_3D_DISABLED
-
-#ifdef DEBUG_ENABLED
-	if (bake_navigation) {
-		if (g.navigation_debug_edge_connections_instance.is_valid()) {
-			RenderingServer::get_singleton()->free(g.navigation_debug_edge_connections_instance);
-			g.navigation_debug_edge_connections_instance = RID();
-		}
-		if (g.navigation_debug_edge_connections_mesh.is_valid()) {
-			g.navigation_debug_edge_connections_mesh.unref();
-		}
-	}
-#endif // DEBUG_ENABLED
+#endif // !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 
 	//erase multimeshes
 
@@ -979,11 +941,6 @@ void GridMap::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
-#if defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
-			if (bake_navigation && NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
-				_update_navigation_debug_edge_connections();
-			}
-#endif // defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
 			_update_visibility();
 		} break;
 
@@ -1127,13 +1084,15 @@ void GridMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_physics_material"), &GridMap::get_physics_material);
 #endif // PHYSICS_3D_DISABLED
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_bake_navigation", "bake_navigation"), &GridMap::set_bake_navigation);
 	ClassDB::bind_method(D_METHOD("is_baking_navigation"), &GridMap::is_baking_navigation);
+#endif // DISABLE_DEPRECATED
 
-#ifndef NAVIGATION_3D_DISABLED
+#if !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 	ClassDB::bind_method(D_METHOD("set_navigation_map", "navigation_map"), &GridMap::set_navigation_map);
 	ClassDB::bind_method(D_METHOD("get_navigation_map"), &GridMap::get_navigation_map);
-#endif // NAVIGATION_3D_DISABLED
+#endif // !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 
 	ClassDB::bind_method(D_METHOD("set_mesh_library", "mesh_library"), &GridMap::set_mesh_library);
 	ClassDB::bind_method(D_METHOD("get_mesh_library"), &GridMap::get_mesh_library);
@@ -1195,8 +1154,11 @@ void GridMap::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_priority"), "set_collision_priority", "get_collision_priority");
 #endif // PHYSICS_3D_DISABLED
+
+#ifndef DISABLE_DEPRECATED
 	ADD_GROUP("Navigation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bake_navigation"), "set_bake_navigation", "is_baking_navigation");
+#endif // DISABLE_DEPRECATED
 
 	BIND_CONSTANT(INVALID_CELL_ITEM);
 
@@ -1396,10 +1358,6 @@ RID GridMap::get_bake_mesh_instance(int p_idx) {
 
 GridMap::GridMap() {
 	set_notify_transform(true);
-#if defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
-	NavigationServer3D::get_singleton()->connect("map_changed", callable_mp(this, &GridMap::_navigation_map_changed));
-	NavigationServer3D::get_singleton()->connect("navigation_debug_changed", callable_mp(this, &GridMap::_update_navigation_debug_edge_connections));
-#endif // defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
 }
 
 #ifndef NAVIGATION_3D_DISABLED
@@ -1544,126 +1502,6 @@ void GridMap::navmesh_parse_source_geometry(const Ref<NavigationMesh> &p_navigat
 }
 #endif // NAVIGATION_3D_DISABLED
 
-#if defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
-void GridMap::_update_navigation_debug_edge_connections() {
-	if (bake_navigation) {
-		for (const KeyValue<OctantKey, Octant *> &E : octant_map) {
-			_update_octant_navigation_debug_edge_connections_mesh(E.key);
-		}
-	}
-}
-
-void GridMap::_navigation_map_changed(RID p_map) {
-	if (bake_navigation && is_inside_tree() && p_map == get_world_3d()->get_navigation_map()) {
-		_update_navigation_debug_edge_connections();
-	}
-}
-#endif // defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
-
 GridMap::~GridMap() {
 	clear();
-#if defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
-	NavigationServer3D::get_singleton()->disconnect("map_changed", callable_mp(this, &GridMap::_navigation_map_changed));
-	NavigationServer3D::get_singleton()->disconnect("navigation_debug_changed", callable_mp(this, &GridMap::_update_navigation_debug_edge_connections));
-#endif // defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
 }
-
-#if defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
-void GridMap::_update_octant_navigation_debug_edge_connections_mesh(const OctantKey &p_key) {
-	ERR_FAIL_COND(!octant_map.has(p_key));
-	Octant &g = *octant_map[p_key];
-
-	if (!NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
-		if (g.navigation_debug_edge_connections_instance.is_valid()) {
-			RS::get_singleton()->instance_set_visible(g.navigation_debug_edge_connections_instance, false);
-		}
-		return;
-	}
-
-	if (!is_inside_tree()) {
-		return;
-	}
-
-	if (!bake_navigation) {
-		if (g.navigation_debug_edge_connections_instance.is_valid()) {
-			RS::get_singleton()->instance_set_visible(g.navigation_debug_edge_connections_instance, false);
-		}
-		return;
-	}
-
-	if (!g.navigation_debug_edge_connections_instance.is_valid()) {
-		g.navigation_debug_edge_connections_instance = RenderingServer::get_singleton()->instance_create();
-	}
-
-	if (g.navigation_debug_edge_connections_mesh.is_null()) {
-		g.navigation_debug_edge_connections_mesh.instantiate();
-	}
-
-	g.navigation_debug_edge_connections_mesh->clear_surfaces();
-
-	float edge_connection_margin = NavigationServer3D::get_singleton()->map_get_edge_connection_margin(get_world_3d()->get_navigation_map());
-	float half_edge_connection_margin = edge_connection_margin * 0.5;
-
-	Vector<Vector3> vertex_array;
-
-	for (KeyValue<IndexKey, Octant::NavigationCell> &F : g.navigation_cell_ids) {
-		if (cell_map.has(F.key) && F.value.region.is_valid()) {
-			int connections_count = NavigationServer3D::get_singleton()->region_get_connections_count(F.value.region);
-			if (connections_count == 0) {
-				continue;
-			}
-
-			for (int i = 0; i < connections_count; i++) {
-				Vector3 connection_pathway_start = NavigationServer3D::get_singleton()->region_get_connection_pathway_start(F.value.region, i);
-				Vector3 connection_pathway_end = NavigationServer3D::get_singleton()->region_get_connection_pathway_end(F.value.region, i);
-
-				Vector3 direction_start_end = connection_pathway_start.direction_to(connection_pathway_end);
-				Vector3 direction_end_start = connection_pathway_end.direction_to(connection_pathway_start);
-
-				Vector3 start_right_dir = direction_start_end.cross(Vector3(0, 1, 0));
-				Vector3 start_left_dir = -start_right_dir;
-
-				Vector3 end_right_dir = direction_end_start.cross(Vector3(0, 1, 0));
-				Vector3 end_left_dir = -end_right_dir;
-
-				Vector3 left_start_pos = connection_pathway_start + (start_left_dir * half_edge_connection_margin);
-				Vector3 right_start_pos = connection_pathway_start + (start_right_dir * half_edge_connection_margin);
-				Vector3 left_end_pos = connection_pathway_end + (end_right_dir * half_edge_connection_margin);
-				Vector3 right_end_pos = connection_pathway_end + (end_left_dir * half_edge_connection_margin);
-
-				vertex_array.push_back(right_end_pos);
-				vertex_array.push_back(left_start_pos);
-				vertex_array.push_back(right_start_pos);
-
-				vertex_array.push_back(left_end_pos);
-				vertex_array.push_back(right_end_pos);
-				vertex_array.push_back(right_start_pos);
-			}
-		}
-	}
-
-	if (vertex_array.is_empty()) {
-		return;
-	}
-
-	Ref<StandardMaterial3D> edge_connections_material = NavigationServer3D::get_singleton()->get_debug_navigation_edge_connections_material();
-
-	Array mesh_array;
-	mesh_array.resize(Mesh::ARRAY_MAX);
-	mesh_array[Mesh::ARRAY_VERTEX] = vertex_array;
-
-	g.navigation_debug_edge_connections_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, mesh_array);
-	g.navigation_debug_edge_connections_mesh->surface_set_material(0, edge_connections_material);
-
-	RS::get_singleton()->instance_set_base(g.navigation_debug_edge_connections_instance, g.navigation_debug_edge_connections_mesh->get_rid());
-	RS::get_singleton()->instance_set_visible(g.navigation_debug_edge_connections_instance, is_visible_in_tree());
-	if (is_inside_tree()) {
-		RS::get_singleton()->instance_set_scenario(g.navigation_debug_edge_connections_instance, get_world_3d()->get_scenario());
-	}
-
-	bool enable_edge_connections = NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_connections();
-	if (!enable_edge_connections) {
-		RS::get_singleton()->instance_set_visible(g.navigation_debug_edge_connections_instance, false);
-	}
-}
-#endif // defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -98,12 +98,14 @@ class GridMap : public Node3D {
 	 * A GridMap can have multiple Octants.
 	 */
 	struct Octant {
+#if !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 		struct NavigationCell {
 			RID region;
 			Transform3D xform;
 			RID navigation_mesh_debug_instance;
 			uint32_t navigation_layers = 1;
 		};
+#endif // !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 
 		struct MultimeshInstance {
 			RID instance;
@@ -121,14 +123,12 @@ class GridMap : public Node3D {
 		HashSet<IndexKey> cells;
 		RID collision_debug;
 		RID collision_debug_instance;
-#ifdef DEBUG_ENABLED
-		RID navigation_debug_edge_connections_instance;
-		Ref<ArrayMesh> navigation_debug_edge_connections_mesh;
-#endif // DEBUG_ENABLED
 
 		bool dirty = false;
 		RID static_body;
+#if !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 		HashMap<IndexKey, NavigationCell> navigation_cell_ids;
+#endif // !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 	};
 
 	union OctantKey {
@@ -158,7 +158,9 @@ class GridMap : public Node3D {
 	real_t collision_priority = 1.0;
 	Ref<PhysicsMaterial> physics_material;
 #endif // PHYSICS_3D_DISABLED
+#ifndef DISABLE_DEPRECATED
 	bool bake_navigation = false;
+#endif // DISABLE_DEPRECATED
 	RID map_override;
 
 	Transform3D last_transform;
@@ -200,11 +202,6 @@ class GridMap : public Node3D {
 	bool _octant_update(const OctantKey &p_key);
 	void _octant_clean_up(const OctantKey &p_key);
 	void _octant_transform(const OctantKey &p_key);
-#if defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
-	void _update_octant_navigation_debug_edge_connections_mesh(const OctantKey &p_key);
-	void _navigation_map_changed(RID p_map);
-	void _update_navigation_debug_edge_connections();
-#endif // defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
 	bool awaiting_update = false;
 
 	void _queue_octants_dirty();
@@ -261,13 +258,15 @@ public:
 	Array get_collision_shapes() const;
 #endif // PHYSICS_3D_DISABLED
 
+#ifndef DISABLE_DEPRECATED
 	void set_bake_navigation(bool p_bake_navigation);
 	bool is_baking_navigation();
+#endif // DISABLE_DEPRECATED
 
-#ifndef NAVIGATION_3D_DISABLED
+#if !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 	void set_navigation_map(RID p_navigation_map);
 	RID get_navigation_map() const;
-#endif // NAVIGATION_3D_DISABLED
+#endif // !defined(DISABLE_DEPRECATED) && !defined(NAVIGATION_3D_DISABLED)
 
 	void set_mesh_library(const Ref<MeshLibrary> &p_mesh_library);
 	Ref<MeshLibrary> get_mesh_library() const;


### PR DESCRIPTION
Deprecates GridMap built-in navmesh feature, aka `bake_navigation` option.

Also removes the half broken edge connection margin debug. It is not essential for compatibility and causes development issues. This debug will be rendered by the server (soon) going forward.

To be clear, this PR is NOT removing general navmesh support for GridMap. Also not removing NavigationMesh from MeshLibrary as some projects may use that resource navmesh for custom stuff.

You can bake navmesh using GridMap with e.g. `NavigationRegion3D` or `NavigationServer3D` just fine like usual.  In fact both can be improved the moment we no longer need to care to support the inferior and technically broken and unfixable built-in version of GridMap.

The problems with the GridMap built-in navmesh are a long list. To be blunt that feature was a design failure from the moment it was added (2016) as it ignored core basics of navmesh making half the issues unfixable.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
