### PR TITLE
[Web] Add `memory64` option to setup the foundations of wasm64

### DIFF
--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -73,6 +73,8 @@ public:
 	// Override return type to make writing static callbacks less tedious.
 	static OS_Web *get_singleton();
 
+	_FORCE_INLINE_ bool is_memory64() const { return sizeof(size_t) == sizeof(uint64_t); }
+
 	bool pwa_needs_update() const { return pwa_is_waiting; }
 	Error pwa_update();
 	void force_fs_sync();


### PR DESCRIPTION
Even if [wasm64 is not the silver bullet](https://spidermonkey.dev/blog/2025/01/15/is-memory64-actually-worth-using.html), [browsers begin to support it](https://webassembly.org/features/#table-row-memory64), so we may as well begin work to officially support builds.

The new `memory64` option has 3 values (and some aliases).
- `wasm32` (default, aliases: `0`, `no`)
- `wasm64` (aliases: `1`, `yes`)
- `wasm32+64bitptrs` (aliases: `2`)

`0`, `1`, and `2` aliases correspond to [`-sMEMORY64` values for Emscripten](https://emscripten.org/docs/tools_reference/settings_reference.html#memory64). (see that link for the `wasm32+64bitptrs` option explanation)

~~For `wasm64` and `wasm32+64bitptrs`, the `WASM_MEMORY64_ENABLED` define will be set.~~

Currently, actually using `MEMORY64` seems to break our current JS logic (as `BigInt` arithmetic don't like to be mixed with standard numbers). So `wasm64` and `wasm32+64bitptrs` builds wont actually technically work out of the box.

I'm doing this PR right now because I want to setup the grounds for supporting the feature in future PRs, ~~especially with the help of `WASM_MEMORY64_ENABLED`.~~

I currently have a feature currently baking that will need to know which type of memory we're dealing with.

_Edit:_ I modified the PR to introduce instead `bool OS_Web::is_memory64()`.