### PR TITLE
Capitalize global navigation constants

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -196,7 +196,7 @@
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="10.0">
 			The radius of the avoidance agent. This is the "body" of the avoidance agent and not the avoidance maneuver starting radius (which is controlled by [member neighbor_distance]).
-			Does not affect normal pathfinding. To change an actor's pathfinding radius bake [NavigationMesh] resources with a different [member NavigationMesh.agent_radius] property and use different navigation maps for each actor size.
+			Does not affect normal pathfinding. To change an actor's pathfinding radius bake [NavigationPolygon] resources with a different [member NavigationPolygon.agent_radius] property and use different navigation maps for each actor size.
 		</member>
 		<member name="simplify_epsilon" type="float" setter="set_simplify_epsilon" getter="get_simplify_epsilon" default="0.0">
 			The path simplification amount in worlds units.

--- a/modules/navigation_2d/nav_map_2d.cpp
+++ b/modules/navigation_2d/nav_map_2d.cpp
@@ -71,7 +71,7 @@ void NavMap2D::set_cell_size(real_t p_cell_size) {
 	if (cell_size == p_cell_size) {
 		return;
 	}
-	cell_size = MAX(p_cell_size, NavigationDefaults2D::navmesh_cell_size_min);
+	cell_size = MAX(p_cell_size, NavigationDefaults2D::NAV_MESH_CELL_SIZE_MIN);
 	_update_merge_rasterizer_cell_dimensions();
 	map_settings_dirty = true;
 }
@@ -80,7 +80,7 @@ void NavMap2D::set_merge_rasterizer_cell_scale(float p_value) {
 	if (merge_rasterizer_cell_scale == p_value) {
 		return;
 	}
-	merge_rasterizer_cell_scale = MAX(p_value, NavigationDefaults2D::navmesh_cell_size_min);
+	merge_rasterizer_cell_scale = MAX(p_value, NavigationDefaults2D::NAV_MESH_CELL_SIZE_MIN);
 	_update_merge_rasterizer_cell_dimensions();
 	map_settings_dirty = true;
 }

--- a/modules/navigation_2d/nav_map_2d.h
+++ b/modules/navigation_2d/nav_map_2d.h
@@ -50,7 +50,7 @@ class NavObstacle2D;
 class NavMap2D : public NavRid2D {
 	/// To find the polygons edges the vertices are displaced in a grid where
 	/// each cell has the following cell_size.
-	real_t cell_size = NavigationDefaults2D::navmesh_cell_size;
+	real_t cell_size = NavigationDefaults2D::NAV_MESH_CELL_SIZE;
 
 	// For the inter-region merging to work, internal rasterization is performed.
 	Vector2 merge_rasterizer_cell_size = Vector2(cell_size, cell_size);
@@ -60,10 +60,10 @@ class NavMap2D : public NavRid2D {
 
 	bool use_edge_connections = true;
 	/// This value is used to detect the near edges to connect.
-	real_t edge_connection_margin = NavigationDefaults2D::edge_connection_margin;
+	real_t edge_connection_margin = NavigationDefaults2D::EDGE_CONNECTION_MARGIN;
 
 	/// This value is used to limit how far links search to find polygons to connect to.
-	real_t link_connection_radius = NavigationDefaults2D::link_connection_radius;
+	real_t link_connection_radius = NavigationDefaults2D::LINK_CONNECTION_RADIUS;
 
 	bool map_settings_dirty = true;
 

--- a/modules/navigation_3d/nav_map_3d.cpp
+++ b/modules/navigation_3d/nav_map_3d.cpp
@@ -79,7 +79,7 @@ void NavMap3D::set_cell_size(real_t p_cell_size) {
 	if (cell_size == p_cell_size) {
 		return;
 	}
-	cell_size = MAX(p_cell_size, NavigationDefaults3D::navmesh_cell_size_min);
+	cell_size = MAX(p_cell_size, NavigationDefaults3D::NAV_MESH_CELL_SIZE_MIN);
 	_update_merge_rasterizer_cell_dimensions();
 	map_settings_dirty = true;
 }
@@ -88,7 +88,7 @@ void NavMap3D::set_cell_height(real_t p_cell_height) {
 	if (cell_height == p_cell_height) {
 		return;
 	}
-	cell_height = MAX(p_cell_height, NavigationDefaults3D::navmesh_cell_size_min);
+	cell_height = MAX(p_cell_height, NavigationDefaults3D::NAV_MESH_CELL_SIZE_MIN);
 	_update_merge_rasterizer_cell_dimensions();
 	map_settings_dirty = true;
 }
@@ -97,7 +97,7 @@ void NavMap3D::set_merge_rasterizer_cell_scale(float p_value) {
 	if (merge_rasterizer_cell_scale == p_value) {
 		return;
 	}
-	merge_rasterizer_cell_scale = MAX(p_value, NavigationDefaults3D::navmesh_cell_size_min);
+	merge_rasterizer_cell_scale = MAX(p_value, NavigationDefaults3D::NAV_MESH_CELL_SIZE_MIN);
 	_update_merge_rasterizer_cell_dimensions();
 	map_settings_dirty = true;
 }

--- a/modules/navigation_3d/nav_map_3d.h
+++ b/modules/navigation_3d/nav_map_3d.h
@@ -55,8 +55,8 @@ class NavMap3D : public NavRid3D {
 
 	/// To find the polygons edges the vertices are displaced in a grid where
 	/// each cell has the following cell_size and cell_height.
-	real_t cell_size = NavigationDefaults3D::navmesh_cell_size;
-	real_t cell_height = NavigationDefaults3D::navmesh_cell_height;
+	real_t cell_size = NavigationDefaults3D::NAV_MESH_CELL_SIZE;
+	real_t cell_height = NavigationDefaults3D::NAV_MESH_CELL_HEIGHT;
 
 	// For the inter-region merging to work, internal rasterization is performed.
 	Vector3 merge_rasterizer_cell_size = Vector3(cell_size, cell_height, cell_size);
@@ -66,10 +66,10 @@ class NavMap3D : public NavRid3D {
 
 	bool use_edge_connections = true;
 	/// This value is used to detect the near edges to connect.
-	real_t edge_connection_margin = NavigationDefaults3D::edge_connection_margin;
+	real_t edge_connection_margin = NavigationDefaults3D::EDGE_CONNECTION_MARGIN;
 
 	/// This value is used to limit how far links search to find polygons to connect to.
-	real_t link_connection_radius = NavigationDefaults3D::link_connection_radius;
+	real_t link_connection_radius = NavigationDefaults3D::LINK_CONNECTION_RADIUS;
 
 	bool map_settings_dirty = true;
 

--- a/scene/2d/navigation/navigation_region_2d.cpp
+++ b/scene/2d/navigation/navigation_region_2d.cpp
@@ -301,7 +301,7 @@ PackedStringArray NavigationRegion2D::get_configuration_warnings() const {
 
 	if (is_visible_in_tree() && is_inside_tree()) {
 		if (navigation_polygon.is_null()) {
-			warnings.push_back(RTR("A NavigationMesh resource must be set or created for this node to work. Please set a property or draw a polygon."));
+			warnings.push_back(RTR("A NavigationPolygon resource must be set or created for this node to work. Please set a property or draw a polygon."));
 		}
 	}
 

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1251,7 +1251,7 @@ void TileMapLayer::_navigation_update(bool p_force_cleanup) {
 					// Create a dedicated map for each layer.
 					RID new_layer_map = ns->map_create();
 					// Set the default NavigationPolygon cell_size on the new map as a mismatch causes an error.
-					ns->map_set_cell_size(new_layer_map, NavigationDefaults2D::navmesh_cell_size);
+					ns->map_set_cell_size(new_layer_map, NavigationDefaults2D::NAV_MESH_CELL_SIZE);
 					ns->map_set_active(new_layer_map, true);
 					navigation_map_override = new_layer_map;
 				}

--- a/scene/resources/2d/navigation_polygon.cpp
+++ b/scene/resources/2d/navigation_polygon.cpp
@@ -386,7 +386,7 @@ void NavigationPolygon::make_polygons_from_outlines() {
 
 	TPPLPartition tpart;
 	if (tpart.ConvexPartition_HM(&in_poly, &out_poly) == 0) { //failed!
-		ERR_PRINT("NavigationPolygon: Convex partition failed! Failed to convert outlines to a valid NavigationMesh."
+		ERR_PRINT("NavigationPolygon: Convex partition failed! Failed to convert outlines to a valid NavigationPolygon."
 				  "\nNavigationPolygon outlines can not overlap vertices or edges inside same outline or with other outlines or have any intersections."
 				  "\nAdd the outmost and largest outline first. To add holes inside this outline add the smaller outlines with same winding order.");
 		return;

--- a/scene/resources/2d/navigation_polygon.h
+++ b/scene/resources/2d/navigation_polygon.h
@@ -50,7 +50,7 @@ class NavigationPolygon : public Resource {
 	// Navigation mesh
 	Ref<NavigationMesh> navigation_mesh;
 
-	real_t cell_size = NavigationDefaults2D::navmesh_cell_size;
+	real_t cell_size = NavigationDefaults2D::NAV_MESH_CELL_SIZE;
 	real_t border_size = 0.0f;
 
 	Rect2 baking_rect;

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -77,8 +77,8 @@ public:
 	};
 
 protected:
-	float cell_size = NavigationDefaults3D::navmesh_cell_size;
-	float cell_height = NavigationDefaults3D::navmesh_cell_height;
+	float cell_size = NavigationDefaults3D::NAV_MESH_CELL_SIZE;
+	float cell_height = NavigationDefaults3D::NAV_MESH_CELL_HEIGHT;
 	float border_size = 0.0f;
 	float agent_height = 1.5f;
 	float agent_radius = 0.5f;

--- a/servers/navigation/navigation_globals.h
+++ b/servers/navigation/navigation_globals.h
@@ -36,15 +36,15 @@ namespace NavigationDefaults3D {
 
 // To find the polygons edges the vertices are displaced in a grid where
 // each cell has the following cell_size and cell_height.
-constexpr float navmesh_cell_size{ 0.25f }; // Must match ProjectSettings default 3D cell_size and NavigationMesh cell_size.
-constexpr float navmesh_cell_height{ 0.25f }; // Must match ProjectSettings default 3D cell_height and NavigationMesh cell_height.
-constexpr float navmesh_cell_size_min{ 0.01f };
-constexpr auto navmesh_cell_size_hint{ "0.001,100,0.001,or_greater" };
+constexpr float NAV_MESH_CELL_HEIGHT = 0.25f; // Must match ProjectSettings default 3D cell_height and NavigationMesh cell_height.
+constexpr float NAV_MESH_CELL_SIZE = 0.25f; // Must match ProjectSettings default 3D cell_size and NavigationMesh cell_size.
+constexpr float NAV_MESH_CELL_SIZE_MIN = 0.01f;
+constexpr const char *const NAV_MESH_CELL_SIZE_HINT = "0.001,100,0.001,or_greater";
 
 // Map.
 
-constexpr float edge_connection_margin{ 0.25f };
-constexpr float link_connection_radius{ 1.0f };
+constexpr float EDGE_CONNECTION_MARGIN = 0.25f;
+constexpr float LINK_CONNECTION_RADIUS = 1.0f;
 
 } //namespace NavigationDefaults3D
 
@@ -53,13 +53,13 @@ namespace NavigationDefaults2D {
 // Rasterization.
 
 // Same as in 3D but larger since 1px is treated as 1m.
-constexpr float navmesh_cell_size{ 1.0f }; // Must match ProjectSettings default 2D cell_size.
-constexpr float navmesh_cell_size_min{ 0.01f };
-constexpr auto navmesh_cell_size_hint{ "0.001,100,0.001,or_greater" };
+constexpr float NAV_MESH_CELL_SIZE = 1.0f; // Must match ProjectSettings default 2D cell_size.
+constexpr float NAV_MESH_CELL_SIZE_MIN = 0.01f;
+constexpr const char *const NAV_MESH_CELL_SIZE_HINT = "0.001,100,0.001,or_greater";
 
 // Map.
 
-constexpr float edge_connection_margin{ 1.0f };
-constexpr float link_connection_radius{ 4.0f };
+constexpr float EDGE_CONNECTION_MARGIN = 1.0f;
+constexpr float LINK_CONNECTION_RADIUS = 4.0f;
 
 } //namespace NavigationDefaults2D

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -217,10 +217,10 @@ NavigationServer2D::NavigationServer2D() {
 	ERR_FAIL_COND(singleton != nullptr);
 	singleton = this;
 
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_cell_size", PROPERTY_HINT_RANGE, NavigationDefaults2D::navmesh_cell_size_hint), NavigationDefaults2D::navmesh_cell_size);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_cell_size", PROPERTY_HINT_RANGE, NavigationDefaults2D::NAV_MESH_CELL_SIZE_HINT), NavigationDefaults2D::NAV_MESH_CELL_SIZE);
 	GLOBAL_DEF("navigation/2d/use_edge_connections", true);
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_edge_connection_margin", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults2D::edge_connection_margin);
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_link_connection_radius", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults2D::link_connection_radius);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_edge_connection_margin", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults2D::EDGE_CONNECTION_MARGIN);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_link_connection_radius", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults2D::LINK_CONNECTION_RADIUS);
 
 #ifdef DEBUG_ENABLED
 	debug_navigation_edge_connection_color = GLOBAL_DEF("debug/shapes/navigation/2d/edge_connection_color", Color(1.0, 0.0, 1.0, 1.0));

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -241,13 +241,13 @@ NavigationServer3D::NavigationServer3D() {
 	ERR_FAIL_COND(singleton != nullptr);
 	singleton = this;
 
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_cell_size", PROPERTY_HINT_RANGE, NavigationDefaults3D::navmesh_cell_size_hint), NavigationDefaults3D::navmesh_cell_size);
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_cell_height", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater"), NavigationDefaults3D::navmesh_cell_height);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_cell_size", PROPERTY_HINT_RANGE, NavigationDefaults3D::NAV_MESH_CELL_SIZE_HINT), NavigationDefaults3D::NAV_MESH_CELL_SIZE);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_cell_height", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater"), NavigationDefaults3D::NAV_MESH_CELL_HEIGHT);
 	GLOBAL_DEF("navigation/3d/default_up", Vector3(0, 1, 0));
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "navigation/3d/merge_rasterizer_cell_scale", PROPERTY_HINT_RANGE, "0.001,1,0.001,or_greater"), 1.0);
 	GLOBAL_DEF("navigation/3d/use_edge_connections", true);
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_edge_connection_margin", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults3D::edge_connection_margin);
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_link_connection_radius", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults3D::link_connection_radius);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_edge_connection_margin", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults3D::EDGE_CONNECTION_MARGIN);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_link_connection_radius", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults3D::LINK_CONNECTION_RADIUS);
 
 #ifdef DEBUG_ENABLED
 #ifndef DISABLE_DEPRECATED


### PR DESCRIPTION
While working on PR #89409 I couldn't help but commit some scope creep and capitalize these constants, but I don't want to overload that PR with so much so I moved this to a separate PR.

This PR:
* Capitalizes all constants in `servers/navigation/navigation_globals.h`
* Adds an underscore after `NAV` for readability. (the prefix is useful because in a few places it's `using namespace`'d).
* ~~Renames the 2D ones from `NAVMESH` to `NAV_POLYGON`.~~
* Replace `{}` initialization with `=` initialization for simplicity.
* ~~Moves the range hint into where it's used in the server cpp files (each was only used once).~~
  * This also eradicates a usage of `auto` 🥳
* Fix a few places in docs and error prints where `NavigationMesh` was used instead of `NavigationPolygon`.