### PR TITLE
Update the Android NDK to the latest LTS version (r27c)

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
 
+import platform
 import subprocess
 import sys
 
@@ -51,18 +52,34 @@ lib = env_android.add_shared_library("#bin/libgodot", android_objects, redirect_
 env.Depends(lib, thirdparty_obj)
 
 lib_arch_dir = ""
+triple_target_dir = ""
 if env["arch"] == "arm32":
     lib_arch_dir = "armeabi-v7a"
+    triple_target_dir = "arm-linux-androideabi"
 elif env["arch"] == "arm64":
     lib_arch_dir = "arm64-v8a"
+    triple_target_dir = "aarch64-linux-android"
 elif env["arch"] == "x86_32":
     lib_arch_dir = "x86"
+    triple_target_dir = "i686-linux-android"
 elif env["arch"] == "x86_64":
     lib_arch_dir = "x86_64"
+    triple_target_dir = "x86_64-linux-android"
 else:
     print_warning("Architecture not suitable for embedding into APK; keeping .so at \\bin")
 
-if lib_arch_dir != "":
+host_subpath = ""
+if sys.platform.startswith("linux"):
+    host_subpath = "linux-x86_64"
+elif sys.platform.startswith("darwin"):
+    host_subpath = "darwin-x86_64"
+elif sys.platform.startswith("win"):
+    if platform.machine().endswith("64"):
+        host_subpath = "windows-x86_64"
+    else:
+        host_subpath = "windows"
+
+if lib_arch_dir != "" and host_subpath != "":
     if env.dev_build:
         lib_type_dir = "dev"
     elif env.debug_features:
@@ -81,9 +98,7 @@ if lib_arch_dir != "":
     out_dir = "#platform/android/java/lib/libs/" + lib_tools_dir + lib_type_dir + "/" + lib_arch_dir
     env_android.CommandNoCache(out_dir + "/libgodot_android.so", lib, Move("$TARGET", "$SOURCE"))
 
-    stl_lib_path = (
-        str(env["ANDROID_NDK_ROOT"]) + "/sources/cxx-stl/llvm-libc++/libs/" + lib_arch_dir + "/libc++_shared.so"
-    )
+    stl_lib_path = f"{env['ANDROID_NDK_ROOT']}/toolchains/llvm/prebuilt/{host_subpath}/sysroot/usr/lib/{triple_target_dir}/libc++_shared.so"
     env_android.CommandNoCache(out_dir + "/libc++_shared.so", stl_lib_path, Copy("$TARGET", "$SOURCE"))
 
     def generate_android_binaries(target, source, env):
@@ -98,10 +113,11 @@ if lib_arch_dir != "":
         else:
             gradle_process = ["./gradlew"]
 
-        gradle_process += [
-            "generateGodotEditor" if env["target"] == "editor" else "generateGodotTemplates",
-            "--quiet",
-        ]
+        if env["target"] == "editor":
+            gradle_process += ["generateGodotEditor", "generateGodotHorizonOSEditor", "generateGodotPicoOSEditor"]
+        else:
+            gradle_process += ["generateGodotTemplates"]
+        gradle_process += ["--quiet"]
 
         if env["gradle_do_not_strip"]:
             gradle_process += ["-PdoNotStrip=true"]

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -69,7 +69,7 @@ def get_android_ndk_root(env: "SConsEnvironment"):
 
 # This is kept in sync with the value in 'platform/android/java/app/config.gradle'.
 def get_ndk_version():
-    return "23.2.8568313"
+    return "27.2.12479018"
 
 
 # This is kept in sync with the value in 'platform/android/java/app/config.gradle'.

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -11,7 +11,7 @@ ext.versions = [
     nexusPublishVersion: '1.3.0',
     javaVersion        : JavaVersion.VERSION_17,
     // Also update 'platform/android/detect.py#get_ndk_version()' when this is updated.
-    ndkVersion         : '23.2.8568313',
+    ndkVersion         : '27.2.12479018',
     splashscreenVersion: '1.0.1',
     openxrVendorsVersion: '3.1.2-stable'
 

--- a/platform/android/java/scripts/publish-module.gradle
+++ b/platform/android/java/scripts/publish-module.gradle
@@ -43,7 +43,11 @@ afterEvaluate {
                             name = 'Rémi Verschelde'
                             email = 'rverschelde@gmail.com'
                         }
-                        // Add all other devs here...
+                        developer {
+                            id = 'godotengine'
+                            name = 'Godot Engine contributors'
+                            email = 'contact@godotengine.org'
+                        }
                     }
 
                     // Version control info - if you're using GitHub, follow the
@@ -91,7 +95,11 @@ afterEvaluate {
                             name = 'Rémi Verschelde'
                             email = 'rverschelde@gmail.com'
                         }
-                        // Add all other devs here...
+                        developer {
+                            id = 'godotengine'
+                            name = 'Godot Engine contributors'
+                            email = 'contact@godotengine.org'
+                        }
                     }
 
                     // Version control info - if you're using GitHub, follow the


### PR DESCRIPTION
Updating to the latest NDK LTS version, [r27c](https://github.com/android/ndk/wiki/Changelog-r27), released in July 2024.

The current NDK version, r23c, is no longer supported.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
