### PR TITLE
.NET array extensions to match some Godot array functionality (`Fill`, `PickRandom`)

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/ListExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/ListExtensions.cs
@@ -1,0 +1,35 @@
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace Godot;
+
+/// <summary>
+/// Extension methods to manipulate arrays and lists.
+/// </summary>
+public static class ListExtensions
+{
+    /// <summary>
+    /// Assigns the given value to all elements in the array.
+    /// </summary>
+    public static void Fill<T>(this IList<T> list, T value)
+    {
+        for (int i = 0; i < list.Count; i++)
+            list[i] = value;
+    }
+
+    /// <summary>
+    /// Returns a random value from the target array.
+    /// Note that this uses <see cref="GD.RandRange(int, int)"/> to advance the Godot global seed.
+    /// </summary>
+    /// <returns>A random element from the array, or <see langword="null"/> if the array is empty.</returns>
+    public static T? PickRandom<T>(this IList<T> list)
+    {
+        if (list.Count == 0)
+            return default;
+        if (list.Count == 1)
+            return list[0];
+
+        return list[GD.RandRange(0, list.Count - 1)];
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Core\Interfaces\IAwaitable.cs" />
     <Compile Include="Core\Interfaces\IAwaiter.cs" />
     <Compile Include="Core\Interfaces\ISerializationListener.cs" />
+    <Compile Include="Core\ListExtensions.cs" />
     <Compile Include="Core\Mathf.cs" />
     <Compile Include="Core\MathfEx.cs" />
     <Compile Include="Core\NativeInterop\CustomUnsafe.cs" />


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Adds some useful helper functions to .NET's `IList<>` types (arrays, lists, custom collections, etc) to match the built-in functionality in the Godot array without any of the performance penalties of using the native implementation.

Note that `PickRandom` in particular is very important as it uses and advances the Godot random seed, thus allowing for reproducible random number generation with a given seed. 