### PR TITLE
Remove redundant `line_spacing` editor setting

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1560,9 +1560,6 @@
 		<member name="text_editor/theme/highlighting/word_highlighted_color" type="Color" setter="" getter="">
 			The script editor's color for words highlighted by selecting them. Only visible if [member text_editor/appearance/caret/highlight_all_occurrences] is [code]true[/code].
 		</member>
-		<member name="text_editor/theme/line_spacing" type="int" setter="" getter="">
-			The vertical line separation used in text editors, in pixels.
-		</member>
 		<member name="version_control/ssh_private_key_path" type="String" setter="" getter="">
 			Path to private SSH key file for the editor's Version Control integration credentials.
 		</member>

--- a/editor/editor_native_shader_source_visualizer.cpp
+++ b/editor/editor_native_shader_source_visualizer.cpp
@@ -98,7 +98,7 @@ void EditorNativeShaderSourceVisualizer::_inspect_shader(RID p_shader) {
 			code_edit->set_syntax_highlighter(syntax_highlighter);
 			code_edit->add_theme_font_override(SceneStringName(font), get_theme_font("source", EditorStringName(EditorFonts)));
 			code_edit->add_theme_font_size_override(SceneStringName(font_size), get_theme_font_size("source_size", EditorStringName(EditorFonts)));
-			code_edit->add_theme_constant_override("line_spacing", EDITOR_GET("text_editor/theme/line_spacing"));
+			code_edit->add_theme_constant_override("line_spacing", EDITOR_GET("text_editor/appearance/whitespace/line_spacing"));
 
 			// Appearance: Caret
 			code_edit->set_caret_type((TextEdit::CaretType)EDITOR_GET("text_editor/appearance/caret/type").operator int());

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -676,7 +676,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	/* Text editor */
 
 	// Theme
-	_initial_set("text_editor/theme/line_spacing", 6);
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_ENUM, "text_editor/theme/color_theme", "Default", "Default,Godot 2,Custom")
 
 	// Theme: Highlighting
@@ -1220,6 +1219,7 @@ void EditorSettings::_remove_deprecated_settings() {
 	erase("network/connection/engine_version_update_mode");
 	erase("run/output/always_open_output_on_play");
 	erase("run/output/always_close_output_on_stop");
+	erase("text_editor/theme/line_spacing"); // See GH-106137.
 }
 #endif
 


### PR DESCRIPTION
The setting `text_editor/theme/line_spacing` was only used in this one code location.
Meanwhile, `text_editor/appearance/whitespace/line_spacing` is used everywhere else.

Seems best to just merge them and remove the one that only affects the native shader code viewer :D

Code changes are untested... 🙏