### PR TITLE
[macOS] Fix embedded window position when host control is moved, but not resized.

### DIFF
--- a/platform/macos/editor/embedded_process_macos.mm
+++ b/platform/macos/editor/embedded_process_macos.mm
@@ -43,7 +43,10 @@
 
 void EmbeddedProcessMacOS::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_RESIZED:
+		case NOTIFICATION_ENTER_TREE: {
+			set_notify_transform(true);
+		} break;
+		case NOTIFICATION_TRANSFORM_CHANGED:
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			update_embedded_process();
 		} break;


### PR DESCRIPTION
A quick fix for resizing issue mentioned in https://github.com/godotengine/godot/pull/106166 review.