### PR TITLE
CI: Ensure Windows Actions handle utf-8 characters

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -7,6 +7,7 @@ on:
 env:
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes d3d12=yes strict_checks=yes "angle_libs=${{ github.workspace }}/" "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.15.1/"
   SCONS_CACHE_MSVC_CONFIG: true
+  PYTHONIOENCODING: utf8
 
 jobs:
   build-windows:


### PR DESCRIPTION
- Related #103968

After seeing that the Windows GHA failed because of an illegal codepoint, I looked into it and found that we can simply enable utf-8 as the default codepage. Validated with multiple print function calls of unicode gibberish `²∞み`

Before:
![chrome_PbbTqkbnw4](https://github.com/user-attachments/assets/be1aed04-790c-4916-a80f-76cfcff723b0)
After:
![chrome_5s4zLQqtey](https://github.com/user-attachments/assets/a40bca52-aef1-4e5a-b94d-97481ad849d9)
