### PR TITLE
Fixed popup box size on Android

### DIFF
--- a/editor/run_instances_dialog.cpp
+++ b/editor/run_instances_dialog.cpp
@@ -194,7 +194,7 @@ void RunInstancesDialog::_instance_tree_rmb(const Vector2 &p_pos, MouseButton p_
 }
 
 void RunInstancesDialog::popup_dialog() {
-	popup_centered(Vector2(1200, 600) * EDSCALE);
+	popup_centered_clamped(Size2(900, 700) * EDSCALE, 0.8);
 }
 
 int RunInstancesDialog::get_instance_count() const {


### PR DESCRIPTION
Fixed popup size on Android being unusually large on small screen devices.
