### PR TITLE
SCons: SCU spring clean to make sure folders are accelerated

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1220,7 +1220,7 @@ void RasterizerSceneGLES3::voxel_gi_update(RID p_probe, bool p_update_light_inst
 void RasterizerSceneGLES3::voxel_gi_set_quality(RS::VoxelGIQuality) {
 }
 
-_FORCE_INLINE_ static uint32_t _indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) {
+uint32_t RasterizerSceneGLES3::_indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) const {
 	static const uint32_t divisor[RS::PRIMITIVE_MAX] = { 1, 2, 1, 3, 1 };
 	static const uint32_t subtractor[RS::PRIMITIVE_MAX] = { 0, 0, 1, 0, 2 };
 	return (p_indices - subtractor[p_primitive]) / divisor[p_primitive];

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -649,6 +649,8 @@ private:
 	template <PassMode p_pass_mode>
 	_FORCE_INLINE_ void _render_list_template(RenderListParameters *p_params, const RenderDataGLES3 *p_render_data, uint32_t p_from_element, uint32_t p_to_element, bool p_alpha_pass = false);
 
+	_FORCE_INLINE_ uint32_t _indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) const;
+
 protected:
 	double time;
 	double time_step = 0;

--- a/modules/jolt_physics/SCsub
+++ b/modules/jolt_physics/SCsub
@@ -160,19 +160,31 @@ env_thirdparty = env_jolt.Clone()
 env_thirdparty.disable_warnings()
 
 thirdparty_obj = []
-env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+
+# If in a SCU build, add all the jolt files at once,
+# specify the jolt folders in "scu_builders.py".
+if env["scu_build"]:
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "Jolt/*.cpp")
+else:
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+
 env.modules_sources += thirdparty_obj
 
 # Godot source files
 
 module_obj = []
 
-env_jolt.add_source_files(module_obj, "*.cpp")
-env_jolt.add_source_files(module_obj, "joints/*.cpp")
-env_jolt.add_source_files(module_obj, "misc/*.cpp")
-env_jolt.add_source_files(module_obj, "objects/*.cpp")
-env_jolt.add_source_files(module_obj, "shapes/*.cpp")
-env_jolt.add_source_files(module_obj, "spaces/*.cpp")
+# If not in a SCU build, add the subfolders individually.
+if env["scu_build"]:
+    env_jolt.add_source_files(module_obj, "*.cpp")
+else:
+    env_jolt.add_source_files(module_obj, "*.cpp")
+    env_jolt.add_source_files(module_obj, "joints/*.cpp")
+    env_jolt.add_source_files(module_obj, "misc/*.cpp")
+    env_jolt.add_source_files(module_obj, "objects/*.cpp")
+    env_jolt.add_source_files(module_obj, "shapes/*.cpp")
+    env_jolt.add_source_files(module_obj, "spaces/*.cpp")
+
 env.modules_sources += module_obj
 
 # Needed to force rebuilding the module files when the thirdparty library is updated.

--- a/scene/resources/2d/SCsub
+++ b/scene/resources/2d/SCsub
@@ -3,21 +3,25 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-env.add_source_files(env.scene_sources, "tile_set.cpp")
 
-if not env["disable_physics_2d"]:
-    env.add_source_files(env.scene_sources, "capsule_shape_2d.cpp")
-    env.add_source_files(env.scene_sources, "circle_shape_2d.cpp")
-    env.add_source_files(env.scene_sources, "concave_polygon_shape_2d.cpp")
-    env.add_source_files(env.scene_sources, "convex_polygon_shape_2d.cpp")
-    env.add_source_files(env.scene_sources, "rectangle_shape_2d.cpp")
-    env.add_source_files(env.scene_sources, "segment_shape_2d.cpp")
-    env.add_source_files(env.scene_sources, "separation_ray_shape_2d.cpp")
-    env.add_source_files(env.scene_sources, "shape_2d.cpp")
-    env.add_source_files(env.scene_sources, "world_boundary_shape_2d.cpp")
-if not env["disable_navigation_2d"]:
-    env.add_source_files(env.scene_sources, "navigation_mesh_source_geometry_data_2d.cpp")
-    env.add_source_files(env.scene_sources, "navigation_polygon.cpp")
-    env.add_source_files(env.scene_sources, "polygon_path_finder.cpp")
+if env["disable_physics_2d"] or env["disable_navigation_2d"]:
+    env.add_source_files(env.scene_sources, "tile_set.cpp")
+
+    if not env["disable_physics_2d"]:
+        env.add_source_files(env.scene_sources, "capsule_shape_2d.cpp")
+        env.add_source_files(env.scene_sources, "circle_shape_2d.cpp")
+        env.add_source_files(env.scene_sources, "concave_polygon_shape_2d.cpp")
+        env.add_source_files(env.scene_sources, "convex_polygon_shape_2d.cpp")
+        env.add_source_files(env.scene_sources, "rectangle_shape_2d.cpp")
+        env.add_source_files(env.scene_sources, "segment_shape_2d.cpp")
+        env.add_source_files(env.scene_sources, "separation_ray_shape_2d.cpp")
+        env.add_source_files(env.scene_sources, "shape_2d.cpp")
+        env.add_source_files(env.scene_sources, "world_boundary_shape_2d.cpp")
+    if not env["disable_navigation_2d"]:
+        env.add_source_files(env.scene_sources, "navigation_mesh_source_geometry_data_2d.cpp")
+        env.add_source_files(env.scene_sources, "navigation_polygon.cpp")
+        env.add_source_files(env.scene_sources, "polygon_path_finder.cpp")
+else:
+    env.add_source_files(env.scene_sources, "*.cpp")
 
 SConscript("skeleton/SCsub")

--- a/scene/resources/2d/skeleton/SCsub
+++ b/scene/resources/2d/skeleton/SCsub
@@ -3,14 +3,13 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-env.add_source_files(env.scene_sources, "skeleton_modification_2d.cpp")
-env.add_source_files(env.scene_sources, "skeleton_modification_2d_ccdik.cpp")
-env.add_source_files(env.scene_sources, "skeleton_modification_2d_fabrik.cpp")
-env.add_source_files(env.scene_sources, "skeleton_modification_2d_lookat.cpp")
-env.add_source_files(env.scene_sources, "skeleton_modification_2d_stackholder.cpp")
-env.add_source_files(env.scene_sources, "skeleton_modification_2d_twoboneik.cpp")
-env.add_source_files(env.scene_sources, "skeleton_modification_stack_2d.cpp")
-
-if not env["disable_physics_2d"]:
-    env.add_source_files(env.scene_sources, "skeleton_modification_2d_jiggle.cpp")
-    env.add_source_files(env.scene_sources, "skeleton_modification_2d_physicalbones.cpp")
+if env["disable_physics_2d"]:
+    env.add_source_files(env.scene_sources, "skeleton_modification_2d.cpp")
+    env.add_source_files(env.scene_sources, "skeleton_modification_2d_ccdik.cpp")
+    env.add_source_files(env.scene_sources, "skeleton_modification_2d_fabrik.cpp")
+    env.add_source_files(env.scene_sources, "skeleton_modification_2d_lookat.cpp")
+    env.add_source_files(env.scene_sources, "skeleton_modification_2d_stackholder.cpp")
+    env.add_source_files(env.scene_sources, "skeleton_modification_2d_twoboneik.cpp")
+    env.add_source_files(env.scene_sources, "skeleton_modification_stack_2d.cpp")
+else:
+    env.add_source_files(env.scene_sources, "*.cpp")

--- a/scene/resources/3d/SCsub
+++ b/scene/resources/3d/SCsub
@@ -3,26 +3,28 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-env.add_source_files(env.scene_sources, "fog_material.cpp")
-env.add_source_files(env.scene_sources, "importer_mesh.cpp")
-env.add_source_files(env.scene_sources, "mesh_library.cpp")
-env.add_source_files(env.scene_sources, "primitive_meshes.cpp")
-env.add_source_files(env.scene_sources, "skin.cpp")
-env.add_source_files(env.scene_sources, "sky_material.cpp")
-env.add_source_files(env.scene_sources, "world_3d.cpp")
-env.add_source_files(env.scene_sources, "skeleton/*.cpp")
+if env["disable_physics_3d"] or env["disable_navigation_3d"]:
+    env.add_source_files(env.scene_sources, "fog_material.cpp")
+    env.add_source_files(env.scene_sources, "importer_mesh.cpp")
+    env.add_source_files(env.scene_sources, "mesh_library.cpp")
+    env.add_source_files(env.scene_sources, "primitive_meshes.cpp")
+    env.add_source_files(env.scene_sources, "skin.cpp")
+    env.add_source_files(env.scene_sources, "sky_material.cpp")
+    env.add_source_files(env.scene_sources, "world_3d.cpp")
 
-if not env["disable_physics_3d"]:
-    env.add_source_files(env.scene_sources, "box_shape_3d.cpp")
-    env.add_source_files(env.scene_sources, "capsule_shape_3d.cpp")
-    env.add_source_files(env.scene_sources, "circle_shape_3d.cpp")
-    env.add_source_files(env.scene_sources, "concave_polygon_shape_3d.cpp")
-    env.add_source_files(env.scene_sources, "convex_polygon_shape_3d.cpp")
-    env.add_source_files(env.scene_sources, "cylinder_shape_3d.cpp")
-    env.add_source_files(env.scene_sources, "height_map_shape_3d.cpp")
-    env.add_source_files(env.scene_sources, "separation_ray_shape_3d.cpp")
-    env.add_source_files(env.scene_sources, "shape_3d.cpp")
-    env.add_source_files(env.scene_sources, "sphere_shape_3d.cpp")
-    env.add_source_files(env.scene_sources, "world_boundary_shape_3d.cpp")
-if not env["disable_navigation_3d"]:
-    env.add_source_files(env.scene_sources, "navigation_mesh_source_geometry_data_3d.cpp")
+    if not env["disable_physics_3d"]:
+        env.add_source_files(env.scene_sources, "box_shape_3d.cpp")
+        env.add_source_files(env.scene_sources, "capsule_shape_3d.cpp")
+        env.add_source_files(env.scene_sources, "circle_shape_3d.cpp")
+        env.add_source_files(env.scene_sources, "concave_polygon_shape_3d.cpp")
+        env.add_source_files(env.scene_sources, "convex_polygon_shape_3d.cpp")
+        env.add_source_files(env.scene_sources, "cylinder_shape_3d.cpp")
+        env.add_source_files(env.scene_sources, "height_map_shape_3d.cpp")
+        env.add_source_files(env.scene_sources, "separation_ray_shape_3d.cpp")
+        env.add_source_files(env.scene_sources, "shape_3d.cpp")
+        env.add_source_files(env.scene_sources, "sphere_shape_3d.cpp")
+        env.add_source_files(env.scene_sources, "world_boundary_shape_3d.cpp")
+    if not env["disable_navigation_3d"]:
+        env.add_source_files(env.scene_sources, "navigation_mesh_source_geometry_data_3d.cpp")
+else:
+    env.add_source_files(env.scene_sources, "*.cpp")

--- a/servers/navigation/SCsub
+++ b/servers/navigation/SCsub
@@ -3,10 +3,13 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-if not env["disable_navigation_2d"]:
-    env.add_source_files(env.servers_sources, "navigation_path_query_parameters_2d.cpp")
-    env.add_source_files(env.servers_sources, "navigation_path_query_result_2d.cpp")
+if env["disable_navigation_2d"] or env["disable_navigation_3d"]:
+    if not env["disable_navigation_2d"]:
+        env.add_source_files(env.servers_sources, "navigation_path_query_parameters_2d.cpp")
+        env.add_source_files(env.servers_sources, "navigation_path_query_result_2d.cpp")
 
-if not env["disable_navigation_3d"]:
-    env.add_source_files(env.servers_sources, "navigation_path_query_parameters_3d.cpp")
-    env.add_source_files(env.servers_sources, "navigation_path_query_result_3d.cpp")
+    if not env["disable_navigation_3d"]:
+        env.add_source_files(env.servers_sources, "navigation_path_query_parameters_3d.cpp")
+        env.add_source_files(env.servers_sources, "navigation_path_query_result_3d.cpp")
+else:
+    env.add_source_files(env.servers_sources, "*.cpp")


### PR DESCRIPTION
* Adds ability in `scu_builders.py` to process folders recursively
* adds Jolt to the SCU build (15 second improvement)
* updates 2D and 3D `scene/resources` SCsub files to enable SCU building
* updates navigation to accelerate

Overall this gives 30-40 second improvement to build times for me (from 2min25 full rebuild excluding thirdparty & platform).

### Disables
The reason the resource `SCsub` files weren't working is because the SCU recognises `*.cpp` in a folder but doesn't recognise the pattern of `if not env["disable_physics_2d"]:`. In order to get around this it now detects if there are no disables, and if not, `add_source_files "*.cpp"`.

This means that in SCU builds these folders will be accelerated _unless_ you disable these parts from the build via scons etc, in which case they revert to the old build method.

### Jolt
Jolt gives quite an improvement as both the thirdparty files and the jolt module are accelerated.
In response to feedback I've added the `process_folder_recursive()` function which enables adding all the jolt subfolders via a one-liner, this should greatly reduce any maintenance concerns.

This globs all the folders recursively (except some standard excludes like `.scu/` etc), and allows specifying optionally folders _not_ to include. This is the opposite spirit to the existing `process_folder()` which specifies which folders to include explicitly.

```
# The second list here is a list of subfolders that are not required to be built.
process_folder_recursive("thirdparty/jolt_physics/Jolt", ["NodeCodec", "TriangleCodec", "ConstraintPart"])
process_folder_recursive("modules/jolt_physics")
```

## Notes
* As I've added the new folder globbing this probably needs review by someone who is python proficient (I rarely use python :slightly_smiling_face: )
* Also brings in the possibility of platform specific bugs with the slashing (which can differ linux / windows), so would appreciate if someone could test on windows as I don't have a windows machine.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
