### PR TITLE
Clarify intrinsic/local Euler rotation order in 3D documentation

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1777,22 +1777,22 @@
 			A bit mask for [code]INLINE_ALIGNMENT_TO_*[/code] alignment constants.
 		</constant>
 		<constant name="EULER_ORDER_XYZ" value="0" enum="EulerOrder">
-			Specifies that Euler angles should be in XYZ order. When composing, the order is X, Y, Z. When decomposing, the order is reversed, first Z, then Y, and X last.
+			Specifies that Euler angles should be in intrinsic XYZ order. When composing, the rotations happen around the local X, Y, and Z axes, in that order. When decomposing, the order is reversed, first Z, then Y, and X last.
 		</constant>
 		<constant name="EULER_ORDER_XZY" value="1" enum="EulerOrder">
-			Specifies that Euler angles should be in XZY order. When composing, the order is X, Z, Y. When decomposing, the order is reversed, first Y, then Z, and X last.
+			Specifies that Euler angles should be in intrinsic XZY order. When composing, the rotations happen around the local X, Z, and Y axes, in that order. When decomposing, the order is reversed, first Y, then Z, and X last.
 		</constant>
 		<constant name="EULER_ORDER_YXZ" value="2" enum="EulerOrder">
-			Specifies that Euler angles should be in YXZ order. When composing, the order is Y, X, Z. When decomposing, the order is reversed, first Z, then X, and Y last.
+			Specifies that Euler angles should be in intrinsic YXZ order. When composing, the rotations happen around the local Y, X, and Z axes, in that order. When decomposing, the order is reversed, first Z, then X, and Y last.
 		</constant>
 		<constant name="EULER_ORDER_YZX" value="3" enum="EulerOrder">
-			Specifies that Euler angles should be in YZX order. When composing, the order is Y, Z, X. When decomposing, the order is reversed, first X, then Z, and Y last.
+			Specifies that Euler angles should be in intrinsic YZX order. When composing, the rotations happen around the local Y, Z, and X axes, in that order. When decomposing, the order is reversed, first X, then Z, and Y last.
 		</constant>
 		<constant name="EULER_ORDER_ZXY" value="4" enum="EulerOrder">
-			Specifies that Euler angles should be in ZXY order. When composing, the order is Z, X, Y. When decomposing, the order is reversed, first Y, then X, and Z last.
+			Specifies that Euler angles should be in intrinsic ZXY order. When composing, the rotations happen around the local Z, X, and Y axes, in that order. When decomposing, the order is reversed, first Y, then X, and Z last.
 		</constant>
 		<constant name="EULER_ORDER_ZYX" value="5" enum="EulerOrder">
-			Specifies that Euler angles should be in ZYX order. When composing, the order is Z, Y, X. When decomposing, the order is reversed, first X, then Y, and Z last.
+			Specifies that Euler angles should be in intrinsic ZYX order. When composing, the rotations happen around the local Z, Y, and X axes, in that order. When decomposing, the order is reversed, first X, then Y, and Z last.
 		</constant>
 		<constant name="KEY_NONE" value="0" enum="Key">
 			Enum value which doesn't correspond to any key. This is used to initialize [enum Key] properties with a generic state.

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -101,7 +101,7 @@
 				GD.Print(myBasis.Z); // Prints (0, -1, 0)
 				[/csharp]
 				[/codeblocks]
-				The order of each consecutive rotation can be changed with [param order] (see [enum EulerOrder] constants). By default, the YXZ convention is used ([constant EULER_ORDER_YXZ]): the basis rotates first around the Y axis (yaw), then X (pitch), and lastly Z (roll). When using the opposite method [method get_euler], this order is reversed.
+				The order of each consecutive rotation can be changed with [param order] (see [enum EulerOrder] constants). In Godot, Euler angles always use intrinsic order. By default, the intrinsic YXZ convention is used ([constant EULER_ORDER_YXZ]): the basis rotates first around the local Y axis (yaw), then local X (pitch), and lastly local Z (roll). When using the opposite method [method get_euler] to decompose a rotation, this order is reversed.
 			</description>
 		</method>
 		<method name="from_scale" qualifiers="static">
@@ -136,7 +136,7 @@
 				- The [member Vector3.x] contains the angle around the [member x] axis (pitch);
 				- The [member Vector3.y] contains the angle around the [member y] axis (yaw);
 				- The [member Vector3.z] contains the angle around the [member z] axis (roll).
-				The order of each consecutive rotation can be changed with [param order] (see [enum EulerOrder] constants). By default, the YXZ convention is used ([constant EULER_ORDER_YXZ]): Z (roll) is calculated first, then X (pitch), and lastly Y (yaw). When using the opposite method [method from_euler], this order is reversed.
+				The order of each consecutive rotation can be changed with [param order] (see [enum EulerOrder] constants). In Godot, Euler angles always use intrinsic order. By default, the intrinsic YXZ convention is used ([constant EULER_ORDER_YXZ]): since we are decomposing, local Z (roll) is calculated first, then local X (pitch), and lastly local Y (yaw). When using the opposite method [method from_euler] to compose a rotation, this order is reversed.
 				[b]Note:[/b] For this method to return correctly, the basis needs to be [i]orthonormal[/i] (see [method orthonormalized]).
 				[b]Note:[/b] Euler angles are much more intuitive but are not suitable for 3D math. Because of this, consider using the [method get_rotation_quaternion] method instead, which returns a [Quaternion].
 				[b]Note:[/b] In the Inspector dock, a basis's rotation is often displayed in Euler angles (in degrees), as is the case with the [member Node3D.rotation] property.

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -329,7 +329,7 @@
 			- The [member Vector3.x] is the angle around the local X axis (pitch);
 			- The [member Vector3.y] is the angle around the local Y axis (yaw);
 			- The [member Vector3.z] is the angle around the local Z axis (roll).
-			The order of each consecutive rotation can be changed with [member rotation_order] (see [enum EulerOrder] constants). By default, the YXZ convention is used ([constant EULER_ORDER_YXZ]).
+			The order of each consecutive rotation can be changed with [member rotation_order] (see [enum EulerOrder] constants). In Godot, Euler angles always use intrinsic order. By default, the intrinsic YXZ convention is used ([constant EULER_ORDER_YXZ]).
 			[b]Note:[/b] This property is edited in degrees in the inspector. If you want to use degrees in a script, use [member rotation_degrees].
 		</member>
 		<member name="rotation_degrees" type="Vector3" setter="set_rotation_degrees" getter="get_rotation_degrees">
@@ -340,7 +340,7 @@
 			How this node's rotation and scale are displayed in the Inspector dock.
 		</member>
 		<member name="rotation_order" type="int" setter="set_rotation_order" getter="get_rotation_order" enum="EulerOrder" default="2">
-			The axis rotation order of the [member rotation] property. The final orientation is calculated by rotating around the local X, Y, and Z axis in this order.
+			The axis rotation order of the [member rotation] property. In Godot, Euler angles always use intrinsic order, meaning that the final orientation is calculated by rotating around the local axes in this order.
 		</member>
 		<member name="scale" type="Vector3" setter="set_scale" getter="get_scale" default="Vector3(1, 1, 1)">
 			Scale of this node in local space (relative to this node). This value is obtained from [member basis]'s scale.
@@ -391,10 +391,10 @@
 			[b]Note:[/b] Some 3D nodes such as [CSGShape3D] or [CollisionShape3D] automatically enable this to function correctly.
 		</constant>
 		<constant name="ROTATION_EDIT_MODE_EULER" value="0" enum="RotationEditMode">
-			The rotation is edited using a [Vector3] in [url=https://en.wikipedia.org/wiki/Euler_angles]Euler angles[/url].
+			The rotation is edited using a [Vector3] in [url=https://en.wikipedia.org/wiki/Euler_angles]Euler angles[/url]. In Godot, Euler angles always use intrinsic order, meaning that rotation happens around the local axes of the object.
 		</constant>
 		<constant name="ROTATION_EDIT_MODE_QUATERNION" value="1" enum="RotationEditMode">
-			The rotation is edited using a [Quaternion].
+			The rotation is edited using a [Quaternion]. Quaternions avoid [url=$DOCS_URL/tutorials/3d/using_transforms.html]gimbal lock[/url] and having to choose an order of rotation, but are less intuitive. Quaternion rotation is mostly the same as rotors in 3D geometric algebra, except that the numbers are labeled differently.
 		</constant>
 		<constant name="ROTATION_EDIT_MODE_BASIS" value="2" enum="RotationEditMode">
 			The rotation is edited using a [Basis]. In this mode, the raw [member basis]'s axes can be freely modified, but the [member scale] property is not available.

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -96,7 +96,7 @@
 			<return type="Quaternion" />
 			<param index="0" name="euler" type="Vector3" />
 			<description>
-				Constructs a new [Quaternion] from the given [Vector3] of [url=https://en.wikipedia.org/wiki/Euler_angles]Euler angles[/url], in radians. This method always uses the YXZ convention ([constant EULER_ORDER_YXZ]).
+				Constructs a new [Quaternion] from the given [Vector3] of [url=https://en.wikipedia.org/wiki/Euler_angles]Euler angles[/url], in radians. In Godot, Euler angles always use intrinsic order. This method always uses the intrinsic YXZ convention ([constant EULER_ORDER_YXZ]).
 			</description>
 		</method>
 		<method name="get_angle" qualifiers="const">
@@ -117,7 +117,7 @@
 			<param index="0" name="order" type="int" default="2" />
 			<description>
 				Returns this quaternion's rotation as a [Vector3] of [url=https://en.wikipedia.org/wiki/Euler_angles]Euler angles[/url], in radians.
-				The order of each consecutive rotation can be changed with [param order] (see [enum EulerOrder] constants). By default, the YXZ convention is used ([constant EULER_ORDER_YXZ]): Z (roll) is calculated first, then X (pitch), and lastly Y (yaw). When using the opposite method [method from_euler], this order is reversed.
+				The order of each consecutive rotation can be changed with [param order] (see [enum EulerOrder] constants). In Godot, Euler angles always use intrinsic order. By default, the intrinsic YXZ convention is used ([constant EULER_ORDER_YXZ]): since we are decomposing, local Z (roll) is calculated first, then local X (pitch), and lastly local Y (yaw). When using the opposite method [method from_euler] to compose a rotation, this order is reversed.
 			</description>
 		</method>
 		<method name="inverse" qualifiers="const">


### PR DESCRIPTION
This PR fixes #105115 by clarifying the intrinsic/local Euler rotation behavior.

Rotating around the object's local axes is called the "intrinsic" rotation in math-speak. While the documentation already mentioned "local" in a few places, we didn't mention "intrinsic" even once before, and didn't mention "local" enough either.

Game developers expect intrinsic rotation, but Blender uses extrinsic. Either way, it's good clarify to avoid confusion.