### PR TITLE
[GDExtension] Add function to register main loop callbacks

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -686,6 +686,13 @@ void GDExtension::_register_get_classes_used_callback(GDExtensionClassLibraryPtr
 #endif
 }
 
+void GDExtension::_register_main_loop_callbacks(GDExtensionClassLibraryPtr p_library, const GDExtensionMainLoopCallbacks *p_callbacks) {
+	GDExtension *self = reinterpret_cast<GDExtension *>(p_library);
+	self->startup_callback = p_callbacks->startup_func;
+	self->shutdown_callback = p_callbacks->shutdown_func;
+	self->frame_callback = p_callbacks->frame_func;
+}
+
 void GDExtension::register_interface_function(const StringName &p_function_name, GDExtensionInterfaceFunctionPtr p_function_pointer) {
 	ERR_FAIL_COND_MSG(gdextension_interface_functions.has(p_function_name), vformat("Attempt to register interface function '%s', which appears to be already registered.", p_function_name));
 	gdextension_interface_functions.insert(p_function_name, p_function_pointer);
@@ -805,6 +812,7 @@ void GDExtension::initialize_gdextensions() {
 	register_interface_function("classdb_unregister_extension_class", (GDExtensionInterfaceFunctionPtr)&GDExtension::_unregister_extension_class);
 	register_interface_function("get_library_path", (GDExtensionInterfaceFunctionPtr)&GDExtension::_get_library_path);
 	register_interface_function("editor_register_get_classes_used_callback", (GDExtensionInterfaceFunctionPtr)&GDExtension::_register_get_classes_used_callback);
+	register_interface_function("register_main_loop_callbacks", (GDExtensionInterfaceFunctionPtr)&GDExtension::_register_main_loop_callbacks);
 }
 
 void GDExtension::finalize_gdextensions() {

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -94,6 +94,7 @@ class GDExtension : public Resource {
 	static void _unregister_extension_class(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name);
 	static void _get_library_path(GDExtensionClassLibraryPtr p_library, GDExtensionStringPtr r_path);
 	static void _register_get_classes_used_callback(GDExtensionClassLibraryPtr p_library, GDExtensionEditorGetClassesUsedCallback p_callback);
+	static void _register_main_loop_callbacks(GDExtensionClassLibraryPtr p_library, const GDExtensionMainLoopCallbacks *p_callbacks);
 
 	GDExtensionInitialization initialization;
 	int32_t level_initialized = -1;
@@ -114,6 +115,10 @@ class GDExtension : public Resource {
 	void finish_reload();
 	void clear_instance_bindings();
 #endif
+
+	GDExtensionMainLoopStartupCallback startup_callback = nullptr;
+	GDExtensionMainLoopShutdownCallback shutdown_callback = nullptr;
+	GDExtensionMainLoopFrameCallback frame_callback = nullptr;
 
 	static inline HashMap<StringName, GDExtensionInterfaceFunctionPtr> gdextension_interface_functions;
 

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -805,6 +805,21 @@ typedef struct {
 	const char *string; // (e.g. "Godot v3.1.4.stable.official.mono")
 } GDExtensionGodotVersion2;
 
+/* Called when starting the main loop. */
+typedef void (*GDExtensionMainLoopStartupCallback)();
+
+/* Called when shutting down the main loop. */
+typedef void (*GDExtensionMainLoopShutdownCallback)();
+
+/* Called for every frame iteration of the main loop. */
+typedef void (*GDExtensionMainLoopFrameCallback)();
+
+typedef struct {
+	GDExtensionMainLoopStartupCallback startup_func;
+	GDExtensionMainLoopShutdownCallback shutdown_func;
+	GDExtensionMainLoopFrameCallback frame_func;
+} GDExtensionMainLoopCallbacks;
+
 /**
  * @name get_godot_version
  * @since 4.1
@@ -3130,6 +3145,17 @@ typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8CharsAndLen)(const 
  * @param p_callback The callback to retrieve the list of classes used.
  */
 typedef void (*GDExtensionInterfaceEditorRegisterGetClassesUsedCallback)(GDExtensionClassLibraryPtr p_library, GDExtensionEditorGetClassesUsedCallback p_callback);
+
+/**
+ * @name register_main_loop_callbacks
+ * @since 4.5
+ *
+ * Registers callbacks to be called at different phases of the main loop.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_callback A pointer to the structure that contains the callbacks.
+ */
+typedef void (*GDExtensionInterfaceRegisterMainLoopCallbacks)(GDExtensionClassLibraryPtr p_library, const GDExtensionMainLoopCallbacks *p_callbacks);
 
 #ifdef __cplusplus
 }

--- a/core/extension/gdextension_manager.h
+++ b/core/extension/gdextension_manager.h
@@ -39,6 +39,9 @@ class GDExtensionManager : public Object {
 	HashMap<String, Ref<GDExtension>> gdextension_map;
 	HashMap<String, String> gdextension_class_icon_paths;
 
+	bool startup_callback_called = false;
+	bool shutdown_callback_called = false;
+
 	static void _bind_methods();
 
 	static inline GDExtensionManager *singleton = nullptr;
@@ -85,6 +88,10 @@ public:
 	void load_extensions();
 	void reload_extensions();
 	bool ensure_extensions_loaded(const HashSet<String> &p_extensions);
+
+	void startup();
+	void shutdown();
+	void frame();
 
 	GDExtensionManager();
 	~GDExtensionManager();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4562,6 +4562,8 @@ int Main::start() {
 		movie_writer->begin(DisplayServer::get_singleton()->window_get_size(), fixed_fps, Engine::get_singleton()->get_write_movie_path());
 	}
 
+	GDExtensionManager::get_singleton()->startup();
+
 	if (minimum_time_msec) {
 		uint64_t minimum_time = 1000 * minimum_time_msec;
 		uint64_t elapsed_time = OS::get_singleton()->get_ticks_usec();
@@ -4767,6 +4769,8 @@ bool Main::iteration() {
 	process_max = MAX(process_ticks, process_max);
 	uint64_t frame_time = OS::get_singleton()->get_ticks_usec() - ticks;
 
+	GDExtensionManager::get_singleton()->frame();
+
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 		ScriptServer::get_language(i)->frame();
 	}
@@ -4886,6 +4890,8 @@ void Main::cleanup(bool p_force) {
 		input->flush_frame_parsed_events();
 	}
 #endif
+
+	GDExtensionManager::get_singleton()->shutdown();
 
 	for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
 		TextServerManager::get_singleton()->get_interface(i)->cleanup();


### PR DESCRIPTION
We need the `frame` callback in the C# GDExtension bindings to call the queued continuations on the synchronization context every frame (similar to how we use the `ScriptLanguage::frame` API works today in GodotSharp).

@dsnopek also suggested adding the `startup` and `shutdown` callbacks while we're at it, and I may have misunderstood what he meant, but I added them anyway, although I don't think we'll be using them in C#.