### PR TITLE
Web: Don't try to send process ID over the debugger

### DIFF
--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -141,9 +141,11 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, bo
 		}
 		singleton = memnew(RemoteDebugger(Ref<RemoteDebuggerPeer>(peer)));
 		script_debugger = memnew(ScriptDebugger);
+#ifndef WEB_ENABLED
 		// Notify editor of our pid (to allow focus stealing).
 		Array msg = { OS::get_singleton()->get_process_id() };
 		singleton->send_message("set_pid", msg);
+#endif
 	}
 	if (!singleton) {
 		return;


### PR DESCRIPTION
Silences an error about `OS::get_process_id()` not being implemented on Web.

I didn't check whether the editor expects to receive this message with a valid process ID, but in a quick test things seem to work, and previously the ID would be invalid anyway. Might still be worth a quick check from someone familiar with the debugger (cc @Faless ).