### PR TITLE
Add warning for `@export` applied to properties of non-exportable classes

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -564,6 +564,9 @@
 		<member name="debug/gdscript/warnings/onready_with_export" type="int" setter="" getter="" default="2">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when the [code]@onready[/code] annotation is used together with the [code]@export[/code] annotation, since it may not behave as expected.
 		</member>
+		<member name="debug/gdscript/warnings/export_not_node_or_resource" type="int" setter="" getter="" default="2">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a script that does not extend from either Node or Resource has the [code]@export[/code] annotation applied to any property, as they cannot be the target of an export in the first place.
+		</member>
 		<member name="debug/gdscript/warnings/property_used_as_function" type="int" setter="" getter="" default="1" deprecated="This warning is never produced. Instead, an error is generated if the expression type is known at compile time.">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when using a property as if it is a function.
 		</member>

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1065,6 +1065,9 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 				if (member.variable->exported && member.variable->onready) {
 					parser->push_warning(member.variable, GDScriptWarning::ONREADY_WITH_EXPORT);
 				}
+				if (member.variable->exported && !p_class->can_export()) {
+					parser->push_warning(member.variable, GDScriptWarning::EXPORT_NOT_NODE_OR_RESOURCE, p_class->base_type.to_string());
+				}
 				if (member.variable->initializer) {
 					// Check if it is call to get_node() on self (using shorthand $ or not), so we can check if @onready is needed.
 					// This could be improved by traversing the expression fully and checking the presence of get_node at any level.

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -795,6 +795,15 @@ public:
 			members_indices[name] = members.size();
 			members.push_back(Member(p_annotation_node));
 		}
+		bool can_export() const {
+			if (ClassDB::is_parent_class(base_type.native_type, SNAME("Resource"))) {
+				return true;
+			}
+			if (ClassDB::is_parent_class(base_type.native_type, SNAME("Node"))) {
+				return true;
+			}
+			return false;
+		}
 
 		ClassNode() {
 			type = CLASS;

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -162,6 +162,8 @@ String GDScriptWarning::get_message() const {
 			return vformat(R"*(The default value uses "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
 		case ONREADY_WITH_EXPORT:
 			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
+		case EXPORT_NOT_NODE_OR_RESOURCE:
+			return vformat(R"(Properties can only be exported on classes that extend Resource or Node, but the current class inherits "%s".)", symbols[0]);
 #ifndef DISABLE_DEPRECATED
 		// Never produced. These warnings migrated from 3.x by mistake.
 		case PROPERTY_USED_AS_FUNCTION: // There is already an error.
@@ -238,6 +240,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"NATIVE_METHOD_OVERRIDE",
 		"GET_NODE_DEFAULT_WITHOUT_ONREADY",
 		"ONREADY_WITH_EXPORT",
+		"EXPORT_NOT_NODE_OR_RESOURCE",
 #ifndef DISABLE_DEPRECATED
 		"PROPERTY_USED_AS_FUNCTION",
 		"CONSTANT_USED_AS_FUNCTION",

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -89,6 +89,7 @@ public:
 		NATIVE_METHOD_OVERRIDE, // The script method overrides a native one, this may not work as intended.
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
 		ONREADY_WITH_EXPORT, // The `@onready` annotation will set the value after `@export` which is likely not intended.
+		EXPORT_NOT_NODE_OR_RESOURCE, // `@export` annotations serve no function when applied to properties of a script that does not extend Node or Resource
 #ifndef DISABLE_DEPRECATED
 		PROPERTY_USED_AS_FUNCTION, // Function not found, but there's a property with the same name.
 		CONSTANT_USED_AS_FUNCTION, // Function not found, but there's a constant with the same name.
@@ -146,6 +147,7 @@ public:
 		ERROR, // NATIVE_METHOD_OVERRIDE // May not work as expected.
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.
 		ERROR, // ONREADY_WITH_EXPORT // May not work as expected.
+		WARN, // EXPORT_NOT_NODE_OR_RESOURCE
 #ifndef DISABLE_DEPRECATED
 		WARN, // PROPERTY_USED_AS_FUNCTION
 		WARN, // CONSTANT_USED_AS_FUNCTION

--- a/modules/gdscript/tests/scripts/analyzer/features/annotation_constant_expression_parameters.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/annotation_constant_expression_parameters.gd
@@ -1,3 +1,5 @@
+extends Resource
+
 const BEFORE = 1
 
 @export_range(-10, 10) var a = 0

--- a/modules/gdscript/tests/scripts/analyzer/features/export_enum_as_dictionary.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/export_enum_as_dictionary.gd
@@ -1,4 +1,5 @@
 class_name TestExportEnumAsDictionary
+extends Resource
 
 enum MyEnum {A, B, C}
 

--- a/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_warnings.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_warnings.gd
@@ -9,6 +9,10 @@ class A extends Node:
 	@warning_ignore("get_node_default_without_onready")
 	var get_node_default_without_onready = $Node
 
+class B extends RefCounted:
+	@warning_ignore("export_not_node_or_resource")
+	@export var prop: int = 0
+
 @warning_ignore("unused_private_class_variable")
 var _unused_private_class_variable
 

--- a/modules/gdscript/tests/scripts/analyzer/warnings/export_not_node_or_resource.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/export_not_node_or_resource.gd
@@ -1,0 +1,6 @@
+extends RefCounted
+
+@export var prop = ""
+
+func test():
+	print("warn")

--- a/modules/gdscript/tests/scripts/analyzer/warnings/export_not_node_or_resource.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/export_not_node_or_resource.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+~~ WARNING at line 3: (EXPORT_NOT_NODE_OR_RESOURCE) Properties can only be exported on classes that extend Resource or Node, but the current class inherits "RefCounted".
+warn

--- a/modules/gdscript/tests/scripts/parser/features/export_arrays.gd
+++ b/modules/gdscript/tests/scripts/parser/features/export_arrays.gd
@@ -1,3 +1,5 @@
+extends Resource
+
 @export_dir var test_dir: Array[String]
 @export_dir var test_dir_packed: PackedStringArray
 @export_file var test_file: Array[String]

--- a/modules/gdscript/tests/scripts/parser/features/export_enum.gd
+++ b/modules/gdscript/tests/scripts/parser/features/export_enum.gd
@@ -1,3 +1,5 @@
+extends Resource
+
 @export_enum("Red", "Green", "Blue") var test_untyped
 @export_enum("Red:10", "Green:20", "Blue:30") var test_with_values
 

--- a/modules/gdscript/tests/scripts/runtime/features/export_group_no_name_conflict_with_properties.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/export_group_no_name_conflict_with_properties.gd
@@ -1,3 +1,5 @@
+extends Resource
+
 # GH-73843
 @export_group("Resource")
 

--- a/modules/gdscript/tests/scripts/runtime/features/member_info.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/member_info.gd
@@ -1,4 +1,5 @@
 class_name TestMemberInfo
+extends Resource
 
 class MyClass:
 	pass


### PR DESCRIPTION
Pretty simple one.

Classes in GDScript that do not extend from Resource or from Node have no use for the `@export` annotation(s). If a user tried to apply the annotation to such an object, they are likely to try and apply it as an export for another script, and when they find they cannot they may also try to find a work around (that won't work).

Warning users as early as possible should help to educate users before they've put effort into writing a full script/class that will not be usable.