### PR TITLE
Add support for custom font colors in the TabBar

### DIFF
--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -52,10 +52,21 @@ public:
 		CLOSE_BUTTON_MAX
 	};
 
+	enum DrawMode {
+		DRAW_NORMAL,
+		DRAW_PRESSED,
+		DRAW_HOVER,
+		DRAW_DISABLED,
+		DRAW_MAX,
+	};
+
 private:
 	struct Tab {
 		mutable RID accessibility_item_element;
 		mutable bool accessibility_item_dirty = true;
+
+		// Corresponds to color overrides for the DrawMode enum
+		Color font_color_overrides[DrawMode::DRAW_MAX] = { Color(0, 0, 0, 0), Color(0, 0, 0, 0), Color(0, 0, 0, 0), Color(0, 0, 0, 0) };
 
 		String text;
 		String tooltip;
@@ -227,6 +238,10 @@ public:
 
 	void set_tab_icon_max_width(int p_tab, int p_width);
 	int get_tab_icon_max_width(int p_tab) const;
+
+	void set_font_color_override_all(int p_tab, const Color &p_color);
+	void set_font_color_override(int p_tab, DrawMode p_draw_mode, const Color &p_color);
+	Color get_font_color_override(int p_tab, DrawMode p_draw_mode) const;
 
 	void set_tab_disabled(int p_tab, bool p_disabled);
 	bool is_tab_disabled(int p_tab) const;


### PR DESCRIPTION
Partially Addresses: https://github.com/godotengine/godot-proposals/issues/9161
Related: #88709, #106164 

The inspiration for this PR was #106164 and the desire to set a custom color for the `Output` and `Debugger` tabs now that they are within a TabBar, but there is a desire to do such, as evidenced by the previous proposal.

Currently it is impossible to set colors individually for tabs in a TabBar. This PR adds support to set custom overrides for the selected, unselected, hovered, and disabled colors on a *per tab* basis.

<img width="429" alt="TabBar with Rainbow-Colored Tabs" src="https://github.com/user-attachments/assets/6fbde07c-60c4-4656-9c1e-c3f00a2c8d90" />
