### PR TITLE
Document `SceneTree.set_multiplayer()` should be called in `_enter_tree()`

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -234,6 +234,7 @@
 			<description>
 				Sets a custom [MultiplayerAPI] with the given [param root_path] (controlling also the relative subpaths), or override the default one if [param root_path] is empty.
 				[b]Note:[/b] No [MultiplayerAPI] must be configured for the subpath containing [param root_path], nested custom multiplayers are not allowed. I.e. if one is configured for [code]"/root/Foo"[/code] setting one for [code]"/root/Foo/Bar"[/code] will cause an error.
+				[b]Note:[/b] [method set_multiplayer] should be called [i]before[/i] the child nodes are ready at the given [param root_path]. If multiplayer nodes like [MultiplayerSpawner] or [MultiplayerSynchronizer] are added to the tree before the custom multiplayer API is set, they will not work.
 			</description>
 		</method>
 		<method name="unload_current_scene">


### PR DESCRIPTION
If it's called in `_ready()`, it will be too late as child nodes will already be set up by the time the custom multiplayer API is set.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/371#discussioncomment-12341458.
