### PR TITLE
Bump script bytecode version after token enum change

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -45,6 +45,7 @@ public:
 	};
 
 	struct Token {
+		// If this enum changes, please increment the TOKENIZER_VERSION in gdscript_tokenizer_buffer.h
 		enum Type {
 			EMPTY,
 			// Basic

--- a/modules/gdscript/gdscript_tokenizer_buffer.h
+++ b/modules/gdscript/gdscript_tokenizer_buffer.h
@@ -39,6 +39,7 @@ public:
 		COMPRESS_ZSTD,
 	};
 
+	static constexpr uint32_t TOKENIZER_VERSION = 101;
 	static constexpr uint32_t TOKEN_BYTE_MASK = 0x80;
 	static constexpr uint32_t TOKEN_BITS = 8;
 	static constexpr uint32_t TOKEN_MASK = (1 << (TOKEN_BITS - 1)) - 1;


### PR DESCRIPTION
See #67777 .

This change altered the token enum values when `ABSTRACT` was inserted, thus rendering all previous 4.x script bytecode incompatible with our parser. This necessitates bumping the bytecode version number.