### PR TITLE
Fixes gdscript static variable does not contain `static` qualifier

### DIFF
--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -377,6 +377,7 @@ public:
 		String name;
 		String type;
 		String enumeration;
+		String qualifiers;
 		bool is_bitfield = false;
 		String description;
 		String setter, getter;
@@ -407,6 +408,10 @@ public:
 				if (p_dict.has("is_bitfield")) {
 					doc.is_bitfield = p_dict["is_bitfield"];
 				}
+			}
+
+			if (p_dict.has("qualifiers")) {
+				doc.qualifiers = p_dict["qualifiers"];
 			}
 
 			if (p_dict.has("description")) {
@@ -473,6 +478,10 @@ public:
 			if (!p_doc.enumeration.is_empty()) {
 				dict["enumeration"] = p_doc.enumeration;
 				dict["is_bitfield"] = p_doc.is_bitfield;
+			}
+
+			if (!p_doc.qualifiers.is_empty()) {
+				dict["qualifiers"] = p_doc.qualifiers;
 			}
 
 			if (!p_doc.description.is_empty()) {

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -151,7 +151,7 @@ static void _add_qualifiers_to_rt(const String &p_qualifiers, RichTextLabel *p_r
 		} else if (qualifier == "const") {
 			hint = TTR("This method has no side effects.\nIt does not modify the object in any way.");
 		} else if (qualifier == "static") {
-			hint = TTR("This method does not need an instance to be called.\nIt can be called directly using the class name.");
+			hint = TTR("This member does not need an instance to be accessed or called.\nIt can be accessed or called directly using the class name.");
 		}
 
 		p_rt->add_text(" ");
@@ -532,6 +532,14 @@ void EditorHelp::_add_type_icon(const String &p_type, int p_size, const String &
 	} else {                                                                                    \
 		_add_text(m_message);                                                                   \
 	}
+
+void EditorHelp::_add_property_qualifiers(const DocData::PropertyDoc &p_prop) {
+	if (!p_prop.qualifiers.is_empty()) {
+		class_desc->push_color(theme_cache.qualifier_color);
+		_add_qualifiers_to_rt(p_prop.qualifiers, class_desc);
+		class_desc->pop(); // color
+	}
+}
 
 void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview, bool p_override) {
 	if (p_override) {
@@ -1284,7 +1292,7 @@ void EditorHelp::_update_doc() {
 
 			class_desc->pop(); // cell
 
-			// Property setter/getter and deprecated/experimental marks.
+			// Property setter/getter, qualifiers and deprecated/experimental marks.
 			class_desc->push_cell();
 
 			bool has_prev_text = false;
@@ -1316,6 +1324,8 @@ void EditorHelp::_update_doc() {
 				class_desc->add_text("]");
 				class_desc->pop(); // color
 			}
+
+			_add_property_qualifiers(prop);
 
 			if (prop.is_deprecated) {
 				if (has_prev_text) {
@@ -2226,6 +2236,9 @@ void EditorHelp::_update_doc() {
 			}
 
 			class_desc->pop(); // table
+
+			// Property qualifiers
+			_add_property_qualifiers(prop);
 
 			class_desc->add_newline();
 			class_desc->add_newline();

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -159,6 +159,7 @@ class EditorHelp : public VBoxContainer {
 	//void _button_pressed(int p_idx);
 	void _add_type(const String &p_type, const String &p_enum = String(), bool p_is_bitfield = false);
 	void _add_type_icon(const String &p_type, int p_size = 0, const String &p_fallback = "");
+	void _add_property_qualifiers(const DocData::PropertyDoc &p_prop);
 	void _add_method(const DocData::MethodDoc &p_method, bool p_overview, bool p_override = true);
 
 	void _add_bulletpoint();

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -471,6 +471,7 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 				prop_doc.deprecated_message = m_var->doc_data.deprecated_message;
 				prop_doc.is_experimental = m_var->doc_data.is_experimental;
 				prop_doc.experimental_message = m_var->doc_data.experimental_message;
+				prop_doc.qualifiers = m_var->is_static ? "static" : "";
 				_doctype_from_gdtype(m_var->get_datatype(), prop_doc.type, prop_doc.enumeration);
 
 				switch (m_var->property) {


### PR DESCRIPTION
Sorry but for no reason I cannot explore `Issue` tab as normal as you can, so I'm not sure if there is any issue that related to the topic of this pr

This PR addresses the issue of missing `static` qualifier after a GDScript static variable. Meanwhile, the qualifier hint of `static` is fixed to synchronize and match the modification.

## Known issues and to be fixed

- [ ] A `static` qualifier in Property Description does not show its hint when the mouse is hovering on it, and each letter in the qualifier `static` is too close to each other.
