### PR TITLE
Fix null pointer crash in GDScript compiler for invalid method calls

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -677,12 +677,18 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								// It's a static native method call.
 								StringName class_name = static_cast<GDScriptParser::IdentifierNode *>(subscript->base)->name;
 								MethodBind *method = ClassDB::get_method(class_name, subscript->attribute->name);
-								if (_can_use_validate_call(method, arguments)) {
-									// Exact arguments, use validated call.
-									gen->write_call_native_static_validated(result, method, arguments);
+								if (method != nullptr) {
+									if (_can_use_validate_call(method, arguments)) {
+										// Exact arguments, use validated call.
+										gen->write_call_native_static_validated(result, method, arguments);
+									} else {
+										// Not exact arguments, use regular static call
+										gen->write_call_native_static(result, class_name, subscript->attribute->name, arguments);
+									}
 								} else {
-									// Not exact arguments, use regular static call
-									gen->write_call_native_static(result, class_name, subscript->attribute->name, arguments);
+									_set_error("Method '" + String(subscript->attribute->name) + "' not found in class '" + String(class_name) + "'.", call->callee);
+									r_error = ERR_COMPILATION_FAILED;
+									return GDScriptCodeGenerator::Address();
 								}
 							} else {
 								GDScriptCodeGenerator::Address base = _parse_expression(codegen, r_error, subscript->base);


### PR DESCRIPTION
fixes #105940

Added a null check for ClassDB::get_method to prevent crashes when a method is not found.