### PR TITLE
Docs: Remove misleading comment from `Rect2`

### DIFF
--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -4,7 +4,7 @@
 		A 2D axis-aligned bounding box using floating-point coordinates.
 	</brief_description>
 	<description>
-		The [Rect2] built-in [Variant] type represents an axis-aligned rectangle in a 2D space. It is defined by its [member position] and [member size], which are [Vector2]. It is frequently used for fast overlap tests (see [method intersects]). Although [Rect2] itself is axis-aligned, it can be combined with [Transform2D] to represent a rotated or skewed rectangle.
+		The [Rect2] built-in [Variant] type represents an axis-aligned rectangle in a 2D space. It is defined by its [member position] and [member size], which are [Vector2]. It is frequently used for fast overlap tests (see [method intersects]).
 		For integer coordinates, use [Rect2i]. The 3D equivalent to [Rect2] is [AABB].
 		[b]Note:[/b] Negative values for [member size] are not supported. With negative size, most [Rect2] methods do not work correctly. Use [method abs] to get an equivalent [Rect2] with a non-negative size.
 		[b]Note:[/b] In a boolean context, a [Rect2] evaluates to [code]false[/code] if both [member position] and [member size] are zero (equal to [constant Vector2.ZERO]). Otherwise, it always evaluates to [code]true[/code].


### PR DESCRIPTION
Removed "Although [Rect2] itself is axis-aligned, it can be combined with [Transform2D] to represent a rotated or skewed rectangle." because it's misleading.

What is being transformed are the A and B points. Resulting into a new axis aligned rectangle with the two points being transformed. It's not the rotated rectangle, but the "bounding box" that you obtain.

You can test if a point is in a rotated rectangle by doing the inverse transform of the point such as that the point is in same coordinate space as the rectangle.

"Check if a point is in a rotated axis aligned rectangle" could be a tutorial.

```gdscript
rect.has_point(transform.inverse()*event.position)
```