### PR TITLE
Expand `GDType` to cover GDExtension types as well

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -491,6 +491,8 @@ void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr 
 	}
 #endif
 
+	extension->gdextension.create_gdtype();
+
 	ClassDB::register_extension_class(&extension->gdextension);
 
 	if (p_extension_funcs->icon_path != nullptr) {
@@ -970,6 +972,8 @@ void GDExtension::_clear_extension(Extension *p_extension) {
 
 		obj->clear_internal_extension();
 	}
+
+	p_extension->gdextension.destroy_gdtype();
 }
 
 void GDExtension::track_instance_binding(Object *p_object) {

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -196,6 +196,8 @@ public:
 		obj->_extension = ClassDB::get_placeholder_extension(ti->name);
 		obj->_extension_instance = memnew(PlaceholderExtensionInstance(ti->name));
 
+		obj->_reset_gdtype();
+
 #ifdef TOOLS_ENABLED
 		if (obj->_extension->track_instance) {
 			obj->_extension->track_instance(obj->_extension->tracking_userdata, obj);
@@ -756,9 +758,18 @@ ObjectGDExtension *ClassDB::get_placeholder_extension(const StringName &p_class)
 	placeholder_extension->call_virtual_with_data = nullptr;
 	placeholder_extension->recreate_instance = &PlaceholderExtensionInstance::placeholder_class_recreate_instance;
 
+	placeholder_extension->create_gdtype();
+
 	return placeholder_extension;
 }
 #endif
+
+const GDType *ClassDB::get_gdtype(const StringName &p_class) {
+	Locker::Lock lock(Locker::STATE_READ);
+	ClassInfo *type = classes.getptr(p_class);
+	ERR_FAIL_NULL_V(type, nullptr);
+	return type->gdtype;
+}
 
 void ClassDB::set_object_extension_instance(Object *p_object, const StringName &p_class, GDExtensionClassInstancePtr p_instance) {
 	ERR_FAIL_NULL(p_object);
@@ -778,6 +789,8 @@ void ClassDB::set_object_extension_instance(Object *p_object, const StringName &
 
 	p_object->_extension = ti->gdextension;
 	p_object->_extension_instance = p_instance;
+
+	p_object->_reset_gdtype();
 
 #ifdef TOOLS_ENABLED
 	if (p_object->_extension->track_instance) {
@@ -870,17 +883,20 @@ use_script:
 	return scr.is_valid() && scr->is_valid() && scr->is_abstract();
 }
 
-void ClassDB::_add_class(const StringName &p_class, const StringName &p_inherits) {
+void ClassDB::_add_class(const GDType &p_class, const GDType *p_inherits) {
 	Locker::Lock lock(Locker::STATE_WRITE);
 
-	const StringName &name = p_class;
+	const StringName &name = p_class.get_name();
 
-	ERR_FAIL_COND_MSG(classes.has(name), vformat("Class '%s' already exists.", String(p_class)));
+	ERR_FAIL_COND_MSG(classes.has(name), vformat("Class '%s' already exists.", name));
 
 	classes[name] = ClassInfo();
 	ClassInfo &ti = classes[name];
 	ti.name = name;
-	ti.inherits = p_inherits;
+	ti.gdtype = &p_class;
+	if (p_inherits) {
+		ti.inherits = p_inherits->get_name();
+	}
 	ti.api = current_api;
 
 	if (ti.inherits) {
@@ -2349,6 +2365,8 @@ void ClassDB::register_extension_class(ObjectGDExtension *p_extension) {
 #ifdef TOOLS_ENABLED
 	c.is_runtime = p_extension->is_runtime;
 #endif
+
+	c.gdtype = p_extension->gdtype;
 
 	classes[p_extension->class_name] = c;
 }

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -123,6 +123,7 @@ public:
 		APIType api = API_NONE;
 		ClassInfo *inherits_ptr = nullptr;
 		void *class_ptr = nullptr;
+		const GDType *gdtype = nullptr;
 
 		ObjectGDExtension *gdextension = nullptr;
 
@@ -218,7 +219,7 @@ public:
 	static APIType current_api;
 	static HashMap<APIType, uint32_t> api_hashes_cache;
 
-	static void _add_class(const StringName &p_class, const StringName &p_inherits);
+	static void _add_class(const GDType &p_class, const GDType *p_inherits);
 
 	static HashMap<StringName, HashMap<StringName, Variant>> default_values;
 	static HashSet<StringName> default_values_cached;
@@ -334,6 +335,7 @@ public:
 	static void get_extension_class_list(const Ref<GDExtension> &p_extension, List<StringName> *p_classes);
 	static ObjectGDExtension *get_placeholder_extension(const StringName &p_class);
 #endif
+	static const GDType *get_gdtype(const StringName &p_class);
 	static void get_inheriters_from_class(const StringName &p_class, LocalVector<StringName> &p_classes);
 	static void get_direct_inheriters_from_class(const StringName &p_class, List<StringName> *p_classes);
 	static StringName get_parent_class_nocheck(const StringName &p_class);

--- a/core/object/gdtype.cpp
+++ b/core/object/gdtype.cpp
@@ -32,11 +32,11 @@
 
 GDType::GDType(const GDType *p_super_type, StringName p_name) :
 		super_type(p_super_type), name(std::move(p_name)) {
-	name_hierarchy.push_back(StringName(name, true));
+	name_hierarchy.push_back(name);
 
 	if (super_type) {
 		for (const StringName &ancestor_name : super_type->name_hierarchy) {
-			name_hierarchy.push_back(StringName(ancestor_name, true));
+			name_hierarchy.push_back(ancestor_name);
 		}
 	}
 }


### PR DESCRIPTION
- Requires / Includes #105793.

`GDType` is explained in the corresponding proposal: https://github.com/godotengine/godot-proposals/issues/12323.

This PR expands `GDType` to cover GDExtension added classes as well, by swapping the pointer when a GDExtension subtype is assigned to the `Object`. This eliminates branching and separate computation in typing functions such as `is_class`.

This should be merged relatively soon after, or even together with #105793, to eliminate the possibility of `GDType` being used in contexts assuming internal types only.

### Explanation

`Object` instances can get assigned a GDExtension 'subtype'. According to Godot's typing logic, this makes the `Object`'s new type the GDExtension's supplied type, i.e. a subtype of the builtin type. You can read more about this general idea here: https://github.com/godotengine/godot-proposals/issues/12155

Note: Instances are usually assigned a GDExtension instance exactly once, right after the `Object` is created. When this happens, all we have to do is use the GDExtension's `GDType` instead of the builtin one.
