### PR TITLE
Core: Add `[[deprecated]]` suppression macros

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -701,7 +701,7 @@ String OS::get_unique_id() const {
 }
 
 void OS::add_logger(const Ref<Logger> &p_logger) {
-	ERR_FAIL_COND(p_logger.is_null());
+	ERR_FAIL_NULL(p_logger);
 
 	if (!logger_bind) {
 		logger_bind = memnew(LoggerBind);
@@ -713,7 +713,7 @@ void OS::add_logger(const Ref<Logger> &p_logger) {
 }
 
 void OS::remove_logger(const Ref<Logger> &p_logger) {
-	ERR_FAIL_COND(p_logger.is_null());
+	ERR_FAIL_NULL(p_logger);
 	ERR_FAIL_COND_MSG(!logger_bind || logger_bind->loggers.find(p_logger) == -1, "Could not remove logger, as it hasn't been added.");
 	logger_bind->loggers.erase(p_logger);
 }
@@ -2123,7 +2123,7 @@ bool EngineDebugger::is_active() {
 }
 
 void EngineDebugger::register_profiler(const StringName &p_name, Ref<EngineProfiler> p_profiler) {
-	ERR_FAIL_COND(p_profiler.is_null());
+	ERR_FAIL_NULL(p_profiler);
 	ERR_FAIL_COND_MSG(p_profiler->is_bound(), "Profiler already registered.");
 	ERR_FAIL_COND_MSG(profilers.has(p_name) || has_profiler(p_name), vformat("Profiler name already in use: '%s'.", p_name));
 	Error err = p_profiler->bind(p_name);

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -332,7 +332,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If it is null, the current function returns.
  */
 #define ERR_FAIL_NULL(m_param)                                                                          \
+	GODOT_DEPRECATED_BEGIN                                                                              \
 	if (unlikely(m_param == nullptr)) {                                                                 \
+		GODOT_DEPRECATED_END                                                                            \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
 		return;                                                                                         \
 	} else                                                                                              \
@@ -343,7 +345,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If it is null, prints `m_msg` and the current function returns.
  */
 #define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                      \
+	GODOT_DEPRECATED_BEGIN                                                                                     \
 	if (unlikely(m_param == nullptr)) {                                                                        \
+		GODOT_DEPRECATED_END                                                                                   \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
 		return;                                                                                                \
 	} else                                                                                                     \
@@ -353,7 +357,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Same as `ERR_FAIL_NULL_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_NULL_EDMSG(m_param, m_msg)                                                                          \
+	GODOT_DEPRECATED_BEGIN                                                                                           \
 	if (unlikely(m_param == nullptr)) {                                                                              \
+		GODOT_DEPRECATED_END                                                                                         \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg, true); \
 		return;                                                                                                      \
 	} else                                                                                                           \
@@ -367,7 +373,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If it is null, the current function returns `m_retval`.
  */
 #define ERR_FAIL_NULL_V(m_param, m_retval)                                                              \
+	GODOT_DEPRECATED_BEGIN                                                                              \
 	if (unlikely(m_param == nullptr)) {                                                                 \
+		GODOT_DEPRECATED_END                                                                            \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
 		return m_retval;                                                                                \
 	} else                                                                                              \
@@ -378,7 +386,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If it is null, prints `m_msg` and the current function returns `m_retval`.
  */
 #define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                          \
+	GODOT_DEPRECATED_BEGIN                                                                                     \
 	if (unlikely(m_param == nullptr)) {                                                                        \
+		GODOT_DEPRECATED_END                                                                                   \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
 		return m_retval;                                                                                       \
 	} else                                                                                                     \
@@ -388,7 +398,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Same as `ERR_FAIL_NULL_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_NULL_V_EDMSG(m_param, m_retval, m_msg)                                                              \
+	GODOT_DEPRECATED_BEGIN                                                                                           \
 	if (unlikely(m_param == nullptr)) {                                                                              \
+		GODOT_DEPRECATED_END                                                                                         \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg, true); \
 		return m_retval;                                                                                             \
 	} else                                                                                                           \

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -95,11 +95,19 @@ public:
 	_FORCE_INLINE_ bool operator!=(const T *p_ptr) const {
 		return reference != p_ptr;
 	}
+
 #ifdef STRICT_CHECKS
-	// Delete these to prevent raw comparisons with `nullptr`.
-	bool operator==(std::nullptr_t) const = delete;
-	bool operator!=(std::nullptr_t) const = delete;
-#endif // STRICT_CHECKS
+	[[deprecated("Raw comparison with `nullptr` discouraged; use `is_null()` instead.")]]
+#endif
+	_FORCE_INLINE_ bool operator==(std::nullptr_t) const {
+		return is_null();
+	}
+#ifdef STRICT_CHECKS
+	[[deprecated("Raw comparison with `nullptr` discouraged; use `is_null()` instead.")]]
+#endif
+	_FORCE_INLINE_ bool operator!=(std::nullptr_t) const {
+		return !is_null();
+	}
 
 	_FORCE_INLINE_ bool operator<(const Ref<T> &p_r) const {
 		return reference < p_r.reference;

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -388,3 +388,12 @@ inline constexpr bool is_zero_constructible_v = is_zero_constructible<T>::value;
 #define GODOT_MSVC_WARNING_POP
 #define GODOT_MSVC_WARNING_PUSH_AND_IGNORE(m_warning)
 #endif
+
+#define GODOT_DEPRECATED_BEGIN                                       \
+	GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations") \
+	GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations")   \
+	GODOT_MSVC_WARNING_PUSH_AND_IGNORE(4996)
+#define GODOT_DEPRECATED_END \
+	GODOT_CLANG_WARNING_POP  \
+	GODOT_GCC_WARNING_POP    \
+	GODOT_MSVC_WARNING_POP


### PR DESCRIPTION
One of the roadblocks I ran into when trying to implement a template wrapper for non-nullable types is `Ref<T>` having them explicitly deleted. While I understand the reasoning behind it, I wanted a way to expose that logic while still effectively discouraging it. This manifested by using `[[deprecated]]` instead of `= delete`, as it would still be functionally blocking for anyone using it (if `werror` is on), but could still be safely called to for more nuanced use-cases. In order to give engine developers a convenient means of enabling/disabling use of `[[deprecated]]` in this sort of context, it necessitated the addition of new wrapper macros: `GODOT_DEPRECATED_BEGIN` and `GODOT_DEPRECATED_END`

To showcase their use, I've added these wrappers to the `ERR_FAIL_NULL*` macro conditionals. This means that it's now possible to use the more "appropriate" error macro with `Ref<T>` variables, **without** encuraging `nullptr` comparison elsewhere. For demonstration purposes, this is integrated in a single file: `core_bind.cpp`; I leave further integration to followup PRs