### PR TITLE
PopupMenu: Fix shortcut not v-aligned with text

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -959,7 +959,8 @@ void PopupMenu::_draw_items() {
 			} else {
 				item_ofs.x = display_width - theme_cache.panel_style->get_margin(SIDE_RIGHT) - items[i].accel_text_buf->get_size().x - theme_cache.item_end_padding;
 			}
-			Vector2 text_pos = item_ofs + Point2(0, Math::floor((h - items[i].text_buf->get_size().y) / 2.0));
+			real_t baseline = (h - items[i].text_buf->get_size().y) / 2.0 + items[i].text_buf->get_line_ascent();
+			Vector2 text_pos = item_ofs + Point2(0, Math::floor(baseline - items[i].accel_text_buf->get_line_ascent()));
 			if (theme_cache.font_outline_size > 0 && theme_cache.font_outline_color.a > 0) {
 				items[i].accel_text_buf->draw_outline(ci, text_pos, theme_cache.font_outline_size, theme_cache.font_outline_color);
 			}


### PR DESCRIPTION
Shortcut text is currently top-aligned with item text. This becomes obvious when they use different fonts (e.g., caused by font fallback).

| Before | After |
|----|----|
| ![Before](https://github.com/user-attachments/assets/66bca9f8-9757-4fc9-a4e6-765bceab2665) | ![After](https://github.com/user-attachments/assets/07690c3b-af8c-4b64-ae30-098fc594ab93) |

This PR attempts to baseline-align these two strings.