### PR TITLE
GUI: Copy all text in `RichTextLabel` if nothing is selected

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2821,7 +2821,10 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 					handled = true;
 				}
 				if (k->is_action("ui_copy", true)) {
-					selection_copy();
+					const String txt = get_selected_text();
+					if (!txt.is_empty()) {
+						DisplayServer::get_singleton()->clipboard_set(txt);
+					}
 					handled = true;
 				}
 			}
@@ -6634,14 +6637,6 @@ void RichTextLabel::deselect() {
 	queue_redraw();
 }
 
-void RichTextLabel::selection_copy() {
-	String txt = get_selected_text();
-
-	if (!txt.is_empty()) {
-		DisplayServer::get_singleton()->clipboard_set(txt);
-	}
-}
-
 void RichTextLabel::select_all() {
 	_validate_line_caches();
 
@@ -7618,7 +7613,14 @@ Key RichTextLabel::_get_menu_action_accelerator(const String &p_action) {
 void RichTextLabel::menu_option(int p_option) {
 	switch (p_option) {
 		case MENU_COPY: {
-			selection_copy();
+			String txt = get_selected_text();
+			if (txt.is_empty()) {
+				txt = get_parsed_text();
+			}
+
+			if (!txt.is_empty()) {
+				DisplayServer::get_singleton()->clipboard_set(txt);
+			}
 		} break;
 		case MENU_SELECT_ALL: {
 			select_all();

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -866,7 +866,6 @@ public:
 	float get_selection_line_offset() const;
 	String get_selected_text() const;
 	void select_all();
-	void selection_copy();
 
 	_FORCE_INLINE_ void set_selection_modifier(const Callable &p_modifier) {
 		selection_modifier = p_modifier;


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/77776#pullrequestreview-2826496547, CC @Calinou:

> Also, right-clicking the error message and choosing **Copy** has no effect if no text is selected. (This is why I had the impression the option had no effect for the longest time.) This is an issue with the RichTextLabel context menu, so we should look into addressing it in a separate PR.

The behavior of the <kbd>Ctrl+C</kbd> shortcut is not changed because people probably expect it to copy only the selected text, unlike the context menu item.

Also, the `RichTextLabel::selection_copy()` method was removed because it was used in one place, is not exposed, and can easily be reproduced by composing `get_selected_text()` and `clipboard_set()`.

* See also https://github.com/godotengine/godot-proposals/issues/133.

The above proposal is already resolved, but some people for some reason might prefer to use the context menu instead of the button in the sidebar. Now the behavior will be consistent.

![](https://github.com/user-attachments/assets/8d0aed9b-3caf-4c4b-a432-26386852f047)

See also (this PR does not fix the following):

* #74109
* #87463
* #87467
* #91525