### PR TITLE
Added get_ceiling_normal() function

### DIFF
--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -405,6 +405,7 @@ void CharacterBody2D::_set_collision_direction(const PhysicsServer2D::MotionResu
 		_set_platform_data(p_result);
 	} else if (motion_mode == MOTION_MODE_GROUNDED && p_result.get_angle(-up_direction) <= floor_max_angle + FLOOR_ANGLE_THRESHOLD) { //ceiling
 		on_ceiling = true;
+		ceiling_normal = p_result.collision_normal;
 	} else {
 		on_wall = true;
 		wall_normal = p_result.collision_normal;
@@ -460,6 +461,11 @@ const Vector2 &CharacterBody2D::get_floor_normal() const {
 
 const Vector2 &CharacterBody2D::get_wall_normal() const {
 	return wall_normal;
+}
+
+
+const Vector2 &CharacterBody2D::get_ceiling_normal() const {
+	return ceiling_normal;
 }
 
 const Vector2 &CharacterBody2D::get_last_motion() const {
@@ -702,6 +708,7 @@ void CharacterBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_on_wall"), &CharacterBody2D::is_on_wall);
 	ClassDB::bind_method(D_METHOD("is_on_wall_only"), &CharacterBody2D::is_on_wall_only);
 	ClassDB::bind_method(D_METHOD("get_floor_normal"), &CharacterBody2D::get_floor_normal);
+	ClassDB::bind_method(D_METHOD("get_ceiling_normal"), &CharacterBody2D::get_ceiling_normal);
 	ClassDB::bind_method(D_METHOD("get_wall_normal"), &CharacterBody2D::get_wall_normal);
 	ClassDB::bind_method(D_METHOD("get_last_motion"), &CharacterBody2D::get_last_motion);
 	ClassDB::bind_method(D_METHOD("get_position_delta"), &CharacterBody2D::get_position_delta);

--- a/scene/2d/physics/character_body_2d.h
+++ b/scene/2d/physics/character_body_2d.h
@@ -61,6 +61,7 @@ public:
 	const Vector2 &get_last_motion() const;
 	Vector2 get_position_delta() const;
 	const Vector2 &get_floor_normal() const;
+	const Vector2 &get_ceiling_normal() const;
 	const Vector2 &get_wall_normal() const;
 	const Vector2 &get_real_velocity() const;
 
@@ -131,8 +132,9 @@ private:
 	Vector2 velocity;
 
 	Vector2 floor_normal;
-	Vector2 platform_velocity;
 	Vector2 wall_normal;
+	Vector2 ceiling_normal;
+	Vector2 platform_velocity;
 	Vector2 last_motion;
 	Vector2 previous_position;
 	Vector2 real_velocity;


### PR DESCRIPTION
Function get_ceiling_normal() works similar to get_floor_normal() and get_wall_normal()

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
