### PR TITLE
Fix 'Script class can only be set together with base class name' error with .NET typed collections upon rebuild

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -833,6 +833,25 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 		return;
 	}
 
+	// Add all script types to script bridge before reloading exports,
+	// so typed collections can be reconstructed correctly regardless of script load order.
+	for (Ref<CSharpScript> &scr : to_reload) {
+		if (!scr->get_path().is_empty() && !scr->get_path().begins_with("csharp://")) {
+			String script_path = scr->get_path();
+
+			bool valid = GDMonoCache::managed_callbacks.ScriptManagerBridge_AddScriptBridge(scr.ptr(), &script_path);
+
+			if (valid) {
+				scr->valid = true;
+
+				CSharpScript::update_script_class_info(scr);
+
+				// Ensure that the next call to CSharpScript::reload will refresh the exports
+				scr->reload_invalidated = true;
+			}
+		}
+	}
+
 	List<Ref<CSharpScript>> to_reload_state;
 
 	for (Ref<CSharpScript> &scr : to_reload) {


### PR DESCRIPTION
Should fix #103343.

This bug was made apparent by an edge case that was not known when #98545 was made.

The .NET script-type bimap is reset every time a project is rebuilt because the assembly needs to be reloaded. This means that all the scripts need to be reloaded, and the instances of those scripts in the scene need to be refreshed so their exports are correct again.

Typed collections that contain script objects require a reference to the script to be constructed. The bug arises when exports are reconstructed before a required script is reloaded, which makes the engine unable to determine the native base class of the script type. This scenario can be forced by introducing a cyclic dependency, as I've done in the MRP attached at the bottom, although this is not the only way to cause the bug to occur.

The fix here is to populate the .NET script-type bimap and update some type info in a separate pass prior to reloading the scripts properly, so the collections can be reconstructed correctly.

**MRP:** [DotnetScriptInitializationOrderBug.zip](https://github.com/user-attachments/files/20139710/DotnetScriptInitializationOrderBug.zip)
