### PR TITLE
Editor: Allow non-finite values in `Range`

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -135,10 +135,6 @@ void Range::set_value(double p_val) {
 }
 
 void Range::_set_value_no_signal(double p_val) {
-	if (!Math::is_finite(p_val)) {
-		return;
-	}
-
 	if (shared->step > 0) {
 		p_val = Math::round((p_val - shared->min) / shared->step) * shared->step + shared->min;
 	}


### PR DESCRIPTION
- Originally subset of #100414
- Fixes #88006
- Fixes (partially) godotengine/godot-proposals#10068

Didn't want to lose the original purpose of aaron's PR, so I've added the change in isolation. That PR has already accounted for the use of non-finite inspector values, so no further adjustments were necessary beyond removing the conditional