### PR TITLE
[Android] Store native libraries uncompressed in APK

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -785,7 +785,7 @@ Error EditorExportPlatformAndroid::save_apk_so(void *p_userdata, const SharedObj
 			String abi = abis[abi_index].abi;
 			String dst_path = String("lib").path_join(abi).path_join(p_so.path.get_file());
 			Vector<uint8_t> array = FileAccess::get_file_as_bytes(p_so.path);
-			Error store_err = store_in_apk(ed, dst_path, array);
+			Error store_err = store_in_apk(ed, dst_path, array, Z_NO_COMPRESSION);
 			ERR_FAIL_COND_V_MSG(store_err, store_err, "Cannot store in apk file '" + dst_path + "'.");
 		}
 	}


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/106148.

It looks like since we bumped the minSdk version to 24, native libraries now are expected to be uncompressed but the `save_apk_so` method was saving them compressed (because the default value for the `compression_method`  parameter is [`Z_DEFLATED`](https://github.com/godotengine/godot/blob/19bb18716ef08b811fec330cba4d35fbdb027bcc/platform/android/export/export_plugin.h#L148)).

As a result, exported C# projects failed to install with this error:

```
adb: failed to install Test.apk: Failure [INSTALL_FAILED_INVALID_APK: INSTALL_FAILED_INVALID_APK: Failed to extract native libraries, res=-2]
Library 'libSystem.Security.Cryptography.Native.Android.so' is compressed - will not be able to open it directly from apk.
Failure copying native libraries [errorCode=-2]
```

Since C# exports use the `EditorExportPlugin::add_shared_object` API which ends up going through `save_apk_so` and compresses the native library.

This PR changes the `store_in_apk` invocation to explicitly avoid compressing the native library and fixes installing exported C# projects, although I don't know if it breaks other scenarios.