### PR TITLE
Gave billboarded sprites and labels more fitting AABBs

### DIFF
--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -620,6 +620,24 @@ void Label3D::_shape() {
 		offset.y -= (TS->shaped_text_get_descent(lines_rid[i]) + line_spacing) * pixel_size;
 	}
 
+	switch (get_billboard_mode()) {
+		case StandardMaterial3D::BILLBOARD_ENABLED: {
+			real_t size_new = MAX(Math::abs(aabb.position.x), (aabb.position.x + aabb.size.x));
+			size_new = MAX(size_new, MAX(Math::abs(aabb.position.y), (aabb.position.y + aabb.size.y)));
+			aabb.position = Vector3(-size_new, -size_new, -size_new);
+			aabb.size = Vector3(size_new * 2.0, size_new * 2.0, size_new * 2.0);
+		} break;
+		case StandardMaterial3D::BILLBOARD_FIXED_Y: {
+			real_t size_new = MAX(Math::abs(aabb.position.x), (aabb.position.x + aabb.size.x));
+			aabb.position.x = -size_new;
+			aabb.position.z = -size_new;
+			aabb.size.x = size_new * 2.0;
+			aabb.size.z = size_new * 2.0;
+		} break;
+		default:
+			break;
+	}
+
 	for (const KeyValue<SurfaceKey, SurfaceData> &E : surfaces) {
 		Array mesh_array;
 		mesh_array.resize(RS::ARRAY_MAX);

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -243,6 +243,27 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 		memcpy(&attribute_write_buffer[i * attrib_stride + mesh_surface_offsets[RS::ARRAY_COLOR]], v_color, 4);
 	}
 
+	switch (get_billboard_mode()) {
+		case StandardMaterial3D::BILLBOARD_ENABLED: {
+			real_t size_new = MAX(Math::abs(final_rect.position.x) * px_size, (final_rect.position.x + final_rect.size.x) * px_size);
+			size_new = MAX(size_new, MAX(Math::abs(final_rect.position.y) * px_size, (final_rect.position.y + final_rect.size.y) * px_size));
+			aabb_new.position = Vector3(-size_new, -size_new, -size_new);
+			aabb_new.size = Vector3(size_new * 2.0, size_new * 2.0, size_new * 2.0);
+		} break;
+		case StandardMaterial3D::BILLBOARD_FIXED_Y: {
+			real_t size_new = MAX(Math::abs(final_rect.position.x) * px_size, (final_rect.position.x + final_rect.size.x) * px_size);
+			if (ax == Vector3::AXIS_Y) {
+				size_new = MAX(size_new, MAX(Math::abs(final_rect.position.y) * px_size, (final_rect.position.y + final_rect.size.y) * px_size));
+			}
+			aabb_new.position.x = -size_new;
+			aabb_new.position.z = -size_new;
+			aabb_new.size.x = size_new * 2.0;
+			aabb_new.size.z = size_new * 2.0;
+		} break;
+		default:
+			break;
+	}
+
 	RID mesh_new = get_mesh();
 	RS::get_singleton()->mesh_surface_update_vertex_region(mesh_new, 0, 0, vertex_buffer);
 	RS::get_singleton()->mesh_surface_update_attribute_region(mesh_new, 0, 0, attribute_buffer);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Implements https://github.com/godotengine/godot-proposals/issues/12313, giving billboarded sprites and labels appropriate AABBs so they will not be culled while still visible.