### PR TITLE
Add missing description of `FileAccess.store_half` behavior on error

### DIFF
--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -517,6 +517,7 @@
 			<param index="0" name="value" type="float" />
 			<description>
 				Stores a half-precision floating-point number as 16 bits in the file.
+				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
 			</description>
 		</method>
 		<method name="store_line">


### PR DESCRIPTION
All other `store_*` methods have this description.

`store_half()` calls `store_16()` under the hood, so they should have the same behavior on error.