### PR TITLE
Fix font resolution issue when setting content_scale_factor during size_changed signal

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1253,7 +1253,7 @@ void Window::_update_viewport_size() {
 	}
 
 	bool allocate = is_inside_tree() && visible && (window_id != DisplayServer::INVALID_WINDOW_ID || embedder != nullptr);
-	bool ci_updated = _set_size(final_size, final_size_override, allocate);
+	_set_size(final_size, final_size_override, allocate);
 
 	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
 		RenderingServer::get_singleton()->viewport_attach_to_screen(get_viewport_rid(), attach_to_screen_rect, window_id);
@@ -1267,10 +1267,8 @@ void Window::_update_viewport_size() {
 		}
 		if (!Math::is_equal_approx(TS->font_get_global_oversampling(), font_oversampling)) {
 			TS->font_set_global_oversampling(font_oversampling);
-			if (!ci_updated) {
-				update_canvas_items();
-				emit_signal(SNAME("size_changed"));
-			}
+			update_canvas_items();
+			emit_signal(SNAME("size_changed"));
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/103703

This PR fixes a bug where fonts would render at an incorrect resolution when content_scale_factor is modified inside a size_changed signal handler.
The issue was caused by ci_updated not having the correct value in some cases, in window.cpp's _update_viewport_size() function, preventing canvas items from properly updating.
The fix ensures that oversampling verification alone is sufficient to correctly update ci_updated, allowing fonts and other canvas items to render at the appropriate scale.
