### PR TITLE
Fix item translation and icon in the Anchors Preset dropdown

### DIFF
--- a/editor/plugins/control_editor_plugin.h
+++ b/editor/plugins/control_editor_plugin.h
@@ -33,20 +33,17 @@
 #include "editor/editor_inspector.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/box_container.h"
-#include "scene/gui/button.h"
-#include "scene/gui/check_box.h"
-#include "scene/gui/control.h"
-#include "scene/gui/label.h"
 #include "scene/gui/margin_container.h"
-#include "scene/gui/option_button.h"
-#include "scene/gui/panel_container.h"
-#include "scene/gui/popup.h"
-#include "scene/gui/separator.h"
-#include "scene/gui/texture_rect.h"
 
+class CheckBox;
 class CheckButton;
 class EditorSelection;
 class GridContainer;
+class Label;
+class OptionButton;
+class PanelContainer;
+class Separator;
+class TextureRect;
 
 // Inspector controls.
 class ControlPositioningWarning : public MarginContainer {
@@ -84,6 +81,7 @@ class EditorPropertyAnchorsPreset : public EditorProperty {
 
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
+	void _notification(int p_what);
 
 public:
 	void setup(const Vector<String> &p_options);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -33,11 +33,9 @@
 #include "container.h"
 #include "core/config/project_settings.h"
 #include "core/input/input_map.h"
-#include "core/math/geometry_2d.h"
 #include "core/os/os.h"
+#include "core/string/string_builder.h"
 #include "core/string/translation_server.h"
-#include "scene/gui/label.h"
-#include "scene/gui/panel.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/main/canvas_layer.h"
 #include "scene/main/window.h"
@@ -3992,10 +3990,37 @@ void Control::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layout_mode", PROPERTY_HINT_ENUM, "Position,Anchors,Container,Uncontrolled", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "_set_layout_mode", "_get_layout_mode");
 	ADD_PROPERTY_DEFAULT("layout_mode", LayoutMode::LAYOUT_MODE_POSITION);
 
-	const String anchors_presets_options = "Custom:-1,PresetFullRect:15,"
-										   "PresetTopLeft:0,PresetTopRight:1,PresetBottomRight:3,PresetBottomLeft:2,"
-										   "PresetCenterLeft:4,PresetCenterTop:5,PresetCenterRight:6,PresetCenterBottom:7,PresetCenter:8,"
-										   "PresetLeftWide:9,PresetTopWide:10,PresetRightWide:11,PresetBottomWide:12,PresetVCenterWide:13,PresetHCenterWide:14";
+	constexpr struct {
+		const char *name;
+		LayoutPreset value;
+	} anchors_presets[] = {
+		{ TTRC("Full Rect"), PRESET_FULL_RECT },
+		{ TTRC("Top Left"), PRESET_TOP_LEFT },
+		{ TTRC("Top Right"), PRESET_TOP_RIGHT },
+		{ TTRC("Bottom Right"), PRESET_BOTTOM_RIGHT },
+		{ TTRC("Bottom Left"), PRESET_BOTTOM_LEFT },
+		{ TTRC("Center Left"), PRESET_CENTER_LEFT },
+		{ TTRC("Center Top"), PRESET_CENTER_TOP },
+		{ TTRC("Center Right"), PRESET_CENTER_RIGHT },
+		{ TTRC("Center Bottom"), PRESET_CENTER_BOTTOM },
+		{ TTRC("Center"), PRESET_CENTER },
+		{ TTRC("Left Wide"), PRESET_LEFT_WIDE },
+		{ TTRC("Top Wide"), PRESET_TOP_WIDE },
+		{ TTRC("Right Wide"), PRESET_RIGHT_WIDE },
+		{ TTRC("Bottom Wide"), PRESET_BOTTOM_WIDE },
+		{ TTRC("VCenter Wide"), PRESET_VCENTER_WIDE },
+		{ TTRC("HCenter Wide"), PRESET_HCENTER_WIDE },
+	};
+	StringBuilder builder;
+	builder.append(TTRC("Custom"));
+	builder.append(":-1");
+	for (size_t i = 0; i < std::size(anchors_presets); i++) {
+		builder.append(",");
+		builder.append(anchors_presets[i].name);
+		builder.append(":");
+		builder.append(itos(anchors_presets[i].value));
+	}
+	const String anchors_presets_options = builder.as_string();
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "anchors_preset", PROPERTY_HINT_ENUM, anchors_presets_options, PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "_set_anchors_layout_preset", "_get_anchors_layout_preset");
 	ADD_PROPERTY_DEFAULT("anchors_preset", -1);


### PR DESCRIPTION
## Problem

I noticed that the last two items in `anchors_preset` property's dropdown menu were not translated. Also, all the icons in this menu does not react to light/dark theme switch.

![The last two presets were not translated](https://github.com/user-attachments/assets/40f44d92-c26d-4bb9-a801-a6c287da9142)

## Cause

The preset names are actually not extracted from the `anchors_preset` property's hint string, but from texts in the control layout toolbar.

https://github.com/godotengine/godot/blob/e37c6261ea48b1a339c469282df7e9b7c073a72f/editor/plugins/control_editor_plugin.cpp#L651-L655

https://github.com/godotengine/godot/blob/e37c6261ea48b1a339c469282df7e9b7c073a72f/scene/gui/control.cpp#L3990-L3993

It's `VCenter Wide` in the toolbar, while it's `V Center Wide` after prefix-trimming and calling `capitalize()` on `PresetVCenterWide`. So this entry does not have translation available.

The reason for generating names by using string magic seems to be to make it easier to concatenate the icon name (e.g. `ControlAlignVCenterWide`). I believe it's kind of over-engineering :P

https://github.com/godotengine/godot/blob/e37c6261ea48b1a339c469282df7e9b7c073a72f/editor/plugins/control_editor_plugin.cpp#L194-L199

## Solution

This PR updates the menu item's icon based on its enum value when editor's theme changes.

Once this is done, the string magic around hint string is no longer necessary. The preset names can be marked for translation normally.

p.s. Also cleaned up header includes in the files I touched.

_Update:_ Marked StringNames in the static array as static so that the leak checker will be happy :P