### PR TITLE
Fix empty lines being added for errors with no script backtrace

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -88,7 +88,9 @@ void Logger::log_error(const char *p_function, const char *p_file, int p_line, c
 	logf_error("   at: %s (%s:%i)\n", p_function, p_file, p_line);
 
 	for (const Ref<ScriptBacktrace> &backtrace : p_script_backtraces) {
-		logf_error("%s\n", backtrace->format(3).utf8().get_data());
+		if (!backtrace->is_empty()) {
+			logf_error("%s\n", backtrace->format(3).utf8().get_data());
+		}
 	}
 }
 

--- a/core/object/script_backtrace.cpp
+++ b/core/object/script_backtrace.cpp
@@ -52,6 +52,7 @@ void ScriptBacktrace::_store_variables(const List<String> &p_names, const List<V
 void ScriptBacktrace::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_language_name"), &ScriptBacktrace::get_language_name);
 
+	ClassDB::bind_method(D_METHOD("is_empty"), &ScriptBacktrace::is_empty);
 	ClassDB::bind_method(D_METHOD("get_frame_count"), &ScriptBacktrace::get_frame_count);
 	ClassDB::bind_method(D_METHOD("get_frame_function", "index"), &ScriptBacktrace::get_frame_function);
 	ClassDB::bind_method(D_METHOD("get_frame_file", "index"), &ScriptBacktrace::get_frame_file);
@@ -173,7 +174,7 @@ Variant ScriptBacktrace::get_member_variable_value(int p_frame_index, int p_vari
 }
 
 String ScriptBacktrace::format(int p_indent_all, int p_indent_frames) const {
-	if (stack_frames.is_empty()) {
+	if (is_empty()) {
 		return String();
 	}
 

--- a/core/object/script_backtrace.h
+++ b/core/object/script_backtrace.h
@@ -65,6 +65,7 @@ public:
 
 	String get_language_name() const { return language_name; }
 
+	bool is_empty() const { return stack_frames.is_empty(); }
 	int get_frame_count() const { return stack_frames.size(); }
 	String get_frame_function(int p_index) const;
 	String get_frame_file(int p_index) const;

--- a/doc/classes/ScriptBacktrace.xml
+++ b/doc/classes/ScriptBacktrace.xml
@@ -124,5 +124,11 @@
 				[b]Warning:[/b] With GDScript backtraces, the returned [Variant] will be the variable's actual value, including any object references. This means that storing the returned [Variant] will prevent any such object from being deallocated, so it's generally recommended not to do so.
 			</description>
 		</method>
+		<method name="is_empty" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the backtrace has no stack frames.
+			</description>
+		</method>
 	</methods>
 </class>

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1228,7 +1228,9 @@ void UnixTerminalLogger::log_error(const char *p_function, const char *p_file, i
 	logf_error("%s%sat: %s (%s:%i)%s\n", gray, indent, p_function, p_file, p_line, reset);
 
 	for (const Ref<ScriptBacktrace> &backtrace : p_script_backtraces) {
-		logf_error("%s%s%s\n", gray, backtrace->format(strlen(indent)).utf8().get_data(), reset);
+		if (!backtrace->is_empty()) {
+			logf_error("%s%s%s\n", gray, backtrace->format(strlen(indent)).utf8().get_data(), reset);
+		}
 	}
 }
 

--- a/platform/ios/ios_terminal_logger.mm
+++ b/platform/ios/ios_terminal_logger.mm
@@ -71,7 +71,9 @@ void IOSTerminalLogger::log_error(const char *p_function, const char *p_file, in
 	}
 
 	for (const Ref<ScriptBacktrace> &backtrace : p_script_backtraces) {
-		os_log_error(OS_LOG_DEFAULT, "%{public}s", backtrace->format().utf8().get_data());
+		if (!backtrace->is_empty()) {
+			os_log_error(OS_LOG_DEFAULT, "%{public}s", backtrace->format().utf8().get_data());
+		}
 	}
 }
 

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -153,7 +153,9 @@ static void handle_crash(int sig) {
 	}
 	if (!script_backtraces.is_empty()) {
 		for (const Ref<ScriptBacktrace> &backtrace : script_backtraces) {
-			print_error(backtrace->format());
+			if (!backtrace->is_empty()) {
+				print_error(backtrace->format());
+			}
 		}
 		print_error("-- END OF SCRIPT BACKTRACE --");
 		print_error("================================================================");

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -183,7 +183,9 @@ static void handle_crash(int sig) {
 	}
 	if (!script_backtraces.is_empty()) {
 		for (const Ref<ScriptBacktrace> &backtrace : script_backtraces) {
-			print_error(backtrace->format());
+			if (!backtrace->is_empty()) {
+				print_error(backtrace->format());
+			}
 		}
 		print_error("-- END OF SCRIPT BACKTRACE --");
 		print_error("================================================================");

--- a/platform/macos/macos_terminal_logger.mm
+++ b/platform/macos/macos_terminal_logger.mm
@@ -84,8 +84,10 @@ void MacOSTerminalLogger::log_error(const char *p_function, const char *p_file, 
 	}
 
 	for (const Ref<ScriptBacktrace> &backtrace : p_script_backtraces) {
-		os_log_error(OS_LOG_DEFAULT, "%{public}s", backtrace->format().utf8().get_data());
-		logf_error("\E[0;90m%s\E[0m\n", backtrace->format(strlen(indent)).utf8().get_data());
+		if (!backtrace->is_empty()) {
+			os_log_error(OS_LOG_DEFAULT, "%{public}s", backtrace->format().utf8().get_data());
+			logf_error("\E[0;90m%s\E[0m\n", backtrace->format(strlen(indent)).utf8().get_data());
+		}
 	}
 }
 

--- a/platform/windows/crash_handler_windows_seh.cpp
+++ b/platform/windows/crash_handler_windows_seh.cpp
@@ -237,7 +237,9 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 	}
 	if (!script_backtraces.is_empty()) {
 		for (const Ref<ScriptBacktrace> &backtrace : script_backtraces) {
-			print_error(backtrace->format());
+			if (!backtrace->is_empty()) {
+				print_error(backtrace->format());
+			}
 		}
 		print_error("-- END OF SCRIPT BACKTRACE --");
 		print_error("================================================================");

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -191,7 +191,9 @@ extern void CrashHandlerException(int signal) {
 	}
 	if (!script_backtraces.is_empty()) {
 		for (const Ref<ScriptBacktrace> &backtrace : script_backtraces) {
-			print_error(backtrace->format());
+			if (!backtrace->is_empty()) {
+				print_error(backtrace->format());
+			}
 		}
 		print_error("-- END OF SCRIPT BACKTRACE --");
 		print_error("================================================================");

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -143,7 +143,9 @@ void WindowsTerminalLogger::log_error(const char *p_function, const char *p_file
 		}
 
 		for (const Ref<ScriptBacktrace> &backtrace : p_script_backtraces) {
-			logf_error("%s\n", backtrace->format(strlen(indent)).utf8().get_data());
+			if (!backtrace->is_empty()) {
+				logf_error("%s\n", backtrace->format(strlen(indent)).utf8().get_data());
+			}
 		}
 
 		SetConsoleTextAttribute(hCon, sbi.wAttributes);


### PR DESCRIPTION
#91006 introduced a minor regression with how errors are printed for the case where there are no script backtraces, where they now add empty lines after the `at:` part, one for every registered script language:

```
ERROR: Expected Image data size of 256x256x1 (DXT5 RGBA8 with 8 mipmaps) = 87408 bytes, got 87360 bytes instead.
   at: initialize_data (./core/io/image.cpp:2230)

ERROR: Invalid image: image is empty
   at: create_from_image (./scene/resources/image_texture.cpp:77)

ERROR: Failed loading resource: res://broken.dds. Make sure resources have been imported by opening the project in the editor at least once.
   at: _load (./core/io/resource_loader.cpp:342)
```

This PR fixes that by checking whether the backtraces are empty before printing them, in all the relevant places.

Note that this could also be fixed in a less intrusive way, by simply changing `Engine.capture_script_backtraces` to not include empty backtraces at all, but I'm personally of the opinion that a backtrace should always be returned for every registered script language, to clearly indicate that there are indeed no stack frames for that particular script language.