### PR TITLE
Fix Quaternion tolerance to take into account accumulated 4 float errors

### DIFF
--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -71,7 +71,10 @@ Quaternion Quaternion::normalized() const {
 }
 
 bool Quaternion::is_normalized() const {
-	return Math::is_equal_approx(length_squared(), 1, (real_t)UNIT_EPSILON); //use less epsilon
+	// Float input precision is 0.001 per component, then worst case sums push len2 off by about 0.004.
+	// So round-off margin bumps limit to 0.005.
+	constexpr real_t NRM_EPSILON = 0.005;
+	return Math::is_equal_approx(length_squared(), 1, NRM_EPSILON);
 }
 
 Quaternion Quaternion::inverse() const {


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/98090
- Supersedes/Closes https://github.com/godotengine/godot/pull/98308

For the Quaternion element in the Godot editor, the input precision of the float is 0.001. However, the accumulation of precision error in synthesizing four floats is not taken into account.

This PR ensures that the epsilon is determined taking into account the accumulation of errors. From a mathematical point of view, the worst-case error should be 0.004004, so the epsilon is 0.005 by ceil.

<details>

<summary>Calculation of accumulated error from 4 floats</summary>

```
Public callers are allowed an absolute component error of ±0.001.

For a unit quaternion q₀ = (x, y, z, w) and perturbation δᵢ:

‖q‖² = Σ(xᵢ + δᵢ)² = 1 + 2 Σ xᵢ δᵢ + Σ δᵢ²

with |δᵢ| ≤ 0.001,   Σ|xᵢ| ≤ 2  ⇒  |2 Σ xᵢ δᵢ| ≤ 0.004  

Σ δᵢ² ≤ 0.000004

Worst-case deviation ≈ 0.004004.
```

</details>

The following code will be identified as not normalized in most cases before the application of this PR, but will pass the normalization check after the PR is applied.

**test_quat_compose.gd**
```gdscript
extends Node3D

func _process(delta: float) -> void:
	var q: Quaternion = Quaternion(randf_range(-1, 1), randf_range(-1, 1), randf_range(-1, 1), randf_range(-1, 1)).normalized()
	q = Quaternion(snappedf(q.x, 0.001), snappedf(q.y, 0.001), snappedf(q.z, 0.001), snappedf(q.w, 0.001))

	if !q.is_normalized():
		print(str(q))
```

[test_quat.zip](https://github.com/user-attachments/files/20180648/test_quat.zip)

However, errors may still accumulate due to multiplication between quaternions.

This means that the result of multiplication between normalized quaternions may not be normalized. If the multiplication exceeds three times, normalize may collapse. This can be checked with the following gdscript.

**test_quat_accum.gd**
```gdscript
extends Node3D

func _process(delta: float) -> void:
	for i in range(100000):
		var q1: Quaternion = Quaternion(randf_range(-1, 1), randf_range(-1, 1), randf_range(-1, 1), randf_range(-1, 1)).normalized()
		q1 = Quaternion(snappedf(q1.x, 0.001), snappedf(q1.y, 0.001), snappedf(q1.z, 0.001), snappedf(q1.w, 0.001))
		var q2: Quaternion = Quaternion(randf_range(-1, 1), randf_range(-1, 1), randf_range(-1, 1), randf_range(-1, 1)).normalized()
		q2 = Quaternion(snappedf(q2.x, 0.001), snappedf(q2.y, 0.001), snappedf(q2.z, 0.001), snappedf(q2.w, 0.001))
		var q3: Quaternion = q1 * q2
		var q4: Quaternion = q3 * q1

		if q1.is_normalized() && q2.is_normalized() && q3.is_normalized() && !q4.is_normalized():
			print(str(q1), str(q2), str(q3), str(q4))
```

To solve this, it is safe to normalize the result of multiplication between normalized quaternions.

```cpp
constexpr void Quaternion::operator*=(const Quaternion &p_q) {
	bool is_safe = is_normalized() && p_q.is_normalized();
	real_t xx = w * p_q.x + x * p_q.w + y * p_q.z - z * p_q.y;
	real_t yy = w * p_q.y + y * p_q.w + z * p_q.x - x * p_q.z;
	real_t zz = w * p_q.z + z * p_q.w + x * p_q.y - y * p_q.x;
	w = w * p_q.w - x * p_q.x - y * p_q.y - z * p_q.z;
	x = xx;
	y = yy;
	z = zz;
	if (is_safe) {
		normalize();
	}
}
```

But I believe that this probably should not be done from a performance standpoint.

What we should find with care here is a function that directly returns the result of normalized Quaternion multiplication like `return q1 * q2;`. If anyone find that, I think it should be fixed accordingly as follow up this PR.

Also the fact that the multiplications between normalized Quaternion results may not be normalized, so that normalization is necessary may need to be documented, e.g., in the https://docs.godotengine.org/en/latest/tutorials/math/matrices_and_transforms.html.

