### PR TITLE
Fix some leftovers in ColorPicker

### DIFF
--- a/scene/gui/color_mode.cpp
+++ b/scene/gui/color_mode.cpp
@@ -108,6 +108,17 @@ void ColorModeHSV::_value_changed() {
 	if (values[2] > 0 || values[1] != cached_saturation) {
 		cached_saturation = values[1];
 	}
+
+	// Cache real HSV values in ColorPicker.
+	color_picker->h = color_picker->sliders[0]->get_value();
+	color_picker->s = color_picker->sliders[1]->get_value();
+	color_picker->v = color_picker->sliders[2]->get_value();
+	color_picker->ok_hsl_h = color_picker->color.get_ok_hsl_h();
+	color_picker->ok_hsl_s = color_picker->color.get_ok_hsl_s();
+	color_picker->ok_hsl_l = color_picker->color.get_ok_hsl_l();
+
+	// This prevents _set_pick_color() from overwriting the values set above.
+	color_picker->last_color = color_picker->color;
 }
 
 String ColorModeHSV::get_slider_label(int idx) const {
@@ -281,6 +292,17 @@ void ColorModeOKHSL::_value_changed() {
 	if (values[2] > 0 || values[1] != cached_saturation) {
 		cached_saturation = values[1];
 	}
+
+	// Cache real OKHSL values in ColorPicker.
+	color_picker->ok_hsl_h = color_picker->sliders[0]->get_value() / 360.0;
+	color_picker->ok_hsl_s = color_picker->sliders[1]->get_value() / 100.0;
+	color_picker->ok_hsl_l = color_picker->sliders[2]->get_value() / 100.0;
+	color_picker->h = color_picker->color.get_h();
+	color_picker->s = color_picker->color.get_s();
+	color_picker->v = color_picker->color.get_v();
+
+	// This prevents _set_pick_color() from overwriting the values set above.
+	color_picker->last_color = color_picker->color;
 }
 
 String ColorModeOKHSL::get_slider_label(int idx) const {

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -464,28 +464,6 @@ void ColorPicker::_slider_value_changed() {
 	color = modes[current_mode]->get_color();
 	modes[current_mode]->_value_changed();
 
-	if (current_mode == MODE_HSV) {
-		h = sliders[0]->get_value() / 360.0;
-		s = sliders[1]->get_value() / 100.0;
-		v = sliders[2]->get_value() / 100.0;
-		ok_hsl_h = color.get_ok_hsl_h();
-		ok_hsl_s = color.get_ok_hsl_s();
-		ok_hsl_l = color.get_ok_hsl_l();
-
-		circle_keyboard_joypad_picker_cursor_position = Vector2i();
-		last_color = color;
-	} else if (current_mode == MODE_OKHSL) {
-		ok_hsl_h = sliders[0]->get_value() / 360.0;
-		ok_hsl_s = sliders[1]->get_value() / 100.0;
-		ok_hsl_l = sliders[2]->get_value() / 100.0;
-		h = color.get_h();
-		s = color.get_s();
-		v = color.get_v();
-
-		circle_keyboard_joypad_picker_cursor_position = Vector2i();
-		last_color = color;
-	}
-
 	_set_pick_color(color, false);
 	if (!deferred_mode_enabled || !currently_dragging) {
 		emit_signal(SNAME("color_changed"), color);
@@ -862,7 +840,6 @@ void ColorPicker::set_picker_shape(PickerShapeType p_shape) {
 		btn_shape->set_button_icon(shape_popup->get_item_icon(p_shape));
 	}
 
-	circle_keyboard_joypad_picker_cursor_position = Vector2i();
 	current_shape = p_shape;
 
 #ifdef TOOLS_ENABLED
@@ -1037,7 +1014,6 @@ void ColorPicker::_set_mode_popup_value(ColorModeType p_mode) {
 	} else {
 		set_color_mode(p_mode);
 	}
-	circle_keyboard_joypad_picker_cursor_position = Vector2i();
 }
 
 Variant ColorPicker::_get_drag_data_fw(const Point2 &p_point, Control *p_from_control) {
@@ -1837,7 +1813,6 @@ void ColorPicker::_html_focus_exit() {
 	} else {
 		_update_text_value();
 	}
-	circle_keyboard_joypad_picker_cursor_position = Vector2i();
 }
 
 void ColorPicker::set_can_add_swatches(bool p_enabled) {

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -133,7 +133,6 @@ private:
 #endif
 
 	int current_slider_count = SLIDER_COUNT;
-	Vector2i circle_keyboard_joypad_picker_cursor_position;
 
 	const float DEFAULT_GAMEPAD_EVENT_DELAY_MS = 1.0 / 2;
 	const float GAMEPAD_EVENT_REPEAT_RATE_MS = 1.0 / 30;


### PR DESCRIPTION
- Removed unused `circle_keyboard_joypad_picker_cursor_position` (leftover from #99515, the property was moved to ColorPickerShape)
- Moved some ColorMode dependent code out of ColorPicker

The latter change is questionable, or at least its implementation. While ColorModes should be responsible for all color handling, modifying private members is probably not the best way to do that. Proper solution would involve passing `h`, `s`, `v` values to ColorModes to update them, but it's more hassle than it's worth it.
ColorPickerShapes already operate on private members. All these classes are friends  of ColorPicker for a reason🙃 They are supposed to be used internally and only by ColorPicker, so it's _probably fine_.