### PR TITLE
Improve `GraphEdit` signals

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -452,13 +452,17 @@
 			</description>
 		</signal>
 		<signal name="copy_nodes_request">
+			<param index="0" name="nodes" type="StringName[]" />
 			<description>
 				Emitted when this [GraphEdit] captures a [code]ui_copy[/code] action ([kbd]Ctrl + C[/kbd] by default). In general, this signal indicates that the selected [GraphElement]s should be copied.
+				[param nodes] is an array of node names that should be copied. These usually include all selected nodes.
 			</description>
 		</signal>
 		<signal name="cut_nodes_request">
+			<param index="0" name="nodes" type="StringName[]" />
 			<description>
 				Emitted when this [GraphEdit] captures a [code]ui_cut[/code] action ([kbd]Ctrl + X[/kbd] by default). In general, this signal indicates that the selected [GraphElement]s should be cut.
+				[param nodes] is an array of node names that should be cut. These usually include all selected nodes.
 			</description>
 		</signal>
 		<signal name="delete_nodes_request">
@@ -478,8 +482,10 @@
 			</description>
 		</signal>
 		<signal name="duplicate_nodes_request">
+			<param index="0" name="nodes" type="StringName[]" />
 			<description>
 				Emitted when this [GraphEdit] captures a [code]ui_graph_duplicate[/code] action ([kbd]Ctrl + D[/kbd] by default). In general, this signal indicates that the selected [GraphElement]s should be duplicated.
+				[param nodes] is an array of node names that should be duplicated. These usually include all selected nodes.
 			</description>
 		</signal>
 		<signal name="end_node_move">

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2268,7 +2268,7 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 
 void GraphEdit::key_input(const Ref<InputEvent> &p_ev) {
 	if (p_ev->is_pressed()) {
-		if (p_ev->is_action("ui_graph_duplicate", true)) {
+		if (p_ev->is_action("ui_graph_duplicate", true)) { //maybe create a function to do this
 			TypedArray<StringName> nodes;
 
 			for (int i = 0; i < get_child_count(); i++) {

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2269,13 +2269,49 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 void GraphEdit::key_input(const Ref<InputEvent> &p_ev) {
 	if (p_ev->is_pressed()) {
 		if (p_ev->is_action("ui_graph_duplicate", true)) {
-			emit_signal(SNAME("duplicate_nodes_request"));
+			TypedArray<StringName> nodes;
+
+			for (int i = 0; i < get_child_count(); i++) {
+				GraphElement *graph_element = Object::cast_to<GraphElement>(get_child(i));
+				if (!graph_element) {
+					continue;
+				}
+				if (graph_element->is_selected()) {
+					nodes.push_back(graph_element->get_name());
+				}
+			}
+
+			emit_signal(SNAME("duplicate_nodes_request"), nodes);
 			accept_event();
 		} else if (p_ev->is_action("ui_copy", true)) {
-			emit_signal(SNAME("copy_nodes_request"));
+			TypedArray<StringName> nodes;
+
+			for (int i = 0; i < get_child_count(); i++) {
+				GraphElement *graph_element = Object::cast_to<GraphElement>(get_child(i));
+				if (!graph_element) {
+					continue;
+				}
+				if (graph_element->is_selected()) {
+					nodes.push_back(graph_element->get_name());
+				}
+			}
+
+			emit_signal(SNAME("copy_nodes_request"), nodes);
 			accept_event();
 		} else if (p_ev->is_action("ui_cut", true)) {
-			emit_signal(SNAME("cut_nodes_request"));
+			TypedArray<StringName> nodes;
+
+			for (int i = 0; i < get_child_count(); i++) {
+				GraphElement *graph_element = Object::cast_to<GraphElement>(get_child(i));
+				if (!graph_element) {
+					continue;
+				}
+				if (graph_element->is_selected()) {
+					nodes.push_back(graph_element->get_name());
+				}
+			}
+
+			emit_signal(SNAME("cut_nodes_request"), nodes);
 			accept_event();
 		} else if (p_ev->is_action("ui_paste", true)) {
 			emit_signal(SNAME("paste_nodes_request"));
@@ -3080,10 +3116,10 @@ void GraphEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("connection_drag_started", PropertyInfo(Variant::STRING_NAME, "from_node"), PropertyInfo(Variant::INT, "from_port"), PropertyInfo(Variant::BOOL, "is_output")));
 	ADD_SIGNAL(MethodInfo("connection_drag_ended"));
 
-	ADD_SIGNAL(MethodInfo("copy_nodes_request"));
-	ADD_SIGNAL(MethodInfo("cut_nodes_request"));
+	ADD_SIGNAL(MethodInfo("copy_nodes_request", PropertyInfo(Variant::ARRAY, "nodes", PROPERTY_HINT_ARRAY_TYPE, "StringName")));
+	ADD_SIGNAL(MethodInfo("cut_nodes_request", PropertyInfo(Variant::ARRAY, "nodes", PROPERTY_HINT_ARRAY_TYPE, "StringName")));
 	ADD_SIGNAL(MethodInfo("paste_nodes_request"));
-	ADD_SIGNAL(MethodInfo("duplicate_nodes_request"));
+	ADD_SIGNAL(MethodInfo("duplicate_nodes_request", PropertyInfo(Variant::ARRAY, "nodes", PROPERTY_HINT_ARRAY_TYPE, "StringName")));
 	ADD_SIGNAL(MethodInfo("delete_nodes_request", PropertyInfo(Variant::ARRAY, "nodes", PROPERTY_HINT_ARRAY_TYPE, "StringName")));
 
 	ADD_SIGNAL(MethodInfo("node_selected", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12322

Add parameters to the `copy_nodes_request`, `duplicate_nodes_request`, and `cut_nodes_request` signals, in the same way that `delete_nodes_request` already does. These parameters allow you to obtain the list of nodes to select when copying, cutting, or duplicating. This makes graphs easier to use.
The parameters have been added to the signals documentation in godot.

![Capture d'écran 2025-04-30 160157](https://github.com/user-attachments/assets/77574724-9635-427a-8879-b3dc4683985d)
![Capture d'écran 2025-04-30 160056](https://github.com/user-attachments/assets/eeb69a37-1473-4342-a067-c4637e031c6c)

