### PR TITLE
Core: Modernize C headers with C++ equivalents

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 Checks:
   - -*
   - cppcoreguidelines-pro-type-member-init
+  - modernize-deprecated-headers
   - modernize-redundant-void-arg
   - modernize-use-bool-literals
   - modernize-use-default-member-init
@@ -14,6 +15,7 @@ FormatStyle: file
 CheckOptions:
   cppcoreguidelines-pro-type-member-init.IgnoreArrays: true
   cppcoreguidelines-pro-type-member-init.UseAssignment: true
+  modernize-deprecated-headers.CheckHeaderFile: true
   modernize-use-bool-literals.IgnoreMacros: false
   modernize-use-default-member-init.IgnoreMacros: false
   modernize-use-default-member-init.UseAssignment: true

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -43,8 +43,6 @@
 #include "core/variant/variant.h"
 #include "core/version.h"
 
-#include <string.h>
-
 class CallableCustomExtension : public CallableCustom {
 	void *userdata;
 	void *token;

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -34,15 +34,16 @@
  * Together with the JSON file, you should be able to generate any binder.
  */
 
+#ifndef __cplusplus
 #include <stddef.h>
 #include <stdint.h>
 
-#ifndef __cplusplus
 typedef uint32_t char32_t;
 typedef uint16_t char16_t;
-#endif
+#else
+#include <cstddef>
+#include <cstdint>
 
-#ifdef __cplusplus
 extern "C" {
 #endif
 

--- a/core/io/ip_address.cpp
+++ b/core/io/ip_address.cpp
@@ -34,8 +34,6 @@ IPAddress::operator Variant() const {
 	return operator String();
 }*/
 
-#include <string.h>
-
 IPAddress::operator String() const {
 	if (wildcard) {
 		return "*";

--- a/core/io/logger.h
+++ b/core/io/logger.h
@@ -35,7 +35,7 @@
 #include "core/string/ustring.h"
 #include "core/templates/vector.h"
 
-#include <stdarg.h>
+#include <cstdarg>
 
 class RegEx;
 

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -35,8 +35,8 @@
 #include "core/object/script_language.h"
 #include "core/variant/container_type_validate.h"
 
-#include <limits.h>
-#include <stdio.h>
+#include <climits>
+#include <cstdio>
 
 void EncodedObjectAsID::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_object_id", "id"), &EncodedObjectAsID::set_object_id);

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -43,7 +43,8 @@
 #include "core/math/vector3.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/pooled_list.h"
-#include <limits.h>
+
+#include <climits>
 
 #define BVHABB_CLASS BVH_ABB<BOUNDS, POINT>
 

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -88,7 +88,7 @@ subject to the following restrictions:
 #endif
 
 #if defined(DEBUG_CONVEX_HULL) || defined(SHOW_ITERATIONS)
-#include <stdio.h>
+#include <cstdio>
 #endif
 
 // Convex hull implementation based on Preparata and Hong

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -34,7 +34,7 @@
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 #ifdef DEV_ENABLED
 // Includes safety checks to ensure that a queue set as a thread singleton override

--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -32,8 +32,7 @@
 
 #include "core/templates/safe_refcount.h"
 
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
 
 void *operator new(size_t p_size, const char *p_description) {
 	return Memory::alloc_static(p_size, false);

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -33,7 +33,6 @@
 #include "core/error/error_macros.h"
 #include "core/templates/safe_refcount.h"
 
-#include <cstring>
 #include <new> // IWYU pragma: keep // `new` operators.
 #include <type_traits>
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -37,7 +37,7 @@
 #include "core/os/midi_driver.h"
 #include "core/version_generated.gen.h"
 
-#include <stdarg.h>
+#include <cstdarg>
 
 #ifdef MINGW_ENABLED
 #define MINGW_STDTHREAD_REDUNDANCY_WARNING

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -38,7 +38,7 @@
 #include "core/templates/list.h"
 #include "core/templates/vector.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 
 class OS {
 	static OS *singleton;

--- a/core/os/time.cpp
+++ b/core/os/time.cpp
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "time.h"
+#include "time.h" // NOLINT(modernize-deprecated-headers) False positive with C-Header of the same name.
 
 #include "core/os/os.h"
 

--- a/core/string/string_builder.cpp
+++ b/core/string/string_builder.cpp
@@ -30,8 +30,6 @@
 
 #include "string_builder.h"
 
-#include <string.h>
-
 StringBuilder &StringBuilder::append(const String &p_string) {
 	if (p_string.is_empty()) {
 		return *this;

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -35,7 +35,6 @@
 #include "core/templates/safe_refcount.h"
 #include "core/templates/span.h"
 
-#include <string.h>
 #include <initializer_list>
 #include <type_traits>
 

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -37,7 +37,7 @@
 #include "core/templates/rid.h"
 #include "core/templates/safe_refcount.h"
 
-#include <stdio.h>
+#include <cstdio>
 #include <typeinfo> // IWYU pragma: keep // Used in macro.
 
 #ifdef SANITIZERS_ENABLED

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -50,6 +50,7 @@ static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <utility>
 
 // IWYU pragma: end_exports

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -40,7 +40,7 @@
 #include "core/variant/variant.h"
 #include "core/variant/variant_internal.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 // Variant cannot define an implicit cast operator for every Object subclass, so the
 // casting is done here, to allow binding methods with parameters more specific than Object *

--- a/core/version.h
+++ b/core/version.h
@@ -32,7 +32,7 @@
 
 #include "core/version_generated.gen.h" // IWYU pragma: export
 
-#include <stdint.h>
+#include <stdint.h> // NOLINT(modernize-deprecated-headers) FIXME: MinGW compilation fails when changing to C++ Header.
 
 // Copied from typedefs.h to stay lean.
 #ifndef _STR

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -35,7 +35,7 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 
-#include <errno.h>
+#include <cerrno>
 
 #if defined(PULSEAUDIO_ENABLED) && defined(SOWRAP_ENABLED)
 extern "C" {

--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -34,7 +34,7 @@
 
 #include "core/os/os.h"
 
-#include <errno.h>
+#include <cerrno>
 
 MIDIDriverALSAMidi::InputConnection::InputConnection(int p_device_index,
 		snd_rawmidi_t *p_rawmidi) :

--- a/drivers/coremidi/midi_driver_coremidi.h
+++ b/drivers/coremidi/midi_driver_coremidi.h
@@ -37,7 +37,7 @@
 #include "core/templates/vector.h"
 
 #import <CoreMIDI/CoreMIDI.h>
-#include <stdio.h>
+#include <cstdio>
 
 class MIDIDriverCoreMidi : public MIDIDriver {
 	MIDIClientRef client = 0;

--- a/drivers/d3d12/d3d12_godot_nir_bridge.h
+++ b/drivers/d3d12/d3d12_godot_nir_bridge.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -32,8 +32,6 @@
 
 #include "drivers/png/png_driver_common.h"
 
-#include <string.h>
-
 Error ImageLoaderPNG::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	const uint64_t buffer_size = f->get_length();
 	Vector<uint8_t> file_buffer;

--- a/drivers/png/png_driver_common.cpp
+++ b/drivers/png/png_driver_common.cpp
@@ -33,7 +33,6 @@
 #include "core/config/engine.h"
 
 #include <png.h>
-#include <string.h>
 
 namespace PNGDriverCommon {
 

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -37,14 +37,13 @@
 #include "core/string/print_string.h"
 #include "core/templates/list.h"
 
-#include <errno.h>
 #include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
 
 #if __has_include(<mntent.h>)
 #include <mntent.h>

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -35,15 +35,15 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 
-#include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cerrno>
 
 #if defined(TOOLS_ENABLED)
-#include <limits.h>
-#include <stdlib.h>
+#include <climits>
+#include <cstdlib>
 #endif
 
 void FileAccessUnix::check_errors(bool p_write) const {

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -33,7 +33,7 @@
 #include "core/io/file_access.h"
 #include "core/os/memory.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 #if defined(UNIX_ENABLED)
 

--- a/drivers/unix/file_access_unix_pipe.cpp
+++ b/drivers/unix/file_access_unix_pipe.cpp
@@ -35,12 +35,12 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 
-#include <errno.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cerrno>
 
 Error FileAccessUnixPipe::open_existing(int p_rfd, int p_wfd, bool p_blocking) {
 	// Open pipe using handles created by pipe(fd) call in the OS.execute_with_pipe.

--- a/drivers/unix/file_access_unix_pipe.h
+++ b/drivers/unix/file_access_unix_pipe.h
@@ -33,7 +33,7 @@
 #include "core/io/file_access.h"
 #include "core/os/memory.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 #if defined(UNIX_ENABLED)
 

--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -54,8 +54,6 @@
 
 #include <net/if.h> // Order is important on OpenBSD, leave as last.
 
-#include <string.h>
-
 static IPAddress _sockaddr2ip(struct sockaddr *p_addr) {
 	IPAddress ip;
 

--- a/drivers/unix/net_socket_unix.cpp
+++ b/drivers/unix/net_socket_unix.cpp
@@ -34,19 +34,18 @@
 
 #include "net_socket_unix.h"
 
-#include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <poll.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
 
 #ifdef WEB_ENABLED
 #include <arpa/inet.h>

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -69,19 +69,18 @@
 #endif
 
 #include <dlfcn.h>
-#include <errno.h>
 #include <poll.h>
-#include <signal.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/wait.h>
-#include <time.h>
 #include <unistd.h>
+#include <cerrno>
+#include <csignal>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
 
 #ifndef RTLD_DEEPBIND
 #define RTLD_DEEPBIND 0

--- a/drivers/vulkan/godot_vulkan.h
+++ b/drivers/vulkan/godot_vulkan.h
@@ -33,7 +33,7 @@
 #ifdef USE_VOLK
 #include <volk.h>
 #else
-#include <stdint.h>
+#include <cstdint>
 #define VK_NO_STDINT_H
 #include <vulkan/vulkan.h>
 #endif

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -38,8 +38,8 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 
-#include <stdio.h>
-#include <wchar.h>
+#include <cstdio>
+#include <cwchar>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -41,12 +41,12 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-#include <errno.h>
 #include <io.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <tchar.h>
-#include <wchar.h>
+#include <cerrno>
+#include <cwchar>
 
 #ifdef _MSC_VER
 #define S_ISREG(m) ((m) & _S_IFREG)

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -35,7 +35,7 @@
 #include "core/io/file_access.h"
 #include "core/os/memory.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 class FileAccessWindows : public FileAccess {
 	GDSOFTCLASS(FileAccessWindows, FileAccess);

--- a/drivers/windows/ip_windows.cpp
+++ b/drivers/windows/ip_windows.cpp
@@ -39,9 +39,7 @@
 
 #include <iphlpapi.h>
 
-#include <stdio.h>
-
-#include <string.h>
+#include <cstdio>
 
 static IPAddress _sockaddr2ip(struct sockaddr *p_addr) {
 	IPAddress ip;

--- a/drivers/winmidi/midi_driver_winmidi.h
+++ b/drivers/winmidi/midi_driver_winmidi.h
@@ -35,7 +35,7 @@
 #include "core/os/midi_driver.h"
 #include "core/templates/vector.h"
 
-#include <stdio.h>
+#include <cstdio>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -40,7 +40,7 @@
 #include "scene/gui/view_panner.h"
 #include "scene/resources/text_line.h"
 
-#include <limits.h>
+#include <climits>
 
 float AnimationBezierTrackEdit::_bezier_h_to_pixel(float p_h) {
 	float h = p_h;
@@ -1578,7 +1578,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (scaling_selection && mb.is_valid() && !read_only && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
-		if (abs(scaling_selection_scale.x - 1) > CMP_EPSILON || abs(scaling_selection_scale.y - 1) > CMP_EPSILON) {
+		if (std::abs(scaling_selection_scale.x - 1) > CMP_EPSILON || std::abs(scaling_selection_scale.y - 1) > CMP_EPSILON) {
 			// Scale it.
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 			undo_redo->create_action(TTR("Scale Bezier Points"));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -180,7 +180,7 @@
 #include "editor/gui/touch_actions_panel.h"
 #endif // ANDROID_ENABLED
 
-#include <stdlib.h>
+#include <cstdlib>
 
 EditorNode *EditorNode::singleton = nullptr;
 

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -77,8 +77,8 @@
 #define GLTF_IMPORT_DISCARD_MESHES_AND_MATERIALS 32
 #define GLTF_IMPORT_FORCE_DISABLE_MESH_COMPRESSION 64
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 constexpr int COMPONENT_COUNT_FOR_ACCESSOR_TYPE[7] = {
 	1, 2, 3, 4, 4, 9, 16

--- a/modules/jolt_physics/jolt_globals.cpp
+++ b/modules/jolt_physics/jolt_globals.cpp
@@ -42,7 +42,7 @@
 
 #include "Jolt/RegisterTypes.h"
 
-#include <stdarg.h>
+#include <cstdarg>
 
 void *jolt_alloc(size_t p_size) {
 	return Memory::alloc_static(p_size);

--- a/modules/jolt_physics/jolt_project_settings.h
+++ b/modules/jolt_physics/jolt_project_settings.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 enum JoltJointWorldNode : int {
 	JOLT_JOINT_WORLD_NODE_A,

--- a/modules/jolt_physics/spaces/jolt_broad_phase_layer.h
+++ b/modules/jolt_physics/spaces/jolt_broad_phase_layer.h
@@ -34,7 +34,7 @@
 
 #include "Jolt/Physics/Collision/BroadPhase/BroadPhaseLayer.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace JoltBroadPhaseLayer {
 

--- a/modules/jolt_physics/spaces/jolt_temp_allocator.h
+++ b/modules/jolt_physics/spaces/jolt_temp_allocator.h
@@ -34,7 +34,7 @@
 
 #include "Jolt/Core/TempAllocator.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 class JoltTempAllocator final : public JPH::TempAllocator {
 	uint64_t capacity = 0;

--- a/modules/jpg/image_loader_libjpeg_turbo.cpp
+++ b/modules/jpg/image_loader_libjpeg_turbo.cpp
@@ -32,8 +32,6 @@
 
 #include <turbojpeg.h>
 
-#include <string.h>
-
 Error jpeg_turbo_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p_buffer_len) {
 	tjhandle tj_instance = tj3Init(TJINIT_DECOMPRESS);
 	if (tj_instance == NULL) {

--- a/modules/mono/interop_types.h
+++ b/modules/mono/interop_types.h
@@ -36,9 +36,6 @@
 extern "C" {
 #endif
 
-#include <stdbool.h>
-#include <stdint.h>
-
 // This is taken from the old GDNative, which was removed.
 
 #define GODOT_VARIANT_SIZE (sizeof(real_t) * 4 + sizeof(int64_t))

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -35,7 +35,7 @@
 #include "core/io/file_access.h"
 #include "core/os/os.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #ifdef WINDOWS_ENABLED
 #define WIN32_LEAN_AND_MEAN
@@ -43,8 +43,8 @@
 
 #define ENV_PATH_SEP ";"
 #else
-#include <limits.h>
 #include <unistd.h>
+#include <climits>
 
 #define ENV_PATH_SEP ":"
 #endif

--- a/modules/mono/utils/string_utils.cpp
+++ b/modules/mono/utils/string_utils.cpp
@@ -32,8 +32,8 @@
 
 #include "core/io/file_access.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 namespace {
 

--- a/modules/mono/utils/string_utils.h
+++ b/modules/mono/utils/string_utils.h
@@ -33,7 +33,7 @@
 #include "core/string/ustring.h"
 #include "core/variant/variant.h"
 
-#include <stdarg.h>
+#include <cstdarg>
 
 String sformat(const String &p_text, const String &p1 = String(), const String &p2 = String(),
 		const String &p3 = String(), const String &p4 = String(), const String &p5 = String(), const String &p6 = String());

--- a/modules/text_server_adv/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_adv/thorvg_svg_in_ot.cpp
@@ -60,7 +60,7 @@ using namespace godot;
 #include <freetype/otsvg.h>
 #include <ft2build.h>
 
-#include <stdlib.h>
+#include <cstdlib>
 
 FT_Error tvg_svg_in_ot_init(FT_Pointer *p_state) {
 	*p_state = memnew(TVG_State);

--- a/modules/text_server_fb/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_fb/thorvg_svg_in_ot.cpp
@@ -60,7 +60,7 @@ using namespace godot;
 #include <freetype/otsvg.h>
 #include <ft2build.h>
 
-#include <stdlib.h>
+#include <cstdlib>
 
 FT_Error tvg_svg_in_ot_init(FT_Pointer *p_state) {
 	*p_state = memnew(TVG_State);

--- a/modules/upnp/upnp_miniupnp.cpp
+++ b/modules/upnp/upnp_miniupnp.cpp
@@ -37,7 +37,7 @@
 #include <miniupnpc/miniwget.h>
 #include <miniupnpc/upnpcommands.h>
 
-#include <stdlib.h>
+#include <cstdlib>
 
 void UPNPMiniUPNP::make_default() {
 	UPNP::_create = UPNPMiniUPNP::_create;

--- a/modules/webp/webp_common.cpp
+++ b/modules/webp/webp_common.cpp
@@ -35,8 +35,6 @@
 #include <webp/decode.h>
 #include <webp/encode.h>
 
-#include <string.h>
-
 namespace WebPCommon {
 Vector<uint8_t> _webp_lossy_pack(const Ref<Image> &p_image, float p_quality) {
 	ERR_FAIL_COND_V(p_image.is_null() || p_image->is_empty(), Vector<uint8_t>());

--- a/modules/webxr/godot_webxr.h
+++ b/modules/webxr/godot_webxr.h
@@ -34,8 +34,6 @@
 extern "C" {
 #endif
 
-#include <stddef.h>
-
 enum WebXRInputEvent {
 	WEBXR_INPUT_EVENT_SELECTSTART,
 	WEBXR_INPUT_EVENT_SELECTEND,

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -45,7 +45,7 @@
 #include "servers/xr/xr_hand_tracker.h"
 
 #include <emscripten.h>
-#include <stdlib.h>
+#include <cstdlib>
 
 void _emwebxr_on_session_supported(char *p_session_mode, int p_supported) {
 	XRServer *xr_server = XRServer::get_singleton();

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -30,8 +30,6 @@
 
 #include "audio_driver_opensl.h"
 
-#include <string.h>
-
 #define MAX_NUMBER_INTERFACES 3
 #define MAX_NUMBER_OUTPUT_DEVICES 6
 

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -35,7 +35,7 @@
 #include "core/io/dir_access.h"
 #include "drivers/unix/dir_access_unix.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 /// Android implementation of the DirAccess interface used to provide access to
 /// ACCESS_FILESYSTEM and ACCESS_RESOURCES directory resources.

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -61,8 +61,6 @@
 #include "../os_android.h"
 #endif
 
-#include <string.h>
-
 static const char *ANDROID_PERMS[] = {
 	"ACCESS_CHECKIN_PROPERTIES",
 	"ACCESS_COARSE_LOCATION",

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -35,7 +35,7 @@
 #include <android/asset_manager.h>
 #include <android/log.h>
 #include <jni.h>
-#include <stdio.h>
+#include <cstdio>
 
 class FileAccessAndroid : public FileAccess {
 	GDSOFTCLASS(FileAccessAndroid, FileAccess);

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -45,7 +45,6 @@
 #include "main/splash.gen.h"
 #include "scene/resources/image_texture.h"
 
-#include <string.h>
 #include <sys/stat.h>
 
 // Optional environment variables for defining confidential information. If any

--- a/platform/ios/godot_ios.mm
+++ b/platform/ios/godot_ios.mm
@@ -33,9 +33,8 @@
 #include "core/string/ustring.h"
 #include "main/main.h"
 
-#include <stdio.h>
-#include <string.h>
 #include <unistd.h>
+#include <cstdio>
 
 static OS_IOS *os = nullptr;
 

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -46,8 +46,8 @@
 #include <dlfcn.h>
 #include <execinfo.h>
 #include <link.h>
-#include <signal.h>
-#include <stdlib.h>
+#include <csignal>
+#include <cstdlib>
 
 static void handle_crash(int sig) {
 	signal(SIGSEGV, SIG_DFL);

--- a/platform/linuxbsd/freedesktop_screensaver.h
+++ b/platform/linuxbsd/freedesktop_screensaver.h
@@ -32,7 +32,7 @@
 
 #ifdef DBUS_ENABLED
 
-#include <stdint.h>
+#include <cstdint>
 
 class FreeDesktopScreenSaver {
 private:

--- a/platform/linuxbsd/godot_linuxbsd.cpp
+++ b/platform/linuxbsd/godot_linuxbsd.cpp
@@ -32,10 +32,10 @@
 
 #include "main/main.h"
 
-#include <limits.h>
-#include <locale.h>
-#include <stdlib.h>
 #include <unistd.h>
+#include <climits>
+#include <clocale>
+#include <cstdlib>
 
 #if defined(SANITIZERS_ENABLED)
 #include <sys/resource.h>

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -35,10 +35,10 @@
 #include "core/os/os.h"
 
 #include <dirent.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <linux/input.h>
 #include <unistd.h>
+#include <cerrno>
 
 #ifdef UDEV_ENABLED
 #ifdef SOWRAP_ENABLED

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -68,13 +68,12 @@
 #endif
 
 #include <dlfcn.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
 
 #if __has_include(<mntent.h>)
 #include <mntent.h>

--- a/platform/linuxbsd/platform_config.h
+++ b/platform/linuxbsd/platform_config.h
@@ -35,7 +35,7 @@
 #endif
 
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
-#include <stdlib.h> // alloca
+#include <cstdlib> // alloca
 // FreeBSD and OpenBSD use pthread_set_name_np, while other platforms,
 // include NetBSD, use pthread_setname_np. NetBSD's version however requires
 // a different format, we handle this directly in thread_posix.

--- a/platform/linuxbsd/wayland/detect_prime_egl.cpp
+++ b/platform/linuxbsd/wayland/detect_prime_egl.cpp
@@ -36,13 +36,10 @@
 #include "core/string/print_string.h"
 #include "core/string/ustring.h"
 
-#include <stdlib.h>
-
-#include <cstring>
-
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <cstdlib>
 
 // To prevent shadowing warnings.
 #undef glGetString

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -61,8 +61,8 @@
 #include "core/input/input.h"
 #include "servers/display_server.h"
 
-#include <limits.h>
-#include <stdio.h>
+#include <climits>
+#include <cstdio>
 
 #undef CursorShape
 

--- a/platform/linuxbsd/x11/detect_prime_x11.cpp
+++ b/platform/linuxbsd/x11/detect_prime_x11.cpp
@@ -46,11 +46,10 @@
 #include <X11/Xutil.h>
 #endif
 
-#include <stdlib.h>
-#include <string.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <cstdlib>
 
 #define GLX_CONTEXT_MAJOR_VERSION_ARB 0x2091
 #define GLX_CONTEXT_MINOR_VERSION_ARB 0x2092

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -58,13 +58,12 @@
 #endif
 
 #include <dlfcn.h>
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
 
 #undef CursorShape
 #include <X11/XKBlib.h>

--- a/platform/linuxbsd/x11/gl_manager_x11.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11.cpp
@@ -34,9 +34,9 @@
 
 #include "thirdparty/glad/glad/glx.h"
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
 
 #define GLX_CONTEXT_MAJOR_VERSION_ARB 0x2091
 #define GLX_CONTEXT_MINOR_VERSION_ARB 0x2092

--- a/platform/linuxbsd/x11/gl_manager_x11_egl.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11_egl.cpp
@@ -32,8 +32,8 @@
 
 #if defined(X11_ENABLED) && defined(GLES3_ENABLED)
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 const char *GLManagerEGL_X11::_get_platform_extension_name() const {
 	return "EGL_KHR_platform_x11";

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -37,7 +37,6 @@
 #include "core/version.h"
 #include "main/main.h"
 
-#include <string.h>
 #include <unistd.h>
 
 #if defined(DEBUG_ENABLED)
@@ -48,8 +47,8 @@
 #include <cxxabi.h>
 #include <dlfcn.h>
 #include <execinfo.h>
-#include <signal.h>
-#include <stdlib.h>
+#include <csignal>
+#include <cstdlib>
 
 #import <mach-o/dyld.h>
 #import <mach-o/getsect.h>

--- a/platform/macos/dir_access_macos.mm
+++ b/platform/macos/dir_access_macos.mm
@@ -34,7 +34,7 @@
 
 #include "core/config/project_settings.h"
 
-#include <errno.h>
+#include <cerrno>
 
 #import <AppKit/NSWorkspace.h>
 #import <Foundation/Foundation.h>

--- a/platform/macos/gl_manager_macos_angle.mm
+++ b/platform/macos/gl_manager_macos_angle.mm
@@ -32,8 +32,8 @@
 
 #if defined(MACOS_ENABLED) && defined(GLES3_ENABLED)
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #import <EGL/eglext_angle.h>
 

--- a/platform/macos/gl_manager_macos_legacy.mm
+++ b/platform/macos/gl_manager_macos_legacy.mm
@@ -33,8 +33,8 @@
 #if defined(MACOS_ENABLED) && defined(GLES3_ENABLED)
 
 #include <dlfcn.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations") // OpenGL is deprecated in macOS 10.14.
 

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -32,7 +32,6 @@
 
 #include "main/main.h"
 
-#include <string.h>
 #include <unistd.h>
 
 #if defined(SANITIZERS_ENABLED)

--- a/platform/web/godot_audio.h
+++ b/platform/web/godot_audio.h
@@ -30,12 +30,11 @@
 
 #pragma once
 
+#include <cstdint>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stddef.h>
-#include <stdint.h>
 
 extern int godot_audio_is_available();
 extern int godot_audio_has_worklet();

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -32,12 +32,11 @@
 
 #define WASM_EXPORT __attribute__((visibility("default")))
 
+#include <cstdint>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stddef.h>
-#include <stdint.h>
 
 // Config
 extern void godot_js_config_locale_get(char *p_ptr, int p_ptr_max);

--- a/platform/web/godot_midi.h
+++ b/platform/web/godot_midi.h
@@ -30,11 +30,12 @@
 
 #pragma once
 
+#include <cstdint>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <stdint.h>
 extern int godot_js_webmidi_open_midi_inputs(
 		void (*p_callback)(int p_size, const char **p_connected_input_names),
 		void (*p_on_midi_message)(int p_device_index, int p_status, const uint8_t *p_data, int p_data_len),

--- a/platform/web/http_client_web.h
+++ b/platform/web/http_client_web.h
@@ -36,8 +36,6 @@
 extern "C" {
 #endif
 
-#include <stddef.h>
-
 typedef enum {
 	GODOT_JS_FETCH_STATE_REQUESTING = 0,
 	GODOT_JS_FETCH_STATE_BODY = 1,

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -46,7 +46,7 @@
 
 #include <dlfcn.h>
 #include <emscripten.h>
-#include <stdlib.h>
+#include <cstdlib>
 
 void OS_Web::alert(const String &p_alert, const String &p_title) {
 	godot_js_display_alert(p_alert.utf8().get_data());

--- a/platform/web/web_main.cpp
+++ b/platform/web/web_main.cpp
@@ -43,7 +43,7 @@
 #endif
 
 #include <emscripten/emscripten.h>
-#include <stdlib.h>
+#include <cstdlib>
 
 static OS_Web *os = nullptr;
 #ifndef PROXY_TO_PTHREAD_ENABLED

--- a/platform/windows/console_wrapper_windows.cpp
+++ b/platform/windows/console_wrapper_windows.cpp
@@ -31,8 +31,8 @@
 #include <windows.h>
 
 #include <shlwapi.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
 #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x4

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -40,8 +40,8 @@
 #ifdef CRASH_HANDLER_EXCEPTION
 
 #include <cxxabi.h>
-#include <signal.h>
 #include <algorithm>
+#include <csignal>
 #include <cstdlib>
 #include <iterator>
 #include <string>

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -63,7 +63,7 @@
 #include "native_menu_windows.h"
 
 #include <io.h>
-#include <stdio.h>
+#include <cstdio>
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/platform/windows/gl_manager_windows_angle.cpp
+++ b/platform/windows/gl_manager_windows_angle.cpp
@@ -32,8 +32,8 @@
 
 #if defined(WINDOWS_ENABLED) && defined(GLES3_ENABLED)
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include <EGL/eglext_angle.h>
 

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -38,8 +38,8 @@
 #include "thirdparty/misc/nvapi_minimal.h"
 
 #include <dwmapi.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #define WGL_CONTEXT_MAJOR_VERSION_ARB 0x2091
 #define WGL_CONTEXT_MINOR_VERSION_ARB 0x2092

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -32,8 +32,8 @@
 
 #include "main/main.h"
 
-#include <locale.h>
-#include <stdio.h>
+#include <clocale>
+#include <cstdio>
 
 // For export templates, add a section; the exporter will patch it to enclose
 // the data appended to the executable (bundled PCK).

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -50,7 +50,7 @@
 
 #include <io.h>
 #include <shellapi.h>
-#include <stdio.h>
+#include <cstdio>
 
 #define WIN32_LEAN_AND_MEAN
 #include <dwrite.h>

--- a/platform/windows/tts_windows.h
+++ b/platform/windows/tts_windows.h
@@ -38,8 +38,8 @@
 
 #include <objbase.h>
 #include <sapi.h>
-#include <wchar.h>
 #include <winnls.h>
+#include <cwchar>
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/platform/windows/wgl_detect_version.cpp
+++ b/platform/windows/wgl_detect_version.cpp
@@ -40,8 +40,8 @@
 #include <windows.h>
 
 #include <dwmapi.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #define WGL_CONTEXT_MAJOR_VERSION_ARB 0x2091
 #define WGL_CONTEXT_MINOR_VERSION_ARB 0x2092

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -34,7 +34,7 @@
 
 #ifdef WINDOWS_ENABLED
 
-#include <stdio.h>
+#include <cstdio>
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -41,7 +41,7 @@
 #include "scene/main/window.h"
 #include "scene/theme/theme_db.h"
 
-#include <limits.h>
+#include <climits>
 
 Size2 TreeItem::Cell::get_icon_size() const {
 	if (icon.is_null()) {

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -43,8 +43,6 @@
 #include "servers/audio/audio_stream.h"
 #include "servers/audio/effects/audio_effect_compressor.h"
 
-#include <cstring>
-
 #ifdef TOOLS_ENABLED
 #define MARK_EDITED set_edited(true);
 #else

--- a/servers/rendering/renderer_rd/effects/fsr2.cpp
+++ b/servers/rendering/renderer_rd/effects/fsr2.cpp
@@ -36,7 +36,7 @@
 using namespace RendererRD;
 
 #ifndef _MSC_VER
-#include <wchar.h>
+#include <cwchar>
 #define wcscpy_s wcscpy
 #endif
 

--- a/servers/rendering/renderer_rd/storage_rd/forward_id_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/forward_id_storage.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 class RendererSceneRenderRD;
 


### PR DESCRIPTION
- Related #104386
- Alternative to #105877

In contrast to the math header, it seems that our compilation units actually handle C++ headers as drop-in replacements for their C counterparts. This might not be wholly the case, as there could be some overlapping shenanigans with third-party includes going on, but for all intents and purposes we can make a complete transition to the C++ headers! This comes alongside a new `clang-tidy` rule, which warns when deprecated C headers are used; the only exception in the repo is in `version.h`, which has an explicit suppression & explanation. This also includes the `#include <cstring>` reshuffling from #105877, matching godot-cpp