### PR TITLE
Add optional rotation axis & Fix initial pose with rotation axis in SpringBone

### DIFF
--- a/doc/classes/SpringBoneSimulator3D.xml
+++ b/doc/classes/SpringBoneSimulator3D.xml
@@ -226,6 +226,15 @@
 				Returns the rotation axis at [param joint] in the bone chain's joint list.
 			</description>
 		</method>
+		<method name="get_joint_rotation_axis_vector" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="joint" type="int" />
+			<description>
+				Returns the rotation axis vector for the specified joint in the bone chain. This vector represents the axis around which the joint can rotate. It is determined based on the rotation axis set for the joint.
+				If [method get_joint_rotation_axis] is [constant ROTATION_AXIS_ALL], this method returns [code]Vector3(0, 0, 0)[/code].
+			</description>
+		</method>
 		<method name="get_joint_stiffness" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="index" type="int" />
@@ -267,6 +276,14 @@
 			<param index="0" name="index" type="int" />
 			<description>
 				Returns the rotation axis of the bone chain.
+			</description>
+		</method>
+		<method name="get_rotation_axis_vector" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns the rotation axis vector of the bone chain. This vector represents the axis around which the bone chain can rotate. It is determined based on the rotation axis set for the bone chain.
+				If [method get_rotation_axis] is [constant ROTATION_AXIS_ALL], this method returns [code]Vector3(0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_stiffness" qualifiers="const">
@@ -520,6 +537,19 @@
 			<param index="2" name="axis" type="int" enum="SpringBoneSimulator3D.RotationAxis" />
 			<description>
 				Sets the rotation axis at [param joint] in the bone chain's joint list when [method is_config_individual] is [code]true[/code].
+				The axes are based on the [method Skeleton3D.get_bone_rest]'s space, if [param axis] is [constant ROTATION_AXIS_CUSTOM], you can specify any axis.
+				[b]Note:[/b] The rotation axis and the forward vector shouldn't be colinear to avoid unintended rotation since [SpringBoneSimulator3D] does not factor in twisting forces.
+			</description>
+		</method>
+		<method name="set_joint_rotation_axis_vector">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="joint" type="int" />
+			<param index="2" name="vector" type="Vector3" />
+			<description>
+				Sets the rotation axis vector for the specified joint in the bone chain.
+				This vector is normalized by an internal process and represents the axis around which the bone chain can rotate.
+				If the vector length is [code]0[/code], it is considered synonymous with [constant ROTATION_AXIS_ALL].
 			</description>
 		</method>
 		<method name="set_joint_stiffness">
@@ -569,9 +599,19 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="axis" type="int" enum="SpringBoneSimulator3D.RotationAxis" />
 			<description>
-				Sets the rotation axis of the bone chain. If sets a specific axis, it acts like a hinge joint.
-				The value is cached in each joint setting in the joint list.
-				[b]Note:[/b] The rotation axis and the forward vector shouldn't be colinear to avoid unintended rotation since [SpringBoneSimulator3D] does not factor in twisting forces.
+				Sets the rotation axis of the bone chain. If set to a specific axis, it acts like a hinge joint. The value is cached in each joint setting in the joint list.
+				The axes are based on the [method Skeleton3D.get_bone_rest]'s space, if [param axis] is [constant ROTATION_AXIS_CUSTOM], you can specify any axis.
+				[b]Note:[/b] The rotation axis vector and the forward vector shouldn't be colinear to avoid unintended rotation since [SpringBoneSimulator3D] does not factor in twisting forces.
+			</description>
+		</method>
+		<method name="set_rotation_axis_vector">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="vector" type="Vector3" />
+			<description>
+				Sets the rotation axis vector of the bone chain. The value is cached in each joint setting in the joint list.
+				This vector is normalized by an internal process and represents the axis around which the bone chain can rotate.
+				If the vector length is [code]0[/code], it is considered synonymous with [constant ROTATION_AXIS_ALL].
 			</description>
 		</method>
 		<method name="set_stiffness">
@@ -646,6 +686,9 @@
 		</constant>
 		<constant name="ROTATION_AXIS_ALL" value="3" enum="RotationAxis">
 			Enumerated value for the unconstrained rotation.
+		</constant>
+		<constant name="ROTATION_AXIS_CUSTOM" value="4" enum="RotationAxis">
+			Enumerated value for an optional rotation axis. See also [method set_joint_rotation_axis_vector].
 		</constant>
 	</constants>
 </class>

--- a/scene/3d/skeleton_modifier_3d.h
+++ b/scene/3d/skeleton_modifier_3d.h
@@ -97,6 +97,11 @@ public:
 	static Vector3 get_vector_from_axis(Vector3::Axis p_axis);
 	static Vector3::Axis get_axis_from_bone_axis(BoneAxis p_axis);
 
+	static Vector3 limit_length(const Vector3 &p_origin, const Vector3 &p_destination, float p_length);
+	static Quaternion get_local_pose_rotation(Skeleton3D *p_skeleton, int p_bone, const Quaternion &p_global_pose_rotation);
+	static Quaternion get_from_to_rotation(const Vector3 &p_from, const Vector3 &p_to, const Quaternion &p_prev_rot);
+	static Vector3 snap_vector_to_plane(const Vector3 &p_plane_normal, const Vector3 &p_vector);
+
 #ifdef TOOLS_ENABLED
 	virtual bool is_processed_on_saving() const { return false; }
 #endif

--- a/scene/3d/spring_bone_simulator_3d.h
+++ b/scene/3d/spring_bone_simulator_3d.h
@@ -69,6 +69,7 @@ public:
 		ROTATION_AXIS_Y,
 		ROTATION_AXIS_Z,
 		ROTATION_AXIS_ALL,
+		ROTATION_AXIS_CUSTOM,
 	};
 
 	struct SpringBone3DVerletInfo {
@@ -84,6 +85,29 @@ public:
 		int bone = -1;
 
 		RotationAxis rotation_axis = ROTATION_AXIS_ALL;
+		Vector3 rotation_axis_vector = Vector3(1, 0, 0);
+		Vector3 get_rotation_axis_vector() const {
+			Vector3 ret;
+			switch (rotation_axis) {
+				case ROTATION_AXIS_X:
+					ret = Vector3(1, 0, 0);
+					break;
+				case ROTATION_AXIS_Y:
+					ret = Vector3(0, 1, 0);
+					break;
+				case ROTATION_AXIS_Z:
+					ret = Vector3(0, 0, 1);
+					break;
+				case ROTATION_AXIS_ALL:
+					ret = Vector3(0, 0, 0);
+					break;
+				case ROTATION_AXIS_CUSTOM:
+					ret = rotation_axis_vector;
+					break;
+			}
+			return ret;
+		}
+
 		float radius = 0.1;
 		float stiffness = 1.0;
 		float drag = 0.0;
@@ -125,6 +149,7 @@ public:
 		Ref<Curve> gravity_damping_curve;
 		Vector3 gravity_direction = Vector3(0, -1, 0);
 		RotationAxis rotation_axis = ROTATION_AXIS_ALL;
+		Vector3 rotation_axis_vector = Vector3(1, 0, 0);
 		Vector<SpringBone3DJointSetting *> joints;
 
 		// Cache into collisions.
@@ -151,6 +176,7 @@ protected:
 	void _notification(int p_what);
 
 	virtual void _validate_bone_names() override;
+	virtual void _skeleton_changed(Skeleton3D *p_old, Skeleton3D *p_new) override;
 
 	static void _bind_methods();
 
@@ -203,6 +229,8 @@ public:
 
 	void set_rotation_axis(int p_index, RotationAxis p_axis);
 	RotationAxis get_rotation_axis(int p_index) const;
+	void set_rotation_axis_vector(int p_index, const Vector3 &p_vector);
+	Vector3 get_rotation_axis_vector(int p_index) const;
 	void set_radius(int p_index, float p_radius);
 	float get_radius(int p_index) const;
 	void set_radius_damping_curve(int p_index, const Ref<Curve> &p_damping_curve);
@@ -237,6 +265,8 @@ public:
 
 	void set_joint_rotation_axis(int p_index, int p_joint, RotationAxis p_axis);
 	RotationAxis get_joint_rotation_axis(int p_index, int p_joint) const;
+	void set_joint_rotation_axis_vector(int p_index, int p_joint, const Vector3 &p_vector);
+	Vector3 get_joint_rotation_axis_vector(int p_index, int p_joint) const;
 	void set_joint_radius(int p_index, int p_joint, float p_radius);
 	float get_joint_radius(int p_index, int p_joint) const;
 	void set_joint_stiffness(int p_index, int p_joint, float p_stiffness);
@@ -273,12 +303,6 @@ public:
 
 	void set_external_force(const Vector3 &p_force);
 	Vector3 get_external_force() const;
-
-	// Helper.
-	static Quaternion get_local_pose_rotation(Skeleton3D *p_skeleton, int p_bone, const Quaternion &p_global_pose_rotation);
-	static Quaternion get_from_to_rotation(const Vector3 &p_from, const Vector3 &p_to, const Quaternion &p_prev_rot);
-	static Vector3 snap_position_to_plane(const Transform3D &p_rest, RotationAxis p_axis, const Vector3 &p_position);
-	static Vector3 limit_length(const Vector3 &p_origin, const Vector3 &p_destination, float p_length);
 
 	// To process manually.
 	void reset();


### PR DESCRIPTION
**Enhancement:**

RotationAxis is now displayed in Gizmo. Also, it is now possible to specify an arbitrary axis for RotationAxis with Vector3 (which will be normalized internally).

![image](https://github.com/user-attachments/assets/77643b73-d4d0-4faf-a5e9-168022092392)

Furthermore, some static methods (in C++) used in SpringBone have been moved to SkeletonModifier because we plan to use them in common for IK and etc.

**Bugfix:**

Fixed an issue where the initial pose would corrupt depending on forward_axis if rotation_axis is specified.

Before (set Y to rotation axis):

![image](https://github.com/user-attachments/assets/4517a5eb-9a54-4d62-971f-7874ece74ec8)

After fix (set Y to rotation axis):

![image](https://github.com/user-attachments/assets/119e7d7b-65b0-4056-9f5d-b3784e5a28d0)

Also fix end bone `FromParent` mode didn't consider parent rest space correctly.
