### PR TITLE
Fix empty Script Editor members overview visible

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2016,7 +2016,10 @@ void ScriptEditor::_update_members_overview_visibility() {
 	if (!se) {
 		members_overview_alphabeta_sort_button->set_visible(false);
 		members_overview->set_visible(false);
-		overview_vbox->set_visible(help_overview_enabled);
+
+		Node *current = tab_container->get_tab_control(tab_container->get_current_tab());
+		EditorHelp *editor_help = Object::cast_to<EditorHelp>(current);
+		overview_vbox->set_visible(help_overview_enabled && editor_help);
 		return;
 	}
 


### PR DESCRIPTION
My bad, missed this when reviewing #91264
When the script editor is empty, the members overview should not show.

Before:
![Screenshot 2025-04-28 161741](https://github.com/user-attachments/assets/d6f5d3ef-da06-4d96-a024-78731a68db50)

After (normal):
![image](https://github.com/user-attachments/assets/562ab153-76ec-4708-8b5f-ab2d2ab889b8)