### PR TITLE
Use notification Ready instead of EnterTree when connecting Signals

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1003,7 +1003,7 @@ void ScriptEditorDebugger::_set_reason_text(const String &p_reason, MessageType 
 
 void ScriptEditorDebugger::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_READY: {
 			le_set->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_live_edit_set));
 			le_clear->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_live_edit_clear));
 			error_tree->connect(SceneStringName(item_selected), callable_mp(this, &ScriptEditorDebugger::_error_selected));

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -132,7 +132,7 @@ void EditorLog::_editor_settings_changed() {
 
 void EditorLog::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_READY: {
 			_update_theme();
 			_load_state();
 		} break;

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -119,7 +119,7 @@ void AnimationPlayerEditor::_notification(int p_what) {
 			updating = false;
 		} break;
 
-		case NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_READY: {
 			tool_anim->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &AnimationPlayerEditor::_animation_tool_menu));
 
 			onion_skinning->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &AnimationPlayerEditor::_onion_skinning_menu));

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -1863,7 +1863,7 @@ void ThemeItemEditorDialog::_select_another_theme_cbk(const String &p_path) {
 
 void ThemeItemEditorDialog::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_READY: {
 			connect("about_to_popup", callable_mp(this, &ThemeItemEditorDialog::_dialog_about_to_show));
 			[[fallthrough]];
 		}
@@ -2216,7 +2216,7 @@ void ThemeTypeDialog::_add_type_confirmed() {
 
 void ThemeTypeDialog::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_READY: {
 			connect("about_to_popup", callable_mp(this, &ThemeTypeDialog::_dialog_about_to_show));
 			[[fallthrough]];
 		}

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -204,14 +204,13 @@ void ThemeEditorPreview::_notification(int p_what) {
 			if (is_visible_in_tree()) {
 				set_process(true);
 			}
-
-			connect(SceneStringName(visibility_changed), callable_mp(this, &ThemeEditorPreview::_preview_visibility_changed));
 		} break;
 
 		case NOTIFICATION_READY: {
 			Vector<Ref<Theme>> preview_themes;
 			preview_themes.push_back(ThemeDB::get_singleton()->get_default_theme());
 			ThemeDB::get_singleton()->create_theme_context(preview_root, preview_themes);
+			connect(SceneStringName(visibility_changed), callable_mp(this, &ThemeEditorPreview::_preview_visibility_changed));
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1171,6 +1171,7 @@ void GridMapEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
+			mesh_library_palette->disconnect(SceneStringName(item_selected), callable_mp(this, &GridMapEditor::_item_selected_cbk));
 			_clear_clipboard_data();
 
 			for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
This PR shares the same overarching goal as #106164. The Bottom Panel should be more integrated into the dock system, and this PR builds towards that.

Currently, the theme editor, animation, and debugger panels (that you can access from the bottom panel) connect signals that never change in their ENTER_TREE notifications. Normally this is not an issue because these panels do not repeatedly enter and exit the tree, however if these panels move between different parents (say, if you wanted to move the animation panel to the right dock, it would leave the tree then re-enter) this would print errors as it tries to connect signals that are already connected.

In essence, signals should only be connected in `NOTIFICATION_ENTER_TREE` if they are also disconnected in `NOTIFICATION_EXIT_TREE`. This PR changes `NOTIFICATION_ENTER_TREE` to `NOTIFICATION_READY`. This makes it so that the signals are only ever connected once. Even if these specific panels are not made moveable, this bug still should be corrected.

The `NOTIFICATION_ENTER_TREE` can be turned into a `NOTIFICATION_READY` if the class owns the objects that are connecting to it, otherwise they should be disconnected in `NOTIFICATION_EXIT_TREE`.

Instead of reworking how the grid map editor functions (which probably should be done in another PR), this PR simply disconnects the offending signal in `NOTIFICATION_EXIT_TREE`.