### PR TITLE
Fix NaN saturation when converting white to OKHSV 

### DIFF
--- a/thirdparty/misc/ok_color.h
+++ b/thirdparty/misc/ok_color.h
@@ -644,6 +644,13 @@ static HSV srgb_to_okhsv(RGB rgb)
 		});
 
 	float C = sqrtf(lab.a * lab.a + lab.b * lab.b);
+	
+	// Special case for pure white and black (C == 0)
+	if (C < 1e-8f)
+	{
+		return { 0.f, 0.f, lab.L };  // Hue = 0, Saturation = 0, Value = Luminance
+	}
+	
 	float a_ = lab.a / C;
 	float b_ = lab.b / C;
 


### PR DESCRIPTION
fixes #106006. converting white (rgb 1,1,1) to okhsv was returning nan for saturation due to a divide-by-zero when chroma is zero. this happens because lab.a and lab.b are both zero for white, so chroma is zero, and the code tries to normalize it anyway.

this adds a check for near-zero chroma (less than 1e-8) and returns sensible default values instead. hue is set to 0 (arbitrary), saturation to 0, and value is based on luminance from the lab color.

this avoids floating point exceptions and gives stable output for grayscale colors. fix is minimal and isolated.