### PR TITLE
Fix editing resources in the inspector when inside an array or dictionary

### DIFF
--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -301,6 +301,10 @@ void EditorPropertyArray::_object_id_selected(const StringName &p_property, Obje
 	emit_signal(SNAME("object_id_selected"), p_property, p_id);
 }
 
+void EditorPropertyArray::_resource_selected(const String &p_path, Ref<Resource> p_resource) {
+	emit_signal(SNAME("resource_selected"), get_edited_property(), p_resource);
+}
+
 void EditorPropertyArray::_create_new_property_slot() {
 	int idx = slots.size();
 	HBoxContainer *hbox = memnew(HBoxContainer);
@@ -511,6 +515,9 @@ void EditorPropertyArray::update_property() {
 				new_prop->set_use_folding(is_using_folding());
 				new_prop->connect(SNAME("property_changed"), callable_mp(this, &EditorPropertyArray::_property_changed));
 				new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyArray::_object_id_selected));
+				if (value_type == Variant::OBJECT) {
+					new_prop->connect("resource_selected", callable_mp(this, &EditorPropertyArray::_resource_selected), CONNECT_DEFERRED);
+				}
 				new_prop->set_h_size_flags(SIZE_EXPAND_FILL);
 				new_prop->set_read_only(is_read_only());
 				slot.prop->add_sibling(new_prop, false);
@@ -1393,6 +1400,9 @@ void EditorPropertyDictionary::update_property() {
 				new_prop->set_use_folding(is_using_folding());
 				new_prop->connect(SNAME("property_changed"), callable_mp(this, &EditorPropertyDictionary::_property_changed));
 				new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyDictionary::_object_id_selected));
+				if (value_type == Variant::OBJECT) {
+					new_prop->connect("resource_selected", callable_mp(this, &EditorPropertyDictionary::_resource_selected), CONNECT_DEFERRED);
+				}
 				new_prop->set_h_size_flags(SIZE_EXPAND_FILL);
 				if (slot.index != EditorPropertyDictionaryObject::NEW_KEY_INDEX && slot.index != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
 					new_prop->set_draw_label(false);
@@ -1441,6 +1451,10 @@ void EditorPropertyDictionary::_remove_pressed(int p_slot_index) {
 
 void EditorPropertyDictionary::_object_id_selected(const StringName &p_property, ObjectID p_id) {
 	emit_signal(SNAME("object_id_selected"), p_property, p_id);
+}
+
+void EditorPropertyDictionary::_resource_selected(const String &p_path, Ref<Resource> p_resource) {
+	emit_signal(SNAME("resource_selected"), get_edited_property(), p_resource);
 }
 
 void EditorPropertyDictionary::_notification(int p_what) {

--- a/editor/inspector/editor_properties_array_dict.h
+++ b/editor/inspector/editor_properties_array_dict.h
@@ -139,6 +139,8 @@ class EditorPropertyArray : public EditorProperty {
 	void _reorder_button_up();
 	void _create_new_property_slot();
 
+	void _resource_selected(const String &p_path, Ref<Resource> p_resource);
+
 	Node *get_base_node();
 
 protected:
@@ -243,6 +245,7 @@ class EditorPropertyDictionary : public EditorProperty {
 	void _page_changed(int p_page);
 	void _edit_pressed();
 	void _property_changed(const String &p_property, Variant p_value, const String &p_name = "", bool p_changing = false);
+	void _resource_selected(const String &p_path, Ref<Resource> p_resource);
 	void _change_type(Object *p_button, int p_slot_index);
 	void _change_type_menu(int p_index);
 


### PR DESCRIPTION
Fixes #91473 - First PR (first time using C++)

Fixes Inspector not opening Resource from inside Array or Dictionary when
clicking "Edit", by properly signaling `resource_selected`.

When clicking "Edit" on a Resource in the Inspector, the `resource_selected`
signal is emitted. This works correctly when the Resource is a standalone
exported property, and the signal reaches `EditorInspector::_resource_selected`.

However, when the Resource is stored inside an Array or Dictionary, the signal
was not reaching the EditorInspector, because it was blocked by the container
property (Array/Dictionary) in between.

This fix forwards the `resource_selected` signal from the nested Resource
through the container (Array or Dictionary), up to the Inspector, allowing it
to display the selected Resource as expected.