### PR TITLE
Improve zoom performance in `Script` and `Shader` editors

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1813,9 +1813,6 @@ void CodeTextEditor::set_zoom_factor(float p_zoom_factor) {
 
 	zoom_button->set_text(itos(Math::round(zoom_factor * 100)) + " %");
 
-	if (text_editor->has_theme_font_size_override(SceneStringName(font_size))) {
-		text_editor->remove_theme_font_size_override(SceneStringName(font_size));
-	}
 	text_editor->add_theme_font_size_override(SceneStringName(font_size), new_font_size);
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4808,7 +4808,7 @@ void EditorNode::_update_recent_scenes() {
 	recent_scenes->clear();
 
 	if (rc.size() == 0) {
-		recent_scenes->add_item(TTR("No Recent Scenes"), -1);
+		recent_scenes->add_item(TTRC("No Recent Scenes"), -1);
 		recent_scenes->set_item_disabled(-1, true);
 	} else {
 		String path;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2625,7 +2625,8 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 	CodeTextEditor *cte = se->get_code_editor();
 	if (cte) {
 		cte->set_zoom_factor(zoom_factor);
-		cte->connect("zoomed", callable_mp(this, &ScriptEditor::_set_zoom_factor));
+		cte->connect("zoomed", callable_mp(this, &ScriptEditor::_set_script_zoom_factor));
+		cte->connect(SceneStringName(visibility_changed), callable_mp(this, &ScriptEditor::_update_code_editor_zoom_factor).bind(cte));
 	}
 
 	//test for modification, maybe the script was not edited but was loaded
@@ -3558,7 +3559,7 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 		}
 	}
 
-	_set_zoom_factor(p_layout->get_value("ScriptEditor", "zoom_factor", 1.0f));
+	_set_script_zoom_factor(p_layout->get_value("ScriptEditor", "zoom_factor", 1.0f));
 
 	restoring_layout = false;
 
@@ -4057,21 +4058,17 @@ void ScriptEditor::_on_find_in_files_modified_files(const PackedStringArray &pat
 	_update_modified_scripts_for_external_editor();
 }
 
-void ScriptEditor::_set_zoom_factor(float p_zoom_factor) {
+void ScriptEditor::_set_script_zoom_factor(float p_zoom_factor) {
 	if (zoom_factor == p_zoom_factor) {
 		return;
 	}
+
 	zoom_factor = p_zoom_factor;
-	for (int i = 0; i < tab_container->get_tab_count(); i++) {
-		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
-		if (se) {
-			CodeTextEditor *cte = se->get_code_editor();
-			if (cte) {
-				if (zoom_factor != cte->get_zoom_factor()) {
-					cte->set_zoom_factor(zoom_factor);
-				}
-			}
-		}
+}
+
+void ScriptEditor::_update_code_editor_zoom_factor(CodeTextEditor *p_code_text_editor) {
+	if (p_code_text_editor && p_code_text_editor->is_visible_in_tree() && zoom_factor != p_code_text_editor->get_zoom_factor()) {
+		p_code_text_editor->set_zoom_factor(zoom_factor);
 	}
 }
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -537,7 +537,8 @@ class ScriptEditor : public PanelContainer {
 	void _on_find_in_files_modified_files(const PackedStringArray &paths);
 	void _on_find_in_files_close_button_clicked();
 
-	void _set_zoom_factor(float p_zoom_factor);
+	void _set_script_zoom_factor(float p_zoom_factor);
+	void _update_code_editor_zoom_factor(CodeTextEditor *p_code_text_editor);
 
 	void _window_changed(bool p_visible);
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -188,6 +188,7 @@ void ShaderEditorPlugin::edit(Object *p_object) {
 		if (cte) {
 			cte->set_zoom_factor(text_shader_zoom_factor);
 			cte->connect("zoomed", callable_mp(this, &ShaderEditorPlugin::_set_text_shader_zoom_factor));
+			cte->connect(SceneStringName(visibility_changed), callable_mp(this, &ShaderEditorPlugin::_update_shader_editor_zoom_factor).bind(cte));
 		}
 
 		if (text_shader_editor->get_top_bar()) {
@@ -768,17 +769,16 @@ void ShaderEditorPlugin::_window_changed(bool p_visible) {
 }
 
 void ShaderEditorPlugin::_set_text_shader_zoom_factor(float p_zoom_factor) {
-	if (text_shader_zoom_factor != p_zoom_factor) {
-		text_shader_zoom_factor = p_zoom_factor;
-		for (const EditedShader &edited_shader : edited_shaders) {
-			TextShaderEditor *text_shader_editor = Object::cast_to<TextShaderEditor>(edited_shader.shader_editor);
-			if (text_shader_editor) {
-				CodeTextEditor *cte = text_shader_editor->get_code_editor();
-				if (cte && cte->get_zoom_factor() != text_shader_zoom_factor) {
-					cte->set_zoom_factor(text_shader_zoom_factor);
-				}
-			}
-		}
+	if (text_shader_zoom_factor == p_zoom_factor) {
+		return;
+	}
+
+	text_shader_zoom_factor = p_zoom_factor;
+}
+
+void ShaderEditorPlugin::_update_shader_editor_zoom_factor(CodeTextEditor *p_shader_editor) const {
+	if (p_shader_editor && p_shader_editor->is_visible_in_tree() && text_shader_zoom_factor != p_shader_editor->get_zoom_factor()) {
+		p_shader_editor->set_zoom_factor(text_shader_zoom_factor);
 	}
 }
 

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -32,6 +32,7 @@
 
 #include "editor/plugins/editor_plugin.h"
 
+class CodeTextEditor;
 class HSplitContainer;
 class ItemList;
 class MenuButton;
@@ -125,6 +126,8 @@ class ShaderEditorPlugin : public EditorPlugin {
 	void _window_changed(bool p_visible);
 
 	void _set_text_shader_zoom_factor(float p_zoom_factor);
+	void _update_shader_editor_zoom_factor(CodeTextEditor *p_shader_editor) const;
+
 	void _switch_to_editor(ShaderEditor *p_editor);
 
 protected:


### PR DESCRIPTION
This improves the zoom performance **when you have multiple (previously) opened scripts** in the script/shader text editors. This was done by deferring the expensive `set_zoom_factor` (and subsequent cache invalidation) function calls to only be called when you open a script. 

This was previously updated **N * scroll wheel spins** times for **each script** you had opened; this was done to keep the zoom percentage in sync between scripts, but is now updated and stored in the script/shader editor plugins instead.

> [!WARNING]
>Zooming can still stutter on bigger and/or first-time opened scripts due to cache invalidation within that single code editor instance. Further work could be done to improve this.

| Before | After |
| ------------- | ------------- |
|  <video src=https://github.com/user-attachments/assets/7d11a10c-b5e1-4fb8-a69d-34b721ac5102></video> |  <video src=https://github.com/user-attachments/assets/b844c9b8-1c00-4fb9-a7da-ba0966adb125></video> |