### PR TITLE
Add editor setting to collapse main menu into a `MenuButton`

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -836,6 +836,11 @@
 		<member name="interface/editor/code_font_size" type="int" setter="" getter="">
 			The size of the font in the script editor. This setting does not impact the font size of the Output panel (see [member run/output/font_size]).
 		</member>
+		<member name="interface/editor/collapse_main_menu" type="bool" setter="" getter="">
+			If [code]true[/code], the main menu collapses into a [MenuButton].
+			[b]Note:[/b] This setting is only applicable on macOS when [member interface/editor/use_embedded_menu] is [code]true[/code].
+			[b]Note:[/b] Defaults to [code]true[/code] on the Android editor.
+		</member>
 		<member name="interface/editor/custom_display_scale" type="float" setter="" getter="">
 			The custom editor scale factor to use. This can be used for displays with very high DPI where a scale factor of 200% is not sufficient.
 			[b]Note:[/b] Only effective if [member interface/editor/display_scale] is set to [b]Custom[/b].

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7426,21 +7426,27 @@ EditorNode::EditorNode() {
 	main_vbox = memnew(VBoxContainer);
 
 #ifdef ANDROID_ENABLED
-	main_hbox = memnew(HBoxContainer);
-	main_hbox->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	base_vbox = memnew(VBoxContainer);
+	base_vbox->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT, Control::PRESET_MODE_MINSIZE, theme->get_constant(SNAME("window_border_margin"), EditorStringName(Editor)));
 
+	title_bar = memnew(EditorTitleBar);
+	base_vbox->add_child(title_bar);
+
+	main_hbox = memnew(HBoxContainer);
 	main_hbox->add_child(main_vbox);
 	main_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	main_hbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	base_vbox->add_child(main_hbox);
 
 	_touch_actions_panel_mode_changed();
 
-	gui_base->add_child(main_hbox);
+	gui_base->add_child(base_vbox);
 #else
 	gui_base->add_child(main_vbox);
-#endif
 
 	title_bar = memnew(EditorTitleBar);
 	main_vbox->add_child(title_bar);
+#endif
 
 	left_l_hsplit = memnew(DockSplitContainer);
 	left_l_hsplit->set_name("DockHSplitLeftL");

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -282,7 +282,8 @@ private:
 	OptionButton *renderer = nullptr;
 
 #ifdef ANDROID_ENABLED
-	HBoxContainer *main_hbox = nullptr; // Only created on Android for TouchActionsPanel.
+	VBoxContainer *base_vbox = nullptr; // It only contains the title_bar and main_hbox.
+	HBoxContainer *main_hbox = nullptr; // It only contains the touch_actions_panel and main_vbox.
 	TouchActionsPanel *touch_actions_panel = nullptr;
 	void _touch_actions_panel_mode_changed();
 #endif

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -45,6 +45,7 @@ class ColorPicker;
 class ConfirmationDialog;
 class Control;
 class FileDialog;
+class HBoxContainer;
 class MenuBar;
 class MenuButton;
 class OptionButton;
@@ -100,7 +101,6 @@ class SceneImportSettingsDialog;
 class ProjectUpgradeTool;
 
 #ifdef ANDROID_ENABLED
-class HBoxContainer;
 class TouchActionsPanel;
 #endif
 
@@ -325,7 +325,16 @@ private:
 	Control *right_menu_spacer = nullptr;
 	EditorTitleBar *title_bar = nullptr;
 	EditorRunBar *project_run_bar = nullptr;
-	MenuBar *main_menu = nullptr;
+	HBoxContainer *right_menu_hb = nullptr;
+
+	// Spacers to center 2D / 3D / Script buttons.
+	HBoxContainer *left_spacer = nullptr;
+	Control *right_spacer = nullptr;
+
+	Control *menu_btn_spacer = nullptr;
+	MenuButton *main_menu_button = nullptr;
+	MenuBar *main_menu_bar = nullptr;
+
 	PopupMenu *apple_menu = nullptr;
 	PopupMenu *file_menu = nullptr;
 	PopupMenu *project_menu = nullptr;
@@ -688,6 +697,9 @@ private:
 	void _execute_upgrades();
 
 	bool _is_project_data_missing();
+
+	void _update_main_menu_type();
+	void _add_to_main_menu(const String &p_name, PopupMenu *p_menu);
 
 protected:
 	friend class FileSystemDock;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -529,6 +529,14 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/vsync_mode", 1, "Disabled,Enabled,Adaptive,Mailbox")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/update_continuously", false, "")
 
+	bool is_android_editor = false;
+#ifdef ANDROID_ENABLED
+	if (!OS::get_singleton()->has_feature("xr_editor")) {
+		is_android_editor = true;
+	}
+#endif
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/collapse_main_menu", is_android_editor, "")
+
 	_initial_set("interface/editors/show_scene_tree_root_selection", true);
 	_initial_set("interface/editors/derive_script_globals_by_name", true);
 	_initial_set("docks/scene_tree/ask_before_revoking_unique_name", true);

--- a/editor/gui/touch_actions_panel.cpp
+++ b/editor/gui/touch_actions_panel.cpp
@@ -240,7 +240,6 @@ TouchActionsPanel::TouchActionsPanel() {
 	}
 
 	box = memnew(BoxContainer);
-	box->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 	box->add_theme_constant_override("separation", 20);
 	if (is_floating) {
 		box->set_vertical(EDITOR_DEF("_touch_actions_panel_vertical_layout", false));


### PR DESCRIPTION
This PR adds an editor setting `interface/editor/collapse_main_menu` to collapse the main menu. It replaces `MenuBar` with a `MenuButton` to reduce clutter on the title bar. Given the limited screen space on mobile, the full menubar occupies too much horizontal space. On devices with a more square-ish aspect ratio, some of the content also gets cut off on the right side.

![square-ish tablet](https://github.com/user-attachments/assets/5b4d9e3e-9036-4477-b0b5-5cdf26cd99dd)


The new button opens a popup containing the same menu options previously available in the menubar, preserving functionality while making the layout compact.

https://github.com/user-attachments/assets/6491b358-9e5e-4b2f-b3d3-70dc03893d63
