### PR TITLE
Sync array folded states after movement

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -542,6 +542,12 @@ void EditorPropertyArray::_remove_pressed(int p_slot_index) {
 	Variant array = object->get_array().duplicate();
 	array.call("remove_at", slots[p_slot_index].index);
 
+	// Sync folded state after deletion.
+	for (int i = p_slot_index; i < (int)array.call("size"); i++) {
+		bool folded = object->editor_is_section_unfolded("indices/" + itos(i + 1));
+		object->editor_set_section_unfold("indices/" + itos(i), folded);
+	}
+
 	emit_changed(get_edited_property(), array);
 }
 
@@ -931,6 +937,24 @@ void EditorPropertyArray::_reorder_button_up() {
 	if (reorder_slot.index != reorder_to_index) {
 		// Move the element.
 		Variant array = object->get_array().duplicate();
+		int min_i = MIN(reorder_slot.index, reorder_to_index);
+		int max_i = MAX(reorder_slot.index, reorder_to_index);
+
+		// Sync folded state after move.
+		Vector<bool> folds;
+		for (int i = min_i; i <= max_i; i++) {
+			StringName p = "indices/" + itos(i);
+			bool folded = object->editor_is_section_unfolded(p);
+			folds.append(folded);
+		}
+		bool f = folds[reorder_slot.index - min_i];
+		folds.remove_at(reorder_slot.index - min_i);
+		folds.insert(reorder_to_index - min_i, f);
+
+		for (int i = 0; i < folds.size(); i++) {
+			bool folded = folds[i];
+			object->editor_set_section_unfold("indices/" + itos(i + min_i), folded);
+		}
 
 		property_vbox->move_child(reorder_slot.container, reorder_slot.index % page_length);
 		Variant value_to_move = array.get(reorder_slot.index);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes folded states not being updated when moving & deleting array items. Originally part of #103257, but makes more sense to be a separate PR

Before:

https://github.com/user-attachments/assets/94b805d5-7f97-47b9-b49d-7942199c649c 

After:

https://github.com/user-attachments/assets/31a41327-6504-47ee-a389-607d61281d10

*Bugsquad edit:* Fixes #96595 Supersedes #98364