### PR TITLE
[3.x] FTI - Fix `SceneTreeFTI` behaviour on exit tree

### DIFF
--- a/scene/main/scene_tree_fti.h
+++ b/scene/main/scene_tree_fti.h
@@ -93,6 +93,7 @@ class SceneTreeFTI {
 	void _update_request_resets();
 
 	void _reset_flags(Node *p_node);
+	void _reset_spatial_flags(Spatial &r_spatial);
 	void _spatial_notify_set_xform(Spatial &r_spatial);
 	void _spatial_notify_set_property(Spatial &r_spatial);
 


### PR DESCRIPTION
Fixes #105970

Backport of #105973

## Notes
* I totally missed this during testing because none of the demos re-added objects to the scene tree.
* When the flags got out of sync, the `SceneTreeFTI` would incorrectly think an object was already added to a list.
* Localized the flag resets to a single function so less likely to miss any in future.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
