### PR TITLE
Fix array span constructors in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Godot.NativeInterop;
 using System.Diagnostics;
+using System.ComponentModel;
 
 #nullable enable
 
@@ -83,96 +84,92 @@ namespace Godot.Collections
         /// Constructs a new <see cref="Array"/> from the given span's elements.
         /// </summary>
         /// <exception cref="ArgumentNullException">
-        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// The <paramref name="span"/> is <see langword="null"/>.
         /// </exception>
         /// <returns>A new Godot Array.</returns>
-        public Array(Span<StringName> array)
+        public Array(scoped ReadOnlySpan<StringName> span)
         {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
-
             NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
             _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
 
-            int length = array.Length;
+            int length = span.Length;
 
             Resize(length);
 
             for (int i = 0; i < length; i++)
-                this[i] = array[i];
+                this[i] = span[i];
         }
+
+        /// <inheritdoc cref="Array(ReadOnlySpan{StringName})"/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Array(scoped Span<StringName> span) : this((ReadOnlySpan<StringName>)span) { }
 
         /// <summary>
         /// Constructs a new <see cref="Array"/> from the given span's elements.
         /// </summary>
         /// <exception cref="ArgumentNullException">
-        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// The <paramref name="span"/> is <see langword="null"/>.
         /// </exception>
         /// <returns>A new Godot Array.</returns>
-        public Array(Span<NodePath> array)
+        public Array(scoped ReadOnlySpan<NodePath> span)
         {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
-
             NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
             _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
 
-            int length = array.Length;
+            int length = span.Length;
 
             Resize(length);
 
             for (int i = 0; i < length; i++)
-                this[i] = array[i];
+                this[i] = span[i];
         }
+
+        /// <inheritdoc cref="Array(ReadOnlySpan{NodePath})"/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Array(scoped Span<NodePath> span) : this((ReadOnlySpan<NodePath>)span) { }
 
         /// <summary>
         /// Constructs a new <see cref="Array"/> from the given span's elements.
         /// </summary>
         /// <exception cref="ArgumentNullException">
-        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// The <paramref name="span"/> is <see langword="null"/>.
         /// </exception>
         /// <returns>A new Godot Array.</returns>
-        public Array(Span<Rid> array)
+        public Array(scoped ReadOnlySpan<Rid> span)
         {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
-
             NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
             _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
 
-            int length = array.Length;
+            int length = span.Length;
 
             Resize(length);
 
             for (int i = 0; i < length; i++)
-                this[i] = array[i];
+                this[i] = span[i];
         }
 
-        // We must use ReadOnlySpan instead of Span here as this can accept implicit conversions
-        // from derived types (e.g.: Node[]). Implicit conversion from Derived[] to Base[] are
-        // fine as long as the array is not mutated. However, Span does this type checking at
-        // instantiation, so it's not possible to use it even when not mutating anything.
+        /// <inheritdoc cref="Array(ReadOnlySpan{Rid})"/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Array(scoped Span<Rid> span) : this((ReadOnlySpan<Rid>)span) { }
+
         /// <summary>
         /// Constructs a new <see cref="Array"/> from the given ReadOnlySpan's elements.
         /// </summary>
         /// <exception cref="ArgumentNullException">
-        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// The <paramref name="span"/> is <see langword="null"/>.
         /// </exception>
         /// <returns>A new Godot Array.</returns>
-        public Array(ReadOnlySpan<GodotObject> array)
+        public Array(scoped ReadOnlySpan<GodotObject> span)
         {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
-
             NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
             _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
 
-            int length = array.Length;
+            int length = span.Length;
 
             Resize(length);
 
             for (int i = 0; i < length; i++)
-                this[i] = array[i];
+                this[i] = span[i];
         }
 
         private Array(godot_array nativeValueToOwn)


### PR DESCRIPTION
Fixes the `Span`/`ReadOnlySpan` constructors for `Godot.Collections.Array` in C#.

The following code:
```cs
Godot.Collections.Array Array = new(new Span<StringName>());
GD.Print(Array);
```
Throws:
```
E 0:00:03:219   Array.cs:92 @ Godot.Collections.Array..ctor(System.Span`1[Godot.StringName]): System.ArgumentNullException: Value cannot be null. (Parameter 'array')
  <C# Error>    System.ArgumentNullException
  <C# Source>   /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs:92 @ Godot.Collections.Array..ctor(System.Span`1[Godot.StringName])
  <Stack Trace> Array.cs:92 @ Godot.Collections.Array..ctor(System.Span`1[Godot.StringName])
                Mirror.cs:5 @ void Mirror._Ready()
                Node.cs:2546 @ bool Godot.Node.InvokeGodotClassMethod(Godot.NativeInterop.godot_string_name&, Godot.NativeInterop.NativeVariantPtrArgs, Godot.NativeInterop.godot_variant&)
                Node3D.cs:1101 @ bool Godot.Node3D.InvokeGodotClassMethod(Godot.NativeInterop.godot_string_name&, Godot.NativeInterop.NativeVariantPtrArgs, Godot.NativeInterop.godot_variant&)
                Mirror_ScriptMethods.generated.cs:48 @ bool Mirror.InvokeGodotClassMethod(Godot.NativeInterop.godot_string_name&, Godot.NativeInterop.NativeVariantPtrArgs, Godot.NativeInterop.godot_variant&)
                CSharpInstanceBridge.cs:24 @ Godot.NativeInterop.godot_bool Godot.Bridge.CSharpInstanceBridge.Call(nint, Godot.NativeInterop.godot_string_name*, Godot.NativeInterop.godot_variant**, int, Godot.NativeInterop.godot_variant_call_error*, Godot.NativeInterop.godot_variant*)
```

The reason is that the constructors erroneously assume that `Span`/`ReadOnlySpan` are nullable, and that `null` checks are necessary. In fact, they are not only not nullable, making these checks redundant, but there is an implicit cast from arrays to spans, meaning casting `null` to a `Span`/`ReadOnlySpan` actually creates an empty span. So `span == null` is the same as `span.IsEmpty`.

I also took the opportunity to normalise the use of `ReadOnlySpan` rather than `Span` to allow read-only spans, add `scoped` to make it clear that `stackalloc` is allowed, and renamed the parameter for clarity.