### PR TITLE
Return the length of the playing stream for AudioStreamRandomizer

### DIFF
--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -729,7 +729,10 @@ String AudioStreamRandomizer::get_stream_name() const {
 }
 
 double AudioStreamRandomizer::get_length() const {
-	return 0;
+	if (!last_playback.is_valid()) {
+		return 0;
+	}
+	return last_playback->get_length();
 }
 
 bool AudioStreamRandomizer::is_monophonic() const {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105929
Fixes https://github.com/godotengine/godot/issues/104684