### PR TITLE
Fix float/int comparison in acos_approx in sky template shader

### DIFF
--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -157,7 +157,7 @@ float acos_approx(float p_x) {
 	float x = abs(p_x);
 	float res = -0.156583f * x + (M_PI / 2.0);
 	res *= sqrt(1.0f - x);
-	return (p_x >= 0) ? res : M_PI - res;
+	return (p_x >= 0.0) ? res : M_PI - res;
 }
 
 // Based on https://math.stackexchange.com/questions/1098487/atan2-faster-approximation

--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -193,7 +193,7 @@ float acos_approx(float p_x) {
 	float x = abs(p_x);
 	float res = -0.156583f * x + (M_PI / 2.0);
 	res *= sqrt(1.0f - x);
-	return (p_x >= 0) ? res : M_PI - res;
+	return (p_x >= 0.0) ? res : M_PI - res;
 }
 
 // Based on https://math.stackexchange.com/questions/1098487/atan2-faster-approximation


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105783 (I think)

I was not able to reproduce the shader compilation error in https://github.com/godotengine/godot/issues/105783. But looking at the error it complains about comparing a float and a const int using `>=`. `>=` is only used in one place in the sky shader and it was indeed comparing between a float and a const int. 

Notably, some strict GLSL implementations will not convert `0` to a float in a comparison and require users to be extremely explicit. I tested https://github.com/godotengine/godot/pull/101973 on a MacBook which has a less strict GLSL implementation, so no error was produced. 
