### PR TITLE
Improve `ColorPicker`

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3658,7 +3658,7 @@ void EditorNode::_update_file_menu_opened() {
 
 void EditorNode::_palette_quick_open_dialog() {
 	quick_open_color_palette->popup_dialog({ "ColorPalette" }, palette_file_selected_callback);
-	quick_open_color_palette->set_title(TTR("Quick Open Color Palette..."));
+	quick_open_color_palette->set_title(TTRC("Quick Open Color Palette..."));
 }
 
 void EditorNode::replace_resources_in_object(Object *p_object, const Vector<Ref<Resource>> &p_source_resources, const Vector<Ref<Resource>> &p_target_resource) {

--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -132,7 +132,7 @@ public:
 	float slider_max[4] = { 359, 100, 100, 255 };
 	float cached_hue = 0.0;
 	float cached_saturation = 0.0;
-	Ref<GradientTexture2D> hue_texture = nullptr;
+	Ref<GradientTexture2D> hue_texture;
 
 	virtual String get_name() const override { return "OKHSL"; }
 

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -54,6 +54,7 @@ class ColorPresetButton : public BaseButton {
 	GDCLASS(ColorPresetButton, BaseButton);
 
 	Color preset_color;
+	bool recent = false;
 
 	struct ThemeCache {
 		Ref<StyleBox> foreground_style;
@@ -71,7 +72,9 @@ public:
 	void set_preset_color(const Color &p_color);
 	Color get_preset_color() const;
 
-	ColorPresetButton(Color p_color, int p_size);
+	virtual String get_tooltip(const Point2 &p_pos) const override;
+
+	ColorPresetButton(Color p_color, int p_size, bool p_recent);
 	~ColorPresetButton();
 };
 
@@ -181,7 +184,7 @@ private:
 	HBoxContainer *hex_hbc = nullptr;
 	MenuButton *btn_mode = nullptr;
 	Button *mode_btns[MODE_BUTTON_COUNT];
-	Ref<ButtonGroup> mode_group = nullptr;
+	Ref<ButtonGroup> mode_group;
 	ColorPresetButton *selected_recent_preset = nullptr;
 	Ref<ButtonGroup> preset_group;
 	Ref<ButtonGroup> recent_preset_group;
@@ -301,7 +304,9 @@ private:
 	void _update_controls();
 	void _update_color(bool p_update_sliders = true);
 	void _update_text_value();
+#ifdef TOOLS_ENABLED
 	void _text_type_toggled();
+#endif // TOOLS_ENABLED
 	void _sample_input(const Ref<InputEvent> &p_event);
 	void _sample_draw();
 	void _slider_draw(int p_which);
@@ -344,6 +349,8 @@ private:
 	bool _can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from_control) const;
 	void _drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from_control);
 
+	void _ensure_file_dialog();
+
 protected:
 	virtual void _update_theme_item_cache() override;
 
@@ -355,7 +362,10 @@ public:
 	void set_editor_settings(Object *p_editor_settings);
 	void set_quick_open_callback(const Callable &p_file_selected);
 	void set_palette_saved_callback(const Callable &p_palette_saved);
+
+	void _quick_open_palette_file_selected(const String &p_path);
 #endif
+
 	HSlider *get_slider(int idx);
 	Vector<float> get_active_slider_values();
 
@@ -373,7 +383,7 @@ public:
 	Color get_pick_color() const;
 	void set_old_color(const Color &p_color);
 	Color get_old_color() const;
-	void _quick_open_palette_file_selected(const String &p_path);
+
 	void _palette_file_selected(const String &p_path);
 
 	void set_display_old_color(bool p_enabled);


### PR DESCRIPTION
This PR

- Fixed some UI texts not marked as extractable translation, and some editor-only texts marked as extractable.
- Fixed palette open/save dialog title not being set on first open
- Made picker mode button use the three-dots icon instead of "..." text
- Made preset option menu items disabled when do nothing instead of hiding them from the user (e.g., The "Clear" item is disabled instead of hidden when there are no color presets.)
- Wrapped some editor-only logic inside `TOOLS_ENABLED`
- Refactored some color preset button code to avoid duplication and scattering of tooltip texts
- Cleaned up header includes in the files that this PR touches