### PR TITLE
FTI - Add custom interpolation for wheels

### DIFF
--- a/scene/3d/physics/vehicle_body_3d.h
+++ b/scene/3d/physics/vehicle_body_3d.h
@@ -40,6 +40,44 @@ class VehicleWheel3D : public Node3D {
 
 	friend class VehicleBody3D;
 
+	struct WheelXform {
+		Vector3 up;
+		Vector3 right;
+		Vector3 origin;
+		real_t steering = 0;
+	};
+
+	class FTIData {
+		real_t curr_rotation = 0;
+		real_t curr_rotation_delta = 0;
+
+	public:
+		WheelXform curr;
+		WheelXform prev;
+
+		// If a wheel is added on a frame, the xform will not be set until it has been physics updated at least once.
+		bool unset = true;
+		bool reset_queued = false;
+
+		void rotate(real_t p_delta) {
+			curr_rotation += p_delta;
+			curr_rotation_delta = p_delta;
+
+			// Wrap rotation to prevent float error.
+			double wrapped = Math::fmod(curr_rotation + Math::PI, Math::TAU);
+			if (wrapped < 0) {
+				wrapped += Math::TAU;
+			}
+			curr_rotation = wrapped - Math::PI;
+		}
+
+		void pump() {
+			prev = curr;
+			curr_rotation_delta = 0;
+		}
+		void update_world_xform(Transform3D &r_xform, real_t p_interpolation_fraction);
+	} fti_data;
+
 	Transform3D m_worldTransform;
 	Transform3D local_xform;
 	bool engine_traction = false;
@@ -193,6 +231,8 @@ class VehicleBody3D : public RigidBody3D {
 	void _update_wheel_transform(VehicleWheel3D &wheel, PhysicsDirectBodyState3D *s);
 	void _update_wheel(int p_idx, PhysicsDirectBodyState3D *s);
 
+	void _update_process_mode();
+
 	friend class VehicleWheel3D;
 	Vector<VehicleWheel3D *> wheels;
 
@@ -200,6 +240,12 @@ class VehicleBody3D : public RigidBody3D {
 
 	static void _body_state_changed_callback(void *p_instance, PhysicsDirectBodyState3D *p_state);
 	virtual void _body_state_changed(PhysicsDirectBodyState3D *p_state) override;
+
+protected:
+	void _notification(int p_what);
+
+	virtual void _physics_interpolated_changed() override;
+	virtual void fti_pump_xform() override;
 
 public:
 	void set_engine_force(real_t p_engine_force);


### PR DESCRIPTION
Now the 3D FTI has been moved to scene side, we have the opportunity to finally fix wheel interpolation to cope with high speed rotation.

Fixes #72207
Forward port of #105816

See https://github.com/godotengine/godot/pull/52846#issuecomment-979811468
See https://github.com/godotengine/godot/pull/52846#issuecomment-980526067

## Description
Uses a somewhat "new" approach of managing the wheel interpolation from the vehicle rather than the wheels. This should be more efficient, and I don't think there should be any downsides. The vehicle is therefore set to the default `physics_interpolation_mode` ON and the wheels OFF, and the vehicle controls the wheels.

## Notes
* Adds bespoke interpolation code to cope with wheels rotating at more than 180 degrees per tick.
* Now handles wrapping of the rotation to prevent float error once `m_rotation` reaches high values.
* Custom wheel interpolation solutions are no longer required in games after this PR.
* Handles `resets` and also vehicles first entering the tree on the frame, where transform must be reset _after_ the first physics tick (which is the first place an xform is available).

## Discussion
This doesn't provide a general solution to the problem of phasing, it is specific to wheels. If we later do decide on a general solution, this solution can easily be replaced.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
