### PR TITLE
Allow filename prefixes and suffixes to be substrings of valid filenames

### DIFF
--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -324,7 +324,7 @@ Ref<DirAccess> DirAccess::create(AccessType p_access) {
 Ref<DirAccess> DirAccess::create_temp(const String &p_prefix, bool p_keep, Error *r_error) {
 	const String ERROR_COMMON_PREFIX = "Error while creating temporary directory";
 
-	if (!p_prefix.is_valid_filename()) {
+	if (!p_prefix.is_empty() && !p_prefix.strip_edges(false, true).is_valid_filename()) {
 		*r_error = ERR_FILE_BAD_PATH;
 		ERR_FAIL_V_MSG(Ref<FileAccess>(), vformat(R"(%s: "%s" is not a valid prefix.)", ERROR_COMMON_PREFIX, p_prefix));
 	}

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -82,12 +82,12 @@ Ref<FileAccess> FileAccess::create_for_path(const String &p_path) {
 Ref<FileAccess> FileAccess::create_temp(int p_mode_flags, const String &p_prefix, const String &p_extension, bool p_keep, Error *r_error) {
 	const String ERROR_COMMON_PREFIX = "Error while creating temporary file";
 
-	if (!p_prefix.is_empty() && !p_prefix.is_valid_filename()) {
+	if (!p_prefix.is_empty() && !p_prefix.strip_edges(false, true).is_valid_filename()) {
 		*r_error = ERR_FILE_BAD_PATH;
 		ERR_FAIL_V_MSG(Ref<FileAccess>(), vformat(R"(%s: "%s" is not a valid prefix.)", ERROR_COMMON_PREFIX, p_prefix));
 	}
 
-	if (!p_extension.is_empty() && !p_extension.is_valid_filename()) {
+	if (!p_extension.is_empty() && !p_extension.strip_edges(true, false).is_valid_filename()) {
 		*r_error = ERR_FILE_BAD_PATH;
 		ERR_FAIL_V_MSG(Ref<FileAccess>(), vformat(R"(%s: "%s" is not a valid extension.)", ERROR_COMMON_PREFIX, p_extension));
 	}


### PR DESCRIPTION
Fixes #105893.

The prefix and suffix were being checked for full filename validity, which includes a check for at least one non whitespace character. For the prefix or suffix of a filename, these aren't actually problems, so let them pass safely. We're always putting a timestamp in the middle, so they can be empty without issue.

I grepped for `is_valid_filename` usages and found another similar one in `DirAccess`, so I updated that, too.