### PR TITLE
Android: Don't request `CAMERA` permission on editor startup

### DIFF
--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -190,6 +190,8 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 			// The RECORD_AUDIO permission is requested when the "audio/driver/enable_input" project
 			// setting is enabled.
 			Manifest.permission.RECORD_AUDIO,
+			// The CAMERA permission is requested when `CameraFeed.feed_is_active` is enabled.
+			Manifest.permission.CAMERA,
 		)
 
 		excludedPermissions.add(


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
fixed #106461
Preventing the camera permission request on Android editor startup. Now, the permission prompt will only appear when `OS.request_permission("CAMERA")` is called in the editor.
relation: https://github.com/godotengine/godot/pull/106094#issuecomment-2884941303