### PR TITLE
Draw checkerboard (or clear color) under embedded window.

### DIFF
--- a/editor/plugins/embedded_process.h
+++ b/editor/plugins/embedded_process.h
@@ -47,6 +47,12 @@ protected:
 	Point2i margin_bottom_right;
 	Window *window = nullptr;
 
+	bool transp_enabled = false;
+	Color clear_color;
+	Ref<Texture2D> checkerboard;
+
+	void _project_settings_changed();
+
 	static void _bind_methods();
 	void _notification(int p_what);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3132,6 +3132,9 @@ Error Main::setup2(bool p_show_boot_logo) {
 			// from --position and --resolution parameters.
 			window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
 			window_flags = DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
+			if (bool(GLOBAL_GET("display/window/size/transparent"))) {
+				window_flags |= DisplayServer::WINDOW_FLAG_TRANSPARENT_BIT;
+			}
 		}
 
 #ifdef TOOLS_ENABLED

--- a/platform/macos/display_server_embedded.mm
+++ b/platform/macos/display_server_embedded.mm
@@ -192,7 +192,7 @@ DisplayServerEmbedded::DisplayServerEmbedded(const String &p_rendering_driver, W
 	layer.contentsScale = scale;
 	layer.magnificationFilter = kCAFilterNearest;
 	layer.minificationFilter = kCAFilterNearest;
-	layer.opaque = YES; // Always opaque when embedded.
+	layer.opaque = NO; // Never opaque when embedded, clear color is drawn by control under the view.
 	layer.actions = @{ @"contents" : [NSNull null] }; // Disable implicit animations for contents.
 	// AppKit frames, bounds and positions are always in points.
 	CGRect bounds = CGRectMake(0, 0, p_resolution.width, p_resolution.height);


### PR DESCRIPTION
- Allow transparency for embedded game window.
- Adds checkered background under the embedded transparent window to make testing it easier.

<img width="893" alt="Screenshot 2025-05-13 093314" src="https://github.com/user-attachments/assets/d5749bb9-bbcd-4f64-a0df-cf6db0a457ed" />

~Note: this will need a small adjustment after https://github.com/godotengine/godot/pull/106166/ is merged.~

Partially fixes https://github.com/godotengine/godot/issues/104680