### PR TITLE
Don't create unnecessary arrays in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -479,8 +479,8 @@ namespace Godot
         /// </returns>
         public readonly bool IntersectsPlane(Plane plane)
         {
-            Vector3[] points =
-            {
+            ReadOnlySpan<Vector3> points =
+            [
                 new Vector3(_position.X, _position.Y, _position.Z),
                 new Vector3(_position.X, _position.Y, _position.Z + _size.Z),
                 new Vector3(_position.X, _position.Y + _size.Y, _position.Z),
@@ -489,7 +489,7 @@ namespace Godot
                 new Vector3(_position.X + _size.X, _position.Y, _position.Z + _size.Z),
                 new Vector3(_position.X + _size.X, _position.Y + _size.Y, _position.Z),
                 new Vector3(_position.X + _size.X, _position.Y + _size.Y, _position.Z + _size.Z)
-            };
+            ];
 
             bool over = false;
             bool under = false;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -1665,8 +1665,8 @@ namespace Godot
         /// <returns>The position of the first non-zero digit.</returns>
         public static int StepDecimals(double step)
         {
-            double[] sd = new double[]
-            {
+            ReadOnlySpan<double> sd =
+            [
                 0.9999,
                 0.09999,
                 0.009999,
@@ -1676,7 +1676,7 @@ namespace Godot
                 0.0000009999,
                 0.00000009999,
                 0.000000009999,
-            };
+            ];
             double abs = Math.Abs(step);
             double decs = abs - (int)abs; // Strip away integer part
             for (int i = 0; i < sd.Length; i++)


### PR DESCRIPTION
Replaces two local array (`type[]`) declarations with `ReadOnlySpan<type>`.
Using collection expressions (`[ ... ]`) with `ReadOnlySpan<type>` is short-hand for `stackalloc type[] { ... }` which avoids unnecessary allocations.

This should dramatically improve performance for these two functions:
- `Aabb.IntersectsPlane(Plane)`
- `Mathf.StepDecimals(double)`