### PR TITLE
[macOS] Update entered state from `mouseMoved`.

### DIFF
--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -515,6 +515,11 @@
 	mm->set_relative_screen_position(relativeMotion);
 	ds->get_key_modifier_state([event modifierFlags], mm);
 
+	const NSRect contentRect = [wd.window_view frame];
+	if (NSPointInRect([event locationInWindow], contentRect)) {
+		ds->mouse_enter_window(window_id);
+	}
+
 	Input::get_singleton()->parse_input_event(mm);
 }
 


### PR DESCRIPTION
It seems like there are still condition when mouse enter event is not received (similar to https://github.com/godotengine/godot/issues/104324, hard to reproduce, so I'm not entirely sure what causing it).