### PR TITLE
Add additional `Game View` shortcuts

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -981,6 +981,34 @@ void ScriptEditorDebugger::_msg_embed_next_frame(uint64_t p_thread_id, const Arr
 	emit_signal(SNAME("embed_shortcut_requested"), EMBED_NEXT_FRAME);
 }
 
+void ScriptEditorDebugger::_msg_embed_input_override(uint64_t p_thread_id, const Array &p_data) {
+	emit_signal(SNAME("embed_shortcut_requested"), EMBED_INPUT_OVERRIDE);
+}
+
+void ScriptEditorDebugger::_msg_embed_2d_selection_override(uint64_t p_thread_id, const Array &p_data) {
+	emit_signal(SNAME("embed_shortcut_requested"), EMBED_2D_SELECTION_OVERRIDE);
+}
+
+void ScriptEditorDebugger::_msg_embed_3d_selection_override(uint64_t p_thread_id, const Array &p_data) {
+	emit_signal(SNAME("embed_shortcut_requested"), EMBED_3D_SELECTION_OVERRIDE);
+}
+
+void ScriptEditorDebugger::_msg_embed_toggle_camera_override(uint64_t p_thread_id, const Array &p_data) {
+	emit_signal(SNAME("embed_shortcut_requested"), EMBED_TOGGLE_CAMERA_OVERRIDE);
+}
+
+void ScriptEditorDebugger::_msg_embed_increase_speed(uint64_t p_thread_id, const Array &p_data) {
+	emit_signal(SNAME("embed_shortcut_requested"), EMBED_INCREASE_SPEED);
+}
+
+void ScriptEditorDebugger::_msg_embed_decrease_speed(uint64_t p_thread_id, const Array &p_data) {
+	emit_signal(SNAME("embed_shortcut_requested"), EMBED_DECREASE_SPEED);
+}
+
+void ScriptEditorDebugger::_msg_embed_reset_speed(uint64_t p_thread_id, const Array &p_data) {
+	emit_signal(SNAME("embed_shortcut_requested"), EMBED_RESET_SPEED);
+}
+
 void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread_id, const Array &p_data) {
 	emit_signal(SNAME("debug_data"), p_msg, p_data);
 
@@ -1035,6 +1063,13 @@ void ScriptEditorDebugger::_init_parse_message_handlers() {
 	parse_message_handlers["window:title"] = &ScriptEditorDebugger::_msg_window_title;
 	parse_message_handlers["request_embed_suspend_toggle"] = &ScriptEditorDebugger::_msg_embed_suspend_toggle;
 	parse_message_handlers["request_embed_next_frame"] = &ScriptEditorDebugger::_msg_embed_next_frame;
+	parse_message_handlers["game_view_input_override"] = &ScriptEditorDebugger::_msg_embed_input_override;
+	parse_message_handlers["game_view_2d_selection_override"] = &ScriptEditorDebugger::_msg_embed_2d_selection_override;
+	parse_message_handlers["game_view_3d_selection_override"] = &ScriptEditorDebugger::_msg_embed_3d_selection_override;
+	parse_message_handlers["game_view_toggle_camera_override"] = &ScriptEditorDebugger::_msg_embed_toggle_camera_override;
+	parse_message_handlers["game_view_increase_speed"] = &ScriptEditorDebugger::_msg_embed_increase_speed;
+	parse_message_handlers["game_view_decrease_speed"] = &ScriptEditorDebugger::_msg_embed_decrease_speed;
+	parse_message_handlers["game_view_reset_speed"] = &ScriptEditorDebugger::_msg_embed_reset_speed;
 }
 
 void ScriptEditorDebugger::_set_reason_text(const String &p_reason, MessageType p_type) {

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -244,6 +244,13 @@ private:
 	void _msg_window_title(uint64_t p_thread_id, const Array &p_data);
 	void _msg_embed_suspend_toggle(uint64_t p_thread_id, const Array &p_data);
 	void _msg_embed_next_frame(uint64_t p_thread_id, const Array &p_data);
+	void _msg_embed_input_override(uint64_t p_thread_id, const Array &p_data);
+	void _msg_embed_2d_selection_override(uint64_t p_thread_id, const Array &p_data);
+	void _msg_embed_3d_selection_override(uint64_t p_thread_id, const Array &p_data);
+	void _msg_embed_toggle_camera_override(uint64_t p_thread_id, const Array &p_data);
+	void _msg_embed_increase_speed(uint64_t p_thread_id, const Array &p_data);
+	void _msg_embed_decrease_speed(uint64_t p_thread_id, const Array &p_data);
+	void _msg_embed_reset_speed(uint64_t p_thread_id, const Array &p_data);
 
 	void _parse_message(const String &p_msg, uint64_t p_thread_id, const Array &p_data);
 	void _set_reason_text(const String &p_reason, MessageType p_type);
@@ -311,6 +318,13 @@ public:
 	enum EmbedShortcutAction {
 		EMBED_SUSPEND_TOGGLE,
 		EMBED_NEXT_FRAME,
+		EMBED_INPUT_OVERRIDE,
+		EMBED_2D_SELECTION_OVERRIDE,
+		EMBED_3D_SELECTION_OVERRIDE,
+		EMBED_TOGGLE_CAMERA_OVERRIDE,
+		EMBED_INCREASE_SPEED,
+		EMBED_DECREASE_SPEED,
+		EMBED_RESET_SPEED
 	};
 
 	void request_remote_objects(const TypedArray<uint64_t> &p_obj_ids, bool p_update_selection = true);

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -150,6 +150,13 @@ void GameViewDebugger::_session_started(Ref<EditorDebuggerSession> p_session) {
 	Dictionary shortcut_settings;
 	shortcut_settings["editor/suspend_resume_embedded_project"] = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/suspend_resume_embedded_project"));
 	shortcut_settings["editor/next_frame_embedded_project"] = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/next_frame_embedded_project"));
+	shortcut_settings["editor/game_view_input_override"] = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/game_view_input_override"));
+	shortcut_settings["editor/game_view_2d_selection_override"] = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/game_view_2d_selection_override"));
+	shortcut_settings["editor/game_view_3d_selection_override"] = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/game_view_3d_selection_override"));
+	shortcut_settings["editor/game_view_toggle_camera_override"] = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/game_view_toggle_camera_override"));
+	shortcut_settings["editor/game_view_increase_speed"] = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/game_view_increase_speed"));
+	shortcut_settings["editor/game_view_decrease_speed"] = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/game_view_decrease_speed"));
+	shortcut_settings["editor/game_view_reset_speed"] = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/game_view_reset_speed"));
 
 	p_session->send_message("scene:setup_embedded_shortcuts", { shortcut_settings });
 
@@ -435,6 +442,15 @@ GameViewDebugger::GameViewDebugger() {
 	ED_SHORTCUT_OVERRIDE("editor/suspend_resume_embedded_project", "macos", KeyModifierMask::META | KeyModifierMask::SHIFT | Key::B);
 
 	ED_SHORTCUT("editor/next_frame_embedded_project", TTRC("Next Frame"), Key::F10);
+
+	ED_SHORTCUT("editor/game_view_input_override", TTRC("Override Game Input"), KeyModifierMask::CTRL | KeyModifierMask::ALT | Key::KEY_1);
+	ED_SHORTCUT("editor/game_view_2d_selection_override", TTRC("Override 2D Selection"), KeyModifierMask::CTRL | KeyModifierMask::ALT | Key::KEY_2);
+	ED_SHORTCUT("editor/game_view_3d_selection_override", TTRC("Override 3D Selection"), KeyModifierMask::CTRL | KeyModifierMask::ALT | Key::KEY_3);
+	ED_SHORTCUT("editor/game_view_toggle_camera_override", TTRC("Override 2D/3D Camera"), KeyModifierMask::CTRL | KeyModifierMask::ALT | Key::KEY_4);
+
+	ED_SHORTCUT("editor/game_view_increase_speed", TTRC("Increase Game Speed"), KeyModifierMask::CTRL | KeyModifierMask::SHIFT | Key::EQUAL);
+	ED_SHORTCUT("editor/game_view_decrease_speed", TTRC("Decrease Game Speed"), KeyModifierMask::CTRL | KeyModifierMask::SHIFT | Key::MINUS);
+	ED_SHORTCUT("editor/game_view_reset_speed", TTRC("Reset Game Speed"), KeyModifierMask::CTRL | KeyModifierMask::SHIFT | Key::BACKSPACE);
 }
 
 ///////
@@ -707,6 +723,27 @@ void GameView::_handle_shortcut_requested(int p_embed_action) {
 		case ScriptEditorDebugger::EMBED_NEXT_FRAME: {
 			debugger->next_frame();
 		} break;
+		case ScriptEditorDebugger::EMBED_INPUT_OVERRIDE: {
+			_node_type_pressed(RuntimeNodeSelect::NODE_TYPE_NONE);
+		} break;
+		case ScriptEditorDebugger::EMBED_2D_SELECTION_OVERRIDE: {
+			_node_type_pressed(RuntimeNodeSelect::NODE_TYPE_2D);
+		} break;
+		case ScriptEditorDebugger::EMBED_3D_SELECTION_OVERRIDE: {
+			_node_type_pressed(RuntimeNodeSelect::NODE_TYPE_3D);
+		} break;
+		case ScriptEditorDebugger::EMBED_TOGGLE_CAMERA_OVERRIDE: {
+			camera_override_button->set_pressed(!camera_override_button->is_pressed());
+		} break;
+		case ScriptEditorDebugger::EMBED_INCREASE_SPEED: {
+			_increase_speed();
+		} break;
+		case ScriptEditorDebugger::EMBED_DECREASE_SPEED: {
+			_decrease_speed();
+		} break;
+		case ScriptEditorDebugger::EMBED_RESET_SPEED: {
+			_reset_time_scales();
+		} break;
 	}
 }
 
@@ -835,6 +872,36 @@ void GameView::_reset_time_scales() {
 	if (is_inside_tree()) {
 		_update_speed_state_icon(DEFAULT_TIME_SCALE_INDEX);
 		_update_speed_buttons();
+	}
+}
+
+void GameView::_increase_speed() {
+	int target = time_scale_index + 1;
+	while (target >= 4 && target <= 8 && target < time_scale_range.size()) {
+		target++;
+	}
+	if (target < time_scale_range.size()) {
+		time_scale_index = target;
+		debugger->set_time_scale(time_scale_range[time_scale_index]);
+		if (is_inside_tree()) {
+			_update_speed_state_icon(time_scale_index);
+			_update_speed_buttons();
+		}
+	}
+}
+
+void GameView::_decrease_speed() {
+	int target = time_scale_index - 1;
+	while (target >= 4 && target <= 8 && target >= 0) {
+		target--;
+	}
+	if (target >= 0) {
+		time_scale_index = target;
+		debugger->set_time_scale(time_scale_range[time_scale_index]);
+		if (is_inside_tree()) {
+			_update_speed_state_icon(time_scale_index);
+			_update_speed_buttons();
+		}
 	}
 }
 
@@ -1501,7 +1568,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	suspend_button->set_toggle_mode(true);
 	suspend_button->set_theme_type_variation(SceneStringName(FlatButton));
 	suspend_button->connect(SceneStringName(toggled), callable_mp(this, &GameView::_suspend_button_toggled));
-	suspend_button->set_accessibility_name(TTRC("Suspend"));
+	suspend_button->set_accessibility_name(TTRC("Suspend/Resume Embedded Game"));
 	suspend_button->set_shortcut(ED_GET_SHORTCUT("editor/suspend_resume_embedded_project"));
 	suspend_button->set_tooltip_text(TTRC("Force pause at SceneTree level. Stops all processing, but you can still interact with the game."));
 
@@ -1545,6 +1612,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_NONE]->set_theme_type_variation("FlatButtonNoIconTint");
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_NONE]->connect(SceneStringName(pressed), callable_mp(this, &GameView::_node_type_pressed).bind(RuntimeNodeSelect::NODE_TYPE_NONE));
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_NONE]->set_tooltip_text(TTRC("Allow game input as usual."));
+	node_type_button[RuntimeNodeSelect::NODE_TYPE_NONE]->set_shortcut(ED_GET_SHORTCUT("editor/game_view_input_override"));
 
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_2D] = memnew(Button);
 	input_hb->add_child(node_type_button[RuntimeNodeSelect::NODE_TYPE_2D]);
@@ -1553,6 +1621,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_2D]->set_theme_type_variation("FlatButtonNoIconTint");
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_2D]->connect(SceneStringName(pressed), callable_mp(this, &GameView::_node_type_pressed).bind(RuntimeNodeSelect::NODE_TYPE_2D));
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_2D]->set_tooltip_text(TTRC("Disable game input to allow selecting Node2Ds and Controls, as well as manipulate the 2D camera."));
+	node_type_button[RuntimeNodeSelect::NODE_TYPE_2D]->set_shortcut(ED_GET_SHORTCUT("editor/game_view_2d_selection_override"));
 
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D] = memnew(Button);
 	input_hb->add_child(node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]);
@@ -1561,6 +1630,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_theme_type_variation("FlatButtonNoIconTint");
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->connect(SceneStringName(pressed), callable_mp(this, &GameView::_node_type_pressed).bind(RuntimeNodeSelect::NODE_TYPE_3D));
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_tooltip_text(TTRC("Disable game input to allow selecting Node3Ds and manipulating the 3D camera."));
+	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_shortcut(ED_GET_SHORTCUT("editor/game_view_3d_selection_override"));
 
 	main_menu_fc->add_child(memnew(VSeparator));
 
@@ -1628,6 +1698,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	camera_override_button->set_theme_type_variation(SceneStringName(FlatButton));
 	camera_override_button->set_tooltip_text(TTRC("Override the in-game camera."));
 	camera_override_button->connect(SceneStringName(toggled), callable_mp(this, &GameView::_camera_override_button_toggled));
+	camera_override_button->set_shortcut(ED_GET_SHORTCUT("editor/game_view_toggle_camera_override"));
 
 	camera_override_menu = memnew(MenuButton);
 	camera_hb->add_child(camera_override_menu);

--- a/editor/run/game_view_plugin.h
+++ b/editor/run/game_view_plugin.h
@@ -236,6 +236,8 @@ class GameView : public VBoxContainer {
 	void _game_window_options_menu_menu_id_pressed(int p_id);
 
 	void _reset_time_scales();
+	void _increase_speed();
+	void _decrease_speed();
 	void _speed_state_menu_pressed(int p_id);
 	void _update_speed_buttons();
 	void _update_speed_state_icon(int p_id);

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -137,6 +137,48 @@ void SceneDebugger::_handle_embed_input(const Ref<InputEvent> &p_event, const Di
 		EngineDebugger::get_singleton()->send_message("request_embed_suspend_toggle", Array());
 		return;
 	}
+
+	p_shortcut = p_settings.get("editor/game_view_input_override", Ref<Shortcut>());
+	if (p_shortcut.is_valid() && p_shortcut->matches_event(k)) {
+		EngineDebugger::get_singleton()->send_message("game_view_input_override", Array());
+		return;
+	}
+
+	p_shortcut = p_settings.get("editor/game_view_2d_selection_override", Ref<Shortcut>());
+	if (p_shortcut.is_valid() && p_shortcut->matches_event(k)) {
+		EngineDebugger::get_singleton()->send_message("game_view_2d_selection_override", Array());
+		return;
+	}
+
+	p_shortcut = p_settings.get("editor/game_view_3d_selection_override", Ref<Shortcut>());
+	if (p_shortcut.is_valid() && p_shortcut->matches_event(k)) {
+		EngineDebugger::get_singleton()->send_message("game_view_3d_selection_override", Array());
+		return;
+	}
+
+	p_shortcut = p_settings.get("editor/game_view_toggle_camera_override", Ref<Shortcut>());
+	if (p_shortcut.is_valid() && p_shortcut->matches_event(k)) {
+		EngineDebugger::get_singleton()->send_message("game_view_toggle_camera_override", Array());
+		return;
+	}
+
+	p_shortcut = p_settings.get("editor/game_view_increase_speed", Ref<Shortcut>());
+	if (p_shortcut.is_valid() && p_shortcut->matches_event(k)) {
+		EngineDebugger::get_singleton()->send_message("game_view_increase_speed", Array());
+		return;
+	}
+
+	p_shortcut = p_settings.get("editor/game_view_decrease_speed", Ref<Shortcut>());
+	if (p_shortcut.is_valid() && p_shortcut->matches_event(k)) {
+		EngineDebugger::get_singleton()->send_message("game_view_decrease_speed", Array());
+		return;
+	}
+
+	p_shortcut = p_settings.get("editor/game_view_reset_speed", Ref<Shortcut>());
+	if (p_shortcut.is_valid() && p_shortcut->matches_event(k)) {
+		EngineDebugger::get_singleton()->send_message("game_view_reset_speed", Array());
+		return;
+	}
 }
 
 void SceneDebugger::_on_window_size_changed() {


### PR DESCRIPTION
Adds additional shortcuts for `Game View`:
- Switching between Input, 2D and 3D
- Overriding the camera

Here is an **_exciting_** video of keyboard shortcuts being pressed:

https://github.com/user-attachments/assets/1f5f78d4-fb88-4eb9-8a9e-571546dc0848

![image](https://github.com/user-attachments/assets/b2c86c4e-2500-46a9-a0de-763a41978138)



