### PR TITLE
Fix wrongly assigned `emission_normal_texture`

### DIFF
--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -465,7 +465,7 @@ void GPUParticles2DEditorPlugin::_generate_emission_mask() {
 		undo_redo->add_undo_property(pmptr, "emission_color_texture", pm->get_emission_color_texture());
 	}
 
-	if (valid_normals.size()) {
+	if (!valid_normals.is_empty()) {
 		undo_redo->add_do_property(pmptr, "emission_shape", ParticleProcessMaterial::EMISSION_SHAPE_DIRECTED_POINTS);
 		undo_redo->add_undo_property(pmptr, "emission_shape", pm->get_emission_shape());
 		pm->set_emission_shape(ParticleProcessMaterial::EMISSION_SHAPE_DIRECTED_POINTS);
@@ -557,7 +557,7 @@ void CPUParticles2DEditorPlugin::_generate_emission_mask() {
 		undo_redo->add_undo_property(particles, "emission_colors", particles->get_emission_colors());
 	}
 
-	if (valid_normals.size()) {
+	if (!valid_normals.is_empty()) {
 		undo_redo->add_do_property(particles, "emission_shape", CPUParticles2D::EMISSION_SHAPE_DIRECTED_POINTS);
 		undo_redo->add_undo_property(particles, "emission_shape", particles->get_emission_shape());
 		PackedVector2Array norms;
@@ -933,7 +933,7 @@ void GPUParticles3DEditorPlugin::_generate_emission_points() {
 	undo_redo->create_action(TTR("Create Emission Points"));
 	ParticleProcessMaterial *matptr = mat.ptr();
 
-	if (normals.size() > 0) {
+	if (!normals.is_empty()) {
 		undo_redo->add_do_property(matptr, "emission_shape", ParticleProcessMaterial::EMISSION_SHAPE_DIRECTED_POINTS);
 		undo_redo->add_undo_property(matptr, "emission_shape", matptr->get_emission_shape());
 
@@ -953,7 +953,7 @@ void GPUParticles3DEditorPlugin::_generate_emission_points() {
 		}
 
 		Ref<Image> image2 = memnew(Image(w, h, false, Image::FORMAT_RGBF, point_img2));
-		undo_redo->add_do_property(matptr, "emission_normal_texture", image2);
+		undo_redo->add_do_property(matptr, "emission_normal_texture", ImageTexture::create_from_image(image2));
 		undo_redo->add_undo_property(matptr, "emission_normal_texture", matptr->get_emission_normal_texture());
 	} else {
 		undo_redo->add_do_property(matptr, "emission_shape", ParticleProcessMaterial::EMISSION_SHAPE_POINTS);


### PR DESCRIPTION
Fixes #106092

(I also included some unrelated `is_empty()` changes)