### PR TITLE
Fix install_vulkan_sdk_macos.sh incorrectly saying Vulkan was installed when jq is missing

### DIFF
--- a/misc/scripts/install_vulkan_sdk_macos.sh
+++ b/misc/scripts/install_vulkan_sdk_macos.sh
@@ -22,6 +22,9 @@ if command -v jq 2>&1 >/dev/null; then
 			fi
 		fi
 	done
+else
+	echo 'Error: Could not find 'jq' command. Is jq installed? Try running "brew install jq" or "port install jq" and rerunning this script.'
+	exit 0
 fi
 
 # Download and install the Vulkan SDK.


### PR DESCRIPTION
In its current state this script will silently fail if the jq command isn't available since new_ver_full never gets set.
In fact... it even prints that it successfully installed! This was confusing and I had to debug the script. 

My change adds a very explicit error message for the user so they can resolve their issue. We could make this a package manager agnostic message if that's preferred. 