### PR TITLE
Core: Implement `NotNull<T>`

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -88,7 +88,7 @@ static String get_property_info_type_name(const PropertyInfo &p_info) {
 }
 
 static String get_type_meta_name(const GodotTypeInfo::Metadata metadata) {
-	static const char *argmeta[13] = { "none", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "float", "double", "char16", "char32" };
+	static const char *argmeta[14] = { "none", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "float", "double", "char16", "char32", "not_null" };
 	return argmeta[metadata];
 }
 

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1359,7 +1359,7 @@ static void gdextension_object_free_instance_binding(GDExtensionObjectPtr p_obje
 
 static void gdextension_object_set_instance(GDExtensionObjectPtr p_object, GDExtensionConstStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance) {
 	const StringName classname = *reinterpret_cast<const StringName *>(p_classname);
-	Object *o = (Object *)p_object;
+	NeverNull<Object *> o = NeverNull<Object *>((Object *)p_object);
 	ClassDB::set_object_extension_instance(o, classname, p_instance);
 }
 

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -730,8 +730,7 @@ ObjectGDExtension *ClassDB::get_placeholder_extension(const StringName &p_class)
 }
 #endif
 
-void ClassDB::set_object_extension_instance(Object *p_object, const StringName &p_class, GDExtensionClassInstancePtr p_instance) {
-	ERR_FAIL_NULL(p_object);
+void ClassDB::set_object_extension_instance(NeverNull<Object *> p_object, const StringName &p_class, GDExtensionClassInstancePtr p_instance) {
 	ClassInfo *ti;
 	{
 		Locker::Lock lock(Locker::STATE_READ);

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -325,7 +325,7 @@ public:
 	static Object *instantiate(const StringName &p_class);
 	static Object *instantiate_no_placeholders(const StringName &p_class);
 	static Object *instantiate_without_postinitialization(const StringName &p_class);
-	static void set_object_extension_instance(Object *p_object, const StringName &p_class, GDExtensionClassInstancePtr p_instance);
+	static void set_object_extension_instance(NeverNull<Object *> p_object, const StringName &p_class, GDExtensionClassInstancePtr p_instance);
 
 	static APIType get_api_type(const StringName &p_class);
 

--- a/core/templates/not_null.h
+++ b/core/templates/not_null.h
@@ -1,0 +1,523 @@
+/**************************************************************************/
+/*  not_null.h                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/error/error_macros.h"
+
+// Implementation derived heavily from gsl-lite:
+// https://github.com/gsl-lite/gsl-lite
+
+template <typename T, bool Fatal = false>
+class NotNull;
+
+template <typename T>
+using NeverNull = NotNull<T, true>;
+
+namespace Internal {
+
+// Helper to figure out whether a pointer has an element type.
+// Avoid SFINAE for unary `operator*` (doesn't work for `std::unique_ptr<>` and the like) if an `element_type` member exists.
+template <typename T, typename E = void>
+struct has_element_type_ : std::false_type {};
+template <typename T>
+struct has_element_type_<T, std::void_t<decltype(*std::declval<T>())>> : std::true_type {};
+template <typename T, typename E = void>
+struct has_element_type : has_element_type_<T> {};
+template <typename T>
+struct has_element_type<T, std::void_t<typename T::element_type>> : std::true_type {};
+
+template <typename T, typename E = void>
+inline constexpr bool has_element_type_v = has_element_type<T, E>::value;
+
+// Helper to figure out the pointed-to type of a pointer.
+template <typename T, typename E = void>
+struct element_type_helper {
+	// For types without a member element_type (this could handle typed raw pointers but not `void*`)
+	using type = std::remove_reference_t<decltype(*std::declval<T>())>;
+};
+template <typename T>
+struct element_type_helper<T, std::void_t<typename T::element_type>> {
+	// For types with a member element_type
+	using type = typename T::element_type;
+};
+template <typename T>
+struct element_type_helper<T *> {
+	using type = T;
+};
+
+template <typename T>
+using element_type_helper_t = typename element_type_helper<T>::type;
+
+template <typename T>
+struct is_not_null_or_bool_oracle : std::false_type {};
+template <typename T, bool Fatal>
+struct is_not_null_or_bool_oracle<NotNull<T, Fatal>> : std::true_type {};
+template <>
+struct is_not_null_or_bool_oracle<bool> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_not_null_or_bool_oracle_v = is_not_null_or_bool_oracle<T>::value;
+
+template <typename T, bool Fatal, bool IsCopyable>
+struct not_null_data;
+
+template <typename T, bool Fatal>
+struct not_null_data<T, Fatal, false> {
+	T _ptr;
+
+	constexpr not_null_data(T &&p_ptr) :
+			_ptr(std::move(p_ptr)) {}
+
+	constexpr not_null_data(not_null_data &&p_other) :
+			_ptr(std::move(p_other._ptr)) {
+		if constexpr (Fatal) {
+			CRASH_COND(_ptr == nullptr);
+		} else {
+			ERR_FAIL_NULL(_ptr);
+		}
+	}
+	constexpr not_null_data &operator=(not_null_data &&p_other) {
+		if (unlikely(&p_other == this)) {
+			return *this;
+		}
+		if constexpr (Fatal) {
+			CRASH_COND(p_other._ptr == nullptr);
+		} else {
+			ERR_FAIL_NULL_V(p_other._ptr, *this);
+		}
+		_ptr = std::move(p_other._ptr);
+		return *this;
+	}
+
+	not_null_data(const not_null_data &) = delete;
+	not_null_data &operator=(const not_null_data &) = delete;
+};
+
+template <typename T, bool Fatal>
+struct not_null_data<T, Fatal, true> {
+	T _ptr;
+
+	constexpr not_null_data(const T &p_ptr) :
+			_ptr(p_ptr) {}
+
+	constexpr not_null_data(T &&p_ptr) :
+			_ptr(std::move(p_ptr)) {}
+
+	constexpr not_null_data(not_null_data &&p_other) :
+			_ptr(std::move(p_other._ptr)) {
+		if constexpr (Fatal) {
+			CRASH_COND(_ptr == nullptr);
+		} else {
+			ERR_FAIL_NULL(_ptr);
+		}
+	}
+	constexpr not_null_data &operator=(not_null_data &&p_other) {
+		if (unlikely(&p_other == this)) {
+			return *this;
+		}
+		if constexpr (Fatal) {
+			CRASH_COND(p_other._ptr == nullptr);
+		} else {
+			ERR_FAIL_NULL_V(p_other._ptr, *this);
+		}
+		_ptr = std::move(p_other._ptr);
+		return *this;
+	}
+
+	constexpr not_null_data(const not_null_data &p_other) :
+			_ptr(p_other._ptr) {
+		if constexpr (Fatal) {
+			CRASH_COND(_ptr == nullptr);
+		} else {
+			ERR_FAIL_NULL(_ptr);
+		}
+	}
+	constexpr not_null_data &operator=(const not_null_data &p_other) {
+		if constexpr (Fatal) {
+			CRASH_COND(p_other._ptr == nullptr);
+		} else {
+			ERR_FAIL_NULL_V(p_other._ptr, *this);
+		}
+		_ptr = p_other._ptr;
+		return *this;
+	}
+};
+
+template <typename T, bool Fatal>
+struct not_null_data<T *, Fatal, true> {
+	T *_ptr;
+
+	constexpr not_null_data(T *p_ptr) :
+			_ptr(p_ptr) {}
+};
+
+template <typename T>
+struct is_copyable : std::bool_constant<std::is_copy_constructible_v<T> && std::is_copy_assignable_v<T>> {};
+
+template <typename T>
+inline constexpr bool is_copyable_v = is_copyable<T>::value;
+
+template <typename T>
+struct not_null_accessor;
+
+template <typename Derived, typename T, bool Fatal, bool HasElementType>
+struct not_null_elem {
+	using element_type = element_type_helper_t<T>;
+
+	[[nodiscard]] constexpr element_type *get() const {
+		return not_null_accessor<T>::get_checked<Fatal>(static_cast<const Derived &>(*this)).get();
+	}
+};
+template <typename Derived, typename T, bool Fatal>
+struct not_null_elem<Derived, T, Fatal, false> {};
+
+template <typename Derived, typename T, bool Fatal, bool IsDereferencable>
+struct not_null_deref : not_null_elem<Derived, T, Fatal, has_element_type_v<T>> {
+	using element_type = element_type_helper_t<T>;
+
+	[[nodiscard]] constexpr element_type &operator*() const {
+		return *not_null_accessor<T>::get_checked<Fatal>(static_cast<const Derived &>(*this));
+	}
+};
+
+template <typename Derived, typename T, bool Fatal>
+struct not_null_deref<Derived, T, Fatal, false> : not_null_elem<Derived, T, Fatal, has_element_type_v<T>> {};
+
+template <typename T>
+struct is_void_ptr : std::is_void<element_type_helper_t<T>> {};
+
+template <typename T>
+struct is_dereferencable : std::conjunction<has_element_type<T>, std::negation<is_void_ptr<T>>> {};
+
+template <typename T>
+inline constexpr bool is_dereferencable_v = is_dereferencable<T>::value;
+
+} // namespace Internal
+
+template <typename T>
+struct is_nullable : std::is_assignable<std::remove_cv_t<T> &, std::nullptr_t> {};
+
+template <typename T>
+inline constexpr bool is_nullable_v = is_nullable<T>::value;
+
+template <typename T, bool Fatal>
+class NotNull : public Internal::not_null_deref<NotNull<T, Fatal>, T, Fatal, Internal::is_dereferencable_v<T>> {
+	static_assert(!std::is_reference_v<T>, "T may not be a reference type");
+	static_assert(!std::is_const_v<T> && !std::is_volatile_v<T>, "T may not be cv-qualified");
+	static_assert(is_nullable_v<T>, "T must be a nullable type");
+
+	Internal::not_null_data<T, Fatal, Internal::is_copyable_v<T>> _data;
+
+	// need to access `NotNull<U>::_data`
+	template <typename U>
+	friend struct Internal::not_null_accessor;
+
+	using accessor = Internal::not_null_accessor<T>;
+
+public:
+	// Cannot be constructed as empty, nor via `nullptr`.
+	NotNull() = delete;
+	NotNull(std::nullptr_t) = delete;
+
+	// `NotNull` of same type.
+	constexpr NotNull(const NotNull &p_other) = default;
+	constexpr NotNull(NotNull &&p_other) = default;
+	constexpr NotNull &operator=(const NotNull &p_other) = default;
+	constexpr NotNull &operator=(NotNull &&p_other) = default;
+
+	// `NotNull` of different type.
+	template <typename U, bool UFatal, std::enable_if_t<std::is_constructible_v<T, U> && !std::is_convertible_v<U, T>, int> = 0>
+	constexpr explicit NotNull(NotNull<U, UFatal> p_other) :
+			_data(T(Internal::not_null_accessor<U>::get_checked<Fatal || UFatal>(std::move(p_other)))) {}
+
+	template <typename U, bool UFatal, std::enable_if_t<std::is_convertible_v<U, T>, int> = 0>
+	constexpr NotNull(NotNull<U, UFatal> p_other) :
+			_data(T(Internal::not_null_accessor<U>::get_checked<Fatal || UFatal>(std::move(p_other)))) {}
+
+	// Fatal constructors (explicit).
+	template <typename U, std::enable_if_t<Fatal && std::is_constructible_v<T, U> && is_nullable_v<U>, int> = 0>
+	constexpr explicit NotNull(U p_other) :
+			_data(T(std::move(p_other))) {
+		CRASH_COND(_data._ptr == nullptr);
+	}
+	template <typename U, std::enable_if_t<Fatal && std::is_constructible_v<T, U> && std::is_function_v<U>, int> = 0>
+	constexpr NotNull(const U &p_other) :
+			_data(T(p_other)) {}
+
+	template <typename U, std::enable_if_t<Fatal && std::is_constructible_v<T, U> && !std::is_function_v<U> && !is_nullable_v<U>, int> = 0>
+	constexpr NotNull(U p_other) :
+			_data(T(std::move(p_other))) {
+		CRASH_COND(_data._ptr == nullptr);
+	}
+
+	// Nonfatal constructors (implicit).
+	template <typename U, std::enable_if_t<!Fatal && std::is_constructible_v<T, U> && !std::is_convertible_v<U, T>, int> = 0>
+	constexpr explicit NotNull(U other) :
+			_data(T(std::move(other))) {
+		ERR_FAIL_NULL(_data._ptr);
+	}
+	template <typename U, std::enable_if_t<!Fatal && std::is_convertible_v<U, T>, int> = 0>
+	constexpr NotNull(U other) :
+			_data(std::move(other)) {
+		ERR_FAIL_NULL(_data._ptr);
+	}
+
+	// Conversion operators from explicitly convertible types.
+	template <typename U, std::enable_if_t<std::is_constructible_v<U, const T &> && !std::is_convertible_v<T, U> && !Internal::is_not_null_or_bool_oracle_v<U>, int> = 0>
+	[[nodiscard]] constexpr explicit operator U() const & {
+		return U(accessor::get_checked<Fatal>(*this));
+	}
+	template <typename U, std::enable_if_t<std::is_constructible_v<U, T> && !std::is_convertible_v<T, U> && !Internal::is_not_null_or_bool_oracle_v<U>, int> = 0>
+	[[nodiscard]] constexpr explicit operator U() && {
+		return U(accessor::get_checked<Fatal>(std::move(*this)));
+	}
+
+	// Conversion operators from implicitly convertible types.
+	template <typename U, std::enable_if_t<std::is_constructible_v<U, const T &> && std::is_convertible_v<T, U> && !Internal::is_not_null_or_bool_oracle_v<U>, int> = 0>
+	[[nodiscard]] constexpr operator U() const & {
+		return accessor::get_checked<Fatal>(*this);
+	}
+	template <typename U, std::enable_if_t<std::is_convertible_v<T, U> && !Internal::is_not_null_or_bool_oracle_v<U>, int> = 0>
+	[[nodiscard]] constexpr operator U() && {
+		return accessor::get_checked<Fatal>(std::move(*this));
+	}
+
+	[[nodiscard]] constexpr const T &operator->() const {
+		return accessor::get_checked<Fatal>(*this);
+	}
+
+	template <typename... Ts>
+	constexpr auto operator()(Ts &&...args) const
+			-> decltype(_data._ptr(std::forward<Ts>(args)...)) {
+		return accessor::get_checked<Fatal>(*this)(std::forward<Ts>(args)...);
+	}
+
+	// Comparison operators.
+	template <typename U, bool UFatal>
+	[[nodiscard]] inline constexpr bool operator==(const NotNull<U, UFatal> &p_right) { return (*this).operator->() == p_right.operator->(); }
+	template <typename U>
+	[[nodiscard]] inline constexpr bool operator==(const U &p_right) { return (*this).operator->() == p_right; }
+
+	template <typename U, bool UFatal>
+	[[nodiscard]] inline constexpr bool operator!=(const NotNull<U, UFatal> &p_right) { return !(*this == p_right); }
+	template <typename U>
+	[[nodiscard]] inline constexpr bool operator!=(const U &p_right) { return !(*this == p_right); }
+
+	template <typename U, bool UFatal>
+	[[nodiscard]] inline constexpr bool operator<(const NotNull<U, UFatal> &p_right) { return (*this).operator->() < p_right.operator->(); }
+	template <typename U>
+	[[nodiscard]] inline constexpr bool operator<(const U &p_right) { return (*this).operator->() < p_right; }
+
+	template <typename U, bool UFatal>
+	[[nodiscard]] inline constexpr bool operator<=(const NotNull<U, UFatal> &p_right) { return !(p_right < *this); }
+	template <typename U>
+	[[nodiscard]] inline constexpr bool operator<=(const U &p_right) { return !(p_right < *this); }
+
+	template <typename U, bool UFatal>
+	[[nodiscard]] inline constexpr bool operator>(const NotNull<U, UFatal> &p_right) { return p_right < *this; }
+	template <typename U>
+	[[nodiscard]] inline constexpr bool operator>(const U &p_right) { return p_right < *this; }
+
+	template <typename U, bool UFatal>
+	[[nodiscard]] inline constexpr bool operator>=(const NotNull<U, UFatal> &p_right) { return !(*this < p_right); }
+	template <typename U>
+	[[nodiscard]] inline constexpr bool operator>=(const U &p_right) { return !(*this < p_right); }
+
+	// Operators we never want.
+	NotNull &operator=(std::nullptr_t) = delete;
+	NotNull &operator++() = delete;
+	NotNull &operator--() = delete;
+	NotNull operator++(int) = delete;
+	NotNull operator--(int) = delete;
+	NotNull operator+(size_t) = delete;
+	NotNull &operator+=(size_t) = delete;
+	NotNull operator-(size_t) = delete;
+	NotNull &operator-=(size_t) = delete;
+	NotNull operator+(std::ptrdiff_t) = delete;
+	NotNull &operator+=(std::ptrdiff_t) = delete;
+	NotNull operator=(std::ptrdiff_t) = delete;
+	NotNull &operator-=(std::ptrdiff_t) = delete;
+	void operator[](std::ptrdiff_t) const = delete;
+	template <typename U, bool UFatal>
+	std::ptrdiff_t operator+(const NotNull<U, UFatal> &) = delete;
+	template <typename U, bool UFatal>
+	std::ptrdiff_t operator-(const NotNull<U, UFatal> &) = delete;
+};
+
+// template <typename U>
+// NotNull(U) -> NotNull<U, false>;
+// template <typename U>
+// NotNull(NotNull<U, false>) -> NotNull<U, false>;
+
+void make_not_null(std::nullptr_t) = delete;
+
+template <typename U, bool Fatal>
+[[nodiscard]] constexpr NotNull<U, Fatal> make_not_null(U u) {
+	return NotNull<U, Fatal>(std::move(u));
+}
+template <typename U, bool Fatal>
+[[nodiscard]] constexpr NotNull<U, Fatal> make_not_null(NotNull<U, Fatal> u) {
+	return std::move(u);
+}
+
+namespace Internal {
+
+template <typename T>
+struct as_nullable_helper {
+	using type = std::remove_reference_t<std::remove_cv_t<T>>;
+};
+template <typename T, bool Fatal>
+struct as_nullable_helper<NotNull<T, Fatal>> {};
+
+template <typename T>
+using as_nullable_helper_t = typename as_nullable_helper<T>::type;
+
+template <typename T>
+struct not_null_accessor {
+	template <bool Fatal>
+	static T get(NotNull<T, Fatal> &&p_value) {
+		return std::move(p_value._data._ptr);
+	}
+	template <bool Fatal>
+	static T get_checked(NotNull<T, Fatal> &&p_value) {
+		if constexpr (Fatal) {
+			CRASH_COND(p_value._data._ptr == nullptr);
+		} else {
+			ERR_FAIL_NULL_V(p_value._data._ptr, std::move(p_value._data._ptr));
+		}
+		return std::move(p_value._data._ptr);
+	}
+	template <bool Fatal>
+	static const T &get(const NotNull<T, Fatal> &p_value) {
+		return p_value._data._ptr;
+	}
+	template <bool Fatal>
+	static bool is_valid(const NotNull<T, Fatal> &p_value) {
+		return p_value._data._ptr != nullptr;
+	}
+	template <bool Fatal>
+	static void check(const NotNull<T, Fatal> &p_value) {
+		if constexpr (Fatal) {
+			CRASH_COND(p_value._data._ptr == nullptr);
+		} else {
+			ERR_FAIL_NULL(p_value._data._ptr);
+		}
+	}
+	template <bool Fatal>
+	static const T &get_checked(const NotNull<T, Fatal> &p_value) {
+		if constexpr (Fatal) {
+			CRASH_COND(p_value._data._ptr == nullptr);
+		} else {
+			ERR_FAIL_NULL_V(p_value._data._ptr, p_value._data._ptr);
+		}
+		return p_value._data._ptr;
+	}
+};
+template <typename T>
+struct not_null_accessor<T *> {
+	template <bool Fatal>
+	static T *const &get(const NotNull<T *, Fatal> &p_value) { return p_value._data._ptr; }
+	template <bool Fatal>
+	static bool is_valid(const NotNull<T *, Fatal> & /*p_value*/) { return true; }
+	template <bool Fatal>
+	static void checkconst(NotNull<T *, Fatal> & /*p_value*/) {}
+	template <bool Fatal>
+	static T *const &get_checked(const NotNull<T *, Fatal> &p_value) { return p_value._data._ptr; }
+};
+
+namespace NoADL {
+
+template <typename T>
+[[nodiscard]] constexpr as_nullable_helper_t<T> as_nullable(T &&p_value) {
+	return std::move(p_value);
+}
+
+template <typename T, bool Fatal>
+[[nodiscard]] constexpr T as_nullable(NotNull<T, Fatal> &&p_value) {
+	return not_null_accessor<T>::get_checked<Fatal>(std::move(p_value));
+}
+
+template <typename T, bool Fatal>
+[[nodiscard]] constexpr const T &as_nullable(const NotNull<T, Fatal> &p_value) {
+	return not_null_accessor<T>::get_checked<Fatal>(p_value);
+}
+
+template <typename T, bool Fatal>
+[[nodiscard]] constexpr bool is_valid(const NotNull<T, Fatal> &p_value) {
+	return not_null_accessor<T>::is_valid<Fatal>(p_value);
+}
+
+} // namespace NoADL
+} // namespace Internal
+
+using namespace Internal::NoADL;
+
+// Unwanted operators.
+
+template <typename T, bool Fatal>
+NotNull<T, Fatal> operator+(std::ptrdiff_t, const NotNull<T, Fatal> &) = delete;
+template <typename T, bool Fatal>
+NotNull<T, Fatal> operator-(std::ptrdiff_t, const NotNull<T, Fatal> &) = delete;
+template <typename T /* Fatal == true */>
+constexpr bool operator==(const NotNull<T, true> &, std::nullptr_t) = delete;
+template <typename T /* Fatal == true */>
+constexpr bool operator==(std::nullptr_t, const NotNull<T, true> &) = delete;
+template <typename T /* Fatal == true */>
+constexpr bool operator!=(const NotNull<T, true> &, std::nullptr_t) = delete;
+template <typename T /* Fatal == true */>
+constexpr bool operator!=(std::nullptr_t, const NotNull<T, true> &) = delete;
+
+// Right-hand operators. Convert to class methods in C++20.
+
+template <typename T, typename U, bool Fatal>
+[[nodiscard]] inline constexpr bool operator==(const T &p_left, const NotNull<U, Fatal> &p_right) {
+	return p_left == p_right.operator->();
+}
+template <typename T, typename U, bool Fatal>
+[[nodiscard]] inline constexpr bool operator!=(const T &p_left, const NotNull<U, Fatal> &p_right) {
+	return p_left != p_right.operator->();
+}
+template <typename T, typename U, bool Fatal>
+[[nodiscard]] inline constexpr bool operator<(const T &p_left, const NotNull<U, Fatal> &p_right) {
+	return p_left < p_right.operator->();
+}
+template <typename T, typename U, bool Fatal>
+[[nodiscard]] inline constexpr bool operator<=(const T &p_left, const NotNull<U, Fatal> &p_right) {
+	return p_left <= p_right.operator->();
+}
+template <typename T, typename U, bool Fatal>
+[[nodiscard]] inline constexpr bool operator>(const T &p_left, const NotNull<U, Fatal> &p_right) {
+	return p_left > p_right.operator->();
+}
+template <typename T, typename U, bool Fatal>
+[[nodiscard]] inline constexpr bool operator>=(const T &p_left, const NotNull<U, Fatal> &p_right) {
+	return p_left >= p_right.operator->();
+}

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -123,6 +123,13 @@ VARIANT_ENUM_CAST(Key);
 VARIANT_BITFIELD_CAST(KeyModifierMask);
 VARIANT_ENUM_CAST(KeyLocation);
 
+template <typename T, bool Fatal>
+struct VariantCaster<NotNull<T *, Fatal>> {
+	static _FORCE_INLINE_ NotNull<T *, Fatal> cast(const Variant &p_variant) {
+		return NotNull<T *, Fatal>(const_cast<T *>(Object::cast_to<T>(p_variant)));
+	}
+};
+
 template <>
 struct VariantCaster<char32_t> {
 	static _FORCE_INLINE_ char32_t cast(const Variant &p_variant) {

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -167,6 +167,17 @@ struct PtrToArg<const T *> {
 	}
 };
 
+template <typename T, bool Fatal>
+struct PtrToArg<NotNull<T *, Fatal>> {
+	_FORCE_INLINE_ static NotNull<T *, Fatal> convert(const void *p_ptr) {
+		return NotNull<T *, Fatal>(*reinterpret_cast<T *const *>(p_ptr));
+	}
+	typedef NotNull<T *, Fatal> EncodeT;
+	_FORCE_INLINE_ static void encode(NotNull<T *, Fatal> p_val, const void *p_ptr) {
+		*(const_cast<NotNull<T *, Fatal> *>(reinterpret_cast<const NotNull<T *, Fatal> *>(p_ptr))) = p_val;
+	}
+};
+
 // This is for ObjectID.
 
 template <>

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -50,6 +50,7 @@ enum Metadata {
 	METADATA_REAL_IS_DOUBLE,
 	METADATA_INT_IS_CHAR16,
 	METADATA_INT_IS_CHAR32,
+	METADATA_OBJECT_IS_NOT_NULL,
 };
 }
 
@@ -177,6 +178,15 @@ struct GetTypeInfo<T *, std::enable_if_t<std::is_base_of_v<Object, T>>> {
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(StringName(T::get_class_static()));
+	}
+};
+
+template <typename T, bool Fatal>
+struct GetTypeInfo<NotNull<T *, Fatal>> {
+	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_OBJECT_IS_NOT_NULL;
+	static inline PropertyInfo get_class_info() {
+		return PropertyInfo(StringName(std::remove_pointer_t<T>::get_class_static()));
 	}
 };
 

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -56,6 +56,7 @@
 #include "core/string/ustring.h"
 #include "core/templates/bit_field.h"
 #include "core/templates/list.h"
+#include "core/templates/not_null.h"
 #include "core/templates/paged_allocator.h"
 #include "core/templates/rid.h"
 #include "core/variant/array.h"

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -1045,6 +1045,12 @@ struct VariantInternalAccessor<Object *> {
 	static _FORCE_INLINE_ void set(Variant *v, const Object *p_value) { VariantInternal::object_assign(v, p_value); }
 };
 
+template <typename T, bool Fatal>
+struct VariantInternalAccessor<NotNull<T *, Fatal>> {
+	static _FORCE_INLINE_ NotNull<T *, Fatal> get(const Variant *v) { return NotNull<T *, Fatal>(const_cast<T *>(static_cast<const T *>(*VariantInternal::get_object(v)))); }
+	static _FORCE_INLINE_ void set(Variant *v, const NotNull<T *, Fatal> p_value) { VariantInternal::object_assign(v, p_value); }
+};
+
 template <>
 struct VariantInternalAccessor<Variant> {
 	static _FORCE_INLINE_ Variant &get(Variant *v) { return *v; }

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1807,7 +1807,7 @@ void Node::_add_child_nocheck(Node *p_child, const StringName &p_name, InternalM
 	emit_signal(SNAME("child_order_changed"));
 }
 
-void Node::add_child(Node *p_child, bool p_force_readable_name, InternalMode p_internal) {
+void Node::add_child(NotNull<Node *> p_child, bool p_force_readable_name, InternalMode p_internal) {
 	ERR_FAIL_COND_MSG(data.inside_tree && !Thread::is_main_thread(), "Adding children to a node inside the SceneTree is only allowed from the main thread. Use call_deferred(\"add_child\",node).");
 
 	ERR_THREAD_GUARD

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -477,7 +477,7 @@ public:
 
 	InternalMode get_internal_mode() const;
 
-	void add_child(Node *p_child, bool p_force_readable_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
+	void add_child(NotNull<Node *> p_child, bool p_force_readable_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
 	void add_sibling(Node *p_sibling, bool p_force_readable_name = false);
 	void remove_child(Node *p_child);
 


### PR DESCRIPTION
- Implements godotengine/godot-proposals#2241
- Related #86079
- Supersedes #90767

An alternative to David's `RequiredPtr`, implemented as a generic wrapper instead. This is a variation of the `gsl-lite` implementation of `not_null`, which diverges from that implementation in one main way: there's now a distinction between fatal & non-fatal nullability. That is:
- `NotNull`: Non-fatal failure if assigned null, but it will produce an error immediately so it's obvious where the mistake was made. Assignment is generally implicit, making transitioning to it for bound objects easy.
- `NeverNull`: Will fatally crash if assigned null, removing the need for external null handlers. Assignment is generally explicit, meaning binding changes need to be deliberate & null comparison is outright disabled.

In both cases, this implementation will prevent being assigned pure null/empty values at compile-time. For bound pointers, they can likely be replaced 1-to-1; `Ref` wrappers will need more work to ensure it functions, which I'll work on finalizing throughout the week. The gsl-lite logic could likely be further reduced in scope, as our needs are more specific, but this gives a functional starting point