### PR TITLE
[Web] Fix `LineEdit` `select_all_on_focus` behavior when using a virtual keyboard

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -75,7 +75,7 @@ void LineEdit::_edit(bool p_show_virtual_keyboard) {
 	editing = true;
 	_validate_caret_can_draw();
 
-	if (p_show_virtual_keyboard) {
+	if (p_show_virtual_keyboard && !pending_select_all_on_focus) {
 		show_virtual_keyboard();
 	}
 	queue_redraw();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/106536

After a bit of debugging I found that this happens because the `show_virtual_keyboard()` gets called twice. Before and after the selection happens. The first call happens when the focus is detected and the second one when the mouse/touch is released. This leads to having the LineEdit text entirely selected but the input in html5 not selected. 

This fixes the double call to `show_virtual_keyboard()` where we would only send the appropriate offsets (after the select all).

This changes the behaviour of the VK when the input is not focused. Now we only show it when the touch is released. But this change of behaviour only impacts LineEdit with select_all_on_focus enabled and is not noticeable at all (unless you keep the touch for long). 

**Before:**

https://github.com/user-attachments/assets/c15953f5-b5c0-45ea-a718-63d4b3a0b668


**After:**

https://github.com/user-attachments/assets/060da711-f157-40a4-860c-d01c4fb7d6d9