### PR TITLE
Expose `get_rect` in AnimatedSprite2D

### DIFF
--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -11,6 +11,36 @@
 		<link title="2D Dodge The Creeps Demo">https://godotengine.org/asset-library/asset/2712</link>
 	</tutorials>
 	<methods>
+		<method name="get_rect" qualifiers="const">
+			<return type="Rect2" />
+			<description>
+				Returns a [Rect2] representing the AnimatedSprite2D's boundary in local coordinates.
+				[b]Example:[/b] Detect if the AnimatedSprite2D was clicked:
+				[codeblocks]
+				[gdscript]
+				func _input(event):
+				    if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+				        if get_rect().has_point(to_local(event.position)):
+				            print("A click!")
+				[/gdscript]
+				[csharp]
+				public override void _Input(InputEvent @event)
+				{
+				    if (@event is InputEventMouseButton inputEventMouse)
+				    {
+				        if (inputEventMouse.Pressed &amp;&amp; inputEventMouse.ButtonIndex == MouseButton.Left)
+				        {
+				            if (GetRect().HasPoint(ToLocal(inputEventMouse.Position)))
+				            {
+				                GD.Print("A click!");
+				            }
+				        }
+				    }
+				}
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="get_playing_speed" qualifiers="const">
 			<return type="float" />
 			<description>

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -60,7 +60,7 @@ bool AnimatedSprite2D::_edit_use_pivot() const {
 
 #ifdef DEBUG_ENABLED
 Rect2 AnimatedSprite2D::_edit_get_rect() const {
-	return _get_rect();
+	return get_rect();
 }
 
 bool AnimatedSprite2D::_edit_use_rect() const {
@@ -80,10 +80,10 @@ bool AnimatedSprite2D::_edit_use_rect() const {
 #endif // DEBUG_ENABLED
 
 Rect2 AnimatedSprite2D::get_anchorable_rect() const {
-	return _get_rect();
+	return get_rect();
 }
 
-Rect2 AnimatedSprite2D::_get_rect() const {
+Rect2 AnimatedSprite2D::get_rect() const {
 	if (frames.is_null() || !frames->has_animation(animation)) {
 		return Rect2();
 	}
@@ -171,7 +171,7 @@ void AnimatedSprite2D::_notification(int p_what) {
 			RID ae = get_accessibility_element();
 			ERR_FAIL_COND(ae.is_null());
 
-			Rect2 dst_rect = _get_rect();
+			Rect2 dst_rect = get_rect();
 
 			DisplayServer::get_singleton()->accessibility_update_set_role(ae, DisplayServer::AccessibilityRole::ROLE_IMAGE);
 			DisplayServer::get_singleton()->accessibility_update_set_transform(ae, get_transform());
@@ -657,6 +657,8 @@ void AnimatedSprite2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "speed_scale"), &AnimatedSprite2D::set_speed_scale);
 	ClassDB::bind_method(D_METHOD("get_speed_scale"), &AnimatedSprite2D::get_speed_scale);
 	ClassDB::bind_method(D_METHOD("get_playing_speed"), &AnimatedSprite2D::get_playing_speed);
+
+	ClassDB::bind_method(D_METHOD("get_rect"), &AnimatedSprite2D::get_rect);
 
 	ADD_SIGNAL(MethodInfo("sprite_frames_changed"));
 	ADD_SIGNAL(MethodInfo("animation_changed"));

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -60,8 +60,6 @@ class AnimatedSprite2D : public Node2D {
 	void _calc_frame_speed_scale();
 	void _stop_internal(bool p_reset);
 
-	Rect2 _get_rect() const;
-
 protected:
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -126,6 +124,8 @@ public:
 
 	void set_flip_v(bool p_flip);
 	bool is_flipped_v() const;
+
+	Rect2 get_rect() const;
 
 	PackedStringArray get_configuration_warnings() const override;
 


### PR DESCRIPTION
This PR exposes the `get_rect` function in AnimatedSprite2D that was previously only used internally so that it is consistently available between AnimatedSprite2D and other CanvasItem nodes like Sprite2D.

This shouldn't have any side effects since it's basically just a function name change and a method binding, and just makes people's lives easier if they need to get the rectangle of an AnimatedSprite2D (you don't need to manually calculate it anymore).