### PR TITLE
Doc: Add search keywords for `Vector2/3.limit_length` method

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -267,7 +267,7 @@
 				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight]. [param weight] is on the range of [code]0.0[/code] to [code]1.0[/code], representing the amount of interpolation.
 			</description>
 		</method>
-		<method name="limit_length" qualifiers="const" keywords="truncate">
+		<method name="limit_length" qualifiers="const" keywords="clamp, saturate, truncate">
 			<return type="Vector2" />
 			<param index="0" name="length" type="float" default="1.0" />
 			<description>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -235,7 +235,7 @@
 				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight]. [param weight] is on the range of [code]0.0[/code] to [code]1.0[/code], representing the amount of interpolation.
 			</description>
 		</method>
-		<method name="limit_length" qualifiers="const" keywords="truncate">
+		<method name="limit_length" qualifiers="const" keywords="clamp, saturate, truncate">
 			<return type="Vector3" />
 			<param index="0" name="length" type="float" default="1.0" />
 			<description>


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/12393

To elaborate: `saturate` seems to be used as a term in shader programming to clamp a value between 0 and 1.
Vector length can't be negative, and default value for the method is `1.0` so it works like a saturate operator by default.