### PR TITLE
Fix TileSet Editor harmless error when switching resources in inspector

### DIFF
--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -48,6 +48,11 @@
 TileSetEditor *TileSetEditor::singleton = nullptr;
 
 void TileSetEditor::_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
+	// Skip processing if data is invalid (prevents spurious error messages)
+	if (p_data.get_type() == Variant::NIL || !p_data.is_dictionary()) {
+		return;
+	}
+	
 	ERR_FAIL_COND(tile_set.is_null());
 
 	if (!_can_drop_data_fw(p_point, p_data, p_from)) {


### PR DESCRIPTION
fixes #106017. switching between resources in the inspector that have a tileset property causes a harmless error to appear: "condition 'tile_set.is_null()' is true". this happens because the drag-and-drop system wrongly triggers _drop_data_fw() with invalid data during the switch.

this pr adds validation inside _drop_data_fw() to check the drag data before doing anything, which prevents the error while keeping all functionality intact. error is gone, everything still works as expected.