### PR TITLE
Accelerate `HashMap` and `HashSet` lookup by using `if` based modulo in loops

### DIFF
--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -91,9 +91,19 @@ private:
 		return hash;
 	}
 
+	_FORCE_INLINE_ static constexpr void _increment_mod(uint32_t &r_pos, const uint32_t p_capacity) {
+		r_pos++;
+		// `if` is faster than both fastmod and mod.
+		if (unlikely(r_pos == p_capacity)) {
+			r_pos = 0;
+		}
+	}
+
 	static _FORCE_INLINE_ uint32_t _get_probe_length(const uint32_t p_pos, const uint32_t p_hash, const uint32_t p_capacity, const uint64_t p_capacity_inv) {
 		const uint32_t original_pos = fastmod(p_hash, p_capacity_inv, p_capacity);
-		return fastmod(p_pos - original_pos + p_capacity, p_capacity_inv, p_capacity);
+		const uint32_t distance_pos = p_pos - original_pos + p_capacity;
+		// At most p_capacity over 0, so we can use an if (faster than fastmod).
+		return distance_pos >= p_capacity ? distance_pos - p_capacity : distance_pos;
 	}
 
 	bool _lookup_pos(const TKey &p_key, uint32_t &r_pos) const {
@@ -121,7 +131,7 @@ private:
 				return true;
 			}
 
-			pos = fastmod((pos + 1), capacity_inv, capacity);
+			_increment_mod(pos, capacity);
 			distance++;
 		}
 	}
@@ -152,7 +162,7 @@ private:
 				distance = existing_probe_len;
 			}
 
-			pos = fastmod((pos + 1), capacity_inv, capacity);
+			_increment_mod(pos, capacity);
 			distance++;
 		}
 	}
@@ -357,7 +367,7 @@ public:
 			SWAP(hashes[next_pos], hashes[pos]);
 			SWAP(elements[next_pos], elements[pos]);
 			pos = next_pos;
-			next_pos = fastmod((pos + 1), capacity_inv, capacity);
+			_increment_mod(next_pos, capacity);
 		}
 
 		hashes[pos] = EMPTY_HASH;
@@ -406,7 +416,7 @@ public:
 			SWAP(hashes[next_pos], hashes[pos]);
 			SWAP(elements[next_pos], elements[pos]);
 			pos = next_pos;
-			next_pos = fastmod((pos + 1), capacity_inv, capacity);
+			_increment_mod(next_pos, capacity);
 		}
 		hashes[pos] = EMPTY_HASH;
 		elements[pos] = nullptr;

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -70,9 +70,19 @@ private:
 		return hash;
 	}
 
+	_FORCE_INLINE_ static constexpr void _increment_mod(uint32_t &r_pos, const uint32_t p_capacity) {
+		r_pos++;
+		// `if` is faster than both fastmod and mod.
+		if (unlikely(r_pos == p_capacity)) {
+			r_pos = 0;
+		}
+	}
+
 	static _FORCE_INLINE_ uint32_t _get_probe_length(const uint32_t p_pos, const uint32_t p_hash, const uint32_t p_capacity, const uint64_t p_capacity_inv) {
 		const uint32_t original_pos = fastmod(p_hash, p_capacity_inv, p_capacity);
-		return fastmod(p_pos - original_pos + p_capacity, p_capacity_inv, p_capacity);
+		const uint32_t distance_pos = p_pos - original_pos + p_capacity;
+		// At most p_capacity over 0, so we can use an if (faster than fastmod).
+		return distance_pos >= p_capacity ? distance_pos - p_capacity : distance_pos;
 	}
 
 	bool _lookup_pos(const TKey &p_key, uint32_t &r_pos) const {
@@ -91,16 +101,16 @@ private:
 				return false;
 			}
 
-			if (distance > _get_probe_length(pos, hashes[pos], capacity, capacity_inv)) {
-				return false;
-			}
-
 			if (hashes[pos] == hash && Comparator::compare(keys[hash_to_key[pos]], p_key)) {
 				r_pos = hash_to_key[pos];
 				return true;
 			}
 
-			pos = fastmod(pos + 1, capacity_inv, capacity);
+			if (distance > _get_probe_length(pos, hashes[pos], capacity, capacity_inv)) {
+				return false;
+			}
+
+			_increment_mod(pos, capacity);
 			distance++;
 		}
 	}
@@ -130,7 +140,7 @@ private:
 				distance = existing_probe_len;
 			}
 
-			pos = fastmod(pos + 1, capacity_inv, capacity);
+			_increment_mod(pos, capacity);
 			distance++;
 		}
 	}
@@ -274,7 +284,7 @@ public:
 			SWAP(hash_to_key[next_pos], hash_to_key[pos]);
 
 			pos = next_pos;
-			next_pos = fastmod(pos + 1, capacity_inv, capacity);
+			_increment_mod(next_pos, capacity);
 		}
 
 		hashes[pos] = EMPTY_HASH;


### PR DESCRIPTION
`HashMap` uses modulo to map hashes and positions to the `0 to capacity` range.
Modulo is slow, so it was exchanged for `fastmod` in https://github.com/godotengine/godot/pull/62327.
However, `fastmod` is still a bottleneck for `HashMap` lookup. I was able to accelerate calls by using an `if` pseudo modulo instead, which is faster than `fastmod`.

This change can accelerate `HashMap` lookup by 40%.

## Explanation

On my machine, `fastmod` uses 2 multiplications (3-10 clock cycles[^2] each) and a bitshift (1 clock cycle[^3]). 

An `if` is an integer comparison (1 clock cycle[^3]) and a mostly predictable branch (0-2 clock cycles[^1] normally, 12 - 25 clock cycles on modulo case). 

It stands to reason that in most cases, an `if` based modulo will be faster than `fastmod`. It can be used when we're sure the number is between `(0, capacity * 2 - 1)`.

## Benchmarks

Theory is well and good, but benchmarks are better. 
I measured an up to 40% improvement in `HashMap` `get`, 11% for `insert`, and 2.5% for `erase`.
This will be the case notably mostly when the memory is in cache. When it is not in cache, the bottleneck is likely to be RAM access.

<details>
<summary>Test Code</summary>

```c++
	for (int size : { 1, 2, 8, 64, 1024, 4096}) {
		{
			size_t time_ns = 0;
			for (int run = 0; run < 20000000 / size; run++) {
				auto t0 = std::chrono::high_resolution_clock::now();
				HashMap<int64_t, int64_t> dictionary;
				for (int idx = 0; idx < size; idx ++) {
					// Test
					dictionary.insert(idx, idx);
				}
				auto t1 = std::chrono::high_resolution_clock::now();
				time_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
			}

			std::cout << "insert:" << size << std::endl;
			std::cout << time_ns / 1000 / 1000 << "ms\n";
		}
		{
			size_t time_ns = 0;
			for (int run = 0; run < 20000000 / size; run++) {
				HashMap<int64_t, int64_t> dictionary;
				for (int idx = 0; idx < size; idx ++) {
					// Test
					dictionary.insert(idx, idx);
				}
				auto t0 = std::chrono::high_resolution_clock::now();
				for (int idx = 0; idx < size; idx ++) {
					// Test
					dictionary.erase(idx);
				}
				auto t1 = std::chrono::high_resolution_clock::now();
				time_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
			}

			std::cout << "erase:" << size << std::endl;
			std::cout << time_ns / 1000 / 1000 << "ms\n";
		}
		{
			size_t time_ns = 0;
			for (int run = 0; run < 20000000 / size; run++) {
				HashMap<int64_t, int64_t> dictionary;
				for (int idx = 0; idx < size; idx ++) {
					// Test
					dictionary.insert(idx, idx);
				}
				size_t total = 0;
				auto t0 = std::chrono::high_resolution_clock::now();
				for (int idx = 0; idx < size; idx ++) {
					// Test
					total += dictionary.get(idx);
				}
				auto t1 = std::chrono::high_resolution_clock::now();
				time_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();

				// Prevent compiling this out.
				volatile_size_t = total;
			}

			std::cout << "get:" << size << std::endl;
			std::cout << time_ns / 1000 / 1000 << "ms\n";
		}
	}
```
</details>

On master:
```
insert:1
912ms
erase:1
522ms
get:1
330ms
insert:2
552ms
erase:2
383ms
get:2
174ms
insert:8
310ms
erase:8
376ms
get:8
86ms
insert:64
406ms
erase:64
462ms
get:64
98ms
insert:1024
511ms
erase:1024
587ms
get:1024
105ms
insert:4096
861ms
erase:4096
643ms
get:4096
272ms
```

On this PR:
```
insert:1
913ms
erase:1
521ms
get:1
321ms
insert:2
544ms
erase:2
376ms
get:2
164ms
insert:8
292ms
erase:8
371ms
get:8
61ms
insert:64
376ms
erase:64
459ms
get:64
65ms
insert:1024
475ms
erase:1024
565ms
get:1024
64ms
insert:4096
769ms
erase:4096
627ms
get:4096
190ms
```

## Alternatives

@nazarwadim has proposed in https://github.com/godotengine/godot/pull/90082 to switch to `&` for modulus. This would make the operation near instantaneous. 

However, we currently use prime based capacities, because those decrease collision counts when a mediocre hash strategy is chosen. There is definitely a trade off to be measured some time, but it should be measured with both strategies at an ideal implementation.

Since we know our hash functions are high quality, this may be a better solution in the end. Using power of two growth seems to make for a better trade-off in most modern `HashMap` implementations anyway. I will likely test this soon.
Java apparently applies a secondary hash function to the given hash, to increase quality (https://stackoverflow.com/a/15437377/730797). We could always use that for unknown hash functions (and not do it for known, high quality hash functions).

[^1]: https://agner.org/optimize/optimizing_cpp.pdf p. 43
[^2]: https://agner.org/optimize/optimizing_cpp.pdf p. 149
[^3]: https://agner.org/optimize/optimizing_cpp.pdf p. 30