### PR TITLE
Add `HelperRect2D` as 2D-specific `ReferenceRect`

### DIFF
--- a/doc/classes/HelperRect2D.xml
+++ b/doc/classes/HelperRect2D.xml
@@ -20,15 +20,15 @@
 		</method>
 	</methods>
 	<members>
-		<member name="border_color" type="Color" setter="set_border_color" getter="get_border_color">
+		<member name="border_color" type="Color" setter="set_border_color" getter="get_border_color" default="Color(1, 1, 1, 0)">
 			The color of the rect's border.
 		</member>
-		<member name="dragged" type="bool" setter="" getter="get_global_rotation_degrees">
+		<member name="dragged" type="bool" setter="" getter="is_being_dragged">
 			If [code]true[/code], the rectangle is changed by the user dragging the node's rectangle area.
 			See [method _rect_updated] for its usage.
 			[b]Note:[/b] This property is read-only, so you cannot assign any value to it.
 		</member>
-		<member name="rect" type="Rect2" setter="set_rect" getter="get_rect">
+		<member name="rect" type="Rect2" setter="set_rect" getter="get_rect" default="Rect2(-10, -10, 20, 20)">
 			The rectangle of the node, also the border of the node.
 			See also [method _rect_updated].
 		</member>

--- a/doc/classes/HelperRect2D.xml
+++ b/doc/classes/HelperRect2D.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="HelperRect2D" inherits="Node2D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A 2D editor helper node that helps you customize dragging behavior.
+	</brief_description>
+	<description>
+		HelperRect2D is a 2D helper node in the editor that is draggable and allows you to customize your behavior. You can customize the behavior by overriding [method _rect_updated].
+		Unlike [ReferenceRect], this node is light and will not be affected by its parent node (except the parent node's transform).
+		[b]Note:[/b] To get this node work in the editor, you should use a tool script.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_rect_updated" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the [member rect] is changed. You can customize the behavior of dragging in this method.
+				[b]Note:[/b] This will be called no matter when you are dragging the rectangle border of the node in the editor, or setting [member rect] in the inspector. To specify in which condition the behavior should be handled, please use [member dragged] to control this.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="border_color" type="Color" setter="set_border_color" getter="get_border_color">
+			The color of the rect's border.
+		</member>
+		<member name="dragged" type="bool" setter="" getter="get_global_rotation_degrees">
+			If [code]true[/code], the rectangle is changed by the user dragging the node's rectangle area.
+			See [method _rect_updated] for its usage.
+			[b]Note:[/b] This property is read-only, so you cannot assign any value to it.
+		</member>
+		<member name="rect" type="Rect2" setter="set_rect" getter="get_rect">
+			The rectangle of the node, also the border of the node.
+			See also [method _rect_updated].
+		</member>
+	</members>
+</class>

--- a/doc/classes/HelperRect2D.xml
+++ b/doc/classes/HelperRect2D.xml
@@ -5,8 +5,7 @@
 	</brief_description>
 	<description>
 		HelperRect2D is a 2D helper node in the editor that is draggable and allows you to customize your behavior. You can customize the behavior by overriding [method _rect_updated].
-		Unlike [ReferenceRect], this node is light and will not be affected by its parent node (except the parent node's transform).
-		[b]Note:[/b] To get this node work in the editor, you should use a tool script.
+		Unlike [ReferenceRect], this node is light enough to allow you to customize your own behavior.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -15,6 +14,7 @@
 			<return type="void" />
 			<description>
 				Called when the [member rect] is changed. You can customize the behavior of dragging in this method.
+				[b]Note:[/b] To make this work in the editor, please consider to annotate the script with an [code]@tool[/code] annotation.
 				[b]Note:[/b] This will be called no matter when you are dragging the rectangle border of the node in the editor, or setting [member rect] in the inspector. To specify in which condition the behavior should be handled, please use [member dragged] to control this.
 			</description>
 		</method>

--- a/editor/icons/HelperRect2D.svg
+++ b/editor/icons/HelperRect2D.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#8da5f3" d="m1 1v2h2v-2zm3 0v2h8v-2zm9 0v2h2v-2zm-12 3v8h2v-8zm12 0v8h2v-8zm-12 9v2h2v-2zm3 0v2h8v-2zm9 0v2h2v-2z"/></svg>

--- a/scene/2d/helper_rect_2d.cpp
+++ b/scene/2d/helper_rect_2d.cpp
@@ -30,8 +30,6 @@
 
 #include "helper_rect_2d.h"
 
-#include "editor/editor_node.h"
-
 Dictionary HelperRect2D::_edit_get_state() const {
 	Dictionary ret = Node2D::_edit_get_state();
 	ret["rect"] = rect;

--- a/scene/2d/helper_rect_2d.cpp
+++ b/scene/2d/helper_rect_2d.cpp
@@ -30,10 +30,11 @@
 
 #include "helper_rect_2d.h"
 
+#ifdef TOOLS_ENABLED
 Dictionary HelperRect2D::_edit_get_state() const {
-	Dictionary ret = Node2D::_edit_get_state();
-	ret["rect"] = rect;
-	return ret;
+	Dictionary state = Node2D::_edit_get_state();
+	state["rect"] = rect;
+	return state;
 }
 
 void HelperRect2D::_edit_set_state(const Dictionary &p_state) {
@@ -62,12 +63,19 @@ void HelperRect2D::_edit_set_pivot(const Point2 &p_pivot) {
 bool HelperRect2D::_edit_use_pivot() const {
 	return true;
 }
+#endif // TOOLS_ENABLED
 
+#ifdef DEBUG_ENABLED
 Rect2 HelperRect2D::_edit_get_rect() const {
 	return rect;
 }
+#endif // DEBUG_ENABLED
 
 void HelperRect2D::set_rect(const Rect2 &p_rect) {
+	if (rect == p_rect) {
+		return;
+	}
+
 	rect = p_rect;
 	GDVIRTUAL_CALL(_rect_updated);
 	item_rect_changed();
@@ -76,10 +84,6 @@ void HelperRect2D::set_rect(const Rect2 &p_rect) {
 
 Rect2 HelperRect2D::get_rect() const {
 	return rect;
-}
-
-bool HelperRect2D::_edit_use_rect() const {
-	return true;
 }
 
 void HelperRect2D::set_border_color(const Color &p_border_color) {

--- a/scene/2d/helper_rect_2d.cpp
+++ b/scene/2d/helper_rect_2d.cpp
@@ -1,0 +1,129 @@
+/**************************************************************************/
+/*  helper_rect_2d.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "helper_rect_2d.h"
+
+#include "editor/editor_node.h"
+
+Dictionary HelperRect2D::_edit_get_state() const {
+	Dictionary ret = Node2D::_edit_get_state();
+	ret["rect"] = rect;
+	return ret;
+}
+
+void HelperRect2D::_edit_set_state(const Dictionary &p_state) {
+	set_rect(p_state["rect"]);
+	Node2D::_edit_set_state(p_state);
+}
+
+void HelperRect2D::_edit_set_rect(const Rect2 &p_edit_rect) {
+	dragged = true;
+	set_rect(p_edit_rect);
+	dragged = false;
+}
+
+void HelperRect2D::_edit_set_pivot(const Point2 &p_pivot) {
+	dragged = true;
+
+	set_position(get_transform().xform(p_pivot));
+
+	Rect2 tmp = rect;
+	tmp.position -= p_pivot;
+	set_rect(tmp);
+
+	dragged = false;
+}
+
+bool HelperRect2D::_edit_use_pivot() const {
+	return true;
+}
+
+Rect2 HelperRect2D::_edit_get_rect() const {
+	return rect;
+}
+
+void HelperRect2D::set_rect(const Rect2 &p_rect) {
+	rect = p_rect;
+	GDVIRTUAL_CALL(_rect_updated);
+	item_rect_changed();
+	queue_redraw();
+}
+
+Rect2 HelperRect2D::get_rect() const {
+	return rect;
+}
+
+bool HelperRect2D::_edit_use_rect() const {
+	return true;
+}
+
+void HelperRect2D::set_border_color(const Color &p_border_color) {
+	border_color = p_border_color;
+	queue_redraw();
+}
+
+Color HelperRect2D::get_border_color() const {
+	return border_color;
+}
+
+bool HelperRect2D::is_being_dragged() const {
+	return dragged;
+}
+
+void HelperRect2D::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			Rect2 drawn_rect = rect;
+			drawn_rect.size *= get_global_scale();
+
+			draw_set_transform(-get_global_position(), 0.0, Vector2(1.0, 1.0) / get_global_scale());
+			draw_rect(drawn_rect, border_color, false, 2.0);
+
+			// Restore the drawing transform to ensure `_draw()` work as expected
+			draw_set_transform(Vector2(), 0.0, Vector2(1.0, 1.0));
+		} break;
+	}
+}
+
+void HelperRect2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_rect", "rect"), &HelperRect2D::set_rect);
+	ClassDB::bind_method(D_METHOD("set_border_color", "border_color"), &HelperRect2D::set_border_color);
+
+	ClassDB::bind_method(D_METHOD("get_rect"), &HelperRect2D::get_rect);
+	ClassDB::bind_method(D_METHOD("get_border_color"), &HelperRect2D::get_border_color);
+
+	ClassDB::bind_method(D_METHOD("is_being_dragged"), &HelperRect2D::is_being_dragged);
+
+	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "rect", PROPERTY_HINT_NONE, "suffix:px"), "set_rect", "get_rect");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "border_color", PROPERTY_HINT_NONE, ""), "set_border_color", "get_border_color");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "dragged", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "is_being_dragged");
+
+	GDVIRTUAL_BIND(_rect_updated);
+}

--- a/scene/2d/helper_rect_2d.h
+++ b/scene/2d/helper_rect_2d.h
@@ -36,10 +36,9 @@ class HelperRect2D : public Node2D {
 	GDCLASS(HelperRect2D, Node2D);
 
 	Rect2 rect = Rect2(-10, -10, 20, 20);
+	Color border_color = Color(1, 1, 1, 0);
 
 	bool dragged;
-
-	Color border_color = Color(1, 1, 1, 0);
 
 protected:
 	static void _bind_methods();
@@ -64,7 +63,7 @@ public:
 
 #ifdef DEBUG_ENABLED
 	virtual Rect2 _edit_get_rect() const override;
-	virtual bool _edit_use_rect() const override;
+	virtual bool _edit_use_rect() const override { return true; }
 #endif // DEBUG_ENABLED
 
 	void set_rect(const Rect2 &p_rect);

--- a/scene/2d/helper_rect_2d.h
+++ b/scene/2d/helper_rect_2d.h
@@ -1,0 +1,77 @@
+/**************************************************************************/
+/*  helper_rect_2d.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/2d/node_2d.h"
+
+class HelperRect2D : public Node2D {
+	GDCLASS(HelperRect2D, Node2D);
+
+	Rect2 rect = Rect2(-10, -10, 20, 20);
+
+	bool dragged;
+
+	Color border_color = Color(1, 1, 1, 0);
+
+protected:
+	static void _bind_methods();
+
+	void _notification(int p_what);
+
+	GDVIRTUAL0(_rect_updated);
+
+public:
+#ifdef TOOLS_ENABLED
+	virtual Dictionary _edit_get_state() const override;
+	virtual void _edit_set_state(const Dictionary &p_state) override;
+
+	virtual void _edit_set_pivot(const Point2 &p_pivot) override;
+	virtual Point2 _edit_get_pivot() const override { return Point2(); }
+	virtual bool _edit_use_pivot() const override;
+
+	virtual void _edit_set_rect(const Rect2 &p_edit_rect) override;
+
+	virtual Size2 _edit_get_minimum_size() const override { return Size2(); }
+#endif // TOOLS_ENABLED
+
+#ifdef DEBUG_ENABLED
+	virtual Rect2 _edit_get_rect() const override;
+	virtual bool _edit_use_rect() const override;
+#endif // DEBUG_ENABLED
+
+	void set_rect(const Rect2 &p_rect);
+	Rect2 get_rect() const;
+
+	void set_border_color(const Color &p_border_color);
+	Color get_border_color() const;
+
+	bool is_being_dragged() const;
+};

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -174,6 +174,7 @@
 #include "scene/2d/canvas_modulate.h"
 #include "scene/2d/cpu_particles_2d.h"
 #include "scene/2d/gpu_particles_2d.h"
+#include "scene/2d/helper_rect_2d.h"
 #include "scene/2d/light_2d.h"
 #include "scene/2d/light_occluder_2d.h"
 #include "scene/2d/line_2d.h"
@@ -854,6 +855,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(Sprite2D);
 	GDREGISTER_CLASS(SpriteFrames);
 	GDREGISTER_CLASS(AnimatedSprite2D);
+	GDREGISTER_CLASS(HelperRect2D);
 	GDREGISTER_CLASS(Marker2D);
 	GDREGISTER_CLASS(Line2D);
 	GDREGISTER_CLASS(MeshInstance2D);


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/12353
Also closes: https://github.com/godotengine/godot-proposals/issues/9575 in another way

Simply exposing `_edit_*` methods would bring with a lot of issues, so why not adding a node that achieves the similar way, with an interface exposed to users to customize their behavior of dragging the rect?

## Why not using `ReferenceRect`, as the latter is also used in 2D space
Even though it is, the new `HelperRect2D` is so light that it does take not so much space as `ReferenceRect`, and that users can easily customize their behavior by simply overriding `_rect_updated()`.

## What are the advantages of `HelperRect2D`?

- Lightness, as I've mentioned, this does not contain so many properties as `Control`-derived classes, i.e. the interface is neat and you will easily find the key properties of the node.
- Pureness, as this only provides a frame. Without any script, you can clip the children with this node, unlike `Sprite2D` which requires you to have its `texture` given so as to drag the border.
- Flexibility, as this is the nature of most of nodes in Godot. With a tool script, you can define your custom dragging behavior in the editor
