### PR TITLE
FileDialog code cleanup

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -45,6 +45,7 @@
 #include "scene/gui/file_dialog.h"
 #include "scene/gui/link_button.h"
 #include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/tree.h"
 #include "scene/main/http_request.h"


### PR DESCRIPTION
Preparations for https://github.com/godotengine/godot-proposals/issues/6831

Cleanup of FileDialog code, without altering its functionality.

- Cleaned up includes.
- Reorganized the constructor for better readability and to match usual order of things.
- Reorganized members order (better consistency with constructor's order and with usual order in classes).
- Renamed some badly named members.
- Added `_setup_button()` method to simplify button theme initialization.
- Some Labels had wrong focus mode after accessibility changes.
- Changed the position of `shortcuts_container`. It was in a weird spot between buttons, but not sure where should it go tbh.