### PR TITLE
CI: Remove legacy dependency workaround

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -106,8 +106,7 @@ jobs:
         if: matrix.proj-test
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EB8B81E14DA65431D7504EA8F63F0F2B90935439
-          sudo add-apt-repository "deb https://ppa.launchpadcontent.net/kisak/turtle/ubuntu jammy main"
+          sudo add-apt-repository ppa:kisak/kisak-mesa
           sudo apt-get install -qq mesa-vulkan-drivers
 
       # TODO: Figure out somehow how to embed this one.


### PR DESCRIPTION
- Related #83147
- Related #83214

The above PRs were meant to address an at-the-time regression in the Launchpad access of Mesa for CI testing. Accessing the initial workaround's repo has been inconsistent as of late, so this returns the repo we pull from `turtle` to `kisak-mesa`, as that change didn't ultimately impact the original problem. Additionally, as the original problem has since been fixed, we can return to the less-verbose syntax we had before, which no longer requires us jumping through nickname hoops on the command line