### PR TITLE
Add missing `backward` flag to TRS3D & BlendShape Track's interpolation in the `AnimationMixer` for Nearest interpolation

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1262,15 +1262,15 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 							Quaternion rot;
 							if (!backward) {
 								if (Animation::is_greater_approx(prev_time, time)) {
-									Error err = a->try_position_track_interpolate(i, prev_time, &loc[0]);
+									Error err = a->try_position_track_interpolate(i, prev_time, &loc[0], backward);
 									if (err != OK) {
 										continue;
 									}
 									loc[0] = post_process_key_value(a, i, loc[0], t->object_id, t->bone_idx);
-									a->try_position_track_interpolate(i, end, &loc[1]);
+									a->try_position_track_interpolate(i, end, &loc[1], backward);
 									loc[1] = post_process_key_value(a, i, loc[1], t->object_id, t->bone_idx);
 
-									a->try_rotation_track_interpolate(rot_track, end, &rot);
+									a->try_rotation_track_interpolate(rot_track, end, &rot, backward);
 									rot = post_process_key_value(a, rot_track, rot, t->object_id, t->bone_idx);
 
 									root_motion_cache.loc += rot.xform_inv(loc[1] - loc[0]) * blend;
@@ -1278,30 +1278,30 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 								}
 							} else {
 								if (Animation::is_less_approx(prev_time, time)) {
-									Error err = a->try_position_track_interpolate(i, prev_time, &loc[0]);
+									Error err = a->try_position_track_interpolate(i, prev_time, &loc[0], backward);
 									if (err != OK) {
 										continue;
 									}
 									loc[0] = post_process_key_value(a, i, loc[0], t->object_id, t->bone_idx);
-									a->try_position_track_interpolate(i, start, &loc[1]);
+									a->try_position_track_interpolate(i, start, &loc[1], backward);
 									loc[1] = post_process_key_value(a, i, loc[1], t->object_id, t->bone_idx);
 
-									a->try_rotation_track_interpolate(rot_track, start, &rot);
+									a->try_rotation_track_interpolate(rot_track, start, &rot, backward);
 									rot = post_process_key_value(a, rot_track, rot, t->object_id, t->bone_idx);
 
 									root_motion_cache.loc += rot.xform_inv(loc[1] - loc[0]) * blend;
 									prev_time = end;
 								}
 							}
-							Error err = a->try_position_track_interpolate(i, prev_time, &loc[0]);
+							Error err = a->try_position_track_interpolate(i, prev_time, &loc[0], backward);
 							if (err != OK) {
 								continue;
 							}
 							loc[0] = post_process_key_value(a, i, loc[0], t->object_id, t->bone_idx);
-							a->try_position_track_interpolate(i, time, &loc[1]);
+							a->try_position_track_interpolate(i, time, &loc[1], backward);
 							loc[1] = post_process_key_value(a, i, loc[1], t->object_id, t->bone_idx);
 
-							a->try_rotation_track_interpolate(rot_track, time, &rot);
+							a->try_rotation_track_interpolate(rot_track, time, &rot, backward);
 							rot = post_process_key_value(a, rot_track, rot, t->object_id, t->bone_idx);
 
 							root_motion_cache.loc += rot.xform_inv(loc[1] - loc[0]) * blend;
@@ -1310,35 +1310,35 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 							Vector3 loc[2];
 							if (!backward) {
 								if (Animation::is_greater_approx(prev_time, time)) {
-									Error err = a->try_position_track_interpolate(i, prev_time, &loc[0]);
+									Error err = a->try_position_track_interpolate(i, prev_time, &loc[0], backward);
 									if (err != OK) {
 										continue;
 									}
 									loc[0] = post_process_key_value(a, i, loc[0], t->object_id, t->bone_idx);
-									a->try_position_track_interpolate(i, end, &loc[1]);
+									a->try_position_track_interpolate(i, end, &loc[1], backward);
 									loc[1] = post_process_key_value(a, i, loc[1], t->object_id, t->bone_idx);
 									root_motion_cache.loc += (loc[1] - loc[0]) * blend;
 									prev_time = start;
 								}
 							} else {
 								if (Animation::is_less_approx(prev_time, time)) {
-									Error err = a->try_position_track_interpolate(i, prev_time, &loc[0]);
+									Error err = a->try_position_track_interpolate(i, prev_time, &loc[0], backward);
 									if (err != OK) {
 										continue;
 									}
 									loc[0] = post_process_key_value(a, i, loc[0], t->object_id, t->bone_idx);
-									a->try_position_track_interpolate(i, start, &loc[1]);
+									a->try_position_track_interpolate(i, start, &loc[1], backward);
 									loc[1] = post_process_key_value(a, i, loc[1], t->object_id, t->bone_idx);
 									root_motion_cache.loc += (loc[1] - loc[0]) * blend;
 									prev_time = end;
 								}
 							}
-							Error err = a->try_position_track_interpolate(i, prev_time, &loc[0]);
+							Error err = a->try_position_track_interpolate(i, prev_time, &loc[0], backward);
 							if (err != OK) {
 								continue;
 							}
 							loc[0] = post_process_key_value(a, i, loc[0], t->object_id, t->bone_idx);
-							a->try_position_track_interpolate(i, time, &loc[1]);
+							a->try_position_track_interpolate(i, time, &loc[1], backward);
 							loc[1] = post_process_key_value(a, i, loc[1], t->object_id, t->bone_idx);
 							root_motion_cache.loc += (loc[1] - loc[0]) * blend;
 							prev_time = !backward ? start : end;
@@ -1346,7 +1346,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					}
 					{
 						Vector3 loc;
-						Error err = a->try_position_track_interpolate(i, time, &loc);
+						Error err = a->try_position_track_interpolate(i, time, &loc, backward);
 						if (err != OK) {
 							continue;
 						}
@@ -1399,42 +1399,42 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						Quaternion rot[2];
 						if (!backward) {
 							if (Animation::is_greater_approx(prev_time, time)) {
-								Error err = a->try_rotation_track_interpolate(i, prev_time, &rot[0]);
+								Error err = a->try_rotation_track_interpolate(i, prev_time, &rot[0], backward);
 								if (err != OK) {
 									continue;
 								}
 								rot[0] = post_process_key_value(a, i, rot[0], t->object_id, t->bone_idx);
-								a->try_rotation_track_interpolate(i, end, &rot[1]);
+								a->try_rotation_track_interpolate(i, end, &rot[1], backward);
 								rot[1] = post_process_key_value(a, i, rot[1], t->object_id, t->bone_idx);
 								root_motion_cache.rot = (root_motion_cache.rot * Quaternion().slerp(rot[0].inverse() * rot[1], blend)).normalized();
 								prev_time = start;
 							}
 						} else {
 							if (Animation::is_less_approx(prev_time, time)) {
-								Error err = a->try_rotation_track_interpolate(i, prev_time, &rot[0]);
+								Error err = a->try_rotation_track_interpolate(i, prev_time, &rot[0], backward);
 								if (err != OK) {
 									continue;
 								}
 								rot[0] = post_process_key_value(a, i, rot[0], t->object_id, t->bone_idx);
-								a->try_rotation_track_interpolate(i, start, &rot[1]);
+								a->try_rotation_track_interpolate(i, start, &rot[1], backward);
 								rot[1] = post_process_key_value(a, i, rot[1], t->object_id, t->bone_idx);
 								root_motion_cache.rot = (root_motion_cache.rot * Quaternion().slerp(rot[0].inverse() * rot[1], blend)).normalized();
 								prev_time = end;
 							}
 						}
-						Error err = a->try_rotation_track_interpolate(i, prev_time, &rot[0]);
+						Error err = a->try_rotation_track_interpolate(i, prev_time, &rot[0], backward);
 						if (err != OK) {
 							continue;
 						}
 						rot[0] = post_process_key_value(a, i, rot[0], t->object_id, t->bone_idx);
-						a->try_rotation_track_interpolate(i, time, &rot[1]);
+						a->try_rotation_track_interpolate(i, time, &rot[1], backward);
 						rot[1] = post_process_key_value(a, i, rot[1], t->object_id, t->bone_idx);
 						root_motion_cache.rot = (root_motion_cache.rot * Quaternion().slerp(rot[0].inverse() * rot[1], blend)).normalized();
 						prev_time = !backward ? start : end;
 					}
 					{
 						Quaternion rot;
-						Error err = a->try_rotation_track_interpolate(i, time, &rot);
+						Error err = a->try_rotation_track_interpolate(i, time, &rot, backward);
 						if (err != OK) {
 							continue;
 						}
@@ -1487,42 +1487,42 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						Vector3 scale[2];
 						if (!backward) {
 							if (Animation::is_greater_approx(prev_time, time)) {
-								Error err = a->try_scale_track_interpolate(i, prev_time, &scale[0]);
+								Error err = a->try_scale_track_interpolate(i, prev_time, &scale[0], backward);
 								if (err != OK) {
 									continue;
 								}
 								scale[0] = post_process_key_value(a, i, scale[0], t->object_id, t->bone_idx);
-								a->try_scale_track_interpolate(i, end, &scale[1]);
+								a->try_scale_track_interpolate(i, end, &scale[1], backward);
 								scale[1] = post_process_key_value(a, i, scale[1], t->object_id, t->bone_idx);
 								root_motion_cache.scale += (scale[1] - scale[0]) * blend;
 								prev_time = start;
 							}
 						} else {
 							if (Animation::is_less_approx(prev_time, time)) {
-								Error err = a->try_scale_track_interpolate(i, prev_time, &scale[0]);
+								Error err = a->try_scale_track_interpolate(i, prev_time, &scale[0], backward);
 								if (err != OK) {
 									continue;
 								}
 								scale[0] = post_process_key_value(a, i, scale[0], t->object_id, t->bone_idx);
-								a->try_scale_track_interpolate(i, start, &scale[1]);
+								a->try_scale_track_interpolate(i, start, &scale[1], backward);
 								scale[1] = post_process_key_value(a, i, scale[1], t->object_id, t->bone_idx);
 								root_motion_cache.scale += (scale[1] - scale[0]) * blend;
 								prev_time = end;
 							}
 						}
-						Error err = a->try_scale_track_interpolate(i, prev_time, &scale[0]);
+						Error err = a->try_scale_track_interpolate(i, prev_time, &scale[0], backward);
 						if (err != OK) {
 							continue;
 						}
 						scale[0] = post_process_key_value(a, i, scale[0], t->object_id, t->bone_idx);
-						a->try_scale_track_interpolate(i, time, &scale[1]);
+						a->try_scale_track_interpolate(i, time, &scale[1], backward);
 						scale[1] = post_process_key_value(a, i, scale[1], t->object_id, t->bone_idx);
 						root_motion_cache.scale += (scale[1] - scale[0]) * blend;
 						prev_time = !backward ? start : end;
 					}
 					{
 						Vector3 scale;
-						Error err = a->try_scale_track_interpolate(i, time, &scale);
+						Error err = a->try_scale_track_interpolate(i, time, &scale, backward);
 						if (err != OK) {
 							continue;
 						}
@@ -1538,7 +1538,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					}
 					TrackCacheBlendShape *t = static_cast<TrackCacheBlendShape *>(track);
 					float value;
-					Error err = a->try_blend_shape_track_interpolate(i, time, &value);
+					Error err = a->try_blend_shape_track_interpolate(i, time, &value, backward);
 					//ERR_CONTINUE(err!=OK); //used for testing, should be removed
 					if (err != OK) {
 						continue;
@@ -1561,7 +1561,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 
 						Variant value;
 						if (t->is_variant_interpolatable) {
-							value = is_value ? a->value_track_interpolate(i, time, is_discrete && force_continuous ? backward : false) : Variant(a->bezier_track_interpolate(i, time));
+							value = is_value ? a->value_track_interpolate(i, time, backward) : Variant(a->bezier_track_interpolate(i, time));
 							value = post_process_key_value(a, i, value, t->object_id);
 							if (value == Variant()) {
 								continue;


### PR DESCRIPTION
Context: https://github.com/godotengine/godot/issues/105385

The `backward` flag was added by https://github.com/godotengine/godot/pull/92861 to handle backward nearest interpolation. It was applied to ValueTrack, but not applied TRS3D & BlendShape Tracks so now apply it to them.

This changes the behavior of the reverse playback when Nearest mode is used in TRS3D & Blend Track, so the break compat label is added (but that means it has been fixed to a more correct and expected result).

In the case:
![image](https://github.com/user-attachments/assets/95cd478f-3f99-4e43-92ba-10b413b1ba64)

Before:

https://github.com/user-attachments/assets/357c7790-fe10-447c-a62d-2e2845b645f9

After fix:

https://github.com/user-attachments/assets/3ee7c73b-e962-4e55-86a8-175422d7eb53

Note that scrubbing in the editor does not affect it, as it cannot determine if it is playing backwards or not (to see the effect as debugging/testing, you must play it back with play()). This would be consistent behavior with ValueTrack.
