### PR TITLE
Fix `FOCUS_ACCESSIBILITY` grabbing focus when it is not supposed to, forward `GraphNode` key input to `GraphEdit`.

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2158,6 +2158,11 @@ Control::FocusBehaviorRecursive Control::get_focus_behavior_recursive() const {
 	return data.focus_behavior_recursive;
 }
 
+bool Control::_is_focusable() const {
+	bool ac_enabled = is_inside_tree() && get_tree()->is_accessibility_enabled();
+	return (is_visible_in_tree() && ((get_focus_mode_with_override() == FOCUS_ALL) || (get_focus_mode_with_override() == FOCUS_CLICK) || (ac_enabled && get_focus_mode_with_override() == FOCUS_ACCESSIBILITY)));
+}
+
 bool Control::_is_focus_mode_enabled() const {
 	if (data.focus_behavior_recursive == FOCUS_BEHAVIOR_INHERITED) {
 		if (data.parent_control) {
@@ -2270,7 +2275,7 @@ Control *Control::find_next_valid_focus() const {
 		ERR_FAIL_NULL_V_MSG(n, nullptr, "Next focus node path is invalid: '" + data.focus_next + "'.");
 		Control *c = Object::cast_to<Control>(n);
 		ERR_FAIL_NULL_V_MSG(c, nullptr, "Next focus node is not a control: '" + n->get_name() + "'.");
-		if (c->is_visible_in_tree() && c->get_focus_mode_with_override() != FOCUS_NONE) {
+		if (c->_is_focusable()) {
 			return c;
 		}
 	}
@@ -2374,7 +2379,7 @@ Control *Control::find_prev_valid_focus() const {
 		ERR_FAIL_NULL_V_MSG(n, nullptr, "Previous focus node path is invalid: '" + data.focus_prev + "'.");
 		Control *c = Object::cast_to<Control>(n);
 		ERR_FAIL_NULL_V_MSG(c, nullptr, "Previous focus node is not a control: '" + n->get_name() + "'.");
-		if (c->is_visible_in_tree() && c->get_focus_mode_with_override() != FOCUS_NONE) {
+		if (c->_is_focusable()) {
 			return c;
 		}
 	}
@@ -2494,7 +2499,7 @@ Control *Control::_get_focus_neighbor(Side p_side, int p_count) {
 		ERR_FAIL_NULL_V_MSG(n, nullptr, "Neighbor focus node path is invalid: '" + data.focus_neighbor[p_side] + "'.");
 		Control *c = Object::cast_to<Control>(n);
 		ERR_FAIL_NULL_V_MSG(c, nullptr, "Neighbor focus node is not a control: '" + n->get_name() + "'.");
-		if (c->is_visible_in_tree() && c->get_focus_mode_with_override() != FOCUS_NONE) {
+		if (c->_is_focusable()) {
 			return c;
 		}
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -337,6 +337,7 @@ private:
 
 	// Focus.
 
+	bool _is_focusable() const;
 	void _window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, const Rect2 &p_rect, const Rect2 &p_clamp, real_t p_min, real_t &r_closest_dist_squared, Control **r_closest);
 	Control *_get_focus_neighbor(Side p_side, int p_count = 0);
 	bool _is_focus_mode_enabled() const;

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2263,6 +2263,10 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 		}
 	}
 
+	key_input(p_ev);
+}
+
+void GraphEdit::key_input(const Ref<InputEvent> &p_ev) {
 	if (p_ev->is_pressed()) {
 		if (p_ev->is_action("ui_graph_duplicate", true)) {
 			emit_signal(SNAME("duplicate_nodes_request"));

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -401,6 +401,8 @@ public:
 
 	PackedStringArray get_configuration_warnings() const override;
 
+	void key_input(const Ref<InputEvent> &p_ev);
+
 	// This method has to be public (for undo redo).
 	// TODO: Find a better way to do this.
 	void _update_graph_frame(GraphFrame *p_frame);

--- a/scene/gui/graph_element.cpp
+++ b/scene/gui/graph_element.cpp
@@ -173,6 +173,11 @@ void GraphElement::gui_input(const Ref<InputEvent> &p_ev) {
 
 		emit_signal(SNAME("resize_request"), resizing_from_size + diff);
 	}
+
+	GraphEdit *graph = Object::cast_to<GraphEdit>(get_parent());
+	if (graph && has_focus()) {
+		graph->key_input(p_ev);
+	}
 }
 
 void GraphElement::set_resizable(bool p_enable) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1933,7 +1933,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				while (ci) {
 					Control *control = Object::cast_to<Control>(ci);
 					if (control) {
-						if (control->get_focus_mode_with_override() != Control::FOCUS_NONE) {
+						if (control->_is_focusable()) {
 							// Grabbing unhovered focus can cause issues when mouse is dragged
 							// with another button held down.
 							if (control != gui.key_focus && gui.mouse_over_hierarchy.has(control)) {


### PR DESCRIPTION
- Fixes `FOCUS_ACCESSIBILITY` grabbing focus on click even if screen reader is not active.
- Forwards key input from focused `GraphNode` (can have keyboard focus when screen reader is active) to the `GraphEdit` (which is handling copy-paste-delete shortcuts).

Fixes https://github.com/godotengine/godot/issues/105591
