### PR TITLE
Allow hiding the main window (Windows & Linux)

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -977,6 +977,69 @@ void DisplayServerWayland::delete_sub_window(DisplayServerEnums::WindowID p_wind
 	_delete_window(p_window_id);
 }
 
+void DisplayServerWayland::window_set_visible(bool p_visible, DisplayServerEnums::WindowID p_window) {
+	MutexLock mutex_lock(wayland_thread.mutex);
+	ERR_FAIL_COND(!windows.has(p_window));
+	WindowData &wd = windows[p_window];
+
+	if (wd.visible == p_visible) {
+		return;
+	}
+
+	if (Engine::get_singleton()->is_embedded_in_editor()) {
+		print_line("Embedded window can't be hidden.");
+		return;
+	}
+
+	bool is_vulkan = (rendering_driver == "vulkan");
+	if (!p_visible) {
+		if (is_vulkan) {
+			if (hovered_window_id == p_window) {
+				_hover_window(DisplayServerEnums::INVALID_WINDOW_ID);
+			}
+
+#ifdef RD_ENABLED
+			if (rendering_device) {
+				rendering_device->screen_free(p_window);
+			}
+
+			if (rendering_context) {
+				rendering_context->window_destroy(p_window);
+			}
+#endif
+
+			if (wd.created) {
+				wayland_thread.window_destroy(p_window);
+				wd.created = false;
+			}
+		} else {
+			wayland_thread.window_set_visible(p_window, false);
+		}
+
+		wd.visible = false;
+	} else {
+		if (is_vulkan) {
+			show_window(p_window);
+		} else {
+			wayland_thread.window_set_visible(p_window, true);
+
+			wayland_thread.window_set_title(p_window, wd.title);
+			wayland_thread.window_set_app_id(p_window, _get_app_id_from_context(context));
+			wayland_thread.window_set_min_size(p_window, wd.min_size);
+			wayland_thread.window_set_max_size(p_window, wd.max_size);
+			wayland_thread.window_set_borderless(p_window, window_get_flag(DisplayServerEnums::WINDOW_FLAG_BORDERLESS, p_window));
+
+			bool ready = wayland_thread.window_wait_ready(p_window, WINDOW_READY_TIMEOUT_MS);
+			if (!ready) {
+				ERR_PRINT(vformat("Could not map window %d: timeout waiting for configure.", p_window));
+				return;
+			}
+
+			wd.visible = true;
+		}
+	}
+}
+
 DisplayServerEnums::WindowID DisplayServerWayland::window_get_active_popup() const {
 	MutexLock mutex_lock(wayland_thread.mutex);
 
@@ -1391,6 +1454,11 @@ bool DisplayServerWayland::window_is_focused(DisplayServerEnums::WindowID p_wind
 
 bool DisplayServerWayland::window_can_draw(DisplayServerEnums::WindowID p_window_id) const {
 	MutexLock mutex_lock(wayland_thread.mutex);
+	ERR_FAIL_COND_V(!windows.has(p_window_id), false);
+
+	if (!windows[p_window_id].visible) {
+		return false;
+	}
 
 	uint64_t last_frame_time = wayland_thread.window_get_last_frame_time(p_window_id);
 	uint64_t time_since_frame = OS::get_singleton()->get_ticks_usec() - last_frame_time;

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -260,6 +260,7 @@ public:
 	virtual void show_window(DisplayServerEnums::WindowID p_id) override;
 	virtual void delete_sub_window(DisplayServerEnums::WindowID p_id) override;
 
+	virtual void window_set_visible(bool p_visible, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 	virtual DisplayServerEnums::WindowID window_get_active_popup() const override;
 	virtual void window_set_popup_safe_rect(DisplayServerEnums::WindowID p_window, const Rect2i &p_rect) override;
 	virtual Rect2i window_get_popup_safe_rect(DisplayServerEnums::WindowID p_window) const override;

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -4560,6 +4560,29 @@ void WaylandThread::window_destroy(DisplayServerEnums::WindowID p_window_id) {
 	_window_hover();
 }
 
+void WaylandThread::window_set_visible(DisplayServerEnums::WindowID p_window_id, bool p_visible) {
+	ERR_FAIL_COND(!windows.has(p_window_id));
+	WindowState &ws = windows[p_window_id];
+
+	if (ws.visible == p_visible) {
+		return;
+	}
+
+	ws.visible = p_visible;
+
+	if (!p_visible) {
+		ws.ready = false;
+
+		wl_surface_attach(ws.wl_surface, nullptr, 0, 0);
+		wl_surface_commit(ws.wl_surface);
+	} else {
+		ws.last_frame_time = OS::get_singleton()->get_ticks_usec();
+
+		set_frame();
+		wl_surface_commit(ws.wl_surface);
+	}
+}
+
 bool WaylandThread::window_exists(DisplayServerEnums::WindowID p_window_id) const {
 	if (p_window_id == DisplayServerEnums::INVALID_WINDOW_ID) {
 		return false;

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -295,6 +295,7 @@ public:
 		Rect2i rect;
 		DisplayServerEnums::WindowMode mode = DisplayServerEnums::WINDOW_MODE_WINDOWED;
 
+		bool visible = true;
 		bool ready = false; // Is configured or otherwise ready to be mapped.
 
 		// Toplevel states.
@@ -1274,6 +1275,8 @@ public:
 	void window_create(DisplayServerEnums::WindowID p_window_id, const Size2i &p_size, DisplayServerEnums::WindowID p_parent_id = DisplayServerEnums::INVALID_WINDOW_ID);
 	void window_create_popup(DisplayServerEnums::WindowID p_window_id, DisplayServerEnums::WindowID p_parent_id, Rect2i p_rect);
 	void window_destroy(DisplayServerEnums::WindowID p_window_Id);
+
+	void window_set_visible(DisplayServerEnums::WindowID p_window_id, bool p_visible);
 
 	// Checks if a window exists for this ID (NOT if its data is valid). Useful to
 	// detect deleted windows.

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2135,6 +2135,32 @@ void DisplayServerX11::delete_sub_window(DisplayServerEnums::WindowID p_id) {
 	}
 }
 
+void DisplayServerX11::window_set_visible(bool p_visible, DisplayServerEnums::WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
+	WindowData &wd = windows[p_window];
+
+	if (wd.visible == p_visible) {
+		return;
+	}
+
+	if (wd.embed_parent) {
+		print_line("Embedded window can't be hidden.");
+		return;
+	}
+
+	wd.visible = p_visible;
+
+	if (p_visible) {
+		XMapWindow(x11_display, wd.x11_window);
+	} else {
+		XUnmapWindow(x11_display, wd.x11_window);
+	}
+
+	XFlush(x11_display);
+}
+
 int64_t DisplayServerX11::window_get_native_handle(DisplayServerEnums::HandleType p_handle_type, DisplayServerEnums::WindowID p_window) const {
 	ERR_FAIL_COND_V(!windows.has(p_window), 0);
 	switch (p_handle_type) {
@@ -3488,8 +3514,9 @@ bool DisplayServerX11::window_is_focused(DisplayServerEnums::WindowID p_window) 
 }
 
 bool DisplayServerX11::window_can_draw(DisplayServerEnums::WindowID p_window) const {
+	ERR_FAIL_COND_V(!windows.has(p_window), false);
 	//this seems to be all that is provided by X11
-	return window_get_mode(p_window) != DisplayServerEnums::WINDOW_MODE_MINIMIZED;
+	return windows[p_window].visible && window_get_mode(p_window) != DisplayServerEnums::WINDOW_MODE_MINIMIZED;
 }
 
 bool DisplayServerX11::can_any_window_draw() const {

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -155,6 +155,7 @@ class DisplayServerX11 : public DisplayServer {
 		Ref<Image> icon;
 		bool icon_set = false;
 
+		bool visible = true;
 		Size2i min_size;
 		Size2i max_size;
 		Point2i position;
@@ -466,6 +467,7 @@ public:
 	virtual void show_window(DisplayServerEnums::WindowID p_id) override;
 	virtual void delete_sub_window(DisplayServerEnums::WindowID p_id) override;
 
+	virtual void window_set_visible(bool p_visible, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 	virtual DisplayServerEnums::WindowID window_get_active_popup() const override;
 	virtual void window_set_popup_safe_rect(DisplayServerEnums::WindowID p_window, const Rect2i &p_rect) override;
 	virtual Rect2i window_get_popup_safe_rect(DisplayServerEnums::WindowID p_window) const override;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1998,6 +1998,40 @@ void DisplayServerWindows::delete_sub_window(DisplayServerEnums::WindowID p_wind
 	}
 }
 
+void DisplayServerWindows::window_set_visible(bool p_visible, DisplayServerEnums::WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
+	WindowData &wd = windows[p_window];
+
+	if (p_visible) {
+		if (wd.maximized) {
+			ShowWindow(wd.hWnd, SW_SHOWMAXIMIZED);
+			SetForegroundWindow(wd.hWnd); // Slightly higher priority.
+			SetFocus(wd.hWnd); // Set keyboard focus.
+		} else if (wd.minimized) {
+			ShowWindow(wd.hWnd, SW_SHOWMINIMIZED);
+		} else if (wd.no_focus) {
+			// https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow
+			ShowWindow(wd.hWnd, SW_SHOWNA);
+		} else if (wd.is_popup) {
+			ShowWindow(wd.hWnd, SW_SHOWNA);
+			SetFocus(wd.hWnd); // Set keyboard focus.
+		} else {
+			ShowWindow(wd.hWnd, SW_SHOW);
+			SetForegroundWindow(wd.hWnd); // Slightly higher priority.
+			SetFocus(wd.hWnd); // Set keyboard focus.
+		}
+	} else {
+		if (wd.parent_hwnd) {
+			print_line("Embedded window can't be hidden.");
+			return;
+		}
+
+		ShowWindow(wd.hWnd, SW_HIDE);
+	}
+}
+
 void DisplayServerWindows::gl_window_make_current(DisplayServerEnums::WindowID p_window_id) {
 #if defined(GLES3_ENABLED)
 #if defined(ANGLE_ENABLED)
@@ -3093,7 +3127,7 @@ bool DisplayServerWindows::window_can_draw(DisplayServerEnums::WindowID p_window
 
 	ERR_FAIL_COND_V(!windows.has(p_window), false);
 	const WindowData &wd = windows[p_window];
-	return !wd.minimized;
+	return !wd.minimized && IsWindowVisible(wd.hWnd);
 }
 
 bool DisplayServerWindows::can_any_window_draw() const {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -634,6 +634,7 @@ public:
 	virtual void show_window(DisplayServerEnums::WindowID p_window) override;
 	virtual void delete_sub_window(DisplayServerEnums::WindowID p_window) override;
 
+	virtual void window_set_visible(bool p_visible, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 	virtual DisplayServerEnums::WindowID window_get_active_popup() const override;
 	virtual void window_set_popup_safe_rect(DisplayServerEnums::WindowID p_window, const Rect2i &p_rect) override;
 	virtual Rect2i window_get_popup_safe_rect(DisplayServerEnums::WindowID p_window) const override;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1014,8 +1014,43 @@ void Window::set_visible(bool p_visible) {
 		return;
 	}
 
-	ERR_FAIL_NULL_MSG(get_parent(), "Can't change visibility of main window.");
+#if defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED)
+	if (!get_parent()) {
+		if (Engine::get_singleton()->is_embedded_in_editor()) {
+			return;
+		}
 
+		if (window_id != DisplayServerEnums::INVALID_WINDOW_ID) {
+			DisplayServer::get_singleton()->window_set_visible(p_visible, window_id);
+		}
+
+		visible = p_visible;
+
+		if (visible) {
+			if (get_tree() && get_tree()->is_accessibility_supported()) {
+				get_tree()->_accessibility_force_update();
+				_accessibility_notify_enter(this);
+				AccessibilityServer::get_singleton()->window_activation_completed(get_window_id());
+			}
+		} else {
+			if (get_tree() && get_tree()->is_accessibility_supported()) {
+				_accessibility_notify_exit(this);
+				AccessibilityServer::get_singleton()->window_deactivation_completed(get_window_id());
+			}
+			focused = false;
+			if (focused_window == this) {
+				focused_window = nullptr;
+			}
+		}
+
+		notification(NOTIFICATION_VISIBILITY_CHANGED);
+		emit_signal(SceneStringName(visibility_changed));
+		RS::get_singleton()->viewport_set_active(get_viewport_rid(), visible);
+		return;
+	}
+#else
+	ERR_FAIL_NULL_MSG(get_parent(), "Can't change visibility of main window.");
+#endif
 	visible = p_visible;
 
 	// Stop any queued resizing, as the window will be resized right now.

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -377,6 +377,7 @@ public:
 	virtual void show_window(DisplayServerEnums::WindowID p_id);
 	virtual void delete_sub_window(DisplayServerEnums::WindowID p_id);
 
+	virtual void window_set_visible(bool p_visible, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) {}
 	virtual DisplayServerEnums::WindowID window_get_active_popup() const { return DisplayServerEnums::INVALID_WINDOW_ID; }
 	virtual void window_set_popup_safe_rect(DisplayServerEnums::WindowID p_window, const Rect2i &p_rect) {}
 	virtual Rect2i window_get_popup_safe_rect(DisplayServerEnums::WindowID p_window) const { return Rect2i(); }


### PR DESCRIPTION
Close https://github.com/godotengine/godot-proposals/issues/9032

This feature is not commonly found in games, but many other apps have it—hiding the main window without closing the program and showing it again when needed.  

~~I attempted to implement this on Wayland but failed, and I don’t have a Mac device to test it on macOS.~~
I tried to implement this feature on Wayland, but for some reason, VK cannot redisplay the main window; only the taskbar icon reappears.
I still don't have a Mac device, so this PR does not include the implementation of macOS features.

function display:  

https://github.com/user-attachments/assets/1de85924-4322-4ed8-899d-69e21921bdf4

test project:
[hidw-windows_2026-06-07_16-21-59.zip](https://github.com/user-attachments/files/28678022/hidw-windows_2026-06-07_16-21-59.zip)