### PR TITLE
Modify button label to ok on create dialog

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -58,7 +58,7 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 
 	if (p_replace_mode) {
 		set_title(vformat(TTR("Change Type of \"%s\""), p_current_name));
-		set_ok_button_text(TTR("Change"));
+		set_ok_button_text(TTR("OK"));
 	} else {
 		set_title(vformat(TTR("Create New %s"), base_type));
 		set_ok_button_text(TTR("Create"));


### PR DESCRIPTION
Correction on closed PR #106154
Related to : https://github.com/godotengine/godot/issues/106127

Modify 'Change' button label name to 'OK' in popup create dialog window in all cases.
This is to avoid adding complexity or confusion.

Before:
![image](https://github.com/user-attachments/assets/fd3538dd-d206-4d68-93a3-ada70d4dec29)

After:
![image](https://github.com/user-attachments/assets/e31b443f-8bc5-4552-97a3-9540cd9df705)
