### PR TITLE
Never show progress bar when moving files to trash on Windows to prevent losing focus

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2465,7 +2465,7 @@ Error OS_Windows::move_to_trash(const String &p_path) {
 	sf.wFunc = FO_DELETE;
 	sf.pFrom = from;
 	sf.pTo = nullptr;
-	sf.fFlags = FOF_ALLOWUNDO | FOF_NOCONFIRMATION;
+	sf.fFlags = FOF_ALLOWUNDO | FOF_NO_UI;
 	sf.fAnyOperationsAborted = FALSE;
 	sf.hNameMappings = nullptr;
 	sf.lpszProgressTitle = nullptr;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Closes https://github.com/godotengine/godot/issues/99552. This also affects the Godot editor itself when deleting files on Windows.

Hides all UI when sending files to the recycle bin on Windows. With the previous flags, we were still requesting a progress bar to be displayed. It typically wouldn't be visible because trashing even large files is often nearly instant (though I could see it when deleting a large directory with many files), but even when not visibly appearing the progress dialog would still momentarily steal focus from the main window.

See https://learn.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-shfileopstructw#fof_no_ui

Based on the implementations for other platforms, I'm assuming that showing a system progress bar is not needed or desired, so changing this in order to avoid the focus steal should be okay.
