### PR TITLE
Allow @export_range to support numeric types

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2775,7 +2775,7 @@
 			The property has no hint for the editor.
 		</constant>
 		<constant name="PROPERTY_HINT_RANGE" value="1" enum="PropertyHint">
-			Hints that an [int] or [float] property should be within a range specified via the hint string [code]"min,max"[/code] or [code]"min,max,step"[/code]. The hint string can optionally include [code]"or_greater"[/code] and/or [code]"or_less"[/code] to allow manual input going respectively above the max or below the min values.
+			Hints that a numeric type property (such as [int] or [float]) should be within a range specified via the hint string [code]"min,max"[/code] or [code]"min,max,step"[/code]. The hint string can optionally include [code]"or_greater"[/code] and/or [code]"or_less"[/code] to allow manual input going respectively above the max or below the min values.
 			[b]Example:[/b] [code]"-360,360,1,or_greater,or_less"[/code].
 			Additionally, other keywords can be included: [code]"exp"[/code] for exponential range editing, [code]"radians_as_degrees"[/code] for editing radian angles in degrees (the range values are also in degrees), [code]"degrees"[/code] to hint at an angle, [code]"prefer_slider"[/code] to show the slider for integers, [code]"hide_control"[/code] to hide the slider or up-down arrows, and [code]"suffix:px/s"[/code] to display a suffix indicating the value's unit (e.g. [code]px/s[/code] for pixels per second).
 		</constant>

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -2005,8 +2005,8 @@ void EditorPropertyRect2::setup(const EditorPropertyRangeHint &p_range_hint) {
 		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
-		spin[i]->set_allow_greater(true);
-		spin[i]->set_allow_lesser(true);
+		spin[i]->set_allow_greater(p_range_hint.or_greater);
+		spin[i]->set_allow_lesser(p_range_hint.or_less);
 		spin[i]->set_suffix(p_range_hint.suffix);
 	}
 }
@@ -2098,8 +2098,8 @@ void EditorPropertyRect2i::setup(const EditorPropertyRangeHint &p_range_hint) {
 		spin[i]->set_min(p_range_hint.min);
 		spin[i]->set_max(p_range_hint.max);
 		spin[i]->set_step(1);
-		spin[i]->set_allow_greater(true);
-		spin[i]->set_allow_lesser(true);
+		spin[i]->set_allow_greater(p_range_hint.or_greater);
+		spin[i]->set_allow_lesser(p_range_hint.or_less);
 		spin[i]->set_suffix(p_range_hint.suffix);
 		spin[i]->set_editing_integer(true);
 	}
@@ -2195,8 +2195,8 @@ void EditorPropertyPlane::setup(const EditorPropertyRangeHint &p_range_hint) {
 		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
-		spin[i]->set_allow_greater(true);
-		spin[i]->set_allow_lesser(true);
+		spin[i]->set_allow_greater(p_range_hint.or_greater);
+		spin[i]->set_allow_lesser(p_range_hint.or_less);
 	}
 	spin[3]->set_suffix(p_range_hint.suffix);
 }
@@ -2346,8 +2346,8 @@ void EditorPropertyQuaternion::setup(const EditorPropertyRangeHint &p_range_hint
 		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
-		spin[i]->set_allow_greater(true);
-		spin[i]->set_allow_lesser(true);
+		spin[i]->set_allow_greater(p_range_hint.or_greater);
+		spin[i]->set_allow_lesser(p_range_hint.or_less);
 		// Quaternion is inherently unitless, however someone may want to use it as
 		// a generic way to store 4 values, so we'll still respect the suffix.
 		spin[i]->set_suffix(p_range_hint.suffix);
@@ -2495,8 +2495,8 @@ void EditorPropertyAABB::setup(const EditorPropertyRangeHint &p_range_hint) {
 		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
-		spin[i]->set_allow_greater(true);
-		spin[i]->set_allow_lesser(true);
+		spin[i]->set_allow_greater(p_range_hint.or_greater);
+		spin[i]->set_allow_lesser(p_range_hint.or_less);
 		spin[i]->set_suffix(p_range_hint.suffix);
 	}
 }
@@ -2575,8 +2575,8 @@ void EditorPropertyTransform2D::setup(const EditorPropertyRangeHint &p_range_hin
 		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
-		spin[i]->set_allow_greater(true);
-		spin[i]->set_allow_lesser(true);
+		spin[i]->set_allow_greater(p_range_hint.or_greater);
+		spin[i]->set_allow_lesser(p_range_hint.or_less);
 		if (i % 3 == 2) {
 			spin[i]->set_suffix(p_range_hint.suffix);
 		}
@@ -2659,8 +2659,8 @@ void EditorPropertyBasis::setup(const EditorPropertyRangeHint &p_range_hint) {
 		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
-		spin[i]->set_allow_greater(true);
-		spin[i]->set_allow_lesser(true);
+		spin[i]->set_allow_greater(p_range_hint.or_greater);
+		spin[i]->set_allow_lesser(p_range_hint.or_less);
 		// Basis is inherently unitless, however someone may want to use it as
 		// a generic way to store 9 values, so we'll still respect the suffix.
 		spin[i]->set_suffix(p_range_hint.suffix);
@@ -2750,8 +2750,8 @@ void EditorPropertyTransform3D::setup(const EditorPropertyRangeHint &p_range_hin
 		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
-		spin[i]->set_allow_greater(true);
-		spin[i]->set_allow_lesser(true);
+		spin[i]->set_allow_greater(p_range_hint.or_greater);
+		spin[i]->set_allow_lesser(p_range_hint.or_less);
 		if (i % 4 == 3) {
 			spin[i]->set_suffix(p_range_hint.suffix);
 		}
@@ -2849,8 +2849,8 @@ void EditorPropertyProjection::setup(const EditorPropertyRangeHint &p_range_hint
 		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
-		spin[i]->set_allow_greater(true);
-		spin[i]->set_allow_lesser(true);
+		spin[i]->set_allow_greater(p_range_hint.or_greater);
+		spin[i]->set_allow_lesser(p_range_hint.or_less);
 		if (i % 4 == 3) {
 			spin[i]->set_suffix(p_range_hint.suffix);
 		}

--- a/editor/inspector/editor_properties_vector.cpp
+++ b/editor/inspector/editor_properties_vector.cpp
@@ -163,8 +163,8 @@ void EditorPropertyVectorN::setup(const EditorPropertyRangeHint &p_range_hint, b
 		if (p_range_hint.hide_control) {
 			spin->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
-		spin->set_allow_greater(true);
-		spin->set_allow_lesser(true);
+		spin->set_allow_greater(p_range_hint.or_greater);
+		spin->set_allow_lesser(p_range_hint.or_less);
 		spin->set_suffix(p_range_hint.suffix);
 		spin->set_editing_integer(p_is_int);
 	}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4727,8 +4727,43 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 	bool use_default_variable_type_check = true;
 
 	if (p_annotation->name == SNAME("@export_range")) {
-		if (export_type.builtin_type == Variant::INT) {
-			variable->export_info.type = Variant::INT;
+		use_default_variable_type_check = false;
+
+		switch (export_type.builtin_type) {
+			case Variant::NIL:
+				break;
+			case Variant::INT:
+			case Variant::FLOAT:
+			case Variant::VECTOR2:
+			case Variant::VECTOR2I:
+			case Variant::RECT2:
+			case Variant::RECT2I:
+			case Variant::VECTOR3:
+			case Variant::VECTOR3I:
+			case Variant::VECTOR4:
+			case Variant::VECTOR4I:
+			case Variant::TRANSFORM2D:
+			case Variant::TRANSFORM3D:
+			case Variant::PLANE:
+			case Variant::QUATERNION:
+			case Variant::AABB:
+			case Variant::BASIS:
+			case Variant::PROJECTION:
+			case Variant::PACKED_BYTE_ARRAY:
+			case Variant::PACKED_INT32_ARRAY:
+			case Variant::PACKED_INT64_ARRAY:
+			case Variant::PACKED_FLOAT32_ARRAY:
+			case Variant::PACKED_FLOAT64_ARRAY:
+			case Variant::PACKED_VECTOR2_ARRAY:
+			case Variant::PACKED_VECTOR3_ARRAY:
+			case Variant::PACKED_VECTOR4_ARRAY: {
+				variable->export_info.type = export_type.builtin_type;
+				break;
+			}
+			default: {
+				push_error(vformat(R"("@export_range" annotation requires a numeric variable or array, but %s was given instead.)", variable->get_datatype().to_string()), p_annotation);
+				return false;
+			}
 		}
 	} else if (p_annotation->name == SNAME("@export_multiline")) {
 		use_default_variable_type_check = false;


### PR DESCRIPTION
Fixes #105875, Fixes #112647

Currently, numeric inspector properties support `PROPERTY_HINT_RANGE` implicitly (and are used by many editor classes), but the `@export_range` does not recognize this. This PR allows `@export_range` annotation to use the following types:
Vector2, Vector2I, Rect2, Rect2I, Vector3, Vector3I, Vector4, Vector4I, Transform2D, Transform3D, Plane, Quaternion, AABB, Basis, and Projection

It does this by replacing the float and int type check done in master with a custom check that was already partially implemented.