### PR TITLE
Add scaling of bezier handles when box scaling bezier keys

### DIFF
--- a/editor/animation/animation_bezier_editor.cpp
+++ b/editor/animation/animation_bezier_editor.cpp
@@ -95,6 +95,9 @@ void AnimationBezierTrackEdit::_draw_track(int p_track, const Color &p_color) {
 			} else if (scaling_selection) {
 				offset += -scaling_selection_offset.x + (offset - scaling_selection_pivot.x) * (scaling_selection_scale.x - 1);
 				height += -scaling_selection_offset.y + (height - scaling_selection_pivot.y) * (scaling_selection_scale.y - 1);
+
+				out_handle.x *= scaling_selection_scale.x;
+				out_handle.y *= scaling_selection_scale.y;
 			}
 		}
 
@@ -112,6 +115,9 @@ void AnimationBezierTrackEdit::_draw_track(int p_track, const Color &p_color) {
 			} else if (scaling_selection) {
 				offset_n += -scaling_selection_offset.x + (offset_n - scaling_selection_pivot.x) * (scaling_selection_scale.x - 1);
 				height_n += -scaling_selection_offset.y + (height_n - scaling_selection_pivot.y) * (scaling_selection_scale.y - 1);
+
+				in_handle.x *= scaling_selection_scale.x;
+				in_handle.y *= scaling_selection_scale.y;
 			}
 		}
 
@@ -698,6 +704,13 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 
 								animation->bezier_track_calculate_handles(offset, prev_time, prev_value, next_time, next_value, handle_mode, Animation::HANDLE_SET_MODE_AUTO, &in_vec, &out_vec);
 							}
+						}
+
+						if (is_selected && scaling_selection) {
+							in_vec.x *= scaling_selection_scale.x;
+							in_vec.y *= scaling_selection_scale.y;
+							out_vec.x *= scaling_selection_scale.x;
+							out_vec.y *= scaling_selection_scale.y;
 						}
 
 						Vector2 pos_in(((offset + in_vec.x) - timeline->get_value()) * scale + limit, _bezier_h_to_pixel(value + in_vec.y));
@@ -1804,6 +1817,14 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				h += -scaling_selection_offset.y + (h - scaling_selection_pivot.y) * (scaling_selection_scale.y - 1);
 				key[0] = h;
 
+				Vector2 in_handle = Vector2(key[1], key[2]);
+				Vector2 out_handle = Vector2(key[3], key[4]);
+
+				in_handle.x *= scaling_selection_scale.x;
+				in_handle.y *= scaling_selection_scale.y;
+				out_handle.x *= scaling_selection_scale.x;
+				out_handle.y *= scaling_selection_scale.y;
+
 				undo_redo->add_do_method(
 						this,
 						"_bezier_track_insert_key_at_anim",
@@ -1811,8 +1832,8 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 						E->get().first,
 						newpos,
 						key[0],
-						Vector2(key[1], key[2]),
-						Vector2(key[3], key[4]),
+						in_handle,
+						out_handle,
 						animation->bezier_track_get_key_handle_mode(E->get().first, E->get().second));
 			}
 


### PR DESCRIPTION
Complements #100470.

This PR changes the scaling of multiple bezier animation keys to also scale the bezier handles along with it, which helps better preserve the shape of the curve as you scale it up/down.

Here's a (somewhat contrived) example of what it looks like currently:

https://github.com/user-attachments/assets/fb14bcea-51b3-47ed-9080-3410d2ab8547

And here's what it looks like with this PR:

https://github.com/user-attachments/assets/d74676d2-ed0c-4823-ab15-9e549bb1694c

As you can hopefully see, the inherent shape of the selected curve is better preserved with this PR.

~~Note that I deliberately exclude the left/in handle of the leftmost selected key, as well as the right/out handle of the rightmost selected key, since you could otherwise drastically change the shape of the connected curves as well.~~