### PR TITLE
Fix `RefCounted` appearing in editor inspector when multiple nodes selected

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -4014,7 +4014,7 @@ void EditorInspector::update_tree() {
 			List<PropertyInfo>::Element *N = E_property->next();
 			bool valid = true;
 			while (N) {
-				if (!N->get().name.begins_with("metadata/_") && N->get().usage & PROPERTY_USAGE_EDITOR &&
+				if (!N->get().name.begins_with("metadata/_") && !(N->get().name == "script") && N->get().usage & PROPERTY_USAGE_EDITOR &&
 						(!filter.is_empty() || !restrict_to_basic || (N->get().usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING))) {
 					break;
 				}
@@ -4026,7 +4026,7 @@ void EditorInspector::update_tree() {
 				}
 				N = N->next();
 			}
-			if (!valid) {
+			if (!valid || !N) {
 				continue; // Empty, ignore it.
 			}
 


### PR DESCRIPTION
Fixes #105566
Fixes #33302

As described in the issues, an empty `RefCounted` category is added to the property list when multiple nodes are selected due to `MultiNodeEdit` inheriting from it.

~~This PR adds a check to remove the category when this is the case.~~

This PR fixes some incorrect behavior in how sections are validated as non-empty, allowing this category to be hidden as expected.