### PR TITLE
[RTL] Add extra table inline alignment options.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -520,8 +520,10 @@
 			<param index="1" name="inline_align" type="int" enum="InlineAlignment" default="0" />
 			<param index="2" name="align_to_row" type="int" default="-1" />
 			<param index="3" name="name" type="String" default="&quot;&quot;" />
+			<param index="4" name="use_row_width" type="int" default="-1" />
+			<param index="5" name="row_align" type="int" enum="HorizontalAlignment" default="1" />
 			<description>
-				Adds a [code skip-lint][table=columns,inline_align][/code] tag to the tag stack. Use [method set_table_column_expand] to set column expansion ratio. Use [method push_cell] to add cells. [param name] is used as the table name for assistive apps.
+				Adds a [code skip-lint][table=columns,inline_align,align_to_row,use_row_width][/code] tag to the tag stack. Use [method set_table_column_expand] to set column expansion ratio. Use [method push_cell] to add cells. [param name] is used as the table name for assistive apps. If [param align_to_row] is set and baseline alignment is used, baseline of specified row is used to align table. If [param use_row_width] is set, table width is overridden by specified row width and table contents is aligned using [param row_align].
 			</description>
 		</method>
 		<method name="push_underline">

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -82,3 +82,10 @@ Validate extension JSON: Error: Field 'classes/TextServerExtension/methods/_shap
 Validate extension JSON: Error: Field 'classes/TextServerExtension/methods/_shaped_text_draw_outline/arguments': size changed value in new API, from 7 to 8.
 
 Optional "oversmpling" argument added. Compatibility methods registered.
+
+
+GH-105795
+=========
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_table/arguments': size changed value in new API, from 3 to 6.
+
+Optional arguments added. Compatibility method registered.

--- a/scene/gui/rich_text_label.compat.inc
+++ b/scene/gui/rich_text_label.compat.inc
@@ -59,11 +59,15 @@ void RichTextLabel::_add_image_bind_compat_76829(const Ref<Texture2D> &p_image, 
 }
 
 void RichTextLabel::_push_table_bind_compat_76829(int p_columns, InlineAlignment p_alignment, int p_align_to_row) {
-	push_table(p_columns, p_alignment, p_align_to_row, String());
+	push_table(p_columns, p_alignment, p_align_to_row, String(), -1);
 }
 
 bool RichTextLabel::_remove_paragraph_bind_compat_91098(int p_paragraph) {
 	return remove_paragraph(p_paragraph, false);
+}
+
+void RichTextLabel::_push_table_bind_compat_105795(int p_columns, InlineAlignment p_alignment, int p_align_to_row, const String &p_name) {
+	push_table(p_columns, p_alignment, p_align_to_row, p_name, -1);
 }
 
 void RichTextLabel::_bind_compatibility_methods() {
@@ -76,6 +80,7 @@ void RichTextLabel::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("add_image", "image", "width", "height", "color", "inline_align", "region", "key", "pad", "tooltip", "size_in_percent"), &RichTextLabel::_add_image_bind_compat_76829, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()), DEFVAL(Variant()), DEFVAL(false), DEFVAL(String()), DEFVAL(false));
 	ClassDB::bind_compatibility_method(D_METHOD("push_table", "columns", "inline_align", "align_to_row"), &RichTextLabel::_push_table_bind_compat_76829, DEFVAL(INLINE_ALIGNMENT_TOP), DEFVAL(-1));
 	ClassDB::bind_compatibility_method(D_METHOD("remove_paragraph", "paragraph"), &RichTextLabel::_remove_paragraph_bind_compat_91098);
+	ClassDB::bind_compatibility_method(D_METHOD("push_table", "columns", "inline_align", "align_to_row", "name"), &RichTextLabel::_push_table_bind_compat_105795, DEFVAL(INLINE_ALIGNMENT_TOP), DEFVAL(-1), DEFVAL(String()));
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -139,6 +139,7 @@ protected:
 	void _add_image_bind_compat_80410(const Ref<Texture2D> &p_image, const int p_width, const int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region);
 	void _add_image_bind_compat_76829(const Ref<Texture2D> &p_image, const int p_width, const int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region, const Variant &p_key, bool p_pad, const String &p_tooltip, bool p_size_in_percent);
 	void _push_table_bind_compat_76829(int p_columns, InlineAlignment p_alignment, int p_align_to_row);
+	void _push_table_bind_compat_105795(int p_columns, InlineAlignment p_alignment, int p_align_to_row, const String &p_name);
 	bool _remove_paragraph_bind_compat_91098(int p_paragraph);
 	void _set_table_column_expand_bind_compat_101482(int p_column, bool p_expand, int p_ratio);
 
@@ -389,14 +390,17 @@ private:
 
 		LocalVector<Column> columns;
 		LocalVector<float> rows;
+		LocalVector<float> rows_width;
 		LocalVector<float> rows_no_padding;
 		LocalVector<float> rows_baseline;
 		String name;
 
 		int align_to_row = -1;
+		int use_row_width = -1;
 		int total_width = 0;
 		int total_height = 0;
 		InlineAlignment inline_align = INLINE_ALIGNMENT_TOP;
+		HorizontalAlignment row_align = HORIZONTAL_ALIGNMENT_CENTER;
 		ItemTable() { type = ITEM_TABLE; }
 	};
 
@@ -781,7 +785,7 @@ public:
 	void push_list(int p_level, ListType p_list, bool p_capitalize, const String &p_bullet = String::utf8("•"));
 	void push_meta(const Variant &p_meta, MetaUnderline p_underline_mode = META_UNDERLINE_ALWAYS, const String &p_tooltip = String());
 	void push_hint(const String &p_string);
-	void push_table(int p_columns, InlineAlignment p_alignment = INLINE_ALIGNMENT_TOP, int p_align_to_row = -1, const String &p_name = String());
+	void push_table(int p_columns, InlineAlignment p_alignment = INLINE_ALIGNMENT_TOP, int p_align_to_row = -1, const String &p_name = String(), int p_use_row_width = -1, HorizontalAlignment p_row_align = HORIZONTAL_ALIGNMENT_CENTER);
 	void push_fade(int p_start_index, int p_length);
 	void push_shake(int p_strength, float p_rate, bool p_connected);
 	void push_wave(float p_frequency, float p_amplitude, bool p_connected);


### PR DESCRIPTION
Add option to only account for a specified row width when inlineing tables, for more control over underline/overline text.

<img width="1186" alt="Screenshot 2025-04-26 at 19 07 19" src="https://github.com/user-attachments/assets/1d4e2c5e-0506-4b9d-b728-4ec31bae5cf4" />

Related to https://github.com/godotengine/godot-proposals/issues/5876 (not a full implementation, since require manual work).