### PR TITLE
Evaluator: keep editing after submit

### DIFF
--- a/editor/debugger/editor_expression_evaluator.cpp
+++ b/editor/debugger/editor_expression_evaluator.cpp
@@ -110,6 +110,7 @@ EditorExpressionEvaluator::EditorExpressionEvaluator() {
 	expression_input->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	expression_input->set_placeholder(TTR("Expression to evaluate"));
 	expression_input->set_clear_button_enabled(true);
+	expression_input->set_keep_editing_on_text_submit(true);
 	expression_input->connect(SceneStringName(text_submitted), callable_mp(this, &EditorExpressionEvaluator::_evaluate).unbind(1));
 	expression_input->connect(SceneStringName(text_changed), callable_mp(this, &EditorExpressionEvaluator::_on_expression_input_changed));
 	hb->add_child(expression_input);


### PR DESCRIPTION
This is my first pull request, yay! :)

This improves the usability of the evaluator by continuing to edit the expression after submitting, so you don't have to manually activate it each time after submitting.

Before:
![CleanShot 2025-05-01 at 10 06 24](https://github.com/user-attachments/assets/1c781529-90d6-46b3-a654-cd933ec8d343)

After:

![CleanShot 2025-05-01 at 10 03 30](https://github.com/user-attachments/assets/df3857f5-f247-49ab-86f7-65db7cd57a5b)
