### PR TITLE
Enable game window close button on PicoOS

### DIFF
--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame.kt
@@ -41,6 +41,7 @@ import androidx.core.view.isVisible
 import org.godotengine.editor.embed.GameMenuFragment
 import org.godotengine.godot.utils.GameMenuUtils
 import org.godotengine.godot.utils.ProcessPhoenix
+import org.godotengine.godot.utils.isHorizonOSDevice
 import org.godotengine.godot.utils.isNativeXRDevice
 
 /**
@@ -228,7 +229,7 @@ open class GodotGame : BaseGodotGame() {
 
 	override fun isMinimizedButtonEnabled() = isTaskRoot && !isNativeXRDevice(applicationContext)
 
-	override fun isCloseButtonEnabled() = !isNativeXRDevice(applicationContext)
+	override fun isCloseButtonEnabled() = !isHorizonOSDevice(applicationContext)
 
 	override fun isPiPButtonEnabled() = hasPiPSystemFeature()
 


### PR DESCRIPTION
On PicoOS, Game window opens in same window as editor and there's no way to close it and return to editor.

https://github.com/user-attachments/assets/007a5e86-5e67-452d-9766-48d923ad049b

This PR fixes it by enabling the close button on PICO devices.