### PR TITLE
Fix EditorHelp's `FindBar` search index

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -4813,6 +4813,8 @@ void FindBar::popup_search() {
 		search_text->select_all();
 		search_text->set_caret_column(search_text->get_text().length());
 		if (grabbed_focus) {
+			rich_text_label->deselect();
+			results_count_to_current = 0;
 			_search();
 		}
 	}


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/105968 has added search match index. But if you will try to popup and hide `FindBar` several times, search index will increment each time (so first match will become second and so on).