### PR TITLE
Fix `LineEdit` `editing_toggled` signal when calling `unedit()`

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -79,6 +79,8 @@ void LineEdit::_edit(bool p_show_virtual_keyboard) {
 		show_virtual_keyboard();
 	}
 	queue_redraw();
+
+	emit_signal(SNAME("editing_toggled"), true);
 }
 
 void LineEdit::unedit() {
@@ -99,6 +101,8 @@ void LineEdit::unedit() {
 	if (deselect_on_focus_loss_enabled && !selection.drag_attempt) {
 		deselect();
 	}
+
+	emit_signal(SNAME("editing_toggled"), false);
 }
 
 bool LineEdit::is_editing() const {
@@ -416,7 +420,6 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 			if (editable && !editing) {
 				edit();
-				emit_signal(SNAME("editing_toggled"), true);
 			}
 
 			accept_event();
@@ -433,7 +436,6 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 			if (!editing) {
 				edit();
-				emit_signal(SNAME("editing_toggled"), true);
 			}
 
 			if (!paste_buffer.is_empty()) {
@@ -536,7 +538,6 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 			if (editable && !editing) {
 				edit();
-				emit_signal(SNAME("editing_toggled"), true);
 				return;
 			}
 
@@ -631,7 +632,6 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (editable && !editing && k->is_action_pressed("ui_text_submit", false)) {
 		edit();
-		emit_signal(SNAME("editing_toggled"), true);
 		accept_event();
 		return;
 	}
@@ -877,7 +877,6 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (editing && !keep_editing_on_text_submit) {
 			unedit();
-			emit_signal(SNAME("editing_toggled"), false);
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
 				DisplayServer::get_singleton()->virtual_keyboard_hide();
 			}
@@ -890,7 +889,6 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	if (k->is_action("ui_cancel")) {
 		if (editing) {
 			unedit();
-			emit_signal(SNAME("editing_toggled"), false);
 		}
 
 		accept_event();
@@ -1622,14 +1620,12 @@ void LineEdit::_notification(int p_what) {
 			// Only allow editing if the LineEdit is not focused with arrow keys.
 			if (!(Input::get_singleton()->is_action_pressed("ui_up") || Input::get_singleton()->is_action_pressed("ui_down") || Input::get_singleton()->is_action_pressed("ui_left") || Input::get_singleton()->is_action_pressed("ui_right"))) {
 				_edit(virtual_keyboard_show_on_focus);
-				emit_signal(SNAME("editing_toggled"), true);
 			}
 		} break;
 
 		case NOTIFICATION_FOCUS_EXIT: {
 			if (editing) {
 				unedit();
-				emit_signal(SNAME("editing_toggled"), false);
 			}
 		} break;
 
@@ -2502,7 +2498,6 @@ void LineEdit::set_editable(bool p_editable) {
 
 	if (!editable && editing) {
 		unedit();
-		emit_signal(SNAME("editing_toggled"), false);
 	}
 	_validate_caret_can_draw();
 


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot/issues/104887

Note: `grab_focus()` always enters edit mode and it's the same as calling `edit()`, so there's no way to only `grab_focus()` in select mode, fixing this will require a new variable `edit_on_focus` with default value to true to avoid changing all editor files that uses `LineEdit`, `SpinBox` and `EditorSpinSlider`.