### PR TITLE
Add signals `node_added_to_group` and `node_removed_from_group` to `SceneTree`

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -299,6 +299,13 @@
 				Emitted when the [param node] enters this tree.
 			</description>
 		</signal>
+		<signal name="node_added_to_group">
+			<param index="0" name="group" type="StringName" />
+			<param index="1" name="node" type="Node" />
+			<description>
+				Emitted when the [param node] is added to the given [param group].
+			</description>
+		</signal>
 		<signal name="node_configuration_warning_changed">
 			<param index="0" name="node" type="Node" />
 			<description>
@@ -309,6 +316,13 @@
 			<param index="0" name="node" type="Node" />
 			<description>
 				Emitted when the [param node] exits this tree.
+			</description>
+		</signal>
+		<signal name="node_removed_from_group">
+			<param index="0" name="group" type="StringName" />
+			<param index="1" name="node" type="Node" />
+			<description>
+				Emitted when the [param node] is removed from the given [param group].
 			</description>
 		</signal>
 		<signal name="node_renamed">

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -171,6 +171,7 @@ SceneTree::Group *SceneTree::add_to_group(const StringName &p_group, Node *p_nod
 	ERR_FAIL_COND_V_MSG(E->value.nodes.has(p_node), &E->value, "Already in group: " + p_group + ".");
 	E->value.nodes.push_back(p_node);
 	E->value.changed = true;
+	emit_signal(SNAME("node_added_to_group"), p_group, p_node);
 	return &E->value;
 }
 
@@ -183,6 +184,7 @@ void SceneTree::remove_from_group(const StringName &p_group, Node *p_node) {
 	E->value.nodes.erase(p_node);
 	if (E->value.nodes.is_empty()) {
 		group_map.remove(E);
+		emit_signal(SNAME("node_removed_from_group"), p_group, p_node);
 	}
 }
 
@@ -1933,6 +1935,8 @@ void SceneTree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("node_added", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("node_removed", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("node_renamed", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
+	ADD_SIGNAL(MethodInfo("node_added_to_group", PropertyInfo(Variant::STRING_NAME, "group"), PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
+	ADD_SIGNAL(MethodInfo("node_removed_from_group", PropertyInfo(Variant::STRING_NAME, "group"), PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("node_configuration_warning_changed", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 
 	ADD_SIGNAL(MethodInfo("process_frame"));


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/1259
Adds signals `node_added_to_group` and `node_removed_from_group` to `SceneTree`.
The emitting of these signals is done in `SceneTree::add_to_group` and `SceneTree::remove_from_group`.

I based the name of these signals on `add_to_group` and `remove_from_group` found in both `SceneTree` and `Node`.