### PR TITLE
Mark referenced packages in SDK as implicitly defined

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
@@ -25,13 +25,13 @@
 
   <!-- C# source generators -->
   <ItemGroup Condition=" '$(DisableImplicitGodotGeneratorReferences)' != 'true' ">
-    <PackageReference Include="Godot.SourceGenerators" Version="$(PackageVersion_Godot_SourceGenerators)" />
+    <PackageReference Include="Godot.SourceGenerators" IsImplicitlyDefined="true" Version="$(PackageVersion_Godot_SourceGenerators)" />
   </ItemGroup>
 
   <!-- Godot API references -->
   <ItemGroup Condition=" '$(DisableImplicitGodotSharpReferences)' != 'true' ">
-    <PackageReference Include="GodotSharp" Version="$(PackageVersion_GodotSharp)" />
-    <PackageReference Include="GodotSharpEditor" Version="$(PackageVersion_GodotSharp)" Condition=" '$(Configuration)' == 'Debug' " />
+    <PackageReference Include="GodotSharp" IsImplicitlyDefined="true" Version="$(PackageVersion_GodotSharp)" />
+    <PackageReference Include="GodotSharpEditor" IsImplicitlyDefined="true" Version="$(PackageVersion_GodotSharp)" Condition=" '$(Configuration)' == 'Debug' " />
   </ItemGroup>
 
   <!-- iOS-specific build targets -->


### PR DESCRIPTION
Add `IsImplicitlyDefined="true"` to `PackageReference` tags in Sdk.targets.

Will fix two problems i had with C# scripting.

## 1. Prevent Package Manager in Visual Studio from trying to update SDK packages

When viewing installed packages in IDE, Package Manager suggests updating `Godot.SourceGenerators`, `GodotSharp` and `GodotSharpEditor` to the latest version. Looks like this action doesn't do anything, but it can mislead user into thinking they upgraded their environment to the latest version.

Adding `IsImplicitlyDefined` should prevent IDE from changing versions of these packages.

<details>

<summary>Screenshots</summary>

Before:

![vs-packagemanager-bugged](https://github.com/user-attachments/assets/8fb2823a-b6d2-4739-ac1f-bcaf05f6f123)

After:

![vs-packagemanager-fixed](https://github.com/user-attachments/assets/221e1a31-6985-401c-b516-eb20bdce05a0)

</details> 

## 2. Restore in Godot project fails when Central Package Management enabled

When using CPM with Godot, restore fails with error:

```
/path/cpm-test/CPM Test.csproj : error NU1008: Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: Godot.SourceGenerators;GodotSharp;GodotSharpEditor.
```

[Example repository](https://github.com/hexog/godot-cpm-error)

With `IsImplicitlyDefined="true"`, NuGet will not try to manage the SDK packages, resolving this error.

---

This change is backwards compatible and should not break anything in existing projects. However, since `IsImplicitlyDefined` is not properly documented, I’d appreciate it if someone more knowledgeable in MSBuild could ensure that nothing will break unexpectedly.

What i found about `IsImplicitlyDefined`:

https://github.com/NuGet/Home/issues/13529
https://github.com/dotnet/sdk/pull/43151/files#r1746148520

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
