### PR TITLE
Always duplicate modified properties when instantiating packed scenes

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -190,7 +190,6 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 		Node *node = nullptr;
 		MissingNode *missing_node = nullptr;
-		bool is_inherited_scene = false;
 
 		if (i == 0 && base_scene_idx >= 0) {
 			// Scene inheritance on root node.
@@ -201,7 +200,6 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			if (p_edit_state != GEN_EDIT_STATE_DISABLED) {
 				node->set_scene_inherited_state(sdata->get_state());
 			}
-			is_inherited_scene = true;
 		} else if (n.instance >= 0) {
 			// Instance a scene into this node.
 			if (n.instance & FLAG_INSTANCE_IS_PLACEHOLDER) {
@@ -356,11 +354,9 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 					} else {
 						Variant value = props[nprops[j].value];
 
-						// Making sure that instances of inherited scenes don't share the same
+						// Making sure that instances of scenes don't share the same
 						// reference between them.
-						if (is_inherited_scene) {
-							value = value.duplicate(true);
-						}
+						value = value.duplicate(true);
 
 						if (value.get_type() == Variant::OBJECT) {
 							//handle resources that are local to scene by duplicating them if needed


### PR DESCRIPTION
Fixes #96181
Fixes #101476

As described in the above issues, scene instances currently share the base `PackedScene`'s copy of reference types (eg. `Array`, `Dictionary`) rather than creating their own, leading to unintuitive behavior.

This PR makes properties always duplicate when instantiating a scene.