### PR TITLE
Peer Connected and Peer Disconnected Incorrect Event Order

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1529,8 +1529,14 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 		slot.reference_count = 1;
 	}
 
-	//use callable version as key, so binds can be ignored
-	s->slot_map[*p_callable.get_base_comparator()] = slot;
+	// Add first in the HashMap, if requested.
+	if (p_flags & CONNECT_FRONTINSERT){	
+		s->slot_map.insert(*p_callable.get_base_comparator(), slot, true);
+	}
+	else
+	{
+		s->slot_map[*p_callable.get_base_comparator()] = slot;
+	}
 
 	return OK;
 }

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1535,6 +1535,7 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 	}
 	else
 	{
+		//use callable version as key, so binds can be ignored
 		s->slot_map[*p_callable.get_base_comparator()] = slot;
 	}
 

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1530,11 +1530,9 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 	}
 
 	// Add first in the HashMap, if requested.
-	if (p_flags & CONNECT_FRONTINSERT){	
+	if (p_flags & CONNECT_FRONTINSERT) {
 		s->slot_map.insert(*p_callable.get_base_comparator(), slot, true);
-	}
-	else
-	{
+	} else {
 		//use callable version as key, so binds can be ignored
 		s->slot_map[*p_callable.get_base_comparator()] = slot;
 	}

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -573,6 +573,7 @@ public:
 		CONNECT_ONE_SHOT = 4,
 		CONNECT_REFERENCE_COUNTED = 8,
 		CONNECT_INHERITED = 16, // Used in editor builds.
+		CONNECT_FRONTINSERT = 32 // Inserted at the front of the Signal Map.
 	};
 
 	struct Connection {

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -203,6 +203,7 @@ void SceneMultiplayer::set_multiplayer_peer(const Ref<MultiplayerPeer> &p_peer) 
 	multiplayer_peer = p_peer;
 
 	if (multiplayer_peer.is_valid()) {
+		// We need to insert these first, otherwise prior bound events will not be able to utilize Network abilities like RPCs.
 		multiplayer_peer->connect("peer_connected", callable_mp(this, &SceneMultiplayer::_add_peer), CONNECT_FRONTINSERT);
 		multiplayer_peer->connect("peer_disconnected", callable_mp(this, &SceneMultiplayer::_del_peer), CONNECT_FRONTINSERT);
 	}

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -203,8 +203,9 @@ void SceneMultiplayer::set_multiplayer_peer(const Ref<MultiplayerPeer> &p_peer) 
 	multiplayer_peer = p_peer;
 
 	if (multiplayer_peer.is_valid()) {
-		multiplayer_peer->connect("peer_connected", callable_mp(this, &SceneMultiplayer::_add_peer));
-		multiplayer_peer->connect("peer_disconnected", callable_mp(this, &SceneMultiplayer::_del_peer));
+		// We to insert these first, otherwise prior bound events will not be able to utilise Network abilities like RPCs.
+		multiplayer_peer->connect("peer_connected", callable_mp(this, &SceneMultiplayer::_add_peer), CONNECT_FRONTINSERT);
+		multiplayer_peer->connect("peer_disconnected", callable_mp(this, &SceneMultiplayer::_del_peer), CONNECT_FRONTINSERT);
 	}
 	_update_status();
 }

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -203,7 +203,6 @@ void SceneMultiplayer::set_multiplayer_peer(const Ref<MultiplayerPeer> &p_peer) 
 	multiplayer_peer = p_peer;
 
 	if (multiplayer_peer.is_valid()) {
-		// We to insert these first, otherwise prior bound events will not be able to utilise Network abilities like RPCs.
 		multiplayer_peer->connect("peer_connected", callable_mp(this, &SceneMultiplayer::_add_peer), CONNECT_FRONTINSERT);
 		multiplayer_peer->connect("peer_disconnected", callable_mp(this, &SceneMultiplayer::_del_peer), CONNECT_FRONTINSERT);
 	}


### PR DESCRIPTION
- Added a new flag for the Connections to add a Signal to the front of the SignalMap.

- Implemented said flag into the `Object::connect`.

- Used this new flag on the SceneMultiplayer to have the "peer_connected" and "peer_disconnected" bound before any previous listeners.

The reason for this change is that if you bound these methods in C#/GDScript before setting the `MultiplayerPeer`, they wouldn't be unbound, but would just be before the Engine ones. The reason this is a problem is because the User will see their bound events triggered, but since no Players have been added by the Engine, RPCs, and other networked methods like `GetPeers()` either fail, or provide incorrect information.

For example:

```
ENetMultiplayerPeer ServerPeer = new ENetMultiplayerPeer();

ServerPeer.PeerConnected += OnUserConnected;
ServerPeer.PeerDisconnected += OnUserDisconnected;

Multiplayer.MultiplayerPeer = ServerPeer;
```
Would previously mean that the `OnUserConnected/Disconnected` would run before the Engine's bound events which actually adds the Peers. This mean that my code for trying to run an RPC would 'fail'. My `GetPeers()` call would also be incorrect. 

The front-end fix for me here is to bind after I assign the MultiplayerPeer, but I feel this is unintuitive and ambigious, especially with a lack of Warning, or Error.

An argument could be made this is on purpose to provide you with the choice; however, I would say having a separate `PrePeerConnected/Disconnected`, would be more apt.