### PR TITLE
OpenXR: Fix saving action map when UID is used in project settings

### DIFF
--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -288,13 +288,12 @@ void OpenXRActionMapEditor::_load_action_map(const String p_path, bool p_create_
 	} else if (p_create_new_if_missing) {
 		action_map.instantiate();
 		action_map->create_default_action_sets();
-		action_map->set_path(p_path);
 
 		// Save it immediately
 		err = ResourceSaver::save(action_map, p_path);
 		if (err != OK) {
 			// Show warning but continue.
-			EditorNode::get_singleton()->show_warning(vformat(TTR("Error saving file %s: %s"), edited_path, error_names[err]));
+			EditorNode::get_singleton()->show_warning(vformat(TTR("Error saving file %s: %s"), p_path, error_names[err]));
 		}
 	}
 
@@ -495,5 +494,5 @@ OpenXRActionMapEditor::OpenXRActionMapEditor() {
 
 	// Our Action map editor is only shown if openxr is enabled in project settings
 	// So load our action map and if it doesn't exist, create it right away.
-	_load_action_map(GLOBAL_GET("xr/openxr/default_action_map"), true);
+	_load_action_map(ResourceUID::ensure_path(GLOBAL_GET("xr/openxr/default_action_map")), true);
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105607

I don't know if this is the right way to fix this (because I'm not sure the proper way to handle UIDs in editor code) but it does fix the issue in my testing