### PR TITLE
FileAccess: Introduce advance() for skipping bytes

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -294,6 +294,10 @@ String FileAccess::fix_path(const String &p_path) const {
 	return r_path;
 }
 
+void FileAccess::advance(int64_t p_offset) {
+	seek(get_position() + p_offset);
+}
+
 /* these are all implemented for ease of porting, then can later be optimized */
 uint8_t FileAccess::get_8() const {
 	uint8_t data = 0;
@@ -966,6 +970,7 @@ void FileAccess::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_path"), &FileAccess::get_path);
 	ClassDB::bind_method(D_METHOD("get_path_absolute"), &FileAccess::get_path_absolute);
 	ClassDB::bind_method(D_METHOD("is_open"), &FileAccess::is_open);
+	ClassDB::bind_method(D_METHOD("advance", "offset"), &FileAccess::advance);
 	ClassDB::bind_method(D_METHOD("seek", "position"), &FileAccess::seek);
 	ClassDB::bind_method(D_METHOD("seek_end", "position"), &FileAccess::seek_end, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_position"), &FileAccess::get_position);

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -163,6 +163,7 @@ public:
 	virtual String get_path() const { return ""; } /// returns the path for the current open file
 	virtual String get_path_absolute() const { return ""; } /// returns the absolute path for the current open file
 
+	void advance(int64_t p_offset); ///< advance a specific amount of bytes
 	virtual void seek(uint64_t p_position) = 0; ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0) = 0; ///< seek from the end of file with negative offset
 	virtual uint64_t get_position() const = 0; ///< get position in the file

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -42,6 +42,13 @@
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/2755</link>
 	</tutorials>
 	<methods>
+		<method name="advance">
+			<return type="void" />
+			<param index="0" name="offset" type="int" />
+			<description>
+				Shifts the file reading/writing cursor by the specified offset (in bytes from the cursor's current position).
+			</description>
+		</method>
 		<method name="close">
 			<return type="void" />
 			<description>


### PR DESCRIPTION
This adds a `advance(offset)` method to _FileAccess_, providing a more readable & streamlined way to move the file cursor forward/backward. Unless I'm missing something, the only way to do this is by manually calling `seek(file.get_position() + amount)`, which feels unnecessarily verbose for an operation like this. While you can also use methods like `get_32()` or `get_buffer()` to advance the cursor, these actually read data into memory, which is something that can negatively impact performance when skipping over large segments (it's also not very explicit that these functions do that). This method offers a more readable and purpose-specific alternative. 