### PR TITLE
`SceneTreeFTI` faster access to `Node` children

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -47,6 +47,8 @@ SAFE_NUMERIC_TYPE_PUN_GUARANTEES(uint32_t)
 class Node : public Object {
 	GDCLASS(Node, Object);
 
+	friend class SceneTreeFTI;
+
 protected:
 	// During group processing, these are thread-safe.
 	// Outside group processing, these avoid the cost of sync by working as plain primitive types.

--- a/scene/main/scene_tree_fti.cpp
+++ b/scene/main/scene_tree_fti.cpp
@@ -318,12 +318,19 @@ void SceneTreeFTI::_update_dirty_nodes(Node *p_node, uint32_t p_current_frame, f
 		return;
 	}
 
+	// Temporary direct access to children cache for speed.
+	// Maybe replaced later by a more generic fast access method
+	// for children.
+	p_node->_update_children_cache();
+	Span<Node *> children = p_node->data.children_cache.span();
+	uint32_t num_children = children.size();
+
 	// Not a Node3D.
 	// Could be e.g. a viewport or something
 	// so we should still recurse to children.
 	if (!s) {
-		for (int n = 0; n < p_node->get_child_count(); n++) {
-			_update_dirty_nodes(p_node->get_child(n), p_current_frame, p_interpolation_fraction, p_active, nullptr, p_depth + 1);
+		for (uint32_t n = 0; n < num_children; n++) {
+			_update_dirty_nodes(children.ptr()[n], p_current_frame, p_interpolation_fraction, p_active, nullptr, p_depth + 1);
 		}
 		return;
 	}
@@ -424,8 +431,8 @@ void SceneTreeFTI::_update_dirty_nodes(Node *p_node, uint32_t p_current_frame, f
 	s->_clear_dirty_bits(Node3D::DIRTY_GLOBAL_INTERPOLATED_TRANSFORM);
 
 	// Recurse to children.
-	for (int n = 0; n < p_node->get_child_count(); n++) {
-		_update_dirty_nodes(p_node->get_child(n), p_current_frame, p_interpolation_fraction, p_active, s->data.fti_global_xform_interp_set ? &s->data.global_transform_interpolated : &s->data.global_transform, p_depth + 1);
+	for (uint32_t n = 0; n < num_children; n++) {
+		_update_dirty_nodes(children.ptr()[n], p_current_frame, p_interpolation_fraction, p_active, s->data.fti_global_xform_interp_set ? &s->data.global_transform_interpolated : &s->data.global_transform, p_depth + 1);
 	}
 }
 


### PR DESCRIPTION
Adds methods to directly access cached children from outside `Node`:

`update_cached_children()`
`get_cached_children()`

Helps address #106185.
Supersedes #106214.

### MRP
[ManyStaticColliders2.zip](https://github.com/user-attachments/files/20130487/ManyStaticColliders2.zip)

Before this PR: 160fps
After this PR: 250fps
Physics interpolation off: 360fps

## Discussion
#104269 introduced the new 3D FTI and uses a reference approach traversing the entire scene tree which is expected to not be super fast with large numbers of nodes in the tree. This is to be considerably optimized in #105728 (which only updates branches that have changed) and #105901.

However the reason for a lot of the slowdown in #106185 was unexpected - it was due to changes made for 4.x in #75627 which seem to make it (very?) inefficient to access children via `get_child_count()` and `get_child()`. This problem does not exist in 3.x.

This is worth optimizing because although after #105728 this MRP will no longer be an issue for static nodes, the bottleneck will still exist when moving large numbers of nodes (e.g. via a parent).

Profiling makes clear what is happening (this is debug, but should represent release to an extent):

![profile_traversal_master](https://github.com/user-attachments/assets/6eaa6ad6-6cb4-4461-a66b-236a6d00dd47)

Investigating suggested that `get_child_count()` and `get_child()` could be very inefficient, especially in debug with thread checks.

## Notes
* Access via these new methods seems to benchmark at approx 16x faster than via `get_child()` and `get_child_count()`.
* `get_child()` is slow because it includes a thread guard, updates child cache every call, branches on internal and index, and includes bounds checking.
* `get_child_count()` is especially slow in for loops because it includes thread guard, update to child cache, branches on internal, and math.
* Alternatives including making `SceneTreeFTI` a `friend` and accessing the cached children directly.
* I tested allowing access to the `LocalVector` directly versus `Span`, and `Span` is optimized out and runs as fast as the former, so is probably a more generic solution than returning the `LocalVector`.
* If we roll out this or similar approach, we should look through existing bottleneck child iteration code to see whether it can be improved, perhaps using the same paradigm / API. In particular as a first step, storing `child_count` in a local variable is an easy win in for loops.

I don't have strong opinions as to which method would be best for access:
* `friend` discourages use in other areas of the engine (especially while evaluating whether this will work in the wild)
* `friend` is usually better to use sparingly, because it makes inter dependencies in the engine less clear
* `public` methods allow use from other parts of the engine
* It would alternatively be possible to have wrapper functions for `size` and `[]` instead of returning a `Span`

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
