### PR TITLE
Fix fbx runtime import not generating meshes properly

### DIFF
--- a/modules/fbx/SCsub
+++ b/modules/fbx/SCsub
@@ -40,6 +40,8 @@ module_obj = []
 env_fbx.add_source_files(module_obj, "*.cpp")
 env_fbx.add_source_files(module_obj, "structures/*.cpp")
 
+SConscript("extensions/SCsub")
+
 if env.editor_build:
     env_fbx.add_source_files(module_obj, "editor/*.cpp")
 

--- a/modules/fbx/extensions/SCsub
+++ b/modules/fbx/extensions/SCsub
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+Import("env_modules")
+
+env_gltf = env_modules.Clone()
+
+# Godot source files
+
+env_gltf.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/fbx/register_types.cpp
+++ b/modules/fbx/register_types.cpp
@@ -30,6 +30,7 @@
 
 #include "register_types.h"
 
+#include "../gltf/extensions/gltf_document_extension_convert_importer_mesh.h"
 #include "fbx_document.h"
 
 #ifdef TOOLS_ENABLED
@@ -53,10 +54,19 @@ static void _editor_init() {
 }
 #endif // TOOLS_ENABLED
 
+#define FBX_REGISTER_DOCUMENT_EXTENSION(m_doc_ext_class) \
+	Ref<m_doc_ext_class> extension_##m_doc_ext_class;    \
+	extension_##m_doc_ext_class.instantiate();           \
+	FBXDocument::register_gltf_document_extension(extension_##m_doc_ext_class);
+
 void initialize_fbx_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		GDREGISTER_CLASS(FBXDocument);
 		GDREGISTER_CLASS(FBXState);
+		bool is_editor = Engine::get_singleton()->is_editor_hint();
+		if (!is_editor) {
+			FBX_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionConvertImporterMesh);
+		}
 	}
 
 #ifdef TOOLS_ENABLED
@@ -77,6 +87,5 @@ void uninitialize_fbx_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
-	// TODO: 20240118 // fire
-	// FBXDocument::unregister_all_gltf_document_extensions();
+	FBXDocument::unregister_all_gltf_document_extensions();
 }


### PR DESCRIPTION
reviving https://github.com/godotengine/godot/pull/96059 to fix fbx runtime mesh importing. previously importing would only work properly for meshes while in the editor.

fixes https://github.com/godotengine/godot/issues/96029
fixes https://github.com/godotengine/godot/issues/96043

should also accommodate document extensions appropriately

lemme know if there is anything further i should do! ^-^

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
