### PR TITLE
Make documentation ignore undocumented private signals

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1512,15 +1512,27 @@ void EditorHelp::_update_doc() {
 			cd.signals.sort();
 		}
 
-		class_desc->add_newline();
-		class_desc->add_newline();
-
-		section_line.push_back(Pair<String, int>(TTR("Signals"), class_desc->get_paragraph_count() - 2));
-		_push_title_font();
-		class_desc->add_text(TTR("Signals"));
-		_pop_title_font();
+		bool header_added = false;
 
 		for (const DocData::MethodDoc &signal : cd.signals) {
+			// Ignore undocumented private.
+			const bool is_documented = signal.is_deprecated || signal.is_experimental || !signal.description.strip_edges().is_empty();
+			if (!is_documented && signal.name.begins_with("_")) {
+				continue;
+			}
+
+			if (!header_added) {
+				header_added = true;
+
+				class_desc->add_newline();
+				class_desc->add_newline();
+
+				section_line.push_back(Pair<String, int>(TTR("Signals"), class_desc->get_paragraph_count() - 2));
+				_push_title_font();
+				class_desc->add_text(TTR("Signals"));
+				_pop_title_font();
+			}
+
 			class_desc->add_newline();
 			class_desc->add_newline();
 


### PR DESCRIPTION
Currently, the automatically-generated documentation hides properties, methods, and constants that are "private" (ie underscore-prefixed) and "undocumented" (ie have no description, are deprecated, or are experimental).

However, signals that fulfill these conditions are still displayed.

This PR makes undocumented private signals no longer appear in auto-generated docs, matching the behavior of other member types.

### Convenience MRP

Example project showing each permutation of member type, public/private, and documented/undocumented.

Secondary-click the `DocTestClass` node and select "Open Documentation" from the context menu.

[Undocumented.zip](https://github.com/user-attachments/files/19872746/Undocumented.zip)