### PR TITLE
mbedTLS: Fix concurrency issues with TLS

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -109,6 +109,13 @@ ResourceUID::ID ResourceUID::text_to_id(const String &p_text) const {
 }
 
 ResourceUID::ID ResourceUID::create_id() {
+	// mbedTLS may not be fully initialized when the ResourceUID is created, so we
+	// need to lazily instantiate the random number generator.
+	if (crypto == nullptr) {
+		crypto = memnew(CryptoCore::RandomGenerator);
+		((CryptoCore::RandomGenerator *)crypto)->init();
+	}
+
 	while (true) {
 		ID id = INVALID_ID;
 		MutexLock lock(mutex);
@@ -363,9 +370,9 @@ ResourceUID *ResourceUID::singleton = nullptr;
 ResourceUID::ResourceUID() {
 	ERR_FAIL_COND(singleton != nullptr);
 	singleton = this;
-	crypto = memnew(CryptoCore::RandomGenerator);
-	((CryptoCore::RandomGenerator *)crypto)->init();
 }
 ResourceUID::~ResourceUID() {
-	memdelete((CryptoCore::RandomGenerator *)crypto);
+	if (crypto != nullptr) {
+		memdelete((CryptoCore::RandomGenerator *)crypto);
+	}
 }

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -634,8 +634,8 @@ File extracted from upstream release tarball:
 - The `LICENSE` file (edited to keep only the Apache 2.0 variant)
 - Added 2 files `godot_core_mbedtls_platform.c` and `godot_core_mbedtls_config.h`
   providing configuration for light bundling with core
-- Added the file `godot_module_mbedtls_config.h` to customize the build
-  configuration when bundling the full library
+- Added 2 files `godot_module_mbedtls_config.h` and `threading_alt.h`
+  to customize the build configuration when bundling the full library
 
 Patches:
 

--- a/thirdparty/mbedtls/include/godot_module_mbedtls_config.h
+++ b/thirdparty/mbedtls/include/godot_module_mbedtls_config.h
@@ -49,6 +49,13 @@
 #undef MBEDTLS_DES_C
 #undef MBEDTLS_DHM_C
 
+#ifdef THREADS_ENABLED
+// In mbedTLS 3, the PSA subsystem has an implicit shared context, MBEDTLS_THREADING_C is required to make it thread safe.
+#define MBEDTLS_THREADING_C
+#define MBEDTLS_THREADING_ALT
+#define GODOT_MBEDTLS_THREADING_ALT
+#endif
+
 #if !(defined(__linux__) && defined(__aarch64__))
 // ARMv8 hardware AES operations. Detection only possible on linux.
 // May technically be supported on some ARM32 arches but doesn't seem

--- a/thirdparty/mbedtls/include/threading_alt.h
+++ b/thirdparty/mbedtls/include/threading_alt.h
@@ -1,0 +1,3 @@
+typedef struct {
+	void *mutex;
+} mbedtls_threading_mutex_t;


### PR DESCRIPTION
When we first integrated mbedTLS, we decided not to enable MBEDTLS_THREADING_C (which adds mutex locking to calls modifying the state), and instead to simply create separate contexts ("states") for each connection.

This worked fine until recently.
Sadly, mbedTLS 3 added a global state for the new PSA crypto functionalities (which are required to support TLSv1.3), and this change was originally [not properly reported in the docs](https://github.com/Mbed-TLS/mbedtls/issues/10103#issuecomment-2771869231).
This results in TLSv1.3 connections accessing and modifying the global state concurrently when running in threads.

This commit enables MBEDTLS_THREADING_C, and MBEDTLS_THREADING_C_ALT to provide a generic Godot implementation using the engine Mutex class.

Fixes #104820