### PR TITLE
[Web] Include emscripten headers by default

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from emscripten_helpers import (
@@ -111,6 +112,14 @@ def configure(env: "SConsEnvironment"):
     except Exception:
         print_error("Initial memory must be a valid integer")
         sys.exit(255)
+
+    # Add Emscripten to the included paths (for compile_commands.json completion)
+    emcc_path = Path(str(WhereIs("emcc")))
+    while emcc_path.is_symlink():
+        # For some reason, mypy trips on `Path.readlink` not being defined, somehow.
+        emcc_path = emcc_path.readlink()  # type: ignore[attr-defined]
+    emscripten_include_path = emcc_path.parent.joinpath("cache", "sysroot", "include")
+    env.Append(CPPPATH=[emscripten_include_path])
 
     ## Build type
 


### PR DESCRIPTION
Currently, developing using Emscripten for the Web platform is kinda a pain. As Emscripten uses by default it's own patched and new headers, the IDEs usually don't know what to do with Emscripten code because including manually those headers is not required.

<img width="792" alt="Capture d’écran, le 2025-04-26 à 13 59 12" src="https://github.com/user-attachments/assets/051ad4f1-67ad-4e4c-8afc-6f2c2e11240b" />

_This code compiles with Emscripten even if clangd complains._

~~So this PR adds a new option: `emscripten_include_path`. When added, this path will be included as an include path in the compilation.~~

_Edit:_ This PR now detects and adds the include path automatically, based on the detected binary.

<img width="696" alt="Capture d’écran, le 2025-04-26 à 14 09 15" src="https://github.com/user-attachments/assets/e5adaa7c-fa11-4437-8b0f-f9bfdf2da63e" />

_See how great it looks?_

> [!NOTE]
> **If you're using [emsdk](https://github.com/emscripten-core/emsdk):** 
> ~~`scons platform=web emscripten_include_path=<emsdk path>/upstream/emscripten/cache/sysroot/include`~~ (not needed anymore)
> 
> **If you're using directly [emscripten](https://github.com/emscripten-core/emscripten):**
> ~~`scons platform=web emscripten_include_path=<emscripten path>/cache/sysroot/include`~~ (not needed anymore)
