### PR TITLE
Change Selected value for OptionButton when last item is deleted.

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -314,6 +314,10 @@ void OptionButton::set_item_count(int p_count) {
 		return;
 	}
 
+	if (current > p_count - 1) {
+		_select(p_count - 1, false);
+	}
+
 	popup->set_item_count(p_count);
 
 	if (p_count > count_old) {


### PR DESCRIPTION
* Fixes [Visual bug in OptionButton #105582](https://github.com/godotengine/godot/issues/105582)
* Also fixes selected value not changing when last item is deleted.

Note: undoing the deletion of the last item will not update selected. As far as I could tell, undoing adds back the item that was deleted.
This lead me to conclude that there is no way of undoing the selected value without being able to determine the add was part of an undo.