### PR TITLE
Add notification for exported variables initialization on Resource

### DIFF
--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -83,6 +83,8 @@ private:
 
 	SelfList<Resource> remapped_list;
 
+	bool _exported_variables_initialized = false;
+
 	void _dupe_sub_resources(Variant &r_variant, Node *p_for_scene, HashMap<Ref<Resource>, Ref<Resource>> &p_remap_cache);
 	void _find_sub_resources(const Variant &p_variant, HashSet<Ref<Resource>> &p_resources_found);
 
@@ -104,7 +106,13 @@ protected:
 	GDVIRTUAL1C(_set_path_cache, String);
 	GDVIRTUAL0(_reset_state);
 
+	GDVIRTUAL0(_exported_variables_initialized);
+
 public:
+	enum {
+		NOTIFICATION_EXPORT_VARIABLES_INITIALIZED = 2100,
+	};
+
 	static Node *(*_get_local_scene_func)(); //used by editor
 	static void (*_update_configuration_warning)(); //used by editor
 
@@ -163,6 +171,8 @@ public:
 	//helps keep IDs same number when loading/saving scenes. -1 clears ID and it Returns -1 when no id stored
 	void set_id_for_path(const String &p_path, const String &p_id);
 	String get_id_for_path(const String &p_path) const;
+
+	void exported_variables_initialized();
 
 	Resource();
 	~Resource();

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -322,6 +322,7 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 	load_nesting--;
 
 	if (res.is_valid()) {
+		res->exported_variables_initialized();
 		return res;
 	} else {
 		print_verbose(vformat("Failed loading resource: %s", p_path));

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -14,6 +14,12 @@
 		<link title="When and how to avoid using nodes for everything">$DOCS_URL/tutorials/best_practices/node_alternatives.html</link>
 	</tutorials>
 	<methods>
+		<method name="_exported_variables_initialized" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Override this method to be notified when the exported variables are initialized.
+			</description>
+		</method>
 		<method name="_get_rid" qualifiers="virtual const">
 			<return type="RID" />
 			<description>


### PR DESCRIPTION
Related to [#296](https://github.com/godotengine/godot-proposals/issues/296)
Closes [#5994](https://github.com/godotengine/godot-proposals/issues/5994)
Closes [#10219](https://github.com/godotengine/godot-proposals/issues/10219)

Now Resource has a private method that if called it will send a `NOTIFICATION_EXPORT_VARIABLES_INITIALIZED` notification and a call to `_exported_variables_initialized` virtual method. This method uses a private flag to avoid sending the notification multiple times, for example when loading a resource from cache.

Project to test it: [resource-notifications.zip](https://github.com/user-attachments/files/19985778/resource-notifications.zip)


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
