### PR TITLE
Fix background size calculation in TreeItem

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2391,9 +2391,6 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				if (i == 0) {
 					r.position.x = p_draw_ofs.x;
 					r.size.x = item_width + ofs;
-				} else {
-					r.position.x -= theme_cache.h_separation;
-					r.size.x += theme_cache.h_separation;
 				}
 				if (rtl) {
 					r.position.x = get_size().width - r.position.x - r.size.x;


### PR DESCRIPTION
| Master | This PR |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/18a9ad95-e091-4f73-ab57-272f40b7fe31)  | ![image](https://github.com/user-attachments/assets/a6ff8720-edf0-471f-9ecf-621c0254baf7)  |
| ![image](https://github.com/user-attachments/assets/51b4c814-2dab-4141-875e-14926265fa14)  | ![image](https://github.com/user-attachments/assets/cd26c2bb-b365-4b18-b6ff-ae1e584f9165)  |