### PR TITLE
Clarify Windows export warnings for File and Product Version

### DIFF
--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -388,17 +388,14 @@ String EditorExportPlatformWindows::get_export_option_warning(const EditorExport
 				if (version_array.size() != 4 || !version_array[0].is_valid_int() ||
 						!version_array[1].is_valid_int() || !version_array[2].is_valid_int() ||
 						!version_array[3].is_valid_int() || file_version.contains_char('-')) {
-					return TTR("Invalid file version.");
+					return TTR("Invalid file version. Proper format is x.x.x.x where x is any int.");
 				}
 			}
 		} else if (p_name == "application/product_version") {
 			String product_version = p_preset->get("application/product_version");
 			if (!product_version.is_empty()) {
-				PackedStringArray version_array = product_version.split(".", false);
-				if (version_array.size() != 4 || !version_array[0].is_valid_int() ||
-						!version_array[1].is_valid_int() || !version_array[2].is_valid_int() ||
-						!version_array[3].is_valid_int() || product_version.contains_char('-')) {
-					return TTR("Invalid product version.");
+				if (product_version[0].is_valid_int()) {
+					return TTR("Invalid product version. Allowable format is any string beginning with a number");
 				}
 			}
 		}


### PR DESCRIPTION
A proposed fix for  #104814  - See the comment there

Does the following

- Fixes the File Version warning to be more specific
- Fixes the Product Version warning to be more specific
- Edits the file warning logic to match the new "any string starting with a number" req

*Bugsquad edit:*
- Fixes #104814