### PR TITLE
Change CPPEXTPATH to CPPPATH for mesa_private_inc_paths

### DIFF
--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -155,7 +155,7 @@ else:
         env.Append(CCFLAGS=["-Wno-unknown-pragmas"])
 
 # This is needed since rendering_device_d3d12.cpp needs to include some Mesa internals.
-env_d3d12_rdd.Prepend(CPPEXTPATH=mesa_private_inc_paths)
+env_d3d12_rdd.Prepend(CPPPATH=mesa_private_inc_paths)
 # For the same reason as above, the defines must be the same as in the 3rd-party code itself.
 env_d3d12_rdd.Append(CPPDEFINES=extra_defines)
 


### PR DESCRIPTION
Just another PR to consider alongside https://github.com/godotengine/godot/pull/106413.

Fixes: https://github.com/issues/created?issue=godotengine%7Cgodot%7C106376

Hopefully this doesn't bring back the warnings that the other PR does and we get to have our cake and eat it to! :)