### PR TITLE
Some QOL and cleanup to EditorHelp's `FindBar`

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -797,6 +797,7 @@ FindReplaceBar::FindReplaceBar() {
 
 	find_prev = memnew(Button);
 	find_prev->set_flat(true);
+	find_prev->set_disabled(results_count < 1);
 	find_prev->set_tooltip_text(TTR("Previous Match"));
 	find_prev->set_accessibility_name(TTRC("Previous Match"));
 	hbc_button_search->add_child(find_prev);
@@ -805,6 +806,7 @@ FindReplaceBar::FindReplaceBar() {
 
 	find_next = memnew(Button);
 	find_next->set_flat(true);
+	find_next->set_disabled(results_count < 1);
 	find_next->set_tooltip_text(TTR("Next Match"));
 	find_next->set_accessibility_name(TTRC("Next Match"));
 	hbc_button_search->add_child(find_next);

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -47,12 +47,13 @@ class FindBar : public HBoxContainer {
 	Button *find_prev = nullptr;
 	Button *find_next = nullptr;
 	Label *matches_label = nullptr;
-	TextureButton *hide_button = nullptr;
-	String prev_search;
+	Button *hide_button = nullptr;
 
 	RichTextLabel *rich_text_label = nullptr;
 
+	String prev_search;
 	int results_count = 0;
+	int results_count_to_current = 0;
 
 	virtual void input(const Ref<InputEvent> &p_event) override;
 
@@ -61,7 +62,7 @@ class FindBar : public HBoxContainer {
 	void _search_text_changed(const String &p_text);
 	void _search_text_submitted(const String &p_text);
 
-	void _update_results_count();
+	void _update_results_count(bool p_search_previous);
 	void _update_matches_label();
 
 protected:


### PR DESCRIPTION
Some small TLC for `FindBar` in `EditorHelp` that matches some functionality from `FindReplaceBar`:
- Display index of search result
- Disable `Previous` and `Next` match buttons if search results are 0
- Add tooltips to buttons
- Minor code cleanup

![image](https://github.com/user-attachments/assets/4c490372-f04b-4f4d-84c4-3e75a115bf6d)


