### PR TITLE
Simplify Project Settings window title

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -647,7 +647,7 @@ void ProjectSettingsEditor::_bind_methods() {
 
 ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	singleton = this;
-	set_title(TTR("Project Settings (project.godot)"));
+	set_title(TTR("Project Settings"));
 	set_clamp_to_embedder(true);
 
 	ps = ProjectSettings::get_singleton();


### PR DESCRIPTION
That condition (project.godot) is simply not used and is only reflected in the text, that is, it has no functionality and in the editor it is seen just as it is written in the text.