### PR TITLE
Add viewport zoom by dragging with Ctrl+MiddleMouse button

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -944,6 +944,9 @@
 			If [code]true[/code], redraws the editor every frame even if nothing has changed on screen. When this setting is enabled, the update spinner displays in red (see [member interface/editor/show_update_spinner]).
 			[b]Warning:[/b] This greatly increases CPU and GPU utilization, leading to increased power usage. This should only be enabled for troubleshooting purposes.
 		</member>
+		<member name="interface/editor/zoom_drag_sensivity" type="float" setter="" getter="">
+			The zoom-drag sensivity factor to use. Increasing the value will increase the zoom-drag speed.
+		</member>
 		<member name="interface/editor/use_embedded_menu" type="bool" setter="" getter="">
 			If [code]true[/code], editor main menu is using embedded [MenuBar] instead of system global menu.
 			Specific to the macOS platform.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -944,8 +944,8 @@
 			If [code]true[/code], redraws the editor every frame even if nothing has changed on screen. When this setting is enabled, the update spinner displays in red (see [member interface/editor/show_update_spinner]).
 			[b]Warning:[/b] This greatly increases CPU and GPU utilization, leading to increased power usage. This should only be enabled for troubleshooting purposes.
 		</member>
-		<member name="interface/editor/zoom_drag_sensivity" type="float" setter="" getter="">
-			The zoom-drag sensivity factor to use. Increasing the value will increase the zoom-drag speed.
+		<member name="interface/editor/zoom_drag_sensitivity" type="float" setter="" getter="">
+			The zoom-drag sensitivity factor to use. Increasing the value will increase the zoom-drag speed.
 		</member>
 		<member name="interface/editor/use_embedded_menu" type="bool" setter="" getter="">
 			If [code]true[/code], editor main menu is using embedded [MenuBar] instead of system global menu.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -582,6 +582,9 @@
 		<member name="editors/panning/warped_mouse_panning" type="bool" setter="" getter="">
 			If [code]true[/code], warps the mouse around the 2D viewport while panning in the 2D editor. This makes it possible to pan over a large area without having to exit panning and adjust the mouse cursor.
 		</member>
+		<member name="editors/panning/zoom_drag_sensitivity" type="float" setter="" getter="">
+			The zoom-drag sensitivity factor to use. Increasing the value will increase the zoom-drag speed.
+		</member>
 		<member name="editors/polygon_editor/auto_bake_delay" type="float" setter="" getter="">
 			The delay in seconds until more complex and performance costly polygon editors commit their outlines, e.g. the 2D navigation polygon editor rebakes the navigation mesh polygons. A negative value stops the auto bake.
 		</member>
@@ -943,9 +946,6 @@
 		<member name="interface/editor/update_continuously" type="bool" setter="" getter="">
 			If [code]true[/code], redraws the editor every frame even if nothing has changed on screen. When this setting is enabled, the update spinner displays in red (see [member interface/editor/show_update_spinner]).
 			[b]Warning:[/b] This greatly increases CPU and GPU utilization, leading to increased power usage. This should only be enabled for troubleshooting purposes.
-		</member>
-		<member name="interface/editor/zoom_drag_sensitivity" type="float" setter="" getter="">
-			The zoom-drag sensitivity factor to use. Increasing the value will increase the zoom-drag speed.
 		</member>
 		<member name="interface/editor/use_embedded_menu" type="bool" setter="" getter="">
 			If [code]true[/code], editor main menu is using embedded [MenuBar] instead of system global menu.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -528,7 +528,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/vsync_mode", 1, "Disabled,Enabled,Adaptive,Mailbox")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/update_continuously", false, "")
-	_initial_set("interface/editor/zoom_drag_sensivity", 1.0);
 
 	_initial_set("interface/editors/show_scene_tree_root_selection", true);
 	_initial_set("interface/editors/derive_script_globals_by_name", true);
@@ -921,6 +920,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/panning/simple_panning", false);
 	_initial_set("editors/panning/warped_mouse_panning", true);
 	_initial_set("editors/panning/2d_editor_pan_speed", 20, true);
+	_initial_set("editors/panning/zoom_drag_sensitivity", 1.0);
 
 	// Tiles editor
 	_initial_set("editors/tiles_editor/display_grid", true);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -528,6 +528,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/vsync_mode", 1, "Disabled,Enabled,Adaptive,Mailbox")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/update_continuously", false, "")
+	_initial_set("interface/editor/zoom_drag_sensivity", 1.0);
 
 	_initial_set("interface/editors/show_scene_tree_root_selection", true);
 	_initial_set("interface/editors/derive_script_globals_by_name", true);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4129,6 +4129,7 @@ void CanvasItemEditor::_update_editor_settings() {
 	panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/2d_editor_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 	panner->set_scroll_speed(EDITOR_GET("editors/panning/2d_editor_pan_speed"));
 	panner->setup_warped_panning(get_viewport(), EDITOR_GET("editors/panning/warped_mouse_panning"));
+	panner->set_zoom_drag_sensitivity(float(EDITOR_GET("editors/panning/zoom_drag_sensitivity")));
 }
 
 void CanvasItemEditor::_project_settings_changed() {

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -124,7 +124,6 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 		} else if (is_zoom_dragging) {
 			// Zoom drag with vertical movement
 			Vector2 drag_distance = mm->get_relative();
-			float zoom_drag_sensitivity = EditorSettings::get_singleton()->get("interface/editor/zoom_drag_sensitivity");
 			float zoom_factor = 1.0 + (drag_distance.y * zoom_drag_sensitivity * zoom_drag_sensitivity_factor);
 			zoom_callback.call(zoom_factor, mm->get_position(), p_event);
 			return true;
@@ -217,6 +216,11 @@ void ViewPanner::set_scroll_zoom_factor(float p_scroll_zoom_factor) {
 
 void ViewPanner::set_pan_axis(PanAxis p_pan_axis) {
 	pan_axis = p_pan_axis;
+}
+
+void ViewPanner::set_zoom_drag_sensitivity(float p_zoom_drag_sensitivity) {
+	ERR_FAIL_COND(p_zoom_drag_sensitivity < 0.0f);
+	zoom_drag_sensitivity = p_zoom_drag_sensitivity;
 }
 
 void ViewPanner::setup(ControlScheme p_scheme, Ref<Shortcut> p_shortcut, bool p_simple_panning) {

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -87,6 +87,11 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 			}
 		}
 
+		if (mb->get_button_index() == MouseButton::MIDDLE && mb->is_ctrl_pressed()) {
+			is_zoom_dragging = mb->is_pressed();
+			return true;
+		}
+
 		// Alt is not used for button presses, so ignore it.
 		if (mb->is_alt_pressed()) {
 			return false;
@@ -115,6 +120,13 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 			} else {
 				pan_callback.call(mm->get_relative(), p_event);
 			}
+			return true;
+		} else if (is_zoom_dragging) {
+			// Zoom drag with vertical movement
+			Vector2 drag_distance = mm->get_relative();
+			float zoom_drag_sensivity = EditorSettings::get_singleton()->get("interface/editor/zoom_drag_sensivity");
+			float zoom_factor = 1.0 + (drag_distance.y * zoom_drag_sensivity * zoom_drag_sensitivity_factor);
+			zoom_callback.call(zoom_factor, mm->get_position(), p_event);
 			return true;
 		}
 	}

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -124,8 +124,8 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 		} else if (is_zoom_dragging) {
 			// Zoom drag with vertical movement
 			Vector2 drag_distance = mm->get_relative();
-			float zoom_drag_sensivity = EditorSettings::get_singleton()->get("interface/editor/zoom_drag_sensivity");
-			float zoom_factor = 1.0 + (drag_distance.y * zoom_drag_sensivity * zoom_drag_sensitivity_factor);
+			float zoom_drag_sensitivity = EditorSettings::get_singleton()->get("interface/editor/zoom_drag_sensitivity");
+			float zoom_factor = 1.0 + (drag_distance.y * zoom_drag_sensitivity * zoom_drag_sensitivity_factor);
 			zoom_callback.call(zoom_factor, mm->get_position(), p_event);
 			return true;
 		}

--- a/scene/gui/view_panner.h
+++ b/scene/gui/view_panner.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
-#include "editor/editor_settings.h"
 
 class InputEvent;
 class Shortcut;
@@ -62,6 +61,7 @@ private:
 	bool force_drag = false;
 
 	bool is_zoom_dragging = false;
+	float zoom_drag_sensitivity = 1.0f;
 	float zoom_drag_sensitivity_factor = -0.01f;
 
 	bool enable_rmb = false;
@@ -84,6 +84,7 @@ public:
 	void set_scroll_speed(int p_scroll_speed);
 	void set_scroll_zoom_factor(float p_scroll_zoom_factor);
 	void set_pan_axis(PanAxis p_pan_axis);
+	void set_zoom_drag_sensitivity(float p_sensitivity);
 
 	void setup(ControlScheme p_scheme, Ref<Shortcut> p_shortcut, bool p_simple_panning);
 	void setup_warped_panning(Viewport *p_viewport, bool p_allowed);

--- a/scene/gui/view_panner.h
+++ b/scene/gui/view_panner.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "editor/editor_settings.h"
 
 class InputEvent;
 class Shortcut;
@@ -59,6 +60,9 @@ private:
 	bool is_dragging = false;
 	bool pan_key_pressed = false;
 	bool force_drag = false;
+
+	bool is_zoom_dragging = false;
+	float zoom_drag_sensitivity_factor = -0.01f;
 
 	bool enable_rmb = false;
 	bool simple_panning_enabled = false;


### PR DESCRIPTION
With the new additions you can zoom in the editor with CTRL+MMB+Drag (vertical). The same shortcut is present in Blender, and a similar functionality can be found in other software as well, such as Adobe Photoshop. This make the experience much better as you can pan with MMB and hold CTRL for fine-tuned zooming.

Demo:

https://github.com/user-attachments/assets/c3325659-8bbc-4e06-aac8-6805c9c8daca

(The slight lag is caused by the screen recorder)
