### PR TITLE
C#: Use `stackalloc` to create the pivot arrays in `Projection.Inverse`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -674,8 +674,8 @@ namespace Godot
         {
             Projection proj = this;
             int i, j, k;
-            int[] pvt_i = new int[4];
-            int[] pvt_j = new int[4]; /* Locations of pivot matrix */
+            Span<int> pvt_i = stackalloc int[4];
+            Span<int> pvt_j = stackalloc int[4]; /* Locations of pivot matrix */
             real_t pvt_val; /* Value of current pivot element */
             real_t hold; /* Temporary storage */
             real_t determinant = 1.0f;


### PR DESCRIPTION
Found while randomly browsing through the codebase.

Replaces two instances of `new int[4]` with `stackalloc int[4]`. Avoids a small heap allocation.

As far as I know, the JITer only got the ability to do this by itself in .NET 10.

The two arrays are initialized in the first for-loop, so there's no danger of reading uninitialized data from them.