### PR TITLE
macOS: Embedded window fixes

### DIFF
--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -864,7 +864,7 @@ void GameView::_update_arguments_for_instance(int p_idx, List<String> &r_argumen
 	N = r_arguments.insert_after(N, itos(DisplayServer::get_singleton()->window_get_native_handle(DisplayServer::WINDOW_HANDLE, get_window()->get_window_id())));
 
 #if MACOS_ENABLED
-	r_arguments.push_back("--embedded");
+	N = r_arguments.insert_after(N, "--embedded");
 #endif
 
 	// Be sure to have the correct window size in the embedded_process control.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1399,9 +1399,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			display_driver = NULL_DISPLAY_DRIVER;
 
 		} else if (arg == "--embedded") { // Enable embedded mode.
-
+#ifdef MACOS_ENABLED
 			display_driver = EMBEDDED_DISPLAY_DRIVER;
-
+#else
+			OS::get_singleton()->print("--embedded is only supported on macOS, aborting.\n");
+			goto error;
+#endif
 		} else if (arg == "--log-file") { // write to log file
 
 			if (N) {

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3297,6 +3297,7 @@ Error DisplayServerMacOS::embed_process_update(WindowID p_window, const Embedded
 	[CATransaction setDisableActions:YES];
 
 	EmbeddedProcessData *ed = embedded_processes.getptr(p_pid);
+	CGFloat scale = screen_get_max_scale();
 	if (ed == nil) {
 		ed = &embedded_processes.insert(p_pid, EmbeddedProcessData())->value;
 
@@ -3305,7 +3306,7 @@ Error DisplayServerMacOS::embed_process_update(WindowID p_window, const Embedded
 		CALayerHost *host = [CALayerHost new];
 		uint32_t p_context_id = p_process->get_context_id();
 		host.contextId = static_cast<CAContextID>(p_context_id);
-		host.contentsScale = wd->window_object.backingScaleFactor;
+		host.contentsScale = scale;
 		host.contentsGravity = kCAGravityCenter;
 		ed->layer_host = host;
 		[wd->window_view.layer addSublayer:host];
@@ -3313,7 +3314,7 @@ Error DisplayServerMacOS::embed_process_update(WindowID p_window, const Embedded
 
 	Rect2i p_rect = p_process->get_screen_embedded_window_rect();
 	CGRect rect = CGRectMake(p_rect.position.x, p_rect.position.y, p_rect.size.x, p_rect.size.y);
-	rect = CGRectApplyAffineTransform(rect, CGAffineTransformMakeScale(0.5, 0.5));
+	rect = CGRectApplyAffineTransform(rect, CGAffineTransformInvert(CGAffineTransformMakeScale(scale, scale)));
 
 	CGFloat height = wd->window_view.frame.size.height;
 	CGFloat x = rect.origin.x;

--- a/platform/macos/editor/embedded_process_macos.h
+++ b/platform/macos/editor/embedded_process_macos.h
@@ -102,12 +102,12 @@ public:
 		return embedding_state == EmbeddingState::COMPLETED;
 	}
 
-	virtual bool is_process_focused() const override { return layer_host->has_focus(); }
-	virtual void embed_process(OS::ProcessID p_pid) override;
-	virtual int get_embedded_pid() const override { return current_process_id; }
-	virtual void reset() override;
-	virtual void request_close() override;
-	virtual void queue_update_embedded_process() override { update_embedded_process(); }
+	bool is_process_focused() const override { return layer_host->has_focus(); }
+	void embed_process(OS::ProcessID p_pid) override;
+	int get_embedded_pid() const override { return current_process_id; }
+	void reset() override;
+	void request_close() override;
+	void queue_update_embedded_process() override { update_embedded_process(); }
 
 	Rect2i get_adjusted_embedded_window_rect(const Rect2i &p_rect) const override;
 
@@ -117,4 +117,5 @@ public:
 	_FORCE_INLINE_ DisplayServer::MouseMode get_mouse_mode() const { return mouse_mode; }
 
 	EmbeddedProcessMacOS();
+	~EmbeddedProcessMacOS() override;
 };

--- a/platform/macos/embedded_debugger.h
+++ b/platform/macos/embedded_debugger.h
@@ -63,6 +63,7 @@ private:
 	Error _msg_ime_update(const Array &p_args);
 	Error _msg_joy_add(const Array &p_args);
 	Error _msg_joy_del(const Array &p_args);
+	Error _msg_ds_state(const Array &p_args);
 
 public:
 	static Error parse_message(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured);

--- a/platform/macos/embedded_debugger.mm
+++ b/platform/macos/embedded_debugger.mm
@@ -76,21 +76,25 @@ void EmbeddedDebugger::_init_parse_message_handlers() {
 	parse_message_handlers["ime_update"] = &EmbeddedDebugger::_msg_ime_update;
 	parse_message_handlers["joy_add"] = &EmbeddedDebugger::_msg_joy_add;
 	parse_message_handlers["joy_del"] = &EmbeddedDebugger::_msg_joy_del;
+	parse_message_handlers["ds_state"] = &EmbeddedDebugger::_msg_ds_state;
 }
 
 Error EmbeddedDebugger::_msg_window_size(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, ERR_INVALID_PARAMETER, "Invalid number of arguments for 'window_size' message.");
 	Size2i size = p_args[0];
 	ds->window_set_size(size);
 	return OK;
 }
 
 Error EmbeddedDebugger::_msg_mouse_set_mode(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, ERR_INVALID_PARAMETER, "Invalid number of arguments for 'mouse_set_mode' message.");
 	DisplayServer::MouseMode mode = p_args[0];
 	ds->mouse_set_mode(mode);
 	return OK;
 }
 
 Error EmbeddedDebugger::_msg_event(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, ERR_INVALID_PARAMETER, "Invalid number of arguments for 'event' message.");
 	Input *input = Input::get_singleton();
 	if (!input) {
 		// Ignore if we've received an event before the process has initialized.
@@ -130,6 +134,7 @@ Error EmbeddedDebugger::_msg_event(const Array &p_args) {
 }
 
 Error EmbeddedDebugger::_msg_win_event(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, ERR_INVALID_PARAMETER, "Invalid number of arguments for 'win_event' message.");
 	DisplayServer::WindowEvent win_event = p_args[0];
 	ds->send_window_event(win_event, DisplayServer::MAIN_WINDOW_ID);
 	if (win_event == DisplayServer::WindowEvent::WINDOW_EVENT_MOUSE_EXIT) {
@@ -158,6 +163,15 @@ Error EmbeddedDebugger::_msg_joy_del(const Array &p_args) {
 	ERR_FAIL_COND_V_MSG(p_args.size() != 1, ERR_INVALID_PARAMETER, "Invalid number of arguments for 'joy_del' message.");
 	int idx = p_args[0];
 	ds->joy_del(idx);
+	return OK;
+}
+
+Error EmbeddedDebugger::_msg_ds_state(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, ERR_INVALID_PARAMETER, "Invalid number of arguments for 'ds_state' message.");
+	PackedByteArray data = p_args[0];
+	DisplayServerEmbeddedState state;
+	state.deserialize(data);
+	ds->set_state(state);
 	return OK;
 }
 

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -116,7 +116,9 @@ int main(int argc, char **argv) {
 
 	os->run();
 
+	int exit_code = os->get_exit_code();
+
 	memdelete(os);
 
-	return os->get_exit_code();
+	return exit_code;
 }


### PR DESCRIPTION
Fixes in this PR:

- [x] The separate embedded process window can be dismissed by clicking the 🔴 close button.
- [x] Running Godot from a terminal will shutdown gracefully when it receives `SIGINT` 
- [x] When using Metal in Truck Town (Forward+/Mobile), the sky takes the background color of the game window
- [x] Return error if `--embedded` is specified on unsupported platforms 
- [x] Fix display scaling noted in https://github.com/godotengine/godot/pull/106134#issuecomment-2860466013