### PR TITLE
[Web] Always return `0` for `OS::get_process_id()`

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -441,7 +441,7 @@
 			<return type="int" />
 			<description>
 				Returns the number used by the host machine to uniquely identify this application.
-				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS, and Windows.
+				[b]Note:[/b] On Web, this method always returns [code]0[/code].
 			</description>
 		</method>
 		<method name="get_processor_count" qualifiers="const">

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -129,7 +129,7 @@ Error OS_Web::kill(const ProcessID &p_pid) {
 }
 
 int OS_Web::get_process_id() const {
-	ERR_FAIL_V_MSG(0, "OS::get_process_id() is not available on the Web platform.");
+	return 0;
 }
 
 bool OS_Web::is_process_running(const ProcessID &p_pid) const {


### PR DESCRIPTION
Supersedes #106497.

Removes the obnoxious error complaining that `OS::get_process_id()` is not implemented on Web.

Changes the documentation to mention that it always return `0` on Web.