### PR TITLE
Fix Windows `OS.get_unique_id()` null termination issue

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2437,7 +2437,9 @@ String OS_Windows::get_user_data_dir(const String &p_user_dir) const {
 String OS_Windows::get_unique_id() const {
 	HW_PROFILE_INFOA HwProfInfo;
 	ERR_FAIL_COND_V(!GetCurrentHwProfileA(&HwProfInfo), "");
-	return String::ascii(Span((HwProfInfo.szHwProfileGuid), HW_PROFILE_GUIDLEN));
+
+	// Note: Windows API returns a GUID with null termination.
+	return String::ascii(Span<char>(HwProfInfo.szHwProfileGuid, strnlen(HwProfInfo.szHwProfileGuid, HW_PROFILE_GUIDLEN)));
 }
 
 bool OS_Windows::_check_internal_feature_support(const String &p_feature) {


### PR DESCRIPTION
Fixes: #106012 

It appears the function return from the windows API included a null termination? 
I've commented this specific segment of code with a safety to handle this. 
There was quite a bit of changes between 4.4 and 4.5-Dev around print() and print_rich() that created some difficulty in hunting the exact cause of the editor output hang while the console exe continued to function

This fix addresses the length, output and concat, issues. 

Before:
![image](https://github.com/user-attachments/assets/c87e9a6c-cb14-49a4-bc07-5ebb50b3636e)


After:
![image](https://github.com/user-attachments/assets/2a22eb82-c94f-4239-928f-0fc80a2814c9)
