### PR TITLE
Fix error spam to due wrong use of `reserve()` in D3D12 driver.

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -4469,10 +4469,10 @@ void RenderingDeviceDriverD3D12::_command_bind_uniform_set(CommandBufferID p_cmd
 	}
 #endif
 
-	last_bind->root_tables.resources.reserve(shader_set.num_root_params.resources);
 	last_bind->root_tables.resources.clear();
-	last_bind->root_tables.samplers.reserve(shader_set.num_root_params.samplers);
 	last_bind->root_tables.samplers.clear();
+	last_bind->root_tables.resources.reserve(shader_set.num_root_params.resources);
+	last_bind->root_tables.samplers.reserve(shader_set.num_root_params.samplers);
 	last_bind->uses++;
 
 	struct {


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/105278 introduced some error spam per frame in the D3D12 driver as it detected an incorrect use of reserve(). This PR fixes it.

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/105873