### PR TITLE
Linux: Drop `ppc32` (32-bit PowerPC) architecture support

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -224,39 +224,22 @@ String Engine::get_license_text() const {
 String Engine::get_architecture_name() const {
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
 	return "x86_64";
-
 #elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
 	return "x86_32";
-
 #elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 	return "arm64";
-
 #elif defined(__arm__) || defined(_M_ARM)
 	return "arm32";
-
 #elif defined(__riscv)
-#if __riscv_xlen == 8
 	return "rv64";
-#else
-	return "riscv";
-#endif
-
-#elif defined(__powerpc__)
-#if defined(__powerpc64__)
+#elif defined(__powerpc64__)
 	return "ppc64";
-#else
-	return "ppc";
-#endif
-
 #elif defined(__loongarch64)
 	return "loongarch64";
-
-#elif defined(__wasm__)
-#if defined(__wasm64__)
+#elif defined(__wasm64__)
 	return "wasm64";
 #elif defined(__wasm32__)
 	return "wasm32";
-#endif
 #endif
 }
 

--- a/core/os/spin_lock.h
+++ b/core/os/spin_lock.h
@@ -81,7 +81,7 @@ _ALWAYS_INLINE_ static void _cpu_pause() {
 	__builtin_ia32_pause();
 #elif defined(__arm__) || defined(__aarch64__) // ARM.
 	asm volatile("yield");
-#elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__) // PowerPC.
+#elif defined(__powerpc__) // PowerPC.
 	asm volatile("or 27,27,27");
 #elif defined(__riscv) // RISC-V.
 	asm volatile(".insn i 0x0F, 0, x0, x0, 0x010");

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -22,7 +22,7 @@
 		<method name="get_architecture_name" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the name of the CPU architecture the Godot binary was built for. Possible return values include [code]"x86_64"[/code], [code]"x86_32"[/code], [code]"arm64"[/code], [code]"arm32"[/code], [code]"rv64"[/code], [code]"riscv"[/code], [code]"ppc64"[/code], [code]"ppc"[/code], [code]"wasm64"[/code], and [code]"wasm32"[/code].
+				Returns the name of the CPU architecture the Godot binary was built for. Possible return values include [code]"x86_64"[/code], [code]"x86_32"[/code], [code]"arm64"[/code], [code]"arm32"[/code], [code]"rv64"[/code], [code]"ppc64"[/code], [code]"loongarch64"[/code], [code]"wasm64"[/code], and [code]"wasm32"[/code].
 				To detect whether the current build is 64-bit, or the type of architecture, don't use the architecture name. Instead, use [method OS.has_feature] to check for the [code]"64"[/code] feature tag, or tags such as [code]"x86"[/code] or [code]"arm"[/code]. See the [url=$DOCS_URL/tutorials/export/feature_tags.html]Feature Tags[/url] documentation for more details.
 				[b]Note:[/b] This method does [i]not[/i] return the name of the system's CPU architecture (like [method OS.get_processor_name]). For example, when running an [code]x86_32[/code] Godot binary on an [code]x86_64[/code] system, the returned value will still be [code]"x86_32"[/code].
 			</description>

--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -255,7 +255,6 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["pck"] = "PCK";
 	capitalize_string_remaps["png"] = "PNG";
 	capitalize_string_remaps["po2"] = "(Power of 2)"; // Unit.
-	capitalize_string_remaps["ppc32"] = "ppc32";
 	capitalize_string_remaps["ppc64"] = "ppc64";
 	capitalize_string_remaps["pvrtc"] = "PVRTC";
 	capitalize_string_remaps["pvs"] = "PVS";

--- a/editor/plugins/gdextension_export_plugin.h
+++ b/editor/plugins/gdextension_export_plugin.h
@@ -69,7 +69,6 @@ void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p
 	all_archs.insert("arm32");
 	all_archs.insert("arm64");
 	all_archs.insert("rv64");
-	all_archs.insert("ppc32");
 	all_archs.insert("ppc64");
 	all_archs.insert("wasm32");
 	all_archs.insert("loongarch64");

--- a/modules/jolt_physics/config.py
+++ b/modules/jolt_physics/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return not env["disable_physics_3d"] and not env["arch"] == "ppc32"
+    return not env["disable_physics_3d"]
 
 
 def configure(env):

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -73,7 +73,7 @@ def get_flags():
 
 def configure(env: "SConsEnvironment"):
     # Validate arch.
-    supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "loongarch64"]
+    supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc64", "loongarch64"]
     validate_arch(env["arch"], get_name(), supported_arches)
 
     ## Build type

--- a/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
+++ b/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
@@ -11,7 +11,7 @@
 	<members>
 		<member name="binary_format/architecture" type="String" setter="" getter="">
 			Application executable architecture.
-			Supported architectures: [code]x86_32[/code], [code]x86_64[/code], [code]arm64[/code], [code]arm32[/code], [code]rv64[/code], [code]ppc64[/code], [code]ppc32[/code], and [code]loongarch64[/code].
+			Supported architectures: [code]x86_32[/code], [code]x86_64[/code], [code]arm64[/code], [code]arm32[/code], [code]rv64[/code], [code]ppc64[/code], and [code]loongarch64[/code].
 			Official export templates include [code]x86_32[/code], [code]x86_64[/code], [code]arm32[/code], and [code]arm64[/code] binaries only.
 		</member>
 		<member name="binary_format/embed_pck" type="bool" setter="" getter="">

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -184,7 +184,7 @@ bool EditorExportPlatformLinuxBSD::get_export_option_visibility(const EditorExpo
 void EditorExportPlatformLinuxBSD::get_export_options(List<ExportOption> *r_options) const {
 	EditorExportPlatformPC::get_export_options(r_options);
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "x86_64,x86_32,arm64,arm32,rv64,ppc64,ppc32,loongarch64"), "x86_64"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "x86_64,x86_32,arm64,arm32,rv64,ppc64,loongarch64"), "x86_64"));
 
 	String run_script = "#!/usr/bin/env bash\n"
 						"export DISPLAY=:0\n"
@@ -276,8 +276,6 @@ String EditorExportPlatformLinuxBSD::_get_exe_arch(const String &p_path) const {
 			return "x86_32";
 		case 0x003e:
 			return "x86_64";
-		case 0x0014:
-			return "ppc32";
 		case 0x0015:
 			return "ppc64";
 		case 0x0028:

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -16,7 +16,7 @@ compatibility_platform_aliases = {
 }
 
 # CPU architecture options.
-architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32", "loongarch64"]
+architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc64", "wasm32", "loongarch64"]
 architecture_aliases = {
     "x86": "x86_32",
     "x64": "x86_64",
@@ -28,8 +28,6 @@ architecture_aliases = {
     "rv": "rv64",
     "riscv": "rv64",
     "riscv64": "rv64",
-    "ppcle": "ppc32",
-    "ppc": "ppc32",
     "ppc64le": "ppc64",
     "loong64": "loongarch64",
 }


### PR DESCRIPTION
This was added together with `ppc64le` in #54490, but seemingly only for the purpose of getting it to compile on a Linux distro that aims at maximizing support for all CPU architectures.

I don't think anyone has ever _run_ Godot on a `ppc32` system (do those even support OpenGL ES 3.0?) and so I don't think we should aim to support it.

Debian dropped support for its PowerPC (`ppc32`) arch in Debian 9, released in 2017.

CC @q66 in case you feel strongly about this. The maintenance burden for us isn't too high (as seen in this PR), but I'm not too comfortable having a platform that we can theoretically compile to but with likely no actual use case for it.

If someone can actually test Godot on PowerPC and see if there's any valid use case (e.g. running a headless server or somehow working 2D with software rendering), I'm happy to keep the theoretical support as a "tier 2" platform, like the *BSD flavors we support on a best-effort basis.