### PR TITLE
Fix `uiautomationcore` linking in 32-bit x86 MinGW builds.

### DIFF
--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -61,6 +61,7 @@ env.add_source_files(sources, common_win)
 sources += res_obj
 
 if env["accesskit"] and not env.msvc:
+    env["BUILDERS"]["DEF"].emitter = redirect_emitter
     def_file = "uiautomationcore." + env["arch"] + ".def"
     def_target = "libuiautomationcore." + env["arch"] + ".a"
     def_obj = env.DEF(def_target, def_file)

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -254,7 +254,9 @@ def build_def_file(target, source, env: "SConsEnvironment"):
     }
 
     cmdbase = "dlltool -m " + arch_aliases[env["arch"]]
-    if env["arch"] != "x86_32":
+    if env["arch"] == "x86_32":
+        cmdbase += " -k"
+    else:
         cmdbase += " --no-leading-underscore"
 
     mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
@@ -857,6 +859,7 @@ def configure_mingw(env: "SConsEnvironment"):
                     env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/windows/x86_64/mingw/static/"])
                 elif env["arch"] == "x86_32":
                     env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/windows/x86/mingw/static/"])
+            env.Append(LIBPATH=["#bin/obj/platform/windows"])
             env.Append(
                 LIBS=[
                     "accesskit",


### PR DESCRIPTION
- Fixes `uiautomationcore` incorrectly linked in 32-bit x86 MinGW builds.
- Adds `redirect_emitter` to the `uiautomationcore` import library build step.