### PR TITLE
CI: Remove legacy dependency

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -101,14 +101,11 @@ jobs:
         with:
           submodules: recursive
 
-      # Need newer mesa for lavapipe to work properly.
       - name: Linux dependencies for tests
         if: matrix.proj-test
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EB8B81E14DA65431D7504EA8F63F0F2B90935439
-          sudo add-apt-repository "deb https://ppa.launchpadcontent.net/kisak/turtle/ubuntu jammy main"
-          sudo apt-get install -qq mesa-vulkan-drivers
+          sudo apt-get install mesa-vulkan-drivers
 
       # TODO: Figure out somehow how to embed this one.
       - name: wayland-scanner dependency


### PR DESCRIPTION
- Supersedes #105660

Turns out we can just ditch the middleman entirely. Ubuntu-22.04's implementation of `mesa-vulkan-drivers` is already satisfactory for our tests, so installing that directly fixes all of our issues