### PR TITLE
Components for Node

### DIFF
--- a/editor/add_component_dialog.cpp
+++ b/editor/add_component_dialog.cpp
@@ -36,10 +36,10 @@ AddComponentDialog::AddComponentDialog() {
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
 
-	add_component_type = memnew(OptionButton);
-	add_component_type->set_accessibility_name(TTRC("Type:"));
+	component_picker = memnew(EditorResourcePicker);
+	component_picker->set_base_type("Component");
 
-	vbc->add_child(add_component_type);
+	vbc->add_child(component_picker);
 
 	Control *spacing = memnew(Control);
 	vbc->add_child(spacing);
@@ -59,20 +59,7 @@ void AddComponentDialog::_complete_init(const StringName &p_title) {
 
 	set_title(vformat(TTR("Add Component to \"%s\""), p_title));
 
-	// Skip if we already completed the initialization.
-	if (add_component_type->get_item_count()) {
-		return;
-	}
-
-	// Theme icons can be retrieved only the Window has been initialized.
-	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
-		if (i == Variant::NIL || i == Variant::RID || i == Variant::CALLABLE || i == Variant::SIGNAL) {
-			continue; //not editable by inspector.
-		}
-		String type = i == Variant::OBJECT ? String("Resource") : Variant::get_type_name(Variant::Type(i));
-
-		add_component_type->add_icon_item(get_editor_theme_icon(type), type, i);
-	}
+	component_picker->set_edited_resource(nullptr);
 }
 
 void AddComponentDialog::open(const StringName p_title, List<StringName> &p_existing_components) {
@@ -81,8 +68,8 @@ void AddComponentDialog::open(const StringName p_title, List<StringName> &p_exis
 	popup_centered();
 }
 
-StringName AddComponentDialog::get_component_name() {
-	return "FIXME:: component name.";// add_meta_name->get_text();
+Ref<Component> AddComponentDialog::get_component() {
+	return Object::cast_to<Component>(*component_picker->get_edited_resource());
 }
 
 void AddComponentDialog::_check_component() {

--- a/editor/add_component_dialog.cpp
+++ b/editor/add_component_dialog.cpp
@@ -1,0 +1,122 @@
+/**************************************************************************/
+/*  add_component_dialog.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "add_component_dialog.h"
+
+#include "editor/themes/editor_scale.h"
+
+AddComponentDialog::AddComponentDialog() {
+	VBoxContainer *vbc = memnew(VBoxContainer);
+	add_child(vbc);
+
+	HBoxContainer *hbc = memnew(HBoxContainer);
+	vbc->add_child(hbc);
+	hbc->add_child(memnew(Label(TTR("Name:"))));
+
+	add_meta_name = memnew(LineEdit);
+	add_meta_name->set_accessibility_name(TTRC("Name:"));
+	add_meta_name->set_custom_minimum_size(Size2(200 * EDSCALE, 1));
+	hbc->add_child(add_meta_name);
+	hbc->add_child(memnew(Label(TTR("Type:"))));
+
+	add_meta_type = memnew(OptionButton);
+	add_meta_type->set_accessibility_name(TTRC("Type:"));
+
+	hbc->add_child(add_meta_type);
+
+	Control *spacing = memnew(Control);
+	vbc->add_child(spacing);
+	spacing->set_custom_minimum_size(Size2(0, 10 * EDSCALE));
+
+	set_ok_button_text(TTR("Add"));
+	register_text_enter(add_meta_name);
+
+	validation_panel = memnew(EditorValidationPanel);
+	vbc->add_child(validation_panel);
+	validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name is valid."));
+	validation_panel->set_update_callback(callable_mp(this, &AddComponentDialog::_check_meta_name));
+	validation_panel->set_accept_button(get_ok_button());
+
+	add_meta_name->connect(SceneStringName(text_changed), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
+}
+
+void AddComponentDialog::_complete_init(const StringName &p_title) {
+	add_meta_name->set_text("");
+	validation_panel->update();
+
+	set_title(vformat(TTR("Add Metadata Property for \"%s\""), p_title));
+
+	// Skip if we already completed the initialization.
+	if (add_meta_type->get_item_count()) {
+		return;
+	}
+
+	// Theme icons can be retrieved only the Window has been initialized.
+	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+		if (i == Variant::NIL || i == Variant::RID || i == Variant::CALLABLE || i == Variant::SIGNAL) {
+			continue; //not editable by inspector.
+		}
+		String type = i == Variant::OBJECT ? String("Resource") : Variant::get_type_name(Variant::Type(i));
+
+		add_meta_type->add_icon_item(get_editor_theme_icon(type), type, i);
+	}
+}
+
+void AddComponentDialog::open(const StringName p_title, List<StringName> &p_existing_metas) {
+	this->_existing_metas = p_existing_metas;
+	_complete_init(p_title);
+	popup_centered();
+	add_meta_name->grab_focus();
+}
+
+StringName AddComponentDialog::get_meta_name() {
+	return add_meta_name->get_text();
+}
+
+Variant AddComponentDialog::get_meta_defval() {
+	Variant defval;
+	Callable::CallError ce;
+	Variant::construct(Variant::Type(add_meta_type->get_selected_id()), defval, nullptr, 0, ce);
+	return defval;
+}
+
+void AddComponentDialog::_check_meta_name() {
+	const String meta_name = add_meta_name->get_text();
+
+	if (meta_name.is_empty()) {
+		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name can't be empty."), EditorValidationPanel::MSG_ERROR);
+	} else if (!meta_name.is_valid_ascii_identifier()) {
+		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name must be a valid identifier."), EditorValidationPanel::MSG_ERROR);
+	} else if (_existing_metas.find(meta_name)) {
+		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, vformat(TTR("Metadata with name \"%s\" already exists."), meta_name), EditorValidationPanel::MSG_ERROR);
+	} else if (meta_name[0] == '_') {
+		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Names starting with _ are reserved for editor-only metadata."), EditorValidationPanel::MSG_ERROR);
+	}
+}

--- a/editor/add_component_dialog.cpp
+++ b/editor/add_component_dialog.cpp
@@ -36,45 +36,31 @@ AddComponentDialog::AddComponentDialog() {
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
 
-	HBoxContainer *hbc = memnew(HBoxContainer);
-	vbc->add_child(hbc);
-	hbc->add_child(memnew(Label(TTR("Name:"))));
+	add_component_type = memnew(OptionButton);
+	add_component_type->set_accessibility_name(TTRC("Type:"));
 
-	add_meta_name = memnew(LineEdit);
-	add_meta_name->set_accessibility_name(TTRC("Name:"));
-	add_meta_name->set_custom_minimum_size(Size2(200 * EDSCALE, 1));
-	hbc->add_child(add_meta_name);
-	hbc->add_child(memnew(Label(TTR("Type:"))));
-
-	add_meta_type = memnew(OptionButton);
-	add_meta_type->set_accessibility_name(TTRC("Type:"));
-
-	hbc->add_child(add_meta_type);
+	vbc->add_child(add_component_type);
 
 	Control *spacing = memnew(Control);
 	vbc->add_child(spacing);
 	spacing->set_custom_minimum_size(Size2(0, 10 * EDSCALE));
 
 	set_ok_button_text(TTR("Add"));
-	register_text_enter(add_meta_name);
 
 	validation_panel = memnew(EditorValidationPanel);
 	vbc->add_child(validation_panel);
-	validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name is valid."));
-	validation_panel->set_update_callback(callable_mp(this, &AddComponentDialog::_check_meta_name));
+	validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Component is valid."));
+	validation_panel->set_update_callback(callable_mp(this, &AddComponentDialog::_check_component));
 	validation_panel->set_accept_button(get_ok_button());
-
-	add_meta_name->connect(SceneStringName(text_changed), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
 }
 
 void AddComponentDialog::_complete_init(const StringName &p_title) {
-	add_meta_name->set_text("");
 	validation_panel->update();
 
-	set_title(vformat(TTR("Add Metadata Property for \"%s\""), p_title));
+	set_title(vformat(TTR("Add Component to \"%s\""), p_title));
 
 	// Skip if we already completed the initialization.
-	if (add_meta_type->get_item_count()) {
+	if (add_component_type->get_item_count()) {
 		return;
 	}
 
@@ -85,38 +71,30 @@ void AddComponentDialog::_complete_init(const StringName &p_title) {
 		}
 		String type = i == Variant::OBJECT ? String("Resource") : Variant::get_type_name(Variant::Type(i));
 
-		add_meta_type->add_icon_item(get_editor_theme_icon(type), type, i);
+		add_component_type->add_icon_item(get_editor_theme_icon(type), type, i);
 	}
 }
 
-void AddComponentDialog::open(const StringName p_title, List<StringName> &p_existing_metas) {
-	this->_existing_metas = p_existing_metas;
+void AddComponentDialog::open(const StringName p_title, List<StringName> &p_existing_components) {
+	this->_existing_components = p_existing_components;
 	_complete_init(p_title);
 	popup_centered();
-	add_meta_name->grab_focus();
 }
 
-StringName AddComponentDialog::get_meta_name() {
-	return add_meta_name->get_text();
+StringName AddComponentDialog::get_component_name() {
+	return "FIXME:: component name.";// add_meta_name->get_text();
 }
 
-Variant AddComponentDialog::get_meta_defval() {
-	Variant defval;
-	Callable::CallError ce;
-	Variant::construct(Variant::Type(add_meta_type->get_selected_id()), defval, nullptr, 0, ce);
-	return defval;
-}
-
-void AddComponentDialog::_check_meta_name() {
-	const String meta_name = add_meta_name->get_text();
-
-	if (meta_name.is_empty()) {
-		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name can't be empty."), EditorValidationPanel::MSG_ERROR);
-	} else if (!meta_name.is_valid_ascii_identifier()) {
-		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name must be a valid identifier."), EditorValidationPanel::MSG_ERROR);
-	} else if (_existing_metas.find(meta_name)) {
-		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, vformat(TTR("Metadata with name \"%s\" already exists."), meta_name), EditorValidationPanel::MSG_ERROR);
-	} else if (meta_name[0] == '_') {
-		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Names starting with _ are reserved for editor-only metadata."), EditorValidationPanel::MSG_ERROR);
-	}
+void AddComponentDialog::_check_component() {
+//	const String meta_name = add_meta_name->get_text();
+//
+//	if (meta_name.is_empty()) {
+//		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name can't be empty."), EditorValidationPanel::MSG_ERROR);
+//	} else if (!meta_name.is_valid_ascii_identifier()) {
+//		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name must be a valid identifier."), EditorValidationPanel::MSG_ERROR);
+//	} else if (_existing_metas.find(meta_name)) {
+//		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, vformat(TTR("Metadata with name \"%s\" already exists."), meta_name), EditorValidationPanel::MSG_ERROR);
+//	} else if (meta_name[0] == '_') {
+//		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Names starting with _ are reserved for editor-only metadata."), EditorValidationPanel::MSG_ERROR);
+//	}
 }

--- a/editor/add_component_dialog.h
+++ b/editor/add_component_dialog.h
@@ -31,9 +31,10 @@
 #pragma once
 
 #include "editor/gui/editor_validation_panel.h"
+#include "editor/editor_resource_picker.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/line_edit.h"
-#include "scene/gui/option_button.h"
+#include "modules/components/component.h"
 
 class AddComponentDialog : public ConfirmationDialog {
 	GDCLASS(AddComponentDialog, ConfirmationDialog);
@@ -42,7 +43,7 @@ public:
 	AddComponentDialog();
 	void open(const StringName p_title, List<StringName> &p_existing_components);
 
-	StringName get_component_name();
+	Ref<Component> get_component();
 
 private:
 	List<StringName> _existing_components;
@@ -50,6 +51,6 @@ private:
 	void _check_component();
 	void _complete_init(const StringName &p_label);
 
-	OptionButton *add_component_type = nullptr;
+	EditorResourcePicker *component_picker = nullptr;
 	EditorValidationPanel *validation_panel = nullptr;
 };

--- a/editor/add_component_dialog.h
+++ b/editor/add_component_dialog.h
@@ -40,18 +40,16 @@ class AddComponentDialog : public ConfirmationDialog {
 
 public:
 	AddComponentDialog();
-	void open(const StringName p_title, List<StringName> &p_existing_metas);
+	void open(const StringName p_title, List<StringName> &p_existing_components);
 
-	StringName get_meta_name();
-	Variant get_meta_defval();
+	StringName get_component_name();
 
 private:
-	List<StringName> _existing_metas;
+	List<StringName> _existing_components;
 
-	void _check_meta_name();
+	void _check_component();
 	void _complete_init(const StringName &p_label);
 
-	LineEdit *add_meta_name = nullptr;
-	OptionButton *add_meta_type = nullptr;
+	OptionButton *add_component_type = nullptr;
 	EditorValidationPanel *validation_panel = nullptr;
 };

--- a/editor/add_component_dialog.h
+++ b/editor/add_component_dialog.h
@@ -30,11 +30,11 @@
 
 #pragma once
 
-#include "editor/gui/editor_validation_panel.h"
 #include "editor/editor_resource_picker.h"
+#include "editor/gui/editor_validation_panel.h"
+#include "modules/components/component.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/line_edit.h"
-#include "modules/components/component.h"
 
 class AddComponentDialog : public ConfirmationDialog {
 	GDCLASS(AddComponentDialog, ConfirmationDialog);

--- a/editor/add_component_dialog.h
+++ b/editor/add_component_dialog.h
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  add_component_dialog.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/gui/editor_validation_panel.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/option_button.h"
+
+class AddComponentDialog : public ConfirmationDialog {
+	GDCLASS(AddComponentDialog, ConfirmationDialog);
+
+public:
+	AddComponentDialog();
+	void open(const StringName p_title, List<StringName> &p_existing_metas);
+
+	StringName get_meta_name();
+	Variant get_meta_defval();
+
+private:
+	List<StringName> _existing_metas;
+
+	void _check_meta_name();
+	void _complete_init(const StringName &p_label);
+
+	LineEdit *add_meta_name = nullptr;
+	OptionButton *add_meta_type = nullptr;
+	EditorValidationPanel *validation_panel = nullptr;
+};

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -5313,7 +5313,6 @@ Variant EditorInspector::get_property_clipboard() const {
 	return property_clipboard;
 }
 
-
 void EditorInspector::_add_component_confirm() {
 	// Ensure metadata is unfolded when adding a new metadata.
 	object->editor_set_section_unfold("component", true);
@@ -5326,7 +5325,6 @@ void EditorInspector::_add_component_confirm() {
 	undo_redo->add_undo_method(object, "remove_component", name);
 	undo_redo->commit_action();
 }
-
 
 void EditorInspector::_show_add_component_dialog() {
 	Actor *actor = Object::cast_to<Actor>(object);
@@ -5348,7 +5346,6 @@ void EditorInspector::_show_add_component_dialog() {
 	actor->get_component_class_list(&existing_components);
 	add_component_dialog->open(dialog_title, existing_components);
 }
-
 
 void EditorInspector::_show_add_meta_dialog() {
 	if (!add_meta_dialog) {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -49,6 +49,7 @@
 #include "editor/plugins/script_editor_plugin.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
+#include "scene/gui/box_container.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/spin_box.h"
@@ -4148,10 +4149,6 @@ void EditorInspector::update_tree() {
 					if (epr) {
 						epr->set_use_filter(true);
 					}
-
-					if (p.name.begins_with("components/")) {
-						//TODO::
-					}
 				}
 
 				Node *section_search = current_vbox->get_parent();
@@ -4167,14 +4164,12 @@ void EditorInspector::update_tree() {
 					}
 				}
 
-				if (p.name.begins_with("metadata/")) {//TODO:: check this out
+				if (p.name.begins_with("metadata/") || p.name.begins_with("components/")) {
 					Variant _default = Variant();
 					if (node != nullptr) {
 						_default = PropertyUtils::get_property_default_value(node, p.name, nullptr, &sstack, false, nullptr, nullptr);
 					}
 					ep->set_deletable(_default == Variant());
-				} else if (p.name.begins_with("components/")) {
-					ep->set_deletable(true);
 				} else {
 					ep->set_deletable(deletable_properties);
 				}
@@ -4314,6 +4309,8 @@ void EditorInspector::update_tree() {
 		}
 	}
 
+	Button *add_component = nullptr;
+	Button *add_md = nullptr;
 	{//TODO:: put in its own function
 		Actor *actor = Object::cast_to<Actor>(object);
 		if (actor) {
@@ -4321,10 +4318,10 @@ void EditorInspector::update_tree() {
 			spacer->set_custom_minimum_size(Size2(0, 4) * EDSCALE);
 			main_vbox->add_child(spacer);
 
-			Button *add_component = EditorInspector::create_inspector_action_button(TTR("Add Component"));
+			add_component = EditorInspector::create_inspector_action_button(TTR("Add Component"));
 			add_component->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 			add_component->connect(SceneStringName(pressed), callable_mp(this, &EditorInspector::_show_add_component_dialog));
-			main_vbox->add_child(add_component);
+//			main_vbox->add_child(add_component);
 			if (all_read_only) {
 				add_component->set_disabled(true);
 			}
@@ -4337,13 +4334,23 @@ void EditorInspector::update_tree() {
 		spacer->set_custom_minimum_size(Size2(0, 4) * EDSCALE);
 		main_vbox->add_child(spacer);
 
-		Button *add_md = EditorInspector::create_inspector_action_button(TTR("Add Metadata"));
+		add_md = EditorInspector::create_inspector_action_button(TTR("Add Metadata"));
 		add_md->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 		add_md->connect(SceneStringName(pressed), callable_mp(this, &EditorInspector::_show_add_meta_dialog));
-		main_vbox->add_child(add_md);
+//		main_vbox->add_child(add_md);
 		if (all_read_only) {
 			add_md->set_disabled(true);
 		}
+	}
+
+	if (add_component and add_md) {
+		HBoxContainer *hbox = memnew(HBoxContainer);
+		hbox->set_alignment(BoxContainer::ALIGNMENT_CENTER);
+		hbox->add_child(add_component);
+		hbox->add_child(add_md);
+		main_vbox->add_child(hbox);
+	} else if (add_component) {
+		main_vbox->add_child(add_component);
 	}
 
 	// Get the lists of to add at the end.

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -5309,6 +5309,12 @@ void EditorInspector::_add_component_confirm() {
 
 
 void EditorInspector::_show_add_component_dialog() {
+	Node *node = Object::cast_to<Node>(object);
+
+	if (!node) {
+		return;
+	}
+
 	if (!add_component_dialog) {
 		add_component_dialog = memnew(AddComponentDialog());
 		add_component_dialog->connect(SceneStringName(confirmed), callable_mp(this, &EditorInspector::_add_component_confirm));
@@ -5316,13 +5322,11 @@ void EditorInspector::_show_add_component_dialog() {
 	}
 
 	StringName dialog_title;
-	Node *node = Object::cast_to<Node>(object);
-	// If object is derived from Node use node name, if derived from Resource use classname.
-	dialog_title = node ? node->get_name() : StringName(object->get_class());
+	dialog_title = node->get_name();
 
-	List<StringName> existing_meta_keys;
-	object->get_meta_list(&existing_meta_keys);
-	add_component_dialog->open(dialog_title, existing_meta_keys);
+	List<StringName> existing_components;
+	node->get_component_list(&existing_components);
+	add_component_dialog->open(dialog_title, existing_components);
 }
 
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4144,7 +4144,7 @@ void EditorInspector::update_tree() {
 					}
 				}
 
-				if (sub_inspector_use_filter) {//TODO:: check this out
+				if (sub_inspector_use_filter) {
 					EditorPropertyResource *epr = Object::cast_to<EditorPropertyResource>(ep);
 					if (epr) {
 						epr->set_use_filter(true);
@@ -4311,7 +4311,7 @@ void EditorInspector::update_tree() {
 
 	Button *add_component = nullptr;
 	Button *add_md = nullptr;
-	{//TODO:: put in its own function
+	{
 		Actor *actor = Object::cast_to<Actor>(object);
 		if (actor) {
 			Control *spacer = memnew(Control);
@@ -4321,7 +4321,6 @@ void EditorInspector::update_tree() {
 			add_component = EditorInspector::create_inspector_action_button(TTR("Add Component"));
 			add_component->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 			add_component->connect(SceneStringName(pressed), callable_mp(this, &EditorInspector::_show_add_component_dialog));
-//			main_vbox->add_child(add_component);
 			if (all_read_only) {
 				add_component->set_disabled(true);
 			}
@@ -4337,7 +4336,6 @@ void EditorInspector::update_tree() {
 		add_md = EditorInspector::create_inspector_action_button(TTR("Add Metadata"));
 		add_md->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 		add_md->connect(SceneStringName(pressed), callable_mp(this, &EditorInspector::_show_add_meta_dialog));
-//		main_vbox->add_child(add_md);
 		if (all_read_only) {
 			add_md->set_disabled(true);
 		}

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4148,6 +4148,10 @@ void EditorInspector::update_tree() {
 					if (epr) {
 						epr->set_use_filter(true);
 					}
+
+					if (p.name.begins_with("components/")) {
+						//TODO::
+					}
 				}
 
 				Node *section_search = current_vbox->get_parent();
@@ -5310,7 +5314,7 @@ void EditorInspector::_add_component_confirm() {
 	object->editor_set_section_unfold("component", true);
 
 	Ref<Component> component = add_component_dialog->get_component();
-	String name = component->get_component_class();
+	String name = component->get_class();
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(vformat(TTR("Add component %s"), name));
 	undo_redo->add_do_method(object, "set_component", component);

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -5324,9 +5324,9 @@ void EditorInspector::_show_add_component_dialog() {
 	StringName dialog_title;
 	dialog_title = node->get_name();
 
-	List<StringName> existing_components;
-	node->get_component_list(&existing_components);
-	add_component_dialog->open(dialog_title, existing_components);
+//	List<StringName> existing_components;
+//	node->get_component_list(&existing_components);
+//	add_component_dialog->open(dialog_title, existing_components);
 }
 
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "editor/add_component_dialog.h"
 #include "editor/add_metadata_dialog.h"
 #include "editor_property_name_processor.h"
 #include "scene/gui/box_container.h"
@@ -669,11 +670,18 @@ class EditorInspector : public ScrollContainer {
 	bool _is_property_disabled_by_feature_profile(const StringName &p_property);
 
 	void _section_toggled_by_user(const String &p_path, bool p_value);
+	AddComponentDialog *add_component_dialog = nullptr;
+	LineEdit *add_component_name = nullptr;
+	OptionButton *add_component_type = nullptr;
+	EditorValidationPanel *component_validation_panel = nullptr;
 
 	AddMetadataDialog *add_meta_dialog = nullptr;
 	LineEdit *add_meta_name = nullptr;
 	OptionButton *add_meta_type = nullptr;
 	EditorValidationPanel *validation_panel = nullptr;
+
+	void _add_component_confirm();
+	void _show_add_component_dialog();
 
 	void _add_meta_confirm();
 	void _show_add_meta_dialog();

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -671,7 +671,6 @@ class EditorInspector : public ScrollContainer {
 
 	void _section_toggled_by_user(const String &p_path, bool p_value);
 	AddComponentDialog *add_component_dialog = nullptr;
-	LineEdit *add_component_name = nullptr;
 	OptionButton *add_component_type = nullptr;
 	EditorValidationPanel *component_validation_panel = nullptr;
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -33,10 +33,10 @@
 #include "editor/add_component_dialog.h"
 #include "editor/add_metadata_dialog.h"
 #include "editor_property_name_processor.h"
+#include "modules/components/component.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/main/actor.h"
-#include "modules/components/component.h"
 
 class AcceptDialog;
 class Button;

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -35,6 +35,8 @@
 #include "editor_property_name_processor.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/scroll_container.h"
+#include "scene/main/actor.h"
+#include "modules/components/component.h"
 
 class AcceptDialog;
 class Button;

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -207,16 +207,18 @@ void EditorResourcePicker::_update_menu_items() {
 	if (is_editable()) {
 		set_create_options(edit_menu);
 
-		// Add an option to load a resource from a file using the QuickOpen dialog.
-		edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Quick Load..."), OBJ_MENU_QUICKLOAD);
-		edit_menu->set_item_tooltip(-1, TTR("Opens a quick menu to select from a list of allowed Resource files."));
+		if (can_load()) {
+			// Add an option to load a resource from a file using the QuickOpen dialog.
+			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Quick Load..."), OBJ_MENU_QUICKLOAD);
+			edit_menu->set_item_tooltip(-1, TTR("Opens a quick menu to select from a list of allowed Resource files."));
 
-		// Add an option to load a resource from a file using the regular file dialog.
-		edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Load..."), OBJ_MENU_LOAD);
+			// Add an option to load a resource from a file using the regular file dialog.
+			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Load..."), OBJ_MENU_LOAD);
+		}
 	}
 
 	// Add options for changing existing value of the resource.
-	if (edited_resource.is_valid()) {
+	if (edited_resource.is_valid() && can_load()) {
 		// Determine if the edited resource is part of another scene (foreign) which was imported
 		bool is_edited_resource_foreign_import = EditorNode::get_singleton()->is_resource_read_only(edited_resource, true);
 
@@ -280,7 +282,7 @@ void EditorResourcePicker::_update_menu_items() {
 		}
 	}
 
-	if (edited_resource.is_valid() || paste_valid) {
+	if ((edited_resource.is_valid() || paste_valid) && can_load()) {
 		edit_menu->add_separator();
 
 		if (edited_resource.is_valid()) {
@@ -1006,6 +1008,14 @@ void EditorResourcePicker::set_editable(bool p_editable) {
 
 bool EditorResourcePicker::is_editable() const {
 	return editable;
+}
+
+void EditorResourcePicker::set_can_load(bool p_load) {
+	load = p_load;
+}
+
+bool EditorResourcePicker::can_load() const {
+	return load;
 }
 
 void EditorResourcePicker::_ensure_resource_menu() {

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -47,6 +47,7 @@ class EditorResourcePicker : public HBoxContainer {
 	Ref<Resource> edited_resource;
 
 	bool editable = true;
+	bool load = true;
 	bool dropping = false;
 
 	Vector<String> inheritors_array;
@@ -143,6 +144,9 @@ public:
 
 	void set_editable(bool p_editable);
 	bool is_editable() const;
+
+	void set_can_load(bool p_editable);
+	bool can_load() const;
 
 	virtual void set_create_options(Object *p_menu_node);
 	virtual bool handle_menu_selected(int p_which);

--- a/modules/components/SCsub
+++ b/modules/components/SCsub
@@ -1,0 +1,5 @@
+# SCsub
+
+Import('env')
+
+env.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/components/SCsub
+++ b/modules/components/SCsub
@@ -1,5 +1,6 @@
-# SCsub
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
 
-Import('env')
+Import("env")
 
 env.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/components/component.cpp
+++ b/modules/components/component.cpp
@@ -48,7 +48,71 @@ StringName Component::get_component_class() {
 	return get_class_name();
 }
 
+void Component::enter_tree() {
+	if (GDVIRTUAL_CALL(_enter_tree)) {
+		//
+	}
+}
+
+void Component::exit_tree() {
+	if (GDVIRTUAL_CALL(_exit_tree)) {
+		//
+	}
+}
+
+void Component::ready() {
+	if (GDVIRTUAL_CALL(_ready)) {
+		//
+	}
+}
+
+void Component::process(double delta) {
+	if (GDVIRTUAL_CALL(_process, delta)) {
+		//
+	}
+}
+
+void Component::physics_process(double delta) {
+	if (GDVIRTUAL_CALL(_physics_process, delta)) {
+		//
+	}
+}
+
+void Component::input(const Ref<InputEvent> &p_event) {
+	if (GDVIRTUAL_CALL(_input, p_event)) {
+		//
+	}
+}
+
+void Component::shortcut_input(const Ref<InputEvent> &p_key_event) {
+	if (GDVIRTUAL_CALL(_shortcut_input, p_key_event)) {
+		//
+	}
+}
+
+void Component::unhandled_input(const Ref<InputEvent> &p_event) {
+	if (GDVIRTUAL_CALL(_unhandled_input, p_event)) {
+		//
+	}
+}
+
+void Component::unhandled_key_input(const Ref<InputEvent> &p_key_event) {
+	if (GDVIRTUAL_CALL(_unhandled_key_input, p_key_event)) {
+		//
+	}
+}
 
 void Component::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_component_class"), &Component::get_component_class);
+
+	GDVIRTUAL_BIND(_enter_tree);
+	GDVIRTUAL_BIND(_exit_tree);
+	GDVIRTUAL_BIND(_ready);
+	GDVIRTUAL_BIND(_process, "delta");
+	GDVIRTUAL_BIND(_physics_process, "delta");
+
+	GDVIRTUAL_BIND(_input, "event");
+	GDVIRTUAL_BIND(_shortcut_input, "event");
+	GDVIRTUAL_BIND(_unhandled_input, "event");
+	GDVIRTUAL_BIND(_unhandled_key_input, "event");
 }

--- a/modules/components/component.cpp
+++ b/modules/components/component.cpp
@@ -28,12 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-
 #include "component.h"
 
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
-
 
 StringName Component::get_component_class() {
 	Ref<Script> s = get_script();

--- a/modules/components/component.cpp
+++ b/modules/components/component.cpp
@@ -78,28 +78,64 @@ void Component::physics_process(double delta) {
 	}
 }
 
-void Component::input(const Ref<InputEvent> &p_event) {
-	if (GDVIRTUAL_CALL(_input, p_event)) {
+bool Component::input(const Ref<InputEvent> &p_event) {
+	bool result = false;
+	if (GDVIRTUAL_CALL(_input, p_event, result)) {
 		//
 	}
+
+	return result;
 }
 
-void Component::shortcut_input(const Ref<InputEvent> &p_key_event) {
-	if (GDVIRTUAL_CALL(_shortcut_input, p_key_event)) {
+bool Component::shortcut_input(const Ref<InputEvent> &p_key_event) {
+	bool result = false;
+	if (GDVIRTUAL_CALL(_shortcut_input, p_key_event, result)) {
 		//
 	}
+
+	return result;
 }
 
-void Component::unhandled_input(const Ref<InputEvent> &p_event) {
-	if (GDVIRTUAL_CALL(_unhandled_input, p_event)) {
+bool Component::unhandled_input(const Ref<InputEvent> &p_event) {
+	bool result = false;
+	if (GDVIRTUAL_CALL(_unhandled_input, p_event, result)) {
 		//
 	}
+
+	return result;
 }
 
-void Component::unhandled_key_input(const Ref<InputEvent> &p_key_event) {
-	if (GDVIRTUAL_CALL(_unhandled_key_input, p_key_event)) {
+bool Component::unhandled_key_input(const Ref<InputEvent> &p_key_event) {
+	bool result = false;
+	if (GDVIRTUAL_CALL(_unhandled_key_input, p_key_event, result)) {
 		//
 	}
+
+	return result;
+}
+
+bool Component::is_process_overridden() const {
+	return GDVIRTUAL_IS_OVERRIDDEN(_process);
+}
+
+bool Component::is_physics_process_overridden() const {
+	return GDVIRTUAL_IS_OVERRIDDEN(_physics_process);
+}
+
+bool Component::is_input_overridden() const {
+	return GDVIRTUAL_IS_OVERRIDDEN(_input);
+}
+
+bool Component::is_shortcut_input_overridden() const {
+	return GDVIRTUAL_IS_OVERRIDDEN(_shortcut_input);
+}
+
+bool Component::is_unhandled_input_overridden() const {
+	return GDVIRTUAL_IS_OVERRIDDEN(_unhandled_input);
+}
+
+bool Component::is_unhandled_key_input_overridden() const {
+	return GDVIRTUAL_IS_OVERRIDDEN(_unhandled_key_input);
 }
 
 void Component::_bind_methods() {

--- a/modules/components/component.cpp
+++ b/modules/components/component.cpp
@@ -1,0 +1,9 @@
+//
+// Created by rfish on 4/12/2025.
+//
+
+#include "component.h"
+
+void Component::_bind_methods() {
+	//
+}

--- a/modules/components/component.cpp
+++ b/modules/components/component.cpp
@@ -32,13 +32,19 @@
 #include "component.h"
 
 #include "core/object/class_db.h"
+#include "core/object/script_language.h"
 
 
 StringName Component::get_component_class() {
-	return StringName("Component");
+	Ref<Script> s = get_script();
+	if (s.is_valid()) {
+		return s->get_global_name();
+	}
+
+	return get_class_name();
 }
 
 
 void Component::_bind_methods() {
-	ClassDB::bind_static_method("Component", D_METHOD("get_component_class"), &Component::get_component_class);
+	ClassDB::bind_method(D_METHOD("get_component_class"), &Component::get_component_class);
 }

--- a/modules/components/component.cpp
+++ b/modules/components/component.cpp
@@ -37,8 +37,12 @@
 
 StringName Component::get_component_class() {
 	Ref<Script> s = get_script();
-	if (s.is_valid()) {
-		return s->get_global_name();
+	while (s.is_valid()) {
+		if (!s->get_global_name().is_empty()) {
+			return s->get_global_name();
+		} else {
+			s = s->get_base_script();
+		}
 	}
 
 	return get_class_name();

--- a/modules/components/component.h
+++ b/modules/components/component.h
@@ -36,6 +36,7 @@
 #include "core/object/object.h"
 #include "core/string/string_name.h"
 #include "core/io/resource.h"
+#include "core/input/input_event.h"
 
 
 class Component : public Resource {
@@ -47,9 +48,31 @@ public:
 
 	StringName get_component_class();
 
+	void enter_tree();
+	void exit_tree();
+	void ready();
+	void process(double delta);
+	void physics_process(double delta);
+
+	void input(const Ref<InputEvent> &p_event);
+	void shortcut_input(const Ref<InputEvent> &p_key_event);
+	void unhandled_input(const Ref<InputEvent> &p_event);
+	void unhandled_key_input(const Ref<InputEvent> &p_key_event);
+
 
 protected:
 	static void _bind_methods();
+
+	GDVIRTUAL0(_enter_tree)
+	GDVIRTUAL0(_exit_tree)
+	GDVIRTUAL0(_ready)
+	GDVIRTUAL1(_process, double)
+	GDVIRTUAL1(_physics_process, double)
+
+	GDVIRTUAL1(_input, Ref<InputEvent>)
+	GDVIRTUAL1(_shortcut_input, Ref<InputEvent>)
+	GDVIRTUAL1(_unhandled_input, Ref<InputEvent>)
+	GDVIRTUAL1(_unhandled_key_input, Ref<InputEvent>)
 };
 
 #endif //GODOT_FROM_SOURCE_COMPONENT_H

--- a/modules/components/component.h
+++ b/modules/components/component.h
@@ -45,7 +45,7 @@ class Component : public Resource {
 public:
 	Component() = default;
 
-	static StringName get_component_class();
+	static StringName get_component_class();//TODO:: figure out how to allow gdscript inheritance without warnings
 
 
 protected:

--- a/modules/components/component.h
+++ b/modules/components/component.h
@@ -1,24 +1,55 @@
-//
-// Created by rfish on 4/12/2025.
-//
+/**************************************************************************/
+/*  component.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
 
 #ifndef GODOT_FROM_SOURCE_COMPONENT_H
 #define GODOT_FROM_SOURCE_COMPONENT_H
 
 
 #include "core/object/object.h"
+#include "core/string/string_name.h"
 #include "core/io/resource.h"
 
 
 class Component : public Resource {
 	GDCLASS(Component, Resource);
 
-protected:
-	static void _bind_methods();
-
 
 public:
 	Component() = default;
+
+	static StringName get_component_class();
+
+
+protected:
+	static void _bind_methods();
 };
 
 #endif //GODOT_FROM_SOURCE_COMPONENT_H

--- a/modules/components/component.h
+++ b/modules/components/component.h
@@ -44,6 +44,9 @@ class Component : public Resource {
 
 
 public:
+	Object* owner = nullptr;
+
+public:
 	Component() = default;
 
 	StringName get_component_class();
@@ -54,10 +57,18 @@ public:
 	void process(double delta);
 	void physics_process(double delta);
 
-	void input(const Ref<InputEvent> &p_event);
-	void shortcut_input(const Ref<InputEvent> &p_key_event);
-	void unhandled_input(const Ref<InputEvent> &p_event);
-	void unhandled_key_input(const Ref<InputEvent> &p_key_event);
+	bool input(const Ref<InputEvent> &p_event);
+	bool shortcut_input(const Ref<InputEvent> &p_key_event);
+	bool unhandled_input(const Ref<InputEvent> &p_event);
+	bool unhandled_key_input(const Ref<InputEvent> &p_key_event);
+
+	bool is_process_overridden() const;
+	bool is_physics_process_overridden() const;
+
+	bool is_input_overridden() const;
+	bool is_shortcut_input_overridden() const;
+	bool is_unhandled_input_overridden() const;
+	bool is_unhandled_key_input_overridden() const;
 
 
 protected:
@@ -69,10 +80,10 @@ protected:
 	GDVIRTUAL1(_process, double)
 	GDVIRTUAL1(_physics_process, double)
 
-	GDVIRTUAL1(_input, Ref<InputEvent>)
-	GDVIRTUAL1(_shortcut_input, Ref<InputEvent>)
-	GDVIRTUAL1(_unhandled_input, Ref<InputEvent>)
-	GDVIRTUAL1(_unhandled_key_input, Ref<InputEvent>)
+	GDVIRTUAL1R(bool, _input, Ref<InputEvent>)
+	GDVIRTUAL1R(bool, _shortcut_input, Ref<InputEvent>)
+	GDVIRTUAL1R(bool, _unhandled_input, Ref<InputEvent>)
+	GDVIRTUAL1R(bool, _unhandled_key_input, Ref<InputEvent>)
 };
 
 #endif //GODOT_FROM_SOURCE_COMPONENT_H

--- a/modules/components/component.h
+++ b/modules/components/component.h
@@ -28,23 +28,18 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#pragma once
 
-#ifndef GODOT_FROM_SOURCE_COMPONENT_H
-#define GODOT_FROM_SOURCE_COMPONENT_H
-
-
+#include "core/input/input_event.h"
+#include "core/io/resource.h"
 #include "core/object/object.h"
 #include "core/string/string_name.h"
-#include "core/io/resource.h"
-#include "core/input/input_event.h"
-
 
 class Component : public Resource {
 	GDCLASS(Component, Resource);
 
-
 public:
-	Object* owner = nullptr;
+	Object *owner = nullptr;
 
 public:
 	Component() = default;
@@ -70,7 +65,6 @@ public:
 	bool is_unhandled_input_overridden() const;
 	bool is_unhandled_key_input_overridden() const;
 
-
 protected:
 	static void _bind_methods();
 
@@ -85,5 +79,3 @@ protected:
 	GDVIRTUAL1R(bool, _unhandled_input, Ref<InputEvent>)
 	GDVIRTUAL1R(bool, _unhandled_key_input, Ref<InputEvent>)
 };
-
-#endif //GODOT_FROM_SOURCE_COMPONENT_H

--- a/modules/components/component.h
+++ b/modules/components/component.h
@@ -1,0 +1,24 @@
+//
+// Created by rfish on 4/12/2025.
+//
+
+#ifndef GODOT_FROM_SOURCE_COMPONENT_H
+#define GODOT_FROM_SOURCE_COMPONENT_H
+
+
+#include "core/object/object.h"
+#include "core/io/resource.h"
+
+
+class Component : public Resource {
+	GDCLASS(Component, Resource);
+
+protected:
+	static void _bind_methods();
+
+
+public:
+	Component() = default;
+};
+
+#endif //GODOT_FROM_SOURCE_COMPONENT_H

--- a/modules/components/component.h
+++ b/modules/components/component.h
@@ -45,7 +45,7 @@ class Component : public Resource {
 public:
 	Component() = default;
 
-	static StringName get_component_class();//TODO:: figure out how to allow gdscript inheritance without warnings
+	StringName get_component_class();
 
 
 protected:

--- a/modules/components/config.py
+++ b/modules/components/config.py
@@ -1,0 +1,7 @@
+# config.py
+
+def can_build(env, platform):
+    return True
+
+def configure(env):
+    pass

--- a/modules/components/register_types.cpp
+++ b/modules/components/register_types.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  components/register_types.cpp                                         */
+/*  register_types.cpp                                                    */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,12 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-
 #include "register_types.h"
 
-#include "core/object/class_db.h"
 #include "component.h"
-
+#include "core/object/class_db.h"
 
 void initialize_components_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
@@ -42,7 +40,6 @@ void initialize_components_module(ModuleInitializationLevel p_level) {
 
 	ClassDB::register_class<Component>();
 }
-
 
 void uninitialize_components_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {

--- a/modules/components/register_types.cpp
+++ b/modules/components/register_types.cpp
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  components/register_types.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+
+#include "register_types.h"
+
+#include "core/object/class_db.h"
+#include "component.h"
+
+
+void initialize_components_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+
+	ClassDB::register_class<Component>();
+}
+
+
+void uninitialize_components_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+}

--- a/modules/components/register_types.h
+++ b/modules/components/register_types.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  components/register_types.h                                           */
+/*  register_types.h                                                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,15 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-
-#ifndef COMPONENTS_REGISTER_TYPES_H
-#define COMPONENTS_REGISTER_TYPES_H
+#pragma once
 
 #include "modules/register_module_types.h"
 
-
 void initialize_components_module(ModuleInitializationLevel p_level);
 void uninitialize_components_module(ModuleInitializationLevel p_level);
-
-
-#endif //COMPONENTS_REGISTER_TYPES_H

--- a/modules/components/register_types.h
+++ b/modules/components/register_types.h
@@ -1,0 +1,42 @@
+/**************************************************************************/
+/*  components/register_types.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+
+#ifndef COMPONENTS_REGISTER_TYPES_H
+#define COMPONENTS_REGISTER_TYPES_H
+
+#include "modules/register_module_types.h"
+
+
+void initialize_components_module(ModuleInitializationLevel p_level);
+void uninitialize_components_module(ModuleInitializationLevel p_level);
+
+
+#endif //COMPONENTS_REGISTER_TYPES_H

--- a/scene/main/actor.cpp
+++ b/scene/main/actor.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  component.cpp                                                         */
+/*  actor.cpp                                                             */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -29,16 +29,55 @@
 /**************************************************************************/
 
 
-#include "component.h"
+#include "actor.h"
 
 #include "core/object/class_db.h"
+#include "core/variant/variant.h"
 
 
-StringName Component::get_component_class() {
-	return StringName("Component");
+bool Actor::has_component(StringName component_class) const {
+	return _component_resources.has(component_class);
 }
 
 
-void Component::_bind_methods() {
-	ClassDB::bind_static_method("Component", D_METHOD("get_component_class"), &Component::get_component_class);
+Ref<Component> Actor::get_component(StringName component_class) {
+	Ref<Component> result;
+
+	return result;
+}
+
+
+bool Actor::set_component(Ref<Component> value) {
+	bool result = false;
+
+	return result;
+}
+
+
+bool Actor::remove_component(StringName component_class) {
+	bool result = false;
+
+	return result;
+}
+
+
+void Actor::get_component_list(List<Ref<Component>> *out) {
+	//
+}
+
+
+void Actor::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("has_component", "component_class"), &Actor::has_component);
+	ClassDB::bind_method(D_METHOD("get_component", "component_class"), &Actor::get_component);
+	ClassDB::bind_method(D_METHOD("set_component", "value"), &Actor::set_component);
+	ClassDB::bind_method(D_METHOD("remove_component", "component_class"), &Actor::remove_component);
+//	ClassDB::bind_method(D_METHOD("get_component_list", "out"), &Actor::_get_component_list_bind);
+}
+
+
+void Actor::_get_property_list(List<PropertyInfo> *out) const {
+	for (const KeyValue<StringName, Ref<Component>> &k_v: _component_resources) {
+		PropertyInfo property_info = PropertyInfo(Variant::OBJECT, "components/" + k_v.key.operator String(), PROPERTY_HINT_RESOURCE_TYPE, "Component");
+		out->push_back(property_info);
+	}
 }

--- a/scene/main/actor.cpp
+++ b/scene/main/actor.cpp
@@ -32,6 +32,7 @@
 #include "actor.h"
 
 #include "core/object/class_db.h"
+#include "core/object/script_language.h"
 #include "core/string/ustring.h"
 #include "core/variant/variant.h"
 
@@ -97,7 +98,7 @@ void Actor::_bind_methods() {
 
 void Actor::_get_property_list(List<PropertyInfo> *out) const {
 	for (const KeyValue<StringName, Ref<Component>> &k_v: _component_resources) {
-		PropertyInfo property_info = PropertyInfo(Variant::OBJECT, "components/" + k_v.key.operator String(), PROPERTY_HINT_RESOURCE_TYPE, "Component");
+		PropertyInfo property_info = PropertyInfo(Variant::OBJECT, "components/" + k_v.key.operator String(), PROPERTY_HINT_RESOURCE_TYPE, "Component", PropertyUsageFlags::PROPERTY_USAGE_DEFAULT | PropertyUsageFlags::PROPERTY_USAGE_READ_ONLY);
 		out->push_back(property_info);
 	}
 }

--- a/scene/main/actor.cpp
+++ b/scene/main/actor.cpp
@@ -28,7 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-
 #include "actor.h"
 
 #include "core/object/class_db.h"
@@ -36,11 +35,9 @@
 #include "core/string/ustring.h"
 #include "core/variant/variant.h"
 
-
 bool Actor::has_component(StringName component_class) const {
 	return _component_resources.has(component_class);
 }
-
 
 Ref<Component> Actor::get_component(StringName component_class) const {
 	if (!has_component(component_class)) {
@@ -53,7 +50,6 @@ Ref<Component> Actor::get_component(StringName component_class) const {
 
 	return result;
 }
-
 
 void Actor::set_component(Ref<Component> value) {
 	ERR_FAIL_COND_MSG(value->owner != nullptr, vformat("This component already has owner. Remove it first."));
@@ -89,7 +85,6 @@ void Actor::set_component(Ref<Component> value) {
 	notify_property_list_changed();
 }
 
-
 void Actor::remove_component(StringName component_class) {
 	Ref<Component> value = _component_resources.get(component_class);
 	if (value.is_valid()) {
@@ -107,20 +102,17 @@ void Actor::remove_component(StringName component_class) {
 	}
 }
 
-
 void Actor::get_component_list(List<Ref<Component>> *out) const {
 	for (const KeyValue<StringName, Ref<Component>> &K : _component_resources) {
 		out->push_back(K.value);
 	}
 }
 
-
 void Actor::get_component_class_list(List<StringName> *out) const {
 	for (const KeyValue<StringName, Ref<Component>> &K : _component_resources) {
 		out->push_back(K.key);
 	}
 }
-
 
 void Actor::call_components_enter_tree() {
 	for (const KeyValue<StringName, Ref<Component>> &K : _component_resources) {
@@ -142,13 +134,13 @@ void Actor::call_components_ready() {
 
 void Actor::call_components_process(double delta) {
 	for (const Ref<Component> &K : _process_group) {
-		K->process(delta);//NOTE:: this ideally should call Node::get_process_delta_time()
+		K->process(delta); //NOTE:: this ideally should call Node::get_process_delta_time()
 	}
 }
 
 void Actor::call_components_physics_process(double delta) {
 	for (const Ref<Component> &K : _physics_process_group) {
-		K->physics_process(delta);//NOTE:: this ideally should call Node::get_physics_process_delta_time()
+		K->physics_process(delta); //NOTE:: this ideally should call Node::get_physics_process_delta_time()
 	}
 }
 
@@ -199,14 +191,12 @@ void Actor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_component", "component_class"), &Actor::remove_component);
 }
 
-
 void Actor::_get_property_list(List<PropertyInfo> *out) const {
-	for (const KeyValue<StringName, Ref<Component>> &k_v: _component_resources) {
+	for (const KeyValue<StringName, Ref<Component>> &k_v : _component_resources) {
 		PropertyInfo property_info = PropertyInfo(Variant::OBJECT, "components/" + k_v.key.operator String(), PROPERTY_HINT_RESOURCE_TYPE, "Component", PropertyUsageFlags::PROPERTY_USAGE_DEFAULT | PropertyUsageFlags::PROPERTY_USAGE_READ_ONLY);
 		out->push_back(property_info);
 	}
 }
-
 
 bool Actor::_get(const StringName &p_property, Variant &r_value) const {
 	bool result = false;
@@ -225,7 +215,6 @@ bool Actor::_get(const StringName &p_property, Variant &r_value) const {
 
 	return result;
 }
-
 
 bool Actor::_set(const StringName &p_property, const Variant &p_value) {
 	bool result = false;

--- a/scene/main/actor.cpp
+++ b/scene/main/actor.cpp
@@ -55,9 +55,10 @@ Ref<Component> Actor::get_component(StringName component_class) const {
 
 
 void Actor::set_component(Ref<Component> value) {
-	ERR_FAIL_COND_MSG(!value.is_valid(), vformat("Can't set a component to a null value."));
+	ERR_FAIL_COND_MSG(!value.is_valid(), vformat("Can't add a null component."));
 
 	_component_resources[value->get_component_class()] = value;
+	print_line("Success setting component: ", value->get_component_class());
 
 	notify_property_list_changed();
 }
@@ -71,8 +72,17 @@ void Actor::remove_component(StringName component_class) {
 }
 
 
-void Actor::get_component_list(List<Ref<Component>> *out) {
-	//
+void Actor::get_component_list(List<Ref<Component>> *out) const {
+	for (const KeyValue<StringName, Ref<Component>> &K : _component_resources) {
+		out->push_back(K.value);
+	}
+}
+
+
+void Actor::get_component_class_list(List<StringName> *out) const {
+	for (const KeyValue<StringName, Ref<Component>> &K : _component_resources) {
+		out->push_back(K.key);
+	}
 }
 
 
@@ -87,7 +97,7 @@ void Actor::_bind_methods() {
 
 void Actor::_get_property_list(List<PropertyInfo> *out) const {
 	for (const KeyValue<StringName, Ref<Component>> &k_v: _component_resources) {
-		PropertyInfo property_info = PropertyInfo(Variant::OBJECT, "components/", PROPERTY_HINT_RESOURCE_TYPE, "Component");
+		PropertyInfo property_info = PropertyInfo(Variant::OBJECT, "components/" + k_v.key.operator String(), PROPERTY_HINT_RESOURCE_TYPE, "Component");
 		out->push_back(property_info);
 	}
 }

--- a/scene/main/actor.cpp
+++ b/scene/main/actor.cpp
@@ -86,8 +86,6 @@ void Actor::set_component(Ref<Component> value) {
 		(void)_unhandled_key_input_group.insert(value);
 	}
 
-	print_line("Success setting component: ", value->get_component_class());
-
 	notify_property_list_changed();
 }
 
@@ -144,13 +142,13 @@ void Actor::call_components_ready() {
 
 void Actor::call_components_process(double delta) {
 	for (const Ref<Component> &K : _process_group) {
-		K->process(delta);//TODO:: this ideally should call Node::get_process_delta_time()
+		K->process(delta);//NOTE:: this ideally should call Node::get_process_delta_time()
 	}
 }
 
 void Actor::call_components_physics_process(double delta) {
 	for (const Ref<Component> &K : _physics_process_group) {
-		K->physics_process(delta);//TODO:: this ideally should call Node::get_physics_process_delta_time()
+		K->physics_process(delta);//NOTE:: this ideally should call Node::get_physics_process_delta_time()
 	}
 }
 

--- a/scene/main/actor.cpp
+++ b/scene/main/actor.cpp
@@ -221,6 +221,10 @@ bool Actor::_set(const StringName &p_property, const Variant &p_value) {
 }
 
 bool Actor::_remove_component(StringName component_class) {
+	if (!_component_resources.has(component_class)) {
+		return false;
+	}
+
 	bool result = false;
 	Ref<Component> value = _component_resources.get(component_class);
 	if (value.is_valid()) {

--- a/scene/main/actor.cpp
+++ b/scene/main/actor.cpp
@@ -59,7 +59,7 @@ void Actor::set_component(Ref<Component> value) {
 	ERR_FAIL_COND_MSG(!value.is_valid(), vformat("Can't add a null component."));
 
 	_component_resources[value->get_component_class()] = value;
-	print_line("Success setting component: ", value->get_component_class());
+//	print_line("Success setting component: ", value->get_component_class());
 
 	notify_property_list_changed();
 }
@@ -92,7 +92,6 @@ void Actor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_component", "component_class"), &Actor::get_component);
 	ClassDB::bind_method(D_METHOD("set_component", "value"), &Actor::set_component);
 	ClassDB::bind_method(D_METHOD("remove_component", "component_class"), &Actor::remove_component);
-//	ClassDB::bind_method(D_METHOD("get_component_list", "out"), &Actor::_get_component_list_bind);
 }
 
 

--- a/scene/main/actor.cpp
+++ b/scene/main/actor.cpp
@@ -59,7 +59,7 @@ void Actor::set_component(Ref<Component> value) {
 	ERR_FAIL_COND_MSG(!value.is_valid(), vformat("Can't add a null component."));
 
 	_component_resources[value->get_component_class()] = value;
-//	print_line("Success setting component: ", value->get_component_class());
+	print_line("Success setting component: ", value->get_component_class());
 
 	notify_property_list_changed();
 }

--- a/scene/main/actor.h
+++ b/scene/main/actor.h
@@ -28,21 +28,17 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-
 #pragma once
 
-
 #include "core/object/object.h"
+#include "core/string/string_name.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/hash_set.h"
 #include "core/templates/list.h"
-#include "core/string/string_name.h"
 #include "modules/components/component.h"
-
 
 class Actor : public Object {
 	GDCLASS(Actor, Object);
-
 
 protected:
 	HashMap<StringName, Ref<Component>> _component_resources;
@@ -52,7 +48,6 @@ protected:
 	HashSet<Ref<Component>> _shortcut_input_group;
 	HashSet<Ref<Component>> _unhandled_input_group;
 	HashSet<Ref<Component>> _unhandled_key_input_group;
-
 
 public:
 	Actor() = default;
@@ -65,7 +60,6 @@ public:
 	void get_component_list(List<Ref<Component>> *out) const;
 	void get_component_class_list(List<StringName> *out) const;
 
-
 	void call_components_enter_tree();
 	void call_components_exit_tree();
 	void call_components_ready();
@@ -76,7 +70,6 @@ public:
 	bool call_components_shortcut_input(const Ref<InputEvent> &p_key_event);
 	bool call_components_unhandled_input(const Ref<InputEvent> &p_event);
 	bool call_components_unhandled_key_input(const Ref<InputEvent> &p_key_event);
-
 
 protected:
 	static void _bind_methods();

--- a/scene/main/actor.h
+++ b/scene/main/actor.h
@@ -34,6 +34,7 @@
 
 #include "core/object/object.h"
 #include "core/templates/hash_map.h"
+#include "core/templates/hash_set.h"
 #include "core/templates/list.h"
 #include "core/string/string_name.h"
 #include "modules/components/component.h"
@@ -45,6 +46,12 @@ class Actor : public Object {
 
 protected:
 	HashMap<StringName, Ref<Component>> _component_resources;
+	HashSet<Ref<Component>> _process_group;
+	HashSet<Ref<Component>> _physics_process_group;
+	HashSet<Ref<Component>> _input_group;
+	HashSet<Ref<Component>> _shortcut_input_group;
+	HashSet<Ref<Component>> _unhandled_input_group;
+	HashSet<Ref<Component>> _unhandled_key_input_group;
 
 
 public:
@@ -53,10 +60,22 @@ public:
 
 	bool has_component(StringName component_class) const;
 	Ref<Component> get_component(StringName component_class) const;
-	void set_component(Ref<Component> value);
-	void remove_component(StringName component_class);
+	virtual void set_component(Ref<Component> value);
+	virtual void remove_component(StringName component_class);
 	void get_component_list(List<Ref<Component>> *out) const;
 	void get_component_class_list(List<StringName> *out) const;
+
+
+	void call_components_enter_tree();
+	void call_components_exit_tree();
+	void call_components_ready();
+	void call_components_process(double delta);
+	void call_components_physics_process(double delta);
+
+	bool call_components_input(const Ref<InputEvent> &p_event);
+	bool call_components_shortcut_input(const Ref<InputEvent> &p_key_event);
+	bool call_components_unhandled_input(const Ref<InputEvent> &p_event);
+	bool call_components_unhandled_key_input(const Ref<InputEvent> &p_key_event);
 
 
 protected:

--- a/scene/main/actor.h
+++ b/scene/main/actor.h
@@ -44,9 +44,7 @@ class Actor : public Object {
 
 
 protected:
-	HashMap<StringName, Ref<Component>> _component_resources {
-		{Component::get_component_class(), memnew(Component)}
-	};
+	HashMap<StringName, Ref<Component>> _component_resources;
 
 
 public:
@@ -54,13 +52,15 @@ public:
 	virtual ~Actor() = default;
 
 	bool has_component(StringName component_class) const;
-	Ref<Component> get_component(StringName component_class);
-	bool set_component(Ref<Component> value);
-	bool remove_component(StringName component_class);
+	Ref<Component> get_component(StringName component_class) const;
+	void set_component(Ref<Component> value);
+	void remove_component(StringName component_class);
 	void get_component_list(List<Ref<Component>> *out);
 
 
 protected:
 	static void _bind_methods();
 	void _get_property_list(List<PropertyInfo> *out) const;
+	bool _get(const StringName &p_property, Variant &r_value) const;
+	bool _set(const StringName &p_property, const Variant &p_value);
 };

--- a/scene/main/actor.h
+++ b/scene/main/actor.h
@@ -55,7 +55,8 @@ public:
 	Ref<Component> get_component(StringName component_class) const;
 	void set_component(Ref<Component> value);
 	void remove_component(StringName component_class);
-	void get_component_list(List<Ref<Component>> *out);
+	void get_component_list(List<Ref<Component>> *out) const;
+	void get_component_class_list(List<StringName> *out) const;
 
 
 protected:

--- a/scene/main/actor.h
+++ b/scene/main/actor.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  component.cpp                                                         */
+/*  actor.h                                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -29,16 +29,38 @@
 /**************************************************************************/
 
 
-#include "component.h"
-
-#include "core/object/class_db.h"
+#pragma once
 
 
-StringName Component::get_component_class() {
-	return StringName("Component");
-}
+#include "core/object/object.h"
+#include "core/templates/hash_map.h"
+#include "core/templates/list.h"
+#include "core/string/string_name.h"
+#include "modules/components/component.h"
 
 
-void Component::_bind_methods() {
-	ClassDB::bind_static_method("Component", D_METHOD("get_component_class"), &Component::get_component_class);
-}
+class Actor : public Object {
+	GDCLASS(Actor, Object);
+
+
+protected:
+	HashMap<StringName, Ref<Component>> _component_resources {
+		{Component::get_component_class(), memnew(Component)}
+	};
+
+
+public:
+	Actor() = default;
+	virtual ~Actor() = default;
+
+	bool has_component(StringName component_class) const;
+	Ref<Component> get_component(StringName component_class);
+	bool set_component(Ref<Component> value);
+	bool remove_component(StringName component_class);
+	void get_component_list(List<Ref<Component>> *out);
+
+
+protected:
+	static void _bind_methods();
+	void _get_property_list(List<PropertyInfo> *out) const;
+};

--- a/scene/main/actor.h
+++ b/scene/main/actor.h
@@ -76,4 +76,6 @@ protected:
 	void _get_property_list(List<PropertyInfo> *out) const;
 	bool _get(const StringName &p_property, Variant &r_value) const;
 	bool _set(const StringName &p_property, const Variant &p_value);
+
+	bool _remove_component(StringName component_class);
 };

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3917,8 +3917,8 @@ void Node::_bind_methods() {
 	ClassDB::bind_static_method("Node", D_METHOD("print_orphan_nodes"), &Node::print_orphan_nodes);
 	ClassDB::bind_method(D_METHOD("add_sibling", "sibling", "force_readable_name"), &Node::add_sibling, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("set_component", "value"), &Node::set_component);
-	ClassDB::bind_method(D_METHOD("remove_component", "component_class"), &Node::remove_component);
+//	ClassDB::bind_method(D_METHOD("set_component", "value"), &Node::set_component);
+//	ClassDB::bind_method(D_METHOD("remove_component", "component_class"), &Node::remove_component);
 
 	ClassDB::bind_method(D_METHOD("set_name", "name"), &Node::set_name);
 	ClassDB::bind_method(D_METHOD("get_name"), &Node::get_name);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -47,6 +47,9 @@ int Node::orphan_node_count = 0;
 
 thread_local Node *Node::current_process_thread_group = nullptr;
 
+void get_component_list(List<StringName> *out) const {
+	//
+}
 
 Ref<Resource> Node::get_my_resource() const {
 	return data.my_resource;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3917,9 +3917,6 @@ void Node::_bind_methods() {
 	ClassDB::bind_static_method("Node", D_METHOD("print_orphan_nodes"), &Node::print_orphan_nodes);
 	ClassDB::bind_method(D_METHOD("add_sibling", "sibling", "force_readable_name"), &Node::add_sibling, DEFVAL(false));
 
-//	ClassDB::bind_method(D_METHOD("set_component", "value"), &Node::set_component);
-//	ClassDB::bind_method(D_METHOD("remove_component", "component_class"), &Node::remove_component);
-
 	ClassDB::bind_method(D_METHOD("set_name", "name"), &Node::set_name);
 	ClassDB::bind_method(D_METHOD("get_name"), &Node::get_name);
 	ClassDB::bind_method(D_METHOD("add_child", "node", "force_readable_name", "internal"), &Node::add_child, DEFVAL(false), DEFVAL(0));

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -47,6 +47,16 @@ int Node::orphan_node_count = 0;
 
 thread_local Node *Node::current_process_thread_group = nullptr;
 
+
+Ref<Resource> Node::get_my_resource() const {
+	return data.my_resource;
+}
+
+void Node::set_my_resource(Ref<Resource> value) {
+	data.my_resource = value;
+}
+
+
 void Node::_notification(int p_notification) {
 	switch (p_notification) {
 		case NOTIFICATION_ACCESSIBILITY_INVALIDATE: {
@@ -3952,6 +3962,9 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("rpc_config", "method", "config"), &Node::rpc_config);
 	ClassDB::bind_method(D_METHOD("get_rpc_config"), &Node::get_rpc_config);
 
+	ClassDB::bind_method(D_METHOD("set_my_resource", "value"), &Node::set_my_resource);
+	ClassDB::bind_method(D_METHOD("get_my_resource"), &Node::get_my_resource);
+
 	ClassDB::bind_method(D_METHOD("set_editor_description", "editor_description"), &Node::set_editor_description);
 	ClassDB::bind_method(D_METHOD("get_editor_description"), &Node::get_editor_description);
 
@@ -4126,6 +4139,9 @@ void Node::_bind_methods() {
 
 	ADD_GROUP("Auto Translate", "auto_translate_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "auto_translate_mode", PROPERTY_HINT_ENUM, "Inherit,Always,Disabled"), "set_auto_translate_mode", "get_auto_translate_mode");
+
+	ADD_GROUP("My Resource", "my_");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "my_resource"), "set_my_resource", "get_my_resource");
 
 	ADD_GROUP("Editor Description", "editor_");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT), "set_editor_description", "get_editor_description");

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -47,19 +47,6 @@ int Node::orphan_node_count = 0;
 
 thread_local Node *Node::current_process_thread_group = nullptr;
 
-void get_component_list(List<StringName> *out) const {
-	//
-}
-
-Ref<Resource> Node::get_my_resource() const {
-	return data.my_resource;
-}
-
-void Node::set_my_resource(Ref<Resource> value) {
-	data.my_resource = value;
-}
-
-
 void Node::_notification(int p_notification) {
 	switch (p_notification) {
 		case NOTIFICATION_ACCESSIBILITY_INVALIDATE: {
@@ -3965,9 +3952,6 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("rpc_config", "method", "config"), &Node::rpc_config);
 	ClassDB::bind_method(D_METHOD("get_rpc_config"), &Node::get_rpc_config);
 
-	ClassDB::bind_method(D_METHOD("set_my_resource", "value"), &Node::set_my_resource);
-	ClassDB::bind_method(D_METHOD("get_my_resource"), &Node::get_my_resource);
-
 	ClassDB::bind_method(D_METHOD("set_editor_description", "editor_description"), &Node::set_editor_description);
 	ClassDB::bind_method(D_METHOD("get_editor_description"), &Node::get_editor_description);
 
@@ -4142,9 +4126,6 @@ void Node::_bind_methods() {
 
 	ADD_GROUP("Auto Translate", "auto_translate_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "auto_translate_mode", PROPERTY_HINT_ENUM, "Inherit,Always,Disabled"), "set_auto_translate_mode", "get_auto_translate_mode");
-
-	ADD_GROUP("My Resource", "my_");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "my_resource"), "set_my_resource", "get_my_resource");
 
 	ADD_GROUP("Editor Description", "editor_");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT), "set_editor_description", "get_editor_description");

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -35,6 +35,8 @@
 #include "scene/main/scene_tree.h"
 #include "scene/scene_string_names.h"
 #include "core/io/resource.h"
+#include "core/templates/hash_set.h"
+#include "scene/main/actor.h"
 
 class Viewport;
 class Window;
@@ -45,8 +47,8 @@ class PropertyTweener;
 SAFE_FLAG_TYPE_PUN_GUARANTEES
 SAFE_NUMERIC_TYPE_PUN_GUARANTEES(uint32_t)
 
-class Node : public Object {
-	GDCLASS(Node, Object);
+class Node : public Actor {
+	GDCLASS(Node, Actor);
 
 protected:
 	// During group processing, these are thread-safe.
@@ -273,10 +275,12 @@ private:
 
 	Ref<MultiplayerAPI> multiplayer;
 
+public:
 	void get_component_list(List<StringName> *out) const;
 	Ref<Resource> get_my_resource() const;
 	void set_my_resource(Ref<Resource> value);
 
+private:
 	String _get_tree_string_pretty(const String &p_prefix, bool p_last);
 	String _get_tree_string(const Node *p_node);
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -30,13 +30,13 @@
 
 #pragma once
 
+#include "core/io/resource.h"
 #include "core/string/node_path.h"
+#include "core/templates/hash_set.h"
 #include "core/variant/typed_array.h"
+#include "scene/main/actor.h"
 #include "scene/main/scene_tree.h"
 #include "scene/scene_string_names.h"
-#include "core/io/resource.h"
-#include "core/templates/hash_set.h"
-#include "scene/main/actor.h"
 
 class Viewport;
 class Window;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -273,6 +273,7 @@ private:
 
 	Ref<MultiplayerAPI> multiplayer;
 
+	void get_component_list(List<StringName> *out) const;
 	Ref<Resource> get_my_resource() const;
 	void set_my_resource(Ref<Resource> value);
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -186,7 +186,6 @@ private:
 		NodePath import_path; // Path used when imported, used by scene editors to keep tracking.
 #endif
 		String editor_description;
-		Ref<Resource> my_resource;
 
 		Viewport *viewport = nullptr;
 
@@ -274,11 +273,6 @@ private:
 	} data;
 
 	Ref<MultiplayerAPI> multiplayer;
-
-public:
-	void get_component_list(List<StringName> *out) const;
-	Ref<Resource> get_my_resource() const;
-	void set_my_resource(Ref<Resource> value);
 
 private:
 	String _get_tree_string_pretty(const String &p_prefix, bool p_last);
@@ -478,6 +472,11 @@ public:
 		NOTIFICATION_SUSPENDED = 9003,
 		NOTIFICATION_UNSUSPENDED = 9004
 	};
+
+	/* ACTOR/COMPONENT */
+
+	void set_component(Ref<Component> value) override;
+	void remove_component(StringName component_class) override;
 
 	/* NODE/TREE */
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -34,6 +34,7 @@
 #include "core/variant/typed_array.h"
 #include "scene/main/scene_tree.h"
 #include "scene/scene_string_names.h"
+#include "core/io/resource.h"
 
 class Viewport;
 class Window;
@@ -183,6 +184,7 @@ private:
 		NodePath import_path; // Path used when imported, used by scene editors to keep tracking.
 #endif
 		String editor_description;
+		Ref<Resource> my_resource;
 
 		Viewport *viewport = nullptr;
 
@@ -270,6 +272,9 @@ private:
 	} data;
 
 	Ref<MultiplayerAPI> multiplayer;
+
+	Ref<Resource> get_my_resource() const;
+	void set_my_resource(Ref<Resource> value);
 
 	String _get_tree_string_pretty(const String &p_prefix, bool p_last);
 	String _get_tree_string(const Node *p_node);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -93,6 +93,7 @@
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
 #include "scene/gui/video_stream_player.h"
+#include "scene/main/actor.h"
 #include "scene/main/canvas_item.h"
 #include "scene/main/canvas_layer.h"
 #include "scene/main/http_request.h"
@@ -400,6 +401,8 @@ void register_scene_types() {
 	OS::get_singleton()->yield(); // may take time to init
 
 	GDREGISTER_CLASS(Object);
+
+	GDREGISTER_CLASS(Actor);
 
 	GDREGISTER_CLASS(Node);
 	GDREGISTER_VIRTUAL_CLASS(MissingNode);


### PR DESCRIPTION
- _Production Edit: Closes_ https://github.com/godotengine/godot-proposals/issues/12306

This PR adds components to Node. The implementation is simple for now but there are options to tweak if desired.

Use case:
- It has been a topic of discussion to allow Nodes to inherit or implement >1 "classes" of functionality (e.g. traits, interfaces, multiple inheritance). (See links below.) This solves many cases where this type of modularity is needed/useful by adding Components to all Node types similar to Entity-Component engines (Unreal, Flax, etc.).
- Child Nodes can be used, however, there are limitations to how instanced child scenes can be managed in the inspector. Having the components directly attached to the scene's root Node allows for easy tweaking and access at design time in the inspector and at runtime. There is also a performance concern when using deeply nested Nodes with partial implementations, as the official docs also indicate it is more performant to implement more functionality in a single Node's script rather than separate them across several Nodes' script throughout the hierarchy.

Usage:
- An "Add Component" button was added to the inspector:
![image](https://github.com/user-attachments/assets/c02d6dcd-66e5-4419-8ae8-dedbac64f2a0)
- A dialog gives a drop-down of all Component types available (duplicates are not allowed). An 'X' allows user to remove a component just like metadata:
![image](https://github.com/user-attachments/assets/0317e72c-3477-435b-abd2-d569610dad97)
- User can manage the Component's \@export'ed properties as usual:
![image](https://github.com/user-attachments/assets/635ff16f-19ae-4a5e-8d79-7c601c694b22)
- Scripts can manage components too. Note for now, a Component must belong to only 1 Node:
![image](https://github.com/user-attachments/assets/696063d3-7bd4-4bbd-81e7-ad64c76db75b)
- GDExtension and GDScripts, of course, can override the necessary Node notification callbacks:
![image](https://github.com/user-attachments/assets/314f4824-61cd-4731-aeec-bcaab8a79ee8)


Implementation overview:
- An Actor class extends Object. Node extends Actor. Actor handles most of the component-related details. components are stored in a HashMap similar to Object::metadata. Duplicates of the same Component type are not allowed; the keys use the most derived global_class_name of the Component's script or the class_name of the C++ class.
- Node manages the Node/SceneTree-specific notifications for its components (\_process(), \_input(), etc.). Node also sets set_processing_...(bool) accordingly to allow the components' callbacks to execute if overridden. This means that, for example, set_processing_input(true) will be true if >= 1 attached component overrides _input(event), and the Node's script (if one is attached) doesn't necessarily override _input(event).
- Component extends Resource to allow serialization of properties and for using \@export annotation.

Some initial considerations:
- Currently, HashSets hold each Component based on the notifications they handle (e.g., if they override \_process(), etc.). This allows for O(1) add/erase but doesn't guarantee any execution order of the overridden function. This means if 2 Components both handle the same input action, it is unknown which Component would mark it as handled on the viewport.

https://github.com/godotengine/godot-proposals/issues/4872

https://github.com/godotengine/godot-proposals/issues/6416

[Edit] Changed title as I realized these are not script components as they don't need scripts (as defined in Godot) to implement their functionality - they can be built-in or native types instead.
