### PR TITLE
Fix some extensions missing in resource load dialog

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -320,6 +320,9 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			List<String> extensions;
 			for (int i = 0; i < base_type.get_slice_count(","); i++) {
 				String base = base_type.get_slicec(',', i);
+				if (base == "Resource") {
+					base = "";
+				}
 				ResourceLoader::get_recognized_extensions_for_type(base, &extensions);
 				if (ScriptServer::is_global_class(base)) {
 					ResourceLoader::get_recognized_extensions_for_type(ScriptServer::get_global_class_native_base(base), &extensions);


### PR DESCRIPTION
Fixes #102948

When "Resource" is passed to `ResourceLoader::get_recognized_extensions_for_type()`, most `ResourceFormatLoader`s think that they can't load that type of resource, and therefore won't return the extensions they support. Only generic format loaders like `ResourceFormatLoaderBinary` and `ResourceFormatLoaderText` are able to load any resource.

Therefore, the missing files are not limited to .ogv files mentioned in the original issue, extensions like .json and .po are also nonexistent.

In this case, since `Resource` is the base class of all resources, we should set the parameter to an empty string, skipping the type check.