### PR TITLE
Improve `Timer::start` error message.

### DIFF
--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -114,7 +114,7 @@ bool Timer::has_autostart() const {
 }
 
 void Timer::start(double p_time) {
-	ERR_FAIL_COND_MSG(!is_inside_tree(), "Timer was not added to the SceneTree. Either add it or set autostart to true.");
+	ERR_FAIL_COND_MSG(!is_inside_tree(), "Unable to start the timer because it's not inside the scene tree. Either add it or set autostart to true.");
 
 	if (p_time > 0) {
 		set_wait_time(p_time);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

The current message can be confusing in scenarios where the Timer was indeed added to the scene tree previously.

Closes #106275.