### PR TITLE
Optimize `Theme::get_type_list`

### DIFF
--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -88,10 +88,10 @@ void ThemeItemImportTree::_update_items_tree() {
 
 	String filter_text = import_items_filter->get_text();
 
-	List<StringName> types;
+	LocalVector<StringName> types;
 	List<StringName> names;
 	List<StringName> filtered_names;
-	base_theme->get_type_list(&types);
+	base_theme->get_type_list(types);
 	types.sort_custom<StringName::AlphCompare>();
 
 	int color_amount = 0;
@@ -1247,8 +1247,8 @@ void ThemeItemEditorDialog::_dialog_about_to_show() {
 void ThemeItemEditorDialog::_update_edit_types() {
 	Ref<Theme> base_theme = ThemeDB::get_singleton()->get_default_theme();
 
-	List<StringName> theme_types;
-	edited_theme->get_type_list(&theme_types);
+	LocalVector<StringName> theme_types;
+	edited_theme->get_type_list(theme_types);
 	theme_types.sort_custom<StringName::AlphCompare>();
 
 	bool item_reselected = false;
@@ -1281,10 +1281,6 @@ void ThemeItemEditorDialog::_update_edit_types() {
 			list_root->get_child(0)->select(0);
 		}
 	}
-
-	List<StringName> default_types;
-	base_theme->get_type_list(&default_types);
-	default_types.sort_custom<StringName::AlphCompare>();
 
 	String selected_type = "";
 	TreeItem *selected_item = edit_type_list->get_selected();
@@ -1343,9 +1339,9 @@ void ThemeItemEditorDialog::_edited_type_edited() {
 		return;
 	}
 
-	List<StringName> theme_types;
-	edited_theme->get_type_list(&theme_types);
-	if (theme_types.find(new_type_name) != nullptr) {
+	LocalVector<StringName> theme_types;
+	edited_theme->get_type_list(theme_types);
+	if (theme_types.has(new_type_name)) {
 		edited_item->set_text(0, old_type_name);
 		return;
 	}
@@ -2201,10 +2197,10 @@ void ThemeTypeDialog::ok_pressed() {
 void ThemeTypeDialog::_update_add_type_options(const String &p_filter) {
 	add_type_options->clear();
 
-	List<StringName> names;
-	ThemeDB::get_singleton()->get_default_theme()->get_type_list(&names);
+	LocalVector<StringName> names;
+	ThemeDB::get_singleton()->get_default_theme()->get_type_list(names);
 	if (include_own_types) {
-		edited_theme->get_type_list(&names);
+		edited_theme->get_type_list(names);
 	}
 	names.sort_custom<StringName::AlphCompare>();
 
@@ -2405,8 +2401,8 @@ void ThemeTypeEditor::_update_type_list() {
 		}
 	}
 
-	List<StringName> theme_types;
-	edited_theme->get_type_list(&theme_types);
+	LocalVector<StringName> theme_types;
+	edited_theme->get_type_list(theme_types);
 	theme_types.sort_custom<StringName::AlphCompare>();
 
 	theme_type_list->clear();
@@ -2894,9 +2890,9 @@ void ThemeTypeEditor::_theme_type_rename_dialog_confirmed() {
 		return;
 	}
 
-	List<StringName> theme_types;
-	edited_theme->get_type_list(&theme_types);
-	if (theme_types.find(new_type_name) != nullptr) {
+	LocalVector<StringName> theme_types;
+	edited_theme->get_type_list(theme_types);
+	if (theme_types.has(new_type_name)) {
 		return;
 	}
 

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -1337,9 +1337,7 @@ void Theme::rename_type(const StringName &p_old_theme_type, const StringName &p_
 	_emit_theme_changed(true);
 }
 
-void Theme::get_type_list(List<StringName> *p_list) const {
-	ERR_FAIL_NULL(p_list);
-
+void Theme::get_type_list(LocalVector<StringName> &p_list) const {
 	// This Set guarantees uniqueness.
 	// Because each map can have the same type defined, but for this method
 	// we only want one occurrence of each type.
@@ -1381,7 +1379,7 @@ void Theme::get_type_list(List<StringName> *p_list) const {
 	}
 
 	for (const StringName &E : types) {
-		p_list->push_back(E);
+		p_list.push_back(E);
 	}
 }
 
@@ -1644,15 +1642,16 @@ Vector<String> Theme::_get_type_variation_list(const StringName &p_theme_type) c
 
 Vector<String> Theme::_get_type_list() const {
 	Vector<String> ilret;
-	List<StringName> il;
+	LocalVector<StringName> il;
 
-	get_type_list(&il);
+	get_type_list(il);
 	ilret.resize(il.size());
 
 	int i = 0;
 	String *w = ilret.ptrw();
-	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
-		w[i] = E->get();
+	for (const StringName &E : il) {
+		w[i] = E;
+		i++;
 	}
 	return ilret;
 }

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -224,7 +224,7 @@ public:
 	void add_type(const StringName &p_theme_type);
 	void remove_type(const StringName &p_theme_type);
 	void rename_type(const StringName &p_old_theme_type, const StringName &p_theme_type);
-	void get_type_list(List<StringName> *p_list) const;
+	void get_type_list(LocalVector<StringName> &p_list) const;
 	void get_type_dependencies(const StringName &p_base_type, const StringName &p_type_variant, Vector<StringName> &r_result);
 
 	void merge_with(const Ref<Theme> &p_other);


### PR DESCRIPTION
Change return type to `LocalVector`.

Test script:
```GDScript
extends Node2D

@onready var theme = ThemeDB.get_default_theme() # default theme has 62 types

func _process(delta: float) -> void:
	for i in range(1000):
		theme.get_type_list()
```

Master: 100fps (~10mspf)
This PR: 150fps (~6.5mspf)