### PR TITLE
Fix GridMap scenario crash when outside tree

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -83,7 +83,10 @@ bool GridMap::_set(const StringName &p_name, const Variant &p_value) {
 
 		Array meshes = p_value;
 
-		const RID scenario = get_world_3d()->get_scenario();
+		RID scenario;
+		if (is_inside_tree()) {
+			scenario = get_world_3d()->get_scenario();
+		}
 
 		for (int i = 0; i < meshes.size(); i++) {
 			BakedMesh bm;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/106451 GridMap scenario crash when outside tree.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
