### PR TITLE
[Android] Misc build fixes

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -269,8 +269,8 @@ task copyAndRenameBinary(type: Copy) {
  * Used to validate the version of the Java SDK used for the Godot gradle builds.
  */
 task validateJavaVersion {
-    if (JavaVersion.current() != versions.javaVersion) {
-        throw new GradleException("Invalid Java version ${JavaVersion.current()}. Version ${versions.javaVersion} is the required Java version for Godot gradle builds.")
+    if (!JavaVersion.current().isCompatibleWith(versions.javaVersion)) {
+        throw new GradleException("Invalid Java version ${JavaVersion.current()}. Version ${versions.javaVersion} is the minimum supported Java version for Godot gradle builds.")
     }
 }
 

--- a/platform/android/java/editor/src/horizonos/AndroidManifest.xml
+++ b/platform/android/java/editor/src/horizonos/AndroidManifest.xml
@@ -79,18 +79,6 @@
             android:value="quest3|questpro"
             tools:replace="android:value" />
 
-        <!--
-        We remove this meta-data originating from the vendors plugin as we only need the loader for
-        now since the project being edited provides its own version of the vendors plugin.
-
-        This needs to be removed once we start implementing the immersive version of the project
-        manager and editor windows.
-         -->
-        <meta-data
-            android:name="org.godotengine.plugin.v2.GodotOpenXRMeta"
-            android:value="org.godotengine.openxr.vendors.meta.GodotOpenXRMeta"
-            tools:node="remove" />
-
         <!-- Enable system splash screen -->
         <meta-data android:name="com.oculus.ossplash" android:value="true"/>
         <!-- Enable passthrough background during the splash screen -->

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -102,6 +102,18 @@
             android:resizeableActivity="false"
             android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
         </activity>
+
+        <!--
+        We remove this meta-data originating from the vendors plugin as we only need the loader for
+        now since the project being edited provides its own version of the vendors plugin.
+
+        This needs to be removed once we start implementing the immersive version of the project
+        manager and editor windows.
+         -->
+        <meta-data
+            android:name="org.godotengine.plugin.v2.GodotOpenXR"
+            android:value="org.godotengine.openxr.vendors.GodotOpenXR"
+            tools:node="remove" />
     </application>
 
 </manifest>

--- a/platform/android/java/editor/src/picoos/AndroidManifest.xml
+++ b/platform/android/java/editor/src/picoos/AndroidManifest.xml
@@ -38,18 +38,6 @@
             </intent-filter>
         </activity>
 
-        <!--
-        We remove this meta-data originating from the vendors plugin as we only need the loader for
-        now since the project being edited provides its own version of the vendors plugin.
-
-        This needs to be removed once we start implementing the immersive version of the project
-        manager and editor windows.
-         -->
-        <meta-data
-            android:name="org.godotengine.plugin.v2.GodotOpenXRPico"
-            android:value="org.godotengine.openxr.vendors.pico.GodotOpenXRPico"
-            tools:node="remove"/>
-
         <!-- Enable system splash screen. Passthrough splash screen is not supported yet-->
         <meta-data
             android:name="pvr.app.splash"


### PR DESCRIPTION
- Commit 1 loosens the check for the java version used for export. The previous logic is a strict check against Java 17; this PR updates the logic to support any java versions >= 17
- Commit 2 updates the manifest declaration for the XR build of the editor to match the latest version of the Godot OpenXR Vendor plugin (v4.0.0-stable)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
