### PR TITLE
basis_universal: Add missing `ctype.h` include to fix MSVC build

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -89,6 +89,8 @@ Patches:
 - `0002-external-tinyexr.patch` (GH-97582)
 - `0003-remove-tinydds-qoi.patch` (GH-97582)
 - `0004-ambiguous-calls.patch` (GH-103968)
+- `0005-msvc-include-ctype.patch` (GH-106155)
+
 
 ## brotli
 

--- a/thirdparty/basis_universal/patches/0005-msvc-include-ctype.patch
+++ b/thirdparty/basis_universal/patches/0005-msvc-include-ctype.patch
@@ -1,0 +1,13 @@
+diff --git a/thirdparty/basis_universal/transcoder/basisu_containers_impl.h b/thirdparty/basis_universal/transcoder/basisu_containers_impl.h
+index d4d3eb23bc..3d7aaddcad 100644
+--- a/thirdparty/basis_universal/transcoder/basisu_containers_impl.h
++++ b/thirdparty/basis_universal/transcoder/basisu_containers_impl.h
+@@ -1,6 +1,8 @@
+ // basisu_containers_impl.h
+ // Do not include directly
+ 
++#include <ctype.h>
++
+ #ifdef _MSC_VER
+ #pragma warning (disable:4127) // warning C4127: conditional expression is constant
+ #endif

--- a/thirdparty/basis_universal/transcoder/basisu_containers_impl.h
+++ b/thirdparty/basis_universal/transcoder/basisu_containers_impl.h
@@ -1,6 +1,8 @@
 // basisu_containers_impl.h
 // Do not include directly
 
+#include <ctype.h>
+
 #ifdef _MSC_VER
 #pragma warning (disable:4127) // warning C4127: conditional expression is constant
 #endif


### PR DESCRIPTION
Seems like latest MSVC tweaked some headers and we no longer have definitions for `isdigit` and `isalpha` without an explicit include.

- Upstream PR: https://github.com/BinomialLLC/basis_universal/pull/395