### PR TITLE
Force weights on custom editor fonts when variable

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -899,9 +899,11 @@
 		</member>
 		<member name="interface/editor/main_font" type="String" setter="" getter="">
 			The font to use for the editor interface. Must be a resource of a [Font] type such as a [code].ttf[/code] or [code].otf[/code] font file.
+			[b]Note:[/b] If the provided font is variable, a weight of 400 (normal) will be used.
 		</member>
 		<member name="interface/editor/main_font_bold" type="String" setter="" getter="">
 			The font to use for bold text in the editor interface. Must be a resource of a [Font] type such as a [code].ttf[/code] or [code].otf[/code] font file.
+			[b]Note:[/b] If the provided font is variable, a weight of 700 (bold) will be used.
 		</member>
 		<member name="interface/editor/main_font_size" type="int" setter="" getter="">
 			The size of the font in the editor interface.

--- a/editor/themes/editor_fonts.cpp
+++ b/editor/themes/editor_fonts.cpp
@@ -249,6 +249,9 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	}
 	default_fc->set_spacing(TextServer::SPACING_TOP, -EDSCALE);
 	default_fc->set_spacing(TextServer::SPACING_BOTTOM, -EDSCALE);
+	Dictionary default_fc_opentype;
+	default_fc_opentype["weight"] = 400;
+	default_fc->set_variation_opentype(default_fc_opentype);
 
 	Ref<FontVariation> default_fc_msdf;
 	default_fc_msdf.instantiate();
@@ -265,6 +268,7 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	}
 	default_fc_msdf->set_spacing(TextServer::SPACING_TOP, -EDSCALE);
 	default_fc_msdf->set_spacing(TextServer::SPACING_BOTTOM, -EDSCALE);
+	default_fc_msdf->set_variation_opentype(default_fc_opentype);
 
 	Ref<FontVariation> bold_fc;
 	bold_fc.instantiate();
@@ -289,6 +293,9 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	}
 	bold_fc->set_spacing(TextServer::SPACING_TOP, -EDSCALE);
 	bold_fc->set_spacing(TextServer::SPACING_BOTTOM, -EDSCALE);
+	Dictionary bold_fc_opentype;
+	bold_fc_opentype["weight"] = 700;
+	bold_fc->set_variation_opentype(bold_fc_opentype);
 
 	Ref<FontVariation> bold_fc_msdf;
 	bold_fc_msdf.instantiate();
@@ -313,6 +320,7 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	}
 	bold_fc_msdf->set_spacing(TextServer::SPACING_TOP, -EDSCALE);
 	bold_fc_msdf->set_spacing(TextServer::SPACING_BOTTOM, -EDSCALE);
+	bold_fc_msdf->set_variation_opentype(bold_fc_opentype);
 
 	Ref<FontVariation> mono_fc;
 	mono_fc.instantiate();


### PR DESCRIPTION
If you use a variable font in Main Font and Main Font Bold, there is no way to tell which weight to use through the editor settings.

This defaults Main Font weight to 400 and Main Font Bold weight to 700, the default weights for Regular and Bold. Should only affect variable fonts.

The ideal would be to add a setting to control both variations and features like it's done with Code Font, but I wanted to take the easy way and use the default values. Some kind of setting could be added later.

### Using Inter Variable on both Main Font and Main Font Bold
#### Before (everything defaults to Regular weight):
![image](https://github.com/user-attachments/assets/ad264752-d8ad-46d2-a0be-1f983d9701aa)

#### After (wording is slightly changed since I'm comparing it to 4.4.1 stable):
![image](https://github.com/user-attachments/assets/089514e7-94c6-4b9c-94a2-1fb60affe91a)
