### PR TITLE
SCons: Explicitly enable `-mfpmath=sse -mstackrealign` for x86_32

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -718,7 +718,7 @@ if env["arch"] == "x86_32":
     if env.msvc:
         env.Append(CCFLAGS=["/arch:SSE2"])
     else:
-        env.Append(CCFLAGS=["-msse2"])
+        env.Append(CCFLAGS=["-msse2", "-mfpmath=sse", "-mstackrealign"])
 
 # Explicitly specify colored output.
 if methods.using_gcc(env):

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -71,7 +71,6 @@ if env["builtin_embree"]:
             env.Append(LINKFLAGS=["psapi.lib"])
         else:
             env.Append(LIBS=["psapi"])
-            env_raycast.Append(CCFLAGS=["-mstackrealign"])
 
     if env.msvc:  # Disable bogus warning about intentional struct padding.
         env_raycast.Append(CCFLAGS=["/wd4324"])

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -207,8 +207,6 @@ def configure(env: "SConsEnvironment"):
         env.Append(CPPDEFINES=[("_FILE_OFFSET_BITS", 64)])
 
     if env["arch"] == "x86_32":
-        # The NDK adds this if targeting API < 24, so we can drop it when Godot targets it at least
-        env.Append(CCFLAGS=["-mstackrealign"])
         if has_swappy:
             env.Append(LIBPATH=["#thirdparty/swappy-frame-pacing/x86"])
     elif env["arch"] == "x86_64":


### PR DESCRIPTION
Passing `-msse2` doesn't seem to be sufficient to opt into SSE floating point math instead of the less stable x87.
See https://github.com/godotengine/godot/issues/105455#issuecomment-2824383079 for context.

`-mstackrealign` also seems necessary when using SSE on x86_32, see https://github.com/godotengine/godot/pull/105696#issuecomment-2827046072.

Someone better versed in old x86 architectures (@hpvb?) and what's a reasonable baseline for us to target could see if it wouldn't make sense to pass `-march=pentium4` or similar (or `-mtune`, but I'm not clear on the distinction and whether Clang supports it).

References:
- https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html#index-mfpmath-1
- https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-mfpmath (lol)
- https://github.com/RenderKit/embree/blob/ffc56d50a319c5eb3f246b3c8623f054514b06e6/tutorials/common/image/stb_image.h#L706-L719