### PR TITLE
Do not grab focus on filename `LineEdit` in `EditorFileDialog` when outside the tree

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -1419,9 +1419,9 @@ void EditorFileDialog::set_current_file(const String &p_file) {
 	file->set_text(p_file);
 	update_dir();
 	invalidate();
-	_focus_file_text();
 
 	if (is_visible()) {
+		_focus_file_text();
 		_request_single_thumbnail(get_current_dir().path_join(get_current_file()));
 	}
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

When a POT is generated for the first time, `last_pot_path` is added to the project metadata and this value gets used the next time the Editor runs to configure the POT generator dialog.

The problem is that currently the code configures the dialog too early and an error shows up the next time the Editor runs:

```
ERROR: Condition "!is_inside_tree()" is true.
   at: grab_focus (scene/gui/control.cpp:2210)
```

This PR fixes this issue.

To reproduce the bug, simply run the following project in the CLI:

[POTGeneratorDialogBug.zip](https://github.com/user-attachments/files/20144111/POTGeneratorDialogBug.zip)
