### PR TITLE
Return the length of the longest stream in AudioStreamRandomizer

### DIFF
--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -729,7 +729,13 @@ String AudioStreamRandomizer::get_stream_name() const {
 }
 
 double AudioStreamRandomizer::get_length() const {
-	return 0;
+	double greatest_length = 0.0;
+	for (const PoolEntry &entry : audio_stream_pool) {
+		if (entry.stream.is_valid()) {
+			greatest_length = MAX(greatest_length, entry.stream->get_length());
+		}
+	}
+	return greatest_length;
 }
 
 bool AudioStreamRandomizer::is_monophonic() const {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105929
Fixes https://github.com/godotengine/godot/issues/104684

Currently, **AudioStreamRandomizer**'s `get_length()`returns `0.0`, meaning the engine essentially thinks the length cannot be obtained. This is somewhat silly in hindsight.

This PR makes it so that the longest... length out of the available streams in the **AudioStreamRandomizer** is chosen, thus allowing **AudioStreamInteractive** to work with it, as well.
From there, it is up to the developer to ensure all random streams are roughly the same length, in order to avoid awkward silence.

As of writing this has not been tested just yet. It may need to be documented as well.