### PR TITLE
Add editor option to toggle idle parsing

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1564,9 +1564,11 @@
 		</member>
 		<member name="text_editor/completion/idle_parse_delay" type="float" setter="" getter="">
 			The delay in seconds after which the script editor should check for errors when the user stops typing.
+			[b]Note:[/b] [member text_editor/completion/idle_parse_enabled] must be [code]true[/code].
 		</member>
 		<member name="text_editor/completion/idle_parse_delay_with_errors_found" type="float" setter="" getter="">
 			The delay used instead of [member text_editor/completion/idle_parse_delay], when the parser has found errors. A lower value should feel more responsive while fixing code, but may cause notable stuttering and increase CPU usage.
+			[b]Note:[/b] [member text_editor/completion/idle_parse_enabled] must be [code]true[/code].
 		</member>
 		<member name="text_editor/completion/idle_parse_enabled" type="bool" setter="" getter="">
 			If [code]true[/code], scripts are checked for errors after typing stops. The delay before this happens is determined by [member text_editor/completion/idle_parse_delay] and [member text_editor/completion/idle_parse_delay_with_errors_found]. Saving will check for errors regardless of this setting.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1568,6 +1568,9 @@
 		<member name="text_editor/completion/idle_parse_delay_with_errors_found" type="float" setter="" getter="">
 			The delay used instead of [member text_editor/completion/idle_parse_delay], when the parser has found errors. A lower value should feel more responsive while fixing code, but may cause notable stuttering and increase CPU usage.
 		</member>
+		<member name="text_editor/completion/idle_parse_enabled" type="bool" setter="" getter="">
+			Whether or not scripts should periodically be parsed when the user stops typing. If enabled, the idle parsing delay is determined by [member text_editor/completion/idle_parse_delay] and [member text_editor/completion/idle_parse_delay_with_errors_found]. Parsing is always performed when the script is saved.
+		</member>
 		<member name="text_editor/completion/put_callhint_tooltip_below_current_line" type="bool" setter="" getter="">
 			If [code]true[/code], the code completion tooltip will appear below the current line unless there is no space on screen below the current line. If [code]false[/code], the code completion tooltip will appear above the current line.
 		</member>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1562,6 +1562,9 @@
 		<member name="text_editor/completion/complete_file_paths" type="bool" setter="" getter="">
 			If [code]true[/code], provides autocompletion suggestions for file paths in methods such as [code]load()[/code] and [code]preload()[/code].
 		</member>
+		<member name="text_editor/completion/idle_parse_enabled" type="bool" setter="" getter="">
+			If [code]true[/code], scripts are checked for errors after typing stops. The delay before this happens is determined by [member text_editor/completion/idle_parse_delay] and [member text_editor/completion/idle_parse_delay_with_errors_found]. Saving will check for errors regardless of this setting.
+		</member>
 		<member name="text_editor/completion/idle_parse_delay" type="float" setter="" getter="">
 			The delay in seconds after which the script editor should check for errors when the user stops typing.
 			[b]Note:[/b] [member text_editor/completion/idle_parse_enabled] must be [code]true[/code].
@@ -1569,9 +1572,6 @@
 		<member name="text_editor/completion/idle_parse_delay_with_errors_found" type="float" setter="" getter="">
 			The delay used instead of [member text_editor/completion/idle_parse_delay], when the parser has found errors. A lower value should feel more responsive while fixing code, but may cause notable stuttering and increase CPU usage.
 			[b]Note:[/b] [member text_editor/completion/idle_parse_enabled] must be [code]true[/code].
-		</member>
-		<member name="text_editor/completion/idle_parse_enabled" type="bool" setter="" getter="">
-			If [code]true[/code], scripts are checked for errors after typing stops. The delay before this happens is determined by [member text_editor/completion/idle_parse_delay] and [member text_editor/completion/idle_parse_delay_with_errors_found]. Saving will check for errors regardless of this setting.
 		</member>
 		<member name="text_editor/completion/put_callhint_tooltip_below_current_line" type="bool" setter="" getter="">
 			If [code]true[/code], the code completion tooltip will appear below the current line unless there is no space on screen below the current line. If [code]false[/code], the code completion tooltip will appear above the current line.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1569,7 +1569,7 @@
 			The delay used instead of [member text_editor/completion/idle_parse_delay], when the parser has found errors. A lower value should feel more responsive while fixing code, but may cause notable stuttering and increase CPU usage.
 		</member>
 		<member name="text_editor/completion/idle_parse_enabled" type="bool" setter="" getter="">
-			Whether or not scripts should periodically be parsed when the user stops typing. If enabled, the idle parsing delay is determined by [member text_editor/completion/idle_parse_delay] and [member text_editor/completion/idle_parse_delay_with_errors_found]. Parsing is always performed when the script is saved.
+			If [code]true[/code], scripts are checked for errors after typing stops. The delay before this happens is determined by [member text_editor/completion/idle_parse_delay] and [member text_editor/completion/idle_parse_delay_with_errors_found]. Saving will check for errors regardless of this setting.
 		</member>
 		<member name="text_editor/completion/put_callhint_tooltip_below_current_line" type="bool" setter="" getter="">
 			If [code]true[/code], the code completion tooltip will appear below the current line unless there is no space on screen below the current line. If [code]false[/code], the code completion tooltip will appear above the current line.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1562,9 +1562,6 @@
 		<member name="text_editor/completion/complete_file_paths" type="bool" setter="" getter="">
 			If [code]true[/code], provides autocompletion suggestions for file paths in methods such as [code]load()[/code] and [code]preload()[/code].
 		</member>
-		<member name="text_editor/completion/idle_parse_enabled" type="bool" setter="" getter="">
-			If [code]true[/code], scripts are checked for errors after typing stops. The delay before this happens is determined by [member text_editor/completion/idle_parse_delay] and [member text_editor/completion/idle_parse_delay_with_errors_found]. Saving will check for errors regardless of this setting.
-		</member>
 		<member name="text_editor/completion/idle_parse_delay" type="float" setter="" getter="">
 			The delay in seconds after which the script editor should check for errors when the user stops typing.
 			[b]Note:[/b] [member text_editor/completion/idle_parse_enabled] must be [code]true[/code].
@@ -1572,6 +1569,9 @@
 		<member name="text_editor/completion/idle_parse_delay_with_errors_found" type="float" setter="" getter="">
 			The delay used instead of [member text_editor/completion/idle_parse_delay], when the parser has found errors. A lower value should feel more responsive while fixing code, but may cause notable stuttering and increase CPU usage.
 			[b]Note:[/b] [member text_editor/completion/idle_parse_enabled] must be [code]true[/code].
+		</member>
+		<member name="text_editor/completion/idle_parse_enabled" type="bool" setter="" getter="">
+			If [code]true[/code], scripts are checked for errors after typing stops. The delay before this happens is determined by [member text_editor/completion/idle_parse_delay] and [member text_editor/completion/idle_parse_delay_with_errors_found]. Saving will check for errors regardless of this setting.
 		</member>
 		<member name="text_editor/completion/put_callhint_tooltip_below_current_line" type="bool" setter="" getter="">
 			If [code]true[/code], the code completion tooltip will appear below the current line unless there is no space on screen below the current line. If [code]false[/code], the code completion tooltip will appear above the current line.

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1021,7 +1021,9 @@ void CodeTextEditor::_text_changed() {
 		code_complete_timer->start();
 	}
 
-	idle->start();
+	if (idle_parse_enabled) {
+		idle->start();
+	}
 
 	if (find_replace_bar) {
 		find_replace_bar->needs_to_count_results = true;
@@ -1171,6 +1173,7 @@ void CodeTextEditor::update_editor_settings() {
 	code_complete_timer->set_wait_time(EDITOR_GET("text_editor/completion/code_complete_delay"));
 	idle_time = EDITOR_GET("text_editor/completion/idle_parse_delay");
 	idle_time_with_errors = EDITOR_GET("text_editor/completion/idle_parse_delay_with_errors_found");
+	idle_parse_enabled = EDITOR_GET("text_editor/completion/idle_parse_enabled");
 
 	// Appearance: Guidelines
 	if (EDITOR_GET("text_editor/appearance/guidelines/show_line_length_guidelines")) {
@@ -1682,12 +1685,16 @@ void CodeTextEditor::_update_font_ligatures() {
 }
 
 void CodeTextEditor::_text_changed_idle_timeout() {
-	_validate_script();
-	emit_signal(SNAME("validate_script"));
+	if (idle_parse_enabled) {
+		_validate_script();
+		emit_signal(SNAME("validate_script"));
+	}
 }
 
 void CodeTextEditor::validate_script() {
-	idle->start();
+	if (idle_parse_enabled) {
+		idle->start();
+	}
 }
 
 void CodeTextEditor::_error_button_pressed() {

--- a/editor/gui/code_editor.h
+++ b/editor/gui/code_editor.h
@@ -179,6 +179,7 @@ class CodeTextEditor : public VBoxContainer {
 	bool code_complete_enabled = true;
 	Timer *code_complete_timer = nullptr;
 	int code_complete_timer_line = 0;
+	bool idle_parse_enabled = true;
 
 	float zoom_factor = 1.0f;
 

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -238,7 +238,7 @@ void ScriptTextEditor::apply_code() {
 
 	code_editor->get_text_editor()->get_syntax_highlighter()->update_cache();
 
-	_validate_script(); // Same as caling
+	_validate_script();
 	apply_code_locked = false;
 }
 

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -221,6 +221,12 @@ Vector<String> ScriptTextEditor::get_functions() {
 }
 
 void ScriptTextEditor::apply_code() {
+	if (apply_code_locked) {
+		WARN_PRINT("apply_code() called twice within the same callstack!");
+		return;
+	}
+
+	apply_code_locked = true;
 	Ref<Script> script = edited_res;
 	if (script.is_valid()) {
 		script->set_source_code(code_editor->get_text_editor()->get_text());
@@ -231,6 +237,9 @@ void ScriptTextEditor::apply_code() {
 	}
 
 	code_editor->get_text_editor()->get_syntax_highlighter()->update_cache();
+
+	_validate_script(); // Same as caling
+	apply_code_locked = false;
 }
 
 void ScriptTextEditor::set_edited_resource(const Ref<Resource> &p_res) {

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -238,7 +238,9 @@ void ScriptTextEditor::apply_code() {
 
 	code_editor->get_text_editor()->get_syntax_highlighter()->update_cache();
 
-	_validate_script();
+	if (editor_enabled) {
+		_validate_script();
+	}
 	apply_code_locked = false;
 }
 

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -60,6 +60,7 @@ class ScriptTextEditor : public CodeEditorBase {
 
 	Variant pending_state;
 	bool script_is_valid = false;
+	bool apply_code_locked = false;
 
 	RichTextLabel *errors_panel = nullptr;
 	Label *drag_info_label = nullptr;

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -855,9 +855,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_PLACEHOLDER_TEXT, "text_editor/external/exec_flags", "{file}", "Call flags with placeholders: {project}, {file}, {col}, {line}.");
 
 	// Completion
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/completion/idle_parse_enabled", true, "");
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay", 1.5, "0.1,10,0.01");
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay_with_errors_found", 0.5, "0.1,5,0.01");
-	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/completion/idle_parse_enabled", true, "");
 	_initial_set("text_editor/completion/auto_brace_complete", true, true);
 	_initial_set("text_editor/completion/code_complete_enabled", true, true);
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01,or_greater");

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -855,11 +855,12 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_PLACEHOLDER_TEXT, "text_editor/external/exec_flags", "{file}", "Call flags with placeholders: {project}, {file}, {col}, {line}.");
 
 	// Completion
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay", 1.5, "0.1,10,0.01")
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay_with_errors_found", 0.5, "0.1,5,0.01")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay", 1.5, "0.1,10,0.01");
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay_with_errors_found", 0.5, "0.1,5,0.01");
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/completion/idle_parse_enabled", true, "");
 	_initial_set("text_editor/completion/auto_brace_complete", true, true);
 	_initial_set("text_editor/completion/code_complete_enabled", true, true);
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01,or_greater")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01,or_greater");
 	_initial_set("text_editor/completion/put_callhint_tooltip_below_current_line", true);
 	_initial_set("text_editor/completion/complete_file_paths", true);
 	_initial_set("text_editor/completion/add_type_hints", true, true);


### PR DESCRIPTION
_(Rewritten on 11.03.2026 following a rebase)_

---

This PR adds an editor option to toggle idle parsing.

<img width="693" height="213" alt="image" src="https://github.com/user-attachments/assets/c2b0b4dc-f351-4893-a592-5689ce4f27b1" />

When idle parsing is disabled, the script editor will no longer automatically parse any opened script files. It will, however, continue to parse scripts:
- when they are saved to disk, or
- when another script is opened (e.g. by switching through scripts in the script editor).

That first point is worth elaborating on. Currently (Godot 4.6 / 4.7), scripts are not parsed in the script editor upon saving. Instead, you have to wait for the idle parsing timer to complete in order to have your scripts validated/checked for errors.

I didn't aim to address that specific problem, as it was originally unrelated to my PR and worth a separate issue. However, with idle parsing disabled, this mechanism is the de facto primary way to parse files, which is why that change is part of this PR. It also happens to make the script editor feel snappier/more responsive when paired with idle parsing, which is a welcome bonus as far as I'm concerned. :stuck_out_tongue: 

- Fixes https://github.com/godotengine/godot/issues/92998
- Closes https://github.com/godotengine/godot-proposals/issues/12411