### PR TITLE
Fix potential crash when checking unsaved history

### DIFF
--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -377,16 +377,20 @@ void EditorUndoRedoManager::set_history_as_saved(int p_id) {
 
 void EditorUndoRedoManager::set_history_as_unsaved(int p_id) {
 	History &history = get_or_create_history(p_id);
-	history.saved_version = -1;
+	history.saved_version = 0;
 }
 
 bool EditorUndoRedoManager::is_history_unsaved(int p_id) {
 	History &history = get_or_create_history(p_id);
+	if (history.saved_version == 0) {
+		return true;
+	}
 
 	int version_difference = history.undo_redo->get_version() - history.saved_version;
 	if (version_difference > 0) {
 		List<Action>::Element *E = history.undo_stack.back();
 		for (int i = 0; i < version_difference; i++) {
+			ERR_FAIL_NULL_V_MSG(E, false, "Inconsistent undo history.");
 			if (E->get().mark_unsaved) {
 				return true;
 			}
@@ -395,6 +399,7 @@ bool EditorUndoRedoManager::is_history_unsaved(int p_id) {
 	} else if (version_difference < 0) {
 		List<Action>::Element *E = history.redo_stack.back();
 		for (int i = 0; i > version_difference; i--) {
+			ERR_FAIL_NULL_V_MSG(E, false, "Inconsistent redo history.");
 			if (E->get().mark_unsaved) {
 				return true;
 			}


### PR DESCRIPTION
#106121 added a code that iterates a list based on external index. It's looks super unsafe, but nothing should go wrong if the undo stack is consistent with version, no?

Well :D
```
CrashHandlerException: Program crashed
Engine version: Godot Engine v4.5.dev.custom_build (428a762e9866afc41e9ba7fa334751142a81b432)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[0] EditorUndoRedoManager::is_history_unsaved (C:\godot_source\editor\editor_undo_redo_manager.cpp:398)
[1] EditorUndoRedoManager::is_history_unsaved (C:\godot_source\editor\editor_undo_redo_manager.cpp:398)
[2] EditorNode::_update_unsaved_cache (C:\godot_source\editor\editor_node.cpp:358)
[3] call_with_variant_args_helper<EditorNode> (C:\godot_source\core\variant\binder_common.h:228)
[4] call_with_variant_args<EditorNode> (C:\godot_source\core\variant\binder_common.h:338)
[5] CallableCustomMethodPointer<EditorNode,void>::call (C:\godot_source\core\object\callable_method_pointer.h:107)
[6] Callable::callp (C:\godot_source\core\variant\callable.cpp:58)
[7] Object::emit_signalp (C:\godot_source\core\object\object.cpp:1288)
[8] Object::emit_signal<> (C:\godot_source\core\object\object.h:930)
[9] EditorUndoRedoManager::commit_action (C:\godot_source\editor\editor_undo_redo_manager.cpp:287)
[10] ThemeTypeEditor::_theme_type_rename_dialog_confirmed (C:\godot_source\editor\plugins\theme_editor_plugin.cpp:2909)
[11] call_with_variant_args_helper<ThemeTypeEditor> (C:\godot_source\core\variant\binder_common.h:228)
[12] call_with_variant_args<ThemeTypeEditor> (C:\godot_source\core\variant\binder_common.h:338)
[13] CallableCustomMethodPointer<ThemeTypeEditor,void>::call (C:\godot_source\core\object\callable_method_pointer.h:107)
[14] Callable::callp (C:\godot_source\core\variant\callable.cpp:58)
[15] Object::emit_signalp (C:\godot_source\core\object\object.cpp:1288)
[16] Node::emit_signalp (C:\godot_source\scene\main\node.cpp:4292)
[17] Object::emit_signal<> (C:\godot_source\core\object\object.h:930)
[18] AcceptDialog::_ok_pressed (C:\godot_source\scene\gui\dialogs.cpp:141)
[19] AcceptDialog::_text_submitted (C:\godot_source\scene\gui\dialogs.cpp:127)
[20] call_with_variant_args_helper<AcceptDialog,String const &,0> (C:\godot_source\core\variant\binder_common.h:223)
[21] call_with_variant_args<AcceptDialog,String const &> (C:\godot_source\core\variant\binder_common.h:338)
[22] CallableCustomMethodPointer<AcceptDialog,void,String const &>::call (C:\godot_source\core\object\callable_method_pointer.h:107)
[23] Callable::callp (C:\godot_source\core\variant\callable.cpp:58)
[24] Object::emit_signalp (C:\godot_source\core\object\object.cpp:1288)
[25] Node::emit_signalp (C:\godot_source\scene\main\node.cpp:4292)
[26] Object::emit_signal<String> (C:\godot_source\core\object\object.h:930)
[27] LineEdit::gui_input (C:\godot_source\scene\gui\line_edit.cpp:876)
[28] Control::_call_gui_input (C:\godot_source\scene\gui\control.cpp:1871)
[29] Viewport::_gui_input_event (C:\godot_source\scene\main\viewport.cpp:2274)
[30] Viewport::push_input (C:\godot_source\scene\main\viewport.cpp:3427)
[31] Window::_window_input (C:\godot_source\scene\main\window.cpp:1839)
[32] call_with_variant_args_helper<Window,Ref<InputEvent> const &,0> (C:\godot_source\core\variant\binder_common.h:223)
[33] call_with_variant_args<Window,Ref<InputEvent> const &> (C:\godot_source\core\variant\binder_common.h:338)
[34] CallableCustomMethodPointer<Window,void,Ref<InputEvent> const &>::call (C:\godot_source\core\object\callable_method_pointer.h:107)
[35] Callable::callp (C:\godot_source\core\variant\callable.cpp:58)
[36] Callable::call<Ref<InputEvent> > (C:\godot_source\core\variant\variant.h:951)
[37] DisplayServerWindows::_dispatch_input_event (C:\godot_source\platform\windows\display_server_windows.cpp:4414)
[38] DisplayServerWindows::_dispatch_input_events (C:\godot_source\platform\windows\display_server_windows.cpp:4385)
[39] Input::_parse_input_event_impl (C:\godot_source\core\input\input.cpp:903)
[40] Input::flush_buffered_events (C:\godot_source\core\input\input.cpp:1184)
[41] DisplayServerWindows::process_events (C:\godot_source\platform\windows\display_server_windows.cpp:3798)
[42] OS_Windows::run (C:\godot_source\platform\windows\os_windows.cpp:2272)
[43] widechar_main (C:\godot_source\platform\windows\godot_windows.cpp:97)
[44] _main (C:\godot_source\platform\windows\godot_windows.cpp:122)
[45] main (C:\godot_source\platform\windows\godot_windows.cpp:136)
[46] WinMain (C:\godot_source\platform\windows\godot_windows.cpp:150)
[47] __scrt_common_main_seh (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[48] <couldn't map PC to fn name>
-- END OF C++ BACKTRACE --
```
I don't know how to reproduce it yet (I tried repeating the same thing I did with no result), so I though for now there should be a safeguard at least.

Fixes #106459