### PR TITLE
Remove unused `trigger_live_script_reload_all()`

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1107,14 +1107,6 @@ void ScriptEditor::trigger_live_script_reload(const String &p_script_path) {
 	}
 }
 
-void ScriptEditor::trigger_live_script_reload_all() {
-	if (!pending_auto_reload && auto_reload_running_scripts) {
-		call_deferred(SNAME("_live_auto_reload_running_scripts"));
-		pending_auto_reload = true;
-		reload_all_scripts = true;
-	}
-}
-
 void ScriptEditor::_live_auto_reload_running_scripts() {
 	pending_auto_reload = false;
 	if (reload_all_scripts) {

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -595,7 +595,6 @@ public:
 	void update_docs_from_script(const Ref<Script> &p_script);
 
 	void trigger_live_script_reload(const String &p_script_path);
-	void trigger_live_script_reload_all();
 
 	bool can_take_away_focus() const;
 


### PR DESCRIPTION
Added in #86676, but never used.

EDIT:
I realized there is more unused related code. The debugger has method for reloading all scripts, but not sure if there is a way to use it.

EDIT2:
#86676 didn't actually add this method, it renamed another method to this method. It's unused after that PR though.