### PR TITLE
Fix LineEdit with secret checked reveals the secret when a selection is dragged

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -522,7 +522,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 				selection.drag_attempt = false;
 				if (!selection.double_click) {
 					bool is_inside_sel = selection.enabled && caret_column >= selection.begin && caret_column <= selection.end;
-					if (drag_and_drop_selection_enabled && is_inside_sel) {
+					if (!pass && drag_and_drop_selection_enabled && is_inside_sel) {
 						selection.drag_attempt = true;
 					} else {
 						deselect();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/106564

Checked how an HTML5 `<input type="password">` behaves and the drag and drop are disabled.

**Before**

https://github.com/user-attachments/assets/ec413f24-b79e-4564-a053-c64827f658c2

**After**

https://github.com/user-attachments/assets/d050ba63-4527-4927-b157-d641aeb532a2

