### PR TITLE
Allow Control Rect tool to not snap to pixel

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -130,8 +130,8 @@ Size2 Control::_edit_get_scale() const {
 
 void Control::_edit_set_rect(const Rect2 &p_edit_rect) {
 	ERR_FAIL_COND_MSG(!Engine::get_singleton()->is_editor_hint(), "This function can only be used from editor plugins.");
-	set_position((get_position() + get_transform().basis_xform(p_edit_rect.position)).snappedf(1), ControlEditorToolbar::get_singleton()->is_anchors_mode_enabled());
-	set_size(p_edit_rect.size.snappedf(1), ControlEditorToolbar::get_singleton()->is_anchors_mode_enabled());
+	set_position((get_position() + get_transform().basis_xform(p_edit_rect.position)), ControlEditorToolbar::get_singleton()->is_anchors_mode_enabled());
+	set_size(p_edit_rect.size, ControlEditorToolbar::get_singleton()->is_anchors_mode_enabled());
 }
 
 void Control::_edit_set_rotation(real_t p_rotation) {


### PR DESCRIPTION
Disabling snap to pixel worked for moving the position, but not for using the rect handles to resize.
Using snap to pixel still works, and it now snaps only the side that was moved.

Before:

https://github.com/user-attachments/assets/4f1c840e-3c79-4f42-8e21-be36cd05fc26

After:

https://github.com/user-attachments/assets/e2bf4093-6d58-45cc-b0c0-183ecae17376
