### PR TITLE
[Codestyle] Use `BitField` instead of multiple bool arguments in `EditorNode::load_scene()`

### DIFF
--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -647,7 +647,7 @@ void EditorInterface::open_scene_from_path(const String &scene_path, bool p_set_
 	if (EditorNode::get_singleton()->is_changing_scene()) {
 		return;
 	}
-	EditorNode::get_singleton()->load_scene(scene_path, false, p_set_inherited);
+	EditorNode::get_singleton()->load_scene(scene_path, p_set_inherited ? EditorNode::FLAG_SET_INHERITED : 0);
 }
 
 void EditorInterface::reload_scene_from_path(const String &scene_path) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -217,6 +217,13 @@ public:
 		SETTINGS_PICK_MAIN_SCENE,
 	};
 
+	enum LoadSceneFlags {
+		FLAG_IGNORE_BROKEN_DEPS = 1 << 0,
+		FLAG_SET_INHERITED = 1 << 1,
+		FLAG_FORCE_OPEN_IMPORTED = 1 << 2,
+		FLAG_SILENT_CHANGE_TAB = 1 << 3,
+	};
+
 	struct ExecuteThreadArgs {
 		String path;
 		List<String> args;
@@ -804,7 +811,7 @@ public:
 
 	void fix_dependencies(const String &p_for_file);
 	int new_scene();
-	Error load_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_force_open_imported = false, bool p_silent_change_tab = false);
+	Error load_scene(const String &p_scene, BitField<LoadSceneFlags> p_flags = 0);
 	Error load_resource(const String &p_resource, bool p_ignore_broken_deps = false);
 	Error load_scene_or_resource(const String &p_file, bool p_ignore_broken_deps = false, bool p_change_scene_tab_if_already_open = true);
 
@@ -978,6 +985,8 @@ public:
 	bool ensure_main_scene(bool p_from_native);
 	bool validate_custom_directory();
 };
+
+VARIANT_BITFIELD_CAST(EditorNode::LoadSceneFlags);
 
 class EditorPluginList : public Object {
 private:

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -6128,7 +6128,7 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 		Ref<PackedScene> scene = res;
 		if (scene.is_valid()) {
 			// Without root node act the same as "Load Inherited Scene".
-			Error err = EditorNode::get_singleton()->load_scene(path, false, true);
+			Error err = EditorNode::get_singleton()->load_scene(path, EditorNode::FLAG_SET_INHERITED);
 			if (err != OK) {
 				accept->set_text(vformat(TTR("Error instantiating scene from %s."), path.get_file()));
 				accept->popup_centered();

--- a/editor/plugins/packed_scene_editor_plugin.cpp
+++ b/editor/plugins/packed_scene_editor_plugin.cpp
@@ -36,7 +36,7 @@
 
 void PackedSceneEditor::_on_open_scene_pressed() {
 	// Using deferred call because changing scene updates the Inspector and thus destroys this plugin.
-	callable_mp(EditorNode::get_singleton(), &EditorNode::load_scene).call_deferred(packed_scene->get_path(), false, false, false, false);
+	callable_mp(EditorNode::get_singleton(), &EditorNode::load_scene).call_deferred(packed_scene->get_path(), 0);
 }
 
 void PackedSceneEditor::_notification(int p_what) {


### PR DESCRIPTION
When debugging a crash, I came across calls like these:

https://github.com/godotengine/godot/blob/e37c6261ea48b1a339c469282df7e9b7c073a72f/editor/editor_node.cpp#L1351
https://github.com/godotengine/godot/blob/e37c6261ea48b1a339c469282df7e9b7c073a72f/editor/editor_node.cpp#L6262

These booleans are very difficult to understand.

This PR changes these bool arguments into one bit field argument. So, for example, the calls above become:

https://github.com/godotengine/godot/blob/ff2e42c6db369fb571abb7dbba41f21944870419/editor/editor_node.cpp#L1351
https://github.com/godotengine/godot/blob/ff2e42c6db369fb571abb7dbba41f21944870419/editor/editor_node.cpp#L6262

Since this class is internal, the change does not break compatibility.