### PR TITLE
Fix damping calculation for GodotSoftBody3D

### DIFF
--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -1084,7 +1084,7 @@ void GodotSoftBody3D::solve_constraints(real_t p_delta) {
 		const real_t ti = isolve / (real_t)iteration_count;
 		solve_links(1.0, ti);
 	}
-	const real_t vc = (1.0 - damping_coefficient) * inv_delta;
+	const real_t vc = MAX(inv_delta - damping_coefficient, 0.0);
 	for (Node &node : nodes) {
 		node.x += node.bv * p_delta;
 		node.bv = Vector3();


### PR DESCRIPTION
The existing damping calculation was inconsistent with the one used in godot body 3d and caused excessive damping / made it possible for damping to flip the velocity of a particle.

This makes the behavior similar to the one used by Jolt Physics.

See discussion at #105987
