### PR TITLE
Fix double translations in Project Manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1504,6 +1504,7 @@ ProjectManager::ProjectManager() {
 				project_list_panel->add_child(empty_list_placeholder);
 
 				empty_list_message = memnew(RichTextLabel);
+				empty_list_message->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 				empty_list_message->set_use_bbcode(true);
 				empty_list_message->set_fit_content(true);
 				empty_list_message->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -1092,6 +1092,7 @@ ProjectDialog::ProjectDialog() {
 	rvb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	rshc->add_child(rvb);
 	renderer_info = memnew(Label);
+	renderer_info->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	renderer_info->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	renderer_info->set_modulate(Color(1, 1, 1, 0.7));
 	rvb->add_child(renderer_info);

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -323,6 +323,7 @@ void ProjectListItemControl::_bind_methods() {
 
 ProjectListItemControl::ProjectListItemControl() {
 	set_focus_mode(FocusMode::FOCUS_ALL);
+	set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 
 	VBoxContainer *favorite_box = memnew(VBoxContainer);
 	favorite_box->set_alignment(BoxContainer::ALIGNMENT_CENTER);
@@ -330,8 +331,9 @@ ProjectListItemControl::ProjectListItemControl() {
 
 	favorite_button = memnew(TextureButton);
 	favorite_button->set_name("FavoriteButton");
-	favorite_button->set_tooltip_text(TTR("Add to favorites"));
+	favorite_button->set_tooltip_text(TTRC("Add to favorites"));
 	favorite_button->set_accessibility_name(TTRC("Add to favorites"));
+	favorite_button->set_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
 	// This makes the project's "hover" style display correctly when hovering the favorite icon.
 	favorite_button->set_mouse_filter(MOUSE_FILTER_PASS);
 	favorite_box->add_child(favorite_button);
@@ -358,7 +360,6 @@ ProjectListItemControl::ProjectListItemControl() {
 
 		project_title = memnew(Label);
 		project_title->set_focus_mode(FOCUS_ACCESSIBILITY);
-		project_title->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 		project_title->set_name("ProjectName");
 		project_title->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		project_title->set_clip_text(true);
@@ -380,7 +381,8 @@ ProjectListItemControl::ProjectListItemControl() {
 
 		explore_button = memnew(Button);
 		explore_button->set_name("ExploreButton");
-		explore_button->set_tooltip_text(TTR("Open in file manager"));
+		explore_button->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
+		explore_button->set_tooltip_text(TTRC("Open in file manager"));
 		explore_button->set_accessibility_name(TTRC("Open in file manager"));
 		explore_button->set_flat(true);
 		path_hb->add_child(explore_button);
@@ -411,6 +413,7 @@ ProjectListItemControl::ProjectListItemControl() {
 		last_edited_info->set_focus_mode(FOCUS_ACCESSIBILITY);
 		last_edited_info->set_name("LastEditedInfo");
 		last_edited_info->set_mouse_filter(Control::MOUSE_FILTER_PASS);
+		last_edited_info->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
 		last_edited_info->set_tooltip_text(TTRC("Last edited timestamp"));
 		last_edited_info->set_modulate(Color(1, 1, 1, 0.5));
 		path_hb->add_child(last_edited_info);

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -30,7 +30,6 @@
 
 #include "quick_settings_dialog.h"
 
-#include "core/config/project_settings.h"
 #include "core/string/translation_server.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
@@ -281,6 +280,7 @@ QuickSettingsDialog::QuickSettingsDialog() {
 		// Language options.
 		{
 			language_option_button = memnew(OptionButton);
+			language_option_button->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 			language_option_button->set_fit_to_longest_item(false);
 			language_option_button->connect(SceneStringName(item_selected), callable_mp(this, &QuickSettingsDialog::_language_selected));
 


### PR DESCRIPTION
Follow-up to #104845

- Fixed some double translations.
- Disabled auto translation on some controls. e.g., project path, last modification time, version string.
- ~~Changed "empty list message" to use the tag stack API instead of BBCode so that it won't be broken by editor pseudolocalization :P~~
- Cleaned header includes in files that this PR touched.