### PR TITLE
Fix class reference discrepancy when using `--doctool` with TextServerFallback

### DIFF
--- a/scene/resources/text_line.cpp
+++ b/scene/resources/text_line.cpp
@@ -39,6 +39,10 @@ void TextLine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_inferred_direction"), &TextLine::get_inferred_direction);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "direction", PROPERTY_HINT_ENUM, "Auto,Left-to-right,Right-to-left"), "set_direction", "get_direction");
+	// If compiling the editor with TextServerFallback only,
+	// `--doctool` would change the default value to `TextServer::DIRECTION_LTR`.
+	// Force it so that it's consistent regardless of the backend.
+	ADD_PROPERTY_DEFAULT("direction", TextServer::DIRECTION_AUTO);
 
 	ClassDB::bind_method(D_METHOD("set_orientation", "orientation"), &TextLine::set_orientation);
 	ClassDB::bind_method(D_METHOD("get_orientation"), &TextLine::get_orientation);

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -39,6 +39,10 @@ void TextParagraph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_inferred_direction"), &TextParagraph::get_inferred_direction);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "direction", PROPERTY_HINT_ENUM, "Auto,Light-to-right,Right-to-left"), "set_direction", "get_direction");
+	// If compiling the editor with TextServerFallback only,
+	// `--doctool` would change the default value to `TextServer::DIRECTION_LTR`.
+	// Force it so that it's consistent regardless of the backend.
+	ADD_PROPERTY_DEFAULT("direction", TextServer::DIRECTION_AUTO);
 
 	ClassDB::bind_method(D_METHOD("set_custom_punctuation", "custom_punctuation"), &TextParagraph::set_custom_punctuation);
 	ClassDB::bind_method(D_METHOD("get_custom_punctuation"), &TextParagraph::get_custom_punctuation);


### PR DESCRIPTION
This is noticeable if you use an editor build compiled with the `module_text_server_adv_enabled=no module_text_server_fb_enabled=yes` SCons options.

Previously, running `--doctool` with no changes would cause a diff to be generated between the `master` version and your local copy.
