### PR TITLE
Fix case sensitivity for fuzzy searching

### DIFF
--- a/core/string/fuzzy_search.cpp
+++ b/core/string/fuzzy_search.cpp
@@ -296,7 +296,10 @@ bool FuzzySearch::search(const String &p_target, FuzzySearchResult &p_result) co
 	// which does not conflict with prior token matches. This is not ensured to find the highest scoring
 	// combination of matches, or necessarily the highest scoring single subsequence, as it only considers
 	// eager subsequences for a given index, and likewise eagerly finds matches for each token in sequence.
-	for (const FuzzySearchToken &token : tokens) {
+	for (FuzzySearchToken token : tokens) {
+		if (!case_sensitive) {
+			token.string = token.string.to_lower();
+		}
 		FuzzyTokenMatch best_match;
 		int offset = start_offset;
 


### PR DESCRIPTION
While working on https://github.com/godotengine/godot/pull/105239 and https://github.com/godotengine/godot/pull/105240 I found that disabling case sensitivity with fuzzy searching doesn't work.

This is because only the target is lower cased when case sensitivity is disabled, not the search tokens. The simplest solution seems to be to just lower-case the tokens when they are looped for the search. They cannot be lower-cased when they are set up as case sensitivity will be set later than the tokens being set up.

I believe @a-johnston and @samsface added the fuzzy search, so maybe one of them can confirm this.