### PR TITLE
Change canvas_item transform and rect update logic of Control node

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -712,6 +712,10 @@ Transform2D Control::get_transform() const {
 	return xform;
 }
 
+void Control::update_canvas_item_rect() {
+	RenderingServer::get_singleton()->canvas_item_set_custom_rect(get_canvas_item(), !data.disable_visibility_clip, Rect2(Point2(), get_size()));
+}
+
 void Control::_top_level_changed_on_parent() {
 	// Update root control status.
 	_notification(NOTIFICATION_EXIT_CANVAS);
@@ -1755,9 +1759,11 @@ void Control::_size_changed() {
 
 	if (pos_changed) {
 		data.pos_cache = new_pos_cache;
+		_update_canvas_item_transform();
 	}
 	if (size_changed) {
 		data.size_cache = new_size_cache;
+		update_canvas_item_rect();
 	}
 
 	if (is_inside_tree()) {
@@ -1770,10 +1776,6 @@ void Control::_size_changed() {
 			if (approx_size_changed) {
 				notification(NOTIFICATION_RESIZED);
 			}
-		}
-
-		if (pos_changed && !approx_size_changed) {
-			_update_canvas_item_transform();
 		}
 
 		queue_accessibility_update();
@@ -2742,6 +2744,7 @@ void Control::set_disable_visibility_clip(bool p_ignore) {
 		return;
 	}
 	data.disable_visibility_clip = p_ignore;
+	update_canvas_item_rect();
 	queue_redraw();
 }
 
@@ -3732,8 +3735,6 @@ void Control::_notification(int p_notification) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			_update_canvas_item_transform();
-			RenderingServer::get_singleton()->canvas_item_set_custom_rect(get_canvas_item(), !data.disable_visibility_clip, Rect2(Point2(), get_size()));
 			RenderingServer::get_singleton()->canvas_item_set_clip(get_canvas_item(), data.clip_contents);
 		} break;
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -300,6 +300,8 @@ private:
 	void _update_canvas_item_transform();
 	Transform2D _get_internal_transform() const;
 
+	void update_canvas_item_rect();
+
 	void _set_anchor(Side p_side, real_t p_anchor);
 	void _set_position(const Point2 &p_point);
 	void _set_global_position(const Point2 &p_point);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Previously, the Control node would call the RenderingServer API at the end of the _size_changed to update the transform of the Control's canvas_item if the position changed and the size not changed. I don't quite understand what this conditional branch does. In some cases, the position and size are changed at the same time (e.g. via Control::set_rect) and the transform should also need to be updated.
I've also noticed that the transform is also updated when the Control receives a draw notification. I'm guessing that if the transform isn't updated in the _size_changed because of the same-time changing of position and size, it will be updated here.

I don't quite understand the intent of doing this, guessing that it's some kind of legacy. I tried changing the logic for these sections, removing the size not changed condition and the update transform call in the draw notification, and dont found obvious issues. I'm not sure if this will have any hidden side effects