### PR TITLE
Fix IP `_resolve_hostname` for Unix

### DIFF
--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -83,6 +83,7 @@ void IPUnix::_resolve_hostname(List<IPAddress> &r_addresses, const String &p_hos
 		hints.ai_flags = AI_ADDRCONFIG;
 	}
 	hints.ai_flags &= ~AI_NUMERICHOST;
+	hints.ai_socktype = SOCK_STREAM;
 
 	int s = getaddrinfo(p_hostname.utf8().get_data(), nullptr, &hints, &result);
 	if (s != 0) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fix the implementation of `_resolve_hostname` for the unix ip driver.
Can resolve `.local` domains now using mDNS.
Fixes #101453