### PR TITLE
Fix script backtrace reporting wrong line numbers in release exports

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -583,6 +583,7 @@ public:
 
 	} strings;
 
+	_FORCE_INLINE_ bool should_track_call_stack() const { return track_call_stack; }
 	_FORCE_INLINE_ bool should_track_locals() const { return track_locals; }
 	_FORCE_INLINE_ int get_global_array_size() const { return global_array.size(); }
 	_FORCE_INLINE_ Variant *get_global_array() { return _global_array; }

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "gdscript.h"
 #include "gdscript_codegen.h"
 #include "gdscript_function.h"
 #include "gdscript_utility_functions.h"
@@ -74,7 +75,6 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 
 	bool ended = false;
 	GDScriptFunction *function = nullptr;
-	bool debug_stack = false;
 
 	Vector<int> opcodes;
 	List<RBMap<StringName, int>> stack_id_stack;
@@ -162,7 +162,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 			max_locals = locals.size();
 		}
 		stack_identifiers[p_id] = p_stackpos;
-		if (debug_stack) {
+		if (GDScriptLanguage::get_singleton()->should_track_locals()) {
 			block_identifiers[p_id] = p_stackpos;
 			GDScriptFunction::StackDebug sd;
 			sd.added = true;
@@ -176,7 +176,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	void push_stack_identifiers() {
 		stack_identifiers_counts.push_back(locals.size());
 		stack_id_stack.push_back(stack_identifiers);
-		if (debug_stack) {
+		if (GDScriptLanguage::get_singleton()->should_track_locals()) {
 			RBMap<StringName, int> block_ids(block_identifiers);
 			block_identifier_stack.push_back(block_ids);
 			block_identifiers.clear();
@@ -197,7 +197,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 			dirty_locals.insert(i + GDScriptFunction::FIXED_ADDRESSES_MAX);
 		}
 		locals.resize(current_locals);
-		if (debug_stack) {
+		if (GDScriptLanguage::get_singleton()->should_track_locals()) {
 			for (const KeyValue<StringName, int> &E : block_identifiers) {
 				GDScriptFunction::StackDebug sd;
 				sd.added = false;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1903,10 +1903,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 	for (int i = 0; i < p_block->statements.size(); i++) {
 		const GDScriptParser::Node *s = p_block->statements[i];
 
-#ifdef DEBUG_ENABLED
-		// Add a newline before each statement, since the debugger needs those.
 		gen->write_newline(s->start_line);
-#endif
 
 		switch (s->type) {
 			case GDScriptParser::Node::MATCH: {
@@ -1955,10 +1952,8 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 					// Add locals in block before patterns, so temporaries don't use the stack address for binds.
 					List<GDScriptCodeGenerator::Address> branch_locals = _add_block_locals(codegen, branch->block);
 
-#ifdef DEBUG_ENABLED
-					// Add a newline before each branch, since the debugger needs those.
 					gen->write_newline(branch->start_line);
-#endif
+
 					// For each pattern in branch.
 					GDScriptCodeGenerator::Address pattern_result = codegen.add_temporary();
 					for (int k = 0; k < branch->patterns.size(); k++) {
@@ -2367,7 +2362,6 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 			}
 
 			if (field->initializer) {
-				// Emit proper line change.
 				codegen.generator->write_newline(field->initializer->start_line);
 
 				GDScriptCodeGenerator::Address src_address = _parse_expression(codegen, r_error, field->initializer, false, true);
@@ -2562,7 +2556,6 @@ GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDS
 		}
 
 		if (field->initializer) {
-			// Emit proper line change.
 			codegen.generator->write_newline(field->initializer->start_line);
 
 			GDScriptCodeGenerator::Address src_address = _parse_expression(codegen, r_error, field->initializer, false, true);


### PR DESCRIPTION
In release exports, capturing script backtraces reports incorrect line numbers in GDScript, always pointing to the function signature. This PR fixes it by enabling adding line opcodes for projects with `always_track_call_stacks` enabled in the project setting.

Resolves #106484

Related PR:
- https://github.com/godotengine/godot/pull/91006

cc @mihe
