### PR TITLE
Warn when running low on disk space when performing certain editor operations

### DIFF
--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -37,6 +37,23 @@
 #include "core/os/time.h"
 #include "core/templates/local_vector.h"
 
+// Check for available disk space on the target disk and warn the user if needed according to a set threshold.
+// The threshold (set in GiB) should be set to cover most use cases for the file being written.
+void DirAccess::check_disk_space(const String &p_target_path, float p_size_gib, const String &p_rationale) {
+	String path = p_target_path;
+	if (path.is_relative_path()) {
+		path = "res://" + path;
+	}
+	// Use a global path for more user-friendly warning display.
+	path = ProjectSettings::get_singleton()->globalize_path(path.get_base_dir());
+
+	const Ref<DirAccess> dir = DirAccess::open(path);
+	if (dir.is_valid() && dir->get_space_left() < p_size_gib * Math::pow(1024.0, 3.0)) {
+		// Less than `p_size_gib` GiB available.
+		WARN_PRINT_ED(vformat("%s: Current available space on target disk is low (%s).", path, String::humanize_size(dir->get_space_left())) + " " + p_rationale);
+	}
+}
+
 String DirAccess::_get_root_path() const {
 	switch (_access_type) {
 		case ACCESS_RESOURCES:

--- a/core/io/dir_access.h
+++ b/core/io/dir_access.h
@@ -82,6 +82,8 @@ protected:
 	}
 
 public:
+	static void check_disk_space(const String &p_target_path, float p_size_gib, const String &p_rationale);
+
 	virtual Error list_dir_begin() = 0; ///< This starts dir listing
 	virtual String get_next() = 0;
 	virtual bool current_is_dir() const = 0;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2296,6 +2296,11 @@ void EditorNode::_find_node_types(Node *p_node, int &count_2d, int &count_3d) {
 }
 
 void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
+	// Scene files are typically less than 1 MB, but text-based scenes with large amounts of embedded binary data
+	// can be much larger (sometimes 100 MB or more). Consider a buffer of 1 GiB to be safe, since there are
+	// also temporary files and thumbnails that come into play.
+	DirAccess::check_disk_space(p_file, 1.0, TTR("Saving scenes will fail if the disk runs out of space."));
+
 	save_scene_progress = memnew(EditorProgress("save", TTR("Saving Scene"), 4));
 
 	if (editor_data.get_edited_scene_root() != nullptr) {

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -224,6 +224,11 @@ bool EditorExportPlatform::fill_log_messages(RichTextLabel *p_log, Error p_err) 
 	return has_messages;
 }
 
+void EditorExportPlatform::check_disk_space(const String &p_path) const {
+	// Project files can grow quite large, so check for a reasonable amount of available space before exporting.
+	DirAccess::check_disk_space(p_path, 10.0, TTR("Exporting the project will fail if the disk runs out of space."));
+}
+
 Error EditorExportPlatform::_extract_android_assets(const String &p_bundle_path, String &r_pck_path, String &r_temp_dir) {
 	Error err = OK;
 
@@ -2463,11 +2468,13 @@ Error EditorExportPlatform::save_zip_patch(const Ref<EditorExportPreset> &p_pres
 
 Error EditorExportPlatform::export_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+	check_disk_space(p_path);
 	return save_pack(p_preset, p_debug, p_path);
 }
 
 Error EditorExportPlatform::export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+	check_disk_space(p_path);
 	return save_zip(p_preset, p_debug, p_path);
 }
 
@@ -2477,6 +2484,7 @@ Error EditorExportPlatform::export_pack_patch(const Ref<EditorExportPreset> &p_p
 	if (err != OK) {
 		return err;
 	}
+	check_disk_space(p_path);
 	err = save_pack_patch(p_preset, p_debug, p_path);
 	_unload_patches();
 	return err;
@@ -2488,6 +2496,7 @@ Error EditorExportPlatform::export_zip_patch(const Ref<EditorExportPreset> &p_pr
 	if (err != OK) {
 		return err;
 	}
+	check_disk_space(p_path);
 	err = save_zip_patch(p_preset, p_debug, p_path);
 	_unload_patches();
 	return err;

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -252,6 +252,8 @@ public:
 	virtual Ref<EditorExportPreset> create_preset();
 	virtual bool is_executable(const String &p_path) const { return false; }
 
+	void check_disk_space(const String &p_path) const;
+
 	virtual void clear_messages() { messages.clear(); }
 	virtual void add_message(ExportMessageType p_type, const String &p_category, const String &p_message) {
 		ExportMessage msg;

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -1716,6 +1716,7 @@ Error EditorExportPlatformAppleEmbedded::_export_apple_embedded_plugins(const Re
 }
 
 Error EditorExportPlatformAppleEmbedded::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags, bool p_notify) {
+	check_disk_space(p_path);
 	return _export_project_helper(p_preset, p_debug, p_path, p_flags, p_notify, false);
 }
 

--- a/editor/export/editor_export_platform_extension.cpp
+++ b/editor/export/editor_export_platform_extension.cpp
@@ -282,6 +282,7 @@ List<String> EditorExportPlatformExtension::get_binary_extensions(const Ref<Edit
 
 Error EditorExportPlatformExtension::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags, bool p_notify) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags, p_notify);
+	check_disk_space(p_path);
 
 	Error ret = FAILED;
 	GDVIRTUAL_CALL(_export_project, p_preset, p_debug, p_path, p_flags, ret);

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -140,6 +140,7 @@ bool EditorExportPlatformPC::has_valid_project_configuration(const Ref<EditorExp
 
 Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags, bool p_notify) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags, p_notify);
+	check_disk_space(p_path);
 
 	Error err = prepare_template(p_preset, p_debug, p_path, p_flags);
 	if (err == OK) {

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -223,6 +223,17 @@ void ExportTemplateManager::_delete_file(const TreeItem *p_item) {
 }
 
 void ExportTemplateManager::_tpz_file_selected(const String &p_file) {
+	// Decompressed official export templates are typically around 2 GiB on disk.
+	// While this is not necessarily the case, we assume the selected export templates TPZ
+	// contains all files (similar to official templates).
+	//
+	// The compressed file also has to stay on disk until the export templates are done extracting,
+	// so we also need to account for its compressed size on top.
+	DirAccess::check_disk_space(
+			EditorPaths::get_singleton()->get_data_dir(),
+			4.0,
+			TTR("Installing export templates will fail if the disk runs out of space."));
+
 	Ref<FileAccess> io_fa;
 	zlib_filefunc_def io = zipio_create_io(&io_fa);
 
@@ -1991,6 +2002,14 @@ void TemplateDownloader::_bind_methods() {
 }
 
 Error TemplateDownloader::download_template(const String &p_file_name, const String &p_source) {
+	// The largest official individual export template file is around 200 MiB on disk (`android_source.zip`).
+	// However, the compressed file has to stay on disk until the export templates are done extracting,
+	// so we also need to account for its compressed size on top.
+	DirAccess::check_disk_space(
+			EditorPaths::get_singleton()->get_data_dir(),
+			1.0,
+			TTR("Downloading export templates will fail if the disk runs out of space."));
+
 	url = p_source;
 	filename = p_file_name;
 

--- a/editor/export/project_zip_packer.cpp
+++ b/editor/export/project_zip_packer.cpp
@@ -37,6 +37,7 @@
 #include "core/os/os.h"
 #include "core/os/time.h"
 #include "core/string/ustring.h"
+#include "editor/editor_node.h"
 
 String ProjectZIPPacker::get_project_zip_safe_name() {
 	// Name the downloaded ZIP file to contain the project name and download date for easier organization.
@@ -52,6 +53,9 @@ String ProjectZIPPacker::get_project_zip_safe_name() {
 }
 
 void ProjectZIPPacker::pack_project_zip(const String &p_path) {
+	// Project files can grow quite large, so check for a reasonable amount of available space before packing.
+	DirAccess::check_disk_space(p_path, 10.0, TTR("Packing the project as ZIP will fail if the disk runs out of space."));
+
 	Ref<FileAccess> io_fa;
 	zlib_filefunc_def io = zipio_create_io(&io_fa);
 

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -3263,6 +3263,13 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 
 	EditorProgress *ep = memnew(EditorProgress("reimport", TTR("(Re)Importing Assets"), p_files.size()));
 
+	if (!p_files.is_empty()) {
+		// Imported resources can be relatively large, so check if there is enough disk space.
+		// We perform the check here so it's performed only one for all files to be reimported,
+		// instead of once for each file.
+		DirAccess::check_disk_space(p_files[0], 2.0, TTR("Importing resources will fail if the disk runs out of space."));
+	}
+
 	// The method reimport_files runs on the main thread, and if VSync is enabled
 	// or Update Continuously is disabled, Main::Iteration takes longer each frame.
 	// Each EditorProgress::step can trigger a redraw, and when there are many files to import,

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1295,6 +1295,10 @@ void SceneImportSettingsDialog::_viewport_input(const Ref<InputEvent> &p_input) 
 }
 
 void SceneImportSettingsDialog::_re_import() {
+	// Complex 3D scenes can be quite large. Consider a buffer of 1 GiB to be
+	// safe, since there are also temporary files and thumbnails that come into play.
+	DirAccess::check_disk_space(base_path, 1.0, TTR("Importing resources will fail if the disk runs out of space."));
+
 	HashMap<StringName, Variant> main_settings;
 
 	main_settings = scene_import_settings_data->current;

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -32,6 +32,7 @@
 
 #include "core/object/callable_mp.h"
 #include "editor/audio/audio_stream_preview.h"
+#include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/themes/editor_scale.h"
@@ -557,6 +558,10 @@ void AudioStreamImportSettingsDialog::_settings_changed() {
 }
 
 void AudioStreamImportSettingsDialog::_reimport() {
+	// Long audio files can be quite large. Consider a buffer of 1 GiB to be
+	// safe, since there are also temporary files and thumbnails that come into play.
+	DirAccess::check_disk_space(path, 1.0, TTR("Importing resources will fail if the disk runs out of space."));
+
 	params["loop"] = loop->is_pressed();
 	params["loop_offset"] = loop_offset->get_value();
 	params["bpm"] = bpm_enabled->is_pressed() ? double(bpm_edit->get_value()) : double(0);

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -641,6 +641,10 @@ void DynamicFontImportSettingsDialog::_notification(int p_what) {
 }
 
 void DynamicFontImportSettingsDialog::_re_import() {
+	// Complex fonts can be quite large. Consider a buffer of 1 GiB to be
+	// safe, since there are also temporary files and thumbnails that come into play.
+	DirAccess::check_disk_space(base_path, 1.0, TTR("Importing resources will fail if the disk runs out of space."));
+
 	HashMap<StringName, Variant> main_settings;
 
 	main_settings["face_index"] = import_settings_data->get("face_index");

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -3606,6 +3606,7 @@ bool EditorExportPlatformAndroid::_is_clean_build_required(const Ref<EditorExpor
 Error EditorExportPlatformAndroid::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags, bool p_notify) {
 	int export_format = int(p_preset->get("gradle_build/export_format"));
 	bool should_sign = p_preset->get("package/signed");
+	check_disk_space(p_path);
 	return export_project_helper(p_preset, p_debug, p_path, export_format, should_sign, p_flags);
 }
 

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -1625,6 +1625,7 @@ Error EditorExportPlatformMacOS::_export_debug_script(const Ref<EditorExportPres
 
 Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags, bool p_notify) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags, p_notify);
+	check_disk_space(p_path);
 
 	const String base_dir = p_path.get_base_dir();
 

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -492,6 +492,7 @@ List<String> EditorExportPlatformWeb::get_binary_extensions(const Ref<EditorExpo
 
 Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags, bool p_notify) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags, p_notify);
+	check_disk_space(p_path);
 
 	const String custom_debug = p_preset->get("custom_template/debug");
 	const String custom_release = p_preset->get("custom_template/release");

--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -105,16 +105,7 @@ void MovieWriter::begin(const Size2i &p_movie_size, uint32_t p_fps, const String
 
 	print_line(vformat(U"Movie Maker mode enabled, recording movie in %s×%s @ %d FPS...", movie_size.width, movie_size.height, p_fps));
 
-	// Check for available disk space and warn the user if needed.
-	String path = p_base_path.get_base_dir();
-	if (path.is_relative_path()) {
-		path = "res://" + path;
-	}
-	Ref<DirAccess> dir = DirAccess::open(path);
-	if (dir->get_space_left() < 10 * Math::pow(1024.0, 3.0)) {
-		// Less than 10 GiB available.
-		WARN_PRINT(vformat("Current available space on disk is low (%s). MovieWriter will fail during movie recording if the disk runs out of available space.", String::humanize_size(dir->get_space_left())));
-	}
+	DirAccess::check_disk_space(p_base_path, 10.0, "MovieWriter will fail during movie recording if the disk runs out of space.");
 
 	cpu_time = 0.0f;
 	gpu_time = 0.0f;


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/62418.

The following editor operations will now warn the user if the available space on the target disk is low:

- Saving a scene (< 1 GiB).
- Importing a set of resources (< 2 GiB).
- Downloading an export template (< 1 GiB, checked per-file).
- Installing export templates from a TPZ (< 4 GiB).
- Exporting a project (< 10 GiB).
- Packing a project as a ZIP file (< 10 GiB).

The existing MovieWriter disk space check now makes use of the newly added method for consistency.

___

- This closes https://github.com/godotengine/godot/issues/95111.
- See https://github.com/godotengine/godot/issues/45354
and https://github.com/godotengine/godot/issues/105742.
