### PR TITLE
Allow RigidBody2D freeze while flushing queries

### DIFF
--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -567,7 +567,6 @@ RID GodotPhysicsServer2D::body_get_space(RID p_body) const {
 void GodotPhysicsServer2D::body_set_mode(RID p_body, BodyMode p_mode) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
-	FLUSH_QUERY_CHECK(body);
 
 	body->set_mode(p_mode);
 }


### PR DESCRIPTION
I noticed that 3d physics [allows](https://github.com/godotengine/godot/blob/master/modules/godot_physics_3d/godot_physics_server_3d.cpp#L478) setting/unsetting freeze on rigidbodies during query flushes, but 2d physics doesn't. After removing the check I can now change it inside a `body_entered` event or similar and it works without any issues. Is there any context I am missing though?

- Fixes #50876
- Fixes #85371