### PR TITLE
CI: Propagate `matrix.sconsflags` in macos_builds.yml

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Compilation (x86_64)
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=x86_64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
+          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }} arch=x86_64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
           platform: macos
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
@@ -76,7 +76,7 @@ jobs:
       - name: Compilation (arm64)
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=arm64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
+          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }} arch=arm64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
           platform: macos
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}


### PR DESCRIPTION
This PR updates `macos_builds.yml` to match the other platforms' use of per-job sconsflags.

While I was [setting up CI for a branch that I do not currently plan on upstreaming](https://github.com/juanjp600/godot/tree/rl-hg-fork), I noticed that I couldn't get the macOS jobs to build with the Mono module enabled, and this is the reason why.

Currently, this doesn't affect the behavior of the macOS template job because the only flag it sets is `debug_symbols=no`, which is the default. However, this could become a bug if the flags were to change to something more meaningful, so I figured I'd just upstream this fix.