### PR TITLE
Add option to make floating window fully transparent.

### DIFF
--- a/editor/plugins/embedded_process.cpp
+++ b/editor/plugins/embedded_process.cpp
@@ -81,7 +81,7 @@ void EmbeddedProcessBase::_bind_methods() {
 }
 
 void EmbeddedProcessBase::_draw() {
-	if (is_embedding_completed()) {
+	if (is_embedding_completed() && !floating_transp) {
 		Rect2 r = get_adjusted_embedded_window_rect(get_rect());
 #ifndef MACOS_ENABLED
 		r.position -= get_window()->get_position();

--- a/editor/plugins/embedded_process.h
+++ b/editor/plugins/embedded_process.h
@@ -48,6 +48,7 @@ protected:
 	Window *window = nullptr;
 
 	bool transp_enabled = false;
+	bool floating_transp = false;
 	Color clear_color;
 	Ref<Texture2D> checkerboard;
 
@@ -68,6 +69,7 @@ public:
 	virtual void request_close() = 0;
 	virtual void queue_update_embedded_process() = 0;
 
+	void set_floating_transp(bool p_enabled) { floating_transp = p_enabled; }
 	void set_window_size(const Size2i &p_window_size);
 	void set_keep_aspect(bool p_keep_aspect);
 	virtual Rect2i get_adjusted_embedded_window_rect(const Rect2i &p_rect) const = 0;

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -95,6 +95,7 @@ class GameView : public VBoxContainer {
 		CAMERA_MODE_EDITORS,
 		EMBED_RUN_GAME_EMBEDDED,
 		EMBED_MAKE_FLOATING_ON_PLAY,
+		EMBED_MAKE_FLOATING_TRANSPARENT,
 	};
 
 	enum EmbedSizeMode {
@@ -123,8 +124,12 @@ class GameView : public VBoxContainer {
 	int screen_index_before_start = -1;
 	ScriptEditorDebugger *embedded_script_debugger = nullptr;
 
+	MarginContainer *toolbar_margin = nullptr;
+	Ref<StyleBox> toolbar_panel_style;
+
 	bool embed_on_play = true;
 	bool make_floating_on_play = true;
+	bool make_floating_transp = false;
 	EmbedSizeMode embed_size_mode = SIZE_MODE_FIXED;
 	bool paused = false;
 	Size2 size_paused;

--- a/editor/window_wrapper.h
+++ b/editor/window_wrapper.h
@@ -68,6 +68,7 @@ protected:
 public:
 	void set_wrapped_control(Control *p_control, const Ref<Shortcut> &p_enable_shortcut = Ref<Shortcut>());
 	Control *get_wrapped_control() const;
+	Panel *get_window_background() const { return window_background; }
 	Control *release_wrapped_control();
 
 	bool is_window_available() const;


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/106340

Related issue https://github.com/godotengine/godot/issues/104680

https://github.com/user-attachments/assets/3d260b87-1924-49ec-8c0f-7667aee56570

