### PR TITLE
Update Mesa-NIR library detection and download script.

### DIFF
--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -43,8 +43,16 @@ if env["use_pix"]:
 
 # Mesa (SPIR-V to DXIL functionality).
 
-mesa_dir = (env["mesa_libs"] + "/godot-mesa").replace("\\", "/")
-mesa_gen_dir = (env["mesa_libs"] + "/godot-mesa/generated").replace("\\", "/")
+mesa_libs = env["mesa_libs"]
+if env.msvc and os.path.exists(env["mesa_libs"] + "-" + env["arch"] + "-msvc"):
+    mesa_libs = env["mesa_libs"] + "-" + env["arch"] + "-msvc"
+elif env["use_llvm"] and os.path.exists(env["mesa_libs"] + "-" + env["arch"] + "-llvm"):
+    mesa_libs = env["mesa_libs"] + "-" + env["arch"] + "-llvm"
+elif not env["use_llvm"] and os.path.exists(env["mesa_libs"] + "-" + env["arch"] + "-gcc"):
+    mesa_libs = env["mesa_libs"] + "-" + env["arch"] + "-gcc"
+
+mesa_dir = (mesa_libs + "/godot-mesa").replace("\\", "/")
+mesa_gen_dir = (mesa_libs + "/godot-mesa/generated").replace("\\", "/")
 mesa_absdir = Dir(mesa_dir).abspath
 mesa_gen_absdir = Dir(mesa_dir + "/generated").abspath
 

--- a/misc/scripts/install_d3d12_sdk_windows.py
+++ b/misc/scripts/install_d3d12_sdk_windows.py
@@ -20,10 +20,7 @@ else:
 
 # Mesa NIR
 # Check for latest version: https://github.com/godotengine/godot-nir-static/releases/latest
-mesa_version = "23.1.9"
-mesa_filename = "godot-nir-23.1.9.zip"
-mesa_archive = os.path.join(deps_folder, mesa_filename)
-mesa_folder = os.path.join(deps_folder, "mesa")
+mesa_version = "23.1.9-1"
 # WinPixEventRuntime
 # Check for latest version: https://www.nuget.org/api/v2/package/WinPixEventRuntime (check downloaded filename)
 pix_version = "1.0.240308001"
@@ -43,20 +40,34 @@ if not os.path.exists(deps_folder):
 
 # Mesa NIR
 color_print(f"{Ansi.BOLD}[1/3] Mesa NIR")
-if os.path.isfile(mesa_archive):
+for arch in [
+    "arm64-llvm",
+    "arm64-msvc",
+    "x86_32-gcc",
+    "x86_32-llvm",
+    "x86_32-msvc",
+    "x86_64-gcc",
+    "x86_64-llvm",
+    "x86_64-msvc",
+]:
+    mesa_filename = "godot-nir-static-" + arch + "-release.zip"
+    mesa_archive = os.path.join(deps_folder, mesa_filename)
+    mesa_folder = os.path.join(deps_folder, "mesa-" + arch)
+
+    if os.path.isfile(mesa_archive):
+        os.remove(mesa_archive)
+    print(f"Downloading Mesa NIR {mesa_filename} ...")
+    urllib.request.urlretrieve(
+        f"https://github.com/godotengine/godot-nir-static/releases/download/{mesa_version}/{mesa_filename}",
+        mesa_archive,
+    )
+    if os.path.exists(mesa_folder):
+        print(f"Removing existing local Mesa NIR installation in {mesa_folder} ...")
+        shutil.rmtree(mesa_folder)
+    print(f"Extracting Mesa NIR {mesa_filename} to {mesa_folder} ...")
+    shutil.unpack_archive(mesa_archive, mesa_folder)
     os.remove(mesa_archive)
-print(f"Downloading Mesa NIR {mesa_filename} ...")
-urllib.request.urlretrieve(
-    f"https://github.com/godotengine/godot-nir-static/releases/download/{mesa_version}/{mesa_filename}",
-    mesa_archive,
-)
-if os.path.exists(mesa_folder):
-    print(f"Removing existing local Mesa NIR installation in {mesa_folder} ...")
-    shutil.rmtree(mesa_folder)
-print(f"Extracting Mesa NIR {mesa_filename} to {mesa_folder} ...")
-shutil.unpack_archive(mesa_archive, mesa_folder)
-os.remove(mesa_archive)
-print(f"Mesa NIR {mesa_filename} installed successfully.\n")
+print("Mesa NIR installed successfully.\n")
 
 # WinPixEventRuntime
 


### PR DESCRIPTION
- Updates download script to use current build of Mesa (23.1.9-1).
- Adds path checks to detect compiler specific libs.

Supersede https://github.com/godotengine/godot/pull/105468