### PR TITLE
Vulkan: Disable anisotropy when `anisotropy_max` is set to 1.0

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -2318,6 +2318,10 @@ RDD::SamplerID RenderingDeviceDriverVulkan::sampler_create(const SamplerState &p
 	sampler_create_info.borderColor = (VkBorderColor)p_state.border_color;
 	sampler_create_info.unnormalizedCoordinates = p_state.unnormalized_uvw;
 
+	if (sampler_create_info.maxAnisotropy == 1.0f) {
+		sampler_create_info.anisotropyEnable = false;
+	}
+
 	VkSampler vk_sampler = VK_NULL_HANDLE;
 	VkResult res = vkCreateSampler(vk_device, &sampler_create_info, VKC::get_allocation_callbacks(VK_OBJECT_TYPE_SAMPLER), &vk_sampler);
 	ERR_FAIL_COND_V_MSG(res, SamplerID(), "vkCreateSampler failed with error " + itos(res) + ".");


### PR DESCRIPTION
This fixes an issue where setting the anisotropic filtering level in the project settings to "Disabled" has undefined behavior (In my case, it looks the same as setting it to 2x).

I don't know whether or not D3D12 and Metal also have this issue, so I only added the patch to Vulkan.

- *Production edit: This partially addresses https://github.com/godotengine/godot/issues/105530.*