### PR TITLE
doctest: Patch for clang warning about replacing `<ciso646>` by `<version>`

### DIFF
--- a/thirdparty/doctest/doctest.h
+++ b/thirdparty/doctest/doctest.h
@@ -490,14 +490,20 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 #endif
 #endif // DOCTEST_CONFIG_USE_IOSFWD
 
-// for clang - always include ciso646 (which drags some std stuff) because
-// we want to check if we are using libc++ with the _LIBCPP_VERSION macro in
+// BEGIN TEMPORARY PATCH (comes from https://github.com/doctest/doctest/pull/901)
+// for clang - always include <version> or <ciso646> (which drags some std stuff)
+// because we want to check if we are using libc++ with the _LIBCPP_VERSION macro in
 // which case we don't want to forward declare stuff from std - for reference:
 // https://github.com/doctest/doctest/issues/126
 // https://github.com/doctest/doctest/issues/356
 #if DOCTEST_CLANG
+#if DOCTEST_CPLUSPLUS >= 201703L && __has_include(<version>)
+#include <version>
+#else
 #include <ciso646>
+#endif
 #endif // clang
+// END TEMPORARY PATCH
 
 #ifdef _LIBCPP_VERSION
 #ifndef DOCTEST_CONFIG_USE_STD_HEADERS

--- a/thirdparty/doctest/patches/0000-ciso646-version.patch
+++ b/thirdparty/doctest/patches/0000-ciso646-version.patch
@@ -1,0 +1,27 @@
+diff --git a/thirdparty/doctest/doctest.h b/thirdparty/doctest/doctest.h
+index 5c754cde08a..482749ccb2b 100644
+--- a/thirdparty/doctest/doctest.h
++++ b/thirdparty/doctest/doctest.h
+@@ -490,14 +490,20 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
+ #endif
+ #endif // DOCTEST_CONFIG_USE_IOSFWD
+ 
+-// for clang - always include ciso646 (which drags some std stuff) because
+-// we want to check if we are using libc++ with the _LIBCPP_VERSION macro in
++// BEGIN TEMPORARY PATCH (comes from https://github.com/doctest/doctest/pull/901)
++// for clang - always include <version> or <ciso646> (which drags some std stuff)
++// because we want to check if we are using libc++ with the _LIBCPP_VERSION macro in
+ // which case we don't want to forward declare stuff from std - for reference:
+ // https://github.com/doctest/doctest/issues/126
+ // https://github.com/doctest/doctest/issues/356
+ #if DOCTEST_CLANG
++#if DOCTEST_CPLUSPLUS >= 201703L && __has_include(<version>)
++#include <version>
++#else
+ #include <ciso646>
++#endif
+ #endif // clang
++// END TEMPORARY PATCH
+ 
+ #ifdef _LIBCPP_VERSION
+ #ifndef DOCTEST_CONFIG_USE_STD_HEADERS


### PR DESCRIPTION
This PR creates a patch to fix doctest when using `clang`. On Fedora 42, clang complains that including `<ciso646>` is deprecated with C++17 and that we should include `<version>` instead. And that's what the PR does.
 
It uses the upstream https://github.com/doctest/doctest/pull/901 (currently draft) PR to fix the issue.
