### PR TITLE
Use a type-hinted dictionary for AnimationLibrary's `libraries` property

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -108,7 +108,7 @@ bool AnimationMixer::_get(const StringName &p_name, Variant &r_ret) const {
 
 void AnimationMixer::_get_property_list(List<PropertyInfo> *p_list) const {
 	List<PropertyInfo> anim_names;
-	anim_names.push_back(PropertyInfo(Variant::DICTIONARY, PNAME("libraries")));
+	anim_names.push_back(PropertyInfo(Variant::DICTIONARY, PNAME("libraries"), PROPERTY_HINT_DICTIONARY_TYPE, "StringName;AnimationLibrary"));
 	for (const PropertyInfo &E : anim_names) {
 		p_list->push_back(E);
 	}


### PR DESCRIPTION
This is done at a editor property hint level so that it doesn't break compatibility. In other words, the actual `libraries` property exposed to the scripting API remains an untyped Dictionary.

Thanks to @efeagca55 for the advice about using a Dictionary type hint to preserve compatibility :slightly_smiling_face:

- This closes https://github.com/godotengine/godot-proposals/issues/12158.
