### PR TITLE
Style: Remove redundant `DEBUG_METHODS_ENABLED` macro

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -232,18 +232,18 @@ void ProjectSettings::set_as_internal(const String &p_name, bool p_internal) {
 
 void ProjectSettings::set_ignore_value_in_docs(const String &p_name, bool p_ignore) {
 	ERR_FAIL_COND_MSG(!props.has(p_name), vformat("Request for nonexistent project setting: '%s'.", p_name));
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	props[p_name].ignore_value_in_docs = p_ignore;
-#endif
+#endif // DEBUG_ENABLED
 }
 
 bool ProjectSettings::get_ignore_value_in_docs(const String &p_name) const {
 	ERR_FAIL_COND_V_MSG(!props.has(p_name), false, vformat("Request for nonexistent project setting: '%s'.", p_name));
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	return props[p_name].ignore_value_in_docs;
 #else
 	return false;
-#endif
+#endif // DEBUG_ENABLED
 }
 
 void ProjectSettings::add_hidden_prefix(const String &p_prefix) {

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -74,9 +74,9 @@ protected:
 		Variant initial;
 		bool hide_from_editor = false;
 		bool restart_if_changed = false;
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		bool ignore_value_in_docs = false;
-#endif
+#endif // DEBUG_ENABLED
 
 		VariantContainer() {}
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -661,7 +661,7 @@ bool OS::is_debug_build() const {
 	return true;
 #else
 	return false;
-#endif
+#endif // DEBUG_ENABLED
 }
 
 String OS::get_system_dir(SystemDir p_dir, bool p_shared_storage) const {
@@ -1669,13 +1669,13 @@ TypedArray<Dictionary> ClassDB::class_get_method_list(const StringName &p_class,
 	TypedArray<Dictionary> ret;
 
 	for (const MethodInfo &E : methods) {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		ret.push_back(E.operator Dictionary());
 #else
 		Dictionary dict;
 		dict["name"] = E.name;
 		ret.push_back(dict);
-#endif
+#endif // DEBUG_ENABLED
 	}
 
 	return ret;

--- a/core/core_constants.cpp
+++ b/core/core_constants.cpp
@@ -36,17 +36,17 @@
 #include "core/variant/variant.h"
 
 struct _CoreConstant {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	bool ignore_value_in_docs = false;
 	bool is_bitfield = false;
-#endif
+#endif // DEBUG_ENABLED
 	StringName enum_name;
 	const char *name = nullptr;
 	int64_t value = 0;
 
 	_CoreConstant() {}
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	_CoreConstant(const StringName &p_enum_name, const char *p_name, int64_t p_value, bool p_ignore_value_in_docs = false, bool p_is_bitfield = false) :
 			ignore_value_in_docs(p_ignore_value_in_docs),
 			is_bitfield(p_is_bitfield),
@@ -60,14 +60,14 @@ struct _CoreConstant {
 			name(p_name),
 			value(p_value) {
 	}
-#endif
+#endif // DEBUG_ENABLED
 };
 
 static Vector<_CoreConstant> _global_constants;
 static HashMap<StringName, int> _global_constants_map;
 static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 
 #define BIND_CORE_CONSTANT(m_constant)                                                 \
 	_global_constants.push_back(_CoreConstant(StringName(), #m_constant, m_constant)); \
@@ -249,7 +249,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 
-#endif
+#endif // DEBUG_ENABLED
 
 void register_global_constants() {
 	BIND_CORE_ENUM_CONSTANT(SIDE_LEFT);
@@ -816,7 +816,7 @@ StringName CoreConstants::get_global_constant_enum(int p_idx) {
 	return _global_constants[p_idx].enum_name;
 }
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 bool CoreConstants::is_global_constant_bitfield(int p_idx) {
 	return _global_constants[p_idx].is_bitfield;
 }
@@ -832,7 +832,7 @@ bool CoreConstants::is_global_constant_bitfield(int p_idx) {
 bool CoreConstants::get_ignore_value_in_docs(int p_idx) {
 	return false;
 }
-#endif
+#endif // DEBUG_ENABLED
 
 const char *CoreConstants::get_global_constant_name(int p_idx) {
 	return _global_constants[p_idx].name;

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -87,7 +87,7 @@ public:
 	virtual bool is_valid() const override { return valid; }
 #endif
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	virtual GodotTypeInfo::Metadata get_argument_meta(int p_arg) const override {
 		if (p_arg < 0) {
 			return return_value_metadata;
@@ -95,7 +95,7 @@ public:
 			return arguments_metadata.get(p_arg);
 		}
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 #ifdef TOOLS_ENABLED
@@ -219,9 +219,9 @@ public:
 		_set_returns(p_method_info->has_return_value);
 		_set_const(p_method_info->method_flags & GDEXTENSION_METHOD_FLAG_CONST);
 		_set_static(p_method_info->method_flags & GDEXTENSION_METHOD_FLAG_STATIC);
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		_generate_argument_types(p_method_info->argument_count);
-#endif
+#endif // DEBUG_ENABLED
 		set_argument_count(p_method_info->argument_count);
 
 		Vector<Variant> defargs;

--- a/core/object/callable_method_pointer.h
+++ b/core/object/callable_method_pointer.h
@@ -40,9 +40,9 @@ class CallableCustomMethodPointerBase : public CallableCustom {
 	uint32_t *comp_ptr = nullptr;
 	uint32_t comp_size;
 	uint32_t h;
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	const char *text = "";
-#endif
+#endif // DEBUG_ENABLED
 	static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
 	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
 
@@ -51,14 +51,14 @@ protected:
 
 public:
 	virtual StringName get_method() const {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		return StringName(text);
 #else
 		return StringName();
-#endif
+#endif // DEBUG_ENABLED
 	}
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	void set_text(const char *p_text) {
 		text = p_text;
 	}
@@ -69,7 +69,7 @@ public:
 	virtual String get_as_text() const {
 		return String();
 	}
-#endif
+#endif // DEBUG_ENABLED
 	virtual CompareEqualFunc get_compare_equal_func() const;
 	virtual CompareLessFunc get_compare_less_func() const;
 
@@ -117,29 +117,29 @@ public:
 
 template <typename T, typename... P>
 Callable create_custom_callable_function_pointer(T *p_instance,
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		const char *p_func_text,
-#endif
+#endif // DEBUG_ENABLED
 		void (T::*p_method)(P...)) {
 	typedef CallableCustomMethodPointer<T, void, P...> CCMP; // Messes with memnew otherwise.
 	CCMP *ccmp = memnew(CCMP(p_instance, p_method));
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	ccmp->set_text(p_func_text + 1); // Try to get rid of the ampersand.
-#endif
+#endif // DEBUG_ENABLED
 	return Callable(ccmp);
 }
 
 template <typename T, typename R, typename... P>
 Callable create_custom_callable_function_pointer(T *p_instance,
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		const char *p_func_text,
-#endif
+#endif // DEBUG_ENABLED
 		R (T::*p_method)(P...)) {
 	typedef CallableCustomMethodPointer<T, R, P...> CCMP; // Messes with memnew otherwise.
 	CCMP *ccmp = memnew(CCMP(p_instance, p_method));
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	ccmp->set_text(p_func_text + 1); // Try to get rid of the ampersand.
-#endif
+#endif // DEBUG_ENABLED
 	return Callable(ccmp);
 }
 
@@ -186,37 +186,37 @@ public:
 
 template <typename T, typename... P>
 Callable create_custom_callable_function_pointer(T *p_instance,
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		const char *p_func_text,
-#endif
+#endif // DEBUG_ENABLED
 		void (T::*p_method)(P...) const) {
 	typedef CallableCustomMethodPointerC<T, void, P...> CCMP; // Messes with memnew otherwise.
 	CCMP *ccmp = memnew(CCMP(p_instance, p_method));
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	ccmp->set_text(p_func_text + 1); // Try to get rid of the ampersand.
-#endif
+#endif // DEBUG_ENABLED
 	return Callable(ccmp);
 }
 
 template <typename T, typename R, typename... P>
 Callable create_custom_callable_function_pointer(T *p_instance,
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		const char *p_func_text,
 #endif
 		R (T::*p_method)(P...) const) {
 	typedef CallableCustomMethodPointerC<T, R, P...> CCMP; // Messes with memnew otherwise.
 	CCMP *ccmp = memnew(CCMP(p_instance, p_method));
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	ccmp->set_text(p_func_text + 1); // Try to get rid of the ampersand.
-#endif
+#endif // DEBUG_ENABLED
 	return Callable(ccmp);
 }
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 #define callable_mp(I, M) create_custom_callable_function_pointer(I, #M, M)
 #else
 #define callable_mp(I, M) create_custom_callable_function_pointer(I, M)
-#endif
+#endif // DEBUG_ENABLED
 
 // STATIC VERSIONS
 
@@ -257,33 +257,33 @@ public:
 
 template <typename... P>
 Callable create_custom_callable_static_function_pointer(
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		const char *p_func_text,
-#endif
+#endif // DEBUG_ENABLED
 		void (*p_method)(P...)) {
 	typedef CallableCustomStaticMethodPointer<void, P...> CCMP; // Messes with memnew otherwise.
 	CCMP *ccmp = memnew(CCMP(p_method));
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	ccmp->set_text(p_func_text + 1); // Try to get rid of the ampersand.
-#endif
+#endif // DEBUG_ENABLED
 	return Callable(ccmp);
 }
 
 template <typename R, typename... P>
 Callable create_custom_callable_static_function_pointer(
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		const char *p_func_text,
-#endif
+#endif // DEBUG_ENABLED
 		R (*p_method)(P...)) {
 	typedef CallableCustomStaticMethodPointer<R, P...> CCMP; // Messes with memnew otherwise.
 	CCMP *ccmp = memnew(CCMP(p_method));
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	ccmp->set_text(p_func_text + 1); // Try to get rid of the ampersand.
-#endif
+#endif // DEBUG_ENABLED
 	return Callable(ccmp);
 }
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 #define callable_mp_static(M) create_custom_callable_static_function_pointer(#M, M)
 #else
 #define callable_mp_static(M) create_custom_callable_static_function_pointer(M)

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -35,7 +35,7 @@
 #include "core/object/script_language.h"
 #include "core/version.h"
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 
 MethodDefinition D_METHODP(const char *p_name, const char *const **p_args, uint32_t p_argcount) {
 	MethodDefinition md;
@@ -47,7 +47,7 @@ MethodDefinition D_METHODP(const char *p_name, const char *const **p_args, uint3
 	return md;
 }
 
-#endif
+#endif // DEBUG_ENABLED
 
 ClassDB::APIType ClassDB::current_api = API_CORE;
 HashMap<ClassDB::APIType, uint32_t> ClassDB::api_hashes_cache;
@@ -368,7 +368,7 @@ ClassDB::APIType ClassDB::get_api_type(const StringName &p_class) {
 }
 
 uint32_t ClassDB::get_api_hash(APIType p_api) {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	Locker::Lock lock(Locker::STATE_WRITE);
 
 	if (api_hashes_cache.has(p_api)) {
@@ -513,7 +513,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 	return hash;
 #else
 	return 0;
-#endif
+#endif // DEBUG_ENABLED
 }
 
 bool ClassDB::class_exists(const StringName &p_class) {
@@ -898,7 +898,7 @@ void ClassDB::get_method_list(const StringName &p_class, List<MethodInfo> *p_met
 			continue;
 		}
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		for (const MethodInfo &E : type->virtual_methods) {
 			p_methods->push_back(E);
 		}
@@ -919,7 +919,7 @@ void ClassDB::get_method_list(const StringName &p_class, List<MethodInfo> *p_met
 			MethodInfo minfo = info_from_bind(m);
 			p_methods->push_back(minfo);
 		}
-#endif
+#endif // DEBUG_ENABLED
 
 		if (p_no_inheritance) {
 			break;
@@ -944,7 +944,7 @@ void ClassDB::get_method_list_with_compatibility(const StringName &p_class, List
 			continue;
 		}
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		for (const MethodInfo &E : type->virtual_methods) {
 			Pair<MethodInfo, uint32_t> pair(E, E.get_compatibility_hash());
 			p_methods->push_back(pair);
@@ -969,7 +969,7 @@ void ClassDB::get_method_list_with_compatibility(const StringName &p_class, List
 			Pair<MethodInfo, uint32_t> pair(minfo, method->get_hash());
 			p_methods->push_back(pair);
 		}
-#endif
+#endif // DEBUG_ENABLED
 
 		for (const KeyValue<StringName, LocalVector<MethodBind *, unsigned int, false, false>> &E : type->method_map_compatibility) {
 			LocalVector<MethodBind *> compat = E.value;
@@ -1004,7 +1004,7 @@ bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_met
 			continue;
 		}
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		MethodBind **method = type->method_map.getptr(p_method);
 		if (method && *method) {
 			if (r_info != nullptr) {
@@ -1027,7 +1027,7 @@ bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_met
 			}
 			return true;
 		}
-#endif
+#endif // DEBUG_ENABLED
 
 		if (p_no_inheritance) {
 			break;
@@ -1140,9 +1140,9 @@ void ClassDB::bind_integer_constant(const StringName &p_class, const StringName 
 		}
 	}
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	type->constant_order.push_back(p_name);
-#endif
+#endif // DEBUG_ENABLED
 }
 
 void ClassDB::get_integer_constant_list(const StringName &p_class, List<String> *p_constants, bool p_no_inheritance) {
@@ -1151,7 +1151,7 @@ void ClassDB::get_integer_constant_list(const StringName &p_class, List<String> 
 	ClassInfo *type = classes.getptr(p_class);
 
 	while (type) {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		for (const StringName &E : type->constant_order) {
 			p_constants->push_back(E);
 		}
@@ -1161,7 +1161,7 @@ void ClassDB::get_integer_constant_list(const StringName &p_class, List<String> 
 			p_constants->push_back(E.key);
 		}
 
-#endif
+#endif // DEBUG_ENABLED
 		if (p_no_inheritance) {
 			break;
 		}
@@ -1278,18 +1278,18 @@ void ClassDB::get_enum_constants(const StringName &p_class, const StringName &p_
 }
 
 void ClassDB::set_method_error_return_values(const StringName &p_class, const StringName &p_method, const Vector<Error> &p_values) {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	Locker::Lock lock(Locker::STATE_WRITE);
 	ClassInfo *type = classes.getptr(p_class);
 
 	ERR_FAIL_NULL(type);
 
 	type->method_error_values[p_method] = p_values;
-#endif
+#endif // DEBUG_ENABLED
 }
 
 Vector<Error> ClassDB::get_method_error_return_values(const StringName &p_class, const StringName &p_method) {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	Locker::Lock lock(Locker::STATE_READ);
 	ClassInfo *type = classes.getptr(p_class);
 
@@ -1301,7 +1301,7 @@ Vector<Error> ClassDB::get_method_error_return_values(const StringName &p_class,
 	return type->method_error_values[p_method];
 #else
 	return Vector<Error>();
-#endif
+#endif // DEBUG_ENABLED
 }
 
 bool ClassDB::has_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance) {
@@ -1350,13 +1350,13 @@ void ClassDB::add_signal(const StringName &p_class, const MethodInfo &p_signal) 
 
 	StringName sname = p_signal.name;
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	ClassInfo *check = type;
 	while (check) {
 		ERR_FAIL_COND_MSG(check->signal_map.has(sname), vformat("Class '%s' already has signal '%s'.", String(p_class), String(sname)));
 		check = check->inherits_ptr;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	type->signal_map[sname] = p_signal;
 }
@@ -1465,41 +1465,41 @@ void ClassDB::add_property(const StringName &p_class, const PropertyInfo &p_pinf
 	MethodBind *mb_set = nullptr;
 	if (p_setter) {
 		mb_set = get_method(p_class, p_setter);
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 
 		ERR_FAIL_NULL_MSG(mb_set, vformat("Invalid setter '%s::%s' for property '%s'.", p_class, p_setter, p_pinfo.name));
 
 		int exp_args = 1 + (p_index >= 0 ? 1 : 0);
 		ERR_FAIL_COND_MSG(mb_set->get_argument_count() != exp_args, vformat("Invalid function for setter '%s::%s' for property '%s'.", p_class, p_setter, p_pinfo.name));
-#endif
+#endif // DEBUG_ENABLED
 	}
 
 	MethodBind *mb_get = nullptr;
 	if (p_getter) {
 		mb_get = get_method(p_class, p_getter);
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 
 		ERR_FAIL_NULL_MSG(mb_get, vformat("Invalid getter '%s::%s' for property '%s'.", p_class, p_getter, p_pinfo.name));
 
 		int exp_args = 0 + (p_index >= 0 ? 1 : 0);
 		ERR_FAIL_COND_MSG(mb_get->get_argument_count() != exp_args, vformat("Invalid function for getter '%s::%s' for property '%s'.", p_class, p_getter, p_pinfo.name));
-#endif
+#endif // DEBUG_ENABLED
 	}
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(type->property_setget.has(p_pinfo.name), vformat("Object '%s' already has property '%s'.", p_class, p_pinfo.name));
-#endif
+#endif // DEBUG_ENABLED
 
 	type->property_list.push_back(p_pinfo);
 	type->property_map[p_pinfo.name] = p_pinfo;
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	if (mb_get) {
 		type->methods_in_properties.insert(p_getter);
 	}
 	if (mb_set) {
 		type->methods_in_properties.insert(p_setter);
 	}
-#endif
+#endif // DEBUG_ENABLED
 	PropertySetGet psg;
 	psg.setter = p_setter;
 	psg.getter = p_getter;
@@ -1887,9 +1887,9 @@ void ClassDB::_bind_method_custom(const StringName &p_class, MethodBind *p_metho
 		ERR_FAIL_MSG(vformat("Method already bound '%s::%s'.", p_class, method_name));
 	}
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	type->method_order.push_back(method_name);
-#endif
+#endif // DEBUG_ENABLED
 
 	type->method_map[method_name] = p_method;
 }
@@ -1918,22 +1918,22 @@ MethodBind *ClassDB::_bind_vararg_method(MethodBind *p_bind, const StringName &p
 		ERR_FAIL_V_MSG(nullptr, vformat("Method already bound: '%s::%s'.", instance_type, p_name));
 	}
 	type->method_map[p_name] = bind;
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	// FIXME: <reduz> set_return_type is no longer in MethodBind, so I guess it should be moved to vararg method bind
 	//bind->set_return_type("Variant");
 	type->method_order.push_back(p_name);
-#endif
+#endif // DEBUG_ENABLED
 
 	return bind;
 }
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, bool p_compatibility, const MethodDefinition &method_name, const Variant **p_defs, int p_defcount) {
 	StringName mdname = method_name.name;
 #else
 MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, bool p_compatibility, const char *method_name, const Variant **p_defs, int p_defcount) {
 	StringName mdname = StringName(method_name);
-#endif
+#endif // DEBUG_ENABLED
 
 	Locker::Lock lock(Locker::STATE_WRITE);
 	ERR_FAIL_NULL_V(p_bind, nullptr);
@@ -1944,7 +1944,7 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, bool p_
 #ifdef DEBUG_ENABLED
 
 	ERR_FAIL_COND_V_MSG(!p_compatibility && has_method(instance_type, mdname), nullptr, vformat("Class '%s' already has a method '%s'.", String(instance_type), String(mdname)));
-#endif
+#endif // DEBUG_ENABLED
 
 	ClassInfo *type = classes.getptr(instance_type);
 	if (!type) {
@@ -1958,7 +1958,7 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, bool p_
 		ERR_FAIL_V_MSG(nullptr, vformat("Method already bound '%s::%s'.", instance_type, mdname));
 	}
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 
 	if (method_name.args.size() > p_bind->get_argument_count()) {
 		memdelete(p_bind);
@@ -1975,7 +1975,7 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, bool p_
 	if (!p_compatibility) {
 		type->method_order.push_back(mdname);
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	if (p_compatibility) {
 		_bind_compatibility(type, p_bind);
@@ -2000,7 +2000,7 @@ void ClassDB::add_virtual_method(const StringName &p_class, const MethodInfo &p_
 
 	Locker::Lock lock(Locker::STATE_WRITE);
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	MethodInfo mi = p_method;
 	if (p_virtual) {
 		mi.flags |= METHOD_FLAG_VIRTUAL;
@@ -2026,7 +2026,7 @@ void ClassDB::add_virtual_method(const StringName &p_class, const MethodInfo &p_
 	classes[p_class].virtual_methods.push_back(mi);
 	classes[p_class].virtual_methods_map[p_method.name] = mi;
 
-#endif
+#endif // DEBUG_ENABLED
 }
 
 void ClassDB::add_virtual_compatibility_method(const StringName &p_class, const MethodInfo &p_method, bool p_virtual, const Vector<String> &p_arg_names, bool p_object_core) {
@@ -2048,7 +2048,7 @@ void ClassDB::add_virtual_compatibility_method(const StringName &p_class, const 
 void ClassDB::get_virtual_methods(const StringName &p_class, List<MethodInfo> *p_methods, bool p_no_inheritance) {
 	ERR_FAIL_COND_MSG(!classes.has(p_class), vformat("Request for nonexistent class '%s'.", p_class));
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 
 	ClassInfo *type = classes.getptr(p_class);
 	ClassInfo *check = type;
@@ -2063,7 +2063,7 @@ void ClassDB::get_virtual_methods(const StringName &p_class, List<MethodInfo> *p
 		check = check->inherits_ptr;
 	}
 
-#endif
+#endif // DEBUG_ENABLED
 }
 
 Vector<uint32_t> ClassDB::get_virtual_method_compatibility_hashes(const StringName &p_class, const StringName &p_name) {
@@ -2088,7 +2088,7 @@ Vector<uint32_t> ClassDB::get_virtual_method_compatibility_hashes(const StringNa
 void ClassDB::add_extension_class_virtual_method(const StringName &p_class, const GDExtensionClassVirtualMethodInfo *p_method_info) {
 	ERR_FAIL_COND_MSG(!classes.has(p_class), vformat("Request for nonexistent class '%s'.", p_class));
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	PackedStringArray arg_names;
 
 	MethodInfo mi;
@@ -2104,7 +2104,7 @@ void ClassDB::add_extension_class_virtual_method(const StringName &p_class, cons
 	}
 
 	add_virtual_method(p_class, mi, true, arg_names);
-#endif
+#endif // DEBUG_ENABLED
 }
 
 void ClassDB::set_class_enabled(const StringName &p_class, bool p_enable) {
@@ -2250,7 +2250,7 @@ Variant ClassDB::class_get_default_property_value(const StringName &p_class, con
 			WARN_PRINT(vformat("Instantiated %s used as default value for %s's \"%s\" property.", obj->get_class(), p_class, p_property));
 		}
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	return var;
 }

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -44,7 +44,7 @@
 #define DEFVAL(m_defval) (m_defval)
 #define DEFVAL_ARRAY DEFVAL(ClassDB::default_array_arg)
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 
 struct MethodDefinition {
 	StringName name;
@@ -71,11 +71,11 @@ MethodDefinition D_METHOD(const char *p_name, const VarArgs... p_args) {
 
 #else
 
-// When DEBUG_METHODS_ENABLED is set this will let the engine know
+// When DEBUG_ENABLED is set this will let the engine know
 // the argument names for easier debugging.
 #define D_METHOD(m_c, ...) m_c
 
-#endif
+#endif // DEBUG_ENABLED
 
 class ClassDB {
 	friend class Object;
@@ -118,7 +118,7 @@ public:
 		HashMap<StringName, MethodInfo> signal_map;
 		List<PropertyInfo> property_list;
 		HashMap<StringName, PropertyInfo> property_map;
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		List<StringName> constant_order;
 		List<StringName> method_order;
 		HashSet<StringName> methods_in_properties;
@@ -126,7 +126,7 @@ public:
 		HashMap<StringName, MethodInfo> virtual_methods_map;
 		HashMap<StringName, Vector<Error>> method_error_values;
 		HashMap<StringName, List<StringName>> linked_properties;
-#endif
+#endif // DEBUG_ENABLED
 		HashMap<StringName, PropertySetGet> property_setget;
 		HashMap<StringName, Vector<uint32_t>> virtual_methods_compat;
 
@@ -186,11 +186,11 @@ public:
 	static HashMap<StringName, ObjectGDExtension> placeholder_extensions;
 #endif
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	static MethodBind *bind_methodfi(uint32_t p_flags, MethodBind *p_bind, bool p_compatibility, const MethodDefinition &method_name, const Variant **p_defs, int p_defcount);
 #else
 	static MethodBind *bind_methodfi(uint32_t p_flags, MethodBind *p_bind, bool p_compatibility, const char *method_name, const Variant **p_defs, int p_defcount);
-#endif
+#endif // DEBUG_ENABLED
 
 	static APIType current_api;
 	static HashMap<APIType, uint32_t> api_hashes_cache;
@@ -529,7 +529,7 @@ public:
 #define BIND_CONSTANT(m_constant) \
 	::ClassDB::bind_integer_constant(get_class_static(), StringName(), #m_constant, m_constant);
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 
 _FORCE_INLINE_ void errarray_add_str(Vector<Error> &arr) {
 }
@@ -558,7 +558,7 @@ _FORCE_INLINE_ Vector<Error> errarray(P... p_args) {
 
 #define BIND_METHOD_ERR_RETURN_DOC(m_method, ...)
 
-#endif
+#endif // DEBUG_ENABLED
 
 #define GDREGISTER_CLASS(m_class)             \
 	if (m_class::_class_is_enabled) {         \

--- a/core/object/method_bind.cpp
+++ b/core/object/method_bind.cpp
@@ -50,11 +50,11 @@ PropertyInfo MethodBind::get_argument_info(int p_argument) const {
 	ERR_FAIL_INDEX_V(p_argument, get_argument_count(), PropertyInfo());
 
 	PropertyInfo info = _gen_argument_type_info(p_argument);
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	if (info.name.is_empty()) {
 		info.name = p_argument < arg_names.size() ? String(arg_names[p_argument]) : String("_unnamed_arg" + itos(p_argument));
 	}
-#endif
+#endif // DEBUG_ENABLED
 	return info;
 }
 
@@ -82,7 +82,7 @@ void MethodBind::set_name(const StringName &p_name) {
 	name = p_name;
 }
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 void MethodBind::set_argument_names(const Vector<StringName> &p_names) {
 	arg_names = p_names;
 }
@@ -91,7 +91,7 @@ Vector<StringName> MethodBind::get_argument_names() const {
 	return arg_names;
 }
 
-#endif
+#endif // DEBUG_ENABLED
 
 void MethodBind::set_default_arguments(const Vector<Variant> &p_defargs) {
 	default_arguments = p_defargs;

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -52,9 +52,9 @@ class MethodBind {
 
 protected:
 	Variant::Type *argument_types = nullptr;
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	Vector<StringName> arg_names;
-#endif
+#endif // DEBUG_ENABLED
 	void _set_const(bool p_const);
 	void _set_static(bool p_static);
 	void _set_returns(bool p_returns);
@@ -96,12 +96,12 @@ public:
 	PropertyInfo get_argument_info(int p_argument) const;
 	PropertyInfo get_return_info() const;
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	void set_argument_names(const Vector<StringName> &p_names); // Set by ClassDB, can't be inferred otherwise.
 	Vector<StringName> get_argument_names() const;
 
 	virtual GodotTypeInfo::Metadata get_argument_meta(int p_arg) const = 0;
-#endif
+#endif // DEBUG_ENABLED
 
 	void set_hint_flags(uint32_t p_hint) { hint_flags = p_hint; }
 	uint32_t get_hint_flags() const { return hint_flags | (is_const() ? METHOD_FLAG_CONST : 0) | (is_vararg() ? METHOD_FLAG_VARARG : 0) | (is_static() ? METHOD_FLAG_STATIC : 0); }
@@ -160,11 +160,11 @@ public:
 		return _gen_argument_type_info(p_arg).type;
 	}
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	virtual GodotTypeInfo::Metadata get_argument_meta(int) const override {
 		return GodotTypeInfo::METADATA_NONE;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	virtual void validated_call(Object *p_object, const Variant **p_args, Variant *r_ret) const override {
 		ERR_FAIL_MSG("Validated call can't be used with vararg methods. This is a bug.");
@@ -187,20 +187,20 @@ public:
 		Variant::Type *at = memnew_arr(Variant::Type, method_info.arguments.size() + 1);
 		at[0] = _gen_return_type_info().type;
 		if (method_info.arguments.size()) {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 			Vector<StringName> names;
 			names.resize(method_info.arguments.size());
-#endif
+#endif // DEBUG_ENABLED
 			for (int64_t i = 0; i < method_info.arguments.size(); ++i) {
 				at[i + 1] = method_info.arguments[i].type;
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 				names.write[i] = method_info.arguments[i].name;
-#endif
+#endif // DEBUG_ENABLED
 			}
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 			set_argument_names(names);
-#endif
+#endif // DEBUG_ENABLED
 		}
 		argument_types = at;
 		if (p_return_nil_is_variant) {
@@ -321,12 +321,12 @@ protected:
 	}
 
 public:
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	virtual GodotTypeInfo::Metadata get_argument_meta(int p_arg) const override {
 		return call_get_argument_metadata<P...>(p_arg);
 	}
 
-#endif
+#endif // DEBUG_ENABLED
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 #ifdef TOOLS_ENABLED
 		ERR_FAIL_COND_V_MSG(p_object && p_object->is_extension_placeholder() && p_object->get_class_name() == get_instance_class(), Variant(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
@@ -405,12 +405,12 @@ protected:
 	}
 
 public:
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	virtual GodotTypeInfo::Metadata get_argument_meta(int p_arg) const override {
 		return call_get_argument_metadata<P...>(p_arg);
 	}
 
-#endif
+#endif // DEBUG_ENABLED
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 #ifdef TOOLS_ENABLED
 		ERR_FAIL_COND_V_MSG(p_object && p_object->is_extension_placeholder() && p_object->get_class_name() == get_instance_class(), Variant(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
@@ -494,7 +494,7 @@ protected:
 	}
 
 public:
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	virtual GodotTypeInfo::Metadata get_argument_meta(int p_arg) const override {
 		if (p_arg >= 0) {
 			return call_get_argument_metadata<P...>(p_arg);
@@ -502,7 +502,7 @@ public:
 			return GetTypeInfo<R>::METADATA;
 		}
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 		Variant ret;
@@ -589,7 +589,7 @@ protected:
 	}
 
 public:
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	virtual GodotTypeInfo::Metadata get_argument_meta(int p_arg) const override {
 		if (p_arg >= 0) {
 			return call_get_argument_metadata<P...>(p_arg);
@@ -597,7 +597,7 @@ public:
 			return GetTypeInfo<R>::METADATA;
 		}
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 		Variant ret;
@@ -678,12 +678,12 @@ protected:
 	}
 
 public:
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	virtual GodotTypeInfo::Metadata get_argument_meta(int p_arg) const override {
 		return call_get_argument_metadata<P...>(p_arg);
 	}
 
-#endif
+#endif // DEBUG_ENABLED
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 		(void)p_object; // unused
 		call_with_variant_args_static_dv(function, p_args, p_arg_count, r_error, get_default_arguments());
@@ -740,7 +740,7 @@ protected:
 	}
 
 public:
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	virtual GodotTypeInfo::Metadata get_argument_meta(int p_arg) const override {
 		if (p_arg >= 0) {
 			return call_get_argument_metadata<P...>(p_arg);
@@ -749,7 +749,7 @@ public:
 		}
 	}
 
-#endif
+#endif // DEBUG_ENABLED
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 		Variant ret;
 		call_with_variant_args_static_ret_dv(function, p_args, p_arg_count, ret, r_error, get_default_arguments());

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -380,11 +380,11 @@ struct ObjectGDExtension {
 #define GDVIRTUAL_CALL(m_name, ...) _gdvirtual_##m_name##_call(__VA_ARGS__)
 #define GDVIRTUAL_CALL_PTR(m_obj, m_name, ...) m_obj->_gdvirtual_##m_name##_call(__VA_ARGS__)
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 #define GDVIRTUAL_BIND(m_name, ...) ::ClassDB::add_virtual_method(get_class_static(), _gdvirtual_##m_name##_get_method_info(), true, sarray(__VA_ARGS__));
 #else
 #define GDVIRTUAL_BIND(m_name, ...)
-#endif
+#endif // DEBUG_ENABLED
 #define GDVIRTUAL_BIND_COMPAT(m_alias, ...) ::ClassDB::add_virtual_compatibility_method(get_class_static(), _gdvirtual_##m_alias##_get_method_info(), true, sarray(__VA_ARGS__));
 #define GDVIRTUAL_IS_OVERRIDDEN(m_name) _gdvirtual_##m_name##_overridden()
 #define GDVIRTUAL_IS_OVERRIDDEN_PTR(m_obj, m_name) m_obj->_gdvirtual_##m_name##_overridden()
@@ -592,7 +592,7 @@ public:
 private:
 #ifdef DEBUG_ENABLED
 	friend struct _ObjectDebugLock;
-#endif
+#endif // DEBUG_ENABLED
 	friend bool predelete_handler(Object *);
 	friend void postinitialize_handler(Object *);
 
@@ -616,7 +616,7 @@ private:
 	List<Connection> connections;
 #ifdef DEBUG_ENABLED
 	SafeRefCount _lock_index;
-#endif
+#endif // DEBUG_ENABLED
 	bool _block_signals = false;
 	int _predelete_ok = 0;
 	ObjectID _instance_id;
@@ -893,7 +893,7 @@ public:
 #define MTVIRTUAL virtual
 #else
 #define MTVIRTUAL
-#endif
+#endif // DEBUG_ENABLED
 
 	MTVIRTUAL void set_script(const Variant &p_script);
 	MTVIRTUAL Variant get_script() const;

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -317,10 +317,6 @@ struct BuildIndexSequence<0, Is...> : IndexSequence<Is...> {};
 // Limit the depth of recursive algorithms when dealing with Array/Dictionary
 #define MAX_RECURSION 100
 
-#ifdef DEBUG_ENABLED
-#define DEBUG_METHODS_ENABLED
-#endif
-
 // Macro GD_IS_DEFINED() allows to check if a macro is defined. It needs to be defined to anything (say 1) to work.
 #define __GDARG_PLACEHOLDER_1 false,
 #define __gd_take_second_arg(__ignored, val, ...) val

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -166,7 +166,7 @@ struct VariantObjectClassChecker<const Ref<T> &> {
 	}
 };
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 
 template <typename T>
 struct VariantCasterAndValidate {
@@ -213,17 +213,17 @@ struct VariantCasterAndValidate<const T &> {
 	}
 };
 
-#endif // DEBUG_METHODS_ENABLED
+#endif // DEBUG_ENABLED
 
 template <typename T, typename... P, size_t... Is>
 void call_with_variant_args_helper(T *p_instance, void (T::*p_method)(P...), const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	(p_instance->*p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
 #else
 	(p_instance->*p_method)(VariantCaster<P>::cast(*p_args[Is])...);
-#endif
+#endif // DEBUG_ENABLED
 	(void)(p_args); //avoid warning
 }
 
@@ -231,11 +231,11 @@ template <typename T, typename... P, size_t... Is>
 void call_with_variant_argsc_helper(T *p_instance, void (T::*p_method)(P...) const, const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	(p_instance->*p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
 #else
 	(p_instance->*p_method)(VariantCaster<P>::cast(*p_args[Is])...);
-#endif
+#endif // DEBUG_ENABLED
 	(void)(p_args); //avoid warning
 }
 
@@ -321,7 +321,7 @@ void call_with_validated_variant_args_static_method_helper(void (*p_method)(P...
 
 template <typename T, typename... P>
 void call_with_variant_args(T *p_instance, void (T::*p_method)(P...), const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
 		r_error.expected = sizeof...(P);
@@ -333,7 +333,7 @@ void call_with_variant_args(T *p_instance, void (T::*p_method)(P...), const Vari
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 	call_with_variant_args_helper<T, P...>(p_instance, p_method, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
@@ -345,7 +345,7 @@ void call_with_variant_args_dv(T *p_instance, void (T::*p_method)(P...), const V
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
 
@@ -356,7 +356,7 @@ void call_with_variant_args_dv(T *p_instance, void (T::*p_method)(P...), const V
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
 	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
@@ -372,7 +372,7 @@ void call_with_variant_args_dv(T *p_instance, void (T::*p_method)(P...), const V
 
 template <typename T, typename... P>
 void call_with_variant_argsc(T *p_instance, void (T::*p_method)(P...) const, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
 		r_error.expected = sizeof...(P);
@@ -384,7 +384,7 @@ void call_with_variant_argsc(T *p_instance, void (T::*p_method)(P...) const, con
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 	call_with_variant_argsc_helper<T, P...>(p_instance, p_method, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
@@ -396,7 +396,7 @@ void call_with_variant_argsc_dv(T *p_instance, void (T::*p_method)(P...) const, 
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
 
@@ -407,7 +407,7 @@ void call_with_variant_argsc_dv(T *p_instance, void (T::*p_method)(P...) const, 
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
 	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
@@ -429,7 +429,7 @@ void call_with_variant_args_ret_dv(T *p_instance, R (T::*p_method)(P...), const 
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
 
@@ -440,7 +440,7 @@ void call_with_variant_args_ret_dv(T *p_instance, R (T::*p_method)(P...), const 
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
 	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
@@ -462,7 +462,7 @@ void call_with_variant_args_retc_dv(T *p_instance, R (T::*p_method)(P...) const,
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
 
@@ -473,7 +473,7 @@ void call_with_variant_args_retc_dv(T *p_instance, R (T::*p_method)(P...) const,
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
 	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
@@ -638,7 +638,7 @@ void call_get_argument_type_info(int p_arg, PropertyInfo &info) {
 	(void)index; // Suppress GCC warning.
 }
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 template <typename Q>
 void call_get_argument_metadata_helper(int p_arg, int &index, GodotTypeInfo::Metadata &md) {
 	if (p_arg == index) {
@@ -660,7 +660,7 @@ GodotTypeInfo::Metadata call_get_argument_metadata(int p_arg) {
 	return md;
 }
 
-#endif // DEBUG_METHODS_ENABLED
+#endif // DEBUG_ENABLED
 
 //////////////////////
 
@@ -668,7 +668,7 @@ template <typename T, typename R, typename... P, size_t... Is>
 void call_with_variant_args_ret_helper(T *p_instance, R (T::*p_method)(P...), const Variant **p_args, Variant &r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	r_ret = (p_instance->*p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
 #else
 	r_ret = (p_instance->*p_method)(VariantCaster<P>::cast(*p_args[Is])...);
@@ -679,27 +679,27 @@ template <typename R, typename... P, size_t... Is>
 void call_with_variant_args_static_ret(R (*p_method)(P...), const Variant **p_args, Variant &r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	r_ret = (p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
 #else
 	r_ret = (p_method)(VariantCaster<P>::cast(*p_args[Is])...);
-#endif
+#endif // DEBUG_ENABLED
 }
 
 template <typename... P, size_t... Is>
 void call_with_variant_args_static(void (*p_method)(P...), const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	(p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
 #else
 	(p_method)(VariantCaster<P>::cast(*p_args[Is])...);
-#endif
+#endif // DEBUG_ENABLED
 }
 
 template <typename T, typename R, typename... P>
 void call_with_variant_args_ret(T *p_instance, R (T::*p_method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
 		r_error.expected = sizeof...(P);
@@ -711,7 +711,7 @@ void call_with_variant_args_ret(T *p_instance, R (T::*p_method)(P...), const Var
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 	call_with_variant_args_ret_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
@@ -719,17 +719,17 @@ template <typename T, typename R, typename... P, size_t... Is>
 void call_with_variant_args_retc_helper(T *p_instance, R (T::*p_method)(P...) const, const Variant **p_args, Variant &r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	r_ret = (p_instance->*p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
 #else
 	r_ret = (p_instance->*p_method)(VariantCaster<P>::cast(*p_args[Is])...);
-#endif
+#endif // DEBUG_ENABLED
 	(void)p_args;
 }
 
 template <typename R, typename... P>
 void call_with_variant_args_static_ret(R (*p_method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
 		r_error.expected = sizeof...(P);
@@ -741,13 +741,13 @@ void call_with_variant_args_static_ret(R (*p_method)(P...), const Variant **p_ar
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 	call_with_variant_args_static_ret<R, P...>(p_method, p_args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
 template <typename... P>
 void call_with_variant_args_static(void (*p_method)(P...), const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
 		r_error.expected = sizeof...(P);
@@ -759,13 +759,13 @@ void call_with_variant_args_static(void (*p_method)(P...), const Variant **p_arg
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 	call_with_variant_args_static<P...>(p_method, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
 template <typename T, typename R, typename... P>
 void call_with_variant_args_retc(T *p_instance, R (T::*p_method)(P...) const, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
 		r_error.expected = sizeof...(P);
@@ -777,7 +777,7 @@ void call_with_variant_args_retc(T *p_instance, R (T::*p_method)(P...) const, co
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 	call_with_variant_args_retc_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
@@ -785,11 +785,11 @@ template <typename T, typename R, typename... P, size_t... Is>
 void call_with_variant_args_retc_static_helper(T *p_instance, R (*p_method)(T *, P...), const Variant **p_args, Variant &r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	r_ret = (p_method)(p_instance, VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
 #else
 	r_ret = (p_method)(p_instance, VariantCaster<P>::cast(*p_args[Is])...);
-#endif
+#endif // DEBUG_ENABLED
 
 	(void)p_args;
 }
@@ -802,7 +802,7 @@ void call_with_variant_args_retc_static_helper_dv(T *p_instance, R (*p_method)(T
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
 
@@ -813,7 +813,7 @@ void call_with_variant_args_retc_static_helper_dv(T *p_instance, R (*p_method)(T
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
 	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
@@ -831,11 +831,11 @@ template <typename T, typename... P, size_t... Is>
 void call_with_variant_args_static_helper(T *p_instance, void (*p_method)(T *, P...), const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	(p_method)(p_instance, VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
 #else
 	(p_method)(p_instance, VariantCaster<P>::cast(*p_args[Is])...);
-#endif
+#endif // DEBUG_ENABLED
 
 	(void)p_args;
 }
@@ -848,7 +848,7 @@ void call_with_variant_args_static_helper_dv(T *p_instance, void (*p_method)(T *
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
 
@@ -859,7 +859,7 @@ void call_with_variant_args_static_helper_dv(T *p_instance, void (*p_method)(T *
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
 	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
@@ -881,7 +881,7 @@ void call_with_variant_args_static_ret_dv(R (*p_method)(P...), const Variant **p
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
 
@@ -892,7 +892,7 @@ void call_with_variant_args_static_ret_dv(R (*p_method)(P...), const Variant **p
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
 	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
@@ -914,7 +914,7 @@ void call_with_variant_args_static_dv(void (*p_method)(P...), const Variant **p_
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
 
@@ -925,7 +925,7 @@ void call_with_variant_args_static_dv(void (*p_method)(P...), const Variant **p_
 		r_error.expected = sizeof...(P);
 		return;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
 	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1158,11 +1158,11 @@ struct _VariantCall {
 		HashMap<StringName, int64_t> value;
 #ifdef DEBUG_ENABLED
 		List<StringName> value_ordered;
-#endif
+#endif // DEBUG_ENABLED
 		HashMap<StringName, Variant> variant_value;
 #ifdef DEBUG_ENABLED
 		List<StringName> variant_value_ordered;
-#endif
+#endif // DEBUG_ENABLED
 	};
 
 	static ConstantData *constant_data;
@@ -1172,18 +1172,18 @@ struct _VariantCall {
 		ERR_FAIL_COND(constant_data[p_type].value.has(p_constant_name));
 		ERR_FAIL_COND(enum_data[p_type].value.has(p_constant_name));
 		ERR_FAIL_COND(enum_data[p_type].value_to_enum.has(p_constant_name));
-#endif
+#endif // DEBUG_ENABLED
 		constant_data[p_type].value[p_constant_name] = p_constant_value;
 #ifdef DEBUG_ENABLED
 		constant_data[p_type].value_ordered.push_back(p_constant_name);
-#endif
+#endif // DEBUG_ENABLED
 	}
 
 	static void add_variant_constant(int p_type, const StringName &p_constant_name, const Variant &p_constant_value) {
 		constant_data[p_type].variant_value[p_constant_name] = p_constant_value;
 #ifdef DEBUG_ENABLED
 		constant_data[p_type].variant_value_ordered.push_back(p_constant_name);
-#endif
+#endif // DEBUG_ENABLED
 	}
 
 	struct EnumData {
@@ -1198,7 +1198,7 @@ struct _VariantCall {
 		ERR_FAIL_COND(constant_data[p_type].value.has(p_enumeration_name));
 		ERR_FAIL_COND(enum_data[p_type].value.has(p_enumeration_name));
 		ERR_FAIL_COND(enum_data[p_type].value_to_enum.has(p_enumeration_name));
-#endif
+#endif // DEBUG_ENABLED
 		enum_data[p_type].value[p_enum_type_name][p_enumeration_name] = p_enum_value;
 		enum_data[p_type].value_to_enum[p_enumeration_name] = p_enum_type_name;
 	}
@@ -1246,11 +1246,11 @@ struct VariantBuiltInMethodInfo {
 
 		for (int i = 0; i < argument_count; i++) {
 			PropertyInfo pi;
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 			pi.name = argument_names[i];
 #else
 			pi.name = "arg" + itos(i + 1);
-#endif
+#endif // DEBUG_ENABLED
 			pi.type = (*get_argument_type)(i);
 			if (pi.type == Variant::NIL) {
 				pi.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
@@ -1290,9 +1290,9 @@ static void register_builtin_method(const Vector<String> &p_argnames, const Vect
 	imi.return_type = T::get_return_type();
 	imi.argument_count = T::get_argument_count();
 	imi.get_argument_type = T::get_argument_type;
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND(!imi.is_vararg && imi.argument_count != imi.argument_names.size());
-#endif
+#endif // DEBUG_ENABLED
 
 	builtin_method_info[T::get_base_type()].insert(name, imi);
 	builtin_method_names[T::get_base_type()].push_back(name);
@@ -1312,7 +1312,7 @@ void Variant::callp(const StringName &p_method, const Variant **p_args, int p_ar
 			return;
 		}
 
-#endif
+#endif // DEBUG_ENABLED
 		r_ret = _get_obj().obj->callp(p_method, p_args, p_argcount, r_error);
 
 	} else {
@@ -1343,7 +1343,7 @@ void Variant::call_const(const StringName &p_method, const Variant **p_args, int
 			return;
 		}
 
-#endif
+#endif // DEBUG_ENABLED
 		r_ret = _get_obj().obj->call_const(p_method, p_args, p_argcount, r_error);
 
 		//else if (type==Variant::METHOD) {
@@ -1442,12 +1442,12 @@ String Variant::get_builtin_method_argument_name(Variant::Type p_type, const Str
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, String());
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
 	ERR_FAIL_NULL_V(method, String());
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_INDEX_V(p_argument, method->argument_count, String());
 	return method->argument_names[p_argument];
 #else
 	return "arg" + itos(p_argument + 1);
-#endif
+#endif // DEBUG_ENABLED
 }
 
 Vector<Variant> Variant::get_builtin_method_default_arguments(Variant::Type p_type, const StringName &p_method) {
@@ -1549,7 +1549,7 @@ void Variant::get_constants_for_type(Variant::Type p_type, List<StringName> *p_c
 #else
 	for (const KeyValue<StringName, int64_t> &E : cd.value) {
 		p_constants->push_back(E.key);
-#endif
+#endif // DEBUG_ENABLED
 	}
 
 #ifdef DEBUG_ENABLED
@@ -1558,7 +1558,7 @@ void Variant::get_constants_for_type(Variant::Type p_type, List<StringName> *p_c
 #else
 	for (const KeyValue<StringName, Variant> &E : cd.variant_value) {
 		p_constants->push_back(E.key);
-#endif
+#endif // DEBUG_ENABLED
 	}
 }
 
@@ -1667,7 +1667,7 @@ StringName Variant::get_enum_for_enumeration(Variant::Type p_type, const StringN
 	return (enum_name == nullptr) ? StringName() : *enum_name;
 }
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 #define bind_method(m_type, m_method, m_arg_names, m_default_args) \
 	METHOD_CLASS(m_type, m_method, &m_type::m_method);             \
 	register_builtin_method<Method_##m_type##_##m_method>(m_arg_names, m_default_args);
@@ -1675,9 +1675,9 @@ StringName Variant::get_enum_for_enumeration(Variant::Type p_type, const StringN
 #define bind_method(m_type, m_method, m_arg_names, m_default_args) \
 	METHOD_CLASS(m_type, m_method, &m_type ::m_method);            \
 	register_builtin_method<Method_##m_type##_##m_method>(sarray(), m_default_args);
-#endif
+#endif // DEBUG_ENABLED
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 #define bind_convert_method(m_type_from, m_type_to, m_method, m_arg_names, m_default_args) \
 	CONVERT_METHOD_CLASS(m_type_from, m_method, &m_type_to::m_method);                     \
 	register_builtin_method<Method_##m_type_from##_##m_method>(m_arg_names, m_default_args);
@@ -1685,9 +1685,9 @@ StringName Variant::get_enum_for_enumeration(Variant::Type p_type, const StringN
 #define bind_convert_method(m_type_from, m_type_to, m_method, m_arg_names, m_default_args) \
 	CONVERT_METHOD_CLASS(m_type_from, m_method, &m_type_to ::m_method);                    \
 	register_builtin_method<Method_##m_type_from##_##m_method>(sarray(), m_default_args);
-#endif
+#endif // DEBUG_ENABLED
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 #define bind_static_method(m_type, m_method, m_arg_names, m_default_args) \
 	STATIC_METHOD_CLASS(m_type, m_method, m_type::m_method);              \
 	register_builtin_method<Method_##m_type##_##m_method>(m_arg_names, m_default_args);
@@ -1695,9 +1695,9 @@ StringName Variant::get_enum_for_enumeration(Variant::Type p_type, const StringN
 #define bind_static_method(m_type, m_method, m_arg_names, m_default_args) \
 	STATIC_METHOD_CLASS(m_type, m_method, m_type ::m_method);             \
 	register_builtin_method<Method_##m_type##_##m_method>(sarray(), m_default_args);
-#endif
+#endif // DEBUG_ENABLED
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 #define bind_methodv(m_type, m_name, m_method, m_arg_names, m_default_args) \
 	METHOD_CLASS(m_type, m_name, m_method);                                 \
 	register_builtin_method<Method_##m_type##_##m_name>(m_arg_names, m_default_args);
@@ -1705,9 +1705,9 @@ StringName Variant::get_enum_for_enumeration(Variant::Type p_type, const StringN
 #define bind_methodv(m_type, m_name, m_method, m_arg_names, m_default_args) \
 	METHOD_CLASS(m_type, m_name, m_method);                                 \
 	register_builtin_method<Method_##m_type##_##m_name>(sarray(), m_default_args);
-#endif
+#endif // DEBUG_ENABLED
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 #define bind_convert_methodv(m_type_from, m_type_to, m_name, m_method, m_arg_names, m_default_args) \
 	CONVERT_METHOD_CLASS(m_type_from, m_name, m_method);                                            \
 	register_builtin_method<Method_##m_type_from##_##m_name>(m_arg_names, m_default_args);
@@ -1715,9 +1715,9 @@ StringName Variant::get_enum_for_enumeration(Variant::Type p_type, const StringN
 #define bind_convert_methodv(m_type_from, m_type_to, m_name, m_method, m_arg_names, m_default_args) \
 	CONVERT_METHOD_CLASS(m_type_from, m_name, m_method);                                            \
 	register_builtin_method<Method_##m_type_from##_##m_name>(sarray(), m_default_args);
-#endif
+#endif // DEBUG_ENABLED
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 #define bind_function(m_type, m_name, m_method, m_arg_names, m_default_args) \
 	FUNCTION_CLASS(m_type, m_name, m_method, true);                          \
 	register_builtin_method<Method_##m_type##_##m_name>(m_arg_names, m_default_args);
@@ -1725,9 +1725,9 @@ StringName Variant::get_enum_for_enumeration(Variant::Type p_type, const StringN
 #define bind_function(m_type, m_name, m_method, m_arg_names, m_default_args) \
 	FUNCTION_CLASS(m_type, m_name, m_method, true);                          \
 	register_builtin_method<Method_##m_type##_##m_name>(sarray(), m_default_args);
-#endif
+#endif // DEBUG_ENABLED
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 #define bind_functionnc(m_type, m_name, m_method, m_arg_names, m_default_args) \
 	FUNCTION_CLASS(m_type, m_name, m_method, false);                           \
 	register_builtin_method<Method_##m_type##_##m_name>(m_arg_names, m_default_args);
@@ -1735,7 +1735,7 @@ StringName Variant::get_enum_for_enumeration(Variant::Type p_type, const StringN
 #define bind_functionnc(m_type, m_name, m_method, m_arg_names, m_default_args) \
 	FUNCTION_CLASS(m_type, m_name, m_method, false);                           \
 	register_builtin_method<Method_##m_type##_##m_name>(sarray(), m_default_args);
-#endif
+#endif // DEBUG_ENABLED
 
 #define bind_string_method(m_method, m_arg_names, m_default_args) \
 	bind_method(String, m_method, m_arg_names, m_default_args);   \

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -104,11 +104,11 @@ class VariantConstructor {
 	static _FORCE_INLINE_ void construct_helper(T &base, const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
 		r_error.error = Callable::CallError::CALL_OK;
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 		base = T(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
 #else
 		base = T(VariantCaster<P>::cast(*p_args[Is])...);
-#endif
+#endif // DEBUG_ENABLED
 	}
 
 	template <size_t... Is>

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1159,13 +1159,13 @@ String VariantUtilityFunctions::join_string(const Variant **p_args, int p_arg_co
 	return s;
 }
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 #define VCALLR *ret = p_func(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...)
 #define VCALL p_func(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...)
 #else
 #define VCALLR *ret = p_func(VariantCaster<P>::cast(*p_args[Is])...)
 #define VCALL p_func(VariantCaster<P>::cast(*p_args[Is])...)
-#endif
+#endif // DEBUG_ENABLED
 
 template <typename R, typename... P, size_t... Is>
 static _FORCE_INLINE_ void call_helperpr(R (*p_func)(P...), Variant *ret, const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -69,11 +69,11 @@ static MethodInfo info_from_utility_func(const StringName &p_function) {
 	} else {
 		for (int i = 0; i < Variant::get_utility_function_argument_count(p_function); i++) {
 			PropertyInfo pi;
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 			pi.name = Variant::get_utility_function_argument_name(p_function, i);
 #else
 			pi.name = "arg" + itos(i + 1);
-#endif
+#endif // DEBUG_ENABLED
 			pi.type = Variant::get_utility_function_argument_type(p_function, i);
 			info.arguments.push_back(pi);
 		}
@@ -452,7 +452,7 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 			if (!parser->_is_tool && ext_parser->get_parser()->_is_tool) {
 				parser->push_warning(p_class, GDScriptWarning::MISSING_TOOL);
 			}
-#endif
+#endif // DEBUG_ENABLED
 
 			base = ext_parser->get_parser()->head->get_datatype();
 		} else {
@@ -486,7 +486,7 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 					if (!parser->_is_tool && base_parser->get_parser()->_is_tool) {
 						parser->push_warning(p_class, GDScriptWarning::MISSING_TOOL);
 					}
-#endif
+#endif // DEBUG_ENABLED
 
 					base = base_parser->get_parser()->head->get_datatype();
 				}
@@ -513,7 +513,7 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 				if (!parser->_is_tool && info_parser->get_parser()->_is_tool) {
 					parser->push_warning(p_class, GDScriptWarning::MISSING_TOOL);
 				}
-#endif
+#endif // DEBUG_ENABLED
 
 				base = info_parser->get_parser()->head->get_datatype();
 			} else if (class_exists(name)) {
@@ -1039,7 +1039,7 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 				}
 			}
 		}
-#endif
+#endif // DEBUG_ENABLED
 		switch (member.type) {
 			case GDScriptParser::ClassNode::Member::VARIABLE: {
 				bool previous_static_context = static_context;
@@ -1102,7 +1102,7 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 						}
 					}
 				}
-#endif
+#endif // DEBUG_ENABLED
 			} break;
 			case GDScriptParser::ClassNode::Member::CONSTANT: {
 				check_class_member_name_conflict(p_class, member.constant->identifier->name, member.constant);
@@ -1132,7 +1132,7 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 					if (param->datatype_specifier == nullptr) {
 						parser->push_warning(param, GDScriptWarning::UNTYPED_DECLARATION, "Parameter", param->identifier->name);
 					}
-#endif
+#endif // DEBUG_ENABLED
 					mi.arguments.push_back(param_type.to_property_info(param->identifier->name));
 					// Signals do not support parameter default values.
 				}
@@ -1185,7 +1185,7 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 					if (member.m_enum->identifier->name == StringName()) {
 						is_shadowing(element.identifier, "enum member", false);
 					}
-#endif
+#endif // DEBUG_ENABLED
 				}
 
 				current_enum = prev_enum;
@@ -1273,7 +1273,7 @@ void GDScriptAnalyzer::resolve_class_interface(GDScriptParser::ClassNode *p_clas
 	if (!p_class->resolved_interface) {
 #ifdef DEBUG_ENABLED
 		bool has_static_data = p_class->has_static_data;
-#endif
+#endif // DEBUG_ENABLED
 
 		if (!parser->has_class(p_class)) {
 			if (parser_ref.is_null()) {
@@ -1322,7 +1322,7 @@ void GDScriptAnalyzer::resolve_class_interface(GDScriptParser::ClassNode *p_clas
 					has_static_data = member.m_class->has_static_data;
 				}
 			}
-#endif
+#endif // DEBUG_ENABLED
 		}
 
 #ifdef DEBUG_ENABLED
@@ -1336,7 +1336,7 @@ void GDScriptAnalyzer::resolve_class_interface(GDScriptParser::ClassNode *p_clas
 			}
 			parser->push_warning(static_unload ? static_unload : p_class, GDScriptWarning::REDUNDANT_STATIC_UNLOAD);
 		}
-#endif
+#endif // DEBUG_ENABLED
 	}
 }
 
@@ -1443,7 +1443,7 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 			if (member.variable->usages == 0 && String(member.variable->identifier->name).begins_with("_")) {
 				parser->push_warning(member.variable->identifier, GDScriptWarning::UNUSED_PRIVATE_CLASS_VARIABLE, member.variable->identifier->name);
 			}
-#endif
+#endif // DEBUG_ENABLED
 
 			if (member.variable->property == GDScriptParser::VariableNode::PROP_SETGET) {
 				GDScriptParser::FunctionNode *getter_function = nullptr;
@@ -1477,7 +1477,7 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 							if (member.variable->datatype.builtin_type == Variant::INT && return_datatype.builtin_type == Variant::FLOAT) {
 								parser->push_warning(member.variable, GDScriptWarning::NARROWING_CONVERSION);
 							}
-#endif
+#endif // DEBUG_ENABLED
 						}
 					}
 				}
@@ -1503,7 +1503,7 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 						if (member.variable->datatype.builtin_type == Variant::FLOAT && setter_function->parameters[0]->datatype.builtin_type == Variant::INT) {
 							parser->push_warning(member.variable, GDScriptWarning::NARROWING_CONVERSION);
 						}
-#endif
+#endif // DEBUG_ENABLED
 					}
 				}
 
@@ -1518,7 +1518,7 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 			if (member.signal->usages == 0) {
 				parser->push_warning(member.signal->identifier, GDScriptWarning::UNUSED_SIGNAL, member.signal->identifier->name);
 			}
-#endif
+#endif // DEBUG_ENABLED
 		}
 	}
 
@@ -1662,7 +1662,7 @@ void GDScriptAnalyzer::resolve_annotation(GDScriptParser::AnnotationNode *p_anno
 			if (argument_info.type == Variant::INT && value.get_type() == Variant::FLOAT) {
 				parser->push_warning(argument, GDScriptWarning::NARROWING_CONVERSION);
 			}
-#endif
+#endif // DEBUG_ENABLED
 
 			if (!Variant::can_convert_strict(value.get_type(), argument_info.type)) {
 				push_error(vformat(R"(Invalid argument for annotation "%s": argument %d should be "%s" but is "%s".)", p_annotation->name, i + 1, Variant::get_type_name(argument_info.type), argument->get_datatype().to_string()), argument);
@@ -1735,7 +1735,7 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 	if (function_name == StringName()) {
 		function_visible_name = p_is_lambda ? "<anonymous lambda>" : "<unknown function>";
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	for (int i = 0; i < p_function->parameters.size(); i++) {
 		resolve_parameter(p_function->parameters[i]);
@@ -1879,7 +1879,7 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 			if (native_base != StringName()) {
 				parser->push_warning(p_function, GDScriptWarning::NATIVE_METHOD_OVERRIDE, function_name, native_base);
 			}
-#endif
+#endif // DEBUG_ENABLED
 		}
 #endif // TOOLS_ENABLED
 	}
@@ -1888,7 +1888,7 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 	if (p_function->return_type == nullptr) {
 		parser->push_warning(p_function, GDScriptWarning::UNTYPED_DECLARATION, "Function", function_visible_name);
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	method_info.default_arguments.append_array(p_function->default_arg_values);
 	method_info.return_val = p_function->get_datatype().to_property_info("");
@@ -1984,7 +1984,7 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 			parser->push_warning(p_assignable->identifier, GDScriptWarning::CONFUSABLE_LOCAL_DECLARATION, local.get_name(), p_assignable->identifier->name);
 		}
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	GDScriptParser::DataType specified_type;
 	bool has_specified_type = p_assignable->datatype_specifier != nullptr;
@@ -2034,7 +2034,7 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 			if (initializer_type.is_hard_type() && initializer_type.is_variant()) {
 				parser->push_warning(p_assignable, GDScriptWarning::INFERENCE_ON_VARIANT, p_kind);
 			}
-#endif
+#endif // DEBUG_ENABLED
 		} else {
 			if (!initializer_type.is_set()) {
 				push_error(vformat(R"(Could not resolve type for %s "%s".)", p_kind, p_assignable->identifier->name), p_assignable->initializer);
@@ -2072,7 +2072,7 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 #ifdef DEBUG_ENABLED
 			} else if (specified_type.builtin_type == Variant::INT && initializer_type.builtin_type == Variant::FLOAT) {
 				parser->push_warning(p_assignable->initializer, GDScriptWarning::NARROWING_CONVERSION);
-#endif
+#endif // DEBUG_ENABLED
 			}
 		}
 	}
@@ -2104,7 +2104,7 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 			parser->push_warning(p_assignable, GDScriptWarning::ENUM_VARIABLE_WITHOUT_DEFAULT, p_assignable->identifier->name);
 		}
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	type.is_constant = is_constant;
 	type.is_read_only = false;
@@ -2122,7 +2122,7 @@ void GDScriptAnalyzer::resolve_variable(GDScriptParser::VariableNode *p_variable
 		}
 	}
 	is_shadowing(p_variable->identifier, kind, p_is_local);
-#endif
+#endif // DEBUG_ENABLED
 }
 
 void GDScriptAnalyzer::resolve_constant(GDScriptParser::ConstantNode *p_constant, bool p_is_local) {
@@ -2136,7 +2136,7 @@ void GDScriptAnalyzer::resolve_constant(GDScriptParser::ConstantNode *p_constant
 		}
 	}
 	is_shadowing(p_constant->identifier, kind, p_is_local);
-#endif
+#endif // DEBUG_ENABLED
 }
 
 void GDScriptAnalyzer::resolve_parameter(GDScriptParser::ParameterNode *p_parameter) {
@@ -2326,7 +2326,7 @@ void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 			} else {
 				parser->push_warning(p_for->variable, GDScriptWarning::UNTYPED_DECLARATION, R"("for" iterator variable)", p_for->variable->name);
 			}
-#endif
+#endif // DEBUG_ENABLED
 		}
 	}
 
@@ -2336,7 +2336,7 @@ void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 	if (p_for->variable) {
 		is_shadowing(p_for->variable, R"("for" iterator variable)", true);
 	}
-#endif
+#endif // DEBUG_ENABLED
 }
 
 void GDScriptAnalyzer::resolve_while(GDScriptParser::WhileNode *p_while) {
@@ -2365,7 +2365,7 @@ void GDScriptAnalyzer::resolve_assert(GDScriptParser::AssertNode *p_assert) {
 			parser->push_warning(p_assert->condition, GDScriptWarning::ASSERT_ALWAYS_FALSE);
 		}
 	}
-#endif
+#endif // DEBUG_ENABLED
 }
 
 void GDScriptAnalyzer::resolve_match(GDScriptParser::MatchNode *p_match) {
@@ -2444,7 +2444,7 @@ void GDScriptAnalyzer::resolve_match_pattern(GDScriptParser::PatternNode *p_matc
 			if (p_match_pattern->bind->usages == 0 && !String(p_match_pattern->bind->name).begins_with("_")) {
 				parser->push_warning(p_match_pattern->bind, GDScriptWarning::UNUSED_VARIABLE, p_match_pattern->bind->name);
 			}
-#endif
+#endif // DEBUG_ENABLED
 			break;
 		case GDScriptParser::PatternNode::PT_ARRAY:
 			for (int i = 0; i < p_match_pattern->array.size(); i++) {
@@ -2504,7 +2504,7 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 				String called_function_name = static_cast<GDScriptParser::CallNode *>(p_return->return_value)->function_name.operator String();
 #ifdef DEBUG_ENABLED
 				parser->push_warning(p_return, GDScriptWarning::UNSAFE_VOID_RETURN, function_name, called_function_name);
-#endif
+#endif // DEBUG_ENABLED
 				mark_node_unsafe(p_return);
 			} else if (!is_call) {
 				push_error("A void function cannot return a value.", p_return);
@@ -2547,7 +2547,7 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 #ifdef DEBUG_ENABLED
 		} else if (expected_type.builtin_type == Variant::INT && result.builtin_type == Variant::FLOAT) {
 			parser->push_warning(p_return, GDScriptWarning::NARROWING_CONVERSION);
-#endif
+#endif // DEBUG_ENABLED
 		}
 	}
 
@@ -2681,7 +2681,7 @@ static bool enum_has_value(const GDScriptParser::DataType p_type, int64_t p_valu
 	}
 	return false;
 }
-#endif
+#endif // DEBUG_ENABLED
 
 void GDScriptAnalyzer::update_const_expression_builtin_type(GDScriptParser::ExpressionNode *p_expression, const GDScriptParser::DataType &p_type, const char *p_usage, bool p_is_cast) {
 	if (p_expression->get_datatype() == p_type) {
@@ -2708,7 +2708,7 @@ void GDScriptAnalyzer::update_const_expression_builtin_type(GDScriptParser::Expr
 	if (p_type.kind == GDScriptParser::DataType::ENUM && value_type.builtin_type == Variant::INT && !enum_has_value(p_type, p_expression->reduced_value)) {
 		parser->push_warning(p_expression, GDScriptWarning::INT_AS_ENUM_WITHOUT_MATCH, p_usage, p_expression->reduced_value.stringify(), p_type.to_string());
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	if (value_type.builtin_type == p_type.builtin_type) {
 		p_expression->set_datatype(p_type);
@@ -2728,7 +2728,7 @@ void GDScriptAnalyzer::update_const_expression_builtin_type(GDScriptParser::Expr
 	if (p_type.builtin_type == Variant::INT && value_type.builtin_type == Variant::FLOAT) {
 		parser->push_warning(p_expression, GDScriptWarning::NARROWING_CONVERSION);
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	p_expression->reduced_value = converted_to;
 	p_expression->set_datatype(p_type);
@@ -2825,7 +2825,7 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 			id->variable_source->assignments++;
 		}
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	reduce_expression(p_assignment->assignee);
 
@@ -2865,7 +2865,7 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 			}
 		}
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	if (p_assignment->assigned_value == nullptr || p_assignment->assignee == nullptr) {
 		return;
@@ -3014,7 +3014,7 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 			parser->push_warning(p_assignment, GDScriptWarning::UNASSIGNED_VARIABLE_OP_ASSIGN, id->name, Variant::get_operator_name(p_assignment->variant_op));
 		}
 	}
-#endif
+#endif // DEBUG_ENABLED
 }
 
 void GDScriptAnalyzer::reduce_await(GDScriptParser::AwaitNode *p_await) {
@@ -3048,7 +3048,7 @@ void GDScriptAnalyzer::reduce_await(GDScriptParser::AwaitNode *p_await) {
 	if (!to_await_type.is_coroutine && !to_await_type.is_variant() && to_await_type.builtin_type != Variant::SIGNAL) {
 		parser->push_warning(p_await, GDScriptWarning::REDUNDANT_AWAIT);
 	}
-#endif
+#endif // DEBUG_ENABLED
 }
 
 void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_op) {
@@ -3072,7 +3072,7 @@ void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_o
 	if (p_binary_op->variant_op == Variant::OP_DIVIDE && left_type.builtin_type == Variant::INT && right_type.builtin_type == Variant::INT) {
 		parser->push_warning(p_binary_op, GDScriptWarning::INTEGER_DIVISION);
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	if (p_binary_op->left_operand->is_constant && p_binary_op->right_operand->is_constant) {
 		p_binary_op->is_constant = true;
@@ -3313,7 +3313,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 							expected_types += "\", or \"" + types[types.size() - 1];
 						}
 						parser->push_warning(p_call->arguments[0], GDScriptWarning::UNSAFE_CALL_ARGUMENT, "1", "constructor", function_name, expected_types, "Variant");
-#endif
+#endif // DEBUG_ENABLED
 						p_call->set_datatype(call_type);
 						return;
 					}
@@ -3344,7 +3344,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 							if (par_type.builtin_type == Variant::INT && arg_type.builtin_type == Variant::FLOAT && builtin_type != Variant::INT) {
 								parser->push_warning(p_call, GDScriptWarning::NARROWING_CONVERSION, function_name);
 							}
-#endif
+#endif // DEBUG_ENABLED
 						}
 					}
 
@@ -3362,7 +3362,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 									parser->push_warning(p_call->arguments[i], GDScriptWarning::UNSAFE_CALL_ARGUMENT, itos(i + 1), "constructor", function_name, par_type.to_string(), arg_type.to_string_strict());
 								}
 							}
-#endif
+#endif // DEBUG_ENABLED
 						}
 						match = true;
 						call_type = type_from_property(info.return_val);
@@ -3400,7 +3400,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 					}
 				}
 			}
-#endif
+#endif // DEBUG_ENABLED
 
 			p_call->set_datatype(call_type);
 			return;
@@ -3698,7 +3698,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 				} else if (!is_self && !(base_type.is_hard_type() && base_type.kind == GDScriptParser::DataType::BUILTIN)) {
 					parser->push_warning(p_call, GDScriptWarning::UNSAFE_METHOD_ACCESS, p_call->function_name, base_type.to_string());
 					mark_node_unsafe(p_call);
-#endif
+#endif // DEBUG_ENABLED
 				}
 			}
 		}
@@ -3762,7 +3762,7 @@ void GDScriptAnalyzer::reduce_cast(GDScriptParser::CastNode *p_cast) {
 			mark_node_unsafe(p_cast);
 #ifdef DEBUG_ENABLED
 			parser->push_warning(p_cast, GDScriptWarning::UNSAFE_CAST, cast_type.to_string());
-#endif
+#endif // DEBUG_ENABLED
 		} else {
 			bool valid = false;
 			if (op_type.builtin_type == Variant::INT && cast_type.kind == GDScriptParser::DataType::ENUM) {
@@ -4387,7 +4387,7 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 			if (p_identifier->variable_source && p_identifier->variable_source->assignments == 0 && !(p_identifier->get_datatype().is_hard_type() && p_identifier->get_datatype().kind == GDScriptParser::DataType::BUILTIN)) {
 				parser->push_warning(p_identifier, GDScriptWarning::UNASSIGNED_VARIABLE, p_identifier->name);
 			}
-#endif
+#endif // DEBUG_ENABLED
 			break;
 		case GDScriptParser::IdentifierNode::LOCAL_ITERATOR:
 			p_identifier->set_datatype(p_identifier->bind_source->get_datatype());
@@ -4409,7 +4409,7 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 	if (!found_source && p_identifier->suite != nullptr && p_identifier->suite->has_local(p_identifier->name)) {
 		parser->push_warning(p_identifier, GDScriptWarning::CONFUSABLE_LOCAL_USAGE, p_identifier->name);
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	// Not a local, so check members.
 
@@ -4831,7 +4831,7 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 				if (valid) {
 					parser->push_warning(p_subscript, GDScriptWarning::UNSAFE_PROPERTY_ACCESS, p_subscript->attribute->name, base_type.to_string());
 				}
-#endif
+#endif // DEBUG_ENABLED
 				result_type.kind = GDScriptParser::DataType::VARIANT;
 				mark_node_unsafe(p_subscript);
 			}
@@ -5127,7 +5127,7 @@ void GDScriptAnalyzer::reduce_ternary_op(GDScriptParser::TernaryOpNode *p_ternar
 				result.kind = GDScriptParser::DataType::VARIANT;
 #ifdef DEBUG_ENABLED
 				parser->push_warning(p_ternary_op, GDScriptWarning::INCOMPATIBLE_TERNARY);
-#endif
+#endif // DEBUG_ENABLED
 			}
 		}
 	}
@@ -5855,7 +5855,7 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::Node *p_source, bo
 		if (native_method && r_native_class) {
 			*r_native_class = native_method->get_instance_class();
 		}
-#endif
+#endif // DEBUG_ENABLED
 		return valid;
 	}
 
@@ -5911,7 +5911,7 @@ void GDScriptAnalyzer::validate_call_arg(const List<GDScriptParser::DataType> &p
 				mark_node_unsafe(p_call->arguments[i]);
 				parser->push_warning(p_call->arguments[i], GDScriptWarning::UNSAFE_CALL_ARGUMENT, itos(i + 1), "function", p_call->function_name, par_type.to_string(), arg_type.to_string_strict());
 			}
-#endif
+#endif // DEBUG_ENABLED
 		} else if (par_type.is_hard_type() && !is_type_compatible(par_type, arg_type, true)) {
 			if (!is_type_compatible(arg_type, par_type)) {
 				push_error(vformat(R"*(Invalid argument for "%s()" function: argument %d should be "%s" but is "%s".)*",
@@ -5922,12 +5922,12 @@ void GDScriptAnalyzer::validate_call_arg(const List<GDScriptParser::DataType> &p
 				// Supertypes are acceptable for dynamic compliance, but it's unsafe.
 				mark_node_unsafe(p_call);
 				parser->push_warning(p_call->arguments[i], GDScriptWarning::UNSAFE_CALL_ARGUMENT, itos(i + 1), "function", p_call->function_name, par_type.to_string(), arg_type.to_string_strict());
-#endif
+#endif // DEBUG_ENABLED
 			}
 #ifdef DEBUG_ENABLED
 		} else if (par_type.kind == GDScriptParser::DataType::BUILTIN && par_type.builtin_type == Variant::INT && arg_type.kind == GDScriptParser::DataType::BUILTIN && arg_type.builtin_type == Variant::FLOAT) {
 			parser->push_warning(p_call->arguments[i], GDScriptWarning::NARROWING_CONVERSION, p_call->function_name);
-#endif
+#endif // DEBUG_ENABLED
 		}
 	}
 }
@@ -6088,7 +6088,7 @@ bool GDScriptAnalyzer::is_type_compatible(const GDScriptParser::DataType &p_targ
 			}
 		}
 	}
-#endif
+#endif // DEBUG_ENABLED
 	return check_type_compatibility(p_target, p_source, p_allow_implicit_conversion, p_source_node);
 }
 
@@ -6260,7 +6260,7 @@ void GDScriptAnalyzer::mark_node_unsafe(const GDScriptParser::Node *p_node) {
 	for (int i = p_node->start_line; i <= p_node->end_line; i++) {
 		parser->unsafe_lines.insert(i);
 	}
-#endif
+#endif // DEBUG_ENABLED
 }
 
 void GDScriptAnalyzer::downgrade_node_type_source(GDScriptParser::Node *p_node) {
@@ -6376,7 +6376,7 @@ Error GDScriptAnalyzer::resolve_body() {
 #ifdef DEBUG_ENABLED
 	// Apply here, after all `@warning_ignore`s have been resolved and applied.
 	parser->apply_pending_warnings();
-#endif
+#endif // DEBUG_ENABLED
 
 	return parser->errors.is_empty() ? OK : ERR_PARSE_ERROR;
 }

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -30,7 +30,7 @@
 
 #include "class_db_api_json.h"
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 
 #include "core/config/project_settings.h"
 #include "core/io/file_access.h"
@@ -232,4 +232,4 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 	print_line(String() + "ClassDB API JSON written to: " + ProjectSettings::get_singleton()->globalize_path(p_output_file));
 }
 
-#endif // DEBUG_METHODS_ENABLED
+#endif // DEBUG_ENABLED

--- a/modules/mono/class_db_api_json.h
+++ b/modules/mono/class_db_api_json.h
@@ -30,14 +30,10 @@
 
 #pragma once
 
-// 'core/object/method_bind.h' defines DEBUG_METHODS_ENABLED, but it looks like we
-// cannot include it here. That's why we include it through 'core/object/class_db.h'.
+#ifdef DEBUG_ENABLED
+
 #include "core/object/class_db.h"
-
-#ifdef DEBUG_METHODS_ENABLED
-
-#include "core/string/ustring.h"
 
 void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api);
 
-#endif // DEBUG_METHODS_ENABLED
+#endif // DEBUG_ENABLED

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -39,9 +39,9 @@
 #include "utils/path_utils.h"
 #include "utils/string_utils.h"
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 #include "class_db_api_json.h"
-#endif
+#endif // DEBUG_ENABLED
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_internal_calls.h"
@@ -104,14 +104,14 @@ void CSharpLanguage::init() {
 		return;
 	}
 #endif
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	if (OS::get_singleton()->get_cmdline_args().find("--class-db-json")) {
 		class_db_api_to_json("user://class_db_api.json", ClassDB::API_CORE);
 #ifdef TOOLS_ENABLED
 		class_db_api_to_json("user://class_db_api_editor.json", ClassDB::API_EDITOR);
 #endif
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	GLOBAL_DEF("dotnet/project/assembly_name", "");
 #ifdef TOOLS_ENABLED
@@ -179,7 +179,7 @@ void CSharpLanguage::finalize() {
 			ERR_PRINT("Leaked unsafe reference to deleted object: " + itos(id));
 		}
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	memdelete(managed_callable_middleman);
 
@@ -518,7 +518,7 @@ void CSharpLanguage::post_unsafe_reference(Object *p_obj) {
 	MutexLock lock(unsafe_object_references_lock);
 	ObjectID id = p_obj->get_instance_id();
 	unsafe_object_references[id]++;
-#endif
+#endif // DEBUG_ENABLED
 }
 
 void CSharpLanguage::pre_unsafe_unreference(Object *p_obj) {
@@ -530,7 +530,7 @@ void CSharpLanguage::pre_unsafe_unreference(Object *p_obj) {
 	if (--elem->value == 0) {
 		unsafe_object_references.remove(elem);
 	}
-#endif
+#endif // DEBUG_ENABLED
 }
 
 void CSharpLanguage::frame() {
@@ -932,7 +932,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 #ifdef DEBUG_ENABLED
 				// If we reached here, the instantiated script must be a placeholder.
 				CRASH_COND(!obj->get_script_instance()->is_placeholder());
-#endif
+#endif // DEBUG_ENABLED
 			}
 		}
 
@@ -1117,7 +1117,7 @@ bool CSharpLanguage::setup_csharp_script_binding(CSharpScriptBinding &r_script_b
 		CSharpInstance *csharp_instance = CAST_CSHARP_INSTANCE(p_object->get_script_instance());
 		CRASH_COND(csharp_instance != nullptr && !csharp_instance->is_destructing_script_instance());
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	StringName type_name = p_object->get_class_name();
 
@@ -1140,7 +1140,7 @@ bool CSharpLanguage::setup_csharp_script_binding(CSharpScriptBinding &r_script_b
 
 #ifdef DEBUG_ENABLED
 	CRASH_COND(!r_script_binding.gchandle.is_released());
-#endif
+#endif // DEBUG_ENABLED
 
 	GCHandleIntPtr strong_gchandle =
 			GDMonoCache::managed_callbacks.ScriptManagerBridge_CreateManagedForGodotObjectBinding(
@@ -1194,8 +1194,8 @@ void CSharpLanguage::_instance_binding_free_callback(void *, void *, void *p_bin
 	if (GDMono::get_singleton() == nullptr) {
 #ifdef DEBUG_ENABLED
 		CRASH_COND(csharp_lang && !csharp_lang->script_bindings.is_empty());
-#endif
-		// Mono runtime finalized, all the gchandle bindings were already released
+#endif // DEBUG_ENABLED
+	   // Mono runtime finalized, all the gchandle bindings were already released
 		return;
 	}
 
@@ -1238,7 +1238,7 @@ GDExtensionBool CSharpLanguage::_instance_binding_reference_callback(void *p_tok
 
 #ifdef DEBUG_ENABLED
 	CRASH_COND(!rc_owner);
-#endif
+#endif // DEBUG_ENABLED
 
 	MonoGCHandleData &gchandle = script_binding.gchandle;
 
@@ -1331,7 +1331,7 @@ void *CSharpLanguage::get_instance_binding_with_setup(Object *p_object) {
 void *CSharpLanguage::get_existing_instance_binding(Object *p_object) {
 #ifdef DEBUG_ENABLED
 	CRASH_COND(p_object->has_instance_binding(p_object));
-#endif
+#endif // DEBUG_ENABLED
 	return get_instance_binding(p_object);
 }
 
@@ -1686,7 +1686,7 @@ bool CSharpInstance::_reference_owner_unsafe() {
 	CRASH_COND(!base_ref_counted);
 	CRASH_COND(owner == nullptr);
 	CRASH_COND(unsafe_referenced); // already referenced
-#endif
+#endif // DEBUG_ENABLED
 
 	// Unsafe refcount increment. The managed instance also counts as a reference.
 	// This way if the unmanaged world has no references to our owner
@@ -1706,7 +1706,7 @@ bool CSharpInstance::_unreference_owner_unsafe() {
 #ifdef DEBUG_ENABLED
 	CRASH_COND(!base_ref_counted);
 	CRASH_COND(owner == nullptr);
-#endif
+#endif // DEBUG_ENABLED
 
 	if (!unsafe_referenced) {
 		return false; // Already unreferenced
@@ -1754,7 +1754,7 @@ void CSharpInstance::mono_object_disposed(GCHandleIntPtr p_gchandle_to_free) {
 #ifdef DEBUG_ENABLED
 	CRASH_COND(base_ref_counted);
 	CRASH_COND(gchandle.is_released());
-#endif
+#endif // DEBUG_ENABLED
 	CSharpLanguage::get_singleton()->release_script_gchandle_thread_safe(p_gchandle_to_free, gchandle);
 }
 
@@ -1762,7 +1762,7 @@ void CSharpInstance::mono_object_disposed_baseref(GCHandleIntPtr p_gchandle_to_f
 #ifdef DEBUG_ENABLED
 	CRASH_COND(!base_ref_counted);
 	CRASH_COND(gchandle.is_released());
-#endif
+#endif // DEBUG_ENABLED
 
 	// Must make sure event signals are not left dangling
 	disconnect_event_signals();
@@ -1824,7 +1824,7 @@ void CSharpInstance::refcount_incremented() {
 #ifdef DEBUG_ENABLED
 	CRASH_COND(!base_ref_counted);
 	CRASH_COND(owner == nullptr);
-#endif
+#endif // DEBUG_ENABLED
 
 	RefCounted *rc_owner = Object::cast_to<RefCounted>(owner);
 
@@ -1855,7 +1855,7 @@ bool CSharpInstance::refcount_decremented() {
 #ifdef DEBUG_ENABLED
 	CRASH_COND(!base_ref_counted);
 	CRASH_COND(owner == nullptr);
-#endif
+#endif // DEBUG_ENABLED
 
 	RefCounted *rc_owner = Object::cast_to<RefCounted>(owner);
 
@@ -2011,7 +2011,7 @@ CSharpInstance::~CSharpInstance() {
 #ifdef DEBUG_ENABLED
 		// The "instance binding" holds a reference so the refcount should be at least 2 before `scope_keep_owner_alive` goes out of scope
 		CRASH_COND(rc_owner->get_reference_count() <= 1);
-#endif
+#endif // DEBUG_ENABLED
 	}
 
 	if (script.is_valid() && owner) {
@@ -2024,7 +2024,7 @@ CSharpInstance::~CSharpInstance() {
 		script->instances.remove(match);
 #else
 		script->instances.erase(owner);
-#endif
+#endif // DEBUG_ENABLED
 	}
 }
 
@@ -2076,7 +2076,7 @@ void GD_CLR_STDCALL CSharpScript::_add_property_info_list_callback(CSharpScript 
 
 #if defined(TOOLS_ENABLED) || defined(DEBUG_ENABLED)
 			p_script->exported_members_names.insert(name);
-#endif
+#endif // DEBUG_ENABLED
 		}
 	}
 }
@@ -2433,7 +2433,7 @@ Variant CSharpScript::_new(const Variant **p_args, int p_argcount, Callable::Cal
 ScriptInstance *CSharpScript::instance_create(Object *p_this) {
 #ifdef DEBUG_ENABLED
 	CRASH_COND(!valid);
-#endif
+#endif // DEBUG_ENABLED
 
 	StringName native_name;
 	GDMonoCache::managed_callbacks.ScriptManagerBridge_GetScriptNativeName(this, &native_name);
@@ -2588,7 +2588,7 @@ Error CSharpScript::reload(bool p_keep_state) {
 	if (valid) {
 #ifdef DEBUG_ENABLED
 		print_verbose("Found class for script " + get_path());
-#endif
+#endif // DEBUG_ENABLED
 
 		update_script_class_info(this);
 
@@ -2770,7 +2770,7 @@ CSharpScript::CSharpScript() {
 		MutexLock lock(CSharpLanguage::get_singleton()->script_instances_mutex);
 		CSharpLanguage::get_singleton()->script_list.add(&script_list);
 	}
-#endif
+#endif // DEBUG_ENABLED
 }
 
 CSharpScript::~CSharpScript() {
@@ -2779,7 +2779,7 @@ CSharpScript::~CSharpScript() {
 		MutexLock lock(CSharpLanguage::get_singleton()->script_instances_mutex);
 		CSharpLanguage::get_singleton()->script_list.remove(&script_list);
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	if (GDMonoCache::godot_api_cache_updated) {
 		GDMonoCache::managed_callbacks.ScriptManagerBridge_RemoveScriptBridge(this);
@@ -2787,13 +2787,13 @@ CSharpScript::~CSharpScript() {
 }
 
 void CSharpScript::get_members(HashSet<StringName> *p_members) {
-#if defined(TOOLS_ENABLED) || defined(DEBUG_ENABLED)
+#ifdef DEBUG_ENABLED
 	if (p_members) {
 		for (const StringName &member_name : exported_members_names) {
 			p_members->insert(member_name);
 		}
 	}
-#endif
+#endif // DEBUG_ENABLED
 }
 
 /*************** RESOURCE ***************/
@@ -2821,10 +2821,10 @@ Ref<Resource> ResourceFormatLoaderCSharpScript::load(const String &p_path, const
 		scr.instantiate();
 	}
 
-#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+#ifdef DEBUG_ENABLED
 	Error err = scr->load_source_code(real_path);
 	ERR_FAIL_COND_V_MSG(err != OK, Ref<Resource>(), "Cannot load C# script file '" + real_path + "'.");
-#endif
+#endif // DEBUG_ENABLED
 
 	// Only one instance of a C# script is allowed to exist.
 	ERR_FAIL_COND_V_MSG(!scr->get_path().is_empty() && scr->get_path() != p_original_path, Ref<Resource>(),

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -30,7 +30,7 @@
 
 #include "bindings_generator.h"
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 
 #include "../godotsharp_defs.h"
 #include "../utils/naming_utils.h"
@@ -5300,4 +5300,4 @@ void BindingsGenerator::handle_cmdline_args(const List<String> &p_cmdline_args) 
 	}
 }
 
-#endif
+#endif // DEBUG_ENABLED

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -30,14 +30,13 @@
 
 #pragma once
 
-#include "core/typedefs.h" // DEBUG_METHODS_ENABLED
-
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 
 #include "core/doc_data.h"
 #include "core/object/class_db.h"
 #include "core/string/string_builder.h"
 #include "core/string/ustring.h"
+#include "core/typedefs.h"
 #include "editor/doc_tools.h"
 #include "editor/editor_help.h"
 
@@ -873,4 +872,4 @@ public:
 	}
 };
 
-#endif
+#endif // DEBUG_ENABLED

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -585,7 +585,7 @@ static bool _on_core_api_assembly_loaded() {
 	debug = true;
 #else
 	debug = false;
-#endif
+#endif // DEBUG_ENABLED
 
 	GDMonoCache::managed_callbacks.GD_OnCoreApiAssemblyLoaded(debug);
 
@@ -690,13 +690,13 @@ void GDMono::_try_load_project_assembly() {
 #endif
 
 void GDMono::_init_godot_api_hashes() {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	get_api_core_hash();
 
 #ifdef TOOLS_ENABLED
 	get_api_editor_hash();
 #endif // TOOLS_ENABLED
-#endif // DEBUG_METHODS_ENABLED
+#endif // DEBUG_ENABLED
 }
 
 #ifdef TOOLS_ENABLED

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -76,9 +76,9 @@ class GDMono {
 	void _try_load_project_assembly();
 #endif
 
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	uint64_t api_core_hash = 0;
-#endif
+#endif // DEBUG_ENABLED
 #ifdef TOOLS_ENABLED
 	uint64_t api_editor_hash = 0;
 #endif
@@ -92,7 +92,7 @@ protected:
 	static GDMono *singleton;
 
 public:
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	uint64_t get_api_core_hash() {
 		if (api_core_hash == 0) {
 			api_core_hash = ClassDB::get_api_hash(ClassDB::API_CORE);
@@ -107,7 +107,7 @@ public:
 		return api_editor_hash;
 	}
 #endif // TOOLS_ENABLED
-#endif // DEBUG_METHODS_ENABLED
+#endif // DEBUG_ENABLED
 
 	_FORCE_INLINE_ static String get_expected_api_build_config() {
 #ifdef TOOLS_ENABLED
@@ -117,7 +117,7 @@ public:
 		return "Debug";
 #else
 		return "Release";
-#endif
+#endif // DEBUG_ENABLED
 #endif
 	}
 

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -407,13 +407,13 @@ void validate_property(const Context &p_context, const ExposedClass &p_class, co
 }
 
 void validate_argument(const Context &p_context, const ExposedClass &p_class, const String &p_owner_name, const String &p_owner_type, const ArgumentData &p_arg) {
-#ifdef DEBUG_METHODS_ENABLED
+#ifdef DEBUG_ENABLED
 	TEST_COND((p_arg.name.is_empty() || p_arg.name.begins_with("_unnamed_arg")),
 			vformat("Unnamed argument in position %d of %s '%s.%s'.", p_arg.position, p_owner_type, p_class.name, p_owner_name));
 
 	TEST_FAIL_COND((p_arg.name != "@varargs@" && !p_arg.name.is_valid_ascii_identifier()),
 			vformat("Invalid argument name '%s' of %s '%s.%s'.", p_arg.name, p_owner_type, p_class.name, p_owner_name));
-#endif // DEBUG_METHODS_ENABLED
+#endif // DEBUG_ENABLED
 
 	const ExposedClass *arg_class = p_context.find_exposed_class(p_arg.type);
 	if (arg_class) {


### PR DESCRIPTION
The macro `DEBUG_METHODS_ENABLED` is entirely redundant, serving no niche that isn't already fulfilled by the more ubiquitous and always-available `DEBUG_ENABLED`. This PR removes the former completely, because there's no risk of breaking backwards compatibility; A 1-to-1 replacement already exists with `DEBUG_ENABLED`, so anything using `DEBUG_METHODS_ENABLED` could just use `DEBUG_ENABLED` instead. Also adds `// DEBUG_ENABLED` to all `#endif` statements in the files that needed to be changed, because this is already a style pass so why not