### PR TITLE
[Web] Fix cut-copy-paste

### DIFF
--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -266,6 +266,36 @@ const GodotOS = {
 				}, 0);
 			});
 		},
+
+		/**
+		 * Returns Web features.
+		 * NOTE: This is not the fully featured `OS.has_feature()`.
+		 *       This is only what is returned from browser land to Godot.
+		 * @param {string} pFeature
+		 * @returns {boolean}
+		 */
+		has_feature_web: function (pFeature) {
+			const ua = navigator.userAgent;
+			if (pFeature === 'web_macos') {
+				return ua.indexOf('Mac') !== -1;
+			}
+			if (pFeature === 'web_windows') {
+				return ua.indexOf('Windows') !== -1;
+			}
+			if (pFeature === 'web_android') {
+				return ua.indexOf('Android') !== -1;
+			}
+			if (pFeature === 'web_ios') {
+				return ua.indexOf('iPhone') !== -1 || ua.indexOf('iPad') !== -1 || ua.indexOf('iPod') !== -1;
+			}
+			if (pFeature === 'web_linuxbsd') {
+				return ua.indexOf('cross') !== -1
+					|| ua.indexOf('BSD') !== -1
+					|| ua.indexOf('Linux') !== -1
+					|| ua.indexOf('X11') !== -1;
+			}
+			return false;
+		},
 	},
 
 	godot_js_os_finish_async__proxy: 'sync',
@@ -299,25 +329,9 @@ const GodotOS = {
 
 	godot_js_os_has_feature__proxy: 'sync',
 	godot_js_os_has_feature__sig: 'ii',
-	godot_js_os_has_feature: function (p_ftr) {
-		const ftr = GodotRuntime.parseString(p_ftr);
-		const ua = navigator.userAgent;
-		if (ftr === 'web_macos') {
-			return (ua.indexOf('Mac') !== -1) ? 1 : 0;
-		}
-		if (ftr === 'web_windows') {
-			return (ua.indexOf('Windows') !== -1) ? 1 : 0;
-		}
-		if (ftr === 'web_android') {
-			return (ua.indexOf('Android') !== -1) ? 1 : 0;
-		}
-		if (ftr === 'web_ios') {
-			return ((ua.indexOf('iPhone') !== -1) || (ua.indexOf('iPad') !== -1) || (ua.indexOf('iPod') !== -1)) ? 1 : 0;
-		}
-		if (ftr === 'web_linuxbsd') {
-			return ((ua.indexOf('CrOS') !== -1) || (ua.indexOf('BSD') !== -1) || (ua.indexOf('Linux') !== -1) || (ua.indexOf('X11') !== -1)) ? 1 : 0;
-		}
-		return 0;
+	godot_js_os_has_feature: function (pFeaturePtr) {
+		const feature = GodotRuntime.parseString(pFeaturePtr);
+		return Number(GodotOS.has_feature_web(feature));
 	},
 
 	godot_js_os_execute__proxy: 'sync',


### PR DESCRIPTION
Believe it or not, copy-cut-paste on the Web platform seems to be completely broken. (I mean cut/copy/paste from outside to the game or from the game to outside.) [Try it out.](https://editor.godotengine.org/) This PR fixes this. 

https://github.com/user-attachments/assets/c9ce8412-9105-42e6-98c8-63151b66db88

The issue is caused by the fact that we use `event.preventDefault()` for every key input. This makes it impossible for the browser to actually trigger and dispatch the `ClipboardEvent` needed to read the browser's clipboard. It is only available on [transient user activation](https://developer.mozilla.org/en-US/docs/Web/Security/User_activation) due to [security considerations](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#security_considerations).

So, I've added exceptions for {Ctrl,Cmd}-{X,C,V} (ctrl/cmd depends on the host). Keyboard-based copy/cut/paste aren't prevented by default, and this fixes the issues with copy/pasting.

So, it will be possible to copy/paste code from and to the browser. Very useful for code editors.