### PR TITLE
Fix doc theme not updating on NOTIFICATION_THEME_CHANGED in EditorHelp

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -3222,7 +3222,12 @@ void EditorHelp::_notification(int p_what) {
 			_class_desc_resized(false);
 		} break;
 
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+		case NOTIFICATION_THEME_CHANGED: {
+			if (is_inside_tree()) {
+				_class_desc_resized(true);
+			}
+			update_toggle_files_button();
+
 			bool need_update = false;
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/help")) {
 				need_update = true;
@@ -3240,13 +3245,6 @@ void EditorHelp::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			_wait_for_thread();
 			_update_doc();
-		} break;
-
-		case NOTIFICATION_THEME_CHANGED: {
-			if (is_inside_tree()) {
-				_class_desc_resized(true);
-			}
-			update_toggle_files_button();
 		} break;
 
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -577,6 +577,8 @@ void EditorNode::_update_translations() {
 }
 
 void EditorNode::_update_theme(bool p_skip_creation) {
+	class_icon_cache.clear();
+
 	if (!p_skip_creation) {
 		theme = EditorThemeManager::generate_theme(theme);
 		DisplayServer::set_early_window_clear_color_override(true, theme->get_color(SNAME("background"), EditorStringName(Editor)));


### PR DESCRIPTION
Currently, in-editor documentation pages check to update their theme when editor settings are changed (ie when a theme is set manually).

However, the docs do not perform this check on the "theme changed" notification, so they fail to update when the theme changes by other means, such as when the system theme changes while `interface/theme/follow_system_theme` is enabled.

This PR merges the `NOTIFICATION_EDITOR_SETTINGS_CHANGED` behavior into the `NOTIFICATION_THEME_CHANGED` case so that the theme is always properly updated.

For reference, here is a screenshot of the incorrect behavior, captured after switching the system theme from light mode to dark mode, with `interface/theme/follow_system_theme` enabled (macOS 15.4, latest `master` 1f787b63):
![Screenshot 2025-04-24 at 13 04 17](https://github.com/user-attachments/assets/81764e3d-b84e-489f-b354-764e6eb654f9)