### PR TITLE
[Web] Avoid unnecessary gamepad polling when no gamepads are connected

### DIFF
--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -829,6 +829,9 @@ void DisplayServerWeb::gamepad_callback(int p_index, int p_connected, const char
 
 void DisplayServerWeb::_gamepad_callback(int p_index, int p_connected, const String &p_id, const String &p_guid) {
 	Input *input = Input::get_singleton();
+	DisplayServerWeb *ds = get_singleton();
+	ds->active_gamepad_sample_count = -1; // Invalidate cache
+
 	if (p_connected) {
 		input->joy_connection_changed(p_index, true, p_id, p_guid);
 	} else {
@@ -1406,7 +1409,10 @@ DisplayServer::VSyncMode DisplayServerWeb::window_get_vsync_mode(WindowID p_vsyn
 void DisplayServerWeb::process_events() {
 	process_keys();
 	Input::get_singleton()->flush_buffered_events();
-	if (godot_js_input_gamepad_sample() == OK) {
+	if (active_gamepad_sample_count == -1) {
+		active_gamepad_sample_count = godot_js_input_gamepad_sample();
+	}
+	if (active_gamepad_sample_count > 0) {
 		process_joypads();
 	}
 }

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -104,6 +104,8 @@ private:
 	bool swap_cancel_ok = false;
 	NativeMenu *native_menu = nullptr;
 
+	int active_gamepad_sample_count = -1;
+
 	MouseMode mouse_mode_base = MOUSE_MODE_VISIBLE;
 	MouseMode mouse_mode_override = MOUSE_MODE_VISIBLE;
 	bool mouse_mode_override_enabled = false;

--- a/platform/web/js/libs/library_godot_input.js
+++ b/platform/web/js/libs/library_godot_input.js
@@ -205,6 +205,7 @@ const GodotInputGamepads = {
 		sample: function () {
 			const pads = GodotInputGamepads.get_pads();
 			const samples = [];
+			let active = 0;
 			for (let i = 0; i < pads.length; i++) {
 				const pad = pads[i];
 				if (!pad) {
@@ -224,8 +225,10 @@ const GodotInputGamepads = {
 					s.axes.push(pad.axes[a]);
 				}
 				samples.push(s);
+				active++;
 			}
 			GodotInputGamepads.samples = samples;
+			return active;
 		},
 
 		init: function (onchange) {
@@ -651,8 +654,7 @@ const GodotInput = {
 	godot_js_input_gamepad_sample__proxy: 'sync',
 	godot_js_input_gamepad_sample__sig: 'i',
 	godot_js_input_gamepad_sample: function () {
-		GodotInputGamepads.sample();
-		return 0;
+		return GodotInputGamepads.sample();
 	},
 
 	godot_js_input_gamepad_sample_get__proxy: 'sync',


### PR DESCRIPTION
`godot_js_input_gamepad_sample()` was being called every frame when no gamepads were connected, triggering `process_joypads()` which performs 5 JS <-> WASM calls, costing ~0.17ms.

![image](https://github.com/user-attachments/assets/56f47b6f-0c4b-476f-98fe-19eed6a3b076)

The call is now cached and only refreshed when a gamepad connection/disconnection event occurs.

