### PR TITLE
Fix for edge case when anisotropic filtering `maxAnisotropy` is set to 1

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -2411,7 +2411,7 @@ MaterialStorage::Samplers MaterialStorage::samplers_rd_allocate(float p_mipmap_b
 					sampler_state.min_filter = RD::SAMPLER_FILTER_NEAREST;
 					sampler_state.mip_filter = mip_filter;
 					sampler_state.lod_bias = samplers.mipmap_bias;
-					sampler_state.use_anisotropy = true;
+					sampler_state.use_anisotropy = anisotropic_filtering_level != RS::VIEWPORT_ANISOTROPY_DISABLED;
 					sampler_state.anisotropy_max = anisotropy_max;
 				} break;
 				case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC: {
@@ -2419,7 +2419,7 @@ MaterialStorage::Samplers MaterialStorage::samplers_rd_allocate(float p_mipmap_b
 					sampler_state.min_filter = RD::SAMPLER_FILTER_LINEAR;
 					sampler_state.mip_filter = mip_filter;
 					sampler_state.lod_bias = samplers.mipmap_bias;
-					sampler_state.use_anisotropy = true;
+					sampler_state.use_anisotropy = anisotropic_filtering_level != RS::VIEWPORT_ANISOTROPY_DISABLED;
 					sampler_state.anisotropy_max = anisotropy_max;
 
 				} break;


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-Docs/issues/1361

In Vulkan, enabling anisotropic filtering for a sampler when the `maxAnisotropy` value is set to 1 is an edge case, and on some Intel GPU drivers, it doesn't fully disable anisotropic filtering.

- *Production edit: This partially addresses https://github.com/godotengine/godot/issues/105530.*