### PR TITLE
[Accessibility] Add dedicated auto-translation mode for names/descriptions.

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -1414,7 +1414,11 @@
 			Always automatically translate. This is the inverse of [constant AUTO_TRANSLATE_MODE_DISABLED], and the default for the root node.
 		</constant>
 		<constant name="AUTO_TRANSLATE_MODE_DISABLED" value="2" enum="AutoTranslateMode">
-			Never automatically translate. This is the inverse of [constant AUTO_TRANSLATE_MODE_ALWAYS].
+			Never automatically translate node content. [member accessibility_name] and [member accessibility_description] are still translated. This is the inverse of [constant AUTO_TRANSLATE_MODE_ALWAYS].
+			String parsing for POT generation will be skipped for this node and children that are set to [constant AUTO_TRANSLATE_MODE_INHERIT].
+		</constant>
+		<constant name="AUTO_TRANSLATE_MODE_DISABLED_INCLUDING_ACCESSIBILITY" value="3" enum="AutoTranslateMode">
+			Never automatically translate node content, [member accessibility_name], and [member accessibility_description].
 			String parsing for POT generation will be skipped for this node and children that are set to [constant AUTO_TRANSLATE_MODE_INHERIT].
 		</constant>
 	</constants>

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1748,7 +1748,6 @@ void ScriptEditor::_notification(int p_what) {
 		}
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			disk_changed_list->set_accessibility_name(TTR("The following files are newer on disk"));
 			[[fallthrough]];
 		}
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
@@ -4464,6 +4463,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 		disk_changed_list->set_hide_root(true);
 		disk_changed_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 		disk_changed_list->set_v_size_flags(SIZE_EXPAND_FILL);
+		disk_changed_list->set_accessibility_name(TTRC("The following files are newer on disk"));
 		vbc->add_child(disk_changed_list);
 
 		Label *what_action_label = memnew(Label);

--- a/modules/gdscript/tests/scripts/parser/features/export_variable.out
+++ b/modules/gdscript/tests/scripts/parser/features/export_variable.out
@@ -18,7 +18,7 @@ var test_node_path: NodePath = NodePath("hello")
 var test_side: Side = 0
   hint=ENUM hint_string="Side Left:0,Side Top:1,Side Right:2,Side Bottom:3" usage=DEFAULT|SCRIPT_VARIABLE|CLASS_IS_ENUM class_name=&"Side"
 var test_atm: Node.AutoTranslateMode = 0
-  hint=ENUM hint_string="Auto Translate Mode Inherit:0,Auto Translate Mode Always:1,Auto Translate Mode Disabled:2" usage=DEFAULT|SCRIPT_VARIABLE|CLASS_IS_ENUM class_name=&"Node.AutoTranslateMode"
+  hint=ENUM hint_string="Auto Translate Mode Inherit:0,Auto Translate Mode Always:1,Auto Translate Mode Disabled:2,Auto Translate Mode Disabled Including Accessibility:3" usage=DEFAULT|SCRIPT_VARIABLE|CLASS_IS_ENUM class_name=&"Node.AutoTranslateMode"
 var test_image: Image = null
   hint=RESOURCE_TYPE hint_string="Image" usage=DEFAULT|SCRIPT_VARIABLE class_name=&"Image"
 var test_timer: Timer = null
@@ -38,7 +38,7 @@ var test_array_array: Array = Array[Array]([])
 var test_array_side: Array = Array[int]([])
   hint=TYPE_STRING hint_string="<int>/<ENUM>:Side Left:0,Side Top:1,Side Right:2,Side Bottom:3" usage=DEFAULT|SCRIPT_VARIABLE class_name=&""
 var test_array_atm: Array = Array[int]([])
-  hint=TYPE_STRING hint_string="<int>/<ENUM>:Auto Translate Mode Inherit:0,Auto Translate Mode Always:1,Auto Translate Mode Disabled:2" usage=DEFAULT|SCRIPT_VARIABLE class_name=&""
+  hint=TYPE_STRING hint_string="<int>/<ENUM>:Auto Translate Mode Inherit:0,Auto Translate Mode Always:1,Auto Translate Mode Disabled:2,Auto Translate Mode Disabled Including Accessibility:3" usage=DEFAULT|SCRIPT_VARIABLE class_name=&""
 var test_array_image: Array = Array[Image]([])
   hint=TYPE_STRING hint_string="<Object>/<RESOURCE_TYPE>:Image" usage=DEFAULT|SCRIPT_VARIABLE class_name=&""
 var test_array_timer: Array = Array[Timer]([])

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1928,7 +1928,8 @@ String ItemList::_atr(int p_idx, const String &p_text) const {
 		case AUTO_TRANSLATE_MODE_ALWAYS: {
 			return tr(p_text);
 		} break;
-		case AUTO_TRANSLATE_MODE_DISABLED: {
+		case AUTO_TRANSLATE_MODE_DISABLED:
+		case AUTO_TRANSLATE_MODE_DISABLED_INCLUDING_ACCESSIBILITY: {
 			return p_text;
 		} break;
 	}

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -472,7 +472,8 @@ String OptionButton::_get_translated_text(const String &p_text) const {
 			case AUTO_TRANSLATE_MODE_ALWAYS: {
 				return tr(p_text);
 			} break;
-			case AUTO_TRANSLATE_MODE_DISABLED: {
+			case AUTO_TRANSLATE_MODE_DISABLED:
+			case AUTO_TRANSLATE_MODE_DISABLED_INCLUDING_ACCESSIBILITY: {
 				return p_text;
 			} break;
 		}

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3179,7 +3179,8 @@ String PopupMenu::_atr(int p_idx, const String &p_text) const {
 		case AUTO_TRANSLATE_MODE_ALWAYS: {
 			return tr(p_text);
 		} break;
-		case AUTO_TRANSLATE_MODE_DISABLED: {
+		case AUTO_TRANSLATE_MODE_DISABLED:
+		case AUTO_TRANSLATE_MODE_DISABLED_INCLUDING_ACCESSIBILITY: {
 			return p_text;
 		} break;
 	}

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -297,7 +297,8 @@ String TreeItem::atr(int p_column, const String &p_text) const {
 		case Node::AUTO_TRANSLATE_MODE_ALWAYS: {
 			return tree->tr(p_text);
 		} break;
-		case Node::AUTO_TRANSLATE_MODE_DISABLED: {
+		case Node::AUTO_TRANSLATE_MODE_DISABLED:
+		case Node::AUTO_TRANSLATE_MODE_DISABLED_INCLUDING_ACCESSIBILITY: {
 			return p_text;
 		} break;
 	}

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -122,6 +122,7 @@ public:
 		AUTO_TRANSLATE_MODE_INHERIT,
 		AUTO_TRANSLATE_MODE_ALWAYS,
 		AUTO_TRANSLATE_MODE_DISABLED,
+		AUTO_TRANSLATE_MODE_DISABLED_INCLUDING_ACCESSIBILITY,
 	};
 
 	struct Comparator {
@@ -262,6 +263,7 @@ private:
 
 		AutoTranslateMode auto_translate_mode = AUTO_TRANSLATE_MODE_INHERIT;
 		mutable bool is_auto_translating = true;
+		mutable bool is_auto_translating_ac = true;
 		mutable bool is_auto_translate_dirty = true;
 
 		mutable bool is_translation_domain_inherited = true;
@@ -809,12 +811,14 @@ public:
 	void set_auto_translate_mode(AutoTranslateMode p_mode);
 	AutoTranslateMode get_auto_translate_mode() const;
 	bool can_auto_translate() const;
+	bool can_auto_translate_accessibility() const;
 
 	virtual StringName get_translation_domain() const override;
 	virtual void set_translation_domain(const StringName &p_domain) override;
 	void set_translation_domain_inherited();
 
 	_FORCE_INLINE_ String atr(const String &p_message, const StringName &p_context = "") const { return can_auto_translate() ? tr(p_message, p_context) : p_message; }
+	_FORCE_INLINE_ String ac_atr(const String &p_message, const StringName &p_context = "") const { return can_auto_translate_accessibility() ? tr(p_message, p_context) : p_message; }
 	_FORCE_INLINE_ String atr_n(const String &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const {
 		if (can_auto_translate()) {
 			return tr_n(p_message, p_message_plural, p_n, p_context);


### PR DESCRIPTION
Some editor controls have auto-translation disabled, but this is relevant only for the control content, and almost never for the name and description.

This PR:
- Changes `AUTO_TRANSLATE_MODE_DISABLED` to keep translating `accessibility_name` and `accessibility_description`.
- Adds new mode to disable it for both control content and name/description.