### PR TITLE
macOS: Process first click event without requiring focus

### DIFF
--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -68,6 +68,10 @@
 
 @implementation GodotContentView
 
+- (BOOL)acceptsFirstMouse:(NSEvent *)event {
+	return YES;
+}
+
 - (void)setFrameSize:(NSSize)newSize {
 	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
 	if (ds && ds->has_window(window_id)) {


### PR DESCRIPTION
This improves the user experience for macOS users, to be consistent with other macOS applications. When a Godot window is not focused, and the user clicks on the window, the event is forwarded to the receiving control to be processed as if the window was already focused. This is the same behaviour as applications like Safari, Blender, CLion, Xcode, etc.

https://github.com/user-attachments/assets/fe9f708e-0f1a-4260-9f9a-87ddd982eaec

Note the following points in this video:

I launch the project as embedded, and then move focus of the Godot editor to another application.

> [!NOTE]
>
> When the window focus is on an application other than the Godot editor, and the traffic lights are greyed out, I can still click **Stop**

Next, I launch with a separate embedded window

> [!NOTE]
>
> When the separate embedded window is focused, I can still click **Stop**