### PR TITLE
Core: Explicitly delete `free()` from `Object`, to help users new to engine to use `memdelete` instead

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -996,6 +996,9 @@ public:
 
 	void cancel_free();
 
+	/// Use memdelete(object) instead.
+	void free() = delete;
+
 	Object();
 	virtual ~Object();
 };

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -821,7 +821,7 @@ void EditorNode3DGizmo::transform() {
 	_update_bvh();
 }
 
-void EditorNode3DGizmo::free() {
+void EditorNode3DGizmo::free_gizmo() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	ERR_FAIL_NULL(spatial_node);
 	ERR_FAIL_COND(!valid);

--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -134,7 +134,7 @@ public:
 	virtual void create() override;
 	virtual void transform() override;
 	virtual void redraw() override;
-	virtual void free() override;
+	virtual void free_gizmo() override;
 
 	virtual bool is_editable() const;
 

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -817,7 +817,7 @@ void Node3D::remove_gizmo(Ref<Node3DGizmo> p_gizmo) {
 #ifdef TOOLS_ENABLED
 	int idx = data.gizmos.find(p_gizmo);
 	if (idx != -1) {
-		p_gizmo->free();
+		p_gizmo->free_gizmo();
 		data.gizmos.remove_at(idx);
 	}
 #endif
@@ -827,7 +827,7 @@ void Node3D::clear_gizmos() {
 	ERR_THREAD_GUARD;
 #ifdef TOOLS_ENABLED
 	for (int i = 0; i < data.gizmos.size(); i++) {
-		data.gizmos.write[i]->free();
+		data.gizmos.write[i]->free_gizmo();
 	}
 	data.gizmos.clear();
 #endif

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -41,7 +41,7 @@ public:
 	virtual void transform() = 0;
 	virtual void clear() = 0;
 	virtual void redraw() = 0;
-	virtual void free() = 0;
+	virtual void free_gizmo() = 0;
 
 	Node3DGizmo();
 	virtual ~Node3DGizmo() {}


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/pull/103231

This revealed that `Node3DGizmo` was defining a `free` function with different semantics. I have renamed the function to avoid confusing users.