### PR TITLE
Fix docgen showing wrong parent class in some situations

### DIFF
--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -344,13 +344,13 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 	doc.script_path = p_script->get_script_path();
 
 	if (p_script->base.is_valid() && p_script->base->is_valid()) {
-		if (!p_script->base->doc.name.is_empty()) {
-			doc.inherits = p_script->base->doc.name;
+		if (p_script->base->local_name != StringName()) {
+			doc.inherits = p_script->base->local_name;
 		} else {
-			doc.inherits = p_script->base->get_instance_base_type();
+			doc.inherits = p_script->base->get_script_path();
 		}
-	} else if (p_script->native.is_valid()) {
-		doc.inherits = p_script->native->get_name();
+	} else {
+		doc.inherits = p_script->get_instance_base_type();
 	}
 
 	doc.brief_description = p_class->doc_data.brief;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This fixes doc gen sometimes skipping the actual parent of a given class, which affects both XML files exported with `godot --doctool --gdscript-docs` and the in-editor help.

If you consider the following inheritance tree: `ClassB < ClassA < RefCounted < Object`, in some circumstances `ClassB` could show `Inherits: RefCounted` instead of `Inherits: ClassA`; conversely, `ClassA` would not show `Inherited by: ClassB`.
The exact circumstances for this to happen are not entirely clear to me, but I noticed it in at least 2 projects. It appears the issue is caused in part by the order in which scripts are loaded and their respective docs updated.

With this PR, both exported XML files and the in-editor help properly display the correct inherited and inheriting classes in both of my affected projects. I just hope this does not somehow break something else.

Fixes #105926 