### PR TITLE
register_editor_types: Fix `DISABLE_DEPREACTED` typo

### DIFF
--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -254,7 +254,7 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<ThemeEditorPlugin>();
 	EditorPlugins::add_by_type<ToolButtonEditorPlugin>();
 	EditorPlugins::add_by_type<VoxelGIEditorPlugin>();
-#ifndef DISABLE_DEPREACTED
+#ifndef DISABLE_DEPRECATED
 	EditorPlugins::add_by_type<SkeletonIK3DEditorPlugin>();
 #endif
 


### PR DESCRIPTION
Issue #106093 contained a typo, not properly guarding `SkeletonIK3DEditorPlugin`