### PR TITLE
[Web] Prevent unnecessary canvas resizes by flooring scaled dimensions

### DIFF
--- a/platform/web/js/libs/library_godot_display.js
+++ b/platform/web/js/libs/library_godot_display.js
@@ -306,11 +306,11 @@ const GodotDisplayScreen = {
 			const scale = GodotDisplayScreen.getPixelRatio();
 			if (isFullscreen || wantsFullWindow) {
 				// We need to match screen size.
-				width = window.innerWidth * scale;
-				height = window.innerHeight * scale;
+				width = Math.floor(window.innerWidth * scale);
+				height = Math.floor(window.innerHeight * scale);
 			}
-			const csw = `${width / scale}px`;
-			const csh = `${height / scale}px`;
+			const csw = `${Math.floor(width / scale)}px`;
+			const csh = `${Math.floor(height / scale)}px`;
 			if (canvas.style.width !== csw || canvas.style.height !== csh || canvas.width !== width || canvas.height !== height) {
 				// Size doesn't match.
 				// Resize canvas, set correct CSS pixel size, update GL.


### PR DESCRIPTION
`GodotDisplayScreen.updateSize()` was triggering canvas resizes on every frame due to fractional dimensions, leading to repeated [`emscripten_set_canvas_element_size` calls and unnecessary GL redraws](https://github.com/godotengine/godot/blob/2d3bdcac35ac22ee6c4d5d5edc88ba947d0659d5/platform/web/display_server_web.cpp#L59-L60).

Since `canvas.width` and `canvas.height` must be integers, both the canvas size and CSS size are now explicitly floored to avoid floating-point mismatches.

![Screenshot from 2025-04-20 16-56-55](https://github.com/user-attachments/assets/4ad8fb63-dd1f-4cae-ab15-402b79687b40)

This reduces frame time by **0.75-2ms** on my computer.

---

In my case it was always doing this check:
```
2559 != 2559.599932193756 
```