### PR TITLE
GLTF: Make skeleton bone names unique per-skeleton instead of scene-wide

### DIFF
--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -2221,7 +2221,7 @@ Error FBXDocument::_parse_fbx_state(Ref<FBXState> p_state, const String &p_searc
 	ERR_FAIL_COND_V(err != OK, ERR_PARSE_ERROR);
 
 	/* CREATE SKELETONS */
-	err = SkinTool::_create_skeletons(p_state->unique_names, p_state->skins, p_state->nodes, p_state->skeleton3d_to_fbx_skeleton, p_state->skeletons, p_state->scene_nodes);
+	err = SkinTool::_create_skeletons(p_state->unique_names, p_state->skins, p_state->nodes, p_state->skeleton3d_to_fbx_skeleton, p_state->skeletons, p_state->scene_nodes, _naming_version);
 	ERR_FAIL_COND_V(err != OK, ERR_PARSE_ERROR);
 
 	/* CREATE SKINS */

--- a/modules/fbx/fbx_document.h
+++ b/modules/fbx/fbx_document.h
@@ -40,6 +40,8 @@
 class FBXDocument : public GLTFDocument {
 	GDCLASS(FBXDocument, GLTFDocument);
 
+	int _naming_version = 2;
+
 public:
 	enum {
 		TEXTURE_TYPE_GENERIC = 0,

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -8622,7 +8622,7 @@ Node *GLTFDocument::_generate_scene_node_tree(Ref<GLTFState> p_state) {
 	// Generate the skeletons and skins (if any).
 	HashMap<ObjectID, SkinSkeletonIndex> skeleton_map;
 	Error err = SkinTool::_create_skeletons(p_state->unique_names, p_state->skins, p_state->nodes,
-			skeleton_map, p_state->skeletons, p_state->scene_nodes);
+			skeleton_map, p_state->skeletons, p_state->scene_nodes, _naming_version);
 	ERR_FAIL_COND_V_MSG(err != OK, nullptr, "glTF: Failed to create skeletons.");
 	err = _create_skins(p_state);
 	ERR_FAIL_COND_V_MSG(err != OK, nullptr, "glTF: Failed to create skins.");

--- a/modules/gltf/skin_tool.h
+++ b/modules/gltf/skin_tool.h
@@ -97,6 +97,7 @@ public:
 			Vector<Ref<GLTFNode>> &r_nodes,
 			HashMap<ObjectID, GLTFSkeletonIndex> &r_skeleton3d_to_fbx_skeleton,
 			Vector<Ref<GLTFSkeleton>> &r_skeletons,
-			HashMap<GLTFNodeIndex, Node *> &r_scene_nodes);
+			HashMap<GLTFNodeIndex, Node *> &r_scene_nodes,
+			int p_naming_version);
 	static Error _create_skins(Vector<Ref<GLTFSkin>> &skins, Vector<Ref<GLTFNode>> &nodes, bool use_named_skin_binds, HashSet<String> &unique_names);
 };


### PR DESCRIPTION
Fixes #106073, fixes #93758, fixes #96248. This restores the behavior in Godot 4.2 and earlier.

This PR makes the unique name feature no longer apply cross-skeleton. Skeleton bones now need to be unique within the same skeleton and compared to scene nodes, but not compared to all skeletons in the scene node.

This only affects glTF files with multiple skeletons in it, which is a niche use case, so this is low-risk. Users of this feature expect to be able to use the same bone map for each skeleton for animation targeting.

Note: This PR makes it possible to generate multiple nodes with the same name in the case of BoneAttachment3D nodes, since they are given the same name as the bone they are attached to. I think this is fine, and the alternatives are worse.

Note: This PR does not affect export. A comment introduced in PR #53114 indicates the current export behavior of having all glTF nodes including bones be unique was intentional. We could change the export behavior too, though.

~~Note: This PR adds a `duplicate()` function to HashSet, because I needed to duplicate a HashSet.~~