### PR TITLE
[3.x] FTI - Optimize `SceneTree` traversal

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1418,6 +1418,12 @@
 			Sets which physics engine to use for 3D physics.
 			"DEFAULT" is currently the [url=https://bulletphysics.org]Bullet[/url] physics engine. The "GodotPhysics" engine is still supported as an alternative.
 		</member>
+		<member name="physics/3d/physics_interpolation/scene_traversal" type="String" setter="" getter="" default="&quot;DEFAULT&quot;">
+			The approach used for 3D scene traversal when physics interpolation is enabled.
+			- [code]DEFAULT[/code]: The default optimized method.
+			- [code]Legacy[/code]: The previous reference method used for scene tree traversal, which is slower.
+			- [code]Debug[/code]: Swaps between [code]DEFAULT[/code] and [code]Legacy[/code] methods on alternating frames, and provides logging information (which in turn makes it slower). Intended for debugging only; you should use the [code]DEFAULT[/code] method in most cases.
+		</member>
 		<member name="physics/3d/smooth_trimesh_collision" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], smooths out collision with trimesh shapes ([ConcavePolygonShape]) by telling the Bullet physics engine to generate internal edge information for every trimesh shape created.
 			[b]Note:[/b] Only effective if [member physics/3d/physics_engine] is set to [code]DEFAULT[/code] or [code]Bullet[/code], [i]not[/i] [code]GodotPhysics[/code].

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -285,6 +285,10 @@ void Spatial::_notification(int p_what) {
 			// unless they need to perform specific tasks (like changing process modes).
 			fti_pump_xform();
 			fti_pump_property();
+
+			// Detect whether we are using an identity transform.
+			// This is an optimization for faster tree transform concatenation.
+			data.fti_is_identity_xform = data.local_transform == Transform();
 		} break;
 
 		case NOTIFICATION_PAUSED: {
@@ -1127,6 +1131,8 @@ Spatial::Spatial() :
 	data.fti_on_tick_property_list = false;
 	data.fti_global_xform_interp_set = false;
 	data.fti_frame_xform_force_update = false;
+	data.fti_is_identity_xform = false;
+	data.fti_processed = false;
 
 	data.merging_mode = MERGING_MODE_INHERIT;
 

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -53,6 +53,7 @@ class Spatial : public Node {
 	OBJ_CATEGORY("3D");
 
 	friend class SceneTreeFTI;
+	friend class SceneTreeFTITests;
 
 public:
 	enum MergingMode : unsigned int {
@@ -129,6 +130,8 @@ private:
 		bool fti_on_tick_property_list : 1;
 		bool fti_global_xform_interp_set : 1;
 		bool fti_frame_xform_force_update : 1;
+		bool fti_is_identity_xform : 1;
+		bool fti_processed : 1;
 
 		bool merging_allowed : 1;
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -111,8 +111,8 @@ private:
 		HashMap<StringName, Node *> owned_unique_nodes;
 		bool unique_name_in_owner = false;
 
+		int32_t depth;
 		int pos;
-		int depth;
 		int blocked; // safeguard that throws an error when attempting to modify the tree in a harmful way while being traversed.
 		StringName name;
 		SceneTree *tree;
@@ -266,6 +266,7 @@ protected:
 	bool _is_physics_interpolation_reset_requested() const { return data.physics_interpolation_reset_requested; }
 	void _set_use_identity_transform(bool p_enable);
 	bool _is_using_identity_transform() const { return data.use_identity_transform; }
+	int32_t _get_scene_tree_depth() const { return data.depth; }
 
 public:
 	enum {

--- a/scene/main/scene_tree_fti_tests.cpp
+++ b/scene/main/scene_tree_fti_tests.cpp
@@ -1,0 +1,246 @@
+/**************************************************************************/
+/*  scene_tree_fti_tests.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef _3D_DISABLED
+
+#ifdef GODOT_SCENE_TREE_FTI_VERIFY
+#include "scene_tree_fti_tests.h"
+
+#include "scene/3d/spatial.h"
+#include "scene/3d/visual_instance.h"
+#include "scene/main/scene_tree_fti.h"
+
+void SceneTreeFTITests::debug_verify_failed(const Spatial *p_spatial, const Transform &p_test) {
+	print_line("VERIFY FAILED\n");
+	print_line("test xform : " + String(Variant(p_test)));
+
+	bool first = true;
+
+	while (p_spatial) {
+		int32_t depth = MAX(p_spatial->_get_scene_tree_depth(), 0);
+		String tabs;
+		for (int32_t n = 0; n < depth; n++) {
+			tabs += "\t";
+		}
+
+		bool interp_equal = p_spatial->_get_cached_global_transform_interpolated() == p_test;
+		bool glob_equal = p_spatial->get_global_transform() == p_test;
+
+		String sz = tabs + p_spatial->get_name() + " [ " + p_spatial->get_class_name() + " ]\n";
+
+		if (first) {
+			sz += tabs + "... " + String(Variant(p_test)) + "\n";
+		}
+
+		sz += tabs + (p_spatial->data.fti_global_xform_interp_set ? "[I] " : "[i] ") + String(Variant(p_spatial->_get_cached_global_transform_interpolated())) + (interp_equal ? " ***" : "") + "\n";
+		sz += tabs + "[g] " + String(Variant(p_spatial->get_global_transform())) + (glob_equal ? " ***" : "");
+
+		print_line(sz);
+
+		p_spatial = p_spatial->get_parent_spatial();
+		first = false;
+	}
+}
+
+void SceneTreeFTITests::update_dirty_spatials(Node *p_node, uint32_t p_current_half_frame, float p_interpolation_fraction, bool p_active, const Transform *p_parent_global_xform, int p_depth) {
+	SceneTreeFTI::Data &data = _fti.data;
+
+	// There are two runs going on here.
+	// FIRST the naive entire scene tree (reference), where we are
+	// setting state (i.e. writing out xforms, and other state)
+	// SECOND the optimized run, where we are NOT
+	// writing state, but only verifying that the xforms calculated
+	// match those from the reference approach.
+	bool should_verify = (data.traversal_mode == SceneTreeFTI::TM_DEBUG) && data.use_optimized_traversal_method;
+	bool set_state = !should_verify;
+
+	Spatial *s = Object::cast_to<Spatial>(p_node);
+
+	if (s && !s->is_visible()) {
+		return;
+	}
+
+	if (!s) {
+		for (int n = 0; n < p_node->get_child_count(); n++) {
+			update_dirty_spatials(p_node->get_child(n), p_current_half_frame, p_interpolation_fraction, p_active, nullptr, p_depth + 1);
+		}
+		return;
+	}
+
+	if (s->data.dirty & Spatial::DIRTY_GLOBAL) {
+		_ALLOW_DISCARD_ s->get_global_transform();
+	}
+
+	if (!p_active) {
+		if (data.frame_start) {
+			if (s->data.fti_on_frame_xform_list || s->data.fti_frame_xform_force_update) {
+				p_active = true;
+			}
+		} else {
+			if (s->data.dirty & Spatial::DIRTY_GLOBAL_INTERPOLATED) {
+				p_active = true;
+			}
+		}
+	}
+
+	if (data.frame_start) {
+		s->data.fti_global_xform_interp_set = p_active;
+	}
+
+	if (p_active) {
+		Transform local_interp;
+		if (s->is_physics_interpolated()) {
+			if (s->data.fti_on_tick_xform_list) {
+				TransformInterpolator::interpolate_transform(s->data.local_transform_prev, s->get_transform(), local_interp, p_interpolation_fraction);
+			} else {
+				local_interp = s->get_transform();
+			}
+		} else {
+			local_interp = s->get_transform();
+		}
+
+		if (!s->is_set_as_toplevel()) {
+			if (p_parent_global_xform) {
+				if (should_verify) {
+					Transform test = (*p_parent_global_xform) * local_interp;
+					if (s->data.disable_scale) {
+						test.basis.orthonormalize();
+					}
+					if (s->data.global_transform_interpolated != test) {
+						debug_verify_failed(s, test);
+						DEV_ASSERT(s->data.global_transform_interpolated == test);
+					}
+				} else {
+					s->data.global_transform_interpolated = s->data.fti_is_identity_xform ? (*p_parent_global_xform) : (*p_parent_global_xform) * local_interp;
+				}
+			} else {
+				const Spatial *parent = s->get_parent_spatial();
+
+				if (parent) {
+					const Transform &parent_glob = parent->data.fti_global_xform_interp_set ? parent->data.global_transform_interpolated : parent->get_global_transform();
+
+					if (should_verify) {
+						Transform test = parent_glob * local_interp;
+						if (s->data.disable_scale) {
+							test.basis.orthonormalize();
+						}
+						if (s->data.global_transform_interpolated != test) {
+							debug_verify_failed(s, test);
+							DEV_ASSERT(s->data.global_transform_interpolated == test);
+						}
+
+					} else {
+						s->data.global_transform_interpolated = s->data.fti_is_identity_xform ? parent_glob : parent_glob * local_interp;
+					}
+				} else {
+					if (set_state) {
+						s->data.global_transform_interpolated = local_interp;
+					}
+				}
+			}
+		} else {
+			if (set_state) {
+				s->data.global_transform_interpolated = local_interp;
+			}
+		}
+
+		if (set_state) {
+			if (s->data.disable_scale) {
+				s->data.global_transform_interpolated.basis.orthonormalize();
+			}
+
+			s->fti_update_servers_xform();
+
+			s->data.fti_frame_xform_force_update = false;
+		}
+
+		s->data.fti_processed = true;
+	} // if active.
+
+	if (set_state) {
+		s->data.dirty &= ~Spatial::DIRTY_GLOBAL_INTERPOLATED;
+	}
+
+	for (int n = 0; n < p_node->get_child_count(); n++) {
+		update_dirty_spatials(p_node->get_child(n), p_current_half_frame, p_interpolation_fraction, p_active, s->data.fti_global_xform_interp_set ? &s->data.global_transform_interpolated : &s->data.global_transform, p_depth + 1);
+	}
+}
+
+void SceneTreeFTITests::frame_update(Node *p_root, uint32_t p_half_frame, float p_interpolation_fraction) {
+	SceneTreeFTI::Data &data = _fti.data;
+
+	// For testing, use both methods.
+	// FIRST the entire tree, writing out state.
+	{
+		data.use_optimized_traversal_method = false;
+		update_dirty_spatials(p_root, p_half_frame, p_interpolation_fraction, false);
+	}
+
+	// SECOND the optimized depth lists only,
+	// no writing of state, and verifying results.
+	{
+		data.use_optimized_traversal_method = true;
+
+		_fti._create_depth_lists();
+
+		for (uint32_t d = 0; d < data.scene_tree_depth_limit; d++) {
+			const LocalVector<Spatial *> &list = data.dirty_spatial_depth_lists[d];
+
+			for (uint32_t n = 0; n < list.size(); n++) {
+				Spatial *s = list[n];
+
+				if (s->data.fti_processed) {
+					continue;
+				}
+
+				if (Object::cast_to<VisualInstance>(s)) {
+					if (!s->_is_vi_visible()) {
+						continue;
+					}
+				} else if (!s->is_visible_in_tree()) {
+					continue;
+				}
+
+				update_dirty_spatials(s, p_half_frame, p_interpolation_fraction, true);
+			}
+		}
+
+		_fti._clear_depth_lists();
+	}
+}
+
+SceneTreeFTITests::SceneTreeFTITests(SceneTreeFTI &p_fti) :
+		_fti(p_fti) {
+	print_line("SceneTreeFTI : GODOT_SCENE_TREE_FTI_VERIFY defined");
+}
+
+#endif // def GODOT_SCENE_TREE_FTI_VERIFY
+
+#endif // ndef _3D_DISABLED

--- a/scene/main/scene_tree_fti_tests.h
+++ b/scene/main/scene_tree_fti_tests.h
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  scene_tree_fti_tests.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef SCENE_TREE_FTI_TESTS_H
+#define SCENE_TREE_FTI_TESTS_H
+
+class Spatial;
+class Node;
+class Transform;
+class SceneTreeFTI;
+
+class SceneTreeFTITests {
+	SceneTreeFTI &_fti;
+
+	void debug_verify_failed(const Spatial *p_spatial, const Transform &p_test);
+
+public:
+	void update_dirty_spatials(Node *p_node, uint32_t p_current_half_frame, float p_interpolation_fraction, bool p_active, const Transform *p_parent_global_xform = nullptr, int p_depth = 0);
+	void frame_update(Node *p_root, uint32_t p_half_frame, float p_interpolation_fraction);
+
+	SceneTreeFTITests(SceneTreeFTI &p_fti);
+};
+
+#endif // SCENE_TREE_FTI_TESTS_H


### PR DESCRIPTION
This takes the `SceneTreeFTI` and optimizes it up to eleven.
Benchmarking shows this to be approx 2-10x faster for the physics interpolation.

## Introduction
The original implementation for scene tree traversal in `SceneTreeFTI` was naive but foolproof, I had always intended to write a more optimized version, but didn't want to make the original PR too hard to review / understand.

Optimization is a trade off - it offers better performance, at a cost of readability and complexity, so we normally reserve it for bottleneck areas. The `SceneTreeFTI` *is* such a bottleneck area (like rendering or physics), and so some trade offs are made here for performance. Fair warning it is not for the faint of heart.

## How it works
Instead of naively traversing the entire scene tree, as nodes are moved we record them in frame xform lists for later processing. We ideally want to sort these nodes by depth, as traversing down from the higher nodes (low `depth`, close to root) will prevent duplication of branch processing from lower nodes.

Instead of sorting with e.g. quicksort, we maintain a fixed number of depth layers, and just place the node in the corresponding depth layer. Then as we process the nodes on the frame, we can do it in depth order with no sorting required. If we blow past the max layers, this is not a problem, it just might do a little more processing.

## Further optimizations done in this PR
* Nodes that are on the tick list are currently being interpolated, but nodes that are *not* on the tick list are not requiring interpolation (expensive) so we can just directly substitute their current local xform.
* Concatenating parent xforms is also expensive. We can reduce the cost of this by noting that a lot of nodes have an identity xform. We test at opportune places for identity xform, and mark a flag on the node. If a node is using identity, we don't need to concat, we can directly copy the parent global xform to be the child nodes' global xform.

## Debugging / Testing
3 modes are offered via a (temporary?) project setting:
* Default (optimized)
* Legacy (naive whole tree traversal)
* Debug (alternates between the two methods, and prints stats)

Additionally there are new debugging compile defines:
* `GODOT_SCENE_TREE_FTI_PRINT_TREE` - prints the nodes processed.
* `GODOT_SCENE_TREE_FTI_VERIFY` - kind of like a unit test, it uses both methods, and tests that the optimized result is the same as the naive full tree result.

### Testing / verification code
Verifying the results of the optimized path are the same as the reference path is itself rather complex, and is implemented here as a separate file, which will be compiled out in regular builds.

The tests file contains a duplicate of the traversal code. This makes both easier to read and understand, although it does mean the test would need to be kept in sync with any changes to the regular path if it to still do its job.

I did start by keeping both paths in the same function using `#ifdefs`, but it was becoming unreadable (for me, let alone reviewers), so on balance I have gone for a separate file. Another alternative would be to remove the testing code from the main Godot repo and do this independently, but it is kind of nice that anyone can easily run the testing just by defining `GODOT_SCENE_TREE_FTI_VERIFY`.

### Example debug logging when DEBUG is set in the project setting
```
FTI reference nodes traversed : 949, processed : 0, took 35 usec (start)
FTI reference nodes traversed : 949, processed : 40, took 33 usec (end)
FTI optimized nodes traversed : 0, processed : 0, took 0 usec (start)
FTI optimized nodes traversed : 44, skipped 2, processed : 40, took 5 usec (end)

9 nodes moved during frame:
	Armature
	VAimer
	VAimer
	VAimer
	HairAttachment
	BoneAttachment
	WeaponPivotPoint
	WeaponPivotPoint
	WeaponPivotPoint
```
This shows how many nodes were touched, how many processed, and timings.

Additionally, what should be a very useful function, it lists all nodes that were moved _during_ the frame. When using physics interpolation most nodes should be moved during the physics tick, and moving during the frame is normally a user error unless that branch has been switched to `physics_interpolation_mode` OFF.

This allows users to quickly track down which nodes in their scene might be causing problems with physics interpolation. Particularly useful when converting existing game projects, especially ones you have not authored.

## Notes
* Same applies in 4.x.
* It's just possible there is a better folder for `SceneTreeFTITests`, but I wasn't sure whether putting it in `main/tests` was a good idea if that folder uses auto-generation of tests (as this is nothing like the unit tests).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
