### PR TITLE
Fix ios aot dotnet crash

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -52,7 +52,7 @@
     <Optimize Condition=" '$(Optimize)' == '' ">false</Optimize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ExportRelease' ">
-    <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
+    <Optimize Condition=" '$(GodotTargetPlatform)' != 'ios' and '$(Optimize)' == '' ">false</Optimize>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes the ios portion of:

https://github.com/issues/recent?issue=godotengine%7Cgodot%7C96072

I noticed that this user also reported they are having crashes on their windows machine.  I'll see if I can reproduce it on ours as well.  Currently I've only fixed it for ios.  Granted I'm not super happy with this fix as the solution is to just disable optimizations entirely.  Maybe a more fine grained approach of disabling optimizations per godot interface method is better.