### PR TITLE
Remove `Don't save` button from "running project" confirmation modal

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3115,6 +3115,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 					unsaved_message = _get_unsaved_scene_dialog_text(scene_filename, started_timestamp);
 					confirmation->set_text(unsaved_message + "\n\n" + TTR("Save before reloading the scene?"));
 					confirmation->popup_centered();
+					confirmation_button->show();
 					confirmation_button->grab_focus();
 					break;
 				} else {
@@ -3204,6 +3205,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 					}
 					confirmation->reset_size();
 					confirmation->popup_centered();
+					confirmation_button->hide();
 					break;
 				}
 


### PR DESCRIPTION
This happens when you run the project and try to close the editor.

System info
> Godot [v4.5.dev](https://v4.5.dev/) (ee2314da9) - macOS Sequoia (15.4.1) - Multi-window, 1 monitor - Metal (Forward+) - integrated Apple M1 Max (Apple7) - Apple M1 Max (10 threads)

A fresh build of the editor from the main branch.


The prompt was added in this PR https://github.com/godotengine/godot/pull/95392 and was using `confirmation` which had that button added by default.

Before:

<img src="https://github.com/user-attachments/assets/82bf9fe8-6a1a-4574-9dcd-5b6a7dcf0367" width="512" />

After:

<img src="https://github.com/user-attachments/assets/ce5dd630-741e-4d20-ad0c-1918cb2a6f56" width="512" />
