### PR TITLE
Core: Replace string C header with C++ equivalent

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -43,8 +43,6 @@
 #include "core/variant/variant.h"
 #include "core/version.h"
 
-#include <string.h>
-
 class CallableCustomExtension : public CallableCustom {
 	void *userdata;
 	void *token;
@@ -873,7 +871,7 @@ static GDExtensionPtrUtilityFunction gdextension_variant_get_ptr_utility_functio
 
 static void gdextension_string_new_with_latin1_chars(GDExtensionUninitializedStringPtr r_dest, const char *p_contents) {
 	String *dest = memnew_placement(r_dest, String);
-	dest->append_latin1(Span<char>(p_contents, p_contents ? strlen(p_contents) : 0));
+	dest->append_latin1(Span<char>(p_contents, p_contents ? std::strlen(p_contents) : 0));
 }
 
 static void gdextension_string_new_with_utf8_chars(GDExtensionUninitializedStringPtr r_dest, const char *p_contents) {
@@ -888,7 +886,7 @@ static void gdextension_string_new_with_utf16_chars(GDExtensionUninitializedStri
 
 static void gdextension_string_new_with_utf32_chars(GDExtensionUninitializedStringPtr r_dest, const char32_t *p_contents) {
 	String *dest = memnew_placement(r_dest, String);
-	dest->append_utf32(Span(p_contents, p_contents ? strlen(p_contents) : 0));
+	dest->append_utf32(Span(p_contents, p_contents ? std::strlen(p_contents) : 0));
 }
 
 static void gdextension_string_new_with_wide_chars(GDExtensionUninitializedStringPtr r_dest, const wchar_t *p_contents) {
@@ -899,7 +897,7 @@ static void gdextension_string_new_with_wide_chars(GDExtensionUninitializedStrin
 	} else {
 		// wchar_t is 32 bit (UTF-32).
 		String *string = memnew_placement(r_dest, String);
-		string->append_utf32(Span((const char32_t *)p_contents, p_contents ? strlen(p_contents) : 0));
+		string->append_utf32(Span((const char32_t *)p_contents, p_contents ? std::strlen(p_contents) : 0));
 	}
 }
 
@@ -1672,7 +1670,7 @@ static void gdextension_editor_help_load_xml_from_utf8_chars_and_len(const char 
 
 static void gdextension_editor_help_load_xml_from_utf8_chars(const char *p_data) {
 #ifdef TOOLS_ENABLED
-	size_t len = strlen(p_data);
+	size_t len = std::strlen(p_data);
 	gdextension_editor_help_load_xml_from_utf8_chars_and_len(p_data, len);
 #endif
 }

--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -56,8 +56,8 @@ int Compression::compress(uint8_t *p_dst, const uint8_t *p_src, int p_src_size, 
 		case MODE_FASTLZ: {
 			if (p_src_size < 16) {
 				uint8_t src[16];
-				memset(&src[p_src_size], 0, 16 - p_src_size);
-				memcpy(src, p_src, p_src_size);
+				std::memset(&src[p_src_size], 0, 16 - p_src_size);
+				std::memcpy(src, p_src, p_src_size);
 				return fastlz_compress(src, 16, p_dst);
 			} else {
 				return fastlz_compress(p_src, p_src_size, p_dst);
@@ -161,7 +161,7 @@ int Compression::decompress(uint8_t *p_dst, int p_dst_max_size, const uint8_t *p
 			if (p_dst_max_size < 16) {
 				uint8_t dst[16];
 				fastlz_decompress(p_src, p_src_size, dst, 16);
-				memcpy(p_dst, dst, p_dst_max_size);
+				std::memcpy(p_dst, dst, p_dst_max_size);
 				ret_size = p_dst_max_size;
 			} else {
 				ret_size = fastlz_decompress(p_src, p_src_size, p_dst, p_dst_max_size);

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -264,7 +264,7 @@ uint64_t FileAccessCompressed::get_buffer(uint8_t *p_dst, uint64_t p_length) con
 	while (true) {
 		// Copy over as much of our current block as possible.
 		const uint32_t copied_bytes_count = MIN(p_length - dst_idx, read_block_size - read_pos);
-		memcpy(p_dst + dst_idx, read_ptr + read_pos, copied_bytes_count);
+		std::memcpy(p_dst + dst_idx, read_ptr + read_pos, copied_bytes_count);
 		dst_idx += copied_bytes_count;
 		read_pos += copied_bytes_count;
 
@@ -322,7 +322,7 @@ bool FileAccessCompressed::store_buffer(const uint8_t *p_src, uint64_t p_length)
 	}
 
 	if (p_length) {
-		memcpy(write_ptr + write_pos, p_src, p_length);
+		std::memcpy(write_ptr + write_pos, p_src, p_length);
 	}
 
 	write_pos += p_length;

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -150,7 +150,7 @@ void FileAccessEncrypted::_close() {
 		ERR_FAIL_COND(CryptoCore::md5(data.ptr(), data.size(), hash) != OK); // Bug?
 
 		compressed.resize(len);
-		memset(compressed.ptrw(), 0, len);
+		std::memset(compressed.ptrw(), 0, len);
 		for (int i = 0; i < data.size(); i++) {
 			compressed.write[i] = data[i];
 		}
@@ -231,7 +231,7 @@ uint64_t FileAccessEncrypted::get_buffer(uint8_t *p_dst, uint64_t p_length) cons
 
 	uint64_t to_copy = MIN(p_length, get_length() - pos);
 
-	memcpy(p_dst, data.ptr() + pos, to_copy);
+	std::memcpy(p_dst, data.ptr() + pos, to_copy);
 	pos += to_copy;
 
 	if (to_copy < p_length) {
@@ -258,7 +258,7 @@ bool FileAccessEncrypted::store_buffer(const uint8_t *p_src, uint64_t p_length) 
 		ERR_FAIL_COND_V(data.resize(pos + p_length) != OK, false);
 	}
 
-	memcpy(data.ptrw() + pos, p_src, p_length);
+	std::memcpy(data.ptrw() + pos, p_src, p_length);
 	pos += p_length;
 
 	return true;

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -135,7 +135,7 @@ uint64_t FileAccessMemory::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 		WARN_PRINT("Reading less data than requested");
 	}
 
-	memcpy(p_dst, &data[pos], read);
+	std::memcpy(p_dst, &data[pos], read);
 	pos += read;
 
 	return read;
@@ -159,7 +159,7 @@ bool FileAccessMemory::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	uint64_t left = length - pos;
 	uint64_t write = MIN(p_length, left);
 
-	memcpy(&data[pos], p_src, write);
+	std::memcpy(&data[pos], p_src, write);
 	pos += write;
 
 	ERR_FAIL_COND_V_MSG(write < p_length, false, "Writing less data than requested.");

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -120,7 +120,7 @@ unzFile ZipArchive::get_file_handle(const String &p_file) const {
 	File file = files[p_file];
 
 	zlib_filefunc_def io;
-	memset(&io, 0, sizeof(io));
+	std::memset(&io, 0, sizeof(io));
 
 	io.opaque = nullptr;
 	io.zopen_file = godot_open;
@@ -155,7 +155,7 @@ bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint6
 	}
 
 	zlib_filefunc_def io;
-	memset(&io, 0, sizeof(io));
+	std::memset(&io, 0, sizeof(io));
 
 	io.opaque = nullptr;
 	io.zopen_file = godot_open;

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -670,7 +670,7 @@ PackedByteArray HTTPClientTCP::read_response_body_chunk() {
 
 					ret.resize(chunk_size - 2);
 					uint8_t *w = ret.ptrw();
-					memcpy(w, chunk.ptr(), chunk_size - 2);
+					std::memcpy(w, chunk.ptr(), chunk_size - 2);
 					chunk.clear();
 				}
 

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -139,12 +139,12 @@ Ref<Image> (*Image::basis_universal_unpacker_ptr)(const uint8_t *, int) = nullpt
 
 void Image::_put_pixelb(int p_x, int p_y, uint32_t p_pixel_size, uint8_t *p_data, const uint8_t *p_pixel) {
 	uint32_t ofs = (p_y * width + p_x) * p_pixel_size;
-	memcpy(p_data + ofs, p_pixel, p_pixel_size);
+	std::memcpy(p_data + ofs, p_pixel, p_pixel_size);
 }
 
 void Image::_get_pixelb(int p_x, int p_y, uint32_t p_pixel_size, const uint8_t *p_data, uint8_t *p_pixel) {
 	uint32_t ofs = (p_y * width + p_x) * p_pixel_size;
-	memcpy(p_pixel, p_data + ofs, p_pixel_size);
+	std::memcpy(p_pixel, p_data + ofs, p_pixel_size);
 }
 
 int Image::get_format_pixel_size(Format p_format) {
@@ -544,11 +544,11 @@ static void _convert_fast(int p_width, int p_height, const T *p_src, T *p_dst) {
 	const int resolution = p_width * p_height;
 
 	for (int i = 0; i < resolution; i++) {
-		memcpy(p_dst + dst_count, p_src + src_count, MIN(read_channels, write_channels) * sizeof(T));
+		std::memcpy(p_dst + dst_count, p_src + src_count, MIN(read_channels, write_channels) * sizeof(T));
 
 		if constexpr (write_channels > read_channels) {
 			const T def_value[4] = { def_zero, def_zero, def_zero, def_one };
-			memcpy(p_dst + dst_count + read_channels, &def_value[read_channels], (write_channels - read_channels) * sizeof(T));
+			std::memcpy(p_dst + dst_count + read_channels, &def_value[read_channels], (write_channels - read_channels) * sizeof(T));
 		}
 
 		dst_count += write_channels;
@@ -599,7 +599,7 @@ void Image::convert(Format p_new_format) {
 			int64_t mip_size = 0;
 			new_img.get_mipmap_offset_and_size(mip, mip_offset, mip_size);
 
-			memcpy(new_img.data.ptrw() + mip_offset, new_mip->data.ptr(), mip_size);
+			std::memcpy(new_img.data.ptrw() + mip_offset, new_mip->data.ptr(), mip_size);
 		}
 
 		_copy_internals_from(new_img);
@@ -1565,13 +1565,13 @@ void Image::rotate_90(ClockDirection p_direction) {
 			for (int y = 0; y < h / 2; y++) {
 				for (int x = 0; x < (w + 1) / 2; x++) {
 					int current = y * w + x;
-					memcpy(single_pixel_buffer, data_ptr + current * pixel_size, pixel_size);
+					std::memcpy(single_pixel_buffer, data_ptr + current * pixel_size, pixel_size);
 					for (int i = 0; i < 3; i++) {
 						int prev = PREV_INDEX_IN_CYCLE(current);
-						memcpy(data_ptr + current * pixel_size, data_ptr + prev * pixel_size, pixel_size);
+						std::memcpy(data_ptr + current * pixel_size, data_ptr + prev * pixel_size, pixel_size);
 						current = prev;
 					}
-					memcpy(data_ptr + current * pixel_size, single_pixel_buffer, pixel_size);
+					std::memcpy(data_ptr + current * pixel_size, single_pixel_buffer, pixel_size);
 				}
 			}
 		} else { // Rectangular case (w != h), kinda unpredictable cycles.
@@ -1597,13 +1597,13 @@ void Image::rotate_90(ClockDirection p_direction) {
 				}
 
 				// Save the in-cycle pixel with the smallest index (`i`).
-				memcpy(single_pixel_buffer, data_ptr + i * pixel_size, pixel_size);
+				std::memcpy(single_pixel_buffer, data_ptr + i * pixel_size, pixel_size);
 
 				// Overwrite pixels one by one by the preceding pixel in the cycle.
 				int current = i;
 				prev = PREV_INDEX_IN_CYCLE(current);
 				while (prev != i) {
-					memcpy(data_ptr + current * pixel_size, data_ptr + prev * pixel_size, pixel_size);
+					std::memcpy(data_ptr + current * pixel_size, data_ptr + prev * pixel_size, pixel_size);
 					permuted_pixels_count++;
 
 					current = prev;
@@ -1611,7 +1611,7 @@ void Image::rotate_90(ClockDirection p_direction) {
 				};
 
 				// Overwrite the remaining pixel in the cycle by the saved pixel with the smallest index.
-				memcpy(data_ptr + current * pixel_size, single_pixel_buffer, pixel_size);
+				std::memcpy(data_ptr + current * pixel_size, single_pixel_buffer, pixel_size);
 				permuted_pixels_count++;
 
 				if (permuted_pixels_count == size) {
@@ -1651,9 +1651,9 @@ void Image::rotate_180() {
 		uint8_t *from_end_ptr = data_ptr + (width * height - 1) * pixel_size;
 
 		while (from_begin_ptr < from_end_ptr) {
-			memcpy(single_pixel_buffer, from_begin_ptr, pixel_size);
-			memcpy(from_begin_ptr, from_end_ptr, pixel_size);
-			memcpy(from_end_ptr, single_pixel_buffer, pixel_size);
+			std::memcpy(single_pixel_buffer, from_begin_ptr, pixel_size);
+			std::memcpy(from_begin_ptr, from_end_ptr, pixel_size);
+			std::memcpy(from_end_ptr, single_pixel_buffer, pixel_size);
 
 			from_begin_ptr += pixel_size;
 			from_end_ptr -= pixel_size;
@@ -1918,7 +1918,7 @@ void Image::shrink_x2() {
 		new_data.resize(new_size);
 		ERR_FAIL_COND(new_data.is_empty());
 
-		memcpy(new_data.ptrw(), data.ptr() + ofs, new_size);
+		std::memcpy(new_data.ptrw(), data.ptr() + ofs, new_size);
 	} else {
 		// Generate a mipmap and replace the original.
 		ERR_FAIL_COND(is_compressed());
@@ -2217,7 +2217,7 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 
 	{
 		uint8_t *w = data.ptrw();
-		memset(w, 0, size);
+		std::memset(w, 0, size);
 	}
 
 	width = p_width;
@@ -3085,11 +3085,11 @@ void Image::blend_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, c
 void Image::_repeat_pixel_over_subsequent_memory(uint8_t *p_pixel, int p_pixel_size, int p_count) {
 	int offset = 1;
 	for (int stride = 1; offset + stride <= p_count; stride *= 2) {
-		memcpy(p_pixel + offset * p_pixel_size, p_pixel, stride * p_pixel_size);
+		std::memcpy(p_pixel + offset * p_pixel_size, p_pixel, stride * p_pixel_size);
 		offset += stride;
 	}
 	if (offset < p_count) {
-		memcpy(p_pixel + offset * p_pixel_size, p_pixel, (p_count - offset) * p_pixel_size);
+		std::memcpy(p_pixel + offset * p_pixel_size, p_pixel, (p_count - offset) * p_pixel_size);
 	}
 }
 
@@ -3134,7 +3134,7 @@ void Image::fill_rect(const Rect2i &p_rect, const Color &p_color) {
 	} else {
 		_repeat_pixel_over_subsequent_memory(rect_first_pixel_ptr, pixel_size, r.size.x);
 		for (int y = 1; y < r.size.y; y++) {
-			memcpy(rect_first_pixel_ptr + y * width * pixel_size, rect_first_pixel_ptr, r.size.x * pixel_size);
+			std::memcpy(rect_first_pixel_ptr + y * width * pixel_size, rect_first_pixel_ptr, r.size.x * pixel_size);
 		}
 	}
 }
@@ -3764,7 +3764,7 @@ Ref<Image> Image::get_image_from_mipmap(int p_mipmap) const {
 	{
 		uint8_t *wr = new_data.ptrw();
 		const uint8_t *rd = data.ptr();
-		memcpy(wr, rd + ofs, size);
+		std::memcpy(wr, rd + ofs, size);
 	}
 
 	Ref<Image> image;
@@ -4296,7 +4296,7 @@ Ref<Resource> Image::duplicate(bool p_subresources) const {
 }
 
 void Image::set_as_black() {
-	memset(data.ptrw(), 0, data.size());
+	std::memset(data.ptrw(), 0, data.size());
 }
 
 void Image::copy_internals_from(const Ref<Image> &p_image) {
@@ -4359,7 +4359,7 @@ Dictionary Image::compute_image_metrics(const Ref<Image> p_compared_image, bool 
 
 	// Histogram approach originally due to Charles Bloom.
 	double hist[256];
-	memset(hist, 0, sizeof(hist));
+	std::memset(hist, 0, sizeof(hist));
 
 	for (uint32_t y = 0; y < h; y++) {
 		for (uint32_t x = 0; x < w; x++) {

--- a/core/io/ip_address.cpp
+++ b/core/io/ip_address.cpp
@@ -34,8 +34,6 @@ IPAddress::operator Variant() const {
 	return operator String();
 }*/
 
-#include <string.h>
-
 IPAddress::operator String() const {
 	if (wildcard) {
 		return "*";
@@ -161,7 +159,7 @@ void IPAddress::_parse_ipv4(const String &p_string, int p_start, uint8_t *p_ret)
 }
 
 void IPAddress::clear() {
-	memset(&field8[0], 0, sizeof(field8));
+	std::memset(&field8[0], 0, sizeof(field8));
 	valid = false;
 	wildcard = false;
 }

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1308,7 +1308,7 @@ static void _encode_string(const String &p_string, uint8_t *&buf, int &r_len) {
 	if (buf) {
 		encode_uint32(utf8.length(), buf);
 		buf += 4;
-		memcpy(buf, utf8.get_data(), utf8.length());
+		std::memcpy(buf, utf8.get_data(), utf8.length());
 		buf += utf8.length();
 	}
 
@@ -1518,7 +1518,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 				if (buf) {
 					encode_uint32(utf8.length(), buf);
 					buf += 4;
-					memcpy(buf, utf8.get_data(), utf8.length());
+					std::memcpy(buf, utf8.get_data(), utf8.length());
 					buf += pad + utf8.length();
 				}
 
@@ -1602,7 +1602,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 				Transform2D val = p_variant;
 				for (int i = 0; i < 3; i++) {
 					for (int j = 0; j < 2; j++) {
-						memcpy(&buf[(i * 2 + j) * sizeof(real_t)], &val.columns[i][j], sizeof(real_t));
+						std::memcpy(&buf[(i * 2 + j) * sizeof(real_t)], &val.columns[i][j], sizeof(real_t));
 					}
 				}
 			}
@@ -1677,7 +1677,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 				Basis val = p_variant;
 				for (int i = 0; i < 3; i++) {
 					for (int j = 0; j < 3; j++) {
-						memcpy(&buf[(i * 3 + j) * sizeof(real_t)], &val.rows[i][j], sizeof(real_t));
+						std::memcpy(&buf[(i * 3 + j) * sizeof(real_t)], &val.rows[i][j], sizeof(real_t));
 					}
 				}
 			}
@@ -1690,7 +1690,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 				Transform3D val = p_variant;
 				for (int i = 0; i < 3; i++) {
 					for (int j = 0; j < 3; j++) {
-						memcpy(&buf[(i * 3 + j) * sizeof(real_t)], &val.basis.rows[i][j], sizeof(real_t));
+						std::memcpy(&buf[(i * 3 + j) * sizeof(real_t)], &val.basis.rows[i][j], sizeof(real_t));
 					}
 				}
 
@@ -1707,7 +1707,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 				Projection val = p_variant;
 				for (int i = 0; i < 4; i++) {
 					for (int j = 0; j < 4; j++) {
-						memcpy(&buf[(i * 4 + j) * sizeof(real_t)], &val.columns[i][j], sizeof(real_t));
+						std::memcpy(&buf[(i * 4 + j) * sizeof(real_t)], &val.columns[i][j], sizeof(real_t));
 					}
 				}
 			}
@@ -1910,7 +1910,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 				buf += 4;
 				const uint8_t *r = data.ptr();
 				if (r) {
-					memcpy(buf, &r[0], datalen * datasize);
+					std::memcpy(buf, &r[0], datalen * datasize);
 					buf += datalen * datasize;
 				}
 			}
@@ -2009,7 +2009,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 				if (buf) {
 					encode_uint32(utf8.length() + 1, buf);
 					buf += 4;
-					memcpy(buf, utf8.get_data(), utf8.length() + 1);
+					std::memcpy(buf, utf8.get_data(), utf8.length() + 1);
 					buf += utf8.length() + 1;
 				}
 
@@ -2133,7 +2133,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 }
 
 Vector<float> vector3_to_float32_array(const Vector3 *vecs, size_t count) {
-	// We always allocate a new array, and we don't `memcpy()`.
+	// We always allocate a new array, and we don't `std::memcpy()`.
 	// We also don't consider returning a pointer to the passed vectors when `sizeof(real_t) == 4`.
 	// One reason is that we could decide to put a 4th component in `Vector3` for SIMD/mobile performance,
 	// which would cause trouble with these optimizations.

--- a/core/io/packed_data_container.cpp
+++ b/core/io/packed_data_container.cpp
@@ -326,7 +326,7 @@ Error PackedDataContainer::pack(const Variant &p_data) {
 	datalen = tmpdata.size();
 	data.resize(tmpdata.size());
 	uint8_t *w = data.ptrw();
-	memcpy(w, tmpdata.ptr(), tmpdata.size());
+	std::memcpy(w, tmpdata.ptr(), tmpdata.size());
 
 	return OK;
 }

--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -165,7 +165,7 @@ void ResourceUID::set_id(ID p_id, const String &p_path) {
 	if (update_ptr == nullptr && cached_ptr == nullptr) {
 		return; // Both are empty strings.
 	}
-	if ((update_ptr == nullptr) != (cached_ptr == nullptr) || strcmp(update_ptr, cached_ptr) != 0) {
+	if ((update_ptr == nullptr) != (cached_ptr == nullptr) || std::strcmp(update_ptr, cached_ptr) != 0) {
 		unique_ids[p_id].cs = cs;
 		unique_ids[p_id].saved_to_cache = false; //changed
 		changed = true;

--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -632,7 +632,7 @@ Error StreamPeerBuffer::put_data(const uint8_t *p_data, int p_bytes) {
 	}
 
 	uint8_t *w = data.ptrw();
-	memcpy(&w[pointer], p_data, p_bytes);
+	std::memcpy(&w[pointer], p_data, p_bytes);
 
 	pointer += p_bytes;
 	return OK;
@@ -670,7 +670,7 @@ Error StreamPeerBuffer::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_
 	}
 
 	const uint8_t *r = data.ptr();
-	memcpy(p_buffer, r + pointer, r_received);
+	std::memcpy(p_buffer, r + pointer, r_received);
 
 	pointer += r_received;
 	// FIXME: return what? OK or ERR_*

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -464,7 +464,7 @@ Error XMLParser::open_buffer(const Vector<uint8_t> &p_buffer) {
 
 	length = p_buffer.size();
 	data_copy = memnew_arr(char, length + 1);
-	memcpy(data_copy, p_buffer.ptr(), length);
+	std::memcpy(data_copy, p_buffer.ptr(), length);
 	data_copy[length] = 0;
 	data = data_copy;
 	P = data;

--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -162,7 +162,7 @@ int zipio_testerror(voidpf opaque, voidpf stream) {
 
 voidpf zipio_alloc(voidpf opaque, uInt items, uInt size) {
 	voidpf ptr = memalloc((size_t)items * size);
-	memset(ptr, 0, items * size);
+	std::memset(ptr, 0, items * size);
 	return ptr;
 }
 

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -137,7 +137,7 @@ public:
 		if (depth > threshold) {
 			if (aux_stack.is_empty()) {
 				aux_stack.resize(ALLOCA_STACK_SIZE * 2);
-				memcpy(aux_stack.ptr(), stack, get_alloca_stacksize());
+				std::memcpy(aux_stack.ptr(), stack, get_alloca_stacksize());
 			} else {
 				aux_stack.resize(aux_stack.size() * 2);
 			}

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -343,7 +343,7 @@ void DynamicBVH::aabb_query(const AABB &p_box, QueryResult &r_result) {
 				if (depth > threshold) {
 					if (aux_stack.is_empty()) {
 						aux_stack.resize(ALLOCA_STACK_SIZE * 2);
-						memcpy(aux_stack.ptr(), alloca_stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
+						std::memcpy(aux_stack.ptr(), alloca_stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
 						alloca_stack = nullptr;
 					} else {
 						aux_stack.resize(aux_stack.size() * 2);
@@ -396,7 +396,7 @@ void DynamicBVH::convex_query(const Plane *p_planes, int p_plane_count, const Ve
 				if (depth > threshold) {
 					if (aux_stack.is_empty()) {
 						aux_stack.resize(ALLOCA_STACK_SIZE * 2);
-						memcpy(aux_stack.ptr(), alloca_stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
+						std::memcpy(aux_stack.ptr(), alloca_stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
 						alloca_stack = nullptr;
 					} else {
 						aux_stack.resize(aux_stack.size() * 2);
@@ -455,7 +455,7 @@ void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResu
 				if (depth > threshold) {
 					if (aux_stack.is_empty()) {
 						aux_stack.resize(ALLOCA_STACK_SIZE * 2);
-						memcpy(aux_stack.ptr(), alloca_stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
+						std::memcpy(aux_stack.ptr(), alloca_stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
 						alloca_stack = nullptr;
 					} else {
 						aux_stack.resize(aux_stack.size() * 2);

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -368,7 +368,7 @@ Vector<Vector<Point2>> Geometry2D::_polypath_offset(const Vector<Point2> &p_poly
 Vector<Vector3i> Geometry2D::partial_pack_rects(const Vector<Vector2i> &p_sizes, const Size2i &p_atlas_size) {
 	Vector<stbrp_node> nodes;
 	nodes.resize(p_atlas_size.width);
-	memset(nodes.ptrw(), 0, sizeof(stbrp_node) * nodes.size());
+	std::memset(nodes.ptrw(), 0, sizeof(stbrp_node) * nodes.size());
 
 	stbrp_context context;
 	stbrp_init_target(&context, p_atlas_size.width, p_atlas_size.height, nodes.ptrw(), p_atlas_size.width);

--- a/core/object/callable_method_pointer.cpp
+++ b/core/object/callable_method_pointer.cpp
@@ -41,7 +41,7 @@ bool CallableCustomMethodPointerBase::compare_equal(const CallableCustom *p_a, c
 	// Avoid sorting by memory address proximity, which leads to unpredictable performance over time
 	// due to the reuse of old addresses for newer objects. Use byte-wise comparison to leverage the
 	// backwards encoding of little-endian systems as a way to decouple spatiality and time.
-	return memcmp(a->comp_ptr, b->comp_ptr, a->comp_size * 4) == 0;
+	return std::memcmp(a->comp_ptr, b->comp_ptr, a->comp_size * 4) == 0;
 }
 
 bool CallableCustomMethodPointerBase::compare_less(const CallableCustom *p_a, const CallableCustom *p_b) {
@@ -53,7 +53,7 @@ bool CallableCustomMethodPointerBase::compare_less(const CallableCustom *p_a, co
 	}
 
 	// See note in compare_equal().
-	return memcmp(a->comp_ptr, b->comp_ptr, a->comp_size * 4) < 0;
+	return std::memcmp(a->comp_ptr, b->comp_ptr, a->comp_size * 4) < 0;
 }
 
 CallableCustom::CompareEqualFunc CallableCustomMethodPointerBase::get_compare_equal_func() const {

--- a/core/object/callable_method_pointer.h
+++ b/core/object/callable_method_pointer.h
@@ -107,7 +107,7 @@ public:
 	}
 
 	CallableCustomMethodPointer(T *p_instance, R (T::*p_method)(P...)) {
-		memset(&data, 0, sizeof(Data)); // Clear beforehand, may have padding bytes.
+		std::memset(&data, 0, sizeof(Data)); // Clear beforehand, may have padding bytes.
 		data.instance = p_instance;
 		data.object_id = p_instance->get_instance_id();
 		data.method = p_method;
@@ -176,7 +176,7 @@ public:
 	}
 
 	CallableCustomMethodPointerC(T *p_instance, R (T::*p_method)(P...) const) {
-		memset(&data, 0, sizeof(Data)); // Clear beforehand, may have padding bytes.
+		std::memset(&data, 0, sizeof(Data)); // Clear beforehand, may have padding bytes.
 		data.instance = p_instance;
 		data.object_id = p_instance->get_instance_id();
 		data.method = p_method;
@@ -249,7 +249,7 @@ public:
 	}
 
 	CallableCustomStaticMethodPointer(R (*p_method)(P...)) {
-		memset(&data, 0, sizeof(Data)); // Clear beforehand, may have padding bytes.
+		std::memset(&data, 0, sizeof(Data)); // Clear beforehand, may have padding bytes.
 		data.method = p_method;
 		_setup((uint32_t *)&data, sizeof(Data));
 	}

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -540,7 +540,7 @@ void WorkerThreadPool::_wait_collaboratively(ThreadData *p_caller_pool_thread, T
 void WorkerThreadPool::_switch_runlevel(Runlevel p_runlevel) {
 	DEV_ASSERT(p_runlevel > runlevel);
 	runlevel = p_runlevel;
-	memset(&runlevel_data, 0, sizeof(runlevel_data));
+	std::memset(&runlevel_data, 0, sizeof(runlevel_data));
 	for (uint32_t i = 0; i < threads.size(); i++) {
 		threads[i].cond_var.notify_one();
 		threads[i].signaled = true;

--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -33,7 +33,6 @@
 #include "core/templates/safe_refcount.h"
 
 #include <stdlib.h>
-#include <string.h>
 
 void *operator new(size_t p_size, const char *p_description) {
 	return Memory::alloc_static(p_size, false);
@@ -82,7 +81,7 @@ void *Memory::realloc_aligned_static(void *p_memory, size_t p_bytes, size_t p_pr
 
 	void *ret = alloc_aligned_static(p_bytes, p_alignment);
 	if (ret) {
-		memcpy(ret, p_memory, p_prev_bytes);
+		std::memcpy(ret, p_memory, p_prev_bytes);
 	}
 	free_aligned_static(p_memory);
 	return ret;

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -33,7 +33,6 @@
 #include "core/error/error_macros.h"
 #include "core/templates/safe_refcount.h"
 
-#include <cstring>
 #include <new> // IWYU pragma: keep // `new` operators.
 #include <type_traits>
 
@@ -202,7 +201,7 @@ _FORCE_INLINE_ void memnew_arr_placement(T *p_start, size_t p_num) {
 		(void)p_num;
 	} else if constexpr (is_zero_constructible_v<T>) {
 		// Can optimize with memset.
-		memset(static_cast<void *>(p_start), 0, p_num * sizeof(T));
+		std::memset(static_cast<void *>(p_start), 0, p_num * sizeof(T));
 	} else {
 		// Need to use a for loop.
 		for (size_t i = 0; i < p_num; i++) {

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -169,7 +169,7 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 	uint8_t *cw = strings.ptrw();
 
 	for (int i = 0; i < compressed.size(); i++) {
-		memcpy(&cw[compressed[i].offset], compressed[i].compressed.get_data(), compressed[i].compressed.size());
+		std::memcpy(&cw[compressed[i].offset], compressed[i].compressed.get_data(), compressed[i].compressed.size());
 	}
 
 	ERR_FAIL_COND(btindex != bucket_table_size);

--- a/core/string/string_buffer.h
+++ b/core/string/string_buffer.h
@@ -92,7 +92,7 @@ StringBuffer<SHORT_BUFFER_SIZE> &StringBuffer<SHORT_BUFFER_SIZE>::append(const S
 
 template <int SHORT_BUFFER_SIZE>
 StringBuffer<SHORT_BUFFER_SIZE> &StringBuffer<SHORT_BUFFER_SIZE>::append(const char *p_str) {
-	int len = strlen(p_str);
+	int len = std::strlen(p_str);
 	reserve(string_length + len + 1);
 
 	char32_t *buf = current_buffer_ptr();
@@ -109,7 +109,7 @@ StringBuffer<SHORT_BUFFER_SIZE> &StringBuffer<SHORT_BUFFER_SIZE>::append(const c
 		++len;
 	}
 	reserve(string_length + len + 1);
-	memcpy(&(current_buffer_ptr()[string_length]), p_str, len * sizeof(char32_t));
+	std::memcpy(&(current_buffer_ptr()[string_length]), p_str, len * sizeof(char32_t));
 	string_length += len;
 
 	return *this;
@@ -125,7 +125,7 @@ StringBuffer<SHORT_BUFFER_SIZE> &StringBuffer<SHORT_BUFFER_SIZE>::reserve(int p_
 	bool need_copy = string_length > 0 && buffer.is_empty();
 	buffer.resize(next_power_of_2(p_size));
 	if (need_copy) {
-		memcpy(buffer.ptrw(), short_buffer, string_length * sizeof(char32_t));
+		std::memcpy(buffer.ptrw(), short_buffer, string_length * sizeof(char32_t));
 	}
 
 	return *this;

--- a/core/string/string_builder.cpp
+++ b/core/string/string_builder.cpp
@@ -30,8 +30,6 @@
 
 #include "string_builder.h"
 
-#include <string.h>
-
 StringBuilder &StringBuilder::append(const String &p_string) {
 	if (p_string.is_empty()) {
 		return *this;
@@ -46,7 +44,7 @@ StringBuilder &StringBuilder::append(const String &p_string) {
 }
 
 StringBuilder &StringBuilder::append(const char *p_cstring) {
-	int32_t len = strlen(p_cstring);
+	int32_t len = std::strlen(p_cstring);
 
 	c_strings.push_back(p_cstring);
 	appended_strings.push_back(len);
@@ -77,7 +75,7 @@ String StringBuilder::as_string() const {
 			// Godot string
 			const String &s = strings[godot_string_elem];
 
-			memcpy(buffer + current_position, s.ptr(), s.length() * sizeof(char32_t));
+			std::memcpy(buffer + current_position, s.ptr(), s.length() * sizeof(char32_t));
 
 			current_position += s.length();
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -43,14 +43,6 @@
 #include "core/variant/variant.h"
 #include "core/version_generated.gen.h"
 
-#ifdef _MSC_VER
-#define _CRT_SECURE_NO_WARNINGS // to disable build-time warning which suggested to use strcpy_s instead strcpy
-#endif
-
-#if defined(MINGW_ENABLED) || defined(_MSC_VER)
-#define snprintf _snprintf_s
-#endif
-
 static const int MAX_DECIMALS = 32;
 
 static _FORCE_INLINE_ char32_t lower_case(char32_t c) {
@@ -223,7 +215,7 @@ void String::append_utf32(const Span<char32_t> &p_cstr) {
 void String::copy_from_unchecked(const char32_t *p_char, const int p_length) {
 	resize(p_length + 1); // + 1 for \0
 	char32_t *dst = ptrw();
-	memcpy(dst, p_char, p_length * sizeof(char32_t));
+	std::memcpy(dst, p_char, p_length * sizeof(char32_t));
 	*(dst + p_length) = _null;
 }
 
@@ -305,7 +297,7 @@ String &String::operator+=(const wchar_t *p_str) {
 }
 
 String &String::operator+=(const char32_t *p_str) {
-	append_utf32(Span(p_str, strlen(p_str)));
+	append_utf32(Span(p_str, std::strlen(p_str)));
 	return *this;
 }
 
@@ -316,7 +308,7 @@ String &String::operator+=(char32_t p_char) {
 
 bool String::operator==(const char *p_str) const {
 	// compare Latin-1 encoded c-string
-	int len = strlen(p_str);
+	int len = std::strlen(p_str);
 
 	if (length() != len) {
 		return false;
@@ -350,7 +342,7 @@ bool String::operator==(const wchar_t *p_str) const {
 }
 
 bool String::operator==(const char32_t *p_str) const {
-	const int len = strlen(p_str);
+	const int len = std::strlen(p_str);
 
 	if (length() != len) {
 		return false;
@@ -359,7 +351,7 @@ bool String::operator==(const char32_t *p_str) const {
 		return true;
 	}
 
-	return memcmp(ptr(), p_str, len * sizeof(char32_t)) == 0;
+	return std::memcmp(ptr(), p_str, len * sizeof(char32_t)) == 0;
 }
 
 bool String::operator==(const String &p_str) const {
@@ -370,7 +362,7 @@ bool String::operator==(const String &p_str) const {
 		return true;
 	}
 
-	return memcmp(ptr(), p_str.ptr(), length() * sizeof(char32_t)) == 0;
+	return std::memcmp(ptr(), p_str.ptr(), length() * sizeof(char32_t)) == 0;
 }
 
 bool String::operator==(const Span<char32_t> &p_str_range) const {
@@ -383,7 +375,7 @@ bool String::operator==(const Span<char32_t> &p_str_range) const {
 		return true;
 	}
 
-	return memcmp(ptr(), p_str_range.ptr(), len * sizeof(char32_t)) == 0;
+	return std::memcmp(ptr(), p_str_range.ptr(), len * sizeof(char32_t)) == 0;
 }
 
 bool operator==(const char *p_chr, const String &p_str) {
@@ -896,7 +888,7 @@ int String::get_slice_count(const char *p_splitter) const {
 
 	int pos = 0;
 	int slices = 1;
-	int splitter_length = strlen(p_splitter);
+	int splitter_length = std::strlen(p_splitter);
 
 	while ((pos = find(p_splitter, pos)) >= 0) {
 		slices++;
@@ -962,7 +954,7 @@ String String::get_slice(const char *p_splitter, int p_slice) const {
 	}
 
 	int i = 0;
-	const int splitter_length = strlen(p_splitter);
+	const int splitter_length = std::strlen(p_splitter);
 	while (true) {
 		pos = find(p_splitter, pos);
 		if (pos == -1) {
@@ -1118,7 +1110,7 @@ Vector<String> String::split(const char *p_splitter, bool p_allow_empty, int p_m
 
 	int from = 0;
 	int len = length();
-	const int splitter_length = strlen(p_splitter);
+	const int splitter_length = std::strlen(p_splitter);
 
 	while (true) {
 		int end;
@@ -1200,7 +1192,7 @@ Vector<String> String::rsplit(const String &p_splitter, bool p_allow_empty, int 
 Vector<String> String::rsplit(const char *p_splitter, bool p_allow_empty, int p_maxsplit) const {
 	Vector<String> ret;
 	const int len = length();
-	const int splitter_length = strlen(p_splitter);
+	const int splitter_length = std::strlen(p_splitter);
 	int remaining_len = len;
 
 	while (true) {
@@ -1377,13 +1369,13 @@ String String::join(const Vector<String> &parts) const {
 		if (first) {
 			first = false;
 		} else if (this_length) {
-			memcpy(ret_ptrw, this_ptr, this_length * sizeof(char32_t));
+			std::memcpy(ret_ptrw, this_ptr, this_length * sizeof(char32_t));
 			ret_ptrw += this_length;
 		}
 
 		const int part_length = part.length();
 		if (part_length) {
-			memcpy(ret_ptrw, part.ptr(), part_length * sizeof(char32_t));
+			std::memcpy(ret_ptrw, part.ptr(), part_length * sizeof(char32_t));
 			ret_ptrw += part_length;
 		}
 	}
@@ -1815,7 +1807,7 @@ Error String::append_utf8(const char *p_utf8, int p_len, bool p_skip_cr) {
 	}
 
 	if (p_len < 0) {
-		p_len = strlen(p_utf8);
+		p_len = std::strlen(p_utf8);
 	}
 
 	const int prev_length = length();
@@ -2926,15 +2918,15 @@ String String::insert(int p_at_pos, const String &p_string) const {
 	const char32_t *this_ptr = ptr();
 
 	if (p_at_pos > 0) {
-		memcpy(ret_ptrw, this_ptr, p_at_pos * sizeof(char32_t));
+		std::memcpy(ret_ptrw, this_ptr, p_at_pos * sizeof(char32_t));
 		ret_ptrw += p_at_pos;
 	}
 
-	memcpy(ret_ptrw, p_string.ptr(), p_string.length() * sizeof(char32_t));
+	std::memcpy(ret_ptrw, p_string.ptr(), p_string.length() * sizeof(char32_t));
 	ret_ptrw += p_string.length();
 
 	if (p_at_pos < length()) {
-		memcpy(ret_ptrw, this_ptr + p_at_pos, (length() - p_at_pos) * sizeof(char32_t));
+		std::memcpy(ret_ptrw, this_ptr + p_at_pos, (length() - p_at_pos) * sizeof(char32_t));
 		ret_ptrw += length() - p_at_pos;
 	}
 
@@ -2989,7 +2981,7 @@ String String::remove_char(char32_t p_char) const {
 	char32_t *new_ptr = new_string.ptrw();
 
 	// Copy part of input before `char`.
-	memcpy(new_ptr, old_ptr, index * sizeof(char32_t));
+	std::memcpy(new_ptr, old_ptr, index * sizeof(char32_t));
 
 	int new_size = index;
 
@@ -3044,7 +3036,7 @@ static String _remove_chars_common(const String &p_this, const T *p_chars, int p
 	char32_t *new_ptr = new_string.ptrw();
 
 	// Copy part of input before `char`.
-	memcpy(new_ptr, old_ptr, index * sizeof(char32_t));
+	std::memcpy(new_ptr, old_ptr, index * sizeof(char32_t));
 
 	int new_size = index;
 
@@ -3070,7 +3062,7 @@ String String::remove_chars(const String &p_chars) const {
 }
 
 String String::remove_chars(const char *p_chars) const {
-	return _remove_chars_common(*this, p_chars, strlen(p_chars));
+	return _remove_chars_common(*this, p_chars, std::strlen(p_chars));
 }
 
 String String::substr(int p_from, int p_chars) const {
@@ -3144,7 +3136,7 @@ int String::find(const char *p_str, int p_from) const {
 		return -1;
 	}
 
-	const int src_len = strlen(p_str);
+	const int src_len = std::strlen(p_str);
 
 	const int len = length();
 
@@ -3303,7 +3295,7 @@ int String::findn(const char *p_str, int p_from) const {
 		return -1;
 	}
 
-	int src_len = strlen(p_str);
+	int src_len = std::strlen(p_str);
 
 	if (src_len == 0 || length() == 0) {
 		return -1; // won't find anything!
@@ -3387,7 +3379,7 @@ int String::rfind(const String &p_str, int p_from) const {
 
 int String::rfind(const char *p_str, int p_from) const {
 	const int source_length = length();
-	int substring_length = strlen(p_str);
+	int substring_length = std::strlen(p_str);
 
 	if (source_length == 0 || substring_length == 0) {
 		return -1; // won't find anything!
@@ -3498,7 +3490,7 @@ int String::rfindn(const String &p_str, int p_from) const {
 
 int String::rfindn(const char *p_str, int p_from) const {
 	const int source_length = length();
-	int substring_length = strlen(p_str);
+	int substring_length = std::strlen(p_str);
 
 	if (source_length == 0 || substring_length == 0) {
 		return -1; // won't find anything!
@@ -3559,7 +3551,7 @@ bool String::ends_with(const String &p_string) const {
 		return true;
 	}
 
-	return memcmp(ptr() + (length() - l), p_string.ptr(), l * sizeof(char32_t)) == 0;
+	return std::memcmp(ptr() + (length() - l), p_string.ptr(), l * sizeof(char32_t)) == 0;
 }
 
 bool String::ends_with(const char *p_string) const {
@@ -3567,7 +3559,7 @@ bool String::ends_with(const char *p_string) const {
 		return false;
 	}
 
-	int l = strlen(p_string);
+	int l = std::strlen(p_string);
 	if (l > length()) {
 		return false;
 	}
@@ -3596,7 +3588,7 @@ bool String::begins_with(const String &p_string) const {
 		return true;
 	}
 
-	return memcmp(ptr(), p_string.ptr(), l * sizeof(char32_t)) == 0;
+	return std::memcmp(ptr(), p_string.ptr(), l * sizeof(char32_t)) == 0;
 }
 
 bool String::begins_with(const char *p_string) const {
@@ -3683,7 +3675,7 @@ int String::_count(const String &p_string, int p_from, int p_to, bool p_case_ins
 }
 
 int String::_count(const char *p_string, int p_from, int p_to, bool p_case_insensitive) const {
-	int substring_length = strlen(p_string);
+	int substring_length = std::strlen(p_string);
 	if (substring_length == 0) {
 		return 0;
 	}
@@ -3936,18 +3928,18 @@ static String _replace_common(const String &p_this, const String &p_key, const S
 
 	for (const int &pos : found) {
 		if (last_pos != pos) {
-			memcpy(new_ptrw, old_ptr + last_pos, (pos - last_pos) * sizeof(char32_t));
+			std::memcpy(new_ptrw, old_ptr + last_pos, (pos - last_pos) * sizeof(char32_t));
 			new_ptrw += (pos - last_pos);
 		}
 		if (with_length) {
-			memcpy(new_ptrw, with_ptr, with_length * sizeof(char32_t));
+			std::memcpy(new_ptrw, with_ptr, with_length * sizeof(char32_t));
 			new_ptrw += with_length;
 		}
 		last_pos = pos + key_length;
 	}
 
 	if (last_pos != old_length) {
-		memcpy(new_ptrw, old_ptr + last_pos, (old_length - last_pos) * sizeof(char32_t));
+		std::memcpy(new_ptrw, old_ptr + last_pos, (old_length - last_pos) * sizeof(char32_t));
 		new_ptrw += old_length - last_pos;
 	}
 
@@ -3957,7 +3949,7 @@ static String _replace_common(const String &p_this, const String &p_key, const S
 }
 
 static String _replace_common(const String &p_this, char const *p_key, char const *p_with, bool p_case_insensitive) {
-	size_t key_length = strlen(p_key);
+	size_t key_length = std::strlen(p_key);
 
 	if (key_length == 0 || p_this.is_empty()) {
 		return p_this;
@@ -3995,18 +3987,18 @@ static String _replace_common(const String &p_this, char const *p_key, char cons
 
 	for (const int &pos : found) {
 		if (last_pos != pos) {
-			memcpy(new_ptrw, old_ptr + last_pos, (pos - last_pos) * sizeof(char32_t));
+			std::memcpy(new_ptrw, old_ptr + last_pos, (pos - last_pos) * sizeof(char32_t));
 			new_ptrw += (pos - last_pos);
 		}
 		if (with_length) {
-			memcpy(new_ptrw, with_ptr, with_length * sizeof(char32_t));
+			std::memcpy(new_ptrw, with_ptr, with_length * sizeof(char32_t));
 			new_ptrw += with_length;
 		}
 		last_pos = pos + key_length;
 	}
 
 	if (last_pos != old_length) {
-		memcpy(new_ptrw, old_ptr + last_pos, (old_length - last_pos) * sizeof(char32_t));
+		std::memcpy(new_ptrw, old_ptr + last_pos, (old_length - last_pos) * sizeof(char32_t));
 		new_ptrw += old_length - last_pos;
 	}
 
@@ -4038,18 +4030,18 @@ String String::replace_first(const String &p_key, const String &p_with) const {
 		const char32_t *with_ptr = p_with.ptr();
 
 		if (pos > 0) {
-			memcpy(new_ptrw, old_ptr, pos * sizeof(char32_t));
+			std::memcpy(new_ptrw, old_ptr, pos * sizeof(char32_t));
 			new_ptrw += pos;
 		}
 
 		if (with_length) {
-			memcpy(new_ptrw, with_ptr, with_length * sizeof(char32_t));
+			std::memcpy(new_ptrw, with_ptr, with_length * sizeof(char32_t));
 			new_ptrw += with_length;
 		}
 		pos += key_length;
 
 		if (pos != old_length) {
-			memcpy(new_ptrw, old_ptr + pos, (old_length - pos) * sizeof(char32_t));
+			std::memcpy(new_ptrw, old_ptr + pos, (old_length - pos) * sizeof(char32_t));
 			new_ptrw += (old_length - pos);
 		}
 
@@ -4065,8 +4057,8 @@ String String::replace_first(const char *p_key, const char *p_with) const {
 	int pos = find(p_key);
 	if (pos >= 0) {
 		const int old_length = length();
-		const int key_length = strlen(p_key);
-		const int with_length = strlen(p_with);
+		const int key_length = std::strlen(p_key);
+		const int with_length = std::strlen(p_with);
 
 		String new_string;
 		new_string.resize(old_length + (with_length - key_length) + 1);
@@ -4075,7 +4067,7 @@ String String::replace_first(const char *p_key, const char *p_with) const {
 		const char32_t *old_ptr = ptr();
 
 		if (pos > 0) {
-			memcpy(new_ptrw, old_ptr, pos * sizeof(char32_t));
+			std::memcpy(new_ptrw, old_ptr, pos * sizeof(char32_t));
 			new_ptrw += pos;
 		}
 
@@ -4085,7 +4077,7 @@ String String::replace_first(const char *p_key, const char *p_with) const {
 		pos += key_length;
 
 		if (pos != old_length) {
-			memcpy(new_ptrw, old_ptr + pos, (old_length - pos) * sizeof(char32_t));
+			std::memcpy(new_ptrw, old_ptr + pos, (old_length - pos) * sizeof(char32_t));
 			new_ptrw += (old_length - pos);
 		}
 
@@ -4128,7 +4120,7 @@ String String::replace_char(char32_t p_key, char32_t p_with) const {
 	char32_t *new_ptr = new_string.ptrw();
 
 	// Copy part of input before `key`.
-	memcpy(new_ptr, old_ptr, index * sizeof(char32_t));
+	std::memcpy(new_ptr, old_ptr, index * sizeof(char32_t));
 
 	new_ptr[index] = p_with;
 
@@ -4181,7 +4173,7 @@ static String _replace_chars_common(const String &p_this, const T *p_keys, int p
 	char32_t *new_ptr = new_string.ptrw();
 
 	// Copy part of input before `key`.
-	memcpy(new_ptr, old_ptr, index * sizeof(char32_t));
+	std::memcpy(new_ptr, old_ptr, index * sizeof(char32_t));
 
 	new_ptr[index] = p_with;
 
@@ -4205,7 +4197,7 @@ String String::replace_chars(const String &p_keys, char32_t p_with) const {
 }
 
 String String::replace_chars(const char *p_keys, char32_t p_with) const {
-	return _replace_chars_common(*this, p_keys, strlen(p_keys), p_with);
+	return _replace_chars_common(*this, p_keys, std::strlen(p_keys), p_with);
 }
 
 String String::replacen(const String &p_key, const String &p_with) const {
@@ -4235,7 +4227,7 @@ String String::repeat(int p_count) const {
 	int offset = 1;
 	int stride = 1;
 	while (offset < p_count) {
-		memcpy(dst + offset * len, dst, stride * len * sizeof(char32_t));
+		std::memcpy(dst + offset * len, dst, stride * len * sizeof(char32_t));
 		offset += stride;
 		stride = MIN(stride * 2, p_count - offset);
 	}
@@ -5011,7 +5003,7 @@ String String::trim_prefix(const String &p_prefix) const {
 String String::trim_prefix(const char *p_prefix) const {
 	String s = *this;
 	if (s.begins_with(p_prefix)) {
-		int prefix_length = strlen(p_prefix);
+		int prefix_length = std::strlen(p_prefix);
 		return s.substr(prefix_length);
 	}
 	return s;
@@ -5028,7 +5020,7 @@ String String::trim_suffix(const String &p_suffix) const {
 String String::trim_suffix(const char *p_suffix) const {
 	String s = *this;
 	if (s.ends_with(p_suffix)) {
-		return s.substr(0, s.length() - strlen(p_suffix));
+		return s.substr(0, s.length() - std::strlen(p_suffix));
 	}
 	return s;
 }
@@ -5915,7 +5907,7 @@ Vector<uint8_t> String::to_ascii_buffer() const {
 	size_t len = charstr.length();
 	retval.resize(len);
 	uint8_t *w = retval.ptrw();
-	memcpy(w, charstr.ptr(), len);
+	std::memcpy(w, charstr.ptr(), len);
 
 	return retval;
 }
@@ -5931,7 +5923,7 @@ Vector<uint8_t> String::to_utf8_buffer() const {
 	size_t len = charstr.length();
 	retval.resize(len);
 	uint8_t *w = retval.ptrw();
-	memcpy(w, charstr.ptr(), len);
+	std::memcpy(w, charstr.ptr(), len);
 
 	return retval;
 }
@@ -5947,7 +5939,7 @@ Vector<uint8_t> String::to_utf16_buffer() const {
 	size_t len = charstr.length() * sizeof(char16_t);
 	retval.resize(len);
 	uint8_t *w = retval.ptrw();
-	memcpy(w, (const void *)charstr.ptr(), len);
+	std::memcpy(w, (const void *)charstr.ptr(), len);
 
 	return retval;
 }
@@ -5962,7 +5954,7 @@ Vector<uint8_t> String::to_utf32_buffer() const {
 	size_t len = s->length() * sizeof(char32_t);
 	retval.resize(len);
 	uint8_t *w = retval.ptrw();
-	memcpy(w, (const void *)s->ptr(), len);
+	std::memcpy(w, (const void *)s->ptr(), len);
 
 	return retval;
 }

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -46,6 +46,8 @@ class CharStringT;
 /*  Utility Functions                                                    */
 /*************************************************************************/
 
+namespace std {
+
 // Not defined by std.
 // strlen equivalent function for char16_t * arguments.
 constexpr size_t strlen(const char16_t *p_str) {
@@ -66,20 +68,22 @@ constexpr size_t strlen(const char32_t *p_str) {
 }
 
 // strlen equivalent function for wchar_t * arguments; depends on the platform.
-constexpr size_t strlen(const wchar_t *str) {
+constexpr size_t strlen(const wchar_t *p_str) {
 	// Use static_cast twice because reinterpret_cast is not allowed in constexpr
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit
-	return strlen(static_cast<const char16_t *>(static_cast<const void *>(str)));
+	return strlen(static_cast<const char16_t *>(static_cast<const void *>(p_str)));
 #else
 	// wchar_t is 32-bit
-	return strlen(static_cast<const char32_t *>(static_cast<const void *>(str)));
+	return strlen(static_cast<const char32_t *>(static_cast<const void *>(p_str)));
 #endif
 }
 
+} //namespace std
+
 constexpr size_t _strlen_clipped(const char *p_str, int p_clip_to_len) {
 	if (p_clip_to_len < 0) {
-		return strlen(p_str);
+		return std::strlen(p_str);
 	}
 
 	int len = 0;
@@ -91,7 +95,7 @@ constexpr size_t _strlen_clipped(const char *p_str, int p_clip_to_len) {
 
 constexpr size_t _strlen_clipped(const char32_t *p_str, int p_clip_to_len) {
 	if (p_clip_to_len < 0) {
-		return strlen(p_str);
+		return std::strlen(p_str);
 	}
 
 	int len = 0;
@@ -200,7 +204,7 @@ public:
 		if (length() != p_other.length()) {
 			return false;
 		}
-		return memcmp(ptr(), p_other.ptr(), length() * sizeof(T)) == 0;
+		return std::memcmp(ptr(), p_other.ptr(), length() * sizeof(T)) == 0;
 	}
 	_FORCE_INLINE_ bool operator!=(const CharStringT<T> &p_other) const { return !(*this == p_other); }
 	_FORCE_INLINE_ bool operator<(const CharStringT<T> &p_other) const {
@@ -235,7 +239,7 @@ protected:
 			return;
 		}
 
-		size_t len = strlen(p_cstr);
+		size_t len = std::strlen(p_cstr);
 		if (len == 0) {
 			resize(0);
 			return;
@@ -245,7 +249,7 @@ protected:
 
 		ERR_FAIL_COND_MSG(err != OK, "Failed to copy C-string.");
 
-		memcpy(ptrw(), p_cstr, len * sizeof(T));
+		std::memcpy(ptrw(), p_cstr, len * sizeof(T));
 	}
 };
 
@@ -269,10 +273,10 @@ class String {
 
 	// NULL-terminated c string copy - automatically parse the string to find the length.
 	void append_latin1(const char *p_cstr) {
-		append_latin1(Span(p_cstr, p_cstr ? strlen(p_cstr) : 0));
+		append_latin1(Span(p_cstr, p_cstr ? std::strlen(p_cstr) : 0));
 	}
 	void append_utf32(const char32_t *p_cstr) {
-		append_utf32(Span(p_cstr, p_cstr ? strlen(p_cstr) : 0));
+		append_utf32(Span(p_cstr, p_cstr ? std::strlen(p_cstr) : 0));
 	}
 
 	// wchar_t copy_from depends on the platform.

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -88,7 +88,7 @@ public:
 	// Must be a power of two.
 	static constexpr uint32_t INITIAL_CAPACITY = 16;
 	static constexpr uint32_t EMPTY_HASH = 0;
-	static_assert(EMPTY_HASH == 0, "EMPTY_HASH must always be 0 for the memcpy() optimization.");
+	static_assert(EMPTY_HASH == 0, "EMPTY_HASH must always be 0 for the std::memcpy() optimization.");
 
 private:
 	typedef KeyValue<TKey, TValue> MapKeyValue;
@@ -217,7 +217,7 @@ private:
 		map_data = reinterpret_cast<HashMapData *>(Memory::alloc_static(sizeof(HashMapData) * real_capacity));
 		elements = reinterpret_cast<MapKeyValue *>(Memory::realloc_static(elements, sizeof(MapKeyValue) * (_get_resize_count(capacity) + 1)));
 
-		memset(map_data, EMPTY_HASH, real_capacity * sizeof(HashMapData));
+		std::memset(map_data, EMPTY_HASH, real_capacity * sizeof(HashMapData));
 
 		if (num_elements != 0) {
 			for (uint32_t i = 0; i < real_old_capacity; i++) {
@@ -239,7 +239,7 @@ private:
 			map_data = reinterpret_cast<HashMapData *>(Memory::alloc_static(sizeof(HashMapData) * real_capacity));
 			elements = reinterpret_cast<MapKeyValue *>(Memory::alloc_static(sizeof(MapKeyValue) * (_get_resize_count(capacity) + 1)));
 
-			memset(map_data, EMPTY_HASH, real_capacity * sizeof(HashMapData));
+			std::memset(map_data, EMPTY_HASH, real_capacity * sizeof(HashMapData));
 		}
 
 		if (unlikely(num_elements > _get_resize_count(capacity))) {
@@ -268,14 +268,14 @@ private:
 		if constexpr (std::is_trivially_copyable_v<TKey> && std::is_trivially_copyable_v<TValue>) {
 			void *destination = elements;
 			const void *source = p_other.elements;
-			memcpy(destination, source, sizeof(MapKeyValue) * num_elements);
+			std::memcpy(destination, source, sizeof(MapKeyValue) * num_elements);
 		} else {
 			for (uint32_t i = 0; i < num_elements; i++) {
 				memnew_placement(&elements[i], MapKeyValue(p_other.elements[i]));
 			}
 		}
 
-		memcpy(map_data, p_other.map_data, sizeof(HashMapData) * real_capacity);
+		std::memcpy(map_data, p_other.map_data, sizeof(HashMapData) * real_capacity);
 	}
 
 public:
@@ -293,7 +293,7 @@ public:
 			return;
 		}
 
-		memset(map_data, EMPTY_HASH, (capacity + 1) * sizeof(HashMapData));
+		std::memset(map_data, EMPTY_HASH, (capacity + 1) * sizeof(HashMapData));
 		if constexpr (!(std::is_trivially_destructible_v<TKey> && std::is_trivially_destructible_v<TValue>)) {
 			for (uint32_t i = 0; i < num_elements; i++) {
 				elements[i].key.~TKey();
@@ -373,7 +373,7 @@ public:
 		if (element_pos < num_elements) {
 			void *destination = &elements[element_pos];
 			const void *source = &elements[num_elements];
-			memcpy(destination, source, sizeof(MapKeyValue));
+			std::memcpy(destination, source, sizeof(MapKeyValue));
 			uint32_t h_pos = 0;
 			_lookup_pos(elements[num_elements].key, pos, h_pos);
 			map_data[h_pos].hash_to_key = element_pos;

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -35,7 +35,6 @@
 #include "core/templates/safe_refcount.h"
 #include "core/templates/span.h"
 
-#include <string.h>
 #include <initializer_list>
 #include <type_traits>
 
@@ -300,7 +299,7 @@ typename CowData<T>::USize CowData<T>::_copy_on_write() {
 
 		// initialize new elements
 		if constexpr (std::is_trivially_copyable_v<T>) {
-			memcpy((uint8_t *)_data_ptr, _ptr, current_size * sizeof(T));
+			std::memcpy((uint8_t *)_data_ptr, _ptr, current_size * sizeof(T));
 		} else {
 			for (USize i = 0; i < current_size; i++) {
 				memnew_placement(&_data_ptr[i], T(_ptr[i]));

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -309,7 +309,7 @@ public:
 		T *w = ret.ptrw();
 		if (w) {
 			if constexpr (std::is_trivially_copyable_v<T>) {
-				memcpy(w, data, sizeof(T) * count);
+				std::memcpy(w, data, sizeof(T) * count);
 			} else {
 				for (U i = 0; i < count; i++) {
 					w[i] = data[i];
@@ -324,7 +324,7 @@ public:
 		ret.resize(count * sizeof(T));
 		uint8_t *w = ret.ptrw();
 		if (w) {
-			memcpy(w, data, sizeof(T) * count);
+			std::memcpy(w, data, sizeof(T) * count);
 		}
 		return ret;
 	}

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -181,7 +181,7 @@ public:
 		size_t alloc_size = size() * sizeof(T);
 		ret.resize(alloc_size);
 		if (alloc_size) {
-			memcpy(ret.ptrw(), ptr(), alloc_size);
+			std::memcpy(ret.ptrw(), ptr(), alloc_size);
 		}
 		return ret;
 	}

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -50,6 +50,7 @@ static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <utility>
 
 // IWYU pragma: end_exports

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -686,7 +686,7 @@ struct _VariantCall {
 			const uint8_t *r = p_instance->ptr();
 			CharString cs;
 			cs.resize(p_instance->size() + 1);
-			memcpy(cs.ptrw(), r, p_instance->size());
+			std::memcpy(cs.ptrw(), r, p_instance->size());
 			cs[(int)p_instance->size()] = 0;
 
 			s = cs.get_data();
@@ -966,7 +966,7 @@ struct _VariantCall {
 		const uint8_t *r = p_instance->ptr();
 		dest.resize(size / sizeof(int32_t));
 		ERR_FAIL_COND_V(dest.is_empty(), dest); // Avoid UB in case resize failed.
-		memcpy(dest.ptrw(), r, dest.size() * sizeof(int32_t));
+		std::memcpy(dest.ptrw(), r, dest.size() * sizeof(int32_t));
 		return dest;
 	}
 
@@ -980,7 +980,7 @@ struct _VariantCall {
 		const uint8_t *r = p_instance->ptr();
 		dest.resize(size / sizeof(int64_t));
 		ERR_FAIL_COND_V(dest.is_empty(), dest); // Avoid UB in case resize failed.
-		memcpy(dest.ptrw(), r, dest.size() * sizeof(int64_t));
+		std::memcpy(dest.ptrw(), r, dest.size() * sizeof(int64_t));
 		return dest;
 	}
 
@@ -994,7 +994,7 @@ struct _VariantCall {
 		const uint8_t *r = p_instance->ptr();
 		dest.resize(size / sizeof(float));
 		ERR_FAIL_COND_V(dest.is_empty(), dest); // Avoid UB in case resize failed.
-		memcpy(dest.ptrw(), r, dest.size() * sizeof(float));
+		std::memcpy(dest.ptrw(), r, dest.size() * sizeof(float));
 		return dest;
 	}
 
@@ -1008,7 +1008,7 @@ struct _VariantCall {
 		const uint8_t *r = p_instance->ptr();
 		dest.resize(size / sizeof(double));
 		ERR_FAIL_COND_V(dest.is_empty(), dest); // Avoid UB in case resize failed.
-		memcpy(dest.ptrw(), r, dest.size() * sizeof(double));
+		std::memcpy(dest.ptrw(), r, dest.size() * sizeof(double));
 		return dest;
 	}
 

--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -246,10 +246,10 @@ public:
 		((void)0)
 
 void Variant::_register_variant_operators() {
-	memset(operator_return_type_table, 0, sizeof(operator_return_type_table));
-	memset(operator_evaluator_table, 0, sizeof(operator_evaluator_table));
-	memset(validated_operator_evaluator_table, 0, sizeof(validated_operator_evaluator_table));
-	memset(ptr_operator_evaluator_table, 0, sizeof(ptr_operator_evaluator_table));
+	std::memset(operator_return_type_table, 0, sizeof(operator_return_type_table));
+	std::memset(operator_evaluator_table, 0, sizeof(operator_evaluator_table));
+	std::memset(validated_operator_evaluator_table, 0, sizeof(validated_operator_evaluator_table));
+	std::memset(ptr_operator_evaluator_table, 0, sizeof(ptr_operator_evaluator_table));
 
 	register_op<OperatorEvaluatorAdd<int64_t, int64_t, int64_t>>(Variant::OP_ADD, Variant::INT, Variant::INT);
 	register_op<OperatorEvaluatorAdd<double, int64_t, double>>(Variant::OP_ADD, Variant::INT, Variant::FLOAT);

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -103,7 +103,7 @@ uint32_t VariantParser::StreamString::_read_buffer(char32_t *p_buffer, uint32_t 
 	if (available >= (int)p_num_chars) {
 		const char32_t *src = s.ptr();
 		src += pos;
-		memcpy(p_buffer, src, p_num_chars * sizeof(char32_t));
+		std::memcpy(p_buffer, src, p_num_chars * sizeof(char32_t));
 		pos += p_num_chars;
 
 		return p_num_chars;
@@ -113,7 +113,7 @@ uint32_t VariantParser::StreamString::_read_buffer(char32_t *p_buffer, uint32_t 
 	if (available) {
 		const char32_t *src = s.ptr();
 		src += pos;
-		memcpy(p_buffer, src, available * sizeof(char32_t));
+		std::memcpy(p_buffer, src, available * sizeof(char32_t));
 		pos += available;
 	}
 

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -292,7 +292,7 @@ PackedStringArray AudioDriverALSA::get_output_device_list() {
 		char *name = snd_device_name_get_hint(*n, "NAME");
 		char *desc = snd_device_name_get_hint(*n, "DESC");
 
-		if (name != nullptr && !strncmp(name, "plughw", 6)) {
+		if (name != nullptr && !std::strncmp(name, "plughw", 6)) {
 			if (desc) {
 				list.push_back(String::utf8(name) + ";" + String::utf8(desc));
 			} else {

--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -75,7 +75,7 @@ OSStatus AudioDriverCoreAudio::output_device_address_cb(AudioObjectID inObjectID
 
 Error AudioDriverCoreAudio::init() {
 	AudioComponentDescription desc;
-	memset(&desc, 0, sizeof(desc));
+	std::memset(&desc, 0, sizeof(desc));
 	desc.componentType = kAudioUnitType_Output;
 #ifdef MACOS_ENABLED
 	desc.componentSubType = kAudioUnitSubType_HALOutput;
@@ -102,7 +102,7 @@ Error AudioDriverCoreAudio::init() {
 
 	AudioStreamBasicDescription strdesc;
 
-	memset(&strdesc, 0, sizeof(strdesc));
+	std::memset(&strdesc, 0, sizeof(strdesc));
 	UInt32 size = sizeof(strdesc);
 	result = AudioUnitGetProperty(audio_unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, kOutputBus, &strdesc, &size);
 	ERR_FAIL_COND_V(result != noErr, FAILED);
@@ -140,7 +140,7 @@ Error AudioDriverCoreAudio::init() {
 #endif
 	mix_rate = hw_mix_rate;
 
-	memset(&strdesc, 0, sizeof(strdesc));
+	std::memset(&strdesc, 0, sizeof(strdesc));
 	strdesc.mFormatID = kAudioFormatLinearPCM;
 	strdesc.mFormatFlags = kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked;
 	strdesc.mChannelsPerFrame = channels;
@@ -170,7 +170,7 @@ Error AudioDriverCoreAudio::init() {
 	print_verbose("CoreAudio: output audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
 
 	AURenderCallbackStruct callback;
-	memset(&callback, 0, sizeof(AURenderCallbackStruct));
+	std::memset(&callback, 0, sizeof(AURenderCallbackStruct));
 	callback.inputProc = &AudioDriverCoreAudio::output_callback;
 	callback.inputProcRefCon = this;
 	result = AudioUnitSetProperty(audio_unit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, kOutputBus, &callback, sizeof(callback));
@@ -195,7 +195,7 @@ OSStatus AudioDriverCoreAudio::output_callback(void *inRefCon,
 	if (!ad->active || !ad->try_lock()) {
 		for (unsigned int i = 0; i < ioData->mNumberBuffers; i++) {
 			AudioBuffer *abuf = &ioData->mBuffers[i];
-			memset(abuf->mData, 0, abuf->mDataByteSize);
+			std::memset(abuf->mData, 0, abuf->mDataByteSize);
 		}
 		return 0;
 	}
@@ -321,7 +321,7 @@ void AudioDriverCoreAudio::finish() {
 		lock();
 
 		AURenderCallbackStruct callback;
-		memset(&callback, 0, sizeof(AURenderCallbackStruct));
+		std::memset(&callback, 0, sizeof(AURenderCallbackStruct));
 		result = AudioUnitSetProperty(audio_unit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, kOutputBus, &callback, sizeof(callback));
 		if (result != noErr) {
 			ERR_PRINT("AudioUnitSetProperty failed");
@@ -365,7 +365,7 @@ void AudioDriverCoreAudio::finish() {
 
 Error AudioDriverCoreAudio::init_input_device() {
 	AudioComponentDescription desc;
-	memset(&desc, 0, sizeof(desc));
+	std::memset(&desc, 0, sizeof(desc));
 	desc.componentType = kAudioUnitType_Output;
 #ifdef MACOS_ENABLED
 	desc.componentSubType = kAudioUnitSubType_HALOutput;
@@ -411,7 +411,7 @@ Error AudioDriverCoreAudio::init_input_device() {
 #endif
 
 	AudioStreamBasicDescription strdesc;
-	memset(&strdesc, 0, sizeof(strdesc));
+	std::memset(&strdesc, 0, sizeof(strdesc));
 	size = sizeof(strdesc);
 	result = AudioUnitGetProperty(input_unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, kInputBus, &strdesc, &size);
 	ERR_FAIL_COND_V(result != noErr, FAILED);
@@ -443,7 +443,7 @@ Error AudioDriverCoreAudio::init_input_device() {
 #endif
 	capture_mix_rate = hw_mix_rate;
 
-	memset(&strdesc, 0, sizeof(strdesc));
+	std::memset(&strdesc, 0, sizeof(strdesc));
 	strdesc.mFormatID = kAudioFormatLinearPCM;
 	strdesc.mFormatFlags = kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked;
 	strdesc.mChannelsPerFrame = capture_channels;
@@ -464,7 +464,7 @@ Error AudioDriverCoreAudio::init_input_device() {
 	input_buf.resize(buffer_size);
 
 	AURenderCallbackStruct callback;
-	memset(&callback, 0, sizeof(AURenderCallbackStruct));
+	std::memset(&callback, 0, sizeof(AURenderCallbackStruct));
 	callback.inputProc = &AudioDriverCoreAudio::input_callback;
 	callback.inputProcRefCon = this;
 	result = AudioUnitSetProperty(input_unit, kAudioOutputUnitProperty_SetInputCallback, kAudioUnitScope_Global, kInputBus, &callback, sizeof(callback));
@@ -484,7 +484,7 @@ void AudioDriverCoreAudio::finish_input_device() {
 		lock();
 
 		AURenderCallbackStruct callback;
-		memset(&callback, 0, sizeof(AURenderCallbackStruct));
+		std::memset(&callback, 0, sizeof(AURenderCallbackStruct));
 		OSStatus result = AudioUnitSetProperty(input_unit, kAudioOutputUnitProperty_SetInputCallback, kAudioUnitScope_Global, 0, &callback, sizeof(callback));
 		if (result != noErr) {
 			ERR_PRINT("AudioUnitSetProperty failed");

--- a/drivers/d3d12/dxil_hash.cpp
+++ b/drivers/d3d12/dxil_hash.cpp
@@ -33,7 +33,7 @@
 
 #include "dxil_hash.h"
 
-#include <memory.h>
+#include "core/typedefs.h"
 
 #define S11 7
 #define S12 12
@@ -102,18 +102,18 @@ void compute_dxil_hash(const BYTE *pData, UINT byteCount, BYTE *pOutHash) {
 			if (!bTwoRowsPadding && i == N - 1) {
 				UINT remainder = byteCount - offset;
 				x[0] = byteCount << 3;
-				memcpy((BYTE *)x + 4, pCurrData, remainder);
-				memcpy((BYTE *)x + 4 + remainder, padding, padAmount);
+				std::memcpy((BYTE *)x + 4, pCurrData, remainder);
+				std::memcpy((BYTE *)x + 4 + remainder, padding, padAmount);
 				x[15] = 1 | (byteCount << 1);
 			} else if (bTwoRowsPadding) {
 				if (i == N - 2) {
 					UINT remainder = byteCount - offset;
-					memcpy(x, pCurrData, remainder);
-					memcpy((BYTE *)x + remainder, padding, padAmount - 56);
+					std::memcpy(x, pCurrData, remainder);
+					std::memcpy((BYTE *)x + remainder, padding, padAmount - 56);
 					NextEndState = N - 1;
 				} else if (i == N - 1) {
 					x[0] = byteCount << 3;
-					memcpy((BYTE *)x + 4, padding + padAmount - 56, 56);
+					std::memcpy((BYTE *)x + 4, padding + padAmount - 56, 56);
 					x[15] = 1 | (byteCount << 1);
 				}
 			}
@@ -205,5 +205,5 @@ void compute_dxil_hash(const BYTE *pData, UINT byteCount, BYTE *pOutHash) {
 		state[3] += d;
 	}
 
-	memcpy(pOutHash, state, 16);
+	std::memcpy(pOutHash, state, 16);
 }

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -3424,7 +3424,7 @@ Vector<uint8_t> RenderingDeviceDriverD3D12::shader_compile_binary_from_spirv(Vec
 
 			Vector<uint8_t> blob_copy;
 			blob_copy.resize(dxil_blob.size);
-			memcpy(blob_copy.ptrw(), dxil_blob.data, dxil_blob.size);
+			std::memcpy(blob_copy.ptrw(), dxil_blob.data, dxil_blob.size);
 			blob_finish(&dxil_blob);
 			dxil_blobs.insert(stage, blob_copy);
 		}
@@ -3705,19 +3705,19 @@ Vector<uint8_t> RenderingDeviceDriverD3D12::shader_compile_binary_from_spirv(Vec
 		offset += sizeof(uint32_t);
 		encode_uint32(sizeof(ShaderBinary::Data), binptr + offset);
 		offset += sizeof(uint32_t);
-		memcpy(binptr + offset, &binary_data, sizeof(ShaderBinary::Data));
+		std::memcpy(binptr + offset, &binary_data, sizeof(ShaderBinary::Data));
 		offset += sizeof(ShaderBinary::Data);
 
-#define ADVANCE_OFFSET_WITH_ALIGNMENT(m_bytes)                         \
-	{                                                                  \
-		offset += m_bytes;                                             \
-		uint32_t padding = STEPIFY(m_bytes, 4) - m_bytes;              \
-		memset(binptr + offset, 0, padding); /* Avoid garbage data. */ \
-		offset += padding;                                             \
+#define ADVANCE_OFFSET_WITH_ALIGNMENT(m_bytes)                              \
+	{                                                                       \
+		offset += m_bytes;                                                  \
+		uint32_t padding = STEPIFY(m_bytes, 4) - m_bytes;                   \
+		std::memset(binptr + offset, 0, padding); /* Avoid garbage data. */ \
+		offset += padding;                                                  \
 	}
 
 		if (binary_data.shader_name_len > 0) {
-			memcpy(binptr + offset, shader_name_utf.ptr(), binary_data.shader_name_len);
+			std::memcpy(binptr + offset, shader_name_utf.ptr(), binary_data.shader_name_len);
 			ADVANCE_OFFSET_WITH_ALIGNMENT(binary_data.shader_name_len);
 		}
 
@@ -3726,13 +3726,13 @@ Vector<uint8_t> RenderingDeviceDriverD3D12::shader_compile_binary_from_spirv(Vec
 			encode_uint32(count, binptr + offset);
 			offset += sizeof(uint32_t);
 			if (count > 0) {
-				memcpy(binptr + offset, sets_bindings[i].ptr(), sizeof(ShaderBinary::DataBinding) * count);
+				std::memcpy(binptr + offset, sets_bindings[i].ptr(), sizeof(ShaderBinary::DataBinding) * count);
 				offset += sizeof(ShaderBinary::DataBinding) * count;
 			}
 		}
 
 		if (specialization_constants.size()) {
-			memcpy(binptr + offset, specialization_constants.ptr(), sizeof(ShaderBinary::SpecializationConstant) * specialization_constants.size());
+			std::memcpy(binptr + offset, specialization_constants.ptr(), sizeof(ShaderBinary::SpecializationConstant) * specialization_constants.size());
 			offset += sizeof(ShaderBinary::SpecializationConstant) * specialization_constants.size();
 		}
 
@@ -3743,11 +3743,11 @@ Vector<uint8_t> RenderingDeviceDriverD3D12::shader_compile_binary_from_spirv(Vec
 			offset += sizeof(uint32_t);
 			encode_uint32(zstd_size[i], binptr + offset);
 			offset += sizeof(uint32_t);
-			memcpy(binptr + offset, compressed_stages[i].ptr(), compressed_stages[i].size());
+			std::memcpy(binptr + offset, compressed_stages[i].ptr(), compressed_stages[i].size());
 			ADVANCE_OFFSET_WITH_ALIGNMENT(compressed_stages[i].size());
 		}
 
-		memcpy(binptr + offset, root_sig_blob->GetBufferPointer(), root_sig_blob->GetBufferSize());
+		std::memcpy(binptr + offset, root_sig_blob->GetBufferPointer(), root_sig_blob->GetBufferSize());
 		offset += root_sig_blob->GetBufferSize();
 
 		ERR_FAIL_COND_V(offset != (uint32_t)ret.size(), Vector<uint8_t>());
@@ -3826,7 +3826,7 @@ RDD::ShaderID RenderingDeviceDriverD3D12::shader_create_from_bytecode(const Vect
 			binding.writable = set_ptr[j].writable;
 #endif
 			static_assert(sizeof(ShaderInfo::UniformBindingInfo::root_sig_locations) == sizeof(ShaderBinary::DataBinding::root_sig_locations));
-			memcpy((void *)&binding.root_sig_locations, (void *)&set_ptr[j].root_sig_locations, sizeof(ShaderInfo::UniformBindingInfo::root_sig_locations));
+			std::memcpy((void *)&binding.root_sig_locations, (void *)&set_ptr[j].root_sig_locations, sizeof(ShaderInfo::UniformBindingInfo::root_sig_locations));
 
 			if (binding.root_sig_locations.resource.root_param_idx != UINT32_MAX) {
 				shader_info_in.sets[i].num_root_params.resources++;
@@ -3858,7 +3858,7 @@ RDD::ShaderID RenderingDeviceDriverD3D12::shader_create_from_bytecode(const Vect
 		ShaderInfo::SpecializationConstant ssc;
 		ssc.constant_id = src_sc.constant_id;
 		ssc.int_value = src_sc.int_value;
-		memcpy(ssc.stages_bit_offsets, src_sc.stages_bit_offsets, sizeof(ssc.stages_bit_offsets));
+		std::memcpy(ssc.stages_bit_offsets, src_sc.stages_bit_offsets, sizeof(ssc.stages_bit_offsets));
 		shader_info_in.specialization_constants[i] = ssc;
 
 		read_offset += sizeof(ShaderBinary::SpecializationConstant);
@@ -6143,7 +6143,7 @@ void RenderingDeviceDriverD3D12::timestamp_query_pool_get_results(QueryPoolID p_
 
 	void *results_buffer_data = nullptr;
 	results_buffer->Map(0, &VOID_RANGE, &results_buffer_data);
-	memcpy(r_results, results_buffer_data, sizeof(uint64_t) * p_query_count);
+	std::memcpy(r_results, results_buffer_data, sizeof(uint64_t) * p_query_count);
 	results_buffer->Unmap(0, &VOID_RANGE);
 }
 
@@ -6499,7 +6499,7 @@ Error RenderingDeviceDriverD3D12::_initialize_device() {
 			}
 			DXGI_ADAPTER_DESC1 desc;
 			desired_adapter->GetDesc1(&desc);
-			if (!memcmp(&desc.AdapterLuid, &adapter_luid, sizeof(LUID))) {
+			if (!std::memcmp(&desc.AdapterLuid, &adapter_luid, sizeof(LUID))) {
 				break;
 			}
 		}

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -297,7 +297,7 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 #else
 		// On Desktop and mobile we map the memory without synchronizing for maximum speed.
 		void *ubo = glMapBufferRange(GL_UNIFORM_BUFFER, 0, sizeof(LightUniform) * light_count, GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
-		memcpy(ubo, state.light_uniforms, sizeof(LightUniform) * light_count);
+		std::memcpy(ubo, state.light_uniforms, sizeof(LightUniform) * light_count);
 		glUnmapBuffer(GL_UNIFORM_BUFFER);
 #endif
 
@@ -672,7 +672,7 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 #else
 	// On Desktop and mobile we map the memory without synchronizing for maximum speed.
 	void *buffer = glMapBufferRange(GL_ARRAY_BUFFER, state.last_item_index * sizeof(InstanceData), index * sizeof(InstanceData), GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
-	memcpy(buffer, state.instance_data_array, index * sizeof(InstanceData));
+	std::memcpy(buffer, state.instance_data_array, index * sizeof(InstanceData));
 	glUnmapBuffer(GL_ARRAY_BUFFER);
 #endif
 
@@ -1559,7 +1559,7 @@ void RasterizerCanvasGLES3::_add_to_batch(uint32_t &r_index, bool &r_batch_broke
 #else
 		// On Desktop and mobile we map the memory without synchronizing for maximum speed.
 		void *buffer = glMapBufferRange(GL_ARRAY_BUFFER, state.last_item_index * sizeof(InstanceData), r_index * sizeof(InstanceData), GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
-		memcpy(buffer, state.instance_data_array, r_index * sizeof(InstanceData));
+		std::memcpy(buffer, state.instance_data_array, r_index * sizeof(InstanceData));
 		glUnmapBuffer(GL_ARRAY_BUFFER);
 #endif
 		_allocate_instance_buffer();
@@ -2555,7 +2555,7 @@ RendererCanvasRender::PolygonID RasterizerCanvasGLES3::request_polygon(const Vec
 		index_buffer.resize(p_indices.size() * sizeof(int32_t));
 		{
 			uint8_t *w = index_buffer.ptrw();
-			memcpy(w, p_indices.ptr(), sizeof(int32_t) * p_indices.size());
+			std::memcpy(w, p_indices.ptr(), sizeof(int32_t) * p_indices.size());
 		}
 		glGenBuffers(1, &pb.index_buffer);
 		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, pb.index_buffer);

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -84,10 +84,6 @@
 
 #include "platform_gl.h"
 
-#if defined(MINGW_ENABLED) || defined(_MSC_VER)
-#define strcpy strcpy_s
-#endif
-
 #ifdef WINDOWS_ENABLED
 bool RasterizerGLES3::screen_flipped_y = false;
 #endif
@@ -145,42 +141,42 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 		return;
 	}
 
-	char debSource[256], debType[256], debSev[256];
+	String debSource, debType, debSev;
 
 	if (source == _EXT_DEBUG_SOURCE_API_ARB) {
-		strcpy(debSource, "OpenGL");
+		debSource = "OpenGL";
 	} else if (source == _EXT_DEBUG_SOURCE_WINDOW_SYSTEM_ARB) {
-		strcpy(debSource, "Windows");
+		debSource = "Windows";
 	} else if (source == _EXT_DEBUG_SOURCE_SHADER_COMPILER_ARB) {
-		strcpy(debSource, "Shader Compiler");
+		debSource = "Shader Compiler";
 	} else if (source == _EXT_DEBUG_SOURCE_THIRD_PARTY_ARB) {
-		strcpy(debSource, "Third Party");
+		debSource = "Third Party";
 	} else if (source == _EXT_DEBUG_SOURCE_APPLICATION_ARB) {
-		strcpy(debSource, "Application");
+		debSource = "Application";
 	} else if (source == _EXT_DEBUG_SOURCE_OTHER_ARB) {
-		strcpy(debSource, "Other");
+		debSource = "Other";
 	} else {
 		ERR_FAIL_MSG(vformat("GL ERROR: Invalid or unhandled source '%d' in debug callback.", source));
 	}
 
 	if (type == _EXT_DEBUG_TYPE_ERROR_ARB) {
-		strcpy(debType, "Error");
+		debType = "Error";
 	} else if (type == _EXT_DEBUG_TYPE_DEPRECATED_BEHAVIOR_ARB) {
-		strcpy(debType, "Deprecated behavior");
+		debType = "Deprecated behavior";
 	} else if (type == _EXT_DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB) {
-		strcpy(debType, "Undefined behavior");
+		debType = "Undefined behavior";
 	} else if (type == _EXT_DEBUG_TYPE_PORTABILITY_ARB) {
-		strcpy(debType, "Portability");
+		debType = "Portability";
 	} else {
 		ERR_FAIL_MSG(vformat("GL ERROR: Invalid or unhandled type '%d' in debug callback.", type));
 	}
 
 	if (severity == _EXT_DEBUG_SEVERITY_HIGH_ARB) {
-		strcpy(debSev, "High");
+		debSev = "High";
 	} else if (severity == _EXT_DEBUG_SEVERITY_MEDIUM_ARB) {
-		strcpy(debSev, "Medium");
+		debSev = "Medium";
 	} else if (severity == _EXT_DEBUG_SEVERITY_LOW_ARB) {
-		strcpy(debSev, "Low");
+		debSev = "Low";
 	} else {
 		ERR_FAIL_MSG(vformat("GL ERROR: Invalid or unhandled severity '%d' in debug callback.", severity));
 	}

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -154,7 +154,7 @@ void RasterizerSceneGLES3::GeometryInstanceGLES3::set_lightmap_capture(const Col
 			lightmap_sh = memnew(GeometryInstanceLightmapSH);
 		}
 
-		memcpy(lightmap_sh->sh, p_sh9, sizeof(Color) * 9);
+		std::memcpy(lightmap_sh->sh, p_sh9, sizeof(Color) * 9);
 	} else {
 		if (lightmap_sh != nullptr) {
 			memdelete(lightmap_sh);

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -341,7 +341,7 @@ void ShaderGLES3::_compile_specialization(Version::Specialization &spec, uint32_
 				}
 
 				char *ilogmem = (char *)Memory::alloc_static(iloglen + 1);
-				memset(ilogmem, 0, iloglen + 1);
+				std::memset(ilogmem, 0, iloglen + 1);
 				glGetShaderInfoLog(spec.vert_id, iloglen, &iloglen, ilogmem);
 
 				String err_string = name + ": Vertex shader compilation failed:\n";
@@ -389,7 +389,7 @@ void ShaderGLES3::_compile_specialization(Version::Specialization &spec, uint32_
 				}
 
 				char *ilogmem = (char *)Memory::alloc_static(iloglen + 1);
-				memset(ilogmem, 0, iloglen + 1);
+				std::memset(ilogmem, 0, iloglen + 1);
 				glGetShaderInfoLog(spec.frag_id, iloglen, &iloglen, ilogmem);
 
 				String err_string = name + ": Fragment shader compilation failed:\n";

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -510,34 +510,34 @@ _FORCE_INLINE_ static void _fill_std140_ubo_empty(ShaderLanguage::DataType type,
 		case ShaderLanguage::TYPE_INT:
 		case ShaderLanguage::TYPE_UINT:
 		case ShaderLanguage::TYPE_FLOAT: {
-			memset(data, 0, 4 * p_array_size);
+			std::memset(data, 0, 4 * p_array_size);
 		} break;
 		case ShaderLanguage::TYPE_BVEC2:
 		case ShaderLanguage::TYPE_IVEC2:
 		case ShaderLanguage::TYPE_UVEC2:
 		case ShaderLanguage::TYPE_VEC2: {
-			memset(data, 0, 8 * p_array_size);
+			std::memset(data, 0, 8 * p_array_size);
 		} break;
 		case ShaderLanguage::TYPE_BVEC3:
 		case ShaderLanguage::TYPE_IVEC3:
 		case ShaderLanguage::TYPE_UVEC3:
 		case ShaderLanguage::TYPE_VEC3: {
-			memset(data, 0, 12 * p_array_size);
+			std::memset(data, 0, 12 * p_array_size);
 		} break;
 		case ShaderLanguage::TYPE_BVEC4:
 		case ShaderLanguage::TYPE_IVEC4:
 		case ShaderLanguage::TYPE_UVEC4:
 		case ShaderLanguage::TYPE_VEC4: {
-			memset(data, 0, 16 * p_array_size);
+			std::memset(data, 0, 16 * p_array_size);
 		} break;
 		case ShaderLanguage::TYPE_MAT2: {
-			memset(data, 0, 32 * p_array_size);
+			std::memset(data, 0, 32 * p_array_size);
 		} break;
 		case ShaderLanguage::TYPE_MAT3: {
-			memset(data, 0, 48 * p_array_size);
+			std::memset(data, 0, 48 * p_array_size);
 		} break;
 		case ShaderLanguage::TYPE_MAT4: {
-			memset(data, 0, 64 * p_array_size);
+			std::memset(data, 0, 64 * p_array_size);
 		} break;
 
 		default: {
@@ -1063,7 +1063,7 @@ void MaterialData::update_parameters_internal(const HashMap<StringName, Variant>
 		ubo_data.resize(p_ubo_size);
 		if (ubo_data.size()) {
 			ERR_FAIL_COND(p_ubo_size > uint32_t(Config::get_singleton()->max_uniform_buffer_size));
-			memset(ubo_data.ptrw(), 0, ubo_data.size()); //clear
+			std::memset(ubo_data.ptrw(), 0, ubo_data.size()); //clear
 		}
 	}
 
@@ -1123,10 +1123,10 @@ MaterialStorage::MaterialStorage() {
 	}
 
 	global_shader_uniforms.buffer_values = memnew_arr(GlobalShaderUniforms::Value, global_shader_uniforms.buffer_size);
-	memset(global_shader_uniforms.buffer_values, 0, sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size);
+	std::memset(global_shader_uniforms.buffer_values, 0, sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size);
 	global_shader_uniforms.buffer_usage = memnew_arr(GlobalShaderUniforms::ValueUsage, global_shader_uniforms.buffer_size);
 	global_shader_uniforms.buffer_dirty_regions = memnew_arr(bool, 1 + (global_shader_uniforms.buffer_size / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE));
-	memset(global_shader_uniforms.buffer_dirty_regions, 0, sizeof(bool) * (1 + (global_shader_uniforms.buffer_size / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE)));
+	std::memset(global_shader_uniforms.buffer_dirty_regions, 0, sizeof(bool) * (1 + (global_shader_uniforms.buffer_size / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE)));
 	glGenBuffers(1, &global_shader_uniforms.buffer);
 	glBindBuffer(GL_UNIFORM_BUFFER, global_shader_uniforms.buffer);
 	glBufferData(GL_UNIFORM_BUFFER, sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size, nullptr, GL_DYNAMIC_DRAW);
@@ -2100,7 +2100,7 @@ void MaterialStorage::_update_global_shader_uniforms() {
 			glBindBuffer(GL_UNIFORM_BUFFER, global_shader_uniforms.buffer);
 			glBufferData(GL_UNIFORM_BUFFER, sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size, global_shader_uniforms.buffer_values, GL_DYNAMIC_DRAW);
 			glBindBuffer(GL_UNIFORM_BUFFER, 0);
-			memset(global_shader_uniforms.buffer_dirty_regions, 0, sizeof(bool) * total_regions);
+			std::memset(global_shader_uniforms.buffer_dirty_regions, 0, sizeof(bool) * total_regions);
 		} else {
 			uint32_t region_byte_size = sizeof(GlobalShaderUniforms::Value) * GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE;
 			glBindBuffer(GL_UNIFORM_BUFFER, global_shader_uniforms.buffer);

--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -228,7 +228,7 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 			// Unfortunately, we need to copy the buffer, which is fine as doing a resize triggers a CoW anyway.
 			Vector<uint8_t> new_vertex_data;
 			new_vertex_data.resize_zeroed(new_surface.vertex_data.size() + sizeof(uint16_t) * 2);
-			memcpy(new_vertex_data.ptrw(), new_surface.vertex_data.ptr(), new_surface.vertex_data.size());
+			std::memcpy(new_vertex_data.ptrw(), new_surface.vertex_data.ptr(), new_surface.vertex_data.size());
 			GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s->vertex_buffer, new_vertex_data.size(), new_vertex_data.ptr(), (s->format & RS::ARRAY_FLAG_USE_DYNAMIC_UPDATE) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW, "Mesh vertex buffer");
 			s->vertex_buffer_size = new_vertex_data.size();
 		} else {
@@ -1050,7 +1050,7 @@ void MeshStorage::mesh_surface_remove(RID p_mesh, int p_surface) {
 	_mesh_surface_clear(mesh, p_surface);
 
 	if ((uint32_t)p_surface < mesh->surface_count - 1) {
-		memmove(mesh->surfaces + p_surface, mesh->surfaces + p_surface + 1, sizeof(Mesh::Surface *) * (mesh->surface_count - (p_surface + 1)));
+		std::memmove(mesh->surfaces + p_surface, mesh->surfaces + p_surface + 1, sizeof(Mesh::Surface *) * (mesh->surface_count - (p_surface + 1)));
 	}
 	mesh->surfaces = (Mesh::Surface **)memrealloc(mesh->surfaces, sizeof(Mesh::Surface *) * (mesh->surface_count - 1));
 	--mesh->surface_count;
@@ -1617,10 +1617,10 @@ void MeshStorage::_multimesh_make_local(MultiMesh *multimesh) const {
 
 			{
 				const uint8_t *r = buffer.ptr();
-				memcpy(w, r, buffer.size());
+				std::memcpy(w, r, buffer.size());
 			}
 		} else {
-			memset(w, 0, (size_t)multimesh->instances * multimesh->stride_cache * sizeof(float));
+			std::memset(w, 0, (size_t)multimesh->instances * multimesh->stride_cache * sizeof(float));
 		}
 	}
 	uint32_t data_cache_dirty_region_count = Math::division_round_up(multimesh->instances, MULTIMESH_DIRTY_REGION_SIZE);
@@ -1791,7 +1791,7 @@ void MeshStorage::_multimesh_instance_set_color(RID p_multimesh, int p_index, co
 
 		float *dataptr = w + p_index * multimesh->stride_cache + multimesh->color_offset_cache;
 		uint16_t val[4] = { Math::make_half_float(p_color.r), Math::make_half_float(p_color.g), Math::make_half_float(p_color.b), Math::make_half_float(p_color.a) };
-		memcpy(dataptr, val, 2 * 4);
+		std::memcpy(dataptr, val, 2 * 4);
 	}
 
 	_multimesh_mark_dirty(multimesh, p_index, false);
@@ -1810,7 +1810,7 @@ void MeshStorage::_multimesh_instance_set_custom_data(RID p_multimesh, int p_ind
 
 		float *dataptr = w + p_index * multimesh->stride_cache + multimesh->custom_data_offset_cache;
 		uint16_t val[4] = { Math::make_half_float(p_color.r), Math::make_half_float(p_color.g), Math::make_half_float(p_color.b), Math::make_half_float(p_color.a) };
-		memcpy(dataptr, val, 2 * 4);
+		std::memcpy(dataptr, val, 2 * 4);
 	}
 
 	_multimesh_mark_dirty(multimesh, p_index, false);
@@ -1918,7 +1918,7 @@ Color MeshStorage::_multimesh_instance_get_color(RID p_multimesh, int p_index) c
 
 		const float *dataptr = r + p_index * multimesh->stride_cache + multimesh->color_offset_cache;
 		uint16_t raw_data[4];
-		memcpy(raw_data, dataptr, 2 * 4);
+		std::memcpy(raw_data, dataptr, 2 * 4);
 		c.r = Math::half_to_float(raw_data[0]);
 		c.g = Math::half_to_float(raw_data[1]);
 		c.b = Math::half_to_float(raw_data[2]);
@@ -1942,7 +1942,7 @@ Color MeshStorage::_multimesh_instance_get_custom_data(RID p_multimesh, int p_in
 
 		const float *dataptr = r + p_index * multimesh->stride_cache + multimesh->custom_data_offset_cache;
 		uint16_t raw_data[4];
-		memcpy(raw_data, dataptr, 2 * 4);
+		std::memcpy(raw_data, dataptr, 2 * 4);
 		c.r = Math::half_to_float(raw_data[0]);
 		c.g = Math::half_to_float(raw_data[1]);
 		c.b = Math::half_to_float(raw_data[2]);
@@ -1975,27 +1975,27 @@ void MeshStorage::_multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_
 				float *dataptr = w + i * old_stride;
 				float *newptr = w + i * multimesh->stride_cache;
 				float vals[8] = { dataptr[0], dataptr[1], dataptr[2], dataptr[3], dataptr[4], dataptr[5], dataptr[6], dataptr[7] };
-				memcpy(newptr, vals, 8 * 4);
+				std::memcpy(newptr, vals, 8 * 4);
 			}
 
 			if (multimesh->xform_format == RS::MULTIMESH_TRANSFORM_3D) {
 				float *dataptr = w + i * old_stride + 8;
 				float *newptr = w + i * multimesh->stride_cache + 8;
 				float vals[8] = { dataptr[0], dataptr[1], dataptr[2], dataptr[3] };
-				memcpy(newptr, vals, 4 * 4);
+				std::memcpy(newptr, vals, 4 * 4);
 			}
 
 			if (multimesh->uses_colors) {
 				float *dataptr = w + i * old_stride + (multimesh->xform_format == RS::MULTIMESH_TRANSFORM_2D ? 8 : 12);
 				float *newptr = w + i * multimesh->stride_cache + multimesh->color_offset_cache;
 				uint16_t val[4] = { Math::make_half_float(dataptr[0]), Math::make_half_float(dataptr[1]), Math::make_half_float(dataptr[2]), Math::make_half_float(dataptr[3]) };
-				memcpy(newptr, val, 2 * 4);
+				std::memcpy(newptr, val, 2 * 4);
 			}
 			if (multimesh->uses_custom_data) {
 				float *dataptr = w + i * old_stride + (multimesh->xform_format == RS::MULTIMESH_TRANSFORM_2D ? 8 : 12) + (multimesh->uses_colors ? 4 : 0);
 				float *newptr = w + i * multimesh->stride_cache + multimesh->custom_data_offset_cache;
 				uint16_t val[4] = { Math::make_half_float(dataptr[0]), Math::make_half_float(dataptr[1]), Math::make_half_float(dataptr[2]), Math::make_half_float(dataptr[3]) };
-				memcpy(newptr, val, 2 * 4);
+				std::memcpy(newptr, val, 2 * 4);
 			}
 		}
 
@@ -2065,7 +2065,7 @@ Vector<float> MeshStorage::_multimesh_get_buffer(RID p_multimesh) const {
 		{
 			float *w = ret.ptrw();
 			const uint8_t *r = buffer.ptr();
-			memcpy(w, r, buffer.size());
+			std::memcpy(w, r, buffer.size());
 		}
 	}
 	if (multimesh->uses_colors || multimesh->uses_custom_data) {
@@ -2084,21 +2084,21 @@ Vector<float> MeshStorage::_multimesh_get_buffer(RID p_multimesh) const {
 				float *newptr = w + i * new_stride;
 				const float *oldptr = r + i * multimesh->stride_cache;
 				float vals[8] = { oldptr[0], oldptr[1], oldptr[2], oldptr[3], oldptr[4], oldptr[5], oldptr[6], oldptr[7] };
-				memcpy(newptr, vals, 8 * 4);
+				std::memcpy(newptr, vals, 8 * 4);
 			}
 
 			if (multimesh->xform_format == RS::MULTIMESH_TRANSFORM_3D) {
 				float *newptr = w + i * new_stride + 8;
 				const float *oldptr = r + i * multimesh->stride_cache + 8;
 				float vals[8] = { oldptr[0], oldptr[1], oldptr[2], oldptr[3] };
-				memcpy(newptr, vals, 4 * 4);
+				std::memcpy(newptr, vals, 4 * 4);
 			}
 
 			if (multimesh->uses_colors) {
 				float *newptr = w + i * new_stride + (multimesh->xform_format == RS::MULTIMESH_TRANSFORM_2D ? 8 : 12);
 				const float *oldptr = r + i * multimesh->stride_cache + multimesh->color_offset_cache;
 				uint16_t raw_data[4];
-				memcpy(raw_data, oldptr, 2 * 4);
+				std::memcpy(raw_data, oldptr, 2 * 4);
 				newptr[0] = Math::half_to_float(raw_data[0]);
 				newptr[1] = Math::half_to_float(raw_data[1]);
 				newptr[2] = Math::half_to_float(raw_data[2]);
@@ -2108,7 +2108,7 @@ Vector<float> MeshStorage::_multimesh_get_buffer(RID p_multimesh) const {
 				float *newptr = w + i * new_stride + (multimesh->xform_format == RS::MULTIMESH_TRANSFORM_2D ? 8 : 12) + (multimesh->uses_colors ? 4 : 0);
 				const float *oldptr = r + i * multimesh->stride_cache + multimesh->custom_data_offset_cache;
 				uint16_t raw_data[4];
-				memcpy(raw_data, oldptr, 2 * 4);
+				std::memcpy(raw_data, oldptr, 2 * 4);
 				newptr[0] = Math::half_to_float(raw_data[0]);
 				newptr[1] = Math::half_to_float(raw_data[1]);
 				newptr[2] = Math::half_to_float(raw_data[2]);
@@ -2276,7 +2276,7 @@ void MeshStorage::skeleton_allocate_data(RID p_skeleton, int p_bones, bool p_2d_
 		glBindTexture(GL_TEXTURE_2D, 0);
 		GLES3::Utilities::get_singleton()->texture_allocated_data(skeleton->transforms_texture, skeleton->data.size() * sizeof(float), "Skeleton transforms texture");
 
-		memset(skeleton->data.ptr(), 0, skeleton->data.size() * sizeof(float));
+		std::memset(skeleton->data.ptr(), 0, skeleton->data.size() * sizeof(float));
 
 		_skeleton_make_dirty(skeleton);
 	}

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1937,7 +1937,7 @@ void TextureStorage::update_texture_atlas() {
 			v_offsetsv.resize(base_size);
 
 			int *v_offsets = v_offsetsv.ptrw();
-			memset(v_offsets, 0, sizeof(int) * base_size);
+			std::memset(v_offsets, 0, sizeof(int) * base_size);
 
 			int max_height = 0;
 

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -135,7 +135,7 @@ Vector<uint8_t> Utilities::buffer_get_data(GLenum p_target, GLuint p_buffer, uin
 	ERR_FAIL_NULL_V(data, Vector<uint8_t>());
 	{
 		uint8_t *w = ret.ptrw();
-		memcpy(w, data, p_buffer_size);
+		std::memcpy(w, data, p_buffer_size);
 	}
 	glUnmapBuffer(p_target);
 #endif

--- a/drivers/metal/metal_objects.h
+++ b/drivers/metal/metal_objects.h
@@ -167,7 +167,7 @@ struct ClearAttKey {
 	_FORCE_INLINE_ bool is_layered_rendering_enabled() const { return flags::any(flags, CLEAR_FLAGS_LAYERED); }
 
 	_FORCE_INLINE_ bool operator==(const ClearAttKey &p_rhs) const {
-		return memcmp(this, &p_rhs, sizeof(ClearAttKey)) == 0;
+		return std::memcmp(this, &p_rhs, sizeof(ClearAttKey)) == 0;
 	}
 
 	uint32_t hash() const {
@@ -668,7 +668,7 @@ struct SHA256Digest {
 template <>
 struct HashMapComparatorDefault<SHA256Digest> {
 	static bool compare(const SHA256Digest &p_lhs, const SHA256Digest &p_rhs) {
-		return memcmp(p_lhs.data, p_rhs.data, CC_SHA256_DIGEST_LENGTH) == 0;
+		return std::memcmp(p_lhs.data, p_rhs.data, CC_SHA256_DIGEST_LENGTH) == 0;
 	}
 };
 

--- a/drivers/metal/pixel_formats.mm
+++ b/drivers/metal/pixel_formats.mm
@@ -99,7 +99,7 @@
 
 template <typename T>
 void clear(T *p_val, size_t p_count = 1) {
-	memset(p_val, 0, sizeof(T) * p_count);
+	std::memset(p_val, 0, sizeof(T) * p_count);
 }
 
 #pragma mark -

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -282,7 +282,7 @@ RDD::TextureID RenderingDeviceDriverMetal::texture_create(const TextureFormat &p
 		.alpha = MTLTextureSwizzleAlpha,
 	};
 
-	bool no_swizzle = memcmp(&IDENTITY_SWIZZLE, &swizzle, sizeof(MTLTextureSwizzleChannels)) == 0;
+	bool no_swizzle = std::memcmp(&IDENTITY_SWIZZLE, &swizzle, sizeof(MTLTextureSwizzleChannels)) == 0;
 	if (!no_swizzle) {
 		desc.swizzle = swizzle;
 	}
@@ -1206,7 +1206,7 @@ private:
 		write(p_length);
 
 		DEV_ASSERT(pos + p_length <= length);
-		memcpy(data + pos, p_buffer, p_length);
+		std::memcpy(data + pos, p_buffer, p_length);
 		pos += p_length;
 	}
 };
@@ -1307,7 +1307,7 @@ public:
 		read(len);
 		CHECK(len);
 		p_val.resize(len + 1 /* NUL */);
-		memcpy(p_val.ptrw(), data + pos, len);
+		std::memcpy(p_val.ptrw(), data + pos, len);
 		p_val.set(len, 0);
 		pos += len;
 	}
@@ -1335,7 +1335,7 @@ public:
 		read(len);
 		CHECK(len);
 		p_val.resize(len);
-		memcpy(p_val.ptr(), data + pos, len);
+		std::memcpy(p_val.ptr(), data + pos, len);
 		pos += len;
 	}
 
@@ -2450,7 +2450,7 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_bytecode(const Vect
 	BufReader reader(binptr, binsize);
 	uint8_t header[4];
 	reader.read((uint32_t &)header);
-	ERR_FAIL_COND_V_MSG(memcmp(header, "GMSL", 4) != 0, ShaderID(), "Invalid header");
+	ERR_FAIL_COND_V_MSG(std::memcmp(header, "GMSL", 4) != 0, ShaderID(), "Invalid header");
 	uint32_t version = 0;
 	reader.read(version);
 	ERR_FAIL_COND_V_MSG(version != SHADER_BINARY_VERSION, ShaderID(), "Invalid shader binary version");
@@ -3792,7 +3792,7 @@ void RenderingDeviceDriverMetal::command_timestamp_write(CommandBufferID p_cmd_b
 
 void RenderingDeviceDriverMetal::command_begin_label(CommandBufferID p_cmd_buffer, const char *p_label_name, const Color &p_color) {
 	MDCommandBuffer *cb = (MDCommandBuffer *)(p_cmd_buffer.id);
-	NSString *s = [[NSString alloc] initWithBytesNoCopy:(void *)p_label_name length:strlen(p_label_name) encoding:NSUTF8StringEncoding freeWhenDone:NO];
+	NSString *s = [[NSString alloc] initWithBytesNoCopy:(void *)p_label_name length:std::strlen(p_label_name) encoding:NSUTF8StringEncoding freeWhenDone:NO];
 	[cb->get_command_buffer() pushDebugGroup:s];
 }
 

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -32,8 +32,6 @@
 
 #include "drivers/png/png_driver_common.h"
 
-#include <string.h>
-
 Error ImageLoaderPNG::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	const uint64_t buffer_size = f->get_length();
 	Vector<uint8_t> file_buffer;
@@ -86,7 +84,7 @@ Vector<uint8_t> ImageLoaderPNG::lossless_pack_png(const Ref<Image> &p_image) {
 	{
 		// must be closed before call to image_to_png
 		uint8_t *writer = out_buffer.ptrw();
-		memcpy(writer, "PNG ", 4);
+		std::memcpy(writer, "PNG ", 4);
 	}
 
 	Error err = PNGDriverCommon::image_to_png(p_image, out_buffer);

--- a/drivers/png/png_driver_common.cpp
+++ b/drivers/png/png_driver_common.cpp
@@ -33,7 +33,6 @@
 #include "core/config/engine.h"
 
 #include <png.h>
-#include <string.h>
 
 namespace PNGDriverCommon {
 
@@ -49,7 +48,7 @@ static bool check_error(const png_image &image) {
 		// suppress this warning, to avoid log spam when opening assetlib
 		const static char *const noisy = "iCCP: known incorrect sRGB profile";
 		const Engine *const eng = Engine::get_singleton();
-		if (eng && eng->is_editor_hint() && !strcmp(image.message, noisy)) {
+		if (eng && eng->is_editor_hint() && !std::strcmp(image.message, noisy)) {
 			return false;
 		}
 #endif
@@ -60,7 +59,7 @@ static bool check_error(const png_image &image) {
 
 Error png_to_image(const uint8_t *p_source, size_t p_size, bool p_force_linear, Ref<Image> p_image) {
 	png_image png_img;
-	memset(&png_img, 0, sizeof(png_img));
+	std::memset(&png_img, 0, sizeof(png_img));
 	png_img.version = PNG_IMAGE_VERSION;
 
 	// fetch image properties
@@ -134,7 +133,7 @@ Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer) {
 	ERR_FAIL_COND_V(source_image->is_compressed(), FAILED);
 
 	png_image png_img;
-	memset(&png_img, 0, sizeof(png_img));
+	std::memset(&png_img, 0, sizeof(png_img));
 	png_img.version = PNG_IMAGE_VERSION;
 	png_img.width = source_image->get_width();
 	png_img.height = source_image->get_height();

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -41,7 +41,6 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
@@ -195,15 +194,15 @@ void DirAccessUnix::list_dir_end() {
 #if __has_include(<mntent.h>) && defined(LINUXBSD_ENABLED)
 static bool _filter_drive(struct mntent *mnt) {
 	// Ignore devices that don't point to /dev
-	if (strncmp(mnt->mnt_fsname, "/dev", 4) != 0) {
+	if (std::strncmp(mnt->mnt_fsname, "/dev", 4) != 0) {
 		return false;
 	}
 
 	// Accept devices mounted at common locations
-	if (strncmp(mnt->mnt_dir, "/media", 6) == 0 ||
-			strncmp(mnt->mnt_dir, "/mnt", 4) == 0 ||
-			strncmp(mnt->mnt_dir, "/home", 5) == 0 ||
-			strncmp(mnt->mnt_dir, "/run/media", 10) == 0) {
+	if (std::strncmp(mnt->mnt_dir, "/media", 6) == 0 ||
+			std::strncmp(mnt->mnt_dir, "/mnt", 4) == 0 ||
+			std::strncmp(mnt->mnt_dir, "/home", 5) == 0 ||
+			std::strncmp(mnt->mnt_dir, "/run/media", 10) == 0) {
 		return true;
 	}
 
@@ -255,7 +254,7 @@ static void _get_drives(List<String> *list) {
 			char string[1024];
 			while (fgets(string, 1024, fd)) {
 				// Parse only file:// links
-				if (strncmp(string, "file://", 7) == 0) {
+				if (std::strncmp(string, "file://", 7) == 0) {
 					// Strip any unwanted edges on the strings and push_back if it's not a duplicate.
 					String fpath = String::utf8(string + 7).strip_edges().split_spaces()[0].uri_file_decode();
 					if (!list->find(fpath)) {
@@ -483,7 +482,7 @@ String DirAccessUnix::read_link(String p_file) {
 	}
 
 	char buf[256];
-	memset(buf, 0, 256);
+	std::memset(buf, 0, 256);
 	ssize_t len = readlink(p_file.utf8().get_data(), buf, sizeof(buf));
 	String link;
 	if (len > 0) {

--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -54,8 +54,6 @@
 
 #include <net/if.h> // Order is important on OpenBSD, leave as last.
 
-#include <string.h>
-
 static IPAddress _sockaddr2ip(struct sockaddr *p_addr) {
 	IPAddress ip;
 
@@ -74,7 +72,7 @@ void IPUnix::_resolve_hostname(List<IPAddress> &r_addresses, const String &p_hos
 	struct addrinfo hints;
 	struct addrinfo *result = nullptr;
 
-	memset(&hints, 0, sizeof(struct addrinfo));
+	std::memset(&hints, 0, sizeof(struct addrinfo));
 	if (p_type == TYPE_IPV4) {
 		hints.ai_family = AF_INET;
 	} else if (p_type == TYPE_IPV6) {

--- a/drivers/unix/net_socket_unix.cpp
+++ b/drivers/unix/net_socket_unix.cpp
@@ -42,7 +42,6 @@
 #include <poll.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -61,7 +60,7 @@
 #endif
 
 size_t NetSocketUnix::_set_addr_storage(struct sockaddr_storage *p_addr, const IPAddress &p_ip, uint16_t p_port, IP::Type p_ip_type) {
-	memset(p_addr, 0, sizeof(struct sockaddr_storage));
+	std::memset(p_addr, 0, sizeof(struct sockaddr_storage));
 	if (p_ip_type == IP::TYPE_IPV6 || p_ip_type == IP::TYPE_ANY) { // IPv6 socket.
 
 		// IPv6 only socket with IPv4 address.
@@ -71,7 +70,7 @@ size_t NetSocketUnix::_set_addr_storage(struct sockaddr_storage *p_addr, const I
 		addr6->sin6_family = AF_INET6;
 		addr6->sin6_port = htons(p_port);
 		if (p_ip.is_valid()) {
-			memcpy(&addr6->sin6_addr.s6_addr, p_ip.get_ipv6(), 16);
+			std::memcpy(&addr6->sin6_addr.s6_addr, p_ip.get_ipv6(), 16);
 		} else {
 			addr6->sin6_addr = in6addr_any;
 		}
@@ -86,7 +85,7 @@ size_t NetSocketUnix::_set_addr_storage(struct sockaddr_storage *p_addr, const I
 		addr4->sin_port = htons(p_port); // Short, network byte order.
 
 		if (p_ip.is_valid()) {
-			memcpy(&addr4->sin_addr.s_addr, p_ip.get_ipv4(), 4);
+			std::memcpy(&addr4->sin_addr.s_addr, p_ip.get_ipv4(), 4);
 		} else {
 			addr4->sin_addr.s_addr = INADDR_ANY;
 		}
@@ -212,13 +211,13 @@ _FORCE_INLINE_ Error NetSocketUnix::_change_multicast_group(IPAddress p_ip, Stri
 		ERR_FAIL_COND_V(!if_ip.is_valid(), ERR_INVALID_PARAMETER);
 		struct ip_mreq greq;
 		int sock_opt = p_add ? IP_ADD_MEMBERSHIP : IP_DROP_MEMBERSHIP;
-		memcpy(&greq.imr_multiaddr, p_ip.get_ipv4(), 4);
-		memcpy(&greq.imr_interface, if_ip.get_ipv4(), 4);
+		std::memcpy(&greq.imr_multiaddr, p_ip.get_ipv4(), 4);
+		std::memcpy(&greq.imr_interface, if_ip.get_ipv4(), 4);
 		ret = setsockopt(_sock, level, sock_opt, (const char *)&greq, sizeof(greq));
 	} else {
 		struct ipv6_mreq greq;
 		int sock_opt = p_add ? IPV6_ADD_MEMBERSHIP : IPV6_DROP_MEMBERSHIP;
-		memcpy(&greq.ipv6mr_multiaddr, p_ip.get_ipv6(), 16);
+		std::memcpy(&greq.ipv6mr_multiaddr, p_ip.get_ipv6(), 16);
 		greq.ipv6mr_interface = if_v6id;
 		ret = setsockopt(_sock, level, sock_opt, (const char *)&greq, sizeof(greq));
 	}
@@ -422,7 +421,7 @@ Error NetSocketUnix::recvfrom(uint8_t *p_buffer, int p_len, int &r_read, IPAddre
 
 	struct sockaddr_storage from;
 	socklen_t len = sizeof(struct sockaddr_storage);
-	memset(&from, 0, len);
+	std::memset(&from, 0, len);
 
 	r_read = ::recvfrom(_sock, p_buffer, p_len, p_peek ? MSG_PEEK : 0, (struct sockaddr *)&from, &len);
 

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -75,7 +75,6 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -144,7 +143,7 @@ static void handle_interrupt(int sig) {
 void OS_Unix::initialize_debugging() {
 	if (EngineDebugger::is_active()) {
 		struct sigaction action;
-		memset(&action, 0, sizeof(action));
+		std::memset(&action, 0, sizeof(action));
 		action.sa_handler = handle_interrupt;
 		sigaction(SIGINT, &action, nullptr);
 	}
@@ -406,13 +405,13 @@ Dictionary OS_Unix::get_memory_info() const {
 	int pagesize = 0;
 	size_t len = sizeof(pagesize);
 	if (sysctlbyname("vm.pagesize", &pagesize, &len, nullptr, 0) < 0) {
-		ERR_PRINT(vformat("Could not get vm.pagesize, error code: %d - %s", errno, strerror(errno)));
+		ERR_PRINT(vformat("Could not get vm.pagesize, error code: %d - %s", errno, std::strerror(errno)));
 	}
 
 	int64_t phy_mem = 0;
 	len = sizeof(phy_mem);
 	if (sysctlbyname("hw.memsize", &phy_mem, &len, nullptr, 0) < 0) {
-		ERR_PRINT(vformat("Could not get hw.memsize, error code: %d - %s", errno, strerror(errno)));
+		ERR_PRINT(vformat("Could not get hw.memsize, error code: %d - %s", errno, std::strerror(errno)));
 	}
 
 	mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
@@ -423,7 +422,7 @@ Dictionary OS_Unix::get_memory_info() const {
 	struct xsw_usage swap_used;
 	len = sizeof(swap_used);
 	if (sysctlbyname("vm.swapusage", &swap_used, &len, nullptr, 0) < 0) {
-		ERR_PRINT(vformat("Could not get vm.swapusage, error code: %d - %s", errno, strerror(errno)));
+		ERR_PRINT(vformat("Could not get vm.swapusage, error code: %d - %s", errno, std::strerror(errno)));
 	}
 
 	if (phy_mem != 0) {
@@ -439,18 +438,18 @@ Dictionary OS_Unix::get_memory_info() const {
 	int pagesize = 0;
 	size_t len = sizeof(pagesize);
 	if (sysctlbyname("vm.stats.vm.v_page_size", &pagesize, &len, nullptr, 0) < 0) {
-		ERR_PRINT(vformat("Could not get vm.stats.vm.v_page_size, error code: %d - %s", errno, strerror(errno)));
+		ERR_PRINT(vformat("Could not get vm.stats.vm.v_page_size, error code: %d - %s", errno, std::strerror(errno)));
 	}
 
 	uint64_t mtotal = 0;
 	len = sizeof(mtotal);
 	if (sysctlbyname("vm.stats.vm.v_page_count", &mtotal, &len, nullptr, 0) < 0) {
-		ERR_PRINT(vformat("Could not get vm.stats.vm.v_page_count, error code: %d - %s", errno, strerror(errno)));
+		ERR_PRINT(vformat("Could not get vm.stats.vm.v_page_count, error code: %d - %s", errno, std::strerror(errno)));
 	}
 	uint64_t mfree = 0;
 	len = sizeof(mfree);
 	if (sysctlbyname("vm.stats.vm.v_free_count", &mfree, &len, nullptr, 0) < 0) {
-		ERR_PRINT(vformat("Could not get vm.stats.vm.v_free_count, error code: %d - %s", errno, strerror(errno)));
+		ERR_PRINT(vformat("Could not get vm.stats.vm.v_free_count, error code: %d - %s", errno, std::strerror(errno)));
 	}
 
 	uint64_t stotal = 0;
@@ -485,7 +484,7 @@ Dictionary OS_Unix::get_memory_info() const {
 	uvmexp uvmexp_info;
 	size_t len = sizeof(uvmexp_info);
 	if (sysctl(mib, 2, &uvmexp_info, &len, nullptr, 0) < 0) {
-		ERR_PRINT(vformat("Could not get CTL_VM, VM_UVMEXP, error code: %d - %s", errno, strerror(errno)));
+		ERR_PRINT(vformat("Could not get CTL_VM, VM_UVMEXP, error code: %d - %s", errno, std::strerror(errno)));
 	}
 
 	uint64_t stotal = 0;
@@ -519,7 +518,7 @@ Dictionary OS_Unix::get_memory_info() const {
 	uvmexp_sysctl uvmexp_info;
 	size_t len = sizeof(uvmexp_info);
 	if (sysctl(mib, 2, &uvmexp_info, &len, nullptr, 0) < 0) {
-		ERR_PRINT(vformat("Could not get CTL_VM, VM_UVMEXP2, error code: %d - %s", errno, strerror(errno)));
+		ERR_PRINT(vformat("Could not get CTL_VM, VM_UVMEXP2, error code: %d - %s", errno, std::strerror(errno)));
 	}
 
 	if (uvmexp_info.npages * pagesize != 0) {
@@ -649,7 +648,7 @@ String OS_Unix::multibyte_to_string(const String &p_encoding, const PackedByteAr
 	while (gd_iconv(ctx, &in_ptr, &in_size, &out_ptr, &out_size) == (size_t)-1) {
 		if (errno != E2BIG) {
 			gd_iconv_close(ctx);
-			ERR_FAIL_V_MSG(String(), vformat("Conversion failed: %d - %s", errno, strerror(errno)));
+			ERR_FAIL_V_MSG(String(), vformat("Conversion failed: %d - %s", errno, std::strerror(errno)));
 		}
 		int64_t rate = (chars.size()) / (p_array.size() - in_size);
 		size_t oldpos = chars.size() - out_size;
@@ -686,7 +685,7 @@ PackedByteArray OS_Unix::string_to_multibyte(const String &p_encoding, const Str
 	while (gd_iconv(ctx, &in_ptr, &in_size, &out_ptr, &out_size) == (size_t)-1) {
 		if (errno != E2BIG) {
 			gd_iconv_close(ctx);
-			ERR_FAIL_V_MSG(PackedByteArray(), vformat("Conversion failed: %d - %s", errno, strerror(errno)));
+			ERR_FAIL_V_MSG(PackedByteArray(), vformat("Conversion failed: %d - %s", errno, std::strerror(errno)));
 		}
 		int64_t rate = (ret.size()) / (charstr.size() - in_size);
 		size_t oldpos = ret.size() - out_size;
@@ -1115,7 +1114,7 @@ String OS_Unix::get_executable_path() const {
 #ifdef __linux__
 	//fix for running from a symlink
 	char buf[256];
-	memset(buf, 0, 256);
+	std::memset(buf, 0, 256);
 	ssize_t len = readlink("/proc/self/exe", buf, sizeof(buf));
 	String b;
 	if (len > 0) {
@@ -1229,7 +1228,7 @@ void UnixTerminalLogger::log_error(const char *p_function, const char *p_file, i
 	logf_error("%s%sat: %s (%s:%i)%s\n", gray, indent, p_function, p_file, p_line, reset);
 
 	for (const Ref<ScriptBacktrace> &backtrace : p_script_backtraces) {
-		logf_error("%s%s%s\n", gray, backtrace->format(strlen(indent)).utf8().get_data(), reset);
+		logf_error("%s%s%s\n", gray, backtrace->format(std::strlen(indent)).utf8().get_data(), reset);
 	}
 }
 

--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -522,7 +522,7 @@ Error RenderingContextDriverVulkan::_find_validation_layers(TightLocalVector<con
 				layers_found = false;
 
 				for (const VkLayerProperties &properties : layer_properties) {
-					if (!strcmp(properties.layerName, layer_name)) {
+					if (!std::strcmp(properties.layerName, layer_name)) {
 						layers_found = true;
 						break;
 					}
@@ -549,24 +549,24 @@ Error RenderingContextDriverVulkan::_find_validation_layers(TightLocalVector<con
 
 VKAPI_ATTR VkBool32 VKAPI_CALL RenderingContextDriverVulkan::_debug_messenger_callback(VkDebugUtilsMessageSeverityFlagBitsEXT p_message_severity, VkDebugUtilsMessageTypeFlagsEXT p_message_type, const VkDebugUtilsMessengerCallbackDataEXT *p_callback_data, void *p_user_data) {
 	// This error needs to be ignored because the AMD allocator will mix up memory types on IGP processors.
-	if (strstr(p_callback_data->pMessage, "Mapping an image with layout") != nullptr && strstr(p_callback_data->pMessage, "can result in undefined behavior if this memory is used by the device") != nullptr) {
+	if (std::strstr(p_callback_data->pMessage, "Mapping an image with layout") != nullptr && std::strstr(p_callback_data->pMessage, "can result in undefined behavior if this memory is used by the device") != nullptr) {
 		return VK_FALSE;
 	}
 	// This needs to be ignored because Validator is wrong here.
-	if (strstr(p_callback_data->pMessage, "Invalid SPIR-V binary version 1.3") != nullptr) {
+	if (std::strstr(p_callback_data->pMessage, "Invalid SPIR-V binary version 1.3") != nullptr) {
 		return VK_FALSE;
 	}
 	// This needs to be ignored because Validator is wrong here.
-	if (strstr(p_callback_data->pMessage, "Shader requires flag") != nullptr) {
+	if (std::strstr(p_callback_data->pMessage, "Shader requires flag") != nullptr) {
 		return VK_FALSE;
 	}
 
 	// This needs to be ignored because Validator is wrong here.
-	if (strstr(p_callback_data->pMessage, "SPIR-V module not valid: Pointer operand") != nullptr && strstr(p_callback_data->pMessage, "must be a memory object") != nullptr) {
+	if (std::strstr(p_callback_data->pMessage, "SPIR-V module not valid: Pointer operand") != nullptr && std::strstr(p_callback_data->pMessage, "must be a memory object") != nullptr) {
 		return VK_FALSE;
 	}
 
-	if (p_callback_data->pMessageIdName && strstr(p_callback_data->pMessageIdName, "UNASSIGNED-CoreValidation-DrawState-ClearCmdBeforeDraw") != nullptr) {
+	if (p_callback_data->pMessageIdName && std::strstr(p_callback_data->pMessageIdName, "UNASSIGNED-CoreValidation-DrawState-ClearCmdBeforeDraw") != nullptr) {
 		return VK_FALSE;
 	}
 
@@ -595,7 +595,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL RenderingContextDriverVulkan::_debug_messenger_ca
 					" - " + string_VkObjectType(p_callback_data->pObjects[object].objectType) +
 					", Handle " + String::num_int64(p_callback_data->pObjects[object].objectHandle);
 
-			if (p_callback_data->pObjects[object].pObjectName != nullptr && strlen(p_callback_data->pObjects[object].pObjectName) > 0) {
+			if (p_callback_data->pObjects[object].pObjectName != nullptr && std::strlen(p_callback_data->pObjects[object].pObjectName) > 0) {
 				objects_string += ", Name \"" + String(p_callback_data->pObjects[object].pObjectName) + "\"";
 			}
 		}

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -1244,7 +1244,7 @@ Error RenderingDeviceDriverVulkan::_initialize_pipeline_cache() {
 	header->device_id = physical_device_properties.deviceID;
 	header->vendor_id = physical_device_properties.vendorID;
 	header->driver_version = physical_device_properties.driverVersion;
-	memcpy(header->uuid, physical_device_properties.pipelineCacheUUID, VK_UUID_SIZE);
+	std::memcpy(header->uuid, physical_device_properties.pipelineCacheUUID, VK_UUID_SIZE);
 	header->driver_abi = sizeof(void *);
 
 	pipeline_cache_id = String::hex_encode_buffer(physical_device_properties.pipelineCacheUUID, VK_UUID_SIZE);
@@ -3635,7 +3635,7 @@ Vector<uint8_t> RenderingDeviceDriverVulkan::shader_compile_binary_from_spirv(Ve
 				} else {
 					Vector<uint8_t> smv;
 					smv.resize(smolv.size());
-					memcpy(smv.ptrw(), &smolv[0], smolv.size());
+					std::memcpy(smv.ptrw(), &smolv[0], smolv.size());
 					zstd_size.push_back(0); // Not using zstd.
 					compressed_stages.push_back(smv);
 				}
@@ -3684,19 +3684,19 @@ Vector<uint8_t> RenderingDeviceDriverVulkan::shader_compile_binary_from_spirv(Ve
 		offset += sizeof(uint32_t);
 		encode_uint32(0, binptr + offset); // Pad to align ShaderBinary::Data to 8 bytes.
 		offset += sizeof(uint32_t);
-		memcpy(binptr + offset, &binary_data, sizeof(ShaderBinary::Data));
+		std::memcpy(binptr + offset, &binary_data, sizeof(ShaderBinary::Data));
 		offset += sizeof(ShaderBinary::Data);
 
-#define ADVANCE_OFFSET_WITH_ALIGNMENT(m_bytes)                         \
-	{                                                                  \
-		offset += m_bytes;                                             \
-		uint32_t padding = STEPIFY(m_bytes, 4) - m_bytes;              \
-		memset(binptr + offset, 0, padding); /* Avoid garbage data. */ \
-		offset += padding;                                             \
+#define ADVANCE_OFFSET_WITH_ALIGNMENT(m_bytes)                              \
+	{                                                                       \
+		offset += m_bytes;                                                  \
+		uint32_t padding = STEPIFY(m_bytes, 4) - m_bytes;                   \
+		std::memset(binptr + offset, 0, padding); /* Avoid garbage data. */ \
+		offset += padding;                                                  \
 	}
 
 		if (binary_data.shader_name_len > 0) {
-			memcpy(binptr + offset, shader_name_utf.ptr(), binary_data.shader_name_len);
+			std::memcpy(binptr + offset, shader_name_utf.ptr(), binary_data.shader_name_len);
 			ADVANCE_OFFSET_WITH_ALIGNMENT(binary_data.shader_name_len);
 		}
 
@@ -3705,13 +3705,13 @@ Vector<uint8_t> RenderingDeviceDriverVulkan::shader_compile_binary_from_spirv(Ve
 			encode_uint32(count, binptr + offset);
 			offset += sizeof(uint32_t);
 			if (count > 0) {
-				memcpy(binptr + offset, uniforms[i].ptr(), sizeof(ShaderBinary::DataBinding) * count);
+				std::memcpy(binptr + offset, uniforms[i].ptr(), sizeof(ShaderBinary::DataBinding) * count);
 				offset += sizeof(ShaderBinary::DataBinding) * count;
 			}
 		}
 
 		if (specialization_constants.size()) {
-			memcpy(binptr + offset, specialization_constants.ptr(), sizeof(ShaderBinary::SpecializationConstant) * specialization_constants.size());
+			std::memcpy(binptr + offset, specialization_constants.ptr(), sizeof(ShaderBinary::SpecializationConstant) * specialization_constants.size());
 			offset += sizeof(ShaderBinary::SpecializationConstant) * specialization_constants.size();
 		}
 
@@ -3722,7 +3722,7 @@ Vector<uint8_t> RenderingDeviceDriverVulkan::shader_compile_binary_from_spirv(Ve
 			offset += sizeof(uint32_t);
 			encode_uint32(zstd_size[i], binptr + offset);
 			offset += sizeof(uint32_t);
-			memcpy(binptr + offset, compressed_stages[i].ptr(), compressed_stages[i].size());
+			std::memcpy(binptr + offset, compressed_stages[i].ptr(), compressed_stages[i].size());
 			ADVANCE_OFFSET_WITH_ALIGNMENT(compressed_stages[i].size());
 		}
 
@@ -4555,7 +4555,7 @@ void RenderingDeviceDriverVulkan::command_resolve_texture(CommandBufferID p_cmd_
 
 void RenderingDeviceDriverVulkan::command_clear_color_texture(CommandBufferID p_cmd_buffer, TextureID p_texture, TextureLayout p_texture_layout, const Color &p_color, const TextureSubresourceRange &p_subresources) {
 	VkClearColorValue vk_color = {};
-	memcpy(&vk_color.float32, p_color.components, sizeof(VkClearColorValue::float32));
+	std::memcpy(&vk_color.float32, p_color.components, sizeof(VkClearColorValue::float32));
 
 	VkImageSubresourceRange vk_subresources = {};
 	_texture_subresource_range_to_vk(p_subresources, &vk_subresources);
@@ -4653,7 +4653,7 @@ bool RenderingDeviceDriverVulkan::pipeline_cache_create(const Vector<uint8_t> &p
 						loaded_header->vendor_id != current_header->vendor_id ||
 						loaded_header->device_id != current_header->device_id ||
 						loaded_header->driver_version != current_header->driver_version ||
-						memcmp(loaded_header->uuid, current_header->uuid, VK_UUID_SIZE) != 0 ||
+						std::memcmp(loaded_header->uuid, current_header->uuid, VK_UUID_SIZE) != 0 ||
 						loaded_header->driver_abi != current_header->driver_abi) {
 					print_verbose("Invalid Vulkan pipelines cache header. This may be due to an engine change, GPU change or graphics driver version change. Existing shader pipeline cache will be ignored, which may result in stuttering during gameplay.");
 				} else {
@@ -4987,7 +4987,7 @@ void RenderingDeviceDriverVulkan::command_render_clear_attachments(CommandBuffer
 	VkClearAttachment *vk_clears = ALLOCA_ARRAY(VkClearAttachment, p_attachment_clears.size());
 	for (uint32_t i = 0; i < p_attachment_clears.size(); i++) {
 		vk_clears[i] = {};
-		memcpy(&vk_clears[i].clearValue, &p_attachment_clears[i].value, sizeof(VkClearValue));
+		std::memcpy(&vk_clears[i].clearValue, &p_attachment_clears[i].value, sizeof(VkClearValue));
 		vk_clears[i].colorAttachment = p_attachment_clears[i].color_attachment;
 		vk_clears[i].aspectMask = p_attachment_clears[i].aspect;
 	}

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -486,7 +486,7 @@ private:
 		uint16_t uniform_type[UNIFORM_TYPE_MAX] = {};
 
 		bool operator<(const DescriptorSetPoolKey &p_other) const {
-			return memcmp(uniform_type, p_other.uniform_type, sizeof(uniform_type)) < 0;
+			return std::memcmp(uniform_type, p_other.uniform_type, sizeof(uniform_type)) < 0;
 		}
 	};
 

--- a/drivers/windows/ip_windows.cpp
+++ b/drivers/windows/ip_windows.cpp
@@ -41,8 +41,6 @@
 
 #include <stdio.h>
 
-#include <string.h>
-
 static IPAddress _sockaddr2ip(struct sockaddr *p_addr) {
 	IPAddress ip;
 
@@ -61,7 +59,7 @@ void IPWindows::_resolve_hostname(List<IPAddress> &r_addresses, const String &p_
 	struct addrinfo hints;
 	struct addrinfo *result = nullptr;
 
-	memset(&hints, 0, sizeof(struct addrinfo));
+	std::memset(&hints, 0, sizeof(struct addrinfo));
 	if (p_type == TYPE_IPV4) {
 		hints.ai_family = AF_INET;
 	} else if (p_type == TYPE_IPV6) {

--- a/drivers/windows/net_socket_winsock.cpp
+++ b/drivers/windows/net_socket_winsock.cpp
@@ -42,7 +42,7 @@
 #endif
 
 size_t NetSocketWinSock::_set_addr_storage(struct sockaddr_storage *p_addr, const IPAddress &p_ip, uint16_t p_port, IP::Type p_ip_type) {
-	memset(p_addr, 0, sizeof(struct sockaddr_storage));
+	std::memset(p_addr, 0, sizeof(struct sockaddr_storage));
 	if (p_ip_type == IP::TYPE_IPV6 || p_ip_type == IP::TYPE_ANY) { // IPv6 socket.
 
 		// IPv6 only socket with IPv4 address.
@@ -52,7 +52,7 @@ size_t NetSocketWinSock::_set_addr_storage(struct sockaddr_storage *p_addr, cons
 		addr6->sin6_family = AF_INET6;
 		addr6->sin6_port = htons(p_port);
 		if (p_ip.is_valid()) {
-			memcpy(&addr6->sin6_addr.s6_addr, p_ip.get_ipv6(), 16);
+			std::memcpy(&addr6->sin6_addr.s6_addr, p_ip.get_ipv6(), 16);
 		} else {
 			addr6->sin6_addr = in6addr_any;
 		}
@@ -67,7 +67,7 @@ size_t NetSocketWinSock::_set_addr_storage(struct sockaddr_storage *p_addr, cons
 		addr4->sin_port = htons(p_port); // Short, network byte order.
 
 		if (p_ip.is_valid()) {
-			memcpy(&addr4->sin_addr.s_addr, p_ip.get_ipv4(), 4);
+			std::memcpy(&addr4->sin_addr.s_addr, p_ip.get_ipv4(), 4);
 		} else {
 			addr4->sin_addr.s_addr = INADDR_ANY;
 		}
@@ -196,13 +196,13 @@ _FORCE_INLINE_ Error NetSocketWinSock::_change_multicast_group(IPAddress p_ip, S
 		ERR_FAIL_COND_V(!if_ip.is_valid(), ERR_INVALID_PARAMETER);
 		struct ip_mreq greq;
 		int sock_opt = p_add ? IP_ADD_MEMBERSHIP : IP_DROP_MEMBERSHIP;
-		memcpy(&greq.imr_multiaddr, p_ip.get_ipv4(), 4);
-		memcpy(&greq.imr_interface, if_ip.get_ipv4(), 4);
+		std::memcpy(&greq.imr_multiaddr, p_ip.get_ipv4(), 4);
+		std::memcpy(&greq.imr_interface, if_ip.get_ipv4(), 4);
 		ret = setsockopt(_sock, level, sock_opt, (const char *)&greq, sizeof(greq));
 	} else {
 		struct ipv6_mreq greq;
 		int sock_opt = p_add ? IPV6_ADD_MEMBERSHIP : IPV6_DROP_MEMBERSHIP;
-		memcpy(&greq.ipv6mr_multiaddr, p_ip.get_ipv6(), 16);
+		std::memcpy(&greq.ipv6mr_multiaddr, p_ip.get_ipv6(), 16);
 		greq.ipv6mr_interface = if_v6id;
 		ret = setsockopt(_sock, level, sock_opt, (const char *)&greq, sizeof(greq));
 	}
@@ -420,7 +420,7 @@ Error NetSocketWinSock::recvfrom(uint8_t *p_buffer, int p_len, int &r_read, IPAd
 
 	struct sockaddr_storage from;
 	socklen_t len = sizeof(struct sockaddr_storage);
-	memset(&from, 0, len);
+	std::memset(&from, 0, len);
 
 	r_read = ::recvfrom(_sock, (char *)p_buffer, p_len, p_peek ? MSG_PEEK : 0, (struct sockaddr *)&from, &len);
 

--- a/editor/editor_translation.cpp
+++ b/editor/editor_translation.cpp
@@ -170,7 +170,7 @@ Vector<Vector<String>> get_extractable_message_list() {
 	Vector<Vector<String>> list;
 
 	while (etl->data) {
-		if (strcmp(etl->lang, "source")) {
+		if (std::strcmp(etl->lang, "source")) {
 			etl++;
 			continue;
 		}

--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -933,7 +933,7 @@ CodeSignCodeDirectory::CodeSignCodeDirectory(uint8_t p_hash_size, uint8_t p_hash
 		blob.push_back(x);
 	}
 	blob.resize(cd_size);
-	memset(blob.ptrw() + 8, 0x00, cd_size - 8);
+	std::memset(blob.ptrw() + 8, 0x00, cd_size - 8);
 	CodeDirectoryHeader *cd = reinterpret_cast<CodeDirectoryHeader *>(blob.ptrw() + 8);
 
 	bool is_64_cl = (p_code_limit >= std::numeric_limits<uint32_t>::max());
@@ -963,13 +963,13 @@ CodeSignCodeDirectory::CodeSignCodeDirectory(uint8_t p_hash_size, uint8_t p_hash
 
 	// Copy ID.
 	cd->ident_offset = BSWAP32(cd_off);
-	memcpy(blob.ptrw() + cd_off, p_id.get_data(), p_id.size());
+	std::memcpy(blob.ptrw() + cd_off, p_id.get_data(), p_id.size());
 	cd_off += p_id.size();
 
 	// Copy Team ID.
 	if (p_team_id.length() > 0) {
 		cd->team_offset = BSWAP32(cd_off);
-		memcpy(blob.ptrw() + cd_off, p_team_id.get_data(), p_team_id.size());
+		std::memcpy(blob.ptrw() + cd_off, p_team_id.get_data(), p_team_id.size());
 		cd_off += p_team_id.size();
 	} else {
 		cd->team_offset = 0;

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1399,7 +1399,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				CharString cs = import_text.utf8();
 				Vector<uint8_t> sarr;
 				sarr.resize(cs.size());
-				memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
+				std::memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
 
 				err = save_proxy.save_file(p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed);
 				if (err != OK) {
@@ -1466,7 +1466,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				CharString cs = import_text.utf8();
 				Vector<uint8_t> sarr;
 				sarr.resize(cs.size());
-				memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
+				std::memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
 
 				err = save_proxy.save_file(p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed);
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -850,13 +850,13 @@ void EditorAssetLibrary::_image_update(bool p_use_cache, bool p_final, const Pac
 	if (r) {
 		Ref<Image> parsed_image;
 
-		if ((memcmp(&r[0], &png_signature[0], 8) == 0) && Image::_png_mem_loader_func) {
+		if ((std::memcmp(&r[0], &png_signature[0], 8) == 0) && Image::_png_mem_loader_func) {
 			parsed_image = Image::_png_mem_loader_func(r, len);
-		} else if ((memcmp(&r[0], &jpg_signature[0], 3) == 0) && Image::_jpg_mem_loader_func) {
+		} else if ((std::memcmp(&r[0], &jpg_signature[0], 3) == 0) && Image::_jpg_mem_loader_func) {
 			parsed_image = Image::_jpg_mem_loader_func(r, len);
-		} else if ((memcmp(&r[0], &webp_signature[0], 4) == 0) && Image::_webp_mem_loader_func) {
+		} else if ((std::memcmp(&r[0], &webp_signature[0], 4) == 0) && Image::_webp_mem_loader_func) {
 			parsed_image = Image::_webp_mem_loader_func(r, len);
-		} else if ((memcmp(&r[0], &bmp_signature[0], 2) == 0) && Image::_bmp_mem_loader_func) {
+		} else if ((std::memcmp(&r[0], &bmp_signature[0], 2) == 0) && Image::_bmp_mem_loader_func) {
 			parsed_image = Image::_bmp_mem_loader_func(r, len);
 		} else if (Image::_svg_scalable_mem_loader_func) {
 			parsed_image = Image::_svg_scalable_mem_loader_func(r, len, 1.0);

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -913,7 +913,7 @@ void GPUParticles3DEditorPlugin::_generate_emission_points() {
 
 	{
 		uint8_t *iw = point_img.ptrw();
-		memset(iw, 0, w * h * 3 * sizeof(float));
+		std::memset(iw, 0, w * h * 3 * sizeof(float));
 		const Vector3 *r = points.ptr();
 		float *wf = reinterpret_cast<float *>(iw);
 		for (int i = 0; i < point_count; i++) {
@@ -942,7 +942,7 @@ void GPUParticles3DEditorPlugin::_generate_emission_points() {
 
 		{
 			uint8_t *iw = point_img2.ptrw();
-			memset(iw, 0, w * h * 3 * sizeof(float));
+			std::memset(iw, 0, w * h * 3 * sizeof(float));
 			const Vector3 *r = normals.ptr();
 			float *wf = reinterpret_cast<float *>(iw);
 			for (int i = 0; i < point_count; i++) {

--- a/editor/themes/editor_icons.cpp
+++ b/editor/themes/editor_icons.cpp
@@ -242,7 +242,7 @@ void editor_copy_icons(const Ref<Theme> &p_theme, const Ref<Theme> &p_old_theme)
 String get_default_project_icon() {
 	// FIXME: This icon can probably be predefined in editor_icons.gen.h so we don't have to look up.
 	for (int i = 0; i < editor_icons_count; i++) {
-		if (strcmp(editor_icons_names[i], "DefaultProjectIcon") == 0) {
+		if (std::strcmp(editor_icons_names[i], "DefaultProjectIcon") == 0) {
 			return String(editor_icons_sources[i]);
 		}
 	}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -906,11 +906,11 @@ void Main::test_cleanup() {
 int Main::test_entrypoint(int argc, char *argv[], bool &tests_need_run) {
 	for (int x = 0; x < argc; x++) {
 		// Early return to ignore a possible user-provided "--test" argument.
-		if ((strlen(argv[x]) == 2) && ((strncmp(argv[x], "--", 2) == 0) || (strncmp(argv[x], "++", 2) == 0))) {
+		if ((std::strlen(argv[x]) == 2) && ((std::strncmp(argv[x], "--", 2) == 0) || (std::strncmp(argv[x], "++", 2) == 0))) {
 			tests_need_run = false;
 			return EXIT_SUCCESS;
 		}
-		if ((strncmp(argv[x], "--test", 6) == 0) && (strlen(argv[x]) == 6)) {
+		if ((std::strncmp(argv[x], "--test", 6) == 0) && (std::strlen(argv[x]) == 6)) {
 			tests_need_run = true;
 #ifdef TESTS_ENABLED
 			// TODO: need to come up with different test contexts.

--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -207,7 +207,7 @@ Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::UsedCha
 			// Copy the source mipmap's data to a BasisU image.
 			if (is_hdr) {
 				basisu::imagef basisu_image(width, height);
-				memcpy(reinterpret_cast<uint8_t *>(basisu_image.get_ptr()), image_mip_data, size);
+				std::memcpy(reinterpret_cast<uint8_t *>(basisu_image.get_ptr()), image_mip_data, size);
 
 				if (i == 0) {
 					params.m_source_images_hdr.push_back(basisu_image);
@@ -217,7 +217,7 @@ Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::UsedCha
 
 			} else {
 				basisu::image basisu_image(width, height);
-				memcpy(basisu_image.get_ptr(), image_mip_data, size);
+				std::memcpy(basisu_image.get_ptr(), image_mip_data, size);
 
 				if (i == 0) {
 					params.m_source_images.push_back(basisu_image);
@@ -249,7 +249,7 @@ Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::UsedCha
 
 	// Copy the encoded BasisU data into the output buffer.
 	*(uint32_t *)basisu_data_ptr = decompress_format;
-	memcpy(basisu_data_ptr + 4, basisu_encoded.get_ptr(), basisu_encoded.size());
+	std::memcpy(basisu_data_ptr + 4, basisu_encoded.get_ptr(), basisu_encoded.size());
 
 	print_verbose(vformat("BasisU: Encoding a %dx%d image with %d mipmaps took %d ms.", p_image->get_width(), p_image->get_height(), p_image->get_mipmap_count(), OS::get_singleton()->get_ticks_msec() - start_time));
 
@@ -411,7 +411,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 	out_data.resize(Image::get_image_data_size(basisu_info.m_width, basisu_info.m_height, image_format, basisu_info.m_total_levels > 1));
 
 	uint8_t *dst = out_data.ptrw();
-	memset(dst, 0, out_data.size());
+	std::memset(dst, 0, out_data.size());
 
 	for (uint32_t i = 0; i < basisu_info.m_total_levels; i++) {
 		basist::basisu_image_level_info basisu_level;

--- a/modules/bcdec/image_decompress_bcdec.cpp
+++ b/modules/bcdec/image_decompress_bcdec.cpp
@@ -58,26 +58,26 @@ static void decompress_image(BCdecFormat format, const void *src, void *dst, con
 		dst_pos += 3 * width * color_bytesize;                                          \
 	}
 
-#define DECOMPRESS_LOOP_SAFE(func, block_size, color_bytesize, color_components, output)                                                              \
-	for (uint64_t y = 0; y < height; y += 4) {                                                                                                        \
-		for (uint64_t x = 0; x < width; x += 4) {                                                                                                     \
-			const uint32_t yblock = MIN(height - y, 4ul);                                                                                             \
-			const uint32_t xblock = MIN(width - x, 4ul);                                                                                              \
-                                                                                                                                                      \
-			const bool incomplete = yblock < 4 || xblock < 4;                                                                                         \
-			uint8_t *dec_out = incomplete ? output : &dec_blocks[y * 4 * width + x * color_bytesize];                                                 \
-                                                                                                                                                      \
-			func(&src_blocks[src_pos], dec_out, 4 * color_components);                                                                                \
-			src_pos += block_size;                                                                                                                    \
-                                                                                                                                                      \
-			if (incomplete) {                                                                                                                         \
-				for (uint32_t cy = 0; cy < yblock; cy++) {                                                                                            \
-					for (uint32_t cx = 0; cx < xblock; cx++) {                                                                                        \
-						memcpy(&dec_blocks[(y + cy) * 4 * width + (x + cx) * color_bytesize], &output[cy * 4 + cx * color_bytesize], color_bytesize); \
-					}                                                                                                                                 \
-				}                                                                                                                                     \
-			}                                                                                                                                         \
-		}                                                                                                                                             \
+#define DECOMPRESS_LOOP_SAFE(func, block_size, color_bytesize, color_components, output)                                                                   \
+	for (uint64_t y = 0; y < height; y += 4) {                                                                                                             \
+		for (uint64_t x = 0; x < width; x += 4) {                                                                                                          \
+			const uint32_t yblock = MIN(height - y, 4ul);                                                                                                  \
+			const uint32_t xblock = MIN(width - x, 4ul);                                                                                                   \
+                                                                                                                                                           \
+			const bool incomplete = yblock < 4 || xblock < 4;                                                                                              \
+			uint8_t *dec_out = incomplete ? output : &dec_blocks[y * 4 * width + x * color_bytesize];                                                      \
+                                                                                                                                                           \
+			func(&src_blocks[src_pos], dec_out, 4 * color_components);                                                                                     \
+			src_pos += block_size;                                                                                                                         \
+                                                                                                                                                           \
+			if (incomplete) {                                                                                                                              \
+				for (uint32_t cy = 0; cy < yblock; cy++) {                                                                                                 \
+					for (uint32_t cx = 0; cx < xblock; cx++) {                                                                                             \
+						std::memcpy(&dec_blocks[(y + cy) * 4 * width + (x + cx) * color_bytesize], &output[cy * 4 + cx * color_bytesize], color_bytesize); \
+					}                                                                                                                                      \
+				}                                                                                                                                          \
+			}                                                                                                                                              \
+		}                                                                                                                                                  \
 	}
 
 	if (width % 4 != 0 || height % 4 != 0) {

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -439,7 +439,7 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 	if ((dest_format == Image::FORMAT_DXT1 || dest_format == Image::FORMAT_DXT5) && dxt1_encoding_table_buffer.is_null()) {
 		Vector<uint8_t> data;
 		data.resize(1024 * 4);
-		memcpy(data.ptrw(), dxt1_encoding_table, 1024 * 4);
+		std::memcpy(data.ptrw(), dxt1_encoding_table, 1024 * 4);
 
 		dxt1_encoding_table_buffer = compress_rd->storage_buffer_create(1024 * 4, data);
 	}
@@ -484,25 +484,25 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 			int x = 0, y = 0;
 			for (y = 0; y < src_mip_h; y++) {
 				for (x = 0; x < src_mip_w; x++) {
-					memcpy(ptrw + (width * y + x) * px_size, src_mip_read + (src_mip_w * y + x) * px_size, px_size);
+					std::memcpy(ptrw + (width * y + x) * px_size, src_mip_read + (src_mip_w * y + x) * px_size, px_size);
 				}
 
 				// First, smear in x.
 				for (; x < width; x++) {
-					memcpy(ptrw + (width * y + x) * px_size, ptrw + (width * y + x - 1) * px_size, px_size);
+					std::memcpy(ptrw + (width * y + x) * px_size, ptrw + (width * y + x - 1) * px_size, px_size);
 				}
 			}
 
 			// Then, smear in y.
 			for (; y < height; y++) {
 				for (x = 0; x < width; x++) {
-					memcpy(ptrw + (width * y + x) * px_size, ptrw + (width * y + x - width) * px_size, px_size);
+					std::memcpy(ptrw + (width * y + x) * px_size, ptrw + (width * y + x - width) * px_size, px_size);
 				}
 			}
 		} else {
 			// Create a buffer filled with the source mip layer data.
 			src_image_ptr[0].resize(src_mip_size);
-			memcpy(src_image_ptr[0].ptrw(), r_img->ptr() + src_mip_ofs, src_mip_size);
+			std::memcpy(src_image_ptr[0].ptrw(), r_img->ptr() + src_mip_ofs, src_mip_size);
 		}
 
 		// Create the textures on the GPU.
@@ -685,7 +685,7 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 		const Vector<uint8_t> texture_data = compress_rd->texture_get_data(dst_texture_rid, 0);
 		int64_t dst_ofs = Image::get_image_mipmap_offset(img_width, img_height, dest_format, i);
 
-		memcpy(dst_data_ptr + dst_ofs, texture_data.ptr(), texture_data.size());
+		std::memcpy(dst_data_ptr + dst_ofs, texture_data.ptr(), texture_data.size());
 
 		// Free the source and dest texture.
 		compress_rd->free(src_texture);

--- a/modules/camera/buffer_decoder.cpp
+++ b/modules/camera/buffer_decoder.cpp
@@ -187,7 +187,7 @@ CopyBufferDecoder::CopyBufferDecoder(CameraFeed *p_camera_feed, bool p_rgba) :
 
 void CopyBufferDecoder::decode(StreamingBuffer p_buffer) {
 	uint8_t *dst = (uint8_t *)image_data.ptrw();
-	memcpy(dst, p_buffer.start, p_buffer.length);
+	std::memcpy(dst, p_buffer.start, p_buffer.length);
 
 	if (image.is_valid()) {
 		image->set_data(width, height, false, rgba ? Image::FORMAT_RGBA8 : Image::FORMAT_LA8, image_data);
@@ -205,7 +205,7 @@ JpegBufferDecoder::JpegBufferDecoder(CameraFeed *p_camera_feed) :
 void JpegBufferDecoder::decode(StreamingBuffer p_buffer) {
 	image_data.resize(p_buffer.length);
 	uint8_t *dst = (uint8_t *)image_data.ptrw();
-	memcpy(dst, p_buffer.start, p_buffer.length);
+	std::memcpy(dst, p_buffer.start, p_buffer.length);
 	if (image->load_jpg_from_buffer(image_data) == OK) {
 		camera_feed->set_rgb_image(image);
 	}

--- a/modules/camera/camera_feed_linux.cpp
+++ b/modules/camera/camera_feed_linux.cpp
@@ -63,7 +63,7 @@ void CameraFeedLinux::_query_device(const String &p_device_name) {
 
 	for (int index = 0;; index++) {
 		struct v4l2_fmtdesc fmtdesc;
-		memset(&fmtdesc, 0, sizeof(fmtdesc));
+		std::memset(&fmtdesc, 0, sizeof(fmtdesc));
 		fmtdesc.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 		fmtdesc.index = index;
 
@@ -73,7 +73,7 @@ void CameraFeedLinux::_query_device(const String &p_device_name) {
 
 		for (int res_index = 0;; res_index++) {
 			struct v4l2_frmsizeenum frmsizeenum;
-			memset(&frmsizeenum, 0, sizeof(frmsizeenum));
+			std::memset(&frmsizeenum, 0, sizeof(frmsizeenum));
 			frmsizeenum.pixel_format = fmtdesc.pixelformat;
 			frmsizeenum.index = res_index;
 
@@ -83,7 +83,7 @@ void CameraFeedLinux::_query_device(const String &p_device_name) {
 
 			for (int framerate_index = 0;; framerate_index++) {
 				struct v4l2_frmivalenum frmivalenum;
-				memset(&frmivalenum, 0, sizeof(frmivalenum));
+				std::memset(&frmivalenum, 0, sizeof(frmivalenum));
 				frmivalenum.pixel_format = fmtdesc.pixelformat;
 				frmivalenum.width = frmsizeenum.discrete.width;
 				frmivalenum.height = frmsizeenum.discrete.height;
@@ -119,7 +119,7 @@ void CameraFeedLinux::_add_format(v4l2_fmtdesc p_description, v4l2_frmsize_discr
 bool CameraFeedLinux::_request_buffers() {
 	struct v4l2_requestbuffers requestbuffers;
 
-	memset(&requestbuffers, 0, sizeof(requestbuffers));
+	std::memset(&requestbuffers, 0, sizeof(requestbuffers));
 	requestbuffers.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 	requestbuffers.memory = V4L2_MEMORY_MMAP;
 	requestbuffers.count = 4;
@@ -136,7 +136,7 @@ bool CameraFeedLinux::_request_buffers() {
 	for (unsigned int i = 0; i < buffer_count; i++) {
 		struct v4l2_buffer buffer;
 
-		memset(&buffer, 0, sizeof(buffer));
+		std::memset(&buffer, 0, sizeof(buffer));
 		buffer.type = requestbuffers.type;
 		buffer.memory = V4L2_MEMORY_MMAP;
 		buffer.index = i;
@@ -165,7 +165,7 @@ bool CameraFeedLinux::_start_capturing() {
 	for (unsigned int i = 0; i < buffer_count; i++) {
 		struct v4l2_buffer buffer;
 
-		memset(&buffer, 0, sizeof(buffer));
+		std::memset(&buffer, 0, sizeof(buffer));
 		buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 		buffer.memory = V4L2_MEMORY_MMAP;
 		buffer.index = i;
@@ -187,7 +187,7 @@ bool CameraFeedLinux::_start_capturing() {
 
 void CameraFeedLinux::_read_frame() {
 	struct v4l2_buffer buffer;
-	memset(&buffer, 0, sizeof(buffer));
+	std::memset(&buffer, 0, sizeof(buffer));
 	buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 	buffer.memory = V4L2_MEMORY_MMAP;
 
@@ -318,7 +318,7 @@ bool CameraFeedLinux::set_format(int p_index, const Dictionary &p_parameters) {
 	file_descriptor = open(device_name.ascii().get_data(), O_RDWR | O_NONBLOCK, 0);
 
 	struct v4l2_format format;
-	memset(&format, 0, sizeof(format));
+	std::memset(&format, 0, sizeof(format));
 	format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 	format.fmt.pix.width = feed_format.width;
 	format.fmt.pix.height = feed_format.height;
@@ -331,7 +331,7 @@ bool CameraFeedLinux::set_format(int p_index, const Dictionary &p_parameters) {
 
 	if (feed_format.frame_numerator > 0) {
 		struct v4l2_streamparm param;
-		memset(&param, 0, sizeof(param));
+		std::memset(&param, 0, sizeof(param));
 
 		param.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 		param.parm.capture.capability = V4L2_CAP_TIMEPERFRAME;

--- a/modules/camera/camera_linux.cpp
+++ b/modules/camera/camera_linux.cpp
@@ -67,7 +67,7 @@ void CameraLinux::_update_devices() {
 			if (count != -1) {
 				for (int i = 0; i < count; i++) {
 					struct dirent *device = devices[i];
-					if (strncmp(device->d_name, "video", 5) == 0) {
+					if (std::strncmp(device->d_name, "video", 5) == 0) {
 						String device_name = String("/dev/") + String(device->d_name);
 						if (!_has_device(device_name)) {
 							_add_device(device_name);
@@ -156,7 +156,7 @@ bool CameraLinux::_is_video_capture_device(int p_file_descriptor) {
 
 bool CameraLinux::_can_query_format(int p_file_descriptor, int p_type) {
 	struct v4l2_format format;
-	memset(&format, 0, sizeof(format));
+	std::memset(&format, 0, sizeof(format));
 	format.type = p_type;
 
 	return ioctl(p_file_descriptor, VIDIOC_G_FMT, &format) != -1;

--- a/modules/camera/camera_macos.mm
+++ b/modules/camera/camera_macos.mm
@@ -156,7 +156,7 @@
 			}
 
 			uint8_t *w = img_data[0].ptrw();
-			memcpy(w, dataY, new_width * new_height);
+			std::memcpy(w, dataY, new_width * new_height);
 
 			img[0].instantiate();
 			img[0]->set_data(new_width, new_height, 0, Image::FORMAT_R8, img_data[0]);
@@ -174,7 +174,7 @@
 			}
 
 			uint8_t *w = img_data[1].ptrw();
-			memcpy(w, dataCbCr, 2 * new_width * new_height);
+			std::memcpy(w, dataCbCr, 2 * new_width * new_height);
 
 			///TODO OpenGL doesn't support FORMAT_RG8, need to do some form of conversion
 			img[1].instantiate();

--- a/modules/cvtt/image_compress_cvtt.cpp
+++ b/modules/cvtt/image_compress_cvtt.cpp
@@ -99,10 +99,10 @@ static void _digest_row_task(const CVTTCompressionJobParams &p_job_params, const
 				int block_index = (x - x_start) / 4;
 				int block_element = (x - x_start) % 4 + first_input_element;
 				if (is_hdr) {
-					memcpy(input_blocks_hdr[block_index].m_pixels[block_element], pixel_start, bytes_per_pixel);
+					std::memcpy(input_blocks_hdr[block_index].m_pixels[block_element], pixel_start, bytes_per_pixel);
 					input_blocks_hdr[block_index].m_pixels[block_element][3] = 0x3c00; // 1.0 (unused)
 				} else {
-					memcpy(input_blocks_ldr[block_index].m_pixels[block_element], pixel_start, bytes_per_pixel);
+					std::memcpy(input_blocks_ldr[block_index].m_pixels[block_element], pixel_start, bytes_per_pixel);
 				}
 			}
 		}
@@ -124,7 +124,7 @@ static void _digest_row_task(const CVTTCompressionJobParams &p_job_params, const
 			num_real_blocks = cvtt::NumParallelBlocks;
 		}
 
-		memcpy(out_bytes, output_blocks, 16 * num_real_blocks);
+		std::memcpy(out_bytes, output_blocks, 16 * num_real_blocks);
 		out_bytes += 16 * num_real_blocks;
 	}
 }
@@ -235,25 +235,25 @@ void image_compress_cvtt(Image *p_image, Image::UsedChannels p_channels) {
 			int x = 0, y = 0;
 			for (y = 0; y < src_mip_h; y++) {
 				for (x = 0; x < src_mip_w; x++) {
-					memcpy(ptrw + (width * y + x) * px_size, src_mip_read + (src_mip_w * y + x) * px_size, px_size);
+					std::memcpy(ptrw + (width * y + x) * px_size, src_mip_read + (src_mip_w * y + x) * px_size, px_size);
 				}
 
 				// First, smear in x.
 				for (; x < width; x++) {
-					memcpy(ptrw + (width * y + x) * px_size, ptrw + (width * y + x - 1) * px_size, px_size);
+					std::memcpy(ptrw + (width * y + x) * px_size, ptrw + (width * y + x - 1) * px_size, px_size);
 				}
 			}
 
 			// Then, smear in y.
 			for (; y < height; y++) {
 				for (x = 0; x < width; x++) {
-					memcpy(ptrw + (width * y + x) * px_size, ptrw + (width * y + x - width) * px_size, px_size);
+					std::memcpy(ptrw + (width * y + x) * px_size, ptrw + (width * y + x - width) * px_size, px_size);
 				}
 			}
 		} else {
 			// Create a buffer filled with the source mip layer data.
 			in_data.resize(src_mip_size);
-			memcpy(in_data.ptrw(), p_image->ptr() + src_mip_ofs, src_mip_size);
+			std::memcpy(in_data.ptrw(), p_image->ptr() + src_mip_ofs, src_mip_size);
 		}
 
 		//const uint8_t *in_bytes = &rb[src_ofs];
@@ -338,14 +338,14 @@ void image_decompress_cvtt(Image *p_image) {
 
 			for (int x_start = 0; x_start < w; x_start += 4 * cvtt::NumParallelBlocks) {
 				uint8_t input_blocks[16 * cvtt::NumParallelBlocks];
-				memset(input_blocks, 0, sizeof(input_blocks));
+				std::memset(input_blocks, 0, sizeof(input_blocks));
 
 				unsigned int num_real_blocks = ((w - x_start) + 3) / 4;
 				if (num_real_blocks > cvtt::NumParallelBlocks) {
 					num_real_blocks = cvtt::NumParallelBlocks;
 				}
 
-				memcpy(input_blocks, in_bytes, 16 * num_real_blocks);
+				std::memcpy(input_blocks, in_bytes, 16 * num_real_blocks);
 				in_bytes += 16 * num_real_blocks;
 
 				int x_end = x_start + 4 * num_real_blocks;
@@ -380,9 +380,9 @@ void image_decompress_cvtt(Image *p_image) {
 						int block_index = (x - x_start) / 4;
 						int block_element = (x - x_start) % 4 + first_input_element;
 						if (is_hdr) {
-							memcpy(pixel_start, output_blocks_hdr[block_index].m_pixels[block_element], bytes_per_pixel);
+							std::memcpy(pixel_start, output_blocks_hdr[block_index].m_pixels[block_element], bytes_per_pixel);
 						} else {
-							memcpy(pixel_start, output_blocks_ldr[block_index].m_pixels[block_element], bytes_per_pixel);
+							std::memcpy(pixel_start, output_blocks_ldr[block_index].m_pixels[block_element], bytes_per_pixel);
 						}
 					}
 				}

--- a/modules/enet/enet_connection.cpp
+++ b/modules/enet/enet_connection.cpp
@@ -47,7 +47,7 @@ Error ENetConnection::create_host_bound(const IPAddress &p_bind_address, int p_p
 	ERR_FAIL_COND_V_MSG(p_port < 0 || p_port > 65535, ERR_INVALID_PARAMETER, "The local port number must be between 0 and 65535 (inclusive).");
 
 	ENetAddress address;
-	memset(&address, 0, sizeof(address));
+	std::memset(&address, 0, sizeof(address));
 	address.port = p_port;
 #ifdef GODOT_ENET
 	if (p_bind_address.is_wildcard()) {
@@ -427,7 +427,7 @@ size_t ENetConnection::Compressor::enet_compress(void *context, const ENetBuffer
 	while (total) {
 		for (size_t i = 0; i < inBufferCount; i++) {
 			int to_copy = MIN(total, int(inBuffers[i].dataLength));
-			memcpy(&compressor->src_mem.write[ofs], inBuffers[i].data, to_copy);
+			std::memcpy(&compressor->src_mem.write[ofs], inBuffers[i].data, to_copy);
 			ofs += to_copy;
 			total -= to_copy;
 		}
@@ -464,7 +464,7 @@ size_t ENetConnection::Compressor::enet_compress(void *context, const ENetBuffer
 		return 0; // Do not bother
 	}
 
-	memcpy(outData, compressor->dst_mem.ptr(), ret);
+	std::memcpy(outData, compressor->dst_mem.ptr(), ret);
 
 	return ret;
 }

--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -365,7 +365,7 @@ Error ENetMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size
 #endif
 
 	ENetPacket *packet = enet_packet_create(nullptr, p_buffer_size, packet_flags);
-	memcpy(&packet->data[0], p_buffer, p_buffer_size);
+	std::memcpy(&packet->data[0], p_buffer, p_buffer_size);
 
 	if (is_server()) {
 		if (target_peer == 0) {

--- a/modules/etcpak/image_decompress_etcpak.cpp
+++ b/modules/etcpak/image_decompress_etcpak.cpp
@@ -54,26 +54,26 @@ static void decompress_image(EtcpakFormat format, const void *src, void *dst, co
 		dst_pos += 3 * width * m_color_bytesize;                       \
 	}
 
-#define DECOMPRESS_LOOP_SAFE(m_func, m_block_size, m_color_bytesize, m_output)                                                                                \
-	for (uint64_t y = 0; y < height; y += 4) {                                                                                                                \
-		for (uint64_t x = 0; x < width; x += 4) {                                                                                                             \
-			const uint32_t yblock = MIN(height - y, 4ul);                                                                                                     \
-			const uint32_t xblock = MIN(width - x, 4ul);                                                                                                      \
-                                                                                                                                                              \
-			const bool incomplete = yblock < 4 && xblock < 4;                                                                                                 \
-			uint8_t *dec_out = incomplete ? m_output : &dec_blocks[y * 4 * width + x * m_color_bytesize];                                                     \
-                                                                                                                                                              \
-			m_func(&src_blocks[src_pos], dec_out, incomplete ? 4 : width);                                                                                    \
-			src_pos += m_block_size;                                                                                                                          \
-                                                                                                                                                              \
-			if (incomplete) {                                                                                                                                 \
-				for (uint32_t cy = 0; cy < yblock; cy++) {                                                                                                    \
-					for (uint32_t cx = 0; cx < xblock; cx++) {                                                                                                \
-						memcpy(&dec_blocks[(y + cy) * 4 * width + (x + cx) * m_color_bytesize], &m_output[cy * 4 + cx * m_color_bytesize], m_color_bytesize); \
-					}                                                                                                                                         \
-				}                                                                                                                                             \
-			}                                                                                                                                                 \
-		}                                                                                                                                                     \
+#define DECOMPRESS_LOOP_SAFE(m_func, m_block_size, m_color_bytesize, m_output)                                                                                     \
+	for (uint64_t y = 0; y < height; y += 4) {                                                                                                                     \
+		for (uint64_t x = 0; x < width; x += 4) {                                                                                                                  \
+			const uint32_t yblock = MIN(height - y, 4ul);                                                                                                          \
+			const uint32_t xblock = MIN(width - x, 4ul);                                                                                                           \
+                                                                                                                                                                   \
+			const bool incomplete = yblock < 4 && xblock < 4;                                                                                                      \
+			uint8_t *dec_out = incomplete ? m_output : &dec_blocks[y * 4 * width + x * m_color_bytesize];                                                          \
+                                                                                                                                                                   \
+			m_func(&src_blocks[src_pos], dec_out, incomplete ? 4 : width);                                                                                         \
+			src_pos += m_block_size;                                                                                                                               \
+                                                                                                                                                                   \
+			if (incomplete) {                                                                                                                                      \
+				for (uint32_t cy = 0; cy < yblock; cy++) {                                                                                                         \
+					for (uint32_t cx = 0; cx < xblock; cx++) {                                                                                                     \
+						std::memcpy(&dec_blocks[(y + cy) * 4 * width + (x + cx) * m_color_bytesize], &m_output[cy * 4 + cx * m_color_bytesize], m_color_bytesize); \
+					}                                                                                                                                              \
+				}                                                                                                                                                  \
+			}                                                                                                                                                      \
+		}                                                                                                                                                          \
 	}
 
 	if (width % 4 != 0 || height % 4 != 0) {

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1069,7 +1069,7 @@ Error FBXDocument::_parse_images(Ref<FBXState> p_state, const String &p_base_pat
 		Vector<uint8_t> data;
 		if (fbx_texture_file.content.size > 0 && fbx_texture_file.content.size <= INT_MAX) {
 			data.resize(int(fbx_texture_file.content.size));
-			memcpy(data.ptrw(), fbx_texture_file.content.data, fbx_texture_file.content.size);
+			std::memcpy(data.ptrw(), fbx_texture_file.content.data, fbx_texture_file.content.size);
 		} else {
 			String base_dir = p_state->get_base_path();
 			Ref<Texture2D> texture = ResourceLoader::load(_get_texture_path(base_dir, path), "Texture2D");

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -485,7 +485,7 @@ void GDScriptTest::error_handler(void *p_this, const char *p_function, const cha
 
 	StringBuilder error_string;
 	error_string.append(vformat(">> %s: %s\n", header, String::utf8(p_error)));
-	if (strlen(p_explanation) > 0) {
+	if (std::strlen(p_explanation) > 0) {
 		error_string.append(vformat(">>   %s\n", String::utf8(p_explanation)));
 	}
 

--- a/modules/glslang/register_types.cpp
+++ b/modules/glslang/register_types.cpp
@@ -181,7 +181,7 @@ static Vector<uint8_t> _compile_shader_glsl(RenderingDevice::ShaderStage p_stage
 	ret.resize(SpirV.size() * sizeof(uint32_t));
 	{
 		uint8_t *w = ret.ptrw();
-		memcpy(w, &SpirV[0], SpirV.size() * sizeof(uint32_t));
+		std::memcpy(w, &SpirV[0], SpirV.size() * sizeof(uint32_t));
 	}
 
 	return ret;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -1229,7 +1229,7 @@ Error GLTFDocument::_encode_buffer_view(Ref<GLTFState> p_state, const double *p_
 			const int64_t old_size = gltf_buffer.size();
 			const size_t buffer_size = buffer.size() * sizeof(int8_t);
 			gltf_buffer.resize(old_size + buffer_size);
-			memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
+			std::memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
 			bv->byte_length = buffer_size;
 		} break;
 		case GLTFAccessor::COMPONENT_TYPE_UNSIGNED_BYTE: {
@@ -1277,7 +1277,7 @@ Error GLTFDocument::_encode_buffer_view(Ref<GLTFState> p_state, const double *p_
 			const int64_t old_size = gltf_buffer.size();
 			const size_t buffer_size = buffer.size() * sizeof(int16_t);
 			gltf_buffer.resize(old_size + buffer_size);
-			memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
+			std::memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
 			bv->byte_length = buffer_size;
 		} break;
 		case GLTFAccessor::COMPONENT_TYPE_UNSIGNED_SHORT: {
@@ -1302,7 +1302,7 @@ Error GLTFDocument::_encode_buffer_view(Ref<GLTFState> p_state, const double *p_
 			const int64_t old_size = gltf_buffer.size();
 			const size_t buffer_size = buffer.size() * sizeof(uint16_t);
 			gltf_buffer.resize(old_size + buffer_size);
-			memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
+			std::memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
 			bv->byte_length = buffer_size;
 		} break;
 		case GLTFAccessor::COMPONENT_TYPE_SIGNED_INT: {
@@ -1323,7 +1323,7 @@ Error GLTFDocument::_encode_buffer_view(Ref<GLTFState> p_state, const double *p_
 			const int64_t old_size = gltf_buffer.size();
 			const size_t buffer_size = buffer.size() * sizeof(int32_t);
 			gltf_buffer.resize(old_size + buffer_size);
-			memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
+			std::memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
 			bv->byte_length = buffer_size;
 		} break;
 		case GLTFAccessor::COMPONENT_TYPE_UNSIGNED_INT: {
@@ -1344,7 +1344,7 @@ Error GLTFDocument::_encode_buffer_view(Ref<GLTFState> p_state, const double *p_
 			const int64_t old_size = gltf_buffer.size();
 			const size_t buffer_size = buffer.size() * sizeof(uint32_t);
 			gltf_buffer.resize(old_size + buffer_size);
-			memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
+			std::memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
 			bv->byte_length = buffer_size;
 		} break;
 		case GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT: {
@@ -1365,7 +1365,7 @@ Error GLTFDocument::_encode_buffer_view(Ref<GLTFState> p_state, const double *p_
 			const int64_t old_size = gltf_buffer.size();
 			const size_t buffer_size = buffer.size() * sizeof(float);
 			gltf_buffer.resize(old_size + buffer_size);
-			memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
+			std::memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
 			bv->byte_length = buffer_size;
 		} break;
 		case GLTFAccessor::COMPONENT_TYPE_DOUBLE_FLOAT: {
@@ -1386,7 +1386,7 @@ Error GLTFDocument::_encode_buffer_view(Ref<GLTFState> p_state, const double *p_
 			const int64_t old_size = gltf_buffer.size();
 			const size_t buffer_size = buffer.size() * sizeof(double);
 			gltf_buffer.resize(old_size + buffer_size);
-			memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
+			std::memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
 			bv->byte_length = buffer_size;
 		} break;
 		case GLTFAccessor::COMPONENT_TYPE_HALF_FLOAT: {
@@ -1411,7 +1411,7 @@ Error GLTFDocument::_encode_buffer_view(Ref<GLTFState> p_state, const double *p_
 			const int64_t old_size = gltf_buffer.size();
 			const size_t buffer_size = buffer.size() * sizeof(int64_t);
 			gltf_buffer.resize(old_size + buffer_size);
-			memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
+			std::memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
 			bv->byte_length = buffer_size;
 		} break;
 		case GLTFAccessor::COMPONENT_TYPE_UNSIGNED_LONG: {
@@ -1433,7 +1433,7 @@ Error GLTFDocument::_encode_buffer_view(Ref<GLTFState> p_state, const double *p_
 			const int64_t old_size = gltf_buffer.size();
 			const size_t buffer_size = buffer.size() * sizeof(uint64_t);
 			gltf_buffer.resize(old_size + buffer_size);
-			memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
+			std::memcpy(gltf_buffer.ptrw() + old_size, buffer.ptrw(), buffer_size);
 			bv->byte_length = buffer_size;
 		} break;
 	}
@@ -3955,7 +3955,7 @@ Dictionary GLTFDocument::_serialize_image(Ref<GLTFState> p_state, Ref<Image> p_i
 
 		bv->byte_length = buffer.size();
 		p_state->buffers.write[bi].resize(p_state->buffers[bi].size() + bv->byte_length);
-		memcpy(&p_state->buffers.write[bi].write[bv->byte_offset], buffer.ptr(), buffer.size());
+		std::memcpy(&p_state->buffers.write[bi].write[bv->byte_offset], buffer.ptr(), buffer.size());
 		ERR_FAIL_COND_V(bv->byte_offset + bv->byte_length > p_state->buffers[bi].size(), image_dict);
 
 		p_state->buffer_views.push_back(bv);

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -247,7 +247,7 @@ void GodotSoftBody3D::update_area() {
 	LocalVector<int> counts;
 	if (nodes.size() > 0) {
 		counts.resize(nodes.size());
-		memset(counts.ptr(), 0, counts.size() * sizeof(int));
+		std::memset(counts.ptr(), 0, counts.size() * sizeof(int));
 	}
 
 	for (Node &node : nodes) {
@@ -547,7 +547,7 @@ bool GodotSoftBody3D::create_from_trimesh(const Vector<int> &p_indices, const Ve
 	// Create links and faces from triangles.
 	LocalVector<bool> chks;
 	chks.resize(node_count * node_count);
-	memset(chks.ptr(), 0, chks.size() * sizeof(bool));
+	std::memset(chks.ptr(), 0, chks.size() * sizeof(bool));
 
 	for (uint32_t i = 0; i < triangle_count * 3; i += 3) {
 		const int idx[] = { triangles[i], triangles[i + 1], triangles[i + 2] };
@@ -738,7 +738,7 @@ void GodotSoftBody3D::reoptimize_link_order() {
 
 	// Copy the original, unsorted links to a side buffer.
 	Link *link_buffer = memnew_arr(Link, link_count);
-	memcpy(link_buffer, &(links[0]), sizeof(Link) * link_count);
+	std::memcpy(link_buffer, &(links[0]), sizeof(Link) * link_count);
 
 	// Clear out the node setup and ready list.
 	for (i = 0; i < node_count + 1; i++) {

--- a/modules/jpg/image_loader_jpegd.cpp
+++ b/modules/jpg/image_loader_jpegd.cpp
@@ -33,8 +33,6 @@
 #include <jpgd.h>
 #include <jpge.h>
 
-#include <string.h>
-
 Error jpeg_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p_buffer_len) {
 	jpgd::jpeg_decoder_mem_stream mem_stream(p_buffer, p_buffer_len);
 
@@ -75,7 +73,7 @@ Error jpeg_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p
 		jpgd::uint8 *pDst = pImage_data + y * dst_bpl;
 
 		if (comps == 1) {
-			memcpy(pDst, pScan_line, dst_bpl);
+			std::memcpy(pDst, pScan_line, dst_bpl);
 		} else {
 			// For images with more than 1 channel pScan_line will always point to a buffer
 			// containing 32-bit RGBA pixels. Alpha is always 255 and we ignore it.
@@ -146,7 +144,7 @@ public:
 	virtual bool put_buf(const void *Pbuf, int len) {
 		uint32_t base = buffer->size();
 		buffer->resize(base + len);
-		memcpy(buffer->ptrw() + base, Pbuf, len);
+		std::memcpy(buffer->ptrw() + base, Pbuf, len);
 		return true;
 	}
 };

--- a/modules/ktx/texture_loader_ktx.cpp
+++ b/modules/ktx/texture_loader_ktx.cpp
@@ -495,7 +495,7 @@ static Ref<Image> load_from_file_access(Ref<FileAccess> f, Error *r_error) {
 		}
 		int prev_size = src_data.size();
 		src_data.resize(prev_size + mip_size);
-		memcpy(src_data.ptrw() + prev_size, ktxTexture_GetData(ktx_texture) + offset, mip_size);
+		std::memcpy(src_data.ptrw() + prev_size, ktxTexture_GetData(ktx_texture) + offset, mip_size);
 	}
 
 	Ref<Image> img = memnew(Image(width, height, mipmaps - 1, format, src_data));

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -529,7 +529,7 @@ void LightmapperRD::_create_acceleration_structures(RenderingDevice *rd, Size2i 
 	triangle_indices.resize(triangle_sort.size());
 	Vector<uint32_t> grid_indices;
 	grid_indices.resize(grid_size * grid_size * grid_size * 2);
-	memset(grid_indices.ptrw(), 0, grid_indices.size() * sizeof(uint32_t));
+	std::memset(grid_indices.ptrw(), 0, grid_indices.size() * sizeof(uint32_t));
 
 	{
 		// Fill grid with cell indices.
@@ -2299,7 +2299,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	if (probe_positions.size() > 0) {
 		probe_values.resize(probe_positions.size() * 9);
 		Vector<uint8_t> probe_data = rd->buffer_get_data(light_probe_buffer);
-		memcpy(probe_values.ptrw(), probe_data.ptr(), probe_data.size());
+		std::memcpy(probe_values.ptrw(), probe_data.ptr(), probe_data.size());
 		rd->free(light_probe_buffer);
 
 #ifdef DEBUG_TEXTURES
@@ -2379,7 +2379,7 @@ Vector<Color> LightmapperRD::get_bake_probe_sh(int p_probe) const {
 	ERR_FAIL_INDEX_V(p_probe, probe_positions.size(), Vector<Color>());
 	Vector<Color> ret;
 	ret.resize(9);
-	memcpy(ret.ptrw(), &probe_values[p_probe * 9], sizeof(Color) * 9);
+	std::memcpy(ret.ptrw(), &probe_values[p_probe * 9], sizeof(Color) * 9);
 	return ret;
 }
 

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -78,7 +78,7 @@ Error CryptoKeyMbedTLS::save(const String &p_path, bool p_public_only) {
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_INVALID_PARAMETER, "Cannot save CryptoKeyMbedTLS file '" + p_path + "'.");
 
 	unsigned char w[16000];
-	memset(w, 0, sizeof(w));
+	std::memset(w, 0, sizeof(w));
 
 	int ret = 0;
 	if (p_public_only) {
@@ -91,7 +91,7 @@ Error CryptoKeyMbedTLS::save(const String &p_path, bool p_public_only) {
 		ERR_FAIL_V_MSG(FAILED, "Error writing key '" + itos(ret) + "'.");
 	}
 
-	size_t len = strlen((char *)w);
+	size_t len = std::strlen((char *)w);
 	f->store_buffer(w, len);
 	mbedtls_platform_zeroize(w, sizeof(w)); // Zeroize temporary buffer.
 	return OK;
@@ -113,7 +113,7 @@ Error CryptoKeyMbedTLS::load_from_string(const String &p_string_key, bool p_publ
 
 String CryptoKeyMbedTLS::save_to_string(bool p_public_only) {
 	unsigned char w[16000];
-	memset(w, 0, sizeof(w));
+	std::memset(w, 0, sizeof(w));
 
 	int ret = 0;
 	if (p_public_only) {
@@ -421,7 +421,7 @@ Ref<X509Certificate> CryptoMbedTLS::generate_self_signed_certificate(Ref<CryptoK
 	mbedtls_x509write_crt_set_basic_constraints(&crt, 1, 0);
 
 	unsigned char buf[4096];
-	memset(buf, 0, 4096);
+	std::memset(buf, 0, 4096);
 	int ret = mbedtls_x509write_crt_pem(&crt, buf, 4096, mbedtls_ctr_drbg_random, &ctr_drbg);
 #if MBEDTLS_VERSION_MAJOR < 3
 	mbedtls_mpi_free(&serial);
@@ -432,7 +432,7 @@ Ref<X509Certificate> CryptoMbedTLS::generate_self_signed_certificate(Ref<CryptoK
 
 	Ref<X509CertificateMbedTLS> out;
 	out.instantiate();
-	out->load_from_memory(buf, strlen((char *)buf) + 1); // Use strlen to find correct output size.
+	out->load_from_memory(buf, std::strlen((char *)buf) + 1); // Use strlen to find correct output size.
 	return out;
 }
 
@@ -492,7 +492,7 @@ Vector<uint8_t> CryptoMbedTLS::sign(HashingContext::HashType p_hash_type, const 
 			&sig_size, mbedtls_ctr_drbg_random, &ctr_drbg);
 	ERR_FAIL_COND_V_MSG(ret, out, "Error while signing: " + itos(ret));
 	out.resize(sig_size);
-	memcpy(out.ptrw(), buf, sig_size);
+	std::memcpy(out.ptrw(), buf, sig_size);
 	return out;
 }
 
@@ -515,7 +515,7 @@ Vector<uint8_t> CryptoMbedTLS::encrypt(Ref<CryptoKey> p_key, const Vector<uint8_
 	int ret = mbedtls_pk_encrypt(&(key->pkey), p_plaintext.ptr(), p_plaintext.size(), buf, &size, sizeof(buf), mbedtls_ctr_drbg_random, &ctr_drbg);
 	ERR_FAIL_COND_V_MSG(ret, out, "Error while encrypting: " + itos(ret));
 	out.resize(size);
-	memcpy(out.ptrw(), buf, size);
+	std::memcpy(out.ptrw(), buf, size);
 	return out;
 }
 
@@ -529,6 +529,6 @@ Vector<uint8_t> CryptoMbedTLS::decrypt(Ref<CryptoKey> p_key, const Vector<uint8_
 	int ret = mbedtls_pk_decrypt(&(key->pkey), p_ciphertext.ptr(), p_ciphertext.size(), buf, &size, sizeof(buf), mbedtls_ctr_drbg_random, &ctr_drbg);
 	ERR_FAIL_COND_V_MSG(ret, out, "Error while decrypting: " + itos(ret));
 	out.resize(size);
-	memcpy(out.ptrw(), buf, size);
+	std::memcpy(out.ptrw(), buf, size);
 	return out;
 }

--- a/modules/mbedtls/packet_peer_mbed_dtls.cpp
+++ b/modules/mbedtls/packet_peer_mbed_dtls.cpp
@@ -70,7 +70,7 @@ int PacketPeerMbedDTLS::bio_recv(void *ctx, unsigned char *buf, size_t len) {
 	if (err != OK) {
 		return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
 	}
-	memcpy(buf, buffer, buffer_size);
+	std::memcpy(buf, buffer, buffer_size);
 	return buffer_size;
 }
 
@@ -85,8 +85,8 @@ int PacketPeerMbedDTLS::_set_cookie() {
 	uint8_t client_id[18];
 	IPAddress addr = base->get_packet_address();
 	uint16_t port = base->get_packet_port();
-	memcpy(client_id, addr.get_ipv6(), 16);
-	memcpy(&client_id[16], (uint8_t *)&port, 2);
+	std::memcpy(client_id, addr.get_ipv6(), 16);
+	std::memcpy(&client_id[16], (uint8_t *)&port, 2);
 	return mbedtls_ssl_set_client_transport_id(tls_ctx->get_context(), client_id, 18);
 }
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -397,7 +397,7 @@ godot_packed_array godotsharp_packed_byte_array_new_mem_copy(const uint8_t *p_sr
 	PackedByteArray *array = reinterpret_cast<PackedByteArray *>(&ret);
 	array->resize(p_length);
 	uint8_t *dst = array->ptrw();
-	memcpy(dst, p_src, p_length * sizeof(uint8_t));
+	std::memcpy(dst, p_src, p_length * sizeof(uint8_t));
 	return ret;
 }
 
@@ -407,7 +407,7 @@ godot_packed_array godotsharp_packed_int32_array_new_mem_copy(const int32_t *p_s
 	PackedInt32Array *array = reinterpret_cast<PackedInt32Array *>(&ret);
 	array->resize(p_length);
 	int32_t *dst = array->ptrw();
-	memcpy(dst, p_src, p_length * sizeof(int32_t));
+	std::memcpy(dst, p_src, p_length * sizeof(int32_t));
 	return ret;
 }
 
@@ -417,7 +417,7 @@ godot_packed_array godotsharp_packed_int64_array_new_mem_copy(const int64_t *p_s
 	PackedInt64Array *array = reinterpret_cast<PackedInt64Array *>(&ret);
 	array->resize(p_length);
 	int64_t *dst = array->ptrw();
-	memcpy(dst, p_src, p_length * sizeof(int64_t));
+	std::memcpy(dst, p_src, p_length * sizeof(int64_t));
 	return ret;
 }
 
@@ -427,7 +427,7 @@ godot_packed_array godotsharp_packed_float32_array_new_mem_copy(const float *p_s
 	PackedFloat32Array *array = reinterpret_cast<PackedFloat32Array *>(&ret);
 	array->resize(p_length);
 	float *dst = array->ptrw();
-	memcpy(dst, p_src, p_length * sizeof(float));
+	std::memcpy(dst, p_src, p_length * sizeof(float));
 	return ret;
 }
 
@@ -437,7 +437,7 @@ godot_packed_array godotsharp_packed_float64_array_new_mem_copy(const double *p_
 	PackedFloat64Array *array = reinterpret_cast<PackedFloat64Array *>(&ret);
 	array->resize(p_length);
 	double *dst = array->ptrw();
-	memcpy(dst, p_src, p_length * sizeof(double));
+	std::memcpy(dst, p_src, p_length * sizeof(double));
 	return ret;
 }
 
@@ -447,7 +447,7 @@ godot_packed_array godotsharp_packed_vector2_array_new_mem_copy(const Vector2 *p
 	PackedVector2Array *array = reinterpret_cast<PackedVector2Array *>(&ret);
 	array->resize(p_length);
 	Vector2 *dst = array->ptrw();
-	memcpy(dst, p_src, p_length * sizeof(Vector2));
+	std::memcpy(dst, p_src, p_length * sizeof(Vector2));
 	return ret;
 }
 
@@ -457,7 +457,7 @@ godot_packed_array godotsharp_packed_vector3_array_new_mem_copy(const Vector3 *p
 	PackedVector3Array *array = reinterpret_cast<PackedVector3Array *>(&ret);
 	array->resize(p_length);
 	Vector3 *dst = array->ptrw();
-	memcpy(dst, p_src, p_length * sizeof(Vector3));
+	std::memcpy(dst, p_src, p_length * sizeof(Vector3));
 	return ret;
 }
 
@@ -467,7 +467,7 @@ godot_packed_array godotsharp_packed_vector4_array_new_mem_copy(const Vector4 *p
 	PackedVector4Array *array = reinterpret_cast<PackedVector4Array *>(&ret);
 	array->resize(p_length);
 	Vector4 *dst = array->ptrw();
-	memcpy(dst, p_src, p_length * sizeof(Vector4));
+	std::memcpy(dst, p_src, p_length * sizeof(Vector4));
 	return ret;
 }
 
@@ -477,7 +477,7 @@ godot_packed_array godotsharp_packed_color_array_new_mem_copy(const Color *p_src
 	PackedColorArray *array = reinterpret_cast<PackedColorArray *>(&ret);
 	array->resize(p_length);
 	Color *dst = array->ptrw();
-	memcpy(dst, p_src, p_length * sizeof(Color));
+	std::memcpy(dst, p_src, p_length * sizeof(Color));
 	return ret;
 }
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -485,7 +485,7 @@ MonoAssembly *load_assembly_from_pck(MonoAssemblyName *p_assembly_name, char **p
 	const char *culture = mono_assembly_name_get_culture(p_assembly_name);
 
 	String assembly_name;
-	if (culture && strcmp(culture, "")) {
+	if (culture && std::strcmp(culture, "")) {
 		assembly_name += culture;
 		assembly_name += "/";
 	}

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -100,7 +100,7 @@ Error SceneMultiplayer::poll() {
 			PackedByteArray pba;
 			pba.resize(len - 2);
 			if (pba.size()) {
-				memcpy(pba.ptrw(), &packet[2], len - 2);
+				std::memcpy(pba.ptrw(), &packet[2], len - 2);
 				// User callback
 				const Variant sv = sender;
 				const Variant pbav = pba;
@@ -448,7 +448,7 @@ Error SceneMultiplayer::send_bytes(Vector<uint8_t> p_data, int p_to, Multiplayer
 
 	const uint8_t *r = p_data.ptr();
 	packet_cache.write[0] = NETWORK_COMMAND_RAW;
-	memcpy(&packet_cache.write[1], &r[0], p_data.size());
+	std::memcpy(&packet_cache.write[1], &r[0], p_data.size());
 
 	multiplayer_peer->set_transfer_channel(p_channel);
 	multiplayer_peer->set_transfer_mode(p_mode);
@@ -468,7 +468,7 @@ Error SceneMultiplayer::send_auth(int p_to, Vector<uint8_t> p_data) {
 
 	packet_cache.write[0] = NETWORK_COMMAND_SYS;
 	packet_cache.write[1] = SYS_COMMAND_AUTH;
-	memcpy(&packet_cache.write[2], p_data.ptr(), p_data.size());
+	std::memcpy(&packet_cache.write[2], p_data.ptr(), p_data.size());
 
 	multiplayer_peer->set_target_peer(p_to);
 	multiplayer_peer->set_transfer_channel(0);
@@ -523,7 +523,7 @@ void SceneMultiplayer::_process_raw(int p_from, const uint8_t *p_packet, int p_p
 	out.resize(len);
 	{
 		uint8_t *w = out.ptrw();
-		memcpy(&w[0], &p_packet[1], len);
+		std::memcpy(&w[0], &p_packet[1], len);
 	}
 	emit_signal(SNAME("peer_packet"), p_from, out);
 }

--- a/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
@@ -308,7 +308,7 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(Ref<Navigation
 	rcCalcBounds(verts, nverts, bmin, bmax);
 
 	rcConfig cfg;
-	memset(&cfg, 0, sizeof(cfg));
+	std::memset(&cfg, 0, sizeof(cfg));
 
 	cfg.cs = p_navigation_mesh->get_cell_size();
 	cfg.ch = p_navigation_mesh->get_cell_height();
@@ -400,7 +400,7 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(Ref<Navigation
 
 		ERR_FAIL_COND(tri_areas.is_empty());
 
-		memset(tri_areas.ptrw(), 0, ntris * sizeof(unsigned char));
+		std::memset(tri_areas.ptrw(), 0, ntris * sizeof(unsigned char));
 		rcMarkWalkableTriangles(&ctx, cfg.walkableSlopeAngle, verts, nverts, tris, ntris, tri_areas.ptrw());
 
 		ERR_FAIL_COND(!rcRasterizeTriangles(&ctx, verts, nverts, tris, tri_areas.ptr(), ntris, *hf, cfg.walkableClimb));

--- a/modules/openxr/extensions/openxr_valve_analog_threshold_extension.cpp
+++ b/modules/openxr/extensions/openxr_valve_analog_threshold_extension.cpp
@@ -187,7 +187,7 @@ PackedByteArray OpenXRAnalogThresholdModifier::get_ip_modification() {
 
 	// Copy into byte array so we can return it.
 	ERR_FAIL_COND_V(ret.resize(sizeof(XrInteractionProfileAnalogThresholdVALVE)) != OK, ret);
-	memcpy(ret.ptrw(), &analog_threshold, sizeof(XrInteractionProfileAnalogThresholdVALVE));
+	std::memcpy(ret.ptrw(), &analog_threshold, sizeof(XrInteractionProfileAnalogThresholdVALVE));
 
 	return ret;
 }

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -444,7 +444,7 @@ bool OpenXRAPI::is_extension_enabled(const String &p_extension) const {
 	CharString extension = p_extension.ascii();
 
 	for (int i = 0; i < enabled_extensions.size(); i++) {
-		if (strcmp(enabled_extensions[i].ptr(), extension.ptr()) == 0) {
+		if (std::strcmp(enabled_extensions[i].ptr(), extension.ptr()) == 0) {
 			return true;
 		}
 	}
@@ -521,10 +521,10 @@ void OpenXRAPI::copy_string_to_char_buffer(const String p_string, char *p_buffer
 	int len = char_string.length();
 	if (len < p_buffer_len - 1) {
 		// was having weird CI issues with strcpy so....
-		memcpy(p_buffer, char_string.get_data(), len);
+		std::memcpy(p_buffer, char_string.get_data(), len);
 		p_buffer[len] = '\0';
 	} else {
-		memcpy(p_buffer, char_string.get_data(), p_buffer_len - 1);
+		std::memcpy(p_buffer, char_string.get_data(), p_buffer_len - 1);
 		p_buffer[p_buffer_len - 1] = '\0';
 	}
 }

--- a/modules/raycast/lightmap_raycaster_embree.cpp
+++ b/modules/raycast/lightmap_raycaster_embree.cpp
@@ -127,10 +127,10 @@ void LightmapRaycasterEmbree::add_mesh(const Vector<Vector3> &p_vertices, const 
 	ERR_FAIL_COND(!p_normals.is_empty() && vertex_count != p_normals.size());
 
 	Vector3 *embree_vertices = (Vector3 *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_VERTEX, 0, RTC_FORMAT_FLOAT3, sizeof(Vector3), vertex_count);
-	memcpy(embree_vertices, p_vertices.ptr(), sizeof(Vector3) * vertex_count);
+	std::memcpy(embree_vertices, p_vertices.ptr(), sizeof(Vector3) * vertex_count);
 
 	Vector2 *embree_light_uvs = (Vector2 *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_VERTEX_ATTRIBUTE, 0, RTC_FORMAT_FLOAT2, sizeof(Vector2), vertex_count);
-	memcpy(embree_light_uvs, p_uv2s.ptr(), sizeof(Vector2) * vertex_count);
+	std::memcpy(embree_light_uvs, p_uv2s.ptr(), sizeof(Vector2) * vertex_count);
 
 	uint32_t *embree_triangles = (uint32_t *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_INDEX, 0, RTC_FORMAT_UINT3, sizeof(uint32_t) * 3, vertex_count / 3);
 	for (int i = 0; i < vertex_count; i++) {
@@ -139,7 +139,7 @@ void LightmapRaycasterEmbree::add_mesh(const Vector<Vector3> &p_vertices, const 
 
 	if (!p_normals.is_empty()) {
 		Vector3 *embree_normals = (Vector3 *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_VERTEX_ATTRIBUTE, 1, RTC_FORMAT_FLOAT3, sizeof(Vector3), vertex_count);
-		memcpy(embree_normals, p_normals.ptr(), sizeof(Vector3) * vertex_count);
+		std::memcpy(embree_normals, p_normals.ptr(), sizeof(Vector3) * vertex_count);
 	}
 
 	rtcCommitGeometry(embree_mesh);

--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -77,7 +77,7 @@ void RaycastOcclusionCull::RaycastHZBuffer::resize(const Size2i &p_size) {
 	camera_rays = (CameraRayTile *)(camera_rays_unaligned_buffer + alignment - (((uint64_t)camera_rays_unaligned_buffer) % alignment));
 
 	camera_ray_masks.resize(camera_rays_tile_count * TILE_RAYS);
-	memset(camera_ray_masks.ptr(), ~0, camera_rays_tile_count * TILE_RAYS * sizeof(uint32_t));
+	std::memset(camera_ray_masks.ptr(), ~0, camera_rays_tile_count * TILE_RAYS * sizeof(uint32_t));
 }
 
 void RaycastOcclusionCull::RaycastHZBuffer::update_camera_rays(const Transform3D &p_cam_transform, const Vector3 &p_near_bottom_left, const Vector2 &p_near_extents, real_t p_z_far, bool p_cam_orthogonal) {
@@ -355,7 +355,7 @@ void RaycastOcclusionCull::Scenario::_update_dirty_instance(int p_idx, RID *p_in
 	}
 
 	occ_inst->indices.resize(occ->indices.size());
-	memcpy(occ_inst->indices.ptr(), occ->indices.ptr(), occ->indices.size() * sizeof(int32_t));
+	std::memcpy(occ_inst->indices.ptr(), occ->indices.ptr(), occ->indices.size() * sizeof(int32_t));
 }
 
 void RaycastOcclusionCull::Scenario::_transform_vertices_thread(uint32_t p_thread, TransformThreadData *p_data) {

--- a/modules/raycast/static_raycaster_embree.cpp
+++ b/modules/raycast/static_raycaster_embree.cpp
@@ -75,7 +75,7 @@ void StaticRaycasterEmbree::add_mesh(const PackedVector3Array &p_vertices, const
 	int vertex_count = p_vertices.size();
 
 	Vector3 *embree_vertices = (Vector3 *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_VERTEX, 0, RTC_FORMAT_FLOAT3, sizeof(Vector3), vertex_count);
-	memcpy(embree_vertices, p_vertices.ptr(), sizeof(Vector3) * vertex_count);
+	std::memcpy(embree_vertices, p_vertices.ptr(), sizeof(Vector3) * vertex_count);
 
 	if (p_indices.is_empty()) {
 		ERR_FAIL_COND(vertex_count % 3 != 0);
@@ -85,7 +85,7 @@ void StaticRaycasterEmbree::add_mesh(const PackedVector3Array &p_vertices, const
 		}
 	} else {
 		uint32_t *embree_triangles = (uint32_t *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_INDEX, 0, RTC_FORMAT_UINT3, sizeof(uint32_t) * 3, p_indices.size() / 3);
-		memcpy(embree_triangles, p_indices.ptr(), sizeof(uint32_t) * p_indices.size());
+		std::memcpy(embree_triangles, p_indices.ptr(), sizeof(uint32_t) * p_indices.size());
 	}
 
 	rtcCommitGeometry(embree_mesh);

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -485,7 +485,7 @@ bool TextServerAdvanced::_save_support_data(const String &p_filename) const {
 
 	PackedByteArray icu_data_static;
 	icu_data_static.resize(U_ICUDATA_SIZE);
-	memcpy(icu_data_static.ptrw(), U_ICUDATA_ENTRY_POINT, U_ICUDATA_SIZE);
+	std::memcpy(icu_data_static.ptrw(), U_ICUDATA_ENTRY_POINT, U_ICUDATA_SIZE);
 	f->store_buffer(icu_data_static);
 
 	return true;
@@ -500,7 +500,7 @@ PackedByteArray TextServerAdvanced::_get_support_data() const {
 
 	PackedByteArray icu_data_static;
 	icu_data_static.resize(U_ICUDATA_SIZE);
-	memcpy(icu_data_static.ptrw(), U_ICUDATA_ENTRY_POINT, U_ICUDATA_SIZE);
+	std::memcpy(icu_data_static.ptrw(), U_ICUDATA_ENTRY_POINT, U_ICUDATA_SIZE);
 
 	return icu_data_static;
 #else
@@ -810,7 +810,7 @@ String TextServerAdvanced::_tag_to_name(int64_t p_tag) const {
 
 	// No readable name, use tag string.
 	char name[5];
-	memset(name, 0, 5);
+	std::memset(name, 0, 5);
 	hb_tag_to_string(p_tag, name);
 	return String("custom_") + String(name);
 }
@@ -1408,13 +1408,13 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_f
 #endif
 			}
 
-			memset(&fd->stream, 0, sizeof(FT_StreamRec));
+			std::memset(&fd->stream, 0, sizeof(FT_StreamRec));
 			fd->stream.base = (unsigned char *)p_font_data->data_ptr;
 			fd->stream.size = p_font_data->data_size;
 			fd->stream.pos = 0;
 
 			FT_Open_Args fargs;
-			memset(&fargs, 0, sizeof(FT_Open_Args));
+			std::memset(&fargs, 0, sizeof(FT_Open_Args));
 			fargs.memory_base = (unsigned char *)p_font_data->data_ptr;
 			fargs.memory_size = p_font_data->data_size;
 			fargs.flags = FT_OPEN_MEMORY;
@@ -1771,7 +1771,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_f
 						PackedInt32Array lbl;
 						unsigned int text_size = hb_ot_name_get_utf32(hb_face, lbl_id, hb_language_from_string(TranslationServer::get_singleton()->get_tool_locale().ascii().get_data(), -1), nullptr, nullptr) + 1;
 						lbl.resize(text_size);
-						memset((uint32_t *)lbl.ptrw(), 0, sizeof(uint32_t) * text_size);
+						std::memset((uint32_t *)lbl.ptrw(), 0, sizeof(uint32_t) * text_size);
 						hb_ot_name_get_utf32(hb_face, lbl_id, hb_language_from_string(TranslationServer::get_singleton()->get_tool_locale().ascii().get_data(), -1), &text_size, (uint32_t *)lbl.ptrw());
 						ftr["label"] = String((const char32_t *)lbl.ptr());
 					}
@@ -1800,7 +1800,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_f
 						PackedInt32Array lbl;
 						unsigned int text_size = hb_ot_name_get_utf32(hb_face, lbl_id, hb_language_from_string(TranslationServer::get_singleton()->get_tool_locale().ascii().get_data(), -1), nullptr, nullptr) + 1;
 						lbl.resize(text_size);
-						memset((uint32_t *)lbl.ptrw(), 0, sizeof(uint32_t) * text_size);
+						std::memset((uint32_t *)lbl.ptrw(), 0, sizeof(uint32_t) * text_size);
 						hb_ot_name_get_utf32(hb_face, lbl_id, hb_language_from_string(TranslationServer::get_singleton()->get_tool_locale().ascii().get_data(), -1), &text_size, (uint32_t *)lbl.ptrw());
 						ftr["label"] = String((const char32_t *)lbl.ptr());
 					}
@@ -2056,13 +2056,13 @@ int64_t TextServerAdvanced::_font_get_face_count(const RID &p_font_rid) const {
 		}
 
 		FT_StreamRec stream;
-		memset(&stream, 0, sizeof(FT_StreamRec));
+		std::memset(&stream, 0, sizeof(FT_StreamRec));
 		stream.base = (unsigned char *)fd->data_ptr;
 		stream.size = fd->data_size;
 		stream.pos = 0;
 
 		FT_Open_Args fargs;
-		memset(&fargs, 0, sizeof(FT_Open_Args));
+		std::memset(&fargs, 0, sizeof(FT_Open_Args));
 		fargs.memory_base = (unsigned char *)fd->data_ptr;
 		fargs.memory_size = fd->data_size;
 		fargs.flags = FT_OPEN_MEMORY;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -232,7 +232,7 @@ String TextServerFallback::_tag_to_name(int64_t p_tag) const {
 
 	// No readable name, use tag string.
 	char name[5];
-	memset(name, 0, 5);
+	std::memset(name, 0, 5);
 	ot_tag_to_string(p_tag, name);
 	return String("custom_") + String(name);
 }
@@ -832,13 +832,13 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_f
 #endif
 			}
 
-			memset(&fd->stream, 0, sizeof(FT_StreamRec));
+			std::memset(&fd->stream, 0, sizeof(FT_StreamRec));
 			fd->stream.base = (unsigned char *)p_font_data->data_ptr;
 			fd->stream.size = p_font_data->data_size;
 			fd->stream.pos = 0;
 
 			FT_Open_Args fargs;
-			memset(&fargs, 0, sizeof(FT_Open_Args));
+			std::memset(&fargs, 0, sizeof(FT_Open_Args));
 			fargs.memory_base = (unsigned char *)p_font_data->data_ptr;
 			fargs.memory_size = p_font_data->data_size;
 			fargs.flags = FT_OPEN_MEMORY;
@@ -1182,13 +1182,13 @@ int64_t TextServerFallback::_font_get_face_count(const RID &p_font_rid) const {
 		}
 
 		FT_StreamRec stream;
-		memset(&stream, 0, sizeof(FT_StreamRec));
+		std::memset(&stream, 0, sizeof(FT_StreamRec));
 		stream.base = (unsigned char *)fd->data_ptr;
 		stream.size = fd->data_size;
 		stream.pos = 0;
 
 		FT_Open_Args fargs;
-		memset(&fargs, 0, sizeof(FT_Open_Args));
+		std::memset(&fargs, 0, sizeof(FT_Open_Args));
 		fargs.memory_base = (unsigned char *)fd->data_ptr;
 		fargs.memory_size = fd->data_size;
 		fargs.flags = FT_OPEN_MEMORY;

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -169,7 +169,7 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 			/* identify the codec: try theora */
 			if (!theora_p && th_decode_headerin(&ti, &tc, &ts, &op) >= 0) {
 				/* it is theora */
-				memcpy(&to, &test, sizeof(test));
+				std::memcpy(&to, &test, sizeof(test));
 				theora_p = 1;
 			} else if (!vorbis_p && vorbis_synthesis_headerin(&vi, &vc, &op) >= 0) {
 				/* it is vorbis */
@@ -182,7 +182,7 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 
 					audio_track_skip--;
 				} else {
-					memcpy(&vo, &test, sizeof(test));
+					std::memcpy(&vo, &test, sizeof(test));
 					vorbis_p = 1;
 				}
 			} else {

--- a/modules/tinyexr/image_loader_tinyexr.cpp
+++ b/modules/tinyexr/image_loader_tinyexr.cpp
@@ -95,15 +95,15 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitF
 	int idxB = -1;
 	int idxA = -1;
 	for (int c = 0; c < exr_header.num_channels; c++) {
-		if (strcmp(exr_header.channels[c].name, "R") == 0) {
+		if (std::strcmp(exr_header.channels[c].name, "R") == 0) {
 			idxR = c;
-		} else if (strcmp(exr_header.channels[c].name, "G") == 0) {
+		} else if (std::strcmp(exr_header.channels[c].name, "G") == 0) {
 			idxG = c;
-		} else if (strcmp(exr_header.channels[c].name, "B") == 0) {
+		} else if (std::strcmp(exr_header.channels[c].name, "B") == 0) {
 			idxB = c;
-		} else if (strcmp(exr_header.channels[c].name, "A") == 0) {
+		} else if (std::strcmp(exr_header.channels[c].name, "A") == 0) {
 			idxA = c;
-		} else if (strcmp(exr_header.channels[c].name, "Y") == 0) {
+		} else if (std::strcmp(exr_header.channels[c].name, "Y") == 0) {
 			idxR = c;
 			idxG = c;
 			idxB = c;

--- a/modules/tinyexr/image_saver_tinyexr.cpp
+++ b/modules/tinyexr/image_saver_tinyexr.cpp
@@ -278,7 +278,7 @@ Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale) {
 	}
 	Vector<uint8_t> buffer;
 	buffer.resize(bytes);
-	memcpy(buffer.ptrw(), mem, bytes);
+	std::memcpy(buffer.ptrw(), mem, bytes);
 	free(mem);
 	return buffer;
 }

--- a/modules/upnp/upnp_miniupnp.cpp
+++ b/modules/upnp/upnp_miniupnp.cpp
@@ -86,7 +86,7 @@ int UPNPMiniUPNP::discover(int timeout, int ttl, const String &device_filter) {
 	struct UPNPDev *dev = devlist;
 
 	while (dev) {
-		if (device_filter.is_empty() || strstr(dev->st, device_filter.utf8().get_data())) {
+		if (device_filter.is_empty() || std::strstr(dev->st, device_filter.utf8().get_data())) {
 			add_device_to_list(dev, devlist);
 		}
 

--- a/modules/vhacd/register_types.cpp
+++ b/modules/vhacd/register_types.cpp
@@ -81,7 +81,7 @@ static Vector<Vector<Vector3>> convex_decompose(const real_t *p_vertices, int p_
 			Vector<uint32_t> &indices = r_convex_indices->write[i];
 			indices.resize(hull.m_nTriangles * 3);
 
-			memcpy(indices.ptrw(), hull.m_triangles, hull.m_nTriangles * 3 * sizeof(uint32_t));
+			std::memcpy(indices.ptrw(), hull.m_triangles, hull.m_nTriangles * 3 * sizeof(uint32_t));
 		}
 	}
 

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -580,7 +580,7 @@ Ref<AudioStreamOggVorbis> AudioStreamOggVorbis::load_from_buffer(const Vector<ui
 			if (copy_size > OGG_SYNC_BUFFER_SIZE) {
 				copy_size = OGG_SYNC_BUFFER_SIZE;
 			}
-			memcpy(sync_buf, &p_stream_data[cursor], copy_size);
+			std::memcpy(sync_buf, &p_stream_data[cursor], copy_size);
 			ogg_sync_wrote(&sync_state, copy_size);
 			cursor += copy_size;
 			err = ogg_sync_check(&sync_state);
@@ -635,7 +635,7 @@ Ref<AudioStreamOggVorbis> AudioStreamOggVorbis::load_from_buffer(const Vector<ui
 			if (packet.bytes > 0) {
 				PackedByteArray data;
 				data.resize(packet.bytes);
-				memcpy(data.ptrw(), packet.packet, packet.bytes);
+				std::memcpy(data.ptrw(), packet.packet, packet.bytes);
 				sorted_packets[granule_pos].push_back(data);
 				packet_count++;
 			}

--- a/modules/webp/webp_common.cpp
+++ b/modules/webp/webp_common.cpp
@@ -35,8 +35,6 @@
 #include <webp/decode.h>
 #include <webp/encode.h>
 
-#include <string.h>
-
 namespace WebPCommon {
 Vector<uint8_t> _webp_lossy_pack(const Ref<Image> &p_image, float p_quality) {
 	ERR_FAIL_COND_V(p_image.is_null() || p_image->is_empty(), Vector<uint8_t>());
@@ -116,7 +114,7 @@ Vector<uint8_t> _webp_packer(const Ref<Image> &p_image, float p_quality, bool p_
 	Vector<uint8_t> dst;
 	dst.resize(wrt.size);
 	uint8_t *w = dst.ptrw();
-	memcpy(w, wrt.mem, wrt.size);
+	std::memcpy(w, wrt.mem, wrt.size);
 	WebPMemoryWriterClear(&wrt);
 	return dst;
 }

--- a/modules/websocket/packet_buffer.h
+++ b/modules/websocket/packet_buffer.h
@@ -86,7 +86,7 @@ public:
 		ERR_FAIL_COND_V(p_bytes < (int)p.size, ERR_OUT_OF_MEMORY);
 
 		r_read = p.size;
-		memcpy(r_info, &p.info, sizeof(T));
+		std::memcpy(r_info, &p.info, sizeof(T));
 		_payload.read(r_payload, p.size);
 		return OK;
 	}

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -251,7 +251,7 @@ void WebSocketMultiplayerPeer::_poll_client() {
 			ERR_FAIL_COND(size <= 0);
 			Packet packet;
 			packet.data = (uint8_t *)memalloc(size);
-			memcpy(packet.data, in_buffer, size);
+			std::memcpy(packet.data, in_buffer, size);
 			packet.size = size;
 			packet.source = 1;
 			incoming_packets.push_back(packet);
@@ -385,7 +385,7 @@ void WebSocketMultiplayerPeer::_poll_server() {
 			}
 			Packet packet;
 			packet.data = (uint8_t *)memalloc(size);
-			memcpy(packet.data, in_buffer, size);
+			std::memcpy(packet.data, in_buffer, size);
 			packet.size = size;
 			packet.source = E.key;
 			incoming_packets.push_back(packet);

--- a/modules/xatlas_unwrap/register_types.cpp
+++ b/modules/xatlas_unwrap/register_types.cpp
@@ -60,7 +60,7 @@ bool xatlas_mesh_lightmap_unwrap_callback(float p_texel_size, const float *p_ver
 		int n_entries = cache_data[0];
 		unsigned int read_idx = 1;
 		for (int i = 0; i < n_entries; ++i) {
-			if (memcmp(&cache_data[read_idx], hash, 16) == 0) {
+			if (std::memcmp(&cache_data[read_idx], hash, 16) == 0) {
 				cached = true;
 				cache_idx = read_idx;
 				break;
@@ -187,7 +187,7 @@ bool xatlas_mesh_lightmap_unwrap_callback(float p_texel_size, const float *p_ver
 		unsigned int new_cache_idx = 0;
 
 		// hash
-		memcpy(&new_cache_data[new_cache_idx], hash, 16);
+		std::memcpy(&new_cache_data[new_cache_idx], hash, 16);
 		new_cache_idx += 4;
 
 		// size hint
@@ -200,11 +200,11 @@ bool xatlas_mesh_lightmap_unwrap_callback(float p_texel_size, const float *p_ver
 		new_cache_idx++;
 
 		// vertices
-		memcpy(&new_cache_data[new_cache_idx], *r_vertex, sizeof(int) * (*r_vertex_count));
+		std::memcpy(&new_cache_data[new_cache_idx], *r_vertex, sizeof(int) * (*r_vertex_count));
 		new_cache_idx += *r_vertex_count;
 
 		// uvs
-		memcpy(&new_cache_data[new_cache_idx], *r_uv, sizeof(float) * (*r_vertex_count) * 2);
+		std::memcpy(&new_cache_data[new_cache_idx], *r_uv, sizeof(float) * (*r_vertex_count) * 2);
 		new_cache_idx += *r_vertex_count * 2;
 
 		// index count
@@ -212,7 +212,7 @@ bool xatlas_mesh_lightmap_unwrap_callback(float p_texel_size, const float *p_ver
 		new_cache_idx++;
 
 		// indices
-		memcpy(&new_cache_data[new_cache_idx], *r_index, sizeof(int) * (*r_index_count));
+		std::memcpy(&new_cache_data[new_cache_idx], *r_index, sizeof(int) * (*r_index_count));
 
 		// Return cache data to the caller
 		*r_mesh_cache = (uint8_t *)new_cache_data;

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -30,8 +30,6 @@
 
 #include "audio_driver_opensl.h"
 
-#include <string.h>
-
 #define MAX_NUMBER_INTERFACES 3
 #define MAX_NUMBER_OUTPUT_DEVICES 6
 
@@ -103,7 +101,7 @@ void AudioDriverOpenSL::start() {
 
 	for (int i = 0; i < BUFFER_COUNT; i++) {
 		buffers[i] = memnew_arr(int16_t, buffer_size * 2);
-		memset(buffers[i], 0, buffer_size * 4);
+		std::memset(buffers[i], 0, buffer_size * 4);
 	}
 
 	mixdown_buffer = memnew_arr(int32_t, buffer_size * 2);

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -61,8 +61,6 @@
 #include "../os_android.h"
 #endif
 
-#include <string.h>
-
 static const char *ANDROID_PERMS[] = {
 	"ACCESS_CHECKIN_PROPERTIES",
 	"ACCESS_COARSE_LOCATION",
@@ -1286,7 +1284,7 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 					uint32_t manifest_cur_size = p_manifest.size();
 
 					manifest_end.resize(p_manifest.size() - ofs);
-					memcpy(manifest_end.ptrw(), &p_manifest[ofs], manifest_end.size());
+					std::memcpy(manifest_end.ptrw(), &p_manifest[ofs], manifest_end.size());
 
 					int32_t attr_name_string = string_table.find("name");
 					ERR_FAIL_COND_MSG(attr_name_string == -1, "Template does not have 'name' attribute.");
@@ -1563,7 +1561,7 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 					}
 
 					// copy footer back in
-					memcpy(&p_manifest.write[ofs], manifest_end.ptr(), manifest_end.size());
+					std::memcpy(&p_manifest.write[ofs], manifest_end.ptr(), manifest_end.size());
 				}
 			} break;
 		}
@@ -1783,7 +1781,7 @@ void EditorExportPlatformAndroid::_load_image_data(const Ref<Image> &p_splash_im
 	Error err = PNGDriverCommon::image_to_png(p_splash_image, png_buffer);
 	if (err == OK) {
 		p_data.resize(png_buffer.size());
-		memcpy(p_data.ptrw(), png_buffer.ptr(), p_data.size());
+		std::memcpy(p_data.ptrw(), png_buffer.ptr(), p_data.size());
 	} else {
 		String err_str = String("Failed to convert splash image to png.");
 		WARN_PRINT(err_str.utf8().get_data());
@@ -1802,7 +1800,7 @@ void EditorExportPlatformAndroid::_process_launcher_icons(const String &p_file_n
 	Error err = PNGDriverCommon::image_to_png(working_image, png_buffer);
 	if (err == OK) {
 		p_data.resize(png_buffer.size());
-		memcpy(p_data.ptrw(), png_buffer.ptr(), p_data.size());
+		std::memcpy(p_data.ptrw(), png_buffer.ptr(), p_data.size());
 	} else {
 		String err_str = String("Failed to convert resized icon (") + p_file_name + ") to png.";
 		WARN_PRINT(err_str.utf8().get_data());
@@ -3032,7 +3030,7 @@ void EditorExportPlatformAndroid::get_command_line_flags(const Ref<EditorExportP
 			}
 			r_command_line_flags.resize(base + 4 + length);
 			encode_uint32(length, &r_command_line_flags.write[base]);
-			memcpy(&r_command_line_flags.write[base + 4], command_line_argument.ptr(), length);
+			std::memcpy(&r_command_line_flags.write[base + 4], command_line_argument.ptr(), length);
 		}
 	}
 }
@@ -3974,7 +3972,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 	int bias = 0;
 	while (ret == UNZ_OK) {
 		unz_file_info info;
-		memset(&info, 0, sizeof(info));
+		std::memset(&info, 0, sizeof(info));
 
 		char fname[16384];
 		char extra[16384];
@@ -4003,7 +4001,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 			padding = (ZIP_ALIGNMENT - (new_offset % ZIP_ALIGNMENT)) % ZIP_ALIGNMENT;
 		}
 
-		memset(extra + info.size_file_extra, 0, padding);
+		std::memset(extra + info.size_file_extra, 0, padding);
 
 		zip_fileinfo fileinfo = get_zip_fileinfo();
 		zipOpenNewFileInZip2(final_apk,

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -45,7 +45,6 @@
 #include "main/splash.gen.h"
 #include "scene/resources/image_texture.h"
 
-#include <string.h>
 #include <sys/stat.h>
 
 // Optional environment variables for defining confidential information. If any

--- a/platform/ios/godot_ios.mm
+++ b/platform/ios/godot_ios.mm
@@ -34,7 +34,6 @@
 #include "main/main.h"
 
 #include <stdio.h>
-#include <string.h>
 #include <unistd.h>
 
 static OS_IOS *os = nullptr;
@@ -72,7 +71,7 @@ int add_cmdline(int p_argc, char **p_args) {
 }
 
 int ios_main(int argc, char **argv) {
-	size_t len = strlen(argv[0]);
+	size_t len = std::strlen(argv[0]);
 
 	while (len--) {
 		if (argv[0][len] == '/') {
@@ -82,7 +81,7 @@ int ios_main(int argc, char **argv) {
 
 	if (len >= 0) {
 		char path[512];
-		memcpy(path, argv[0], len > sizeof(path) ? sizeof(path) : len);
+		std::memcpy(path, argv[0], len > sizeof(path) ? sizeof(path) : len);
 		path[len] = 0;
 		chdir(path);
 	}

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -373,7 +373,7 @@ Error EditorExportPlatformLinuxBSD::fixup_embedded_pck(const String &p_path, int
 		f->seek(section_header_pos);
 
 		uint32_t name_offset = f->get_32();
-		if (strcmp((char *)strings + name_offset, "pck") == 0) {
+		if (std::strcmp((char *)strings + name_offset, "pck") == 0) {
 			// "pck" section found, let's patch!
 
 			if (bits == 32) {

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -382,7 +382,7 @@ bool FreeDesktopPortalDesktop::color_picker_parse_response(DBusMessageIter *p_it
 
 				DBusMessageIter var_iter;
 				dbus_message_iter_recurse(&iter, &var_iter);
-				if (strcmp(key, "color") == 0) { // (ddd)
+				if (std::strcmp(key, "color") == 0) { // (ddd)
 					if (dbus_message_iter_get_arg_type(&var_iter) == DBUS_TYPE_STRUCT) {
 						DBusMessageIter struct_iter;
 						dbus_message_iter_recurse(&var_iter, &struct_iter);
@@ -437,7 +437,7 @@ bool FreeDesktopPortalDesktop::file_chooser_parse_response(DBusMessageIter *p_it
 
 				DBusMessageIter var_iter;
 				dbus_message_iter_recurse(&iter, &var_iter);
-				if (strcmp(key, "current_filter") == 0) { // (sa(us))
+				if (std::strcmp(key, "current_filter") == 0) { // (sa(us))
 					if (dbus_message_iter_get_arg_type(&var_iter) == DBUS_TYPE_STRUCT) {
 						DBusMessageIter struct_iter;
 						dbus_message_iter_recurse(&var_iter, &struct_iter);
@@ -452,7 +452,7 @@ bool FreeDesktopPortalDesktop::file_chooser_parse_response(DBusMessageIter *p_it
 							}
 						}
 					}
-				} else if (strcmp(key, "choices") == 0) { // a(ss) {
+				} else if (std::strcmp(key, "choices") == 0) { // a(ss) {
 					if (dbus_message_iter_get_arg_type(&var_iter) == DBUS_TYPE_ARRAY) {
 						DBusMessageIter struct_iter;
 						dbus_message_iter_recurse(&var_iter, &struct_iter);
@@ -483,7 +483,7 @@ bool FreeDesktopPortalDesktop::file_chooser_parse_response(DBusMessageIter *p_it
 							}
 						}
 					}
-				} else if (strcmp(key, "uris") == 0) { // as
+				} else if (std::strcmp(key, "uris") == 0) { // as
 					if (dbus_message_iter_get_arg_type(&var_iter) == DBUS_TYPE_ARRAY) {
 						DBusMessageIter uri_iter;
 						dbus_message_iter_recurse(&var_iter, &uri_iter);

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -240,7 +240,7 @@ void JoypadLinux::monitor_joypads() {
 			char fname[64];
 
 			while ((current = readdir(input_directory)) != nullptr) {
-				if (strncmp(current->d_name, "event", 5) != 0) {
+				if (std::strncmp(current->d_name, "event", 5) != 0) {
 					continue;
 				}
 				sprintf(fname, "/dev/input/%.*s", 16, current->d_name);
@@ -412,7 +412,7 @@ void JoypadLinux::open_joypad(const char *p_path) {
 
 			if (inpid.vendor == VALVE_GAMEPAD_VID && inpid.product == VALVE_GAMEPAD_PID) {
 				if (name.begins_with(VALVE_GAMEPAD_NAME_PREFIX)) {
-					String idx_str = name.substr(strlen(VALVE_GAMEPAD_NAME_PREFIX));
+					String idx_str = name.substr(std::strlen(VALVE_GAMEPAD_NAME_PREFIX));
 					if (idx_str.is_valid_int()) {
 						joypad_info["steam_input_index"] = idx_str.to_int();
 					}

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -70,7 +70,6 @@
 #include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
@@ -170,7 +169,7 @@ String OS_LinuxBSD::get_unique_id() const {
 #if defined(__FreeBSD__)
 		const int mib[2] = { CTL_KERN, KERN_HOSTUUID };
 		char buf[4096];
-		memset(buf, 0, sizeof(buf));
+		std::memset(buf, 0, sizeof(buf));
 		size_t len = sizeof(buf) - 1;
 		if (sysctl(mib, 2, buf, &len, 0x0, 0) != -1) {
 			machine_id = String::utf8(buf).remove_char('-');
@@ -191,7 +190,7 @@ String OS_LinuxBSD::get_processor_name() const {
 #if defined(__FreeBSD__)
 	const int mib[2] = { CTL_HW, HW_MODEL };
 	char buf[4096];
-	memset(buf, 0, sizeof(buf));
+	std::memset(buf, 0, sizeof(buf));
 	size_t len = sizeof(buf) - 1;
 	if (sysctl(mib, 2, buf, &len, 0x0, 0) != -1) {
 		return String::utf8(buf);
@@ -653,7 +652,7 @@ uint64_t OS_LinuxBSD::get_embedded_pck_offset() const {
 		f->seek(section_header_pos);
 
 		uint32_t name_offset = f->get_32();
-		if (strcmp((char *)strings + name_offset, "pck") == 0) {
+		if (std::strcmp((char *)strings + name_offset, "pck") == 0) {
 			if (bits == 32) {
 				f->seek(section_header_pos + 0x10);
 				off = f->get_32();

--- a/platform/linuxbsd/wayland/detect_prime_egl.cpp
+++ b/platform/linuxbsd/wayland/detect_prime_egl.cpp
@@ -37,9 +37,6 @@
 #include "core/string/ustring.h"
 
 #include <stdlib.h>
-
-#include <cstring>
-
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -151,7 +148,7 @@ int DetectPrimeEGL::detect_prime(EGLenum p_platform_enum) {
 				// Leave it 'Unknown' otherwise.
 				if (read(fdset[0], string, sizeof(string) - 1) > 0) {
 					vendors[i] = string;
-					renderers[i] = string + strlen(string) + 1;
+					renderers[i] = string + std::strlen(string) + 1;
 				}
 			}
 
@@ -176,15 +173,15 @@ int DetectPrimeEGL::detect_prime(EGLenum p_platform_enum) {
 			const char *vendor = (const char *)glGetString(GL_VENDOR);
 			const char *renderer = (const char *)glGetString(GL_RENDERER);
 
-			unsigned int vendor_len = strlen(vendor) + 1;
-			unsigned int renderer_len = strlen(renderer) + 1;
+			unsigned int vendor_len = std::strlen(vendor) + 1;
+			unsigned int renderer_len = std::strlen(renderer) + 1;
 
 			if (vendor_len + renderer_len >= sizeof(string)) {
 				renderer_len = 200 - vendor_len;
 			}
 
-			memcpy(&string, vendor, vendor_len);
-			memcpy(&string[vendor_len], renderer, renderer_len);
+			std::memcpy(&string, vendor, vendor_len);
+			std::memcpy(&string[vendor_len], renderer, renderer_len);
 
 			if (write(fdset[1], string, vendor_len + renderer_len) == -1) {
 				print_verbose("Couldn't write vendor/renderer string.");

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -426,32 +426,32 @@ void WaylandThread::_wl_registry_on_global(void *data, struct wl_registry *wl_re
 	RegistryState *registry = (RegistryState *)data;
 	ERR_FAIL_NULL(registry);
 
-	if (strcmp(interface, wl_shm_interface.name) == 0) {
+	if (std::strcmp(interface, wl_shm_interface.name) == 0) {
 		registry->wl_shm = (struct wl_shm *)wl_registry_bind(wl_registry, name, &wl_shm_interface, 1);
 		registry->wl_shm_name = name;
 		return;
 	}
 
 	// NOTE: Deprecated.
-	if (strcmp(interface, zxdg_exporter_v1_interface.name) == 0) {
+	if (std::strcmp(interface, zxdg_exporter_v1_interface.name) == 0) {
 		registry->xdg_exporter_v1 = (struct zxdg_exporter_v1 *)wl_registry_bind(wl_registry, name, &zxdg_exporter_v1_interface, 1);
 		registry->xdg_exporter_v1_name = name;
 		return;
 	}
 
-	if (strcmp(interface, zxdg_exporter_v2_interface.name) == 0) {
+	if (std::strcmp(interface, zxdg_exporter_v2_interface.name) == 0) {
 		registry->xdg_exporter_v2 = (struct zxdg_exporter_v2 *)wl_registry_bind(wl_registry, name, &zxdg_exporter_v2_interface, 1);
 		registry->xdg_exporter_v2_name = name;
 		return;
 	}
 
-	if (strcmp(interface, wl_compositor_interface.name) == 0) {
+	if (std::strcmp(interface, wl_compositor_interface.name) == 0) {
 		registry->wl_compositor = (struct wl_compositor *)wl_registry_bind(wl_registry, name, &wl_compositor_interface, CLAMP((int)version, 1, 6));
 		registry->wl_compositor_name = name;
 		return;
 	}
 
-	if (strcmp(interface, wl_data_device_manager_interface.name) == 0) {
+	if (std::strcmp(interface, wl_data_device_manager_interface.name) == 0) {
 		registry->wl_data_device_manager = (struct wl_data_device_manager *)wl_registry_bind(wl_registry, name, &wl_data_device_manager_interface, CLAMP((int)version, 1, 3));
 		registry->wl_data_device_manager_name = name;
 
@@ -468,7 +468,7 @@ void WaylandThread::_wl_registry_on_global(void *data, struct wl_registry *wl_re
 		return;
 	}
 
-	if (strcmp(interface, wl_output_interface.name) == 0) {
+	if (std::strcmp(interface, wl_output_interface.name) == 0) {
 		struct wl_output *wl_output = (struct wl_output *)wl_registry_bind(wl_registry, name, &wl_output_interface, CLAMP((int)version, 1, 4));
 		wl_proxy_tag_godot((struct wl_proxy *)wl_output);
 
@@ -483,7 +483,7 @@ void WaylandThread::_wl_registry_on_global(void *data, struct wl_registry *wl_re
 		return;
 	}
 
-	if (strcmp(interface, wl_seat_interface.name) == 0) {
+	if (std::strcmp(interface, wl_seat_interface.name) == 0) {
 		struct wl_seat *wl_seat = (struct wl_seat *)wl_registry_bind(wl_registry, name, &wl_seat_interface, CLAMP((int)version, 1, 9));
 		wl_proxy_tag_godot((struct wl_proxy *)wl_seat);
 
@@ -534,7 +534,7 @@ void WaylandThread::_wl_registry_on_global(void *data, struct wl_registry *wl_re
 		return;
 	}
 
-	if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
+	if (std::strcmp(interface, xdg_wm_base_interface.name) == 0) {
 		registry->xdg_wm_base = (struct xdg_wm_base *)wl_registry_bind(wl_registry, name, &xdg_wm_base_interface, CLAMP((int)version, 1, 6));
 		registry->xdg_wm_base_name = name;
 
@@ -542,12 +542,12 @@ void WaylandThread::_wl_registry_on_global(void *data, struct wl_registry *wl_re
 		return;
 	}
 
-	if (strcmp(interface, wp_viewporter_interface.name) == 0) {
+	if (std::strcmp(interface, wp_viewporter_interface.name) == 0) {
 		registry->wp_viewporter = (struct wp_viewporter *)wl_registry_bind(wl_registry, name, &wp_viewporter_interface, 1);
 		registry->wp_viewporter_name = name;
 	}
 
-	if (strcmp(interface, wp_fractional_scale_manager_v1_interface.name) == 0) {
+	if (std::strcmp(interface, wp_fractional_scale_manager_v1_interface.name) == 0) {
 		registry->wp_fractional_scale_manager = (struct wp_fractional_scale_manager_v1 *)wl_registry_bind(wl_registry, name, &wp_fractional_scale_manager_v1_interface, 1);
 		registry->wp_fractional_scale_manager_name = name;
 
@@ -556,25 +556,25 @@ void WaylandThread::_wl_registry_on_global(void *data, struct wl_registry *wl_re
 		// knows), add a conditional branch for creating the add-on object.
 	}
 
-	if (strcmp(interface, zxdg_decoration_manager_v1_interface.name) == 0) {
+	if (std::strcmp(interface, zxdg_decoration_manager_v1_interface.name) == 0) {
 		registry->xdg_decoration_manager = (struct zxdg_decoration_manager_v1 *)wl_registry_bind(wl_registry, name, &zxdg_decoration_manager_v1_interface, 1);
 		registry->xdg_decoration_manager_name = name;
 		return;
 	}
 
-	if (strcmp(interface, xdg_system_bell_v1_interface.name) == 0) {
+	if (std::strcmp(interface, xdg_system_bell_v1_interface.name) == 0) {
 		registry->xdg_system_bell = (struct xdg_system_bell_v1 *)wl_registry_bind(wl_registry, name, &xdg_system_bell_v1_interface, 1);
 		registry->xdg_system_bell_name = name;
 		return;
 	}
 
-	if (strcmp(interface, xdg_activation_v1_interface.name) == 0) {
+	if (std::strcmp(interface, xdg_activation_v1_interface.name) == 0) {
 		registry->xdg_activation = (struct xdg_activation_v1 *)wl_registry_bind(wl_registry, name, &xdg_activation_v1_interface, 1);
 		registry->xdg_activation_name = name;
 		return;
 	}
 
-	if (strcmp(interface, zwp_primary_selection_device_manager_v1_interface.name) == 0) {
+	if (std::strcmp(interface, zwp_primary_selection_device_manager_v1_interface.name) == 0) {
 		registry->wp_primary_selection_device_manager = (struct zwp_primary_selection_device_manager_v1 *)wl_registry_bind(wl_registry, name, &zwp_primary_selection_device_manager_v1_interface, 1);
 
 		// This global creates some seat data. Let's do that for the ones already available.
@@ -589,31 +589,31 @@ void WaylandThread::_wl_registry_on_global(void *data, struct wl_registry *wl_re
 		}
 	}
 
-	if (strcmp(interface, zwp_relative_pointer_manager_v1_interface.name) == 0) {
+	if (std::strcmp(interface, zwp_relative_pointer_manager_v1_interface.name) == 0) {
 		registry->wp_relative_pointer_manager = (struct zwp_relative_pointer_manager_v1 *)wl_registry_bind(wl_registry, name, &zwp_relative_pointer_manager_v1_interface, 1);
 		registry->wp_relative_pointer_manager_name = name;
 		return;
 	}
 
-	if (strcmp(interface, zwp_pointer_constraints_v1_interface.name) == 0) {
+	if (std::strcmp(interface, zwp_pointer_constraints_v1_interface.name) == 0) {
 		registry->wp_pointer_constraints = (struct zwp_pointer_constraints_v1 *)wl_registry_bind(wl_registry, name, &zwp_pointer_constraints_v1_interface, 1);
 		registry->wp_pointer_constraints_name = name;
 		return;
 	}
 
-	if (strcmp(interface, zwp_pointer_gestures_v1_interface.name) == 0) {
+	if (std::strcmp(interface, zwp_pointer_gestures_v1_interface.name) == 0) {
 		registry->wp_pointer_gestures = (struct zwp_pointer_gestures_v1 *)wl_registry_bind(wl_registry, name, &zwp_pointer_gestures_v1_interface, 1);
 		registry->wp_pointer_gestures_name = name;
 		return;
 	}
 
-	if (strcmp(interface, zwp_idle_inhibit_manager_v1_interface.name) == 0) {
+	if (std::strcmp(interface, zwp_idle_inhibit_manager_v1_interface.name) == 0) {
 		registry->wp_idle_inhibit_manager = (struct zwp_idle_inhibit_manager_v1 *)wl_registry_bind(wl_registry, name, &zwp_idle_inhibit_manager_v1_interface, 1);
 		registry->wp_idle_inhibit_manager_name = name;
 		return;
 	}
 
-	if (strcmp(interface, zwp_tablet_manager_v2_interface.name) == 0) {
+	if (std::strcmp(interface, zwp_tablet_manager_v2_interface.name) == 0) {
 		registry->wp_tablet_manager = (struct zwp_tablet_manager_v2 *)wl_registry_bind(wl_registry, name, &zwp_tablet_manager_v2_interface, 1);
 		registry->wp_tablet_manager_name = name;
 
@@ -629,7 +629,7 @@ void WaylandThread::_wl_registry_on_global(void *data, struct wl_registry *wl_re
 		return;
 	}
 
-	if (strcmp(interface, zwp_text_input_manager_v3_interface.name) == 0) {
+	if (std::strcmp(interface, zwp_text_input_manager_v3_interface.name) == 0) {
 		registry->wp_text_input_manager = (struct zwp_text_input_manager_v3 *)wl_registry_bind(wl_registry, name, &zwp_text_input_manager_v3_interface, 1);
 		registry->wp_text_input_manager_name = name;
 
@@ -645,7 +645,7 @@ void WaylandThread::_wl_registry_on_global(void *data, struct wl_registry *wl_re
 		return;
 	}
 
-	if (strcmp(interface, FIFO_INTERFACE_NAME) == 0) {
+	if (std::strcmp(interface, FIFO_INTERFACE_NAME) == 0) {
 		registry->wp_fifo_manager_name = name;
 	}
 }
@@ -2219,9 +2219,9 @@ void WaylandThread::_wl_data_source_on_send(void *data, struct wl_data_source *w
 
 		bool valid_mime = false;
 
-		if (strcmp(mime_type, "text/plain;charset=utf-8") == 0) {
+		if (std::strcmp(mime_type, "text/plain;charset=utf-8") == 0) {
 			valid_mime = true;
-		} else if (strcmp(mime_type, "text/plain") == 0) {
+		} else if (std::strcmp(mime_type, "text/plain") == 0) {
 			valid_mime = true;
 		}
 
@@ -2413,7 +2413,7 @@ void WaylandThread::_wp_primary_selection_source_on_send(void *data, struct zwp_
 	if (data_to_send) {
 		ssize_t written_bytes = 0;
 
-		if (strcmp(mime_type, "text/plain") == 0) {
+		if (std::strcmp(mime_type, "text/plain") == 0) {
 			written_bytes = write(fd, data_to_send->ptr(), data_to_send->size());
 		}
 

--- a/platform/linuxbsd/x11/detect_prime_x11.cpp
+++ b/platform/linuxbsd/x11/detect_prime_x11.cpp
@@ -47,7 +47,6 @@
 #endif
 
 #include <stdlib.h>
-#include <string.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -174,7 +173,7 @@ int DetectPrimeX11::detect_prime() {
 				// Leave it 'Unknown' otherwise.
 				if (read(fdset[0], string, sizeof(string) - 1) > 0) {
 					vendors[i] = string;
-					renderers[i] = string + strlen(string) + 1;
+					renderers[i] = string + std::strlen(string) + 1;
 				}
 			}
 
@@ -207,15 +206,15 @@ int DetectPrimeX11::detect_prime() {
 			const char *vendor = (const char *)glGetString(GL_VENDOR);
 			const char *renderer = (const char *)glGetString(GL_RENDERER);
 
-			unsigned int vendor_len = strlen(vendor) + 1;
-			unsigned int renderer_len = strlen(renderer) + 1;
+			unsigned int vendor_len = std::strlen(vendor) + 1;
+			unsigned int renderer_len = std::strlen(renderer) + 1;
 
 			if (vendor_len + renderer_len >= sizeof(string)) {
 				renderer_len = 200 - vendor_len;
 			}
 
-			memcpy(&string, vendor, vendor_len);
-			memcpy(&string[vendor_len], renderer, renderer_len);
+			std::memcpy(&string, vendor, vendor_len);
+			std::memcpy(&string[vendor_len], renderer, renderer_len);
 
 			if (write(fdset[1], string, vendor_len + renderer_len) == -1) {
 				print_verbose("Couldn't write vendor/renderer string.");

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -61,7 +61,6 @@
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -779,7 +778,7 @@ String DisplayServerX11::_clipboard_get_impl(Atom p_source, Window x11_window, A
 							} else {
 								// New chunk, resize to be safe and append data.
 								incr_data.resize(MAX(data_size + len, prev_size));
-								memcpy(incr_data.ptr() + data_size, data, len);
+								std::memcpy(incr_data.ptr() + data_size, data, len);
 								data_size += len;
 							}
 						} else {
@@ -1024,7 +1023,7 @@ Ref<Image> DisplayServerX11::clipboard_get_image() const {
 							uint32_t prev_size = incr_data.size();
 							// New chunk, resize to be safe and append data.
 							incr_data.resize(MAX(data_size + len, prev_size));
-							memcpy(incr_data.ptr() + data_size, data, len);
+							std::memcpy(incr_data.ptr() + data_size, data, len);
 							data_size += len;
 						} else if (!(format == 0 && len == 0)) {
 							// For unclear reasons the first GetWindowProperty always returns a length and format of 0.
@@ -2648,7 +2647,7 @@ bool DisplayServerX11::_window_maximize_check(WindowID p_window, const char *p_a
 		Atom *atoms = (Atom *)data;
 		Atom wm_act_max_horz;
 		Atom wm_act_max_vert;
-		bool checking_state = strcmp(p_atom_name, "_NET_WM_STATE") == 0;
+		bool checking_state = std::strcmp(p_atom_name, "_NET_WM_STATE") == 0;
 		if (checking_state) {
 			wm_act_max_horz = XInternAtom(x11_display, "_NET_WM_STATE_MAXIMIZED_HORZ", False);
 			wm_act_max_vert = XInternAtom(x11_display, "_NET_WM_STATE_MAXIMIZED_VERT", False);
@@ -2791,7 +2790,7 @@ void DisplayServerX11::_validate_mode_on_map(WindowID p_window) {
 		Atom wm_above = XInternAtom(x11_display, "_NET_WM_STATE_ABOVE", False);
 
 		XClientMessageEvent xev;
-		memset(&xev, 0, sizeof(xev));
+		std::memset(&xev, 0, sizeof(xev));
 		xev.type = ClientMessage;
 		xev.window = wd.x11_window;
 		xev.message_type = wm_state;
@@ -2818,7 +2817,7 @@ void DisplayServerX11::_set_wm_maximized(WindowID p_window, bool p_enabled) {
 	Atom wm_max_horz = XInternAtom(x11_display, "_NET_WM_STATE_MAXIMIZED_HORZ", False);
 	Atom wm_max_vert = XInternAtom(x11_display, "_NET_WM_STATE_MAXIMIZED_VERT", False);
 
-	memset(&xev, 0, sizeof(xev));
+	std::memset(&xev, 0, sizeof(xev));
 	xev.type = ClientMessage;
 	xev.xclient.window = wd.x11_window;
 	xev.xclient.message_type = wm_state;
@@ -2846,7 +2845,7 @@ void DisplayServerX11::_set_wm_minimized(WindowID p_window, bool p_enabled) {
 	XEvent xev;
 	Atom wm_change = XInternAtom(x11_display, "WM_CHANGE_STATE", False);
 
-	memset(&xev, 0, sizeof(xev));
+	std::memset(&xev, 0, sizeof(xev));
 	xev.type = ClientMessage;
 	xev.xclient.window = wd.x11_window;
 	xev.xclient.message_type = wm_change;
@@ -2858,7 +2857,7 @@ void DisplayServerX11::_set_wm_minimized(WindowID p_window, bool p_enabled) {
 	Atom wm_state = XInternAtom(x11_display, "_NET_WM_STATE", False);
 	Atom wm_hidden = XInternAtom(x11_display, "_NET_WM_STATE_HIDDEN", False);
 
-	memset(&xev, 0, sizeof(xev));
+	std::memset(&xev, 0, sizeof(xev));
 	xev.type = ClientMessage;
 	xev.xclient.window = wd.x11_window;
 	xev.xclient.message_type = wm_state;
@@ -2896,7 +2895,7 @@ void DisplayServerX11::_set_wm_fullscreen(WindowID p_window, bool p_enabled, boo
 	Atom wm_state = XInternAtom(x11_display, "_NET_WM_STATE", False);
 	Atom wm_fullscreen = XInternAtom(x11_display, "_NET_WM_STATE_FULLSCREEN", False);
 
-	memset(&xev, 0, sizeof(xev));
+	std::memset(&xev, 0, sizeof(xev));
 	xev.type = ClientMessage;
 	xev.xclient.window = wd.x11_window;
 	xev.xclient.message_type = wm_state;
@@ -3110,7 +3109,7 @@ void DisplayServerX11::window_set_flag(WindowFlags p_flag, bool p_enabled, Windo
 			Atom wm_above = XInternAtom(x11_display, "_NET_WM_STATE_ABOVE", False);
 
 			XClientMessageEvent xev;
-			memset(&xev, 0, sizeof(xev));
+			std::memset(&xev, 0, sizeof(xev));
 			xev.type = ClientMessage;
 			xev.window = wd.x11_window;
 			xev.message_type = wm_state;
@@ -3226,7 +3225,7 @@ void DisplayServerX11::window_request_attention(WindowID p_window) {
 	Atom wm_state = XInternAtom(x11_display, "_NET_WM_STATE", False);
 	Atom wm_attention = XInternAtom(x11_display, "_NET_WM_STATE_DEMANDS_ATTENTION", False);
 
-	memset(&xev, 0, sizeof(xev));
+	std::memset(&xev, 0, sizeof(xev));
 	xev.type = ClientMessage;
 	xev.xclient.window = wd.x11_window;
 	xev.xclient.message_type = wm_state;
@@ -3247,7 +3246,7 @@ void DisplayServerX11::window_move_to_foreground(WindowID p_window) {
 	XEvent xev;
 	Atom net_active_window = XInternAtom(x11_display, "_NET_ACTIVE_WINDOW", False);
 
-	memset(&xev, 0, sizeof(xev));
+	std::memset(&xev, 0, sizeof(xev));
 	xev.type = ClientMessage;
 	xev.xclient.window = wd.x11_window;
 	xev.xclient.message_type = net_active_window;
@@ -5438,7 +5437,7 @@ void DisplayServerX11::process_events() {
 
 					//Reply that all is well.
 					XClientMessageEvent m;
-					memset(&m, 0, sizeof(m));
+					std::memset(&m, 0, sizeof(m));
 					m.type = ClientMessage;
 					m.display = x11_display;
 					m.window = xdnd_source_window;
@@ -5476,7 +5475,7 @@ void DisplayServerX11::process_events() {
 					//xdnd position event, reply with an XDND status message
 					//just depending on type of data for now
 					XClientMessageEvent m;
-					memset(&m, 0, sizeof(m));
+					std::memset(&m, 0, sizeof(m));
 					m.type = ClientMessage;
 					m.display = event.xclient.display;
 					m.window = event.xclient.data.l[0];
@@ -5501,7 +5500,7 @@ void DisplayServerX11::process_events() {
 					} else {
 						//Reply that we're not interested.
 						XClientMessageEvent m;
-						memset(&m, 0, sizeof(m));
+						std::memset(&m, 0, sizeof(m));
 						m.type = ClientMessage;
 						m.display = event.xclient.display;
 						m.window = event.xclient.data.l[0];
@@ -5772,7 +5771,7 @@ void DisplayServerX11::window_start_drag(WindowID p_window) {
 	}
 
 	XClientMessageEvent m;
-	memset(&m, 0, sizeof(m));
+	std::memset(&m, 0, sizeof(m));
 
 	XUngrabPointer(x11_display, CurrentTime);
 
@@ -5812,7 +5811,7 @@ void DisplayServerX11::window_start_resize(WindowResizeEdge p_edge, WindowID p_w
 	}
 
 	XClientMessageEvent m;
-	memset(&m, 0, sizeof(m));
+	std::memset(&m, 0, sizeof(m));
 
 	XUngrabPointer(x11_display, CurrentTime);
 
@@ -5960,7 +5959,7 @@ void DisplayServerX11::_set_window_taskbar_pager_enabled(Window p_window, bool p
 	Atom skipPager = XInternAtom(x11_display, "_NET_WM_STATE_SKIP_PAGER", False);
 
 	XClientMessageEvent xev;
-	memset(&xev, 0, sizeof(xev));
+	std::memset(&xev, 0, sizeof(xev));
 	xev.type = ClientMessage;
 	xev.window = p_window;
 	xev.message_type = wmState;
@@ -6128,7 +6127,7 @@ Error DisplayServerX11::request_close_embedded_process(OS::ProcessID p_pid) {
 	if (XGetWindowAttributes(x11_display, ep->process_window, &attr)) {
 		// Send the message to gracefully close the window.
 		XEvent ev;
-		memset(&ev, 0, sizeof(ev));
+		std::memset(&ev, 0, sizeof(ev));
 		ev.xclient.type = ClientMessage;
 		ev.xclient.window = ep->process_window;
 		ev.xclient.message_type = XInternAtom(x11_display, "WM_PROTOCOLS", True);

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -37,7 +37,6 @@
 #include "core/version.h"
 #include "main/main.h"
 
-#include <string.h>
 #include <unistd.h>
 
 #if defined(DEBUG_ENABLED)
@@ -63,7 +62,7 @@ static uint64_t load_address() {
 		uint32_t dyld_count = _dyld_image_count();
 		for (uint32_t i = 0; i < dyld_count; i++) {
 			const char *image_name = _dyld_get_image_name(i);
-			if (image_name && strncmp(image_name, full_path, 1024) == 0) {
+			if (image_name && std::strncmp(image_name, full_path, 1024) == 0) {
 				return cmd->vmaddr + _dyld_get_image_vmaddr_slide(i);
 			}
 		}

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3854,7 +3854,7 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 
 	r_error = OK;
 
-	memset(cursors, 0, sizeof(cursors));
+	std::memset(cursors, 0, sizeof(cursors));
 
 	event_source = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
 	ERR_FAIL_COND(!event_source);

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -639,7 +639,7 @@ void _rgba8_to_packbits_encode(int p_ch, int p_size, Vector<uint8_t> &p_source, 
 
 	int ofs = p_dest.size();
 	p_dest.resize(p_dest.size() + result.size());
-	memcpy(&p_dest.write[ofs], result.ptr(), result.size());
+	std::memcpy(&p_dest.write[ofs], result.ptr(), result.size());
 }
 
 void EditorExportPlatformMacOS::_make_icon(const Ref<EditorExportPreset> &p_preset, const Ref<Image> &p_icon, Vector<uint8_t> &p_data) {
@@ -684,10 +684,10 @@ void EditorExportPlatformMacOS::_make_icon(const Ref<EditorExportPreset> &p_pres
 				int ofs = data.size();
 				uint64_t len = png_buffer.size();
 				data.resize(data.size() + len + 8);
-				memcpy(&data.write[ofs + 8], png_buffer.ptr(), len);
+				std::memcpy(&data.write[ofs + 8], png_buffer.ptr(), len);
 				len += 8;
 				len = BSWAP32(len);
-				memcpy(&data.write[ofs], icon_infos[i].name, 4);
+				std::memcpy(&data.write[ofs], icon_infos[i].name, 4);
 				encode_uint32(len, &data.write[ofs + 4]);
 			}
 		} else {
@@ -707,7 +707,7 @@ void EditorExportPlatformMacOS::_make_icon(const Ref<EditorExportPreset> &p_pres
 
 				int len = data.size() - ofs;
 				len = BSWAP32(len);
-				memcpy(&data.write[ofs], icon_infos[i].name, 4);
+				std::memcpy(&data.write[ofs], icon_infos[i].name, 4);
 				encode_uint32(len, &data.write[ofs + 4]);
 			}
 
@@ -722,7 +722,7 @@ void EditorExportPlatformMacOS::_make_icon(const Ref<EditorExportPreset> &p_pres
 				}
 				len += 8;
 				len = BSWAP32(len);
-				memcpy(&data.write[ofs], icon_infos[i].mask_name, 4);
+				std::memcpy(&data.write[ofs], icon_infos[i].mask_name, 4);
 				encode_uint32(len, &data.write[ofs + 4]);
 			}
 		}

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -32,7 +32,6 @@
 
 #include "main/main.h"
 
-#include <string.h>
 #include <unistd.h>
 
 #if defined(SANITIZERS_ENABLED)
@@ -54,7 +53,7 @@ int main(int argc, char **argv) {
 	int first_arg = 1;
 	const char *dbg_arg = "-NSDocumentRevisionsDebugMode";
 	for (int i = 0; i < argc; i++) {
-		if (strcmp(dbg_arg, argv[i]) == 0) {
+		if (std::strcmp(dbg_arg, argv[i]) == 0) {
 			first_arg = i + 2;
 		}
 	}

--- a/platform/macos/macos_terminal_logger.mm
+++ b/platform/macos/macos_terminal_logger.mm
@@ -85,7 +85,7 @@ void MacOSTerminalLogger::log_error(const char *p_function, const char *p_file, 
 
 	for (const Ref<ScriptBacktrace> &backtrace : p_script_backtraces) {
 		os_log_error(OS_LOG_DEFAULT, "%{public}s", backtrace->format().utf8().get_data());
-		logf_error("\E[0;90m%s\E[0m\n", backtrace->format(strlen(indent)).utf8().get_data());
+		logf_error("\E[0;90m%s\E[0m\n", backtrace->format(std::strlen(indent)).utf8().get_data());
 	}
 }
 

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -519,7 +519,7 @@ void DisplayServerWeb::cursor_set_custom_image(const Ref<Resource> &p_cursor, Cu
 		}
 
 		png_image png_meta;
-		memset(&png_meta, 0, sizeof png_meta);
+		std::memset(&png_meta, 0, sizeof png_meta);
 		png_meta.version = PNG_IMAGE_VERSION;
 		png_meta.width = texture_size.width;
 		png_meta.height = texture_size.height;
@@ -1045,7 +1045,7 @@ void DisplayServerWeb::set_icon(const Ref<Image> &p_icon) {
 		}
 
 		png_image png_meta;
-		memset(&png_meta, 0, sizeof png_meta);
+		std::memset(&png_meta, 0, sizeof png_meta);
 		png_meta.version = PNG_IMAGE_VERSION;
 		png_meta.width = icon->get_width();
 		png_meta.height = icon->get_height();

--- a/platform/web/dom_keys.inc
+++ b/platform/web/dom_keys.inc
@@ -32,9 +32,9 @@
 
 // See https://w3c.github.io/uievents-code/#code-value-tables
 Key dom_code2godot_scancode(EM_UTF8 const p_code[32], EM_UTF8 const p_key[32], bool p_physical) {
-#define DOM2GODOT(p_str, p_godot_code)                                                                \
-	if (memcmp((const void *)p_str, (void *)(p_physical ? p_code : p_key), strlen(p_str) + 1) == 0) { \
-		return Key::p_godot_code;                                                                     \
+#define DOM2GODOT(p_str, p_godot_code)                                                                          \
+	if (std::memcmp((const void *)p_str, (void *)(p_physical ? p_code : p_key), std::strlen(p_str) + 1) == 0) { \
+		return Key::p_godot_code;                                                                               \
 	}
 
 	// Numpad section.
@@ -225,9 +225,9 @@ Key dom_code2godot_scancode(EM_UTF8 const p_code[32], EM_UTF8 const p_key[32], b
 }
 
 KeyLocation dom_code2godot_key_location(EM_UTF8 const p_code[32]) {
-#define DOM2GODOT(m_str, m_godot_code)                                         \
-	if (memcmp((const void *)m_str, (void *)p_code, strlen(m_str) + 1) == 0) { \
-		return KeyLocation::m_godot_code;                                      \
+#define DOM2GODOT(m_str, m_godot_code)                                                   \
+	if (std::memcmp((const void *)m_str, (void *)p_code, std::strlen(m_str) + 1) == 0) { \
+		return KeyLocation::m_godot_code;                                                \
 	}
 
 	DOM2GODOT("AltLeft", LEFT);

--- a/platform/web/export/editor_http_server.cpp
+++ b/platform/web/export/editor_http_server.cpp
@@ -45,7 +45,7 @@ void EditorHTTPServer::_clear_client() {
 	peer = Ref<StreamPeer>();
 	tls = Ref<StreamPeerTLS>();
 	tcp = Ref<StreamPeerTCP>();
-	memset(req_buf, 0, sizeof(req_buf));
+	std::memset(req_buf, 0, sizeof(req_buf));
 	time = 0;
 	req_pos = 0;
 }

--- a/platform/web/http_client_web.cpp
+++ b/platform/web/http_client_web.cpp
@@ -181,7 +181,7 @@ PackedByteArray HTTPClientWeb::read_response_body_chunk() {
 		return chunk;
 	}
 	chunk.resize(read);
-	memcpy(chunk.ptrw(), response_buffer.ptr(), read);
+	std::memcpy(chunk.ptrw(), response_buffer.ptr(), read);
 	return chunk;
 }
 

--- a/platform/windows/crash_handler_windows_seh.cpp
+++ b/platform/windows/crash_handler_windows_seh.cpp
@@ -70,7 +70,7 @@ class symbol {
 public:
 	symbol(HANDLE process, DWORD64 address) :
 			sym((sym_type *)::operator new(sizeof(*sym) + max_name_len)) {
-		memset(sym, '\0', sizeof(*sym) + max_name_len);
+		std::memset(sym, '\0', sizeof(*sym) + max_name_len);
 		sym->SizeOfStruct = sizeof(*sym);
 		sym->MaxNameLength = max_name_len;
 		DWORD64 displacement;
@@ -85,7 +85,7 @@ public:
 		}
 		std::vector<char> und_name(max_name_len);
 		UnDecorateSymbolName(sym->Name, &und_name[0], max_name_len, UNDNAME_COMPLETE);
-		return std::string(&und_name[0], strlen(&und_name[0]));
+		return std::string(&und_name[0], std::strlen(&und_name[0]));
 	}
 };
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -964,7 +964,7 @@ void DisplayServerWindows::clipboard_set(const String &p_text) {
 	ERR_FAIL_NULL_MSG(mem, "Unable to allocate memory for clipboard contents.");
 
 	LPWSTR lptstrCopy = (LPWSTR)GlobalLock(mem);
-	memcpy(lptstrCopy, utf16.get_data(), (utf16.length() + 1) * sizeof(WCHAR));
+	std::memcpy(lptstrCopy, utf16.get_data(), (utf16.length() + 1) * sizeof(WCHAR));
 	GlobalUnlock(mem);
 
 	SetClipboardData(CF_UNICODETEXT, mem);
@@ -975,7 +975,7 @@ void DisplayServerWindows::clipboard_set(const String &p_text) {
 	ERR_FAIL_NULL_MSG(mem, "Unable to allocate memory for clipboard contents.");
 
 	LPTSTR ptr = (LPTSTR)GlobalLock(mem);
-	memcpy(ptr, utf8.get_data(), utf8.length());
+	std::memcpy(ptr, utf8.get_data(), utf8.length());
 	ptr[utf8.length()] = 0;
 	GlobalUnlock(mem);
 
@@ -1251,7 +1251,7 @@ static BOOL CALLBACK _MonitorEnumProcUsableSize(HMONITOR hMonitor, HDC hdcMonito
 	EnumRectData *data = (EnumRectData *)dwData;
 	if (data->count == data->screen) {
 		MONITORINFO minfo;
-		memset(&minfo, 0, sizeof(MONITORINFO));
+		std::memset(&minfo, 0, sizeof(MONITORINFO));
 		minfo.cbSize = sizeof(MONITORINFO);
 		GetMonitorInfoA(hMonitor, &minfo);
 
@@ -1269,14 +1269,14 @@ static BOOL CALLBACK _MonitorEnumProcRefreshRate(HMONITOR hMonitor, HDC hdcMonit
 	EnumRefreshRateData *data = (EnumRefreshRateData *)dwData;
 	if (data->count == data->screen) {
 		MONITORINFOEXW minfo;
-		memset(&minfo, 0, sizeof(minfo));
+		std::memset(&minfo, 0, sizeof(minfo));
 		minfo.cbSize = sizeof(minfo);
 		GetMonitorInfoW(hMonitor, &minfo);
 
 		bool found = false;
 		for (const DISPLAYCONFIG_PATH_INFO &path : data->paths) {
 			DISPLAYCONFIG_SOURCE_DEVICE_NAME source_name;
-			memset(&source_name, 0, sizeof(source_name));
+			std::memset(&source_name, 0, sizeof(source_name));
 			source_name.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
 			source_name.header.size = sizeof(source_name);
 			source_name.header.adapterId = path.sourceInfo.adapterId;
@@ -1291,7 +1291,7 @@ static BOOL CALLBACK _MonitorEnumProcRefreshRate(HMONITOR hMonitor, HDC hdcMonit
 		}
 		if (!found) {
 			DEVMODEW dm;
-			memset(&dm, 0, sizeof(dm));
+			std::memset(&dm, 0, sizeof(dm));
 			dm.dmSize = sizeof(dm);
 			EnumDisplaySettingsW(minfo.szDevice, ENUM_CURRENT_SETTINGS, &dm);
 
@@ -3585,7 +3585,7 @@ String DisplayServerWindows::keyboard_get_layout_language(int p_index) const {
 	GetKeyboardLayoutList(layout_count, layouts);
 
 	WCHAR buf[LOCALE_NAME_MAX_LENGTH];
-	memset(buf, 0, LOCALE_NAME_MAX_LENGTH * sizeof(WCHAR));
+	std::memset(buf, 0, LOCALE_NAME_MAX_LENGTH * sizeof(WCHAR));
 	LCIDToLocaleName(MAKELCID(LOWORD(layouts[p_index]), SORT_DEFAULT), buf, LOCALE_NAME_MAX_LENGTH, 0);
 
 	memfree(layouts);
@@ -3649,7 +3649,7 @@ Key DisplayServerWindows::keyboard_get_label_from_physical(Key p_keycode) const 
 
 	HKL current_layout = GetKeyboardLayout(0);
 	static BYTE keyboard_state[256];
-	memset(keyboard_state, 0, 256);
+	std::memset(keyboard_state, 0, 256);
 	wchar_t chars[256] = {};
 	UINT extended_code = MapVirtualKey(scancode, MAPVK_VSC_TO_VK_EX);
 	if (ToUnicodeEx(extended_code, scancode, keyboard_state, chars, 255, 4, current_layout) > 0) {
@@ -3757,11 +3757,11 @@ String DisplayServerWindows::keyboard_get_layout_name(int p_index) const {
 	String ret = _get_keyboard_layout_display_name(_get_klid(layouts[p_index])); // Try reading full name from Windows registry, fallback to locale name if failed (e.g. on Wine).
 	if (ret.is_empty()) {
 		WCHAR buf[LOCALE_NAME_MAX_LENGTH];
-		memset(buf, 0, LOCALE_NAME_MAX_LENGTH * sizeof(WCHAR));
+		std::memset(buf, 0, LOCALE_NAME_MAX_LENGTH * sizeof(WCHAR));
 		LCIDToLocaleName(MAKELCID(LOWORD(layouts[p_index]), SORT_DEFAULT), buf, LOCALE_NAME_MAX_LENGTH, 0);
 
 		WCHAR name[1024];
-		memset(name, 0, 1024 * sizeof(WCHAR));
+		std::memset(name, 0, 1024 * sizeof(WCHAR));
 		GetLocaleInfoEx(buf, LOCALE_SLOCALIZEDDISPLAYNAME, (LPWSTR)&name, 1024);
 
 		ret = String::utf16((const char16_t *)name);
@@ -4058,7 +4058,7 @@ DisplayServer::IndicatorID DisplayServerWindows::create_status_indicator(const R
 	ndat.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE;
 	ndat.uCallbackMessage = WM_INDICATOR_CALLBACK_MESSAGE;
 	ndat.hIcon = hicon;
-	memcpy(ndat.szTip, p_tooltip.utf16().get_data(), MIN(p_tooltip.utf16().length(), 127) * sizeof(WCHAR));
+	std::memcpy(ndat.szTip, p_tooltip.utf16().get_data(), MIN(p_tooltip.utf16().length(), 127) * sizeof(WCHAR));
 	ndat.uVersion = NOTIFYICON_VERSION;
 
 	Shell_NotifyIconW(NIM_ADD, &ndat);
@@ -4141,7 +4141,7 @@ void DisplayServerWindows::status_indicator_set_tooltip(IndicatorID p_id, const 
 	ndat.hWnd = windows[MAIN_WINDOW_ID].hWnd;
 	ndat.uID = p_id;
 	ndat.uFlags = NIF_TIP;
-	memcpy(ndat.szTip, p_tooltip.utf16().get_data(), MIN(p_tooltip.utf16().length(), 127) * sizeof(WCHAR));
+	std::memcpy(ndat.szTip, p_tooltip.utf16().get_data(), MIN(p_tooltip.utf16().length(), 127) * sizeof(WCHAR));
 	ndat.uVersion = NOTIFYICON_VERSION;
 
 	Shell_NotifyIconW(NIM_MODIFY, &ndat);
@@ -6092,7 +6092,7 @@ void DisplayServerWindows::_process_key_events() {
 					Key physical_keycode = KeyMappingWindows::get_scansym((ke.lParam >> 16) & 0xFF, ke.lParam & (1 << 24));
 
 					static BYTE keyboard_state[256];
-					memset(keyboard_state, 0, 256);
+					std::memset(keyboard_state, 0, 256);
 					wchar_t chars[256] = {};
 					UINT extended_code = MapVirtualKey((ke.lParam >> 16) & 0xFF, MAPVK_VSC_TO_VK_EX);
 					if (!(ke.lParam & (1 << 24)) && ToUnicodeEx(extended_code, (ke.lParam >> 16) & 0xFF, keyboard_state, chars, 255, 4, GetKeyboardLayout(0)) > 0) {
@@ -6154,7 +6154,7 @@ void DisplayServerWindows::_process_key_events() {
 				KeyLocation location = KeyMappingWindows::get_location((ke.lParam >> 16) & 0xFF, ke.lParam & (1 << 24));
 
 				static BYTE keyboard_state[256];
-				memset(keyboard_state, 0, 256);
+				std::memset(keyboard_state, 0, 256);
 				wchar_t chars[256] = {};
 				UINT extended_code = MapVirtualKey((ke.lParam >> 16) & 0xFF, MAPVK_VSC_TO_VK_EX);
 				if (!(ke.lParam & (1 << 24)) && ToUnicodeEx(extended_code, (ke.lParam >> 16) & 0xFF, keyboard_state, chars, 255, 4, GetKeyboardLayout(0)) > 0) {
@@ -6936,7 +6936,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 
 	OleInitialize(nullptr);
 
-	memset(&wc, 0, sizeof(WNDCLASSEXW));
+	std::memset(&wc, 0, sizeof(WNDCLASSEXW));
 	wc.cbSize = sizeof(WNDCLASSEXW);
 	wc.style = CS_OWNDC | CS_DBLCLKS;
 	wc.lpfnWndProc = (WNDPROC)::WndProc;

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -952,7 +952,7 @@ Error EditorExportPlatformWindows::fixup_embedded_pck(const String &p_path, int6
 		f->get_buffer(section_name, 8);
 		section_name[8] = '\0';
 
-		if (strcmp((char *)section_name, "pck") == 0) {
+		if (std::strcmp((char *)section_name, "pck") == 0) {
 			// "pck" section found, let's patch!
 
 			// Set virtual size to a little to avoid it taking memory (zero would give issues)

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -209,7 +209,7 @@ void GLManagerNative_Windows::_nvapi_setup_profile() {
 		NVDRS_PROFILE profile_info;
 		profile_info.version = NVDRS_PROFILE_VER;
 		profile_info.isPredefined = 0;
-		memcpy(profile_info.profileName, app_profile_name_u16.get_data(), sizeof(char16_t) * app_profile_name_u16.size());
+		std::memcpy(profile_info.profileName, app_profile_name_u16.get_data(), sizeof(char16_t) * app_profile_name_u16.size());
 
 		if (!nvapi_err_check("NVAPI: Error creating profile", NvAPI_DRS_CreateProfile(session_handle, &profile_info, &profile_handle))) {
 			NvAPI_DRS_DestroySession(session_handle);
@@ -227,9 +227,9 @@ void GLManagerNative_Windows::_nvapi_setup_profile() {
 		print_verbose("NVAPI: Application not found in profile, creating...");
 
 		app.isPredefined = 0;
-		memcpy(app.appName, app_executable_name_u16.get_data(), sizeof(char16_t) * app_executable_name_u16.size());
-		memcpy(app.launcher, L"", sizeof(wchar_t));
-		memcpy(app.fileInFolder, L"", sizeof(wchar_t));
+		std::memcpy(app.appName, app_executable_name_u16.get_data(), sizeof(char16_t) * app_executable_name_u16.size());
+		std::memcpy(app.launcher, L"", sizeof(wchar_t));
+		std::memcpy(app.fileInFolder, L"", sizeof(wchar_t));
 
 		if (!nvapi_err_check("NVAPI: Error creating application", NvAPI_DRS_CreateApplication(session_handle, profile_handle, &app))) {
 			NvAPI_DRS_DestroySession(session_handle);

--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -113,18 +113,18 @@ bool JoypadWindows::is_xinput_joypad(const GUID *p_guid) {
 	static GUID IID_XOneEliteWirelessGamepad = { MAKELONG(0x045E, 0x02E3), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
 	static GUID IID_XOneElite2WirelessGamepad = { MAKELONG(0x045E, 0x0B22), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
 
-	if (memcmp(p_guid, &IID_ValveStreamingGamepad, sizeof(*p_guid)) == 0 ||
-			memcmp(p_guid, &IID_X360WiredGamepad, sizeof(*p_guid)) == 0 ||
-			memcmp(p_guid, &IID_X360WirelessGamepad, sizeof(*p_guid)) == 0 ||
-			memcmp(p_guid, &IID_XSWirelessGamepad, sizeof(*p_guid)) == 0 ||
-			memcmp(p_guid, &IID_XEliteWirelessGamepad, sizeof(*p_guid)) == 0 ||
-			memcmp(p_guid, &IID_XOneWiredGamepad, sizeof(*p_guid)) == 0 ||
-			memcmp(p_guid, &IID_XOneWirelessGamepad, sizeof(*p_guid)) == 0 ||
-			memcmp(p_guid, &IID_XOneNewWirelessGamepad, sizeof(*p_guid)) == 0 ||
-			memcmp(p_guid, &IID_XOneSWirelessGamepad, sizeof(*p_guid)) == 0 ||
-			memcmp(p_guid, &IID_XOneSBluetoothGamepad, sizeof(*p_guid)) == 0 ||
-			memcmp(p_guid, &IID_XOneEliteWirelessGamepad, sizeof(*p_guid)) == 0 ||
-			memcmp(p_guid, &IID_XOneElite2WirelessGamepad, sizeof(*p_guid)) == 0) {
+	if (std::memcmp(p_guid, &IID_ValveStreamingGamepad, sizeof(*p_guid)) == 0 ||
+			std::memcmp(p_guid, &IID_X360WiredGamepad, sizeof(*p_guid)) == 0 ||
+			std::memcmp(p_guid, &IID_X360WirelessGamepad, sizeof(*p_guid)) == 0 ||
+			std::memcmp(p_guid, &IID_XSWirelessGamepad, sizeof(*p_guid)) == 0 ||
+			std::memcmp(p_guid, &IID_XEliteWirelessGamepad, sizeof(*p_guid)) == 0 ||
+			std::memcmp(p_guid, &IID_XOneWiredGamepad, sizeof(*p_guid)) == 0 ||
+			std::memcmp(p_guid, &IID_XOneWirelessGamepad, sizeof(*p_guid)) == 0 ||
+			std::memcmp(p_guid, &IID_XOneNewWirelessGamepad, sizeof(*p_guid)) == 0 ||
+			std::memcmp(p_guid, &IID_XOneSWirelessGamepad, sizeof(*p_guid)) == 0 ||
+			std::memcmp(p_guid, &IID_XOneSBluetoothGamepad, sizeof(*p_guid)) == 0 ||
+			std::memcmp(p_guid, &IID_XOneEliteWirelessGamepad, sizeof(*p_guid)) == 0 ||
+			std::memcmp(p_guid, &IID_XOneElite2WirelessGamepad, sizeof(*p_guid)) == 0) {
 		return true;
 	}
 
@@ -152,7 +152,7 @@ bool JoypadWindows::is_xinput_joypad(const GUID *p_guid) {
 				(GetRawInputDeviceInfoA(dev_list[i].hDevice, RIDI_DEVICEINFO, &rdi, &rdiSize) != (UINT)-1) &&
 				(MAKELONG(rdi.hid.dwVendorId, rdi.hid.dwProductId) == (LONG)p_guid->Data1) &&
 				(GetRawInputDeviceInfoA(dev_list[i].hDevice, RIDI_DEVICENAME, &dev_name, &nameSize) != (UINT)-1) &&
-				(strstr(dev_name, "IG_") != nullptr)) {
+				(std::strstr(dev_name, "IG_") != nullptr)) {
 			memfree(dev_list);
 			return true;
 		}
@@ -186,7 +186,7 @@ void JoypadWindows::probe_xinput_joypad(const String &name) {
 			joypad_info["xinput_index"] = (int)i;
 
 			JOYCAPSW jc;
-			memset(&jc, 0, sizeof(JOYCAPSW));
+			std::memset(&jc, 0, sizeof(JOYCAPSW));
 			MMRESULT jcResult = winmm_get_joycaps((UINT)id, &jc, sizeof(JOYCAPSW));
 			if (jcResult == JOYERR_NOERROR) {
 				joypad_info["vendor_id"] = itos(jc.wMid);
@@ -232,7 +232,7 @@ bool JoypadWindows::setup_dinput_joypad(const DIDEVICEINSTANCE *instance) {
 	const GUID &guid = instance->guidProduct;
 	char uid[128];
 
-	ERR_FAIL_COND_V_MSG(memcmp(&guid.Data4[2], "PIDVID", 6), false, "DirectInput device not recognized.");
+	ERR_FAIL_COND_V_MSG(std::memcmp(&guid.Data4[2], "PIDVID", 6), false, "DirectInput device not recognized.");
 	WORD type = BSWAP16(0x03);
 	WORD vendor = BSWAP16(LOWORD(guid.Data1));
 	WORD product = BSWAP16(HIWORD(guid.Data1));

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1456,7 +1456,7 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 			_append_to_pipe(bytes.ptr(), bytes_to_convert, r_pipe, p_pipe_mutex);
 
 			bytes_in_buffer = read - (newline_index + 1);
-			memmove(bytes.ptr(), bytes.ptr() + bytes_to_convert, bytes_in_buffer);
+			std::memmove(bytes.ptr(), bytes.ptr() + bytes_to_convert, bytes_in_buffer);
 		}
 
 		if (bytes_in_buffer > 0) {
@@ -2323,7 +2323,7 @@ uint64_t OS_Windows::get_embedded_pck_offset() const {
 		f->get_buffer(section_name, 8);
 		section_name[8] = '\0';
 
-		if (strcmp((char *)section_name, "pck") == 0) {
+		if (std::strcmp((char *)section_name, "pck") == 0) {
 			f->seek(section_header_pos + 20);
 			off = f->get_32();
 			break;
@@ -2603,7 +2603,7 @@ bool OS_Windows::_test_create_rendering_device_and_gl(const String &p_display_dr
 	// Tests OpenGL context and Rendering Device simultaneous creation. This function is expected to crash on some NVIDIA drivers.
 
 	WNDCLASSEXW wc_probe;
-	memset(&wc_probe, 0, sizeof(WNDCLASSEXW));
+	std::memset(&wc_probe, 0, sizeof(WNDCLASSEXW));
 	wc_probe.cbSize = sizeof(WNDCLASSEXW);
 	wc_probe.style = CS_OWNDC | CS_DBLCLKS;
 	wc_probe.lpfnWndProc = (WNDPROC)::DefWindowProcW;

--- a/platform/windows/wgl_detect_version.cpp
+++ b/platform/windows/wgl_detect_version.cpp
@@ -152,8 +152,8 @@ Dictionary detect_wgl() {
 										const String device_vendor = String::utf8((const char *)gd_wglGetString(WGL_VENDOR)).strip_edges().trim_suffix(" Corporation");
 										const String device_name = String::utf8((const char *)gd_wglGetString(WGL_RENDERER)).strip_edges().trim_suffix("/PCIe/SSE2");
 										for (int i = 0; prefixes[i]; i++) {
-											size_t length = strlen(prefixes[i]);
-											if (strncmp(version, prefixes[i], length) == 0) {
+											size_t length = std::strlen(prefixes[i]);
+											if (std::strncmp(version, prefixes[i], length) == 0) {
 												version += length;
 												break;
 											}

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -143,7 +143,7 @@ void WindowsTerminalLogger::log_error(const char *p_function, const char *p_file
 		}
 
 		for (const Ref<ScriptBacktrace> &backtrace : p_script_backtraces) {
-			logf_error("%s\n", backtrace->format(strlen(indent)).utf8().get_data());
+			logf_error("%s\n", backtrace->format(std::strlen(indent)).utf8().get_data());
 		}
 
 		SetConsoleTextAttribute(hCon, sbi.wAttributes);

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1173,7 +1173,7 @@ void CPUParticles2D::_update_particle_data_buffer() {
 			ptr[7] = t.columns[2][1];
 
 		} else {
-			memset(ptr, 0, sizeof(float) * 8);
+			std::memset(ptr, 0, sizeof(float) * 8);
 		}
 
 		Color c = r[idx].color;

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -1295,7 +1295,7 @@ void CPUParticles3D::_update_particle_data_buffer() {
 			ptr[10] = t.basis.rows[2][2];
 			ptr[11] = t.origin.z;
 		} else {
-			memset(ptr, 0, sizeof(float) * 12);
+			std::memset(ptr, 0, sizeof(float) * 12);
 		}
 
 		Color c = r[idx].color;
@@ -1401,7 +1401,7 @@ void CPUParticles3D::_notification(int p_what) {
 						ptr[10] = t.basis.rows[2][2];
 						ptr[11] = t.origin.z;
 					} else {
-						memset(ptr, 0, sizeof(float) * 12);
+						std::memset(ptr, 0, sizeof(float) * 12);
 					}
 
 					ptr += 20;

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -400,7 +400,7 @@ void PolygonOccluder3D::_update_arrays(PackedVector3Array &r_vertices, PackedInt
 	}
 
 	r_indices.resize(occluder_indices.size());
-	memcpy(r_indices.ptrw(), occluder_indices.ptr(), occluder_indices.size() * sizeof(int));
+	std::memcpy(r_indices.ptrw(), occluder_indices.ptr(), occluder_indices.size() * sizeof(int));
 }
 
 bool PolygonOccluder3D::_has_editable_3d_polygon_no_depth() const {
@@ -553,7 +553,7 @@ void OccluderInstance3D::_bake_surface(const Transform3D &p_transform, Array p_s
 
 	int vertex_offset = r_vertices.size();
 	r_vertices.resize(vertex_offset + vertices.size());
-	memcpy(r_vertices.ptrw() + vertex_offset, vertices.ptr(), vertices.size() * sizeof(Vector3));
+	std::memcpy(r_vertices.ptrw() + vertex_offset, vertices.ptr(), vertices.size() * sizeof(Vector3));
 
 	int index_offset = r_indices.size();
 	r_indices.resize(index_offset + indices.size());

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -94,7 +94,7 @@ void SoftBodyRenderingServerHandler::set_normal(int p_vertex_id, const Vector3 &
 	uint32_t value = 0;
 	value |= (uint16_t)CLAMP(res.x * 65535, 0, 65535);
 	value |= (uint16_t)CLAMP(res.y * 65535, 0, 65535) << 16;
-	memcpy(&write_buffer[p_vertex_id * normal_stride + offset_normal], &value, sizeof(uint32_t));
+	std::memcpy(&write_buffer[p_vertex_id * normal_stride + offset_normal], &value, sizeof(uint32_t));
 }
 
 void SoftBodyRenderingServerHandler::set_aabb(const AABB &p_aabb) {

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -233,14 +233,14 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 		}
 
 		float v_uv[2] = { (float)uvs[i].x, (float)uvs[i].y };
-		memcpy(&attribute_write_buffer[i * attrib_stride + mesh_surface_offsets[RS::ARRAY_TEX_UV]], v_uv, 8);
+		std::memcpy(&attribute_write_buffer[i * attrib_stride + mesh_surface_offsets[RS::ARRAY_TEX_UV]], v_uv, 8);
 
 		float v_vertex[3] = { (float)vtx.x, (float)vtx.y, (float)vtx.z };
 
-		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
-		memcpy(&vertex_write_buffer[i * normal_tangent_stride + mesh_surface_offsets[RS::ARRAY_NORMAL]], &v_normal, 4);
-		memcpy(&vertex_write_buffer[i * normal_tangent_stride + mesh_surface_offsets[RS::ARRAY_TANGENT]], &v_tangent, 4);
-		memcpy(&attribute_write_buffer[i * attrib_stride + mesh_surface_offsets[RS::ARRAY_COLOR]], v_color, 4);
+		std::memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
+		std::memcpy(&vertex_write_buffer[i * normal_tangent_stride + mesh_surface_offsets[RS::ARRAY_NORMAL]], &v_normal, 4);
+		std::memcpy(&vertex_write_buffer[i * normal_tangent_stride + mesh_surface_offsets[RS::ARRAY_TANGENT]], &v_tangent, 4);
+		std::memcpy(&attribute_write_buffer[i * attrib_stride + mesh_surface_offsets[RS::ARRAY_COLOR]], v_color, 4);
 	}
 
 	RID mesh_new = get_mesh();

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3038,32 +3038,32 @@ Variant Control::get_theme_item(Theme::DataType p_data_type, const StringName &p
 
 Variant Control::get_used_theme_item(const String &p_full_name, const StringName &p_theme_type) const {
 	if (p_full_name.begins_with("theme_override_icons/")) {
-		String name = p_full_name.substr(strlen("theme_override_icons/"));
+		String name = p_full_name.substr(std::strlen("theme_override_icons/"));
 		if (has_theme_icon(name)) { // Exclude cached and default ones.
 			return get_theme_icon(name);
 		}
 	} else if (p_full_name.begins_with("theme_override_styles/")) {
-		String name = p_full_name.substr(strlen("theme_override_styles/"));
+		String name = p_full_name.substr(std::strlen("theme_override_styles/"));
 		if (has_theme_stylebox(name)) {
 			return get_theme_stylebox(name);
 		}
 	} else if (p_full_name.begins_with("theme_override_fonts/")) {
-		String name = p_full_name.substr(strlen("theme_override_fonts/"));
+		String name = p_full_name.substr(std::strlen("theme_override_fonts/"));
 		if (has_theme_font(name)) {
 			return get_theme_font(name);
 		}
 	} else if (p_full_name.begins_with("theme_override_font_sizes/")) {
-		String name = p_full_name.substr(strlen("theme_override_font_sizes/"));
+		String name = p_full_name.substr(std::strlen("theme_override_font_sizes/"));
 		if (has_theme_font_size(name)) {
 			return get_theme_font_size(name);
 		}
 	} else if (p_full_name.begins_with("theme_override_colors/")) {
-		String name = p_full_name.substr(strlen("theme_override_colors/"));
+		String name = p_full_name.substr(std::strlen("theme_override_colors/"));
 		if (has_theme_color(name)) {
 			return get_theme_color(name);
 		}
 	} else if (p_full_name.begins_with("theme_override_constants/")) {
-		String name = p_full_name.substr(strlen("theme_override_constants/"));
+		String name = p_full_name.substr(std::strlen("theme_override_constants/"));
 		if (has_theme_constant(name)) {
 			return get_theme_constant(name);
 		}

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -108,7 +108,7 @@ Error HTTPRequest::request(const String &p_url, const Vector<String> &p_custom_h
 	if (len > 0) {
 		raw_data.resize(len);
 		uint8_t *w = raw_data.ptrw();
-		memcpy(w, charstr.ptr(), len);
+		std::memcpy(w, charstr.ptr(), len);
 	}
 
 	return request_raw(p_url, p_custom_headers, p_method, raw_data);

--- a/scene/main/multiplayer_api.cpp
+++ b/scene/main/multiplayer_api.cpp
@@ -223,7 +223,7 @@ Error MultiplayerAPI::encode_and_compress_variants(const Variant **p_variants, i
 			*r_raw = true;
 			const PackedByteArray pba = v;
 			if (p_buffer) {
-				memcpy(p_buffer, pba.ptr(), pba.size());
+				std::memcpy(p_buffer, pba.ptr(), pba.size());
 			}
 			r_len += pba.size();
 		} else {
@@ -253,7 +253,7 @@ Error MultiplayerAPI::decode_and_decompress_variants(Vector<Variant> &r_variants
 		r_len = p_len;
 		PackedByteArray pba;
 		pba.resize(p_len);
-		memcpy(pba.ptrw(), p_buffer, p_len);
+		std::memcpy(pba.ptrw(), p_buffer, p_len);
 		r_variants.write[0] = pba;
 		return OK;
 	}

--- a/scene/main/multiplayer_peer.cpp
+++ b/scene/main/multiplayer_peer.cpp
@@ -158,7 +158,7 @@ Error MultiplayerPeerExtension::put_packet(const uint8_t *p_buffer, int p_buffer
 	if (GDVIRTUAL_IS_OVERRIDDEN(_put_packet_script)) {
 		PackedByteArray a;
 		a.resize(p_buffer_size);
-		memcpy(a.ptrw(), p_buffer, p_buffer_size);
+		std::memcpy(a.ptrw(), p_buffer, p_buffer_size);
 
 		if (!GDVIRTUAL_CALL(_put_packet_script, a, err)) {
 			return FAILED;

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -6168,7 +6168,7 @@ TileData *TileData::duplicate() {
 #endif // PHYSICS_2D_DISABLED
 	// Terrain
 	output->terrain_set = -1;
-	memcpy(output->terrain_peering_bits, terrain_peering_bits, 16 * sizeof(int));
+	std::memcpy(output->terrain_peering_bits, terrain_peering_bits, 16 * sizeof(int));
 #ifndef NAVIGATION_2D_DISABLED
 	// Navigation
 	output->navigation = navigation;

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -1150,7 +1150,7 @@ Error ImporterMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, 
 
 	if (gen_cache_size > 0) {
 		r_dst_cache.resize(gen_cache_size);
-		memcpy(r_dst_cache.ptrw(), gen_cache, gen_cache_size);
+		std::memcpy(r_dst_cache.ptrw(), gen_cache, gen_cache_size);
 		memfree(gen_cache);
 	}
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -5129,7 +5129,7 @@ void Animation::compress(uint32_t p_page_size, uint32_t p_fps, float p_split_tol
 						}
 						encode_uint32(time_tracks[i].packets.size(), page_ptr + (track_header_size * i + 4));
 						encode_uint32(base_offset, page_ptr + (track_header_size * i + 8));
-						memcpy(page_ptr + base_offset, data_tracks[i].data.ptr(), data_tracks[i].data.size());
+						std::memcpy(page_ptr + base_offset, data_tracks[i].data.ptr(), data_tracks[i].data.size());
 						base_offset += data_tracks[i].data.size();
 
 						//reset track

--- a/scene/resources/audio_stream_wav.h
+++ b/scene/resources/audio_stream_wav.h
@@ -266,8 +266,8 @@ public:
 		dst_data.resize(8 + frames_len + slices_len);
 
 		for (uint32_t c = 0; c < p_desc->channels; c++) {
-			memset(p_desc->lms[c].history, 0, sizeof(p_desc->lms[c].history));
-			memset(p_desc->lms[c].weights, 0, sizeof(p_desc->lms[c].weights));
+			std::memset(p_desc->lms[c].history, 0, sizeof(p_desc->lms[c].history));
+			std::memset(p_desc->lms[c].weights, 0, sizeof(p_desc->lms[c].weights));
 			p_desc->lms[c].weights[2] = -(1 << 13);
 			p_desc->lms[c].weights[3] = (1 << 14);
 		}

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -44,7 +44,7 @@ void BitMap::create(const Size2i &p_size) {
 	width = p_size.width;
 	height = p_size.height;
 
-	memset(bitmask.ptrw(), 0, bitmask.size());
+	std::memset(bitmask.ptrw(), 0, bitmask.size());
 }
 
 void BitMap::create_from_image_alpha(const Ref<Image> &p_image, float p_threshold) {

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -384,7 +384,7 @@ Ref<Image> CompressedTexture2D::load_image_from_file(Ref<FileAccess> f, int p_si
 					Vector<uint8_t> id = mipmap_images[i]->get_data();
 					int len = id.size();
 					const uint8_t *r = id.ptr();
-					memcpy(&wr[ofs], r, len);
+					std::memcpy(&wr[ofs], r, len);
 					ofs += len;
 				}
 			}

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -2096,7 +2096,7 @@ void FontFile::set_data(const PackedByteArray &p_data) {
 PackedByteArray FontFile::get_data() const {
 	if (unlikely((size_t)data.size() != data_size)) {
 		data.resize(data_size);
-		memcpy(data.ptrw(), data_ptr, data_size);
+		std::memcpy(data.ptrw(), data_ptr, data_size);
 	}
 	return data;
 }

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -346,18 +346,18 @@ private:
 		uint32_t flags;
 
 		MaterialKey() {
-			memset(this, 0, sizeof(MaterialKey));
+			std::memset(this, 0, sizeof(MaterialKey));
 		}
 
 		static uint32_t hash(const MaterialKey &p_key) {
 			return hash_djb2_buffer((const uint8_t *)&p_key, sizeof(MaterialKey));
 		}
 		bool operator==(const MaterialKey &p_key) const {
-			return memcmp(this, &p_key, sizeof(MaterialKey)) == 0;
+			return std::memcmp(this, &p_key, sizeof(MaterialKey)) == 0;
 		}
 
 		bool operator<(const MaterialKey &p_key) const {
-			return memcmp(this, &p_key, sizeof(MaterialKey)) < 0;
+			return std::memcmp(this, &p_key, sizeof(MaterialKey)) < 0;
 		}
 	};
 

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -2249,7 +2249,7 @@ Error ArrayMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, flo
 
 	if (gen_cache_size > 0) {
 		r_dst_cache.resize(gen_cache_size);
-		memcpy(r_dst_cache.ptrw(), gen_cache, gen_cache_size);
+		std::memcpy(r_dst_cache.ptrw(), gen_cache, gen_cache_size);
 		memfree(gen_cache);
 	}
 

--- a/scene/resources/particle_process_material.h
+++ b/scene/resources/particle_process_material.h
@@ -129,17 +129,17 @@ private:
 		uint64_t orbit_uses_curve_xyz : 1;
 
 		MaterialKey() {
-			memset(this, 0, sizeof(MaterialKey));
+			std::memset(this, 0, sizeof(MaterialKey));
 		}
 
 		static uint32_t hash(const MaterialKey &p_key) {
 			return hash_djb2_buffer((const uint8_t *)&p_key, sizeof(MaterialKey));
 		}
 		bool operator==(const MaterialKey &p_key) const {
-			return memcmp(this, &p_key, sizeof(MaterialKey)) == 0;
+			return std::memcmp(this, &p_key, sizeof(MaterialKey)) == 0;
 		}
 		bool operator<(const MaterialKey &p_key) const {
-			return memcmp(this, &p_key, sizeof(MaterialKey)) < 0;
+			return std::memcmp(this, &p_key, sizeof(MaterialKey)) < 0;
 		}
 	};
 

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -69,7 +69,7 @@ void SurfaceTool::strip_mesh_arrays(PackedVector3Array &r_vertices, PackedInt32A
 		}
 
 		if (i != filtered_indices_count) {
-			memcpy(idx_ptr + (filtered_indices_count * 3), tri, sizeof(int) * 3);
+			std::memcpy(idx_ptr + (filtered_indices_count * 3), tri, sizeof(int) * 3);
 		}
 
 		found_triangles.insert_new(tri, true);
@@ -1290,7 +1290,7 @@ void SurfaceTool::optimize_indices_for_cache() {
 	ERR_FAIL_COND(index_array.size() % 3 != 0);
 
 	LocalVector old_index_array = index_array;
-	memset(index_array.ptr(), 0, index_array.size() * sizeof(int));
+	std::memset(index_array.ptr(), 0, index_array.size() * sizeof(int));
 	optimize_vertex_cache_func((unsigned int *)index_array.ptr(), (unsigned int *)old_index_array.ptr(), old_index_array.size(), vertex_array.size());
 }
 

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -165,8 +165,8 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 				ERR_PRINT_ONCE("Invalid FFT frame size for PitchShift. This is a bug, please report.");
 				return;
 			}
-			memset(gSynMagn, 0, fftBufferSize);
-			memset(gSynFreq, 0, fftBufferSize);
+			std::memset(gSynMagn, 0, fftBufferSize);
+			std::memset(gSynFreq, 0, fftBufferSize);
 			for (k = 0; k <= fftFrameSize2; k++) {
 				index = k*pitchShift;
 				if (index <= fftFrameSize2) {
@@ -219,7 +219,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 }
 
 			/* shift accumulator */
-			memmove(gOutputAccum, gOutputAccum+stepSize, fftBufferSize);
+			std::memmove(gOutputAccum, gOutputAccum+stepSize, fftBufferSize);
 
 			/* move input FIFO */
 			for (k = 0; k < inFifoLatency; k++) { gInFIFO[k] = gInFIFO[k+stepSize];

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -43,8 +43,6 @@
 #include "servers/audio/audio_stream.h"
 #include "servers/audio/effects/audio_effect_compressor.h"
 
-#include <cstring>
-
 #ifdef TOOLS_ENABLED
 #define MARK_EDITED set_edited(true);
 #else
@@ -1263,7 +1261,7 @@ void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, con
 	playback_node->highshelf_gain.set(p_highshelf_gain);
 	playback_node->attenuation_filter_cutoff_hz.set(p_attenuation_cutoff_hz);
 
-	memset(playback_node->prev_bus_details->volume, 0, sizeof(playback_node->prev_bus_details->volume));
+	std::memset(playback_node->prev_bus_details->volume, 0, sizeof(playback_node->prev_bus_details->volume));
 
 	for (AudioFrame &frame : playback_node->lookahead) {
 		frame = AudioFrame(0, 0);

--- a/servers/rendering/dummy/storage/mesh_storage.cpp
+++ b/servers/rendering/dummy/storage/mesh_storage.cpp
@@ -91,7 +91,7 @@ void MeshStorage::_multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_
 	ERR_FAIL_NULL(multimesh);
 	multimesh->buffer.resize(p_buffer.size());
 	float *cache_data = multimesh->buffer.ptrw();
-	memcpy(cache_data, p_buffer.ptr(), p_buffer.size() * sizeof(float));
+	std::memcpy(cache_data, p_buffer.ptr(), p_buffer.size() * sizeof(float));
 }
 
 Vector<float> MeshStorage::_multimesh_get_buffer(RID p_multimesh) const {

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -75,8 +75,8 @@ void RendererCanvasCull::_render_canvas_item_tree(RID p_to_render_target, Canvas
 	// transform is normally concatenated with the item global transform.
 	_current_camera_transform = p_transform;
 
-	memset(z_list, 0, z_range * sizeof(RendererCanvasRender::Item *));
-	memset(z_last_list, 0, z_range * sizeof(RendererCanvasRender::Item *));
+	std::memset(z_list, 0, z_range * sizeof(RendererCanvasRender::Item *));
+	std::memset(z_last_list, 0, z_range * sizeof(RendererCanvasRender::Item *));
 
 	for (int i = 0; i < p_child_item_count; i++) {
 		_cull_canvas_item(p_child_items[i].item, p_transform, p_clip_rect, Color(1, 1, 1, 1), 0, z_list, z_last_list, nullptr, nullptr, false, p_canvas_cull_mask, Point2(), 1, nullptr);

--- a/servers/rendering/renderer_rd/cluster_builder_rd.cpp
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.cpp
@@ -103,13 +103,13 @@ ClusterBuilderSharedDataRD::ClusterBuilderSharedDataRD() {
 
 		Vector<uint8_t> vertex_data;
 		vertex_data.resize(sizeof(float) * icosphere_vertex_count * 3);
-		memcpy(vertex_data.ptrw(), icosphere_vertices, vertex_data.size());
+		std::memcpy(vertex_data.ptrw(), icosphere_vertices, vertex_data.size());
 
 		sphere_vertex_buffer = RD::get_singleton()->vertex_buffer_create(vertex_data.size(), vertex_data);
 
 		Vector<uint8_t> index_data;
 		index_data.resize(sizeof(uint16_t) * icosphere_triangle_count * 3);
-		memcpy(index_data.ptrw(), icosphere_triangle_indices, index_data.size());
+		std::memcpy(index_data.ptrw(), icosphere_triangle_indices, index_data.size());
 
 		sphere_index_buffer = RD::get_singleton()->index_buffer_create(icosphere_triangle_count * 3, RD::INDEX_BUFFER_FORMAT_UINT16, index_data);
 
@@ -147,13 +147,13 @@ ClusterBuilderSharedDataRD::ClusterBuilderSharedDataRD() {
 
 		Vector<uint8_t> vertex_data;
 		vertex_data.resize(sizeof(float) * cone_vertex_count * 3);
-		memcpy(vertex_data.ptrw(), cone_vertices, vertex_data.size());
+		std::memcpy(vertex_data.ptrw(), cone_vertices, vertex_data.size());
 
 		cone_vertex_buffer = RD::get_singleton()->vertex_buffer_create(vertex_data.size(), vertex_data);
 
 		Vector<uint8_t> index_data;
 		index_data.resize(sizeof(uint16_t) * cone_triangle_count * 3);
-		memcpy(index_data.ptrw(), cone_triangle_indices, index_data.size());
+		std::memcpy(index_data.ptrw(), cone_triangle_indices, index_data.size());
 
 		cone_index_buffer = RD::get_singleton()->index_buffer_create(cone_triangle_count * 3, RD::INDEX_BUFFER_FORMAT_UINT16, index_data);
 
@@ -201,13 +201,13 @@ ClusterBuilderSharedDataRD::ClusterBuilderSharedDataRD() {
 
 		Vector<uint8_t> vertex_data;
 		vertex_data.resize(sizeof(float) * box_vertex_count * 3);
-		memcpy(vertex_data.ptrw(), box_vertices, vertex_data.size());
+		std::memcpy(vertex_data.ptrw(), box_vertices, vertex_data.size());
 
 		box_vertex_buffer = RD::get_singleton()->vertex_buffer_create(vertex_data.size(), vertex_data);
 
 		Vector<uint8_t> index_data;
 		index_data.resize(sizeof(uint16_t) * box_triangle_count * 3);
-		memcpy(index_data.ptrw(), box_triangle_indices, index_data.size());
+		std::memcpy(index_data.ptrw(), box_triangle_indices, index_data.size());
 
 		box_index_buffer = RD::get_singleton()->index_buffer_create(box_triangle_count * 3, RD::INDEX_BUFFER_FORMAT_UINT16, index_data);
 

--- a/servers/rendering/renderer_rd/effects/bokeh_dof.cpp
+++ b/servers/rendering/renderer_rd/effects/bokeh_dof.cpp
@@ -105,7 +105,7 @@ void BokehDOF::bokeh_dof_compute(const BokehBuffers &p_buffers, RID p_camera_att
 	RS::DOFBlurQuality blur_quality = RSG::camera_attributes->camera_attributes_get_dof_blur_quality();
 
 	// setup our push constant
-	memset(&bokeh.push_constant, 0, sizeof(BokehPushConstant));
+	std::memset(&bokeh.push_constant, 0, sizeof(BokehPushConstant));
 	bokeh.push_constant.blur_far_active = dof_far;
 	bokeh.push_constant.blur_far_begin = dof_far_begin;
 	bokeh.push_constant.blur_far_end = dof_far_begin + dof_far_size; // Only used with non-physically-based.
@@ -310,7 +310,7 @@ void BokehDOF::bokeh_dof_raster(const BokehBuffers &p_buffers, RID p_camera_attr
 	RS::DOFBlurQuality blur_quality = RSG::camera_attributes->camera_attributes_get_dof_blur_quality();
 
 	// setup our base push constant
-	memset(&bokeh.push_constant, 0, sizeof(BokehPushConstant));
+	std::memset(&bokeh.push_constant, 0, sizeof(BokehPushConstant));
 
 	bokeh.push_constant.orthogonal = p_cam_orthogonal;
 	bokeh.push_constant.size[0] = p_buffers.base_texture_size.width;

--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -59,7 +59,7 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 		blur_modes.push_back("\n#define MODE_SET_COLOR\n"); // BLUR_MODE_SET_COLOR
 
 		blur_raster.shader.initialize(blur_modes);
-		memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
+		std::memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
 		blur_raster.shader_version = blur_raster.shader.version_create();
 
 		for (int i = 0; i < BLUR_MODE_MAX; i++) {
@@ -90,7 +90,7 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 		copy_modes.push_back("\n#define MODE_CUBEMAP_ARRAY_TO_PANORAMA\n");
 
 		copy.shader.initialize(copy_modes);
-		memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+		std::memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
 
 		copy.shader_version = copy.shader.version_create();
 
@@ -342,7 +342,7 @@ void CopyEffects::copy_to_rect(RID p_source_rd_texture, RID p_dest_texture, cons
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	std::memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
 	if (p_flip_y) {
 		copy.push_constant.flags |= COPY_FLAG_FLIP_Y;
 	}
@@ -391,7 +391,7 @@ void CopyEffects::copy_cubemap_to_panorama(RID p_source_cube, RID p_dest_panoram
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	std::memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
 
 	copy.push_constant.section[0] = 0;
 	copy.push_constant.section[1] = 0;
@@ -426,7 +426,7 @@ void CopyEffects::copy_depth_to_rect(RID p_source_rd_texture, RID p_dest_texture
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	std::memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
 	if (p_flip_y) {
 		copy.push_constant.flags |= COPY_FLAG_FLIP_Y;
 	}
@@ -463,7 +463,7 @@ void CopyEffects::copy_depth_to_rect_and_linearize(RID p_source_rd_texture, RID 
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	std::memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
 	if (p_flip_y) {
 		copy.push_constant.flags |= COPY_FLAG_FLIP_Y;
 	}
@@ -502,7 +502,7 @@ void CopyEffects::copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuff
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy_to_fb.push_constant, 0, sizeof(CopyToFbPushConstant));
+	std::memset(&copy_to_fb.push_constant, 0, sizeof(CopyToFbPushConstant));
 
 	copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_USE_SECTION;
 	copy_to_fb.push_constant.section[0] = p_uv_rect.position.x;
@@ -539,7 +539,7 @@ void CopyEffects::copy_to_fb_rect(RID p_source_rd_texture, RID p_dest_framebuffe
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy_to_fb.push_constant, 0, sizeof(CopyToFbPushConstant));
+	std::memset(&copy_to_fb.push_constant, 0, sizeof(CopyToFbPushConstant));
 	copy_to_fb.push_constant.luminance_multiplier = 1.0;
 
 	if (p_flip_y) {
@@ -611,7 +611,7 @@ void CopyEffects::copy_to_drawlist(RD::DrawListID p_draw_list, RD::FramebufferFo
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy_to_fb.push_constant, 0, sizeof(CopyToFbPushConstant));
+	std::memset(&copy_to_fb.push_constant, 0, sizeof(CopyToFbPushConstant));
 	copy_to_fb.push_constant.luminance_multiplier = 1.0;
 
 	if (p_linear) {
@@ -647,7 +647,7 @@ void CopyEffects::copy_raster(RID p_source_texture, RID p_dest_framebuffer) {
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
+	std::memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
@@ -675,7 +675,7 @@ void CopyEffects::gaussian_blur(RID p_source_rd_texture, RID p_texture, const Re
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	std::memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
 
 	copy.push_constant.section[0] = p_region.position.x;
 	copy.push_constant.section[1] = p_region.position.y;
@@ -716,7 +716,7 @@ void CopyEffects::gaussian_blur_raster(RID p_source_rd_texture, RID p_dest_textu
 
 	RID dest_framebuffer = FramebufferCacheRD::get_singleton()->get_cache(p_dest_texture);
 
-	memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
+	std::memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
 
 	BlurRasterMode blur_mode = BLUR_MODE_GAUSSIAN_BLUR;
 
@@ -749,7 +749,7 @@ void CopyEffects::gaussian_glow(RID p_source_rd_texture, RID p_back_texture, con
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	std::memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
 
 	CopyMode copy_mode = p_first_pass && p_auto_exposure.is_valid() ? COPY_MODE_GAUSSIAN_GLOW_AUTO_EXPOSURE : COPY_MODE_GAUSSIAN_GLOW;
 	uint32_t base_flags = 0;
@@ -803,7 +803,7 @@ void CopyEffects::gaussian_glow_raster(RID p_source_rd_texture, RID p_half_textu
 	RID half_framebuffer = FramebufferCacheRD::get_singleton()->get_cache(p_half_texture);
 	RID dest_framebuffer = FramebufferCacheRD::get_singleton()->get_cache(p_dest_texture);
 
-	memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
+	std::memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
 
 	BlurRasterMode blur_mode = p_first_pass && p_auto_exposure.is_valid() ? BLUR_MODE_GAUSSIAN_GLOW_AUTO_EXPOSURE : BLUR_MODE_GAUSSIAN_GLOW;
 	uint32_t base_flags = 0;
@@ -872,7 +872,7 @@ void CopyEffects::make_mipmap(RID p_source_rd_texture, RID p_dest_texture, const
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	std::memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
 
 	copy.push_constant.section[0] = 0;
 	copy.push_constant.section[1] = 0;
@@ -908,7 +908,7 @@ void CopyEffects::make_mipmap_raster(RID p_source_rd_texture, RID p_dest_texture
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
+	std::memset(&blur_raster.push_constant, 0, sizeof(BlurRasterPushConstant));
 
 	BlurRasterMode mode = BLUR_MIPMAP;
 
@@ -938,7 +938,7 @@ void CopyEffects::set_color(RID p_dest_texture, const Color &p_color, const Rect
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
 	ERR_FAIL_NULL(uniform_set_cache);
 
-	memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
+	std::memset(&copy.push_constant, 0, sizeof(CopyPushConstant));
 
 	copy.push_constant.section[0] = 0;
 	copy.push_constant.section[1] = 0;
@@ -974,7 +974,7 @@ void CopyEffects::set_color_raster(RID p_dest_texture, const Color &p_color, con
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&copy_to_fb.push_constant, 0, sizeof(CopyToFbPushConstant));
+	std::memset(&copy_to_fb.push_constant, 0, sizeof(CopyToFbPushConstant));
 
 	copy_to_fb.push_constant.set_color[0] = p_color.r;
 	copy_to_fb.push_constant.set_color[1] = p_color.g;
@@ -1188,7 +1188,7 @@ void CopyEffects::cubemap_roughness(RID p_source_rd_texture, RID p_dest_texture,
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&roughness.push_constant, 0, sizeof(CubemapRoughnessPushConstant));
+	std::memset(&roughness.push_constant, 0, sizeof(CubemapRoughnessPushConstant));
 
 	roughness.push_constant.face_id = p_face_id > 9 ? 0 : p_face_id;
 	// Remap to perceptual-roughness^2 to create more detail in lower mips and match the mapping of cubemap_filter.
@@ -1231,7 +1231,7 @@ void CopyEffects::cubemap_roughness_raster(RID p_source_rd_texture, RID p_dest_f
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&roughness.push_constant, 0, sizeof(CubemapRoughnessPushConstant));
+	std::memset(&roughness.push_constant, 0, sizeof(CubemapRoughnessPushConstant));
 
 	roughness.push_constant.face_id = p_face_id;
 	roughness.push_constant.roughness = p_roughness * p_roughness; // Shader expects roughness, not perceptual roughness, so multiply before passing in.

--- a/servers/rendering/renderer_rd/effects/fsr.cpp
+++ b/servers/rendering/renderer_rd/effects/fsr.cpp
@@ -73,7 +73,7 @@ void FSR::process(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_source_rd_te
 	RID upscale_texture = p_render_buffers->get_texture(SNAME("FSR"), SNAME("upscale_texture"));
 
 	FSRUpscalePushConstant push_constant;
-	memset(&push_constant, 0, sizeof(FSRUpscalePushConstant));
+	std::memset(&push_constant, 0, sizeof(FSRUpscalePushConstant));
 
 	int dispatch_x = (target_size.x + 15) / 16;
 	int dispatch_y = (target_size.y + 15) / 16;

--- a/servers/rendering/renderer_rd/effects/fsr2.cpp
+++ b/servers/rendering/renderer_rd/effects/fsr2.cpp
@@ -223,7 +223,7 @@ static FfxErrorCode create_resource_rd(FfxFsr2Interface *p_backend_interface, co
 	if (p_create_resource_description->initDataSize) {
 		PackedByteArray byte_array;
 		byte_array.resize(p_create_resource_description->initDataSize);
-		memcpy(byte_array.ptrw(), p_create_resource_description->initData, p_create_resource_description->initDataSize);
+		std::memcpy(byte_array.ptrw(), p_create_resource_description->initData, p_create_resource_description->initDataSize);
 		initial_data.push_back(byte_array);
 	}
 
@@ -317,15 +317,15 @@ static FfxErrorCode create_pipeline_rd(FfxFsr2Interface *p_backend_interface, Ff
 
 	p_out_pipeline->srvCount = effect_pass.sampled_bindings.size();
 	ERR_FAIL_COND_V(p_out_pipeline->srvCount > FFX_MAX_NUM_SRVS, FFX_ERROR_OUT_OF_RANGE);
-	memcpy(p_out_pipeline->srvResourceBindings, effect_pass.sampled_bindings.ptr(), sizeof(FfxResourceBinding) * p_out_pipeline->srvCount);
+	std::memcpy(p_out_pipeline->srvResourceBindings, effect_pass.sampled_bindings.ptr(), sizeof(FfxResourceBinding) * p_out_pipeline->srvCount);
 
 	p_out_pipeline->uavCount = effect_pass.storage_bindings.size();
 	ERR_FAIL_COND_V(p_out_pipeline->uavCount > FFX_MAX_NUM_UAVS, FFX_ERROR_OUT_OF_RANGE);
-	memcpy(p_out_pipeline->uavResourceBindings, effect_pass.storage_bindings.ptr(), sizeof(FfxResourceBinding) * p_out_pipeline->uavCount);
+	std::memcpy(p_out_pipeline->uavResourceBindings, effect_pass.storage_bindings.ptr(), sizeof(FfxResourceBinding) * p_out_pipeline->uavCount);
 
 	p_out_pipeline->constCount = effect_pass.uniform_bindings.size();
 	ERR_FAIL_COND_V(p_out_pipeline->constCount > FFX_MAX_NUM_CONST_BUFFERS, FFX_ERROR_OUT_OF_RANGE);
-	memcpy(p_out_pipeline->cbResourceBindings, effect_pass.uniform_bindings.ptr(), sizeof(FfxResourceBinding) * p_out_pipeline->constCount);
+	std::memcpy(p_out_pipeline->cbResourceBindings, effect_pass.uniform_bindings.ptr(), sizeof(FfxResourceBinding) * p_out_pipeline->constCount);
 
 	bool low_resolution_mvs = (p_pipeline_description->contextFlags & FFX_FSR2_ENABLE_DISPLAY_RESOLUTION_MOTION_VECTORS) == 0;
 

--- a/servers/rendering/renderer_rd/effects/luminance.cpp
+++ b/servers/rendering/renderer_rd/effects/luminance.cpp
@@ -166,7 +166,7 @@ void Luminance::luminance_reduction(RID p_source_texture, const Size2i p_source_
 
 	if (prefer_raster_effects) {
 		LuminanceReduceRasterPushConstant push_constant;
-		memset(&push_constant, 0, sizeof(LuminanceReduceRasterPushConstant));
+		std::memset(&push_constant, 0, sizeof(LuminanceReduceRasterPushConstant));
 
 		push_constant.max_luminance = p_max_luminance;
 		push_constant.min_luminance = p_min_luminance;
@@ -201,7 +201,7 @@ void Luminance::luminance_reduction(RID p_source_texture, const Size2i p_source_
 		}
 	} else {
 		LuminanceReducePushConstant push_constant;
-		memset(&push_constant, 0, sizeof(LuminanceReducePushConstant));
+		std::memset(&push_constant, 0, sizeof(LuminanceReducePushConstant));
 
 		push_constant.source_size[0] = p_source_size.x;
 		push_constant.source_size[1] = p_source_size.y;

--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -666,7 +666,7 @@ void SSEffects::screen_space_indirect_lighting(Ref<RenderSceneBuffersRD> p_rende
 
 	RD::get_singleton()->buffer_update(ssil.projection_uniform_buffer, 0, sizeof(SSILProjectionUniforms), &projection_uniforms);
 
-	memset(&ssil.gather_push_constant, 0, sizeof(SSILGatherPushConstant));
+	std::memset(&ssil.gather_push_constant, 0, sizeof(SSILGatherPushConstant));
 
 	RID shader = ssil.gather_shader.version_get_shader(ssil.gather_shader_version, SSIL_GATHER);
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
@@ -1063,7 +1063,7 @@ void SSEffects::generate_ssao(Ref<RenderSceneBuffersRD> p_render_buffers, SSAORe
 	}
 
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
-	memset(&ssao.gather_push_constant, 0, sizeof(SSAOGatherPushConstant));
+	std::memset(&ssao.gather_push_constant, 0, sizeof(SSAOGatherPushConstant));
 	/* FIRST PASS */
 
 	RID shader = ssao.gather_shader.version_get_shader(ssao.gather_shader_version, SSAO_GATHER);

--- a/servers/rendering/renderer_rd/effects/taa.cpp
+++ b/servers/rendering/renderer_rd/effects/taa.cpp
@@ -59,7 +59,7 @@ void TAA::resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_pr
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
 	TAAResolvePushConstant push_constant;
-	memset(&push_constant, 0, sizeof(TAAResolvePushConstant));
+	std::memset(&push_constant, 0, sizeof(TAAResolvePushConstant));
 	push_constant.resolution_width = p_resolution.width;
 	push_constant.resolution_height = p_resolution.height;
 	push_constant.disocclusion_threshold = 2.5f; // If velocity changes by less than this amount of texels we can retain the accumulation buffer.

--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -87,7 +87,7 @@ void ToneMapper::tonemapper(RID p_source_color, RID p_dst_framebuffer, const Ton
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&tonemap.push_constant, 0, sizeof(TonemapPushConstant));
+	std::memset(&tonemap.push_constant, 0, sizeof(TonemapPushConstant));
 
 	tonemap.push_constant.flags |= p_settings.use_bcs ? TONEMAP_FLAG_USE_BCS : 0;
 	tonemap.push_constant.bcs[0] = p_settings.brightness;
@@ -184,7 +184,7 @@ void ToneMapper::tonemapper(RD::DrawListID p_subpass_draw_list, RID p_source_col
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	memset(&tonemap.push_constant, 0, sizeof(TonemapPushConstant));
+	std::memset(&tonemap.push_constant, 0, sizeof(TonemapPushConstant));
 
 	tonemap.push_constant.flags |= p_settings.use_bcs ? TONEMAP_FLAG_USE_BCS : 0;
 	tonemap.push_constant.bcs[0] = p_settings.brightness;

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -2037,7 +2037,7 @@ void GI::SDFGI::render_region(Ref<RenderSceneBuffersRD> p_render_buffers, int p_
 		//clear dispatch indirect data
 
 		SDFGIShader::PreprocessPushConstant push_constant;
-		memset(&push_constant, 0, sizeof(SDFGIShader::PreprocessPushConstant));
+		std::memset(&push_constant, 0, sizeof(SDFGIShader::PreprocessPushConstant));
 
 		RENDER_TIMESTAMP("SDFGI Scroll SDF");
 
@@ -3131,7 +3131,7 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 				RendererSceneRenderRD::get_singleton()->_render_material(to_world_xform * xform, cm, true, RendererSceneRenderRD::get_singleton()->cull_argument, dynamic_maps[0].fb, Rect2i(Vector2i(), rect.size), exposure_normalization);
 
 				VoxelGIDynamicPushConstant push_constant;
-				memset(&push_constant, 0, sizeof(VoxelGIDynamicPushConstant));
+				std::memset(&push_constant, 0, sizeof(VoxelGIDynamicPushConstant));
 				push_constant.limits[0] = octree_size.x;
 				push_constant.limits[1] = octree_size.y;
 				push_constant.limits[2] = octree_size.z;

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -213,7 +213,7 @@ static _FORCE_INLINE_ void store_transform_3x3(const Basis &p_basis, float *p_ar
 void SkyRD::_render_sky(RD::DrawListID p_list, float p_time, RID p_fb, PipelineCacheRD *p_pipeline, RID p_uniform_set, RID p_texture_set, const Projection &p_projection, const Basis &p_orientation, const Vector3 &p_position, float p_luminance_multiplier, float p_brightness_multiplier) {
 	SkyPushConstant sky_push_constant;
 
-	memset(&sky_push_constant, 0, sizeof(SkyPushConstant));
+	std::memset(&sky_push_constant, 0, sizeof(SkyPushConstant));
 
 	// We only need key components of our projection matrix
 	sky_push_constant.projection[0] = p_projection.columns[2][0];

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -4721,7 +4721,7 @@ void RenderForwardClustered::GeometryInstanceForwardClustered::set_lightmap_capt
 			lightmap_sh = RenderForwardClustered::get_singleton()->geometry_instance_lightmap_sh.alloc();
 		}
 
-		memcpy(lightmap_sh->sh, p_sh9, sizeof(Color) * 9);
+		std::memcpy(lightmap_sh->sh, p_sh9, sizeof(Color) * 9);
 	} else {
 		if (lightmap_sh != nullptr) {
 			RenderForwardClustered::get_singleton()->geometry_instance_lightmap_sh.free(lightmap_sh);

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2432,7 +2432,7 @@ void RenderForwardMobile::GeometryInstanceForwardMobile::set_lightmap_capture(co
 			lightmap_sh = RenderForwardMobile::get_singleton()->geometry_instance_lightmap_sh.alloc();
 		}
 
-		memcpy(lightmap_sh->sh, p_sh9, sizeof(Color) * 9);
+		std::memcpy(lightmap_sh->sh, p_sh9, sizeof(Color) * 9);
 	} else {
 		if (lightmap_sh != nullptr) {
 			RenderForwardMobile::get_singleton()->geometry_instance_lightmap_sh.free(lightmap_sh);

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -314,7 +314,7 @@ RendererCanvasRender::PolygonID RendererCanvasRenderRD::request_polygon(const Ve
 		index_buffer.resize(p_indices.size() * sizeof(int32_t));
 		{
 			uint8_t *w = index_buffer.ptrw();
-			memcpy(w, p_indices.ptr(), sizeof(int32_t) * p_indices.size());
+			std::memcpy(w, p_indices.ptr(), sizeof(int32_t) * p_indices.size());
 		}
 		pb.index_buffer = RD::get_singleton()->index_buffer_create(p_indices.size(), RD::INDEX_BUFFER_FORMAT_UINT32, index_buffer);
 		pb.indices = RD::get_singleton()->index_array_create(pb.index_buffer, 0, p_indices.size());

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -516,34 +516,34 @@ _FORCE_INLINE_ static void _fill_std140_ubo_empty(ShaderLanguage::DataType type,
 		case ShaderLanguage::TYPE_INT:
 		case ShaderLanguage::TYPE_UINT:
 		case ShaderLanguage::TYPE_FLOAT: {
-			memset(data, 0, 4 * p_array_size);
+			std::memset(data, 0, 4 * p_array_size);
 		} break;
 		case ShaderLanguage::TYPE_BVEC2:
 		case ShaderLanguage::TYPE_IVEC2:
 		case ShaderLanguage::TYPE_UVEC2:
 		case ShaderLanguage::TYPE_VEC2: {
-			memset(data, 0, 8 * p_array_size);
+			std::memset(data, 0, 8 * p_array_size);
 		} break;
 		case ShaderLanguage::TYPE_BVEC3:
 		case ShaderLanguage::TYPE_IVEC3:
 		case ShaderLanguage::TYPE_UVEC3:
 		case ShaderLanguage::TYPE_VEC3: {
-			memset(data, 0, 12 * p_array_size);
+			std::memset(data, 0, 12 * p_array_size);
 		} break;
 		case ShaderLanguage::TYPE_BVEC4:
 		case ShaderLanguage::TYPE_IVEC4:
 		case ShaderLanguage::TYPE_UVEC4:
 		case ShaderLanguage::TYPE_VEC4: {
-			memset(data, 0, 16 * p_array_size);
+			std::memset(data, 0, 16 * p_array_size);
 		} break;
 		case ShaderLanguage::TYPE_MAT2: {
-			memset(data, 0, 32 * p_array_size);
+			std::memset(data, 0, 32 * p_array_size);
 		} break;
 		case ShaderLanguage::TYPE_MAT3: {
-			memset(data, 0, 48 * p_array_size);
+			std::memset(data, 0, 48 * p_array_size);
 		} break;
 		case ShaderLanguage::TYPE_MAT4: {
-			memset(data, 0, 64 * p_array_size);
+			std::memset(data, 0, 64 * p_array_size);
 		} break;
 
 		default: {
@@ -1104,7 +1104,7 @@ bool MaterialStorage::MaterialData::update_parameters_uniform_set(const HashMap<
 		ubo_data[p_use_linear_color].resize(p_ubo_size);
 		if (ubo_data[p_use_linear_color].size()) {
 			uniform_buffer[p_use_linear_color] = RD::get_singleton()->uniform_buffer_create(ubo_data[p_use_linear_color].size());
-			memset(ubo_data[p_use_linear_color].ptrw(), 0, ubo_data[p_use_linear_color].size()); //clear
+			std::memset(ubo_data[p_use_linear_color].ptrw(), 0, ubo_data[p_use_linear_color].size()); //clear
 		}
 
 		//clear previous uniform set
@@ -1269,10 +1269,10 @@ MaterialStorage::MaterialStorage() {
 
 	global_shader_uniforms.buffer_size = MAX(4096, (int)GLOBAL_GET("rendering/limits/global_shader_variables/buffer_size"));
 	global_shader_uniforms.buffer_values = memnew_arr(GlobalShaderUniforms::Value, global_shader_uniforms.buffer_size);
-	memset(global_shader_uniforms.buffer_values, 0, sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size);
+	std::memset(global_shader_uniforms.buffer_values, 0, sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size);
 	global_shader_uniforms.buffer_usage = memnew_arr(GlobalShaderUniforms::ValueUsage, global_shader_uniforms.buffer_size);
 	global_shader_uniforms.buffer_dirty_regions = memnew_arr(bool, 1 + (global_shader_uniforms.buffer_size / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE));
-	memset(global_shader_uniforms.buffer_dirty_regions, 0, sizeof(bool) * (1 + (global_shader_uniforms.buffer_size / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE)));
+	std::memset(global_shader_uniforms.buffer_dirty_regions, 0, sizeof(bool) * (1 + (global_shader_uniforms.buffer_size / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE)));
 	global_shader_uniforms.buffer = RD::get_singleton()->storage_buffer_create(sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size);
 }
 
@@ -1880,7 +1880,7 @@ void MaterialStorage::_update_global_shader_uniforms() {
 		if (total_regions / global_shader_uniforms.buffer_dirty_region_count <= 4) {
 			// 25% of regions dirty, just update all buffer
 			RD::get_singleton()->buffer_update(global_shader_uniforms.buffer, 0, sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size, global_shader_uniforms.buffer_values);
-			memset(global_shader_uniforms.buffer_dirty_regions, 0, sizeof(bool) * total_regions);
+			std::memset(global_shader_uniforms.buffer_dirty_regions, 0, sizeof(bool) * total_regions);
 		} else {
 			uint32_t region_byte_size = sizeof(GlobalShaderUniforms::Value) * GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE;
 

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -384,7 +384,7 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 			// Unfortunately, we need to copy the buffer, which is fine as doing a resize triggers a CoW anyway.
 			Vector<uint8_t> new_vertex_data;
 			new_vertex_data.resize_zeroed(new_surface.vertex_data.size() + sizeof(uint16_t) * 2);
-			memcpy(new_vertex_data.ptrw(), new_surface.vertex_data.ptr(), new_surface.vertex_data.size());
+			std::memcpy(new_vertex_data.ptrw(), new_surface.vertex_data.ptr(), new_surface.vertex_data.size());
 			s->vertex_buffer = RD::get_singleton()->vertex_buffer_create(new_vertex_data.size(), new_vertex_data, as_storage_flag);
 			s->vertex_buffer_size = new_vertex_data.size();
 		} else {
@@ -884,7 +884,7 @@ void MeshStorage::mesh_surface_remove(RID p_mesh, int p_surface) {
 	_mesh_surface_clear(mesh, p_surface);
 
 	if ((uint32_t)p_surface < mesh->surface_count - 1) {
-		memmove(mesh->surfaces + p_surface, mesh->surfaces + p_surface + 1, sizeof(Mesh::Surface *) * (mesh->surface_count - (p_surface + 1)));
+		std::memmove(mesh->surfaces + p_surface, mesh->surfaces + p_surface + 1, sizeof(Mesh::Surface *) * (mesh->surface_count - (p_surface + 1)));
 	}
 	mesh->surfaces = (Mesh::Surface **)memrealloc(mesh->surfaces, sizeof(Mesh::Surface *) * (mesh->surface_count - 1));
 	--mesh->surface_count;
@@ -1711,19 +1711,19 @@ void MeshStorage::_multimesh_make_local(MultiMesh *multimesh) const {
 			Vector<uint8_t> buffer = RD::get_singleton()->buffer_get_data(multimesh->buffer);
 			{
 				const uint8_t *r = buffer.ptr();
-				memcpy(w, r, buffer.size());
+				std::memcpy(w, r, buffer.size());
 			}
 		} else {
-			memset(w, 0, buffer_size * sizeof(float));
+			std::memset(w, 0, buffer_size * sizeof(float));
 		}
 	}
 	uint32_t data_cache_dirty_region_count = Math::division_round_up(multimesh->instances, MULTIMESH_DIRTY_REGION_SIZE);
 	multimesh->data_cache_dirty_regions = memnew_arr(bool, data_cache_dirty_region_count);
-	memset(multimesh->data_cache_dirty_regions, 0, data_cache_dirty_region_count * sizeof(bool));
+	std::memset(multimesh->data_cache_dirty_regions, 0, data_cache_dirty_region_count * sizeof(bool));
 	multimesh->data_cache_dirty_region_count = 0;
 
 	multimesh->previous_data_cache_dirty_regions = memnew_arr(bool, data_cache_dirty_region_count);
-	memset(multimesh->previous_data_cache_dirty_regions, 0, data_cache_dirty_region_count * sizeof(bool));
+	std::memset(multimesh->previous_data_cache_dirty_regions, 0, data_cache_dirty_region_count * sizeof(bool));
 	multimesh->previous_data_cache_dirty_region_count = 0;
 }
 
@@ -1751,7 +1751,7 @@ void MeshStorage::_multimesh_update_motion_vectors_data_cache(MultiMesh *multime
 			for (uint32_t i = 0; i < visible_region_count; i++) {
 				if (multimesh->previous_data_cache_dirty_regions[i]) {
 					uint32_t offset = i * region_size;
-					memcpy(data + current_ofs + offset, data + previous_ofs + offset, MIN(region_size, size - offset));
+					std::memcpy(data + current_ofs + offset, data + previous_ofs + offset, MIN(region_size, size - offset));
 				}
 			}
 		}
@@ -2112,7 +2112,7 @@ void MeshStorage::_multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_
 
 	if (multimesh->data_cache.size()) {
 		float *cache_data = multimesh->data_cache.ptrw();
-		memcpy(cache_data + (multimesh->motion_vectors_current_offset * multimesh->stride_cache), p_buffer.ptr(), p_buffer.size() * sizeof(float));
+		std::memcpy(cache_data + (multimesh->motion_vectors_current_offset * multimesh->stride_cache), p_buffer.ptr(), p_buffer.size() * sizeof(float));
 		_multimesh_mark_all_dirty(multimesh, true, true); //update AABB
 	} else if (multimesh->mesh.is_valid()) {
 		//if we have a mesh set, we need to re-generate the AABB from the new data
@@ -2149,11 +2149,11 @@ Vector<float> MeshStorage::_multimesh_get_buffer(RID p_multimesh) const {
 
 		if (multimesh->data_cache.size()) {
 			const uint8_t *r = (uint8_t *)multimesh->data_cache.ptr() + multimesh->motion_vectors_current_offset * multimesh->stride_cache * sizeof(float);
-			memcpy(w, r, ret.size() * sizeof(float));
+			std::memcpy(w, r, ret.size() * sizeof(float));
 		} else {
 			Vector<uint8_t> buffer = RD::get_singleton()->buffer_get_data(multimesh->buffer);
 			const uint8_t *r = buffer.ptr() + multimesh->motion_vectors_current_offset * multimesh->stride_cache * sizeof(float);
-			memcpy(w, r, ret.size() * sizeof(float));
+			std::memcpy(w, r, ret.size() * sizeof(float));
 		}
 		return ret;
 	}
@@ -2260,8 +2260,8 @@ void MeshStorage::_update_dirty_multimeshes() {
 					}
 				}
 
-				memcpy(multimesh->previous_data_cache_dirty_regions, multimesh->data_cache_dirty_regions, data_cache_dirty_region_count * sizeof(bool));
-				memset(multimesh->data_cache_dirty_regions, 0, data_cache_dirty_region_count * sizeof(bool));
+				std::memcpy(multimesh->previous_data_cache_dirty_regions, multimesh->data_cache_dirty_regions, data_cache_dirty_region_count * sizeof(bool));
+				std::memset(multimesh->data_cache_dirty_regions, 0, data_cache_dirty_region_count * sizeof(bool));
 
 				multimesh->previous_data_cache_dirty_region_count = multimesh->data_cache_dirty_region_count;
 				multimesh->data_cache_dirty_region_count = 0;
@@ -2334,7 +2334,7 @@ void MeshStorage::skeleton_allocate_data(RID p_skeleton, int p_bones, bool p_2d_
 	if (skeleton->size) {
 		skeleton->data.resize(skeleton->size * (skeleton->use_2d ? 8 : 12));
 		skeleton->buffer = RD::get_singleton()->storage_buffer_create(skeleton->data.size() * sizeof(float));
-		memset(skeleton->data.ptr(), 0, skeleton->data.size() * sizeof(float));
+		std::memset(skeleton->data.ptr(), 0, skeleton->data.size() * sizeof(float));
 
 		_skeleton_make_dirty(skeleton);
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -539,7 +539,7 @@ void ParticlesStorage::_particles_allocate_emission_buffer(Particles *particles)
 	ERR_FAIL_COND(particles->emission_buffer != nullptr);
 
 	particles->emission_buffer_data.resize(sizeof(ParticleEmissionBuffer::Data) * particles->amount + sizeof(uint32_t) * 4);
-	memset(particles->emission_buffer_data.ptrw(), 0, particles->emission_buffer_data.size());
+	std::memset(particles->emission_buffer_data.ptrw(), 0, particles->emission_buffer_data.size());
 	particles->emission_buffer = reinterpret_cast<ParticleEmissionBuffer *>(particles->emission_buffer_data.ptrw());
 	particles->emission_buffer->particle_max = particles->amount;
 
@@ -1483,7 +1483,7 @@ void ParticlesStorage::update_particles() {
 
 			if (uint32_t(history_size) != particles->frame_history.size()) {
 				particles->frame_history.resize(history_size);
-				memset(particles->frame_history.ptr(), 0, sizeof(ParticlesFrameParams) * history_size);
+				std::memset(particles->frame_history.ptr(), 0, sizeof(ParticlesFrameParams) * history_size);
 				// Set the frame number so that we are able to distinguish an uninitialized
 				// frame from the true frame number zero. See issue #88712 for details.
 				for (int i = 0; i < history_size; i++) {

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -73,7 +73,7 @@ void RenderSceneDataRD::update_ubo(RID p_uniform_buffer, RS::ViewportDebugDraw p
 	RendererSceneRenderRD *render_scene_render = RendererSceneRenderRD::get_singleton();
 
 	UBODATA ubo_data;
-	memset(&ubo_data, 0, sizeof(UBODATA));
+	std::memset(&ubo_data, 0, sizeof(UBODATA));
 
 	// just for easy access..
 	UBO &ubo = ubo_data.ubo;
@@ -261,7 +261,7 @@ void RenderSceneDataRD::update_ubo(RID p_uniform_buffer, RS::ViewportDebugDraw p
 
 	if (calculate_motion_vectors) {
 		// Q : Should we make a complete copy or should we define a separate UBO with just the components we need?
-		memcpy(&prev_ubo, &ubo, sizeof(UBO));
+		std::memcpy(&prev_ubo, &ubo, sizeof(UBO));
 
 		Projection prev_correction;
 		prev_correction.set_depth_correction(true);

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -997,7 +997,7 @@ void TextureStorage::texture_3d_initialize(RID p_texture, Image::Format p_format
 		for (int i = 0; i < p_data.size(); i++) {
 			uint32_t s = images[i]->get_data().size();
 
-			memcpy(&all_data.write[offset], images[i]->get_data().ptr(), s);
+			std::memcpy(&all_data.write[offset], images[i]->get_data().ptr(), s);
 			{
 				Texture::BufferSlice3D slice;
 				slice.size.width = images[i]->get_width();
@@ -1360,7 +1360,7 @@ void TextureStorage::texture_3d_update(RID p_texture, const Vector<Ref<Image>> &
 
 		for (int i = 0; i < p_data.size(); i++) {
 			uint32_t s = images[i]->get_data().size();
-			memcpy(&all_data.write[offset], images[i]->get_data().ptr(), s);
+			std::memcpy(&all_data.write[offset], images[i]->get_data().ptr(), s);
 			offset += s;
 		}
 	}
@@ -2862,7 +2862,7 @@ void TextureStorage::update_decal_atlas() {
 			v_offsetsv.resize(base_size);
 
 			int *v_offsets = v_offsetsv.ptrw();
-			memset(v_offsets, 0, sizeof(int) * base_size);
+			std::memset(v_offsets, 0, sizeof(int) * base_size);
 
 			int max_height = 0;
 
@@ -3874,7 +3874,7 @@ RID TextureStorage::render_target_get_sdf_texture(RID p_render_target) {
 
 		Vector<uint8_t> pv;
 		pv.resize(16 * 4);
-		memset(pv.ptrw(), 0, 16 * 4);
+		std::memset(pv.ptrw(), 0, 16 * 4);
 		Vector<Vector<uint8_t>> vpv;
 
 		rt->sdf_buffer_read = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -264,7 +264,7 @@ Error RenderingDevice::_buffer_initialize(Buffer *p_buffer, const uint8_t *p_dat
 	uint8_t *data_ptr = driver->buffer_map(transfer_worker->staging_buffer);
 	ERR_FAIL_NULL_V(data_ptr, ERR_CANT_CREATE);
 
-	memcpy(data_ptr + transfer_worker_offset, p_data, p_data_size);
+	std::memcpy(data_ptr + transfer_worker_offset, p_data, p_data_size);
 	driver->buffer_unmap(transfer_worker->staging_buffer);
 
 	// Copy from the staging buffer to the real buffer.
@@ -521,7 +521,7 @@ Error RenderingDevice::buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p
 		ERR_FAIL_NULL_V(data_ptr, ERR_CANT_CREATE);
 
 		// Copy to staging buffer.
-		memcpy(data_ptr + block_write_offset, src_data + submit_from, block_write_amount);
+		std::memcpy(data_ptr + block_write_offset, src_data + submit_from, block_write_amount);
 
 		// Unmap.
 		driver->buffer_unmap(upload_staging_buffers.blocks[upload_staging_buffers.current].driver_id);
@@ -693,7 +693,7 @@ Vector<uint8_t> RenderingDevice::buffer_get_data(RID p_buffer, uint32_t p_offset
 	{
 		buffer_data.resize(p_size);
 		uint8_t *w = buffer_data.ptrw();
-		memcpy(w, buffer_mem, p_size);
+		std::memcpy(w, buffer_mem, p_size);
 	}
 
 	driver->buffer_unmap(tmp_buffer);
@@ -1941,7 +1941,7 @@ Vector<uint8_t> RenderingDevice::_texture_get_data(Texture *tex, uint32_t p_laye
 						const uint8_t *rptr = slice_read_ptr + y * layout.row_pitch;
 						uint8_t *wptr = write_ptr + y * line_width;
 
-						memcpy(wptr, rptr, line_width);
+						std::memcpy(wptr, rptr, line_width);
 					}
 
 				} else {
@@ -1949,7 +1949,7 @@ Vector<uint8_t> RenderingDevice::_texture_get_data(Texture *tex, uint32_t p_laye
 					for (uint32_t y = 0; y < height; y++) {
 						const uint8_t *rptr = slice_read_ptr + y * layout.row_pitch;
 						uint8_t *wptr = write_ptr + y * pixel_size * width;
-						memcpy(wptr, rptr, (uint64_t)pixel_size * width);
+						std::memcpy(wptr, rptr, (uint64_t)pixel_size * width);
 					}
 				}
 			}
@@ -2060,7 +2060,7 @@ Vector<uint8_t> RenderingDevice::texture_get_data(RID p_texture, uint32_t p_laye
 			const uint8_t *rp = read_ptr;
 			uint8_t *wp = write_ptr;
 			for (uint32_t row = h * d / block_h; row != 0; row--) {
-				memcpy(wp, rp, tight_row_pitch);
+				std::memcpy(wp, rp, tight_row_pitch);
 				rp += mip_layouts[i].row_pitch;
 				wp += tight_row_pitch;
 			}
@@ -5238,7 +5238,7 @@ void RenderingDevice::compute_list_set_push_constant(ComputeListID p_list, const
 	draw_graph.add_compute_list_set_push_constant(compute_list.state.pipeline_shader_driver_id, p_data, p_data_size);
 
 	// Store it in the state in case we need to restart the compute list.
-	memcpy(compute_list.state.push_constant_data, p_data, p_data_size);
+	std::memcpy(compute_list.state.push_constant_data, p_data, p_data_size);
 	compute_list.state.push_constant_size = p_data_size;
 
 #ifdef DEBUG_ENABLED
@@ -6553,7 +6553,7 @@ void RenderingDevice::_stall_for_frame(uint32_t p_frame) {
 					uint32_t local_index = request.frame_local_index + j;
 					const RDD::BufferCopyRegion &region = frames[p_frame].download_buffer_copy_regions[local_index];
 					uint8_t *buffer_data = driver->buffer_map(frames[p_frame].download_buffer_staging_buffers[local_index]);
-					memcpy(&packed_byte_array.write[array_offset], &buffer_data[region.dst_offset], region.size);
+					std::memcpy(&packed_byte_array.write[array_offset], &buffer_data[region.dst_offset], region.size);
 					driver->buffer_unmap(frames[p_frame].download_buffer_staging_buffers[local_index]);
 					array_offset += region.size;
 				}
@@ -6604,7 +6604,7 @@ void RenderingDevice::_stall_for_frame(uint32_t p_frame) {
 
 					write_ptr += ((region.texture_offset.y / block_h) * (w / block_w) + (region.texture_offset.x / block_w)) * unit_size;
 					for (uint32_t y = region_h / block_h; y > 0; y--) {
-						memcpy(write_ptr, read_ptr, (region_w / block_w) * unit_size);
+						std::memcpy(write_ptr, read_ptr, (region_w / block_w) * unit_size);
 						write_ptr += (w / block_w) * unit_size;
 						read_ptr += region_pitch;
 					}

--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -1755,7 +1755,7 @@ void RenderingDeviceGraph::add_compute_list_set_push_constant(RDD::ShaderID p_sh
 	instruction->type = ComputeListInstruction::TYPE_SET_PUSH_CONSTANT;
 	instruction->size = p_data_size;
 	instruction->shader = p_shader;
-	memcpy(instruction->data(), p_data, p_data_size);
+	std::memcpy(instruction->data(), p_data, p_data_size);
 }
 
 void RenderingDeviceGraph::add_compute_list_uniform_set_prepare_for_use(RDD::ShaderID p_shader, RDD::UniformSetID p_uniform_set, uint32_t set_index) {
@@ -1800,7 +1800,7 @@ void RenderingDeviceGraph::add_compute_list_end() {
 	command->type = RecordedCommand::TYPE_COMPUTE_LIST;
 	command->self_stages = compute_instruction_list.stages;
 	command->instruction_data_size = instruction_data_size;
-	memcpy(command->instruction_data(), compute_instruction_list.data.ptr(), instruction_data_size);
+	std::memcpy(command->instruction_data(), compute_instruction_list.data.ptr(), instruction_data_size);
 	_add_command_to_graph(compute_instruction_list.command_trackers.ptr(), compute_instruction_list.command_tracker_usages.ptr(), compute_instruction_list.command_trackers.size(), command_index, command);
 }
 
@@ -1953,7 +1953,7 @@ void RenderingDeviceGraph::add_draw_list_set_push_constant(RDD::ShaderID p_shade
 	instruction->type = DrawListInstruction::TYPE_SET_PUSH_CONSTANT;
 	instruction->size = p_data_size;
 	instruction->shader = p_shader;
-	memcpy(instruction->data(), p_data, p_data_size);
+	std::memcpy(instruction->data(), p_data, p_data_size);
 }
 
 void RenderingDeviceGraph::add_draw_list_set_scissor(Rect2i p_rect) {
@@ -2060,7 +2060,7 @@ void RenderingDeviceGraph::add_draw_list_end() {
 		clear_values[i] = draw_instruction_list.attachment_clear_values[i];
 	}
 
-	memcpy(command->instruction_data(), draw_instruction_list.data.ptr(), instruction_data_size);
+	std::memcpy(command->instruction_data(), draw_instruction_list.data.ptr(), instruction_data_size);
 	_add_command_to_graph(draw_instruction_list.command_trackers.ptr(), draw_instruction_list.command_tracker_usages.ptr(), draw_instruction_list.command_trackers.size(), command_index, command);
 }
 
@@ -2223,7 +2223,7 @@ void RenderingDeviceGraph::begin_label(const String &p_label_name, const Color &
 	PackedByteArray command_label_utf8 = p_label_name.to_utf8_buffer();
 	int command_label_utf8_size = command_label_utf8.size();
 	command_label_chars.resize(command_label_offset + command_label_utf8_size + 1);
-	memcpy(&command_label_chars[command_label_offset], command_label_utf8.ptr(), command_label_utf8.size());
+	std::memcpy(&command_label_chars[command_label_offset], command_label_utf8.ptr(), command_label_utf8.size());
 	command_label_chars[command_label_offset + command_label_utf8_size] = '\0';
 	command_label_colors.push_back(p_color);
 	command_label_offsets.push_back(command_label_offset);
@@ -2251,7 +2251,7 @@ void RenderingDeviceGraph::end(bool p_reorder_commands, bool p_full_barriers, RD
 
 		// Count all the incoming connections to every node by traversing their adjacency list.
 		command_degrees.resize(command_count);
-		memset(command_degrees.ptr(), 0, sizeof(uint32_t) * command_degrees.size());
+		std::memset(command_degrees.ptr(), 0, sizeof(uint32_t) * command_degrees.size());
 		for (uint32_t i = 0; i < command_count; i++) {
 			const RecordedCommand &recorded_command = *reinterpret_cast<const RecordedCommand *>(&command_data[command_data_offsets[i]]);
 			adjacency_list_index = recorded_command.adjacent_command_list_index;

--- a/servers/rendering/storage/variant_converters.h
+++ b/servers/rendering/storage/variant_converters.h
@@ -303,7 +303,7 @@ void write_array_std140(const Vector<From> &p_values, To *p_write, int p_array_s
 	const From *read = p_values.ptr();
 	const T default_value{};
 
-	memset(p_write, 0, sizeof(To) * stride_count);
+	std::memset(p_write, 0, sizeof(To) * stride_count);
 
 	for (int i = 0, j = 0; i < dst_count; i += elements, j += p_stride) {
 		if (i + elements - 1 < src_count) {

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -436,7 +436,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 						for (int i = 0; i < p_vertex_array_len; i++) {
 							float vector[2] = { (float)src[i].x, (float)src[i].y };
 
-							memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(float) * 2);
+							std::memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(float) * 2);
 
 							if (i == 0) {
 								aabb = Rect2(src[i], SMALL_VEC2); // Must have a bit of size.
@@ -469,7 +469,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 									(uint16_t)0
 								};
 
-								memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(uint16_t) * 4);
+								std::memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(uint16_t) * 4);
 							}
 							continue;
 						}
@@ -505,7 +505,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 										(uint16_t)CLAMP(res.y * 65535, 0, 65535),
 									};
 
-									memcpy(&vw[p_offsets[RS::ARRAY_NORMAL] + i * p_normal_stride], vector, 4);
+									std::memcpy(&vw[p_offsets[RS::ARRAY_NORMAL] + i * p_normal_stride], vector, 4);
 								}
 
 								// Store vertex position + angle.
@@ -518,7 +518,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 										(uint16_t)CLAMP(angle * 65535, 0, 65535)
 									};
 
-									memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(uint16_t) * 4);
+									std::memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(uint16_t) * 4);
 								}
 							}
 						} else if (tangent_type == Variant::PACKED_FLOAT64_ARRAY) {
@@ -541,7 +541,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 										(uint16_t)CLAMP(res.y * 65535, 0, 65535),
 									};
 
-									memcpy(&vw[p_offsets[RS::ARRAY_NORMAL] + i * p_normal_stride], vector, 4);
+									std::memcpy(&vw[p_offsets[RS::ARRAY_NORMAL] + i * p_normal_stride], vector, 4);
 								}
 
 								// Store vertex position + angle.
@@ -554,7 +554,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 										(uint16_t)CLAMP(angle * 65535, 0, 65535)
 									};
 
-									memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(uint16_t) * 4);
+									std::memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(uint16_t) * 4);
 								}
 							}
 						} else { // No tangent array.
@@ -576,7 +576,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 										(uint16_t)CLAMP(res.y * 65535, 0, 65535),
 									};
 
-									memcpy(&vw[p_offsets[RS::ARRAY_NORMAL] + i * p_normal_stride], vector, 4);
+									std::memcpy(&vw[p_offsets[RS::ARRAY_NORMAL] + i * p_normal_stride], vector, 4);
 								}
 
 								// Store vertex position + angle.
@@ -589,7 +589,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 										(uint16_t)CLAMP(angle * 65535, 0, 65535)
 									};
 
-									memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(uint16_t) * 4);
+									std::memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(uint16_t) * 4);
 								}
 							}
 						}
@@ -597,7 +597,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 						for (int i = 0; i < p_vertex_array_len; i++) {
 							float vector[3] = { (float)src[i].x, (float)src[i].y, (float)src[i].z };
 
-							memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(float) * 3);
+							std::memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, sizeof(float) * 3);
 						}
 					}
 				}
@@ -619,7 +619,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 							(uint16_t)CLAMP(res.y * 65535, 0, 65535),
 						};
 
-						memcpy(&vw[p_offsets[ai] + i * p_normal_stride], vector, 4);
+						std::memcpy(&vw[p_offsets[ai] + i * p_normal_stride], vector, 4);
 					}
 				}
 			} break;
@@ -649,7 +649,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 								vector[0] = 65535;
 							}
 
-							memcpy(&vw[p_offsets[ai] + i * p_normal_stride], vector, 4);
+							std::memcpy(&vw[p_offsets[ai] + i * p_normal_stride], vector, 4);
 						}
 					} else if (type == Variant::PACKED_FLOAT64_ARRAY) {
 						Vector<double> array = p_arrays[ai];
@@ -670,7 +670,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 								vector[0] = 65535;
 							}
 
-							memcpy(&vw[p_offsets[ai] + i * p_normal_stride], vector, 4);
+							std::memcpy(&vw[p_offsets[ai] + i * p_normal_stride], vector, 4);
 						}
 					} else { // No tangent array.
 						ERR_FAIL_COND_V(p_arrays[RS::ARRAY_NORMAL].get_type() != Variant::PACKED_VECTOR3_ARRAY, ERR_INVALID_PARAMETER);
@@ -695,7 +695,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 								vector[0] = 65535;
 							}
 
-							memcpy(&vw[p_offsets[ai] + i * p_normal_stride], vector, 4);
+							std::memcpy(&vw[p_offsets[ai] + i * p_normal_stride], vector, 4);
 						}
 					}
 				}
@@ -715,7 +715,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 						uint8_t(CLAMP(src[i].b * 255.0, 0.0, 255.0)),
 						uint8_t(CLAMP(src[i].a * 255.0, 0.0, 255.0))
 					};
-					memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], color8, 4);
+					std::memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], color8, 4);
 				}
 			} break;
 			case RS::ARRAY_TEX_UV: {
@@ -735,12 +735,12 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 						}
 
 						uint16_t uv[2] = { (uint16_t)CLAMP(vec.x * 65535, 0, 65535), (uint16_t)CLAMP(vec.y * 65535, 0, 65535) };
-						memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], uv, 4);
+						std::memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], uv, 4);
 					}
 				} else {
 					for (int i = 0; i < p_vertex_array_len; i++) {
 						float uv[2] = { (float)src[i].x, (float)src[i].y };
-						memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], uv, 2 * 4);
+						std::memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], uv, 2 * 4);
 					}
 				}
 			} break;
@@ -762,12 +762,12 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 							vec = vec / (Vector2(r_uv_scale.z, r_uv_scale.w)) + Vector2(0.5, 0.5);
 						}
 						uint16_t uv[2] = { (uint16_t)CLAMP(vec.x * 65535, 0, 65535), (uint16_t)CLAMP(vec.y * 65535, 0, 65535) };
-						memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], uv, 4);
+						std::memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], uv, 4);
 					}
 				} else {
 					for (int i = 0; i < p_vertex_array_len; i++) {
 						float uv[2] = { (float)src[i].x, (float)src[i].y };
-						memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], uv, 2 * 4);
+						std::memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], uv, 2 * 4);
 					}
 				}
 			} break;
@@ -790,7 +790,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 						const uint8_t *src = array.ptr();
 
 						for (int i = 0; i < p_vertex_array_len; i++) {
-							memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], &src[i * 4], 4);
+							std::memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], &src[i * 4], 4);
 						}
 
 					} break;
@@ -805,7 +805,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 						const uint8_t *src = array.ptr();
 
 						for (int i = 0; i < p_vertex_array_len; i++) {
-							memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], &src[i * 8], 8);
+							std::memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], &src[i * 8], 8);
 						}
 					} break;
 					case ARRAY_CUSTOM_R_FLOAT:
@@ -823,7 +823,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 						const float *src = array.ptr();
 
 						for (int i = 0; i < p_vertex_array_len; i++) {
-							memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], &src[i * s], sizeof(float) * s);
+							std::memcpy(&aw[p_offsets[ai] + i * p_attrib_stride], &src[i * s], sizeof(float) * s);
 						}
 					} break;
 					default: {
@@ -846,7 +846,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 								data[j] = CLAMP(src[i * bone_count + j] * 65535, 0, 65535);
 							}
 
-							memcpy(&sw[p_offsets[ai] + i * p_skin_stride], data, 2 * bone_count);
+							std::memcpy(&sw[p_offsets[ai] + i * p_skin_stride], data, 2 * bone_count);
 						}
 					}
 				} else { // PACKED_FLOAT64_ARRAY
@@ -860,7 +860,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 								data[j] = CLAMP(src[i * bone_count + j] * 65535, 0, 65535);
 							}
 
-							memcpy(&sw[p_offsets[ai] + i * p_skin_stride], data, 2 * bone_count);
+							std::memcpy(&sw[p_offsets[ai] + i * p_skin_stride], data, 2 * bone_count);
 						}
 					}
 				}
@@ -884,7 +884,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 						max_bone = MAX(data[j], max_bone);
 					}
 
-					memcpy(&sw[p_offsets[ai] + i * p_skin_stride], data, 2 * bone_count);
+					std::memcpy(&sw[p_offsets[ai] + i * p_skin_stride], data, 2 * bone_count);
 				}
 
 			} break;
@@ -906,11 +906,11 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 					if (p_vertex_array_len <= (1 << 16) && p_vertex_array_len > 0) {
 						uint16_t v = src[i];
 
-						memcpy(&iw[i * 2], &v, 2);
+						std::memcpy(&iw[i * 2], &v, 2);
 					} else {
 						uint32_t v = src[i];
 
-						memcpy(&iw[i * 4], &v, 4);
+						std::memcpy(&iw[i * 4], &v, 4);
 					}
 				}
 			} break;
@@ -1598,7 +1598,7 @@ Array RenderingServer::_get_array_from_surface(uint64_t p_format, Vector<uint8_t
 
 						for (int j = 0; j < p_vertex_len; j++) {
 							const uint8_t *v = reinterpret_cast<const uint8_t *>(&ar[j * attrib_elem_size + offsets[i]]);
-							memcpy(&w[j * s], v, s);
+							std::memcpy(&w[j * s], v, s);
 						}
 
 						ret[i] = arr;
@@ -1617,7 +1617,7 @@ Array RenderingServer::_get_array_from_surface(uint64_t p_format, Vector<uint8_t
 
 						for (int j = 0; j < p_vertex_len; j++) {
 							const float *v = reinterpret_cast<const float *>(&ar[j * attrib_elem_size + offsets[i]]);
-							memcpy(&w[j * s], v, s * sizeof(float));
+							std::memcpy(&w[j * s], v, s * sizeof(float));
 						}
 						ret[i] = arr;
 

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -716,7 +716,7 @@ _FORCE_INLINE_ void ot_tag_to_string(int32_t p_tag, char *p_buf) {
 String TextServer::tag_to_name(int64_t p_tag) const {
 	// No readable name, use tag string.
 	char name[5];
-	memset(name, 0, 5);
+	std::memset(name, 0, 5);
 	ot_tag_to_string(p_tag, name);
 	return String("custom_") + String(name);
 }

--- a/servers/xr/xr_face_tracker.cpp
+++ b/servers/xr/xr_face_tracker.cpp
@@ -211,7 +211,7 @@ PackedFloat32Array XRFaceTracker::get_blend_shapes() const {
 	// Create a packed float32 array and copy the blend shape values into it.
 	PackedFloat32Array data;
 	data.resize(FT_MAX);
-	memcpy(data.ptrw(), blend_shape_values, sizeof(blend_shape_values));
+	std::memcpy(data.ptrw(), blend_shape_values, sizeof(blend_shape_values));
 
 	// Return the blend shape array.
 	return data;
@@ -222,7 +222,7 @@ void XRFaceTracker::set_blend_shapes(const PackedFloat32Array &p_blend_shapes) {
 	ERR_FAIL_COND(p_blend_shapes.size() != FT_MAX);
 
 	// Copy the blend shape values into the blend shape array.
-	memcpy(blend_shape_values, p_blend_shapes.ptr(), sizeof(blend_shape_values));
+	std::memcpy(blend_shape_values, p_blend_shapes.ptr(), sizeof(blend_shape_values));
 }
 
 XRFaceTracker::XRFaceTracker() {

--- a/tests/core/io/test_packet_peer.h
+++ b/tests/core/io/test_packet_peer.h
@@ -134,7 +134,7 @@ TEST_CASE("[PacketPeer][PacketPeerStream] Get packet buffer") {
 	CharString cs = godot_rules.ascii();
 	Vector<uint8_t> buffer = { (uint8_t)(cs.length() + 1), 0, 0, 0 };
 	buffer.resize_zeroed(4 + cs.length() + 1);
-	memcpy(buffer.ptrw() + 4, cs.get_data(), cs.length());
+	std::memcpy(buffer.ptrw() + 4, cs.get_data(), cs.length());
 	spb->set_data_array(buffer);
 
 	Ref<PacketPeerStream> pps;
@@ -180,7 +180,7 @@ TEST_CASE("[PacketPeer][PacketPeerStream] Put packet buffer") {
 	CharString cs = godot_rules.ascii();
 	Vector<uint8_t> buffer = { (uint8_t)cs.length(), 0, 0, 0 };
 	buffer.resize(4 + cs.length());
-	memcpy(buffer.ptrw() + 4, cs.get_data(), cs.length());
+	std::memcpy(buffer.ptrw() + 4, cs.get_data(), cs.length());
 	CHECK_EQ(spb->get_data_array(), buffer);
 }
 

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -544,7 +544,7 @@ TEST_CASE("[Object] Destruction at the end of the call chain is safe") {
 			// Unfortunately, we may not poison the memory after the deletion, because the memory would no longer belong to us
 			// and on doing so we may cause a more generalized crash on some platforms (allocator implementations).
 			p_self->~Object();
-			memset((void *)p_self, 0, sizeof(Object));
+			std::memset((void *)p_self, 0, sizeof(Object));
 			Memory::free_static(p_self, false);
 #endif
 		}

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1955,15 +1955,15 @@ TEST_CASE("[String] SHA1/SHA256/MD5") {
 	};
 
 	PackedByteArray buf = s.sha1_buffer();
-	CHECK(memcmp(sha1_buf, buf.ptr(), 20) == 0);
+	CHECK(std::memcmp(sha1_buf, buf.ptr(), 20) == 0);
 	CHECK(s.sha1_text() == sha1);
 
 	buf = s.sha256_buffer();
-	CHECK(memcmp(sha256_buf, buf.ptr(), 32) == 0);
+	CHECK(std::memcmp(sha256_buf, buf.ptr(), 32) == 0);
 	CHECK(s.sha256_text() == sha256);
 
 	buf = s.md5_buffer();
-	CHECK(memcmp(md5_buf, buf.ptr(), 16) == 0);
+	CHECK(std::memcmp(md5_buf, buf.ptr(), 16) == 0);
 	CHECK(s.md5_text() == md5);
 }
 

--- a/tests/core/templates/test_rid.h
+++ b/tests/core/templates/test_rid.h
@@ -186,7 +186,7 @@ TEST_CASE("[RID_Owner] Thread safety") {
 
 							// 2. Each thread makes a RID holding unique data.
 							DataHolder initial_data;
-							memset(&initial_data, _compute_thread_unique_byte(self_th_idx), Thread::CACHE_LINE_BYTES);
+							std::memset(&initial_data, _compute_thread_unique_byte(self_th_idx), Thread::CACHE_LINE_BYTES);
 							RID my_rid = rot->rid_owner.make_rid(initial_data);
 							rot->rids[self_th_idx].store(my_rid.get_id(), std::memory_order_relaxed);
 

--- a/tests/core/test_hashing_context.h
+++ b/tests/core/test_hashing_context.h
@@ -54,17 +54,17 @@ TEST_CASE("[HashingContext] Default - MD5/SHA1/SHA256") {
 	CHECK(ctx.start(HashingContext::HASH_MD5) == OK);
 	PackedByteArray result = ctx.finish();
 	REQUIRE(result.size() == 16);
-	CHECK(memcmp(result.ptr(), md5_expected, 16) == 0);
+	CHECK(std::memcmp(result.ptr(), md5_expected, 16) == 0);
 
 	CHECK(ctx.start(HashingContext::HASH_SHA1) == OK);
 	result = ctx.finish();
 	REQUIRE(result.size() == 20);
-	CHECK(memcmp(result.ptr(), sha1_expected, 20) == 0);
+	CHECK(std::memcmp(result.ptr(), sha1_expected, 20) == 0);
 
 	CHECK(ctx.start(HashingContext::HASH_SHA256) == OK);
 	result = ctx.finish();
 	REQUIRE(result.size() == 32);
-	CHECK(memcmp(result.ptr(), sha256_expected, 32) == 0);
+	CHECK(std::memcmp(result.ptr(), sha256_expected, 32) == 0);
 }
 
 TEST_CASE("[HashingContext] Multiple updates - MD5/SHA1/SHA256") {
@@ -95,7 +95,7 @@ TEST_CASE("[HashingContext] Multiple updates - MD5/SHA1/SHA256") {
 	CHECK(ctx.update(s_byte_parts[2]) == OK);
 	PackedByteArray result = ctx.finish();
 	REQUIRE(result.size() == 16);
-	CHECK(memcmp(result.ptr(), md5_expected, 16) == 0);
+	CHECK(std::memcmp(result.ptr(), md5_expected, 16) == 0);
 
 	CHECK(ctx.start(HashingContext::HASH_SHA1) == OK);
 	CHECK(ctx.update(s_byte_parts[0]) == OK);
@@ -103,7 +103,7 @@ TEST_CASE("[HashingContext] Multiple updates - MD5/SHA1/SHA256") {
 	CHECK(ctx.update(s_byte_parts[2]) == OK);
 	result = ctx.finish();
 	REQUIRE(result.size() == 20);
-	CHECK(memcmp(result.ptr(), sha1_expected, 20) == 0);
+	CHECK(std::memcmp(result.ptr(), sha1_expected, 20) == 0);
 
 	CHECK(ctx.start(HashingContext::HASH_SHA256) == OK);
 	CHECK(ctx.update(s_byte_parts[0]) == OK);
@@ -111,7 +111,7 @@ TEST_CASE("[HashingContext] Multiple updates - MD5/SHA1/SHA256") {
 	CHECK(ctx.update(s_byte_parts[2]) == OK);
 	result = ctx.finish();
 	REQUIRE(result.size() == 32);
-	CHECK(memcmp(result.ptr(), sha256_expected, 32) == 0);
+	CHECK(std::memcmp(result.ptr(), sha256_expected, 32) == 0);
 }
 
 TEST_CASE("[HashingContext] Invalid use of start") {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -265,9 +265,9 @@ int test_main(int argc, char *argv[]) {
 			CharString cs = test_args[x].utf8();
 			const char *str = cs.get_data();
 			// Allocate the string copy.
-			doctest_args[x] = new char[strlen(str) + 1];
+			doctest_args[x] = new char[std::strlen(str) + 1];
 			// Copy this into memory.
-			memcpy(doctest_args[x], str, strlen(str) + 1);
+			std::memcpy(doctest_args[x], str, std::strlen(str) + 1);
 		}
 
 		test_context.applyCommandLine(test_args.size(), doctest_args);


### PR DESCRIPTION
- Related #104386

I thought about doing a full pass of changing all the remaining C headers to their C++ equivalents, but I underestimated how much coverage there was of the `string.h` functions. For convenience, this also consolidates the the `<cstring>` header to just `typedefs.h`, similar to godot.cpp's implementation.