### PR TITLE
Change editor button focus mode to `FOCUS_ACCESSIBILITY`.

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -758,7 +758,7 @@ FindReplaceBar::FindReplaceBar() {
 	add_child(toggle_replace_button);
 	toggle_replace_button->set_accessibility_name(TTRC("Replace Mode"));
 	toggle_replace_button->set_flat(true);
-	toggle_replace_button->set_focus_mode(FOCUS_NONE);
+	toggle_replace_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	toggle_replace_button->connect(SceneStringName(pressed), callable_mp(this, &FindReplaceBar::_toggle_replace_pressed));
 
 	VBoxContainer *vbc_lineedit = memnew(VBoxContainer);
@@ -806,7 +806,7 @@ FindReplaceBar::FindReplaceBar() {
 	find_prev->set_tooltip_text(TTRC("Previous Match"));
 	find_prev->set_accessibility_name(TTRC("Previous Match"));
 	hbc_button_search->add_child(find_prev);
-	find_prev->set_focus_mode(FOCUS_NONE);
+	find_prev->set_focus_mode(FOCUS_ACCESSIBILITY);
 	find_prev->connect(SceneStringName(pressed), callable_mp(this, &FindReplaceBar::search_prev));
 
 	find_next = memnew(Button);
@@ -815,19 +815,19 @@ FindReplaceBar::FindReplaceBar() {
 	find_next->set_tooltip_text(TTRC("Next Match"));
 	find_next->set_accessibility_name(TTRC("Next Match"));
 	hbc_button_search->add_child(find_next);
-	find_next->set_focus_mode(FOCUS_NONE);
+	find_next->set_focus_mode(FOCUS_ACCESSIBILITY);
 	find_next->connect(SceneStringName(pressed), callable_mp(this, &FindReplaceBar::search_next));
 
 	case_sensitive = memnew(CheckBox);
 	hbc_option_search->add_child(case_sensitive);
 	case_sensitive->set_text(TTRC("Match Case"));
-	case_sensitive->set_focus_mode(FOCUS_NONE);
+	case_sensitive->set_focus_mode(FOCUS_ACCESSIBILITY);
 	case_sensitive->connect(SceneStringName(toggled), callable_mp(this, &FindReplaceBar::_search_options_changed));
 
 	whole_words = memnew(CheckBox);
 	hbc_option_search->add_child(whole_words);
 	whole_words->set_text(TTRC("Whole Words"));
-	whole_words->set_focus_mode(FOCUS_NONE);
+	whole_words->set_focus_mode(FOCUS_ACCESSIBILITY);
 	whole_words->connect(SceneStringName(toggled), callable_mp(this, &FindReplaceBar::_search_options_changed));
 
 	// Replace toolbar.
@@ -852,14 +852,14 @@ FindReplaceBar::FindReplaceBar() {
 	selection_only = memnew(CheckBox);
 	hbc_option_replace->add_child(selection_only);
 	selection_only->set_text(TTRC("Selection Only"));
-	selection_only->set_focus_mode(FOCUS_NONE);
+	selection_only->set_focus_mode(FOCUS_ACCESSIBILITY);
 	selection_only->connect(SceneStringName(toggled), callable_mp(this, &FindReplaceBar::_search_options_changed));
 
 	hide_button = memnew(Button);
 	hide_button->set_flat(true);
 	hide_button->set_tooltip_text(TTRC("Hide"));
 	hide_button->set_accessibility_name(TTRC("Hide"));
-	hide_button->set_focus_mode(FOCUS_NONE);
+	hide_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	hide_button->connect(SceneStringName(pressed), callable_mp(this, &FindReplaceBar::_hide_bar));
 	hide_button->set_v_size_flags(SIZE_SHRINK_CENTER);
 	add_child(hide_button);

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -844,7 +844,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	solo->set_toggle_mode(true);
 	solo->set_tooltip_text(TTR("Solo"));
 	solo->set_accessibility_name(TTRC("Solo"));
-	solo->set_focus_mode(FOCUS_NONE);
+	solo->set_focus_mode(FOCUS_ACCESSIBILITY);
 	solo->connect(SceneStringName(pressed), callable_mp(this, &EditorAudioBus::_solo_toggled));
 	hbc->add_child(solo);
 	mute = memnew(Button);
@@ -852,7 +852,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	mute->set_toggle_mode(true);
 	mute->set_tooltip_text(TTR("Mute"));
 	mute->set_accessibility_name(TTRC("Mute"));
-	mute->set_focus_mode(FOCUS_NONE);
+	mute->set_focus_mode(FOCUS_ACCESSIBILITY);
 	mute->connect(SceneStringName(pressed), callable_mp(this, &EditorAudioBus::_mute_toggled));
 	hbc->add_child(mute);
 	bypass = memnew(Button);
@@ -860,7 +860,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	bypass->set_toggle_mode(true);
 	bypass->set_tooltip_text(TTR("Bypass"));
 	bypass->set_accessibility_name(TTRC("Bypass"));
-	bypass->set_focus_mode(FOCUS_NONE);
+	bypass->set_focus_mode(FOCUS_ACCESSIBILITY);
 	bypass->connect(SceneStringName(pressed), callable_mp(this, &EditorAudioBus::_bypass_toggled));
 	hbc->add_child(bypass);
 	hbc->add_spacer();

--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -1269,7 +1269,7 @@ DockContextPopup::DockContextPopup() {
 	tab_move_left_button = memnew(Button);
 	tab_move_left_button->set_accessibility_name(TTRC("Move Tab Left"));
 	tab_move_left_button->set_flat(true);
-	tab_move_left_button->set_focus_mode(Control::FOCUS_NONE);
+	tab_move_left_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	tab_move_left_button->connect(SceneStringName(pressed), callable_mp(this, &DockContextPopup::_tab_move_left));
 	header_hb->add_child(tab_move_left_button);
 
@@ -1282,7 +1282,7 @@ DockContextPopup::DockContextPopup() {
 	tab_move_right_button = memnew(Button);
 	tab_move_right_button->set_accessibility_name(TTRC("Move Tab Right"));
 	tab_move_right_button->set_flat(true);
-	tab_move_right_button->set_focus_mode(Control::FOCUS_NONE);
+	tab_move_right_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	tab_move_right_button->connect(SceneStringName(pressed), callable_mp(this, &DockContextPopup::_tab_move_right));
 
 	header_hb->add_child(tab_move_right_button);
@@ -1304,7 +1304,7 @@ DockContextPopup::DockContextPopup() {
 	} else {
 		make_float_button->set_tooltip_text(TTR("Make this dock floating."));
 	}
-	make_float_button->set_focus_mode(Control::FOCUS_NONE);
+	make_float_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	make_float_button->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	make_float_button->connect(SceneStringName(pressed), callable_mp(this, &DockContextPopup::_float_dock));
 	dock_select_popup_vb->add_child(make_float_button);
@@ -1312,7 +1312,7 @@ DockContextPopup::DockContextPopup() {
 	dock_to_bottom_button = memnew(Button);
 	dock_to_bottom_button->set_text(TTR("Move to Bottom"));
 	dock_to_bottom_button->set_tooltip_text(TTR("Move this dock to the bottom panel."));
-	dock_to_bottom_button->set_focus_mode(Control::FOCUS_NONE);
+	dock_to_bottom_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	dock_to_bottom_button->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	dock_to_bottom_button->connect(SceneStringName(pressed), callable_mp(this, &DockContextPopup::_move_dock_to_bottom));
 	dock_to_bottom_button->hide();
@@ -1321,7 +1321,7 @@ DockContextPopup::DockContextPopup() {
 	close_button = memnew(Button);
 	close_button->set_text(TTR("Close"));
 	close_button->set_tooltip_text(TTR("Close this dock."));
-	close_button->set_focus_mode(Control::FOCUS_NONE);
+	close_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	close_button->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	close_button->connect(SceneStringName(pressed), callable_mp(this, &DockContextPopup::_close_dock));
 	dock_select_popup_vb->add_child(close_button);

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -4800,7 +4800,7 @@ FindBar::FindBar() {
 	find_prev->set_tooltip_text(TTR("Previous Match"));
 	find_prev->set_accessibility_name(TTRC("Previous Match"));
 	add_child(find_prev);
-	find_prev->set_focus_mode(FOCUS_NONE);
+	find_prev->set_focus_mode(FOCUS_ACCESSIBILITY);
 	find_prev->connect(SceneStringName(pressed), callable_mp(this, &FindBar::search_prev));
 
 	find_next = memnew(Button);
@@ -4809,14 +4809,14 @@ FindBar::FindBar() {
 	find_next->set_tooltip_text(TTR("Next Match"));
 	find_next->set_accessibility_name(TTRC("Next Match"));
 	add_child(find_next);
-	find_next->set_focus_mode(FOCUS_NONE);
+	find_next->set_focus_mode(FOCUS_ACCESSIBILITY);
 	find_next->connect(SceneStringName(pressed), callable_mp(this, &FindBar::search_next));
 
 	hide_button = memnew(Button);
 	hide_button->set_flat(true);
 	hide_button->set_tooltip_text(TTR("Hide"));
 	hide_button->set_accessibility_name(TTRC("Hide"));
-	hide_button->set_focus_mode(FOCUS_NONE);
+	hide_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	hide_button->connect(SceneStringName(pressed), callable_mp(this, &FindBar::_hide_bar));
 	hide_button->set_v_size_flags(SIZE_SHRINK_CENTER);
 	add_child(hide_button);

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -344,7 +344,7 @@ EditorHelpSearch::EditorHelpSearch() {
 	case_sensitive_button->set_accessibility_name(TTRC("Case Sensitive"));
 	case_sensitive_button->connect(SceneStringName(pressed), callable_mp(this, &EditorHelpSearch::_update_results));
 	case_sensitive_button->set_toggle_mode(true);
-	case_sensitive_button->set_focus_mode(Control::FOCUS_NONE);
+	case_sensitive_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	hbox->add_child(case_sensitive_button);
 
 	hierarchy_button = memnew(Button);
@@ -354,7 +354,7 @@ EditorHelpSearch::EditorHelpSearch() {
 	hierarchy_button->connect(SceneStringName(pressed), callable_mp(this, &EditorHelpSearch::_update_results));
 	hierarchy_button->set_toggle_mode(true);
 	hierarchy_button->set_pressed(true);
-	hierarchy_button->set_focus_mode(Control::FOCUS_NONE);
+	hierarchy_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	hbox->add_child(hierarchy_button);
 
 	filter_combo = memnew(OptionButton);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -484,7 +484,7 @@ EditorLog::EditorLog() {
 	clear_button = memnew(Button);
 	clear_button->set_accessibility_name(TTRC("Clear Log"));
 	clear_button->set_theme_type_variation(SceneStringName(FlatButton));
-	clear_button->set_focus_mode(FOCUS_NONE);
+	clear_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	clear_button->set_shortcut(ED_SHORTCUT("editor/clear_output", TTRC("Clear Output"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::K));
 	clear_button->connect(SceneStringName(pressed), callable_mp(this, &EditorLog::_clear_request));
 	hb_tools->add_child(clear_button);
@@ -493,7 +493,7 @@ EditorLog::EditorLog() {
 	copy_button = memnew(Button);
 	copy_button->set_accessibility_name(TTRC("Copy Selection"));
 	copy_button->set_theme_type_variation(SceneStringName(FlatButton));
-	copy_button->set_focus_mode(FOCUS_NONE);
+	copy_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	copy_button->set_shortcut(ED_SHORTCUT("editor/copy_output", TTRC("Copy Selection"), KeyModifierMask::CMD_OR_CTRL | Key::C));
 	copy_button->set_shortcut_context(this);
 	copy_button->connect(SceneStringName(pressed), callable_mp(this, &EditorLog::_copy_request));
@@ -510,7 +510,7 @@ EditorLog::EditorLog() {
 	// Collapse.
 	collapse_button = memnew(Button);
 	collapse_button->set_theme_type_variation(SceneStringName(FlatButton));
-	collapse_button->set_focus_mode(FOCUS_NONE);
+	collapse_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	collapse_button->set_tooltip_text(TTR("Collapse duplicate messages into one log entry. Shows number of occurrences."));
 	collapse_button->set_accessibility_name(TTRC("Collapse Duplicate Messages"));
 	collapse_button->set_toggle_mode(true);
@@ -522,7 +522,7 @@ EditorLog::EditorLog() {
 	show_search_button = memnew(Button);
 	show_search_button->set_accessibility_name(TTRC("Show Search"));
 	show_search_button->set_theme_type_variation(SceneStringName(FlatButton));
-	show_search_button->set_focus_mode(FOCUS_NONE);
+	show_search_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	show_search_button->set_toggle_mode(true);
 	show_search_button->set_pressed(true);
 	show_search_button->set_shortcut(ED_SHORTCUT("editor/open_search", TTRC("Focus Search/Filter Bar"), KeyModifierMask::CMD_OR_CTRL | Key::F));

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -94,7 +94,7 @@ private:
 			toggle_button->set_text(itos(message_count));
 			toggle_button->set_accessibility_name(TTRGET(p_name));
 			toggle_button->set_tooltip_text(TTRGET(p_tooltip));
-			toggle_button->set_focus_mode(FOCUS_NONE);
+			toggle_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 			// When toggled call the callback and pass the MessageType this button is for.
 			toggle_button->connect(SceneStringName(toggled), p_toggled_callback.bind(type));
 		}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8103,7 +8103,7 @@ EditorNode::EditorNode() {
 	renderer->set_flat(true);
 	renderer->set_theme_type_variation("TopBarOptionButton");
 	renderer->set_fit_to_longest_item(false);
-	renderer->set_focus_mode(Control::FOCUS_NONE);
+	renderer->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	renderer->set_tooltip_text(TTR("Choose a rendering method.\n\nNotes:\n- On mobile platforms, the Mobile rendering method is used if Forward+ is selected here.\n- On the web platform, the Compatibility rendering method is always used."));
 	renderer->set_accessibility_name(TTRC("Rendering Method"));
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -1353,7 +1353,7 @@ void EditorPropertyDictionary::update_property() {
 					}
 					new_prop->set_read_only(true);
 					new_prop->set_selectable(false);
-					new_prop->set_focus_mode(Control::FOCUS_NONE);
+					new_prop->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 					new_prop->set_draw_background(false);
 					new_prop->set_use_folding(is_using_folding());
 					new_prop->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -4140,7 +4140,7 @@ FileSystemDock::FileSystemDock() {
 	button_hist_prev = memnew(Button);
 	button_hist_prev->set_flat(true);
 	button_hist_prev->set_disabled(true);
-	button_hist_prev->set_focus_mode(FOCUS_NONE);
+	button_hist_prev->set_focus_mode(FOCUS_ACCESSIBILITY);
 	button_hist_prev->set_tooltip_text(TTRC("Go to previous selected folder/file."));
 	button_hist_prev->set_accessibility_name(TTRC("Previous"));
 	nav_hbc->add_child(button_hist_prev);
@@ -4148,7 +4148,7 @@ FileSystemDock::FileSystemDock() {
 	button_hist_next = memnew(Button);
 	button_hist_next->set_flat(true);
 	button_hist_next->set_disabled(true);
-	button_hist_next->set_focus_mode(FOCUS_NONE);
+	button_hist_next->set_focus_mode(FOCUS_ACCESSIBILITY);
 	button_hist_next->set_tooltip_text(TTRC("Go to next selected folder/file."));
 	button_hist_next->set_accessibility_name(TTRC("Next"));
 	nav_hbc->add_child(button_hist_next);
@@ -4162,7 +4162,7 @@ FileSystemDock::FileSystemDock() {
 
 	button_toggle_display_mode = memnew(Button);
 	button_toggle_display_mode->connect(SceneStringName(pressed), callable_mp(this, &FileSystemDock::_change_split_mode));
-	button_toggle_display_mode->set_focus_mode(FOCUS_NONE);
+	button_toggle_display_mode->set_focus_mode(FOCUS_ACCESSIBILITY);
 	button_toggle_display_mode->set_tooltip_text(TTRC("Change Split Mode"));
 	button_toggle_display_mode->set_accessibility_name(TTRC("Change Split Mode"));
 	button_toggle_display_mode->set_theme_type_variation("FlatMenuButton");

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -209,7 +209,7 @@ Button *EditorBottomPanel::add_item(String p_text, Control *p_item, const Ref<Sh
 	tb->set_text(p_text);
 	tb->set_shortcut(p_shortcut);
 	tb->set_toggle_mode(true);
-	tb->set_focus_mode(Control::FOCUS_NONE);
+	tb->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	item_vbox->add_child(p_item);
 
 	bottom_hbox->move_to_front();
@@ -309,7 +309,7 @@ EditorBottomPanel::EditorBottomPanel() {
 	left_button->set_tooltip_text(TTR("Scroll Left\nHold Ctrl to scroll to the begin.\nHold Shift to scroll one page."));
 	left_button->set_accessibility_name(TTRC("Scroll Left"));
 	left_button->set_theme_type_variation("BottomPanelButton");
-	left_button->set_focus_mode(Control::FOCUS_NONE);
+	left_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	left_button->connect(SceneStringName(pressed), callable_mp(this, &EditorBottomPanel::_scroll).bind(false));
 	bottom_hbox->add_child(left_button);
 	left_button->hide();
@@ -326,7 +326,7 @@ EditorBottomPanel::EditorBottomPanel() {
 	right_button->set_tooltip_text(TTR("Scroll Right\nHold Ctrl to scroll to the end.\nHold Shift to scroll one page."));
 	right_button->set_accessibility_name(TTRC("Scroll Right"));
 	right_button->set_theme_type_variation("BottomPanelButton");
-	right_button->set_focus_mode(Control::FOCUS_NONE);
+	right_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	right_button->connect(SceneStringName(pressed), callable_mp(this, &EditorBottomPanel::_scroll).bind(true));
 	bottom_hbox->add_child(right_button);
 	right_button->hide();

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -182,7 +182,7 @@ void EditorQuickOpenDialog::_search_box_text_changed(const String &p_query) {
 
 void style_button(Button *p_button) {
 	p_button->set_flat(true);
-	p_button->set_focus_mode(Control::FOCUS_NONE);
+	p_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	p_button->set_default_cursor_shape(Control::CURSOR_POINTING_HAND);
 }
 

--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -519,7 +519,7 @@ EditorRunBar::EditorRunBar() {
 	// Use a button for the indicator since it comes with a background panel and pixel perfect centering of an icon.
 	profiler_autostart_indicator = memnew(Button);
 	profiler_autostart_indicator->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	profiler_autostart_indicator->set_focus_mode(FOCUS_NONE);
+	profiler_autostart_indicator->set_focus_mode(FOCUS_ACCESSIBILITY);
 	profiler_autostart_indicator->set_theme_type_variation("ProfilerAutostartIndicator");
 	profiler_autostart_indicator->connect(SceneStringName(pressed), callable_mp(this, &EditorRunBar::_profiler_autostart_indicator_pressed));
 	outer_hbox->add_child(profiler_autostart_indicator);
@@ -549,7 +549,7 @@ EditorRunBar::EditorRunBar() {
 		recovery_mode_reload_button = memnew(Button);
 		main_hbox->add_child(recovery_mode_reload_button);
 		recovery_mode_reload_button->set_theme_type_variation("RunBarButton");
-		recovery_mode_reload_button->set_focus_mode(Control::FOCUS_NONE);
+		recovery_mode_reload_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 		recovery_mode_reload_button->set_tooltip_text(TTR("Disable recovery mode and reload the project."));
 		recovery_mode_reload_button->set_accessibility_name(TTRC("Disable Recovery Mode"));
 		recovery_mode_reload_button->connect(SceneStringName(pressed), callable_mp(this, &EditorRunBar::recovery_mode_reload_project));
@@ -560,7 +560,7 @@ EditorRunBar::EditorRunBar() {
 		recovery_mode_button = memnew(Button);
 		recovery_mode_panel->add_child(recovery_mode_button);
 		recovery_mode_button->set_theme_type_variation("RunBarButton");
-		recovery_mode_button->set_focus_mode(Control::FOCUS_NONE);
+		recovery_mode_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 		recovery_mode_button->set_text(TTR("Recovery Mode"));
 		recovery_mode_button->set_tooltip_text(TTR("Recovery Mode is enabled. Click for more details."));
 		recovery_mode_button->connect(SceneStringName(pressed), callable_mp(this, &EditorRunBar::recovery_mode_show_dialog));
@@ -572,7 +572,7 @@ EditorRunBar::EditorRunBar() {
 	main_hbox->add_child(play_button);
 	play_button->set_theme_type_variation("RunBarButton");
 	play_button->set_toggle_mode(true);
-	play_button->set_focus_mode(Control::FOCUS_NONE);
+	play_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	play_button->set_tooltip_text(TTRC("Run the project's default scene."));
 	play_button->set_accessibility_name(TTRC("Run Default Scene"));
 	play_button->connect(SceneStringName(pressed), callable_mp(this, &EditorRunBar::play_main_scene).bind(false));
@@ -585,7 +585,7 @@ EditorRunBar::EditorRunBar() {
 	main_hbox->add_child(pause_button);
 	pause_button->set_theme_type_variation("RunBarButton");
 	pause_button->set_toggle_mode(true);
-	pause_button->set_focus_mode(Control::FOCUS_NONE);
+	pause_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	pause_button->set_tooltip_text(TTRC("Pause the running project's execution for debugging."));
 	pause_button->set_accessibility_name(TTRC("Pause"));
 	pause_button->set_disabled(true);
@@ -597,7 +597,7 @@ EditorRunBar::EditorRunBar() {
 	stop_button = memnew(Button);
 	main_hbox->add_child(stop_button);
 	stop_button->set_theme_type_variation("RunBarButton");
-	stop_button->set_focus_mode(Control::FOCUS_NONE);
+	stop_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	stop_button->set_tooltip_text(TTRC("Stop the currently running project."));
 	stop_button->set_accessibility_name(TTRC("Stop"));
 	stop_button->set_disabled(true);
@@ -639,7 +639,7 @@ EditorRunBar::EditorRunBar() {
 	}
 	main_hbox->add_child(play_scene_button);
 	play_scene_button->set_theme_type_variation("RunBarButton");
-	play_scene_button->set_focus_mode(Control::FOCUS_NONE);
+	play_scene_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	play_scene_button->set_tooltip_text(TTRC("Run the currently edited scene."));
 	play_scene_button->set_accessibility_name(TTRC("Run Edited Scene"));
 
@@ -661,7 +661,7 @@ EditorRunBar::EditorRunBar() {
 	}
 	main_hbox->add_child(play_custom_scene_button);
 	play_custom_scene_button->set_theme_type_variation("RunBarButton");
-	play_custom_scene_button->set_focus_mode(Control::FOCUS_NONE);
+	play_custom_scene_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	play_custom_scene_button->set_tooltip_text(TTRC("Run a specific scene."));
 	play_custom_scene_button->set_accessibility_name(TTRC("Run Specific Scene"));
 
@@ -680,7 +680,7 @@ EditorRunBar::EditorRunBar() {
 
 	write_movie_panel->add_child(write_movie_button);
 	write_movie_button->set_theme_type_variation("RunBarButtonMovieMakerDisabled");
-	write_movie_button->set_focus_mode(Control::FOCUS_NONE);
+	write_movie_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	write_movie_button->set_tooltip_text(TTR("Enable Movie Maker mode.\nThe project will run at stable FPS and the visual and audio output will be recorded to a video file."));
 	write_movie_button->set_accessibility_name(TTRC("Enable Movie Maker Mode"));
 }

--- a/editor/gui/editor_zoom_widget.cpp
+++ b/editor/gui/editor_zoom_widget.cpp
@@ -190,7 +190,7 @@ EditorZoomWidget::EditorZoomWidget() {
 	zoom_minus->set_flat(true);
 	zoom_minus->set_shortcut(ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_minus", TTRC("Zoom Out"), { int32_t(KeyModifierMask::CMD_OR_CTRL | Key::MINUS), int32_t(KeyModifierMask::CMD_OR_CTRL | Key::KP_SUBTRACT) }));
 	zoom_minus->set_shortcut_context(this);
-	zoom_minus->set_focus_mode(FOCUS_NONE);
+	zoom_minus->set_focus_mode(FOCUS_ACCESSIBILITY);
 	add_child(zoom_minus);
 	zoom_minus->connect(SceneStringName(pressed), callable_mp(this, &EditorZoomWidget::_button_zoom_minus));
 
@@ -209,7 +209,7 @@ EditorZoomWidget::EditorZoomWidget() {
 
 	zoom_reset->set_shortcut(ED_GET_SHORTCUT("canvas_item_editor/zoom_100_percent"));
 	zoom_reset->set_shortcut_context(this);
-	zoom_reset->set_focus_mode(FOCUS_NONE);
+	zoom_reset->set_focus_mode(FOCUS_ACCESSIBILITY);
 	zoom_reset->set_text_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	// Prevent the button's size from changing when the text size changes
 	zoom_reset->set_custom_minimum_size(Size2(56 * EDSCALE, 0));
@@ -221,7 +221,7 @@ EditorZoomWidget::EditorZoomWidget() {
 	zoom_plus->set_flat(true);
 	zoom_plus->set_shortcut(ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_plus", TTRC("Zoom In"), { int32_t(KeyModifierMask::CMD_OR_CTRL | Key::EQUAL), int32_t(KeyModifierMask::CMD_OR_CTRL | Key::KP_ADD) }));
 	zoom_plus->set_shortcut_context(this);
-	zoom_plus->set_focus_mode(FOCUS_NONE);
+	zoom_plus->set_focus_mode(FOCUS_ACCESSIBILITY);
 	add_child(zoom_plus);
 	zoom_plus->connect(SceneStringName(pressed), callable_mp(this, &EditorZoomWidget::_button_zoom_plus));
 

--- a/editor/gui/touch_actions_panel.cpp
+++ b/editor/gui/touch_actions_panel.cpp
@@ -130,7 +130,7 @@ Button *TouchActionsPanel::_add_new_action_button(const String &p_shortcut, cons
 	Button *action_button = memnew(Button);
 	action_button->set_theme_type_variation("FlatMenuButton");
 	action_button->set_accessibility_name(p_name);
-	action_button->set_focus_mode(FOCUS_NONE);
+	action_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	action_button->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	if (p_keycode == Key::NONE) {
 		action_button->connect(SceneStringName(pressed), callable_mp(this, &TouchActionsPanel::_simulate_editor_shortcut).bind(p_shortcut));
@@ -159,7 +159,7 @@ void TouchActionsPanel::_add_new_modifier_button(Modifier p_modifier) {
 	toggle_button->set_toggle_mode(true);
 	toggle_button->set_theme_type_variation("FlatMenuButton");
 	toggle_button->set_accessibility_name(text);
-	toggle_button->set_focus_mode(FOCUS_NONE);
+	toggle_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	toggle_button->connect(SceneStringName(toggled), callable_mp(this, &TouchActionsPanel::_on_modifier_button_toggled).bind((int)p_modifier));
 	box->add_child(toggle_button);
 }
@@ -258,7 +258,7 @@ TouchActionsPanel::TouchActionsPanel() {
 		layout_toggle_button = memnew(Button);
 		layout_toggle_button->set_theme_type_variation("FlatMenuButton");
 		layout_toggle_button->set_accessibility_name(TTRC("Switch Layout"));
-		layout_toggle_button->set_focus_mode(FOCUS_NONE);
+		layout_toggle_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 		layout_toggle_button->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 		layout_toggle_button->connect(SceneStringName(pressed), callable_mp(this, &TouchActionsPanel::_switch_layout));
 		box->add_child(layout_toggle_button);
@@ -267,7 +267,7 @@ TouchActionsPanel::TouchActionsPanel() {
 		lock_panel_button->set_toggle_mode(true);
 		lock_panel_button->set_theme_type_variation("FlatMenuButton");
 		lock_panel_button->set_accessibility_name(TTRC("Lock Panel"));
-		lock_panel_button->set_focus_mode(FOCUS_NONE);
+		lock_panel_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 		lock_panel_button->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 		lock_panel_button->connect(SceneStringName(toggled), callable_mp(this, &TouchActionsPanel::_lock_panel_toggled));
 		box->add_child(lock_panel_button);
@@ -275,7 +275,7 @@ TouchActionsPanel::TouchActionsPanel() {
 		panel_pos_button = memnew(Button);
 		panel_pos_button->set_theme_type_variation("FlatMenuButton");
 		panel_pos_button->set_accessibility_name(TTRC("Switch Embedded Panel Position"));
-		panel_pos_button->set_focus_mode(FOCUS_NONE);
+		panel_pos_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 		panel_pos_button->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 		panel_pos_button->connect(SceneStringName(pressed), callable_mp(this, &TouchActionsPanel::_switch_embedded_panel_side));
 		box->add_child(panel_pos_button);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1724,7 +1724,7 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	animation_hbox->add_child(animation_play_button);
 	animation_play_button->set_flat(true);
 	animation_play_button->set_accessibility_name(TTRC("Play"));
-	animation_play_button->set_focus_mode(Control::FOCUS_NONE);
+	animation_play_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	animation_play_button->set_shortcut(ED_SHORTCUT("scene_import_settings/play_selected_animation", TTRC("Selected Animation Play/Pause"), Key::SPACE));
 	animation_play_button->connect(SceneStringName(pressed), callable_mp(this, &SceneImportSettingsDialog::_play_animation));
 
@@ -1732,7 +1732,7 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	animation_hbox->add_child(animation_stop_button);
 	animation_stop_button->set_flat(true);
 	animation_stop_button->set_accessibility_name(TTRC("Stop"));
-	animation_stop_button->set_focus_mode(Control::FOCUS_NONE);
+	animation_stop_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	animation_stop_button->set_tooltip_text(TTR("Selected Animation Stop"));
 	animation_stop_button->connect(SceneStringName(pressed), callable_mp(this, &SceneImportSettingsDialog::_stop_current_animation));
 
@@ -1743,7 +1743,7 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	animation_slider->set_max(1.0);
 	animation_slider->set_step(1.0 / 100.0);
 	animation_slider->set_value_no_signal(0.0);
-	animation_slider->set_focus_mode(Control::FOCUS_NONE);
+	animation_slider->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	animation_slider->set_accessibility_name(TTRC("Animation"));
 	animation_slider->connect(SceneStringName(value_changed), callable_mp(this, &SceneImportSettingsDialog::_animation_slider_value_changed));
 
@@ -1751,7 +1751,7 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	animation_hbox->add_child(animation_toggle_skeleton_visibility);
 	animation_toggle_skeleton_visibility->set_toggle_mode(true);
 	animation_toggle_skeleton_visibility->set_theme_type_variation("FlatButton");
-	animation_toggle_skeleton_visibility->set_focus_mode(Control::FOCUS_NONE);
+	animation_toggle_skeleton_visibility->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	animation_toggle_skeleton_visibility->set_tooltip_text(TTR("Toggle Animation Skeleton Visibility"));
 	animation_toggle_skeleton_visibility->set_accessibility_name(TTRC("Skeleton Visibility"));
 

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -722,7 +722,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	resource_new_button->set_accessibility_name(TTRC("New Resource"));
 	general_options_hb->add_child(resource_new_button);
 	resource_new_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_new_resource));
-	resource_new_button->set_focus_mode(Control::FOCUS_NONE);
+	resource_new_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 
 	resource_load_button = memnew(Button);
 	resource_load_button->set_theme_type_variation("FlatMenuButton");
@@ -730,7 +730,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	resource_load_button->set_accessibility_name(TTRC("Load Resource"));
 	general_options_hb->add_child(resource_load_button);
 	resource_load_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_open_resource_selector));
-	resource_load_button->set_focus_mode(Control::FOCUS_NONE);
+	resource_load_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 
 	resource_save_button = memnew(MenuButton);
 	resource_save_button->set_flat(false);
@@ -741,7 +741,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	resource_save_button->get_popup()->add_item(TTRC("Save"), RESOURCE_SAVE);
 	resource_save_button->get_popup()->add_item(TTRC("Save As..."), RESOURCE_SAVE_AS);
 	resource_save_button->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_menu_option));
-	resource_save_button->set_focus_mode(Control::FOCUS_NONE);
+	resource_save_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	resource_save_button->set_disabled(true);
 
 	resource_extra_button = memnew(MenuButton);

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -174,7 +174,7 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 			if (!read_only) {
 				Button *delete_button = memnew(Button);
 				delete_button->set_flat(true);
-				delete_button->set_focus_mode(FOCUS_NONE);
+				delete_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 				delete_button->set_button_icon(get_editor_theme_icon(SNAME("Close")));
 				delete_button->set_accessibility_name(TTRC("Delete"));
 				delete_button->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendTreeEditor::_delete_node_request).bind(E), CONNECT_DEFERRED);

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -99,7 +99,7 @@ void AnimationTreeEditor::_update_path() {
 	b->set_toggle_mode(true);
 	b->set_button_group(group);
 	b->set_pressed(true);
-	b->set_focus_mode(FOCUS_NONE);
+	b->set_focus_mode(FOCUS_ACCESSIBILITY);
 	b->connect(SceneStringName(pressed), callable_mp(this, &AnimationTreeEditor::_path_button_pressed).bind(-1));
 	path_hb->add_child(b);
 	for (int i = 0; i < button_path.size(); i++) {
@@ -110,7 +110,7 @@ void AnimationTreeEditor::_update_path() {
 		b->set_button_group(group);
 		path_hb->add_child(b);
 		b->set_pressed(true);
-		b->set_focus_mode(FOCUS_NONE);
+		b->set_focus_mode(FOCUS_ACCESSIBILITY);
 		b->connect(SceneStringName(pressed), callable_mp(this, &AnimationTreeEditor::_path_button_pressed).bind(i));
 	}
 }

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1152,7 +1152,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 		first->connect(SceneStringName(pressed), callable_mp(this, &EditorAssetLibrary::_search).bind(0));
 	} else {
 		first->set_disabled(true);
-		first->set_focus_mode(Control::FOCUS_NONE);
+		first->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	}
 	hbc->add_child(first);
 
@@ -1163,7 +1163,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 		prev->connect(SceneStringName(pressed), callable_mp(this, &EditorAssetLibrary::_search).bind(p_page - 1));
 	} else {
 		prev->set_disabled(true);
-		prev->set_focus_mode(Control::FOCUS_NONE);
+		prev->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	}
 	hbc->add_child(prev);
 	hbc->add_child(memnew(VSeparator));
@@ -1175,7 +1175,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 		current->set_theme_type_variation("PanelBackgroundButton");
 		if (i == p_page) {
 			current->set_disabled(true);
-			current->set_focus_mode(Control::FOCUS_NONE);
+			current->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 		} else {
 			current->connect(SceneStringName(pressed), callable_mp(this, &EditorAssetLibrary::_search).bind(i));
 		}
@@ -1189,7 +1189,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 		next->connect(SceneStringName(pressed), callable_mp(this, &EditorAssetLibrary::_search).bind(p_page + 1));
 	} else {
 		next->set_disabled(true);
-		next->set_focus_mode(Control::FOCUS_NONE);
+		next->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	}
 	hbc->add_child(memnew(VSeparator));
 	hbc->add_child(next);
@@ -1201,7 +1201,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 		last->connect(SceneStringName(pressed), callable_mp(this, &EditorAssetLibrary::_search).bind(p_page_count - 1));
 	} else {
 		last->set_disabled(true);
-		last->set_focus_mode(Control::FOCUS_NONE);
+		last->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	}
 	hbc->add_child(last);
 

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -242,7 +242,7 @@ AudioStreamEditor::AudioStreamEditor() {
 	_play_button = memnew(Button);
 	hbox->add_child(_play_button);
 	_play_button->set_flat(true);
-	_play_button->set_focus_mode(Control::FOCUS_NONE);
+	_play_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	_play_button->connect(SceneStringName(pressed), callable_mp(this, &AudioStreamEditor::_play));
 	_play_button->set_shortcut(ED_SHORTCUT("audio_stream_editor/audio_preview_play_pause", TTRC("Audio Preview Play/Pause"), Key::SPACE));
 	_play_button->set_accessibility_name(TTRC("Play"));
@@ -250,7 +250,7 @@ AudioStreamEditor::AudioStreamEditor() {
 	_stop_button = memnew(Button);
 	hbox->add_child(_stop_button);
 	_stop_button->set_flat(true);
-	_stop_button->set_focus_mode(Control::FOCUS_NONE);
+	_stop_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	_stop_button->connect(SceneStringName(pressed), callable_mp(this, &AudioStreamEditor::_stop));
 	_stop_button->set_accessibility_name(TTRC("Stop"));
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5714,7 +5714,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	key_loc_button->set_theme_type_variation(SceneStringName(FlatButton));
 	key_loc_button->set_toggle_mode(true);
 	key_loc_button->set_pressed(true);
-	key_loc_button->set_focus_mode(FOCUS_NONE);
+	key_loc_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	key_loc_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_popup_callback).bind(ANIM_INSERT_POS));
 	key_loc_button->set_tooltip_text(TTRC("Translation mask for inserting keys."));
 	key_loc_button->set_accessibility_name(TTRC("Translation Mask"));
@@ -5724,7 +5724,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	key_rot_button->set_theme_type_variation(SceneStringName(FlatButton));
 	key_rot_button->set_toggle_mode(true);
 	key_rot_button->set_pressed(true);
-	key_rot_button->set_focus_mode(FOCUS_NONE);
+	key_rot_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	key_rot_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_popup_callback).bind(ANIM_INSERT_ROT));
 	key_rot_button->set_tooltip_text(TTRC("Rotation mask for inserting keys."));
 	key_rot_button->set_accessibility_name(TTRC("Rotation Mask"));
@@ -5733,7 +5733,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	key_scale_button = memnew(Button);
 	key_scale_button->set_theme_type_variation(SceneStringName(FlatButton));
 	key_scale_button->set_toggle_mode(true);
-	key_scale_button->set_focus_mode(FOCUS_NONE);
+	key_scale_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	key_scale_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_popup_callback).bind(ANIM_INSERT_SCALE));
 	key_scale_button->set_tooltip_text(TTRC("Scale mask for inserting keys."));
 	key_scale_button->set_accessibility_name(TTRC("Scale Mask"));
@@ -5741,7 +5741,7 @@ CanvasItemEditor::CanvasItemEditor() {
 
 	key_insert_button = memnew(Button);
 	key_insert_button->set_theme_type_variation(SceneStringName(FlatButton));
-	key_insert_button->set_focus_mode(FOCUS_NONE);
+	key_insert_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	key_insert_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_popup_callback).bind(ANIM_INSERT_KEY));
 	key_insert_button->set_tooltip_text(TTRC("Insert keys (based on mask)."));
 	key_insert_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/anim_insert_key", TTRC("Insert Key"), Key::INSERT));
@@ -5752,7 +5752,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	key_auto_insert_button = memnew(Button);
 	key_auto_insert_button->set_theme_type_variation(SceneStringName(FlatButton));
 	key_auto_insert_button->set_toggle_mode(true);
-	key_auto_insert_button->set_focus_mode(FOCUS_NONE);
+	key_auto_insert_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	key_auto_insert_button->set_tooltip_text(TTRC("Auto insert keys when objects are translated, rotated or scaled (based on mask).\nKeys are only added to existing tracks, no new tracks will be created.\nKeys must be inserted manually for the first time."));
 	key_auto_insert_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/anim_auto_insert_key", TTRC("Auto Insert Key")));
 	key_auto_insert_button->set_accessibility_name(TTRC("Auto Insert Keys"));

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -720,7 +720,7 @@ Path2DEditor::Path2DEditor() {
 	curve_edit->set_theme_type_variation(SceneStringName(FlatButton));
 	curve_edit->set_toggle_mode(true);
 	curve_edit->set_pressed(true);
-	curve_edit->set_focus_mode(Control::FOCUS_NONE);
+	curve_edit->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	curve_edit->set_tooltip_text(TTR("Select Points") + "\n" + TTR("Shift+Drag: Select Control Points") + "\n" + keycode_get_string((Key)KeyModifierMask::CMD_OR_CTRL) + TTR("Click: Add Point") + "\n" + TTR("Left Click: Split Segment (in curve)") + "\n" + TTR("Right Click: Delete Point"));
 	curve_edit->set_accessibility_name(TTRC("Select Points"));
 	curve_edit->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_EDIT));
@@ -729,7 +729,7 @@ Path2DEditor::Path2DEditor() {
 	curve_edit_curve = memnew(Button);
 	curve_edit_curve->set_theme_type_variation(SceneStringName(FlatButton));
 	curve_edit_curve->set_toggle_mode(true);
-	curve_edit_curve->set_focus_mode(Control::FOCUS_NONE);
+	curve_edit_curve->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	curve_edit_curve->set_tooltip_text(TTR("Select Control Points (Shift+Drag)"));
 	curve_edit_curve->set_accessibility_name(TTRC("Select Control Points"));
 	curve_edit_curve->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_EDIT_CURVE));
@@ -738,7 +738,7 @@ Path2DEditor::Path2DEditor() {
 	curve_create = memnew(Button);
 	curve_create->set_theme_type_variation(SceneStringName(FlatButton));
 	curve_create->set_toggle_mode(true);
-	curve_create->set_focus_mode(Control::FOCUS_NONE);
+	curve_create->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	curve_create->set_tooltip_text(TTR("Add Point (in empty space)") + "\n" + TTR("Right Click: Delete Point"));
 	curve_create->set_accessibility_name(TTRC("Add Point"));
 	curve_create->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_CREATE));
@@ -747,7 +747,7 @@ Path2DEditor::Path2DEditor() {
 	curve_del = memnew(Button);
 	curve_del->set_theme_type_variation(SceneStringName(FlatButton));
 	curve_del->set_toggle_mode(true);
-	curve_del->set_focus_mode(Control::FOCUS_NONE);
+	curve_del->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	curve_del->set_tooltip_text(TTR("Delete Point"));
 	curve_del->set_accessibility_name(TTRC("Delete Point"));
 	curve_del->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_DELETE));
@@ -755,7 +755,7 @@ Path2DEditor::Path2DEditor() {
 
 	curve_close = memnew(Button);
 	curve_close->set_theme_type_variation(SceneStringName(FlatButton));
-	curve_close->set_focus_mode(Control::FOCUS_NONE);
+	curve_close->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	curve_close->set_tooltip_text(TTR("Close Curve"));
 	curve_close->set_accessibility_name(TTRC("Close Curve"));
 	curve_close->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_CLOSE));
@@ -763,7 +763,7 @@ Path2DEditor::Path2DEditor() {
 
 	curve_clear_points = memnew(Button);
 	curve_clear_points->set_theme_type_variation(SceneStringName(FlatButton));
-	curve_clear_points->set_focus_mode(Control::FOCUS_NONE);
+	curve_clear_points->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	curve_clear_points->set_tooltip_text(TTR("Clear Points"));
 	curve_clear_points->set_accessibility_name(TTRC("Clear Points"));
 	curve_clear_points->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_confirm_clear_points));

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -917,7 +917,7 @@ Path3DEditorPlugin::Path3DEditorPlugin() {
 	curve_edit = memnew(Button);
 	curve_edit->set_theme_type_variation(SceneStringName(FlatButton));
 	curve_edit->set_toggle_mode(true);
-	curve_edit->set_focus_mode(Control::FOCUS_NONE);
+	curve_edit->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	curve_edit->set_tooltip_text(TTR("Select Points") + "\n" + TTR("Shift+Click: Select multiple Points") + "\n" + keycode_get_string((Key)KeyModifierMask::CMD_OR_CTRL) + TTR("Click: Add Point") + "\n" + TTR("Right Click: Delete Point"));
 	curve_edit->set_accessibility_name(TTRC("Select Points"));
 	toolbar->add_child(curve_edit);
@@ -926,7 +926,7 @@ Path3DEditorPlugin::Path3DEditorPlugin() {
 	curve_edit_curve = memnew(Button);
 	curve_edit_curve->set_theme_type_variation(SceneStringName(FlatButton));
 	curve_edit_curve->set_toggle_mode(true);
-	curve_edit_curve->set_focus_mode(Control::FOCUS_NONE);
+	curve_edit_curve->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	curve_edit_curve->set_tooltip_text(TTR("Select Control Points") + "\n" + TTR("Shift+Click: Drag out Control Points"));
 	curve_edit_curve->set_accessibility_name(TTRC("Select Control Points"));
 	toolbar->add_child(curve_edit_curve);
@@ -935,7 +935,7 @@ Path3DEditorPlugin::Path3DEditorPlugin() {
 	curve_edit_tilt = memnew(Button);
 	curve_edit_tilt->set_theme_type_variation(SceneStringName(FlatButton));
 	curve_edit_tilt->set_toggle_mode(true);
-	curve_edit_tilt->set_focus_mode(Control::FOCUS_NONE);
+	curve_edit_tilt->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	curve_edit_tilt->set_tooltip_text(TTR("Select Tilt Handles"));
 	curve_edit_tilt->set_accessibility_name(TTRC("Select Tilt Handles"));
 	toolbar->add_child(curve_edit_tilt);
@@ -944,7 +944,7 @@ Path3DEditorPlugin::Path3DEditorPlugin() {
 	curve_create = memnew(Button);
 	curve_create->set_theme_type_variation(SceneStringName(FlatButton));
 	curve_create->set_toggle_mode(true);
-	curve_create->set_focus_mode(Control::FOCUS_NONE);
+	curve_create->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	curve_create->set_tooltip_text(TTR("Add Point (in empty space)") + "\n" + TTR("Split Segment (in curve)"));
 	curve_create->set_accessibility_name(TTRC("Add Point"));
 	toolbar->add_child(curve_create);
@@ -953,7 +953,7 @@ Path3DEditorPlugin::Path3DEditorPlugin() {
 	curve_del = memnew(Button);
 	curve_del->set_theme_type_variation(SceneStringName(FlatButton));
 	curve_del->set_toggle_mode(true);
-	curve_del->set_focus_mode(Control::FOCUS_NONE);
+	curve_del->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	curve_del->set_tooltip_text(TTR("Delete Point"));
 	curve_del->set_accessibility_name(TTRC("Delete Point"));
 	toolbar->add_child(curve_del);
@@ -961,7 +961,7 @@ Path3DEditorPlugin::Path3DEditorPlugin() {
 
 	curve_closed = memnew(Button);
 	curve_closed->set_theme_type_variation(SceneStringName(FlatButton));
-	curve_closed->set_focus_mode(Control::FOCUS_NONE);
+	curve_closed->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	curve_closed->set_tooltip_text(TTR("Close Curve"));
 	curve_closed->set_accessibility_name(TTRC("Close Curve"));
 	toolbar->add_child(curve_closed);
@@ -969,7 +969,7 @@ Path3DEditorPlugin::Path3DEditorPlugin() {
 
 	curve_clear_points = memnew(Button);
 	curve_clear_points->set_theme_type_variation(SceneStringName(FlatButton));
-	curve_clear_points->set_focus_mode(Control::FOCUS_NONE);
+	curve_clear_points->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	curve_clear_points->set_tooltip_text(TTR("Clear Points"));
 	curve_clear_points->set_accessibility_name(TTRC("Clear Points"));
 	curve_clear_points->connect(SceneStringName(pressed), callable_mp(this, &Path3DEditorPlugin::_confirm_clear_points));

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1302,7 +1302,7 @@ Polygon2DEditor::Polygon2DEditor() {
 		action_buttons[i]->set_toggle_mode(true);
 		toolbar->add_child(action_buttons[i]);
 		action_buttons[i]->connect(SceneStringName(pressed), callable_mp(this, &Polygon2DEditor::_set_action).bind(i));
-		action_buttons[i]->set_focus_mode(FOCUS_NONE);
+		action_buttons[i]->set_focus_mode(FOCUS_ACCESSIBILITY);
 	}
 
 	action_buttons[ACTION_CREATE]->set_tooltip_text(TTR("Create Polygon"));
@@ -1392,7 +1392,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	b_snap_enable->set_theme_type_variation(SceneStringName(FlatButton));
 	toolbar->add_child(b_snap_enable);
 	b_snap_enable->set_text(TTR("Snap"));
-	b_snap_enable->set_focus_mode(FOCUS_NONE);
+	b_snap_enable->set_focus_mode(FOCUS_ACCESSIBILITY);
 	b_snap_enable->set_toggle_mode(true);
 	b_snap_enable->set_pressed(use_snap);
 	b_snap_enable->set_tooltip_text(TTR("Enable Snap"));
@@ -1402,7 +1402,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	b_snap_grid->set_theme_type_variation(SceneStringName(FlatButton));
 	toolbar->add_child(b_snap_grid);
 	b_snap_grid->set_text(TTR("Grid"));
-	b_snap_grid->set_focus_mode(FOCUS_NONE);
+	b_snap_grid->set_focus_mode(FOCUS_ACCESSIBILITY);
 	b_snap_grid->set_toggle_mode(true);
 	b_snap_grid->set_pressed(snap_show_grid);
 	b_snap_grid->set_tooltip_text(TTR("Show Grid"));

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -275,7 +275,7 @@ ShaderFileEditor::ShaderFileEditor() {
 	for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
 		Button *button = memnew(Button(stage_str[i]));
 		button->set_toggle_mode(true);
-		button->set_focus_mode(FOCUS_NONE);
+		button->set_focus_mode(FOCUS_ACCESSIBILITY);
 		stage_hb->add_child(button);
 		stages[i] = button;
 		button->set_button_group(bg);

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -1024,7 +1024,7 @@ void Skeleton3DEditor::create_editors() {
 	topmenu_bar->add_child(edit_mode_button);
 	edit_mode_button->set_theme_type_variation(SceneStringName(FlatButton));
 	edit_mode_button->set_toggle_mode(true);
-	edit_mode_button->set_focus_mode(FOCUS_NONE);
+	edit_mode_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	edit_mode_button->set_tooltip_text(TTR("Edit Mode\nShow buttons on joints."));
 	edit_mode_button->set_accessibility_name(TTRC("Edit Mode"));
 	edit_mode_button->connect(SceneStringName(toggled), callable_mp(this, &Skeleton3DEditor::edit_mode_toggled));
@@ -1046,7 +1046,7 @@ void Skeleton3DEditor::create_editors() {
 	key_loc_button->set_theme_type_variation(SceneStringName(FlatButton));
 	key_loc_button->set_toggle_mode(true);
 	key_loc_button->set_pressed(false);
-	key_loc_button->set_focus_mode(FOCUS_NONE);
+	key_loc_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	key_loc_button->set_tooltip_text(TTR("Translation mask for inserting keys."));
 	key_loc_button->set_accessibility_name(TTRC("Translation Mask"));
 	animation_hb->add_child(key_loc_button);
@@ -1055,7 +1055,7 @@ void Skeleton3DEditor::create_editors() {
 	key_rot_button->set_theme_type_variation(SceneStringName(FlatButton));
 	key_rot_button->set_toggle_mode(true);
 	key_rot_button->set_pressed(true);
-	key_rot_button->set_focus_mode(FOCUS_NONE);
+	key_rot_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	key_rot_button->set_tooltip_text(TTR("Rotation mask for inserting keys."));
 	key_rot_button->set_accessibility_name(TTRC("Rotation Mask"));
 	animation_hb->add_child(key_rot_button);
@@ -1064,14 +1064,14 @@ void Skeleton3DEditor::create_editors() {
 	key_scale_button->set_theme_type_variation(SceneStringName(FlatButton));
 	key_scale_button->set_toggle_mode(true);
 	key_scale_button->set_pressed(false);
-	key_scale_button->set_focus_mode(FOCUS_NONE);
+	key_scale_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	key_scale_button->set_tooltip_text(TTR("Scale mask for inserting keys."));
 	key_scale_button->set_accessibility_name(TTRC("Scale Mask"));
 	animation_hb->add_child(key_scale_button);
 
 	key_insert_button = memnew(Button);
 	key_insert_button->set_theme_type_variation(SceneStringName(FlatButton));
-	key_insert_button->set_focus_mode(FOCUS_NONE);
+	key_insert_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	key_insert_button->connect(SceneStringName(pressed), callable_mp(this, &Skeleton3DEditor::insert_keys).bind(false));
 	key_insert_button->set_tooltip_text(TTRC("Insert key (based on mask) for bones with an existing track."));
 	key_insert_button->set_shortcut(ED_SHORTCUT("skeleton_3d_editor/insert_key_to_existing_tracks", TTRC("Insert Key (Existing Tracks)"), Key::INSERT));
@@ -1080,7 +1080,7 @@ void Skeleton3DEditor::create_editors() {
 
 	key_insert_all_button = memnew(Button);
 	key_insert_all_button->set_theme_type_variation(SceneStringName(FlatButton));
-	key_insert_all_button->set_focus_mode(FOCUS_NONE);
+	key_insert_all_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	key_insert_all_button->connect(SceneStringName(pressed), callable_mp(this, &Skeleton3DEditor::insert_keys).bind(true));
 	key_insert_all_button->set_tooltip_text(TTRC("Insert key (based on mask) for all bones."));
 	key_insert_all_button->set_accessibility_name(TTRC("Insert Key for All Bones"));

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -2371,7 +2371,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 
 	split_sheet_zoom_out = memnew(Button);
 	split_sheet_zoom_out->set_theme_type_variation(SceneStringName(FlatButton));
-	split_sheet_zoom_out->set_focus_mode(FOCUS_NONE);
+	split_sheet_zoom_out->set_focus_mode(FOCUS_ACCESSIBILITY);
 	split_sheet_zoom_out->set_tooltip_text(TTR("Zoom Out"));
 	split_sheet_zoom_out->set_accessibility_name(TTRC("Zoom Out"));
 	split_sheet_zoom_out->connect(SceneStringName(pressed), callable_mp(this, &SpriteFramesEditor::_sheet_zoom_out));
@@ -2379,7 +2379,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 
 	split_sheet_zoom_reset = memnew(Button);
 	split_sheet_zoom_reset->set_theme_type_variation(SceneStringName(FlatButton));
-	split_sheet_zoom_reset->set_focus_mode(FOCUS_NONE);
+	split_sheet_zoom_reset->set_focus_mode(FOCUS_ACCESSIBILITY);
 	split_sheet_zoom_reset->set_tooltip_text(TTR("Zoom Reset"));
 	split_sheet_zoom_reset->set_accessibility_name(TTRC("Reset Zoom"));
 	split_sheet_zoom_reset->connect(SceneStringName(pressed), callable_mp(this, &SpriteFramesEditor::_sheet_zoom_reset));
@@ -2387,7 +2387,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 
 	split_sheet_zoom_in = memnew(Button);
 	split_sheet_zoom_in->set_theme_type_variation(SceneStringName(FlatButton));
-	split_sheet_zoom_in->set_focus_mode(FOCUS_NONE);
+	split_sheet_zoom_in->set_focus_mode(FOCUS_ACCESSIBILITY);
 	split_sheet_zoom_in->set_tooltip_text(TTR("Zoom In"));
 	split_sheet_zoom_in->set_accessibility_name(TTRC("Zoom In"));
 	split_sheet_zoom_in->connect(SceneStringName(pressed), callable_mp(this, &SpriteFramesEditor::_sheet_zoom_in));

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -143,7 +143,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor) {
 	but_insert_name = memnew(Button);
 	but_insert_name->set_text("NAME");
 	but_insert_name->set_tooltip_text(String("${NAME}\n") + TTR("Node name."));
-	but_insert_name->set_focus_mode(Control::FOCUS_NONE);
+	but_insert_name->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	but_insert_name->connect(SceneStringName(pressed), callable_mp(this, &RenameDialog::_insert_text).bind("${NAME}"));
 	but_insert_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_name);
@@ -153,7 +153,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor) {
 	but_insert_parent = memnew(Button);
 	but_insert_parent->set_text("PARENT");
 	but_insert_parent->set_tooltip_text(String("${PARENT}\n") + TTR("Node's parent name, if available."));
-	but_insert_parent->set_focus_mode(Control::FOCUS_NONE);
+	but_insert_parent->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	but_insert_parent->connect(SceneStringName(pressed), callable_mp(this, &RenameDialog::_insert_text).bind("${PARENT}"));
 	but_insert_parent->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_parent);
@@ -163,7 +163,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor) {
 	but_insert_type = memnew(Button);
 	but_insert_type->set_text("TYPE");
 	but_insert_type->set_tooltip_text(String("${TYPE}\n") + TTR("Node type."));
-	but_insert_type->set_focus_mode(Control::FOCUS_NONE);
+	but_insert_type->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	but_insert_type->connect(SceneStringName(pressed), callable_mp(this, &RenameDialog::_insert_text).bind("${TYPE}"));
 	but_insert_type->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_type);
@@ -173,7 +173,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor) {
 	but_insert_scene = memnew(Button);
 	but_insert_scene->set_text("SCENE");
 	but_insert_scene->set_tooltip_text(String("${SCENE}\n") + TTR("Current scene name."));
-	but_insert_scene->set_focus_mode(Control::FOCUS_NONE);
+	but_insert_scene->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	but_insert_scene->connect(SceneStringName(pressed), callable_mp(this, &RenameDialog::_insert_text).bind("${SCENE}"));
 	but_insert_scene->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_scene);
@@ -183,7 +183,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor) {
 	but_insert_root = memnew(Button);
 	but_insert_root->set_text("ROOT");
 	but_insert_root->set_tooltip_text(String("${ROOT}\n") + TTR("Root node name."));
-	but_insert_root->set_focus_mode(Control::FOCUS_NONE);
+	but_insert_root->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	but_insert_root->connect(SceneStringName(pressed), callable_mp(this, &RenameDialog::_insert_text).bind("${ROOT}"));
 	but_insert_root->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_root);
@@ -193,7 +193,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor) {
 	but_insert_count = memnew(Button);
 	but_insert_count->set_text("COUNTER");
 	but_insert_count->set_tooltip_text(String("${COUNTER}\n") + TTR("Sequential integer counter.\nCompare counter options."));
-	but_insert_count->set_focus_mode(Control::FOCUS_NONE);
+	but_insert_count->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	but_insert_count->connect(SceneStringName(pressed), callable_mp(this, &RenameDialog::_insert_text).bind("${COUNTER}"));
 	but_insert_count->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_count);
@@ -359,12 +359,12 @@ void RenameDialog::_update_substitute() {
 	but_insert_count->set_disabled(!is_main_field);
 
 	// The focus mode seems to be reset when disabling/re-enabling
-	but_insert_name->set_focus_mode(Control::FOCUS_NONE);
-	but_insert_parent->set_focus_mode(Control::FOCUS_NONE);
-	but_insert_type->set_focus_mode(Control::FOCUS_NONE);
-	but_insert_scene->set_focus_mode(Control::FOCUS_NONE);
-	but_insert_root->set_focus_mode(Control::FOCUS_NONE);
-	but_insert_count->set_focus_mode(Control::FOCUS_NONE);
+	but_insert_name->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	but_insert_parent->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	but_insert_type->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	but_insert_scene->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	but_insert_root->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	but_insert_count->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 }
 
 void RenameDialog::_post_popup() {

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -532,7 +532,7 @@ void ColorPicker::create_slider(GridContainer *gc, int idx) {
 
 	HSlider *slider = memnew(HSlider);
 	slider->set_v_size_flags(SIZE_SHRINK_CENTER);
-	slider->set_focus_mode(FOCUS_NONE);
+	slider->set_focus_mode(FOCUS_ACCESSIBILITY);
 	gc->add_child(slider);
 
 	SpinBox *val = memnew(SpinBox);

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -3252,7 +3252,7 @@ GraphEdit::GraphEdit() {
 	toggle_grid_button->set_pressed(true);
 	toggle_grid_button->set_tooltip_text(ETR("Toggle the visual grid."));
 	toggle_grid_button->set_accessibility_name(ETR("Grid"));
-	toggle_grid_button->set_focus_mode(FOCUS_NONE);
+	toggle_grid_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	menu_hbox->add_child(toggle_grid_button);
 	toggle_grid_button->connect(SceneStringName(pressed), callable_mp(this, &GraphEdit::_show_grid_toggled));
 
@@ -3263,7 +3263,7 @@ GraphEdit::GraphEdit() {
 	toggle_snapping_button->set_tooltip_text(ETR("Toggle snapping to the grid."));
 	toggle_snapping_button->set_accessibility_name(ETR("Snap to Grid"));
 	toggle_snapping_button->set_pressed(snapping_enabled);
-	toggle_snapping_button->set_focus_mode(FOCUS_NONE);
+	toggle_snapping_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	menu_hbox->add_child(toggle_snapping_button);
 	toggle_snapping_button->connect(SceneStringName(pressed), callable_mp(this, &GraphEdit::_snapping_toggled));
 
@@ -3287,7 +3287,7 @@ GraphEdit::GraphEdit() {
 	minimap_button->set_tooltip_text(ETR("Toggle the graph minimap."));
 	minimap_button->set_accessibility_name(ETR("Minimap"));
 	minimap_button->set_pressed(show_grid);
-	minimap_button->set_focus_mode(FOCUS_NONE);
+	minimap_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	menu_hbox->add_child(minimap_button);
 	minimap_button->connect(SceneStringName(pressed), callable_mp(this, &GraphEdit::_minimap_toggled));
 
@@ -3296,7 +3296,7 @@ GraphEdit::GraphEdit() {
 	arrange_button->set_visible(show_arrange_button);
 	arrange_button->set_accessibility_name(ETR("Auto Arrange"));
 	arrange_button->connect(SceneStringName(pressed), callable_mp(this, &GraphEdit::arrange_nodes));
-	arrange_button->set_focus_mode(FOCUS_NONE);
+	arrange_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	menu_hbox->add_child(arrange_button);
 	arrange_button->set_tooltip_text(ETR("Automatically arrange selected nodes."));
 


### PR DESCRIPTION
Changes a bunch of editor buttons focus mode from `FOCUS_NONE` to `FOCUS_ACCESSIBILITY` to make them usable with screen reader.