### PR TITLE
Fix Set focus on right control on user action "show in file system"

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -710,7 +710,7 @@ void FileSystemDock::_set_current_path_line_edit_text(const String &p_path) {
 	}
 }
 
-void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_favorites) {
+void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_favorites, bool p_grab_focus) {
 	String target_path = p_path;
 	bool is_directory = false;
 
@@ -763,9 +763,15 @@ void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_fa
 			}
 			item = item->get_next();
 		}
+		if (p_grab_focus) {
+			tree->grab_focus();
+		}
 	} else {
 		(*directory_ptr)->select(0);
 		_update_file_list(false);
+		if (p_grab_focus) {
+			files->grab_focus();
+		}
 	}
 	tree->ensure_cursor_is_visible();
 }
@@ -802,10 +808,10 @@ bool FileSystemDock::_update_filtered_items(TreeItem *p_tree_item) {
 
 void FileSystemDock::navigate_to_path(const String &p_path) {
 	file_list_search_box->clear();
-	_navigate_to_path(p_path);
-
-	// Ensure that the FileSystem dock is visible.
+	// Try to set the FileSystem dock visible.
 	EditorDockManager::get_singleton()->focus_dock(this);
+	_navigate_to_path(p_path, false, is_visible_in_tree());
+
 	import_dock_needs_update = true;
 	_update_import_dock();
 }

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -249,7 +249,7 @@ private:
 	Ref<Texture2D> _get_tree_item_icon(bool p_is_valid, const String &p_file_type, const String &p_icon_path);
 	void _create_tree(TreeItem *p_parent, EditorFileSystemDirectory *p_dir, Vector<String> &uncollapsed_paths, bool p_select_in_favorites, bool p_unfold_path = false);
 	void _update_tree(const Vector<String> &p_uncollapsed_paths = Vector<String>(), bool p_uncollapse_root = false, bool p_scroll_to_selected = true);
-	void _navigate_to_path(const String &p_path, bool p_select_in_favorites = false);
+	void _navigate_to_path(const String &p_path, bool p_select_in_favorites = false, bool p_grab_focus = false);
 	bool _update_filtered_items(TreeItem *p_tree_item = nullptr);
 
 	void _file_list_gui_input(Ref<InputEvent> p_event);


### PR DESCRIPTION
## Problem

Previously, when using the "Show in File System" action (e.g., from the 3D viewport), the target file would be selected in the File System dock, but keyboard focus remained on the dock's header instead of moving to the file list/tree.

This forced an extra manual step: after triggering the action via shortcut, users had to click the file again before they could use shortcuts like "Open in external program" or "Open in terminal".

## Solution

This PR ensures that focus automatically moves to the File System dock's content area (tree/list view) when "Show in File System" is triggered.

But it does this only when calling the `navigate_to_path` method. When calling the internal `_navigate_to_path` method, the behavior remains the same.

## Result

Now, the workflow is seamless:

- Select a resource (e.g., in the 3D viewport).
- Press "Show in File System" shortcut (focus moves to the file list).
- Immediately use "Open in external program" shortcut or other actions without extra clicks.

![image](https://github.com/user-attachments/assets/215f81b2-cdfa-4414-87b2-7843d7e1c486)
