### PR TITLE
Add `Modified` button to Project/Editor settings

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -105,7 +105,7 @@ bool EditorInspector::_resource_properties_matches(const Ref<Resource> &p_resour
 			continue;
 
 		} else if (p.name.begins_with("metadata/_") || !(p.usage & PROPERTY_USAGE_EDITOR) || _is_property_disabled_by_feature_profile(p.name) ||
-				(p_filter.is_empty() && restrict_to_basic && !(p.usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING))) {
+				(p_filter.is_empty() && restrict_to_basic && !(p.usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING)) || (restrict_to_modified && !EditorPropertyRevert::can_property_revert(object, p.name))) {
 			// Ignore properties that are not supposed to be in the inspector.
 			continue;
 		}
@@ -3705,8 +3705,9 @@ void EditorInspector::update_tree() {
 			List<PropertyInfo>::Element *N = E_property->next();
 			bool valid = true;
 			while (N) {
-				if (!N->get().name.begins_with("metadata/_") && N->get().usage & PROPERTY_USAGE_EDITOR &&
-						(!filter.is_empty() || !restrict_to_basic || (N->get().usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING))) {
+				if ((!N->get().name.begins_with("metadata/_") && N->get().usage & PROPERTY_USAGE_EDITOR &&
+							(!filter.is_empty() || !restrict_to_basic || N->get().usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING)) ||
+						(restrict_to_modified && !EditorPropertyRevert::can_property_revert(object, p.name))) {
 					break;
 				}
 				// Treat custom categories as second-level ones. Do not skip a normal category if it is followed by a custom one.
@@ -3778,7 +3779,7 @@ void EditorInspector::update_tree() {
 			continue;
 
 		} else if (p.name.begins_with("metadata/_") || !(p.usage & PROPERTY_USAGE_EDITOR) || _is_property_disabled_by_feature_profile(p.name) ||
-				(filter.is_empty() && restrict_to_basic && !(p.usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING))) {
+				(filter.is_empty() && restrict_to_basic && !(p.usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING)) || (restrict_to_modified && !EditorPropertyRevert::can_property_revert(object, p.name))) {
 			// Ignore properties that are not supposed to be in the inspector.
 			continue;
 		}
@@ -5478,6 +5479,11 @@ void EditorInspector::_feature_profile_changed() {
 
 void EditorInspector::set_restrict_to_basic_settings(bool p_restrict) {
 	restrict_to_basic = p_restrict;
+	update_tree();
+}
+
+void EditorInspector::set_restrict_to_modified_settings(bool p_restrict) {
+	restrict_to_modified = p_restrict;
 	update_tree();
 }
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -697,6 +697,7 @@ class EditorInspector : public ScrollContainer {
 	Variant property_clipboard;
 
 	bool restrict_to_basic = false;
+	bool restrict_to_modified = false;
 
 	void _edit_set(const String &p_name, const Variant &p_value, bool p_refresh_all, const String &p_changed_field);
 
@@ -819,6 +820,7 @@ public:
 	void set_use_deletable_properties(bool p_enabled);
 
 	void set_restrict_to_basic_settings(bool p_restrict);
+	void set_restrict_to_modified_settings(bool p_restrict);
 	void set_property_clipboard(const Variant &p_value);
 	Variant get_property_clipboard() const;
 

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -247,7 +247,7 @@ void SectionedInspector::update_category_list() {
 		if (pi.usage & PROPERTY_USAGE_CATEGORY) {
 			continue;
 		} else if (!(pi.usage & PROPERTY_USAGE_EDITOR) ||
-				(filter_text.is_empty() && restrict_to_basic && !(pi.usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING))) {
+				(filter_text.is_empty() && restrict_to_basic && !(pi.usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING)) || (restrict_to_modified && !EditorPropertyRevert::can_property_revert(o, pi.name))) {
 			continue;
 		}
 
@@ -319,6 +319,12 @@ void SectionedInspector::register_advanced_toggle(CheckButton *p_toggle) {
 	_advanced_toggled(advanced_toggle->is_pressed());
 }
 
+void SectionedInspector::register_modified_toggle(CheckButton *p_toggle) {
+	modified_toggle = p_toggle;
+	modified_toggle->connect(SceneStringName(toggled), callable_mp(this, &SectionedInspector::_modified_toggled));
+	_modified_toggled(modified_toggle->is_pressed());
+}
+
 void SectionedInspector::_search_changed(const String &p_what) {
 	if (advanced_toggle) {
 		if (p_what.is_empty()) {
@@ -338,6 +344,12 @@ void SectionedInspector::_advanced_toggled(bool p_toggled_on) {
 	restrict_to_basic = !p_toggled_on;
 	update_category_list();
 	inspector->set_restrict_to_basic_settings(restrict_to_basic);
+}
+
+void SectionedInspector::_modified_toggled(bool p_toggled_on) {
+	restrict_to_modified = p_toggled_on;
+	update_category_list();
+	inspector->set_restrict_to_modified_settings(restrict_to_modified);
 }
 
 void SectionedInspector::_notification(int p_notification) {

--- a/editor/editor_sectioned_inspector.h
+++ b/editor/editor_sectioned_inspector.h
@@ -51,16 +51,19 @@ class SectionedInspector : public HSplitContainer {
 	EditorInspector *inspector = nullptr;
 	LineEdit *search_box = nullptr;
 	CheckButton *advanced_toggle = nullptr;
+	CheckButton *modified_toggle = nullptr;
 
 	String selected_category;
 
 	bool restrict_to_basic = false;
+	bool restrict_to_modified = false;
 
 	static void _bind_methods();
 	void _section_selected();
 
 	void _search_changed(const String &p_what);
 	void _advanced_toggled(bool p_toggled_on);
+	void _modified_toggled(bool p_toggled_on);
 
 protected:
 	void _notification(int p_notification);
@@ -68,6 +71,7 @@ protected:
 public:
 	void register_search_box(LineEdit *p_box);
 	void register_advanced_toggle(CheckButton *p_toggle);
+	void register_modified_toggle(CheckButton *p_toggle);
 
 	EditorInspector *get_inspector();
 	void edit(Object *p_object);

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -899,6 +899,10 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hbc->add_child(search_box);
 
+	show_modified_switch = memnew(CheckButton(TTRC("Modified")));
+	show_modified_switch->set_tooltip_text(TTRC("Only display editor settings that have been modified from their default value."));
+	hbc->add_child(show_modified_switch);
+
 	advanced_switch = memnew(CheckButton(TTRC("Advanced Settings")));
 	hbc->add_child(advanced_switch);
 
@@ -911,6 +915,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	inspector->get_inspector()->set_mark_unsaved(false);
 	inspector->register_search_box(search_box);
 	inspector->register_advanced_toggle(advanced_switch);
+	inspector->register_modified_toggle(show_modified_switch);
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tab_general->add_child(inspector);
 	inspector->get_inspector()->connect("property_edited", callable_mp(this, &EditorSettingsDialog::_settings_property_edited));

--- a/editor/editor_settings_dialog.h
+++ b/editor/editor_settings_dialog.h
@@ -54,6 +54,7 @@ class EditorSettingsDialog : public AcceptDialog {
 	Control *tab_shortcuts = nullptr;
 
 	LineEdit *search_box = nullptr;
+	CheckButton *show_modified_switch = nullptr;
 	CheckButton *advanced_switch = nullptr;
 	SectionedInspector *inspector = nullptr;
 	EditorEventSearchBar *shortcut_search_bar = nullptr;

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -713,6 +713,11 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	search_bar->add_child(search_box);
 
+	show_modified = memnew(CheckButton);
+	show_modified->set_text(TTR("Modified"));
+	show_modified->set_tooltip_text(TTR("Only display project settings that have been modified from their default value."));
+	search_bar->add_child(show_modified);
+
 	advanced = memnew(CheckButton);
 	advanced->set_text(TTRC("Advanced Settings"));
 	search_bar->add_child(advanced);
@@ -757,6 +762,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	general_settings_inspector->register_search_box(search_box);
 	general_settings_inspector->register_advanced_toggle(advanced);
 	general_settings_inspector->connect("category_changed", callable_mp(this, &ProjectSettingsEditor::_on_category_changed));
+	general_settings_inspector->register_modified_toggle(show_modified);
 	general_settings_inspector->get_inspector()->set_use_filter(true);
 	general_settings_inspector->get_inspector()->set_mark_unsaved(false);
 	general_settings_inspector->get_inspector()->connect("property_selected", callable_mp(this, &ProjectSettingsEditor::_setting_selected));

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -72,6 +72,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	EditorPluginSettings *plugin_settings = nullptr;
 
 	LineEdit *search_box = nullptr;
+	CheckButton *show_modified = nullptr;
 	CheckButton *advanced = nullptr;
 
 	HBoxContainer *custom_properties = nullptr;


### PR DESCRIPTION
Adds a button to the Project and Editor settings dialogs that will only display settings that have been modified. 
Open for suggestions to potentially change how the button looks as well.

https://github.com/user-attachments/assets/de76a560-6893-443e-be12-de6128efd0f3