### PR TITLE
Have the "Attach Node Script" dialog check for new languages

### DIFF
--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -110,6 +110,9 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	void _load_exist();
 	void _update_template_menu();
 	void _update_dialog();
+	void _update_language_menu();
+	void _update_language_menu_icon(int p_index, int p_icon_size);
+	Ref<Texture2D> _find_language_icon(int p_index, bool *p_update_icon_max_width) const;
 	ScriptLanguage::ScriptTemplate _get_current_template() const;
 	Vector<ScriptLanguage::ScriptTemplate> _get_user_templates(const ScriptLanguage *p_language, const StringName &p_object, const String &p_dir, const ScriptLanguage::TemplateLocation &p_origin) const;
 	ScriptLanguage::ScriptTemplate _parse_template(const ScriptLanguage *p_language, const String &p_path, const String &p_filename, const ScriptLanguage::TemplateLocation &p_origin, const String &p_inherits) const;


### PR DESCRIPTION
Closes #106480 

In addition:
 * Fixes an issue with the "Language" option icons not showing unless the theme updates.
 * Allows an icon to be configured using `@icon` on a `ScriptLanguageExtension` class implemented in GDScript.
