### PR TITLE
Fix errors in Curve2D and 3D when points overlap

### DIFF
--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -88,7 +88,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="t" type="float" />
 			<description>
-				Returns the position between the vertex [param idx] and the vertex [code]idx + 1[/code], where [param t] controls if the point is the first vertex ([code]t = 0.0[/code]), the last vertex ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &lt;= t &lt;= 1.0[/code]) give strange, but predictable results.
+				Returns the position between the vertex [param idx] and the vertex [code]idx + 1[/code], where [param t] controls if the point is the first vertex ([code]t = 0.0[/code]), the last vertex ([code]t = 1.0[/code]), or in between. Values of [param t] outside the [code][0.0, 1.0][/code] range give strange, but predictable results.
 				If [param idx] is out of bounds it is truncated to the first or last vertex, and [param t] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
@@ -107,7 +107,7 @@
 			<param index="0" name="offset" type="float" default="0.0" />
 			<param index="1" name="cubic" type="bool" default="false" />
 			<description>
-				Similar to [method sample_baked], but returns [Transform2D] that includes a rotation along the curve, with [member Transform2D.origin] as the point position and the [member Transform2D.x] vector pointing in the direction of the path at that point. Returns an empty transform if the length of the curve is [code]0[/code].
+				Similar to [method sample_baked], but returns [Transform2D] that includes a rotation along the curve, with [member Transform2D.origin] as the point position and the [member Transform2D.x] vector pointing in the direction of the path at that point. If the length of the curve is [code]0[/code], the transform will use the identity basis.
 				[codeblock]
 				var baked = curve.sample_baked_with_rotation(offset)
 				# The returned Transform2D can be set directly.

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -108,7 +108,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="t" type="float" />
 			<description>
-				Returns the position between the vertex [param idx] and the vertex [code]idx + 1[/code], where [param t] controls if the point is the first vertex ([code]t = 0.0[/code]), the last vertex ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &gt;= t &lt;=1[/code]) give strange, but predictable results.
+				Returns the position between the vertex [param idx] and the vertex [code]idx + 1[/code], where [param t] controls if the point is the first vertex ([code]t = 0.0[/code]), the last vertex ([code]t = 1.0[/code]), or in between. Values of [param t] outside the [code][0.0, 1.0][/code] range give strange, but predictable results.
 				If [param idx] is out of bounds it is truncated to the first or last vertex, and [param t] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
@@ -127,7 +127,7 @@
 			<param index="1" name="apply_tilt" type="bool" default="false" />
 			<description>
 				Returns an up vector within the curve at position [param offset], where [param offset] is measured as a distance in 3D units along the curve. To do that, it finds the two cached up vectors where the [param offset] lies between, then interpolates the values. If [param apply_tilt] is [code]true[/code], an interpolated tilt is applied to the interpolated up vector.
-				If the curve has no up vectors, the function sends an error to the console, and returns [code](0, 1, 0)[/code].
+				If the curve has no up vectors, the function sends an error to the console, and returns [code](0, 1, 0)[/code]. See [member up_vector_enabled].
 			</description>
 		</method>
 		<method name="sample_baked_with_rotation" qualifiers="const">
@@ -136,7 +136,7 @@
 			<param index="1" name="cubic" type="bool" default="false" />
 			<param index="2" name="apply_tilt" type="bool" default="false" />
 			<description>
-				Returns a [Transform3D] with [code]origin[/code] as point position, [code]basis.x[/code] as sideway vector, [code]basis.y[/code] as up vector, [code]basis.z[/code] as forward vector. When the curve length is 0, there is no reasonable way to calculate the rotation, all vectors aligned with global space axes. See also [method sample_baked].
+				Returns a [Transform3D] within the curve at position [param offset], where [param offset] is measured as a distance in 3D units along the curve. The [member Transform3D.origin] is the point position, the [member Basis.z] is the forward vector, the [member Basis.y] is the up vector, and the [member Basis.x] is a perpendicular vector. If the curve length is [code]0[/code], the transform will use [constant Basis.IDENTITY] as there is no reasonable way to calculate the rotation. See also [method sample_baked].
 			</description>
 		</method>
 		<method name="samplef" qualifiers="const">

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -959,11 +959,32 @@ void Curve2D::_bake() const {
 				pidx++;
 				bpw[pidx] = E.value;
 				bfw[pidx] = _calculate_tangent(points[i].position, points[i].position + points[i].out, points[i + 1].position + points[i + 1].in, points[i + 1].position, E.key);
+				if (bfw[pidx].is_zero_approx()) {
+					bfw[pidx] = bfw[pidx - 1];
+				}
 			}
 
 			pidx++;
 			bpw[pidx] = points[i + 1].position;
 			bfw[pidx] = _calculate_tangent(points[i].position, points[i].position + points[i].out, points[i + 1].position + points[i + 1].in, points[i + 1].position, 1.0);
+			if (bfw[pidx].is_zero_approx()) {
+				bfw[pidx] = bfw[pidx - 1];
+			}
+		}
+		if (bfw[0].is_zero_approx()) {
+			// Use the first non-zero forward vector when the first points overlap.
+			Vector2 first_forward = Vector2(1, 0);
+			int first_not_zero = pc;
+			for (int i = 1; i < pc; i++) {
+				if (!bfw[i].is_zero_approx()) {
+					first_not_zero = i;
+					first_forward = bfw[i];
+					break;
+				}
+			}
+			for (int i = first_not_zero - 1; i >= 0; i--) {
+				bfw[i] = first_forward;
+			}
 		}
 
 		// Recalculate the baked distances.
@@ -1015,9 +1036,9 @@ Curve2D::Interval Curve2D::_find_interval(real_t p_offset) const {
 	ERR_FAIL_COND_V_MSG(p_offset < offset_begin || p_offset > offset_end, interval, "Offset out of range.");
 
 	interval.idx = idx;
-	if (idx_interval < FLT_EPSILON) {
+	if (idx_interval < CMP_EPSILON) {
 		interval.frac = 0.5; // For a very short interval, 0.5 is a reasonable choice.
-		ERR_FAIL_V_MSG(interval, "Zero length interval.");
+		return interval;
 	}
 
 	interval.frac = (p_offset - offset_begin) / idx_interval;
@@ -1752,6 +1773,9 @@ void Curve3D::_bake() const {
 					bfw[pidx] = _calculate_tangent(points[i].position, points[i].position + points[i].out, points[0].position + points[0].in, points[0].position, E.key);
 					btw[pidx] = Math::lerp(points[i].tilt, points[0].tilt, E.key);
 				}
+				if (bfw[pidx].is_zero_approx()) {
+					bfw[pidx] = bfw[pidx - 1];
+				}
 			}
 
 			pidx++;
@@ -1763,6 +1787,24 @@ void Curve3D::_bake() const {
 				bpw[pidx] = points[0].position;
 				bfw[pidx] = _calculate_tangent(points[i].position, points[i].position + points[i].out, points[0].position + points[0].in, points[0].position, 1.0);
 				btw[pidx] = points[0].tilt;
+			}
+			if (bfw[pidx].is_zero_approx()) {
+				bfw[pidx] = bfw[pidx - 1];
+			}
+		}
+		if (bfw[0].is_zero_approx()) {
+			// Use the first non-zero forward vector when the first points overlap.
+			Vector3 first_forward = Vector3(0, 0, -1);
+			int first_not_zero = pc;
+			for (int i = 1; i < pc; i++) {
+				if (!bfw[i].is_zero_approx()) {
+					first_not_zero = i;
+					first_forward = bfw[i];
+					break;
+				}
+			}
+			for (int i = first_not_zero - 1; i >= 0; i--) {
+				bfw[i] = first_forward;
 			}
 		}
 
@@ -1898,9 +1940,9 @@ Curve3D::Interval Curve3D::_find_interval(real_t p_offset) const {
 	ERR_FAIL_COND_V_MSG(p_offset < offset_begin || p_offset > offset_end, interval, "Offset out of range.");
 
 	interval.idx = idx;
-	if (idx_interval < FLT_EPSILON) {
+	if (idx_interval < CMP_EPSILON) {
 		interval.frac = 0.5; // For a very short interval, 0.5 is a reasonable choice.
-		ERR_FAIL_V_MSG(interval, "Zero length interval.");
+		return interval;
 	}
 
 	interval.frac = (p_offset - offset_begin) / idx_interval;

--- a/tests/scene/test_curve_2d.h
+++ b/tests/scene/test_curve_2d.h
@@ -249,6 +249,41 @@ TEST_CASE("[Curve2D] Sampling") {
 		CHECK(cross_linear_curve->get_baked_points().size() >= 3);
 		CHECK(cross_linear_curve->sample_baked_with_rotation(cross_linear_curve->get_closest_offset(Vector2(0.5, 0))).is_equal_approx(Transform2D(Vector2(1, 0), Vector2(0, 1), Vector2(0.5, 0))));
 	}
+
+	SUBCASE("Sample overlapping points") {
+		// Only overlapping points.
+		curve->clear_points();
+		curve->add_point(Vector2(10, 0));
+		curve->add_point(Vector2(10, 0));
+		curve->add_point(Vector2(10, 0));
+
+		CHECK(curve->sample_baked_with_rotation(0.0) == Transform2D(Vector2(1, 0), Vector2(0, 1), Vector2(10, 0)));
+
+		// Overlapping points at start.
+		curve->clear_points();
+		curve->add_point(Vector2(10, 0));
+		curve->add_point(Vector2(10, 0));
+		curve->add_point(Vector2(10, 10));
+
+		CHECK(curve->sample_baked_with_rotation(0.0) == Transform2D(Vector2(0, 1), Vector2(-1, 0), Vector2(10, 0)));
+
+		// Overlapping points at end.
+		curve->clear_points();
+		curve->add_point(Vector2(10, -5));
+		curve->add_point(Vector2(10, 0));
+		curve->add_point(Vector2(10, 0));
+
+		CHECK(curve->sample_baked_with_rotation(5.0) == Transform2D(Vector2(0, 1), Vector2(-1, 0), Vector2(10, 0)));
+
+		// Overlapping points at middle.
+		curve->clear_points();
+		curve->add_point(Vector2(10, -5));
+		curve->add_point(Vector2(10, 0));
+		curve->add_point(Vector2(10, 0));
+		curve->add_point(Vector2(10, 10));
+
+		CHECK(curve->sample_baked_with_rotation(5.0) == Transform2D(Vector2(0, 1), Vector2(-1, 0), Vector2(10, 0)));
+	}
 }
 
 TEST_CASE("[Curve2D] Tessellation") {

--- a/tests/scene/test_curve_3d.h
+++ b/tests/scene/test_curve_3d.h
@@ -246,6 +246,42 @@ TEST_CASE("[Curve3D] Sampling") {
 		CHECK(cross_linear_curve->get_baked_points().size() >= 3);
 		CHECK(cross_linear_curve->sample_baked_with_rotation(cross_linear_curve->get_closest_offset(Vector3(0.5, 0, 0))).is_equal_approx(Transform3D(Basis(Vector3(0, 0, 1), Vector3(0, 1, 0), Vector3(-1, 0, 0)), Vector3(0.5, 0, 0))));
 	}
+
+	SUBCASE("Sample overlapping points") {
+		// Only overlapping points.
+		curve->clear_points();
+		curve->add_point(Vector3(10, 0, 0));
+		curve->add_point(Vector3(10, 0, 0));
+		curve->add_point(Vector3(10, 0, 0));
+
+		CHECK(curve->sample_baked_with_rotation(0.0) == Transform3D(Basis(), Vector3(10, 0, 0)));
+
+		// Overlapping points at start.
+		curve->clear_points();
+		curve->add_point(Vector3(10, 0, 0));
+		curve->add_point(Vector3(10, 0, 0));
+		curve->add_point(Vector3(20, 0, 0));
+
+		const Basis right_facing_basis = Basis::looking_at(Vector3(1, 0, 0), Vector3(0, 1, 0), false);
+		CHECK(curve->sample_baked_with_rotation(0.0).is_equal_approx(Transform3D(right_facing_basis, Vector3(10, 0, 0))));
+
+		// Overlapping points at end.
+		curve->clear_points();
+		curve->add_point(Vector3(5, 0, 0));
+		curve->add_point(Vector3(10, 0, 0));
+		curve->add_point(Vector3(10, 0, 0));
+
+		CHECK(curve->sample_baked_with_rotation(5.0).is_equal_approx(Transform3D(right_facing_basis, Vector3(10, 0, 0))));
+
+		// Overlapping points at middle.
+		curve->clear_points();
+		curve->add_point(Vector3(5, 0, 0));
+		curve->add_point(Vector3(10, 0, 0));
+		curve->add_point(Vector3(10, 0, 0));
+		curve->add_point(Vector3(20, 0, 0));
+
+		CHECK(curve->sample_baked_with_rotation(5.0).is_equal_approx(Transform3D(right_facing_basis, Vector3(10, 0, 0))));
+	}
 }
 
 TEST_CASE("[Curve3D] Tessellation") {


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/74421
- related https://github.com/godotengine/godot/issues/102395#issuecomment-2634138334

Prevents errors when using Curve3D and Curve2D for having consecutive overlapping points.
It should now be possible to use Path2D and Path3D in the editor without errors printing.

Prevents `ERROR: The target vector can't be zero.
   at: Basis::looking_at (core/math/basis.cpp:1037)`
This happened because Curve3D called looking_at with a zero vector at a couple points. I don't think there is any use for the forward vector to be zero, so I make sure it is never zero when baking.
When there first points overlap, their forward vectors will now use the next non-zero forward vector. If there is none, it will use a default forward vector so the basis is the identity. This way, it should be like there is no overlapping points.

Curve2D `sample_baked_with_rotation` with only points that overlap now return a Transform2D with the identity 2d basis, instead of a zero basis. It still has a position, like before and this way better matches the Curve3D behavior.

Changed `FLT_EPSILON` to `CMP_EPSILON`, since `FLT_EPSILON` is not very common in the codebase.
Added some simple tests. Some of them previously would only log the error while the test case passes.
Also made some documentation tweaks.
