### PR TITLE
Fix redundant signal connection in `TextureRegionEditor`

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -818,11 +818,11 @@ void TextureRegionEditor::_update_autoslice() {
 void TextureRegionEditor::_notification(int p_what) {
 	switch (p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			if (!EditorSettings::get_singleton()->check_changed_settings_in_group("editors/panning")) {
-				break;
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/panning")) {
+				panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
+				panner->setup_warped_panning(get_viewport(), EDITOR_GET("editors/panning/warped_mouse_panning"));
 			}
-			[[fallthrough]];
-		}
+		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
 			get_tree()->connect("node_removed", callable_mp(this, &TextureRegionEditor::_node_removed));


### PR DESCRIPTION
Fixes #106387.

Regression from #100444 which moved the `panner` setup from `NOTIFICATION_READY` to `NOTIFICATION_ENTER_TREE`, removing `NOTIFICATION_READY` case to which `NOTIFICATION_EDITOR_SETTINGS_CHANGED` was falling through previously. Afterwards it was falling through to `NOTIFICATION_ENTER_TREE` containing unrelated code like connecting to `node_removed` signal.