### PR TITLE
Skip default font loading if Brotli is disabled.

### DIFF
--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -31,8 +31,6 @@
 #include "default_theme.h"
 
 #include "core/io/image.h"
-#include "default_font.gen.h"
-#include "default_theme_icons.gen.h"
 #include "scene/resources/font.h"
 #include "scene/resources/gradient_texture.h"
 #include "scene/resources/image_texture.h"
@@ -41,8 +39,13 @@
 #include "scene/resources/svg_texture.h"
 #include "scene/resources/theme.h"
 #include "scene/scene_string_names.h"
+#include "scene/theme/default_theme_icons.gen.h"
 #include "scene/theme/theme_db.h"
 #include "servers/text_server.h"
+
+#ifdef BROTLI_ENABLED
+#include "scene/theme/default_font.gen.h"
+#endif
 
 static const int default_font_size = 16;
 
@@ -1314,13 +1317,14 @@ void make_default_theme(float p_scale, Ref<Font> p_font, TextServer::SubpixelPos
 		// embedded in both editor and export template binaries.
 		Ref<FontFile> dynamic_font;
 		dynamic_font.instantiate();
+#ifdef BROTLI_ENABLED
 		dynamic_font->set_data_ptr(_font_OpenSans_SemiBold, _font_OpenSans_SemiBold_size);
 		dynamic_font->set_subpixel_positioning(p_font_subpixel);
 		dynamic_font->set_hinting(p_font_hinting);
 		dynamic_font->set_antialiasing(p_font_antialiasing);
 		dynamic_font->set_multichannel_signed_distance_field(p_font_msdf);
 		dynamic_font->set_generate_mipmaps(p_font_generate_mipmaps);
-
+#endif
 		default_font = dynamic_font;
 	}
 


### PR DESCRIPTION
- Skips including and loading default font (which is in woff2 format) if Brotli is disabled.

Should prevent error spam, see https://github.com/godot-build-options-generator/godot-build-options-generator.github.io/issues/17

System fallback and custom fonts will still work if default font is empty, so templates are fully usable in this config.