### PR TITLE
Reintroduce the dragging method of Sprite2D's region_rect

### DIFF
--- a/editor/plugins/sprite_2d_editor_plugin.h
+++ b/editor/plugins/sprite_2d_editor_plugin.h
@@ -35,8 +35,10 @@
 #include "scene/gui/spin_box.h"
 
 class AcceptDialog;
+class Button;
 class ConfirmationDialog;
 class EditorZoomWidget;
+class HBoxContainer;
 class MenuButton;
 class Panel;
 class ViewPanner;
@@ -51,11 +53,14 @@ class Sprite2DEditor : public Control {
 		MENU_OPTION_CREATE_LIGHT_OCCLUDER_2D
 	};
 
+	HBoxContainer *top_hb = nullptr;
+
 	Menu selected_menu_item;
 
 	Sprite2D *node = nullptr;
 
 	MenuButton *options = nullptr;
+	Button *resize_region_rect = nullptr;
 
 	ConfirmationDialog *outline_dialog = nullptr;
 
@@ -104,6 +109,9 @@ class Sprite2DEditor : public Control {
 
 	void _add_as_sibling_or_child(Node *p_own_node, Node *p_new_node);
 
+	void _sync_sprite_resize_mode();
+	void _update_sprite_resize_mode_button();
+
 protected:
 	void _node_removed(Node *p_node);
 	void _notification(int p_what);
@@ -120,9 +128,6 @@ class Sprite2DEditorPlugin : public EditorPlugin {
 	Sprite2DEditor *sprite_editor = nullptr;
 
 	Label *dragging_mode_hint = nullptr;
-
-	void _editor_theme_changed();
-	void _update_dragging_mode_hint(bool p_region_enabled);
 
 public:
 	virtual String get_plugin_name() const override { return "Sprite2D"; }

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -64,7 +64,7 @@ void Sprite2D::_edit_set_rect(const Rect2 &p_rect) {
 	if (texture.is_null()) {
 		return;
 	}
-	if (!(region_enabled && hframes <= 1 && vframes <= 1 && Input::get_singleton()->is_key_label_pressed(Key::CTRL))) {
+	if (!region_enabled || hframes > 1 || vframes > 1 || !dragging_to_resize_rect) {
 		Node2D::_edit_set_rect(p_rect);
 		return;
 	}
@@ -428,6 +428,15 @@ bool Sprite2D::is_editor_region_rect_draggable() const {
 	return hframes <= 1 && vframes <= 1 && region_enabled;
 }
 
+#ifdef TOOLS_ENABLED
+void Sprite2D::_editor_set_dragging_to_resize_rect(bool p_dragging_to_resize_rect) {
+	dragging_to_resize_rect = p_dragging_to_resize_rect;
+}
+bool Sprite2D::_editor_is_dragging_to_resiz_rect() const {
+	return dragging_to_resize_rect;
+}
+#endif
+
 Rect2 Sprite2D::get_rect() const {
 	if (texture.is_null()) {
 		return Rect2(0, 0, 1, 1);
@@ -477,7 +486,7 @@ void Sprite2D::_texture_changed() {
 }
 
 void Sprite2D::_emit_region_rect_enabled() {
-	emit_signal("_editor_region_rect_enabled", is_editor_region_rect_draggable());
+	emit_signal("_editor_region_rect_enabled");
 }
 
 void Sprite2D::_bind_methods() {
@@ -544,9 +553,6 @@ void Sprite2D::_bind_methods() {
 
 Sprite2D::Sprite2D() {
 #ifdef TOOLS_ENABLED
-	add_user_signal(MethodInfo("_editor_region_rect_enabled", PropertyInfo(Variant::BOOL, "enabled"))); // Sprite2DEditorPlugin listens to this.
+	add_user_signal(MethodInfo("_editor_region_rect_enabled"));
 #endif
-}
-
-Sprite2D::~Sprite2D() {
 }

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -40,6 +40,10 @@ class Sprite2D : public Node2D {
 	Color specular_color;
 	real_t shininess = 0.0;
 
+#ifdef TOOLS_ENABLED
+	bool dragging_to_resize_rect = false;
+#endif // TOOLS_ENABLED
+
 	bool centered = true;
 	Point2 offset;
 
@@ -86,6 +90,11 @@ public:
 	virtual bool _edit_use_rect() const override;
 #endif // DEBUG_ENABLED
 
+#ifdef TOOLS_ENABLED
+	void _editor_set_dragging_to_resize_rect(bool p_dragging_to_resize_rect);
+	bool _editor_is_dragging_to_resiz_rect() const;
+#endif
+
 	bool is_pixel_opaque(const Point2 &p_point) const;
 	bool is_editor_region_rect_draggable() const;
 
@@ -129,5 +138,4 @@ public:
 	virtual Rect2 get_anchorable_rect() const override;
 
 	Sprite2D();
-	~Sprite2D();
 };


### PR DESCRIPTION
Fixes and closes: https://github.com/godotengine/godot/issues/106081

Due to the fact that holding ctrl, shift, and alt have been used for other handlings in the editor, the original implementation of pr #105147 is not dedicate enough.

This time I turned it into a small plugin button at the right of the Sprite2D plugin. The icon of the new button is “KeepAspect” (not sure if there are any better icon for this). The button is togglable so only when it is pressed can you drag the selected sprite to resize its `region_rect`, otherwise you will resize its `scale`.
