### PR TITLE
AudioEffectPitchShift: Silence bogus GCC `-Wstringop-overflow` warning

### DIFF
--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -160,6 +160,16 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 
 			/* ***************** PROCESSING ******************* */
 			/* this does the actual pitch shifting */
+
+			/* Bogus MinGW/GCC warning:
+			* servers/audio/effects/audio_effect_pitch_shift.cpp: In member function 'void SMBPitchShift::PitchShift(float, long int, long int, long int, float, float*, float*, int)':
+			* servers/audio/effects/audio_effect_pitch_shift.cpp:163:31: error: 'void* memset(void*, int, size_t)' specified bound between 18446744065119617024 and 18446744073709551608
+			*                                                                   exceeds maximum object size 9223372036854775807 [-Werror=stringop-overflow=]
+			* 163 |                         memset(gSynMagn, 0, fftFrameSize*sizeof(float));
+			*     |                         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+			*/
+			GODOT_GCC_WARNING_PUSH
+			GODOT_GCC_PRAGMA(GCC diagnostic warning "-Wstringop-overflow=0") // Can't "ignore" this for some reason.
 			memset(gSynMagn, 0, fftFrameSize*sizeof(float));
 			memset(gSynFreq, 0, fftFrameSize*sizeof(float));
 			for (k = 0; k <= fftFrameSize2; k++) {
@@ -169,6 +179,8 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 					gSynFreq[index] = gAnaFreq[k] * pitchShift;
 				}
 			}
+
+			GODOT_GCC_WARNING_POP
 
 			/* ***************** SYNTHESIS ******************* */
 			/* this is the synthesis step */


### PR DESCRIPTION
I've tried and failed to give GCC guarantees that this is fine, at this point I suspect it's just a GCC bug. I'm tired of running into it every time I try to validate that our older branches still compile fine, so I'll backport it to all branches.

Previous attempts at fixing this:
- #88509
- #88658

Which actually didn't work, I was likely just (un)lucky while working on those and hit conditions where GCC didn't bug out.