### PR TITLE
[.NET] Load assemblies directly from PCK on Android

### DIFF
--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -169,6 +169,10 @@ private:
 		String arch = Engine::get_singleton()->get_architecture_name();
 		String appname_safe = Path::get_csharp_project_name();
 		String packed_path = "res://.godot/mono/publish/" + arch;
+#ifdef ANDROID_ENABLED
+		api_assemblies_dir = packed_path;
+		print_verbose(".NET: Android platform detected. Setting api_assemblies_dir directly to pck path: " + api_assemblies_dir);
+#else
 		if (DirAccess::exists(packed_path)) {
 			// The dotnet publish data is packed in the pck/zip.
 			String data_dir_root = OS::get_singleton()->get_cache_path().path_join("data_" + appname_safe + "_" + platform + "_" + arch);
@@ -214,6 +218,7 @@ private:
 #endif
 			api_assemblies_dir = data_dir_root;
 		}
+#endif // ANDROID_ENABLED
 #endif
 	}
 


### PR DESCRIPTION
Fixes #105832.

Addresses limitations observed after #105262 ("Avoids using assemblies extracted to a temporary directory in Android."), where testing confirmed the cache directory was still referenced.

Assemblies are now loaded directly from the PCK (`res://`) instead of a cache directory. This prevents runtime failures that occurred when the OS cleared cached files (e.g., under low storage), ensuring the required assemblies are always available.

See attached logs and screenshots comparing AS-IS and TO-BE behavior (showing no DLL files copied to cache).

---


AS-IS:
<img width="368" alt="image" src="https://github.com/user-attachments/assets/1b244485-78da-486c-bc48-e49cbb58894e" />
```
.NET: Initializing module...
Found monosgen: libmonosgen-2.0.so
.NET: CoreCLR initialized
.NET: Loading assembly 'System.Private.CoreLib.dll' from '/data/data/net.enchantedlab.creamia/cache/data_Creamia_android_arm64/System.Private.CoreLib.dll'.
.NET: Loading assembly 'Creamia.dll' from '/data/data/net.enchantedlab.creamia/cache/data_Creamia_android_arm64/Creamia.dll'.
.NET: Loading assembly 'System.Runtime.dll' from '/data/data/net.enchantedlab.creamia/cache/data_Creamia_android_arm64/System.Runtime.dll'.
.NET: Loading assembly 'System.Runtime.InteropServices.dll' from '/data/data/net.enchantedlab.creamia/cache/data_Creamia_android_arm64/System.Runtime.InteropServices.dll'.
.NET: Loading assembly 'GodotSharp.dll' from '/data/data/net.enchantedlab.creamia/cache/data_Creamia_android_arm64/GodotSharp.dll'.
.NET: Loading assembly 'System.Collections.dll' from '/data/data/net.enchantedlab.creamia/cache/data_Creamia_android_arm64/System.Collections.dll'.
.NET: Loading assembly 'System.Collections.Concurrent.dll' from '/data/data/net.enchantedlab.creamia/cache/data_Creamia_android_arm64/System.Collections.Concurrent.dll'.
.NET: Loading assembly 'System.Runtime.Loader.dll' from '/data/data/net.enchantedlab.creamia/cache/data_Creamia_android_arm64/System.Runtime.Loader.dll'.
.NET: Loading assembly 'System.Console.dll' from '/data/data/net.enchantedlab.creamia/cache/data_Creamia_android_arm64/System.Console.dll'.
.NET: Loading assembly 'System.Threading.dll' from '/data/data/net.enchantedlab.creamia/cache/data_Creamia_android_arm64/System.Threading.dll'.
.NET: Loading assembly 'System.Linq.dll' from '/data/data/net.enchantedlab.creamia/cache/data_Creamia_android_arm64/System.Linq.dll'.
.NET: GodotPlugins initialized
.NET: Loading assembly 'System.Diagnostics.TraceSource.dll' from '/data/data/net.enchantedlab.creamia/cache/data_Creamia_android_arm64/System.Diagnostics.TraceSource.dll'.
.NET: Loading assembly 'System.Collections.Specialized.dll' from '/data/data/net.enchantedlab.creamia/cache/data_Creamia_android_arm64/System.Collections.Specialized.dll'.
```

TO-BE:
<img width="359" alt="SCR-20250428-krlr" src="https://github.com/user-attachments/assets/724a896c-43c0-49ef-8a67-4a9e0c724a8b" />
```
.NET: Initializing module...
.NET: Android platform detected. Setting api_assemblies_dir directly to pck path: res://.godot/mono/publish/arm64
Found monosgen: libmonosgen-2.0.so
.NET: CoreCLR initialized
.NET: Loading assembly 'System.Private.CoreLib.dll' from 'res://.godot/mono/publish/arm64/System.Private.CoreLib.dll'.
.NET: Loading assembly 'Creamia.dll' from 'res://.godot/mono/publish/arm64/Creamia.dll'.
.NET: Loading assembly 'System.Runtime.dll' from 'res://.godot/mono/publish/arm64/System.Runtime.dll'.
.NET: Loading assembly 'System.Runtime.InteropServices.dll' from 'res://.godot/mono/publish/arm64/System.Runtime.InteropServices.dll'.
.NET: Loading assembly 'GodotSharp.dll' from 'res://.godot/mono/publish/arm64/GodotSharp.dll'.
.NET: Loading assembly 'System.Collections.dll' from 'res://.godot/mono/publish/arm64/System.Collections.dll'.
.NET: Loading assembly 'System.Collections.Concurrent.dll' from 'res://.godot/mono/publish/arm64/System.Collections.Concurrent.dll'.
.NET: Loading assembly 'System.Runtime.Loader.dll' from 'res://.godot/mono/publish/arm64/System.Runtime.Loader.dll'.
.NET: Loading assembly 'System.Console.dll' from 'res://.godot/mono/publish/arm64/System.Console.dll'.
.NET: Loading assembly 'System.Threading.dll' from 'res://.godot/mono/publish/arm64/System.Threading.dll'.
.NET: Loading assembly 'System.Linq.dll' from 'res://.godot/mono/publish/arm64/System.Linq.dll'.
.NET: GodotPlugins initialized
.NET: Loading assembly 'System.Diagnostics.TraceSource.dll' from 'res://.godot/mono/publish/arm64/System.Diagnostics.TraceSource.dll'.
.NET: Loading assembly 'System.Collections.Specialized.dll' from 'res://.godot/mono/publish/arm64/System.Collections.Specialized.dll'.
```