### PR TITLE
C#: Generate string overload methods for StringName and NodePath to speed up and avoid GC

### DIFF
--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -842,7 +842,7 @@ class BindingsGenerator {
 	Error _generate_cs_type(const TypeInterface &itype, const String &p_output_file);
 
 	Error _generate_cs_property(const TypeInterface &p_itype, const PropertyInterface &p_iprop, StringBuilder &p_output);
-	Error _generate_cs_method(const TypeInterface &p_itype, const MethodInterface &p_imethod, int &p_method_bind_count, StringBuilder &p_output, bool p_use_span);
+	Error _generate_cs_method(const TypeInterface &p_itype, const MethodInterface &p_imethod, int &p_method_bind_count, StringBuilder &p_output, bool p_use_span, bool p_use_string);
 	Error _generate_cs_signal(const BindingsGenerator::TypeInterface &p_itype, const BindingsGenerator::SignalInterface &p_isignal, StringBuilder &p_output);
 
 	Error _generate_cs_native_calls(const InternalCall &p_icall, StringBuilder &r_output);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportToolButtonAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportToolButtonAttribute.cs
@@ -16,7 +16,7 @@ namespace Godot
         public string Text { get; }
 
         /// <summary>
-        /// If defined, used to fetch an icon for the button via <see cref="Control.GetThemeIcon"/>,
+        /// If defined, used to fetch an icon for the button via <see cref="Control.GetThemeIcon(StringName,StringName)"/>,
         /// from the <code>EditorIcons</code> theme type.
         /// </summary>
         public string? Icon { get; init; }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
@@ -48,7 +48,7 @@ namespace Godot
         }
 
         /// <summary>
-        /// Similar to <see cref="GetNode"/>, but does not log an error if <paramref name="path"/>
+        /// Similar to <see cref="GetNode(NodePath)"/>, but does not log an error if <paramref name="path"/>
         /// does not point to a valid <see cref="Node"/>.
         /// </summary>
         /// <example>
@@ -86,7 +86,7 @@ namespace Godot
         /// Returns a child node by its index (see <see cref="GetChildCount"/>).
         /// This method is often used for iterating all children of a node.
         /// Negative indices access the children from the last one.
-        /// To access a child node via its name, use <see cref="GetNode"/>.
+        /// To access a child node via its name, use <see cref="GetNode(NodePath)"/>.
         /// </summary>
         /// <seealso cref="GetChildOrNull{T}(int, bool)"/>
         /// <param name="idx">Child index.</param>
@@ -110,7 +110,7 @@ namespace Godot
         /// Returns a child node by its index (see <see cref="GetChildCount"/>).
         /// This method is often used for iterating all children of a node.
         /// Negative indices access the children from the last one.
-        /// To access a child node via its name, use <see cref="GetNode"/>.
+        /// To access a child node via its name, use <see cref="GetNode(NodePath)"/>.
         /// </summary>
         /// <seealso cref="GetChild{T}(int, bool)"/>
         /// <param name="idx">Child index.</param>


### PR DESCRIPTION
Related issue: #105750 and https://github.com/godotengine/godot-proposals/discussions/10826.
Supersedes #100452.

Generated code examples:
```cs
	// Node.cs
        public Node GetNode(NodePath path)
        {
            return (Node)NativeCalls.godot_icall_1_817(MethodBind12, GodotObject.GetPtr(this), (godot_node_path)(path?.NativeValue ?? default));
        }

        public Node GetNode(string path)
        {
            using godot_node_path pathNativeValue = NativeFuncs.godotsharp_node_path_new_from_string(path);
            return (Node)NativeCalls.godot_icall_1_817(MethodBind12, GodotObject.GetPtr(this), pathNativeValue);
        }

	public string Atr(string message, StringName context = null)
        {
            return NativeCalls.godot_icall_2_822(MethodBind125, GodotObject.GetPtr(this), message, (godot_string_name)(context?.NativeValue ?? default));
        }

	public string Atr(string message, string context = "")
        {
            using godot_string_name contextNativeValue = NativeFuncs.godotsharp_string_name_new_from_string(context);
            return NativeCalls.godot_icall_2_822(MethodBind125, GodotObject.GetPtr(this), message, contextNativeValue);
        }
```
```cs
	// Input.cs
	public static bool IsActionPressed(StringName action, bool exactMatch = false)
        {
            return NativeCalls.godot_icall_2_675(MethodBind6, GodotObject.GetPtr(Singleton), (godot_string_name)(action?.NativeValue ?? default), exactMatch.ToGodotBool()).ToBool();
        }

	public static bool IsActionPressed(string action, bool exactMatch = false)
        {
            using godot_string_name actionNativeValue = NativeFuncs.godotsharp_string_name_new_from_string(action);
            return NativeCalls.godot_icall_2_675(MethodBind6, GodotObject.GetPtr(Singleton), actionNativeValue, exactMatch.ToGodotBool()).ToBool();
        }
```

Benchmark:
```cs
using Godot;
using System.Diagnostics;

public partial class Main : Node2D
{
    [Export] int testCount = 100000;

    StringName cached_sn = new("ui_accept");

    public override void _Ready()
    {
        var sw = new Stopwatch();

        sw.Restart();
        for (int i = 0; i < testCount; i++)
        {
            Input.IsActionPressed(cached_sn);
        }
        sw.Stop();
        GD.Print(sw.ElapsedMilliseconds);

        sw.Restart();
        for (int i = 0; i < testCount; i++)
        {
            Input.IsActionPressed("ui_accept");
        }
        sw.Stop();
        GD.Print(sw.ElapsedMilliseconds);

        sw.Restart();
        for (int i = 0; i < testCount; i++)
        {
            Input.IsActionPressed(new StringName("ui_accept"));
        }
        sw.Stop();
        GD.Print(sw.ElapsedMilliseconds);
    }
}

```
The above prints: 
```
9
26
101
^C⏎                                                                                                                                                          
8
25
97
^C⏎                                                                                                                                                          
8
24
95
^C⏎ 
```
This PR achieves about 4x speedup ( but still much slower than cached StringName ).