### PR TITLE
Fix texture atlas import deadlock by keeping `group_file=` on failed `import_file()` attempts

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -2794,6 +2794,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 
 	ResourceUID::ID uid = ResourceUID::INVALID_ID;
 	Variant generator_parameters;
+	String group_file;
 	if (p_generator_parameters) {
 		generator_parameters = *p_generator_parameters;
 	}
@@ -2821,6 +2822,10 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 				if (cf->has_section_key("remap", "uid")) {
 					String uidt = cf->get_value("remap", "uid");
 					uid = ResourceUID::get_singleton()->text_to_id(uidt);
+				}
+
+				if (cf->has_section_key("remap", "group_file")) {
+					group_file = cf->get_value("remap", "group_file");
 				}
 
 				if (!p_generator_parameters) {
@@ -2918,6 +2923,9 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		}
 
 		f->store_line("uid=\"" + ResourceUID::get_singleton()->id_to_text(uid) + "\""); // Store in readable format.
+		if (!group_file.is_empty()) {
+			f->store_line("group_file=\"" + group_file + "\"");
+		}
 
 		if (err == OK) {
 			if (importer->get_save_extension().is_empty()) {


### PR DESCRIPTION
The problem is that when a texture_atlas resource is loaded during startup (e.g. because it's referenced by an autoload) using _load_resource_on_startup(), we always call _reimport_file() even if the resource has a group_file= attribute.

This causes _reimport_file() to drop the group_file= and when reimport_files() is called later it causes the deadlock as detailed below and in the issue linked.

I was wondering whether we could try to instead update _load_resource_on_startup() so it's aware of group_file, but at that point the filesystem hasn't been scanned yet, so it doesn't seem possible to find all the files in the group.

Instead, this PR makes it so _reimport_file() doesn't drop the group_file= attribute when import fails during startup. This allows the file to be loaded as part of the group in reimport_files().

Without group_file= set, this actually causes a deadlock in the editor as the ResourceImporterTextureAtlas::import() call attempts to use the rendering server while the main thread is waiting on a semaphore for imports to finish.

This fixes #104796 (verified locally), which has more details about the issue.