### PR TITLE
Use `separate_debug_symbols` to control generation of the separate Android debug symbols file

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -40,7 +40,6 @@ def get_opts():
             False,
         ),
         BoolVariable("swappy", "Use Swappy Frame Pacing library", False),
-        BoolVariable("gradle_do_not_strip", "Whether Gradle should strip the Android *.so libraries or not", False),
     ]
 
 

--- a/platform/android/platform_android_builders.py
+++ b/platform/android/platform_android_builders.py
@@ -22,7 +22,7 @@ def generate_android_binaries(target, source, env):
         gradle_process += ["generateGodotTemplates"]
     gradle_process += ["--quiet"]
 
-    if env["gradle_do_not_strip"]:
+    if env["debug_symbols"] and not env["separate_debug_symbols"]:
         gradle_process += ["-PdoNotStrip=true"]
 
     subprocess.run(


### PR DESCRIPTION
This addresses feedback from https://github.com/godotengine/godot/pull/105605#issuecomment-2822756257.

As mentioned in https://github.com/godotengine/godot/pull/105605#issuecomment-2822820370, I don't have a preference over which parameter to use, so looking for feedback.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
