### PR TITLE
Optimize `InputMap::get_actions`

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -39,7 +39,7 @@
 
 void InputMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_action", "action"), &InputMap::has_action);
-	ClassDB::bind_method(D_METHOD("get_actions"), &InputMap::_get_actions);
+	ClassDB::bind_method(D_METHOD("get_actions"), &InputMap::get_actions);
 	ClassDB::bind_method(D_METHOD("add_action", "action", "deadzone"), &InputMap::add_action, DEFVAL(DEFAULT_DEADZONE));
 	ClassDB::bind_method(D_METHOD("erase_action", "action"), &InputMap::erase_action);
 
@@ -61,16 +61,15 @@ void InputMap::_bind_methods() {
  * matching action name (if possible).
  */
 String InputMap::suggest_actions(const StringName &p_action) const {
-	List<StringName> actions = get_actions();
 	StringName closest_action;
 	float closest_similarity = 0.0;
 
 	// Find the most action with the most similar name.
-	for (const StringName &action : actions) {
-		const float similarity = String(action).similarity(p_action);
+	for (const KeyValue<StringName, Action> &kv : input_map) {
+		const float similarity = String(kv.key).similarity(p_action);
 
 		if (similarity > closest_similarity) {
-			closest_action = action;
+			closest_action = kv.key;
 			closest_similarity = similarity;
 		}
 	}
@@ -128,31 +127,18 @@ void InputMap::erase_action(const StringName &p_action) {
 	input_map.erase(p_action);
 }
 
-TypedArray<StringName> InputMap::_get_actions() {
+TypedArray<StringName> InputMap::get_actions() {
 	TypedArray<StringName> ret;
-	List<StringName> actions = get_actions();
-	if (actions.is_empty()) {
-		return ret;
-	}
 
-	for (const StringName &E : actions) {
-		ret.push_back(E);
+	ret.resize(input_map.size());
+
+	uint32_t i = 0;
+	for (const KeyValue<StringName, Action> &kv : input_map) {
+		ret[i] = kv.key;
+		i++;
 	}
 
 	return ret;
-}
-
-List<StringName> InputMap::get_actions() const {
-	List<StringName> actions = List<StringName>();
-	if (input_map.is_empty()) {
-		return actions;
-	}
-
-	for (const KeyValue<StringName, Action> &E : input_map) {
-		actions.push_back(E.key);
-	}
-
-	return actions;
 }
 
 List<Ref<InputEvent>>::Element *InputMap::_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool p_exact_match, bool *r_pressed, float *r_strength, float *r_raw_strength, int *r_event_index) const {

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "core/input/input_event.h"
-#include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "core/templates/hash_map.h"
 
@@ -67,7 +66,6 @@ private:
 	List<Ref<InputEvent>>::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool p_exact_match = false, bool *r_pressed = nullptr, float *r_strength = nullptr, float *r_raw_strength = nullptr, int *r_event_index = nullptr) const;
 
 	TypedArray<InputEvent> _action_get_events(const StringName &p_action);
-	TypedArray<StringName> _get_actions();
 
 protected:
 	static void _bind_methods();
@@ -81,7 +79,7 @@ public:
 	static _FORCE_INLINE_ InputMap *get_singleton() { return singleton; }
 
 	bool has_action(const StringName &p_action) const;
-	List<StringName> get_actions() const;
+	TypedArray<StringName> get_actions();
 	void add_action(const StringName &p_action, float p_deadzone = DEFAULT_DEADZONE);
 	void erase_action(const StringName &p_action);
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -2166,7 +2166,7 @@ void EditorSettings::get_argument_options(const StringName &p_function, int p_id
 				r_options->push_back(section.quote());
 			}
 		} else if (pf == "set_builtin_action_override") {
-			for (const StringName &action : InputMap::get_singleton()->get_actions()) {
+			for (const Variant &action : InputMap::get_singleton()->get_actions()) {
 				r_options->push_back(String(action).quote());
 			}
 		}


### PR DESCRIPTION
Change return type to `LocalVector` and add reserve logic.

Test script:
```GDScript
extends Node2D

func _process(delta: float) -> void:
	for i in range(1000):
		InputMap.get_actions()
```

Master: 75 fps (~13mspf)
This PR: 240 fps (~4mspf)


By the way I wonder if any interface can benifit from `PackedStringNameArray`(a.k.a. `Vector<StringName>`) to eliminate the copy from `List`/`LocalVector`/`Vector` to `Array` (not this one, it is fast enough)