### PR TITLE
Support overriding `speaker_mode` in `AudioServer`

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -461,6 +461,11 @@
 		<member name="audio/driver/output_latency.web" type="int" setter="" getter="" default="50">
 			Safer override for [member audio/driver/output_latency] in the Web platform, to avoid audio issues especially on mobile devices.
 		</member>
+		<member name="audio/driver/speaker_mode_override" type="int" setter="" getter="" default="0">
+			Override the speaker mode used internally by Godot. [code]Disabled[/code] will use the audio driver's speaker mode, while other values will override the internal speaker mode, and thus the number of audio channels, used by the [AudioServer].
+			When the [AudioServer] speaker mode is overridden and differs from the audio driver's speaker mode, audio channels will be ignored or muted, depending on if there are more channels than the driver supports, or fewer (respectively).
+			This setting can itself be overridden using the [code]--speaker-mode-override &lt;mode&gt;[/code] command line argument.
+		</member>
 		<member name="audio/general/2d_panning_strength" type="float" setter="" getter="" default="0.5">
 			The base strength of the panning effect for all [AudioStreamPlayer2D] nodes. The panning strength can be further scaled on each Node using [member AudioStreamPlayer2D.panning_strength]. A value of [code]0.0[/code] disables stereo panning entirely, leaving only volume attenuation in place. A value of [code]1.0[/code] completely mutes one of the channels if the sound is located exactly to the left (or right) of the listener.
 			The default value of [code]0.5[/code] is tuned for headphones. When using speakers, you may find lower values to sound better as speakers have a lower stereo separation compared to headphones.
@@ -484,11 +489,6 @@
 		</member>
 		<member name="audio/general/ios/session_category" type="int" setter="" getter="" default="0" keywords="ambient, play, record, solo">
 			Sets the [url=https://developer.apple.com/documentation/avfaudio/avaudiosessioncategory]AVAudioSessionCategory[/url] on iOS. Use the [code]Playback[/code] category to get sound output, even if the phone is in silent mode.
-		</member>
-		<member name="audio/general/speaker_mode_override" type="int" setter="" getter="" default="0">
-			Override the speaker mode used internally by Godot. [code]Disabled[/code] will use the Godot audio driver's speaker mode, while other values will override the internal speaker mode, and thus the number of audio channels, used by the [AudioServer].
-			When the [AudioServer] speaker mode is overridden and differs from the audio driver's speaker mode, audio channels will be ignored or muted, depending on if there are more channels than the driver supports, or fewer (respectively).
-			This setting can itself be overridden using the [code]--speaker-mode-override &lt;mode&gt;[/code] command line argument.
 		</member>
 		<member name="audio/general/text_to_speech" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], text-to-speech support is enabled on startup, otherwise it is enabled the first time any TTS method is used. See also [method DisplayServer.tts_get_voices] and [method DisplayServer.tts_speak].

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -461,7 +461,7 @@
 		<member name="audio/driver/output_latency.web" type="int" setter="" getter="" default="50">
 			Safer override for [member audio/driver/output_latency] in the Web platform, to avoid audio issues especially on mobile devices.
 		</member>
-		<member name="audio/driver/speaker_mode_override" type="int" setter="" getter="" default="0">
+		<member name="audio/driver/speaker_mode_override" type="int" setter="" getter="" default="-1">
 			Override the speaker mode used internally by Godot. Can be used to enforce a particular speaker mode (e.g. stereo in a 2D game), or to help test or troubleshoot different speaker configurations.
 			[code]Disabled[/code] will use the audio driver's speaker mode, while other values will override the internal speaker mode, and thus the number of audio channels, used by the [AudioServer].
 			If the specified mode has fewer channels than the system's audio driver, remaining channels will not receive any audio.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -485,10 +485,10 @@
 		<member name="audio/general/ios/session_category" type="int" setter="" getter="" default="0" keywords="ambient, play, record, solo">
 			Sets the [url=https://developer.apple.com/documentation/avfaudio/avaudiosessioncategory]AVAudioSessionCategory[/url] on iOS. Use the [code]Playback[/code] category to get sound output, even if the phone is in silent mode.
 		</member>
-		<member name="audio/general/speaker_mode" type="int" setter="" getter="" default="0">
-			The speaker mode used internally by Godot. [code]Default[/code] will use the audio driver's speaker mode, while other values will override the internal speaker mode, and thus the number of audio channels, used by the [AudioServer].
-			When the [AudioServer] speaker mode differs from the audio driver's speaker mode, audio channels will be ignored or muted, depending on if there are more channels than the driver supports, or fewer (respectively).
-			This setting can be overridden using the [code]--speaker-mode &lt;mode&gt;[/code] command line argument.
+		<member name="audio/general/speaker_mode_override" type="int" setter="" getter="" default="0">
+			Override the speaker mode used internally by Godot. [code]Disabled[/code] will use the Godot audio driver's speaker mode, while other values will override the internal speaker mode, and thus the number of audio channels, used by the [AudioServer].
+			When the [AudioServer] speaker mode is overridden and differs from the audio driver's speaker mode, audio channels will be ignored or muted, depending on if there are more channels than the driver supports, or fewer (respectively).
+			This setting can itself be overridden using the [code]--speaker-mode-override &lt;mode&gt;[/code] command line argument.
 		</member>
 		<member name="audio/general/text_to_speech" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], text-to-speech support is enabled on startup, otherwise it is enabled the first time any TTS method is used. See also [method DisplayServer.tts_get_voices] and [method DisplayServer.tts_speak].

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -485,9 +485,10 @@
 		<member name="audio/general/ios/session_category" type="int" setter="" getter="" default="0" keywords="ambient, play, record, solo">
 			Sets the [url=https://developer.apple.com/documentation/avfaudio/avaudiosessioncategory]AVAudioSessionCategory[/url] on iOS. Use the [code]Playback[/code] category to get sound output, even if the phone is in silent mode.
 		</member>
-		<member name="audio/general/speaker_mode" type="int" setter="" getter="" default="-1">
+		<member name="audio/general/speaker_mode" type="int" setter="" getter="" default="0">
 			The speaker mode used internally by Godot. [code]Default[/code] will use the audio driver's speaker mode, while other values will override the internal speaker mode, and thus the number of audio channels, used by the [AudioServer].
-			When the internal speaker mode differs from the driver's speaker mode, audio channels will be muted, ignored, or mapped to the audio driver's channels.
+			When the [AudioServer] speaker mode differs from the audio driver's speaker mode, audio channels will be ignored or muted, depending on if there are more channels than the driver supports, or fewer (respectively).
+			This setting can be overridden using the [code]--speaker-mode &lt;mode&gt;[/code] command line argument.
 		</member>
 		<member name="audio/general/text_to_speech" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], text-to-speech support is enabled on startup, otherwise it is enabled the first time any TTS method is used. See also [method DisplayServer.tts_get_voices] and [method DisplayServer.tts_speak].

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -462,8 +462,10 @@
 			Safer override for [member audio/driver/output_latency] in the Web platform, to avoid audio issues especially on mobile devices.
 		</member>
 		<member name="audio/driver/speaker_mode_override" type="int" setter="" getter="" default="0">
-			Override the speaker mode used internally by Godot. [code]Disabled[/code] will use the audio driver's speaker mode, while other values will override the internal speaker mode, and thus the number of audio channels, used by the [AudioServer].
-			When the [AudioServer] speaker mode is overridden and differs from the audio driver's speaker mode, audio channels will be ignored or muted, depending on if there are more channels than the driver supports, or fewer (respectively).
+			Override the speaker mode used internally by Godot. Can be used to enforce a particular speaker mode (e.g. stereo in a 2D game), or to help test or troubleshoot different speaker configurations.
+			[code]Disabled[/code] will use the audio driver's speaker mode, while other values will override the internal speaker mode, and thus the number of audio channels, used by the [AudioServer].
+			If the specified mode has fewer channels than the system's audio driver, remaining channels will not receive any audio.
+			If the specified mode has more channels than the system's audio driver, the superfluous channels will be discarded.
 			This setting can itself be overridden using the [code]--speaker-mode-override &lt;mode&gt;[/code] command line argument.
 		</member>
 		<member name="audio/general/2d_panning_strength" type="float" setter="" getter="" default="0.5">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -485,6 +485,10 @@
 		<member name="audio/general/ios/session_category" type="int" setter="" getter="" default="0" keywords="ambient, play, record, solo">
 			Sets the [url=https://developer.apple.com/documentation/avfaudio/avaudiosessioncategory]AVAudioSessionCategory[/url] on iOS. Use the [code]Playback[/code] category to get sound output, even if the phone is in silent mode.
 		</member>
+		<member name="audio/general/speaker_mode" type="int" setter="" getter="" default="-1">
+			The speaker mode used internally by Godot. [code]Default[/code] will use the audio driver's speaker mode, while other values will override the internal speaker mode, and thus the number of audio channels, used by the [AudioServer].
+			When the internal speaker mode differs from the driver's speaker mode, audio channels will be muted, ignored, or mapped to the audio driver's channels.
+		</member>
 		<member name="audio/general/text_to_speech" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], text-to-speech support is enabled on startup, otherwise it is enabled the first time any TTS method is used. See also [method DisplayServer.tts_get_voices] and [method DisplayServer.tts_speak].
 			[b]Note:[/b] Enabling TTS can cause additional idle CPU usage and interfere with the sleep mode, so consider disabling it if TTS is not used.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -271,6 +271,7 @@ static bool debug_mute_audio = false;
 static int max_fps = -1;
 static int frame_delay = 0;
 static int audio_output_latency = 0;
+static int speaker_mode = -1;
 static bool disable_render_loop = false;
 static int fixed_fps = -1;
 static MovieWriter *movie_writer = nullptr;
@@ -605,6 +606,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("].\n");
 	print_help_option("--audio-output-latency <ms>", "Override audio output latency in milliseconds (default is 15 ms).\n");
 	print_help_option("", "Lower values make sound playback more reactive but increase CPU usage, and may result in audio cracking if the CPU can't keep up.\n");
+	print_help_option("--speaker-mode <mode>", "Override speaker mode used by Godot to mix audio (0: driver default, 1: stereo, 2: 3.1 surround, 3: 5.1 surround, 4: 7.1 surround).\n");
 
 	print_help_option("--rendering-method <renderer>", "Renderer name. Requires driver support.\n");
 	print_help_option("--rendering-driver <driver>", "Rendering driver (depends on display driver).\n");
@@ -1225,6 +1227,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing audio output latency argument, aborting.\n");
+				goto error;
+			}
+		} else if (arg == "--speaker-mode") {
+			if (N) {
+				speaker_mode = N->get().to_int();
+				N = N->next();
+			} else {
+				OS::get_singleton()->print("Missing speaker mode argument, aborting.\n");
 				goto error;
 			}
 		} else if (arg == "--text-driver") {
@@ -3464,6 +3474,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 		// Right moment to create and initialize the audio server.
 		audio_server = memnew(AudioServer);
 		audio_server->init();
+		audio_server->set_speaker_mode_config(speaker_mode);
 
 		OS::get_singleton()->benchmark_end_measure("Servers", "Audio");
 	}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -271,7 +271,7 @@ static bool debug_mute_audio = false;
 static int max_fps = -1;
 static int frame_delay = 0;
 static int audio_output_latency = 0;
-static int speaker_mode_override = -1;
+static int speaker_mode_override = -2;
 static bool disable_render_loop = false;
 static int fixed_fps = -1;
 static MovieWriter *movie_writer = nullptr;
@@ -606,7 +606,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("].\n");
 	print_help_option("--audio-output-latency <ms>", "Override audio output latency in milliseconds (default is 15 ms).\n");
 	print_help_option("", "Lower values make sound playback more reactive but increase CPU usage, and may result in audio cracking if the CPU can't keep up.\n");
-	print_help_option("--speaker-mode-override <mode>", "Override speaker mode used by the audio engine to mix audio (0: driver default (disable override), 1: force stereo, 2: force 3.1 surround, 3: force 5.1 surround, 4: force 7.1 surround).\n");
+	print_help_option("--speaker-mode-override <mode>", "Override speaker mode [\"disabled\", \"stereo\", \"3.1\", \"5.1\", \"7.1\"].\n");
 
 	print_help_option("--rendering-method <renderer>", "Renderer name. Requires driver support.\n");
 	print_help_option("--rendering-driver <driver>", "Rendering driver (depends on display driver).\n");
@@ -1231,10 +1231,24 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			}
 		} else if (arg == "--speaker-mode-override") {
 			if (N) {
-				speaker_mode_override = N->get().to_int();
+				String override_mode = N->get().to_lower();
 				N = N->next();
+				if (override_mode == "disabled") {
+					speaker_mode_override = -1;
+				} else if (override_mode == "stereo") {
+					speaker_mode_override = AudioServer::SPEAKER_MODE_STEREO;
+				} else if (override_mode == "3.1") {
+					speaker_mode_override = AudioServer::SPEAKER_SURROUND_31;
+				} else if (override_mode == "5.1") {
+					speaker_mode_override = AudioServer::SPEAKER_SURROUND_51;
+				} else if (override_mode == "7.1") {
+					speaker_mode_override = AudioServer::SPEAKER_SURROUND_71;
+				} else {
+					OS::get_singleton()->print("Unknown --speaker-mode-override argument \"%s\", aborting.\n", override_mode.ascii().get_data());
+					goto error;
+				}
 			} else {
-				OS::get_singleton()->print("Missing speaker mode override argument, aborting.\n");
+				OS::get_singleton()->print("Missing --speaker-mode-override argument, aborting.\n");
 				goto error;
 			}
 		} else if (arg == "--text-driver") {
@@ -3474,7 +3488,9 @@ Error Main::setup2(bool p_show_boot_logo) {
 		// Right moment to create and initialize the audio server.
 		audio_server = memnew(AudioServer);
 		audio_server->init();
-		audio_server->set_speaker_mode_config(speaker_mode_override);
+		if (speaker_mode_override >= -1) {
+			audio_server->set_speaker_mode_config(speaker_mode_override);
+		}
 
 		OS::get_singleton()->benchmark_end_measure("Servers", "Audio");
 	}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -606,7 +606,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("].\n");
 	print_help_option("--audio-output-latency <ms>", "Override audio output latency in milliseconds (default is 15 ms).\n");
 	print_help_option("", "Lower values make sound playback more reactive but increase CPU usage, and may result in audio cracking if the CPU can't keep up.\n");
-	print_help_option("--speaker-mode-override <mode>", "Override speaker mode used by Godot to mix audio (0: driver default (disable override), 1: force stereo, 2: force 3.1 surround, 3: force 5.1 surround, 4: force 7.1 surround).\n");
+	print_help_option("--speaker-mode-override <mode>", "Override speaker mode used by the audio engine to mix audio (0: driver default (disable override), 1: force stereo, 2: force 3.1 surround, 3: force 5.1 surround, 4: force 7.1 surround).\n");
 
 	print_help_option("--rendering-method <renderer>", "Renderer name. Requires driver support.\n");
 	print_help_option("--rendering-driver <driver>", "Rendering driver (depends on display driver).\n");

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -271,7 +271,7 @@ static bool debug_mute_audio = false;
 static int max_fps = -1;
 static int frame_delay = 0;
 static int audio_output_latency = 0;
-static int speaker_mode = -1;
+static int speaker_mode_override = -1;
 static bool disable_render_loop = false;
 static int fixed_fps = -1;
 static MovieWriter *movie_writer = nullptr;
@@ -606,7 +606,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("].\n");
 	print_help_option("--audio-output-latency <ms>", "Override audio output latency in milliseconds (default is 15 ms).\n");
 	print_help_option("", "Lower values make sound playback more reactive but increase CPU usage, and may result in audio cracking if the CPU can't keep up.\n");
-	print_help_option("--speaker-mode <mode>", "Override speaker mode used by Godot to mix audio (0: driver default, 1: stereo, 2: 3.1 surround, 3: 5.1 surround, 4: 7.1 surround).\n");
+	print_help_option("--speaker-mode-override <mode>", "Override speaker mode used by Godot to mix audio (0: driver default (disable override), 1: force stereo, 2: force 3.1 surround, 3: force 5.1 surround, 4: force 7.1 surround).\n");
 
 	print_help_option("--rendering-method <renderer>", "Renderer name. Requires driver support.\n");
 	print_help_option("--rendering-driver <driver>", "Rendering driver (depends on display driver).\n");
@@ -1229,12 +1229,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing audio output latency argument, aborting.\n");
 				goto error;
 			}
-		} else if (arg == "--speaker-mode") {
+		} else if (arg == "--speaker-mode-override") {
 			if (N) {
-				speaker_mode = N->get().to_int();
+				speaker_mode_override = N->get().to_int();
 				N = N->next();
 			} else {
-				OS::get_singleton()->print("Missing speaker mode argument, aborting.\n");
+				OS::get_singleton()->print("Missing speaker mode override argument, aborting.\n");
 				goto error;
 			}
 		} else if (arg == "--text-driver") {
@@ -3474,7 +3474,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 		// Right moment to create and initialize the audio server.
 		audio_server = memnew(AudioServer);
 		audio_server->init();
-		audio_server->set_speaker_mode_config(speaker_mode);
+		audio_server->set_speaker_mode_config(speaker_mode_override);
 
 		OS::get_singleton()->benchmark_end_measure("Servers", "Audio");
 	}

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -43,6 +43,7 @@ _arguments \
   '--remote-fs-password[password for remote filesystem]:remote filesystem password' \
   '--audio-driver[set the audio driver]:audio driver name' \
   '--audio-output-latency[override audio output latency in milliseconds (default is 15 ms)]:number of milliseconds' \
+  '--speaker-mode-override[speaker mode override used to mix audio]:speaker override mode:(disabled(0), stereo(1), 3.1(2), 5.1(3), 7.1(4))' \
   '--display-driver[set the display driver]:display driver name' \
   "--rendering-method[set the renderer]:renderer name:((forward_plus\:'Desktop renderer' mobile\:'Desktop and mobile renderer' gl_compatibility\:'Desktop, mobile and web renderer'))" \
   "--rendering-driver[set the rendering driver]:rendering driver name:((vulkan\:'Vulkan renderer' opengl3\:'OpenGL ES 3.0 renderer' dummy\:'Dummy renderer'))" \

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -43,7 +43,7 @@ _arguments \
   '--remote-fs-password[password for remote filesystem]:remote filesystem password' \
   '--audio-driver[set the audio driver]:audio driver name' \
   '--audio-output-latency[override audio output latency in milliseconds (default is 15 ms)]:number of milliseconds' \
-  '--speaker-mode-override[speaker mode override used to mix audio]:speaker override mode:(disabled(0), stereo(1), 3.1(2), 5.1(3), 7.1(4))' \
+  '--speaker-mode-override[speaker mode override used to mix audio]:speaker override mode:(disabled stereo 3.1 5.1 7.1)' \
   '--display-driver[set the display driver]:display driver name' \
   "--rendering-method[set the renderer]:renderer name:((forward_plus\:'Desktop renderer' mobile\:'Desktop and mobile renderer' gl_compatibility\:'Desktop, mobile and web renderer'))" \
   "--rendering-driver[set the rendering driver]:rendering driver name:((vulkan\:'Vulkan renderer' opengl3\:'OpenGL ES 3.0 renderer' dummy\:'Dummy renderer'))" \

--- a/misc/dist/shell/godot.bash-completion
+++ b/misc/dist/shell/godot.bash-completion
@@ -44,6 +44,7 @@ _complete_godot_options() {
 --remote-fs-password
 --audio-driver
 --audio-output-latency
+--speaker-mode-override
 --display-driver
 --rendering-method
 --rendering-driver

--- a/misc/dist/shell/godot.fish
+++ b/misc/dist/shell/godot.fish
@@ -59,6 +59,7 @@ complete -c godot -l remote-fs -d "Use a remote filesystem (<host/IP>[:<port>] a
 complete -c godot -l remote-fs-password -d "Password for remote filesystem" -x
 complete -c godot -l audio-driver -d "Set the audio driver" -x
 complete -c godot -l audio-output-latency -d "Override audio output latency in milliseconds (default is 15 ms)" -x
+complete -c godot -l speaker-mode-override -d "Override speaker mode used to mix audio" -x -a "0=disabled 1=stereo 2=3.1 3=5.1 4=7.1"
 complete -c godot -l display-driver -d "Set the display driver" -x
 complete -c godot -l rendering-method -d "Set the renderer" -x -a "(godot_rendering_method_args)"
 complete -c godot -l rendering-driver -d "Set the rendering driver" -x -a "(godot_rendering_driver_args)"

--- a/misc/dist/shell/godot.fish
+++ b/misc/dist/shell/godot.fish
@@ -59,7 +59,7 @@ complete -c godot -l remote-fs -d "Use a remote filesystem (<host/IP>[:<port>] a
 complete -c godot -l remote-fs-password -d "Password for remote filesystem" -x
 complete -c godot -l audio-driver -d "Set the audio driver" -x
 complete -c godot -l audio-output-latency -d "Override audio output latency in milliseconds (default is 15 ms)" -x
-complete -c godot -l speaker-mode-override -d "Override speaker mode used to mix audio" -x -a "0=disabled 1=stereo 2=3.1 3=5.1 4=7.1"
+complete -c godot -l speaker-mode-override -d "Override speaker mode used to mix audio" -x -a "disabled stereo 3.1 5.1 7.1"
 complete -c godot -l display-driver -d "Set the display driver" -x
 complete -c godot -l rendering-method -d "Set the renderer" -x -a "(godot_rendering_method_args)"
 complete -c godot -l rendering-driver -d "Set the rendering driver" -x -a "(godot_rendering_driver_args)"

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -1538,7 +1538,7 @@ void AudioServer::init() {
 	channel_disable_threshold_db = GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_threshold_db", PROPERTY_HINT_RANGE, "-80,0,0.1,suffix:dB"), -60.0);
 	channel_disable_frames = float(GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_time", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"), 2.0)) * get_mix_rate();
 
-	speaker_mode_config = GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/speaker_mode_override", PROPERTY_HINT_ENUM, "Disabled:0,Force Stereo:1,Force Surround 3.1:2,Force Surround 5.1:3,Force Surround 7.1:4"), 0);
+	speaker_mode_config = GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/driver/speaker_mode_override", PROPERTY_HINT_ENUM, "Disabled:0,Force Stereo:1,Force Surround 3.1:2,Force Surround 5.1:3,Force Surround 7.1:4"), 0);
 
 	// TODO: Buffer size is hardcoded for now. This would be really nice to have as a project setting because currently it limits audio latency to an absolute minimum of 11ms with default mix rate, but there's some additional work required to make that happen. See TODOs in `_mix_step_for_channel`.
 	// When this becomes a project setting, it should be specified in milliseconds rather than raw sample count, because 512 samples at 192khz is shorter than it is at 48khz, for example.
@@ -1566,15 +1566,9 @@ void AudioServer::init() {
 	}
 }
 
-void AudioServer::set_speaker_mode_config(int p_speaker_mode) {
-	if (p_speaker_mode >= 0 && p_speaker_mode <= 4) {
-		speaker_mode_config = p_speaker_mode;
-	}
-}
-
 void AudioServer::_project_settings_changed_cb() {
 	lock();
-	set_speaker_mode_config(GLOBAL_GET("audio/general/speaker_mode_override"));
+	set_speaker_mode_config(GLOBAL_GET("audio/driver/speaker_mode_override"));
 	unlock();
 }
 
@@ -1695,6 +1689,12 @@ void AudioServer::lock() {
 
 void AudioServer::unlock() {
 	AudioDriver::get_singleton()->unlock();
+}
+
+void AudioServer::set_speaker_mode_config(int p_speaker_mode) {
+	if (p_speaker_mode >= 0 && p_speaker_mode <= 4) {
+		speaker_mode_config = p_speaker_mode;
+	}
 }
 
 AudioServer::SpeakerMode AudioServer::get_speaker_mode() const {

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -1538,7 +1538,7 @@ void AudioServer::init() {
 	channel_disable_threshold_db = GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_threshold_db", PROPERTY_HINT_RANGE, "-80,0,0.1,suffix:dB"), -60.0);
 	channel_disable_frames = float(GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_time", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"), 2.0)) * get_mix_rate();
 
-	speaker_mode_config = GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/driver/speaker_mode_override", PROPERTY_HINT_ENUM, "Disabled:0,Force Stereo:1,Force Surround 3.1:2,Force Surround 5.1:3,Force Surround 7.1:4"), 0);
+	speaker_mode_config = GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/driver/speaker_mode_override", PROPERTY_HINT_ENUM, "Disabled:-1,Force Stereo:0,Force 3.1 Surround:1,Force 5.1 Surround:2,Force 7.1 Surround:3"), -1);
 
 	// TODO: Buffer size is hardcoded for now. This would be really nice to have as a project setting because currently it limits audio latency to an absolute minimum of 11ms with default mix rate, but there's some additional work required to make that happen. See TODOs in `_mix_step_for_channel`.
 	// When this becomes a project setting, it should be specified in milliseconds rather than raw sample count, because 512 samples at 192khz is shorter than it is at 48khz, for example.
@@ -1692,20 +1692,18 @@ void AudioServer::unlock() {
 }
 
 void AudioServer::set_speaker_mode_config(int p_speaker_mode) {
-	if (p_speaker_mode >= 0 && p_speaker_mode <= 4) {
-		speaker_mode_config = p_speaker_mode;
-	}
+	speaker_mode_config = p_speaker_mode;
 }
 
 AudioServer::SpeakerMode AudioServer::get_speaker_mode() const {
 	switch (speaker_mode_config) {
-		case 1:
+		case 0:
 			return SPEAKER_MODE_STEREO;
-		case 2:
+		case 1:
 			return SPEAKER_SURROUND_31;
-		case 3:
+		case 2:
 			return SPEAKER_SURROUND_51;
-		case 4:
+		case 3:
 			return SPEAKER_SURROUND_71;
 		default:
 			return get_driver_speaker_mode();
@@ -1714,13 +1712,13 @@ AudioServer::SpeakerMode AudioServer::get_speaker_mode() const {
 
 String AudioServer::_get_speaker_mode_name() const {
 	switch (speaker_mode_config) {
-		case 1:
+		case 0:
 			return "Stereo";
-		case 2:
+		case 1:
 			return "Surround 3.1";
-		case 3:
+		case 2:
 			return "Surround 5.1";
-		case 4:
+		case 3:
 			return "Surround 7.1";
 		default:
 			return "Default";

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -267,7 +267,7 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 #endif
 
 	if (channel_count != get_channel_count()) {
-		// Amount of channels changed due to a output_device change
+		// Number of channels changed due to a output_device or speaker_mode change
 		// reinitialize the buses channels and buffers
 		init_channels_and_buffers();
 	}
@@ -285,8 +285,9 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 		int from = buffer_size - to_mix;
 		int from_buf = p_frames - todo;
 
-		//master master, send to output
-		int cs = master->channels.size();
+		// Channels size from driver and channels used by master
+		int cs = get_driver_channel_count();
+		int mcs = master->channels.size();
 
 		// Take away 1 from the stride, as we are manually incrementing by 1 for stereo.
 		uintptr_t stride_minus_one = (cs * 2) - 1;
@@ -296,9 +297,9 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 			int32_t *dest = &p_buffer[from_buf * (cs * 2) + (k * 2)];
 
 #ifdef DEBUG_ENABLED
-			if (!debug_mute && master->channels[k].active) {
+			if (!debug_mute && k < mcs && master->channels[k].active) {
 #else
-			if (master->channels[k].active) {
+			if (k < mcs && master->channels[k].active) {
 #endif // DEBUG_ENABLED
 				const AudioFrame *buf = master->channels[k].buffer.ptr();
 
@@ -1488,6 +1489,24 @@ String AudioServer::get_driver_name() const {
 	return AudioDriver::get_singleton()->get_name();
 }
 
+AudioServer::SpeakerMode AudioServer::get_driver_speaker_mode() const {
+	return (AudioServer::SpeakerMode)AudioDriver::get_singleton()->get_speaker_mode();
+}
+
+int AudioServer::get_driver_channel_count() const {
+	switch (get_driver_speaker_mode()) {
+		case SPEAKER_MODE_STEREO:
+			return 1;
+		case SPEAKER_SURROUND_31:
+			return 2;
+		case SPEAKER_SURROUND_51:
+			return 3;
+		case SPEAKER_SURROUND_71:
+			return 4;
+	}
+	ERR_FAIL_V(1);
+}
+
 void AudioServer::notify_listener_changed() {
 	for (CallbackItem *ci : listener_changed_callback_list) {
 		ci->callback(ci->userdata);
@@ -1496,6 +1515,9 @@ void AudioServer::notify_listener_changed() {
 
 void AudioServer::init_channels_and_buffers() {
 	channel_count = get_channel_count();
+
+	print_verbose(vformat("AudioServer: Speaker mode set to %s, initializing %d stereo channel(s)", _get_speaker_mode_name(), channel_count));
+
 	temp_buffer.resize(channel_count);
 	mix_buffer.resize(buffer_size + LOOKAHEAD_BUFFER_SIZE);
 
@@ -1515,6 +1537,9 @@ void AudioServer::init_channels_and_buffers() {
 void AudioServer::init() {
 	channel_disable_threshold_db = GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_threshold_db", PROPERTY_HINT_RANGE, "-80,0,0.1,suffix:dB"), -60.0);
 	channel_disable_frames = float(GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_time", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"), 2.0)) * get_mix_rate();
+
+	speaker_mode_config = GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/speaker_mode", PROPERTY_HINT_ENUM, "Default:-1,Stereo:0,Surround 3.1:1,Surround 5.1:2,Surround 7.1:3"), -1);
+
 	// TODO: Buffer size is hardcoded for now. This would be really nice to have as a project setting because currently it limits audio latency to an absolute minimum of 11ms with default mix rate, but there's some additional work required to make that happen. See TODOs in `_mix_step_for_channel`.
 	// When this becomes a project setting, it should be specified in milliseconds rather than raw sample count, because 512 samples at 192khz is shorter than it is at 48khz, for example.
 	buffer_size = 512;
@@ -1535,6 +1560,14 @@ void AudioServer::init() {
 #endif
 
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "audio/video/video_delay_compensation_ms", PROPERTY_HINT_RANGE, "-1000,1000,1,suffix:ms"), 0);
+
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &AudioServer::project_settings_changed));
+}
+
+void AudioServer::project_settings_changed() {
+	lock();
+	speaker_mode_config = GLOBAL_GET("audio/general/speaker_mode");
+	unlock();
 }
 
 void AudioServer::update() {
@@ -1657,7 +1690,33 @@ void AudioServer::unlock() {
 }
 
 AudioServer::SpeakerMode AudioServer::get_speaker_mode() const {
-	return (AudioServer::SpeakerMode)AudioDriver::get_singleton()->get_speaker_mode();
+	switch (speaker_mode_config) {
+		case 0:
+			return SPEAKER_MODE_STEREO;
+		case 1:
+			return SPEAKER_SURROUND_31;
+		case 2:
+			return SPEAKER_SURROUND_51;
+		case 3:
+			return SPEAKER_SURROUND_71;
+		default:
+			return get_driver_speaker_mode();
+	}
+}
+
+String AudioServer::_get_speaker_mode_name() const {
+	switch (speaker_mode_config) {
+		case 0:
+			return "Stereo";
+		case 1:
+			return "Surround 3.1";
+		case 2:
+			return "Surround 5.1";
+		case 3:
+			return "Surround 7.1";
+		default:
+			return "Default";
+	}
 }
 
 float AudioServer::get_mix_rate() const {

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -267,8 +267,8 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 #endif
 
 	if (channel_count != get_channel_count()) {
-		// Number of channels changed due to a output_device or speaker_mode change
-		// reinitialize the buses channels and buffers
+		// Number of channels changed due to an output_device or speaker_mode change,
+		// reinitialize the buses channels and buffers.
 		init_channels_and_buffers();
 	}
 
@@ -285,9 +285,9 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 		int from = buffer_size - to_mix;
 		int from_buf = p_frames - todo;
 
-		// Channels size from driver and channels used by master
+		// Channels size from driver and channels used by master.
 		int cs = get_driver_channel_count();
-		int mcs = master->channels.size();
+		int master_cs = master->channels.size();
 
 		// Take away 1 from the stride, as we are manually incrementing by 1 for stereo.
 		uintptr_t stride_minus_one = (cs * 2) - 1;
@@ -297,9 +297,9 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 			int32_t *dest = &p_buffer[from_buf * (cs * 2) + (k * 2)];
 
 #ifdef DEBUG_ENABLED
-			if (!debug_mute && k < mcs && master->channels[k].active) {
+			if (!debug_mute && k < master_cs && master->channels[k].active) {
 #else
-			if (k < mcs && master->channels[k].active) {
+			if (k < master_cs && master->channels[k].active) {
 #endif // DEBUG_ENABLED
 				const AudioFrame *buf = master->channels[k].buffer.ptr();
 

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -1516,7 +1516,7 @@ void AudioServer::notify_listener_changed() {
 void AudioServer::init_channels_and_buffers() {
 	channel_count = get_channel_count();
 
-	print_verbose(vformat("AudioServer: Speaker mode set to %s, initializing %d stereo channel(s)", _get_speaker_mode_name(), channel_count));
+	print_verbose(vformat("AudioServer: Speaker mode set to %s, initializing %d stereo channel%s", _get_speaker_mode_name(), channel_count, channel_count == 1 ? "" : "s"));
 
 	temp_buffer.resize(channel_count);
 	mix_buffer.resize(buffer_size + LOOKAHEAD_BUFFER_SIZE);
@@ -1538,7 +1538,7 @@ void AudioServer::init() {
 	channel_disable_threshold_db = GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_threshold_db", PROPERTY_HINT_RANGE, "-80,0,0.1,suffix:dB"), -60.0);
 	channel_disable_frames = float(GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_time", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"), 2.0)) * get_mix_rate();
 
-	speaker_mode_config = GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/speaker_mode", PROPERTY_HINT_ENUM, "Default:0,Stereo:1,Surround 3.1:2,Surround 5.1:3,Surround 7.1:4"), 0);
+	speaker_mode_config = GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/speaker_mode_override", PROPERTY_HINT_ENUM, "Disabled:0,Force Stereo:1,Force Surround 3.1:2,Force Surround 5.1:3,Force Surround 7.1:4"), 0);
 
 	// TODO: Buffer size is hardcoded for now. This would be really nice to have as a project setting because currently it limits audio latency to an absolute minimum of 11ms with default mix rate, but there's some additional work required to make that happen. See TODOs in `_mix_step_for_channel`.
 	// When this becomes a project setting, it should be specified in milliseconds rather than raw sample count, because 512 samples at 192khz is shorter than it is at 48khz, for example.
@@ -1574,7 +1574,7 @@ void AudioServer::set_speaker_mode_config(int p_speaker_mode) {
 
 void AudioServer::_project_settings_changed_cb() {
 	lock();
-	set_speaker_mode_config(GLOBAL_GET("audio/general/speaker_mode"));
+	set_speaker_mode_config(GLOBAL_GET("audio/general/speaker_mode_override"));
 	unlock();
 }
 

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -1538,7 +1538,7 @@ void AudioServer::init() {
 	channel_disable_threshold_db = GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_threshold_db", PROPERTY_HINT_RANGE, "-80,0,0.1,suffix:dB"), -60.0);
 	channel_disable_frames = float(GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_time", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"), 2.0)) * get_mix_rate();
 
-	speaker_mode_config = GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/speaker_mode", PROPERTY_HINT_ENUM, "Default:-1,Stereo:0,Surround 3.1:1,Surround 5.1:2,Surround 7.1:3"), -1);
+	speaker_mode_config = GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/speaker_mode", PROPERTY_HINT_ENUM, "Default:0,Stereo:1,Surround 3.1:2,Surround 5.1:3,Surround 7.1:4"), 0);
 
 	// TODO: Buffer size is hardcoded for now. This would be really nice to have as a project setting because currently it limits audio latency to an absolute minimum of 11ms with default mix rate, but there's some additional work required to make that happen. See TODOs in `_mix_step_for_channel`.
 	// When this becomes a project setting, it should be specified in milliseconds rather than raw sample count, because 512 samples at 192khz is shorter than it is at 48khz, for example.
@@ -1561,12 +1561,20 @@ void AudioServer::init() {
 
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "audio/video/video_delay_compensation_ms", PROPERTY_HINT_RANGE, "-1000,1000,1,suffix:ms"), 0);
 
-	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &AudioServer::project_settings_changed));
+	if (Engine::get_singleton()->is_editor_hint()) {
+		ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &AudioServer::_project_settings_changed_cb));
+	}
 }
 
-void AudioServer::project_settings_changed() {
+void AudioServer::set_speaker_mode_config(int p_speaker_mode) {
+	if (p_speaker_mode >= 0 && p_speaker_mode <= 4) {
+		speaker_mode_config = p_speaker_mode;
+	}
+}
+
+void AudioServer::_project_settings_changed_cb() {
 	lock();
-	speaker_mode_config = GLOBAL_GET("audio/general/speaker_mode");
+	set_speaker_mode_config(GLOBAL_GET("audio/general/speaker_mode"));
 	unlock();
 }
 
@@ -1691,13 +1699,13 @@ void AudioServer::unlock() {
 
 AudioServer::SpeakerMode AudioServer::get_speaker_mode() const {
 	switch (speaker_mode_config) {
-		case 0:
-			return SPEAKER_MODE_STEREO;
 		case 1:
-			return SPEAKER_SURROUND_31;
+			return SPEAKER_MODE_STEREO;
 		case 2:
-			return SPEAKER_SURROUND_51;
+			return SPEAKER_SURROUND_31;
 		case 3:
+			return SPEAKER_SURROUND_51;
+		case 4:
 			return SPEAKER_SURROUND_71;
 		default:
 			return get_driver_speaker_mode();
@@ -1706,13 +1714,13 @@ AudioServer::SpeakerMode AudioServer::get_speaker_mode() const {
 
 String AudioServer::_get_speaker_mode_name() const {
 	switch (speaker_mode_config) {
-		case 0:
-			return "Stereo";
 		case 1:
-			return "Surround 3.1";
+			return "Stereo";
 		case 2:
-			return "Surround 5.1";
+			return "Surround 3.1";
 		case 3:
+			return "Surround 5.1";
+		case 4:
 			return "Surround 7.1";
 		default:
 			return "Default";

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -224,6 +224,8 @@ private:
 	int channel_count = 0;
 	int to_mix = 0;
 
+	int speaker_mode_config = -1;
+
 	float playback_speed_scale = 1.0f;
 
 	bool tag_used_audio_streams = false;
@@ -325,6 +327,8 @@ private:
 
 	void _update_bus_effects(int p_bus);
 
+	String _get_speaker_mode_name() const;
+
 	static AudioServer *singleton;
 
 	void init_channels_and_buffers();
@@ -377,6 +381,8 @@ public:
 	void set_debug_mute(bool p_mute);
 	bool get_debug_mute() const;
 #endif // DEBUG_ENABLED
+
+	void project_settings_changed();
 
 	void set_bus_count(int p_count);
 	int get_bus_count() const;
@@ -451,6 +457,8 @@ public:
 	uint64_t get_mixed_frames() const;
 
 	String get_driver_name() const;
+	SpeakerMode get_driver_speaker_mode() const;
+	int get_driver_channel_count() const;
 
 	void notify_listener_changed();
 

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -348,6 +348,8 @@ private:
 	SafeList<CallbackItem *> mix_callback_list;
 	SafeList<CallbackItem *> listener_changed_callback_list;
 
+	void _project_settings_changed_cb();
+
 	friend class AudioDriver;
 	void _driver_process(int p_frames, int32_t *p_buffer);
 
@@ -381,8 +383,6 @@ public:
 	void set_debug_mute(bool p_mute);
 	bool get_debug_mute() const;
 #endif // DEBUG_ENABLED
-
-	void project_settings_changed();
 
 	void set_bus_count(int p_count);
 	int get_bus_count() const;
@@ -459,6 +459,8 @@ public:
 	String get_driver_name() const;
 	SpeakerMode get_driver_speaker_mode() const;
 	int get_driver_channel_count() const;
+
+	void set_speaker_mode_config(int p_speaker_mode);
 
 	void notify_listener_changed();
 

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -224,8 +224,8 @@ private:
 	int channel_count = 0;
 	int to_mix = 0;
 
-	// Either '1 + SpeakerMode' for any SpeakerMode enum value, or any other value for default.
-	int speaker_mode_config = 0;
+	// Either a SpeakerMode value, or any other value for default.
+	int speaker_mode_config = -1;
 
 	float playback_speed_scale = 1.0f;
 

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -224,7 +224,8 @@ private:
 	int channel_count = 0;
 	int to_mix = 0;
 
-	int speaker_mode_config = -1;
+	// Either '1 + SpeakerMode' for any SpeakerMode enum value, or any other value for default.
+	int speaker_mode_config = 0;
 
 	float playback_speed_scale = 1.0f;
 


### PR DESCRIPTION
**Updated**: _Refactored this to only handle setting/overriding the `speaker_mode` of a project. Channel remapping will be moved to another PR._

Adds support (via project settings under `audio/general/speaker_mode_override`) to the `AudioServer` to change the speaker mode (i.e. number of channels) that Godot uses internally, independent of the audio driver used. It can also be set by command line argument `--speaker-mode-override`, which will override the project setting.

It can be used to test more channels (e.g. 7.1 surround when using a stereo audio setup), or fewer channels (e.g. stereo when using a 7.1 surround setup). This is primarily intended to be used to help troubleshoot audio issues when testing with different speaker setups, or hard coding a speaker mode for a project. But it can also be used by end users to tweak how the engine behaves for their specific hardware, using the command line arg.

~~This PR also adds the ability to remap internal channels onto different output channels of the audio device. For example, you can remap the rear or side stereo channels of a 7.1 surround system into the front channels of a stereo system in order to verify the audio is correct.~~

This is a extension of, and replacement for #105682. Like that PR, this feature makes it possible for Godot developers without the necessary surround sound peripheral to reproduce bugs and review fixes to issues that are the result of an unanticipated number of channels, such as: #92532
