### PR TITLE
macOS: Embedded window support.

### DIFF
--- a/core/input/input_enums.h
+++ b/core/input/input_enums.h
@@ -32,6 +32,23 @@
 
 #include "core/error/error_macros.h"
 
+enum class InputEventType {
+	INVALID = -1,
+	KEY,
+	MOUSE_BUTTON,
+	MOUSE_MOTION,
+	JOY_MOTION,
+	JOY_BUTTON,
+	SCREEN_TOUCH,
+	SCREEN_DRAG,
+	MAGNIFY_GESTURE,
+	PAN_GESTURE,
+	MIDI,
+	SHORTCUT,
+	ACTION,
+	MAX,
+};
+
 enum class HatDir {
 	UP = 0,
 	RIGHT = 1,

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -89,6 +89,8 @@ public:
 
 	virtual bool accumulate(const Ref<InputEvent> &p_event) { return false; }
 
+	virtual InputEventType get_type() const { return InputEventType::INVALID; }
+
 	InputEvent() {}
 };
 
@@ -202,6 +204,8 @@ public:
 
 	static Ref<InputEventKey> create_reference(Key p_keycode_with_modifier_masks, bool p_physical = false);
 
+	InputEventType get_type() const final override { return InputEventType::KEY; }
+
 	InputEventKey() {}
 };
 
@@ -261,6 +265,8 @@ public:
 	virtual String as_text() const override;
 	virtual String to_string() override;
 
+	InputEventType get_type() const final override { return InputEventType::MOUSE_BUTTON; }
+
 	InputEventMouseButton() {}
 };
 
@@ -306,6 +312,8 @@ public:
 
 	virtual bool accumulate(const Ref<InputEvent> &p_event) override;
 
+	InputEventType get_type() const final override { return InputEventType::MOUSE_MOTION; }
+
 	InputEventMouseMotion() {}
 };
 
@@ -332,6 +340,8 @@ public:
 	virtual String to_string() override;
 
 	static Ref<InputEventJoypadMotion> create_reference(JoyAxis p_axis, float p_value);
+
+	InputEventType get_type() const final override { return InputEventType::JOY_MOTION; }
 
 	InputEventJoypadMotion() {}
 };
@@ -363,6 +373,8 @@ public:
 
 	static Ref<InputEventJoypadButton> create_reference(JoyButton p_btn_index);
 
+	InputEventType get_type() const final override { return InputEventType::JOY_BUTTON; }
+
 	InputEventJoypadButton() {}
 };
 
@@ -391,6 +403,8 @@ public:
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
 	virtual String to_string() override;
+
+	InputEventType get_type() const final override { return InputEventType::SCREEN_TOUCH; }
 
 	InputEventScreenTouch() {}
 };
@@ -444,6 +458,8 @@ public:
 
 	virtual bool accumulate(const Ref<InputEvent> &p_event) override;
 
+	InputEventType get_type() const final override { return InputEventType::SCREEN_DRAG; }
+
 	InputEventScreenDrag() {}
 };
 
@@ -479,6 +495,8 @@ public:
 	virtual String as_text() const override;
 	virtual String to_string() override;
 
+	InputEventType get_type() const final override { return InputEventType::ACTION; }
+
 	InputEventAction() {}
 };
 
@@ -510,6 +528,8 @@ public:
 	virtual String as_text() const override;
 	virtual String to_string() override;
 
+	InputEventType get_type() const final override { return InputEventType::MAGNIFY_GESTURE; }
+
 	InputEventMagnifyGesture() {}
 };
 
@@ -527,6 +547,8 @@ public:
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
 	virtual String to_string() override;
+
+	InputEventType get_type() const final override { return InputEventType::PAN_GESTURE; }
 
 	InputEventPanGesture() {}
 };
@@ -574,6 +596,8 @@ public:
 	virtual String as_text() const override;
 	virtual String to_string() override;
 
+	InputEventType get_type() const final override { return InputEventType::MIDI; }
+
 	InputEventMIDI() {}
 };
 
@@ -591,6 +615,8 @@ public:
 
 	virtual String as_text() const override;
 	virtual String to_string() override;
+
+	InputEventType get_type() const final override { return InputEventType::SHORTCUT; }
 
 	InputEventShortcut();
 };

--- a/core/input/input_event_codec.cpp
+++ b/core/input/input_event_codec.cpp
@@ -1,0 +1,474 @@
+/**************************************************************************/
+/*  input_event_codec.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "input_event_codec.h"
+
+#include "core/input/input.h"
+#include "core/io/marshalls.h"
+#include "core/os/os.h"
+
+enum class BoolShift : uint8_t {
+	SHIFT = 0,
+	CTRL,
+	ALT,
+	META,
+	ECHO,
+	PRESSED,
+	DOUBLE_CLICK,
+	PEN_INVERTED,
+};
+
+// cast operator for BoolShift to uint8_t
+inline uint8_t operator<<(uint8_t a, BoolShift b) {
+	return a << static_cast<uint8_t>(b);
+}
+
+uint8_t encode_key_modifier_state(Ref<InputEventWithModifiers> p_event) {
+	uint8_t bools = 0;
+	bools |= (uint8_t)p_event->is_shift_pressed() << BoolShift::SHIFT;
+	bools |= (uint8_t)p_event->is_ctrl_pressed() << BoolShift::CTRL;
+	bools |= (uint8_t)p_event->is_alt_pressed() << BoolShift::ALT;
+	bools |= (uint8_t)p_event->is_meta_pressed() << BoolShift::META;
+	return bools;
+}
+
+void decode_key_modifier_state(uint8_t bools, Ref<InputEventWithModifiers> p_event) {
+	p_event->set_shift_pressed(bools & (1 << BoolShift::SHIFT));
+	p_event->set_ctrl_pressed(bools & (1 << BoolShift::CTRL));
+	p_event->set_alt_pressed(bools & (1 << BoolShift::ALT));
+	p_event->set_meta_pressed(bools & (1 << BoolShift::META));
+}
+
+int encode_vector2(const Vector2 &p_vector, uint8_t *p_data) {
+	p_data += encode_float(p_vector.x, p_data);
+	encode_float(p_vector.y, p_data);
+	return sizeof(float) * 2;
+}
+
+const uint8_t *decode_vector2(Vector2 &r_vector, const uint8_t *p_data) {
+	r_vector.x = decode_float(p_data);
+	p_data += sizeof(float);
+	r_vector.y = decode_float(p_data);
+	p_data += sizeof(float);
+	return p_data;
+}
+
+void encode_input_event_key(const Ref<InputEventKey> &p_event, PackedByteArray &r_data) {
+	r_data.resize(19);
+
+	uint8_t *data = r_data.ptrw();
+	*data = (uint8_t)InputEventType::KEY;
+	data++;
+	uint8_t bools = encode_key_modifier_state(p_event);
+	bools |= (uint8_t)p_event->is_echo() << BoolShift::ECHO;
+	bools |= (uint8_t)p_event->is_pressed() << BoolShift::PRESSED;
+	*data = bools;
+	data++;
+	data += encode_uint32((uint32_t)p_event->get_keycode(), data);
+	data += encode_uint32((uint32_t)p_event->get_physical_keycode(), data);
+	data += encode_uint32((uint32_t)p_event->get_key_label(), data);
+	data += encode_uint32(p_event->get_unicode(), data);
+	*data = (uint8_t)p_event->get_location();
+	data++;
+
+	// Assert we had enough space.
+	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+}
+
+Error decode_input_event_key(const PackedByteArray &p_data, Ref<InputEventKey> &r_event) {
+	const uint8_t *data = p_data.ptr();
+	DEV_ASSERT(static_cast<InputEventType>(*data) == InputEventType::KEY);
+	data++; // Skip event type.
+
+	uint8_t bools = *data;
+	data++;
+	decode_key_modifier_state(bools, r_event);
+	r_event->set_echo(bools & (1 << BoolShift::ECHO));
+	r_event->set_pressed(bools & (1 << BoolShift::PRESSED));
+
+	Key keycode = (Key)decode_uint32(data);
+	data += sizeof(uint32_t);
+	Key physical_keycode = (Key)decode_uint32(data);
+	data += sizeof(uint32_t);
+	Key key_label = (Key)decode_uint32(data);
+	data += sizeof(uint32_t);
+	char32_t unicode = (char32_t)decode_uint32(data);
+	data += sizeof(uint32_t);
+	KeyLocation location = (KeyLocation)*data;
+
+	r_event->set_keycode(keycode);
+	r_event->set_physical_keycode(physical_keycode);
+	r_event->set_key_label(key_label);
+	r_event->set_unicode(unicode);
+	r_event->set_location(location);
+
+	return OK;
+}
+
+void encode_input_event_mouse_button(const Ref<InputEventMouseButton> &p_event, PackedByteArray &r_data) {
+	r_data.resize(12);
+
+	uint8_t *data = r_data.ptrw();
+	*data = (uint8_t)InputEventType::MOUSE_BUTTON;
+	data++;
+
+	uint8_t bools = encode_key_modifier_state(p_event);
+	bools |= (uint8_t)p_event->is_pressed() << BoolShift::PRESSED;
+	bools |= (uint8_t)p_event->is_double_click() << BoolShift::DOUBLE_CLICK;
+	*data = bools;
+	data++;
+
+	*data = (uint8_t)p_event->get_button_index();
+	data++;
+
+	// Rather than use encode_variant, we explicitly encode the Vector2,
+	// so decoding is easier. Specifically, we don't have to perform additional error
+	// checking for decoding the variant and then checking the variant type.
+	data += encode_vector2(p_event->get_position(), data);
+	*data = (uint8_t)p_event->get_button_mask();
+	data++;
+
+	// Assert we had enough space.
+	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+}
+
+Error decode_input_event_mouse_button(const PackedByteArray &p_data, Ref<InputEventMouseButton> &r_event) {
+	const uint8_t *data = p_data.ptr();
+	DEV_ASSERT(static_cast<InputEventType>(*data) == InputEventType::MOUSE_BUTTON);
+	data++; // Skip event type.
+
+	uint8_t bools = *data;
+	data++;
+	decode_key_modifier_state(bools, r_event);
+	r_event->set_pressed(bools & (1 << BoolShift::PRESSED));
+	r_event->set_double_click(bools & (1 << BoolShift::DOUBLE_CLICK));
+
+	r_event->set_button_index((MouseButton)*data);
+	data++;
+
+	Vector2 pos;
+	data = decode_vector2(pos, data);
+	r_event->set_position(pos);
+	r_event->set_global_position(pos); // these are the same
+	BitField<MouseButtonMask> button_mask = (MouseButtonMask)*data;
+	r_event->set_button_mask(button_mask);
+
+	return OK;
+}
+
+void encode_input_event_mouse_motion(const Ref<InputEventMouseMotion> &p_event, PackedByteArray &r_data) {
+	r_data.resize(31);
+
+	uint8_t *data = r_data.ptrw();
+	*data = (uint8_t)InputEventType::MOUSE_MOTION;
+	data++;
+
+	uint8_t bools = encode_key_modifier_state(p_event);
+	bools |= (uint8_t)p_event->get_pen_inverted() << BoolShift::PEN_INVERTED;
+	*data = bools;
+	data++;
+
+	// Rather than use encode_variant, we explicitly encode the Vector2,
+	// so decoding is easier. Specifically, we don't have to perform additional error
+	// checking for decoding the variant and then checking the variant type.
+	data += encode_vector2(p_event->get_position(), data);
+	data += encode_float(p_event->get_pressure(), data);
+	data += encode_vector2(p_event->get_tilt(), data);
+	data += encode_vector2(p_event->get_relative(), data);
+	*data = (uint8_t)p_event->get_button_mask();
+	data++;
+
+	// Assert we had enough space.
+	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+}
+
+void decode_input_event_mouse_motion(const PackedByteArray &p_data, Ref<InputEventMouseMotion> &r_event) {
+	Input *input = Input::get_singleton();
+
+	const uint8_t *data = p_data.ptr();
+	DEV_ASSERT(static_cast<InputEventType>(*data) == InputEventType::MOUSE_MOTION);
+	data++; // Skip event type.
+
+	uint8_t bools = *data;
+	data++;
+	decode_key_modifier_state(bools, r_event);
+	r_event->set_pen_inverted(bools & (1 << BoolShift::PEN_INVERTED));
+
+	{
+		Vector2 pos;
+		data = decode_vector2(pos, data);
+		r_event->set_position(pos);
+		r_event->set_global_position(pos); // these are the same
+	}
+	r_event->set_pressure(decode_float(data));
+	data += sizeof(float);
+	{
+		Vector2 tilt;
+		data = decode_vector2(tilt, data);
+		r_event->set_tilt(tilt);
+	}
+	r_event->set_velocity(input->get_last_mouse_velocity());
+	r_event->set_screen_velocity(input->get_last_mouse_screen_velocity());
+	{
+		Vector2 relative;
+		data = decode_vector2(relative, data);
+		r_event->set_relative(relative);
+		r_event->set_relative_screen_position(relative);
+	}
+	BitField<MouseButtonMask> button_mask = (MouseButtonMask)*data;
+	r_event->set_button_mask(button_mask);
+	data++;
+
+	// Assert we had enough space.
+	DEV_ASSERT(data - p_data.ptr() >= p_data.size());
+}
+
+void encode_input_event_joypad_button(const Ref<InputEventJoypadButton> &p_event, PackedByteArray &r_data) {
+	r_data.resize(11);
+
+	uint8_t *data = r_data.ptrw();
+	*data = (uint8_t)InputEventType::JOY_BUTTON;
+	data++;
+
+	uint8_t bools = 0;
+	bools |= (uint8_t)p_event->is_pressed() << BoolShift::PRESSED;
+	*data = bools;
+	data++;
+
+	data += encode_uint64(p_event->get_device(), data);
+	*data = (uint8_t)p_event->get_button_index();
+	data++;
+
+	// Assert we had enough space.
+	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+}
+
+void decode_input_event_joypad_button(const PackedByteArray &p_data, Ref<InputEventJoypadButton> &r_event) {
+	const uint8_t *data = p_data.ptr();
+	DEV_ASSERT(static_cast<InputEventType>(*data) == InputEventType::JOY_BUTTON);
+	data++; // Skip event type.
+
+	uint8_t bools = *data;
+	data++;
+	r_event->set_pressed(bools & (1 << BoolShift::PRESSED));
+	r_event->set_device(decode_uint64(data));
+	data += sizeof(uint64_t);
+	r_event->set_button_index((JoyButton)*data);
+	data++;
+
+	// Assert we had enough space.
+	DEV_ASSERT(data - p_data.ptr() >= p_data.size());
+}
+
+void encode_input_event_joypad_motion(const Ref<InputEventJoypadMotion> &p_event, PackedByteArray &r_data) {
+	r_data.resize(14);
+
+	uint8_t *data = r_data.ptrw();
+	*data = (uint8_t)InputEventType::JOY_MOTION;
+	data++;
+
+	data += encode_uint64(p_event->get_device(), data);
+	*data = (uint8_t)p_event->get_axis();
+	data++;
+	data += encode_float(p_event->get_axis_value(), data);
+
+	// Assert we had enough space.
+	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+}
+
+void decode_input_event_joypad_motion(const PackedByteArray &p_data, Ref<InputEventJoypadMotion> &r_event) {
+	const uint8_t *data = p_data.ptr();
+	DEV_ASSERT(static_cast<InputEventType>(*data) == InputEventType::JOY_MOTION);
+	data++; // Skip event type.
+
+	r_event->set_device(decode_uint64(data));
+	data += sizeof(uint64_t);
+	r_event->set_axis((JoyAxis)*data);
+	data++;
+	r_event->set_axis_value(decode_float(data));
+	data += sizeof(float);
+
+	// Assert we had enough space.
+	DEV_ASSERT(data - p_data.ptr() >= p_data.size());
+}
+
+void encode_input_event_gesture_pan(const Ref<InputEventPanGesture> &p_event, PackedByteArray &r_data) {
+	r_data.resize(18);
+
+	uint8_t *data = r_data.ptrw();
+	*data = (uint8_t)InputEventType::PAN_GESTURE;
+	data++;
+
+	uint8_t bools = encode_key_modifier_state(p_event);
+	*data = bools;
+	data++;
+	data += encode_vector2(p_event->get_position(), data);
+	data += encode_vector2(p_event->get_delta(), data);
+
+	// Assert we had enough space.
+	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+}
+
+void decode_input_event_gesture_pan(const PackedByteArray &p_data, Ref<InputEventPanGesture> &r_event) {
+	const uint8_t *data = p_data.ptr();
+	DEV_ASSERT(static_cast<InputEventType>(*data) == InputEventType::PAN_GESTURE);
+	data++; // Skip event type.
+
+	uint8_t bools = *data;
+	data++;
+	decode_key_modifier_state(bools, r_event);
+
+	Vector2 pos;
+	data = decode_vector2(pos, data);
+	r_event->set_position(pos);
+	Vector2 delta;
+	data = decode_vector2(delta, data);
+	r_event->set_delta(delta);
+
+	// Assert we had enough space.
+	DEV_ASSERT(data - p_data.ptr() >= p_data.size());
+}
+
+void encode_input_event_gesture_magnify(const Ref<InputEventMagnifyGesture> &p_event, PackedByteArray &r_data) {
+	r_data.resize(14);
+
+	uint8_t *data = r_data.ptrw();
+	*data = (uint8_t)InputEventType::MAGNIFY_GESTURE;
+	data++;
+
+	uint8_t bools = encode_key_modifier_state(p_event);
+	*data = bools;
+	data++;
+	data += encode_vector2(p_event->get_position(), data);
+	data += encode_float(p_event->get_factor(), data);
+
+	// Assert we had enough space.
+	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+}
+
+void decode_input_event_gesture_magnify(const PackedByteArray &p_data, Ref<InputEventMagnifyGesture> &r_event) {
+	const uint8_t *data = p_data.ptr();
+	DEV_ASSERT(static_cast<InputEventType>(*data) == InputEventType::MAGNIFY_GESTURE);
+	data++; // Skip event type.
+
+	uint8_t bools = *data;
+	data++;
+	decode_key_modifier_state(bools, r_event);
+
+	Vector2 pos;
+	data = decode_vector2(pos, data);
+	r_event->set_position(pos);
+	r_event->set_factor(decode_float(data));
+	data += sizeof(float);
+
+	// Assert we had enough space.
+	DEV_ASSERT(data - p_data.ptr() >= p_data.size());
+}
+
+bool encode_input_event(const Ref<InputEvent> &p_event, PackedByteArray &r_data) {
+	switch (p_event->get_type()) {
+		case InputEventType::KEY:
+			encode_input_event_key(p_event, r_data);
+			break;
+		case InputEventType::MOUSE_BUTTON:
+			encode_input_event_mouse_button(p_event, r_data);
+			break;
+		case InputEventType::MOUSE_MOTION:
+			encode_input_event_mouse_motion(p_event, r_data);
+			break;
+		case InputEventType::JOY_MOTION:
+			encode_input_event_joypad_motion(p_event, r_data);
+			break;
+		case InputEventType::JOY_BUTTON:
+			encode_input_event_joypad_button(p_event, r_data);
+			break;
+		case InputEventType::MAGNIFY_GESTURE:
+			encode_input_event_gesture_magnify(p_event, r_data);
+			break;
+		case InputEventType::PAN_GESTURE:
+			encode_input_event_gesture_pan(p_event, r_data);
+			break;
+		default:
+			return false;
+	}
+	return true;
+}
+
+void decode_input_event(const PackedByteArray &p_data, Ref<InputEvent> &r_event) {
+	const uint8_t *data = p_data.ptr();
+
+	switch (static_cast<InputEventType>(*data)) {
+		case InputEventType::KEY: {
+			Ref<InputEventKey> event;
+			event.instantiate();
+			decode_input_event_key(p_data, event);
+			r_event = event;
+		} break;
+		case InputEventType::MOUSE_BUTTON: {
+			Ref<InputEventMouseButton> event;
+			event.instantiate();
+			decode_input_event_mouse_button(p_data, event);
+			r_event = event;
+		} break;
+		case InputEventType::MOUSE_MOTION: {
+			Ref<InputEventMouseMotion> event;
+			event.instantiate();
+			decode_input_event_mouse_motion(p_data, event);
+			r_event = event;
+		} break;
+		case InputEventType::JOY_BUTTON: {
+			Ref<InputEventJoypadButton> event;
+			event.instantiate();
+			decode_input_event_joypad_button(p_data, event);
+			r_event = event;
+		} break;
+		case InputEventType::JOY_MOTION: {
+			Ref<InputEventJoypadMotion> event;
+			event.instantiate();
+			decode_input_event_joypad_motion(p_data, event);
+			r_event = event;
+		} break;
+		case InputEventType::PAN_GESTURE: {
+			Ref<InputEventPanGesture> event;
+			event.instantiate();
+			decode_input_event_gesture_pan(p_data, event);
+			r_event = event;
+		} break;
+		case InputEventType::MAGNIFY_GESTURE: {
+			Ref<InputEventMagnifyGesture> event;
+			event.instantiate();
+			decode_input_event_gesture_magnify(p_data, event);
+			r_event = event;
+		} break;
+		default: {
+			WARN_PRINT(vformat("Unknown event type %d.", static_cast<int>(*data)));
+		} break;
+	}
+}

--- a/core/input/input_event_codec.h
+++ b/core/input/input_event_codec.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  godot_application.h                                                   */
+/*  input_event_codec.h                                                   */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,21 +30,20 @@
 
 #pragma once
 
-#include "core/os/os.h"
+#include "core/input/input_event.h"
 
-#import <AppKit/AppKit.h>
-#import <Foundation/Foundation.h>
-#import <IOKit/hidsystem/ev_keymap.h>
+/**
+ * Encodes the input event as a byte array.
+ *
+ * Returns `true` if the event was successfully encoded, `false` otherwise.
+ */
+bool encode_input_event(const Ref<InputEvent> &p_event, PackedByteArray &r_data);
+void decode_input_event(const PackedByteArray &p_data, Ref<InputEvent> &r_event);
 
-@class GodotApplicationDelegate;
-
-@interface GodotApplication : NSApplication
-
-extern "C" GodotApplication *GodotApp;
-
-@property(readonly, nonatomic) GodotApplicationDelegate *godotDelegate;
-
-- (GodotApplication *)init;
-
-- (void)activateApplication;
-@end
+void encode_input_event_key(const Ref<InputEventKey> &p_event, PackedByteArray &r_data);
+void encode_input_event_mouse_button(const Ref<InputEventMouseButton> &p_event, PackedByteArray &r_data);
+void encode_input_event_mouse_motion(const Ref<InputEventMouseMotion> &p_event, PackedByteArray &r_data);
+void encode_input_event_joypad_button(const Ref<InputEventJoypadButton> &p_event, PackedByteArray &r_data);
+void encode_input_event_joypad_motion(const Ref<InputEventJoypadMotion> &p_event, PackedByteArray &r_data);
+void encode_input_event_gesture_pan(const Ref<InputEventPanGesture> &p_event, PackedByteArray &r_data);
+void encode_input_event_gesture_magnify(const Ref<InputEventMagnifyGesture> &p_event, PackedByteArray &r_data);

--- a/drivers/apple/joypad_apple.h
+++ b/drivers/apple/joypad_apple.h
@@ -49,7 +49,8 @@ struct GameController {
 	bool double_nintendo_joycon_layout = false;
 	bool single_nintendo_joycon_layout = false;
 
-	bool axis_changed[(int)JoyAxis::MAX];
+	uint32_t axis_changed_mask = 0;
+	static_assert(static_cast<uint32_t>(JoyAxis::MAX) < 32, "JoyAxis::MAX must be less than 32");
 	double axis_value[(int)JoyAxis::MAX];
 
 	GameController(int p_joy_id, GCController *p_controller);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -408,6 +408,8 @@ void ScriptEditorDebugger::_msg_debug_exit(uint64_t p_thread_id, const Array &p_
 void ScriptEditorDebugger::_msg_set_pid(uint64_t p_thread_id, const Array &p_data) {
 	ERR_FAIL_COND(p_data.is_empty());
 	remote_pid = p_data[0];
+	// We emit the started signal after we've set the PID.
+	emit_signal(SNAME("started"));
 }
 
 void ScriptEditorDebugger::_msg_scene_click_ctrl(uint64_t p_thread_id, const Array &p_data) {
@@ -1174,7 +1176,6 @@ void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {
 
 	_set_reason_text(TTR("Debug session started."), MESSAGE_SUCCESS);
 	_update_buttons_state();
-	emit_signal(SNAME("started"));
 
 	Array quit_keys = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/stop_running_project"));
 	_put_msg("scene:setup_scene", quit_keys);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7097,6 +7097,14 @@ void EditorNode::_touch_actions_panel_mode_changed() {
 }
 #endif
 
+#ifdef MACOS_ENABLED
+extern "C" GameViewPluginBase *get_game_view_plugin();
+#else
+GameViewPluginBase *get_game_view_plugin() {
+	return memnew(GameViewPlugin);
+}
+#endif
+
 EditorNode::EditorNode() {
 	DEV_ASSERT(!singleton);
 	singleton = this;
@@ -8175,7 +8183,7 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(ScriptEditorPlugin));
 
 	if (!Engine::get_singleton()->is_recovery_mode_hint()) {
-		add_editor_plugin(memnew(GameViewPlugin));
+		add_editor_plugin(get_game_view_plugin());
 	}
 
 	EditorAudioBuses *audio_bus_editor = EditorAudioBuses::register_editor();

--- a/editor/plugins/embedded_process.cpp
+++ b/editor/plugins/embedded_process.cpp
@@ -35,24 +35,13 @@
 #include "scene/resources/style_box_flat.h"
 #include "scene/theme/theme_db.h"
 
-void EmbeddedProcess::_notification(int p_what) {
+void EmbeddedProcessBase::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			window = get_window();
 		} break;
-		case NOTIFICATION_PROCESS: {
-			if (updated_embedded_process_queued) {
-				updated_embedded_process_queued = false;
-				_update_embedded_process();
-			}
-		} break;
 		case NOTIFICATION_DRAW: {
 			_draw();
-		} break;
-		case NOTIFICATION_RESIZED:
-		case NOTIFICATION_VISIBILITY_CHANGED:
-		case NOTIFICATION_WM_POSITION_CHANGED: {
-			queue_update_embedded_process();
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			focus_style_box = get_theme_stylebox(SNAME("FocusViewport"), EditorStringName(EditorStyles));
@@ -68,60 +57,43 @@ void EmbeddedProcess::_notification(int p_what) {
 				margin_bottom_right = Point2i();
 			}
 		} break;
-		case NOTIFICATION_FOCUS_ENTER: {
-			queue_update_embedded_process();
-		} break;
-		case NOTIFICATION_APPLICATION_FOCUS_IN: {
-			application_has_focus = true;
-			last_application_focus_time = OS::get_singleton()->get_ticks_msec();
-		} break;
-		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
-			application_has_focus = false;
-		} break;
 	}
 }
 
-void EmbeddedProcess::set_window_size(const Size2i p_window_size) {
+void EmbeddedProcessBase::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("embedding_completed"));
+	ADD_SIGNAL(MethodInfo("embedding_failed"));
+	ADD_SIGNAL(MethodInfo("embedded_process_updated"));
+	ADD_SIGNAL(MethodInfo("embedded_process_focused"));
+}
+
+void EmbeddedProcessBase::_draw() {
+	if (is_process_focused() && focus_style_box.is_valid()) {
+		Size2 size = get_size();
+		Rect2 r = Rect2(Point2(), size);
+		focus_style_box->draw(get_canvas_item(), r);
+	}
+}
+
+void EmbeddedProcessBase::set_window_size(const Size2i &p_window_size) {
 	if (window_size != p_window_size) {
 		window_size = p_window_size;
 		queue_update_embedded_process();
 	}
 }
 
-void EmbeddedProcess::set_keep_aspect(bool p_keep_aspect) {
+void EmbeddedProcessBase::set_keep_aspect(bool p_keep_aspect) {
 	if (keep_aspect != p_keep_aspect) {
 		keep_aspect = p_keep_aspect;
 		queue_update_embedded_process();
 	}
 }
 
-Rect2i EmbeddedProcess::get_adjusted_embedded_window_rect(Rect2i p_rect) {
-	Rect2i control_rect = Rect2i(p_rect.position + margin_top_left, (p_rect.size - get_margins_size()).maxi(1));
-	if (window) {
-		control_rect.position += window->get_position();
-	}
-	if (window_size != Size2i()) {
-		Rect2i desired_rect = Rect2i();
-		if (!keep_aspect && control_rect.size.x >= window_size.x && control_rect.size.y >= window_size.y) {
-			// Fixed at the desired size.
-			desired_rect.size = window_size;
-		} else {
-			float ratio = MIN((float)control_rect.size.x / window_size.x, (float)control_rect.size.y / window_size.y);
-			desired_rect.size = Size2i(window_size.x * ratio, window_size.y * ratio).maxi(1);
-		}
-		desired_rect.position = Size2i(control_rect.position.x + ((control_rect.size.x - desired_rect.size.x) / 2), control_rect.position.y + ((control_rect.size.y - desired_rect.size.y) / 2));
-		return desired_rect;
-	} else {
-		// Stretch, use all the control area.
-		return control_rect;
-	}
-}
-
-Rect2i EmbeddedProcess::get_screen_embedded_window_rect() {
+Rect2i EmbeddedProcessBase::get_screen_embedded_window_rect() const {
 	return get_adjusted_embedded_window_rect(get_global_rect());
 }
 
-int EmbeddedProcess::get_margin_size(Side p_side) const {
+int EmbeddedProcessBase::get_margin_size(Side p_side) const {
 	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
 
 	switch (p_side) {
@@ -138,16 +110,49 @@ int EmbeddedProcess::get_margin_size(Side p_side) const {
 	return 0;
 }
 
-Size2 EmbeddedProcess::get_margins_size() {
+Size2 EmbeddedProcessBase::get_margins_size() const {
 	return margin_top_left + margin_bottom_right;
 }
 
-bool EmbeddedProcess::is_embedding_in_progress() {
+EmbeddedProcessBase::EmbeddedProcessBase() {
+	set_focus_mode(FOCUS_ALL);
+}
+
+EmbeddedProcessBase::~EmbeddedProcessBase() {
+}
+
+Rect2i EmbeddedProcess::get_adjusted_embedded_window_rect(const Rect2i &p_rect) const {
+	Rect2i control_rect = Rect2i(p_rect.position + margin_top_left, (p_rect.size - get_margins_size()).maxi(1));
+	if (window) {
+		control_rect.position += window->get_position();
+	}
+	if (window_size != Size2i()) {
+		Rect2i desired_rect;
+		if (!keep_aspect && control_rect.size.x >= window_size.x && control_rect.size.y >= window_size.y) {
+			// Fixed at the desired size.
+			desired_rect.size = window_size;
+		} else {
+			float ratio = MIN((float)control_rect.size.x / window_size.x, (float)control_rect.size.y / window_size.y);
+			desired_rect.size = Size2i(window_size.x * ratio, window_size.y * ratio).maxi(1);
+		}
+		desired_rect.position = Size2i(control_rect.position.x + ((control_rect.size.x - desired_rect.size.x) / 2), control_rect.position.y + ((control_rect.size.y - desired_rect.size.y) / 2));
+		return desired_rect;
+	} else {
+		// Stretch, use all the control area.
+		return control_rect;
+	}
+}
+
+bool EmbeddedProcess::is_embedding_in_progress() const {
 	return !timer_embedding->is_stopped();
 }
 
-bool EmbeddedProcess::is_embedding_completed() {
+bool EmbeddedProcess::is_embedding_completed() const {
 	return embedding_completed;
+}
+
+bool EmbeddedProcess::is_process_focused() const {
+	return focused_process_id == current_process_id && has_focus();
 }
 
 int EmbeddedProcess::get_embedded_pid() const {
@@ -270,11 +275,29 @@ void EmbeddedProcess::_timer_embedding_timeout() {
 	_try_embed_process();
 }
 
-void EmbeddedProcess::_draw() {
-	if (focused_process_id == current_process_id && has_focus() && focus_style_box.is_valid()) {
-		Size2 size = get_size();
-		Rect2 r = Rect2(Point2(), size);
-		focus_style_box->draw(get_canvas_item(), r);
+void EmbeddedProcess::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_PROCESS: {
+			if (updated_embedded_process_queued) {
+				updated_embedded_process_queued = false;
+				_update_embedded_process();
+			}
+		} break;
+		case NOTIFICATION_RESIZED:
+		case NOTIFICATION_VISIBILITY_CHANGED:
+		case NOTIFICATION_WM_POSITION_CHANGED: {
+			queue_update_embedded_process();
+		} break;
+		case NOTIFICATION_APPLICATION_FOCUS_IN: {
+			application_has_focus = true;
+			last_application_focus_time = OS::get_singleton()->get_ticks_msec();
+		} break;
+		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
+			application_has_focus = false;
+		} break;
+		case NOTIFICATION_FOCUS_ENTER: {
+			queue_update_embedded_process();
+		} break;
 	}
 }
 
@@ -386,14 +409,8 @@ Window *EmbeddedProcess::_get_current_modal_window() {
 	return nullptr;
 }
 
-void EmbeddedProcess::_bind_methods() {
-	ADD_SIGNAL(MethodInfo("embedding_completed"));
-	ADD_SIGNAL(MethodInfo("embedding_failed"));
-	ADD_SIGNAL(MethodInfo("embedded_process_updated"));
-	ADD_SIGNAL(MethodInfo("embedded_process_focused"));
-}
-
-EmbeddedProcess::EmbeddedProcess() {
+EmbeddedProcess::EmbeddedProcess() :
+		EmbeddedProcessBase() {
 	timer_embedding = memnew(Timer);
 	timer_embedding->set_wait_time(0.1);
 	timer_embedding->set_one_shot(true);
@@ -404,8 +421,6 @@ EmbeddedProcess::EmbeddedProcess() {
 	timer_update_embedded_process->set_wait_time(0.1);
 	add_child(timer_update_embedded_process);
 	timer_update_embedded_process->connect("timeout", callable_mp(this, &EmbeddedProcess::_timer_update_embedded_process_timeout));
-
-	set_focus_mode(FOCUS_ALL);
 }
 
 EmbeddedProcess::~EmbeddedProcess() {

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -37,7 +37,7 @@
 #include "scene/debugger/scene_debugger.h"
 #include "scene/gui/box_container.h"
 
-class EmbeddedProcess;
+class EmbeddedProcessBase;
 class VSeparator;
 class WindowWrapper;
 class ScriptEditorDebugger;
@@ -154,7 +154,7 @@ class GameView : public VBoxContainer {
 	MenuButton *embed_options_menu = nullptr;
 	Label *game_size_label = nullptr;
 	Panel *panel = nullptr;
-	EmbeddedProcess *embedded_process = nullptr;
+	EmbeddedProcessBase *embedded_process = nullptr;
 	Label *state_label = nullptr;
 
 	void _sessions_changed();
@@ -214,11 +214,11 @@ public:
 	void set_window_layout(Ref<ConfigFile> p_layout);
 	void get_window_layout(Ref<ConfigFile> p_layout);
 
-	GameView(Ref<GameViewDebugger> p_debugger, WindowWrapper *p_wrapper);
+	GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embedded_process, WindowWrapper *p_wrapper);
 };
 
-class GameViewPlugin : public EditorPlugin {
-	GDCLASS(GameViewPlugin, EditorPlugin);
+class GameViewPluginBase : public EditorPlugin {
+	GDCLASS(GameViewPluginBase, EditorPlugin);
 
 #ifndef ANDROID_ENABLED
 	GameView *game_view = nullptr;
@@ -238,6 +238,9 @@ class GameViewPlugin : public EditorPlugin {
 
 protected:
 	void _notification(int p_what);
+#ifndef ANDROID_ENABLED
+	void setup(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embedded_process);
+#endif
 
 public:
 	virtual String get_plugin_name() const override { return TTRC("Game"); }
@@ -254,6 +257,12 @@ public:
 	virtual void set_window_layout(Ref<ConfigFile> p_layout) override;
 	virtual void get_window_layout(Ref<ConfigFile> p_layout) override;
 #endif // ANDROID_ENABLED
+	GameViewPluginBase();
+};
 
+class GameViewPlugin : public GameViewPluginBase {
+	GDCLASS(GameViewPlugin, GameViewPluginBase);
+
+public:
 	GameViewPlugin();
 };

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -11,7 +11,10 @@ files = [
     "godot_application_delegate.mm",
     "crash_handler_macos.mm",
     "macos_terminal_logger.mm",
+    "display_server_embedded.mm",
     "display_server_macos.mm",
+    "embedded_debugger.mm",
+    "embedded_gl_manager.mm",
     "godot_button_view.mm",
     "godot_content_view.mm",
     "godot_status_item.mm",
@@ -29,6 +32,12 @@ files = [
     "gl_manager_macos_angle.mm",
     "gl_manager_macos_legacy.mm",
 ]
+
+if env.editor_build:
+    files += [
+        "editor/embedded_game_view_plugin.mm",
+        "editor/embedded_process_macos.mm",
+    ]
 
 prog = env.add_program("#bin/godot", files)
 

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -231,6 +231,8 @@ def configure(env: "SConsEnvironment"):
             "Security",
             "-framework",
             "UniformTypeIdentifiers",
+            "-framework",
+            "IOSurface",
         ]
     )
     env.Append(LIBS=["pthread", "z"])
@@ -245,7 +247,6 @@ def configure(env: "SConsEnvironment"):
             env.Append(LINKFLAGS=["-lANGLE.macos." + env["arch"]])
             env.Append(LINKFLAGS=["-lEGL.macos." + env["arch"]])
             env.Append(LINKFLAGS=["-lGLES.macos." + env["arch"]])
-            extra_frameworks.add("IOSurface")
         env.Prepend(CPPEXTPATH=["#thirdparty/angle/include"])
 
     env.Append(LINKFLAGS=["-rpath", "@executable_path/../Frameworks", "-rpath", "@executable_path"])
@@ -264,7 +265,6 @@ def configure(env: "SConsEnvironment"):
     if env["vulkan"]:
         env.AppendUnique(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])
         extra_frameworks.add("Metal")
-        extra_frameworks.add("IOSurface")
         if not env["use_volk"]:
             env.Append(LINKFLAGS=["-lMoltenVK"])
 

--- a/platform/macos/display_server_embedded.h
+++ b/platform/macos/display_server_embedded.h
@@ -1,0 +1,231 @@
+/**************************************************************************/
+/*  display_server_embedded.h                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/input/input.h"
+#include "servers/display_server.h"
+
+#if defined(GLES3_ENABLED)
+#include "embedded_gl_manager.h"
+#include "platform_gl.h"
+#endif // GLES3_ENABLED
+
+#if defined(RD_ENABLED)
+#include "servers/rendering/rendering_device.h"
+
+#if defined(VULKAN_ENABLED)
+#import "rendering_context_driver_vulkan_macos.h"
+#endif // VULKAN_ENABLED
+#if defined(METAL_ENABLED)
+#import "drivers/metal/rendering_context_driver_metal.h"
+#endif
+#endif // RD_ENABLED
+
+@class CAContext;
+
+class DisplayServerEmbedded : public DisplayServer {
+	GDCLASS(DisplayServerEmbedded, DisplayServer)
+
+	_THREAD_SAFE_CLASS_
+
+	struct {
+		float screen_max_scale = 1.0f;
+		float screen_dpi = 96.0f;
+	} state;
+
+	NativeMenu *native_menu = nullptr;
+
+	HashMap<WindowID, ObjectID> window_attached_instance_id;
+
+	HashMap<WindowID, Callable> window_event_callbacks;
+	HashMap<WindowID, Callable> window_resize_callbacks;
+	HashMap<WindowID, Callable> input_event_callbacks;
+	HashMap<WindowID, Callable> input_text_callbacks;
+
+	float content_scale = 1.0f;
+
+	WindowID window_id_counter = MAIN_WINDOW_ID;
+
+	CAContext *ca_context = nil;
+	// Either be a CAMetalLayer or a CALayer depending on the rendering driver.
+	CALayer *layer = nil;
+#ifdef GLES3_ENABLED
+	GLManagerEmbedded *gl_manager = nullptr;
+#endif
+
+#if defined(RD_ENABLED)
+	RenderingContextDriver *rendering_context = nullptr;
+	RenderingDevice *rendering_device = nullptr;
+#endif
+
+	String rendering_driver;
+
+	Point2i ime_last_position;
+	Point2i im_selection;
+	String im_text;
+
+	MouseMode mouse_mode = MOUSE_MODE_VISIBLE;
+	MouseMode mouse_mode_base = MOUSE_MODE_VISIBLE;
+	MouseMode mouse_mode_override = MOUSE_MODE_VISIBLE;
+	bool mouse_mode_override_enabled = false;
+	void _mouse_update_mode();
+
+	CursorShape cursor_shape = CURSOR_ARROW;
+
+	struct Joy {
+		String name;
+		uint64_t timestamp = 0;
+
+		Joy() = default;
+		Joy(const String &p_name) :
+				name(p_name) {}
+	};
+	HashMap<int, Joy> joysticks;
+
+public:
+	static void register_embedded_driver();
+	static DisplayServer *create_func(const String &p_rendering_driver, WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error);
+	static Vector<String> get_rendering_drivers_func();
+
+	// MARK: - Events
+
+	virtual void process_events() override;
+
+	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_window_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_input_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_input_text_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_drop_files_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	static void _dispatch_input_events(const Ref<InputEvent> &p_event);
+	void send_input_event(const Ref<InputEvent> &p_event, DisplayServer::WindowID p_id = MAIN_WINDOW_ID) const;
+	void send_input_text(const String &p_text, DisplayServer::WindowID p_id = MAIN_WINDOW_ID) const;
+	void send_window_event(DisplayServer::WindowEvent p_event, DisplayServer::WindowID p_id = MAIN_WINDOW_ID) const;
+	void _window_callback(const Callable &p_callable, const Variant &p_arg) const;
+
+	virtual void beep() const override;
+
+	// MARK: - Mouse
+	virtual void mouse_set_mode(MouseMode p_mode) override;
+	virtual MouseMode mouse_get_mode() const override;
+	virtual void mouse_set_mode_override(MouseMode p_mode) override;
+	virtual MouseMode mouse_get_mode_override() const override;
+	virtual void mouse_set_mode_override_enabled(bool p_override_enabled) override;
+	virtual bool mouse_is_mode_override_enabled() const override;
+
+	virtual Point2i mouse_get_position() const override;
+	virtual BitField<MouseButtonMask> mouse_get_button_state() const override;
+
+	// MARK: - Joystick
+
+	void joy_add(int p_idx, const String &p_name);
+	void joy_del(int p_idx);
+
+	// MARK: - Window
+
+	virtual bool has_feature(Feature p_feature) const override;
+	virtual String get_name() const override;
+
+	virtual int get_screen_count() const override;
+	virtual int get_primary_screen() const override;
+	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+
+	virtual Vector<DisplayServer::WindowID> get_window_list() const override;
+
+	virtual WindowID get_window_at_screen_position(const Point2i &p_position) const override;
+
+	virtual void window_attach_instance_id(ObjectID p_instance, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual ObjectID window_get_attached_instance_id(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	virtual Point2i window_get_position(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual Point2i window_get_position_with_decorations(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual void window_set_position(const Point2i &p_position, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	virtual void window_set_transient(WindowID p_window, WindowID p_parent) override;
+
+	virtual void window_set_max_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual Size2i window_get_max_size(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_set_min_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual Size2i window_get_min_size(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_set_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual Size2i window_get_size(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual Size2i window_get_size_with_decorations(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_set_mode(WindowMode p_mode, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual WindowMode window_get_mode(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual bool window_is_maximize_allowed(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_set_flag(WindowFlags p_flag, bool p_enabled, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual bool window_get_flag(WindowFlags p_flag, WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_request_attention(WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_move_to_foreground(WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual bool window_is_focused(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual float screen_get_max_scale() const override;
+
+	virtual bool window_can_draw(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual bool can_any_window_draw() const override;
+
+	virtual void window_set_ime_active(const bool p_active, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_ime_position(const Point2i &p_pos, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	virtual void window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mode, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual DisplayServer::VSyncMode window_get_vsync_mode(WindowID p_vsync_mode) const override;
+
+	void update_im_text(const Point2i &p_selection, const String &p_text);
+	virtual Point2i ime_get_selection() const override;
+	virtual String ime_get_text() const override;
+
+	virtual void cursor_set_shape(CursorShape p_shape) override;
+	virtual CursorShape cursor_get_shape() const override;
+	virtual void cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2()) override;
+
+	void update_state(const Dictionary &p_state);
+	void set_content_scale(float p_scale);
+	virtual void swap_buffers() override;
+
+	DisplayServerEmbedded(const String &p_rendering_driver, DisplayServer::WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, Error &r_error);
+	~DisplayServerEmbedded();
+};

--- a/platform/macos/display_server_embedded.mm
+++ b/platform/macos/display_server_embedded.mm
@@ -1,0 +1,744 @@
+/**************************************************************************/
+/*  display_server_embedded.mm                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#import "display_server_embedded.h"
+
+#import "embedded_debugger.h"
+#import "macos_quartz_core_spi.h"
+
+#import "core/config/project_settings.h"
+#import "core/debugger/engine_debugger.h"
+
+#if defined(GLES3_ENABLED)
+#include "drivers/gles3/rasterizer_gles3.h"
+#endif
+
+#if defined(RD_ENABLED)
+#import "servers/rendering/renderer_rd/renderer_compositor_rd.h"
+#endif
+
+DisplayServerEmbedded::DisplayServerEmbedded(const String &p_rendering_driver, WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, Error &r_error) {
+	EmbeddedDebugger::initialize(this);
+
+	r_error = OK; // default to OK
+
+	native_menu = memnew(NativeMenu);
+
+	Input::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
+
+	rendering_driver = p_rendering_driver;
+
+#if defined(RD_ENABLED)
+#if defined(VULKAN_ENABLED)
+#if defined(__x86_64__)
+	bool fallback_to_vulkan = GLOBAL_GET("rendering/rendering_device/fallback_to_vulkan");
+	if (!fallback_to_vulkan) {
+		WARN_PRINT("Metal is not supported on Intel Macs, switching to Vulkan.");
+	}
+	// Metal rendering driver not available on Intel.
+	if (rendering_driver == "metal") {
+		rendering_driver = "vulkan";
+		OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+	}
+#endif
+	if (rendering_driver == "vulkan") {
+		rendering_context = memnew(RenderingContextDriverVulkanMacOS);
+	}
+#endif
+#if defined(METAL_ENABLED)
+	if (rendering_driver == "metal") {
+		rendering_context = memnew(RenderingContextDriverMetal);
+	}
+#endif
+
+	if (rendering_context) {
+		if (rendering_context->initialize() != OK) {
+			memdelete(rendering_context);
+			rendering_context = nullptr;
+#if defined(GLES3_ENABLED)
+			bool fallback_to_opengl3 = GLOBAL_GET("rendering/rendering_device/fallback_to_opengl3");
+			if (fallback_to_opengl3 && rendering_driver != "opengl3") {
+				WARN_PRINT("Your device seem not to support MoltenVK or Metal, switching to OpenGL 3.");
+				rendering_driver = "opengl3";
+				OS::get_singleton()->set_current_rendering_method("gl_compatibility");
+				OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+			} else
+#endif
+			{
+				r_error = ERR_CANT_CREATE;
+				ERR_FAIL_MSG("Could not initialize " + rendering_driver);
+			}
+		}
+	}
+#endif
+
+#if defined(GLES3_ENABLED)
+	if (rendering_driver == "opengl3_angle") {
+		WARN_PRINT("ANGLE not supported for embedded display, switching to native OpenGL.");
+		rendering_driver = "opengl3";
+		OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
+	}
+
+	if (rendering_driver == "opengl3") {
+		gl_manager = memnew(GLManagerEmbedded);
+		if (gl_manager->initialize() != OK) {
+			memdelete(gl_manager);
+			gl_manager = nullptr;
+			r_error = ERR_UNAVAILABLE;
+			ERR_FAIL_MSG("Could not initialize native OpenGL.");
+		}
+		layer = [CALayer new];
+		// OpenGL content is flipped, so it must be transformed.
+		layer.anchorPoint = CGPointMake(0, 0);
+		layer.transform = CATransform3DMakeScale(1.0, -1.0, 1.0);
+
+		Error err = gl_manager->window_create(window_id_counter, layer, p_resolution.width, p_resolution.height);
+		if (err != OK) {
+			ERR_FAIL_MSG("Could not create OpenGL context.");
+		}
+	}
+#endif
+
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		layer = [CAMetalLayer new];
+		layer.anchorPoint = CGPointMake(0, 1);
+
+		union {
+#ifdef VULKAN_ENABLED
+			RenderingContextDriverVulkanMacOS::WindowPlatformData vulkan;
+#endif
+#ifdef METAL_ENABLED
+			RenderingContextDriverMetal::WindowPlatformData metal;
+#endif
+		} wpd;
+#ifdef VULKAN_ENABLED
+		if (rendering_driver == "vulkan") {
+			wpd.vulkan.layer_ptr = (CAMetalLayer *const *)&layer;
+		}
+#endif
+#ifdef METAL_ENABLED
+		if (rendering_driver == "metal") {
+			wpd.metal.layer = (CAMetalLayer *)layer;
+		}
+#endif
+		Error err = rendering_context->window_create(window_id_counter, &wpd);
+		ERR_FAIL_COND_MSG(err != OK, vformat("Can't create a %s context", rendering_driver));
+
+		// The rendering context is always in pixels
+		rendering_context->window_set_size(window_id_counter, p_resolution.width, p_resolution.height);
+		rendering_context->window_set_vsync_mode(window_id_counter, p_vsync_mode);
+	}
+#endif
+
+#if defined(GLES3_ENABLED)
+	if (rendering_driver == "opengl3") {
+		RasterizerGLES3::make_current(true);
+	}
+	if (rendering_driver == "opengl3_angle") {
+		RasterizerGLES3::make_current(false);
+	}
+#endif
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		rendering_device = memnew(RenderingDevice);
+		rendering_device->initialize(rendering_context, MAIN_WINDOW_ID);
+		rendering_device->screen_create(MAIN_WINDOW_ID);
+
+		RendererCompositorRD::make_current();
+	}
+#endif
+
+	constexpr CGFloat CONTENT_SCALE = 2.0;
+	layer.contentsScale = CONTENT_SCALE;
+	layer.magnificationFilter = kCAFilterNearest;
+	layer.minificationFilter = kCAFilterNearest;
+	layer.opaque = NO; // Never opaque when embedded.
+	layer.actions = @{ @"contents" : [NSNull null] }; // Disable implicit animations for contents.
+	// AppKit frames, bounds and positions are always in points.
+	CGRect bounds = CGRectMake(0, 0, p_resolution.width, p_resolution.height);
+	bounds = CGRectApplyAffineTransform(bounds, CGAffineTransformMakeScale(1.0 / CONTENT_SCALE, 1.0 / CONTENT_SCALE));
+	layer.bounds = bounds;
+
+	CGSConnectionID connection_id = CGSMainConnectionID();
+	ca_context = [CAContext contextWithCGSConnection:connection_id options:@{ kCAContextCIFilterBehavior : @"ignore" }];
+	ca_context.layer = layer;
+
+	{
+		Array arr = { ca_context.contextId };
+		EngineDebugger::get_singleton()->send_message("game_view:set_context_id", arr);
+	}
+}
+
+DisplayServerEmbedded::~DisplayServerEmbedded() {
+	if (native_menu) {
+		memdelete(native_menu);
+		native_menu = nullptr;
+	}
+
+	EmbeddedDebugger::deinitialize();
+
+#if defined(GLES3_ENABLED)
+	if (gl_manager) {
+		memdelete(gl_manager);
+		gl_manager = nullptr;
+	}
+#endif
+
+#if defined(RD_ENABLED)
+	if (rendering_device) {
+		memdelete(rendering_device);
+		rendering_device = nullptr;
+	}
+
+	if (rendering_context) {
+		memdelete(rendering_context);
+		rendering_context = nullptr;
+	}
+#endif
+}
+
+DisplayServer *DisplayServerEmbedded::create_func(const String &p_rendering_driver, WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t /* p_parent_window */, Error &r_error) {
+	return memnew(DisplayServerEmbedded(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, r_error));
+}
+
+Vector<String> DisplayServerEmbedded::get_rendering_drivers_func() {
+	Vector<String> drivers;
+
+#if defined(VULKAN_ENABLED)
+	drivers.push_back("vulkan");
+#endif
+#if defined(METAL_ENABLED)
+	drivers.push_back("metal");
+#endif
+#if defined(GLES3_ENABLED)
+	drivers.push_back("opengl3");
+#endif
+
+	return drivers;
+}
+
+void DisplayServerEmbedded::register_embedded_driver() {
+	register_create_function("embedded", create_func, get_rendering_drivers_func);
+}
+
+void DisplayServerEmbedded::beep() const {
+	NSBeep();
+}
+
+// MARK: - Mouse
+
+void DisplayServerEmbedded::_mouse_update_mode() {
+	MouseMode wanted_mouse_mode = mouse_mode_override_enabled
+			? mouse_mode_override
+			: mouse_mode_base;
+
+	if (wanted_mouse_mode == mouse_mode) {
+		return;
+	}
+
+	EngineDebugger::get_singleton()->send_message("game_view:mouse_set_mode", { wanted_mouse_mode });
+
+	mouse_mode = wanted_mouse_mode;
+}
+
+void DisplayServerEmbedded::mouse_set_mode(MouseMode p_mode) {
+	if (p_mode == mouse_mode_base) {
+		return;
+	}
+	mouse_mode_base = p_mode;
+	_mouse_update_mode();
+}
+
+DisplayServerEmbedded::MouseMode DisplayServerEmbedded::mouse_get_mode() const {
+	return mouse_mode;
+}
+
+void DisplayServerEmbedded::mouse_set_mode_override(MouseMode p_mode) {
+	ERR_FAIL_INDEX(p_mode, MouseMode::MOUSE_MODE_MAX);
+	if (p_mode == mouse_mode_override) {
+		return;
+	}
+	mouse_mode_override = p_mode;
+	_mouse_update_mode();
+}
+
+DisplayServer::MouseMode DisplayServerEmbedded::mouse_get_mode_override() const {
+	return mouse_mode_override;
+}
+
+void DisplayServerEmbedded::mouse_set_mode_override_enabled(bool p_override_enabled) {
+	if (p_override_enabled == mouse_mode_override_enabled) {
+		return;
+	}
+	mouse_mode_override_enabled = p_override_enabled;
+	_mouse_update_mode();
+}
+
+bool DisplayServerEmbedded::mouse_is_mode_override_enabled() const {
+	return mouse_mode_override_enabled;
+}
+
+Point2i DisplayServerEmbedded::mouse_get_position() const {
+	_THREAD_SAFE_METHOD_
+
+	const NSPoint mouse_pos = [NSEvent mouseLocation];
+	const float scale = screen_get_max_scale();
+
+	for (NSScreen *screen in [NSScreen screens]) {
+		NSRect frame = [screen frame];
+		if (NSMouseInRect(mouse_pos, frame, NO)) {
+			Vector2i pos = Vector2i((int)mouse_pos.x, (int)mouse_pos.y);
+			pos *= scale;
+			// TODO(sgc): fix this
+			// pos -= _get_screens_origin();
+			pos.y *= -1;
+			return pos;
+		}
+	}
+	return Vector2i();
+}
+
+BitField<MouseButtonMask> DisplayServerEmbedded::mouse_get_button_state() const {
+	BitField<MouseButtonMask> last_button_state = MouseButtonMask::NONE;
+
+	NSUInteger buttons = [NSEvent pressedMouseButtons];
+	if (buttons & (1 << 0)) {
+		last_button_state.set_flag(MouseButtonMask::LEFT);
+	}
+	if (buttons & (1 << 1)) {
+		last_button_state.set_flag(MouseButtonMask::RIGHT);
+	}
+	if (buttons & (1 << 2)) {
+		last_button_state.set_flag(MouseButtonMask::MIDDLE);
+	}
+	if (buttons & (1 << 3)) {
+		last_button_state.set_flag(MouseButtonMask::MB_XBUTTON1);
+	}
+	if (buttons & (1 << 4)) {
+		last_button_state.set_flag(MouseButtonMask::MB_XBUTTON2);
+	}
+	return last_button_state;
+}
+
+// MARK: Events
+
+void DisplayServerEmbedded::window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window) {
+	window_resize_callbacks[p_window] = p_callable;
+}
+
+void DisplayServerEmbedded::window_set_window_event_callback(const Callable &p_callable, WindowID p_window) {
+	window_event_callbacks[p_window] = p_callable;
+}
+void DisplayServerEmbedded::window_set_input_event_callback(const Callable &p_callable, WindowID p_window) {
+	input_event_callbacks[p_window] = p_callable;
+}
+
+void DisplayServerEmbedded::window_set_input_text_callback(const Callable &p_callable, WindowID p_window) {
+	input_text_callbacks[p_window] = p_callable;
+}
+
+void DisplayServerEmbedded::window_set_drop_files_callback(const Callable &p_callable, WindowID p_window) {
+	// Not supported
+}
+
+void DisplayServerEmbedded::joy_add(int p_idx, const String &p_name) {
+	Joy *joy = joysticks.getptr(p_idx);
+	if (joy == nullptr) {
+		joysticks[p_idx] = Joy(p_name);
+		Input::get_singleton()->joy_connection_changed(p_idx, true, p_name);
+	}
+}
+
+void DisplayServerEmbedded::joy_del(int p_idx) {
+	if (joysticks.erase(p_idx)) {
+		Input::get_singleton()->joy_connection_changed(p_idx, false, String());
+	}
+}
+
+void DisplayServerEmbedded::process_events() {
+	Input *input = Input::get_singleton();
+	for (KeyValue<int, Joy> &kv : joysticks) {
+		uint64_t ts = input->get_joy_vibration_timestamp(kv.key);
+		if (ts > kv.value.timestamp) {
+			kv.value.timestamp = ts;
+			Vector2 strength = input->get_joy_vibration_strength(kv.key);
+			if (strength == Vector2()) {
+				EngineDebugger::get_singleton()->send_message("game_view:joy_stop", { kv.key });
+			} else {
+				float duration = input->get_joy_vibration_duration(kv.key);
+				EngineDebugger::get_singleton()->send_message("game_view:joy_start", { kv.key, duration, strength });
+			}
+		}
+	}
+
+	input->flush_buffered_events();
+}
+
+void DisplayServerEmbedded::_dispatch_input_events(const Ref<InputEvent> &p_event) {
+	Ref<InputEventFromWindow> event_from_window = p_event;
+	WindowID window_id = INVALID_WINDOW_ID;
+	if (event_from_window.is_valid()) {
+		window_id = event_from_window->get_window_id();
+	}
+	DisplayServerEmbedded *ds = (DisplayServerEmbedded *)DisplayServer::get_singleton();
+	ds->send_input_event(p_event, window_id);
+}
+
+void DisplayServerEmbedded::send_input_event(const Ref<InputEvent> &p_event, WindowID p_id) const {
+	if (p_id != INVALID_WINDOW_ID) {
+		_window_callback(input_event_callbacks[p_id], p_event);
+	} else {
+		for (const KeyValue<WindowID, Callable> &E : input_event_callbacks) {
+			_window_callback(E.value, p_event);
+		}
+	}
+}
+
+void DisplayServerEmbedded::send_input_text(const String &p_text, WindowID p_id) const {
+	const Callable *cb = input_text_callbacks.getptr(p_id);
+	if (cb) {
+		_window_callback(*cb, p_text);
+	}
+}
+
+void DisplayServerEmbedded::send_window_event(DisplayServer::WindowEvent p_event, WindowID p_id) const {
+	const Callable *cb = window_event_callbacks.getptr(p_id);
+	if (cb) {
+		_window_callback(*cb, int(p_event));
+	}
+}
+
+void DisplayServerEmbedded::_window_callback(const Callable &p_callable, const Variant &p_arg) const {
+	if (p_callable.is_valid()) {
+		p_callable.call(p_arg);
+	}
+}
+
+// MARK: -
+
+bool DisplayServerEmbedded::has_feature(Feature p_feature) const {
+	switch (p_feature) {
+#ifndef DISABLE_DEPRECATED
+		case FEATURE_GLOBAL_MENU: {
+			return (native_menu && native_menu->has_feature(NativeMenu::FEATURE_GLOBAL_MENU));
+		} break;
+#endif
+		case FEATURE_CURSOR_SHAPE:
+		case FEATURE_IME:
+			// case FEATURE_CUSTOM_CURSOR_SHAPE:
+			// case FEATURE_HIDPI:
+			// case FEATURE_ICON:
+			// case FEATURE_MOUSE:
+			// case FEATURE_MOUSE_WARP:
+			// case FEATURE_NATIVE_DIALOG:
+			// case FEATURE_NATIVE_ICON:
+			// case FEATURE_WINDOW_TRANSPARENCY:
+			// case FEATURE_CLIPBOARD:
+			// case FEATURE_KEEP_SCREEN_ON:
+			// case FEATURE_ORIENTATION:
+			// case FEATURE_VIRTUAL_KEYBOARD:
+			// case FEATURE_TEXT_TO_SPEECH:
+			// case FEATURE_TOUCHSCREEN:
+			return true;
+		default:
+			return false;
+	}
+}
+
+String DisplayServerEmbedded::get_name() const {
+	return "embedded";
+}
+
+int DisplayServerEmbedded::get_screen_count() const {
+	return 1;
+}
+
+int DisplayServerEmbedded::get_primary_screen() const {
+	return 0;
+}
+
+Point2i DisplayServerEmbedded::screen_get_position(int p_screen) const {
+	return Size2i();
+}
+
+Size2i DisplayServerEmbedded::screen_get_size(int p_screen) const {
+	return window_get_size(MAIN_WINDOW_ID);
+}
+
+Rect2i DisplayServerEmbedded::screen_get_usable_rect(int p_screen) const {
+	return Rect2i(screen_get_position(p_screen), screen_get_size(p_screen));
+}
+
+int DisplayServerEmbedded::screen_get_dpi(int p_screen) const {
+	return 96;
+}
+
+float DisplayServerEmbedded::screen_get_refresh_rate(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	p_screen = _get_screen_index(p_screen);
+	NSArray *screenArray = [NSScreen screens];
+	if ((NSUInteger)p_screen < [screenArray count]) {
+		NSDictionary *description = [[screenArray objectAtIndex:p_screen] deviceDescription];
+		const CGDisplayModeRef displayMode = CGDisplayCopyDisplayMode([[description objectForKey:@"NSScreenNumber"] unsignedIntValue]);
+		const double displayRefreshRate = CGDisplayModeGetRefreshRate(displayMode);
+		return (float)displayRefreshRate;
+	}
+	ERR_PRINT("An error occurred while trying to get the screen refresh rate.");
+	return SCREEN_REFRESH_RATE_FALLBACK;
+}
+
+Vector<DisplayServer::WindowID> DisplayServerEmbedded::get_window_list() const {
+	Vector<DisplayServer::WindowID> list;
+	list.push_back(MAIN_WINDOW_ID);
+	return list;
+}
+
+DisplayServer::WindowID DisplayServerEmbedded::get_window_at_screen_position(const Point2i &p_position) const {
+	return MAIN_WINDOW_ID;
+}
+
+void DisplayServerEmbedded::window_attach_instance_id(ObjectID p_instance, WindowID p_window) {
+	window_attached_instance_id[p_window] = p_instance;
+}
+
+ObjectID DisplayServerEmbedded::window_get_attached_instance_id(WindowID p_window) const {
+	return window_attached_instance_id[p_window];
+}
+
+void DisplayServerEmbedded::window_set_title(const String &p_title, WindowID p_window) {
+	// Not supported
+}
+
+int DisplayServerEmbedded::window_get_current_screen(WindowID p_window) const {
+	return SCREEN_OF_MAIN_WINDOW;
+}
+
+void DisplayServerEmbedded::window_set_current_screen(int p_screen, WindowID p_window) {
+	// Not supported
+}
+
+Point2i DisplayServerEmbedded::window_get_position(WindowID p_window) const {
+	return Point2i();
+}
+
+Point2i DisplayServerEmbedded::window_get_position_with_decorations(WindowID p_window) const {
+	return Point2i();
+}
+
+void DisplayServerEmbedded::window_set_position(const Point2i &p_position, WindowID p_window) {
+	// Probably not supported for single window iOS app
+}
+
+void DisplayServerEmbedded::window_set_transient(WindowID p_window, WindowID p_parent) {
+	// Not supported
+}
+
+void DisplayServerEmbedded::window_set_max_size(const Size2i p_size, WindowID p_window) {
+	// Not supported
+}
+
+Size2i DisplayServerEmbedded::window_get_max_size(WindowID p_window) const {
+	return Size2i();
+}
+
+void DisplayServerEmbedded::window_set_min_size(const Size2i p_size, WindowID p_window) {
+	// Not supported
+}
+
+Size2i DisplayServerEmbedded::window_get_min_size(WindowID p_window) const {
+	return Size2i();
+}
+
+void DisplayServerEmbedded::window_set_size(const Size2i p_size, WindowID p_window) {
+	[CATransaction begin];
+	[CATransaction setDisableActions:YES];
+
+	// TODO(sgc): Pass scale as argument from parent process.
+	constexpr CGFloat CONTENT_SCALE = 2.0;
+	CGRect bounds = CGRectMake(0, 0, p_size.width, p_size.height);
+	bounds = CGRectApplyAffineTransform(bounds, CGAffineTransformMakeScale(1.0 / CONTENT_SCALE, 1.0 / CONTENT_SCALE));
+	layer.bounds = bounds;
+
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		rendering_context->window_set_size(p_window, p_size.width, p_size.height);
+	}
+#endif
+#if defined(GLES3_ENABLED)
+	if (gl_manager) {
+		gl_manager->window_resize(p_window, p_size.width, p_size.height);
+	}
+#endif
+	[CATransaction commit];
+
+	Callable *cb = window_resize_callbacks.getptr(p_window);
+	if (cb) {
+		Variant resize_rect = Rect2i(Point2i(), p_size);
+		_window_callback(window_resize_callbacks[p_window], resize_rect);
+	}
+}
+
+Size2i DisplayServerEmbedded::window_get_size(WindowID p_window) const {
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		RenderingContextDriver::SurfaceID surface = rendering_context->surface_get_from_window(p_window);
+		ERR_FAIL_COND_V_MSG(surface == 0, Size2i(), "Invalid window ID");
+		uint32_t width = rendering_context->surface_get_width(surface);
+		uint32_t height = rendering_context->surface_get_height(surface);
+		return Size2i(width, height);
+	}
+#endif
+#ifdef GLES3_ENABLED
+	if (gl_manager) {
+		return gl_manager->window_get_size(p_window);
+	}
+#endif
+	return Size2i();
+}
+
+Size2i DisplayServerEmbedded::window_get_size_with_decorations(WindowID p_window) const {
+	return window_get_size(p_window);
+}
+
+void DisplayServerEmbedded::window_set_mode(WindowMode p_mode, WindowID p_window) {
+	// Not supported
+}
+
+DisplayServer::WindowMode DisplayServerEmbedded::window_get_mode(WindowID p_window) const {
+	return WindowMode::WINDOW_MODE_WINDOWED;
+}
+
+bool DisplayServerEmbedded::window_is_maximize_allowed(WindowID p_window) const {
+	return false;
+}
+
+void DisplayServerEmbedded::window_set_flag(WindowFlags p_flag, bool p_enabled, WindowID p_window) {
+	// Not supported
+}
+
+bool DisplayServerEmbedded::window_get_flag(WindowFlags p_flag, WindowID p_window) const {
+	return false;
+}
+
+void DisplayServerEmbedded::window_request_attention(WindowID p_window) {
+	// Not supported
+}
+
+void DisplayServerEmbedded::window_move_to_foreground(WindowID p_window) {
+	// Not supported
+}
+
+bool DisplayServerEmbedded::window_is_focused(WindowID p_window) const {
+	return true;
+}
+
+float DisplayServerEmbedded::screen_get_max_scale() const {
+	return state.screen_max_scale;
+}
+
+bool DisplayServerEmbedded::window_can_draw(WindowID p_window) const {
+	return true;
+}
+
+bool DisplayServerEmbedded::can_any_window_draw() const {
+	return true;
+}
+
+void DisplayServerEmbedded::window_set_ime_active(const bool p_active, WindowID p_window) {
+	EngineDebugger::get_singleton()->send_message("game_view:window_set_ime_active", { p_active });
+}
+
+void DisplayServerEmbedded::window_set_ime_position(const Point2i &p_pos, WindowID p_window) {
+	if (p_pos == ime_last_position) {
+		return;
+	}
+	EngineDebugger::get_singleton()->send_message("game_view:window_set_ime_position", { p_pos });
+	ime_last_position = p_pos;
+}
+
+void DisplayServerEmbedded::update_state(const Dictionary &p_state) {
+	state.screen_max_scale = p_state["screen_get_max_scale"];
+}
+
+void DisplayServerEmbedded::set_content_scale(float p_scale) {
+	content_scale = p_scale;
+}
+
+void DisplayServerEmbedded::window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mode, WindowID p_window) {
+	// Not supported
+}
+
+DisplayServer::VSyncMode DisplayServerEmbedded::window_get_vsync_mode(WindowID p_window) const {
+	_THREAD_SAFE_METHOD_
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		return rendering_context->window_get_vsync_mode(p_window);
+	}
+#endif
+	return DisplayServer::VSYNC_ENABLED;
+}
+
+void DisplayServerEmbedded::update_im_text(const Point2i &p_selection, const String &p_text) {
+	im_selection = p_selection;
+	im_text = p_text;
+
+	OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
+}
+
+Point2i DisplayServerEmbedded::ime_get_selection() const {
+	return im_selection;
+}
+
+String DisplayServerEmbedded::ime_get_text() const {
+	return im_text;
+}
+
+void DisplayServerEmbedded::cursor_set_shape(CursorShape p_shape) {
+	cursor_shape = p_shape;
+	EngineDebugger::get_singleton()->send_message("game_view:cursor_set_shape", { p_shape });
+}
+
+DisplayServer::CursorShape DisplayServerEmbedded::cursor_get_shape() const {
+	return cursor_shape;
+}
+
+void DisplayServerEmbedded::cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
+	WARN_PRINT_ONCE("Custom cursor images are not supported in embedded mode.");
+}
+
+void DisplayServerEmbedded::swap_buffers() {
+#ifdef GLES3_ENABLED
+	if (gl_manager) {
+		gl_manager->swap_buffers();
+	}
+#endif
+}

--- a/platform/macos/editor/embedded_game_view_plugin.h
+++ b/platform/macos/editor/embedded_game_view_plugin.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  godot_application.h                                                   */
+/*  embedded_game_view_plugin.h                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,21 +30,46 @@
 
 #pragma once
 
-#include "core/os/os.h"
+#include "editor/plugins/game_view_plugin.h"
 
-#import <AppKit/AppKit.h>
-#import <Foundation/Foundation.h>
-#import <IOKit/hidsystem/ev_keymap.h>
+class EmbeddedProcessMacOS;
 
-@class GodotApplicationDelegate;
+class GameViewDebuggerMacOS : public GameViewDebugger {
+	GDCLASS(GameViewDebuggerMacOS, GameViewDebugger);
 
-@interface GodotApplication : NSApplication
+	EmbeddedProcessMacOS *embedded_process = nullptr;
 
-extern "C" GodotApplication *GodotApp;
+	/// Message handler function for capture.
 
-@property(readonly, nonatomic) GodotApplicationDelegate *godotDelegate;
+	/// @brief A function pointer to the message handler function.
+	typedef bool (GameViewDebuggerMacOS::*ParseMessageFunc)(const Array &p_args);
 
-- (GodotApplication *)init;
+	/// @brief A map of message handlers.
+	static HashMap<String, ParseMessageFunc> parse_message_handlers;
 
-- (void)activateApplication;
-@end
+	/// @brief Initialize the message handlers.
+	static void _init_capture_message_handlers();
+
+	bool _msg_set_context_id(const Array &p_args);
+	bool _msg_cursor_set_shape(const Array &p_args);
+	bool _msg_mouse_set_mode(const Array &p_args);
+	bool _msg_window_set_ime_active(const Array &p_args);
+	bool _msg_window_set_ime_position(const Array &p_args);
+	bool _msg_joy_start(const Array &p_args);
+	bool _msg_joy_stop(const Array &p_args);
+
+public:
+	virtual bool capture(const String &p_message, const Array &p_data, int p_session) override;
+	virtual bool has_capture(const String &p_capture) const override;
+
+	GameViewDebuggerMacOS(EmbeddedProcessMacOS *p_embedded_process);
+};
+
+class GameViewPluginMacOS : public GameViewPluginBase {
+	GDCLASS(GameViewPluginMacOS, GameViewPluginBase);
+
+public:
+	GameViewPluginMacOS();
+};
+
+extern "C" void register_game_view_plugin();

--- a/platform/macos/editor/embedded_game_view_plugin.mm
+++ b/platform/macos/editor/embedded_game_view_plugin.mm
@@ -1,0 +1,154 @@
+/**************************************************************************/
+/*  embedded_game_view_plugin.mm                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "embedded_game_view_plugin.h"
+
+#include "embedded_process_macos.h"
+
+#include "editor/editor_node.h"
+#include "editor/window_wrapper.h"
+
+HashMap<String, GameViewDebuggerMacOS::ParseMessageFunc> GameViewDebuggerMacOS::parse_message_handlers;
+
+bool GameViewDebuggerMacOS::_msg_set_context_id(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "set_context_id: invalid number of arguments");
+
+	embedded_process->set_context_id(p_args[0]);
+	return true;
+}
+
+bool GameViewDebuggerMacOS::_msg_cursor_set_shape(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "cursor_set_shape: invalid number of arguments");
+
+	Control::CursorShape shape = Control::CursorShape(p_args[0]);
+	embedded_process->get_layer_host()->set_default_cursor_shape(static_cast<Control::CursorShape>(shape));
+
+	return true;
+}
+
+bool GameViewDebuggerMacOS::_msg_mouse_set_mode(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "mouse_set_mode: invalid number of arguments");
+
+	DisplayServer::MouseMode mode = DisplayServer::MouseMode(p_args[0]);
+	embedded_process->mouse_set_mode(mode);
+
+	return true;
+}
+
+bool GameViewDebuggerMacOS::_msg_window_set_ime_active(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "window_set_ime_active: invalid number of arguments");
+
+	bool active = p_args[0];
+	DisplayServer::WindowID wid = embedded_process->get_window()->get_window_id();
+	DisplayServer::get_singleton()->window_set_ime_active(active, wid);
+	return true;
+}
+
+bool GameViewDebuggerMacOS::_msg_window_set_ime_position(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "window_set_ime_position: invalid number of arguments");
+
+	Point2i pos = p_args[0];
+	Point2i xpos = embedded_process->get_layer_host()->get_global_transform_with_canvas().xform(pos);
+	DisplayServer::WindowID wid = embedded_process->get_window()->get_window_id();
+	DisplayServer::get_singleton()->window_set_ime_position(xpos, wid);
+	return true;
+}
+
+bool GameViewDebuggerMacOS::_msg_joy_start(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 3, false, "joy_start: invalid number of arguments");
+
+	int joy_id = p_args[0];
+	float duration = p_args[1];
+	Vector2 strength = p_args[2];
+	Input::get_singleton()->start_joy_vibration(joy_id, strength.x, strength.y, duration);
+	return true;
+}
+
+bool GameViewDebuggerMacOS::_msg_joy_stop(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "joy_stop: invalid number of arguments");
+
+	int joy_id = p_args[0];
+	Input::get_singleton()->stop_joy_vibration(joy_id);
+	return true;
+}
+
+void GameViewDebuggerMacOS::_init_capture_message_handlers() {
+	parse_message_handlers["game_view:set_context_id"] = &GameViewDebuggerMacOS::_msg_set_context_id;
+	parse_message_handlers["game_view:cursor_set_shape"] = &GameViewDebuggerMacOS::_msg_cursor_set_shape;
+	parse_message_handlers["game_view:mouse_set_mode"] = &GameViewDebuggerMacOS::_msg_mouse_set_mode;
+	parse_message_handlers["game_view:window_set_ime_active"] = &GameViewDebuggerMacOS::_msg_window_set_ime_active;
+	parse_message_handlers["game_view:window_set_ime_position"] = &GameViewDebuggerMacOS::_msg_window_set_ime_position;
+	parse_message_handlers["game_view:joy_start"] = &GameViewDebuggerMacOS::_msg_joy_start;
+	parse_message_handlers["game_view:joy_stop"] = &GameViewDebuggerMacOS::_msg_joy_stop;
+}
+
+bool GameViewDebuggerMacOS::has_capture(const String &p_capture) const {
+	return p_capture == "game_view";
+}
+
+bool GameViewDebuggerMacOS::capture(const String &p_message, const Array &p_data, int p_session) {
+	Ref<EditorDebuggerSession> session = get_session(p_session);
+	ERR_FAIL_COND_V(session.is_null(), true);
+
+	ParseMessageFunc *fn_ptr = parse_message_handlers.getptr(p_message);
+	if (fn_ptr) {
+		return (this->**fn_ptr)(p_data);
+	} else {
+		// Any other messages with this prefix should be ignored.
+		WARN_PRINT("GameViewDebuggerMacOS unknown message: " + p_message);
+		return ERR_SKIP;
+	}
+
+	return true;
+}
+
+GameViewDebuggerMacOS::GameViewDebuggerMacOS(EmbeddedProcessMacOS *p_embedded_process) :
+		embedded_process(p_embedded_process) {
+	if (parse_message_handlers.is_empty()) {
+		_init_capture_message_handlers();
+	}
+}
+
+GameViewPluginMacOS::GameViewPluginMacOS() {
+	if (Engine::get_singleton()->is_recovery_mode_hint()) {
+		return;
+	}
+
+	EmbeddedProcessMacOS *embedded_process = memnew(EmbeddedProcessMacOS);
+
+	Ref<GameViewDebuggerMacOS> debugger;
+	debugger.instantiate(embedded_process);
+
+	setup(debugger, embedded_process);
+}
+
+extern "C" GameViewPluginBase *get_game_view_plugin() {
+	return memnew(GameViewPluginMacOS);
+}

--- a/platform/macos/editor/embedded_process_macos.mm
+++ b/platform/macos/editor/embedded_process_macos.mm
@@ -1,0 +1,248 @@
+/**************************************************************************/
+/*  embedded_process_macos.mm                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "embedded_process_macos.h"
+
+#include "platform/macos/display_server_macos.h"
+
+#include "core/input/input_event_codec.h"
+#include "editor/debugger/script_editor_debugger.h"
+#include "editor/editor_settings.h"
+#include "scene/gui/control.h"
+#include "scene/main/window.h"
+
+void EmbeddedProcessMacOS::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_RESIZED:
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			update_embedded_process();
+		} break;
+	}
+}
+
+void EmbeddedProcessMacOS::update_embedded_process() const {
+	layer_host->set_rect(get_adjusted_embedded_window_rect(get_rect()));
+	if (is_embedding_completed()) {
+		ds->embed_process_update(window->get_window_id(), this);
+		Rect2i rect = get_screen_embedded_window_rect();
+		script_debugger->send_message("embed:window_size", { rect.size });
+	}
+}
+
+void EmbeddedProcessMacOS::set_context_id(uint32_t p_context_id) {
+	if (!window) {
+		return;
+	}
+
+	context_id = p_context_id;
+
+	_try_embed_process();
+}
+
+void EmbeddedProcessMacOS::set_script_debugger(ScriptEditorDebugger *p_debugger) {
+	script_debugger = p_debugger;
+	layer_host->set_script_debugger(script_debugger);
+	_try_embed_process();
+}
+
+void EmbeddedProcessMacOS::embed_process(OS::ProcessID p_pid) {
+	if (!window) {
+		return;
+	}
+
+	if (current_process_id != 0) {
+		// Stop embedding the last process.
+		OS::get_singleton()->kill(current_process_id);
+	}
+
+	reset();
+
+	current_process_id = p_pid;
+	embedding_state = EmbeddingState::IN_PROGRESS;
+	// Attempt to embed the process, but if it has just started and the window is not ready yet,
+	// we will retry in this case.
+	_try_embed_process();
+}
+
+void EmbeddedProcessMacOS::_joy_connection_changed(int p_index, bool p_connected) const {
+	if (!script_debugger) {
+		return;
+	}
+
+	if (p_connected) {
+		String name = Input::get_singleton()->get_joy_name(p_index);
+		script_debugger->send_message("embed:joy_add", { p_index, name });
+	} else {
+		script_debugger->send_message("embed:joy_del", { p_index });
+	}
+}
+
+void EmbeddedProcessMacOS::reset() {
+	if (!ds) {
+		ds = static_cast<DisplayServerMacOS *>(DisplayServer::get_singleton());
+	}
+	if (current_process_id != 0 && is_embedding_completed()) {
+		ds->remove_embedded_process(current_process_id);
+	}
+	current_process_id = 0;
+	embedding_state = EmbeddingState::IDLE;
+	context_id = 0;
+	script_debugger = nullptr;
+	queue_redraw();
+}
+
+void EmbeddedProcessMacOS::request_close() {
+	if (current_process_id != 0 && is_embedding_completed()) {
+		ds->request_close_embedded_process(current_process_id);
+	}
+}
+
+void EmbeddedProcessMacOS::_try_embed_process() {
+	if (current_process_id == 0 || script_debugger == nullptr || context_id == 0) {
+		return;
+	}
+
+	Error err = ds->embed_process_update(window->get_window_id(), this);
+	if (err == OK) {
+		Rect2i rect = get_screen_embedded_window_rect();
+		script_debugger->send_message("embed:window_size", { rect.size });
+		embedding_state = EmbeddingState::COMPLETED;
+		queue_redraw();
+		emit_signal(SNAME("embedding_completed"));
+
+		// Replicate some of the DisplayServer state.
+		{
+			Dictionary state;
+			state["screen_get_max_scale"] = ds->screen_get_max_scale();
+			// script_debugger->send_message("embed:ds_state", { state });
+		}
+
+		// Send initial joystick state.
+		{
+			Input *input = Input::get_singleton();
+			TypedArray<int> joy_pads = input->get_connected_joypads();
+			for (const Variant &idx : joy_pads) {
+				String name = input->get_joy_name(idx);
+				script_debugger->send_message("embed:joy_add", { idx, name });
+			}
+		}
+
+		layer_host->grab_focus();
+	} else {
+		// Another unknown error.
+		reset();
+		emit_signal(SNAME("embedding_failed"));
+	}
+}
+
+Rect2i EmbeddedProcessMacOS::get_adjusted_embedded_window_rect(const Rect2i &p_rect) const {
+	Rect2i control_rect = Rect2i(p_rect.position + margin_top_left, (p_rect.size - get_margins_size()).maxi(1));
+	if (window_size != Size2i()) {
+		Rect2i desired_rect;
+		if (!keep_aspect && control_rect.size.x >= window_size.x && control_rect.size.y >= window_size.y) {
+			// Fixed at the desired size.
+			desired_rect.size = window_size;
+		} else {
+			float ratio = MIN((float)control_rect.size.x / window_size.x, (float)control_rect.size.y / window_size.y);
+			desired_rect.size = Size2i(window_size.x * ratio, window_size.y * ratio).maxi(1);
+		}
+		desired_rect.position = Size2i(control_rect.position.x + ((control_rect.size.x - desired_rect.size.x) / 2), control_rect.position.y + ((control_rect.size.y - desired_rect.size.y) / 2));
+		return desired_rect;
+	} else {
+		// Stretch, use all the control area.
+		return control_rect;
+	}
+}
+
+void EmbeddedProcessMacOS::mouse_set_mode(DisplayServer::MouseMode p_mode) {
+	DisplayServer::get_singleton()->mouse_set_mode(p_mode);
+}
+
+EmbeddedProcessMacOS::EmbeddedProcessMacOS() :
+		EmbeddedProcessBase() {
+	layer_host = memnew(LayerHost);
+	add_child(layer_host);
+	layer_host->set_focus_mode(FOCUS_ALL);
+	layer_host->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+	layer_host->set_custom_minimum_size(Size2(100, 100));
+
+	Input *input = Input::get_singleton();
+	input->connect(SNAME("joy_connection_changed"), callable_mp(this, &EmbeddedProcessMacOS::_joy_connection_changed));
+
+	// This shortcut allows a user to forcibly release a captured mouse from within the editor, regardless of whether
+	// the embedded process has implemented support to release the cursor.
+	ED_SHORTCUT("game_view/release_mouse", TTRC("Release Mouse"), KeyModifierMask::ALT | Key::ESCAPE);
+}
+
+void LayerHost::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_FOCUS_ENTER: {
+			if (script_debugger) {
+				script_debugger->send_message("embed:win_event", { DisplayServer::WINDOW_EVENT_MOUSE_ENTER });
+			}
+		} break;
+		case NOTIFICATION_FOCUS_EXIT: {
+			if (script_debugger) {
+				script_debugger->send_message("embed:win_event", { DisplayServer::WINDOW_EVENT_MOUSE_EXIT });
+			}
+		} break;
+		case MainLoop::NOTIFICATION_OS_IME_UPDATE: {
+			if (script_debugger && has_focus()) {
+				const String ime_text = DisplayServer::get_singleton()->ime_get_text();
+				const Vector2i ime_selection = DisplayServer::get_singleton()->ime_get_selection();
+				script_debugger->send_message("embed:ime_update", { ime_text, ime_selection });
+			}
+		} break;
+	}
+}
+
+void LayerHost::gui_input(const Ref<InputEvent> &p_event) {
+	if (!script_debugger) {
+		return;
+	}
+
+	if (p_event->is_pressed()) {
+		if (ED_IS_SHORTCUT("game_view/release_mouse", p_event)) {
+			DisplayServer *ds = DisplayServer::get_singleton();
+			if (ds->mouse_get_mode() != DisplayServer::MOUSE_MODE_VISIBLE) {
+				ds->mouse_set_mode(DisplayServer::MOUSE_MODE_VISIBLE);
+				script_debugger->send_message("embed:mouse_set_mode", { DisplayServer::MOUSE_MODE_VISIBLE });
+			}
+			accept_event();
+			return;
+		}
+	}
+
+	PackedByteArray data;
+	if (encode_input_event(p_event, data)) {
+		script_debugger->send_message("embed:event", { data });
+		accept_event();
+	}
+}

--- a/platform/macos/embedded_debugger.mm
+++ b/platform/macos/embedded_debugger.mm
@@ -1,0 +1,177 @@
+/**************************************************************************/
+/*  embedded_debugger.mm                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "embedded_debugger.h"
+
+#include "display_server_embedded.h"
+
+#include "core/debugger/engine_debugger.h"
+#include "core/input/input_event_codec.h"
+
+#ifdef DEBUG_ENABLED
+HashMap<String, EmbeddedDebugger::ParseMessageFunc> EmbeddedDebugger::parse_message_handlers;
+#endif
+
+EmbeddedDebugger::EmbeddedDebugger(DisplayServerEmbedded *p_ds) {
+	singleton = this;
+
+#ifdef DEBUG_ENABLED
+	ds = p_ds;
+	if (parse_message_handlers.is_empty()) {
+		_init_parse_message_handlers();
+	}
+	EngineDebugger::register_message_capture("embed", EngineDebugger::Capture(this, EmbeddedDebugger::parse_message));
+#endif
+}
+
+EmbeddedDebugger::~EmbeddedDebugger() {
+	singleton = nullptr;
+}
+
+void EmbeddedDebugger::initialize(DisplayServerEmbedded *p_ds) {
+	if (EngineDebugger::is_active()) {
+		memnew(EmbeddedDebugger(p_ds));
+	}
+}
+
+void EmbeddedDebugger::deinitialize() {
+	if (singleton) {
+		memdelete(singleton);
+	}
+}
+
+#ifdef DEBUG_ENABLED
+void EmbeddedDebugger::_init_parse_message_handlers() {
+	parse_message_handlers["window_size"] = &EmbeddedDebugger::_msg_window_size;
+	parse_message_handlers["mouse_set_mode"] = &EmbeddedDebugger::_msg_mouse_set_mode;
+	parse_message_handlers["event"] = &EmbeddedDebugger::_msg_event;
+	parse_message_handlers["win_event"] = &EmbeddedDebugger::_msg_win_event;
+	parse_message_handlers["ime_update"] = &EmbeddedDebugger::_msg_ime_update;
+	parse_message_handlers["joy_add"] = &EmbeddedDebugger::_msg_joy_add;
+	parse_message_handlers["joy_del"] = &EmbeddedDebugger::_msg_joy_del;
+}
+
+Error EmbeddedDebugger::_msg_window_size(const Array &p_args) {
+	Size2i size = p_args[0];
+	ds->window_set_size(size);
+	return OK;
+}
+
+Error EmbeddedDebugger::_msg_mouse_set_mode(const Array &p_args) {
+	DisplayServer::MouseMode mode = p_args[0];
+	ds->mouse_set_mode(mode);
+	return OK;
+}
+
+Error EmbeddedDebugger::_msg_event(const Array &p_args) {
+	Input *input = Input::get_singleton();
+	if (!input) {
+		// Ignore if we've received an event before the process has initialized.
+		return OK;
+	}
+
+	PackedByteArray data = p_args[0];
+	Ref<InputEvent> event;
+	decode_input_event(data, event);
+
+	{
+		Ref<InputEventMouse> e = event;
+		if (e.is_valid()) {
+			input->set_mouse_position(e->get_position());
+		}
+	}
+
+	{
+		Ref<InputEventMagnifyGesture> e = event;
+		if (e.is_valid()) {
+			input->set_mouse_position(e->get_position());
+		}
+	}
+
+	{
+		Ref<InputEventPanGesture> e = event;
+		if (e.is_valid()) {
+			input->set_mouse_position(e->get_position());
+		}
+	}
+
+	if (event.is_valid()) {
+		input->parse_input_event(event);
+	}
+
+	return OK;
+}
+
+Error EmbeddedDebugger::_msg_win_event(const Array &p_args) {
+	DisplayServer::WindowEvent win_event = p_args[0];
+	ds->send_window_event(win_event, DisplayServer::MAIN_WINDOW_ID);
+	if (win_event == DisplayServer::WindowEvent::WINDOW_EVENT_MOUSE_EXIT) {
+		Input::get_singleton()->release_pressed_events();
+	}
+	return OK;
+}
+
+Error EmbeddedDebugger::_msg_ime_update(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 2, ERR_INVALID_PARAMETER, "Invalid number of arguments for 'ime_update' message.");
+	String ime_text = p_args[0];
+	Vector2i ime_selection = p_args[1];
+	ds->update_im_text(ime_selection, ime_text);
+	return OK;
+}
+
+Error EmbeddedDebugger::_msg_joy_add(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 2, ERR_INVALID_PARAMETER, "Invalid number of arguments for 'joy_add' message.");
+	int idx = p_args[0];
+	String name = p_args[1];
+	ds->joy_add(idx, name);
+	return OK;
+}
+
+Error EmbeddedDebugger::_msg_joy_del(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, ERR_INVALID_PARAMETER, "Invalid number of arguments for 'joy_del' message.");
+	int idx = p_args[0];
+	ds->joy_del(idx);
+	return OK;
+}
+
+Error EmbeddedDebugger::parse_message(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured) {
+	EmbeddedDebugger *self = static_cast<EmbeddedDebugger *>(p_user);
+	r_captured = true;
+
+	ParseMessageFunc *fn_ptr = parse_message_handlers.getptr(p_msg);
+	if (fn_ptr) {
+		return (self->**fn_ptr)(p_args);
+	} else {
+		// Any other messages with this prefix should be ignored.
+		WARN_PRINT("Unknown message: " + p_msg);
+		return ERR_SKIP;
+	}
+}
+#endif

--- a/platform/macos/embedded_gl_manager.mm
+++ b/platform/macos/embedded_gl_manager.mm
@@ -1,0 +1,271 @@
+/**************************************************************************/
+/*  embedded_gl_manager.mm                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#import "embedded_gl_manager.h"
+
+#import "drivers/gles3/storage/texture_storage.h"
+#import "platform_gl.h"
+
+#if defined(MACOS_ENABLED) && defined(GLES3_ENABLED)
+
+#import <QuartzCore/QuartzCore.h>
+#include <dlfcn.h>
+
+GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations") // OpenGL is deprecated in macOS 10.14.
+
+Error GLManagerEmbedded::create_context(GLWindow &p_win) {
+	NSOpenGLPixelFormatAttribute attributes[] = {
+		NSOpenGLPFADoubleBuffer,
+		NSOpenGLPFAClosestPolicy,
+		NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core,
+		NSOpenGLPFAColorSize, 32,
+		NSOpenGLPFADepthSize, 24,
+		NSOpenGLPFAStencilSize, 8,
+		0
+	};
+
+	NSOpenGLPixelFormat *pixel_format = [[NSOpenGLPixelFormat alloc] initWithAttributes:attributes];
+	ERR_FAIL_NULL_V(pixel_format, ERR_CANT_CREATE);
+
+	p_win.context = [[NSOpenGLContext alloc] initWithFormat:pixel_format shareContext:shared_context];
+	ERR_FAIL_NULL_V(p_win.context, ERR_CANT_CREATE);
+	if (shared_context == nullptr) {
+		shared_context = p_win.context;
+	}
+
+	[p_win.context makeCurrentContext];
+
+	return OK;
+}
+
+Error GLManagerEmbedded::window_create(DisplayServer::WindowID p_window_id, CALayer *p_layer, int p_width, int p_height) {
+	GLWindow win;
+	win.layer = p_layer;
+	win.width = 0;
+	win.height = 0;
+
+	if (create_context(win) != OK) {
+		return FAILED;
+	}
+
+	windows[p_window_id] = win;
+	window_make_current(p_window_id);
+
+	return OK;
+}
+
+void GLManagerEmbedded::window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height) {
+	GLWindowElement *el = windows.find(p_window_id);
+	ERR_FAIL_NULL_MSG(el, "Window resize failed: window does not exist.");
+
+	GLWindow &win = el->get();
+
+	if (win.width == (uint32_t)p_width && win.height == (uint32_t)p_height) {
+		return;
+	}
+
+	win.width = (uint32_t)p_width;
+	win.height = (uint32_t)p_height;
+
+	win.destroy_framebuffers();
+
+	for (FrameBuffer &fb : win.framebuffers) {
+		NSDictionary *surfaceProps = @{
+			(NSString *)kIOSurfaceWidth : @(p_width),
+			(NSString *)kIOSurfaceHeight : @(p_height),
+			(NSString *)kIOSurfaceBytesPerElement : @(4),
+			(NSString *)kIOSurfacePixelFormat : @(kCVPixelFormatType_32BGRA),
+		};
+		fb.surface = IOSurfaceCreate((__bridge CFDictionaryRef)surfaceProps);
+		if (fb.surface == nullptr) {
+			ERR_PRINT(vformat("Failed to create IOSurface: width=%d, height=%d", p_width, p_height));
+			win.destroy_framebuffers();
+			return;
+		}
+
+		glGenTextures(1, &fb.tex);
+		glBindTexture(GL_TEXTURE_RECTANGLE, fb.tex);
+
+		glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+		CGLError err = CGLTexImageIOSurface2D(CGLGetCurrentContext(),
+				GL_TEXTURE_RECTANGLE,
+				GL_RGBA,
+				p_width,
+				p_height,
+				GL_BGRA,
+				GL_UNSIGNED_INT_8_8_8_8_REV,
+				fb.surface,
+				0);
+		if (err != kCGLNoError) {
+			String err_string = String(CGLErrorString(err));
+			ERR_PRINT(vformat("CGLTexImageIOSurface2D failed (%d): %s", err, err_string));
+			win.destroy_framebuffers();
+			return;
+		}
+
+		glGenFramebuffers(1, &fb.fbo);
+		glBindFramebuffer(GL_FRAMEBUFFER, fb.fbo);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE, fb.tex, 0);
+
+		if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+			ERR_PRINT("Unable to create framebuffer from IOSurface texture.");
+			win.destroy_framebuffers();
+			return;
+		}
+
+		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		glBindTexture(GL_TEXTURE_RECTANGLE, 0);
+	}
+	win.current_fb = 0;
+	GLES3::TextureStorage::system_fbo = win.framebuffers[win.current_fb].fbo;
+	win.is_valid = true;
+}
+
+void GLManagerEmbedded::GLWindow::destroy_framebuffers() {
+	is_valid = false;
+	GLES3::TextureStorage::system_fbo = 0;
+
+	for (FrameBuffer &fb : framebuffers) {
+		if (fb.fbo) {
+			glDeleteFramebuffers(1, &fb.fbo);
+			fb.fbo = 0;
+		}
+
+		if (fb.tex) {
+			glDeleteTextures(1, &fb.tex);
+			fb.tex = 0;
+		}
+
+		if (fb.surface) {
+			IOSurfaceRef old_surface = fb.surface;
+			fb.surface = nullptr;
+			CFRelease(old_surface);
+		}
+	}
+}
+
+Size2i GLManagerEmbedded::window_get_size(DisplayServer::WindowID p_window_id) const {
+	const GLWindowElement *el = windows.find(p_window_id);
+	if (el == nullptr) {
+		return Size2i();
+	}
+
+	const GLWindow &win = el->value();
+	return Size2i(win.width, win.height);
+}
+
+void GLManagerEmbedded::window_destroy(DisplayServer::WindowID p_window_id) {
+	GLWindowElement *el = windows.find(p_window_id);
+	if (el == nullptr) {
+		return;
+	}
+
+	if (current_window == p_window_id) {
+		current_window = DisplayServer::INVALID_WINDOW_ID;
+	}
+
+	windows.erase(el);
+}
+
+void GLManagerEmbedded::release_current() {
+	if (current_window == DisplayServer::INVALID_WINDOW_ID) {
+		return;
+	}
+
+	[NSOpenGLContext clearCurrentContext];
+	current_window = DisplayServer::INVALID_WINDOW_ID;
+}
+
+void GLManagerEmbedded::window_make_current(DisplayServer::WindowID p_window_id) {
+	if (current_window == p_window_id) {
+		return;
+	}
+
+	const GLWindowElement *el = windows.find(p_window_id);
+	if (el == nullptr) {
+		return;
+	}
+
+	const GLWindow &win = el->value();
+	[win.context makeCurrentContext];
+
+	current_window = p_window_id;
+}
+
+void GLManagerEmbedded::swap_buffers() {
+	GLWindow &win = windows[current_window];
+	[win.context flushBuffer];
+
+	static bool last_valid = false;
+	if (!win.is_valid) {
+		if (last_valid) {
+			ERR_PRINT("GLWindow framebuffers are invalid.");
+			last_valid = false;
+		}
+		return;
+	}
+	last_valid = true;
+
+	[CATransaction begin];
+	[CATransaction setDisableActions:YES];
+	win.layer.contents = (__bridge id)win.framebuffers[win.current_fb].surface;
+	[CATransaction commit];
+	win.current_fb = (win.current_fb + 1) % BUFFER_COUNT;
+	GLES3::TextureStorage::system_fbo = win.framebuffers[win.current_fb].fbo;
+}
+
+Error GLManagerEmbedded::initialize() {
+	return framework_loaded ? OK : ERR_CANT_CREATE;
+}
+
+GLManagerEmbedded::GLManagerEmbedded() {
+	NSBundle *framework = [NSBundle bundleWithIdentifier:@"com.apple.opengl"];
+	if ([framework load]) {
+		void *library_handle = dlopen([framework.executablePath UTF8String], RTLD_NOW);
+		if (library_handle) {
+			CGLGetCurrentContext = (CGLGetCurrentContextPtr)dlsym(library_handle, "CGLGetCurrentContext");
+			CGLTexImageIOSurface2D = (CGLTexImageIOSurface2DPtr)dlsym(library_handle, "CGLTexImageIOSurface2D");
+			CGLErrorString = (CGLErrorStringPtr)dlsym(library_handle, "CGLErrorString");
+			framework_loaded = CGLGetCurrentContext && CGLTexImageIOSurface2D && CGLErrorString;
+		}
+	}
+}
+
+GLManagerEmbedded::~GLManagerEmbedded() {
+	release_current();
+}
+
+GODOT_CLANG_WARNING_POP
+
+#endif // MACOS_ENABLED && GLES3_ENABLED

--- a/platform/macos/godot_application.mm
+++ b/platform/macos/godot_application.mm
@@ -31,8 +31,45 @@
 #import "godot_application.h"
 
 #import "display_server_macos.h"
+#import "godot_application_delegate.h"
+#import "os_macos.h"
+
+GodotApplication *GodotApp = nil;
+
+@interface GodotApplication ()
+- (void)forceUnbundledWindowActivationHackStep1;
+- (void)forceUnbundledWindowActivationHackStep2;
+- (void)forceUnbundledWindowActivationHackStep3;
+@end
 
 @implementation GodotApplication
+
+- (GodotApplication *)init {
+	self = [super init];
+
+	GodotApp = self;
+
+	return self;
+}
+
+- (GodotApplicationDelegate *)godotDelegate {
+	return (GodotApplicationDelegate *)self.delegate;
+}
+
+- (void)activateApplication {
+	[NSApp activateIgnoringOtherApps:YES];
+	NSString *nsappname = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];
+	const char *bundled_id = getenv("__CFBundleIdentifier");
+	NSString *nsbundleid_env = [NSString stringWithUTF8String:(bundled_id != nullptr) ? bundled_id : ""];
+	NSString *nsbundleid = [[NSBundle mainBundle] bundleIdentifier];
+	if (nsappname == nil || isatty(STDOUT_FILENO) || isatty(STDIN_FILENO) || isatty(STDERR_FILENO) || ![nsbundleid isEqualToString:nsbundleid_env]) {
+#if DEV_ENABLED
+		if (!OS_MacOS::is_debugger_attached())
+#endif
+			// If the executable is started from terminal or is not bundled, macOS WindowServer won't register and activate app window correctly (menu and title bar are grayed out and input ignored).
+			[self performSelector:@selector(forceUnbundledWindowActivationHackStep1) withObject:nil afterDelay:0.02];
+	}
+}
 
 - (void)mediaKeyEvent:(int)key state:(BOOL)state repeat:(BOOL)repeat {
 	Key keycode = Key::NONE;
@@ -127,6 +164,30 @@
 	} else {
 		[super sendEvent:event];
 	}
+}
+
+- (void)forceUnbundledWindowActivationHackStep1 {
+	// Step 1: Switch focus to macOS SystemUIServer process.
+	// Required to perform step 2, TransformProcessType will fail if app is already the in focus.
+	for (NSRunningApplication *app in [NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.apple.systemuiserver"]) {
+		[app activateWithOptions:NSApplicationActivateIgnoringOtherApps];
+		break;
+	}
+	[self performSelector:@selector(forceUnbundledWindowActivationHackStep2)
+			   withObject:nil
+			   afterDelay:0.02];
+}
+
+- (void)forceUnbundledWindowActivationHackStep2 {
+	// Step 2: Register app as foreground process.
+	ProcessSerialNumber psn = { 0, kCurrentProcess };
+	(void)TransformProcessType(&psn, kProcessTransformToForegroundApplication);
+	[self performSelector:@selector(forceUnbundledWindowActivationHackStep3) withObject:nil afterDelay:0.02];
+}
+
+- (void)forceUnbundledWindowActivationHackStep3 {
+	// Step 3: Switch focus back to app window.
+	[[NSRunningApplication currentApplication] activateWithOptions:NSApplicationActivateIgnoringOtherApps];
 }
 
 @end

--- a/platform/macos/godot_application_delegate.h
+++ b/platform/macos/godot_application_delegate.h
@@ -35,18 +35,12 @@
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
 
-@interface GodotApplicationDelegate : NSObject <NSUserInterfaceItemSearching, NSApplicationDelegate> {
-	bool high_contrast;
-	bool reduce_motion;
-	bool reduce_transparency;
-	bool voice_over;
-}
+class OS_MacOS_NSApp;
 
-- (void)forceUnbundledWindowActivationHackStep1;
-- (void)forceUnbundledWindowActivationHackStep2;
-- (void)forceUnbundledWindowActivationHackStep3;
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context;
-- (void)accessibilityDisplayOptionsChange:(NSNotification *)notification;
+@interface GodotApplicationDelegate : NSObject <NSUserInterfaceItemSearching, NSApplicationDelegate>
+
+- (GodotApplicationDelegate *)initWithOS:(OS_MacOS_NSApp *)os;
+
 - (bool)getHighContrast;
 - (bool)getReduceMotion;
 - (bool)getReduceTransparency;

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -31,6 +31,7 @@
 #import "godot_content_view.h"
 
 #import "display_server_macos.h"
+#import "godot_window.h"
 #import "key_mapping_macos.h"
 
 #include "main/main.h"
@@ -153,7 +154,12 @@
 // MARK: Backing Layer
 
 - (CALayer *)makeBackingLayer {
-	return [[CAMetalLayer class] layer];
+	CAMetalLayer *layer = [CAMetalLayer new];
+	layer.edgeAntialiasingMask = 0;
+	layer.masksToBounds = NO;
+	layer.presentsWithTransaction = NO;
+	[layer removeAllAnimations];
+	return layer;
 }
 
 - (BOOL)wantsUpdateLayer {

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -30,9 +30,9 @@
 
 #import "os_macos.h"
 
-#include "main/main.h"
+#import "godot_application.h"
 
-#include <unistd.h>
+#include "main/main.h"
 
 #if defined(SANITIZERS_ENABLED)
 #include <sys/resource.h>
@@ -50,20 +50,74 @@ int main(int argc, char **argv) {
 	setrlimit(RLIMIT_STACK, &stack_lim);
 #endif
 
-	int first_arg = 1;
-	const char *dbg_arg = "-NSDocumentRevisionsDebugMode";
+	LocalVector<char *> args;
+	args.resize(argc);
+	uint32_t argsc = 0;
+
+	int wait_for_debugger = 0; // wait 5 second by default
+	bool is_embedded = false;
+
 	for (int i = 0; i < argc; i++) {
-		if (strcmp(dbg_arg, argv[i]) == 0) {
-			first_arg = i + 2;
+		if (strcmp("-NSDocumentRevisionsDebugMode", argv[i]) == 0) {
+			// remove "-NSDocumentRevisionsDebugMode" and the next argument
+			continue;
 		}
+
+		if (strcmp("--os-debug", argv[i]) == 0) {
+			i++;
+			wait_for_debugger = 5000; // wait 5 seconds by default
+			if (i < argc && strncmp(argv[i], "--", 2) != 0) {
+				wait_for_debugger = atoi(argv[i]);
+			}
+			continue;
+		}
+
+		if (strcmp("--embedded", argv[i]) == 0) {
+			is_embedded = true;
+			continue;
+		}
+
+		args.ptr()[argsc] = argv[i];
+		argsc++;
 	}
 
-	OS_MacOS os(argv[0], argc - first_arg, &argv[first_arg]);
+	uint32_t remaining_args = argsc - 1;
+
+	OS_MacOS *os = nullptr;
+	if (is_embedded) {
+#ifdef DEBUG_ENABLED
+		os = memnew(OS_MacOS_Embedded(args[0], remaining_args, remaining_args > 0 ? &args[1] : nullptr));
+#else
+		WARN_PRINT("Embedded mode is not supported in release builds.");
+		return EXIT_FAILURE;
+#endif
+	} else {
+		os = memnew(OS_MacOS_NSApp(args[0], remaining_args, remaining_args > 0 ? &args[1] : nullptr));
+	}
+
+#ifdef TOOLS_ENABLED
+	if (wait_for_debugger > 0) {
+		os->wait_for_debugger(wait_for_debugger);
+		print_verbose("Continuing execution.");
+	}
+#else
+	if (wait_for_debugger > 0) {
+		WARN_PRINT("--os-debug is not supported in release builds.");
+	}
+#endif
+
+	if (is_embedded) {
+		// No dock icon for the embedded process, as it is hosted in the Godot editor.
+		ProcessSerialNumber psn = { 0, kCurrentProcess };
+		(void)TransformProcessType(&psn, kProcessTransformToBackgroundApplication);
+	}
 
 	// We must override main when testing is enabled.
 	TEST_MAIN_OVERRIDE
 
-	os.run(); // Note: This function will never return.
+	os->run();
 
-	return os.get_exit_code();
+	memdelete(os);
+
+	return os->get_exit_code();
 }

--- a/platform/macos/godot_window_delegate.mm
+++ b/platform/macos/godot_window_delegate.mm
@@ -32,6 +32,7 @@
 
 #import "display_server_macos.h"
 #import "godot_button_view.h"
+#import "godot_content_view.h"
 #import "godot_window.h"
 
 @implementation GodotWindowDelegate
@@ -307,7 +308,7 @@
 	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
 
 	if (wd.window_button_view) {
-		[(GodotButtonView *)wd.window_button_view displayButtons];
+		[wd.window_button_view displayButtons];
 	}
 
 	if (ds->mouse_get_mode() == DisplayServer::MOUSE_MODE_CAPTURED) {
@@ -339,7 +340,7 @@
 	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
 
 	if (wd.window_button_view) {
-		[(GodotButtonView *)wd.window_button_view displayButtons];
+		[wd.window_button_view displayButtons];
 	}
 
 	wd.focused = false;

--- a/platform/macos/macos_quartz_core_spi.h
+++ b/platform/macos/macos_quartz_core_spi.h
@@ -1,0 +1,94 @@
+/**************************************************************************/
+/*  macos_quartz_core_spi.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+// Copyright 2014 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+#import <Quartz/Quartz.h>
+
+#include <stdint.h>
+
+// https://chromium.googlesource.com/chromium/src/+/refs/heads/main/ui/base/cocoa/remote_layer_api.h
+
+// The CAContextID type identifies a CAContext across processes. This is the
+// token that is passed from the process that is sharing the CALayer that it is
+// rendering to the process that will be displaying that CALayer.
+typedef uint32_t CAContextID;
+
+// The CAContext has a static CAContextID which can be sent to another process.
+// When a CALayerHost is created using that CAContextID in another process, the
+// content displayed by that CALayerHost will be the content of the CALayer
+// that is set as the |layer| property on the CAContext.
+@interface CAContext : NSObject
++ (instancetype)contextWithCGSConnection:(CAContextID)contextId options:(NSDictionary *)optionsDict;
+@property(readonly) CAContextID contextId;
+@property(retain) CALayer *layer;
+@end
+
+// The CALayerHost is created in the process that will display the content
+// being rendered by another process. Setting the |contextId| property on
+// an object of this class will make this layer display the content of the
+// CALayer that is set to the CAContext with that CAContextID in the layer
+// sharing process.
+@interface CALayerHost : CALayer
+@property CAContextID contextId;
+@end
+
+// The CGSConnectionID is used to create the CAContext in the process that is
+// going to share the CALayers that it is rendering to another process to
+// display.
+typedef uint32_t CGSConnectionID;
+extern "C" CGSConnectionID CGSMainConnectionID(void);
+
+extern "C" NSString *const kCAContextCIFilterBehavior;


### PR DESCRIPTION
Embedded window support for macOS.

This feature is implemented using `CARemoteLayer`, which is similar to how we implemented it for OpenEmu. This works by creating a CALayer in the child process and passing the CAContextID back to the Godot Editor. The editor is then able to create an instance of `CARemoteLayer` and display the rendered output in real-time, as if it was hosted in the app. A major difference is that we serialise the events from the host app, the Godot Editor, and process them in the running game.

The following additional state / events are processed correctly:

- [x] Joystick add / remove events must be sent to the child process

https://github.com/user-attachments/assets/43aa5846-1565-46ad-8fb7-bbf2315ba638

- [x] Joystick rumble timestamps (can't demonstrate that in a video)
- DisplayDriver events
  - [x] cursor changes within embedded window

https://github.com/user-attachments/assets/fb1cc98f-4259-4cc9-ba92-4ff2210e74f5

  - [x] IME events

https://github.com/user-attachments/assets/58f6d80f-f19a-42ca-94aa-eb6761ce3a43

- [x] OpenGL Support, selection, panning, and more

https://github.com/user-attachments/assets/1ae09395-50c6-4263-8e3b-8435553face3

- [x] Mouse Capture and `⌥+ESC` shortcut, always available to the editor, to release capture

https://github.com/user-attachments/assets/f120c280-3758-438f-b42b-505708ea3a1a


___

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/11453.*