### PR TITLE
Remove trailing newline in .import files when [params] section is empty

### DIFF
--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -210,9 +210,9 @@ Error ConfigFile::_internal_save(Ref<FileAccess> file) {
 			file->store_string("[" + E.key.replace("]", "\\]") + "]\n");
 
 			if (!E.value.is_empty()) {
-				file->store_string("\n"); 
+				file->store_string("\n");
 			}
-}
+		}
 
 		for (const KeyValue<String, Variant> &F : E.value) {
 			String vstr;

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -207,8 +207,12 @@ Error ConfigFile::_internal_save(Ref<FileAccess> file) {
 			file->store_string("\n");
 		}
 		if (!E.key.is_empty()) {
-			file->store_string("[" + E.key.replace("]", "\\]") + "]\n\n");
-		}
+			file->store_string("[" + E.key.replace("]", "\\]") + "]\n");
+
+			if (!E.value.is_empty()) {
+				file->store_string("\n"); 
+			}
+}
 
 		for (const KeyValue<String, Variant> &F : E.value) {
 			String vstr;


### PR DESCRIPTION
Fixes #105456

This PR addresses an issue in `ConfigFile::_internal_save()` where a trailing newline would be written after the `[params]` section in `.import` files, even when no parameters existed.

The change ensures that `.import` files with empty `[params]` blocks end cleanly, preventing unnecessary whitespace that interferes with pre-commit formatting hooks (e.g., in godot-demo-projects).

Tested locally using custom-built Godot binary and importing GLSL and Shader files with no parameters.
