### PR TITLE
Fix Reflection Mask not working on Mobile

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -212,6 +212,11 @@ void RendererSceneCull::_instance_pair(Instance *p_A, Instance *p_B) {
 		}
 
 	} else if (self->geometry_instance_pair_mask & (1 << RS::INSTANCE_REFLECTION_PROBE) && B->base_type == RS::INSTANCE_REFLECTION_PROBE && ((1 << A->base_type) & RS::INSTANCE_GEOMETRY_MASK)) {
+		if (!(A->layer_mask & RSG::light_storage->reflection_probe_get_reflection_mask(B->base))) {
+			// Early return if the object's layer mask doesn't match the reflection mask.
+			return;
+		}
+
 		InstanceReflectionProbeData *reflection_probe = static_cast<InstanceReflectionProbeData *>(B->base_data);
 		InstanceGeometryData *geom = static_cast<InstanceGeometryData *>(A->base_data);
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -504,10 +504,10 @@ public:
 				case Dependency::DEPENDENCY_CHANGED_PARTICLES:
 				case Dependency::DEPENDENCY_CHANGED_MULTIMESH:
 				case Dependency::DEPENDENCY_CHANGED_DECAL:
-				case Dependency::DEPENDENCY_CHANGED_LIGHT:
-				case Dependency::DEPENDENCY_CHANGED_REFLECTION_PROBE: {
+				case Dependency::DEPENDENCY_CHANGED_LIGHT: {
 					singleton->_instance_queue_update(instance, true, true);
 				} break;
+				case Dependency::DEPENDENCY_CHANGED_REFLECTION_PROBE:
 				case Dependency::DEPENDENCY_CHANGED_LIGHT_SOFT_SHADOW_AND_PROJECTOR:
 				case Dependency::DEPENDENCY_CHANGED_CULL_MASK: {
 					//requires repairing


### PR DESCRIPTION
Closes #93173 
Supersedes #93175 

Fix reflection masks on the mobile renderer according @clayjohn [commnet on the previews attempt](https://github.com/godotengine/godot/pull/93175#pullrequestreview-2138921050). Now it uses RendererSceneCull in order to cull the reflections before calling the shader.

MRP for the picure: 
[reflection_mask_test.zip](https://github.com/user-attachments/files/20214351/reflection_mask_test.zip)

![Reflection_Mask](https://github.com/user-attachments/assets/ab852cd1-4c46-4cee-8cfd-972f9e215f6a)


Note: the new [cull_mask overhaul](https://github.com/godotengine/godot/pull/102399/) is great! In 4.4 I did an ugly workaround, now it just works the right way.