### PR TITLE
Refactor `TextEdit::search` to be more robust to failure.

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -256,7 +256,7 @@ private:
 		void invalidate_all();
 		void invalidate_all_lines();
 
-		_FORCE_INLINE_ String operator[](int p_line) const;
+		_FORCE_INLINE_ const String &operator[](int p_line) const;
 		_FORCE_INLINE_ const String &get_text_with_ime(int p_line) const;
 
 		/* Gutters. */


### PR DESCRIPTION
- Required pre-work for https://github.com/godotengine/godot/pull/104332

The current implementation of this function is unnecessarily complex. The new implementation is more robust to failure or changing interfaces, by making fewer assumptions. Especially, it currently relies on `rfind` not caring exactly about indices out of bounds (defaulting to the back of the array), by being sloppy with its own indices, which makes it impossible to change this fact.

It should also be noticeably faster (by not changing string refcounts on iteration, and generally doing less logic), and hopefully a bit easier to understand too :)
