### PR TITLE
find export templates in XDG_DATA_DIRS

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -290,6 +290,11 @@ String OS::get_data_path() const {
 	return ".";
 }
 
+// OS equivalent of XDG_DATA_DIRS, including XDG_DATA_HOME
+Vector<String> OS::get_data_search_paths() const {
+	return { get_data_path() };
+}
+
 // OS equivalent of XDG_CONFIG_HOME
 String OS::get_config_path() const {
 	return ".";

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -286,6 +286,7 @@ public:
 	virtual String get_godot_dir_name() const;
 
 	virtual String get_data_path() const;
+	virtual Vector<String> get_data_search_paths() const;
 	virtual String get_config_path() const;
 	virtual String get_cache_path() const;
 	virtual String get_temp_path() const;

--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -46,6 +46,10 @@ String EditorPaths::get_data_dir() const {
 	return data_dir;
 }
 
+const Vector<String> &EditorPaths::get_data_search_paths() const {
+	return data_search_paths;
+}
+
 String EditorPaths::get_config_dir() const {
 	return config_dir;
 }
@@ -72,6 +76,10 @@ String EditorPaths::get_self_contained_file() const {
 
 String EditorPaths::get_export_templates_dir() const {
 	return get_data_dir().path_join(export_templates_folder);
+}
+
+const Vector<String> &EditorPaths::get_export_templates_search_paths() const {
+	return export_templates_search_paths;
 }
 
 String EditorPaths::get_debug_keystore_path() const {
@@ -170,6 +178,9 @@ EditorPaths::EditorPaths() {
 		// Typically XDG_DATA_HOME or %APPDATA%.
 		data_path = OS::get_singleton()->get_data_path();
 		data_dir = data_path.path_join(OS::get_singleton()->get_godot_dir_name());
+		for (auto const &dir : OS::get_singleton()->get_data_search_paths()) {
+			data_search_paths.push_back(dir.path_join(OS::get_singleton()->get_godot_dir_name()));
+		}
 		// Can be different from data_path e.g. on Linux or macOS.
 		config_path = OS::get_singleton()->get_config_path();
 		config_dir = config_path.path_join(OS::get_singleton()->get_godot_dir_name());
@@ -181,6 +192,10 @@ EditorPaths::EditorPaths() {
 			cache_dir = cache_path.path_join(OS::get_singleton()->get_godot_dir_name());
 		}
 		temp_dir = OS::get_singleton()->get_temp_path();
+	}
+
+	for (auto const &dir : data_search_paths) {
+		export_templates_search_paths.push_back(dir.path_join(export_templates_folder));
 	}
 
 	paths_valid = (!data_path.is_empty() && !config_path.is_empty() && !cache_path.is_empty());

--- a/editor/editor_paths.h
+++ b/editor/editor_paths.h
@@ -39,6 +39,8 @@ class EditorPaths : public Object {
 
 	bool paths_valid = false; // If any of the paths can't be created, this is false.
 	String data_dir; // Editor data (templates, shader cache, etc.).
+	Vector<String> data_search_paths;
+	Vector<String> export_templates_search_paths;
 	String config_dir; // Editor config (settings, profiles, themes, etc.).
 	String cache_dir; // Editor cache (thumbnails, tmp generated files).
 	String temp_dir; // Editor temporary directory.
@@ -59,11 +61,13 @@ public:
 	bool are_paths_valid() const;
 
 	String get_data_dir() const;
+	const Vector<String> &get_data_search_paths() const;
 	String get_config_dir() const;
 	String get_cache_dir() const;
 	String get_temp_dir() const;
 	String get_project_data_dir() const;
 	String get_export_templates_dir() const;
+	const Vector<String> &get_export_templates_search_paths() const;
 	String get_debug_keystore_path() const;
 	String get_project_settings_dir() const;
 	String get_text_editor_themes_dir() const;

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -407,15 +407,22 @@ Ref<ImageTexture> EditorExportPlatform::get_option_icon(int p_index) const {
 
 String EditorExportPlatform::find_export_template(const String &template_file_name, String *err) const {
 	String current_version = GODOT_VERSION_FULL_CONFIG;
-	String template_path = EditorPaths::get_singleton()->get_export_templates_dir().path_join(current_version).path_join(template_file_name);
 
-	if (FileAccess::exists(template_path)) {
-		return template_path;
+	for (auto const &dir : EditorPaths::get_singleton()->get_export_templates_search_paths()) {
+		String template_path = dir.path_join(current_version).path_join(template_file_name);
+
+		if (FileAccess::exists(template_path)) {
+			return template_path;
+		}
 	}
 
 	// Not found
 	if (err) {
-		*err += TTR("No export template found at the expected path:") + "\n" + template_path + "\n";
+		*err += TTR("No export template found at the expected path:") + "\n";
+		for (auto const &dir : EditorPaths::get_singleton()->get_export_templates_search_paths()) {
+			String template_path = dir.path_join(current_version).path_join(template_file_name);
+			*err += template_path + "\n";
+		}
 	}
 	return String();
 }
@@ -962,13 +969,16 @@ Dictionary EditorExportPlatform::get_internal_export_files(const Ref<EditorExpor
 				}
 			} else {
 				String current_version = GODOT_VERSION_FULL_CONFIG;
-				String template_path = EditorPaths::get_singleton()->get_export_templates_dir().path_join(current_version);
-				if (p_debug && p_preset->has("custom_template/debug") && p_preset->get("custom_template/debug") != "") {
-					template_path = p_preset->get("custom_template/debug").operator String().get_base_dir();
-				} else if (!p_debug && p_preset->has("custom_template/release") && p_preset->get("custom_template/release") != "") {
-					template_path = p_preset->get("custom_template/release").operator String().get_base_dir();
+				String custom_preset_name = p_debug ? "custom_template/debug" : "custom_template/release";
+				String template_path = p_preset->get(custom_preset_name).operator String().strip_edges();
+
+				String data_file_name;
+				if (template_path.is_empty()) {
+					data_file_name = find_export_template(ts_name);
+				} else {
+					data_file_name = template_path.get_base_dir().path_join(ts_name);
 				}
-				String data_file_name = template_path.path_join(ts_name);
+
 				if (FileAccess::exists(data_file_name)) {
 					const PackedByteArray &ts_data = FileAccess::get_file_as_bytes(data_file_name);
 					if (!ts_data.is_empty()) {

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -900,6 +900,18 @@ String OS_LinuxBSD::get_data_path() const {
 	}
 }
 
+Vector<String> OS_LinuxBSD::get_data_search_paths() const {
+	Vector<String> paths = OS_Unix::get_data_search_paths();
+
+	if (has_environment("XDG_DATA_DIRS")) {
+		paths.append_array(get_environment("XDG_DATA_DIRS").split(":", false));
+	} else {
+		paths.push_back("/usr/local/share/");
+		paths.push_back("/usr/share/");
+	}
+	return paths;
+}
+
 String OS_LinuxBSD::get_cache_path() const {
 	if (has_environment("XDG_CACHE_HOME")) {
 		if (get_environment("XDG_CACHE_HOME").is_absolute_path()) {

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -113,6 +113,7 @@ public:
 
 	virtual String get_config_path() const override;
 	virtual String get_data_path() const override;
+	virtual Vector<String> get_data_search_paths() const override;
 	virtual String get_cache_path() const override;
 
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;

--- a/tests/core/os/test_os.h
+++ b/tests/core/os/test_os.h
@@ -96,6 +96,11 @@ TEST_CASE("[OS] Executable and data paths") {
 	CHECK_MESSAGE(
 			OS::get_singleton()->get_data_path().is_absolute_path(),
 			"The user data path returned should be an absolute path.");
+	for (const String &path : OS::get_singleton()->get_data_search_paths()) {
+		CHECK_MESSAGE(
+				path.is_absolute_path(),
+				"The data search path returned should be an absolute path.");
+	}
 	CHECK_MESSAGE(
 			OS::get_singleton()->get_config_path().is_absolute_path(),
 			"The user configuration path returned should be an absolute path.");


### PR DESCRIPTION
This is just a WIP to start a discussion around.

### The Problem

In `nixpkgs` we package godot, the binary blob export templates, and a source-built export template, all as separate packages.

In order for godot to be able to find the export templates, we have do to something like:

```
    ln -s "$export_templates"/share/godot/export_templates "$HOME"/.local/share/godot/
```

It would simplify build scripts and be more user-friendly if godot could locate a system-installed template package.

### The Solution

Export templates are currently found in `$XDG_DATA_HOME`.  This PR extends `EditorExportPlatform::find_export_template` to search all paths in `$XDG_DATA_DIRS` as well.

There's some groundwork that I'd like to split into separate commits if the approach is used:

- `OS::get_data_path` -> `get_data_home`/`get_data_dirs`
- corresponding `EditorPaths` changes

### Questions

- should we improve the search for `icudt_godot.dat`?

Currently it does a separate search for the file in the search paths, but it might be preferable for it to find the file relative to the export template being used.  The changes for this got messy, and I'm not sure if an export template is always known/used when packing this file.

- should a similar search be used for anything other than export templates?
- how should script compatibility be handled?
- how should `ExportTemplateManager` behave if system-installed export templates exist?

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
