### PR TITLE
Only update case sensitive fuzzy searching within `set_query`

### DIFF
--- a/core/string/fuzzy_search.cpp
+++ b/core/string/fuzzy_search.cpp
@@ -265,12 +265,19 @@ void FuzzySearch::sort_and_filter(Vector<FuzzySearchResult> &p_results) const {
 }
 
 void FuzzySearch::set_query(const String &p_query) {
-	tokens.clear();
-	for (const String &string : p_query.split(" ", false)) {
-		tokens.append({ static_cast<int>(tokens.size()), string });
-	}
+	set_query(p_query, !p_query.is_lowercase());
+}
 
-	case_sensitive = !p_query.is_lowercase();
+void FuzzySearch::set_query(const String &p_query, bool p_case_sensitive) {
+	tokens.clear();
+	case_sensitive = p_case_sensitive;
+
+	for (const String &string : p_query.split(" ", false)) {
+		tokens.append({
+				static_cast<int>(tokens.size()),
+				p_case_sensitive ? string : string.to_lower(),
+		});
+	}
 
 	struct TokenComparator {
 		bool operator()(const FuzzySearchToken &A, const FuzzySearchToken &B) const {

--- a/core/string/fuzzy_search.h
+++ b/core/string/fuzzy_search.h
@@ -84,16 +84,17 @@ public:
 class FuzzySearch {
 	Vector<FuzzySearchToken> tokens;
 
+	bool case_sensitive = false;
 	void sort_and_filter(Vector<FuzzySearchResult> &p_results) const;
 
 public:
 	int start_offset = 0;
-	bool case_sensitive = false;
 	int max_results = 100;
 	int max_misses = 2;
 	bool allow_subsequences = true;
 
 	void set_query(const String &p_query);
+	void set_query(const String &p_query, bool p_case_sensitive);
 	bool search(const String &p_target, FuzzySearchResult &p_result) const;
 	void search_all(const PackedStringArray &p_targets, Vector<FuzzySearchResult> &p_results) const;
 };


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/105900. There is a bit of discussion on that pr about possible approaches and changes to the behavior; I would be open to further changes such as removing case sensitive filtering entirely but this is the smallest change which I thought made sense. Potentially it makes sense to preemptively make the other "config" variables also private but I think `case_sensitive` is unique in that the stored token values change wrt to its value while the other vars only affect the returned values.

Unblocks https://github.com/godotengine/godot/pull/105239 and https://github.com/godotengine/godot/pull/105240