### PR TITLE
Physics Interpolation - Fix XR Nodes to work with `SceneTreeFTI`

### DIFF
--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -72,36 +72,13 @@ void XRCamera3D::_removed_tracker(const StringName &p_tracker_name, int p_tracke
 
 void XRCamera3D::_pose_changed(const Ref<XRPose> &p_pose) {
 	if (p_pose->get_name() == pose_name) {
-		Node3D *parent = Object::cast_to<Node3D>(get_parent());
-
-		if (is_inside_tree() && parent && parent->is_physics_interpolated_and_enabled() && !is_set_as_top_level() && !is_physics_interpolated()) {
-			pose_offset = p_pose->get_adjusted_transform();
-		} else {
-			set_transform(p_pose->get_adjusted_transform());
-		}
+		set_transform(p_pose->get_adjusted_transform());
 	}
 }
 
-void XRCamera3D::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
-			if (!Engine::get_singleton()->is_editor_hint()) {
-				set_desired_process_modes(true, false);
-			}
-		} break;
-
-		case NOTIFICATION_INTERNAL_PROCESS: {
-			if (!is_inside_tree() || is_physics_interpolated() || Engine::get_singleton()->is_editor_hint()) {
-				break;
-			}
-
-			Node3D *parent = Object::cast_to<Node3D>(get_parent());
-
-			if (parent && parent->is_physics_interpolated_and_enabled() && !is_set_as_top_level()) {
-				set_global_transform(parent->get_global_transform_interpolated() * pose_offset);
-			}
-		} break;
-	}
+void XRCamera3D::_physics_interpolated_changed() {
+	Camera3D::_physics_interpolated_changed();
+	update_configuration_warnings();
 }
 
 PackedStringArray XRCamera3D::get_configuration_warnings() const {
@@ -114,6 +91,10 @@ PackedStringArray XRCamera3D::get_configuration_warnings() const {
 		if (parent && origin == nullptr) {
 			warnings.push_back(RTR("XRCamera3D may not function as expected without an XROrigin3D node as its parent."));
 		};
+
+		if (is_physics_interpolated()) {
+			warnings.push_back(RTR("XRCamera3D should have physics_interpolation_mode set to OFF in order to avoid jitter."));
+		}
 	}
 
 	return warnings;
@@ -431,13 +412,7 @@ void XRNode3D::_removed_tracker(const StringName &p_tracker_name, int p_tracker_
 
 void XRNode3D::_pose_changed(const Ref<XRPose> &p_pose) {
 	if (p_pose.is_valid() && p_pose->get_name() == pose_name) {
-		Node3D *parent = Object::cast_to<Node3D>(get_parent());
-
-		if (is_inside_tree() && parent && parent->is_physics_interpolated_and_enabled() && !is_set_as_top_level() && !is_physics_interpolated()) {
-			pose_offset = p_pose->get_adjusted_transform();
-		} else {
-			set_transform(p_pose->get_adjusted_transform());
-		}
+		set_transform(p_pose->get_adjusted_transform());
 		_set_has_tracking_data(p_pose->get_has_tracking_data());
 	}
 }
@@ -477,26 +452,8 @@ void XRNode3D::_update_visibility() {
 	}
 }
 
-void XRNode3D::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
-			if (!Engine::get_singleton()->is_editor_hint()) {
-				set_process_internal(true);
-			}
-		} break;
-
-		case NOTIFICATION_INTERNAL_PROCESS: {
-			if (!is_inside_tree() || is_physics_interpolated() || Engine::get_singleton()->is_editor_hint()) {
-				break;
-			}
-
-			Node3D *parent = Object::cast_to<Node3D>(get_parent());
-
-			if (parent && parent->is_physics_interpolated_and_enabled() && !is_set_as_top_level()) {
-				set_global_transform(parent->get_global_transform_interpolated() * pose_offset);
-			}
-		} break;
-	}
+void XRNode3D::_physics_interpolated_changed() {
+	update_configuration_warnings();
 }
 
 XRNode3D::XRNode3D() {
@@ -539,6 +496,10 @@ PackedStringArray XRNode3D::get_configuration_warnings() const {
 
 		if (pose_name == "") {
 			warnings.push_back(RTR("No pose is set."));
+		}
+
+		if (is_physics_interpolated()) {
+			warnings.push_back(RTR("XRNode3D should have physics_interpolation_mode set to OFF in order to avoid jitter."));
 		}
 	}
 

--- a/scene/3d/xr/xr_nodes.h
+++ b/scene/3d/xr/xr_nodes.h
@@ -46,14 +46,13 @@ protected:
 	StringName tracker_name = "head";
 	StringName pose_name = SceneStringName(default_);
 	Ref<XRPositionalTracker> tracker;
-	Transform3D pose_offset;
 
 	void _bind_tracker();
 	void _unbind_tracker();
 	void _changed_tracker(const StringName &p_tracker_name, int p_tracker_type);
 	void _removed_tracker(const StringName &p_tracker_name, int p_tracker_type);
 	void _pose_changed(const Ref<XRPose> &p_pose);
-	void _notification(int p_what);
+	virtual void _physics_interpolated_changed() override;
 
 public:
 	PackedStringArray get_configuration_warnings() const override;
@@ -81,7 +80,6 @@ private:
 	StringName pose_name = SceneStringName(default_);
 	bool has_tracking_data = false;
 	bool show_when_tracked = false;
-	Transform3D pose_offset;
 
 protected:
 	Ref<XRPositionalTracker> tracker;
@@ -98,7 +96,7 @@ protected:
 	void _set_has_tracking_data(bool p_has_tracking_data);
 
 	void _update_visibility();
-	void _notification(int p_what);
+	virtual void _physics_interpolated_changed() override;
 
 public:
 	void _validate_property(PropertyInfo &p_property) const;


### PR DESCRIPTION
Fixes physics interpolation on XR Nodes being broken caused by this PR: https://github.com/godotengine/godot/pull/104269

This PR mainly removes the workarounds for `XRCamera3D` and `XRNode3D` of my previous PR (https://github.com/godotengine/godot/pull/103233), leaves the fix for `XROrigin3D` and adds warnings to let users know they shouldn't force XR Nodes to be interpolated.
This ultimately makes physics interpolation work flawlessly on XR thanks to the amazing work by @lawnjelly on his `SceneTreeFTI`.

Here is the current behavior on `master` branch:

https://github.com/user-attachments/assets/bc02abbf-3b00-483a-ab42-43091779ddc5

And here is the result of this PR:

https://github.com/user-attachments/assets/885e1670-8c98-4a88-8627-97f750fb5c65

I've used the existing [`openxr_character_centric_movement`](https://github.com/godotengine/godot-demo-projects/tree/master/xr/openxr_character_centric_movement) demo as MRP.