### PR TITLE
Increase float precision in the editor inspector for Quaternions

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -128,7 +128,10 @@ void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 					pre_grab_value = get_max();
 				}
 
-				double new_value = pre_grab_value + get_step() * grabbing_spinner_dist_cache;
+				// Prevent dragging properties with very precise steps from being agonizingly slow.
+				const double default_float_step = EDITOR_GET("interface/inspector/default_float_step");
+				const double drag_step = MAX(get_step(), default_float_step);
+				const double new_value = pre_grab_value + drag_step * grabbing_spinner_dist_cache;
 				set_value((mm->is_command_or_control_pressed() && !editing_integer) ? Math::round(new_value) : new_value);
 			}
 		} else if (updown_offset != -1) {

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -4029,7 +4029,14 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 		} break;
 		case Variant::QUATERNION: {
 			EditorPropertyQuaternion *editor = memnew(EditorPropertyQuaternion);
-			editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step), p_hint == PROPERTY_HINT_HIDE_QUATERNION_EDIT);
+			// Quaternions are almost never used for human-readable values that need stepifying,
+			// so we should be more precise with their step, as much as the float precision allows.
+#ifdef REAL_T_IS_DOUBLE
+			constexpr double QUATERNION_STEP = 1e-14;
+#else
+			constexpr double QUATERNION_STEP = 1e-6;
+#endif
+			editor->setup(_parse_range_hint(p_hint, p_hint_text, QUATERNION_STEP), p_hint == PROPERTY_HINT_HIDE_QUATERNION_EDIT);
 			return editor;
 		} break;
 		case Variant::AABB: {

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -78,7 +78,18 @@ void BonePropertiesEditor::create_editors() {
 
 	// Rotation property.
 	rotation_property = memnew(EditorPropertyQuaternion());
-	rotation_property->setup(large_range_hint);
+	// Quaternions are almost never used for human-readable values that need stepifying,
+	// so we should be more precise with their step, as much as the float precision allows.
+#ifdef REAL_T_IS_DOUBLE
+	constexpr double QUATERNION_STEP = 1e-14;
+#else
+	constexpr double QUATERNION_STEP = 1e-6;
+#endif
+	EditorPropertyRangeHint quaternion_range_hint;
+	quaternion_range_hint.min = -1.0;
+	quaternion_range_hint.max = 1.0;
+	quaternion_range_hint.step = QUATERNION_STEP;
+	rotation_property->setup(quaternion_range_hint);
 	rotation_property->set_label("Rotation");
 	rotation_property->set_selectable(false);
 	rotation_property->connect("property_changed", callable_mp(this, &BonePropertiesEditor::_value_changed));


### PR DESCRIPTION
Made in response to #106335. For Quaternions, it's better to display more digits in the inspector for precision, beyond the usual float step found in the editor settings in `"interface/inspector/default_float_step"`. Note that property hints can still override the step to a different value, this change only overrides the editor setting.

This PR also adjusts the `EditorSpinSlider` code to clamp the step used for dragging to a minimum of 0.001. Without this change, clicking and dragging on Quaternion elements becomes very slow. I didn't even test double precision, but imagine how slow that would be too. This may affect editor plugins that expect this behavior, but I don't think it's good behavior. It's bad to discourage users from using high precision because the usability is worse. Perhaps there needs to be separate settings for drag step and the actual number step, but that's a larger proposal...

_Bugsquad Edited:_
- Fixes https://github.com/godotengine/godot/issues/98090