### PR TITLE
Make `script_class_get_icon_path()` return any value when `r_valid` is passed.

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1024,10 +1024,12 @@ String EditorData::script_class_get_icon_path(const String &p_class, bool *r_val
 		}
 		HashMap<StringName, String>::ConstIterator E = _script_class_icon_paths.find(current);
 		if ((bool)E) {
-			if (r_valid && !E->value.is_empty()) {
-				*r_valid = true;
+			if (r_valid) {
+				*r_valid = !E->value.is_empty();
+				return E->value;
+			} else if (!E->value.is_empty()) {
+				return E->value;
 			}
-			return E->value;
 		}
 		current = ScriptServer::get_global_class_base(current);
 	}


### PR DESCRIPTION
Closes #105194 by making it so when passing something to `r_value` in `script_class_get_icon_path()`, the function returns `E->value`, even if `value` is empty.
This is needed due to [this (IMO useless optimization)](https://github.com/godotengine/godot/blob/ce94b26de74a0a0f2463c5dc61b9b683a1e3676b/editor/editor_data.cpp#L1125-L1135). Removing these 11 lines also fixes the problem, and to which I just think this overcomplication isn't worth saving a couple of instruction. But maybe I'm just missing something.