### PR TITLE
Android: Enable native debug symbols generation

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -86,7 +86,7 @@ if lib_arch_dir != "":
     )
     env_android.CommandNoCache(out_dir + "/libc++_shared.so", stl_lib_path, Copy("$TARGET", "$SOURCE"))
 
-    def generate_apk(target, source, env):
+    def generate_android_binaries(target, source, env):
         gradle_process = []
 
         if sys.platform.startswith("win"):
@@ -103,7 +103,7 @@ if lib_arch_dir != "":
             "--quiet",
         ]
 
-        if env["debug_symbols"]:
+        if env["gradle_do_not_strip"]:
             gradle_process += ["-PdoNotStrip=true"]
 
         subprocess.run(
@@ -111,5 +111,7 @@ if lib_arch_dir != "":
             cwd="platform/android/java",
         )
 
-    if env["generate_apk"]:
-        env_android.AlwaysBuild(env_android.CommandNoCache("generate_apk", lib, env.Run(generate_apk)))
+    if env["generate_android_binaries"]:
+        env_android.AlwaysBuild(
+            env_android.CommandNoCache("generate_android_binaries", lib, env.Run(generate_android_binaries))
+        )

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -34,8 +34,13 @@ def get_opts():
             "android-" + str(get_min_target_api()),
         ),
         BoolVariable("store_release", "Editor build for Google Play Store (for official builds only)", False),
-        BoolVariable("generate_apk", "Generate an APK/AAB after building Android library by calling Gradle", False),
+        BoolVariable(
+            "generate_android_binaries",
+            "Generate APK, AAB & AAR binaries after building Android library by calling Gradle",
+            False,
+        ),
         BoolVariable("swappy", "Use Swappy Frame Pacing library", False),
+        BoolVariable("gradle_do_not_strip", "Whether Gradle should strip the Android *.so libraries or not", False),
     ]
 
 

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -101,6 +101,7 @@ android {
         }
 
         ndk {
+            debugSymbolLevel 'FULL'
             String[] export_abi_list = getExportEnabledABIs()
             abiFilters export_abi_list
         }

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -173,9 +173,14 @@ def generateBuildTasks(String flavor = "template", String edition = "standard", 
                     buildTasks += tasks.create(name: copyBinaryTaskName, type: Copy) {
                         String filenameSuffix = edition == "mono" ? "${edition}${capitalizedTarget}" : target
                         dependsOn ":app:assemble${capitalizedEdition}${capitalizedTarget}"
-                        from("app/build/outputs/apk/${edition}/${target}")
+                        from("app/build/outputs/apk/${edition}/${target}") {
+                            include("android_${filenameSuffix}.apk")
+                        }
+                        from("app/build/outputs/native-debug-symbols/${edition}${capitalizedTarget}") {
+                            include("native-debug-symbols.zip")
+                            rename ("native-debug-symbols.zip", "android-template-${edition}-${target}-native-debug-symbols.zip")
+                        }
                         into(binDir)
-                        include("android_${filenameSuffix}.apk")
                     }
                 }
             } else {
@@ -186,9 +191,14 @@ def generateBuildTasks(String flavor = "template", String edition = "standard", 
                 } else {
                     buildTasks += tasks.create(name: copyEditorApkTaskName, type: Copy) {
                         dependsOn ":editor:assemble${capitalizedAndroidDistro}${capitalizedTarget}"
-                        from("editor/build/outputs/apk/${androidDistro}/${target}")
+                        from("editor/build/outputs/apk/${androidDistro}/${target}") {
+                            include("android_editor-${androidDistro}-${target}*.apk")
+                        }
+                        from("editor/build/outputs/native-debug-symbols/${androidDistro}${capitalizedTarget}") {
+                            include("native-debug-symbols.zip")
+                            rename ("native-debug-symbols.zip", "android-editor-${androidDistro}-${target}-native-debug-symbols.zip")
+                        }
                         into(androidEditorBuildsDir)
-                        include("android_editor-${androidDistro}-${target}*.apk")
                     }
                 }
 
@@ -270,19 +280,6 @@ task generateGodotMonoTemplates {
     finalizedBy 'zipGradleBuild'
 }
 
-/**
- * Generates the same output as generateGodotTemplates but with dev symbols
- */
-task generateDevTemplate {
-    // add parameter to set symbols to true
-    project.ext.doNotStrip = "true"
-
-    gradle.startParameter.excludedTaskNames += templateExcludedBuildTask()
-    dependsOn = generateBuildTasks("template")
-
-    finalizedBy 'zipGradleBuild'
-}
-
 task clean(type: Delete) {
     dependsOn 'cleanGodotEditor'
     dependsOn 'cleanGodotTemplates'
@@ -326,11 +323,17 @@ task cleanGodotTemplates(type: Delete) {
 
     // Delete the Godot templates in the Godot bin directory
     delete("$binDir/android_debug.apk")
+    delete("$binDir/android-template-standard-debug-native-debug-symbols.zip")
     delete("$binDir/android_dev.apk")
+    delete("$binDir/android-template-standard-dev-native-debug-symbols.zip")
     delete("$binDir/android_release.apk")
+    delete("$binDir/android-template-standard-release-native-debug-symbols.zip")
     delete("$binDir/android_monoDebug.apk")
+    delete("$binDir/android-template-mono-debug-native-debug-symbols.zip")
     delete("$binDir/android_monoDev.apk")
+    delete("$binDir/android-template-mono-dev-native-debug-symbols.zip")
     delete("$binDir/android_monoRelease.apk")
+    delete("$binDir/android-template-mono-release-native-debug-symbols.zip")
     delete("$binDir/android_source.zip")
     delete("$binDir/godot-lib.template_debug.aar")
     delete("$binDir/godot-lib.template_debug.dev.aar")

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -89,6 +89,8 @@ android {
             editorAppName: "Godot Engine 4",
             editorBuildSuffix: ""
         ]
+
+        ndk { debugSymbolLevel 'FULL' }
     }
 
     base {


### PR DESCRIPTION
Enable native debug symbols generation for Android builds (template & editor)

The native debug symbols generation by `gradle` is controlled by the [`ndk.debugSymbolLevel` property](https://developer.android.com/reference/tools/gradle-api/8.3/com/android/build/api/dsl/Ndk#debugSymbolLevel()).
This PR sets that property to `FULL`, which causes both the debug info and symbol tables to be packaged. This results in a native debug symbols zip file which is about `~1G` in size for all Android supported arches (`arm32`, `arm64`, `x86_32`, `x86_64`). The size of the symbols file can be brought down by setting the `ndk.debugSymbolLevel` property to `symbol_table`, which only packages the symbol tables.

Build-scripts counterpart PR - https://github.com/godotengine/godot-build-scripts/pull/112

The build script PR can be used to see how to generate the debug symbols. Here a quick example for the `arm64` arch:
```
scons platform=android arch=arm64 target=template_debug debug_symbols=yes generate_android_binaries=yes
```

Alongside generating the Android binaries, the inclusion of the `debug_symbols=yes` parameter will generate and output native debug symbols in the output `bin` directory.

The generated native debug symbols are stripped from the `*.so` libraries by `gradle`. To keep the debug symbols within the `*.so` packaged in the APK/AAB binaries, at the expense of binary size, the `gradle_do_not_strip=yes` parameter can be used.

```
scons platform=android arch=arm64 target=template_debug debug_symbols=yes generate_android_binaries=yes gradle_do_not_strip=yes
```

**Note:** The `generate_apk` scons parameter has been replaced by the `generate_android_binaries` parameter to reflect the fact the command generates `APK`, `AAB`, and `AAR` binaries. https://github.com/godotengine/godot-docs/pull/10886 updates the documentation.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
