### PR TITLE
Add exclude prefix to POT generator

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1680,6 +1680,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translations", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translations_pot_files", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translation_add_builtin_strings_to_pot", false);
+	GLOBAL_DEF_INTERNAL("internationalization/locale/translation_exclude_prefix", "$$");
 
 #if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
 	GLOBAL_DEF("navigation/world/map_use_async_iterations", true);

--- a/editor/localization_editor.h
+++ b/editor/localization_editor.h
@@ -30,12 +30,16 @@
 
 #pragma once
 
-#include "editor/editor_locale_dialog.h"
-#include "scene/gui/check_box.h"
-#include "scene/gui/tree.h"
+#include "scene/gui/box_container.h"
 
+class Button;
+class CheckBox;
 class EditorFileDialog;
+class EditorLocaleDialog;
 class FileSystemDock;
+class LineEdit;
+class Timer;
+class Tree;
 
 class LocalizationEditor : public VBoxContainer {
 	GDCLASS(LocalizationEditor, VBoxContainer);
@@ -53,6 +57,8 @@ class LocalizationEditor : public VBoxContainer {
 
 	Tree *translation_pot_list = nullptr;
 	CheckBox *translation_pot_add_builtin = nullptr;
+	LineEdit *translation_pot_exclude_prefix = nullptr;
+	Timer *translation_pot_exclude_prefix_debounce = nullptr;
 	EditorFileDialog *pot_file_open_dialog = nullptr;
 	EditorFileDialog *pot_generate_dialog = nullptr;
 	Button *pot_generate_button = nullptr;
@@ -80,6 +86,7 @@ class LocalizationEditor : public VBoxContainer {
 	void _pot_file_open();
 	void _pot_generate_open();
 	void _pot_add_builtin_toggled();
+	void _pot_prefix_changed();
 	void _pot_generate(const String &p_file);
 	void _update_pot_file_extensions();
 

--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -56,6 +56,7 @@ void POTGenerator::_print_all_translation_strings() {
 
 void POTGenerator::generate_pot(const String &p_file) {
 	Vector<String> files = GLOBAL_GET("internationalization/locale/translations_pot_files");
+	const String exclude_prefix = GLOBAL_GET("internationalization/locale/translation_exclude_prefix");
 
 	if (files.is_empty()) {
 		WARN_PRINT("No files selected for POT generation.");
@@ -81,6 +82,10 @@ void POTGenerator::generate_pot(const String &p_file) {
 
 		for (const Vector<String> &translation : translations) {
 			ERR_CONTINUE(translation.is_empty());
+			if (!exclude_prefix.is_empty() && translation[0].begins_with(exclude_prefix)) {
+				continue;
+			}
+
 			const String &msgctxt = (translation.size() > 1) ? translation[1] : String();
 			const String &msgid_plural = (translation.size() > 2) ? translation[2] : String();
 			const String &comment = (translation.size() > 3) ? translation[3] : String();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11841

![image](https://github.com/user-attachments/assets/9b410dca-5a28-4e83-a6dc-5ffc5bdbf7c1)
![image](https://github.com/user-attachments/assets/0a2068bf-f815-4d9c-89c7-da52135f6e66)
```
#: Trash/POTest.tscn
msgid "Text1"
msgstr ""

#: Trash/POTest.tscn
msgid "Text3"
msgstr ""
```