### PR TITLE
Add notes about the signs of Projection functions

### DIFF
--- a/doc/classes/Projection.xml
+++ b/doc/classes/Projection.xml
@@ -174,12 +174,14 @@
 			<return type="float" />
 			<description>
 				Returns the X:Y aspect ratio of this [Projection]'s viewport.
+				[b]Note:[/b] The returned value may be negative.
 			</description>
 		</method>
 		<method name="get_far_plane_half_extents" qualifiers="const">
 			<return type="Vector2" />
 			<description>
 				Returns the dimensions of the far clipping plane of the projection, divided by two.
+				[b]Note:[/b] Either of the components of the returned vector may be negative.
 			</description>
 		</method>
 		<method name="get_fov" qualifiers="const">
@@ -222,6 +224,7 @@
 			<return type="Vector2" />
 			<description>
 				Returns the dimensions of the viewport plane that this [Projection] projects positions onto, divided by two.
+				[b]Note:[/b] Either of the components of the returned vector may be negative.
 			</description>
 		</method>
 		<method name="get_z_far" qualifiers="const">
@@ -234,6 +237,7 @@
 			<return type="float" />
 			<description>
 				Returns the distance for this [Projection] before which positions are clipped.
+				[b]Note:[/b] The returned value may be negative.
 			</description>
 		</method>
 		<method name="inverse" qualifiers="const">


### PR DESCRIPTION
Partially fixes #106312.

I've added notes in the descriptions of Projection's get_z_near and get_aspect functions about how they can return negatives values. While testing out more functions, I also realized that get_far_plane_half_extents, get_pixels_per_meter, and get_viewport_half_extents can all also be negative.

In 4.4, get_z_near could return a negative and get_pixels_per_meter was always positive, but it seems both of these functions have changed along the way. Just in case these end up being a bug, I've left the descriptions of them alone.