### PR TITLE
[Web] Add required exported functions and runtime methods for emscripten

### DIFF
--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -76,6 +76,11 @@ for ext in sys_env["JS_EXTERNS"]:
     sys_env["ENV"]["EMCC_CLOSURE_ARGS"] += " --externs " + ext.abspath
 sys_env["ENV"]["EMCC_CLOSURE_ARGS"] = sys_env["ENV"]["EMCC_CLOSURE_ARGS"].strip()
 
+if len(env["EXPORTED_FUNCTIONS"]):
+    sys_env.Append(LINKFLAGS=["-sEXPORTED_FUNCTIONS=" + repr(sorted(list(set(env["EXPORTED_FUNCTIONS"]))))])
+if len(env["EXPORTED_RUNTIME_METHODS"]):
+    sys_env.Append(LINKFLAGS=["-sEXPORTED_RUNTIME_METHODS=" + repr(sorted(list(set(env["EXPORTED_RUNTIME_METHODS"]))))])
+
 build = []
 build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm"]
 if env["dlink_enabled"]:


### PR DESCRIPTION
[As of Emscripten 4.0.7](https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#407---041525), `HEAPN` functions will not be exposed by default, and we need those to be.

So this PR includes these in the EXPORTED_RUNTIME_METHODS.

This PR also takes the time to clean up the way we did track which functions/runtime methods were exported.