### PR TITLE
Fix GDScript stack leak.

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -239,9 +239,7 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 
 		GDScriptLanguage::get_singleton()->exit_function();
 
-#ifdef DEBUG_ENABLED
 		_clear_stack();
-#endif
 	}
 
 	return ret;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105834

Counterpart of this cleanup code was moved out of `DEBUG_ENABLED` block in https://github.com/godotengine/godot/pull/91006

Tested using https://github.com/godot-rust/gdext with release template build on macOS.
| Before | After |
|-----|-----|
| <img width="534" alt="Screenshot 2025-04-27 at 23 41 44" src="https://github.com/user-attachments/assets/64b4075e-5228-4c48-a016-1fa64d7a16c7" /> | <img width="552" alt="Screenshot 2025-04-27 at 23 35 21" src="https://github.com/user-attachments/assets/74c1a0a0-5194-4f2d-b7f0-70b6324f4485" /> |
