### PR TITLE
Rename `String::size` to `String::buffer_size`, to prevent misinterpretation. Use `length()` instead where appropriate.

### DIFF
--- a/core/io/plist.cpp
+++ b/core/io/plist.cpp
@@ -300,7 +300,7 @@ bool PListNode::store_asn1(PackedByteArray &p_stream, uint8_t p_len_octets) cons
 		case PList::PLNodeType::PL_NODE_TYPE_STRING: {
 			p_stream.push_back(0x0C);
 			store_asn1_size(p_stream, p_len_octets);
-			for (int i = 0; i < data_string.size(); i++) {
+			for (int i = 0; i < data_string.buffer_size(); i++) {
 				p_stream.push_back(data_string[i]);
 			}
 		} break;

--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -267,7 +267,7 @@ Error ResourceUID::load_from_cache(bool p_reset) {
 		int32_t len = f->get_32();
 		Cache c;
 		c.cs.resize(len + 1);
-		ERR_FAIL_COND_V(c.cs.size() != len + 1, ERR_FILE_CORRUPT); // Out of memory.
+		ERR_FAIL_COND_V(c.cs.length() != len, ERR_FILE_CORRUPT); // Out of memory.
 		c.cs[len] = 0;
 		int32_t rl = f->get_buffer((uint8_t *)c.cs.ptrw(), len);
 		ERR_FAIL_COND_V(rl != len, ERR_FILE_CORRUPT);
@@ -327,7 +327,7 @@ String ResourceUID::get_path_from_cache(Ref<FileAccess> &p_cache_file, const Str
 		int64_t id = p_cache_file->get_64();
 		int32_t len = p_cache_file->get_32();
 		cs.resize(len + 1);
-		ERR_FAIL_COND_V(cs.size() != len + 1, String());
+		ERR_FAIL_COND_V(cs.length() != len, String());
 		cs[len] = 0;
 		int32_t rl = p_cache_file->get_buffer((uint8_t *)cs.ptrw(), len);
 		ERR_FAIL_COND_V(rl != len, String());

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -128,7 +128,7 @@ String Color::to_html(bool p_alpha) const {
 	if (p_alpha) {
 		_append_hex(a, ptr + 6);
 	}
-	ptr[txt.size() - 1] = '\0';
+	ptr[txt.buffer_size() - 1] = '\0';
 
 	return txt;
 }

--- a/core/string/fuzzy_search.cpp
+++ b/core/string/fuzzy_search.cpp
@@ -50,7 +50,7 @@ static Vector2i _extend_interval(const Vector2i &p_a, const Vector2i &p_b) {
 }
 
 static bool _is_word_boundary(const String &p_str, int p_index) {
-	if (p_index == -1 || p_index == p_str.size()) {
+	if (p_index == -1 || p_index == p_str.buffer_size()) {
 		return true;
 	}
 	return boundary_chars.find_char(p_str[p_index]) != -1;

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -77,16 +77,16 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 		//compress string
 		CharString src_s = p_from->get_message(E).operator String().utf8();
 		CompressedString ps;
-		ps.orig_len = src_s.size();
+		ps.orig_len = src_s.buffer_size();
 		ps.offset = total_compression_size;
 
 		if (ps.orig_len != 0) {
 			CharString dst_s;
-			dst_s.resize(src_s.size());
-			int ret = smaz_compress(src_s.get_data(), src_s.size(), dst_s.ptrw(), src_s.size());
-			if (ret >= src_s.size()) {
+			dst_s.resize(src_s.buffer_size());
+			int ret = smaz_compress(src_s.get_data(), src_s.buffer_size(), dst_s.ptrw(), src_s.buffer_size());
+			if (ret >= src_s.buffer_size()) {
 				//if compressed is larger than original, just use original
-				ps.orig_len = src_s.size();
+				ps.orig_len = src_s.buffer_size();
 				ps.compressed = src_s;
 			} else {
 				dst_s.resize(ret);
@@ -100,7 +100,7 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 		}
 
 		compressed.write[idx] = ps;
-		total_compression_size += ps.compressed.size();
+		total_compression_size += ps.compressed.buffer_size();
 		idx++;
 	}
 
@@ -160,7 +160,7 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 		for (const KeyValue<uint32_t, int> &E : t) {
 			btw[btindex++] = E.key;
 			btw[btindex++] = compressed[E.value].offset;
-			btw[btindex++] = compressed[E.value].compressed.size();
+			btw[btindex++] = compressed[E.value].compressed.buffer_size();
 			btw[btindex++] = compressed[E.value].orig_len;
 		}
 	}
@@ -169,7 +169,7 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 	uint8_t *cw = strings.ptrw();
 
 	for (int i = 0; i < compressed.size(); i++) {
-		memcpy(&cw[compressed[i].offset], compressed[i].compressed.get_data(), compressed[i].compressed.size());
+		memcpy(&cw[compressed[i].offset], compressed[i].compressed.get_data(), compressed[i].compressed.buffer_size());
 	}
 
 	ERR_FAIL_COND(btindex != bucket_table_size);

--- a/core/string/string_buffer.h
+++ b/core/string/string_buffer.h
@@ -118,7 +118,7 @@ StringBuffer<SHORT_BUFFER_SIZE> &StringBuffer<SHORT_BUFFER_SIZE>::append(const c
 template <int SHORT_BUFFER_SIZE>
 StringBuffer<SHORT_BUFFER_SIZE> &StringBuffer<SHORT_BUFFER_SIZE>::reserve(int p_size) {
 	ERR_FAIL_COND_V_MSG(p_size < length(), *this, "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
-	if (p_size <= SHORT_BUFFER_SIZE || p_size <= buffer.size()) {
+	if (p_size <= SHORT_BUFFER_SIZE || p_size <= buffer.length()) {
 		return *this;
 	}
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -117,14 +117,6 @@ void Char16String::operator=(const char16_t *p_cstr) {
 	copy_from(p_cstr);
 }
 
-const char16_t *Char16String::get_data() const {
-	if (size()) {
-		return &operator[](0);
-	} else {
-		return u"";
-	}
-}
-
 void Char16String::copy_from(const char16_t *p_cstr) {
 	if (!p_cstr) {
 		resize(0);
@@ -185,14 +177,6 @@ CharString &CharString::operator+=(char p_char) {
 
 void CharString::operator=(const char *p_cstr) {
 	copy_from(p_cstr);
-}
-
-const char *CharString::get_data() const {
-	if (size()) {
-		return &operator[](0);
-	} else {
-		return "";
-	}
 }
 
 void CharString::copy_from(const char *p_cstr) {
@@ -877,11 +861,6 @@ signed char String::filenocasecmp_to(const String &p_str) const {
 	return naturalnocasecmp_to_base(this_str, that_str);
 }
 
-const char32_t *String::get_data() const {
-	static const char32_t zero = 0;
-	return size() ? &operator[](0) : &zero;
-}
-
 String String::_separate_compound_words() const {
 	if (length() == 0) {
 		return *this;
@@ -920,9 +899,9 @@ String String::_separate_compound_words() const {
 		is_prev_digit = is_curr_digit;
 	}
 
-	new_string += substr(start_index, size() - start_index);
+	new_string += substr(start_index);
 
-	for (int i = 0; i < new_string.size(); i++) {
+	for (int i = 0; i < new_string.length(); i++) {
 		const bool whitespace = is_whitespace(new_string[i]);
 		const bool underscore = is_underscore(new_string[i]);
 		const bool hyphen = is_hyphen(new_string[i]);
@@ -1541,7 +1520,7 @@ String String::to_upper() const {
 	}
 
 	String upper;
-	upper.resize(size());
+	upper.resize(length() + 1); // + 1 for NUL terminator
 	const char32_t *old_ptr = ptr();
 	char32_t *upper_ptrw = upper.ptrw();
 
@@ -1560,7 +1539,7 @@ String String::to_lower() const {
 	}
 
 	String lower;
-	lower.resize(size());
+	lower.resize(length() + 1); // + 1 for NUL terminator
 	const char32_t *old_ptr = ptr();
 	char32_t *lower_ptrw = lower.ptrw();
 
@@ -1879,11 +1858,11 @@ CharString String::ascii(bool p_allow_extended) const {
 	}
 
 	CharString cs;
-	cs.resize(size());
+	cs.resize(length() + 1); // + 1 for NUL terminator
 	char *cs_ptrw = cs.ptrw();
 	const char32_t *this_ptr = ptr();
 
-	for (int i = 0; i < size(); i++) {
+	for (int i = 0; i < length(); i++) {
 		char32_t c = this_ptr[i];
 		if ((c <= 0x7f) || (c <= 0xff && p_allow_extended)) {
 			cs_ptrw[i] = char(c);
@@ -1892,6 +1871,7 @@ CharString String::ascii(bool p_allow_extended) const {
 			cs_ptrw[i] = 0x20; // ASCII doesn't have a replacement character like unicode, 0x1a is sometimes used but is kinda arcane.
 		}
 	}
+	cs[cs.length()] = 0;
 
 	return cs;
 }
@@ -5509,7 +5489,7 @@ String String::path_join(const String &p_file) const {
 	if (is_empty()) {
 		return p_file;
 	}
-	if (operator[](length() - 1) == '/' || (p_file.size() > 0 && p_file.operator[](0) == '/')) {
+	if (operator[](length() - 1) == '/' || (p_file.length() > 0 && p_file.operator[](0) == '/')) {
 		return *this + p_file;
 	}
 	return *this + "/" + p_file;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -152,7 +152,6 @@ class Char16String {
 public:
 	_FORCE_INLINE_ char16_t *ptrw() { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const char16_t *ptr() const { return _cowdata.ptr(); }
-	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 
 	_FORCE_INLINE_ operator Span<char16_t>() const { return Span(ptr(), length()); }
 	_FORCE_INLINE_ Span<char16_t> span() const { return Span(ptr(), length()); }
@@ -180,8 +179,13 @@ public:
 	void operator=(const char16_t *p_cstr);
 	bool operator<(const Char16String &p_right) const;
 	Char16String &operator+=(char16_t p_char);
-	int length() const { return size() ? size() - 1 : 0; }
-	const char16_t *get_data() const;
+
+	int length() const { return _cowdata.is_empty() ? 0 : _cowdata.size() - 1; }
+	/// Size of the underlying buffer, including the NULL terminator.
+	/// Usually, length() is preferable.
+	_FORCE_INLINE_ int buffer_size() const { return _cowdata.size(); }
+	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
+	const char16_t *get_data() const { return is_empty() ? &_null : _cowdata.ptr(); }
 
 protected:
 	void copy_from(const char16_t *p_cstr);
@@ -198,7 +202,6 @@ class CharString {
 public:
 	_FORCE_INLINE_ char *ptrw() { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const char *ptr() const { return _cowdata.ptr(); }
-	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 
 	_FORCE_INLINE_ operator Span<char>() const { return Span(ptr(), length()); }
 	_FORCE_INLINE_ Span<char> span() const { return Span(ptr(), length()); }
@@ -227,8 +230,13 @@ public:
 	bool operator<(const CharString &p_right) const;
 	bool operator==(const CharString &p_right) const;
 	CharString &operator+=(char p_char);
-	int length() const { return size() ? size() - 1 : 0; }
-	const char *get_data() const;
+
+	int length() const { return _cowdata.is_empty() ? 0 : _cowdata.size() - 1; }
+	/// Size of the underlying buffer, including the NULL terminator.
+	/// Usually, length() is preferable.
+	_FORCE_INLINE_ int buffer_size() const { return _cowdata.size(); }
+	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
+	const char *get_data() const { return is_empty() ? &_null : _cowdata.ptr(); }
 
 protected:
 	void copy_from(const char *p_cstr);
@@ -286,7 +294,6 @@ public:
 
 	_FORCE_INLINE_ char32_t *ptrw() { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const char32_t *ptr() const { return _cowdata.ptr(); }
-	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 
 	_FORCE_INLINE_ operator Span<char32_t>() const { return Span(ptr(), length()); }
 	_FORCE_INLINE_ Span<char32_t> span() const { return Span(ptr(), length()); }
@@ -350,13 +357,14 @@ public:
 	signed char filecasecmp_to(const String &p_str) const;
 	signed char filenocasecmp_to(const String &p_str) const;
 
-	const char32_t *get_data() const;
 	/* standard size stuff */
 
-	_FORCE_INLINE_ int length() const {
-		int s = size();
-		return s ? (s - 1) : 0; // length does not include zero
-	}
+	int length() const { return _cowdata.is_empty() ? 0 : _cowdata.size() - 1; }
+	/// Size of the underlying buffer, including the NULL terminator.
+	/// Usually, length() is preferable.
+	_FORCE_INLINE_ int buffer_size() const { return _cowdata.size(); }
+	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
+	const char32_t *get_data() const { return is_empty() ? &_null : _cowdata.ptr(); }
 
 	bool is_valid_string() const;
 
@@ -551,7 +559,6 @@ public:
 	Vector<uint8_t> sha1_buffer() const;
 	Vector<uint8_t> sha256_buffer() const;
 
-	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
 	_FORCE_INLINE_ bool contains(const char *p_str) const { return find(p_str) != -1; }
 	_FORCE_INLINE_ bool contains(const String &p_str) const { return find(p_str) != -1; }
 	_FORCE_INLINE_ bool contains_char(char32_t p_chr) const { return find_char(p_chr) != -1; }

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -6212,7 +6212,7 @@ void RenderingDeviceDriverD3D12::end_segment() {
 
 void RenderingDeviceDriverD3D12::_set_object_name(ID3D12Object *p_object, String p_object_name) {
 	ERR_FAIL_NULL(p_object);
-	int name_len = p_object_name.size();
+	int name_len = p_object_name.buffer_size();
 	WCHAR *name_w = (WCHAR *)alloca(sizeof(WCHAR) * (name_len + 1));
 	MultiByteToWideChar(CP_UTF8, 0, p_object_name.utf8().get_data(), -1, name_w, name_len);
 	p_object->SetName(name_w);

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -176,7 +176,7 @@ void ShaderGLES3::_build_variant_code(StringBuilder &builder, uint32_t p_variant
 			builder.append("#define " + String(specializations[i].name) + "\n");
 		}
 	}
-	if (p_version->uniforms.size()) {
+	if (p_version->uniforms.length()) {
 		builder.append("#define MATERIAL_UNIFORMS_USED\n");
 	}
 	for (const KeyValue<StringName, CharString> &E : p_version->code_sections) {

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -677,7 +677,7 @@ PackedByteArray OS_Unix::string_to_multibyte(const String &p_encoding, const Str
 	ERR_FAIL_COND_V_MSG(ctx == (gd_iconv_t)(-1), PackedByteArray(), "Conversion failed: Unknown encoding");
 
 	char *in_ptr = (char *)charstr.ptr();
-	size_t in_size = charstr.size();
+	size_t in_size = charstr.buffer_size();
 
 	ret.resize(in_size);
 	char *out_ptr = (char *)ret.ptrw();
@@ -688,7 +688,7 @@ PackedByteArray OS_Unix::string_to_multibyte(const String &p_encoding, const Str
 			gd_iconv_close(ctx);
 			ERR_FAIL_V_MSG(PackedByteArray(), vformat("Conversion failed: %d - %s", errno, strerror(errno)));
 		}
-		int64_t rate = (ret.size()) / (charstr.size() - in_size);
+		int64_t rate = (ret.size()) / (charstr.buffer_size() - in_size);
 		size_t oldpos = ret.size() - out_size;
 		ret.resize(ret.size() + in_size * rate);
 		out_ptr = (char *)ret.ptrw() + oldpos;

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -156,7 +156,7 @@ Error DirAccessWindows::change_dir(String p_dir) {
 	Char16String real_current_dir_name;
 	size_t str_len = GetCurrentDirectoryW(0, nullptr);
 	real_current_dir_name.resize(str_len + 1);
-	GetCurrentDirectoryW(real_current_dir_name.size(), (LPWSTR)real_current_dir_name.ptrw());
+	GetCurrentDirectoryW(real_current_dir_name.buffer_size(), (LPWSTR)real_current_dir_name.ptrw());
 	String prev_dir = String::utf16((const char16_t *)real_current_dir_name.get_data());
 
 	SetCurrentDirectoryW((LPCWSTR)(current_dir.utf16().get_data()));
@@ -166,7 +166,7 @@ Error DirAccessWindows::change_dir(String p_dir) {
 	if (!base.is_empty()) {
 		str_len = GetCurrentDirectoryW(0, nullptr);
 		real_current_dir_name.resize(str_len + 1);
-		GetCurrentDirectoryW(real_current_dir_name.size(), (LPWSTR)real_current_dir_name.ptrw());
+		GetCurrentDirectoryW(real_current_dir_name.buffer_size(), (LPWSTR)real_current_dir_name.ptrw());
 		String new_dir = String::utf16((const char16_t *)real_current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/');
 		if (!new_dir.begins_with(base)) {
 			worked = false;
@@ -176,7 +176,7 @@ Error DirAccessWindows::change_dir(String p_dir) {
 	if (worked) {
 		str_len = GetCurrentDirectoryW(0, nullptr);
 		real_current_dir_name.resize(str_len + 1);
-		GetCurrentDirectoryW(real_current_dir_name.size(), (LPWSTR)real_current_dir_name.ptrw());
+		GetCurrentDirectoryW(real_current_dir_name.buffer_size(), (LPWSTR)real_current_dir_name.ptrw());
 		current_dir = String::utf16((const char16_t *)real_current_dir_name.get_data());
 	}
 
@@ -476,7 +476,7 @@ DirAccessWindows::DirAccessWindows() {
 	Char16String real_current_dir_name;
 	size_t str_len = GetCurrentDirectoryW(0, nullptr);
 	real_current_dir_name.resize(str_len + 1);
-	GetCurrentDirectoryW(real_current_dir_name.size(), (LPWSTR)real_current_dir_name.ptrw());
+	GetCurrentDirectoryW(real_current_dir_name.buffer_size(), (LPWSTR)real_current_dir_name.ptrw());
 	current_dir = String::utf16((const char16_t *)real_current_dir_name.get_data());
 
 	DWORD mask = GetLogicalDrives();

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -86,7 +86,7 @@ String FileAccessWindows::fix_path(const String &p_path) const {
 		Char16String current_dir_name;
 		size_t str_len = GetCurrentDirectoryW(0, nullptr);
 		current_dir_name.resize(str_len + 1);
-		GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
+		GetCurrentDirectoryW(current_dir_name.buffer_size(), (LPWSTR)current_dir_name.ptrw());
 		r_path = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(r_path);
 	}
 	r_path = r_path.simplify_path();

--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -146,7 +146,7 @@ Dictionary DebugAdapterParser::req_initialize(const Dictionary &p_params) const 
 		ScriptEditor::get_singleton()->get_breakpoints(&breakpoints);
 		for (const String &breakpoint : breakpoints) {
 			String path = breakpoint.left(breakpoint.find_char(':', 6)); // Skip initial part of path, aka "res://"
-			int line = breakpoint.substr(path.size()).to_int();
+			int line = breakpoint.substr(path.length() + 1).to_int();
 
 			DebugAdapterProtocol::get_singleton()->on_debug_breakpoint_toggled(path, line, true);
 		}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -252,9 +252,7 @@ void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vecto
 				scene_name = scene_name.trim_suffix("/");
 				full_path = full_path.trim_suffix("/");
 
-				int scene_name_size = scene_name.size();
-				int full_path_size = full_path.size();
-				int difference = full_path_size - scene_name_size;
+				int difference = full_path.length() - scene_name.length();
 
 				// Find just the parent folder of the current path and append it.
 				// If the current name is foo.tscn, and the full path is /some/folder/foo.tscn
@@ -309,7 +307,7 @@ void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vecto
 				// We can proceed if the full path is longer than the scene name,
 				// meaning that there is at least one more parent folder we can
 				// tack onto the name.
-				can_proceed = can_proceed || (path.size() - scene_name.size()) >= 1;
+				can_proceed = can_proceed || (path.length() - scene_name.length()) >= 1;
 
 				E = E->next();
 				if (to_erase) {

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -60,7 +60,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 	}
 
 	const String debug_uri = EditorDebuggerNode::get_singleton()->get_server_uri();
-	if (debug_uri.size()) {
+	if (debug_uri.length()) {
 		args.push_back("--remote-debug");
 		args.push_back(debug_uri);
 	}

--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -925,7 +925,7 @@ CodeSignCodeDirectory::CodeSignCodeDirectory(uint8_t p_hash_size, uint8_t p_hash
 	code_slots = pages + (remain > 0 ? 1 : 0);
 	special_slots = 7;
 
-	int cd_size = 8 + sizeof(CodeDirectoryHeader) + (code_slots + special_slots) * p_hash_size + p_id.size() + p_team_id.size();
+	int cd_size = 8 + sizeof(CodeDirectoryHeader) + (code_slots + special_slots) * p_hash_size + p_id.buffer_size() + p_team_id.buffer_size();
 	int cd_off = 8 + sizeof(CodeDirectoryHeader);
 	blob.append_array({ 0xFA, 0xDE, 0x0C, 0x02 }); // Code Directory magic.
 	for (int i = 3; i >= 0; i--) {
@@ -963,14 +963,14 @@ CodeSignCodeDirectory::CodeSignCodeDirectory(uint8_t p_hash_size, uint8_t p_hash
 
 	// Copy ID.
 	cd->ident_offset = BSWAP32(cd_off);
-	memcpy(blob.ptrw() + cd_off, p_id.get_data(), p_id.size());
-	cd_off += p_id.size();
+	memcpy(blob.ptrw() + cd_off, p_id.get_data(), p_id.buffer_size());
+	cd_off += p_id.buffer_size();
 
 	// Copy Team ID.
 	if (p_team_id.length() > 0) {
 		cd->team_offset = BSWAP32(cd_off);
-		memcpy(blob.ptrw() + cd_off, p_team_id.get_data(), p_team_id.size());
-		cd_off += p_team_id.size();
+		memcpy(blob.ptrw() + cd_off, p_team_id.get_data(), p_team_id.buffer_size());
+		cd_off += p_team_id.buffer_size();
 	} else {
 		cd->team_offset = 0;
 	}

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1399,7 +1399,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				String import_text = config->encode_to_text();
 				CharString cs = import_text.utf8();
 				Vector<uint8_t> sarr;
-				sarr.resize(cs.size());
+				sarr.resize(cs.buffer_size());
 				memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
 
 				err = save_proxy.save_file(p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed);
@@ -1468,7 +1468,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				String import_text = config->encode_to_text();
 				CharString cs = import_text.utf8();
 				Vector<uint8_t> sarr;
-				sarr.resize(cs.size());
+				sarr.resize(cs.buffer_size());
 				memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
 
 				err = save_proxy.save_file(p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed);
@@ -1721,7 +1721,7 @@ void EditorExportPlatform::zip_folder_recursive(zipFile &p_zip, const String &p_
 					1 << 11); // Bit 11 is the language encoding flag. When set, filename and comment fields must be encoded using UTF-8.
 
 			const CharString target_utf8 = da->read_link(f).utf8();
-			zipWriteInFileInZip(p_zip, target_utf8.get_data(), target_utf8.size());
+			zipWriteInFileInZip(p_zip, target_utf8.get_data(), target_utf8.buffer_size());
 			zipCloseFileInZip(p_zip);
 		} else if (da->current_is_dir()) {
 			zip_folder_recursive(p_zip, p_root_path, p_folder.path_join(f), p_pkg_name);

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -481,7 +481,7 @@ bool ExportTemplateManager::_install_file_selected(const String &p_file, bool p_
 			contents_dir = file.get_base_dir().trim_suffix("/").trim_suffix("\\");
 		}
 
-		if (file.get_file().size() != 0) {
+		if (file.get_file().length() != 0) {
 			fc++;
 		}
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3696,8 +3696,8 @@ void FileSystemDock::_file_list_gui_input(Ref<InputEvent> p_event) {
 		} else {
 			// Find parent folder.
 			fpath = fpath.substr(0, fpath.rfind_char('/') + 1);
-			if (fpath.size() > String("res://").size()) {
-				fpath = fpath.left(fpath.size() - 2); // Remove last '/'.
+			if ((size_t)fpath.length() > strlen("res://")) {
+				fpath = fpath.left(fpath.length() - 1); // Remove last '/'.
 				const int slash_idx = fpath.rfind_char('/');
 				fpath = fpath.substr(slash_idx + 1);
 			}

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -72,7 +72,7 @@ static bool find_next(const String &line, const String &pattern, int from, bool 
 			if (begin > 0 && (is_ascii_identifier_char(line[begin - 1]))) {
 				continue;
 			}
-			if (end < line.size() && (is_ascii_identifier_char(line[end]))) {
+			if (end < line.buffer_size() && (is_ascii_identifier_char(line[end]))) {
 				continue;
 			}
 		}
@@ -772,9 +772,9 @@ void FindInFilesPanel::_on_result_found(const String &fpath, int line_number, in
 	item->set_cell_mode(text_index, TreeItem::CELL_MODE_CUSTOM);
 
 	// Trim result item line.
-	int old_text_size = text.size();
+	int old_text_length = text.length();
 	text = text.strip_edges(true, false);
-	int chars_removed = old_text_size - text.size();
+	int chars_removed = old_text_length - text.length();
 	String start = vformat("%3s: ", line_number);
 
 	item->set_text(text_index, start + text);
@@ -784,7 +784,7 @@ void FindInFilesPanel::_on_result_found(const String &fpath, int line_number, in
 	r.line_number = line_number;
 	r.begin = begin;
 	r.end = end;
-	r.begin_trimmed = begin - chars_removed + start.size() - 1;
+	r.begin_trimmed = begin - chars_removed + start.length();
 	_result_items[item] = r;
 
 	if (_with_replace) {

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -1432,7 +1432,7 @@ void EditorFileDialog::set_current_file(const String &p_file) {
 }
 
 void EditorFileDialog::set_current_path(const String &p_path) {
-	if (!p_path.size()) {
+	if (!p_path.length()) {
 		return;
 	}
 	int pos = MAX(p_path.rfind_char('/'), p_path.rfind_char('\\'));

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -504,7 +504,7 @@ String ScriptEditor::_get_debug_tooltip(const String &p_text, Node *p_se) {
 	String debug_value = EditorDebuggerNode::get_singleton()->get_var_value(p_text);
 	if (!debug_value.is_empty()) {
 		constexpr int DISPLAY_LIMIT = 1024;
-		if (debug_value.size() > DISPLAY_LIMIT) {
+		if (debug_value.length() > DISPLAY_LIMIT) {
 			debug_value = debug_value.left(DISPLAY_LIMIT) + "... " + TTR("(truncated)");
 		}
 		debug_value = TTR("Current value: ") + debug_value;
@@ -2506,7 +2506,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 		bool has_file_flag = false;
 		String script_path = ProjectSettings::get_singleton()->globalize_path(p_resource->get_path());
 
-		if (flags.size()) {
+		if (flags.length()) {
 			String project_path = ProjectSettings::get_singleton()->get_resource_path();
 
 			flags = flags.replacen("{line}", itos(p_line > 0 ? p_line : 0));
@@ -2517,7 +2517,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 			int num_chars = 0;
 			bool inside_quotes = false;
 
-			for (int i = 0; i < flags.size(); i++) {
+			for (int i = 0; i < flags.buffer_size(); i++) {
 				if (flags[i] == '"' && (!i || flags[i - 1] != '\\')) {
 					if (!inside_quotes) {
 						from++;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1211,7 +1211,7 @@ void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, i
 	String debug_value = EditorDebuggerNode::get_singleton()->get_var_value(p_symbol);
 	if (!debug_value.is_empty()) {
 		constexpr int DISPLAY_LIMIT = 1024;
-		if (debug_value.size() > DISPLAY_LIMIT) {
+		if (debug_value.length() > DISPLAY_LIMIT) {
 			debug_value = debug_value.left(DISPLAY_LIMIT) + "... " + TTR("(truncated)");
 		}
 		debug_value = TTR("Current value: ") + debug_value.replace("[", "[lb]");
@@ -1590,7 +1590,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 
 				for (int i = 0; i < lines.size(); i++) {
 					const String &line = lines[i];
-					String whitespace = line.substr(0, line.size() - line.strip_edges(true, false).size()); // Extract the whitespace at the beginning.
+					String whitespace = line.substr(0, line.length() - line.strip_edges(true, false).length()); // Extract the whitespace at the beginning.
 					if (expression.parse(line) == OK) {
 						Variant result = expression.execute(Array(), Variant(), false, true);
 						if (expression.get_error_text().is_empty()) {

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1477,7 +1477,7 @@ void SpriteFramesEditor::_update_library_impl() {
 		}
 		missing_anim_label->hide();
 		anim_frames_vb->show();
-		bool searching = anim_search_box->get_text().size();
+		bool searching = anim_search_box->get_text().length();
 		String searched_string = searching ? anim_search_box->get_text().to_lower() : String();
 
 		TreeItem *selected = nullptr;

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -374,7 +374,7 @@ bool ProjectConverter3To4::convert() {
 		}
 		String file_content_before = collect_string_from_vector(source_lines);
 		uint64_t hash_before = file_content_before.hash();
-		uint64_t file_size = file_content_before.size();
+		uint64_t file_size = file_content_before.buffer_size();
 		print_line(vformat("Trying to convert\t%d/%d file - \"%s\" with size - %d KB", i + 1, collected_files.size(), file_name.trim_prefix("res://"), file_size / 1024));
 
 		Vector<String> reason;
@@ -566,7 +566,7 @@ bool ProjectConverter3To4::validate_conversion() {
 			ERR_CONTINUE_MSG(file.is_null(), vformat("Unable to read content of \"%s\".", file_name));
 			while (!file->eof_reached()) {
 				String line = file->get_line();
-				file_size += line.size();
+				file_size += line.buffer_size();
 				lines.append(line);
 			}
 		}
@@ -1046,7 +1046,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		String expected = "kieliszek.";
 		String got = get_object_of_execution(base);
 		if (got != expected) {
-			ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.size(), got, got.size()));
+			ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.buffer_size(), got, got.buffer_size()));
 		}
 		valid = valid && (got == expected);
 	}
@@ -1055,7 +1055,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		String expected = "r.";
 		String got = get_object_of_execution(base);
 		if (got != expected) {
-			ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.size(), got, got.size()));
+			ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.buffer_size(), got, got.buffer_size()));
 		}
 		valid = valid && (got == expected);
 	}
@@ -1064,7 +1064,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		String expected = "";
 		String got = get_object_of_execution(base);
 		if (got != expected) {
-			ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.size(), got, got.size()));
+			ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.buffer_size(), got, got.buffer_size()));
 		}
 		valid = valid && (got == expected);
 	}
@@ -1073,7 +1073,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		String expected = "$world/ukraine/lviv.";
 		String got = get_object_of_execution(base);
 		if (got != expected) {
-			ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.size(), got, got.size()));
+			ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.buffer_size(), got, got.buffer_size()));
 		}
 		valid = valid && (got == expected);
 	}
@@ -1084,7 +1084,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		String expected = "\t\t\t";
 		String got = get_starting_space(base);
 		if (got != expected) {
-			ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.size(), got, got.size()));
+			ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.buffer_size(), got, got.buffer_size()));
 		}
 		valid = valid && (got == expected);
 	}
@@ -1099,7 +1099,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 			got += part + "|||";
 		}
 		if (got != expected) {
-			ERR_PRINT(vformat("Failed to get proper data from parse_arguments. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", line, expected, expected.size(), got, got.size()));
+			ERR_PRINT(vformat("Failed to get proper data from parse_arguments. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", line, expected, expected.buffer_size(), got, got.buffer_size()));
 		}
 		valid = valid && (got == expected);
 	}
@@ -1112,7 +1112,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 			got += part + "|||";
 		}
 		if (got != expected) {
-			ERR_PRINT(vformat("Failed to get proper data from parse_arguments. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", line, expected, expected.size(), got, got.size()));
+			ERR_PRINT(vformat("Failed to get proper data from parse_arguments. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", line, expected, expected.buffer_size(), got, got.buffer_size()));
 		}
 		valid = valid && (got == expected);
 	}
@@ -1125,7 +1125,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 			got += part + "|||";
 		}
 		if (got != expected) {
-			ERR_PRINT(vformat("Failed to get proper data from parse_arguments. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", line, expected, expected.size(), got, got.size()));
+			ERR_PRINT(vformat("Failed to get proper data from parse_arguments. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", line, expected, expected.buffer_size(), got, got.buffer_size()));
 		}
 		valid = valid && (got == expected);
 	}
@@ -1138,7 +1138,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 			got += part + "|||";
 		}
 		if (got != expected) {
-			ERR_PRINT(vformat("Failed to get proper data from parse_arguments. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", line, expected, expected.size(), got, got.size()));
+			ERR_PRINT(vformat("Failed to get proper data from parse_arguments. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", line, expected, expected.buffer_size(), got, got.buffer_size()));
 		}
 		valid = valid && (got == expected);
 	}
@@ -1387,7 +1387,7 @@ String ProjectConverter3To4::get_starting_space(const String &line) const {
 	}
 
 	if (line[0] == ' ') {
-		while (current_character < line.size()) {
+		while (current_character < line.buffer_size()) {
 			if (line[current_character] == ' ') {
 				empty_space += ' ';
 				current_character++;
@@ -1397,7 +1397,7 @@ String ProjectConverter3To4::get_starting_space(const String &line) const {
 		}
 	}
 	if (line[0] == '\t') {
-		while (current_character < line.size()) {
+		while (current_character < line.buffer_size()) {
 			if (line[current_character] == '\t') {
 				empty_space += '\t';
 				current_character++;
@@ -1412,7 +1412,7 @@ String ProjectConverter3To4::get_starting_space(const String &line) const {
 // Returns the object that’s executing the function in the line.
 // e.g. Passing the line "var roman = kieliszek.funkcja()" to this function returns "kieliszek".
 String ProjectConverter3To4::get_object_of_execution(const String &line) const {
-	int end = line.size() - 1; // Last one is \0
+	int end = line.length();
 	int variable_start = end - 1;
 	int start = end - 1;
 
@@ -2908,13 +2908,13 @@ Vector<String> ProjectConverter3To4::check_for_rename_common(const char *array[]
 // Prints full info about renamed things e.g.:
 // Line (67) remove -> remove_at  -  LINE """ doubler._blacklist.remove(0) """
 String ProjectConverter3To4::line_formatter(int current_line, String from, String to, String line) {
-	if (from.size() > 200) {
+	if (from.length() > 200) {
 		from = from.substr(0, 197) + "...";
 	}
-	if (to.size() > 200) {
+	if (to.length() > 200) {
 		to = to.substr(0, 197) + "...";
 	}
-	if (line.size() > 400) {
+	if (line.length() > 400) {
 		line = line.substr(0, 397) + "...";
 	}
 
@@ -2928,10 +2928,10 @@ String ProjectConverter3To4::line_formatter(int current_line, String from, Strin
 // Prints only full lines e.g.:
 // Line (1) - FULL LINES - """yield(get_tree().create_timer(3), 'timeout')"""  =====>  """ await get_tree().create_timer(3).timeout """
 String ProjectConverter3To4::simple_line_formatter(int current_line, String old_line, String new_line) {
-	if (old_line.size() > 1000) {
+	if (old_line.length() > 1000) {
 		old_line = old_line.substr(0, 997) + "...";
 	}
-	if (new_line.size() > 1000) {
+	if (new_line.length() > 1000) {
 		new_line = new_line.substr(0, 997) + "...";
 	}
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -573,7 +573,7 @@ void ProjectSettingsEditor::_update_action_map_editor() {
 		}
 
 		// Strip the "input/" from the left.
-		String display_name = property_name.substr(String("input/").size() - 1);
+		String display_name = property_name.substr(strlen("input/"));
 		Dictionary action = GLOBAL_GET(property_name);
 
 		ActionMapEditor::ActionInfo action_info;

--- a/editor/run_instances_dialog.cpp
+++ b/editor/run_instances_dialog.cpp
@@ -251,7 +251,7 @@ void RunInstancesDialog::get_argument_list_for_instance(int p_idx, List<String> 
 			}
 
 			// Append Godot-specific custom arguments.
-			custom_args = _split_cmdline_args(raw_custom_args.substr(placeholder_pos + String("%command%").size()));
+			custom_args = _split_cmdline_args(raw_custom_args.substr(placeholder_pos + strlen("%command%") + 1));
 			for (int i = 0; i < custom_args.size(); i++) {
 				r_list.push_back(custom_args[i].replace(" ", "%20"));
 			}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4428,7 +4428,7 @@ int Main::start() {
 
 			if (!local_game_path.begins_with("res://")) {
 				bool absolute =
-						(local_game_path.size() > 1) && (local_game_path[0] == '/' || local_game_path[1] == ':');
+						(local_game_path.length() > 1) && (local_game_path[0] == '/' || local_game_path[1] == ':');
 
 				if (!absolute) {
 					if (ProjectSettings::get_singleton()->is_using_datapack()) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -368,7 +368,7 @@ Error GDScriptParser::parse(const String &p_source_code, const String &p_script_
 		for (int i = 0; i < lines.size(); i++) {
 			bool found = false;
 			const String &line = lines[i];
-			for (int j = 0; j < line.size(); j++) {
+			for (int j = 0; j < line.buffer_size(); j++) {
 				if (line[j] == char32_t(0xFFFF)) {
 					found = true;
 					break;

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -73,7 +73,7 @@ LSP::Position GodotPosition::to_lsp(const Vector<String> &p_lines) const {
 		int in_col = 1;
 		int res_char = 0;
 
-		while (res_char < pos_line.size() && in_col < column) {
+		while (res_char < pos_line.buffer_size() && in_col < column) {
 			if (pos_line[res_char] == '\t') {
 				in_col += tab_size;
 				res_char++;
@@ -693,7 +693,7 @@ String ExtendGDScriptParser::get_identifier_under_position(const LSP::Position &
 	if (line.is_empty()) {
 		return "";
 	}
-	ERR_FAIL_INDEX_V(p_position.character, line.size(), "");
+	ERR_FAIL_INDEX_V(p_position.character, line.buffer_size(), "");
 
 	// `p_position` cursor is BETWEEN chars, not ON chars.
 	// ->

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -105,15 +105,15 @@ Error GDScriptLanguageProtocol::LSPeer::send_data() {
 	int sent = 0;
 	while (!res_queue.is_empty()) {
 		CharString c_res = res_queue[0];
-		if (res_sent < c_res.size()) {
-			Error err = connection->put_partial_data((const uint8_t *)c_res.get_data() + res_sent, c_res.size() - res_sent - 1, sent);
+		if (res_sent < c_res.buffer_size()) {
+			Error err = connection->put_partial_data((const uint8_t *)c_res.get_data() + res_sent, c_res.buffer_size() - res_sent - 1, sent);
 			if (err != OK) {
 				return err;
 			}
 			res_sent += sent;
 		}
 		// Response sent
-		if (res_sent >= c_res.size() - 1) {
+		if (res_sent >= c_res.buffer_size() - 1) {
 			res_sent = 0;
 			res_queue.remove_at(0);
 		}

--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -173,7 +173,7 @@ static void test_directory(const String &p_dir) {
 						break;
 					}
 				}
-				for (; end < code.size(); ++end) {
+				for (; end < code.length(); ++end) {
 					if (code.get(end) == '\n') {
 						break;
 					}

--- a/modules/gltf/editor/editor_import_blend_runner.cpp
+++ b/modules/gltf/editor/editor_import_blend_runner.cpp
@@ -324,8 +324,8 @@ bool EditorImportBlendRunner::_extract_error_message_xml(const Vector<uint8_t> &
 	r_error_message = String();
 	while (parser->read() == OK) {
 		if (parser->get_node_type() == XMLParser::NODE_TEXT) {
-			if (parser->get_node_data().size()) {
-				if (r_error_message.size()) {
+			if (parser->get_node_data().length()) {
+				if (r_error_message.length()) {
 					r_error_message += " ";
 				}
 				r_error_message += parser->get_node_data().trim_suffix("\n");
@@ -333,7 +333,7 @@ bool EditorImportBlendRunner::_extract_error_message_xml(const Vector<uint8_t> &
 		}
 	}
 
-	return r_error_message.size();
+	return r_error_message.length();
 }
 
 Error EditorImportBlendRunner::do_import_direct(const Dictionary &p_options) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3629,7 +3629,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 					const Array &target_names = extras.has("targetNames") ? (Array)extras["targetNames"] : Array();
 					for (int k = 0; k < targets.size(); k++) {
 						String bs_name;
-						if (k < target_names.size() && ((String)target_names[k]).size() != 0) {
+						if (k < target_names.size() && ((String)target_names[k]).length() != 0) {
 							bs_name = (String)target_names[k];
 						} else {
 							bs_name = String("morph_") + itos(k);

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -101,9 +101,9 @@ Error CryptoKeyMbedTLS::load_from_string(const String &p_string_key, bool p_publ
 	int ret = 0;
 	const CharString string_key_utf8 = p_string_key.utf8();
 	if (p_public_only) {
-		ret = mbedtls_pk_parse_public_key(&pkey, (const unsigned char *)string_key_utf8.get_data(), string_key_utf8.size());
+		ret = mbedtls_pk_parse_public_key(&pkey, (const unsigned char *)string_key_utf8.get_data(), string_key_utf8.buffer_size());
 	} else {
-		ret = _parse_key((const unsigned char *)string_key_utf8.get_data(), string_key_utf8.size());
+		ret = _parse_key((const unsigned char *)string_key_utf8.get_data(), string_key_utf8.buffer_size());
 	}
 	ERR_FAIL_COND_V_MSG(ret, FAILED, "Error parsing key '" + itos(ret) + "'.");
 
@@ -227,7 +227,7 @@ Error X509CertificateMbedTLS::load_from_string(const String &p_string_key) {
 	ERR_FAIL_COND_V_MSG(locks, ERR_ALREADY_IN_USE, "Certificate is already in use.");
 	CharString cs = p_string_key.utf8();
 
-	int ret = mbedtls_x509_crt_parse(&cert, (const unsigned char *)cs.get_data(), cs.size());
+	int ret = mbedtls_x509_crt_parse(&cert, (const unsigned char *)cs.get_data(), cs.buffer_size());
 	ERR_FAIL_COND_V_MSG(ret < 0, FAILED, vformat("Error parsing X509 certificates: %d.", ret));
 	if (ret > 0) { // Some certs parsed fine, don't error.
 		print_verbose(vformat("MbedTLS: Some X509 certificates could not be parsed (%d certificates skipped).", ret));
@@ -363,7 +363,7 @@ void CryptoMbedTLS::load_default_certificates(const String &p_path) {
 		String system_certs = OS::get_singleton()->get_system_ca_certificates();
 		if (!system_certs.is_empty()) {
 			CharString cs = system_certs.utf8();
-			default_certs->load_from_memory((const uint8_t *)cs.get_data(), cs.size());
+			default_certs->load_from_memory((const uint8_t *)cs.get_data(), cs.buffer_size());
 			print_verbose("Loaded system CA certificates");
 		}
 #ifdef BUILTIN_CERTS_ENABLED

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1632,7 +1632,7 @@ void BindingsGenerator::_generate_global_constants(StringBuilder &p_output) {
 	p_output.append("public static partial class " BINDINGS_GLOBAL_SCOPE_CLASS "\n" OPEN_BLOCK);
 
 	for (const ConstantInterface &iconstant : global_constants) {
-		if (iconstant.const_doc && iconstant.const_doc->description.size()) {
+		if (iconstant.const_doc && iconstant.const_doc->description.length()) {
 			String xml_summary = bbcode_to_xml(fix_doc_description(iconstant.const_doc->description), nullptr);
 			Vector<String> summary_lines = xml_summary.length() ? xml_summary.split("\n") : Vector<String>();
 
@@ -1696,7 +1696,7 @@ void BindingsGenerator::_generate_global_constants(StringBuilder &p_output) {
 				 << maybe_indent << OPEN_BLOCK;
 
 		for (const ConstantInterface &iconstant : ienum.constants) {
-			if (iconstant.const_doc && iconstant.const_doc->description.size()) {
+			if (iconstant.const_doc && iconstant.const_doc->description.length()) {
 				String xml_summary = bbcode_to_xml(fix_doc_description(iconstant.const_doc->description), nullptr);
 				Vector<String> summary_lines = xml_summary.length() ? xml_summary.split("\n") : Vector<String>();
 
@@ -2158,7 +2158,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 	const DocData::ClassDoc *class_doc = itype.class_doc;
 
-	if (class_doc && class_doc->description.size()) {
+	if (class_doc && class_doc->description.length()) {
 		String xml_summary = bbcode_to_xml(fix_doc_description(class_doc->description), &itype);
 		Vector<String> summary_lines = xml_summary.length() ? xml_summary.split("\n") : Vector<String>();
 
@@ -2220,7 +2220,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 	// Add constants
 
 	for (const ConstantInterface &iconstant : itype.constants) {
-		if (iconstant.const_doc && iconstant.const_doc->description.size()) {
+		if (iconstant.const_doc && iconstant.const_doc->description.length()) {
 			String xml_summary = bbcode_to_xml(fix_doc_description(iconstant.const_doc->description), &itype);
 			Vector<String> summary_lines = xml_summary.length() ? xml_summary.split("\n") : Vector<String>();
 
@@ -2270,7 +2270,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 		const ConstantInterface &last = ienum.constants.back()->get();
 		for (const ConstantInterface &iconstant : ienum.constants) {
-			if (iconstant.const_doc && iconstant.const_doc->description.size()) {
+			if (iconstant.const_doc && iconstant.const_doc->description.length()) {
 				String xml_summary = bbcode_to_xml(fix_doc_description(iconstant.const_doc->description), &itype);
 				Vector<String> summary_lines = xml_summary.length() ? xml_summary.split("\n") : Vector<String>();
 
@@ -2756,7 +2756,7 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 						"' from the editor API. Core API cannot have dependencies on the editor API.");
 	}
 
-	if (p_iprop.prop_doc && p_iprop.prop_doc->description.size()) {
+	if (p_iprop.prop_doc && p_iprop.prop_doc->description.length()) {
 		String xml_summary = bbcode_to_xml(fix_doc_description(p_iprop.prop_doc->description), &p_itype);
 		Vector<String> summary_lines = xml_summary.length() ? xml_summary.split("\n") : Vector<String>();
 
@@ -2898,7 +2898,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 			self_reference = CS_PROPERTY_SINGLETON;
 		}
 
-		if (p_itype.cs_in.size()) {
+		if (p_itype.cs_in.length()) {
 			cs_in_statements << sformat(p_itype.cs_in, p_itype.c_type, self_reference,
 					String(), String(), String(), INDENT2);
 		}
@@ -2923,7 +2923,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 							arg_type->name + "' from the editor API. Core API cannot have dependencies on the editor API.");
 		}
 
-		if (iarg.default_argument.size()) {
+		if (iarg.default_argument.length()) {
 			CRASH_COND_MSG(!_arg_default_value_is_assignable_to_type(iarg.def_param_value, *arg_type),
 					"Invalid default value for parameter '" + iarg.name + "' of method '" + p_itype.name + "." + p_imethod.name + "'.");
 		}
@@ -2957,7 +2957,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 
 			arguments_sig += iarg.name;
 
-			if (!p_use_span && !p_imethod.is_compat && iarg.default_argument.size()) {
+			if (!p_use_span && !p_imethod.is_compat && iarg.default_argument.length()) {
 				if (iarg.def_param_mode != ArgumentInterface::CONSTANT) {
 					arguments_sig += " = null";
 				} else {
@@ -2968,7 +2968,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 
 		icall_params += ", ";
 
-		if (iarg.default_argument.size() && iarg.def_param_mode != ArgumentInterface::CONSTANT && !use_span_for_arg) {
+		if (iarg.default_argument.length() && iarg.def_param_mode != ArgumentInterface::CONSTANT && !use_span_for_arg) {
 			// The default value of an argument must be constant. Otherwise we make it Nullable and do the following:
 			// Type arg_in = arg.HasValue ? arg.Value : <non-const default value>;
 			String arg_or_defval_local = iarg.name;
@@ -2999,7 +2999,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 
 			cs_in_statements << def_arg << ";\n";
 
-			if (arg_type->cs_in.size()) {
+			if (arg_type->cs_in.length()) {
 				cs_in_statements << sformat(arg_type->cs_in, arg_type->c_type, arg_or_defval_local,
 						String(), String(), String(), INDENT2);
 			}
@@ -3017,7 +3017,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 
 			default_args_doc.append(MEMBER_BEGIN "/// <param name=\"" + param_tag_name + "\">If the parameter is null, then the default value is <c>" + param_def_arg + "</c>.</param>");
 		} else {
-			if (arg_type->cs_in.size()) {
+			if (arg_type->cs_in.length()) {
 				cs_in_statements << sformat(arg_type->cs_in, arg_type->c_type, iarg.name,
 						String(), String(), String(), INDENT2);
 			}
@@ -3054,7 +3054,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 					 << ");\n";
 		}
 
-		if (p_imethod.method_doc && p_imethod.method_doc->description.size()) {
+		if (p_imethod.method_doc && p_imethod.method_doc->description.length()) {
 			String xml_summary = bbcode_to_xml(fix_doc_description(p_imethod.method_doc->description), &p_itype);
 			Vector<String> summary_lines = xml_summary.length() ? xml_summary.split("\n") : Vector<String>();
 
@@ -3265,7 +3265,7 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 					 << INDENT1 "}\n";
 		}
 
-		if (p_isignal.method_doc && p_isignal.method_doc->description.size()) {
+		if (p_isignal.method_doc && p_isignal.method_doc->description.length()) {
 			String xml_summary = bbcode_to_xml(fix_doc_description(p_isignal.method_doc->description), &p_itype, true);
 			Vector<String> summary_lines = xml_summary.length() ? xml_summary.split("\n") : Vector<String>();
 
@@ -3435,7 +3435,7 @@ Error BindingsGenerator::_generate_cs_native_calls(const InternalCall &p_icall, 
 			if (i > 0) {
 				c_args_var_content << ", ";
 			}
-			if (arg_type->c_in.size()) {
+			if (arg_type->c_in.length()) {
 				c_in_statements << sformat(arg_type->c_in, arg_type->c_type, c_param_name,
 						String(), String(), String(), INDENT2);
 			}

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -176,7 +176,7 @@ String join(const String &p_a, const String &p_b) {
 
 	const char32_t a_last = p_a[p_a.length() - 1];
 	if ((a_last == '/' || a_last == '\\') ||
-			(p_b.size() > 0 && (p_b[0] == '/' || p_b[0] == '\\'))) {
+			(p_b.length() > 0 && (p_b[0] == '/' || p_b[0] == '\\'))) {
 		return p_a + p_b;
 	}
 

--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -236,7 +236,7 @@ void EditorNetworkProfiler::_replication_button_clicked(TreeItem *p_item, int p_
 		return;
 	}
 	String meta = p_item->get_metadata(p_column);
-	if (meta.size() && ResourceLoader::exists(meta)) {
+	if (meta.length() && ResourceLoader::exists(meta)) {
 		emit_signal("open_request", meta);
 	}
 }

--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -557,7 +557,7 @@ void ReplicationEditor::_add_property(const NodePath &p_property, bool p_spawn, 
 	Ref<Texture2D> icon = _get_class_icon(root_node);
 	if (root_node) {
 		String path = prop.substr(0, prop.find_char(':'));
-		String subpath = prop.substr(path.size());
+		String subpath = prop.substr(path.length() + 1);
 		Node *node = root_node->get_node_or_null(path);
 		if (!node) {
 			node = root_node;

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -873,8 +873,8 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 	// !BAS! I'm assuming the 9 in the original code was a typo. I've added -1 or else it seems to also be adding our terminating zero...
 	// should apply the same fix in our macOS export.
 	CharString cs = strnew.utf8();
-	pfile.resize(cs.size() - 1);
-	for (int i = 0; i < cs.size() - 1; i++) {
+	pfile.resize(cs.buffer_size() - 1);
+	for (int i = 0; i < cs.buffer_size() - 1; i++) {
 		pfile.write[i] = cs[i];
 	}
 }
@@ -1546,8 +1546,8 @@ void EditorExportPlatformIOS::_add_assets_to_project(const String &p_out_dir, co
 	str = str.replace("$pbx_embeded_frameworks", pbx_embeded_frameworks);
 
 	CharString cs = str.utf8();
-	p_project_data.resize(cs.size() - 1);
-	for (int i = 0; i < cs.size() - 1; i++) {
+	p_project_data.resize(cs.buffer_size() - 1);
+	for (int i = 0; i < cs.buffer_size() - 1; i++) {
 		p_project_data.write[i] = cs[i];
 	}
 }

--- a/platform/ios/keyboard_input_view.mm
+++ b/platform/ios/keyboard_input_view.mm
@@ -124,7 +124,7 @@
 - (void)enterText:(NSString *)substring {
 	String characters = String::utf8([substring UTF8String]);
 
-	for (int i = 0; i < characters.size(); i++) {
+	for (int i = 0; i < characters.buffer_size(); i++) {
 		int character = characters[i];
 		Key key = Key::NONE;
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -780,7 +780,7 @@ Vector<String> OS_LinuxBSD::get_system_font_path_for_text(const String &p_font_n
 			FcPatternAddInteger(pattern, FC_SLANT, p_italic ? FC_SLANT_ITALIC : FC_SLANT_ROMAN);
 
 			FcCharSet *char_set = FcCharSetCreate();
-			for (int j = 0; j < p_text.size(); j++) {
+			for (int j = 0; j < p_text.buffer_size(); j++) {
 				FcCharSetAddChar(char_set, p_text[j]);
 			}
 			FcPatternAddCharSet(pattern, FC_CHARSET, char_set);

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -807,8 +807,8 @@ void EditorExportPlatformMacOS::_fix_privacy_manifest(const Ref<EditorExportPres
 	}
 
 	CharString cs = strnew.utf8();
-	plist.resize(cs.size() - 1);
-	for (int i = 0; i < cs.size() - 1; i++) {
+	plist.resize(cs.buffer_size() - 1);
+	for (int i = 0; i < cs.buffer_size() - 1; i++) {
 		plist.write[i] = cs[i];
 	}
 }
@@ -912,8 +912,8 @@ void EditorExportPlatformMacOS::_fix_plist(const Ref<EditorExportPreset> &p_pres
 	}
 
 	CharString cs = strnew.utf8();
-	plist.resize(cs.size() - 1);
-	for (int i = 0; i < cs.size() - 1; i++) {
+	plist.resize(cs.buffer_size() - 1);
+	for (int i = 0; i < cs.buffer_size() - 1; i++) {
 		plist.write[i] = cs[i];
 	}
 }

--- a/platform/web/export/editor_http_server.cpp
+++ b/platform/web/export/editor_http_server.cpp
@@ -94,7 +94,7 @@ void EditorHTTPServer::_send_response() {
 		s += "Connection: Close\r\n";
 		s += "\r\n";
 		CharString cs = s.utf8();
-		peer->put_data((const uint8_t *)cs.get_data(), cs.size() - 1);
+		peer->put_data((const uint8_t *)cs.get_data(), cs.length());
 		return;
 	}
 	const String ctype = mimes[req_ext];
@@ -110,7 +110,7 @@ void EditorHTTPServer::_send_response() {
 	s += "Cache-Control: no-store, max-age=0\r\n";
 	s += "\r\n";
 	CharString cs = s.utf8();
-	Error err = peer->put_data((const uint8_t *)cs.get_data(), cs.size() - 1);
+	Error err = peer->put_data((const uint8_t *)cs.get_data(), cs.length());
 	if (err != OK) {
 		ERR_FAIL();
 	}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -616,7 +616,7 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 			Char16String current_dir_name;
 			size_t str_len = GetCurrentDirectoryW(0, nullptr);
 			current_dir_name.resize(str_len + 1);
-			GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
+			GetCurrentDirectoryW(current_dir_name.buffer_size(), (LPWSTR)current_dir_name.ptrw());
 			if (dir == ".") {
 				dir = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/');
 			} else {
@@ -3393,7 +3393,7 @@ static INT_PTR input_text_dialog_cmd_proc(HWND hWnd, UINT code, WPARAM wParam, L
 
 		Char16String text;
 		text.resize(GetWindowTextLengthW(text_edit) + 1);
-		GetWindowTextW(text_edit, (LPWSTR)text.get_data(), text.size());
+		GetWindowTextW(text_edit, (LPWSTR)text.get_data(), text.buffer_size());
 
 		const Callable *callback = (const Callable *)GetWindowLongPtrW(hWnd, GWLP_USERDATA);
 		if (callback && callback->is_valid()) {
@@ -7166,7 +7166,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 		if (RegOpenKeyW(HKEY_CURRENT_USER_LOCAL_SETTINGS, L"Software\\Microsoft\\Windows\\Shell\\MuiCache", &key) == ERROR_SUCCESS) {
 			Char16String cs_name = name.utf16();
 			String value_name = OS::get_singleton()->get_executable_path().replace_char('/', '\\') + ".FriendlyAppName";
-			RegSetValueExW(key, (LPCWSTR)value_name.utf16().get_data(), 0, REG_SZ, (const BYTE *)cs_name.get_data(), cs_name.size() * sizeof(WCHAR));
+			RegSetValueExW(key, (LPCWSTR)value_name.utf16().get_data(), 0, REG_SZ, (const BYTE *)cs_name.get_data(), cs_name.buffer_size() * sizeof(WCHAR));
 			RegCloseKey(key);
 		}
 #endif

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -53,12 +53,12 @@ static String fix_path(const String &p_path) {
 		Char16String current_dir_name;
 		size_t str_len = GetCurrentDirectoryW(0, nullptr);
 		current_dir_name.resize(str_len + 1);
-		GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
+		GetCurrentDirectoryW(current_dir_name.buffer_size(), (LPWSTR)current_dir_name.ptrw());
 		path = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(path);
 	}
 	path = path.simplify_path();
 	path = path.replace_char('/', '\\');
-	if (path.size() >= MAX_PATH && !path.is_network_share_path() && !path.begins_with(R"(\\?\)")) {
+	if (path.buffer_size() >= MAX_PATH && !path.is_network_share_path() && !path.begins_with(R"(\\?\)")) {
 		path = R"(\\?\)" + path;
 	}
 	return path;

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -209,7 +209,7 @@ void GLManagerNative_Windows::_nvapi_setup_profile() {
 		NVDRS_PROFILE profile_info;
 		profile_info.version = NVDRS_PROFILE_VER;
 		profile_info.isPredefined = 0;
-		memcpy(profile_info.profileName, app_profile_name_u16.get_data(), sizeof(char16_t) * app_profile_name_u16.size());
+		memcpy(profile_info.profileName, app_profile_name_u16.get_data(), sizeof(char16_t) * app_profile_name_u16.buffer_size());
 
 		if (!nvapi_err_check("NVAPI: Error creating profile", NvAPI_DRS_CreateProfile(session_handle, &profile_info, &profile_handle))) {
 			NvAPI_DRS_DestroySession(session_handle);
@@ -227,7 +227,7 @@ void GLManagerNative_Windows::_nvapi_setup_profile() {
 		print_verbose("NVAPI: Application not found in profile, creating...");
 
 		app.isPredefined = 0;
-		memcpy(app.appName, app_executable_name_u16.get_data(), sizeof(char16_t) * app_executable_name_u16.size());
+		memcpy(app.appName, app_executable_name_u16.get_data(), sizeof(char16_t) * app_executable_name_u16.buffer_size());
 		memcpy(app.launcher, L"", sizeof(wchar_t));
 		memcpy(app.fileInFolder, L"", sizeof(wchar_t));
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -112,12 +112,12 @@ static String fix_path(const String &p_path) {
 		Char16String current_dir_name;
 		size_t str_len = GetCurrentDirectoryW(0, nullptr);
 		current_dir_name.resize(str_len + 1);
-		GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
+		GetCurrentDirectoryW(current_dir_name.buffer_size(), (LPWSTR)current_dir_name.ptrw());
 		path = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(path);
 	}
 	path = path.simplify_path();
 	path = path.replace_char('/', '\\');
-	if (path.size() >= MAX_PATH && !path.is_network_share_path() && !path.begins_with(R"(\\?\)")) {
+	if (path.buffer_size() >= MAX_PATH && !path.is_network_share_path() && !path.begins_with(R"(\\?\)")) {
 		path = R"(\\?\)" + path;
 	}
 	return path;
@@ -943,7 +943,7 @@ uint64_t OS_Windows::get_ticks_usec() const {
 }
 
 String OS_Windows::_quote_command_line_argument(const String &p_text) const {
-	for (int i = 0; i < p_text.size(); i++) {
+	for (int i = 0; i < p_text.length(); i++) {
 		char32_t c = p_text[i];
 		if (c == ' ' || c == '&' || c == '(' || c == ')' || c == '[' || c == ']' || c == '{' || c == '}' || c == '^' || c == '=' || c == ';' || c == '!' || c == '\'' || c == '+' || c == ',' || c == '`' || c == '~') {
 			return "\"" + p_text + "\"";
@@ -1160,14 +1160,14 @@ PackedByteArray OS_Windows::string_to_multibyte(const String &p_encoding, const 
 
 	Char16String charstr = p_string.utf16();
 	PackedByteArray ret;
-	int total_mbchars = WideCharToMultiByte(*encoding, 0, (const wchar_t *)charstr.ptr(), charstr.size(), nullptr, 0, nullptr, nullptr);
+	int total_mbchars = WideCharToMultiByte(*encoding, 0, (const wchar_t *)charstr.ptr(), charstr.buffer_size(), nullptr, 0, nullptr, nullptr);
 	if (total_mbchars == 0) {
 		DWORD err_code = GetLastError();
 		ERR_FAIL_V_MSG(PackedByteArray(), vformat("Conversion failed: %s", format_error_message(err_code)));
 	}
 
 	ret.resize(total_mbchars);
-	if (WideCharToMultiByte(*encoding, 0, (const wchar_t *)charstr.ptr(), charstr.size(), (char *)ret.ptrw(), ret.size(), nullptr, nullptr) == 0) {
+	if (WideCharToMultiByte(*encoding, 0, (const wchar_t *)charstr.ptr(), charstr.buffer_size(), (char *)ret.ptrw(), ret.size(), nullptr, nullptr) == 0) {
 		DWORD err_code = GetLastError();
 		ERR_FAIL_V_MSG(PackedByteArray(), vformat("Conversion failed: %s", format_error_message(err_code)));
 	}
@@ -1300,12 +1300,12 @@ Dictionary OS_Windows::execute_with_pipe(const String &p_path, const List<String
 	Char16String current_dir_name;
 	size_t str_len = GetCurrentDirectoryW(0, nullptr);
 	current_dir_name.resize(str_len + 1);
-	GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
-	if (current_dir_name.size() >= MAX_PATH) {
+	GetCurrentDirectoryW(current_dir_name.buffer_size(), (LPWSTR)current_dir_name.ptrw());
+	if (current_dir_name.buffer_size() >= MAX_PATH) {
 		Char16String current_short_dir_name;
 		str_len = GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), nullptr, 0);
 		current_short_dir_name.resize(str_len);
-		GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), (LPWSTR)current_short_dir_name.ptrw(), current_short_dir_name.size());
+		GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), (LPWSTR)current_short_dir_name.ptrw(), current_short_dir_name.buffer_size());
 		current_dir_name = current_short_dir_name;
 	}
 
@@ -1406,12 +1406,12 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 	Char16String current_dir_name;
 	size_t str_len = GetCurrentDirectoryW(0, nullptr);
 	current_dir_name.resize(str_len + 1);
-	GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
-	if (current_dir_name.size() >= MAX_PATH) {
+	GetCurrentDirectoryW(current_dir_name.buffer_size(), (LPWSTR)current_dir_name.ptrw());
+	if (current_dir_name.buffer_size() >= MAX_PATH) {
 		Char16String current_short_dir_name;
 		str_len = GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), nullptr, 0);
 		current_short_dir_name.resize(str_len);
-		GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), (LPWSTR)current_short_dir_name.ptrw(), current_short_dir_name.size());
+		GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), (LPWSTR)current_short_dir_name.ptrw(), current_short_dir_name.buffer_size());
 		current_dir_name = current_short_dir_name;
 	}
 
@@ -1505,12 +1505,12 @@ Error OS_Windows::create_process(const String &p_path, const List<String> &p_arg
 	Char16String current_dir_name;
 	size_t str_len = GetCurrentDirectoryW(0, nullptr);
 	current_dir_name.resize(str_len + 1);
-	GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
-	if (current_dir_name.size() >= MAX_PATH) {
+	GetCurrentDirectoryW(current_dir_name.buffer_size(), (LPWSTR)current_dir_name.ptrw());
+	if (current_dir_name.buffer_size() >= MAX_PATH) {
 		Char16String current_short_dir_name;
 		str_len = GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), nullptr, 0);
 		current_short_dir_name.resize(str_len);
-		GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), (LPWSTR)current_short_dir_name.ptrw(), current_short_dir_name.size());
+		GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), (LPWSTR)current_short_dir_name.ptrw(), current_short_dir_name.buffer_size());
 		current_dir_name = current_short_dir_name;
 	}
 
@@ -2666,12 +2666,12 @@ OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	Char16String current_dir_name;
 	size_t str_len = GetCurrentDirectoryW(0, nullptr);
 	current_dir_name.resize(str_len + 1);
-	GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
+	GetCurrentDirectoryW(current_dir_name.buffer_size(), (LPWSTR)current_dir_name.ptrw());
 
 	Char16String new_current_dir_name;
 	str_len = GetLongPathNameW((LPCWSTR)current_dir_name.get_data(), nullptr, 0);
 	new_current_dir_name.resize(str_len + 1);
-	GetLongPathNameW((LPCWSTR)current_dir_name.get_data(), (LPWSTR)new_current_dir_name.ptrw(), new_current_dir_name.size());
+	GetLongPathNameW((LPCWSTR)current_dir_name.get_data(), (LPWSTR)new_current_dir_name.ptrw(), new_current_dir_name.buffer_size());
 
 	SetCurrentDirectoryW((LPCWSTR)new_current_dir_name.get_data());
 

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1168,7 +1168,7 @@ Ref<AnimationNodeStateMachine> AnimationNodeStateMachinePlayback::_get_parent_st
 	Ref<AnimationNode> root = p_tree->get_root_animation_node();
 	ERR_FAIL_COND_V_MSG(root.is_null(), Ref<AnimationNodeStateMachine>(), "There is no root AnimationNode in AnimationTree: " + String(p_tree->get_name()));
 	String anodesm_path = String("/").join(split);
-	Ref<AnimationNodeStateMachine> anodesm = !anodesm_path.size() ? root : root->find_node_by_path(anodesm_path);
+	Ref<AnimationNodeStateMachine> anodesm = !anodesm_path.length() ? root : root->find_node_by_path(anodesm_path);
 	ERR_FAIL_COND_V_MSG(anodesm.is_null(), Ref<AnimationNodeStateMachine>(), "Can't get state machine with path: " + anodesm_path);
 	return anodesm;
 }

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1180,10 +1180,10 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 					// No need to move the brace below if we are not taking the text with us.
 					if (p_split_current_line) {
 						brace_indent = true;
-						ins += "\n" + ins.substr(indent_text.size(), ins.length() - 2);
+						ins += "\n" + ins.substr(indent_text.length() + 1, ins.length() - 2);
 					} else {
 						brace_indent = false;
-						ins = "\n" + ins.substr(indent_text.size(), ins.length() - 2);
+						ins = "\n" + ins.substr(indent_text.length() + 1, ins.length() - 2);
 					}
 				}
 			}
@@ -1638,11 +1638,11 @@ bool CodeEdit::can_fold_line(int p_line) const {
 	int in_comment = is_in_comment(p_line);
 	int in_string = (in_comment == -1) ? is_in_string(p_line) : -1;
 	if (in_string != -1 || in_comment != -1) {
-		if (get_delimiter_start_position(p_line, get_line(p_line).size() - 1).y != p_line) {
+		if (get_delimiter_start_position(p_line, get_line(p_line).length()).y != p_line) {
 			return false;
 		}
 
-		int delimiter_end_line = get_delimiter_end_position(p_line, get_line(p_line).size() - 1).y;
+		int delimiter_end_line = get_delimiter_end_position(p_line, get_line(p_line).length()).y;
 		/* No end line, therefore we have a multiline region over the rest of the file. */
 		if (delimiter_end_line == -1) {
 			return true;
@@ -1704,7 +1704,7 @@ void CodeEdit::fold_line(int p_line) {
 	int in_string = (in_comment == -1) ? is_in_string(p_line) : -1;
 	if (!is_line_code_region_start(p_line)) {
 		if (in_string != -1 || in_comment != -1) {
-			end_line = get_delimiter_end_position(p_line, get_line(p_line).size() - 1).y;
+			end_line = get_delimiter_end_position(p_line, get_line(p_line).length()).y;
 			// End line is the same therefore we have a block of single line delimiters.
 			if (end_line == p_line) {
 				for (int i = p_line + 1; i <= line_count; i++) {
@@ -1972,7 +1972,7 @@ Point2 CodeEdit::get_delimiter_start_position(int p_line, int p_column) const {
 		return Point2(-1, -1);
 	}
 	ERR_FAIL_INDEX_V(p_line, get_line_count(), Point2(-1, -1));
-	ERR_FAIL_COND_V(p_column - 1 > get_line(p_line).size(), Point2(-1, -1));
+	ERR_FAIL_COND_V(p_column - 1 > get_line(p_line).buffer_size(), Point2(-1, -1));
 
 	Point2 start_position;
 	start_position.y = -1;
@@ -2023,7 +2023,7 @@ Point2 CodeEdit::get_delimiter_end_position(int p_line, int p_column) const {
 		return Point2(-1, -1);
 	}
 	ERR_FAIL_INDEX_V(p_line, get_line_count(), Point2(-1, -1));
-	ERR_FAIL_COND_V(p_column - 1 > get_line(p_line).size(), Point2(-1, -1));
+	ERR_FAIL_COND_V(p_column - 1 > get_line(p_line).buffer_size(), Point2(-1, -1));
 
 	Point2 end_position;
 	end_position.y = -1;
@@ -2419,7 +2419,7 @@ String CodeEdit::get_text_with_cursor_char(int p_line, int p_column) const {
 	StringBuilder result;
 	for (int i = 0; i < text_size; i++) {
 		String line_text = get_line(i);
-		if (i == p_line && p_column >= 0 && p_column <= line_text.size()) {
+		if (i == p_line && p_column >= 0 && p_column <= line_text.buffer_size()) {
 			result += line_text.substr(0, p_column);
 			/* Not unicode, represents the cursor. */
 			result += String::chr(0xFFFF);
@@ -3591,7 +3591,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 		}
 
 		String target_lower = option.display.to_lower();
-		int long_option = target_lower.size() > 50;
+		int long_option = target_lower.buffer_size() > 50;
 		const char32_t *string_to_complete_char_lower = &string_to_complete_lower[0];
 		const char32_t *target_char_lower = &target_lower[0];
 

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1129,7 +1129,7 @@ void FileDialog::set_current_file(const String &p_file) {
 }
 
 void FileDialog::set_current_path(const String &p_path) {
-	if (!p_path.size()) {
+	if (!p_path.length()) {
 		return;
 	}
 	int pos = MAX(p_path.rfind_char('/'), p_path.rfind_char('\\'));

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1860,7 +1860,7 @@ Vector2 LineEdit::get_caret_pixel_pos() {
 		if (ime_selection.y != 0) {
 			caret = TS->shaped_text_get_carets(text_rid, caret_column + ime_selection.x + ime_selection.y);
 		} else {
-			caret = TS->shaped_text_get_carets(text_rid, caret_column + ime_text.size());
+			caret = TS->shaped_text_get_carets(text_rid, caret_column + ime_text.buffer_size());
 		}
 		if ((caret.l_caret != Rect2() && (caret.l_dir == TextServer::DIRECTION_AUTO || caret.l_dir == (TextServer::Direction)input_direction)) || (caret.t_caret == Rect2())) {
 			ret.y = x_ofs + caret.l_caret.position.x + scroll_offset;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -186,8 +186,8 @@ float TextEdit::Text::get_indent_offset(int p_line, bool p_rtl) const {
 	Line &text_line = text.write[p_line];
 	if (text_line.indent_ofs < 0.0) {
 		int char_count = 0;
-		int line_length = text_line.data.size();
-		for (int i = 0; i < line_length - 1; i++) {
+		int line_length = text_line.data.length();
+		for (int i = 0; i < line_length; i++) {
 			if (text_line.data[i] == '\t') {
 				char_count++;
 			} else if (text_line.data[i] == ' ') {
@@ -3778,7 +3778,7 @@ void TextEdit::_clear() {
 		_move_caret_document_start(false);
 		begin_complex_operation();
 
-		_remove_text(0, 0, MAX(0, get_line_count() - 1), MAX(get_line(MAX(get_line_count() - 1, 0)).size() - 1, 0));
+		_remove_text(0, 0, MAX(0, get_line_count() - 1), MAX(get_line(MAX(get_line_count() - 1, 0)).length(), 0));
 		insert_text_at_caret("");
 		text.clear();
 
@@ -3816,7 +3816,7 @@ void TextEdit::set_text(const String &p_text) {
 
 		begin_complex_operation();
 		deselect();
-		_remove_text(0, 0, MAX(0, get_line_count() - 1), MAX(get_line(MAX(get_line_count() - 1, 0)).size() - 1, 0));
+		_remove_text(0, 0, MAX(0, get_line_count() - 1), MAX(get_line(MAX(get_line_count() - 1, 0)).length(), 0));
 		insert_text_at_caret(p_text);
 		end_complex_operation();
 	}
@@ -3931,8 +3931,8 @@ int TextEdit::_get_wrapped_indent_level(int p_line, int &r_first_wrap) const {
 
 	int tab_count = 0;
 	int whitespace_count = 0;
-	int line_length = text[p_line].size();
-	for (int i = 0; i < line_length - 1; i++) {
+	int line_length = text[p_line].length();
+	for (int i = 0; i < line_length; i++) {
 		if (r_first_wrap < wr.size() && i >= wr[r_first_wrap].y) {
 			tab_count = 0;
 			whitespace_count = 0;
@@ -3954,8 +3954,8 @@ int TextEdit::get_indent_level(int p_line) const {
 
 	int tab_count = 0;
 	int whitespace_count = 0;
-	int line_length = text[p_line].size();
-	for (int i = 0; i < line_length - 1; i++) {
+	int line_length = text[p_line].length();
+	for (int i = 0; i < line_length; i++) {
 		if (text[p_line][i] == '\t') {
 			tab_count++;
 		} else if (text[p_line][i] == ' ') {

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -1750,11 +1750,11 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 			int pos = delimiter + 1;
 			HashMap<String, String> keys;
 
-			while (pos < line.size() && line[pos] == ' ') {
+			while (pos < line.buffer_size() && line[pos] == ' ') {
 				pos++;
 			}
 
-			while (pos < line.size()) {
+			while (pos < line.buffer_size()) {
 				int eq = line.find_char('=', pos);
 				if (eq == -1) {
 					break;
@@ -1772,13 +1772,13 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 				} else {
 					end = line.find_char(' ', eq + 1);
 					if (end == -1) {
-						end = line.size();
+						end = line.buffer_size();
 					}
 					value = line.substr(eq + 1, end - eq);
 					pos = end;
 				}
 
-				while (pos < line.size() && line[pos] == ' ') {
+				while (pos < line.buffer_size() && line[pos] == ' ') {
 					pos++;
 				}
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -634,7 +634,7 @@ String VisualShaderNodeCustom::generate_code(Shader::Mode p_mode, VisualShader::
 		if (!nend) {
 			code += "\n	}";
 		} else {
-			code.remove_at(code.size() - 1);
+			code.remove_at(code.length());
 			code += "}";
 		}
 		code += "\n";
@@ -669,7 +669,7 @@ String VisualShaderNodeCustom::generate_global_per_func(Shader::Mode p_mode, Vis
 			if (!nend) {
 				code += "\n	}";
 			} else {
-				code.remove_at(code.size() - 1);
+				code.remove_at(code.length());
 				code += "}";
 			}
 			code += "\n";
@@ -4604,7 +4604,7 @@ void VisualShaderNodeGroupBase::add_input_port(int p_id, int p_type, const Strin
 				inputs = inputs.insert(index, str);
 				break;
 			}
-			index += inputs_strings[i].size();
+			index += inputs_strings[i].buffer_size();
 		}
 	} else {
 		inputs += str;
@@ -4615,7 +4615,7 @@ void VisualShaderNodeGroupBase::add_input_port(int p_id, int p_type, const Strin
 
 	for (int i = 0; i < inputs_strings.size(); i++) {
 		int count = 0;
-		for (int j = 0; j < inputs_strings[i].size(); j++) {
+		for (int j = 0; j < inputs_strings[i].buffer_size(); j++) {
 			if (inputs_strings[i][j] == ',') {
 				break;
 			}
@@ -4624,7 +4624,7 @@ void VisualShaderNodeGroupBase::add_input_port(int p_id, int p_type, const Strin
 
 		inputs = inputs.left(index) + inputs.substr(index + count);
 		inputs = inputs.insert(index, itos(i));
-		index += inputs_strings[i].size();
+		index += inputs_strings[i].buffer_size();
 	}
 
 	_apply_port_changes();
@@ -4640,10 +4640,10 @@ void VisualShaderNodeGroupBase::remove_input_port(int p_id) {
 	for (int i = 0; i < inputs_strings.size(); i++) {
 		Vector<String> arr = inputs_strings[i].split(",");
 		if (arr[0].to_int() == p_id) {
-			count = inputs_strings[i].size();
+			count = inputs_strings[i].buffer_size();
 			break;
 		}
-		index += inputs_strings[i].size();
+		index += inputs_strings[i].buffer_size();
 	}
 	inputs = inputs.left(index) + inputs.substr(index + count);
 
@@ -4679,7 +4679,7 @@ void VisualShaderNodeGroupBase::add_output_port(int p_id, int p_type, const Stri
 				outputs = outputs.insert(index, str);
 				break;
 			}
-			index += outputs_strings[i].size();
+			index += outputs_strings[i].buffer_size();
 		}
 	} else {
 		outputs += str;
@@ -4690,7 +4690,7 @@ void VisualShaderNodeGroupBase::add_output_port(int p_id, int p_type, const Stri
 
 	for (int i = 0; i < outputs_strings.size(); i++) {
 		int count = 0;
-		for (int j = 0; j < outputs_strings[i].size(); j++) {
+		for (int j = 0; j < outputs_strings[i].buffer_size(); j++) {
 			if (outputs_strings[i][j] == ',') {
 				break;
 			}
@@ -4699,7 +4699,7 @@ void VisualShaderNodeGroupBase::add_output_port(int p_id, int p_type, const Stri
 
 		outputs = outputs.left(index) + outputs.substr(index + count);
 		outputs = outputs.insert(index, itos(i));
-		index += outputs_strings[i].size();
+		index += outputs_strings[i].buffer_size();
 	}
 
 	_apply_port_changes();
@@ -4715,10 +4715,10 @@ void VisualShaderNodeGroupBase::remove_output_port(int p_id) {
 	for (int i = 0; i < outputs_strings.size(); i++) {
 		Vector<String> arr = outputs_strings[i].split(",");
 		if (arr[0].to_int() == p_id) {
-			count = outputs_strings[i].size();
+			count = outputs_strings[i].buffer_size();
 			break;
 		}
-		index += outputs_strings[i].size();
+		index += outputs_strings[i].buffer_size();
 	}
 	outputs = outputs.left(index) + outputs.substr(index + count);
 
@@ -4765,11 +4765,11 @@ void VisualShaderNodeGroupBase::set_input_port_type(int p_id, int p_type) {
 		ERR_FAIL_COND(arr.size() != 3);
 
 		if (arr[0].to_int() == p_id) {
-			index += arr[0].size();
-			count = arr[1].size() - 1;
+			index += arr[0].buffer_size();
+			count = arr[1].buffer_size() - 1;
 			break;
 		}
-		index += inputs_strings[i].size();
+		index += inputs_strings[i].buffer_size();
 	}
 
 	inputs = inputs.left(index) + inputs.substr(index + count);
@@ -4800,11 +4800,11 @@ void VisualShaderNodeGroupBase::set_input_port_name(int p_id, const String &p_na
 		ERR_FAIL_COND(arr.size() != 3);
 
 		if (arr[0].to_int() == p_id) {
-			index += arr[0].size() + arr[1].size();
-			count = arr[2].size() - 1;
+			index += arr[0].buffer_size() + arr[1].buffer_size();
+			count = arr[2].buffer_size() - 1;
 			break;
 		}
-		index += inputs_strings[i].size();
+		index += inputs_strings[i].buffer_size();
 	}
 
 	inputs = inputs.left(index) + inputs.substr(index + count);
@@ -4835,11 +4835,11 @@ void VisualShaderNodeGroupBase::set_output_port_type(int p_id, int p_type) {
 		ERR_FAIL_COND(arr.size() != 3);
 
 		if (arr[0].to_int() == p_id) {
-			index += arr[0].size();
-			count = arr[1].size() - 1;
+			index += arr[0].buffer_size();
+			count = arr[1].buffer_size() - 1;
 			break;
 		}
-		index += output_strings[i].size();
+		index += output_strings[i].buffer_size();
 	}
 
 	outputs = outputs.left(index) + outputs.substr(index + count);
@@ -4871,11 +4871,11 @@ void VisualShaderNodeGroupBase::set_output_port_name(int p_id, const String &p_n
 		ERR_FAIL_COND(arr.size() != 3);
 
 		if (arr[0].to_int() == p_id) {
-			index += arr[0].size() + arr[1].size();
-			count = arr[2].size() - 1;
+			index += arr[0].buffer_size() + arr[1].buffer_size();
+			count = arr[2].buffer_size() - 1;
 			break;
 		}
-		index += output_strings[i].size();
+		index += output_strings[i].buffer_size();
 	}
 
 	outputs = outputs.left(index) + outputs.substr(index + count);

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -221,7 +221,7 @@ void ShaderRD::_build_variant_code(StringBuilder &builder, uint32_t p_variant, c
 					builder.append(p_version->custom_defines[j].get_data());
 				}
 				builder.append("\n"); //make sure defines begin at newline
-				if (p_version->uniforms.size()) {
+				if (p_version->uniforms.length()) {
 					builder.append("#define MATERIAL_UNIFORMS_USED\n");
 				}
 				for (const KeyValue<StringName, CharString> &E : p_version->code_sections) {

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -821,7 +821,7 @@ ShaderLanguage::Token ShaderLanguage::_get_token() {
 							// Compensate reading cursor position.
 							char_idx += 1;
 						}
-						if (str.size() > 11 || !str.is_valid_hex_number(true)) { // > 0xFFFFFFFF
+						if (str.length() > 10 || !str.is_valid_hex_number(true)) { // > 0xFFFFFFFF
 							return _make_token(TK_ERROR, "Invalid (hexadecimal) numeric constant");
 						}
 					} else if (period_found || exponent_found || float_suffix_found) { // Float

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -213,7 +213,7 @@ ShaderPreprocessor::Tokenizer::Tokenizer(const String &p_code) {
 	code = p_code;
 	line = 0;
 	index = 0;
-	size = code.size();
+	size = code.buffer_size();
 }
 
 // ShaderPreprocessor::CommentRemover
@@ -233,14 +233,14 @@ int ShaderPreprocessor::CommentRemover::get_error_line() const {
 }
 
 char32_t ShaderPreprocessor::CommentRemover::peek() const {
-	if (index < code.size()) {
+	if (index < code.buffer_size()) {
 		return code[index];
 	}
 	return 0;
 }
 
 bool ShaderPreprocessor::CommentRemover::advance(char32_t p_what) {
-	while (index < code.size()) {
+	while (index < code.buffer_size()) {
 		char32_t c = code[index++];
 
 		if (c == '\n') {
@@ -263,7 +263,7 @@ String ShaderPreprocessor::CommentRemover::strip() {
 	comments_open = 0;
 	strings_open = 0;
 
-	while (index < code.size()) {
+	while (index < code.buffer_size()) {
 		char32_t c = code[index++];
 
 		if (c == CURSOR) {
@@ -870,7 +870,7 @@ Error ShaderPreprocessor::expand_condition(const String &p_string, int p_line, S
 		int bracket_start_count = 0;
 		int bracket_end_count = 0;
 
-		for (int i = 0; i < p_string.size(); i++) {
+		for (int i = 0; i < p_string.buffer_size(); i++) {
 			switch (p_string[i]) {
 				case CURSOR:
 					state->completion_type = COMPLETION_TYPE_CONDITION;
@@ -906,7 +906,7 @@ Error ShaderPreprocessor::expand_condition(const String &p_string, int p_line, S
 
 		LocalVector<char32_t> text;
 		int post_bracket_index = -1;
-		int size = result.size();
+		int size = result.buffer_size();
 
 		for (int i = (index_start - 1); i < size; i++) {
 			char32_t c = result[i];
@@ -1153,7 +1153,7 @@ void ShaderPreprocessor::concatenate_macro_body(String &r_body) {
 	while (index_start > -1) {
 		int index_end = index_start + 2; // First character after ##.
 		// The macro was checked during creation so this should never happen.
-		ERR_FAIL_INDEX(index_end, r_body.size());
+		ERR_FAIL_INDEX(index_end, r_body.buffer_size());
 
 		// If there more than two # in a row, then it's not a concatenation.
 		bool is_concat = true;

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -1704,8 +1704,8 @@ int64_t TextServer::shaped_text_closest_character_pos(const RID &p_shaped, int64
 PackedInt32Array TextServer::string_get_character_breaks(const String &p_string, const String &p_language) const {
 	PackedInt32Array ret;
 	if (!p_string.is_empty()) {
-		ret.resize(p_string.size() - 1);
-		for (int i = 0; i < p_string.size() - 1; i++) {
+		ret.resize(p_string.length());
+		for (int i = 0; i < p_string.length(); i++) {
 			ret.write[i] = i + 1;
 		}
 	}
@@ -1968,7 +1968,7 @@ void TextServer::shaped_text_debug_print(const RID &p_shaped) const {
 #endif // DEBUG_ENABLED
 
 void TextServer::_diacritics_map_add(const String &p_from, char32_t p_to) {
-	for (int i = 0; i < p_from.size(); i++) {
+	for (int i = 0; i < p_from.length(); i++) {
 		diacritics_map[p_from[i]] = p_to;
 	}
 }

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -299,10 +299,6 @@ TEST_CASE("[String] Concatenation") {
 }
 
 TEST_CASE("[String] Testing size and length of string") {
-	// todo: expand this test to do more tests on size() as it is complicated under the hood.
-	CHECK(String("Mellon").size() == 7);
-	CHECK(String("Mellon1").size() == 8);
-
 	// length works fine and is easier to test
 	CHECK(String("Mellon").length() == 6);
 	CHECK(String("Mellon1").length() == 7);
@@ -1551,32 +1547,24 @@ TEST_CASE("[String] Checking case conversion methods") {
 }
 
 TEST_CASE("[String] Checking string is empty when it should be") {
-	bool state = true;
-	bool success;
-
 	String a = "";
-	success = a[0] == 0;
-	if (!success) {
-		state = false;
-	}
+	CHECK(a.is_empty());
+	CHECK(a[0] == 0);
+
 	String b = "Godot";
-	success = b[b.size()] == 0;
-	if (!success) {
-		state = false;
-	}
-	const String c = "";
-	success = c[0] == 0;
-	if (!success) {
-		state = false;
-	}
+	CHECK(!b.is_empty());
+	CHECK(b.length() == 5);
+	CHECK(b[b.length()] == 0);
+
+	const String c = U"";
+	CHECK(c.is_empty());
+	CHECK(c.length() == 0);
+	CHECK(c[0] == 0);
 
 	const String d = "Godot";
-	success = d[d.size()] == 0;
-	if (!success) {
-		state = false;
-	}
-
-	CHECK(state);
+	CHECK(!d.is_empty());
+	CHECK(d.length() == 5);
+	CHECK(d[d.length()] == 0);
 }
 
 TEST_CASE("[String] lstrip and rstrip") {

--- a/tests/scene/test_arraymesh.h
+++ b/tests/scene/test_arraymesh.h
@@ -123,7 +123,7 @@ TEST_CASE("[SceneTree][ArrayMesh] Adding and modifying blendshapes.") {
 
 		String name_string = mesh->get_blend_shape_name(0);
 		CHECK(name_string.contains("ShapeB"));
-		CHECK(name_string.length() > static_cast<String>(name_b).size());
+		CHECK(name_string.length() > static_cast<String>(name_b).length());
 	}
 
 	SUBCASE("Clear all blend shapes before surface has been added.") {

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -837,7 +837,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "new\ntesting\nswap");
 			CHECK(text_edit->get_caret_line() == 2);
-			CHECK(text_edit->get_caret_column() == text_edit->get_line(2).size() - 1);
+			CHECK(text_edit->get_caret_column() == text_edit->get_line(2).length());
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selection_from_line() == 1);
 			CHECK(text_edit->get_selection_from_column() == 0);
@@ -881,7 +881,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "new\ntesting\nafter\nswap");
 			CHECK(text_edit->get_caret_line() == 3);
-			CHECK(text_edit->get_caret_column() == text_edit->get_line(3).size() - 1);
+			CHECK(text_edit->get_caret_column() == text_edit->get_line(3).length());
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selection_from_line() == 0);
 			CHECK(text_edit->get_selection_to_line() == 3);
@@ -1114,7 +1114,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "testing\nswap");
 			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == text_edit->get_line(1).size() - 1);
+			CHECK(text_edit->get_caret_column() == text_edit->get_line(1).length());
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
@@ -1147,7 +1147,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "new line\nswap");
 			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).size() - 1);
+			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).length());
 			CHECK_FALSE(text_edit->has_selection());
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);

--- a/tests/servers/rendering/test_shader_preprocessor.h
+++ b/tests/servers/rendering/test_shader_preprocessor.h
@@ -58,12 +58,12 @@ bool is_operator_char(unsigned char c) {
 String remove_spaces(String &p_str) {
 	String res;
 	// Result is guaranteed to not be longer than the input.
-	res.resize(p_str.size());
+	res.resize(p_str.length() + 1); // + 1 for NUL
 	int wp = 0;
 	char32_t last = 0;
 	bool has_removed = false;
 
-	for (int n = 0; n < p_str.size(); n++) {
+	for (int n = 0; n < p_str.length(); n++) {
 		// These test cases only use ASCII.
 		unsigned char c = static_cast<unsigned char>(p_str[n]);
 		if (std::isblank(c)) {
@@ -82,6 +82,7 @@ String remove_spaces(String &p_str) {
 			last = c;
 		}
 	}
+	res[wp++] = 0;
 	res.resize(wp);
 	return res;
 }


### PR DESCRIPTION
Supersedes #105710. 

`String::size` is error prone and misleading. I am proposing to rename it to `buffer_size` to make its purpose clearer.
`String::size` is luckily not exposed to GDExtension or GDScript.

This PR is likely to both fix subtle bugs and cause regressions (though less likely than #105710). I recommend merging it soon (early in the 4.5 release cycle).

## Explanation

I was investigating why https://github.com/godotengine/godot/pull/102369 failed, when I realized that empty strings have a dichotomous state:
- `_cowdata` is empty (`_ptr == nullptr`)
- `_cowdata` is allocated and `_size` is 1. The only character is used for the trailing 0 (`NUL` terminator).

This peculiarity does not seem to be widely known. It is currently common to check for `String` emptiness like this:

https://github.com/godotengine/godot/blob/931820d33cbc38328e4014d65dd62c359b5116fc/drivers/gles3/shader_gles3.cpp#L179

This is incorrect because the `String` in question might be empty but allocated, whereupon `size()` would return 1. It should call `if (p_version->uniforms.length())` instead (or better, `if (!p_version->uniforms.is_empty())`).

Additionally, `size` is currently often mistaken for `length` in the codebase. While making this PR, I found many subtle bugs of code that was iterating over the trailing `NUL` character and (potentially) inserting it into strings or other data.

By renaming to `buffer_size`, it's clearer that this should only be used when interacting with the buffer directly (such as when using `resize` and filling contents).

## Changes

Interface:
- `size()` is renamed to `buffer_size()` in `ustring.h`
- A related unit test was edited to do more
- `get_data()` is moved to the header to allow inlining.

Callers:
- `size() - 1` is almost always replaced by `length()`
- `if (size())` is replaced by `if (length())` (could be `!is_empty` but that's out of scope)
- `size()` is replaced by `length()` if it is obviously more correct
- `size()` is replaced by `buffer_size()` in other cases.

## Addendum

We should resolve the dichotomy mentioned above. Empty `String`s should not allocate. Without the dichotomy, https://github.com/godotengine/godot/pull/102369 can also be merged for a pretty significant speed boost.
This will unfortunately require a little bit of a compatibility breakage, so I wanted to do this PR first.