### PR TITLE
Fix fade out duration to extend a bit take into account current delta in NodeOneShot

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -678,7 +678,7 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 		double os_rem = os_nti.get_remain(break_loop_at_end) * tscl;
 		if (Animation::is_less_or_equal_approx(os_rem, fade_out)) {
 			is_fading_out = true;
-			cur_fade_out_remaining = os_rem;
+			cur_fade_out_remaining = os_rem + abs_delta;
 			cur_fade_in_remaining = 0;
 			set_parameter(internal_active, false);
 		}


### PR DESCRIPTION
- Prerequisite https://github.com/godotengine/godot/pull/101792
- Fixes https://github.com/godotengine/godot/issues/103070
- Supersedes/Closes https://github.com/godotengine/godot/pull/103078

I think the cause of the issue is that the delta is subtracted immediately, so the fadeout duration is shortened by one frame. This may be a bit of a hack, but it can be solved by extending the duration by delta which will be subtracted in advance.