### PR TITLE
Fix tests that fail when alone

### DIFF
--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -48,8 +48,10 @@ TEST_SUITE("[Modules][GDScript]") {
 		REQUIRE_MESSAGE(fail_count == 0, "All GDScript tests should pass.");
 	}
 }
+#endif // TOOLS_ENABLED
 
 TEST_CASE("[Modules][GDScript] Load source code dynamically and run it") {
+	GDScriptLanguage::get_singleton()->init();
 	Ref<GDScript> gdscript = memnew(GDScript);
 	gdscript->set_source_code(R"(
 extends RefCounted
@@ -69,7 +71,6 @@ func _init():
 	ref_counted->set_script(gdscript);
 	CHECK_MESSAGE(int(ref_counted->get_meta("result")) == 42, "The script should assign object metadata successfully.");
 }
-#endif // TOOLS_ENABLED
 
 TEST_CASE("[Modules][GDScript] Validate built-in API") {
 	GDScriptLanguage *lang = GDScriptLanguage::get_singleton();

--- a/tests/core/config/test_project_settings.h
+++ b/tests/core/config/test_project_settings.h
@@ -44,28 +44,25 @@ public:
 
 namespace TestProjectSettings {
 
-// TODO: Handle some cases failing on release builds. See: https://github.com/godotengine/godot/pull/88452
-#ifdef TOOLS_ENABLED
 TEST_CASE("[ProjectSettings] Get existing setting") {
-	CHECK(ProjectSettings::get_singleton()->has_setting("application/config/name"));
+	CHECK(ProjectSettings::get_singleton()->has_setting("application/run/main_scene"));
 
-	Variant variant = ProjectSettings::get_singleton()->get_setting("application/config/name");
+	Variant variant = ProjectSettings::get_singleton()->get_setting("application/run/main_scene");
 	CHECK_EQ(variant.get_type(), Variant::STRING);
 
 	String name = variant;
-	CHECK_EQ(name, "GDScript Integration Test Suite");
+	CHECK_EQ(name, String());
 }
 
 TEST_CASE("[ProjectSettings] Default value is ignored if setting exists") {
-	CHECK(ProjectSettings::get_singleton()->has_setting("application/config/name"));
+	CHECK(ProjectSettings::get_singleton()->has_setting("application/run/main_scene"));
 
-	Variant variant = ProjectSettings::get_singleton()->get_setting("application/config/name", "SomeDefaultValue");
+	Variant variant = ProjectSettings::get_singleton()->get_setting("application/run/main_scene", "SomeDefaultValue");
 	CHECK_EQ(variant.get_type(), Variant::STRING);
 
 	String name = variant;
-	CHECK_EQ(name, "GDScript Integration Test Suite");
+	CHECK_EQ(name, String());
 }
-#endif // TOOLS_ENABLED
 
 TEST_CASE("[ProjectSettings] Non existing setting is null") {
 	CHECK_FALSE(ProjectSettings::get_singleton()->has_setting("not_existing_setting"));


### PR DESCRIPTION
- related #88452

Certain tests fail when by themselves, since they depend on other tests.
Use these args to test:
`--test --tc="[ProjectSettings]*"`, `--test --tc="[Modules][GDScript] Load source code dynamically and run it"`

I tested on release build and this seems to fix the issues from #88452 for these 3 tests, the other one still has an issue in non-editor builds.

For `[ProjectSettings] Get existing setting` and `[ProjectSettings] Default value is ignored if setting exists`, they expect to be ran after the `[Modules][GDScript]` `Script compilation and runtime` test, which modifies the ProjectSettings.
I changed them to use a different project setting that was untouched by that test.

For `[Modules][GDScript] Load source code dynamically and run it`, the GDScript fails during compilation with an error `Compile Error: GDScript bug (please report): Native class "RefCounted" not found.`.
This is because the language wasn't initialized for this test.