### PR TITLE
macOS: Fix a crash if no input event is set for a specific window

### DIFF
--- a/platform/macos/display_server_embedded.mm
+++ b/platform/macos/display_server_embedded.mm
@@ -426,7 +426,10 @@ void DisplayServerEmbedded::_dispatch_input_events(const Ref<InputEvent> &p_even
 
 void DisplayServerEmbedded::send_input_event(const Ref<InputEvent> &p_event, WindowID p_id) const {
 	if (p_id != INVALID_WINDOW_ID) {
-		_window_callback(input_event_callbacks[p_id], p_event);
+		const Callable *cb = input_event_callbacks.getptr(p_id);
+		if (cb) {
+			_window_callback(*cb, p_event);
+		}
 	} else {
 		for (const KeyValue<WindowID, Callable> &E : input_event_callbacks) {
 			_window_callback(E.value, p_event);


### PR DESCRIPTION
Check a callback is present for a specific window ID.

This was observed when the process is slow to start due to compiling shaders, and all signals had not been connected.