### PR TITLE
Fix description of `EditorProperty`'s `draw_background` and `draw_label`

### DIFF
--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -110,10 +110,10 @@
 			Used by the inspector, set to [code]true[/code] when the property can be deleted by the user.
 		</member>
 		<member name="draw_background" type="bool" setter="set_draw_background" getter="is_draw_background" default="true">
-			Used by the inspector, set to [code]true[/code] when the property label is drawn.
+			Used by the inspector, set to [code]true[/code] when the property background is drawn.
 		</member>
 		<member name="draw_label" type="bool" setter="set_draw_label" getter="is_draw_label" default="true">
-			Used by the inspector, set to [code]true[/code] when the property background is drawn.
+			Used by the inspector, set to [code]true[/code] when the property label is drawn.
 		</member>
 		<member name="draw_warning" type="bool" setter="set_draw_warning" getter="is_draw_warning" default="false">
 			Used by the inspector, set to [code]true[/code] when the property is drawn with the editor theme's warning color. This is used for editable children's properties.


### PR DESCRIPTION
Seems like the description of `EditorProperty.draw_background` and `EditorProperty.draw_label` are swapped. The first one refers to showing a label and the second one refers to showing a background.