### PR TITLE
Remove "prioritize master" comment on PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,4 @@
 <!--
-Please target the `master` branch in priority.
-
-Relevant fixes are cherry-picked for stable branches as needed by maintainers.
-
 To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
 https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
 -->


### PR DESCRIPTION
Removes a remnant developing 4.0 pre-release.

![Capture d’écran du 2025-05-13 07-56-28](https://github.com/user-attachments/assets/4d1515f8-bd00-4a2d-bff1-9425a4652a65)
