### PR TITLE
Optimize static allocations by removing unused `Memory::alloc_count`.

### DIFF
--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -62,8 +62,6 @@ SafeNumeric<uint64_t> Memory::mem_usage;
 SafeNumeric<uint64_t> Memory::max_usage;
 #endif
 
-SafeNumeric<uint64_t> Memory::alloc_count;
-
 void *Memory::alloc_aligned_static(size_t p_bytes, size_t p_alignment) {
 	DEV_ASSERT(is_power_of_2(p_alignment));
 
@@ -106,8 +104,6 @@ void *Memory::alloc_static(size_t p_bytes, bool p_pad_align) {
 	void *mem = malloc(p_bytes + (prepad ? DATA_OFFSET : 0));
 
 	ERR_FAIL_NULL_V(mem, nullptr);
-
-	alloc_count.increment();
 
 	if (prepad) {
 		uint8_t *s8 = (uint8_t *)mem;
@@ -185,8 +181,6 @@ void Memory::free_static(void *p_ptr, bool p_pad_align) {
 #else
 	bool prepad = p_pad_align;
 #endif
-
-	alloc_count.decrement();
 
 	if (prepad) {
 		mem -= DATA_OFFSET;

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -43,8 +43,6 @@ class Memory {
 	static SafeNumeric<uint64_t> max_usage;
 #endif
 
-	static SafeNumeric<uint64_t> alloc_count;
-
 public:
 	// Alignment:  ↓ max_align_t        ↓ uint64_t          ↓ max_align_t
 	//             ┌─────────────────┬──┬────────────────┬──┬───────────...


### PR DESCRIPTION
The int `Memory::alloc_count` is being incremented and decremented in `Memory`, but never used.
As an atomic, it is quite slow. It should be removed.

This bottleneck was found by @Nazarwadim in https://github.com/godotengine/godot/pull/97016#issuecomment-2356447368.

## Benchmark

I benchmarked a ~15% improvement for `Memory::alloc_static`:

```c++
	auto t0 = std::chrono::high_resolution_clock::now();
	for (int i = 0; i < 20000000; i ++) {
		Memory::alloc_static(16);
	}
	auto t1 = std::chrono::high_resolution_clock::now();
	std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
```

This printed:
- `306ms` on master
- `263ms` on this PR