### PR TITLE
Only instantiate `MovieWriterMJPEG` and `MovieWriterPNGWAV` movie writers if they are enabled

### DIFF
--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -342,11 +342,15 @@ void register_server_types() {
 	GDREGISTER_ABSTRACT_CLASS(XRTracker);
 #endif // XR_DISABLED
 
-	writer_mjpeg = memnew(MovieWriterMJPEG);
-	MovieWriter::add_writer(writer_mjpeg);
+	if (GD_IS_CLASS_ENABLED(MovieWriterMJPEG)) {
+		writer_mjpeg = memnew(MovieWriterMJPEG);
+		MovieWriter::add_writer(writer_mjpeg);
+	}
 
-	writer_pngwav = memnew(MovieWriterPNGWAV);
-	MovieWriter::add_writer(writer_pngwav);
+	if (GD_IS_CLASS_ENABLED(MovieWriterPNGWAV)) {
+		writer_pngwav = memnew(MovieWriterPNGWAV);
+		MovieWriter::add_writer(writer_pngwav);
+	}
 
 	OS::get_singleton()->benchmark_end_measure("Servers", "Register Extensions");
 }
@@ -356,9 +360,12 @@ void unregister_server_types() {
 
 	ServersDebugger::deinitialize();
 	memdelete(shader_types);
-	memdelete(writer_mjpeg);
-	memdelete(writer_pngwav);
-
+	if (GD_IS_CLASS_ENABLED(MovieWriterMJPEG)) {
+		memdelete(writer_mjpeg);
+	}
+	if (GD_IS_CLASS_ENABLED(MovieWriterPNGWAV)) {
+		memdelete(writer_pngwav);
+	}
 	OS::get_singleton()->benchmark_end_measure("Servers", "Unregister Extensions");
 }
 


### PR DESCRIPTION
While building for the web with a build profile
```
scons target=template_release build_profile=custom.build
```
I noticed the following when running an empty project
<img width="617" alt="image" src="https://github.com/user-attachments/assets/7ad0ed4e-2482-47af-9af8-0d3bdb293fd2" />

In the build profile `MovieWriter` was disabled but `MovieWriterMJPEG` and `MovieWriterPNGWAV` were being initialised regardless. This PR puts the instantiation of these two classes behind a `GD_IS_CLASS_ENABLED` check.

System info: Godot v4.5.dev (8edf97e34) - macOS Sequoia (15.3.2) - Multi-window, 1 monitor - Metal (Forward+) - integrated Apple M1 Max (Apple7) - Apple M1 Max (10 threads)