### PR TITLE
macOS: Fix `template_debug` build after #105884

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -460,7 +460,7 @@ public:
 	virtual bool get_swap_cancel_ok() override;
 
 	virtual void enable_for_stealing_focus(OS::ProcessID pid) override;
-#ifdef DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
 	Error embed_process_update(WindowID p_window, const EmbeddedProcessMacOS *p_process);
 #endif
 	virtual Error request_close_embedded_process(OS::ProcessID p_pid) override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -30,9 +30,6 @@
 
 #import "display_server_macos.h"
 
-#ifdef DEBUG_ENABLED
-#import "editor/embedded_process_macos.h"
-#endif
 #import "godot_application.h"
 #import "godot_application_delegate.h"
 #import "godot_button_view.h"
@@ -55,6 +52,10 @@
 #include "drivers/png/png_driver_common.h"
 #include "main/main.h"
 #include "scene/resources/image_texture.h"
+
+#ifdef TOOLS_ENABLED
+#import "editor/embedded_process_macos.h"
+#endif
 
 #include <AppKit/AppKit.h>
 
@@ -3283,7 +3284,7 @@ void DisplayServerMacOS::enable_for_stealing_focus(OS::ProcessID pid) {
 		ERR_FAIL_V(m_retval);                        \
 	}
 
-#ifdef DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
 
 Error DisplayServerMacOS::embed_process_update(WindowID p_window, const EmbeddedProcessMacOS *p_process) {
 	_THREAD_SAFE_METHOD_


### PR DESCRIPTION
There's a few more uses of `DEBUG_ENABLED` in #105884 which may need to be reviewed and might also be intended only for editor/tools builds.