### PR TITLE
Fix incorrect transform when editor camera is moved externally

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2986,9 +2986,10 @@ void Node3DEditorViewport::_notification(int p_what) {
 			if (_camera_moved_externally()) {
 				// If camera moved after this plugin last set it, presumably a tool script has moved it, accept the new camera transform as the cursor position.
 				_apply_camera_transform_to_cursor();
+				_update_camera(0);
+			} else {
+				_update_camera(delta);
 			}
-
-			_update_camera(delta);
 
 			const HashMap<Node *, Object *> &selection = editor_selection->get_selection();
 
@@ -3494,8 +3495,18 @@ bool Node3DEditorViewport::_camera_moved_externally() {
 
 void Node3DEditorViewport::_apply_camera_transform_to_cursor() {
 	// Effectively the reverse of to_camera_transform, use camera transform to set cursor position and rotation.
-	Transform3D camera_transform = camera->get_camera_transform();
-	cursor.pos = camera_transform.origin;
+	const Transform3D camera_transform = camera->get_camera_transform();
+	const Basis basis = camera_transform.basis;
+
+	real_t distance;
+	if (orthogonal) {
+		distance = (get_zfar() - get_znear()) / 2.0;
+	} else {
+		distance = cursor.distance;
+	}
+
+	cursor.pos = camera_transform.origin - basis.get_column(2) * distance;
+
 	cursor.x_rot = -camera_transform.basis.get_euler().x;
 	cursor.y_rot = -camera_transform.basis.get_euler().y;
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Related: https://github.com/godotengine/godot-proposals/issues/11424#issuecomment-2817938811

When modifying the global transform directly the result ends up being wrong. The method `_apply_camera_transform_to_cursor()` didn't fully deconstruct the externally modified transform for the cursor data that would be used to transform the camera when the update for it is called. 

It is not applying the cursor / z distance to the position of the cursor.

Note how the camera is translated here:

https://github.com/godotengine/godot/blob/2d3bdcac35ac22ee6c4d5d5edc88ba947d0659d5/editor/plugins/node_3d_editor_plugin.cpp#L627-L640

Additionally, interpolation is removed when modified externally because it is unnecessary (or can be done externally) and leads to minor inaccuracies. 

Before:

https://github.com/user-attachments/assets/bd676a9e-5884-4e6b-b04e-2e992c7d0c5d

After:

https://github.com/user-attachments/assets/f8c02e8e-f537-4bd7-bea6-f4b98331eabd


How to test:

Download Zylann `Editor Debugger` addon and enable it:

![image](https://github.com/user-attachments/assets/cfcb8be2-b8c8-405f-91c4-7d376433977d)

Check `Show in Inspector`: 

![image](https://github.com/user-attachments/assets/3ed7cb43-244f-46ef-b0ed-8f69c22c72dc)

Use the addon's `F12` functionality to select the 3D viewport (this will select a `Control` node which is on top), then navigate from there to the `Camera3D` node.

![image](https://github.com/user-attachments/assets/8952160c-fb65-42dd-81d3-0866a1a919da)

Open the inspector and manipulate the Camera's transform. 



