### PR TITLE
Fix ghost collisions in `segment_intersects_convex()`

### DIFF
--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -292,6 +292,10 @@ public:
 			real_t den = p.normal.dot(dir);
 
 			if (Math::abs(den) <= (real_t)CMP_EPSILON) {
+				if (p.is_point_over(p_from)) {
+					// Separating plane.
+					return false;
+				}
 				continue; // Ignore parallel plane.
 			}
 

--- a/tests/core/math/test_geometry_3d.h
+++ b/tests/core/math/test_geometry_3d.h
@@ -160,6 +160,7 @@ TEST_CASE("[Geometry3D] Does Segment Intersect Convex") {
 	CHECK(Geometry3D::segment_intersects_convex(Vector3(10, 10, 10), Vector3(0, 0, 0), &box_planes[0], box_planes.size(), &result, &normal) == true);
 	CHECK(Geometry3D::segment_intersects_convex(Vector3(10, 10, 10), Vector3(5, 5, 5), &box_planes[0], box_planes.size(), &result, &normal) == true);
 	CHECK(Geometry3D::segment_intersects_convex(Vector3(10, 10, 10), Vector3(6, 5, 5), &box_planes[0], box_planes.size(), &result, &normal) == false);
+	CHECK(Geometry3D::segment_intersects_convex(Vector3(10, 10, 0), Vector3(10, 0, 0), &box_planes[0], box_planes.size(), &result, &normal) == false);
 }
 
 TEST_CASE("[Geometry3D] Segment Intersects Cylinder") {


### PR DESCRIPTION
Previously ```segment_intersects_convex()``` ignored planes parallel to the segment. This is because the segment cannot intersect this plane. However, if the points are above the plane then that means the plane separates the hull from the segment and therefore the segment cannot possibly intersect the convex hull.

I encountered this bug doing procedural level generation with a concave shape similar to a heightmap with true holes and found it much faster to skip the physics server and just do manual collision checking, but this bug caused many incorrect collisions and poor results. After the fix the collision works flawlessly.

master:
![image](https://github.com/user-attachments/assets/e176c217-ff50-4fb3-8f54-5acf675fba46)

This pr:
![image](https://github.com/user-attachments/assets/04cd627c-6838-459b-9903-9429799025d4)

As you can see the function works in most cases in master, however the two segment marked as "bad" are parallel to the plane of the box which is facing them. Currently this means that the top plane of the box is counted as intersecting (which is wrong).

The project from the screenshots is available here: [mrp.zip](https://github.com/user-attachments/files/20940749/mrp.zip)

Notice how in master if you change the x coordinates for segments 0 or 1, they stop reporting false collisions.

Fixes #69455.