### PR TITLE
Rename `nav_2d` namespace to `Nav2D` to match `Nav3D`

### DIFF
--- a/modules/navigation_2d/2d/nav_base_iteration_2d.h
+++ b/modules/navigation_2d/2d/nav_base_iteration_2d.h
@@ -44,7 +44,7 @@ struct NavBaseIteration2D {
 	ObjectID owner_object_id;
 	RID owner_rid;
 	bool owner_use_edge_connections = false;
-	LocalVector<nav_2d::Polygon> navmesh_polygons;
+	LocalVector<Nav2D::Polygon> navmesh_polygons;
 
 	bool get_enabled() const { return enabled; }
 	NavigationUtilities::PathSegmentType get_type() const { return owner_type; }
@@ -54,5 +54,5 @@ struct NavBaseIteration2D {
 	real_t get_enter_cost() const { return enter_cost; }
 	real_t get_travel_cost() const { return travel_cost; }
 	bool get_use_edge_connections() const { return owner_use_edge_connections; }
-	const LocalVector<nav_2d::Polygon> &get_navmesh_polygons() const { return navmesh_polygons; }
+	const LocalVector<Nav2D::Polygon> &get_navmesh_polygons() const { return navmesh_polygons; }
 };

--- a/modules/navigation_2d/2d/nav_map_builder_2d.cpp
+++ b/modules/navigation_2d/2d/nav_map_builder_2d.cpp
@@ -37,7 +37,7 @@
 #include "nav_map_iteration_2d.h"
 #include "nav_region_iteration_2d.h"
 
-using namespace nav_2d;
+using namespace Nav2D;
 
 PointKey NavMapBuilder2D::get_point_key(const Vector2 &p_pos, const Vector2 &p_cell_size) {
 	const int x = static_cast<int>(Math::floor(p_pos.x / p_cell_size.x));

--- a/modules/navigation_2d/2d/nav_map_builder_2d.h
+++ b/modules/navigation_2d/2d/nav_map_builder_2d.h
@@ -43,7 +43,7 @@ class NavMapBuilder2D {
 	static void _build_update_map_iteration(NavMapIterationBuild2D &r_build);
 
 public:
-	static nav_2d::PointKey get_point_key(const Vector2 &p_pos, const Vector2 &p_cell_size);
+	static Nav2D::PointKey get_point_key(const Vector2 &p_pos, const Vector2 &p_cell_size);
 
 	static void build_navmap_iteration(NavMapIterationBuild2D &r_build);
 };

--- a/modules/navigation_2d/2d/nav_map_iteration_2d.h
+++ b/modules/navigation_2d/2d/nav_map_iteration_2d.h
@@ -47,12 +47,12 @@ struct NavMapIterationBuild2D {
 	bool use_edge_connections = true;
 	real_t edge_connection_margin;
 	real_t link_connection_radius;
-	nav_2d::PerformanceData performance_data;
+	Nav2D::PerformanceData performance_data;
 	int polygon_count = 0;
 	int free_edge_count = 0;
 
-	HashMap<nav_2d::EdgeKey, nav_2d::EdgeConnectionPair, nav_2d::EdgeKey> iter_connection_pairs_map;
-	LocalVector<nav_2d::Edge::Connection> iter_free_edges;
+	HashMap<Nav2D::EdgeKey, Nav2D::EdgeConnectionPair, Nav2D::EdgeKey> iter_connection_pairs_map;
+	LocalVector<Nav2D::Edge::Connection> iter_free_edges;
 
 	NavMapIteration2D *map_iteration = nullptr;
 
@@ -80,7 +80,7 @@ struct NavMapIteration2D {
 	int navmesh_polygon_count = 0;
 
 	// The edge connections that the map builds on top with the edge connection margin.
-	HashMap<uint32_t, LocalVector<nav_2d::Edge::Connection>> external_region_connections;
+	HashMap<uint32_t, LocalVector<Nav2D::Edge::Connection>> external_region_connections;
 
 	HashMap<NavRegion2D *, uint32_t> region_ptr_to_region_id;
 

--- a/modules/navigation_2d/2d/nav_mesh_queries_2d.cpp
+++ b/modules/navigation_2d/2d/nav_mesh_queries_2d.cpp
@@ -38,7 +38,7 @@
 #include "core/math/geometry_2d.h"
 #include "servers/navigation/navigation_utilities.h"
 
-using namespace nav_2d;
+using namespace Nav2D;
 
 #define THREE_POINTS_CROSS_PRODUCT(m_a, m_b, m_c) (((m_c) - (m_a)).cross((m_b) - (m_a)))
 

--- a/modules/navigation_2d/2d/nav_mesh_queries_2d.h
+++ b/modules/navigation_2d/2d/nav_mesh_queries_2d.h
@@ -44,8 +44,8 @@ struct NavMapIteration2D;
 class NavMeshQueries2D {
 public:
 	struct PathQuerySlot {
-		LocalVector<nav_2d::NavigationPoly> path_corridor;
-		Heap<nav_2d::NavigationPoly *, nav_2d::NavPolyTravelCostGreaterThan, nav_2d::NavPolyHeapIndexer> traversable_polys;
+		LocalVector<Nav2D::NavigationPoly> path_corridor;
+		Heap<Nav2D::NavigationPoly *, Nav2D::NavPolyTravelCostGreaterThan, Nav2D::NavPolyHeapIndexer> traversable_polys;
 		bool in_use = false;
 		uint32_t slot_index = 0;
 	};
@@ -76,8 +76,8 @@ public:
 		// Path building.
 		Vector2 begin_position;
 		Vector2 end_position;
-		const nav_2d::Polygon *begin_polygon = nullptr;
-		const nav_2d::Polygon *end_polygon = nullptr;
+		const Nav2D::Polygon *begin_polygon = nullptr;
+		const Nav2D::Polygon *end_polygon = nullptr;
 		uint32_t least_cost_id = 0;
 
 		// Map.
@@ -112,27 +112,27 @@ public:
 
 	static bool emit_callback(const Callable &p_callback);
 
-	static Vector2 polygons_get_random_point(const LocalVector<nav_2d::Polygon> &p_polygons, uint32_t p_navigation_layers, bool p_uniformly);
+	static Vector2 polygons_get_random_point(const LocalVector<Nav2D::Polygon> &p_polygons, uint32_t p_navigation_layers, bool p_uniformly);
 
-	static Vector2 polygons_get_closest_point(const LocalVector<nav_2d::Polygon> &p_polygons, const Vector2 &p_point);
-	static nav_2d::ClosestPointQueryResult polygons_get_closest_point_info(const LocalVector<nav_2d::Polygon> &p_polygons, const Vector2 &p_point);
-	static RID polygons_get_closest_point_owner(const LocalVector<nav_2d::Polygon> &p_polygons, const Vector2 &p_point);
+	static Vector2 polygons_get_closest_point(const LocalVector<Nav2D::Polygon> &p_polygons, const Vector2 &p_point);
+	static Nav2D::ClosestPointQueryResult polygons_get_closest_point_info(const LocalVector<Nav2D::Polygon> &p_polygons, const Vector2 &p_point);
+	static RID polygons_get_closest_point_owner(const LocalVector<Nav2D::Polygon> &p_polygons, const Vector2 &p_point);
 
 	static Vector2 map_iteration_get_closest_point(const NavMapIteration2D &p_map_iteration, const Vector2 &p_point);
 	static RID map_iteration_get_closest_point_owner(const NavMapIteration2D &p_map_iteration, const Vector2 &p_point);
-	static nav_2d::ClosestPointQueryResult map_iteration_get_closest_point_info(const NavMapIteration2D &p_map_iteration, const Vector2 &p_point);
+	static Nav2D::ClosestPointQueryResult map_iteration_get_closest_point_info(const NavMapIteration2D &p_map_iteration, const Vector2 &p_point);
 	static Vector2 map_iteration_get_random_point(const NavMapIteration2D &p_map_iteration, uint32_t p_navigation_layers, bool p_uniformly);
 
 	static void map_query_path(NavMap2D *p_map, const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result, const Callable &p_callback);
 
 	static void query_task_map_iteration_get_path(NavMeshPathQueryTask2D &p_query_task, const NavMapIteration2D &p_map_iteration);
-	static void _query_task_push_back_point_with_metadata(NavMeshPathQueryTask2D &p_query_task, const Vector2 &p_point, const nav_2d::Polygon *p_point_polygon);
+	static void _query_task_push_back_point_with_metadata(NavMeshPathQueryTask2D &p_query_task, const Vector2 &p_point, const Nav2D::Polygon *p_point_polygon);
 	static void _query_task_find_start_end_positions(NavMeshPathQueryTask2D &p_query_task, const NavMapIteration2D &p_map_iteration);
 	static void _query_task_build_path_corridor(NavMeshPathQueryTask2D &p_query_task);
 	static void _query_task_post_process_corridorfunnel(NavMeshPathQueryTask2D &p_query_task);
 	static void _query_task_post_process_edgecentered(NavMeshPathQueryTask2D &p_query_task);
 	static void _query_task_post_process_nopostprocessing(NavMeshPathQueryTask2D &p_query_task);
-	static void _query_task_clip_path(NavMeshPathQueryTask2D &p_query_task, const nav_2d::NavigationPoly *p_from_poly, const Vector2 &p_to_point, const nav_2d::NavigationPoly *p_to_poly);
+	static void _query_task_clip_path(NavMeshPathQueryTask2D &p_query_task, const Nav2D::NavigationPoly *p_from_poly, const Vector2 &p_to_point, const Nav2D::NavigationPoly *p_to_poly);
 	static void _query_task_simplified_path_points(NavMeshPathQueryTask2D &p_query_task);
 	static bool _query_task_is_connection_owner_usable(const NavMeshPathQueryTask2D &p_query_task, const NavBaseIteration2D *p_owner);
 

--- a/modules/navigation_2d/nav_map_2d.cpp
+++ b/modules/navigation_2d/nav_map_2d.cpp
@@ -44,7 +44,7 @@
 
 #include <Obstacle2d.h>
 
-using namespace nav_2d;
+using namespace Nav2D;
 
 #ifdef DEBUG_ENABLED
 #define NAVMAP_ITERATION_ZERO_ERROR_MSG() \

--- a/modules/navigation_2d/nav_map_2d.h
+++ b/modules/navigation_2d/nav_map_2d.h
@@ -99,7 +99,7 @@ class NavMap2D : public NavRid2D {
 	bool avoidance_use_high_priority_threads = true;
 
 	// Performance Monitor
-	nav_2d::PerformanceData performance_data;
+	Nav2D::PerformanceData performance_data;
 
 	struct {
 		SelfList<NavRegion2D>::List regions;
@@ -159,13 +159,13 @@ public:
 		return link_connection_radius;
 	}
 
-	nav_2d::PointKey get_point_key(const Vector2 &p_pos) const;
+	Nav2D::PointKey get_point_key(const Vector2 &p_pos) const;
 	Vector2 get_merge_rasterizer_cell_size() const;
 
 	void query_path(NavMeshQueries2D::NavMeshPathQueryTask2D &p_query_task);
 
 	Vector2 get_closest_point(const Vector2 &p_point) const;
-	nav_2d::ClosestPointQueryResult get_closest_point_info(const Vector2 &p_point) const;
+	Nav2D::ClosestPointQueryResult get_closest_point_info(const Vector2 &p_point) const;
 	RID get_closest_point_owner(const Vector2 &p_point) const;
 
 	void add_region(NavRegion2D *p_region);

--- a/modules/navigation_2d/nav_region_2d.cpp
+++ b/modules/navigation_2d/nav_region_2d.cpp
@@ -37,7 +37,7 @@
 #include "2d/nav_mesh_queries_2d.h"
 #include "2d/nav_region_iteration_2d.h"
 
-using namespace nav_2d;
+using namespace Nav2D;
 
 void NavRegion2D::set_map(NavMap2D *p_map) {
 	if (map == p_map) {

--- a/modules/navigation_2d/nav_region_2d.h
+++ b/modules/navigation_2d/nav_region_2d.h
@@ -50,7 +50,7 @@ class NavRegion2D : public NavBase2D {
 	bool region_dirty = true;
 	bool polygons_dirty = true;
 
-	LocalVector<nav_2d::Polygon> navmesh_polygons;
+	LocalVector<Nav2D::Polygon> navmesh_polygons;
 
 	real_t surface_area = 0.0;
 	Rect2 bounds;
@@ -91,11 +91,11 @@ public:
 
 	void set_navigation_polygon(Ref<NavigationPolygon> p_navigation_polygon);
 
-	LocalVector<nav_2d::Polygon> const &get_polygons() const {
+	LocalVector<Nav2D::Polygon> const &get_polygons() const {
 		return navmesh_polygons;
 	}
 
-	nav_2d::ClosestPointQueryResult get_closest_point_info(const Vector2 &p_point) const;
+	Nav2D::ClosestPointQueryResult get_closest_point_info(const Vector2 &p_point) const;
 	Vector2 get_random_point(uint32_t p_navigation_layers, bool p_uniformly) const;
 
 	real_t get_surface_area() const { return surface_area; }

--- a/modules/navigation_2d/nav_utils_2d.h
+++ b/modules/navigation_2d/nav_utils_2d.h
@@ -38,7 +38,7 @@
 
 struct NavBaseIteration2D;
 
-namespace nav_2d {
+namespace Nav2D {
 struct Polygon;
 
 union PointKey {
@@ -205,4 +205,4 @@ struct PerformanceData {
 	}
 };
 
-} // namespace nav_2d
+} //namespace Nav2D


### PR DESCRIPTION
This matches `namespace Nav3D` in the `navigation_3d` module.