### PR TITLE
Add `@themed` annotation

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -140,6 +140,26 @@ protected:
 	}
 
 public:
+	struct ThemedPropertyInfo {
+		/*
+			NOTE: This is just a mirror of Theme::DataType
+		*/
+		enum DataType {
+			DATA_TYPE_COLOR,
+			DATA_TYPE_CONSTANT,
+			DATA_TYPE_FONT,
+			DATA_TYPE_FONT_SIZE,
+			DATA_TYPE_ICON,
+			DATA_TYPE_STYLEBOX,
+			DATA_TYPE_MAX
+		};
+
+		StringName property_name = StringName();
+		DataType theme_item_type = DATA_TYPE_MAX;
+		StringName theme_item_name = StringName();
+		StringName theme_type = StringName();
+	};
+
 	virtual void reload_from_file() override;
 
 	virtual bool can_instantiate() const = 0;
@@ -168,6 +188,8 @@ public:
 	// TODO: In the next compat breakage rename to `*_script_*` to disambiguate from `Object::has_method()`.
 	virtual bool has_method(const StringName &p_method) const = 0;
 	virtual bool has_static_method(const StringName &p_method) const { return false; }
+	virtual bool has_themed_property(const StringName &p_property) const { return false; }
+	virtual ThemedPropertyInfo get_themed_property(const StringName &p_method) const { return ThemedPropertyInfo(); }
 
 	virtual int get_script_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const;
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -616,6 +616,9 @@
 		<member name="debug/gdscript/warnings/static_called_on_instance" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when calling a static method from an instance of a class instead of from the class directly.
 		</member>
+		<member name="debug/gdscript/warnings/themed_assignment" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when assigning to a [code]@themed[/code] property outside of its setter.
+		</member>
 		<member name="debug/gdscript/warnings/unassigned_variable" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when using a variable that wasn't previously assigned.
 		</member>

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -773,6 +773,123 @@
 				[b]Warning:[/b] Currently, due to a bug, scripts are never freed, even if [annotation @static_unload] annotation is used.
 			</description>
 		</annotation>
+		<annotation name="@themed" qualifiers="vararg">
+			<return type="void" />
+			<param index="0" name="theme_item" type="String" default="&quot;&quot;" />
+			<param index="1" name="theme_type" type="String" default="&quot;&quot;" />
+			<description>
+				Mark the following property as a themed property, binding it to a theme item name. By default, the same name as the property is used, but a specific theme item and theme type names can be provided.
+				After a property is bound to a theme item, the engine will update its value with the result of the appropriate [code]get_theme_*(theme_item, theme_type)[/code] call whenever a theme change notification occurs.
+				The bound theme item will be available for overriding through code or within the editor.
+
+				[annotation @themed] infers the type of theme item to bind to. The property must thus be explicitly typed as one of [int], [float], [bool], [Color], [Font], [Texture2D] or [StyleBox].
+				Numerical types ([int], [float], [bool]) are bound to theme constants.
+				[Font], [Texture2D] and [StyleBox] are bound to theme fonts, icons, and styleboxes.
+				[annotation @themed] doesn't bind to font sizes. If you need to bind to a font size, use [annotation @themed_font_size] instead.
+				[b]Note:[/b] Themed properties are only supported on globally registered scripts using the [code]class_name[/code] keyword and extending [Control] or [Window].
+				[b]Warning:[/b] Since themed properties have their values automatically updated by the engine, it's best to avoid writing to them outside of their setter, as any assigned value will be lost when the next update takes place.
+				[codeblock]
+				extends Control
+				class_name MainMenu
+
+				# Theme item name and property name match
+				@themed var line_thickness: int
+				@themed var foreground_color: Color
+				@themed var main_font: Font
+				@themed var button_icon: Texture2D
+				@themed var dark_background: StyleBox
+
+				# Property name is different from the item name
+				@themed("separation_horizontal") var hsep: int
+				@themed("accent") var item_name_color: Color
+				@themed("creepy_font") var game_over_font: Font
+				@themed("accept_2x") var accept_icon: Texture2D
+				@themed("panel_secondary") var tooltip_box: StyleBox
+
+				# The theme item is fetched in a specific theme type
+				@themed("healthbar_color", "healthbar") var healthbar_color: Color
+				@themed("default_size", "defaults") var default_size: int
+				[/codeblock]
+			</description>
+		</annotation>
+		<annotation name="@themed_color" qualifiers="vararg">
+			<return type="void" />
+			<param index="0" name="theme_item" type="String" default="&quot;&quot;" />
+			<param index="1" name="theme_type" type="String" default="&quot;&quot;" />
+			<description>
+				Mark the following property as bound to a theme color name.
+				See [annotation @themed] for more information.
+				[codeblock]
+				@themed_color var foreground_color
+				@themed_color("background_color") var bg_color
+				[/codeblock]
+			</description>
+		</annotation>
+		<annotation name="@themed_constant" qualifiers="vararg">
+			<return type="void" />
+			<param index="0" name="theme_item" type="String" default="&quot;&quot;" />
+			<param index="1" name="theme_type" type="String" default="&quot;&quot;" />
+			<description>
+				Mark the following property as bound to a theme constant name.
+				See [annotation @themed] for more information.
+				[codeblock]
+				@themed_constant var vertical_separation
+				@themed_constant("horizontal_separation") var hsep
+				[/codeblock]
+			</description>
+		</annotation>
+		<annotation name="@themed_font" qualifiers="vararg">
+			<return type="void" />
+			<param index="0" name="theme_item" type="String" default="&quot;&quot;" />
+			<param index="1" name="theme_type" type="String" default="&quot;&quot;" />
+			<description>
+				Mark the following property as bound to a theme font name.
+				See [annotation @themed] for more information.
+				[codeblock]
+				@themed_font var main_font
+				@themed_font("secondary_font") var alt_font
+				[/codeblock]
+			</description>
+		</annotation>
+		<annotation name="@themed_font_size" qualifiers="vararg">
+			<return type="void" />
+			<param index="0" name="theme_item" type="String" default="&quot;&quot;" />
+			<param index="1" name="theme_type" type="String" default="&quot;&quot;" />
+			<description>
+				Mark the following property as bound to a theme font size name.
+				See [annotation @themed] for more information.
+				[codeblock]
+				@themed_font_size var small_text_size
+				@themed_font_size("large_text_size") var header_size
+				[/codeblock]
+			</description>
+		</annotation>
+		<annotation name="@themed_icon" qualifiers="vararg">
+			<return type="void" />
+			<param index="0" name="theme_item" type="String" default="&quot;&quot;" />
+			<param index="1" name="theme_type" type="String" default="&quot;&quot;" />
+			<description>
+				Mark the following property as bound to a theme icon name.
+				See [annotation @themed] for more information.
+				[codeblock]
+				@themed_icon var accept_icon
+				@themed_icon("delete") var delete_icon
+				[/codeblock]
+			</description>
+		</annotation>
+		<annotation name="@themed_stylebox" qualifiers="vararg">
+			<return type="void" />
+			<param index="0" name="theme_item" type="String" default="&quot;&quot;" />
+			<param index="1" name="theme_type" type="String" default="&quot;&quot;" />
+			<description>
+				Mark the following property as bound to a theme stylebox name.
+				See [annotation @themed] for more information.
+				[codeblock]
+				@themed_stylebox var highlighted
+				@themed_stylebox("primary") var primary_background
+				[/codeblock]
+			</description>
+		</annotation>
 		<annotation name="@tool">
 			<return type="void" />
 			<description>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -51,8 +51,11 @@
 #include "core/core_constants.h"
 #include "core/io/file_access.h"
 
+#include "scene/gui/control.h"
+#include "scene/main/window.h"
 #include "scene/resources/packed_scene.h"
 #include "scene/scene_string_names.h"
+#include "scene/theme/theme_db.h"
 
 #ifdef TOOLS_ENABLED
 #include "core/extension/gdextension_manager.h"
@@ -362,6 +365,18 @@ bool GDScript::has_method(const StringName &p_method) const {
 
 bool GDScript::has_static_method(const StringName &p_method) const {
 	return member_functions.has(p_method) && member_functions[p_method]->is_static();
+}
+
+bool GDScript::has_themed_property(const StringName &p_property) const {
+	return themed_property_indices.has(p_property);
+}
+
+Script::ThemedPropertyInfo GDScript::get_themed_property(const StringName &p_property) const {
+	if (themed_property_indices.has(p_property)) {
+		return themed_property_indices[p_property];
+	}
+
+	return Script::ThemedPropertyInfo();
 }
 
 int GDScript::get_script_method_argument_count(const StringName &p_method, bool *r_is_valid) const {
@@ -717,6 +732,44 @@ void GDScript::_static_default_init() {
 	}
 }
 
+void GDScript::_bind_themed_properties() {
+	if (get_global_name().is_empty()) {
+		return;
+	}
+
+	for (const StringName &prop_name : themed_properties) {
+		StringName prop_item = themed_property_indices[prop_name].theme_item_name;
+		StringName theme_type = themed_property_indices[prop_name].theme_type;
+		Theme::DataType prop_type = static_cast<Theme::DataType>(themed_property_indices[prop_name].theme_item_type);
+		ThemeDB::ThemeItemSetter setter = [prop_type, prop_name](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) {
+			Control *c_cast = Object::cast_to<Control>(p_instance);
+			Window *w_cast = Object::cast_to<Window>(p_instance);
+			Variant value = Variant();
+			if (c_cast) {
+				value = c_cast->get_theme_item(prop_type, p_item_name, p_type_name);
+			} else {
+				value = w_cast->get_theme_item(prop_type, p_item_name, p_type_name);
+			}
+
+			p_instance->get_script_instance()->set(prop_name, value);
+		};
+
+		if (theme_type.is_empty()) {
+			ThemeDB::get_singleton()->bind_class_item(prop_type, get_global_name(), prop_name, prop_item, setter);
+		} else {
+			ThemeDB::get_singleton()->bind_class_external_item(prop_type, get_global_name(), prop_name, prop_item, theme_type, setter);
+		}
+	}
+}
+
+void GDScript::_unbind_themed_properties() {
+	if (get_global_name().is_empty()) {
+		return;
+	}
+
+	ThemeDB::get_singleton()->unbind_class_items(get_global_name());
+}
+
 #ifdef TOOLS_ENABLED
 
 void GDScript::_save_old_static_data() {
@@ -811,6 +864,10 @@ Error GDScript::reload(bool p_keep_state) {
 	}
 #endif
 
+	if (is_valid()) {
+		_unbind_themed_properties();
+	}
+
 	valid = false;
 	GDScriptParser parser;
 	Error err;
@@ -885,6 +942,10 @@ Error GDScript::reload(bool p_keep_state) {
 		if (err) {
 			return err;
 		}
+	}
+
+	if (is_valid()) {
+		_bind_themed_properties();
 	}
 
 #ifdef TOOLS_ENABLED
@@ -1597,6 +1658,8 @@ void GDScript::clear(ClearData *p_clear_data) {
 		clear_data->functions.insert(static_initializer);
 		static_initializer = nullptr;
 	}
+
+	_unbind_themed_properties();
 
 	_save_orphaned_subclasses(clear_data);
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -175,6 +175,12 @@ private:
 	Error _static_init();
 	void _static_default_init(); // Initialize static variables with default values based on their types.
 
+	// Theme features
+	HashMap<StringName, ThemedPropertyInfo> themed_property_indices; //@themed properties, including those in all base GDScript classes.
+	HashSet<StringName> themed_properties; //@themed properties declared in this class specifically.
+	void _bind_themed_properties(); // Register `@themed` variables with ThemeDB.
+	void _unbind_themed_properties(); // Clear `@themed` variables (e.g. when reloading the script)
+
 	int subclass_count = 0;
 	RBSet<Object *> instances;
 	bool destructing = false;
@@ -325,6 +331,9 @@ public:
 	virtual void get_script_method_list(List<MethodInfo> *p_list) const override;
 	virtual bool has_method(const StringName &p_method) const override;
 	virtual bool has_static_method(const StringName &p_method) const override;
+
+	bool has_themed_property(const StringName &p_method) const override;
+	ThemedPropertyInfo get_themed_property(const StringName &p_method) const override;
 
 	virtual int get_script_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override;
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1065,6 +1065,19 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 				if (member.variable->exported && member.variable->onready) {
 					parser->push_warning(member.variable, GDScriptWarning::ONREADY_WITH_EXPORT);
 				}
+
+				if (member.variable->themed) {
+					if (member.variable->exported) {
+						parser->push_error("@themed variable may not be used together with @export.", p_source);
+						return;
+					}
+
+					if (member.variable->onready) {
+						parser->push_error("@themed may not be used together with @onready.", p_source);
+						return;
+					}
+				}
+
 				if (member.variable->initializer) {
 					// Check if it is call to get_node() on self (using shorthand $ or not), so we can check if @onready is needed.
 					// This could be improved by traversing the expression fully and checking the presence of get_node at any level.
@@ -2828,6 +2841,30 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 #endif // DEBUG_ENABLED
 
 	reduce_expression(p_assignment->assignee);
+
+#ifdef DEBUG_ENABLED
+	if (p_assignment->assignee->type == GDScriptParser::Node::IDENTIFIER) {
+		GDScriptParser::IdentifierNode *id = static_cast<GDScriptParser::IdentifierNode *>(p_assignment->assignee);
+		if (id->source == GDScriptParser::IdentifierNode::MEMBER_VARIABLE && id->variable_source && id->variable_source->themed) {
+			GDScriptParser::VariableNode *v_source = id->variable_source;
+			bool warn = true;
+
+			if (v_source->property == GDScriptParser::VariableNode::PROP_INLINE) {
+				if (v_source->setter && v_source->setter == id->suite->parent_function) {
+					warn = false;
+				}
+			} else if (v_source->property == GDScriptParser::VariableNode::PROP_SETGET) {
+				if (v_source->setter_pointer && v_source->setter_pointer->name == id->suite->parent_function->identifier->name) {
+					warn = false;
+				}
+			}
+
+			if (warn) {
+				parser->push_warning(p_assignment, GDScriptWarning::THEMED_ASSIGNMENT, id->name);
+			}
+		}
+	}
+#endif
 
 #ifdef DEBUG_ENABLED
 	{

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2692,6 +2692,8 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 	p_script->member_indices.clear();
 	p_script->static_variables_indices.clear();
 	p_script->static_variables.clear();
+	p_script->themed_property_indices.clear();
+	p_script->themed_properties.clear();
 	p_script->_signals.clear();
 	p_script->initializer = nullptr;
 	p_script->implicit_initializer = nullptr;
@@ -2769,6 +2771,7 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 			p_script->base = base;
 			p_script->_base = base.ptr();
 			p_script->member_indices = base->member_indices;
+			p_script->themed_property_indices = base->themed_property_indices;
 		} break;
 		default: {
 			_set_error("Parser bug (please report): invalid inheritance.", nullptr);
@@ -2834,6 +2837,16 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 					minfo.index = p_script->member_indices.size();
 					p_script->member_indices[name] = minfo;
 					p_script->members.insert(name);
+
+					if (variable->themed) {
+						Script::ThemedPropertyInfo t_info;
+						t_info.property_name = name;
+						t_info.theme_item_name = variable->themed_item_name;
+						t_info.theme_item_type = variable->themed_data_type;
+						t_info.theme_type = variable->themed_theme_type;
+						p_script->themed_properties.insert(name);
+						p_script->themed_property_indices.insert(name, t_info);
+					}
 				}
 
 #ifdef TOOLS_ENABLED

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1254,6 +1254,10 @@ public:
 
 		bool exported = false;
 		bool onready = false;
+		bool themed = false;
+		Script::ThemedPropertyInfo::DataType themed_data_type = Script::ThemedPropertyInfo::DATA_TYPE_MAX;
+		StringName themed_item_name = StringName();
+		StringName themed_theme_type = StringName();
 		PropertyInfo export_info;
 		int assignments = 0;
 		bool is_static = false;
@@ -1519,6 +1523,8 @@ private:
 	bool icon_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	template <Script::ThemedPropertyInfo::DataType t_type>
+	bool themed_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_storage_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -169,6 +169,8 @@ String GDScriptWarning::get_message() const {
 		case FUNCTION_USED_AS_PROPERTY: // This is valid, returns `Callable`.
 			break;
 #endif
+		case THEMED_ASSIGNMENT:
+			return vformat(R"*("%s" is a themed property. Values assigned to it outside of its setter are likely to be overwritten unexpectedly.)*", symbols[0]);
 		case WARNING_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -243,6 +245,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"CONSTANT_USED_AS_FUNCTION",
 		"FUNCTION_USED_AS_PROPERTY",
 #endif
+		"THEMED_ASSIGNMENT",
 	};
 
 	static_assert(std::size(names) == WARNING_MAX, "Amount of warning types don't match the amount of warning names.");

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -94,6 +94,7 @@ public:
 		CONSTANT_USED_AS_FUNCTION, // Function not found, but there's a constant with the same name.
 		FUNCTION_USED_AS_PROPERTY, // Property not found, but there's a function with the same name.
 #endif
+		THEMED_ASSIGNMENT, // A `@themed` property is being assigned to outside of its setter.
 		WARNING_MAX,
 	};
 
@@ -151,6 +152,7 @@ public:
 		WARN, // CONSTANT_USED_AS_FUNCTION
 		WARN, // FUNCTION_USED_AS_PROPERTY
 #endif
+		WARN, // THEMED_ASSIGNMENT
 	};
 
 	static_assert(std::size(default_warning_levels) == WARNING_MAX, "Amount of default levels does not match the amount of warnings.");

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -33,6 +33,7 @@
 #include "container.h"
 #include "core/config/project_settings.h"
 #include "core/input/input_map.h"
+#include "core/object/script_language.h"
 #include "core/os/os.h"
 #include "core/string/string_builder.h"
 #include "core/string/translation_server.h"
@@ -399,7 +400,13 @@ bool Control::_get(const StringName &p_name, Variant &r_ret) const {
 void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 	ERR_MAIN_THREAD_GUARD;
 	List<ThemeDB::ThemeItemBind> theme_items;
-	ThemeDB::get_singleton()->get_class_items(get_class_name(), &theme_items, true);
+
+	Ref<Script> scr = get_script();
+	if (scr.is_valid() && scr->is_valid()) {
+		ThemeDB::get_singleton()->get_script_items(scr, &theme_items, true);
+	} else {
+		ThemeDB::get_singleton()->get_class_items(get_class_name(), &theme_items, true);
+	}
 
 	p_list->push_back(PropertyInfo(Variant::NIL, GNAME("Theme Overrides", "theme_override_"), PROPERTY_HINT_NONE, "theme_override_", PROPERTY_USAGE_GROUP));
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/input/shortcut.h"
+#include "core/object/script_language.h"
 #include "core/string/translation_server.h"
 #include "scene/gui/control.h"
 #include "scene/theme/theme_db.h"
@@ -157,80 +158,65 @@ bool Window::_get(const StringName &p_name, Variant &r_ret) const {
 void Window::_get_property_list(List<PropertyInfo> *p_list) const {
 	ERR_READ_THREAD_GUARD;
 
-	Ref<Theme> default_theme = ThemeDB::get_singleton()->get_default_theme();
+	List<ThemeDB::ThemeItemBind> theme_items;
+
+	Ref<Script> scr = get_script();
+	if (scr.is_valid() && scr->is_valid()) {
+		ThemeDB::get_singleton()->get_script_items(scr, &theme_items, true);
+	} else {
+		ThemeDB::get_singleton()->get_class_items(get_class_name(), &theme_items, true);
+	}
 
 	p_list->push_back(PropertyInfo(Variant::NIL, GNAME("Theme Overrides", "theme_override_"), PROPERTY_HINT_NONE, "theme_override_", PROPERTY_USAGE_GROUP));
+	for (const ThemeDB::ThemeItemBind &E : theme_items) {
+		uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 
-	{
-		List<StringName> names;
-		default_theme->get_color_list(get_class_name(), &names);
-		for (const StringName &E : names) {
-			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
-			if (theme_color_override.has(E)) {
-				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
-			}
+		switch (E.data_type) {
+			case Theme::DATA_TYPE_COLOR: {
+				if (theme_color_override.has(E.item_name)) {
+					usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
+				}
+				p_list->push_back(PropertyInfo(Variant::COLOR, PNAME("theme_override_colors") + String("/") + E.item_name, PROPERTY_HINT_NONE, "", usage));
+			} break;
 
-			p_list->push_back(PropertyInfo(Variant::COLOR, PNAME("theme_override_colors") + String("/") + E, PROPERTY_HINT_NONE, "", usage));
-		}
-	}
-	{
-		List<StringName> names;
-		default_theme->get_constant_list(get_class_name(), &names);
-		for (const StringName &E : names) {
-			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
-			if (theme_constant_override.has(E)) {
-				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
-			}
+			case Theme::DATA_TYPE_CONSTANT: {
+				if (theme_constant_override.has(E.item_name)) {
+					usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
+				}
+				p_list->push_back(PropertyInfo(Variant::INT, PNAME("theme_override_constants") + String("/") + E.item_name, PROPERTY_HINT_RANGE, "-16384,16384", usage));
+			} break;
 
-			p_list->push_back(PropertyInfo(Variant::INT, PNAME("theme_override_constants") + String("/") + E, PROPERTY_HINT_RANGE, "-16384,16384", usage));
-		}
-	}
-	{
-		List<StringName> names;
-		default_theme->get_font_list(get_class_name(), &names);
-		for (const StringName &E : names) {
-			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
-			if (theme_font_override.has(E)) {
-				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
-			}
+			case Theme::DATA_TYPE_FONT: {
+				if (theme_font_override.has(E.item_name)) {
+					usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
+				}
+				p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_fonts") + String("/") + E.item_name, PROPERTY_HINT_RESOURCE_TYPE, "Font", usage));
+			} break;
 
-			p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_fonts") + String("/") + E, PROPERTY_HINT_RESOURCE_TYPE, "Font", usage));
-		}
-	}
-	{
-		List<StringName> names;
-		default_theme->get_font_size_list(get_class_name(), &names);
-		for (const StringName &E : names) {
-			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
-			if (theme_font_size_override.has(E)) {
-				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
-			}
+			case Theme::DATA_TYPE_FONT_SIZE: {
+				if (theme_font_size_override.has(E.item_name)) {
+					usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
+				}
+				p_list->push_back(PropertyInfo(Variant::INT, PNAME("theme_override_font_sizes") + String("/") + E.item_name, PROPERTY_HINT_RANGE, "1,256,1,or_greater,suffix:px", usage));
+			} break;
 
-			p_list->push_back(PropertyInfo(Variant::INT, PNAME("theme_override_font_sizes") + String("/") + E, PROPERTY_HINT_RANGE, "1,256,1,or_greater,suffix:px", usage));
-		}
-	}
-	{
-		List<StringName> names;
-		default_theme->get_icon_list(get_class_name(), &names);
-		for (const StringName &E : names) {
-			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
-			if (theme_icon_override.has(E)) {
-				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
-			}
+			case Theme::DATA_TYPE_ICON: {
+				if (theme_icon_override.has(E.item_name)) {
+					usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
+				}
+				p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_icons") + String("/") + E.item_name, PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", usage));
+			} break;
 
-			p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_icons") + String("/") + E, PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", usage));
-		}
-	}
-	{
-		List<StringName> names;
-		default_theme->get_stylebox_list(get_class_name(), &names);
-		for (const StringName &E : names) {
-			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
-			if (theme_style_override.has(E)) {
-				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
-			}
+			case Theme::DATA_TYPE_STYLEBOX: {
+				if (theme_style_override.has(E.item_name)) {
+					usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
+				}
+				p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_styles") + String("/") + E.item_name, PROPERTY_HINT_RESOURCE_TYPE, "StyleBox", usage));
+			} break;
 
-			p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_styles") + String("/") + E, PROPERTY_HINT_RESOURCE_TYPE, "StyleBox", usage));
+			default: {
+				// Silences warning.
+			} break;
 		}
 	}
 }

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
+#include "core/object/script_language.h"
 #include "scene/gui/control.h"
 #include "scene/main/node.h"
 #include "scene/main/window.h"
@@ -355,6 +356,13 @@ void ThemeDB::bind_class_external_item(Theme::DataType p_data_type, const String
 	theme_item_binds_list[p_class_name].push_back(bind);
 }
 
+void ThemeDB::unbind_class_items(const StringName &p_class_name) {
+	if (theme_item_binds.has(p_class_name)) {
+		theme_item_binds[p_class_name].clear();
+		theme_item_binds_list[p_class_name].clear();
+	}
+}
+
 void ThemeDB::update_class_instance_items(Node *p_instance) {
 	ERR_FAIL_NULL(p_instance);
 
@@ -371,10 +379,28 @@ void ThemeDB::update_class_instance_items(Node *p_instance) {
 
 		class_name = ClassDB::get_parent_class_nocheck(class_name);
 	}
+
+	// We also traverse the script class hierarchy (if present) to do the same with user-defined theme binds.
+	Ref<Script> current_script = p_instance->get_script();
+	while (current_script.is_valid() && current_script->is_valid() && p_instance->get_script_instance()) {
+		StringName script_class_name = current_script->get_global_name();
+
+		if (!script_class_name.is_empty()) {
+			HashMap<StringName, HashMap<StringName, ThemeItemBind>>::Iterator E = theme_item_binds.find(script_class_name);
+			if (E) {
+				for (const KeyValue<StringName, ThemeItemBind> &F : E->value) {
+					F.value.setter(p_instance, F.value.item_name, F.value.type_name);
+				}
+			}
+		}
+
+		current_script = current_script->get_base_script();
+	}
 }
 
 void ThemeDB::get_class_items(const StringName &p_class_name, List<ThemeItemBind> *r_list, bool p_include_inherited, Theme::DataType p_filter_type) {
 	List<StringName> class_hierarchy;
+
 	StringName class_name = p_class_name;
 	while (class_name != StringName()) {
 		class_hierarchy.push_front(class_name); // Put parent classes in front.
@@ -393,6 +419,49 @@ void ThemeDB::get_class_items(const StringName &p_class_name, List<ThemeItemBind
 					continue; // Skip inherited properties.
 				}
 				if (F.external || F.class_name != p_class_name) {
+					inherited_props.insert(F.item_name);
+
+					if (!p_include_inherited) {
+						continue; // Track properties defined in parent classes, and skip them.
+					}
+				}
+
+				r_list->push_back(F);
+			}
+		}
+	}
+}
+
+void ThemeDB::get_script_items(const Ref<Script> p_script, List<ThemeItemBind> *r_list, bool p_include_inherited, Theme::DataType p_filter_type) {
+	List<StringName> class_hierarchy;
+	StringName script_class = p_script->get_global_name();
+
+	Ref<Script> current_script = p_script;
+	while (current_script.is_valid() && current_script->is_valid()) {
+		if (!current_script->get_global_name().is_empty()) {
+			class_hierarchy.push_front(current_script->get_global_name());
+		}
+		current_script = current_script->get_base_script();
+	}
+
+	StringName class_name = p_script->get_instance_base_type();
+	while (class_name != StringName()) {
+		class_hierarchy.push_front(class_name);
+		class_name = ClassDB::get_parent_class_nocheck(class_name);
+	}
+
+	HashSet<StringName> inherited_props;
+	for (const StringName &theme_type : class_hierarchy) {
+		HashMap<StringName, List<ThemeItemBind>>::Iterator E = theme_item_binds_list.find(theme_type);
+		if (E) {
+			for (const ThemeItemBind &F : E->value) {
+				if (p_filter_type != Theme::DATA_TYPE_MAX && F.data_type != p_filter_type) {
+					continue;
+				}
+				if (inherited_props.has(F.item_name)) {
+					continue; // Skip inherited properties.
+				}
+				if (F.external || F.class_name != script_class) {
 					inherited_props.insert(F.item_name);
 
 					if (!p_include_inherited) {

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -170,9 +170,10 @@ public:
 
 	void bind_class_item(Theme::DataType p_data_type, const StringName &p_class_name, const StringName &p_prop_name, const StringName &p_item_name, ThemeItemSetter p_setter);
 	void bind_class_external_item(Theme::DataType p_data_type, const StringName &p_class_name, const StringName &p_prop_name, const StringName &p_item_name, const StringName &p_type_name, ThemeItemSetter p_setter);
+	void unbind_class_items(const StringName &p_class_name);
 	void update_class_instance_items(Node *p_instance);
-
 	void get_class_items(const StringName &p_class_name, List<ThemeItemBind> *r_list, bool p_include_inherited = false, Theme::DataType p_filter_type = Theme::DATA_TYPE_MAX);
+	void get_script_items(const Ref<Script> p_script, List<ThemeItemBind> *r_list, bool p_include_inherited = false, Theme::DataType p_filter_type = Theme::DATA_TYPE_MAX);
 
 	// Memory management, reference, and initialization.
 


### PR DESCRIPTION
### Description

This implements godotengine/godot-proposals#12250. A set of GDScript annotations is introduced, allowing properties on a script to be bound to a specific theme item name. `@themed` infers the theme typing from the property's annotated type, while the various `@themed_` annotations (i.e. `@themed_icon`) have their own type. A theme item name can be provided, but the script property's name is used by default. **The theme type to search the theme item in can also be provided.**

Once a property is marked as themed, the engine will update it automatically so that it holds the value of the equivalent `get_theme_*` call. Furthermore, theme overrides become available for usage in the editor, ~and writing to the property during execution turns into an override addition instead.~
### How it works

Functionality is split between Control/Windows and Scripts.

Scripts have the responsibility to keep track of their themed properties and provide information to Controls/Windows when requested. In the GDScript implementation, each GDScript registers its themed properties with ThemeDB on reload, in a process similar to the one used by Controls and Windows. The difference here is that the script provides a lambda setting the correct property on the script instance, instead of saving this value in a struct like native classes do. In order to obtain this, ThemeDB methods have been expanded to iterate over a node's script type hierarchy in addition to the native class hierarchy.

~Controls/Windows have the job of converting writes into overrides, and this effect is obtained simply by overriding `_set` (or rather, extending the already existing override of it) so that it checks if a property is a themed property or not.~

### How this doesn't work

I've been doing some testing of the functionality and it seems to work, although of course it will require more rigorous testing. Since I wrote this specifically to meet my own use case, I plan to continue development of my game by using this feature, so I am sure I will be finding bugs to fix.

The main way this doesn't work has nothing to do with the feature itself but rather with the way the theme system works. Currently, themed properties bind to the script's global class name. One might expect then that, if I have a script class `MyPanel` extending `Panel`, and I bind some properties in it, and create the corresponding `MyPanel` theme type, that the values will be correctly fetched from it.

This isn't the case, as the `MyPanel` theme type needs to be correctly designated as a type variation of `Panel` and said type variation must be correctly set on each `MyPanel` script. This is simply how `get_theme_*` (which themed properties are really only proxies for) works, it doesn't use the node's script hierarchy in any way. I was unsure if it was proper to change that behavior in this PR, because I originally meant for this feature to be completely additive. Making the `get_theme_*` methods be script aware would most certainly be a breaking change.
