### PR TITLE
Wayland: Fix compile error with DBUS disabled

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1541,7 +1541,10 @@ bool DisplayServerWayland::color_picker(const Callable &p_callback) {
 	// TODO: Use window IDs for multiwindow support.
 
 	WaylandThread::WindowState *ws = wayland_thread.wl_surface_get_window_state(wayland_thread.window_get_wl_surface(window_id));
+#ifdef DBUS_ENABLED
 	return portal_desktop->color_picker((ws ? ws->exported_handle : String()), p_callback);
+#endif
+	return false;
 }
 
 void DisplayServerWayland::try_suspend() {


### PR DESCRIPTION
fix  /platform/linuxbsd/wayland/display_server_wayland.cpp  line:1544 Compile error when turning off DBUS
