### PR TITLE
GDScript: Reserve local function Vectors with known final size

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1056,6 +1056,7 @@ void GDScript::_get_property_list(List<PropertyInfo> *p_properties) const {
 
 	for (const List<const GDScript *>::Element *E = classes.back(); E; E = E->prev()) {
 		Vector<_GDScriptMemberSort> msort;
+		msort.reserve(E->get()->static_variables_indices.size());
 		for (const KeyValue<StringName, MemberInfo> &F : E->get()->static_variables_indices) {
 			_GDScriptMemberSort ms;
 			ms.index = F.value.index;
@@ -1440,6 +1441,7 @@ void GDScript::_save_orphaned_subclasses(ClearData *p_clear_data) {
 		String fully_qualified_name;
 	};
 	Vector<ClassRefWithName> weak_subclasses;
+	weak_subclasses.reserve(subclasses.size());
 	// collect subclasses ObjectID and name
 	for (KeyValue<StringName, Ref<GDScript>> &E : subclasses) {
 		E.value->_owner = nullptr; //bye, you are no longer owned cause I died

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -67,6 +67,7 @@ static MethodInfo info_from_utility_func(const StringName &p_function) {
 	if (Variant::is_utility_function_vararg(p_function)) {
 		info.flags |= METHOD_FLAG_VARARG;
 	} else {
+		info.arguments.reserve(Variant::get_utility_function_argument_count(p_function));
 		for (int i = 0; i < Variant::get_utility_function_argument_count(p_function); i++) {
 			PropertyInfo pi;
 #ifdef DEBUG_ENABLED
@@ -1123,6 +1124,7 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 				// This is the _only_ way to declare a signal. Therefore, we can generate its
 				// MethodInfo inline so it's a tiny bit more efficient.
 				MethodInfo mi = MethodInfo(member.signal->identifier->name);
+				mi.arguments.reserve(member.signal->parameters.size());
 
 				for (int j = 0; j < member.signal->parameters.size(); j++) {
 					GDScriptParser::ParameterNode *param = member.signal->parameters[j];
@@ -1677,6 +1679,7 @@ void GDScriptAnalyzer::resolve_annotation(GDScriptParser::AnnotationNode *p_anno
 	p_annotation->is_resolved = true;
 
 	const MethodInfo &annotation_info = parser->valid_annotations[p_annotation->name].info;
+	p_annotation->resolved_arguments.reserve(p_annotation->arguments.size());
 
 	for (int64_t i = 0, j = 0; i < p_annotation->arguments.size(); i++) {
 		GDScriptParser::ExpressionNode *argument = p_annotation->arguments[i];
@@ -1774,7 +1777,7 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 		function_visible_name = p_is_lambda ? "<anonymous lambda>" : "<unknown function>";
 	}
 #endif // DEBUG_ENABLED
-
+	method_info.arguments.reserve(p_function->parameters.size());
 	for (int i = 0; i < p_function->parameters.size(); i++) {
 		resolve_parameter(p_function->parameters[i]);
 		method_info.arguments.push_back(p_function->parameters[i]->get_datatype().to_property_info(p_function->parameters[i]->identifier->name));
@@ -3283,6 +3286,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			if (all_is_constant && safe_to_fold) {
 				// Construct here.
 				Vector<const Variant *> args;
+				args.reserve(p_call->arguments.size());
 				for (int i = 0; i < p_call->arguments.size(); i++) {
 					args.push_back(&(p_call->arguments[i]->reduced_value));
 				}
@@ -3453,6 +3457,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			if (all_is_constant && GDScriptUtilityFunctions::is_function_constant(function_name)) {
 				// Can call on compilation.
 				Vector<const Variant *> args;
+				args.reserve(p_call->arguments.size());
 				for (int i = 0; i < p_call->arguments.size(); i++) {
 					args.push_back(&(p_call->arguments[i]->reduced_value));
 				}
@@ -3504,6 +3509,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			if (all_is_constant && Variant::get_utility_function_type(function_name) == Variant::UTILITY_FUNC_TYPE_MATH) {
 				// Can call on compilation.
 				Vector<const Variant *> args;
+				args.reserve(p_call->arguments.size());
 				for (int i = 0; i < p_call->arguments.size(); i++) {
 					args.push_back(&(p_call->arguments[i]->reduced_value));
 				}

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -199,6 +199,7 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 		}
 	}
 
+	result.container_element_types.reserve(p_datatype.container_element_types.size());
 	for (int i = 0; i < p_datatype.container_element_types.size(); i++) {
 		result.set_container_element_type(i, _gdtype_from_datatype(p_datatype.get_container_element_type_or_variant(i), p_owner, false));
 	}
@@ -501,6 +502,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 		case GDScriptParser::Node::ARRAY: {
 			const GDScriptParser::ArrayNode *an = static_cast<const GDScriptParser::ArrayNode *>(p_expression);
 			Vector<GDScriptCodeGenerator::Address> values;
+			values.reserve(an->elements.size());
 
 			// Create the result temporary first since it's the last to be killed.
 			GDScriptDataType array_type = _gdtype_from_datatype(an->get_datatype(), codegen.script);
@@ -531,6 +533,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 		case GDScriptParser::Node::DICTIONARY: {
 			const GDScriptParser::DictionaryNode *dn = static_cast<const GDScriptParser::DictionaryNode *>(p_expression);
 			Vector<GDScriptCodeGenerator::Address> elements;
+			elements.reserve(dn->elements.size() * 2);
 
 			// Create the result temporary first since it's the last to be killed.
 			GDScriptDataType dict_type = _gdtype_from_datatype(dn->get_datatype(), codegen.script);
@@ -612,6 +615,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			}
 
 			Vector<GDScriptCodeGenerator::Address> arguments;
+			arguments.reserve(call->arguments.size());
 			for (int i = 0; i < call->arguments.size(); i++) {
 				GDScriptCodeGenerator::Address arg = _parse_expression(codegen, r_error, call->arguments[i]);
 				if (r_error) {
@@ -2336,6 +2340,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	GDScriptCodeGenerator::Address vararg_addr;
 
 	if (p_func) {
+		method_info.arguments.reserve(p_func->parameters.size());
 		for (int i = 0; i < p_func->parameters.size(); i++) {
 			const GDScriptParser::ParameterNode *parameter = p_func->parameters[i];
 			GDScriptDataType par_type = _gdtype_from_datatype(parameter->get_datatype(), p_script);
@@ -3201,6 +3206,7 @@ GDScriptCompiler::FunctionLambdaInfo GDScriptCompiler::_get_function_replacement
 Vector<GDScriptCompiler::FunctionLambdaInfo> GDScriptCompiler::_get_function_lambda_replacement_info(GDScriptFunction *p_func, int p_depth, GDScriptFunction *p_parent_func) {
 	Vector<FunctionLambdaInfo> result;
 	// Only scrape the lambdas inside p_func.
+	result.reserve(p_func->lambdas.size());
 	for (int i = 0; i < p_func->lambdas.size(); ++i) {
 		result.push_back(_get_function_replacement_info(p_func->lambdas[i], i, p_depth + 1, p_func));
 	}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -438,11 +438,13 @@ String GDScriptLanguage::debug_parse_stack_level_expression(int p_level, const S
 	debug_get_stack_level_locals(p_level, &names, &values, p_max_subitems, p_max_depth);
 
 	Vector<String> name_vector;
+	name_vector.reserve(names.size());
 	for (const String &name : names) {
 		name_vector.push_back(name);
 	}
 
 	Array value_array;
+	value_array.reserve(values.size());
 	for (const Variant &value : values) {
 		value_array.push_back(value);
 	}

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -85,7 +85,8 @@ void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<String
 		}
 	}
 
-	List<_GDFKCS> stackpositions;
+	LocalVector<_GDFKCS> stackpositions;
+	stackpositions.reserve(sdmap.size());
 	for (const KeyValue<StringName, _GDFKC> &E : sdmap) {
 		_GDFKCS spp;
 		spp.id = E.key;
@@ -148,6 +149,7 @@ Variant GDScriptFunctionState::_signal_callback(const Variant **p_args, int p_ar
 		arg = *p_args[0];
 	} else {
 		Array extra_args;
+		extra_args.reserve(p_argcount - 1);
 		for (int i = 0; i < p_argcount - 1; i++) {
 			extra_args.push_back(*p_args[i]);
 		}

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -376,6 +376,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 
 		ScriptLanguage *script = GDScriptLanguage::get_singleton();
 		TypedArray<Dictionary> ret;
+		ret.reserve(script->debug_get_stack_level_count());
 		for (int i = 0; i < script->debug_get_stack_level_count(); i++) {
 			Dictionary frame;
 			frame["source"] = script->debug_get_stack_level_source(i);


### PR DESCRIPTION
Many functions in the GDScript codebase create a temporary `Vector` to push back a few structs. In some cases, however, the final size is already known, so reserve is possible.

I have modified some cases that meet the following requirements:
- The Vector/Array is instantiated within the function's scope.
- The amount of iterations in the `for` loop are pre-defined.
- There are no conditions that will deny the `push_back` from happening, with exception of conditions that end the function early.

I measured a slight performance increase when running [Bunnymark](https://github.com/GaijinEntertainment/godot-das/tree/master/examples/bunnymark) with 500 bunnies, an amount I presume is reasonable for common cases.

Also:
- CPU usage is between 0.4% less and 0.1% more (on an Intel Core i5-11400H).
- RAM usage is between 4MB lower and 1MB higher (less memory fragmentation?).
- Template release build size increased by 12KiB, which I believe to be too big for this improvement.