### PR TITLE
Fix some EditorPropertyEasing presets not translated

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -8196,10 +8196,10 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	transition_selection->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED); // Translation context is needed.
 	ease_selection = memnew(OptionButton);
 	ease_selection->set_accessibility_name(TTRC("Ease Type:"));
-	ease_selection->add_item(TTR("In", "Ease Type"), Tween::EASE_IN);
-	ease_selection->add_item(TTR("Out", "Ease Type"), Tween::EASE_OUT);
-	ease_selection->add_item(TTR("InOut", "Ease Type"), Tween::EASE_IN_OUT);
-	ease_selection->add_item(TTR("OutIn", "Ease Type"), Tween::EASE_OUT_IN);
+	ease_selection->add_item(TTR("Ease In", "Ease Type"), Tween::EASE_IN);
+	ease_selection->add_item(TTR("Ease Out", "Ease Type"), Tween::EASE_OUT);
+	ease_selection->add_item(TTR("Ease In-Out", "Ease Type"), Tween::EASE_IN_OUT);
+	ease_selection->add_item(TTR("Ease Out-In", "Ease Type"), Tween::EASE_OUT_IN);
 	ease_selection->select(Tween::EASE_IN_OUT); // Default
 	ease_selection->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED); // Translation context is needed.
 	ease_fps = memnew(SpinBox);

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1772,21 +1772,41 @@ void EditorPropertyEasing::_spin_focus_exited() {
 void EditorPropertyEasing::setup(bool p_positive_only, bool p_flip) {
 	flip = p_flip;
 	positive_only = p_positive_only;
+
+	// Names need translation context, so they are set in NOTIFICATION_TRANSLATION_CHANGED.
+	preset->add_item("", EASING_LINEAR);
+	preset->add_item("", EASING_IN);
+	preset->add_item("", EASING_OUT);
+	preset->add_item("", EASING_ZERO);
+	if (!positive_only) {
+		preset->add_item("", EASING_IN_OUT);
+		preset->add_item("", EASING_OUT_IN);
+	}
 }
 
 void EditorPropertyEasing::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			preset->clear();
-			preset->add_icon_item(get_editor_theme_icon(SNAME("CurveLinear")), "Linear", EASING_LINEAR);
-			preset->add_icon_item(get_editor_theme_icon(SNAME("CurveIn")), "Ease In", EASING_IN);
-			preset->add_icon_item(get_editor_theme_icon(SNAME("CurveOut")), "Ease Out", EASING_OUT);
-			preset->add_icon_item(get_editor_theme_icon(SNAME("CurveConstant")), "Zero", EASING_ZERO);
+			preset->set_item_icon(preset->get_item_index(EASING_LINEAR), get_editor_theme_icon(SNAME("CurveLinear")));
+			preset->set_item_icon(preset->get_item_index(EASING_IN), get_editor_theme_icon(SNAME("CurveIn")));
+			preset->set_item_icon(preset->get_item_index(EASING_OUT), get_editor_theme_icon(SNAME("CurveOut")));
+			preset->set_item_icon(preset->get_item_index(EASING_ZERO), get_editor_theme_icon(SNAME("CurveConstant")));
 			if (!positive_only) {
-				preset->add_icon_item(get_editor_theme_icon(SNAME("CurveInOut")), "Ease In-Out", EASING_IN_OUT);
-				preset->add_icon_item(get_editor_theme_icon(SNAME("CurveOutIn")), "Ease Out-In", EASING_OUT_IN);
+				preset->set_item_icon(preset->get_item_index(EASING_IN_OUT), get_editor_theme_icon(SNAME("CurveInOut")));
+				preset->set_item_icon(preset->get_item_index(EASING_OUT_IN), get_editor_theme_icon(SNAME("CurveOutIn")));
 			}
 			easing_draw->set_custom_minimum_size(Size2(0, get_theme_font(SceneStringName(font), SNAME("Label"))->get_height(get_theme_font_size(SceneStringName(font_size), SNAME("Label"))) * 2));
+		} break;
+
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			preset->set_item_text(preset->get_item_index(EASING_LINEAR), TTR("Linear", "Ease Type"));
+			preset->set_item_text(preset->get_item_index(EASING_IN), TTR("Ease In", "Ease Type"));
+			preset->set_item_text(preset->get_item_index(EASING_OUT), TTR("Ease Out", "Ease Type"));
+			preset->set_item_text(preset->get_item_index(EASING_ZERO), TTR("Zero", "Ease Type"));
+			if (!positive_only) {
+				preset->set_item_text(preset->get_item_index(EASING_IN_OUT), TTR("Ease In-Out", "Ease Type"));
+				preset->set_item_text(preset->get_item_index(EASING_OUT_IN), TTR("Ease Out-In", "Ease Type"));
+			}
 		} break;
 	}
 }
@@ -1799,6 +1819,7 @@ EditorPropertyEasing::EditorPropertyEasing() {
 	add_child(easing_draw);
 
 	preset = memnew(PopupMenu);
+	preset->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	add_child(preset);
 	preset->connect(SceneStringName(id_pressed), callable_mp(this, &EditorPropertyEasing::_set_preset));
 


### PR DESCRIPTION
For properties using `PROPERTY_HINT_EXP_EASING`, the Inspector allows users to choose from a list of easing presets.

![image](https://github.com/user-attachments/assets/571d7603-79ce-44a7-844d-764e14e27d1d)

These preset names are not marked for translation extraction, so some of them lack a translation in the current version.

Since the Make Easing Selection dialog in the AnimationPlayer editor provides a list of easing types that is a subset of the list of preset names here, I unified the wording they are using.