### PR TITLE
Remove deprecated `engine_version_update_mode` editor setting

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1217,6 +1217,7 @@ const String EditorSettings::_get_project_metadata_path() const {
 
 #ifndef DISABLE_DEPRECATED
 void EditorSettings::_remove_deprecated_settings() {
+	erase("network/connection/engine_version_update_mode");
 	erase("run/output/always_open_output_on_play");
 	erase("run/output/always_close_output_on_stop");
 }


### PR DESCRIPTION
Removes the `engine_version_update_mode` editor setting that was deprecated in https://github.com/godotengine/godot/pull/105291.