### PR TITLE
Add `SVGTexture` importer.

### DIFF
--- a/doc/classes/ResourceImporterSVG.xml
+++ b/doc/classes/ResourceImporterSVG.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterSVG" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Imports a SVG file as a scalable texture for use in 2D or 3D rendering.
+	</brief_description>
+	<description>
+		This importer imports [SVGTexture] resources. See also [ResourceImporterTexture] and [ResourceImporterImage].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="base_scale" type="float" setter="" getter="" default="1.0">
+			SVG texture scale. [code]1.0[/code] is the original SVG size. Higher values result in a larger image.
+		</member>
+		<member name="color_map" type="Dictionary" setter="" getter="" default="{}">
+			If set, remaps SVG texture colors according to [Color]-[Color] map.
+		</member>
+		<member name="compress" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], uses lossless compression for the SVG source.
+		</member>
+		<member name="saturation" type="float" setter="" getter="" default="1.0">
+			Overrides texture saturation.
+		</member>
+	</members>
+</class>

--- a/doc/classes/SVGTexture.xml
+++ b/doc/classes/SVGTexture.xml
@@ -19,11 +19,24 @@
 				Creates a new [SVGTexture] and initializes it by allocating and setting the SVG data from string.
 			</description>
 		</method>
+		<method name="get_source" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns SVG source code.
+			</description>
+		</method>
 		<method name="set_size_override">
 			<return type="void" />
 			<param index="0" name="size" type="Vector2i" />
 			<description>
 				Resizes the texture to the specified dimensions.
+			</description>
+		</method>
+		<method name="set_source">
+			<return type="void" />
+			<param index="0" name="source" type="String" />
+			<description>
+				Sets SVG source code.
 			</description>
 		</method>
 	</methods>
@@ -37,9 +50,6 @@
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="saturation" type="float" setter="set_saturation" getter="get_saturation" default="1.0">
 			Overrides texture saturation.
-		</member>
-		<member name="source" type="String" setter="set_source" getter="get_source" default="&quot;&quot;">
-			SVG source code.
 		</member>
 	</members>
 </class>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -128,6 +128,7 @@
 #include "editor/import/resource_importer_imagefont.h"
 #include "editor/import/resource_importer_layered_texture.h"
 #include "editor/import/resource_importer_shader_file.h"
+#include "editor/import/resource_importer_svg.h"
 #include "editor/import/resource_importer_texture.h"
 #include "editor/import/resource_importer_texture_atlas.h"
 #include "editor/import/resource_importer_wav.h"
@@ -7274,6 +7275,10 @@ EditorNode::EditorNode() {
 		Ref<ResourceImporterImage> import_image;
 		import_image.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(import_image);
+
+		Ref<ResourceImporterSVG> import_svg;
+		import_svg.instantiate();
+		ResourceFormatImporter::get_singleton()->add_importer(import_svg);
 
 		Ref<ResourceImporterTextureAtlas> import_texture_atlas;
 		import_texture_atlas.instantiate();

--- a/editor/import/resource_importer_svg.cpp
+++ b/editor/import/resource_importer_svg.cpp
@@ -1,0 +1,104 @@
+/**************************************************************************/
+/*  resource_importer_svg.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "resource_importer_svg.h"
+
+#include "core/io/file_access.h"
+#include "scene/resources/svg_texture.h"
+
+String ResourceImporterSVG::get_importer_name() const {
+	return "svg";
+}
+
+String ResourceImporterSVG::get_visible_name() const {
+	return "SVGTexture";
+}
+
+void ResourceImporterSVG::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("svg");
+}
+
+String ResourceImporterSVG::get_save_extension() const {
+	return "svgtex";
+}
+
+String ResourceImporterSVG::get_resource_type() const {
+	return "SVGTexture";
+}
+
+bool ResourceImporterSVG::get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
+	return true;
+}
+
+int ResourceImporterSVG::get_preset_count() const {
+	return 0;
+}
+
+String ResourceImporterSVG::get_preset_name(int p_idx) const {
+	return String();
+}
+
+void ResourceImporterSVG::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {
+	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "base_scale", PROPERTY_HINT_RANGE, "0.001,100,0.001"), 1.0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "saturation", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), 1.0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::DICTIONARY, "color_map"), Dictionary()));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "compress"), true));
+}
+
+Error ResourceImporterSVG::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+	Ref<SVGTexture> svg_tex;
+	svg_tex.instantiate();
+
+	String source = FileAccess::get_file_as_string(p_source_file);
+	ERR_FAIL_COND_V_MSG(source.is_empty(), ERR_CANT_OPEN, vformat("Cannot open file from path \"%s\".", p_source_file));
+
+	double base_scale = p_options["base_scale"];
+	double saturation = p_options["saturation"];
+	Dictionary color_map = p_options["color_map"];
+
+	svg_tex->set_base_scale(base_scale);
+	svg_tex->set_saturation(saturation);
+	svg_tex->set_color_map(color_map);
+	svg_tex->set_source(source);
+
+	ERR_FAIL_COND_V_MSG(svg_tex->get_rid().is_null(), ERR_CANT_OPEN, vformat("Failed loading SVG, unsupported or invalid SVG data in \"%s\".", p_source_file));
+
+	int flg = 0;
+	if ((bool)p_options["compress"]) {
+		flg |= ResourceSaver::SaverFlags::FLAG_COMPRESS;
+	}
+
+	print_verbose("Saving to: " + p_save_path + ".svgtex");
+	Error err = ResourceSaver::save(svg_tex, p_save_path + ".svgtex", flg);
+	ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Cannot save SVG texture to file \"%s.svgtex\".", p_save_path));
+	print_verbose("Done saving to: " + p_save_path + ".svgtex");
+
+	return OK;
+}

--- a/editor/import/resource_importer_svg.h
+++ b/editor/import/resource_importer_svg.h
@@ -1,0 +1,54 @@
+/**************************************************************************/
+/*  resource_importer_svg.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/resource_importer.h"
+
+class ResourceImporterSVG : public ResourceImporter {
+	GDCLASS(ResourceImporterSVG, ResourceImporter);
+
+public:
+	virtual String get_importer_name() const override;
+	virtual String get_visible_name() const override;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual String get_save_extension() const override;
+	virtual String get_resource_type() const override;
+
+	virtual int get_preset_count() const override;
+	virtual String get_preset_name(int p_idx) const override;
+
+	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
+	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
+
+	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+
+	virtual bool can_import_threaded() const override { return true; }
+};

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -65,6 +65,7 @@
 #include "editor/import/resource_importer_imagefont.h"
 #include "editor/import/resource_importer_layered_texture.h"
 #include "editor/import/resource_importer_shader_file.h"
+#include "editor/import/resource_importer_svg.h"
 #include "editor/import/resource_importer_texture.h"
 #include "editor/import/resource_importer_texture_atlas.h"
 #include "editor/import/resource_importer_wav.h"
@@ -197,6 +198,7 @@ void register_editor_types() {
 	GDREGISTER_CLASS(ResourceImporterDynamicFont);
 	GDREGISTER_CLASS(ResourceImporterImage);
 	GDREGISTER_CLASS(ResourceImporterImageFont);
+	GDREGISTER_CLASS(ResourceImporterSVG);
 	GDREGISTER_CLASS(ResourceImporterLayeredTexture);
 	GDREGISTER_CLASS(ResourceImporterOBJ);
 	GDREGISTER_CLASS(ResourceImporterScene);

--- a/scene/resources/svg_texture.cpp
+++ b/scene/resources/svg_texture.cpp
@@ -186,7 +186,9 @@ RID SVGTexture::_load_at_scale(double p_scale, bool p_set_size) const {
 	const bool upsample = !Math::is_equal_approx(Math::round(p_scale * base_scale), p_scale * base_scale);
 
 	Error err = ImageLoaderSVG::create_image_from_string(img, source, p_scale * base_scale, upsample, cmap);
-	ERR_FAIL_COND_V_MSG(err != OK, RID(), "Failed generating icon, unsupported or invalid SVG data in default theme.");
+	if (err != OK) {
+		return RID();
+	}
 #else
 	img = Image::create_empty(Math::round(16 * p_scale * base_scale), Math::round(16 * p_scale * base_scale), false, Image::FORMAT_RGBA8);
 #endif
@@ -365,7 +367,7 @@ void SVGTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_color_map"), &SVGTexture::get_color_map);
 	ClassDB::bind_method(D_METHOD("set_size_override", "size"), &SVGTexture::set_size_override);
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source", PROPERTY_HINT_MULTILINE_TEXT), "set_source", "get_source");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "_source", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_STORAGE), "set_source", "get_source");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "base_scale", PROPERTY_HINT_RANGE, "0.01,10.0,0.01"), "set_base_scale", "get_base_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "saturation", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_saturation", "get_saturation");
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "color_map"), "set_color_map", "get_color_map");

--- a/scene/resources/svg_texture.h
+++ b/scene/resources/svg_texture.h
@@ -37,6 +37,7 @@ class BitMap;
 
 class SVGTexture : public Texture2D {
 	GDCLASS(SVGTexture, Texture2D);
+	RES_BASE_EXTENSION("svgtex");
 
 	String source;
 	float base_scale = 1.0;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105652

Adds `ResourceImporterSVG` to directly import SVG files as `SVGTexture`.