### PR TITLE
[3.x] FTI - Reduce `VisualInstance` xform notifications (reverted)

### DIFF
--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -168,6 +168,7 @@ void Camera::_update_camera() {
 
 void Camera::_physics_interpolated_changed() {
 	_update_process_mode();
+	Spatial::_physics_interpolated_changed();
 }
 
 void Camera::set_desired_process_modes(bool p_process_internal, bool p_physics_process_internal) {

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -943,8 +943,18 @@ Vector3 Spatial::to_global(Vector3 p_local) const {
 	return get_global_transform().xform(p_local);
 }
 
+void Spatial::_physics_interpolated_changed() {
+	data.notify_transform = data.notify_transform_requested || (data.notify_transform_when_fti_off && !is_physics_interpolated_and_enabled());
+}
+
+void Spatial::_set_notify_transform_when_fti_off(bool p_enable) {
+	data.notify_transform_when_fti_off = p_enable;
+	data.notify_transform = data.notify_transform_requested || (data.notify_transform_when_fti_off && !is_physics_interpolated_and_enabled());
+}
+
 void Spatial::set_notify_transform(bool p_enable) {
-	data.notify_transform = p_enable;
+	data.notify_transform_requested = p_enable;
+	data.notify_transform = data.notify_transform_requested || (data.notify_transform_when_fti_off && !is_physics_interpolated_and_enabled());
 }
 
 bool Spatial::is_transform_notification_enabled() const {
@@ -1144,6 +1154,9 @@ Spatial::Spatial() :
 #endif
 	data.notify_local_transform = false;
 	data.notify_transform = false;
+	data.notify_transform_requested = false;
+	data.notify_transform_when_fti_off = false;
+
 	data.parent = nullptr;
 	data.C = nullptr;
 }

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -120,6 +120,9 @@ private:
 		bool notify_local_transform : 1;
 		bool notify_transform : 1;
 
+		bool notify_transform_requested : 1;
+		bool notify_transform_when_fti_off : 1;
+
 		bool visible : 1;
 		bool disable_scale : 1;
 
@@ -173,6 +176,9 @@ protected:
 	// or requires an update in terms of interpolation
 	// (e.g. changing Camera zoom even if position hasn't changed).
 	void fti_notify_node_changed(bool p_transform_changed = true);
+
+	void _set_notify_transform_when_fti_off(bool p_enable);
+	virtual void _physics_interpolated_changed();
 
 	// Opportunity after FTI to update the servers
 	// with global_transform_interpolated,

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -103,7 +103,9 @@ void VisualInstance::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			// ToDo : Can we turn off notify transform for physics interpolated cases?
+			// NOTIFICATION normally turned off for physics interpolated cases (via
+			// `notify_transform_when_fti_off`), however derived classes can still turn this back on,
+			// so always wrap with is_physics_interpolation_enabled().
 			if (_is_vi_visible() && !(is_inside_tree() && get_tree()->is_physics_interpolation_enabled()) && !_is_using_identity_transform()) {
 				// Physics interpolation global off, always send.
 				VisualServer::get_singleton()->instance_set_transform(instance, get_global_transform());
@@ -211,7 +213,7 @@ VisualInstance::VisualInstance() {
 	layers = 1;
 	sorting_offset = 0.0f;
 	sorting_use_aabb_center = true;
-	set_notify_transform(true);
+	_set_notify_transform_when_fti_off(true);
 }
 
 VisualInstance::~VisualInstance() {


### PR DESCRIPTION
`Spatial` transforms are already not sent to the `VisualServer` when physics interpolation is active, so there is actually no need for them to have `NOTIFICATION_TRANSFORM_CHANGED` called.
This PR manages the `notify_transform` state while respecting calls to `set_notify_transform()` in derived classes.

## Notes
* Small optimization from #105463 I left for a separate PR because of the risk of regressions. So far it seems fine in testing.
* Has to manage a separate request to be notified by derived classes, it does this by maintaining two state bools and calculating the actual `notify_transform` state from these when required.
* Also applicable in 4.x.
* I'm not absolutely sure how much _real world_ performance will be gained here, but needless notifications are always good to remove.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
