### PR TITLE
Add function to get navigation link iteration id from NavigationServer

### DIFF
--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -344,6 +344,14 @@
 				Returns the enter cost of this [param link].
 			</description>
 		</method>
+		<method name="link_get_iteration_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="link" type="RID" />
+			<description>
+				Returns the current iteration ID of the navigation link. Every time the navigation link changes and synchronizes, the iteration ID increases. An iteration ID of [code]0[/code] means the navigation link has never synchronized.
+				[b]Note:[/b] The iteration ID will wrap around to [code]1[/code] after reaching its range limit.
+			</description>
+		</method>
 		<method name="link_get_map" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="link" type="RID" />

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -376,6 +376,14 @@
 				Returns the enter cost of this [param link].
 			</description>
 		</method>
+		<method name="link_get_iteration_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="link" type="RID" />
+			<description>
+				Returns the current iteration ID of the navigation link. Every time the navigation link changes and synchronizes, the iteration ID increases. An iteration ID of [code]0[/code] means the navigation link has never synchronized.
+				[b]Note:[/b] The iteration ID will wrap around to [code]1[/code] after reaching its range limit.
+			</description>
+		</method>
 		<method name="link_get_map" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="link" type="RID" />

--- a/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
@@ -644,6 +644,13 @@ RID GodotNavigationServer2D::link_create() {
 	return rid;
 }
 
+uint32_t GodotNavigationServer2D::link_get_iteration_id(RID p_link) const {
+	NavLink2D *link = link_owner.get_or_null(p_link);
+	ERR_FAIL_NULL_V(link, 0);
+
+	return link->get_iteration_id();
+}
+
 COMMAND_2(link_set_map, RID, p_link, RID, p_map) {
 	NavLink2D *link = link_owner.get_or_null(p_link);
 	ERR_FAIL_NULL(link);

--- a/modules/navigation_2d/2d/godot_navigation_server_2d.h
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.h
@@ -177,6 +177,7 @@ public:
 	virtual Rect2 region_get_bounds(RID p_region) const override;
 
 	virtual RID link_create() override;
+	virtual uint32_t link_get_iteration_id(RID p_link) const override;
 
 	/// Set the map of this link.
 	COMMAND_2(link_set_map, RID, p_link, RID, p_map);

--- a/modules/navigation_2d/nav_link_2d.cpp
+++ b/modules/navigation_2d/nav_link_2d.cpp
@@ -141,6 +141,10 @@ bool NavLink2D::is_dirty() const {
 }
 
 void NavLink2D::sync() {
+	if (link_dirty) {
+		iteration_id = iteration_id % UINT32_MAX + 1;
+	}
+
 	link_dirty = false;
 }
 

--- a/modules/navigation_2d/nav_link_2d.h
+++ b/modules/navigation_2d/nav_link_2d.h
@@ -57,9 +57,13 @@ class NavLink2D : public NavBase2D {
 
 	SelfList<NavLink2D> sync_dirty_request_list_element;
 
+	uint32_t iteration_id = 0;
+
 public:
 	NavLink2D();
 	~NavLink2D();
+
+	uint32_t get_iteration_id() const { return iteration_id; }
 
 	void set_map(NavMap2D *p_map);
 	NavMap2D *get_map() const {

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
@@ -613,6 +613,13 @@ RID GodotNavigationServer3D::link_create() {
 	return rid;
 }
 
+uint32_t GodotNavigationServer3D::link_get_iteration_id(RID p_link) const {
+	NavLink3D *link = link_owner.get_or_null(p_link);
+	ERR_FAIL_NULL_V(link, 0);
+
+	return link->get_iteration_id();
+}
+
 COMMAND_2(link_set_map, RID, p_link, RID, p_map) {
 	NavLink3D *link = link_owner.get_or_null(p_link);
 	ERR_FAIL_NULL(link);

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.h
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.h
@@ -185,6 +185,7 @@ public:
 	virtual AABB region_get_bounds(RID p_region) const override;
 
 	virtual RID link_create() override;
+	virtual uint32_t link_get_iteration_id(RID p_link) const override;
 	COMMAND_2(link_set_map, RID, p_link, RID, p_map);
 	virtual RID link_get_map(RID p_link) const override;
 	COMMAND_2(link_set_enabled, RID, p_link, bool, p_enabled);

--- a/modules/navigation_3d/nav_link_3d.cpp
+++ b/modules/navigation_3d/nav_link_3d.cpp
@@ -141,6 +141,10 @@ bool NavLink3D::is_dirty() const {
 }
 
 void NavLink3D::sync() {
+	if (link_dirty) {
+		iteration_id = iteration_id % UINT32_MAX + 1;
+	}
+
 	link_dirty = false;
 }
 

--- a/modules/navigation_3d/nav_link_3d.h
+++ b/modules/navigation_3d/nav_link_3d.h
@@ -57,9 +57,13 @@ class NavLink3D : public NavBase3D {
 
 	SelfList<NavLink3D> sync_dirty_request_list_element;
 
+	uint32_t iteration_id = 0;
+
 public:
 	NavLink3D();
 	~NavLink3D();
+
+	uint32_t get_iteration_id() const { return iteration_id; }
 
 	void set_map(NavMap3D *p_map);
 	NavMap3D *get_map() const {

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -102,6 +102,7 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("region_get_bounds", "region"), &NavigationServer2D::region_get_bounds);
 
 	ClassDB::bind_method(D_METHOD("link_create"), &NavigationServer2D::link_create);
+	ClassDB::bind_method(D_METHOD("link_get_iteration_id", "link"), &NavigationServer2D::link_get_iteration_id);
 	ClassDB::bind_method(D_METHOD("link_set_map", "link", "map"), &NavigationServer2D::link_set_map);
 	ClassDB::bind_method(D_METHOD("link_get_map", "link"), &NavigationServer2D::link_get_map);
 	ClassDB::bind_method(D_METHOD("link_set_enabled", "link", "enabled"), &NavigationServer2D::link_set_enabled);

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -161,6 +161,7 @@ public:
 
 	/// Creates a new link between positions in the nav map.
 	virtual RID link_create() = 0;
+	virtual uint32_t link_get_iteration_id(RID p_link) const = 0;
 
 	/// Set the map of this link.
 	virtual void link_set_map(RID p_link, RID p_map) = 0;

--- a/servers/navigation_server_2d_dummy.h
+++ b/servers/navigation_server_2d_dummy.h
@@ -90,6 +90,7 @@ public:
 	Rect2 region_get_bounds(RID p_region) const override { return Rect2(); }
 
 	RID link_create() override { return RID(); }
+	uint32_t link_get_iteration_id(RID p_link) const override { return 0; }
 	void link_set_map(RID p_link, RID p_map) override {}
 	RID link_get_map(RID p_link) const override { return RID(); }
 	void link_set_enabled(RID p_link, bool p_enabled) override {}

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -115,6 +115,7 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("region_get_bounds", "region"), &NavigationServer3D::region_get_bounds);
 
 	ClassDB::bind_method(D_METHOD("link_create"), &NavigationServer3D::link_create);
+	ClassDB::bind_method(D_METHOD("link_get_iteration_id", "link"), &NavigationServer3D::link_get_iteration_id);
 	ClassDB::bind_method(D_METHOD("link_set_map", "link", "map"), &NavigationServer3D::link_set_map);
 	ClassDB::bind_method(D_METHOD("link_get_map", "link"), &NavigationServer3D::link_get_map);
 	ClassDB::bind_method(D_METHOD("link_set_enabled", "link", "enabled"), &NavigationServer3D::link_set_enabled);

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -185,6 +185,7 @@ public:
 
 	/// Creates a new link between positions in the nav map.
 	virtual RID link_create() = 0;
+	virtual uint32_t link_get_iteration_id(RID p_link) const = 0;
 
 	/// Set the map of this link.
 	virtual void link_set_map(RID p_link, RID p_map) = 0;

--- a/servers/navigation_server_3d_dummy.h
+++ b/servers/navigation_server_3d_dummy.h
@@ -102,6 +102,7 @@ public:
 	AABB region_get_bounds(RID p_region) const override { return AABB(); }
 
 	RID link_create() override { return RID(); }
+	uint32_t link_get_iteration_id(RID p_link) const override { return 0; }
 	void link_set_map(RID p_link, RID p_map) override {}
 	RID link_get_map(RID p_link) const override { return RID(); }
 	void link_set_enabled(RID p_link, bool p_enabled) override {}


### PR DESCRIPTION
Adds function to get navigation link iteration id from NavigationServer.

This is useful to give users an option to check if a navigation link has synchronized before doing queries, same as https://github.com/godotengine/godot/pull/104826 for regions.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
