### PR TITLE
Fallback to ScriptInstance::get_property_state when get_property_state is not implemented in ScriptInstanceExtension

### DIFF
--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -818,7 +818,9 @@ public:
 	virtual void get_property_state(List<Pair<StringName, Variant>> &state) override {
 		if (native_info->get_property_state_func) {
 			native_info->get_property_state_func(instance, _add_property_with_state, &state);
+			return;
 		}
+		ScriptInstance::get_property_state(state);
 	}
 
 	virtual void get_method_list(List<MethodInfo> *p_list) const override {


### PR DESCRIPTION
This adds a fallback to default `ScriptInstance::get_property_state` when no function pointer is provided to `ScriptInstanceExtension`.  
This way it makes `ScriptInstanceExtension` behaviour similar to module script implementation.
