### PR TITLE
Add original index field to fuzzy search result

### DIFF
--- a/core/string/fuzzy_search.cpp
+++ b/core/string/fuzzy_search.cpp
@@ -338,9 +338,10 @@ bool FuzzySearch::search(const String &p_target, FuzzySearchResult &p_result) co
 void FuzzySearch::search_all(const PackedStringArray &p_targets, Vector<FuzzySearchResult> &p_results) const {
 	p_results.clear();
 
-	for (const String &target : p_targets) {
+	for (int i = 0; i < p_targets.size(); i++) {
 		FuzzySearchResult result;
-		if (search(target, result)) {
+		result.original_index = i;
+		if (search(p_targets[i], result)) {
 			p_results.append(result);
 		}
 	}

--- a/core/string/fuzzy_search.h
+++ b/core/string/fuzzy_search.h
@@ -76,6 +76,7 @@ class FuzzySearchResult {
 public:
 	String target;
 	int score = 0;
+	int original_index = -1;
 	int dir_index = -1;
 	Vector<FuzzyTokenMatch> token_matches;
 };


### PR DESCRIPTION
Very simple pr to track the original index within the targets array of a given fuzzy search result. This is useful as typically there is other data associated with whatever is being searched against and without this new field it's required to build a path to data mapping. Specifically, see https://github.com/godotengine/godot/pull/105239 and https://github.com/godotengine/godot/pull/105240.

I briefly looked into applying this new field to the current use case of the quick open dialog but it would require reworking how history is incorporated into the results so I didn't think it was worth it. Hypothetically it would be a tiny bit faster to do so as it would replace a few hash lookups with indexed lookups.