### PR TITLE
SvgTexture not in 3D

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -936,7 +936,6 @@ void register_scene_types() {
 #ifndef _3D_DISABLED
 	GDREGISTER_CLASS(AudioStreamPlayer3D);
 	GDREGISTER_VIRTUAL_CLASS(PrimitiveMesh);
-	GDREGISTER_CLASS(SVGTexture);
 	GDREGISTER_CLASS(BoxMesh);
 	GDREGISTER_CLASS(CapsuleMesh);
 	GDREGISTER_CLASS(CylinderMesh);
@@ -1021,6 +1020,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(PlaceholderTexture2DArray);
 	GDREGISTER_CLASS(PlaceholderCubemap);
 	GDREGISTER_CLASS(PlaceholderCubemapArray);
+	GDREGISTER_CLASS(SVGTexture);
 
 	// These classes are part of renderer_rd
 	GDREGISTER_CLASS(Texture2DRD);


### PR DESCRIPTION
Move `SvgTexture` out of the `_3D_DISABLED` scope to ensure it remains available even when 3D is disabled, as it is indeed unrelated to 3D.
