### PR TITLE
Add capitalized `PRINT_VERBOSE` macro alongside the lowercase one

### DIFF
--- a/core/string/print_string.h
+++ b/core/string/print_string.h
@@ -58,12 +58,15 @@ extern void print_error(const String &p_string);
 extern bool is_print_verbose_enabled();
 
 // This version avoids processing the text to be printed until it actually has to be printed, saving some CPU usage.
-#define print_verbose(m_text) \
+#define PRINT_VERBOSE(m_text) \
 	{ \
 		if (is_print_verbose_enabled()) { \
 			print_line(m_text); \
 		} \
 	}
+
+// For compatibility, and for parity with the print_line() function, also provide as lowercase.
+#define print_verbose PRINT_VERBOSE
 
 template <typename... Args>
 void print_line(Args... p_args) {


### PR DESCRIPTION
In the Godot core team meeting on 2025-05-07, it was discussed that PR #100224 is a massive codebase-wide change that will conflict with many PRs and break compatibility with third-party modules. Therefore, there is a lot of hesitation with merging it for a minor improvement, which is itself not unanimously agreed on.

However, there is still the problem of the name conflict in godot-cpp GDExtension, which currently uses a work-around of using a function instead of a macro. This means that `print_verbose` in godot-cpp has different behavior compared to the macro in the engine, and is objectively slower for no good reason.

This PR adds the capitalized `PRINT_VERBOSE` macro without changing all existing uses throughout the codebase. This allows us to gradually migrate without breaking every PR, and more importantly, allows us to add the capitalized macro to godot-cpp, which lets users get the behavior and performance benefits of the macro, while still having their code be compatible between in-engine C++ and godot-cpp GDExtension C++.