### PR TITLE
Fix `Camera2D` right and bottom limit to depend on bottom right corner

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -272,16 +272,17 @@ Transform2D Camera2D::get_camera_transform() {
 	Rect2 screen_rect(-screen_offset + ret_camera_pos, screen_size * zoom_scale);
 
 	if (limit_enabled && (!position_smoothing_enabled || !limit_smoothing_enabled)) {
+		Point2 bottom_right_corner = Point2(screen_rect.position + 2.0 * (camera_pos - screen_rect.position));
 		if (screen_rect.position.x < limit[SIDE_LEFT]) {
 			screen_rect.position.x = limit[SIDE_LEFT];
 		}
 
-		if (screen_rect.position.x + screen_rect.size.x > limit[SIDE_RIGHT]) {
-			screen_rect.position.x = limit[SIDE_RIGHT] - screen_rect.size.x;
+		if (bottom_right_corner.x > limit[SIDE_RIGHT]) {
+			screen_rect.position.x = limit[SIDE_RIGHT] - (bottom_right_corner.x - screen_rect.position.x);
 		}
 
-		if (screen_rect.position.y + screen_rect.size.y > limit[SIDE_BOTTOM]) {
-			screen_rect.position.y = limit[SIDE_BOTTOM] - screen_rect.size.y;
+		if (bottom_right_corner.y > limit[SIDE_BOTTOM]) {
+			screen_rect.position.y = limit[SIDE_BOTTOM] - (bottom_right_corner.y - screen_rect.position.y);
 		}
 
 		if (screen_rect.position.y < limit[SIDE_TOP]) {


### PR DESCRIPTION
Fixed #105775 

Before : "Right" and "Bottom" limits for Camera2D clamped camera's position based on top-left corner of screen rect plus a certain constant. This meant that when the camera was rotated, the limits weren't computed properly since the offset was constant, which meant the limits used to behave weird.

Now : for "Right" and "Bottom" limits, clamp the position of camera based on the bottom-right corner of the camera, just as it is with "Top" and "Left" limits with the top-left corner. Now, even when the camera is rotated the limits behave properly.