### PR TITLE
Android: Re-add `generate_apk` alias for compatibility

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -35,7 +35,7 @@ def get_opts():
         ),
         BoolVariable("store_release", "Editor build for Google Play Store (for official builds only)", False),
         BoolVariable(
-            "generate_android_binaries",
+            ("generate_android_binaries", "generate_apk"),
             "Generate APK, AAB & AAR binaries after building Android library by calling Gradle",
             False,
         ),


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot/pull/105605#issuecomment-2883348660.

This is a SCons feature that many aren't familiar with, hence why it's not systematically used. But for this kind of renames it's worth keeping an alias and doesn't have a significant maintenance overhead.

```
$ scons p=android --help
...
generate_android_binaries: Generate APK, AAB & AAR binaries after building Android library by calling Gradle (yes|no)
    default: False
    actual: False
    aliases: ['generate_apk']
```