### PR TITLE
Fix Omnilight3D Cube shadow mode crash with multiple lights

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -2603,6 +2603,26 @@ int LightStorage::get_directional_light_shadow_size(RID p_light_instance) {
 
 LightStorage::ShadowCubemap *LightStorage::_get_shadow_cubemap(int p_size) {
 	if (!shadow_cubemaps.has(p_size)) {
+		// First check if we've already got too many shadow cubemaps allocated
+		// This helps prevent crashes with multiple Omnilight3D lights with cube shadows
+		if (shadow_cubemaps.size() >= MAX_CUBE_SHADOWS) {
+			// Return the existing shadow cubemap with closest matching size
+			int closest_size = 0;
+			int closest_diff = INT_MAX;
+
+			for (const KeyValue<int, ShadowCubemap> &E : shadow_cubemaps) {
+				int diff = ABS(E.key - p_size);
+				if (diff < closest_diff) {
+					closest_diff = diff;
+					closest_size = E.key;
+				}
+			}
+
+			if (closest_size > 0) {
+				return &shadow_cubemaps[closest_size];
+			}
+		}
+
 		ShadowCubemap sc;
 		{
 			RD::TextureFormat tf;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -55,6 +55,9 @@ public:
 		SHADOW_INVALID = 0xFFFFFFFF
 	};
 
+	// Maximum number of shadow cubemaps we'll allocate to prevent VRAM exhaustion
+	static const int MAX_CUBE_SHADOWS = 16;
+
 private:
 	static LightStorage *singleton;
 	uint32_t max_cluster_elements = 512;


### PR DESCRIPTION
fixes #106023. using multiple omnilight3d lights with cube shadow mode was causing crashes due to vram exhaustion. the engine kept allocating new shadow cubemaps without any limit.

this adds a max_cube_shadows limit (set to 16) and updates _get_shadow_cubemap() to reuse existing cubemaps once the limit is hit. it also uses a size-matching strategy to pick the closest available cubemap to maintain visual quality.

this avoids crashes while still providing decent shadows. the change is minimal and keeps existing scenes working.