### PR TITLE
Change Occlusion Culling Buffer debug view to use log scaling

### DIFF
--- a/servers/rendering/renderer_scene_occlusion_cull.cpp
+++ b/servers/rendering/renderer_scene_occlusion_cull.cpp
@@ -186,7 +186,7 @@ RID RendererSceneOcclusionCull::HZBuffer::get_debug_texture() {
 
 	unsigned char *ptrw = debug_data.ptrw();
 	for (int i = 0; i < debug_data.size(); i++) {
-		ptrw[i] = MIN(mips[0][i] / debug_tex_range, 1.0) * 255;
+		ptrw[i] = MIN(Math::log(1.0 + mips[0][i]) / Math::log(1.0 + debug_tex_range), 1.0) * 255;
 	}
 
 	debug_image->set_data(sizes[0].x, sizes[0].y, false, Image::FORMAT_L8, debug_data);


### PR DESCRIPTION
This changes the Occlusion Culling Buffer debug view to use a log gradient instead of a linear gradient.

Before:
![image](https://github.com/user-attachments/assets/968b4d94-a826-48dc-8db6-fd375cb55338)

After:
![image](https://github.com/user-attachments/assets/7df8d5a8-2b1f-4a89-8765-a1562991ab72)

This came out of a discussion in #106184 where @snowflower pointed out the limited use of the Occlusion Culling Buffer debug view due to it being mostly black and white by default and requiring changes to the camera z-far setting to introduce gradients.