### PR TITLE
Remove `alt` key transforms in 3D to prevent navigation key conflicts

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -1983,8 +1983,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					clicked = ObjectID();
 
 					bool node_selected = get_selected_count() > 0;
-
-					if (after != EditorPlugin::AFTER_GUI_INPUT_CUSTOM && !b->is_alt_pressed()) {
+					if (after != EditorPlugin::AFTER_GUI_INPUT_CUSTOM && (spatial_editor->get_tool_mode() != Node3DEditor::TOOL_MODE_SELECT || !b->is_command_or_control_pressed())) {
 						// Single item selection.
 						clicked = _select_ray(b->get_position());
 
@@ -2002,18 +2001,8 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						}
 					}
 
-					if (!clicked_wants_append && node_selected && ((spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT && b->is_command_or_control_pressed()) || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE)) {
+					if (!clicked_wants_append && node_selected && spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT && b->is_command_or_control_pressed()) {
 						begin_transform(TRANSFORM_ROTATE, false);
-						break;
-					}
-
-					if (!clicked_wants_append && node_selected && spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE) {
-						begin_transform(TRANSFORM_TRANSLATE, false);
-						break;
-					}
-
-					if (!clicked_wants_append && node_selected && spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE) {
-						begin_transform(TRANSFORM_SCALE, false);
 						break;
 					}
 
@@ -2169,10 +2158,22 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					return;
 				}
 
-				if (clicked.is_valid() && movement_threshold_passed && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE)) {
-					_compute_edit(_edit.original_mouse_pos);
-					clicked = ObjectID();
-					_edit.mode = TRANSFORM_TRANSLATE;
+				if (clicked.is_valid() && movement_threshold_passed) {
+					TransformMode mode = TRANSFORM_NONE;
+
+					if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE) {
+						mode = TRANSFORM_TRANSLATE;
+					} else if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE) {
+						mode = TRANSFORM_ROTATE;
+					} else if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE) {
+						mode = TRANSFORM_SCALE;
+					}
+
+					if (mode != TRANSFORM_NONE) {
+						_compute_edit(_edit.original_mouse_pos);
+						clicked = ObjectID();
+						_edit.mode = mode;
+					}
 				}
 
 				if (_edit.mode == TRANSFORM_NONE || _edit.numeric_input != 0 || _edit.numeric_next_decimal != 0) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

See: https://github.com/godotengine/godot/pull/87756#issuecomment-2831964966

Removes the ability to use the `alt` key to initiate transforms outside the geometry of selected nodes. 

Added code to handle similar functionality but only when initiating inside geometry of selected nodes.

The alt key is often used for navigating in 3D in different ways depending on the scheme. Godot offers a lot of flexibility in this regard, so there is high chance for conflict. Instead of trying to hard-code specific scenarios I think it makes sense to just remove this functionality entirely and recommended users to use blender-style shortcuts. This allows for a fully customizable solution. 

![image](https://github.com/user-attachments/assets/eafee8c2-2f76-42b6-8a43-dfd4a1acd2f3)



