### PR TITLE
Fix FileSystemTree rename TextEdit is offset

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2358,7 +2358,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				}
 			}
 
-			if ((select_mode == SELECT_ROW && selected_item == p_item) || p_item->cells[i].selected || !p_item->has_meta("__focus_rect")) {
+			if ((select_mode != SELECT_SINGLE && selected_item == p_item) || p_item->cells[i].selected || !p_item->has_meta("__focus_rect")) {
 				Rect2i r = cell_rect;
 
 				if (select_mode != SELECT_ROW) {


### PR DESCRIPTION
Before:
![filesystem2](https://github.com/user-attachments/assets/4ae44ce8-0748-4731-b0ae-78e6c415e2d0)
After:
![filesystem1](https://github.com/user-attachments/assets/b30b383e-9463-46ad-82e7-789f9abb0ddb)

Steps to reproduce:
1. Select a file in FileSystemTree;
2. Press arrow key to change selected file;
3. Scroll;
4. Press rename shortcut to rename;
Rename TextEdit is offset.

The issue is reported in #105677 first.
