### PR TITLE
Improve editor accessibility warnings.

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -2070,6 +2070,8 @@ void SceneTreeEditor::set_accessibility_warnings(bool p_enable, bool p_update_se
 		EditorSettings::get_singleton()->set("docks/scene_tree/accessibility_warnings", p_enable);
 	}
 	accessibility_warnings = p_enable;
+	node_cache.force_update = true;
+	_update_tree();
 }
 
 void SceneTreeEditor::set_connect_to_script_mode(bool p_enable) {

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -185,6 +185,19 @@ Ref<StyleBox> Button::_get_current_stylebox() const {
 	return stylebox;
 }
 
+PackedStringArray Button::get_accessibility_configuration_warnings() const {
+	ERR_READ_THREAD_GUARD_V(PackedStringArray());
+	PackedStringArray warnings = Node::get_accessibility_configuration_warnings();
+
+	String ac_name = get_accessibility_name();
+	if (!xl_text.is_empty() && ac_name.is_empty()) {
+		ac_name = xl_text;
+	}
+	_accessibility_configuration_check_name(String(), ac_name, RTR("Text"), warnings);
+
+	return warnings;
+}
+
 void Button::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ACCESSIBILITY_UPDATE: {

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -113,6 +113,8 @@ protected:
 	virtual void _queue_update_size_cache();
 	virtual String _get_translated_text(const String &p_text) const;
 
+	PackedStringArray get_accessibility_configuration_warnings() const override;
+
 	Size2 _fit_icon_size(const Size2 &p_size) const;
 	Ref<StyleBox> _get_current_stylebox() const;
 	Size2 _get_largest_stylebox_size() const;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -252,20 +252,11 @@ PackedStringArray Control::get_accessibility_configuration_warnings() const {
 	ERR_READ_THREAD_GUARD_V(PackedStringArray());
 	PackedStringArray warnings = Node::get_accessibility_configuration_warnings();
 
-	String ac_name = get_accessibility_name().strip_edges();
-	if (ac_name.is_empty()) {
-		warnings.push_back(RTR("Accessibility Name must not be empty, or contain only spaces."));
-	}
-	if (ac_name.contains(get_class_name())) {
-		warnings.push_back(RTR("Accessibility Name must not include Node class name."));
-	}
-	for (int i = 0; i < ac_name.length(); i++) {
-		if (is_control(ac_name[i])) {
-			warnings.push_back(RTR("Accessibility Name must not include control character."));
-			break;
-		}
+	if (get_focus_mode_with_override() == FOCUS_NONE) {
+		return warnings;
 	}
 
+	_accessibility_configuration_check_name(String(), get_accessibility_name().strip_edges(), String(), warnings);
 	return warnings;
 }
 

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -111,6 +111,8 @@ class GraphNode : public GraphElement {
 
 	void _port_pos_update();
 
+	String _get_ac_name() const;
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -123,6 +125,8 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+	PackedStringArray get_accessibility_configuration_warnings() const override;
 
 public:
 	virtual String get_accessibility_container_name(const Node *p_node) const override;

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1248,6 +1248,17 @@ void ItemList::_accessibility_action_blur(const Variant &p_data, int p_index) {
 	deselect(p_index);
 }
 
+PackedStringArray ItemList::get_accessibility_configuration_warnings() const {
+	PackedStringArray warnings = Control::get_accessibility_configuration_warnings();
+
+	for (int i = 0; i < items.size(); i++) {
+		const Item &item = items[i];
+		_accessibility_configuration_check_name(vformat(RTR("Item %d"), i), item.xl_text.strip_edges(), RTR("Text"), warnings);
+	}
+
+	return warnings;
+}
+
 void ItemList::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_EXIT_TREE:
@@ -1283,7 +1294,7 @@ void ItemList::_notification(int p_what) {
 			DisplayServer::get_singleton()->accessibility_update_set_bounds(accessibility_scroll_element, Rect2(0, 0, scroll_bar_h->get_max(), scroll_bar_v->get_max()));
 
 			for (int i = 0; i < items.size(); i++) {
-				const Item &item = items.write[i];
+				const Item &item = items[i];
 
 				if (item.accessibility_item_element.is_null()) {
 					item.accessibility_item_element = DisplayServer::get_singleton()->accessibility_create_sub_element(accessibility_scroll_element, DisplayServer::AccessibilityRole::ROLE_LIST_BOX_OPTION);

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -196,6 +196,8 @@ protected:
 	void _accessibility_action_focus(const Variant &p_data, int p_index);
 	void _accessibility_action_blur(const Variant &p_data, int p_index);
 
+	PackedStringArray get_accessibility_configuration_warnings() const override;
+
 public:
 	virtual RID get_focused_accessibility_element() const override;
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1164,6 +1164,19 @@ void LineEdit::_accessibility_action_menu(const Variant &p_data) {
 	menu->grab_focus();
 }
 
+PackedStringArray LineEdit::get_accessibility_configuration_warnings() const {
+	ERR_READ_THREAD_GUARD_V(PackedStringArray());
+	PackedStringArray warnings = Node::get_accessibility_configuration_warnings();
+
+	String ac_name = get_accessibility_name();
+	if (!placeholder.is_empty() && get_accessibility_name().is_empty()) {
+		ac_name = placeholder;
+	}
+	_accessibility_configuration_check_name(String(), ac_name, RTR("Placeholder"), warnings);
+
+	return warnings;
+}
+
 void LineEdit::_notification(int p_what) {
 	switch (p_what) {
 #ifdef TOOLS_ENABLED

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -282,6 +282,8 @@ protected:
 	void _accessibility_action_set_value(const Variant &p_data);
 	void _accessibility_action_menu(const Variant &p_data);
 
+	PackedStringArray get_accessibility_configuration_warnings() const override;
+
 public:
 	void edit();
 	void unedit();

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -150,6 +150,19 @@ Size2 LinkButton::get_minimum_size() const {
 	return text_buf->get_size();
 }
 
+PackedStringArray LinkButton::get_accessibility_configuration_warnings() const {
+	ERR_READ_THREAD_GUARD_V(PackedStringArray());
+	PackedStringArray warnings = Node::get_accessibility_configuration_warnings();
+
+	String ac_name = get_accessibility_name();
+	if (!xl_text.is_empty() && get_accessibility_name().is_empty()) {
+		ac_name = xl_text;
+	}
+	_accessibility_configuration_check_name(String(), ac_name, RTR("Text"), warnings);
+
+	return warnings;
+}
+
 void LinkButton::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ACCESSIBILITY_UPDATE: {

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -82,6 +82,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	PackedStringArray get_accessibility_configuration_warnings() const override;
+
 public:
 	void set_text(const String &p_text);
 	String get_text() const;

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1123,6 +1123,24 @@ RID PopupMenu::get_focused_accessibility_element() const {
 	}
 }
 
+PackedStringArray PopupMenu::get_accessibility_configuration_warnings() const {
+	ERR_READ_THREAD_GUARD_V(PackedStringArray());
+	PackedStringArray warnings = Node::get_accessibility_configuration_warnings();
+
+	String ac_name = get_accessibility_name();
+	if (has_meta("_menu_name")) {
+		ac_name = get_meta("_menu_name", get_name());
+	}
+	_accessibility_configuration_check_name(String(), ac_name, RTR("Name"), warnings);
+
+	for (int i = 0; i < items.size(); i++) {
+		const Item &item = items[i];
+		_accessibility_configuration_check_name(vformat(RTR("Item %d"), i), item.xl_text.strip_edges(), RTR("Text"), warnings);
+	}
+
+	return warnings;
+}
+
 void PopupMenu::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_EXIT_TREE: {
@@ -1163,7 +1181,7 @@ void PopupMenu::_notification(int p_what) {
 			Point2 ofs;
 
 			for (int i = 0; i < items.size(); i++) {
-				const Item &item = items.write[i];
+				const Item &item = items[i];
 
 				ofs.y += i > 0 ? theme_cache.v_separation : (float)theme_cache.v_separation / 2;
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -240,6 +240,8 @@ protected:
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return property_helper.property_get_revert(p_name, r_property); }
 	static void _bind_methods();
 
+	PackedStringArray get_accessibility_configuration_warnings() const override;
+
 #ifndef DISABLE_DEPRECATED
 	void _add_shortcut_bind_compat_36493(const Ref<Shortcut> &p_shortcut, int p_id = -1, bool p_global = false);
 	void _add_icon_shortcut_bind_compat_36493(const Ref<Texture2D> &p_icon, const Ref<Shortcut> &p_shortcut, int p_id = -1, bool p_global = false);

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1891,7 +1891,12 @@ PackedStringArray RichTextLabel::get_accessibility_configuration_warnings() cons
 		if (it->type == ITEM_IMAGE) {
 			ItemImage *img = static_cast<ItemImage *>(it);
 			if (img && img->alt_text.strip_edges().is_empty()) {
-				warnings.push_back(RTR("Image alternative text must not be empty."));
+				warnings.push_back(RTR("Image alternative text is empty, or contain only spaces."));
+			}
+		} else if (it->type == ITEM_TABLE) {
+			ItemTable *tab = static_cast<ItemTable *>(it);
+			if (tab && tab->name.strip_edges().is_empty()) {
+				warnings.push_back(RTR("Table name is empty, or contain only spaces."));
 			}
 		}
 		it = _get_next_item(it, true);

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -386,6 +386,18 @@ void TabBar::_accessibility_action_focus(const Variant &p_data, int p_index) {
 	set_current_tab(p_index);
 }
 
+PackedStringArray TabBar::get_accessibility_configuration_warnings() const {
+	ERR_READ_THREAD_GUARD_V(PackedStringArray());
+	PackedStringArray warnings = Control::get_accessibility_configuration_warnings();
+
+	for (int i = 0; i < tabs.size(); i++) {
+		const Tab &item = tabs[i];
+		_accessibility_configuration_check_name(vformat(RTR("Tab %d"), i), item.text.strip_edges(), RTR("Text"), warnings);
+	}
+
+	return warnings;
+}
+
 void TabBar::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -194,6 +194,8 @@ protected:
 	void drop_data(const Point2 &p_point, const Variant &p_data) override;
 	void _move_tab_from(TabBar *p_from_tabbar, int p_from_index, int p_to_index);
 
+	PackedStringArray get_accessibility_configuration_warnings() const override;
+
 public:
 	RID get_tab_accessibility_element(int p_tab) const;
 	virtual RID get_focused_accessibility_element() const override;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -714,6 +714,19 @@ void TextEdit::_accessibility_action_scroll_into_view(const Variant &p_data, int
 	}
 }
 
+PackedStringArray TextEdit::get_accessibility_configuration_warnings() const {
+	ERR_READ_THREAD_GUARD_V(PackedStringArray());
+	PackedStringArray warnings = Node::get_accessibility_configuration_warnings();
+
+	String ac_name = get_accessibility_name();
+	if (!placeholder_text.is_empty() && get_accessibility_name().is_empty()) {
+		ac_name = placeholder_text;
+	}
+	_accessibility_configuration_check_name(String(), ac_name, RTR("Placeholder"), warnings);
+
+	return warnings;
+}
+
 void TextEdit::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_EXIT_TREE:

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -758,6 +758,8 @@ protected:
 	void _accessibility_scroll_set(const Variant &p_data);
 	void _accessibility_action_scroll_into_view(const Variant &p_data, int p_line, int p_wrap);
 
+	PackedStringArray get_accessibility_configuration_warnings() const override;
+
 	GDVIRTUAL2(_handle_unicode_input, int, int)
 	GDVIRTUAL1(_backspace, int)
 	GDVIRTUAL1(_cut, int)

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4509,11 +4509,11 @@ void Tree::_check_item_accessibility(TreeItem *p_item, PackedStringArray &r_warn
 	for (int i = 0; i < p_item->cells.size(); i++) {
 		const TreeItem::Cell &cell = p_item->cells[i];
 		if (cell.alt_text.strip_edges().is_empty() && cell.text.strip_edges().is_empty()) {
-			r_warnings.push_back(vformat(RTR("Cell %d x %d: either text or alternative text must not be empty."), r_row, i));
+			r_warnings.push_back(vformat(RTR("Cell %d x %d: text and alternative text are empty, or contain only spaces."), r_row, i));
 		}
 		for (int j = 0; j < cell.buttons.size(); j++) {
 			if (cell.buttons[j].alt_text.strip_edges().is_empty()) {
-				r_warnings.push_back(vformat(RTR("Button %d in %d x %d: alternative text must not be empty."), j, r_row, i));
+				r_warnings.push_back(vformat(RTR("Button %d in %d x %d: alternative text is empty, or contain only spaces."), j, r_row, i));
 			}
 		}
 	}

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3590,6 +3590,33 @@ void Node::get_argument_options(const StringName &p_function, int p_idx, List<St
 }
 #endif
 
+void Node::_accessibility_configuration_check_name(const String &p_prefix, const String &p_name, const String &p_alt_prop_name, PackedStringArray &r_warnings) const {
+	if (p_name.is_empty()) {
+		if (p_alt_prop_name.is_empty()) {
+			r_warnings.push_back(p_prefix + RTR("Accessibility name is empty, or contain only spaces."));
+		} else {
+			r_warnings.push_back(p_prefix + vformat(RTR("Accessibility name / %s is empty, or contain only spaces."), p_alt_prop_name));
+		}
+	}
+	if (p_name.contains(get_class_name())) {
+		if (p_alt_prop_name.is_empty()) {
+			r_warnings.push_back(p_prefix + RTR("Accessibility name include Node class name."));
+		} else {
+			r_warnings.push_back(p_prefix + vformat(RTR("Accessibility name / %s include Node class name."), p_alt_prop_name));
+		}
+	}
+	for (int i = 0; i < p_name.length(); i++) {
+		if (is_control(p_name[i])) {
+			if (p_alt_prop_name.is_empty()) {
+				r_warnings.push_back(p_prefix + RTR("Accessibility name include control character(s)."));
+			} else {
+				r_warnings.push_back(p_prefix + vformat(RTR("Accessibility name / %s include control character(s)."), p_alt_prop_name));
+			}
+			break;
+		}
+	}
+}
+
 void Node::clear_internal_tree_resource_paths() {
 	clear_internal_resource_paths();
 	for (KeyValue<StringName, Node *> &K : data.children) {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -699,6 +699,7 @@ public:
 	virtual String get_accessibility_container_name(const Node *p_node) const;
 	virtual bool accessibility_override_tree_hierarchy() const { return false; }
 
+	void _accessibility_configuration_check_name(const String &p_prefix, const String &p_name, const String &p_alt_prop_name, PackedStringArray &r_warnings) const;
 	virtual PackedStringArray get_accessibility_configuration_warnings() const;
 
 	Node *duplicate(int p_flags = DUPLICATE_GROUPS | DUPLICATE_SIGNALS | DUPLICATE_SCRIPTS) const;


### PR DESCRIPTION
- Removes unnecessery configurat ion warnings for unfocusable nodes.
- Adds checks for alternative name sources (placeholders, text).
- Adds checks for RTL table names.
- Adds checks for tab, list item and popup menu item names.