### PR TITLE
OpenXR: Fix building with Wayland support and `opengl3=no`

### DIFF
--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -27,7 +27,7 @@ elif env["platform"] == "linuxbsd":
     if env["x11"]:
         env_openxr.AppendUnique(CPPDEFINES=["XR_USE_PLATFORM_XLIB"])
 
-    if env["wayland"]:
+    if env["wayland"] and env["opengl3"]:
         env_openxr.AppendUnique(CPPDEFINES=["XR_USE_PLATFORM_EGL"])
 
     # FIXME: Review what needs to be set for Android and macOS.


### PR DESCRIPTION
While working on https://github.com/godotengine/godot/pull/105708, I noticed that building with Wayland support and `opengl3=no` would lead to a series of compiler errors:

```
In file included from modules/openxr/openxr_platform_inc.h:92,
                 from modules/openxr/openxr_api.cpp:41:
thirdparty/openxr/include/openxr/openxr_platform.h:551:5: error: 'EGLDisplay' does not name a type; did you mean 'Display'?
  551 |     EGLDisplay                     display;
      |     ^~~~~~~~~~
      |     Display
thirdparty/openxr/include/openxr/openxr_platform.h:552:5: error: 'EGLConfig' does not name a type
  552 |     EGLConfig                      config;
      |     ^~~~~~~~~
thirdparty/openxr/include/openxr/openxr_platform.h:553:5: error: 'EGLContext' does not name a type; did you mean 'GContext'?
  553 |     EGLContext                     context;
      |     ^~~~~~~~~~
      |     GContext
In file included from modules/openxr/extensions/platform/../../openxr_platform_inc.h:92,
                 from modules/openxr/extensions/platform/openxr_vulkan_extension.h:41,
                 from modules/openxr/extensions/platform/openxr_vulkan_extension.cpp:31:
thirdparty/openxr/include/openxr/openxr_platform.h:551:5: error: 'EGLDisplay' does not name a type; did you mean 'Display'?
  551 |     EGLDisplay                     display;
      |     ^~~~~~~~~~
      |     Display
thirdparty/openxr/include/openxr/openxr_platform.h:552:5: error: 'EGLConfig' does not name a type
  552 |     EGLConfig                      config;
      |     ^~~~~~~~~
thirdparty/openxr/include/openxr/openxr_platform.h:553:5: error: 'EGLContext' does not name a type; did you mean 'GContext'?
  553 |     EGLContext                     context;
      |     ^~~~~~~~~~
      |     GContext
```

This PR fixes it for me!