### PR TITLE
Fix floor spinbox tooltip in GridMap editor

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -43,9 +43,11 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/item_list.h"
 #include "scene/gui/label.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/separator.h"
+#include "scene/gui/spin_box.h"
 #include "scene/main/window.h"
 
 void GridMapEditor::_configure() {
@@ -84,13 +86,9 @@ void GridMapEditor::_menu_option(int p_option) {
 			}
 
 			if (edit_axis != new_axis) {
-				if (edit_axis == Vector3::AXIS_Y) {
-					floor->set_tooltip_text("Change Grid Plane");
-				} else if (new_axis == Vector3::AXIS_Y) {
-					floor->set_tooltip_text("Change Grid Floor");
-				}
+				edit_axis = Vector3::Axis(new_axis);
+				_update_floor_tooltip_text();
 			}
-			edit_axis = Vector3::Axis(new_axis);
 			update_grid();
 
 		} break;
@@ -500,6 +498,15 @@ void GridMapEditor::_fill_selection() {
 	undo_redo->add_do_method(this, "_set_selection", !selection.active, selection.begin, selection.end);
 	undo_redo->add_undo_method(this, "_set_selection", selection.active, selection.begin, selection.end);
 	undo_redo->commit_action();
+}
+
+void GridMapEditor::_update_floor_tooltip_text() {
+	String action_name = edit_axis == Vector3::AXIS_Y ? TTR("Change Grid Plane") : TTR("Change Grid Floor");
+	// TRANSLATORS: The placeholders are the keyboard shortcut texts.
+	String shortcuts = vformat(TTR("Previous Plane: %s\nNext Plane: %s"),
+			ED_GET_SHORTCUT("grid_map/previous_floor")->get_as_text(),
+			ED_GET_SHORTCUT("grid_map/next_floor")->get_as_text());
+	floor->set_tooltip_text(action_name + '\n' + shortcuts);
 }
 
 void GridMapEditor::_clear_clipboard_data() {
@@ -1494,10 +1501,8 @@ GridMapEditor::GridMapEditor() {
 	floor->set_max(32767);
 	floor->set_step(1);
 	floor->set_accessibility_name(TTRC("Change Grid Floor:"));
-	floor->set_tooltip_text(
-			vformat(TTR("Change Grid Floor:\nPrevious Plane (%s)\nNext Plane (%s)"),
-					ED_GET_SHORTCUT("grid_map/previous_floor")->get_as_text(),
-					ED_GET_SHORTCUT("grid_map/next_floor")->get_as_text()));
+	floor->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	_update_floor_tooltip_text();
 	toolbar->add_child(floor);
 	floor->get_line_edit()->add_theme_constant_override("minimum_character_width", 2);
 	floor->get_line_edit()->set_context_menu_enabled(false);

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -34,16 +34,16 @@
 
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/box_container.h"
-#include "scene/gui/item_list.h"
-#include "scene/gui/slider.h"
-#include "scene/gui/spin_box.h"
 
+class BaseButton;
+class ButtonGroup;
 class ConfirmationDialog;
+class EditorZoomWidget;
+class ItemList;
+class LineEdit;
 class MenuButton;
 class Node3DEditorPlugin;
-class ButtonGroup;
-class EditorZoomWidget;
-class BaseButton;
+class SpinBox;
 
 class GridMapEditor : public VBoxContainer {
 	GDCLASS(GridMapEditor, VBoxContainer);
@@ -94,7 +94,6 @@ class GridMapEditor : public VBoxContainer {
 	Button *mode_thumbnail = nullptr;
 	Button *mode_list = nullptr;
 	LineEdit *search_box = nullptr;
-	HSlider *size_slider = nullptr;
 	ConfirmationDialog *settings_dialog = nullptr;
 	VBoxContainer *settings_vbc = nullptr;
 	SpinBox *settings_pick_distance = nullptr;
@@ -247,6 +246,8 @@ class GridMapEditor : public VBoxContainer {
 
 	void _delete_selection();
 	void _fill_selection();
+
+	void _update_floor_tooltip_text();
 
 	bool do_input_action(Camera3D *p_camera, const Point2 &p_point, bool p_click);
 


### PR DESCRIPTION
Currently, after switching the editing axis:

- Information about plane-switching shortcuts is no longer included in the tooltip text
- Tooltip text is not translated, because these new texts are not marked for translation extraction

Also fixed header includes in these files (thanks to this, I also found and removed a member variable that is no longer used :stuck_out_tongue:)