### PR TITLE
Fix loading BPTC/ASTC textures on devices that don't support them

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -121,6 +121,12 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 		}
 	}
 
+	if (p_load && !path_found && decomp_path_found) {
+		print_verbose(vformat("No natively supported texture format found for %s, using decompressable format %s.", p_path, decomp_path));
+		r_path_and_type.path = decomp_path;
+		return OK;
+	}
+
 #ifdef TOOLS_ENABLED
 	if (r_path_and_type.metadata && !r_path_and_type.path.is_empty()) {
 		Dictionary meta = r_path_and_type.metadata;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/102696
~https://github.com/godotengine/godot/issues/95561~ (while this does work around the issue, there is a better fix https://github.com/godotengine/godot/pull/106086)

This is a continuation of https://github.com/godotengine/godot/pull/104590 which added support for loading textures with unsupported formats so long as we know that they can be decompressed at run time. 

The problem with the check in https://github.com/godotengine/godot/pull/104590 is that it only takes effect once we reach the end of the ".import" file while parsing. If we early-out of the parsing loop, the code is never triggered. Therefore, we need to do the check both if we finish parsing the ".import" file from reaching the EOF and if we finish parsing due to any other condition. 