### PR TITLE
Add getter for character ceiling normal 3D and 2D

### DIFF
--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -20,6 +20,13 @@
 				Allows to manually apply a snap to the floor regardless of the body's velocity. This function does nothing when [method is_on_floor] returns [code]true[/code].
 			</description>
 		</method>
+		<method name="get_ceiling_normal" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the collision normal of the ceiling at the last collision point. Only valid after calling [method move_and_slide] and when [method is_on_ceiling] returns [code]true[/code].
+				[b]Warning:[/b] The collision normal is not always the same as the surface normal.
+			</description>
+		</method>
 		<method name="get_floor_angle" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="up_direction" type="Vector2" default="Vector2(0, -1)" />

--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -21,6 +21,13 @@
 				Allows to manually apply a snap to the floor regardless of the body's velocity. This function does nothing when [method is_on_floor] returns [code]true[/code].
 			</description>
 		</method>
+		<method name="get_ceiling_normal" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the collision normal of the ceiling at the last collision point. Only valid after calling [method move_and_slide] and when [method is_on_ceiling] returns [code]true[/code].
+				[b]Warning:[/b] The collision normal is not always the same as the surface normal.
+			</description>
+		</method>
 		<method name="get_floor_angle" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="up_direction" type="Vector3" default="Vector3(0, 1, 0)" />

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -405,6 +405,7 @@ void CharacterBody2D::_set_collision_direction(const PhysicsServer2D::MotionResu
 		_set_platform_data(p_result);
 	} else if (motion_mode == MOTION_MODE_GROUNDED && p_result.get_angle(-up_direction) <= floor_max_angle + FLOOR_ANGLE_THRESHOLD) { //ceiling
 		on_ceiling = true;
+		ceiling_normal = p_result.collision_normal;
 	} else {
 		on_wall = true;
 		wall_normal = p_result.collision_normal;
@@ -460,6 +461,10 @@ const Vector2 &CharacterBody2D::get_floor_normal() const {
 
 const Vector2 &CharacterBody2D::get_wall_normal() const {
 	return wall_normal;
+}
+
+const Vector2 &CharacterBody2D::get_ceiling_normal() const {
+	return ceiling_normal;
 }
 
 const Vector2 &CharacterBody2D::get_last_motion() const {
@@ -703,6 +708,7 @@ void CharacterBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_on_wall_only"), &CharacterBody2D::is_on_wall_only);
 	ClassDB::bind_method(D_METHOD("get_floor_normal"), &CharacterBody2D::get_floor_normal);
 	ClassDB::bind_method(D_METHOD("get_wall_normal"), &CharacterBody2D::get_wall_normal);
+	ClassDB::bind_method(D_METHOD("get_ceiling_normal"), &CharacterBody2D::get_ceiling_normal);
 	ClassDB::bind_method(D_METHOD("get_last_motion"), &CharacterBody2D::get_last_motion);
 	ClassDB::bind_method(D_METHOD("get_position_delta"), &CharacterBody2D::get_position_delta);
 	ClassDB::bind_method(D_METHOD("get_real_velocity"), &CharacterBody2D::get_real_velocity);

--- a/scene/2d/physics/character_body_2d.h
+++ b/scene/2d/physics/character_body_2d.h
@@ -62,6 +62,7 @@ public:
 	Vector2 get_position_delta() const;
 	const Vector2 &get_floor_normal() const;
 	const Vector2 &get_wall_normal() const;
+	const Vector2 &get_ceiling_normal() const;
 	const Vector2 &get_real_velocity() const;
 
 	real_t get_floor_angle(const Vector2 &p_up_direction = Vector2(0.0, -1.0)) const;
@@ -133,6 +134,7 @@ private:
 	Vector2 floor_normal;
 	Vector2 platform_velocity;
 	Vector2 wall_normal;
+	Vector2 ceiling_normal;
 	Vector2 last_motion;
 	Vector2 previous_position;
 	Vector2 real_velocity;

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -662,6 +662,10 @@ const Vector3 &CharacterBody3D::get_wall_normal() const {
 	return wall_normal;
 }
 
+const Vector3 &CharacterBody3D::get_ceiling_normal() const {
+	return ceiling_normal;
+}
+
 const Vector3 &CharacterBody3D::get_last_motion() const {
 	return last_motion;
 }
@@ -890,6 +894,7 @@ void CharacterBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_on_wall_only"), &CharacterBody3D::is_on_wall_only);
 	ClassDB::bind_method(D_METHOD("get_floor_normal"), &CharacterBody3D::get_floor_normal);
 	ClassDB::bind_method(D_METHOD("get_wall_normal"), &CharacterBody3D::get_wall_normal);
+	ClassDB::bind_method(D_METHOD("get_ceiling_normal"), &CharacterBody3D::get_ceiling_normal);
 	ClassDB::bind_method(D_METHOD("get_last_motion"), &CharacterBody3D::get_last_motion);
 	ClassDB::bind_method(D_METHOD("get_position_delta"), &CharacterBody3D::get_position_delta);
 	ClassDB::bind_method(D_METHOD("get_real_velocity"), &CharacterBody3D::get_real_velocity);

--- a/scene/3d/physics/character_body_3d.h
+++ b/scene/3d/physics/character_body_3d.h
@@ -62,6 +62,7 @@ public:
 	Vector3 get_position_delta() const;
 	const Vector3 &get_floor_normal() const;
 	const Vector3 &get_wall_normal() const;
+	const Vector3 &get_ceiling_normal() const;
 	const Vector3 &get_real_velocity() const;
 	real_t get_floor_angle(const Vector3 &p_up_direction = Vector3(0.0, 1.0, 0.0)) const;
 	const Vector3 &get_platform_velocity() const;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/10730
Exposes ceiling normals for `CharacterBody3D/2D`.
