### PR TITLE
DDS: Load BGRA4 textures directly as RGBA4

### DIFF
--- a/modules/dds/dds_enums.h
+++ b/modules/dds/dds_enums.h
@@ -196,7 +196,7 @@ static const DDSFormatInfo dds_format_info[DDS_MAX] = {
 	{ "B2GR3A8", false, 1, 2, Image::FORMAT_RGBA8 },
 	{ "BGR10A2", false, 1, 4, Image::FORMAT_RGBA8 },
 	{ "RGB10A2", false, 1, 4, Image::FORMAT_RGBA8 },
-	{ "BGRA4", false, 1, 2, Image::FORMAT_RGBA8 },
+	{ "BGRA4", false, 1, 2, Image::FORMAT_RGBA4444 },
 	{ "GRAYSCALE", false, 1, 1, Image::FORMAT_L8 },
 	{ "GRAYSCALE_ALPHA", false, 1, 2, Image::FORMAT_LA8 },
 	{ "GRAYSCALE_ALPHA_4", false, 1, 1, Image::FORMAT_LA8 },

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -177,7 +177,6 @@ static Ref<Image> _dds_load_layer(Ref<FileAccess> p_file, DDSFormat p_dds_format
 				break;
 
 			case DDS_BGR5A1:
-			case DDS_BGRA4:
 			case DDS_B2GR3A8:
 			case DDS_LUMINANCE_ALPHA_4:
 				size = size * 2;
@@ -235,22 +234,13 @@ static Ref<Image> _dds_load_layer(Ref<FileAccess> p_file, DDSFormat p_dds_format
 
 			} break;
 			case DDS_BGRA4: {
-				// To RGBA8.
-				int colcount = size / 4;
+				// To RGBA4.
+				for (uint32_t i = 0; i < size; i += 2) {
+					uint8_t ar = wb[i + 0];
+					uint8_t gb = wb[i + 1];
 
-				for (int i = colcount - 1; i >= 0; i--) {
-					int src_ofs = i * 2;
-					int dst_ofs = i * 4;
-
-					uint8_t b = wb[src_ofs] & 0x0F;
-					uint8_t g = wb[src_ofs] & 0xF0;
-					uint8_t r = wb[src_ofs + 1] & 0x0F;
-					uint8_t a = wb[src_ofs + 1] & 0xF0;
-
-					wb[dst_ofs] = (r << 4) | r;
-					wb[dst_ofs + 1] = g | (g >> 4);
-					wb[dst_ofs + 2] = (b << 4) | b;
-					wb[dst_ofs + 3] = a | (a >> 4);
+					wb[i + 0] = ((ar & 0x0F) << 4) | ((gb & 0xF0) >> 4);
+					wb[i + 1] = ((ar & 0xF0) >> 4) | ((gb & 0x0F) << 4);
 				}
 
 			} break;


### PR DESCRIPTION
Changes the code for loading RGBA4 images to avoid expanding to RGBA8. This saves memory and makes loading slightly faster.

Doing the same for RGB565 would require #103635

Test images: [dds.zip](https://github.com/user-attachments/files/20023519/dds.zip)
