### PR TITLE
Expose a way to set a material's RID for custom Material types

### DIFF
--- a/doc/classes/Material.xml
+++ b/doc/classes/Material.xml
@@ -48,6 +48,13 @@
 				Only available when running in the editor. Opens a popup that visualizes the generated shader code, including all variants and internal shader code. See also [method Shader.inspect_native_shader_code].
 			</description>
 		</method>
+		<method name="set_material_rid" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="material" type="RID" />
+			<description>
+				Sets the [RenderingServer]'s material RID of this [Material].
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="next_pass" type="Material" setter="set_next_pass" getter="get_next_pass">

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -162,6 +162,7 @@ void Material::_bind_methods() {
 	ClassDB::set_method_flags(get_class_static(), _scs_create("inspect_native_shader_code"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 
 	ClassDB::bind_method(D_METHOD("create_placeholder"), &Material::create_placeholder);
+	ClassDB::bind_method(D_METHOD("set_material_rid", "material"), &Material::_set_material);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_priority", PROPERTY_HINT_RANGE, itos(RENDER_PRIORITY_MIN) + "," + itos(RENDER_PRIORITY_MAX) + ",1"), "set_render_priority", "get_render_priority");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "next_pass", PROPERTY_HINT_RESOURCE_TYPE, "Material"), "set_next_pass", "get_next_pass");


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/105575

The documentation for `Material` states that it is possible to create a custom material by extending it, but this is impossible without a way to set the `RID`. This PR exposes the method to do it.