### PR TITLE
Fix reflection probe dark borders

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1949,11 +1949,11 @@ void fragment_shader(in SceneData scene_data) {
 		}
 
 		if (ambient_accum.a < 1.0) {
-			ambient_accum.rgb = mix(ambient_light, ambient_accum.rgb, ambient_accum.a);
+			ambient_accum.rgb = ambient_light * (1.0 - ambient_accum.a) + ambient_accum.rgb;
 		}
 
 		if (reflection_accum.a < 1.0) {
-			reflection_accum.rgb = mix(specular_light, reflection_accum.rgb, reflection_accum.a);
+			reflection_accum.rgb = specular_light * (1.0 - reflection_accum.a) + reflection_accum.rgb;
 		}
 
 		if (reflection_accum.a > 0.0) {

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1418,11 +1418,11 @@ void main() {
 		}
 
 		if (ambient_accum.a < 1.0) {
-			ambient_accum.rgb = mix(ambient_light, ambient_accum.rgb, ambient_accum.a);
+			ambient_accum.rgb = ambient_light * (1.0 - ambient_accum.a) + ambient_accum.rgb;
 		}
 
 		if (reflection_accum.a < 1.0) {
-			reflection_accum.rgb = mix(specular_light, reflection_accum.rgb, reflection_accum.a);
+			reflection_accum.rgb = specular_light * (1.0 - reflection_accum.a) + reflection_accum.rgb;
 		}
 
 		if (reflection_accum.a > 0.0) {


### PR DESCRIPTION
Fixes #105540

Since reflections are accumulated by addition, where reflection probes overlap we need to multiply the reflection.rgb by its blend factor to account for how much reflection it should contribute, this happens in `scene_forward_lights_inc.glsl` in `void reflection_process()`.

When blending with the environment we need to undo that multiplication in `scene_forward_clustered.glsl`.

|  | Master | This PR |
| - | - | - |
| Forward+ | ![image](https://github.com/user-attachments/assets/84e909db-e2e8-48c0-8023-9a594f636030) | ![image](https://github.com/user-attachments/assets/4cf325e5-d74a-416f-9f73-1989984b5eb1) |
| Mobile | ![image](https://github.com/user-attachments/assets/82f11bea-b7dd-41c5-8dc4-bbdd1c175d04) | ![image](https://github.com/user-attachments/assets/431acd83-e062-40a3-bffa-c40e40a78204) |
