### PR TITLE
Fix Quaternion arc constructor tolerance

### DIFF
--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -139,7 +139,11 @@ struct [[nodiscard]] Quaternion {
 #ifdef MATH_CHECKS
 		ERR_FAIL_COND_MSG(p_v0.is_zero_approx() || p_v1.is_zero_approx(), "The vectors must not be zero.");
 #endif
-		constexpr real_t ALMOST_ONE = 1.0f - (real_t)CMP_EPSILON;
+#ifdef REAL_T_IS_DOUBLE
+		constexpr real_t ALMOST_ONE = 0.999999999999999;
+#else
+		constexpr real_t ALMOST_ONE = 0.99999975f;
+#endif
 		Vector3 n0 = p_v0.normalized();
 		Vector3 n1 = p_v1.normalized();
 		real_t d = n0.dot(n1);
@@ -162,6 +166,7 @@ struct [[nodiscard]] Quaternion {
 			z = c.z * rs;
 			w = s * 0.5f;
 		}
+		normalize();
 	}
 };
 


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/102679 to follow https://github.com/godotengine/godot/pull/102144

Also fix unsafe constructor for normalizing. With the fix with https://github.com/godotengine/godot/pull/106335, normalization is not necessary for the constructor, but I add there since errors will be accumulated, so the decimal point error generated in the constructor should be as small as possible.

A value of `0.00000025` seems reasonable. There is a close value `CMP_EPSILON2`, but when I used `CMP_EPSILON2` in Quaternion's arc constructor, it broke Basis in case `Quaternion(Vector3.FORWARD, Vector3.BACK)` and failed the test.

I have a feeling there are other places where `0.00000025` should be used, but when I changed it to be used for Basis and other checks, it caused an error in the test case, so it seems that it should be applied more carefully than I had thought.