### PR TITLE
New test for animation blend tree

### DIFF
--- a/tests/scene/test_animation_blend_tree.h
+++ b/tests/scene/test_animation_blend_tree.h
@@ -1,0 +1,84 @@
+/**************************************************************************/
+/*  test_animation_blend_tree.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/animation/animation_blend_tree.h"
+
+#include "tests/test_macros.h"
+#include "tests/test_utils.h"
+
+namespace TestAnimationBlendTree {
+TEST_CASE("[SceneTree][AnimationBlendTree] Create AnimationBlendTree and add AnimationNode") {
+	Ref<AnimationNodeBlendTree> blend_tree;
+	blend_tree.instantiate();
+
+	// Test initial state.
+	CHECK(blend_tree->has_node("output"));
+	CHECK_EQ(blend_tree->get_graph_offset(), Vector2(0, 0));
+	CHECK_EQ(blend_tree->get_node_list().size(), 1);
+
+	// Test adding animation node.
+	Ref<AnimationNodeAnimation> anim_node;
+	anim_node.instantiate();
+	anim_node->set_animation(StringName("test_animation"));
+	Vector2 position(100, 100);
+	blend_tree->add_node("test_node", anim_node, position);
+
+	// Test node existence.
+	CHECK(blend_tree->has_node("test_node"));
+	CHECK_EQ(blend_tree->get_node("test_node"), anim_node);
+	CHECK_EQ(blend_tree->get_node_position("test_node"), position);
+
+	// Test node connection on port 0.
+	CHECK_EQ(blend_tree->can_connect_node("output", 0, "test_node"), AnimationNodeBlendTree::CONNECTION_OK);
+	blend_tree->connect_node("output", 0, "test_node");
+
+	Vector<StringName> connections = blend_tree->get_node_connection_array("output");
+	CHECK_EQ(connections.size(), 1);
+	CHECK_EQ(connections[0], StringName("test_node"));
+
+	// Test node rename.
+	blend_tree->rename_node("test_node", "renamed_node");
+	CHECK_FALSE(blend_tree->has_node("test_node"));
+	CHECK(blend_tree->has_node("renamed_node"));
+
+	connections = blend_tree->get_node_connection_array("output");
+	CHECK_EQ(connections[0], StringName("renamed_node"));
+
+	// Test node removal.
+	blend_tree->remove_node("renamed_node");
+	CHECK_FALSE(blend_tree->has_node("renamed_node"));
+
+	connections = blend_tree->get_node_connection_array("output");
+	CHECK_EQ(connections[0], StringName());
+}
+
+} //namespace TestAnimationBlendTree

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -119,6 +119,7 @@
 #include "tests/core/variant/test_variant.h"
 #include "tests/core/variant/test_variant_utility.h"
 #include "tests/scene/test_animation.h"
+#include "tests/scene/test_animation_blend_tree.h"
 #include "tests/scene/test_audio_stream_wav.h"
 #include "tests/scene/test_bit_map.h"
 #include "tests/scene/test_button.h"


### PR DESCRIPTION
Added new test file and test cases for AnimationBlendTree in tests/scene/test_animation_blend_tree.h.

Tested creation of AnimationNodeBlendTree object and basic node connect/rename/remove functionalities.

This PR is related to issue https://github.com/godotengine/godot/issues/43440.