### PR TITLE
Implicit `StringName` (.NET) cache

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Godot.NativeInterop;
 
@@ -74,11 +75,13 @@ namespace Godot
             }
         }
 
+        private static readonly ConcurrentDictionary<string, StringName> _stringNameCache = [];
+
         /// <summary>
         /// Converts a string to a <see cref="StringName"/>.
         /// </summary>
         /// <param name="from">The string to convert.</param>
-        public static implicit operator StringName(string from) => new StringName(from);
+        public static implicit operator StringName(string from) => _stringNameCache.GetOrAdd(from, static from => new StringName(from));
 
         /// <summary>
         /// Converts a <see cref="StringName"/> to a string.


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/106096 for related analyzer to avoid implicit `StringName` allocations, since they are so expensive to create every frame multiple times. See also https://github.com/godotengine/godot/pull/106066 and https://github.com/godotengine/godot/issues/105750 for more history.

This fix is very simple, just cache the `StringName` instance and return cached values instead of repeatedly creating new instances. This works because `StringName` instances are supposed to be cached on the C++ side (for quick comparisons, etc), however just getting to call the C++ cache lookup requires creating an entire `StringName` instance in .Net.

```C#
        private static readonly ConcurrentDictionary<string, StringName> _stringNameCache = [];

        /// <summary>
        /// Converts a string to a <see cref="StringName"/>.
        /// </summary>
        /// <param name="from">The string to convert.</param>
        public static implicit operator StringName(string from) => _stringNameCache.GetOrAdd(from, static from => new StringName(from));
```

This has several benefits:
 - It's lightning fast for cached values since it never leaves the .Net context (no context switching or marshalling)
 - In the worst case (ie the very first call), it works as before, so no performance loss
 - Zero allocations in the hot path (cache hit)
 - Zero finalizers that require the GC to pause all threads (since the instances are never released)
 - This requires no code changes (especially no overloads created as per https://github.com/godotengine/godot/pull/106066)
 - Don't let that concurrent dictionary scare you, without contention (most if not all calls) there are no kernel locks acquired

Drawbacks:
 - Since the values are never released, there is some slight memory increase. However, object sizes are minimal (bytes) and really, how many `StringName` instances do you create in a full game? 

I ran the test provided in https://github.com/godotengine/godot/pull/106066, and while it is not perfect or anything, the difference is night and day. I'm getting equal performance with the fully statically cached variable with no code changes:

```
5   <-- static readonly cached StringName
5   <-- implicit construction from string with new code
128
```

Very artificial test, but that's a 20x improvement for essentially free, and that's not even counting the benefits of zero GC allocations and zero GC finalizers. It's so good in fact that I'd recommend not even considering the analyzer linked above, there's very little reason to make code unreadable with this cache in. 