### PR TITLE
Add BlendSpace BlendPoint weight transitions by velocity limiting

### DIFF
--- a/doc/classes/AnimationNodeBlendSpace1D.xml
+++ b/doc/classes/AnimationNodeBlendSpace1D.xml
@@ -34,11 +34,25 @@
 				Returns the [AnimationNode] referenced by the point at index [param point].
 			</description>
 		</method>
+		<method name="get_blend_point_ovl" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="point" type="int" />
+			<description>
+				Returns the velocity limit override of the point at index [param point].
+			</description>
+		</method>
 		<method name="get_blend_point_position" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="point" type="int" />
 			<description>
 				Returns the position of the point at index [param point].
+			</description>
+		</method>
+		<method name="get_blend_point_vl" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="point" type="int" />
+			<description>
+				Returns the velocity limit of the point at index [param point].
 			</description>
 		</method>
 		<method name="remove_blend_point">
@@ -56,12 +70,28 @@
 				Changes the [AnimationNode] referenced by the point at index [param point].
 			</description>
 		</method>
+		<method name="set_blend_point_ovl">
+			<return type="void" />
+			<param index="0" name="point" type="int" />
+			<param index="1" name="override_velocity_limit" type="bool" />
+			<description>
+				Updates the velocity limit override of the point at index [param point] in the blend space.
+			</description>
+		</method>
 		<method name="set_blend_point_position">
 			<return type="void" />
 			<param index="0" name="point" type="int" />
 			<param index="1" name="pos" type="float" />
 			<description>
 				Updates the position of the point at index [param point] on the blend axis.
+			</description>
+		</method>
+		<method name="set_blend_point_vl">
+			<return type="void" />
+			<param index="0" name="point" type="int" />
+			<param index="1" name="velocity_limit" type="float" />
+			<description>
+				Updates the velocity limit of the point at index [param point] in the blend space.
 			</description>
 		</method>
 	</methods>
@@ -82,8 +112,17 @@
 			If [code]false[/code], the blended animations' frame are stopped when the blend value is [code]0[/code].
 			If [code]true[/code], forcing the blended animations to advance frame.
 		</member>
+		<member name="use_velocity_limit" type="bool" setter="set_use_velocity_limit" getter="get_use_velocity_limit" default="false">
+			If [code]true[/code], while [member sync] is [code]true[/code] a blend point's weight is applied over time using [member velocity_limit] with [member velocity_limit_ease].
+		</member>
 		<member name="value_label" type="String" setter="set_value_label" getter="get_value_label" default="&quot;value&quot;">
 			Label of the virtual axis of the blend space.
+		</member>
+		<member name="velocity_limit" type="float" setter="set_velocity_limit" getter="get_velocity_limit" default="0.0">
+			Controls the blend point velocity limit speed.
+		</member>
+		<member name="velocity_limit_ease" type="float" setter="set_velocity_limit_ease" getter="get_velocity_limit_ease" default="1.0">
+			Controls the easing of the velocity limit speed.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/AnimationNodeBlendSpace2D.xml
+++ b/doc/classes/AnimationNodeBlendSpace2D.xml
@@ -45,11 +45,25 @@
 				Returns the [AnimationRootNode] referenced by the point at index [param point].
 			</description>
 		</method>
+		<method name="get_blend_point_ovl" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="point" type="int" />
+			<description>
+				Returns the velocity limit override of the point at index [param point].
+			</description>
+		</method>
 		<method name="get_blend_point_position" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="point" type="int" />
 			<description>
 				Returns the position of the point at index [param point].
+			</description>
+		</method>
+		<method name="get_blend_point_vl" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="point" type="int" />
+			<description>
+				Returns the velocity limit of the point at index [param point].
 			</description>
 		</method>
 		<method name="get_triangle_count" qualifiers="const">
@@ -88,12 +102,28 @@
 				Changes the [AnimationNode] referenced by the point at index [param point].
 			</description>
 		</method>
+		<method name="set_blend_point_ovl">
+			<return type="void" />
+			<param index="0" name="point" type="int" />
+			<param index="1" name="override_velocity_limit" type="bool" />
+			<description>
+				Updates the velocity limit override of the point at index [param point] in the blend space.
+			</description>
+		</method>
 		<method name="set_blend_point_position">
 			<return type="void" />
 			<param index="0" name="point" type="int" />
 			<param index="1" name="pos" type="Vector2" />
 			<description>
 				Updates the position of the point at index [param point] in the blend space.
+			</description>
+		</method>
+		<method name="set_blend_point_vl">
+			<return type="void" />
+			<param index="0" name="point" type="int" />
+			<param index="1" name="velocity_limit" type="float" />
+			<description>
+				Updates the velocity limit of the point at index [param point] in the blend space.
 			</description>
 		</method>
 	</methods>
@@ -116,6 +146,15 @@
 		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
 			If [code]false[/code], the blended animations' frame are stopped when the blend value is [code]0[/code].
 			If [code]true[/code], forcing the blended animations to advance frame.
+		</member>
+		<member name="use_velocity_limit" type="bool" setter="set_use_velocity_limit" getter="get_use_velocity_limit" default="false">
+			If [code]true[/code], while [member sync] is [code]true[/code] a blend point's weight is applied over time using [member velocity_limit] with [member velocity_limit_ease].
+		</member>
+		<member name="velocity_limit" type="float" setter="set_velocity_limit" getter="get_velocity_limit" default="0.0">
+			Controls the blend point velocity limit speed.
+		</member>
+		<member name="velocity_limit_ease" type="float" setter="set_velocity_limit_ease" getter="get_velocity_limit_ease" default="1.0">
+			Controls the easing of the velocity limit speed.
 		</member>
 		<member name="x_label" type="String" setter="set_x_label" getter="get_x_label" default="&quot;x&quot;">
 			Name of the blend space's X axis.

--- a/editor/animation/animation_blend_space_1d_editor.h
+++ b/editor/animation/animation_blend_space_1d_editor.h
@@ -43,6 +43,7 @@ class PanelContainer;
 class SpinBox;
 class VSeparator;
 
+class BlendPointEditor1D;
 class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeBlendSpace1DEditor, AnimationTreeNodeEditorPlugin);
 
@@ -67,6 +68,11 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 
 	CheckBox *sync = nullptr;
 	OptionButton *interpolation = nullptr;
+
+	HBoxContainer *blending_hb = nullptr;
+	CheckBox *use_velocity_limit = nullptr;
+	SpinBox *default_velocity_limit = nullptr;
+	Ref<BlendPointEditor1D> current_blend_point_editor;
 
 	HBoxContainer *edit_hb = nullptr;
 	SpinBox *edit_value = nullptr;
@@ -134,4 +140,34 @@ public:
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) override;
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
 	AnimationNodeBlendSpace1DEditor();
+};
+
+class BlendPointEditor1D : public RefCounted {
+	GDCLASS(BlendPointEditor1D, RefCounted);
+
+private:
+	Ref<AnimationNodeBlendSpace1D> blend_space;
+	Ref<AnimationNode> anim_node;
+	float velocity_limit_ease;
+	int selected_point = -1;
+	float velocity_limit = 0.0;
+	bool override_velocity_limit = false;
+	bool updating = false;
+
+public:
+	void setup(Ref<AnimationNodeBlendSpace1D> p_blend_space, int idx, Ref<AnimationNode> p_anim_node);
+
+	void set_velocity_limit(float p_value);
+	double get_velocity_limit() const;
+	void set_override_velocity_limit(bool const p_ovl);
+	bool get_override_velocity_limit() const;
+
+	Ref<AnimationNode> get_anim_node() const;
+	void set_velocity_limit_ease(float const p_ease);
+	float get_velocity_limit_ease() const;
+	bool _hide_script_from_inspector() { return true; }
+	bool _hide_metadata_from_inspector() { return true; }
+	bool _dont_undo_redo() { return true; }
+
+	static void _bind_methods();
 };

--- a/editor/animation/animation_blend_space_2d_editor.h
+++ b/editor/animation/animation_blend_space_2d_editor.h
@@ -33,7 +33,9 @@
 #include "editor/animation/animation_tree_editor_plugin.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/animation/animation_blend_space_2d.h"
+#include "scene/gui/dialogs.h"
 #include "scene/gui/graph_edit.h"
+#include "scene/gui/tree.h"
 
 class Button;
 class CheckBox;
@@ -43,6 +45,7 @@ class PanelContainer;
 class SpinBox;
 class VSeparator;
 
+class BlendPointEditor2D;
 class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeBlendSpace2DEditor, AnimationTreeNodeEditorPlugin);
 
@@ -60,7 +63,13 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	SpinBox *snap_x = nullptr;
 	SpinBox *snap_y = nullptr;
 	CheckBox *sync = nullptr;
+
 	OptionButton *interpolation = nullptr;
+
+	HBoxContainer *blending_hb = nullptr;
+	CheckBox *use_velocity_limit = nullptr;
+	SpinBox *default_velocity_limit = nullptr;
+	Ref<BlendPointEditor2D> current_blend_point_editor;
 
 	Button *auto_triangles = nullptr;
 
@@ -145,4 +154,35 @@ public:
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) override;
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
 	AnimationNodeBlendSpace2DEditor();
+	~AnimationNodeBlendSpace2DEditor();
+};
+
+class BlendPointEditor2D : public RefCounted {
+	GDCLASS(BlendPointEditor2D, RefCounted);
+
+private:
+	Ref<AnimationNodeBlendSpace2D> blend_space;
+	Ref<AnimationNode> anim_node;
+	float velocity_limit_ease;
+	int selected_point = -1;
+	float velocity_limit = 0.0;
+	bool override_velocity_limit = false;
+	bool updating = false;
+
+public:
+	void setup(Ref<AnimationNodeBlendSpace2D> p_blend_space, int idx, Ref<AnimationNode> p_anim_node);
+
+	void set_velocity_limit(float p_value);
+	double get_velocity_limit() const;
+	void set_override_velocity_limit(bool const p_ovl);
+	bool get_override_velocity_limit() const;
+
+	Ref<AnimationNode> get_anim_node() const;
+	void set_velocity_limit_ease(float const p_ease);
+	float get_velocity_limit_ease() const;
+	bool _hide_script_from_inspector() { return true; }
+	bool _hide_metadata_from_inspector() { return true; }
+	bool _dont_undo_redo() { return true; }
+
+	static void _bind_methods();
 };

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -51,7 +51,13 @@ protected:
 		StringName name;
 		Ref<AnimationRootNode> node;
 		float position = 0.0;
+		float weight = -1.0;
+		float velocity_limit = 0.1;
+		bool override_velocity_limit = false;
 	};
+	bool use_velocity_limit = false;
+	float default_velocity_limit = 0.0;
+	float velocity_limit_ease = 1.0;
 
 	BlendPoint blend_points[MAX_BLEND_POINTS];
 	int blend_points_used = 0;
@@ -111,6 +117,23 @@ public:
 
 	void set_use_sync(bool p_sync);
 	bool is_using_sync() const;
+
+	float velocity_limit(float p_start, float p_target, float p_velocity_limit, float p_delta);
+
+	void set_blend_point_vl(int p_point, const float &p_velocity_limit);
+	float get_blend_point_vl(int p_point) const;
+
+	void set_blend_point_ovl(int p_point, const bool &p_override_velocity_limit);
+	bool get_blend_point_ovl(int p_point) const;
+
+	void set_use_velocity_limit(bool p_use_velocity_limit);
+	bool get_use_velocity_limit() const;
+
+	void set_velocity_limit(const double &p_default_blend_time);
+	double get_velocity_limit() const;
+
+	void set_velocity_limit_ease(const float p_ease);
+	float get_velocity_limit_ease() const;
 
 	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
 	String get_caption() const override;

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/animation/animation_tree.h"
+#include "scene/resources/curve.h"
 
 class AnimationNodeBlendSpace2D : public AnimationRootNode {
 	GDCLASS(AnimationNodeBlendSpace2D, AnimationRootNode);
@@ -51,7 +52,13 @@ protected:
 		StringName name;
 		Ref<AnimationRootNode> node;
 		Vector2 position;
+		float weight = -1.0;
+		float velocity_limit = 0.1;
+		bool override_velocity_limit = false;
 	};
+	bool use_velocity_limit = false;
+	float default_velocity_limit = 0.0;
+	float velocity_limit_ease = 1.0;
 
 	BlendPoint blend_points[MAX_BLEND_POINTS];
 	int blend_points_used = 0;
@@ -112,6 +119,8 @@ public:
 	void remove_triangle(int p_triangle);
 	int get_triangle_count() const;
 
+	float velocity_limit(float p_start, float p_target, float p_velocity_limit, float p_delta);
+
 	void set_min_space(const Vector2 &p_min);
 	Vector2 get_min_space() const;
 
@@ -140,6 +149,21 @@ public:
 
 	void set_use_sync(bool p_sync);
 	bool is_using_sync() const;
+
+	void set_blend_point_vl(int p_point, const float &p_velocity_limit);
+	float get_blend_point_vl(int p_point) const;
+
+	void set_blend_point_ovl(int p_point, const bool &p_override_velocity_limit);
+	bool get_blend_point_ovl(int p_point) const;
+
+	void set_use_velocity_limit(bool p_use_velocity_limit);
+	bool get_use_velocity_limit() const;
+
+	void set_velocity_limit_ease(const float p_ease);
+	float get_velocity_limit_ease() const;
+
+	void set_velocity_limit(const double &p_default_blend_time);
+	double get_velocity_limit() const;
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes godotengine/godot-proposals#12335 
Still need more input on the proposal to improve usability but its pretty much done for the most part. This is my first PR did the best I could but I'm sure some things can defiantly be improved.

Implementation of blend point weight smoothing

- [x] Weight smoothing to AnimationBlendSpace2D
- [x] Weight smoothing to AnimationBlendSpace1D
- [x] Editor UI (change smoothing to only appear when using sync and continuous)

[Demo project file](https://github.com/ZeEndy/BlendSpace-BlendPoint-Smoothing-Demo.git)

