### PR TITLE
Remove inline from constexpr variables

### DIFF
--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -73,7 +73,7 @@ public:
 class EditorResourcePreview : public Node {
 	GDCLASS(EditorResourcePreview, Node);
 
-	inline static constexpr int CURRENT_METADATA_VERSION = 1; // Increment this number to invalidate all previews.
+	static constexpr int CURRENT_METADATA_VERSION = 1; // Increment this number to invalidate all previews.
 	inline static EditorResourcePreview *singleton = nullptr;
 
 	struct QueueItem {

--- a/editor/plugins/editor_context_menu_plugin.h
+++ b/editor/plugins/editor_context_menu_plugin.h
@@ -43,7 +43,7 @@ class EditorContextMenuPlugin : public RefCounted {
 
 	friend class EditorContextMenuPluginManager;
 
-	inline static constexpr int MAX_ITEMS = 100;
+	static constexpr int MAX_ITEMS = 100;
 
 public:
 	enum ContextMenuSlot {
@@ -55,7 +55,7 @@ public:
 		CONTEXT_SLOT_SCENE_TABS,
 		CONTEXT_SLOT_2D_EDITOR,
 	};
-	inline static constexpr int BASE_ID = 2000;
+	static constexpr int BASE_ID = 2000;
 
 private:
 	int slot = -1;

--- a/scene/gui/color_picker_shape.h
+++ b/scene/gui/color_picker_shape.h
@@ -107,7 +107,7 @@ public:
 class ColorPickerShapeWheel : public ColorPickerShape {
 	GDCLASS(ColorPickerShapeWheel, ColorPickerShape);
 
-	inline static constexpr float WHEEL_RADIUS = 0.42;
+	static constexpr float WHEEL_RADIUS = 0.42;
 
 	MarginContainer *wheel_margin = nullptr;
 	Control *wheel = nullptr;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -43,7 +43,7 @@ public:
 	typedef uint32_t TypeHash;
 
 	static inline String PARAMETERS_BASE_PATH = "parameters/";
-	static inline constexpr real_t DEFAULT_STEP = 1.0 / 30;
+	static constexpr real_t DEFAULT_STEP = 1.0 / 30;
 
 	enum TrackType : uint8_t {
 		TYPE_VALUE, // Set a value in a property, can be interpolated.


### PR DESCRIPTION
Apparently it's not required if static variable is constexpr.