### PR TITLE
Fix unexpected control position change when left/top offsets not match `pos_cache` (reverted)

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1420,11 +1420,12 @@ void Control::set_position(const Point2 &p_point, bool p_keep_offsets) {
 
 	real_t edge_pos[4];
 	_compute_edge_positions(get_parent_anchorable_rect(), edge_pos);
+	Point2 offset_pos = Point2(edge_pos[0], edge_pos[1]) + (p_point - data.pos_cache);
 	Size2 offset_size(edge_pos[2] - edge_pos[0], edge_pos[3] - edge_pos[1]);
 	if (p_keep_offsets) {
-		_compute_anchors(Rect2(p_point, offset_size), data.offset, data.anchor);
+		_compute_anchors(Rect2(offset_pos, offset_size), data.offset, data.anchor);
 	} else {
-		_compute_offsets(Rect2(p_point, offset_size), data.anchor, data.offset);
+		_compute_offsets(Rect2(offset_pos, offset_size), data.anchor, data.offset);
 	}
 	_size_changed();
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

In https://github.com/godotengine/godot/pull/104357, in order to prevent the size of the offsets from being broken during offsets recalculate in set_position, the rect which use size calculated in real time via the offsets (previously use size_cache) is used in the offsets' recalculating

But this doesn't take into account the position of the rect. If the current pos_cache does not match (edge[0], edge[1]) calculated via offsets (e.g. the control's size is propped up by the minimum size when the grow_direction is not Right/Bottom), the position of the control may be offset to the top left of the expected position. This pr solve this

Fixes : https://github.com/godotengine/godot/issues/105771