### PR TITLE
Improve script backtrace print in crash handlers

### DIFF
--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -67,9 +67,8 @@ static void handle_crash(int sig) {
 	String _execpath = OS::get_singleton()->get_executable_path();
 
 	String msg;
-	const ProjectSettings *proj_settings = ProjectSettings::get_singleton();
-	if (proj_settings) {
-		msg = proj_settings->get("debug/settings/crash_handler/message");
+	if (ProjectSettings::get_singleton()) {
+		msg = GLOBAL_GET("debug/settings/crash_handler/message");
 	}
 
 	// Tell MainLoop about the crash. This can be handled by users too in Node.
@@ -144,21 +143,18 @@ static void handle_crash(int sig) {
 
 		free(strings);
 	}
-	print_error("-- END OF BACKTRACE --");
+	print_error("-- END OF C++ BACKTRACE --");
 	print_error("================================================================");
 
-	Vector<Ref<ScriptBacktrace>> script_backtraces;
 	if (ScriptServer::are_languages_initialized()) {
-		script_backtraces = ScriptServer::capture_script_backtraces(false);
-	}
-	if (!script_backtraces.is_empty()) {
+		Vector<Ref<ScriptBacktrace>> script_backtraces = ScriptServer::capture_script_backtraces(false);
 		for (const Ref<ScriptBacktrace> &backtrace : script_backtraces) {
 			if (!backtrace->is_empty()) {
 				print_error(backtrace->format());
+				print_error(vformat("-- END OF %s BACKTRACE --", backtrace->get_language_name().to_upper()));
+				print_error("================================================================");
 			}
 		}
-		print_error("-- END OF SCRIPT BACKTRACE --");
-		print_error("================================================================");
 	}
 
 	// Abort to pass the error to the OS

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -90,9 +90,8 @@ static void handle_crash(int sig) {
 	String _execpath = OS::get_singleton()->get_executable_path();
 
 	String msg;
-	const ProjectSettings *proj_settings = ProjectSettings::get_singleton();
-	if (proj_settings) {
-		msg = proj_settings->get("debug/settings/crash_handler/message");
+	if (ProjectSettings::get_singleton()) {
+		msg = GLOBAL_GET("debug/settings/crash_handler/message");
 	}
 
 	// Tell MainLoop about the crash. This can be handled by users too in Node.
@@ -174,21 +173,18 @@ static void handle_crash(int sig) {
 
 		free(strings);
 	}
-	print_error("-- END OF BACKTRACE --");
+	print_error("-- END OF C++ BACKTRACE --");
 	print_error("================================================================");
 
-	Vector<Ref<ScriptBacktrace>> script_backtraces;
 	if (ScriptServer::are_languages_initialized()) {
-		script_backtraces = ScriptServer::capture_script_backtraces(false);
-	}
-	if (!script_backtraces.is_empty()) {
+		Vector<Ref<ScriptBacktrace>> script_backtraces = ScriptServer::capture_script_backtraces(false);
 		for (const Ref<ScriptBacktrace> &backtrace : script_backtraces) {
 			if (!backtrace->is_empty()) {
 				print_error(backtrace->format());
+				print_error(vformat("-- END OF %s BACKTRACE --", backtrace->get_language_name().to_upper()));
+				print_error("================================================================");
 			}
 		}
-		print_error("-- END OF SCRIPT BACKTRACE --");
-		print_error("================================================================");
 	}
 
 	// Abort to pass the error to the OS

--- a/platform/windows/crash_handler_windows_seh.cpp
+++ b/platform/windows/crash_handler_windows_seh.cpp
@@ -134,9 +134,8 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 	}
 
 	String msg;
-	const ProjectSettings *proj_settings = ProjectSettings::get_singleton();
-	if (proj_settings) {
-		msg = proj_settings->get("debug/settings/crash_handler/message");
+	if (ProjectSettings::get_singleton()) {
+		msg = GLOBAL_GET("debug/settings/crash_handler/message");
 	}
 
 	// Tell MainLoop about the crash. This can be handled by users too in Node.
@@ -226,23 +225,20 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 		}
 	} while (frame.AddrReturn.Offset != 0 && n < 256);
 
-	print_error("-- END OF BACKTRACE --");
+	print_error("-- END OF C++ BACKTRACE --");
 	print_error("================================================================");
 
 	SymCleanup(process);
 
-	Vector<Ref<ScriptBacktrace>> script_backtraces;
 	if (ScriptServer::are_languages_initialized()) {
-		script_backtraces = ScriptServer::capture_script_backtraces(false);
-	}
-	if (!script_backtraces.is_empty()) {
+		Vector<Ref<ScriptBacktrace>> script_backtraces = ScriptServer::capture_script_backtraces(false);
 		for (const Ref<ScriptBacktrace> &backtrace : script_backtraces) {
 			if (!backtrace->is_empty()) {
 				print_error(backtrace->format());
+				print_error(vformat("-- END OF %s BACKTRACE --", backtrace->get_language_name().to_upper()));
+				print_error("================================================================");
 			}
 		}
-		print_error("-- END OF SCRIPT BACKTRACE --");
-		print_error("================================================================");
 	}
 
 	// Pass the exception to the OS

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -140,9 +140,8 @@ extern void CrashHandlerException(int signal) {
 	}
 
 	String msg;
-	const ProjectSettings *proj_settings = ProjectSettings::get_singleton();
-	if (proj_settings) {
-		msg = proj_settings->get("debug/settings/crash_handler/message");
+	if (ProjectSettings::get_singleton()) {
+		msg = GLOBAL_GET("debug/settings/crash_handler/message");
 	}
 
 	// Tell MainLoop about the crash. This can be handled by users too in Node.
@@ -182,21 +181,18 @@ extern void CrashHandlerException(int signal) {
 		backtrace_simple(data.state, 1, &trace_callback, &error_callback, reinterpret_cast<void *>(&data));
 	}
 
-	print_error("-- END OF BACKTRACE --");
+	print_error("-- END OF C++ BACKTRACE --");
 	print_error("================================================================");
 
-	Vector<Ref<ScriptBacktrace>> script_backtraces;
 	if (ScriptServer::are_languages_initialized()) {
-		script_backtraces = ScriptServer::capture_script_backtraces(false);
-	}
-	if (!script_backtraces.is_empty()) {
+		Vector<Ref<ScriptBacktrace>> script_backtraces = ScriptServer::capture_script_backtraces(false);
 		for (const Ref<ScriptBacktrace> &backtrace : script_backtraces) {
 			if (!backtrace->is_empty()) {
 				print_error(backtrace->format());
+				print_error(vformat("-- END OF %s BACKTRACE --", backtrace->get_language_name().to_upper()));
+				print_error("================================================================");
 			}
 		}
-		print_error("-- END OF SCRIPT BACKTRACE --");
-		print_error("================================================================");
 	}
 }
 #endif


### PR DESCRIPTION
- Follow-up to #91006.

Also fix the editor crash handler message for bug reports not properly using the `.editor` override.

Before this change, `-- END OF SCRIPT BACKTRACE --` would always be printed, even if it's a pure C++ crash with no script backtrace. That's because `ScriptServer::capture_script_backtraces` is never empty (unless there's no script language compiled in) as it includes empty backtraces for languages with no backtrace.

I moved that end message to the inner loop so it's only printed if each specific backtrace is non-empty, and while at it I included the language name in that message.

### Before

C++ only crash:
```
[1] /lib64/libc.so.6(+0x19c30) [0x7ffff7ccec30] (??:0)
[2] EditorNode::drag_resource(Ref<Resource> const&, Control*) (/home/akien/Godot/godot/editor/editor_node.cpp:6033 (discriminator 1))
[3] EditorResourcePicker::get_drag_data_fw(Vector2 const&, Control*) (/home/akien/Godot/godot/editor/editor_resource_picker.cpp:741)
[4] void call_with_variant_args_ret_helper<EditorResourcePicker, Variant, Vector2 const&, Control*, 0ul, 1ul>(EditorResourcePicker*, Variant (EditorResourcePicker::*)(Vector2 const&, Control*), Variant const**, Variant&, Callable::CallError&, IndexSequence<0ul, 1ul>) (/home/akien/Godot/godot/core/variant/binder_common.h:672 (discriminator 7))
[5] void call_with_variant_args_ret<EditorResourcePicker, Variant, Vector2 const&, Control*>(EditorResourcePicker*, Variant (EditorResourcePicker::*)(Vector2 const&, Control*), Variant const**, int, Variant&, Callable::CallError&) (/home/akien/Godot/godot/core/variant/binder_common.h:716)
[6] CallableCustomMethodPointer<EditorResourcePicker, Variant, Vector2 const&, Control*>::call(Variant const**, int, Variant&, Callable::CallError&) const (/home/akien/Godot/godot/core/object/callable_method_pointer.h:105)
[7] Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const (/home/akien/Godot/godot/core/variant/callable.cpp:57)
[8] CallableCustomBind::call(Variant const**, int, Variant&, Callable::CallError&) const (/home/akien/Godot/godot/core/variant/callable_bind.cpp:151)
[9] Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const (/home/akien/Godot/godot/core/variant/callable.cpp:57)
[10] Control::get_drag_data(Vector2 const&) (/home/akien/Godot/godot/scene/gui/control.cpp:2019)
[11] Viewport::_gui_input_event(Ref<InputEvent>) (/home/akien/Godot/godot/scene/main/viewport.cpp:2015 (discriminator 5))
[12] Viewport::push_input(Ref<InputEvent> const&, bool) (/home/akien/Godot/godot/scene/main/viewport.cpp:3426 (discriminator 2))
[13] Window::_window_input(Ref<InputEvent> const&) (/home/akien/Godot/godot/scene/main/window.cpp:1812)
[14] void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) (/home/akien/Godot/godot/core/variant/binder_common.h:223 (discriminator 6))
[15] void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) (/home/akien/Godot/godot/core/variant/binder_common.h:338)
[16] CallableCustomMethodPointer<Window, void, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const (/home/akien/Godot/godot/core/object/callable_method_pointer.h:107)
[17] Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const (/home/akien/Godot/godot/core/variant/callable.cpp:57)
[18] Variant Callable::call<Ref<InputEvent> >(Ref<InputEvent>) const (/home/akien/Godot/godot/core/variant/variant.h:942)
[19] DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) (/home/akien/Godot/godot/platform/linuxbsd/x11/display_server_x11.cpp:4393 (discriminator 2))
[20] DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) (/home/akien/Godot/godot/platform/linuxbsd/x11/display_server_x11.cpp:4370)
[21] Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) (/home/akien/Godot/godot/core/input/input.cpp:903)
[22] Input::flush_buffered_events() (/home/akien/Godot/godot/core/input/input.cpp:1184)
[23] DisplayServerX11::process_events() (/home/akien/Godot/godot/platform/linuxbsd/x11/display_server_x11.cpp:5548)
[24] OS_LinuxBSD::run() (/home/akien/Godot/godot/platform/linuxbsd/os_linuxbsd.cpp:977)
[25] /home/akien/Godot/godot/bin/godot.linuxbsd.editor.dev.x86_64(main+0x14b) [0x6c7e4f1] (/home/akien/Godot/godot/platform/linuxbsd/godot_linuxbsd.cpp:85)
[26] /lib64/libc.so.6(+0x35f5) [0x7ffff7cb85f5] (??:0)
[27] /lib64/libc.so.6(__libc_start_main+0x88) [0x7ffff7cb86a8] (??:0)
[28] /home/akien/Godot/godot/bin/godot.linuxbsd.editor.dev.x86_64(_start+0x25) [0x6c7e2e5] (??:?)
-- END OF BACKTRACE --
================================================================
-- END OF SCRIPT BACKTRACE --
================================================================
```

Crash originating in GDScript (`OS.crash()`):
```
ERROR: This is the end.
   at: crash (./core/core_bind.cpp:344)
   GDScript backtrace (most recent call first):
       [0] _ready (res://main.gd:5)

================================================================
handle_crash: Program crashed with signal 4
Engine version: Godot Engine v4.5.dev.custom_build (6a6a1168a5a7b14ef988f3516303b6d67a985ebd)
Dumping the backtrace. Please include this when reporting the bug to the project developer.
[1] /lib64/libc.so.6(+0x19c30) [0x7f7714186c30] (??:0)
[2] CoreBind::OS::crash(String const&) (/home/akien/Godot/godot/core/core_bind.cpp:344 (discriminator 2))
[3] void call_with_validated_variant_args_helper<__UnexistingClass, String const&, 0ul>(__UnexistingClass*, void (__UnexistingClass::*)(String const&), Variant const**, IndexSequence<0ul>) (/home/akien/Godot/godot/core/variant/binder_common.h:285)
[4] void call_with_validated_object_instance_args<__UnexistingClass, String const&>(__UnexistingClass*, void (__UnexistingClass::*)(String const&), Variant const**) (/home/akien/Godot/godot/core/variant/binder_common.h:572)
[5] MethodBindT<String const&>::validated_call(Object*, Variant const**, Variant*) const (/home/akien/Godot/godot/core/object/method_bind.h:351)
[6] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) (/home/akien/Godot/godot/modules/gdscript/gdscript_vm.cpp:2294)
[7] GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) (/home/akien/Godot/godot/modules/gdscript/gdscript.cpp:2058 (discriminator 1))
[8] Node::_gdvirtual__ready_call() (/home/akien/Godot/godot/scene/main/node.h:401 (discriminator 11))
[9] Node::_notification(int) (/home/akien/Godot/godot/scene/main/node.cpp:320)
[10] Node::_notification_forwardv(int) (/home/akien/Godot/godot/scene/main/node.h:48)
[11] CanvasItem::_notification_forwardv(int) (/home/akien/Godot/godot/scene/main/canvas_item.h:43 (discriminator 1))
[12] Node2D::_notification_forwardv(int) (/home/akien/Godot/godot/scene/2d/node_2d.h:36 (discriminator 1))
[13] Object::_notification_forward(int) (/home/akien/Godot/godot/core/object/object.cpp:933)
[14] Object::notification(int, bool) (/home/akien/Godot/godot/core/object/object.h:880)
[15] Node::_propagate_ready() (/home/akien/Godot/godot/scene/main/node.cpp:371)
[16] Node::_propagate_ready() (/home/akien/Godot/godot/scene/main/node.cpp:360 (discriminator 8))
[17] Node::_set_tree(SceneTree*) (/home/akien/Godot/godot/scene/main/node.cpp:3451)
[18] SceneTree::initialize() (/home/akien/Godot/godot/scene/main/scene_tree.cpp:574)
[19] OS_LinuxBSD::run() (/home/akien/Godot/godot/platform/linuxbsd/os_linuxbsd.cpp:975)
[20] /home/akien/Godot/godot/bin/godot.linuxbsd.editor.dev.x86_64(main+0x14b) [0x6c7e4f1] (/home/akien/Godot/godot/platform/linuxbsd/godot_linuxbsd.cpp:85)
[21] /lib64/libc.so.6(+0x35f5) [0x7f77141705f5] (??:0)
[22] /lib64/libc.so.6(__libc_start_main+0x88) [0x7f77141706a8] (??:0)
[23] /home/akien/Godot/godot/bin/godot.linuxbsd.editor.dev.x86_64(_start+0x25) [0x6c7e2e5] (??:?)
-- END OF BACKTRACE --
================================================================
GDScript backtrace (most recent call first):
    [0] _ready (res://main.gd:5)
-- END OF SCRIPT BACKTRACE --
================================================================
```

### After

C++ only crash:
```
================================================================
handle_crash: Program crashed with signal 11
Engine version: Godot Engine v4.5.dev.custom_build (6a6a1168a5a7b14ef988f3516303b6d67a985ebd)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[1] /lib64/libc.so.6(+0x19c30) [0x7fbeb7964c30] (??:0)
[2] EditorNode::drag_resource(Ref<Resource> const&, Control*) (/home/akien/Godot/godot/editor/editor_node.cpp:6033 (discriminator 1))
[3] EditorResourcePicker::get_drag_data_fw(Vector2 const&, Control*) (/home/akien/Godot/godot/editor/editor_resource_picker.cpp:741)
[4] void call_with_variant_args_ret_helper<EditorResourcePicker, Variant, Vector2 const&, Control*, 0ul, 1ul>(EditorResourcePicker*, Variant (EditorResourcePicker::*)(Vector2 const&, Control*), Variant const**, Variant&, Callable::CallError&, IndexSequence<0ul, 1ul>) (/home/akien/Godot/godot/core/variant/binder_common.h:672 (discriminator 7))
[5] void call_with_variant_args_ret<EditorResourcePicker, Variant, Vector2 const&, Control*>(EditorResourcePicker*, Variant (EditorResourcePicker::*)(Vector2 const&, Control*), Variant const**, int, Variant&, Callable::CallError&) (/home/akien/Godot/godot/core/variant/binder_common.h:716)
[6] CallableCustomMethodPointer<EditorResourcePicker, Variant, Vector2 const&, Control*>::call(Variant const**, int, Variant&, Callable::CallError&) const (/home/akien/Godot/godot/core/object/callable_method_pointer.h:105)
[7] Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const (/home/akien/Godot/godot/core/variant/callable.cpp:57)
[8] CallableCustomBind::call(Variant const**, int, Variant&, Callable::CallError&) const (/home/akien/Godot/godot/core/variant/callable_bind.cpp:151)
[9] Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const (/home/akien/Godot/godot/core/variant/callable.cpp:57)
[10] Control::get_drag_data(Vector2 const&) (/home/akien/Godot/godot/scene/gui/control.cpp:2019)
[11] Viewport::_gui_input_event(Ref<InputEvent>) (/home/akien/Godot/godot/scene/main/viewport.cpp:2015 (discriminator 5))
[12] Viewport::push_input(Ref<InputEvent> const&, bool) (/home/akien/Godot/godot/scene/main/viewport.cpp:3426 (discriminator 2))
[13] Window::_window_input(Ref<InputEvent> const&) (/home/akien/Godot/godot/scene/main/window.cpp:1812)
[14] void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) (/home/akien/Godot/godot/core/variant/binder_common.h:223 (discriminator 6))
[15] void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) (/home/akien/Godot/godot/core/variant/binder_common.h:338)
[16] CallableCustomMethodPointer<Window, void, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const (/home/akien/Godot/godot/core/object/callable_method_pointer.h:107)
[17] Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const (/home/akien/Godot/godot/core/variant/callable.cpp:57)
[18] Variant Callable::call<Ref<InputEvent> >(Ref<InputEvent>) const (/home/akien/Godot/godot/core/variant/variant.h:942)
[19] DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) (/home/akien/Godot/godot/platform/linuxbsd/x11/display_server_x11.cpp:4393 (discriminator 2))
[20] DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) (/home/akien/Godot/godot/platform/linuxbsd/x11/display_server_x11.cpp:4370)
[21] Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) (/home/akien/Godot/godot/core/input/input.cpp:903)
[22] Input::flush_buffered_events() (/home/akien/Godot/godot/core/input/input.cpp:1184)
[23] DisplayServerX11::process_events() (/home/akien/Godot/godot/platform/linuxbsd/x11/display_server_x11.cpp:5548)
[24] OS_LinuxBSD::run() (/home/akien/Godot/godot/platform/linuxbsd/os_linuxbsd.cpp:977)
[25] /home/akien/Godot/godot/bin/godot.linuxbsd.editor.dev.x86_64(main+0x14b) [0x6c7e3f1] (/home/akien/Godot/godot/platform/linuxbsd/godot_linuxbsd.cpp:85)
[26] /lib64/libc.so.6(+0x35f5) [0x7fbeb794e5f5] (??:0)
[27] /lib64/libc.so.6(__libc_start_main+0x88) [0x7fbeb794e6a8] (??:0)
[28] /home/akien/Godot/godot/bin/godot.linuxbsd.editor.dev.x86_64(_start+0x25) [0x6c7e1e5] (??:?)
-- END OF C++ BACKTRACE --
================================================================
```

Crash originating in GDScript (`OS.crash()`):
```
ERROR: This is the end.
   at: crash (./core/core_bind.cpp:344)
   GDScript backtrace (most recent call first):
       [0] _ready (res://main.gd:5)

================================================================
handle_crash: Program crashed with signal 4
Engine version: Godot Engine v4.5.dev.custom_build (6a6a1168a5a7b14ef988f3516303b6d67a985ebd)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[1] /lib64/libc.so.6(+0x19c30) [0x7f31a2d63c30] (??:0)
[2] CoreBind::OS::crash(String const&) (/home/akien/Godot/godot/core/core_bind.cpp:344 (discriminator 2))
[3] void call_with_validated_variant_args_helper<__UnexistingClass, String const&, 0ul>(__UnexistingClass*, void (__UnexistingClass::*)(String const&), Variant const**, IndexSequence<0ul>) (/home/akien/Godot/godot/core/variant/binder_common.h:285)
[4] void call_with_validated_object_instance_args<__UnexistingClass, String const&>(__UnexistingClass*, void (__UnexistingClass::*)(String const&), Variant const**) (/home/akien/Godot/godot/core/variant/binder_common.h:572)
[5] MethodBindT<String const&>::validated_call(Object*, Variant const**, Variant*) const (/home/akien/Godot/godot/core/object/method_bind.h:351)
[6] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) (/home/akien/Godot/godot/modules/gdscript/gdscript_vm.cpp:2294)
[7] GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) (/home/akien/Godot/godot/modules/gdscript/gdscript.cpp:2058 (discriminator 1))
[8] Node::_gdvirtual__ready_call() (/home/akien/Godot/godot/scene/main/node.h:401 (discriminator 11))
[9] Node::_notification(int) (/home/akien/Godot/godot/scene/main/node.cpp:320)
[10] Node::_notification_forwardv(int) (/home/akien/Godot/godot/scene/main/node.h:48)
[11] CanvasItem::_notification_forwardv(int) (/home/akien/Godot/godot/scene/main/canvas_item.h:43 (discriminator 1))
[12] Node2D::_notification_forwardv(int) (/home/akien/Godot/godot/scene/2d/node_2d.h:36 (discriminator 1))
[13] Object::_notification_forward(int) (/home/akien/Godot/godot/core/object/object.cpp:933)
[14] Object::notification(int, bool) (/home/akien/Godot/godot/core/object/object.h:880)
[15] Node::_propagate_ready() (/home/akien/Godot/godot/scene/main/node.cpp:371)
[16] Node::_propagate_ready() (/home/akien/Godot/godot/scene/main/node.cpp:360 (discriminator 8))
[17] Node::_set_tree(SceneTree*) (/home/akien/Godot/godot/scene/main/node.cpp:3451)
[18] SceneTree::initialize() (/home/akien/Godot/godot/scene/main/scene_tree.cpp:574)
[19] OS_LinuxBSD::run() (/home/akien/Godot/godot/platform/linuxbsd/os_linuxbsd.cpp:975)
[20] /home/akien/Godot/godot/bin/godot.linuxbsd.editor.dev.x86_64(main+0x14b) [0x6c7e3f1] (/home/akien/Godot/godot/platform/linuxbsd/godot_linuxbsd.cpp:85)
[21] /lib64/libc.so.6(+0x35f5) [0x7f31a2d4d5f5] (??:0)
[22] /lib64/libc.so.6(__libc_start_main+0x88) [0x7f31a2d4d6a8] (??:0)
[23] /home/akien/Godot/godot/bin/godot.linuxbsd.editor.dev.x86_64(_start+0x25) [0x6c7e1e5] (??:?)
-- END OF C++ BACKTRACE --
================================================================
GDScript backtrace (most recent call first):
    [0] _ready (res://main.gd:5)
-- END OF GDSCRIPT BACKTRACE --
================================================================
```