### PR TITLE
[.NET] Avoid heap alloc when using StringNames as key in a Dictionary

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
@@ -161,7 +161,7 @@ namespace Godot
 
         public override int GetHashCode()
         {
-            return NativeValue.GetHashCode();
+            return NativeValue.DangerousSelfRef.GetHashCode();
         }
     }
 }


### PR DESCRIPTION
 `StringNames` in Godot C# are IEquatable, and overrides `GetHashCode()`, which calls `godot_string_name.movable`'s version of that method, which was not overridden. This led to heap allocations when e.g. calling the indexer in a Dictionary with `StringName` type as Key.

This PR just adds the (assuming) missing method, which seems to fix the issue.