### PR TITLE
Jolt Physics: Improve performance for overlapping non-monitoring Area3Ds

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -60,6 +60,22 @@ JPH::ObjectLayer JoltArea3D::_get_object_layer() const {
 	return space->map_to_object_layer(_get_broad_phase_layer(), collision_layer, collision_mask);
 }
 
+void JoltArea3D::_make_body_kinematic() {
+	motion_type = JPH::EMotionType::Kinematic;
+	if (!in_space()) {
+		return;
+	}
+	space->get_body_iface().SetMotionType(jolt_body->GetID(), motion_type, JPH::EActivation::Activate);
+}
+
+void JoltArea3D::_make_body_static() {
+	motion_type = JPH::EMotionType::Static;
+	if (!in_space()) {
+		return;
+	}
+	space->get_body_iface().SetMotionType(jolt_body->GetID(), motion_type, JPH::EActivation::DontActivate);
+}
+
 void JoltArea3D::_add_to_space() {
 	jolt_shape = build_shapes(true);
 
@@ -73,6 +89,7 @@ void JoltArea3D::_add_to_space() {
 	jolt_settings->mMotionType = _get_motion_type();
 	jolt_settings->mIsSensor = true;
 	jolt_settings->mUseManifoldReduction = false;
+	jolt_settings->mAllowDynamicOrKinematic = true;
 	jolt_settings->mOverrideMassProperties = JPH::EOverrideMassProperties::MassAndInertiaProvided;
 	jolt_settings->mMassPropertiesOverride.mMass = 1.0f;
 	jolt_settings->mMassPropertiesOverride.mInertia = JPH::Mat44::sIdentity();
@@ -325,8 +342,10 @@ void JoltArea3D::_body_monitoring_changed() {
 
 void JoltArea3D::_area_monitoring_changed() {
 	if (has_area_monitor_callback()) {
+		_make_body_kinematic();
 		_force_areas_entered();
 	} else {
+		_make_body_static();
 		_force_areas_exited(false);
 	}
 }

--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -60,20 +60,12 @@ JPH::ObjectLayer JoltArea3D::_get_object_layer() const {
 	return space->map_to_object_layer(_get_broad_phase_layer(), collision_layer, collision_mask);
 }
 
-void JoltArea3D::_make_body_kinematic() {
-	motion_type = JPH::EMotionType::Kinematic;
+void JoltArea3D::_update_body_motion_type() const {
 	if (!in_space()) {
 		return;
 	}
-	space->get_body_iface().SetMotionType(jolt_body->GetID(), motion_type, JPH::EActivation::Activate);
-}
 
-void JoltArea3D::_make_body_static() {
-	motion_type = JPH::EMotionType::Static;
-	if (!in_space()) {
-		return;
-	}
-	space->get_body_iface().SetMotionType(jolt_body->GetID(), motion_type, JPH::EActivation::DontActivate);
+	space->get_body_iface().SetMotionType(jolt_body->GetID(), _get_motion_type(), JPH::EActivation::Activate);
 }
 
 void JoltArea3D::_add_to_space() {
@@ -338,16 +330,18 @@ void JoltArea3D::_body_monitoring_changed() {
 	} else {
 		_force_bodies_exited(false);
 	}
+
+	_update_body_motion_type();
 }
 
 void JoltArea3D::_area_monitoring_changed() {
 	if (has_area_monitor_callback()) {
-		_make_body_kinematic();
 		_force_areas_entered();
 	} else {
-		_make_body_static();
 		_force_areas_exited(false);
 	}
+
+	_update_body_motion_type();
 }
 
 void JoltArea3D::_monitorable_changed() {

--- a/modules/jolt_physics/objects/jolt_area_3d.h
+++ b/modules/jolt_physics/objects/jolt_area_3d.h
@@ -111,10 +111,15 @@ private:
 	bool monitorable = false;
 	bool point_gravity = false;
 
+	JPH::EMotionType motion_type = JPH::EMotionType::Kinematic;
+
 	virtual JPH::BroadPhaseLayer _get_broad_phase_layer() const override;
 	virtual JPH::ObjectLayer _get_object_layer() const override;
 
-	virtual JPH::EMotionType _get_motion_type() const override { return JPH::EMotionType::Kinematic; }
+	virtual JPH::EMotionType _get_motion_type() const override { return motion_type; }
+
+	void _make_body_kinematic();
+	void _make_body_static();
 
 	virtual void _add_to_space() override;
 

--- a/modules/jolt_physics/objects/jolt_area_3d.h
+++ b/modules/jolt_physics/objects/jolt_area_3d.h
@@ -111,15 +111,12 @@ private:
 	bool monitorable = false;
 	bool point_gravity = false;
 
-	JPH::EMotionType motion_type = JPH::EMotionType::Kinematic;
-
 	virtual JPH::BroadPhaseLayer _get_broad_phase_layer() const override;
 	virtual JPH::ObjectLayer _get_object_layer() const override;
 
-	virtual JPH::EMotionType _get_motion_type() const override { return motion_type; }
+	virtual JPH::EMotionType _get_motion_type() const override { return has_area_monitor_callback() || has_body_monitor_callback() ? JPH::EMotionType::Kinematic : JPH::EMotionType::Static; }
 
-	void _make_body_kinematic();
-	void _make_body_static();
+	void _update_body_motion_type() const;
 
 	virtual void _add_to_space() override;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This potentially fixes #106482 by toggling the `motion_type` of the underlying Jolt sensor body between `kinematic` and `static` based on the set `monitoring` callback.

