### PR TITLE
Rewritten viewport to remove size_2d_override and add resolution_override instead

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3908,6 +3908,13 @@
 				Returns the viewport's last rendered frame.
 			</description>
 		</method>
+		<method name="viewport_get_size">
+			<return type="Size2i" />
+			<param index="0" name="viewport" type="RID" />
+			<description>
+				Gets the viewport's width and height in pixels.
+			</description>
+		</method>
 		<method name="viewport_get_update_mode" qualifiers="const">
 			<return type="int" enum="RenderingServer.ViewportUpdateMode" />
 			<param index="0" name="viewport" type="RID" />
@@ -4165,13 +4172,6 @@
 			<param index="2" name="height" type="int" />
 			<description>
 				Sets the viewport's width and height in pixels.
-			</description>
-		</method>
-		<method name="viewport_get_size">
-			<return type="Size2i" />
-			<param index="0" name="viewport" type="RID" />
-			<description>
-				Gets the viewport's width and height in pixels.
 			</description>
 		</method>
 		<method name="viewport_set_snap_2d_transforms_to_pixel">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -4167,6 +4167,13 @@
 				Sets the viewport's width and height in pixels.
 			</description>
 		</method>
+		<method name="viewport_get_size">
+			<return type="Size2i" />
+			<param index="0" name="viewport" type="RID" />
+			<description>
+				Gets the viewport's width and height in pixels.
+			</description>
+		</method>
 		<method name="viewport_set_snap_2d_transforms_to_pixel">
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />

--- a/doc/classes/SubViewport.xml
+++ b/doc/classes/SubViewport.xml
@@ -19,6 +19,9 @@
 		<link title="3D Resolution Scaling Demo">https://godotengine.org/asset-library/asset/2805</link>
 	</tutorials>
 	<members>
+		<member name="auto_adjust_resolution" type="bool" setter="set_auto_adjust_resolution" getter="get_auto_adjust_resolutione" default="false">
+			Set to true to automatically resize the resolution of the backing texture if the game window is resized. If a [member SubViewport.texture_resolution_override] is set, it will scale this value instead.
+		</member>
 		<member name="render_target_clear_mode" type="int" setter="set_clear_mode" getter="get_clear_mode" enum="SubViewport.ClearMode" default="0">
 			The clear mode when the sub-viewport is used as a render target.
 			[b]Note:[/b] This property is intended for 2D usage.
@@ -31,9 +34,6 @@
 		</member>
 		<member name="texture_resolution_override" type="Vector2i" setter="set_texture_resolution_override" getter="get_texture_resolution_override" default="Vector2i(0, 0)">
 			The size to initialize the backing texture at. If both values are set to a value greater than [code]0[/code], these dimensions will be used when the viewport texture is initialized.
-		</member>
-		<member name="auto_adjust_resolution" type="bool" setter="set_auto_adjust_resolution" getter="get_auto_adjust_resolutione" default="false">
-			Set to true to automatically resize the resolution of the backing texture if the game window is resized. If a [member SubViewport.texture_resolution_override] is set, it will scale this value instead.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/SubViewport.xml
+++ b/doc/classes/SubViewport.xml
@@ -26,15 +26,11 @@
 		<member name="render_target_update_mode" type="int" setter="set_update_mode" getter="get_update_mode" enum="SubViewport.UpdateMode" default="2">
 			The update mode when the sub-viewport is used as a render target.
 		</member>
-		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i(512, 512)">
-			The width and height of the sub-viewport. Must be set to a value greater than or equal to 2 pixels on both dimensions. Otherwise, nothing will be displayed.
-			[b]Note:[/b] If the parent node is a [SubViewportContainer] and its [member SubViewportContainer.stretch] is [code]true[/code], the viewport size cannot be changed manually.
+		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2(512, 512)">
+			The width and height of the sub-viewport. This will also be used as the resolution of the backing texture unless a resolution is specified in [member SubViewport.texture_resolution_override]
 		</member>
-		<member name="size_2d_override" type="Vector2i" setter="set_size_2d_override" getter="get_size_2d_override" default="Vector2i(0, 0)">
-			The 2D size override of the sub-viewport. If either the width or height is [code]0[/code], the override is disabled.
-		</member>
-		<member name="size_2d_override_stretch" type="bool" setter="set_size_2d_override_stretch" getter="is_size_2d_override_stretch_enabled" default="false">
-			If [code]true[/code], the 2D size override affects stretch as well.
+		<member name="texture_resolution_override" type="Vector2i" setter="set_texture_resolution_override" getter="get_texture_resolution_override" default="Vector2i(0, 0)">
+			The size to initialize the backing texture at. If both values are set to a value greater than [code]0[/code], these dimensions will be used when the viewport texture is initialized
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/SubViewport.xml
+++ b/doc/classes/SubViewport.xml
@@ -27,10 +27,13 @@
 			The update mode when the sub-viewport is used as a render target.
 		</member>
 		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2(512, 512)">
-			The width and height of the sub-viewport. This will also be used as the resolution of the backing texture unless a resolution is specified in [member SubViewport.texture_resolution_override]
+			The width and height of the sub-viewport. This will also be used as the resolution of the backing texture unless a resolution is specified in [member SubViewport.texture_resolution_override].
 		</member>
 		<member name="texture_resolution_override" type="Vector2i" setter="set_texture_resolution_override" getter="get_texture_resolution_override" default="Vector2i(0, 0)">
-			The size to initialize the backing texture at. If both values are set to a value greater than [code]0[/code], these dimensions will be used when the viewport texture is initialized
+			The size to initialize the backing texture at. If both values are set to a value greater than [code]0[/code], these dimensions will be used when the viewport texture is initialized.
+		</member>
+		<member name="auto_adjust_resolution" type="bool" setter="set_auto_adjust_resolution" getter="get_auto_adjust_resolutione" default="false">
+			Set to true to automatically resize the resolution of the backing texture if the game window is resized. If a [member SubViewport.texture_resolution_override] is set, it will scale this value instead.
 		</member>
 	</members>
 	<constants>

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -104,6 +104,10 @@ Rect2 AnimatedSprite2D::_get_rect() const {
 	if (centered) {
 		ofs -= s / 2;
 	}
+	Ref<AtlasTexture> atlas_texture = t;
+	if (atlas_texture.is_valid()) {
+		ofs -= atlas_texture->get_pivot();
+	}
 
 	if (s == Size2(0, 0)) {
 		s = Size2(1, 1);
@@ -277,6 +281,10 @@ void AnimatedSprite2D::_notification(int p_what) {
 			Point2 ofs = offset;
 			if (centered) {
 				ofs -= s / 2;
+			}
+			Ref<AtlasTexture> atlas_texture = texture;
+			if (atlas_texture.is_valid()) {
+				ofs -= atlas_texture->get_pivot();
 			}
 
 			if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -31,8 +31,8 @@
 #pragma once
 
 #include "scene/2d/node_2d.h"
-#include "scene/resources/sprite_frames.h"
 #include "scene/resources/atlas_texture.h"
+#include "scene/resources/sprite_frames.h"
 
 class AnimatedSprite2D : public Node2D {
 	GDCLASS(AnimatedSprite2D, Node2D);

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -32,6 +32,7 @@
 
 #include "scene/2d/node_2d.h"
 #include "scene/resources/sprite_frames.h"
+#include "scene/resources/atlas_texture.h"
 
 class AnimatedSprite2D : public Node2D {
 	GDCLASS(AnimatedSprite2D, Node2D);

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -114,6 +114,10 @@ void Sprite2D::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_c
 	if (centered) {
 		dest_offset -= frame_size / 2;
 	}
+	Ref<AtlasTexture> atlas_texture = texture;
+	if (atlas_texture.is_valid()) {
+		dest_offset -= atlas_texture->get_pivot();
+	}
 
 	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
 		dest_offset = (dest_offset + Point2(0.5, 0.5)).floor();
@@ -133,6 +137,10 @@ Point2 Sprite2D::_get_rect_offset(const Size2i &p_size) const {
 	Point2 ofs = offset;
 	if (centered) {
 		ofs -= Size2(p_size) / 2;
+	}
+	Ref<AtlasTexture> atlas_texture = texture;
+	if (atlas_texture.is_valid()) {
+		ofs -= atlas_texture->get_pivot();
 	}
 
 	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -32,6 +32,7 @@
 
 #include "scene/2d/node_2d.h"
 #include "scene/resources/texture.h"
+#include "scene/resources/atlas_texture.h"
 
 class Sprite2D : public Node2D {
 	GDCLASS(Sprite2D, Node2D);

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -31,8 +31,9 @@
 #pragma once
 
 #include "scene/2d/node_2d.h"
-#include "scene/resources/texture.h"
 #include "scene/resources/atlas_texture.h"
+#include "scene/resources/texture.h"
+
 
 class Sprite2D : public Node2D {
 	GDCLASS(Sprite2D, Node2D);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -574,9 +574,9 @@ void Viewport::_notification(int p_what) {
 				set_physics_process_internal(true);
 			}
 #endif // !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
-			SceneTree* scene_tree = SceneTree::get_singleton();
+			SceneTree *scene_tree = SceneTree::get_singleton();
 			if (scene_tree) {
-				Viewport* root_vp = scene_tree->get_root()->get_viewport();
+				Viewport *root_vp = scene_tree->get_root()->get_viewport();
 				if (root_vp) {
 					root_vp->connect("size_changed", callable_mp(this, &Viewport::_root_viewport_size_changed));
 				}
@@ -644,9 +644,9 @@ void Viewport::_notification(int p_what) {
 
 			RS::get_singleton()->viewport_set_active(viewport, false);
 			RenderingServer::get_singleton()->viewport_set_parent_viewport(viewport, RID());
-			SceneTree* scene_tree = SceneTree::get_singleton();
+			SceneTree *scene_tree = SceneTree::get_singleton();
 			if (scene_tree) {
-				Viewport* root_vp = scene_tree->get_root()->get_viewport();
+				Viewport *root_vp = scene_tree->get_root()->get_viewport();
 				if (root_vp) {
 					root_vp->disconnect("size_changed", callable_mp(this, &Viewport::_root_viewport_size_changed));
 				}
@@ -1150,18 +1150,18 @@ bool Viewport::_set_size(const Size2 &p_size, const Size2i &p_texture_resolution
 
 Size2i Viewport::_calculate_texture_resolution(const Size2 &p_size, const Size2i &p_texture_resolution_override, const bool p_auto_adjust) const {
 	Size2i resolution = p_texture_resolution_override.width > 0 && p_texture_resolution_override.height > 0 ? p_texture_resolution_override : Size2i(p_size.ceil()).maxi(2);
-	if(p_auto_adjust) {
+	if (p_auto_adjust) {
 		Size2 scale = Size2(1, 1);
-		SceneTree* scene_tree = SceneTree::get_singleton();
+		SceneTree *scene_tree = SceneTree::get_singleton();
 		if (scene_tree) {
-			Viewport* vp = scene_tree->get_root()->get_viewport();
-			if(vp) {
+			Viewport *vp = scene_tree->get_root()->get_viewport();
+			if (vp) {
 				scale = Size2(vp->_calculate_texture_resolution(vp->size, vp->texture_resolution_override, false)) / vp->size;
 			}
 		}
 		resolution = Size2i(Math::ceil(resolution.x * scale.x), Math::ceil(resolution.y * scale.y));
 		Size2i current_texture_size = RS::get_singleton()->viewport_get_size(viewport);
-		if(resolution.x < current_texture_size.x && resolution.y < current_texture_size.y) {
+		if (resolution.x < current_texture_size.x && resolution.y < current_texture_size.y) {
 			resolution = current_texture_size;
 		}
 	}
@@ -1169,7 +1169,7 @@ Size2i Viewport::_calculate_texture_resolution(const Size2 &p_size, const Size2i
 }
 
 void Viewport::_root_viewport_size_changed() {
-	if(auto_adjust_resolution) {
+	if (auto_adjust_resolution) {
 		_update_viewport_with_current_settings();
 	}
 }
@@ -1181,7 +1181,7 @@ void Viewport::_update_viewport_with_current_settings() {
 void Viewport::_update_viewport_resolution() {
 	if (size_allocated) {
 		Size2i resolution = _calculate_texture_resolution(_get_size(), texture_resolution_override, auto_adjust_resolution);
-		if(resolution != RS::get_singleton()->viewport_get_size(viewport)) {
+		if (resolution != RS::get_singleton()->viewport_get_size(viewport)) {
 			RS::get_singleton()->viewport_set_size(viewport, resolution.width, resolution.height);
 		}
 	} else {
@@ -1214,7 +1214,7 @@ bool Viewport::_is_size_allocated() const {
 }
 
 void Viewport::_set_auto_adjust_resolution(const bool &p_enable) {
-	if(auto_adjust_resolution != p_enable) {
+	if (auto_adjust_resolution != p_enable) {
 		auto_adjust_resolution = p_enable;
 		_update_viewport_with_current_settings();
 	}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1181,9 +1181,6 @@ void Viewport::_update_viewport_with_current_settings() {
 void Viewport::_update_viewport_resolution() {
 	if (size_allocated) {
 		Size2i resolution = _calculate_texture_resolution(_get_size(), texture_resolution_override, auto_adjust_resolution);
-		print_line("Size: " + _get_size());
-		print_line("Tex Override: " + texture_resolution_override);
-		print_line("Resolution: " + resolution);
 		if(resolution != RS::get_singleton()->viewport_get_size(viewport)) {
 			RS::get_singleton()->viewport_set_size(viewport, resolution.width, resolution.height);
 		}

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -254,8 +254,8 @@ private:
 	Transform2D global_canvas_transform;
 	Transform2D stretch_transform;
 
-	Size2i size = Size2i(512, 512);
-	Size2 size_2d_override;
+	Size2 size = Size2(512, 512);
+	Size2i texture_resolution_override;
 	bool size_allocated = false;
 
 	RID contact_2d_debug;
@@ -501,10 +501,12 @@ private:
 	void _window_start_resize(SubWindowResize p_edge, Window *p_window);
 
 protected:
-	bool _set_size(const Size2i &p_size, const Size2 &p_size_2d_override, bool p_allocated);
+	bool _set_size(const Size2 &p_size, const Size2i &p_texture_resolution_override, bool p_allocated);
 
-	Size2i _get_size() const;
-	Size2 _get_size_2d_override() const;
+	Size2 _get_size() const;
+	Size2i _get_texture_resolution_override() const;
+	bool _valid_texture_resolution_override() const;
+	Size2i _texture_resolution_adjusted() const;
 	bool _is_size_allocated() const;
 
 	void _notification(int p_what);
@@ -725,8 +727,6 @@ public:
 	bool is_visible_subviewport() const;
 #endif // TOOLS_ENABLED
 
-	virtual bool is_size_2d_override_stretch_enabled() const { return true; }
-
 	Transform2D get_screen_transform() const;
 	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const;
 	virtual Transform2D get_popup_base_transform() const { return Transform2D(); }
@@ -875,9 +875,8 @@ public:
 private:
 	UpdateMode update_mode = UPDATE_WHEN_VISIBLE;
 	ClearMode clear_mode = CLEAR_MODE_ALWAYS;
-	bool size_2d_override_stretch = false;
 
-	void _internal_set_size(const Size2i &p_size, bool p_force = false);
+	void _internal_set_size(const Size2 &p_size, bool p_force = false);
 
 protected:
 	static void _bind_methods();
@@ -885,15 +884,12 @@ protected:
 	void _notification(int p_what);
 
 public:
-	void set_size(const Size2i &p_size);
-	Size2i get_size() const;
-	void set_size_force(const Size2i &p_size);
-
-	void set_size_2d_override(const Size2i &p_size);
-	Size2i get_size_2d_override() const;
-
-	void set_size_2d_override_stretch(bool p_enable);
-	bool is_size_2d_override_stretch_enabled() const override;
+	void set_size(const Size2 &p_size);
+	Size2 get_size() const;
+	void set_size_force(const Size2 &p_size);
+	
+	void set_texture_resolution_override(const Size2i &p_size);
+	Size2i get_texture_resolution_override() const;
 
 	void set_update_mode(UpdateMode p_mode);
 	UpdateMode get_update_mode() const;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -502,6 +502,7 @@ private:
 	void _window_start_resize(SubWindowResize p_edge, Window *p_window);
 
 	void _root_viewport_size_changed();
+	void _update_viewport_with_current_settings(); 
 	void _update_viewport_resolution();
 
 protected:

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -257,6 +257,7 @@ private:
 	Size2 size = Size2(512, 512);
 	Size2i texture_resolution_override;
 	bool size_allocated = false;
+	bool auto_adjust_resolution = false;
 
 	RID contact_2d_debug;
 	RID contact_3d_debug_multimesh;
@@ -500,14 +501,20 @@ private:
 	void _window_start_drag(Window *p_window);
 	void _window_start_resize(SubWindowResize p_edge, Window *p_window);
 
+	void _root_viewport_size_changed();
+	void _update_viewport_resolution();
+
 protected:
 	bool _set_size(const Size2 &p_size, const Size2i &p_texture_resolution_override, bool p_allocated);
 
 	Size2 _get_size() const;
 	Size2i _get_texture_resolution_override() const;
-	bool _valid_texture_resolution_override() const;
-	Size2i _texture_resolution_adjusted() const;
+	Size2i _calculate_texture_resolution(const Size2 &p_size, const Size2i &p_texture_resolution_override, const bool p_auto_adjust) const;
+	
 	bool _is_size_allocated() const;
+
+	void _set_auto_adjust_resolution(const bool &p_enable);
+	bool _is_auto_adjust_resolution_enabled() const;
 
 	void _notification(int p_what);
 #if !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
@@ -890,6 +897,9 @@ public:
 	
 	void set_texture_resolution_override(const Size2i &p_size);
 	Size2i get_texture_resolution_override() const;
+
+	void set_auto_adjust_resolution(const bool &p_enable);
+	bool get_auto_adjust_resolution() const;
 
 	void set_update_mode(UpdateMode p_mode);
 	UpdateMode get_update_mode() const;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -502,7 +502,7 @@ private:
 	void _window_start_resize(SubWindowResize p_edge, Window *p_window);
 
 	void _root_viewport_size_changed();
-	void _update_viewport_with_current_settings(); 
+	void _update_viewport_with_current_settings();
 	void _update_viewport_resolution();
 
 protected:
@@ -511,7 +511,7 @@ protected:
 	Size2 _get_size() const;
 	Size2i _get_texture_resolution_override() const;
 	Size2i _calculate_texture_resolution(const Size2 &p_size, const Size2i &p_texture_resolution_override, const bool p_auto_adjust) const;
-	
+
 	bool _is_size_allocated() const;
 
 	void _set_auto_adjust_resolution(const bool &p_enable);
@@ -895,7 +895,7 @@ public:
 	void set_size(const Size2 &p_size);
 	Size2 get_size() const;
 	void set_size_force(const Size2 &p_size);
-	
+
 	void set_texture_resolution_override(const Size2i &p_size);
 	Size2i get_texture_resolution_override() const;
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1431,8 +1431,8 @@ void Window::_notification(int p_what) {
 				DisplayServer::get_singleton()->accessibility_update_set_name(accessibility_title_element, tr_title);
 				DisplayServer::get_singleton()->accessibility_update_set_bounds(accessibility_title_element, Rect2(Vector2(0, -w), Size2(size.x, w)));
 			} else {
-				DisplayServer::get_singleton()->accessibility_update_set_transform(ae, Transform2D());
-				DisplayServer::get_singleton()->accessibility_update_set_bounds(ae, Rect2(Point2(), size));
+				DisplayServer::get_singleton()->accessibility_update_set_transform(ae, get_final_transform());
+				DisplayServer::get_singleton()->accessibility_update_set_bounds(ae, Rect2(Point2(), _get_size()));
 
 				if (accessibility_announcement_element.is_null()) {
 					accessibility_announcement_element = DisplayServer::get_singleton()->accessibility_create_sub_element(ae, DisplayServer::AccessibilityRole::ROLE_STATIC_TEXT);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1195,7 +1195,7 @@ void Window::_update_viewport_size() {
 
 	Size2 final_viewport_size;
 	Size2i final_viewport_resolution;
-	
+
 	Rect2i attach_to_screen_rect(Point2i(), size);
 	window_transform = Transform2D();
 

--- a/scene/resources/atlas_texture.cpp
+++ b/scene/resources/atlas_texture.cpp
@@ -113,6 +113,18 @@ Rect2 AtlasTexture::get_margin() const {
 	return margin;
 }
 
+void AtlasTexture::set_pivot(const Vector2 &p_pivot) {
+	if (pivot == p_pivot) {
+		return;
+	}
+	pivot = p_pivot;
+	emit_changed();
+}
+
+Vector2 AtlasTexture::get_pivot() const {
+	return pivot;
+}
+
 void AtlasTexture::set_filter_clip(const bool p_enable) {
 	filter_clip = p_enable;
 	emit_changed();
@@ -145,12 +157,16 @@ void AtlasTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &AtlasTexture::set_margin);
 	ClassDB::bind_method(D_METHOD("get_margin"), &AtlasTexture::get_margin);
 
+	ClassDB::bind_method(D_METHOD("set_pivot", "pivot"), &AtlasTexture::set_pivot);
+	ClassDB::bind_method(D_METHOD("get_pivot"), &AtlasTexture::get_pivot);
+
 	ClassDB::bind_method(D_METHOD("set_filter_clip", "enable"), &AtlasTexture::set_filter_clip);
 	ClassDB::bind_method(D_METHOD("has_filter_clip"), &AtlasTexture::has_filter_clip);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "atlas", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_atlas", "get_atlas");
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "region", PROPERTY_HINT_NONE, "suffix:px"), "set_region", "get_region");
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "margin", PROPERTY_HINT_NONE, "suffix:px"), "set_margin", "get_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "pivot", PROPERTY_HINT_NONE, "suffix:px"), "set_pivot", "get_pivot");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter_clip"), "set_filter_clip", "has_filter_clip");
 }
 

--- a/scene/resources/atlas_texture.h
+++ b/scene/resources/atlas_texture.h
@@ -42,6 +42,7 @@ protected:
 	Ref<Texture2D> atlas;
 	Rect2 region;
 	Rect2 margin;
+	Vector2 pivot;
 	bool filter_clip = false;
 
 	static void _bind_methods();
@@ -61,6 +62,9 @@ public:
 
 	void set_margin(const Rect2 &p_margin);
 	Rect2 get_margin() const;
+
+	void set_pivot(const Vector2 &p_pivot);
+	Vector2 get_pivot() const;
 
 	void set_filter_clip(const bool p_enable);
 	bool has_filter_clip() const;

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -1051,6 +1051,13 @@ void RendererViewport::_viewport_set_size(Viewport *p_viewport, int p_width, int
 	}
 }
 
+Size2i RendererViewport::viewport_get_size(RID p_viewport) const {
+	Viewport *viewport = viewport_owner.get_or_null(p_viewport);
+	ERR_FAIL_NULL_V(viewport, Size2i());
+
+	return RSG::texture_storage->render_target_get_size(viewport->render_target);
+}
+
 bool RendererViewport::_viewport_requires_motion_vectors(Viewport *p_viewport) {
 	return p_viewport->use_taa ||
 			RS::scaling_3d_mode_type(p_viewport->scaling_3d_mode) == RS::VIEWPORT_SCALING_3D_TYPE_TEMPORAL ||

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -219,6 +219,7 @@ public:
 	void viewport_set_use_xr(RID p_viewport, bool p_use_xr);
 
 	void viewport_set_size(RID p_viewport, int p_width, int p_height);
+	Size2i viewport_get_size(RID p_viewport) const;
 
 	void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID);
 	void viewport_set_render_direct_to_screen(RID p_viewport, bool p_enable);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -683,6 +683,7 @@ public:
 
 	FUNC2(viewport_set_use_xr, RID, bool)
 	FUNC3(viewport_set_size, RID, int, int)
+	FUNC1RC(Size2i, viewport_get_size, RID)
 
 	FUNC2(viewport_set_active, RID, bool)
 	FUNC2(viewport_set_parent_viewport, RID, RID)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2805,6 +2805,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_create"), &RenderingServer::viewport_create);
 	ClassDB::bind_method(D_METHOD("viewport_set_use_xr", "viewport", "use_xr"), &RenderingServer::viewport_set_use_xr);
 	ClassDB::bind_method(D_METHOD("viewport_set_size", "viewport", "width", "height"), &RenderingServer::viewport_set_size);
+	ClassDB::bind_method(D_METHOD("viewport_get_size", "viewport"), &RenderingServer::viewport_get_size);
 	ClassDB::bind_method(D_METHOD("viewport_set_active", "viewport", "active"), &RenderingServer::viewport_set_active);
 	ClassDB::bind_method(D_METHOD("viewport_set_parent_viewport", "viewport", "parent_viewport"), &RenderingServer::viewport_set_parent_viewport);
 	ClassDB::bind_method(D_METHOD("viewport_attach_to_screen", "viewport", "rect", "screen"), &RenderingServer::viewport_attach_to_screen, DEFVAL(Rect2()), DEFVAL(DisplayServer::MAIN_WINDOW_ID));

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -976,6 +976,7 @@ public:
 
 	virtual void viewport_set_use_xr(RID p_viewport, bool p_use_xr) = 0;
 	virtual void viewport_set_size(RID p_viewport, int p_width, int p_height) = 0;
+	virtual Size2i viewport_get_size(RID p_viewport) const = 0;
 	virtual void viewport_set_active(RID p_viewport, bool p_active) = 0;
 	virtual void viewport_set_parent_viewport(RID p_viewport, RID p_parent_viewport) = 0;
 	virtual void viewport_set_canvas_cull_mask(RID p_viewport, uint32_t p_canvas_cull_mask) = 0;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Viewport has always been confusing in how it handled size, size_override and stretch_override. Not only was it unclear what it did, it also didn't function as intended. 

These changes remove size_2d_override and size_2d_override_stretch in favor of a more intuitive texture_resolution_override which can change the resolution of the backing texture without changing the size of the viewport.

Also introduced a property auto_adjust_resolution which will update the viewport resolution when the game window changes