### PR TITLE
Allow Dock Icon Overrides

### DIFF
--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -185,7 +185,7 @@ void EditorDockManager::update_docks_menu() {
 		} else {
 			docks_menu->add_item(dock.value.title, id);
 		}
-		const Ref<Texture2D> icon = dock.value.icon_name ? docks_menu->get_editor_theme_native_menu_icon(dock.value.icon_name, global_menu, dark_mode) : dock.value.icon;
+		const Ref<Texture2D> icon = dock.value.icon.is_valid() ? dock.value.icon : docks_menu->get_editor_theme_native_menu_icon(dock.value.icon_name, global_menu, dark_mode);
 		docks_menu->set_item_icon(id, icon.is_valid() ? icon : default_icon);
 		if (!dock.value.open) {
 			docks_menu->set_item_icon_modulate(id, closed_icon_color_mod);
@@ -403,13 +403,13 @@ void EditorDockManager::_update_tab_style(Control *p_dock) {
 			tab_container->set_tab_tooltip(index, String());
 		} break;
 		case TabStyle::ICON_ONLY: {
-			const Ref<Texture2D> icon = dock_info.icon_name ? tab_container->get_editor_theme_icon(dock_info.icon_name) : dock_info.icon;
+			const Ref<Texture2D> icon = dock_info.icon.is_valid() ? dock_info.icon : tab_container->get_editor_theme_icon(dock_info.icon_name);
 			tab_container->set_tab_title(index, icon.is_valid() ? String() : dock_info.title);
 			tab_container->set_tab_icon(index, icon);
 			tab_container->set_tab_tooltip(index, icon.is_valid() ? dock_info.title : String());
 		} break;
 		case TabStyle::TEXT_AND_ICON: {
-			const Ref<Texture2D> icon = dock_info.icon_name ? tab_container->get_editor_theme_icon(dock_info.icon_name) : dock_info.icon;
+			const Ref<Texture2D> icon = dock_info.icon.is_valid() ? dock_info.icon : tab_container->get_editor_theme_icon(dock_info.icon_name);
 			tab_container->set_tab_title(index, dock_info.title);
 			tab_container->set_tab_icon(index, icon);
 			tab_container->set_tab_tooltip(index, String());

--- a/editor/editor_dock_manager.h
+++ b/editor/editor_dock_manager.h
@@ -86,7 +86,7 @@ private:
 		WindowWrapper *dock_window = nullptr;
 		int dock_slot_index = DOCK_SLOT_NONE;
 		Ref<Shortcut> shortcut;
-		Ref<Texture2D> icon; // Only used when `icon_name` is empty.
+		Ref<Texture2D> icon; // Used an an override for `icon_name`.
 		StringName icon_name;
 	};
 


### PR DESCRIPTION
Related: #91039 

Currently, Editor Docks have two ways to store icons, a StringName (pointing to theme) and a texture2D. The string takes priority and is only assigned upon creation. The icon is able to be assigned through API access (see `EditorPlugin::set_dock_tab_icon`), but it does not take precedence over the StringName, so if you previously set an icon using the StringName then setting it using the icon would not change anything.

Before, there was no method of overriding Dock Icons, and the StringName was rarely used simultaneously with the icon because it was not useful to permanently set a variable that could not then be overridded. This PR changes the order of precedence. This makes it so that the StringName that is assigned can be overridden by the icon.

This is extremely useful if you want a dock to store a default icon, but then want to override it with a temporary icon. For example, when the Output panel is transformed to a dock (see #106426), it would want to override its default icon with the `warning` or `error` icons when issues occur.