### PR TITLE
[macOS] Fix touch bar observer crash.

### DIFF
--- a/platform/macos/godot_content_view.h
+++ b/platform/macos/godot_content_view.h
@@ -66,6 +66,7 @@ GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations") // OpenGL is de
 	bool last_pen_inverted;
 	bool ime_suppress_next_keyup;
 	id layer_delegate;
+	NSMutableSet<NSString *> *registered_observers;
 }
 
 - (void)processScrollEvent:(NSEvent *)event button:(MouseButton)button factor:(double)factor;

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -109,6 +109,22 @@
 	self.layer.needsDisplayOnBoundsChange = YES;
 }
 
+- (void)addObserver:(NSObject *)targetObserver forKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options context:(void *)context {
+	[registered_observers addObject:[[targetObserver description] stringByAppendingString:keyPath]];
+	[super addObserver:targetObserver forKeyPath:keyPath options:options context:context];
+}
+
+- (void)removeObserver:(NSObject *)targetObserver forKeyPath:(NSString *)keyPath {
+	if ([registered_observers containsObject:[[targetObserver description] stringByAppendingString:keyPath]]) {
+		@try {
+			[super removeObserver:targetObserver forKeyPath:keyPath];
+			[registered_observers removeObject:[[targetObserver description] stringByAppendingString:keyPath]];
+		} @catch (NSException *exception) {
+			ERR_PRINT("NSException: " + String::utf8([exception reason].UTF8String));
+		}
+	}
+}
+
 - (id)init {
 	self = [super init];
 	layer_delegate = [[GodotContentLayerDelegate alloc] init];
@@ -118,6 +134,7 @@
 	mouse_down_control = false;
 	ignore_momentum_scroll = false;
 	last_pen_inverted = false;
+	registered_observers = [[NSMutableSet alloc] init];
 	[self updateTrackingAreas];
 
 	self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawDuringViewResize;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105796

Seems to be some strange interaction of touch bar service and AccessKit (probably `NSView` subclassing in general, I have found similar crash logs for Unity, Excel, and a bunch of Electron based apps with Firebase Analytics), it is trying to unregister observer for both `AccessKit` subclass and base `GodotContextView`.

Tested only with [a simulator](https://github.com/jslegendre/TouchBar-Simulator) (test branch with minimal touch bar support added to Godot to ensure it's not interfering with touch bar operation - https://github.com/bruvzg/godot/commit/6d33cb4c67679fcfe7f3978c219036d838745298), I do not have Mac with touch bar.