### PR TITLE
Rework editor docks

### DIFF
--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorDock" inherits="MarginContainer" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Dockable container for the editor.
+	</brief_description>
+	<description>
+		EditorDock is a [Container] node that can be docked in one of the editor's dock slots. Docks are added by plugins to provide space for controls related to an [EditorPlugin]. The editor comes with a few built-in docks, such as the Scene dock, FileSystem dock, etc.
+		You can add a dock by using [method EditorPlugin.add_dock]. The dock can be customized by changing its properties.
+		[codeblock]
+		@tool
+		extends EditorPlugin
+
+		# Dock reference.
+		var dock
+
+		# Plugin initialization.
+		func _enter_tree():
+			dock = EditorDock.new()
+			dock.title = "My Dock"
+			dock.dock_icon = preload("./dock_icon.png")
+			dock.default_slot = EditorPlugin.DOCK_SLOT_RIGHT_UL
+			var dock_content = preload("./dock_content.tscn").instantiate()
+			dock.add_child(dock_content)
+			add_dock(dock)
+
+		# Plugin clean-up.
+		func _exit_tree():
+			remove_dock(dock)
+			dock.queue_free()
+			dock = null
+		[/codeblock]
+	</description>
+	<tutorials>
+		<link title="Making plugins">$DOCS_URL/tutorials/plugins/editor/making_plugins.html</link>
+	</tutorials>
+	<methods>
+		<method name="_load_layout_from_config" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="config" type="ConfigFile" />
+			<param index="1" name="section" type="String" />
+			<description>
+				Implement this method to handle loading this dock's layout. It's equivalent to [method EditorPlugin._set_window_layout]. [param section] is a unique section based on [member layout_key].
+			</description>
+		</method>
+		<method name="_save_layout_to_config" qualifiers="virtual const">
+			<return type="void" />
+			<param index="0" name="config" type="ConfigFile" />
+			<param index="1" name="section" type="String" />
+			<description>
+				Implement this method to handle saving this dock's layout. It's equivalent to [method EditorPlugin._get_window_layout]. [param section] is a unique section based on [member layout_key].
+			</description>
+		</method>
+		<method name="_update_layout" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="layout" type="int" />
+			<description>
+				Implement this method to handle the layout switching for this dock. [param layout] is one of the [enum DockLayout] constants.
+				[codeblock]
+				_update_layout(layout):
+					box_container.vertical = (layout == DOCK_LAYOUT_VERTICAL)
+				[/codeblock]
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="available_layouts" type="int" setter="set_available_layouts" getter="get_available_layouts" enum="EditorDock.DockLayout" is_bitfield="true" default="1">
+			The available layouts for this dock, as a bitmask.
+			If you want to make all layouts available, use [code]available_layouts = DOCK_LAYOUT_VERTICAL | DOCK_LAYOUT_HORIZONTAL[/code].
+		</member>
+		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" overrides="Control" default="true" />
+		<member name="default_slot" type="int" setter="set_default_slot" getter="get_default_slot" enum="EditorPlugin.DockSlot" default="-1">
+			The default dock slot used when adding the dock with [method EditorPlugin.add_dock].
+			After the dock is added, it can be moved to a different slot and the editor will automatically remember its position between sessions. If you remove and re-add the dock, it will be reset to default.
+		</member>
+		<member name="dock_icon" type="Texture2D" setter="set_dock_icon" getter="get_dock_icon">
+			The icon for the dock, as a texture. If specified, it will override [member icon_name].
+		</member>
+		<member name="dock_shortcut" type="Shortcut" setter="set_dock_shortcut" getter="get_dock_shortcut">
+			The shortcut used to open the dock. This property can only be set before this dock is added via [method EditorPlugin.add_dock].
+		</member>
+		<member name="icon_name" type="StringName" setter="set_icon_name" getter="get_icon_name" default="&amp;&quot;&quot;">
+			The icon for the dock, as a name from the [code]EditorIcons[/code] theme type in the editor theme. You can find the list of available icons [url=https://godot-editor-icons.github.io/]here[/url].
+		</member>
+		<member name="layout_key" type="String" setter="set_layout_key" getter="get_layout_key" default="&quot;&quot;">
+			The key representing this dock in the editor's layout file. If empty, the dock's displayed name will be used instead.
+		</member>
+		<member name="title" type="String" setter="set_title" getter="get_title" default="&quot;&quot;">
+			The title of the dock's tab. If empty, the dock's [member Node.name] will be used. If the name is auto-generated (contains [code]@[/code]), the first child's name will be used instead.
+		</member>
+	</members>
+	<constants>
+		<constant name="DOCK_LAYOUT_VERTICAL" value="1" enum="DockLayout" is_bitfield="true">
+			Allows placing the dock in the vertical dock slots on either side of the editor.
+			[b]Note:[/b] Currently this flag has no effect because the bottom panel is not a proper dock slot. This means that the dock can always be vertical.
+		</constant>
+		<constant name="DOCK_LAYOUT_HORIZONTAL" value="2" enum="DockLayout" is_bitfield="true">
+			Allows placing the dock in the editor's bottom panel. Implement [method _update_layout] to handle changing layouts.
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -430,7 +430,7 @@
 				When your plugin is deactivated, make sure to remove your custom control with [method remove_control_from_container] and free it with [method Node.queue_free].
 			</description>
 		</method>
-		<method name="add_control_to_dock">
+		<method name="add_control_to_dock" deprecated="Use [method add_dock] instead.">
 			<return type="void" />
 			<param index="0" name="slot" type="int" enum="EditorPlugin.DockSlot" />
 			<param index="1" name="control" type="Control" />
@@ -462,6 +462,14 @@
 			<param index="0" name="script" type="EditorDebuggerPlugin" />
 			<description>
 				Adds a [Script] as debugger plugin to the Debugger. The script must extend [EditorDebuggerPlugin].
+			</description>
+		</method>
+		<method name="add_dock">
+			<return type="void" />
+			<param index="0" name="dock" type="EditorDock" />
+			<description>
+				Adds a new dock.
+				When your plugin is deactivated, make sure to remove your custom dock with [method remove_dock] and free it with [method Node.queue_free].
 			</description>
 		</method>
 		<method name="add_export_platform">
@@ -655,7 +663,7 @@
 				Removes the control from the specified container. You have to manually [method Node.queue_free] the control.
 			</description>
 		</method>
-		<method name="remove_control_from_docks">
+		<method name="remove_control_from_docks" deprecated="Use [method remove_dock] instead.">
 			<return type="void" />
 			<param index="0" name="control" type="Control" />
 			<description>
@@ -674,6 +682,13 @@
 			<param index="0" name="script" type="EditorDebuggerPlugin" />
 			<description>
 				Removes the debugger plugin with given script from the Debugger.
+			</description>
+		</method>
+		<method name="remove_dock">
+			<return type="void" />
+			<param index="0" name="dock" type="EditorDock" />
+			<description>
+				Removes [param dock] from the available docks. You should manually call [method Node.queue_free] to free it.
 			</description>
 		</method>
 		<method name="remove_export_platform">
@@ -753,7 +768,7 @@
 				Removes a callback previously added by [method add_undo_redo_inspector_hook_callback].
 			</description>
 		</method>
-		<method name="set_dock_tab_icon">
+		<method name="set_dock_tab_icon" deprecated="Use [member EditorDock.dock_icon] instead.">
 			<return type="void" />
 			<param index="0" name="control" type="Control" />
 			<param index="1" name="icon" type="Texture2D" />
@@ -853,6 +868,9 @@
 		</constant>
 		<constant name="CONTAINER_PROJECT_SETTING_TAB_RIGHT" value="11" enum="CustomControlContainer">
 			Tab of Project Settings dialog, to the right of other tabs.
+		</constant>
+		<constant name="DOCK_SLOT_NONE" value="-1" enum="DockSlot">
+			The dock is closed.
 		</constant>
 		<constant name="DOCK_SLOT_LEFT_UL" value="0" enum="DockSlot">
 			Dock slot, left side, upper-left (empty in default layout).

--- a/doc/classes/FileSystemDock.xml
+++ b/doc/classes/FileSystemDock.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="FileSystemDock" inherits="VBoxContainer" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="FileSystemDock" inherits="EditorDock" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Godot editor's dock for managing files in the project.
 	</brief_description>

--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -1,0 +1,131 @@
+/**************************************************************************/
+/*  editor_dock.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_dock.h"
+
+#include "core/input/shortcut.h"
+#include "core/io/config_file.h"
+
+void EditorDock::_set_default_slot_bind(EditorPlugin::DockSlot p_slot) {
+	ERR_FAIL_COND(p_slot < EditorPlugin::DOCK_SLOT_NONE || p_slot >= EditorPlugin::DOCK_SLOT_MAX);
+	default_slot = (EditorDockManager::DockSlot)p_slot;
+}
+
+void EditorDock::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_title", "title"), &EditorDock::set_title);
+	ClassDB::bind_method(D_METHOD("get_title"), &EditorDock::get_title);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "title"), "set_title", "get_title");
+
+	ClassDB::bind_method(D_METHOD("set_layout_key", "layout_key"), &EditorDock::set_layout_key);
+	ClassDB::bind_method(D_METHOD("get_layout_key"), &EditorDock::get_layout_key);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "layout_key"), "set_layout_key", "get_layout_key");
+
+	ClassDB::bind_method(D_METHOD("set_icon_name", "icon_name"), &EditorDock::set_icon_name);
+	ClassDB::bind_method(D_METHOD("get_icon_name"), &EditorDock::get_icon_name);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "icon_name"), "set_icon_name", "get_icon_name");
+
+	ClassDB::bind_method(D_METHOD("set_dock_icon", "icon"), &EditorDock::set_dock_icon);
+	ClassDB::bind_method(D_METHOD("get_dock_icon"), &EditorDock::get_dock_icon);
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "dock_icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_dock_icon", "get_dock_icon");
+
+	ClassDB::bind_method(D_METHOD("set_dock_shortcut", "shortcut"), &EditorDock::set_dock_shortcut);
+	ClassDB::bind_method(D_METHOD("get_dock_shortcut"), &EditorDock::get_dock_shortcut);
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "dock_shortcut", PROPERTY_HINT_RESOURCE_TYPE, "ShortCut"), "set_dock_shortcut", "get_dock_shortcut");
+
+	ClassDB::bind_method(D_METHOD("set_default_slot", "slot"), &EditorDock::_set_default_slot_bind);
+	ClassDB::bind_method(D_METHOD("get_default_slot"), &EditorDock::_get_default_slot_bind);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "default_slot"), "set_default_slot", "get_default_slot");
+
+	ClassDB::bind_method(D_METHOD("set_available_layouts", "layouts"), &EditorDock::set_available_layouts);
+	ClassDB::bind_method(D_METHOD("get_available_layouts"), &EditorDock::get_available_layouts);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "available_layouts", PROPERTY_HINT_FLAGS, "Vertical:1,Horizontal:2"), "set_available_layouts", "get_available_layouts");
+
+	BIND_BITFIELD_FLAG(DOCK_LAYOUT_VERTICAL);
+	BIND_BITFIELD_FLAG(DOCK_LAYOUT_HORIZONTAL);
+
+	GDVIRTUAL_BIND(_update_layout, "layout");
+	GDVIRTUAL_BIND(_save_layout_to_config, "config", "section");
+	GDVIRTUAL_BIND(_load_layout_from_config, "config", "section");
+}
+
+EditorDock::EditorDock() {
+	set_clip_contents(true);
+	add_user_signal(MethodInfo("tab_style_changed"));
+}
+
+void EditorDock::set_title(const String &p_title) {
+	if (title == p_title) {
+		return;
+	}
+	title = p_title;
+	emit_signal("tab_style_changed");
+}
+
+void EditorDock::set_icon_name(const StringName &p_name) {
+	if (icon_name == p_name) {
+		return;
+	}
+	icon_name = p_name;
+	emit_signal("tab_style_changed");
+}
+
+void EditorDock::set_dock_icon(const Ref<Texture2D> &p_icon) {
+	if (dock_icon == p_icon) {
+		return;
+	}
+	dock_icon = p_icon;
+	emit_signal("tab_style_changed");
+}
+
+void EditorDock::set_default_slot(EditorDockManager::DockSlot p_slot) {
+	ERR_FAIL_INDEX(p_slot, EditorDockManager::DOCK_SLOT_MAX);
+	default_slot = p_slot;
+}
+
+String EditorDock::get_display_title() const {
+	if (!title.is_empty()) {
+		return title;
+	}
+
+	const String sname = get_name();
+	if (sname.contains_char('@')) {
+		// Auto-generated name, try to use something better.
+		const Node *child = get_child_count() > 0 ? get_child(0) : nullptr;
+		if (child) {
+			// In user plugins, the child will usually be dock's content and have a proper name.
+			return child->get_name();
+		}
+	}
+	return sname;
+}
+
+String EditorDock::get_effective_layout_key() const {
+	return layout_key.is_empty() ? get_display_title() : layout_key;
+}

--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -1,0 +1,113 @@
+/**************************************************************************/
+/*  editor_dock.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/docks/editor_dock_manager.h"
+#include "editor/plugins/editor_plugin.h"
+#include "scene/gui/margin_container.h"
+
+class ConfigFile;
+class Shortcut;
+class WindowWrapper;
+
+class EditorDock : public MarginContainer {
+	GDCLASS(EditorDock, MarginContainer);
+
+public:
+	enum DockLayout {
+		DOCK_LAYOUT_VERTICAL = 1,
+		DOCK_LAYOUT_HORIZONTAL = 2,
+	};
+
+private:
+	friend class EditorDockManager;
+	friend class DockContextPopup;
+
+	String title;
+	String layout_key;
+	StringName icon_name;
+	Ref<Texture2D> dock_icon;
+	Ref<Shortcut> shortcut;
+	EditorDockManager::DockSlot default_slot = EditorDockManager::DOCK_SLOT_NONE;
+
+	BitField<DockLayout> available_layouts = DOCK_LAYOUT_VERTICAL;
+
+	bool open = false;
+	bool enabled = true;
+	bool at_bottom = false;
+	int previous_tab_index = -1;
+	bool previous_at_bottom = false;
+	WindowWrapper *dock_window = nullptr;
+	int dock_slot_index = EditorDockManager::DOCK_SLOT_NONE;
+
+	void _set_default_slot_bind(EditorPlugin::DockSlot p_slot);
+	EditorPlugin::DockSlot _get_default_slot_bind() const { return (EditorPlugin::DockSlot)default_slot; }
+
+protected:
+	static void _bind_methods();
+
+	GDVIRTUAL1(_update_layout, int)
+	GDVIRTUAL2C(_save_layout_to_config, Ref<ConfigFile>, const String &)
+	GDVIRTUAL2(_load_layout_from_config, Ref<ConfigFile>, const String &)
+
+public:
+	EditorDock();
+
+	void set_title(const String &p_title);
+	String get_title() const { return title; }
+
+	void set_layout_key(const String &p_key) { layout_key = p_key; }
+	String get_layout_key() const { return layout_key; }
+
+	void set_icon_name(const StringName &p_name);
+	StringName get_icon_name() const { return icon_name; }
+
+	void set_dock_icon(const Ref<Texture2D> &p_icon);
+	Ref<Texture2D> get_dock_icon() const { return dock_icon; }
+
+	void set_dock_shortcut(const Ref<Shortcut> &p_shortcut) { shortcut = p_shortcut; }
+	Ref<Shortcut> get_dock_shortcut() const { return shortcut; }
+
+	void set_default_slot(EditorDockManager::DockSlot p_slot);
+	EditorDockManager::DockSlot get_default_slot() const { return default_slot; }
+
+	void set_available_layouts(BitField<DockLayout> p_layouts) { available_layouts = p_layouts; }
+	BitField<DockLayout> get_available_layouts() const { return available_layouts; }
+
+	String get_display_title() const;
+	String get_effective_layout_key() const;
+
+	virtual void update_layout(DockLayout p_layout) { GDVIRTUAL_CALL(_update_layout, p_layout); }
+	virtual void save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const { GDVIRTUAL_CALL(_save_layout_to_config, p_layout, p_section); }
+	virtual void load_layout_from_config(const Ref<ConfigFile> &p_layout, const String &p_section) { GDVIRTUAL_CALL(_load_layout_from_config, p_layout, p_section); }
+};
+
+VARIANT_BITFIELD_CAST(EditorDock::DockLayout);

--- a/editor/docks/editor_dock_manager.h
+++ b/editor/docks/editor_dock_manager.h
@@ -36,6 +36,7 @@
 class Button;
 class ConfigFile;
 class Control;
+class EditorDock;
 class PopupMenu;
 class TabBar;
 class TabContainer;
@@ -83,21 +84,7 @@ private:
 	friend class DockContextPopup;
 	friend class EditorDockDragHint;
 
-	struct DockInfo {
-		String title;
-		bool open = false;
-		bool enabled = true;
-		bool at_bottom = false;
-		int previous_tab_index = -1;
-		bool previous_at_bottom = false;
-		WindowWrapper *dock_window = nullptr;
-		int dock_slot_index = DOCK_SLOT_NONE;
-		Ref<Shortcut> shortcut;
-		Ref<Texture2D> icon; // Only used when `icon_name` is empty.
-		StringName icon_name;
-	};
-
-	static EditorDockManager *singleton;
+	static inline EditorDockManager *singleton = nullptr;
 
 	// To access splits easily by index.
 	Vector<DockSplitContainer *> vsplits;
@@ -106,38 +93,38 @@ private:
 	Vector<WindowWrapper *> dock_windows;
 	TabContainer *dock_slot[DOCK_SLOT_MAX];
 	EditorDockDragHint *dock_drag_rects[DOCK_SLOT_MAX];
-	HashMap<Control *, DockInfo> all_docks;
-	Control *dock_tab_dragged = nullptr;
+	LocalVector<EditorDock *> all_docks;
+	EditorDock *dock_tab_dragged = nullptr;
 	bool docks_visible = true;
 
 	DockContextPopup *dock_context_popup = nullptr;
 	PopupMenu *docks_menu = nullptr;
-	Vector<Control *> docks_menu_docks;
+	LocalVector<EditorDock *> docks_menu_docks;
 	Control *closed_dock_parent = nullptr;
 
-	Control *_get_dock_tab_dragged();
+	EditorDock *_get_dock_tab_dragged();
 	void _dock_drag_stopped();
 	void _dock_split_dragged(int p_offset);
 	void _dock_container_gui_input(const Ref<InputEvent> &p_input, TabContainer *p_dock_container);
-	void _bottom_dock_button_gui_input(const Ref<InputEvent> &p_input, Control *p_dock, Button *p_bottom_button);
+	void _bottom_dock_button_gui_input(const Ref<InputEvent> &p_input, EditorDock *p_dock, Button *p_bottom_button);
 	void _dock_container_update_visibility(TabContainer *p_dock_container);
 	void _update_layout();
 
 	void _docks_menu_option(int p_id);
 
 	void _window_close_request(WindowWrapper *p_wrapper);
-	Control *_close_window(WindowWrapper *p_wrapper);
-	void _open_dock_in_window(Control *p_dock, bool p_show_window = true, bool p_reset_size = false);
-	void _restore_dock_to_saved_window(Control *p_dock, const Dictionary &p_window_dump);
+	EditorDock *_close_window(WindowWrapper *p_wrapper);
+	void _open_dock_in_window(EditorDock *p_dock, bool p_show_window = true, bool p_reset_size = false);
+	void _restore_dock_to_saved_window(EditorDock *p_dock, const Dictionary &p_window_dump);
 
-	void _dock_move_to_bottom(Control *p_dock, bool p_visible);
-	void _dock_remove_from_bottom(Control *p_dock);
-	bool _is_dock_at_bottom(Control *p_dock);
+	void _dock_move_to_bottom(EditorDock *p_dock, bool p_visible);
+	void _dock_remove_from_bottom(EditorDock *p_dock);
+	bool _is_dock_at_bottom(EditorDock *p_dock);
 
-	void _move_dock_tab_index(Control *p_dock, int p_tab_index, bool p_set_current);
-	void _move_dock(Control *p_dock, Control *p_target, int p_tab_index = -1, bool p_set_current = true);
+	void _move_dock_tab_index(EditorDock *p_dock, int p_tab_index, bool p_set_current);
+	void _move_dock(EditorDock *p_dock, Control *p_target, int p_tab_index = -1, bool p_set_current = true);
 
-	void _update_tab_style(Control *p_dock);
+	void _update_tab_style(EditorDock *p_dock);
 
 public:
 	static EditorDockManager *get_singleton() { return singleton; }
@@ -156,22 +143,20 @@ public:
 	void save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
 	void load_docks_from_config(Ref<ConfigFile> p_layout, const String &p_section, bool p_first_load = false);
 
-	void set_dock_enabled(Control *p_dock, bool p_enabled);
-	void close_dock(Control *p_dock);
-	void open_dock(Control *p_dock, bool p_set_current = true);
-	void focus_dock(Control *p_dock);
+	void set_dock_enabled(EditorDock *p_dock, bool p_enabled);
+	void close_dock(EditorDock *p_dock);
+	void open_dock(EditorDock *p_dock, bool p_set_current = true);
+	void focus_dock(EditorDock *p_dock);
 
 	TabContainer *get_dock_tab_container(Control *p_dock) const;
 
-	void bottom_dock_show_placement_popup(const Rect2i &p_position, Control *p_dock);
+	void bottom_dock_show_placement_popup(const Rect2i &p_position, EditorDock *p_dock);
 
 	void set_docks_visible(bool p_show);
 	bool are_docks_visible() const;
 
-	void add_dock(Control *p_dock, const String &p_title = "", DockSlot p_slot = DOCK_SLOT_NONE, const Ref<Shortcut> &p_shortcut = nullptr, const StringName &p_icon_name = StringName());
-	void remove_dock(Control *p_dock);
-
-	void set_dock_tab_icon(Control *p_dock, const Ref<Texture2D> &p_icon);
+	void add_dock(EditorDock *p_dock);
+	void remove_dock(EditorDock *p_dock);
 
 	EditorDockManager();
 };
@@ -222,7 +207,7 @@ private:
 	Rect2 dock_select_rects[EditorDockManager::DOCK_SLOT_MAX];
 	int dock_select_rect_over_idx = -1;
 
-	Control *context_dock = nullptr;
+	EditorDock *context_dock = nullptr;
 
 	EditorDockManager *dock_manager = nullptr;
 
@@ -243,8 +228,8 @@ protected:
 
 public:
 	void select_current_dock_in_dock_slot(int p_dock_slot);
-	void set_dock(Control *p_dock);
-	Control *get_dock() const;
+	void set_dock(EditorDock *p_dock);
+	EditorDock *get_dock() const;
 	void docks_updated();
 
 	DockContextPopup();

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "editor/docks/editor_dock.h"
 #include "editor/file_system/dependency_editor.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/file_system/file_info.h"
@@ -44,6 +45,7 @@
 
 class CreateDialog;
 class EditorDirDialog;
+class HBoxContainer;
 class ItemList;
 class LineEdit;
 class ProgressBar;
@@ -51,6 +53,7 @@ class SceneCreateDialog;
 class ShaderCreateDialog;
 class DirectoryCreateDialog;
 class EditorResourceTooltipPlugin;
+class VBoxContainer;
 
 class FileSystemTree : public Tree {
 	virtual Control *make_custom_tooltip(const String &p_text) const;
@@ -78,8 +81,8 @@ public:
 	FileSystemList();
 };
 
-class FileSystemDock : public VBoxContainer {
-	GDCLASS(FileSystemDock, VBoxContainer);
+class FileSystemDock : public EditorDock {
+	GDCLASS(FileSystemDock, EditorDock);
 
 public:
 	enum FileListDisplayMode {
@@ -230,7 +233,7 @@ private:
 	int history_pos;
 	int history_max_size;
 
-	String current_path;
+	String current_path = "res://";
 	String select_after_scan;
 
 	bool updating_tree = false;
@@ -361,12 +364,6 @@ private:
 
 	void _change_bottom_dock_placement();
 
-	bool _can_dock_horizontal() const;
-	void _set_dock_horizontal(bool p_enable);
-
-	void _save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
-	void _load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section);
-
 private:
 	inline static FileSystemDock *singleton = nullptr;
 
@@ -376,6 +373,10 @@ public:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+
+	virtual void update_layout(EditorDock::DockLayout p_layout) override;
+	virtual void save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const override;
+	virtual void load_layout_from_config(const Ref<ConfigFile> &p_layout, const String &p_section) override;
 
 public:
 	static constexpr double ITEM_COLOR_SCALE = 1.75;

--- a/editor/docks/history_dock.cpp
+++ b/editor/docks/history_dock.cpp
@@ -34,6 +34,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/item_list.h"
@@ -175,14 +176,14 @@ void HistoryDock::refresh_version() {
 	action_list->set_current(idx);
 }
 
-void HistoryDock::_save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const {
-	p_layout->set_value(p_section, "dock_history_include_scene", current_scene_checkbox->is_pressed());
-	p_layout->set_value(p_section, "dock_history_include_global", global_history_checkbox->is_pressed());
+void HistoryDock::save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const {
+	p_layout->set_value(p_section, "include_scene", current_scene_checkbox->is_pressed());
+	p_layout->set_value(p_section, "include_global", global_history_checkbox->is_pressed());
 }
 
-void HistoryDock::_load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section) {
-	current_scene_checkbox->set_pressed_no_signal(p_layout->get_value(p_section, "dock_history_include_scene", true));
-	global_history_checkbox->set_pressed_no_signal(p_layout->get_value(p_section, "dock_history_include_global", true));
+void HistoryDock::load_layout_from_config(const Ref<ConfigFile> &p_layout, const String &p_section) {
+	current_scene_checkbox->set_pressed_no_signal(p_layout->get_value(p_section, "include_scene", true));
+	global_history_checkbox->set_pressed_no_signal(p_layout->get_value(p_section, "include_global", true));
 	refresh_history();
 }
 
@@ -234,20 +235,21 @@ void HistoryDock::_notification(int p_notification) {
 	}
 }
 
-void HistoryDock::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_save_layout_to_config"), &HistoryDock::_save_layout_to_config);
-	ClassDB::bind_method(D_METHOD("_load_layout_from_config"), &HistoryDock::_load_layout_from_config);
-}
-
 HistoryDock::HistoryDock() {
-	set_name("History");
+	set_name(TTRC("History"));
+	set_icon_name("History");
+	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_history", TTRC("Open History Dock")));
+	set_default_slot(EditorDockManager::DOCK_SLOT_RIGHT_UL);
 
 	ur_manager = EditorUndoRedoManager::get_singleton();
 	ur_manager->connect("history_changed", callable_mp(this, &HistoryDock::on_history_changed));
 	ur_manager->connect("version_changed", callable_mp(this, &HistoryDock::on_version_changed));
 
+	VBoxContainer *main_vb = memnew(VBoxContainer);
+	add_child(main_vb);
+
 	HBoxContainer *mode_hb = memnew(HBoxContainer);
-	add_child(mode_hb);
+	main_vb->add_child(mode_hb);
 
 	current_scene_checkbox = memnew(CheckBox);
 	mode_hb->add_child(current_scene_checkbox);
@@ -269,7 +271,7 @@ HistoryDock::HistoryDock() {
 
 	action_list = memnew(ItemList);
 	action_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	add_child(action_list);
+	main_vb->add_child(action_list);
 	action_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	action_list->connect(SceneStringName(item_selected), callable_mp(this, &HistoryDock::seek_history));
 }

--- a/editor/docks/history_dock.h
+++ b/editor/docks/history_dock.h
@@ -30,15 +30,15 @@
 
 #pragma once
 
-#include "scene/gui/box_container.h"
+#include "editor/docks/editor_dock.h"
 
 class CheckBox;
 class ConfigFile;
 class ItemList;
 class EditorUndoRedoManager;
 
-class HistoryDock : public VBoxContainer {
-	GDCLASS(HistoryDock, VBoxContainer);
+class HistoryDock : public EditorDock {
+	GDCLASS(HistoryDock, EditorDock);
 
 	EditorUndoRedoManager *ur_manager;
 	ItemList *action_list = nullptr;
@@ -54,12 +54,11 @@ class HistoryDock : public VBoxContainer {
 	void on_version_changed();
 	void refresh_version();
 
-	void _save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
-	void _load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section);
-
 protected:
 	void _notification(int p_notification);
-	static void _bind_methods();
+
+	virtual void save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const override;
+	virtual void load_layout_from_config(const Ref<ConfigFile> &p_layout, const String &p_section) override;
 
 public:
 	void seek_history(int p_index);

--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -35,9 +35,11 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/inspector/editor_resource_preview.h"
+#include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
+#include "scene/gui/box_container.h"
 
 class ImportDockParameters : public Object {
 	GDCLASS(ImportDockParameters, Object);
@@ -742,11 +744,17 @@ void ImportDock::initialize_import_options() const {
 
 ImportDock::ImportDock() {
 	singleton = this;
-	set_name("Import");
+	set_name(TTRC("Import"));
+	set_icon_name("FileAccess");
+	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_import", TTRC("Open Import Dock")));
+	set_default_slot(EditorDockManager::DOCK_SLOT_LEFT_UR);
+
+	VBoxContainer *main_vb = memnew(VBoxContainer);
+	add_child(main_vb);
 
 	content = memnew(VBoxContainer);
 	content->set_v_size_flags(SIZE_EXPAND_FILL);
-	add_child(content);
+	main_vb->add_child(content);
 	content->hide();
 
 	imported = memnew(Label);
@@ -819,7 +827,7 @@ ImportDock::ImportDock() {
 	select_a_resource->set_v_size_flags(SIZE_EXPAND_FILL);
 	select_a_resource->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	select_a_resource->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
-	add_child(select_a_resource);
+	main_vb->add_child(select_a_resource);
 }
 
 ImportDock::~ImportDock() {

--- a/editor/docks/import_dock.h
+++ b/editor/docks/import_dock.h
@@ -32,6 +32,7 @@
 
 #include "core/io/config_file.h"
 #include "core/io/resource_importer.h"
+#include "editor/docks/editor_dock.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/inspector/editor_inspector.h"
 #include "scene/gui/box_container.h"
@@ -41,8 +42,10 @@
 #include "scene/gui/popup_menu.h"
 
 class ImportDockParameters;
-class ImportDock : public VBoxContainer {
-	GDCLASS(ImportDock, VBoxContainer);
+class VBoxContainer;
+
+class ImportDock : public EditorDock {
+	GDCLASS(ImportDock, EditorDock);
 
 	Label *imported = nullptr;
 	OptionButton *import_as = nullptr;

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -40,10 +40,10 @@
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_object_selector.h"
 #include "editor/script/script_editor_plugin.h"
+#include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
-
-InspectorDock *InspectorDock::singleton = nullptr;
+#include "scene/gui/box_container.h"
 
 void InspectorDock::_prepare_menu() {
 	PopupMenu *menu = object_menu->get_popup();
@@ -707,14 +707,20 @@ void InspectorDock::shortcut_input(const Ref<InputEvent> &p_event) {
 
 InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	singleton = this;
-	set_name("Inspector");
+	set_name(TTRC("Inspector"));
+	set_icon_name("AnimationTrackList");
+	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_inspector", TTRC("Open Inspector Dock")));
+	set_default_slot(EditorDockManager::DOCK_SLOT_RIGHT_UL);
+
+	VBoxContainer *main_vb = memnew(VBoxContainer);
+	add_child(main_vb);
 
 	editor_data = &p_editor_data;
 
 	property_name_style = EditorPropertyNameProcessor::get_default_inspector_style();
 
 	HBoxContainer *general_options_hb = memnew(HBoxContainer);
-	add_child(general_options_hb);
+	main_vb->add_child(general_options_hb);
 
 	resource_new_button = memnew(Button);
 	resource_new_button->set_theme_type_variation("FlatMenuButton");
@@ -782,7 +788,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	history_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_select_history));
 
 	HBoxContainer *subresource_hb = memnew(HBoxContainer);
-	add_child(subresource_hb);
+	main_vb->add_child(subresource_hb);
 	object_selector = memnew(EditorObjectSelector(EditorNode::get_singleton()->get_editor_selection_history()));
 	object_selector->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	subresource_hb->add_child(object_selector);
@@ -801,7 +807,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	new_resource_dialog->connect("create", callable_mp(this, &InspectorDock::_resource_created));
 
 	HBoxContainer *property_tools_hb = memnew(HBoxContainer);
-	add_child(property_tools_hb);
+	main_vb->add_child(property_tools_hb);
 
 	search = memnew(LineEdit);
 	search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -818,14 +824,14 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	object_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_menu_option));
 
 	info = memnew(Button);
-	add_child(info);
+	main_vb->add_child(info);
 	info->set_clip_text(true);
 	info->set_accessibility_name(TTRC("Information"));
 	info->hide();
 	info->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_info_pressed));
 
 	unique_resources_confirmation = memnew(ConfirmationDialog);
-	add_child(unique_resources_confirmation);
+	main_vb->add_child(unique_resources_confirmation);
 
 	VBoxContainer *container = memnew(VBoxContainer);
 	unique_resources_confirmation->add_child(container);
@@ -852,12 +858,12 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	EditorNode::get_singleton()->get_gui_base()->add_child(info_dialog);
 
 	load_resource_dialog = memnew(EditorFileDialog);
-	add_child(load_resource_dialog);
+	main_vb->add_child(load_resource_dialog);
 	load_resource_dialog->set_current_dir("res://");
 	load_resource_dialog->connect("file_selected", callable_mp(this, &InspectorDock::_resource_file_selected));
 
 	inspector = memnew(EditorInspector);
-	add_child(inspector);
+	main_vb->add_child(inspector);
 	inspector->set_autoclear(true);
 	inspector->set_show_categories(true, true);
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/docks/inspector_dock.h
+++ b/editor/docks/inspector_dock.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "editor/docks/editor_dock.h"
 #include "editor/editor_data.h"
 #include "editor/gui/create_dialog.h"
 #include "editor/inspector/editor_inspector.h"
@@ -43,8 +44,8 @@
 class EditorFileDialog;
 class EditorObjectSelector;
 
-class InspectorDock : public VBoxContainer {
-	GDCLASS(InspectorDock, VBoxContainer);
+class InspectorDock : public EditorDock {
+	GDCLASS(InspectorDock, EditorDock);
 
 	enum MenuOptions {
 		RESOURCE_LOAD,
@@ -136,7 +137,7 @@ class InspectorDock : public VBoxContainer {
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 private:
-	static InspectorDock *singleton;
+	static inline InspectorDock *singleton = nullptr;
 
 public:
 	static InspectorDock *get_singleton() { return singleton; }

--- a/editor/docks/node_dock.cpp
+++ b/editor/docks/node_dock.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/config_file.h"
 #include "editor/scene/connections_dialog.h"
+#include "editor/settings/editor_command_palette.h"
 #include "editor/themes/editor_scale.h"
 
 void NodeDock::show_groups() {
@@ -48,12 +49,12 @@ void NodeDock::show_connections() {
 	connections->show();
 }
 
-void NodeDock::_save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const {
-	p_layout->set_value(p_section, "dock_node_current_tab", int(groups_button->is_pressed()));
+void NodeDock::save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const {
+	p_layout->set_value(p_section, "current_tab", int(groups_button->is_pressed()));
 }
 
-void NodeDock::_load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section) {
-	const int current_tab = p_layout->get_value(p_section, "dock_node_current_tab", 0);
+void NodeDock::load_layout_from_config(const Ref<ConfigFile> &p_layout, const String &p_section) {
+	const int current_tab = p_layout->get_value(p_section, "current_tab", 0);
 	if (select_a_node->is_visible()) {
 		if (current_tab == 0) {
 			groups_button->set_pressed_no_signal(false);
@@ -76,11 +77,6 @@ void NodeDock::_notification(int p_what) {
 			groups_button->set_button_icon(get_editor_theme_icon(SNAME("Groups")));
 		} break;
 	}
-}
-
-void NodeDock::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_save_layout_to_config"), &NodeDock::_save_layout_to_config);
-	ClassDB::bind_method(D_METHOD("_load_layout_from_config"), &NodeDock::_load_layout_from_config);
 }
 
 void NodeDock::update_lists() {
@@ -110,10 +106,16 @@ void NodeDock::set_node(Node *p_node) {
 
 NodeDock::NodeDock() {
 	singleton = this;
+	set_name(TTRC("Node"));
+	set_icon_name("Object");
+	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_node", TTRC("Open Node Dock")));
+	set_default_slot(EditorDockManager::DOCK_SLOT_RIGHT_UL);
 
-	set_name("Node");
+	VBoxContainer *main_vb = memnew(VBoxContainer);
+	add_child(main_vb);
+
 	mode_hb = memnew(HBoxContainer);
-	add_child(mode_hb);
+	main_vb->add_child(mode_hb);
 	mode_hb->hide();
 
 	connections_button = memnew(Button);
@@ -137,12 +139,12 @@ NodeDock::NodeDock() {
 	groups_button->connect(SceneStringName(pressed), callable_mp(this, &NodeDock::show_groups));
 
 	connections = memnew(ConnectionsDock);
-	add_child(connections);
+	main_vb->add_child(connections);
 	connections->set_v_size_flags(SIZE_EXPAND_FILL);
 	connections->hide();
 
 	groups = memnew(GroupsEditor);
-	add_child(groups);
+	main_vb->add_child(groups);
 	groups->set_v_size_flags(SIZE_EXPAND_FILL);
 	groups->hide();
 
@@ -154,7 +156,7 @@ NodeDock::NodeDock() {
 	select_a_node->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	select_a_node->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	select_a_node->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
-	add_child(select_a_node);
+	main_vb->add_child(select_a_node);
 }
 
 NodeDock::~NodeDock() {

--- a/editor/docks/node_dock.h
+++ b/editor/docks/node_dock.h
@@ -30,13 +30,14 @@
 
 #pragma once
 
+#include "editor/docks/editor_dock.h"
 #include "groups_editor.h"
 
 class ConfigFile;
 class ConnectionsDock;
 
-class NodeDock : public VBoxContainer {
-	GDCLASS(NodeDock, VBoxContainer);
+class NodeDock : public EditorDock {
+	GDCLASS(NodeDock, EditorDock);
 
 	Button *connections_button = nullptr;
 	Button *groups_button = nullptr;
@@ -48,9 +49,6 @@ class NodeDock : public VBoxContainer {
 
 	Label *select_a_node = nullptr;
 
-	void _save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
-	void _load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section);
-
 private:
 	inline static NodeDock *singleton = nullptr;
 
@@ -59,7 +57,9 @@ public:
 
 protected:
 	void _notification(int p_what);
-	static void _bind_methods();
+
+	virtual void save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const override;
+	virtual void load_layout_from_config(const Ref<ConfigFile> &p_layout, const String &p_section) override;
 
 public:
 	void set_node(Node *p_node);

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -55,6 +55,7 @@
 #include "editor/scene/rename_dialog.h"
 #include "editor/scene/reparent_dialog.h"
 #include "editor/script/script_editor_plugin.h"
+#include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_feature_profile.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/shader/shader_create_dialog.h"
@@ -62,6 +63,7 @@
 #include "scene/2d/node_2d.h"
 #include "scene/animation/animation_tree.h"
 #include "scene/audio/audio_stream_player.h"
+#include "scene/gui/box_container.h"
 #include "scene/gui/check_box.h"
 #include "scene/property_utils.h"
 #include "scene/resources/packed_scene.h"
@@ -4689,13 +4691,18 @@ void SceneTreeDock::_update_configuration_warning() {
 }
 
 SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selection, EditorData &p_editor_data) {
+	set_name(TTRC("Scene"));
+	set_icon_name("PackedScene");
+	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_scene", TTRC("Open Scene Dock")));
+	set_default_slot(EditorDockManager::DOCK_SLOT_LEFT_UR);
+
 	singleton = this;
-	set_name("Scene");
 	editor_data = &p_editor_data;
 	editor_selection = p_editor_selection;
 	scene_root = p_scene_root;
 
-	VBoxContainer *vbc = this;
+	VBoxContainer *vbc = memnew(VBoxContainer);
+	add_child(vbc);
 
 	HBoxContainer *filter_hbc = memnew(HBoxContainer);
 	filter_hbc->add_theme_constant_override("separate", 0);

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -30,22 +30,24 @@
 
 #pragma once
 
+#include "editor/docks/editor_dock.h"
 #include "editor/scene/scene_tree_editor.h"
 #include "editor/script/script_create_dialog.h"
-#include "scene/gui/box_container.h"
 #include "scene/resources/animation.h"
 
 class CheckBox;
 class EditorData;
 class EditorSelection;
+class HBoxContainer;
 class MenuButton;
 class RenameDialog;
 class ReparentDialog;
 class ShaderCreateDialog;
 class TextureRect;
+class VBoxContainer;
 
-class SceneTreeDock : public VBoxContainer {
-	GDCLASS(SceneTreeDock, VBoxContainer);
+class SceneTreeDock : public EditorDock {
+	GDCLASS(SceneTreeDock, EditorDock);
 
 	enum Tool {
 		TOOL_NEW,

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -33,6 +33,7 @@
 
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/editor_debugger_plugin.h"
+#include "editor/docks/editor_dock.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/docks/scene_tree_dock.h"
@@ -84,24 +85,48 @@ Button *EditorPlugin::add_control_to_bottom_panel(Control *p_control, const Stri
 	return EditorNode::get_bottom_panel()->add_item(p_title, p_control, p_shortcut);
 }
 
+#ifndef DISABLE_DEPRECATED
 void EditorPlugin::add_control_to_dock(DockSlot p_slot, Control *p_control, const Ref<Shortcut> &p_shortcut) {
 	ERR_FAIL_NULL(p_control);
-	EditorDockManager::get_singleton()->add_dock(p_control, String(), EditorDockManager::DockSlot(p_slot), p_shortcut);
+	ERR_FAIL_COND(legacy_docks.has(p_control));
+
+	EditorDock *dock = memnew(EditorDock);
+	dock->set_title(p_control->get_name());
+	dock->set_dock_shortcut(p_shortcut);
+	dock->set_default_slot((EditorDockManager::DockSlot)p_slot);
+	dock->add_child(p_control);
+	legacy_docks[p_control] = dock;
+
+	EditorDockManager::get_singleton()->add_dock(dock);
 }
 
 void EditorPlugin::remove_control_from_docks(Control *p_control) {
 	ERR_FAIL_NULL(p_control);
-	EditorDockManager::get_singleton()->remove_dock(p_control);
+	ERR_FAIL_COND(!legacy_docks.has(p_control));
+
+	EditorDockManager::get_singleton()->remove_dock(legacy_docks[p_control]);
+	legacy_docks[p_control]->queue_free();
+	legacy_docks.erase(p_control);
 }
+
+void EditorPlugin::set_dock_tab_icon(Control *p_control, const Ref<Texture2D> &p_icon) {
+	ERR_FAIL_NULL(p_control);
+	ERR_FAIL_COND(!legacy_docks.has(p_control));
+	legacy_docks[p_control]->set_dock_icon(p_icon);
+}
+#endif
 
 void EditorPlugin::remove_control_from_bottom_panel(Control *p_control) {
 	ERR_FAIL_NULL(p_control);
 	EditorNode::get_bottom_panel()->remove_item(p_control);
 }
 
-void EditorPlugin::set_dock_tab_icon(Control *p_control, const Ref<Texture2D> &p_icon) {
-	ERR_FAIL_NULL(p_control);
-	EditorDockManager::get_singleton()->set_dock_tab_icon(p_control, p_icon);
+void EditorPlugin::add_dock(EditorDock *p_dock) {
+	EditorDockManager::get_singleton()->add_dock(p_dock);
+}
+
+void EditorPlugin::remove_dock(EditorDock *p_dock) {
+	EditorDockManager::get_singleton()->remove_dock(p_dock);
 }
 
 void EditorPlugin::add_control_to_container(CustomControlContainer p_location, Control *p_control) {
@@ -588,19 +613,24 @@ void EditorPlugin::_notification(int p_what) {
 }
 
 void EditorPlugin::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_dock", "dock"), &EditorPlugin::add_dock);
+	ClassDB::bind_method(D_METHOD("remove_dock", "dock"), &EditorPlugin::remove_dock);
 	ClassDB::bind_method(D_METHOD("add_control_to_container", "container", "control"), &EditorPlugin::add_control_to_container);
 	ClassDB::bind_method(D_METHOD("add_control_to_bottom_panel", "control", "title", "shortcut"), &EditorPlugin::add_control_to_bottom_panel, DEFVAL(Ref<Shortcut>()));
-	ClassDB::bind_method(D_METHOD("add_control_to_dock", "slot", "control", "shortcut"), &EditorPlugin::add_control_to_dock, DEFVAL(Ref<Shortcut>()));
-	ClassDB::bind_method(D_METHOD("remove_control_from_docks", "control"), &EditorPlugin::remove_control_from_docks);
 	ClassDB::bind_method(D_METHOD("remove_control_from_bottom_panel", "control"), &EditorPlugin::remove_control_from_bottom_panel);
 	ClassDB::bind_method(D_METHOD("remove_control_from_container", "container", "control"), &EditorPlugin::remove_control_from_container);
-	ClassDB::bind_method(D_METHOD("set_dock_tab_icon", "control", "icon"), &EditorPlugin::set_dock_tab_icon);
 	ClassDB::bind_method(D_METHOD("add_tool_menu_item", "name", "callable"), &EditorPlugin::add_tool_menu_item);
 	ClassDB::bind_method(D_METHOD("add_tool_submenu_item", "name", "submenu"), &EditorPlugin::add_tool_submenu_item);
 	ClassDB::bind_method(D_METHOD("remove_tool_menu_item", "name"), &EditorPlugin::remove_tool_menu_item);
 	ClassDB::bind_method(D_METHOD("get_export_as_menu"), &EditorPlugin::get_export_as_menu);
 	ClassDB::bind_method(D_METHOD("add_custom_type", "type", "base", "script", "icon"), &EditorPlugin::add_custom_type);
 	ClassDB::bind_method(D_METHOD("remove_custom_type", "type"), &EditorPlugin::remove_custom_type);
+
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("add_control_to_dock", "slot", "control", "shortcut"), &EditorPlugin::add_control_to_dock, DEFVAL(Ref<Shortcut>()));
+	ClassDB::bind_method(D_METHOD("remove_control_from_docks", "control"), &EditorPlugin::remove_control_from_docks);
+	ClassDB::bind_method(D_METHOD("set_dock_tab_icon", "control", "icon"), &EditorPlugin::set_dock_tab_icon);
+#endif
 
 	ClassDB::bind_method(D_METHOD("add_autoload_singleton", "name", "path"), &EditorPlugin::add_autoload_singleton);
 	ClassDB::bind_method(D_METHOD("remove_autoload_singleton", "name"), &EditorPlugin::remove_autoload_singleton);
@@ -688,6 +718,7 @@ void EditorPlugin::_bind_methods() {
 	BIND_ENUM_CONSTANT(CONTAINER_PROJECT_SETTING_TAB_LEFT);
 	BIND_ENUM_CONSTANT(CONTAINER_PROJECT_SETTING_TAB_RIGHT);
 
+	BIND_ENUM_CONSTANT(DOCK_SLOT_NONE);
 	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_UL);
 	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_BL);
 	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_UR);

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/config_file.h"
+#include "editor/docks/editor_dock_manager.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/gui/control.h"
@@ -39,6 +40,7 @@ class Node3D;
 class Button;
 class PopupMenu;
 class EditorDebuggerPlugin;
+class EditorDock;
 class EditorExport;
 class EditorExportPlugin;
 class EditorExportPlatform;
@@ -65,6 +67,8 @@ class EditorPlugin : public Node {
 	String plugin_version;
 
 #ifndef DISABLE_DEPRECATED
+	static inline HashMap<Control *, EditorDock *> legacy_docks;
+
 	void _editor_project_settings_changed();
 #endif
 
@@ -85,15 +89,16 @@ public:
 	};
 
 	enum DockSlot {
-		DOCK_SLOT_LEFT_UL,
-		DOCK_SLOT_LEFT_BL,
-		DOCK_SLOT_LEFT_UR,
-		DOCK_SLOT_LEFT_BR,
-		DOCK_SLOT_RIGHT_UL,
-		DOCK_SLOT_RIGHT_BL,
-		DOCK_SLOT_RIGHT_UR,
-		DOCK_SLOT_RIGHT_BR,
-		DOCK_SLOT_MAX
+		DOCK_SLOT_NONE = EditorDockManager::DOCK_SLOT_NONE,
+		DOCK_SLOT_LEFT_UL = EditorDockManager::DOCK_SLOT_LEFT_UL,
+		DOCK_SLOT_LEFT_BL = EditorDockManager::DOCK_SLOT_LEFT_BL,
+		DOCK_SLOT_LEFT_UR = EditorDockManager::DOCK_SLOT_LEFT_UR,
+		DOCK_SLOT_LEFT_BR = EditorDockManager::DOCK_SLOT_LEFT_BR,
+		DOCK_SLOT_RIGHT_UL = EditorDockManager::DOCK_SLOT_RIGHT_UL,
+		DOCK_SLOT_RIGHT_BL = EditorDockManager::DOCK_SLOT_RIGHT_BL,
+		DOCK_SLOT_RIGHT_UR = EditorDockManager::DOCK_SLOT_RIGHT_UR,
+		DOCK_SLOT_RIGHT_BR = EditorDockManager::DOCK_SLOT_RIGHT_BR,
+		DOCK_SLOT_MAX = EditorDockManager::DOCK_SLOT_MAX
 	};
 
 	enum AfterGUIInput {
@@ -140,6 +145,10 @@ protected:
 	Button *_add_control_to_bottom_panel_compat_88081(Control *p_control, const String &p_title);
 	void _add_control_to_dock_compat_88081(DockSlot p_slot, Control *p_control);
 	static void _bind_compatibility_methods();
+
+	void add_control_to_dock(DockSlot p_slot, Control *p_control, const Ref<Shortcut> &p_shortcut = nullptr);
+	void remove_control_from_docks(Control *p_control);
+	void set_dock_tab_icon(Control *p_control, const Ref<Texture2D> &p_icon);
 #endif
 
 public:
@@ -148,11 +157,10 @@ public:
 	void add_control_to_container(CustomControlContainer p_location, Control *p_control);
 	void remove_control_from_container(CustomControlContainer p_location, Control *p_control);
 	Button *add_control_to_bottom_panel(Control *p_control, const String &p_title, const Ref<Shortcut> &p_shortcut = nullptr);
-	void add_control_to_dock(DockSlot p_slot, Control *p_control, const Ref<Shortcut> &p_shortcut = nullptr);
-	void remove_control_from_docks(Control *p_control);
 	void remove_control_from_bottom_panel(Control *p_control);
 
-	void set_dock_tab_icon(Control *p_control, const Ref<Texture2D> &p_icon);
+	void add_dock(EditorDock *p_dock);
+	void remove_dock(EditorDock *p_dock);
 
 	void add_tool_menu_item(const String &p_name, const Callable &p_callable);
 	void add_tool_submenu_item(const String &p_name, PopupMenu *p_submenu);

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -146,6 +146,7 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorTranslationParserPlugin);
 	GDREGISTER_CLASS(EditorImportPlugin);
 	GDREGISTER_CLASS(EditorScript);
+	GDREGISTER_CLASS(EditorDock);
 	GDREGISTER_CLASS(EditorSelection);
 	GDREGISTER_CLASS(EditorFileDialog);
 	GDREGISTER_CLASS(EditorSettings);

--- a/editor/settings/editor_layouts_dialog.cpp
+++ b/editor/settings/editor_layouts_dialog.cpp
@@ -98,7 +98,9 @@ void EditorLayoutsDialog::_post_popup() {
 	Vector<String> layouts = config->get_sections();
 
 	for (const String &E : layouts) {
-		layout_names->add_item(E);
+		if (!E.contains_char('/')) {
+			layout_names->add_item(E);
+		}
 	}
 	if (name->is_visible()) {
 		name->grab_focus();

--- a/editor/version_control/version_control_editor_plugin.cpp
+++ b/editor/version_control/version_control_editor_plugin.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/os/keyboard.h"
 #include "core/os/time.h"
+#include "editor/docks/editor_dock.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/editor_interface.h"
@@ -907,7 +908,7 @@ void VersionControlEditorPlugin::fetch_available_vcs_plugin_names() {
 }
 
 void VersionControlEditorPlugin::register_editor() {
-	EditorDockManager::get_singleton()->add_dock(version_commit_dock, "", EditorDockManager::DOCK_SLOT_RIGHT_UL, ED_SHORTCUT_AND_COMMAND("docks/open_version_control", TTRC("Open Version Control Dock")));
+	EditorDockManager::get_singleton()->add_dock(version_commit_dock);
 
 	version_control_dock_button = EditorNode::get_bottom_panel()->add_item(TTRC("Version Control"), version_control_dock, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_version_control_bottom_panel", TTRC("Toggle Version Control Bottom Panel")));
 
@@ -1144,14 +1145,21 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	set_up_warning_text->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	set_up_settings_vbc->add_child(set_up_warning_text);
 
-	version_commit_dock = memnew(VBoxContainer);
+	version_commit_dock = memnew(EditorDock);
 	version_commit_dock->set_visible(false);
-	version_commit_dock->set_name(TTR("Commit"));
+	version_commit_dock->set_name(TTRC("Commit"));
+	version_commit_dock->set_layout_key("VersionCommit");
+	version_commit_dock->set_icon_name("VcsBranches");
+	version_commit_dock->set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_version_control", TTRC("Open Version Control Dock")));
+	version_commit_dock->set_default_slot(EditorDockManager::DOCK_SLOT_RIGHT_UL);
+
+	VBoxContainer *dock_vb = memnew(VBoxContainer);
+	version_commit_dock->add_child(dock_vb);
 
 	VBoxContainer *unstage_area = memnew(VBoxContainer);
 	unstage_area->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	unstage_area->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	version_commit_dock->add_child(unstage_area);
+	dock_vb->add_child(unstage_area);
 
 	HBoxContainer *unstage_title = memnew(HBoxContainer);
 	unstage_area->add_child(unstage_title);
@@ -1178,7 +1186,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	discard_all_confirm->set_hide_on_ok(true);
 	discard_all_confirm->set_ok_button_text(TTR("Permanentally delete my changes"));
 	discard_all_confirm->add_cancel_button();
-	version_commit_dock->add_child(discard_all_confirm);
+	dock_vb->add_child(discard_all_confirm);
 
 	discard_all_confirm->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_discard_all));
 
@@ -1210,7 +1218,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	VBoxContainer *stage_area = memnew(VBoxContainer);
 	stage_area->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	stage_area->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	version_commit_dock->add_child(stage_area);
+	dock_vb->add_child(stage_area);
 
 	HBoxContainer *stage_title = memnew(HBoxContainer);
 	stage_area->add_child(stage_title);
@@ -1242,10 +1250,10 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	unstage_all_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_move_all).bind(staged_files));
 	stage_all_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_move_all).bind(unstaged_files));
 
-	version_commit_dock->add_child(memnew(HSeparator));
+	dock_vb->add_child(memnew(HSeparator));
 
 	VBoxContainer *commit_area = memnew(VBoxContainer);
-	version_commit_dock->add_child(commit_area);
+	dock_vb->add_child(commit_area);
 
 	Label *commit_label = memnew(Label);
 	commit_label->set_text(TTR("Commit Message"));
@@ -1271,10 +1279,10 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	commit_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_commit));
 	commit_area->add_child(commit_button);
 
-	version_commit_dock->add_child(memnew(HSeparator));
+	dock_vb->add_child(memnew(HSeparator));
 
 	HBoxContainer *commit_list_hbc = memnew(HBoxContainer);
-	version_commit_dock->add_child(commit_list_hbc);
+	dock_vb->add_child(commit_list_hbc);
 
 	Label *commit_list_label = memnew(Label);
 	commit_list_label->set_text(TTR("Commit List"));
@@ -1304,14 +1312,14 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	commit_list->set_column_custom_minimum_width(1, 20);
 	commit_list->set_theme_type_variation("TreeSecondary");
 	commit_list->connect(SceneStringName(item_selected), callable_mp(this, &VersionControlEditorPlugin::_load_diff).bind(commit_list));
-	version_commit_dock->add_child(commit_list);
+	dock_vb->add_child(commit_list);
 
-	version_commit_dock->add_child(memnew(HSeparator));
+	dock_vb->add_child(memnew(HSeparator));
 
 	HFlowContainer *menu_bar = memnew(HFlowContainer);
 	menu_bar->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	menu_bar->set_v_size_flags(Control::SIZE_FILL);
-	version_commit_dock->add_child(menu_bar);
+	dock_vb->add_child(menu_bar);
 
 	branch_select = memnew(OptionButton);
 	branch_select->set_tooltip_text(TTR("Branches"));

--- a/editor/version_control/version_control_editor_plugin.h
+++ b/editor/version_control/version_control_editor_plugin.h
@@ -39,6 +39,8 @@
 #include "scene/gui/text_edit.h"
 #include "scene/gui/tree.h"
 
+class EditorDock;
+
 class VersionControlEditorPlugin : public EditorPlugin {
 	GDCLASS(VersionControlEditorPlugin, EditorPlugin)
 
@@ -98,7 +100,7 @@ private:
 	HashMap<EditorVCSInterface::ChangeType, Color> change_type_to_color;
 	HashMap<EditorVCSInterface::ChangeType, Ref<Texture>> change_type_to_icon;
 
-	VBoxContainer *version_commit_dock = nullptr;
+	EditorDock *version_commit_dock = nullptr;
 	Tree *staged_files = nullptr;
 	Tree *unstaged_files = nullptr;
 	Tree *commit_list = nullptr;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12435
Fixes #106927

There are some differences from the proposal. The new class is called EditorDock and inherits MarginContainer.

I still need to expose it. For now I changed all docks to use the new system.

EDIT:
Done. I made an example plugin that uses the new system:
[dock-test.zip](https://github.com/user-attachments/files/20534966/dock-test.zip)
It can be moved to bottom and supports saving layout.

Also supersedes #106428