### PR TITLE
Remove emitting of error in `JoltBody3D::_exit_all_areas`

### DIFF
--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -423,7 +423,9 @@ void JoltBody3D::_destroy_joint_constraints() {
 }
 
 void JoltBody3D::_exit_all_areas() {
-	ERR_FAIL_COND(!in_space());
+	if (!in_space()) {
+		return;
+	}
 
 	for (JoltArea3D *area : areas) {
 		area->body_exited(jolt_body->GetID(), false);


### PR DESCRIPTION
As reported in https://github.com/godotengine/godot/pull/105748#issuecomment-2852003232.

This `ERR_FAIL_COND` check (which wasn't there before #105748) was a bit overzealous, as its condition was likely to be `true` under perfectly valid circumstances, in which case we still need to early-out, but we don't need to emit any error about it.