### PR TITLE
FTI - Add `Node::get_children_fast()` for `SceneTreeFTI`

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1951,6 +1951,28 @@ Node *Node::get_child(int p_index, bool p_include_internal) const {
 	}
 }
 
+void Node::get_children_fast(LocalVector<Node *> &r_children, bool p_include_internal) const {
+	r_children.clear();
+	ERR_THREAD_GUARD
+	_update_children_cache();
+
+	if (p_include_internal) {
+		uint32_t num_children = data.children_cache.size();
+		r_children.resize(num_children);
+		for (uint32_t n = 0; n < num_children; n++) {
+			r_children[n] = data.children_cache[n];
+		}
+	} else {
+		uint32_t num_children = data.children_cache.size() - data.internal_children_front_count_cache - data.internal_children_back_count_cache;
+		r_children.resize(num_children);
+		uint32_t internal_count = data.internal_children_front_count_cache;
+
+		for (uint32_t n = 0; n < num_children; n++) {
+			r_children[n] = data.children_cache[n + internal_count];
+		}
+	}
+}
+
 TypedArray<Node> Node::get_children(bool p_include_internal) const {
 	ERR_THREAD_GUARD_V(TypedArray<Node>());
 	TypedArray<Node> arr;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -489,6 +489,7 @@ public:
 	int get_child_count(bool p_include_internal = true) const;
 	Node *get_child(int p_index, bool p_include_internal = true) const;
 	TypedArray<Node> get_children(bool p_include_internal = true) const;
+	void get_children_fast(LocalVector<Node *> &r_children, bool p_include_internal = true) const;
 	bool has_node(const NodePath &p_path) const;
 	Node *get_node(const NodePath &p_path) const;
 	Node *get_node_or_null(const NodePath &p_path) const;

--- a/scene/main/scene_tree_fti.cpp
+++ b/scene/main/scene_tree_fti.cpp
@@ -318,12 +318,17 @@ void SceneTreeFTI::_update_dirty_nodes(Node *p_node, uint32_t p_current_frame, f
 		return;
 	}
 
+	// Godot 4.x is very inefficient at getting children
+	// via get_child_count() and get_child(), so we use
+	// a fast version.
+	p_node->get_children_fast(data.temp_child_list);
+
 	// Not a Node3D.
 	// Could be e.g. a viewport or something
 	// so we should still recurse to children.
 	if (!s) {
-		for (int n = 0; n < p_node->get_child_count(); n++) {
-			_update_dirty_nodes(p_node->get_child(n), p_current_frame, p_interpolation_fraction, p_active, nullptr, p_depth + 1);
+		for (uint32_t n = 0; n < data.temp_child_list.size(); n++) {
+			_update_dirty_nodes(data.temp_child_list[n], p_current_frame, p_interpolation_fraction, p_active, nullptr, p_depth + 1);
 		}
 		return;
 	}
@@ -424,8 +429,8 @@ void SceneTreeFTI::_update_dirty_nodes(Node *p_node, uint32_t p_current_frame, f
 	s->_clear_dirty_bits(Node3D::DIRTY_GLOBAL_INTERPOLATED_TRANSFORM);
 
 	// Recurse to children.
-	for (int n = 0; n < p_node->get_child_count(); n++) {
-		_update_dirty_nodes(p_node->get_child(n), p_current_frame, p_interpolation_fraction, p_active, s->data.fti_global_xform_interp_set ? &s->data.global_transform_interpolated : &s->data.global_transform, p_depth + 1);
+	for (uint32_t n = 0; n < data.temp_child_list.size(); n++) {
+		_update_dirty_nodes(data.temp_child_list[n], p_current_frame, p_interpolation_fraction, p_active, s->data.fti_global_xform_interp_set ? &s->data.global_transform_interpolated : &s->data.global_transform, p_depth + 1);
 	}
 }
 

--- a/scene/main/scene_tree_fti.h
+++ b/scene/main/scene_tree_fti.h
@@ -86,6 +86,8 @@ class SceneTreeFTI {
 		Mutex mutex;
 
 		bool debug = false;
+
+		LocalVector<Node *> temp_child_list;
 	} data;
 
 	void _update_dirty_nodes(Node *p_node, uint32_t p_current_frame, float p_interpolation_fraction, bool p_active, const Transform3D *p_parent_global_xform = nullptr, int p_depth = 0);


### PR DESCRIPTION
Adds new allocation-free `Node` function for retrieving children from nodes efficiently using `LocalVector`.

Fixes worst aspect of #106185

## MRP
[ManyStaticColliders2.zip](https://github.com/user-attachments/files/20125722/ManyStaticColliders2.zip)

_(release build)_
Before this PR: 160fps
After this PR: 360fps
Physics Interpolation off: 360fps

Note that this PR likely doesn't solve _all_ performance issues in #106185, but seems to ameliorate a particular problem in 4.x. I had to double check the timings, because the difference is so pronounced.

## Discussion
#104269 introduced the new 3D FTI and uses a reference approach traversing the entire scene tree which is expected to not be super fast with large numbers of nodes in the tree. This is to be considerably optimized in #105728 (which only updates branches that have changed) and #105901.

However the reason for most of the slowdown in #106185 was unexpected - it was due to changes made for 4.x in #75627 which seem to make it (very?) inefficient to access children via `get_child_count()` and `get_child()`. This problem does not exist in 3.x.

Profiling shows this to be the case (this is debug, but should represent release to an extent):

![profile_traversal_master](https://github.com/user-attachments/assets/6eaa6ad6-6cb4-4461-a66b-236a6d00dd47)

Investigating suggested that `get_child_count()` and `get_child()` could be very inefficient, especially in debug with thread checks.

## Notes
* I don't use 4.x regularly, so was somewhat surprised by this inefficiency.
* Welcome any alternative naming.
* We should probably review existing code in 4.x that uses the `get_child_count()` / `get_child()` pattern and consider replacing.
* The existing `Node::get_children()` command should probably become a wrapper around `get_children_fast()` or use a similar approach, because it is likely also inefficient.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
