### PR TITLE
Fix crash on aot unloading

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -539,7 +539,8 @@ void GDMono::initialize() {
 		if (load_coreclr(coreclr_dll_handle)) {
 			godot_plugins_initialize = initialize_coreclr_and_godot_plugins(runtime_initialized);
 		} else {
-			godot_plugins_initialize = try_load_native_aot_library(hostfxr_dll_handle);
+			void *dll_handle = nullptr;
+			godot_plugins_initialize = try_load_native_aot_library(dll_handle);
 			if (godot_plugins_initialize != nullptr) {
 				runtime_initialized = true;
 			}


### PR DESCRIPTION
We are currently debugging why AOT build are crashing on ios devices.  In doing so, we tried to reproduce it on our Linux devices.  I'm unable to reproduce the ios crash on linux BUT I did discover a new crash on Linux.  I expect this issue applies to all platforms when exiting the application as well.  Anyways, the segfault is due to attempting to unload the .net aot dll on program exit.  .NET does not support this for aot builds.  Here's the issue confirming as such on the .net side:

https://github.com/dotnet/runtime/issues/79348

The fix is simple.  Don't unload aot dll's and just let them die with the process on program exit :)