### PR TITLE
Remove `AStar2D/3D` comments on `reserve_space()` capacity needs

### DIFF
--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -278,7 +278,7 @@
 			<return type="void" />
 			<param index="0" name="num_nodes" type="int" />
 			<description>
-				Reserves space internally for [param num_nodes] points. Useful if you're adding a known large number of points at once, such as points on a grid. The new capacity must be greater or equal to the old capacity.
+				Reserves space internally for [param num_nodes] points. Useful if you're adding a known large number of points at once, such as points on a grid.
 			</description>
 		</method>
 		<method name="set_point_disabled">

--- a/doc/classes/AStar3D.xml
+++ b/doc/classes/AStar3D.xml
@@ -318,7 +318,7 @@
 			<return type="void" />
 			<param index="0" name="num_nodes" type="int" />
 			<description>
-				Reserves space internally for [param num_nodes] points. Useful if you're adding a known large number of points at once, such as points on a grid. New capacity must be greater or equals to old capacity.
+				Reserves space internally for [param num_nodes] points. Useful if you're adding a known large number of points at once, such as points on a grid.
 			</description>
 		</method>
 		<method name="set_point_disabled">


### PR DESCRIPTION
Removes AStar2D/3D comments of `reserve_space()` new capacity needing to be greater or equal than old capacity.

This is no longer an error case with recent PR https://github.com/godotengine/godot/pull/105278 merged.

Documentation could still merge https://github.com/godotengine/godot/pull/102941 so users know the default point alloc.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
