### PR TITLE
Reduce allocations/copies in `String::format`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3843,34 +3843,28 @@ bool String::matchn(const String &p_wildcard) const {
 }
 
 String String::format(const Variant &values, const String &placeholder) const {
-	String new_string = String(ptr());
+	String new_string = *this;
 
 	if (values.get_type() == Variant::ARRAY) {
 		Array values_arr = values;
 
 		for (int i = 0; i < values_arr.size(); i++) {
-			String i_as_str = String::num_int64(i);
-
 			if (values_arr[i].get_type() == Variant::ARRAY) { //Array in Array structure [["name","RobotGuy"],[0,"godot"],["strength",9000.91]]
 				Array value_arr = values_arr[i];
 
 				if (value_arr.size() == 2) {
-					Variant v_key = value_arr[0];
-					String key = v_key;
-
-					Variant v_val = value_arr[1];
-					String val = v_val;
+					String key = value_arr[0];
+					String val = value_arr[1];
 
 					new_string = new_string.replace(placeholder.replace("_", key), val);
 				} else {
 					ERR_PRINT(vformat("Invalid format: the inner Array at index %d needs to contain only 2 elements, as a key-value pair.", i).ascii().get_data());
 				}
 			} else { //Array structure ["RobotGuy","Logis","rookie"]
-				Variant v_val = values_arr[i];
-				String val = v_val;
+				String val = values_arr[i];
 
 				if (placeholder.contains_char('_')) {
-					new_string = new_string.replace(placeholder.replace("_", i_as_str), val);
+					new_string = new_string.replace(placeholder.replace("_", String::num_int64(i)), val);
 				} else {
 					new_string = new_string.replace_first(placeholder, val);
 				}


### PR DESCRIPTION
- Updated initial `new_string` copy to use copy constructor/increase ref count instead of copying to new allocated memory
- Removed `Variant` copies from `Array` before assigning to `String`
- Only convert `i` to `String` when needed

Makes `String::format` around 5-30% faster depending on how arguments are passed in, compared with gdscript below:

```gdscript
var pos3 := Vector3(1, 2, 3)
func _ready() -> void:
	run_test("nested_arrays")
	run_test("array_with_index")
	run_test("array_no_index")
	run_test("dictionary")
	
func run_test(p_name : String):
	var start := Time.get_ticks_msec()
	call(p_name)
	var end := Time.get_ticks_msec()
	print("%s: %dms" % [p_name, end - start])

func nested_arrays():
	var args := [["x", pos3.x], ["y", pos3.y], ["z", pos3.z]]
	for i in 100000:
		"(x: {x}, y: {y}, z: {z})".format(args)

func array_with_index():
	var args := [pos3.x, pos3.y, pos3.z]
	for i in 100000:
		"(x: {0}, y: {1}, z: {2})".format(args)
		
func array_no_index():
	var args := [pos3.x, pos3.y, pos3.z]
	for i in 100000:
		"(x: {}, y: {}, z: {})".format(args, "{}")

func dictionary():
	var args := {"x": pos3.x, "y": pos3.y, "z": pos3.z}
	for i in 100000:
		"(x: {x}, y: {y}, z: {z})".format(args)
```

old
```
nested_arrays: 237ms
array_with_index: 220ms
array_no_index: 130ms
dictionary: 194ms
```

new
```
nested_arrays: 206ms
array_with_index: 212ms
array_no_index: 103ms
dictionary: 184ms
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
