### PR TITLE
[Docs] Remove redundant info on the enum types used

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -674,7 +674,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="mode" type="int" enum="Animation.UpdateMode" />
 			<description>
-				Sets the update mode (see [enum UpdateMode]) of a value track.
+				Sets the update mode of a value track.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -92,8 +92,8 @@
 			<param index="5" name="blend" type="float" />
 			<param index="6" name="looped_flag" type="int" enum="Animation.LoopedFlag" default="0" />
 			<description>
-				Blend an animation by [param blend] amount (name must be valid in the linked [AnimationPlayer]). A [param time] and [param delta] may be passed, as well as whether [param seeked] happened.
-				A [param looped_flag] is used by internal processing immediately after the loop. See also [enum Animation.LoopedFlag].
+				Blends an animation by [param blend] amount (name must be valid in the linked [AnimationPlayer]). A [param time] and [param delta] may be passed, as well as whether [param seeked] happened.
+				A [param looped_flag] is used by internal processing immediately after the loop.
 			</description>
 		</method>
 		<method name="blend_input">
@@ -107,7 +107,7 @@
 			<param index="6" name="sync" type="bool" default="true" />
 			<param index="7" name="test_only" type="bool" default="false" />
 			<description>
-				Blend an input. This is only useful for animation nodes created for an [AnimationNodeBlendTree]. The [param time] parameter is a relative delta, unless [param seek] is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed (see [enum FilterAction] for options).
+				Blends an input. This is only useful for animation nodes created for an [AnimationNodeBlendTree]. The [param time] parameter is a relative delta, unless [param seek] is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed.
 			</description>
 		</method>
 		<method name="blend_node">

--- a/doc/classes/AnimationNodeBlendSpace1D.xml
+++ b/doc/classes/AnimationNodeBlendSpace1D.xml
@@ -67,7 +67,7 @@
 	</methods>
 	<members>
 		<member name="blend_mode" type="int" setter="set_blend_mode" getter="get_blend_mode" enum="AnimationNodeBlendSpace1D.BlendMode" default="0">
-			Controls the interpolation between animations. See [enum BlendMode] constants.
+			Controls the interpolation between animations.
 		</member>
 		<member name="max_space" type="float" setter="set_max_space" getter="get_max_space" default="1.0">
 			The blend space's axis's upper limit for the points' position. See [method add_blend_point].

--- a/doc/classes/AnimationNodeBlendSpace2D.xml
+++ b/doc/classes/AnimationNodeBlendSpace2D.xml
@@ -102,7 +102,7 @@
 			If [code]true[/code], the blend space is triangulated automatically. The mesh updates every time you add or remove points with [method add_blend_point] and [method remove_blend_point].
 		</member>
 		<member name="blend_mode" type="int" setter="set_blend_mode" getter="get_blend_mode" enum="AnimationNodeBlendSpace2D.BlendMode" default="0">
-			Controls the interpolation between animations. See [enum BlendMode] constants.
+			Controls the interpolation between animations.
 		</member>
 		<member name="max_space" type="Vector2" setter="set_max_space" getter="get_max_space" default="Vector2(1, 1)">
 			The blend space's X and Y axes' upper limit for the points' position. See [method add_blend_point].

--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -67,7 +67,7 @@
 			See [member ProjectSettings.physics/2d/default_angular_damp] for more details about damping.
 		</member>
 		<member name="angular_damp_space_override" type="int" setter="set_angular_damp_space_override_mode" getter="get_angular_damp_space_override_mode" enum="Area2D.SpaceOverride" default="0">
-			Override mode for angular damping calculations within this area. See [enum SpaceOverride] for possible values.
+			Override mode for angular damping calculations within this area.
 		</member>
 		<member name="audio_bus_name" type="StringName" setter="set_audio_bus_name" getter="get_audio_bus_name" default="&amp;&quot;Master&quot;">
 			The name of the area's audio bus.
@@ -92,14 +92,14 @@
 			The above is true only when the unit distance is a positive number. When this is set to 0.0, the gravity will be constant regardless of distance.
 		</member>
 		<member name="gravity_space_override" type="int" setter="set_gravity_space_override_mode" getter="get_gravity_space_override_mode" enum="Area2D.SpaceOverride" default="0">
-			Override mode for gravity calculations within this area. See [enum SpaceOverride] for possible values.
+			Override mode for gravity calculations within this area.
 		</member>
 		<member name="linear_damp" type="float" setter="set_linear_damp" getter="get_linear_damp" default="0.1">
 			The rate at which objects stop moving in this area. Represents the linear velocity lost per second.
 			See [member ProjectSettings.physics/2d/default_linear_damp] for more details about damping.
 		</member>
 		<member name="linear_damp_space_override" type="int" setter="set_linear_damp_space_override_mode" getter="get_linear_damp_space_override_mode" enum="Area2D.SpaceOverride" default="0">
-			Override mode for linear damping calculations within this area. See [enum SpaceOverride] for possible values.
+			Override mode for linear damping calculations within this area.
 		</member>
 		<member name="monitorable" type="bool" setter="set_monitorable" getter="is_monitorable" default="true">
 			If [code]true[/code], other monitoring areas can detect this area.

--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -67,7 +67,7 @@
 			See [member ProjectSettings.physics/3d/default_angular_damp] for more details about damping.
 		</member>
 		<member name="angular_damp_space_override" type="int" setter="set_angular_damp_space_override_mode" getter="get_angular_damp_space_override_mode" enum="Area3D.SpaceOverride" default="0">
-			Override mode for angular damping calculations within this area. See [enum SpaceOverride] for possible values.
+			Override mode for angular damping calculations within this area.
 		</member>
 		<member name="audio_bus_name" type="StringName" setter="set_audio_bus_name" getter="get_audio_bus_name" default="&amp;&quot;Master&quot;">
 			The name of the area's audio bus.
@@ -92,14 +92,14 @@
 			The above is true only when the unit distance is a positive number. When this is set to 0.0, the gravity will be constant regardless of distance.
 		</member>
 		<member name="gravity_space_override" type="int" setter="set_gravity_space_override_mode" getter="get_gravity_space_override_mode" enum="Area3D.SpaceOverride" default="0">
-			Override mode for gravity calculations within this area. See [enum SpaceOverride] for possible values.
+			Override mode for gravity calculations within this area.
 		</member>
 		<member name="linear_damp" type="float" setter="set_linear_damp" getter="get_linear_damp" default="0.1">
 			The rate at which objects stop moving in this area. Represents the linear velocity lost per second.
 			See [member ProjectSettings.physics/3d/default_linear_damp] for more details about damping.
 		</member>
 		<member name="linear_damp_space_override" type="int" setter="set_linear_damp_space_override_mode" getter="get_linear_damp_space_override_mode" enum="Area3D.SpaceOverride" default="0">
-			Override mode for linear damping calculations within this area. See [enum SpaceOverride] for possible values.
+			Override mode for linear damping calculations within this area.
 		</member>
 		<member name="monitorable" type="bool" setter="set_monitorable" getter="is_monitorable" default="true">
 			If [code]true[/code], other monitoring areas can detect this area.

--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -207,7 +207,7 @@
 	</methods>
 	<members>
 		<member name="blend_shape_mode" type="int" setter="set_blend_shape_mode" getter="get_blend_shape_mode" enum="Mesh.BlendShapeMode" default="1">
-			Sets the blend shape mode to one of [enum Mesh.BlendShapeMode].
+			The blend shape mode.
 		</member>
 		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)">
 			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.

--- a/doc/classes/AudioEffectRecord.xml
+++ b/doc/classes/AudioEffectRecord.xml
@@ -36,7 +36,7 @@
 	</methods>
 	<members>
 		<member name="format" type="int" setter="set_format" getter="get_format" enum="AudioStreamWAV.Format" default="1">
-			Specifies the format in which the sample will be recorded. See [enum AudioStreamWAV.Format] for available formats.
+			Specifies the format in which the sample will be recorded.
 		</member>
 	</members>
 </class>

--- a/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
+++ b/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
@@ -18,7 +18,7 @@
 			<param index="2" name="mode" type="int" enum="AudioEffectSpectrumAnalyzerInstance.MagnitudeMode" default="1" />
 			<description>
 				Returns the magnitude of the frequencies from [param from_hz] to [param to_hz] in linear energy as a Vector2. The [code]x[/code] component of the return value represents the left stereo channel, and [code]y[/code] represents the right channel.
-				[param mode] determines how the frequency range will be processed. See [enum MagnitudeMode].
+				[param mode] determines how the frequency range will be processed.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -70,7 +70,7 @@
 			The maximum number of sounds this node can play at the same time. Calling [method play] after this value is reached will cut off the oldest sounds.
 		</member>
 		<member name="mix_target" type="int" setter="set_mix_target" getter="get_mix_target" enum="AudioStreamPlayer.MixTarget" default="0">
-			The mix target channels, as one of the [enum MixTarget] constants. Has no effect when two speakers or less are detected (see [enum AudioServer.SpeakerMode]).
+			The mix target channels. Has no effect when two speakers or less are detected (see [enum AudioServer.SpeakerMode]).
 		</member>
 		<member name="pitch_scale" type="float" setter="set_pitch_scale" getter="get_pitch_scale" default="1.0">
 			The audio's pitch and tempo, as a multiplier of the [member stream]'s sample rate. A value of [code]2.0[/code] doubles the audio's pitch, while a value of [code]0.5[/code] halves the pitch.

--- a/doc/classes/AudioStreamWAV.xml
+++ b/doc/classes/AudioStreamWAV.xml
@@ -60,7 +60,7 @@
 			[b]Note:[/b] If [member format] is set to [constant FORMAT_QOA], this property expects data from a full QOA file.
 		</member>
 		<member name="format" type="int" setter="set_format" getter="get_format" enum="AudioStreamWAV.Format" default="0">
-			Audio format. See [enum Format] constants for values.
+			Audio format.
 		</member>
 		<member name="loop_begin" type="int" setter="set_loop_begin" getter="get_loop_begin" default="0">
 			The loop start point (in number of samples, relative to the beginning of the stream).
@@ -69,7 +69,7 @@
 			The loop end point (in number of samples, relative to the beginning of the stream).
 		</member>
 		<member name="loop_mode" type="int" setter="set_loop_mode" getter="get_loop_mode" enum="AudioStreamWAV.LoopMode" default="0">
-			The loop mode. See [enum LoopMode] constants for values.
+			The loop mode.
 		</member>
 		<member name="mix_rate" type="int" setter="set_mix_rate" getter="get_mix_rate" default="44100">
 			The sample rate for mixing this audio. Higher values require more storage space, but result in better quality.

--- a/doc/classes/BackBufferCopy.xml
+++ b/doc/classes/BackBufferCopy.xml
@@ -12,7 +12,7 @@
 	</tutorials>
 	<members>
 		<member name="copy_mode" type="int" setter="set_copy_mode" getter="get_copy_mode" enum="BackBufferCopy.CopyMode" default="1">
-			Buffer mode. See [enum CopyMode] constants.
+			Buffer mode.
 		</member>
 		<member name="rect" type="Rect2" setter="set_rect" getter="get_rect" default="Rect2(-100, -100, 200, 200)">
 			The area covered by the [BackBufferCopy]. Only used if [member copy_mode] is [constant COPY_MODE_RECT].

--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -45,7 +45,7 @@
 	</methods>
 	<members>
 		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" enum="BaseButton.ActionMode" default="1">
-			Determines when the button is considered clicked, one of the [enum ActionMode] constants.
+			Determines when the button is considered clicked.
 		</member>
 		<member name="button_group" type="ButtonGroup" setter="set_button_group" getter="get_button_group">
 			The [ButtonGroup] associated with the button. Not to be confused with node groups.

--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -21,7 +21,7 @@
 			<return type="bool" />
 			<param index="0" name="flag" type="int" enum="BaseMaterial3D.Flags" />
 			<description>
-				Returns [code]true[/code], if the specified flag is enabled. See [enum Flags] enumerator for options.
+				Returns [code]true[/code] if the specified flag is enabled.
 			</description>
 		</method>
 		<method name="get_texture" qualifiers="const">
@@ -44,7 +44,7 @@
 			<param index="0" name="flag" type="int" enum="BaseMaterial3D.Flags" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				If [code]true[/code], enables the specified flag. Flags are optional behavior that can be turned on and off. Only one flag can be enabled at a time with this function, the flag enumerators cannot be bit-masked together to enable or disable multiple flags at once. Flags can also be enabled by setting the corresponding member to [code]true[/code]. See [enum Flags] enumerator for options.
+				If [code]true[/code], enables the specified flag. Flags are optional behavior that can be turned on and off. Only one flag can be enabled at a time with this function, the flag enumerators cannot be bit-masked together to enable or disable multiple flags at once. Flags can also be enabled by setting the corresponding member to [code]true[/code].
 			</description>
 		</method>
 		<method name="set_texture">
@@ -52,7 +52,7 @@
 			<param index="0" name="param" type="int" enum="BaseMaterial3D.TextureParam" />
 			<param index="1" name="texture" type="Texture2D" />
 			<description>
-				Sets the texture for the slot specified by [param param]. See [enum TextureParam] for available slots.
+				Sets the texture for the slot specified by [param param].
 			</description>
 		</method>
 	</methods>
@@ -76,7 +76,7 @@
 			Threshold at which antialiasing will be applied on the alpha channel.
 		</member>
 		<member name="alpha_antialiasing_mode" type="int" setter="set_alpha_antialiasing" getter="get_alpha_antialiasing" enum="BaseMaterial3D.AlphaAntiAliasing">
-			The type of alpha antialiasing to apply. See [enum AlphaAntiAliasing].
+			The type of alpha antialiasing to apply.
 		</member>
 		<member name="alpha_hash_scale" type="float" setter="set_alpha_hash_scale" getter="get_alpha_hash_scale">
 			The hashing scale for Alpha Hash. Recommended values between [code]0[/code] and [code]2[/code].
@@ -133,12 +133,12 @@
 			If [code]true[/code], the shader will keep the scale set for the mesh. Otherwise, the scale is lost when billboarding. Only applies when [member billboard_mode] is not [constant BILLBOARD_DISABLED].
 		</member>
 		<member name="billboard_mode" type="int" setter="set_billboard_mode" getter="get_billboard_mode" enum="BaseMaterial3D.BillboardMode" default="0">
-			Controls how the object faces the camera. See [enum BillboardMode].
+			Controls how the object faces the camera.
 			[b]Note:[/b] Billboard mode is not suitable for VR because the left-right vector of the camera is not horizontal when the screen is attached to your head instead of on the table. See [url=https://github.com/godotengine/godot/issues/41567]GitHub issue #41567[/url] for details.
 		</member>
 		<member name="blend_mode" type="int" setter="set_blend_mode" getter="get_blend_mode" enum="BaseMaterial3D.BlendMode" default="0">
 			The material's blend mode.
-			[b]Note:[/b] Values other than [code]Mix[/code] force the object into the transparent pipeline. See [enum BlendMode].
+			[b]Note:[/b] Values other than [code]Mix[/code] force the object into the transparent pipeline.
 		</member>
 		<member name="clearcoat" type="float" setter="set_clearcoat" getter="get_clearcoat" default="1.0">
 			Sets the strength of the clearcoat effect. Setting to [code]0[/code] looks the same as disabling the clearcoat effect.
@@ -154,17 +154,17 @@
 			Texture that defines the strength of the clearcoat effect and the glossiness of the clearcoat. Strength is specified in the red channel while glossiness is specified in the green channel.
 		</member>
 		<member name="cull_mode" type="int" setter="set_cull_mode" getter="get_cull_mode" enum="BaseMaterial3D.CullMode" default="0">
-			Determines which side of the triangle to cull depending on whether the triangle faces towards or away from the camera. See [enum CullMode].
+			Determines which side of the triangle to cull depending on whether the triangle faces towards or away from the camera.
 		</member>
 		<member name="depth_draw_mode" type="int" setter="set_depth_draw_mode" getter="get_depth_draw_mode" enum="BaseMaterial3D.DepthDrawMode" default="0">
-			Determines when depth rendering takes place. See [enum DepthDrawMode]. See also [member transparency].
+			Determines when depth rendering takes place. See also [member transparency].
 		</member>
 		<member name="detail_albedo" type="Texture2D" setter="set_texture" getter="get_texture">
 			Texture that specifies the color of the detail overlay. [member detail_albedo]'s alpha channel is used as a mask, even when the material is opaque. To use a dedicated texture as a mask, see [member detail_mask].
 			[b]Note:[/b] [member detail_albedo] is [i]not[/i] modulated by [member albedo_color].
 		</member>
 		<member name="detail_blend_mode" type="int" setter="set_detail_blend_mode" getter="get_detail_blend_mode" enum="BaseMaterial3D.BlendMode" default="0">
-			Specifies how the [member detail_albedo] should blend with the current [code]ALBEDO[/code]. See [enum BlendMode] for options.
+			Specifies how the [member detail_albedo] should blend with the current [code]ALBEDO[/code].
 		</member>
 		<member name="detail_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
 			If [code]true[/code], enables the detail overlay. Detail is a second texture that gets mixed over the surface of the object based on [member detail_mask] and [member detail_albedo]'s alpha channel. This can be used to add variation to objects, or to blend between two different albedo/normal textures.
@@ -177,10 +177,10 @@
 			[b]Note:[/b] Godot expects the normal map to use X+, Y+, and Z+ coordinates. See [url=http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates]this page[/url] for a comparison of normal map coordinates expected by popular engines.
 		</member>
 		<member name="detail_uv_layer" type="int" setter="set_detail_uv" getter="get_detail_uv" enum="BaseMaterial3D.DetailUV" default="0">
-			Specifies whether to use [code]UV[/code] or [code]UV2[/code] for the detail layer. See [enum DetailUV] for options.
+			Specifies whether to use [code]UV[/code] or [code]UV2[/code] for the detail layer.
 		</member>
 		<member name="diffuse_mode" type="int" setter="set_diffuse_mode" getter="get_diffuse_mode" enum="BaseMaterial3D.DiffuseMode" default="0">
-			The algorithm used for diffuse light scattering. See [enum DiffuseMode].
+			The algorithm used for diffuse light scattering.
 		</member>
 		<member name="disable_ambient_light" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the object receives no ambient light.
@@ -221,7 +221,7 @@
 			Use [code]UV2[/code] to read from the [member emission_texture].
 		</member>
 		<member name="emission_operator" type="int" setter="set_emission_operator" getter="get_emission_operator" enum="BaseMaterial3D.EmissionOperator" default="0">
-			Sets how [member emission] interacts with [member emission_texture]. Can either add or multiply. See [enum EmissionOperator] for options.
+			Sets how [member emission] interacts with [member emission_texture]. Can either add or multiply.
 		</member>
 		<member name="emission_texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			Texture that specifies how much surface emits light at a given point.
@@ -371,7 +371,7 @@
 			If [code]true[/code], enables the "shadow to opacity" render mode where lighting modifies the alpha so shadowed areas are opaque and non-shadowed areas are transparent. Useful for overlaying shadows onto a camera feed in AR.
 		</member>
 		<member name="specular_mode" type="int" setter="set_specular_mode" getter="get_specular_mode" enum="BaseMaterial3D.SpecularMode" default="0">
-			The method for rendering the specular blob. See [enum SpecularMode].
+			The method for rendering the specular blob.
 			[b]Note:[/b] [member specular_mode] only applies to the specular blob. It does not affect specular reflections from the sky, screen-space reflections, [VoxelGI], SDFGI or [ReflectionProbe]s. To disable reflections from these sources as well, set [member metallic_specular] to [code]0.0[/code] instead.
 		</member>
 		<member name="subsurf_scatter_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
@@ -402,11 +402,11 @@
 			The texture to use for multiplying the intensity of the subsurface scattering transmittance intensity. See also [member subsurf_scatter_texture]. Ignored if [member subsurf_scatter_skin_mode] is [code]true[/code].
 		</member>
 		<member name="texture_filter" type="int" setter="set_texture_filter" getter="get_texture_filter" enum="BaseMaterial3D.TextureFilter" default="3">
-			Filter flags for the texture. See [enum TextureFilter] for options.
+			Filter flags for the texture.
 			[b]Note:[/b] [member heightmap_texture] is always sampled with linear filtering, even if nearest-neighbor filtering is selected here. This is to ensure the heightmap effect looks as intended. If you need sharper height transitions between pixels, resize the heightmap texture in an image editor with nearest-neighbor filtering.
 		</member>
 		<member name="texture_repeat" type="bool" setter="set_flag" getter="get_flag" default="true">
-			Repeat flags for the texture. See [enum TextureFilter] for options.
+			If [code]true[/code], the texture repeats when exceeding the texture's size. See [constant FLAG_USE_TEXTURE_REPEAT].
 		</member>
 		<member name="transparency" type="int" setter="set_transparency" getter="get_transparency" enum="BaseMaterial3D.Transparency" default="0">
 			The material's transparency mode. Some transparency modes will disable shadow casting. Any transparency mode other than [constant TRANSPARENCY_DISABLED] has a greater performance impact compared to opaque rendering. See also [member blend_mode].

--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -41,7 +41,7 @@
 	</tutorials>
 	<members>
 		<member name="alignment" type="int" setter="set_text_alignment" getter="get_text_alignment" enum="HorizontalAlignment" default="1">
-			Text alignment policy for the button's text, use one of the [enum HorizontalAlignment] constants.
+			Text alignment policy for the button's text.
 		</member>
 		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="TextServer.AutowrapMode" default="0">
 			If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle.
@@ -75,7 +75,7 @@
 			Base text writing direction.
 		</member>
 		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="0">
-			Sets the clipping behavior when the text exceeds the node's bounding rectangle. See [enum TextServer.OverrunBehavior] for a description of all modes.
+			Sets the clipping behavior when the text exceeds the node's bounding rectangle.
 		</member>
 		<member name="vertical_icon_alignment" type="int" setter="set_vertical_icon_alignment" getter="get_vertical_icon_alignment" enum="VerticalAlignment" default="1">
 			Specifies if the icon should be aligned vertically to the top, bottom, or center of a button. Uses the same [enum VerticalAlignment] constants as the text alignment. If centered horizontally and vertically, text will draw on top of the icon.

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -43,7 +43,7 @@
 			<return type="bool" />
 			<param index="0" name="particle_flag" type="int" enum="CPUParticles2D.ParticleFlags" />
 			<description>
-				Returns the enabled state of the given particle flag (see [enum ParticleFlags] for options).
+				Returns the enabled state of the given particle flag.
 			</description>
 		</method>
 		<method name="request_particles_process">
@@ -91,7 +91,7 @@
 			<param index="0" name="particle_flag" type="int" enum="CPUParticles2D.ParticleFlags" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				Enables or disables the given flag (see [enum ParticleFlags] for options).
+				Enables or disables the given flag.
 			</description>
 		</method>
 	</methods>
@@ -158,7 +158,7 @@
 			Unit vector specifying the particles' emission direction.
 		</member>
 		<member name="draw_order" type="int" setter="set_draw_order" getter="get_draw_order" enum="CPUParticles2D.DrawOrder" default="0">
-			Particle draw order. Uses [enum DrawOrder] values.
+			Particle draw order.
 		</member>
 		<member name="emission_colors" type="PackedColorArray" setter="set_emission_colors" getter="get_emission_colors">
 			Sets the [Color]s to modulate particles by when using [constant EMISSION_SHAPE_POINTS] or [constant EMISSION_SHAPE_DIRECTED_POINTS].
@@ -173,7 +173,7 @@
 			The rectangle's extents if [member emission_shape] is set to [constant EMISSION_SHAPE_RECTANGLE].
 		</member>
 		<member name="emission_shape" type="int" setter="set_emission_shape" getter="get_emission_shape" enum="CPUParticles2D.EmissionShape" default="0">
-			Particles will be emitted inside this region. See [enum EmissionShape] for possible values.
+			Particles will be emitted inside this region.
 		</member>
 		<member name="emission_sphere_radius" type="float" setter="set_emission_sphere_radius" getter="get_emission_sphere_radius">
 			The sphere's radius if [member emission_shape] is set to [constant EMISSION_SHAPE_SPHERE].

--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -49,7 +49,7 @@
 			<return type="bool" />
 			<param index="0" name="particle_flag" type="int" enum="CPUParticles3D.ParticleFlags" />
 			<description>
-				Returns the enabled state of the given particle flag (see [enum ParticleFlags] for options).
+				Returns the enabled state of the given particle flag.
 			</description>
 		</method>
 		<method name="request_particles_process">
@@ -97,7 +97,7 @@
 			<param index="0" name="particle_flag" type="int" enum="CPUParticles3D.ParticleFlags" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				Enables or disables the given particle flag (see [enum ParticleFlags] for options).
+				Enables or disables the given particle flag.
 			</description>
 		</method>
 	</methods>
@@ -166,7 +166,7 @@
 			Unit vector specifying the particles' emission direction.
 		</member>
 		<member name="draw_order" type="int" setter="set_draw_order" getter="get_draw_order" enum="CPUParticles3D.DrawOrder" default="0">
-			Particle draw order. Uses [enum DrawOrder] values.
+			Particle draw order.
 		</member>
 		<member name="emission_box_extents" type="Vector3" setter="set_emission_box_extents" getter="get_emission_box_extents">
 			The rectangle's extents if [member emission_shape] is set to [constant EMISSION_SHAPE_BOX].
@@ -198,7 +198,7 @@
 			The radius of the ring when using the emitter [constant EMISSION_SHAPE_RING].
 		</member>
 		<member name="emission_shape" type="int" setter="set_emission_shape" getter="get_emission_shape" enum="CPUParticles3D.EmissionShape" default="0">
-			Particles will be emitted inside this region. See [enum EmissionShape] for possible values.
+			Particles will be emitted inside this region.
 		</member>
 		<member name="emission_sphere_radius" type="float" setter="set_emission_sphere_radius" getter="get_emission_sphere_radius">
 			The sphere's radius if [enum EmissionShape] is set to [constant EMISSION_SHAPE_SPHERE].

--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -92,7 +92,7 @@
 	</methods>
 	<members>
 		<member name="anchor_mode" type="int" setter="set_anchor_mode" getter="get_anchor_mode" enum="Camera2D.AnchorMode" default="1">
-			The Camera2D's anchor point. See [enum AnchorMode] constants.
+			The Camera2D's anchor point.
 		</member>
 		<member name="custom_viewport" type="Node" setter="set_custom_viewport" getter="get_custom_viewport">
 			The custom [Viewport] node attached to the [Camera2D]. If [code]null[/code] or not a [Viewport], uses the default viewport instead.
@@ -169,7 +169,7 @@
 			Speed in pixels per second of the camera's smoothing effect when [member position_smoothing_enabled] is [code]true[/code].
 		</member>
 		<member name="process_callback" type="int" setter="set_process_callback" getter="get_process_callback" enum="Camera2D.Camera2DProcessCallback" default="1">
-			The camera's process callback. See [enum Camera2DProcessCallback].
+			The camera's process callback.
 		</member>
 		<member name="rotation_smoothing_enabled" type="bool" setter="set_rotation_smoothing_enabled" getter="is_rotation_smoothing_enabled" default="false">
 			If [code]true[/code], the camera's view smoothly rotates, via asymptotic smoothing, to align with its target rotation at [member rotation_smoothing_speed].

--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -173,7 +173,7 @@
 			If multiple cameras are in the scene, one will always be made current. For example, if two [Camera3D] nodes are present in the scene and only one is current, setting one camera's [member current] to [code]false[/code] will cause the other camera to be made current.
 		</member>
 		<member name="doppler_tracking" type="int" setter="set_doppler_tracking" getter="get_doppler_tracking" enum="Camera3D.DopplerTracking" default="0">
-			If not [constant DOPPLER_TRACKING_DISABLED], this camera will simulate the [url=https://en.wikipedia.org/wiki/Doppler_effect]Doppler effect[/url] for objects changed in particular [code]_process[/code] methods. See [enum DopplerTracking] for possible values.
+			If not [constant DOPPLER_TRACKING_DISABLED], this camera will simulate the [url=https://en.wikipedia.org/wiki/Doppler_effect]Doppler effect[/url] for objects changed in particular [code]_process[/code] methods.
 		</member>
 		<member name="environment" type="Environment" setter="set_environment" getter="get_environment">
 			The [Environment] to use for this camera.

--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -169,13 +169,13 @@
 			Maximum number of times the body can change direction before it stops when calling [method move_and_slide]. Must be greater than zero.
 		</member>
 		<member name="motion_mode" type="int" setter="set_motion_mode" getter="get_motion_mode" enum="CharacterBody2D.MotionMode" default="0">
-			Sets the motion mode which defines the behavior of [method move_and_slide]. See [enum MotionMode] constants for available modes.
+			Sets the motion mode which defines the behavior of [method move_and_slide].
 		</member>
 		<member name="platform_floor_layers" type="int" setter="set_platform_floor_layers" getter="get_platform_floor_layers" default="4294967295">
 			Collision layers that will be included for detecting floor bodies that will act as moving platforms to be followed by the [CharacterBody2D]. By default, all floor bodies are detected and propagate their velocity.
 		</member>
 		<member name="platform_on_leave" type="int" setter="set_platform_on_leave" getter="get_platform_on_leave" enum="CharacterBody2D.PlatformOnLeave" default="0">
-			Sets the behavior to apply when you leave a moving platform. By default, to be physically accurate, when you leave the last platform velocity is applied. See [enum PlatformOnLeave] constants for available behavior.
+			Sets the behavior to apply when you leave a moving platform. By default, to be physically accurate, when you leave the last platform velocity is applied.
 		</member>
 		<member name="platform_wall_layers" type="int" setter="set_platform_wall_layers" getter="get_platform_wall_layers" default="0">
 			Collision layers that will be included for detecting wall bodies that will act as moving platforms to be followed by the [CharacterBody2D]. By default, all wall bodies are ignored.

--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -160,13 +160,13 @@
 			Maximum number of times the body can change direction before it stops when calling [method move_and_slide]. Must be greater than zero.
 		</member>
 		<member name="motion_mode" type="int" setter="set_motion_mode" getter="get_motion_mode" enum="CharacterBody3D.MotionMode" default="0">
-			Sets the motion mode which defines the behavior of [method move_and_slide]. See [enum MotionMode] constants for available modes.
+			Sets the motion mode which defines the behavior of [method move_and_slide].
 		</member>
 		<member name="platform_floor_layers" type="int" setter="set_platform_floor_layers" getter="get_platform_floor_layers" default="4294967295">
 			Collision layers that will be included for detecting floor bodies that will act as moving platforms to be followed by the [CharacterBody3D]. By default, all floor bodies are detected and propagate their velocity.
 		</member>
 		<member name="platform_on_leave" type="int" setter="set_platform_on_leave" getter="get_platform_on_leave" enum="CharacterBody3D.PlatformOnLeave" default="0">
-			Sets the behavior to apply when you leave a moving platform. By default, to be physically accurate, when you leave the last platform velocity is applied. See [enum PlatformOnLeave] constants for available behavior.
+			Sets the behavior to apply when you leave a moving platform. By default, to be physically accurate, when you leave the last platform velocity is applied.
 		</member>
 		<member name="platform_wall_layers" type="int" setter="set_platform_wall_layers" getter="get_platform_wall_layers" default="0">
 			Collision layers that will be included for detecting wall bodies that will act as moving platforms to be followed by the [CharacterBody3D]. By default, all wall bodies are ignored.

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -35,7 +35,7 @@
 			<return type="int" enum="ClassDB.APIType" />
 			<param index="0" name="class" type="StringName" />
 			<description>
-				Returns the API type of [param class]. See [enum APIType].
+				Returns the API type of the specified [param class].
 			</description>
 		</method>
 		<method name="class_get_enum_constants" qualifiers="const">

--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -236,7 +236,7 @@
 			The priority used to solve colliding when occurring penetration. The higher the priority is, the lower the penetration into the object will be. This can for example be used to prevent the player from breaking through the boundaries of a level.
 		</member>
 		<member name="disable_mode" type="int" setter="set_disable_mode" getter="get_disable_mode" enum="CollisionObject2D.DisableMode" default="0">
-			Defines the behavior in physics when [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED]. See [enum DisableMode] for more details about the different modes.
+			Defines the behavior in physics when [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED].
 		</member>
 		<member name="input_pickable" type="bool" setter="set_pickable" getter="is_pickable" default="true">
 			If [code]true[/code], this object is pickable. A pickable object can detect the mouse pointer entering/leaving, and if the mouse is inside it, report input events. Requires at least one [member collision_layer] bit to be set.

--- a/doc/classes/CollisionObject3D.xml
+++ b/doc/classes/CollisionObject3D.xml
@@ -194,7 +194,7 @@
 			The priority used to solve colliding when occurring penetration. The higher the priority is, the lower the penetration into the object will be. This can for example be used to prevent the player from breaking through the boundaries of a level.
 		</member>
 		<member name="disable_mode" type="int" setter="set_disable_mode" getter="get_disable_mode" enum="CollisionObject3D.DisableMode" default="0">
-			Defines the behavior in physics when [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED]. See [enum DisableMode] for more details about the different modes.
+			Defines the behavior in physics when [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED].
 		</member>
 		<member name="input_capture_on_drag" type="bool" setter="set_capture_input_on_drag" getter="get_capture_input_on_drag" default="false">
 			If [code]true[/code], the [CollisionObject3D] will continue to receive input events as the mouse is dragged across its shapes.

--- a/doc/classes/CollisionPolygon2D.xml
+++ b/doc/classes/CollisionPolygon2D.xml
@@ -11,7 +11,7 @@
 	</tutorials>
 	<members>
 		<member name="build_mode" type="int" setter="set_build_mode" getter="get_build_mode" enum="CollisionPolygon2D.BuildMode" default="0">
-			Collision build mode. Use one of the [enum BuildMode] constants.
+			Collision build mode.
 		</member>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false" keywords="enabled">
 			If [code]true[/code], no collisions will be detected.

--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -62,7 +62,7 @@
 			The currently selected color.
 		</member>
 		<member name="color_mode" type="int" setter="set_color_mode" getter="get_color_mode" enum="ColorPicker.ColorModeType" default="0">
-			The currently selected color mode. See [enum ColorModeType].
+			The currently selected color mode.
 		</member>
 		<member name="color_modes_visible" type="bool" setter="set_modes_visible" getter="are_modes_visible" default="true">
 			If [code]true[/code], the color mode buttons are visible.
@@ -80,7 +80,7 @@
 			If [code]true[/code], the hex color code input field is visible.
 		</member>
 		<member name="picker_shape" type="int" setter="set_picker_shape" getter="get_picker_shape" enum="ColorPicker.PickerShapeType" default="0">
-			The shape of the color space view. See [enum PickerShapeType].
+			The shape of the color space view.
 		</member>
 		<member name="presets_visible" type="bool" setter="set_presets_visible" getter="are_presets_visible" default="true">
 			If [code]true[/code], the Swatches and Recent Colors presets are visible.

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -406,7 +406,7 @@
 			<return type="int" enum="Control.CursorShape" />
 			<param index="0" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Returns the mouse cursor shape for this control when hovered over [param position] in local coordinates. For most controls, this is the same as [member mouse_default_cursor_shape], but some built-in controls implement more complex logic. See [enum CursorShape].
+				Returns the mouse cursor shape for this control when hovered over [param position] in local coordinates. For most controls, this is the same as [member mouse_default_cursor_shape], but some built-in controls implement more complex logic.
 			</description>
 		</method>
 		<method name="get_end" qualifiers="const">

--- a/doc/classes/DirectionalLight3D.xml
+++ b/doc/classes/DirectionalLight3D.xml
@@ -21,7 +21,7 @@
 			The maximum distance for shadow splits. Increasing this value will make directional shadows visible from further away, at the cost of lower overall shadow detail and performance (since more objects need to be included in the directional shadow rendering).
 		</member>
 		<member name="directional_shadow_mode" type="int" setter="set_shadow_mode" getter="get_shadow_mode" enum="DirectionalLight3D.ShadowMode" default="2">
-			The light's shadow rendering algorithm. See [enum ShadowMode].
+			The light's shadow rendering algorithm.
 		</member>
 		<member name="directional_shadow_pancake_size" type="float" setter="set_param" getter="get_param" default="20.0">
 			Sets the size of the directional shadow pancake. The pancake offsets the start of the shadow's camera frustum to provide a higher effective depth resolution for the shadow. However, a high pancake size can cause artifacts in the shadows of large objects that are close to the edge of the frustum. Reducing the pancake size can help. Setting the size to [code]0[/code] turns off the pancaking effect.
@@ -36,7 +36,7 @@
 			The distance from shadow split 2 to split 3. Relative to [member directional_shadow_max_distance]. Only used when [member directional_shadow_mode] is [constant SHADOW_PARALLEL_4_SPLITS].
 		</member>
 		<member name="sky_mode" type="int" setter="set_sky_mode" getter="get_sky_mode" enum="DirectionalLight3D.SkyMode" default="0">
-			Set whether this [DirectionalLight3D] is visible in the sky, in the scene, or both in the sky and in the scene. See [enum SkyMode] for options.
+			Whether this [DirectionalLight3D] is visible in the sky, in the scene, or both in the sky and in the scene.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -278,7 +278,7 @@
 			<param index="1" name="flag" type="int" enum="DisplayServer.AccessibilityFlags" />
 			<param index="2" name="value" type="bool" />
 			<description>
-				Sets element flag, see [enum DisplayServer.AccessibilityFlags].
+				Sets element flag.
 			</description>
 		</method>
 		<method name="accessibility_update_set_focus">
@@ -2296,7 +2296,7 @@
 			<param index="1" name="enabled" type="bool" />
 			<param index="2" name="window_id" type="int" default="0" />
 			<description>
-				Enables or disables the given window's given [param flag]. See [enum WindowFlags] for possible values and their behavior.
+				Enables or disables the given window's given [param flag].
 			</description>
 		</method>
 		<method name="window_set_ime_active">
@@ -2359,7 +2359,7 @@
 			<param index="0" name="mode" type="int" enum="DisplayServer.WindowMode" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets window mode for the given window to [param mode]. See [enum WindowMode] for possible values and how each mode behaves.
+				Sets window mode for the given window to [param mode].
 				[b]Note:[/b] On Android, setting it to [constant WINDOW_MODE_FULLSCREEN] or [constant WINDOW_MODE_EXCLUSIVE_FULLSCREEN] will enable immersive mode.
 				[b]Note:[/b] Setting the window to full screen forcibly sets the borderless flag to [code]true[/code], so make sure to set it back to [code]false[/code] when not wanted.
 			</description>
@@ -2468,7 +2468,6 @@
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
 				Sets the V-Sync mode of the given window. See also [member ProjectSettings.display/window/vsync/vsync_mode].
-				See [enum DisplayServer.VSyncMode] for possible values and how they affect the behavior of your application.
 				Depending on the platform and used renderer, the engine will fall back to [constant VSYNC_ENABLED] if the desired mode is not supported.
 				[b]Note:[/b] V-Sync modes other than [constant VSYNC_ENABLED] are only supported in the Forward+ and Mobile rendering methods, not Compatibility.
 			</description>

--- a/doc/classes/EditorFileDialog.xml
+++ b/doc/classes/EditorFileDialog.xml
@@ -162,7 +162,7 @@
 			The view format in which the [EditorFileDialog] displays resources to the user.
 		</member>
 		<member name="file_mode" type="int" setter="set_file_mode" getter="get_file_mode" enum="EditorFileDialog.FileMode" default="4">
-			The dialog's open or save mode, which affects the selection behavior. See [enum FileMode].
+			The dialog's open or save mode, which affects the selection behavior.
 		</member>
 		<member name="filters" type="PackedStringArray" setter="set_filters" getter="get_filters" default="PackedStringArray()">
 			The available file type filters. For example, this shows only [code].png[/code] and [code].gd[/code] files: [code]set_filters(PackedStringArray(["*.png ; PNG Images","*.gd ; GDScript Files"]))[/code]. Multiple file types can also be specified in a single filter. [code]"*.png, *.jpg, *.jpeg ; Supported Images"[/code] will show both PNG and JPEG files when selected.

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -407,7 +407,7 @@
 			<param index="1" name="plugin" type="EditorContextMenuPlugin" />
 			<description>
 				Adds a plugin to the context menu. [param slot] is the context menu where the plugin will be added.
-				See [enum EditorContextMenuPlugin.ContextMenuSlot] for available context menus. A plugin instance can belong only to a single context menu slot.
+				[b]Note:[/b] A plugin instance can belong only to a single context menu slot.
 			</description>
 		</method>
 		<method name="add_control_to_bottom_panel">
@@ -425,7 +425,7 @@
 			<param index="0" name="container" type="int" enum="EditorPlugin.CustomControlContainer" />
 			<param index="1" name="control" type="Control" />
 			<description>
-				Adds a custom control to a container (see [enum CustomControlContainer]). There are many locations where custom controls can be added in the editor UI.
+				Adds a custom control to a container in the editor UI.
 				Please remember that you have to manage the visibility of your custom controls yourself (and likely hide it after adding it).
 				When your plugin is deactivated, make sure to remove your custom control with [method remove_control_from_container] and free it with [method Node.queue_free].
 			</description>
@@ -436,7 +436,7 @@
 			<param index="1" name="control" type="Control" />
 			<param index="2" name="shortcut" type="Shortcut" default="null" />
 			<description>
-				Adds the control to a specific dock slot (see [enum DockSlot] for options).
+				Adds the control to a specific dock slot.
 				If the dock is repositioned and as long as the plugin is active, the editor will save the dock position on further sessions.
 				When your plugin is deactivated, make sure to remove your custom control with [method remove_control_from_docks] and free it with [method Node.queue_free].
 				Optionally, you can specify a shortcut parameter. When pressed, this shortcut will open and focus the dock.

--- a/doc/classes/EditorUndoRedoManager.xml
+++ b/doc/classes/EditorUndoRedoManager.xml
@@ -99,7 +99,7 @@
 			<param index="4" name="mark_unsaved" type="bool" default="true" />
 			<description>
 				Create a new action. After this is called, do all your calls to [method add_do_method], [method add_undo_method], [method add_do_property], and [method add_undo_property], then commit the action with [method commit_action].
-				The way actions are merged is dictated by the [param merge_mode] argument. See [enum UndoRedo.MergeMode] for details.
+				The way actions are merged is dictated by the [param merge_mode] argument.
 				If [param custom_context] object is provided, it will be used for deducing target history (instead of using the first operation).
 				The way undo operation are ordered in actions is dictated by [param backward_undo_ops]. When [param backward_undo_ops] is [code]false[/code] undo option are ordered in the same order they were added. Which means the first operation to be added will be the first to be undone.
 				If [param mark_unsaved] is [code]false[/code], the action will not mark the history as unsaved. This is useful for example for actions that change a selection, or a setting that will be saved automatically. Otherwise, this should be left to [code]true[/code] if the action requires saving by the user or if it can cause data loss when left unsaved.

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -78,7 +78,7 @@
 			Luminance of background measured in nits (candela per square meter). Only used when [member ProjectSettings.rendering/lights_and_shadows/use_physical_light_units] is enabled. The default value is roughly equivalent to the sky at midday.
 		</member>
 		<member name="background_mode" type="int" setter="set_background" getter="get_background" enum="Environment.BGMode" default="0">
-			The background mode. See [enum BGMode] for possible values.
+			The background mode.
 		</member>
 		<member name="fog_aerial_perspective" type="float" setter="set_fog_aerial_perspective" getter="get_fog_aerial_perspective" default="0.0">
 			If set above [code]0.0[/code] (exclusive), blends between the fog's color and the color of the background [Sky], as read from the radiance cubemap. This has a small performance cost when set above [code]0.0[/code]. Must have [member background_mode] set to [constant BG_SKY].
@@ -115,7 +115,7 @@
 			The fog's brightness. Higher values result in brighter fog.
 		</member>
 		<member name="fog_mode" type="int" setter="set_fog_mode" getter="get_fog_mode" enum="Environment.FogMode" default="0">
-			The fog mode. See [enum FogMode] for possible values.
+			The fog mode.
 		</member>
 		<member name="fog_sky_affect" type="float" setter="set_fog_sky_affect" getter="get_fog_sky_affect" default="1.0">
 			The factor to use when affecting the sky with non-volumetric fog. [code]1.0[/code] means that fog can fully obscure the sky. Lower values reduce the impact of fog on sky rendering, with [code]0.0[/code] not affecting sky rendering at all.

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -123,7 +123,7 @@
 	</methods>
 	<members>
 		<member name="access" type="int" setter="set_access" getter="get_access" enum="FileDialog.Access" default="0">
-			The file system access scope. See [enum Access] constants.
+			The file system access scope.
 			[b]Warning:[/b] In Web builds, FileDialog cannot access the host file system. In sandboxed Linux and macOS environments, [member use_native_dialog] is automatically used to allow limited access to host file system.
 		</member>
 		<member name="current_dir" type="String" setter="set_current_dir" getter="get_current_dir">
@@ -141,7 +141,7 @@
 			Display mode of the dialog's file list.
 		</member>
 		<member name="file_mode" type="int" setter="set_file_mode" getter="get_file_mode" enum="FileDialog.FileMode" default="4">
-			The dialog's open or save mode, which affects the selection behavior. See [enum FileMode].
+			The dialog's open or save mode, which affects the selection behavior.
 		</member>
 		<member name="filename_filter" type="String" setter="set_filename_filter" getter="get_filename_filter" default="&quot;&quot;">
 			The filter for file names (case-insensitive). When set to a non-empty string, only files that contains the substring will be shown. [member filename_filter] can be edited by the user with the filter button at the top of the file dialog.

--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -175,7 +175,7 @@
 		<method name="get_font_style" qualifiers="const">
 			<return type="int" enum="TextServer.FontStyle" is_bitfield="true" />
 			<description>
-				Returns font style flags, see [enum TextServer.FontStyle].
+				Returns font style flags.
 			</description>
 		</method>
 		<method name="get_font_style_name" qualifiers="const">
@@ -236,7 +236,7 @@
 			<return type="int" />
 			<param index="0" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<description>
-				Returns the spacing for the given [code]type[/code] (see [enum TextServer.SpacingType]).
+				Returns the amount of spacing for the given [param spacing] type.
 			</description>
 		</method>
 		<method name="get_string_size" qualifiers="const">

--- a/doc/classes/FontFile.xml
+++ b/doc/classes/FontFile.xml
@@ -143,7 +143,7 @@
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<description>
-				Returns spacing for [param spacing] (see [enum TextServer.SpacingType]) in pixels (not relative to the font size).
+				Returns spacing for [param spacing] in pixels (not relative to the font size).
 			</description>
 		</method>
 		<method name="get_face_index" qualifiers="const">
@@ -466,7 +466,7 @@
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<param index="2" name="value" type="int" />
 			<description>
-				Sets the spacing for [param spacing] (see [enum TextServer.SpacingType]) to [param value] in pixels (not relative to the font size).
+				Sets the spacing for [param spacing] to [param value] in pixels (not relative to the font size).
 			</description>
 		</method>
 		<method name="set_face_index">
@@ -617,7 +617,7 @@
 			Font stretch amount, compared to a normal width. A percentage value between [code]50%[/code] and [code]200%[/code].
 		</member>
 		<member name="font_style" type="int" setter="set_font_style" getter="get_font_style" enum="TextServer.FontStyle" is_bitfield="true" default="0">
-			Font style flags, see [enum TextServer.FontStyle].
+			Font style flags.
 		</member>
 		<member name="font_weight" type="int" setter="set_font_weight" getter="get_font_weight" default="400">
 			Weight (boldness) of the font. A value in the [code]100...999[/code] range, normal font weight is [code]400[/code], bold font weight is [code]700[/code].

--- a/doc/classes/FontVariation.xml
+++ b/doc/classes/FontVariation.xml
@@ -38,7 +38,7 @@
 			<param index="0" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<param index="1" name="value" type="int" />
 			<description>
-				Sets the spacing for [param spacing] (see [enum TextServer.SpacingType]) to [param value] in pixels (not relative to the font size).
+				Sets the spacing for [param spacing] to [param value] in pixels (not relative to the font size).
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/GPUParticles2D.xml
+++ b/doc/classes/GPUParticles2D.xml
@@ -73,7 +73,7 @@
 			[b]Note:[/b] Particles always have a spherical collision shape.
 		</member>
 		<member name="draw_order" type="int" setter="set_draw_order" getter="get_draw_order" enum="GPUParticles2D.DrawOrder" default="1">
-			Particle draw order. Uses [enum DrawOrder] values.
+			Particle draw order.
 		</member>
 		<member name="emitting" type="bool" setter="set_emitting" getter="is_emitting" default="true">
 			If [code]true[/code], particles are being emitted. [member emitting] can be used to start and stop particles from emitting. However, if [member one_shot] is [code]true[/code] setting [member emitting] to [code]true[/code] will not restart the emission cycle unless all active particles have finished processing. Use the [signal finished] signal to be notified once all active particles finish processing.

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -86,7 +86,7 @@
 			[b]Note:[/b] Particles always have a spherical collision shape.
 		</member>
 		<member name="draw_order" type="int" setter="set_draw_order" getter="get_draw_order" enum="GPUParticles3D.DrawOrder" default="0">
-			Particle draw order. Uses [enum DrawOrder] values.
+			Particle draw order.
 			[b]Note:[/b] [constant DRAW_ORDER_INDEX] is the only option that supports motion vectors for effects like TAA. It is suggested to use this draw order if the particles are opaque to fix ghosting artifacts.
 		</member>
 		<member name="draw_pass_1" type="Mesh" setter="set_draw_pass_mesh" getter="get_draw_pass_mesh">

--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -193,7 +193,7 @@
 			<param index="2" name="join_type" type="int" enum="Geometry2D.PolyJoinType" default="0" />
 			<description>
 				Inflates or deflates [param polygon] by [param delta] units (pixels). If [param delta] is positive, makes the polygon grow outward. If [param delta] is negative, shrinks the polygon inward. Returns an array of polygons because inflating/deflating may result in multiple discrete polygons. Returns an empty array if [param delta] is negative and the absolute value of it approximately exceeds the minimum bounding rectangle dimensions of the polygon.
-				Each polygon's vertices will be rounded as determined by [param join_type], see [enum PolyJoinType].
+				Each polygon's vertices will be rounded as determined by [param join_type].
 				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
 				[b]Note:[/b] To translate the polygon's vertices specifically, multiply them to a [Transform2D]:
 				[codeblocks]
@@ -220,8 +220,8 @@
 			<param index="3" name="end_type" type="int" enum="Geometry2D.PolyEndType" default="3" />
 			<description>
 				Inflates or deflates [param polyline] by [param delta] units (pixels), producing polygons. If [param delta] is positive, makes the polyline grow outward. Returns an array of polygons because inflating/deflating may result in multiple discrete polygons. If [param delta] is negative, returns an empty array.
-				Each polygon's vertices will be rounded as determined by [param join_type], see [enum PolyJoinType].
-				Each polygon's endpoints will be rounded as determined by [param end_type], see [enum PolyEndType].
+				Each polygon's vertices will be rounded as determined by [param join_type].
+				Each polygon's endpoints will be rounded as determined by [param end_type].
 				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
 			</description>
 		</method>

--- a/doc/classes/GeometryInstance3D.xml
+++ b/doc/classes/GeometryInstance3D.xml
@@ -31,7 +31,7 @@
 	</methods>
 	<members>
 		<member name="cast_shadow" type="int" setter="set_cast_shadows_setting" getter="get_cast_shadows_setting" enum="GeometryInstance3D.ShadowCastingSetting" default="1">
-			The selected shadow casting flag. See [enum ShadowCastingSetting] for possible values.
+			The selected shadow casting flag.
 		</member>
 		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)">
 			Overrides the bounding box of this node with a custom one. This can be used to avoid the expensive [AABB] recalculation that happens when a skeleton is used with a [MeshInstance3D] or to have precise control over the [MeshInstance3D]'s bounding box. To use the default AABB, set value to an [AABB] with all fields set to [code]0.0[/code]. To avoid frustum culling, set [member custom_aabb] to a very large AABB that covers your entire game world such as [code]AABB(-10000, -10000, -10000, 20000, 20000, 20000)[/code]. To disable all forms of culling (including occlusion culling), call [method RenderingServer.instance_set_ignore_culling] on the [GeometryInstance3D]'s [RID].
@@ -87,7 +87,7 @@
 			If [member visibility_range_fade_mode] is [constant VISIBILITY_RANGE_FADE_DISABLED], this acts as a hysteresis distance. If [member visibility_range_fade_mode] is [constant VISIBILITY_RANGE_FADE_SELF] or [constant VISIBILITY_RANGE_FADE_DEPENDENCIES], this acts as a fade transition distance and must be set to a value greater than [code]0.0[/code] for the effect to be noticeable.
 		</member>
 		<member name="visibility_range_fade_mode" type="int" setter="set_visibility_range_fade_mode" getter="get_visibility_range_fade_mode" enum="GeometryInstance3D.VisibilityRangeFadeMode" default="0" keywords="lod_fade_mode, hlod_fade_mode">
-			Controls which instances will be faded when approaching the limits of the visibility range. See [enum VisibilityRangeFadeMode] for possible values.
+			Controls which instances will be faded when approaching the limits of the visibility range.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/Gradient.xml
+++ b/doc/classes/Gradient.xml
@@ -82,11 +82,11 @@
 			[b]Note:[/b] Setting this property updates all colors at once. To update any color individually use [method set_color].
 		</member>
 		<member name="interpolation_color_space" type="int" setter="set_interpolation_color_space" getter="get_interpolation_color_space" enum="Gradient.ColorSpace" default="0">
-			The color space used to interpolate between points of the gradient. It does not affect the returned colors, which will always be in sRGB space. See [enum ColorSpace] for available modes.
+			The color space used to interpolate between points of the gradient. It does not affect the returned colors, which will always be in sRGB space.
 			[b]Note:[/b] This setting has no effect when [member interpolation_mode] is set to [constant GRADIENT_INTERPOLATE_CONSTANT].
 		</member>
 		<member name="interpolation_mode" type="int" setter="set_interpolation_mode" getter="get_interpolation_mode" enum="Gradient.InterpolationMode" default="0">
-			The algorithm used to interpolate between points of the gradient. See [enum InterpolationMode] for available modes.
+			The algorithm used to interpolate between points of the gradient.
 		</member>
 		<member name="offsets" type="PackedFloat32Array" setter="set_offsets" getter="get_offsets" default="PackedFloat32Array(0, 1)">
 			Gradient's offsets as a [PackedFloat32Array].

--- a/doc/classes/GradientTexture2D.xml
+++ b/doc/classes/GradientTexture2D.xml
@@ -4,13 +4,14 @@
 		A 2D texture that creates a pattern with colors obtained from a [Gradient].
 	</brief_description>
 	<description>
-		A 2D texture that obtains colors from a [Gradient] to fill the texture data. This texture is able to transform a color transition into different patterns such as a linear or a radial gradient. The gradient is sampled individually for each pixel so it does not necessarily represent an exact copy of the gradient(see [member width] and [member height]). See also [GradientTexture1D], [CurveTexture] and [CurveXYZTexture].
+		A 2D texture that obtains colors from a [Gradient] to fill the texture data. This texture is able to transform a color transition into different patterns such as a linear or a radial gradient. The texture is filled by interpolating colors starting from [member fill_from] to [member fill_to] offsets by default, but the gradient fill can be repeated to cover the entire texture.
+		The gradient is sampled individually for each pixel so it does not necessarily represent an exact copy of the gradient (see [member width] and [member height]). See also [GradientTexture1D], [CurveTexture] and [CurveXYZTexture].
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="fill" type="int" setter="set_fill" getter="get_fill" enum="GradientTexture2D.Fill" default="0">
-			The gradient fill type, one of the [enum Fill] values. The texture is filled by interpolating colors starting from [member fill_from] to [member fill_to] offsets.
+			The gradient's fill type.
 		</member>
 		<member name="fill_from" type="Vector2" setter="set_fill_from" getter="get_fill_from" default="Vector2(0, 0)">
 			The initial offset used to fill the texture specified in UV coordinates.
@@ -25,7 +26,7 @@
 			The number of vertical color samples that will be obtained from the [Gradient], which also represents the texture's height.
 		</member>
 		<member name="repeat" type="int" setter="set_repeat" getter="get_repeat" enum="GradientTexture2D.Repeat" default="0">
-			The gradient repeat type, one of the [enum Repeat] values. The texture is filled starting from [member fill_from] to [member fill_to] offsets by default, but the gradient fill can be repeated to cover the entire texture.
+			The gradient's repeat type.
 		</member>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="use_hdr" type="bool" setter="set_use_hdr" getter="is_using_hdr" default="false">

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -142,9 +142,9 @@
 			<param index="2" name="headers" type="PackedStringArray" />
 			<param index="3" name="body" type="String" default="&quot;&quot;" />
 			<description>
-				Sends a request to the connected host.
+				Sends an HTTP request to the connected host with the given [param method].
 				The URL parameter is usually just the part after the host, so for [code]https://example.com/index.php[/code], it is [code]/index.php[/code]. When sending requests to an HTTP proxy server, it should be an absolute URL. For [constant HTTPClient.METHOD_OPTIONS] requests, [code]*[/code] is also allowed. For [constant HTTPClient.METHOD_CONNECT] requests, it should be the authority component ([code]host:port[/code]).
-				Headers are HTTP request headers. For available HTTP methods, see [enum Method].
+				[param headers] are HTTP request headers.
 				To create a POST request with query strings to push to the server, do:
 				[codeblocks]
 				[gdscript]
@@ -170,9 +170,9 @@
 			<param index="2" name="headers" type="PackedStringArray" />
 			<param index="3" name="body" type="PackedByteArray" />
 			<description>
-				Sends a raw request to the connected host.
+				Sends a raw HTTP request to the connected host with the given [param method].
 				The URL parameter is usually just the part after the host, so for [code]https://example.com/index.php[/code], it is [code]/index.php[/code]. When sending requests to an HTTP proxy server, it should be an absolute URL. For [constant HTTPClient.METHOD_OPTIONS] requests, [code]*[/code] is also allowed. For [constant HTTPClient.METHOD_CONNECT] requests, it should be the authority component ([code]host:port[/code]).
-				Headers are HTTP request headers. For available HTTP methods, see [enum Method].
+				[param headers] are HTTP request headers.
 				Sends the body data raw, as a byte array and does not encode it in any way.
 			</description>
 		</method>

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -179,7 +179,7 @@
 		<method name="get_http_client_status" qualifiers="const">
 			<return type="int" enum="HTTPClient.Status" />
 			<description>
-				Returns the current status of the underlying [HTTPClient]. See [enum HTTPClient.Status].
+				Returns the current status of the underlying [HTTPClient].
 			</description>
 		</method>
 		<method name="request">

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -109,7 +109,7 @@
 			<return type="void" />
 			<param index="0" name="format" type="int" enum="Image.Format" />
 			<description>
-				Converts the image's format. See [enum Format] constants.
+				Converts this image's format to the given [param format].
 			</description>
 		</method>
 		<method name="copy_from">
@@ -126,7 +126,7 @@
 			<param index="2" name="use_mipmaps" type="bool" />
 			<param index="3" name="format" type="int" enum="Image.Format" />
 			<description>
-				Creates an empty image of given size and format. See [enum Format] constants. If [param use_mipmaps] is [code]true[/code], then generate mipmaps for this image. See the [method generate_mipmaps].
+				Creates an empty image of the given size and format. If [param use_mipmaps] is [code]true[/code], generates mipmaps for this image. See the [method generate_mipmaps].
 			</description>
 		</method>
 		<method name="create_empty" qualifiers="static">
@@ -136,7 +136,7 @@
 			<param index="2" name="use_mipmaps" type="bool" />
 			<param index="3" name="format" type="int" enum="Image.Format" />
 			<description>
-				Creates an empty image of given size and format. See [enum Format] constants. If [param use_mipmaps] is [code]true[/code], then generate mipmaps for this image. See the [method generate_mipmaps].
+				Creates an empty image of the given size and format. If [param use_mipmaps] is [code]true[/code], generates mipmaps for this image. See the [method generate_mipmaps].
 			</description>
 		</method>
 		<method name="create_from_data" qualifiers="static">
@@ -147,7 +147,7 @@
 			<param index="3" name="format" type="int" enum="Image.Format" />
 			<param index="4" name="data" type="PackedByteArray" />
 			<description>
-				Creates a new image of given size and format. See [enum Format] constants. Fills the image with the given raw data. If [param use_mipmaps] is [code]true[/code] then loads mipmaps for this image from [param data]. See [method generate_mipmaps].
+				Creates a new image of the given size and format. Fills the image with the given raw data. If [param use_mipmaps] is [code]true[/code], loads the mipmaps for this image from [param data]. See [method generate_mipmaps].
 			</description>
 		</method>
 		<method name="crop">
@@ -175,7 +175,7 @@
 			<return type="int" enum="Image.UsedChannels" />
 			<param index="0" name="source" type="int" enum="Image.CompressSource" default="0" />
 			<description>
-				Returns the color channels used by this image, as one of the [enum UsedChannels] constants. If the image is compressed, the original [param source] must be specified.
+				Returns the color channels used by this image. If the image is compressed, the original [param source] must be specified.
 			</description>
 		</method>
 		<method name="fill">
@@ -234,7 +234,7 @@
 		<method name="get_format" qualifiers="const">
 			<return type="int" enum="Image.Format" />
 			<description>
-				Returns the image's format. See [enum Format] constants.
+				Returns this image's format.
 			</description>
 		</method>
 		<method name="get_height" qualifiers="const">

--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -39,7 +39,7 @@
 		<method name="get_format" qualifiers="const">
 			<return type="int" enum="Image.Format" />
 			<description>
-				Returns the format of the texture, one of [enum Image.Format].
+				Returns the format of the texture.
 			</description>
 		</method>
 		<method name="set_image">

--- a/doc/classes/ImageTexture3D.xml
+++ b/doc/classes/ImageTexture3D.xml
@@ -19,7 +19,7 @@
 			<param index="4" name="use_mipmaps" type="bool" />
 			<param index="5" name="data" type="Image[]" />
 			<description>
-				Creates the [ImageTexture3D] with specified [param width], [param height], and [param depth]. See [enum Image.Format] for [param format] options. If [param use_mipmaps] is [code]true[/code], then generate mipmaps for the [ImageTexture3D].
+				Creates the [ImageTexture3D] with specified [param format], [param width], [param height], and [param depth]. If [param use_mipmaps] is [code]true[/code], generates mipmaps for the [ImageTexture3D].
 			</description>
 		</method>
 		<method name="update">

--- a/doc/classes/ImporterMesh.xml
+++ b/doc/classes/ImporterMesh.xml
@@ -165,7 +165,7 @@
 			<return type="void" />
 			<param index="0" name="mode" type="int" enum="Mesh.BlendShapeMode" />
 			<description>
-				Sets the blend shape mode to one of [enum Mesh.BlendShapeMode].
+				Sets the blend shape mode.
 			</description>
 		</method>
 		<method name="set_lightmap_size_hint">

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -90,7 +90,7 @@
 		<method name="get_current_cursor_shape" qualifiers="const">
 			<return type="int" enum="Input.CursorShape" />
 			<description>
-				Returns the currently assigned cursor shape (see [enum CursorShape]).
+				Returns the currently assigned cursor shape.
 			</description>
 		</method>
 		<method name="get_gravity" qualifiers="const">
@@ -114,7 +114,7 @@
 			<param index="0" name="device" type="int" />
 			<param index="1" name="axis" type="int" enum="JoyAxis" />
 			<description>
-				Returns the current value of the joypad axis at given index (see [enum JoyAxis]).
+				Returns the current value of the joypad axis at index [param axis].
 			</description>
 		</method>
 		<method name="get_joy_guid" qualifiers="const">
@@ -247,7 +247,7 @@
 			<param index="0" name="device" type="int" />
 			<param index="1" name="button" type="int" enum="JoyButton" />
 			<description>
-				Returns [code]true[/code] if you are pressing the joypad button (see [enum JoyButton]).
+				Returns [code]true[/code] if you are pressing the joypad button at index [param button].
 			</description>
 		</method>
 		<method name="is_joy_known" keywords="is_gamepad_known, is_controller_known">
@@ -333,7 +333,7 @@
 			<param index="1" name="shape" type="int" enum="Input.CursorShape" default="0" />
 			<param index="2" name="hotspot" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Sets a custom mouse cursor image, which is only visible inside the game window. The hotspot can also be specified. Passing [code]null[/code] to the image parameter resets to the system cursor. See [enum CursorShape] for the list of shapes.
+				Sets a custom mouse cursor image, which is only visible inside the game window, for the given mouse [param shape]. The hotspot can also be specified. Passing [code]null[/code] to the image parameter resets to the system cursor.
 				[param image] can be either [Texture2D] or [Image] and its size must be lower than or equal to 256×256. To avoid rendering issues, sizes lower than or equal to 128×128 are recommended.
 				[param hotspot] must be within [param image]'s size.
 				[b]Note:[/b] [AnimatedTexture]s aren't supported as custom mouse cursors. If using an [AnimatedTexture], only the first frame will be displayed.
@@ -434,7 +434,7 @@
 			If [code]true[/code], sends touch input events when clicking or dragging the mouse. See also [member ProjectSettings.input_devices/pointing/emulate_touch_from_mouse].
 		</member>
 		<member name="mouse_mode" type="int" setter="set_mouse_mode" getter="get_mouse_mode" enum="Input.MouseMode">
-			Controls the mouse mode. See [enum MouseMode] for more information.
+			Controls the mouse mode.
 		</member>
 		<member name="use_accumulated_input" type="bool" setter="set_use_accumulated_input" getter="is_using_accumulated_input">
 			If [code]true[/code], similar input events sent by the operating system are accumulated. When input accumulation is enabled, all input events generated during a frame will be merged and emitted when the frame is done rendering. Therefore, this limits the number of input method calls per second to the rendering FPS.

--- a/doc/classes/InputEventJoypadMotion.xml
+++ b/doc/classes/InputEventJoypadMotion.xml
@@ -11,7 +11,7 @@
 	</tutorials>
 	<members>
 		<member name="axis" type="int" setter="set_axis" getter="get_axis" enum="JoyAxis" default="0">
-			Axis identifier. Use one of the [enum JoyAxis] axis constants.
+			Axis identifier.
 		</member>
 		<member name="axis_value" type="float" setter="set_axis_value" getter="get_axis_value" default="0.0">
 			Current position of the joystick on the given axis. The value ranges from [code]-1.0[/code] to [code]1.0[/code]. A value of [code]0[/code] means the axis is in its resting position.

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -425,7 +425,7 @@
 			Allows single or multiple item selection. See the [enum SelectMode] constants.
 		</member>
 		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="3">
-			Sets the clipping behavior when the text exceeds an item's bounding rectangle. See [enum TextServer.OverrunBehavior] for a description of all modes.
+			The clipping behavior when the text exceeds an item's bounding rectangle.
 		</member>
 		<member name="wraparound_items" type="bool" setter="set_wraparound_items" getter="has_wraparound_items" default="true">
 			If [code]true[/code], the control will automatically move items into a new row to fit its content. See also [HFlowContainer] for this behavior.

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -47,7 +47,7 @@
 	</methods>
 	<members>
 		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="TextServer.AutowrapMode" default="0">
-			If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text. To see how each mode behaves, see [enum TextServer.AutowrapMode].
+			If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text.
 		</member>
 		<member name="autowrap_trim_flags" type="int" setter="set_autowrap_trim_flags" getter="get_autowrap_trim_flags" enum="TextServer.LineBreakFlag" is_bitfield="true" default="192">
 			Autowrap space trimming flags. See [constant TextServer.BREAK_TRIM_START_EDGE_SPACES] and [constant TextServer.BREAK_TRIM_END_EDGE_SPACES] for more info.
@@ -59,10 +59,10 @@
 			Ellipsis character used for text clipping.
 		</member>
 		<member name="horizontal_alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="0">
-			Controls the text's horizontal alignment. Supports left, center, right, and fill, or justify. Set it to one of the [enum HorizontalAlignment] constants.
+			Controls the text's horizontal alignment. Supports left, center, right, and fill (also known as justify).
 		</member>
 		<member name="justification_flags" type="int" setter="set_justification_flags" getter="get_justification_flags" enum="TextServer.JustificationFlag" is_bitfield="true" default="163">
-			Line fill alignment rules. See [enum TextServer.JustificationFlag] for more information.
+			Line fill alignment rules.
 		</member>
 		<member name="label_settings" type="LabelSettings" setter="set_label_settings" getter="get_label_settings">
 			A [LabelSettings] resource that can be shared between multiple [Label] nodes. Takes priority over theme properties.
@@ -97,20 +97,20 @@
 			Base text writing direction.
 		</member>
 		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="0">
-			Sets the clipping behavior when the text exceeds the node's bounding rectangle. See [enum TextServer.OverrunBehavior] for a description of all modes.
+			The clipping behavior when the text exceeds the node's bounding rectangle.
 		</member>
 		<member name="uppercase" type="bool" setter="set_uppercase" getter="is_uppercase" default="false">
 			If [code]true[/code], all the text displays as UPPERCASE.
 		</member>
 		<member name="vertical_alignment" type="int" setter="set_vertical_alignment" getter="get_vertical_alignment" enum="VerticalAlignment" default="0">
-			Controls the text's vertical alignment. Supports top, center, bottom, and fill. Set it to one of the [enum VerticalAlignment] constants.
+			Controls the text's vertical alignment. Supports top, center, bottom, and fill.
 		</member>
 		<member name="visible_characters" type="int" setter="set_visible_characters" getter="get_visible_characters" default="-1">
 			The number of characters to display. If set to [code]-1[/code], all characters are displayed. This can be useful when animating the text appearing in a dialog box.
 			[b]Note:[/b] Setting this property updates [member visible_ratio] accordingly.
 		</member>
 		<member name="visible_characters_behavior" type="int" setter="set_visible_characters_behavior" getter="get_visible_characters_behavior" enum="TextServer.VisibleCharactersBehavior" default="0">
-			Sets the clipping behavior when [member visible_characters] or [member visible_ratio] is set. See [enum TextServer.VisibleCharactersBehavior] for more info.
+			The clipping behavior when [member visible_characters] or [member visible_ratio] is set.
 		</member>
 		<member name="visible_ratio" type="float" setter="set_visible_ratio" getter="get_visible_ratio" default="1.0">
 			The fraction of characters to display, relative to the total number of characters (see [method get_total_character_count]). If set to [code]1.0[/code], all characters are displayed. If set to [code]0.5[/code], only half of the characters will be displayed. This can be useful when animating the text appearing in a dialog box.

--- a/doc/classes/Label3D.xml
+++ b/doc/classes/Label3D.xml
@@ -28,7 +28,7 @@
 			<param index="0" name="flag" type="int" enum="Label3D.DrawFlags" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [code]true[/code], the specified flag will be enabled. See [enum Label3D.DrawFlags] for a list of flags.
+				If [code]true[/code], the specified [param flag] will be enabled.
 			</description>
 		</method>
 	</methods>
@@ -37,10 +37,10 @@
 			Threshold at which antialiasing will be applied on the alpha channel.
 		</member>
 		<member name="alpha_antialiasing_mode" type="int" setter="set_alpha_antialiasing" getter="get_alpha_antialiasing" enum="BaseMaterial3D.AlphaAntiAliasing" default="0">
-			The type of alpha antialiasing to apply. See [enum BaseMaterial3D.AlphaAntiAliasing].
+			The type of alpha antialiasing to apply.
 		</member>
 		<member name="alpha_cut" type="int" setter="set_alpha_cut_mode" getter="get_alpha_cut_mode" enum="Label3D.AlphaCutMode" default="0">
-			The alpha cutting mode to use for the sprite. See [enum AlphaCutMode] for possible values.
+			The alpha cutting mode to use for the sprite.
 		</member>
 		<member name="alpha_hash_scale" type="float" setter="set_alpha_hash_scale" getter="get_alpha_hash_scale" default="1.0">
 			The hashing scale for Alpha Hash. Recommended values between [code]0[/code] and [code]2[/code].
@@ -49,13 +49,13 @@
 			Threshold at which the alpha scissor will discard values.
 		</member>
 		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="TextServer.AutowrapMode" default="0">
-			If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text. To see how each mode behaves, see [enum TextServer.AutowrapMode].
+			If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text.
 		</member>
 		<member name="autowrap_trim_flags" type="int" setter="set_autowrap_trim_flags" getter="get_autowrap_trim_flags" enum="TextServer.LineBreakFlag" is_bitfield="true" default="192">
 			Autowrap space trimming flags. See [constant TextServer.BREAK_TRIM_START_EDGE_SPACES] and [constant TextServer.BREAK_TRIM_END_EDGE_SPACES] for more info.
 		</member>
 		<member name="billboard" type="int" setter="set_billboard_mode" getter="get_billboard_mode" enum="BaseMaterial3D.BillboardMode" default="0">
-			The billboard mode to use for the label. See [enum BaseMaterial3D.BillboardMode] for possible values.
+			The billboard mode to use for the label.
 		</member>
 		<member name="cast_shadow" type="int" setter="set_cast_shadows_setting" getter="get_cast_shadows_setting" overrides="GeometryInstance3D" enum="GeometryInstance3D.ShadowCastingSetting" default="0" />
 		<member name="double_sided" type="bool" setter="set_draw_flag" getter="get_draw_flag" default="true">
@@ -73,10 +73,10 @@
 		</member>
 		<member name="gi_mode" type="int" setter="set_gi_mode" getter="get_gi_mode" overrides="GeometryInstance3D" enum="GeometryInstance3D.GIMode" default="0" />
 		<member name="horizontal_alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="1">
-			Controls the text's horizontal alignment. Supports left, center, right, and fill, or justify. Set it to one of the [enum HorizontalAlignment] constants.
+			Controls the text's horizontal alignment. Supports left, center, right, and fill (also known as justify).
 		</member>
 		<member name="justification_flags" type="int" setter="set_justification_flags" getter="get_justification_flags" enum="TextServer.JustificationFlag" is_bitfield="true" default="163">
-			Line fill alignment rules. See [enum TextServer.JustificationFlag] for more information.
+			Line fill alignment rules.
 		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
@@ -128,13 +128,13 @@
 			Base text writing direction.
 		</member>
 		<member name="texture_filter" type="int" setter="set_texture_filter" getter="get_texture_filter" enum="BaseMaterial3D.TextureFilter" default="3">
-			Filter flags for the texture. See [enum BaseMaterial3D.TextureFilter] for options.
+			Filter flags for the texture.
 		</member>
 		<member name="uppercase" type="bool" setter="set_uppercase" getter="is_uppercase" default="false">
 			If [code]true[/code], all the text displays as UPPERCASE.
 		</member>
 		<member name="vertical_alignment" type="int" setter="set_vertical_alignment" getter="get_vertical_alignment" enum="VerticalAlignment" default="1">
-			Controls the text's vertical alignment. Supports top, center, bottom. Set it to one of the [enum VerticalAlignment] constants.
+			Controls the text's vertical alignment. Supports top, center, and bottom.
 		</member>
 		<member name="width" type="float" setter="set_width" getter="get_width" default="500.0">
 			Text width (in pixels), used for autowrap and fill alignment.

--- a/doc/classes/Light2D.xml
+++ b/doc/classes/Light2D.xml
@@ -26,7 +26,7 @@
 	</methods>
 	<members>
 		<member name="blend_mode" type="int" setter="set_blend_mode" getter="get_blend_mode" enum="Light2D.BlendMode" default="0">
-			The Light2D's blend mode. See [enum BlendMode] constants for values.
+			The Light2D's blend mode.
 		</member>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)" keywords="colour">
 			The Light2D's [Color].
@@ -63,7 +63,7 @@
 			If [code]true[/code], the Light2D will cast shadows.
 		</member>
 		<member name="shadow_filter" type="int" setter="set_shadow_filter" getter="get_shadow_filter" enum="Light2D.ShadowFilter" default="0">
-			Shadow filter type. See [enum ShadowFilter] for possible values.
+			Shadow filter type.
 		</member>
 		<member name="shadow_filter_smooth" type="float" setter="set_shadow_smooth" getter="get_shadow_smooth" default="0.0">
 			Smoothing value for shadows. Higher values will result in softer shadows, at the cost of visible streaks that can appear in shadow rendering. [member shadow_filter_smooth] only has an effect if [member shadow_filter] is [constant SHADOW_FILTER_PCF5] or [constant SHADOW_FILTER_PCF13].

--- a/doc/classes/Light3D.xml
+++ b/doc/classes/Light3D.xml
@@ -60,7 +60,7 @@
 			[b]Note:[/b] PCSS for directional lights is only supported in the Forward+ rendering method, not Mobile or Compatibility.
 		</member>
 		<member name="light_bake_mode" type="int" setter="set_bake_mode" getter="get_bake_mode" enum="Light3D.BakeMode" default="2" keywords="global_illumination_mode, gi_mode">
-			The light's bake mode. This will affect the global illumination techniques that have an effect on the light's rendering. See [enum BakeMode].
+			The light's bake mode. This will affect the global illumination techniques that have an effect on the light's rendering.
 			[b]Note:[/b] Meshes' global illumination mode will also affect the global illumination rendering. See [member GeometryInstance3D.gi_mode].
 		</member>
 		<member name="light_color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">

--- a/doc/classes/Line2D.xml
+++ b/doc/classes/Line2D.xml
@@ -63,7 +63,7 @@
 			[b]Note:[/b] [Line2D] is not accelerated by batching when being anti-aliased.
 		</member>
 		<member name="begin_cap_mode" type="int" setter="set_begin_cap_mode" getter="get_begin_cap_mode" enum="Line2D.LineCapMode" default="0">
-			The style of the beginning of the polyline, if [member closed] is [code]false[/code]. Use [enum LineCapMode] constants.
+			The style of the beginning of the polyline, if [member closed] is [code]false[/code].
 		</member>
 		<member name="closed" type="bool" setter="set_closed" getter="is_closed" default="false">
 			If [code]true[/code] and the polyline has more than 2 points, the last point and the first one will be connected by a segment.
@@ -74,13 +74,13 @@
 			The color of the polyline. Will not be used if a gradient is set.
 		</member>
 		<member name="end_cap_mode" type="int" setter="set_end_cap_mode" getter="get_end_cap_mode" enum="Line2D.LineCapMode" default="0">
-			The style of the end of the polyline, if [member closed] is [code]false[/code]. Use [enum LineCapMode] constants.
+			The style of the end of the polyline, if [member closed] is [code]false[/code].
 		</member>
 		<member name="gradient" type="Gradient" setter="set_gradient" getter="get_gradient">
 			The gradient is drawn through the whole line from start to finish. The [member default_color] will not be used if this property is set.
 		</member>
 		<member name="joint_mode" type="int" setter="set_joint_mode" getter="get_joint_mode" enum="Line2D.LineJointMode" default="0">
-			The style of the connections between segments of the polyline. Use [enum LineJointMode] constants.
+			The style of the connections between segments of the polyline.
 		</member>
 		<member name="points" type="PackedVector2Array" setter="set_points" getter="get_points" default="PackedVector2Array()">
 			The points of the polyline, interpreted in local 2D coordinates. Segments are drawn between the adjacent points in this array.
@@ -95,7 +95,7 @@
 			The texture used for the polyline. Uses [member texture_mode] for drawing style.
 		</member>
 		<member name="texture_mode" type="int" setter="set_texture_mode" getter="get_texture_mode" enum="Line2D.LineTextureMode" default="0">
-			The style to render the [member texture] of the polyline. Use [enum LineTextureMode] constants.
+			The style to render the [member texture] of the polyline.
 		</member>
 		<member name="width" type="float" setter="set_width" getter="get_width" default="10.0">
 			The polyline's width.

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -28,7 +28,7 @@
 			Base text writing direction.
 		</member>
 		<member name="underline" type="int" setter="set_underline_mode" getter="get_underline_mode" enum="LinkButton.UnderlineMode" default="0">
-			The underline mode to use for the text. See [enum LinkButton.UnderlineMode] for the available modes.
+			The underline mode to use for the text.
 		</member>
 		<member name="uri" type="String" setter="set_uri" getter="get_uri" default="&quot;&quot;">
 			The [url=https://en.wikipedia.org/wiki/Uniform_Resource_Identifier]URI[/url] for this [LinkButton]. If set to a valid URI, pressing the button opens the URI using the operating system's default program for the protocol (via [method OS.shell_open]). HTTP and HTTPS URLs open the default web browser.

--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -49,7 +49,7 @@
 			<return type="int" enum="RenderingServer.ShadowCastingSetting" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns the item's shadow casting mode. See [enum RenderingServer.ShadowCastingSetting] for possible values.
+				Returns the item's shadow casting mode.
 			</description>
 		</method>
 		<method name="get_item_mesh_transform" qualifiers="const">
@@ -128,7 +128,7 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="shadow_casting_setting" type="int" enum="RenderingServer.ShadowCastingSetting" />
 			<description>
-				Sets the item's shadow casting mode. See [enum RenderingServer.ShadowCastingSetting] for possible values.
+				Sets the item's shadow casting mode to [param shadow_casting_setting].
 			</description>
 		</method>
 		<method name="set_item_mesh_transform">

--- a/doc/classes/MultiplayerPeer.xml
+++ b/doc/classes/MultiplayerPeer.xml
@@ -35,7 +35,7 @@
 		<method name="get_connection_status" qualifiers="const">
 			<return type="int" enum="MultiplayerPeer.ConnectionStatus" />
 			<description>
-				Returns the current state of the connection. See [enum ConnectionStatus].
+				Returns the current state of the connection.
 			</description>
 		</method>
 		<method name="get_packet_channel" qualifiers="const">
@@ -92,7 +92,7 @@
 			[b]Note:[/b] The default channel ([code]0[/code]) actually works as 3 separate channels (one for each [enum TransferMode]) so that [constant TRANSFER_MODE_RELIABLE] and [constant TRANSFER_MODE_UNRELIABLE_ORDERED] does not interact with each other by default. Refer to the specific network API documentation (e.g. ENet or WebRTC) to learn how to set up channels correctly.
 		</member>
 		<member name="transfer_mode" type="int" setter="set_transfer_mode" getter="get_transfer_mode" enum="MultiplayerPeer.TransferMode" default="2">
-			The manner in which to send packets to the target peer. See [enum TransferMode], and the [method set_target_peer] method.
+			The manner in which to send packets to the target peer. See the [method set_target_peer] method.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -140,10 +140,10 @@
 			Only used when [member geometry_parsed_geometry_type] is [constant PARSED_GEOMETRY_STATIC_COLLIDERS] or [constant PARSED_GEOMETRY_BOTH].
 		</member>
 		<member name="geometry_parsed_geometry_type" type="int" setter="set_parsed_geometry_type" getter="get_parsed_geometry_type" enum="NavigationMesh.ParsedGeometryType" default="2">
-			Determines which type of nodes will be parsed as geometry. See [enum ParsedGeometryType] for possible values.
+			Determines which type of nodes will be parsed as geometry.
 		</member>
 		<member name="geometry_source_geometry_mode" type="int" setter="set_source_geometry_mode" getter="get_source_geometry_mode" enum="NavigationMesh.SourceGeometryMode" default="0">
-			The source of the geometry used when baking. See [enum SourceGeometryMode] for possible values.
+			The source of the geometry used when baking.
 		</member>
 		<member name="geometry_source_group_name" type="StringName" setter="set_source_group_name" getter="get_source_group_name" default="&amp;&quot;navigation_mesh_source_group&quot;">
 			The name of the group to scan for geometry.
@@ -158,7 +158,7 @@
 			[b]Note:[/b] This value will be squared to calculate the minimum number of cells allowed to form isolated island areas. For example, a value of 8 will set the number of cells to 64.
 		</member>
 		<member name="sample_partition_type" type="int" setter="set_sample_partition_type" getter="get_sample_partition_type" enum="NavigationMesh.SamplePartitionType" default="0">
-			Partitioning algorithm for creating the navigation mesh polys. See [enum SamplePartitionType] for possible values.
+			Partitioning algorithm for creating the navigation mesh polys.
 		</member>
 		<member name="vertices_per_polygon" type="float" setter="set_vertices_per_polygon" getter="get_vertices_per_polygon" default="6.0">
 			The maximum number of vertices allowed for polygons generated during the contour to polygon conversion process.

--- a/doc/classes/NavigationPolygon.xml
+++ b/doc/classes/NavigationPolygon.xml
@@ -191,17 +191,17 @@
 			Only used when [member parsed_geometry_type] is [constant PARSED_GEOMETRY_STATIC_COLLIDERS] or [constant PARSED_GEOMETRY_BOTH].
 		</member>
 		<member name="parsed_geometry_type" type="int" setter="set_parsed_geometry_type" getter="get_parsed_geometry_type" enum="NavigationPolygon.ParsedGeometryType" default="2">
-			Determines which type of nodes will be parsed as geometry. See [enum ParsedGeometryType] for possible values.
+			Determines which type of nodes will be parsed as geometry.
 		</member>
 		<member name="sample_partition_type" type="int" setter="set_sample_partition_type" getter="get_sample_partition_type" enum="NavigationPolygon.SamplePartitionType" default="0">
-			Partitioning algorithm for creating the navigation mesh polys. See [enum SamplePartitionType] for possible values.
+			Partitioning algorithm for creating the navigation mesh polys.
 		</member>
 		<member name="source_geometry_group_name" type="StringName" setter="set_source_geometry_group_name" getter="get_source_geometry_group_name" default="&amp;&quot;navigation_polygon_source_geometry_group&quot;">
 			The group name of nodes that should be parsed for baking source geometry.
 			Only used when [member source_geometry_mode] is [constant SOURCE_GEOMETRY_GROUPS_WITH_CHILDREN] or [constant SOURCE_GEOMETRY_GROUPS_EXPLICIT].
 		</member>
 		<member name="source_geometry_mode" type="int" setter="set_source_geometry_mode" getter="get_source_geometry_mode" enum="NavigationPolygon.SourceGeometryMode" default="0">
-			The source of the geometry used when baking. See [enum SourceGeometryMode] for possible values.
+			The source of the geometry used when baking.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -307,7 +307,7 @@
 			<return type="int" />
 			<param index="0" name="process_info" type="int" enum="NavigationServer2D.ProcessInfo" />
 			<description>
-				Returns information about the current state of the NavigationServer. See [enum ProcessInfo] for a list of available states.
+				Returns information about the current state of the NavigationServer.
 			</description>
 		</method>
 		<method name="is_baking_navigation_polygon" qualifiers="const">

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -339,7 +339,7 @@
 			<return type="int" />
 			<param index="0" name="process_info" type="int" enum="NavigationServer3D.ProcessInfo" />
 			<description>
-				Returns information about the current state of the NavigationServer. See [enum ProcessInfo] for a list of available states.
+				Returns information about the current state of the NavigationServer.
 			</description>
 		</method>
 		<method name="is_baking_navigation_mesh" qualifiers="const">

--- a/doc/classes/NinePatchRect.xml
+++ b/doc/classes/NinePatchRect.xml
@@ -27,10 +27,10 @@
 	</methods>
 	<members>
 		<member name="axis_stretch_horizontal" type="int" setter="set_h_axis_stretch_mode" getter="get_h_axis_stretch_mode" enum="NinePatchRect.AxisStretchMode" default="0">
-			The stretch mode to use for horizontal stretching/tiling. See [enum NinePatchRect.AxisStretchMode] for possible values.
+			The stretch mode to use for horizontal stretching/tiling.
 		</member>
 		<member name="axis_stretch_vertical" type="int" setter="set_v_axis_stretch_mode" getter="get_v_axis_stretch_mode" enum="NinePatchRect.AxisStretchMode" default="0">
-			The stretch mode to use for vertical stretching/tiling. See [enum NinePatchRect.AxisStretchMode] for possible values.
+			The stretch mode to use for vertical stretching/tiling.
 		</member>
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="is_draw_center_enabled" default="true">
 			If [code]true[/code], draw the panel's center. Else, only draw the 9-slice's borders.

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -162,7 +162,7 @@
 			<description>
 				Adds a child [param node]. Nodes can have any number of children, but every child must have a unique name. Child nodes are automatically deleted when the parent node is deleted, so an entire scene can be removed by deleting its topmost node.
 				If [param force_readable_name] is [code]true[/code], improves the readability of the added [param node]. If not named, the [param node] is renamed to its type, and if it shares [member name] with a sibling, a number is suffixed more appropriately. This operation is very slow. As such, it is recommended leaving this to [code]false[/code], which assigns a dummy name featuring [code]@[/code] in both situations.
-				If [param internal] is different than [constant INTERNAL_MODE_DISABLED], the child will be added as internal node. These nodes are ignored by methods like [method get_children], unless their parameter [code]include_internal[/code] is [code]true[/code]. It also prevents these nodes being duplicated with their parent. The intended usage is to hide the internal nodes from the user, so the user won't accidentally delete or modify them. Used by some GUI nodes, e.g. [ColorPicker]. See [enum InternalMode] for available modes.
+				If [param internal] is different than [constant INTERNAL_MODE_DISABLED], the child will be added as internal node. These nodes are ignored by methods like [method get_children], unless their parameter [code]include_internal[/code] is [code]true[/code]. It also prevents these nodes being duplicated with their parent. The intended usage is to hide the internal nodes from the user, so the user won't accidentally delete or modify them. Used by some GUI nodes, e.g. [ColorPicker].
 				[b]Note:[/b] If [param node] already has a parent, this method will fail. Use [method remove_child] first to remove [param node] from its current parent. For example:
 				[codeblocks]
 				[gdscript]
@@ -1080,7 +1080,7 @@
 			[b]Note:[/b] When teleporting a node to a distant position you should temporarily disable interpolation with [method Node.reset_physics_interpolation].
 		</member>
 		<member name="process_mode" type="int" setter="set_process_mode" getter="get_process_mode" enum="Node.ProcessMode" default="0">
-			The node's processing behavior (see [enum ProcessMode]). To check if the node can process in its current mode, use [method can_process].
+			The node's processing behavior. To check if the node can process in its current mode, use [method can_process].
 		</member>
 		<member name="process_physics_priority" type="int" setter="set_physics_process_priority" getter="get_physics_process_priority" default="0">
 			Similar to [member process_priority] but for [constant NOTIFICATION_PHYSICS_PROCESS], [method _physics_process], or [constant NOTIFICATION_INTERNAL_PHYSICS_PROCESS].

--- a/doc/classes/OmniLight3D.xml
+++ b/doc/classes/OmniLight3D.xml
@@ -25,7 +25,6 @@
 			[b]Note:[/b] [member omni_range] is not affected by [member Node3D.scale] (the light's scale or its parent's scale).
 		</member>
 		<member name="omni_shadow_mode" type="int" setter="set_shadow_mode" getter="get_shadow_mode" enum="OmniLight3D.ShadowMode" default="1">
-			See [enum ShadowMode].
 		</member>
 		<member name="shadow_normal_bias" type="float" setter="set_param" getter="get_param" overrides="Light3D" default="1.0" />
 	</members>

--- a/doc/classes/PacketPeerDTLS.xml
+++ b/doc/classes/PacketPeerDTLS.xml
@@ -29,7 +29,7 @@
 		<method name="get_status" qualifiers="const">
 			<return type="int" enum="PacketPeerDTLS.Status" />
 			<description>
-				Returns the status of the connection. See [enum Status] for values.
+				Returns the status of the connection.
 			</description>
 		</method>
 		<method name="poll">

--- a/doc/classes/ParticleProcessMaterial.xml
+++ b/doc/classes/ParticleProcessMaterial.xml
@@ -42,7 +42,7 @@
 			<return type="bool" />
 			<param index="0" name="particle_flag" type="int" enum="ParticleProcessMaterial.ParticleFlags" />
 			<description>
-				Returns [code]true[/code] if the specified particle flag is enabled. See [enum ParticleFlags] for options.
+				Returns [code]true[/code] if the specified particle flag is enabled.
 			</description>
 		</method>
 		<method name="set_param">
@@ -83,7 +83,7 @@
 			<param index="0" name="particle_flag" type="int" enum="ParticleProcessMaterial.ParticleFlags" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				If [code]true[/code], enables the specified particle flag. See [enum ParticleFlags] for options.
+				Sets the [param particle_flag] to [param enable].
 			</description>
 		</method>
 	</methods>
@@ -222,7 +222,7 @@
 			The radius of the ring when using the emitter [constant EMISSION_SHAPE_RING].
 		</member>
 		<member name="emission_shape" type="int" setter="set_emission_shape" getter="get_emission_shape" enum="ParticleProcessMaterial.EmissionShape" default="0">
-			Particles will be emitted inside this region. Use [enum EmissionShape] constants for values.
+			Particles will be emitted inside this region.
 		</member>
 		<member name="emission_shape_offset" type="Vector3" setter="set_emission_shape_offset" getter="get_emission_shape_offset" default="Vector3(0, 0, 0)">
 			The offset for the [member emission_shape], in local space.

--- a/doc/classes/PhysicalBone3D.xml
+++ b/doc/classes/PhysicalBone3D.xml
@@ -61,7 +61,7 @@
 			See [member ProjectSettings.physics/3d/default_angular_damp] for more details about damping.
 		</member>
 		<member name="angular_damp_mode" type="int" setter="set_angular_damp_mode" getter="get_angular_damp_mode" enum="PhysicalBone3D.DampMode" default="0">
-			Defines how [member angular_damp] is applied. See [enum DampMode] for possible values.
+			Defines how [member angular_damp] is applied.
 		</member>
 		<member name="angular_velocity" type="Vector3" setter="set_angular_velocity" getter="get_angular_velocity" default="Vector3(0, 0, 0)">
 			The PhysicalBone3D's rotational velocity in [i]radians[/i] per second.
@@ -93,14 +93,14 @@
 			Sets the joint's rotation in radians.
 		</member>
 		<member name="joint_type" type="int" setter="set_joint_type" getter="get_joint_type" enum="PhysicalBone3D.JointType" default="0">
-			Sets the joint type. See [enum JointType] for possible values.
+			Sets the joint type.
 		</member>
 		<member name="linear_damp" type="float" setter="set_linear_damp" getter="get_linear_damp" default="0.0">
 			Damps the body's movement. By default, the body will use [member ProjectSettings.physics/3d/default_linear_damp] or any value override set by an [Area3D] the body is in. Depending on [member linear_damp_mode], [member linear_damp] may be added to or replace the body's damping value.
 			See [member ProjectSettings.physics/3d/default_linear_damp] for more details about damping.
 		</member>
 		<member name="linear_damp_mode" type="int" setter="set_linear_damp_mode" getter="get_linear_damp_mode" enum="PhysicalBone3D.DampMode" default="0">
-			Defines how [member linear_damp] is applied. See [enum DampMode] for possible values.
+			Defines how [member linear_damp] is applied.
 		</member>
 		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector3(0, 0, 0)">
 			The body's linear velocity in units per second. Can be used sporadically, but [b]don't set this every frame[/b], because physics may run in another thread and runs at a different granularity. Use [method _integrate_forces] as your process loop for precise control of the body state.

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -89,7 +89,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.AreaParameter" />
 			<description>
-				Returns the value of the given area parameter. See [enum AreaParameter] for the list of available parameters.
+				Returns the value of the given area parameter.
 			</description>
 		</method>
 		<method name="area_get_shape" qualifiers="const">
@@ -195,7 +195,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.AreaParameter" />
 			<param index="2" name="value" type="Variant" />
 			<description>
-				Sets the value of the given area parameter. See [enum AreaParameter] for the list of available parameters.
+				Sets the value of the given area parameter.
 			</description>
 		</method>
 		<method name="area_set_shape">
@@ -422,7 +422,7 @@
 			<return type="int" enum="PhysicsServer2D.CCDMode" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the body's continuous collision detection mode (see [enum CCDMode]).
+				Returns the body's continuous collision detection mode.
 			</description>
 		</method>
 		<method name="body_get_direct_state">
@@ -443,7 +443,7 @@
 			<return type="int" enum="PhysicsServer2D.BodyMode" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the body's mode (see [enum BodyMode]).
+				Returns the body's mode.
 			</description>
 		</method>
 		<method name="body_get_object_instance_id" qualifiers="const">
@@ -458,7 +458,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.BodyParameter" />
 			<description>
-				Returns the value of the given body parameter. See [enum BodyParameter] for the list of available parameters.
+				Returns the value of the given body parameter.
 			</description>
 		</method>
 		<method name="body_get_shape" qualifiers="const">
@@ -496,7 +496,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer2D.BodyState" />
 			<description>
-				Returns the value of the given state of the body. See [enum BodyState] for the list of available states.
+				Returns the value of the given state of the body.
 			</description>
 		</method>
 		<method name="body_is_omitting_force_integration" qualifiers="const">
@@ -584,7 +584,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mode" type="int" enum="PhysicsServer2D.CCDMode" />
 			<description>
-				Sets the continuous collision detection mode using one of the [enum CCDMode] constants.
+				Sets the continuous collision detection mode.
 				Continuous collision detection tries to predict where a moving body would collide in between physics updates, instead of moving it and correcting its movement if it collided.
 			</description>
 		</method>
@@ -615,7 +615,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mode" type="int" enum="PhysicsServer2D.BodyMode" />
 			<description>
-				Sets the body's mode. See [enum BodyMode] for the list of available modes.
+				Sets the body's mode.
 			</description>
 		</method>
 		<method name="body_set_omit_force_integration">
@@ -633,7 +633,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.BodyParameter" />
 			<param index="2" name="value" type="Variant" />
 			<description>
-				Sets the value of the given body parameter. See [enum BodyParameter] for the list of available parameters.
+				Sets the value of the given body parameter.
 			</description>
 		</method>
 		<method name="body_set_shape">
@@ -690,7 +690,7 @@
 			<param index="1" name="state" type="int" enum="PhysicsServer2D.BodyState" />
 			<param index="2" name="value" type="Variant" />
 			<description>
-				Sets the value of a body's state. See [enum BodyState] for the list of available states.
+				Sets the value of a body's state.
 				[b]Note:[/b] The state change doesn't take effect immediately. The state will change on the next physics frame.
 			</description>
 		</method>
@@ -743,7 +743,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.DampedSpringParam" />
 			<description>
-				Returns the value of the given damped spring joint parameter. See [enum DampedSpringParam] for the list of available parameters.
+				Returns the value of the given damped spring joint parameter.
 			</description>
 		</method>
 		<method name="damped_spring_joint_set_param">
@@ -752,7 +752,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.DampedSpringParam" />
 			<param index="2" name="value" type="float" />
 			<description>
-				Sets the value of the given damped spring joint parameter. See [enum DampedSpringParam] for the list of available parameters.
+				Sets the value of the given damped spring joint parameter.
 			</description>
 		</method>
 		<method name="free_rid">
@@ -766,7 +766,7 @@
 			<return type="int" />
 			<param index="0" name="process_info" type="int" enum="PhysicsServer2D.ProcessInfo" />
 			<description>
-				Returns information about the current state of the 2D physics engine. See [enum ProcessInfo] for the list of available states.
+				Returns the value of a physics engine state specified by [param process_info].
 			</description>
 		</method>
 		<method name="joint_clear">
@@ -795,14 +795,14 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.JointParam" />
 			<description>
-				Returns the value of the given joint parameter. See [enum JointParam] for the list of available parameters.
+				Returns the value of the given joint parameter.
 			</description>
 		</method>
 		<method name="joint_get_type" qualifiers="const">
 			<return type="int" enum="PhysicsServer2D.JointType" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns the joint's type (see [enum JointType]).
+				Returns the joint's type.
 			</description>
 		</method>
 		<method name="joint_is_disabled_collisions_between_bodies" qualifiers="const">
@@ -851,7 +851,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.JointParam" />
 			<param index="2" name="value" type="float" />
 			<description>
-				Sets the value of the given joint parameter. See [enum JointParam] for the list of available parameters.
+				Sets the value of the given joint parameter.
 			</description>
 		</method>
 		<method name="pin_joint_get_flag" qualifiers="const">
@@ -859,7 +859,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="flag" type="int" enum="PhysicsServer2D.PinJointFlag" />
 			<description>
-				Gets a pin joint flag (see [enum PinJointFlag] constants).
+				Gets a pin joint flag.
 			</description>
 		</method>
 		<method name="pin_joint_get_param" qualifiers="const">
@@ -867,7 +867,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.PinJointParam" />
 			<description>
-				Returns the value of a pin joint parameter. See [enum PinJointParam] for a list of available parameters.
+				Returns the value of a pin joint parameter.
 			</description>
 		</method>
 		<method name="pin_joint_set_flag">
@@ -876,7 +876,7 @@
 			<param index="1" name="flag" type="int" enum="PhysicsServer2D.PinJointFlag" />
 			<param index="2" name="enabled" type="bool" />
 			<description>
-				Sets a pin joint flag (see [enum PinJointFlag] constants).
+				Sets a pin joint flag.
 			</description>
 		</method>
 		<method name="pin_joint_set_param">
@@ -885,7 +885,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.PinJointParam" />
 			<param index="2" name="value" type="float" />
 			<description>
-				Sets a pin joint parameter. See [enum PinJointParam] for a list of available parameters.
+				Sets a pin joint parameter.
 			</description>
 		</method>
 		<method name="rectangle_shape_create">
@@ -924,7 +924,7 @@
 			<return type="int" enum="PhysicsServer2D.ShapeType" />
 			<param index="0" name="shape" type="RID" />
 			<description>
-				Returns the shape's type (see [enum ShapeType]).
+				Returns the shape's type.
 			</description>
 		</method>
 		<method name="shape_set_data">
@@ -962,7 +962,7 @@
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.SpaceParameter" />
 			<description>
-				Returns the value of the given space parameter. See [enum SpaceParameter] for the list of available parameters.
+				Returns the value of the given space parameter.
 			</description>
 		</method>
 		<method name="space_is_active" qualifiers="const">
@@ -986,7 +986,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.SpaceParameter" />
 			<param index="2" name="value" type="float" />
 			<description>
-				Sets the value of the given space parameter. See [enum SpaceParameter] for the list of available parameters.
+				Sets the value of the given space parameter.
 			</description>
 		</method>
 		<method name="world_boundary_shape_create">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -606,7 +606,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mode" type="int" enum="PhysicsServer3D.BodyMode" />
 			<description>
-				Sets the body mode, from one of the [enum BodyMode] constants.
+				Sets the body mode.
 			</description>
 		</method>
 		<method name="body_set_omit_force_integration">
@@ -675,7 +675,7 @@
 			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
 			<param index="2" name="value" type="Variant" />
 			<description>
-				Sets a body state (see [enum BodyState] constants).
+				Sets a body state.
 			</description>
 		</method>
 		<method name="body_set_state_sync_callback">
@@ -718,7 +718,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.ConeTwistJointParam" />
 			<description>
-				Gets a cone_twist_joint parameter (see [enum ConeTwistJointParam] constants).
+				Gets a cone twist joint parameter.
 			</description>
 		</method>
 		<method name="cone_twist_joint_set_param">
@@ -727,7 +727,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.ConeTwistJointParam" />
 			<param index="2" name="value" type="float" />
 			<description>
-				Sets a cone_twist_joint parameter (see [enum ConeTwistJointParam] constants).
+				Sets a cone twist joint parameter.
 			</description>
 		</method>
 		<method name="convex_polygon_shape_create">
@@ -758,7 +758,7 @@
 			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
 			<param index="2" name="flag" type="int" enum="PhysicsServer3D.G6DOFJointAxisFlag" />
 			<description>
-				Returns the value of a generic 6DOF joint flag. See [enum G6DOFJointAxisFlag] for the list of available flags.
+				Returns the value of a generic 6DOF joint flag.
 			</description>
 		</method>
 		<method name="generic_6dof_joint_get_param" qualifiers="const">
@@ -767,7 +767,7 @@
 			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
 			<param index="2" name="param" type="int" enum="PhysicsServer3D.G6DOFJointAxisParam" />
 			<description>
-				Returns the value of a generic 6DOF joint parameter. See [enum G6DOFJointAxisParam] for the list of available parameters.
+				Returns the value of a generic 6DOF joint parameter.
 			</description>
 		</method>
 		<method name="generic_6dof_joint_set_flag">
@@ -777,7 +777,7 @@
 			<param index="2" name="flag" type="int" enum="PhysicsServer3D.G6DOFJointAxisFlag" />
 			<param index="3" name="enable" type="bool" />
 			<description>
-				Sets the value of a given generic 6DOF joint flag. See [enum G6DOFJointAxisFlag] for the list of available flags.
+				Sets the value of a given generic 6DOF joint flag.
 			</description>
 		</method>
 		<method name="generic_6dof_joint_set_param">
@@ -787,14 +787,14 @@
 			<param index="2" name="param" type="int" enum="PhysicsServer3D.G6DOFJointAxisParam" />
 			<param index="3" name="value" type="float" />
 			<description>
-				Sets the value of a given generic 6DOF joint parameter. See [enum G6DOFJointAxisParam] for the list of available parameters.
+				Sets the value of a given generic 6DOF joint parameter.
 			</description>
 		</method>
 		<method name="get_process_info">
 			<return type="int" />
 			<param index="0" name="process_info" type="int" enum="PhysicsServer3D.ProcessInfo" />
 			<description>
-				Returns information about the current state of the 3D physics engine. See [enum ProcessInfo] for a list of available states.
+				Returns the value of a physics engine state specified by [param process_info].
 			</description>
 		</method>
 		<method name="heightmap_shape_create">
@@ -807,7 +807,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="flag" type="int" enum="PhysicsServer3D.HingeJointFlag" />
 			<description>
-				Gets a hinge_joint flag (see [enum HingeJointFlag] constants).
+				Gets a hinge joint flag.
 			</description>
 		</method>
 		<method name="hinge_joint_get_param" qualifiers="const">
@@ -815,7 +815,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.HingeJointParam" />
 			<description>
-				Gets a hinge_joint parameter (see [enum HingeJointParam]).
+				Gets a hinge joint parameter.
 			</description>
 		</method>
 		<method name="hinge_joint_set_flag">
@@ -824,7 +824,7 @@
 			<param index="1" name="flag" type="int" enum="PhysicsServer3D.HingeJointFlag" />
 			<param index="2" name="enabled" type="bool" />
 			<description>
-				Sets a hinge_joint flag (see [enum HingeJointFlag] constants).
+				Sets a hinge joint flag.
 			</description>
 		</method>
 		<method name="hinge_joint_set_param">
@@ -833,7 +833,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.HingeJointParam" />
 			<param index="2" name="value" type="float" />
 			<description>
-				Sets a hinge_joint parameter (see [enum HingeJointParam] constants).
+				Sets a hinge joint parameter.
 			</description>
 		</method>
 		<method name="joint_clear">
@@ -954,7 +954,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.PinJointParam" />
 			<description>
-				Gets a pin_joint parameter (see [enum PinJointParam] constants).
+				Gets a pin joint parameter.
 			</description>
 		</method>
 		<method name="pin_joint_set_local_a">
@@ -979,7 +979,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.PinJointParam" />
 			<param index="2" name="value" type="float" />
 			<description>
-				Sets a pin_joint parameter (see [enum PinJointParam] constants).
+				Sets a pin joint parameter.
 			</description>
 		</method>
 		<method name="separation_ray_shape_create">
@@ -1013,7 +1013,7 @@
 			<return type="int" enum="PhysicsServer3D.ShapeType" />
 			<param index="0" name="shape" type="RID" />
 			<description>
-				Returns the type of shape (see [enum ShapeType] constants).
+				Returns the type of shape.
 			</description>
 		</method>
 		<method name="shape_set_data">
@@ -1038,7 +1038,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.SliderJointParam" />
 			<description>
-				Gets a slider_joint parameter (see [enum SliderJointParam] constants).
+				Gets a slider joint parameter.
 			</description>
 		</method>
 		<method name="slider_joint_set_param">
@@ -1047,7 +1047,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.SliderJointParam" />
 			<param index="2" name="value" type="float" />
 			<description>
-				Gets a slider_joint parameter (see [enum SliderJointParam] constants).
+				Gets a slider joint parameter.
 			</description>
 		</method>
 		<method name="soft_body_add_collision_exception">
@@ -1183,7 +1183,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
 			<description>
-				Returns the given soft body state (see [enum BodyState] constants).
+				Returns the given soft body state.
 				[b]Note:[/b] Godot's default physics implementation does not support [constant BODY_STATE_LINEAR_VELOCITY], [constant BODY_STATE_ANGULAR_VELOCITY], [constant BODY_STATE_SLEEPING], or [constant BODY_STATE_CAN_SLEEP].
 			</description>
 		</method>
@@ -1331,7 +1331,7 @@
 			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
 			<param index="2" name="variant" type="Variant" />
 			<description>
-				Sets the given body state for the given body (see [enum BodyState] constants).
+				Sets the given body state for the given body.
 				[b]Note:[/b] Godot's default physics implementation does not support [constant BODY_STATE_LINEAR_VELOCITY], [constant BODY_STATE_ANGULAR_VELOCITY], [constant BODY_STATE_SLEEPING], or [constant BODY_STATE_CAN_SLEEP].
 			</description>
 		</method>

--- a/doc/classes/PlaneMesh.xml
+++ b/doc/classes/PlaneMesh.xml
@@ -14,7 +14,7 @@
 			Offset of the generated plane. Useful for particles.
 		</member>
 		<member name="orientation" type="int" setter="set_orientation" getter="get_orientation" enum="PlaneMesh.Orientation" default="1">
-			Direction that the [PlaneMesh] is facing. See [enum Orientation] for options.
+			Direction that the [PlaneMesh] is facing.
 		</member>
 		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2(2, 2)">
 			Size of the generated plane.

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -630,7 +630,7 @@
 			<param index="1" name="rid" type="RID" />
 			<param index="2" name="index" type="int" />
 			<description>
-				Returns the unique identifier of the driver [param resource] for the specified [param rid]. Some driver resource types ignore the specified [param rid] (see [enum DriverResource] descriptions). [param index] is always ignored but must be specified anyway.
+				Returns the unique identifier of the driver [param resource] for the specified [param rid]. Some driver resource types ignore the specified [param rid]. [param index] is always ignored but must be specified anyway.
 			</description>
 		</method>
 		<method name="get_driver_total_memory" qualifiers="const">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -72,7 +72,7 @@
 			<return type="void" />
 			<param index="0" name="shape" type="int" enum="RenderingServer.DOFBokehShape" />
 			<description>
-				Sets the shape of the DOF bokeh pattern. Different shapes may be used to achieve artistic effect, or to meet performance targets. For more detail on available options see [enum DOFBokehShape].
+				Sets the shape of the DOF bokeh pattern to [param shape]. Different shapes may be used to achieve artistic effect, or to meet performance targets.
 			</description>
 		</method>
 		<method name="camera_attributes_set_dof_blur_quality">
@@ -80,7 +80,7 @@
 			<param index="0" name="quality" type="int" enum="RenderingServer.DOFBlurQuality" />
 			<param index="1" name="use_jitter" type="bool" />
 			<description>
-				Sets the quality level of the DOF blur effect to one of the options in [enum DOFBlurQuality]. [param use_jitter] can be used to jitter samples taken during the blur pass to hide artifacts at the cost of looking more fuzzy.
+				Sets the quality level of the DOF blur effect to [param quality]. [param use_jitter] can be used to jitter samples taken during the blur pass to hide artifacts at the cost of looking more fuzzy.
 			</description>
 		</method>
 		<method name="camera_attributes_set_exposure">
@@ -791,7 +791,7 @@
 			<param index="0" name="light" type="RID" />
 			<param index="1" name="mode" type="int" enum="RenderingServer.CanvasLightBlendMode" />
 			<description>
-				Sets the blend mode for the given canvas light. See [enum CanvasLightBlendMode] for options. Equivalent to [member Light2D.blend_mode].
+				Sets the blend mode for the given canvas light to [param mode]. Equivalent to [member Light2D.blend_mode].
 			</description>
 		</method>
 		<method name="canvas_light_set_color">
@@ -864,7 +864,7 @@
 			<param index="0" name="light" type="RID" />
 			<param index="1" name="mode" type="int" enum="RenderingServer.CanvasLightMode" />
 			<description>
-				The mode of the light, see [enum CanvasLightMode] constants.
+				Sets the mode of the canvas light.
 			</description>
 		</method>
 		<method name="canvas_light_set_shadow_color">
@@ -888,7 +888,7 @@
 			<param index="0" name="light" type="RID" />
 			<param index="1" name="filter" type="int" enum="RenderingServer.CanvasLightShadowFilter" />
 			<description>
-				Sets the canvas light's shadow's filter, see [enum CanvasLightShadowFilter] constants.
+				Sets the canvas light's shadow's filter.
 			</description>
 		</method>
 		<method name="canvas_light_set_shadow_smooth">
@@ -962,7 +962,7 @@
 			<param index="0" name="occluder_polygon" type="RID" />
 			<param index="1" name="mode" type="int" enum="RenderingServer.CanvasOccluderPolygonCullMode" />
 			<description>
-				Sets an occluder polygons cull mode. See [enum CanvasOccluderPolygonCullMode] constants.
+				Sets an occluder polygon's cull mode.
 			</description>
 		</method>
 		<method name="canvas_occluder_polygon_set_shape">
@@ -1629,7 +1629,7 @@
 			<return type="int" />
 			<param index="0" name="info" type="int" enum="RenderingServer.RenderingInfo" />
 			<description>
-				Returns a statistic about the rendering engine which can be used for performance profiling. See [enum RenderingServer.RenderingInfo] for a list of values that can be queried. See also [method viewport_get_render_info], which returns information specific to a viewport.
+				Returns a statistic about the rendering engine which can be used for performance profiling. See also [method viewport_get_render_info], which returns information specific to a viewport.
 				[b]Note:[/b] Only 3D rendering is currently taken into account by some of these values, such as the number of draw calls.
 				[b]Note:[/b] Rendering information is not available until at least 2 frames have been rendered by the engine. If rendering information is not available, [method get_rendering_info] returns [code]0[/code]. To print rendering information in [code]_ready()[/code] successfully, use the following:
 				[codeblock]
@@ -1853,7 +1853,7 @@
 			<param index="0" name="instance" type="RID" />
 			<param index="1" name="shadow_casting_setting" type="int" enum="RenderingServer.ShadowCastingSetting" />
 			<description>
-				Sets the shadow casting setting to one of [enum ShadowCastingSetting]. Equivalent to [member GeometryInstance3D.cast_shadow].
+				Sets the shadow casting setting. Equivalent to [member GeometryInstance3D.cast_shadow].
 			</description>
 		</method>
 		<method name="instance_geometry_set_flag">
@@ -1862,7 +1862,7 @@
 			<param index="1" name="flag" type="int" enum="RenderingServer.InstanceFlags" />
 			<param index="2" name="enabled" type="bool" />
 			<description>
-				Sets the flag for a given [enum InstanceFlags]. See [enum InstanceFlags] for more details.
+				Sets the [param flag] for a given [param instance] to [param enabled].
 			</description>
 		</method>
 		<method name="instance_geometry_set_lightmap">
@@ -2084,7 +2084,7 @@
 			<param index="0" name="light" type="RID" />
 			<param index="1" name="mode" type="int" enum="RenderingServer.LightDirectionalShadowMode" />
 			<description>
-				Sets the shadow mode for this directional light. Equivalent to [member DirectionalLight3D.directional_shadow_mode]. See [enum LightDirectionalShadowMode] for options.
+				Sets the shadow mode for this directional light. Equivalent to [member DirectionalLight3D.directional_shadow_mode].
 			</description>
 		</method>
 		<method name="light_directional_set_sky_mode">
@@ -2167,7 +2167,7 @@
 			<param index="1" name="param" type="int" enum="RenderingServer.LightParam" />
 			<param index="2" name="value" type="float" />
 			<description>
-				Sets the specified 3D light parameter. See [enum LightParam] for options. Equivalent to [method Light3D.set_param].
+				Sets the specified 3D light parameter. Equivalent to [method Light3D.set_param].
 			</description>
 		</method>
 		<method name="light_set_projector" keywords="light_set_cookie">
@@ -3020,7 +3020,7 @@
 			<param index="0" name="particles" type="RID" />
 			<param index="1" name="order" type="int" enum="RenderingServer.ParticlesDrawOrder" />
 			<description>
-				Sets the draw order of the particles to one of the named enums from [enum ParticlesDrawOrder]. See [enum ParticlesDrawOrder] for options. Equivalent to [member GPUParticles3D.draw_order].
+				Sets the draw order of the particles. Equivalent to [member GPUParticles3D.draw_order].
 			</description>
 		</method>
 		<method name="particles_set_draw_pass_mesh">
@@ -3339,7 +3339,7 @@
 			<param index="0" name="probe" type="RID" />
 			<param index="1" name="mode" type="int" enum="RenderingServer.ReflectionProbeUpdateMode" />
 			<description>
-				Sets how often the reflection probe updates. Can either be once or every frame. See [enum ReflectionProbeUpdateMode] for options.
+				Sets how often the reflection probe updates. Can either be once or every frame.
 			</description>
 		</method>
 		<method name="request_frame_drawn_callback">
@@ -3878,7 +3878,7 @@
 			<param index="1" name="type" type="int" enum="RenderingServer.ViewportRenderInfoType" />
 			<param index="2" name="info" type="int" enum="RenderingServer.ViewportRenderInfo" />
 			<description>
-				Returns a statistic about the rendering engine which can be used for performance profiling. This is separated into render pass [param type]s, each of them having the same [param info]s you can query (different passes will return different values). See [enum RenderingServer.ViewportRenderInfoType] for a list of render pass types and [enum RenderingServer.ViewportRenderInfo] for a list of information that can be queried.
+				Returns a statistic about the rendering engine which can be used for performance profiling. This is separated into render pass [param type]s, each of them having the same [param info]s you can query (different passes will return different values).
 				See also [method get_rendering_info], which returns global information across all viewports.
 				[b]Note:[/b] Viewport rendering information is not available until at least 2 frames have been rendered by the engine. If rendering information is not available, [method viewport_get_render_info] returns [code]0[/code]. To print rendering information in [code]_ready()[/code] successfully, use the following:
 				[codeblock]
@@ -3912,7 +3912,7 @@
 			<return type="int" enum="RenderingServer.ViewportUpdateMode" />
 			<param index="0" name="viewport" type="RID" />
 			<description>
-				Returns the viewport's update mode. See [enum ViewportUpdateMode] constants for options.
+				Returns the viewport's update mode.
 				[b]Warning:[/b] Calling this from any thread other than the rendering thread will be detrimental to performance.
 			</description>
 		</method>
@@ -3976,7 +3976,7 @@
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="clear_mode" type="int" enum="RenderingServer.ViewportClearMode" />
 			<description>
-				Sets the clear mode of a viewport. See [enum ViewportClearMode] for options.
+				Sets the clear mode of a viewport.
 			</description>
 		</method>
 		<method name="viewport_set_debug_draw">
@@ -3984,7 +3984,7 @@
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="draw" type="int" enum="RenderingServer.ViewportDebugDraw" />
 			<description>
-				Sets the debug draw mode of a viewport. See [enum ViewportDebugDraw] for options.
+				Sets the debug draw mode of a viewport.
 			</description>
 		</method>
 		<method name="viewport_set_default_canvas_item_texture_filter">
@@ -3992,7 +3992,7 @@
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="filter" type="int" enum="RenderingServer.CanvasItemTextureFilter" />
 			<description>
-				Sets the default texture filtering mode for the specified [param viewport] RID. See [enum CanvasItemTextureFilter] for options.
+				Sets the default texture filtering mode for the specified [param viewport] RID.
 			</description>
 		</method>
 		<method name="viewport_set_default_canvas_item_texture_repeat">
@@ -4000,7 +4000,7 @@
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="repeat" type="int" enum="RenderingServer.CanvasItemTextureRepeat" />
 			<description>
-				Sets the default texture repeat mode for the specified [param viewport] RID. See [enum CanvasItemTextureRepeat] for options.
+				Sets the default texture repeat mode for the specified [param viewport] RID.
 			</description>
 		</method>
 		<method name="viewport_set_disable_2d">
@@ -4056,7 +4056,7 @@
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="msaa" type="int" enum="RenderingServer.ViewportMSAA" />
 			<description>
-				Sets the multisample antialiasing mode for 2D/Canvas on the specified [param viewport] RID. See [enum ViewportMSAA] for options. Equivalent to [member ProjectSettings.rendering/anti_aliasing/quality/msaa_2d] or [member Viewport.msaa_2d].
+				Sets the multisample antialiasing mode for 2D/Canvas on the specified [param viewport] RID. Equivalent to [member ProjectSettings.rendering/anti_aliasing/quality/msaa_2d] or [member Viewport.msaa_2d].
 			</description>
 		</method>
 		<method name="viewport_set_msaa_3d">
@@ -4064,7 +4064,7 @@
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="msaa" type="int" enum="RenderingServer.ViewportMSAA" />
 			<description>
-				Sets the multisample antialiasing mode for 3D on the specified [param viewport] RID. See [enum ViewportMSAA] for options. Equivalent to [member ProjectSettings.rendering/anti_aliasing/quality/msaa_3d] or [member Viewport.msaa_3d].
+				Sets the multisample antialiasing mode for 3D on the specified [param viewport] RID. Equivalent to [member ProjectSettings.rendering/anti_aliasing/quality/msaa_3d] or [member Viewport.msaa_3d].
 			</description>
 		</method>
 		<method name="viewport_set_occlusion_culling_build_quality">
@@ -4205,7 +4205,7 @@
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="update_mode" type="int" enum="RenderingServer.ViewportUpdateMode" />
 			<description>
-				Sets when the viewport should be updated. See [enum ViewportUpdateMode] constants for options.
+				Sets when the viewport should be updated.
 			</description>
 		</method>
 		<method name="viewport_set_use_debanding">

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -97,7 +97,7 @@
 				Loads a resource at the given [param path], caching the result for further access.
 				The registered [ResourceFormatLoader]s are queried sequentially to find the first one which can handle the file's extension, and then attempt loading. If loading fails, the remaining ResourceFormatLoaders are also attempted.
 				An optional [param type_hint] can be used to further specify the [Resource] type that should be handled by the [ResourceFormatLoader]. Anything that inherits from [Resource] can be used as a type hint, for example [Image].
-				The [param cache_mode] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
+				The [param cache_mode] property defines whether and how the cache should be used or updated when loading the resource.
 				Returns an empty resource if no [ResourceFormatLoader] could handle the file, and prints an error if no file is found at the specified path.
 				GDScript has a simplified [method @GDScript.load] built-in method which can be used in most situations, leaving the use of [ResourceLoader] for more advanced scenarios.
 				[b]Note:[/b] If [member ProjectSettings.editor/export/convert_text_resources_to_binary] is [code]true[/code], [method @GDScript.load] will not be able to read converted files in an exported project. If you rely on run-time loading of files present within the PCK, set [member ProjectSettings.editor/export/convert_text_resources_to_binary] to [code]false[/code].
@@ -117,7 +117,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="progress" type="Array" default="[]" />
 			<description>
-				Returns the status of a threaded loading operation started with [method load_threaded_request] for the resource at [param path]. See [enum ThreadLoadStatus] for possible return values.
+				Returns the status of a threaded loading operation started with [method load_threaded_request] for the resource at [param path].
 				An array variable can optionally be passed via [param progress], and will return a one-element array containing the ratio of completion of the threaded loading (between [code]0.0[/code] and [code]1.0[/code]).
 				[b]Note:[/b] The recommended way of using this method is to call it during different frames (e.g., in [method Node._process], instead of a loop).
 			</description>
@@ -130,7 +130,7 @@
 			<param index="3" name="cache_mode" type="int" enum="ResourceLoader.CacheMode" default="1" />
 			<description>
 				Loads the resource using threads. If [param use_sub_threads] is [code]true[/code], multiple threads will be used to load the resource, which makes loading faster, but may affect the main thread (and thus cause game slowdowns).
-				The [param cache_mode] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
+				The [param cache_mode] parameter defines whether and how the cache should be used or updated when loading the resource.
 			</description>
 		</method>
 		<method name="remove_resource_format_loader">

--- a/doc/classes/ResourceSaver.xml
+++ b/doc/classes/ResourceSaver.xml
@@ -48,7 +48,7 @@
 			<param index="2" name="flags" type="int" enum="ResourceSaver.SaverFlags" is_bitfield="true" default="0" />
 			<description>
 				Saves a resource to disk to the given path, using a [ResourceFormatSaver] that recognizes the resource object. If [param path] is empty, [ResourceSaver] will try to use [member Resource.resource_path].
-				The [param flags] bitmask can be specified to customize the save behavior using [enum SaverFlags] flags.
+				The [param flags] bitmask can be specified to customize the save behavior.
 				Returns [constant OK] on success.
 				[b]Note:[/b] When the project is running, any generated UID associated with the resource will not be saved as the required code is only executed in editor mode.
 			</description>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -659,7 +659,7 @@
 	</methods>
 	<members>
 		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="TextServer.AutowrapMode" default="3">
-			If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. To see how each mode behaves, see [enum TextServer.AutowrapMode].
+			If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle.
 		</member>
 		<member name="autowrap_trim_flags" type="int" setter="set_autowrap_trim_flags" getter="get_autowrap_trim_flags" enum="TextServer.LineBreakFlag" is_bitfield="true" default="192">
 			Autowrap space trimming flags. See [constant TextServer.BREAK_TRIM_START_EDGE_SPACES] and [constant TextServer.BREAK_TRIM_END_EDGE_SPACES] for more info.
@@ -690,10 +690,10 @@
 			If [code]true[/code], the label underlines hint tags such as [code skip-lint][hint=description]{text}[/hint][/code].
 		</member>
 		<member name="horizontal_alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="0">
-			Controls the text's horizontal alignment. Supports left, center, right, and fill, or justify. Set it to one of the [enum HorizontalAlignment] constants.
+			Controls the text's horizontal alignment. Supports left, center, right, and fill, or justify.
 		</member>
 		<member name="justification_flags" type="int" setter="set_justification_flags" getter="get_justification_flags" enum="TextServer.JustificationFlag" is_bitfield="true" default="163">
-			Line fill alignment rules. See [enum TextServer.JustificationFlag] for more information.
+			Line fill alignment rules.
 		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
@@ -740,14 +740,14 @@
 			If [code]true[/code], text processing is done in a background thread.
 		</member>
 		<member name="vertical_alignment" type="int" setter="set_vertical_alignment" getter="get_vertical_alignment" enum="VerticalAlignment" default="0">
-			Controls the text's vertical alignment. Supports top, center, bottom, and fill. Set it to one of the [enum VerticalAlignment] constants.
+			Controls the text's vertical alignment. Supports top, center, bottom, and fill.
 		</member>
 		<member name="visible_characters" type="int" setter="set_visible_characters" getter="get_visible_characters" default="-1">
 			The number of characters to display. If set to [code]-1[/code], all characters are displayed. This can be useful when animating the text appearing in a dialog box.
 			[b]Note:[/b] Setting this property updates [member visible_ratio] accordingly.
 		</member>
 		<member name="visible_characters_behavior" type="int" setter="set_visible_characters_behavior" getter="get_visible_characters_behavior" enum="TextServer.VisibleCharactersBehavior" default="0">
-			Sets the clipping behavior when [member visible_characters] or [member visible_ratio] is set. See [enum TextServer.VisibleCharactersBehavior] for more info.
+			The clipping behavior when [member visible_characters] or [member visible_ratio] is set.
 		</member>
 		<member name="visible_ratio" type="float" setter="set_visible_ratio" getter="get_visible_ratio" default="1.0">
 			The fraction of characters to display, relative to the total number of characters (see [method get_total_character_count]). If set to [code]1.0[/code], all characters are displayed. If set to [code]0.5[/code], only half of the characters will be displayed. This can be useful when animating the text appearing in a dialog box.

--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -127,7 +127,7 @@
 			See [member ProjectSettings.physics/2d/default_angular_damp] for more details about damping.
 		</member>
 		<member name="angular_damp_mode" type="int" setter="set_angular_damp_mode" getter="get_angular_damp_mode" enum="RigidBody2D.DampMode" default="0">
-			Defines how [member angular_damp] is applied. See [enum DampMode] for possible values.
+			Defines how [member angular_damp] is applied.
 		</member>
 		<member name="angular_velocity" type="float" setter="set_angular_velocity" getter="get_angular_velocity" default="0.0">
 			The body's rotational velocity in [i]radians[/i] per second.
@@ -140,7 +140,7 @@
 			When [member center_of_mass_mode] is set to [constant CENTER_OF_MASS_MODE_AUTO] (default value), the center of mass is automatically computed.
 		</member>
 		<member name="center_of_mass_mode" type="int" setter="set_center_of_mass_mode" getter="get_center_of_mass_mode" enum="RigidBody2D.CenterOfMassMode" default="0">
-			Defines the way the body's center of mass is set. See [enum CenterOfMassMode] for possible values.
+			Defines the way the body's center of mass is set.
 		</member>
 		<member name="constant_force" type="Vector2" setter="set_constant_force" getter="get_constant_force" default="Vector2(0, 0)">
 			The body's total constant positional forces applied during each physics update.
@@ -156,7 +156,7 @@
 		</member>
 		<member name="continuous_cd" type="int" setter="set_continuous_collision_detection_mode" getter="get_continuous_collision_detection_mode" enum="RigidBody2D.CCDMode" default="0">
 			Continuous collision detection mode.
-			Continuous collision detection tries to predict where a moving body will collide instead of moving it and correcting its movement after collision. Continuous collision detection is slower, but more precise and misses fewer collisions with small, fast-moving objects. Raycasting and shapecasting methods are available. See [enum CCDMode] for details.
+			Continuous collision detection tries to predict where a moving body will collide instead of moving it and correcting its movement after collision. Continuous collision detection is slower, but more precise and misses fewer collisions with small, fast-moving objects. Raycasting and shapecasting methods are available.
 		</member>
 		<member name="custom_integrator" type="bool" setter="set_use_custom_integrator" getter="is_using_custom_integrator" default="false">
 			If [code]true[/code], the standard force integration (like gravity or damping) will be disabled for this body. Other than collision response, the body will only move as determined by the [method _integrate_forces] method, if that virtual method is overridden.
@@ -168,7 +168,7 @@
 			For a body that is always frozen, use [StaticBody2D] or [AnimatableBody2D] instead.
 		</member>
 		<member name="freeze_mode" type="int" setter="set_freeze_mode" getter="get_freeze_mode" enum="RigidBody2D.FreezeMode" default="0">
-			The body's freeze mode. Can be used to set the body's behavior when [member freeze] is enabled. See [enum FreezeMode] for possible values.
+			The body's freeze mode. Can be used to set the body's behavior when [member freeze] is enabled.
 			For a body that is always frozen, use [StaticBody2D] or [AnimatableBody2D] instead.
 		</member>
 		<member name="gravity_scale" type="float" setter="set_gravity_scale" getter="get_gravity_scale" default="1.0">
@@ -205,7 +205,7 @@
 			See [member ProjectSettings.physics/2d/default_linear_damp] for more details about damping.
 		</member>
 		<member name="linear_damp_mode" type="int" setter="set_linear_damp_mode" getter="get_linear_damp_mode" enum="RigidBody2D.DampMode" default="0">
-			Defines how [member linear_damp] is applied. See [enum DampMode] for possible values.
+			Defines how [member linear_damp] is applied.
 		</member>
 		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector2(0, 0)">
 			The body's linear velocity in pixels per second. Can be used sporadically, but [b]don't set this every frame[/b], because physics may run in another thread and runs at a different granularity. Use [method _integrate_forces] as your process loop for precise control of the body state.

--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -134,7 +134,7 @@
 			See [member ProjectSettings.physics/3d/default_angular_damp] for more details about damping.
 		</member>
 		<member name="angular_damp_mode" type="int" setter="set_angular_damp_mode" getter="get_angular_damp_mode" enum="RigidBody3D.DampMode" default="0">
-			Defines how [member angular_damp] is applied. See [enum DampMode] for possible values.
+			Defines how [member angular_damp] is applied.
 		</member>
 		<member name="angular_velocity" type="Vector3" setter="set_angular_velocity" getter="get_angular_velocity" default="Vector3(0, 0, 0)">
 			The RigidBody3D's rotational velocity in [i]radians[/i] per second.
@@ -147,7 +147,7 @@
 			When [member center_of_mass_mode] is set to [constant CENTER_OF_MASS_MODE_AUTO] (default value), the center of mass is automatically computed.
 		</member>
 		<member name="center_of_mass_mode" type="int" setter="set_center_of_mass_mode" getter="get_center_of_mass_mode" enum="RigidBody3D.CenterOfMassMode" default="0">
-			Defines the way the body's center of mass is set. See [enum CenterOfMassMode] for possible values.
+			Defines the way the body's center of mass is set.
 		</member>
 		<member name="constant_force" type="Vector3" setter="set_constant_force" getter="get_constant_force" default="Vector3(0, 0, 0)">
 			The body's total constant positional forces applied during each physics update.
@@ -175,7 +175,7 @@
 			For a body that is always frozen, use [StaticBody3D] or [AnimatableBody3D] instead.
 		</member>
 		<member name="freeze_mode" type="int" setter="set_freeze_mode" getter="get_freeze_mode" enum="RigidBody3D.FreezeMode" default="0">
-			The body's freeze mode. Can be used to set the body's behavior when [member freeze] is enabled. See [enum FreezeMode] for possible values.
+			The body's freeze mode. Can be used to set the body's behavior when [member freeze] is enabled.
 			For a body that is always frozen, use [StaticBody3D] or [AnimatableBody3D] instead.
 		</member>
 		<member name="gravity_scale" type="float" setter="set_gravity_scale" getter="get_gravity_scale" default="1.0">
@@ -212,7 +212,7 @@
 			See [member ProjectSettings.physics/3d/default_linear_damp] for more details about damping.
 		</member>
 		<member name="linear_damp_mode" type="int" setter="set_linear_damp_mode" getter="get_linear_damp_mode" enum="RigidBody3D.DampMode" default="0">
-			Defines how [member linear_damp] is applied. See [enum DampMode] for possible values.
+			Defines how [member linear_damp] is applied.
 		</member>
 		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector3(0, 0, 0)">
 			The body's linear velocity in units per second. Can be used sporadically, but [b]don't set this every frame[/b], because physics may run in another thread and runs at a different granularity. Use [method _integrate_forces] as your process loop for precise control of the body state.

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -47,7 +47,7 @@
 			If [code]true[/code], the ScrollContainer will automatically scroll to focused children (including indirect children) to make sure they are fully visible.
 		</member>
 		<member name="horizontal_scroll_mode" type="int" setter="set_horizontal_scroll_mode" getter="get_horizontal_scroll_mode" enum="ScrollContainer.ScrollMode" default="1">
-			Controls whether horizontal scrollbar can be used and when it should be visible. See [enum ScrollMode] for options.
+			Controls whether horizontal scrollbar can be used and when it should be visible.
 		</member>
 		<member name="scroll_deadzone" type="int" setter="set_deadzone" getter="get_deadzone" default="0">
 			Deadzone for touch scrolling. Lower deadzone makes the scrolling more sensitive.
@@ -75,7 +75,7 @@
 			Overrides the [member ScrollBar.custom_step] used when clicking the internal scroll bar's vertical increment and decrement buttons or when using arrow keys when the [ScrollBar] is focused.
 		</member>
 		<member name="vertical_scroll_mode" type="int" setter="set_vertical_scroll_mode" getter="get_vertical_scroll_mode" enum="ScrollContainer.ScrollMode" default="1">
-			Controls whether vertical scrollbar can be used and when it should be visible. See [enum ScrollMode] for options.
+			Controls whether vertical scrollbar can be used and when it should be visible.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/Sky.xml
+++ b/doc/classes/Sky.xml
@@ -10,11 +10,10 @@
 	</tutorials>
 	<members>
 		<member name="process_mode" type="int" setter="set_process_mode" getter="get_process_mode" enum="Sky.ProcessMode" default="0">
-			Sets the method for generating the radiance map from the sky. The radiance map is a cubemap with increasingly blurry versions of the sky corresponding to different levels of roughness. Radiance maps can be expensive to calculate. See [enum ProcessMode] for options.
+			The method for generating the radiance map from the sky. The radiance map is a cubemap with increasingly blurry versions of the sky corresponding to different levels of roughness. Radiance maps can be expensive to calculate.
 		</member>
 		<member name="radiance_size" type="int" setter="set_radiance_size" getter="get_radiance_size" enum="Sky.RadianceSize" default="3">
 			The [Sky]'s radiance map size. The higher the radiance map size, the more detailed the lighting from the [Sky] will be.
-			See [enum RadianceSize] constants for values.
 			[b]Note:[/b] Some hardware will have trouble with higher radiance sizes, especially [constant RADIANCE_SIZE_512] and above. Only use such high values on high-end hardware.
 		</member>
 		<member name="sky_material" type="Material" setter="set_material" getter="get_material">

--- a/doc/classes/SliderJoint3D.xml
+++ b/doc/classes/SliderJoint3D.xml
@@ -13,7 +13,7 @@
 			<return type="float" />
 			<param index="0" name="param" type="int" enum="SliderJoint3D.Param" />
 			<description>
-				Returns the value of the given parameter (see [enum Param] constants).
+				Returns the value of the given parameter.
 			</description>
 		</method>
 		<method name="set_param">
@@ -21,7 +21,7 @@
 			<param index="0" name="param" type="int" enum="SliderJoint3D.Param" />
 			<param index="1" name="value" type="float" />
 			<description>
-				Assigns [param value] to the given parameter (see [enum Param] constants).
+				Assigns [param value] to the given parameter.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -138,7 +138,7 @@
 			The body's damping coefficient. Higher values will slow down the body more noticeably when forces are applied.
 		</member>
 		<member name="disable_mode" type="int" setter="set_disable_mode" getter="get_disable_mode" enum="SoftBody3D.DisableMode" default="0">
-			Defines the behavior in physics when [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED]. See [enum DisableMode] for more details about the different modes.
+			Defines the behavior in physics when [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED].
 		</member>
 		<member name="drag_coefficient" type="float" setter="set_drag_coefficient" getter="get_drag_coefficient" default="0.0">
 			The body's drag coefficient. Higher values increase this body's air resistance.

--- a/doc/classes/SplitContainer.xml
+++ b/doc/classes/SplitContainer.xml
@@ -45,7 +45,7 @@
 			Shifts the drag area in the axis of the container to prevent the drag area from overlapping the [ScrollBar] or other selectable [Control] of a child node.
 		</member>
 		<member name="dragger_visibility" type="int" setter="set_dragger_visibility" getter="get_dragger_visibility" enum="SplitContainer.DraggerVisibility" default="0">
-			Determines the dragger's visibility. See [enum DraggerVisibility] for details. This property does not determine whether dragging is enabled or not. Use [member dragging_enabled] for that.
+			Determines the dragger's visibility. This property does not determine whether dragging is enabled or not. Use [member dragging_enabled] for that.
 		</member>
 		<member name="dragging_enabled" type="bool" setter="set_dragging_enabled" getter="is_dragging_enabled" default="true">
 			Enables or disables split dragging.

--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -33,7 +33,7 @@
 			<param index="0" name="flag" type="int" enum="SpriteBase3D.DrawFlags" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [code]true[/code], the specified flag will be enabled. See [enum SpriteBase3D.DrawFlags] for a list of flags.
+				If [code]true[/code], the specified flag will be enabled.
 			</description>
 		</method>
 	</methods>
@@ -42,10 +42,10 @@
 			Threshold at which antialiasing will be applied on the alpha channel.
 		</member>
 		<member name="alpha_antialiasing_mode" type="int" setter="set_alpha_antialiasing" getter="get_alpha_antialiasing" enum="BaseMaterial3D.AlphaAntiAliasing" default="0">
-			The type of alpha antialiasing to apply. See [enum BaseMaterial3D.AlphaAntiAliasing].
+			The type of alpha antialiasing to apply.
 		</member>
 		<member name="alpha_cut" type="int" setter="set_alpha_cut_mode" getter="get_alpha_cut_mode" enum="SpriteBase3D.AlphaCutMode" default="0">
-			The alpha cutting mode to use for the sprite. See [enum AlphaCutMode] for possible values.
+			The alpha cutting mode to use for the sprite.
 		</member>
 		<member name="alpha_hash_scale" type="float" setter="set_alpha_hash_scale" getter="get_alpha_hash_scale" default="1.0">
 			The hashing scale for Alpha Hash. Recommended values between [code]0[/code] and [code]2[/code].
@@ -57,7 +57,7 @@
 			The direction in which the front of the texture faces.
 		</member>
 		<member name="billboard" type="int" setter="set_billboard_mode" getter="get_billboard_mode" enum="BaseMaterial3D.BillboardMode" default="0">
-			The billboard mode to use for the sprite. See [enum BaseMaterial3D.BillboardMode] for possible values.
+			The billboard mode to use for the sprite.
 			[b]Note:[/b] When billboarding is enabled and the material also casts shadows, billboards will face [b]the[/b] camera in the scene when rendering shadows. In scenes with multiple cameras, the intended shadow cannot be determined and this will result in undefined behavior. See [url=https://github.com/godotengine/godot/pull/72638]GitHub Pull Request #72638[/url] for details.
 		</member>
 		<member name="centered" type="bool" setter="set_centered" getter="is_centered" default="true">
@@ -99,7 +99,7 @@
 			If [code]true[/code], the [Light3D] in the [Environment] has effects on the sprite.
 		</member>
 		<member name="texture_filter" type="int" setter="set_texture_filter" getter="get_texture_filter" enum="BaseMaterial3D.TextureFilter" default="3">
-			Filter flags for the texture. See [enum BaseMaterial3D.TextureFilter] for options.
+			Filter flags for the texture.
 			[b]Note:[/b] Linear filtering may cause artifacts around the edges, which are especially noticeable on opaque textures. To prevent this, use textures with transparent or identical colors around the edges.
 		</member>
 		<member name="transparent" type="bool" setter="set_draw_flag" getter="get_draw_flag" default="true">

--- a/doc/classes/StreamPeerTCP.xml
+++ b/doc/classes/StreamPeerTCP.xml
@@ -54,7 +54,7 @@
 		<method name="get_status" qualifiers="const">
 			<return type="int" enum="StreamPeerTCP.Status" />
 			<description>
-				Returns the status of the connection, see [enum Status].
+				Returns the status of the connection.
 			</description>
 		</method>
 		<method name="poll">

--- a/doc/classes/StreamPeerTLS.xml
+++ b/doc/classes/StreamPeerTLS.xml
@@ -37,7 +37,7 @@
 		<method name="get_status" qualifiers="const">
 			<return type="int" enum="StreamPeerTLS.Status" />
 			<description>
-				Returns the status of the connection. See [enum Status] for values.
+				Returns the status of the connection.
 			</description>
 		</method>
 		<method name="get_stream" qualifiers="const">

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -37,7 +37,7 @@
 			<return type="int" />
 			<param index="0" name="corner" type="int" enum="Corner" />
 			<description>
-				Returns the given [param corner]'s radius. See [enum Corner] for possible values.
+				Returns the given [param corner]'s radius.
 			</description>
 		</method>
 		<method name="get_expand_margin" qualifiers="const">
@@ -67,7 +67,7 @@
 			<param index="0" name="corner" type="int" enum="Corner" />
 			<param index="1" name="radius" type="int" />
 			<description>
-				Sets the corner radius to [param radius] pixels for the given [param corner]. See [enum Corner] for possible values.
+				Sets the corner radius to [param radius] pixels for the given [param corner].
 			</description>
 		</method>
 		<method name="set_corner_radius_all">

--- a/doc/classes/StyleBoxTexture.xml
+++ b/doc/classes/StyleBoxTexture.xml
@@ -56,10 +56,10 @@
 	</methods>
 	<members>
 		<member name="axis_stretch_horizontal" type="int" setter="set_h_axis_stretch_mode" getter="get_h_axis_stretch_mode" enum="StyleBoxTexture.AxisStretchMode" default="0">
-			Controls how the stylebox's texture will be stretched or tiled horizontally. See [enum AxisStretchMode] for possible values.
+			Controls how the stylebox's texture will be stretched or tiled horizontally.
 		</member>
 		<member name="axis_stretch_vertical" type="int" setter="set_v_axis_stretch_mode" getter="get_v_axis_stretch_mode" enum="StyleBoxTexture.AxisStretchMode" default="0">
-			Controls how the stylebox's texture will be stretched or tiled vertically. See [enum AxisStretchMode] for possible values.
+			Controls how the stylebox's texture will be stretched or tiled vertically.
 		</member>
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="is_draw_center_enabled" default="true">
 			If [code]true[/code], the nine-patch texture's center tile will be drawn.

--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -271,10 +271,10 @@
 			If [code]true[/code], enables selecting a tab with the right mouse button.
 		</member>
 		<member name="tab_alignment" type="int" setter="set_tab_alignment" getter="get_tab_alignment" enum="TabBar.AlignmentMode" default="0">
-			Sets the position at which tabs will be placed. See [enum AlignmentMode] for details.
+			The position at which tabs will be placed.
 		</member>
 		<member name="tab_close_display_policy" type="int" setter="set_tab_close_display_policy" getter="get_tab_close_display_policy" enum="TabBar.CloseButtonDisplayPolicy" default="0">
-			Sets when the close button will appear on the tabs. See [enum CloseButtonDisplayPolicy] for details.
+			When the close button will appear on the tabs.
 		</member>
 		<member name="tab_count" type="int" setter="set_tab_count" getter="get_tab_count" default="0">
 			The number of tabs currently in the bar.

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -224,13 +224,13 @@
 			If [code]true[/code], tabs can be rearranged with mouse drag.
 		</member>
 		<member name="tab_alignment" type="int" setter="set_tab_alignment" getter="get_tab_alignment" enum="TabBar.AlignmentMode" default="0">
-			Sets the position at which tabs will be placed. See [enum TabBar.AlignmentMode] for details.
+			The position at which tabs will be placed.
 		</member>
 		<member name="tab_focus_mode" type="int" setter="set_tab_focus_mode" getter="get_tab_focus_mode" enum="Control.FocusMode" default="2">
 			The focus access mode for the internal [TabBar] node.
 		</member>
 		<member name="tabs_position" type="int" setter="set_tabs_position" getter="get_tabs_position" enum="TabContainer.TabPosition" default="0">
-			Sets the position of the tab bar. See [enum TabPosition] for details.
+			The position of the tab bar.
 		</member>
 		<member name="tabs_rearrange_group" type="int" setter="set_tabs_rearrange_group" getter="get_tabs_rearrange_group" default="-1">
 			[TabContainer]s with the same rearrange group ID will allow dragging the tabs between them. Enable drag with [member drag_to_rearrange_enabled].

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -295,7 +295,7 @@
 			<return type="int" enum="TextEdit.GutterType" />
 			<param index="0" name="gutter" type="int" />
 			<description>
-				Returns the type of the gutter at the given index. Gutters can contain icons, text, or custom visuals. See [enum TextEdit.GutterType] for options.
+				Returns the type of the gutter at the given index. Gutters can contain icons, text, or custom visuals.
 			</description>
 		</method>
 		<method name="get_gutter_width" qualifiers="const">
@@ -1085,7 +1085,7 @@
 			<param index="0" name="gutter" type="int" />
 			<param index="1" name="type" type="int" enum="TextEdit.GutterType" />
 			<description>
-				Sets the type of gutter at the given index. Gutters can contain icons, text, or custom visuals. See [enum TextEdit.GutterType] for options.
+				Sets the type of gutter at the given index. Gutters can contain icons, text, or custom visuals.
 			</description>
 		</method>
 		<method name="set_gutter_width">
@@ -1281,7 +1281,7 @@
 	</methods>
 	<members>
 		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="TextServer.AutowrapMode" default="3">
-			If [member wrap_mode] is set to [constant LINE_WRAPPING_BOUNDARY], sets text wrapping mode. To see how each mode behaves, see [enum TextServer.AutowrapMode].
+			If [member wrap_mode] is set to [constant LINE_WRAPPING_BOUNDARY], sets text wrapping mode.
 		</member>
 		<member name="backspace_deletes_composite_character_enabled" type="bool" setter="set_backspace_deletes_composite_character_enabled" getter="is_backspace_deletes_composite_character_enabled" default="false">
 			If [code]true[/code] and [member caret_mid_grapheme] is [code]false[/code], backspace deletes an entire composite character such as ❤️‍🩹, instead of deleting part of the composite character.

--- a/doc/classes/TextLine.xml
+++ b/doc/classes/TextLine.xml
@@ -175,7 +175,7 @@
 			If set to [code]true[/code] text will display invalid characters.
 		</member>
 		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="3">
-			Sets the clipping behavior when the text exceeds the text line's set width. See [enum TextServer.OverrunBehavior] for a description of all modes.
+			The clipping behavior when the text exceeds the text line's set width.
 		</member>
 		<member name="width" type="float" setter="set_width" getter="get_width" default="-1.0">
 			Text line width.

--- a/doc/classes/TextMesh.xml
+++ b/doc/classes/TextMesh.xml
@@ -13,7 +13,7 @@
 	</tutorials>
 	<members>
 		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="TextServer.AutowrapMode" default="0">
-			If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text. To see how each mode behaves, see [enum TextServer.AutowrapMode].
+			If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text.
 		</member>
 		<member name="curve_step" type="float" setter="set_curve_step" getter="get_curve_step" default="0.5">
 			Step (in pixels) used to approximate Bézier curves.
@@ -28,10 +28,10 @@
 			Font size of the [TextMesh]'s text.
 		</member>
 		<member name="horizontal_alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="1">
-			Controls the text's horizontal alignment. Supports left, center, right, and fill, or justify. Set it to one of the [enum HorizontalAlignment] constants.
+			Controls the text's horizontal alignment. Supports left, center, right, and fill, or justify.
 		</member>
 		<member name="justification_flags" type="int" setter="set_justification_flags" getter="get_justification_flags" enum="TextServer.JustificationFlag" is_bitfield="true" default="163">
-			Line fill alignment rules. See [enum TextServer.JustificationFlag] for more information.
+			Line fill alignment rules.
 		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for text shaping algorithms, if left empty current locale is used instead.
@@ -62,7 +62,7 @@
 			If [code]true[/code], all the text displays as UPPERCASE.
 		</member>
 		<member name="vertical_alignment" type="int" setter="set_vertical_alignment" getter="get_vertical_alignment" enum="VerticalAlignment" default="1">
-			Controls the text's vertical alignment. Supports top, center, bottom. Set it to one of the [enum VerticalAlignment] constants.
+			Controls the text's vertical alignment. Supports top, center, and bottom.
 		</member>
 		<member name="width" type="float" setter="set_width" getter="get_width" default="500.0">
 			Text width (in pixels), used for fill alignment.

--- a/doc/classes/TextParagraph.xml
+++ b/doc/classes/TextParagraph.xml
@@ -296,7 +296,7 @@
 			Ellipsis character used for text clipping.
 		</member>
 		<member name="justification_flags" type="int" setter="set_justification_flags" getter="get_justification_flags" enum="TextServer.JustificationFlag" is_bitfield="true" default="163">
-			Line fill alignment rules. See [enum TextServer.JustificationFlag] for more information.
+			Line fill alignment rules.
 		</member>
 		<member name="line_spacing" type="float" setter="set_line_spacing" getter="get_line_spacing" default="0.0">
 			Additional vertical spacing between lines (in pixels), spacing is added to line descent. This value can be negative.
@@ -314,7 +314,7 @@
 			If set to [code]true[/code] text will display invalid characters.
 		</member>
 		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="0">
-			Sets the clipping behavior when the text exceeds the paragraph's set width. See [enum TextServer.OverrunBehavior] for a description of all modes.
+			The clipping behavior when the text exceeds the paragraph's set width.
 		</member>
 		<member name="width" type="float" setter="set_width" getter="get_width" default="-1.0">
 			Paragraph width.

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -448,7 +448,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<description>
-				Returns the spacing for [param spacing] (see [enum TextServer.SpacingType]) in pixels (not relative to the font size).
+				Returns the spacing for [param spacing] in pixels (not relative to the font size).
 			</description>
 		</method>
 		<method name="font_get_stretch" qualifiers="const">
@@ -462,7 +462,7 @@
 			<return type="int" enum="TextServer.FontStyle" is_bitfield="true" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				Returns font style flags, see [enum FontStyle].
+				Returns font style flags.
 			</description>
 		</method>
 		<method name="font_get_style_name" qualifiers="const">
@@ -960,7 +960,7 @@
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<param index="2" name="value" type="int" />
 			<description>
-				Sets the spacing for [param spacing] (see [enum TextServer.SpacingType]) to [param value] in pixels (not relative to the font size).
+				Sets the spacing for [param spacing] to [param value] in pixels (not relative to the font size).
 			</description>
 		</method>
 		<method name="font_set_stretch">
@@ -977,7 +977,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="style" type="int" enum="TextServer.FontStyle" is_bitfield="true" />
 			<description>
-				Sets the font style flags, see [enum FontStyle].
+				Sets the font style flags.
 				[b]Note:[/b] This value is used for font matching only and will not affect font rendering. Use [method font_set_face_index], [method font_set_variation_coordinates], [method font_set_embolden], or [method font_set_transform] instead.
 			</description>
 		</method>
@@ -1211,7 +1211,7 @@
 			<param index="1" name="args" type="Array" />
 			<param index="2" name="text" type="String" />
 			<description>
-				Default implementation of the BiDi algorithm override function. See [enum StructuredTextParser] for more info.
+				Default implementation of the BiDi algorithm override function.
 			</description>
 		</method>
 		<method name="percent_sign" qualifiers="const">
@@ -1682,7 +1682,7 @@
 			<param index="1" name="grapheme_flags" type="int" enum="TextServer.GraphemeFlag" is_bitfield="true" default="264" />
 			<param index="2" name="skip_grapheme_flags" type="int" enum="TextServer.GraphemeFlag" is_bitfield="true" default="4" />
 			<description>
-				Breaks text into words and returns array of character ranges. Use [param grapheme_flags] to set what characters are used for breaking (see [enum GraphemeFlag]).
+				Breaks text into words and returns array of character ranges. Use [param grapheme_flags] to set what characters are used for breaking.
 			</description>
 		</method>
 		<method name="shaped_text_has_visible_chars" qualifiers="const">

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -478,7 +478,7 @@
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<description>
 				[b]Optional.[/b]
-				Returns the spacing for [param spacing] (see [enum TextServer.SpacingType]) in pixels (not relative to the font size).
+				Returns the spacing for [param spacing] in pixels (not relative to the font size).
 			</description>
 		</method>
 		<method name="_font_get_stretch" qualifiers="virtual const">
@@ -494,7 +494,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<description>
 				[b]Optional.[/b]
-				Returns font style flags, see [enum TextServer.FontStyle].
+				Returns font style flags.
 			</description>
 		</method>
 		<method name="_font_get_style_name" qualifiers="virtual const">
@@ -1057,7 +1057,7 @@
 			<param index="2" name="value" type="int" />
 			<description>
 				[b]Optional.[/b]
-				Sets the spacing for [param spacing] (see [enum TextServer.SpacingType]) to [param value] in pixels (not relative to the font size).
+				Sets the spacing for [param spacing] to [param value] in pixels (not relative to the font size).
 			</description>
 		</method>
 		<method name="_font_set_stretch" qualifiers="virtual">
@@ -1075,7 +1075,7 @@
 			<param index="1" name="style" type="int" enum="TextServer.FontStyle" is_bitfield="true" />
 			<description>
 				[b]Optional.[/b]
-				Sets the font style flags, see [enum TextServer.FontStyle].
+				Sets the font style flags.
 			</description>
 		</method>
 		<method name="_font_set_style_name" qualifiers="virtual">
@@ -1321,7 +1321,7 @@
 			<param index="2" name="text" type="String" />
 			<description>
 				[b]Optional.[/b]
-				Default implementation of the BiDi algorithm override function. See [enum TextServer.StructuredTextParser] for more info.
+				Default implementation of the BiDi algorithm override function.
 			</description>
 		</method>
 		<method name="_percent_sign" qualifiers="virtual const">
@@ -1855,7 +1855,7 @@
 			<param index="2" name="skip_grapheme_flags" type="int" enum="TextServer.GraphemeFlag" is_bitfield="true" />
 			<description>
 				[b]Optional.[/b]
-				Breaks text into words and returns array of character ranges. Use [param grapheme_flags] to set what characters are used for breaking (see [enum TextServer.GraphemeFlag]).
+				Breaks text into words and returns array of character ranges. Use [param grapheme_flags] to set what characters are used for breaking.
 			</description>
 		</method>
 		<method name="_shaped_text_hit_test_grapheme" qualifiers="virtual const">

--- a/doc/classes/Texture3D.xml
+++ b/doc/classes/Texture3D.xml
@@ -68,7 +68,7 @@
 		<method name="get_format" qualifiers="const">
 			<return type="int" enum="Image.Format" />
 			<description>
-				Returns the current format being used by this texture. See [enum Image.Format] for details.
+				Returns the current format being used by this texture.
 			</description>
 		</method>
 		<method name="get_height" qualifiers="const">

--- a/doc/classes/TextureLayered.xml
+++ b/doc/classes/TextureLayered.xml
@@ -59,7 +59,7 @@
 		<method name="get_format" qualifiers="const">
 			<return type="int" enum="Image.Format" />
 			<description>
-				Returns the current format being used by this texture. See [enum Image.Format] for details.
+				Returns the current format being used by this texture.
 			</description>
 		</method>
 		<method name="get_height" qualifiers="const">

--- a/doc/classes/TextureRect.xml
+++ b/doc/classes/TextureRect.xml
@@ -11,7 +11,7 @@
 	</tutorials>
 	<members>
 		<member name="expand_mode" type="int" setter="set_expand_mode" getter="get_expand_mode" enum="TextureRect.ExpandMode" default="0" experimental="Using [constant EXPAND_FIT_WIDTH], [constant EXPAND_FIT_WIDTH_PROPORTIONAL], [constant EXPAND_FIT_HEIGHT], or [constant EXPAND_FIT_HEIGHT_PROPORTIONAL] may result in unstable behavior in some [Container] controls. This behavior may be re-evaluated and changed in the future.">
-			Defines how minimum size is determined based on the texture's size. See [enum ExpandMode] for options.
+			Defines how minimum size is determined based on the texture's size.
 		</member>
 		<member name="flip_h" type="bool" setter="set_flip_h" getter="is_flipped_h" default="false">
 			If [code]true[/code], texture is flipped horizontally.
@@ -21,7 +21,7 @@
 		</member>
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" overrides="Control" enum="Control.MouseFilter" default="1" />
 		<member name="stretch_mode" type="int" setter="set_stretch_mode" getter="get_stretch_mode" enum="TextureRect.StretchMode" default="0">
-			Controls the texture's behavior when resizing the node's bounding rectangle. See [enum StretchMode].
+			Controls the texture's behavior when resizing the node's bounding rectangle.
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			The node's [Texture2D] resource.

--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -55,7 +55,7 @@
 			If [code]true[/code], the timer is paused. A paused timer does not process until this property is set back to [code]false[/code], even when [method start] is called.
 		</member>
 		<member name="process_callback" type="int" setter="set_timer_process_callback" getter="get_timer_process_callback" enum="Timer.TimerProcessCallback" default="1">
-			Specifies when the timer is updated during the main loop (see [enum TimerProcessCallback]).
+			Specifies when the timer is updated during the main loop.
 		</member>
 		<member name="time_left" type="float" setter="" getter="get_time_left">
 			The timer's remaining time in seconds. This is always [code]0[/code] if the timer is stopped.

--- a/doc/classes/TouchScreenButton.xml
+++ b/doc/classes/TouchScreenButton.xml
@@ -45,7 +45,7 @@
 			The button's texture for the pressed state.
 		</member>
 		<member name="visibility_mode" type="int" setter="set_visibility_mode" getter="get_visibility_mode" enum="TouchScreenButton.VisibilityMode" default="0">
-			The button's visibility mode. See [enum VisibilityMode] for possible values.
+			The button's visibility mode.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -589,7 +589,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="mode" type="int" enum="TreeItem.TreeCellMode" />
 			<description>
-				Sets the given column's cell mode to [param mode]. This determines how the cell is displayed and edited. See [enum TreeCellMode] constants for details.
+				Sets the given column's cell mode to [param mode]. This determines how the cell is displayed and edited.
 			</description>
 		</method>
 		<method name="set_checked">
@@ -822,7 +822,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="text_alignment" type="int" enum="HorizontalAlignment" />
 			<description>
-				Sets the given column's text alignment. See [enum HorizontalAlignment] for possible values.
+				Sets the given column's text alignment to [param text_alignment].
 			</description>
 		</method>
 		<method name="set_text_direction">

--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -261,7 +261,7 @@
 			<return type="Tween" />
 			<param index="0" name="mode" type="int" enum="Tween.TweenPauseMode" />
 			<description>
-				Determines the behavior of the [Tween] when the [SceneTree] is paused. Check [enum TweenPauseMode] for options.
+				Determines the behavior of the [Tween] when the [SceneTree] is paused.
 				Default value is [constant TWEEN_PAUSE_BOUND].
 			</description>
 		</method>

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -178,7 +178,7 @@
 			<param index="2" name="backward_undo_ops" type="bool" default="false" />
 			<description>
 				Create a new action. After this is called, do all your calls to [method add_do_method], [method add_undo_method], [method add_do_property], and [method add_undo_property], then commit the action with [method commit_action].
-				The way actions are merged is dictated by [param merge_mode]. See [enum MergeMode] for details.
+				The way actions are merged is dictated by [param merge_mode].
 				The way undo operation are ordered in actions is dictated by [param backward_undo_ops]. When [param backward_undo_ops] is [code]false[/code] undo option are ordered in the same order they were added. Which means the first operation to be added will be the first to be undone.
 			</description>
 		</method>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -101,7 +101,7 @@
 			<param index="0" name="type" type="int" enum="Viewport.RenderInfoType" />
 			<param index="1" name="info" type="int" enum="Viewport.RenderInfo" />
 			<description>
-				Returns rendering statistics of the given type. See [enum RenderInfoType] and [enum RenderInfo] for options.
+				Returns rendering statistics of the given type.
 			</description>
 		</method>
 		<method name="get_screen_transform" qualifiers="const">
@@ -317,10 +317,10 @@
 			The rendering layers in which this [Viewport] renders [CanvasItem] nodes.
 		</member>
 		<member name="canvas_item_default_texture_filter" type="int" setter="set_default_canvas_item_texture_filter" getter="get_default_canvas_item_texture_filter" enum="Viewport.DefaultCanvasItemTextureFilter" default="1">
-			Sets the default filter mode used by [CanvasItem]s in this Viewport. See [enum DefaultCanvasItemTextureFilter] for options.
+			Sets the default filter mode used by [CanvasItem]s in this Viewport.
 		</member>
 		<member name="canvas_item_default_texture_repeat" type="int" setter="set_default_canvas_item_texture_repeat" getter="get_default_canvas_item_texture_repeat" enum="Viewport.DefaultCanvasItemTextureRepeat" default="0">
-			Sets the default repeat mode used by [CanvasItem]s in this Viewport. See [enum DefaultCanvasItemTextureRepeat] for options.
+			Sets the default repeat mode used by [CanvasItem]s in this Viewport.
 		</member>
 		<member name="canvas_transform" type="Transform2D" setter="set_canvas_transform" getter="get_canvas_transform">
 			The canvas transform of the viewport, useful for changing the on-screen positions of all child [CanvasItem]s. This is relative to the global canvas transform of the viewport.

--- a/doc/classes/VisualShaderNodeBillboard.xml
+++ b/doc/classes/VisualShaderNodeBillboard.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="billboard_type" type="int" setter="set_billboard_type" getter="get_billboard_type" enum="VisualShaderNodeBillboard.BillboardType" default="1">
-			Controls how the object faces the camera. See [enum BillboardType].
+			Controls how the object faces the camera.
 		</member>
 		<member name="keep_scale" type="bool" setter="set_keep_scale_enabled" getter="is_keep_scale_enabled" default="false">
 			If [code]true[/code], the shader will keep the scale set for the mesh. Otherwise, the scale is lost when billboarding.

--- a/doc/classes/VisualShaderNodeColorFunc.xml
+++ b/doc/classes/VisualShaderNodeColorFunc.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeColorFunc.Function" default="0">
-			A function to be applied to the input color. See [enum Function] for options.
+			A function to be applied to the input color.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeColorOp.xml
+++ b/doc/classes/VisualShaderNodeColorOp.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeColorOp.Operator" default="0">
-			An operator to be applied to the inputs. See [enum Operator] for options.
+			An operator to be applied to the inputs.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeCompare.xml
+++ b/doc/classes/VisualShaderNodeCompare.xml
@@ -13,10 +13,10 @@
 			Extra condition which is applied if [member type] is set to [constant CTYPE_VECTOR_3D].
 		</member>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeCompare.Function" default="0">
-			A comparison function. See [enum Function] for options.
+			A comparison function.
 		</member>
 		<member name="type" type="int" setter="set_comparison_type" getter="get_comparison_type" enum="VisualShaderNodeCompare.ComparisonType" default="0">
-			The type to be used in the comparison. See [enum ComparisonType] for options.
+			The type to be used in the comparison.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeCubemap.xml
+++ b/doc/classes/VisualShaderNodeCubemap.xml
@@ -13,10 +13,10 @@
 			The [Cubemap] texture to sample when using [constant SOURCE_TEXTURE] as [member source].
 		</member>
 		<member name="source" type="int" setter="set_source" getter="get_source" enum="VisualShaderNodeCubemap.Source" default="0">
-			Defines which source should be used for the sampling. See [enum Source] for options.
+			Defines which source should be used for the sampling.
 		</member>
 		<member name="texture_type" type="int" setter="set_texture_type" getter="get_texture_type" enum="VisualShaderNodeCubemap.TextureType" default="0">
-			Defines the type of data provided by the source texture. See [enum TextureType] for options.
+			Defines the type of data provided by the source texture.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeCustom.xml
+++ b/doc/classes/VisualShaderNodeCustom.xml
@@ -33,7 +33,7 @@
 				Override this method to define the actual shader code of the associated custom node. The shader code should be returned as a string, which can have multiple lines (the [code]"""[/code] multiline string construct can be used for convenience).
 				The [param input_vars] and [param output_vars] arrays contain the string names of the various input and output variables, as defined by [code]_get_input_*[/code] and [code]_get_output_*[/code] virtual methods in this class.
 				The output ports can be assigned values in the shader code. For example, [code]return output_vars[0] + " = " + input_vars[0] + ";"[/code].
-				You can customize the generated code based on the shader [param mode] (see [enum Shader.Mode]) and/or [param type] (see [enum VisualShader.Type]).
+				You can customize the generated code based on the shader [param mode] and/or [param type].
 				Defining this method is [b]required[/b].
 			</description>
 		</method>
@@ -59,7 +59,7 @@
 			<description>
 				Override this method to add a shader code to the beginning of each shader function (once). The shader code should be returned as a string, which can have multiple lines (the [code]"""[/code] multiline string construct can be used for convenience).
 				If there are multiple custom nodes of different types which use this feature the order of each insertion is undefined.
-				You can customize the generated code based on the shader [param mode] (see [enum Shader.Mode]) and/or [param type] (see [enum VisualShader.Type]).
+				You can customize the generated code based on the shader [param mode] and/or [param type].
 				Defining this method is [b]optional[/b].
 			</description>
 		</method>
@@ -69,7 +69,7 @@
 			<description>
 				Override this method to add shader code on top of the global shader, to define your own standard library of reusable methods, varyings, constants, uniforms, etc. The shader code should be returned as a string, which can have multiple lines (the [code]"""[/code] multiline string construct can be used for convenience).
 				Be careful with this functionality as it can cause name conflicts with other custom nodes, so be sure to give the defined entities unique names.
-				You can customize the generated code based on the shader [param mode] (see [enum Shader.Mode]).
+				You can customize the generated code based on the shader [param mode].
 				Defining this method is [b]optional[/b].
 			</description>
 		</method>
@@ -100,7 +100,7 @@
 			<return type="int" enum="VisualShaderNode.PortType" />
 			<param index="0" name="port" type="int" />
 			<description>
-				Override this method to define the returned type of each input port of the associated custom node (see [enum VisualShaderNode.PortType] for possible types).
+				Override this method to define the returned type of each input port of the associated custom node.
 				Defining this method is [b]optional[/b], but recommended. If not overridden, input ports will return the [constant VisualShaderNode.PORT_TYPE_SCALAR] type.
 			</description>
 		</method>
@@ -130,7 +130,7 @@
 			<return type="int" enum="VisualShaderNode.PortType" />
 			<param index="0" name="port" type="int" />
 			<description>
-				Override this method to define the returned type of each output port of the associated custom node (see [enum VisualShaderNode.PortType] for possible types).
+				Override this method to define the returned type of each output port of the associated custom node.
 				Defining this method is [b]optional[/b], but recommended. If not overridden, output ports will return the [constant VisualShaderNode.PORT_TYPE_SCALAR] type.
 			</description>
 		</method>
@@ -177,7 +177,7 @@
 			<param index="0" name="mode" type="int" enum="Shader.Mode" />
 			<param index="1" name="type" type="int" enum="VisualShader.Type" />
 			<description>
-				Override this method to prevent the node to be visible in the member dialog for the certain [param mode] (see [enum Shader.Mode]) and/or [param type] (see [enum VisualShader.Type]).
+				Override this method to prevent the node to be visible in the member dialog for the certain [param mode] and/or [param type].
 				Defining this method is [b]optional[/b]. If not overridden, it's [code]true[/code].
 			</description>
 		</method>

--- a/doc/classes/VisualShaderNodeDerivativeFunc.xml
+++ b/doc/classes/VisualShaderNodeDerivativeFunc.xml
@@ -10,13 +10,13 @@
 	</tutorials>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeDerivativeFunc.Function" default="0">
-			A derivative function type. See [enum Function] for options.
+			A derivative function type.
 		</member>
 		<member name="op_type" type="int" setter="set_op_type" getter="get_op_type" enum="VisualShaderNodeDerivativeFunc.OpType" default="0">
-			A type of operands and returned value. See [enum OpType] for options.
+			A type of operands and returned value.
 		</member>
 		<member name="precision" type="int" setter="set_precision" getter="get_precision" enum="VisualShaderNodeDerivativeFunc.Precision" default="0">
-			Sets the level of precision to use for the derivative function. See [enum Precision] for options. When using the Compatibility renderer, this setting has no effect.
+			Sets the level of precision to use for the derivative function. When using the Compatibility renderer, this setting has no effect.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeFloatFunc.xml
+++ b/doc/classes/VisualShaderNodeFloatFunc.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeFloatFunc.Function" default="13">
-			A function to be applied to the scalar. See [enum Function] for options.
+			A function to be applied to the scalar.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeFloatOp.xml
+++ b/doc/classes/VisualShaderNodeFloatOp.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeFloatOp.Operator" default="0">
-			An operator to be applied to the inputs. See [enum Operator] for options.
+			An operator to be applied to the inputs.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeIntFunc.xml
+++ b/doc/classes/VisualShaderNodeIntFunc.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeIntFunc.Function" default="2">
-			A function to be applied to the scalar. See [enum Function] for options.
+			A function to be applied to the scalar.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeIntOp.xml
+++ b/doc/classes/VisualShaderNodeIntOp.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeIntOp.Operator" default="0">
-			An operator to be applied to the inputs. See [enum Operator] for options.
+			An operator to be applied to the inputs.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeIs.xml
+++ b/doc/classes/VisualShaderNodeIs.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeIs.Function" default="0">
-			The comparison function. See [enum Function] for options.
+			The comparison function.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeTexture.xml
+++ b/doc/classes/VisualShaderNodeTexture.xml
@@ -10,13 +10,13 @@
 	</tutorials>
 	<members>
 		<member name="source" type="int" setter="set_source" getter="get_source" enum="VisualShaderNodeTexture.Source" default="0">
-			Determines the source for the lookup. See [enum Source] for options.
+			Determines the source for the lookup.
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			The source texture, if needed for the selected [member source].
 		</member>
 		<member name="texture_type" type="int" setter="set_texture_type" getter="get_texture_type" enum="VisualShaderNodeTexture.TextureType" default="0">
-			Specifies the type of the texture if [member source] is set to [constant SOURCE_TEXTURE]. See [enum TextureType] for options.
+			Specifies the type of the texture if [member source] is set to [constant SOURCE_TEXTURE].
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeTextureParameter.xml
+++ b/doc/classes/VisualShaderNodeTextureParameter.xml
@@ -13,16 +13,16 @@
 			Sets the default color if no texture is assigned to the uniform.
 		</member>
 		<member name="texture_filter" type="int" setter="set_texture_filter" getter="get_texture_filter" enum="VisualShaderNodeTextureParameter.TextureFilter" default="0">
-			Sets the texture filtering mode. See [enum TextureFilter] for options.
+			Sets the texture filtering mode.
 		</member>
 		<member name="texture_repeat" type="int" setter="set_texture_repeat" getter="get_texture_repeat" enum="VisualShaderNodeTextureParameter.TextureRepeat" default="0">
-			Sets the texture repeating mode. See [enum TextureRepeat] for options.
+			Sets the texture repeating mode.
 		</member>
 		<member name="texture_source" type="int" setter="set_texture_source" getter="get_texture_source" enum="VisualShaderNodeTextureParameter.TextureSource" default="0">
-			Sets the texture source mode. Used for reading from the screen, depth, or normal_roughness texture. See [enum TextureSource] for options.
+			Sets the texture source mode. Used for reading from the screen, depth, or normal_roughness texture.
 		</member>
 		<member name="texture_type" type="int" setter="set_texture_type" getter="get_texture_type" enum="VisualShaderNodeTextureParameter.TextureType" default="0">
-			Defines the type of data provided by the source texture. See [enum TextureType] for options.
+			Defines the type of data provided by the source texture.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeTransformFunc.xml
+++ b/doc/classes/VisualShaderNodeTransformFunc.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeTransformFunc.Function" default="0">
-			The function to be computed. See [enum Function] for options.
+			The function to be computed.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeTransformOp.xml
+++ b/doc/classes/VisualShaderNodeTransformOp.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeTransformOp.Operator" default="0">
-			The type of the operation to be performed on the transforms. See [enum Operator] for options.
+			The type of the operation to be performed on the transforms.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeTransformVecMult.xml
+++ b/doc/classes/VisualShaderNodeTransformVecMult.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeTransformVecMult.Operator" default="0">
-			The multiplication type to be performed. See [enum Operator] for options.
+			The multiplication type to be performed.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeUIntFunc.xml
+++ b/doc/classes/VisualShaderNodeUIntFunc.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeUIntFunc.Function" default="0">
-			A function to be applied to the scalar. See [enum Function] for options.
+			A function to be applied to the scalar.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeUIntOp.xml
+++ b/doc/classes/VisualShaderNodeUIntOp.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeUIntOp.Operator" default="0">
-			An operator to be applied to the inputs. See [enum Operator] for options.
+			An operator to be applied to the inputs.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeUVFunc.xml
+++ b/doc/classes/VisualShaderNodeUVFunc.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeUVFunc.Function" default="0">
-			A function to be applied to the texture coordinates. See [enum Function] for options.
+			A function to be applied to the texture coordinates.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeVectorFunc.xml
+++ b/doc/classes/VisualShaderNodeVectorFunc.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeVectorFunc.Function" default="0">
-			The function to be performed. See [enum Function] for options.
+			The function to be performed.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeVectorOp.xml
+++ b/doc/classes/VisualShaderNodeVectorOp.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeVectorOp.Operator" default="0">
-			The operator to be used. See [enum Operator] for options.
+			The operator to be used.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -623,7 +623,7 @@
 			If [code]true[/code], native window will be used regardless of parent viewport and project settings.
 		</member>
 		<member name="initial_position" type="int" setter="set_initial_position" getter="get_initial_position" enum="Window.WindowInitialPosition" default="0">
-			Specifies the initial type of position for the [Window]. See [enum WindowInitialPosition] constants.
+			Specifies the initial type of position for the [Window].
 		</member>
 		<member name="keep_title_visible" type="bool" setter="set_keep_title_visible" getter="get_keep_title_visible" default="false">
 			If [code]true[/code], the [Window] width is expanded to keep the title bar text fully visible.

--- a/doc/classes/XRBodyTracker.xml
+++ b/doc/classes/XRBodyTracker.xml
@@ -15,7 +15,7 @@
 			<return type="int" enum="XRBodyTracker.JointFlags" is_bitfield="true" />
 			<param index="0" name="joint" type="int" enum="XRBodyTracker.Joint" />
 			<description>
-				Returns flags about the validity of the tracking data for the given body joint (see [enum XRBodyTracker.JointFlags]).
+				Returns flags about the validity of the tracking data for the given body joint.
 			</description>
 		</method>
 		<method name="get_joint_transform" qualifiers="const">

--- a/doc/classes/XRController3D.xml
+++ b/doc/classes/XRController3D.xml
@@ -32,7 +32,7 @@
 		<method name="get_tracker_hand" qualifiers="const">
 			<return type="int" enum="XRPositionalTracker.TrackerHand" />
 			<description>
-				Returns the hand holding this controller, if known. See [enum XRPositionalTracker.TrackerHand].
+				Returns the hand holding this controller, if known.
 			</description>
 		</method>
 		<method name="get_vector2" qualifiers="const">

--- a/doc/classes/XRHandTracker.xml
+++ b/doc/classes/XRHandTracker.xml
@@ -22,7 +22,7 @@
 			<return type="int" enum="XRHandTracker.HandJointFlags" is_bitfield="true" />
 			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
 			<description>
-				Returns flags about the validity of the tracking data for the given hand joint (see [enum XRHandTracker.HandJointFlags]).
+				Returns flags about the validity of the tracking data for the given hand joint.
 			</description>
 		</method>
 		<method name="get_hand_joint_linear_velocity" qualifiers="const">

--- a/modules/enet/doc_classes/ENetConnection.xml
+++ b/modules/enet/doc_classes/ENetConnection.xml
@@ -129,7 +129,7 @@
 			<return type="float" />
 			<param index="0" name="statistic" type="int" enum="ENetConnection.HostStatistic" />
 			<description>
-				Returns and resets host statistics. See [enum HostStatistic] for more info.
+				Returns and resets host statistics.
 			</description>
 		</method>
 		<method name="refuse_new_connections">

--- a/modules/enet/doc_classes/ENetPacketPeer.xml
+++ b/modules/enet/doc_classes/ENetPacketPeer.xml
@@ -39,14 +39,14 @@
 		<method name="get_state" qualifiers="const">
 			<return type="int" enum="ENetPacketPeer.PeerState" />
 			<description>
-				Returns the current peer state. See [enum PeerState].
+				Returns the current peer state.
 			</description>
 		</method>
 		<method name="get_statistic">
 			<return type="float" />
 			<param index="0" name="statistic" type="int" enum="ENetPacketPeer.PeerStatistic" />
 			<description>
-				Returns the requested [param statistic] for this peer. See [enum PeerStatistic].
+				Returns the requested [param statistic] for this peer.
 			</description>
 		</method>
 		<method name="is_active" qualifiers="const">

--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -130,11 +130,11 @@
 			If [member image_format] is a lossy image format, this determines the lossy quality of the image. On a range of [code]0.0[/code] to [code]1.0[/code], where [code]0.0[/code] is the lowest quality and [code]1.0[/code] is the highest quality. A lossy quality of [code]1.0[/code] is not the same as lossless.
 		</member>
 		<member name="root_node_mode" type="int" setter="set_root_node_mode" getter="get_root_node_mode" enum="GLTFDocument.RootNodeMode" default="0">
-			How to process the root node during export. See [enum RootNodeMode] for details. The default and recommended value is [constant ROOT_NODE_MODE_SINGLE_ROOT].
+			How to process the root node during export. The default and recommended value is [constant ROOT_NODE_MODE_SINGLE_ROOT].
 			[b]Note:[/b] Regardless of how the glTF file is exported, when importing, the root node type and name can be overridden in the scene import settings tab.
 		</member>
 		<member name="visibility_mode" type="int" setter="set_visibility_mode" getter="get_visibility_mode" enum="GLTFDocument.VisibilityMode" default="0">
-			How to deal with node visibility during export. This setting does nothing if all nodes are visible. See [enum VisibilityMode] for details. The default and recommended value is [constant VISIBILITY_MODE_INCLUDE_REQUIRED], which uses the [code]KHR_node_visibility[/code] extension.
+			How to deal with node visibility during export. This setting does nothing if all nodes are visible. The default and recommended value is [constant VISIBILITY_MODE_INCLUDE_REQUIRED], which uses the [code]KHR_node_visibility[/code] extension.
 		</member>
 	</members>
 	<constants>

--- a/modules/gltf/doc_classes/GLTFObjectModelProperty.xml
+++ b/modules/gltf/doc_classes/GLTFObjectModelProperty.xml
@@ -70,7 +70,7 @@
 			In most cases [member node_paths] will only have one item, but in some cases a single glTF JSON pointer will map to multiple Godot properties. For example, a [GLTFCamera] or [GLTFLight] used on multiple glTF nodes will be represented by multiple Godot nodes.
 		</member>
 		<member name="object_model_type" type="int" setter="set_object_model_type" getter="get_object_model_type" enum="GLTFObjectModelProperty.GLTFObjectModelType" default="0">
-			The type of data stored in the glTF file as defined by the object model. This is a superset of the available accessor types, and determines the accessor type. See [enum GLTFObjectModelType] for possible values.
+			The type of data stored in the glTF file as defined by the object model. This is a superset of the available accessor types, and determines the accessor type.
 		</member>
 		<member name="variant_type" type="int" setter="set_variant_type" getter="get_variant_type" enum="Variant.Type" default="0">
 			The type of data stored in the Godot property. This is the type of the property that the [member node_paths] point to.

--- a/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
+++ b/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
@@ -69,7 +69,7 @@
 			If [member root_path] was spawned by a [MultiplayerSpawner], the node will be also be spawned and despawned based on this synchronizer visibility options.
 		</member>
 		<member name="visibility_update_mode" type="int" setter="set_visibility_update_mode" getter="get_visibility_update_mode" enum="MultiplayerSynchronizer.VisibilityUpdateMode" default="0">
-			Specifies when visibility filters are updated (see [enum VisibilityUpdateMode] for options).
+			Specifies when visibility filters are updated.
 		</member>
 	</members>
 	<signals>

--- a/modules/multiplayer/doc_classes/SceneReplicationConfig.xml
+++ b/modules/multiplayer/doc_classes/SceneReplicationConfig.xml
@@ -41,7 +41,7 @@
 			<return type="int" enum="SceneReplicationConfig.ReplicationMode" />
 			<param index="0" name="path" type="NodePath" />
 			<description>
-				Returns the replication mode for the property identified by the given [param path]. See [enum ReplicationMode].
+				Returns the replication mode for the property identified by the given [param path].
 			</description>
 		</method>
 		<method name="property_get_spawn">
@@ -70,7 +70,7 @@
 			<param index="0" name="path" type="NodePath" />
 			<param index="1" name="mode" type="int" enum="SceneReplicationConfig.ReplicationMode" />
 			<description>
-				Sets the synchronization mode for the property identified by the given [param path]. See [enum ReplicationMode].
+				Sets the synchronization mode for the property identified by the given [param path].
 			</description>
 		</method>
 		<method name="property_set_spawn">

--- a/modules/noise/doc_classes/FastNoiseLite.xml
+++ b/modules/noise/doc_classes/FastNoiseLite.xml
@@ -11,13 +11,13 @@
 	</tutorials>
 	<members>
 		<member name="cellular_distance_function" type="int" setter="set_cellular_distance_function" getter="get_cellular_distance_function" enum="FastNoiseLite.CellularDistanceFunction" default="0">
-			Determines how the distance to the nearest/second-nearest point is computed. See [enum CellularDistanceFunction] for options.
+			Determines how the distance to the nearest/second-nearest point is computed.
 		</member>
 		<member name="cellular_jitter" type="float" setter="set_cellular_jitter" getter="get_cellular_jitter" default="1.0">
 			Maximum distance a point can move off of its grid position. Set to [code]0[/code] for an even grid.
 		</member>
 		<member name="cellular_return_type" type="int" setter="set_cellular_return_type" getter="get_cellular_return_type" enum="FastNoiseLite.CellularReturnType" default="1">
-			Return type from cellular noise calculations. See [enum CellularReturnType].
+			Return type from cellular noise calculations.
 		</member>
 		<member name="domain_warp_amplitude" type="float" setter="set_domain_warp_amplitude" getter="get_domain_warp_amplitude" default="30.0">
 			Sets the maximum warp distance from the origin.
@@ -36,13 +36,13 @@
 			The number of noise layers that are sampled to get the final value for the fractal noise which warps the space.
 		</member>
 		<member name="domain_warp_fractal_type" type="int" setter="set_domain_warp_fractal_type" getter="get_domain_warp_fractal_type" enum="FastNoiseLite.DomainWarpFractalType" default="1">
-			The method for combining octaves into a fractal which is used to warp the space. See [enum DomainWarpFractalType].
+			The method for combining octaves into a fractal which is used to warp the space.
 		</member>
 		<member name="domain_warp_frequency" type="float" setter="set_domain_warp_frequency" getter="get_domain_warp_frequency" default="0.05">
 			Frequency of the noise which warps the space. Low frequency results in smooth noise while high frequency results in rougher, more granular noise.
 		</member>
 		<member name="domain_warp_type" type="int" setter="set_domain_warp_type" getter="get_domain_warp_type" enum="FastNoiseLite.DomainWarpType" default="0">
-			Sets the warp algorithm. See [enum DomainWarpType].
+			The warp algorithm.
 		</member>
 		<member name="fractal_gain" type="float" setter="set_fractal_gain" getter="get_fractal_gain" default="0.5">
 			Determines the strength of each subsequent layer of noise in fractal noise.
@@ -58,7 +58,7 @@
 			Sets the strength of the fractal ping pong type.
 		</member>
 		<member name="fractal_type" type="int" setter="set_fractal_type" getter="get_fractal_type" enum="FastNoiseLite.FractalType" default="1">
-			The method for combining octaves into a fractal. See [enum FractalType].
+			The method for combining octaves into a fractal.
 		</member>
 		<member name="fractal_weighted_strength" type="float" setter="set_fractal_weighted_strength" getter="get_fractal_weighted_strength" default="0.0">
 			Higher weighting means higher octaves have less impact if lower octaves have a large impact.
@@ -67,7 +67,7 @@
 			The frequency for all noise types. Low frequency results in smooth noise while high frequency results in rougher, more granular noise.
 		</member>
 		<member name="noise_type" type="int" setter="set_noise_type" getter="get_noise_type" enum="FastNoiseLite.NoiseType" default="1">
-			The noise algorithm used. See [enum NoiseType].
+			The noise algorithm used.
 		</member>
 		<member name="offset" type="Vector3" setter="set_offset" getter="get_offset" default="Vector3(0, 0, 0)">
 			Translate the noise input coordinates by the given [Vector3].

--- a/modules/upnp/doc_classes/UPNPDevice.xml
+++ b/modules/upnp/doc_classes/UPNPDevice.xml
@@ -55,7 +55,7 @@
 			IGD service type.
 		</member>
 		<member name="igd_status" type="int" setter="set_igd_status" getter="get_igd_status" enum="UPNPDevice.IGDStatus" default="9">
-			IGD status. See [enum IGDStatus].
+			IGD status.
 		</member>
 		<member name="service_type" type="String" setter="set_service_type" getter="get_service_type" default="&quot;&quot;">
 			Service type.

--- a/modules/webrtc/doc_classes/WebRTCDataChannel.xml
+++ b/modules/webrtc/doc_classes/WebRTCDataChannel.xml
@@ -55,7 +55,7 @@
 		<method name="get_ready_state" qualifiers="const">
 			<return type="int" enum="WebRTCDataChannel.ChannelState" />
 			<description>
-				Returns the current state of this channel, see [enum ChannelState].
+				Returns the current state of this channel.
 			</description>
 		</method>
 		<method name="is_negotiated" qualifiers="const">

--- a/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
+++ b/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
@@ -64,7 +64,7 @@
 		<method name="get_connection_state" qualifiers="const">
 			<return type="int" enum="WebRTCPeerConnection.ConnectionState" />
 			<description>
-				Returns the connection state. See [enum ConnectionState].
+				Returns the connection state.
 			</description>
 		</method>
 		<method name="get_gathering_state" qualifiers="const">

--- a/modules/websocket/doc_classes/WebSocketPeer.xml
+++ b/modules/websocket/doc_classes/WebSocketPeer.xml
@@ -100,7 +100,7 @@
 		<method name="get_ready_state" qualifiers="const">
 			<return type="int" enum="WebSocketPeer.State" />
 			<description>
-				Returns the ready state of the connection. See [enum State].
+				Returns the ready state of the connection.
 			</description>
 		</method>
 		<method name="get_requested_url" qualifiers="const">


### PR DESCRIPTION
In the classref, we can see various descriptions about the enum types used. e.g.:

> See [enum FooBar] for possible values.
> See [enum Foobar] constants for values.
> See [enum Foobar] for options.
> See [enum Foobar] for more information.
> Use one of [enum Foobar] constants.
> Sets something to one of [enum FooBar].
> To see how each mode behaves, see [enum FooBar].
> ... [param qux] (see [enum FooBar]) ...

Most of the usages are redundant because the enum type used is already shown as the type of the property, parameter, or return value. I believe this convention is a remnant of the workaround used when it was not possible to mark `int` value's enum type.

There are still many valid use cases, e.g.:

<details><summary><code>int</code> return value</summary>

- `EditorPlugin._forward_3d_gui_input()`
- `UPNP.{add,delete}_port_mapping()`, `UPNP.discover()`
- `Tree.get_drop_section_at_position()`
- `SceneState.get_connection_flags()`
- `EditorImportPlugin._get_import_order()`
- `TextServer.get_features()`, `TextServerExtension._get_features()`
- `XRInterface.get_supported_environment_blend_modes()`
</details>

<details><summary><code>int</code> parameter(s) or content of a dictionary / array parameter</summary>

- `ResourceFormatLoader._load()`
- `GPUParticle{2D,3D}.emit_particle()`
- `CodeEdit.add_code_completion_option()`
- `VisualShaderNodeGroupBase` methods that need `PortType`
- `Signal.connect()`
- `Quaternion.get_euler()`
- `Basis.{from,get}_euler()`
- `Rect2{,i}.grow_side()`
- `SceneTree` methods that need `GroupCallFlag`
- `Node.duplicate()`, `Node.rpc_config()`
- `Object.connect()`
- `PackedByteArray` methods that need `CompressionMode`
- `{Project,Editor}Settings.add_property_info()`
- `Object.add_user_signal()`, `Object.get_property_list()`
</details>

<details><summary><code>int</code> properties</summary>

- `Tree.drop_mode_flags`
- `{,Texture}ProgressBar.fill_mode`
- `GLTFAccessor.component_type`
- `ProjectSettings`
    - `display/window/handheld/orientation`
    - `display/window/size/mode`
    - `display/window/vsync/vsync_mode`
    - `editor/movie_writer/speaker_mode`
    - `gui/theme/lcd_subpixel_layout`
- `EditorSettings.text_editor/appearance/lines/autowrap_mode`
- `CharFXTransform.glyph_flags`
</details>

<details><summary>Needed for further reading</summary>

- `WebSocketPeer.was_string_packet` and `WriteMode`
- `Tree.drop_position_color` and `DropModeFlags`
- `RenderingServer.ARRAY_FORMAT_CUSTOM_{BITS,MASK}` and `ArrayCustomFormat`
- `ProjectSettings.physics_{2d,3d}_default_{angular,linear}_damp` and `DampMode`
- `PhysicsServer{2D,3D}.BODY_PARAM_{ANGULAR,LINEAR}_DAMP_OVERRIDE_MODE` and `BodyDampMode`
- `PhysicsServer{2D,3D}.AREA_PARAM_{ANGULAR,LINEAR}_DAMP_OVERRIDE_MODE` and `AreaSpaceOverrideMode`
- `PhysicsServer{2D,3D}.AREA_PARAM_GRAVITY_OVERRIDE_MODE` and `AreaSpaceOverrideMode`
- `TextureServer.OVERRUN_JUSTIFICATION_AWARE` and `JustificationFlag`
- `Image.data` and `Format`
- `FileAccess.store_var()` and `PropertyUsageFlags`
- `@rpc` and `RPCMode`
- `Variant` and `Variant.Type`
- `{LineEdit,RichTextLabel}.get_menu()` and `MenuItem`
- `EditorUndoRedoManager.get_hisotry_undo_redo()` and `SpecialHistory`
- `AudioStreamPlayer.mix_target` and `SpeakerMode`
- `BaseMaterial3D.DEPTH_DRAW_ALWAYS` and `Transparency`
- `Node3D.rotation` and `EulerOrder`
</details>

The main reason to remove these redundant description is that I feel they add unnecessary workload when translating the class reference.

This convention also hides the fact that some descriptions does not provide anything useful. e.g., the following description looks long and detailed, but it's just repeating the property's name and type.

https://github.com/godotengine/godot/blob/0793c626d2e203c6db04656853f8088478181888/doc/classes/ArrayMesh.xml#L209-L211

Also found a mistake where a boolean property is described like an enum :P

https://github.com/godotengine/godot/blob/0793c626d2e203c6db04656853f8088478181888/doc/classes/BaseMaterial3D.xml#L392-L394
