### PR TITLE
[iOS] Prevent startup crash with Input singleton null check

### DIFF
--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -291,7 +291,12 @@ void DisplayServerAppleEmbedded::touch_drag(int p_idx, int p_prev_x, int p_prev_
 }
 
 void DisplayServerAppleEmbedded::perform_event(const Ref<InputEvent> &p_event) {
-	Input::get_singleton()->parse_input_event(p_event);
+	Input *input_singleton = Input::get_singleton();
+	if (input_singleton == nullptr) {
+		return;
+	}
+
+	input_singleton->parse_input_event(p_event);
 }
 
 void DisplayServerAppleEmbedded::touches_canceled(int p_idx) {


### PR DESCRIPTION
Fixes #105921.

This change fixes a crash that occurred when a touch event was received from iOS before the Input singleton was initialized. In such cases, the singleton would return a nullptr, and any call to it without a null check would result in a crash. Although the Input singleton is used in many places, I'm not sure if it's ideal to address the issue only where the crash was observed. That said, I have confirmed that this change resolves the crash I encountered.