### PR TITLE
Add a dropdown menu option to insert marker at timeline position in animation track

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3103,6 +3103,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 				menu->clear();
 				menu->add_icon_item(get_editor_theme_icon(SNAME("Key")), TTR("Insert Key..."), MENU_KEY_INSERT);
+				
 				if (selected || editor->is_selection_active()) {
 					menu->add_separator();
 					menu->add_icon_item(get_editor_theme_icon(SNAME("Duplicate")), TTR("Duplicate Key(s)"), MENU_KEY_DUPLICATE);
@@ -3130,7 +3131,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				menu->popup();
 
 				insert_at_pos = offset + timeline->get_value();
-				accept_event();
+				insert_at_pos_current = timeline->get_play_position();
 			}
 		}
 	}
@@ -3470,6 +3471,9 @@ void AnimationTrackEdit::_menu_selected(int p_index) {
 		} break;
 		case MENU_KEY_INSERT: {
 			emit_signal(SNAME("insert_key"), insert_at_pos);
+		} break;
+		case MENU_KEY_INSERT_CURRENT: {
+			emit_signal(SNAME("duplicate_request"), insert_at_pos_current, true); //change insert_at_pos to be the indicator position
 		} break;
 		case MENU_KEY_DUPLICATE: {
 			emit_signal(SNAME("duplicate_request"), insert_at_pos, true);
@@ -8163,6 +8167,9 @@ void AnimationMarkerEdit::_menu_selected(int p_index) {
 		case MENU_KEY_INSERT: {
 			_insert_marker(insert_at_pos);
 		} break;
+		case MENU_KEY_INSERT_CURRENT: {
+			_insert_marker(insert_at_pos_current);
+		} break;
 		case MENU_KEY_RENAME: {
 			if (selection.size() > 0) {
 				_rename_marker(*selection.last());
@@ -8554,6 +8561,9 @@ void AnimationMarkerEdit::gui_input(const Ref<InputEvent> &p_event) {
 				menu->clear();
 				menu->add_icon_item(get_editor_theme_icon(SNAME("Key")), TTR("Insert Marker..."), MENU_KEY_INSERT);
 
+				//added - works as intended, creates another menu button
+				menu->add_icon_item(get_editor_theme_icon(SNAME("Key")), TTR("Insert Marker on Current Time..."), MENU_KEY_INSERT_CURRENT);
+
 				if (selected || selection.size() > 0) {
 					menu->add_icon_item(get_editor_theme_icon(SNAME("Edit")), TTR("Rename Marker"), MENU_KEY_RENAME);
 					menu->add_icon_item(get_editor_theme_icon(SNAME("Remove")), TTR("Delete Marker(s)"), MENU_KEY_DELETE);
@@ -8569,6 +8579,7 @@ void AnimationMarkerEdit::gui_input(const Ref<InputEvent> &p_event) {
 				menu->popup();
 
 				insert_at_pos = offset + timeline->get_value();
+				insert_at_pos_current = timeline->get_play_position();
 				accept_event();
 			}
 		}

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -278,6 +278,7 @@ class AnimationMarkerEdit : public Control {
 
 	enum {
 		MENU_KEY_INSERT,
+		MENU_KEY_INSERT_CURRENT, //added
 		MENU_KEY_RENAME,
 		MENU_KEY_DELETE,
 		MENU_KEY_TOGGLE_MARKER_NAMES,
@@ -311,6 +312,7 @@ class AnimationMarkerEdit : public Control {
 	bool _is_ui_pos_in_current_section(const Point2 &p_pos);
 
 	float insert_at_pos = 0.0f;
+	float insert_at_pos_current = 0.0f;
 	bool moving_selection_attempt = false;
 	bool moving_selection_effective = false;
 	float moving_selection_offset = 0.0f;
@@ -421,6 +423,7 @@ class AnimationTrackEdit : public Control {
 		MENU_LOOP_WRAP,
 		MENU_LOOP_CLAMP,
 		MENU_KEY_INSERT,
+		MENU_KEY_INSERT_CURRENT,
 		MENU_KEY_DUPLICATE,
 		MENU_KEY_CUT,
 		MENU_KEY_COPY,
@@ -476,6 +479,7 @@ class AnimationTrackEdit : public Control {
 
 	mutable int dropping_at = 0;
 	float insert_at_pos = 0.0f;
+	float insert_at_pos_current = 0.0f;
 	bool moving_selection_attempt = false;
 	bool moving_selection_effective = false;
 	float moving_selection_pivot = 0.0f;

--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -119,16 +119,6 @@ void LightmapGIEditorPlugin::_bake_select_file(const String &p_file) {
 			case LightmapGI::BAKE_ERROR_ATLAS_TOO_SMALL: {
 				EditorNode::get_singleton()->show_warning(TTR("Failed fitting a lightmap image into an atlas. This should never happen and should be reported."));
 			} break;
-			case LightmapGI::BAKE_ERROR_USER_ABORTED: {
-				/*EditorNode::get_singleton()->show_warning(TTR("User cancelled bake."));
-				if (tmp_progress != nullptr) {
-					memdelete(tmp_progress);
-					tmp_progress = nullptr;
-				}
-				bake->hide();*/
-
-				//close process here?
-			} break;
 			default: {
 			} break;
 		}

--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -119,6 +119,16 @@ void LightmapGIEditorPlugin::_bake_select_file(const String &p_file) {
 			case LightmapGI::BAKE_ERROR_ATLAS_TOO_SMALL: {
 				EditorNode::get_singleton()->show_warning(TTR("Failed fitting a lightmap image into an atlas. This should never happen and should be reported."));
 			} break;
+			case LightmapGI::BAKE_ERROR_USER_ABORTED: {
+				/*EditorNode::get_singleton()->show_warning(TTR("User cancelled bake."));
+				if (tmp_progress != nullptr) {
+					memdelete(tmp_progress);
+					tmp_progress = nullptr;
+				}
+				bake->hide();*/
+
+				//close process here?
+			} break;
 			default: {
 			} break;
 		}
@@ -157,6 +167,8 @@ bool LightmapGIEditorPlugin::bake_func_step(float p_progress, const String &p_de
 		tmp_progress = memnew(EditorProgress("bake_lightmaps", TTR("Bake Lightmaps"), 1000, true));
 		ERR_FAIL_NULL_V(tmp_progress, false);
 	}
+
+
 	return tmp_progress->step(p_description, p_progress * 1000, p_refresh);
 }
 

--- a/editor/plugins/lightmap_gi_editor_plugin.h
+++ b/editor/plugins/lightmap_gi_editor_plugin.h
@@ -63,4 +63,5 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	LightmapGIEditorPlugin();
+
 };

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -1033,7 +1033,7 @@ LightmapperRD::BakeError LightmapperRD::_denoise(RenderingDevice *p_rd, Ref<RDSh
 		if (p_step_function) {
 			int percent = (s + 1) * 100 / p_atlas_slices;
 			float p = float(s) / p_atlas_slices * 0.1;
-			if (p_step_function(0.8 + p, vformat(RTR("Denoising %d%%"), percent), p_bake_userdata, false)) {
+			if (p_step_function(0.8 + p, vformat(RTR("Denoising %d%%"), percent), p_bake_userdata, true)) {
 				return BAKE_ERROR_USER_ABORTED;
 			}
 		}
@@ -1046,6 +1046,8 @@ LightmapperRD::BakeError LightmapperRD::_denoise(RenderingDevice *p_rd, Ref<RDSh
 }
 
 LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_denoiser, float p_denoiser_strength, int p_denoiser_range, int p_bounces, float p_bounce_indirect_energy, float p_bias, int p_max_texture_size, bool p_bake_sh, bool p_bake_shadowmask, bool p_texture_for_bounces, GenerateProbes p_generate_probes, const Ref<Image> &p_environment_panorama, const Basis &p_environment_transform, BakeStepFunc p_step_function, void *p_bake_userdata, float p_exposure_normalization, float p_supersampling_factor) {
+
+
 	int denoiser = GLOBAL_GET("rendering/lightmapping/denoising/denoiser");
 	String oidn_path = EDITOR_GET("filesystem/tools/oidn/oidn_denoise_path");
 


### PR DESCRIPTION
Addressed #103272 (added functionality in terms of a drop-down menu item) to allow users to insert marker at the mouse position and the timeline cursor position for ease of use with animation timeline
