### PR TITLE
Delete test cache before running it

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -30,6 +30,8 @@
 
 #include "test_main.h"
 
+#include "core/error/error_macros.h"
+#include "core/io/dir_access.h"
 #include "modules/modules_enabled.gen.h"
 
 #ifdef TOOLS_ENABLED
@@ -230,6 +232,15 @@ int test_main(int argc, char *argv[]) {
 	DisplayServerMock::register_mock_driver();
 
 	WorkerThreadPool::get_singleton()->init();
+
+	String test_path = OS::get_singleton()->get_cache_path().path_join("godot_test");
+
+	Ref<DirAccess> da;
+	if (DirAccess::exists(test_path)) {
+		da = DirAccess::open(test_path);
+		ERR_FAIL_COND_V(da.is_null(), 0);
+		ERR_FAIL_COND_V_MSG(da->erase_contents_recursive() != OK, 0, "Failed to delete files");
+	}
 
 	// Run custom test tools.
 	if (test_commands) {


### PR DESCRIPTION
May help with certain aspects of #103530

This PR makes the test runner delete the test cache before running it.

The reason for that is there is a couple of combination of compilation arguments, that if used, will disable the creation of certain assets, but those assets are then used later on for unit tests, which promptly fail to load (Here's a case of it happening: https://github.com/godotengine/godot/issues/103530#issuecomment-2695878864).

But, if you run unit tests with a previous Godot version with different compilation flags, you can be lucky and have the test files already saved into the cache from a completely unrelated build of Godot, and then the tests might run just fine, when they shouldn't.

So the reason to delete caches is to help diagnose tests that should've failed, but doesn't.

I also run some benchmarking, in my machine running tests with cache takes 25 seconds, without, it takes 26 seconds. Which makes me think that the cache is being saved just as a place to run stuff, and not as an actual cache.