### PR TITLE
Implement dithering option for Gradient resources

### DIFF
--- a/doc/classes/Gradient.xml
+++ b/doc/classes/Gradient.xml
@@ -32,6 +32,18 @@
 				Returns the offset of the gradient color at index [param point].
 			</description>
 		</method>
+		<method name="get_dithering">
+			<return type="bool" />
+			<description>
+				Returns whether or not dithering is used to generate the gradient.
+			</description>
+		</method>
+		<method name="get_dithering_noise_granularity">
+			<return type="float" />
+			<description>
+				Returns the strength of the dithering noise.
+			</description>
+		</method>
 		<method name="get_point_count" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -75,6 +87,20 @@
 				Sets the offset for the gradient color at index [param point].
 			</description>
 		</method>
+		<method name="set_dithering">
+			<return type="void" />
+			<param index="0" name="dithering" type="bool" />
+			<description>
+				Sets whether or not the texture enables dithering.
+			</description>
+		</method>
+		<method name="set_dithering_noise_granularity">
+			<return type="void" />
+			<param index="0" name="dithering_noise_granularity" type="float" />
+			<description>
+				Sets the strength of the dithering.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="colors" type="PackedColorArray" setter="set_colors" getter="get_colors" default="PackedColorArray(0, 0, 0, 1, 1, 1, 1, 1)">
@@ -87,6 +113,12 @@
 		</member>
 		<member name="interpolation_mode" type="int" setter="set_interpolation_mode" getter="get_interpolation_mode" enum="Gradient.InterpolationMode" default="0">
 			The algorithm used to interpolate between points of the gradient. See [enum InterpolationMode] for available modes.
+		</member>
+		<member name="dithering" type="bool" setter="set_dithering" getter="get_dithering" default="false">
+			If [code]true[/code], the generated texture will apply dithering on the texture. If [code]false[/code], the generated texture will use the default interpolation method.
+		</member>
+		<member name="dithering_noise_granularity" type="float" setter="set_dithering_noise_granularity" getter="get_dithering_noise_granularity" default="0.5">
+			Coefficient applied on the dithering if enabled. The higher it is, the stronger the dithering will be.
 		</member>
 		<member name="offsets" type="PackedFloat32Array" setter="set_offsets" getter="get_offsets" default="PackedFloat32Array(0, 1)">
 			Gradient's offsets as a [PackedFloat32Array].


### PR DESCRIPTION
Implementation based on this tutorial: https://shader-tutorial.dev/advanced/color-banding-dithering/

I implemented this as an option: the users will be able to disable it if they want and tweak the dithering intensity.

### Why didn't I implement this as a plugin?

My first thought was that it could be an extension of the `Gradient` class. However, I needed to make changes to the `get_color_at_offset` of the `Gradient` class by either overriding it in a child class or changing it's implementation directly.
Since the method isn't virtual, creating a child class wasn't an option, excluding the possibility of implementing the dithering effect in a plugin.

- _Bugsquad edit: closes https://github.com/godotengine/godot-proposals/issues/12295_