### PR TITLE
Fixes for `.sln` project generation for Rider on Mac/Linux

### DIFF
--- a/misc/msvs/nmake.substitution.props
+++ b/misc/msvs/nmake.substitution.props
@@ -16,4 +16,23 @@
   <Target Name="Clean">
     <Exec Command="$(NMakeCleanCommandLine)"/>
   </Target>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalOptions>$(AdditionalOptions)</AdditionalOptions>
+      <ForcedIncludeFiles>$(NMakeForcedIncludes)</ForcedIncludeFiles>
+      <ForcedUsingFiles>$(NMakeForcedUsingAssemblies)</ForcedUsingFiles>
+      <PreprocessorDefinitions>$(NMakePreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <!-- check get_platforms in each msvs.py for possible value of those conditions -->
+    <!-- MSVC Platform.Common.props for possible TargetMachine values -->
+    <Link Condition="'$(Platform)' == 'arm64'">
+      <TargetMachine>MachineARM64</TargetMachine>
+    </Link>
+    <Link Condition="'$(Platform)' == 'x64'">
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+    <Link Condition="'$(Platform)' == 'Win32'">
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
1. `size_t` ambigious symbol
2. LanguageStandard was not parsed from AdditionalOptions

<img width="1442" alt="image" src="https://github.com/user-attachments/assets/c0ca5c37-0547-46e4-9630-3080569a9d85" />
