### PR TITLE
AspectRatioContainer: Use `Vector2` for aspect ratio

### DIFF
--- a/doc/classes/AspectRatioContainer.xml
+++ b/doc/classes/AspectRatioContainer.xml
@@ -16,7 +16,10 @@
 		<member name="alignment_vertical" type="int" setter="set_alignment_vertical" getter="get_alignment_vertical" enum="AspectRatioContainer.AlignmentMode" default="1">
 			Specifies the vertical relative position of child controls.
 		</member>
-		<member name="ratio" type="float" setter="set_ratio" getter="get_ratio" default="1.0">
+		<member name="aspect" type="Vector2" setter="set_aspect" getter="get_aspect" default="Vector2(1, 1)">
+			The aspect ratio to enforce on child controls. The ratio depends on the [member stretch_mode].
+		</member>
+		<member name="ratio" type="float" setter="set_ratio" getter="get_ratio" deprecated="Use [member aspect] instead.">
 			The aspect ratio to enforce on child controls. This is the width divided by the height. The ratio depends on the [member stretch_mode].
 		</member>
 		<member name="stretch_mode" type="int" setter="set_stretch_mode" getter="get_stretch_mode" enum="AspectRatioContainer.StretchMode" default="2">

--- a/scene/gui/aspect_ratio_container.h
+++ b/scene/gui/aspect_ratio_container.h
@@ -54,14 +54,19 @@ public:
 	};
 
 private:
-	float ratio = 1.0;
+	Vector2 aspect = Vector2(1, 1);
 	StretchMode stretch_mode = STRETCH_FIT;
 	AlignmentMode alignment_horizontal = ALIGNMENT_CENTER;
 	AlignmentMode alignment_vertical = ALIGNMENT_CENTER;
 
 public:
+	void set_aspect(const Vector2 &p_aspect);
+	Vector2 get_aspect() const { return aspect; }
+
+#ifndef DISABLE_DEPRECATED
 	void set_ratio(float p_ratio);
-	float get_ratio() const { return ratio; }
+	float get_ratio() const;
+#endif // DISABLE_DEPRECATED
 
 	void set_stretch_mode(StretchMode p_mode);
 	StretchMode get_stretch_mode() const { return stretch_mode; }


### PR DESCRIPTION
`AspectRatioContainer` uses `float` for the aspect ratio. This makes it easy to introduce errors when using non-integral ratio.

For example, the value would be `1.7778` for 16:9 aspect ratio. A 640x480 container would make its children `640x359.995` at position `(0,60.002)`.

This PR makes `AspectRatioContainer` use `Vector2` for the aspect ratio, i.e., the user specifies `(16,9)` instead of `1.7778`, minimizing errors.

- A new `aspect` property is introduced.
- The old `ratio` property is marked as deprecated, hidden from the inspector, and acts as a proxy for `aspect`.