### PR TITLE
Improve Path2D debug performance

### DIFF
--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -443,6 +443,14 @@ void Path2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 	int len = curve->get_point_count();
 	Control *vpc = canvas_item_editor->get_viewport_control();
 
+	debug_handle_lines.clear();
+	debug_handle_curve_transforms.clear();
+	debug_handle_sharp_transforms.clear();
+	debug_handle_smooth_transforms.clear();
+
+	Transform2D handle_curve_transform = Transform2D().scaled(curve_handle_size * 0.5);
+	Transform2D handle_point_transform = Transform2D().scaled(handle_size * 0.5);
+
 	for (int i = 0; i < len; i++) {
 		Vector2 point = xform.xform(curve->get_point_position(i));
 		// Determines the point icon to be used
@@ -452,10 +460,10 @@ void Path2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 			Vector2 point_out = xform.xform(curve->get_point_position(i) + curve->get_point_out(i));
 			if (point != point_out) {
 				smooth = true;
-				// Draw the line with a dark and light color to be visible on all backgrounds
-				vpc->draw_line(point, point_out, Color(0, 0, 0, 0.5), Math::round(EDSCALE));
-				vpc->draw_line(point, point_out, Color(1, 1, 1, 0.5), Math::round(EDSCALE));
-				vpc->draw_texture_rect(curve_handle, Rect2(point_out - curve_handle_size * 0.5, curve_handle_size), false, Color(1, 1, 1, 0.75));
+				debug_handle_lines.push_back(point);
+				debug_handle_lines.push_back(point_out);
+				handle_curve_transform.set_origin(point_out);
+				debug_handle_curve_transforms.push_back(handle_curve_transform);
 			}
 		}
 
@@ -463,22 +471,142 @@ void Path2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 			Vector2 point_in = xform.xform(curve->get_point_position(i) + curve->get_point_in(i));
 			if (point != point_in) {
 				smooth = true;
-				// Draw the line with a dark and light color to be visible on all backgrounds
-				vpc->draw_line(point, point_in, Color(0, 0, 0, 0.5), Math::round(EDSCALE));
-				vpc->draw_line(point, point_in, Color(1, 1, 1, 0.5), Math::round(EDSCALE));
-				vpc->draw_texture_rect(curve_handle, Rect2(point_in - curve_handle_size * 0.5, curve_handle_size), false, Color(1, 1, 1, 0.75));
+				debug_handle_lines.push_back(point);
+				debug_handle_lines.push_back(point_in);
+				handle_curve_transform.set_origin(point_in);
+				debug_handle_curve_transforms.push_back(handle_curve_transform);
 			}
 		}
 
-		vpc->draw_texture_rect(
-				smooth ? path_smooth_handle : path_sharp_handle,
-				Rect2(point - handle_size * 0.5, handle_size),
-				false);
+		handle_point_transform.set_origin(point);
+		if (smooth) {
+			debug_handle_smooth_transforms.push_back(handle_point_transform);
+		} else {
+			debug_handle_sharp_transforms.push_back(handle_point_transform);
+		}
 	}
 
 	if (on_edge) {
 		Ref<Texture2D> add_handle = get_editor_theme_icon(SNAME("EditorHandleAdd"));
 		p_overlay->draw_texture(add_handle, edge_point - add_handle->get_size() * 0.5);
+	}
+
+	RenderingServer *rs = RS::get_singleton();
+	rs->mesh_clear(debug_mesh_rid);
+
+	if (!debug_handle_lines.is_empty()) {
+		Array handles_array;
+		handles_array.resize(Mesh::ARRAY_MAX);
+
+		handles_array[Mesh::ARRAY_VERTEX] = Vector<Vector2>(debug_handle_lines);
+
+		rs->mesh_add_surface_from_arrays(debug_mesh_rid, RS::PRIMITIVE_LINES, handles_array, Array(), Dictionary(), RS::ARRAY_FLAG_USE_2D_VERTICES);
+		rs->canvas_item_add_mesh(vpc->get_canvas_item(), debug_mesh_rid, Transform2D(), Color(0.5, 0.5, 0.5, 1.0));
+	}
+
+	// Add texture rects multimeshes for handle vertices.
+
+	uint32_t handle_curve_count = debug_handle_curve_transforms.size();
+	uint32_t handle_sharp_count = debug_handle_sharp_transforms.size();
+	uint32_t handle_smooth_count = debug_handle_smooth_transforms.size();
+
+	// Add texture rects for curve handle vertices.
+
+	rs->multimesh_set_visible_instances(debug_handle_curve_multimesh_rid, 0);
+	if (handle_curve_count > 0) {
+		if (rs->multimesh_get_instance_count(debug_handle_curve_multimesh_rid) != int(handle_curve_count)) {
+			rs->multimesh_allocate_data(debug_handle_curve_multimesh_rid, handle_curve_count, RS::MULTIMESH_TRANSFORM_2D);
+		}
+
+		Vector<float> multimesh_buffer;
+		multimesh_buffer.resize(8 * handle_curve_count);
+		float *multimesh_buffer_ptrw = multimesh_buffer.ptrw();
+
+		const Transform2D *debug_handle_transforms_ptr = debug_handle_curve_transforms.ptr();
+
+		for (uint32_t i = 0; i < handle_curve_count; i++) {
+			const Transform2D &handle_transform = debug_handle_transforms_ptr[i];
+
+			multimesh_buffer_ptrw[i * 8 + 0] = handle_transform[0][0];
+			multimesh_buffer_ptrw[i * 8 + 1] = handle_transform[1][0];
+			multimesh_buffer_ptrw[i * 8 + 2] = 0;
+			multimesh_buffer_ptrw[i * 8 + 3] = handle_transform[2][0];
+			multimesh_buffer_ptrw[i * 8 + 4] = handle_transform[0][1];
+			multimesh_buffer_ptrw[i * 8 + 5] = handle_transform[1][1];
+			multimesh_buffer_ptrw[i * 8 + 6] = 0;
+			multimesh_buffer_ptrw[i * 8 + 7] = handle_transform[2][1];
+		}
+
+		rs->multimesh_set_buffer(debug_handle_curve_multimesh_rid, multimesh_buffer);
+		rs->multimesh_set_visible_instances(debug_handle_curve_multimesh_rid, handle_curve_count);
+
+		rs->canvas_item_add_multimesh(vpc->get_canvas_item(), debug_handle_curve_multimesh_rid, curve_handle->get_rid());
+	}
+
+	// Add texture rects for sharp handle vertices.
+
+	rs->multimesh_set_visible_instances(debug_handle_sharp_multimesh_rid, 0);
+	if (handle_sharp_count > 0) {
+		if (rs->multimesh_get_instance_count(debug_handle_sharp_multimesh_rid) != int(handle_sharp_count)) {
+			rs->multimesh_allocate_data(debug_handle_sharp_multimesh_rid, handle_sharp_count, RS::MULTIMESH_TRANSFORM_2D);
+		}
+
+		Vector<float> multimesh_buffer;
+		multimesh_buffer.resize(8 * handle_sharp_count);
+		float *multimesh_buffer_ptrw = multimesh_buffer.ptrw();
+
+		const Transform2D *debug_handle_transforms_ptr = debug_handle_sharp_transforms.ptr();
+
+		for (uint32_t i = 0; i < handle_sharp_count; i++) {
+			const Transform2D &handle_transform = debug_handle_transforms_ptr[i];
+
+			multimesh_buffer_ptrw[i * 8 + 0] = handle_transform[0][0];
+			multimesh_buffer_ptrw[i * 8 + 1] = handle_transform[1][0];
+			multimesh_buffer_ptrw[i * 8 + 2] = 0;
+			multimesh_buffer_ptrw[i * 8 + 3] = handle_transform[2][0];
+			multimesh_buffer_ptrw[i * 8 + 4] = handle_transform[0][1];
+			multimesh_buffer_ptrw[i * 8 + 5] = handle_transform[1][1];
+			multimesh_buffer_ptrw[i * 8 + 6] = 0;
+			multimesh_buffer_ptrw[i * 8 + 7] = handle_transform[2][1];
+		}
+
+		rs->multimesh_set_buffer(debug_handle_sharp_multimesh_rid, multimesh_buffer);
+		rs->multimesh_set_visible_instances(debug_handle_sharp_multimesh_rid, handle_sharp_count);
+
+		rs->canvas_item_add_multimesh(vpc->get_canvas_item(), debug_handle_sharp_multimesh_rid, curve_handle->get_rid());
+	}
+
+	// Add texture rects for smooth handle vertices.
+
+	rs->multimesh_set_visible_instances(debug_handle_smooth_multimesh_rid, 0);
+	if (handle_smooth_count > 0) {
+		if (rs->multimesh_get_instance_count(debug_handle_smooth_multimesh_rid) != int(handle_smooth_count)) {
+			rs->multimesh_allocate_data(debug_handle_smooth_multimesh_rid, handle_smooth_count, RS::MULTIMESH_TRANSFORM_2D);
+		}
+
+		Vector<float> multimesh_buffer;
+		multimesh_buffer.resize(8 * handle_smooth_count);
+		float *multimesh_buffer_ptrw = multimesh_buffer.ptrw();
+
+		const Transform2D *debug_handle_transforms_ptr = debug_handle_smooth_transforms.ptr();
+
+		for (uint32_t i = 0; i < handle_smooth_count; i++) {
+			const Transform2D &handle_transform = debug_handle_transforms_ptr[i];
+
+			multimesh_buffer_ptrw[i * 8 + 0] = handle_transform[0][0];
+			multimesh_buffer_ptrw[i * 8 + 1] = handle_transform[1][0];
+			multimesh_buffer_ptrw[i * 8 + 2] = 0;
+			multimesh_buffer_ptrw[i * 8 + 3] = handle_transform[2][0];
+			multimesh_buffer_ptrw[i * 8 + 4] = handle_transform[0][1];
+			multimesh_buffer_ptrw[i * 8 + 5] = handle_transform[1][1];
+			multimesh_buffer_ptrw[i * 8 + 6] = 0;
+			multimesh_buffer_ptrw[i * 8 + 7] = handle_transform[2][1];
+		}
+
+		rs->multimesh_set_buffer(debug_handle_smooth_multimesh_rid, multimesh_buffer);
+		rs->multimesh_set_visible_instances(debug_handle_smooth_multimesh_rid, handle_smooth_count);
+
+		rs->canvas_item_add_multimesh(vpc->get_canvas_item(), debug_handle_smooth_multimesh_rid, curve_handle->get_rid());
 	}
 }
 
@@ -795,6 +923,66 @@ Path2DEditor::Path2DEditor() {
 	create_curve_button->hide();
 	add_child(create_curve_button);
 	create_curve_button->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_create_curve));
+
+	ERR_FAIL_NULL(RS::get_singleton());
+	RenderingServer *rs = RS::get_singleton();
+
+	debug_mesh_rid = rs->mesh_create();
+
+	{
+		debug_handle_mesh_rid = rs->mesh_create();
+
+		Vector<Vector2> vertex_array;
+		vertex_array.resize(4);
+		Vector2 *vertex_array_ptrw = vertex_array.ptrw();
+		vertex_array_ptrw[0] = Vector2(-1.0, -1.0);
+		vertex_array_ptrw[1] = Vector2(1.0, -1.0);
+		vertex_array_ptrw[2] = Vector2(1.0, 1.0);
+		vertex_array_ptrw[3] = Vector2(-1.0, 1.0);
+
+		Vector<Vector2> uv_array;
+		uv_array.resize(4);
+		Vector2 *uv_array_ptrw = uv_array.ptrw();
+		uv_array_ptrw[0] = Vector2(0.0, 0.0);
+		uv_array_ptrw[1] = Vector2(1.0, 0.0);
+		uv_array_ptrw[2] = Vector2(1.0, 1.0);
+		uv_array_ptrw[3] = Vector2(0.0, 1.0);
+
+		Vector<int> index_array;
+		index_array.resize(6);
+		int *index_array_ptrw = index_array.ptrw();
+		index_array_ptrw[0] = 0;
+		index_array_ptrw[1] = 1;
+		index_array_ptrw[2] = 3;
+		index_array_ptrw[3] = 1;
+		index_array_ptrw[4] = 2;
+		index_array_ptrw[5] = 3;
+
+		Array mesh_arrays;
+		mesh_arrays.resize(RS::ARRAY_MAX);
+		mesh_arrays[RS::ARRAY_VERTEX] = vertex_array;
+		mesh_arrays[RS::ARRAY_TEX_UV] = uv_array;
+		mesh_arrays[RS::ARRAY_INDEX] = index_array;
+
+		rs->mesh_add_surface_from_arrays(debug_handle_mesh_rid, RS::PRIMITIVE_TRIANGLES, mesh_arrays, Array(), Dictionary(), RS::ARRAY_FLAG_USE_2D_VERTICES);
+
+		debug_handle_curve_multimesh_rid = rs->multimesh_create();
+		debug_handle_sharp_multimesh_rid = rs->multimesh_create();
+		debug_handle_smooth_multimesh_rid = rs->multimesh_create();
+
+		rs->multimesh_set_mesh(debug_handle_curve_multimesh_rid, debug_handle_mesh_rid);
+		rs->multimesh_set_mesh(debug_handle_sharp_multimesh_rid, debug_handle_mesh_rid);
+		rs->multimesh_set_mesh(debug_handle_smooth_multimesh_rid, debug_handle_mesh_rid);
+	}
+}
+
+Path2DEditor::~Path2DEditor() {
+	ERR_FAIL_NULL(RS::get_singleton());
+	RS::get_singleton()->free(debug_mesh_rid);
+	RS::get_singleton()->free(debug_handle_curve_multimesh_rid);
+	RS::get_singleton()->free(debug_handle_sharp_multimesh_rid);
+	RS::get_singleton()->free(debug_handle_smooth_multimesh_rid);
+	RS::get_singleton()->free(debug_handle_mesh_rid);
 }
 
 void Path2DEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -112,6 +112,19 @@ class Path2DEditor : public HBoxContainer {
 	void _clear_curve_points(Path2D *p_path2d);
 	void _restore_curve_points(Path2D *p_path2d, const PackedVector2Array &p_points);
 
+	RID debug_mesh_rid;
+	RID debug_handle_mesh_rid;
+	RID debug_handle_multimesh_rid;
+
+	RID debug_handle_curve_multimesh_rid;
+	RID debug_handle_sharp_multimesh_rid;
+	RID debug_handle_smooth_multimesh_rid;
+
+	LocalVector<Vector2> debug_handle_lines;
+	LocalVector<Transform2D> debug_handle_curve_transforms;
+	LocalVector<Transform2D> debug_handle_sharp_transforms;
+	LocalVector<Transform2D> debug_handle_smooth_transforms;
+
 protected:
 	void _notification(int p_what);
 	void _node_removed(Node *p_node);
@@ -122,6 +135,7 @@ public:
 	void forward_canvas_draw_over_viewport(Control *p_overlay);
 	void edit(Node *p_path2d);
 	Path2DEditor();
+	~Path2DEditor();
 };
 
 class Path2DEditorPlugin : public EditorPlugin {

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -87,80 +87,168 @@ bool Path2D::_edit_is_selected_on_click(const Point2 &p_point, double p_toleranc
 
 void Path2D::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+#ifdef DEBUG_ENABLED
+			_debug_create();
+#endif
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+#ifdef DEBUG_ENABLED
+			_debug_free();
+#endif
+		} break;
 		// Draw the curve if path debugging is enabled.
 		case NOTIFICATION_DRAW: {
-			if (curve.is_null()) {
-				break;
-			}
-
-			if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_paths_hint()) {
-				return;
-			}
-
-			if (curve->get_point_count() < 2) {
-				return;
-			}
-
-#ifdef TOOLS_ENABLED
-			const real_t line_width = get_tree()->get_debug_paths_width() * EDSCALE;
-#else
-			const real_t line_width = get_tree()->get_debug_paths_width();
+#ifdef DEBUG_ENABLED
+			_debug_update();
 #endif
-			real_t interval = 10;
-			const real_t length = curve->get_baked_length();
-
-			if (length > CMP_EPSILON) {
-				const int sample_count = int(length / interval) + 2;
-				interval = length / (sample_count - 1); // Recalculate real interval length.
-
-				Vector<Transform2D> frames;
-				frames.resize(sample_count);
-
-				{
-					Transform2D *w = frames.ptrw();
-
-					for (int i = 0; i < sample_count; i++) {
-						w[i] = curve->sample_baked_with_rotation(i * interval, false);
-					}
-				}
-
-				const Transform2D *r = frames.ptr();
-				// Draw curve segments
-				{
-					PackedVector2Array v2p;
-					v2p.resize(sample_count);
-					Vector2 *w = v2p.ptrw();
-
-					for (int i = 0; i < sample_count; i++) {
-						w[i] = r[i].get_origin();
-					}
-					draw_polyline(v2p, get_tree()->get_debug_paths_color(), line_width, false);
-				}
-
-				// Draw fish bone every 4 points to reduce visual noise and performance impact
-				// (compared to drawing it for every point).
-				{
-					PackedVector2Array v2p;
-					v2p.resize(3);
-					Vector2 *w = v2p.ptrw();
-
-					for (int i = 0; i < sample_count; i += 4) {
-						const Vector2 p = r[i].get_origin();
-						const Vector2 side = r[i].columns[1];
-						const Vector2 forward = r[i].columns[0];
-
-						// Fish Bone.
-						w[0] = p + (side - forward) * 5;
-						w[1] = p;
-						w[2] = p + (-side - forward) * 5;
-
-						draw_polyline(v2p, get_tree()->get_debug_paths_color(), line_width * 0.5, false);
-					}
-				}
-			}
 		} break;
 	}
 }
+
+#ifdef DEBUG_ENABLED
+void Path2D::_debug_create() {
+	ERR_FAIL_NULL(RS::get_singleton());
+
+	if (debug_mesh_rid.is_null()) {
+		debug_mesh_rid = RS::get_singleton()->mesh_create();
+	}
+
+	if (debug_instance.is_null()) {
+		debug_instance = RS::get_singleton()->instance_create();
+	}
+
+	RS::get_singleton()->instance_set_base(debug_instance, debug_mesh_rid);
+	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(debug_instance, RS::SHADOW_CASTING_SETTING_OFF);
+}
+
+void Path2D::_debug_free() {
+	ERR_FAIL_NULL(RS::get_singleton());
+
+	if (debug_instance.is_valid()) {
+		RS::get_singleton()->free(debug_instance);
+		debug_instance = RID();
+	}
+	if (debug_mesh_rid.is_valid()) {
+		RS::get_singleton()->free(debug_mesh_rid);
+		debug_mesh_rid = RID();
+	}
+}
+
+void Path2D::_debug_update() {
+	ERR_FAIL_NULL(RS::get_singleton());
+
+	RenderingServer *rs = RS::get_singleton();
+
+	ERR_FAIL_NULL(SceneTree::get_singleton());
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+
+	const bool path_debug_enabled = (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_paths_hint());
+
+	if (!path_debug_enabled) {
+		_debug_free();
+		return;
+	}
+
+	if (debug_mesh_rid.is_null() || debug_instance.is_null()) {
+		_debug_create();
+	}
+
+	rs->mesh_clear(debug_mesh_rid);
+
+	if (curve.is_null()) {
+		return;
+	}
+	if (curve->get_point_count() < 2) {
+		return;
+	}
+
+	const real_t baked_length = curve->get_baked_length();
+
+	if (baked_length <= CMP_EPSILON) {
+		return;
+	}
+
+	const Color debug_color = get_tree()->get_debug_paths_color();
+
+	bool debug_paths_show_fish_bones = true;
+
+	real_t sample_interval = 10.0;
+
+	const int sample_count = int(baked_length / sample_interval) + 2;
+	sample_interval = baked_length / (sample_count - 1); // Recalculate real interval length.
+
+	Vector<Transform2D> samples;
+	samples.resize(sample_count);
+	Transform2D *samples_ptrw = samples.ptrw();
+
+	for (int i = 0; i < sample_count; i++) {
+		samples_ptrw[i] = curve->sample_baked_with_rotation(i * sample_interval, false);
+	}
+
+	const Transform2D *samples_ptr = samples.ptr();
+
+	// Draw curve segments
+	{
+		Vector<Vector2> ribbon;
+		ribbon.resize(sample_count);
+		Vector2 *ribbon_ptrw = ribbon.ptrw();
+
+		for (int i = 0; i < sample_count; i++) {
+			ribbon_ptrw[i] = samples_ptr[i].get_origin();
+		}
+
+		Array ribbon_array;
+		ribbon_array.resize(Mesh::ARRAY_MAX);
+		ribbon_array[Mesh::ARRAY_VERTEX] = ribbon;
+		Vector<Color> ribbon_color;
+		ribbon_color.resize(ribbon.size());
+		ribbon_color.fill(debug_color);
+		ribbon_array[Mesh::ARRAY_COLOR] = ribbon_color;
+
+		rs->mesh_add_surface_from_arrays(debug_mesh_rid, RS::PRIMITIVE_LINE_STRIP, ribbon_array, Array(), Dictionary(), RS::ARRAY_FLAG_USE_2D_VERTICES);
+	}
+
+	// Render path fish bones.
+	if (debug_paths_show_fish_bones) {
+		int fish_bones_interval = 4;
+
+		const int vertex_per_bone = 4;
+		Vector<Vector2> bones;
+		bones.resize(sample_count * vertex_per_bone);
+		Vector2 *bones_ptrw = bones.ptrw();
+
+		for (int i = 0; i < sample_count; i += fish_bones_interval) {
+			const Transform2D &sample_transform = samples_ptr[i];
+
+			const Vector2 point = sample_transform.get_origin();
+			const Vector2 &side = sample_transform.columns[1];
+			const Vector2 &forward = sample_transform.columns[0];
+
+			const int bone_idx = i * vertex_per_bone;
+
+			bones_ptrw[bone_idx] = point;
+			bones_ptrw[bone_idx + 1] = point + (side - forward) * 5;
+			bones_ptrw[bone_idx + 2] = point;
+			bones_ptrw[bone_idx + 3] = point + (-side - forward) * 5;
+		}
+
+		Array bone_array;
+		bone_array.resize(Mesh::ARRAY_MAX);
+		bone_array[Mesh::ARRAY_VERTEX] = bones;
+		Vector<Color> bones_color;
+		bones_color.resize(bones.size());
+		bones_color.fill(debug_color);
+		bone_array[Mesh::ARRAY_COLOR] = bones_color;
+
+		rs->mesh_add_surface_from_arrays(debug_mesh_rid, RS::PRIMITIVE_LINES, bone_array, Array(), Dictionary(), RS::ARRAY_FLAG_USE_2D_VERTICES);
+	}
+
+	rs->canvas_item_clear(get_canvas_item());
+	rs->canvas_item_add_mesh(get_canvas_item(), debug_mesh_rid, Transform2D());
+}
+#endif // DEBUG_ENABLED
 
 void Path2D::_curve_changed() {
 	if (!is_inside_tree()) {

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -42,6 +42,15 @@ class Path2D : public Node2D {
 
 	void _curve_changed();
 
+#ifdef DEBUG_ENABLED
+	RID debug_mesh_rid;
+	RID debug_instance;
+
+	void _debug_create();
+	void _debug_update();
+	void _debug_free();
+#endif // DEBUG_ENABLED
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
Improves `Path2D` node debug performance by changing the debug to use mesh and multimesh instead of the slower canvas line draw functions.

This PR removes the old remnants of what was a fake open-gl line anti-aliasing that no longer works (it rendered everything twice with 0.5 alpha, aka very efficient).

The PR also removes the debug path width that did not really work and caused a lot of rendering issues on high res and dpi displays or different zoom and scale levels in the editor. It is now all thin "hardware" mesh lines.

![linezoom](https://github.com/user-attachments/assets/ad912757-cd03-4f1f-a19d-8e224227be85)

This largely means it replaces the old debug rendering. For editing paths the internal arrays got replaced with more efficient LocalVectors that keep the memory between path edits.

The rather slow canvas item draw for each segment and point were replaced with a combination of using static meshes for path lines and several multimeshes for the rendering of the editor handles and textures.

The nodes now always render the static debug visuals while the editor plugin only renders the editing parts like handles of the selected node on top.

![thick](https://github.com/user-attachments/assets/11a065c4-10f3-4ee2-b2a5-6a907828cb30)

The result is a very noticeable performance boost editing and rendering many complex 2d paths at the same time.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
