### PR TITLE
[Web] Add WebAssembly SIMD support (`wasm_simd`) and enable it by default

### DIFF
--- a/modules/jolt_physics/SCsub
+++ b/modules/jolt_physics/SCsub
@@ -6,6 +6,12 @@ Import("env_modules")
 
 env_jolt = env_modules.Clone()
 
+# Platform specific flags.
+if env["platform"] == "web" and env["wasm_simd"]:
+    # Enable SSE 4.2 so that WebAssembly SIMD can benefit from it.
+    # SSE 4.2 is the highest version supported by WebAssembly SIMD.
+    env_jolt.Append(CCFLAGS=["-msse4.2"])
+
 # Thirdparty source files
 
 thirdparty_dir = "#thirdparty/jolt_physics/"

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -57,6 +57,7 @@ def get_opts():
             "Use Emscripten PROXY_TO_PTHREAD option to run the main application code to a separate thread",
             False,
         ),
+        BoolVariable("wasm_simd", "Use WebAssembly SIMD to improve CPU performance", True),
     ]
 
 
@@ -275,6 +276,10 @@ def configure(env: "SConsEnvironment"):
         env.Append(LINKFLAGS=["-sEXPORTED_RUNTIME_METHODS=['_emscripten_proxy_main']"])
         # https://github.com/emscripten-core/emscripten/issues/18034#issuecomment-1277561925
         env.Append(LINKFLAGS=["-sTEXTDECODER=0"])
+
+    # Enable WebAssembly SIMD
+    if env["wasm_simd"]:
+        env.Append(CCFLAGS=["-msimd128"])
 
     # Reduce code size by generating less support code (e.g. skip NodeJS support).
     env.Append(LINKFLAGS=["-sENVIRONMENT=web,worker"])


### PR DESCRIPTION
This PR adds WebAssembly [SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) support (by default).
This new option is a boolean named `wasm_simd=[yes|no]`.

SIMD improves CPU performance **by a lot** when supported. Pretty important when most Web games run single threaded.

From [Can I Use...](https://caniuse.com/wasm-simd), it seems that WebAssembly SIMD is supported on major browsers for about two years now. The [Wonderland Engine](https://wonderlandengine.com/) (a game engine optimized for the Web) [just announced](https://wonderlandengine.com/news/release-1.4.0/#always-simd) that they drop support for non-SIMD exports on their latest release, arguing that SIMD support is pretty much a given nowadays.

### Demos
| Demo name | without SIMD | with SIMD |
| :---: | :---: | :---: |
| Jolt Physics<br>(with @passivestar's demo) | https://adamscott.github.io/godot-physics-demo-without-simd/ | https://adamscott.github.io/godot-physics-demo-with-simd/ |
| Array copy | https://adamscott.github.io/godot-array-copy-without-simd/ | https://adamscott.github.io/godot-array-copy-with-simd/ |

> [!NOTE]
> I promised I would shoutout @Squareys (Jonathan Hale from the Wonderland Engine) for the suggestion. It seems that using SIMD really does a difference.