### PR TITLE
Make it possible to run CI manually if `DISABLE_GODOT_CI` is set.

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -9,7 +9,7 @@ jobs:
   # First stage: Only static checks, fast and prevent expensive builds from running.
 
   static-checks:
-    if: "!vars.DISABLE_GODOT_CI"
+    if: ${{ !vars.DISABLE_GODOT_CI || github.run_attempt > 1 }}
     name: 📊 Static checks
     uses: ./.github/workflows/static_checks.yml
 


### PR DESCRIPTION
There is currently an undocumented feature to disable CI entirely, by setting `DISABLE_GODOT_CI` to `1` in the environment variables.

However, it is impossible right now to manually trigger CI when it is disabled, because if the `Re-run all jobs` button is clicked, it will just skip the CI again.

This PR rectifies this, by ignoring `DISABLE_GODOT_CI` on the second run attempt:

![SCR-20250515-mjlh](https://github.com/user-attachments/assets/6b434ff0-cc55-4de2-b3ad-013bba4b8db5)

## Relations
It was proposed in https://github.com/godotengine/godot/pull/75336 to add a manual `workflow_dispatch` trigger. 
However, this trigger would not work for this use case, because if `DISABLE_GODOT_CI` is set, the workflow would be skipped even on manual dispatch.
It would be possible to allow CI to ignore `DISABLE_GODOT_CI` on `workflow_dispatch` events, but as @YuriSizov described in https://github.com/godotengine/godot/pull/75336, there is no reason to add this dispatch if we already have the `Re-run all jobs` button.