### PR TITLE
Fix for Node3D request gizmos multiple times

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -229,7 +229,8 @@ void Node3D::_notification(int p_what) {
 			}
 
 #ifdef TOOLS_ENABLED
-			if (is_part_of_edited_scene()) {
+			if (is_part_of_edited_scene() && !data.gizmos_requested) {
+				data.gizmos_requested = true;
 				get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringName(_spatial_editor_group), SNAME("_request_gizmo_for_id"), get_instance_id());
 			}
 #endif
@@ -753,7 +754,10 @@ void Node3D::update_gizmos() {
 	}
 
 	if (data.gizmos.is_empty()) {
-		get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringName(_spatial_editor_group), SNAME("_request_gizmo_for_id"), get_instance_id());
+		if (!data.gizmos_requested) {
+			data.gizmos_requested = true;
+			get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringName(_spatial_editor_group), SNAME("_request_gizmo_for_id"), get_instance_id());
+		}
 		return;
 	}
 	if (data.gizmos_dirty) {
@@ -1450,6 +1454,7 @@ Node3D::Node3D() :
 	data.fti_frame_xform_force_update = false;
 
 #ifdef TOOLS_ENABLED
+	data.gizmos_requested = false;
 	data.gizmos_disabled = false;
 	data.gizmos_dirty = false;
 	data.transform_gizmo_visible = true;

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -154,6 +154,7 @@ private:
 
 #ifdef TOOLS_ENABLED
 		Vector<Ref<Node3DGizmo>> gizmos;
+		bool gizmos_requested : 1;
 		bool gizmos_disabled : 1;
 		bool gizmos_dirty : 1;
 		bool transform_gizmo_visible : 1;


### PR DESCRIPTION
FIXES: #88119

This can result in multiple gizmos being created for the same nodes in some circumstances

Requests for node gizmos are meant to happen only once, as specified in the [documentation](https://docs.godotengine.org/en/4.4/classes/class_editornode3dgizmoplugin.html#class-editornode3dgizmoplugin-private-method-has-gizmo) "Whenever a node is added to a scene this method is called".

In practice, it was possible for this to be called multiple times in some circumstances, resulting in multiple gizmos being created for a given node.

To Reproduce Error:
1. Create new 3D scene from FileSystem dock
2. With the scene open, select the created Node3D
3. Save the scene by pressing Ctrl + S
4. Click Scene > Reload Saved Scene
5. (you will now have multiple gizmos requested for the selected Node3D)

It is possible to reproduce this problem in other ways that are more complex and less likely to occur, and more impactful, while harder to debug. (Took me several hours of debugging to narrow it down to a `emit_changed.call_deferred()` being called by a setter function applying initial `@export` values to an instance in the scene - these were then being executed in order, and resulted in many deffered calls to `_request_gizmo` being stacked due to multiple `update_gizmos` calls)

(as an aside, it is likely that repeated and un-needed calls to `_request_gizmo` are being made for nodes that have no applicable gizmos)

For the plugin, the following code shoud suffice for testing/debugging purposes.

```GDScript
@tool
extends EditorPlugin

var gizmo_plugin = MyGizmo.new()
func _enter_tree() -> void:
	add_node_3d_gizmo_plugin(gizmo_plugin)
func _exit_tree() -> void:
	remove_node_3d_gizmo_plugin(gizmo_plugin)

class MyGizmo extends EditorNode3DGizmoPlugin:
	func _has_gizmo(for_node_3d: Node3D) -> bool:
		print(for_node_3d)
		return false
```

(note: this is my first ever pull request! sorry if this comes off as strange)