### PR TITLE
Remove registration of deprecated classes

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -51,7 +51,6 @@
 #include "core/io/json.h"
 #include "core/io/marshalls.h"
 #include "core/io/missing_resource.h"
-#include "core/io/packed_data_container.h"
 #include "core/io/packet_peer.h"
 #include "core/io/packet_peer_dtls.h"
 #include "core/io/packet_peer_udp.h"
@@ -80,6 +79,9 @@
 #include "core/string/optimized_translation.h"
 #include "core/string/translation.h"
 #include "core/string/translation_server.h"
+#ifndef DISABLE_DEPRECATED
+#include "core/io/packed_data_container.h"
+#endif
 
 static Ref<ResourceFormatSaverBinary> resource_saver_binary;
 static Ref<ResourceFormatLoaderBinary> resource_loader_binary;
@@ -264,13 +266,15 @@ void register_core_types() {
 
 	GDREGISTER_CLASS(PCKPacker);
 
-	GDREGISTER_CLASS(PackedDataContainer);
-	GDREGISTER_ABSTRACT_CLASS(PackedDataContainerRef);
 	GDREGISTER_CLASS(AStar3D);
 	GDREGISTER_CLASS(AStar2D);
 	GDREGISTER_CLASS(AStarGrid2D);
 	GDREGISTER_CLASS(EncodedObjectAsID);
 	GDREGISTER_CLASS(RandomNumberGenerator);
+#ifndef DISABLE_DEPRECATED
+	GDREGISTER_CLASS(PackedDataContainer);
+	GDREGISTER_ABSTRACT_CLASS(PackedDataContainerRef);
+#endif
 
 	GDREGISTER_ABSTRACT_CLASS(ImageFormatLoader);
 	GDREGISTER_CLASS(ImageFormatLoaderExtension);

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -32,7 +32,7 @@
 
 #include "editor/editor_settings.h"
 #include "editor/themes/editor_scale.h"
-#include "scene/2d/tile_map.h"
+#include "scene/2d/tile_map_layer.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/panel.h"

--- a/editor/plugins/tiles/tile_data_editors.h
+++ b/editor/plugins/tiles/tile_data_editors.h
@@ -33,7 +33,6 @@
 #include "tile_atlas_view.h"
 
 #include "editor/editor_properties.h"
-#include "scene/2d/tile_map.h"
 #include "scene/gui/box_container.h"
 
 class Label;

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -39,6 +39,7 @@
 #include "editor/multi_node_edit.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/2d/tile_map.h"
 #include "scene/2d/tile_map_layer.h"
 #include "scene/gui/split_container.h"
 

--- a/editor/plugins/tiles/tile_map_layer_editor.h
+++ b/editor/plugins/tiles/tile_map_layer_editor.h
@@ -33,7 +33,6 @@
 #include "tile_atlas_view.h"
 
 #include "core/os/thread.h"
-#include "scene/2d/tile_map.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/flow_container.h"
@@ -46,6 +45,7 @@
 #include "scene/gui/tab_bar.h"
 #include "scene/gui/tree.h"
 
+class TileMapLayer;
 class TileMapLayerEditor;
 
 class TileMapLayerSubEditorPlugin : public Object {

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -104,7 +104,6 @@
 #include "editor/plugins/node_3d_editor_gizmos.h"
 #include "editor/plugins/occluder_instance_3d_editor_plugin.h"
 #include "editor/plugins/packed_scene_editor_plugin.h"
-#include "editor/plugins/parallax_background_editor_plugin.h"
 #include "editor/plugins/particles_editor_plugin.h"
 #include "editor/plugins/path_2d_editor_plugin.h"
 #include "editor/plugins/path_3d_editor_plugin.h"
@@ -117,7 +116,6 @@
 #include "editor/plugins/shader_file_editor_plugin.h"
 #include "editor/plugins/skeleton_2d_editor_plugin.h"
 #include "editor/plugins/skeleton_3d_editor_plugin.h"
-#include "editor/plugins/skeleton_ik_3d_editor_plugin.h"
 #include "editor/plugins/sprite_2d_editor_plugin.h"
 #include "editor/plugins/sprite_frames_editor_plugin.h"
 #include "editor/plugins/style_box_editor_plugin.h"
@@ -131,6 +129,10 @@
 #include "editor/plugins/tool_button_editor_plugin.h"
 #include "editor/plugins/voxel_gi_editor_plugin.h"
 #include "editor/register_exporters.h"
+#ifndef DISABLE_DEPRECATED
+#include "editor/plugins/parallax_background_editor_plugin.h"
+#include "editor/plugins/skeleton_ik_3d_editor_plugin.h"
+#endif
 
 void register_editor_types() {
 	OS::get_singleton()->benchmark_begin_measure("Editor", "Register Types");
@@ -242,7 +244,6 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<ShaderEditorPlugin>();
 	EditorPlugins::add_by_type<ShaderFileEditorPlugin>();
 	EditorPlugins::add_by_type<Skeleton3DEditorPlugin>();
-	EditorPlugins::add_by_type<SkeletonIK3DEditorPlugin>();
 	EditorPlugins::add_by_type<SpriteFramesEditorPlugin>();
 	EditorPlugins::add_by_type<StyleBoxEditorPlugin>();
 	EditorPlugins::add_by_type<SubViewportPreviewEditorPlugin>();
@@ -253,6 +254,9 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<ThemeEditorPlugin>();
 	EditorPlugins::add_by_type<ToolButtonEditorPlugin>();
 	EditorPlugins::add_by_type<VoxelGIEditorPlugin>();
+#ifndef DISABLE_DEPREACTED
+	EditorPlugins::add_by_type<SkeletonIK3DEditorPlugin>();
+#endif
 
 	// 2D
 	EditorPlugins::add_by_type<Camera2DEditorPlugin>();
@@ -265,7 +269,6 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<NavigationLink2DEditorPlugin>();
 	EditorPlugins::add_by_type<NavigationObstacle2DEditorPlugin>();
 	EditorPlugins::add_by_type<NavigationPolygonEditorPlugin>();
-	EditorPlugins::add_by_type<ParallaxBackgroundEditorPlugin>();
 	EditorPlugins::add_by_type<Path2DEditorPlugin>();
 	EditorPlugins::add_by_type<Polygon2DEditorPlugin>();
 	EditorPlugins::add_by_type<Cast2DEditorPlugin>();
@@ -273,6 +276,9 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<Sprite2DEditorPlugin>();
 	EditorPlugins::add_by_type<TileSetEditorPlugin>();
 	EditorPlugins::add_by_type<TileMapEditorPlugin>();
+#ifndef DISABLE_DEPRECATED
+	EditorPlugins::add_by_type<ParallaxBackgroundEditorPlugin>();
+#endif
 
 	// For correct doc generation.
 	GLOBAL_DEF("editor/run/main_run_args", "");

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -41,13 +41,13 @@
 
 #ifndef DISABLE_DEPRECATED
 #include "extensions/openxr_extension_wrapper_extension.h"
+#include "scene/openxr_hand.h"
 #endif // DISABLE_DEPRECATED
 
 #include "scene/openxr_composition_layer.h"
 #include "scene/openxr_composition_layer_cylinder.h"
 #include "scene/openxr_composition_layer_equirect.h"
 #include "scene/openxr_composition_layer_quad.h"
-#include "scene/openxr_hand.h"
 #include "scene/openxr_visibility_mask.h"
 
 #include "extensions/openxr_composition_layer_depth_extension.h"
@@ -229,7 +229,9 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(OpenXRCompositionLayerCylinder);
 		GDREGISTER_CLASS(OpenXRCompositionLayerQuad);
 
+#ifndef DISABLE_DEPRECATED
 		GDREGISTER_CLASS(OpenXRHand);
+#endif
 
 		GDREGISTER_CLASS(OpenXRVisibilityMask);
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -106,7 +106,6 @@
 #include "scene/main/timer.h"
 #include "scene/main/viewport.h"
 #include "scene/main/window.h"
-#include "scene/resources/animated_texture.h"
 #include "scene/resources/animation_library.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/audio_stream_polyphonic.h"
@@ -161,6 +160,9 @@
 #include "scene/resources/visual_shader_particle_nodes.h"
 #include "scene/resources/visual_shader_sdf_nodes.h"
 #include "scene/theme/theme_db.h"
+#ifndef DISABLE_DEPRECATED
+#include "scene/resources/animated_texture.h"
+#endif
 
 // 2D
 #include "scene/2d/animated_sprite_2d.h"
@@ -179,14 +181,11 @@
 #include "scene/2d/mesh_instance_2d.h"
 #include "scene/2d/multimesh_instance_2d.h"
 #include "scene/2d/parallax_2d.h"
-#include "scene/2d/parallax_background.h"
-#include "scene/2d/parallax_layer.h"
 #include "scene/2d/path_2d.h"
 #include "scene/2d/polygon_2d.h"
 #include "scene/2d/remote_transform_2d.h"
 #include "scene/2d/skeleton_2d.h"
 #include "scene/2d/sprite_2d.h"
-#include "scene/2d/tile_map.h"
 #include "scene/2d/tile_map_layer.h"
 #include "scene/2d/visible_on_screen_notifier_2d.h"
 #include "scene/resources/2d/polygon_path_finder.h"
@@ -199,6 +198,11 @@
 #include "scene/resources/2d/skeleton/skeleton_modification_stack_2d.h"
 #include "scene/resources/2d/tile_set.h"
 #include "scene/resources/world_2d.h"
+#ifndef DISABLE_DEPRECATED
+#include "scene/2d/parallax_background.h"
+#include "scene/2d/parallax_layer.h"
+#include "scene/2d/tile_map.h"
+#endif
 
 #ifndef NAVIGATION_2D_DISABLED
 #include "scene/2d/navigation/navigation_agent_2d.h"
@@ -235,7 +239,6 @@
 #include "scene/3d/remote_transform_3d.h"
 #include "scene/3d/retarget_modifier_3d.h"
 #include "scene/3d/skeleton_3d.h"
-#include "scene/3d/skeleton_ik_3d.h"
 #include "scene/3d/skeleton_modifier_3d.h"
 #include "scene/3d/sprite_3d.h"
 #include "scene/3d/visible_on_screen_notifier_3d.h"
@@ -262,6 +265,9 @@
 #include "scene/3d/xr/xr_hand_modifier_3d.h"
 #include "scene/3d/xr/xr_nodes.h"
 #endif // XR_DISABLED
+#ifndef DISABLE_DEPRECATED
+#include "scene/3d/skeleton_ik_3d.h"
+#endif
 #endif // _3D_DISABLED
 
 #if !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
@@ -663,9 +669,11 @@ void register_scene_types() {
 	GDREGISTER_CLASS(SoftBody3D);
 #endif // PHYSICS_3D_DISABLED
 
-	GDREGISTER_CLASS(SkeletonIK3D);
 	GDREGISTER_CLASS(BoneAttachment3D);
 	GDREGISTER_CLASS(LookAtModifier3D);
+#ifndef DISABLE_DEPRECATED
+	GDREGISTER_CLASS(SkeletonIK3D);
+#endif
 
 #ifndef PHYSICS_3D_DISABLED
 	GDREGISTER_CLASS(VehicleBody3D);
@@ -894,12 +902,15 @@ void register_scene_types() {
 	GDREGISTER_CLASS(TileSetScenesCollectionSource);
 	GDREGISTER_CLASS(TileMapPattern);
 	GDREGISTER_CLASS(TileData);
-	GDREGISTER_CLASS(TileMap);
 	GDREGISTER_CLASS(TileMapLayer);
 	GDREGISTER_CLASS(Parallax2D);
+	GDREGISTER_CLASS(RemoteTransform2D);
+
+#ifndef DISABLE_DEPRECATED
 	GDREGISTER_CLASS(ParallaxBackground);
 	GDREGISTER_CLASS(ParallaxLayer);
-	GDREGISTER_CLASS(RemoteTransform2D);
+	GDREGISTER_CLASS(TileMap);
+#endif
 
 	GDREGISTER_CLASS(SkeletonModificationStack2D);
 	GDREGISTER_CLASS(SkeletonModification2D);
@@ -999,7 +1010,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(CurveXYZTexture);
 	GDREGISTER_CLASS(GradientTexture1D);
 	GDREGISTER_CLASS(GradientTexture2D);
-	GDREGISTER_CLASS(AnimatedTexture);
 	GDREGISTER_CLASS(CameraTexture);
 	GDREGISTER_CLASS(ExternalTexture);
 	GDREGISTER_VIRTUAL_CLASS(TextureLayered);
@@ -1021,6 +1031,9 @@ void register_scene_types() {
 	GDREGISTER_CLASS(PlaceholderCubemap);
 	GDREGISTER_CLASS(PlaceholderCubemapArray);
 	GDREGISTER_CLASS(SVGTexture);
+#ifndef DISABLE_DEPRECATED
+	GDREGISTER_CLASS(AnimatedTexture);
+#endif
 
 	// These classes are part of renderer_rd
 	GDREGISTER_CLASS(Texture2DRD);
@@ -1106,7 +1119,9 @@ void register_scene_types() {
 	MultiMeshInstance2D::navmesh_parse_init();
 	NavigationObstacle2D::navmesh_parse_init();
 	Polygon2D::navmesh_parse_init();
+#ifndef DISABLE_DEPRECATED
 	TileMap::navmesh_parse_init();
+#endif
 	TileMapLayer::navmesh_parse_init();
 #ifndef PHYSICS_2D_DISABLED
 	StaticBody2D::navmesh_parse_init();

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -44,7 +44,6 @@
 #include "audio/effects/audio_effect_eq.h"
 #include "audio/effects/audio_effect_filter.h"
 #include "audio/effects/audio_effect_hard_limiter.h"
-#include "audio/effects/audio_effect_limiter.h"
 #include "audio/effects/audio_effect_panner.h"
 #include "audio/effects/audio_effect_phaser.h"
 #include "audio/effects/audio_effect_pitch_shift.h"
@@ -78,6 +77,9 @@
 #include "text/text_server_dummy.h"
 #include "text/text_server_extension.h"
 #include "text_server.h"
+#ifndef DISABLE_DEPRECATED
+#include "audio/effects/audio_effect_limiter.h"
+#endif
 
 // 2D physics and navigation.
 #ifndef NAVIGATION_2D_DISABLED
@@ -205,16 +207,18 @@ void register_server_types() {
 		GDREGISTER_CLASS(AudioEffectChorus);
 		GDREGISTER_CLASS(AudioEffectDelay);
 		GDREGISTER_CLASS(AudioEffectCompressor);
-		GDREGISTER_CLASS(AudioEffectLimiter);
 		GDREGISTER_CLASS(AudioEffectHardLimiter);
 		GDREGISTER_CLASS(AudioEffectPitchShift);
 		GDREGISTER_CLASS(AudioEffectPhaser);
-
 		GDREGISTER_CLASS(AudioEffectRecord);
 		GDREGISTER_CLASS(AudioEffectSpectrumAnalyzer);
 		GDREGISTER_ABSTRACT_CLASS(AudioEffectSpectrumAnalyzerInstance);
 
 		GDREGISTER_CLASS(AudioEffectCapture);
+
+#ifndef DISABLE_DEPRECATED
+		GDREGISTER_CLASS(AudioEffectLimiter);
+#endif
 	}
 
 	GDREGISTER_ABSTRACT_CLASS(RenderingDevice);


### PR DESCRIPTION
This PR wraps registration of deprecated classes in `DISABLE_DEPRECATED`, so they are not registered when compiling with `deprecated=no`. It _may_ decrease binary size a bit, but I didn't handle all includes. Especially removing TileMap would result in unreadable code.