### PR TITLE
Faster `Node::get_child_count()`

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1922,13 +1922,12 @@ void Node::_update_children_cache_impl() const {
 
 int Node::get_child_count(bool p_include_internal) const {
 	ERR_THREAD_GUARD_V(0);
-	_update_children_cache();
-
 	if (p_include_internal) {
-		return data.children_cache.size();
-	} else {
-		return data.children_cache.size() - data.internal_children_front_count_cache - data.internal_children_back_count_cache;
+		return data.children.size();
 	}
+
+	_update_children_cache();
+	return data.children_cache.size() - data.internal_children_front_count_cache - data.internal_children_back_count_cache;
 }
 
 Node *Node::get_child(int p_index, bool p_include_internal) const {


### PR DESCRIPTION
There is no need to update the children cache when including internal nodes in the count, we can grab the size directly from the `HashMap`.

## Notes
* This should be an easy win, as calling `get_child()` ensures the cache is updated anyway, and `get_child_count()` may be used in tight loops. _(The optimizer likely can't optimize this out, because in the case of zero children, `get_child()` will never be called.)_
* It is possible (but seemingly unlikely) that some logic would require this function to update the cache, but this should show quickly on testing.
* It is generally far better to store `get_child_count()` into a local variable prior to a loop (unless you have some race condition where the children are being altered from another thread), but this seems a free win, and effectively should optimize down to a single `getter` when `p_include_internal` is true.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
