### PR TITLE
Fog light projectors

### DIFF
--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -181,18 +181,30 @@ void LightStorage::light_set_projector(RID p_light, RID p_texture) {
 		return;
 	}
 
-	if (light->type != RS::LIGHT_DIRECTIONAL && light->projector.is_valid()) {
+	if (light->projector.is_valid()) {
 		texture_storage->texture_remove_from_decal_atlas(light->projector, light->type == RS::LIGHT_OMNI);
 	}
 
 	light->projector = p_texture;
 
-	if (light->type != RS::LIGHT_DIRECTIONAL) {
-		if (light->projector.is_valid()) {
-			texture_storage->texture_add_to_decal_atlas(light->projector, light->type == RS::LIGHT_OMNI);
-		}
-		light->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_LIGHT_SOFT_SHADOW_AND_PROJECTOR);
+	if (light->projector.is_valid()) {
+		texture_storage->texture_add_to_decal_atlas(light->projector, light->type == RS::LIGHT_OMNI);
 	}
+	light->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_LIGHT_SOFT_SHADOW_AND_PROJECTOR);
+}
+
+void LightStorage::light_set_projector_scale(RID p_light, const Vector2 &p_scale) {
+	Light *light = light_owner.get_or_null(p_light);
+	ERR_FAIL_NULL(light);
+
+	light->projector_scale = p_scale;
+}
+
+void LightStorage::light_set_projector_offset(RID p_light, const Vector2 &p_offset) {
+	Light *light = light_owner.get_or_null(p_light);
+	ERR_FAIL_NULL(light);
+
+	light->projector_offset = p_offset;
 }
 
 void LightStorage::light_set_negative(RID p_light, bool p_enable) {

--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -50,6 +50,8 @@ struct Light {
 	float param[RS::LIGHT_PARAM_MAX];
 	Color color = Color(1, 1, 1, 1);
 	RID projector;
+	Vector2 projector_scale;
+	Vector2 projector_offset;
 	bool shadow = false;
 	bool negative = false;
 	bool reverse_cull = false;
@@ -322,6 +324,8 @@ public:
 	virtual void light_set_param(RID p_light, RS::LightParam p_param, float p_value) override;
 	virtual void light_set_shadow(RID p_light, bool p_enabled) override;
 	virtual void light_set_projector(RID p_light, RID p_texture) override;
+	virtual void light_set_projector_scale(RID p_light, const Vector2 &p_scale) override;
+	virtual void light_set_projector_offset(RID p_light, const Vector2 &p_offset) override;
 	virtual void light_set_negative(RID p_light, bool p_enable) override;
 	virtual void light_set_cull_mask(RID p_light, uint32_t p_mask) override;
 	virtual void light_set_distance_fade(RID p_light, bool p_enabled, float p_begin, float p_shadow, float p_length) override;

--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -84,6 +84,8 @@ private:
 	void _update_visibility();
 	BakeMode bake_mode = BAKE_DYNAMIC;
 	Ref<Texture2D> projector;
+	Vector2 projector_scale;
+	Vector2 projector_offset;
 	Color correlated_color = Color(1.0, 1.0, 1.0);
 	float temperature = 6500.0;
 
@@ -144,6 +146,12 @@ public:
 
 	void set_projector(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_projector() const;
+
+	void set_projector_scale(const Vector2 &p_scale);
+	Vector2 get_projector_scale() const;
+
+	void set_projector_offset(const Vector2 &p_offset);
+	Vector2 get_projector_offset() const;
 
 	void set_temperature(const float p_temperature);
 	float get_temperature() const;
@@ -219,8 +227,6 @@ protected:
 public:
 	void set_shadow_mode(ShadowMode p_mode);
 	ShadowMode get_shadow_mode() const;
-
-	PackedStringArray get_configuration_warnings() const override;
 
 	OmniLight3D();
 };

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -903,6 +903,7 @@ void Environment::_update_volumetric_fog() {
 			environment,
 			volumetric_fog_enabled,
 			volumetric_fog_density,
+			volumetric_fog_fade,
 			volumetric_fog_albedo,
 			volumetric_fog_emission,
 			volumetric_fog_emission_energy,
@@ -931,6 +932,13 @@ void Environment::set_volumetric_fog_density(float p_density) {
 }
 float Environment::get_volumetric_fog_density() const {
 	return volumetric_fog_density;
+}
+void Environment::set_volumetric_fog_fade(float p_fade) {
+	volumetric_fog_fade = p_fade;
+	_update_volumetric_fog();
+}
+float Environment::get_volumetric_fog_fade() const {
+	return volumetric_fog_fade;
 }
 void Environment::set_volumetric_fog_albedo(Color p_color) {
 	volumetric_fog_albedo = p_color;
@@ -1503,6 +1511,8 @@ void Environment::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_volumetric_fog_albedo"), &Environment::get_volumetric_fog_albedo);
 	ClassDB::bind_method(D_METHOD("set_volumetric_fog_density", "density"), &Environment::set_volumetric_fog_density);
 	ClassDB::bind_method(D_METHOD("get_volumetric_fog_density"), &Environment::get_volumetric_fog_density);
+	ClassDB::bind_method(D_METHOD("set_volumetric_fog_fade", "density"), &Environment::set_volumetric_fog_fade);
+	ClassDB::bind_method(D_METHOD("get_volumetric_fog_fade"), &Environment::get_volumetric_fog_fade);
 	ClassDB::bind_method(D_METHOD("set_volumetric_fog_emission_energy", "begin"), &Environment::set_volumetric_fog_emission_energy);
 	ClassDB::bind_method(D_METHOD("get_volumetric_fog_emission_energy"), &Environment::get_volumetric_fog_emission_energy);
 	ClassDB::bind_method(D_METHOD("set_volumetric_fog_anisotropy", "anisotropy"), &Environment::set_volumetric_fog_anisotropy);
@@ -1525,6 +1535,7 @@ void Environment::_bind_methods() {
 	ADD_GROUP("Volumetric Fog", "volumetric_fog_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "volumetric_fog_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_volumetric_fog_enabled", "is_volumetric_fog_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volumetric_fog_density", PROPERTY_HINT_RANGE, "0,1,0.0001,or_greater"), "set_volumetric_fog_density", "get_volumetric_fog_density");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volumetric_fog_fade", PROPERTY_HINT_RANGE, "0.0001,1,0.0001,or_greater"), "set_volumetric_fog_fade", "get_volumetric_fog_fade");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "volumetric_fog_albedo", PROPERTY_HINT_COLOR_NO_ALPHA), "set_volumetric_fog_albedo", "get_volumetric_fog_albedo");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "volumetric_fog_emission", PROPERTY_HINT_COLOR_NO_ALPHA), "set_volumetric_fog_emission", "get_volumetric_fog_emission");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volumetric_fog_emission_energy", PROPERTY_HINT_RANGE, "0,1024,0.01,or_greater"), "set_volumetric_fog_emission_energy", "get_volumetric_fog_emission_energy");

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -199,6 +199,7 @@ private:
 	// Volumetric Fog
 	bool volumetric_fog_enabled = false;
 	float volumetric_fog_density = 0.05;
+	float volumetric_fog_fade = 0.1;
 	Color volumetric_fog_albedo = Color(1.0, 1.0, 1.0);
 	Color volumetric_fog_emission = Color(0.0, 0.0, 0.0);
 	float volumetric_fog_emission_energy = 1.0;
@@ -407,6 +408,8 @@ public:
 	bool is_volumetric_fog_enabled() const;
 	void set_volumetric_fog_density(float p_density);
 	float get_volumetric_fog_density() const;
+	void set_volumetric_fog_fade(float p_fade);
+	float get_volumetric_fog_fade() const;
 	void set_volumetric_fog_albedo(Color p_color);
 	Color get_volumetric_fog_albedo() const;
 	void set_volumetric_fog_emission(Color p_color);

--- a/servers/rendering/dummy/storage/light_storage.h
+++ b/servers/rendering/dummy/storage/light_storage.h
@@ -73,6 +73,8 @@ public:
 	virtual void light_set_param(RID p_light, RS::LightParam p_param, float p_value) override {}
 	virtual void light_set_shadow(RID p_light, bool p_enabled) override {}
 	virtual void light_set_projector(RID p_light, RID p_texture) override {}
+	virtual void light_set_projector_scale(RID p_light, const Vector2 &p_scale) override {}
+	virtual void light_set_projector_offset(RID p_light, const Vector2 &p_offset) override {}
 	virtual void light_set_negative(RID p_light, bool p_enable) override {}
 	virtual void light_set_cull_mask(RID p_light, uint32_t p_mask) override {}
 	virtual void light_set_distance_fade(RID p_light, bool p_enabled, float p_begin, float p_shadow, float p_length) override {}

--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -496,7 +496,7 @@ void CopyEffects::copy_depth_to_rect_and_linearize(RID p_source_rd_texture, RID 
 	RD::get_singleton()->compute_list_end();
 }
 
-void CopyEffects::copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2 &p_uv_rect, RD::DrawListID p_draw_list, bool p_flip_y, bool p_panorama) {
+void CopyEffects::copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2 &p_uv_rect, RD::DrawListID p_draw_list, bool p_flip_y, bool p_panorama, Vector2 uv_offset) {
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
 	ERR_FAIL_NULL(uniform_set_cache);
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
@@ -516,8 +516,13 @@ void CopyEffects::copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuff
 
 	copy_to_fb.push_constant.luminance_multiplier = 1.0;
 
+	copy_to_fb.push_constant.set_color[0] = uv_offset.x;
+	copy_to_fb.push_constant.set_color[1] = uv_offset.y;
+
 	// setup our uniforms
-	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+	// This work too but maybe worse ? I don't know if there is scenario where we want to use repeat disabled
+	// RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED);
 
 	RD::Uniform u_source_rd_texture(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_rd_texture }));
 

--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -329,7 +329,7 @@ public:
 	void copy_depth_to_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false);
 	void copy_depth_to_rect_and_linearize(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y, float p_z_near, float p_z_far);
 	void copy_to_fb_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false, bool p_force_luminance = false, bool p_alpha_to_zero = false, bool p_srgb = false, RID p_secondary = RID(), bool p_multiview = false, bool alpha_to_one = false, bool p_linear = false, bool p_normal = false, const Rect2 &p_src_rect = Rect2());
-	void copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2 &p_uv_rect, RD::DrawListID p_draw_list, bool p_flip_y = false, bool p_panorama = false);
+	void copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2 &p_uv_rect, RD::DrawListID p_draw_list, bool p_flip_y = false, bool p_panorama = false, Vector2 uv_offset = Vector2());
 	void copy_to_drawlist(RD::DrawListID p_draw_list, RD::FramebufferFormatID p_fb_format, RID p_source_rd_texture, bool p_linear = false);
 	void copy_raster(RID p_source_texture, RID p_dest_framebuffer);
 

--- a/servers/rendering/renderer_rd/environment/fog.h
+++ b/servers/rendering/renderer_rd/environment/fog.h
@@ -173,6 +173,9 @@ private:
 			float cam_rotation[12];
 			float to_prev_view[16];
 			float radiance_inverse_xform[12];
+
+			float inv_fog_fade;
+			float pads[3];
 		};
 
 		VolumetricFogProcessShaderRD process_shader;
@@ -350,7 +353,7 @@ public:
 		RID env;
 		SkyRD *sky;
 	};
-	void volumetric_fog_update(const VolumetricFogSettings &p_settings, const Projection &p_cam_projection, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes);
+	void volumetric_fog_update(const VolumetricFogSettings &p_settings, const Projection &p_cam_projection, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes, const RendererRD::MaterialStorage::Samplers &p_samplers);
 };
 
 } // namespace RendererRD

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -426,6 +426,7 @@ void RenderForwardClustered::_render_list_template(RenderingDevice::DrawListID p
 			pipeline_specialization.use_light_soft_shadows = element_info.uses_softshadow;
 			pipeline_specialization.use_light_projector = element_info.uses_projector;
 			pipeline_specialization.use_directional_soft_shadows = p_params->use_directional_soft_shadow;
+			pipeline_specialization.use_directional_projector = p_params->use_directional_projector;
 		}
 
 		pipeline_key.color_pass_flags = 0;
@@ -1579,7 +1580,7 @@ void RenderForwardClustered::_pre_opaque_render(RenderDataRD *p_render_data, boo
 
 	uint32_t directional_light_count = 0;
 	uint32_t positional_light_count = 0;
-	light_storage->update_light_buffers(p_render_data, *p_render_data->lights, p_render_data->scene_data->cam_transform, p_render_data->shadow_atlas, using_shadows, directional_light_count, positional_light_count, p_render_data->directional_light_soft_shadows);
+	light_storage->update_light_buffers(p_render_data, *p_render_data->lights, p_render_data->scene_data->cam_transform, p_render_data->shadow_atlas, using_shadows, directional_light_count, positional_light_count, p_render_data->directional_light_soft_shadows, p_render_data->directional_light_use_projectors);
 	texture_storage->update_decal_buffer(*p_render_data->decals, p_render_data->scene_data->cam_transform);
 
 	p_render_data->directional_light_count = directional_light_count;
@@ -2068,7 +2069,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		RID rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_OPAQUE, nullptr, RID(), samplers);
 
 		bool finish_depth = using_ssao || using_ssil || using_sdfgi || using_voxelgi || ce_pre_opaque_resolved_depth || ce_post_opaque_resolved_depth;
-		RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].element_info.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, depth_pass_mode, 0, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].element_info.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, depth_pass_mode, 0, rb_data.is_null(), p_render_data->directional_light_soft_shadows, p_render_data->directional_light_use_projectors, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
 		_render_list_with_draw_list(&render_list_params, depth_framebuffer, RD::DrawFlags(needs_pre_resolve ? RD::DRAW_DEFAULT_ALL : RD::DRAW_CLEAR_ALL), depth_pass_clear, 0.0f, 0u, p_render_data->render_region);
 
 		RD::get_singleton()->draw_command_end_label();
@@ -2147,7 +2148,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 			uint32_t opaque_color_pass_flags = using_motion_pass ? (color_pass_flags & ~uint32_t(COLOR_PASS_FLAG_MOTION_VECTORS)) : color_pass_flags;
 			RID opaque_framebuffer = using_motion_pass ? rb_data->get_color_pass_fb(opaque_color_pass_flags) : color_framebuffer;
-			RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].element_info.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, PASS_MODE_COLOR, opaque_color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
+			RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].element_info.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, PASS_MODE_COLOR, opaque_color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, p_render_data->directional_light_use_projectors, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
 			_render_list_with_draw_list(&render_list_params, opaque_framebuffer, RD::DrawFlags(load_color ? RD::DRAW_DEFAULT_ALL : RD::DRAW_CLEAR_COLOR_ALL) | (depth_pre_pass ? RD::DRAW_DEFAULT_ALL : RD::DRAW_CLEAR_DEPTH), c, 0.0f, 0u, p_render_data->render_region);
 		}
 
@@ -2173,7 +2174,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 			rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_MOTION, p_render_data, radiance_texture, samplers, true);
 
-			RenderListParameters render_list_params(render_list[RENDER_LIST_MOTION].elements.ptr(), render_list[RENDER_LIST_MOTION].element_info.ptr(), render_list[RENDER_LIST_MOTION].elements.size(), reverse_cull, PASS_MODE_COLOR, color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
+			RenderListParameters render_list_params(render_list[RENDER_LIST_MOTION].elements.ptr(), render_list[RENDER_LIST_MOTION].element_info.ptr(), render_list[RENDER_LIST_MOTION].elements.size(), reverse_cull, PASS_MODE_COLOR, color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, p_render_data->directional_light_use_projectors, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
 			_render_list_with_draw_list(&render_list_params, color_framebuffer);
 
 			RD::get_singleton()->draw_command_end_label();
@@ -2360,7 +2361,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		}
 
 		RID alpha_framebuffer = rb_data.is_valid() ? rb_data->get_color_pass_fb(transparent_color_pass_flags) : color_only_framebuffer;
-		RenderListParameters render_list_params(render_list[RENDER_LIST_ALPHA].elements.ptr(), render_list[RENDER_LIST_ALPHA].element_info.ptr(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, PASS_MODE_COLOR, transparent_color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_ALPHA].elements.ptr(), render_list[RENDER_LIST_ALPHA].element_info.ptr(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, PASS_MODE_COLOR, transparent_color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, p_render_data->directional_light_use_projectors, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
 		_render_list_with_draw_list(&render_list_params, alpha_framebuffer, RD::DRAW_DEFAULT_ALL, Vector<Color>(), 0.0f, 0u, p_render_data->render_region);
 	}
 
@@ -2812,7 +2813,7 @@ void RenderForwardClustered::_render_shadow_end() {
 	RD::get_singleton()->draw_command_begin_label("Shadow Render");
 
 	for (SceneState::ShadowPass &shadow_pass : scene_state.shadow_passes) {
-		RenderListParameters render_list_parameters(render_list[RENDER_LIST_SECONDARY].elements.ptr() + shadow_pass.element_from, render_list[RENDER_LIST_SECONDARY].element_info.ptr() + shadow_pass.element_from, shadow_pass.element_count, shadow_pass.flip_cull, shadow_pass.pass_mode, 0, true, false, shadow_pass.rp_uniform_set, false, Vector2(), shadow_pass.lod_distance_multiplier, shadow_pass.screen_mesh_lod_threshold, 1, shadow_pass.element_from);
+		RenderListParameters render_list_parameters(render_list[RENDER_LIST_SECONDARY].elements.ptr() + shadow_pass.element_from, render_list[RENDER_LIST_SECONDARY].element_info.ptr() + shadow_pass.element_from, shadow_pass.element_count, shadow_pass.flip_cull, shadow_pass.pass_mode, 0, true, false, false, shadow_pass.rp_uniform_set, false, Vector2(), shadow_pass.lod_distance_multiplier, shadow_pass.screen_mesh_lod_threshold, 1, shadow_pass.element_from);
 		_render_list_with_draw_list(&render_list_parameters, shadow_pass.framebuffer, shadow_pass.clear_depth ? RD::DRAW_CLEAR_DEPTH : RD::DRAW_DEFAULT_ALL, Vector<Color>(), 0.0f, 0, shadow_pass.rect);
 	}
 
@@ -2859,7 +2860,7 @@ void RenderForwardClustered::_render_particle_collider_heightfield(RID p_fb, con
 
 	{
 		//regular forward for now
-		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), false, pass_mode, 0, true, false, rp_uniform_set);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), false, pass_mode, 0, true, false, false, rp_uniform_set);
 		_render_list_with_draw_list(&render_list_params, p_fb, RD::DRAW_CLEAR_ALL);
 	}
 	RD::get_singleton()->draw_command_end_label();
@@ -2904,7 +2905,7 @@ void RenderForwardClustered::_render_material(const Transform3D &p_cam_transform
 	RENDER_TIMESTAMP("Render 3D Material");
 
 	{
-		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, 0, true, false, rp_uniform_set);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, 0, true, false, false, rp_uniform_set);
 		//regular forward for now
 		Vector<Color> clear = {
 			Color(0, 0, 0, 0),
@@ -2955,7 +2956,7 @@ void RenderForwardClustered::_render_uv2(const PagedArray<RenderGeometryInstance
 	RENDER_TIMESTAMP("Render 3D Material");
 
 	{
-		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, 0, true, false, rp_uniform_set, true);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, 0, true, false, false, rp_uniform_set, true);
 		//regular forward for now
 		Vector<Color> clear = {
 			Color(0, 0, 0, 0),
@@ -3072,7 +3073,7 @@ void RenderForwardClustered::_render_sdfgi(Ref<RenderSceneBuffersRD> p_render_bu
 			E = sdfgi_framebuffer_size_cache.insert(fb_size, fb);
 		}
 
-		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, 0, true, false, rp_uniform_set, false);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, 0, true, false, false, rp_uniform_set, false);
 		_render_list_with_draw_list(&render_list_params, E->value);
 	}
 

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -227,9 +227,10 @@ private:
 		RD::FramebufferFormatID framebuffer_format = 0;
 		uint32_t element_offset = 0;
 		bool use_directional_soft_shadow = false;
+		bool use_directional_projector = false;
 		SceneShaderForwardClustered::ShaderSpecialization base_specialization = {};
 
-		RenderListParameters(GeometryInstanceSurfaceDataCache **p_elements, RenderElementInfo *p_element_info, int p_element_count, bool p_reverse_cull, PassMode p_pass_mode, uint32_t p_color_pass_flags, bool p_no_gi, bool p_use_directional_soft_shadows, RID p_render_pass_uniform_set, bool p_force_wireframe = false, const Vector2 &p_uv_offset = Vector2(), float p_lod_distance_multiplier = 0.0, float p_screen_mesh_lod_threshold = 0.0, uint32_t p_view_count = 1, uint32_t p_element_offset = 0, SceneShaderForwardClustered::ShaderSpecialization p_base_specialization = {}) {
+		RenderListParameters(GeometryInstanceSurfaceDataCache **p_elements, RenderElementInfo *p_element_info, int p_element_count, bool p_reverse_cull, PassMode p_pass_mode, uint32_t p_color_pass_flags, bool p_no_gi, bool p_use_directional_soft_shadows, bool p_use_directional_projectors, RID p_render_pass_uniform_set, bool p_force_wireframe = false, const Vector2 &p_uv_offset = Vector2(), float p_lod_distance_multiplier = 0.0, float p_screen_mesh_lod_threshold = 0.0, uint32_t p_view_count = 1, uint32_t p_element_offset = 0, SceneShaderForwardClustered::ShaderSpecialization p_base_specialization = {}) {
 			elements = p_elements;
 			element_info = p_element_info;
 			element_count = p_element_count;
@@ -245,6 +246,7 @@ private:
 			screen_mesh_lod_threshold = p_screen_mesh_lod_threshold;
 			element_offset = p_element_offset;
 			use_directional_soft_shadow = p_use_directional_soft_shadows;
+			use_directional_projector = p_use_directional_projectors;
 			base_specialization = p_base_specialization;
 		}
 	};

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -737,7 +737,7 @@ private:
 	/* Volumetric fog */
 	RID shadow_sampler;
 
-	void _update_volumetric_fog(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_environment, const Projection &p_cam_projection, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes);
+	void _update_volumetric_fog(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_environment, const Projection &p_cam_projection, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes, const RendererRD::MaterialStorage::Samplers &p_samplers);
 
 	/* Render shadows */
 
@@ -751,7 +751,7 @@ private:
 	void _process_ssao(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_environment, const RID *p_normal_buffers, const Projection *p_projections);
 	void _process_ssil(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_environment, const RID *p_normal_buffers, const Projection *p_projections, const Transform3D &p_transform);
 	void _copy_framebuffer_to_ssil(Ref<RenderSceneBuffersRD> p_render_buffers);
-	void _pre_opaque_render(RenderDataRD *p_render_data, bool p_use_ssao, bool p_use_ssil, bool p_use_gi, const RID *p_normal_roughness_slices, RID p_voxel_gi_buffer);
+	void _pre_opaque_render(RenderDataRD *p_render_data, bool p_use_ssao, bool p_use_ssil, bool p_use_gi, const RID *p_normal_roughness_slices, RID p_voxel_gi_buffer, const RendererRD::MaterialStorage::Samplers &p_samplers);
 	void _process_ssr(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_dest_framebuffer, const RID *p_normal_buffer_slices, RID p_specular_buffer, const RID *p_metallic_slices, RID p_environment, const Projection *p_projections, const Vector3 *p_eye_offsets, bool p_use_additive);
 	void _process_sss(Ref<RenderSceneBuffersRD> p_render_buffers, const Projection &p_camera);
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -125,6 +125,7 @@ public:
 				uint32_t multimesh_format_2d : 1;
 				uint32_t multimesh_has_color : 1;
 				uint32_t multimesh_has_custom_data : 1;
+				uint32_t use_directional_projector : 1;
 			};
 		};
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -836,7 +836,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 	// Update light and decal buffer first so we know what lights and decals are safe to pair with.
 	uint32_t directional_light_count = 0;
 	uint32_t positional_light_count = 0;
-	light_storage->update_light_buffers(p_render_data, *p_render_data->lights, p_render_data->scene_data->cam_transform, p_render_data->shadow_atlas, using_shadows, directional_light_count, positional_light_count, p_render_data->directional_light_soft_shadows);
+	light_storage->update_light_buffers(p_render_data, *p_render_data->lights, p_render_data->scene_data->cam_transform, p_render_data->shadow_atlas, using_shadows, directional_light_count, positional_light_count, p_render_data->directional_light_soft_shadows, p_render_data->directional_light_use_projectors);
 	texture_storage->update_decal_buffer(*p_render_data->decals, p_render_data->scene_data->cam_transform);
 
 	p_render_data->directional_light_count = directional_light_count;
@@ -1045,6 +1045,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 
 	{
 		base_specialization.use_directional_soft_shadows = p_render_data->directional_light_count > 0 ? p_render_data->directional_light_soft_shadows : false;
+		base_specialization.use_directional_projector = p_render_data->directional_light_count > 0 ? p_render_data->directional_light_use_projectors : false;
 		base_specialization.directional_lights = p_render_data->directional_light_count;
 		base_specialization.directional_light_blend_splits = light_storage->get_directional_light_blend_splits(p_render_data->directional_light_count);
 

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -79,7 +79,8 @@ public:
 				uint32_t scene_use_ambient_cubemap : 1;
 				uint32_t scene_use_reflection_cubemap : 1;
 				uint32_t scene_roughness_limiter_enabled : 1;
-				uint32_t padding_0 : 2;
+				uint32_t use_directional_projector : 1;
+				uint32_t padding_0 : 1;
 				uint32_t soft_shadow_samples : 6;
 				uint32_t penumbra_shadow_samples : 6;
 			};

--- a/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
@@ -138,6 +138,9 @@ void main() {
 	vec3 uv = uv_interp;
 #else
 	vec2 uv = uv_interp;
+
+	// params.color.xy contain the XY atlas border size scaled to the current texture UV space
+	uv.xy = uv.xy * vec2(1.0 + params.color.xy) - params.color.xy * 0.5;
 #endif
 
 #ifdef MODE_PANORAMA_TO_DP

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -185,6 +185,11 @@ layout(set = 0, binding = 14, std140) uniform Params {
 	mat4 to_prev_view;
 
 	mat3 radiance_inverse_xform;
+
+	float inv_fog_fade;
+	float pad0;
+	float pad1;
+	float pad2;
 }
 params;
 #ifndef MODE_COPY
@@ -212,6 +217,9 @@ layout(set = 0, binding = 19) uniform textureCubeArray sky_texture;
 layout(set = 0, binding = 19) uniform textureCube sky_texture;
 #endif
 #endif // MODE_COPY
+
+layout(set = 0, binding = 20) uniform texture2D decal_atlas_srgb;
+layout(set = 0, binding = 21) uniform sampler light_projector_sampler;
 
 float get_depth_at_pos(float cell_depth_size, int z) {
 	float d = float(z) * cell_depth_size + cell_depth_size * 0.5; //center of voxels
@@ -276,7 +284,7 @@ const vec3 halton_map[TEMPORAL_FRAMES] = vec3[](
 		vec3(0.03125, 0.59259259, 0.32));
 
 // Higher values will make light in volumetric fog fade out sooner when it's occluded by shadow.
-const float INV_FOG_FADE = 10.0;
+// const float INV_FOG_FADE = 300.0;
 
 void main() {
 	vec3 fog_cell_size = 1.0 / vec3(params.fog_volume_size);
@@ -385,6 +393,7 @@ void main() {
 		for (uint i = 0; i < params.directional_light_count; i++) {
 			if (directional_lights.data[i].volumetric_fog_energy > 0.001) {
 				vec3 shadow_attenuation = vec3(1.0);
+				vec3 light_color = directional_lights.data[i].color;
 
 				if (directional_lights.data[i].shadow_opacity > 0.001) {
 					float depth_z = -view_pos.z;
@@ -416,14 +425,28 @@ void main() {
 					}
 
 					float depth = texture(sampler2D(directional_shadow_atlas, linear_sampler), pssm_coord.xy).r;
-					float shadow = exp(min(0.0, (pssm_coord.z - depth)) * z_range * INV_FOG_FADE);
+					float shadow = exp(min(0.0, (pssm_coord.z - depth)) * z_range * params.inv_fog_fade);
 
 					shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, view_pos.z)); //done with negative values for performance
+
+					// Compute projector color
+					if (directional_lights.data[i].projector_rect != vec4(0.0)) {
+						vec4 splane = (directional_lights.data[i].projector_matrix * v);
+						splane /= splane.w;
+
+						splane.xy = (splane.xy * 0.5 + 0.5) * directional_lights.data[i].projector_scale.xy + directional_lights.data[i].projector_offset.xy;
+						splane.xy = fract(splane.xy);
+						vec2 proj_uv = splane.xy * directional_lights.data[i].projector_rect.zw;
+
+						vec4 proj = textureLod(sampler2D(decal_atlas_srgb, light_projector_sampler), proj_uv + directional_lights.data[i].projector_rect.xy, 0.0);
+
+						light_color *= proj.rgb * proj.a;
+					}
 
 					shadow_attenuation = mix(vec3(1.0 - directional_lights.data[i].shadow_opacity), vec3(1.0), shadow);
 				}
 
-				total_light += shadow_attenuation * directional_lights.data[i].color * directional_lights.data[i].energy * henyey_greenstein(dot(normalize(view_pos), normalize(directional_lights.data[i].direction)), params.phase_g) * directional_lights.data[i].volumetric_fog_energy;
+				total_light += shadow_attenuation * light_color * directional_lights.data[i].energy * henyey_greenstein(dot(normalize(view_pos), normalize(directional_lights.data[i].direction)), params.phase_g) * directional_lights.data[i].volumetric_fog_energy;
 			}
 		}
 
@@ -505,13 +528,16 @@ void main() {
 
 							float shadow_len = length(local_vert); //need to remember shadow len from here
 							vec3 shadow_sample = normalize(local_vert);
+							float original_shadow_sample_z = shadow_sample.z;
 
-							if (shadow_sample.z >= 0.0) {
+							if (original_shadow_sample_z >= 0.0) {
 								uv_rect.xy += flip_offset;
 							}
 
 							shadow_sample.z = 1.0 + abs(shadow_sample.z);
-							vec3 pos = vec3(shadow_sample.xy / shadow_sample.z, shadow_len - omni_lights.data[light_index].shadow_bias);
+							shadow_sample.xy /= shadow_sample.z;
+
+							vec3 pos = vec3(shadow_sample.xy, shadow_len - omni_lights.data[light_index].shadow_bias);
 							pos.z *= omni_lights.data[light_index].inv_radius;
 							pos.z = 1.0 - pos.z;
 
@@ -520,7 +546,20 @@ void main() {
 
 							float depth = texture(sampler2D(shadow_atlas, linear_sampler), pos.xy).r;
 
-							shadow_attenuation = mix(1.0 - omni_lights.data[light_index].shadow_opacity, 1.0, exp(min(0.0, (pos.z - depth)) / omni_lights.data[light_index].inv_radius * INV_FOG_FADE));
+							// Compute projector color
+							if (omni_lights.data[light_index].projector_rect != vec4(0.0)) {
+								vec4 atlas_rect = omni_lights.data[light_index].projector_rect;
+								if (original_shadow_sample_z >= 0.0) {
+									atlas_rect.y += atlas_rect.w;
+								}
+
+								vec2 proj_uv = (shadow_sample.xy * 0.5 + 0.5) * atlas_rect.zw;
+
+								vec4 proj = textureLod(sampler2D(decal_atlas_srgb, light_projector_sampler), proj_uv + atlas_rect.xy, 0.0);
+								light *= proj.rgb * proj.a;
+							}
+
+							shadow_attenuation = mix(1.0 - omni_lights.data[light_index].shadow_opacity, 1.0, exp(min(0.0, (pos.z - depth)) / omni_lights.data[light_index].inv_radius * params.inv_fog_fade));
 						}
 						total_light += light * attenuation * shadow_attenuation * henyey_greenstein(dot(normalize(light_pos - view_pos), normalize(view_pos)), params.phase_g) * omni_lights.data[light_index].volumetric_fog_energy;
 					}
@@ -598,7 +637,15 @@ void main() {
 
 							float depth = texture(sampler2D(shadow_atlas, linear_sampler), pos.xy).r;
 
-							shadow_attenuation = mix(1.0 - spot_lights.data[light_index].shadow_opacity, 1.0, exp(min(0.0, (pos.z - depth)) / spot_lights.data[light_index].inv_radius * INV_FOG_FADE));
+							// Compute projector color
+							if (spot_lights.data[light_index].projector_rect != vec4(0.0)) {
+								vec2 proj_uv = splane.xy * spot_lights.data[light_index].projector_rect.zw;
+
+								vec4 proj = textureLod(sampler2D(decal_atlas_srgb, light_projector_sampler), proj_uv + spot_lights.data[light_index].projector_rect.xy, 0.0);
+								light *= proj.rgb * proj.a;
+							}
+
+							shadow_attenuation = mix(1.0 - spot_lights.data[light_index].shadow_opacity, 1.0, exp(min(0.0, (pos.z - depth)) / spot_lights.data[light_index].inv_radius * params.inv_fog_fade));
 						}
 						total_light += light * attenuation * shadow_attenuation * henyey_greenstein(dot(normalize(light_rel_vec), normalize(view_pos)), params.phase_g) * spot_lights.data[light_index].volumetric_fog_energy;
 					}

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -2405,12 +2405,46 @@ void fragment_shader(in SceneData scene_data) {
 #endif
 
 			float size_A = sc_use_directional_soft_shadows() ? directional_lights.data[i].size : 0.0;
+			vec3 light_color = directional_lights.data[i].color;
+
+			// Directional light projector
+			if (sc_use_directional_projector() && directional_lights.data[i].projector_rect != vec4(0.0)) {
+				vec4 splane = (directional_lights.data[i].projector_matrix * vec4(vertex, 1.0));
+				splane /= splane.w;
+
+				if (sc_projector_use_mipmaps()) {
+					//ensure we have proper mipmaps
+					vec4 splane_ddx = (directional_lights.data[i].projector_matrix * vec4(vertex + vertex_ddx, 1.0));
+					splane_ddx /= splane_ddx.w;
+					vec2 proj_uv_ddx = (splane_ddx.xy - splane.xy) * directional_lights.data[i].projector_rect.zw;
+
+					vec4 splane_ddy = (directional_lights.data[i].projector_matrix * vec4(vertex + vertex_ddy, 1.0));
+					splane_ddy /= splane_ddy.w;
+					vec2 proj_uv_ddy = (splane_ddy.xy - splane.xy) * directional_lights.data[i].projector_rect.zw;
+
+					splane.xy = (splane.xy * 0.5 + 0.5) * directional_lights.data[i].projector_scale.xy + directional_lights.data[i].projector_offset.xy;
+
+					// Repeating
+					splane.xy = fract(splane.xy);
+					vec2 proj_uv = splane.xy * directional_lights.data[i].projector_rect.zw;
+
+					vec4 proj = textureGrad(sampler2D(decal_atlas_srgb, light_projector_sampler), proj_uv + directional_lights.data[i].projector_rect.xy, proj_uv_ddx, proj_uv_ddy);
+					light_color *= proj.rgb * proj.a;
+				} else {
+					splane.xy = (splane.xy * 0.5 + 0.5) * directional_lights.data[i].projector_scale.xy + directional_lights.data[i].projector_offset.xy;
+					splane.xy = fract(splane.xy);
+					vec2 proj_uv = splane.xy * directional_lights.data[i].projector_rect.zw;
+
+					vec4 proj = textureLod(sampler2D(decal_atlas_srgb, light_projector_sampler), proj_uv + directional_lights.data[i].projector_rect.xy, 0.0);
+					light_color *= proj.rgb * proj.a;
+				}
+			}
 
 			light_compute(normal, directional_lights.data[i].direction, normalize(view), size_A,
 #ifndef DEBUG_DRAW_PSSM_SPLITS
-					directional_lights.data[i].color * directional_lights.data[i].energy,
+					light_color * directional_lights.data[i].energy,
 #else
-					directional_lights.data[i].color * directional_lights.data[i].energy * tint,
+					light_color * directional_lights.data[i].energy * tint,
 #endif
 					true, shadow, f0, orms, directional_lights.data[i].specular, albedo, alpha, screen_uv, energy_compensation,
 #ifdef LIGHT_BACKLIGHT_USED

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -147,6 +147,10 @@ bool sc_multimesh_has_custom_data() {
 	return ((sc_packed_1() >> 3) & 1U) != 0;
 }
 
+bool sc_use_directional_projector() {
+	return ((sc_packed_1() >> 4) & 1U) != 0;
+}
+
 float sc_luminance_multiplier() {
 	// Not used in clustered renderer but we share some code with the mobile renderer that requires this.
 	return 1.0;

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1627,7 +1627,6 @@ void main() {
 						float shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor2 + (1.0 - blur_factor2) * blend_split_weight), pssm_coord, scene_data.taa_frame_count);
 						shadow = mix(shadow, shadow2, pssm_blend);
 					}
-
 #ifdef USE_LIGHTMAP
 					if (shadowmask_mode == LIGHTMAP_SHADOWMASK_MODE_REPLACE) {
 						shadow = mix(shadow, shadowmask, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
@@ -1708,9 +1707,43 @@ void main() {
 #endif
 
 			float size_A = sc_use_light_soft_shadows() ? directional_lights.data[i].size : 0.0;
+			vec3 light_color = directional_lights.data[i].color;
+
+			// Directional light projector
+			if (sc_use_directional_projector() && directional_lights.data[i].projector_rect != vec4(0.0)) {
+				vec4 splane = (directional_lights.data[i].projector_matrix * vec4(vertex, 1.0));
+				splane /= splane.w;
+
+				if (sc_projector_use_mipmaps()) {
+					//ensure we have proper mipmaps
+					vec4 splane_ddx = (directional_lights.data[i].projector_matrix * vec4(vertex + vertex_ddx, 1.0));
+					splane_ddx /= splane_ddx.w;
+					vec2 proj_uv_ddx = (splane_ddx.xy - splane.xy) * directional_lights.data[i].projector_rect.zw;
+
+					vec4 splane_ddy = (directional_lights.data[i].projector_matrix * vec4(vertex + vertex_ddy, 1.0));
+					splane_ddy /= splane_ddy.w;
+					vec2 proj_uv_ddy = (splane_ddy.xy - splane.xy) * directional_lights.data[i].projector_rect.zw;
+
+					splane.xy = (splane.xy * 0.5 + 0.5) * directional_lights.data[i].projector_scale.xy + directional_lights.data[i].projector_offset.xy;
+
+					// Repeating
+					splane.xy = fract(splane.xy);
+					vec2 proj_uv = splane.xy * directional_lights.data[i].projector_rect.zw;
+
+					vec4 proj = textureGrad(sampler2D(decal_atlas_srgb, light_projector_sampler), proj_uv + directional_lights.data[i].projector_rect.xy, proj_uv_ddx, proj_uv_ddy);
+					light_color *= proj.rgb * proj.a;
+				} else {
+					splane.xy = (splane.xy * 0.5 + 0.5) * directional_lights.data[i].projector_scale.xy + directional_lights.data[i].projector_offset.xy;
+					splane.xy = fract(splane.xy);
+					vec2 proj_uv = splane.xy * directional_lights.data[i].projector_rect.zw;
+
+					vec4 proj = textureLod(sampler2D(decal_atlas_srgb, light_projector_sampler), proj_uv + directional_lights.data[i].projector_rect.xy, 0.0);
+					light_color *= proj.rgb * proj.a;
+				}
+			}
 
 			light_compute(normal, directional_lights.data[i].direction, view, size_A,
-					directional_lights.data[i].color * directional_lights.data[i].energy * tint,
+					light_color * directional_lights.data[i].energy * tint,
 					true, shadow, f0, orms, directional_lights.data[i].specular, albedo, alpha,
 					screen_uv, vec3(1.0),
 #ifdef LIGHT_BACKLIGHT_USED

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
@@ -160,6 +160,10 @@ bool sc_scene_roughness_limiter_enabled() {
 	return ((sc_packed_0() >> 17) & 1U) != 0;
 }
 
+bool sc_use_directional_projector() {
+	return ((sc_packed_0() >> 18) & 1U) != 0;
+}
+
 uint sc_soft_shadow_samples() {
 	return (sc_packed_0() >> 20) & 63U;
 }

--- a/servers/rendering/renderer_rd/shaders/light_data_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/light_data_inc.glsl
@@ -84,4 +84,8 @@ struct DirectionalLightData {
 	highp vec2 uv_scale2;
 	highp vec2 uv_scale3;
 	highp vec2 uv_scale4;
+	highp mat4 projector_matrix;
+	highp vec4 projector_rect; //projector rect in srgb decal atlas
+	highp vec2 projector_scale;
+	highp vec2 projector_offset;
 };

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -240,18 +240,30 @@ void LightStorage::light_set_projector(RID p_light, RID p_texture) {
 
 	ERR_FAIL_COND(p_texture.is_valid() && !texture_storage->owns_texture(p_texture));
 
-	if (light->type != RS::LIGHT_DIRECTIONAL && light->projector.is_valid()) {
+	if (light->projector.is_valid()) {
 		texture_storage->texture_remove_from_decal_atlas(light->projector, light->type == RS::LIGHT_OMNI);
 	}
 
 	light->projector = p_texture;
 
-	if (light->type != RS::LIGHT_DIRECTIONAL) {
-		if (light->projector.is_valid()) {
-			texture_storage->texture_add_to_decal_atlas(light->projector, light->type == RS::LIGHT_OMNI);
-		}
-		light->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_LIGHT_SOFT_SHADOW_AND_PROJECTOR);
+	if (light->projector.is_valid()) {
+		texture_storage->texture_add_to_decal_atlas(light->projector, light->type == RS::LIGHT_OMNI);
 	}
+	light->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_LIGHT_SOFT_SHADOW_AND_PROJECTOR);
+}
+
+void LightStorage::light_set_projector_scale(RID p_light, const Vector2 &p_scale) {
+	Light *light = light_owner.get_or_null(p_light);
+	ERR_FAIL_NULL(light);
+
+	light->projector_scale = p_scale;
+}
+
+void LightStorage::light_set_projector_offset(RID p_light, const Vector2 &p_offset) {
+	Light *light = light_owner.get_or_null(p_light);
+	ERR_FAIL_NULL(light);
+
+	light->projector_offset = p_offset;
 }
 
 void LightStorage::light_set_negative(RID p_light, bool p_enable) {
@@ -597,7 +609,7 @@ void LightStorage::set_max_lights(const uint32_t p_max_lights) {
 	directional_light_buffer = RD::get_singleton()->uniform_buffer_create(directional_light_buffer_size);
 }
 
-void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const PagedArray<RID> &p_lights, const Transform3D &p_camera_transform, RID p_shadow_atlas, bool p_using_shadows, uint32_t &r_directional_light_count, uint32_t &r_positional_light_count, bool &r_directional_light_soft_shadows) {
+void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const PagedArray<RID> &p_lights, const Transform3D &p_camera_transform, RID p_shadow_atlas, bool p_using_shadows, uint32_t &r_directional_light_count, uint32_t &r_positional_light_count, bool &r_directional_light_soft_shadows, bool &r_directional_light_use_projectors) {
 	ForwardIDStorage *forward_id_storage = ForwardIDStorage::get_singleton();
 	RendererRD::TextureStorage *texture_storage = RendererRD::TextureStorage::get_singleton();
 
@@ -610,6 +622,7 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 	spot_light_count = 0;
 
 	r_directional_light_soft_shadows = false;
+	r_directional_light_use_projectors = false;
 
 	for (int i = 0; i < (int)p_lights.size(); i++) {
 		LightInstance *light_instance = light_instance_owner.get_or_null(p_lights[i]);
@@ -692,6 +705,51 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 
 					if (angular_diameter <= 0.0) {
 						light_data.soft_shadow_scale *= RendererSceneRenderRD::get_singleton()->directional_shadow_quality_radius_get(); // Only use quality radius for PCF
+					}
+
+					RID projector = light->projector;
+
+					if (projector.is_valid()) {
+						Rect2 rect = texture_storage->decal_atlas_get_texture_rect(projector);
+
+						light_data.projector_rect[0] = rect.position.x;
+						light_data.projector_rect[1] = rect.position.y + rect.size.height; //flip because shadow is flipped
+						light_data.projector_rect[2] = rect.size.width;
+						light_data.projector_rect[3] = -rect.size.height;
+
+						light_data.projector_scale[0] = light->projector_scale.x;
+						light_data.projector_scale[1] = light->projector_scale.y;
+						light_data.projector_offset[0] = light->projector_offset.x;
+						light_data.projector_offset[1] = light->projector_offset.y;
+
+						// Compute projector matrix
+						float projector_size = 50.0f;
+						float projector_near = -25.0f;
+						float projector_far = 25.0f;
+
+						Projection projector_projection;
+						projector_projection.set_orthogonal(projector_size, 1.0f, projector_near, projector_far, false);
+
+						Transform3D modelview = (inverse_transform * light_transform).inverse();
+
+						// We could use this instead if we don't want to use an arbitrary orthogonal projection
+						//Projection correction;
+						//correction.set_depth_correction(false, true, false);
+						//Projection cm = correction * light_instance->shadow_transform[0].camera;
+						//
+						//Projection projector_mtx = cm * modelview;
+
+						Projection projector_mtx = projector_projection * modelview;
+
+						RendererRD::MaterialStorage::store_camera(projector_mtx, light_data.projector_matrix);
+
+						r_directional_light_use_projectors = true;
+
+					} else {
+						light_data.projector_rect[0] = 0;
+						light_data.projector_rect[1] = 0;
+						light_data.projector_rect[2] = 0;
+						light_data.projector_rect[3] = 0;
 					}
 
 					int limit = smode == RS::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL ? 0 : (smode == RS::LIGHT_DIRECTIONAL_SHADOW_PARALLEL_2_SPLITS ? 1 : 3);

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -65,6 +65,8 @@ private:
 		float param[RS::LIGHT_PARAM_MAX];
 		Color color = Color(1, 1, 1, 1);
 		RID projector;
+		Vector2 projector_scale;
+		Vector2 projector_offset;
 		bool shadow = false;
 		bool negative = false;
 		bool reverse_cull = false;
@@ -210,6 +212,10 @@ private:
 		float uv_scale2[2];
 		float uv_scale3[2];
 		float uv_scale4[2];
+		float projector_matrix[16];
+		float projector_rect[4];
+		float projector_scale[2];
+		float projector_offset[2];
 	};
 
 	uint32_t max_directional_lights;
@@ -485,6 +491,8 @@ public:
 	virtual void light_set_param(RID p_light, RS::LightParam p_param, float p_value) override;
 	virtual void light_set_shadow(RID p_light, bool p_enabled) override;
 	virtual void light_set_projector(RID p_light, RID p_texture) override;
+	virtual void light_set_projector_scale(RID p_light, const Vector2 &p_scale) override;
+	virtual void light_set_projector_offset(RID p_light, const Vector2 &p_offset) override;
 	virtual void light_set_negative(RID p_light, bool p_enable) override;
 	virtual void light_set_cull_mask(RID p_light, uint32_t p_mask) override;
 	virtual void light_set_distance_fade(RID p_light, bool p_enabled, float p_begin, float p_shadow, float p_length) override;
@@ -825,7 +833,7 @@ public:
 		}
 		return false;
 	}
-	void update_light_buffers(RenderDataRD *p_render_data, const PagedArray<RID> &p_lights, const Transform3D &p_camera_transform, RID p_shadow_atlas, bool p_using_shadows, uint32_t &r_directional_light_count, uint32_t &r_positional_light_count, bool &r_directional_light_soft_shadows);
+	void update_light_buffers(RenderDataRD *p_render_data, const PagedArray<RID> &p_lights, const Transform3D &p_camera_transform, RID p_shadow_atlas, bool p_using_shadows, uint32_t &r_directional_light_count, uint32_t &r_positional_light_count, bool &r_directional_light_soft_shadows, bool &r_directional_light_use_projectors);
 
 	/* REFLECTION PROBE */
 

--- a/servers/rendering/renderer_rd/storage_rd/render_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_data_rd.h
@@ -71,6 +71,7 @@ public:
 
 	uint32_t directional_light_count = 0;
 	bool directional_light_soft_shadows = false;
+	bool directional_light_use_projectors = false;
 
 	bool lightmap_bicubic_filter = false;
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1268,7 +1268,7 @@ public:
 	PASS1RC(float, environment_get_fog_depth_end, RID)
 
 	// Volumentric Fog
-	PASS14(environment_set_volumetric_fog, RID, bool, float, const Color &, const Color &, float, float, float, float, float, bool, float, float, float)
+	PASS15(environment_set_volumetric_fog, RID, bool, float, float, const Color &, const Color &, float, float, float, float, float, bool, float, float, float)
 
 	PASS1RC(bool, environment_get_volumetric_fog_enabled, RID)
 	PASS1RC(float, environment_get_volumetric_fog_density, RID)

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -443,8 +443,8 @@ float RendererSceneRender::environment_get_fog_depth_end(RID p_env) const {
 
 // Volumetric Fog
 
-void RendererSceneRender::environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect) {
-	environment_storage.environment_set_volumetric_fog(p_env, p_enable, p_density, p_albedo, p_emission, p_emission_energy, p_anisotropy, p_length, p_detail_spread, p_gi_inject, p_temporal_reprojection, p_temporal_reprojection_amount, p_ambient_inject, p_sky_affect);
+void RendererSceneRender::environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, float p_fade, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect) {
+	environment_storage.environment_set_volumetric_fog(p_env, p_enable, p_density, p_fade, p_albedo, p_emission, p_emission_energy, p_anisotropy, p_length, p_detail_spread, p_gi_inject, p_temporal_reprojection, p_temporal_reprojection_amount, p_ambient_inject, p_sky_affect);
 }
 
 bool RendererSceneRender::environment_get_volumetric_fog_enabled(RID p_env) const {
@@ -453,6 +453,10 @@ bool RendererSceneRender::environment_get_volumetric_fog_enabled(RID p_env) cons
 
 float RendererSceneRender::environment_get_volumetric_fog_density(RID p_env) const {
 	return environment_storage.environment_get_volumetric_fog_density(p_env);
+}
+
+float RendererSceneRender::environment_get_volumetric_fog_fade(RID p_env) const {
+	return environment_storage.environment_get_volumetric_fog_fade(p_env);
 }
 
 Color RendererSceneRender::environment_get_volumetric_fog_scattering(RID p_env) const {

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -159,9 +159,10 @@ public:
 	float environment_get_fog_depth_end(RID p_env) const;
 
 	// Volumetric Fog
-	void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect);
+	void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, float p_fade, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect);
 	bool environment_get_volumetric_fog_enabled(RID p_env) const;
 	float environment_get_volumetric_fog_density(RID p_env) const;
+	float environment_get_volumetric_fog_fade(RID p_env) const;
 	Color environment_get_volumetric_fog_scattering(RID p_env) const;
 	Color environment_get_volumetric_fog_emission(RID p_env) const;
 	float environment_get_volumetric_fog_emission_energy(RID p_env) const;

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -212,7 +212,7 @@ public:
 	virtual float environment_get_fog_depth_end(RID p_env) const = 0;
 
 	// Volumetric Fog
-	virtual void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect) = 0;
+	virtual void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, float p_fade, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect) = 0;
 
 	virtual bool environment_get_volumetric_fog_enabled(RID p_env) const = 0;
 	virtual float environment_get_volumetric_fog_density(RID p_env) const = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -442,6 +442,8 @@ public:
 	FUNC3(light_set_param, RID, LightParam, float)
 	FUNC2(light_set_shadow, RID, bool)
 	FUNC2(light_set_projector, RID, RID)
+	FUNC2(light_set_projector_scale, RID, const Vector2 &)
+	FUNC2(light_set_projector_offset, RID, const Vector2 &)
 	FUNC2(light_set_negative, RID, bool)
 	FUNC2(light_set_cull_mask, RID, uint32_t)
 	FUNC5(light_set_distance_fade, RID, bool, float, float, float)

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -822,7 +822,7 @@ public:
 	FUNC11(environment_set_fog, RID, bool, const Color &, float, float, float, float, float, float, float, EnvironmentFogMode)
 
 	FUNC4(environment_set_fog_depth, RID, float, float, float)
-	FUNC14(environment_set_volumetric_fog, RID, bool, float, const Color &, const Color &, float, float, float, float, float, bool, float, float, float)
+	FUNC15(environment_set_volumetric_fog, RID, bool, float, float, const Color &, const Color &, float, float, float, float, float, bool, float, float, float)
 
 	FUNC2(environment_set_volumetric_fog_volume_size, int, int)
 	FUNC1(environment_set_volumetric_fog_filter_active, bool)

--- a/servers/rendering/storage/environment_storage.cpp
+++ b/servers/rendering/storage/environment_storage.cpp
@@ -336,7 +336,7 @@ float RendererEnvironmentStorage::environment_get_fog_depth_end(RID p_env) const
 
 // Volumetric Fog
 
-void RendererEnvironmentStorage::environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect) {
+void RendererEnvironmentStorage::environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, float p_fade, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect) {
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_NULL(env);
 #ifdef DEBUG_ENABLED
@@ -346,6 +346,7 @@ void RendererEnvironmentStorage::environment_set_volumetric_fog(RID p_env, bool 
 #endif
 	env->volumetric_fog_enabled = p_enable;
 	env->volumetric_fog_density = p_density;
+	env->volumetric_fog_fade = p_fade;
 	env->volumetric_fog_scattering = p_albedo;
 	env->volumetric_fog_emission = p_emission;
 	env->volumetric_fog_emission_energy = p_emission_energy;
@@ -369,6 +370,12 @@ float RendererEnvironmentStorage::environment_get_volumetric_fog_density(RID p_e
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_NULL_V(env, 0.01);
 	return env->volumetric_fog_density;
+}
+
+float RendererEnvironmentStorage::environment_get_volumetric_fog_fade(RID p_env) const {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_NULL_V(env, 0.1);
+	return env->volumetric_fog_fade;
 }
 
 Color RendererEnvironmentStorage::environment_get_volumetric_fog_scattering(RID p_env) const {

--- a/servers/rendering/storage/environment_storage.h
+++ b/servers/rendering/storage/environment_storage.h
@@ -83,6 +83,7 @@ private:
 		// Volumetric Fog
 		bool volumetric_fog_enabled = false;
 		float volumetric_fog_density = 0.01;
+		float volumetric_fog_fade = 0.1;
 		Color volumetric_fog_scattering = Color(1, 1, 1);
 		Color volumetric_fog_emission = Color(0, 0, 0);
 		float volumetric_fog_emission_energy = 0.0;
@@ -224,9 +225,10 @@ public:
 	float environment_get_fog_depth_end(RID p_env) const;
 
 	// Volumetric Fog
-	void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect);
+	void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, float p_fade, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect);
 	bool environment_get_volumetric_fog_enabled(RID p_env) const;
 	float environment_get_volumetric_fog_density(RID p_env) const;
+	float environment_get_volumetric_fog_fade(RID p_env) const;
 	Color environment_get_volumetric_fog_scattering(RID p_env) const;
 	Color environment_get_volumetric_fog_emission(RID p_env) const;
 	float environment_get_volumetric_fog_emission_energy(RID p_env) const;

--- a/servers/rendering/storage/light_storage.h
+++ b/servers/rendering/storage/light_storage.h
@@ -54,6 +54,8 @@ public:
 	virtual void light_set_param(RID p_light, RS::LightParam p_param, float p_value) = 0;
 	virtual void light_set_shadow(RID p_light, bool p_enabled) = 0;
 	virtual void light_set_projector(RID p_light, RID p_texture) = 0;
+	virtual void light_set_projector_scale(RID p_light, const Vector2 &p_scale) = 0;
+	virtual void light_set_projector_offset(RID p_light, const Vector2 &p_offset) = 0;
 	virtual void light_set_negative(RID p_light, bool p_enable) = 0;
 	virtual void light_set_cull_mask(RID p_light, uint32_t p_mask) = 0;
 	virtual void light_set_distance_fade(RID p_light, bool p_enabled, float p_begin, float p_shadow, float p_length) = 0;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3027,7 +3027,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("environment_set_fog", "env", "enable", "light_color", "light_energy", "sun_scatter", "density", "height", "height_density", "aerial_perspective", "sky_affect", "fog_mode"), &RenderingServer::environment_set_fog, DEFVAL(RS::ENV_FOG_MODE_EXPONENTIAL));
 	ClassDB::bind_method(D_METHOD("environment_set_fog_depth", "env", "curve", "begin", "end"), &RenderingServer::environment_set_fog_depth);
 	ClassDB::bind_method(D_METHOD("environment_set_sdfgi", "env", "enable", "cascades", "min_cell_size", "y_scale", "use_occlusion", "bounce_feedback", "read_sky", "energy", "normal_bias", "probe_bias"), &RenderingServer::environment_set_sdfgi);
-	ClassDB::bind_method(D_METHOD("environment_set_volumetric_fog", "env", "enable", "density", "albedo", "emission", "emission_energy", "anisotropy", "length", "p_detail_spread", "gi_inject", "temporal_reprojection", "temporal_reprojection_amount", "ambient_inject", "sky_affect"), &RenderingServer::environment_set_volumetric_fog);
+	ClassDB::bind_method(D_METHOD("environment_set_volumetric_fog", "env", "enable", "density", "fade", "albedo", "emission", "emission_energy", "anisotropy", "length", "p_detail_spread", "gi_inject", "temporal_reprojection", "temporal_reprojection_amount", "ambient_inject", "sky_affect"), &RenderingServer::environment_set_volumetric_fog);
 
 	ClassDB::bind_method(D_METHOD("environment_glow_set_use_bicubic_upscale", "enable"), &RenderingServer::environment_glow_set_use_bicubic_upscale);
 	ClassDB::bind_method(D_METHOD("environment_set_ssr_roughness_quality", "quality"), &RenderingServer::environment_set_ssr_roughness_quality);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -564,6 +564,8 @@ public:
 	virtual void light_set_param(RID p_light, LightParam p_param, float p_value) = 0;
 	virtual void light_set_shadow(RID p_light, bool p_enabled) = 0;
 	virtual void light_set_projector(RID p_light, RID p_texture) = 0;
+	virtual void light_set_projector_scale(RID p_light, const Vector2 &p_scale) = 0;
+	virtual void light_set_projector_offset(RID p_light, const Vector2 &p_offset) = 0;
 	virtual void light_set_negative(RID p_light, bool p_enable) = 0;
 	virtual void light_set_cull_mask(RID p_light, uint32_t p_mask) = 0;
 	virtual void light_set_distance_fade(RID p_light, bool p_enabled, float p_begin, float p_shadow, float p_length) = 0;

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1364,7 +1364,7 @@ public:
 	virtual void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective, float p_sky_affect, EnvironmentFogMode p_mode = EnvironmentFogMode::ENV_FOG_MODE_EXPONENTIAL) = 0;
 	virtual void environment_set_fog_depth(RID p_env, float p_curve, float p_begin, float p_end) = 0;
 
-	virtual void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect) = 0;
+	virtual void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, float p_fade, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect) = 0;
 	virtual void environment_set_volumetric_fog_volume_size(int p_size, int p_depth) = 0;
 	virtual void environment_set_volumetric_fog_filter_active(bool p_enable) = 0;
 


### PR DESCRIPTION
This is a WIP branch which is based on my precedent [branch](https://github.com/godotengine/godot/pull/106294) to add directional light projectors.

Its goal is to responds to this discussion : https://github.com/godotengine/godot-proposals/discussions/11987 and make the volumetric fog affected lights projectors

**Done in this PR :**
- Added atlas texture srgb and projector sampler in the fog shaders
- Added computation of the projector in the fog

**To do :**
- Add control over the impact of the projector in the fog ? (Don't know if needed in addition to the light_volumetric_fog_energy parameter)
- Verify if we want to use mipmaps

**My main concerns are :**
- Is my approach to add the samplers available in the volumetric_fog_update method the good one ? (Adding it as a parameter)
- What is the performance impact of adding a condition and sampling a texture in it in the fog shader, since, unlike the scene shaders, It seems like the fog shader don't have shader specialization constants yet

**Little preview :**
![godotRays](https://github.com/user-attachments/assets/20e5b3a8-6ccf-4c08-851a-5105ea1fa38f)
![OmniLights](https://github.com/user-attachments/assets/61d3d0bc-f3f5-4395-bf59-5857b0d135ce)
![otherRays](https://github.com/user-attachments/assets/f7374217-ad0a-46a7-99aa-951bf6b200e4)
![party](https://github.com/user-attachments/assets/57e44f9c-c837-47b9-9a6c-4195be4d9f1b)



https://github.com/user-attachments/assets/1be09bb9-43ed-4118-9a56-c52190ae10a3

- *Bugsquad edit: This closes https://github.com/godotengine/godot/issues/77384
and closes https://github.com/godotengine/godot-proposals/discussions/11987.*
