### PR TITLE
Fix `GDExtensionLoader` using the wrong super type in `GDSOFTCLASS`.

### DIFF
--- a/core/extension/gdextension_loader.h
+++ b/core/extension/gdextension_loader.h
@@ -35,7 +35,7 @@
 class GDExtension;
 
 class GDExtensionLoader : public RefCounted {
-	GDSOFTCLASS(GDExtensionLoader, GDExtensionLoader);
+	GDSOFTCLASS(GDExtensionLoader, RefCounted);
 
 public:
 	virtual Error open_library(const String &p_path) = 0;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/commit/fa0a3c9c6ef04c60e7edca739e6ae4ff9569a28b#r155932677 (thanks @BenLubar!).
Regression from https://github.com/godotengine/godot/pull/104844 (4.5).

The superclass of `GDExtensionLoader` is currently incorrectly set in `GDSOFTCLASS`, leading to an infinite recursion on inheritance check.