### PR TITLE
Quick `StringName` improvements.

### DIFF
--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -30,6 +30,7 @@
 
 #include "string_name.h"
 
+#include "core/os/mutex.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 
@@ -174,14 +175,6 @@ int StringName::length() const {
 	}
 
 	return 0;
-}
-
-bool StringName::is_empty() const {
-	if (_data) {
-		return _data->name.is_empty();
-	}
-
-	return true;
 }
 
 StringName &StringName::operator=(const StringName &p_name) {

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/os/mutex.h"
 #include "core/string/ustring.h"
 #include "core/templates/safe_refcount.h"
 
@@ -78,7 +77,7 @@ class StringName {
 	StringName(_Data *p_data) { _data = p_data; }
 
 public:
-	explicit operator bool() const { return _data && !_data->name.is_empty(); }
+	_FORCE_INLINE_ explicit operator bool() const { return _data; }
 
 	bool operator==(const String &p_name) const;
 	bool operator==(const char *p_name) const;
@@ -88,7 +87,7 @@ public:
 	const char32_t *get_data() const { return _data ? _data->name.ptr() : U""; }
 	char32_t operator[](int p_index) const;
 	int length() const;
-	bool is_empty() const;
+	_FORCE_INLINE_ bool is_empty() const { return !_data; }
 
 	_FORCE_INLINE_ bool is_node_unique_name() const {
 		if (!_data) {

--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/os/mutex.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/hash_set.h"
 #include "core/templates/hashfuncs.h"


### PR DESCRIPTION
Two quick changes:
- Simplify `StringName` to `bool` conversions. If `_data` is set, `_data->name` is guaranteed to be not empty. This speeds up the function considerably, and decreases the binary size by 0.6mb.
- Move `mutex.h` include of `string_name.h` to `string_name.cpp`. This removes the include from most of the codebase, improving compile speeds a bit.
