### PR TITLE
CI: Replace `gold` with `mold`

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -35,11 +35,11 @@ jobs:
             # Validate godot-cpp compatibility on one arbitrary editor build.
             godot-cpp: true
 
-          - name: Editor with doubles and GCC sanitizers (target=editor, tests=yes, dev_build=yes, scu_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=gold)
+          - name: Editor with doubles and GCC sanitizers (target=editor, tests=yes, dev_build=yes, scu_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=mold)
             cache-name: linux-editor-double-sanitizers
             target: editor
             # Debug symbols disabled as they're huge on this build and we hit the 14 GB limit for runners.
-            sconsflags: dev_build=yes scu_build=yes debug_symbols=no precision=double use_asan=yes use_ubsan=yes linker=gold
+            sconsflags: dev_build=yes scu_build=yes debug_symbols=no precision=double use_asan=yes use_ubsan=yes linker=mold
             bin: ./bin/godot.linuxbsd.editor.dev.double.x86_64.san
             build-mono: false
             tests: true
@@ -161,6 +161,10 @@ jobs:
 
       - name: Extract pre-built AccessKit
         run: unzip -o accesskit-c-0.15.1/accesskit_c.zip
+
+      - name: Install mold linker
+        if: matrix.proj-test
+        uses: rui314/setup-mold@v1
 
       - name: Compilation
         uses: ./.github/actions/godot-build


### PR DESCRIPTION
With the `gold` linker being deprecated in the latest binutils[^1], this PR aims to fill the void with `mold`—the linker [our documentation recommends](https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_linuxbsd.html#using-mold-for-faster-development) as the absolute fastest/best option. The documentation in question is somewhat outdated, as the linker is actually available from virtually all distros at time of writing, so the one real fallback it had before is no longer relevant. It's a complete drop-in replacement, and already shows a *significant* increase in speed compared to `gold`!

[^1]: https://lists.gnu.org/archive/html/info-gnu/2025-02/msg00001.html