### PR TITLE
Fix SpinBox not calling base Range::_value_changed

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -602,6 +602,7 @@ double SpinBox::get_custom_arrow_step() const {
 
 void SpinBox::_value_changed(double p_value) {
 	_update_buttons_state_for_current_value();
+	Range::_value_changed(p_value);
 }
 
 void SpinBox::_update_buttons_state_for_current_value() {


### PR DESCRIPTION
Fixes #105769.


In PR #89265, `SpinBox::_value_changed` was added, overriding `Range::_value_changed` without calling the base class method, which broke expected behavior. This PR adds a call to `Range::_value_changed(p_value)` to ensure the base class logic is executed.

## Changes
- Modified `scene/gui/spin_box.cpp` to call `Range::_value_changed(p_value)` in `SpinBox::_value_changed`.
