### PR TITLE
Add collision points to `PhysicsDirectSpaceState2/3D::intersect_shape()` results

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -75,12 +75,16 @@
 			<return type="Dictionary[]" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters2D" />
 			<param index="1" name="max_results" type="int" default="32" />
+			<param index="2" name="with_points" type="bool" default="false" />
 			<description>
 				Checks the intersections of a shape, given through a [PhysicsShapeQueryParameters2D] object, against the space. The intersected shapes are returned in an array containing dictionaries with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
+				If [param with_points] is [code]true[/code], each result dictionary will also contain:
+				[code]point_a[/code]: The contact point on the shape defined by [PhysicsShapeQueryParameters2D].
+				[code]point_b[/code]: The contact point on the colliding shape.
 				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
 			</description>
 		</method>

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -78,12 +78,16 @@
 			<return type="Dictionary[]" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters3D" />
 			<param index="1" name="max_results" type="int" default="32" />
+			<param index="2" name="with_points" type="bool" default="false" />
 			<description>
 				Checks the intersections of a shape, given through a [PhysicsShapeQueryParameters3D] object, against the space. The intersected shapes are returned in an array containing dictionaries with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
+				If [param with_points] is [code]true[/code], each result dictionary will also contain:
+				[code]point_a[/code]: The contact point on the shape defined by [PhysicsShapeQueryParameters3D].
+				[code]point_b[/code]: The contact point on the colliding shape.
 				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
 				[b]Note:[/b] This method does not take into account the [code]motion[/code] property of the object.
 			</description>

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -104,3 +104,11 @@ GH-105570
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/texture_create_from_extension/arguments': size changed value in new API, from 9 to 10.
 
 Argument added; p_mipmaps. Compatibility method registered.
+
+
+GH-106037
+---------
+Validate extension JSON: Error: Field 'classes/PhysicsDirectSpaceState2D/methods/intersect_shape/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/PhysicsDirectSpaceState3D/methods/intersect_shape/arguments': size changed value in new API, from 2 to 3.
+
+Optional "with_points" argument added. Compatibility methods registered.

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -207,6 +207,12 @@ bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parame
 	return true;
 }
 
+static void _shape_cbk_result(const Vector3 &p_point_A, int p_index_A, const Vector3 &p_point_B, int p_index_B, const Vector3 &normal, void *p_userdata) {
+	PhysicsDirectSpaceState3D::ShapeResult *const result = static_cast<PhysicsDirectSpaceState3D::ShapeResult *>(p_userdata);
+	result->point_a = p_point_A;
+	result->point_b = p_point_B;
+}
+
 int GodotPhysicsDirectSpaceState3D::intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) {
 	if (p_result_max <= 0) {
 		return 0;
@@ -222,6 +228,10 @@ int GodotPhysicsDirectSpaceState3D::intersect_shape(const ShapeParameters &p_par
 	int cc = 0;
 
 	//Transform3D ai = p_xform.affine_inverse();
+	GodotCollisionSolver3D::CallbackResult cbkres = nullptr;
+	if (p_parameters.result_with_points) {
+		cbkres = _shape_cbk_result;
+	}
 
 	for (int i = 0; i < amount; i++) {
 		if (cc >= p_result_max) {
@@ -241,7 +251,7 @@ int GodotPhysicsDirectSpaceState3D::intersect_shape(const ShapeParameters &p_par
 		const GodotCollisionObject3D *col_obj = space->intersection_query_results[i];
 		int shape_idx = space->intersection_query_subindex_results[i];
 
-		if (!GodotCollisionSolver3D::solve_static(shape, p_parameters.transform, col_obj->get_shape(shape_idx), col_obj->get_transform() * col_obj->get_shape_transform(shape_idx), nullptr, nullptr, nullptr, p_parameters.margin, 0)) {
+		if (!GodotCollisionSolver3D::solve_static(shape, p_parameters.transform, col_obj->get_shape(shape_idx), col_obj->get_transform() * col_obj->get_shape_transform(shape_idx), cbkres, r_results + cc, nullptr, p_parameters.margin, 0)) {
 			continue;
 		}
 

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -587,6 +587,8 @@ int JoltPhysicsDirectSpaceState3D::intersect_shape(const ShapeParameters &p_para
 	const Vector3 com_scaled = to_godot(jolt_shape->GetCenterOfMass());
 	const Transform3D transform_com = transform.translated_local(com_scaled);
 
+	const Vector3 &base_offset = transform_com.origin;
+
 	JPH::CollideShapeSettings settings;
 	settings.mMaxSeparationDistance = (float)p_parameters.margin;
 
@@ -614,6 +616,11 @@ int JoltPhysicsDirectSpaceState3D::intersect_shape(const ShapeParameters &p_para
 		result.rid = object->get_rid();
 		result.collider_id = object->get_instance_id();
 		result.collider = object->get_instance();
+
+		if (p_parameters.result_with_points) {
+			result.point_a = base_offset + to_godot(hit.mContactPointOn1);
+			result.point_b = base_offset + to_godot(hit.mContactPointOn2);
+		}
 	}
 
 	return hit_count;

--- a/servers/physics_server_2d.compat.inc
+++ b/servers/physics_server_2d.compat.inc
@@ -1,0 +1,43 @@
+/**************************************************************************/
+/*  physics_server_2d.compat.inc                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "core/variant/typed_array.h"
+
+TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_shape_bind_compat_106037(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results) {
+	return _intersect_shape(p_shape_query, p_max_results, false);
+}
+
+void PhysicsDirectSpaceState2D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("intersect_shape", "parameters", "max_results"), &PhysicsDirectSpaceState2D::_intersect_shape_bind_compat_106037, DEFVAL(32));
+}
+
+#endif // DISABLE_DEPRECATED

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -120,13 +120,18 @@ class PhysicsDirectSpaceState2D : public Object {
 
 	Dictionary _intersect_ray(const Ref<PhysicsRayQueryParameters2D> &p_ray_query);
 	TypedArray<Dictionary> _intersect_point(const Ref<PhysicsPointQueryParameters2D> &p_point_query, int p_max_results = 32);
-	TypedArray<Dictionary> _intersect_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results = 32);
+	TypedArray<Dictionary> _intersect_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results = 32, bool p_with_points = false);
 	Vector<real_t> _cast_motion(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query);
 	TypedArray<Vector2> _collide_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results = 32);
 	Dictionary _get_rest_info(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query);
 
 protected:
 	static void _bind_methods();
+
+#ifndef DISABLE_DEPRECATED
+	TypedArray<Dictionary> _intersect_shape_bind_compat_106037(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results = 32);
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
 
 public:
 	struct RayParameters {
@@ -153,6 +158,8 @@ public:
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) = 0;
 
 	struct ShapeResult {
+		Vector2 point_a;
+		Vector2 point_b;
 		RID rid;
 		ObjectID collider_id;
 		Object *collider = nullptr;
@@ -183,6 +190,7 @@ public:
 
 		bool collide_with_bodies = true;
 		bool collide_with_areas = false;
+		bool result_with_points = false;
 	};
 
 	struct ShapeRestInfo {

--- a/servers/physics_server_3d.compat.inc
+++ b/servers/physics_server_3d.compat.inc
@@ -1,0 +1,43 @@
+/**************************************************************************/
+/*  physics_server_3d.compat.inc                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "core/variant/typed_array.h"
+
+TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_shape_bind_compat_106037(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results) {
+	return _intersect_shape(p_shape_query, p_max_results, false);
+}
+
+void PhysicsDirectSpaceState3D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("intersect_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_shape_bind_compat_106037, DEFVAL(32));
+}
+
+#endif // DISABLE_DEPRECATED

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -124,13 +124,18 @@ class PhysicsDirectSpaceState3D : public Object {
 private:
 	Dictionary _intersect_ray(const Ref<PhysicsRayQueryParameters3D> &p_ray_query);
 	TypedArray<Dictionary> _intersect_point(const Ref<PhysicsPointQueryParameters3D> &p_point_query, int p_max_results = 32);
-	TypedArray<Dictionary> _intersect_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32);
+	TypedArray<Dictionary> _intersect_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32, bool p_with_points = false);
 	Vector<real_t> _cast_motion(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query);
 	TypedArray<Vector3> _collide_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32);
 	Dictionary _get_rest_info(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query);
 
 protected:
 	static void _bind_methods();
+
+#ifndef DISABLE_DEPRECATED
+	TypedArray<Dictionary> _intersect_shape_bind_compat_106037(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32);
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
 
 public:
 	struct RayParameters {
@@ -161,6 +166,8 @@ public:
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) = 0;
 
 	struct ShapeResult {
+		Vector3 point_a;
+		Vector3 point_b;
 		RID rid;
 		ObjectID collider_id;
 		Object *collider = nullptr;
@@ -188,6 +195,7 @@ public:
 
 		bool collide_with_bodies = true;
 		bool collide_with_areas = false;
+		bool result_with_points = false;
 	};
 
 	struct ShapeRestInfo {


### PR DESCRIPTION
## Description

This PR enhances `PhysicsDirectSpaceState2/3D::intersect_shape()` with an optional `with_points` parameter.
When enabled, each result dictionary will include:

- `point_a`: Contact point on the queried shape
- `point_b`: Contact point on the collided shape

This addresses [proposal #8667](https://github.com/godotengine/godot-proposals/issues/8667) which requested position/normal information in shape query results.

## Motivation

Currently, there's no efficient way to get both collision points and object RIDs in a single call:

- `collide_shape()`: Returns points without RIDs
- `get_rest_info()`: Returns only the nearest collision
- `intersect_shape()`: Returns RIDs without points

This enhancement eliminates the need for multiple physics calls when both position and object data are required.

## Implementation Details

```GDScript
Array[Dictionary] intersect_shape(parameters: PhysicsShapeQueryParameters2D, max_results: int = 32, with_points: bool = false)
Array[Dictionary] intersect_shape(parameters: PhysicsShapeQueryParameters3D, max_results: int = 32, with_points: bool = false)
```

- Default `with_points=false` maintains backward compatibility
- Collision normal can be calculated as needed with `(point_b - point_a).normalized()`
- The additional point calculations only occur when explicitly requested with `with_points=true`, ensuring no performance regression for existing code

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/8667*