### PR TITLE
Optimize the `callback` argument of `popup_create_dialog()`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -292,7 +292,7 @@
 			<param index="4" name="type_blocklist" type="StringName[]" default="[]" />
 			<description>
 				Pops up an editor dialog for creating an object.
-				The [param callback] must take a single argument of type [StringName] which will contain the type name of the selected object or be empty if no item is selected.
+				The [param callback] must take a single argument of type [String], which will contain the type name of the selected object (or the script path of the type, if the type is created from a script), or be an empty string if no item is selected.
 				The [param base_type] specifies the base type of objects to display. For example, if you set this to "Resource", all types derived from [Resource] will display in the create dialog.
 				The [param current_type] will be passed in the search box of the create dialog, and the specified type can be immediately selected when the dialog pops up. If the [param current_type] is not derived from [param base_type], there will be no result of the type in the dialog.
 				The [param dialog_title] allows you to define a custom title for the dialog. This is useful if you want to accurately hint the usage of the dialog. If the [param dialog_title] is an empty string, the dialog will use "Create New 'Base Type'" as the default title.

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -370,7 +370,9 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 		if (is_tool) {
 			tooltip = TTR("The script will run in the editor.") + "\n" + tooltip;
 		}
-		r_item->add_button(0, get_editor_theme_icon(SNAME("Script")), 1, false, vformat(tooltip, ScriptServer::get_global_class_path(p_type)));
+		const String script_path = ScriptServer::get_global_class_path(p_type);
+		r_item->add_button(0, get_editor_theme_icon(SNAME("Script")), 1, false, vformat(tooltip, script_path));
+		r_item->set_meta(SNAME("_script_path"), script_path);
 		if (is_tool) {
 			int button_index = r_item->get_button_count(0) - 1;
 			r_item->set_button_color(0, button_index, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
@@ -608,11 +610,13 @@ void CreateDialog::select_base() {
 
 String CreateDialog::get_selected_type() {
 	TreeItem *selected = search_options->get_selected();
+
 	if (!selected) {
 		return String();
 	}
 
-	return selected->get_text(0);
+	String type = selected->get_text(0);
+	return ClassDB::class_exists(type) ? type : String(selected->get_meta("_script_path", ""));
 }
 
 void CreateDialog::set_base_type(const String &p_base) {


### PR DESCRIPTION
Improvement of #100135 

I noticed that the callback (`callable` argument in the method) only returns the name of the type. However, when it comes to scripts, you cannot have any idea to instantiate it from the name.
Now the callback will return a string: If the type is script, it will return the path to the script file instead of its name. Native types keep still.

Chat log: https://chat.godotengine.org/channel/editor?msg=EiJdzCYoZaYihNRTR