### PR TITLE
Reduce cross project includes by rewriting `HashMapHasherDefault`.

### DIFF
--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -32,6 +32,7 @@
 
 #include "core/math/plane.h"
 #include "core/math/vector3.h"
+#include "core/templates/hashfuncs.h"
 
 /**
  * AABB (Axis Aligned Bounding Box)
@@ -129,6 +130,16 @@ struct [[nodiscard]] AABB {
 
 	_FORCE_INLINE_ Vector3 get_center() const {
 		return position + (size * 0.5f);
+	}
+
+	uint32_t hash() const {
+		uint32_t h = hash_murmur3_one_real(position.x);
+		h = hash_murmur3_one_real(position.y, h);
+		h = hash_murmur3_one_real(position.z, h);
+		h = hash_murmur3_one_real(size.x, h);
+		h = hash_murmur3_one_real(size.y, h);
+		h = hash_murmur3_one_real(size.z, h);
+		return hash_fmix32(h);
 	}
 
 	explicit operator String() const;

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/math/math_funcs.h"
+#include "core/templates/hashfuncs.h"
 
 class String;
 
@@ -238,6 +239,14 @@ struct [[nodiscard]] Color {
 	_FORCE_INLINE_ void set_ok_hsl_h(float p_h) { set_ok_hsl(p_h, get_ok_hsl_s(), get_ok_hsl_l(), a); }
 	_FORCE_INLINE_ void set_ok_hsl_s(float p_s) { set_ok_hsl(get_ok_hsl_h(), p_s, get_ok_hsl_l(), a); }
 	_FORCE_INLINE_ void set_ok_hsl_l(float p_l) { set_ok_hsl(get_ok_hsl_h(), get_ok_hsl_s(), p_l, a); }
+
+	uint32_t hash() const {
+		uint32_t h = hash_murmur3_one_float(r);
+		h = hash_murmur3_one_float(r, h);
+		h = hash_murmur3_one_float(b, h);
+		h = hash_murmur3_one_float(a, h);
+		return hash_fmix32(h);
+	}
 
 	constexpr Color() :
 			r(0), g(0), b(0), a(1) {}

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -33,6 +33,7 @@
 #include "core/math/aabb.h"
 #include "core/math/projection.h"
 #include "core/math/vector3.h"
+#include "core/math/vector3i.h"
 #include "core/templates/a_hash_map.h"
 #include "core/templates/list.h"
 #include "core/templates/local_vector.h"

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -30,8 +30,10 @@
 
 #pragma once
 
+#include "core/math/color.h"
 #include "core/math/delaunay_3d.h"
 #include "core/math/face3.h"
+#include "core/math/vector2.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/vector.h"
 

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -32,6 +32,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/vector2.h"
+#include "core/templates/hashfuncs.h"
 
 class String;
 struct Rect2i;
@@ -360,6 +361,14 @@ struct [[nodiscard]] Rect2 {
 
 	explicit operator String() const;
 	operator Rect2i() const;
+
+	uint32_t hash() const {
+		uint32_t h = hash_murmur3_one_real(position.x);
+		h = hash_murmur3_one_real(position.y, h);
+		h = hash_murmur3_one_real(size.x, h);
+		h = hash_murmur3_one_real(size.y, h);
+		return hash_fmix32(h);
+	}
 
 	Rect2() = default;
 	constexpr Rect2(real_t p_x, real_t p_y, real_t p_width, real_t p_height) :

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -32,6 +32,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/vector2i.h"
+#include "core/templates/hashfuncs.h"
 
 class String;
 struct Rect2;
@@ -225,6 +226,14 @@ struct [[nodiscard]] Rect2i {
 
 	explicit operator String() const;
 	operator Rect2() const;
+
+	uint32_t hash() const {
+		uint32_t h = hash_murmur3_one_32(uint32_t(position.x));
+		h = hash_murmur3_one_32(uint32_t(position.y), h);
+		h = hash_murmur3_one_32(uint32_t(size.x), h);
+		h = hash_murmur3_one_32(uint32_t(size.y), h);
+		return hash_fmix32(h);
+	}
 
 	Rect2i() = default;
 	constexpr Rect2i(int p_x, int p_y, int p_width, int p_height) :

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -32,6 +32,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
+#include "core/templates/hashfuncs.h"
 
 class String;
 struct Vector2i;
@@ -189,6 +190,12 @@ struct [[nodiscard]] Vector2 {
 
 	explicit operator String() const;
 	operator Vector2i() const;
+
+	uint32_t hash() const {
+		uint32_t h = hash_murmur3_one_real(x);
+		h = hash_murmur3_one_real(y, h);
+		return hash_fmix32(h);
+	}
 
 	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
 	constexpr Vector2() :

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -32,6 +32,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
+#include "core/templates/hashfuncs.h"
 
 class String;
 struct Vector2;
@@ -146,6 +147,12 @@ struct [[nodiscard]] Vector2i {
 
 	explicit operator String() const;
 	operator Vector2() const;
+
+	uint32_t hash() const {
+		uint32_t h = hash_murmur3_one_32(uint32_t(x));
+		h = hash_murmur3_one_32(uint32_t(y), h);
+		return hash_fmix32(h);
+	}
 
 	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
 	constexpr Vector2i() :

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -214,6 +214,13 @@ struct [[nodiscard]] Vector3 {
 	explicit operator String() const;
 	operator Vector3i() const;
 
+	uint32_t hash() const {
+		uint32_t h = hash_murmur3_one_real(x);
+		h = hash_murmur3_one_real(y, h);
+		h = hash_murmur3_one_real(z, h);
+		return hash_fmix32(h);
+	}
+
 	constexpr Vector3() :
 			x(0), y(0), z(0) {}
 	constexpr Vector3(real_t p_x, real_t p_y, real_t p_z) :

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -32,6 +32,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
+#include "core/templates/hashfuncs.h"
 
 class String;
 struct Vector3;
@@ -139,6 +140,13 @@ struct [[nodiscard]] Vector3i {
 
 	explicit operator String() const;
 	operator Vector3() const;
+
+	uint32_t hash() const {
+		uint32_t h = hash_murmur3_one_32(uint32_t(x));
+		h = hash_murmur3_one_32(uint32_t(y), h);
+		h = hash_murmur3_one_32(uint32_t(z), h);
+		return hash_fmix32(h);
+	}
 
 	constexpr Vector3i() :
 			x(0), y(0), z(0) {}

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -32,6 +32,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/math_defs.h"
+#include "core/templates/hashfuncs.h"
 #include "core/typedefs.h"
 
 class String;
@@ -145,6 +146,14 @@ struct [[nodiscard]] Vector4 {
 
 	explicit operator String() const;
 	operator Vector4i() const;
+
+	uint32_t hash() const {
+		uint32_t h = hash_murmur3_one_real(x);
+		h = hash_murmur3_one_real(y, h);
+		h = hash_murmur3_one_real(z, h);
+		h = hash_murmur3_one_real(w, h);
+		return hash_fmix32(h);
+	}
 
 	constexpr Vector4() :
 			x(0), y(0), z(0), w(0) {}

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -32,6 +32,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
+#include "core/templates/hashfuncs.h"
 
 class String;
 struct Vector4;
@@ -134,6 +135,14 @@ struct [[nodiscard]] Vector4i {
 
 	explicit operator String() const;
 	operator Vector4() const;
+
+	uint32_t hash() const {
+		uint32_t h = hash_murmur3_one_32(uint32_t(x));
+		h = hash_murmur3_one_32(uint32_t(y), h);
+		h = hash_murmur3_one_32(uint32_t(z), h);
+		h = hash_murmur3_one_32(uint32_t(w), h);
+		return hash_fmix32(h);
+	}
 
 	constexpr Vector4i() :
 			x(0), y(0), z(0), w(0) {}

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -641,7 +641,7 @@ private:
 		};
 
 		MethodInfo user;
-		HashMap<Callable, Slot, HashableHasher<Callable>> slot_map;
+		HashMap<Callable, Slot> slot_map;
 		bool removable = false;
 	};
 	friend struct _ObjectSignalLock;

--- a/core/object/object_id.h
+++ b/core/object/object_id.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/hashfuncs.h"
 #include "core/typedefs.h"
 
 // Class to store an object ID (int64)
@@ -53,6 +54,8 @@ public:
 
 	_ALWAYS_INLINE_ void operator=(int64_t p_int64) { id = p_int64; }
 	_ALWAYS_INLINE_ void operator=(uint64_t p_uint64) { id = p_uint64; }
+
+	uint32_t hash() const { return HashMapHasherDefault::hash(id); }
 
 	_ALWAYS_INLINE_ ObjectID() {}
 	_ALWAYS_INLINE_ explicit ObjectID(const uint64_t p_id) { id = p_id; }

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -216,6 +216,8 @@ public:
 		ref(memnew(T(p_params...)));
 	}
 
+	uint32_t hash() const { return HashMapHasherDefault::hash(reference); }
+
 	Ref() = default;
 
 	~Ref() {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -34,6 +34,7 @@
 
 #include "core/string/char_utils.h" // IWYU pragma: export
 #include "core/templates/cowdata.h"
+#include "core/templates/hashfuncs.h"
 #include "core/templates/vector.h"
 #include "core/typedefs.h"
 #include "core/variant/array.h"
@@ -231,6 +232,8 @@ public:
 
 		return *this;
 	}
+
+	uint32_t hash() const { return hash_djb2(get_data()); }
 
 protected:
 	void copy_from(const T *p_cstr) {

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -30,7 +30,11 @@
 
 #pragma once
 
+#include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
+
+class StringName;
+class Variant;
 
 /**
  * An array-based implementation of a hash map. It is very efficient in terms of performance and

--- a/core/templates/rid.h
+++ b/core/templates/rid.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/hashfuncs.h"
 #include "core/typedefs.h"
 
 class RID_AllocBase;
@@ -68,6 +69,8 @@ public:
 		return _rid;
 	}
 	_ALWAYS_INLINE_ uint64_t get_id() const { return _id; }
+
+	uint32_t hash() const { return HashMapHasherDefault::hash(_id); }
 
 	_ALWAYS_INLINE_ RID() {}
 };

--- a/drivers/metal/inflection_map.h
+++ b/drivers/metal/inflection_map.h
@@ -33,6 +33,8 @@
 #include "core/templates/hash_map.h"
 #include "core/templates/local_vector.h"
 
+#include <iterator>
+
 /// An unordered map that splits elements between a fast-access vector of LinearCount consecutively
 /// indexed elements, and a slower-access map holding sparse indexes larger than LinearCount.
 ///

--- a/drivers/metal/metal_objects.h
+++ b/drivers/metal/metal_objects.h
@@ -196,7 +196,7 @@ public:
 
 class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDResourceCache {
 private:
-	typedef HashMap<ClearAttKey, id<MTLRenderPipelineState>, HashableHasher<ClearAttKey>> HashMap;
+	typedef HashMap<ClearAttKey, id<MTLRenderPipelineState>> HashMap;
 	std::unique_ptr<MDResourceFactory> resource_factory;
 	HashMap clear_states;
 

--- a/drivers/metal/pixel_formats.h
+++ b/drivers/metal/pixel_formats.h
@@ -60,6 +60,7 @@ GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations")
 #include "servers/rendering/rendering_device.h"
 
 #import <Metal/Metal.h>
+#include <iterator>
 
 #pragma mark -
 #pragma mark Metal format capabilities

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -90,7 +90,7 @@ class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) RenderingDeviceDriverMet
 	 * To prevent unbounded growth of the cache, cache entries are automatically freed when
 	 * there are no more references to the MDLibrary associated with the cache entry.
 	 */
-	HashMap<SHA256Digest, ShaderCacheEntry *, HashableHasher<SHA256Digest>> _shader_cache;
+	HashMap<SHA256Digest, ShaderCacheEntry *> _shader_cache;
 	void shader_cache_free_entry(const SHA256Digest &key);
 
 public:

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -70,6 +70,8 @@ class GridMap : public Node3D {
 			return Vector3i(x, y, z);
 		}
 
+		uint32_t hash() const { return operator Vector3i().hash(); }
+
 		IndexKey(Vector3i p_vector) {
 			x = (int16_t)p_vector.x;
 			y = (int16_t)p_vector.y;

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -109,22 +109,22 @@ Error ImageLoaderSVG::create_image_from_utf8_buffer(Ref<Image> p_image, const ui
 
 	tvg::Result res = sw_canvas->target((uint32_t *)buffer.ptrw(), width, width, height, tvg::SwCanvas::ABGR8888S);
 	if (res != tvg::Result::Success) {
-		ERR_FAIL_V_MSG(FAILED, "ImageLoaderSVG: Couldn't set target on ThorVG canvas.");
+		ERR_FAIL_V_MSG(FAILED, vformat("ImageLoaderSVG: Couldn't set target on ThorVG canvas, error code %d.", res));
 	}
 
 	res = sw_canvas->push(std::move(picture));
 	if (res != tvg::Result::Success) {
-		ERR_FAIL_V_MSG(FAILED, "ImageLoaderSVG: Couldn't insert ThorVG picture on canvas.");
+		ERR_FAIL_V_MSG(FAILED, vformat("ImageLoaderSVG: Couldn't insert ThorVG picture on canvas, error code %d.", res));
 	}
 
 	res = sw_canvas->draw();
 	if (res != tvg::Result::Success) {
-		ERR_FAIL_V_MSG(FAILED, "ImageLoaderSVG: Couldn't draw ThorVG pictures on canvas.");
+		ERR_FAIL_V_MSG(FAILED, vformat("ImageLoaderSVG: Couldn't draw ThorVG pictures on canvas, error code %d.", res));
 	}
 
 	res = sw_canvas->sync();
 	if (res != tvg::Result::Success) {
-		ERR_FAIL_V_MSG(FAILED, "ImageLoaderSVG: Couldn't sync ThorVG canvas.");
+		ERR_FAIL_V_MSG(FAILED, vformat("ImageLoaderSVG: Couldn't sync ThorVG canvas, error code %d.", res));
 	}
 
 	p_image->set_data(width, height, false, Image::FORMAT_RGBA8, buffer);

--- a/modules/text_server_adv/thorvg_svg_in_ot.h
+++ b/modules/text_server_adv/thorvg_svg_in_ot.h
@@ -43,6 +43,7 @@ using namespace godot;
 // Headers for building as built-in module.
 
 #include "core/os/mutex.h"
+#include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
 #include "core/typedefs.h"
 

--- a/modules/text_server_fb/thorvg_svg_in_ot.h
+++ b/modules/text_server_fb/thorvg_svg_in_ot.h
@@ -43,6 +43,7 @@ using namespace godot;
 // Headers for building as built-in module.
 
 #include "core/os/mutex.h"
+#include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
 #include "core/typedefs.h"
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -153,8 +153,9 @@ private:
 			uint64_t port : 32;
 		};
 		uint64_t key = 0;
-		// This is used to apply default equal and hash methods for uint64_t to ConnectionKey.
-		operator uint64_t() const { return key; }
+
+		uint32_t hash() const { return HashMapHasherDefault::hash(key); }
+		bool is_same(const ConnectionKey &p_key) const { return HashMapComparatorDefault<uint64_t>::compare(key, p_key.key); }
 	};
 
 	Error _write_node(Type p_type, StringBuilder *p_global_code, StringBuilder *p_global_code_per_node, HashMap<Type, StringBuilder> *p_global_code_per_func, StringBuilder &r_code, Vector<DefaultTextureParam> &r_def_tex_params, const HashMap<ConnectionKey, const List<Connection>::Element *> &p_input_connections, int p_node, HashSet<int> &r_processed, bool p_for_preview, HashSet<StringName> &r_classes) const;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -487,7 +487,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 	static void _uniform_set_invalidation_callback(void *p_userdata);
 	static void _canvas_texture_invalidation_callback(bool p_deleted, void *p_userdata);
 
-	typedef LRUCache<RIDSetKey, RID, HashableHasher<RIDSetKey>, HashMapComparatorDefault<RIDSetKey>, _before_evict> RIDCache;
+	typedef LRUCache<RIDSetKey, RID, HashMapHasherDefault, HashMapComparatorDefault<RIDSetKey>, _before_evict> RIDCache;
 	RIDCache rid_set_to_uniform_set;
 	/// Maps a CanvasTexture to its associated uniform sets, which must
 	/// be invalidated when the CanvasTexture is updated, such as changing the
@@ -526,7 +526,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		uint32_t flags = 0;
 	};
 
-	HashMap<TextureState, TextureInfo, HashableHasher<TextureState>, HashMapComparatorDefault<TextureState>, PagedAllocator<HashMapElement<TextureState, TextureInfo>>> texture_info_map;
+	HashMap<TextureState, TextureInfo, HashMapHasherDefault, HashMapComparatorDefault<TextureState>, PagedAllocator<HashMapElement<TextureState, TextureInfo>>> texture_info_map;
 
 	// per-frame buffers
 	struct DataBuffer {


### PR DESCRIPTION
- Helps address https://github.com/godotengine/godot/issues/111218

Godot is plagued by long compile times because of unnecessary cross project includes.
Two of the main culprits in Core are `hashfuncs.h` and `variant.h`.
This PR eliminates cross project includes from `hashfuncs.h`, to improve compile time and reduce type coupling.

### Explanation

`HashMapHasherDefault` was previously written by implementing a `static uint32_t hash(const T &)` function for every known `Variant` type. As `Variant` types grew, so did the includes for `hashfuncs.h`.

I rewrote the struct by adding a type trait called `HashMapHasherDefaultImpl<T>`. This type trait can be declared for any type, providing a hash function for default hashing, analogous to `HashMapComparatorDefault`.

The type trait is specialized for primitives (like `double` and `int32_t`).
It is further specialized for `enum` types by using the underlying type, which was also the previous behavior (through implicit conversion). 

It is also specialized for types that declare `uint32_t hash() const;`, by calling this function. This behavior was previously implemented with `HashableHasher`, whose implementation claimed it is only possible to generalize this with c++20 concepts. I removed the now unnecessary `HashableHasher` type.
Using this specialization, hash functions are moved to the appropriate types. By this move, the includes from `hashfuncs.h` could be removed.

The same trick was applied to `HashMapDefaultComparator`, which previously had unnecessary specializations that all called `is_same`. I generalized this assumption with type trait logic (SFINAE).

### Side effects

- `Color` was previously hashed by converting to `String` and hashing the string (through implicit conversion). This was slow. I optimized the conversion to hash with the components instead.
- `hash_map` previously needed a `Variant` include because it declared a function that assumed `Variant` keys. I generalized the function to use a comparator, and moved the variant comparison method to `dictionary.cpp` (the only place where it was used). This allowed me to delete `hash_map.cpp`.
- It is no longer possible to "auto-declare" hashing functions by declaring an implicit conversion operator. This is sane, especially since we have many lossy and slow implicit conversion operators in the codebase (as seen on `Color`). Two types now need to define an explicit hashing function that did not need to declare it before.
-  It is now possible to hash `enum struct`, which was not possible before. Previously, the enum needed to be implicitly convertible to its underlying type, to support being hashed by `HashMapHasherDefault`.
- I had a problem with `ImageLoaderSVG` remotely, to debug it I inserted the error code to the error message. It seems to have mysteriously disappeared, but I'd argue having the error code for the future is good anyway.
