### PR TITLE
Fix invalid AnimationNode documentation syntax

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -9,9 +9,9 @@
 		You can access the time information as read-only parameter which is processed and stored in the previous frame for all nodes except [AnimationNodeOutput].
 		[b]Note:[/b] If multiple inputs exist in the [AnimationNode], which time information takes precedence depends on the type of [AnimationNode].
 		[codeblock]
-		var current_length = $AnimationTree[parameters/AnimationNodeName/current_length]
-		var current_position = $AnimationTree[parameters/AnimationNodeName/current_position]
-		var current_delta = $AnimationTree[parameters/AnimationNodeName/current_delta]
+		var current_length = $AnimationTree["parameters/AnimationNodeName/current_length"]
+		var current_position = $AnimationTree["parameters/AnimationNodeName/current_position"]
+		var current_delta = $AnimationTree["parameters/AnimationNodeName/current_delta"]
 		[/codeblock]
 	</description>
 	<tutorials>


### PR DESCRIPTION
Documentation has invalid syntax. Quotation marks are needed here.