### PR TITLE
Make NavigationServer backend engine selectable

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1608,8 +1608,14 @@
 		<member name="NavigationServer2D" type="NavigationServer2D" setter="" getter="">
 			The [NavigationServer2D] singleton.
 		</member>
+		<member name="NavigationServer2DManager" type="NavigationServer2DManager" setter="" getter="">
+			The [NavigationServer2DManager] singleton.
+		</member>
 		<member name="NavigationServer3D" type="NavigationServer3D" setter="" getter="">
 			The [NavigationServer3D] singleton.
+		</member>
+		<member name="NavigationServer3DManager" type="NavigationServer3DManager" setter="" getter="">
+			The [NavigationServer3DManager] singleton.
 		</member>
 		<member name="OS" type="OS" setter="" getter="">
 			The [OS] singleton.

--- a/doc/classes/NavigationServer2DManager.xml
+++ b/doc/classes/NavigationServer2DManager.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NavigationServer2DManager" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A singleton for managing [NavigationServer2D] implementations.
+	</brief_description>
+	<description>
+		[NavigationServer2DManager] is the API for registering [NavigationServer2D] implementations and setting the default implementation.
+		[b]Note:[/b] It is not possible to switch servers at runtime. This class is only used on startup at the server initialization level.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="register_server">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="create_callback" type="Callable" />
+			<description>
+				Registers a [NavigationServer2D] implementation by passing a [param name] and a [Callable] that returns a [NavigationServer2D] object.
+			</description>
+		</method>
+		<method name="set_default_server">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="priority" type="int" />
+			<description>
+				Sets the default [NavigationServer2D] implementation to the one identified by [param name], if [param priority] is greater than the priority of the current default implementation.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/NavigationServer3DManager.xml
+++ b/doc/classes/NavigationServer3DManager.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NavigationServer3DManager" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A singleton for managing [NavigationServer3D] implementations.
+	</brief_description>
+	<description>
+		[NavigationServer3DManager] is the API for registering [NavigationServer3D] implementations and setting the default implementation.
+		[b]Note:[/b] It is not possible to switch servers at runtime. This class is only used on startup at the server initialization level.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="register_server">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="create_callback" type="Callable" />
+			<description>
+				Registers a [NavigationServer3D] implementation by passing a [param name] and a [Callable] that returns a [NavigationServer3D] object.
+			</description>
+		</method>
+		<method name="set_default_server">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="priority" type="int" />
+			<description>
+				Sets the default [NavigationServer3D] implementation to the one identified by [param name], if [param priority] is greater than the priority of the current default implementation.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2348,6 +2348,13 @@
 		<member name="navigation/2d/merge_rasterizer_cell_scale" type="float" setter="" getter="" default="1.0">
 			Default merge rasterizer cell scale for 2D navigation maps. See [method NavigationServer2D.map_set_merge_rasterizer_cell_scale].
 		</member>
+		<member name="navigation/2d/navigation_engine" type="String" setter="" getter="" default="&quot;DEFAULT&quot;">
+			Sets which navigation engine to use for 2D navigation.
+			[b]DEFAULT[/b] is equivalent to [b]GodotNavigation2D[/b], but may change in future releases. Select an explicit implementation if you want to ensure that your project stays on the same engine.
+			[b]GodotNavigation2D[/b] is Godot's internal 2D navigation engine.
+			[b]Dummy[/b] is a 2D navigation server that does nothing and returns only dummy values, effectively disabling all 2D navigation functionality.
+			Third-party modules can add other navigation engines to select with this setting.
+		</member>
 		<member name="navigation/2d/use_edge_connections" type="bool" setter="" getter="" default="true">
 			If enabled 2D navigation regions will use edge connections to connect with other navigation regions within proximity of the navigation map edge connection margin. This setting only affects World2D default navigation maps.
 		</member>
@@ -2374,6 +2381,13 @@
 		</member>
 		<member name="navigation/3d/merge_rasterizer_cell_scale" type="float" setter="" getter="" default="1.0">
 			Default merge rasterizer cell scale for 3D navigation maps. See [method NavigationServer3D.map_set_merge_rasterizer_cell_scale].
+		</member>
+		<member name="navigation/3d/navigation_engine" type="String" setter="" getter="" default="&quot;DEFAULT&quot;">
+			Sets which navigation engine to use for 3D navigation.
+			[b]DEFAULT[/b] is equivalent to [b]GodotNavigation3D[/b], but may change in future releases. Select an explicit implementation if you want to ensure that your project stays on the same engine.
+			[b]GodotNavigation3D[/b] is Godot's internal 3D navigation engine.
+			[b]Dummy[/b] is a 3D navigation server that does nothing and returns only dummy values, effectively disabling all 3D navigation functionality.
+			Third-party modules can add other navigation engines to select with this setting.
 		</member>
 		<member name="navigation/3d/use_edge_connections" type="bool" setter="" getter="" default="true">
 			If enabled 3D navigation regions will use edge connections to connect with other navigation regions within proximity of the navigation map edge connection margin. This setting only affects World3D default navigation maps.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -746,6 +746,13 @@ Error Main::test_setup() {
 	physics_server_2d_manager = memnew(PhysicsServer2DManager);
 #endif // PHYSICS_2D_DISABLED
 
+#ifndef NAVIGATION_2D_DISABLED
+	NavigationServer2DManager::initialize_server_manager();
+#endif // NAVIGATION_2D_DISABLED
+#ifndef NAVIGATION_3D_DISABLED
+	NavigationServer3DManager::initialize_server_manager();
+#endif // NAVIGATION_3D_DISABLED
+
 	// From `Main::setup2()`.
 	register_early_core_singletons();
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
@@ -863,9 +870,11 @@ void Main::test_cleanup() {
 
 #ifndef NAVIGATION_2D_DISABLED
 	NavigationServer2DManager::finalize_server();
+	NavigationServer2DManager::finalize_server_manager();
 #endif // NAVIGATION_2D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
 	NavigationServer3DManager::finalize_server();
+	NavigationServer3DManager::finalize_server_manager();
 #endif // NAVIGATION_3D_DISABLED
 
 	GDExtensionManager::get_singleton()->deinitialize_extensions(GDExtension::INITIALIZATION_LEVEL_SERVERS);
@@ -3018,6 +3027,13 @@ Error Main::setup2(bool p_show_boot_logo) {
 	physics_server_2d_manager = memnew(PhysicsServer2DManager);
 #endif // PHYSICS_2D_DISABLED
 
+#ifndef NAVIGATION_2D_DISABLED
+	NavigationServer2DManager::initialize_server_manager();
+#endif // NAVIGATION_2D_DISABLED
+#ifndef NAVIGATION_3D_DISABLED
+	NavigationServer3DManager::initialize_server_manager();
+#endif // NAVIGATION_3D_DISABLED
+
 	register_server_types();
 	{
 		OS::get_singleton()->benchmark_begin_measure("Servers", "Modules and Extensions");
@@ -4979,9 +4995,11 @@ void Main::cleanup(bool p_force) {
 // Before deinitializing server extensions, finalize servers which may be loaded as extensions.
 #ifndef NAVIGATION_2D_DISABLED
 	NavigationServer2DManager::finalize_server();
+	NavigationServer2DManager::finalize_server_manager();
 #endif // NAVIGATION_2D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
 	NavigationServer3DManager::finalize_server();
+	NavigationServer3DManager::finalize_server_manager();
 #endif // NAVIGATION_3D_DISABLED
 	finalize_physics();
 

--- a/modules/navigation_2d/register_types.cpp
+++ b/modules/navigation_2d/register_types.cpp
@@ -41,13 +41,14 @@
 #include "editor/navigation_region_2d_editor_plugin.h"
 #endif
 
-NavigationServer2D *new_navigation_server_2d() {
+static NavigationServer2D *_createGodotNavigation2DCallback() {
 	return memnew(GodotNavigationServer2D);
 }
 
 void initialize_navigation_2d_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SERVERS) {
-		NavigationServer2DManager::set_default_server(new_navigation_server_2d);
+		NavigationServer2DManager::get_singleton()->register_server("GodotNavigation2D", callable_mp_static(_createGodotNavigation2DCallback));
+		NavigationServer2DManager::get_singleton()->set_default_server("GodotNavigation2D");
 	}
 
 #ifdef TOOLS_ENABLED

--- a/modules/navigation_3d/register_types.cpp
+++ b/modules/navigation_3d/register_types.cpp
@@ -49,13 +49,14 @@
 NavigationMeshGenerator *_nav_mesh_generator = nullptr;
 #endif // DISABLE_DEPRECATED
 
-NavigationServer3D *new_navigation_server_3d() {
+static NavigationServer3D *_createGodotNavigation3DCallback() {
 	return memnew(GodotNavigationServer3D);
 }
 
 void initialize_navigation_3d_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SERVERS) {
-		NavigationServer3DManager::set_default_server(new_navigation_server_3d);
+		NavigationServer3DManager::get_singleton()->register_server("GodotNavigation3D", callable_mp_static(_createGodotNavigation3DCallback));
+		NavigationServer3DManager::get_singleton()->set_default_server("GodotNavigation3D");
 
 #ifndef DISABLE_DEPRECATED
 		_nav_mesh_generator = memnew(NavigationMeshGenerator);

--- a/servers/navigation_3d/navigation_server_3d.h
+++ b/servers/navigation_3d/navigation_server_3d.h
@@ -519,18 +519,63 @@ public:
 #endif // DEBUG_ENABLED
 };
 
-typedef NavigationServer3D *(*NavigationServer3DCallback)();
-
 /// Manager used for the server singleton registration
-class NavigationServer3DManager {
-	static NavigationServer3DCallback create_callback;
+class NavigationServer3DManager : public Object {
+	GDCLASS(NavigationServer3DManager, Object);
+
+	static inline NavigationServer3DManager *singleton = nullptr;
+
+	struct ClassInfo {
+		String name;
+		Callable create_callback;
+
+		ClassInfo() {}
+
+		ClassInfo(const String &p_name, const Callable &p_create_callback) :
+				name(p_name),
+				create_callback(p_create_callback) {}
+
+		ClassInfo(const ClassInfo &p_ci) :
+				name(p_ci.name),
+				create_callback(p_ci.create_callback) {}
+
+		void operator=(const ClassInfo &p_ci) {
+			name = p_ci.name;
+			create_callback = p_ci.create_callback;
+		}
+	};
+
+	Vector<ClassInfo> navigation_servers;
+	int default_server_id = -1;
+	int default_server_priority = -1;
+
+	void on_servers_changed();
+
+protected:
+	static void _bind_methods();
 
 public:
-	static void set_default_server(NavigationServer3DCallback p_callback);
-	static NavigationServer3D *new_default_server();
+	static const String setting_property_name;
+
+	static NavigationServer3DManager *get_singleton();
+
+	void register_server(const String &p_name, const Callable &p_create_callback);
+	void set_default_server(const String &p_name, int p_priority = 0);
+	int find_server_id(const String &p_name);
+	int get_servers_count();
+	String get_server_name(int p_id);
+	NavigationServer3D *new_default_server();
+	NavigationServer3D *new_server(const String &p_name);
+
+	NavigationServer3DManager();
+	~NavigationServer3DManager();
 
 	static void initialize_server();
 	static void finalize_server();
+
+	static void initialize_server_manager();
+	static void finalize_server_manager();
+	static NavigationServer3D *create_dummy_server_callback();
 };
 
 VARIANT_ENUM_CAST(NavigationServer3D::ProcessInfo);

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -261,9 +261,16 @@ void register_server_types() {
 	ServersDebugger::initialize();
 
 #ifndef NAVIGATION_2D_DISABLED
+	GDREGISTER_CLASS(NavigationServer2DManager);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer2DManager", NavigationServer2DManager::get_singleton(), "NavigationServer2DManager"));
+
 	GDREGISTER_ABSTRACT_CLASS(NavigationServer2D);
 	GDREGISTER_CLASS(NavigationPathQueryParameters2D);
 	GDREGISTER_CLASS(NavigationPathQueryResult2D);
+
+	GLOBAL_DEF(PropertyInfo(Variant::STRING, NavigationServer2DManager::setting_property_name, PROPERTY_HINT_ENUM, "DEFAULT"), "DEFAULT");
+
+	NavigationServer2DManager::get_singleton()->register_server("Dummy", callable_mp_static(NavigationServer2DManager::create_dummy_server_callback));
 #endif // NAVIGATION_2D_DISABLED
 
 #ifndef PHYSICS_2D_DISABLED
@@ -295,9 +302,16 @@ void register_server_types() {
 #endif // PHYSICS_2D_DISABLED
 
 #ifndef NAVIGATION_3D_DISABLED
+	GDREGISTER_CLASS(NavigationServer3DManager);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer3DManager", NavigationServer3DManager::get_singleton(), "NavigationServer3DManager"));
+
 	GDREGISTER_ABSTRACT_CLASS(NavigationServer3D);
 	GDREGISTER_CLASS(NavigationPathQueryParameters3D);
 	GDREGISTER_CLASS(NavigationPathQueryResult3D);
+
+	GLOBAL_DEF(PropertyInfo(Variant::STRING, NavigationServer3DManager::setting_property_name, PROPERTY_HINT_ENUM, "DEFAULT"), "DEFAULT");
+
+	NavigationServer3DManager::get_singleton()->register_server("Dummy", callable_mp_static(NavigationServer3DManager::create_dummy_server_callback));
 #endif // NAVIGATION_3D_DISABLED
 
 #ifndef PHYSICS_3D_DISABLED

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -368,10 +368,10 @@ struct GodotTestCaseListener : public doctest::IReporter {
 
 			ERR_PRINT_OFF;
 #ifndef NAVIGATION_3D_DISABLED
-			navigation_server_3d = NavigationServer3DManager::new_default_server();
+			navigation_server_3d = NavigationServer3DManager::get_singleton()->new_default_server();
 #endif // NAVIGATION_3D_DISABLED
 #ifndef NAVIGATION_2D_DISABLED
-			navigation_server_2d = NavigationServer2DManager::new_default_server();
+			navigation_server_2d = NavigationServer2DManager::get_singleton()->new_default_server();
 #endif // NAVIGATION_2D_DISABLED
 			ERR_PRINT_ON;
 
@@ -407,7 +407,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 #ifndef NAVIGATION_3D_DISABLED
 		if (suite_name.contains("[Navigation3D]") && navigation_server_3d == nullptr) {
 			ERR_PRINT_OFF;
-			navigation_server_3d = NavigationServer3DManager::new_default_server();
+			navigation_server_3d = NavigationServer3DManager::get_singleton()->new_default_server();
 			ERR_PRINT_ON;
 			return;
 		}
@@ -416,7 +416,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 #ifndef NAVIGATION_2D_DISABLED
 		if (suite_name.contains("[Navigation2D]") && navigation_server_2d == nullptr) {
 			ERR_PRINT_OFF;
-			navigation_server_2d = NavigationServer2DManager::new_default_server();
+			navigation_server_2d = NavigationServer2DManager::get_singleton()->new_default_server();
 			ERR_PRINT_ON;
 			return;
 		}


### PR DESCRIPTION
Adds engine backend selection for NavigationServers.

![navengine](https://github.com/user-attachments/assets/fc6ae850-2bee-4778-929c-0df68a32df53)

Allows to swap navigation module for other backend implementations same as e.g. done for physics where users can select the physics engine between GodotPhysics and Jolt or Dummy. Copies mostly the code from the physics version of this.

Since Godot does not really have another navigation backend available for now the main use is to select the NavigationServerDummy for testing or to have it available without recompiling the engine for games that do not need the 2d/3d navigation server system.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
