### PR TITLE
Fix camera feed device order on Linux

### DIFF
--- a/modules/camera/camera_linux.cpp
+++ b/modules/camera/camera_linux.cpp
@@ -61,23 +61,23 @@ void CameraLinux::_update_devices() {
 				}
 			}
 
-			DIR *devices = opendir("/dev");
+			struct dirent **devices;
+			int count = scandir("/dev", &devices, nullptr, alphasort);
 
-			if (devices) {
-				struct dirent *device;
-
-				while ((device = readdir(devices)) != nullptr) {
-					if (strncmp(device->d_name, "video", 5) != 0) {
-						continue;
+			if (count != -1) {
+				for (int i = 0; i < count; i++) {
+					struct dirent *device = devices[i];
+					if (strncmp(device->d_name, "video", 5) == 0) {
+						String device_name = String("/dev/") + String(device->d_name);
+						if (!_has_device(device_name)) {
+							_add_device(device_name);
+						}
 					}
-					String device_name = String("/dev/") + String(device->d_name);
-					if (!_has_device(device_name)) {
-						_add_device(device_name);
-					}
+					free(device);
 				}
 			}
 
-			closedir(devices);
+			free(devices);
 		}
 
 		usleep(1000000);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This changes Camera Feeds in Linux to respect device order by filename.
`readdir` does not guarantee ordering, which led to inconsistent ids between Godot and v4l2-ctl.

This fixes a personal use-case I had where my application lists available camera devices and I need to send an accurate id to a forked openseeface process, otherwise it won't connect to the correct camera.

