### PR TITLE
macOS: Additional improvements and fixes for embedded window support

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -287,6 +287,7 @@ bool profile_gpu = false;
 // Constants.
 
 static const String NULL_DISPLAY_DRIVER("headless");
+static const String EMBEDDED_DISPLAY_DRIVER("embedded");
 static const String NULL_AUDIO_DRIVER("Dummy");
 
 // The length of the longest column in the command-line help we should align to
@@ -1396,6 +1397,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 			audio_driver = NULL_AUDIO_DRIVER;
 			display_driver = NULL_DISPLAY_DRIVER;
+
+		} else if (arg == "--embedded") { // Enable embedded mode.
+
+			display_driver = EMBEDDED_DISPLAY_DRIVER;
 
 		} else if (arg == "--log-file") { // write to log file
 

--- a/platform/macos/editor/embedded_process_macos.h
+++ b/platform/macos/editor/embedded_process_macos.h
@@ -33,11 +33,13 @@
 #include "editor/plugins/embedded_process.h"
 
 class DisplayServerMacOS;
+class EmbeddedProcessMacOS;
 
-class LayerHost : public Control {
+class LayerHost final : public Control {
 	GDCLASS(LayerHost, Control);
 
 	ScriptEditorDebugger *script_debugger = nullptr;
+	EmbeddedProcessMacOS *process = nullptr;
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
@@ -48,6 +50,8 @@ public:
 	void set_script_debugger(ScriptEditorDebugger *p_debugger) {
 		script_debugger = p_debugger;
 	}
+
+	LayerHost(EmbeddedProcessMacOS *p_process);
 };
 
 class EmbeddedProcessMacOS final : public EmbeddedProcessBase {
@@ -69,8 +73,10 @@ class EmbeddedProcessMacOS final : public EmbeddedProcessBase {
 
 	// Embedded process state.
 
-	/// @brief The current mouse mode of the embedded process.
+	// The last mouse mode sent by the embedded process.
 	DisplayServer::MouseMode mouse_mode = DisplayServer::MOUSE_MODE_VISIBLE;
+
+	// Helper functions.
 
 	void _try_embed_process();
 	void update_embedded_process() const;
@@ -81,7 +87,9 @@ protected:
 
 public:
 	// MARK: - Message Handlers
+
 	void set_context_id(uint32_t p_context_id);
+	void mouse_set_mode(DisplayServer::MouseMode p_mode);
 
 	uint32_t get_context_id() const { return context_id; }
 	void set_script_debugger(ScriptEditorDebugger *p_debugger) override;
@@ -90,7 +98,7 @@ public:
 		return embedding_state == EmbeddingState::IN_PROGRESS;
 	}
 
-	bool is_embedding_completed() const override {
+	_FORCE_INLINE_ bool is_embedding_completed() const override {
 		return embedding_state == EmbeddingState::COMPLETED;
 	}
 
@@ -103,8 +111,10 @@ public:
 
 	Rect2i get_adjusted_embedded_window_rect(const Rect2i &p_rect) const override;
 
-	void mouse_set_mode(DisplayServer::MouseMode p_mode);
 	_FORCE_INLINE_ LayerHost *get_layer_host() const { return layer_host; }
+
+	// MARK: - Embedded process state
+	_FORCE_INLINE_ DisplayServer::MouseMode get_mouse_mode() const { return mouse_mode; }
 
 	EmbeddedProcessMacOS();
 };

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -74,7 +74,6 @@ int main(int argc, char **argv) {
 
 		if (strcmp("--embedded", argv[i]) == 0) {
 			is_embedded = true;
-			continue;
 		}
 
 		args.ptr()[argsc] = argv[i];


### PR DESCRIPTION
This PR includes the following PR feedback and improvements for #105884

- Disables embedded support in single-window mode, as it won't work properly, given the macOS window server composites the embedded layer over the Godot rendered content.
- Fixes for mouse capture, particularly when debugging
- Improves the launch arguments, so `--embedded` is all that is required, and works like an alias to `--display-server embedded`.