### PR TITLE
Add "Show Encryption Key" toggle

### DIFF
--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -117,6 +117,7 @@ class ProjectExportDialog : public ConfirmationDialog {
 	RichTextLabel *custom_feature_display = nullptr;
 
 	LineEdit *script_key = nullptr;
+	Button *show_script_key = nullptr;
 	Label *script_key_error = nullptr;
 
 	ProjectExportTextureFormatError *export_texture_format_error = nullptr;
@@ -200,6 +201,7 @@ class ProjectExportDialog : public ConfirmationDialog {
 	void _enc_filters_changed(const String &p_text);
 	void _seed_input_changed(const String &p_text);
 	void _script_encryption_key_changed(const String &p_key);
+	void _script_encryption_key_visibility_changed(bool p_visible);
 	bool _validate_script_encryption_key(const String &p_key);
 
 	void _script_export_mode_changed(int p_mode);


### PR DESCRIPTION
**What**
I changed the behavior of the Encryption Key LineEdit

![image](https://github.com/user-attachments/assets/41e46ad7-1b1f-40be-b414-26ba02314951)

1. By default, secrets should be hidden, and only displayed if requested by user.

![image](https://github.com/user-attachments/assets/96843318-f08f-4bfd-9183-18549b5c74f2)

2. A toggle option to display the Encryption Key of the project export windows.

![image](https://github.com/user-attachments/assets/9477bfdc-8a88-4a50-afc5-82001e8a9091)

3. The key becomes hidden again when Encrypt Export is deactivated (reactivating it does not reactivate the “show key” toggle).

**Why?**
- As a general rule, “secret” strings should not be readable by default.
- Avoid key leaking by mistake (e.g. visible on screenshots, displayed by mistake, etc.)