### PR TITLE
SceneTree: use `reserve` in a few cases

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -373,6 +373,7 @@ void SceneTree::call_group_flagsp(uint32_t p_call_flags, const StringName &p_gro
 			}
 
 			Vector<Variant> args;
+			args.reserve(p_argcount);
 			for (int i = 0; i < p_argcount; i++) {
 				args.push_back(*p_args[i]);
 			}
@@ -1075,11 +1076,13 @@ Ref<ArrayMesh> SceneTree::get_debug_contact_mesh() {
 	/* clang-format on */
 
 	Vector<int> indices;
+	indices.reserve(8 * 3);
 	for (int i = 0; i < 8 * 3; i++) {
 		indices.push_back(diamond_faces[i]);
 	}
 
 	Vector<Vector3> vertices;
+	vertices.reserve(6);
 	for (int i = 0; i < 6; i++) {
 		vertices.push_back(diamond[i] * 0.1);
 	}
@@ -1270,6 +1273,7 @@ void SceneTree::_process(bool p_physics) {
 
 				if (using_threads) {
 					local_process_group_cache.clear();
+					local_process_group_cache.reserve(i - from);
 				}
 				for (uint32_t j = from; j < i; j++) {
 					if (process_groups[j]->last_pass == process_last_pass) {


### PR DESCRIPTION
Found a few Vectors in `scene_tree.cpp` that may benefit from ~~resize + assign~~ `reserve()`.

If this results in any performance gain, it should be situational and minimal.