### PR TITLE
Fix inspector spacing issues

### DIFF
--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -768,6 +768,8 @@ class EditorInspector : public ScrollContainer {
 	void _add_meta_confirm();
 	void _show_add_meta_dialog();
 
+	void _handle_menu_option(int p_option);
+	void _add_section_in_tree(EditorInspectorSection *p_section, VBoxContainer *p_current_vbox);
 	static EditorInspector *_get_control_parent_inspector(Control *p_control);
 
 protected:


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #104931 and reverts #103309 & #104344. 

This instead adds a new solution, where adjacent `EditorInspectorSections` are automatically grouped into the same vbox, with 0 separation and without disrupting their order.

This has the added benefit of preserving the order of normal groups (They were always stuck to the bottom of the category, unlike subgroups which would stay in place. See https://github.com/godotengine/godot/issues/104931#issuecomment-2829211862)

![image](https://github.com/user-attachments/assets/8362d2fe-8ecf-47f8-a953-eb9cd2b50694)
(Screenshot of normal properties being properly spaced again. And array groups, which are all the groups besides "Resource", having no gaps)