### PR TITLE
Make Jolt Physics the default 3D physics engine

### DIFF
--- a/modules/godot_physics_3d/register_types.cpp
+++ b/modules/godot_physics_3d/register_types.cpp
@@ -34,6 +34,8 @@
 #include "servers/physics_3d/physics_server_3d.h"
 #include "servers/physics_3d/physics_server_3d_wrap_mt.h"
 
+#include "modules/modules_enabled.gen.h" // For jolt_physics.
+
 static PhysicsServer3D *_createGodotPhysics3DCallback() {
 #ifdef THREADS_ENABLED
 	bool using_threads = GLOBAL_GET("physics/3d/run_on_separate_thread");
@@ -51,7 +53,11 @@ void initialize_godot_physics_3d_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 	PhysicsServer3DManager::get_singleton()->register_server("GodotPhysics3D", callable_mp_static(_createGodotPhysics3DCallback));
+#ifndef MODULE_JOLT_PHYSICS_ENABLED
+	// Set the default explicitly as the call to `set_default_server()` in `modules/jolt_physics/` isn't compiled in.
+	// Otherwise, we would fall back to the Dummy physics server and end up with no physics at all.
 	PhysicsServer3DManager::get_singleton()->set_default_server("GodotPhysics3D");
+#endif
 }
 
 void uninitialize_godot_physics_3d_module(ModuleInitializationLevel p_level) {

--- a/modules/jolt_physics/register_types.cpp
+++ b/modules/jolt_physics/register_types.cpp
@@ -55,6 +55,7 @@ void initialize_jolt_physics_module(ModuleInitializationLevel p_level) {
 
 	jolt_initialize();
 	PhysicsServer3DManager::get_singleton()->register_server("Jolt Physics", callable_mp_static(&create_jolt_physics_server));
+	PhysicsServer3DManager::get_singleton()->set_default_server("Jolt Physics");
 	JoltProjectSettings::register_settings();
 }
 


### PR DESCRIPTION
> [!NOTE]
>
> **This PR is not aiming for an immediate merge**, as https://github.com/godotengine/godot/pull/105737 is intended to be merged first.
>
> This PR is still ready for review, but https://github.com/godotengine/godot/pull/105737 is expected to have been merged in a minor version before this PR can be considered for a merge.

___

GodotPhysics3D is still available and can be set in the Project Settings. Projects that have already explicitly set their 3D physics engine to GodotPhysics3D are unaffected by this change.

If Jolt Physics is disabled at compile-time, the default physics engine will still be GodotPhysics3D.

- This implements the **second** part of https://github.com/godotengine/godot-proposals/issues/12289.
