### PR TITLE
Add `set_action_disabled()` and `is_action_disabled()` methods

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -157,6 +157,8 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("warp_mouse", "position"), &Input::warp_mouse);
 	ClassDB::bind_method(D_METHOD("action_press", "action", "strength"), &Input::action_press, DEFVAL(1.f));
 	ClassDB::bind_method(D_METHOD("action_release", "action"), &Input::action_release);
+	ClassDB::bind_method(D_METHOD("set_action_disabled", "action", "disable"), &Input::set_action_disabled);
+	ClassDB::bind_method(D_METHOD("is_action_disabled", "action"), &Input::is_action_disabled);
 	ClassDB::bind_method(D_METHOD("set_default_cursor_shape", "shape"), &Input::set_default_cursor_shape, DEFVAL(CURSOR_ARROW));
 	ClassDB::bind_method(D_METHOD("get_current_cursor_shape"), &Input::get_current_cursor_shape);
 	ClassDB::bind_method(D_METHOD("set_custom_mouse_cursor", "image", "shape", "hotspot"), &Input::set_custom_mouse_cursor, DEFVAL(CURSOR_ARROW), DEFVAL(Vector2()));
@@ -1046,6 +1048,26 @@ void Input::action_release(const StringName &p_action) {
 	action_state.api_strength = 0.0;
 }
 
+void Input::set_action_disabled(const StringName &p_action, bool p_disable) {
+	ERR_FAIL_COND_MSG(!InputMap::get_singleton()->has_action(p_action), InputMap::get_singleton()->suggest_actions(p_action));
+
+	// Create or retrieve existing action.
+	ActionState &action_state = action_states[p_action];
+	action_state.disabled = p_disable;
+	_update_action_cache(p_action, action_state);
+}
+
+bool Input::is_action_disabled(const StringName &p_action) {
+	ERR_FAIL_COND_V_MSG(!InputMap::get_singleton()->has_action(p_action), false, InputMap::get_singleton()->suggest_actions(p_action));
+
+	HashMap<StringName, ActionState>::ConstIterator E = action_states.find(p_action);
+	if (!E) {
+		return false;
+	}
+
+	return E->value.disabled;
+}
+
 void Input::set_emulate_touch_from_mouse(bool p_emulate) {
 	emulate_touch_from_mouse = p_emulate;
 }
@@ -1383,13 +1405,15 @@ void Input::_update_action_cache(const StringName &p_action_name, ActionState &r
 	r_action_state.cache.strength = 0.0;
 	r_action_state.cache.raw_strength = 0.0;
 
-	int max_event = InputMap::get_singleton()->action_get_events(p_action_name)->size() + 1; // +1 comes from InputEventAction.
-	for (const KeyValue<int, ActionState::DeviceState> &kv : r_action_state.device_states) {
-		const ActionState::DeviceState &device_state = kv.value;
-		for (int i = 0; i < max_event; i++) {
-			r_action_state.cache.pressed = r_action_state.cache.pressed || device_state.pressed[i];
-			r_action_state.cache.strength = MAX(r_action_state.cache.strength, device_state.strength[i]);
-			r_action_state.cache.raw_strength = MAX(r_action_state.cache.raw_strength, device_state.raw_strength[i]);
+	if (!r_action_state.disabled) {
+		int max_event = InputMap::get_singleton()->action_get_events(p_action_name)->size() + 1; // +1 comes from InputEventAction.
+		for (const KeyValue<int, ActionState::DeviceState> &kv : r_action_state.device_states) {
+			const ActionState::DeviceState &device_state = kv.value;
+			for (int i = 0; i < max_event; i++) {
+				r_action_state.cache.pressed = r_action_state.cache.pressed || device_state.pressed[i];
+				r_action_state.cache.strength = MAX(r_action_state.cache.strength, device_state.strength[i]);
+				r_action_state.cache.raw_strength = MAX(r_action_state.cache.raw_strength, device_state.raw_strength[i]);
+			}
 		}
 	}
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -110,6 +110,7 @@ private:
 		uint64_t released_physics_frame = UINT64_MAX;
 		uint64_t released_process_frame = UINT64_MAX;
 		bool exact = true;
+		bool disabled = false;
 
 		struct DeviceState {
 			bool pressed[MAX_EVENT] = { false };
@@ -349,6 +350,8 @@ public:
 
 	void action_press(const StringName &p_action, float p_strength = 1.f);
 	void action_release(const StringName &p_action);
+	void set_action_disabled(const StringName &p_action, bool p_disable);
+	bool is_action_disabled(const StringName &p_action);
 
 	void set_emulate_touch_from_mouse(bool p_emulate);
 	bool is_emulating_touch_from_mouse() const;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -202,6 +202,13 @@
 				By default, the deadzone is automatically calculated from the average of the action deadzones. However, you can override the deadzone to be whatever you want (on the range of 0 to 1).
 			</description>
 		</method>
+		<method name="is_action_disabled">
+			<return type="bool" />
+			<param index="0" name="action" type="StringName" />
+			<description>
+				Returns [code]true[/code] when the user has disabled the action by calling [method set_action_disabled].
+			</description>
+		</method>
 		<method name="is_action_just_pressed" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="action" type="StringName" />
@@ -325,6 +332,16 @@
 			<description>
 				Sets the acceleration value of the accelerometer sensor. Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
 				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
+			</description>
+		</method>
+		<method name="set_action_disabled">
+			<return type="void" />
+			<param index="0" name="action" type="StringName" />
+			<param index="1" name="disable" type="bool" />
+			<description>
+				If [param disable] is [code]true[/code], the provided action will not be affected by user input.
+				[b]Note:[/b] This method does not affect simulated input via [method action_press] or [method action_release].
+				[b]Note:[/b] This method does not prevent calls to [method Node._input].
 			</description>
 		</method>
 		<method name="set_custom_mouse_cursor">


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/7176
Also Closes https://github.com/godotengine/godot-proposals/issues/6429

This adds `set_action_disabled()` and `is_action_disabled()` methods.
Setting the action to disabled ignores user input while still allowing overriding via simulated input. This also doesn't prevent `InputEvent`s generated for `_input()`. They can be filtered by checking

```gdscript
func _input(event: InputEvent) -> void:
    if event.is_action("MyAction") && !Input.is_action_disabled("MyAction"):
        # logic
```

I'm not very familiar with the input inner-workings, so this may be a naive approach, but I've been trying it out and haven't seen any issues. If someone more familiar could let me know if I'm missing something major, I'd appreciate it.