### PR TITLE
Add `reserve_exact` to `CowData`, and change growth factor to 1.5x

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -569,6 +569,7 @@ Vector<uint8_t> FileAccess::get_buffer(int64_t p_length) const {
 		return data;
 	}
 
+	data.reserve_exact(p_length);
 	Error err = data.resize(p_length);
 	ERR_FAIL_COND_V_MSG(err != OK, data, vformat("Can't resize data to %d elements.", p_length));
 
@@ -863,6 +864,7 @@ Vector<uint8_t> FileAccess::get_file_as_bytes(const String &p_path, Error *r_err
 		ERR_FAIL_V_MSG(Vector<uint8_t>(), vformat("Can't open file from path '%s'.", String(p_path)));
 	}
 	Vector<uint8_t> data;
+	data.reserve_exact(f->get_length());
 	data.resize(f->get_length());
 	f->get_buffer(data.ptrw(), data.size());
 	return data;

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -166,7 +166,11 @@ public:
 			if (tight) {
 				capacity = p_size;
 			} else {
+				// Try 1.5x the current capacity.
+				// This ratio was chosen because it is close to the ideal growth rate of the golden ratio.
+				// See https://archive.ph/Z2R8w for details.
 				capacity = MAX((U)2, capacity + ((1 + capacity) >> 1));
+				// If 1.5x growth isn't enough, just use the needed size exactly.
 				if (p_size > capacity) {
 					capacity = p_size;
 				}

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -126,6 +126,11 @@ public:
 		return _cowdata.reserve(p_size);
 	}
 
+	Error reserve_exact(Size p_size) {
+		ERR_FAIL_COND_V(p_size < 0, ERR_INVALID_PARAMETER);
+		return _cowdata.reserve_exact(p_size);
+	}
+
 	_FORCE_INLINE_ const T &operator[](Size p_index) const { return _cowdata.get(p_index); }
 	// Must take a copy instead of a reference (see GH-31736).
 	Error insert(Size p_pos, T p_val) { return _cowdata.insert(p_pos, p_val); }


### PR DESCRIPTION
- Requires #105928 

Adds `reserve_exact` to `Vector` (and `CowData`), which can be used to reserve forwards without allocating more than needed (as `reserve` does).

We currently use a deterministic byte-wise growth factor of 2x for `CowData`. 
I'm proposing to change it to an indeterministic object-wise growth factor of 1.5x.

This de-complicates the implementation, and brings it in-line with `LocalVector` (https://github.com/godotengine/godot/pull/100944).

## Benchmarks 

This PR decreases the plain RAM use of the editor by **112mb** for me (10%: `1.099.228.080-986.759.136)/1000/1000 = 112,468944`).

I benchmarked the launch of the editor vs #105928. There is a regression of 1%, although it is within measurement error:

```
 ❯ hyperfine -m25 -iw1 "bin/godot.macos.editor.arm64.exact --path /Users/lukas/dev/godot/empty-game --editor --quit" "bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit"
Benchmark 1: bin/godot.macos.editor.arm64.exact --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      3.330 s ±  0.212 s    [User: 2.484 s, System: 0.359 s]
  Range (min … max):    3.038 s …  3.596 s    25 runs

Benchmark 2: bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit
  Time (mean ± σ):      3.308 s ±  0.185 s    [User: 2.505 s, System: 0.364 s]
  Range (min … max):    3.007 s …  3.593 s    25 runs

Summary
  bin/godot.macos.editor.arm64 --path /Users/lukas/dev/godot/empty-game --editor --quit ran
    1.01 ± 0.09 times faster than bin/godot.macos.editor.arm64.exact --path /Users/lukas/dev/godot/empty-game --editor --quit
```

I also benchmarked the test suite from #105928.
I find that functions are generally faster for small arrays, but can be slower for medium size arrays.
`reserve -> push_back` is always considerably faster, which is good since it's the best option for easy, safe optimization.

```
resize-ptrw: 4
1424ms
resize-write: 4
1450ms
insert back: 4
3284ms
push_back: 4
3046ms
reserve push_back: 4
1525ms
insert front: 4
3ms
remove_at back: 4
1580ms
remove_at front: 4
1ms
resize-ptrw: 32
247ms
resize-write: 32
393ms
insert back: 32
2058ms
push_back: 32
1680ms
reserve push_back: 32
549ms
insert front: 32
2ms
remove_at back: 32
1700ms
remove_at front: 32
2ms
resize-ptrw: 512
27ms
resize-write: 512
164ms
insert back: 512
1125ms
push_back: 512
732ms
reserve push_back: 512
424ms
insert front: 512
8ms
remove_at back: 512
993ms
remove_at front: 512
9ms
resize-ptrw: 1024
22ms
resize-write: 1024
154ms
insert back: 1024
963ms
push_back: 1024
594ms
reserve push_back: 1024
415ms
insert front: 1024
15ms
remove_at back: 1024
904ms
remove_at front: 1024
16ms
resize-ptrw: 20000
31ms
resize-write: 20000
158ms
insert back: 20000
799ms
push_back: 20000
444ms
reserve push_back: 20000
420ms
insert front: 20000
251ms
remove_at back: 20000
843ms
remove_at front: 20000
252ms
resize-ptrw: 200000
130ms
resize-write: 200000
252ms
insert back: 200000
869ms
push_back: 200000
507ms
reserve push_back: 200000
489ms
insert front: 200000
3092ms
remove_at back: 200000
825ms
remove_at front: 200000
3066ms
```