### PR TITLE
Add `FittingContainer` for responsive views

### DIFF
--- a/scene/gui/fitting_container.cpp
+++ b/scene/gui/fitting_container.cpp
@@ -1,0 +1,113 @@
+/**************************************************************************/
+/*  fitting_container.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "fitting_container.h"
+
+#include "core/object/object.h"
+#include "scene/gui/container.h"
+
+void FittingContainer::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_SORT_CHILDREN: {
+			_update_active_control();
+		} break;
+	}
+}
+
+Size2 FittingContainer::get_minimum_size() const {
+	return Size2();
+}
+
+Control *FittingContainer::get_active_control() const {
+	return _active_control;
+}
+
+void FittingContainer::_update_active_control() {
+	Size2 size = get_size();
+
+	_active_control = nullptr;
+	Control *last_control = nullptr;
+	for (int i = 0; i < get_child_count(); i++) {
+		Control *current_control = as_sortable_control(get_child(i), SortableVisibilityMode::IGNORE);
+		if (!current_control) {
+			continue;
+		}
+		last_control = current_control;
+
+		// If axis is set to NONE, we actually activate the first control.
+		if (_axis == FITTING_AXIS_NONE) {
+			_active_control = last_control;
+			break;
+		}
+		if ((_axis == FITTING_AXIS_HORIZONTAL || _axis == FITTING_AXIS_BOTH) && current_control->get_combined_minimum_size().x > size.x) {
+			continue;
+		}
+		if ((_axis == FITTING_AXIS_VERTICAL || _axis == FITTING_AXIS_BOTH) && current_control->get_combined_minimum_size().y > size.y) {
+			continue;
+		}
+
+		_active_control = current_control;
+		break;
+	}
+
+	if (!_active_control && last_control) {
+		_active_control = last_control;
+	}
+	if (!_active_control) {
+		return;
+	}
+
+	for (int i = 0; i < get_child_count(); i++) {
+		Control *current_control = static_cast<Control *>(get_child(i));
+		if (!current_control) {
+			continue;
+		}
+
+		current_control->set_visible(current_control == _active_control);
+		current_control->set_position(Point2());
+	}
+}
+
+void FittingContainer::set_axis(FittingAxis p_axis) {
+	_axis = p_axis;
+}
+
+FittingContainer::FittingAxis FittingContainer::get_axis() const {
+	return _axis;
+}
+
+void FittingContainer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_axis", "axis"), &FittingContainer::set_axis);
+	ClassDB::bind_method(D_METHOD("get_axis"), &FittingContainer::get_axis);
+	ClassDB::bind_method(D_METHOD("get_active_control"), &FittingContainer::get_active_control);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "axis", PROPERTY_HINT_ENUM, "None,Horizontal,Vertical,Both"), "set_axis", "get_axis");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "active_control", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_active_control");
+}

--- a/scene/gui/fitting_container.h
+++ b/scene/gui/fitting_container.h
@@ -1,0 +1,67 @@
+/**************************************************************************/
+/*  fitting_container.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/gui/container.h"
+
+class FittingContainer : public Container {
+	GDCLASS(FittingContainer, Container);
+
+public:
+	enum FittingAxis {
+		FITTING_AXIS_NONE,
+		FITTING_AXIS_HORIZONTAL,
+		FITTING_AXIS_VERTICAL,
+		FITTING_AXIS_BOTH,
+	};
+
+private:
+	FittingAxis _axis = FITTING_AXIS_BOTH;
+
+	Control *_active_control = nullptr;
+	void _update_active_control();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	virtual Size2 get_minimum_size() const override;
+
+	void set_axis(FittingAxis p_axis);
+	FittingAxis get_axis() const;
+
+	Control *get_active_control() const;
+
+	FittingContainer() {}
+};
+
+VARIANT_ENUM_CAST(FittingContainer::FittingAxis);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -56,6 +56,7 @@
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/file_dialog.h"
+#include "scene/gui/fitting_container.h"
 #include "scene/gui/flow_container.h"
 #include "scene/gui/foldable_container.h"
 #include "scene/gui/graph_edit.h"
@@ -477,6 +478,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(CenterContainer);
 	GDREGISTER_CLASS(ScrollContainer);
 	GDREGISTER_CLASS(PanelContainer);
+	GDREGISTER_CLASS(FittingContainer);
 	GDREGISTER_CLASS(FlowContainer);
 	GDREGISTER_CLASS(HFlowContainer);
 	GDREGISTER_CLASS(VFlowContainer);


### PR DESCRIPTION
This adds the `FittingContainer`, the container node that tries to show the first children that fits, then hides the others. Perfect to create responsive views.

https://github.com/user-attachments/assets/7b1c9e56-ae43-4a7b-8f41-8b7de600b626

Closes godotengine/godot-proposals#12397