### PR TITLE
Remove Jolt Physics project setting "Areas Detect Static Bodies"

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2620,12 +2620,6 @@
 		<member name="physics/jolt_physics_3d/simulation/allow_sleep" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], [RigidBody3D] nodes are allowed to go to sleep if their velocity is below the threshold defined in [member physics/jolt_physics_3d/simulation/sleep_velocity_threshold] for the duration set in [member physics/jolt_physics_3d/simulation/sleep_time_threshold]. This can improve physics simulation performance when there are non-moving [RigidBody3D] nodes, at the cost of some nodes possibly failing to wake up in certain scenarios. Consider disabling this temporarily to troubleshoot [RigidBody3D] nodes not moving when they should.
 		</member>
-		<member name="physics/jolt_physics_3d/simulation/areas_detect_static_bodies" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], [Area3D] nodes are able to detect overlaps with [StaticBody3D] nodes.
-			[b]Note:[/b] Enabling this setting can come at a heavy CPU and memory cost if you allow many/large [Area3D] to overlap with complex static geometry, such as [ConcavePolygonShape3D] or [HeightMapShape3D]. It is strongly recommended that you set up your collision layers and masks in such a way that only a few small [Area3D] nodes can detect [StaticBody3D] nodes.
-			[b]Note:[/b] This also applies to overlaps with a [RigidBody3D] frozen with [constant RigidBody3D.FREEZE_MODE_STATIC].
-			[b]Note:[/b] This is not needed to detect overlaps with [AnimatableBody3D], as it is a kinematic body, despite inheriting from [StaticBody3D].
-		</member>
 		<member name="physics/jolt_physics_3d/simulation/baumgarte_stabilization_factor" type="float" setter="" getter="" default="0.2">
 			How much of the position error of a [RigidBody3D] to fix during a physics step, where [code]0.0[/code] is none and [code]1.0[/code] is the full amount. This affects things like how quickly bodies depenetrate.
 			[b]Note:[/b] Setting this value too high can make [RigidBody3D] nodes unstable.

--- a/modules/jolt_physics/jolt_project_settings.cpp
+++ b/modules/jolt_physics/jolt_project_settings.cpp
@@ -36,7 +36,6 @@ void JoltProjectSettings::register_settings() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "physics/jolt_physics_3d/simulation/velocity_steps", PROPERTY_HINT_RANGE, U"2,16,or_greater"), 10);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "physics/jolt_physics_3d/simulation/position_steps", PROPERTY_HINT_RANGE, U"1,16,or_greater"), 2);
 	GLOBAL_DEF(PropertyInfo(Variant::BOOL, "physics/jolt_physics_3d/simulation/use_enhanced_internal_edge_removal"), true);
-	GLOBAL_DEF(PropertyInfo(Variant::BOOL, "physics/jolt_physics_3d/simulation/areas_detect_static_bodies"), false);
 	GLOBAL_DEF(PropertyInfo(Variant::BOOL, "physics/jolt_physics_3d/simulation/generate_all_kinematic_contacts"), false);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/jolt_physics_3d/simulation/penetration_slop", PROPERTY_HINT_RANGE, U"0,1,0.00001,or_greater,suffix:m"), 0.02f);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/jolt_physics_3d/simulation/speculative_contact_distance", PROPERTY_HINT_RANGE, U"0,1,0.00001,or_greater,suffix:m"), 0.02f);
@@ -81,7 +80,6 @@ void JoltProjectSettings::read_settings() {
 	simulation_velocity_steps = GLOBAL_GET("physics/jolt_physics_3d/simulation/velocity_steps");
 	simulation_position_steps = GLOBAL_GET("physics/jolt_physics_3d/simulation/position_steps");
 	use_enhanced_internal_edge_removal_for_bodies = GLOBAL_GET("physics/jolt_physics_3d/simulation/use_enhanced_internal_edge_removal");
-	areas_detect_static_bodies = GLOBAL_GET("physics/jolt_physics_3d/simulation/areas_detect_static_bodies");
 	generate_all_kinematic_contacts = GLOBAL_GET("physics/jolt_physics_3d/simulation/generate_all_kinematic_contacts");
 	penetration_slop = GLOBAL_GET("physics/jolt_physics_3d/simulation/penetration_slop");
 	speculative_contact_distance = GLOBAL_GET("physics/jolt_physics_3d/simulation/speculative_contact_distance");

--- a/modules/jolt_physics/jolt_project_settings.h
+++ b/modules/jolt_physics/jolt_project_settings.h
@@ -42,7 +42,6 @@ public:
 	inline static int simulation_velocity_steps;
 	inline static int simulation_position_steps;
 	inline static bool use_enhanced_internal_edge_removal_for_bodies;
-	inline static bool areas_detect_static_bodies;
 	inline static bool generate_all_kinematic_contacts;
 	inline static float penetration_slop;
 	inline static float speculative_contact_distance;

--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -72,14 +72,11 @@ void JoltArea3D::_add_to_space() {
 	jolt_settings->mCollisionGroup = JPH::CollisionGroup(nullptr, group_id, sub_group_id);
 	jolt_settings->mMotionType = _get_motion_type();
 	jolt_settings->mIsSensor = true;
+	jolt_settings->mCollideKinematicVsNonDynamic = true;
 	jolt_settings->mUseManifoldReduction = false;
 	jolt_settings->mOverrideMassProperties = JPH::EOverrideMassProperties::MassAndInertiaProvided;
 	jolt_settings->mMassPropertiesOverride.mMass = 1.0f;
 	jolt_settings->mMassPropertiesOverride.mInertia = JPH::Mat44::sIdentity();
-
-	if (JoltProjectSettings::areas_detect_static_bodies) {
-		jolt_settings->mCollideKinematicVsNonDynamic = true;
-	}
 
 	jolt_settings->SetShape(jolt_shape);
 

--- a/modules/jolt_physics/spaces/jolt_layers.cpp
+++ b/modules/jolt_physics/spaces/jolt_layers.cpp
@@ -52,28 +52,25 @@ public:
 		using namespace JoltBroadPhaseLayer;
 
 		allow_collision(BODY_STATIC, BODY_DYNAMIC);
+		allow_collision(BODY_STATIC, AREA_DETECTABLE);
+		allow_collision(BODY_STATIC, AREA_UNDETECTABLE);
 		allow_collision(BODY_STATIC_BIG, BODY_DYNAMIC);
+		allow_collision(BODY_STATIC_BIG, AREA_DETECTABLE);
+		allow_collision(BODY_STATIC_BIG, AREA_UNDETECTABLE);
 		allow_collision(BODY_DYNAMIC, BODY_STATIC);
 		allow_collision(BODY_DYNAMIC, BODY_STATIC_BIG);
 		allow_collision(BODY_DYNAMIC, BODY_DYNAMIC);
 		allow_collision(BODY_DYNAMIC, AREA_DETECTABLE);
 		allow_collision(BODY_DYNAMIC, AREA_UNDETECTABLE);
 		allow_collision(AREA_DETECTABLE, BODY_DYNAMIC);
+		allow_collision(AREA_DETECTABLE, BODY_STATIC);
+		allow_collision(AREA_DETECTABLE, BODY_STATIC_BIG);
 		allow_collision(AREA_DETECTABLE, AREA_DETECTABLE);
 		allow_collision(AREA_DETECTABLE, AREA_UNDETECTABLE);
 		allow_collision(AREA_UNDETECTABLE, BODY_DYNAMIC);
+		allow_collision(AREA_UNDETECTABLE, BODY_STATIC);
+		allow_collision(AREA_UNDETECTABLE, BODY_STATIC_BIG);
 		allow_collision(AREA_UNDETECTABLE, AREA_DETECTABLE);
-
-		if (JoltProjectSettings::areas_detect_static_bodies) {
-			allow_collision(BODY_STATIC, AREA_DETECTABLE);
-			allow_collision(BODY_STATIC, AREA_UNDETECTABLE);
-			allow_collision(BODY_STATIC_BIG, AREA_DETECTABLE);
-			allow_collision(BODY_STATIC_BIG, AREA_UNDETECTABLE);
-			allow_collision(AREA_DETECTABLE, BODY_STATIC);
-			allow_collision(AREA_DETECTABLE, BODY_STATIC_BIG);
-			allow_collision(AREA_UNDETECTABLE, BODY_STATIC);
-			allow_collision(AREA_UNDETECTABLE, BODY_STATIC_BIG);
-		}
 	}
 
 	void allow_collision(UnderlyingType p_layer1, UnderlyingType p_layer2) { masks[p_layer1] |= uint8_t(1U << p_layer2); }

--- a/modules/jolt_physics/spaces/jolt_space_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_space_3d.cpp
@@ -48,6 +48,8 @@
 #include "core/string/print_string.h"
 #include "core/variant/variant_utility.h"
 
+#include "Jolt/Physics/Collision/CollideShapeVsShapePerLeaf.h"
+#include "Jolt/Physics/Collision/CollisionCollectorImpl.h"
 #include "Jolt/Physics/PhysicsScene.h"
 
 namespace {
@@ -120,6 +122,18 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem *p_job_system) :
 	physics_system->SetGravity(JPH::Vec3::sZero());
 	physics_system->SetContactListener(contact_listener);
 	physics_system->SetSoftBodyContactListener(contact_listener);
+
+	physics_system->SetSimCollideBodyVsBody([](const JPH::Body &p_body1, const JPH::Body &p_body2, JPH::Mat44Arg p_transform_com1, JPH::Mat44Arg p_transform_com2, JPH::CollideShapeSettings &p_collide_shape_settings, JPH::CollideShapeCollector &p_collector, const JPH::ShapeFilter &p_shape_filter) {
+		if (p_body1.IsSensor() || p_body2.IsSensor()) {
+			JPH::CollideShapeSettings new_collide_shape_settings = p_collide_shape_settings;
+			// Since we're breaking the sensor down into leaf shapes we'll end up stripping away our `JoltCustomDoubleSidedShape` decorator shape and thus any back-face collision, so we simply force-enable it like this rather than going through the trouble of reapplying the decorator.
+			new_collide_shape_settings.mBackFaceMode = JPH::EBackFaceMode::CollideWithBackFaces;
+			JPH::SubShapeIDCreator part1, part2;
+			JPH::CollideShapeVsShapePerLeaf<JPH::AnyHitCollisionCollector<JPH::CollideShapeCollector>>(p_body1.GetShape(), p_body2.GetShape(), JPH::Vec3::sOne(), JPH::Vec3::sOne(), p_transform_com1, p_transform_com2, part1, part2, new_collide_shape_settings, p_collector, p_shape_filter);
+		} else {
+			JPH::PhysicsSystem::sDefaultSimCollideBodyVsBody(p_body1, p_body2, p_transform_com1, p_transform_com2, p_collide_shape_settings, p_collector, p_shape_filter);
+		}
+	});
 
 	physics_system->SetCombineFriction([](const JPH::Body &p_body1, const JPH::SubShapeID &p_sub_shape_id1, const JPH::Body &p_body2, const JPH::SubShapeID &p_sub_shape_id2) {
 		return Math::abs(MIN(p_body1.GetFriction(), p_body2.GetFriction()));


### PR DESCRIPTION
As talked about in the recent update of Jolt Physics (#104449) and originally discussed in jrouwe/JoltPhysics#1476, this PR removes the project setting `physics/jolt_physics_3d/simulation/areas_detect_static_bodies`, effectively making it permanently `true`, in favor of leveraging the newly introduced `JPH::PhysicsSystem::SetSimCollideBodyVsBody` functionality, and the `JPH::CollideShapeVsShapePerLeaf` helper function, which lets us configure the amount of contacts that are generated (and thus cached) by Jolt as part of the collision detection that it does during simulation, thus mitigating the performance impact of enabling this project setting.

> [!WARNING]
> This is technically a breaking change, and potentially quite pervasive, depending on the project, since areas that were maybe not meant to detect static bodies now will. This does however bring Jolt Physics in line with how Godot Physics behaves (although it has its own issues with areas and static bodies) so I feel there's reasonable justification for just removing this setting completely rather than just changing its default to `true` and allowing people to disable it, especially when considering the current experimental label of the Jolt Physics integration.

This project setting has become a fairly popular one to enable over the years, largely due to Godot Physics supporting this already, and despite efforts to warn people about its ill effects in Jolt Physics specifically, most seem to just go ahead and enable it anyway, since the alternatives/workarounds can be inconvenient and/or unintuitive.

As such, this removes a fairly significant performance footgun, since by default Jolt would otherwise (when enabling this project setting) generate contacts for every overlapping triangle when an `Area3D` overlaps with a `ConcavePolygonShape3D`, which when dealing with complex collision meshes (or many/large `Area3D`) can end up being a lot. These contacts can add a lot of overhead both in terms of CPU and memory during the simulation step in ways that might not be easy to correlate to the source of the problem.

This new way of doing it is essentially exploiting the fact that `Area3D` in Godot doesn't actually expose the exact contacts between itself and the thing it's overlapping. This means that the underlying collision detection during simulation really only needs exactly one contact per shape, and that contact can be anywhere, which means we can set Jolt's underlying collision collector to be the much cheaper `JPH::AnyHitCollisionCollector` for any collision involving sensors/areas.

I still need to do some profiling to see the exact gains (and potential losses) from this, but this should hopefully be relatively safe merge, apart from the breaking change.

Note however that since we're now forced to always allow interactions between the broadphase layers belonging to areas and static bodies, this will presumably add some amount of additional cost to `Area3D`'s collision detection, for anyone who wasn't previously relying on this project setting, but it is what it is. Being diligent about using collision masks and layers properly (which should be done anyway) should hopefully mitigate some of that.

CC: @jrouwe