### PR TITLE
[3.x] Add an editor option to copy system info to clipboard

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -628,10 +628,11 @@ void EditorNode::_notification(int p_what) {
 			p->set_item_icon(p->get_item_index(HELP_SEARCH), gui_base->get_icon("HelpSearch", "EditorIcons"));
 			p->set_item_icon(p->get_item_index(HELP_DOCS), gui_base->get_icon("ExternalLink", "EditorIcons"));
 			p->set_item_icon(p->get_item_index(HELP_QA), gui_base->get_icon("ExternalLink", "EditorIcons"));
+			p->set_item_icon(p->get_item_index(HELP_COMMUNITY), gui_base->get_icon("ExternalLink", "EditorIcons"));
+			p->set_item_icon(p->get_item_index(HELP_COPY_SYSTEM_INFO), gui_base->get_icon("ActionCopy", "EditorIcons"));
 			p->set_item_icon(p->get_item_index(HELP_REPORT_A_BUG), gui_base->get_icon("ExternalLink", "EditorIcons"));
 			p->set_item_icon(p->get_item_index(HELP_SUGGEST_A_FEATURE), gui_base->get_icon("ExternalLink", "EditorIcons"));
 			p->set_item_icon(p->get_item_index(HELP_SEND_DOCS_FEEDBACK), gui_base->get_icon("ExternalLink", "EditorIcons"));
-			p->set_item_icon(p->get_item_index(HELP_COMMUNITY), gui_base->get_icon("ExternalLink", "EditorIcons"));
 			p->set_item_icon(p->get_item_index(HELP_ABOUT), gui_base->get_icon("Godot", "EditorIcons"));
 			p->set_item_icon(p->get_item_index(HELP_SUPPORT_GODOT_DEVELOPMENT), gui_base->get_icon("Heart", "EditorIcons"));
 			_update_update_spinner();
@@ -2919,6 +2920,13 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case HELP_QA: {
 			OS::get_singleton()->shell_open("https://godotengine.org/qa/");
 		} break;
+		case HELP_COMMUNITY: {
+			OS::get_singleton()->shell_open("https://godotengine.org/community");
+		} break;
+		case HELP_COPY_SYSTEM_INFO: {
+			String info = _get_system_info();
+			OS::get_singleton()->set_clipboard(info);
+		} break;
 		case HELP_REPORT_A_BUG: {
 			OS::get_singleton()->shell_open("https://github.com/godotengine/godot/issues");
 		} break;
@@ -2927,9 +2935,6 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case HELP_SEND_DOCS_FEEDBACK: {
 			OS::get_singleton()->shell_open("https://github.com/godotengine/godot-docs/issues");
-		} break;
-		case HELP_COMMUNITY: {
-			OS::get_singleton()->shell_open("https://godotengine.org/community");
 		} break;
 		case HELP_ABOUT: {
 			about->popup_centered_minsize(Size2(780, 500) * EDSCALE);
@@ -2969,6 +2974,33 @@ void EditorNode::_save_screenshot(NodePath p_path) {
 	viewport->set_clear_mode(Viewport::CLEAR_MODE_ALWAYS);
 	Error error = img->save_png(p_path);
 	ERR_FAIL_COND_MSG(error != OK, "Cannot save screenshot to file '" + p_path + "'.");
+}
+
+String EditorNode::_get_system_info() {
+	String engine = String(VERSION_FULL_NAME);
+	String hash = String(VERSION_HASH);
+	hash = hash.empty() ? String(" [unknown]") : vformat(" [%s]", hash.left(9));
+	engine += hash;
+
+	String os = OS::get_singleton()->get_name();
+
+	String screen = itos(OS::get_singleton()->get_screen_count());
+	screen += (OS::get_singleton()->get_screen_count() > 1) ? String(" monitors") : String(" monitor");
+	String video_driver = OS::get_singleton()->get_video_driver_name(OS::get_singleton()->get_current_video_driver());
+	String video_adapter = VisualServer::get_singleton()->get_video_adapter_name();
+
+	String processor = OS::get_singleton()->get_processor_name();
+	processor += vformat(" (%s threads)", OS::get_singleton()->get_processor_count());
+
+	Vector<String> info;
+	info.push_back(engine);
+	info.push_back(os);
+	info.push_back(screen);
+	info.push_back(video_driver);
+	info.push_back(video_adapter);
+	info.push_back(processor);
+
+	return String(" - ").join(info);
 }
 
 void EditorNode::_tool_menu_option(int p_idx) {
@@ -5801,6 +5833,7 @@ void EditorNode::_bind_methods() {
 	ClassDB::bind_method("_screenshot", &EditorNode::_screenshot);
 	ClassDB::bind_method("_request_screenshot", &EditorNode::_request_screenshot);
 	ClassDB::bind_method("_save_screenshot", &EditorNode::_save_screenshot);
+	ClassDB::bind_method("_get_system_info", &EditorNode::_get_system_info);
 
 	ADD_SIGNAL(MethodInfo("play_pressed"));
 	ADD_SIGNAL(MethodInfo("pause_pressed"));
@@ -6643,10 +6676,12 @@ EditorNode::EditorNode() {
 	p->add_separator();
 	p->add_icon_shortcut(gui_base->get_icon("ExternalLink", "EditorIcons"), ED_SHORTCUT("editor/online_docs", TTR("Online Documentation")), HELP_DOCS);
 	p->add_icon_shortcut(gui_base->get_icon("ExternalLink", "EditorIcons"), ED_SHORTCUT("editor/q&a", TTR("Questions & Answers")), HELP_QA);
+	p->add_icon_shortcut(gui_base->get_icon("ExternalLink", "EditorIcons"), ED_SHORTCUT("editor/community", TTR("Community")), HELP_COMMUNITY);
+	p->add_separator();
+	p->add_icon_shortcut(gui_base->get_icon("ActionCopy", "EditorIcons"), ED_SHORTCUT("editor/copy_system_info", TTR("Copy System Info")), HELP_COPY_SYSTEM_INFO);
 	p->add_icon_shortcut(gui_base->get_icon("ExternalLink", "EditorIcons"), ED_SHORTCUT("editor/report_a_bug", TTR("Report a Bug")), HELP_REPORT_A_BUG);
 	p->add_icon_shortcut(gui_base->get_icon("ExternalLink", "EditorIcons"), ED_SHORTCUT("editor/suggest_a_feature", TTR("Suggest a Feature")), HELP_SUGGEST_A_FEATURE);
 	p->add_icon_shortcut(gui_base->get_icon("ExternalLink", "EditorIcons"), ED_SHORTCUT("editor/send_docs_feedback", TTR("Send Docs Feedback")), HELP_SEND_DOCS_FEEDBACK);
-	p->add_icon_shortcut(gui_base->get_icon("ExternalLink", "EditorIcons"), ED_SHORTCUT("editor/community", TTR("Community")), HELP_COMMUNITY);
 	p->add_separator();
 	p->add_icon_shortcut(gui_base->get_icon("Godot", "EditorIcons"), ED_SHORTCUT("editor/about", TTR("About Godot")), HELP_ABOUT);
 	p->add_icon_shortcut(gui_base->get_icon("Heart", "EditorIcons"), ED_SHORTCUT("editor/support_development", TTR("Support Godot Development")), HELP_SUPPORT_GODOT_DEVELOPMENT);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -202,10 +202,11 @@ private:
 		HELP_SEARCH,
 		HELP_DOCS,
 		HELP_QA,
+		HELP_COMMUNITY,
+		HELP_COPY_SYSTEM_INFO,
 		HELP_REPORT_A_BUG,
 		HELP_SUGGEST_A_FEATURE,
 		HELP_SEND_DOCS_FEEDBACK,
-		HELP_COMMUNITY,
 		HELP_ABOUT,
 		HELP_SUPPORT_GODOT_DEVELOPMENT,
 
@@ -473,6 +474,7 @@ private:
 	void _request_screenshot();
 	void _screenshot(bool p_use_utc = false);
 	void _save_screenshot(NodePath p_path);
+	String _get_system_info();
 
 	void _tool_menu_option(int p_idx);
 	void _update_debug_options();


### PR DESCRIPTION
Backport : https://github.com/godotengine/godot/pull/77574

- compact single-line output to fit the input field on open issue
- make the item order to mach 4.x branch

Result

`Windows 11`

Godot Engine v3.7.dev.custom_build [c3c918e28] - Windows - 1 monitor - GLES3 - NVIDIA GeForce RTX 4050 Laptop GPU/PCIe/SSE2 - AMD Ryzen 5 7640HS w/ Radeon 760M Graphics (12 threads)

`Ubuntu 24.04.1 LTS (WSL)`

Godot Engine v3.7.dev.custom_build [c3c918e28] - X11 - 1 monitor - GLES3 - D3D12 (AMD Radeon(TM) 760M) - AMD Ryzen 5 7640HS w/ Radeon 760M Graphics (12 threads)

![image](https://github.com/user-attachments/assets/452bb398-d488-4040-9643-ba72fde9a5fe)