### PR TITLE
ENet: Expose the `check_events` method to GDScript

### DIFF
--- a/modules/enet/doc_classes/ENetConnection.xml
+++ b/modules/enet/doc_classes/ENetConnection.xml
@@ -34,6 +34,14 @@
 				Limits the maximum allowed channels of future incoming connections.
 			</description>
 		</method>
+		<method name="check_events">
+			<return type="Array" />
+			<description>
+				Receive the next queued event from the host since the last call to [method service]. The returned [Array] will have 4 elements. An [enum EventType], the [ENetPacketPeer] which generated the event, the event associated data (if any), the event associated channel (if any). If the generated event is [constant EVENT_RECEIVE], the received packet will be queued to the associated [ENetPacketPeer].
+				For each call to [method service] within a frame/tick, call this method until queued events have been exhausted. This is typically used by the caller to handle all queued events without needing to repeatedly call [method service] within a frame/tick (which would potentially cause more events to be enqueued).
+				[b]Note:[/b] This method may be called on either end involved in the event (sending and receiving hosts).
+			</description>
+		</method>
 		<method name="compress">
 			<return type="void" />
 			<param index="0" name="mode" type="int" enum="ENetConnection.CompressionMode" />
@@ -178,7 +186,7 @@
 			[url=https://facebook.github.io/zstd/]Zstandard[/url] compression. Note that this algorithm is not very efficient on packets smaller than 4 KB. Therefore, it's recommended to use other compression algorithms in most cases.
 		</constant>
 		<constant name="EVENT_ERROR" value="-1" enum="EventType">
-			An error occurred during [method service]. You will likely need to [method destroy] the host and recreate it.
+			An error occurred during [method service] or [method check_events]. You will likely need to [method destroy] the host and recreate it.
 		</constant>
 		<constant name="EVENT_NONE" value="0" enum="EventType">
 			No event occurred within the specified time limit.

--- a/modules/enet/enet_connection.cpp
+++ b/modules/enet/enet_connection.cpp
@@ -330,6 +330,17 @@ Array ENetConnection::_service(int p_timeout) {
 	return out;
 }
 
+Array ENetConnection::_check_events() {
+	Event event;
+	EventType event_type = EVENT_NONE;
+	check_events(event_type, event);
+	Array out = { event_type, event.peer, event.data, event.channel_id };
+	if (event.packet && event.peer.is_valid()) {
+		event.peer->_queue_packet(event.packet);
+	}
+	return out;
+}
+
 void ENetConnection::_broadcast(int p_channel, PackedByteArray p_packet, int p_flags) {
 	ERR_FAIL_NULL_MSG(host, "The ENetConnection instance isn't currently active.");
 	ERR_FAIL_COND_MSG(p_channel < 0 || p_channel > (int)host->channelLimit, "Invalid channel");
@@ -377,6 +388,7 @@ void ENetConnection::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("destroy"), &ENetConnection::destroy);
 	ClassDB::bind_method(D_METHOD("connect_to_host", "address", "port", "channels", "data"), &ENetConnection::connect_to_host, DEFVAL(0), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("service", "timeout"), &ENetConnection::_service, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("check_events"), &ENetConnection::_check_events);
 	ClassDB::bind_method(D_METHOD("flush"), &ENetConnection::flush);
 	ClassDB::bind_method(D_METHOD("bandwidth_limit", "in_bandwidth", "out_bandwidth"), &ENetConnection::bandwidth_limit, DEFVAL(0), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("channel_limit", "limit"), &ENetConnection::channel_limit);

--- a/modules/enet/enet_connection.h
+++ b/modules/enet/enet_connection.h
@@ -84,6 +84,7 @@ private:
 	EventType _parse_event(const ENetEvent &p_event, Event &r_event);
 	Error _create(ENetAddress *p_address, int p_max_peers, int p_max_channels, int p_in_bandwidth, int p_out_bandwidth);
 	Array _service(int p_timeout = 0);
+	Array _check_events();
 	void _broadcast(int p_channel, PackedByteArray p_packet, int p_flags);
 	TypedArray<ENetPacketPeer> _get_peers();
 


### PR DESCRIPTION
`ENetConnection::check_events` was added in https://github.com/godotengine/godot/pull/53129 but was not exposed to GDScript. This pull request exposes it to GDScript so that users of the low-level networking API (i.e. `ENetConnection`) can correctly process events within a tick.

Fixes https://github.com/godotengine/godot-proposals/issues/12376.