### PR TITLE
Optimize `HashMap` size for zero-sized Allocators

### DIFF
--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -66,14 +66,13 @@ template <typename TKey, typename TValue,
 		typename Hasher = HashMapHasherDefault,
 		typename Comparator = HashMapComparatorDefault<TKey>,
 		typename Allocator = DefaultTypedAllocator<HashMapElement<TKey, TValue>>>
-class HashMap {
+class HashMap : private Allocator {
 public:
 	static constexpr uint32_t MIN_CAPACITY_INDEX = 2; // Use a prime.
 	static constexpr float MAX_OCCUPANCY = 0.75;
 	static constexpr uint32_t EMPTY_HASH = 0;
 
 private:
-	Allocator element_alloc;
 	HashMapElement<TKey, TValue> **elements = nullptr;
 	uint32_t *hashes = nullptr;
 	HashMapElement<TKey, TValue> *head_element = nullptr;
@@ -214,7 +213,7 @@ private:
 			_resize_and_rehash(capacity_index + 1);
 		}
 
-		HashMapElement<TKey, TValue> *elem = element_alloc.new_allocation(HashMapElement<TKey, TValue>(p_key, p_value));
+		HashMapElement<TKey, TValue> *elem = Allocator::new_allocation(HashMapElement<TKey, TValue>(p_key, p_value));
 
 		if (tail_element == nullptr) {
 			head_element = elem;
@@ -254,7 +253,7 @@ public:
 			}
 
 			hashes[i] = EMPTY_HASH;
-			element_alloc.delete_allocation(elements[i]);
+			Allocator::delete_allocation(elements[i]);
 			elements[i] = nullptr;
 		}
 
@@ -379,7 +378,7 @@ public:
 			elements[pos]->next->prev = elements[pos]->prev;
 		}
 
-		element_alloc.delete_allocation(elements[pos]);
+		Allocator::delete_allocation(elements[pos]);
 		elements[pos] = nullptr;
 
 		num_elements--;


### PR DESCRIPTION
Make `HashMap` privately inherit from `Allocator` to benefit from the Empty Base Optimization (EBO). With this change, a `HashMap` using `DefaultTypedAllocator` is reduced in size from 48 bytes to 40 bytes. `HashMap`s using allocators with a non-zero size (such as `PagedAllocator`) are unaffected.

