### PR TITLE
Remove the `gradle_build/compress_native_libraries` export option (reverted)

### DIFF
--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -52,10 +52,6 @@
 		<member name="gradle_build/android_source_template" type="String" setter="" getter="">
 			Path to a ZIP file holding the source for the export template used in a Gradle build. If left empty, the default template is used.
 		</member>
-		<member name="gradle_build/compress_native_libraries" type="bool" setter="" getter="">
-			If [code]true[/code], native libraries are compressed when performing a Gradle build.
-			[b]Note:[/b] Although your binary may be smaller, your application may load slower because the native libraries are not loaded directly from the binary at runtime.
-		</member>
 		<member name="gradle_build/export_format" type="int" setter="" getter="">
 			Application export format (*.apk or *.aab).
 		</member>

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1950,11 +1950,6 @@ String EditorExportPlatformAndroid::get_export_option_warning(const EditorExport
 			if (!enabled_deprecated_plugins_names.is_empty() && !gradle_build_enabled) {
 				return TTR("\"Use Gradle Build\" must be enabled to use the plugins.");
 			}
-		} else if (p_name == "gradle_build/compress_native_libraries") {
-			bool gradle_build_enabled = p_preset->get("gradle_build/use_gradle_build");
-			if (bool(p_preset->get("gradle_build/compress_native_libraries")) && !gradle_build_enabled) {
-				return TTR("\"Compress Native Libraries\" is only valid when \"Use Gradle Build\" is enabled.");
-			}
 		} else if (p_name == "gradle_build/export_format") {
 			bool gradle_build_enabled = p_preset->get("gradle_build/use_gradle_build");
 			if (int(p_preset->get("gradle_build/export_format")) == EXPORT_FORMAT_AAB && !gradle_build_enabled) {
@@ -2026,7 +2021,6 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "gradle_build/use_gradle_build"), false, true, true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "gradle_build/gradle_build_directory", PROPERTY_HINT_PLACEHOLDER_TEXT, "res://android"), "", false, false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "gradle_build/android_source_template", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "gradle_build/compress_native_libraries"), false, false, true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "gradle_build/export_format", PROPERTY_HINT_ENUM, "Export APK,Export AAB"), EXPORT_FORMAT_APK, false, true));
 	// Using String instead of int to default to an empty string (no override) with placeholder for instructions (see GH-62465).
 	// This implies doing validation that the string is a proper int.
@@ -3500,7 +3494,6 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		String enabled_abi_string = join_abis(enabled_abis, "|", false);
 		String sign_flag = should_sign ? "true" : "false";
 		String zipalign_flag = "true";
-		String compress_native_libraries_flag = bool(p_preset->get("gradle_build/compress_native_libraries")) ? "true" : "false";
 
 		Vector<String> android_libraries;
 		Vector<String> android_dependencies;
@@ -3575,7 +3568,6 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		cmdline.push_back("-Pplugins_maven_repos=" + combined_android_dependencies_maven_repos); // argument to specify the list of maven repos for android dependencies provided by plugins.
 		cmdline.push_back("-Pperform_zipalign=" + zipalign_flag); // argument to specify whether the build should be zipaligned.
 		cmdline.push_back("-Pperform_signing=" + sign_flag); // argument to specify whether the build should be signed.
-		cmdline.push_back("-Pcompress_native_libraries=" + compress_native_libraries_flag); // argument to specify whether the build should compress native libraries.
 
 		// NOTE: The release keystore is not included in the verbose logging
 		// to avoid accidentally leaking sensitive information when sharing verbose logs for troubleshooting.

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -132,14 +132,6 @@ android {
             doNotStrip '**/*.so'
         }
 
-        jniLibs {
-            // Setting this to true causes AGP to package compressed native libraries when building the app
-            // For more background, see:
-            // - https://developer.android.com/build/releases/past-releases/agp-3-6-0-release-notes#extractNativeLibs
-            // - https://stackoverflow.com/a/44704840
-            useLegacyPackaging shouldUseLegacyPackaging()
-        }
-
         // Always select Godot's version of libc++_shared.so in case deps have their own
         pickFirst 'lib/x86/libc++_shared.so'
         pickFirst 'lib/x86_64/libc++_shared.so'

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -375,24 +375,6 @@ ext.shouldNotStrip = { ->
     return isAndroidStudio() || project.hasProperty("doNotStrip")
 }
 
-/**
- * Whether to use the legacy convention of compressing all .so files in the APK.
- *
- * For more background, see:
- * - https://developer.android.com/build/releases/past-releases/agp-3-6-0-release-notes#extractNativeLibs
- * - https://stackoverflow.com/a/44704840
- */
-ext.shouldUseLegacyPackaging = { ->
-    int minSdk = getExportMinSdkVersion()
-    String legacyPackagingFlag = project.hasProperty("compress_native_libraries") ? project.property("compress_native_libraries") : ""
-    if (legacyPackagingFlag != null && !legacyPackagingFlag.isEmpty()) {
-        return Boolean.parseBoolean(legacyPackagingFlag)
-    }
-
-    // Default behavior for minSdk >= 24
-    return false
-}
-
 ext.getAddonsDirectory = { ->
     String addonsDirectory = project.hasProperty("addons_directory") ? project.property("addons_directory") : ""
     return addonsDirectory


### PR DESCRIPTION
Support for 16kb page size added in the previous PR requires the native libraries to be uncompressed, so we're deprecating and removing the option to compress native libraries.
See https://developer.android.com/guide/practices/page-sizes#agp_version_851_or_higher for more details.

Follow-up to https://github.com/godotengine/godot/pull/106358, this is a separate commit / PR since **it shouldn't be cherry-picked in previous releases as it removes existing functionality**.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
