### PR TITLE
Add methods to get project settings without warnings for unknown settings

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -358,6 +358,18 @@ bool ProjectSettings::_get(const StringName &p_name, Variant &r_ret) const {
 Variant ProjectSettings::get_setting_with_override_and_custom_features(const StringName &p_name, const Vector<String> &p_features) const {
 	_THREAD_SAFE_METHOD_
 
+	return _get_setting_with_override_and_custom_features(p_name, p_features, true);
+}
+
+Variant ProjectSettings::get_setting_with_override_and_custom_features_or_null(const StringName &p_name, const Vector<String> &p_features) const {
+	_THREAD_SAFE_METHOD_
+
+	return _get_setting_with_override_and_custom_features(p_name, p_features, false);
+}
+
+Variant ProjectSettings::_get_setting_with_override_and_custom_features(const StringName &p_name, const Vector<String> &p_features, bool p_warn_not_found) const {
+	_THREAD_SAFE_METHOD_
+
 	StringName name = p_name;
 	if (feature_overrides.has(name)) {
 		const LocalVector<Pair<StringName, StringName>> &overrides = feature_overrides[name];
@@ -372,13 +384,27 @@ Variant ProjectSettings::get_setting_with_override_and_custom_features(const Str
 	}
 
 	if (!props.has(name)) {
-		WARN_PRINT("Property not found: " + String(name));
+		if (p_warn_not_found) {
+			WARN_PRINT(vformat("Project setting not found, returning `null`: \"%s\"", name));
+		}
 		return Variant();
 	}
 	return props[name].variant;
 }
 
 Variant ProjectSettings::get_setting_with_override(const StringName &p_name) const {
+	_THREAD_SAFE_METHOD_
+
+	return _get_setting_with_override(p_name, true);
+}
+
+Variant ProjectSettings::get_setting_with_override_or_null(const StringName &p_name) const {
+	_THREAD_SAFE_METHOD_
+
+	return _get_setting_with_override(p_name, false);
+}
+
+Variant ProjectSettings::_get_setting_with_override(const StringName &p_name, bool p_warn_not_found) const {
 	_THREAD_SAFE_METHOD_
 
 	const LocalVector<Pair<StringName, StringName>> *overrides = feature_overrides.getptr(p_name);
@@ -398,7 +424,9 @@ Variant ProjectSettings::get_setting_with_override(const StringName &p_name) con
 
 	const RBMap<StringName, VariantContainer>::Element *prop = props.find(p_name);
 	if (!prop) {
-		WARN_PRINT(vformat("Property not found: '%s'.", p_name));
+		if (p_warn_not_found) {
+			WARN_PRINT(vformat("Project setting not found, returning `null`: \"%s\"", p_name));
+		}
 		return Variant();
 	}
 
@@ -1427,7 +1455,8 @@ void ProjectSettings::get_argument_options(const StringName &p_function, int p_i
 	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "has_setting" || pf == "set_setting" || pf == "get_setting" || pf == "get_setting_with_override" ||
-				pf == "set_order" || pf == "get_order" || pf == "set_initial_value" || pf == "set_as_basic" ||
+				pf == "get_setting_with_override_or_null" || pf == "set_order" || pf == "get_order" ||
+				pf == "set_initial_value" || pf == "set_as_basic" ||
 				pf == "set_as_internal" || pf == "set_restart_if_changed" || pf == "clear") {
 			for (const KeyValue<StringName, VariantContainer> &E : props) {
 				if (E.value.hide_from_editor) {
@@ -1447,8 +1476,10 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_setting", "name", "value"), &ProjectSettings::set_setting);
 	ClassDB::bind_method(D_METHOD("get_setting", "name", "default_value"), &ProjectSettings::get_setting, DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("get_setting_with_override", "name"), &ProjectSettings::get_setting_with_override);
-	ClassDB::bind_method(D_METHOD("get_global_class_list"), &ProjectSettings::get_global_class_list);
+	ClassDB::bind_method(D_METHOD("get_setting_with_override_or_null", "name"), &ProjectSettings::get_setting_with_override_or_null);
 	ClassDB::bind_method(D_METHOD("get_setting_with_override_and_custom_features", "name", "features"), &ProjectSettings::get_setting_with_override_and_custom_features);
+	ClassDB::bind_method(D_METHOD("get_setting_with_override_and_custom_features_or_null", "name", "features"), &ProjectSettings::get_setting_with_override_and_custom_features_or_null);
+	ClassDB::bind_method(D_METHOD("get_global_class_list"), &ProjectSettings::get_global_class_list);
 	ClassDB::bind_method(D_METHOD("set_order", "name", "position"), &ProjectSettings::set_order);
 	ClassDB::bind_method(D_METHOD("get_order", "name"), &ProjectSettings::get_order);
 	ClassDB::bind_method(D_METHOD("set_initial_value", "name", "value"), &ProjectSettings::set_initial_value);

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -193,7 +193,11 @@ public:
 	List<String> get_input_presets() const { return input_presets; }
 
 	Variant get_setting_with_override(const StringName &p_name) const;
+	Variant get_setting_with_override_or_null(const StringName &p_name) const;
+	Variant _get_setting_with_override(const StringName &p_name, bool p_warn_not_found) const;
 	Variant get_setting_with_override_and_custom_features(const StringName &p_name, const Vector<String> &p_features) const;
+	Variant get_setting_with_override_and_custom_features_or_null(const StringName &p_name, const Vector<String> &p_features) const;
+	Variant _get_setting_with_override_and_custom_features(const StringName &p_name, const Vector<String> &p_features, bool p_warn_not_found) const;
 
 	bool is_using_datapack() const;
 	bool is_project_loaded() const;

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -102,7 +102,7 @@
 			<return type="Variant" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Similar to [method get_setting], but applies feature tag overrides if any exists and is valid.
+				Similar to [method get_setting], but applies feature tag overrides if any exists and is valid. Prints a warning if the setting is not found. To silence this warning, use [method get_setting_with_override_or_null] instead.
 				[b]Example:[/b] If the setting override [code]"application/config/name.windows"[/code] exists, and the following code is executed on a [i]Windows[/i] operating system, the overridden setting is printed instead:
 				[codeblocks]
 				[gdscript]
@@ -119,7 +119,22 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="features" type="PackedStringArray" />
 			<description>
-				Similar to [method get_setting_with_override], but applies feature tag overrides instead of current OS features.
+				Similar to [method get_setting_with_override], but applies feature tag overrides instead of current OS features. Prints a warning if the setting is not found. To silence this warning, use [method get_setting_with_override_and_custom_features_or_null] instead.
+			</description>
+		</method>
+		<method name="get_setting_with_override_and_custom_features_or_null" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="features" type="PackedStringArray" />
+			<description>
+				Similar to [method get_setting_with_override_and_custom_features], but does not print a warning if the setting is not found.
+			</description>
+		</method>
+		<method name="get_setting_with_override_or_null" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Similar to [method get_setting_with_override], but does not print a warning if the setting is not found.
 			</description>
 		</method>
 		<method name="globalize_path" qualifiers="const">


### PR DESCRIPTION
Note that this does not apply to `get()` and `get_setting()`, as these do not print warnings for settings that are not found. Changing this may break existing projects, so I chose to kept these as-is.

This was made for https://github.com/godotengine/godot/pull/102552 specifically.