### PR TITLE
D3D12: Silence `-Wmaybe-uninitialized` warning in D3D12MemAlloc

### DIFF
--- a/drivers/d3d12/d3d12ma.cpp
+++ b/drivers/d3d12/d3d12ma.cpp
@@ -28,6 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "rendering_context_driver_d3d12.h"
+// Wrapper needed to set the required rpcndr version for MinGW compatibility.
+// Since we're compiling thirdparty code in a Godot SCons environment with
+// warnings enabled, we also need to silence them manually.
+
+#include "rendering_device_driver_d3d12.h" // For __REQUIRED_RPCNDR_H_VERSION__.
+
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wmaybe-uninitialized")
 
 #include <D3D12MemAlloc.cpp>
+
+GODOT_GCC_WARNING_POP


### PR DESCRIPTION
This was lost in #104893 when removing the warning ignores no longer relevant when including the D3D12MemAlloc _header_ as external. But we still compile the .cpp directly and it has this warning.

Clarified why have a wrapper for this file.

I also experimented with removing the wrapper and properly building this file in a cloned `env_thirdparty` with warnings disabled, but that requires also re-adding the define of `__REQUIRED_RPCNDR_H_VERSION__` in the `SCsub` for the whole `env`, polluting a bit the command line for the vast majority of files that don't need this.

Fixes warnings reported in https://github.com/godotengine/godot/issues/106376#issuecomment-2880276424.