### PR TITLE
Clarify that Tree.create_item() can fail and when.

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -50,6 +50,7 @@
 				Creates an item in the tree and adds it as a child of [param parent], which can be either a valid [TreeItem] or [code]null[/code].
 				If [param parent] is [code]null[/code], the root item will be the parent, or the new item will be the root itself if the tree is empty.
 				The new item will be the [param index]-th child of parent, or it will be the last child if there are not enough siblings.
+				Returns [code]null[/code] if called while a mouse selection occurs.
 			</description>
 		</method>
 		<method name="deselect_all">


### PR DESCRIPTION
This minor change addresses [`_OnTreeItemSelected()` signal receiver method using C# doesn't allow adding of items #103101](https://github.com/godotengine/godot/issues/103101).
 
Updates the `Tree.create_item()` documentation to clarify that the method fails and returns null if called during a mouse selection event.

Note: This is my first time contributing, so I apologize for any mistakes! I initially did this in the godot-docs repository, as I misunderstood the documentation instructions. Thank you AThousandShips for clarifying how to correctly contribute!