### PR TITLE
Set current directory when using "Save Branch as Scene..."

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1182,6 +1182,11 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			new_scene_from_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
+			if (determine_path_automatically) {
+				new_scene_from_dialog->set_current_dir(editor_data->get_edited_scene_root()->get_scene_file_path().get_base_dir());
+			} else {
+				determine_path_automatically = true;
+			}
 
 			List<String> extensions;
 			Ref<PackedScene> sd = memnew(PackedScene);
@@ -4069,6 +4074,7 @@ void SceneTreeDock::set_filter(const String &p_filter) {
 
 void SceneTreeDock::save_branch_to_file(const String &p_directory) {
 	new_scene_from_dialog->set_current_dir(p_directory);
+	determine_path_automatically = false;
 	_tool_selected(TOOL_NEW_SCENE_FROM);
 }
 

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -290,6 +290,7 @@ class SceneTreeDock : public VBoxContainer {
 
 	bool profile_allow_editing = true;
 	bool profile_allow_script_editing = true;
+	bool determine_path_automatically = true;
 
 	static void _update_configuration_warning();
 


### PR DESCRIPTION
When saving a tree of nodes as a scene from an existing scene, usually you want to save them next to the existing scene. This PR adds a call to `set_current_dir` which sets this, defaulting the file dialog to that directory.

I tested that this works for both saved scenes and unsaved scenes. For the latter case, it does nothing, the same as master.

<img width="360" alt="Screenshot 2025-05-05 at 1 44 11 PM" src="https://github.com/user-attachments/assets/84dcdfb5-d6b5-45b7-9b4c-320413e6ce4a" />
