### PR TITLE
SoftBody3D: Add a property for scaling rest lengths of edge constraints

### DIFF
--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1121,6 +1121,13 @@
 				Returns the pressure coefficient of the given soft body.
 			</description>
 		</method>
+		<method name="soft_body_get_shrinking_factor" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the shrinking factor of the given soft body.
+			</description>
+		</method>
 		<method name="soft_body_get_simulation_precision" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
@@ -1256,6 +1263,14 @@
 			<param index="1" name="enable" type="bool" />
 			<description>
 				Sets whether the given soft body will be pickable when using object picking.
+			</description>
+		</method>
+		<method name="soft_body_set_shrinking_factor">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shrinking_factor" type="float" />
+			<description>
+				Sets the shrinking factor of the given soft body.
 			</description>
 		</method>
 		<method name="soft_body_set_simulation_precision">

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -1049,6 +1049,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_soft_body_get_shrinking_factor" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_soft_body_get_simulation_precision" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
@@ -1163,6 +1169,13 @@
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_shrinking_factor" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shrinking_factor" type="float" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -124,6 +124,10 @@
 		<member name="ray_pickable" type="bool" setter="set_ray_pickable" getter="is_ray_pickable" default="true">
 			If [code]true[/code], the [SoftBody3D] will respond to [RayCast3D]s.
 		</member>
+		<member name="shrinking_factor" type="float" setter="set_shrinking_factor" getter="get_shrinking_factor" default="0.0">
+			Scales the rest lengths of [SoftBody3D]'s edge constraints. Positive values shrink the mesh, while negative values expand it. For example, a value of [code]0.1[/code] shortens the edges of the mesh by 10%, while [code]-0.1[/code] expands the edges by 10%.
+			[b]Note:[/b] [member shrinking_factor] is best used on surface meshes with pinned points.
+		</member>
 		<member name="simulation_precision" type="int" setter="set_simulation_precision" getter="get_simulation_precision" default="5">
 			Increasing this value will improve the resulting simulation, but can affect performance. Use with care.
 		</member>

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1104,6 +1104,20 @@ real_t GodotPhysicsServer3D::soft_body_get_linear_stiffness(RID p_body) const {
 	return soft_body->get_linear_stiffness();
 }
 
+void GodotPhysicsServer3D::soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(soft_body);
+
+	soft_body->set_shrinking_factor(p_shrinking_factor);
+}
+
+real_t GodotPhysicsServer3D::soft_body_get_shrinking_factor(RID p_body) const {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(soft_body, 0.f);
+
+	return soft_body->get_shrinking_factor();
+}
+
 void GodotPhysicsServer3D::soft_body_set_pressure_coefficient(RID p_body, real_t p_pressure_coefficient) {
 	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(soft_body);

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -289,6 +289,9 @@ public:
 	virtual void soft_body_set_linear_stiffness(RID p_body, real_t p_stiffness) override;
 	virtual real_t soft_body_get_linear_stiffness(RID p_body) const override;
 
+	virtual void soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) override;
+	virtual real_t soft_body_get_shrinking_factor(RID p_body) const override;
+
 	virtual void soft_body_set_pressure_coefficient(RID p_body, real_t p_pressure_coefficient) override;
 	virtual real_t soft_body_get_pressure_coefficient(RID p_body) const override;
 

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -272,8 +272,10 @@ void GodotSoftBody3D::update_area() {
 }
 
 void GodotSoftBody3D::reset_link_rest_lengths() {
+	float multiplier = 1.0 - shrinking_factor;
 	for (Link &link : links) {
 		link.rl = (link.n[0]->x - link.n[1]->x).length();
+		link.rl *= multiplier;
 		link.c1 = link.rl * link.rl;
 	}
 }
@@ -837,6 +839,7 @@ void GodotSoftBody3D::append_link(uint32_t p_node1, uint32_t p_node2) {
 	link.n[0] = node1;
 	link.n[1] = node2;
 	link.rl = (node1->x - node2->x).length();
+	link.rl *= 1.0 - shrinking_factor;
 
 	links.push_back(link);
 }
@@ -892,6 +895,10 @@ void GodotSoftBody3D::set_collision_margin(real_t p_val) {
 
 void GodotSoftBody3D::set_linear_stiffness(real_t p_val) {
 	linear_stiffness = p_val;
+}
+
+void GodotSoftBody3D::set_shrinking_factor(real_t p_val) {
+	shrinking_factor = p_val;
 }
 
 void GodotSoftBody3D::set_pressure_coefficient(real_t p_val) {

--- a/modules/godot_physics_3d/godot_soft_body_3d.h
+++ b/modules/godot_physics_3d/godot_soft_body_3d.h
@@ -95,6 +95,7 @@ class GodotSoftBody3D : public GodotCollisionObject3D {
 
 	int iteration_count = 5;
 	real_t linear_stiffness = 0.5; // [0,1]
+	real_t shrinking_factor = 0.0; // [-1,1]
 	real_t pressure_coefficient = 0.0; // [-inf,+inf]
 	real_t damping_coefficient = 0.01; // [0,1]
 	real_t drag_coefficient = 0.0; // [0,1]
@@ -190,6 +191,9 @@ public:
 
 	void set_linear_stiffness(real_t p_val);
 	_FORCE_INLINE_ real_t get_linear_stiffness() const { return linear_stiffness; }
+
+	void set_shrinking_factor(real_t p_val);
+	_FORCE_INLINE_ real_t get_shrinking_factor() const { return shrinking_factor; }
 
 	void set_pressure_coefficient(real_t p_val);
 	_FORCE_INLINE_ real_t get_pressure_coefficient() const { return pressure_coefficient; }

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1126,6 +1126,20 @@ real_t JoltPhysicsServer3D::soft_body_get_linear_stiffness(RID p_body) const {
 	return (real_t)body->get_stiffness_coefficient();
 }
 
+void JoltPhysicsServer3D::soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	return body->set_shrinking_factor((float)p_shrinking_factor);
+}
+
+real_t JoltPhysicsServer3D::soft_body_get_shrinking_factor(RID p_body) const {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, 0.0);
+
+	return (real_t)body->get_shrinking_factor();
+}
+
 void JoltPhysicsServer3D::soft_body_set_pressure_coefficient(RID p_body, real_t p_coefficient) {
 	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -331,6 +331,9 @@ public:
 	virtual void soft_body_set_linear_stiffness(RID p_body, real_t p_coefficient) override;
 	virtual real_t soft_body_get_linear_stiffness(RID p_body) const override;
 
+	virtual void soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) override;
+	virtual real_t soft_body_get_shrinking_factor(RID p_body) const override;
+
 	virtual void soft_body_set_pressure_coefficient(RID p_body, real_t p_coefficient) override;
 	virtual real_t soft_body_get_pressure_coefficient(RID p_body) const override;
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -202,6 +202,10 @@ bool JoltSoftBody3D::_ref_shared_data() {
 		vertex_attrib.mCompliance = vertex_attrib.mShearCompliance = inverse_stiffness;
 
 		settings.CreateConstraints(&vertex_attrib, 1, JPH::SoftBodySharedSettings::EBendType::None);
+		float multiplier = 1.0f - shrinking_factor;
+		for (JPH::SoftBodySharedSettings::Edge &e : settings.mEdgeConstraints) {
+			e.mRestLength *= multiplier;
+		}
 		settings.Optimize();
 	} else {
 		iter_shared_data->value.ref_count++;
@@ -452,6 +456,14 @@ float JoltSoftBody3D::get_stiffness_coefficient() const {
 
 void JoltSoftBody3D::set_stiffness_coefficient(float p_coefficient) {
 	stiffness_coefficient = CLAMP(p_coefficient, 0.0f, 1.0f);
+}
+
+float JoltSoftBody3D::get_shrinking_factor() const {
+	return shrinking_factor;
+}
+
+void JoltSoftBody3D::set_shrinking_factor(float p_shrinking_factor) {
+	shrinking_factor = p_shrinking_factor;
 }
 
 void JoltSoftBody3D::set_pressure(float p_pressure) {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -64,6 +64,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 	float pressure = 0.0f;
 	float linear_damping = 0.01f;
 	float stiffness_coefficient = 0.5f;
+	float shrinking_factor = 0.0f;
 
 	int simulation_precision = 5;
 
@@ -137,6 +138,9 @@ public:
 
 	float get_stiffness_coefficient() const;
 	void set_stiffness_coefficient(float p_coefficient);
+
+	float get_shrinking_factor() const;
+	void set_shrinking_factor(float p_shrinking_factor);
 
 	float get_pressure() const { return pressure; }
 	void set_pressure(float p_pressure);

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -352,6 +352,9 @@ void SoftBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_linear_stiffness", "linear_stiffness"), &SoftBody3D::set_linear_stiffness);
 	ClassDB::bind_method(D_METHOD("get_linear_stiffness"), &SoftBody3D::get_linear_stiffness);
 
+	ClassDB::bind_method(D_METHOD("set_shrinking_factor", "shrinking_factor"), &SoftBody3D::set_shrinking_factor);
+	ClassDB::bind_method(D_METHOD("get_shrinking_factor"), &SoftBody3D::get_shrinking_factor);
+
 	ClassDB::bind_method(D_METHOD("set_pressure_coefficient", "pressure_coefficient"), &SoftBody3D::set_pressure_coefficient);
 	ClassDB::bind_method(D_METHOD("get_pressure_coefficient"), &SoftBody3D::get_pressure_coefficient);
 
@@ -377,6 +380,7 @@ void SoftBody3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "simulation_precision", PROPERTY_HINT_RANGE, "1,100,1"), "set_simulation_precision", "get_simulation_precision");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "total_mass", PROPERTY_HINT_RANGE, "0.01,10000,1"), "set_total_mass", "get_total_mass");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "linear_stiffness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_linear_stiffness", "get_linear_stiffness");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "shrinking_factor", PROPERTY_HINT_RANGE, "-1,1,0.01,or_less,or_greater"), "set_shrinking_factor", "get_shrinking_factor");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pressure_coefficient"), "set_pressure_coefficient", "get_pressure_coefficient");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "damping_coefficient", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_damping_coefficient", "get_damping_coefficient");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "drag_coefficient", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drag_coefficient", "get_drag_coefficient");
@@ -641,6 +645,14 @@ void SoftBody3D::set_linear_stiffness(real_t p_linear_stiffness) {
 
 real_t SoftBody3D::get_linear_stiffness() {
 	return PhysicsServer3D::get_singleton()->soft_body_get_linear_stiffness(physics_rid);
+}
+
+void SoftBody3D::set_shrinking_factor(real_t p_shrinking_factor) {
+	PhysicsServer3D::get_singleton()->soft_body_set_shrinking_factor(physics_rid, p_shrinking_factor);
+}
+
+real_t SoftBody3D::get_shrinking_factor() {
+	return PhysicsServer3D::get_singleton()->soft_body_get_shrinking_factor(physics_rid);
 }
 
 real_t SoftBody3D::get_pressure_coefficient() {

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -164,6 +164,9 @@ public:
 	void set_linear_stiffness(real_t p_linear_stiffness);
 	real_t get_linear_stiffness();
 
+	void set_shrinking_factor(real_t p_shrinking_factor);
+	real_t get_shrinking_factor();
+
 	void set_pressure_coefficient(real_t p_pressure_coefficient);
 	real_t get_pressure_coefficient();
 

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -338,6 +338,9 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_soft_body_set_linear_stiffness, "body", "linear_stiffness");
 	GDVIRTUAL_BIND(_soft_body_get_linear_stiffness, "body");
 
+	GDVIRTUAL_BIND(_soft_body_set_shrinking_factor, "body", "shrinking_factor");
+	GDVIRTUAL_BIND(_soft_body_get_shrinking_factor, "body");
+
 	GDVIRTUAL_BIND(_soft_body_set_pressure_coefficient, "body", "pressure_coefficient");
 	GDVIRTUAL_BIND(_soft_body_get_pressure_coefficient, "body");
 

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -445,6 +445,9 @@ public:
 	EXBIND2(soft_body_set_linear_stiffness, RID, real_t)
 	EXBIND1RC(real_t, soft_body_get_linear_stiffness, RID)
 
+	EXBIND2(soft_body_set_shrinking_factor, RID, real_t)
+	EXBIND1RC(real_t, soft_body_get_shrinking_factor, RID)
+
 	EXBIND2(soft_body_set_pressure_coefficient, RID, real_t)
 	EXBIND1RC(real_t, soft_body_get_pressure_coefficient, RID)
 

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -876,6 +876,9 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("soft_body_set_linear_stiffness", "body", "stiffness"), &PhysicsServer3D::soft_body_set_linear_stiffness);
 	ClassDB::bind_method(D_METHOD("soft_body_get_linear_stiffness", "body"), &PhysicsServer3D::soft_body_get_linear_stiffness);
 
+	ClassDB::bind_method(D_METHOD("soft_body_set_shrinking_factor", "body", "shrinking_factor"), &PhysicsServer3D::soft_body_set_shrinking_factor);
+	ClassDB::bind_method(D_METHOD("soft_body_get_shrinking_factor", "body"), &PhysicsServer3D::soft_body_get_shrinking_factor);
+
 	ClassDB::bind_method(D_METHOD("soft_body_set_pressure_coefficient", "body", "pressure_coefficient"), &PhysicsServer3D::soft_body_set_pressure_coefficient);
 	ClassDB::bind_method(D_METHOD("soft_body_get_pressure_coefficient", "body"), &PhysicsServer3D::soft_body_get_pressure_coefficient);
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -607,6 +607,9 @@ public:
 	virtual void soft_body_set_linear_stiffness(RID p_body, real_t p_stiffness) = 0;
 	virtual real_t soft_body_get_linear_stiffness(RID p_body) const = 0;
 
+	virtual void soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) = 0;
+	virtual real_t soft_body_get_shrinking_factor(RID p_body) const = 0;
+
 	virtual void soft_body_set_pressure_coefficient(RID p_body, real_t p_pressure_coefficient) = 0;
 	virtual real_t soft_body_get_pressure_coefficient(RID p_body) const = 0;
 

--- a/servers/physics_server_3d_dummy.h
+++ b/servers/physics_server_3d_dummy.h
@@ -341,6 +341,9 @@ public:
 	virtual void soft_body_set_linear_stiffness(RID p_body, real_t p_stiffness) override {}
 	virtual real_t soft_body_get_linear_stiffness(RID p_body) const override { return 0; }
 
+	virtual void soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) override {}
+	virtual real_t soft_body_get_shrinking_factor(RID p_body) const override { return 0; }
+
 	virtual void soft_body_set_pressure_coefficient(RID p_body, real_t p_pressure_coefficient) override {}
 	virtual real_t soft_body_get_pressure_coefficient(RID p_body) const override { return 0; }
 

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -304,6 +304,9 @@ public:
 	FUNC2(soft_body_set_linear_stiffness, RID, real_t);
 	FUNC1RC(real_t, soft_body_get_linear_stiffness, RID);
 
+	FUNC2(soft_body_set_shrinking_factor, RID, real_t);
+	FUNC1RC(real_t, soft_body_get_shrinking_factor, RID);
+
 	FUNC2(soft_body_set_pressure_coefficient, RID, real_t);
 	FUNC1RC(real_t, soft_body_get_pressure_coefficient, RID);
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12227

This PR adds `shrinking_factor` property to SoftBody3D, which scales the rest lengths of edge constraints, similarly to the parameter of the same name in Blender's cloth modifier. Applicable primarily in cloth simulation, decreasing the value causes it to tighten between the pinned points.

This is an implementation for Jolt Physics only; in GodotPhysics, the property is always set to default.

![image](https://github.com/user-attachments/assets/09b69690-bdc2-4277-8e10-7be327a7061b)