### PR TITLE
Avoid single character `String` allocations when appending characters

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -142,15 +142,18 @@ String Resource::generate_scene_unique_id() {
 	static constexpr uint32_t char_count = ('z' - 'a');
 	static constexpr uint32_t base = char_count + ('9' - '0');
 	String id;
+	id.resize(characters + 1);
+	char32_t *ptr = id.ptrw();
 	for (uint32_t i = 0; i < characters; i++) {
 		uint32_t c = random_num % base;
 		if (c < char_count) {
-			id += String::chr('a' + c);
+			ptr[i] = ('a' + c);
 		} else {
-			id += String::chr('0' + (c - char_count));
+			ptr[i] = ('0' + (c - char_count));
 		}
 		random_num /= base;
 	}
+	ptr[characters] = '\0';
 
 	return id;
 }

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -408,7 +408,7 @@ Error Expression::_get_token(Token &r_token) {
 						if (reading == READING_DONE) {
 							break;
 						}
-						num += String::chr(c);
+						num += c;
 						c = GET_CHAR();
 						is_first_char = false;
 					}
@@ -435,7 +435,7 @@ Error Expression::_get_token(Token &r_token) {
 					cchar = GET_CHAR();
 
 					while (is_unicode_identifier_continue(cchar)) {
-						id += String::chr(cchar);
+						id += cchar;
 						cchar = GET_CHAR();
 					}
 

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1757,7 +1757,7 @@ Error VariantParser::_parse_tag(Token &token, Stream *p_stream, int &line, Strin
 				} else {
 					escaping = false;
 				}
-				r_tag.name += String::chr(c);
+				r_tag.name += c;
 			}
 		}
 
@@ -1902,7 +1902,7 @@ Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &line, String &r
 				what = tk.value;
 
 			} else if (c != '=') {
-				what += String::chr(c);
+				what += c;
 			} else {
 				r_assign = what;
 				Token token;


### PR DESCRIPTION
Removed calls to `String::chr()` when appending characters to `Strings` in `Expression`, `Resource`, and `VariantParser`, to avoid creating temporary `Strings` for each character.  Also updated the `Resource` case to resize `String` up front, since size is known.

This makes `Expression.parse` around 50% faster, `Resource.generate_scene_unique_id` around 5x faster, and `ConfigFile.load` around 25% faster, compared with gdscript below:

```gdscript
func _ready() -> void:
	run_test("expression_parse")
	run_test("resource_unique_id")
	run_test("load_config")
	
func run_test(p_name : String):
	var start := Time.get_ticks_msec()
	call(p_name)
	var end := Time.get_ticks_msec()
	print("%s: %dms" % [p_name, end - start])

func expression_parse():
	var expression := Expression.new()
	for i in 100000:
		expression.parse("12345 + 67890 - sqrt(1000000)")

func resource_unique_id():
	for i in 1000000:
		Resource.generate_scene_unique_id()

func load_config():
	for i in 1000:
		var config := ConfigFile.new()
		config.load("res://icon.svg.import")
```

old:
```
expression_parse: 380ms
resource_unique_id: 447ms
load_config: 118ms
```

new:
```
expression_parse: 253ms
resource_unique_id: 80ms
load_config: 91ms
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
