### PR TITLE
Fix Signals dock only un-doubling parent class's first signal

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -1491,10 +1491,12 @@ void ConnectionsDock::update_tree() {
 				for (const MethodInfo &signal : base_signals) {
 					base_signal_names.insert(signal.name);
 				}
-				for (List<MethodInfo>::Element *F = class_signals.front(); F; F = F->next()) {
+				for (List<MethodInfo>::Element *F = class_signals.front(); F;) {
+					List<MethodInfo>::Element *N = F->next();
 					if (base_signal_names.has(F->get().name)) {
 						class_signals.erase(F);
 					}
+					F = N;
 				}
 			}
 


### PR DESCRIPTION
When updating the list of a class's signals in the Connections dock, parent classes' signals are removed so that they only appear in the class where they are introduced.

However, the current implementation faultily breaks out of the loop the first time it finds a duplicate item, as `class_signals.erase(F)` causes `F->next()` to return a `nullptr`, which is interpreted as the end of the list.

This PR fixes the loop so it will always iterate over all elements.

For reference, here is an example of the issue (`signal2` and `signal3` should not appear under `class2`):
![Screenshot 2025-04-26 at 21 57 21](https://github.com/user-attachments/assets/1806d1e8-0a2e-4abc-ac99-6bb38a28d6d9)
