### PR TITLE
Add dropdown to Movie Maker button in editor run bar to access settings

### DIFF
--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -41,6 +41,7 @@
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_quick_open_dialog.h"
 #include "editor/gui/editor_toaster.h"
+#include "editor/project_settings_editor.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
@@ -95,20 +96,18 @@ void EditorRunBar::_notification(int p_what) {
 
 			if (is_movie_maker_enabled()) {
 				main_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("LaunchPadMovieMode"), EditorStringName(EditorStyles)));
+				write_movie_button->set_theme_type_variation("RunBarButtonMovieMakerEnabled");
+
 				write_movie_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("MovieWriterButtonPressed"), EditorStringName(EditorStyles)));
 			} else {
 				main_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("LaunchPadNormal"), EditorStringName(EditorStyles)));
+				write_movie_button->set_theme_type_variation("RunBarButtonMovieMakerDisabled");
+
 				write_movie_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("MovieWriterButtonNormal"), EditorStringName(EditorStyles)));
 			}
 
 			write_movie_button->set_button_icon(get_editor_theme_icon(SNAME("MainMovieWrite")));
-			// This button behaves differently, so color it as such.
-			write_movie_button->begin_bulk_theme_override();
-			write_movie_button->add_theme_color_override("icon_normal_color", get_theme_color(SNAME("movie_writer_icon_normal"), EditorStringName(EditorStyles)));
-			write_movie_button->add_theme_color_override("icon_pressed_color", get_theme_color(SNAME("movie_writer_icon_pressed"), EditorStringName(EditorStyles)));
-			write_movie_button->add_theme_color_override("icon_hover_color", get_theme_color(SNAME("movie_writer_icon_hover"), EditorStringName(EditorStyles)));
-			write_movie_button->add_theme_color_override("icon_hover_pressed_color", get_theme_color(SNAME("movie_writer_icon_hover_pressed"), EditorStringName(EditorStyles)));
-			write_movie_button->end_bulk_theme_override();
+
 		} break;
 	}
 }
@@ -154,6 +153,23 @@ void EditorRunBar::_update_play_buttons() {
 		active_button->set_pressed(true);
 		active_button->set_button_icon(get_editor_theme_icon(SNAME("Reload")));
 		active_button->set_tooltip_text(TTR("Reload the played scene."));
+	}
+}
+
+void EditorRunBar::_movie_maker_item_pressed(int p_id) {
+	switch (p_id) {
+		case MOVIE_MAKER_TOGGLE: {
+			bool new_enabled = !is_movie_maker_enabled();
+			set_movie_maker_enabled(new_enabled);
+			write_movie_button->get_popup()->set_item_checked(0, new_enabled);
+			write_movie_button->set_pressed(new_enabled);
+			_write_movie_toggled(new_enabled);
+			break;
+		}
+		case MOVIE_MAKER_OPEN_SETTINGS:
+			ProjectSettingsEditor::get_singleton()->popup_project_settings(true);
+			ProjectSettingsEditor::get_singleton()->set_general_page("editor/movie_writer");
+			break;
 	}
 }
 
@@ -454,11 +470,12 @@ OS::ProcessID EditorRunBar::get_current_process() const {
 }
 
 void EditorRunBar::set_movie_maker_enabled(bool p_enabled) {
-	write_movie_button->set_pressed(p_enabled);
+	movie_maker_enabled = p_enabled;
+	write_movie_button->get_popup()->set_item_checked(0, p_enabled);
 }
 
 bool EditorRunBar::is_movie_maker_enabled() const {
-	return write_movie_button->is_pressed();
+	return movie_maker_enabled;
 }
 
 void EditorRunBar::update_profiler_autostart_indicator() {
@@ -655,13 +672,15 @@ EditorRunBar::EditorRunBar() {
 	write_movie_panel = memnew(PanelContainer);
 	main_hbox->add_child(write_movie_panel);
 
-	write_movie_button = memnew(Button);
+	write_movie_button = memnew(MenuButton);
+	PopupMenu *write_movie_popup = write_movie_button->get_popup();
+	write_movie_popup->add_check_item(TTRC("Enable Movie Maker Mode"), MOVIE_MAKER_TOGGLE);
+	write_movie_popup->add_item(TTRC("Open Movie Maker Settings..."), MOVIE_MAKER_OPEN_SETTINGS);
+	write_movie_popup->connect(SceneStringName(id_pressed), callable_mp(this, &EditorRunBar::_movie_maker_item_pressed));
+
 	write_movie_panel->add_child(write_movie_button);
-	write_movie_button->set_theme_type_variation("RunBarButton");
-	write_movie_button->set_toggle_mode(true);
-	write_movie_button->set_pressed(false);
+	write_movie_button->set_theme_type_variation("RunBarButtonMovieMakerDisabled");
 	write_movie_button->set_focus_mode(Control::FOCUS_NONE);
 	write_movie_button->set_tooltip_text(TTR("Enable Movie Maker mode.\nThe project will run at stable FPS and the visual and audio output will be recorded to a video file."));
 	write_movie_button->set_accessibility_name(TTRC("Enable Movie Maker Mode"));
-	write_movie_button->connect(SceneStringName(toggled), callable_mp(this, &EditorRunBar::_write_movie_toggled));
 }

--- a/editor/gui/editor_run_bar.h
+++ b/editor/gui/editor_run_bar.h
@@ -36,6 +36,7 @@
 
 class Button;
 class EditorRunNative;
+class MenuButton;
 class PanelContainer;
 class HBoxContainer;
 class AcceptDialog;
@@ -72,8 +73,13 @@ class EditorRunBar : public MarginContainer {
 	EditorRun editor_run;
 	EditorRunNative *run_native = nullptr;
 
+	enum MovieMakerMenuItem {
+		MOVIE_MAKER_TOGGLE,
+		MOVIE_MAKER_OPEN_SETTINGS,
+	};
 	PanelContainer *write_movie_panel = nullptr;
-	Button *write_movie_button = nullptr;
+	MenuButton *write_movie_button = nullptr;
+	bool movie_maker_enabled = false;
 
 	RunMode current_mode = RunMode::STOPPED;
 	String run_custom_filename;
@@ -82,6 +88,7 @@ class EditorRunBar : public MarginContainer {
 	void _reset_play_buttons();
 	void _update_play_buttons();
 
+	void _movie_maker_item_pressed(int p_id);
 	void _write_movie_toggled(bool p_enabled);
 	void _quick_run_selected(const String &p_file_path, int p_id = -1);
 

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1957,6 +1957,18 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		p_theme->set_stylebox("disabled", "RunBarButton", menu_transparent_style);
 		p_theme->set_stylebox(SceneStringName(pressed), "RunBarButton", menu_transparent_style);
 
+		p_theme->set_type_variation("RunBarButtonMovieMakerDisabled", "RunBarButton");
+		p_theme->set_color("icon_normal_color", "RunBarButtonMovieMakerDisabled", Color(1, 1, 1, 0.7));
+		p_theme->set_color("icon_pressed_color", "RunBarButtonMovieMakerDisabled", Color(1, 1, 1, 0.84));
+		p_theme->set_color("icon_hover_color", "RunBarButtonMovieMakerDisabled", Color(1, 1, 1, 0.9));
+		p_theme->set_color("icon_hover_pressed_color", "RunBarButtonMovieMakerDisabled", Color(1, 1, 1, 0.84));
+
+		p_theme->set_type_variation("RunBarButtonMovieMakerEnabled", "RunBarButton");
+		p_theme->set_color("icon_normal_color", "RunBarButtonMovieMakerEnabled", Color(0, 0, 0, 0.7));
+		p_theme->set_color("icon_pressed_color", "RunBarButtonMovieMakerEnabled", Color(0, 0, 0, 0.84));
+		p_theme->set_color("icon_hover_color", "RunBarButtonMovieMakerEnabled", Color(0, 0, 0, 0.9));
+		p_theme->set_color("icon_hover_pressed_color", "RunBarButtonMovieMakerEnabled", Color(0, 0, 0, 0.84));
+
 		// Bottom panel.
 		Ref<StyleBoxFlat> style_bottom_panel = p_config.content_panel_style->duplicate();
 		style_bottom_panel->set_corner_radius_all(p_config.corner_radius * EDSCALE);
@@ -2019,12 +2031,6 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		style_write_movie_button->set_content_margin(SIDE_RIGHT, 0);
 		style_write_movie_button->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
 		p_theme->set_stylebox("MovieWriterButtonPressed", EditorStringName(EditorStyles), style_write_movie_button);
-
-		// Movie writer button colors.
-		p_theme->set_color("movie_writer_icon_normal", EditorStringName(EditorStyles), Color(1, 1, 1, 0.7));
-		p_theme->set_color("movie_writer_icon_pressed", EditorStringName(EditorStyles), Color(0, 0, 0, 0.84));
-		p_theme->set_color("movie_writer_icon_hover", EditorStringName(EditorStyles), Color(1, 1, 1, 0.9));
-		p_theme->set_color("movie_writer_icon_hover_pressed", EditorStringName(EditorStyles), Color(0, 0, 0, 0.84));
 
 		// Profiler autostart indicator panel.
 		Ref<StyleBoxFlat> style_profiler_autostart = style_launch_pad->duplicate();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11541. Supersedes #104954.

This PR converts the Movie Maker button in the editor run bar from a simple toggle to a dropdown button (MenuButton) with a checkbox item to enable or disable Movie Maker mode, and another item to quickly open the Project Settings section for Movie Maker.

https://github.com/user-attachments/assets/52c69d00-4a28-4eeb-bdb7-6ce15a7f2008

The previous PR (#104954) contained a *bit* more functionality than this - it had an output filepath entry field in the dropdown itself - but I found it was finicky and didn't save much time. This is a safer implementation, in my opinion.
