### PR TITLE
Rename `NavigationMeshEditor` to `NavigationRegion3DEditor`

### DIFF
--- a/modules/navigation_3d/editor/navigation_region_3d_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_region_3d_editor_plugin.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  navigation_mesh_editor_plugin.cpp                                     */
+/*  navigation_region_3d_editor_plugin.cpp                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "navigation_mesh_editor_plugin.h"
+#include "navigation_region_3d_editor_plugin.h"
 
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
@@ -38,7 +38,7 @@
 #include "scene/gui/dialogs.h"
 #include "scene/gui/label.h"
 
-void NavigationMeshEditor::_node_removed(Node *p_node) {
+void NavigationRegion3DEditor::_node_removed(Node *p_node) {
 	if (p_node == node) {
 		node = nullptr;
 
@@ -46,7 +46,7 @@ void NavigationMeshEditor::_node_removed(Node *p_node) {
 	}
 }
 
-void NavigationMeshEditor::_notification(int p_what) {
+void NavigationRegion3DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			button_bake->set_button_icon(get_theme_icon(SNAME("Bake"), EditorStringName(EditorIcons)));
@@ -55,7 +55,7 @@ void NavigationMeshEditor::_notification(int p_what) {
 	}
 }
 
-void NavigationMeshEditor::_bake_pressed() {
+void NavigationRegion3DEditor::_bake_pressed() {
 	button_bake->set_pressed(false);
 
 	ERR_FAIL_NULL(node);
@@ -98,7 +98,7 @@ void NavigationMeshEditor::_bake_pressed() {
 	node->update_gizmos();
 }
 
-void NavigationMeshEditor::_clear_pressed() {
+void NavigationRegion3DEditor::_clear_pressed() {
 	if (node) {
 		if (node->get_navigation_mesh().is_valid()) {
 			node->get_navigation_mesh()->clear();
@@ -113,7 +113,7 @@ void NavigationMeshEditor::_clear_pressed() {
 	}
 }
 
-void NavigationMeshEditor::edit(NavigationRegion3D *p_nav_region) {
+void NavigationRegion3DEditor::edit(NavigationRegion3D *p_nav_region) {
 	if (p_nav_region == nullptr || node == p_nav_region) {
 		return;
 	}
@@ -121,7 +121,7 @@ void NavigationMeshEditor::edit(NavigationRegion3D *p_nav_region) {
 	node = p_nav_region;
 }
 
-NavigationMeshEditor::NavigationMeshEditor() {
+NavigationRegion3DEditor::NavigationRegion3DEditor() {
 	bake_hbox = memnew(HBoxContainer);
 
 	button_bake = memnew(Button);
@@ -130,14 +130,14 @@ NavigationMeshEditor::NavigationMeshEditor() {
 	button_bake->set_toggle_mode(true);
 	button_bake->set_text(TTR("Bake NavigationMesh"));
 	button_bake->set_tooltip_text(TTR("Bakes the NavigationMesh by first parsing the scene for source geometry and then creating the navigation mesh vertices and polygons."));
-	button_bake->connect(SceneStringName(pressed), callable_mp(this, &NavigationMeshEditor::_bake_pressed));
+	button_bake->connect(SceneStringName(pressed), callable_mp(this, &NavigationRegion3DEditor::_bake_pressed));
 
 	button_reset = memnew(Button);
 	button_reset->set_theme_type_variation(SceneStringName(FlatButton));
 	bake_hbox->add_child(button_reset);
 	button_reset->set_text(TTR("Clear NavigationMesh"));
 	button_reset->set_tooltip_text(TTR("Clears the internal NavigationMesh vertices and polygons."));
-	button_reset->connect(SceneStringName(pressed), callable_mp(this, &NavigationMeshEditor::_clear_pressed));
+	button_reset->connect(SceneStringName(pressed), callable_mp(this, &NavigationRegion3DEditor::_clear_pressed));
 
 	bake_info = memnew(Label);
 	bake_info->set_focus_mode(FOCUS_ACCESSIBILITY);
@@ -148,29 +148,29 @@ NavigationMeshEditor::NavigationMeshEditor() {
 	node = nullptr;
 }
 
-void NavigationMeshEditorPlugin::edit(Object *p_object) {
-	navigation_mesh_editor->edit(Object::cast_to<NavigationRegion3D>(p_object));
+void NavigationRegion3DEditorPlugin::edit(Object *p_object) {
+	navigation_region_editor->edit(Object::cast_to<NavigationRegion3D>(p_object));
 }
 
-bool NavigationMeshEditorPlugin::handles(Object *p_object) const {
+bool NavigationRegion3DEditorPlugin::handles(Object *p_object) const {
 	return p_object->is_class("NavigationRegion3D");
 }
 
-void NavigationMeshEditorPlugin::make_visible(bool p_visible) {
+void NavigationRegion3DEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		navigation_mesh_editor->show();
-		navigation_mesh_editor->bake_hbox->show();
+		navigation_region_editor->show();
+		navigation_region_editor->bake_hbox->show();
 	} else {
-		navigation_mesh_editor->hide();
-		navigation_mesh_editor->bake_hbox->hide();
-		navigation_mesh_editor->edit(nullptr);
+		navigation_region_editor->hide();
+		navigation_region_editor->bake_hbox->hide();
+		navigation_region_editor->edit(nullptr);
 	}
 }
 
-NavigationMeshEditorPlugin::NavigationMeshEditorPlugin() {
-	navigation_mesh_editor = memnew(NavigationMeshEditor);
-	EditorNode::get_singleton()->get_gui_base()->add_child(navigation_mesh_editor);
-	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, navigation_mesh_editor->bake_hbox);
-	navigation_mesh_editor->hide();
-	navigation_mesh_editor->bake_hbox->hide();
+NavigationRegion3DEditorPlugin::NavigationRegion3DEditorPlugin() {
+	navigation_region_editor = memnew(NavigationRegion3DEditor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(navigation_region_editor);
+	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, navigation_region_editor->bake_hbox);
+	navigation_region_editor->hide();
+	navigation_region_editor->bake_hbox->hide();
 }

--- a/modules/navigation_3d/editor/navigation_region_3d_editor_plugin.h
+++ b/modules/navigation_3d/editor/navigation_region_3d_editor_plugin.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  navigation_mesh_editor_plugin.h                                       */
+/*  navigation_region_3d_editor_plugin.h                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -38,10 +38,10 @@ class HBoxContainer;
 class Label;
 class NavigationRegion3D;
 
-class NavigationMeshEditor : public Control {
-	friend class NavigationMeshEditorPlugin;
+class NavigationRegion3DEditor : public Control {
+	friend class NavigationRegion3DEditorPlugin;
 
-	GDCLASS(NavigationMeshEditor, Control);
+	GDCLASS(NavigationRegion3DEditor, Control);
 
 	AcceptDialog *err_dialog = nullptr;
 
@@ -61,20 +61,20 @@ protected:
 
 public:
 	void edit(NavigationRegion3D *p_nav_region);
-	NavigationMeshEditor();
+	NavigationRegion3DEditor();
 };
 
-class NavigationMeshEditorPlugin : public EditorPlugin {
-	GDCLASS(NavigationMeshEditorPlugin, EditorPlugin);
+class NavigationRegion3DEditorPlugin : public EditorPlugin {
+	GDCLASS(NavigationRegion3DEditorPlugin, EditorPlugin);
 
-	NavigationMeshEditor *navigation_mesh_editor = nullptr;
+	NavigationRegion3DEditor *navigation_region_editor = nullptr;
 
 public:
-	virtual String get_plugin_name() const override { return "NavigationMesh"; }
+	virtual String get_plugin_name() const override { return "NavigationRegion3D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	NavigationMeshEditorPlugin();
+	NavigationRegion3DEditorPlugin();
 };

--- a/modules/navigation_3d/register_types.cpp
+++ b/modules/navigation_3d/register_types.cpp
@@ -37,7 +37,7 @@
 #endif // DISABLE_DEPRECATED
 
 #ifdef TOOLS_ENABLED
-#include "editor/navigation_mesh_editor_plugin.h"
+#include "editor/navigation_region_3d_editor_plugin.h"
 #endif
 
 #include "core/config/engine.h"
@@ -64,7 +64,7 @@ void initialize_navigation_3d_module(ModuleInitializationLevel p_level) {
 
 #ifdef TOOLS_ENABLED
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
-		EditorPlugins::add_by_type<NavigationMeshEditorPlugin>();
+		EditorPlugins::add_by_type<NavigationRegion3DEditorPlugin>();
 	}
 #endif
 }


### PR DESCRIPTION
Renames `NavigationMeshEditor` to `NavigationRegion3DEditor` to better describe its actual purpose.

This was kinda mislabeled since back in Godot 2/3 as it was always a plugin and editor for the NavigationMeshInstance / NavigationRegion3D node. This creates naming conflict for work on an actual NavigationMesh resource editor plugin, which is partly the reason for this rename.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
