### PR TITLE
Fix oversampling for embedded windows using content scale.

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1322,6 +1322,7 @@ void Window::_update_viewport_size() {
 
 	if (embedder) {
 		float scale = MIN(embedder->stretch_transform.get_scale().width, embedder->stretch_transform.get_scale().height);
+		Viewport::set_oversampling_override(scale);
 		Size2 s = Size2(final_size.width * scale, final_size.height * scale).ceil();
 		RS::get_singleton()->viewport_set_global_canvas_transform(get_viewport_rid(), global_canvas_transform * scale * content_scale_factor);
 		RS::get_singleton()->viewport_set_size(get_viewport_rid(), s.width, s.height);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105941

| Before | After|
|---|---|
| <img width="1036" alt="Screenshot 2025-04-30 at 17 33 48" src="https://github.com/user-attachments/assets/a1f4d1f2-7243-4e74-9f6c-66b6642a0517" /> | <img width="1036" alt="Screenshot 2025-04-30 at 17 31 29" src="https://github.com/user-attachments/assets/65fdd7c8-a078-43f6-bf74-a9fc8f9e679d" /> |