### PR TITLE
[Web] Make sure LineEdit's `text_changed` signal is triggered when using a virtual keyboard

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2783,6 +2783,7 @@ void Viewport::push_text_input(const String &p_text) {
 
 	if (gui.key_focus) {
 		gui.key_focus->call("set_text", p_text);
+		gui.key_focus->call("emit_signal", SNAME("text_changed"), p_text);
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/106539
Partially fixes https://github.com/godotengine/godot/issues/103771
Partially fixes https://github.com/godotengine/godot/issues/76215

It seems that setting the text manually does not trigger `text_changed` and this is by design. However for the web and when using a virtual keyboard we are emulating a text change. This PR makes sure `text_changed` signal is triggered after setting the text.

Another alternative is to introduce a `text_set` signal [similarly to TextEdit](https://github.com/godotengine/godot/blob/master/scene/gui/text_edit.cpp#L3983) (https://github.com/godotengine/godot/pull/50372).