### PR TITLE
[Web] Optimize `GL.getSource` for known-length shader sources

### DIFF
--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -321,7 +321,8 @@ void ShaderGLES3::_compile_specialization(Version::Specialization &spec, uint32_
 		String builder_string = builder.as_string();
 		CharString cs = builder_string.utf8();
 		const char *cstr = cs.ptr();
-		glShaderSource(spec.vert_id, 1, &cstr, nullptr);
+		GLint cstr_len = cs.length();
+		glShaderSource(spec.vert_id, 1, &cstr, &cstr_len);
 		glCompileShader(spec.vert_id);
 
 		glGetShaderiv(spec.vert_id, GL_COMPILE_STATUS, &status);
@@ -369,7 +370,8 @@ void ShaderGLES3::_compile_specialization(Version::Specialization &spec, uint32_
 		String builder_string = builder.as_string();
 		CharString cs = builder_string.utf8();
 		const char *cstr = cs.ptr();
-		glShaderSource(spec.frag_id, 1, &cstr, nullptr);
+		GLint cstr_len = cs.length();
+		glShaderSource(spec.frag_id, 1, &cstr, &cstr_len);
 		glCompileShader(spec.frag_id);
 
 		glGetShaderiv(spec.frag_id, GL_COMPILE_STATUS, &status);

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -54,6 +54,12 @@ sys_env.AddJSExterns(
     ]
 )
 
+sys_env.AddJSPost(
+    [
+        "js/patches/patch_em_gl.js",
+    ]
+)
+
 if env["javascript_eval"]:
     sys_env.AddJSLibraries(["js/libs/library_godot_javascript_singleton.js"])
 
@@ -61,6 +67,8 @@ for lib in sys_env["JS_LIBS"]:
     sys_env.Append(LINKFLAGS=["--js-library", lib.abspath])
 for js in sys_env["JS_PRE"]:
     sys_env.Append(LINKFLAGS=["--pre-js", js.abspath])
+for js in sys_env["JS_POST"]:
+    sys_env.Append(LINKFLAGS=["--post-js", js.abspath])
 
 # Add JS externs to Closure.
 sys_env["ENV"]["EMCC_CLOSURE_ARGS"] = sys_env["ENV"].get("EMCC_CLOSURE_ARGS", "")
@@ -98,6 +106,7 @@ else:
 
 sys_env.Depends(build[0], sys_env["JS_LIBS"])
 sys_env.Depends(build[0], sys_env["JS_PRE"])
+sys_env.Depends(build[0], sys_env["JS_POST"])
 sys_env.Depends(build[0], sys_env["JS_EXTERNS"])
 
 engine = [

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from emscripten_helpers import (
     add_js_externs,
     add_js_libraries,
+    add_js_post,
     add_js_pre,
     create_engine_file,
     create_template_zip,
@@ -168,12 +169,14 @@ def configure(env: "SConsEnvironment"):
         jscc = env.Builder(generator=run_closure_compiler, suffix=".cc.js", src_suffix=".js")
         env.Append(BUILDERS={"BuildJS": jscc})
 
-    # Add helper method for adding libraries, externs, pre-js.
+    # Add helper method for adding libraries, externs, pre-js, post-js.
     env["JS_LIBS"] = []
     env["JS_PRE"] = []
+    env["JS_POST"] = []
     env["JS_EXTERNS"] = []
     env.AddMethod(add_js_libraries, "AddJSLibraries")
     env.AddMethod(add_js_pre, "AddJSPre")
+    env.AddMethod(add_js_post, "AddJSPost")
     env.AddMethod(add_js_externs, "AddJSExterns")
 
     # Add method that joins/compiles our Engine files.

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -125,5 +125,9 @@ def add_js_pre(env, js_pre):
     env.Append(JS_PRE=env.File(js_pre))
 
 
+def add_js_post(env, js_post):
+    env.Append(JS_POST=env.File(js_post))
+
+
 def add_js_externs(env, externs):
     env.Append(JS_EXTERNS=env.File(externs))

--- a/platform/web/eslint.config.cjs
+++ b/platform/web/eslint.config.cjs
@@ -19,14 +19,17 @@ const emscriptenGlobals = {
 	'HEAP8': true,
 	'HEAPF32': true,
 	'HEAPU8': true,
+	'HEAPU32': true,
 	'IDBFS': true,
 	'LibraryManager': true,
 	'Module': true,
 	'UTF8ToString': true,
+	'UTF8Decoder': true,
 	'_emscripten_webgl_get_current_context': true,
 	'_free': true,
 	'_malloc': true,
 	'autoAddDeps': true,
+	'addOnPostRun': true,
 	'getValue': true,
 	'lengthBytesUTF8': true,
 	'mergeInto': true,
@@ -138,7 +141,12 @@ module.exports = [
 
 	// libraries and modules (browser)
 	{
-		files: ['js/libs/**/*.js', 'platform/web/js/libs/**/*.js', 'modules/**/*.js'],
+		files: [
+			'js/libs/**/*.js',
+			'platform/web/js/libs/**/*.js',
+			'platform/web/js/patches/**/*.js',
+			'modules/**/*.js'
+		],
 		languageOptions: {
 			globals: {
 				...globals.browser,

--- a/platform/web/js/patches/patch_em_gl.js
+++ b/platform/web/js/patches/patch_em_gl.js
@@ -1,0 +1,49 @@
+/**************************************************************************/
+/*  patch_em_gl.js                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+addOnPostRun(function () {
+	GL.getSource = (shader, count, string, length) => {
+		let source = '';
+		for (let i = 0; i < count; ++i) {
+			const ptr = HEAPU32[(string + i * 4) >> 2];
+			const len = length ? HEAPU32[(length + i * 4) >> 2] : undefined;
+			if (len) {
+				const endPtr = ptr + len;
+				const slice = HEAPU8.buffer instanceof ArrayBuffer
+					? HEAPU8.subarray(ptr, endPtr)
+					: HEAPU8.slice(ptr, endPtr);
+				source += UTF8Decoder.decode(slice);
+			} else {
+				source += UTF8ToString(ptr, len);
+			}
+		}
+		return source;
+	};
+});


### PR DESCRIPTION
This PR patches [ `GL.getSource`](https://github.com/emscripten-core/emscripten/blob/5cdadd65a5aed12f5d8fc2ef6debfe6336da8d4d/src/lib/libwebgl.js#L513-L518) to use a fast path when the string length is known, avoiding `UTF8ToString`, which is quite slow due to scanning for the null terminator.

With this change, `GL.getSource` time is cut almost by half, on my shader preloader screen it went from ~**14.8ms**~ **35ms** to **7.9ms**. It is especially helpful for uncached shaders compiled during gameplay. In my game, it reduces the overhead of `getSource` by 0.2–0.4ms

**Before**
![image](https://github.com/user-attachments/assets/0a860943-7818-47bc-a4dc-7c6e011de655)

**After**
![image](https://github.com/user-attachments/assets/ad94e1cc-09eb-466a-82ef-8f6be0a6698d)


**Notes:** Added the patch to `--post-js` to avoid 

```
TypeError: Cannot read properties of undefined (reading 'unshift')
    at addOnPostRun (index.js:8:15224)
```