### PR TITLE
[3.x] Disable GPU threaded optimizations via Debug Logging

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -43,6 +43,14 @@
 #include <stdlib.h>
 
 class OS {
+public:
+	enum GraphicsDriverThreadedOptimizations {
+		GRAPHICS_DRIVER_THREADED_OPTIMIZATIONS_DISABLED,
+		GRAPHICS_DRIVER_THREADED_OPTIMIZATIONS_ENABLED,
+		GRAPHICS_DRIVER_THREADED_OPTIMIZATIONS_DEFAULT,
+	};
+
+private:
 	static OS *singleton;
 	static uint64_t target_ticks;
 	String _execpath;
@@ -65,6 +73,7 @@ class OS {
 	bool _use_vsync;
 	bool _vsync_via_compositor;
 	bool _delta_smoothing_enabled;
+	GraphicsDriverThreadedOptimizations _graphics_driver_threaded_optimizations = GRAPHICS_DRIVER_THREADED_OPTIMIZATIONS_DEFAULT;
 
 	char *last_error;
 
@@ -681,6 +690,10 @@ public:
 	virtual void benchmark_begin_measure(const String &p_what);
 	virtual void benchmark_end_measure(const String &p_what);
 	virtual void benchmark_dump();
+
+	// Allow overrides "disable" and can be specified via the command line.
+	GraphicsDriverThreadedOptimizations _get_graphics_driver_threaded_optimizations() const { return _graphics_driver_threaded_optimizations; }
+	void _set_graphics_driver_threaded_optimizations(GraphicsDriverThreadedOptimizations p_value) { _graphics_driver_threaded_optimizations = p_value; }
 
 	virtual void process_and_drop_events() {}
 	OS();

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1667,6 +1667,10 @@
 		<member name="rendering/limits/time/time_rollover_secs" type="float" setter="" getter="" default="3600">
 			Shaders have a time variable that constantly increases. At some point, it needs to be rolled back to zero to avoid precision errors on shader animations. This setting specifies when (in seconds).
 		</member>
+		<member name="rendering/misc/compatibility/driver_threaded_optimizations" type="String" setter="" getter="" default="&quot;DEFAULT&quot;">
+			If set to [code]Disable[/code], graphics driver threaded optimizations will be disabled.
+			[b]Note:[/b] This only takes effect for Nvidia drivers on Windows, where these optimizations are known to cause stuttering in OpenGL games.
+		</member>
 		<member name="rendering/misc/lossless_compression/force_png" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the texture importer will import lossless textures using the PNG format. Otherwise, it will default to using WebP.
 		</member>

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -85,6 +85,12 @@
 #endif
 
 #ifdef CAN_DEBUG
+
+// We offer the option to disable GPU threaded optimizations indirectly by forcing debug output.
+// We aren't actually interested in the strings in this case so we try and make the call as cheap as possible.
+static void GLAPIENTRY _gl_debug_print_dummy(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const GLvoid *userParam) {
+}
+
 static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const GLvoid *userParam) {
 	if (type == _EXT_DEBUG_TYPE_OTHER_ARB) {
 		return;
@@ -216,6 +222,24 @@ Error RasterizerGLES2::is_viable() {
 void RasterizerGLES2::initialize() {
 	print_verbose("Using GLES2 video driver");
 
+	// Use dummy OpenGL logging to indirectly disable threaded optimization if desired.
+	bool threaded_optimization = true;
+
+	if (!OS::get_singleton()->is_stdout_verbose() && !Engine::get_singleton()->is_editor_hint() && OS::get_singleton()->get_name() == "Windows") {
+		threaded_optimization = OS::get_singleton()->_get_graphics_driver_threaded_optimizations() != OS::GRAPHICS_DRIVER_THREADED_OPTIMIZATIONS_DISABLED;
+
+		// Only disable for nvidia currently.
+		if (!threaded_optimization) {
+			String video_adapter = VisualServer::get_singleton()->get_video_adapter_name().to_lower();
+
+			if (video_adapter.find("nvidia") == -1) {
+				threaded_optimization = true;
+			} else {
+				print_line("Attempting to disable GPU Driver threaded optimization via OpenGL debugging : " + VisualServer::get_singleton()->get_video_adapter_name());
+			}
+		}
+	}
+
 #ifdef GLAD_ENABLED
 	if (OS::get_singleton()->is_stdout_verbose()) {
 		if (GLAD_GL_ARB_debug_output) {
@@ -224,6 +248,14 @@ void RasterizerGLES2::initialize() {
 			glEnable(_EXT_DEBUG_OUTPUT);
 		} else {
 			print_line("OpenGL debugging not supported!");
+		}
+	} else if (!threaded_optimization) {
+		if (GLAD_GL_ARB_debug_output) {
+			glEnable(_EXT_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
+			glDebugMessageCallbackARB(_gl_debug_print_dummy, nullptr);
+			glEnable(_EXT_DEBUG_OUTPUT);
+		} else {
+			print_line("Disabling GPU threaded optimization via OpenGL debugging not supported by this driver.");
 		}
 	}
 #endif // GLAD_ENABLED
@@ -243,6 +275,9 @@ void RasterizerGLES2::initialize() {
 			GL_DEBUG_TYPE_OTHER_ARB, 1,
 			GL_DEBUG_SEVERITY_HIGH_ARB, 5, "hello");
 		*/
+	} else if (!threaded_optimization && GLAD_GL_ARB_debug_output) {
+		// Try to enable the minimum debug output to disable threaded optimization.
+		glDebugMessageControlARB(_EXT_DEBUG_SOURCE_API_ARB, _EXT_DEBUG_TYPE_ERROR_ARB, _EXT_DEBUG_SEVERITY_HIGH_ARB, 0, nullptr, GL_TRUE);
 	}
 #else
 	if (OS::get_singleton()->is_stdout_verbose()) {
@@ -255,6 +290,18 @@ void RasterizerGLES2::initialize() {
 			print_line("godot: ENABLING GL DEBUG");
 			glEnable(_EXT_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
 			callback(_gl_debug_print, NULL);
+			glEnable(_EXT_DEBUG_OUTPUT);
+		}
+	} else if (!threaded_optimization) {
+		DebugMessageCallbackARB callback = (DebugMessageCallbackARB)eglGetProcAddress("glDebugMessageCallback");
+		if (!callback) {
+			callback = (DebugMessageCallbackARB)eglGetProcAddress("glDebugMessageCallbackKHR");
+		}
+
+		if (callback) {
+			print_line("godot: ENABLING GL DEBUG dummy output");
+			glEnable(_EXT_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
+			callback(_gl_debug_print_dummy, NULL);
 			glEnable(_EXT_DEBUG_OUTPUT);
 		}
 	}

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -74,6 +74,11 @@ RasterizerScene *RasterizerGLES3::get_scene() {
 #endif
 
 #ifdef GLAD_ENABLED
+// We offer the option to disable GPU threaded optimizations indirectly by forcing debug output.
+// We aren't actually interested in the strings in this case so we try and make the call as cheap as possible.
+static void GLAPIENTRY _gl_debug_print_dummy(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const GLvoid *userParam) {
+}
+
 // Restricting to GLAD as only used in initialize() with GLAD_GL_ARB_debug_output
 static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const GLvoid *userParam) {
 	if (type == _EXT_DEBUG_TYPE_OTHER_ARB) {
@@ -158,6 +163,24 @@ Error RasterizerGLES3::is_viable() {
 void RasterizerGLES3::initialize() {
 	print_verbose("Using GLES3 video driver");
 
+	// Use dummy OpenGL logging to indirectly disable threaded optimization if desired.
+	bool threaded_optimization = true;
+
+	if (!OS::get_singleton()->is_stdout_verbose() && !Engine::get_singleton()->is_editor_hint() && OS::get_singleton()->get_name() == "Windows") {
+		threaded_optimization = OS::get_singleton()->_get_graphics_driver_threaded_optimizations() != OS::GRAPHICS_DRIVER_THREADED_OPTIMIZATIONS_DISABLED;
+
+		// Only disable for nvidia currently.
+		if (!threaded_optimization) {
+			String video_adapter = VisualServer::get_singleton()->get_video_adapter_name().to_lower();
+
+			if (video_adapter.find("nvidia") == -1) {
+				threaded_optimization = true;
+			} else {
+				print_line("Attempting to disable GPU Driver threaded optimization via OpenGL debugging : " + VisualServer::get_singleton()->get_video_adapter_name());
+			}
+		}
+	}
+
 #ifdef GLAD_ENABLED
 	if (OS::get_singleton()->is_stdout_verbose()) {
 		if (GLAD_GL_ARB_debug_output) {
@@ -166,6 +189,14 @@ void RasterizerGLES3::initialize() {
 			glEnable(_EXT_DEBUG_OUTPUT);
 		} else {
 			print_line("OpenGL debugging not supported!");
+		}
+	} else if (!threaded_optimization) {
+		if (GLAD_GL_ARB_debug_output) {
+			glEnable(_EXT_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
+			glDebugMessageCallbackARB(_gl_debug_print_dummy, nullptr);
+			glEnable(_EXT_DEBUG_OUTPUT);
+		} else {
+			print_line("Disabling GPU threaded optimization via OpenGL debugging not supported by this driver.");
 		}
 	}
 #endif // GLAD_ENABLED

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -333,6 +333,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --disable-vsync-via-compositor   Disable vsync via the OS' window compositor (Windows only).\n");
 	OS::get_singleton()->print("  --enable-delta-smoothing         When vsync is enabled, enabled frame delta smoothing.\n");
 	OS::get_singleton()->print("  --disable-delta-smoothing        Disable frame delta smoothing.\n");
+	OS::get_singleton()->print("  --gpu-threaded                   Enable / disable graphics driver threaded optimizations ('true' or 'false').\n");
 	OS::get_singleton()->print("  --tablet-driver                  Tablet input driver (");
 	for (int i = 0; i < OS::get_singleton()->get_tablet_driver_count(); i++) {
 		if (i != 0) {
@@ -496,6 +497,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	bool force_res = false;
 	bool saw_vsync_via_compositor_override = false;
 	bool delta_smoothing_override = false;
+	String driver_threaded_optimizations_string;
+	bool graphics_driver_threaded_optimizations_override = false;
 #ifdef TOOLS_ENABLED
 	bool found_project = false;
 #endif
@@ -940,6 +943,20 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing editor PID argument, aborting.\n");
 				goto error;
 			}
+		} else if (I->get() == "--gpu-threaded") {
+			if (I->next()) {
+				if (I->next()->get().to_lower() == "true") {
+					OS::get_singleton()->_set_graphics_driver_threaded_optimizations(OS::GRAPHICS_DRIVER_THREADED_OPTIMIZATIONS_ENABLED);
+					graphics_driver_threaded_optimizations_override = true;
+				} else if (I->next()->get().to_lower() == "false") {
+					OS::get_singleton()->_set_graphics_driver_threaded_optimizations(OS::GRAPHICS_DRIVER_THREADED_OPTIMIZATIONS_DISABLED);
+					graphics_driver_threaded_optimizations_override = true;
+				}
+				N = I->next()->next();
+			} else {
+				OS::get_singleton()->print("Missing gpu-threaded argument, aborting.\n");
+				goto error;
+			}
 		} else if (I->get() == "--disable-render-loop") {
 			disable_render_loop = true;
 		} else if (I->get() == "--fixed-fps") {
@@ -1253,6 +1270,17 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		rtm = GLOBAL_DEF("rendering/threads/thread_model", OS::RENDER_THREAD_SAFE);
 	}
 	GLOBAL_DEF("rendering/threads/thread_safe_bvh", false);
+
+	driver_threaded_optimizations_string = GLOBAL_DEF_RST("rendering/misc/compatibility/driver_threaded_optimizations", "DEFAULT");
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/misc/compatibility/driver_threaded_optimizations", PropertyInfo(Variant::STRING, "rendering/misc/compatibility/driver_threaded_optimizations", PROPERTY_HINT_ENUM, "DEFAULT,Disable,Enable"));
+
+	if (!graphics_driver_threaded_optimizations_override) {
+		if (driver_threaded_optimizations_string == "Disable") {
+			OS::get_singleton()->_set_graphics_driver_threaded_optimizations(OS::GRAPHICS_DRIVER_THREADED_OPTIMIZATIONS_DISABLED);
+		} else if (driver_threaded_optimizations_string == "Enable") {
+			OS::get_singleton()->_set_graphics_driver_threaded_optimizations(OS::GRAPHICS_DRIVER_THREADED_OPTIMIZATIONS_ENABLED);
+		}
+	}
 
 	if (rtm >= 0 && rtm < 3) {
 #ifdef NO_THREADS


### PR DESCRIPTION
_Update_
Since I originally made this PR, the NVAPI version in 4.x has had a number of bug fixes and is more mature, so it may be preferable for this to be backported.
Unfortunately this may not be possible for me to do personally, as I don't have a windows machine (or indeed windows with Nvidia). I did previously begin to attempt it in #106551 but I must have given up not having windows available.
_Leaving this here though for reference or in case we decide it is a better option for 3.x._

We can disable indirectly by enabling verbose GL debug output.

Fixes #33969

A long standing issue on Windows has been the threaded optimization Nvidia driver setting. This seems to cause significant stuttering for some users (and indeed is reported in many OpenGL non-Godot games).

Godot 4 tries the approach of using the Nvidia SDK (NVAPI) to turn off the optimization directly in the driver (#71472), however that has caused a number of regressions.

It turns out that enabling OpenGL debug logging seems to fix the issue, believed to be by forcing the driver to disable the feature. This is not ideal for exports, because Godot does significant processing to print these debug logs.

Instead of turning on full debug logging, this PR offers the ability to turn on minimal OpenGL debug logging, and ignoring the output (i.e. not printing to console). No processing takes place on the Godot side, minimizing the cost of the technique.

This PR offers:
* A project setting to choose between `Enable` (which is also `DEFAULT`), which doesn't attempt to override the driver, and `Disable`, which does the minimal OpenGL debug logging
* A command line option to override the project setting: `gpu-threaded` (true or false)

## Notes
* Only disables for video adapter with "nvidia" in the name, on windows only.
* Could be an option for 4.x, if the NVAPI doesn't work out.
* Tested by @elvisish and confirmed to work (I can't fully test this, as I don't have windows or nvidia GPU).
* `verbose_logging` takes precedence, but by definition if that is on, it will also disable threaded optimization. So probably no need to mention it in the docs. 
* I've added a `print_line` here just for initial testing so we can see it's active. It would have been a `print_verbose`, but by definition, we can't use this new mode when `verbose` is on. :grin: It might be an idea to leave this message in for a beta to ensure it is all working, then remove it in a followup.

I wasn't quite sure whether this should default to on or off, but for now have defaulted to `Enable` (no change to the driver), so the decision is left to the Godot game developer.

## Downsides (versus instructing driver explicitly)
Although this is kind of simple to do:
* this is non-portable (enabled for Nvidia only)
* depends on driver specific behaviour (they may change in future so it doesn't disable)
* possible performance overhead (just producing debug output from driver may cause sync stalls)
* may turn on validation layers

## Discussion
There's a bit of a philosophical question here (and with 4.x PRs that address similar). If there is currently a bug in Nvidia drivers which causes stuttering, should we be attempting to fix it at all our side?

It's a bit of a damned if you do, damned if you don't situation.

If we fix it, it might improve games _at this time_. But if Nvidia later close the bug, we may be forcing threaded optimizations off for no good reason, and limiting performance if they release a new _fixed_ driver.

However, their drivers have continued to have this problem for over a decade, and they are aware, and have not given indication they intend to fix it their side. If they are using a heuristic to decide automatically to switch it on / off, it might not be playing well with our background threads. But that is guesswork on my part.

## Why it occurs
Afaik the driver was designed for single-threaded OpenGL games to get more performance by offloading draw call processing to a separate thread. This conflicts with more modern OpenGL apps / games that use it's own multiple threads, causing sync locks and stalling the main render loop.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
