### PR TITLE
Clarify the input action that affects `AcceptDialog.dialog_close_on_escape`

### DIFF
--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -62,7 +62,7 @@
 			Sets autowrapping for the text in the dialog.
 		</member>
 		<member name="dialog_close_on_escape" type="bool" setter="set_close_on_escape" getter="get_close_on_escape" default="true">
-			If [code]true[/code], the dialog will be hidden when the escape key ([constant KEY_ESCAPE]) is pressed.
+			If [code]true[/code], the dialog will be hidden when the [code]ui_cancel[/code] action is pressed (by default, this action is bound to [constant KEY_ESCAPE]).
 		</member>
 		<member name="dialog_hide_on_ok" type="bool" setter="set_hide_on_ok" getter="get_hide_on_ok" default="true">
 			If [code]true[/code], the dialog is hidden when the OK button is pressed. You can set it to [code]false[/code] if you want to do e.g. input validation when receiving the [signal confirmed] signal, and handle hiding the dialog in your own logic.


### PR DESCRIPTION
It uses `ui_cancel` behind the scenes, which allows users to add/modify which keys or gamepad buttons are taken into account for this.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/424#discussioncomment-13057261.