### PR TITLE
CI: Run `apt update` before installing libxml2-utils

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Class reference schema checks
         run: |
+          sudo apt update
           sudo apt install -y libxml2-utils
           xmllint --quiet --noout --schema doc/class.xsd doc/classes/*.xml modules/*/doc_classes/*.xml platform/*/doc_classes/*.xml
 


### PR DESCRIPTION
Ubuntu repo seems to be flaky on the current image: 

https://github.com/godotengine/godot/actions/runs/14751221864/job/41408963450?pr=105892