### PR TITLE
Do not sleep when exiting in X11

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4467,7 +4467,9 @@ bool DisplayServerX11::_wait_for_events() const {
 
 void DisplayServerX11::_poll_events() {
 	while (!events_thread_done.is_set()) {
-		_wait_for_events();
+		if (Main::is_iterating()) {
+			_wait_for_events();
+		}
 
 		// Process events from the queue.
 		{


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This simply fixes a X11 display server when they unnecessary go to sleep when exiting the engine by using `Main::is_iterating()` (so we don't have to shake our cursor).

#### TODO
- [ ] Better method to handle this?