### PR TITLE
Improve auto-translation of settings dialogs

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -85,7 +85,7 @@ String ActionMapEditor::_check_new_action_name(const String &p_name) {
 }
 
 void ActionMapEditor::_add_edit_text_changed(const String &p_name) {
-	String error = _check_new_action_name(p_name);
+	const String error = _check_new_action_name(p_name);
 	add_button->set_tooltip_text(error);
 	add_button->set_disabled(!error.is_empty());
 }
@@ -361,6 +361,15 @@ void ActionMapEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 
 void ActionMapEditor::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			if (!actions_cache.is_empty()) {
+				update_action_list();
+			}
+			if (!add_button->get_tooltip_text().is_empty()) {
+				_add_edit_text_changed(add_edit->get_text());
+			}
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			action_list_search->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 			add_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
@@ -455,10 +464,10 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 			bool events_eq = Shortcut::is_event_array_equal(action_info.action_initial["events"], action_info.action["events"]);
 			bool action_eq = deadzone_eq && events_eq;
 			action_item->set_meta("__action_initial", action_info.action_initial);
-			action_item->add_button(2, action_tree->get_editor_theme_icon(SNAME("ReloadSmall")), BUTTON_REVERT_ACTION, action_eq, action_eq ? TTR("Cannot Revert - Action is same as initial") : TTR("Revert Action"));
+			action_item->add_button(2, action_tree->get_editor_theme_icon(SNAME("ReloadSmall")), BUTTON_REVERT_ACTION, action_eq, action_eq ? TTRC("Cannot Revert - Action is same as initial") : TTRC("Revert Action"));
 		}
-		action_item->add_button(2, action_tree->get_editor_theme_icon(SNAME("Add")), BUTTON_ADD_EVENT, false, TTR("Add Event"));
-		action_item->add_button(2, action_tree->get_editor_theme_icon(SNAME("Remove")), BUTTON_REMOVE_ACTION, !action_info.editable, action_info.editable ? TTR("Remove Action") : TTR("Cannot Remove Action"));
+		action_item->add_button(2, action_tree->get_editor_theme_icon(SNAME("Add")), BUTTON_ADD_EVENT, false, TTRC("Add Event"));
+		action_item->add_button(2, action_tree->get_editor_theme_icon(SNAME("Remove")), BUTTON_REMOVE_ACTION, !action_info.editable, action_info.editable ? TTRC("Remove Action") : TTRC("Cannot Remove Action"));
 
 		action_item->set_custom_bg_color(0, action_tree->get_theme_color(SNAME("prop_subsection"), EditorStringName(Editor)));
 		action_item->set_custom_bg_color(1, action_tree->get_theme_color(SNAME("prop_subsection"), EditorStringName(Editor)));
@@ -506,8 +515,8 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 			}
 
 			// Third Column - Buttons
-			event_item->add_button(2, action_tree->get_editor_theme_icon(SNAME("Edit")), BUTTON_EDIT_EVENT, false, TTR("Edit Event"), TTR("Edit Event"));
-			event_item->add_button(2, action_tree->get_editor_theme_icon(SNAME("Remove")), BUTTON_REMOVE_EVENT, false, TTR("Remove Event"), TTR("Remove Event"));
+			event_item->add_button(2, action_tree->get_editor_theme_icon(SNAME("Edit")), BUTTON_EDIT_EVENT, false, TTRC("Edit Event"), TTRC("Edit Event"));
+			event_item->add_button(2, action_tree->get_editor_theme_icon(SNAME("Remove")), BUTTON_REMOVE_EVENT, false, TTRC("Remove Event"), TTRC("Remove Event"));
 			event_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 			event_item->set_button_color(2, 1, Color(1, 1, 1, 0.75));
 		}
@@ -547,7 +556,7 @@ ActionMapEditor::ActionMapEditor() {
 
 	action_list_search = memnew(LineEdit);
 	action_list_search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	action_list_search->set_placeholder(TTR("Filter by Name"));
+	action_list_search->set_placeholder(TTRC("Filter by Name"));
 	action_list_search->set_accessibility_name(TTRC("Filter by Name"));
 	action_list_search->set_clear_button_enabled(true);
 	action_list_search->connect(SceneStringName(text_changed), callable_mp(this, &ActionMapEditor::_search_term_updated));
@@ -563,8 +572,8 @@ ActionMapEditor::ActionMapEditor() {
 	top_hbox->add_child(action_list_search_by_event);
 
 	clear_all_search = memnew(Button);
-	clear_all_search->set_text(TTR("Clear All"));
-	clear_all_search->set_tooltip_text(TTR("Clear all search filters."));
+	clear_all_search->set_text(TTRC("Clear All"));
+	clear_all_search->set_tooltip_text(TTRC("Clear all search filters."));
 	clear_all_search->connect(SceneStringName(pressed), callable_mp(action_list_search_by_event, &EventListenerLineEdit::clear_event));
 	clear_all_search->connect(SceneStringName(pressed), callable_mp(action_list_search, &LineEdit::clear));
 	top_hbox->add_child(clear_all_search);
@@ -575,7 +584,7 @@ ActionMapEditor::ActionMapEditor() {
 
 	add_edit = memnew(LineEdit);
 	add_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	add_edit->set_placeholder(TTR("Add New Action"));
+	add_edit->set_placeholder(TTRC("Add New Action"));
 	add_edit->set_accessibility_name(TTRC("Add New Action"));
 	add_edit->set_clear_button_enabled(true);
 	add_edit->set_keep_editing_on_text_submit(true);
@@ -584,7 +593,7 @@ ActionMapEditor::ActionMapEditor() {
 	add_hbox->add_child(add_edit);
 
 	add_button = memnew(Button);
-	add_button->set_text(TTR("Add"));
+	add_button->set_text(TTRC("Add"));
 	add_button->connect(SceneStringName(pressed), callable_mp(this, &ActionMapEditor::_add_action_pressed));
 	add_hbox->add_child(add_button);
 	// Disable the button and set its tooltip.
@@ -593,7 +602,7 @@ ActionMapEditor::ActionMapEditor() {
 	add_hbox->add_child(memnew(VSeparator));
 
 	show_builtin_actions_checkbutton = memnew(CheckButton);
-	show_builtin_actions_checkbutton->set_text(TTR("Show Built-in Actions"));
+	show_builtin_actions_checkbutton->set_text(TTRC("Show Built-in Actions"));
 	show_builtin_actions_checkbutton->connect(SceneStringName(toggled), callable_mp(this, &ActionMapEditor::set_show_builtin_actions));
 	add_hbox->add_child(show_builtin_actions_checkbutton);
 
@@ -609,9 +618,9 @@ ActionMapEditor::ActionMapEditor() {
 	action_tree->set_columns(3);
 	action_tree->set_hide_root(true);
 	action_tree->set_column_titles_visible(true);
-	action_tree->set_column_title(0, TTR("Action"));
+	action_tree->set_column_title(0, TTRC("Action"));
 	action_tree->set_column_clip_content(0, true);
-	action_tree->set_column_title(1, TTR("Deadzone"));
+	action_tree->set_column_title(1, TTRC("Deadzone"));
 	action_tree->set_column_expand(1, false);
 	action_tree->set_column_custom_minimum_width(1, 80 * EDSCALE);
 	action_tree->set_column_expand(2, false);

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -57,6 +57,12 @@ void EditorAutoloadSettings::_notification(int p_what) {
 			browse_button->set_button_icon(get_editor_theme_icon(SNAME("Folder")));
 		} break;
 
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			if (!error_message->get_text().is_empty()) {
+				_autoload_text_changed(autoload_add_name->get_text());
+			}
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			browse_button->set_button_icon(get_editor_theme_icon(SNAME("Folder")));
 			add_autoload->set_button_icon(get_editor_theme_icon(SNAME("Add")));
@@ -529,7 +535,7 @@ void EditorAutoloadSettings::update_autoload() {
 
 		item->set_cell_mode(2, TreeItem::CELL_MODE_CHECK);
 		item->set_editable(2, true);
-		item->set_text(2, TTR("Enable"));
+		item->set_text(2, TTRC("Enable"));
 		item->set_checked(2, info.is_singleton);
 		item->add_button(3, get_editor_theme_icon(SNAME("Load")), BUTTON_OPEN);
 		item->add_button(3, get_editor_theme_icon(SNAME("MoveUp")), BUTTON_MOVE_UP);
@@ -888,6 +894,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	add_child(hbc);
 
 	error_message = memnew(Label);
+	error_message->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	error_message->set_focus_mode(FOCUS_ACCESSIBILITY);
 	error_message->hide();
 	error_message->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
@@ -895,7 +902,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	add_child(error_message);
 
 	Label *l = memnew(Label);
-	l->set_text(TTR("Path:"));
+	l->set_text(TTRC("Path:"));
 	hbc->add_child(l);
 
 	autoload_add_path = memnew(LineEdit);
@@ -903,7 +910,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	autoload_add_path->set_accessibility_name(TTRC("Autoload Path"));
 	autoload_add_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	autoload_add_path->set_clear_button_enabled(true);
-	autoload_add_path->set_placeholder(vformat(TTR("Set path or press \"%s\" to create a script."), TTR("Add")));
+	autoload_add_path->set_placeholder(TTRC("Set path or press \"Add\" to create a script."));
 	autoload_add_path->connect(SceneStringName(text_changed), callable_mp(this, &EditorAutoloadSettings::_autoload_path_text_changed));
 
 	browse_button = memnew(Button);
@@ -922,7 +929,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	file_dialog->connect("file_selected", callable_mp(this, &EditorAutoloadSettings::_autoload_file_callback));
 
 	l = memnew(Label);
-	l->set_text(TTR("Node Name:"));
+	l->set_text(TTRC("Node Name:"));
 	hbc->add_child(l);
 
 	autoload_add_name = memnew(LineEdit);
@@ -933,7 +940,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	hbc->add_child(autoload_add_name);
 
 	add_autoload = memnew(Button);
-	add_autoload->set_text(TTR("Add"));
+	add_autoload->set_text(TTRC("Add"));
 	add_autoload->connect(SceneStringName(pressed), callable_mp(this, &EditorAutoloadSettings::_autoload_add));
 	// The button will be enabled once a valid name is entered (either automatically or manually).
 	add_autoload->set_disabled(true);
@@ -950,16 +957,16 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	tree->set_columns(4);
 	tree->set_column_titles_visible(true);
 
-	tree->set_column_title(0, TTR("Name"));
+	tree->set_column_title(0, TTRC("Name"));
 	tree->set_column_expand(0, true);
 	tree->set_column_expand_ratio(0, 1);
 
-	tree->set_column_title(1, TTR("Path"));
+	tree->set_column_title(1, TTRC("Path"));
 	tree->set_column_expand(1, true);
 	tree->set_column_clip_content(1, true);
 	tree->set_column_expand_ratio(1, 2);
 
-	tree->set_column_title(2, TTR("Global Variable"));
+	tree->set_column_title(2, TTRC("Global Variable"));
 	tree->set_column_expand(2, false);
 
 	tree->set_column_expand(3, false);

--- a/editor/editor_locale_dialog.cpp
+++ b/editor/editor_locale_dialog.cpp
@@ -39,6 +39,18 @@
 #include "scene/gui/option_button.h"
 #include "scene/gui/tree.h"
 
+void EditorLocaleDialog::_notification(int p_what) {
+	if (p_what == NOTIFICATION_TRANSLATION_CHANGED) {
+		// TRANSLATORS: This is the label for a list of writing systems.
+		script_label1->set_text(TTR("Script:", "Locale"));
+		// TRANSLATORS: This refers to a writing system.
+		script_label2->set_text(TTR("Script", "Locale"));
+
+		script_list->set_accessibility_name(TTR("Script", "Locale"));
+		script_code->set_accessibility_name(TTR("Script", "Locale"));
+	}
+}
+
 void EditorLocaleDialog::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("locale_selected", PropertyInfo(Variant::STRING, "locale")));
 }
@@ -295,7 +307,7 @@ void EditorLocaleDialog::_update_tree() {
 
 	if (!is_edit_mode) {
 		TreeItem *t = script_list->create_item(s_root);
-		t->set_text(0, TTR("[Default]"));
+		t->set_text(0, TTRC("[Default]"));
 		t->set_metadata(0, "");
 	}
 
@@ -323,7 +335,7 @@ void EditorLocaleDialog::_update_tree() {
 
 	if (!is_edit_mode) {
 		TreeItem *t = cnt_list->create_item(c_root);
-		t->set_text(0, TTR("[Default]"));
+		t->set_text(0, TTRC("[Default]"));
 		t->set_metadata(0, "");
 	}
 
@@ -389,7 +401,7 @@ void EditorLocaleDialog::popup_locale_dialog() {
 }
 
 EditorLocaleDialog::EditorLocaleDialog() {
-	set_title(TTR("Select a Locale"));
+	set_title(TTRC("Select a Locale"));
 
 	VBoxContainer *vb = memnew(VBoxContainer);
 	{
@@ -397,16 +409,16 @@ EditorLocaleDialog::EditorLocaleDialog() {
 		{
 			filter_mode = memnew(OptionButton);
 			filter_mode->set_accessibility_name(TTRC("Locale Filter"));
-			filter_mode->add_item(TTR("Show All Locales"), SHOW_ALL_LOCALES);
+			filter_mode->add_item(TTRC("Show All Locales"), SHOW_ALL_LOCALES);
 			filter_mode->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-			filter_mode->add_item(TTR("Show Selected Locales Only"), SHOW_ONLY_SELECTED_LOCALES);
+			filter_mode->add_item(TTRC("Show Selected Locales Only"), SHOW_ONLY_SELECTED_LOCALES);
 			filter_mode->select(0);
 			filter_mode->connect(SceneStringName(item_selected), callable_mp(this, &EditorLocaleDialog::_filter_mode_changed));
 			hb_filter->add_child(filter_mode);
 		}
 		{
 			edit_filters = memnew(CheckButton);
-			edit_filters->set_text(TTR("Edit Filters"));
+			edit_filters->set_text(TTRC("Edit Filters"));
 			edit_filters->set_toggle_mode(true);
 			edit_filters->set_pressed(false);
 			edit_filters->connect(SceneStringName(toggled), callable_mp(this, &EditorLocaleDialog::_edit_filters));
@@ -414,7 +426,7 @@ EditorLocaleDialog::EditorLocaleDialog() {
 		}
 		{
 			advanced = memnew(CheckButton);
-			advanced->set_text(TTR("Advanced"));
+			advanced->set_text(TTRC("Advanced"));
 			advanced->set_toggle_mode(true);
 			advanced->set_pressed(false);
 			advanced->connect(SceneStringName(toggled), callable_mp(this, &EditorLocaleDialog::_toggle_advanced));
@@ -430,7 +442,7 @@ EditorLocaleDialog::EditorLocaleDialog() {
 			vb_lang_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 			{
 				Label *lang_lbl = memnew(Label);
-				lang_lbl->set_text(TTR("Language:"));
+				lang_lbl->set_text(TTRC("Language:"));
 				vb_lang_list->add_child(lang_lbl);
 			}
 			{
@@ -449,14 +461,12 @@ EditorLocaleDialog::EditorLocaleDialog() {
 			vb_script_list = memnew(VBoxContainer);
 			vb_script_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 			{
-				Label *script_lbl = memnew(Label);
-				// TRANSLATORS: This is the label for a list of writing systems.
-				script_lbl->set_text(TTR("Script:", "Locale"));
-				vb_script_list->add_child(script_lbl);
+				script_label1 = memnew(Label);
+				script_label1->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+				vb_script_list->add_child(script_label1);
 			}
 			{
 				script_list = memnew(Tree);
-				script_list->set_accessibility_name(TTR("Script", "Locale"));
 				script_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 				script_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 				script_list->connect("cell_selected", callable_mp(this, &EditorLocaleDialog::_item_selected));
@@ -471,7 +481,7 @@ EditorLocaleDialog::EditorLocaleDialog() {
 			vb_cnt_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 			{
 				Label *cnt_lbl = memnew(Label);
-				cnt_lbl->set_text(TTR("Country:"));
+				cnt_lbl->set_text(TTRC("Country:"));
 				vb_cnt_list->add_child(cnt_lbl);
 			}
 			{
@@ -497,7 +507,7 @@ EditorLocaleDialog::EditorLocaleDialog() {
 				vb_language->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 				{
 					Label *language_lbl = memnew(Label);
-					language_lbl->set_text(TTR("Language"));
+					language_lbl->set_text(TTRC("Language"));
 					vb_language->add_child(language_lbl);
 				}
 				{
@@ -512,15 +522,13 @@ EditorLocaleDialog::EditorLocaleDialog() {
 				VBoxContainer *vb_script = memnew(VBoxContainer);
 				vb_script->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 				{
-					Label *script_lbl = memnew(Label);
-					// TRANSLATORS: This refers to a writing system.
-					script_lbl->set_text(TTR("Script", "Locale"));
-					vb_script->add_child(script_lbl);
+					script_label2 = memnew(Label);
+					script_label2->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+					vb_script->add_child(script_label2);
 				}
 				{
 					script_code = memnew(LineEdit);
 					script_code->set_max_length(4);
-					script_code->set_accessibility_name("Script");
 					vb_script->add_child(script_code);
 				}
 				hb_locale->add_child(vb_script);
@@ -530,7 +538,7 @@ EditorLocaleDialog::EditorLocaleDialog() {
 				vb_country->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 				{
 					Label *country_lbl = memnew(Label);
-					country_lbl->set_text(TTR("Country"));
+					country_lbl->set_text(TTRC("Country"));
 					vb_country->add_child(country_lbl);
 				}
 				{
@@ -546,7 +554,7 @@ EditorLocaleDialog::EditorLocaleDialog() {
 				vb_variant->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 				{
 					Label *variant_lbl = memnew(Label);
-					variant_lbl->set_text(TTR("Variant"));
+					variant_lbl->set_text(TTRC("Variant"));
 					vb_variant->add_child(variant_lbl);
 				}
 				{
@@ -564,5 +572,5 @@ EditorLocaleDialog::EditorLocaleDialog() {
 	add_child(vb);
 	_update_tree();
 
-	set_ok_button_text(TTR("Select"));
+	set_ok_button_text(TTRC("Select"));
 }

--- a/editor/editor_locale_dialog.h
+++ b/editor/editor_locale_dialog.h
@@ -60,10 +60,14 @@ class EditorLocaleDialog : public ConfirmationDialog {
 	Tree *script_list = nullptr;
 	Tree *cnt_list = nullptr;
 
+	Label *script_label1 = nullptr;
+	Label *script_label2 = nullptr;
+
 	bool locale_set = false;
 	bool updating_lists = false;
 
 protected:
+	void _notification(int p_what);
 	static void _bind_methods();
 	virtual void _post_popup() override;
 	virtual void ok_pressed() override;

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -326,7 +326,7 @@ void SectionedInspector::_search_changed(const String &p_what) {
 		} else {
 			advanced_toggle->set_pressed_no_signal(true);
 			advanced_toggle->set_disabled(true);
-			advanced_toggle->set_tooltip_text(TTR("Advanced settings are always shown when searching."));
+			advanced_toggle->set_tooltip_text(TTRC("Advanced settings are always shown when searching."));
 		}
 	}
 	update_category_list();
@@ -336,6 +336,15 @@ void SectionedInspector::_advanced_toggled(bool p_toggled_on) {
 	restrict_to_basic = !p_toggled_on;
 	update_category_list();
 	inspector->set_restrict_to_basic_settings(restrict_to_basic);
+}
+
+void SectionedInspector::_notification(int p_notification) {
+	if (p_notification == NOTIFICATION_TRANSLATION_CHANGED) {
+		if (sections->get_root()) {
+			// Only update when initialized.
+			callable_mp(this, &SectionedInspector::update_category_list).call_deferred();
+		}
+	}
 }
 
 EditorInspector *SectionedInspector::get_inspector() {

--- a/editor/editor_sectioned_inspector.h
+++ b/editor/editor_sectioned_inspector.h
@@ -62,6 +62,9 @@ class SectionedInspector : public HSplitContainer {
 	void _search_changed(const String &p_what);
 	void _advanced_toggled(bool p_toggled_on);
 
+protected:
+	void _notification(int p_notification);
+
 public:
 	void register_search_box(LineEdit *p_box);
 	void register_advanced_toggle(CheckButton *p_toggle);

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -881,7 +881,7 @@ void EditorSettingsDialog::_bind_methods() {
 }
 
 EditorSettingsDialog::EditorSettingsDialog() {
-	set_title(TTR("Editor Settings"));
+	set_title(TTRC("Editor Settings"));
 	set_clamp_to_embedder(true);
 
 	tabs = memnew(TabContainer);
@@ -893,20 +893,20 @@ EditorSettingsDialog::EditorSettingsDialog() {
 
 	tab_general = memnew(VBoxContainer);
 	tabs->add_child(tab_general);
-	tab_general->set_name(TTR("General"));
+	tab_general->set_name(TTRC("General"));
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	hbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	tab_general->add_child(hbc);
 
 	search_box = memnew(LineEdit);
-	search_box->set_placeholder(TTR("Filter Settings"));
+	search_box->set_placeholder(TTRC("Filter Settings"));
 	search_box->set_accessibility_name(TTRC("Filter Settings"));
 	search_box->set_virtual_keyboard_show_on_focus(false);
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hbc->add_child(search_box);
 
-	advanced_switch = memnew(CheckButton(TTR("Advanced Settings")));
+	advanced_switch = memnew(CheckButton(TTRC("Advanced Settings")));
 	hbc->add_child(advanced_switch);
 
 	bool use_advanced = EDITOR_DEF("_editor_settings_advanced_mode", false);
@@ -932,13 +932,13 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	restart_hb->add_child(restart_icon);
 	restart_label = memnew(Label);
 	restart_label->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
-	restart_label->set_text(TTR("The editor must be restarted for changes to take effect."));
+	restart_label->set_text(TTRC("The editor must be restarted for changes to take effect."));
 	restart_hb->add_child(restart_label);
 	restart_hb->add_spacer();
 	Button *restart_button = memnew(Button);
 	restart_button->connect(SceneStringName(pressed), callable_mp(this, &EditorSettingsDialog::_editor_restart));
 	restart_hb->add_child(restart_button);
-	restart_button->set_text(TTR("Save & Restart"));
+	restart_button->set_text(TTRC("Save & Restart"));
 	restart_close_button = memnew(Button);
 	restart_close_button->set_accessibility_name(TTRC("Close"));
 	restart_close_button->set_flat(true);
@@ -951,14 +951,14 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	tab_shortcuts = memnew(VBoxContainer);
 
 	tabs->add_child(tab_shortcuts);
-	tab_shortcuts->set_name(TTR("Shortcuts"));
+	tab_shortcuts->set_name(TTRC("Shortcuts"));
 
 	HBoxContainer *top_hbox = memnew(HBoxContainer);
 	top_hbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	tab_shortcuts->add_child(top_hbox);
 
 	shortcut_search_box = memnew(LineEdit);
-	shortcut_search_box->set_placeholder(TTR("Filter by Name"));
+	shortcut_search_box->set_placeholder(TTRC("Filter by Name"));
 	shortcut_search_box->set_accessibility_name(TTRC("Filter by Name"));
 	shortcut_search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	top_hbox->add_child(shortcut_search_box);
@@ -974,8 +974,8 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	top_hbox->add_child(shortcut_search_by_event);
 
 	clear_all_search = memnew(Button);
-	clear_all_search->set_text(TTR("Clear All"));
-	clear_all_search->set_tooltip_text(TTR("Clear all search filters."));
+	clear_all_search->set_text(TTRC("Clear All"));
+	clear_all_search->set_tooltip_text(TTRC("Clear all search filters."));
 	clear_all_search->connect(SceneStringName(pressed), callable_mp(shortcut_search_box, &LineEdit::clear));
 	clear_all_search->connect(SceneStringName(pressed), callable_mp(shortcut_search_by_event, &EventListenerLineEdit::clear_event));
 	top_hbox->add_child(clear_all_search);
@@ -1008,5 +1008,5 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	timer->set_one_shot(true);
 	add_child(timer);
 	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorSettingsDialog::_settings_changed));
-	set_ok_button_text(TTR("Close"));
+	set_ok_button_text(TTRC("Close"));
 }

--- a/editor/event_listener_line_edit.cpp
+++ b/editor/event_listener_line_edit.cpp
@@ -197,12 +197,12 @@ void EventListenerLineEdit::_on_text_changed(const String &p_text) {
 }
 
 void EventListenerLineEdit::_on_focus() {
-	set_placeholder(TTR("Listening for Input"));
+	set_placeholder(TTRC("Listening for Input"));
 }
 
 void EventListenerLineEdit::_on_unfocus() {
 	ignore_next_event = true;
-	set_placeholder(TTR("Filter by Event"));
+	set_placeholder(TTRC("Filter by Event"));
 }
 
 Ref<InputEvent> EventListenerLineEdit::get_event() const {
@@ -255,5 +255,5 @@ void EventListenerLineEdit::_bind_methods() {
 
 EventListenerLineEdit::EventListenerLineEdit() {
 	set_caret_blink_enabled(false);
-	set_placeholder(TTR("Filter by Event"));
+	set_placeholder(TTRC("Filter by Event"));
 }

--- a/editor/group_settings_editor.cpp
+++ b/editor/group_settings_editor.cpp
@@ -409,7 +409,7 @@ void GroupSettingsEditor::_show_remove_dialog() {
 		vbox->add_child(remove_label);
 
 		remove_check_box = memnew(CheckBox);
-		remove_check_box->set_text(TTR("Delete references from all scenes"));
+		remove_check_box->set_text(TTRC("Delete references from all scenes"));
 		vbox->add_child(remove_check_box);
 
 		remove_dialog->add_child(vbox);
@@ -432,14 +432,14 @@ void GroupSettingsEditor::_show_remove_dialog() {
 void GroupSettingsEditor::_show_rename_dialog() {
 	if (!rename_group_dialog) {
 		rename_group_dialog = memnew(ConfirmationDialog);
-		rename_group_dialog->set_title(TTR("Rename Group"));
+		rename_group_dialog->set_title(TTRC("Rename Group"));
 		rename_group_dialog->connect(SceneStringName(confirmed), callable_mp(this, &GroupSettingsEditor::_confirm_rename));
 
 		VBoxContainer *vbc = memnew(VBoxContainer);
 		rename_group_dialog->add_child(vbc);
 
 		HBoxContainer *hbc = memnew(HBoxContainer);
-		hbc->add_child(memnew(Label(TTR("Name:"))));
+		hbc->add_child(memnew(Label(TTRC("Name:"))));
 
 		rename_group = memnew(LineEdit);
 		rename_group->set_custom_minimum_size(Size2(300 * EDSCALE, 1));
@@ -458,7 +458,7 @@ void GroupSettingsEditor::_show_rename_dialog() {
 		vbc->add_child(rename_validation_panel);
 
 		rename_check_box = memnew(CheckBox);
-		rename_check_box->set_text(TTR("Rename references in all scenes"));
+		rename_check_box->set_text(TTRC("Rename references in all scenes"));
 		vbc->add_child(rename_check_box);
 
 		add_child(rename_group_dialog);
@@ -495,7 +495,7 @@ GroupSettingsEditor::GroupSettingsEditor() {
 	add_child(hbc);
 
 	Label *l = memnew(Label);
-	l->set_text(TTR("Name:"));
+	l->set_text(TTRC("Name:"));
 	hbc->add_child(l);
 
 	group_name = memnew(LineEdit);
@@ -507,7 +507,7 @@ GroupSettingsEditor::GroupSettingsEditor() {
 	hbc->add_child(group_name);
 
 	l = memnew(Label);
-	l->set_text(TTR("Description:"));
+	l->set_text(TTRC("Description:"));
 	hbc->add_child(l);
 
 	group_description = memnew(LineEdit);
@@ -518,7 +518,7 @@ GroupSettingsEditor::GroupSettingsEditor() {
 	hbc->add_child(group_description);
 
 	add_button = memnew(Button);
-	add_button->set_text(TTR("Add"));
+	add_button->set_text(TTRC("Add"));
 	add_button->set_disabled(true);
 	add_button->connect(SceneStringName(pressed), callable_mp(this, &GroupSettingsEditor::_add_group));
 	hbc->add_child(add_button);
@@ -532,8 +532,8 @@ GroupSettingsEditor::GroupSettingsEditor() {
 	tree->set_columns(3);
 	tree->set_column_titles_visible(true);
 
-	tree->set_column_title(0, TTR("Name"));
-	tree->set_column_title(1, TTR("Description"));
+	tree->set_column_title(0, TTRC("Name"));
+	tree->set_column_title(1, TTRC("Description"));
 	tree->set_column_expand(2, false);
 
 	tree->connect("item_edited", callable_mp(this, &GroupSettingsEditor::_item_edited));

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -201,13 +201,13 @@ ImportDefaultsEditor::ImportDefaultsEditor() {
 	ProjectSettings::get_singleton()->add_hidden_prefix("importer_defaults/");
 
 	HBoxContainer *hb = memnew(HBoxContainer);
-	hb->add_child(memnew(Label(TTR("Importer:"))));
+	hb->add_child(memnew(Label(TTRC("Importer:"))));
 	importers = memnew(OptionButton);
 	hb->add_child(importers);
 	hb->add_spacer();
 	importers->connect(SceneStringName(item_selected), callable_mp(this, &ImportDefaultsEditor::_importer_selected));
 	reset_defaults = memnew(Button);
-	reset_defaults->set_text(TTR("Reset to Defaults"));
+	reset_defaults->set_text(TTRC("Reset to Defaults"));
 	reset_defaults->set_disabled(true);
 	reset_defaults->connect(SceneStringName(pressed), callable_mp(this, &ImportDefaultsEditor::_reset));
 	hb->add_child(reset_defaults);
@@ -222,7 +222,7 @@ ImportDefaultsEditor::ImportDefaultsEditor() {
 
 	CenterContainer *cc = memnew(CenterContainer);
 	save_defaults = memnew(Button);
-	save_defaults->set_text(TTR("Save"));
+	save_defaults->set_text(TTRC("Save"));
 	save_defaults->connect(SceneStringName(pressed), callable_mp(this, &ImportDefaultsEditor::_save));
 	cc->add_child(save_defaults);
 	add_child(cc);

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -521,7 +521,7 @@ void LocalizationEditor::update_translations() {
 			t->set_text(0, translations[i].replace_first("res://", ""));
 			t->set_tooltip_text(0, translations[i]);
 			t->set_metadata(0, i);
-			t->add_button(0, get_editor_theme_icon(SNAME("Remove")), 0, false, TTR("Remove"));
+			t->add_button(0, get_editor_theme_icon(SNAME("Remove")), 0, false, TTRC("Remove"));
 		}
 	}
 
@@ -553,7 +553,7 @@ void LocalizationEditor::update_translations() {
 			t->set_text(0, keys[i].replace_first("res://", ""));
 			t->set_tooltip_text(0, keys[i]);
 			t->set_metadata(0, keys[i]);
-			t->add_button(0, get_editor_theme_icon(SNAME("Remove")), 0, false, TTR("Remove"));
+			t->add_button(0, get_editor_theme_icon(SNAME("Remove")), 0, false, TTRC("Remove"));
 
 			// Display that it has been removed if this is the case.
 			if (!FileAccess::exists(keys[i])) {
@@ -577,7 +577,7 @@ void LocalizationEditor::update_translations() {
 					t2->set_text(0, path.replace_first("res://", ""));
 					t2->set_tooltip_text(0, path);
 					t2->set_metadata(0, j);
-					t2->add_button(0, get_editor_theme_icon(SNAME("Remove")), 0, false, TTR("Remove"));
+					t2->add_button(0, get_editor_theme_icon(SNAME("Remove")), 0, false, TTRC("Remove"));
 					t2->set_cell_mode(1, TreeItem::CELL_MODE_CUSTOM);
 					t2->set_text(1, TranslationServer::get_singleton()->get_locale_name(locale));
 					t2->set_editable(1, true);
@@ -605,7 +605,7 @@ void LocalizationEditor::update_translations() {
 		t->set_text(0, pot_translations[i].replace_first("res://", ""));
 		t->set_tooltip_text(0, pot_translations[i]);
 		t->set_metadata(0, i);
-		t->add_button(0, get_editor_theme_icon(SNAME("Remove")), 0, false, TTR("Remove"));
+		t->add_button(0, get_editor_theme_icon(SNAME("Remove")), 0, false, TTRC("Remove"));
 	}
 
 	// New translation parser plugin might extend possible file extensions in POT generation.
@@ -631,17 +631,17 @@ LocalizationEditor::LocalizationEditor() {
 
 	{
 		VBoxContainer *tvb = memnew(VBoxContainer);
-		tvb->set_name(TTR("Translations"));
+		tvb->set_name(TTRC("Translations"));
 		translations->add_child(tvb);
 
 		HBoxContainer *thb = memnew(HBoxContainer);
-		Label *l = memnew(Label(TTR("Translations:")));
+		Label *l = memnew(Label(TTRC("Translations:")));
 		l->set_theme_type_variation("HeaderSmall");
 		thb->add_child(l);
 		thb->add_spacer();
 		tvb->add_child(thb);
 
-		Button *addtr = memnew(Button(TTR("Add...")));
+		Button *addtr = memnew(Button(TTRC("Add...")));
 		addtr->connect(SceneStringName(pressed), callable_mp(this, &LocalizationEditor::_translation_file_open));
 		thb->add_child(addtr);
 
@@ -665,17 +665,17 @@ LocalizationEditor::LocalizationEditor() {
 
 	{
 		VBoxContainer *tvb = memnew(VBoxContainer);
-		tvb->set_name(TTR("Remaps"));
+		tvb->set_name(TTRC("Remaps"));
 		translations->add_child(tvb);
 
 		HBoxContainer *thb = memnew(HBoxContainer);
-		Label *l = memnew(Label(TTR("Resources:")));
+		Label *l = memnew(Label(TTRC("Resources:")));
 		l->set_theme_type_variation("HeaderSmall");
 		thb->add_child(l);
 		thb->add_spacer();
 		tvb->add_child(thb);
 
-		Button *addtr = memnew(Button(TTR("Add...")));
+		Button *addtr = memnew(Button(TTRC("Add...")));
 		addtr->connect(SceneStringName(pressed), callable_mp(this, &LocalizationEditor::_translation_res_file_open));
 		thb->add_child(addtr);
 
@@ -695,13 +695,13 @@ LocalizationEditor::LocalizationEditor() {
 		add_child(translation_res_file_open_dialog);
 
 		thb = memnew(HBoxContainer);
-		l = memnew(Label(TTR("Remaps by Locale:")));
+		l = memnew(Label(TTRC("Remaps by Locale:")));
 		l->set_theme_type_variation("HeaderSmall");
 		thb->add_child(l);
 		thb->add_spacer();
 		tvb->add_child(thb);
 
-		addtr = memnew(Button(TTR("Add...")));
+		addtr = memnew(Button(TTRC("Add...")));
 		addtr->connect(SceneStringName(pressed), callable_mp(this, &LocalizationEditor::_translation_res_option_file_open));
 		translation_res_option_add_button = addtr;
 		thb->add_child(addtr);
@@ -713,8 +713,8 @@ LocalizationEditor::LocalizationEditor() {
 		translation_remap_options = memnew(Tree);
 		translation_remap_options->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		translation_remap_options->set_columns(2);
-		translation_remap_options->set_column_title(0, TTR("Path"));
-		translation_remap_options->set_column_title(1, TTR("Locale"));
+		translation_remap_options->set_column_title(0, TTRC("Path"));
+		translation_remap_options->set_column_title(1, TTRC("Locale"));
 		translation_remap_options->set_column_titles_visible(true);
 		translation_remap_options->set_column_expand(0, true);
 		translation_remap_options->set_column_clip_content(0, true);
@@ -734,21 +734,21 @@ LocalizationEditor::LocalizationEditor() {
 
 	{
 		VBoxContainer *tvb = memnew(VBoxContainer);
-		tvb->set_name(TTR("POT Generation"));
+		tvb->set_name(TTRC("POT Generation"));
 		translations->add_child(tvb);
 
 		HBoxContainer *thb = memnew(HBoxContainer);
-		Label *l = memnew(Label(TTR("Files with translation strings:")));
+		Label *l = memnew(Label(TTRC("Files with translation strings:")));
 		l->set_theme_type_variation("HeaderSmall");
 		thb->add_child(l);
 		thb->add_spacer();
 		tvb->add_child(thb);
 
-		Button *addtr = memnew(Button(TTR("Add...")));
+		Button *addtr = memnew(Button(TTRC("Add...")));
 		addtr->connect(SceneStringName(pressed), callable_mp(this, &LocalizationEditor::_pot_file_open));
 		thb->add_child(addtr);
 
-		pot_generate_button = memnew(Button(TTR("Generate POT")));
+		pot_generate_button = memnew(Button(TTRC("Generate POT")));
 		pot_generate_button->connect(SceneStringName(pressed), callable_mp(this, &LocalizationEditor::_pot_generate_open));
 		thb->add_child(pot_generate_button);
 
@@ -756,8 +756,8 @@ LocalizationEditor::LocalizationEditor() {
 		translation_pot_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		tvb->add_child(translation_pot_list);
 
-		translation_pot_add_builtin = memnew(CheckBox(TTR("Add Built-in Strings to POT")));
-		translation_pot_add_builtin->set_tooltip_text(TTR("Add strings from built-in components such as certain Control nodes."));
+		translation_pot_add_builtin = memnew(CheckBox(TTRC("Add Built-in Strings to POT")));
+		translation_pot_add_builtin->set_tooltip_text(TTRC("Add strings from built-in components such as certain Control nodes."));
 		translation_pot_add_builtin->connect(SceneStringName(pressed), callable_mp(this, &LocalizationEditor::_pot_add_builtin_toggled));
 		tvb->add_child(translation_pot_add_builtin);
 

--- a/editor/plugins/editor_plugin_settings.cpp
+++ b/editor/plugins/editor_plugin_settings.cpp
@@ -48,9 +48,15 @@ void EditorPluginSettings::_notification(int p_what) {
 			update_plugins();
 		} break;
 
-		case Node::NOTIFICATION_READY: {
+		case NOTIFICATION_READY: {
 			plugin_config_dialog->connect("plugin_ready", callable_mp(EditorNode::get_singleton(), &EditorNode::_on_plugin_ready));
 			plugin_list->connect("button_clicked", callable_mp(this, &EditorPluginSettings::_cell_button_pressed));
+		} break;
+
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			if (plugin_list->get_root()) {
+				update_plugins();
+			}
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -120,10 +126,10 @@ void EditorPluginSettings::update_plugins() {
 				item->set_text(COLUMN_AUTHOR, author);
 				item->set_metadata(COLUMN_AUTHOR, description);
 				item->set_cell_mode(COLUMN_STATUS, TreeItem::CELL_MODE_CHECK);
-				item->set_text(COLUMN_STATUS, TTR("On"));
+				item->set_text(COLUMN_STATUS, TTRC("On"));
 				item->set_checked(COLUMN_STATUS, is_enabled);
 				item->set_editable(COLUMN_STATUS, true);
-				item->add_button(COLUMN_EDIT, get_editor_theme_icon(SNAME("Edit")), BUTTON_PLUGIN_EDIT, false, TTR("Edit Plugin"));
+				item->add_button(COLUMN_EDIT, get_editor_theme_icon(SNAME("Edit")), BUTTON_PLUGIN_EDIT, false, TTRC("Edit Plugin"));
 			}
 		}
 	}
@@ -221,7 +227,7 @@ EditorPluginSettings::EditorPluginSettings() {
 		recovery_mode_icon->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 		c->add_child(recovery_mode_icon);
 
-		Label *recovery_mode_label = memnew(Label(TTR("Recovery mode is enabled. Enabled plugins will not run while this mode is active.")));
+		Label *recovery_mode_label = memnew(Label(TTRC("Recovery mode is enabled. Enabled plugins will not run while this mode is active.")));
 		recovery_mode_label->set_theme_type_variation("HeaderSmall");
 		recovery_mode_label->set_h_size_flags(SIZE_EXPAND_FILL);
 		c->add_child(recovery_mode_label);
@@ -231,11 +237,11 @@ EditorPluginSettings::EditorPluginSettings() {
 	}
 
 	HBoxContainer *title_hb = memnew(HBoxContainer);
-	Label *label = memnew(Label(TTR("Installed Plugins:")));
+	Label *label = memnew(Label(TTRC("Installed Plugins:")));
 	label->set_theme_type_variation("HeaderSmall");
 	title_hb->add_child(label);
 	title_hb->add_spacer();
-	Button *create_plugin_button = memnew(Button(TTR("Create New Plugin")));
+	Button *create_plugin_button = memnew(Button(TTRC("Create New Plugin")));
 	create_plugin_button->connect(SceneStringName(pressed), callable_mp(this, &EditorPluginSettings::_create_clicked));
 	title_hb->add_child(create_plugin_button);
 	add_child(title_hb);
@@ -244,11 +250,11 @@ EditorPluginSettings::EditorPluginSettings() {
 	plugin_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	plugin_list->set_columns(COLUMN_MAX);
 	plugin_list->set_column_titles_visible(true);
-	plugin_list->set_column_title(COLUMN_STATUS, TTR("Enabled"));
-	plugin_list->set_column_title(COLUMN_NAME, TTR("Name"));
-	plugin_list->set_column_title(COLUMN_VERSION, TTR("Version"));
-	plugin_list->set_column_title(COLUMN_AUTHOR, TTR("Author"));
-	plugin_list->set_column_title(COLUMN_EDIT, TTR("Edit"));
+	plugin_list->set_column_title(COLUMN_STATUS, TTRC("Enabled"));
+	plugin_list->set_column_title(COLUMN_NAME, TTRC("Name"));
+	plugin_list->set_column_title(COLUMN_VERSION, TTRC("Version"));
+	plugin_list->set_column_title(COLUMN_AUTHOR, TTRC("Author"));
+	plugin_list->set_column_title(COLUMN_EDIT, TTRC("Edit"));
 	plugin_list->set_column_title_alignment(COLUMN_STATUS, HORIZONTAL_ALIGNMENT_LEFT);
 	plugin_list->set_column_title_alignment(COLUMN_NAME, HORIZONTAL_ALIGNMENT_LEFT);
 	plugin_list->set_column_title_alignment(COLUMN_VERSION, HORIZONTAL_ALIGNMENT_LEFT);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -338,8 +338,10 @@ void ProjectSettingsEditor::_add_feature_overrides() {
 	}
 
 	feature_box->clear();
-	feature_box->add_item(TTR("(All)"), FEATURE_ALL); // So it is always on top.
-	feature_box->add_item(TTR("Custom"), FEATURE_CUSTOM);
+	feature_box->add_item(TTRC("(All)"), FEATURE_ALL); // So it is always on top.
+	feature_box->set_item_auto_translate_mode(-1, AUTO_TRANSLATE_MODE_ALWAYS);
+	feature_box->add_item(TTRC("Custom"), FEATURE_CUSTOM);
+	feature_box->set_item_auto_translate_mode(-1, AUTO_TRANSLATE_MODE_ALWAYS);
 	feature_box->add_separator();
 
 	int id = FEATURE_FIRST;
@@ -647,7 +649,7 @@ void ProjectSettingsEditor::_bind_methods() {
 
 ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	singleton = this;
-	set_title(TTR("Project Settings (project.godot)"));
+	set_title(TTRC("Project Settings (project.godot)"));
 	set_clamp_to_embedder(true);
 
 	ps = ProjectSettings::get_singleton();
@@ -660,7 +662,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	add_child(tab_container);
 
 	general_editor = memnew(VBoxContainer);
-	general_editor->set_name(TTR("General"));
+	general_editor->set_name(TTRC("General"));
 	general_editor->set_alignment(BoxContainer::ALIGNMENT_BEGIN);
 	general_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tab_container->add_child(general_editor);
@@ -669,7 +671,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	general_editor->add_child(search_bar);
 
 	search_box = memnew(LineEdit);
-	search_box->set_placeholder(TTR("Filter Settings"));
+	search_box->set_placeholder(TTRC("Filter Settings"));
 	search_box->set_accessibility_name(TTRC("Filter Settings"));
 	search_box->set_clear_button_enabled(true);
 	search_box->set_virtual_keyboard_show_on_focus(false);
@@ -677,14 +679,14 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	search_bar->add_child(search_box);
 
 	advanced = memnew(CheckButton);
-	advanced->set_text(TTR("Advanced Settings"));
+	advanced->set_text(TTRC("Advanced Settings"));
 	search_bar->add_child(advanced);
 
 	custom_properties = memnew(HBoxContainer);
 	general_editor->add_child(custom_properties);
 
 	property_box = memnew(LineEdit);
-	property_box->set_placeholder(TTR("Select a Setting or Type its Name"));
+	property_box->set_placeholder(TTRC("Select a Setting or Type its Name"));
 	property_box->set_accessibility_name(TTRC("Setting Name"));
 	property_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	property_box->connect(SceneStringName(text_changed), callable_mp(this, &ProjectSettingsEditor::_property_box_changed));
@@ -693,6 +695,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	feature_box = memnew(OptionButton);
 	feature_box->set_custom_minimum_size(Size2(120, 0) * EDSCALE);
 	feature_box->set_accessibility_name(TTRC("Feature"));
+	feature_box->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	feature_box->connect(SceneStringName(item_selected), callable_mp(this, &ProjectSettingsEditor::_feature_selected));
 	custom_properties->add_child(feature_box);
 
@@ -702,13 +705,13 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	custom_properties->add_child(type_box);
 
 	add_button = memnew(Button);
-	add_button->set_text(TTR("Add"));
+	add_button->set_text(TTRC("Add"));
 	add_button->set_disabled(true);
 	add_button->connect(SceneStringName(pressed), callable_mp(this, &ProjectSettingsEditor::_add_setting));
 	custom_properties->add_child(add_button);
 
 	del_button = memnew(Button);
-	del_button->set_text(TTR("Delete"));
+	del_button->set_text(TTRC("Delete"));
 	del_button->set_disabled(true);
 	del_button->connect(SceneStringName(pressed), callable_mp(this, &ProjectSettingsEditor::_delete_setting));
 	custom_properties->add_child(del_button);
@@ -737,14 +740,14 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	restart_label = memnew(Label);
 	restart_label->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
-	restart_label->set_text(TTR("Changed settings will be applied to the editor after restarting."));
+	restart_label->set_text(TTRC("Changed settings will be applied to the editor after restarting."));
 	restart_hb->add_child(restart_label);
 	restart_hb->add_spacer();
 
 	Button *restart_button = memnew(Button);
 	restart_button->connect(SceneStringName(pressed), callable_mp(this, &ProjectSettingsEditor::_editor_restart));
 	restart_hb->add_child(restart_button);
-	restart_button->set_text(TTR("Save & Restart"));
+	restart_button->set_text(TTRC("Save & Restart"));
 
 	restart_close_button = memnew(Button);
 	restart_close_button->set_flat(true);
@@ -753,7 +756,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	restart_hb->add_child(restart_close_button);
 
 	action_map_editor = memnew(ActionMapEditor);
-	action_map_editor->set_name(TTR("Input Map"));
+	action_map_editor->set_name(TTRC("Input Map"));
 	action_map_editor->connect("action_added", callable_mp(this, &ProjectSettingsEditor::_action_added));
 	action_map_editor->connect("action_edited", callable_mp(this, &ProjectSettingsEditor::_action_edited));
 	action_map_editor->connect("action_removed", callable_mp(this, &ProjectSettingsEditor::_action_removed));
@@ -764,31 +767,31 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	tab_container->add_child(action_map_editor);
 
 	localization_editor = memnew(LocalizationEditor);
-	localization_editor->set_name(TTR("Localization"));
+	localization_editor->set_name(TTRC("Localization"));
 	localization_editor->connect("localization_changed", callable_mp(this, &ProjectSettingsEditor::queue_save));
 	tab_container->add_child(localization_editor);
 
 	TabContainer *globals_container = memnew(TabContainer);
-	globals_container->set_name(TTR("Globals"));
+	globals_container->set_name(TTRC("Globals"));
 	tab_container->add_child(globals_container);
 
 	autoload_settings = memnew(EditorAutoloadSettings);
-	autoload_settings->set_name(TTR("Autoload"));
+	autoload_settings->set_name(TTRC("Autoload"));
 	autoload_settings->connect("autoload_changed", callable_mp(this, &ProjectSettingsEditor::queue_save));
 	globals_container->add_child(autoload_settings);
 
 	shaders_global_shader_uniforms_editor = memnew(ShaderGlobalsEditor);
-	shaders_global_shader_uniforms_editor->set_name(TTR("Shader Globals"));
+	shaders_global_shader_uniforms_editor->set_name(TTRC("Shader Globals"));
 	shaders_global_shader_uniforms_editor->connect("globals_changed", callable_mp(this, &ProjectSettingsEditor::queue_save));
 	globals_container->add_child(shaders_global_shader_uniforms_editor);
 
 	group_settings = memnew(GroupSettingsEditor);
-	group_settings->set_name(TTR("Groups"));
+	group_settings->set_name(TTRC("Groups"));
 	group_settings->connect("group_changed", callable_mp(this, &ProjectSettingsEditor::queue_save));
 	globals_container->add_child(group_settings);
 
 	plugin_settings = memnew(EditorPluginSettings);
-	plugin_settings->set_name(TTR("Plugins"));
+	plugin_settings->set_name(TTRC("Plugins"));
 	tab_container->add_child(plugin_settings);
 
 	timer = memnew(Timer);
@@ -797,7 +800,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	timer->set_one_shot(true);
 	add_child(timer);
 
-	set_ok_button_text(TTR("Close"));
+	set_ok_button_text(TTRC("Close"));
 	set_hide_on_ok(true);
 
 	bool use_advanced = EDITOR_DEF("_project_settings_advanced_mode", false);
@@ -809,7 +812,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	_update_advanced(use_advanced);
 
 	import_defaults_editor = memnew(ImportDefaultsEditor);
-	import_defaults_editor->set_name(TTR("Import Defaults"));
+	import_defaults_editor->set_name(TTRC("Import Defaults"));
 	tab_container->add_child(import_defaults_editor);
 
 	MovieWriter::set_extensions_hint(); // ensure extensions are properly displayed.

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -358,11 +358,11 @@ static Variant create_var(RS::GlobalShaderParameterType p_type) {
 
 String ShaderGlobalsEditor::_check_new_variable_name(const String &p_variable_name) {
 	if (p_variable_name.is_empty()) {
-		return TTR("Name cannot be empty.");
+		return TTRC("Name cannot be empty.");
 	}
 
 	if (!p_variable_name.is_valid_ascii_identifier()) {
-		return TTR("Name must be a valid identifier.");
+		return TTRC("Name must be a valid identifier.");
 	}
 
 	return "";
@@ -464,7 +464,7 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 	HBoxContainer *add_menu_hb = memnew(HBoxContainer);
 	add_child(add_menu_hb);
 
-	add_menu_hb->add_child(memnew(Label(TTR("Name:"))));
+	add_menu_hb->add_child(memnew(Label(TTRC("Name:"))));
 	variable_name = memnew(LineEdit);
 	variable_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	variable_name->set_clear_button_enabled(true);
@@ -473,7 +473,7 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 
 	add_menu_hb->add_child(variable_name);
 
-	add_menu_hb->add_child(memnew(Label(TTR("Type:"))));
+	add_menu_hb->add_child(memnew(Label(TTRC("Type:"))));
 	variable_type = memnew(OptionButton);
 	variable_type->set_h_size_flags(SIZE_EXPAND_FILL);
 	add_menu_hb->add_child(variable_type);
@@ -482,7 +482,7 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 		variable_type->add_item(global_var_type_names[i]);
 	}
 
-	variable_add = memnew(Button(TTR("Add")));
+	variable_add = memnew(Button(TTRC("Add")));
 	variable_add->set_disabled(true);
 	add_menu_hb->add_child(variable_add);
 	variable_add->connect(SceneStringName(pressed), callable_mp(this, &ShaderGlobalsEditor::_variable_added));


### PR DESCRIPTION
Part of https://github.com/godotengine/godot/issues/104574
Handles Project Settings and EditorSettings Dialogs.

A funny side-effect is that the restart warning label you get after switching language will now use the language you just switched to.