### PR TITLE
Add aligned memory interface to gdextension

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -275,6 +275,19 @@ static void gdextension_mem_free(void *p_mem) {
 	memfree(p_mem);
 }
 
+static void *gdextension_mem_aligned_alloc(size_t p_size, size_t p_alignment) {
+	return Memory::alloc_aligned_static(p_size, p_alignment);
+}
+
+static void *gdextension_mem_aligned_realloc(void *p_mem, size_t p_size, size_t p_prev_size, size_t p_alignment) {
+	return Memory::realloc_aligned_static(p_mem, p_size, p_prev_size, p_alignment);
+}
+
+static void gdextension_mem_aligned_free(void *p_mem) {
+	Memory::free_aligned_static(p_mem);
+}
+
+
 // Helper print functions.
 static void gdextension_print_error(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify) {
 	_err_print_error(p_function, p_file, p_line, p_description, p_editor_notify, ERR_HANDLER_ERROR);

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -862,6 +862,44 @@ typedef void *(*GDExtensionInterfaceMemRealloc)(void *p_ptr, size_t p_bytes);
  */
 typedef void (*GDExtensionInterfaceMemFree)(void *p_ptr);
 
+/**
+ * @name mem_aligned_alloc
+ * @since 4.5
+ * 
+ * Allocates memory aligned to user input
+ * 
+ * @param p_bytes The amount of memory to allocate in bytes
+ * @param p_align The alignment of the memory block to allocate to the nearest byte
+ * 
+ * @return A pointer to the allocated aligned memory, or NULL if unsucessful
+ */
+typedef void *(*GDExtensionInterfaceMemAlignedAlloc)(size_t p_bytes, size_t p_align);
+
+/**
+ * @name mem_aligned_realloc
+ * @since 4.5
+ *
+ * Reallocates memory aligned to user input.
+ *
+ * @param p_ptr A pointer to the previously allocated aligned memory.
+ * @param p_bytes The number of bytes to resize the memory block to.
+ * @param p_prev_bytes The previous size of the memory block in bytes.
+ * @param p_align The alignment of the memory block to allocate to the nearest byte.
+ *
+ * @return A pointer to the allocated aligned memory, or NULL if unsuccessful.
+ */
+typedef void *(*GDExtensionInterfaceMemAlignedRealloc)(void *p_ptr, size_t p_bytes, size_t p_prev_bytes, size_t p_align);
+
+/**
+ * @name mem_aligned_free
+ * @since 4.5
+ *
+ * Frees memory allocated with `mem_aligned_alloc`.
+ *
+ * @param p_ptr A pointer to the previously allocated aligned memory.
+ */
+typedef void (*GDExtensionInterfaceMemAlignedFree)(void *p_ptr);
+
 /* INTERFACE: Godot Core */
 
 /**


### PR DESCRIPTION
Adds gdextension interface to aligned memory control methods.

See [the proposal](https://github.com/godotengine/godot-proposals/issues/12336) for more information.