### PR TITLE
Add Dictionary Type Hint to SVGTexture

### DIFF
--- a/scene/resources/svg_texture.cpp
+++ b/scene/resources/svg_texture.cpp
@@ -377,7 +377,7 @@ void SVGTexture::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "_source", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_STORAGE), "set_source", "get_source");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "base_scale", PROPERTY_HINT_RANGE, "0.01,10.0,0.01"), "set_base_scale", "get_base_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "saturation", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_saturation", "get_saturation");
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "color_map"), "set_color_map", "get_color_map");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "color_map", PROPERTY_HINT_DICTIONARY_TYPE, "Color;Color"), "set_color_map", "get_color_map");
 }
 
 SVGTexture::~SVGTexture() {


### PR DESCRIPTION
Adds the relevant type hint to `SVGTexture`'s `color_map` property, making it easier to add key-value pairs within the inspector.