### PR TITLE
macOS: Ensure LayerHost size is set when first embedded

### DIFF
--- a/platform/macos/editor/embedded_process_macos.mm
+++ b/platform/macos/editor/embedded_process_macos.mm
@@ -137,6 +137,8 @@ void EmbeddedProcessMacOS::_try_embed_process() {
 
 	Error err = ds->embed_process_update(window->get_window_id(), this);
 	if (err == OK) {
+		layer_host->set_rect(get_adjusted_embedded_window_rect(get_rect()));
+
 		// Replicate some of the DisplayServer state.
 		{
 			DisplayServerEmbeddedState state;


### PR DESCRIPTION
Closes #106431

The `LayerHost` control was not always resized directly after embedding.