### PR TITLE
[Android] Add support for 16 KB page sizes, update to NDK r28b

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -68,7 +68,7 @@ def get_android_ndk_root(env: "SConsEnvironment"):
 
 # This is kept in sync with the value in 'platform/android/java/app/config.gradle'.
 def get_ndk_version():
-    return "27.2.12479018"
+    return "28.1.13356709"
 
 
 # This is kept in sync with the value in 'platform/android/java/app/config.gradle'.

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -13,7 +13,7 @@ ext.versions = [
     nexusPublishVersion: '1.3.0',
     javaVersion        : JavaVersion.VERSION_17,
     // Also update 'platform/android/detect.py#get_ndk_version()' when this is updated.
-    ndkVersion         : '27.2.12479018',
+    ndkVersion         : '28.1.13356709',
     splashscreenVersion: '1.0.1',
     openxrVendorsVersion: '4.0.0-stable'
 

--- a/platform/android/java/nativeSrcsConfigs/CMakeLists.txt
+++ b/platform/android/java/nativeSrcsConfigs/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Non functional cmake build file used to provide Android Studio editor support to the project.
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.10)
 project(godot)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
Bump the NDK to version 28.1.13356709; doing so automatically adds support for 16kib page to the Godot Android shared libraries. See https://developer.android.com/guide/practices/page-sizes#compile-16-kb-alignment for details.

Fixes https://github.com/godotengine/godot/issues/106313

This PR, alongside https://github.com/godotengine/godot/pull/106152 and https://github.com/godotengine/godot/pull/105611 should be cherry-picked to previous releases to provide similar support for 16kb page sizes.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
