### PR TITLE
Enable XR play mode options in the regular editor

### DIFF
--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -599,10 +599,9 @@ EditorRunBar::EditorRunBar() {
 
 	bool add_play_xr_mode_options = false;
 #ifndef XR_DISABLED
-	if (OS::get_singleton()->has_feature("xr_editor") &&
-			(XRServer::get_xr_mode() == XRServer::XRMODE_ON ||
-					(XRServer::get_xr_mode() == XRServer::XRMODE_DEFAULT && GLOBAL_GET("xr/openxr/enabled")))) {
-		// If this is the XR editor and openxr is enabled, we turn the `play_scene_button` and
+	if (XRServer::get_xr_mode() == XRServer::XRMODE_ON ||
+			(XRServer::get_xr_mode() == XRServer::XRMODE_DEFAULT && GLOBAL_GET("xr/openxr/enabled"))) {
+		// If OpenXR is enabled, we turn the `play_scene_button` and
 		// `play_custom_scene_button` into MenuButtons to provide the option to start a scene in
 		// either regular mode or XR mode.
 		add_play_xr_mode_options = true;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/101116; the feature is necessary in the regular editor for XR projects with regular scenes, or hybrid app projects.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
