### PR TITLE
Refactor AssetLib pagination

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.h
+++ b/editor/asset_library/asset_library_editor_plugin.h
@@ -30,24 +30,26 @@
 
 #pragma once
 
-#include "editor/asset_library/editor_asset_installer.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/box_container.h"
-#include "scene/gui/grid_container.h"
-#include "scene/gui/line_edit.h"
-#include "scene/gui/link_button.h"
+#include "scene/gui/dialogs.h"
 #include "scene/gui/margin_container.h"
-#include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
-#include "scene/gui/progress_bar.h"
-#include "scene/gui/rich_text_label.h"
-#include "scene/gui/scroll_container.h"
-#include "scene/gui/texture_button.h"
-#include "scene/gui/texture_rect.h"
-#include "scene/main/http_request.h"
 
+class EditorAssetInstaller;
+class EditorAssetLibraryPagination;
 class EditorFileDialog;
+class GridContainer;
+class HTTPRequest;
+class LineEdit;
+class LinkButton;
 class MenuButton;
+class OptionButton;
+class ProgressBar;
+class RichTextLabel;
+class ScrollContainer;
+class TextureButton;
+class TextureRect;
 
 class EditorAssetLibraryItem : public PanelContainer {
 	GDCLASS(EditorAssetLibraryItem, PanelContainer);
@@ -208,9 +210,9 @@ class EditorAssetLibrary : public PanelContainer {
 
 	HBoxContainer *contents = nullptr;
 
-	HBoxContainer *asset_top_page = nullptr;
+	EditorAssetLibraryPagination *asset_top_page = nullptr;
 	GridContainer *asset_items = nullptr;
-	HBoxContainer *asset_bottom_page = nullptr;
+	EditorAssetLibraryPagination *asset_bottom_page = nullptr;
 
 	HTTPRequest *request = nullptr;
 
@@ -269,8 +271,6 @@ class EditorAssetLibrary : public PanelContainer {
 	void _image_request_completed(int p_status, int p_code, const PackedStringArray &headers, const PackedByteArray &p_data, int p_queue_id);
 	void _request_image(ObjectID p_for, int p_asset_id, String p_image_url, ImageType p_type, int p_image_index);
 	void _update_image_queue();
-
-	HBoxContainer *_make_pages(int p_page, int p_page_count, int p_page_len, int p_total_items, int p_current_items);
 
 	//
 	EditorAssetLibraryItemDescription *description = nullptr;

--- a/editor/asset_library/editor_asset_library_pagination.cpp
+++ b/editor/asset_library/editor_asset_library_pagination.cpp
@@ -1,0 +1,148 @@
+/**************************************************************************/
+/*  editor_asset_library_pagination.cpp                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_asset_library_pagination.h"
+
+#include "editor/themes/editor_scale.h"
+#include "scene/gui/button.h"
+#include "scene/gui/separator.h"
+
+static Button *_make_pagination_button(Node *p_parent) {
+	Button *btn = memnew(Button);
+	btn->set_auto_translate_mode(Button::AUTO_TRANSLATE_MODE_DISABLED);
+	btn->set_theme_type_variation("PanelBackgroundButton");
+	p_parent->add_child(btn);
+	return btn;
+}
+
+void EditorAssetLibraryPagination::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("page_pressed", PropertyInfo(Variant::INT, "page")));
+}
+
+void EditorAssetLibraryPagination::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			btn_first->set_text(TTR("First", "Pagination"));
+			btn_prev->set_text(TTR("Previous", "Pagination"));
+			btn_next->set_text(TTR("Next", "Pagination"));
+			btn_last->set_text(TTR("Last", "Pagination"));
+		} break;
+	}
+}
+
+void EditorAssetLibraryPagination::_go_first() {
+	ERR_FAIL_COND(page <= 0);
+	emit_signal(SNAME("page_pressed"), 0);
+}
+
+void EditorAssetLibraryPagination::_go_prev() {
+	ERR_FAIL_COND(page <= 0);
+	emit_signal(SNAME("page_pressed"), page - 1);
+}
+
+void EditorAssetLibraryPagination::_go_next() {
+	ERR_FAIL_COND(page + 1 >= page_count);
+	emit_signal(SNAME("page_pressed"), page + 1);
+}
+
+void EditorAssetLibraryPagination::_go_last() {
+	ERR_FAIL_COND(page + 1 >= page_count);
+	emit_signal(SNAME("page_pressed"), page_count - 1);
+}
+
+void EditorAssetLibraryPagination::_go_page(int p_page) {
+	ERR_FAIL_INDEX(p_page, page_count);
+	emit_signal(SNAME("page_pressed"), p_page);
+}
+
+void EditorAssetLibraryPagination::setup(int p_page, int p_page_count) {
+	page = p_page;
+	page_count = p_page_count;
+
+	while (page_numbers->get_child_count() > 0) {
+		memdelete(page_numbers->get_child(0));
+	}
+
+	if (page_count < 2) {
+		hide();
+		return;
+	}
+
+	const int from = MAX(0, page - (5 / EDSCALE));
+	const int to = MIN(from + (10 / EDSCALE), page_count);
+
+	const bool no_prev = page <= 0;
+	btn_first->set_disabled(no_prev);
+	btn_first->set_focus_mode(no_prev ? FOCUS_ACCESSIBILITY : FOCUS_ALL);
+	btn_prev->set_disabled(no_prev);
+	btn_prev->set_focus_mode(no_prev ? FOCUS_ACCESSIBILITY : FOCUS_ALL);
+
+	for (int i = from; i < to; i++) {
+		Button *current = _make_pagination_button(page_numbers);
+		current->set_custom_minimum_size(Size2(30 * EDSCALE, 0));
+		current->set_text(itos(i + 1));
+		current->set_disabled(i == page);
+		current->set_focus_mode(i == page ? FOCUS_ACCESSIBILITY : FOCUS_ALL);
+		current->connect(SceneStringName(pressed), callable_mp(this, &EditorAssetLibraryPagination::_go_page).bind(i));
+	}
+
+	const bool no_next = page + 1 >= page_count;
+	btn_next->set_disabled(no_next);
+	btn_next->set_focus_mode(no_next ? FOCUS_ACCESSIBILITY : FOCUS_ALL);
+	btn_last->set_disabled(no_next);
+	btn_last->set_focus_mode(no_next ? FOCUS_ACCESSIBILITY : FOCUS_ALL);
+
+	show();
+}
+
+EditorAssetLibraryPagination::EditorAssetLibraryPagination() {
+	set_alignment(ALIGNMENT_CENTER);
+	add_theme_constant_override("separation", 5 * EDSCALE);
+
+	btn_first = _make_pagination_button(this);
+	btn_first->connect(SceneStringName(pressed), callable_mp(this, &EditorAssetLibraryPagination::_go_first));
+	btn_prev = _make_pagination_button(this);
+	btn_prev->connect(SceneStringName(pressed), callable_mp(this, &EditorAssetLibraryPagination::_go_prev));
+
+	add_child(memnew(VSeparator));
+
+	page_numbers = memnew(HBoxContainer);
+	page_numbers->add_theme_constant_override("separation", 5 * EDSCALE);
+	add_child(page_numbers);
+
+	add_child(memnew(VSeparator));
+
+	btn_next = _make_pagination_button(this);
+	btn_next->connect(SceneStringName(pressed), callable_mp(this, &EditorAssetLibraryPagination::_go_next));
+	btn_last = _make_pagination_button(this);
+	btn_last->connect(SceneStringName(pressed), callable_mp(this, &EditorAssetLibraryPagination::_go_last));
+
+	hide();
+}

--- a/editor/asset_library/editor_asset_library_pagination.h
+++ b/editor/asset_library/editor_asset_library_pagination.h
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  editor_asset_library_pagination.h                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/gui/box_container.h"
+
+class Button;
+
+class EditorAssetLibraryPagination : public HBoxContainer {
+	GDCLASS(EditorAssetLibraryPagination, HBoxContainer);
+
+	Button *btn_first = nullptr;
+	Button *btn_prev = nullptr;
+	Control *page_numbers = nullptr;
+	Button *btn_next = nullptr;
+	Button *btn_last = nullptr;
+
+	int page = 0;
+	int page_count = 0;
+
+protected:
+	static void _bind_methods();
+	virtual void _notification(int p_what);
+
+private:
+	void _go_first();
+	void _go_prev();
+	void _go_next();
+	void _go_last();
+	void _go_page(int p_page);
+
+public:
+	void setup(int p_page, int p_page_count);
+
+	EditorAssetLibraryPagination();
+};


### PR DESCRIPTION
Part of #104574.

This PR refactored pagination related UI elements into a `EditorAssetLibraryPagination` class.

- The main reason is that button texts like First, Prev, Next, and Last need context when translating, so they have to be handled manually in `NOTIFICATION_TRANSLATION_CHANGED`. However, the AssetLib screen has two sets of pagination controls (top & bottom) and they are recreated when the search result is updated. It's too cumbersome to track them separately with 8 variables.
- Page buttons originally added space characters around the page number to prevent them from being too narrow. This PR changes that to setting a minimum rect width.
- Cleaned up header includes.