### PR TITLE
SCons: Hide SCU folders by adding "." to foldername

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -68,7 +68,7 @@ def add_source_files_scu(self, sources, files, allow_gen=False):
             return False
 
         # Add all the gen.cpp files in the SCU directory
-        add_source_files_orig(self, sources, subdir + "scu/scu_*.gen.cpp", True)
+        add_source_files_orig(self, sources, subdir + ".scu/scu_*.gen.cpp", True)
         return True
     return False
 

--- a/scu_builders.py
+++ b/scu_builders.py
@@ -223,7 +223,7 @@ def process_folder(folders, sought_exceptions=[], includes_per_scu=0, extension=
     start_line = 0
 
     # These do not vary throughout the loop
-    output_folder = abs_main_folder + "/scu/"
+    output_folder = abs_main_folder + "/.scu/"
     output_filename_prefix = "scu_" + out_filename
 
     fresh_files = set()


### PR DESCRIPTION
Folders beginning with "." are hidden by default on Linux & Mac.

## Notes
* This has been the case for 3.x for a while now.
* It may be an idea to remind contributors to clear out existing SCU folders as they are no longer used.
* Same applies for any cache in the CI.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
