### PR TITLE
Optimize `StringName` construction from statically known strings by evaluating `strlen` at compile-time

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2258,7 +2258,7 @@ void Object::assign_class_name_static(const Span<char> &p_name, StringName &r_ta
 		// Already assigned while we were waiting for the mutex.
 		return;
 	}
-	r_target = StringName(p_name.ptr(), true);
+	r_target = StringName(p_name, true);
 }
 
 Object::~Object() {

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -164,7 +164,9 @@ public:
 		p_name._data = nullptr;
 		return *this;
 	}
-	StringName(const char *p_name, bool p_static = false);
+	StringName(Span<char> p_name, bool p_static = false);
+	_FORCE_INLINE_ StringName(const char *p_name, bool p_static = false) :
+			StringName(Span(p_name, strlen(p_name)), p_static) {}
 	StringName(const StringName &p_name);
 	StringName(StringName &&p_name) {
 		_data = p_name._data;

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -296,24 +296,15 @@ String &String::operator+=(char32_t p_char) {
 	return *this;
 }
 
-bool String::operator==(const char *p_str) const {
+bool String::operator==(Span<char> p_str) const {
 	// compare Latin-1 encoded c-string
-	int len = strlen(p_str);
-
-	if (length() != len) {
+	if ((uint64_t)length() != p_str.size()) {
 		return false;
 	}
-	if (is_empty()) {
-		return true;
-	}
-
-	int l = length();
-
-	const char32_t *dst = get_data();
 
 	// Compare char by char
-	for (int i = 0; i < l; i++) {
-		if ((char32_t)p_str[i] != dst[i]) {
+	for (uint64_t i = 0; i < p_str.size(); i++) {
+		if ((char32_t)p_str.ptr()[i] != ptr()[i]) {
 			return false;
 		}
 	}

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -356,7 +356,8 @@ public:
 	String &operator+=(const wchar_t *p_str);
 	String &operator+=(const char32_t *p_str);
 
-	bool operator==(const char *p_str) const;
+	bool operator==(Span<char> p_str) const;
+	_FORCE_INLINE_ bool operator==(const char *p_str) const { return operator==(Span(p_str, strlen(p_str))); }
 	bool operator==(const wchar_t *p_str) const;
 	bool operator==(const char32_t *p_str) const;
 	bool operator==(const Span<char32_t> &p_str_range) const;

--- a/tests/core/templates/test_command_queue.h
+++ b/tests/core/templates/test_command_queue.h
@@ -284,7 +284,7 @@ public:
 };
 
 static void test_command_queue_basic(bool p_use_thread_pool_sync) {
-	const char *COMMAND_QUEUE_SETTING = "memory/limits/command_queue/multithreading_queue_size_kb";
+	const char COMMAND_QUEUE_SETTING[] = "memory/limits/command_queue/multithreading_queue_size_kb";
 	ProjectSettings::get_singleton()->set_setting(COMMAND_QUEUE_SETTING, 1);
 	SharedThreadState sts;
 	sts.init_threads(p_use_thread_pool_sync);
@@ -334,7 +334,7 @@ TEST_CASE("[CommandQueue] Test Queue Basics with WorkerThreadPool sync.") {
 }
 
 TEST_CASE("[CommandQueue] Test Queue Wrapping to same spot.") {
-	const char *COMMAND_QUEUE_SETTING = "memory/limits/command_queue/multithreading_queue_size_kb";
+	const char COMMAND_QUEUE_SETTING[] = "memory/limits/command_queue/multithreading_queue_size_kb";
 	ProjectSettings::get_singleton()->set_setting(COMMAND_QUEUE_SETTING, 1);
 	SharedThreadState sts;
 	sts.init_threads();
@@ -392,7 +392,7 @@ TEST_CASE("[CommandQueue] Test Queue Wrapping to same spot.") {
 }
 
 TEST_CASE("[CommandQueue] Test Queue Lapping") {
-	const char *COMMAND_QUEUE_SETTING = "memory/limits/command_queue/multithreading_queue_size_kb";
+	const char COMMAND_QUEUE_SETTING[] = "memory/limits/command_queue/multithreading_queue_size_kb";
 	ProjectSettings::get_singleton()->set_setting(COMMAND_QUEUE_SETTING, 1);
 	SharedThreadState sts;
 	sts.init_threads();
@@ -443,7 +443,7 @@ TEST_CASE("[CommandQueue] Test Queue Lapping") {
 }
 
 TEST_CASE("[Stress][CommandQueue] Stress test command queue") {
-	const char *COMMAND_QUEUE_SETTING = "memory/limits/command_queue/multithreading_queue_size_kb";
+	const char COMMAND_QUEUE_SETTING[] = "memory/limits/command_queue/multithreading_queue_size_kb";
 	ProjectSettings::get_singleton()->set_setting(COMMAND_QUEUE_SETTING, 1);
 	SharedThreadState sts;
 	sts.init_threads();


### PR DESCRIPTION
The long anticipated `StringName` version of #100132!

I do not expect any comparable improvements to #100132 because the bottleneck is elsewhere (though small improvements _are_ expected).
However, I think this is an important step in the right direction, because we need `StringName` construction from `Span<char>` if we want to slowly make `Span<char>` the default way of passing around static strings (for its speed benefits over `const char *`).

This need can already be seen in `assign_class_name_static`, where I forgot that `StringName(const char*)` checks null termination, so the function is _technically_ incorrect right now (though it will never fail because all callers currently use null terminated `Span`).
