### PR TITLE
Add thumbnail mode to FIleDialog

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -137,6 +137,9 @@
 			The currently selected file path of the file dialog.
 		</member>
 		<member name="dialog_hide_on_ok" type="bool" setter="set_hide_on_ok" getter="get_hide_on_ok" overrides="AcceptDialog" default="false" />
+		<member name="display_mode" type="int" setter="set_display_mode" getter="get_display_mode" enum="FileDialog.DisplayMode" default="0">
+			Display mode of the dialog's file list.
+		</member>
 		<member name="file_mode" type="int" setter="set_file_mode" getter="get_file_mode" enum="FileDialog.FileMode" default="4">
 			The dialog's open or save mode, which affects the selection behavior. See [enum FileMode].
 		</member>
@@ -223,6 +226,12 @@
 		<constant name="ACCESS_FILESYSTEM" value="2" enum="Access">
 			The dialog allows accessing files on the whole file system.
 		</constant>
+		<constant name="DISPLAY_THUMBNAILS" value="0" enum="DisplayMode">
+			The dialog displays files as a grid of thumbnails. Use [theme_item thumbnail_size] to adjust their size.
+		</constant>
+		<constant name="DISPLAY_LIST" value="1" enum="DisplayMode">
+			The dialog displays files as a list of filenames.
+		</constant>
 	</constants>
 	<theme_items>
 		<theme_item name="file_disabled_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.25)">
@@ -233,6 +242,9 @@
 		</theme_item>
 		<theme_item name="folder_icon_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The color modulation applied to the folder icon.
+		</theme_item>
+		<theme_item name="thumbnail_size" data_type="constant" type="int" default="64">
+			The size of thumbnail icons when [constant DISPLAY_THUMBNAILS] is enabled.
 		</theme_item>
 		<theme_item name="back_folder" data_type="icon" type="Texture2D">
 			Custom icon for the back arrow.
@@ -252,11 +264,20 @@
 		<theme_item name="file" data_type="icon" type="Texture2D">
 			Custom icon for files.
 		</theme_item>
+		<theme_item name="file_thumbnail" data_type="icon" type="Texture2D">
+			Icon for files when in thumbnail mode.
+		</theme_item>
 		<theme_item name="folder" data_type="icon" type="Texture2D">
 			Custom icon for folders.
 		</theme_item>
+		<theme_item name="folder_thumbnail" data_type="icon" type="Texture2D">
+			Icon for folders when in thumbnail mode.
+		</theme_item>
 		<theme_item name="forward_folder" data_type="icon" type="Texture2D">
 			Custom icon for the forward arrow.
+		</theme_item>
+		<theme_item name="list_mode" data_type="icon" type="Texture2D">
+			Icon for the button that enables list mode.
 		</theme_item>
 		<theme_item name="parent_folder" data_type="icon" type="Texture2D">
 			Custom icon for the parent folder arrow.
@@ -266,6 +287,9 @@
 		</theme_item>
 		<theme_item name="sort" data_type="icon" type="Texture2D">
 			Custom icon for the sorting options menu.
+		</theme_item>
+		<theme_item name="thumbnail_mode" data_type="icon" type="Texture2D">
+			Icon for the button that enables thumbnail mode.
 		</theme_item>
 		<theme_item name="toggle_filename_filter" data_type="icon" type="Texture2D">
 			Custom icon for the toggle button for the filter for file names.

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -123,6 +123,11 @@ public:
 		FILE_MODE_SAVE_FILE,
 	};
 
+	enum DisplayMode {
+		DISPLAY_THUMBNAILS,
+		DISPLAY_LIST,
+	};
+
 	enum ItemMenu {
 		ITEM_MENU_COPY_PATH,
 		ITEM_MENU_SHOW_IN_EXPLORER,
@@ -149,6 +154,7 @@ private:
 
 	Access access = ACCESS_RESOURCES;
 	FileMode mode = FILE_MODE_SAVE_FILE;
+	DisplayMode display_mode = DISPLAY_THUMBNAILS;
 	FileSortOption file_sort = FileSortOption::NAME;
 	Ref<DirAccess> dir_access;
 
@@ -187,6 +193,8 @@ private:
 	Button *favorite_button = nullptr;
 	Button *make_dir_button = nullptr;
 	Button *show_hidden = nullptr;
+	Button *thumbnail_mode_button = nullptr;
+	Button *list_mode_button = nullptr;
 	Button *show_filename_filter_button = nullptr;
 	MenuButton *file_sort_button = nullptr;
 
@@ -216,12 +224,16 @@ private:
 	ConfirmationDialog *confirm_save = nullptr;
 
 	struct ThemeCache {
+		int thumbnail_size = 64;
+
 		Ref<Texture2D> parent_folder;
 		Ref<Texture2D> forward_folder;
 		Ref<Texture2D> back_folder;
 		Ref<Texture2D> reload;
 		Ref<Texture2D> toggle_hidden;
 		Ref<Texture2D> toggle_filename_filter;
+		Ref<Texture2D> thumbnail_mode;
+		Ref<Texture2D> list_mode;
 		Ref<Texture2D> folder;
 		Ref<Texture2D> file;
 		Ref<Texture2D> create_folder;
@@ -229,6 +241,8 @@ private:
 		Ref<Texture2D> favorite;
 		Ref<Texture2D> favorite_up;
 		Ref<Texture2D> favorite_down;
+		Ref<Texture2D> file_thumbnail;
+		Ref<Texture2D> folder_thumbnail;
 
 		Color folder_icon_color;
 		Color file_icon_color;
@@ -369,6 +383,9 @@ public:
 	void set_file_mode(FileMode p_mode);
 	FileMode get_file_mode() const;
 
+	void set_display_mode(DisplayMode p_mode);
+	DisplayMode get_display_mode() const;
+
 	VBoxContainer *get_vbox() { return main_vbox; }
 	LineEdit *get_line_edit() { return filename_edit; }
 
@@ -392,3 +409,4 @@ public:
 
 VARIANT_ENUM_CAST(FileDialog::FileMode);
 VARIANT_ENUM_CAST(FileDialog::Access);
+VARIANT_ENUM_CAST(FileDialog::DisplayMode);

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -683,6 +683,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// File Dialog
 
+	theme->set_constant("thumbnail_size", "FileDialog", 64);
 	theme->set_icon("load", "FileDialog", icons["load"]);
 	theme->set_icon("save", "FileDialog", icons["save"]);
 	theme->set_icon("clear", "FileDialog", icons["clear"]);
@@ -695,11 +696,15 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("toggle_filename_filter", "FileDialog", icons["toggle_filename_filter"]);
 	theme->set_icon("folder", "FileDialog", icons["folder"]);
 	theme->set_icon("file", "FileDialog", icons["file"]);
+	theme->set_icon("thumbnail_mode", "FileDialog", icons["file_mode_thumbnail"]);
+	theme->set_icon("list_mode", "FileDialog", icons["file_mode_list"]);
 	theme->set_icon("create_folder", "FileDialog", icons["folder_create"]);
 	theme->set_icon("sort", "FileDialog", icons["sort"]);
 	theme->set_icon("favorite_up", "FileDialog", icons["move_up"]);
 	theme->set_icon("favorite_down", "FileDialog", icons["move_down"]);
 
+	theme->set_icon("file_thumbnail", "FileDialog", icons["file_thumbnail"]);
+	theme->set_icon("folder_thumbnail", "FileDialog", icons["folder_thumbnail"]);
 	theme->set_color("folder_icon_color", "FileDialog", Color(1, 1, 1));
 	theme->set_color("file_icon_color", "FileDialog", Color(1, 1, 1));
 	theme->set_color("file_disabled_color", "FileDialog", Color(1, 1, 1, 0.25));

--- a/scene/theme/icons/file_mode_list.svg
+++ b/scene/theme/icons/file_mode_list.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="m2 2v2h2v-2zm4 0v2h8v-2zm-4 5v2h2v-2zm4 0v2h8v-2zm-4 5v2h2v-2zm4 0v2h8v-2z"/></svg>

--- a/scene/theme/icons/file_mode_thumbnail.svg
+++ b/scene/theme/icons/file_mode_thumbnail.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="m2 2v5h5v-5zm7 0v5h5v-5zm-7 7v5h5v-5zm7 0v5h5v-5z"/></svg>

--- a/scene/theme/icons/file_thumbnail.svg
+++ b/scene/theme/icons/file_thumbnail.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><path fill="#fff" fill-opacity=".6" d="M14 5a4 4 0 0 0-4 4v46a4 4 0 0 0 4 4h36a4 4 0 0 0 4-4V22a1 1 0 0 0-.29-.707l-16-16a1 1 0 0 0-.707-.29V5H14zm0 2h22v12a4 4 0 0 0 4 4h12v32a2 2 0 0 1-2 2H14a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2z"/></svg>

--- a/scene/theme/icons/folder_thumbnail.svg
+++ b/scene/theme/icons/folder_thumbnail.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><path fill="#e0e0e0" d="M12 10a4 4 0 0 0-4 4v36a4 4 0 0 0 4 4h40a4 4 0 0 0 4-4V22a4 4 0 0 0-4-4H36l-2-4c-1-2-2-4-4-4z"/></svg>


### PR DESCRIPTION
Part of godotengine/godot-proposals#6831
Depends on #105641
Also soft-depends on #105723, because it reorganizes icons.

Adds thumbnails mode to FileDialog (enabled by default).
![godot windows editor dev x86_64_vLo1mM3Ypm](https://github.com/user-attachments/assets/b84599a6-6474-427d-b0ee-637390317b47)

File preview (like in EditorFileDialog) is not supported yet. I'll add it when I start integrating FileDialogs with editor. Maybe I'll split that into multiple PRs too. For now that's the last EditorFileDialog's feature missing from FileDialog.