### PR TITLE
Annual versions bump for the Android platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ local.properties
 *.iml
 .gradletasknamecache
 project.properties
+platform/android/java/build/
 platform/android/java/*/.cxx/
 platform/android/java/*/build/
 platform/android/java/*/libs/

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -283,7 +283,7 @@ static const char *AAB_ASSETS_DIRECTORY = "assetPacks/installTime/src/main/asset
 
 static const int OPENGL_MIN_SDK_VERSION = 21; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
 static const int VULKAN_MIN_SDK_VERSION = 24;
-static const int DEFAULT_TARGET_SDK_VERSION = 34; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
+static const int DEFAULT_TARGET_SDK_VERSION = 35; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
 
 #ifndef ANDROID_ENABLED
 void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -90,7 +90,7 @@ android {
         jvmTarget = versions.javaVersion
     }
 
-    assetPacks = [":assetPacks:installTime"]
+    assetPacks = [":assetPacksInstallTime"]
 
     namespace = 'com.godot.game'
 

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,19 +1,19 @@
 ext.versions = [
-    androidGradlePlugin: '8.2.0',
-    compileSdk         : 34,
+    androidGradlePlugin: '8.6.1',
+    compileSdk         : 35,
     // Also update 'platform/android/export/export_plugin.cpp#OPENGL_MIN_SDK_VERSION'
     minSdk             : 21,
     // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
-    targetSdk          : 34,
-    buildTools         : '34.0.0',
-    kotlinVersion      : '1.9.20',
-    fragmentVersion    : '1.7.1',
+    targetSdk          : 35,
+    buildTools         : '35.0.0',
+    kotlinVersion      : '2.1.20',
+    fragmentVersion    : '1.8.6',
     nexusPublishVersion: '1.3.0',
     javaVersion        : JavaVersion.VERSION_17,
     // Also update 'platform/android/detect.py#get_ndk_version()' when this is updated.
     ndkVersion         : '27.2.12479018',
     splashscreenVersion: '1.0.1',
-    openxrVendorsVersion: '3.1.2-stable'
+    openxrVendorsVersion: '4.0.0-stable'
 
 ]
 

--- a/platform/android/java/app/settings.gradle
+++ b/platform/android/java/app/settings.gradle
@@ -15,4 +15,5 @@ pluginManagement {
     }
 }
 
-include ':assetPacks:installTime'
+include ':assetPacksInstallTime'
+project(':assetPacksInstallTime').projectDir = file("assetPacks/installTime")

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -186,7 +186,7 @@ dependencies {
 
     implementation "androidx.window:window:1.3.0"
     implementation "androidx.core:core-splashscreen:$versions.splashscreenVersion"
-    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
+    implementation "androidx.constraintlayout:constraintlayout:2.2.1"
     implementation "org.bouncycastle:bcprov-jdk15to18:1.78"
 
     // Meta dependencies

--- a/platform/android/java/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jan 17 12:08:26 PST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/platform/android/java/settings.gradle
+++ b/platform/android/java/settings.gradle
@@ -25,5 +25,5 @@ include ':lib'
 include ':nativeSrcsConfigs'
 include ':editor'
 
-include ':assetPacks:installTime'
-project(':assetPacks:installTime').projectDir = file("app/assetPacks/installTime")
+include ':assetPacksInstallTime'
+project(':assetPacksInstallTime').projectDir = file("app/assetPacks/installTime")


### PR DESCRIPTION
- gradle: 8.2 -> 8.11.1
- androidx.constraintlayout:constraintlayout: 2.1.4 -> 2.2.1
- Android gradle plugin: 8.2.0 -> 8.6.1
- Android compile sdk: 34 -> 35
- Android target sdk: 34 -> 35
- Android build tools: 34.0.0 -> 35.0.0
- kotlin: 1.9.20 -> 2.1.20
- androidx.fragment:fragment: 1.7.1 -> 1.8.6
- OpenXR vendors plugin: 3.1.2-stable -> 4.0.0-stable

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
