### PR TITLE
Add a project setting to control 3D line drawing thickness in Forward+ and Mobile Vulkan renderers

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -884,6 +884,7 @@
 		</member>
 		<member name="debug/shapes/paths/geometry_width" type="float" setter="" getter="" default="2.0">
 			Line width of the curve path geometry, visible when "Visible Paths" is enabled in the Debug menu.
+			[b]Note:[/b] This setting is only effective in 2D. For 3D, set [member rendering/driver/line_drawing/width] instead.
 		</member>
 		<member name="display/display_server/driver" type="String" setter="" getter="">
 			Sets the driver to be used by the display server. This property can not be edited directly, instead, set the driver using the platform-specific overrides.
@@ -2740,6 +2741,12 @@
 		<member name="rendering/driver/depth_prepass/enable" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], performs a previous depth pass before rendering 3D materials. This increases performance significantly in scenes with high overdraw, when complex materials and lighting are used. However, in scenes with few occluded surfaces, the depth prepass may reduce performance. If your game is viewed from a fixed angle that makes it easy to avoid overdraw (such as top-down or side-scrolling perspective), consider disabling the depth prepass to improve performance. This setting can be changed at run-time to optimize performance depending on the scene currently being viewed.
 			[b]Note:[/b] Depth prepass is only supported when using the Forward+ or Compatibility rendering method. When using the Mobile rendering method, there is no depth prepass performed.
+		</member>
+		<member name="rendering/driver/line_drawing/width" type="float" setter="" getter="" default="1.0">
+			The thickness of all hardware-based 3D lines (in pixels). This thickness does not depend on distance from the camera. This setting affects all lines drawn in 3D, including gizmos in the editor and debug draw options. This can be increased to make debug drawing more visible, particularly when using a high-resolution viewport or on hiDPI displays.
+			[b]Note:[/b] This setting is only implemented in the Forward+ and Mobile renderers. In the Compatibility renderer, drawn lines are always 1 pixel thick.
+			[b]Note:[/b] This setting requires the hardware to support drawing lines thicker than 1 pixel. This is usually supported on Windows and Linux, rarely supported on Android, and not supported on macOS and iOS.
+			[b]Note:[/b] This setting does not affect lines drawn in 2D. For [Path2D] debug drawing, adjust [member debug/shapes/paths/geometry_width] instead.
 		</member>
 		<member name="rendering/driver/threads/thread_model" type="int" setter="" getter="" default="1" experimental="This setting has several known bugs which can lead to crashing, especially when using particles or resizing the window. Not recommended for use in production at this stage.">
 			The thread model to use for rendering. Rendering on a thread may improve performance, but synchronizing to the main thread can cause a bit more jitter.

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -6154,6 +6154,8 @@ bool RenderingDeviceDriverVulkan::has_feature(Features p_feature) {
 			return true;
 		case SUPPORTS_BUFFER_DEVICE_ADDRESS:
 			return buffer_device_address_support;
+		case SUPPORTS_WIDE_LINES:
+			return physical_device_features.wideLines;
 		default:
 			return false;
 	}

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -483,6 +483,7 @@ void RenderForwardClustered::_render_list_template(RenderingDevice::DrawListID p
 
 		pipeline_key.framebuffer_format_id = framebuffer_format;
 		pipeline_key.wireframe = p_params->force_wireframe;
+		pipeline_key.line_width = line_width;
 		pipeline_key.ubershader = 0;
 
 		const RD::PolygonCullMode cull_mode = shader->get_cull_mode_from_cull_variant(cull_variant);
@@ -4463,6 +4464,7 @@ void RenderForwardClustered::_mesh_compile_pipelines_for_surface(const SurfacePi
 	pipeline_key.cull_mode = RD::POLYGON_CULL_DISABLED;
 	pipeline_key.primitive_type = mesh_storage->mesh_surface_get_primitive(p_surface.mesh_surface);
 	pipeline_key.wireframe = false;
+	pipeline_key.line_width = 1;
 
 	// Grab the shader and surface used for most passes.
 	const uint32_t multiview_iterations = multiview_enabled ? 2 : 1;
@@ -4865,6 +4867,12 @@ RenderForwardClustered::RenderForwardClustered() {
 	singleton = this;
 
 	/* SCENE SHADER */
+
+	line_width = float(GLOBAL_GET("rendering/driver/line_drawing/width"));
+	if (!RD::get_singleton()->has_feature(RD::SUPPORTS_WIDE_LINES) && line_width != 1.0f) {
+		WARN_PRINT_ED("Changing line thickness via 'rendering/driver/line_drawing/width' is not supported on this GPU. Line will be drawn as 1 pixel thick.");
+		line_width = 1.0f;
+	}
 
 	{
 		String defines;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -169,6 +169,7 @@ private:
 	RID render_base_uniform_set;
 
 	uint64_t lightmap_texture_array_version = 0xFFFFFFFF;
+	float line_width = 1.0f;
 
 	void _update_render_base_uniform_set();
 	RID _setup_sdfgi_render_pass_uniform_set(RID p_albedo_texture, RID p_emission_texture, RID p_emission_aniso_texture, RID p_geom_facing_texture, const RendererRD::MaterialStorage::Samplers &p_samplers);

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -289,7 +289,8 @@ void SceneShaderForwardClustered::ShaderData::_create_pipeline(PipelineKey p_pip
 			"VERSION:", p_pipeline_key.version,
 			"PASS FLAGS:", p_pipeline_key.color_pass_flags,
 			"SPEC PACKED #0:", p_pipeline_key.shader_specialization.packed_0,
-			"WIREFRAME:", p_pipeline_key.wireframe);
+			"WIREFRAME:", p_pipeline_key.wireframe,
+			"LINE WIDTH:", p_pipeline_key.line_width);
 #endif
 
 	// Color pass -> attachment 0: Color/Diffuse, attachment 1: Separate Specular, attachment 2: Motion Vectors
@@ -322,6 +323,7 @@ void SceneShaderForwardClustered::ShaderData::_create_pipeline(PipelineKey p_pip
 	RD::PipelineRasterizationState raster_state;
 	raster_state.cull_mode = p_pipeline_key.cull_mode;
 	raster_state.wireframe = wireframe || p_pipeline_key.wireframe;
+	raster_state.line_width = p_pipeline_key.line_width;
 
 	RD::PipelineMultisampleState multisample_state;
 	multisample_state.sample_count = RD::get_singleton()->framebuffer_format_get_texture_samples(p_pipeline_key.framebuffer_format_id, 0);

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -176,6 +176,7 @@ public:
 			uint32_t color_pass_flags = 0;
 			ShaderSpecialization shader_specialization = {};
 			uint32_t wireframe = false;
+			float line_width = 1.0f;
 			uint32_t ubershader = false;
 
 			uint32_t hash() const {
@@ -189,6 +190,7 @@ public:
 				h = hash_murmur3_one_32(shader_specialization.packed_1, h);
 				h = hash_murmur3_one_32(shader_specialization.packed_2, h);
 				h = hash_murmur3_one_32(wireframe, h);
+				h = hash_murmur3_one_32(line_width, h);
 				h = hash_murmur3_one_32(ubershader, h);
 				return hash_fmix32(h);
 			}

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2284,6 +2284,7 @@ void RenderForwardMobile::_render_list_template(RenderingDevice::DrawListID p_dr
 
 		pipeline_key.framebuffer_format_id = framebuffer_format;
 		pipeline_key.wireframe = p_params->force_wireframe;
+		pipeline_key.line_width = line_width;
 		pipeline_key.render_pass = p_params->subpass;
 		pipeline_key.ubershader = 0;
 
@@ -3204,6 +3205,12 @@ void RenderForwardMobile::_update_shader_quality_settings() {
 
 RenderForwardMobile::RenderForwardMobile() {
 	singleton = this;
+
+	line_width = float(GLOBAL_GET("rendering/driver/line_drawing/width"));
+	if (!RD::get_singleton()->has_feature(RD::SUPPORTS_WIDE_LINES) && line_width != 1.0f) {
+		WARN_PRINT_ED("Changing line thickness via 'rendering/driver/line_drawing/width' is not supported on this GPU. Line will be drawn as 1 pixel thick.");
+		line_width = 1.0f;
+	}
 
 	sky.set_texture_format(_render_buffers_get_color_format());
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -162,6 +162,7 @@ private:
 	void _pre_opaque_render(RenderDataRD *p_render_data);
 
 	uint64_t lightmap_texture_array_version = 0xFFFFFFFF;
+	float line_width = 1.0f;
 
 	void _update_render_base_uniform_set();
 

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -247,7 +247,8 @@ void SceneShaderForwardMobile::ShaderData::_create_pipeline(PipelineKey p_pipeli
 			"SPEC PACKED #2:", p_pipeline_key.shader_specialization.packed_2,
 			"SPEC PACKED #3:", p_pipeline_key.shader_specialization.packed_3,
 			"RENDER PASS:", p_pipeline_key.render_pass,
-			"WIREFRAME:", p_pipeline_key.wireframe);
+			"WIREFRAME:", p_pipeline_key.wireframe,
+			"LINE WIDTH:", p_pipeline_key.line_width);
 #endif
 
 	RD::PipelineColorBlendState::Attachment blend_attachment = blend_mode_to_blend_attachment(BlendMode(blend_mode));
@@ -281,6 +282,7 @@ void SceneShaderForwardMobile::ShaderData::_create_pipeline(PipelineKey p_pipeli
 	RD::PipelineRasterizationState raster_state;
 	raster_state.cull_mode = p_pipeline_key.cull_mode;
 	raster_state.wireframe = wireframe || p_pipeline_key.wireframe;
+	raster_state.line_width = p_pipeline_key.line_width;
 
 	RD::PipelineMultisampleState multisample_state;
 	multisample_state.sample_count = RD::get_singleton()->framebuffer_format_get_texture_samples(p_pipeline_key.framebuffer_format_id, 0);

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -163,6 +163,7 @@ public:
 			ShaderVersion version = SHADER_VERSION_MAX;
 			uint32_t render_pass = 0;
 			uint32_t wireframe = false;
+			float line_width = 1.0f;
 			uint32_t ubershader = false;
 
 			uint32_t hash() const {
@@ -177,6 +178,7 @@ public:
 				h = hash_murmur3_one_32(version, h);
 				h = hash_murmur3_one_32(render_pass, h);
 				h = hash_murmur3_one_32(wireframe, h);
+				h = hash_murmur3_one_32(line_width, h);
 				h = hash_murmur3_one_32(ubershader, h);
 				return hash_fmix32(h);
 			}

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -897,6 +897,7 @@ public:
 		// If not supported, a fragment shader with only side effects (i.e., writes  to buffers, but doesn't output to attachments), may be optimized down to no-op by the GPU driver.
 		SUPPORTS_FRAGMENT_SHADER_WITH_ONLY_SIDE_EFFECTS,
 		SUPPORTS_BUFFER_DEVICE_ADDRESS,
+		SUPPORTS_WIDE_LINES,
 	};
 
 	enum SubgroupOperations {

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3644,6 +3644,7 @@ void RenderingServer::init() {
 
 	GLOBAL_DEF_RST("rendering/driver/depth_prepass/enable", true);
 	GLOBAL_DEF_RST("rendering/driver/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno,Apple");
+	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "rendering/driver/line_drawing/width", PROPERTY_HINT_RANGE, "1.0,8.0,0.001"), 1.0);
 
 	GLOBAL_DEF_RST("rendering/textures/default_filters/use_nearest_mipmap_filter", false);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/textures/default_filters/anisotropic_filtering_level", PROPERTY_HINT_ENUM, String::utf8("Disabled (Fastest),2× (Faster),4× (Fast),8× (Average),16× (Slow)")), 2);


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/91171
Closes https://github.com/godotengine/godot-proposals/issues/9299

Rebased and used code from @Calinou and @myaaaaaaaaa 

- _In addition_ adds check to determine if GPU supports WIDE_LINES feature (**hopefully done correctly! 🙏**).

### _Line Width:_ **1**
![image](https://github.com/user-attachments/assets/79c2e482-8ceb-477d-a77b-4b5b28745a08)

### _Line Width:_ **5**
![image](https://github.com/user-attachments/assets/5156d48d-edab-411e-ba3b-7299b164e5ce)

