### PR TITLE
Sort animation nodes in `AnimationNodeBlendSpace2DEditor` popup menu

### DIFF
--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -119,10 +119,11 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 			menu->clear(false);
 			animations_menu->clear();
 			animations_to_add.clear();
+
 			LocalVector<StringName> classes;
+			ClassDB::get_inheriters_from_class("AnimationRootNode", classes);
 			classes.sort_custom<StringName::AlphCompare>();
 
-			ClassDB::get_inheriters_from_class("AnimationRootNode", classes);
 			menu->add_submenu_node_item(TTR("Add Animation"), animations_menu);
 
 			List<StringName> names;


### PR DESCRIPTION
Updated `AnimationNodeBlendSpace2DEditor::_blend_space_gui_input` to sort animation nodes for menu when adding new points, to match ordering in `AnimationNodeBlendSpace1DEditor` and `AnimationNodeStateMachineEditor`.  Old code had the sort call before adding the node names, so it wasn't reflected in the menu.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
