### PR TITLE
Obfuscate the AES encryption key

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -184,7 +184,7 @@ env.add_source_files(env.core_sources, gen_hash)
 # Generate AES256 script encryption key
 gen_encrypt = env.CommandNoCache(
     "script_encryption_key.gen.cpp",
-    env.Value(os.environ.get("SCRIPT_AES256_ENCRYPTION_KEY")),
+    [env.Value(os.environ.get("SCRIPT_AES256_ENCRYPTION_KEY")), env.Value(os.environ.get("GODOT_XOR_BITMASK"))],
     env.Run(core_builders.encryption_key_builder),
 )
 env.add_source_files(env.core_sources, gen_encrypt)

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -284,7 +284,9 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 	if (enc_directory) {
 		Ref<FileAccessEncrypted> fae;
 		fae.instantiate();
+#ifdef DEBUG_ENABLED
 		ERR_FAIL_COND_V_MSG(fae.is_null(), false, "Can't open encrypted pack directory.");
+#endif
 
 		Vector<uint8_t> key;
 		key.resize(32);
@@ -292,8 +294,12 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 			key.write[i] = script_encryption_key[i];
 		}
 
+#ifdef DEBUG_ENABLED
 		Error err = fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
 		ERR_FAIL_COND_V_MSG(err, false, "Can't open encrypted pack directory.");
+#else
+		fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
+#endif
 		f = fae;
 	}
 
@@ -464,7 +470,9 @@ void FileAccessPack::close() {
 FileAccessPack::FileAccessPack(const String &p_path, const PackedData::PackedFile &p_file) :
 		pf(p_file),
 		f(FileAccess::open(pf.pack, FileAccess::READ)) {
+#ifdef DEBUG_ENABLE
 	ERR_FAIL_COND_MSG(f.is_null(), vformat("Can't open pack-referenced file '%s'.", String(pf.pack)));
+#endif
 
 	f->seek(pf.offset);
 	off = pf.offset;
@@ -472,7 +480,9 @@ FileAccessPack::FileAccessPack(const String &p_path, const PackedData::PackedFil
 	if (pf.encrypted) {
 		Ref<FileAccessEncrypted> fae;
 		fae.instantiate();
+#ifdef DEBUG_ENABLED
 		ERR_FAIL_COND_MSG(fae.is_null(), vformat("Can't open encrypted pack-referenced file '%s'.", String(pf.pack)));
+#endif
 
 		Vector<uint8_t> key;
 		key.resize(32);
@@ -480,8 +490,12 @@ FileAccessPack::FileAccessPack(const String &p_path, const PackedData::PackedFil
 			key.write[i] = script_encryption_key[i];
 		}
 
+#ifdef DEBUG_ENABLED
 		Error err = fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
 		ERR_FAIL_COND_MSG(err, vformat("Can't open encrypted pack-referenced file '%s'.", String(pf.pack)));
+#else
+		fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
+#endif
 		f = fae;
 		off = 0;
 	}


### PR DESCRIPTION
Right now, a big complaint I see online about Godot is it's security.  After a hacker infected my game's leaderboards, I took some steps to rotate and secure my AES encryption key.

I frequently here the complaint:

> "even encrypting your PCK is trivial." 

Shown by [this tutorial](https://www.youtube.com/watch?v=fWjuFmYGoSY), AES Encryption Keys are essential a ctrl+f away from being discovered in compiled binaries.

My proposal is to remove the identifiable strings in the release template and use a XOR Cipher to obfuscate the key in the compiled binary.

# Generating a XOR Bitmask
`openssl rand -hex 1 > ~/.config/godot/godot.mask`
**Example:** 1F

~/.bashrc
`export GODOT_XOR_BITMASK=$(cat "$HOME/.config/godot/godot.mask")`

You'll need to compile your own export templates with this environment variable set, but this will generate a new `script_encryption_key.gen.cpp` with an obfuscated key as the constructor. The remaining parts of the engine that call the key remain the same.

This isn't meant to **stop your key from being revealed** but makes it _much more difficult to find_.

I created a minimal reproducible project with exported binaries here: https://github.com/bearlikelion/godotxor
The AES Key for the project is: `aa806faf0a80b29b1893d351da03a61facd2181a7522a991b426050aa7534951`

I am looking for feedback on this type of security and to potentially merge it into the engine to help others secure their games.

Thank you,
Mark