### PR TITLE
Improve ConfigFile get_sections and get_section_keys by returning Vector<String>

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1391,8 +1391,7 @@ void ProjectSettings::load_scene_groups_cache() {
 	Ref<ConfigFile> cf;
 	cf.instantiate();
 	if (cf->load(get_scene_groups_cache_path()) == OK) {
-		List<String> scene_paths;
-		cf->get_sections(&scene_paths);
+		Vector<String> scene_paths = cf->get_sections();
 		for (const String &E : scene_paths) {
 			Array scene_groups = cf->get_value(E, "groups", Array());
 			HashSet<StringName> cache;

--- a/core/extension/gdextension_library_loader.cpp
+++ b/core/extension/gdextension_library_loader.cpp
@@ -38,8 +38,7 @@
 Vector<SharedObject> GDExtensionLibraryLoader::find_extension_dependencies(const String &p_path, Ref<ConfigFile> p_config, std::function<bool(String)> p_has_feature) {
 	Vector<SharedObject> dependencies_shared_objects;
 	if (p_config->has_section("dependencies")) {
-		List<String> config_dependencies;
-		p_config->get_section_keys("dependencies", &config_dependencies);
+		Vector<String> config_dependencies = p_config->get_section_keys("dependencies");
 
 		for (const String &dependency : config_dependencies) {
 			Vector<String> dependency_tags = dependency.split(".");
@@ -73,8 +72,7 @@ Vector<SharedObject> GDExtensionLibraryLoader::find_extension_dependencies(const
 String GDExtensionLibraryLoader::find_extension_library(const String &p_path, Ref<ConfigFile> p_config, std::function<bool(String)> p_has_feature, PackedStringArray *r_tags) {
 	// First, check the explicit libraries.
 	if (p_config->has_section("libraries")) {
-		List<String> libraries;
-		p_config->get_section_keys("libraries", &libraries);
+		Vector<String> libraries = p_config->get_section_keys("libraries");
 
 		// Iterate the libraries, finding the best matching tags.
 		String best_library_path;
@@ -378,8 +376,7 @@ Error GDExtensionLibraryLoader::parse_gdextension_file(const String &p_path) {
 
 	// Handle icons if any are specified.
 	if (config->has_section("icons")) {
-		List<String> keys;
-		config->get_section_keys("icons", &keys);
+		Vector<String> keys = config->get_section_keys("icons");
 		for (const String &key : keys) {
 			String icon_path = config->get_value("icons", key);
 			if (icon_path.is_relative_path()) {

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -34,32 +34,6 @@
 #include "core/string/string_builder.h"
 #include "core/variant/variant_parser.h"
 
-PackedStringArray ConfigFile::_get_sections() const {
-	List<String> s;
-	get_sections(&s);
-	PackedStringArray arr;
-	arr.resize(s.size());
-	int idx = 0;
-	for (const String &E : s) {
-		arr.set(idx++, E);
-	}
-
-	return arr;
-}
-
-PackedStringArray ConfigFile::_get_section_keys(const String &p_section) const {
-	List<String> s;
-	get_section_keys(p_section, &s);
-	PackedStringArray arr;
-	arr.resize(s.size());
-	int idx = 0;
-	for (const String &E : s) {
-		arr.set(idx++, E);
-	}
-
-	return arr;
-}
-
 void ConfigFile::set_value(const String &p_section, const String &p_key, const Variant &p_value) {
 	if (p_value.get_type() == Variant::NIL) { // Erase key.
 		if (!values.has(p_section)) {
@@ -101,18 +75,33 @@ bool ConfigFile::has_section_key(const String &p_section, const String &p_key) c
 	return values[p_section].has(p_key);
 }
 
-void ConfigFile::get_sections(List<String> *r_sections) const {
+Vector<String> ConfigFile::get_sections() const {
+	Vector<String> sections;
+	sections.resize(values.size());
+
+	int i = 0;
+	String *sections_write = sections.ptrw();
 	for (const KeyValue<String, HashMap<String, Variant>> &E : values) {
-		r_sections->push_back(E.key);
+		sections_write[i++] = E.key;
 	}
+
+	return sections;
 }
 
-void ConfigFile::get_section_keys(const String &p_section, List<String> *r_keys) const {
-	ERR_FAIL_COND_MSG(!values.has(p_section), vformat("Cannot get keys from nonexistent section \"%s\".", p_section));
+Vector<String> ConfigFile::get_section_keys(const String &p_section) const {
+	Vector<String> keys;
+	ERR_FAIL_COND_V_MSG(!values.has(p_section), keys, vformat("Cannot get keys from nonexistent section \"%s\".", p_section));
 
-	for (const KeyValue<String, Variant> &E : values[p_section]) {
-		r_keys->push_back(E.key);
+	const HashMap<String, Variant> &keys_map = values[p_section];
+	keys.resize(keys_map.size());
+
+	int i = 0;
+	String *keys_write = keys.ptrw();
+	for (const KeyValue<String, Variant> &E : keys_map) {
+		keys_write[i++] = E.key;
 	}
+
+	return keys;
 }
 
 void ConfigFile::erase_section(const String &p_section) {
@@ -325,8 +314,8 @@ void ConfigFile::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_section", "section"), &ConfigFile::has_section);
 	ClassDB::bind_method(D_METHOD("has_section_key", "section", "key"), &ConfigFile::has_section_key);
 
-	ClassDB::bind_method(D_METHOD("get_sections"), &ConfigFile::_get_sections);
-	ClassDB::bind_method(D_METHOD("get_section_keys", "section"), &ConfigFile::_get_section_keys);
+	ClassDB::bind_method(D_METHOD("get_sections"), &ConfigFile::get_sections);
+	ClassDB::bind_method(D_METHOD("get_section_keys", "section"), &ConfigFile::get_section_keys);
 
 	ClassDB::bind_method(D_METHOD("erase_section", "section"), &ConfigFile::erase_section);
 	ClassDB::bind_method(D_METHOD("erase_section_key", "section", "key"), &ConfigFile::erase_section_key);

--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -40,8 +40,6 @@ class ConfigFile : public RefCounted {
 
 	HashMap<String, HashMap<String, Variant>> values;
 
-	PackedStringArray _get_sections() const;
-	PackedStringArray _get_section_keys(const String &p_section) const;
 	Error _internal_load(const String &p_path, Ref<FileAccess> f);
 	Error _internal_save(Ref<FileAccess> file);
 
@@ -57,8 +55,8 @@ public:
 	bool has_section(const String &p_section) const;
 	bool has_section_key(const String &p_section, const String &p_key) const;
 
-	void get_sections(List<String> *r_sections) const;
-	void get_section_keys(const String &p_section, List<String> *r_keys) const;
+	Vector<String> get_sections() const;
+	Vector<String> get_section_keys(const String &p_section) const;
 
 	void erase_section(const String &p_section);
 	void erase_section_key(const String &p_section, const String &p_key);

--- a/editor/debugger/editor_file_server.cpp
+++ b/editor/debugger/editor_file_server.cpp
@@ -69,8 +69,7 @@ void EditorFileServer::_scan_files_changed(EditorFileSystemDirectory *efd, const
 				continue;
 			}
 
-			List<String> remaps;
-			cf->get_section_keys("remap", &remaps);
+			Vector<String> remaps = cf->get_section_keys("remap");
 
 			for (const String &remap : remaps) {
 				if (remap == "path") {

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2585,8 +2585,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		}
 
 		if (config->has_section("params")) {
-			List<String> sk;
-			config->get_section_keys("params", &sk);
+			Vector<String> sk = config->get_section_keys("params");
 			for (const String &param : sk) {
 				Variant value = config->get_value("params", param);
 				//override with whatever is in file
@@ -2769,8 +2768,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		Error err = cf->load(p_file + ".import");
 		if (err == OK) {
 			if (cf->has_section("params")) {
-				List<String> sk;
-				cf->get_section_keys("params", &sk);
+				Vector<String> sk = cf->get_section_keys("params");
 				for (const String &E : sk) {
 					if (!params.has(E)) {
 						params[E] = cf->get_value("params", E);
@@ -3408,8 +3406,7 @@ void EditorFileSystem::_move_group_files(EditorFileSystemDirectory *efd, const S
 				config->set_value("remap", "group_file", p_new_location);
 			}
 
-			List<String> sk;
-			config->get_section_keys("params", &sk);
+			Vector<String> sk = config->get_section_keys("params");
 			for (const String &param : sk) {
 				//not very clean, but should work
 				String value = config->get_value("params", param);

--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -95,8 +95,7 @@ void EditorLayoutsDialog::_post_popup() {
 		return;
 	}
 
-	List<String> layouts;
-	config.ptr()->get_sections(&layouts);
+	Vector<String> layouts = config->get_sections();
 
 	for (const String &E : layouts) {
 		layout_names->add_item(E);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1648,8 +1648,7 @@ void EditorNode::_load_editor_plugin_states_from_config(const Ref<ConfigFile> &p
 		return;
 	}
 
-	List<String> esl;
-	p_config_file->get_section_keys("editor_states", &esl);
+	Vector<String> esl = p_config_file->get_section_keys("editor_states");
 
 	Dictionary md;
 	for (const String &E : esl) {
@@ -2378,8 +2377,7 @@ void EditorNode::_dialog_action(String p_file) {
 			}
 
 			// Erase key values.
-			List<String> keys;
-			config->get_section_keys(p_file, &keys);
+			Vector<String> keys = config->get_section_keys(p_file);
 			for (const String &key : keys) {
 				config->set_value(p_file, key, Variant());
 			}
@@ -5777,8 +5775,7 @@ void EditorNode::_update_layouts_menu() {
 		return; // No config.
 	}
 
-	List<String> layouts;
-	config.ptr()->get_sections(&layouts);
+	Vector<String> layouts = config->get_sections();
 
 	for (const String &layout : layouts) {
 		if (layout == TTR("Default")) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1072,8 +1072,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 		}
 
 		if (p_extra_config->has_section("presets")) {
-			List<String> keys;
-			p_extra_config->get_section_keys("presets", &keys);
+			Vector<String> keys = p_extra_config->get_section_keys("presets");
 
 			for (const String &key : keys) {
 				Variant val = p_extra_config->get_value("presets", key);
@@ -1660,8 +1659,7 @@ void EditorSettings::load_favorites_and_recent_dirs() {
 	Ref<ConfigFile> cf;
 	cf.instantiate();
 	if (cf->load(favorite_properties_file) == OK) {
-		List<String> secs;
-		cf->get_sections(&secs);
+		Vector<String> secs = cf->get_sections();
 
 		for (String &E : secs) {
 			PackedStringArray properties = PackedStringArray(cf->get_value(E, "properties"));
@@ -1730,8 +1728,7 @@ void EditorSettings::load_text_editor_theme() {
 		return;
 	}
 
-	List<String> keys;
-	cf->get_section_keys("color_theme", &keys);
+	Vector<String> keys = cf->get_section_keys("color_theme");
 
 	for (const String &key : keys) {
 		String val = cf->get_value("color_theme", key);
@@ -2150,8 +2147,7 @@ void EditorSettings::get_argument_options(const StringName &p_function, int p_id
 				r_options->push_back(E.key.quote());
 			}
 		} else if (pf == "get_project_metadata" && project_metadata.is_valid()) {
-			List<String> sections;
-			project_metadata->get_sections(&sections);
+			Vector<String> sections = project_metadata->get_sections();
 			for (const String &section : sections) {
 				r_options->push_back(section.quote());
 			}

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -330,8 +330,7 @@ void EditorExport::load_config() {
 
 		String option_section = "preset." + itos(index) + ".options";
 
-		List<String> options;
-		config->get_section_keys(option_section, &options);
+		Vector<String> options = config->get_section_keys(option_section);
 
 		for (const String &E : options) {
 			Variant value = config->get_value(option_section, E);
@@ -339,8 +338,7 @@ void EditorExport::load_config() {
 		}
 
 		if (credentials->has_section(option_section)) {
-			options.clear();
-			credentials->get_section_keys(option_section, &options);
+			options = credentials->get_section_keys(option_section);
 
 			for (const String &E : options) {
 				// Drop values for secret properties that no longer exist, or during the next save they would end up in the regular config file.

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1378,8 +1378,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				config->set_value("remap", "type", ResourceLoader::get_resource_type(export_path));
 
 				// Erase all Paths.
-				List<String> keys;
-				config->get_section_keys("remap", &keys);
+				Vector<String> keys = config->get_section_keys("remap");
 				for (const String &K : keys) {
 					if (K.begins_with("path")) {
 						config->erase_section_key("remap", K);
@@ -1414,9 +1413,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				}
 			} else {
 				// File is imported and not customized, replace by what it imports.
-				List<String> remaps;
-				config->get_section_keys("remap", &remaps);
-
+				Vector<String> remaps = config->get_section_keys("remap");
 				HashSet<String> remap_features;
 
 				for (const String &F : remaps) {

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -348,8 +348,7 @@ void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 		file_type_icons.insert(SNAME("__default_icon"), get_editor_theme_icon(SNAME("Object")));
 
 		bool history_modified = false;
-		List<String> history_keys;
-		history_file->get_section_keys("selected_history", &history_keys);
+		Vector<String> history_keys = history_file->get_section_keys("selected_history");
 		for (const String &type : history_keys) {
 			const StringName type_name = type;
 			const PackedStringArray paths = history_file->get_value("selected_history", type);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -755,8 +755,7 @@ void SceneImportSettingsDialog::open_settings(const String &p_path, const String
 		config.instantiate();
 		Error err = config->load(p_path + ".import");
 		if (err == OK) {
-			List<String> keys;
-			config->get_section_keys("params", &keys);
+			Vector<String> keys = config->get_section_keys("params");
 			for (const String &E : keys) {
 				Variant value = config->get_value("params", E);
 				if (E == "_subresources") {

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -440,8 +440,7 @@ void AudioStreamImportSettingsDialog::edit(const String &p_path, const String &p
 			loop_offset->set_value(config_file->get_value("params", "loop_offset", 0));
 			bar_beats_edit->set_value(config_file->get_value("params", "bar_beats", 4));
 
-			List<String> keys;
-			config_file->get_section_keys("params", &keys);
+			Vector<String> keys = config_file->get_section_keys("params");
 			for (const String &K : keys) {
 				params[K] = config_file->get_value("params", K);
 			}

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -1201,8 +1201,7 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 	Error err = config->load(p_path + ".import");
 	print_verbose("Loading import settings:");
 	if (err == OK) {
-		List<String> keys;
-		config->get_section_keys("params", &keys);
+		Vector<String> keys = config->get_section_keys("params");
 		for (const String &key : keys) {
 			print_verbose(String("    ") + key + " == " + String(config->get_value("params", key)));
 			if (key == "preload") {

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -190,8 +190,7 @@ void ImportDock::_update_options(const String &p_path, const Ref<ConfigFile> &p_
 
 	HashMap<StringName, Variant> import_options;
 	if (p_config.is_valid() && p_config->has_section("params")) {
-		List<String> section_keys;
-		p_config->get_section_keys("params", &section_keys);
+		Vector<String> section_keys = p_config->get_section_keys("params");
 		for (const String &section_key : section_keys) {
 			import_options[section_key] = p_config->get_value("params", section_key);
 		}
@@ -258,8 +257,7 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 			continue;
 		}
 
-		List<String> keys;
-		config->get_section_keys("params", &keys);
+		Vector<String> keys = config->get_section_keys("params");
 
 		for (const String &E : keys) {
 			if (!value_frequency.has(E)) {

--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -889,8 +889,7 @@ Vector<uint64_t> AnimationLibraryEditor::_load_mixer_libs_folding() {
 		//The scene/mixer combination is no longer valid and we'll try to recover
 		uint64_t current_mixer_id = uint64_t(mixer->get_instance_id());
 		String current_mixer_signature = _get_mixer_signature();
-		List<String> sections;
-		config->get_sections(&sections);
+		Vector<String> sections = config->get_sections();
 
 		for (const String &section : sections) {
 			Variant mixer_id = config->get_value(section, "mixer");

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -630,8 +630,7 @@ void ScriptEditor::_clear_breakpoints() {
 	}
 
 	// Clear from closed scripts.
-	List<String> cached_editors;
-	script_editor_cache->get_sections(&cached_editors);
+	Vector<String> cached_editors = script_editor_cache->get_sections();
 	for (const String &E : cached_editors) {
 		Array breakpoints = _get_cached_breakpoints_for_script(E);
 		for (int breakpoint : breakpoints) {
@@ -1918,8 +1917,7 @@ Vector<String> ScriptEditor::_get_breakpoints() {
 	}
 
 	// Load breakpoints that are in closed scripts.
-	List<String> cached_editors;
-	script_editor_cache->get_sections(&cached_editors);
+	Vector<String> cached_editors = script_editor_cache->get_sections();
 	for (const String &E : cached_editors) {
 		if (loaded_scripts.has(E)) {
 			continue;
@@ -1959,8 +1957,7 @@ void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
 	}
 
 	// Load breakpoints that are in closed scripts.
-	List<String> cached_editors;
-	script_editor_cache->get_sections(&cached_editors);
+	Vector<String> cached_editors = script_editor_cache->get_sections();
 	for (const String &E : cached_editors) {
 		if (loaded_scripts.has(E)) {
 			continue;
@@ -3591,8 +3588,7 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 
 	// Remove any deleted editors that have been removed between launches.
 	// and if a Script, register breakpoints with the debugger.
-	List<String> cached_editors;
-	script_editor_cache->get_sections(&cached_editors);
+	Vector<String> cached_editors = script_editor_cache->get_sections();
 	for (const String &E : cached_editors) {
 		if (loaded_scripts.has(E)) {
 			continue;

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -862,9 +862,8 @@ void ProjectList::find_projects_multiple(const PackedStringArray &p_paths) {
 }
 
 void ProjectList::load_project_list() {
-	List<String> sections;
 	_config.load(_config_path);
-	_config.get_sections(&sections);
+	Vector<String> sections = _config.get_sections();
 
 	for (const String &path : sections) {
 		bool favorite = _config.get_value(path, "favorite", false);

--- a/platform/ios/export/godot_plugin_config.cpp
+++ b/platform/ios/export/godot_plugin_config.cpp
@@ -209,8 +209,7 @@ PluginConfigIOS PluginConfigIOS::load_plugin_config(Ref<ConfigFile> config_file,
 	}
 
 	if (config_file->has_section(PluginConfigIOS::PLIST_SECTION)) {
-		List<String> keys;
-		config_file->get_section_keys(PluginConfigIOS::PLIST_SECTION, &keys);
+		Vector<String> keys = config_file->get_section_keys(PluginConfigIOS::PLIST_SECTION);
 
 		for (const String &key : keys) {
 			Vector<String> key_components = key.split(":");


### PR DESCRIPTION
Return `Vector<String>` directly instead of passing in a `List<String>` pointer into `ConfigFile::get_sections` and `get_section_keys`.

Also removed the private functions `_get_sections` and `_get_section_keys` that were used for the bindings as all they did was copy the List into a Vector.

I tested with 200 keys and 200 sections and it was about 3x faster with the Vector. I also tested out if passing the Vector as a pointer like the List was doing initially was better but it ended up being much slower than just returning it by value.