### PR TITLE
Fix `AnimationNodeBlendTree` crash on `Open Editor` button press.

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -1024,6 +1024,11 @@ void AnimationNodeBlendTreeEditor::_scroll_changed(const Vector2 &p_scroll) {
 	if (updating) {
 		return;
 	}
+
+	if (blend_tree.is_null()) {
+		return;
+	}
+
 	updating = true;
 	blend_tree->set_graph_offset(p_scroll / EDSCALE);
 	updating = false;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105784 (likely regression from https://github.com/godotengine/godot/pull/97763)