### PR TITLE
Fix reflection probe box projection stretching

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1916,7 +1916,8 @@ void fragment_shader(in SceneData scene_data) {
 		vec3 bent_normal = normal;
 #endif
 		vec3 ref_vec = normalize(reflect(-view, bent_normal));
-		ref_vec = mix(ref_vec, bent_normal, roughness * roughness);
+		// Interpolate between mirror and rough reflection by using linear_roughness * linear_roughness.
+		ref_vec = mix(ref_vec, bent_normal, roughness * roughness * roughness * roughness);
 
 		for (uint i = item_from; i < item_to; i++) {
 			uint mask = cluster_buffer.data[cluster_reflection_offset + i];

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1401,7 +1401,8 @@ void main() {
 		vec3 bent_normal = normal;
 #endif
 		vec3 ref_vec = normalize(reflect(-view, bent_normal));
-		ref_vec = mix(ref_vec, bent_normal, roughness * roughness);
+		// Interpolate between mirror and rough reflection by using linear_roughness * linear_roughness.
+		ref_vec = mix(ref_vec, bent_normal, roughness * roughness * roughness * roughness);
 
 		uvec2 reflection_indices = instances.data[draw_call.instance_index].reflection_probes;
 		for (uint i = 0; i < sc_reflection_probes(); i++) {


### PR DESCRIPTION
Removes a line that caused reflections to get squished when adjusting roughness when using reflection probes with box projection.
This line comes from  https://github.com/godotengine/godot/pull/62547.


I don't believe there is an issue post for this PR, but it is mentioned in https://github.com/godotengine/godot/pull/104585.

#### Master:

https://github.com/user-attachments/assets/d479be5e-2a6b-4933-b1af-518fefc46ad0

#### PR:

https://github.com/user-attachments/assets/9d4ffbce-c1be-4005-aab6-dacad92f1bb1

| Roughness | Master | PR |
| - | - | - |
| 0.0 | ![image](https://github.com/user-attachments/assets/899d05bf-b2d8-4e43-8527-3f934115d691) | ![image](https://github.com/user-attachments/assets/fa560b96-3263-4288-a6f2-ed75a4eac80b) |
| 0.25 | ![image](https://github.com/user-attachments/assets/b9c5b438-fa20-4b39-bc70-ebbcded430e8) | ![image](https://github.com/user-attachments/assets/5df885e6-b118-4fa4-beaf-5e24049df4cd) |
| 0.5 | ![image](https://github.com/user-attachments/assets/dff962d5-8dc3-4200-9700-5ff7883ebfae) | ![image](https://github.com/user-attachments/assets/e6da3ac7-7e88-43ee-aee4-e9ecbf9ceb90) |
| 0.75 | ![image](https://github.com/user-attachments/assets/1987ac55-cebd-4109-b4ae-af9435edee98) | ![image](https://github.com/user-attachments/assets/37fa51d7-0a47-437d-a774-46f868ef9135) |
| 1.0 | ![image](https://github.com/user-attachments/assets/ffb4718b-60c5-4385-9dbf-cf6691374ca4) | ![image](https://github.com/user-attachments/assets/64135574-bcf5-4a90-8816-8db32a668788) |