### PR TITLE
Walk up inheritance hierarchy when finding which script's docs to open

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1229,8 +1229,12 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			for (const Node *node : selection) {
 				String class_name;
 				Ref<Script> script_base = node->get_script();
-				if (script_base.is_valid()) {
+				while (script_base.is_valid()) {
 					class_name = script_base->get_global_name();
+					if (!class_name.is_empty()) {
+						break;
+					}
+					script_base = script_base->get_base_script();
 				}
 				if (class_name.is_empty()) {
 					class_name = node->get_class();


### PR DESCRIPTION
When opening a Node's documentation, the Scene Tree dock currently checks the node's script to see if it is a global class (eg. via `class_name`).
This allows convenient access to custom node types' documentation.

However, the current implementation does not account for inheritance—

If opening docs for a non-global script that inherits a custom global class, the dock will still default to using the Node's native class instead of the custom class.

This PR makes the method walk up the script's inheritance hierarchy to find the most specific global class, including custom types if present.