### PR TITLE
Fix TabBar Hidden Tabs Handling

### DIFF
--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -261,6 +261,9 @@ public:
 	int get_previous_tab() const;
 	int get_hovered_tab() const;
 
+	int get_previous_available(int p_idx = -1) const;
+	int get_next_available(int p_idx = -1) const;
+
 	bool select_previous_available();
 	bool select_next_available();
 

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -347,14 +347,16 @@ void TabContainer::_repaint() {
 }
 
 void TabContainer::_update_margins() {
-	int menu_width = theme_cache.menu_icon->get_width();
-
 	// Directly check for validity, to avoid errors when quitting.
 	bool has_popup = popup_obj_id.is_valid();
+	int menu_width = 0;
+	if (has_popup) {
+		menu_width = theme_cache.menu_icon->get_width();
+	}
 
 	if (get_tab_count() == 0) {
 		tab_bar->set_offset(SIDE_LEFT, 0);
-		tab_bar->set_offset(SIDE_RIGHT, has_popup ? -menu_width : 0);
+		tab_bar->set_offset(SIDE_RIGHT, -menu_width);
 
 		return;
 	}
@@ -362,12 +364,12 @@ void TabContainer::_update_margins() {
 	switch (get_tab_alignment()) {
 		case TabBar::ALIGNMENT_LEFT: {
 			tab_bar->set_offset(SIDE_LEFT, theme_cache.side_margin);
-			tab_bar->set_offset(SIDE_RIGHT, has_popup ? -menu_width : 0);
+			tab_bar->set_offset(SIDE_RIGHT, -menu_width);
 		} break;
 
 		case TabBar::ALIGNMENT_CENTER: {
 			tab_bar->set_offset(SIDE_LEFT, 0);
-			tab_bar->set_offset(SIDE_RIGHT, has_popup ? -menu_width : 0);
+			tab_bar->set_offset(SIDE_RIGHT, -menu_width);
 		} break;
 
 		case TabBar::ALIGNMENT_RIGHT: {
@@ -384,7 +386,7 @@ void TabContainer::_update_margins() {
 
 			// Calculate if all the tabs would still fit if the margin was present.
 			if (get_clip_tabs() && (tab_bar->get_offset_buttons_visible() || (get_tab_count() > 1 && (total_tabs_width + theme_cache.side_margin) > get_size().width))) {
-				tab_bar->set_offset(SIDE_RIGHT, has_popup ? -menu_width : 0);
+				tab_bar->set_offset(SIDE_RIGHT, -menu_width);
 			} else {
 				tab_bar->set_offset(SIDE_RIGHT, -theme_cache.side_margin);
 			}


### PR DESCRIPTION
See: #106164

These bugfixes are related but necessary for the above PR to function.

The first fix is in TabContainer. Currently TabContainer calls `_update_margins` in the `add_child_notify` method. Since it adds the `TabBar` as a child upon being allocated and the theme cache is not set when allocating the `EditorBottomPanel` class, this leads to a segfault as it is trying to access a nullptr. This PR fixes the bug by wrapping the theme access behind an if statement, removing many redundant ternaries.

The second fix is in TabBar's theme constants. The `tab_separation` theme variable did not work correctly where hidden tabs intermixed with non-hidden tabs could still add their separation even though they are not visible. This PR solves the issue by only adding the separation for non-hidden tabs.