### PR TITLE
Fix for debugging typed dictionaries

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1858,9 +1858,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 				if (buf) {
 					buf += len;
 				}
-				const Variant *value = dict.getptr(kv.key);
-				ERR_FAIL_NULL_V(value, ERR_BUG);
-				err = encode_variant(*value, buf, len, p_full_objects, p_depth + 1);
+				err = encode_variant(kv.value, buf, len, p_full_objects, p_depth + 1);
 				ERR_FAIL_COND_V(err, err);
 				ERR_FAIL_COND_V(len % 4, ERR_BUG);
 				r_len += len;

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -1387,7 +1387,7 @@ void EditorPropertyDictionary::update_property() {
 
 			Variant::Type value_type;
 
-			if (dict.is_typed_value() && slot.prop_key) {
+			if (dict.is_typed_value() && value_subtype != Variant::NIL && slot.prop_key) {
 				value_type = value_subtype;
 			} else {
 				value_type = value.get_type();


### PR DESCRIPTION
FIXES: #105917 fixes #105374 fixes #105441 

There were 2 problems.

First was the problem causing error logs as listed in above issues. This was caused by the serialiser attempting to validate the keys and values during the call to `getptr`. This is solved by simply using the given value from the ConstIterator.

Second was that values were appearing as `<null>` in the editor. This was caused by code optimised for showing editable properties, and not those streaming live from the debugger. Confirming that the configured value was anything other than `Variant::NIL` before using it solves the issue.